### PR TITLE
refactor(xray/epoch): remove the redundant per-stage status glyph (rf2-9wq0v)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -2321,7 +2321,7 @@ when no violation attached to that step. Hot-reload drift no
 longer rides any pipeline step (rf2-7gf7v); it surfaces in the
 Issues panel only.
 
-### §9.1.10.4 Inline EXCEPTION attachment + per-step ✓/✗ status (rf2-ahhgn)
+### §9.1.10.4 Inline EXCEPTION attachment + per-step status (rf2-ahhgn)
 
 > **Motivation.** A handler / interceptor / coeffect / fx / flow
 > EXCEPTION (distinct from a schema VIOLATION) leaves a
@@ -2330,24 +2330,35 @@ Issues panel only.
 > clean. Clicking button-15 (`:standard-epochs/throw-handler`) showed
 > nothing explaining the failure, and the framework epoch
 > `:outcome` read `:ok`. This section adds inline per-step error
-> cards + a per-step pass/fail glyph + a tool-side outcome so a
-> failed event is visible where the operator is already looking.
+> cards + a tool-side outcome so a failed event is visible where the
+> operator is already looking.
 
-**Per-step ✓/✗ status primitive.** Every pipeline step carries a
-`:status` of `:ok` / `:error` (`projection/step-status`). The view
-paints a glyph immediately after the step's badge pill —
-`badge/step-status-glyph` (✓ / ✗) coloured by
-`badge/step-status-colour` (`:success` green / `:error` red). A
-clean step paints the quiet green ✓; a failed step paints the bold
-red ✗ so the operator eye-scans the cascade for the failing step
-without reading every label. `step-status` reads the step's
-stamped `:status` slot first, then falls back to scanning the
-step-level + row-level `:errors` / `:violations` vecs (so a step
-that gained a schema violation via `attach-violations` — which does
-not stamp `:status` — still reads `:error`). **rf2-kt6js reuses
-this exact `:status` shape + the `badge/step-status-*` resolver for
-its SIDE-EFFECTS sub-steps' per-effect ticks — it is a shared
-primitive, not a one-off.**
+**Per-step status (no per-stage glyph — rf2-9wq0v).** Every pipeline
+step carries a `:status` of `:ok` / `:error` / `:skipped`
+(`projection/step-status`). `step-status` reads the step's stamped
+`:status` slot first, then falls back to scanning the step-level +
+row-level `:errors` / `:violations` vecs (so a step that gained a
+schema violation via `attach-violations` — which does not stamp
+`:status` — still reads `:error`).
+
+rf2-ahhgn originally painted a per-stage ✓/✗/⊘ glyph immediately after
+each step's badge pill (off a `badge/step-status-glyph` /
+`badge/step-status-colour` resolver). **rf2-9wq0v RETIRED that
+per-stage glyph** (and the `badge/step-status-set` / `step-status?` /
+`step-status-glyph` / `step-status-token-key` / `step-status-colour`
+resolver primitive it rendered through): a clean run painted a quiet ✓
+on every stage — no information — and a failure is already shown by the
+inline exception card UNDER the failing stage (below; rf2-yz57h /
+rf2-wnvid), so the per-stage ✗ was redundant. The pipeline reads
+quieter without it.
+
+`projection/step-status` SURVIVES — it still drives (a) the SKIPPED-body
+branch (`:skipped` → the "did not run" placeholder, below) and (b) the
+overall cascade-outcome banner (`cascade-outcome` / `epoch-outcome`,
+which scan the step vector for any `:error`). The per-EFFECT SIDE-EFFECTS
+ledger glyphs (`badge/fx-row-status-glyph`, §9.1.10.x SIDE EFFECTS) and
+the machine cascade-outcome glyph (`badge/cascade-outcome-glyph`) are
+distinct per-row / per-cascade signals and are UNAFFECTED.
 
 **Exception harvesting + attachment.** The projection harvests the
 `cascade-exception-ops` subset into per-step error records
