### PR TITLE
refactor(examples/reagent-slim): naming/readability pass (rf2-18pef.26)

### DIFF
--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -1,7 +1,7 @@
 (ns counter-slim-and-fast.core
   "A minimal counter mounted on the day8/reagent-slim rewrite. Binds the
-   S3-008 contract from reagent-slim's
-   IMPL-SPEC §1.4 + §1.8 + §6 + §12.
+   S3-008 + S3-005 bundle-isolation contract from reagent-slim's
+   IMPL-SPEC §1.4 + §1.8 + §8.
 
    Same six-domino dataflow as `examples/reagent/counter`, but every
    user-facing Reagent import points at `reagent2.*` instead of stock
@@ -10,11 +10,12 @@
 
    What this fixture proves (the Reagent Slim bundle-isolation contract):
 
-     - The advanced-compiled bundle for this example contains NO
-       `reagent.impl.*` symbols. The slim rewrite has its own
-       `reagent2.impl.*` substrate; the bridge's `reagent.impl.*`
-       internals must be entirely absent.
-     - The bundle contains NO `react-dom/server` symbols. The slim's
+     - Stock-Reagent impl isolation (S3-008): the advanced-compiled
+       bundle for this example contains NO `reagent.impl.*` symbols.
+       The slim rewrite has its own `reagent2.impl.*` substrate; the
+       bridge's `reagent.impl.*` internals must be entirely absent.
+     - Pure-CLJS SSR (S3-005): the bundle contains NO `react-dom/server`
+       symbols. The slim's
        `reagent2.dom.server/render-to-static-markup` is pure-CLJS
        (per IMPL-SPEC §8.7), so the bundle has no compiled-in path
        to `react-dom/server`.
@@ -25,12 +26,9 @@
    See `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` for the
    bundle-isolation grep that enforces both invariants in CI.
 
-   NOTE on frame-provider: the namespace docstring on
-   `counter.core` describes a frame-provider variant of this example
-   wired in `examples/reagent/login`. The slim variant stays on the
-   default frame for the same reason — it keeps the smoke test
-   focused on the substrate swap (stock → slim) rather than the
-   frame-provider feature."
+   NOTE on frames: this fixture stays on the default frame
+   deliberately. Keeping it single-frame focuses the bundle-isolation
+   check on the substrate swap (stock -> slim) and nothing else."
   (:require [reagent2.dom.client                :as rdc]
             [reagent2.dom.server                :as rds]
             [re-frame.core                      :as rf]


### PR DESCRIPTION
Naming/readability review of `examples/reagent-slim/` (the adapter-owned slim showcase, `counter_slim_and_fast`). Closes rf2-18pef.26 (parent epic rf2-18pef).

## Findings

Code identifiers are already clean: the ns (`counter-slim-and-fast.core`), vars (`root`, `run`, `counter-buttons`, `counter-app`), event/sub keys (`:counter/*`), and require aliases (`rdc`/`rds`/`rf`/`reagent-slim-adapter`) all mirror the canonical `examples/reagent/counter` twin and read clearly. **No renames warranted.**

The clarity defects were in the `core.cljs` namespace docstring:

1. **Wrong IMPL-SPEC section reference.** Header said `§1.4 + §1.8 + §6 + §12`. §6 is "Form-3 (create-class) implementation" and §12 is "Test strategy" — neither relates to this fixture's claim. The relevant section is **§8** (`render-to-static-markup`, the pure-CLJS SSR detail the example exercises). Both sibling READMEs already say `§1.4 + §1.8 + §8`; aligned the docstring to match.
2. **Unattributed contract ids.** Named both ids the fixture binds — **S3-008** (stock-Reagent impl isolation) and **S3-005** (pure-CLJS SSR) — on the two invariant bullets, matching the authoritative READMEs (header previously named only S3-008).
3. **Stale/fabricated frame-provider NOTE.** The NOTE claimed `counter.core`'s docstring "describes a frame-provider variant of this example wired in `examples/reagent/login`." Verified false: `counter.core`'s docstring says no such thing, `login` runs on the default frame (`rf/reg-frame :rf/default`), and the string "frame-provider" appeared **nowhere** in `examples/` except this docstring. Replaced with a self-contained rationale (stays single-frame to focus the bundle-isolation check on the substrate swap).

## Quality gates

All green (from `implementation/`):
- `clj-kondo --lint examples/reagent-slim/counter_slim_and_fast/core.cljs` — 0 errors, 0 warnings
- `npx shadow-cljs compile examples/counter-slim-and-fast` — Build completed, 0 warnings
- `npm run test:cljs` — 5099 tests / 17232 assertions, 0 failures, 0 errors

## Scope notes

- No `*.spec.cjs` added (examples test-free, rf2-8cevm).
- Shadow entry-point ns/fn (`counter-slim-and-fast.core/run`, the `:examples/counter-slim-and-fast` `:init-fn`) left STABLE; no shadow-cljs.edn change needed. **No shadow change flagged.**
- Touched only `examples/reagent-slim/`.