### PR TITLE
docs(skills/re-frame2-improver): naming/readability pass (rf2-18pef.33)

### DIFF
--- a/skills/re-frame2-improver/references/schemaless-events.md
+++ b/skills/re-frame2-improver/references/schemaless-events.md
@@ -111,7 +111,7 @@ Other untrusted-boundary shapes that hit the same rule (the source varies, the g
 
 ;; localStorage rehydration
 (rf/reg-event-fx :session/rehydrate                              ;; flag — no always-on gate
-  (fn [_ _]
+  (fn [{:keys [db]} _]
     (let [raw (.getItem js/localStorage "session")]
       {:db (assoc db :session (js->clj (js/JSON.parse raw)))})))
 


### PR DESCRIPTION
## Quality gates

- mkdocs build --strict — GREEN (exit 0; this skill is in the docs nav). No errors/warnings touching the changed file.
- Internal consistency — all intra-skill links resolve; cross-links to `skills/re-frame2/patterns/`, `skills/re-frame2/references/`, `spec/`, and `skills/shared/retro-protocol.md` all verified to exist. Headings consistent across all six reference leaves (the locked five-section format). Frontmatter `allowed-tools` (Read/Edit/Grep/Glob) intact — no tool entries removed/renamed.
- No skills-structural test covers this skill path; internal-consistency gate applied instead.

## Changes

Naming/readability review of `skills/re-frame2-improver/` (SKILL.md + references/** + spec/**).

One change applied — a code-sample identifier fix in `references/schemaless-events.md`:

- The `:session/rehydrate` `reg-event-fx` worked example destructured its coeffects argument as `(fn [_ _] ...)` but then referenced an unbound `db`. Changed to `(fn [{:keys [db]} _] ...)`, matching the cofx-map signature used by every other `reg-event-fx` sample in the skill.

The rest of the skill was found already clear and internally consistent under the conservative pre-alpha posture:

- File names precisely name their anti-pattern (`boolean-discriminator-subs.md`, `manual-loading-flags.md`, `manual-retry-loops.md`, `schemaless-events.md`, `imperative-effects.md`, `view-side-hook-state.md`).
- Section headings uniform across leaves (Detection rules / Why it's an anti-pattern / The canonical fix / Worked example / Edge cases; schemaless-events carries the documented additive Regression-example section).
- Code-sample identifiers idiomatic CLJS (`!current-tab`, `!state`, `Article`, `:article/load`, etc.); handler arglists otherwise correctly bound.
- Skill vocabulary ("leaf", "catalogue", routing terms) deliberately matches the sibling skills — no renames applied, to preserve cross-skill consistency.