### PR TITLE
refactor(machines): naming/readability pass (rf2-18pef.10)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -95,19 +95,19 @@
     - `:rf.error/machine-spawn-all-with-spawn` — a state node declares
       both `:spawn` and `:spawn-all` (mutually exclusive)."
   [state-key state-node]
-  (let [inv-all (:spawn-all state-node)]
-    (when inv-all
+  (let [spawn-all-spec (:spawn-all state-node)]
+    (when spawn-all-spec
       (when (:spawn state-node)
         (throw (validation-error
                  :rf.error/machine-spawn-all-with-spawn
                  "a state node cannot declare both :spawn and :spawn-all (they are mutually exclusive)"
                  {:state state-key})))
-      (when-not (map? inv-all)
+      (when-not (map? spawn-all-spec)
         (throw (validation-error
                  :rf.error/machine-spawn-all-bad-shape
                  ":spawn-all slot must be a map"
                  {:state state-key})))
-      (let [children (:children inv-all)]
+      (let [children (:children spawn-all-spec)]
         (when-not (and (vector? children) (seq children))
           (throw (validation-error
                    :rf.error/machine-spawn-all-bad-shape
@@ -133,20 +133,20 @@
                        :rf.error/machine-spawn-all-duplicate-id
                        "two children share an :id keyword inside the same :spawn-all block"
                        {:state state-key :duplicate-ids dup}))))))
-      (when-not (keyword? (:on-child-done inv-all))
+      (when-not (keyword? (:on-child-done spawn-all-spec))
         (throw (validation-error
                  :rf.error/machine-spawn-all-bad-shape
                  ":on-child-done is required (event keyword)"
                  {:state state-key})))
-      (when-not (keyword? (:on-child-error inv-all))
+      (when-not (keyword? (:on-child-error spawn-all-spec))
         (throw (validation-error
                  :rf.error/machine-spawn-all-bad-shape
                  ":on-child-error is required (event keyword)"
                  {:state state-key})))
-      (let [join (:join inv-all :all)]
+      (let [join (:join spawn-all-spec :all)]
         (cond
           (= :all join)
-          (when-not (vector? (:on-all-complete inv-all))
+          (when-not (vector? (:on-all-complete spawn-all-spec))
             (throw (validation-error
                      :rf.error/machine-spawn-all-bad-shape
                      ":on-all-complete event-vector is required when :join is :all (default)"
@@ -154,7 +154,7 @@
           (or (= :any join)
               (and (map? join) (or (pos-int? (:n join))
                                    (fn? (:fn join)))))
-          (when-not (vector? (:on-some-complete inv-all))
+          (when-not (vector? (:on-some-complete spawn-all-spec))
             (throw (validation-error
                      :rf.error/machine-spawn-all-bad-shape
                      ":on-some-complete event-vector is required when :join is :any / {:n N} / {:fn ...}"

--- a/implementation/machines/src/re_frame/machines/paths.cljc
+++ b/implementation/machines/src/re_frame/machines/paths.cljc
@@ -53,7 +53,7 @@
 
     (spawned-path)                   => [:rf/runtime :machines :spawned]
     (spawned-path parent-id)         => [:rf/runtime :machines :spawned parent-id]
-    (spawned-path parent-id inv-id)  => [:rf/runtime :machines :spawned parent-id inv-id]"
+    (spawned-path parent-id invoke-id) => [:rf/runtime :machines :spawned parent-id invoke-id]"
   ([]                    [:rf/runtime :machines :spawned])
   ([parent-id]           [:rf/runtime :machines :spawned parent-id])
   ([parent-id invoke-id] [:rf/runtime :machines :spawned parent-id invoke-id]))

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -913,17 +913,17 @@
 ;; wiring is the only delta — a small `args-builder` closure per mode.
 
 (defn- allocate-one
-  "Allocate one spawned-id from `inv-spec`'s `:machine-id` against `snap`'s
-  in-snapshot counter (rf2-gr8q). When `inv-spec` carries an explicit
+  "Allocate one spawned-id from `spawn-spec`'s `:machine-id` against `snap`'s
+  in-snapshot counter (rf2-gr8q). When `spawn-spec` carries an explicit
   `:spawn-id` literal (per-state singleton) the counter is NOT bumped.
   Returns `[snap' spawned-id]`."
-  [snap inv-spec]
-  (if-let [explicit (:spawn-id inv-spec)]
+  [snap spawn-spec]
+  (if-let [explicit (:spawn-id spawn-spec)]
     [snap explicit]
-    (allocate-spawned-id snap (:machine-id inv-spec))))
+    (allocate-spawned-id snap (:machine-id spawn-spec))))
 
 (defn- apply-on-spawn
-  "Run `inv-spec`'s `:on-spawn` advisory callback against `snap`'s `:data`.
+  "Run `spawn-spec`'s `:on-spawn` advisory callback against `snap`'s `:data`.
   Per Spec 005 §Declarative `:spawn` (rf2-grw4i / rf2-v0rrr), the signature
   is `(fn [{:keys [data id]}] _)` — context-map input, advisory return
   (any return value is ignored). Per rf2-t07u (Option A revised) the
@@ -933,8 +933,8 @@
   :rf/patch {...}}]` from a regular `:action`'s `:fx` vector instead (the
   fx is registered in `re-frame.machines` and handled by
   `re-frame.machines.lifecycle-fx.update-snapshot`)."
-  [machine snap inv-spec spawned-id]
-  (when-let [f (let [aref (:on-spawn inv-spec)]
+  [machine snap spawn-spec spawned-id]
+  (when-let [f (let [aref (:on-spawn spawn-spec)]
                  (when aref
                    (or (chase-ref (:on-spawn-actions machine) aref)
                        (chase-ref (:actions machine) aref))))]
@@ -953,17 +953,17 @@
   `:on-spawn` is intentionally NOT invoked here — the caller threads it
   separately because `:spawn-all`'s on-spawn callbacks thread `:data`
   writes across siblings."
-  [inv-spec mat-snap event spawned-id args-builder failure-extra]
-  (let [mat-result (if (contains? inv-spec :data)
-                     (materialise-data (:data inv-spec) mat-snap event)
+  [spawn-spec mat-snap event spawned-id args-builder failure-extra]
+  (let [mat-result (if (contains? spawn-spec :data)
+                     (materialise-data (:data spawn-spec) mat-snap event)
                      [::ok-data nil])]
     (if (result/fail? mat-result)
       (result/fail-with mat-result failure-extra)
-      (let [mat-data   (second mat-result)
-            inv-spec'  (if (contains? inv-spec :data)
-                         (assoc inv-spec :data mat-data)
-                         inv-spec)
-            spawn-args (args-builder inv-spec' spawned-id)]
+      (let [mat-data    (second mat-result)
+            spawn-spec' (if (contains? spawn-spec :data)
+                          (assoc spawn-spec :data mat-data)
+                          spawn-spec)
+            spawn-args  (args-builder spawn-spec' spawned-id)]
         (result/ok spawn-args [[:rf.machine/spawn spawn-args]])))))
 
 ;; ---- :spawn / :spawn-all spawn reducers ----------------------------------
@@ -978,22 +978,22 @@
   around a `result/fail` Result (stamped with
   `:action-ref :rf.spawn/data-fn` and `:spawn-id`) on `:data` failure."
   [machine parent-id s acc-fx prefix n event]
-  (let [inv          (:spawn n)
+  (let [spawn-spec   (:spawn n)
         invoke-id    (vec prefix)
-        [s-alloc id] (allocate-one s inv)
-        args-builder (fn [inv' spawned-id]
-                       (-> inv'
-                           (assoc :id-prefix     (:machine-id inv'))
+        [s-alloc id] (allocate-one s spawn-spec)
+        args-builder (fn [spec' spawned-id]
+                       (-> spec'
+                           (assoc :id-prefix     (:machine-id spec'))
                            (assoc :rf/spawned-id spawned-id)
                            (assoc :rf/parent-id  parent-id)
                            (assoc :rf/spawn-id  invoke-id)))
-        spawn-r      (spawn-one inv s-alloc event id args-builder
+        spawn-r      (spawn-one spawn-spec s-alloc event id args-builder
                                 {:action-ref :rf.spawn/data-fn
                                  :spawn-id  invoke-id})]
     (if (result/fail? spawn-r)
       (reduced spawn-r)
       (let [spawn-fx (result/fx spawn-r)
-            s'       (apply-on-spawn machine s-alloc inv id)]
+            s'       (apply-on-spawn machine s-alloc spawn-spec id)]
         [s' (into acc-fx spawn-fx)]))))
 
 (defn- handle-spawn-all-decl
@@ -1018,8 +1018,8 @@
   `:action-ref :rf.spawn-all/data-fn`, `:spawn-id`, and the failing
   `:child-id`) on `:data` failure."
   [machine parent-id s acc-fx prefix n event]
-  (let [inv-all   (:spawn-all n)
-        children  (:children inv-all)
+  (let [spawn-all-spec (:spawn-all n)
+        children  (:children spawn-all-spec)
         invoke-id (vec prefix)
         ;; (1) Allocate per-child ids deterministically; thread the snapshot.
         [s-alloc children-with-ids]
@@ -1035,7 +1035,7 @@
                       :done      #{}
                       :failed    #{}
                       :resolved? false
-                      :spec      inv-all
+                      :spec      spawn-all-spec
                       :spawn-id invoke-id}
         init-fx      [:rf.machine/spawn-all-init
                       {:rf/parent-id parent-id


### PR DESCRIPTION
## Quality gates

- machines JVM tests (`clojure -M:test`): **274 tests, 901 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5099 tests, 17225 assertions, 0 failures, 0 errors**
- clj-kondo on changed files: **0 errors** (12 pre-existing `with-ok` macro-destructure warnings, none on changed lines)

## Scope

Naming/readability review of `implementation/machines/` (rf2-18pef.10).
The slice is already very mature — it has been through many explicit
naming/clarity passes (rf2-2zzyg pipeline steps, rf2-8sz7f cascade
phases, rf2-aa2rw Result ADT, rf2-gwznv timer-key-as-map, rf2-lha2t
unified teardown, rf2-ur63f trace consolidation). Function names,
namespaces, and the phase decomposition are uniformly clear.

The one genuine terminology-drift island: the spawn-*declaration* map
(`:spawn` / `:spawn-all` body) was bound as `inv` / `inv-spec` /
`inv-all` (a vestige of XState-style "invoke" vocabulary), even though
the same concept is already called `spawn-spec` in
`finalize/find-spawn-spec-at` and throughout the validator docstrings
("child spawn-spec"). This PR unifies on that established term.

Note: the spawn-*site* identifier deliberately stays `invoke-id` — it is
the consistent slice-wide name for the prefix-path key (the `:spawned`
map is `parent-id -> invoke-id -> join-state`). Only the spawn-spec
binding was renamed.

## Renames (from -> to, why)

Private fns + local bindings only — **no public-API or `:rf.machine/*`
vocab change**:

| from | to | where |
|------|-----|-------|
| `inv-spec` | `spawn-spec` | `allocate-one`, `apply-on-spawn`, `spawn-one` (transition.cljc) |
| `inv` / `inv'` | `spawn-spec` / `spec'` | `handle-spawn-decl` (transition.cljc) |
| `inv-all` | `spawn-all-spec` | `handle-spawn-all-decl` (transition.cljc), `validate-spawn-all!` (validation.cljc) |
| `inv-id` | `invoke-id` | `paths/spawned-path` docstring example (match the actual parameter name) |

**Why:** removes the last `inv*` abbreviation island so the spawn path
reads in one consistent vocabulary — `spawn-spec` is the declaration,
`invoke-id` is the site, `spawned-id` is the resulting actor address.