### PR TITLE
refactor(story): naming/readability pass — clearer fn/ns/var names (rf2-18pef.21)

### DIFF
--- a/tools/story/src/re_frame/story/extends.cljc
+++ b/tools/story/src/re_frame/story/extends.cljc
@@ -21,10 +21,12 @@
   Cycle detection:
 
   - Walks the parent chain bounded by `*max-extends-depth*` (default 32).
-  - Throws `:rf.error/extends-cycle` if a cycle is detected (we revisit
-    an id already in the chain).
-  - Throws `:rf.error/extends-unknown` if a parent id is not registered
-    when `:extends` is resolved.
+  - Throws `:rf.error/story-extends-cycle` if a cycle is detected (we
+    revisit an id already in the chain), or
+    `:rf.error/story-extends-chain-too-long` if the chain exceeds the
+    depth cap.
+  - Throws `:rf.error/story-extends-unknown` if a parent id is not
+    registered when `:extends` is resolved.
 
   Stage 2 resolves at registration time (per IMPL-SPEC §2.6). Production
   builds elide the entire registration surface so `:extends` resolution
@@ -46,9 +48,11 @@
 
   `lookup` is a fn `(parent-id) → body-or-nil`.
 
-  Throws `:rf.error/extends-cycle` if a cycle is detected (an id
-  appears twice on the chain). Throws `:rf.error/extends-unknown` if a
-  named parent is not yet registered."
+  Throws `:rf.error/story-extends-cycle` if a cycle is detected (an id
+  appears twice on the chain) or `:rf.error/story-extends-chain-too-long`
+  if the chain exceeds `*max-extends-depth*`. Throws
+  `:rf.error/story-extends-unknown` if a named parent is not yet
+  registered."
   [body lookup]
   (loop [acc      []
          current  body
@@ -131,7 +135,8 @@
   closer to the child still shadow farther ones key-by-key as usual.
 
   Per IMPL-SPEC §4.6: 'Resolution at registration time. Cycles raise
-  `:rf.error/extends-cycle`.'"
+  `:rf.error/extends-cycle`.' (The implemented error id is namespaced
+  `:rf.error/story-extends-cycle` — see `chain-of`.)"
   ([body lookup] (resolve-extends body lookup nil))
   ([body lookup exclusive-groups]
    (if-let [_parent-id (:extends body)]


### PR DESCRIPTION
Naming/readability review of `tools/story/` (the Story tool source under `tools/story/src`), per epic rf2-18pef.

## Outcome — naming is already clean

`tools/story/src` (~100 source files) was reviewed across its spine: the public facade (`re-frame.story`), the play runner (`play/runner`), `extends`, `predicates`, `identity`, `args`, `decorators`, and `registrar`. The slice has been through several deliberate naming/refactor passes (facade thinning rf2-l8eso, the single fingerprint primitive fold rf2-5x1wt.3, the predicates leaf rf2-pzzbw), and it shows:

- Public names are spec-anchored and stable (the seven `reg-*` macros, the query API, the `:rf.story.*` reserved vocab) — renaming any of these would risk the cross-artefact contract with `tools/story-mcp` for no clarity gain.
- Internal fn/ns/var names are descriptive and consistent.
- Local bindings are either fully descriptive or tightly-scoped idiomatic single-letters (reducer accumulators, destructuring heads, PRNG math locals) that read clearly in context.

**No renames were warranted.** Per the conservative posture (rename only where it genuinely improves clarity; no speculative churn), I made no name changes.

## Rename summary

None. (Reviewed; the slice's naming is already at masterpiece standard.)

## Clarity fix applied (docstring-only, no name/behaviour change)

One concrete defect: `tools/story/src/re_frame/story/extends.cljc` docstrings named error ids the code never throws.

| Location | Docstring said | Code actually throws |
|---|---|---|
| ns docstring + `chain-of` + `resolve-extends` | `:rf.error/extends-cycle` | `:rf.error/story-extends-cycle` |
| ns docstring + `chain-of` + `resolve-extends` | `:rf.error/extends-unknown` | `:rf.error/story-extends-unknown` |
| (omitted entirely) | — | `:rf.error/story-extends-chain-too-long` |

The namespaced `:rf.error/story-extends-*` ids are what `extends.cljc` + `plan.cljc` throw, what the tests assert (`story_test.clj`, `plan_test.cljc`, `story_authoring_validation_test.clj`), and what `spec/017-Testing-Story.md` documents. The docstrings now name the actual thrown ids (and document the previously-undocumented chain-too-long id) so a reader grepping a docstring's error id lands on the throwing code. The verbatim IMPL-SPEC §4.6 quote is preserved with a parenthetical pointing at the implemented namespaced id.

## Notes (out of scope — NOT actioned)

- **Spec doc drift (not in this slice's safe-edit zone):** `tools/story/spec/001-Authoring.md` and `tools/story/spec/005-SOTA-Features.md` still use the short `:rf.error/extends-cycle` / `extends-unknown` forms. `spec/017-Testing-Story.md` already uses the correct namespaced ids. Left for a focused spec-consistency pass to avoid mixing a normative-doc edit into a naming PR.
- **`identity.cljc` doc/code mismatch (behavioural, not naming):** the ns docstring (lines 30-31, 88-91) says `canonical-version` was bumped to `:rf/snapshot-canonical-v2` and is "the first hashed slot", but `snapshot-tuple` emits the key `:rf/snapshot-canonical` with value `:rf/snapshot-canonical-v1`. This is a behavioural/version drift (fixing the value would re-stamp the hash), out of scope for a naming review — flagging for a separate bead.

## Quality gates

| Gate | Result |
|---|---|
| `tools/story` JVM tests (`clojure -M:test`) | PASS — 1548 tests, 5778 assertions, 0 failures, 0 errors |
| clj-kondo on changed file (`extends.cljc`) | PASS — 0 errors, 0 warnings |

Cross-artefact CLJS gate (`npm run test:cljs`): not run locally — the change is docstring-only with zero code, name, or signature changes, so there is no cross-artefact surface for it to affect. CI will run it.