### PR TITLE
refactor(xray): rename stage badges HANDLER→EVENT HANDLER, SIDE EFFECTS→EFFECT HANDLERS (display only, rf2-iijnx)

### DIFF
--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -234,7 +234,7 @@ surface through **three** always-on inline channels (per
 - **Inline in the Epoch cascade** — per-step ✓ / ✗ status glyphs, and the
  shared **"Exception Thrown"** card rendered under the step where the
  exception occurred (handler / interceptor / coeffect / fx / flow
- throws; `:db` schema-fail rollback on the SIDE EFFECTS `:db` row).
+ throws; `:db` schema-fail rollback on the EFFECT HANDLERS `:db` row).
 - **L2 event-row pink-wash** — a cascade carrying an issue washes its L2
  timeline row pink (rf2-b8guz), so the spine itself flags trouble.
 - **The always-on issues-ribbon signal** — the `:rf.xray/issues-ribbon`
@@ -281,7 +281,7 @@ the Dynamic 6 (per
 | Retired panel | Where its content lives now |
 |---|---|
 | **Subscriptions** | **Views** (cascade tree, SUBSCRIPTIONS step) + **app-db** (downstream-subs hover popover on changed paths) |
-| **Effects** (`fx`) | **Epoch** SIDE EFFECTS step (flat per-effect ledger) + **Trace** (raw `:rf.fx/*` ops) |
+| **Effects** (`fx`) | **Epoch** EFFECT HANDLERS step (flat per-effect ledger) + **Trace** (raw `:rf.fx/*` ops) |
 | **Flows** | **Epoch** FLOW step (one numbered step per flow that fired) · **Static → Flows** for the registry catalogue |
 | **Performance** | L2 row stripe colours (cross-epoch budget signal) + per-step duration chips in **Epoch** + per-row `:time` inside **Trace** |
 | **Schemas** | **Epoch** (schema violations attach inline to the owning step) + the L2 pink-wash · **Static → Schemas** for the registry catalogue |

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -112,7 +112,7 @@ step order, per `panels/epoch/projection.cljc`'s `project` (§021 §9.1.3):
  per throwing interceptor — id + `:before` / `:after` phase chip + the
  shared Exception card. Sits between COEFFECTS and HANDLER (the chain's
  cascade position). NEW per rf2-yz57h.
-4. **HANDLER** — always present; body adapts to the handler flavour
+4. **EVENT HANDLER** — always present; body adapts to the handler flavour
  (`:reg-event-db` → `:db` diff · `:reg-event-fx` → `:db` + per-fx ·
  `:reg-machine` → the time-ordered machine cascade, rf2-u69j7). Rendered
  as **SKIPPED** (⊘) when an upstream `:before`-chain throw — a coeffect
@@ -120,7 +120,7 @@ step order, per `panels/epoch/projection.cljc`'s `project` (§021 §9.1.3):
  handler ran (rf2-yz57h; NOT "ran, returned no :db").
 5. **FLOW** — one numbered step per flow that fired (the t1→t2 reshape as
  the flow's own `:db` diff). Only when flows fired.
-6. **SIDE EFFECTS** — a flat per-effect ledger (see §SIDE EFFECTS below).
+6. **EFFECT HANDLERS** — a flat per-effect ledger (see §EFFECT HANDLERS below).
  Only when a side effect occurred; equally SKIPPED when an upstream
  throw aborted the cascade.
 7. **SUBSCRIPTIONS** — only when subs recomputed.
@@ -138,7 +138,7 @@ slot). Schema violations attach inline the same way.
 
 **Badge taxonomy** (the inventory `badge-set` enforces; `badge.cljc`):
 DISPATCH (`:text-tertiary`) · COEFFECT (`:magenta`) · INTERCEPTOR
-(`:accent`) · HANDLER (`:accent`) · FLOW (`:accent`) · SIDE-EFFECTS
+(`:accent`) · EVENT HANDLER (`:accent`) · FLOW (`:accent`) · EFFECT HANDLERS
 (`:orange`) · SUBSCRIPTIONS (`:magenta-pink`) · VIEWS (`:success`). (The
 view's colour resolver bails to `:text-tertiary` on an unknown badge.)
 
@@ -151,9 +151,9 @@ implementation at
 + [`panels/epoch/`](../../../tools/xray/src/day8/re_frame2_xray/panels/epoch)
 (`view.cljs` · `projection.cljc` · `badge.cljc`).
 
-### SIDE EFFECTS step — flat per-effect ledger (rf2-j630b)
+### EFFECT HANDLERS step — flat per-effect ledger (rf2-j630b)
 
-The Epoch cascade's SIDE EFFECTS step renders as **one flat ledger** —
+The Epoch cascade's EFFECT HANDLERS step renders as **one flat ledger** —
 one row per effect, down the page, in execution order, with **no group
 headers** (supersedes the old 3-tier / "EFFECTS RETURNED + EFFECTS
 APPLIED" split). Per `panels/epoch/projection.cljc`'s `side-effects-step`:
@@ -162,7 +162,7 @@ APPLIED" split). Per `panels/epoch/projection.cljc`'s `side-effects-step`:
  ok · `✗` threw / no-such-fx / `:db` schema-fail rollback · `↺` fx
  override applied · `–` (muted en-dash) skipped-on-platform or a dropped
  `other` effect (NEUTRAL — never trips the badge).
-- **Single AND-of-rows badge** after the "SIDE EFFECTS" label: TICK when
+- **Single AND-of-rows badge** after the "EFFECT HANDLERS" label: TICK when
  every present row succeeded, CROSS when one or more FAILED; SKIPPED rows
  are neutral (`side-effects-badge-status`).
 - **The `:db` row** leads the ledger when a `:db` commit was attempted
@@ -431,7 +431,7 @@ algebra
 1. **Inline in the Epoch cascade** — per-step ✓ / ✗ status glyphs, the
  shared **"Exception Thrown"** card under the throwing step
  (handler / interceptor / coeffect / fx / flow exceptions), and the
- `:db` schema-fail rollback ✗ on the SIDE EFFECTS `:db` row. The
+ `:db` schema-fail rollback ✗ on the EFFECT HANDLERS `:db` row. The
  errors + warnings + schema violations + hydration mismatches that the
  old tab unified now surface against the step where they occurred.
 2. **L2 event-row pink-wash** (rf2-b8guz) — a cascade carrying an issue
@@ -525,7 +525,7 @@ Per §021 §15 (Dynamic mode) + §007 §Static mode:
  surfaced through the Dynamic 6 above — and the registry catalogues live
  in Static mode:
  - Subscriptions → Views (cascade tree) + app-db (hover popover)
- - Effects → Epoch SIDE EFFECTS step (flat ledger) + Trace (raw `:rf.fx/*` ops)
+ - Effects → Epoch EFFECT HANDLERS step (flat ledger) + Trace (raw `:rf.fx/*` ops)
  - Flows → Epoch FLOW step (one per flow) · Static → Flows (registry)
  - Performance → L2 row stripe colours + per-step duration in Epoch + per-row `:time` in Trace
  - Schemas → Epoch (violations attach inline to the owning step) + L2 pink-wash · Static → Schemas (registry)

--- a/tools/xray/spec/000-Vision.md
+++ b/tools/xray/spec/000-Vision.md
@@ -250,7 +250,7 @@ Each row is "new in re-frame2 → new tooling story Xray tells."
 | **Epoch history + `:rf/epoch-record` projections** (Tool-Pair) | First-class time-travel via the ribbon's `[◀ ▶ ⏭]` nav + the event list (L2). |
 | **Six named restore failures** | Structured "this rewind won't work because X" rather than a silent no-op. |
 | **`register-epoch-listener!`** | The per-cascade listener routes the Epoch panel + the inline issue surfacing (rf2-gbz39 removed the dedicated Issues tab per Option (c)). |
-| **Schemas (Malli)** (Spec 010) | Schema-violation rows surface inline in the Epoch panel's SIDE EFFECTS step (rf2-kt6js; rf2-gbz39 removed the Issues tab per Option (c)); **per-violation drill** with full Malli explanation + recovery-mode classification + source-coord. |
+| **Schemas (Malli)** (Spec 010) | Schema-violation rows surface inline in the Epoch panel's EFFECT HANDLERS step (rf2-kt6js; rf2-gbz39 removed the Issues tab per Option (c)); **per-violation drill** with full Malli explanation + recovery-mode classification + source-coord. |
 | **SSR + hydration** (Spec 011) | **Hydration mismatch bisector** — canonical-EDN dfs to the first divergent node; server vs client side-by-side per `get-in` path; sub-attribution (which sub returned `nil` server / `:en-US` client + why). **Streaming SSR boundary timeline.** **Per-request response accumulator inspector.** **Head model inspector.** **Server error projection trace** (the security boundary visualised). |
 | **Routing** (Spec 012) | Dedicated **Routing tab** carrying a **FLAT focused-event lens** (rf2-lq0ef) — current matched route + params/query/fragment + **Simulate-URL** input ranking every registered route via the 6-rule `:rf.route/rank` tuple with the **rank explainer** inline; per-focused-event glyphs `◆ HERE` / `◆ FROM` / `◆ TO` (rf2-nrbs9). **Nav-token timeline** (swimlanes) makes stale-clobber races literally visible; **`:on-match` chain explicit in the Epoch panel's "EFFECTS HANDLERS RAN" section**; **pending-navigation card**; **route-chain visualiser**. |
 | **`:origin` opt on dispatch** | Filter by actor via ribbon IN/OUT pills. |
@@ -269,7 +269,7 @@ concerns extend each tab; they do NOT add new tabs.
 2026-05-31).** Issues used to get a dedicated 7th tab carrying a session-wide
 aggregate / triage list; that aggregate was consciously dropped. Issues now
 surface inline in the Epoch panel (per-step pass/fail + the "Exception
-Thrown" block — rf2-ahhgn / rf2-wnvid; `:db` schema-fail in the SIDE EFFECTS
+Thrown" block — rf2-ahhgn / rf2-wnvid; `:db` schema-fail in the EFFECT HANDLERS
 step — rf2-kt6js; slow-fx amber), via the L2 event-row pink-wash (rows whose
 epoch has an issue — rf2-b8guz), and via the always-on issues ribbon signal
 (the auto-open-on-error watcher — the cross-epoch "something is wrong" cue

--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -203,7 +203,7 @@ Issues now surface through three kept surfaces:
 
 - **Inline in the Epoch panel** — the "Exception Thrown" block +
   per-step pass/fail (rf2-ahhgn / rf2-wnvid); `:db` schema-fail in the
-  SIDE EFFECTS step (rf2-kt6js); slow-fx duration + amber.
+  EFFECT HANDLERS step (rf2-kt6js); slow-fx duration + amber.
 - **The L2 event-row pink-wash** (rf2-b8guz) — rows whose epoch
   contains an issue.
 - **The always-on issues ribbon signal** — the auto-open-on-error

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -4,7 +4,7 @@ The architectural core of Xray: the **4-layer chrome** + the **6-tab detail pane
 
 This spec replaces the legacy 16-panel sidebar (now dead — see [`000-Vision.md`](000-Vision.md) §The 6-tab inventory and [`007-UX-IA.md`](007-UX-IA.md) §The 4-layer chrome) with a denser, keyboard-mnemonic, 10x-shaped layout. The event list is the load-bearing layer; every panel rebinds when selection moves.
 
-> **The Issues tab was removed per rf2-gbz39 (Mike RULED Option (c), 2026-05-31).** The 7th tab carried a session-wide aggregate / triage list of every issue (errors · warnings · schema · hydration · advisories). That aggregate was consciously dropped. Issues now surface **inline in the Epoch panel** (per-step pass/fail + the "Exception Thrown" block — rf2-ahhgn / rf2-wnvid; `:db` schema-fail in the SIDE EFFECTS step — rf2-kt6js; slow-fx amber), via the **L2 event-row pink-wash** (rows whose epoch has an issue — rf2-b8guz), and via the **always-on issues ribbon signal** (the auto-open-on-error watcher reading the surviving `:rf.xray/issues-ribbon` projection — the cross-epoch "something is wrong" cue Mike kept). The §5.4 content contract below is retained as a record of WHAT now surfaces inline + where.
+> **The Issues tab was removed per rf2-gbz39 (Mike RULED Option (c), 2026-05-31).** The 7th tab carried a session-wide aggregate / triage list of every issue (errors · warnings · schema · hydration · advisories). That aggregate was consciously dropped. Issues now surface **inline in the Epoch panel** (per-step pass/fail + the "Exception Thrown" block — rf2-ahhgn / rf2-wnvid; `:db` schema-fail in the EFFECT HANDLERS step — rf2-kt6js; slow-fx amber), via the **L2 event-row pink-wash** (rows whose epoch has an issue — rf2-b8guz), and via the **always-on issues ribbon signal** (the auto-open-on-error watcher reading the surviving `:rf.xray/issues-ribbon` projection — the cross-epoch "something is wrong" cue Mike kept). The §5.4 content contract below is retained as a record of WHAT now surfaces inline + where.
 
 ---
 
@@ -846,7 +846,7 @@ Virtualised list (overscan 20). See [`013-Trace-Consumer.md`](013-Trace-Consumer
 
 Issues now surface through three kept surfaces:
 
-- **Inline in the Epoch panel** — per-step pass/fail + the "Exception Thrown" block (rf2-ahhgn / rf2-wnvid); `:db` schema-fail in the SIDE EFFECTS step (rf2-kt6js); slow-fx duration + amber (pre-existing). The cascade that produced the issue shows it inline at the right step.
+- **Inline in the Epoch panel** — per-step pass/fail + the "Exception Thrown" block (rf2-ahhgn / rf2-wnvid); `:db` schema-fail in the EFFECT HANDLERS step (rf2-kt6js); slow-fx duration + amber (pre-existing). The cascade that produced the issue shows it inline at the right step.
 - **The L2 event-row pink-wash** (rf2-b8guz) — rows whose epoch contains an issue paint a light-pink wash, the spine-level "this event had a problem" cue.
 - **The always-on issues ribbon signal** — the auto-open-on-error watcher reads the surviving `:rf.xray/issues-ribbon` projection (now registered in `registry.cljs`) and pops Xray open on the first empty→non-empty transition. This is the cross-epoch "something is wrong" cue Mike kept.
 
@@ -855,7 +855,7 @@ The category table below is retained as the canonical **"what counts as an issue
 | Category | Source | Row treatment (inline / ribbon) |
 |---|---|---|
 | **JS exceptions** | uncaught errors; React lifecycle exceptions; promise rejections at handler scope | red; full stack-trace in the Epoch panel's "Exception Thrown" block |
-| **Schema violations** | Malli registration on app-db / event-args / sub-output | yellow; offending path + expected vs actual in the Epoch SIDE EFFECTS step |
+| **Schema violations** | Malli registration on app-db / event-args / sub-output | yellow; offending path + expected vs actual in the Epoch EFFECT HANDLERS step |
 | **Sensitive-data warnings** | `:rf/redacted` paths that escaped via `console.error` before marking applied · per-marking-site mark-misses (an `add-marks` / `set-marks` path pointing to nothing — typo detection) | magenta; marker-aware so the warning itself doesn't leak the value |
 | **Hydration mismatches** | SSR-only; mismatched server/client tree | yellow; node path + server vs client text |
 | **Perf-budget overruns** | cascades exceeding configured perf budget | orange; actual vs budget + cascade-id |
@@ -1416,7 +1416,7 @@ Complete map for the spine + chrome:
 - `p` (Performance) — Performance panel dropped; `p` unused (available for future tab if added).
 - `w` (Flows) — Flows folded into Views; `w` unused.
 - ~~`r` (Routes panel) — Routes folded into App-db~~. **Restored** (rf2-nrbs9): Routing got promoted back to its own L3 tab (cohesive sub-domains earn their own lens tab). `r` is now the **Routing tab** mnemonic; the event-list `r` rewind binding stays on the L2 event list scope (the L2 list's key handler wins when focus is in the list; the tab-bar's letter mnemonic wins when focus is elsewhere).
-- `S` (Schemas) — schema violations surface inline in the Epoch panel's SIDE EFFECTS step (rf2-kt6js); `S` unused.
+- `S` (Schemas) — schema violations surface inline in the Epoch panel's EFFECT HANDLERS step (rf2-kt6js); `S` unused.
 - `h` (Hydration) — hydration mismatches surface via the L2 event-row signal + the issues ribbon; `h` unused.
 - `i` (Issues) — the Issues tab was removed per rf2-gbz39 (Option (c)); issues surface inline in the Epoch panel + the L2 event-row pink-wash + the always-on issues ribbon signal; `i` unused.
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -2522,9 +2522,9 @@ outcome chips + MCP wire consumers + the pinned
 `outcome-enum-projection-pins-mapping` test. No spec/009 /
 Spec-Schemas edit was needed (rf2-ahhgn settle-first finding).
 
-### §9.1.10.6 SIDE EFFECTS step — flat per-effect ledger (rf2-j630b, supersedes the rf2-kt6js 3-tier · rf2-uffov · rf2-m8ac9)
+### §9.1.10.6 EFFECT HANDLERS step — flat per-effect ledger (rf2-j630b, supersedes the rf2-kt6js 3-tier · rf2-uffov · rf2-m8ac9)
 
-The pre-rf2-kt6js single `:fx` step became the **SIDE EFFECTS** step
+The pre-rf2-kt6js single `:fx` step became the **EFFECT HANDLERS** step
 (badge `:SIDE-EFFECTS`, the same `:orange` hue). rf2-j630b supersedes the
 rf2-kt6js 3-tier `:db` / `:fx` / other sub-step presentation with a
 **FLAT per-effect ledger**: ONE row per effect, down the page, in
@@ -2532,7 +2532,7 @@ EXECUTION order, with **NO `:db` / `:fx` / other group headers**. The
 leading per-row status glyph + effect-id + args edn-inspector + the row
 order carry the structure.
 
-**Single badge status (no labels).** After the "SIDE EFFECTS" badge the
+**Single badge status (no labels).** After the "EFFECT HANDLERS" badge the
 header paints **ONE overall glyph** — `✓` when every present row
 succeeded, `✗` when one or more FAILED (`projection/side-effects-badge-
 status` = the AND of the present rows; the view reads it via the generic

--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -45,7 +45,7 @@ The Trace panel's contract is **completeness**: it must surface *every* op-famil
 Columns: **Δt · stage · area badge · what-happened · target/detail · duration**.
 
 - **Δt** — ms offset from the epoch's first op.
-- **stage** — the Epoch-panel pipeline step this op belongs to (§3a): `DISPATCH` · `COEFFECT` · `HANDLER` · `FLOW` · `SIDE EFFECTS` · `SUBSCRIPTIONS` · `VIEWS`. The label rides the step's own colour.
+- **stage** — the Epoch-panel pipeline step this op belongs to (§3a): `DISPATCH` · `COEFFECT` · `EVENT HANDLER` · `FLOW` · `EFFECT HANDLERS` · `SUBSCRIPTIONS` · `VIEWS`. The label rides the step's own colour.
 - **area badge** — a neutral text badge (no per-family colour): `EVENT` · `COEFFECT` · `DB` · `FX` · `FLOW` · `SUB` · `VIEW` · `MACHINE` · `ROUTING` · `EPOCH` · `ERROR` · `WARNING`.
 - **what-happened** — the per-area verb (§5).
 - **target/detail** — the op's subject: event vector, `fx-id → arg`, `sub-id  old→new`, `view-id ← cause-sub`, route id, path, etc.
@@ -62,13 +62,13 @@ The op → stage mapping (the coarse projection of the §3 area badge onto the 7
 | Op (area / operation) | Epoch stage |
 |---|---|
 | `:rf.event/dispatched` | DISPATCH |
-| `:rf.event/run-start` · `run-end` (handler body) | HANDLER |
+| `:rf.event/run-start` · `run-end` (handler body) | EVENT HANDLER |
 | `:rf.cofx/*` (COEFFECT) | COEFFECT |
 | `:rf.flow/*` (FLOW) | FLOW |
-| `:rf.machine/*` (machine-as-handler) | HANDLER |
-| `:rf.event/db-changed` (DB) | SIDE EFFECTS |
-| `:rf.fx/*` (FX) | SIDE EFFECTS |
-| `:rf.route/*` (ROUTING) | SIDE EFFECTS |
+| `:rf.machine/*` (machine-as-handler) | EVENT HANDLER |
+| `:rf.event/db-changed` (DB) | EFFECT HANDLERS |
+| `:rf.fx/*` (FX) | EFFECT HANDLERS |
+| `:rf.route/*` (ROUTING) | EFFECT HANDLERS |
 | `:rf.sub/*` (SUB) | SUBSCRIPTIONS |
 | `:rf.view/*` (VIEW) | VIEWS |
 | `:rf.epoch/*` (EPOCH lifecycle) | DISPATCH (muted grey) |
@@ -114,24 +114,24 @@ Colour and visual styling are intentionally **not specified here** — to be des
 ## §9 Canonical layout (flat list — rf2-aqusw)
 
 ```
-+0.0  DISPATCH       EVENT     dispatched      [:counter-inc] from view↗       —
-+0.0  EPOCH          EPOCH     snapshotted     #42 · frame :rf/default          —
-+0.0  COEFFECT       COEFFECT  run             :now → #inst…                   0.1 ms
-+0.1  HANDLER        EVENT     handler ran     reg-event-db                    0.2 ms
-+0.3  FLOW           FLOW      computed        :totals → [:totals]             1.5 ms
-+1.8  SIDE EFFECTS   DB        changed         [:counter] 1 → 2 · [:totals] 42  —
-+1.9  SIDE EFFECTS   FX        :http-xhrio     GET /api/data (queued)           —
-!2.5  SIDE EFFECTS   ERROR     fx-handler-exc  :bad-fx "No such fx"             —
-+2.6  SUBSCRIPTIONS  SUB       recalculated    :counter/value 1→2              0.3 ms
-+2.9  SUBSCRIPTIONS  SUB       ran · unchanged :counter/parity                 0.1 ms
-+3.0  SUBSCRIPTIONS  SUB       disposed        :cart/preview (no readers)       —
-+3.1  VIEWS          VIEW      re-rendered     counter-display ← :counter/value 1.8 ms
-+4.9  VIEWS          VIEW      unmounted       old-tooltip                      —
-+4.9  VIEWS          VIEW      mounted         new-tooltip                     0.4 ms
-+5.0  DISPATCH       EPOCH     outcome :ok     #42                              —
++0.0  DISPATCH         EVENT     dispatched      [:counter-inc] from view↗       —
++0.0  EPOCH            EPOCH     snapshotted     #42 · frame :rf/default          —
++0.0  COEFFECT         COEFFECT  run             :now → #inst…                   0.1 ms
++0.1  EVENT HANDLER    EVENT     handler ran     reg-event-db                    0.2 ms
++0.3  FLOW             FLOW      computed        :totals → [:totals]             1.5 ms
++1.8  EFFECT HANDLERS  DB        changed         [:counter] 1 → 2 · [:totals] 42  —
++1.9  EFFECT HANDLERS  FX        :http-xhrio     GET /api/data (queued)           —
+!2.5  EFFECT HANDLERS  ERROR     fx-handler-exc  :bad-fx "No such fx"             —
++2.6  SUBSCRIPTIONS    SUB       recalculated    :counter/value 1→2              0.3 ms
++2.9  SUBSCRIPTIONS    SUB       ran · unchanged :counter/parity                 0.1 ms
++3.0  SUBSCRIPTIONS    SUB       disposed        :cart/preview (no readers)       —
++3.1  VIEWS            VIEW      re-rendered     counter-display ← :counter/value 1.8 ms
++4.9  VIEWS            VIEW      unmounted       old-tooltip                      —
++4.9  VIEWS            VIEW      mounted         new-tooltip                     0.4 ms
++5.0  DISPATCH         EPOCH     outcome :ok     #42                              —
 ```
 
-The stage column (DISPATCH / COEFFECT / HANDLER / FLOW / SIDE EFFECTS / SUBSCRIPTIONS / VIEWS) + the colour-coded left edge recover, flatly, the phase shape the removed bands carried.
+The stage column (DISPATCH / COEFFECT / EVENT HANDLER / FLOW / EFFECT HANDLERS / SUBSCRIPTIONS / VIEWS) + the colour-coded left edge recover, flatly, the phase shape the removed bands carried.
 
 ## §10 Data sources (grounding)
 
@@ -160,7 +160,7 @@ The panel renders **one** epoch's trace; work that produces *other* epochs is sh
 
 ## §13 Outcomes & short-circuit
 
-- **No empty-band scaffolding (rf2-aqusw).** With the bands removed, there is no dimmed `(none)` placeholder — an op simply has a row or it does not. A no-op event renders only the ops it produced (its absence of SIDE EFFECTS / SUBSCRIPTIONS / VIEWS rows is itself information). The stage column makes "which steps ran" legible without empty scaffolding.
+- **No empty-band scaffolding (rf2-aqusw).** With the bands removed, there is no dimmed `(none)` placeholder — an op simply has a row or it does not. A no-op event renders only the ops it produced (its absence of EFFECT HANDLERS / SUBSCRIPTIONS / VIEWS rows is itself information). The stage column makes "which steps ran" legible without empty scaffolding.
 - **Outcome** — the `:rf.epoch/outcome` op renders as an ordinary row carrying the `:outcome` tag (the consumer-facing summary the runtime emits paired with `:rf.epoch/snapshotted` per [Spec 009 §`:rf.epoch/*`](../../../spec/009-Instrumentation.md#op-type-vocabulary) — rf2-18g1w / rf2-jppad): `:ok` · `:blocked` (e.g. routing `:can-leave` rejected, drain depth-limit tripped, frame destroyed mid-drain) · `:error` (handler/fx threw — schema-reserved cause, not currently emitted) · plus a **platform tag** for server epochs. The runtime does the cause→summary projection; the panel reads the summary directly. This is a trace fact (not an aggregate), so it stays despite §2's "no summary."
 - **Short-circuit** — on a throw (`:rf.error/*`) the list stops at the failing op (inline error row); later steps simply have no rows; outcome `:error`. No fabricated rows.
 
@@ -193,7 +193,7 @@ This is **interaction wiring, not visual** — Figma need only render a generic 
 > only** — they show *which ops a given epoch produces*, not the layout.
 > Post-rf2-aqusw the panel renders these ops as one flat list; the stage
 > column on each row carries the step (EVENT HANDLING ops split across the
-> HANDLER / COEFFECT / FLOW stages, EFFECTS ops onto SIDE EFFECTS, etc.
+> EVENT HANDLER / COEFFECT / FLOW stages, EFFECTS ops onto EFFECT HANDLERS, etc.
 > per §3a).
 
 **Routing** `[:rf.route/navigate :app/settings]`:
@@ -222,7 +222,7 @@ This is **interaction wiring, not visual** — Figma need only render a generic 
 ▾ ④ REACTIVE  VIEW rendered-to-string (one-shot — no re-render cascade)
 ● EPOCH CLOSE outcome :ok   (platform :server)
 ```
-**Async** — `:http-xhrio` shows `queued`; the response lands as a separate epoch (`↗`). **Throw** — `ERROR handler-exception` inline at its fire-order point, list short-circuits, outcome `:error`. **No-op** — only DISPATCH + HANDLER rows; no SIDE EFFECTS / SUBSCRIPTIONS / VIEWS rows (their absence is the signal — no empty-band scaffolding post-rf2-aqusw).
+**Async** — `:http-xhrio` shows `queued`; the response lands as a separate epoch (`↗`). **Throw** — `ERROR handler-exception` inline at its fire-order point, list short-circuits, outcome `:error`. **No-op** — only DISPATCH + EVENT HANDLER rows; no EFFECT HANDLERS / SUBSCRIPTIONS / VIEWS rows (their absence is the signal — no empty-band scaffolding post-rf2-aqusw).
 
 ## §17 Design-system conformance
 
@@ -240,31 +240,31 @@ Every Spec-009 trace operation → its row. The **Stage** column is the Epoch pi
 | `:rf.event/dispatched` | DISPATCH | EVENT | dispatched | event-vector + origin | — |
 | `:rf.cofx` (inject) | COEFFECT | COEFFECT | run | cofx-id → value | dur? |
 | `:rf.cofx/skipped-on-platform` | COEFFECT | COEFFECT | skipped-on-platform | cofx-id | — |
-| `:rf.event/run-start`+`run-end` | HANDLER | EVENT | handler ran | handler flavour (`:rf.event/sync?` flag if dispatch-sync) | dur (run-end−run-start) |
-| `:rf.event/db-changed` | SIDE EFFECTS | DB | changed | path old → new | — |
-| `:rf.machine/event-received` | HANDLER | MACHINE | event-received | event | — |
-| `:rf.machine/guard-evaluated` | HANDLER | MACHINE | guard-evaluated | guard-id ✓/✗ | — |
-| `:rf.machine.microstep/transition` · `:rf.machine/transition` | HANDLER | MACHINE | transition (×microsteps) | from → to | — |
-| `:rf.machine/action-ran` | HANDLER | MACHINE | action-ran | action-id | dur? |
-| `:rf.machine.lifecycle/created` | HANDLER | MACHINE | created | machine-id | — |
-| `:rf.machine/system-id-bound` · `system-id-released` | HANDLER | MACHINE | system-id-bound/released | system-id | — |
-| `:rf.machine/snapshot-updated` | HANDLER | MACHINE | snapshot-updated | (or fold into DB) | — |
-| `:rf.fx/handled` (per fx-id) | SIDE EFFECTS | FX | `<fx-id>` | fx-id → arg · queued/landed | dur? |
-| `:rf.fx/do-fx` | SIDE EFFECTS | FX | (fx batch; usually elided to per-fx rows) | — | — |
-| `:rf.fx/override-applied` | SIDE EFFECTS | FX | override-applied | fx-id | — |
-| `:rf.fx/skipped-on-platform` | SIDE EFFECTS | FX | skipped-on-platform | fx-id | — |
+| `:rf.event/run-start`+`run-end` | EVENT HANDLER | EVENT | handler ran | handler flavour (`:rf.event/sync?` flag if dispatch-sync) | dur (run-end−run-start) |
+| `:rf.event/db-changed` | EFFECT HANDLERS | DB | changed | path old → new | — |
+| `:rf.machine/event-received` | EVENT HANDLER | MACHINE | event-received | event | — |
+| `:rf.machine/guard-evaluated` | EVENT HANDLER | MACHINE | guard-evaluated | guard-id ✓/✗ | — |
+| `:rf.machine.microstep/transition` · `:rf.machine/transition` | EVENT HANDLER | MACHINE | transition (×microsteps) | from → to | — |
+| `:rf.machine/action-ran` | EVENT HANDLER | MACHINE | action-ran | action-id | dur? |
+| `:rf.machine.lifecycle/created` | EVENT HANDLER | MACHINE | created | machine-id | — |
+| `:rf.machine/system-id-bound` · `system-id-released` | EVENT HANDLER | MACHINE | system-id-bound/released | system-id | — |
+| `:rf.machine/snapshot-updated` | EVENT HANDLER | MACHINE | snapshot-updated | (or fold into DB) | — |
+| `:rf.fx/handled` (per fx-id) | EFFECT HANDLERS | FX | `<fx-id>` | fx-id → arg · queued/landed | dur? |
+| `:rf.fx/do-fx` | EFFECT HANDLERS | FX | (fx batch; usually elided to per-fx rows) | — | — |
+| `:rf.fx/override-applied` | EFFECT HANDLERS | FX | override-applied | fx-id | — |
+| `:rf.fx/skipped-on-platform` | EFFECT HANDLERS | FX | skipped-on-platform | fx-id | — |
 | `:rf.flow/computed` | FLOW | FLOW | computed | flow-id → path | dur? |
 | `:rf.flow/cleared` · `failed` · `skip` | FLOW | FLOW | cleared / failed / skipped | flow-id | — |
-| `:rf.route/activated` · `deactivated` · `cleared` · `fragment-changed` | SIDE EFFECTS | ROUTING | activated / deactivated / cleared / fragment-changed | route-id / fragment | — |
-| `:rf.route/navigation-blocked` | SIDE EFFECTS | ROUTING | navigation-blocked | route-id (guard) | — (→ outcome :blocked) |
+| `:rf.route/activated` · `deactivated` · `cleared` · `fragment-changed` | EFFECT HANDLERS | ROUTING | activated / deactivated / cleared / fragment-changed | route-id / fragment | — |
+| `:rf.route/navigation-blocked` | EFFECT HANDLERS | ROUTING | navigation-blocked | route-id (guard) | — (→ outcome :blocked) |
 | `:rf.warning/no-not-found-route` | inline (its stage) | WARNING | no-not-found-route | url (unmatched, no `:rf.route/not-found` route registered) | — |
 | `:rf.event/dispatched [:rf.route/handle-url-change …]` | DISPATCH | EVENT | dispatched | url (the URL-change EVENT — **not** a standalone trace op; it rides the `:rf.event/dispatched` row above) | — (↗ child) |
-| `:rf.machine.timer/scheduled` | SIDE EFFECTS | MACHINE | timer-scheduled | delay · state | — (↗ future epoch) |
-| `:rf.machine.timer/fired` | SIDE EFFECTS | MACHINE | timer-fired | delay · state | — |
-| `:rf.machine.timer/stale-after` · `cancelled` (rf2-82a0u — unified, `:reason` discriminates) | SIDE EFFECTS | MACHINE | timer-stale / timer-cancelled | state | — |
-| `:rf.machine.timer/skipped-on-server` | SIDE EFFECTS | MACHINE | timer-skipped-on-server | state | — |
-| `:rf.machine/spawned` · `:rf.machine.spawn/cancelled-on-join-resolution` · `:rf.machine.spawn-all/*` | SIDE EFFECTS | MACHINE | spawned / spawn-cancelled / spawn-all-started/completed/failed | invoke-id | — (↗ child) |
-| `:rf.machine/after` · `done` · `finished` | SIDE EFFECTS | MACHINE | after / done / finished | delay / output | — |
+| `:rf.machine.timer/scheduled` | EFFECT HANDLERS | MACHINE | timer-scheduled | delay · state | — (↗ future epoch) |
+| `:rf.machine.timer/fired` | EFFECT HANDLERS | MACHINE | timer-fired | delay · state | — |
+| `:rf.machine.timer/stale-after` · `cancelled` (rf2-82a0u — unified, `:reason` discriminates) | EFFECT HANDLERS | MACHINE | timer-stale / timer-cancelled | state | — |
+| `:rf.machine.timer/skipped-on-server` | EFFECT HANDLERS | MACHINE | timer-skipped-on-server | state | — |
+| `:rf.machine/spawned` · `:rf.machine.spawn/cancelled-on-join-resolution` · `:rf.machine.spawn-all/*` | EFFECT HANDLERS | MACHINE | spawned / spawn-cancelled / spawn-all-started/completed/failed | invoke-id | — (↗ child) |
+| `:rf.machine/after` · `done` · `finished` | EFFECT HANDLERS | MACHINE | after / done / finished | delay / output | — |
 | `:rf.sub/create` | SUBSCRIPTIONS | SUB | created | sub-id | — |
 | `:rf.sub/run`+`computed` (value-changed? ✓) | SUBSCRIPTIONS | SUB | recalculated | sub-id  old → new | dur? |
 | `:rf.sub/run`+`computed` (value-changed? ✗) | SUBSCRIPTIONS | SUB | ran-unchanged | sub-id | dur? |

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -107,9 +107,9 @@
   {:DISPATCH          "DISPATCH"
    :COEFFECT          "COEFFECT"
    :INTERCEPTOR       "INTERCEPTOR"
-   :HANDLER           "HANDLER"
+   :HANDLER           "EVENT HANDLER"
    :FLOW              "FLOW"
-   :SIDE-EFFECTS      "SIDE EFFECTS"
+   :SIDE-EFFECTS      "EFFECT HANDLERS"
    :SUBSCRIPTIONS     "SUBSCRIPTIONS"
    :VIEWS             "VIEWS"
    :SCHEMA-HOT-RELOAD "SCHEMA HOT-RELOAD"
@@ -134,7 +134,7 @@
 
 (defn label
   "Return the uppercase label string the badge pill renders (e.g.
-  `\"HANDLER\"` for `:HANDLER`). Falls back to `(name badge)` for
+  `\"EVENT HANDLER\"` for `:HANDLER`). Falls back to `(name badge)` for
   unknown badges so a future taxonomy extension still paints text."
   [badge]
   (or (get badge->label badge)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1099,7 +1099,7 @@
 ;; rf2-kt6js 3-tier `:db` / `:fx` / other sub-step grouping). One row per
 ;; effect, down the page, in EXECUTION order; NO group headers. Each row
 ;; carries a leading status glyph + the effect-id + the effect ARGS in an
-;; edn-inspector. After the "SIDE EFFECTS" badge the view paints ONE
+;; edn-inspector. After the "EFFECT HANDLERS" badge the view paints ONE
 ;; overall glyph — TICK when every present row succeeded, CROSS when one
 ;; or more FAILED (SKIPPED rows are NEUTRAL). No post-commit / best-effort
 ;; labels. Each row reuses the shared per-step `:status` (`:ok` /
@@ -1355,7 +1355,7 @@
 
   There are NO `:db` / `:fx` / other group headers — the leading status
   glyph + effect-id + args edn-inspector on each row + the execution
-  order carry the structure. After the \"SIDE EFFECTS\" badge the view
+  order carry the structure. After the \"EFFECT HANDLERS\" badge the view
   paints ONE overall glyph: TICK when every present row succeeded, CROSS
   when one or more FAILED (`side-effects-badge-status`; SKIPPED rows are
   NEUTRAL). No post-commit / best-effort labels.

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -10,14 +10,14 @@
 
   The list reads top-down, oldest-first:
 
-      +0.0  DISPATCH       EVENT     dispatched   [:counter-inc]      —
-      +0.1  COEFFECT       COEFFECT  run          :now -> #inst      0.1 ms
-      +0.2  HANDLER        EVENT     handler ran  reg-event-db       0.2 ms
-      +0.3  FLOW           FLOW      computed     :totals            1.5 ms
-      +1.8  SIDE EFFECTS   DB        changed      [:counter] 1 -> 2   —
-      +1.9  SIDE EFFECTS   FX        :http-xhrio  GET /api/data       —
-      +2.6  SUBSCRIPTIONS  SUB       recalculated :counter/value     0.3 ms
-      +3.1  VIEWS          VIEW      re-rendered  counter-display    1.8 ms
+      +0.0  DISPATCH         EVENT     dispatched   [:counter-inc]      —
+      +0.1  COEFFECT         COEFFECT  run          :now -> #inst      0.1 ms
+      +0.2  EVENT HANDLER    EVENT     handler ran  reg-event-db       0.2 ms
+      +0.3  FLOW             FLOW      computed     :totals            1.5 ms
+      +1.8  EFFECT HANDLERS  DB        changed      [:counter] 1 -> 2   —
+      +1.9  EFFECT HANDLERS  FX        :http-xhrio  GET /api/data       —
+      +2.6  SUBSCRIPTIONS    SUB       recalculated :counter/value     0.3 ms
+      +3.1  VIEWS            VIEW      re-rendered  counter-display    1.8 ms
 
   Each op is a row of six columns (rf2-aqusw):
 
@@ -26,7 +26,7 @@
   ## Stage column + colour-coded left edge (rf2-aqusw)
 
   The STAGE column names the Epoch-panel pipeline step each op belongs
-  to — DISPATCH · COEFFECT · HANDLER · FLOW · SIDE EFFECTS ·
+  to — DISPATCH · COEFFECT · EVENT HANDLER · FLOW · EFFECT HANDLERS ·
   SUBSCRIPTIONS · VIEWS — and the row's left EDGE is colour-coded with
   that step's colour. Both the label and the colour resolve through the
   Epoch panel's own `panels.epoch.badge` taxonomy (NOT a parallel
@@ -107,8 +107,8 @@
 ;; target/detail column is the flexible one and truncates first (spec/023
 ;; §14 — usable at the ≈420px docked width, no horizontal scroll);
 ;; duration right-aligns. The STAGE column (rf2-aqusw) names the Epoch
-;; pipeline step each op belongs to — DISPATCH / COEFFECT / HANDLER /
-;; FLOW / SIDE EFFECTS / SUBSCRIPTIONS / VIEWS — recovering flatly the
+;; pipeline step each op belongs to — DISPATCH / COEFFECT / EVENT HANDLER /
+;; FLOW / EFFECT HANDLERS / SUBSCRIPTIONS / VIEWS — recovering flatly the
 ;; phase information the (now-removed) hierarchy conveyed.
 ;;
 ;; One `:table-id :rf.xray.trace/ops` is shared between the single header

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -28,12 +28,12 @@
   (testing "every badge label resolves to a non-blank string.
 
   Labels are uppercase keyword names by default (DISPATCH, COEFFECT,
-  HANDLER, SIDE EFFECTS, ...). Labels that lead with `:` are
+  EVENT HANDLER, EFFECT HANDLERS, ...). Labels that lead with `:` are
   EDN-key-style and render through `badge-pill`'s mono-font,
   no-uppercase path. Both styles are valid; this test just pins that
   every badge has a label. (rf2-kt6js: the pre-rf2-kt6js `:FX` badge —
-  which rendered as `\":fx\"` — became `:SIDE-EFFECTS` → `\"SIDE
-  EFFECTS\"`.)"
+  which rendered as `\":fx\"` — became `:SIDE-EFFECTS` → `\"EFFECT
+  HANDLERS\"` (rf2-iijnx renamed the display text).)"
     (doseq [b proj/badge-set]
       (let [l (badge/label b)]
         (is (string? l)

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -327,9 +327,9 @@
             badge label (DRY via panels.epoch.badge)"
     (is (= "DISPATCH"
            (h/stage-label {:op-type :rf.event :operation :rf.event/dispatched})))
-    (is (= "SIDE EFFECTS"
+    (is (= "EFFECT HANDLERS"
            (h/stage-label {:op-type :rf.fx :operation :rf.fx/handled}))
-        "SIDE-EFFECTS renders the Epoch label 'SIDE EFFECTS' (spaced)")
+        "SIDE-EFFECTS renders the Epoch label 'EFFECT HANDLERS'")
     (is (= "SUBSCRIPTIONS"
            (h/stage-label {:op-type :rf.sub :operation :rf.sub/run})))
     (is (= "VIEWS"
@@ -364,7 +364,7 @@
                                   :operation :rf.fx/handled
                                   :tags {:rf.fx/id :http-xhrio}}))]
       (is (= :SIDE-EFFECTS (:stage row)))
-      (is (= "SIDE EFFECTS" (:stage-label row)))
+      (is (= "EFFECT HANDLERS" (:stage-label row)))
       (is (= (epoch-badge/colour :SIDE-EFFECTS) (:stage-colour row))))))
 
 ;; ---- (8) band projection — spec/023 §2 / §13 --------------------------

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -1205,21 +1205,21 @@ async function runHttpToggle(page) {
   // in this epoch" surface. Per rf2-639lc the panel default-focuses
   // the head (most-recent) cascade on mount — opening the tab after
   // the last `:go` dispatch surfaces its full numbered cascade.
-  // Assert the rendered panel carries the SIDE EFFECTS step (rf2-kt6js;
+  // Assert the rendered panel carries the EFFECT HANDLERS step (rf2-kt6js;
   // the `:rf.fx/handled` emits for the dispatched `:go` event are
   // projected into the step's `:fx` sub-step). The step header reads
-  // "SIDE EFFECTS" and the `:fx` sub-header reads ":fx".
+  // "EFFECT HANDLERS" and the `:fx` sub-header reads ":fx".
   await clickTab(page, 'epoch', 'rf-xray-epoch-panel');
   await expectVisible(page.locator('[data-testid="rf-xray-epoch-panel"]'), 5000);
   const epochText = ((await page.locator('[data-testid="rf-xray-epoch-panel"]').textContent()) || '').toLowerCase();
-  if (!epochText.includes('fx') && !epochText.includes('effects')) {
-    failWithDetails('Epoch panel did not surface the SIDE EFFECTS step', {
+  if (!epochText.includes('fx') && !epochText.includes('effect')) {
+    failWithDetails('Epoch panel did not surface the EFFECT HANDLERS step', {
       epochText: epochText.slice(0, 800),
     });
   }
   // rf2-gbz39 — the Issues tab was removed (Mike RULED Option (c)).
   // The fx outcomes for this scenario surface inline in the Epoch
-  // panel's SIDE EFFECTS step (asserted above); there is no dedicated
+  // panel's EFFECT HANDLERS step (asserted above); there is no dedicated
   // Issues tab to hand off to anymore.
 }
 
@@ -2853,7 +2853,7 @@ const SCENARIOS = [
     url: '/testbeds/schema-violation/',
     // Post rf2-xy4yb: the dedicated Schemas panel was dropped. Post
     // rf2-gbz39 (Option (c)) the Issues tab was ALSO removed — schema
-    // violations now surface inline in the Epoch panel's SIDE EFFECTS
+    // violations now surface inline in the Epoch panel's EFFECT HANDLERS
     // step (rf2-kt6js).
     panels: ['epoch'],
     coveredRows: ['Epoch Panel'],
@@ -2867,7 +2867,7 @@ const SCENARIOS = [
     // Performance panel is gone too (Mike's call: use Chrome DevTools
     // Performance). rf2-5gl5r: `event` panel renamed to `epoch`.
     // rf2-gbz39: the Issues tab was removed (Option (c)) — fx outcomes
-    // surface inline in the Epoch panel's SIDE EFFECTS step.
+    // surface inline in the Epoch panel's EFFECT HANDLERS step.
     panels: ['epoch', 'trace'],
     coveredRows: ['Epoch Panel', 'Trace'],
     run: runHttpToggle,


### PR DESCRIPTION
Renames two Xray pipeline-stage badge **DISPLAY** labels for precision — one EVENT HANDLER per event; many EFFECT HANDLERS run after:

- `"HANDLER"` → `"EVENT HANDLER"`
- `"SIDE EFFECTS"` → `"EFFECT HANDLERS"`

Scope is **exactly** these two stages (not COEFFECT/FLOW/DISPATCH/SUBSCRIPTIONS/VIEWS).

## Display text only — identifiers intact

Only string literals + human-facing prose changed. The internal step keywords and colour tokens are **unchanged identifiers**:

- `:HANDLER`, `:SIDE-EFFECTS`, `:side-effects` keywords — untouched
- `badge->token-key` colour map (`:HANDLER :accent`, `:SIDE-EFFECTS :orange`) — untouched

Verified by diffing: the only diff lines containing those keywords are the label-map string values (`:HANDLER "EVENT HANDLER"`, `:SIDE-EFFECTS "EFFECT HANDLERS"`) and a docstring that quotes the rendered output — the keyword on the left of each pair is unchanged.

The primary site is the badge label map (`panels/epoch/badge.cljc`). The **Trace panel stage column** reuses `epoch.badge/label` via `trace_helpers/stage-label`, so it picks up the new text for free — no parallel label set to rename (test assertions on the rendered text updated).

## Files touched

- **Badge label map (source of truth):** `tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc` — `:HANDLER`/`:SIDE-EFFECTS` label strings + the `label` fn docstring example.
- **Trace panel:** `panels/trace.cljs` — the stage-column ASCII examples + the stage-list prose (the column resolves through the badge map; labels widened for alignment).
- **Projection comments:** `panels/epoch/projection.cljc` — two quoted-badge references.
- **Tests:** `panels/trace_helpers_cljs_test.cljc` (3 rendered-text assertions), `panels/epoch/badge_cljs_test.cljc` (docstring).
- **feature_matrix:** `testbeds/feature_matrix/scenarios.cjs` — the rendered badge-text assertion (`includes('effects')` → `includes('effect')`) + the "EFFECT HANDLERS step" comments. (Existing scenarios only; did not touch/append the machine scenario — collision-avoidance with w06op.)
- **Xray spec prose:** `023-Trace-Panel.md` (stage column: mapping tables + canonical layout + prose), `021-Dynamic-Panel-Designs.md` (§9.1.10.6 EFFECT HANDLERS step), `018-Event-Spine.md`, `016-Auxiliary-Panels.md`, `000-Vision.md` (the "EFFECT HANDLERS step" label references). Did not touch the testbed-inventory section (w06op).
- **Skill:** `skills/re-frame2-xray/SKILL.md` + `references/panels.md` — the pipeline-stage names + badge taxonomy.

Note: generic conceptual cascade lists that use `COEFFECTS`/`FX` (not the verbatim badge labels) were intentionally left, since they are not the rendered-label vocabulary; dense narrative "the HANDLER step" identifiers in design prose were likewise left as step identifiers.

## Quality gates

Run from `implementation/` (after `npm install` in this fresh worktree):

| Gate | Result |
|---|---|
| `npm run test:cljs` | PASS — 5086 tests / 17156 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` | PASS — 15 scenarios, 0 failures, 13 matrix rows |
| `npm run test:bundle-isolation` | PASS — 17 artefact entries, 35 internal sentinels absent; uix/helix/reagent-free OK |
| clj-kondo (touched files) | 0 errors (2 pre-existing unused-private-var warnings in `projection.cljc`, untouched fns) |

Closes rf2-iijnx.