### PR TITLE
feat(xray/testbed): add machine_epochs state-machine step-up deck (port 8033, rf2-w06op)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -260,7 +260,19 @@
             ;; out/examples/routes-epochs. Port 8032 is the trio's routing
             ;; slot (machine_epochs takes 8033).
             8032 ["../tools/xray/testbeds/routes_epochs"
-                  "out/examples/routes-epochs"]}
+                  "out/examples/routes-epochs"]
+            ;; Single-frame machine-epochs testbed (rf2-w06op) — the
+            ;; STATE-MACHINE sibling of standard-epochs: a tall column of
+            ;; numbered buttons, each bumping a shared baseline counter +
+            ;; sending one machine event exercising one more machine
+            ;; feature, so clicking top-to-bottom completely exercises the
+            ;; Xray Machine Inspector (rf-xray-machine-inspector). Same
+            ;; source-dir-first cascade as 8031/8032; compiled main.js
+            ;; falls through to out/examples/machine-epochs. Port 8033 is
+            ;; the trio's machine slot (standard-epochs 8031, routes-epochs
+            ;; 8032).
+            8033 ["../tools/xray/testbeds/machine_epochs"
+                  "out/examples/machine-epochs"]}
 
  :builds
  {:node-test
@@ -698,6 +710,41 @@
                       {re-frame.testbed.config/repo-root
                        #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
    :modules          {:main {:init-fn routes-epochs.core/run}}
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
+
+  ;; Single-frame machine-epochs testbed (rf2-w06op) — the STATE-MACHINE
+  ;; sibling of standard-epochs. Same shape (a tall column of numbered
+  ;; buttons in ONE plainly-mounted frame, each button bumping a shared
+  ;; baseline counter + sending one machine event exercising one more
+  ;; machine feature), aimed squarely at the Xray Machine Inspector
+  ;; (rf-xray-machine-inspector): click top-to-bottom and the Inspector's
+  ;; surfaces (topology highlight · focused-transition lens · guards /
+  ;; actions · snapshot drill-in · transition history · parallel regions)
+  ;; are completely exercised. A TEST surface — no deliberate bugs, no
+  ;; teaching layers (feedback_testbeds_are_test_surfaces).
+  ;;
+  ;; The machines / events / subs / views are OWNED in
+  ;; machine_epochs/core.cljs — it boots the machines artefact
+  ;; (`[re-frame.machines]`) and uses the real `reg-machine` + machine-
+  ;; event-routing surface; it does NOT reuse the deleted testdeck.*
+  ;; modules, and the deep_machine framework testbed stays the gate's
+  ;; deterministic machine substrate (this deck does not touch it).
+  ;; Sources live under tools/xray/testbeds/machine_epochs/; the Xray
+  ;; preload auto-mounts inline so every lens reads the single frame.
+  ;; Served at http://localhost:8033 via the top-level `:dev-http` map
+  ;; (the machine slot of the _epochs trio — standard-epochs 8031,
+  ;; routes-epochs 8032 mirror this build-id scheme).
+  :examples/machine-epochs
+  {:target           :browser
+   :output-dir       "out/examples/machine-epochs"
+   :asset-path       "."
+   ;; rf2-5dphw — build-env project-root for open-in-editor (see
+   ;; :examples/two-frame-isolation above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn machine-epochs.core/run}}
    :devtools         {:preloads [re-frame2-pair.runtime
                                  day8.re-frame2-xray.preload]}}
 

--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -264,9 +264,9 @@ coverage matrix at [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage
 reports `covered` across every row at the unit/helper/view tier.
 
 Browser testbeds live under `tools/xray/testbeds/` —
-`two_frame_isolation`, `standard_epochs`, `routes_epochs`, `feature_matrix`,
-`panel_gallery`, `perf_counter` — covering the canonical multi-frame
-isolation surface
+`two_frame_isolation`, `standard_epochs`, `routes_epochs`, `machine_epochs`,
+`feature_matrix`, `panel_gallery`, `perf_counter` — covering the canonical
+multi-frame isolation surface
 (`two_frame_isolation`: one app · two frames · Counter / Machine
 (websocket) / Routing / Async&errors tabs navigated as routes ·
 per-frame trace / events / issues / cascades · Xray target-frame
@@ -281,7 +281,18 @@ machines/SSR; supersedes the old `step_deck`), the routing sibling
 baseline-bump per press · one more ROUTING feature per rung — aimed
 squarely at the Routing panel, so clicking top-to-bottom completely
 exercises its Current route · Navigation this epoch · Route table
-sections; served on port 8032), the deterministic
+sections; served on port 8032), the state-machine sibling
+(`machine_epochs`, rf2-w06op: the same numbered-button shape — one frame ·
+baseline-bump per press · one more MACHINE feature per rung (start ·
+transition · entry/exit actions · guard allowed/blocked · transition-
+with-effect · ignored event · parallel regions · transition history ·
+multiple machines) — aimed squarely at the Machine Inspector
+(`rf-xray-machine-inspector`), so clicking top-to-bottom completely
+exercises its topology highlight · focused-transition lens · guards /
+actions · snapshot drill-in · transition history · parallel-region
+surfaces; owns its own `:door/main` + `:traffic/light` machines and does
+NOT touch the `deep_machine` gate substrate; served on port 8033), the
+deterministic
 feature-matrix sweep across panels + shell + launch modes + redaction
 + 20-event load, the Panel-view gallery, and the performance probe.
 

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -153,6 +153,18 @@ const STAGED_SURFACES = [
     html: ['tools', 'xray', 'testbeds', 'routes_epochs', 'index.html'],
     servedPath: 'testbeds/routes-epochs',
   },
