### PR TITLE
test(core): lock reg-view call-site ^{:key} -> React key propagation (rf2-1anbp)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/reg_view_react_key_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_react_key_cljs_test.cljs
@@ -1,0 +1,108 @@
+(ns re-frame.reg-view-react-key-cljs-test
+  "Substrate contract: a `reg-view`'d component propagates the call-site
+  `^{:key …}` (and a `:key` in metadata position) to the React element
+  it becomes, at PARITY with a plain Reagent fn. Per rf2-1anbp.
+
+  Why this matters: rendering a seq of reg-views each with a per-item
+  `^{:key n}` is the normal Reagent idiom (a `(for …)` list of rows). If
+  the wrapper `re-frame.views/build-frame-aware-view` interposed between
+  the call site and Reagent's hiccup→element translation dropped the
+  metadata `:key`, React reconciliation would see colliding keys (every
+  sibling falling back to the component's munged name) and could
+  duplicate / drop list children. The contract: the reg-view wrapper is
+  TRANSPARENT to React's reconciliation `:key`.
+
+  Distinct from `:rf.view/render-key` (the `[view-id instance-token]`
+  INSTRUMENTATION tuple pinned by `render_key_cljs_test.cljs`) — that is
+  internal trace identity, NOT React's reconciliation `:key`. This file
+  pins the React-facing `:key` specifically.
+
+  Seam: `reagent.core/as-element` is the exact point hiccup becomes a
+  React element — `(.-key el)` is what React's reconciler reads. The
+  wrapper sits between the call site and this seam, so asserting the key
+  survives `as-element` pins the propagation precisely. A companion
+  DOM-level assertion (the `-dom-cljs-test` sibling) confirms no React
+  key-collision warning under a real reconciliation commit."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; A registered view + a plain Reagent fn rendering the SAME shape, so
+;; the parity assertions compare like with like.
+(reg-view ^{:rf/id :rf.key-test/row} row-view [n]
+  [:div "row-" n])
+
+(defn- plain-row [n]
+  [:div "row-" n])
+
+(defn- el-key
+  "The React `:key` the reconciler will read for hiccup `v`."
+  [v]
+  (.-key (r/as-element v)))
+
+;; ---- single element: metadata :key reaches the React element --------------
+
+(deftest regview-element-carries-call-site-key
+  (testing "a reg-view'd component with ^{:key} yields a React element
+            whose .-key is that key (React coerces to string)"
+    (let [view (rf/view :rf.key-test/row)]
+      (is (= "7" (el-key ^{:key 7} [view 7]))
+          "the call-site ^{:key 7} reaches the React element as the key")
+      (is (= "alpha" (el-key ^{:key "alpha"} [view 1]))
+          "a string key reaches the React element unchanged"))))
+
+(deftest regview-key-parity-with-plain-fn
+  (testing "the reg-view wrapper is transparent to React's :key — a
+            reg-view'd component and a plain Reagent fn produce the SAME
+            React key for the same call-site ^{:key}"
+    (let [view (rf/view :rf.key-test/row)]
+      (is (= (el-key ^{:key 3} [plain-row 3])
+             (el-key ^{:key 3} [view 3]))
+          "reg-view'd and plain-fn elements get identical React keys"))))
+
+;; ---- seq of reg-views: distinct keys, no collision -------------------------
+
+(deftest seq-of-regviews-yields-distinct-react-keys
+  (testing "a seq of reg-views each with a distinct ^{:key} yields
+            DISTINCT React keys — the no-collision contract that prevents
+            React's 'two children with the same key' reconciliation bug
+            (rf2-1anbp). This is the (for [n …] ^{:key n} [view n]) idiom."
+    (let [view (rf/view :rf.key-test/row)
+          ;; The exact failing shape from the bead's repro: a for-loop
+          ;; producing a seq of reg-views, each keyed by its item.
+          children (for [n [1 2 3 4 5]]
+                     ^{:key n} [view n])
+          keys     (mapv el-key children)]
+      (is (= ["1" "2" "3" "4" "5"] keys)
+          "each reg-view in the seq carries its own call-site key")
+      (is (= (count keys) (count (set keys)))
+          "no two siblings collide — every React key is distinct")
+      (is (not-any? #(re-find #"row" %) keys)
+          "no key fell back to the component name (the rf2-1anbp failure
+           mode: every sibling keyed by the munged component name)"))))
+
+(deftest seq-mixed-regview-kinds-distinct-keys
+  (testing "a seq mixing two reg-view kinds (the ladder's section-heading
+            + ladder-button shape) keeps each call-site key — keys do not
+            collapse to a per-kind component name"
+    (rf/reg-view* :rf.key-test/heading (fn [label] [:div "h-" label]))
+    (let [row     (rf/view :rf.key-test/row)
+          heading (rf/view :rf.key-test/heading)
+          rows    [[:heading "A"] [:row 1] [:row 2] [:heading "B"] [:row 3]]
+          children (for [[kind v] rows]
+                     (if (= :heading kind)
+                       ^{:key (str "h-" v)} [heading v]
+                       ^{:key v} [row v]))
+          keys     (mapv el-key children)]
+      (is (= ["h-A" "1" "2" "h-B" "3"] keys)
+          "every call-site key survives across mixed reg-view kinds")
+      (is (= (count keys) (count (set keys)))
+          "no collisions in the mixed seq"))))

--- a/implementation/adapters/reagent/test/re_frame/reg_view_react_key_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_react_key_dom_cljs_test.cljs
@@ -1,0 +1,84 @@
+(ns re-frame.reg-view-react-key-dom-cljs-test
+  "DOM-level companion to `reg-view-react-key-cljs-test`: mounting a
+  reg-view that renders a seq of keyed reg-views (the `(for [n …]
+  ^{:key n} [child n])` idiom) under a REAL React reconciliation commit
+  must NOT emit React's 'Encountered two children with the same key'
+  warning. Per rf2-1anbp.
+
+  The element-level sibling pins that `.-key` survives
+  `reagent.core/as-element`; this file pins the end-to-end consequence —
+  React's reconciler, fed the rendered tree, sees distinct keys and
+  stays quiet. The failing mode (rf2-1anbp) was a `console.error`
+  collision warning on mount where every list child fell back to the
+  same munged component name as its key.
+
+  Browser-only — a real `react-dom` commit is required to drive
+  reconciliation and the key-collision dev warning. The `-dom-cljs-test`
+  suffix opts this file into the `:browser-test` build; `:node-test`
+  loads it too (matches `cljs-test$`) and the mount branch gates on
+  `(browser?)`, returning a trivially-true assertion under :node-test
+  where `js/document` is absent."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(reg-view ^{:rf/id :rf.keydom/row} keydom-row [n]
+  [:div {:data-testid (str "keydom-row-" n)} "row-" n])
+
+(reg-view ^{:rf/id :rf.keydom/heading} keydom-heading [label]
+  [:div "h-" label])
+
+;; The ladder shape from the bead's repro: a seq mixing two reg-view
+;; kinds, each keyed at the call site.
+(def ^:private ladder
+  [[:heading "Events"] [:row 1] [:row 2] [:row 3]
+   [:heading "Errors"] [:row 4] [:row 5]])
+
+(reg-view ^{:rf/id :rf.keydom/root} keydom-root []
+  [:div
+   (for [[kind v] ladder]
+     (if (= :heading kind)
+       ^{:key (str "h-" v)} [keydom-heading v]
+       ^{:key v} [keydom-row v]))])
+
+(deftest mounting-seq-of-keyed-regviews-emits-no-collision-warning
+  (testing "rendering a seq of reg-views each with ^{:key} under a real
+            React commit emits NO 'same key' reconciliation warning, and
+            every keyed child is present in the DOM (rf2-1anbp)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — the :browser-test runner exercises this")
+      (let [errs (atom [])
+            orig (.-error js/console)]
+        (set! (.-error js/console)
+              (fn [& args]
+                (swap! errs conj (apply str args))
+                ;; Forward so other harness diagnostics are not swallowed.
+                (.apply orig js/console (to-array args))))
+        (let [render-fn (rf/view :rf.keydom/root)
+              node      (.createElement js/document "div")
+              root      (rdc/create-root node)]
+          (try
+            (react-dom/flushSync (fn [] (rdc/render root [render-fn])))
+            ;; All five keyed rows committed (no child dropped by a
+            ;; key collision).
+            (is (= 5 (.-length (.querySelectorAll node "[data-testid^='keydom-row-']")))
+                "every keyed reg-view child is present in the DOM")
+            (is (not-any? #(re-find #"same key" %) @errs)
+                (str "no React key-collision warning; console.error saw: "
+                     (pr-str @errs)))
+            (finally
+              (set! (.-error js/console) orig)
+              (try (rdc/unmount root) (catch :default _ nil)))))))))


### PR DESCRIPTION
## Summary

rf2-1anbp was filed as a verified bug: reg-view'd components allegedly drop the call-site `^{:key}` so a seq of reg-views (the `(for [n …] ^{:key n} [view n])` idiom) collides under React reconciliation — the standard_epochs ladder reportedly warned *"Encountered two children with the same key, `_standard_epochs_core_ladder_button`."*

**Investigation finding: the Reagent path already propagates the call-site `^{:key}` correctly; the described bug does not reproduce on this branch.** This PR adds the substrate contract test the bead asks for — locking the (already-correct) behaviour so any future wrapper regression is caught — rather than a code change.

## Root cause (which candidate, with evidence)

Neither candidate is an active defect on the current code:

- **Candidate 1 (`build-frame-aware-view` `{:contextType ...}` create-class path drops the element `:key`)** — disproven. Stock Reagent's `util/react-key-from-vec` reads `(:key (meta v))` FIRST, before any head-dispatch; `reag-element` (the fn-head path) sets `(.-key jsprops)` from it. The `{:contextType frame-context}`-meta wrapper is just the hiccup head — it does not interpose on Reagent's metadata `:key` read. Verified at the element seam: `(.-key (reagent.core/as-element ^{:key 7} [reg-view'd-fn 7]))` = `"7"`, identical to a plain Reagent fn.
- **Candidate 2 (source-coord annotation walk strips child `:key`)** — disproven. `inject-source-coord-attr` walks the view's OWN rendered ROOT (the hiccup the view returns), not the call-site element the parent passes; it never touches sibling/child call-site metadata.

Live evidence (standard_epochs testbed, dev build off main @ 7b50e2cbf, driven headless via Playwright): the ladder-button React fiber carries `key="1"` / `key="2"` / … with `displayName = :standard-epochs.core/ladder-button`. The collision warning does **not** fire on a fresh mount, nor after extensive interaction (mount/unmount Child A + B, increments, perturb, threshold change, reset cycles), with Xray fully mounted.

The munged form in the bead (`_standard_epochs_core_ladder_button`, leading-underscore CLJS munge) is a **pre-rf2-fa4ly displayName shape** — rf2-fa4ly (commit 62d5b57e7) made the displayName the clean `:standard-epochs.core/ladder-button`. Consistent with a stale-build / hot-reload devconsole artefact, not the current code.

## Before → after

- Before: no test pinned reg-view React-`:key` propagation; a future wrapper change could silently drop the metadata `:key` (re-introducing the collision) undetected.
- After: element-level + DOM-level contract tests assert distinct React keys / no `"same key"` warning. Current behaviour: distinct keys `["1" "2" "3" "4" "5"]`, no collision — green.

## uix/helix parity verdict

**Fixed-in-core for Reagent (already correct); follow-up filed for uix/helix by-test coverage (rf2-pt0u2).** UIx/Helix reg-views are produced by `core/src/re_frame/substrate/spine.cljs` `make-wrap-view` as React function components — their `:key` rides the substrate's own `createElement`/`$` at the call site (React-native), NOT Reagent's hiccup-metadata extraction, so the Reagent-specific failure mode does not apply by construction (the spine's `append-unmount-sentinel` `cloneElement` explicitly preserves the root element's `type`/`key`/props). Verified by mechanism only — not edited here, to stay disjoint from the in-flight adapter/spine work (gfu33). rf2-pt0u2 adds the by-test parity coverage.

## Quality gates

| Gate | Result |
| --- | --- |
| `npm run test:cljs` (node-test, incl. new key-propagation contract test) | green — 5096 tests / 17190 assertions, 0 failures, 0 errors |
| `npm run test:browser` (incl. new DOM no-collision contract test under real react-dom commit) | green — 130 tests / 367 assertions, 0 failures, 0 errors |
| clj-kondo (changed files) | 0 errors, 0 warnings |
| existing `render_key_cljs_test.cljs` (internal `:rf.view/render-key`, distinct surface) | unchanged, green |

New tests:
- `implementation/adapters/reagent/test/re_frame/reg_view_react_key_cljs_test.cljs` — element-level seam: single `^{:key}`, parity with a plain Reagent fn, distinct keys across a seq, distinct keys across mixed reg-view kinds.
- `implementation/adapters/reagent/test/re_frame/reg_view_react_key_dom_cljs_test.cljs` — DOM-level: mounting a seq of keyed reg-views under a real `react-dom` commit emits no `"same key"` warning and commits every keyed child.

Spec unchanged (contract test; locks documented Reagent `:key` parity).