### PR TITLE
refactor(examples/_shared): naming/readability pass (rf2-18pef.29)

### DIFF
--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -24,7 +24,7 @@ The pairing nods to the rest of the project (Xray uses Inter + JBM,
 Story uses IBM Plex on a similarly light surface) so examples, dev
 tools, and docs all sit naturally next to one another.
 
-## Layout
+## Files
 
 - `css/style.css` — the shared design system. Linked by
   every `index.html`. Imports `structure.css`.


### PR DESCRIPTION
Naming/readability review of `examples/_shared/` (rf2-18pef.29, parent epic rf2-18pef). SCOPE = `examples/_shared/` only.

## Renames / clarity edits

- `examples/_shared/README.md`: section heading `## Layout` → `## Files`. The section is a file/directory inventory, and "Layout" collided with `structure.css`'s documented CSS-layout ("layout-only class shapes") responsibility within the same slice. Pure prose edit; verified no anchor links target `#layout`.

## Why no other renames

Every other identifier in this slice is part of the **public, gate-caught surface** consumed outside the slice:

- **File names** (`style.css`, `structure.css`, `favicon.svg`, `og.svg`) — referenced by 35+ example `index.html` files and staged by the orchestrator (`examples/scripts/serve-and-run-examples-tests.cjs`) at fixed relative paths. Must stay stable.
- **CSS class names** (`.login-form`, `.pill`, `.cells-grid`, `.boot-progress`, …) — emitted by example views across all three substrates.
- **CSS tokens** (`--ex-*`, `--rg-*`, `--ux-*`, `--hx-*`) — consumed by per-example inline CSS in other substrates (e.g. `notebook/index.html`, `dashboard_uix/index.html`).

Renaming any of these would require editing files in other example substrates — out of slice and out of scope. The README and CSS comments are already accurate and well-written.

## Flagged (not actioned — out of slice / not a pure rename)

- `--ex-serif` (style.css:61) is documented as "alias for legacy serif refs" but nothing consumes `--ex-serif` directly (only `--rg-serif`, which aliases to `--ex-sans`). Candidate dead token — removal is a content change beyond a naming pass, and the comment marks it as a deliberately-kept legacy alias.

## No spec.cjs

Confirmed: no `*.spec.cjs` under `examples/_shared/` (rf2-8cevm — examples test-free). No CLJS/CLJ files in the slice, so clj-kondo has nothing to check here.

## Quality gates

- `npm run test:cljs` (from `implementation/`): **GREEN** — 5099 tests, 17232 assertions, 0 failures, 0 errors; build 0 warnings. (Fresh worktree required a one-time `npm install`.)
- Examples consuming `_shared` unaffected: change is README prose only; no asset path, CSS class, or token altered, so no example build can be impacted.
- clj-kondo: N/A (no Clojure sources in slice).