### PR TITLE
refactor(ssr-ring): naming/readability pass (rf2-18pef.14)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -185,7 +185,7 @@
   appropriate escaping and the app's own styling/shell, instead of the
   hardcoded minimal `render-error-body`:
 
-    - a keyword → resolved as a registered view: `[error-view public]`
+    - a keyword → resolved as a registered view: `[error-view public-error]`
       (the view receives the public-error map as its single prop),
     - a 1-arity fn → called with the public-error map, returning hiccup.
 
@@ -197,13 +197,13 @@
   projector-throws-→-locked-500 fallback (Spec 011 §Where sanitisation
   happens). When no `:error-view` is supplied, the default template is
   used directly."
-  [frame-id error-view public]
+  [frame-id error-view public-error]
   (if (nil? error-view)
-    (render-error-body public)
+    (render-error-body public-error)
     (try
       (let [hiccup (cond
-                     (keyword? error-view) [error-view public]
-                     (fn? error-view)      (error-view public)
+                     (keyword? error-view) [error-view public-error]
+                     (fn? error-view)      (error-view public-error)
                      :else
                      (throw (ex-info ":rf.error/ssr-ring-invalid-error-view"
                                      {:rf.error/id :rf.error/ssr-ring-invalid-error-view
@@ -222,7 +222,7 @@
                             :exception (.getMessage t)
                             :ex-class  (.getName (class t))
                             :recovery  :fell-back-to-default-error-template})
-        (render-error-body public)))))
+        (render-error-body public-error)))))
 
 (defn ^:private build-full-response*
   "The non-error path of `build-full-response`. Split into its own fn
@@ -352,7 +352,7 @@
   (try
     (build-full-response* frame-id resp opts)
     (catch Throwable t
-      (let [public        (ssr/project-render-exception! frame-id t)
+      (let [public-error  (ssr/project-render-exception! frame-id t)
             ;; The projector stamped :status onto the response
             ;; accumulator inside `project-render-exception!`;
             ;; peek-response returns the resolved snapshot without
@@ -363,13 +363,13 @@
             ;; locked-500 generic shape, so the wire still carries
             ;; a well-formed body.
             resp*         (ssr/peek-response frame-id)
-            public*       (or public
+            public-error* (or public-error
                               {:status 500 :code :internal-error
                                :message "Something went wrong"
                                :retryable? false})
             ;; Spec 011 §Server error projection step 5: render a
             ;; caller-registered `:error-view` (receiving the public-
             ;; error map) when present, else the host default template.
-            body-html     (resolve-error-body frame-id (:error-view opts) public*)
+            body-html     (resolve-error-body frame-id (:error-view opts) public-error*)
             content-type  (:content-type opts)]
         (ssr-response->ring-response resp* body-html content-type)))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -118,7 +118,7 @@
 ;; structure (open tags balanced by what was emitted) and the server
 ;; logs the trace via the standard error-projection path.
 
-(defn- ^bytes ->utf8 ^bytes [^String s]
+(defn- ->utf8 ^bytes [^String s]
   (.getBytes s StandardCharsets/UTF_8))
 
 (defn- write-chunk! [^OutputStream out ^String s]


### PR DESCRIPTION
Naming/readability review of the SSR-Ring host adapter (`implementation/ssr-ring/`). Conservative pass per the pre-alpha masterpiece posture — renames only where genuinely clearer, no speculative churn.

## Renames

- **`pipeline.clj`** — `resolve-error-body`'s `public` param and `build-full-response`'s `public` / `public*` catch-block locals renamed to `public-error` / `public-error*`. The file's prose calls this value "the public-error map" in ~10 places; the bare `public` locals were the one place the code disagreed with its own docs (ambiguous: public *what*?). Also updated the matching `[error-view public]` docstring code example to `[error-view public-error]`.
- **`streaming.clj`** — dropped the redundant symbol-position `^bytes` hint on `->utf8` (`(defn- ^bytes ->utf8 ^bytes [...])`). The arg-vector position is the canonical return-type hint; the duplicate added noise.

## Public / reserved surface — unchanged

No change to the public surface (`ssr-handler`, `ssr-middleware`, `stream-handler`, `cookie->set-cookie-header`, `default-html-shell`, the `default-streaming-*` / `default-on-error` re-exports) or to any reserved vocabulary (`:rf/*` keys, `:rf.error/*` ids, opt names). Only internal `let`/param locals and one redundant type hint touched.

## Flagged, not actioned (out of naming-pass remit)

- `run-streaming-writer!` (`streaming.clj`) destructures `emit-hash?` and `content-type` and takes a `resp` param that go unused — three pre-existing clj-kondo `unused binding` warnings (0 errors). Removing them is a behavioural-cleanliness change, not a naming fix; left for a follow-up if desired.

## Quality gates

- `clojure -M:test` (ssr-ring artefact): **76 tests, 364 assertions, 0 failures, 0 errors** (unchanged from baseline).
- `clj-kondo --fail-level error` on both changed files: **0 errors** (3 pre-existing warnings, listed above, none on changed lines).
