### PR TITLE
feat(pair): :await-render render-settle primitive — deterministic dispatch->observe (rf2-gfu33)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -699,8 +699,10 @@ Fire a re-frame2 event tagged with `:origin :pair`. Three modes:
 | any     | true     | trace (synchronous, returns the assembled `:rf/epoch-record`) |
 
 **Args**: `event` (string, required — EDN-encoded event vector),
-`sync` (bool), `trace` (bool), `frame` (string, e.g. `":foo"`),
-`fx-overrides` (object, e.g. `{:http :stub-http}`), `build` (string).
+`sync` (bool), `trace` (bool), `await-render` (bool, rf2-gfu33),
+`timeout-ms` (integer, default `5000` — render-settle deadline),
+`frame` (string, e.g. `":foo"`), `fx-overrides` (object, e.g.
+`{:http :stub-http}`), `build` (string).
 
 The `frame` arg is colon-tolerant (rf2-ldfnx): both the documented
 colon-prefixed id (`":rf/xray"` — the form discover-app surfaces, §Id
@@ -730,6 +732,48 @@ ambiguous (`:reason :ambiguous-frame`) — the tool surfaces a structured
 ERROR envelope (`:isError true`) carrying the runtime's verbatim
 `:ok? false` / `:reason` / `:hint`, with NO `:mode` slot. It never
 reports `{:mode …}` over a no-op.
+
+### Render-settle — `:await-render` (rf2-gfu33)
+
+`dispatch-sync` returns once the handler has committed app-db, but the
+substrate (Reagent / the React spine) re-renders on a LATER tick — so
+"dispatch then observe the DOM" previously needed a manual
+`requestAnimationFrame` dance inside `eval-cljs`. The `:await-render`
+option collapses `dispatch → observe` into one deterministic step: the
+tool resolves only AFTER the substrate has flushed the new state to the
+DOM and the next paint is scheduled.
+
+**Substrate-agnostic flush via the adapter contract.** The flush is NOT
+a Reagent API call. The generated runtime form calls
+`re-frame.interop/after-render` — the framework's render-settle
+primitive, which routes through the `:adapter/after-render` late-bind
+hook (Spec 006 §Substrate adapter contract). Each adapter publishes its
+substrate-native impl: Reagent maps it to `r/after-render` (post-commit),
+the UIx / Helix spine to a `React.useLayoutEffect`-backed queue drain
+(post-commit / pre-paint, rf2-334d9), plain-atom / SSR to `next-tick`.
+`after-render` fires once the DOM reflects the new state; the form then
+chains ONE `requestAnimationFrame` so resolution lands at the paint
+boundary (environments without rAF — headless / SSR — resolve straight
+off the after-render callback). The MCP server therefore never names
+Reagent, UIx, or Helix.
+
+**Wire shape.** `:await-render` forces synchronous dispatch (the cascade
+must commit before the render can settle against the new state), so the
+result is the `pair-dispatch-sync!` envelope (`:cascade-summary`,
+`:epoch-id`, …) with `:mode :sync :settled? true` merged in. The runtime
+form's synchronous return is a browser-side Promise; the server awaits
+it through the shared await mailbox (the same plumbing `eval-cljs :await`
+uses — `re-frame2-pair-mcp.tools.await-promise`). The rf2-ldfnx
+success-vs-error contract holds through the settle path: a runtime
+`:ok? false` (frame untargetable) still surfaces as an `:isError`
+envelope with no `:mode` slot. A render-settle that doesn't complete
+within `:timeout-ms` (default `5000`) returns
+`:reason :rf.error/dispatch-await-render-timeout`.
+
+| `await-render`? | dispatch fn | resolves after |
+|-----------------|-------------|----------------|
+| false (default) | per `sync`/`trace` mode | handler commit (today's semantics) |
+| true            | `pair-dispatch-sync!` (forced; `trace` still wins for the assembled epoch) | substrate flush (`after-render`) + next paint (`requestAnimationFrame`) |
 
 ## dispatch-dry-run
 

--- a/tools/re-frame2-pair-mcp/spec/API.md
+++ b/tools/re-frame2-pair-mcp/spec/API.md
@@ -237,6 +237,15 @@ The trace mode is the workhorse for agent loops: dispatch, see what
 fired, decide next step. See
 [`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md) § `dispatch`.
 
+The `await-render` flag (rf2-gfu33) is orthogonal to the mode table: set
+it and the tool resolves only AFTER the substrate has flushed the new
+state to the DOM and the next paint is scheduled, so `dispatch → observe`
+is one deterministic step. It forces synchronous dispatch and routes the
+flush through the substrate-agnostic `re-frame.interop/after-render`
+adapter primitive (Spec 006) + one `requestAnimationFrame`. See
+[`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md) § dispatch §
+Render-settle.
+
 ## Result shape
 
 All tools return EDN inside the MCP `tools/call` `content` text

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/await_promise.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/await_promise.cljs
@@ -1,0 +1,221 @@
+(ns re-frame2-pair-mcp.tools.await-promise
+  "Shared browser-side Promise-await machinery (rf2-gfu33).
+
+  Two tools need the same capability: run a form over nREPL whose
+  synchronous return is a JS Promise, then resolve to the Promise's
+  eventual value rather than the `\"#object[Promise ...]\"` string a
+  raw `pr-str` would produce. `eval-cljs :await` (rf2-xn4f9) was the
+  first; `dispatch :await-render` (rf2-gfu33) is the second — it awaits
+  a render-settle Promise so `dispatch → observe` is a single
+  deterministic step.
+
+  The nREPL channel is request/response: the server sends a form and
+  reads back the synchronous value. A Promise cannot ride back over
+  that channel because it hasn't settled when the eval returns. So we
+  use a **browser-side mailbox**:
+
+    1. The caller-supplied form is wrapped so its evaluation:
+       - if the result is a thenable, installs a mailbox entry on
+         `js/globalThis.__rf2pair_await__`, chains `.then` / `.catch`
+         to record the resolved value / rejection reason as `pr-str`
+         text into that mailbox, and synchronously returns a
+         `{:rf.mcp/await-mailbox <id>}` sentinel;
+       - otherwise returns `{:rf.mcp/await-direct <v>}` (passthrough
+         fast path — a non-thenable form never needed awaiting).
+    2. On a mailbox sentinel the server polls the mailbox via a tiny
+       second eval at a fast cadence until `:status` flips off
+       `:pending`, or `:timeout-ms` elapses.
+
+  This namespace owns ONLY the mailbox dance — `wrap-form`, the
+  read/discard forms, the poll loop, and the sentinel dispatcher.
+  Each consumer supplies its own envelope shape via the `on-resolved` /
+  `on-rejected` / `on-timeout` / `on-missing` callbacks passed to
+  [[handle-sentinel]] so the same plumbing yields tool-specific result
+  vocabularies (`eval-cljs` returns `:value`; `dispatch :await-render`
+  returns the dispatch envelope merged with `:settled? true`)."
+  (:require [re-frame2-pair-mcp.nrepl :as nrepl]))
+
+(def default-timeout-ms
+  "Default deadline for awaiting a Promise return when the caller
+  doesn't specify `:timeout-ms`. 5 seconds is generous for typical
+  async work (layout, fetch, async fns, render-settle); pathologically
+  long async forms can raise it. Mirrors shape with `tail-build`'s
+  `:wait-ms`."
+  5000)
+
+(def ^:private mailbox-poll-ms
+  "Cadence at which the server re-reads the mailbox after a thenable
+  sentinel. 25ms = ~40 polls/sec — small enough to land within ~25ms
+  of resolution, cheap enough on the nREPL socket to not flood it.
+  The polling stops as soon as the mailbox status flips off
+  `:pending`, so the cadence matters only for short-lived awaits."
+  25)
+
+(defn mailbox-key
+  "The unique key written to `js/globalThis.__rf2pair_await__` for one
+  await call. Random-uuid keeps concurrent awaits (a future N-agent
+  workflow, or interleaved tool calls in a single host) from clobbering
+  each other's mailboxes."
+  []
+  (str "await-" (random-uuid)))
+
+(defn wrap-form
+  "Wrap `form-str` so the browser-side eval:
+
+    - evaluates the form (may return any value, thenable or not),
+    - synchronously returns `{:rf.mcp/await-direct <v>}` for a
+      non-thenable result (server fast-paths back to the value),
+    - for a thenable result, installs a mailbox entry, chains
+      `.then` / `.catch` to record the outcome, and synchronously
+      returns `{:rf.mcp/await-mailbox <id>}`.
+
+  All resolved/rejected values are `pr-str`'d into the mailbox so they
+  survive the next `cljs-eval` round-trip as EDN text — the server
+  reads them back unchanged.
+
+  Uses `(some? (.-then v))` rather than `(instance? js/Promise v)` so
+  any thenable (jQuery deferreds, axios responses, promise shims) is
+  recognised — matching the JS-ecosystem `await` semantic."
+  [form-str mailbox-id]
+  (str
+    "(let [user-fn# (fn [] " form-str ")"
+    "      v# (user-fn#)"
+    "      mailbox# (or (.-__rf2pair_await__ js/globalThis)"
+    "                   (let [m# (cljs.core/js-obj)]"
+    "                     (set! (.-__rf2pair_await__ js/globalThis) m#)"
+    "                     m#))]"
+    "  (if (and (some? v#)"
+    "           (or (object? v#) (instance? js/Object v#))"
+    "           (fn? (some-> v# .-then)))"
+    "    (do"
+    "      (aset mailbox# " (pr-str mailbox-id)
+    "            (cljs.core/js-obj \"status\" \"pending\"))"
+    "      (-> v#"
+    "          (.then (fn [r#]"
+    "                   (aset mailbox# " (pr-str mailbox-id)
+    "                         (cljs.core/js-obj"
+    "                           \"status\" \"resolved\""
+    "                           \"value\" (cljs.core/pr-str r#)))))"
+    "          (.catch (fn [e#]"
+    "                    (aset mailbox# " (pr-str mailbox-id)
+    "                          (cljs.core/js-obj"
+    "                            \"status\" \"rejected\""
+    "                            \"rejection\" (cljs.core/pr-str e#))))))"
+    "      {:rf.mcp/await-mailbox " (pr-str mailbox-id) "})"
+    "    {:rf.mcp/await-direct v#}))"))
+
+(defn- read-mailbox-form
+  "Read + clear the mailbox entry for `mailbox-id`. Resolves to one of:
+
+    - `{:status :pending}`               — promise hasn't settled yet
+    - `{:status :resolved :value v}`     — value is the post-pr-str EDN
+    - `{:status :rejected :rejection s}` — s is pr-str of the rejection
+    - `{:status :missing}`               — mailbox slot is gone (a wire-
+      shape regression; surfaced rather than silently retried)
+
+  Cleared on a non-pending read so a repeated poll after resolution
+  doesn't re-read stale data."
+  [mailbox-id]
+  (str
+    "(let [mailbox# (or (.-__rf2pair_await__ js/globalThis) (cljs.core/js-obj))"
+    "      entry#   (aget mailbox# " (pr-str mailbox-id) ")]"
+    "  (cond"
+    "    (nil? entry#)"
+    "    {:status :missing}"
+    "    (= \"pending\" (aget entry# \"status\"))"
+    "    {:status :pending}"
+    "    (= \"resolved\" (aget entry# \"status\"))"
+    "    (let [v# (cljs.reader/read-string (aget entry# \"value\"))]"
+    "      (js-delete mailbox# " (pr-str mailbox-id) ")"
+    "      {:status :resolved :value v#})"
+    "    (= \"rejected\" (aget entry# \"status\"))"
+    "    (let [s# (aget entry# \"rejection\")]"
+    "      (js-delete mailbox# " (pr-str mailbox-id) ")"
+    "      {:status :rejected :rejection s#})"
+    "    :else"
+    "    {:status :missing}))"))
+
+(defn- discard-mailbox-form
+  "Best-effort drop of the mailbox slot — called after a timeout so a
+  late resolution doesn't pile up garbage on `js/globalThis`. Errors
+  are swallowed; the timeout result is already on its way back."
+  [mailbox-id]
+  (str
+    "(when-let [mailbox# (.-__rf2pair_await__ js/globalThis)]"
+    "  (js-delete mailbox# " (pr-str mailbox-id) ")"
+    "  nil)"))
+
+(defn poll-mailbox!
+  "Poll the mailbox at `mailbox-poll-ms` cadence until status is non-
+  `:pending` or `timeout-ms` elapses. Resolves to the final mailbox
+  read result map (`:resolved` / `:rejected` / `:timeout` / `:missing`).
+  On `:timeout`, fires-and-forgets a discard-form so the late resolution
+  doesn't accumulate."
+  [conn build-id mailbox-id timeout-ms]
+  (let [start     (js/Date.now)
+        read-form (read-mailbox-form mailbox-id)]
+    (js/Promise.
+      (fn [resolve _reject]
+        (letfn [(poll []
+                  (let [elapsed (- (js/Date.now) start)]
+                    (if (>= elapsed timeout-ms)
+                      (do
+                        ;; Fire-and-forget discard; ignore any error.
+                        (-> (nrepl/cljs-eval-value conn build-id
+                                                   (discard-mailbox-form mailbox-id))
+                            (.catch (fn [_] nil)))
+                        (resolve {:status :timeout}))
+                      (-> (nrepl/cljs-eval-value conn build-id read-form)
+                          (.then (fn [r]
+                                   (if (and (map? r) (= :pending (:status r)))
+                                     (js/setTimeout poll mailbox-poll-ms)
+                                     (resolve (if (map? r) r {:status :missing})))))
+                          (.catch (fn [_]
+                                    ;; Transient read failure — keep polling
+                                    ;; until timeout. Reading the mailbox is
+                                    ;; cheap; one hiccup shouldn't abort the
+                                    ;; await.
+                                    (js/setTimeout poll mailbox-poll-ms)))))))]
+          (poll))))))
+
+(defn handle-sentinel
+  "Inspect the wrapper's synchronous return and dispatch.
+
+  - `:rf.mcp/await-direct` map → the form's value verbatim (non-
+    thenable fast path); calls `(on-resolved v)`.
+  - `:rf.mcp/await-mailbox` map → kicks off the polling loop, then
+    routes the final status to the matching callback.
+  - anything else → a regression in `wrap-form`; calls `(on-missing
+    {:sentinel <pr-str>})`.
+
+  The four callbacks (`:on-resolved` `:on-rejected` `:on-timeout`
+  `:on-missing`) each take a map and return the consumer's wire
+  envelope. This is the single seam that keeps the mailbox plumbing
+  tool-agnostic — `eval-cljs` and `dispatch :await-render` plug in
+  their own result vocabularies. Each callback is invoked with:
+
+    :on-resolved {:value <edn-value>}
+    :on-rejected {:rejection <pr-str-of-rejection>}
+    :on-timeout  {:timeout-ms n}
+    :on-missing  {:reason <:missing | :bad-sentinel> :sentinel <pr-str?>}
+
+  Returns a Promise of the chosen callback's return value."
+  [conn build-id timeout-ms sentinel
+   {:keys [on-resolved on-rejected on-timeout on-missing]}]
+  (cond
+    (and (map? sentinel) (contains? sentinel :rf.mcp/await-direct))
+    (js/Promise.resolve (on-resolved {:value (:rf.mcp/await-direct sentinel)}))
+
+    (and (map? sentinel) (contains? sentinel :rf.mcp/await-mailbox))
+    (-> (poll-mailbox! conn build-id (:rf.mcp/await-mailbox sentinel) timeout-ms)
+        (.then (fn [result]
+                 (case (:status result)
+                   :resolved (on-resolved {:value (:value result)})
+                   :rejected (on-rejected {:rejection (:rejection result)})
+                   :timeout  (on-timeout {:timeout-ms timeout-ms})
+                   ;; :missing — defensive; should not happen in practice.
+                   (on-missing {:reason :missing})))))
+
+    :else
+    (js/Promise.resolve
+      (on-missing {:reason :bad-sentinel :sentinel (pr-str sentinel)}))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -311,10 +311,20 @@
                      "additionally carries `:cascade-summary-pending? true` when the cascade hasn't drained "
                      "yet — poll `watch-epochs` for the eventual settlement. See the §Cascade Summary "
                      "subsection in spec/003-Tool-Catalogue.md for the full shape. "
+                     "Render-settle (rf2-gfu33): set `await-render true` and the tool resolves only AFTER the "
+                     "substrate has flushed the new state to the DOM and the next paint is scheduled — `dispatch -> "
+                     "observe the DOM` becomes one deterministic step (no manual requestAnimationFrame dance in "
+                     "eval-cljs). The flush is substrate-agnostic: it routes through the framework's "
+                     "`re-frame.interop/after-render` (the `:adapter/after-render` adapter hook, Spec 006) — Reagent's "
+                     "post-commit `r/after-render`, the UIx/Helix spine's React.useLayoutEffect drain, etc. "
+                     "`await-render` forces synchronous dispatch (the cascade must commit before the render can "
+                     "settle) and merges `:settled? true` into the result. A settle that doesn't complete within "
+                     "`timeout-ms` (default 5000) returns `:reason :rf.error/dispatch-await-render-timeout`. "
                      "Examples: "
                      "1. Fire-and-forget (drained synchronously): {:event \"[:cart/checkout]\"} -> {:ok? true :mode :queued :epoch-id 7 :cascade-summary {:event-id :cart/checkout :db-diff {:changed-paths [[:cart]] :added-paths [] :removed-paths []} :fx-fired [:dispatch] :subs-recomputed 3 :renders 1 :outcome :ok :elapsed-ms 4}}. "
                      "2. Trace mode (get the assembled epoch back): {:event \"[:cart/add {:sku \\\"x\\\"}]\" :trace true} -> {:ok? true :mode :trace :epoch {...} :cascade-summary {...}}. "
-                     "3. Bad event shape: {:event \"42\"} -> {:ok? false :reason :not-an-event-vector :event-edn 42}.")
+                     "3. Render-settle then observe: {:event \"[:counter/inc]\" :await-render true} -> {:ok? true :mode :sync :settled? true :epoch-id 9 :cascade-summary {:renders 1 ...}} — the DOM now reflects the new state; follow with eval-cljs / a DOM read. "
+                     "4. Bad event shape: {:event \"42\"} -> {:ok? false :reason :not-an-event-vector :event-edn 42}.")
    :typicalTokens 300
    :annotations destructive-annotations
    :outputSchema envelope-or-marker
@@ -322,6 +332,22 @@
                  :properties {:event {:type "string" :description "The event vector as EDN, e.g. \"[:cart/checkout]\" or \"[:cart/add {:sku \\\"abc\\\"}]\". MUST be a vector — non-vector EDN and host-form source are rejected."}
                               :sync  {:type "boolean"}
                               :trace {:type "boolean"}
+                              :await-render {:type "boolean"
+                                             :description (str "Render-settle (rf2-gfu33): when true, resolve only AFTER the "
+                                                               "substrate has flushed the new state to the DOM and the next "
+                                                               "paint is scheduled, so `dispatch -> observe` is one "
+                                                               "deterministic step. The flush routes through the "
+                                                               "substrate-agnostic `re-frame.interop/after-render` adapter hook "
+                                                               "(Spec 006), then one requestAnimationFrame pins resolution to "
+                                                               "the paint boundary. Forces synchronous dispatch (the cascade "
+                                                               "must commit before the render can settle); merges :settled? true "
+                                                               "into the result. Default false. A settle exceeding :timeout-ms "
+                                                               "returns :rf.error/dispatch-await-render-timeout.")}
+                              :timeout-ms {:type "integer"
+                                           :description (str "Maximum ms to wait for the render-settle promise when "
+                                                             ":await-render is true. Default 5000. Ignored when "
+                                                             ":await-render is false. Raise it for substrates with a slow "
+                                                             "render path; lower it to fail fast when no root is mounted.")}
                               :frame {:type "string" :description "Operating frame (e.g. :stories)"}
                               :fx-overrides {:type "object"
                                              :description "Per-call fx redirects, e.g. {:http :stub-http}"}

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -19,11 +19,47 @@
   the normal `pr-str` path (`rt-call` arg). Unreadable strings and
   non-vector shapes return a structured `:reason :invalid-event-edn` /
   `:reason :not-an-event-vector` error rather than reaching the
-  runtime."
+  runtime.
+
+  ## Render-settle — `:await-render` (rf2-gfu33)
+
+  `pair-dispatch-sync!` returns once the handler has committed app-db,
+  but the substrate (Reagent / the React spine) re-renders on a LATER
+  tick — so \"dispatch then observe the DOM\" previously needed a manual
+  `requestAnimationFrame` dance inside `eval-cljs`. The `:await-render`
+  option makes `dispatch → observe` one deterministic step: the tool
+  resolves only AFTER the substrate has flushed the new state to the
+  DOM and the next paint has been scheduled.
+
+  ### Substrate-agnostic flush via the adapter contract
+
+  The flush is NOT a Reagent API call. The generated runtime form calls
+  `re-frame.interop/after-render` — the framework's render-settle
+  primitive, which routes through the `:adapter/after-render` late-bind
+  hook (Spec 006 §Substrate adapter contract). Each adapter publishes
+  its substrate-native impl: Reagent maps it to `r/after-render`
+  (post-commit), the UIx / Helix spine to a `React.useLayoutEffect`-
+  backed queue drain (post-commit / pre-paint, rf2-334d9), plain-atom /
+  SSR to `next-tick`. `after-render` fires once the DOM reflects the new
+  state; the form then chains ONE `requestAnimationFrame` so resolution
+  lands at the paint boundary. The MCP server therefore stays
+  substrate-agnostic — it never names Reagent, UIx, or Helix.
+
+  ### Wire shape
+
+  `:await-render` forces synchronous dispatch (the cascade must have
+  committed before we can settle the render against the new state), so
+  the result is the `pair-dispatch-sync!` envelope (`:cascade-summary`
+  and friends) with `:mode :sync :settled? true` merged in. The form
+  returns a browser-side Promise; the server awaits it through the
+  shared `await-promise` mailbox (the same plumbing `eval-cljs :await`
+  uses). A render-settle that doesn't complete within `:timeout-ms`
+  (default 5000) returns `:reason :rf.error/dispatch-await-render-timeout`."
   (:require [cljs.reader]
             [clojure.string :as str]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
+            [re-frame2-pair-mcp.tools.await-promise :as await-promise]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
@@ -101,10 +137,86 @@
     (wire/err-text v)
     (wire/ok-text (merge {:mode mode} (when (map? v) v)))))
 
+;; ---------------------------------------------------------------------------
+;; Render-settle — `:await-render` (rf2-gfu33).
+;;
+;; The settle form runs the dispatch synchronously (so app-db has
+;; committed and the substrate has been invalidated), then returns a
+;; browser-side Promise that resolves AFTER the substrate's render
+;; flush AND the next paint. The flush is the framework's
+;; `re-frame.interop/after-render` — a substrate-agnostic primitive
+;; routed through the `:adapter/after-render` late-bind hook (Spec 006).
+;; A single `requestAnimationFrame` after the flush pins resolution to
+;; the paint boundary; environments without rAF (headless / SSR) resolve
+;; straight off the after-render callback.
+;;
+;; The Promise resolves to the dispatch envelope with `:settled? true`
+;; merged in, so the caller gets the full `pair-dispatch-sync!` result
+;; (`:cascade-summary`, `:epoch-id`, …) AND the settle confirmation in
+;; one round-trip. The server awaits the Promise via the shared
+;; `await-promise` mailbox.
+;; ---------------------------------------------------------------------------
+
+(defn- await-render-callbacks
+  "The dispatch `:await-render` result vocabulary for
+  `await-promise/handle-sentinel`. On resolution the value IS the
+  dispatch envelope (the `pair-dispatch-sync!` / `dispatch-and-collect`
+  return) with `:settled? true` already merged in by the settle form —
+  route it through `runtime-envelope->result` so a frame-targeting
+  failure (`:ok? false`) still surfaces as an `:isError` envelope, never
+  a silent `{:mode :sync}` success (the rf2-ldfnx invariant). Timeout /
+  malformed-sentinel surface as structured dispatch errors."
+  [mode]
+  {:on-resolved (fn [{:keys [value]}] (runtime-envelope->result mode value))
+   :on-rejected (fn [{:keys [rejection]}]
+                  (wire/err-text {:ok?       false
+                                  :reason    :rf.error/dispatch-await-render-rejected
+                                  :rejection rejection}))
+   :on-timeout  (fn [{:keys [timeout-ms]}]
+                  (wire/err-text {:ok?        false
+                                  :reason     :rf.error/dispatch-await-render-timeout
+                                  :timeout-ms timeout-ms
+                                  :hint       (str "the render-settle promise did not resolve within "
+                                                   "timeout-ms. The dispatch may still have committed; "
+                                                   "the substrate's after-render flush never fired (no "
+                                                   "mounted root?) or the page reloaded mid-settle.")}))
+   :on-missing  (fn [{:keys [reason sentinel]}]
+                  (wire/err-text (cond-> {:ok?    false
+                                          :reason :rf.error/dispatch-await-render-mailbox-missing
+                                          :hint   "the render-settle mailbox vanished before the result was read."}
+                                   (= :bad-sentinel reason) (assoc :sentinel sentinel))))})
+
+(defn- render-settle-form
+  "Build the CLJS source for an `:await-render` dispatch. `fn-sym` is the
+  runtime dispatch fn (always a synchronous variant under await-render);
+  `event-vec` + `opts-form` are the dispatch payload. Emits a form whose
+  synchronous return is a `js/Promise` resolving to the dispatch envelope
+  merged with `{:settled? true}` once the substrate has flushed + the
+  next paint is scheduled."
+  [fn-sym event-vec opts-form]
+  (str
+    "(js/Promise."
+    "  (fn [resolve# _reject#]"
+    "    (let [result# " (ef/emit (ef/rt-call fn-sym event-vec opts-form))
+    "          done#   (fn [] (resolve# (if (map? result#)"
+    "                                     (assoc result# :settled? true)"
+    "                                     {:settled? true :result result#})))]"
+    "      (re-frame.interop/after-render"
+    "        (fn []"
+    "          (if (exists? js/requestAnimationFrame)"
+    "            (js/requestAnimationFrame (fn [_#] (done#)))"
+    "            (done#)))))))"))
+
 (defn dispatch-tool [conn args]
   (let [event-str    (wire/arg args :event)
         build-id     (wire/arg-build conn args)
-        sync?        (boolean (wire/arg args :sync))
+        await-render? (boolean (wire/arg args :await-render))
+        timeout-ms   (or (wire/arg args :timeout-ms) await-promise/default-timeout-ms)
+        ;; rf2-gfu33: `:await-render` forces synchronous dispatch — the
+        ;; cascade must have committed before the render can settle
+        ;; against the new state. An explicit `:trace` still wins (the
+        ;; caller asked for the assembled epoch); otherwise sync.
+        sync?        (boolean (or (wire/arg args :sync) await-render?))
         trace?       (boolean (wire/arg args :trace))
         ;; rf2-ldfnx — coerce `frame` via the colon-tolerant
         ;; `->frame-keyword` (the shared `fresh-keyword` path), NOT the
@@ -136,9 +248,23 @@
             fn-sym     (cond trace? 'dispatch-and-collect
                              sync?  'pair-dispatch-sync!
                              :else  'pair-dispatch!)
-            form (ef/emit (ef/rt-call fn-sym event-vec opts-form))
             mode (cond trace? :trace sync? :sync :else :queued)]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [v] (runtime-envelope->result mode v)))
-            (.catch (fn [err] (probe/err->result :dispatch-failed err))))))))
+        (if await-render?
+          ;; rf2-gfu33 — render-settle path. The form's synchronous
+          ;; return is a Promise; await it through the shared mailbox so
+          ;; `dispatch → observe` is one deterministic step.
+          (let [settle-form (render-settle-form fn-sym event-vec opts-form)
+                mailbox-id  (await-promise/mailbox-key)
+                wrapped     (await-promise/wrap-form settle-form mailbox-id)]
+            (-> (probe/ensure-runtime! conn build-id)
+                (.then (fn [_] (nrepl/cljs-eval-value conn build-id wrapped)))
+                (.then (fn [sentinel]
+                         (await-promise/handle-sentinel
+                           conn build-id timeout-ms sentinel
+                           (await-render-callbacks mode))))
+                (.catch (fn [err] (probe/err->result :dispatch-failed err)))))
+          (let [form (ef/emit (ef/rt-call fn-sym event-vec opts-form))]
+            (-> (probe/ensure-runtime! conn build-id)
+                (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+                (.then (fn [v] (runtime-envelope->result mode v)))
+                (.catch (fn [err] (probe/err->result :dispatch-failed err))))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
@@ -111,10 +111,20 @@
   for the form's synchronous evaluation — once the Promise resolves
   on a later tick, the original lexical frame is gone (this matches
   the macro's contract per Spec 002, where async closures must
-  capture via `bound-fn` / `dispatcher` / `subscriber`)."
+  capture via `bound-fn` / `dispatcher` / `subscriber`).
+
+  ## Mailbox machinery extracted (rf2-gfu33)
+
+  The browser-side Promise mailbox dance (`wrap-form`, the read/poll
+  forms, the sentinel dispatcher) moved to
+  `re-frame2-pair-mcp.tools.await-promise` so `dispatch :await-render`
+  can reuse the SAME proven plumbing. This ns now supplies only the
+  eval-cljs result vocabulary (`:value` / `:rf.error/eval-cljs-*`) via
+  the callback seam `await-promise/handle-sentinel` exposes."
   (:require [clojure.string :as str]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
+            [re-frame2-pair-mcp.tools.await-promise :as await-promise]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
@@ -136,217 +146,50 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Await mode — wrap the user's form to detect thenables + automate the
-;; mailbox dance (rf2-xn4f9).
+;; mailbox dance (rf2-xn4f9). The mailbox plumbing lives in
+;; `await-promise` (rf2-gfu33); this ns supplies only the eval-cljs
+;; result vocabulary via the callback seam.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private default-await-timeout-ms
-  "Default deadline for awaiting a Promise return when the caller doesn't
-  specify `:timeout-ms`. 5 seconds is generous for typical async work
-  (layout, fetch, async fns); pathologically long async forms (heavy
-  IndexedDB scans, multi-second elkjs layouts) can raise it. Mirrors
-  shape with `tail-build`'s `:wait-ms`."
-  5000)
-
-(def ^:private mailbox-poll-ms
-  "Cadence at which the server re-reads the mailbox after a thenable
-  sentinel. 25ms = ~40 polls/sec — small enough to land within ~25ms
-  of resolution, cheap enough on the nREPL socket to not flood it.
-  The polling stops as soon as the mailbox status flips off
-  `:pending`, so the cadence matters only for short-lived awaits.
-
-  Aligned with the cost profile of `cljs-eval` round-trips (~5-15ms
-  warm) — finer than `tail-build`'s 100ms because await is in the
-  inner debug loop and the polled form is cheap (a single property
-  read + clear)."
-  25)
-
-(defn- await-mailbox-key
-  "The unique key written to `js/globalThis.__rf2pair_await__` for this
-  call. Random-uuid keeps concurrent awaits (a future N-agent
-  workflow, or interleaved tool calls in a single host) from clobbering
-  each other's mailboxes."
-  []
-  (str "await-" (random-uuid)))
-
-(defn- await-wrap-form
-  "Wrap the user's `form-str` so the browser-side eval:
-
-    - evaluates the user form (may return any value, thenable or not),
-    - synchronously returns `{:rf.mcp/await-direct <v>}` for non-thenable
-      results (server fast-paths back to the today-shape value),
-    - for thenable results, installs a mailbox entry, chains
-      `.then` / `.catch` to record the outcome, and synchronously
-      returns `{:rf.mcp/await-mailbox <id>}`.
-
-  All resolved/rejected values are `pr-str`'d into the mailbox so they
-  survive the next `cljs-eval` round-trip as EDN text — the server
-  reads them back unchanged.
-
-  The wrapper deliberately uses `(some? (.-then v))` rather than
-  `(instance? js/Promise v)` so any thenable (jQuery deferreds, axios
-  responses, library-specific promise shims) is recognised — matching
-  the JS-ecosystem `await` semantic."
-  [form-str mailbox-id]
-  (str
-    "(let [user-fn# (fn [] " form-str ")"
-    "      v# (user-fn#)"
-    "      mailbox# (or (.-__rf2pair_await__ js/globalThis)"
-    "                   (let [m# (cljs.core/js-obj)]"
-    "                     (set! (.-__rf2pair_await__ js/globalThis) m#)"
-    "                     m#))]"
-    "  (if (and (some? v#)"
-    "           (or (object? v#) (instance? js/Object v#))"
-    "           (fn? (some-> v# .-then)))"
-    "    (do"
-    "      (aset mailbox# " (pr-str mailbox-id)
-    "            (cljs.core/js-obj \"status\" \"pending\"))"
-    "      (-> v#"
-    "          (.then (fn [r#]"
-    "                   (aset mailbox# " (pr-str mailbox-id)
-    "                         (cljs.core/js-obj"
-    "                           \"status\" \"resolved\""
-    "                           \"value\" (cljs.core/pr-str r#)))))"
-    "          (.catch (fn [e#]"
-    "                    (aset mailbox# " (pr-str mailbox-id)
-    "                          (cljs.core/js-obj"
-    "                            \"status\" \"rejected\""
-    "                            \"rejection\" (cljs.core/pr-str e#))))))"
-    "      {:rf.mcp/await-mailbox " (pr-str mailbox-id) "})"
-    "    {:rf.mcp/await-direct v#}))"))
-
-(defn- read-mailbox-form
-  "Read + clear the mailbox entry for `mailbox-id`. Resolves to one of:
-
-    - `{:status :pending}`               — promise hasn't settled yet
-    - `{:status :resolved :value v}`     — value is the post-pr-str EDN
-    - `{:status :rejected :rejection s}` — s is pr-str of the rejection
-    - `{:status :missing}`               — mailbox slot is gone (would
-      indicate a serious wire-shape regression; we surface it rather
-      than silently retrying)
-
-  Cleared on a non-pending read so a repeated poll after resolution
-  doesn't re-read stale data."
-  [mailbox-id]
-  (str
-    "(let [mailbox# (or (.-__rf2pair_await__ js/globalThis) (cljs.core/js-obj))"
-    "      entry#   (aget mailbox# " (pr-str mailbox-id) ")]"
-    "  (cond"
-    "    (nil? entry#)"
-    "    {:status :missing}"
-    "    (= \"pending\" (aget entry# \"status\"))"
-    "    {:status :pending}"
-    "    (= \"resolved\" (aget entry# \"status\"))"
-    "    (let [v# (cljs.reader/read-string (aget entry# \"value\"))]"
-    "      (js-delete mailbox# " (pr-str mailbox-id) ")"
-    "      {:status :resolved :value v#})"
-    "    (= \"rejected\" (aget entry# \"status\"))"
-    "    (let [s# (aget entry# \"rejection\")]"
-    "      (js-delete mailbox# " (pr-str mailbox-id) ")"
-    "      {:status :rejected :rejection s#})"
-    "    :else"
-    "    {:status :missing}))"))
-
-(defn- discard-mailbox-form
-  "Best-effort drop of the mailbox slot — called after a timeout so a
-  late resolution doesn't pile up garbage on `js/globalThis`. Errors
-  are swallowed; the timeout result is already on its way back."
-  [mailbox-id]
-  (str
-    "(when-let [mailbox# (.-__rf2pair_await__ js/globalThis)]"
-    "  (js-delete mailbox# " (pr-str mailbox-id) ")"
-    "  nil)"))
-
-(defn- poll-mailbox!
-  "Poll the mailbox at `mailbox-poll-ms` cadence until status is non-
-  `:pending` or `timeout-ms` elapses. Resolves to the final mailbox
-  read result map (`:resolved` / `:rejected` / `:timeout` / `:missing`).
-  On `:timeout`, fires-and-forgets a discard-form so the late resolution
-  doesn't accumulate."
-  [conn build-id mailbox-id timeout-ms]
-  (let [start    (js/Date.now)
-        read-form (read-mailbox-form mailbox-id)]
-    (js/Promise.
-      (fn [resolve _reject]
-        (letfn [(poll []
-                  (let [elapsed (- (js/Date.now) start)]
-                    (if (>= elapsed timeout-ms)
-                      (do
-                        ;; Fire-and-forget discard; ignore any error.
-                        (-> (nrepl/cljs-eval-value conn build-id
-                                                   (discard-mailbox-form mailbox-id))
-                            (.catch (fn [_] nil)))
-                        (resolve {:status :timeout}))
-                      (-> (nrepl/cljs-eval-value conn build-id read-form)
-                          (.then (fn [r]
-                                   (if (and (map? r) (= :pending (:status r)))
-                                     (js/setTimeout poll mailbox-poll-ms)
-                                     (resolve (if (map? r) r {:status :missing})))))
-                          (.catch (fn [_]
-                                    ;; Transient read failure — keep polling
-                                    ;; until timeout. Reading the mailbox is
-                                    ;; cheap; one hiccup shouldn't abort the
-                                    ;; await.
-                                    (js/setTimeout poll mailbox-poll-ms)))))))]
-          (poll))))))
-
-(defn- await-result->envelope
-  "Translate a `poll-mailbox!` result into the eval-cljs envelope shape.
+(defn- sentinel-callbacks
+  "The eval-cljs result vocabulary for `await-promise/handle-sentinel`.
   `resolved-build` is the build the eval ran against; echoed back on
   every envelope so the caller's auto-detect path is visible."
-  [resolved-build timeout-ms mailbox-result]
-  (case (:status mailbox-result)
-    :resolved
-    (wire/ok-text {:ok?   true
-                   :value (:value mailbox-result)
-                   :build resolved-build})
+  [resolved-build timeout-ms]
+  {:on-resolved
+   (fn [{:keys [value]}]
+     (wire/ok-text {:ok?   true
+                    :value value
+                    :build resolved-build}))
 
-    :rejected
-    (wire/ok-text {:ok?       false
-                   :reason    :rf.error/eval-cljs-rejected
-                   :rejection (:rejection mailbox-result)
-                   :build     resolved-build})
+   :on-rejected
+   (fn [{:keys [rejection]}]
+     (wire/ok-text {:ok?       false
+                    :reason    :rf.error/eval-cljs-rejected
+                    :rejection rejection
+                    :build     resolved-build}))
 
-    :timeout
-    (wire/ok-text {:ok?        false
-                   :reason     :rf.error/eval-cljs-timeout
-                   :timeout-ms timeout-ms
-                   :build      resolved-build})
+   :on-timeout
+   (fn [_]
+     (wire/ok-text {:ok?        false
+                    :reason     :rf.error/eval-cljs-timeout
+                    :timeout-ms timeout-ms
+                    :build      resolved-build}))
 
-    ;; :missing — defensive; should not happen in practice.
-    (wire/ok-text {:ok?    false
-                   :reason :rf.error/eval-cljs-mailbox-missing
-                   :hint   (str "eval-cljs await mailbox vanished before the result was read. "
-                                "This indicates a wire-shape regression or a page-reload "
-                                "destroying the mailbox between the wrap and the poll.")
-                   :build  resolved-build})))
-
-(defn- handle-sentinel
-  "Inspect the wrapper's synchronous return — a `:rf.mcp/await-direct`
-  map carries the form's value verbatim (non-thenable fast path);
-  a `:rf.mcp/await-mailbox` map kicks off the polling loop. Anything
-  else is a regression in `await-wrap-form` — surface a structured
-  error rather than silently returning the wrong shape."
-  [conn resolved-build timeout-ms sentinel]
-  (cond
-    (and (map? sentinel) (contains? sentinel :rf.mcp/await-direct))
-    (js/Promise.resolve
-      (wire/ok-text {:ok?   true
-                     :value (:rf.mcp/await-direct sentinel)
-                     :build resolved-build}))
-
-    (and (map? sentinel) (contains? sentinel :rf.mcp/await-mailbox))
-    (-> (poll-mailbox! conn resolved-build
-                       (:rf.mcp/await-mailbox sentinel)
-                       timeout-ms)
-        (.then (partial await-result->envelope resolved-build timeout-ms)))
-
-    :else
-    (js/Promise.resolve
-      (wire/ok-text {:ok?    false
-                     :reason :rf.error/eval-cljs-await-wrap-failed
-                     :hint   "the await wrapper returned an unrecognised sentinel"
-                     :sentinel (pr-str sentinel)
-                     :build  resolved-build}))))
+   :on-missing
+   (fn [{:keys [reason sentinel]}]
+     (if (= :bad-sentinel reason)
+       (wire/ok-text {:ok?      false
+                      :reason   :rf.error/eval-cljs-await-wrap-failed
+                      :hint     "the await wrapper returned an unrecognised sentinel"
+                      :sentinel sentinel
+                      :build    resolved-build})
+       (wire/ok-text {:ok?    false
+                      :reason :rf.error/eval-cljs-mailbox-missing
+                      :hint   (str "eval-cljs await mailbox vanished before the result was read. "
+                                   "This indicates a wire-shape regression or a page-reload "
+                                   "destroying the mailbox between the wrap and the poll.")
+                      :build  resolved-build})))})
 
 ;; ---------------------------------------------------------------------------
 ;; Tool entry point.
@@ -373,7 +216,7 @@
         build-id   (wire/arg-build conn args)
         explicit?  (wire/arg-build-explicit? conn args)
         await?     (boolean (wire/arg args :await))
-        timeout-ms (or (wire/arg args :timeout-ms) default-await-timeout-ms)
+        timeout-ms (or (wire/arg args :timeout-ms) await-promise/default-timeout-ms)
         ;; rf2-ntuzf — optional `:frame` arg targets a named frame for
         ;; the form's lexical scope. Same coercion as dispatch/
         ;; snapshot/get-path: bare names (\"rf/default\") and EDN-
@@ -417,9 +260,15 @@
                                                :build resolved-build}
                                         frame (assoc :frame frame))))))
                        ;; Await path (rf2-xn4f9) — wrap the form, dispatch
