### PR TITLE
refactor(testbed-support): naming/readability pass (rf2-18pef.23)

### DIFF
--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -72,6 +72,7 @@
       (non-blank (.get params param-name)))))
 
 (defn- strip-trailing-slash
+  "Return `s` without a single trailing slash, leaving a lone `\"/\"` intact."
   [s]
   (if (and (> (count s) 1) (str/ends-with? s "/"))
     (subs s 0 (dec (count s)))
@@ -98,10 +99,10 @@
   [subdir]
   (or (query-param "project-root")
       (when-let [root (non-blank repo-root)]
-        (let [root*   (strip-trailing-slash (str/trim root))
-              subdir* (-> (or subdir "")
-                          str/trim
-                          (str/replace #"^/+" ""))]
-          (if (seq subdir*)
-            (str root* "/" subdir*)
-            root*)))))
+        (let [normalized-root   (strip-trailing-slash (str/trim root))
+              normalized-subdir (-> (or subdir "")
+                                    str/trim
+                                    (str/replace #"^/+" ""))]
+          (if (seq normalized-subdir)
+            (str normalized-root "/" normalized-subdir)
+            normalized-root)))))


### PR DESCRIPTION
Naming/readability review of `tools/testbed-support/` (rf2-18pef.23, parent epic rf2-18pef). Scope was `tools/testbed-support` only. Internal-only edits — public surface unchanged.

## Renames
- `resolve-project-root` let-bindings `root*` / `subdir*` → `normalized-root` / `normalized-subdir`. The `*`-suffix idiom was correct but cryptic for a readability pass; the explicit names state intent and match the fn's own "`subdir` is normalised" prose.

## Other clarity edits
- Added a one-line docstring to the private `strip-trailing-slash`, bringing it in line with its two sibling private fns (`non-blank`, `query-param`) which already document their contract.

## Public surface unchanged
The consumed API is byte-stable: the `re-frame.testbed.config` namespace, the `repo-root` goog-define (seeded via `#shadow/env` in `implementation/shadow-cljs.edn`), and the `resolve-project-root` fn signature are all untouched. The 8 consuming Xray/Story testbeds reference only those symbols. Other private names (`non-blank`, `query-param`) were already well-named and left as-is.

## Quality gates
- `clj-kondo --lint` on the changed file: 0 errors, 0 warnings.
- `npm run test:xray-feature-gate` (from `implementation/`): all consuming testbeds compiled with 0 warnings; 16 scenarios ran, 0 failures.