@@ -2418,10 +2429,11 @@ placeholder body ("The handler did not run — an upstream step threw
 before this step could execute.") instead of the normal body. An
 interceptor `:after` throw is NOT a skip — the handler ran first; the
 throw fired on the way out. `step-status` gains a third value `:skipped`
-(distinct from `:ok` / `:error`); the header glyph is a muted `⊘`
-(`badge/step-status-glyph :skipped`, `:text-tertiary` tone) — a skip is
-NEUTRAL, not a failure, so it does NOT inflate the epoch outcome (the
-failing COEFFECT / INTERCEPTOR step is the load-bearing `:error` signal).
+(distinct from `:ok` / `:error`) which drives the SKIPPED placeholder
+body; the SKIPPED body itself ("did not run") carries the signal (the
+per-stage `⊘` glyph retired in rf2-9wq0v). A skip is NEUTRAL, not a
+failure, so it does NOT inflate the epoch outcome (the failing COEFFECT /
+INTERCEPTOR step is the load-bearing `:error` signal).
 
 **Inline error card (rf2-ahhgn · refined rf2-wnvid).** `view/error-block`
 renders a red-edged card (sibling to the amber schema-violation card;
@@ -2610,12 +2622,16 @@ PRESENTATION over already-recorded data — implemented tool-side in
 reshapes that presentation (3-tier → flat ledger); the data source is
 unchanged.
 
-**Header chrome** — badge `:SIDE-EFFECTS` + the single overall `✓ / ✗`
-badge glyph (rf2-j630b). No verb, no `(post-commit)` caption, no
-threw-count chip — the per-row glyphs carry per-effect outcome and the
-single badge carries the at-a-glance overall outcome (the rf2-m8ac9
-"count summary is noise" rationale carries through; rf2-j630b extends it
-to drop the post-commit labels too).
+**Header chrome** — badge `:SIDE-EFFECTS` only. No verb, no
+`(post-commit)` caption, no threw-count chip — the per-row glyphs
+(`badge/fx-row-status-glyph`) carry per-effect outcome and are the whole
+signal (the rf2-m8ac9 "count summary is noise" rationale carries through;
+rf2-j630b extended it to drop the post-commit labels too). rf2-j630b's
+single overall `✓ / ✗` badge glyph was **RETIRED in rf2-9wq0v** along
+with the other per-stage glyphs — it duplicated what the per-row ledger
+already shows. The `:rows`-level AND-of-rows outcome stays queryable via
+`projection/side-effects-badge-status` (tests + the cascade-outcome
+banner).
 
 **Per-action attribution** — when the cascade was driven by a machine
 handler, each `:fx` ledger row that maps to a fx-id emitted by an

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -351,70 +351,20 @@
     :cancelled "·"
     "·"))
 
-;; ---- Per-step pass/fail status primitive (rf2-ahhgn) --------------------
+;; rf2-9wq0v retired the per-STAGE status glyph primitive that used to
+;; live here (`step-status-set` / `step-status?` / `step-status-token-key`
+;; / `step-status-colour` / `step-status-glyph`, rf2-ahhgn · rf2-yz57h). A
+;; clean run painted a quiet ✓ on every stage badge — no information — and
+;; a failure is already surfaced by the inline exception card UNDER the
+;; failing stage (rf2-yz57h / rf2-wnvid), so the per-stage ✗ was redundant
+;; too. The pipeline reads quieter without it.
 ;;
-;; Every pipeline step (DISPATCH / COEFFECT / HANDLER / FLOW / FX /
-;; SUBSCRIPTIONS / VIEWS) carries a `:status` of `:ok` or `:error`
-;; (projection/`step-status`). The view paints a ✓ (ok) / ✗ (error)
-;; glyph on each step header off this primitive so the operator
-;; eye-scans the cascade for the FAILING step without reading every
-;; label — the failure that pre-rf2-ahhgn was invisible (handler /
-;; interceptor / coeffect / fx exceptions surfaced NOWHERE in the
-;; cascade).
-;;
-;; This is the GENERAL per-step status shape rf2-kt6js's SIDE-EFFECTS
-;; sub-steps reuse for their per-effect ticks (:db / :fx / other) — one
-;; glyph + token resolver, not a one-off. The closed `:ok` / `:error`
-;; set mirrors the machine-cascade row outcome chrome above (✓ green /
-;; ✗ red); a step with no failure reads `:ok` and paints the quiet ✓.
-
-(def step-status-set
-  "Closed set of per-step statuses (rf2-ahhgn · rf2-yz57h). Tests + the
-  view's glyph-resolver bail-out read this set.
-
-  rf2-yz57h adds `:skipped` — a step that never RAN because an upstream
-  `:before`-chain throw aborted the cascade (the handler is skipped when a
-  coeffect injector or a `:before` interceptor throws). Distinct from `:ok`
-  (the step ran cleanly) and `:error` (the step ran + failed)."
-  #{:ok :error :skipped})
-
-(defn step-status?
-  "Predicate — `status` keyword is a member of `step-status-set`."
-  [status]
-  (contains? step-status-set status))
-
-(defn step-status-token-key
-  "Theme-token keyword for a per-step status glyph colour (rf2-ahhgn ·
-  rf2-yz57h):
-    :ok      → :success         (✓ green)
-    :error   → :error           (✗ red)
-    :skipped → :text-tertiary   (⊘ muted — neutral; the step didn't run,
-                                  it is NOT a failure)
-  Falls back to `:success` for unknown statuses so a never-failed step
-  paints the quiet success tick."
-  [status]
-  (case status
-    :error   :error
-    :skipped :text-tertiary
-    :success))
-
-(defn step-status-colour
-  "CSS-variable string for a per-step status glyph (rf2-ahhgn)."
-  [status]
-  (get tokens/tokens (step-status-token-key status)
-       (get tokens/tokens :success)))
-
-(defn step-status-glyph
-  "Single-char glyph for a per-step status (rf2-ahhgn · rf2-yz57h):
-    :ok      → \"✓\"
-    :error   → \"✗\"
-    :skipped → \"⊘\"  (circled-slash — 'did not run', muted/neutral)
-  Defaults to the success tick for unknown statuses."
-  [status]
-  (case status
-    :error   "✗"
-    :skipped "⊘"
-    "✓"))
+;; The per-step `:ok` / `:error` / `:skipped` SHAPE still lives in the
+;; projection (`projection/step-status`) — it feeds the overall
+;; cascade-outcome banner (`cascade-outcome`, the `(some #(= :error …))`
+;; scan) — and the per-EFFECT outcome glyphs (`fx-row-status-glyph`,
+;; below) plus the cascade-outcome banner (`cascade-outcome-glyph`, above)
+;; carry the surviving, distinct signals.
 
 ;; ---- Flat SIDE EFFECTS ledger row glyphs (rf2-j630b) --------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -2219,9 +2219,12 @@
                  must NOT read as 'ran, returned no :db'.
     `:ok`      — otherwise (the step ran cleanly).
 
