### PR TITLE
refactor(story-mcp): naming/readability pass (rf2-18pef.20)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/config.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/config.cljc
@@ -18,7 +18,7 @@
     CLI flag), from the JVM property `-Drf.story-mcp.allow-writes=true`,
     or programmatically (tests).
   - `allow-sensitive-reads?` — atom holding the sensitive-read gate. Read
-    by the wire-egress scrubbers (`helpers/include-sensitive?`); a `false`
+    by the wire-egress scrubbers (`args/include-sensitive?`); a `false`
     value forces redaction regardless of any per-call `:include-sensitive`
     arg. The default-OFF posture matches the cross-MCP convention for
     privacy gates: an operator who genuinely needs raw sensitive state
@@ -130,7 +130,7 @@
 ;;
 ;; Per the rf2-uaymx (b) decision, raw sensitive-state reads are an
 ;; operator-only opt-in. The wire-egress helpers
-;; (`helpers/include-sensitive?`) defer to this atom — when it is
+;; (`args/include-sensitive?`) defer to this atom — when it is
 ;; `false` the per-call `:include-sensitive` arg is silently treated as
 ;; `false`, so a hostile or careless caller cannot exfiltrate declared-
 ;; sensitive `:app-db` slots / assertion records by flipping a JSON

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
@@ -64,7 +64,7 @@
   The Anthropic Messages API constrains tool input-schema property
   keys to `^[a-zA-Z0-9_.-]{1,64}$` — the trailing `?` Clojure-idiomatic
   for booleans is rejected at the host, so the wire form drops it. The
-  predicate FUNCTION `helpers/include-sensitive?` retains the `?` (the
+  predicate FUNCTION `args/include-sensitive?` retains the `?` (the
   Clojure idiom belongs on the predicate, not on the data key whose
   wire form disallows it).
 
@@ -101,7 +101,7 @@
 
   Tools that don't carry the slot ignore any caller-supplied
   `:dedup` value at the dispatch boundary
-  (`cap/invoke-tool` gates dedup on the descriptor's
+  (`wire-pipeline/invoke-tool` gates dedup on the descriptor's
   `:dedup-eligible?` flag)."
   [props]
   (assoc props :dedup dedup-schema))
@@ -178,7 +178,7 @@
 ;; ---------------------------------------------------------------------------
 ;; outputSchema fragments (rf2-3l3be)
 ;;
-;; Story-mcp tools route through `helpers/text-result` / `error-result`,
+;; Story-mcp tools route through `result/text-result` / `error-result`,
 ;; both of which emit a dual-slot envelope (rf2-vw4sq) — `:content` plus
 ;; `:structuredContent`. The structuredContent slot carries the EDN
 ;; payload as a JS-coerced object; this fragment describes its shape so

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -1906,7 +1906,7 @@
         (is (= "TOPSECRET" (get-in s [:app-db :secret])))))))
 
 (deftest elide-app-db-include?-true-bypasses-walker
-  ;; rf2-brehq — the `include? true` branch of `helpers/elide-app-db`
+  ;; rf2-brehq — the `include? true` branch of `egress/elide-app-db`
   ;; skips `elide-wire-value` entirely. Pins behavioural equivalence
   ;; with the previous walking-then-no-edit implementation:
   ;;
@@ -1921,7 +1921,7 @@
   ;;      still pass (2) but break (1) — the load-bearing perf invariant
   ;;      this bead fixes.
   ;;
-  ;; Calls `helpers/elide-app-db` directly so the test pins the helper's
+  ;; Calls `egress/elide-app-db` directly so the test pins the helper's
   ;; contract, not a downstream tool's composition of it. Avoids
   ;; coupling to `run-variant`'s lifecycle behaviour.
   (testing ":include? true returns the input ref unchanged AND matches walker-with-both-knobs-on"


### PR DESCRIPTION
## Quality gates

- `clojure -M:test` (tools/story-mcp `:test` alias): **175 tests / 898 assertions, 0 failures, 0 errors**
- clj-kondo on changed files: **0 errors** (the 6 standalone warnings are pre-existing CLJC reader-conditional / unused-binding artefacts, none introduced here)
- Worktree boundary: edits confined to `tools/story-mcp/`; mayor checkout shows no leak

## What changed

Naming/readability review of `tools/story-mcp` (rf2-18pef.20, parent epic rf2-18pef).

The slice's functions, namespaces, files, operations, and let-bindings are already cleanly and consistently named — no code renames were warranted. The one genuine clarity defect found was a set of **stale namespace cross-references** in docstrings/comments, left over from the rf2-8yvyp `tools.helpers` split (helpers → `args` / `result` / `egress` / `cljs-resolve`) and the `cap` → `wire-pipeline` rename. A reader chasing these references landed on a namespace alias that no longer exists.

| Stale reference | Corrected to | Files |
|---|---|---|
| `helpers/include-sensitive?` | `args/include-sensitive?` | config.cljc (x2), schemas.cljc |
| `helpers/text-result` | `result/text-result` | schemas.cljc |
| `cap/invoke-tool` | `wire-pipeline/invoke-tool` | schemas.cljc |
| `helpers/elide-app-db` | `egress/elide-app-db` | tools_test.clj (x2) |

Documentation-only diff (7 lines): no function, namespace, file, let-binding, or **tool-id** renamed.

## Tool-id / wire-vocab confirmation

**No tool id renamed.** No MCP tool `:name`, input-schema property key, or response-payload key was touched. The wire-vocab and skill-drift gates are unaffected — the change is confined to prose inside docstrings/comments.