### PR TITLE
refactor(http): reduce duplication (rf2-jkake.9)

### DIFF
--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -235,19 +235,17 @@
       (= :text resolved)
       body-text
 
-      ;; rf2-5zj6t — binary decode modes return the native Fetch body
-      ;; the transport already read via `.blob()` / `.arrayBuffer()` /
-      ;; `.formData()`. On hosts that have no binary body (the JVM
-      ;; transport reads `.body` as a String) `body-binary` is absent and
-      ;; we fall back to the raw `body-text` so the value is at least the
-      ;; payload, not nil.
-      (= :blob resolved)
-      (if (some? body-binary) body-binary body-text)
-
-      (= :array-buffer resolved)
-      (if (some? body-binary) body-binary body-text)
-
-      (= :form-data resolved)
+      ;; rf2-5zj6t — binary decode modes (`:blob` / `:array-buffer` /
+      ;; `:form-data`, the `binary-decode-kinds` set) return the native
+      ;; Fetch body the transport already read via `.blob()` /
+      ;; `.arrayBuffer()` / `.formData()`. On hosts that have no binary
+      ;; body (the JVM transport reads `.body` as a String) `body-binary`
+      ;; is absent and we fall back to the raw `body-text` so the value
+      ;; is at least the payload, not nil. rf2-jkake.9 — the three modes
+      ;; collapse onto the shared `binary-decode-kinds` set (the same set
+      ;; `binary-read-kind` consults) rather than three identical cond
+      ;; arms.
+      (contains? binary-decode-kinds resolved)
       (if (some? body-binary) body-binary body-text)
 
       ;; Malli schema (or anything keyword-like that isn't recognised above).

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -214,6 +214,75 @@
   (reset! interceptors {})
   nil)
 
+;; rf2-jkake.9 — the `:before` (`run-interceptor-chain!`) and `:after`
+;; (`run-after-chain!`) chains share one walk shape: reduce over the
+;; per-frame chain, skip interceptors lacking the relevant slot, run the
+;; slot fn, reject a non-map return with `:rf.error/http-interceptor-bad-
+;; return`, and wrap any throw as `:rf.error/http-interceptor-failed`
+;; (routed through the privacy composer + re-thrown). `run-chain*`
+;; factors that body out; the two public fns are thin wrappers that vary
+;; only on: the slot key (`:before` / `:after`), how the slot fn is
+;; invoked (`(slot acc)` vs `(slot fixed-ctx acc)`), the chain order
+;; (registration / reverse), the `:where` symbol + optional `:phase`, the
+;; URL source (the threaded `acc` for `:before`; the fixed middleware-ctx
+;; for `:after`), and the bad-return sentence. The load-bearing comments
+;; on each wrapper preserve the per-path rationale.
+(defn- run-chain*
+  [{:keys [chain frame-id slot-key invoke sensitive? where phase url-of slot-noun]} init]
+  (reduce
+    (fn [acc interceptor]
+      (let [{:keys [id]} interceptor
+            slot          (get interceptor slot-key)]
+        (if slot
+          (try
+            (let [out (invoke slot acc)]
+              (if (map? out)
+                out
+                ;; Canonical thrown-error shape (Spec 009): message is
+                ;; the stringified discriminator kw; the descriptive
+                ;; sentence (naming the offending interceptor id) rides
+                ;; on :reason. The outer wrapper carries :interceptor-id
+                ;; so a chain failure is locatable via ex-data; the :id
+                ;; key here is kept for programmatic consumers.
+                (throw (ex-info ":rf.error/http-interceptor-bad-return"
+                                {:rf.error/id :rf.error/http-interceptor-bad-return
+                                 :where       'rf/reg-http-interceptor
+                                 :recovery    :no-recovery
+                                 :reason      (str "interceptor " id " " slot-noun)
+                                 :id          id
+                                 :returned    out}))))
+            (catch #?(:clj Throwable :cljs :default) t
+              (let [data (ex-info ":rf.error/http-interceptor-failed"
+                                  (cond-> {:where    where
+                                           :recovery :no-recovery
+                                           :frame    frame-id
+                                           :interceptor-id id
+                                           :url      (url-of acc)
+                                           ;; Prefer the inner throw's :reason
+                                           ;; (a human sentence naming the
+                                           ;; offending interceptor) over the
+                                           ;; raw message — canonical throws
+                                           ;; stringify the discriminator kw as
+                                           ;; their message.
+                                           :cause    (or (:reason (ex-data t))
+                                                         #?(:clj  (.getMessage ^Throwable t)
+                                                            :cljs (.-message t)))}
+                                    phase (assoc :phase phase)))]
+                (when interop/debug-enabled?
+                  ;; rf2-1jcpm — route through the privacy composer so a
+                  ;; denylisted query param (`?api_key=…`) is scrubbed
+                  ;; and `:sensitive?` is stamped on the trace event when
+                  ;; either the handler/per-call sensitivity OR the URL's
+                  ;; query string carries a denylisted param name.
+                  (trace/emit-error! :rf.error/http-interceptor-failed
+                                     (privacy/prepare-emit-failure
+                                       (ex-data data)
+                                       sensitive?)))
+                (throw data))))
+          acc)))
+    init
+    chain))
+
 (defn run-interceptor-chain!
   "Walk the registration-order interceptor chain for `frame-id`, threading
   `ctx` through each `:before`. Returns the final ctx, or throws
@@ -230,58 +299,20 @@
   `?access_token=…`) leaked into traces whenever an interceptor
   threw — rf2-1jcpm (round-2 security audit finding 1)."
   [frame-id ctx]
