### PR TITLE
refactor(http): naming/readability pass (rf2-18pef.9)

### DIFF
--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -150,7 +150,7 @@
    - `:succeeded` / `:failed` are terminal leaf states; their
      `:entry` dispatches the parent's `[:succeeded value]` or
      `[:failed failure]`. When `:rf/parent-id` is nil (direct dispatch
-     of `[:rf.http/managed ...]` to the wrapper rather tha `:spawn`
+     of `[:rf.http/managed ...]` to the wrapper rather than `:spawn`
      spawning), the parent-dispatch is a benign no-op."
   []
   {:doc "Spec 014 — :rf.http/managed as a child-invokable state machine.

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -254,7 +254,7 @@
                                  :returned    out}))))
             (catch #?(:clj Throwable :cljs :default) t
               (let [data (ex-info ":rf.error/http-interceptor-failed"
-                                  {:where    'run-http-interceptor-chain!
+                                  {:where    'rf.http/run-interceptor-chain!
                                    :recovery :no-recovery
                                    :frame    frame-id
                                    :interceptor-id id
@@ -319,7 +319,7 @@
                                  :returned    out}))))
             (catch #?(:clj Throwable :cljs :default) t
               (let [data (ex-info ":rf.error/http-interceptor-failed"
-                                  {:where    'run-http-interceptor-after-chain!
+                                  {:where    'rf.http/run-after-chain!
                                    :recovery :no-recovery
                                    :frame    frame-id
                                    :interceptor-id id

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -91,8 +91,8 @@
 (defn clear-in-flight!
   "Clear a request handle from both indexes. Two arities:
 
-   - 1-arg `[request-id]` — the legacy form. Resolves the handle from
-     the request-id index and walks both indexes (the handle stores
+   - 1-arg `[request-id]` — the resolve-by-id form. Resolves the handle
+     from the request-id index and walks both indexes (the handle stores
      `:actor-id` so the actor-index slot can be located by identity).
      No-op when `request-id` is nil — anonymous requests use the 2-arg
      form below.


### PR DESCRIPTION
## Quality gates

- http artefact JVM tests (`clojure -M:test` from `implementation/http`): **277 tests, 1435 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5099 tests, 17225 assertions, 0 failures, 0 errors**
- clj-kondo on the 3 changed files: **0 errors, 0 warnings**

## Scope

Naming/readability review of `implementation/http/` (rf2-18pef.9, parent epic rf2-18pef). Read the whole `src` tree (14 namespaces, ~3.5K LoC). The slice is already very clean — descriptive fn/ns/file names, consistent reserved vocab, rich docstrings, multiple prior audit passes. Only three high-confidence, conservative edits applied (5 lines across 3 files).

## Renames / clarity edits

1. **`http-middleware`** — the two `:rf.error/http-interceptor-failed` ex-data `:where` symbols named functions that **do not exist** (`run-http-interceptor-chain!` / `run-http-interceptor-after-chain!`). Retargeted at the actual functions, qualified to match the `:where 'rf.http/...` style already used in `http-decode` and `util-json`:
   - `'run-http-interceptor-chain!` → `'rf.http/run-interceptor-chain!`
   - `'run-http-interceptor-after-chain!` → `'rf.http/run-after-chain!`

   These are diagnostic ex-data values (operator debugging aid), not part of any public contract — a stale symbol there points an operator at a non-existent fn.

2. **`http-machine-wrapper`** — docstring typo `rather tha` → `rather than`.

3. **`http-registry`** — `clear-in-flight!` docstring: `the legacy form` → `the resolve-by-id form`. Pre-alpha posture has no back-compat/legacy shapes; both arities are live and intentional, so "legacy" was misleading.

## Public / reserved vocab unchanged

Confirmed: no public fn names changed; no `:rf.http/*` reserved fx-ids, failure categories, or `:rf/*` reserved keywords touched. Edits are limited to one ex-data diagnostic symbol and two docstrings. No behaviour change.

## Out-of-slice (flagged, not actioned)

None of consequence. A couple of terse `ct` (content-type) locals in `http-transport`/`http-decode` are idiomatic and consistent; renaming would be churn for marginal gain — left as-is per the conservative posture.