### PR TITLE
refactor(examples/uix): naming/readability pass (rf2-18pef.27)

### DIFF
--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -200,24 +200,24 @@
        ($ sparkline {:series series :id id}))))
 
 (defui filter-chips []
-  (let [active   (uix-adapter/use-subscribe [:dashboard/active-tags])
-        dispatch (rf/dispatcher)]
+  (let [active-tags (uix-adapter/use-subscribe [:dashboard/active-tags])
+        dispatch    (rf/dispatcher)]
     ($ :div.dash-chips
        (for [{:keys [id label]} all-tags]
          ($ :button {:key id
-                     :class (str "dash-chip " (when (contains? active id) "is-on"))
+                     :class (str "dash-chip " (when (contains? active-tags id) "is-on"))
                      :data-testid (str "dashboard-chip-" (name id))
                      :on-click #(dispatch [:dashboard/toggle-tag id])}
             ($ :span.dash-chip-dot {:class (str "tag-" (name id))})
             label)))))
 
 (defui range-picker []
-  (let [active   (uix-adapter/use-subscribe [:dashboard/range])
-        dispatch (rf/dispatcher)]
+  (let [active-range-id (uix-adapter/use-subscribe [:dashboard/range])
+        dispatch        (rf/dispatcher)]
     ($ :div.dash-chips
        (for [{:keys [id label]} ranges]
          ($ :button {:key id
-                     :class (str "dash-chip " (when (= active id) "is-on"))
+                     :class (str "dash-chip " (when (= active-range-id id) "is-on"))
                      :data-testid (str "dashboard-range-" (name id))
                      :on-click #(dispatch [:dashboard/set-range id])}
             label)))))


### PR DESCRIPTION
## Quality gates

- `npm run test:cljs`: 5099 tests / 17225 assertions, 0 failures, 0 errors
- `npx shadow-cljs compile examples/dashboard-uix`: build completed, 0 warnings
- clj-kondo: 0 errors / 0 warnings on changed files
- No `*.spec.cjs` under `examples/uix/` (lock rf2-8cevm honoured)
- No shadow-cljs entry-point ns changes (none needed)

## Renames applied (dashboard_uix/core.cljs)

Two sibling views (`filter-chips`, `range-picker`) both bound a local named `active`, but the values have different shapes — a set vs a scalar id. Disambiguated so the name carries the shape:

| View | Before | After | Why |
|---|---|---|---|
| `filter-chips` | `active` | `active-tags` | the active-tags **set**; mirrors the `:dashboard/active-tags` sub/event it reads (`contains?`) |
| `range-picker` | `active` | `active-range-id` | the selected range **id** (scalar); mirrors the `:dashboard/set-range` `range-id` vocabulary (`=`) |

## Left untouched (conservative)

- **counter_uix** — `counter-buttons`/`counter-app`/`count`/`dispatch` are already clear and match the Reagent + Helix counter siblings exactly.
- **login_uix** — local bindings `busy?`/`err`/`authed?` are **deliberately identical** across the Reagent/UIx/Helix login trio to demonstrate that only the view-layer idiom differs; renaming UIx-only would break that parity.
- **`defonce` mount roots** (`root` in counter, `react-root` in login/dashboard) already match each file's cross-substrate sibling; changing them would be cross-substrate churn, not a slice-local clarity win.
- ns names (`counter-uix.core` / `login-uix.core` / `dashboard-uix.core`) and `run` entry-points kept stable (referenced by shadow `:init-fn`).

Closes rf2-18pef.27.