### PR TITLE
refactor(ssr): naming/readability pass (rf2-18pef.13)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -33,9 +33,9 @@
       ;; frame if there is exactly one — the canonical SSR-request
       ;; shape.
       (nil? tag-frame)
-      (let [server-fids (filter error-projector/server-frame? (frame/frame-ids))]
-        (when (= 1 (count server-fids))
-          (first server-fids)))
+      (let [server-frame-ids (filter error-projector/server-frame? (frame/frame-ids))]
+        (when (= 1 (count server-frame-ids))
+          (first server-frame-ids)))
 
       :else nil)))
 
@@ -93,13 +93,13 @@
      (apply-error-projection! frame-id last-trace)))
   ([frame-id trace-event]
    (when (and frame-id trace-event (error-projector/server-frame? frame-id))
-     (let [public    (error-projector/project-error frame-id trace-event)
-           existing  (response/response-of frame-id)
-           redirect? (:redirect existing)]
+     (let [public-error (error-projector/project-error frame-id trace-event)
+           existing     (response/response-of frame-id)
+           redirect?    (:redirect existing)]
        (when-not redirect?
          (response/swap-response! frame-id
-                                  (fn [r] (assoc r :status (:status public)))))
-       public))))
+                                  (fn [r] (assoc r :status (:status public-error)))))
+       public-error))))
 
 (defn project-render-exception!
   "Route a render-time `Throwable` through the SSR error projector for
@@ -168,12 +168,12 @@
       ;; the projection that stamps :status on the response and
       ;; returns the public-error map the caller uses to render the
       ;; wire body.
-      (let [public (apply-error-projection! frame-id trace-event)]
+      (let [public-error (apply-error-projection! frame-id trace-event)]
         ;; Clear any duplicate buffer entry the listener appended above
         ;; (apply-error-projection! 2-arity does not drain). Without
         ;; this a later peek/flush would re-project the same event.
         (consume-pending-traces! frame-id)
-        public))))
+        public-error))))
 
 (defn error-projection-listener
   "Dev-only trace-cb listener — captures error trace events bound to a
@@ -196,8 +196,8 @@
     (let [op (:operation event)]
       ;; Skip our own sanitisation traces to avoid recursion.
       (when-not (= :rf.error/sanitised-on-projection op)
-        (when-let [fid (candidate-frame-for-error event)]
-          (buffer-error-trace! fid event))))))
+        (when-let [frame-id (candidate-frame-for-error event)]
+          (buffer-error-trace! frame-id event))))))
 
 (defn error-emit-projection-listener
   "Always-on error-emit-substrate listener (per rf2-fb598 / audit Finding
@@ -228,7 +228,7 @@
             ;; back to the candidate-frame lookup used on the trace-cb
             ;; path so a record missing `:frame` still routes to the
             ;; single active server frame when one exists.
-            direct-fid (:frame record)
+            direct-frame-id (:frame record)
             ;; Synthesise a trace-event-shaped envelope. The projector
             ;; reads `(:operation event)`; we copy the relevant flat
             ;; slots onto `:tags` so custom projectors using the tag
@@ -244,10 +244,11 @@
                                :time              (:time       record)
                                :source-coord      (:source-coord record)
                                :recovery          :no-recovery}}]
-        (when-let [fid (if (and direct-fid (error-projector/server-frame? direct-fid))
-                         direct-fid
-                         (candidate-frame-for-error event))]
-          (buffer-error-trace! fid event))))))
+        (when-let [frame-id (if (and direct-frame-id
+                                     (error-projector/server-frame? direct-frame-id))
+                              direct-frame-id
+                              (candidate-frame-for-error event))]
+          (buffer-error-trace! frame-id event))))))
 
 (defn peek-response
   "PURE read of the resolved response accumulator for a frame — does

--- a/implementation/ssr/src/re_frame/ssr/error_projector.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_projector.cljc
@@ -176,7 +176,7 @@
                                 :reason            "Error projector threw — using fallback."
                                 :recovery          :warned-and-replaced})
             ::threw))
-        public
+        public-error
         (cond
           (public-error-shape? result)
           result
@@ -196,7 +196,7 @@
                                 :reason            "Error projector returned a non-conforming shape — using fallback."
                                 :recovery          :warned-and-replaced})
             fallback-public-error))]
-    (cond-> public
+    (cond-> public-error
       dev-detail? (assoc :details trace-event))))
 
 (defn server-frame?


### PR DESCRIPTION
Naming/readability review of the `implementation/ssr` artefact (rf2-18pef.13, parent epic rf2-18pef). Conservative, internal-only.

## Rename summary

Two files touched; all changes are internal `let`/binding renames that align with the slice's own dominant vocabulary.

- **`error_projector.cljc`** — `project-error`'s `public` local → `public-error`. Matches the pervasive domain noun (`public-error-keys`, `fallback-public-error`, `public-error-shape?`, the `:rf/public-error` wire shape, and every docstring that says "public-error map").
- **`error_listener.cljc`** —
  - `public` → `public-error` in `apply-error-projection!` (2-arity) and `project-render-exception!`, same rationale.
  - `fid` / `server-fids` / `direct-fid` → `frame-id` / `server-frame-ids` / `direct-frame-id`. The same functions already take a `frame-id` parameter, so the shorthand was a within-file inconsistency, not a convention. (`fid` survives in tests across the repo but appeared in production `src` only here.)

## Reviewed-and-left-unchanged

The slice is already mature and uniformly well-named; most of it needed nothing.

- **`substrate.cljc`** `(fn [_ _ prev nu] ...)` watch callback is **deliberately left as-is** — it is byte-identical to `core/src/re_frame/substrate/atom_container.cljc` and `spine.cljs`. `nu` is the repo-wide convention for the watcher's new-value arg; renaming here would diverge from the parallel core file the SSR adapter intentionally mirrors.
- Public fn names, namespaces, files, and all reserved `:rf.ssr/*` / `:rf.server/*` / `:rf/hydration` / `:rf.ssr.payload/*` vocabulary are **unchanged**.

## Out-of-slice (flagged, not actioned)

- Pre-existing clj-kondo warnings outside scope/untouched: `head/emit.cljc` "namespace clojure.string required but never used" (false positive — `str/replace`/`str/join` are used inside the `:clj` `letfn` branch) and `response.cljc:486` unused binding `loc` in `parse-url-safely`'s `:cljs` arm. Left as-is — neither is in the changed files.

## Quality gates

- ssr artefact JVM tests (`clojure -M:test`): **238 tests, 818 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5099 tests, 17232 assertions, 0 failures, 0 errors**
- clj-kondo on the two changed files: **0 errors, 0 warnings**

Public/reserved surface confirmed unchanged.