### PR TITLE
refactor(adapters/test-react): naming/readability pass (rf2-18pef.6)

### DIFF
--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -148,7 +148,7 @@
 ;; children) can call the mount seam defined below it.
 (declare mount-tree!)
 
-(defn- component-render-fn
+(defn- render-body
   "If `tree` declares an imperative render body, return it; else nil. The body
   is `(fn [mount] ...)` run while a render is in flight (so any `unmount!`
   issued from within fires the guard organically, and any `mount-child!`
@@ -173,7 +173,7 @@
   (try
     (reset! (:render-tree mount) tree)
     (log-phase! mount :render)
-    (when-let [body (component-render-fn tree)]
+    (when-let [body (render-body tree)]
       (binding [*rendering-mount* mount]
         (body mount)))
     (finally


### PR DESCRIPTION
## Quality gates

- Slice JVM tests (`clojure -M:test` in `adapters/test-react`): **12 tests, 37 assertions, 0 failures, 0 errors**
- clj-kondo on the changed file: **0 errors, 0 warnings**
- `npm run test:cljs` (consumer-break catch): **5099 tests, 17225 assertions, 0 failures, 0 errors**

## Rename summary

| from | to | why |
|---|---|---|
| `component-render-fn` (private fn) | `render-body` | Aligns the accessor with the "render body" vocabulary used consistently across the src docstrings/comments, README, and tests (~18 occurrences). The accessor was the lone outlier naming the concept "render-fn"; the local it feeds is already `body`. Private fn, single call site — internal-only. |

Conservative pass: this slice is already very well-named and heavily documented. Only one genuine consistency win was found; everything else (`MountedComponent` + its fields, `active-mounts`, `render-depth`, `*rendering-mount*`, `rendering?`, `run-render!`, `unmount-thunk`, `mount-tree!`, `mount-child!`, the public `mount!`/`trigger-update!`/`unmount!`/`lifecycle-log`/`current-render-tree`/`mounted-roots`/`children` driver helpers) reads clearly and was left untouched to avoid churn.

## Adapter-contract names unchanged

Confirmed: the `:kind :rf.adapter/test-react` discriminator and all public adapter-map keys (`:make-state-container`, `:read-container`, `:replace-container!`, `:subscribe-container`, `:make-derived-value`, `:render`, `:render-to-string`, `:register-context-provider`, `:dispose-adapter!`) are untouched. No out-of-slice edits.

Closes rf2-18pef.6.