-  The view paints a ✓ (`:ok`) / ✗ (`:error`) / ⊘ (`:skipped`) glyph on
-  every step header off this primitive; rf2-kt6js's SIDE-EFFECTS sub-steps
-  reuse the same shape for their per-effect ticks.
+  The view no longer paints a per-stage glyph off this primitive (the
+  per-stage ✓/✗/⊘ retired in rf2-9wq0v — a clean run was all ticks / no
+  information, and a failure already shows on its inline exception card).
+  This status still drives the SKIPPED-body branch (`:skipped` → the
+  'did not run' placeholder) and the overall cascade-outcome banner
+  (`cascade-outcome` / `epoch-outcome` scan `:error`).
 
   A failure (`:error`) takes precedence over a skip — a step that both was
   marked skipped AND carries an attached error reads `:error` (the error is

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -203,19 +203,6 @@
    :font-size   "10px"
    :margin-left "4px"})
 
-;; rf2-ahhgn — per-step pass/fail status glyph. Rides immediately after
-;; the badge pill so the ✓/✗ reads as a property OF the step. Quiet ✓
-;; on success (green, low weight — not alarmist); bold ✗ on failure
-;; (red) so a failing step jumps out of an otherwise-clean cascade. The
-;; colour resolves off `badge/step-status-colour` at render time
-;; (per-step), so it is NOT folded into this hoisted base.
-(def ^:private step-header-status-glyph-base-style
-  {:font-family mono-stack
-   :font-size   "12px"
-   :font-weight 700
-   :line-height 1
-   :flex        "0 0 auto"})
-
 ;; -- sub-header -----------------------------------------------------------
 
 (def ^:private sub-header-style
@@ -722,10 +709,11 @@
   {:color text-tertiary-colour})
 
 ;; The flat SIDE EFFECTS ledger (rf2-j630b) carries NO header verb /
-;; caption — the single badge ✓/✗ + the per-row glyphs are the whole
-;; signal. The pre-rf2-j630b `(post-commit)` caption + `N threw` chip
-;; styles (`fx-verb-style` / `fx-caption-style` / `fx-threw-style`)
-;; retired with the 3-tier presentation.
+;; caption — the per-row glyphs (`fx-row-status-glyph`) are the whole
+;; signal (the per-stage badge glyph retired in rf2-9wq0v). The
+;; pre-rf2-j630b `(post-commit)` caption + `N threw` chip styles
+;; (`fx-verb-style` / `fx-caption-style` / `fx-threw-style`) retired with
+;; the 3-tier presentation.
 
 (def ^:private margin-top-5-style
   {:margin-top "5px"})
