### PR TITLE
refactor(examples/reagent): naming/readability pass (rf2-18pef.25)

### DIFF
--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -247,7 +247,7 @@
    :bio      "Canned demo user."
    :image    ""})
 
-(defn- counter-comment
+(defn- canned-comment
   "Synthesise a saved Comment reply for POST /articles/:slug/comments.
    The Spec 014 reply value is `{:comment <Comment>}`; the comments
    handler patches the optimistic temp card out and inserts this saved
@@ -289,7 +289,7 @@
       ;; POST /articles/:slug/comments — synthesise the saved Comment
       ;; the optimistic submit path expects.
       (and (= method :post) (re-find #"/articles/[^/]+/comments$" u))
-      (counter-comment (some-> req :body :comment :body))
+      (canned-comment (some-> req :body :comment :body))
 
       (str/includes? u "/articles/feed")
       {:articles [] :articlesCount 0}


### PR DESCRIPTION
## Quality gates

- **clj-kondo** on changed file: 0 errors, 0 warnings
- **`examples/realworld` shadow build** (worker sources, node_modules present): 216 files compiled, 0 warnings
- **`npm run test:cljs`**: 5099 tests / 17225 assertions, 0 failures, 0 errors
- (`test:examples` not run — examples are test-free; the build-compile + cljs-test gate covers this rename's correctness. No process kills.)

## Rename summary

One rename applied — a genuinely misleading name in an isolated, fully-contained spot:

| Before | After | Where |
| --- | --- | --- |
| `counter-comment` | `canned-comment` | `examples/reagent/realworld/core.cljs` (private `defn-` + its single call site) |

`counter-comment` suggested the `counter` example or a counting operation; the function actually synthesises a canned Conduit `Comment` payload for the demo `:rf.http/managed` stub. `canned-comment` matches the surrounding demo-stub vocabulary (`demo-articles`, `demo-tags`, `demo-user`; the fn delegates to `:rf.http/managed-canned-success`) and the existing test-fixture id `:realworld.test/canned-comment-post`. Private with one call site, so the rename is contained entirely in `core.cljs`.

## Review notes

The full `examples/reagent` substrate (16 example apps: boot, counter, flows, login, long_running_work, managed_http_counter, nine_states, notebook, realworld, routing, seven_guis ×6, ssr, ssr_streaming, state_machine_walkthrough, todomvc, websocket) was read end-to-end. It is already consistent and clear:

- Entry-point `run`; React root `react-root` / `root` (with documented `root-view` collision-avoidance + lazy-mount-isolation comments where applicable).
- Handler/sub/fx/cofx/action/guard naming conventions hold throughout: `handler-<feature>-<action>`, `sub-<name>`, `fx-<name>`, `cofx-<name>`, `action-<name>`, `guard-<name>?`.
- `:feature/event` keyword naming and machine-spec `def`s are uniform across the cluster. (One slice — `seven_guis/timer` — carries a doc-note that a prior pass already kebab-cased `tick-ms`.)

No further renames applied, per the conservative pre-alpha posture — remaining names are clear and changing them would be speculative churn.

## Confirmations

- **No `*.spec.cjs` added** (examples test-free lock rf2-8cevm respected).
- **No shadow-ns change needed / FLAGGED**: the `examples/realworld` build's `:init-fn realworld.core/run` is unchanged (only a private helper was renamed), so `implementation/shadow-cljs.edn` (hot-zone) is untouched.
- Scope was `examples/reagent/` only.

Closes rf2-18pef.25.