-                       ;; on the sentinel, poll the mailbox if needed.
-                       (let [mailbox-id (await-mailbox-key)
-                             wrapped    (await-wrap-form user-form mailbox-id)]
+                       ;; on the sentinel, poll the mailbox if needed. The
+                       ;; mailbox plumbing lives in `await-promise`
+                       ;; (rf2-gfu33); we supply the eval-cljs result
+                       ;; vocabulary via the callback seam.
+                       (let [mailbox-id (await-promise/mailbox-key)
+                             wrapped    (await-promise/wrap-form user-form mailbox-id)]
                          (-> (nrepl/cljs-eval-value conn resolved-build wrapped)
-                             (.then (partial handle-sentinel conn resolved-build timeout-ms)))))))
+                             (.then (fn [sentinel]
+                                      (await-promise/handle-sentinel
+                                        conn resolved-build timeout-ms sentinel
+                                        (sentinel-callbacks resolved-build timeout-ms)))))))))
             (.catch (fn [err] (probe/err->result :eval-error err))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -557,6 +557,43 @@
     {:isError? true
      :edn-submap {:ok? false :reason :no-new-epoch :frame :rf/xray}}}
 
+   ;; rf2-gfu33 — render-settle. `:await-render true` wraps the settle
+   ;; Promise in the await mailbox; the wrap-form eval returns the
+   ;; mailbox sentinel and the poll read resolves to the dispatch
+   ;; envelope with `:settled? true`. The emitted settle form MUST route
+   ;; the flush through the substrate-agnostic adapter primitive
+   ;; (`re-frame.interop/after-render`) + the paint boundary
+   ;; (`requestAnimationFrame`) and force synchronous dispatch.
+   {:fixture/id    :dispatch/await-render-settles
+    :fixture/doc   "dispatch :await-render true resolves to the dispatch envelope with :settled? true after the render flush, routed through the adapter contract (rf2-gfu33)."
+    :fixture/tool  "dispatch"
+    :fixture/args  {:event "[:counter/inc]" :await-render true}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ;; The wrap form (contains the await-mailbox sentinel literal)
+     ;; returns the mailbox sentinel; first-match-wins orders it before
+     ;; the read form.
+     [":rf.mcp/await-mailbox"     {:rf.mcp/await-mailbox "settle-mbx"}]
+     ;; The poll read resolves immediately to the settled dispatch
+     ;; envelope.
+     ["cljs.reader/read-string"   {:status :resolved
+                                   :value {:ok? true :epoch-id 9
+                                           :frame :rf/default
+                                           :settled? true
+                                           :cascade-summary {:event-id :counter/inc
+                                                             :renders 1}}}]
+     [:default                    nil]]
+    :fixture/eval-form-must-contain
+    ["re-frame.interop/after-render"
+     "requestAnimationFrame"
+     "pair-dispatch-sync!"
+     ":settled? true"]
+    :fixture/eval-form-must-not-contain
+    ["reagent" "setTimeout"]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :mode :sync :settled? true :epoch-id 9}}}
+
    ;; ---------- dispatch-dry-run (rf2-17hvp) ------------------------------
    ;; Dry-run is NOT --allow-writes-gated: the override-set ensures no
    ;; observable effect escapes, and restore-epoch rewinds the would-be

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
@@ -16,6 +16,7 @@
                               the security gate (rf2-vflrg)"
   (:require [cljs.test :refer-macros [deftest is async]]
             [cljs.reader]
+            [clojure.string :as str]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.dispatch :as dispatch]))
@@ -391,4 +392,193 @@
                      (is (= :queued (:mode edn)))
                      (is (true? (:cascade-summary-pending? edn)))
                      (is (= 12 (:before-epoch-id edn))))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; Render-settle — `:await-render` (rf2-gfu33).