@@ -1282,8 +1270,9 @@
 ;; placeholder body — a muted italic line stating the step did not run —
 ;; instead of the normal body (whose `:db` sub-section would otherwise read
 ;; the misleading "— no :db (handler returned no :db)" even though the
-;; handler's body DOES return a :db; it simply never executed). The header
-;; glyph is the muted ⊘ (`badge/step-status-glyph :skipped`).
+;; handler's body DOES return a :db; it simply never executed). The
+;; SKIPPED placeholder body itself carries the "did not run" signal
+;; (the per-stage header glyph retired in rf2-9wq0v).
 (def ^:private skipped-body-style
   {:margin-top  "5px"
    :padding     "6px 8px"
@@ -1405,10 +1394,10 @@
 
 ;; rf2-ahhgn epoch outcome banner — RETIRED (rf2-wnvid). The top-of-
 ;; pipeline "This event failed — see the ✗ step below." banner restated
-;; what the cascade now shows inline (the failing step's red ✗ glyph +
-;; the 'Exception Thrown' card). `outcome-banner-error-style` +
-;; `outcome-banner` are gone; the panel root keeps `data-rf-xray-outcome`
-;; for tools / e2e.
+;; what the cascade now shows inline (the failing step's 'Exception
+;; Thrown' card; the per-stage ✗ glyph itself retired in rf2-9wq0v).
+;; `outcome-banner-error-style` + `outcome-banner` are gone; the panel
+;; root keeps `data-rf-xray-outcome` for tools / e2e.
 
 ;; ---- expansion state helpers ---------------------------------------------
 ;;
@@ -1546,41 +1535,20 @@
 ;; with the default `:color "inherit"` + `:margin-left "4px"` knobs,
 ;; which match this panel's prior shape exactly.
 
-(defn- step-status-glyph
-  "Render the per-step ✓/✗/⊘ status glyph (rf2-ahhgn · rf2-yz57h).
-  `status` is the `:ok` / `:error` / `:skipped` keyword from
-  `projection/step-status`; the colour + glyph resolve off the shared
-  `badge/step-status-*` primitive (the same one rf2-kt6js's SIDE-EFFECTS
-  sub-steps reuse). `:skipped` (rf2-yz57h) is the step that never RAN
-  because an upstream `:before`-chain throw aborted the cascade — a muted
-  ⊘ that reads as 'did not run', NOT a failure. `testid` keys the
-  `-status` suffix + the `data-rf-xray-step-status` attribute tests +
-  the issues-ribbon eye-scan read."
-  [status testid]
-  (let [[aria title] (case status
-                       :error   ["step failed"  "this step failed"]
-                       :skipped ["step skipped" "this step was skipped — an upstream step threw before it could run"]
-                       ["step ok" "this step ran cleanly"])]
-    [:span {:data-testid (str testid "-status")
-            :data-rf-xray-step-status (name (or status :ok))
-            :aria-label aria
-            :title title
-            :style (assoc step-header-status-glyph-base-style
-                          :color (badge/step-status-colour status))}
-     (badge/step-status-glyph status)]))
-
 (defn- step-header
-  "Render a step's header row — badge pill + per-step ✓/✗ status glyph
-  (rf2-ahhgn) + verb/label + optional duration. The flex layout keeps
-  the duration right-aligned via `margin-left: auto`. The whole header
-  is wrapped in an interactive `<div>` so clicking anywhere on the row
-  toggles `expanded?` when the step carries expandable content
-  (`expandable?` true).
+  "Render a step's header row — badge pill + verb/label + optional
+  duration. The flex layout keeps the duration right-aligned via
+  `margin-left: auto`. The whole header is wrapped in an interactive
+  `<div>` so clicking anywhere on the row toggles `expanded?` when the
+  step carries expandable content (`expandable?` true).
 
-  `:status` is the step's `:ok` / `:error` pass-fail (rf2-ahhgn) — the
-  glyph is omitted when no status is supplied so test callers + non-step
-  headers (none today) stay unchanged."
-  [{:keys [badge verb expandable? expanded? testid duration-ms status]} on-toggle]
+  rf2-9wq0v retired the per-stage ✓/✗/⊘ status glyph that used to ride
+  immediately after the badge pill — a clean run painted a tick on every
+  stage (no information), and a failure is already shown by the inline
+  exception card UNDER the failing stage (rf2-yz57h / rf2-wnvid). The
+  overall cascade-outcome banner + the per-EFFECT SIDE-EFFECTS ledger
+  glyphs carry the surviving signals."
+  [{:keys [badge verb expandable? expanded? testid duration-ms]} on-toggle]
   [:div {:data-testid (str testid "-header")
          :on-click    (when (and expandable? on-toggle)
                         (fn [e]
@@ -1590,8 +1558,6 @@
                   step-header-pointer-style
                   step-header-default-cursor-style)}
    (badge-pill badge)
-   (when status
-     (step-status-glyph status testid))
    [:span {:data-testid (str testid "-verb")
            :style step-header-verb-style}
     verb]
@@ -1935,7 +1901,6 @@
                   (dispatch-source-label source coord)]))
        :expandable? false
        :testid "rf-xray-epoch-dispatch"
-       :status (proj/step-status step)
        :duration-ms duration-ms}
       nil)
     (dispatch-body step)
@@ -1996,7 +1961,7 @@
   injecting N user-defined cofx; system-injected cofx (e.g.
   framework-auto `:db`, `:event`) are filtered at projection time
   (rf2-cq0ch + the `system-cofx-ids` set)."
-  [{:keys [id value no-value? step-number violations errors] :as step}]
+  [{:keys [id value no-value? step-number violations errors]}]
   (let [cofx-meta  (when (keyword? id)
                      (try (rf/handler-meta :cofx id)
                           (catch :default _ nil)))
@@ -2019,8 +1984,7 @@
                                      {:style       coeffect-verb-link-button-style
                                       :plain-style coeffect-verb-plain-style})
         :expandable? false
-        :testid (str "rf-xray-epoch-coeffect-" (name id))
-        :status (proj/step-status step)}
+        :testid (str "rf-xray-epoch-coeffect-" (name id))}
        nil)
      ;; Body — `+ [:cofx-id] <value>` diff-style line. Per pair-debug
      ;; 2026-05-26 the body sits left-aligned with the badge (no
@@ -2137,7 +2101,7 @@
   phase chip + the shared 'Exception Thrown' card. The step's `:errors`
   slot (attached by `attach-exceptions`) is rendered per-row by matching
   the exception's `:failing-id` to the row's `:interceptor-id`."
-  [{:keys [rows step-number errors] :as step}]
+  [{:keys [rows step-number errors]}]
   ;; The step-level `:errors` (from `attach-exceptions`) carry the exception
   ;; records; thread each onto its matching row by `:failing-id`.
   (let [rows* (mapv (fn [row]
@@ -2154,8 +2118,7 @@
         :verb (str (count rows) " interceptor"
                    (when (not= 1 (count rows)) "s") " threw")
         :expandable? false
-        :testid "rf-xray-epoch-interceptor"
-        :status (proj/step-status step)}
+        :testid "rf-xray-epoch-interceptor"}
        nil)
      [:div {:style margin-top-5-style}
       (map-indexed (fn [i row] (interceptor-row-view i row)) rows*)]]))
@@ -2933,7 +2896,6 @@
         :verb (handler-verb-link flavour event-id)
         :expandable? false
         :testid "rf-xray-epoch-handler"
-        :status status
         ;; rf2-yz57h — a skipped handler has no real duration (it never
         ;; ran); elide the chip.
         :duration-ms (when-not skipped? duration-ms)}
