### PR TITLE
fix(xray/epoch): correct rolled-back chip + interceptor exception phase-placement + quiet redundant exception chrome (rf2-s6oqd + rf2-vew2n + rf2-oqi0c)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1308,7 +1308,7 @@ is rendered iff its driving trace events surfaced in this epoch:
 |------|---------------|-------------|
 | **DISPATCH** | `:rf.event/dispatched` | always (every epoch starts here) |
 | **COEFFECT** | `:rf.cofx/run` (or `:rf.event/run-end` `:rf.event/coeffects` fallback) | **one COEFFECT step per user-injected coeffect** (rf2-s1jw4 · Mike pair-debug 2026-05-26, commit `ee9def224`). SYSTEM defaults `:db / :event / :frame / :source / :trace-id` are filtered at projection time (rf2-cq0ch). A cascade with 3 user cofx injections renders 3 numbered COEFFECT entries, not 1 entry containing 3 rows. A coeffect that THREW on injection (`:rf.error/coeffect-exception`) but produced no `:rf.cofx/run` gets a synthesised placeholder COEFFECT step (rf2-yz57h) so the exception card has a home. |
-| **INTERCEPTOR** | `:rf.error/interceptor-exception` (rf2-mszrz) | **only when a user interceptor threw** (rf2-yz57h). The substrate emits no per-interceptor "ran" trace (the chain runs as one unit), so a clean chain leaves nothing to show — the step is exception-only. One row per throwing interceptor: id + `:before`/`:after` phase chip + the shared exception card. Sits between COEFFECTS and HANDLER (the chain's cascade position). |
+| **INTERCEPTOR** | `:rf.error/interceptor-exception` (rf2-mszrz) | **only when a user interceptor threw** (rf2-yz57h). The substrate emits no per-interceptor "ran" trace (the chain runs as one unit), so a clean chain leaves nothing to show — the step is exception-only. PHASE-SPLIT (rf2-vew2n): a `:before` throw renders its step BEFORE HANDLER, an `:after` throw AFTER HANDLER (execution order: COEFFECTS → :before → HANDLER → :after). One row per throwing interceptor: id + `:before`/`:after` phase chip + the shared exception card; the badge carries no "N threw" summary verb (rf2-oqi0c). |
 | **HANDLER** | every epoch settles through a handler | always (but rendered as **SKIPPED** — rf2-yz57h — when an upstream `:before`-chain throw aborted the cascade before the handler ran) |
 | **FLOW** | `:rf.flow/recomputed` | only when flows fired |
 | **FX** | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | only when fx-handlers fired (rendered as **SKIPPED** when an upstream `:before`-chain throw aborted the cascade) |
@@ -2381,37 +2381,51 @@ mis-render):
 | Trace op | Owning step | Granularity |
 |----------|-------------|-------------|
 | `:rf.error/coeffect-exception` | COEFFECT, the step whose `:id` = `:failing-id` (cofx id) | step-level; falls back to the first COEFFECT step. When the throwing cofx produced no `:rf.cofx/run` (it threw on injection), `project` synthesises a placeholder COEFFECT step (`:no-value? true`) so the card has a home |
-| `:rf.error/interceptor-exception` | INTERCEPTOR (NEW) | step-level; the row matching `:failing-id` to `:interceptor-id` carries the card |
+| `:rf.error/interceptor-exception` | INTERCEPTOR (NEW), the step whose `:phase` = the exception's `:phase` (rf2-vew2n) | step-level; routes to the `:before` step (before HANDLER) or the `:after` step (after HANDLER); the row matching `:failing-id` to `:interceptor-id` carries the card |
 | `:rf.error/handler-exception` | HANDLER | step-level (only the event handler itself now) |
 | `:rf.error/fx-handler-exception` | SIDE EFFECTS, row whose `:fx-id` = `:failing-id` | row-level (fallback step-level) |
 | `:rf.error/no-such-fx` | SIDE EFFECTS | step-level (fallback) |
 | `:rf.error/flow-eval-exception` | FLOW | step-level (fallback HANDLER when no FLOW step) |
 
