### PR TITLE
refactor(schemas): naming/readability pass (rf2-18pef.12)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -228,7 +228,7 @@
   schema / no validator; false on a logged failure.
 
   Parameters:
-    - `meta`         the registration metadata (handler / cofx / sub /
+    - `reg-meta`     the registration metadata (handler / cofx / sub /
                      fx) — its `:schema` slot, if any, is the schema.
     - `value`        the value being checked (event vector, cofx
                      value, sub return value, fx args).
@@ -266,9 +266,9 @@
   central `redact-tags` cond->. The `:rf.fx/args` clause is a no-op on
   the other three surfaces (their base-tags don't contain the
   slot), so a single redactor covers every meta-bearing emit site."
-  [meta value meta-sensitive? walk-schema? build-base-tags]
+  [reg-meta value meta-sensitive? walk-schema? build-base-tags]
   (if-let [vf @validator/validator-fn]
-    (if-let [schema (:schema meta)]
+    (if-let [schema (:schema reg-meta)]
       (if (vf schema value)
         true
         (let [explanation (validator/run-explainer schema value)


### PR DESCRIPTION
Naming/readability review of `implementation/schemas/` (the Malli schema registry/validation feature artefact), per epic rf2-18pef. Conservative pass — rename only where it genuinely improves clarity.

## Finding + rename

| from | to | why |
|------|----|----|
| `run-validation`'s `meta` param | `reg-meta` | The private validate-core's first positional parameter was named `meta`, shadowing `clojure.core/meta`. The docstring already describes it as "the registration metadata", and every caller passes a `*-meta` argument (`handler-meta` / `cofx-meta` / `sub-meta` / `fx-meta`). `reg-meta` removes the core shadow and reads truer at the binding site. |

That was the single genuine clarity win. The rest of the artefact is already cleanly named:

- **Public façade** (`re-frame.schemas`) and the `validator` / `storage` / `digest` / `validate` / `walker` / `malli` internals carry descriptive fn/ns names with thorough docstrings.
- All public fns (`reg-app-schema`, `app-schema-at`, `app-schemas`, `validate-event!`/`validate-cofx!`/`validate-fx!`/`validate-sub!`/`validate-app-schema!`, `set-schema-validator!` etc.), reserved keywords (`:rf.schema/*`, `:rf.warning/*`, `:rf/redacted`), and every `:schemas/*` late-bind hook key are **unchanged**.
- Checked for other `clojure.core` shadows in binding vectors (`name`/`key`/`val`/`type`/`count`/…) — none found.
- Terse-but-idiomatic locals (`acc'`, `m`, `d`, `vf`) left as-is: each is tightly scoped and conventional; renaming would add churn without a clarity gain (bead = be conservative).

## Public / reserved names
No public fn name, `:rf.schema/*` / reserved vocabulary, or late-bind hook key changed. Diff is internal: one private fn's parameter + its docstring line.

## Quality gates
- schemas artefact JVM tests (`clojure -M:test`): **192 tests, 18251 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (catches cross-artefact consumer breaks): **5099 tests, 17225 assertions, 0 failures, 0 errors**
- clj-kondo on changed file: **0 errors, 0 warnings**