@@ -2992,8 +2954,7 @@
   (a pre-rf2-ta0y7 runtime, or neither t1 nor t2 on the stream) the
   body falls back to the per-path `[path] before → after` scalar line."
   [{:keys [flow-id path before after duration-ms step-number
-           db-pre-flow db-post-flow errors]
-    :as step}]
+           db-pre-flow db-post-flow errors]}]
   (let [flow-meta  (when (keyword? flow-id)
                      (try (rf/handler-meta :flow flow-id)
                           (catch :default _ nil)))
@@ -3028,7 +2989,6 @@
                                       :plain-style coeffect-verb-plain-style})
         :expandable? false
         :testid (str "rf-xray-epoch-flow-" (name flow-id))
-        :status (proj/step-status step)
         :duration-ms duration-ms}
        nil)
      (if db-diff?
@@ -3215,10 +3175,12 @@
   a bare reg-event-db that returns only `:db` (`db-commit?` keys off
   `:rf.event/db-changed`).
 
-  After the 'SIDE EFFECTS' badge the header paints ONE overall glyph —
-  TICK when every present row succeeded, CROSS when one or more FAILED
-  (`proj/side-effects-badge-status` is the AND of the flat `:rows`;
-  SKIPPED rows are NEUTRAL).
+  The SIDE EFFECTS badge carries NO overall stage glyph (the per-stage
+  ✓/✗ retired in rf2-9wq0v — a clean run was an all-tick row of no
+  information, and a failure already shows on its own row + exception
+  card). The per-EFFECT row glyphs are the whole signal. `:rows`-level
+  outcome is still queryable via `proj/side-effects-badge-status` for the
+  cascade-outcome banner + tests.
   There are NO post-commit / best-effort labels and NO group headers: the
   body is one row per effect, in EXECUTION order, each via
   `fx-row-with-violations`:
@@ -3239,7 +3201,7 @@
   exception-under-step rendering. `:fx-args` / fx exception attachments
   that didn't match a row attach to the step level (rf2-xgeag /
   rf2-ahhgn) and render at the foot. `:db` schema-fail (pre-commit) →
-  just the `:db` CROSS row + badge cross, no fx rows (atomicity)."
+  just the `:db` CROSS row, no fx rows (atomicity)."
   [{:keys [rows step-number threw violations errors] :as step}]
   (let [skipped? (= :skipped (proj/step-status step))]
     [:div {:data-testid "rf-xray-epoch-step-side-effects"
@@ -3250,19 +3212,7 @@
        {:step :side-effects
         :badge :SIDE-EFFECTS
         :expandable? false
-        :testid "rf-xray-epoch-side-effects"
-        ;; rf2-yz57h — when the step was skipped (an upstream `:before`-chain
-        ;; throw aborted the cascade before any side effect ran) the header
-        ;; glyph is the muted ⊘ via the generic `step-status`. Otherwise the
-        ;; single overall badge glyph is the AND of the present ledger rows
-        ;; (`side-effects-badge-status`, rf2-j630b): cross iff a row is a real
-        ;; failure (its `:status` is `:error` / `:rollback`, or it carries an
-        ;; attached exception / violation); SKIPPED-on-platform rows are
-        ;; neutral. The row-level AND is distinct from the generic
-        ;; `step-status` (which keys off the step's own `:status` +
-        ;; attachments only) because a row's `:status :error` / `:rollback`
-        ;; must trip the badge too.
-        :status (if skipped? :skipped (proj/side-effects-badge-status rows))}
+        :testid "rf-xray-epoch-side-effects"}
        nil)
      (if skipped?
        ;; rf2-yz57h — side effects never ran (upstream `:before`-chain throw).
@@ -3677,7 +3627,7 @@
   bar's click dispatches into that same captured frame — so toggle
   writes + reads hit THIS instance's Xray app-db (N isolated shells
   stay independent), not the `:rf/xray` singleton."
-  [{:keys [rows disposed-rows step-number violations] :as step}]
+  [{:keys [rows disposed-rows step-number violations]}]
   (let [frame         (rf/current-frame)
         mode          @(rf/subscribe frame
                                      [:rf.xray.epoch/subs-filter-mode])
@@ -3713,8 +3663,7 @@
                  [:span {:style subs-disposed-count-style}
                   (str l " disposed")])]
         :expandable? false
-        :testid "rf-xray-epoch-subscriptions"
-        :status (proj/step-status step)}
+        :testid "rf-xray-epoch-subscriptions"}
        nil)
      (when (pos? n)
        (subscriptions-table visible-rows))
@@ -3910,7 +3859,7 @@
   surfaces are non-empty; collapses to `N re-rendered` or `M
   unmounted` when one half is absent. The unmounted sub-section
   is omitted entirely when no unmount-trace events fired."
-  [{:keys [rows unmounted-rows step-number] :as step}]
+  [{:keys [rows unmounted-rows step-number]}]
   (let [n (count rows)
         m (count unmounted-rows)
         verb (cond
@@ -3928,8 +3877,7 @@
         :badge :VIEWS
         :verb verb
         :expandable? false
-        :testid "rf-xray-epoch-views"
-        :status (proj/step-status step)}
+        :testid "rf-xray-epoch-views"}
        nil)
      (when (pos? n)
        (views-table rows))
