### PR TITLE
refactor(epoch): reduce duplication (rf2-jkake.7)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -284,23 +284,15 @@
       (try
         (capture frame-id (:epoch-id record) (:event-id record) events)
         (catch #?(:clj Throwable :cljs :default) _ nil)))
-    (trace/emit! :rf.epoch :rf.epoch/snapshotted
-                 {:frame             frame-id
-                  :rf.epoch/id       (:epoch-id record)
-                  :rf.trace/event-id (:event-id record)
-                  :outcome           outcome})
-    ;; Per rf2-18g1w / rf2-jppad — consumer-facing `{:ok :blocked :error}`
-    ;; tier emitted as a separate op at the same cascade-trailer point as
-    ;; `:rf.epoch/snapshotted`. Tools that want the detailed CAUSE read
-    ;; the `:outcome` tag on `:rf.epoch/snapshotted`; tools that want the
-    ;; coarse summary (Xray Trace panel close-row §13, Story outcome chips)
-    ;; read this op's `:outcome` tag directly. See
-    ;; `outcome->consumer-facing` above for the mapping rationale.
-    (trace/emit! :rf.epoch :rf.epoch/outcome
-                 {:frame             frame-id
-                  :rf.epoch/id       (:epoch-id record)
-                  :rf.trace/event-id (:event-id record)
-                  :outcome           (assembly/outcome->consumer-facing outcome)})
+    ;; Per rf2-18g1w / rf2-jppad — the cascade-trailer pair: the detailed
+    ;; `:rf.epoch/snapshotted` (tools that want the CAUSE read its
+    ;; `:outcome` tag) plus the consumer-facing `:rf.epoch/outcome`
+    ;; (`{:ok :blocked :error}` — the Xray Trace panel close-row §13 and
+    ;; Story outcome chips read this op's tag directly). The shared
+    ;; `emit-snapshotted+outcome!` keeps the trailer shape identical to
+    ;; the mid-drain destroy commit's.
+    (assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
+                                        (:event-id record) outcome)
     (listeners/notify-listeners! record)
     record))
 

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -82,6 +82,32 @@
     :halted-destroy           :blocked
     :halted-handler-exception :error))
 
+(defn emit-snapshotted+outcome!
+  "Emit the paired cascade-trailer trace ops for a committed epoch:
+  `:rf.epoch/snapshotted` carrying the detailed `:outcome` CAUSE, then
+  `:rf.epoch/outcome` carrying the consumer-facing `{:ok :blocked :error}`
+  tier (via `outcome->consumer-facing`). Both ops share the same
+  `:frame` / `:rf.epoch/id` / `:rf.trace/event-id` so consumers correlate
+  the detailed cause with the coarse summary (rf2-18g1w / rf2-jppad).
+
+  Shared by the per-event clean/halt settle (`re-frame.epoch/commit-record!`)
+  and the mid-drain destroy commit (`re-frame.epoch.listeners/on-frame-
+  destroyed!`) so the two-op trailer shape lives in one place — a future
+  trailer tag lands on both surfaces at once. Both ops are catalogued in
+  `re-frame.epoch.capture/skip-ops` (they fire after the buffer is
+  harvested, outside any cascade)."
+  [frame-id epoch-id event-id outcome]
+  (trace/emit! :rf.epoch :rf.epoch/snapshotted
+               {:frame             frame-id
+                :rf.epoch/id       epoch-id
+                :rf.trace/event-id event-id
+                :outcome           outcome})
+  (trace/emit! :rf.epoch :rf.epoch/outcome
+               {:frame             frame-id
+                :rf.epoch/id       epoch-id
+                :rf.trace/event-id event-id
+                :outcome           (outcome->consumer-facing outcome)}))
+
 ;; ---- redaction hook -------------------------------------------------------
 
 (defn maybe-redact

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -106,16 +106,22 @@
   #{:rf.sub/run
     :rf.sub/skip})
 
