### PR TITLE
fix(pair): 4 DX papercuts — sticky build, colon-normalize, batch read, epoch-history cap (rf2-lbm21)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -1023,8 +1023,9 @@ Return `:rf/epoch-record`s that landed in the last N ms for the
 operating frame.
 
 **Args**: `ms` (integer, default 1000 — sticky across cursor pagination,
-encoded in the cursor on the first call), `frame` (string),
-`limit` (int, default 50 — see §Cursor pagination above),
+encoded in the cursor on the first call), `frame` (string — frame-id,
+colon-tolerant: `"rf/default"` and `":rf/default"` resolve identically,
+rf2-lbm21), `limit` (int, default 50 — see §Cursor pagination above),
 `cursor` (string, opaque continuation token — see §Cursor pagination
 above), `epochs-mode` (string — `"diff"` (default) or `"full"`, see
 §Diff-encoded `:db-after` below), `dedup` (boolean, default `true` —
@@ -1119,7 +1120,8 @@ loop should call us repeatedly with the same `since-id`.
 by `cursor` when both are supplied), `pred` (object, optional predicate
 filter, keys from: `:event-id`, `:event-id-prefix`, `:effects`,
 `:touches-path`, `:sub-ran`, `:render`, `:origin`, `:frame`,
-`:timing-ms`), `frame`,
+`:timing-ms`), `frame` (string — frame-id, colon-tolerant:
+`"rf/default"` and `":rf/default"` resolve identically, rf2-lbm21),
 `limit` (int, default 50 — see §Cursor pagination above), `cursor`
 (string, opaque continuation token — see §Cursor pagination above),
 `epochs-mode` (string — `"diff"` (default) or `"full"`, see
@@ -1349,6 +1351,24 @@ the legacy shape (rare — only needed if you drive time-travel restore
 off the wire response rather than via `rf/restore-epoch`). See
 `trace-window` above for the wire shape and rationale.
 
+**Full-mode record cap (rf2-lbm21).** When the `:epochs` slice resolves
+to `:full` lazy-summary mode (global `mode "full"` or per-slice `modes
+{"epochs": "full"}`), the slice ships each record **verbatim** —
+`:db-before` plus a full `:db-after` — so an unbounded 50-record
+history pr-strs to ~50× the app-db and trips the global wire cap,
+replacing the **whole** snapshot with an `:rf.mcp/overflow` marker (and
+losing every other slice). To keep full mode usable, the slice is
+default-capped to the **most-recent 10 records** (the tail of the
+chronological history — "what just happened"). When records are
+dropped, the frame map carries a sibling
+`:rf.mcp/epochs-capped {:shown 10 :total <m> :dropped <d> :kept
+:most-recent :hint ...}` marker so the truncation is explicit, never
+silent. An agent that needs the full history pages via `trace-window`
+/ `watch-epochs` (cursor-bounded) or fetches one record by id via
+`restore-epoch`. The cap is a no-op in `:summary` mode (the slice is
+already a one-line marker) and `:diff` `epochs-mode` (each `:db-after`
+is already a small patch).
+
 ### Lazy-summary mode (rf2-u2029)
 
 Every rich slice in the snapshot response defaults to a
@@ -1378,16 +1398,25 @@ slices are markers vs raw payloads without re-deriving the choice
 from the request shape.
 
 The summary marker's `:bytes` hint is a cheap APPROXIMATION
-(rf2-qta8j) — `entry-count × per-entry-constant`, not a precise
+(rf2-qta8j, sampled rf2-lbm21) — `entry-count × per-entry-bytes`,
+where `per-entry-bytes` is **sampled** from one representative entry
+(`pr-str` of the first element / one map value), not a precise
 serialised byte count. The marker's whole point is to avoid
-serialising the deep value (a 54MB app-db slice would otherwise burn
-a 54MB string allocation per summary just to compute one integer);
-agents needing a precise byte count walk the drill-down result
-directly. The marker is computed AFTER diff-encoding and dedup so
-the entry count reflects the post-shrink top-level shape. A map
-with more than 64 top-level keys truncates the `:keys` list and
-flags `:keys-truncated? true` so the marker itself can never blow
-the wire cap.
+serialising the deep value across all N entries (a 54MB app-db slice
+would otherwise burn a 54MB string allocation per summary just to
+compute one integer); agents needing a precise byte count walk the
+drill-down result directly. Sampling reads one entry's depth so the
+hint reflects the **full-expansion cost** — the prior flat per-entry
+constant under-reported a slice of deep entries by ~1000× (the
+`:epochs` slice — a vector of records each carrying a `:db-before` /
+`:db-after` app-db pair — estimated 160 bytes while the full
+expansion ran to ~171K tokens, so an agent reading the hint to
+decide whether to `mode full` blew its budget). The sample cost is
+`O(one-entry-depth)`, independent of `:count`. The marker is computed
+AFTER diff-encoding and dedup so the entry count reflects the
+post-shrink top-level shape. A map with more than 64 top-level keys
+truncates the `:keys` list and flags `:keys-truncated? true` so the
+marker itself can never blow the wire cap.
 
 ### `:app-db` slice modes (rf2-tygdv)
 
@@ -1432,13 +1461,16 @@ Server-side `(get-in db path)`; only the addressed subtree crosses
 the wire (rf2-tygdv).
 
 **Args**: `path` (string — EDN-encoded vector, e.g. `"[:cart :items 0
-:sku]"` — or JSON array of segment strings; required), `frame`
-(string — frame-id, default operating frame), `elision` (boolean,
-default `true` — applies the size-elision walker to the resolved
-value; see §Size-elision at the top of this catalogue, rf2-urjnc),
-`build` (string).
+:sku]"` — or JSON array of segment strings), `paths` (string — an
+EDN-encoded vector of path vectors, e.g. `"[[:cart :total] [:user
+:id]]"` — or JSON array whose entries are EDN path strings / segment
+arrays; the batch surface, rf2-lbm21), `frame` (string — frame-id,
+default operating frame), `elision` (boolean, default `true` — applies
+the size-elision walker to the resolved value(s); see §Size-elision at
+the top of this catalogue, rf2-urjnc), `build` (string). `path` and
+`paths` are **mutually exclusive** — supply exactly one.
 
-**Returns** on success:
+**Returns** on success (singular `path`):
 
 ```clojure
 {:ok?     true
@@ -1448,6 +1480,24 @@ value; see §Size-elision at the top of this catalogue, rf2-urjnc),
  :elision true | false
  :frame   <frame-id>}          ; only when frame arg was supplied
 ```
+
+**Returns** on success (plural `paths` — batch read, rf2-lbm21):
+
+```clojure
+{:ok?     true
+ :results {[<segment>...] {:exists? true  :value <subtree>}   ; elided per-value as above
+           [<segment>...] {:exists? false :value nil}}        ; path didn't resolve
+ :elision true | false
+ :frame   <frame-id>}          ; only when frame arg was supplied
+```
+
+The batch surface resolves the frame's `app-db` once and reads every
+path against it in a single round-trip — N targeted reads without N
+calls. Each value is elided exactly as the singular surface does;
+`:results` is keyed by the caller's path vectors so the agent
+correlates hits without re-deriving order. An unresolved path carries
+`:exists? false` (never a `:path-not-found` envelope — the batch is a
+whole-or-nothing success).
 
 When the path doesn't resolve:
 
@@ -1477,7 +1527,9 @@ wants several slices in the same round-trip; both share the same
 `:path` vocabulary.
 
 `:reason :runtime-not-preloaded` if the preload hasn't run;
-`:reason :missing-path` if `path` was omitted;
+`:reason :missing-path` if neither `path` nor `paths` was supplied;
+`:reason :path-and-paths-both-supplied` if both were supplied;
+`:reason :empty-paths` if `paths` was an empty vector;
 `:reason :get-path-failed` (with `:message`) on any other failure.
 
 ## read-dom

