### PR TITLE
refactor(machines): reduce duplication (rf2-jkake.10)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
@@ -39,11 +39,11 @@
   proceeds as before)."
   (:require [re-frame.fx :as fx]
             [re-frame.frame :as frame]
+            [re-frame.machines.lifecycle-fx.traces :as traces]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.paths :as paths]
             [re-frame.machines.result :as result]
-            [re-frame.registrar :as registrar]
-            [re-frame.trace :as trace]))
+            [re-frame.registrar :as registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -85,14 +85,10 @@
           (if (result/fail? r)
             ;; Match `apply-transition-once`'s exit-cascade failure
             ;; trace shape — same category, with a destroy-time
-            ;; discriminator so consumers can disambiguate.
-            (trace/emit-error! :rf.error/machine-action-exception
-                               {:machine-id actor-id
-                                :frame      frame-id
-                                :phase      :rf.machine/destroy-exit
-                                :reason     "An :exit action threw during destroy-time cascade."
-                                :recovery   :skipped
-                                :info       (result/info r)})
+            ;; discriminator so consumers can disambiguate. Shared with
+            ;; `finalize-machine`'s final-state auto-destroy via
+            ;; `traces/emit-destroy-exit-failure!`.
+            (traces/emit-destroy-exit-failure! actor-id frame-id (result/info r))
             (result/with-ok [new-snap exit-fx] r
               ;; (4) Write the post-exit snapshot back. The write is
               ;; transient — the unified teardown projection runs

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -26,8 +26,10 @@
   unregistered.
 
   This namespace also owns `abort-actor-in-flight-http!` — the late-bind
-  hook into the http-managed artefact (rf2-wvkn) — because both the
-  finalize cascade and the spawn-destroy teardowns invoke it.
+  hook into the http-managed artefact (rf2-wvkn) — the single home for
+  the abort contract every destroy trigger shares: the finalize cascade,
+  the spawn-destroy teardowns (`lifecycle-fx.destroy`), and the
+  frame-destroy singleton-straggler pass (`lifecycle-fx.frame-destroy`).
 
   The actor-teardown app-db dance lives in
   `re-frame.machines.lifecycle-fx.teardown` — one helper, three
@@ -145,13 +147,11 @@
                         (assoc-in db (paths/snapshot-path machine-id) next-snapshot)
                         db)
         _             (when (not exit-ok?)
-                        (trace/emit-error! :rf.error/machine-action-exception
-                                           {:machine-id machine-id
-                                            :frame      frame-id
-                                            :phase      :rf.machine/destroy-exit
-                                            :reason     "An :exit action threw during destroy-time cascade."
-                                            :recovery   :skipped
-                                            :info       (result/info exit-result)}))]
+                        ;; Same destroy-exit failure shape as the explicit-
+                        ;; destroy path (`exit-cascade/run-child-exit!`) —
+                        ;; shared via `traces/emit-destroy-exit-failure!`.
+                        (traces/emit-destroy-exit-failure!
+                          machine-id frame-id (result/info exit-result)))]
   (let [child-data (:data next-snapshot)
         ;; Resolve the final state-node so we can extract `:output-key`.
         final-node (cond

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -39,9 +39,9 @@
   but DO live in app-db — the walker covers them as a stragglers pass
   after the recorded vector drains."
   (:require [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.destroy :as destroy]
             [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
+            [re-frame.machines.lifecycle-fx.finalize :as finalize]
             [re-frame.machines.paths :as paths]
             [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.substrate.adapter :as adapter]
@@ -73,16 +73,6 @@
                 :last-state (:state snapshot)
                 :reason     :parent-frame-destroyed}))
 
-(defn- safe-abort-http!
-  "Best-effort HTTP-abort: fire the late-bind hook if registered. The
-  hook is owned by `re-frame.http-managed` (rf2-wvkn). Idempotent —
-  calling against an actor with no in-flight requests is a no-op."
-  [actor-id]
-  (when-let [abort! (late-bind/get-fn :http/abort-on-actor-destroy)]
-    (try (abort! actor-id)
-         (catch #?(:clj Throwable :cljs :default) _ nil)))
-  nil)
-
 (defn- run-singleton-exit-cascade!
   "Singleton-machine destroy on frame teardown: run the actor's `:exit`
   cascade so Spec 005 §Final states §Composition with `:entry` /
@@ -90,10 +80,15 @@
   unregister the handler — singleton handlers live in the global
   registrar per Spec 005 §Spawning §v1-partial footnote: the handler
   outlives any particular frame. Snapshot dissoc is moot at this point
-  (the frame's app-db is about to be released)."
+  (the frame's app-db is about to be released).
+
+  The HTTP-abort fires the shared `:http/abort-on-actor-destroy`
+  late-bind hook via `finalize/abort-actor-in-flight-http!` — the same
+  best-effort, idempotent helper the spawn-destroy + final-state
+  teardowns use, so the rf2-wvkn contract has one home."
   [frame-id actor-id]
   (exit-cascade/run-child-exit! frame-id actor-id)
-  (safe-abort-http! actor-id)
+  (finalize/abort-actor-in-flight-http! actor-id)
   nil)
 
 (defn teardown-on-frame-destroy!

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
@@ -56,3 +56,24 @@
                  {:frame      frame-id
                   :system-id  sid
                   :machine-id actor-id})))
+
+(defn emit-destroy-exit-failure!
+  "Fire the destroy-time exit-cascade failure trace
+  (`:rf.error/machine-action-exception`, `:phase :rf.machine/destroy-exit`)
+  when an actor's active-configuration `:exit` cascade threw during
+  teardown. Both destroy-time `:exit` runners — the explicit-destroy
+  wrapper (`lifecycle-fx.exit-cascade/run-child-exit!`) and the
+  final-state auto-destroy (`lifecycle-fx.finalize/finalize-machine`) —
+  fire the SAME diagnostic shape; centralising it here keeps the
+  `:phase` discriminator + reason string one-edit-touches-both, matching
+  `apply-transition-once`'s transition-time exit-cascade failure category
+  with a destroy-time discriminator. Fail-soft: the destroy proceeds with
+  the pre-cascade snapshot."
+  [actor-id frame-id result-info]
+  (trace/emit-error! :rf.error/machine-action-exception
+                     {:machine-id actor-id
+                      :frame      frame-id
+                      :phase      :rf.machine/destroy-exit
+                      :reason     "An :exit action threw during destroy-time cascade."
+                      :recovery   :skipped
+                      :info       result-info}))


### PR DESCRIPTION
Duplication-reduction review of `implementation/machines/` (rf2-jkake.10, parent epic rf2-jkake). Two behaviour-preserving consolidations inside `lifecycle_fx/`; scope was `implementation/machines/` only.

The slice is already heavily deduplicated (recent `rf2-at4cl` path-literal centralisation, `rf2-18pef.10` naming pass; `paths.cljc` / `path_walk.cljc` / `result.cljc` / `parallel.cljc`'s `reduce-regions` are mature consolidation namespaces). Only two genuinely-identical repetitions remained that made the slice clearer when unified.

## Consolidations

1. **Destroy-time exit-cascade failure trace** — the identical `:rf.error/machine-action-exception` map with `:phase :rf.machine/destroy-exit` was emitted inline in two places: `exit-cascade/run-child-exit!` (explicit destroy) and `finalize/finalize-machine` (final-state auto-destroy). Both call `parallel/run-active-exit-cascade` and fire the same diagnostic on failure. Extracted `traces/emit-destroy-exit-failure!` (the established home for shared trace-emit helpers); both call sites delegate. The `:phase` discriminator + reason string now have one home — one edit touches both.

2. **HTTP-abort late-bind hook** — `frame_destroy/safe-abort-http!` was a byte-for-byte copy of `finalize/abort-actor-in-flight-http!` (same `:http/abort-on-actor-destroy` hook, same try/catch swallow). Deleted the copy; the singleton-straggler pass now calls the finalize helper directly (the require is cycle-free — `frame_destroy` already requires `destroy`, which requires `finalize`). Dropped the now-unused `late-bind` require from `frame_destroy`. The finalize helper's `(when actor-id)` guard is strictly safer and behaviour-equivalent for the sole call site (always a real actor-id).

## Noted, not actioned (conservative — clearer left inline)

- **"Resolve machine spec by id" idiom** — `(let [m (registrar/lookup :event id)] (when (:rf/machine? m) (:rf/machine m)))` appears in 4 sites (`machines/machine-meta`, `spawn/resolve-spawn-machine`, `finalize` parent-meta, `exit-cascade/resolve-machine-spec`). The public `machine-meta` IS this fn but lives at the top of the require graph (`machines.cljc` requires the lifecycle_fx files), so downward callers can't reach it without a cycle. Hosting it in a new leaf ns would pull a `registrar` dep to the bottom of the graph for a 3-line idiom that reads clearly inline — net clarity loss. Left inline.
- **`:platform (frame/frame-meta frame-id)` fallback** (2 sites) and **`walk-state-nodes` vs `walk-state-nodes-with-path`** (validation.cljc) — small, clearly-documented, distinct-consumer repetitions; merging would force every key-only consumer through `(peek path)`. Left inline.

Public API + `:rf.machine/*` reserved vocab + behaviour are unchanged.

## Quality gates

- machines JVM (`clojure -M:test` from `implementation/machines/`): 274 tests / 901 assertions, **0 failures, 0 errors** (re-run green post-rebase)
- `npm run test:cljs` (from `implementation/`): 5094 tests / 17225 assertions, **0 failures, 0 errors**
- clj-kondo on the 4 changed files: **0 errors** (3 pre-existing warnings — `with-ok` macro unresolved-symbol + a redundant-let — verified present on baseline, unchanged by this diff)