-(defn- in-flight-cascade?
+(defn in-flight-cascade?
   "True when the frame's in-flight capture buffer already holds an
   `:event/run-start` emit — the canonical signal that a cascade has
-  begun draining into this buffer (mirrors the gate
-  `re-frame.epoch.listeners/on-frame-destroyed!` uses for mid-drain
-  detection). A render that fires WITH a cascade in flight (synchronous
-  flush — SSR, a render triggered inside another render's reactive read)
-  genuinely belongs to that cascade and is buffered normally; a render
-  that fires with NO cascade in flight is a post-settle async re-render
-  and is back-filled to the cascade that caused it."
+  begun draining into this buffer. The single home for the
+  'is a cascade in flight for this frame?' question; both the
+  post-settle back-fill routing below and
+  `re-frame.epoch.listeners/on-frame-destroyed!`'s mid-drain detection
+  call it so the gate stays one predicate.
+
+  A render that fires WITH a cascade in flight (synchronous flush — SSR,
+  a render triggered inside another render's reactive read) genuinely
+  belongs to that cascade and is buffered normally; a render that fires
+  with NO cascade in flight is a post-settle async re-render and is
+  back-filled to the cascade that caused it. The destroy hook reads the
+  same signal to tell a mid-drain destroy (commit a `:halted-destroy`
+  partial record) from a registration-time tagalong."
   [frame-id]
   (some (fn [ev]
           (= :rf.event/run-start (:operation ev)))

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -215,11 +215,13 @@
     ;; state given `:outcome :halted-destroy` signals the destroy
     ;; context. The record is delivered to listeners only — the ring
     ;; buffer gets wiped in step 3.
-    (let [buffered-events  (state/buffer-for frame-id)
-          in-cascade?      (some (fn [ev]
-                                   (= :rf.event/run-start (:operation ev)))
-                                 buffered-events)]
-      (when in-cascade?
+    ;; Mid-drain detection reuses the canonical
+    ;; `capture/in-flight-cascade?` gate (the same predicate the
+    ;; post-settle render / sub-run back-fill routing uses) so the
+    ;; 'is a cascade in flight?' question lives in one place. The
+    ;; buffered events are read separately for the partial-record build.
+    (let [buffered-events (state/buffer-for frame-id)]
+      (when (capture/in-flight-cascade? frame-id)
         ;; Per rf2-wp70d: even on the halted-destroy partial-record
         ;; commit, `maybe-redact` runs once between `build-record`
         ;; and listener fan-out so listener consumers see the SAME
@@ -228,22 +230,14 @@
                        (assembly/build-record frame-id nil nil buffered-events
                                               :halted-destroy
                                               {:operation :rf.frame/destroyed-mid-drain}))]
-          (trace/emit! :rf.epoch :rf.epoch/snapshotted
-                       {:frame             frame-id
-                        :rf.epoch/id       (:epoch-id record)
-                        :rf.trace/event-id (:event-id record)
-                        :outcome           :halted-destroy})
-          ;; Per rf2-18g1w / rf2-jppad — consumer-facing tier (`:ok` /
-          ;; `:blocked` / `:error`) emitted alongside `:rf.epoch/snapshotted`
-          ;; so the trace stream carries both the detailed cause (snapshotted
-          ;; `:outcome`) and the coarse summary the Trace-panel close-row and
-          ;; Story outcome chips read directly. `:halted-destroy` → `:blocked`.
-          (trace/emit! :rf.epoch :rf.epoch/outcome
-                       {:frame             frame-id
-                        :rf.epoch/id       (:epoch-id record)
-                        :rf.trace/event-id (:event-id record)
-                        :outcome           (assembly/outcome->consumer-facing
-                                             :halted-destroy)})
+          ;; Per rf2-18g1w / rf2-jppad — the cascade-trailer pair (detailed
+          ;; `:rf.epoch/snapshotted` `:outcome :halted-destroy` plus the
+          ;; consumer-facing `:rf.epoch/outcome :blocked`). Shared with the
+          ;; clean/halt settle via `assembly/emit-snapshotted+outcome!` so
+          ;; the two-op trailer shape stays identical across both commit
+          ;; paths.
+          (assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
+                                              (:event-id record) :halted-destroy)
           (notify-listeners! record))))
     (let [silenced-cbs (->> (state/observations-snapshot)
                             (keep (fn [[cb-id frames]]


### PR DESCRIPTION
Duplication-reduction review of `implementation/epoch/` (bead rf2-jkake.7, parent epic rf2-jkake). Conservative: two consolidations that remove genuine, already-flagged duplication and make the slice clearer. Behaviour, public API, and the `:rf.epoch/*` reserved vocab are unchanged.

## Consolidations

1. **cascade-in-flight gate.** `capture/in-flight-cascade?` is now public and is called by `listeners/on-frame-destroyed!`'s mid-drain detection, which previously inlined the identical `(some #(= :rf.event/run-start (:operation %)) buffer)` walk. The `capture` docstring had explicitly flagged the inline copy ("mirrors the gate `…on-frame-destroyed!` uses for mid-drain detection") — the duplication was a known lockstep hazard. One predicate, one home; the destroy path pays one extra (cold-path) `buffer-for` deref for the single-source-of-truth gate.

2. **cascade-trailer emit pair.** The `:rf.epoch/snapshotted` + `:rf.epoch/outcome` two-op emit appeared verbatim-structurally in `epoch/commit-record!` and `listeners/on-frame-destroyed!` (same four tags, same `outcome->consumer-facing` projection). Extracted `assembly/emit-snapshotted+outcome!` (placed next to `outcome->consumer-facing`, which it calls, in the ns both callers already require) so a future trailer-tag change lands on both surfaces at once instead of drifting.

## Left as-is (clearer inline; noted)

- The run-start **data-extraction** walks in `state/settling-dispatch-id`, `capture/find-trigger-event`, and `capture/cascade-cause` extract fields (dispatch-id / event-id / sub accumulation), not just test presence — folding them into the boolean gate would obscure, not clarify.
- The slice was already heavily deduped with documented "considered and rejected" notes (rf2-33lpr the eight-atom shape, rf2-0wi86 the seam split, rf2-dq2b7 the mount-attribution merge, rf2-ecu37/rf2-txrq9 the fused walks, rf2-ee38b the shared `sub-run-row`/`render-row` projectors). Those resting points were respected; no further structural change was warranted.

No cross-slice dedup actioned (out of scope per the bead — would be a note on the parent epic).

## Quality gates

- epoch JVM `clojure -M:test`: **219 tests, 817 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5094 tests, 17225 assertions, 0 failures, 0 errors**
- clj-kondo on the four changed files: **0 errors, 0 warnings**

Behaviour-preserving; public API and `:rf.epoch/*` reserved vocabulary unchanged.