### PR TITLE
refactor(flows): reduce duplication (rf2-jkake.8)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -58,6 +58,23 @@
 (defn- read-inputs [db flow]
   (mapv (fn [path] (get-in db path)) (:inputs flow)))
 
+(defn- elide-inputs
+  "Walk a flow's just-read input values through `elision/elide-wire-value`,
+  each under its own declared input db-path so per-path `:sensitive` /
+  `:large` declarations apply (Spec 009 §Size elision in traces). The
+  single home for the input-value elision the `:rf.flow/computed` success
+  payload and the `:rf.flow/failed` failure payload both ride — the trace
+  bus is the wire boundary on both paths, so a flow reading a large or
+  sensitive input must not surface it raw on either.
+
+  Callers gate this behind their own outer `interop/debug-enabled?` so the
+  walk is DCE'd in CLJS production (rf2-drr4z); this fn does not re-gate."
+  [frame-id flow input-values]
+  (mapv (fn [input-path v]
+          (elision/elide-wire-value v {:frame frame-id :path input-path}))
+        (:inputs flow)
+        input-values))
+
 (defn- validate-output!
   "Dev-only validation of a flow's computed `:output` value against its
   optional `:schema` (Spec 013 §The registration shape — \"Malli schema
@@ -231,12 +248,7 @@
           (when interop/debug-enabled?
             (trace/emit! :flow :rf.flow/computed
                          {:flow-id      flow-id
-                          :input-values (mapv (fn [input-path v]
-                                                (elision/elide-wire-value
-                                                  v
-                                                  {:frame frame-id :path input-path}))
-                                              (:inputs flow)
-                                              new-inputs)
+                          :input-values (elide-inputs frame-id flow new-inputs)
                           :before       (elision/elide-wire-value
                                           old-output
                                           {:frame frame-id :path (:path flow)})
@@ -269,22 +281,16 @@
           ;; flow-attributed detail tools (10x flow panel) consume.
           ;;
           ;; The failure-path `:inputs` payload rides through the
-          ;; elision walker for the same reason as the success path —
-          ;; the value that triggered the throw may itself be a
-          ;; large or sensitive blob, and the trace bus is the wire
-          ;; boundary. Each entry is walked under its own declared
-          ;; input path so per-path declarations apply. Outer debug-
-          ;; enabled? gate elides the walk in CLJS prod (rf2-drr4z).
+          ;; elision walker (`elide-inputs`) for the same reason as the
+          ;; success path — the value that triggered the throw may itself
+          ;; be a large or sensitive blob, and the trace bus is the wire
+          ;; boundary. Outer debug-enabled? gate elides the walk in CLJS
+          ;; prod (rf2-drr4z).
           (when interop/debug-enabled?
             (trace/emit! :flow :rf.flow/failed
                          {:flow-id flow-id
                           :ex      e
-                          :inputs  (mapv (fn [input-path v]
-                                           (elision/elide-wire-value
-                                             v
-                                             {:frame frame-id :path input-path}))
-                                         (:inputs flow)
-                                         new-inputs)
+                          :inputs  (elide-inputs frame-id flow new-inputs)
                           :frame   frame-id}))
           ;; Per rf2-je5p8: wrap the throw in an ex-info carrying the
           ;; flow-attribution slot `:rf.flow/failed-id`.


### PR DESCRIPTION
Duplication-reduction review of `implementation/flows/` (bead rf2-jkake.8, parent epic rf2-jkake).

## Consolidations applied

- **`elide-inputs` helper (flows.cljc).** The input-value elision walk appeared verbatim at two trace-emit sites — the `:rf.flow/computed` success payload (`:input-values`) and the `:rf.flow/failed` failure payload (`:inputs`). Both ran the identical zip `(mapv (fn [input-path v] (elision/elide-wire-value v {:frame frame-id :path input-path})) (:inputs flow) new-inputs)`. Extracted to one private `elide-inputs` fn that holds the per-path elision contract (Spec 009 §Size elision in traces) in a single place; each call site now reads as intent. The caller-side `interop/debug-enabled?` DCE gate stays OUTERMOST and visible at both emit sites (the helper does not re-gate), per the rf2-drr4z perf contract.

Net diff: 1 file, +24/-18.

## Reviewed and deliberately left inline (clearer inline than abstracted)

- **Single-value `elide-wire-value` calls** (`:before`, `:result`, the `validate-output!` value) — one call each, already clear; wrapping would obscure.
- **The five `(when interop/debug-enabled? (trace/emit! :flow <op> {... :frame frame-id}))` gate sites** (skip / computed / failed in flows.cljc; registered / cleared in registry.cljc) — each carries a distinct payload, and the source comments require the DCE gate stay OUTERMOST and visible per site. A macro would hide that contract; left as-is.

## Already consolidated upstream (no action)

- The two-level-map maintenance (`prune-frame-row`) and last-owning-frame check (`no-frame-holds?`) shared by clear-flow / teardown / hot-reload are already extracted in registry.cljc (rf2-ee38b.9).

## Notes (out of scope — not actioned here)

- **JVM test `reset-runtime` fixtures** repeat an ~8-line base reset across files but each layers different concerns (trace capture, error-listener clearing, conformance mid-test re-reset). A shared helper would need options/wrappers and would couple otherwise-independent test files — net not clearer. Left per-file. (CLJS already uses `test-support/make-reset-runtime-fixture`.)
- **Canonical thrown-error shape** is built by `flow-error` in registry.cljc and inlined in topo.cljc's cycle ex-info. topo.cljc is a deliberately require-free pure module (documented), so it cannot reach `flow-error` — intentional non-dedup; cross-coupling the pure module would be worse.
- Cross-slice dedup: none actioned (out of bead scope).

## Quality gates

- flows JVM `clojure -M:test` — 117 tests, 489 assertions, 0 failures, 0 errors (green before and after).
- `npm run test:cljs` — 5094 tests, 17225 assertions, 0 failures, 0 errors.
- clj-kondo `--fail-level error` on changed file — 0 errors, 0 warnings.

Behaviour and public API (`:rf.flow/*` reserved vocab, reg-flow/clear-flow surface, trace payload shapes) unchanged.
