### PR TITLE
refactor(mcp-base): naming/readability pass (rf2-18pef.17)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -439,11 +439,11 @@
   present), the replay routes through the non-validating
   `apply-patches*` rather than the public `apply-patches`."
   [epoch]
-  (let [da (when (map? epoch) (:db-after epoch))]
-    (if-not (and (map? da)
-                 (= :db-before (get da vocab/diff-from-key)))
+  (let [db-after (when (map? epoch) (:db-after epoch))]
+    (if-not (and (map? db-after)
+                 (= :db-before (get db-after vocab/diff-from-key)))
       epoch
-      (let [sections  (:sections da)
+      (let [sections  (:sections db-after)
             _         (validate-sections! (or sections []) 'mcp-base/decode-db-after)
             patches   (sg/sections->patches (or sections []))
             db-before (:db-before epoch)

--- a/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
@@ -95,12 +95,12 @@
     - flat form           `{:rf.mcp/overflow`
     - namespaced-map form `#:rf.mcp{:overflow`"
   [marker-key]
-  (let [flat (str "{" marker-key)
-        ns'  (namespace marker-key)
-        nm   (name marker-key)]
+  (let [flat     (str "{" marker-key)
+        key-ns   (namespace marker-key)
+        key-name (name marker-key)]
     [flat
-     (if ns'
-       (str "#:" ns' "{:" nm)
+     (if key-ns
+       (str "#:" key-ns "{:" key-name)
        flat)]))
 
 (def marker-prefixes

--- a/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
@@ -132,8 +132,7 @@
   - Promote / classify: O(N) over clusters.
 
   All passes are linear in patch count — negligible vs the
-  walk that produced the patches. Pure data → data; `.cljc`."
-  (:require [clojure.string :as str]))
+  walk that produced the patches. Pure data → data; `.cljc`.")
 
 (def default-opts
   "Tunable knobs. Mirrors `tools/xray/.../section_grouping.cljc`'s


### PR DESCRIPTION
## Quality gates

- `clojure -M:test` (tools/mcp-base, JVM): **157 tests / 419 assertions, 0 failures, 0 errors** (green before and after).
- `clj-kondo --lint` on the three changed files: **0 errors, 0 warnings**. The pass also clears the only pre-existing warning in `src/` (a dead `clojure.string` require in `section_grouping.cljc`).
- Public API unchanged → no consumer suites required, but confirmed below.

## Renames

Conservative slice = `tools/mcp-base` only. All changes are internal — a dead require alias and two `let`-locals. No public fn/def/protocol/namespace renamed.

| File | Change | Kind |
|---|---|---|
| `section_grouping.cljc` | drop the dead `[clojure.string :as str]` require (unused since the ns no longer calls `str/*`) | dead require |
| `diff_encode.cljc` (`decode-db-after`) | terse local `da` → `db-after` | let-local |
| `envelope.cljc` (`marker-key-prefixes`) | cryptic locals `ns'` / `nm` → `key-ns` / `key-name` | let-locals |

## Public API unchanged — confirmation

No symbol consumed by `re-frame2-pair-mcp` / `story-mcp` / `mcp-conformance` was touched. The diff is limited to one removed `:require` (an unused alias, not re-exported) and two `let`-binding renames inside private/public fn bodies — no signature, name, or wire-vocabulary change. The cross-MCP wire contract (`vocab.cljc` marker keys, `overflow-payload` shape, `ResultIO`, cursor codec, `apply-patches`/`collect-patches`/`group-patches-into-sections`, `strip-sensitive`, `with-indicators`, `marker-text?`) is byte-identical.

The rest of `mcp-base` already carries genuinely excellent naming (precise public fns, clear private helpers, thorough docstrings); no further renames were warranted under the conservative posture.

Closes rf2-18pef.17.