### PR TITLE
fix(xray/edn-inspector): never leak ::missing — render removed slots as struck-through ghosts (rf2-8pfkk)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -139,6 +139,54 @@ testbed epoch-2 `:rf/runtime` allocation (`:messages []` +
 > the FULL+DIFF family alongside rf2-9d4j8 root-container and
 > rf2-fyd8u scalar-sub-cache cases).
 
+### Removed slots render in place; the absence marker never escapes (rf2-8pfkk)
+
+The diff renders the **union of `before ∪ after`** — a slot present in
+`before` but absent from `after` (a `dissoc`, a `disj`, a popped vector
+tail) must still be visible, rendered **in place** struck-through with
+the `:removed` chrome (the universal diff idiom). The union walker
+threads an internal **`::missing` sentinel** for the slot that does not
+exist on one side; the renderer routes that sentinel through the
+`:added` / `:removed` paths.
+
+Two honesty rules make this robust regardless of how the engine
+anchored the edit:
+
+- **The structural sentinel is authoritative.** A slot whose `value`
+  side is `::missing` is a removal, full stop; a slot whose `before`
+  side is `::missing` is an addition. This overrides the projection's
+  per-path op. The override matters because removing the *only* key of
+  a nested map (`(update db :shapes dissoc :added)`, leaving `:shapes
+  {}`) is anchored by Editscript on the **surviving parent** — `op-at
+  [:shapes]` reports `:removed`/`:children` while the removed child slot
+  `[:shapes :added]` carries the ghost subtree in `:container-ops` and
+  reports `:children`. Trusting that child op leaked the internal
+  `::missing` keyword (`:day8…edn-inspector/missing`) literally into the
+  row (`:added ::missing`). The internal sentinel **must never appear in
+  rendered output**.
+
+- **A removed *container* renders as a collapsed struck-through ghost.**
+  A deleted subtree shows as a single struck-through node (`:shapes {…}
+  (N keys)`, red), expandable on demand to walk the ghost — bounding
+  verbosity and reusing the ordinary collapse / elision machinery rather
+  than `pr-str`-ing the whole deleted tree. Every descendant inside the
+  ghost **inherits `:removed`** via a nearest-removed-ancestor walk-down
+  (the symmetric of rf2-bufw2's `:added` inheritance) — never an
+  `:added` (green) or `:same` row. Maps slot removed keys by sort order;
+  vectors / lists / sets surface a removed index/member via the union
+  walk (a removed index shifts the survivors, so the dropped element is
+  marked by value/index, not by the now-occupied slot).
+
+> **Why the renderer cannot defer to the projection here.** The engine
+> anchors structurally-equivalent deletions in different channels — a
+> dissoc-to-`{}` lands on the surviving parent, a vector-tail deletion
+> lands in the off-path `:vector-removals` channel (no stable after-side
+> path), so `op-at` reports `:same` for the parent. The renderer
+> promotes any container whose `before` and `after` sides genuinely
+> differ but whose projection op reads `:same` to `:children` so the
+> union walk surfaces the struck-through removed slots. (rf2-8pfkk; the
+> fourth operator-honesty fix in the FULL+DIFF family.)
+
 ## Colour coding
 
 | Op | Visual |

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1710,7 +1710,8 @@
                                     zoom-path-prefix path)` so the
                                     zoom-slot stores the full path."
   [{:keys [value kind panel-id mount-id path depth expansion-map opts
-           dispatch-fn diff? before zoomable? zoom-path-prefix projection]}]
+           dispatch-fn diff? before zoomable? zoom-path-prefix projection
+           removed-ancestor?]}]
   (let [{:keys [default-expanded-depth max-depth max-inline-width
                 available-width-px]
          :or {default-expanded-depth default-ceiling-depth
@@ -1742,8 +1743,36 @@
         ;; engine's superset of `:same-shifted` / R7 / R8 nuances
         ;; unreachable from this call path).
         op            (cond
+                        ;; rf2-8pfkk — a removed-container ghost (and
+                        ;; every container inside it) is unconditionally
+                        ;; `:removed`. This MUST precede the projection
+                        ;; lookup: the engine anchors a `dissoc`-to-`{}`
+                        ;; on the surviving parent and classifies the
+                        ;; ghost's own path `:children`, which would
+                        ;; otherwise paint the deletion as a benign
+                        ;; descendant-change rail.
+                        removed-ancestor? :removed
+
                         (and diff? projection)
-                        (engine/op-at projection path)
+                        (let [proj-op (engine/op-at projection path)]
+                          ;; rf2-8pfkk — STRUCTURAL difference wins over a
+                          ;; `:same` projection. A pure vector / list tail
+                          ;; deletion routes through the engine's off-path
+                          ;; `:vector-removals` channel (it owns no stable
+                          ;; after-side path), so `op-at` reports `:same`
+                          ;; for the parent even though `before` ≠
+                          ;; `value`. Trusting that `:same` collapsed the
+                          ;; container and the dropped tail vanished. When
+                          ;; the two sides genuinely differ we promote to
+                          ;; `:children` so the container expands and the
+                          ;; `children-of-pair` union walk surfaces the
+                          ;; struck-through removed indices.
+                          (if (and (= :same proj-op)
+                                   (not= before missing-sentinel)
+                                   (not= value missing-sentinel)
+                                   (not= before value))
+                            :children
+                            proj-op))
 
                         (and diff? (or (= before missing-sentinel)
                                        (= value missing-sentinel)))
@@ -1761,12 +1790,22 @@
         ;; (where R5 chrome-opts are actually gated on them). The
         ;; duplicate container-level bindings were dead code and have
         ;; been removed; the container has no R5-specific behaviour.
+        ;; rf2-8pfkk — a removed-container ghost defaults to COLLAPSED:
+        ;; the deletion reads as a single struck-through summary line
+        ;; (`:shapes {…} (N keys)`), expandable on demand to walk the
+        ;; ghost. We therefore do NOT let its `:removed` op drive the
+        ;; force-open `has-changed-descendant?` rule — the change IS the
+        ;; node itself, not a buried descendant, so the collapsed
+        ;; summary already carries the full signal. The diff-mode
+        ;; collapse rule (`(zero? depth)`) then keeps every nested ghost
+        ;; level collapsed until the operator drills in.
         default?      (and (not depth-capped?)
                            (default-expanded?
                              {:depth                   depth
                               :child-count             cnt
                               :default-expanded-depth  default-expanded-depth
-                              :has-changed-descendant? has-change?
+                              :has-changed-descendant? (and has-change?
+                                                            (not removed-ancestor?))
                               :diff?                   diff?
                               :available-width-px      available-width-px
                               :value                   value}))
@@ -1846,10 +1885,28 @@
                           :line-height 1.4}}
                  zoom-attrs)
      ;; ---- header row ---------------------------------------------------
-     [:div {:style {:display "flex"
-                    :align-items "baseline"
-                    :gap "4px"
-                    :flex-wrap "wrap"}}
+     ;; rf2-8pfkk — a removed-container ghost paints the removed chrome
+     ;; (red wash + 2px red stripe + `−` gutter glyph + strike-through)
+     ;; at the HEADER level so the collapsed `:shapes {…} (N keys)` line
+     ;; reads as a single struck-through deletion, while the triangle
+     ;; stays clickable to walk the ghost. Reuses the same `:diff-
+     ;; removed-*` tokens as the leaf-level `gutter-row :removed`.
+     [:div {:data-rf-removed-ghost (when removed-ancestor? "1")
+            :style (cond-> {:display "flex"
+                            :align-items "baseline"
+                            :gap "4px"
+                            :flex-wrap "wrap"}
+                     removed-ancestor?
+                     (assoc :text-decoration "line-through"
+                            :padding-left "6px"
+                            :border-left (str "2px solid " (:diff-removed-stripe tokens))
+                            :background (:diff-removed-wash tokens)))}
+      (when removed-ancestor?
+        [:span {:data-rf-diff-op "removed"
+                :style (assoc gutter-glyph-base-style
+                              :color (:diff-gutter tokens)
+                              :text-decoration "none")}
+         "−"])
       (cond
         ;; Empty collection — show bracket pair flat, no toggle.
         empty?
@@ -2042,8 +2099,17 @@
                            ;; from "an existing key whose value changed"
                            ;; which paints on the value cell. Pulled off
                            ;; the projection's op at the child path.
-                           child-op (when (and diff? projection)
-                                      (engine/op-at projection child-path))
+                           ;; rf2-8pfkk — inside a removed ghost every
+                           ;; key is `:removed` (the projection's op at
+                           ;; the child path is not authoritative here —
+                           ;; see the `op` override above). Force the
+                           ;; removed key chrome + slot-anchored wash so
+                           ;; the whole row strikes through.
+                           child-op (cond
+                                      removed-ancestor?         :removed
+                                      (and diff? projection)
+                                      (engine/op-at projection child-path)
+                                      :else                     nil)
                            key-side-glyph (case child-op
                                             :added   "+"
                                             :removed "−"
@@ -2080,7 +2146,11 @@
                                          ;; cell here. The gutter glyph
                                          ;; + per-token text colour on
                                          ;; the value still render.
-                                         :slot-anchored? slot-anchored?})]
+                                         :slot-anchored? slot-anchored?
+                                         ;; rf2-8pfkk — propagate the
+                                         ;; ghost so nested containers /
+                                         ;; leaves keep the `:removed` op.
+                                         :removed-ancestor? removed-ancestor?})]
                        [(with-meta
                           ;; Key cell — uses `div` so the grid baseline
                           ;; aligns predictably across rows. `white-
