### PR TITLE
refactor(flows): naming/readability pass (rf2-18pef.8)

### DIFF
--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -118,11 +118,11 @@
   map; remove the `flow-id` key entirely when its inner map empties.
   The single home for the `last-inputs` two-level-map maintenance the
   clear / teardown / hot-reload paths share."
-  [m flow-id frame-id]
-  (let [m' (update m flow-id dissoc frame-id)]
-    (if (empty? (get m' flow-id))
-      (dissoc m' flow-id)
-      m')))
+  [index flow-id frame-id]
+  (let [pruned (update index flow-id dissoc frame-id)]
+    (if (empty? (get pruned flow-id))
+      (dissoc pruned flow-id)
+      pruned)))
 
 (defn- no-frame-holds?
   "True iff no frame in the per-frame `flows` map (`{frame-id {flow-id


### PR DESCRIPTION
## Quality gates

- `clojure -M:test` (flows artefact, from `implementation/flows/`): **117 tests, 489 assertions — 0 failures, 0 errors**
- `npm run test:cljs` (from `implementation/`): **5099 tests, 17225 assertions — 0 failures, 0 errors**
- `clj-kondo --lint src/re_frame/flows/registry.cljc`: **0 errors, 0 warnings**

## Rename summary

Naming/readability review of `implementation/flows/` (bead rf2-18pef.8). The slice is already at a very high standard — clear function names (`evaluate-flow!`, `run-flows-on-db`, `prune-frame-row`, `no-frame-holds?`, `dissoc-in-safe`, `valid-path?`, `depends-on?`, `extract-cycle-path`, `topo-sort`), descriptive let-bindings, and rich docstrings throughout both src and test trees. Conservative posture: one rename applied.

- `re_frame/flows/registry.cljc` — `prune-frame-row`: renamed the generic `m` / `m'` bindings to `index` / `pruned`. The function maintains a two-level `{flow-id {frame-id v}}` index; the new names make that intent legible at the binding site and align with the descriptively-named sibling helper `no-frame-holds?` (which already takes `flows-map`).

No other changes — remaining single-letter bindings (`m`/`acc` in the `teardown-on-frame-destroy!` reduce, the `m'`/`dep-set'`/`ready'` primes in `topo.cljc`) are idiomatic Clojure within short, clear scopes and were left untouched to avoid speculative churn.

## Public / reserved-names-unchanged confirm

Confirmed: all public fn names (`reg-flow`, `clear-flow`, `run-flows-on-db`, `flows-snapshot`, `last-inputs-snapshot`, `reset-flows!`, `reset-last-inputs!`, `teardown-on-frame-destroy!`) and the `:rf.flow/*` reserved vocabulary are unchanged. The only rename touches the parameter/local bindings of the private `prune-frame-row` helper — not part of any cross-artefact contract.

Scope: `implementation/flows/` only.