### PR TITLE
refactor(template): reduce duplication (rf2-jkake.22)

### DIFF
--- a/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
+++ b/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
@@ -27,13 +27,12 @@
             [clojure.java.io :as io]
             [clojure.string :as string]
             [day8.re-frame2-template.test-support
-             :refer [tmp-dir delete-recursively repo-root template-resource-dir]]
-            [org.corfield.new :as deps-new]))
+             :refer [tmp-dir delete-recursively repo-root run-template!]]))
 
 ;; --- Helpers ---------------------------------------------------------------
 ;;
-;; repo-root / template-resource-dir / tmp-dir / delete-recursively live
-;; in the shared `test-support` ns (rf2-5v619, D1). repo-root anchors on
+;; repo-root / run-template! / tmp-dir / delete-recursively live in the
+;; shared `test-support` ns (rf2-5v619, D1). repo-root anchors on
 ;; `implementation/core/src/re_frame` — the same repo root that holds
 ;; VERSION + implementation/package.json read below.
 
@@ -101,18 +100,13 @@
 ;; package.json + deps.edn. This tests the literals as actually-consumed
 ;; (the same value that flows into a generated app), not the source
 ;; string parsed out of the .clj.
-
-(defn- emit-reagent! [tmp]
-  (let [dir-str  (.toString ^java.nio.file.Path tmp)
-        proj-dir (io/file dir-str "my-app")
-        opts     {:template   'day8/re-frame2-template
-                  :name       'acme/my-app
-                  :target-dir (.getCanonicalPath proj-dir)
-                  :src-dirs   [(template-resource-dir)]
-                  :overwrite  :delete
-                  :substrate  :reagent}]
-    (deps-new/create opts)
-    proj-dir))
+;;
+;; Emission uses the shared `run-template!` (test-support) — the
+;; pin literals are substrate-invariant, so the Reagent default path
+;; recovers them. (Previously a local `emit-reagent!` re-implemented
+;; the same `org.corfield.new/create` opts map; folded into the shared
+;; helper per rf2-jkake.22, keeping the rf2-5v619 D1 'one harness'
+;; posture.)
 
 (defn- extract-pin
   "Pull `\"pkg\": \"value\"` out of the emitted package.json text.
@@ -135,7 +129,7 @@
           pkg-react-dom (read-package-json-pin "react-dom")
           tmp           (tmp-dir "rf2-template-lockstep-react-")]
       (try
-        (let [root      (emit-reagent! tmp)
+        (let [root      (run-template! tmp "acme/my-app" :reagent)
               pj-text   (slurp (io/file root "package.json"))
               tpl-react     (extract-pin pj-text "react")
               tpl-react-dom (extract-pin pj-text "react-dom")]
@@ -160,7 +154,7 @@
     (let [pkg-shadow (read-package-json-pin "shadow-cljs")
           tmp        (tmp-dir "rf2-template-lockstep-shadow-")]
       (try
-        (let [root       (emit-reagent! tmp)
+        (let [root       (run-template! tmp "acme/my-app" :reagent)
               pj-text    (slurp (io/file root "package.json"))
               tpl-shadow (extract-pin pj-text "shadow-cljs")]
           (is (= pkg-shadow tpl-shadow)
@@ -176,7 +170,7 @@
     (let [version-file (read-version-file)
           tmp          (tmp-dir "rf2-template-lockstep-rf2-")]
       (try
-        (let [root        (emit-reagent! tmp)
+        (let [root        (run-template! tmp "acme/my-app" :reagent)
               deps-text   (slurp (io/file root "deps.edn"))
               tpl-rf2     (extract-rf2-version deps-text)]
           (is (= version-file tpl-rf2)


### PR DESCRIPTION
Duplication-reduction review of `tools/template/` (per-slice dedup pass under epic rf2-jkake). Conservative: consolidate only where it makes the slice clearer; intentional starter-copies left intact.

## Quality gates

- `tools/template` JVM `clojure -M:test` — **22 tests / 300 assertions, 0 failures, 0 errors** (includes all three `version_lockstep` deftests touched here).
- `implementation/` `npm run test:cljs` — **5094 tests / 17225 assertions, 0 failures, 0 errors** (untouched by this change; run to confirm no regression).
- clj-kondo (native v2025.10.23) on the changed file — **0 errors, 0 warnings**.

## Consolidation applied

- **`version_lockstep_test.clj`**: folded the file-local `emit-reagent!` into the shared `test-support/run-template!`. The local fn re-implemented the `org.corfield.new/create` opts map for the Reagent default path — the exact case `run-template!` already covers — so the slice carried two independently-drifting copies of the deps-new invocation. The three lockstep deftests now call `(run-template! tmp \"acme/my-app\" :reagent)`. This finishes the rf2-5v619 D1 \"one harness\" posture for the last test file that still carried its own emit path. Net −6 lines; the now-unused `org.corfield.new` + `template-resource-dir` requires drop.

## Reviewed and intentionally left as-is (noted, not changed)

- **Per-substrate resource stubs** (`_reagent/` / `_uix/` / `_helix/` `deps.edn`, `shadow-cljs.edn`, `package.json`, `core.cljs`, `views.cljs`): each `_<substrate>/` directory is a self-contained, top-to-bottom-readable starter set. `core.cljs` genuinely differs per substrate (adapter + DOM-mount interop); `deps.edn` differs (adapter coord + substrate deps). `shadow-cljs.edn` and `package.json` are near-identical across substrates, but they are part of that deliberate self-contained-starter pattern and collapsing them into `_shared/` would fragment the per-substrate set for marginal gain — exactly the over-dedup this surface is cautioned against.
- **`package_with_story.json`** is currently byte-identical to `_reagent/package.json` (the qrcode-generator dep was retired in rf2-ymnfx), but the separate file is required by `template-fn`'s flag-switch mechanism (deps-new has no conditional substitution) and the suite pins the with-story package.json's contents. Intentional infrastructure, not accidental dup.
- **`hooks.clj` `template-fn`** `:uix` / `:helix` `case` branches are structurally identical bar the source-dir string; the `case` form keeps each substrate's file-map visible inline. A shared helper would reduce visible-shape clarity for two lines saved — left for clarity.

## Behaviour / output shape

Confirmed unchanged. No public API, no `data-fn`/`template-fn`/`post-process-fn` contract, and no generated-output shape touched — the change is purely a test-harness consolidation; the emitted project tree is identical.