### PR TITLE
refactor(machines-viz): reduce duplication (rf2-jkake.16)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -47,18 +47,19 @@
   is a React lib so the underlying React-class boundary is fine for
   every substrate; only the Reagent `as-element` glue needs a
   substrate-specific shim."
-  (:require ["@xyflow/react" :as xyflow]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.nodes.event-node
              :as event-node]
             [day8.re-frame2-machines-viz.chart.nodes.parallel-region-node
              :as parallel-region-node]
+            [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
+             :refer [Handle pos-top pos-right pos-bottom pos-left
+                     chart-constants]]
             [day8.re-frame2-machines-viz.chart.projection :as projection]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
-             :refer [mono-stack sans-stack]]
-            [day8.re-frame2-machines-viz.visual-constants :as vc]))
+             :refer [mono-stack sans-stack]]))
 
 ;; ---- density-resolved constants -----------------------------------------
 ;;
@@ -66,37 +67,16 @@
 ;; projector threads the resolved density's `visual-constants` map onto
 ;; every node payload as `:data {:chart {...}}`; xyflow `clj->js`-es the
 ;; node array, so the map arrives as a JS object. `chart-constants`
-;; recovers a kebab-keyword CLJS map (the keys `visual-constants` ships),
-;; falling back to `vc/chart-regular` so a node payload without a `:chart`
-;; entry (legacy / direct construction) still renders the regular default.
-
-(defn- chart-constants
-  "Recover the resolved visual-constants map off a node's `:data`
-  (`(.-chart d)`). The projector emits a CLJS map; xyflow `clj->js`-es
-  it into a JS object, so we `js->clj` it back with keyword keys.
-  Returns `vc/chart-regular` when absent so the regular density stays
-  pixel-identical to the pre-rf2-k647w hardcoded numbers."
-  [^js d]
-  (let [c (.-chart d)]
-    (if (some? c)
-      (js->clj c :keywordize-keys true)
-      vc/chart-regular)))
+;; (shared via `chart.nodes.xyflow-node`) recovers a kebab-keyword CLJS
+;; map, falling back to `vc/chart-regular` so a node payload without a
+;; `:chart` entry (legacy / direct construction) still renders the
+;; regular default.
 
 ;; ---- xyflow Handle adapter ----------------------------------------------
-
-(def ^:private Handle
-  "xyflow `Handle` React class. Used inside every custom node via
-  Reagent's `:>` interop so xyflow knows where to attach edges."
-  (.-Handle xyflow))
-
-(def ^:private Position
-  "xyflow position constants (`Top`, `Right`, `Bottom`, `Left`)."
-  (.-Position xyflow))
-
-(def ^:private pos-top    (.-Top Position))
-(def ^:private pos-right  (.-Right Position))
-(def ^:private pos-bottom (.-Bottom Position))
-(def ^:private pos-left   (.-Left Position))
+;;
+;; `Handle` + the four `pos-*` constants are the shared xyflow node-
+;; interop preamble (`chart.nodes.xyflow-node`); referred above so every
+;; custom node attaches edges identically.
 
 ;; ---- node-size floor constants ------------------------------------------
 ;;

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
@@ -37,30 +37,13 @@
   `visual-constants` map threaded through `:data {:chart ...}` —
   same pattern the state-node + edge components use. No hex literals
   appear in this ns; all colour goes through `theme/tokens`."
-  (:require ["@xyflow/react" :as xyflow]
-            [reagent.core :as r]
+  (:require [reagent.core :as r]
+            [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
+             :refer [Handle pos-top pos-right pos-bottom pos-left
+                     chart-constants]]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
-             :refer [mono-stack sans-stack]]
-            [day8.re-frame2-machines-viz.visual-constants :as vc]))
-
-(def ^:private Handle   (.-Handle xyflow))
-(def ^:private Position (.-Position xyflow))
-(def ^:private pos-top    (.-Top Position))
-(def ^:private pos-right  (.-Right Position))
-(def ^:private pos-bottom (.-Bottom Position))
-(def ^:private pos-left   (.-Left Position))
-
-(defn- chart-constants
-  "Recover the resolved visual-constants map off an event-node's `:data`
-  (`(.-chart d)`). xyflow `clj->js`-es the CLJS map into a JS object, so
-  recover it with kebab-keyword keys. Falls back to `vc/chart-regular`
-  when absent (legacy / direct construction)."
-  [^js d]
-  (let [c (.-chart d)]
-    (if (some? c)
-      (js->clj c :keywordize-keys true)
-      vc/chart-regular)))
+             :refer [mono-stack sans-stack]]))
 
 (defn- variant-glyph
   "rf2-qo5xy — convention-glyph variants for the event-node header. The

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -49,18 +49,12 @@
   region container is SILENTLY DROPPED from the DOM. The same
   mechanic the compound-node fix uses; the region-node mirrors it for
   consistency."
-  (:require ["@xyflow/react" :as xyflow]
-            [reagent.core :as r]
+  (:require [reagent.core :as r]
+            [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
+             :refer [Handle pos-top pos-right pos-bottom pos-left]]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
              :refer [sans-stack]]))
