### PR TITLE
refactor(template): naming/readability pass (rf2-18pef.22)

### DIFF
--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -273,7 +273,7 @@
                ;; compiles `:app`, so all of them hard-require `linked?`
                ;; (a real symlink/junction), not just the with-story tier.
                node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
-               env-over  {"NODE_PATH" node-path}]
+               env-overrides {"NODE_PATH" node-path}]
            (is linked?
                (str "project-local node_modules must resolve for the "
                     "`:app` (:browser) compile — it ignores NODE_PATH. "
@@ -288,7 +288,7 @@
              (let [{:keys [exit out]}
                    (run-process! (into ["clojure" "-M:shadow" "compile"]
                                        compile-targets)
-                                 proj env-over)]
+                                 proj env-overrides)]
                (is (zero? exit)
                    (str "`clojure -M:shadow compile "
                         (string/join " " compile-targets) "` exited " exit
@@ -301,7 +301,7 @@
                    (str "Compile step produced out/node-test.js for " label))
                (when (.isFile bundle)
                  (let [{:keys [exit out]}
-                       (run-process! ["node" "out/node-test.js"] proj env-over)]
+                       (run-process! ["node" "out/node-test.js"] proj env-overrides)]
                    (is (zero? exit)
                        (str "`node out/node-test.js` exited " exit
                             " for " label ". Output:\n" out))

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -55,7 +55,7 @@
   the scaffold doesn't trip us."
   [^java.io.File f]
   (let [eof    (Object.)
-        pbr    (rt/source-logging-push-back-reader (slurp f))
+        reader (rt/source-logging-push-back-reader (slurp f))
         ;; tools.reader respects *data-readers*; supply a permissive
         ;; default-data-reader so unknown tags don't throw.
         opts   {:eof eof :read-cond :allow :features #{:cljs}
@@ -63,7 +63,7 @@
     (binding [tr/*read-eval* false
               tr/*default-data-reader-fn* (fn [_tag value] value)]
       (loop [acc []]
-        (let [form (tr/read opts pbr)]
+        (let [form (tr/read opts reader)]
           (if (identical? form eof)
             acc
             (recur (conj acc form))))))))
@@ -89,12 +89,12 @@
           (update acc ::required (fnil conj #{}) spec)
 
           (and (vector? spec) (symbol? (first spec)))
-          (let [nsym  (first spec)
-                rest- (rest spec)
-                pairs (partition 2 rest-)
-                as-kv (some (fn [[k v]] (when (= k :as) v)) pairs)]
-            (cond-> (update acc ::required (fnil conj #{}) nsym)
-              as-kv (assoc as-kv nsym)))
+          (let [ns-sym    (first spec)
+                spec-tail (rest spec)            ;; the `:as alias`, `:refer […]`, … pairs
+                opt-pairs (partition 2 spec-tail)
+                alias-sym (some (fn [[k v]] (when (= k :as) v)) opt-pairs)]
+            (cond-> (update acc ::required (fnil conj #{}) ns-sym)
+              alias-sym (assoc alias-sym ns-sym)))
 
           :else acc))
       {::required #{}}

--- a/tools/template/test/day8/re_frame2_template/test_support.clj
+++ b/tools/template/test/day8/re_frame2_template/test_support.clj
@@ -159,8 +159,10 @@
    (run-template! tmp project-name substrate nil))
   ([tmp project-name substrate include-story?]
    (let [dir-str   (.toString ^Path tmp)
-         proj-name (-> project-name name (string/replace #"^.*?/" ""))
-         proj-dir  (io/file dir-str proj-name)
+         ;; deps-new names the output dir after the artifact portion of
+         ;; `acme/my-app` (the part after the `/`), so strip the group.
+         dir-name  (-> project-name name (string/replace #"^.*?/" ""))
+         proj-dir  (io/file dir-str dir-name)
          opts      (cond-> {:template   'day8/re-frame2-template
                             :name       (symbol project-name)
                             :target-dir (.getCanonicalPath proj-dir)


### PR DESCRIPTION
## Quality gates

| Gate | Command | Result |
|------|---------|--------|
| Template JVM tests | `clojure -M:test` (from `tools/template/`) | green — 22 tests, 300 assertions, 0 failures, 0 errors (unchanged from baseline) |
| clj-kondo (changed files) | `clj-kondo --lint <3 changed test files>` | 0 errors, 0 warnings |

Scope = `tools/template/` only. No production source, `template.edn`, `deps.edn`, `shadow-cljs.edn`, `.github`, or top-level spec touched.

## Naming review summary

The template **source** (`src/.../hooks.clj`), `template.edn`, `deps.edn`, and the per-substrate resource tree were reviewed and found already well-named: the deps-new contract fns (`data-fn`/`template-fn`/`post-process-fn`) are fixed by the deps-new wiring, the `:rf.error/*` ids are clear, and the `->file-path`/`->ns-form`/`coerce-substrate`/`coerce-include-story?` helpers read precisely. No source renames were warranted.

The only genuinely terse/misleading names lived in the **test harness**. Conservative renames applied:

| File / fn | From → To | Why |
|-----------|-----------|-----|
| `template_emission_test.clj` `parse-ns-requires` | `nsym` → `ns-sym` | match the `ns-sym` used in the docstring + Clojure convention |
| | `rest-` → `spec-tail` | drop the shadow-avoidance trailing dash; name what it is (the require-spec tail) |
| | `pairs` → `opt-pairs` | it's the option k/v pairs after the ns symbol |
| | `as-kv` → `alias-sym` | **misleading**: it holds the `:as` alias symbol, not a key/value pair |
| `template_emission_test.clj` `read-cljs-forms` | `pbr` → `reader` | spell out the abbreviation |
| `test_support.clj` `run-template!` | `proj-name` → `dir-name` (+ comment) | it's the output directory name (group stripped off `acme/my-app`), not a synonym for the `project-name` arg |
| `emitted_test_run_test.clj` `compile-and-run-emitted-test!` | `env-over` → `env-overrides` | align the binding with the `run-process!` parameter it feeds |

Closes rf2-18pef.22.