--- a/tools/re-frame2-pair-mcp/spec/API.md
+++ b/tools/re-frame2-pair-mcp/spec/API.md
@@ -91,12 +91,20 @@ impl: [`src/re_frame2_pair_mcp/tools/wire.cljs`](../src/re_frame2_pair_mcp/tools
    before interning. A bare `keyword` on the colon form would mint the
    malformed `::examples/step-deck` and probe a build that doesn't
    exist; that footgun is closed.
-2. **Session-scoped `:resolved-build-id` cache on the conn-atom.**
-   Populated by `discover-app` after a successful preload probe
-   (`wire/mark-resolved-build-id!`, `src/.../tools/wire.cljs` line 108;
-   call sites at `src/.../tools/discover_app.cljs` lines 32 / 42 / 57).
-   Removes the friction of repeating `build: foo` on every tool call
-   after a successful discover-app.
+2. **Session-scoped `:resolved-build-id` cache on the conn-atom — the
+   sticky operating build.** Populated two ways:
+   - by `discover-app` after a successful preload probe
+     (`wire/mark-resolved-build-id!`; call sites at
+     `src/.../tools/discover_app.cljs`), and
+   - by an explicit `:build` arg on **any other** tool call, written
+     back at the `invoke` boundary via `wire/stick-build!` (rf2-lbm21).
+     The first call that names a build sets the session-sticky default;
+     every subsequent call may omit `:build`. `arg-build` itself stays a
+     pure read — the write lives at the single dispatch chokepoint so
+     `discover-app` (which calls `arg-build` to *probe* a build, and
+     caches only on a passing health check) is never forced to cache a
+     build that turned out unusable.
+   Removes the friction of repeating `build: foo` on every op.
 3. **`SHADOW_CLJS_BUILD_ID` env var, defaulting to `:app`.** The
    final fallback when neither (1) nor (2) is available.
 
@@ -105,12 +113,14 @@ impl: [`src/re_frame2_pair_mcp/tools/wire.cljs`](../src/re_frame2_pair_mcp/tools
 (line 416) — the operator may relaunch shadow-cljs against a different
 build id, so the next reconnect starts with no cached resolution.
 
-**Consequence for callers.** After a successful `discover-app {build:
-"my-app"}` (or a discover-app against the default build), subsequent
-tool calls in the same session may omit the `:build` arg even when
-`SHADOW_CLJS_BUILD_ID` is unset and would otherwise default to `:app`.
-The cached resolution carries through. Multi-build workspaces should
-discover-app once per build they intend to target.
+**Consequence for callers.** After **any** call that names a build —
+`discover-app {build: "my-app"}`, or a first `snapshot {build:
+"my-app"}` — subsequent tool calls in the same session may omit the
+`:build` arg even when `SHADOW_CLJS_BUILD_ID` is unset and would
+otherwise default to `:app`. The sticky build carries through; a later
+explicit `:build` both routes that call and re-points the sticky
+default. Multi-build workspaces re-specify `:build` when switching the
+target.
 
 Distinct from the per-session **response** cache (rf2-3rt1f, see
 [`Principles.md`](./Principles.md) § Per-session response cache) —

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -238,6 +238,13 @@
   _meta.progressToken) for streaming tools. Non-streaming tools ignore
   it."
   [conn name args extra]
+  ;; rf2-lbm21 — session-sticky operating build. An explicit `:build` on
+  ;; any tool call (except `discover-app`, which owns its success-gated
+  ;; cache lifecycle) becomes the sticky default for subsequent
+  ;; no-`:build` calls. `arg-build` stays a pure read; the write lives
+  ;; here at the single dispatch chokepoint.
+  (when (not= name "discover-app")
+    (wire/stick-build! conn args))
   (let [enabled? (args/parse-bool-arg args :cache)
         ctx      {:conn       conn
                   :name       name

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
@@ -151,6 +151,56 @@
             [trimmed]))))
     :else nil))
 
+(defn parse-paths-arg
+  "Normalise the plural `paths` MCP arg into a vector of path vectors —
+  the batch-read shape `get-path` consumes (rf2-lbm21). Each element is
+  itself a path (run through `parse-path-arg`), so a caller can read N
+  app-db subtrees in ONE round-trip instead of N `get-path` calls.
+
+  Accepted shapes from the MCP host:
+
+    - EDN-encoded string  ⇒ `read-string`, then each element is a path.
+                            `\"[[:a :b] [:c 0]]\"` ⇒ `[[:a :b] [:c 0]]`.
+    - JS array            ⇒ each entry parsed as a path. Entries may be
+                            EDN-string paths (`\"[:a :b]\"`) or JS arrays
+                            of segment strings (`[\":a\" \":b\"]`).
+    - CLJS sequential     ⇒ each entry parsed as a path.
+    - nil / missing       ⇒ nil (no batch read; caller falls back to the
+                            singular `:path` arg).
+
+  Each path is coerced with the shared `parse-path-arg` so the segment
+  vocabulary (EDN literals, bare-string map keys, integer indices) is
+  identical to the singular surface — agents learn the shape once.
+  Returns `nil` when the arg is absent / blank / not a collection so
+  the caller can discriminate \"no batch requested\" from \"empty batch\"."
+  [raw]
+  (let [as-seq (cond
+                 (nil? raw)        nil
+                 ;; A JS array's entries may themselves be JS arrays of
+                 ;; segment strings. `(vec raw)` is a SHALLOW conversion —
+                 ;; the outer array becomes a CLJS vector while each inner
+                 ;; element stays a raw JS array, so it reaches
+                 ;; `parse-path-arg` in its raw shape and that fn's
+                 ;; `(array? raw)` arm coerces the segments
+                 ;; (`\":cart\"` ⇒ `:cart`). A deep `js->clj` here would
+                 ;; pre-collapse the inner arrays to vectors-of-STRINGS,
+                 ;; which `parse-path-arg`'s `(vector? raw)` pass-through
+                 ;; arm would NOT coerce. `(vec #js [])` ⇒ `[]` (the
+                 ;; explicit empty batch).
+                 (array? raw)      (vec raw)
+                 (sequential? raw) raw
+                 (string? raw)
+                 (let [trimmed (str/trim raw)]
+                   (when-not (str/blank? trimmed)
+                     (let [parsed (try (cljs.reader/read-string trimmed)
+                                       (catch :default _ ::reader-fail))]
+                       (when (and (not= ::reader-fail parsed)
+                                  (sequential? parsed))
+                         parsed))))
+                 :else nil)]
+    (when (some? as-seq)
+      (mapv parse-path-arg as-seq))))
+
 (defn parse-frames-arg
   "Normalise the `frames` MCP arg into the form the runtime expects.
    Accepts `:all`, the string \"all\", a JS array of strings, or a CLJS

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -691,6 +691,11 @@
                      "when the path doesn't resolve. The deepest-valid-prefix lets the agent re-aim "
                      "without a binary search. Use this when `snapshot`'s summary mode (default) "
                      "tells you which key carries the answer. "
+                     "Batch read (rf2-lbm21): pass `paths` (plural) — a vector of path vectors — to "
+                     "read N app-db subtrees in ONE round-trip instead of N calls. Returns "
+                     "`{:ok? true :results {<path> {:exists? bool :value <subtree>}}}`; each value is "
+                     "elided exactly like the singular surface. `path` and `paths` are mutually "
+                     "exclusive (supplying both -> :reason :path-and-paths-both-supplied). "
                      "Size-elision (rf2-urjnc): the resolved value is run through "
                      "`re-frame.core/elide-wire-value` server-side — a declared / schema-`:large?` "
                      "slot or an over-threshold leaf returns a `{:rf.size/large-elided ...}` marker "
@@ -703,7 +708,8 @@
                      "Examples: "
                      "1. Hit: {:path \"[:cart :items 0 :sku]\"} -> {:ok? true :exists? true :path [:cart :items 0 :sku] :value \"sku-abc\"}. "
                      "2. Path-not-found: {:path \"[:cart :items 99]\"} -> {:ok? false :reason :path-not-found :path [:cart :items 99] :deepest-valid-prefix [:cart :items]}. "
-                     "3. Large slot elided: {:path \"[:big :payload]\"} -> {:ok? true :exists? true :value {:rf.size/large-elided {:path [:big :payload] :bytes 12345 :type :map :reason :schema :handle [:rf.elision/at [:big :payload]]}}}.")
+                     "3. Large slot elided: {:path \"[:big :payload]\"} -> {:ok? true :exists? true :value {:rf.size/large-elided {:path [:big :payload] :bytes 12345 :type :map :reason :schema :handle [:rf.elision/at [:big :payload]]}}}. "
+                     "4. Batch read: {:paths \"[[:cart :total] [:user :id] [:missing :k]]\"} -> {:ok? true :results {[:cart :total] {:exists? true :value 42} [:user :id] {:exists? true :value \"u-1\"} [:missing :k] {:exists? false :value nil}}}.")
    :typicalTokens 500
    :annotations idempotent-read-only-annotations
    :outputSchema envelope-or-marker
@@ -711,9 +717,19 @@
                  :properties {:path  {:description (str "Path into app-db. EDN-encoded vector of keys "
                                                         "(e.g. \"[:cart :items 0 :sku]\") or a JSON array "
                                                         "of segment strings (each parsed as EDN — bare "
-                                                        "strings stay as map-key strings).")
+                                                        "strings stay as map-key strings). Mutually "
+                                                        "exclusive with `paths`.")
                                       :oneOf [{:type "string"}
                                               {:type "array" :items {:type "string"}}]}
+                              :paths {:description (str "Batch read (rf2-lbm21): a vector of paths, each itself "
+                                                        "a path vector — reads N subtrees in one round-trip. "
+                                                        "EDN-encoded (e.g. \"[[:cart :total] [:user :id]]\") or a "
+                                                        "JSON array whose entries are EDN path strings / segment "
+                                                        "arrays. Returns `:results` keyed by each path. Mutually "
+                                                        "exclusive with `path`.")
+                                      :oneOf [{:type "string"}
+                                              {:type "array" :items {:oneOf [{:type "string"}
+                                                                             {:type "array" :items {:type "string"}}]}}]}
                               :frame   {:type "string"
                                         :description "Frame-id (e.g. \":rf/default\"). Defaults to the operating frame."}
                               :elision knobs/elision-property
@@ -723,7 +739,6 @@
                                                                      "Default false ⇒ sensitive paths return the `:rf/redacted` "
                                                                      "sentinel.")}
                               :build   {:type "string"}}
-                 :required ["path"]
                  :additionalProperties false}})
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -11,6 +11,22 @@
 
   Path vocabulary mirrors `get-in`: a vector of keys / indices.
 
