### PR TITLE
refactor(routing): reduce duplication (rf2-jkake.11)

### DIFF
--- a/implementation/routing/src/re_frame/routing/events.cljc
+++ b/implementation/routing/src/re_frame/routing/events.cljc
@@ -28,22 +28,30 @@
 
 ;; Per Spec 012 §Multi-frame routing: nav-token and pending-nav id
 ;; counters are per-frame. Pure allocators: take db, return [db' id-str].
+;; Both share one increment-and-stringify shape over a per-frame counter
+;; key under `[:rf/runtime :routing ...]`; the only per-allocator
+;; variation is the counter key and the id prefix.
+
+(defn- alloc-counter
+  "Pure per-frame counter allocator. Increments the counter at
+  `[:rf/runtime :routing counter-key]` and returns
+  `[db' (str prefix n)]`."
+  [db counter-key prefix]
+  (let [n (inc (or (get-in db [:rf/runtime :routing counter-key]) 0))]
+    [(assoc-in db [:rf/runtime :routing counter-key] n)
+     (str prefix n)]))
 
 (defn alloc-nav-token
   "Pure allocator: returns [db' \"nav-N\"]. Increments the per-frame
   counter at [:rf/runtime :routing :nav-token-counter]."
   [db]
-  (let [n (inc (or (get-in db [:rf/runtime :routing :nav-token-counter]) 0))]
-    [(assoc-in db [:rf/runtime :routing :nav-token-counter] n)
-     (str "nav-" n)]))
+  (alloc-counter db :nav-token-counter "nav-"))
 
 (defn alloc-pending-nav-id
   "Pure allocator: returns [db' \"pn-N\"]. Increments the per-frame
   counter at [:rf/runtime :routing :pending-nav-counter]."
   [db]
-  (let [n (inc (or (get-in db [:rf/runtime :routing :pending-nav-counter]) 0))]
-    [(assoc-in db [:rf/runtime :routing :pending-nav-counter] n)
-     (str "pn-" n)]))
+  (alloc-counter db :pending-nav-counter "pn-"))
 
 (defn emit-activation-traces!
   "Per Spec 012 §Trace events: emit `:rf.route/deactivated`

--- a/implementation/routing/src/re_frame/routing/link.cljc
+++ b/implementation/routing/src/re_frame/routing/link.cljc
@@ -13,6 +13,21 @@
   (:require [re-frame.router :as router]
             [re-frame.routing.registry :as registry]))
 