-  (let [chain (get @interceptors frame-id)
-        sensitive? (true? (:sensitive? ctx))]
-    (reduce
-      (fn [acc {:keys [id before]}]
-        (if before
-          (try
-            (let [out (before acc)]
-              (if (map? out)
-                out
-                ;; Canonical thrown-error shape (Spec 009): message is
-                ;; the stringified discriminator kw; the descriptive
-                ;; sentence (naming the offending interceptor id) rides
-                ;; on :reason. The outer wrapper carries :interceptor-id
-                ;; so a chain failure is locatable via ex-data; the :id
-                ;; key here is kept for programmatic consumers.
-                (throw (ex-info ":rf.error/http-interceptor-bad-return"
-                                {:rf.error/id :rf.error/http-interceptor-bad-return
-                                 :where       'rf/reg-http-interceptor
-                                 :recovery    :no-recovery
-                                 :reason      (str "interceptor " id " :before did not return a ctx map")
-                                 :id          id
-                                 :returned    out}))))
-            (catch #?(:clj Throwable :cljs :default) t
-              (let [data (ex-info ":rf.error/http-interceptor-failed"
-                                  {:where    'rf.http/run-interceptor-chain!
-                                   :recovery :no-recovery
-                                   :frame    frame-id
-                                   :interceptor-id id
-                                   :url      (get-in acc [:request :url])
-                                   ;; Prefer the inner throw's :reason
-                                   ;; (a human sentence naming the
-                                   ;; offending interceptor) over the
-                                   ;; raw message — canonical throws
-                                   ;; stringify the discriminator kw as
-                                   ;; their message.
-                                   :cause    (or (:reason (ex-data t))
-                                                 #?(:clj  (.getMessage ^Throwable t)
-                                                    :cljs (.-message t)))})]
-                (when interop/debug-enabled?
-                  ;; rf2-1jcpm — route through the privacy composer so a
-                  ;; denylisted query param (`?api_key=…`) is scrubbed
-                  ;; and `:sensitive?` is stamped on the trace event when
-                  ;; either the handler/per-call sensitivity OR the URL's
-                  ;; query string carries a denylisted param name.
-                  (trace/emit-error! :rf.error/http-interceptor-failed
-                                     (privacy/prepare-emit-failure
-                                       (ex-data data)
-                                       sensitive?)))
-                (throw data))))
-          acc))
-      ctx
-      chain)))
+  (run-chain*
+    {:chain      (get @interceptors frame-id)
+     :frame-id   frame-id
+     :slot-key   :before
+     ;; `:before` reads the URL from the threaded accumulator — the
+     ;; evolving ctx, whose `:request` an earlier `:before` may have
+     ;; rewritten — so the trace carries the URL as the failing
+     ;; interceptor actually saw it.
+     :invoke     (fn [before acc] (before acc))
+     :url-of     #(get-in % [:request :url])
+     :sensitive? (true? (:sensitive? ctx))
+     :where      'rf.http/run-interceptor-chain!
+     :slot-noun  ":before did not return a ctx map"}
+    ctx))
 
 (defn run-after-chain!
   "Per rf2-uheqq + Spec 014 §Middleware. Walk the per-frame interceptor
@@ -301,40 +332,18 @@
   the `:before` path uses, so a misbehaving response-side interceptor
   surfaces on the same trace event."
   [frame-id middleware-ctx response]
-  (let [chain      (get @interceptors frame-id)
-        sensitive? (true? (:sensitive? middleware-ctx))]
-    (reduce
-      (fn [acc {:keys [id after]}]
-        (if after
-          (try
-            (let [out (after middleware-ctx acc)]
-              (if (map? out)
-                out
-                (throw (ex-info ":rf.error/http-interceptor-bad-return"
-                                {:rf.error/id :rf.error/http-interceptor-bad-return
-                                 :where       'rf/reg-http-interceptor
-                                 :recovery    :no-recovery
-                                 :reason      (str "interceptor " id " :after did not return a response map")
-                                 :id          id
-                                 :returned    out}))))
-            (catch #?(:clj Throwable :cljs :default) t
-              (let [data (ex-info ":rf.error/http-interceptor-failed"
-                                  {:where    'rf.http/run-after-chain!
-                                   :recovery :no-recovery
-                                   :frame    frame-id
-                                   :interceptor-id id
-                                   :url      (get-in middleware-ctx [:request :url])
-                                   :phase    :after
-                                   :cause    (or (:reason (ex-data t))
-                                                 #?(:clj  (.getMessage ^Throwable t)
-                                                    :cljs (.-message t)))})]
-                (when interop/debug-enabled?
-                  (trace/emit-error! :rf.error/http-interceptor-failed
-                                     (privacy/prepare-emit-failure
-                                       (ex-data data)
-                                       sensitive?)))
-                (throw data))))
-          acc))
-      response
-      ;; Reverse order — mirror of the event-interceptor onion (Spec 002).
-      (reverse chain))))
+  (run-chain*
+    {;; Reverse order — mirror of the event-interceptor onion (Spec 002).
+     :chain      (reverse (get @interceptors frame-id))
+     :frame-id   frame-id
+     :slot-key   :after
+     ;; `:after` always sees the fixed middleware-ctx the `:before` chain
+     ;; produced (the response, not the ctx, is what threads through the
+     ;; reduce), so the URL is read from that ctx rather than the acc.
+     :invoke     (fn [after acc] (after middleware-ctx acc))
+     :url-of     (fn [_acc] (get-in middleware-ctx [:request :url]))
+     :sensitive? (true? (:sensitive? middleware-ctx))
+     :where      'rf.http/run-after-chain!
+     :phase      :after
+     :slot-noun  ":after did not return a response map"}
+    response))