@@ -2171,7 +2241,11 @@
                                        :dispatch-fn dispatch-fn
                                        :zoomable? zoomable?
                                        :zoom-path-prefix zoom-path-prefix
-                                       :opts opts})
+                                       :opts opts
+                                       ;; rf2-8pfkk — vector / set / list
+                                       ;; ghost members keep the `:removed`
+                                       ;; op down the subtree.
+                                       :removed-ancestor? removed-ancestor?})
                          {:key (str "v-" (pr-str k))})))
                    child-pairs)))))
 
@@ -2281,18 +2355,45 @@
   suppression, the inner wash overlaps the outer cell wash and the
   value half reads darker than the key half. Only the gutter glyph
   and per-token text colour remain on the leaf side."
-  [{:keys [value before diff? projection path slot-anchored?]}]
+  [{:keys [value before diff? projection path slot-anchored? removed-ancestor?]}]
   (if-not diff?
     (render-scalar value)
-    (let [;; Resolve op: prefer the projection at this path; else
-          ;; fall back to a 1-shot (before, after) op classification.
-          op (if projection
-               (engine/op-at projection (vec (or path [])))
-               (cond
-                 (= before ::missing) (if (= value ::missing) :same :added)
-                 (= value ::missing)  :removed
-                 (= before value)     :same
-                 :else                :modified))
+    (let [;; rf2-8pfkk — the STRUCTURAL sentinel is authoritative for
+          ;; one-sided slots, OVERRIDING the projection. A slot whose
+          ;; `value` is `::missing` does not exist in the after-tree —
+          ;; that is the definition of a removal, full stop; symmetric
+          ;; for `before` `::missing` (an addition). The projection's
+          ;; per-path op CANNOT be trusted to agree: the engine anchors
+          ;; a `dissoc`-to-`{}` as a `:children`/`:removed` op on the
+          ;; surviving PARENT path and leaves the removed child slot
+          ;; classified `:children` (it has its own `:container-ops`
+          ;; entry for the ghost subtree). Without this override the
+          ;; leaf fell through `case op`'s default branch and rendered
+          ;; `(render-scalar ::missing)` — leaking the internal sentinel
+          ;; keyword (`:day8…edn-inspector/missing`) into the output.
+          ;; `removed-ancestor?` carries the same force down a removed
+          ;; container ghost so every descendant reads `:removed` (the
+          ;; symmetric of rf2-bufw2's `:added` inheritance).
+          op (cond
+               removed-ancestor?    :removed
+               (= value ::missing)  :removed
+               (= before ::missing) (if (= value ::missing) :same :added)
+               projection           (engine/op-at projection (vec (or path [])))
+               (= before value)     :same
+               :else                :modified)
+          ;; rf2-8pfkk — the value actually painted is always the
+          ;; PRESENT side of the (before, value) pair. `::missing` is an
+          ;; internal absence marker, not a value, so it must never be
+          ;; handed to `render-scalar` (which would `pr-str` the sentinel
+          ;; keyword into the output). For a removal `value` is missing →
+          ;; paint `before`; for a ghost descendant `before` is missing →
+          ;; paint `value`. A pair with BOTH sides missing is structurally
+          ;; impossible (a slot exists in at least one side), so it falls
+          ;; back to `nil` rather than ever surfacing the sentinel.
+          present-value (cond
+                          (not= value ::missing)  value
+                          (not= before ::missing) before
+                          :else                   nil)
           ;; R5-tinted: descendant of wholly-changed root?
           wholly-anc (when projection
                        (engine/wholly-changed-ancestor projection (vec (or path []))))
@@ -2326,10 +2427,16 @@
                      (render-scalar value)]
                     chrome-opts)
         :removed
+        ;; The struck-through value is the PRESENT side: the BEFORE side
+        ;; for an ordinary removal (`value` is `::missing`), or the VALUE
+        ;; side when this leaf is a descendant of a removed container
+        ;; ghost (rf2-8pfkk — the ghost is threaded as `value` with
+        ;; `before` `::missing` so the union walk visits every removed
+        ;; descendant). `present-value` is sentinel-free by construction.
         (gutter-row :removed
                     [:span {:data-rf-diff-op "removed"
                             :style {:text-decoration "line-through"}}
-                     (render-scalar (if (= before ::missing) value before))]
+                     (render-scalar present-value)]
                     chrome-opts)
         :modified
         (gutter-row :modified
@@ -2378,7 +2485,7 @@
                             :style {:display "inline-flex"
                                     :align-items "baseline"
                                     :gap "8px"}}
-                     (render-scalar value)
+                     (render-scalar present-value)
                      ;; R6: `(was N)` muted suffix.
                      (when was-index
                        [:span {:data-rf-diff-was-index (str was-index)
@@ -2392,12 +2499,14 @@
         (gutter-row :same
                     [:span {:data-rf-diff-op "same"
                             :style {:color (:text-tertiary tokens)}}
-                     (render-scalar value)]
+                     (render-scalar present-value)]
                     chrome-opts)
         ;; Default — paint as :same so unknown ops degrade gracefully.
+        ;; `present-value` keeps the internal `::missing` sentinel out of
+        ;; the output even if an unexpected op ever reaches here.
         (gutter-row :same
                     [:span {:data-rf-diff-op (name op)}
-                     (render-scalar value)]
+                     (render-scalar present-value)]
                     chrome-opts)))))
 
 (defn render-node
@@ -2432,9 +2541,23 @@
   cells). Container values inside an added/removed slot already
   render via the recursive `render-container` path; that path paints
   no leaf-wash itself, so the flag only matters when the value bottoms