+;;
+;; `dispatch :await-render true` resolves only AFTER the substrate has
+;; flushed the new state to the DOM and the next paint is scheduled, so
+;; `dispatch -> observe` is one deterministic step. Two invariants we
+;; pin here WITHOUT a sleep:
+;;
+;;   1. SHAPE: the emitted settle form routes the flush through the
+;;      substrate-agnostic adapter primitive `re-frame.interop/after-render`
+;;      and the paint boundary `js/requestAnimationFrame` — NOT a Reagent
+;;      API and NOT a `setTimeout` sleep. (form-substring assertions)
+;;   2. TIMING: the server awaits the render-settle Promise via the
+;;      shared mailbox — it POLLS until the mailbox flips off `:pending`,
+;;      so a settle that takes N polls resolves only once the flush has
+;;      reported done. We drive a stub mailbox that stays `:pending` for
+;;      the first few polls, then flips to `:resolved`, and assert the
+;;      tool waited (multiple poll reads) before resolving.
+;; ---------------------------------------------------------------------------
+
+(defn- await-wrap-form?
+  "True when the emitted form is the await-promise wrapper (the settle
+  Promise wrapped for the mailbox dance)."
+  [form-str]
+  (and (string? form-str)
+       (str/includes? form-str "__rf2pair_await__")
+       (str/includes? form-str ":rf.mcp/await-mailbox")))
+
+(defn- mailbox-read-form?
+  "True when the emitted form is the mailbox-read poll form."
+  [form-str]
+  (and (string? form-str)
+       (str/includes? form-str "__rf2pair_await__")
+       (str/includes? form-str "cljs.reader/read-string")))
+
+(defn- with-staged-mailbox-eval!
+  "Install a stub `cljs-eval-value` that plays the browser:
+
+    - the wrap-form eval records the form into `wrap-form*` and returns
+      the mailbox sentinel `{:rf.mcp/await-mailbox <id>}`;
+    - the mailbox-read polls return `{:status :pending}` for the first
+      `pending-polls` reads, then `{:status :resolved :value resolved}`.
+
+  `read-count*` records how many poll reads happened — the deterministic
+  proof the server waited for the flush rather than resolving eagerly."
+  [{:keys [wrap-form* read-count* pending-polls resolved]} body-fn]
+  (let [orig nrepl/cljs-eval-value
+        respond (fn [form-str]
+                  (cond
+                    (await-wrap-form? form-str)
+                    (do (reset! wrap-form* form-str)
+                        (js/Promise.resolve {:rf.mcp/await-mailbox "settle-mbx"}))
+
+                    (mailbox-read-form? form-str)
+                    (let [n (swap! read-count* inc)]
+                      (js/Promise.resolve
+                        (if (<= n pending-polls)
+                          {:status :pending}
+                          {:status :resolved :value resolved})))
+
+                    :else
+                    (js/Promise.resolve nil)))
+        stub (fn
+               ([_conn _build-id form-str] (respond form-str))
+               ([_conn _build-id form-str _opts] (respond form-str)))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+(deftest await-render-emits-substrate-agnostic-flush-form
+  ;; SHAPE invariant: the settle form must flush via the adapter
+  ;; primitive `re-frame.interop/after-render` and pin resolution to the
+  ;; paint boundary with `js/requestAnimationFrame`. It must NOT name a
+  ;; substrate API (reagent/*) and must NOT sleep via setTimeout.
+  (async done
+    (let [wrap-form*  (atom nil)
+          read-count* (atom 0)]
+      (-> (with-staged-mailbox-eval!
+            {:wrap-form* wrap-form* :read-count* read-count*
+             :pending-polls 0
+             :resolved {:ok? true :epoch-id 9 :frame :rf/default :settled? true
+                        :cascade-summary {:renders 1}}}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:counter/inc]" :await-render true})))
+          (.then (fn [_]
+                   (let [form @wrap-form*]
+                     (is (string? form))
+                     (is (str/includes? form "re-frame.interop/after-render")
+                         "flush routes through the substrate-agnostic adapter primitive")
+                     (is (str/includes? form "requestAnimationFrame")
+                         "resolution pinned to the paint boundary")
+                     (is (not (str/includes? form "reagent"))
+                         "no hardcoded Reagent API — substrate-agnostic")
+                     (is (not (str/includes? form "setTimeout"))
+                         "no sleep — deterministic settle, not a timer")
+                     ;; await-render forces sync dispatch (cascade must
+                     ;; commit before the render can settle).
+                     (is (str/includes? form "pair-dispatch-sync!")
+                         "await-render forces synchronous dispatch")
+                     (is (str/includes? form ":settled? true")
+                         "settle form merges :settled? true into the result"))
+                   (done)))))))
+
+(deftest await-render-waits-for-flush-then-resolves
+  ;; TIMING invariant: the server polls the mailbox until the flush
+  ;; reports done. We hold the mailbox `:pending` for 3 polls; the tool
+  ;; must NOT resolve until the flush flips it to `:resolved`. The proof
+  ;; the wait was real (not a sleep): >= 4 poll reads occurred and the
+  ;; final envelope carries the post-settle value with :settled? true.
+  (async done
+    (let [wrap-form*  (atom nil)
+          read-count* (atom 0)]
+      (-> (with-staged-mailbox-eval!
+            {:wrap-form* wrap-form* :read-count* read-count*
+             :pending-polls 3
+             :resolved {:ok? true :epoch-id 9 :frame :rf/default :settled? true
+                        :cascade-summary {:renders 1 :event-id :counter/inc}}}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:counter/inc]" :await-render true})))
+          (.then (fn [r]
+                   (is (not (err? r)) "settle resolves to a success envelope")
+                   (is (>= @read-count* 4)
+                       "server polled past the pending phase — waited for the flush")
+                   (let [edn (read-result-text r)]
+                     (is (true? (:ok? edn)))
+                     (is (= :sync (:mode edn))
+                         "await-render reports :sync mode (forced)")
+                     (is (true? (:settled? edn))
+                         "result confirms the render settled")
+                     (is (= :counter/inc (get-in edn [:cascade-summary :event-id]))
+                         "the dispatch cascade-summary rides through after settle"))
+                   (done)))))))
+
+(deftest await-render-runtime-failure-surfaces-as-error
+  ;; If the dispatch itself no-op'd (frame untargetable), the settle form
+  ;; still resolves — but to the runtime's {:ok? false ...} envelope. The
+  ;; tool MUST surface that as an :isError (the rf2-ldfnx invariant holds
+  ;; through the settle path), never a {:mode :sync :settled? true}
+  ;; success.
+  (async done
+    (let [read-count* (atom 0)]
+      (-> (with-staged-mailbox-eval!
+            {:wrap-form* (atom nil) :read-count* read-count*
+             :pending-polls 0
+             :resolved {:ok? false :reason :no-new-epoch :settled? true
+                        :frame :rf/gone
+                        :hint "head did not advance."}}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:counter/inc]"
+                                           :frame ":rf/gone"
+                                           :await-render true})))
+          (.then (fn [r]
+                   (is (err? r) "runtime :ok? false ⇒ :isError even on the settle path")
+                   (let [edn (read-result-text r)]
+                     (is (false? (:ok? edn)))
+                     (is (= :no-new-epoch (:reason edn)))
+                     (is (not (contains? edn :mode))
+                         "NO :mode slot — the dispatch did not land"))
+                   (done)))))))
+
+(deftest await-render-timeout-surfaces-structured-error
+  ;; If the mailbox never flips off :pending within timeout-ms, the tool
+  ;; returns a structured :rf.error/dispatch-await-render-timeout — not a
+  ;; hang, not a false success. We use a tiny timeout-ms so the test is
+  ;; fast and deterministic (the mailbox stays pending forever).
+  (async done
+    (let [read-count* (atom 0)]
+      (-> (with-staged-mailbox-eval!
+            {:wrap-form* (atom nil) :read-count* read-count*
+             ;; never resolves — pending-polls larger than any poll count
+             ;; reachable inside the short timeout window
+             :pending-polls 1000000
+             :resolved {:ok? true}}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:counter/inc]"
+                                           :await-render true
+                                           :timeout-ms 60})))
+          (.then (fn [r]
+                   (is (err? r))
+                   (let [edn (read-result-text r)]
+                     (is (= :rf.error/dispatch-await-render-timeout (:reason edn)))
+                     (is (= 60 (:timeout-ms edn))))
                    (done)))))))


### PR DESCRIPTION
## What

`dispatch-sync` returns after the handler commits app-db, but the substrate (Reagent / the React spine) re-renders on a LATER tick — so "dispatch then observe the DOM" previously needed a manual `requestAnimationFrame` dance inside `eval-cljs` (the rf2-yng0y investigation needed double-rAF waits throughout).

This adds an **`:await-render`** option on the `dispatch` tool: when set, the tool resolves only AFTER the substrate has flushed the new state to the DOM and the next paint is scheduled. `dispatch -> observe` becomes one deterministic step.

## Adapter-contract approach (substrate-agnostic)

The flush is **not** a Reagent API call. The generated runtime form calls `re-frame.interop/after-render` — the framework's render-settle primitive, which routes through the `:adapter/after-render` late-bind hook (Spec 006 §Substrate adapter contract). Each adapter already publishes its substrate-native impl:

- Reagent → `r/after-render` (post-commit)
- UIx / Helix spine → a `React.useLayoutEffect`-backed queue drain (post-commit / pre-paint, rf2-334d9)
- plain-atom / SSR → `next-tick`

`after-render` fires once the DOM reflects the new state; the form then chains **one** `requestAnimationFrame` so resolution lands at the paint boundary (environments without rAF resolve straight off the after-render callback). The MCP server therefore never names Reagent, UIx, or Helix — the flush is fully routed through the existing adapter contract. **No core/adapter co-edit was needed** — `after-render` is already a live contract surface.

## Wire contract (the new option)

`dispatch` gains two input args:

| arg | type | default | meaning |
|---|---|---|---|
| `await-render` | bool | `false` | resolve only after substrate flush + next paint |
| `timeout-ms` | integer | `5000` | render-settle deadline |

- `:await-render` forces **synchronous** dispatch (the cascade must commit before the render can settle); `:trace` still wins for the assembled epoch.
- On success the result is the `pair-dispatch-sync!` envelope (`:cascade-summary`, `:epoch-id`, …) with `:mode :sync :settled? true` merged in.
- The runtime form's synchronous return is a browser-side Promise; the server awaits it through the shared await mailbox — the same plumbing `eval-cljs :await` uses, now extracted to a new `await_promise.cljs` ns so both tools share it (no duplication; `eval-cljs` refactored to the callback seam, emitted forms byte-identical).
- The rf2-ldfnx success-vs-error contract holds through the settle path: a runtime `:ok? false` (frame untargetable) still surfaces as an `:isError` envelope with no `:mode` slot.
- A settle exceeding `:timeout-ms` returns `:reason :rf.error/dispatch-await-render-timeout`.

**No new tool** — the option rides on the existing `dispatch` surface, so `tool-names.json` / verb-vocab are unchanged and registry + wire-vocab conformance edits stay minimal (easy rebases for the queued pair-MCP siblings). Tool-local spec updated in-PR (`003-Tool-Catalogue.md`, `API.md`).

## Quality gates

All run locally on Windows from the worktree.

- **Node tools/re-frame2-pair-mcp (shadow-cljs :server-test)** — `npm run test`: **654 tests, 1809 assertions, 0 failures, 0 errors**. Includes the new deterministic await-render unit tests (see below) and the new conformance fixture.
- **MCP conformance tools/re-frame2-pair-mcp (rf2-cum40)** — `node scripts/test-all.cjs`: **ALL CONFORMANCE TESTS GREEN** (re-frame2-pair-mcp end-to-end SDK Client driver validates the live `tools/list` schema with the new args; story-mcp + flag-gates green too).
- **MCP conformance wire-vocab** — `clojure -M:test` in `tools/mcp-conformance/wire-vocab`: **48 tests, 605 assertions, 0 failures, 0 errors**.
- **stdio-roundtrip (tool-names parity)** — `npm run stdio-roundtrip`: **GREEN** — tool list unchanged (18 tools), schema parses.
- **Production server bundle** — `npx shadow-cljs compile server`: **0 warnings** (bundle isolation / elision intact).
- **clj-kondo on changed files** — **0 errors**. 4 warnings, all pre-existing on `origin/main` (verified via `git show origin/main:...dispatch.cljs | clj-kondo`); zero introduced.

### New test — proves await-render resolves AFTER a render flush (deterministic, not a sleep)

`dispatch_test.cljs` adds four arms:

1. `await-render-emits-substrate-agnostic-flush-form` — **SHAPE**: the emitted settle form contains `re-frame.interop/after-render` + `requestAnimationFrame` + `pair-dispatch-sync!` + `:settled? true`, and does **not** contain `reagent` or `setTimeout` (substrate-agnostic, no sleep).
2. `await-render-waits-for-flush-then-resolves` — **TIMING**: a stub mailbox stays `:pending` for 3 polls then flips to `:resolved`; the test asserts the server polled `>= 4` times (waited for the flush) before resolving, and the dispatch `:cascade-summary` rides through.
3. `await-render-runtime-failure-surfaces-as-error` — a runtime `:ok? false` still surfaces as `:isError` with no `:mode` (rf2-ldfnx invariant through the settle path).
4. `await-render-timeout-surfaces-structured-error` — pending-forever mailbox + tiny `timeout-ms` → `:rf.error/dispatch-await-render-timeout`.

Conformance corpus fixture `:dispatch/await-render-settles` pins the wire shape (`eval-form-must-contain` after-render/rAF/sync, `must-not-contain` reagent/setTimeout, `:settled? true` in the result).

Closes rf2-gfu33.