### PR TITLE
refactor(machines-viz): naming/readability pass (rf2-18pef.16)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -389,14 +389,14 @@
                                fallback-edges)
         edge-lines     (map render-edge edges)
         final-lines    (render-final-edges root-path states)
-        compound-lns   (render-compound-blocks root-path states 1)]
+        compound-lines (render-compound-blocks root-path states 1)]
     (str/join "\n"
               (concat
                (when header-comment? [header-comment])
                ["stateDiagram-v2"
                 (str "  [*] --> " (sanitise-id [initial]))]
                (render-root-fallback-alias root-path on 1)
-               compound-lns
+               compound-lines
                edge-lines
                final-lines))))
 


### PR DESCRIPTION
## Quality gates

- machines-viz test suite (`clojure -M:test`): **316 tests, 819 assertions, 0 failures, 0 errors** ✅
- clj-kondo on changed file: **0 errors, 0 warnings** ✅ (the one pre-existing `info` on line 416 is unrelated to this diff)

## Rename summary

Naming/readability review of the whole `tools/machines-viz/` slice (rf2-18pef.16, parent epic rf2-18pef). The codebase is already strongly named — namespaces, files, public fns, internal helpers, and let-bindings are clear, intention-revealing, and consistent across the chart parse / projection / render / overlay / share / export / scxml / mermaid surfaces.

One conservative local-binding rename applied:

| File | Before | After | Why |
|---|---|---|---|
| `mermaid.cljc` (`render-flat-or-compound-body`) | `compound-lns` | `compound-lines` | The lone abbreviated name in a `let` whose siblings are spelled-out `edge-lines` + `final-lines`; aligning it removes the odd-one-out abbreviation. |

## Public API unchanged

No public Var, fn, namespace, file, reserved keyword/namespace, or any reserved vocab changed. The edit is a single private-fn local binding used only twice within one `let`; `mermaid/emit` and every other public surface are byte-identical.