### PR TITLE
refactor(impl/scripts): naming/readability pass (rf2-18pef.15)

### DIFF
--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -542,12 +542,12 @@ function countPattern(blob, re) {
   return m ? m.length : 0;
 }
 
-function checkArtefact(blob, art) {
-  report.detail(`  ${art.name}:`);
+function checkArtefact(blob, artefact) {
+  report.detail(`  ${artefact.name}:`);
 
   let internalOk = true;
   let internalFailures = 0;
-  for (const { source, sentinel } of art.internalSentinels) {
+  for (const { source, sentinel } of artefact.internalSentinels) {
     const hits = countSubstring(blob, sentinel);
     const ok   = hits === 0;
     const tag  = ok ? 'OK' : 'FAIL';
@@ -561,13 +561,13 @@ function checkArtefact(blob, art) {
 
   let allowListOk = true;
   let allowListHits = 0;
-  const allowListChecked = art.consumerAllowList ? 1 : 0;
-  if (art.consumerAllowList) {
-    allowListHits = countPattern(blob, art.consumerAllowList);
-    allowListOk   = allowListHits <= art.expectedAllowListHits;
+  const allowListChecked = artefact.consumerAllowList ? 1 : 0;
+  if (artefact.consumerAllowList) {
+    allowListHits = countPattern(blob, artefact.consumerAllowList);
+    allowListOk   = allowListHits <= artefact.expectedAllowListHits;
     const tag     = allowListOk ? 'OK' : 'FAIL';
-    report.detail(`    [${tag}] consumer allow-list ${art.consumerAllowList}: ` +
-                  `${allowListHits} hit(s), expected <= ${art.expectedAllowListHits}`);
+    report.detail(`    [${tag}] consumer allow-list ${artefact.consumerAllowList}: ` +
+                  `${allowListHits} hit(s), expected <= ${artefact.expectedAllowListHits}`);
   }
 
   return {
@@ -575,7 +575,7 @@ function checkArtefact(blob, art) {
     internalOk,
     allowListOk,
     allowListHits,
-    internalChecked: art.internalSentinels.length,
+    internalChecked: artefact.internalSentinels.length,
     internalFailures,
     allowListChecked,
   };
@@ -604,13 +604,13 @@ function main() {
   const failures = [];
   let internalChecked = 0;
   let allowListChecked = 0;
-  for (const art of ARTEFACTS) {
-    const res = checkArtefact(blob, art);
+  for (const artefact of ARTEFACTS) {
+    const res = checkArtefact(blob, artefact);
     internalChecked += res.internalChecked;
     allowListChecked += res.allowListChecked;
     if (!res.ok) {
       allOk = false;
-      failures.push({ name: art.name, ...res });
+      failures.push({ name: artefact.name, ...res });
     }
   }
 

--- a/implementation/scripts/check-schemas-bundle.cjs
+++ b/implementation/scripts/check-schemas-bundle.cjs
@@ -98,25 +98,25 @@ function main() {
   const sizes = {};
   let bundlesOk = true;
 
-  for (const b of BUNDLES) {
-    const total = sumGzippedBytes(b.bundleDir);
+  for (const bundle of BUNDLES) {
+    const total = sumGzippedBytes(bundle.bundleDir);
     if (total == null) {
-      console.error(`[schemas-bundle] ${b.name}: bundle dir missing — ${b.bundleDir}`);
+      console.error(`[schemas-bundle] ${bundle.name}: bundle dir missing — ${bundle.bundleDir}`);
       console.error('              Did you run "shadow-cljs release ' +
-                    `${b.name}"?`);
+                    `${bundle.name}"?`);
       bundlesOk = false;
       continue;
     }
-    sizes[b.name] = total;
-    const ok = total <= b.gzippedMaxBytes;
+    sizes[bundle.name] = total;
+    const ok = total <= bundle.gzippedMaxBytes;
     const tag = ok ? 'OK' : 'FAIL';
-    report.detail(`  [${tag}] ${b.name}`);
-    report.detail(`        spec:      ${b.specRow}`);
+    report.detail(`  [${tag}] ${bundle.name}`);
+    report.detail(`        spec:      ${bundle.specRow}`);
     report.detail(`        bundle:    ${fmtKb(total)} gzipped (${total} bytes)`);
-    report.detail(`        threshold: ${fmtKb(b.gzippedMaxBytes)} (${b.gzippedMaxBytes} bytes)`);
+    report.detail(`        threshold: ${fmtKb(bundle.gzippedMaxBytes)} (${bundle.gzippedMaxBytes} bytes)`);
     if (!ok) {
       bundlesOk = false;
-      report.detail(`        REGRESSION: bundle exceeds threshold by ${fmtKb(total - b.gzippedMaxBytes)}`);
+      report.detail(`        REGRESSION: bundle exceeds threshold by ${fmtKb(total - bundle.gzippedMaxBytes)}`);
     }
   }
 


### PR DESCRIPTION
Naming/readability review of `implementation/scripts/` (rf2-18pef.15, parent epic rf2-18pef). Scope: `implementation/scripts/` only.

The slice is already in very good shape — consistent, idiomatic naming across all 27 files (`report`, `blob`, `sentinel`, `checkBundle`, `waitForReady`, `enforcePolicy`, `createGateReporter`, …). Only two terse loop/parameter variables were out of step with their own file's domain vocabulary; both renamed.

## Renames (internal-only, behaviour identical)

- `check-bundle-isolation.cjs`: `art` -> `artefact` (the `checkArtefact` parameter + the `for (... of ARTEFACTS)` loop var). Aligns with the file's existing `ARTEFACTS` array, `checkArtefact` fn, and the "artefact" wording throughout the comments.
- `check-schemas-bundle.cjs`: `b` -> `bundle` (the `for (... of BUNDLES)` loop var). Aligns with the `BUNDLES` array and its `bundleDir` field.

Pure renames — equal insertions/deletions, no behavioural lines changed.

## Filename renames — flagged, NOT actioned

Every script *file* in this slice is referenced by name from `implementation/package.json` and (for `check-reagent-slim-bundle-isolation.cjs`) from `.github/scripts/report-changed-surfaces.sh`. No script-file was renamed — a filename change would require a co-edit of the hot-zone `package.json` / CI workflow, out of scope for this bead. No filename was found confusing enough to be worth that cost; the names are descriptive and consistent (`check-*`, `serve-and-run-*`, `lib/*-report.cjs`, `_*.test.cjs`).

## Finding flagged for follow-up (NOT actioned)

`check-reagent-slim-bundle-isolation.cjs` carries a local `readAllJs(dir)` helper that duplicates the shared `readReleaseBlob` from `lib/read-release-bundle.cjs` (its own comment even references that shared fix). Every sibling `check-*` script uses the shared helper. Switching it over is a small dedup refactor rather than a naming change, so it is left for a separate bead to keep this pass purely naming/readability.

## Quality gates

- `node -c` syntax check: both edited scripts parse clean.
- `check-bundle-isolation.cjs`: missing-bundle branch -> exit 1 with expected message; synthetic PASS-path bundle -> `PASS bundle-isolation: 17 artefact entries; 35 internal sentinels absent; 3 allow-list budgets ok` (exit 0). Renamed `artefact` loop body exercised end-to-end.
- `check-schemas-bundle.cjs`: missing-bundle branch -> exit 1 with expected message; synthetic PASS-path bundles (probe 80.0 KB, malli 105.1 KB, delta 25.0 KB) -> `PASS schemas-bundle` (exit 0). Renamed `bundle` loop body exercised end-to-end including the methodology delta guard.
- Synthetic `out/` cleaned up; `git status` shows exactly the two edited files. No `.clj` changed (splint_main.clj read-only), so clj-kondo N/A.