### PR TITLE
feat(pair): record / watch-until ops — first-class signal recorder for races + watch sessions (rf2-zo4b9)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -25,6 +25,9 @@ allowed-tools:
   - mcp__re-frame2-pair__snapshot
   - mcp__re-frame2-pair__get-path
   - mcp__re-frame2-pair__read-dom
+  - mcp__re-frame2-pair__record
+  - mcp__re-frame2-pair__read-recording
+  - mcp__re-frame2-pair__watch-until
   - mcp__re-frame2-pair__subscribe
   - mcp__re-frame2-pair__unsubscribe
   - mcp__re-frame2-pair__list-subscriptions

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -2251,6 +2251,348 @@
     {:ok? false :reason :no-element :selector selector}))
 
 ;; ---------------------------------------------------------------------------
+;; Signal recorder (rf2-zo4b9)
+;; ---------------------------------------------------------------------------
+;;
+;; Intermittent / human-in-the-loop bugs (the rf2-yng0y render-timing
+;; race, only reproducible under real mouse input) need a recorder:
+;; install an observer, let the human interact, read back a change-log.
+;; That move used to be hand-built each session — a `requestAnimationFrame`
+;; loop pushing focus-slot + DOM snapshots into `window.__zoombug`. It was
+;; decisive, but bespoke and footgun-prone: rAF timing, change-dedup,
+;; teardown. This first-classes it.
+;;
+;; A SIGNAL is a read-only sample of one observable: an app-db path, a
+;; subscription value, a DOM text/attribute read, or the currently-focused
+;; element. A RECORDING samples its signal-set every animation frame,
+;; records each CHANGE (per signal, structural `=` against the last value)
+;; with a timestamp + frame counter, and tears itself down at a STOP
+;; condition (after N ms, after N changes, or when a predicate over the
+;; current sample holds). The change-log is read back via `read-recording`.
+;;
+;; Footguns handled once, here:
+;;   - rAF timing      — the sampler runs inside the rAF callback, so it
+;;                       reads post-layout state once per paint and never
+;;                       busy-loops; environments without rAF fall back to
+;;                       `next-tick`.
+;;   - change-dedup    — only a structural change against the per-signal
+;;                       last value appends an entry. A signal that holds
+;;                       steady across 10,000 frames yields ONE baseline
+;;                       entry, not 10,000.
+;;   - teardown        — the rAF loop cancels itself the instant the stop
+;;                       condition trips, and `stop-recording!` is an
+;;                       idempotent manual escape hatch. A capped ring
+;;                       (`max-entries`, drop-oldest) bounds memory even if
+;;                       a recording is forgotten.
+;;
+;; Read-only by construction: every signal sampler only READS (get-in /
+;; subscribe-deref / querySelector text+attr / activeElement). A recording
+;; never dispatches, never mutates app-db, never writes the DOM.
+
+(defonce ^:private recordings
+  ;; recording-id -> recording map (see start-recording! for the shape)
+  (atom {}))
+
+(def ^:private default-recording-max-entries
+  ;; Drop-oldest ring cap on a single recording's change-log. Sized so a
+  ;; busy multi-signal session (focus + a handful of DOM/app-db signals,
+  ;; each flipping a few times a second over a minute) fits comfortably,
+  ;; while a forgotten recording can't accumulate unboundedly.
+  2000)
+
+(def ^:private default-recording-stop-ms
+  ;; Default wall-clock stop when the caller names no stop condition.
+  ;; 30 s is a generous "let me interact while you watch" window.
+  30000)
+
+(defn- sample-one-signal
+  "Read ONE signal's current value. Pure READ — never mutates. `signal`
+   is a map naming exactly one observable; the recognised shapes:
+
+     {:app-db <path-vector>}     — `(get-in app-db path)` for the frame.
+     {:sub <query-vector>}       — current deref of the subscription.
+     {:dom <css-selector>}       — the first matching node's textContent
+       [:attr <name>]              (string), or, with `:attr`, that
+                                    attribute's value. nil when no match.
+     {:focus true}               — a stable descriptor of
+                                    `document.activeElement` (tag + id +
+                                    a short data-/aria- attr digest) — the
+                                    focus-slot the hand-built recorder
+                                    tracked.
+
+   `frame-id` resolves the operating frame for :app-db / :sub signals.
+   Returns the sampled value (any EDN-able shape) or nil. Errors degrade
+   to `{:rf.recording/error <message>}` so one bad signal never collapses
+   the whole sampler tick."
+  [signal frame-id]
+  (try
+    (cond
+      (contains? signal :app-db)
+      (get-in (rf/get-frame-db frame-id) (vec (:app-db signal)))
+
+      (contains? signal :sub)
+      (when frame-id @(rf/subscribe frame-id (vec (:sub signal))))
+
+      (contains? signal :dom)
+      (when-let [el (.querySelector js/document (:dom signal))]
+        (if-let [a (:attr signal)]
+          (.getAttribute el (name a))
+          (let [t (.-textContent el)]
+            (when (string? t) t))))
+
+      (contains? signal :focus)
+      (when-let [el (and (exists? js/document) (.-activeElement js/document))]
+        ;; A stable, EDN-able descriptor — comparing whole DOM nodes by
+        ;; `=` is meaningless, so we project to the identity fields that
+        ;; actually change as focus moves.
+        {:tag   (some-> (.-tagName el) str/lower-case)
+         :id    (not-empty (.-id el))
+         :class (not-empty (.-className el))
+         :name  (not-empty (.getAttribute el "name"))
+         :rf2-src (some-> (.getAttribute el "data-rf2-source-coord"))})
+
+      :else
+      {:rf.recording/error "unrecognised signal shape — expected one of :app-db :sub :dom :focus"})
+    (catch :default e
+      {:rf.recording/error (.-message e)})))
+
+(defn sample-signals
+  "One-shot read of a signal-set against the operating frame — the pure,
+   non-installing counterpart to a recording tick. `signals` is a vector
+   of signal maps (see `sample-one-signal`). Returns
+   `{:ok? true :t <ms> :sample {<signal-index> <value>}}`. The MCP
+   `watch-until` op polls this server-side (like `tail-build`) so it can
+   block on a predicate without installing a rAF loop. The keys of
+   `:sample` are the signals' positional indices so the predicate can
+   address `(get sample 0)` regardless of signal shape."
+  ([signals] (sample-signals signals (current-frame)))
+  ([signals frame-id]
+   {:ok?    true
+    :t      (js/Date.now)
+    :sample (into {}
+                  (map-indexed (fn [i s] [i (sample-one-signal s frame-id)]))
+                  (vec signals))}))
+
+(defn- recording-sampler-tick!
+  "Run one sampler tick for recording `rid`: read every signal, append a
+   change entry for any signal whose value differs structurally from its
+   last-seen value, advance the frame counter, then evaluate the stop
+   condition. Returns true when the recording should KEEP running, false
+   when it should stop (the rAF driver reads this to self-cancel)."
+  [rid]
+  (let [rec (get @recordings rid)]
+    (if (or (nil? rec) (not= :recording (:status rec)))
+      false
+      (let [{:keys [signals frame-id last-values frame-count started-at
+                    stop max-entries]} rec
+            now      (js/Date.now)
+            samples  (mapv #(sample-one-signal % frame-id) signals)
+            ;; Per-signal change detection — structural `=` against the
+            ;; last recorded value. The first tick records every signal
+            ;; as a baseline (last-values starts empty for each index).
+            changes  (keep-indexed
+                       (fn [i v]
+                         (when (not= v (get last-values i ::unset))
+                           {:i i :signal (nth signals i) :value v
+                            :t now :frame frame-count}))
+                       samples)
+            new-last (reduce (fn [m {:keys [i value]}] (assoc m i value))
+                             last-values changes)
+            ;; Stop predicates evaluate against the positional sample map
+            ;; (same shape `sample-signals` returns) so a recording's stop
+            ;; predicate and a watch-until predicate read identically.
+            sample-map (into {} (map-indexed vector samples))
+            elapsed    (- now started-at)
+            n-changes  (+ (count (:entries rec)) (count changes))
+            pred-fn    (:pred-fn stop)
+            stop-hit?  (cond
+                         (and (:ms stop) (>= elapsed (:ms stop)))         :ms
+                         (and (:changes stop) (>= n-changes (:changes stop))) :changes
+                         (and pred-fn (try (pred-fn sample-map)
+                                           (catch :default _ false)))    :predicate
+                         :else nil)]
+        (swap! recordings update rid
+               (fn [r]
+                 (when r
+                   (let [entries' (into (:entries r) changes)
+                         ;; Drop-oldest ring cap — bounds memory on a
+                         ;; forgotten recording. Trims from the FRONT.
+                         capped   (let [n (count entries')]
+                                    (if (> n max-entries)
+                                      (subvec entries' (- n max-entries))
+                                      entries'))]
+                     (cond-> (assoc r
+                                    :entries     capped
+                                    :last-values new-last
+                                    :frame-count (inc frame-count)
+                                    :last-tick-at now)
+                       stop-hit? (assoc :status :stopped
+                                        :stopped-reason stop-hit?
+                                        :stopped-at now))))))
+        (not stop-hit?)))))
+
+(defn- drive-recording!
+  "Install the self-cancelling rAF (or next-tick) loop that runs the
+   sampler each frame until the stop condition trips. Stores the cancel
+   handle on the recording so `stop-recording!` can pre-empt it. The loop
+   reads `recording-sampler-tick!`'s boolean to decide whether to
+   reschedule — teardown is automatic and single-sourced."
+  [rid]
+  (let [raf?   (exists? js/requestAnimationFrame)
+        schedule (fn [f]
+                   (if raf?
+                     (js/requestAnimationFrame f)
+                     (interop/next-tick f)))]
+    (letfn [(step [_]
+              (when (recording-sampler-tick! rid)
+                (let [h (schedule step)]
+                  (swap! recordings update rid
+                         (fn [r] (when r (assoc r :raf-handle h)))))))]
+      (let [h (schedule step)]
+        (swap! recordings update rid
+               (fn [r] (when r (assoc r :raf-handle h))))))))
+
+(defn start-recording!
+  "Install a read-only observer over `signals` and begin recording each
+   CHANGE with a timestamp. Returns `{:ok? true :recording-id <uuid>
+   :signals [...] :stop {...} :frame <frame-id>}` immediately — the
+   recording runs in the background while the human interacts; read the
+   change-log back via `read-recording`.
+
+   Opts:
+     :signals  vector of signal maps (REQUIRED, non-empty). Each names
+               one observable — see `sample-one-signal` for the shapes
+               (:app-db / :sub / :dom / :focus).
+     :stop     stop condition map. Recognised keys (first to trip wins):
+                 :ms       wall-clock milliseconds (default 30000 when no
+                           stop key is supplied at all).
+                 :changes  total recorded change-entry count.
+                 :pred-fn  a 1-arg fn over the positional sample map
+                           `{<signal-index> <value>}`; truthy ⇒ stop. The
+                           MCP layer compiles a data predicate into this.
+     :frame    operating frame for :app-db / :sub signals. Defaults to the
+               session's operating frame.
+     :max-entries  drop-oldest ring cap on the change-log (default 2000).
+
+   Refuses with `{:ok? false :reason :no-signals}` when `signals` is
+   empty, and `{:ok? false :reason :ambiguous-frame}` when an :app-db /
+   :sub signal is present but no frame can be resolved (multi-frame
+   session, no selection) — read ops must not silently fall back to
+   :rf/default."
+  [{:keys [signals stop frame max-entries]}]
+  (let [signals  (vec signals)
+        needs-frame? (some #(or (contains? % :app-db) (contains? % :sub)) signals)
+        frame-id (current-frame frame)]
+    (cond
+      (empty? signals)
+      {:ok? false :reason :no-signals
+       :hint "pass a non-empty :signals vector, e.g. [{:focus true} {:dom \"#count\"} {:app-db [:cart :items]}]"}
+
+      (and needs-frame? (nil? frame-id))
+      {:ok? false :reason :ambiguous-frame
+       :hint "an :app-db / :sub signal needs a frame — pass :frame or call select-frame! first."}
+
+      :else
+      (let [rid (str "rec-" (random-uuid))
+            ;; Default the stop to a wall-clock window when the caller
+            ;; named nothing — a recording with no stop is the forgotten-
+            ;; observer footgun this op exists to kill.
+            stop' (if (and (nil? (:ms stop)) (nil? (:changes stop)) (nil? (:pred-fn stop)))
+                    (assoc stop :ms default-recording-stop-ms)
+                    stop)
+            rec  {:id          rid
+                  :signals     signals
+                  :frame-id    frame-id
+                  :stop        stop'
+                  :max-entries (or max-entries default-recording-max-entries)
+                  :status      :recording
+                  :entries     []
+                  :last-values {}
+                  :frame-count 0
+                  :started-at  (js/Date.now)
+                  :raf-handle  nil}]
+        (swap! recordings assoc rid rec)
+        (drive-recording! rid)
+        {:ok?          true
+         :recording-id rid
+         :signals      signals
+         :frame        frame-id
+         :stop         (dissoc stop' :pred-fn)}))))
+
+(defn read-recording
+  "Read back a recording's change-log. Returns
+   `{:ok? true :recording-id <id> :status :recording|:stopped
+     :stopped-reason <kw|nil> :frames-sampled <n> :count <n>
+     :entries [{:i <signal-index> :signal {...} :value <v> :t <ms>
+                :frame <frame-counter>} ...]}`.
+
+   Each entry is one CHANGE: the moment signal `:i` took a new value.
+   `:t` is the wall clock (ms); `:frame` is the rAF frame counter at the
+   sample, so two signals that changed on the same paint share a `:frame`.
+
+   Opts:
+     :drain   when true, returns the buffered entries AND clears them from
+              the recording (so the next read sees only subsequent
+              changes) — the live-watch idiom: poll, consume, repeat. The
+              recording keeps running (or stays stopped) either way.
+     :stop    when true, tears the recording down after reading (a
+              read-and-close in one round-trip).
+
+   Unknown id ⇒ `{:ok? false :reason :no-such-recording}`."
+  ([recording-id] (read-recording recording-id {}))
+  ([recording-id {:keys [drain stop]}]
+   (if-let [rec (get @recordings recording-id)]
+     (let [entries (:entries rec)
+           result  {:ok?            true
+                    :recording-id   recording-id
+                    :status         (:status rec)
+                    :stopped-reason (:stopped-reason rec)
+                    :frames-sampled (:frame-count rec)
+                    :count          (count entries)
+                    :entries        entries}]
+       (when drain
+         (swap! recordings update recording-id
+                (fn [r] (when r (assoc r :entries [])))))
+       (when stop
+         (some-> (get @recordings recording-id) :raf-handle
+                 (#(when (exists? js/cancelAnimationFrame)
+                     (js/cancelAnimationFrame %))))
+         (swap! recordings dissoc recording-id))
+       result)
+     {:ok? false :reason :no-such-recording :recording-id recording-id})))
+
+(defn stop-recording!
+  "Tear down recording `recording-id` — cancel its rAF loop and drop it
+   from the registry. Idempotent: an unknown / already-stopped id returns
+   `{:ok? true :existed? false}`. The recording's change-log is discarded;
+   read it with `read-recording` BEFORE stopping if you still need it."
+  [recording-id]
+  (let [rec (get @recordings recording-id)]
+    (when-let [h (:raf-handle rec)]
+      (when (exists? js/cancelAnimationFrame)
+        (js/cancelAnimationFrame h)))
+    (swap! recordings dissoc recording-id)
+    {:ok? true :recording-id recording-id :existed? (some? rec)}))
+
+(defn recording-info
+  "List active / stopped recordings — diagnostic counterpart to
+   `subscription-info`. Returns `{:ok? true :recordings [{:id :status
+   :signals :count :frames-sampled :frame :started-at :stopped-reason}]}`.
+   Does not drain or stop."
+  []
+  {:ok? true
+   :recordings (mapv (fn [[rid rec]]
+                       {:id             rid
+                        :status         (:status rec)
+                        :signals        (:signals rec)
+                        :count          (count (:entries rec))
+                        :frames-sampled (:frame-count rec)
+                        :frame          (:frame-id rec)
+                        :started-at     (:started-at rec)
+                        :stopped-reason (:stopped-reason rec)})
+                     @recordings)})
+
+;; ---------------------------------------------------------------------------
 ;; Watch predicate matching
 ;; ---------------------------------------------------------------------------
 ;;

--- a/skills/re-frame2-pair/tests/runtime/recorder_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/recorder_test.clj
@@ -1,0 +1,210 @@
+;;;; tests/runtime/recorder_test.clj
+;;;;
+;;;; Babashka-runnable structural verification of the signal recorder in
+;;;; `preload/re_frame2_pair/runtime.cljs` (rf2-zo4b9).
+;;;;
+;;;; Why a structural test rather than a runtime test:
+;;;;
+;;;; `preload/re_frame2_pair/runtime.cljs` is CLJS-only (loaded into the
+;;;; consumer app via shadow-cljs `:devtools :preloads`) and the recorder
+;;;; leans on `requestAnimationFrame` / `document.activeElement` /
+;;;; reactive subscriptions — none of which exist under bb. The MCP
+;;;; wire-shape contract is unit-tested at
+;;;; `tools/re-frame2-pair-mcp/test/.../record_test.cljs`; the LIVE rAF /
+;;;; dedup / teardown semantics are exercised by the form running in a
+;;;; real tab. What we pin HERE is the source-level contract that solves
+;;;; the three footguns the bead named, so a refactor can't silently drop
+;;;; one:
+;;;;
+;;;;   1. change-dedup — the sampler tick appends only on a structural
+;;;;      change against the per-signal last value (`not=` against
+;;;;      `last-values`), so a steady signal yields one baseline entry,
+;;;;      not one-per-frame.
+;;;;   2. teardown — the rAF driver self-cancels (reads the tick's boolean
+;;;;      to decide whether to reschedule) AND `stop-recording!` /
+;;;;      `read-recording {:stop true}` call `cancelAnimationFrame`.
+;;;;   3. rAF timing — the sampler runs inside `requestAnimationFrame`
+;;;;      (with a `next-tick` fallback when rAF is absent), never a busy
+;;;;      loop.
+;;;;
+;;;; Plus the load-bearing invariants:
+;;;;   - READ-ONLY: the recorder never dispatches / resets / writes the DOM.
+;;;;   - ring cap: a forgotten recording can't grow unboundedly.
+;;;;   - stop conditions: :ms / :changes / a predicate are all handled.
+;;;;
+;;;; Run: bb tests/runtime/recorder_test.clj
+;;;; Exit: 0 = pass, non-zero = fail.
+
+(ns recorder-test
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is run-tests testing]]
+            [clojure.walk :as walk]))
+
+(def ^:private runtime-cljs-path
+  (some (fn [p] (when (.exists (io/file p)) p))
+        ["preload/re_frame2_pair/runtime.cljs"
+         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
+         "../preload/re_frame2_pair/runtime.cljs"]))
+
+(when-not runtime-cljs-path
+  (binding [*out* *err*]
+    (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
+             (System/getProperty "user.dir")))
+  (System/exit 2))
+
+(defn- read-all-forms [^String src]
+  ;; CLJS-tolerant read: the recorder fns sit AFTER the streaming section,
+  ;; which uses `#js {...}` reader literals. Clojure's reader has no `js`
+  ;; tag, so without a default-data-reader the parse aborts mid-file and
+  ;; never reaches the recorder defns. A pass-through default reader keeps
+  ;; the parse going (we never evaluate the forms, only walk their shape).
+  (binding [*default-data-reader-fn* (fn [_tag v] v)]
+    (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
+      (loop [acc []]
+        (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
+                        (catch Exception _ ::eof))]
+          (if (= ::eof form) acc (recur (conj acc form))))))))
+
+(def ^:private src (slurp runtime-cljs-path))
+(def ^:private all-forms (read-all-forms src))
+
+(defn- defn-form [sym]
+  (some (fn [form]
+          (when (and (seq? form)
+                     (#{'defn 'defn-} (first form))
+                     (= sym (second form)))
+            form))
+        all-forms))
+
+(defn- form-contains? [pred form]
+  (let [hit? (atom false)]
+    (walk/postwalk (fn [x] (when (pred x) (reset! hit? true)) x) form)
+    @hit?))
+
+(defn- mentions-sym? [form needle]
+  (form-contains? #(= % needle) form))
+
+;; ---------------------------------------------------------------------------
+;; The recorder fns must all exist.
+;; ---------------------------------------------------------------------------
+
+(deftest recorder-fns-defined
+  (doseq [sym '[sample-one-signal sample-signals start-recording!
+                read-recording stop-recording! recording-info]]
+    (is (some? (defn-form sym))
+        (str "recorder fn " sym " must be defined in runtime.cljs"))))
+
+;; ---------------------------------------------------------------------------
+;; Footgun #1 — change-dedup. The sampler tick appends only on a change
+;; against the per-signal last value.
+;; ---------------------------------------------------------------------------
+
+(deftest sampler-tick-dedups-against-last-values
+  (let [form (defn-form 'recording-sampler-tick!)]
+    (is (some? form))
+    (is (mentions-sym? form 'last-values)
+        "tick must compare against the per-signal last-values map (dedup)")
+    (is (mentions-sym? form 'not=)
+        "tick must use structural not= to detect a change")
+    (is (mentions-sym? form 'keep-indexed)
+        "tick must only emit entries for signals that actually changed")))
+
+;; ---------------------------------------------------------------------------
+;; Footgun #2 — teardown. The driver self-cancels; stop paths cancel rAF.
+;; ---------------------------------------------------------------------------
+
+(deftest driver-self-cancels-on-stop
+  (let [drive (defn-form 'drive-recording!)
+        tick  (defn-form 'recording-sampler-tick!)]
+    (is (some? drive))
+    ;; The driver reschedules only when the tick says keep-running — the
+    ;; tick returns false at the stop condition, so the loop ends itself.
+    (is (mentions-sym? drive 'recording-sampler-tick!)
+        "driver must read the tick's keep-running boolean")
+    (is (form-contains? #(= % :stopped) tick)
+        "tick must flip status to :stopped at the stop condition")))
+
+(deftest stop-paths-cancel-raf
+  (let [stop-fn (defn-form 'stop-recording!)
+        read-fn (defn-form 'read-recording)]
+    (is (mentions-sym? stop-fn 'js/cancelAnimationFrame)
+        "stop-recording! must cancel the rAF loop")
+    (is (mentions-sym? read-fn 'js/cancelAnimationFrame)
+        "read-recording {:stop true} must cancel the rAF loop")
+    (is (mentions-sym? stop-fn 'swap!)
+        "stop-recording! must drop the recording from the registry")))
+
+;; ---------------------------------------------------------------------------
+;; Footgun #3 — rAF timing. The driver schedules via requestAnimationFrame
+;; with a next-tick fallback; it does not busy-loop.
+;; ---------------------------------------------------------------------------
+
+(deftest driver-uses-raf-with-fallback
+  (let [drive (defn-form 'drive-recording!)]
+    (is (mentions-sym? drive 'js/requestAnimationFrame)
+        "driver must sample on requestAnimationFrame")
+    (is (form-contains? #(and (symbol? %)
+                              (str/includes? (str %) "next-tick"))
+                        drive)
+        "driver must fall back to next-tick when rAF is absent")))
+
+;; ---------------------------------------------------------------------------
+;; Ring cap — a forgotten recording can't grow unboundedly.
+;; ---------------------------------------------------------------------------
+
+(deftest sampler-tick-applies-ring-cap
+  (let [tick (defn-form 'recording-sampler-tick!)]
+    (is (mentions-sym? tick 'max-entries)
+        "tick must honour the max-entries cap")
+    (is (mentions-sym? tick 'subvec)
+        "tick must trim from the front (drop-oldest) when over the cap")))
+
+;; ---------------------------------------------------------------------------
+;; Stop conditions — :ms, :changes, and a predicate are all evaluated.
+;; ---------------------------------------------------------------------------
+
+(deftest sampler-tick-evaluates-all-stop-conditions
+  (let [tick (defn-form 'recording-sampler-tick!)]
+    (is (form-contains? #(= % :ms) tick) ":ms stop condition handled")
+    (is (form-contains? #(= % :changes) tick) ":changes stop condition handled")
+    (is (mentions-sym? tick 'pred-fn) "predicate stop condition handled")))
+
+(deftest start-recording-defaults-a-stop-window
+  (let [start (defn-form 'start-recording!)]
+    ;; A recording with no stop is the forgotten-observer footgun — the
+    ;; runtime must default to a wall-clock window.
+    (is (mentions-sym? start 'default-recording-stop-ms)
+        "start-recording! must default a wall-clock stop when none given")
+    (is (form-contains? #(= % :no-signals) start)
+        "start-recording! must refuse an empty signal-set")
+    (is (form-contains? #(= % :ambiguous-frame) start)
+        "start-recording! must refuse an unresolvable frame for app-db/sub signals")))
+
+;; ---------------------------------------------------------------------------
+;; READ-ONLY invariant — the recorder must never mutate the app.
+;; ---------------------------------------------------------------------------
+
+(deftest recorder-source-is-read-only
+  ;; Scope the scan to the recorder fns (the whole file naturally mentions
+  ;; dispatch / reset elsewhere). Concatenate their source and assert no
+  ;; mutation host-forms appear.
+  (let [recorder-src
+        (->> '[sample-one-signal sample-signals recording-sampler-tick!
+               drive-recording! start-recording! read-recording
+               stop-recording! recording-info]
+             (map defn-form)
+             (map pr-str)
+             (str/join "\n"))]
+    (doseq [mutator ["pair-dispatch" "reset-frame-db!" "app-db-reset!"
+                     ".dispatchEvent" ".setAttribute" "restore-epoch"
+                     ".innerHTML"]]
+      (is (not (str/includes? recorder-src mutator))
+          (str "recorder must be read-only — found mutator " mutator)))
+    (testing "the signal samplers DO read"
+      (is (str/includes? recorder-src "get-frame-db") "reads app-db")
+      (is (str/includes? recorder-src "querySelector") "reads the DOM")
+      (is (str/includes? recorder-src "activeElement") "reads focus"))))
+
+(let [{:keys [fail error]} (run-tests 'recorder-test)]
+  (System/exit (if (pos? (+ fail error)) 1 0)))

--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -47,7 +47,8 @@ covers the catalogue surface.
 | **`record-as-<thing>`** | Capture user / agent activity for a bounded duration; emit as an artefact (variant snippet, etc.). | `record-as-variant` | The bridge between live dispatches and the persisted registry. Story-mcp only today. |
 | **`subscribe` / `unsubscribe`** | Streaming pair. Bare verbs, used by re-frame2-pair-mcp. `subscribe` returns one `notifications/progress` per matching batch; `unsubscribe` closes out-of-band. | `subscribe`, `unsubscribe` | Topic vocabulary is per-server (re-frame2-pair ships `:trace` / `:epoch` / `:fx` / `:error`). Story-mcp does not ship streaming. |
 | **`tail-<thing>`** | Wait for an external state change to land. Polls until a probe condition flips or `wait-ms` expires. | `tail-build` | Today only `tail-build` exists (await hot-reload). Future variants (`tail-test`, `tail-deploy`) take the same shape: integer wait, probe form, structured timeout. |
-| **Mega-op bare verbs** | Reserved for derived projections / multi-registry reads that don't fit `get-<thing>`. Bare names, no prefix. | `snapshot`, `trace-window`, `watch-epochs` | These are re-frame2-pair-mcp's coarse-grained reads that span multiple registry kinds (`snapshot` covers app-db + sub-cache + machines + epochs + traces in one round-trip; `trace-window` and `watch-epochs` page over the trace bus). Adding a new bare verb requires a Lock entry in the relevant server's `DESIGN-RATIONALE.md`. |
+| **`watch-<thing>`** | Block until a predicate over a live signal holds, or time out. Distinct from `tail-` (which awaits an EXTERNAL state change via a probe-value delta) — `watch-` blocks on a PREDICATE over an in-runtime signal-set (app-db / sub / DOM / focus). | `watch-until` | Added by rf2-zo4b9 (re-frame2-pair). `watch-epochs` predates the prefix and stays on the bare-verb list (its semantics are pull-mode pagination, not blocking-until). The server-side poll cadence mirrors `tail-build`. |
+| **Mega-op bare verbs** | Reserved for derived projections / multi-registry reads that don't fit `get-<thing>`. Bare names, no prefix. | `snapshot`, `trace-window`, `watch-epochs`, `record` | These are re-frame2-pair-mcp's coarse-grained reads / recorders that span multiple registry kinds (`snapshot` covers app-db + sub-cache + machines + epochs + traces in one round-trip; `trace-window` and `watch-epochs` page over the trace bus; `record` (rf2-zo4b9) installs a read-only change-log observer over a heterogeneous signal-set — app-db / sub / DOM / focus). Adding a new bare verb requires a Lock entry in the relevant server's `DESIGN-RATIONALE.md`. NOTE the contrast with the `record-as-<thing>` PREFIX (story-mcp's `record-as-variant`, capture-as-artefact): bare `record` is the live recorder, `record-as-` persists a captured artefact. |
 
 ## What's NOT a locked verb
 
@@ -65,8 +66,11 @@ out in PR review and pick from the table above instead.
   escape hatch; bare-name dispatch is the catalogued event-fire. Don't
   bypass them.
 - **`stream-`, `observe-`, `tail-trace`** — `subscribe` / `unsubscribe`
-  is the catalogued streaming pair. `tail-` is reserved for state-
-  change-await semantics (one-shot, returns when condition trips).
+  is the catalogued streaming pair. `tail-` is reserved for external-
+  state-change-await semantics (one-shot, returns when a probe-value
+  delta trips); `watch-` (rf2-zo4b9) is reserved for blocking on a
+  PREDICATE over an in-runtime signal-set. Continuous change-logging of
+  a signal-set is `record` (rf2-zo4b9), not `observe-`.
 
 ## Server alignment today
 
@@ -102,6 +106,10 @@ counts" below.)
 | `get-re-frame2-pair-instructions` | `get-` | Conformant — single-record read of the agent-onboarding instructions blob (rf2-fnpqg). Mirrors story-mcp's `get-story-instructions`. |
 | `restore-epoch` | `restore-` | Conformant — time-travel state restore. Gated behind `--allow-writes` (default OFF). Added by rf2-ee38b.18. |
 | `reset-frame-db` | `reset-` | Conformant — state injection, bypassing the normal cascade. Gated behind `--allow-writes` (default OFF). Added by rf2-ee38b.18. |
+| `read-dom` | `read-` | Conformant — diagnostic re-read of rendered DOM content (no recompute; the render already happened). Added by rf2-nfjil. |
+| `record` | bare (mega-op) | Conformant — bare-verb signal recorder spanning app-db / sub / DOM / focus. Lock entry in `DESIGN-RATIONALE.md`. Distinct from the `record-as-` prefix (capture-as-artefact). Added by rf2-zo4b9. |
+| `read-recording` | `read-` | Conformant — diagnostic re-read of a recording's change-log (paired with `record`). Added by rf2-zo4b9. |
+| `watch-until` | `watch-` | Conformant — blocks until a predicate over a signal holds. New `watch-` prefix; Lock entry in `DESIGN-RATIONALE.md`. Added by rf2-zo4b9. |
 
 ### Story-mcp
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/verb_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/verb_vocab_test.clj
@@ -68,12 +68,18 @@
     "explain"     ; rf2-ba86n.17 — `explain-variant` (story-mcp; the agent
                   ; mirror of the human Explain panel over `story/explain`)
     "record-as"
+    "watch"       ; rf2-zo4b9 — `watch-<until>` blocking watch family
+                  ; (re-frame2-pair; block until a predicate over a signal
+                  ; holds). Generalises the `watch-epochs` bare verb into a
+                  ; prefix; `watch-epochs` stays on the bare-verb allowlist
+                  ; below to avoid churn.
     "tail"})
 
 (def ^:private bare-verbs
   "Catalogued bare-verb tool names from NAMING.md §The verb table
   (`dispatch`, `eval-cljs`, `subscribe` / `unsubscribe`) plus the
-  mega-op bare verbs (`snapshot`, `trace-window`, `watch-epochs`)."
+  mega-op bare verbs (`snapshot`, `trace-window`, `watch-epochs`,
+  `record`)."
   #{"dispatch"
     "dispatch-dry-run"  ; sibling of `dispatch` (rf2-ee38b.18 dry-run gate)
     "eval-cljs"
@@ -81,7 +87,12 @@
     "unsubscribe"
     "snapshot"
     "trace-window"
-    "watch-epochs"})
+    "watch-epochs"
+    "record"})          ; rf2-zo4b9 — bare-verb mega-op signal recorder
+                        ; (re-frame2-pair; spans app-db / sub / DOM / focus
+                        ; signals). Distinct from the `record-as-` prefix
+                        ; (capture-as-artefact); `record` installs a live
+                        ; change-log observer.
 
 (def ^:private bare-noun-exceptions
   "Bare-noun reads catalogued in NAMING.md §Server alignment today as

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -6,14 +6,17 @@
 > `register-epoch-listener!`, `restore-epoch`, `reset-frame-db!`,
 > `dispatch`, `dispatch-sync`).
 
-The eighteen MCP tools. All eighteen are catalogued below; the
+The twenty-two MCP tools. All twenty-two are catalogued below; the
 registrar-introspection pair `handler-meta` + `list-handlers` (rf2-cibp8
 / rf2-pctf8 — `list-handlers` renamed from `registry-list` per
 rf2-4y595 for NAMING.md `list-<things>` conformance), the write pair
 `restore-epoch` + `reset-frame-db` (rf2-ee38b.18 — the Tool-Pair
 time-travel + state-injection primitives, gated behind `--allow-writes`),
-and `dispatch-dry-run` (rf2-17hvp — simulate a cascade without
-committing) live in the live registry at
+`dispatch-dry-run` (rf2-17hvp — simulate a cascade without
+committing), the view-plane read `read-dom` (rf2-nfjil), and the signal
+recorder `record` + `read-recording` + `watch-until` (rf2-zo4b9 — the
+first-class recorder for races + watch sessions) live in the live
+registry at
 [`src/re_frame2_pair_mcp/tools/registry.cljs`](../src/re_frame2_pair_mcp/tools/registry.cljs)
 and have full per-tool sections here.
 
@@ -1602,6 +1605,136 @@ nREPL round-trip);
 `js/document` (headless / server-side);
 `:reason :runtime-not-preloaded` if the preload hasn't run;
 `:reason :read-dom-failed` (with `:message`) on any other failure.
+
+## record
+
+First-class **signal recorder** (rf2-zo4b9) — the canonical move for
+intermittent / human-in-the-loop bugs (the rf2-yng0y render-timing
+race, only reproducible under real mouse input): install a read-only
+observer over a heterogeneous signal-set, let the human interact, read
+the change-log back via `read-recording`. Pre-bead this was hand-built
+each session (a `requestAnimationFrame` loop pushing focus + DOM into
+`window.__zoombug`) — decisive but bespoke and footgun-prone. `record`
+first-classes the rAF/dedup/teardown machinery in the runtime.
+
+`record` **returns immediately** with a `:recording-id`; the recording
+runs in the background. The runtime samples every signal once per
+animation frame, records each **change** (structural `=` against the
+last value) with a `:t` timestamp + a rAF `:frame` counter, **dedups**
+(a steady signal yields one baseline entry, not one-per-frame), and
+**tears itself down** at the stop condition. A `requestAnimationFrame`-
+absent target (headless / SSR) falls back to `next-tick`; a drop-oldest
+ring (`max-entries`, default 2000) bounds memory on a forgotten
+recording.
+
+A bare-verb **mega-op** (NAMING.md Lock #8) — like `snapshot`, it spans
+multiple observable kinds. Distinct from the `record-as-` prefix
+(story-mcp's capture-as-artefact); bare `record` installs a live
+change-log observer.
+
+**Read-only by construction.** Every signal sampler only reads (`get-in`
+/ subscribe-deref / `querySelector` text+attr / `activeElement`) — a
+recording never dispatches, never mutates app-db, never writes the DOM.
+
+**Signal shapes** (each a map naming one observable):
+
+| Signal | Samples |
+|---|---|
+| `{:app-db [path]}` | `(get-in app-db path)` for the frame |
+| `{:sub [query-v]}` | current deref of the subscription |
+| `{:dom "sel"}` / `{:dom "sel" :attr "name"}` | first matching node's `textContent`, or that attribute |
+| `{:focus true}` | a stable descriptor of `document.activeElement` (`:tag` / `:id` / `:class` / `:name` / `:rf2-src`) — the focus-slot |
+
+**Stop condition** (`stop` arg; first key to trip wins; defaults to
+`{:ms 30000}` when omitted): `:ms` (wall-clock), `:changes` (total
+change-entry count), `:pred` (a **data** predicate map over the
+positional sample map `{<signal-index> <value>}` — compiled to a pure
+value-comparison fn, no host source crosses the wire; same shapes as
+`watch-until`'s `pred`, below).
+
+**Args**: `signals` (vector of signal maps / one bare signal map; EDN
+string or JSON array; required, non-empty), `stop` (map; JSON object or
+EDN string), `max-entries` (integer, default 2000), `frame` (string —
+operating frame for `:app-db` / `:sub` signals), `build` (string).
+
+**Returns**: `{:ok? true :recording-id "rec-<uuid>" :signals [...]
+:frame <id> :stop {...}}`. `:reason :no-signals` when `signals` is empty;
+`:reason :ambiguous-frame` when an `:app-db` / `:sub` signal needs a
+frame but none resolves (multi-frame session, no selection).
+
+## read-recording
+
+Read back a recording's change-log (rf2-zo4b9) — the diagnostic re-read
+paired with `record`, under the catalogued `read-<thing>` verb.
+
+**Args**: `recording-id` (string, required), `drain` (boolean, default
+false — return the buffered change-entries **and clear them**, so the
+next read sees only subsequent changes: the poll→consume→repeat
+live-watch idiom; the recording keeps running either way), `stop`
+(boolean, default false — tear the recording down after reading:
+read-and-close in one round-trip), `build` (string).
+
+**Returns**:
+
+```clojure
+{:ok?            true
+ :recording-id   "rec-<uuid>"
+ :status         :recording           ; or :stopped
+ :stopped-reason :ms                  ; :ms / :changes / :predicate / nil
+ :frames-sampled 900                  ; rAF ticks since start
+ :count          3
+ :entries [{:i 0 :signal {:focus true}        ; one entry per CHANGE
+            :value {:tag "input" :id "q"}
+            :t 1712... :frame 0}              ; :frame = rAF counter
+           ...]}
+```
+
+Each entry is one **change** — the moment signal `:i` took a new value.
+Two signals that changed on the same paint share a `:frame`.
+`:reason :missing-recording-id` if omitted/blank; `:reason
+:no-such-recording` for an unknown id.
+
+## watch-until
+
+Block until a predicate over a signal holds (rf2-zo4b9) — the
+**blocking** counterpart to `record` ("wait until focus lands on the
+modal" / "wait until `[:upload :status]` flips to `:done`"). Introduces
+the `watch-<thing>` prefix (NAMING.md Lock #8): distinct from `tail-`
+(which awaits an *external* state change via a probe-value delta),
+`watch-` blocks on a **predicate over an in-runtime signal-set**.
+
+Like `tail-build`, the server polls a cheap runtime read on a fixed
+cadence (~100 ms) until the condition trips or `timeout-ms` (default
+30000) elapses — no rAF loop, no browser-side mailbox. Each poll evals
+one form that samples the signal-set (`sample-signals`) and applies the
+compiled predicate **server-side**, returning `{:held? bool :sample {...}
+:t <ms>}`.
+
+**Signals** use the same vocabulary as `record`. **`pred`** is a **data**
+predicate map (no host source crosses the wire; same injection-closing
+posture as `dispatch` / `reset-frame-db`), matched against the positional
+sample map `{<signal-index> <value>}`:
+
+| Predicate | Holds when |
+|---|---|
+| `{:signal 0 :equals <v>}` | sample 0 equals `<v>` |
+| `{:signal 0 :changed true}` | sample 0 is non-nil |
+| `{:signal 0 :path [...] :equals <v>}` | `(get-in (sample 0) path)` equals `<v>` |
+| `{:signal 0 :contains <substr>}` | `(str (sample 0))` includes `<substr>` |
+| `{:signal 0}` | sample 0 took any non-nil value |
+
+**Read-only by construction** — the runtime sampler only reads.
+
+**Args**: `signals` (required, non-empty), `pred` (required — without one
+the watch can only time out), `timeout-ms` (integer, default 30000),
+`frame` (string), `build` (string).
+
+**Returns** on the first poll where the predicate holds: `{:ok? true
+:held? true :elapsed-ms <n> :sample {<i> <v>} :t <ms>}`. On timeout:
+`{:ok? false :reason :watch-timeout :timed-out? true :timeout-ms <n>
+:last-sample {...}}` — `:last-sample` is the final reading, to see how
+close the condition got. `:reason :no-signals` / `:reason :missing-pred`
+on the respective omission.
 
 ## subscribe
 

--- a/tools/re-frame2-pair-mcp/spec/API.md
+++ b/tools/re-frame2-pair-mcp/spec/API.md
@@ -201,9 +201,9 @@ node out/server.js
 
 ## Tool surface
 
-The eighteen tools, in the order a typical session uses them. Argument
-schemas and result shapes are specified in
-[`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md).
+The full tool surface, in the order a typical session uses them
+(canonical count: [`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md)).
+Argument schemas and result shapes are specified there.
 
 | Tool | Purpose |
 |---|---|
@@ -218,6 +218,9 @@ schemas and result shapes are specified in
 | `snapshot`   | Coarse-grained per-frame state read in one round-trip. Returns `:app-db` + `:sub-cache` + `:machines` + `:epochs` + `:traces` slices for every (or a subset of) frame(s). Mega-op for investigate-X workflows. |
 | `get-path` | Direct slice read at a path inside `app-db`. The deep-read peer of `snapshot`; agents drill in once a `:rf.mcp/summary` or elision marker names the path of interest. |
 | `read-dom` | View-plane read — query the **rendered DOM** by CSS selector; returns matched count + per-node `{:tag :text :attrs}` as EDN (rf2-nfjil). Read-only; per-node text + matched-node count capped browser-side (over-cap text → `:rf.size/large-elided` marker). Optional `sub-selector` scopes to descendants of each match; `attrs` picks attributes (default: structural set + `data-*` / `aria-*` sweep). Answers "did the UI update?" / "what does the rendered node say?". Pairs with `dispatch {:await-render true}` for deterministic `dispatch → settle → read`. |
+| `record` | First-class **signal recorder** (rf2-zo4b9) — install a read-only observer over a signal-set (`:app-db [path]` / `:sub [query-v]` / `:dom "sel"` / `:focus true`) with a stop condition (`:ms` / `:changes` / `:pred`), let the human interact, then read the change-log back. Returns immediately with a `:recording-id`; the runtime samples each signal per animation frame, records each change with a timestamp, dedups, and tears itself down at the stop condition — the rAF/dedup/teardown footguns solved once. The canonical move for intermittent / human-in-the-loop bugs (the rf2-yng0y render-timing race). |
+| `read-recording` | Read back a recording's change-log (rf2-zo4b9) — paired with `record`. `drain true` consumes the buffered entries (the live-watch poll→consume→repeat idiom); `stop true` reads-and-closes. Returns `:status` + per-change `:entries` with `:t` timestamps + rAF `:frame` counters. |
+| `watch-until` | Block until a **predicate over a signal holds** (rf2-zo4b9) — the blocking counterpart to `record` ("wait until `[:upload :status]` flips to `:done`"). Server-polls (~100 ms, like `tail-build`) until the data predicate (`{:signal 0 :equals <v>}` / `:changed` / `:path` / `:contains`) holds or `timeout-ms` elapses. Returns the satisfying `:sample`, or `:reason :watch-timeout` with the final `:last-sample`. |
 | `subscribe` | Streaming subscription on the trace / epoch bus (rf2-hq49). Push-mode replacement for `watch-epochs`; each matching event arrives as a `notifications/progress` notification. Topics: `trace`, `epoch`, `fx`, `error`. |
 | `unsubscribe` | Close a streaming subscription out-of-band. Idempotent. |
 | `list-subscriptions` | List the **live reactive sub-cache** for a frame — "what subscriptions are active?" — reading the same source as `snapshot :sub-cache` (rf2-qicji). Returns the cached query-vectors (reflecting disposal); optional `include-values` adds value + ref-count. |

--- a/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
@@ -309,6 +309,24 @@ Post-Lock additions accumulated as follows:
   `re-frame2-pair.runtime` registrar primitives (and `(rf/machines)`
   for the `:machine` kind per Spec 005 §Querying machines); both are
   `:cacheable? true` since the registrar is stable across a session.
+- **rf2-zo4b9** added the **signal recorder** triplet — `record`,
+  `read-recording`, `watch-until`. The canonical move for intermittent
+  / human-in-the-loop bugs (the rf2-yng0y render-timing race, only
+  reproducible under real mouse input): install a read-only observer
+  over a heterogeneous signal-set (app-db path / sub value / DOM
+  query / focus-slot), let the human interact, read the change-log
+  back. Pre-bead this was hand-built each session (a `requestAnimationFrame`
+  loop pushing focus + DOM into `window.__zoombug`) — decisive but
+  bespoke and footgun-prone (rAF timing, change-dedup, teardown). The
+  rAF/dedup/teardown machinery is first-classed in
+  `re-frame2-pair.runtime` (`start-recording!` / `read-recording` /
+  `stop-recording!` / `sample-signals`); the three tools own only the
+  wire shape + the data→predicate compile. `record` is a bare-verb
+  mega-op (a recorder spanning multiple signal kinds — see Lock #8);
+  `read-recording` rides the `read-` prefix; `watch-until` introduces
+  the `watch-` blocking-predicate prefix (Lock #8). All three are
+  read-only observation (no app mutation) and `:cacheable? false` (the
+  recording state is volatile, not a function of an app-db hash).
 
 ---
 
@@ -555,6 +573,72 @@ that the principle alone doesn't carry.
 
 ---
 
+## Lock #8 — Recorder verb shapes (`record` bare, `watch-` prefix)
+
+**Locked 2026-05-31 (rf2-zo4b9).** **`record` is a bare-verb mega-op;
+`watch-until` introduces a `watch-` blocking-predicate prefix.**
+`read-recording` rides the existing `read-` prefix (no new verb).
+
+### Question
+
+The signal-recorder triplet needs three tool names. `read-recording`
+fits the catalogued `read-` prefix (diagnostic re-read of recorded
+state) cleanly. But the recorder-installer and the blocking-watch op
+have no catalogued home: a bare `record` is NOT catalogued (only the
+`record-as-<thing>` PREFIX exists, for capture-as-artefact), and
+`watch-` is NOT a prefix (only `watch-epochs` sits on the bare-verb
+allowlist). What verbs do they take?
+
+### Options considered
+
+- **`record` bare + `watch-until` under a new `watch-` prefix** (the
+  pick). `record` joins the mega-op bare verbs alongside `snapshot` /
+  `trace-window` / `watch-epochs`; `watch-` becomes a locked prefix
+  for blocking-on-a-predicate.
+- **`record-as-recording` + `watch-epochs`-style bare `watch`.** The
+  `record-as-` prefix means *capture as a persisted artefact* (story-
+  mcp's `record-as-variant`) — a live change-log observer is a
+  different semantic, so reusing the prefix would conflate two ideas
+  the agent must keep distinct.
+- **Fold both into `eval-cljs`.** The escape hatch can express either,
+  but that's exactly the per-session boilerplate + timing footgun the
+  bead exists to kill — a first-class op is the whole point.
+
+### Pick
+
+`record` (bare mega-op), `read-recording` (`read-` prefix),
+`watch-until` (`watch-` prefix).
+
+### Why
+
+- **`record` as a mega-op bare verb.** Like `snapshot`, it spans
+  multiple registry/observable kinds (app-db / sub / DOM / focus) in
+  one op — the mega-op clause is its natural home. Reusing the
+  `record-as-` prefix would falsely signal "persist an artefact".
+- **`watch-` distinct from `tail-`.** `tail-build` awaits an EXTERNAL
+  state change via a probe-value delta; `watch-until` blocks on a
+  PREDICATE over an in-runtime signal-set. Two different await
+  semantics earn two prefixes. `watch-epochs` stays on the bare-verb
+  allowlist (its pull-mode pagination predates and differs from the
+  blocking-until semantic) to avoid churn.
+- **`read-recording` needs no new verb** — the diagnostic-re-read
+  `read-` prefix already describes "the recording already ran; this
+  is a cheap reflection of its log".
+
+### Date locked
+
+2026-05-31 (rf2-zo4b9).
+
+### Trail-of-thought citations
+
+- `tools/mcp-conformance/NAMING.md` §The verb table (the `watch-` row,
+  the mega-op row's `record` addition, the §What's NOT a locked verb
+  clarification).
+- `tools/mcp-conformance/wire-vocab/test/.../verb_vocab_test.clj`
+  (`verb-prefixes` gains `watch`; `bare-verbs` gains `record`).
+
+---
+
 ## Summary table
 
 | # | Question | Pick | Date |
@@ -566,8 +650,9 @@ that the principle alone doesn't carry.
 | 5 | bencode pinning | **`bencode@~2.0.3`** (CommonJS; position-not-bytes) | 2026-05-12 |
 | 6 | Bash-shim deprecation | **Side-by-side, no removal scheduled** | 2026-05-12 |
 | 7 | Wire-boundary token cap | **Egress-centralised wrapper + pluggable `:strategy` + truncate-with-`{:rf.mcp/overflow …}`-marker** | 2026-05-13 |
+| 8 | Recorder verb shapes | **`record` bare mega-op; `read-recording` (`read-`); `watch-until` (new `watch-` prefix)** | 2026-05-31 |
 
-These seven locks together define re-frame2-pair-mcp's shipped surface.
+These eight locks together define re-frame2-pair-mcp's shipped surface.
 Anything outside these decisions is up for design discussion;
 anything inside is direction-set and shipped. Lock #4's
 cardinality has since grown additively from seven to fourteen

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
@@ -68,7 +68,13 @@
    ;; rf2-qicji — list-subscriptions toggles its per-entry shape.
    ;; Default false: only the query-vectors ride the wire (the cheap
    ;; "what's subscribed" read); true also ships :value + :ref-count.
-   :include-values    {:default false}})
+   :include-values    {:default false}
+   ;; rf2-zo4b9 — read-recording's two toggles. :drain consumes the
+   ;; buffered change-entries (the live-watch poll→consume→repeat idiom);
+   ;; :stop tears the recording down after reading (read-and-close).
+   ;; Both default false: a bare read is non-destructive.
+   :drain             {:default false}
+   :stop              {:default false}})
 
 (defn parse-bool-arg
   "Resolve a boolean MCP arg by name. Returns the per-arg default from

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -171,6 +171,18 @@
    :idempotentHint true
    :openWorldHint  true})
 
+(def ^:private record-annotations
+  "Annotations for `record` (rf2-zo4b9) — installs a read-only observer
+  on the runtime. `:readOnlyHint true` because the recorder never mutates
+  app-db / the DOM (every signal sampler only reads), but NOT
+  `:idempotentHint` (each call mints a fresh recording-id and starts a
+  new background sampler) and `:openWorldHint true` (it reaches the
+  browser runtime and has an observable side-effect on the recording
+  registry). `read-recording` / `watch-until` are pure reads and ride the
+  plain read-only annotation set."
+  {:readOnlyHint  true
+   :openWorldHint true})
+
 (def ^:private streaming-final-summary
   "Streaming-tool final-summary envelope (subscribe). The progress
   notifications it emits along the way carry their own shape
@@ -799,6 +811,140 @@
                                                                "in control — no prefix sweep.")}
                               :build        {:type "string"}}
                  :required ["selector"]
+                 :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; record
+;; ---------------------------------------------------------------------------
+
+(def record
+  {:name "record"
+   :description (str "First-class signal recorder (rf2-zo4b9): install a READ-ONLY observer over one or more "
+                     "SIGNALS with a STOP condition, let the human interact, then read the change-log back with "
+                     "read-recording. The canonical move for catching intermittent / human-in-the-loop bugs "
+                     "(render-timing races reproducible only under real mouse input). Returns IMMEDIATELY with a "
+                     ":recording-id — the recording runs in the background. The runtime samples each signal once per "
+                     "animation frame, records each CHANGE (structural = against the last value) with a :t timestamp + "
+                     ":frame counter, dedups (a steady signal yields ONE baseline entry, not one-per-frame), and tears "
+                     "itself down at the stop condition. The rAF/dedup/teardown footguns are solved once in the runtime. "
+                     "SIGNAL shapes (each a map naming one observable): {:app-db [path]} (get-in app-db), "
+                     "{:sub [query-v]} (subscription deref), {:dom \"sel\"} or {:dom \"sel\" :attr \"name\"} (a node's "
+                     "textContent or attribute), {:focus true} (a stable descriptor of document.activeElement — the "
+                     "focus-slot). STOP condition (first to trip wins; defaults to {:ms 30000} when omitted): :ms "
+                     "(wall-clock), :changes (total change count), :pred (a DATA predicate map over the positional "
+                     "sample map {<signal-index> <value>} — {:signal 0 :equals <v>} / {:signal 0 :changed true} / "
+                     "{:signal 0 :path [...] :equals <v>} / {:signal 0 :contains <substr>}; compiled to a pure "
+                     "value-comparison fn — no host source crosses the wire). READ-ONLY: never dispatches, never mutates "
+                     "app-db, never writes the DOM. "
+                     "Examples: "
+                     "1. Watch focus + a DOM count during interaction: {:signals \"[{:focus true} {:dom \\\"#count\\\"}]\" :stop {:ms 15000}} -> {:ok? true :recording-id \"rec-<uuid>\" :signals [{:focus true} {:dom \"#count\"}] :frame :rf/default :stop {:ms 15000}}; interact, then read-recording. "
+                     "2. App-db path until a value lands: {:signals \"[{:app-db [:upload :status]}]\" :stop {:pred {:signal 0 :equals :done}}} -> {:ok? true :recording-id \"rec-<uuid>\" ...}. "
+                     "3. Bounded by change count: {:signals \"[{:dom \\\"input\\\" :attr \\\"value\\\"}]\" :stop {:changes 20}} -> {:ok? true :recording-id \"rec-<uuid>\" ...}. "
+                     "4. No signals: {} -> {:ok? false :reason :no-signals}.")
+   :typicalTokens 200
+   :annotations record-annotations
+   :outputSchema envelope-or-marker
+   :inputSchema {:type "object"
+                 :properties {:signals {:description (str "Signal-set to observe — a vector of signal maps (or one bare "
+                                                          "signal map). EDN-encoded string or JSON array. Each names one "
+                                                          "observable: {:app-db [path]}, {:sub [query-v]}, {:dom \"sel\"} "
+                                                          "(optionally :attr \"name\"), or {:focus true}. Required, non-empty.")
+                                        :oneOf [{:type "string"}
+                                                {:type "array" :items {:type "object"}}
+                                                {:type "object"}]}
+                              :stop    {:description (str "Stop condition (first key to trip wins; defaults to {:ms 30000} "
+                                                          "when omitted). :ms (wall-clock ms), :changes (total change-entry "
+                                                          "count), :pred (a DATA predicate map over the positional sample "
+                                                          "map — see the description). JSON object or EDN string.")
+                                        :oneOf [{:type "object"}
+                                                {:type "string"}]}
+                              :max-entries {:type "integer"
+                                            :description "Drop-oldest ring cap on the change-log (default 2000). Bounds memory on a forgotten recording."}
+                              :frame   {:type "string"
+                                        :description "Operating frame for :app-db / :sub signals (e.g. \":rf/default\"). Defaults to the operating frame; an :app-db / :sub signal in a multi-frame session with no resolvable frame returns :reason :ambiguous-frame."}
+                              :build   {:type "string"}}
+                 :required ["signals"]
+                 :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; read-recording
+;; ---------------------------------------------------------------------------
+
+(def read-recording
+  {:name "read-recording"
+   :description (str "Read back a recording's change-log (rf2-zo4b9) — the diagnostic re-read paired with record. "
+                     "Returns {:ok? true :recording-id <id> :status :recording|:stopped :stopped-reason <kw|nil> "
+                     ":frames-sampled <n> :count <n> :entries [{:i <signal-index> :signal {...} :value <v> :t <ms> "
+                     ":frame <frame-counter>} ...]}. Each entry is one CHANGE — the moment signal :i took a new value; "
+                     ":t is wall-clock ms, :frame is the rAF frame counter (two signals that changed on the same paint "
+                     "share a :frame). Pass `drain true` for the live-watch idiom (poll, consume the buffered entries, "
+                     "repeat — the recording keeps running) or `stop true` to read-and-close in one round-trip. "
+                     "Examples: "
+                     "1. Read after interaction: {:recording-id \"rec-abc\"} -> {:ok? true :recording-id \"rec-abc\" :status :stopped :stopped-reason :ms :frames-sampled 900 :count 3 :entries [{:i 0 :signal {:focus true} :value {:tag \"input\" :id \"q\"} :t 1712... :frame 0} ...]}. "
+                     "2. Drain (live watch): {:recording-id \"rec-abc\" :drain true} -> returns buffered entries AND clears them; the next read sees only subsequent changes. "
+                     "3. Read and close: {:recording-id \"rec-abc\" :stop true} -> returns the log and tears the recording down. "
+                     "4. Unknown id: {:recording-id \"nope\"} -> {:ok? false :reason :no-such-recording}.")
+   :typicalTokens 800
+   :annotations read-only-annotations
+   :outputSchema envelope-or-marker
+   :inputSchema {:type "object"
+                 :properties {:recording-id {:type "string"
+                                             :description "The :recording-id returned by record. Required."}
+                              :drain {:type "boolean"
+                                      :description "When true, return the buffered change-entries AND clear them from the recording so the next read sees only subsequent changes (the poll→consume→repeat live-watch idiom). Default false. The recording keeps running either way."}
+                              :stop  {:type "boolean"
+                                      :description "When true, tear the recording down after reading (read-and-close in one round-trip). Default false."}
+                              :build {:type "string"}}
+                 :required ["recording-id"]
+                 :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; watch-until
+;; ---------------------------------------------------------------------------
+
+(def watch-until
+  {:name "watch-until"
+   :description (str "Block until a predicate over a signal holds (rf2-zo4b9) — the blocking counterpart to record. "
+                     "The answer to \"wait until focus lands on the modal\" / \"wait until app-db's [:upload :status] "
+                     "flips to :done\". Like tail-build, the server polls a cheap runtime read on a fixed cadence "
+                     "(~100ms) until the condition trips or `timeout-ms` (default 30000) elapses — no rAF loop, no "
+                     "browser mailbox. Resolves on the first poll where the predicate holds, returning "
+                     "{:ok? true :held? true :elapsed-ms <n> :sample {<signal-index> <value>} :t <ms>}. On timeout: "
+                     "{:ok? false :reason :watch-timeout :timed-out? true :last-sample {...}} — :last-sample shows the "
+                     "final reading so you can see how close it got. SIGNALS use the same vocabulary as record "
+                     "({:app-db [path]} / {:sub [query-v]} / {:dom \"sel\" [:attr \"name\"]} / {:focus true}). PRED is a "
+                     "DATA predicate map (same shapes as record's :stop {:pred ...}, matched against the positional "
+                     "sample map {<signal-index> <value>}): {:signal 0 :equals <v>} / {:signal 0 :changed true} / "
+                     "{:signal 0 :path [...] :equals <v>} / {:signal 0 :contains <substr>} / {:signal 0} (any non-nil). "
+                     "Compiled to a pure value-comparison fn — no host source crosses the wire. READ-ONLY: never "
+                     "dispatches or mutates. "
+                     "Examples: "
+                     "1. Wait for an app-db flag: {:signals \"[{:app-db [:upload :status]}]\" :pred {:signal 0 :equals :done}} -> blocks, then {:ok? true :held? true :elapsed-ms 4200 :sample {0 :done} :t 1712...}. "
+                     "2. Wait for focus to move into the dialog: {:signals \"[{:focus true}]\" :pred {:signal 0 :path [:id] :equals \"dialog-close\"}} -> {:ok? true :held? true :sample {0 {:tag \"button\" :id \"dialog-close\"}}}. "
+                     "3. Timeout: {:signals \"[{:dom \\\"#spinner\\\"}]\" :pred {:signal 0 :equals nil} :timeout-ms 2000} -> {:ok? false :reason :watch-timeout :timed-out? true :last-sample {0 \"loading…\"}}. "
+                     "4. No predicate: {:signals \"[{:focus true}]\"} -> {:ok? false :reason :missing-pred}.")
+   :typicalTokens 200
+   :annotations read-only-annotations
+   :outputSchema envelope-or-marker
+   :inputSchema {:type "object"
+                 :properties {:signals {:description (str "Signal-set to watch — same vocabulary as record. A vector of "
+                                                          "signal maps (or one bare signal map). EDN string or JSON array. "
+                                                          "Required, non-empty.")
+                                        :oneOf [{:type "string"}
+                                                {:type "array" :items {:type "object"}}
+                                                {:type "object"}]}
+                              :pred    {:description (str "DATA predicate map over the positional sample map "
+                                                          "{<signal-index> <value>} — see the description for the shapes. "
+                                                          "Required: without one the watch can only time out. JSON object "
+                                                          "or EDN string.")
+                                        :oneOf [{:type "object"}
+                                                {:type "string"}]}
+                              :timeout-ms {:type "integer"
+                                           :description "Max ms to wait for the predicate to hold (default 30000). On expiry returns :reason :watch-timeout with the final :last-sample."}
+                              :frame   {:type "string"
+                                        :description "Operating frame for :app-db / :sub signals (e.g. \":rf/default\"). Defaults to the operating frame."}
+                              :build   {:type "string"}}
+                 :required ["signals" "pred"]
                  :additionalProperties false}})
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
@@ -1,0 +1,265 @@
+(ns re-frame2-pair-mcp.tools.record
+  "Tools: record + read-recording — first-class signal recorder (rf2-zo4b9).
+
+  ## Why a recorder primitive
+
+  Intermittent / human-in-the-loop bugs (the rf2-yng0y render-timing
+  race, only reproducible under real mouse input) need a recorder:
+  install an observer, let the human interact, read back a change-log.
+  That move used to be hand-built each session — a `requestAnimationFrame`
+  loop pushing focus-slot + DOM snapshots into `window.__zoombug`. It was
+  decisive but bespoke and footgun-prone (rAF timing, change-dedup,
+  teardown). This first-classes it.
+
+  ## The op pair
+
+  - `record` installs a read-only observer over one or more SIGNALS with
+    a STOP condition (N ms, N changes, or a predicate) and returns
+    immediately with a `:recording-id`. The recording runs in the
+    background while the human interacts; the runtime samples each signal
+    once per animation frame, records each CHANGE with a timestamp, and
+    tears itself down at the stop condition.
+  - `read-recording` reads the accumulated change-log back. Pass
+    `:drain true` for the live-watch idiom (poll → consume → repeat) or
+    `:stop true` to read-and-close in one round-trip.
+
+  The heavy lifting — rAF/dedup/teardown, the ring cap, the stop
+  evaluation — lives in `re-frame2-pair.runtime` (`start-recording!` /
+  `read-recording` / `stop-recording!` / `sample-signals`), so the footguns
+  are solved once. This namespace owns only the wire shape: arg coercion,
+  the data→predicate compile for `:stop {:pred ...}`, and forwarding the
+  runtime envelope.
+
+  ## Naming
+
+  `record` is a bare-verb mega-op (a recorder spanning multiple signal
+  kinds), catalogued in NAMING.md §The verb table; `read-recording` rides
+  the `read-` prefix (diagnostic re-read of recorded state). Both are
+  pinned by the verb-vocab conformance gate.
+
+  ## Read-only by construction
+
+  Every signal sampler in the runtime only READS (get-in / subscribe
+  deref / querySelector text+attr / activeElement). A recording never
+  dispatches, never mutates app-db, never writes the DOM. The descriptors
+  carry the read-only annotation (with `:openWorldHint` — the recording
+  reaches the browser runtime and has an observable side-effect on the
+  runtime's recording registry, but no app-state mutation)."
+  (:require [cljs.reader]
+            [clojure.string :as str]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.args :as args]
+            [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.wire :as wire]
+            [re-frame2-pair-mcp.tools.probe :as probe]))
+
+;; ---------------------------------------------------------------------------
+;; Signal-arg parsing — shared with watch-until.
+;; ---------------------------------------------------------------------------
+
+(defn parse-signals-arg
+  "Normalise the `signals` MCP arg into a vector of signal maps the
+  runtime understands. Accepts:
+
+    - a JS array / CLJS vector of signal objects, OR
+    - an EDN-encoded string (`\"[{:focus true} {:dom \\\"#c\\\"}]\"`).
+
+  Each signal map is keywordised. Returns `nil` when the arg is absent /
+  blank / not a collection so the caller can emit the `:no-signals`
+  refusal. Recognised signal shapes (validated runtime-side):
+  `{:app-db [path]}`, `{:sub [query-v]}`, `{:dom \"sel\" :attr \"name\"}`,
+  `{:focus true}`."
+  [raw]
+  (cond
+    (nil? raw) nil
+
+    (array? raw)
+    (let [v (js->clj raw :keywordize-keys true)]
+      (when (sequential? v) (vec v)))
+
+    (vector? raw) raw
+    (sequential? raw) (vec raw)
+
+    (map? raw) [raw] ;; a single bare signal map — sugar for [signal]
+
+    (string? raw)
+    (let [trimmed (str/trim raw)]
+      (when-not (str/blank? trimmed)
+        (let [parsed (try (cljs.reader/read-string trimmed)
+                          (catch :default _ ::reader-fail))]
+          (cond
+            (= ::reader-fail parsed) nil
+            (map? parsed)            [parsed]
+            (sequential? parsed)     (vec parsed)
+            :else                    nil))))
+
+    (object? raw)
+    (let [m (try (js->clj raw :keywordize-keys true) (catch :default _ nil))]
+      (when (map? m) [m]))
+
+    :else nil))
+
+(defn parse-stop-arg
+  "Normalise the `stop` MCP arg into the runtime stop-condition map.
+  Accepts a JS object, a CLJS map, or an EDN string. Recognised keys:
+  `:ms` (integer), `:changes` (integer), `:pred` (a filter map — compiled
+  into the runtime predicate below). Unknown keys are dropped. Returns
+  `{}` when absent so the runtime applies its default wall-clock window."
+  [raw]
+  (let [m (cond
+            (nil? raw)    {}
+            (map? raw)    raw
+            (string? raw) (try (let [p (cljs.reader/read-string raw)]
+                                 (if (map? p) p {}))
+                               (catch :default _ {}))
+            (object? raw) (try (js->clj raw :keywordize-keys true)
+                               (catch :default _ {}))
+            :else {})]
+    (select-keys m [:ms :changes :pred])))
+
+;; ---------------------------------------------------------------------------
+;; Stop / watch predicate compile (data → runtime fn).
+;; ---------------------------------------------------------------------------
+;;
+;; The MCP surface takes a DATA predicate (EDN), never host source — the
+;; same injection-closing posture `dispatch` / `reset-frame-db` adopted
+;; (rf2-vflrg). We compile the data predicate into a CLJS fn server-side-
+;; emitted-into-the-form so the runtime's `start-recording!` / `watch-until`
+;; receives a real `:pred-fn`. The predicate map is matched against the
+;; positional sample map `{<signal-index> <value>}`:
+;;
+;;   {:signal 0 :equals <v>}        — signal 0's value = <v>
+;;   {:signal 0 :changed true}      — signal 0 is non-nil (took any value)
+;;   {:signal 0 :path [...] :equals <v>}  — (get-in (sample 0) path) = <v>
+;;   {:signal 0 :contains <substr>} — (str (sample 0)) includes <substr>
+;;
+;; The compiled form is pure data-comparison — no arbitrary code crosses
+;; the wire. `pred-source` returns the CLJS source string for the fn; the
+;; runtime form splices it into the `:pred-fn` slot.
+
+(defn pred-source
+  "Build the CLJS source for the `:pred-fn` over a data predicate map, or
+  nil when no `:pred` was supplied. The fn takes the positional sample map
+  and returns a boolean — pure value comparison, no host evaluation of
+  caller input. Returns the source string (a `(fn [sample] ...)` literal)
+  or nil.
+
+  Every caller-supplied comparand rides inside `(quote ...)` so it is
+  always DATA, never host source: a hostile `:equals (js/alert \"x\")`
+  becomes `(quote (js/alert \"x\"))` — compared as a literal list, never
+  evaluated. Same injection-closing posture as `dispatch` /
+  `reset-frame-db` (rf2-vflrg). The `:path` vector and the `:signal` index
+  are quoted / integer-coerced for the same reason."
+  [pred]
+  (when (map? pred)
+    (let [{:keys [signal path equals changed contains]} pred
+          idx (if (integer? signal) signal 0)
+          val-src (if (seq path)
+                    (str "(get-in (get sample " idx ") (quote " (pr-str (vec path)) "))")
+                    (str "(get sample " idx ")"))]
+      (cond
+        (some? changed)
+        (str "(fn [sample] (some? " val-src "))")
+
+        (contains? pred :equals)
+        (str "(fn [sample] (= " val-src " (quote " (pr-str equals) ")))")
+
+        (some? contains)
+        (str "(fn [sample] (clojure.string/includes? (str " val-src ") " (pr-str (str contains)) "))")
+
+        :else
+        ;; A bare {:signal n} with no comparator means "any non-nil value
+        ;; of that signal" — the most common watch-until intent.
+        (str "(fn [sample] (some? " val-src "))")))))
+
+;; ---------------------------------------------------------------------------
+;; record — start a recording.
+;; ---------------------------------------------------------------------------
+
+(defn- stop-map-src
+  "Build the CLJS source for the runtime `:stop` map. The data keys
+  (`:ms` / `:changes`) ride as `pr-str`'d EDN literals; the `:pred` data
+  predicate is compiled into a `:pred-fn` raw-source slot via
+  `pred-source` (no host source from the caller crosses the wire — only
+  the value-comparison fn this server synthesised). Built as an explicit
+  source string because the `:pred-fn` value is live CLJS source, not
+  EDN data — `eval-form`'s `pr-str` arg path would render the fn source
+  as a string literal."
+  [stop]
+  (let [pred-src (pred-source (:pred stop))
+        pairs    (cond-> []
+                   (some? (:ms stop))      (conj (str ":ms " (pr-str (:ms stop))))
+                   (some? (:changes stop)) (conj (str ":changes " (pr-str (:changes stop))))
+                   pred-src                (conj (str ":pred-fn " pred-src)))]
+    (str "{" (str/join " " pairs) "}")))
+
+(defn- start-recording-form
+  "Build the runtime `(start-recording! opts)` eval form. The opts map is
+  emitted as explicit source: `:signals` / `:frame` / `:max-entries` are
+  EDN data literals; `:stop` is built by `stop-map-src` (its `:pred-fn`
+  slot carries synthesised CLJS source, which can't ride the EDN-literal
+  arg path)."
+  [signals stop frame max-entries]
+  (let [opts-pairs (cond-> [(str ":signals " (pr-str (vec signals)))
+                            (str ":stop " (stop-map-src stop))]
+                     frame       (conj (str ":frame " (pr-str frame)))
+                     max-entries (conj (str ":max-entries " (pr-str max-entries))))]
+    (ef/emit
+      (ef/rt-call 'start-recording!
+                  (ef/rt-raw (str "{" (str/join " " opts-pairs) "}"))))))
+
+(defn record-tool
+  "MCP `record` handler. Installs a read-only recorder over `signals`
+  with a `stop` condition and returns a `:recording-id` immediately. See
+  the ns docstring for the wire contract."
+  [conn raw-args]
+  (let [build-id    (wire/arg-build conn raw-args)
+        frame       (some-> (wire/arg raw-args :frame) args/->frame-keyword)
+        signals     (parse-signals-arg (wire/arg raw-args :signals))
+        stop        (parse-stop-arg (wire/arg raw-args :stop))
+        max-entries (let [m (wire/arg raw-args :max-entries)]
+                      (when (and (number? m) (pos? m)) (long m)))]
+    (cond
+      (or (nil? signals) (empty? signals))
+      (js/Promise.resolve
+        (wire/err-text
+          {:ok? false :reason :no-signals
+           :hint (str "usage: record {signals '[{:focus true} {:dom \"#count\"} "
+                      "{:app-db [:cart :items]}]' [stop {:ms 30000}] [frame :rf/default]}")}))
+
+      :else
+      (let [form (start-recording-form signals stop frame max-entries)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [envelope] (wire/ok-text envelope)))
+            (.catch (fn [err] (probe/err->result :record-failed err))))))))
+
+;; ---------------------------------------------------------------------------
+;; read-recording — read back the change-log.
+;; ---------------------------------------------------------------------------
+
+(defn read-recording-tool
+  "MCP `read-recording` handler. Reads back a recording's change-log,
+  optionally draining (`drain true`) or closing it (`stop true`). See the
+  ns docstring for the wire contract."
+  [conn raw-args]
+  (let [build-id     (wire/arg-build conn raw-args)
+        recording-id (wire/arg raw-args :recording-id)
+        drain?       (args/parse-bool-arg raw-args :drain)
+        stop?        (args/parse-bool-arg raw-args :stop)]
+    (cond
+      (or (nil? recording-id) (and (string? recording-id) (str/blank? recording-id)))
+      (js/Promise.resolve
+        (wire/err-text
+          {:ok? false :reason :missing-recording-id
+           :hint "usage: read-recording {recording-id \"rec-<uuid>\" [drain true] [stop true]}"}))
+
+      :else
+      (let [form (ef/emit
+                   (ef/rt-call 'read-recording
+                               (str recording-id)
+                               {:drain drain? :stop stop?}))]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [envelope] (wire/ok-text envelope)))
+            (.catch (fn [err] (probe/err->result :read-recording-failed err))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
@@ -74,6 +74,8 @@
             [re-frame2-pair-mcp.tools.snapshot :as snapshot]
             [re-frame2-pair-mcp.tools.get-path :as get-path]
             [re-frame2-pair-mcp.tools.read-dom :as read-dom]
+            [re-frame2-pair-mcp.tools.record :as record]
+            [re-frame2-pair-mcp.tools.watch-until :as watch-until]
             [re-frame2-pair-mcp.tools.subscribe :as subscribe]
             [re-frame2-pair-mcp.tools.unsubscribe :as unsubscribe]
             [re-frame2-pair-mcp.tools.list-subscriptions :as list-subscriptions]
@@ -99,9 +101,8 @@
 
 (defn- ignoring-extra
   "Adapt a 2-arity per-tool fn `(fn [conn args])` into the registry's
-  3-arity convention `(fn [conn args _extra])`. Eighteen of the
-  nineteen registered tools ignore `extra` (only `subscribe`
-  consults it);
+  3-arity convention `(fn [conn args _extra])`. All but one of the
+  registered tools ignore `extra` (only `subscribe` consults it);
   this adapter collapses the verbatim `(fn [conn args _extra]
   (per-tool-fn conn args))` boilerplate at the call sites.
 
@@ -122,13 +123,14 @@
 ;; ---------------------------------------------------------------------------
 
 (def tools
-  "The nineteen-tool catalogue. Single source of truth for the
-  `tools/list` descriptors, the `tools/call` dispatcher, and the
-  per-tool cache opt-in. See ns docstring for the entry shape.
+  "The tool catalogue (canonical count: spec/003-Tool-Catalogue.md).
+  Single source of truth for the `tools/list` descriptors, the
+  `tools/call` dispatcher, and the per-tool cache opt-in. See ns
+  docstring for the entry shape.
 
   Each `:handler` is a thin late-binding wrapper around the per-tool
-  fn — `ignoring-extra` for the eighteen tools that ignore `extra`,
-  or an inline `(fn [conn args extra] ...)` for `subscribe` (which
+  fn — `ignoring-extra` for every tool that ignores `extra`, or an
+  inline `(fn [conn args extra] ...)` for `subscribe` (which
   uses `extra` for its progress-callback plumbing). Both shapes
   resolve the underlying fn per-call so test seams that `set!` the
   var (rf2-nogok) take effect on the next dispatch."
@@ -186,6 +188,27 @@
     ;; as the action / streaming tools.
     :cacheable? false
     :descriptor data/read-dom}
+   {:name       "record"
+    :handler    (ignoring-extra #(record/record-tool %1 %2))
+    ;; Installs a live recorder on the runtime (mints a recording-id, runs
+    ;; a background rAF sampler) — an action with an observable side-effect
+    ;; on the recording registry, NOT a function of frame state. Same
+    ;; non-cacheable posture as the streaming / action tools.
+    :cacheable? false
+    :descriptor data/record}
+   {:name       "read-recording"
+    :handler    (ignoring-extra #(record/read-recording-tool %1 %2))
+    ;; Reads the volatile recording change-log (and may drain / stop it) —
+    ;; the return value is the live recording buffer, not a pure function
+    ;; of app-db, so a precheck-hash cache would serve stale logs.
+    :cacheable? false
+    :descriptor data/read-recording}
+   {:name       "watch-until"
+    :handler    (ignoring-extra #(watch-until/watch-until-tool %1 %2))
+    ;; Blocks (server-polls) until a predicate holds — the result depends
+    ;; on WHEN the condition trips, not on a single app-db snapshot.
+    :cacheable? false
+    :descriptor data/watch-until}
    {:name       "subscribe"
     :handler    (fn [conn args extra] (subscribe/subscribe-tool conn args extra))
     :cacheable? false

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_until.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_until.cljs
@@ -1,0 +1,160 @@
+(ns re-frame2-pair-mcp.tools.watch-until
+  "Tool: watch-until — block until a predicate over a signal holds (rf2-zo4b9).
+
+  ## Why a blocking watch primitive
+
+  `record` is the non-blocking half of the recorder: install an observer,
+  let the human interact, read back the change-log later. `watch-until` is
+  the blocking half — the answer to \"wait until the focus lands on the
+  modal\" / \"wait until app-db's `[:upload :status]` flips to `:done`\".
+  Pre-rf2-zo4b9 this was a hand-rolled `setTimeout` poll inside `eval-cljs`,
+  with the same timing/teardown footguns the recorder exists to kill.
+
+  ## How it blocks
+
+  Like `tail-build`, the server polls a cheap runtime read on a fixed
+  cadence until the condition trips or `timeout-ms` elapses — no rAF loop,
+  no browser-side mailbox. Each poll evals one form that (a) samples the
+  signal-set via the runtime's `sample-signals` and (b) applies the
+  compiled predicate to the positional sample map server-side, returning
+  `{:held? bool :sample {...} :t <ms>}`. The first poll where `:held?` is
+  true resolves the tool with that sample. On timeout the LAST sample
+  rides back so the operator sees how close the condition got.
+
+  ## Predicate vocabulary — DATA, not host source
+
+  The `pred` arg is an EDN data predicate (same injection-closing posture
+  as `dispatch` / `reset-frame-db`, rf2-vflrg). It is compiled into a pure
+  value-comparison fn by `record/pred-source` — shared with `record`'s
+  `:stop {:pred ...}` so the two surfaces read identically. Recognised
+  shapes (matched against the positional sample map `{<signal-index>
+  <value>}`):
+
+    {:signal 0 :equals <v>}              — sample 0 equals <v>
+    {:signal 0 :changed true}            — sample 0 is non-nil
+    {:signal 0 :path [...] :equals <v>}  — (get-in (sample 0) path) = <v>
+    {:signal 0 :contains <substr>}       — (str (sample 0)) includes <substr>
+    {:signal 0}                          — sample 0 took any non-nil value
+
+  ## Read-only by construction
+
+  The runtime sampler only reads; `watch-until` never dispatches or
+  mutates. The descriptor carries the read-only annotation."
+  (:require [cljs.reader]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.args :as args]
+            [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.wire :as wire]
+            [re-frame2-pair-mcp.tools.probe :as probe]
+            [re-frame2-pair-mcp.tools.record :as record]))
+
+(def ^:private default-timeout-ms
+  "Default deadline for the predicate to hold. 30 s matches the
+  recorder's default window — a generous \"interact while I watch\"
+  budget. Pathologically long human-in-the-loop sessions raise it via
+  the `:timeout-ms` arg."
+  30000)
+
+(def ^:private poll-ms
+  "Cadence at which the server re-samples + re-tests the predicate.
+  100ms = ~10 polls/sec — lands within ~100ms of the condition tripping,
+  cheap on the nREPL socket. Matches `tail-build`'s probe cadence."
+  100)
+
+(defn watch-form
+  "Build the per-poll eval form: sample the signal-set against the frame,
+  then apply the compiled predicate to the positional sample map. Returns
+  `{:held? bool :sample {...} :t <ms>}`. `pred-src` is the predicate fn
+  source (from `record/pred-source`); when nil the form reports
+  `:held? false` every tick (a no-predicate watch can only time out — the
+  refusal is enforced at the tool boundary, so this is defensive)."
+  [signals frame pred-src]
+  (let [sample-call (if frame
+                      (ef/rt-call 'sample-signals signals frame)
+                      (ef/rt-call 'sample-signals signals))]
+    (ef/emit
+      (ef/rt-let
+        ['r       sample-call
+         'sample  (ef/rt-raw "(:sample r)")
+         'held?   (ef/rt-raw (if pred-src
+                               (str "(boolean ((" pred-src ") sample))")
+                               "false"))]
+        (ef/rt-raw "{:held? held? :sample sample :t (:t r)}")))))
+
+(defn watch-until-tool
+  "MCP `watch-until` handler. Polls the signal-set until the compiled
+  predicate holds or `timeout-ms` elapses. See the ns docstring for the
+  wire contract."
+  [conn raw-args]
+  (let [build-id   (wire/arg-build conn raw-args)
+        frame      (some-> (wire/arg raw-args :frame) args/->frame-keyword)
+        signals    (record/parse-signals-arg (wire/arg raw-args :signals))
+        pred       (let [p (wire/arg raw-args :pred)]
+                     (cond
+                       (map? p) p
+                       (string? p) (try (let [v (cljs.reader/read-string p)]
+                                          (when (map? v) v))
+                                        (catch :default _ nil))
+                       (object? p) (try (js->clj p :keywordize-keys true)
+                                        (catch :default _ nil))
+                       :else nil))
+        timeout-ms (let [t (wire/arg raw-args :timeout-ms)]
+                     (if (and (number? t) (pos? t)) (long t) default-timeout-ms))
+        pred-src   (record/pred-source pred)]
+    (cond
+      (or (nil? signals) (empty? signals))
+      (js/Promise.resolve
+        (wire/err-text
+          {:ok? false :reason :no-signals
+           :hint (str "usage: watch-until {signals '[{:app-db [:upload :status]}]' "
+                      "pred {:signal 0 :equals :done} [timeout-ms 30000] [frame :rf/default]}")}))
+
+      (nil? pred-src)
+      (js/Promise.resolve
+        (wire/err-text
+          {:ok? false :reason :missing-pred
+           :hint (str "watch-until needs a `pred` data map, e.g. {:signal 0 :equals :done} "
+                      "or {:signal 0 :changed true}. Without one it can only time out.")}))
+
+      :else
+      (let [form (watch-form signals frame pred-src)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then
+              (fn [_]
+                (js/Promise.
+                  (fn [resolve _reject]
+                    (let [start  (js/Date.now)
+                          latest (volatile! nil)]
+                      (letfn [(poll []
+                                (let [elapsed (- (js/Date.now) start)]
+                                  (if (>= elapsed timeout-ms)
+                                    (resolve
+                                      (wire/ok-text
+                                        {:ok?         false
+                                         :reason      :watch-timeout
+                                         :timed-out?  true
+                                         :timeout-ms  timeout-ms
+                                         :last-sample (:sample @latest)
+                                         :hint        (str "predicate did not hold within timeout-ms. "
+                                                           ":last-sample shows the final reading — compare "
+                                                           "it against the predicate to see how close it got.")}))
+                                    (-> (nrepl/cljs-eval-value conn build-id form)
+                                        (.then
+                                          (fn [resp]
+                                            (vreset! latest resp)
+                                            (if (and (map? resp) (:held? resp))
+                                              (resolve
+                                                (wire/ok-text
+                                                  {:ok?       true
+                                                   :held?     true
+                                                   :elapsed-ms (- (js/Date.now) start)
+                                                   :sample    (:sample resp)
+                                                   :t         (:t resp)}))
+                                              (js/setTimeout poll poll-ms))))
+                                        (.catch
+                                          (fn [_]
+                                            ;; nREPL hiccup — keep polling
+                                            ;; rather than collapsing the watch.
+                                            (js/setTimeout poll poll-ms)))))))]
+                        (poll)))))))
+            (.catch (fn [err] (probe/err->result :watch-until-failed err))))))))

--- a/tools/re-frame2-pair-mcp/test/fixtures/tool-names.json
+++ b/tools/re-frame2-pair-mcp/test/fixtures/tool-names.json
@@ -12,6 +12,8 @@
     "list-streams",
     "list-subscriptions",
     "read-dom",
+    "read-recording",
+    "record",
     "reset-frame-db",
     "restore-epoch",
     "snapshot",
@@ -19,6 +21,7 @@
     "tail-build",
     "trace-window",
     "unsubscribe",
-    "watch-epochs"
+    "watch-epochs",
+    "watch-until"
   ]
 }

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
@@ -35,14 +35,18 @@
 (deftest bool-args-table-shape
   ;; The catalogued arg keys; their default postures are the cross-MCP
   ;; convention. Drift here = drift across consumers. `:include-values`
-  ;; was added by rf2-qicji for the reactive `list-subscriptions` tool.
-  (is (= #{:dedup :elision :cache :include-sensitive :include-values}
+  ;; was added by rf2-qicji for the reactive `list-subscriptions` tool;
+  ;; `:drain` / `:stop` by rf2-zo4b9 for `read-recording`.
+  (is (= #{:dedup :elision :cache :include-sensitive :include-values
+           :drain :stop}
          (set (keys args/bool-args))))
   (is (true?  (get-in args/bool-args [:dedup             :default])))
   (is (true?  (get-in args/bool-args [:elision           :default])))
   (is (false? (get-in args/bool-args [:cache             :default])))
   (is (false? (get-in args/bool-args [:include-sensitive :default])))
-  (is (false? (get-in args/bool-args [:include-values    :default]))))
+  (is (false? (get-in args/bool-args [:include-values    :default])))
+  (is (false? (get-in args/bool-args [:drain             :default])))
+  (is (false? (get-in args/bool-args [:stop              :default]))))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-bool-arg — table lookup + JS-args extraction.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/record_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/record_test.cljs
@@ -1,0 +1,297 @@
+(ns re-frame2-pair-mcp.record-test
+  "Unit tests for the signal-recorder triplet — record / read-recording /
+  watch-until (rf2-zo4b9).
+
+  Three layers, mirroring `read_dom_test`:
+
+    1. Arg coercion — `parse-signals-arg` / `parse-stop-arg` accept the
+       JS-array / EDN-string / bare-map shapes the MCP host sends.
+
+    2. Predicate + form composition — `pred-source` compiles a DATA
+       predicate into a pure value-comparison fn source (no host source
+       crosses the wire); the `record` / `watch-until` eval forms carry
+       the load-bearing runtime calls and stay READ-ONLY (no dispatch /
+       reset / DOM-write host-forms).
+
+    3. Tool wiring — stub `cljs-eval-value` (no socket) and pin the wire
+       shape: record returns the runtime envelope, read-recording forwards
+       the change-log, watch-until resolves on the first :held? poll and
+       times out with :last-sample, and the gates (:no-signals /
+       :missing-pred / :missing-recording-id) short-circuit.
+
+  The rAF/dedup/teardown semantics (does the sampler actually dedup? does
+  it tear down at the stop condition?) live in the runtime
+  (`re-frame2-pair.runtime/start-recording!` & friends) and are exercised
+  by the form running in a real tab — out of scope for a node-runtime
+  unit suite. This suite pins the wire contract + the form's internal
+  shape; the runtime structural tests cover the sampler."
+  (:require [cljs.test :refer-macros [deftest is async testing]]
+            [clojure.string :as str]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.record :as record]
+            [re-frame2-pair-mcp.tools.watch-until :as watch-until]))
+
+;; ---------------------------------------------------------------------------
+;; parse-signals-arg — input-shape contract.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-signals-arg-shapes
+  (testing "JS array of signal objects"
+    (is (= [{:focus true} {:dom "#c"}]
+           (record/parse-signals-arg #js [#js {:focus true} #js {:dom "#c"}]))))
+  (testing "CLJS vector passes through"
+    (is (= [{:app-db [:cart]}] (record/parse-signals-arg [{:app-db [:cart]}]))))
+  (testing "a bare single signal map ⇒ wrapped in a vector"
+    (is (= [{:focus true}] (record/parse-signals-arg {:focus true}))))
+  (testing "EDN string ⇒ vector of signal maps"
+    (is (= [{:focus true} {:app-db [:a :b]}]
+           (record/parse-signals-arg "[{:focus true} {:app-db [:a :b]}]"))))
+  (testing "EDN string of a single map ⇒ wrapped"
+    (is (= [{:dom "#x"}] (record/parse-signals-arg "{:dom \"#x\"}"))))
+  (testing "absent / blank / unparseable ⇒ nil"
+    (is (nil? (record/parse-signals-arg nil)))
+    (is (nil? (record/parse-signals-arg "   ")))
+    (is (nil? (record/parse-signals-arg "(not edn")))))
+
+;; ---------------------------------------------------------------------------
+;; parse-stop-arg — keeps only the recognised keys.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-stop-arg-shapes
+  (is (= {:ms 5000} (record/parse-stop-arg #js {:ms 5000})))
+  (is (= {:changes 10} (record/parse-stop-arg "{:changes 10}")))
+  (is (= {:pred {:signal 0 :equals :done}}
+         (record/parse-stop-arg "{:pred {:signal 0 :equals :done}}")))
+  (testing "unrecognised keys dropped"
+    (is (= {:ms 1} (record/parse-stop-arg #js {:ms 1 :bogus 9}))))
+  (testing "absent ⇒ {}"
+    (is (= {} (record/parse-stop-arg nil)))))
+
+;; ---------------------------------------------------------------------------
+;; pred-source — DATA predicate compiles to a pure comparison fn source.
+;; ---------------------------------------------------------------------------
+
+(deftest pred-source-shapes
+  (testing ":equals comparison"
+    (let [src (record/pred-source {:signal 0 :equals :done})]
+      (is (str/includes? src "(get sample 0)"))
+      (is (str/includes? src ":done"))
+      (is (str/includes? src "(="))))
+  (testing ":path drills into the sampled value (path quoted as data)"
+    (let [src (record/pred-source {:signal 1 :path [:id] :equals "x"})]
+      (is (str/includes? src "(get-in (get sample 1) (quote [:id]))"))
+      (is (str/includes? src "\"x\""))))
+  (testing ":changed ⇒ some? check"
+    (let [src (record/pred-source {:signal 0 :changed true})]
+      (is (str/includes? src "some?"))))
+  (testing ":contains ⇒ string includes"
+    (let [src (record/pred-source {:signal 0 :contains "load"})]
+      (is (str/includes? src "clojure.string/includes?"))
+      (is (str/includes? src "\"load\""))))
+  (testing "bare {:signal n} ⇒ any non-nil"
+    (is (str/includes? (record/pred-source {:signal 2}) "some?")))
+  (testing "nil / non-map ⇒ nil"
+    (is (nil? (record/pred-source nil)))
+    (is (nil? (record/pred-source "not-a-map")))))
+
+(deftest pred-source-no-host-source-injection
+  ;; The compiled predicate is pure value comparison — a hostile :equals
+  ;; value is pr-str'd as a DATA literal, never spliced as host source.
+  (let [src (record/pred-source {:signal 0 :equals '(js/alert "pwn")})]
+    ;; The list rides as a quoted EDN literal, not an evaluated call.
+    (is (str/includes? src "(quote (js/alert \"pwn\"))"))))
+
+;; ---------------------------------------------------------------------------
+;; record form composition — load-bearing runtime call + read-only.
+;; ---------------------------------------------------------------------------
+
+(deftest start-recording-form-shape
+  (let [form (#'record/start-recording-form
+               [{:focus true} {:app-db [:cart]}]
+               {:ms 15000 :pred {:signal 0 :equals :done}}
+               :rf/default
+               2000)]
+    (testing "calls the runtime start-recording! with the signals + stop"
+      (is (str/includes? form "re-frame2-pair.runtime/start-recording!"))
+      (is (str/includes? form ":signals"))
+      (is (str/includes? form "{:focus true}"))
+      (is (str/includes? form ":ms 15000"))
+      (is (str/includes? form ":frame :rf/default"))
+      (is (str/includes? form ":max-entries 2000")))
+    (testing "the data predicate compiles into a :pred-fn slot (not raw :pred)"
+      (is (str/includes? form ":pred-fn"))
+      (is (not (str/includes? form ":pred {")) "the data :pred key must not ride verbatim"))))
+
+(deftest record-and-watch-forms-are-read-only
+  ;; READ-ONLY by construction — neither form may carry an app-mutation
+  ;; host-form. The whole point of the recorder is observation.
+  (let [rec-form   (#'record/start-recording-form [{:focus true}] {:ms 1000} nil nil)
+        watch-form (watch-until/watch-form [{:app-db [:x]}] :rf/default
+                                           (record/pred-source {:signal 0 :equals 1}))]
+    (doseq [form [rec-form watch-form]
+            mutator ["pair-dispatch" "reset-frame-db" "app-db-reset"
+                     ".setAttribute" ".dispatchEvent" ".innerHTML"
+                     "restore-epoch"]]
+      (is (not (str/includes? form mutator))
+          (str "recorder form must be read-only — found mutator " mutator)))))
+
+;; ---------------------------------------------------------------------------
+;; Tool wiring — preflight + envelope passthrough.
+;; ---------------------------------------------------------------------------
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{:app})
+    conn))
+
+;; ---- record -----------------------------------------------------------------
+
+(deftest record-returns-recording-id
+  (async done
+    (let [canned {:ok? true :recording-id "rec-abc"
+                  :signals [{:focus true}] :frame :rf/default :stop {:ms 30000}}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (record/record-tool (fresh-conn)
+                                  #js {:signals "[{:focus true}]"})))
+          (.then (fn [r]
+                   (is (not (tu/error? r)))
+                   (let [edn (tu/extract-edn r)]
+                     (is (true? (:ok? edn)))
+                     (is (= "rec-abc" (:recording-id edn)) "recording-id surfaced"))
+                   (done)))))))
+
+(deftest record-no-signals-short-circuits
+  (async done
+    (-> (record/record-tool (fresh-conn) #js {})
+        (.then (fn [r]
+                 (is (tu/error? r))
+                 (is (= :no-signals (:reason (tu/extract-edn r))))
+                 (done))))))
+
+;; ---- read-recording ---------------------------------------------------------
+
+(deftest read-recording-forwards-change-log
+  (async done
+    (let [canned {:ok? true :recording-id "rec-abc" :status :stopped
+                  :stopped-reason :ms :frames-sampled 900 :count 2
+                  :entries [{:i 0 :signal {:focus true}
+                             :value {:tag "input" :id "q"} :t 1 :frame 0}
+                            {:i 0 :signal {:focus true}
+                             :value {:tag "button" :id "go"} :t 2 :frame 42}]}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (record/read-recording-tool (fresh-conn)
+                                          #js {:recording-id "rec-abc"})))
+          (.then (fn [r]
+                   (is (not (tu/error? r)))
+                   (let [edn (tu/extract-edn r)]
+                     (is (true? (:ok? edn)))
+                     (is (= :stopped (:status edn)))
+                     (is (= 2 (:count edn)) "change-entry count surfaced")
+                     (is (= 42 (-> edn :entries second :frame)) "rAF frame counter rides"))
+                   (done)))))))
+
+(deftest read-recording-missing-id-short-circuits
+  (async done
+    (-> (record/read-recording-tool (fresh-conn) #js {})
+        (.then (fn [r]
+                 (is (tu/error? r))
+                 (is (= :missing-recording-id (:reason (tu/extract-edn r))))
+                 (done))))))
+
+(deftest read-recording-drain-and-stop-ride-the-form
+  ;; The :drain / :stop bool args must reach the runtime read-recording
+  ;; call as an opts map — capture the emitted form to confirm.
+  (async done
+    (let [seen   (atom nil)
+          orig   nrepl/cljs-eval-value
+          ;; Explicit 3- and 4-arity (NOT a variadic / rest-arg fn):
+          ;; CLJS direct-arity dispatch calls the var via
+          ;; `...$_invoke$arity$3`, which a `(fn [& a])` doesn't expose —
+          ;; same reason `tu/with-stubbed-eval!` spells both arities out.
+          canned (js/Promise.resolve {:ok? true :recording-id "r" :status :stopped
+                                      :count 0 :entries []})]
+      (set! nrepl/cljs-eval-value
+            (fn
+              ([_conn _build form] (reset! seen form) canned)
+              ([_conn _build form _opts] (reset! seen form) canned)))
+      (-> (record/read-recording-tool (fresh-conn)
+                                      #js {:recording-id "r" :drain true :stop true})
+          (.then (fn [_]
+                   (is (str/includes? @seen "re-frame2-pair.runtime/read-recording"))
+                   (is (str/includes? @seen ":drain true"))
+                   (is (str/includes? @seen ":stop true"))))
+          (.finally (fn []
+                      (set! nrepl/cljs-eval-value orig)
+                      (done)))))))
+
+;; ---- watch-until ------------------------------------------------------------
+
+(deftest watch-until-resolves-on-held-predicate
+  (async done
+    ;; The poll form resolves to {:held? true ...} on the first eval.
+    (let [canned {:held? true :sample {0 :done} :t 1712}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (watch-until/watch-until-tool
+                (fresh-conn)
+                #js {:signals "[{:app-db [:upload :status]}]"
+                     :pred #js {:signal 0 :equals "done"}})))
+          (.then (fn [r]
+                   (is (not (tu/error? r)))
+                   (let [edn (tu/extract-edn r)]
+                     (is (true? (:ok? edn)))
+                     (is (true? (:held? edn)) "watch resolved on the predicate")
+                     (is (= {0 :done} (:sample edn)) "the satisfying sample rides back"))
+                   (done)))))))
+
+(deftest watch-until-times-out-with-last-sample
+  (async done
+    ;; The poll form never reports :held? — the watch must time out and
+    ;; surface the final sample. timeout-ms tiny so the test is fast.
+    (let [canned {:held? false :sample {0 "loading"} :t 1}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (watch-until/watch-until-tool
+                (fresh-conn)
+                #js {:signals "[{:dom \"#spinner\"}]"
+                     :pred #js {:signal 0 :equals "done"}
+                     :timeout-ms 120})))
+          (.then (fn [r]
+                   (let [edn (tu/extract-edn r)]
+                     (is (false? (:ok? edn)))
+                     (is (= :watch-timeout (:reason edn)))
+                     (is (true? (:timed-out? edn)))
+                     (is (= {0 "loading"} (:last-sample edn)) "final reading surfaced"))
+                   (done)))))))
+
+(deftest watch-until-no-signals-short-circuits
+  (async done
+    (-> (watch-until/watch-until-tool (fresh-conn)
+                                      #js {:pred #js {:signal 0 :equals 1}})
+        (.then (fn [r]
+                 (is (tu/error? r))
+                 (is (= :no-signals (:reason (tu/extract-edn r))))
+                 (done))))))
+
+(deftest watch-until-missing-pred-short-circuits
+  (async done
+    (-> (watch-until/watch-until-tool (fresh-conn)
+                                      #js {:signals "[{:focus true}]"})
+        (.then (fn [r]
+                 (is (tu/error? r))
+                 (is (= :missing-pred (:reason (tu/extract-edn r))))
+                 (done))))))
+
+(deftest watch-form-applies-pred-server-side
+  ;; The poll form must sample server-side AND apply the compiled
+  ;; predicate, returning :held? — so the wire payload is a boolean,
+  ;; not the whole sample-set re-tested client-side.
+  (let [form (watch-until/watch-form
+               [{:app-db [:x]}] :rf/default
+               (record/pred-source {:signal 0 :equals 1}))]
+    (is (str/includes? form "re-frame2-pair.runtime/sample-signals"))
+    (is (str/includes? form ":held?"))
+    (is (str/includes? form ":sample"))))


### PR DESCRIPTION
## Summary

First-classes the **signal recorder** the pair-debug workflow has been hand-building each session (a `requestAnimationFrame` loop pushing focus-slot + DOM snapshots into `window.__zoombug`) for intermittent / human-in-the-loop bugs (the rf2-yng0y render-timing race, only reproducible under real mouse input). Install an observer, let the human interact, read back a change-log — now a catalogued op, with the rAF/dedup/teardown footguns solved once in the runtime.

Three MCP tools over a runtime-side observer (`re-frame2-pair.runtime`):

| Tool | Verb shape | Role |
|---|---|---|
| `record` | bare mega-op | install a read-only observer over a signal-set + stop condition; returns a `:recording-id` immediately, runs in the background |
| `read-recording` | `read-` prefix | read the change-log back; `:drain` (poll→consume→repeat) / `:stop` (read-and-close) |
| `watch-until` | new `watch-` prefix | block (server-polls, like `tail-build`) until a predicate over the signal-set holds, or time out |

The rAF/dedup/teardown machinery is first-classed in the preload runtime (`start-recording!` / `read-recording` / `stop-recording!` / `sample-signals`): the sampler runs inside `requestAnimationFrame` (`next-tick` fallback), appends **only on a structural change** against the per-signal last value (dedup), **self-cancels** at the stop condition (and `cancelAnimationFrame` on manual stop), and a drop-oldest ring (`max-entries`) bounds memory on a forgotten recording. **Read-only by construction** — every sampler only reads (`get-in` / subscribe-deref / `querySelector` text+attr / `activeElement`); no dispatch, no app-db mutation, no DOM write. Reuses the nfjil DOM-read idiom + the gfu33 `after-render` family's substrate-agnostic posture where they fit.

## Op wire contracts

### `record`
**Signals** (vector of maps; EDN string or JSON array): `{:app-db [path]}` · `{:sub [query-v]}` · `{:dom "sel"}` / `{:dom "sel" :attr "name"}` · `{:focus true}` (a stable `activeElement` descriptor — the focus-slot).
**Stop** (`stop` arg; first to trip wins; defaults to `{:ms 30000}`): `:ms` · `:changes` · `:pred` (a **data** predicate map — compiled to a pure value-comparison fn, comparand quoted as data; no host source crosses the wire).
**Returns**: `{:ok? true :recording-id "rec-<uuid>" :signals [...] :frame <id> :stop {...}}`. Refusals: `:no-signals`, `:ambiguous-frame`.

### `read-recording`
**Args**: `recording-id` (req), `drain` (bool, default false — return buffered entries AND clear them), `stop` (bool, default false — tear down after reading).
**Returns**: `{:ok? true :recording-id <id> :status :recording|:stopped :stopped-reason <kw|nil> :frames-sampled <n> :count <n> :entries [{:i <signal-index> :signal {...} :value <v> :t <ms> :frame <rAF-counter>} ...]}`. Each entry is one **change**; two signals on the same paint share `:frame`. Refusals: `:missing-recording-id`, `:no-such-recording`.

### `watch-until`
**Args**: `signals` (req, same vocab as `record`), `pred` (req — `{:signal 0 :equals <v>}` / `:changed` / `:path` / `:contains` / bare `{:signal n}`), `timeout-ms` (default 30000), `frame`.
**Returns** on the first satisfying poll: `{:ok? true :held? true :elapsed-ms <n> :sample {<i> <v>} :t <ms>}`. On timeout: `{:ok? false :reason :watch-timeout :timed-out? true :last-sample {...}}`. Refusals: `:no-signals`, `:missing-pred`.

## Tools added + skill allow-list (the flzdp lesson)

Three new MCP tools: `record`, `read-recording`, `watch-until`. All catalogued and wired:
- **NAMING.md** — `record` added to the mega-op bare-verb row; new `watch-<thing>` prefix row; `read-`/`watch-`/`record` rows in the re-frame2-pair-mcp alignment table; §"What's NOT a locked verb" clarified.
- **DESIGN-RATIONALE.md** — Lock #8 records the verb picks (`record` bare mega-op, `watch-` prefix, `read-recording` on the existing `read-` prefix) + Post-Lock-#4 evolution note.
- **verb-vocab linter** — `watch` added to `verb-prefixes`, `record` to `bare-verbs`.
- **`skills/re-frame2-pair/SKILL.md` `allowed-tools`** — `mcp__re-frame2-pair__record`, `mcp__re-frame2-pair__read-recording`, `mcp__re-frame2-pair__watch-until`.
- **tool-names.json** fixture + the catalogue count (canonical site) updated to 22.
- Catalogued in `spec/003-Tool-Catalogue.md` (full per-tool sections) + `spec/API.md` (tool-surface table).

## Quality gates

| Gate | Result |
|---|---|
| pair-mcp unit suite (`npm test`) | **707 tests / 2041 assertions — 0 failures, 0 errors** |
| wire-vocab conformance (incl. verb-vocab) | **48 tests / 615 assertions — green** |
| mcp-base JVM suite (`clojure -M:test`) | **157 tests / 419 assertions — green** |
| pair end-to-end MCP conformance | **green — 22 tools advertised; every descriptor passes the SDK schema (inputSchema + outputSchema + annotations)** |
| mcp-conformance `test-all` orchestrator | **ALL GREEN** (pair end-to-end, story end-to-end, flag-gates, exec-safety) |
| skill↔MCP drift checker (`python scripts/check_skill_mcp_drift.py`) | **0 findings (exit 0)** |
| clj-kondo on changed files | **0 errors** (3 pre-existing warnings, none in new files) |
| runtime structural tests (`bb recorder_test.clj`) | **9 tests / 36 assertions — green** |

New tests: `record_test.cljs` (signal/stop/pred parsing, form composition, read-only, tool wiring, watch-until resolve+timeout — 16 cases) and `recorder_test.clj` (bb structural: change-dedup, self-cancelling teardown, rAF-with-fallback, ring cap, all stop conditions, read-only invariant — 9 cases).

A correctness fix landed while testing: the `:pred`/`:equals` comparand is now wrapped in `(quote ...)` so a hostile or list-shaped value (`:equals (js/alert "x")`) is compared as **data**, never evaluated as host source.

Closes rf2-zo4b9.
