### PR TITLE
refactor(examples/scripts): naming/readability pass (rf2-18pef.30)

### DIFF
--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -160,10 +160,12 @@ function expectedStatusFor(variantId, playKey) {
   return 'pass';
 }
 
-function variantIdToKw(idStr) {
+function variantIdToParam(idStr) {
   // The CI hook serialises `:story.foo/bar` as `"story.foo/bar"` (no
   // leading colon); the Playwright runner reads that string back to
-  // build the URL search-param value the Story shell expects.
+  // build the URL search-param value the Story shell expects. This is
+  // a defensive String() coercion — NOT a keyword conversion — so the
+  // already-string id flows straight into encodeURIComponent below.
   return String(idStr);
 }
 
@@ -177,7 +179,7 @@ function variantIdToKw(idStr) {
  * if the URL parse path is unreachable.
  */
 async function navigateToVariant(page, baseUrl, variantId) {
-  const variantStr = variantIdToKw(variantId);
+  const variantStr = variantIdToParam(variantId);
   // Share-link convention: search params BEFORE the hash route, so
   // `window.location.search` carries `?variant=...` and the share
   // hydrator picks it up on shell mount.
@@ -204,7 +206,7 @@ async function readRunStateOnce(page, variantId) {
     } catch (e) {
       return { error: String(e && e.message ? e.message : e) };
     }
-  }, variantIdToKw(variantId));
+  }, variantIdToParam(variantId));
 }
 
 /**
@@ -221,7 +223,7 @@ async function readPlayRunStateOnce(page, variantId, playKey) {
         return { error: String(e && e.message ? e.message : e) };
       }
     },
-    { vid: variantIdToKw(variantId), pk: playKey || '' },
+    { vid: variantIdToParam(variantId), pk: playKey || '' },
   );
 }
 
@@ -270,7 +272,7 @@ async function triggerPlay(page, variantId, playKey) {
         return false;
       }
     },
-    { vid: variantIdToKw(variantId), pk: playKey || '' },
+    { vid: variantIdToParam(variantId), pk: playKey || '' },
   );
 }
 


### PR DESCRIPTION
## Quality gates

- `node --check examples/scripts/serve-and-run-story-play-scripts.cjs` → SYNTAX_OK (the only changed file; `.cjs`, so clj-kondo N/A).
- Rename is file-local and mechanical (5 references + 1 definition + docstring); `git grep variantIdToKw` across the tree returns zero matches → no stale references. Module export (`expectedStatusFor`) untouched, so behaviour is identical.

## Renames

- `variantIdToKw` → `variantIdToParam` (file-local helper in `serve-and-run-story-play-scripts.cjs`). The old `Kw` suffix claimed a keyword conversion, but the body is a defensive `String()` coercion that yields the URL search-param value the Story shell reads — the name actively misled. Renamed all 5 call sites and clarified the comment.

## No script FILE renamed (hot-zone guard)

Every file under `examples/scripts/` is referenced by name from an external surface, so renaming a FILE would require a hot-zone co-edit (flagged, not actioned):

- `serve-and-run-examples-tests.cjs`, `serve-and-run-story-feature-load-tests.cjs`, `serve-and-run-story-play-scripts.cjs` — pinned by `implementation/package.json` (`test:examples` / `test:story-feature-load` / `test:story-play-scripts`) and `.github/workflows/test.yml`.
- `run-examples-tests.cjs`, `run-story-feature-load-tests.cjs` — invoked by their sibling orchestrators.
- `examples-port.cjs`, `story-feature-load-port.cjs` — required by the orchestrators.
- `spec-helpers.cjs` — required by all three adapter `testbed/spec.cjs`.
- `capture-story-screenshots.cjs` — referenced by its own usage docs.

## Findings (no change warranted)

The other eight scripts are already cleanly named and well-documented (`listSpecFiles`/`isSpecFile`/`matchesFilter`, `resolveExamplesPort`/`findAvailablePort`/`canListen`, `expectTextEquals`/`waitForStableValue`, `groupRowsByVariant`/`expectedStatusFor`, `stageHtml`/`compileAll`). The `selectedExample` (predicate) vs `selectedExamples` (collection) singular/plural pair reads as intentional idiom — left as-is. `variantIdToKw` was the only genuine misnomer in the slice.