### PR TITLE
docs(skills/re-frame2): naming/readability pass (rf2-18pef.38)

### DIFF
--- a/skills/re-frame2/patterns/async-effect.md
+++ b/skills/re-frame2/patterns/async-effect.md
@@ -6,7 +6,7 @@ The canonical "external work + dispatched reply" shape every async-effecting fea
 
 This pattern is the *foundation* the **managed external effect** umbrella specialises. A managed effect (`:rf.http/managed`, `:rf.ws/*`, state-machine `:spawn`, `:rf.server/*`, `:rf.flow/*`) is an async effect with an eight-property contract layered on top — framework-owned lifecycle, structured failure taxonomy, retry/abort/teardown semantics, trace-bus observability. Author an ad-hoc async fx with this leaf; reach for [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) when authoring a *new* framework-owned surface (managed timers, managed background jobs, managed IndexedDB) that should inherit the umbrella's checklist.
 
-## When to load this leaf
+## When to load
 
 Load when the task is:
 

--- a/skills/re-frame2/patterns/forms.md
+++ b/skills/re-frame2/patterns/forms.md
@@ -6,7 +6,7 @@ The standard form-lifecycle convention. A 7-key slice (or one machine region) ca
 
 Forms is an **app-side** lifecycle slice composed on top of a **managed external effect** — almost always `:rf.http/managed` for the submit. The slice carries draft/touched/errors; the submit fx is framework-owned. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; the `:errors` vs `:submit-error` split here is exactly the seam where the umbrella's structured failure taxonomy hands off to app-level field-error UI.
 
-## When to load this leaf
+## When to load
 
 The prompt mentions: a form, validation, "show errors after submit", inline field errors, `:disabled` while submitting, a login / signup / settings / editor screen, or any UI that collects user input and submits it. Also load this leaf when picking between the **slice form** (a key in `app-db`) and the **machine form** (`:form-region` of a `reg-machine`) — see §Common variations.
 

--- a/skills/re-frame2/patterns/long-running-work.md
+++ b/skills/re-frame2/patterns/long-running-work.md
@@ -4,7 +4,7 @@ Cancellable spawn-and-join coordination via `:spawn-all` — one parent coordina
 
 State-machine `:spawn` / `:spawn-all` is one instance of the **managed external effect** umbrella — alongside `:rf.http/managed`, `:rf.ws/*`, `:rf.server/*`, and `:rf.flow/*`. The runtime owns child lifetime (spawn on entry, teardown on exit, abort on parent transition), failure classification under `:rf.machine/*`, and trace-bus observability — which is exactly what makes the spawn-and-join shape below correctness-by-construction. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; this leaf names the *coordination* shape on top.
 
-## When to load this leaf
+## When to load
 
 Load when the task is:
 

--- a/skills/re-frame2/patterns/nine-states.md
+++ b/skills/re-frame2/patterns/nine-states.md
@@ -4,7 +4,7 @@ A page-level rendering convention that makes every legal UI state explicit and t
 
 NineStates is the **rendering layer** that sits over the lifecycles produced by **managed external effects**. The `:data` region typically advances on replies from `:rf.http/managed`, `:rf.ws/*`, or a `:spawn`'d loader; the umbrella's framework-owned reply addressing and structured failure taxonomy is what makes the tag set (`:loading`, `:loaded`, `:error`, …) reliable enough to drive a priority table. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the underlying contract; this leaf names how a page renders across the lifecycle's cardinality.
 
-## When to load this leaf
+## When to load
 
 The prompt mentions: "nine states", "empty / one / some / too-many", "loading vs error vs success render", "page-level rendering states", "render priority", or a page that needs to render the cardinality of its loaded data distinctly. Also load this leaf when the user wants to combine a data lifecycle with a form lifecycle and a read-only mode in one screen and is asking "where does each state go?".
 