### PR DESCRIPTION
Duplication-reduction review of `implementation/http/` (bead rf2-jkake.9, parent epic rf2-jkake). Conservative consolidation — only where it makes the slice clearer; behaviour-preserving.

## Consolidations

1. **`http-middleware` — `run-interceptor-chain!` / `run-after-chain!`.** The `:before` and `:after` walks were two ~60-line `reduce` loops sharing one structure: skip interceptors lacking the slot, run the slot fn, reject a non-map return with `:rf.error/http-interceptor-bad-return`, and wrap any throw as `:rf.error/http-interceptor-failed` (routed through `privacy/prepare-emit-failure` + re-thrown). Extracted a private `run-chain*` helper; the two public fns are now thin wrappers varying only on the genuinely different axes: slot key (`:before`/`:after`), slot-fn arity (`(slot acc)` vs `(slot fixed-ctx acc)`), chain order (registration / reverse), `:where` symbol + optional `:phase :after`, URL source (the threaded `acc` for `:before`; the fixed middleware-ctx for `:after`), and the bad-return sentence. Why clearer: the before/after symmetry the docstrings describe is now expressed in code, not duplicated prose; the few real differences are isolated to the wrapper call sites and annotated.

2. **`http-decode` — binary-decode cond arms.** The `:blob` / `:array-buffer` / `:form-data` branches in `decode-response-body` were three byte-identical `(if (some? body-binary) body-binary body-text)` arms. Collapsed onto the existing `binary-decode-kinds` set (the same set `binary-read-kind` already consults). Why clearer: ties the cond directly to the named set that documents the trio; removes a triple repetition.

## Considered, left inline (note, not actioned)

- `http-privacy` `redact-request-tags-with-flag` / `redact-failure-with-flag` share a `cond->` redaction shape, but redact different slot sets (tags: `:body`/`:params`; failure: `:body`/`:body-text`/`:decoded`/`:detail`/string-`:cause`, the last with a `string?` guard). Folding them would obscure the request-side vs response-side difference and add indirection for a `cond->` — left inline.
- `util-json` JSON-cap `ex-info` throws are duplicated across the `#?(:clj …)` / `:cljs` reader-conditional branches; they cannot share (the comment already documents why the two readers must be host-specific).
- `http-decode` four `malli-*-fn` `defonce` delays follow an identical reader-conditional shape, but the inline comment documents that CLJS `resolve` is a compile-time macro requiring a literal symbol, so they cannot be factored behind a runtime fn arg.

Cross-slice dedup: none actioned (out of scope per bead).

## Quality gates

- http JVM `clojure -M:test` — 277 tests / 1435 assertions, 0 failures, 0 errors (identical to pre-change baseline).
- `npm run test:cljs` — 5094 tests / 17225 assertions, 0 failures, 0 errors.
- clj-kondo on both changed files — 0 errors, 0 warnings.

## Confirmation

Public API, the `:rf.http/*` reserved vocabulary, and observable behaviour are unchanged. Edits are confined to `implementation/http/src/`.