-  out at a scalar leaf."
+  out at a scalar leaf.
+
+  ## rf2-8pfkk — removed-container ghosts + `:removed-ancestor?`
+
+  A removed slot whose prior value is a CONTAINER renders as a single
+  collapsed struck-through ghost node (`:shapes {…} (N keys)`), reusing
+  the ordinary `render-container` collapse / expand / elision machinery
+  — the ghost is threaded as `value` (with `before` `::missing`) so the
+  existing union walk visits every removed descendant. `:removed-
+  ancestor?` is threaded down that ghost subtree so every descendant
+  reads `:removed` regardless of what the projection says about the
+  per-child path (the symmetric of rf2-bufw2's `:added` inheritance).
+  Without the ghost path a deleted subtree either `pr-str`'d in full
+  (unbounded verbosity) or leaked the `::missing` sentinel through the
+  leaf renderer's projection-trusting op resolution."
   [{:keys [value before diff? projection panel-id mount-id path depth expansion-map
-           dispatch-fn zoomable? zoom-path-prefix opts slot-anchored?]
+           dispatch-fn zoomable? zoom-path-prefix opts slot-anchored? removed-ancestor?]
     :or   {depth 0 path [] zoom-path-prefix []}}]
   (or
     ;; Protocol seam (rf2-0qrcr) — light-touch satisfies? gate; nil
@@ -2450,15 +2573,68 @@
                              :expansion-map expansion-map
                              :opts opts}))
     (cond
-      ;; Diff mode: removed slot — render the prior value struck-through.
-      ;; The `value` side is `::missing` but `before` carries the slot
-      ;; that's being removed. Always a leaf-shaped row (containers
-      ;; collapse to one removed line — operator follows the gutter, not
-      ;; the structure, for deletions).
+      ;; rf2-8pfkk — inside a removed container ghost. The `before` side
+      ;; was collapsed to `::missing` when we re-rooted the ghost as
+      ;; `value` (so `children-of-pair` enumerates the deleted subtree),
+      ;; but every node here is REMOVED, not added. `removed-ancestor?`
+      ;; takes precedence over the `before ::missing` → added rule below
+      ;; and forces the whole subtree through the removed render paths.
+      (and diff? removed-ancestor?)
+      (let [kind (collection-kind value)]
+        (if (container? kind)
+          (render-container {:value value
+                             :kind kind
+                             :panel-id panel-id
+                             :mount-id mount-id
+                             :path path
+                             :depth depth
+                             :expansion-map expansion-map
+                             :dispatch-fn dispatch-fn
+                             :zoomable? zoomable?
+                             :zoom-path-prefix zoom-path-prefix
+                             :opts opts
+                             :diff? true
+                             :before ::missing
+                             :projection projection
+                             :removed-ancestor? true})
+          (render-leaf-with-diff {:value value :before ::missing :diff? true
+                                  :projection projection :path path
+                                  :slot-anchored? slot-anchored?
+                                  :removed-ancestor? true})))
+
+      ;; Diff mode: removed slot — render the prior value struck-through
+      ;; IN PLACE (the universal diff idiom). The `value` side is
+      ;; `::missing`; `before` carries the slot being removed.
+      ;;
+      ;; rf2-8pfkk — a removed CONTAINER renders as a recursive ghost
+      ;; (one collapsed struck-through node, expandable to walk the
+      ;; deleted subtree) via `render-container`, NOT a flat
+      ;; `render-scalar` pr-str. The ghost is threaded as `value` with
+      ;; `before` `::missing` (so `children-of-pair` enumerates every
+      ;; removed descendant) plus `:removed-ancestor? true` (so the
+      ;; whole subtree inherits the `:removed` op via the branch above).
+      ;; A removed SCALAR still paints the single struck-through row.
       (and diff? (= value ::missing))