@@ -4613,9 +4561,9 @@
 
 ;; rf2-wnvid — the top-of-cascade outcome banner ("This event failed —
 ;; see the ✗ step below.") is RETIRED (Mike pair-debug 2026-05-31). It
-;; was redundant: the failure now surfaces inline in the cascade — the
-;; failing step paints the red ✗ glyph (rf2-ahhgn `step-status`) and the
-;; inline 'Exception Thrown' card sits right under it. The banner
+;; was redundant: the failure surfaces inline in the cascade — the
+;; failing step's inline 'Exception Thrown' card sits right under the
+;; step (the per-stage ✗ glyph itself retired in rf2-9wq0v). The banner
 ;; restated what the cascade already shows, pushing the actual content
 ;; down. The panel root still stamps `data-rf-xray-outcome` (tools / e2e
 ;; read the tool-side outcome there); the banner element + its style are
@@ -4630,11 +4578,12 @@
   the numbered cascade when steps are present; an empty-state when
   the focus carries no record or the record carries no trace events.
 
-  rf2-ahhgn / rf2-wnvid — when the cascade failed (`:outcome :error`)
-  the failure surfaces INLINE: the failing step paints the red ✗ glyph
-  and the inline 'Exception Thrown' card sits under it. The panel root
-  stamps `data-rf-xray-outcome` for tools / e2e; the pre-rf2-wnvid
-  top banner is retired (it merely restated the inline signal)."
+  rf2-ahhgn / rf2-wnvid / rf2-9wq0v — when the cascade failed
+  (`:outcome :error`) the failure surfaces INLINE: the failing step's
+  'Exception Thrown' card sits under it (the per-stage ✗ glyph retired
+  in rf2-9wq0v). The panel root stamps `data-rf-xray-outcome` for tools /
+  e2e; the pre-rf2-wnvid top banner is retired (it merely restated the
+  inline signal)."
   []
   (let [{:keys [status steps dispatch-id epoch-history outcome]}
         @(rf/subscribe [:rf.xray/epoch-pipeline])]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -156,39 +156,13 @@
     (is (= "✗" (badge/cascade-outcome-glyph :threw)))
     (is (= "·" (badge/cascade-outcome-glyph :cancelled)))))
 
-;; ---- rf2-ahhgn — per-step pass/fail status primitive --------------------
-
-(deftest step-status-set-test
-  (testing "rf2-ahhgn · rf2-yz57h — the per-step status closed set is
-            {:ok :error :skipped} (:skipped added rf2-yz57h for steps that
-            never ran because an upstream :before-chain throw aborted)"
-    (is (= #{:ok :error :skipped} badge/step-status-set))
-    (is (badge/step-status? :ok))
-    (is (badge/step-status? :error))
-    (is (badge/step-status? :skipped))
-    (is (not (badge/step-status? :NOT-A-STATUS)))))
-
-(deftest step-status-glyph-test
-  (testing "rf2-ahhgn — :ok → ✓, :error → ✗, unknown → ✓ (quiet default)"
-    (is (= "✓" (badge/step-status-glyph :ok)))
-    (is (= "✗" (badge/step-status-glyph :error)))
-    (is (= "✓" (badge/step-status-glyph :whatever)))))
-
-(deftest step-status-token-key-test
-  (testing "rf2-ahhgn — :error → :error token (red); everything else →
-            :success token (green) so a clean step paints the quiet ✓"
-    (is (= :error   (badge/step-status-token-key :error)))
-    (is (= :success (badge/step-status-token-key :ok)))
-    (is (= :success (badge/step-status-token-key nil)))))
-
-(deftest step-status-colour-resolves-css-var-test
-  (testing "rf2-ahhgn — the colour resolver returns a CSS-variable string
-            for both statuses (theme-driven, like every other chrome)"
-    (doseq [s [:ok :error]]
-      (let [c (badge/step-status-colour s)]
-        (is (string? c))
-        (is (re-find #"var\(--rf-xray-" c)
-            (str "expected CSS variable for " s ", got " c))))))
+;; rf2-9wq0v retired the per-STAGE status primitive (`step-status-set` /
+;; `step-status?` / `step-status-glyph` / `step-status-token-key` /
+;; `step-status-colour`) along with its per-stage badge glyph — a clean
+;; run painted a tick on every stage (no information) and a failure is
+;; already shown by the inline exception card under the stage. The
+;; per-EFFECT ledger glyphs (below) + the cascade-outcome banner glyph
+;; (above) carry the surviving, distinct signals.
 
 ;; ---- flat SIDE EFFECTS ledger row glyphs (rf2-j630b) --------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -946,42 +946,24 @@
     :rows (vec rows)
     :threw threw}))
 