-
-(def ^:private Handle (.-Handle xyflow))
-(def ^:private Position (.-Position xyflow))
-(def ^:private pos-top    (.-Top Position))
-(def ^:private pos-right  (.-Right Position))
-(def ^:private pos-bottom (.-Bottom Position))
-(def ^:private pos-left   (.-Left Position))
 
 ;; ---- region boundary palette --------------------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/xyflow_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/xyflow_node.cljs
@@ -1,0 +1,52 @@
+(ns day8.re-frame2-machines-viz.chart.nodes.xyflow-node
+  "Shared interop preamble for the MachineChart's custom xyflow node
+  components (`state-node` / `compound-node` / `initial-marker` in
+  `chart.nodes`, plus `event-node` + `parallel-region-node`).
+
+  ## Why this exists
+
+  Every custom node hooks into xyflow the same way: it pulls the
+  `Handle` React class + the four `Position` constants for its
+  invisible edge-attachment points, and (for the geometry-bearing
+  nodes) recovers the resolved density's `visual-constants` map off the
+  `clj->js`-ed node `:data`. That preamble was byte-identical in each
+  node ns; consolidating it here removes the copy-paste while keeping
+  the rendered output pixel-identical.
+
+  This ns deliberately requires NOTHING from `chart.nodes` (which
+  requires the per-kind node nss), so there is no dependency cycle —
+  it sits below them and depends only on `@xyflow/react` + the pure
+  `visual-constants`."
+  (:require ["@xyflow/react" :as xyflow]
+            [day8.re-frame2-machines-viz.visual-constants :as vc]))
+
+;; ---- xyflow Handle adapter ----------------------------------------------
+
+(def Handle
+  "xyflow `Handle` React class. Used inside every custom node via
+  Reagent's `:>` interop so xyflow knows where to attach edges."
+  (.-Handle xyflow))
+
+(def Position
+  "xyflow position constants (`Top`, `Right`, `Bottom`, `Left`)."
+  (.-Position xyflow))
+
+(def pos-top    (.-Top Position))
+(def pos-right  (.-Right Position))
+(def pos-bottom (.-Bottom Position))
+(def pos-left   (.-Left Position))
+
+;; ---- density-resolved constants -----------------------------------------
+
+(defn chart-constants
+  "Recover the resolved visual-constants map off a node's `:data`
+  (`(.-chart d)`). The projector emits a CLJS map; xyflow `clj->js`-es
+  it into a JS object, so we `js->clj` it back with keyword keys.
+  Returns `vc/chart-regular` when absent so the regular density stays
+  pixel-identical to the pre-rf2-k647w hardcoded numbers (legacy /
+  direct construction also lands on the regular default)."
+  [^js d]
+  (let [c (.-chart d)]
+    (if (some? c)
+      (js->clj c :keywordize-keys true)
+      vc/chart-regular)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
@@ -42,18 +42,10 @@
              :as anchor]))
 
 ;; ---- DOM measurement ----------------------------------------------------
-
-(defn- measure-anchor
-  "Walk the DOM under `root` for the cascade-spec's parent node and
-  return the overlay-local waterfall anchor (or nil when the node
-  isn't in the DOM). Uses the shared `overlay-anchor` DOM seam + the
-  pure `overlay-anchor/anchor-below`."
-  [^js root node-id]
-  (when (and root node-id)
-    (let [container (anchor/rect->map (.getBoundingClientRect root))
-          node      (anchor/query-node-rect-by-testid
-                      root (anchor/node->testid node-id))]
-      (anchor/anchor-below node container))))
+;;
+;; The waterfall anchors BELOW the parent state; the DOM walk + container
+;; re-base is the shared `anchor/measure-anchor` seam (rf2-jkake.16) — this
+;; overlay supplies only the `anchor-below` placement.
 
 ;; ---- cascade-step glyph -------------------------------------------------
 
@@ -164,7 +156,8 @@
                      (when-let [root @root-ref]
                        (when-let [spec @latest]
                          (reset! anchored
-                                 (measure-anchor root (:node-id spec))))))
+                                 (anchor/measure-anchor
+                                   anchor/anchor-below root (:node-id spec))))))
         resize-fn  (fn [_] (remeasure!))]
     (r/create-class
       {:display-name "MachinesViz.CancellationCascadeOverlay"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
@@ -68,6 +68,21 @@
          (when el
            (rect->map (.getBoundingClientRect el)))))))
 