-      (render-leaf-with-diff {:value ::missing :before before :diff? true
-                              :projection projection :path path
-                              :slot-anchored? slot-anchored?})
+      (let [before-kind (collection-kind before)]
+        (if (container? before-kind)
+          (render-container {:value before
+                             :kind before-kind
+                             :panel-id panel-id
+                             :mount-id mount-id
+                             :path path
+                             :depth depth
+                             :expansion-map expansion-map
+                             :dispatch-fn dispatch-fn
+                             :zoomable? zoomable?
+                             :zoom-path-prefix zoom-path-prefix
+                             :opts opts
+                             :diff? true
+                             :before ::missing
+                             :projection projection
+                             :removed-ancestor? true})
+          (render-leaf-with-diff {:value ::missing :before before :diff? true
+                                  :projection projection :path path
+                                  :slot-anchored? slot-anchored?})))
 
       ;; Diff mode: added slot at a container → render the new
       ;; container in green via the normal recursive path with `op

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1462,6 +1462,146 @@
     (is (re-find #"line-through" s)
         "at least one row carries strike-through (the removed tag)")))
 
+;; =========================================================================
+;; rf2-8pfkk — the `::missing` sentinel must NEVER reach the output, and a
+;; removed CONTAINER renders as a struck-through collapsed ghost (not a
+;; flat pr-str, not the leaked sentinel keyword).
+;; =========================================================================
+;;
+;; These cases thread a REAL `engine/project` projection (the live render
+;; path) rather than the `projection nil` fallback the older diff tests
+;; use. The leak only surfaces with a projection in play: the engine
+;; anchors a `(update db :shapes dissoc :added)` deletion on the surviving
+;; parent (`op-at [:shapes]` → `:removed`) and classifies the removed
+;; child slot `:children` (`op-at [:shapes :added]` → `:children`, it owns
+;; the ghost subtree in `:container-ops`). Pre-fix the leaf renderer
+;; trusted that `:children` op, fell through `case op`'s default branch,
+;; and rendered `(render-scalar ::missing)` — leaking
+;; `:day8.re-frame2-xray.views.edn-inspector/missing` literally into the
+;; row (`:added ::missing`). The fix makes the structural sentinel
+;; authoritative and routes removed containers through a recursive ghost.
+
+(defn- no-missing-sentinel-leak?
+  "True iff the rendered hiccup carries no trace of the internal
+  `::missing` sentinel keyword in any string leaf OR attribute value.
+  The sentinel's `pr-str` is `:day8.re-frame2-xray.views.edn-
+  inspector/missing`; its `name` is the bare `\"missing\"`. We assert on
+  the broad `pr-str` of the whole tree so a leak anywhere (text, attr,
+  data-* marker) is caught."
+  [h]
+  (let [s (try (pr-str h) (catch :default _ ""))]
+    (not (re-find #"edn-inspector/missing" s))))
+
+(deftest diff-removed-only-key-renders-struck-ghost-not-sentinel
+  ;; Mike's live repro (standard_epochs button 7): `(update db :shapes
+  ;; dissoc :added)` removes the only key of `:shapes`, leaving `{}`.
+  ;; The removed `:added {…}` slot must render as a struck-through ghost,
+  ;; NEVER as `:added ::missing` and NEVER as `:shapes {} :same`.
+  (let [before {:shapes {:added {:label "added" :n 42}}}
+        after  {:shapes {}}
+        proj   (engine/project before after)
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :projection proj
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 6}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    ;; The engine genuinely misclassifies the child path — this pins the
+    ;; precondition so the test documents WHY the renderer cannot trust it.
+    (is (= :children (engine/op-at proj [:shapes :added]))
+        "precondition: engine anchors the removal on the parent, leaves the child :children")
+    (is (no-missing-sentinel-leak? h)
+        "the ::missing sentinel keyword must never reach the rendered output")
+    (is (not (re-find #":day8" all))
+        "no internal namespaced keyword leaks into the visible text")
+    (is (re-find #":added" all)
+        "the removed key :added still appears (struck-through ghost)")
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "the removed slot carries the removed diff-op marker")
+    (is (re-find #"line-through" s)
+        "the removed ghost is struck through")))
+
+(deftest diff-removed-container-renders-collapsed-ghost
+  ;; A removed nested map renders as ONE collapsed struck-through node
+  ;; (`{…} (N keys)` summary), reusing the ordinary collapse machinery —
+  ;; bounds verbosity rather than pr-str'ing the whole deleted subtree.
+  (let [before {:shapes {:added {:label "added" :n 42 :deep {:x 1 :y 2}}}}
+        after  {:shapes {}}
+        proj   (engine/project before after)
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :projection proj
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 6}})
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (no-missing-sentinel-leak? h)
+        "no sentinel leak even with a deeper ghost subtree")
+    ;; The ghost node is marked + collapsed by default.
+    (is (re-find #"data-rf-removed-ghost" s)
+        "the removed container renders as a marked ghost node")
+    (is (re-find #"data-rf-preview" s)
+        "the ghost defaults to a collapsed `{…N keys}` summary, not the full subtree")
+    (is (re-find #"line-through" s)
+        "the ghost line is struck through")))
+
+(deftest diff-deleted-ancestor-children-inherit-removed-when-expanded
+  ;; The deleted-ancestor hard case: when the operator EXPANDS a removed
+  ;; container ghost, every descendant inherits `:removed` (the symmetric
+  ;; of rf2-bufw2's `:added` inheritance) — never an `:added` (green) or
+  ;; `:same` row, and never a leaked sentinel.
+  (let [before {:shapes {:added {:label "added" :nested {:deep 1}}}}
+        after  {:shapes {}}
+        proj   (engine/project before after)
+        ;; Force the whole ghost subtree open via a sticky expansion
+        ;; override at the ghost path + its nested child.
+        expansion-map {(ei/expansion-key :p "m" [:shapes :added])         {:expanded? true}
+                       (ei/expansion-key :p "m" [:shapes :added :nested]) {:expanded? true}}
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :projection proj
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map expansion-map
+                           :opts {:default-expanded-depth 6}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (no-missing-sentinel-leak? h)
+        "no sentinel leak when the ghost subtree is walked")
+    (is (re-find #":deep" all)
+        "the deeply-nested ghost leaf is reachable on expand")
+    (is (not (re-find #"data-rf-diff-op.\"?added" s))
+        "no descendant of a removed subtree renders as :added (green) — all inherit :removed")
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "ghost descendants carry the removed marker")))
+
+(deftest diff-removed-vector-element-no-sentinel-leak
+  ;; A vector that loses its tail under a real projection must not leak
+  ;; the sentinel for the dropped indices.
+  (let [before {:xs [:a :b :c]}
+        after  {:xs [:a]}
+        proj   (engine/project before after)
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :projection proj
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 6}})
+        all (collect-text h)]
+    (is (no-missing-sentinel-leak? h)
+        "popped vector tail must not leak the ::missing sentinel")
+    (is (re-find #":b" all) "dropped element :b still appears struck-through")
+    (is (re-find #":c" all) "dropped element :c still appears struck-through")))
+
 (deftest diff-preserves-added-modified-same-rows
   ;; No regression — added / modified / same rows still render
   ;; alongside the new removed rows.

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -1757,6 +1757,22 @@ async function runLargeDispatcher(page, state) {
       appDbText: appDbText.slice(0, 1200),
     });
   }
+  // rf2-8pfkk — the edn-inspector's internal `::missing` absence
+  // sentinel (`:day8.re-frame2-xray.views.edn-inspector/missing`) must
+  // NEVER reach the rendered App-DB Diff. A removed slot renders as a
+  // struck-through ghost, not a literal sentinel keyword. The
+  // per-rendering removed-to-empty + deleted-ancestor cases are pinned
+  // exhaustively in the CLJS unit tests (`edn_inspector_cljs_test.cljs`
+  // — diff-removed-only-key-renders-struck-ghost-not-sentinel et al.,
+  // which thread a real `engine/project` projection); this is the
+  // browser-layer backstop on the live panel that the sentinel never
+  // escapes into the DOM under any dispatch sequence.
+  if (appDbText.includes('edn-inspector/missing')) {
+    failWithDetails('Internal ::missing sentinel leaked into App-DB Diff text (rf2-8pfkk)', {
+      traceCount: traceEvents.length,
+      appDbText: appDbText.slice(0, 1200),
+    });
+  }
   state.loadStats = {
     eventCountBefore: 0,
     eventCountAfter: traceEvents.length,


### PR DESCRIPTION
## What

The edn-inspector diff leaked its internal `::missing` absence sentinel (`:day8.re-frame2-xray.views.edn-inspector/missing`) into the rendered output. Closes **rf2-8pfkk**.

**Live repro (standard_epochs button 7):** `(update db :shapes dissoc :added)` removes the only key of `:shapes`, leaving `{}`.

```
before:  :shapes {:added {:label "added" :n 42}}
after:   :shapes {}
```

- **Before:** `:shapes` rendered `:added ::missing` (the internal sentinel keyword leaked as a literal value), with the removal otherwise invisible.
- **After:** `:shapes` renders as a container holding a collapsed, struck-through `:added {…} (N keys)` ghost — red wash + 2px red stripe + `−` gutter glyph + line-through. The internal sentinel never appears in the DOM. Expanding the ghost walks the deleted subtree; every descendant inherits `:removed`.

## Root cause

The Editscript engine anchors a dissoc-to-`{}` on the **surviving parent** (`op-at [:shapes]` → `:removed`/`:children`) and classifies the removed child slot `:children` (it owns the ghost subtree in `:container-ops`, so `op-at [:shapes :added]` → `:children`). `render-leaf-with-diff` trusted that projection op, fell through `case op`'s default branch, and rendered `(render-scalar ::missing)`.

## Fix — the structural sentinel is authoritative

The renderer no longer defers to the projection for one-sided slots; the structural fact wins:

1. **`render-leaf-with-diff`** resolves op from the sentinel first (`value ::missing` → `:removed`, `before ::missing` → `:added`) and paints a sentinel-free `present-value` (the present side of the pair) in every branch — bulletproof even in the structurally-impossible both-missing case.
2. **Removed containers render as a collapsed struck-through ghost.** Instead of `pr-str`-ing the whole deleted subtree (unbounded) or leaking the sentinel, a removed container is threaded as `value` (with `before ::missing`) through the ordinary `render-container` path plus a `:removed-ancestor?` flag. This reuses the existing collapse / expand / elision machinery — the ghost shows one `{…} (N keys)` summary line, expandable on demand.
3. **`:removed` inheritance (deleted-ancestor case).** `:removed-ancestor?` threads down the ghost subtree so every nested container + leaf reads `:removed` regardless of what the projection says about its per-child path — the symmetric of rf2-bufw2's `:added` inheritance. No descendant of a removal ever renders `:added` (green) or `:same`.
4. **Vector/set/list tail deletions** route through the engine's off-path `:vector-removals` channel, so `op-at` reports `:same` for the parent. A container whose before/after sides genuinely differ but whose projection op reads `:same` is promoted to `:children`, so the union walk surfaces the struck-through removed indices.

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` | **5095 tests / 17182 assertions, 0 failures** (incl. 4 new rf2-8pfkk diff cases) |
| `npm run test:bundle-isolation` | **PASS** — 35 internal sentinels absent, 3 budgets ok |
| `npm run test:xray-feature-gate` (nightly-full) | **16 scenarios, 0 failures, 13 matrix rows** |
| clj-kondo (changed source + test) | **0 errors, 0 warnings** |

### New diff tests (`edn_inspector_cljs_test.cljs`)

These thread a **real `engine/project` projection** — the only path that reproduces the leak (the older diff tests pass `projection nil` and hit the structural fallback that already handled the sentinel). A `no-missing-sentinel-leak?` helper asserts the broad `pr-str` of the tree carries no `edn-inspector/missing`.

- `diff-removed-only-key-renders-struck-ghost-not-sentinel` — the button-7 repro; pins the engine precondition (`op-at [:shapes :added]` = `:children`), asserts no sentinel/`:day8` leak, `:added` visible, removed marker + strike-through.
- `diff-removed-container-renders-collapsed-ghost` — the ghost defaults to a collapsed `{…N keys}` summary (`data-rf-removed-ghost` + `data-rf-preview`), not the full subtree.
- `diff-deleted-ancestor-children-inherit-removed-when-expanded` — on expand, the deeply-nested ghost leaf is reachable and **no** descendant renders `:added`.
- `diff-removed-vector-element-no-sentinel-leak` — popped vector tail surfaces struck-through `:b`/`:c` with no sentinel.

The feature_matrix `runLargeDispatcher` scenario gains a browser-layer backstop: the live App-DB Diff DOM must never contain `edn-inspector/missing`. (No new Playwright scenario — the per-rendering coverage lives in the CLJS unit tests per the Causa/Story = CLJS-unit-tests convention.)

### Spec

`tools/xray/spec/004-App-DB-Diff.md` documents the removed-slot rendering contract (structural-sentinel authority + collapsed ghost + `:removed` inheritance) as the fourth FULL+DIFF operator-honesty fix, alongside rf2-bufw2 / rf2-9d4j8 / rf2-fyd8u.