-(deftest side-effects-badge-single-status-test
-  (testing "rf2-j630b — after the SIDE EFFECTS badge the header paints ONE
-            overall glyph (no post-commit / best-effort labels, no threw
-            chip): CROSS when any row failed, TICK when all succeeded.
-            The per-row glyphs carry per-effect outcome."
+(deftest side-effects-header-no-caption-test
+  (testing "rf2-j630b · rf2-9wq0v — the SIDE EFFECTS header carries no
+            post-commit / best-effort caption and no threw-count chip; the
+            per-row ledger glyphs are the whole signal (the per-stage badge
+            glyph retired in rf2-9wq0v — the row-level AND-of-rows outcome
+            stays queryable via `proj/side-effects-badge-status`, covered
+            in projection tests)."
     (let [tree   (view/render-side-effects-step
                    (side-effects-step
                      [{:fx-id :db :status :ok}
                       {:fx-id :http/get :status :ok}
                       {:fx-id :bad :status :error}]
                      1))
-          header (text-of tree "rf-xray-epoch-side-effects-header")
-          status (th/find-by-testid tree "rf-xray-epoch-side-effects-status")]
+          header (text-of tree "rf-xray-epoch-side-effects-header")]
       (is (not (string/includes? header "(post-commit)"))
           "the post-commit caption is dropped (rf2-j630b)")
       (is (not (string/includes? header "threw"))
-          "the threw-count chip is dropped — the single badge carries it")
-      (is (= "error" (:data-rf-xray-step-status (second status)))
-          "the single badge reads ✗ when a row failed")))
-
-  (testing "rf2-j630b — all-clean ledger → badge ✓"
-    (let [tree   (view/render-side-effects-step
-                   (side-effects-step
-                     [{:fx-id :db :status :ok}
-                      {:fx-id :http/get :status :ok}]))
-          status (th/find-by-testid tree "rf-xray-epoch-side-effects-status")]
-      (is (= "ok" (:data-rf-xray-step-status (second status))))))
-
-  (testing "rf2-j630b — a SKIPPED row is NEUTRAL — badge stays ✓"
-    (let [tree   (view/render-side-effects-step
-                   (side-effects-step
-                     [{:fx-id :http/get :status :ok}
-                      {:fx-id :clipboard/write :status :skipped}]))
-          status (th/find-by-testid tree "rf-xray-epoch-side-effects-status")]
-      (is (= "ok" (:data-rf-xray-step-status (second status)))
-          "skipped does not trip the badge to cross"))))
+          "the threw-count chip is dropped — the per-row glyphs carry it"))))
 
 (deftest side-effects-flat-ledger-order-test
   (testing "rf2-j630b — rows render flat in execution order: :db first,
@@ -2493,23 +2475,21 @@
       (is (string/includes?
             (text-of tree "rf-xray-epoch-error-handler-0-message")
             "boom in handler"))
-      (let [glyph (th/find-by-testid tree "rf-xray-epoch-handler-status")]
-        (is (some? glyph) "the per-step status glyph renders")
-        (is (= "error" (:data-rf-xray-step-status (th/attrs glyph)))
-            "the glyph data-attr reports :error")
-        (is (string/includes? (th/text-content glyph) "✗")
-            "a failed step paints the ✗ glyph")))))
+      ;; rf2-9wq0v — the per-stage ✗ glyph retired; the inline exception
+      ;; card under the step is the sole inline failure signal.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-status"))
+          "no per-stage status glyph (retired rf2-9wq0v)"))))
 
-(deftest handler-step-clean-paints-ok-glyph-test
-  (testing "rf2-ahhgn — a clean handler step paints the quiet ✓ glyph and
-            renders no error card"
+(deftest handler-step-clean-renders-no-error-card-test
+  (testing "rf2-ahhgn · rf2-9wq0v — a clean handler step renders no error
+            card and no per-stage status glyph (the glyph retired rf2-9wq0v
+            — a clean stage is silent now, not an all-tick row)"
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-event-db :event-id :counter/inc
                 :db-diff [] :fx [] :machine nil}
-          tree (view/render-handler-step step)
-          glyph (th/find-by-testid tree "rf-xray-epoch-handler-status")]
-      (is (= "ok" (:data-rf-xray-step-status (th/attrs glyph))))
-      (is (string/includes? (th/text-content glyph) "✓"))
+          tree (view/render-handler-step step)]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-status"))
+          "no per-stage status glyph on a clean step (retired rf2-9wq0v)")
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-errors-handler"))
           "a clean step renders no error block"))))
 
@@ -2541,8 +2521,9 @@
 
 ;; `outcome-banner-renders-on-error-test` retired (rf2-wnvid) — the
 ;; top-of-pipeline "This event failed" banner is gone; the failure
-;; surfaces inline (the failing step's ✗ glyph + the 'Exception Thrown'
-;; card). The panel root still stamps `data-rf-xray-outcome`.
+;; surfaces inline via the failing step's 'Exception Thrown' card (the
+;; per-stage ✗ glyph itself retired in rf2-9wq0v). The panel root still
+;; stamps `data-rf-xray-outcome`.
 
 ;; ---- rf2-yz57h — per-step exception placement + INTERCEPTOR + skipped ---
 
@@ -2575,9 +2556,9 @@
       (is (string/includes?
             (text-of tree "rf-xray-epoch-error-coeffect-0-message")
             "cofx threw on purpose"))
-      ;; header glyph is ✗ (error)
-      (let [status (th/find-by-testid tree "rf-xray-epoch-coeffect-throwing-cofx-status")]
-        (is (= "error" (:data-rf-xray-step-status (second status))))))))
+      ;; rf2-9wq0v — no per-stage glyph; the exception card is the signal.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-coeffect-throwing-cofx-status"))
+          "no per-stage status glyph (retired rf2-9wq0v)"))))
 
 (deftest interceptor-step-renders-row-and-exception-card-test
   (testing "rf2-yz57h — the INTERCEPTOR step renders the throwing
@@ -2654,9 +2635,10 @@
             (text-of tree "rf-xray-epoch-handler-skipped")
             "did not run")
           "the body states the handler did not run")
