### PR TITLE
docs(skills/re-frame2-xray): naming/readability pass (rf2-18pef.37)

### DIFF
--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -20,7 +20,7 @@ Xray is the **human-facing** panel; for an AI agent surface against the running 
 - `SKILL.md` — the skill itself
 - `references/launch-modes.md` — full launch-mode decision tree (preload vs `init!`, suppress-auto-open, `:rf.xray/layout-host-selector`, host-CSS-variable resize, pop-out lifecycle, wired hotkeys)
 - `references/panels.md` — the full tab tour in depth (6 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance)
-- `references/shared-components.md` — the components every L4 panel reuses (`edn_inspector/render`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
+- `references/shared-components.md` — the components every L4 panel reuses (`edn-inspector/render-node`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
 - `evals/evals.json` — trigger-eval fixtures (should-trigger + should-not-trigger entries, per skill-creator's description-optimisation contract)
 - `.claude-plugin/plugin.json` — Claude Code Plugin packaging metadata
 - `package.json` — npm packaging metadata (skill is also distributable as an Agent Skill)

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -34,7 +34,7 @@ tells*. Every dispatch is a node in a graph of causes; every state delta
 is a slice you can scrub; every machine transition lands on a chart; every
 schema violation surfaces as an issue you cannot miss.
 
-This skill answers two questions, and only two:
+This skill answers three questions, and only three:
 
 1. **How do I launch Xray?** — the inline panel, the pop-out, the
  programmatic entry points, the wired hotkeys, the Dynamic ↔ Static

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -487,7 +487,7 @@ than a single dispatch.
 
 ## Shared components + iconography
 
-The three components every L4 panel reuses (`edn_inspector/render`,
+The three components every L4 panel reuses (`edn-inspector/render-node`,
 `film_strip/header`, `focus_resolver`) and the full tab-icon / L2-badge /
 cross-panel-arrow glyph reference live in
 [`shared-components.md`](shared-components.md).

--- a/skills/re-frame2-xray/references/shared-components.md
+++ b/skills/re-frame2-xray/references/shared-components.md
@@ -8,11 +8,13 @@ each panel's perspective.
 
 Three components are consumed by every (or nearly every) L4 panel.
 
-### `edn_inspector/render`
+### `edn-inspector/render-node`
 
 The single canonical data renderer — lazy collapsible tree + inline
-diff highlighting + keyword accent + clickable paths. Lives at
-[`tools/xray/src/day8/re_frame2_xray/edn_inspector/render.cljs`](../../../tools/xray/src/day8/re_frame2_xray/edn_inspector/render.cljs)
+diff highlighting + keyword accent + clickable paths. The public entry
+point is the `render-node` fn in the
+`day8.re-frame2-xray.views.edn-inspector` namespace, which lives at
+[`tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs`](../../../tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs)
 per §021 §10. Every panel that shows data — app-db, Epoch coeffects /
 side-effect args / inline exception ex-data, Views sub values, Trace raw
 trace-event maps — goes through this renderer (§021 §10.6 — binding).


### PR DESCRIPTION
Naming/readability review of `skills/re-frame2-xray/` (rf2-18pef.37, parent epic rf2-18pef). SCOPE = `skills/re-frame2-xray/` only. Conservative, clarity-only.

## Changes

**Self-contradiction fix**
- `SKILL.md` lead-in said "This skill answers **two** questions, and only two:" but then enumerated **three** (launch / which-tab / chrome-around-the-tabs). Corrected the count to "three". The chrome question is a substantial in-scope section, so three is the accurate count for this file. (`README.md` keeps its own "two questions" higher-level framing — it lists exactly two and relegates chrome/workflow elsewhere, so it is internally consistent and left untouched.)

**Stale component name + dangling link fix**
- The shared data renderer was named `` `edn_inspector/render` `` and linked to `tools/xray/src/day8/re_frame2_xray/edn_inspector/render.cljs` — a path that does not exist. Renamed to the real public entry point `` `edn-inspector/render-node` `` (the `render-node` fn in the `day8.re-frame2-xray.views.edn-inspector` namespace, per spec 021 §10.6) and repointed the link to the actual source `views/edn_inspector.cljs`. Fixed in all three places it appeared: `references/shared-components.md` (heading + body), `references/panels.md`, `README.md`. The hyphenated form also matches the prose `**edn-inspector**` mention and the `:rf.xray.edn-inspector/expansion` app-db key already in the doc.

## Renames / link-fixes
- `edn_inspector/render` → `edn-inspector/render-node` (component name, 4 occurrences across 3 files)
- link `edn_inspector/render.cljs` → `views/edn_inspector.cljs` (was dangling)

## Frontmatter
- `allowed-tools` (Read / Grep / Glob) unchanged — flzdp gate intact.

## Quality gates
- Internal consistency: a relative-link validator over all 5 skill `.md` files reports all links resolve (the one previously-dangling `edn_inspector/render.cljs` is the link this PR fixes).
- `scripts/check_skill_redirect_anchors.py`: PASS
- `scripts/check_skill_mcp_drift.py`: PASS
- Edited files are under `skills/re-frame2-xray/`, outside the mkdocs `docs/` source tree, so `mkdocs build --strict` is unaffected.

## Out-of-scope note (not touched)
- `docs/skills/re-frame2-xray.md` (the mkdocs nav page) is stale — it still describes 7 Dynamic tabs with old names (Event · App DB · View · Routing · Issues). It lives outside `skills/re-frame2-xray/` so it is out of this bead's scope; flagging for a separate docs-sync bead.