### PR TITLE
docs(skills/re-frame-migration): naming/readability pass (rf2-18pef.31)

### DIFF
--- a/skills/re-frame-migration/README.md
+++ b/skills/re-frame-migration/README.md
@@ -58,7 +58,7 @@ skills/re-frame-migration/
 ├── references/
 │   ├── kickoff-prompt.md          # Paste-ready prompt for a fresh session
 │   ├── setup.md                   # M-0 detail: dep-coord swap, substrate adapter picker
-│   ├── xray-replaces-10x.md      # Devtools swap: re-frame-10x → Xray (preload, host, keybindings, parity)
+│   ├── xray-replaces-10x.md       # Devtools swap: re-frame-10x → Xray (preload, host, keybindings, parity)
 │   ├── breaking-changes.md        # Rule index keyed to v1 trigger surfaces
 │   ├── sequencing.md              # Recommended rule order
 │   ├── auto-call-site-rewrites.md # Type A: per-call-site mechanical rewrites

--- a/skills/re-frame-migration/evals/evals.json
+++ b/skills/re-frame-migration/evals/evals.json
@@ -17,7 +17,7 @@
     {"id": 11, "name": "neg-live-pair",         "should_trigger": false, "prompt": "Inspect app-db right now on my running shadow-cljs build.", "rationale": "Live-runtime is re-frame2-pair."},
     {"id": 12, "name": "neg-port-language",     "should_trigger": false, "prompt": "I want to port re-frame2 to F#.", "rationale": "Porting the framework is re-frame2-implementor."},
     {"id": 13, "name": "neg-spec-question",     "should_trigger": false, "prompt": "What's the EP rationale for treating effects as data in v2?", "rationale": "Spec discussion belongs to SKILL-REDIRECT.md."},
-    {"id": 14, "name": "neg-xray-tour",        "should_trigger": false, "prompt": "Which Xray panel shows my schema violations?", "rationale": "Xray tour is its own skill."},
+    {"id": 14, "name": "neg-xray-tour",         "should_trigger": false, "prompt": "Which Xray panel shows my schema violations?", "rationale": "Xray tour is its own skill."},
     {"id": 15, "name": "neg-improver",          "should_trigger": false, "prompt": "Review events.cljs in my v2 project for anti-patterns.", "rationale": "Static critique is re-frame2-improver."},
     {"id": 16, "name": "neg-vocab-migrate-db",  "should_trigger": false, "prompt": "Migrate my Postgres database from 12 to 14.", "rationale": "Vocabulary hit ('migrate') on an unrelated surface."},
     {"id": 17, "name": "v1-addon-http-fx",      "should_trigger": true,  "prompt": "Our handlers use :http-xhrio (http-fx) everywhere — what's the v2 path?"},

--- a/skills/re-frame-migration/references/auto-cross-cutting.md
+++ b/skills/re-frame-migration/references/auto-cross-cutting.md
@@ -9,10 +9,10 @@ For the *why* of each rule, see [`MIGRATION.md`](../../../migration/from-re-fram
 - Framework keyword renames (M-20, M-35, M-54)
 - Tear-down verb renames (M-53)
 - Listener-registration verb unification (M-55)
+- `:rf.http/managed` `:retry :on` closed-set (M-31b)
 - Interceptor list cleanup (M-21 mechanical half)
 - View / hiccup rewrites (M-22, M-24)
 - `reg-event-fx` shape (M-26 mechanical half)
-- `:rf.http/managed` `:retry :on` closed-set (M-31b)
 - Init / adapter (M-40)
 - Per-feature artefact adds (M-27 through M-33)
 
@@ -201,8 +201,8 @@ Inside the body, drop `(rf/dispatcher)` / `(rf/subscriber)` captures — `dispat
 ```clojure
 ;; SEARCH (inside reg-view body)
 (let [d (rf/dispatcher)
- s (rf/subscriber)]
- [:button {:on-click #(d [:inc])} @(s [:count])])
+      s (rf/subscriber)]
+  [:button {:on-click #(d [:inc])} @(s [:count])])
 
 ;; REWRITE
 [:button {:on-click #(dispatch [:inc])} @(subscribe [:count])]

--- a/skills/re-frame-migration/spec/design.md
+++ b/skills/re-frame-migration/spec/design.md
@@ -97,7 +97,7 @@ skills/re-frame-migration/
 ├── references/
 │   ├── kickoff-prompt.md           (~70 lines)
 │   ├── setup.md                    (~170 lines)
-│   ├── xray-replaces-10x.md       (~240 lines; devtools swap — re-frame-10x → Xray)
+│   ├── xray-replaces-10x.md        (~240 lines; devtools swap — re-frame-10x → Xray)
 │   ├── breaking-changes.md         (~150 lines)
 │   ├── sequencing.md               (~150 lines)
 │   ├── auto-call-site-rewrites.md  (~250 lines; Type A — ns / effect-map / dispatch)


### PR DESCRIPTION
Naming/readability review of `skills/re-frame-migration/` (rf2-18pef.31, parent epic rf2-18pef). Conservative, clarity-only — no renames, no content changes, frontmatter (`allowed-tools`) untouched.

## Findings + changes

The slice is in good shape overall: file names, section headings, reference names, and code-sample identifiers are clear and consistent. Four small defects fixed:

- **`references/auto-cross-cutting.md`** — Contents/body order mismatch: the `:rf.http/managed :retry :on` (M-31b) entry was listed near the end of the Contents block but its section sits between M-55 and the M-21 interceptor-cleanup section in the body. Reordered the Contents entry to match.
- **`references/auto-cross-cutting.md`** — the M-22 `reg-view` SEARCH code sample had a mis-indented `let` binding vector + body; fixed to idiomatic Clojure alignment.
- **`README.md`** and **`spec/design.md`** — the `xray-replaces-10x.md` annotation column in both file-tree blocks was one space short of its siblings; aligned.
- **`evals/evals.json`** — the `neg-xray-tour` row's `should_trigger` column was misaligned with the surrounding rows; aligned.

## Quality gates

- `python scripts/check_readme_links.py --ci` — exit 0
- `python scripts/check_doc_slugs.py` — exit 0
- `python -m mkdocs build --strict` — exit 0 (skill is in the mkdocs nav)

No intra-skill links changed (whitespace/ordering only), so no dangling-link risk. Scope confined to `skills/re-frame-migration/`.