### PR TITLE
docs(skills/re-frame2-setup): naming/readability pass (rf2-18pef.36)

### DIFF
--- a/skills/re-frame2-setup/references/deps-versions.md
+++ b/skills/re-frame2-setup/references/deps-versions.md
@@ -1,4 +1,4 @@
-# deps-versions
+# Dependencies & versions
 
 How to choose **which** re-frame2 artefacts to depend on, and **what version** to pin them at.
 

--- a/skills/re-frame2-setup/references/entry-namespace.md
+++ b/skills/re-frame2-setup/references/entry-namespace.md
@@ -1,4 +1,4 @@
-# entry-namespace
+# Entry namespace
 
 The canonical shape of `your-app/core.cljs` — the entry namespace shadow-cljs's `:init-fn` points at. This file is where re-frame2 wires up to the substrate (Reagent) and to the DOM.
 

--- a/skills/re-frame2-setup/references/first-counter.md
+++ b/skills/re-frame2-setup/references/first-counter.md
@@ -1,4 +1,4 @@
-# first-counter
+# First counter
 
 End-to-end worked example: a working re-frame2 counter in one file. This is the smallest piece of code that exercises every layer (event → handler → app-db change → sub recompute → view re-render).
 

--- a/skills/re-frame2-setup/references/shadow-cljs.md
+++ b/skills/re-frame2-setup/references/shadow-cljs.md
@@ -1,4 +1,4 @@
-# shadow-cljs
+# shadow-cljs build & index.html
 
 The minimal `shadow-cljs.edn` build for a greenfield re-frame2 Reagent single-page app, and the matching `index.html`.
 


### PR DESCRIPTION
## Quality gates

- `mkdocs build --strict` — PASS (exit 0, no ERROR/WARNING). The skill's
  doc page lives under `docs/` (out of scope, untouched); these edits are
  inside `skills/re-frame2-setup/`, which mkdocs does not build.
- Internal consistency — PASS. All intra-skill and cross-references
  resolve; no anchored links target the renamed H1s (verified repo-wide);
  frontmatter and `allowed-tools` untouched.

## Changes

Naming/readability review of `skills/re-frame2-setup/`. The slice is in
good shape — file names, code-sample identifiers (`reagent-adapter`,
`react-root`, `root-view`, `counter-buttons`), section headings, and
frontmatter are already clear and consistent across leaves.

The one substantive finding: the four reference-leaf **H1 titles** were
the outlier in the skill family. They opened with the bare file-stem,
while the rest of the family uses descriptive prose titles (e.g.
`re-frame2/references/fundamentals/{events,subs,fx}.md` →
`# Events`, `# Subscriptions`, `# Effects (fx)`;
`re-frame2-pair/references/ops.md` → `# Operations catalogue`).

Aligned them, filenames unchanged:

| File | Before | After |
|---|---|---|
| `references/deps-versions.md` | `# deps-versions` | `# Dependencies & versions` |
| `references/shadow-cljs.md` | `# shadow-cljs` | `# shadow-cljs build & index.html` |
| `references/entry-namespace.md` | `# entry-namespace` | `# Entry namespace` |
| `references/first-counter.md` | `# first-counter` | `# First counter` |

Filenames are clear and widely referenced; no anchored links target the
H1s, so renaming the titles breaks nothing. Scope was
`skills/re-frame2-setup/` only.

### Out-of-scope note (not changed)

`docs/skills/re-frame2-setup.md` says "all ten ship at the same version",
whereas the skill itself consistently says **eleven** artefacts. That doc
page is outside this slice's scope; flagging for a follow-up.
