### PR TITLE
refactor(core): naming/readability pass — internal names only (rf2-18pef.1)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -488,12 +488,12 @@
           (emit-handled! fx-id args frame-id
                          (when interop/debug-enabled? (- (interop/now-ms) t0))))
         (catch #?(:clj Throwable :cljs :default) e
-          (let [d        (ex-data e)
-                category (:rf.error/id d)]
+          (let [ex-data-map (ex-data e)
+                category    (:rf.error/id ex-data-map)]
             (if (keyword? category)
-              (let [msg  #?(:clj (.getMessage ^Throwable e)
-                            :cljs (.-message e))
-                    time (interop/now-ms)]
+              (let [msg     #?(:clj (.getMessage ^Throwable e)
+                               :cljs (.-message e))
+                    errored-at-ms (interop/now-ms)]
                 ;; Sticky hook (rf2-f72pd) — always-on per-error
                 ;; observability fan-out per rf2-bacs4; survives
                 ;; `:advanced` + `goog.DEBUG=false`.
@@ -506,7 +506,7 @@
                     frame-id
                     e
                     0
-                    time
+                    errored-at-ms
                     {:operation category
                      :op-type   :error
                      :tags      (merge {:event-id          origin-event-id
@@ -518,7 +518,7 @@
                                         :exception         e
                                         :exception-message msg
                                         :recovery          :no-recovery}
-                                       (dissoc d :rf.error/id))
+                                       (dissoc ex-data-map :rf.error/id))
                      :recovery  :no-recovery}))
                 ;; Trace path for dev consumers; DCE'd in CLJS prod.
                 (trace/emit-error! category
@@ -529,7 +529,7 @@
                                            :exception         e
                                            :exception-message msg
                                            :recovery          :no-recovery}
-                                          (dissoc d :rf.error/id))))
+                                          (dissoc ex-data-map :rf.error/id))))
               ;; Untyped reserved-fx throw — preserve crash-loud
               ;; contract by re-throwing.
               (throw e)))))


### PR DESCRIPTION
## Summary

Conservative naming/readability pass over `implementation/core/src/re_frame/fx.cljc`, scoped to the reserved-fx error `catch` block. **Internal local bindings only** — no public, reserved, or contract surface is touched.

### Renames (from → to)

| from | to | rationale |
|------|----|-----------|
| `d` | `ex-data-map` | binding holds `(ex-data e)`; the one-letter name obscured that |
| `time` | `errored-at-ms` | binding holds a wall-clock-ms timestamp (`interop/now-ms`); new name states the unit and intent, and avoids shadowing `clojure.core/time` |

Both are local `let` bindings whose scope is a single `catch` block. All call sites within that block were updated; no references leak outside it.

### Explicit safety confirmation

- **No public API symbol changed** — only function-local `let` bindings.
- **No `:rf.fx/*` reserved fx-ids changed.**
- **No `:rf/*` / `:rf.error/*` vocab keys changed** (e.g. `:rf.error/id` and all `:rf.fx/*` map keys are untouched).
- **No `*`-suffix macro/fn pair changed.**
- **No hook key changed.**

## Quality gates

All run from the worktree against the rebased branch:

- **Core JVM tests** (`clojure -M:test` in `implementation/core`): `Ran 808 tests containing 3595 assertions. 0 failures, 0 errors.`
- **Full cross-artefact CLJS suite** (`npm run test:cljs`): `Ran 5094 tests containing 17225 assertions. 0 failures, 0 errors.`
- **clj-kondo** on `core/src/re_frame/fx.cljc`: `errors: 0, warnings: 0`.

Closes rf2-18pef.1.