### PR TITLE
refactor(routing): naming/readability pass (rf2-18pef.11)

### DIFF
--- a/implementation/routing/src/re_frame/routing/match.cljc
+++ b/implementation/routing/src/re_frame/routing/match.cljc
@@ -238,7 +238,7 @@
 ;;   depth  — optional-group nesting depth
 ;;   parts  — accumulating regex string fragments
 ;;   names  — captured param names left-to-right (regex-group order)
-;;   gstack — stack of open optional-group cursor indices; on '{'
+;;   group-stack — stack of open optional-group cursor indices; on '{'
 ;;       we push the group-open index, on '}' we pop and record the
 ;;       close-end position so route-url can skip past an elided group
 ;;   inner  — output {group-open-idx → {:inner-names [...] :close-end <pos>}}
@@ -252,13 +252,13 @@
   [pattern]
   (let [n  (count pattern)
         i0 (if (and (pos? n) (= \/ (.charAt ^String pattern 0))) 1 0)]
-    (loop [i       i0
-           depth   0
-           parts   ["^/?"]
-           names   []
-           inner   {}
-           gstack  ()
-           counts  {:static 0 :named 0 :splat 0 :optional 0 :total 0}]
+    (loop [i           i0
+           depth       0
+           parts       ["^/?"]
+           names       []
+           inner       {}
+           group-stack ()
+           counts      {:static 0 :named 0 :splat 0 :optional 0 :total 0}]
       (if-not (< i n)
         (let [{:keys [static total splat optional named]} counts
               ;; Spec 012 §Route ranking algorithm rule 4: the catch-all
@@ -288,35 +288,35 @@
         (let [ch (.charAt ^String pattern i)]
           (cond
             (= ch \/)
-            (recur (inc i) depth (conj parts "/") names inner gstack counts)
+            (recur (inc i) depth (conj parts "/") names inner group-stack counts)
 
             (= ch \:)
             (let [start (inc i)
                   end   (segment-end pattern n start)
                   nm    (subs pattern start end)
-                  inner' (if (seq gstack)
-                           (update-in inner [(peek gstack) :inner-names]
+                  inner' (if (seq group-stack)
+                           (update-in inner [(peek group-stack) :inner-names]
                                       (fnil conj []) nm)
                            inner)
                   counts' (cond-> counts
                             (zero? depth) (-> (update :named inc)
                                               (update :total inc)))]
               (recur end depth (conj parts "([^/]+)") (conj names nm)
-                     inner' gstack counts'))
+                     inner' group-stack counts'))
 
             (= ch \*)
             (let [start (inc i)
                   end   (segment-end pattern n start)
                   nm    (subs pattern start end)
-                  inner' (if (seq gstack)
-                           (update-in inner [(peek gstack) :inner-names]
+                  inner' (if (seq group-stack)
+                           (update-in inner [(peek group-stack) :inner-names]
                                       (fnil conj []) nm)
                            inner)
                   counts' (cond-> counts
                             (zero? depth) (-> (update :splat inc)
                                               (update :total inc)))]
               (recur end depth (conj parts "(.+)") (conj names nm)
-                     inner' gstack counts'))
+                     inner' group-stack counts'))
 
             (= ch \{)
             ;; Open optional group: push group-open index for later
@@ -327,20 +327,20 @@
             (recur (inc i) (inc depth) (conj parts "(?:") names
                    (assoc-in inner [i :inner-names]
                              (get-in inner [i :inner-names] []))
-                   (conj gstack i)
+                   (conj group-stack i)
                    (update counts :optional inc))
 
             (= ch \})
             (let [i'        (inc i)
                   ?-suffix? (and (< i' n) (= \? (.charAt ^String pattern i')))
                   close-end (if ?-suffix? (inc i') i')
-                  inner'    (assoc-in inner [(peek gstack) :close-end] close-end)]
+                  inner'    (assoc-in inner [(peek group-stack) :close-end] close-end)]
               (recur close-end
                      (dec depth)
                      (cond-> (conj parts ")") ?-suffix? (conj "?"))
                      names
                      inner'
-                     (pop gstack)
+                     (pop group-stack)
                      counts))
 
             :else
@@ -350,7 +350,7 @@
                             (zero? depth) (-> (update :static inc)
                                               (update :total inc)))]
               (recur end depth (conj parts (regex-escape static-seg)) names
-                     inner gstack counts'))))))))
+                     inner group-stack counts'))))))))
 
 ;; ---- match-against --------------------------------------------------------
 

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -682,27 +682,30 @@
            (fn emit-group [i parts]
              (loop [i     i
                     parts parts]
-               (let [c2 (.charAt ^String pattern i)]
+               (let [ch (.charAt ^String pattern i)]
                  (cond
-                   (= c2 \})
-                   (let [k (inc i)]
-                     [(if (and (< k n) (= \? (.charAt ^String pattern k))) (inc k) k)
+                   (= ch \})
+                   (let [after-close (inc i)]
+                     [(if (and (< after-close n)
+                               (= \? (.charAt ^String pattern after-close)))
+                        (inc after-close)
+                        after-close)
                       parts])
 
-                   (= c2 \:)
+                   (= ch \:)
                    (let [start (inc i)
                          end   (match/segment-end pattern n start)
                          k     (keyword (subs pattern start end))]
                      (recur end (conj parts (url/url-encode (get path-params k)))))
 
-                   (= c2 \*)
+                   (= ch \*)
                    (let [start (inc i)
                          end   (match/segment-end pattern n start)
                          k     (keyword (subs pattern start end))]
                      (recur end (conj parts (url/url-encode-splat (get path-params k)))))
 
                    :else
-                   (recur (inc i) (conj parts (str c2)))))))
+                   (recur (inc i) (conj parts (str ch)))))))
            parts
            (loop [i     0
                   parts []]


### PR DESCRIPTION
## Quality gates

- Routing artefact JVM tests (`clojure -M:test` from `implementation/routing/`): **122 tests, 552 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (full node-runtime CLJS suite): **5099 tests, 17225 assertions, 0 failures, 0 errors**
- clj-kondo on the two changed files: **0 errors** (3 pre-existing `clojure.string` unresolved-namespace warnings on untouched lines — baseline, not introduced here)

## Renames (all internal loop-locals)

- **`match.cljc` `parse-pattern`**: `gstack` -> `group-stack` — loop binding, every `recur` site, the `peek`/`pop` uses, and the loop-state doc comment. The abbreviation was the one genuinely cryptic local in the single-pass parser.
- **`registry.cljc` `route-url` / `emit-group`**:
  - `c2` -> `ch` — the `c2` name only existed to dodge a non-existent collision with the outer `ch`; `emit-group` is a separate fn scope, so `ch` is clearer and matches the file convention.
  - the `}`-branch index `k` -> `after-close` — `k` was overloaded with the keyword-binding `k` used in the `:`/`*` branches; the new name says what the index is.

Everything else in the slice is already well-named (clear fns/ns/files/ops/docstrings), so no further changes.

## Public / reserved surface — unchanged

No public fn names, `:rf.route/*` / `:rf.nav/*` reserved vocab, namespaces, file names, or registered ids were touched. Scope was `implementation/routing/` only.

Closes rf2-18pef.11.