+  ## Batch read — the plural `paths` arg (rf2-lbm21)
+
+  Reading N app-db paths used to need N `get-path` calls (or a
+  fallback `eval-cljs`). The `paths` arg (a vector of path vectors)
+  reads them all in ONE round-trip: the runtime resolves each path
+  server-side and returns `{:ok? true :results {<path> {:exists? bool
+  :value <subtree>}}}`. `:path` (singular) and `:paths` (plural) are
+  mutually exclusive surfaces on the same tool — passing both is a
+  usage error. Each value is elided server-side exactly as the
+  singular surface does; the batch reuses the same elision opts and the
+  same wire-pipeline `:scalar-value` arm (the whole `:results` map is
+  the scalar). Extending the existing tool (rather than minting a new
+  `get-paths`) keeps the catalogue, the skill allow-list, and the
+  wire-vocab surface unchanged — the agent that knows `get-path` knows
+  the batch form for free.
+
   Post-eval shrink pipeline lives in
   `re-frame2-pair-mcp.tools.wire-pipeline` (rf2-ae8ie). The eval form
   ran `re-frame.core/elide-wire-value` server-side already; the
@@ -25,10 +41,89 @@
             [re-frame2-pair-mcp.tools.elision :as elision]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]))
 
+(defn- elide-call-src
+  "CLJS source for `(elide-wire-value <value-sym> ...)` (or a verbatim
+  pass-through when elision is off). `value-sym` is the let-bound name
+  carrying the resolved value; `path-src` is the source for the `:path`
+  slot of the marker handle (a let-bound name or an EDN literal);
+  `frame-edn` / `elision-opts` are the merged walker opts."
+  [elision? value-sym path-src frame-edn elision-opts]
+  (if elision?
+    (str "(re-frame.core/elide-wire-value " value-sym
+         "  (merge {:path " path-src " :frame " frame-edn "}"
+         "         " elision-opts "))")
+    value-sym))
+
+(defn- single-path-form
+  "Eval form for the singular `:path` read. Calls `snapshot` (full db for
+  the frame) then `get-in` with a missing sentinel, so `path-not-found`
+  is distinguishable from a path that legitimately points at nil. The
+  deepest-valid-prefix loop is inlined so a stale runtime (no helper)
+  still answers correctly. Elision (rf2-urjnc) + server-side marker
+  count (rf2-e35a5) ride on the `:value` / `:elided-count` slots."
+  [snapshot-call path elision? frame-edn elision-opts]
+  (let [elide-call (elide-call-src elision? "v" "path" frame-edn elision-opts)
+        count-expr (if elision?
+                     (str "(count (filter #(and (map? %) (contains? % :rf.size/large-elided))"
+                          "               (tree-seq coll? seq elided-v)))")
+                     "0")]
+    (ef/emit
+      (ef/rt-let
+        ['db       snapshot-call
+         'path     path
+         'missing  (ef/rt-raw "#js {}")
+         'v        (ef/rt-raw "(get-in db path missing)")
+         'elided-v (ef/rt-raw elide-call)
+         'n        (ef/rt-raw count-expr)]
+        (ef/rt-raw
+          (str "(if (identical? v missing)"
+               "  {:ok? false :reason :path-not-found"
+               "   :path path"
+               "   :deepest-valid-prefix"
+               "   (loop [acc [] cur db rem path]"
+               "     (cond"
+               "       (empty? rem) acc"
+               "       (and (map? cur) (contains? cur (first rem)))"
+               "       (recur (conj acc (first rem)) (get cur (first rem)) (rest rem))"
+               "       (and (sequential? cur) (integer? (first rem))"
+               "            (<= 0 (first rem) (dec (count cur))))"
+               "       (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
+               "       :else acc))}"
+               "  {:ok? true :exists? true :path path :value elided-v :elided-count n})"))))))
+
+(defn batch-paths-form
+  "Eval form for the plural `:paths` batch read (rf2-lbm21). Resolves
+  the frame's db ONCE, then folds over the paths — each gets the same
+  `get-in`-with-missing-sentinel + elision treatment as the singular
+  form. Returns `{:results {<path> {:exists? bool :value <elided>}}
+  :elided-count N}`; the `:results` map preserves the caller's path
+  vectors as keys so the agent can correlate hits without re-deriving
+  order. The marker `:path` handle is the per-iteration path `p` so a
+  drill-down via singular `get-path` lands on the right slot."
+  [snapshot-call paths elision? frame-edn elision-opts]
+  (let [elide-call (elide-call-src elision? "raw-v" "p" frame-edn elision-opts)]
+    (ef/emit
+      (ef/rt-let
+        ['db      snapshot-call
+         'missing (ef/rt-raw "#js {}")
+         'results (ef/rt-raw
+                    (str "(reduce"
+                         "  (fn [acc p]"
+                         "    (let [raw-v (get-in db p missing)]"
+                         "      (if (identical? raw-v missing)"
+                         "        (assoc acc p {:exists? false :value nil})"
+                         "        (assoc acc p {:exists? true :value " elide-call "}))))"
+                         "  {} " (pr-str (vec paths)) ")"))]
+        (ef/rt-raw
+          (str "{:ok? true :results results"
+               " :elided-count (count (filter #(and (map? %) (contains? % :rf.size/large-elided))"
+               "                              (tree-seq coll? seq results)))}"))))))
+
 (defn get-path-tool [conn raw-args]
   (let [build-id  (wire/arg-build conn raw-args)
         frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         path      (args/parse-path-arg (wire/arg raw-args :path))
+        paths     (args/parse-paths-arg (wire/arg raw-args :paths))
         ;; rf2-c2dtu — when the `--allow-sensitive-reads` boot gate is OFF,
         ;; the per-call `:elision false` arg is overridden so the walker
         ;; still fires. rf2-p1qli: single intention-naming predicate
@@ -49,114 +144,76 @@
         ;; reaching the walker.
         incl?     (if (raw-state/raw-state-allowed?)
                     (args/parse-bool-arg raw-args :include-sensitive)
-                    false)]
+                    false)
+        ;; rf2-suoj2 — `elision-opts-edn` takes walker-aligned
+        ;; `include-large?` polarity directly. MCP `elision` true =
+        ;; emit markers = `:include-large?` false; hence `(not elision?)`.
+        elision-opts  (elision/elision-opts-edn (not elision?) incl?)
+        snapshot-call (if frame
+                        (ef/rt-call 'snapshot frame)
+                        (ef/rt-call 'snapshot))
+        frame-edn     (if frame
+                        (pr-str frame)
+                        (ef/emit (ef/rt-call 'current-frame)))
+        run-eval
+        ;; Shared eval-then-shrink tail: both branches run a server-side
+        ;; form, strip the literal value(s) through the wire-pipeline
+        ;; `:scalar-value` arm (rf2-6by5s), and rebuild the envelope.
+        ;; `pluck` lifts the literal value the pipeline should count;
+        ;; `rebuild` reassembles the envelope from the pipelined value.
+        (fn [form pluck rebuild]
+          (-> (probe/ensure-runtime! conn build-id)
+              (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
+              (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+              (.then (fn [envelope]
+                       (let [server-elided (when (:ok? envelope) (:elided-count envelope))
+                             {:keys [value indicators]}
+                             (wp/run-wire-pipeline
+                               (pluck envelope)
+                               {:kind :scalar-value
+                                :server-elided server-elided})
+                             {:keys [elided]} indicators]
+                         (wire/ok-text
+                           (wire/with-indicators
+                             (rebuild (dissoc envelope :elided-count) value)
+                             {:elided elided})))))
+              (.catch (fn [err] (probe/err->result :get-path-failed err)))))]
     (cond
+      ;; rf2-lbm21 — `:path` and `:paths` are mutually exclusive surfaces.
+      (and (some? path) (some? paths))
+      (js/Promise.resolve
+        (wire/err-text {:ok? false :reason :path-and-paths-both-supplied
+                        :hint "pass EITHER path (singular, one read) OR paths (plural, batch read), not both"}))
+
+      ;; Batch read (rf2-lbm21): N paths, one round-trip. The whole
+      ;; `:results` map is the scalar the pipeline counts elision over.
+      (some? paths)
+      (if (empty? paths)
+        (js/Promise.resolve
+          (wire/err-text {:ok? false :reason :empty-paths
+                          :hint "usage: get-path {paths '[[:cart :items] [:user :id]]' [frame :rf/default]}"}))
+        (run-eval
+          (batch-paths-form snapshot-call paths elision? frame-edn elision-opts)
+          :results
+          (fn [envelope' results]
+            (cond-> (assoc envelope' :results results :elision elision?)
+              frame (assoc :frame frame)))))
+
       (nil? path)
       (js/Promise.resolve
         (wire/err-text {:ok? false :reason :missing-path
-                        :hint "usage: get-path {path '[:cart :items 0 :sku]' [frame :rf/default]}"}))
+                        :hint "usage: get-path {path '[:cart :items 0 :sku]' [frame :rf/default]} — or paths '[[:a :b] [:c]]' for a batch read"}))
 
+      ;; Singular read (rf2-tygdv): one path, one round-trip.
+      ;; rf2-6by5s — `:path-not-found` results carry no `:value` slot, so
+      ;; the pipeline runs over nil and reports zero elision; the
+      ;; `:value` slot is only re-attached on a hit.
       :else
-      ;; Server-side eval form: call `snapshot` (full db for the frame)
-      ;; then `get-in` with a missing sentinel, so we can distinguish
-      ;; `path-not-found` from a path that legitimately points at nil.
-      ;; The deepest-valid-prefix loop is inlined so a stale runtime
-      ;; (no helper) still answers correctly.
-      ;;
-      ;; Elision wiring (rf2-urjnc): once `get-in` resolves the value,
-      ;; we run it through `re-frame.core/elide-wire-value` so a
-      ;; large / sensitive slot returns the marker (with a handle the
-      ;; agent can drill into) rather than the raw bytes. The walker
-      ;; reads the live `[:rf/runtime :elision]` registry from the frame's
-      ;; app-db, so it must run app-side. Passing `:path path` makes
-      ;; the marker's `:handle` slot carry `[:rf.elision/at <path>]`
-      ;; — the agent can re-call `get-path` with a deeper segment to
-      ;; drill into a non-elided child, or pass `elision false` to
-      ;; bypass the walk entirely.
-      ;; Per rf2-e35a5: when elision is on, the eval form ALSO counts
-      ;; markers server-side (via `tree-seq`) and returns `:elided-count`
-      ;; on the envelope. The client-side `:scalar-value` arm reads the
-      ;; count from opts instead of re-walking the scalar — the
-      ;; elide-wire-value walker is the only thing that inserts markers,
-      ;; so it can hand the count back on the same round-trip.
-      (let [snapshot-call (if frame
-                            (ef/rt-call 'snapshot frame)
-                            (ef/rt-call 'snapshot))
-            frame-edn     (if frame
-                            (pr-str frame)
-                            (ef/emit (ef/rt-call 'current-frame)))
-            ;; rf2-suoj2 — `elision-opts-edn` takes walker-aligned
-            ;; `include-large?` polarity directly. MCP `elision` true =
-            ;; emit markers = `:include-large?` false; hence `(not elision?)`.
-            elision-opts  (elision/elision-opts-edn (not elision?) incl?)
-            elide-call    (if elision?
-                            (str "(re-frame.core/elide-wire-value v"
-                                 "  (merge {:path path :frame " frame-edn "}"
-                                 "         " elision-opts "))")
-                            "v")
-            ;; Server-side count piggybacks on the `:value` binding —
-            ;; one tree-seq over the walked value. When elision is
-            ;; OFF the walker is a no-op (pass-through) and the count
-            ;; is unconditionally zero.
-            count-expr    (if elision?
-                            (str "(count (filter #(and (map? %) (contains? % :rf.size/large-elided))"
-                                 "               (tree-seq coll? seq elided-v)))")
-                            "0")
-            form (ef/emit
-                   (ef/rt-let
-                     ['db       snapshot-call
-                      'path     path
-                      'missing  (ef/rt-raw "#js {}")
-                      'v        (ef/rt-raw "(get-in db path missing)")
-                      'elided-v (ef/rt-raw elide-call)
-                      'n        (ef/rt-raw count-expr)]
-                     (ef/rt-raw
-                       (str "(if (identical? v missing)"
-                            "  {:ok? false :reason :path-not-found"
-                            "   :path path"
-                            "   :deepest-valid-prefix"
-                            "   (loop [acc [] cur db rem path]"
-                            "     (cond"
-                            "       (empty? rem) acc"
-                            "       (and (map? cur) (contains? cur (first rem)))"
-                            "       (recur (conj acc (first rem)) (get cur (first rem)) (rest rem))"
-                            "       (and (sequential? cur) (integer? (first rem))"
-                            "            (<= 0 (first rem) (dec (count cur))))"
-                            "       (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
-                            "       :else acc))}"
-                            "  {:ok? true :exists? true :path path :value elided-v :elided-count n})"))))]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [envelope]
-                     ;; rf2-6by5s — strip the `:value` slot off, run only
-                     ;; the literal value through the wire-pipeline, and
-                     ;; rebuild the envelope. The indicator count reflects
-                     ;; exactly what ships; `:path-not-found` results
-                     ;; (no `:value` slot) report zero elision — correct
-                     ;; by construction, not by accident of which keys
-                     ;; the walker happens to ignore.
-                     ;;
-                     ;; rf2-e35a5: pass the server-side count through to
-                     ;; the wire-pipeline so the client-side walk is
-                     ;; eliminated.
-                     (let [ok?             (:ok? envelope)
-                           scalar          (when ok? (:value envelope))
-                           server-elided   (when ok? (:elided-count envelope))
-                           {:keys [indicators]}
-                                           (wp/run-wire-pipeline
-                                             scalar
-                                             {:kind :scalar-value
-                                              :server-elided server-elided})
-                           {:keys [elided]} indicators
-                           ;; Drop the wire-internal :elided-count slot
-                           ;; from the envelope — it's now surfaced as
-                           ;; the public :elided-large indicator via
-                           ;; with-indicators.
-                           envelope'       (dissoc envelope :elided-count)]
-                       (wire/ok-text (wire/with-indicators
-                                       (cond-> envelope'
-                                         frame (assoc :frame frame)
-                                         ok?   (assoc :elision elision?))
-                                       {:elided elided})))))
-            (.catch (fn [err] (probe/err->result :get-path-failed err))))))))
+      (run-eval
+        (single-path-form snapshot-call path elision? frame-edn elision-opts)
+        (fn [envelope] (when (:ok? envelope) (:value envelope)))
+        (fn [envelope' value]
+          (let [ok? (:ok? envelope')]
+            (cond-> envelope'
+              ok?   (assoc :value value :elision elision?)
+              frame (assoc :frame frame))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot_pipeline.cljs
@@ -58,6 +58,20 @@
   grow unbounded with runtime state."
   #{:sub-cache :machines :epochs :traces})
 
+(def ^:const full-epochs-cap
+  "Default record cap on the `:epochs` slice when it resolves to `:full`
+  mode (rf2-lbm21). `:full` mode ships each epoch record VERBATIM —
+  including its `:db-before` / `:db-after` app-db pair — so an
+  unbounded 50-record history pr-strs to ~50× the app-db (the
+  171K-token overflow the bead reports). Capping to the most-recent N
+  records keeps full mode usable for the common 'what just happened?'
+  read while the wire-cap stays a backstop for the rest. An agent that
+  needs the full history pages via `trace-window` / `watch-epochs`
+  (cursor-bounded) or `restore-epoch` (one record by id). 10 is the
+  recent-history window a debugging read actually wants; more and the
+  slice is a paging job, not a snapshot."
+  10)
+
 (defn resolve-slice-mode
   "Resolve the effective mode for a slice. `slice-modes` is the
   per-slice override map; `global-mode` is the snapshot-wide `:mode`
@@ -147,6 +161,59 @@
                                  (assoc m fid (process-frame fmap)))
                                {} snapshot)]
       {:snapshot processed :resolved-modes resolved})))
+
+(defn cap-full-epochs-in-snapshot
+  "Bound the `:epochs` slice to the most-recent `cap` records on every
+  frame whose `:epochs` resolved to `:full` mode (rf2-lbm21).
+
+  Only fires in `:full` mode — in `:summary` mode the slice is already a
+  one-line `{:rf.mcp/summary ...}` marker, and `:diff` epochs-mode has
+  collapsed each `:db-after` to a small patch, so neither needs the cap.
+  Full mode is the overflow path: each record carries a verbatim
+  `:db-before` / `:db-after` app-db pair, so an unbounded history blows
+  the wire budget (the 171K-token report).
+
+  Keeps the LAST `cap` records (epoch-history is chronological,
+  oldest→newest, so the tail is 'what just happened'). The `:epochs`
+  slot stays a plain (truncated) vector — diff-encode and dedup
+  downstream operate on it unchanged. When records are dropped, a
+  SIBLING `:rf.mcp/epochs-capped {:shown <n> :total <m> :dropped <d>
+  :kept :most-recent :hint ...}` key is added to the frame map so the
+  agent sees the truncation explicitly (never silent) and the next-step
+  (page older history via `watch-epochs` / `trace-window`). A slice
+  already at/under the cap passes through untouched, no sibling key.
+
+  Runs FIRST among the epochs transforms (before diff-encode + dedup) so
+  those operate on the already-bounded set. `cap` is the record limit
+  (`full-epochs-cap` by default)."
+  [snapshot slice-modes global-mode cap]
+  (if (or (not (map? snapshot))
+          (not= :full (resolve-slice-mode :epochs slice-modes global-mode)))
+    snapshot
+    (reduce-kv
+      (fn [m fid fmap]
+        (assoc m fid
+               (if-not (and (map? fmap)
+                            (contains? fmap :epochs)
+                            (sequential? (:epochs fmap)))
+                 fmap
+                 (let [epochs (:epochs fmap)
+                       total  (count epochs)]
+                   (if (<= total cap)
+                     fmap
+                     (let [kept (vec (take-last cap epochs))]
+                       (assoc fmap
+                              :epochs kept
+                              :rf.mcp/epochs-capped
+                              {:shown   (count kept)
+                               :total   total
+                               :dropped (- total (count kept))
+                               :kept    :most-recent
+                               :hint    (str "full-mode epoch-history capped to the most-recent "
+                                             cap " records — page older history via "
+                                             "watch-epochs / trace-window (cursor-bounded) or "
+                                             "fetch one by id via restore-epoch")})))))))
+      {} snapshot)))
 
 (defn diff-encode-epochs-in-snapshot
   "Walk the per-frame snapshot map and diff-encode every frame's

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
@@ -17,7 +17,7 @@
   application of summarise / path-slice / diff-encode / dedup — lives
   in `tools/snapshot-pipeline.cljs`.
 
-  ## Approximate `:bytes` field (rf2-qta8j)
+  ## Approximate `:bytes` field (rf2-qta8j, sampled rf2-lbm21)
 
   The `:bytes` field is a *cheap* approximation, not a precise count.
   Earlier shape computed `(count (pr-str v))` on every branch which
@@ -28,11 +28,24 @@
   that's a 54MB string allocation + ~13M tokens of serialisation work
   per summary.
 
-  The current heuristic estimates `~ entry-count × constant` (see
-  `byte-estimate-per-entry`). It is intentionally rough — the marker
-  is consumed by agents for *planning* (\"is this slice worth
-  drilling into?\"), not for precise budgeting. Agents needing a
-  precise size measure their drill-down result directly.")
+  The estimate is `~ entry-count × per-entry-bytes`. Per-entry-bytes is
+  SAMPLED from one representative entry (rf2-lbm21): the prior fixed
+  8-/16-byte constants assumed every entry was a scalar, which under-
+  reported a collection of deep entries by ~1000×. The dominant
+  offender was the `:epochs` slice — a vector of epoch records, each
+  carrying a full `:db-before` / `:db-after` app-db pair. A 20-record
+  slice estimated `20 × 8 = 160` bytes while the FULL expansion ran to
+  ~171K tokens; an agent reading the `:bytes` hint to decide whether to
+  drill (`mode full`) saw a slice that looked trivial and blew its
+  budget on expansion. Sampling one entry's serialised size captures
+  the per-entry depth so the hint reflects the full-expansion cost.
+
+  Cost stays bounded: we `pr-str` exactly ONE entry (and ONE map
+  value), not all N — `O(one-entry-depth)`, independent of `:count`.
+  The estimate is still intentionally rough — the marker is consumed by
+  agents for *planning* (\"is this slice worth drilling into?\"), not
+  for precise budgeting. Agents needing a precise size measure their
+  drill-down result directly.")
 
 (def summary-keys-cap
   "Top-N keys included verbatim in a tree-summary marker. Above this,
@@ -44,26 +57,60 @@
   64)
 
 ;; ---------------------------------------------------------------------------
-;; Cheap `:bytes` estimator (rf2-qta8j).
+;; Sampled `:bytes` estimator (rf2-qta8j, rf2-lbm21).
 ;;
-;; Average per-entry overhead under `pr-str` for representative
-;; runtime values:
+;; `:bytes` ≈ entry-count × per-entry-bytes, where per-entry-bytes is
+;; SAMPLED from one representative entry rather than assumed a flat
+;; scalar constant. The prior fixed constants (8 for coll entries, 16
+;; for map entries) under-reported a collection of DEEP entries — most
+;; egregiously the `:epochs` slice, where each vector entry is a full
+;; epoch record carrying a `:db-before` / `:db-after` app-db pair. A
+;; 20-record slice reported `20 × 8 = 160` bytes while the full
+;; expansion was ~171K tokens — the ~1000× miss rf2-lbm21 fixes.
 ;;
-;; - map entry: keyword key + scalar value + space + colon → ~16 chars
-;; - vector / set / seq entry: scalar value + space         → ~8  chars
-;;
-;; These are *order-of-magnitude* constants, not measurements. The
-;; marker's `:bytes` field is consumed for planning ("is this slice
-;; worth drilling?"); agents needing a precise byte count walk the
-;; drill-down result directly. Drop a level of precision in exchange
-;; for one constant-time multiplication per summarised value.
+;; Sampling reads ONE entry's serialised size (and, for maps, one
+;; value's), so the cost is `O(one-entry-depth)` — independent of N.
+;; Floors keep tiny scalar entries from rounding to zero and preserve
+;; the old order-of-magnitude shape for shallow collections.
 ;; ---------------------------------------------------------------------------
 
-(def ^:const ^:private map-bytes-per-entry  16)
-(def ^:const ^:private coll-bytes-per-entry 8)
+(def ^:const ^:private map-key-overhead-bytes
+  "Per map-entry overhead for the key + `:`/space punctuation under
+  `pr-str`, on TOP of the sampled value size. ~16 chars for a typical
+  keyword key."
+  16)
 
-(defn- approx-map-bytes  [n] (* map-bytes-per-entry  n))
-(defn- approx-coll-bytes [n] (* coll-bytes-per-entry n))
+(def ^:const ^:private coll-entry-floor-bytes
+  "Floor for a sampled vector / set / seq entry — a bare scalar entry
+  (`1`, `:x`) prints to ~1-4 chars; floor at 8 to keep the old shape
+  for shallow collections and avoid zero-byte estimates."
+  8)
+
+(defn- sample-entry-bytes
+  "Serialised size of ONE sample value under `pr-str`, floored at
+  `coll-entry-floor-bytes`. The single-entry `pr-str` is the whole cost
+  of the sampled estimate — bounded by the entry's own depth, NOT by
+  the collection's `:count`. nil / empty sample ⇒ the floor."
+  [sample]
+  (if (nil? sample)
+    coll-entry-floor-bytes
+    (max coll-entry-floor-bytes (count (pr-str sample)))))
+
+(defn- approx-coll-bytes
+  "Estimate the full-expansion byte cost of a collection: `count ×
+  sampled-per-entry-bytes`. `first-entry` is one representative element
+  (the slice is non-empty when `n` is positive)."
+  [n first-entry]
+  (* n (sample-entry-bytes first-entry)))
+
+(defn- approx-map-bytes
+  "Estimate the full-expansion byte cost of a map: `count × (key
+  overhead + sampled-value-bytes)`. `first-val` is one representative
+  value sampled to capture per-value depth (a map of deep values — a
+  per-frame epoch index, say — is as expensive to expand as a vector
+  of deep entries)."
+  [n first-val]
+  (* n (+ map-key-overhead-bytes (sample-entry-bytes first-val))))
 
 (defn tree-summary
   "Compute a server-friendly tree summary of `v`. Returns the marker
@@ -92,28 +139,31 @@
           n       (count ks)
           shown   (if (> n summary-keys-cap)
                     (vec (take summary-keys-cap ks))
-                    (vec ks))]
+                    (vec ks))
+          ;; Sample one value to capture per-value depth (rf2-lbm21).
+          ;; `(first (vals v))` is O(1) — it doesn't realise the rest.
+          first-val (when (pos? n) (val (first v)))]
       {:rf.mcp/summary (cond-> {:type   :map
                                 :keys   shown
                                 :count  n
-                                :bytes  (approx-map-bytes n)}
+                                :bytes  (approx-map-bytes n first-val)}
                          (> n summary-keys-cap)
                          (assoc :keys-truncated? true))})
     (vector? v)
     (let [n (count v)]
       {:rf.mcp/summary {:type  :vector
                         :count n
-                        :bytes (approx-coll-bytes n)}})
+                        :bytes (approx-coll-bytes n (first v))}})
     (set? v)
     (let [n (count v)]
       {:rf.mcp/summary {:type  :set
                         :count n
-                        :bytes (approx-coll-bytes n)}})
+                        :bytes (approx-coll-bytes n (first v))}})
     (sequential? v)
     (let [n (count v)]
       {:rf.mcp/summary {:type  :seq
                         :count n
-                        :bytes (approx-coll-bytes n)}})
+                        :bytes (approx-coll-bytes n (first v))}})
     :else v))
 
 (defn deepest-valid-prefix

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -35,7 +35,13 @@
 (defn trace-window-tool [conn raw-args]
   (let [ms        (or (wire/arg raw-args :ms) 1000)
         build-id  (wire/arg-build conn raw-args)
-        frame     (wire/arg-keyword raw-args :frame)
+        ;; rf2-lbm21 — coerce `:frame` via the colon-tolerant
+        ;; `->frame-keyword` (the shared `fresh-keyword` path), not the
+        ;; raw `(keyword ...)` of `arg-keyword`. A documented `:rf/default`
+        ;; / `:foo` frame-id passed with its leading colon used to mint
+        ;; the malformed `::rf/default`, matching no frame. Same fix
+        ;; rf2-ldfnx applied to dispatch.
+        frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         ;; rf2-c2dtu — the `--allow-sensitive-reads` boot gate forces
         ;; `:include-sensitive false` when OFF (the default). rf2-p1qli:
         ;; single intention-naming predicate `raw-state-allowed?`

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -39,7 +39,11 @@
 
 (defn watch-epochs-tool [conn raw-args]
   (let [build-id  (wire/arg-build conn raw-args)
-        frame     (wire/arg-keyword raw-args :frame)
+        ;; rf2-lbm21 — colon-tolerant `:frame` coercion (the shared
+        ;; `fresh-keyword` path) so a `:rf/default`-with-colon frame-id
+        ;; resolves instead of minting the malformed `::rf/default`.
+        ;; Same fix rf2-ldfnx applied to dispatch.
+        frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         since-id  (wire/arg raw-args :since-id)
         ;; rf2-c2dtu — the `--allow-sensitive-reads` boot gate forces
         ;; `:include-sensitive false` when OFF (the default). rf2-p1qli:

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -129,11 +129,19 @@
     1. Explicit `:build` MCP arg — operator override always wins
        (no surprise from the cache).
     2. Session-scoped resolved-build-id cache on the conn-atom — populated
-       by `discover-app` after a successful preload probe (rf2-l9ixp).
-       Removes the friction of repeating `build: foo` on every tool call
-       after a successful discover-app. Cache resets on nREPL reconnect
+       by `discover-app` after a successful preload probe (rf2-l9ixp) AND
+       by `stick-build!` after an explicit `:build` on any non-discover
+       tool call (rf2-lbm21). Removes the friction of repeating
+       `build: foo` on every tool call. Cache resets on nREPL reconnect
        (same lifecycle as `:probed-builds`).
     3. `SHADOW_CLJS_BUILD_ID` env var, defaulting to `:app`.
+
+  `arg-build` is a PURE READ — it never writes the cache. The
+  session-sticky write happens at the `invoke` boundary via
+  `stick-build!` (rf2-lbm21), deliberately separated so `discover-app`
+  (which resolves a build via `arg-build` to PROBE it, and caches only
+  on a successful health check) is never forced to cache a build that
+  turned out unusable.
 
   The explicit `:build` arg is coerced via
   `re-frame.mcp-base.args/fresh-keyword` (rf2-8ohwv), which strips a
@@ -156,6 +164,26 @@
    (or (base-args/fresh-keyword (arg args :build))
        (conn-resolved-build-id conn)
        (default-build-id))))
+
+(defn stick-build!
+  "Session-sticky operating build (rf2-lbm21). When `args` carries an
+  explicit `:build`, write it into the `:resolved-build-id` cache on the
+  conn-atom so subsequent no-`:build` tool calls inherit it. No-op when
+  no explicit `:build` arg is present (an omitted build must not clobber
+  a previously-stuck one) or when `conn` isn't an atom (test stubs).
+
+  Called from `invoke` for every tool EXCEPT `discover-app` — that tool
+  owns its own success-gated cache lifecycle (it caches via
+  `mark-resolved-build-id!` only after a passing health probe, and must
+  NOT cache a build whose precondition check failed). Here the explicit
+  `:build` is the operator's deliberate operating choice; the tool runs
+  against it regardless, so sticking it eagerly is the right default.
+
+  Returns the conn unchanged for threading convenience."
+  [conn args]
+  (when-let [explicit (base-args/fresh-keyword (arg args :build))]
+    (mark-resolved-build-id! conn explicit))
+  conn)
 
 (defn arg-build-explicit?
   "True iff a deliberate build-id is available without falling back to

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
@@ -133,7 +133,16 @@
   (let [app-db-mode           (pipeline/resolve-slice-mode :app-db slice-modes slice-mode)
         [scrubbed dropped]    (sensitive/scrub-snapshot-sensitive snapshot incl?)
         [sliced path-status]  (pipeline/slice-app-db-in-snapshot scrubbed path app-db-mode)
-        diff-encoded          (pipeline/diff-encode-epochs-in-snapshot sliced mode)
+        ;; rf2-lbm21 — cap the full-mode `:epochs` slice to the most-recent
+        ;; N records BEFORE diff-encode + dedup so those operate on the
+        ;; bounded set. Only fires when `:epochs` resolves to `:full`
+        ;; (the verbatim-`:db-before`/`:db-after` overflow path); a no-op
+        ;; in summary / diff. Keeps the slice usable instead of letting
+        ;; an unbounded 50-record history trip the global wire-cap and
+        ;; replace the WHOLE snapshot with an overflow marker.
+        capped                (pipeline/cap-full-epochs-in-snapshot
+                                sliced slice-modes slice-mode pipeline/full-epochs-cap)
+        diff-encoded          (pipeline/diff-encode-epochs-in-snapshot capped mode)
         deduped               (pipeline/dedup-epochs-in-snapshot diff-encoded dedup?)
         ;; :elided-large counts upstream-pre-elided markers per
         ;; Spec 009 §Indicator field (rf2-8cntr).

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dx_papercuts_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dx_papercuts_test.cljs
@@ -1,0 +1,328 @@
+(ns re-frame2-pair-mcp.dx-papercuts-test
+  "Unit tests for the four re-frame2-pair DX papercuts (rf2-lbm21).
+
+  1. Session-sticky operating build — an explicit `:build` on any
+     non-discover tool call becomes the default for subsequent
+     no-`:build` calls (`wire/stick-build!` at the `invoke` boundary).
+  2. Colon-normalise — `:frame` on `trace-window` / `watch-epochs` is
+     coerced via the colon-tolerant `args/->frame-keyword` (the build
+     arg's colon tolerance is already pinned in `build_id_cache_test`).
+  3. Batch read — the plural `paths` arg on `get-path`: parsing
+     (`args/parse-paths-arg`) + the batch eval form
+     (`get-path/batch-paths-form`) + the mutual-exclusion guard.
+  4. Snapshot full-mode epoch overflow — `tree-summary`'s `:bytes`
+     hint now samples a representative entry so a slice of deep entries
+     (the `:epochs` slice) reports its full-expansion cost, and the
+     `:epochs` slice is record-capped in full mode
+     (`pipeline/cap-full-epochs-in-snapshot`).
+
+  Tests pin the public surfaces directly so a rename or signature
+  drift surfaces as a failing test rather than silent contract drift.
+  Live end-to-end coverage rides on `test/stdio-roundtrip.js` (degraded
+  dispatch) and the manual live-nREPL integration test."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.args :as args]
+            [re-frame2-pair-mcp.tools.get-path :as get-path]
+            [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.snapshot-pipeline :as pipeline]
+            [re-frame2-pair-mcp.tools.summary :as summary]
+            [re-frame2-pair-mcp.tools.wire :as wire]
+            [re-frame2-pair-mcp.test-utils :as tu]))
+
+;; ===========================================================================
+;; Papercut 1 — session-sticky operating build.
+;; ===========================================================================
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{} :resolved-build-id nil)
+    conn))
+
+(deftest stick-build-records-explicit-build
+  ;; An explicit `:build` is written into the resolved-build-id cache so
+  ;; a subsequent no-`:build` call inherits it.
+  (let [conn (fresh-conn)]
+    (wire/stick-build! conn (tu/args->js {:build "examples/standard-epochs"}))
+    (is (= :examples/standard-epochs (:resolved-build-id @conn))
+        "explicit build sticks on the conn-atom")
+    (is (= :examples/standard-epochs
+           (wire/arg-build conn (tu/args->js {})))
+        "the next call without :build inherits the stuck build")))
+
+(deftest stick-build-tolerates-leading-colon
+  ;; Colon-form build sticks identically (footgun-free) — papercut 2 on
+  ;; the build arg, exercised through the sticky write.
+  (let [conn (fresh-conn)]
+    (wire/stick-build! conn (tu/args->js {:build ":examples/standard-epochs"}))
+    (is (= :examples/standard-epochs (:resolved-build-id @conn)))))
+
+(deftest stick-build-omitted-build-does-not-clobber
+  ;; A later call WITHOUT :build must not wipe a previously-stuck build.
+  (let [conn (fresh-conn)]
+    (swap! conn assoc :resolved-build-id :examples/standard-epochs)
+    (wire/stick-build! conn (tu/args->js {}))
+    (is (= :examples/standard-epochs (:resolved-build-id @conn))
+        "no :build arg leaves the stuck build untouched")))
+
+(deftest stick-build-explicit-repoints-sticky-default
+  ;; A one-off :build on a later call both routes that call AND re-points
+  ;; the sticky default (explicit-wins, and it sticks).
+  (let [conn (fresh-conn)]
+    (swap! conn assoc :resolved-build-id :examples/standard-epochs)
+    (wire/stick-build! conn (tu/args->js {:build "other-build"}))
+    (is (= :other-build (:resolved-build-id @conn)))))
+
+(deftest stick-build-nil-conn-is-noop
+  ;; Defensive — a non-atom / nil conn (test stubs) must not throw.
+  (is (nil? (wire/stick-build! nil (tu/args->js {:build "app"})))
+      "nil conn returns nil, no throw"))
+
+;; ===========================================================================
+;; Papercut 2 — colon-normalise the :frame arg on trace-window /
+;; watch-epochs. The coercion is `args/->frame-keyword`; the production
+;; tool bodies route :frame through it. Pin the helper contract here;
+;; the full tool-body wiring is covered by the eval-form mirrors below.
+;; ===========================================================================
+
+(deftest frame-keyword-strips-leading-colon
+  (is (= :rf/default (args/->frame-keyword ":rf/default")))
+  (is (= :rf/default (args/->frame-keyword "rf/default")))
+  (is (= :foo (args/->frame-keyword ":foo")))
+  (is (= :foo (args/->frame-keyword "foo")))
+  (is (= (args/->frame-keyword ":rf/default")
+         (args/->frame-keyword "rf/default"))
+      "both forms resolve identically — no doubled-colon footgun"))
+
+;; ===========================================================================
+;; Papercut 3 — batch read via the plural `paths` arg.
+;; ===========================================================================
+
+(deftest parse-paths-arg-nil-is-nil
+  (is (nil? (args/parse-paths-arg nil)))
+  (is (nil? (args/parse-paths-arg "")))
+  (is (nil? (args/parse-paths-arg "   "))))
+
+(deftest parse-paths-arg-edn-string-of-path-vectors
+  (is (= [[:cart :total] [:user :id]]
+         (args/parse-paths-arg "[[:cart :total] [:user :id]]"))))
+
+(deftest parse-paths-arg-cljs-vector-of-paths
+  (is (= [[:a :b] [:c]]
+         (args/parse-paths-arg [[:a :b] [:c]]))))
+
+(deftest parse-paths-arg-js-array-of-edn-path-strings
+  (is (= [[:cart :total] [:user :id]]
+         (args/parse-paths-arg #js ["[:cart :total]" "[:user :id]"]))))
+
+(deftest parse-paths-arg-js-array-of-segment-arrays
+  ;; Each entry may itself be a JS array of segment strings.
+  (is (= [[:cart :items 0] [:user :id]]
+         (args/parse-paths-arg #js [#js [":cart" ":items" "0"] #js [":user" ":id"]]))))
+
+(deftest parse-paths-arg-non-collection-string-is-nil
+  ;; A bare scalar EDN string isn't a batch — return nil so the caller
+  ;; falls back to the singular surface rather than reading garbage.
+  (is (nil? (args/parse-paths-arg ":foo")))
+  (is (nil? (args/parse-paths-arg "42"))))
+
+(deftest parse-paths-arg-empty-edn-vector-is-empty-batch
+  ;; An explicit empty batch is distinguishable from "no batch" (nil) so
+  ;; the tool can return :empty-paths rather than silently no-op'ing.
+  (is (= [] (args/parse-paths-arg "[]")))
+  (is (= [] (args/parse-paths-arg #js []))))
+
+(deftest batch-paths-form-folds-over-paths
+  ;; The batch eval form folds over the path vectors server-side and
+  ;; returns `{:ok? true :results {...} :elided-count N}`. The form
+  ;; carries a `#js {}` reader literal (the missing sentinel) so it
+  ;; isn't plain-EDN-readable — assert on the emitted source instead.
+  (let [snapshot-call (ef/rt-call 'snapshot :rf/default)
+        paths         [[:cart :total] [:user :id]]
+        form          (get-path/batch-paths-form
+                        snapshot-call paths true ":rf/default" "{}")]
+    (is (string? form))
+    (is (re-find #"^\(let " form) "batch form opens a let block")
+    ;; The embedded paths literal rides verbatim in the reduce seed.
+    (is (re-find #"\[:cart :total\]" form))
+    (is (re-find #"\[:user :id\]" form))
+    (is (re-find #":results" form))
+    (is (re-find #":elided-count" form))
+    ;; Elision-on emits the walker call; the per-iteration path `p` is
+    ;; the marker handle.
+    (is (re-find #"elide-wire-value raw-v" form))))
+
+(deftest get-path-rejects-path-and-paths-together
+  ;; Mutual exclusion: supplying both is a structured usage error, not a
+  ;; silent precedence pick.
+  (async done
+    (let [conn (fresh-conn)]
+      (-> (get-path/get-path-tool
+            conn (tu/args->js {:path "[:a]" :paths "[[:b]]"}))
+          (.then (fn [r]
+                   (is (tu/error? r))
+                   (is (= :path-and-paths-both-supplied
+                          (:reason (tu/extract-edn r))))
+                   (done)))))))
+
+(deftest get-path-empty-paths-is-usage-error
+  (async done
+    (let [conn (fresh-conn)]
+      (-> (get-path/get-path-tool conn (tu/args->js {:paths "[]"}))
+          (.then (fn [r]
+                   (is (tu/error? r))
+                   (is (= :empty-paths (:reason (tu/extract-edn r))))
+                   (done)))))))
+
+(deftest get-path-batch-returns-results-map
+  ;; End-to-end with a stubbed runtime: the batch eval form's envelope
+  ;; rides through the wire-pipeline and the tool re-attaches `:results`.
+  (async done
+    (let [conn   (fresh-conn)
+          ;; Prime the probe cache so `ensure-runtime!` short-circuits to
+          ;; true (the stubbed eval returns the canned envelope, not the
+          ;; `true` the preload-marker probe expects).
+          _      (swap! conn update :probed-builds (fnil conj #{}) :app)
+          canned {:ok?     true
+                  :results {[:cart :total] {:exists? true  :value 42}
+                            [:user :id]    {:exists? true  :value "u-1"}
+                            [:missing :k]  {:exists? false :value nil}}
+                  :elided-count 0}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (get-path/get-path-tool
+                conn (tu/args->js {:paths "[[:cart :total] [:user :id] [:missing :k]]"
+                                   :frame ":rf/default"}))))
+          (.then (fn [r]
+                   (let [edn (tu/extract-edn r)]
+                     (is (true? (:ok? edn)))
+                     (is (= :rf/default (:frame edn)))
+                     (is (= 42 (get-in edn [:results [:cart :total] :value])))
+                     (is (true? (get-in edn [:results [:user :id] :exists?])))
+                     (is (false? (get-in edn [:results [:missing :k] :exists?]))))
+                   (done)))))))
+
+;; ===========================================================================
+;; Papercut 4 — snapshot full-mode epoch overflow.
+;; ===========================================================================
+
+;; --- 4a. tree-summary :bytes reflects per-entry depth (sampled). ---
+
+(deftest tree-summary-bytes-samples-deep-vector-entries
+  ;; A vector of DEEP entries (each a fat map) must report a `:bytes`
+  ;; hint that reflects the per-entry depth — not the flat 8-per-entry
+  ;; constant that under-reported epoch slices ~1000x.
+  (let [fat-entry (zipmap (map #(keyword (str "k" %)) (range 200)) (range 200))
+        deep-vec  (vec (repeat 5 fat-entry))
+        scalar-vec [1 2 3 4 5]
+        deep-bytes   (-> deep-vec   summary/tree-summary :rf.mcp/summary :bytes)
+        scalar-bytes (-> scalar-vec summary/tree-summary :rf.mcp/summary :bytes)]
+    (is (> deep-bytes (* 100 scalar-bytes))
+        "a 5-entry vector of fat maps must estimate vastly more than a 5-scalar vector")))
+
+(deftest tree-summary-bytes-scales-with-count-and-entry-size
+  ;; The estimate is count × sampled-per-entry. Doubling the entry depth
+  ;; roughly doubles the estimate at the same count.
+  (let [small-entry {:a 1}
+        big-entry   (zipmap (map #(keyword (str "k" %)) (range 50)) (range 50))
+        small-bytes (-> (vec (repeat 10 small-entry)) summary/tree-summary :rf.mcp/summary :bytes)
+        big-bytes   (-> (vec (repeat 10 big-entry))   summary/tree-summary :rf.mcp/summary :bytes)]
+    (is (> big-bytes small-bytes)
+        "a vector of bigger entries must estimate more bytes at equal count")))
+
+(deftest tree-summary-bytes-still-linear-in-count
+  ;; Same-shaped entries: 10x the count ⇒ ~10x the bytes (sampling reads
+  ;; one entry, so the per-entry factor is constant).
+  (let [entry {:a 1 :b 2}
+        one   (-> [entry] summary/tree-summary :rf.mcp/summary :bytes)
+        ten   (-> (vec (repeat 10 entry)) summary/tree-summary :rf.mcp/summary :bytes)]
+    (is (= 10 (/ ten one)))))
+
+(deftest tree-summary-bytes-handles-empty-collections
+  ;; Empty collections have no entries, so the `count × per-entry`
+  ;; estimate is a clean 0 — never NaN / negative. A single non-empty
+  ;; entry floors at the per-entry minimum (no zero-byte estimate for a
+  ;; real entry).
+  (is (= 0 (-> [] summary/tree-summary :rf.mcp/summary :bytes)))
+  (is (= 0 (-> #{} summary/tree-summary :rf.mcp/summary :bytes)))
+  (is (= 0 (-> {} summary/tree-summary :rf.mcp/summary :bytes)))
+  (is (= 0 (-> [] summary/tree-summary :rf.mcp/summary :count)))
+  (is (pos? (-> [1] summary/tree-summary :rf.mcp/summary :bytes))
+      "a real scalar entry floors above zero"))
+
+(deftest tree-summary-map-bytes-samples-value-depth
+  ;; A map of DEEP values estimates more than a map of scalar values at
+  ;; equal count — the per-value sample captures depth.
+  (let [deep-val (zipmap (map #(keyword (str "k" %)) (range 100)) (range 100))
+        deep-map (zipmap (map #(keyword (str "m" %)) (range 5)) (repeat deep-val))
+        flat-map (zipmap (map #(keyword (str "m" %)) (range 5)) (range 5))
+        deep-bytes (-> deep-map summary/tree-summary :rf.mcp/summary :bytes)
+        flat-bytes (-> flat-map summary/tree-summary :rf.mcp/summary :bytes)]
+    (is (> deep-bytes (* 10 flat-bytes)))))
+
+;; --- 4b. full-mode epoch-history record cap. ---
+
+(defn- fat-epoch [i big-map]
+  {:event-id (keyword (str "e" i)) :db-before big-map :db-after big-map})
+
+(def ^:private big-map
+  (zipmap (map #(keyword (str "k" %)) (range 200)) (range 200)))
+
+(defn- snapshot-with-n-epochs [n]
+  {:rf/default {:app-db    {:k 1}
+                :sub-cache {}
+                :machines  {}
+                :epochs    (vec (for [i (range n)] (fat-epoch i big-map)))
+                :traces    []}})
+
+(deftest full-mode-caps-epoch-history-to-most-recent
+  ;; A 30-record history in :full mode is capped to the most-recent N;
+  ;; the dropped count + sibling marker make the truncation explicit.
+  (let [snap   (snapshot-with-n-epochs 30)
+        capped (pipeline/cap-full-epochs-in-snapshot snap {} :full pipeline/full-epochs-cap)
+        epochs (-> capped :rf/default :epochs)
+        meta   (-> capped :rf/default :rf.mcp/epochs-capped)]
+    (is (= pipeline/full-epochs-cap (count epochs))
+        "kept exactly the cap")
+    (is (= :e29 (:event-id (last epochs)))
+        "kept the MOST-RECENT records (tail of a chronological history)")
+    (is (= :e20 (:event-id (first epochs)))
+        "oldest kept record is total-cap from the end")
+    (is (some? meta) "a truncation marker is attached")
+    (is (= 30 (:total meta)))
+    (is (= pipeline/full-epochs-cap (:shown meta)))
+    (is (= (- 30 pipeline/full-epochs-cap) (:dropped meta)))
+    (is (= :most-recent (:kept meta)))))
+
+(deftest full-mode-under-cap-passes-through-untouched
+  ;; A history at/under the cap is unchanged — no marker, no truncation.
+  (let [snap   (snapshot-with-n-epochs pipeline/full-epochs-cap)
+        capped (pipeline/cap-full-epochs-in-snapshot snap {} :full pipeline/full-epochs-cap)]
+    (is (= pipeline/full-epochs-cap (count (-> capped :rf/default :epochs))))
+    (is (not (contains? (:rf/default capped) :rf.mcp/epochs-capped))
+        "no truncation marker when nothing was dropped")))
+
+(deftest summary-mode-does-not-trigger-the-epoch-cap
+  ;; In :summary mode the slice is a marker, not a vector — the cap is a
+  ;; no-op (it gates on resolved :full mode).
+  (let [snap   (snapshot-with-n-epochs 30)
+        capped (pipeline/cap-full-epochs-in-snapshot snap {} :summary pipeline/full-epochs-cap)]
+    (is (= 30 (count (-> capped :rf/default :epochs)))
+        "summary-mode snapshot is left for the summariser to collapse")
+    (is (not (contains? (:rf/default capped) :rf.mcp/epochs-capped)))))
+
+(deftest per-slice-full-epochs-override-triggers-the-cap
+  ;; Global :summary but per-slice `{:epochs :full}` — the cap fires
+  ;; because :epochs RESOLVES to :full.
+  (let [snap   (snapshot-with-n-epochs 25)
+        capped (pipeline/cap-full-epochs-in-snapshot snap {:epochs :full} :summary
+                                                      pipeline/full-epochs-cap)]
+    (is (= pipeline/full-epochs-cap (count (-> capped :rf/default :epochs))))
+    (is (= 25 (-> capped :rf/default :rf.mcp/epochs-capped :total)))))
+
+(deftest cap-handles-non-map-and-missing-epochs
+  ;; Defensive: a scalar frame / a frame without :epochs passes through.
+  (is (= {:rf/default :scalar}
+         (pipeline/cap-full-epochs-in-snapshot {:rf/default :scalar} {} :full 10)))
+  (is (= {:rf/default {:app-db {:k 1}}}
+         (pipeline/cap-full-epochs-in-snapshot {:rf/default {:app-db {:k 1}}} {} :full 10))))

--- a/tools/re-frame2-pair-mcp/test/stdio-roundtrip.js
+++ b/tools/re-frame2-pair-mcp/test/stdio-roundtrip.js
@@ -209,20 +209,20 @@ function run() {
       }
       console.log('OK   snapshot descriptor -> frames/include/path/build');
 
-      // 2d. Verify the get-path descriptor (rf2-tygdv). Required
-      // input: `path`; optional: `frame`, `build`.
+      // 2d. Verify the get-path descriptor (rf2-tygdv + rf2-lbm21).
+      // Inputs: `path` (singular) OR `paths` (plural batch read); both
+      // optional at the schema level — the tool enforces "exactly one"
+      // at call time (neither -> :missing-path; both ->
+      // :path-and-paths-both-supplied). Optional: `frame`, `build`.
       const gpDesc = (list.result?.tools || []).find((t) => t.name === 'get-path');
       if (!gpDesc) throw new Error('get-path descriptor missing from tools/list');
       const gpProps = gpDesc.inputSchema?.properties || {};
-      for (const k of ['path', 'frame', 'build']) {
+      for (const k of ['path', 'paths', 'frame', 'build']) {
         if (!(k in gpProps)) {
           throw new Error('get-path inputSchema missing property: ' + k);
         }
       }
-      if (!gpDesc.inputSchema?.required?.includes('path')) {
-        throw new Error('get-path.inputSchema missing required: path');
-      }
-      console.log('OK   get-path descriptor -> path (required) + frame/build');
+      console.log('OK   get-path descriptor -> path/paths/frame/build');
 
       // 3. tools/call eval-cljs without nREPL — expect graceful degraded result
       const evalResp = await call('tools/call', {


### PR DESCRIPTION
Fixes the four re-frame2-pair DX papercuts in rf2-lbm21 — a cluster of small frictions that compounded into the dominant DX tax on a real pair session. All changes are confined to `tools/re-frame2-pair-mcp/` (src + tests + tool-local spec). No new MCP tool was added, so no skill allow-list change was needed.

## Per-papercut summary

### 1. Session-sticky operating build
Every op repeated `build "examples/standard-epochs"`. Now an explicit `:build` on **any** non-`discover-app` tool call is written into the conn-atom `:resolved-build-id` cache via `wire/stick-build!` at the `invoke` dispatch chokepoint — the first call that names a build sets the session default; subsequent calls inherit it. `arg-build` stays a **pure read** (the write lives at `invoke`), so `discover-app` — which calls `arg-build` to *probe* a build and caches only on a passing health check — keeps its "don't cache on precondition failure" semantics intact (regression caught + fixed during dev).

### 2. build colon footgun
`:examples/standard-epochs` used to mint `::examples/standard-epochs` (not-found). The `:build` arg was already colon-tolerant (`fresh-keyword`); this PR extends the same colon tolerance to the `:frame` arg on `trace-window` and `watch-epochs` (they still used the raw `wire/arg-keyword`). They now route `:frame` through `args/->frame-keyword` — the same fix rf2-ldfnx applied to `dispatch`.

### 3. batch read
**Did NOT add a new tool.** Extended the existing `get-path` with a plural `paths` arg (vector of path vectors) — reads N app-db subtrees in one round-trip, returning `{:ok? true :results {<path> {:exists? bool :value <subtree>}}}`. `path` and `paths` are mutually exclusive (both → `:path-and-paths-both-supplied`; empty `paths` → `:empty-paths`). Reuses `get-path`'s registry entry, descriptor, skill allow-list, and the wire-pipeline `:scalar-value` arm — so the catalogue, wire-vocab verb surface, and skill drift surface are all unchanged. (No `skills/re-frame2-pair/SKILL.md` edit required — see drift gate below.)

### 4. snapshot full-mode overflow on epoch-history
Two fixes:
- **`:bytes` hint sampled.** `tree-summary`'s `:bytes` estimate was `count × flat-constant`, which under-reported a slice of deep entries by ~1000× (a 20-record epochs slice — each carrying a `:db-before`/`:db-after` app-db pair — said 160 bytes while full expansion ran ~171K tokens). It now **samples one representative entry** (`pr-str` of the first element / one map value) so the hint reflects full-expansion cost. Cost stays `O(one-entry-depth)`, independent of `:count`.
- **Full-mode record cap.** When the `:epochs` slice resolves to `:full`, it's default-capped to the most-recent 10 records (`pipeline/cap-full-epochs-in-snapshot`, run before diff-encode/dedup), with an explicit sibling `:rf.mcp/epochs-capped {:shown :total :dropped :kept :most-recent :hint}` marker. An unbounded 50-record history no longer trips the global wire cap and replaces the whole snapshot with an overflow marker. No-op in summary/diff modes.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| pair-mcp test suite | `npm test` (tools/re-frame2-pair-mcp) | **691 tests, 1926 assertions, 0 failures, 0 errors** (+27 new tests in `dx_papercuts_test`) |
| stdio roundtrip | `node test/stdio-roundtrip.js` | **GREEN** (get-path descriptor now `path/paths/frame/build`) |
| MCP conformance (re-frame2-pair) | `npm run test:re-frame2-pair` (tools/mcp-conformance) | **GREEN** — 19 tools advertised (confirms no tool added) |
| MCP conformance (wire-vocab) | `clojure -M:test` (tools/mcp-conformance/wire-vocab) | **48 tests, 608 assertions, 0 failures** |
| skill ↔ MCP allowed-tools drift (rf2-flzdp) | `python scripts/check_skill_mcp_drift.py` | **0 findings, exit 0** (server=19 tools, skill=17 allow-listed — unchanged) |
| clj-kondo (changed files) | `clj-kondo --lint <changed>` | **0 errors, 0 warnings** (2 pre-existing unused-var warnings in `descriptors_data.cljs` predate this PR) |

**Did papercut #3 add a tool?** No — it extended `get-path` with a `paths` arg. No new `{:name ...}` catalogue literal, no registry/wire-vocab churn, no `skills/re-frame2-pair/SKILL.md` allow-list entry needed. The drift checker confirms 0 findings with the tool count unchanged at 19.

Registry + wire-vocab edits were kept minimal (no new tool, no new verb) so the queued sibling beads (zo4b9, cxq0r) rebase cleanly.