+#?(:cljs
+   (defn measure-anchor
+     "Walk `root`'s subtree for `node-id`'s bearing node, then turn its
+     viewport rect + `root`'s own rect into an overlay-local anchor by
+     applying the pure `anchor-fn` (`anchor-below` / `anchor-right-of`).
+     Returns nil when `root` / `node-id` is missing or the node isn't
+     in the DOM. CLJS-only (DOM interop); the shared measurement seam
+     the card overlays (cancellation-cascade, spawn-all-join) share so
+     each ns keeps only its anchor-fn choice (rf2-jkake.16)."
+     [anchor-fn ^js root node-id]
+     (when (and root node-id)
+       (let [container (rect->map (.getBoundingClientRect root))
+             node      (query-node-rect-by-testid root (node->testid node-id))]
+         (anchor-fn node container)))))
+
 (defn anchor-right-of
   "Anchor a card to the RIGHT of a bearing node. Takes the node's
   viewport rect + the overlay container's rect; returns

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
@@ -41,18 +41,11 @@
              :as anchor]))
 
 ;; ---- DOM measurement ----------------------------------------------------
-
-(defn- measure-anchor
-  "Walk the DOM under `root` for the join-spec's bearing node and
-  return the overlay-local card anchor (or nil when the node isn't in
-  the DOM). Uses the shared `overlay-anchor` DOM seam + the pure
-  `overlay-anchor/anchor-right-of`."
-  [^js root node-id]
-  (when (and root node-id)
-    (let [container (anchor/rect->map (.getBoundingClientRect root))
-          node      (anchor/query-node-rect-by-testid
-                      root (anchor/node->testid node-id))]
-      (anchor/anchor-right-of node container))))
+;;
+;; The join card anchors to the RIGHT of the bearing state; the DOM walk +
+;; container re-base is the shared `anchor/measure-anchor` seam
+;; (rf2-jkake.16) — this overlay supplies only the `anchor-right-of`
+;; placement.
 
 ;; ---- child-row glyph ----------------------------------------------------
 
@@ -200,7 +193,8 @@
                      (when-let [root @root-ref]
                        (when-let [spec @latest]
                          (reset! anchored
-                                 (measure-anchor root (:node-id spec))))))
+                                 (anchor/measure-anchor
+                                   anchor/anchor-right-of root (:node-id spec))))))
         resize-fn  (fn [_] (remeasure!))]
     (r/create-class
       {:display-name "MachinesViz.SpawnAllJoinOverlay"


### PR DESCRIPTION
Duplication-reduction pass over `tools/machines-viz/` only (bead rf2-jkake.16, parent epic rf2-jkake). Conservative: consolidate only the two byte-identical copy-paste patterns where a shared home reads clearer; clearer-inline repetitions stay.

## Consolidations

1. **xyflow custom-node interop preamble** → new `chart.nodes.xyflow-node`.
   The `Handle` / `Position` / `pos-top|right|bottom|left` defs were byte-identical in `chart.nodes`, `nodes.event-node`, and `nodes.parallel-region-node`; the `chart-constants` density-recovery helper was byte-identical in `chart.nodes` + `nodes.event-node`. Both moved to one small cohesive ns. It requires only `@xyflow/react` + the pure `visual-constants`, so it sits *below* the node nss with no dependency cycle (`chart.nodes` requires the per-kind node nss, so the shared code could not live there).

2. **Card-overlay DOM walk** → shared `overlays.overlay-anchor/measure-anchor`.
   `measure-anchor` was identical in `overlays.cancellation-cascade` + `overlays.spawn-all-join` except for the final pure anchor fn. Lifted into the existing DOM-seam home (alongside `query-node-rect-by-testid` / `rect->map`), parameterised by the anchor fn — each overlay keeps only its `anchor-below` / `anchor-right-of` placement choice.

Net: 6 files modified, 1 new ns; ~90 deletions vs ~100 insertions (most of the new lines are the shared ns's docstring).

## Noted (NOT actioned — out of conservative scope / cross-slice)

- The three positioned-card overlays (after-rings, spawn-all-join, cancellation-cascade) share a near-identical form-3 lifecycle scaffold (resize-listener add/remove + `remeasure!` + the absolute-positioned root `:div`). Extracting a shared form-3 builder would need callbacks for the per-overlay measure/render variation (ring-vec vs single-anchor; label-collisions diverges further with rAF scheduling + chart-root attrs), which reads *less* clearly than the explicit repetition. Left inline.
- The `+ <action>` pill chrome appears in both `chart.nodes/action-pill` and inline in `nodes.event-node`; they read off different vc keys and sit in different layout contexts, so the inline repetition stays clearer than a shared pill fn.
- Cross-slice: `tools/xray`'s machine panel consumes these overlay components as a host; any shared shape there is intentionally left untouched per scope (note-only, no reach-across).

## reg-view ids / behaviour

Unchanged. No reg-view ids, reserved vocab, testids, rendered DOM, or overlay anchoring math changed — only the home of shared code moved. Behaviour-preserving.

## Quality gates

- `tools/machines-viz` JVM `clojure -M:test` — 316 tests, 819 assertions, 0 failures, 0 errors (matches pre-change baseline).
- From `implementation/`: `npm run test:cljs` — 5094 tests, 17225 assertions, 0 failures, 0 errors.
- clj-kondo on all 7 changed/new files — 0 errors, 0 warnings.