-The error MESSAGE rides `[:tags :exception-message]` (handler / fx
+The error MESSAGE rides `[:tags :exception-message]` ONLY (handler / fx
 throws — `re-frame.router/emit-handler-exception!` stamps the
-exception's `.getMessage`) with `[:tags :reason]` as fallback; the
-failing handler's SOURCE-COORD rides the hoisted top-level
-`:rf.trace/trigger-handler :source-coord` slot (with
-`:rf.trace/call-site` as fallback). These are the SAME slots the
-Issues panel's `short-description` / `source-coord` read — the bead's
-original probe checked `:message` / `:source` / `:error-id`, which
-the substrate does not stamp (the empty-tags symptom).
+exception's `.getMessage`). rf2-oqi0c **DROPPED** the `[:tags :reason]`
+fallback: `:reason` is the terse CATEGORY boilerplate ("Event handler
+threw." / "…interceptor threw.") already conveyed by the card's position
++ "Exception Thrown" heading, so surfacing it as the card message was
+redundant chrome; the message line now renders ONLY when the throw
+carried a real `.getMessage`. The failing handler's SOURCE-COORD rides
+the hoisted top-level `:rf.trace/trigger-handler :source-coord` slot
+(with `:rf.trace/call-site` as fallback) — the SAME slot the Issues
+panel's `source-coord` reads.
 
-**INTERCEPTOR step (NEW, rf2-yz57h).** The pipeline had no distinct
-interceptor step before rf2-yz57h — interceptors WRAP the handler chain
-rather than appearing as their own cascade entry, so a user-interceptor
-`:before` / `:after` throw had no home. The INTERCEPTOR step
-(`projection/interceptor-step` → `view/render-interceptor-step`) sits
-between COEFFECTS and HANDLER (the cascade position of the chain:
-`:before` runs after coeffects, before the handler). It is
-**CONDITIONAL** — the substrate emits no per-interceptor "ran" trace
-(the chain runs as one unit; only a throw surfaces a trace), so the
-step renders ONLY when an interceptor threw this cascade. Each row is a
-throwing interceptor: the interceptor `:id` (click-to-source via
+**INTERCEPTOR step (NEW, rf2-yz57h · phase-placement rf2-vew2n).** The
+pipeline had no distinct interceptor step before rf2-yz57h — interceptors
+WRAP the handler chain rather than appearing as their own cascade entry,
+so a user-interceptor `:before` / `:after` throw had no home. The
+INTERCEPTOR step (`projection/interceptor-step` →
+`view/render-interceptor-step`) is **PHASE-SPLIT** and placed on the
+correct side of the EVENT HANDLER, reflecting execution ORDER + REACH:
+DISPATCH → COEFFECTS → **[:before interceptors]** → EVENT HANDLER →
+**[:after interceptors]** → EFFECT HANDLERS → FLOWS. A `:before`
+interceptor throws on the way IN (the chain aborts before the handler),
+so its step renders **BEFORE** HANDLER; an `:after` interceptor throws on
+the way OUT (the handler ran first), so its step renders **AFTER**
+HANDLER. (rf2-vew2n fix: the pre-existing single fixed-early step put an
+`:after` throw at position 2, before the handler — wrong; the `:phase`
+captured by rf2-mszrz now drives placement.) Each step carries its own
+`:phase`, and `attach-exceptions` routes each interceptor exception to
+the step matching its phase (`interceptor-exception-target`). Both are
+**CONDITIONAL** — the substrate emits no per-interceptor "ran" trace (the
+chain runs as one unit; only a throw surfaces a trace), so a phase's step
+renders ONLY when an interceptor threw in that phase this cascade. Each
+row is a throwing interceptor: the interceptor `:id` (click-to-source via
 `handler-meta`, degrading to plain text since interceptors are plain
 `->interceptor` records and carry no registered coord) + a `:before` /
-`:after` phase chip + the shared "Exception Thrown" card. Badge:
-`:INTERCEPTOR` pulls the `:accent` token (the chain WRAPS the handler;
+`:after` phase chip + the shared "Exception Thrown" card. rf2-oqi0c
+**DROPPED** the badge's "N interceptor(s) threw" summary verb — redundant
+with the per-row id + the inline card below; the `:INTERCEPTOR` badge
+stands alone (it pulls the `:accent` token — the chain WRAPS the handler;
 they read as one identity family). A `:before` throw skips the handler;
 an `:after` throw runs the handler first, then throws on the way out.
 
@@ -2441,26 +2455,26 @@ renders a red-edged card (sibling to the amber schema-violation card;
 carrying:
 
 1. a `✗ Exception Thrown` title bar + a `Rolled back` recovery chip
-   that paints **ONLY** when a `:db` actually committed before the
-   throw (`db-committed?` — the cascade-level presence of a
-   `:rf.event/db-changed` / schema rollback, stamped onto each
-   exception row by `attach-exceptions`). The substrate stamps
-   `:recovery :no-recovery` on EVERY `:rf.error/handler-exception`, so
-   keying the chip off recovery alone painted a **spurious** "Rolled
-   back" on button-15 — the handler threw before producing any `:db`,
-   so nothing committed and nothing reverted (rf2-wnvid fix);
-2. a one-line human headline derived from the OP (`error-block-label`),
-   naming the TRUE failing component (rf2-mszrz attribution): "The
-   :standard-epochs/throwing-cofx coeffect threw during injection." / "The
-   :app/auth interceptor threw on the way in (:before)." / "The event
-   handler threw." / "The :http/post effect threw." / "A flow's
-   computation threw." Pre-mszrz the router routed handler / interceptor /
-   coeffect throws ALL through `:rf.error/handler-exception`, so the
-   headline could only ever read "The event handler threw."; with the
-   rf2-mszrz split the headline reads off the component-attributed op and
-   `:phase`;
-3. the verbatim `ex-info` message (monospace); and
-4. a **collapsible** `<details>` disclosure ("Details", collapsed by
+   that paints **ONLY** when the cascade **ACTUALLY rolled back**
+   (`db-rolled-back?` — a `:where :app-db` schema-validation failure
+   reverted the commit, stamped onto each exception row by `project`).
+   The substrate stamps `:recovery :no-recovery` on EVERY `:rf.error/*`,
+   so keying the chip off recovery alone painted a **spurious** "Rolled
+   back". The earlier rf2-wnvid gate (`db-committed?`) fixed the
+   pre-commit handler throw (button-16 — no commit) but still mis-fired
+   on a **POST-COMMIT fx throw** (button-20 `:standard-epochs/boom`): fx
+   are best-effort post-commit (the FX atomicity asymmetry), so a
+   throwing fx leaves the `:db` committed yet reverts nothing. Gating on
+   actual rollback (rf2-s6oqd) paints the chip on a `:db` schema-fail
+   rollback (correct) and omits it on a post-commit fx throw AND a
+   pre-commit handler throw;
+2. the verbatim `ex-info` message (monospace) — the punchline. rf2-oqi0c
+   **DROPPED** the one-line category-reason boilerplate headline ("The
+   event handler threw." / "…interceptor threw." — formerly
+   `error-block-label`): it was redundant with the card's position (under
+   the failing step) + the "Exception Thrown" heading, which already
+   attribute the failure. The card now leads with the real `.getMessage`;
+3. a **collapsible** `<details>` disclosure ("Details", collapsed by
    default) carrying the exception's `ex-data` (via `ei/edn-inspector`)
    + its stack trace (monospace `<pre>`), read off the raw `:exception`
    object the projection lifts onto the exception row (rf2-wnvid).
@@ -2475,17 +2489,19 @@ steps); the SIDE EFFECTS step injects per-row cards via
 `fx-row-with-violations` plus a step-level
 `(error-blocks :side-effects errors)` for unmatched fx ids.
 
-**HANDLER `:db` — no phantom `:db` (rf2-wnvid).** The HANDLER step's
-`:db` sub-section (`view/handler-db-diff-block`) renders a
-`— no :db (handler threw)` / `— no :db (handler returned no :db)`
-placeholder when the handler wrote NO `:db` effect (the projection's
-`:db-write?` slot, from `projection/handler-wrote-db?`: t1
+**HANDLER `:db` — no phantom `:db` (rf2-wnvid); omitted on a throw
+(rf2-oqi0c).** When the handler **THREW**, `view/handler-body` OMITS the
+`:db` sub-section entirely (rf2-oqi0c): the redundant
+`— no :db (handler threw)` line was noise — the inline "Exception Thrown"
+card is the signal. For a CLEAN handler that simply wrote no `:db`, the
+sub-section (`view/handler-db-diff-block`) still renders the
+`— no :db (handler returned no :db)` placeholder, keyed off the
+projection's `:db-write?` slot (`projection/handler-wrote-db?`: t1
 `:rf.event/db-pending` OR a `:rf.event/db-changed` commit fired). The
 pre-rf2-wnvid code fell back to the record's full post-cascade
 `:db-after` whenever the post-handler db value was nil — painting the
 ENTIRE app-db tree under the HANDLER step as if the handler had returned
-it (the phantom `:db`, most visible on button-15 where the handler
-mutated nothing).
+it (the phantom `:db`, most visible where the handler mutated nothing).
 
 ### §9.1.10.5 Epoch outcome — tool-side, NOT the framework slot (rf2-ahhgn)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1954,14 +1954,19 @@
    :rf.error/flow-eval-exception  :flow})
 
 (defn- exception-message
-  "Lift the human-readable failure message off an exception trace event
-  (rf2-ahhgn). Reads `[:tags :exception-message]` (handler / fx throws —
-  `re-frame.router/emit-handler-exception!` stamps the exception's
-  `.getMessage`) then `[:tags :reason]` (the canonical terse summary).
-  nil when neither is present."
+  "Lift the REAL exception message off an exception trace event (rf2-ahhgn
+  / rf2-oqi0c). Reads `[:tags :exception-message]` ONLY — the exception's
+  own `.getMessage` (`re-frame.router/emit-handler-exception!` stamps it).
+  nil when absent.
+
+  rf2-oqi0c — the `[:tags :reason]` fallback is DROPPED. `:reason` is the
+  terse CATEGORY boilerplate ('Event handler threw.' / '…interceptor
+  threw.') already conveyed by the card's position (under the failing
+  step) + its 'Exception Thrown' heading; surfacing it as the card's
+  message line was redundant chrome. The card now shows the message line
+  ONLY when the throw carried a real `.getMessage`."
   [ev]
-  (let [msg (or (common/tag-of ev :exception-message)
-                (common/tag-of ev :reason))]
+  (let [msg (common/tag-of ev :exception-message)]
     (when (and (string? msg) (not= "" msg)) msg)))
 
 (defn- exception-source-coord
@@ -1996,10 +2001,12 @@
   collapsible details (stack / ex-data). Empty slots are tolerated
   absent by the view.
 
-  rf2-wnvid — the cascade-level `:db-committed?` slot is stamped LATER
-  by `attach-exceptions` (it needs the whole event stream, not the one
-  exception event); it gates the view's 'Rolled back' chip so the chip
-  only paints when a `:db` install actually preceded the throw."
+  rf2-s6oqd — the cascade-level `:db-rolled-back?` slot is stamped LATER
+  by `project` (it needs the whole event stream, not the one exception
+  event); it gates the view's 'Rolled back' chip so the chip paints ONLY
+  when the cascade ACTUALLY rolled back (a `:where :app-db` schema-fail),
+  NOT merely when a `:db` committed — a post-commit fx throw leaves the
+  `:db` committed yet nothing reverted (the FX atomicity asymmetry)."
   [ev]
   {:operation  (op ev)
    :message    (exception-message ev)
@@ -2051,18 +2058,28 @@
            (exception-rows events)))
 
 (defn interceptor-step
-  "Build the INTERCEPTOR step, or nil when no interceptor exception fired
-  this cascade (the step is OMITTED — conditional, rf2-yz57h). The step's
-  `:rows` are the throwing interceptors (one per
-  `:rf.error/interceptor-exception`), each carrying the interceptor
-  `:interceptor-id` (== the exception row's `:failing-id`) + the `:phase`
-  it threw in. The shared exception card attaches to this step via
-  `attach-exceptions`."
-  [events]
-  (let [exc (interceptor-exception-rows events)]
+  "Build the INTERCEPTOR step for ONE chain `phase` (`:before` / `:after`),
+  or nil when no interceptor threw in that phase this cascade (the step is
+  OMITTED — conditional, rf2-yz57h / rf2-vew2n). The step's `:rows` are the
+  throwing interceptors of that phase (one per
+  `:rf.error/interceptor-exception` with the matching `:phase`), each
+  carrying the interceptor `:interceptor-id` (== the exception row's
+  `:failing-id`) + the `:phase` it threw in. The shared exception card
+  attaches to this step via `attach-exceptions`.
+
+  rf2-vew2n — a `:before` interceptor throws on the way IN (the chain
+  aborts before the handler runs), so the `:before` step renders BEFORE
+  the EVENT HANDLER step. An `:after` interceptor throws on the way OUT
+  (the handler ran first), so the `:after` step renders AFTER the EVENT
+  HANDLER step. The step carries its own `:phase` so `project` can place
+  it on the correct side of HANDLER and `attach-exceptions` routes each
+  interceptor exception to the step matching its phase."
+  [events phase]
+  (let [exc (filterv #(= phase (:phase %)) (interceptor-exception-rows events))]
     (when (seq exc)
       {:step  :interceptor
        :badge :INTERCEPTOR
+       :phase phase
        :rows  (mapv (fn [{:keys [failing-id phase]}]
                       {:interceptor-id failing-id
                        :phase          phase})
@@ -2147,6 +2164,19 @@
   (or (index-of #(and (= :coeffect (:step %)) (= failing-id (:id %))) steps)
       (index-of #(= :coeffect (:step %)) steps)))
 
+(defn- interceptor-exception-target
+  "Index of the INTERCEPTOR step a `:rf.error/interceptor-exception` row
+  attaches to (rf2-vew2n). With the phase-split INTERCEPTOR steps the
+  cascade may carry TWO interceptor steps — a `:before` one (before
+  HANDLER) and an `:after` one (after HANDLER). Match the step whose
+  `:phase` == the exception row's `:phase` so a `:before` throw lands on
+  the pre-HANDLER step and an `:after` throw on the post-HANDLER step.
+  Falls back to ANY interceptor step (phase-less legacy fixtures), else
+  nil."
+  [steps phase]
+  (or (index-of #(and (= :interceptor (:step %)) (= phase (:phase %))) steps)
+      (index-of #(= :interceptor (:step %)) steps)))
+
 (defn attach-exceptions
   "Take a projected step vector + a vec of `exception-row` records and
   return the step vector with each exception attached to its owning step
@@ -2158,7 +2188,10 @@
 
     - COEFFECT exception → the matching COEFFECT step (by `:failing-id` =
       cofx `:id`; falls back to the first COEFFECT step), step-level.
-    - INTERCEPTOR exception → the INTERCEPTOR step, step-level.
+    - INTERCEPTOR exception → the INTERCEPTOR step matching the row's
+      `:phase` (rf2-vew2n — the `:before` step before HANDLER, the
+      `:after` step after HANDLER; falls back to any interceptor step),
+      step-level.
     - HANDLER / FLOW exception → that step, step-level (the exception
       aborted the step's work).
     - FX exception → the SIDE EFFECTS row whose `:fx-id` = `:failing-id`
@@ -2183,6 +2216,8 @@
               i           (cond
                             (= :coeffect target-step)
                             (coeffect-exception-target s (:failing-id row))
+                            (= :interceptor target-step)
+                            (interceptor-exception-target s (:phase row))
                             :else
                             (index-of #(= target-step (:step %)) s))]
           (if i
@@ -2621,29 +2656,45 @@
                                  (assoc :db-post-flow flow-db-post)))
                              (flow-rows events))
             violations (schema-violation-rows events)
-            ;; rf2-wnvid — stamp the cascade-level `:db-committed?` onto
+            ;; rf2-s6oqd — stamp the cascade-level `:db-rolled-back?` onto
             ;; every exception row so the view's 'Rolled back' chip paints
-            ;; ONLY when a `:db` install actually preceded the throw (a real
-            ;; commit there is something to roll back). `db-commit?` keys off
-            ;; `:rf.event/db-changed` / a schema rollback — both absent on a
-            ;; handler that threw before returning (button-15), so the chip
-            ;; correctly stays off there (NO SPURIOUS 'Rolled back').
-            db-committed? (db-commit? events)
-            exceptions (mapv #(assoc % :db-committed? db-committed?)
+            ;; ONLY when the cascade ACTUALLY rolled back — i.e. a
+            ;; `:where :app-db` schema-validation failure reverted the
+            ;; commit. `db-committed?` (the rf2-wnvid predicate) was the
+            ;; WRONG gate: fx are POST-COMMIT / best-effort (the FX
+            ;; atomicity asymmetry), so a throwing fx (button-20
+            ;; `:standard-epochs/boom`) leaves `:db` COMMITTED yet nothing
+            ;; rolled back — the spurious chip. `db-rolled-back?` is true
+            ;; iff a real rollback happened:
+            ;;   - :db schema-fail rollback → committed AND rolled back →
+            ;;     chip (correct);
+            ;;   - post-commit fx throw → committed, NOT rolled back → NO
+            ;;     chip (the baseline bump survives);
+            ;;   - pre-commit handler throw (button-16) → no commit, no
+            ;;     rollback → no chip (already correct under wnvid).
+            db-rolled-back? (db-rolled-back? events)
+            exceptions (mapv #(assoc % :db-rolled-back? db-rolled-back?)
                              (exception-rows events))
             base-steps (vec
                         (concat
                           [(dispatch-row events fallback)]
                           cofx-steps
                           cofx-placeholder-steps
-                          ;; rf2-yz57h — the INTERCEPTOR step rides between
-                          ;; COEFFECTS and HANDLER (the cascade position of
-                          ;; the interceptor chain: `:before` runs after
-                          ;; coeffects, before the handler). Conditional —
+                          ;; rf2-yz57h / rf2-vew2n — the INTERCEPTOR step is
+                          ;; PHASE-SPLIT + placed on the correct side of the
+                          ;; EVENT HANDLER, reflecting execution ORDER:
+                          ;; DISPATCH → COEFFECTS → [:before interceptors] →
+                          ;; EVENT HANDLER → [:after interceptors] → …
+                          ;; A `:before` interceptor throws on the way IN
+                          ;; (the chain aborts before the handler), so it
+                          ;; renders BEFORE HANDLER; an `:after` interceptor
+                          ;; throws on the way OUT (the handler ran first),
+                          ;; so it renders AFTER HANDLER. Both conditional —
                           ;; nil (filtered out below) when no interceptor
-                          ;; threw this cascade.
-                          [(interceptor-step events)
-                           (handler-row events event-id db-before db-after)]
+                          ;; threw in that phase this cascade.
+                          [(interceptor-step events :before)
+                           (handler-row events event-id db-before db-after)
+                           (interceptor-step events :after)]
                           ;; APP-DB DIFF removed pair-debug 2026-05-26 —
                           ;; redundant with the HANDLER step's `:db`
                           ;; sub-section's [diff][all] toggle which

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2112,11 +2112,13 @@
     [:div {:data-testid "rf-xray-epoch-step-interceptor"
            :data-step-kw "interceptor"}
      (numbered-circle step-number :INTERCEPTOR)
+     ;; rf2-oqi0c — the "N interceptor(s) threw" summary verb is DROPPED:
+     ;; redundant with the per-interceptor row(s) + the inline 'Exception
+     ;; Thrown' card(s) below, which already carry which interceptor threw
+     ;; and on which phase. The badge stands alone.
      (step-header
        {:step :interceptor
         :badge :INTERCEPTOR
-        :verb (str (count rows) " interceptor"
-                   (when (not= 1 (count rows)) "s") " threw")
         :expandable? false
         :testid "rf-xray-epoch-interceptor"}
        nil)
@@ -2739,19 +2741,23 @@
   the parent's `handler-body` signature for projection compatibility.
 
   rf2-wnvid — PHANTOM-`:db` fix. When the handler wrote NO `:db` effect
-  (`db-write?` false — it threw before returning, per button-15, or
-  returned only `:fx`), the block renders a `— no :db (…)` placeholder
-  instead of falling back to the record's full post-cascade `:db-after`.
-  The pre-rf2-wnvid fallback painted the ENTIRE app-db tree under the
-  HANDLER step as if the handler had returned it — misleading on a
-  thrown handler that mutated nothing. `threw?` tunes the placeholder
-  wording so a handler-exception reads 'no :db (handler threw)'.
+  (`db-write?` false — e.g. it returned only `:fx`), the block renders a
+  `— no :db (handler returned no :db)` placeholder instead of falling
+  back to the record's full post-cascade `:db-after`. The pre-rf2-wnvid
+  fallback painted the ENTIRE app-db tree under the HANDLER step as if
+  the handler had returned it — misleading on a handler that mutated
+  nothing.
+
+  rf2-oqi0c — the THREW case no longer reaches this block at all: the
+  caller (`handler-body`) OMITS the whole `:db` sub-section when the
+  handler threw (the inline exception card is the signal), so the
+  placeholder is only ever the clean 'returned no :db' wording.
 
   Suppressed for machine handlers — per design §Section 3 §DB DIFF
   the snapshot IS the db change (at `[:rf/runtime :machines :snapshots <id>]`) so the
   slot folds into SNAPSHOT DIFF rather than carrying a redundant
   standalone slot."
-  [_db-diff db-post-handler db-write? threw?]
+  [_db-diff db-post-handler db-write?]
   (let [record    @(rf/subscribe [:rf.xray/selected-epoch-record])
         db-before (:db-before record)
         ;; rf2-4wywy — t1 (post-handler, pre-flow) is the authoritative
@@ -2772,12 +2778,12 @@
      (sub-header ":db" nil)
      (cond
        ;; rf2-wnvid — the handler wrote no `:db` → no phantom app-db.
+       ;; rf2-oqi0c — the threw case is omitted upstream (`handler-body`),
+       ;; so this placeholder is only ever the clean 'returned no :db'.
        (not db-write?)
        [:span {:data-testid "rf-xray-epoch-handler-db-no-write"
                :style handler-db-all-missing-style}
-        (if threw?
-          "— no :db (handler threw)"
-          "— no :db (handler returned no :db)")]
+        "— no :db (handler returned no :db)"]
 
        (some? db-after)
        [:div {:data-testid "rf-xray-epoch-handler-db-full-with-diff"
@@ -2841,8 +2847,12 @@
      ;; folded into SNAPSHOT DIFF for machines. rf2-4wywy — the
      ;; post-handler (t1) db is threaded so the diff shows ONLY the
      ;; handler's contribution, not the post-flow state.
-     (when-not machine?
-       (handler-db-diff-block db-diff db-post-handler db-write? threw?))
+     ;; rf2-oqi0c — OMIT the `:db` sub-section entirely when the handler
+     ;; THREW: the redundant "— no :db (handler threw)" line was noise (the
+     ;; inline 'Exception Thrown' card below is the signal). The slot
+     ;; stays present for a clean handler that simply returned no `:db`.
+     (when (and (not machine?) (not threw?))
+       (handler-db-diff-block db-diff db-post-handler db-write?))
      ;; :fx — the canonical vector-of-vectors, FULL via edn-inspector.
      ;; rf2-5t8y8 — sub-header carries a trailing entry-count chip ("N
      ;; entr{y,ies}") that the edn-inspector vector-header chrome alone
@@ -4165,58 +4175,33 @@
 ;; ---- inline EXCEPTION card (rf2-ahhgn) ----------------------------------
 
 (defn- error-recovery-label
-  "Short recovery chip text for an exception card (rf2-ahhgn / rf2-wnvid).
+  "Short recovery chip text for an exception card (rf2-ahhgn / rf2-wnvid /
+  rf2-s6oqd).
 
-  rf2-wnvid — `db-committed?` gates the `Rolled back` chip: it paints
-  ONLY when a `:db` install actually preceded the throw (so there was a
-  commit to revert). The substrate stamps `:recovery :no-recovery` on
-  EVERY `:rf.error/handler-exception`, so keying off recovery alone
-  painted a SPURIOUS `Rolled back` on button-15 — the handler threw
-  before producing any `:db`, so nothing committed + nothing reverted.
-  With no commit, the chip is omitted (the headline already says the
-  handler threw; there is no rollback to surface). Other recovery
-  keywords render name-d; nil recovery omits the chip."
-  [recovery db-committed?]
+  rf2-s6oqd — `db-rolled-back?` gates the `Rolled back` chip: it paints
+  ONLY when the cascade ACTUALLY rolled back (a `:where :app-db`
+  schema-validation failure reverted the commit). The substrate stamps
+  `:recovery :no-recovery` on EVERY `:rf.error/*`, so keying off recovery
+  alone painted a SPURIOUS `Rolled back`. The earlier rf2-wnvid gate
+  (`db-committed?`) fixed the pre-commit handler throw (button-16 — no
+  commit) but still mis-fired on a POST-COMMIT fx throw (button-20
+  `:standard-epochs/boom`): fx are best-effort post-commit, so the `:db`
+  stays committed yet nothing reverted. Gating on actual rollback paints
+  the chip on a :db schema-fail rollback (correct) and omits it on a
+  post-commit fx throw and a pre-commit handler throw (the headline
+  already names the failure; there is no rollback to surface). Other
+  recovery keywords render name-d; nil recovery omits the chip."
+  [recovery db-rolled-back?]
   (case recovery
-    :no-recovery (when db-committed? "Rolled back")
+    :no-recovery (when db-rolled-back? "Rolled back")
     (when (keyword? recovery) (name recovery))))
 
-(defn- error-block-label
-  "Render the card's one-line failure headline (rf2-ahhgn / rf2-wnvid /
-  rf2-mszrz attribution / rf2-yz57h placement) — the failing unit + a
-  human verb keyed off the exception OP. E.g. 'The event handler threw.' /
-  'The :http/post effect threw.'
-
-  Attribution derives from `:operation` (== the trace `:category` /
-  `:reason` family). rf2-mszrz split the pre-mszrz blanket
-  `:rf.error/handler-exception` (the router used to route handler /
-  interceptor / injected-coeffect throws ALL through it) into
-  component-attributed ops, so the headline now names the TRUE failing
-  component: a coeffect injector (`:rf.error/coeffect-exception`, by cofx
-  id), a user interceptor (`:rf.error/interceptor-exception`, by
-  interceptor id + `:phase`), or the event handler itself
-  (`:rf.error/handler-exception`). The card is rendered UNDER the step
-  where the throw occurred (rf2-yz57h), so the headline reinforces that
-  placement rather than re-attributing."
-  [{:keys [operation failing-id phase]}]
-  (case operation
-    :rf.error/coeffect-exception
-    (str "The " (proj/ns-keyword failing-id) " coeffect threw during injection.")
-    :rf.error/interceptor-exception
-    (str "The " (proj/ns-keyword failing-id) " interceptor threw"
-         (case phase
-           :before " on the way in (:before)."
-           :after  " on the way out (:after)."
-           "."))
-    :rf.error/handler-exception
-    "The event handler threw."
-    :rf.error/fx-handler-exception
-    (str "The " (proj/ns-keyword failing-id) " effect threw.")
-    :rf.error/no-such-fx
-    (str "No fx handler registered for " (proj/ns-keyword failing-id) ".")
-    :rf.error/flow-eval-exception
-    "A flow's computation threw."
-    "An exception was thrown."))
+;; rf2-oqi0c — `error-block-label` (the one-line category-reason headline
+;; 'The event handler threw.' / '…interceptor threw.') was REMOVED. The
+;; card's position (under the failing step) + its 'Exception Thrown'
+;; heading already attribute the failure; the headline merely restated
+;; the category as boilerplate chrome. The card now leads with the real
+;; `.getMessage` (when present) + the collapsible stack / ex-data.
 
 (defn- exception-stack
   "Lift the stack trace string off a thrown exception object (rf2-wnvid).
@@ -4273,13 +4258,14 @@
   projected `exception-row`. Top to bottom:
 
     1. Title bar: `✗` + 'Exception Thrown' + right-aligned recovery chip
-       (`Rolled back`, painted ONLY when a `:db` actually committed +
-       rolled back — `db-committed?`; rf2-wnvid drops the spurious chip
-       on a handler that threw before any commit).
-    2. Failure headline: a one-line human verb (`error-block-label`),
-       attributed off the op (NOT the interceptor `:phase` — rf2-wnvid).
-    3. Exception message: the verbatim `ex-info` message (monospace).
-    4. Collapsible details (`error-block-details`): the stack trace +
+       (`Rolled back`, painted ONLY when the cascade ACTUALLY rolled back
+       — `db-rolled-back?`; rf2-s6oqd drops the spurious chip on a
+       post-commit fx throw, rf2-wnvid on a pre-commit handler throw).
+    2. Exception message: the verbatim `ex-info` message (monospace).
+       rf2-oqi0c — the category-reason boilerplate headline ('The event
+       handler threw.' / '…interceptor threw.') was DROPPED as redundant
+       with the card position + 'Exception Thrown' heading.
+    3. Collapsible details (`error-block-details`): the stack trace +
        any `ex-data`, collapsed behind a `<details>` disclosure.
 
   rf2-wnvid — the pre-existing always-expanded jump-to-source link is
@@ -4291,8 +4277,8 @@
   `step-key` + `idx` give stable test ids. The card paints the failing
   step's blast radius right where the work happened — the inline half of
   rf2-ahhgn, polished by rf2-wnvid for ALL exception kinds."
-  [step-key idx {:keys [message recovery db-committed?] :as row}]
-  (let [recovery-label (error-recovery-label recovery db-committed?)
+  [step-key idx {:keys [message recovery db-rolled-back?] :as row}]
+  (let [recovery-label (error-recovery-label recovery db-rolled-back?)
         testid-base    (str "rf-xray-epoch-error-"
                             (name (or step-key :unknown)) "-" idx)]
     [:div {:key (str "error-" step-key "-" idx)
@@ -4308,16 +4294,16 @@
         [:span {:data-testid (str testid-base "-recovery")
                 :style error-block-recovery-chip-style}
          recovery-label])]
-     ;; 2. Failure headline (human verb)
-     [:p {:data-testid (str testid-base "-headline")
-          :style violation-prose-style}
-      (error-block-label row)]
-     ;; 3. Exception message (verbatim, monospace) — the punchline
+     ;; rf2-oqi0c — the category-reason boilerplate headline ('The event
+     ;; handler threw.' / '…interceptor threw.') is DROPPED: redundant with
+     ;; the card's position (under the failing step) + the 'Exception
+     ;; Thrown' heading. The real `.getMessage` + ex-data carry the signal.
+     ;; 2. Exception message (verbatim, monospace) — the punchline
      (when (and (string? message) (not (str/blank? message)))
        [:div {:data-testid (str testid-base "-message")
               :style error-block-message-style}
         message])
-     ;; 4. Collapsible details — stack + ex-data behind a disclosure
+     ;; 3. Collapsible details — stack + ex-data behind a disclosure
      (error-block-details testid-base row)]))
 
 (defn error-blocks

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -2244,12 +2244,18 @@
       (is (= :standard-epochs/throw-handler (:failing-id row)))
       (is (= :no-recovery (:recovery row)))))
 
-  (testing "rf2-ahhgn — falls back to `:reason` for the message + nil-safe
-            coord when neither trigger-handler nor call-site carries a file"
+  (testing "rf2-oqi0c — the `:reason` CATEGORY boilerplate is NO LONGER
+            surfaced as the card message: when the throw carried no real
+            `:exception-message`, `:message` is nil (the card shows only
+            the position + 'Exception Thrown' heading, no boilerplate line).
+            nil-safe coord when neither trigger-handler nor call-site
+            carries a file."
     (let [ev  (handler-exception-ev :foo/bar nil)
           row (proj/exception-row ev)]
-      ;; handler-exception-ev stamps `:reason "Event handler threw."`
-      (is (= "Event handler threw." (:message row)))
+      ;; handler-exception-ev stamps `:reason "Event handler threw."` —
+      ;; rf2-oqi0c drops the :reason fallback, so :message resolves nil.
+      (is (nil? (:message row))
+          "no :exception-message → :message nil (the :reason boilerplate is dropped)")
       (is (nil? (:coord row)))))
 
   (testing "rf2-wnvid — `exception-row` lifts the raw `:exception` object
@@ -2411,12 +2417,12 @@
         (is (= "standard-epochs / handler (intentional — exercises the handler error surface)"
                (:message err)))
         (is (= {:file "standard_epochs/core.cljs" :line 322} (:coord err)))
-        ;; rf2-wnvid — the live button-15 had NO :db commit (handler
-        ;; threw before returning), so the exception row's cascade-level
-        ;; `:db-committed?` is false → the view omits the spurious
-        ;; 'Rolled back' chip.
-        (is (false? (:db-committed? err))
-            "no :db commit preceded the throw → :db-committed? false (no spurious rollback)"))
+        ;; rf2-s6oqd — the live button-16 handler threw before returning,
+        ;; so NO :db committed AND nothing rolled back. The exception row's
+        ;; cascade-level `:db-rolled-back?` is false → the view omits the
+        ;; spurious 'Rolled back' chip.
+        (is (false? (:db-rolled-back? err))
+            "no rollback (pre-commit handler throw) → :db-rolled-back? false (no spurious chip)"))
       ;; rf2-wnvid — the HANDLER step carries :db-write? false (it threw
       ;; before producing a :db), so the view shows 'no :db (handler
       ;; threw)' rather than the phantom full app-db.
@@ -2438,6 +2444,73 @@
       (is (= :ok (proj/epoch-outcome steps)))
       (is (every? #(nil? (:errors %)) steps))
       (is (every? #(= :ok (proj/step-status %)) steps)))))
+
+;; ---- rf2-s6oqd — 'Rolled back' chip gates on ACTUAL rollback ------------
+;;
+;; fx are POST-COMMIT / best-effort (the FX atomicity asymmetry): a throwing
+;; fx leaves the `:db` committed (the baseline bump survives) — nothing
+;; rolled back. The chip's predicate is `:db-rolled-back?` (a real
+;; `:where :app-db` schema-fail rollback), NOT mere commit. So:
+;;   - post-commit fx throw (button-20 `:standard-epochs/boom`) → committed,
+;;     NOT rolled back → NO chip.
+;;   - :db schema-fail rollback (button-23) → committed AND rolled back →
+;;     chip.
+;;   - pre-commit handler throw (button-16) → no commit, no rollback → no
+;;     chip (covered above).
+
+(deftest fx-exception-stamps-db-rolled-back-false-test
+  (testing "rf2-s6oqd — a POST-COMMIT fx throw (`:standard-epochs/boom`)
+            leaves the :db committed; the cascade did NOT roll back, so the
+            attached exception row carries `:db-rolled-back? false` → the
+            view omits the spurious 'Rolled back' chip"
+    (let [rec   (record [(dispatched-ev [:standard-epochs/throw-fx] :ui nil)
+                         ;; the handler committed a :db (baseline bumped)
+                         ;; BEFORE the post-commit fx walk
+                         (db-pending-ev {:baseline 1})
+                         (db-changed-ev [[[:baseline] 0 1 :modified]])
+                         (run-end-ev 1)
+                         (do-fx-ev {:fx [[:standard-epochs/boom {}]]})
+                         ;; the post-commit fx threw (best-effort; :db stays)
+                         (fx-handler-exception-ev :standard-epochs/boom
+                                                  "standard-epochs / boom fx threw")]
+                        :standard-epochs/throw-fx)
+          steps (proj/project rec)
+          se    (some #(when (= :side-effects (:step %)) %) steps)
+          ;; the fx exception attaches to the SIDE EFFECTS step's :boom row
+          err   (or (first (:errors se))
+                    (->> (:rows se) (mapcat :errors) first))]
+      (is (some? err) "the fx exception attached to the SIDE EFFECTS step")
+      (is (false? (:db-rolled-back? err))
+          "post-commit fx throw → :db-rolled-back? false (NO spurious 'Rolled back' chip)")
+      ;; the cascade did commit (the baseline bump survives) — but nothing
+      ;; was reverted, which is the whole point.
+      (is (true? (proj/db-commit? (:trace-events rec)))
+          "the :db DID commit (baseline survives)")
+      (is (false? (proj/db-rolled-back? (:trace-events rec)))
+          "but nothing rolled back"))))
+
+(deftest schema-rollback-stamps-db-rolled-back-true-test
+  (testing "rf2-s6oqd — a `:where :app-db` schema-fail rollback DID revert
+            the commit, so an exception row this cascade carries
+            `:db-rolled-back? true` → the 'Rolled back' chip DOES paint.
+            (The schema-fail rolled back AND a handler exception fired.)"
+    (let [rec   (record [(dispatched-ev [:standard-epochs/set-bad-auth] :ui nil)
+                         (db-changed-ev [[[:auth :token] "ok" 42 :modified]])
+                         ;; the app-db schema check rejected the write +
+                         ;; flagged the cascade rolled back
+                         (schema-violation-ev :app-db :standard-epochs/set-bad-auth
+                                              [:auth :token] 42 true)
+                         (handler-exception-ev :standard-epochs/set-bad-auth
+                                               "post-rollback handler note")]
+                        :standard-epochs/set-bad-auth)
+          steps (proj/project rec)
+          errs  (mapcat :errors steps)
+          err   (first errs)]
+      (is (true? (proj/db-rolled-back? (:trace-events rec)))
+          "the :app-db schema-fail flagged the cascade rolled back")
+      (is (some? err) "an exception row attached this cascade")
+      (is (true? (:db-rolled-back? err))
+          ":db-rolled-back? true → the 'Rolled back' chip paints (correct)"))))
 
 ;; ---- rf2-yz57h — per-step exception placement + INTERCEPTOR step --------
 ;;
@@ -2508,22 +2581,36 @@
 (deftest interceptor-step-projection-test
   (testing "rf2-yz57h — `interceptor-step` is nil when no interceptor threw"
     (is (nil? (proj/interceptor-step [(dispatched-ev [:x] :ui nil)
-                                      (run-end-ev 1)]))))
+                                      (run-end-ev 1)] :before)))
+    (is (nil? (proj/interceptor-step [(dispatched-ev [:x] :ui nil)
+                                      (run-end-ev 1)] :after))))
 
-  (testing "rf2-yz57h — `interceptor-step` projects one row per throwing
-            interceptor, carrying :interceptor-id + :phase"
+  (testing "rf2-vew2n — `interceptor-step` is PHASE-FILTERED: the :before
+            step carries only :before throws, the :after step only :after"
     (let [events [(interceptor-exception-ev :app/auth :before "intc boom")]
-          step   (proj/interceptor-step events)]
-      (is (= :interceptor (:step step)))
-      (is (= :INTERCEPTOR (:badge step)))
-      (is (= 1 (count (:rows step))))
-      (is (= :app/auth (:interceptor-id (first (:rows step)))))
-      (is (= :before   (:phase (first (:rows step))))))))
+          before (proj/interceptor-step events :before)
+          after  (proj/interceptor-step events :after)]
+      (is (= :interceptor (:step before)))
+      (is (= :INTERCEPTOR (:badge before)))
+      (is (= :before (:phase before)) "the step carries its own :phase")
+      (is (= 1 (count (:rows before))))
+      (is (= :app/auth (:interceptor-id (first (:rows before)))))
+      (is (= :before   (:phase (first (:rows before)))))
+      (is (nil? after) "no :after throw → no :after interceptor step")))
+
+  (testing "rf2-vew2n — an :after throw populates ONLY the :after step"
+    (let [events [(interceptor-exception-ev :app/audit :after "intc boom")]
+          before (proj/interceptor-step events :before)
+          after  (proj/interceptor-step events :after)]
+      (is (nil? before) "no :before throw → no :before interceptor step")
+      (is (= :after (:phase after)))
+      (is (= 1 (count (:rows after))))
+      (is (= :app/audit (:interceptor-id (first (:rows after))))))))
 
 (deftest attach-interceptor-exception-to-interceptor-step-test
   (testing "rf2-yz57h — a `:rf.error/interceptor-exception` attaches to the
             INTERCEPTOR step (not HANDLER)"
-    (let [steps [{:step :interceptor :badge :INTERCEPTOR
+    (let [steps [{:step :interceptor :badge :INTERCEPTOR :phase :before
                   :rows [{:interceptor-id :app/auth :phase :before}]}
                  {:step :handler :badge :HANDLER}]
           rows  [(proj/exception-row
@@ -2531,7 +2618,23 @@
           out   (proj/attach-exceptions steps rows)]
       (is (= 1 (count (:errors (nth out 0)))) "INTERCEPTOR carries the exception")
       (is (= :error (:status (nth out 0))) "INTERCEPTOR stamped :error")
-      (is (nil? (:errors (nth out 1))) "HANDLER untouched"))))
+      (is (nil? (:errors (nth out 1))) "HANDLER untouched")))
+
+  (testing "rf2-vew2n — with TWO phase-split INTERCEPTOR steps, an exception
+            routes to the step whose :phase matches (NOT the first one)"
+    (let [steps [{:step :interceptor :badge :INTERCEPTOR :phase :before
+                  :rows [{:interceptor-id :app/before :phase :before}]}
+                 {:step :handler :badge :HANDLER}
+                 {:step :interceptor :badge :INTERCEPTOR :phase :after
+                  :rows [{:interceptor-id :app/after :phase :after}]}]
+          rows  [(proj/exception-row
+                   (interceptor-exception-ev :app/after :after "after boom"))]
+          out   (proj/attach-exceptions steps rows)]
+      (is (nil? (:errors (nth out 0)))
+          "the :before step (first) is NOT the target — the :after throw skips it")
+      (is (= 1 (count (:errors (nth out 2))))
+          "the :after step (after HANDLER) carries the :after throw")
+      (is (= :error (:status (nth out 2))) "the :after step is stamped :error"))))
 
 (deftest project-interceptor-before-end-to-end-test
   (testing "rf2-yz57h — button-17 live scenario: a `:before` interceptor
@@ -2559,9 +2662,12 @@
       (is (= :error (proj/epoch-outcome steps))))))
 
 (deftest project-interceptor-after-end-to-end-test
-  (testing "rf2-yz57h — button-18 live scenario: an `:after` interceptor
-            threw → INTERCEPTOR step present, HANDLER NOT skipped (it ran
-            first; the throw fired on the way out)"
+  (testing "rf2-yz57h / rf2-vew2n — button-18 live scenario: an `:after`
+            interceptor threw → INTERCEPTOR step present, HANDLER NOT skipped
+            (it ran first; the throw fired on the way out), and the
+            INTERCEPTOR step renders AFTER the EVENT HANDLER step (the
+            rf2-vew2n bug fix — it used to land at position 2, before the
+            handler)"
     (let [rec   (record [(dispatched-ev [:standard-epochs/throw-interceptor-after] :ui nil)
                          ;; the handler ran + committed a :db on the way in
                          (db-pending-ev {:n 1})
@@ -2575,12 +2681,44 @@
           intc  (some #(when (= :interceptor (:step %)) %) steps)
           h     (some #(when (= :handler (:step %)) %) steps)]
       (is (some? intc) "INTERCEPTOR step present")
+      (is (= :after (:phase intc)) "the step itself carries the :after phase")
       (is (= :after (:phase (first (:rows intc)))) "the row records the :after phase")
       (is (= 1 (count (:errors intc))) "exception under INTERCEPTOR")
       (is (not= :skipped (proj/step-status h))
           "HANDLER NOT skipped — it ran before the :after interceptor threw")
       (is (true? (:db-write? h)) "the handler DID write a :db (it ran)")
-      (is (= :error (proj/epoch-outcome steps))))))
+      ;; rf2-vew2n — cascade-position: the :after INTERCEPTOR sits AFTER
+      ;; the EVENT HANDLER (the bug: it used to render at position 2).
+      (let [step-kws (mapv :step steps)
+            i-idx    (.indexOf step-kws :interceptor)
+            h-idx    (.indexOf step-kws :handler)]
+        (is (> i-idx h-idx) "INTERCEPTOR (:after) renders AFTER HANDLER"))
+      (is (= :error (proj/epoch-outcome steps)))))
+
+  (testing "rf2-vew2n — BOTH a :before and an :after interceptor throw in the
+            same cascade → TWO INTERCEPTOR steps, one on each side of HANDLER"
+    (let [rec   (record [(dispatched-ev [:multi/intc] :ui nil)
+                         (interceptor-exception-ev :app/before :before "before boom")
+                         (db-changed-ev [[[:n] 0 1 :modified]])
+                         (run-end-ev 1)
+                         (interceptor-exception-ev :app/after :after "after boom")]
+                        :multi/intc)
+          steps (proj/project rec)
+          step-kws (mapv :step steps)
+          h-idx    (.indexOf step-kws :handler)
+          intc-steps (filterv #(= :interceptor (:step %)) steps)]
+      (is (= 2 (count intc-steps)) "two INTERCEPTOR steps (one per phase)")
+      (is (= #{:before :after} (set (map :phase intc-steps))))
+      ;; the :before step precedes HANDLER; the :after step follows it
+      (let [before-idx (.indexOf (mapv (juxt :step :phase) steps) [:interceptor :before])
+            after-idx  (.indexOf (mapv (juxt :step :phase) steps) [:interceptor :after])]
+        (is (< before-idx h-idx) ":before INTERCEPTOR precedes HANDLER")
+        (is (> after-idx h-idx)  ":after INTERCEPTOR follows HANDLER"))
+      ;; each exception lands on the step of its own phase
+      (let [before-step (some #(when (and (= :interceptor (:step %)) (= :before (:phase %))) %) steps)
+            after-step  (some #(when (and (= :interceptor (:step %)) (= :after (:phase %))) %) steps)]
+        (is (= :app/before (:failing-id (first (:errors before-step)))))
+        (is (= :app/after  (:failing-id (first (:errors after-step)))))))))
 
 ;; -- SKIPPED-step marking -------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -589,12 +589,14 @@
 
 (deftest handler-db-no-write-renders-placeholder-not-phantom-test
   (testing "rf2-wnvid — PHANTOM-`:db` fix. A handler that wrote NO :db
-            (`:db-write?` false — button-15: it threw before returning)
-            renders the `— no :db` placeholder, NOT the full post-cascade
-            app-db (the pre-rf2-wnvid `:db-after` fallback)."
+            (`:db-write?` false) renders the `— no :db` placeholder, NOT the
+            full post-cascade app-db (the pre-rf2-wnvid `:db-after`
+            fallback)."
     (epoch-orchestrator/install!)
     (frame/reg-frame :rf/xray {})
-    (testing "handler threw → 'handler threw' wording"
+    (testing "rf2-oqi0c — handler THREW → the :db sub-section is OMITTED
+              entirely (the inline exception card is the signal); no
+              redundant '— no :db (handler threw)' line"
       (let [tree (rf/with-frame :rf/xray
                    (view/render-handler-step
                      {:step :handler :badge :HANDLER :step-number 3
@@ -603,14 +605,12 @@
                       :status :error
                       :errors [{:operation :rf.error/handler-exception
                                 :message "boom"}]}))]
-        (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-db-no-write"))
-            "the no-write placeholder renders")
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-db-no-write"))
+            "the no-write placeholder is OMITTED when the handler threw")
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-db-diff"))
+            "the whole :db sub-section is dropped on a throw")
         (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-db-full-with-diff"))
-            "NO phantom full-app-db block")
-        (is (string/includes?
-              (text-of tree "rf-xray-epoch-handler-db-no-write")
-              "handler threw")
-            "placeholder wording names the throw")))
+            "NO phantom full-app-db block either")))
     (testing "clean handler returning no :db → 'returned no :db' wording"
       (let [tree (rf/with-frame :rf/xray
                    (view/render-handler-step
@@ -2367,16 +2367,18 @@
 ;; ---- rf2-ahhgn — inline exception card + per-step ✓/✗ + outcome banner ---
 
 (deftest error-block-renders-message-and-title-test
-  (testing "rf2-ahhgn / rf2-wnvid — `error-block` renders the red card with
-            the 'Exception Thrown' title, the op-derived human headline,
-            and the verbatim message. The redundant jump-to-source link is
-            DROPPED (rf2-wnvid — the HANDLER verb is the canonical link)."
+  (testing "rf2-ahhgn / rf2-wnvid / rf2-oqi0c / rf2-s6oqd — `error-block`
+            renders the red card with the 'Exception Thrown' title + the
+            verbatim message. rf2-oqi0c — the category-reason boilerplate
+            headline is DROPPED (redundant with the position + heading);
+            rf2-s6oqd — the 'Rolled back' chip gates on `:db-rolled-back?`
+            (an ACTUAL rollback), not mere commit."
     (let [row  {:operation :rf.error/handler-exception
                 :message "standard-epochs / handler (intentional — exercises the handler error surface)"
                 :failing-id :standard-epochs/throw-handler
                 :recovery :no-recovery
-                ;; a committed-then-rolled-back db → the chip is legitimate
-                :db-committed? true}
+                ;; an actual :app-db schema-fail rollback → the chip is legitimate
+                :db-rolled-back? true}
           tree (view/error-block :handler 0 row)
           base "rf-xray-epoch-error-handler-0"]
       (is (some? (th/find-by-testid tree base))
@@ -2384,42 +2386,39 @@
       (is (string/includes? (text-of tree (str base "-title")) "Exception Thrown")
           "title reads 'Exception Thrown'")
       (is (string/includes? (text-of tree (str base "-recovery")) "Rolled back")
-          ":no-recovery + db-committed? → 'Rolled back' chip")
-      (is (string/includes? (text-of tree (str base "-headline"))
-                            "event handler threw")
-          "headline names the handler failure")
+          ":no-recovery + db-rolled-back? → 'Rolled back' chip")
+      (is (nil? (th/find-by-testid tree (str base "-headline")))
+          "rf2-oqi0c — the category-reason boilerplate headline is dropped")
       (is (string/includes? (text-of tree (str base "-message"))
                             "intentional")
           "the verbatim ex-info message renders")
       (is (nil? (th/find-by-testid tree (str base "-source")))
           "rf2-wnvid — the redundant jump-to-source link is dropped"))))
 
-(deftest error-block-handler-headline-ignores-phase-test
-  (testing "rf2-wnvid — a `:phase :before` handler-exception (button-15's
-            live shape — the handler runs as the terminal :before
-            interceptor) reads 'The event handler threw.', NOT the
-            pre-rf2-wnvid 'An interceptor / coeffect threw (:before).'"
-    (let [tree (view/error-block :handler 0
-                 {:operation :rf.error/handler-exception
-                  :message "boom" :phase :before
-                  :failing-id :standard-epochs/throw-handler})
-          head (text-of tree "rf-xray-epoch-error-handler-0-headline")]
-      (is (string/includes? head "event handler threw"))
-      (is (not (string/includes? head "interceptor"))
-          "no spurious interceptor/coeffect attribution from :phase"))))
-
 (deftest error-block-no-spurious-rolled-back-test
-  (testing "rf2-wnvid — when NO :db committed (`db-committed?` false /
-            absent — button-15: the handler threw before producing any
-            :db), the 'Rolled back' chip is OMITTED even though the
-            substrate stamped :recovery :no-recovery (nothing to revert)."
+  (testing "rf2-s6oqd — a POST-COMMIT fx throw leaves the :db committed but
+            NOTHING rolled back (`:db-rolled-back?` false), so the 'Rolled
+            back' chip is OMITTED even though :recovery :no-recovery was
+            stamped. (`:db-committed?` was the wrong gate — fx are
+            best-effort post-commit.)"
+    (let [tree (view/error-block :side-effects 0
+                 {:operation :rf.error/fx-handler-exception
+                  :message "boom"
+                  :failing-id :standard-epochs/boom
+                  :recovery :no-recovery
+                  :db-rolled-back? false})]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-error-side-effects-0-recovery"))
+          "post-commit fx throw → no spurious 'Rolled back' chip")))
+
+  (testing "rf2-wnvid / rf2-s6oqd — a pre-commit handler throw also rolls
+            nothing back (`:db-rolled-back?` false) → no chip"
     (let [tree (view/error-block :handler 0
                  {:operation :rf.error/handler-exception
                   :message "boom"
                   :recovery :no-recovery
-                  :db-committed? false})]
+                  :db-rolled-back? false})]
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-error-handler-0-recovery"))
-          "no commit → no spurious 'Rolled back' chip"))))
+          "no rollback → no spurious 'Rolled back' chip"))))
 
 (deftest error-block-collapsible-details-test
   (testing "rf2-wnvid — when the exception carries a stack / ex-data, the
@@ -2441,15 +2440,24 @@
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-error-handler-0-details"))
           "nothing to disclose → the details element is omitted"))))
 
-(deftest error-block-fx-headline-test
-  (testing "rf2-ahhgn — an fx-handler exception names the failing fx-id"
-    (let [tree (view/error-block :fx 0
-                 {:operation :rf.error/fx-handler-exception
-                  :message "fx boom" :failing-id :http/post
-                  :recovery :no-recovery})]
-      (is (string/includes? (text-of tree "rf-xray-epoch-error-fx-0-headline")
-                            ":http/post")
-          "headline names the failing effect"))))
+(deftest error-block-drops-boilerplate-headline-test
+  (testing "rf2-oqi0c — the category-reason boilerplate headline is dropped
+            for EVERY exception kind (handler / fx / interceptor); the card
+            shows ONLY the 'Exception Thrown' heading + the real message"
+    (doseq [op [:rf.error/handler-exception
+                :rf.error/fx-handler-exception
+                :rf.error/interceptor-exception]]
+      (let [tree (view/error-block :fx 0
+                   {:operation op
+                    :message "the real ex-info message"
+                    :failing-id :http/post
+                    :phase :after
+                    :recovery :no-recovery})]
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-error-fx-0-headline"))
+            (str "no boilerplate headline for " op))
+        (is (string/includes? (text-of tree "rf-xray-epoch-error-fx-0-message")
+                              "the real ex-info message")
+            "the real message is still surfaced")))))
 
 (deftest error-blocks-nil-safe-test
   (testing "rf2-ahhgn — `error-blocks` renders nothing for empty / nil"
@@ -2569,6 +2577,7 @@
     (let [tree (rf/with-frame :rf/xray
                  (view/render-interceptor-step
                    {:step :interceptor :badge :INTERCEPTOR :step-number 3
+                    :phase :before
                     :status :error
                     :rows [{:interceptor-id :standard-epochs/throwing-interceptor
                             :phase :before}]
@@ -2587,6 +2596,12 @@
             (text-of tree "rf-xray-epoch-interceptor-phase-0")
             "before")
           "the :before phase chip renders")
+      ;; rf2-oqi0c — the "N interceptor(s) threw" summary verb is DROPPED;
+      ;; the per-row id + the inline card carry the signal.
+      (is (not (string/includes?
+                 (or (text-of tree "rf-xray-epoch-interceptor-header-verb") "")
+                 "threw"))
+          "no redundant 'N interceptor threw' summary verb after the badge")
       ;; the shared card under the interceptor row
       (is (string/includes?
             (text-of tree "rf-xray-epoch-error-interceptor-row-0-0-title")
@@ -2604,6 +2619,7 @@
     (let [tree (rf/with-frame :rf/xray
                  (view/render-interceptor-step
                    {:step :interceptor :badge :INTERCEPTOR :step-number 3
+                    :phase :after
                     :status :error
                     :rows [{:interceptor-id :app/auditor :phase :after}]
                     :errors [{:operation :rf.error/interceptor-exception

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -1096,6 +1096,67 @@ async function runExceptionSchemaHttp(page, state, ctx) {
       epochText: exceptionEpochText.slice(0, 800),
     });
   }
+
+  // rf2-s6oqd + rf2-oqi0c — focus the handler-throw epoch (Button A,
+  // `::throw-in-handler`: throws before returning a `:db`) and assert the
+  // exception-chrome fixes hold on the live cascade:
+  //   (s6oqd)  NO spurious "Rolled back" recovery chip — nothing committed
+  //            or rolled back here (and the post-commit/flow throws in this
+  //            deck likewise never roll back the committed `:db`).
+  //   (oqi0c-b) NO category-reason boilerplate headline element on any
+  //            exception card (the position + "Exception Thrown" heading
+  //            carry the attribution).
+  //   (oqi0c-a) the HANDLER step does NOT render the redundant
+  //            "— no :db (handler threw)" line — the inline card is the
+  //            signal, so the `:db` sub-section is omitted on a throw.
+  await focusCascadeByFrameEvent(page, {
+    frame: ':rf/default',
+    eventId: ':deliberate-throw.core/throw-in-handler',
+  });
+  await expectVisible(page.locator('[data-testid="rf-xray-epoch-panel"]'), 5000);
+  // the handler-exception card is present (the inline failure surface)
+  await waitForValue(
+    () => page.locator('[data-testid="rf-xray-epoch-panel"] [data-error-op="handler-exception"]').count(),
+    (count) => count > 0,
+    { timeoutMs: 5000, description: 'oqi0c — handler exception card present' },
+  );
+  // (s6oqd) no rollback happened → NO "Rolled back" recovery chip anywhere
+  const handlerEpochRecoveryChips = await page
+    .locator('[data-testid="rf-xray-epoch-panel"] [data-testid$="-recovery"]')
+    .count();
+  if (handlerEpochRecoveryChips > 0) {
+    const chipText = (await page
+      .locator('[data-testid="rf-xray-epoch-panel"] [data-testid$="-recovery"]')
+      .first()
+      .textContent()) || '';
+    failWithDetails('rf2-s6oqd — spurious recovery chip on an exception that did not roll back', {
+      recoveryChipCount: handlerEpochRecoveryChips,
+      chipText,
+    });
+  }
+  // (oqi0c-b) the category-reason boilerplate headline is dropped
+  const handlerEpochHeadlines = await page
+    .locator('[data-testid="rf-xray-epoch-panel"] [data-testid$="-headline"]')
+    .count();
+  if (handlerEpochHeadlines > 0) {
+    failWithDetails('rf2-oqi0c — boilerplate exception headline not dropped', {
+      headlineCount: handlerEpochHeadlines,
+    });
+  }
+  // (oqi0c-a) the HANDLER step omits the "— no :db (handler threw)" line
+  const handlerThrewNoDbLine = await page
+    .locator('[data-testid="rf-xray-epoch-handler-db-no-write"]')
+    .count();
+  if (handlerThrewNoDbLine > 0) {
+    const lineText = (await page
+      .locator('[data-testid="rf-xray-epoch-handler-db-no-write"]')
+      .first()
+      .textContent()) || '';
+    failWithDetails('rf2-oqi0c — redundant "no :db (handler threw)" line not dropped', {
+      lineText,
+    });
+  }
+
   await clickTab(page, 'trace', 'rf-xray-trace');
   await expectVisible(page.locator('[data-testid="rf-xray-trace-feed"]'), 5000);
   await waitForValue(

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -1299,9 +1299,10 @@
 ;;   - the HANDLER step is NOT skipped (an `:after` throw runs the
 ;;     handler first), so its `:db` write still renders normally.
 ;;
-;; The INTERCEPTOR step rides BETWEEN COEFFECT and HANDLER in the
-;; numbered cascade (the chain's `:before` runs after coeffects, before
-;; the handler; the step position reflects that).
+;; The `:after` INTERCEPTOR step rides AFTER the HANDLER in the numbered
+;; cascade (rf2-vew2n — the chain's `:after` unwinds on the way OUT, past
+;; the handler; the step position reflects that). A `:before` throw's step
+;; would instead sit BEFORE the handler.
 
 (defn interceptor-after-throw-history
   "Cascade where a user interceptor (`:audit/trail`) threw in its


### PR DESCRIPTION
Three tightly-related Epoch-panel exception/step-rendering fixes in one PR — they all edit `panels/epoch/projection.cljc` + `panels/epoch/view.cljs`, so doing them together avoids conflicting rebases.

## Per-bead summary

### rf2-s6oqd [BUG] — spurious "Rolled back" chip on a post-commit fx exception
fx are POST-COMMIT / best-effort (the FX atomicity asymmetry), so a throwing fx (`:standard-epochs/boom`, button 20) leaves `:db` committed (the baseline bump survives) — nothing rolled back, but the title-bar recovery chip wrongly showed "Rolled back". ROOT: the chip was gated on `db-committed?`, not actual rollback.
- `projection.cljc` — `project` now stamps `:db-rolled-back?` (true iff a `:where :app-db` schema-validation failure flagged the cascade rolled back) onto each exception row, replacing the `:db-committed?` stamp.
- `view.cljs` — `error-recovery-label` / `error-block` gate the chip on `db-rolled-back?`.
- Result: `:db` schema-fail rollback → chip; post-commit fx throw → NO chip; pre-commit handler throw → no chip (already correct under rf2-wnvid).

### rf2-vew2n [BUG] — position interceptor exception by :phase
The merged yz57h placed BOTH `:before` and `:after` interceptor exceptions at a single fixed-early INTERCEPTOR step, so an `:after`-interceptor exception wrongly showed at position 2. The `:phase` is captured (rf2-mszrz), so this is a panel-positioning fix.
- `projection.cljc` — `interceptor-step` is now phase-split (takes a `:before`/`:after` arg, carries its own `:phase`); `project` places the `:before` step BEFORE the EVENT HANDLER and the `:after` step AFTER it; `attach-exceptions` routes each interceptor exception to the step matching its `:phase` (new `interceptor-exception-target`).
- Pipeline order now reads DISPATCH → COEFFECTS → [:before interceptors] → EVENT HANDLER → [:after interceptors] → … with the exception attached at the step/phase that threw. (A `:before` abort still renders the unreached HANDLER as the existing yz57h SKIPPED placeholder, which explicitly states "did not run" — it reflects reach, not a phantom "ran" handler.)

### rf2-oqi0c — quiet 3 redundant chrome bits when a step threw
- (a) HANDLER step on a handler throw: DROPPED the "— no :db (handler threw)" line — `handler-body` omits the whole `:db` sub-section on a throw (the exception card is the signal). The clean "returned no :db" placeholder is unchanged.
- (b) Exception card (all step types): DROPPED the category-reason boilerplate headline ("The event handler threw" / "…interceptor threw") — `error-block-label` removed; `exception-message` no longer falls back to the `:reason` boilerplate. The real `.getMessage` + ex-data stay in the collapsible.
- (c) INTERCEPTORS badge: DROPPED the "N interceptor(s) threw" summary verb (the per-row id + inline card carry the signal; projection retains `:threw` on SIDE EFFECTS for non-view consumers).

## Verification (buttons 16/17/18 + boom)
Verified via the CLJS unit lens + the feature_matrix browser gate, WITHOUT editing `standard_epochs/core.cljs` (Mike's live kt5nx diamond probe — untouched):
- **CLJS units** (`projection_cljs_test` / `view_cljs_test`): button-16 handler throw (no chip, `:db` sub-section omitted, no headline); button-17 `:before` interceptor (step before HANDLER); button-18 `:after` interceptor (step AFTER HANDLER — the bug fix — plus a both-phases-in-one-cascade case); post-commit fx (`boom`-shape) → `:db-rolled-back? false` + no chip; `:db` schema-fail rollback → `:db-rolled-back? true` + chip.
- **feature_matrix browser gate** (`runExceptionSchemaHttp`, deliberate-throw deck): the post-commit-fx + handler-throw epochs render NO spurious "Rolled back" chip, NO boilerplate headline element, and NO "no :db (handler threw)" line.

## Quality gates
| Gate | Result |
|------|--------|
| `npm run test:cljs` | PASS — 5092 tests, 17195 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` (full nightly sweep) | PASS — 16 scenarios, 0 failures, 13 matrix rows (1 pre-existing unrelated SKIP: rf2-w1mnq) |
| `npm run test:xray-feature-gate:smoke` | PASS — 4/4 (incl. the modified exception scenario) |
| `npm run test:bundle-isolation` | PASS — 17 artefact entries, 35 sentinels absent; uix/helix reagent-free |
| clj-kondo (`--fail-level error`, full `tools/xray/src` + `tools/xray/test`) | PASS — 0 errors |

Spec updated in-PR: `tools/xray/spec/021-Dynamic-Panel-Designs.md` (INTERCEPTOR phase-placement, recovery-chip gate, dropped headline + badge verb, HANDLER `:db`-on-throw omission). Panel-gallery `:after` fixture comment corrected.

Closes rf2-s6oqd, rf2-vew2n, rf2-oqi0c.