+(defn- href-attrs
+  "Synthesise the `<a>` href from the link control keys (`:to` /
+  `:params` / `:query` / `:fragment`), strip those control keys (plus
+  `:on-click`, which the CLJS path replaces and the SSR path drops) off
+  `props`, and return `[url base-attrs]`. The base attrs carry the
+  synthesised `:href` plus every passthrough HTML attr; both the CLJS
+  and SSR render fns build on it so the control-key list lives in ONE
+  place and cannot drift between the two halves of the Spec 011 render
+  contract."
+  [{:keys [to params query fragment] :as props}]
+  (let [url (registry/route-url to (or params {}) (or query {}) fragment)]
+    [url (-> props
+             (dissoc :to :params :query :fragment :on-click)
+             (assoc :href url))]))
+
 #?(:cljs
    (defn- plain-left-click?
      "Return true when the click event is a plain primary-button click with
@@ -60,31 +75,29 @@
      calls; see `route-url`'s perf note for the precompute follow-on
      should it become a bottleneck."
      [{:keys [to params query fragment on-click] :as props} & children]
-     (let [url   (registry/route-url to (or params {}) (or query {}) fragment)
-           attrs (-> props
-                     (dissoc :to :params :query :fragment :on-click)
-                     (assoc :href url
-                            :on-click
-                            (fn [e]
-                              (when on-click (on-click e))
-                              (when (and (not (.-defaultPrevented e))
-                                         (plain-left-click? e))
-                                (.preventDefault e)
-                                ;; Per rf2-t1lxr: route-link click → :router
-                                ;; origin so the L2 epoch timeline tags the
-                                ;; resulting :rf/url-requested cascade as a
-                                ;; routing-substrate dispatch (not :ui). Per
-                                ;; rf2-1ve9h the single closed-enum
-                                ;; functional-origin axis is `:source` —
-                                ;; routing-internal dispatches stamp
-                                ;; `:source :router`.
-                                (router/dispatch!
-                                  [:rf/url-requested
-                                   (cond-> {:url url :to to}
-                                     (seq params)   (assoc :params params)
-                                     (seq query)    (assoc :query  query)
-                                     fragment       (assoc :fragment fragment))]
-                                  {:source :router})))))]
+     (let [[url base-attrs] (href-attrs props)
+           attrs (assoc base-attrs
+                        :on-click
+                        (fn [e]
+                          (when on-click (on-click e))
+                          (when (and (not (.-defaultPrevented e))
+                                     (plain-left-click? e))
+                            (.preventDefault e)
+                            ;; Per rf2-t1lxr: route-link click → :router
+                            ;; origin so the L2 epoch timeline tags the
+                            ;; resulting :rf/url-requested cascade as a
+                            ;; routing-substrate dispatch (not :ui). Per
+                            ;; rf2-1ve9h the single closed-enum
+                            ;; functional-origin axis is `:source` —
+                            ;; routing-internal dispatches stamp
+                            ;; `:source :router`.
+                            (router/dispatch!
+                              [:rf/url-requested
+                               (cond-> {:url url :to to}
+                                 (seq params)   (assoc :params params)
+                                 (seq query)    (assoc :query  query)
+                                 fragment       (assoc :fragment fragment))]
+                              {:source :router}))))]
        (into [:a attrs] children))))
 
 (defn route-link-render-ssr
@@ -94,11 +107,8 @@
   on the hydrated page run the CLJS render fn's on-click path. Per
   Spec 011 the render tree is the contract; this is the JVM half of
   that contract for the `:route/link` view."
-  [{:keys [to params query fragment] :as props} & children]
-  (let [url   (registry/route-url to (or params {}) (or query {}) fragment)
-        attrs (-> props
-                  (dissoc :to :params :query :fragment :on-click)
-                  (assoc :href url))]
+  [props & children]
+  (let [[_url attrs] (href-attrs props)]
     (into [:a attrs] children)))
 
 ;; The façade owns the `:route/link` registration:


### PR DESCRIPTION
Duplication-reduction review of `implementation/routing/` (rf2-jkake.11, parent epic rf2-jkake). Conservative: consolidate only where it makes the slice clearer; behaviour- and public-API-preserving.

## Quality gates
- routing JVM `clojure -M:test` — **122 tests / 552 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (full corpus, incl. routing CLJS tests) — **5094 tests / 17225 assertions, 0 failures, 0 errors**
- clj-kondo on both changed files — **0 errors** (one pre-existing `re-frame.router` unused-require warning, unchanged from HEAD — `router/` is used only inside the `#?(:cljs ...)` branch)

## Consolidations applied
1. **`events.cljc` — shared `alloc-counter` helper.** `alloc-nav-token` and `alloc-pending-nav-id` were near-identical pure per-frame counter allocators, differing only in the counter key (`:nav-token-counter` vs `:pending-nav-counter`) and id prefix (`"nav-"` vs `"pn-"`). The increment-and-stringify shape now lives once in a private `alloc-counter`; the two public allocators are thin, intent-revealing wrappers. Outputs identical (`[db' "nav-N"]` / `[db' "pn-N"]`).
2. **`link.cljc` — shared `href-attrs` helper.** `route-link-render` (CLJS) and `route-link-render-ssr` (JVM) both synthesised the `<a>` href via `route-url` and built attrs by `(dissoc props :to :params :query :fragment :on-click)` + `(assoc :href url)`. The duplicated control-key list was a real drift hazard across the two halves of the Spec 011 render contract (add a forwarded prop → both lists must change). It now lives in one place; both render fns build on `href-attrs`. Render trees unchanged.

## Behaviour / public API
Unchanged. No public fn signatures changed (`route-link-render-ssr` keeps its arity; only the unused destructure was inlined into the shared helper). Reserved `:rf.route/*` / `:rf.routing/*` / `:rf.nav/*` vocab untouched.

## Noted, not actioned (kept inline — clearer as-is, or cross-cutting)
- `navigate.cljc` vs `url-change.cljc` share the post-allocation `:fx` concat shape (capture-fx + on-match dispatches + settle-transition + scroll-fx), but already share `merge-route-slice` / `alloc-nav-token` / `emit-activation-traces!` / scroll helpers. The remaining parallel diverges meaningfully (push-fx, identical-nav handling, scroll `:from`/`:to`); a further shared helper would need several flags and hurt clarity. Left inline.
- `transitioned-handler` / `handle-url-change-handler` (`url-change.cljc`) are structurally parallel (`(or blocked (url-change-fx ...))`) but differ on the meaningful axis (default scroll `:top`/`:restore`, frame threading) and double as the documented Spec-012 entry points with distinct docstrings. Left as two named handlers.
- `malformed-url?` query-scan (`url.cljc`) vs `match-url` query-parse loop (`registry.cljc`) both split-and-decode query pairs, but serve different purposes (lexical validity scan vs decode-into-map). Not consolidated.
- The four nav entry points share `(or opts {})` + `maybe-block-navigation` — already centralised in `can-leave/maybe-block-navigation`; nothing left to dedup.