### PR TITLE
fix(skills): allow-list mcp__re-frame2-pair__read-dom — restore flzdp gate (rf2-588n0)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -24,6 +24,7 @@ allowed-tools:
   - mcp__re-frame2-pair__tail-build
   - mcp__re-frame2-pair__snapshot
   - mcp__re-frame2-pair__get-path
+  - mcp__re-frame2-pair__read-dom
   - mcp__re-frame2-pair__subscribe
   - mcp__re-frame2-pair__unsubscribe
   - mcp__re-frame2-pair__list-subscriptions


### PR DESCRIPTION
## What

`rf2-nfjil` (#2565) added the `read-dom` MCP tool to `re-frame2-pair-mcp` but did **not** allow-list it in the `re-frame2-pair` skill, so the "Verify skill ↔ MCP allowed-tools drift (rf2-flzdp)" CI gate went red on `main`.

This adds the single missing entry `mcp__re-frame2-pair__read-dom` to the frontmatter `allowed-tools` list in `skills/re-frame2-pair/SKILL.md`, grouped with the read-only data/view reads (`snapshot` / `get-path`) — `read-dom` is the view-plane peer of those data-plane reads per the Tool-Catalogue spec.

One line added; nothing else touched.

## Quality gates

`python scripts/check_skill_mcp_drift.py`

**Before** (on `main`, exit 1):

```
Drift detected (1 finding):
ERROR: re-frame2-pair-mcp <-> re-frame2-pair: MCP server exposes tool 'read-dom' but skill 'skills\re-frame2-pair\SKILL.md' does not allow-list mcp__re-frame2-pair__read-dom.
```

**After** (this branch, exit 0):

```
(0 findings — no output, exit 0)
```

Closes rf2-588n0.