### PR TITLE
docs(skills/re-frame2-implementor): naming/readability pass (rf2-18pef.32)

### DIFF
--- a/skills/re-frame2-implementor/README.md
+++ b/skills/re-frame2-implementor/README.md
@@ -50,7 +50,10 @@ skills/re-frame2-implementor/
 ├── package.json                   # npm metadata for distribution
 ├── .claude-plugin/
 │   └── plugin.json                # Claude Code plugin metadata
+├── evals/
+│   └── evals.json                 # Trigger-accuracy fixtures for the description
 ├── references/
+│   ├── cardinal-rules.md          # The ten rules in prose + anti-pattern corollaries
 │   ├── kickoff-prompt.md          # Paste-ready prompt for a fresh session
 │   ├── phase-1-decisions.md       # The Phase 1 walkthrough
 │   ├── decision-record.md         # Fill-in template for the locked decisions

--- a/skills/re-frame2-implementor/spec/authoring-prompt.md
+++ b/skills/re-frame2-implementor/spec/authoring-prompt.md
@@ -27,6 +27,7 @@ A self-contained prompt that re-authors the `re-frame2-implementor` skill from t
 > ├── package.json (npm metadata; mirror re-frame-migration shape)
 > ├── .claude-plugin/plugin.json (Claude Code plugin metadata)
 > └── references/
+> ├── cardinal-rules.md (~90 lines; the ten rules in prose + anti-pattern corollaries)
 > ├── kickoff-prompt.md (~80 lines; paste-ready prompt)
 > ├── phase-1-decisions.md (~200 lines; D1-D7 walkthrough)
 > ├── decision-record.md (~120 lines; fill-in template)

--- a/skills/re-frame2-implementor/spec/design.md
+++ b/skills/re-frame2-implementor/spec/design.md
@@ -113,7 +113,9 @@ skills/re-frame2-implementor/
 ├── LICENSE (MIT)
 ├── package.json (npm metadata)
 ├── .claude-plugin/plugin.json (Claude Code plugin metadata)
+├── evals/evals.json (trigger-accuracy fixtures for the description)
 ├── references/
+│ ├── cardinal-rules.md (the ten rules in prose + anti-pattern corollaries)
 │ ├── kickoff-prompt.md (paste-ready prompt)
 │ ├── phase-1-decisions.md (Phase 1 walkthrough)
 │ ├── decision-record.md (fill-in template)
@@ -129,7 +131,7 @@ skills/re-frame2-implementor/
 
 ## 6. Why this leaf split
 
-The seven reference leaves are sized to load on demand without spending context budget on irrelevant detail. Typical session loads:
+The eight reference leaves are sized to load on demand without spending context budget on irrelevant detail. Typical session loads:
 
 - **Phase 1 walkthrough**: `phase-1-decisions.md` + `decision-record.md`. ~320 LoC.
 - **Phase 2, single EP**: `phase-2-impl-order.md` (one section) + maybe `reference-impl-tour.md` (one section) + maybe `conformance.md`. ~250-400 LoC.


### PR DESCRIPTION
## Quality gates

- **Surface gate — internal consistency** (no skills-structural test covers this skill; the `skills-structural` CI job only runs `re-frame2-pair` + shared retro-protocol tests): PASS.
  - All eight `references/*.md` leaves referenced by SKILL.md exist on disk.
  - No dangling intra-skill links; sibling-skill links (`../re-frame2/`, `../re-frame-migration/`, `../re-frame2-setup/`) and the `../README.md#skill-routing--single-source` anchor resolve.
  - SKILL.md untouched → `allowed-tools` frontmatter intact (flzdp gate unaffected).
  - mkdocs nav references `docs/skills/re-frame2-implementor.md` (out of scope, not edited); the skill's own `.md` files are not in the nav, so `mkdocs build --strict` is not gated on this change.

## Changes

Naming/readability review of `skills/re-frame2-implementor/`. Content and naming were already high quality and internally consistent (lowercase-hyphenated leaf titles matching filenames, consistent block shape, clean cross-links). The one genuine defect: three layout/structure maps had drifted out of sync with the shipped artefact.

- **README.md Layout tree** — added the missing `references/cardinal-rules.md` leaf and the `evals/` dir. The tree previously omitted the home of cardinal rule 1, the most-referenced reference leaf.
- **spec/design.md §5 file-structure map** — added the same two entries so the "locked" structure matches the directory; **§6** corrected "seven reference leaves" → "eight".
- **spec/authoring-prompt.md reauthor structure** — added `cardinal-rules.md` so a reauthoring run from the prompt reproduces the shipped structure instead of dropping the rules leaf.

Scope confined to `skills/re-frame2-implementor/`. No SKILL.md / spec/ edits. 3 files, +7/-1.

Closes rf2-18pef.32 (parent epic rf2-18pef).