--- a/skills/re-frame2/patterns/remote-data.md
+++ b/skills/re-frame2/patterns/remote-data.md
@@ -6,7 +6,7 @@ The standard request-lifecycle convention. A 5-key slice (or one machine region)
 
 RemoteData is the **app-side** lifecycle slice that sits on top of a **managed external effect** — typically `:rf.http/managed`, but the shape composes with any framework-owned surface (`:rf.ws/*` request-reply messages, state-machine `:spawn`'d loaders, `:rf.server/*` per-request fxs). See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; this leaf names what the *receiving* state looks like once the umbrella's reply lands.
 
-## When to load this leaf
+## When to load
 
 The prompt mentions: fetching data from a server, an HTTP request lifecycle, a list/article/feed/profile that needs to load, "spinner vs revalidate", optimistic update, polling, or any feature whose `app-db` will hold "the result of a fetch". Also load this leaf when picking between the **slice form** (a key in `app-db`) and the **machine form** (`:data-region` of a `reg-machine`) — see §Common variations.
 

--- a/skills/re-frame2/patterns/stale-detection.md
+++ b/skills/re-frame2/patterns/stale-detection.md
@@ -4,7 +4,7 @@ The cross-cutting epoch idiom re-frame2 uses to silently ignore async results fr
 
 Stale-detection is the cross-cutting **correctness** idiom layered over **managed external effects** — `:rf.http/managed`, `:rf.ws/*`, state-machine `:spawn`, `:rf.server/*`, and `:rf.flow/*`. The umbrella's framework-owned reply addressing delivers the reply to the *originating* event id; this leaf names the epoch convention that decides whether the receiving state still wants it. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella.
 
-## When to load this leaf
+## When to load
 
 Load when the task is:
 

--- a/skills/re-frame2/references/cross-cutting/privacy-and-elision.md
+++ b/skills/re-frame2/references/cross-cutting/privacy-and-elision.md
@@ -1,4 +1,4 @@
-# Privacy and Size Elision
+# Privacy and size elision
 
 re-frame2 uses a **schema-first wire-boundary elision pass**. Every tool or listener that emits trace, listener, snapshot, sub-cache, or path data routes through `rf/elide-wire-value`, which consults the active frame's schema-derived `[:rf/runtime :elision]` registry.
 
@@ -9,14 +9,14 @@ Two per-slot Malli metadata flags are canonical:
 
 Sensitive wins when both flags apply; no large marker is emitted for a sensitive slot because the marker carries path/size metadata.
 
-## Authoring Rules
+## Authoring rules
 
 - Put `{:sensitive? true}` on app-schema slots that can hold credentials, auth tokens, payment details, or PII.
 - Put `{:large? true}` on app-schema slots that can exceed the wire budget, such as base64 blobs, PDFs, large JSON, logs, and generated reports.
 - Use handler metadata `{:sensitive? true}` only as a whole-handler escape hatch when sensitivity is cross-cutting and cannot be represented as an app-db schema slot.
 - Do not hand-roll redaction and do not use imperative large-path declarations; schema metadata is the declaration surface.
 
-## Schema Example
+## Schema example
 
 ```clojure
 (rf/reg-app-schema [:auth :login]
@@ -32,7 +32,7 @@ Sensitive wins when both flags apply; no large marker is emitted for a sensitive
 
 For a path-scoped handler like `[(rf/path :auth :login)]`, the router auto-installs trace/error redaction for matching sensitive schema paths. The handler body still receives the raw `:event` coeffect.
 
-## Handler Escape Hatch
+## Handler escape hatch
 
 ```clojure
 (rf/reg-event-fx :auth/exchange-token
@@ -59,7 +59,7 @@ Use this for custom forwarders, loggers, and pair-tool egress. Do not reimplemen
 
 Off-box defaults suppress both large and sensitive values. `:rf.size/include-large? true` and `:rf.size/include-sensitive? true` are for trusted in-box views only.
 
-## Registry Shape
+## Registry shape
 
 The runtime owns `[:rf/runtime :elision]` in app-db:
 
@@ -78,7 +78,7 @@ The registry is populated from app schemas and refreshed on schema hot reload. I
 
 If the walker sees a large string at a path with no `{:large? true}` schema metadata, dev builds emit `:rf.warning/large-value-unschema'd` once per `(frame, path)`. The fix is to add `{:large? true}` to the schema slot when the value should be elided.
 
-## Cross-References
+## Cross-references
 
 - Spec 009: privacy, schema-installed redaction, and size elision.
 - Spec 010: per-slot Malli metadata and schema walkers.

--- a/skills/re-frame2/references/cross-cutting/testing.md
+++ b/skills/re-frame2/references/cross-cutting/testing.md
@@ -74,8 +74,8 @@ Target a non-default frame with `{:frame :feature/frame-id}` in the trailing opt
   (rf/dispatch-sync [:counter/inc])
   (ts/assert-path-equals [:n] 1))
 
-(rf/with-new-frame [f :stories]      ;; bind a symbol AND the dynamic var
-  (is (= :stories f))
+(rf/with-new-frame [f (rf/reg-frame :stories {})]  ;; new frame, symbol AND dynamic var
+  (is (= :stories f))                              ;; reg-frame returns the id
   (is (= :stories (rf/current-frame))))
 ```
 

--- a/skills/re-frame2/references/fundamentals/frames.md
+++ b/skills/re-frame2/references/fundamentals/frames.md
@@ -25,7 +25,7 @@ Frames are mutable runtime objects, not values. User code holds keywords and let
 
 ;; Inspect.
 (rf/current-frame)                  ;; returns the active frame id
-(rf/get-frame-db :frame-id)         ;; underlying container (for tools / tests)
+(rf/get-frame-db :frame-id)         ;; current app-db VALUE (plain map, no deref)
 ```
 
 Verified in `re-frame.frame` (`reg-frame`, `make-frame`, `destroy-frame!`). The public macro layer is in `re-frame.core`.

--- a/skills/re-frame2/references/state-machines/tags.md
+++ b/skills/re-frame2/references/state-machines/tags.md
@@ -71,12 +71,12 @@ From `examples/reagent/nine_states/core.cljs` (the `render-priority` table + `:u
             render-priority))))
 
 ;; The root view: one `case`, not nine boolean discriminator subs + a cond.
-[case @(subscribe [:ui/render])
-   :done      [view-done]
-   :loading   [view-loading]
-   :error     [view-error]
-   ;; ...
-   ]
+(case @(subscribe [:ui/render])
+  :done    [view-done]
+  :loading [view-loading]
+  :error   [view-error]
+  ;; ...
+  )
 ```
 
 The render-priority table is plain data — adding a tenth case is one row.

--- a/skills/re-frame2/references/tooling/routing.md
+++ b/skills/re-frame2/references/tooling/routing.md
@@ -2,7 +2,7 @@
 
 > Authoring `reg-route`, programmatic navigation, link wiring, and the `:can-leave` pending-nav protocol. Assumes you already know what client-side routing is — this leaf only covers re-frame2's specific declarations.
 
-## When to load this leaf
+## When to load
 
 - Author or edit route registrations (`reg-route`).
 - Wire programmatic navigation (`:rf.route/navigate`) or anchor clicks (`:rf/url-requested`).

--- a/skills/re-frame2/references/tooling/stories.md
+++ b/skills/re-frame2/references/tooling/stories.md
@@ -28,7 +28,7 @@ Sketch in Storybook mentally, then translate.
 
 > **One-liner for the next leaf:** the same "think in Storybook, map onto Story" bridge applies to the recorder (`story-recorder.md`) and the agent loop (`story-mcp-loop.md`).
 
-## When to load this leaf
+## When to load
 
 - Author or edit a `.cljs` namespace under `<app>/stories/*` that uses `re-frame.story`.
 - Add a variant, decorator, mode, workspace, panel, or tag.

--- a/skills/re-frame2/references/tooling/story-mcp-loop.md
+++ b/skills/re-frame2/references/tooling/story-mcp-loop.md
@@ -4,7 +4,7 @@
 
 > **Mental model: think in Storybook, map onto Story.** When authoring a variant in step 1, sketch it as a Storybook story first (which args, which play steps?), then translate to the EDN `reg-variant` body — see `stories.md` §Mental model for the full concept map. The loop's distinctive twist over a Storybook play function: `:rf.assert/*` events *record* (they don't throw), so `read-failures` returns **every** mismatch in one pass — the agent refines against the complete failure set, not just the first thrown assertion.
 
-## When to load this leaf
+## When to load
 
 - An agent (Claude Code, Cursor, Copilot) is generating variants against a re-frame2 codebase and needs to iterate against the running Story library.
 - You're hand-driving the loop yourself via the MCP tool palette to debug a flaky variant.

--- a/skills/re-frame2/references/tooling/story-recorder.md
+++ b/skills/re-frame2/references/tooling/story-recorder.md
@@ -4,7 +4,7 @@
 
 > **Mental model: think in Storybook, map onto Story.** The recorder is Story's answer to Storybook 9's "record canvas interactions → CSF" feature. The difference is the output shape: Storybook emits a Testing-Library code translation; Story emits a pure-EDN `:play-script` step sequence with no DOM-event capture and no page-object layer. Picture the Storybook record-and-save flow, then map: `REC` toggle → `start-recording!` / `stop-recording!`; the generated CSF story → a `(reg-variant …)` form with an `:extends` link and a `:play-script` body. Full concept table in `stories.md` §Mental model.
 
-## When to load this leaf
+## When to load
 
 - A variant's `:play-script` body needs to grow but you'd rather drive the canvas than hand-author the event vectors.
 - You're scripting an MCP agent that calls `start-recording!` / `stop-recording!` on the variant frame.

--- a/skills/re-frame2/references/tooling/xray.md
+++ b/skills/re-frame2/references/tooling/xray.md
@@ -2,7 +2,7 @@
 
 > The host-app contract for mounting Xray (re-frame2's devtools panel) into a dev build. Assumes you already know what a devtools panel is — this leaf covers the mount strategy, the launch modes, the host-CSS-variable resize contract, the popout entry, and the suppress-auto-open knob. The deep prose lives in `tools/xray/spec/011-Launch-Modes.md`; this leaf is the authoring-side cheat sheet.
 
-## When to load this leaf
+## When to load
 
 - Adding Xray to an app's dev build (`shadow-cljs.edn` `:devtools :preloads`).
 - Wiring the right-side `[data-rf-xray-host]` layout slot into an app shell.


### PR DESCRIPTION
## Quality gates

- **Scope** — confined to `skills/re-frame2/` (15 files); mayor checkout shows nothing from this worker (no leak).
- **`allowed-tools` frontmatter** — INTACT. `SKILL.md` was not modified at all, so the `allowed-tools` block is byte-identical and the skill↔MCP drift gate (flzdp) is unaffected.
- **Intra-skill links** — no dangling links. No file/directory renames; only heading text changed, and no intra-skill anchor links target the renamed headings (verified `privacy-and-elision.md#…` has zero inbound anchors).
- **Heading consistency** — `## When to load this leaf` fully eliminated; all leaves now use `## When to load` uniformly.
- **mkdocs** — `mkdocs build --strict` passes (9.4s, no warnings/errors). The edited leaves are not in the mkdocs nav; the nav's `docs/skills/re-frame2.md` is a separate hand-authored page that does not reference any changed heading.
- **Skills structural test** — there is no structural runner for `skills/re-frame2` (the CI `skills-structural` job covers only `re-frame2-pair` + the shared retro-protocol test); confirmed internal consistency by hand.

## Summary of changes

Conservative naming/readability pass. No file/directory renames — leaf names are already clear, consistent kebab-case, and the structure is locked in `spec/design.md`. No behavioural-contract changes.

**Heading consistency (section names)**
- Normalised `## When to load this leaf` → `## When to load` across the 11 pattern + tooling leaves (async-effect, forms, long-running-work, nine-states, remote-data, stale-detection, routing, stories, story-mcp-loop, story-recorder, xray), matching `SKILL.md` and every fundamentals/state-machines leaf. The "this leaf" suffix is redundant when read from inside the leaf; dominant convention was 16 plain vs 11 suffixed.
- `privacy-and-elision.md`: converted Title Case headings → sentence case to match the house style of all ~30 other docs — `Authoring rules`, `Schema example`, `Handler escape hatch`, `Registry shape`, `Cross-references`, and H1 `Privacy and size elision`. This file was the lone Title-Case outlier.

**Code-sample correctness (verified against `implementation/**` + `examples/reagent/**`)**
- `frames.md` — the `rf/get-frame-db` signature comment said "underlying container (for tools / tests)". The public `rf/get-frame-db` returns the **deref'd app-db value** (plain map), per `core.cljc:1089` and `api-cheatsheet.md`; the container accessor is the *internal* `frame/app-db-container` (renamed in 49c7a6b2b). Comment corrected to "current app-db VALUE (plain map, no deref)" — it now matches the usage two screens down (`(rf/compute-sub … (rf/get-frame-db f))`).
- `testing.md` — `(rf/with-new-frame [f :stories] …)` is a **compile-time error**: the macro rejects a bare keyword (`core.cljc:818` — "use `with-frame` to pin to an existing frame-id"). Changed to `(rf/reg-frame :stories {})`, a frame-producing expression that yields `:stories`, so the demonstrated `(= :stories f)` / `(= :stories (current-frame))` assertions still hold. Now consistent with `frames.md`, which already used the correct `(rf/make-frame …)` form.
- `tags.md` — the root-view selector was written `[case @(subscribe [:ui/render]) …]` (a hiccup vector). `case` is a special form invoked with parens. Corrected to `(case @(subscribe [:ui/render]) …)`, matching `examples/reagent/nine_states/core.cljs:654` and `nine-states.md`.

## Deliberately left unchanged (conservative)
- Example var/id names that mirror ground truth (`tags-machine`, `nine-states-machine`, `:todo/sorted-todos` → `:todo/todos`) — renaming would diverge from the canonical examples (cardinal rules 1 & 5).
- `:play-script` in `story-recorder.md` worked examples — the recorder genuinely *emits* that transitional spelling and the file documents this honestly; rewriting to `:script` would misrepresent the recorder's output (behavioural, not naming).
- Closing-section heading variants in the patterns (`Pointers` / `Deeper pointers` / `Pointer to the spec`) and `boot`/`websocket`'s `When to use this pattern` — defensible per-leaf variation, high churn for low clarity gain.
- A pre-existing prose cross-ref nit (`production-observability.md` points at `frames.md §:on-error`, a section that lives here, not in frames.md) — content-accuracy, out of scope for a naming pass.