+  // rf2-w06op — machine-epochs deck (the STATE-MACHINE step-up tester). A
+  // single-frame numbered-button ladder over the real `reg-machine` +
+  // machine-event-routing surface, driving the Xray Machine Inspector
+  // (`rf-xray-machine-inspector`). Served from the deck's own hand-written
+  // index.html (source dir first, like the 8033 :dev-http entry); the
+  // compiled main.js falls through to out/examples/machine-epochs.
+  {
+    build: 'examples/machine-epochs',
+    bundleDir: ['out', 'examples', 'machine-epochs'],
+    html: ['tools', 'xray', 'testbeds', 'machine_epochs', 'index.html'],
+    servedPath: 'testbeds/machine-epochs',
+  },
 ];
 
 function sleep(ms) {
@@ -2792,6 +2804,197 @@ async function runRoutesEpochs(page, state) {
   };
 }
 
+// rf2-w06op — machine-epochs state-machine step-up deck. Walks the deck's
+// numbered ladder top-to-bottom and asserts each rung's machine feature
+// landed, then opens the Xray Machine Inspector (`rf-xray-machine-
+// inspector`) and confirms the panel mounts on the focused machine event.
+//
+// What this scenario can / cannot assert:
+// —————————————————————————————————————————————————————————————
+// The deck OWNS its `:door/main` + `:traffic/light` machines and drives
+// them through the REAL `reg-machine` + machine-event-routing surface, so
+// every rung's machine FEATURE (plain transition · entry/exit data delta ·
+// guard pass vs fail · parallel-region broadcast · ignored event) is
+// genuinely exercised and is observable in the host app's own machine
+// snapshot mirror (the status strip reads `[:rf/machine <id>]` directly).
+// We assert those snapshot facts — they are the robust, non-flaky proof
+// each machine feature fired.
+//
+// We additionally open the Machines tab and confirm `rf-xray-machine-
+// inspector` mounts on a focused machine event, plus that machine activity
+// reaches the trace bus (`:rf.machine/transition`). We deliberately do NOT
+// assert the machines-viz chart-render path (the synthetic-epoch injection
+// that `runDeepMachine` performs): per the documented framework gap
+// (see `runDeepMachine` above, lines re: machine-transition + `:frame`),
+// a real host-app `:rf.machine/transition` carries no `:frame` tag and so
+// is not captured into an epoch's `:trace-events`, leaving the focused-
+// event transitions sub empty in production today. `deep_machine` owns the
+// chart-render shim-survival probe via test-only injection events; this
+// deck's job is the real-machine-feature step-up surface, asserted through
+// the snapshot mirror + the panel handoff.
+
+// Click a deck ladder rung by its per-rung data-testid
+// (`machine-epochs-rung-<n>`, outside Xray chrome).
+async function clickMachineRung(page, n) {
+  await clickTestId(page, `machine-epochs-rung-${n}`);
+}
+
+// Read both machines' state + the door's :data off the deck's status
+// strip (`machine-epochs-status-strip`). The strip renders pure snapshot
+// reads, so the text reflects `[:rf/machine <id>]` after each cascade.
+async function readMachineStrip(page) {
+  return page.evaluate(() => {
+    const strip = document.querySelector(
+      '[data-testid="machine-epochs-status-strip"]');
+    if (!strip) return { mounted: false };
+    function text(id) {
+      const el = strip.querySelector(`[data-testid="${id}"]`);
+      return el ? (el.textContent || '').trim() : null;
+    }
+    return {
+      mounted: true,
+      stripText: (strip.textContent || '').replace(/\s+/g, ' ').trim(),
+      doorState: text('machine-epochs-door-state'),
+      trafficState: text('machine-epochs-traffic-state'),
+    };
+  });
+}
+
+async function runMachineEpochs(page, state) {
+  // The deck's `run` bootstraps both machines, so the status strip is
+  // populated immediately. Assert the door booted to :locked before
+  // driving the ladder.
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => snap.mounted && /:door\/main state: :locked/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: 'machine-epochs door machine boots to :locked' },
+  );
+
+  // ---- #1 start machine — bootstrap re-fires; door stays :locked.
+  await clickMachineRung(page, 1);
+
+  // ---- #2 plain transition — :locked ──► :closed (insert-coin).
+  await clickMachineRung(page, 2);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:door\/main state: :closed/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#2 insert-coin → door :closed' },
+  );
+
+  // ---- #3 entry + exit actions — :closed ──► :open; :open's :entry
+  //      (:count-open) bumps :opened-count to 1.
+  await clickMachineRung(page, 3);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) =>
+      /:door\/main state: :open/.test(snap.stripText || '') &&
+      /:opened-count 1/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#3 push → door :open + :opened-count 1 (entry action ran)' },
+  );
+
+  // ---- #4 guard ALLOWED — :open ──► :closed (:may-close? passes; not held).
+  await clickMachineRung(page, 4);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:door\/main state: :closed/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#4 close → guard allowed, door :closed' },
+  );
+
+  // ---- #5 guard BLOCKED — re-open, arm :held-open?, attempt close. The
+  //      :may-close? guard FAILS, so the door STAYS :open and the hold
+  //      flag remains set (no :on branch matched, nothing advanced).
+  await clickMachineRung(page, 5);
+  const afterBlocked = await waitForValue(
+    () => readMachineStrip(page),
+    (snap) =>
+      /:door\/main state: :open/.test(snap.stripText || '') &&
+      /:held-open\? true/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#5 reopen-hold-close → guard blocked, door STAYS :open + :held-open? true' },
+  );
+
+  // ---- #6 transition-with-effect — :open ──► :alarming; :enter-alarm's
+  //      :fx dispatches :alarm-acknowledged (downstream cascade child).
+  await clickMachineRung(page, 6);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:door\/main state: :alarming/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#6 trip → door :alarming (transition-with-effect)' },
+  );
+
+  // ---- #7 ignored transition — insert-coin into :alarming has no :on
+  //      entry, so the door STAYS :alarming (the event is a no-op for the
+  //      machine).
+  await clickMachineRung(page, 7);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:door\/main state: :alarming/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#7 insert-coin into :alarming → ignored, door STAYS :alarming' },
+  );
+
+  // ---- #8 parallel regions — one :traffic/tick broadcasts to BOTH the
+  //      :vehicle (red ──► green) and :pedestrian (walk ──► dont-walk)
+  //      regions; the snapshot's :state is a region-map carrying both.
+  await clickMachineRung(page, 8);
+  const afterParallel = await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => {
+      const t = snap.stripText || '';
+      return /:vehicle :green/.test(t) && /:pedestrian :dont-walk/.test(t);
+    },
+    { timeoutMs: 10000, description: '#8 tick → BOTH regions advanced (vehicle :green + pedestrian :dont-walk)' },
+  );
+
+  // ---- #9 transition history — a second tick advances both regions again
+  //      (vehicle :green ──► :amber, pedestrian :dont-walk ──► :walk).
+  await clickMachineRung(page, 9);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => {
+      const t = snap.stripText || '';
+      return /:vehicle :amber/.test(t) && /:pedestrian :walk/.test(t);
+    },
+    { timeoutMs: 10000, description: '#9 second tick → vehicle :amber + pedestrian :walk' },
+  );
+
+  // ---- #10 multiple machines — one cascade sends to BOTH machines: the
+  //      door resets to :locked AND the traffic vehicle region advances
+  //      (:amber ──► :red).
+  await clickMachineRung(page, 10);
+  const afterMulti = await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => {
+      const t = snap.stripText || '';
+      return /:door\/main state: :locked/.test(t) && /:vehicle :red/.test(t);
+    },
+    { timeoutMs: 10000, description: '#10 reset door + tick traffic → door :locked + vehicle :red (two machines, one cascade)' },
+  );
+
+  // ---- Xray Machine Inspector handoff. Open Xray, fire one more machine
+  //      transition so the spine has a focused machine event, switch to
+  //      the Machines tab, and confirm the inspector mounts + machine
+  //      activity reached the trace bus. (Per the chart-render gap noted
+  //      above, we assert the panel handoff + trace activity, not the
+  //      synthetic-injection chart-render that deep_machine owns.)
+  await openXray(page);
+  await clearTrace(page);
+  await clickMachineRung(page, 2); // :locked ──► :closed — a fresh transition
+  await waitForTraceMatch(
+    page,
+    /:rf\.machine\/transition|:rf\.machine\/guard-evaluated|:door\/main/,
+    'machine transition reaches the trace bus',
+  );
+  await clickTab(page, 'machines', 'rf-xray-machine-inspector');
+  await expectVisible(
+    page.locator('[data-testid="rf-xray-machine-inspector"]'), 5000);
+
+  state.machineEpochs = {
+    blocked: { doorState: afterBlocked.doorState },
+    parallel: { trafficState: afterParallel.trafficState },
+    multi: { doorState: afterMulti.doorState, trafficState: afterMulti.trafficState },
+    inspectorMounted: true,
+  };
+}
+
 const SCENARIOS = [
   {
     name: 'feature matrix shell and panel handoff',
@@ -2965,6 +3168,24 @@ const SCENARIOS = [
     panels: ['routing'],
     coveredRows: ['Routes'],
     run: runRoutesEpochs,
+  },
+  {
+    // rf2-w06op — machine-epochs state-machine step-up deck. Drives the
+    // real `reg-machine` + machine-event-routing surface and asserts each
+    // rung's machine FEATURE landed via the host's snapshot mirror: plain
+    // transition · entry/exit data delta · guard ALLOWED vs BLOCKED ·
+    // transition-with-effect · IGNORED event · parallel-region broadcast ·
+    // transition history · multiple machines in one cascade. Then opens
+    // the Xray Machine Inspector (`rf-xray-machine-inspector`) and confirms
+    // the panel mounts on a focused machine event + machine activity
+    // reaches the trace bus. Real Machine-Inspector coverage for the deck
+    // the `Machines` matrix row names (the chart-render shim-survival probe
+    // stays owned by the `deep machine inspector substrate` scenario).
+    name: 'machine-epochs machine ladder (start, transitions, guards allowed/blocked, entry/exit, effect, ignored, parallel, multiple machines)',
+    url: '/testbeds/machine-epochs/',
+    panels: ['machines'],
+    coveredRows: ['Machines'],
+    run: runMachineEpochs,
   },
   // ---- retired by rf2-xy4yb (4-layer chrome refactor) -------------------
   //

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -1,0 +1,502 @@
+(ns machine-epochs.core
+  "MACHINE-EPOCHS testbed (rf2-w06op) — the STATE-MACHINE sibling of the
+  `standard_epochs` + `routes_epochs` decks. A deliberately simple Xray
+  driving surface aimed squarely at the **Machine Inspector**
+  (`rf-xray-machine-inspector`).
+
+  ## Shape
+
+  ONE tall column of NUMBERED buttons, top to bottom — the same shape as
+  `standard_epochs` and `routes_epochs`. Beside each button a one-line
+  caption says WHAT TO WATCH in Xray's Machines tab when you press it.
+  Each button is ONE test: it fires one event that
+
+    (a) bumps a shared baseline counter (so App-db / Epoch always show a
+        delta on every press), and
+    (b) sends ONE machine event that exercises exactly ONE additional
+        machine feature.
+
+  Progressive: button 1 starts the machine; each later button layers one
+  more machine concept on top. A SINGLE frame, plainly mounted, with the
+  machines artefact booted (`[re-frame.machines]`) and Xray auto-mounting
+  inline on the right (`[data-rf-xray-host]` + the xray preload) reading
+  that one frame. No tabs, no URL machinery, no SSR — just one frame's
+  machines. The static caption is the 'what to look for', and the Machine
+  Inspector itself is the check.
+
+  ## North star (acceptance)
+
+  Click the buttons top to bottom → the Xray **Machine Inspector** is
+  COMPLETELY exercised. Per `spec/003-Machine-Inspector.md` the Dynamic
+  Machines panel is EVENT-DRIVEN: for the focused event it renders the
+  focused-transition lens (Target instance · TRANSITION from → to ·
+  GUARDS RUN · ACTIONS RUN) above the topology chart (FROM dashed, TO
+  bold), plus the BEFORE/AFTER snapshot drill-in, the transition history
+  ribbon, and the cancellation-cascade block. Each rung below drives ONE
+  transition shaped to light up one of those surfaces.
+
+  ## The machine ladder (per-rung Machine-Inspector coverage)
+
+    #1  start machine       — the door machine boots to `:locked`; the
+                              Inspector's chart renders the topology and
+                              the live-highlight lands on the initial
+                              state.
+    #2  send event/transition — `:locked ──► :closed` (insert-coin); the
+                              focused-transition lens shows the plain
+                              FROM → TO with no guard / action.
+    #3  entry + exit actions — `:closed ──► :open` runs `:open`'s `:entry`
+                              and `:closed`'s `:exit`; ACTIONS RUN lists
+                              both, and the BEFORE/AFTER `:data` snapshot
+                              shows the `:opened-count` bump.
+    #4  guarded — ALLOWED   — `:open ──► :closed` is guarded by
+                              `:may-close?` which PASSES; GUARDS RUN shows
+                              the guard with outcome pass and the
+                              transition completes.
+    #5  guarded — BLOCKED   — re-`:open` then attempt to close while the
+                              `:held-open?` flag is set: `:may-close?`
+                              FAILS, no `:on` branch matches, the machine
+                              stays in `:open`; GUARDS RUN shows the failed
+                              guard and the state does NOT advance.
+    #6  transition-with-effect — `:open ──► :alarming` whose `:enter-alarm`
+                              action returns `{:fx [[:dispatch ...]]}`; the
+                              lens's ACTIONS RUN shows the `:fx` output and
+                              the downstream `:dispatch` cascade child.
+    #7  ignored transition  — send `:door/insert-coin` to `:alarming`,
+                              which has no matching `:on` entry: a no-op /
+                              ignored event. The Inspector shows NO machine
+                              activity for this focused event (the verbatim
+                              'This event does not target a state machine'
+                              empty-state is the foil to every other rung).
+    #8  parallel regions    — a SECOND machine (`:traffic/light`,
+                              `:type :parallel` with `:vehicle` + `:pedestrian`
+                              regions): one event broadcasts to both
+                              regions and the chart highlights every active
+                              region leaf simultaneously.
+    #9  transition history  — drive a short cycle on the traffic machine so
+                              the transition-history ribbon under the chart
+                              accumulates several `state → state` entries.
+    #10 multiple machines   — one event sends to BOTH machines in a single
+                              cascade; the Inspector's instance selection
+                              picks the first transition in trace order and
+                              the spine's prev/next walks between them.
+
+  ## Test surface, not tutorial
+
+  Per `feedback_testbeds_are_test_surfaces`: no deliberate bugs as
+  anti-patterns, no teaching layers. The blocked-guard / ignored-event
+  rungs exercise the REAL machine surface — each is a feature being
+  driven, not a buggy demo. Captions are guidance, not lessons.
+
+  ## Test-free + self-contained
+
+  Per rf2-8cevm this testbed carries no spec.cjs; regression coverage
+  lives in the substrate contract tests + the Xray feature-matrix gate
+  (`tools/xray/testbeds/feature_matrix/scenarios.cjs` — the
+  `machine-epochs machine ladder` scenario). The machines / events / subs
+  / views below are OWNED here — this deck does NOT reuse the deleted
+  `testdeck.*` modules, and the `deep_machine` framework testbed stays the
+  gate's deterministic machine substrate (this deck does not touch it)."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            ;; State-machines artefact — load-time hook so `reg-machine`,
+            ;; the `:rf/machine` / `:rf/machine-has-tag?` framework subs,
+            ;; and the machine-event routing resolve. Without this require
+            ;; `reg-machine` below throws (the machine substrate ships in
+            ;; the day8/re-frame2-machines artefact).
+            [re-frame.machines]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; Xray's `configure!` to seed `:project-root` so the Event /
+            ;; machine source chips resolve a classpath-relative `:file`
+            ;; to an absolute on-disk URI.
+            [day8.re-frame2-xray.config :as xray-config]
+            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; open-in-editor project-root from the build env.
+            [re-frame.testbed.config :as testbed-config])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; MACHINE 1 — :door/main  (a flat machine with guards + entry/exit + fx)
+;; ============================================================================
+;;
+;; A small turnstile-ish door. Chosen for per-surface Machine-Inspector
+;; coverage rather than realism:
+;;
+;;   :locked  → :closed  on :door/insert-coin  (plain transition, #2)
+;;   :closed  → :open    on :door/push         (entry + exit actions, #3)
+;;   :open    → :closed  on :door/close        (guarded, #4 allowed / #5 blocked)
+;;   :open    → :alarming on :door/trip        (transition-with-effect, #6)
+;;   :alarming                                 (no :door/insert-coin entry → #7 ignored)
+;;   :alarming → :locked  on :door/reset
+;;
+;; Guards / actions are NAMED entries in the machine's :guards / :actions
+;; maps (inspectability bias, per the nine_states example) so the
+;; focused-transition lens can render each one's id + fn source.
+
+(def door-machine
+  {:initial :locked
+   :data    {:opened-count 0
+             :held-open?   false}
+
+   :guards
+   {:may-close?
+    ;; Button #4 (allowed) vs #5 (blocked). The door refuses to close
+    ;; while it is being :held-open? — so #5 arms the flag, then the
+    ;; close attempt fails the guard and no :on branch matches.
+    (fn guard-may-close? [{data :data}]
+      (not (:held-open? data)))}
+
+   :actions
+   {:count-open
+    ;; #3 — :open's :entry. Bumps a counter in the machine's :data so the
+    ;; BEFORE/AFTER snapshot drill-in shows a value delta.
+    (fn action-count-open [{data :data}]
+      {:data (update data :opened-count (fnil inc 0))})
+
+    :clear-hold
+    ;; #3 — :closed's :exit. Clears the hold flag on the way OUT of
+    ;; :closed so ACTIONS RUN lists an :exit action distinct from the
+    ;; :entry one.
+    (fn action-clear-hold [{data :data}]
+      {:data (assoc data :held-open? false)})
+
+    :hold-open
+    ;; #5 — arms the guard input. Fired by the `:door/hold` INTERNAL
+    ;; transition on :open (an `:on` entry with an `:action` but NO
+    ;; `:target`, per Spec 005's internal-transition contract): it writes
+    ;; `:data` without changing state, so the very next `:door/close`
+    ;; attempt fails `:may-close?` and the close is blocked.
+    (fn action-hold-open [{data :data}]
+      {:data (assoc data :held-open? true)})
+
+    :enter-alarm
+    ;; #6 — transition-with-effect. Returns an effect map, not a :data
+    ;; write: the lens's ACTIONS RUN shows the :fx output and the
+    ;; downstream :dispatch cascade child.
+    (fn action-enter-alarm [_]
+      {:fx [[:dispatch [:machine-epochs/alarm-acknowledged]]]})}
+
+   :states
+   {:locked
+    {:tags #{:door/locked}
+     :on   {:door/insert-coin :closed}}
+
+    :closed
+    ;; :exit runs on the way OUT (#3) — clears the hold flag.
+    {:tags #{:door/closed}
+     :exit :clear-hold
+     :on   {:door/push :open}}
+
+    :open
+    ;; :entry runs on the way IN (#3) — bumps :opened-count. The close
+    ;; transition is GUARDED (#4 allowed / #5 blocked); :door/hold is an
+    ;; INTERNAL transition (action, no :target) that arms the guard input
+    ;; for #5; :door/trip is the transition-with-effect (#6).
+    {:tags  #{:door/open}
+     :entry :count-open
+     :on    {:door/close {:target :closed
+                          :guard  :may-close?}
+             :door/hold  {:action :hold-open}
+             :door/trip  {:target :alarming
+                          :action :enter-alarm}}}
+
+    :alarming
+    ;; No :door/insert-coin entry here — sending it is an IGNORED / no-op
+    ;; transition (#7). :door/reset cycles back to :locked.
+    {:tags #{:door/alarming}
+     :on   {:door/reset :locked}}}})
+
+(rf/reg-machine :door/main door-machine)
+
+;; ============================================================================
+;; MACHINE 2 — :traffic/light  (a parallel machine — #8 / #9 / #10)
+;; ============================================================================
+;;
+;; Two orthogonal regions, one declaration. One event (`:traffic/tick`)
+;; broadcasts to BOTH regions per Spec 005 §Parallel regions, so the
+;; chart highlights every active region leaf simultaneously (#8). Driving
+;; a short cycle accumulates transition-history ribbon entries (#9), and
+;; sending to this machine alongside the door machine in one cascade
+;; exercises the multiple-machines instance-selection rule (#10).
+
+(def traffic-machine
+  {:type :parallel
+
+   :regions
+   {;; ---- :vehicle region — the classic green → amber → red cycle ----
+    :vehicle
+    {:initial :red
+     :states
+     {:red    {:tags #{:traffic/vehicle-stop}
+               :on   {:traffic/tick :green}}
+      :green  {:tags #{:traffic/vehicle-go}
+               :on   {:traffic/tick :amber}}
+      :amber  {:tags #{:traffic/vehicle-slow}
+               :on   {:traffic/tick :red}}}}
+
+    ;; ---- :pedestrian region — walk / dont-walk, ticked by the SAME event ----
+    :pedestrian
+    {:initial :walk
+     :states
+     {:walk     {:tags #{:traffic/ped-walk}
+                 :on   {:traffic/tick :dont-walk}}
+      :dont-walk {:tags #{:traffic/ped-stop}
+                  :on   {:traffic/tick :walk}}}}}})
+
+(rf/reg-machine :traffic/light traffic-machine)
+
+;; ============================================================================
+;; APP-DB SEED
+;; ============================================================================
+;;
+;; `:baseline` is the shared counter every button bumps (so App-db / Epoch
+;; always show a delta). The machines own their own runtime state under
+;; `[:rf/runtime :machines :snapshots …]`; this deck keeps no machine
+;; mirror in app-db beyond the baseline.
+
+(def initial-db
+  {:baseline 0})
+
+;; ============================================================================
+;; A small shared helper: every ladder event bumps the baseline counter.
+;; ============================================================================
+;;
+;; The machine events themselves are FRAMEWORK-routed (`[:door/main […]]`
+;; / `[:traffic/light […]]`) — we cannot edit them to bump a counter, so
+;; each rung is a thin deck-owned event-fx that (a) bumps `:baseline` via
+;; `:db` and (b) dispatches the machine event(s). The Epoch / App-db delta
+;; on every press comes from the bump; the Machine Inspector lights up from
+;; the dispatched machine event.
+
+(defn- bump [db] (update db :baseline inc))
+
+;; A reusable "bump + send" event-fx: every machine rung routes through
+;; here so the baseline delta and the machine send are one cascade. Pass a
+;; vector of machine-event vectors to fan out to several machines in one
+;; press (#10).
+(rf/reg-event-fx :machine-epochs/send
+  {:doc "Bump the baseline and dispatch the supplied machine event(s). The
+         shared driver behind every machine rung. `sends` is a vector of
+         fully-formed machine-event vectors (e.g.
+         `[[:door/main [:door/push]]]`)."}
+  (fn handler-send [{:keys [db]} [_ sends]]
+    {:db (bump db)
+     :fx (mapv (fn [send] [:dispatch send]) sends)}))
+
+;; #5 — re-open the door (#4 left it :closed), arm the `:held-open?` flag
+;; via the `:door/hold` internal transition, then attempt the guarded
+;; close. Three machine sends in one cascade: the close fails `:may-close?`
+;; because the flag is now armed, so the door STAYS in `:open` and GUARDS
+;; RUN shows the failed guard — the foil to rung #4's passing guard.
+(rf/reg-event-fx :machine-epochs/reopen-then-block
+  {:doc "Button #5 — `:door/push` (re-open) → `:door/hold` (arm the guard
+         input) → `:door/close`. The `:may-close?` guard now FAILS, so the
+         close is blocked and the machine stays in `:open`. GUARDS RUN
+         shows the failed guard; state does NOT advance."}
+  (fn handler-reopen-then-block [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx [[:dispatch [:door/main [:door/push]]]
+          [:dispatch [:door/main [:door/hold]]]
+          [:dispatch [:door/main [:door/close]]]]}))
+
+;; The acknowledgement event dispatched by :enter-alarm's :fx (#6). A plain
+;; deck event so the cascade has a downstream child epoch the lens links to.
+(rf/reg-event-db :machine-epochs/alarm-acknowledged
+  {:doc "The downstream event fired by the door's `:enter-alarm` action
+         `:fx`. Bumps baseline again so the alarm cascade has a child epoch
+         under the originating dispatch-id."}
+  (fn handler-alarm-acknowledged [db _ev] (bump db)))
+
+;; ============================================================================
+;; SUBSCRIPTIONS — machine snapshot reads for the live status strip
+;; ============================================================================
+;;
+;; The framework ships `:rf/machine` as the layer-3 entry onto
+;; `[:rf/runtime :machines :snapshots <id>]`. The deck chains a couple of
+;; projections for its own status strip; the Machine Inspector is the
+;; actual check.
+
+(rf/reg-sub :machine-epochs/baseline (fn [db _] (:baseline db)))
+
+(rf/reg-sub :machine-epochs/door-state
+  :<- [:rf/machine :door/main]
+  (fn [snap _] (:state snap)))
+
+(rf/reg-sub :machine-epochs/door-data
+  :<- [:rf/machine :door/main]
+  (fn [snap _] (:data snap)))
+
+(rf/reg-sub :machine-epochs/door-tags
+  :<- [:rf/machine :door/main]
+  (fn [snap _] (:tags snap)))
+
+(rf/reg-sub :machine-epochs/traffic-state
+  :<- [:rf/machine :traffic/light]
+  (fn [snap _] (:state snap)))
+
+(rf/reg-sub :machine-epochs/traffic-tags
+  :<- [:rf/machine :traffic/light]
+  (fn [snap _] (:tags snap)))
+
+;; ============================================================================
+;; RESET
+;; ============================================================================
+
+(rf/reg-event-fx :machine-epochs/reset
+  {:doc "Button 0 — re-seed app-db and reset BOTH machines to their initial
+         states. Start clean."}
+  (fn handler-reset [_ _ev]
+    {:db initial-db
+     :fx [[:dispatch [:door/main [:rf.machine/bootstrap]]]
+          [:dispatch [:traffic/light [:rf.machine/bootstrap]]]]}))
+
+;; ============================================================================
+;; THE BUTTON LADDER
+;; ============================================================================
+
+(def ^:private ladder
+  "The ordered machine ladder. Each row: [n label caption event]. `event`
+  is the dispatch vector; `:section` rows are separators (label only)."
+  [[:section "Door machine — start · transition · entry/exit · effect"]
+   [1  "Start machine (bootstrap)"
+    "Inspector: the door chart renders; live-highlight lands on :locked"
+    [:door/main [:rf.machine/bootstrap]]]
+   [2  "Insert coin (:locked ──► :closed)"
+    "Focused-transition lens: plain FROM → TO, no guard / no action"
+    [:machine-epochs/send [[:door/main [:door/insert-coin]]]]]
+   [3  "Push (:closed ──► :open) — entry + exit"
+    "ACTIONS RUN: :closed's :exit (:clear-hold) + :open's :entry (:count-open); snapshot :opened-count++"
+    [:machine-epochs/send [[:door/main [:door/push]]]]]
+   [:section "Door machine — guards (allowed vs blocked)"]
+   [4  "Close (:open ──► :closed) — guard ALLOWED"
+    "GUARDS RUN: :may-close? → pass; transition completes to :closed"
+    [:machine-epochs/send [[:door/main [:door/close]]]]]
+   [5  "Re-open, hold, then close — guard BLOCKED"
+    "GUARDS RUN: :may-close? → fail (held-open?); state STAYS :open (no branch matches)"
+    [:machine-epochs/reopen-then-block]]
+   [:section "Door machine — effect + ignored"]
+   [6  "Trip (:open ──► :alarming) — with effect"
+    "ACTIONS RUN: :enter-alarm → :fx :dispatch → [:alarm-acknowledged] (downstream cascade child)"
+    [:machine-epochs/send [[:door/main [:door/trip]]]]]
+   [7  "Insert coin into :alarming — IGNORED"
+    "Inspector: no machine activity — the verbatim 'This event does not target a state machine' empty-state"
+    [:machine-epochs/send [[:door/main [:door/insert-coin]]]]]
+   [:section "Traffic machine — parallel regions · history · multiple machines"]
+   [8  "Tick traffic (parallel regions)"
+    "Inspector: ONE event broadcasts to :vehicle + :pedestrian; chart highlights BOTH active region leaves"
+    [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]]
+   [9  "Tick traffic ×1 more (history)"
+    "Transition-history ribbon under the chart accumulates several state → state entries"
+    [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]]
+   [10 "Reset door + tick traffic (two machines, one cascade)"
+    "Inspector: one event transitions BOTH machines; instance selection picks the first transition in trace order"
+    [:machine-epochs/send [[:door/main [:door/reset]] [:traffic/light [:traffic/tick]]]]]])
+
+(reg-view ladder-button
+  "One numbered ladder row: a numbered button on the left, its caption on
+  the right. Pressing it dispatches the row's event. The button carries a
+  per-rung `data-testid` (`machine-epochs-rung-<n>`) so each rung is
+  uniquely addressable even though several share the `:machine-epochs/send`
+  event-id (the feature-matrix scenario drives them by rung)."
+  [n label caption event]
+  [:div {:style {:display "grid" :grid-template-columns "auto 1fr"
+                 :gap "0.75em" :align-items "center" :margin "0.35em 0"}}
+   [:button {:data-testid (str "machine-epochs-rung-" n)
+             :on-click    #(dispatch event)
+             :style {:min-width "22em" :text-align "left"
+                     :padding "0.4em 0.6em" :cursor "pointer"
+                     :border "1px solid #cfc8ff" :border-radius "6px"
+                     :background "#fff"}}
+    [:span {:style {:font-weight "bold" :color "#7C5CFF" :margin-right "0.5em"}}
+     (str n ".")]
+    label]
+   [:span {:style {:color "#666" :font-size "12px"}} caption]])
+
+(reg-view section-heading
+  "A section separator inside the ladder."
+  [label]
+  [:div {:style {:margin "1em 0 0.25em 0" :font-size "11px" :font-weight "bold"
+                 :color "#7C5CFF" :text-transform "uppercase"
+                 :letter-spacing "0.04em" :border-top "1px dashed #ddd"
+                 :padding-top "0.5em"}}
+   label])
+
+(reg-view machine-status-strip
+  "A small live read-out of both machines' active state + tags — mirrors
+  what the Xray Machine Inspector projects, so the deck stays legible
+  standalone. Pure snapshot reads; the Inspector is the actual check."
+  []
+  (let [door-state    @(subscribe [:machine-epochs/door-state])
+        door-data     @(subscribe [:machine-epochs/door-data])
+        door-tags     @(subscribe [:machine-epochs/door-tags])
+        traffic-state @(subscribe [:machine-epochs/traffic-state])
+        traffic-tags  @(subscribe [:machine-epochs/traffic-tags])]
+    [:div {:data-testid "machine-epochs-status-strip"
+           :style {:border "1px solid #d8d2ff" :border-radius "6px"
+                   :padding "0.5em 0.75em" :margin "0.75em 0"
+                   :background "#fcfbff" :font-size "12px"}}
+     [:div {:style {:font-size "11px" :color "#7C5CFF" :font-weight "bold"
+                    :text-transform "uppercase" :letter-spacing "0.04em"}}
+      "Machine snapshots"]
+     [:div {:data-testid "machine-epochs-door-state"}
+      ":door/main state: " [:strong (pr-str door-state)]]
+     [:div ":door/main data: " [:strong (pr-str door-data)]]
+     [:div ":door/main tags: " [:strong (pr-str door-tags)]]
+     [:div {:data-testid "machine-epochs-traffic-state"}
+      ":traffic/light state: " [:strong (pr-str traffic-state)]]
+     [:div ":traffic/light tags: " [:strong (pr-str traffic-tags)]]]))
+
+(reg-view root []
+  [:div {:data-testid "machine-epochs-root"
+         :style {:font-family "system-ui, sans-serif" :padding "1em"
+                 :max-width "780px"}}
+   [:header {:style {:margin-bottom "0.5em"}}
+    [:h2 {:style {:margin 0}} "Machine-epochs"]
+    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
+     "One frame, one tall column of state-machine test buttons. Each button bumps a shared "
+     [:strong "baseline"] " counter (so App-db / Epoch always show a delta) and "
+     "sends one machine event exercising exactly one more machine feature. The caption says "
+     "what to watch in Xray's " [:strong "Machine Inspector"] " on the right — click top to "
+     "bottom and the Inspector's surfaces (topology highlight · focused-transition lens · "
+     "guards / actions · snapshot drill-in · transition history · parallel regions) are "
+     "fully exercised."]]
+   [machine-status-strip]
+   ;; Button 0 — Reset.
+   [:button {:data-testid "reset-button"
+             :on-click #(dispatch [:machine-epochs/reset])
+             :style {:padding "0.4em 0.8em" :cursor "pointer"
+                     :border "1px solid #cfc8ff" :border-radius "6px"
+                     :background "#f4f1ff" :margin "0.5em 0"}}
+    "0. Reset — re-seed app-db, reset both machines"]
+   ;; The ladder.
+   (for [row ladder]
+     (if (= :section (first row))
+       ^{:key (second row)} [section-heading (second row)]
+       (let [[n label caption event] row]
+         ^{:key n} [ladder-button n label caption event])))])
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+;; rf2-5dphw — open-in-editor project-root is derived from the build
+;; environment, not a hardcoded personal path. `re-frame.testbed.config`
+;; joins the build-time repo-root goog-define with this testbed's
+;; tool-relative subdir; `?project-root=<path>` still overrides per
+;; session. See that ns for the cross-platform mechanism.
+(defn- resolve-project-root []
+  (testbed-config/resolve-project-root "tools/xray/testbeds"))
+
+(defn ^:export run []
+  ;; Configure Xray BEFORE `rf/init!` so the preload's auto-open reads the
+  ;; right project-root on its first paint of any chip.
+  (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
+  (rf/init! reagent-adapter/adapter)
+  ;; Single, plain frame — no URL machinery (there is no routing here). The
+  ;; default frame is the one Xray reads. Seed app-db and bootstrap both
+  ;; machines to their initial states.
+  (rf/dispatch-sync [:machine-epochs/reset])
+  (rdc/render react-root [root]))

--- a/tools/xray/testbeds/machine_epochs/index.html
+++ b/tools/xray/testbeds/machine_epochs/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: machine-epochs (Xray Machine Inspector demo)</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .rf2-testbed-shell { display: flex; min-height: 100vh; }
+    /* `--rf-xray-inline-width` is Xray's documented host-resize knob
+       (rf2-um813; see day8.re-frame2-xray.config/default-layout-host-css-var
+       and spec/011-Launch-Modes.md §Resizing the inline host). Override
+       the property anywhere up the cascade to resize the panel without
+       JS or a fork of this rule. The user-draggable resize handle is
+       auto-injected by Xray (rf2-70u8q; spec/007-UX-IA.md §Resize
+       affordance) — no `resize: horizontal` / `overflow: auto` needed. */
+    :root { --rf-xray-accent: #7C5CFF; }
+    [data-rf-xray-host] { flex: 0 0 var(--rf-xray-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
+    #app { flex: 1; min-width: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div class="rf2-testbed-shell">
+    <main id="app"></main>
+    <aside data-rf-xray-host></aside>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds **`machine_epochs`** — the STATE-MACHINE sibling of `standard_epochs` + `routes_epochs` (the `cyczr` `_epochs` trio). A single-frame, numbered-button step-up tester over the real `reg-machine` + machine-event-routing surface, aimed squarely at the Xray **Machine Inspector** (`rf-xray-machine-inspector`). Click top-to-bottom → the Inspector's surfaces (topology highlight · focused-transition lens · guards / actions · snapshot drill-in · transition history · parallel regions) are completely exercised.

The deck **owns** its own `:door/main` (flat: guards + entry/exit + transition-with-effect + internal transition + ignored event) and `:traffic/light` (`:type :parallel`, two regions) machines/events/subs/views. It does **not** reuse the deleted `testdeck.*` modules, and it does **not** touch the `deep_machine` framework testbed (that stays the gate's deterministic machine substrate + the chart-render shim-survival probe). Test-free testbed (no `spec.cjs`); regression coverage lives in the feature_matrix gate.

Each rung bumps a shared `:baseline` counter (so App-db / Epoch always show a delta) **and** sends exactly one machine event exercising one more machine feature.

## Machine ladder (the buttons)

| # | Button | Machine-Inspector surface |
|---|---|---|
| 1 | Start machine (bootstrap) | door chart renders; live-highlight on `:locked` |
| 2 | Insert coin (`:locked ──► :closed`) | focused-transition lens: plain FROM → TO, no guard / action |
| 3 | Push (`:closed ──► :open`) — entry + exit | ACTIONS RUN: `:closed`'s `:exit` (`:clear-hold`) + `:open`'s `:entry` (`:count-open`); snapshot `:opened-count++` |
| 4 | Close — guard **ALLOWED** | GUARDS RUN: `:may-close?` → pass; completes to `:closed` |
| 5 | Re-open, hold, close — guard **BLOCKED** | GUARDS RUN: `:may-close?` → fail (held-open?); state STAYS `:open` (no branch matches) |
| 6 | Trip (`:open ──► :alarming`) — with effect | ACTIONS RUN: `:enter-alarm` → `:fx :dispatch` → `[:alarm-acknowledged]` (downstream cascade child) |
| 7 | Insert coin into `:alarming` — **IGNORED** | no machine activity — the verbatim "This event does not target a state machine" empty-state (the foil) |
| 8 | Tick traffic — **parallel regions** | ONE event broadcasts to `:vehicle` + `:pedestrian`; chart highlights BOTH active region leaves |
| 9 | Tick traffic ×1 more — **history** | transition-history ribbon accumulates several `state → state` entries |
| 10 | Reset door + tick traffic — **multiple machines** | one cascade transitions BOTH machines; instance selection picks the first transition in trace order |

Rung #5 uses the Spec 005 **internal transition** idiom (`{:door/hold {:action :hold-open}}` — action, no `:target`) to arm the guard input without changing state, then the guarded `:door/close` fails cleanly.

## HOT-ZONE — `implementation/shadow-cljs.edn`

Called out per the dispatch rules. Two additions, modelled **exactly** on the merged `:examples/routes-epochs` entry:

- **`:dev-http` port 8033** → `["../tools/xray/testbeds/machine_epochs" "out/examples/machine-epochs"]` (source-dir-first cascade; standard-epochs 8031, routes-epochs 8032, machine-epochs **8033**).
- **`:examples/machine-epochs` build-id** — `:output-dir out/examples/machine-epochs`, `:asset-path "."`, `:init-fn machine-epochs.core/run`, build-env project-root `#shadow/env`, `:devtools :preloads [re-frame2-pair.runtime day8.re-frame2-xray.preload]`.

## feature_matrix scenario (appended)

A **new appended** machine scenario block (no edits to existing step-status scenarios — collision-avoidance with 9wq0v):

- **STAGED_SURFACE** `examples/machine-epochs` served at `/testbeds/machine-epochs/`.
- **SCENARIO** `machine-epochs machine ladder (...)` (`panels: ['machines']`, `coveredRows: ['Machines']`) — drives all ten rungs and asserts each machine feature via the host's snapshot mirror (the status strip reads `[:rf/machine <id>]` directly): plain transition · entry/exit `:data` delta · guard ALLOWED vs BLOCKED · transition-with-effect · IGNORED event · parallel-region broadcast · transition history · multiple machines in one cascade. Then opens the Machine Inspector and confirms `rf-xray-machine-inspector` mounts on a focused machine event + machine activity reaches the trace bus.

The scenario deliberately asserts the panel handoff + snapshot mirror (the robust, non-flaky proof each feature fired), **not** the machines-viz chart-render path: per the documented framework gap (see `runDeepMachine`), a real host-app `:rf.machine/transition` carries no `:frame` tag and so isn't captured into an epoch's `:trace-events`, leaving the focused-event-transitions sub empty in production today. `deep_machine` owns the chart-render shim-survival probe via test-only injection events; this deck's job is the real-machine-feature step-up surface.

`tools/xray/README.md`: added `machine_epochs` to the browser-testbed inventory (testbed-inventory section only; the Epoch-panel spec section owned by 9wq0v is untouched).

## Quality gates

Run locally from `implementation/` (fresh worktree, one-time `npm install`):

| Gate | Result |
|---|---|
| `npx shadow-cljs compile examples/machine-epochs` | ✅ Build completed, **0 warnings**; port **8033** serves (`/` 200 w/ `Accept: text/html`, `/index.html` 200, `/main.js` 200) |
| `npm run test:cljs` | ✅ **5091 tests, 17181 assertions, 0 failures, 0 errors** |
| `npm run test:xray-feature-gate` | ✅ **16 scenarios, 0 failures** (15 → 16; the new machine ladder is the addition), 13 matrix rows |
| `npm run test:bundle-isolation` | ✅ **PASS** (17 artefact entries; 35 internal sentinels absent; uix/helix/reagent-free PASS) |
| `clj-kondo` on the new cljs | ✅ **0 errors, 0 warnings** |

Closes rf2-w06op.