-      (let [status (th/find-by-testid tree "rf-xray-epoch-handler-status")]
-        (is (= "skipped" (:data-rf-xray-step-status (second status)))
-            "the header glyph reads :skipped (⊘), not ✗/✓")))))
+      ;; rf2-9wq0v — the SKIPPED body itself carries the 'did not run'
+      ;; signal; the per-stage ⊘ glyph retired.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-status"))
+          "no per-stage status glyph (retired rf2-9wq0v)"))))
 
 (deftest side-effects-skipped-renders-as-skipped-test
   (testing "rf2-yz57h — a SIDE EFFECTS step marked :skipped renders the
@@ -2667,12 +2649,6 @@
                   :status :skipped})]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-side-effects-skipped"))
           "the SKIPPED body renders")
-      (let [status (th/find-by-testid tree "rf-xray-epoch-side-effects-status")]
-        (is (= "skipped" (:data-rf-xray-step-status (second status))))))))
-
-(deftest step-status-glyph-skipped-test
-  (testing "rf2-yz57h — the badge primitive paints ⊘ (muted) for :skipped"
-    (is (= "⊘" (badge/step-status-glyph :skipped)))
-    (is (= "✓" (badge/step-status-glyph :ok)))
-    (is (= "✗" (badge/step-status-glyph :error)))
-    (is (badge/step-status? :skipped))))
+      ;; rf2-9wq0v — no per-stage glyph; the SKIPPED body is the signal.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-side-effects-status"))
+          "no per-stage status glyph (retired rf2-9wq0v)"))))


### PR DESCRIPTION
## Summary

Removes the per-STAGE status glyph (green tick / red cross / muted skip) that followed each Epoch pipeline-stage badge — DISPATCH / COEFFECT / INTERCEPTOR / HANDLER / FLOW / SIDE EFFECTS / SUBSCRIPTIONS / VIEWS.

**Rationale (rf2-9wq0v):** noise. A clean run painted a tick on every stage (no information); a failure is already surfaced by the inline exception card UNDER the failing stage (rf2-yz57h / rf2-wnvid), so the cross was redundant too. The pipeline reads quieter and more elegant without it. Net −132 lines.

## Changes

- `panels/epoch/view.cljs` — drop the per-stage glyph render from `step-header`; delete the local `step-status-glyph` helper + `step-header-status-glyph-base-style`; stop threading `:status` into all 8 `step-header` call sites; drop the now-unused `:as step` bindings in the COEFFECT / INTERCEPTOR / FLOW / SUBSCRIPTIONS / VIEWS renderers.
- `panels/epoch/badge.cljc` — retire the now-dead per-stage status primitive (see kept-vs-retired below).
- `panels/epoch/projection.cljc` — docstring-only update on `step-status` (its glyph role is gone; its surviving roles documented).
- `spec/021-Dynamic-Panel-Designs.md` — updated the Epoch-panel **step-status** section (§9.1.10.4) + the SIDE EFFECTS header-chrome note. (No edit to the testbed-inventory section — owned by in-flight 5crg4.)
- Epoch panel tests — updated/replaced the assertions that checked the removed per-stage glyph (`rf-xray-epoch-*-status` / `data-rf-xray-step-status`) to assert its ABSENCE + keep the surviving behavioural checks (exception cards, SKIPPED bodies, no-caption header).

## KEPT (distinct signals — NOT removed)

- **`badge/fx-row-status-glyph`** — the per-EFFECT tick/cross/skipped glyph inside the SIDE EFFECTS flat ledger (rf2-j630b). Per-row outcomes. KEPT.
- **`badge/cascade-outcome-glyph`** — the overall machine-cascade outcome glyph. Not a per-stage badge. KEPT.
- **`projection/step-status`** — still drives the SKIPPED-body branch (`:skipped` → "did not run" placeholder) and the overall cascade-outcome banner (`cascade-outcome` / `epoch-outcome` scan for `:error`). KEPT + still tested.
- **`projection/side-effects-badge-status`** — the AND-of-rows SIDE EFFECTS outcome; still read by the cascade-outcome banner and heavily tested in `projection_cljs_test`. KEPT.

## RETIRED (dead after the view change — grep-confirmed no remaining live consumers)

- `badge/step-status-set`
- `badge/step-status?`
- `badge/step-status-token-key`
- `badge/step-status-colour`
- `badge/step-status-glyph`

(Their only references after the view change were the view's deleted helper + the badge/view tests that asserted them — those tests were removed/repointed.)

## Quality gates

Run locally from `implementation/`:

- `npm run test:cljs` — **PASS**: 5086 tests, 17156 assertions, 0 failures, 0 errors (compile: 0 warnings).
- `npm run test:xray-feature-gate` — **PASS**: 14 scenarios, 0 failures, exit 0.
- `npm run test:bundle-isolation` — **PASS**: 17 artefact entries, 35 internal sentinels absent, allow-list budgets ok; uix/helix reagent-free check PASS.
- clj-kondo (changed files) — **0 errors** (and fewer warnings than baseline — the removed `:as step` bindings were cleaned up; no new warnings introduced).

Closes rf2-9wq0v.
