### PR TITLE
docs(skills/re-frame2-pair-retro): naming/readability pass (rf2-18pef.34)

### DIFF
--- a/skills/re-frame2-pair-retro/README.md
+++ b/skills/re-frame2-pair-retro/README.md
@@ -19,14 +19,18 @@ It can draft a GitHub issue (against `day8/re-frame2-pair` for tool-side frictio
 
 It is intentionally diagnosis-first: the default outcome is a better understanding of what went wrong and which improvements would matter most, not pressure to contribute code or file issues.
 
-## Repo contents
+## Directory contents
 
 - `SKILL.md` — the skill itself
+- `README.md` — this human-facing intro
 - `references/analysis-lenses.md` — friction taxonomy and prioritization prompts (re-frame2-aware)
 - `references/known-frictions.md` — recurring classes of product friction to pattern-match against
 - `references/issue-template.md` — GitHub-issue drafting structure (with the shell-safety pattern for transcript-derived bodies)
+- `spec/` — skill-internal meta-docs (`design.md`, `inputs.md`, `authoring-prompt.md`) for re-authoring the skill; not loaded during normal operation
+- `evals/evals.json` — trigger-accuracy fixtures (which prompts should and should not activate the skill)
 - `.claude-plugin/plugin.json` — plugin packaging metadata
 - `agents/openai.yaml` — UI metadata for skill lists and invocation
+- `package.json`, `LICENSE` — npm packaging metadata and the MIT licence
 
 ## Relationship to other repos
 

--- a/skills/re-frame2-pair-retro/spec/design.md
+++ b/skills/re-frame2-pair-retro/spec/design.md
@@ -120,6 +120,8 @@ skills/re-frame2-pair-retro/
 ├── .claude-plugin/plugin.json (Claude Code plugin metadata)
 ├── agents/
 │ └── openai.yaml (alt-host config — kept for cross-LLM operation)
+├── evals/
+│ └── evals.json (trigger-accuracy fixtures — which prompts should / should not activate)
 ├── references/
 │ ├── analysis-lenses.md (~140 lines; nine root-cause lenses + improvement shapes)
 │ ├── known-frictions.md (~120 lines; recurring re-frame2-pair pain patterns)


### PR DESCRIPTION
## Quality gates

- Shared retro-protocol structural test (the skills-structural CI job): `bb skills/shared/tests/retro_protocol_test.clj` — **24 tests, 37 assertions, 0 failures**. The gated `pair-retro-loads-shared-protocol` assertion (SKILL.md must link `../shared/retro-protocol.md`) is preserved (link untouched, 2 occurrences).
- Internal consistency: no file renames, no heading anchors referenced elsewhere, no dangling links introduced. `allowed-tools` frontmatter untouched (flzdp gate). No mkdocs nav page is sourced from these files, so `mkdocs build --strict` is unaffected.
- Edits confined to `skills/re-frame2-pair-retro/` (2 files). Mayor checkout verified clean of this work.

## Changes

Naming/readability review of `skills/re-frame2-pair-retro/`. The slice was already in strong shape after the prior naming-clarity pass (#2369); findings here are two conservative accuracy fixes to the file maps:

- **`README.md`** — renamed `## Repo contents` to `## Directory contents` (this is a skill subdirectory inside the re-frame2 monorepo, not a standalone repo) and completed the file map. It previously listed 6 of 11 top-level entries, omitting `README.md`, the `spec/` triad, `evals/`, `package.json`, and `LICENSE` — a reader using it as a "what's in here" map got an inaccurate picture.
- **`spec/design.md` §5 file structure** — added the `evals/` directory (`evals.json` trigger-accuracy fixtures) to the locked file-structure block, which had drifted (the directory exists but no doc named it).

No renames of files, no changes to section headings linked from other files, no `allowed-tools` changes, no behavioural content changes to the skill.

## Out-of-scope finding (not actioned)

`docs/skills/re-frame2-pair-retro.md` (a hand-authored docs page, outside this bead's scope) claims "classify root causes through **ten** lenses" and enumerates a list including a non-existent `context-window issue` lens. The canonical taxonomy in `analysis-lenses.md §Root-cause categories` and `design.md` L5 both say **nine** lenses with different names. Flagging for a follow-up against the `docs/` slice.