### PR TITLE
refactor(mcp-base): reduce duplication (rf2-jkake.17)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -188,6 +188,33 @@
      :cljs (try (resolve 'malli.core/validate)
                 (catch :default _ nil))))
 
+(defn- validate-against!
+  "Shared soft-pass Malli gate behind `validate-patches!` /
+  `validate-sections!`. Validates `data` against `schema` and throws
+  `:rf.error/<error-id>` ex-info on mismatch; no-op when Malli is not
+  resolvable on the runtime classpath (soft-pass — mirrors
+  `re-frame.schemas.malli`'s default validator) or when
+  `validate-patches?` is elided.
+
+  `where` is the calling-site symbol threaded through to the ex-info
+  `:where` slot so it reflects the ACTUAL wire boundary that tripped
+  (rf2-4ypau) rather than a hardcoded one side. `data-key` names the
+  ex-data slot the offending value rides under (`:patches` /
+  `:sections`) so an operator reading the ex-data finds it under the
+  shape it expected. Returns nil."
+  [schema data where error-id reason data-key]
+  (when validate-patches?
+    (when-let [validate (resolve-malli-validate)]
+      (when-not (validate schema data)
+        (throw (ex-info (str error-id)
+                        {:rf.error/id error-id
+                         :where       where
+                         :recovery    :no-recovery
+                         :reason      reason
+                         :schema      schema
+                         data-key     data})))))
+  nil)
+
 (defn- validate-patches!
   "Validate `patches` against `patches-schema` and throw ex-info on
   mismatch. No-op when Malli is not resolvable on the runtime
@@ -202,17 +229,10 @@
   encoder and misleads operator triage about which side of the wire
   drifted."
   [patches where]
-  (when validate-patches?
-    (when-let [validate (resolve-malli-validate)]
-      (when-not (validate patches-schema patches)
-        (throw (ex-info ":rf.error/bad-diff-patches"
-                        {:rf.error/id    :rf.error/bad-diff-patches
-                         :where          where
-                         :recovery       :no-recovery
-                         :reason         "diff-encode patch grammar violated"
-                         :schema         patches-schema
-                         :patches        patches})))))
-  nil)
+  (validate-against! patches-schema patches where
+                     :rf.error/bad-diff-patches
+                     "diff-encode patch grammar violated"
+                     :patches))
 
 (defn- validate-sections!
   "Validate `sections` against `sections-schema` and throw ex-info on
@@ -226,17 +246,10 @@
   from the decoder. Both boundaries call this; hardcoding one side
   misattributes a decode-side throw to the encoder."
   [sections where]
-  (when validate-patches?
-    (when-let [validate (resolve-malli-validate)]
-      (when-not (validate sections-schema sections)
-        (throw (ex-info ":rf.error/bad-diff-sections"
-                        {:rf.error/id   :rf.error/bad-diff-sections
-                         :where         where
-                         :recovery      :no-recovery
-                         :reason        "diff-encode section grammar violated"
-                         :schema        sections-schema
-                         :sections      sections})))))
-  nil)
+  (validate-against! sections-schema sections where
+                     :rf.error/bad-diff-sections
+                     "diff-encode section grammar violated"
+                     :sections))
 
 (declare collect-patches-into)
 


### PR DESCRIPTION
Per-slice duplication-reduction review of `tools/mcp-base/` only (epic rf2-jkake, bead rf2-jkake.17). Conservative pass: consolidate genuine internal duplication where it makes the slice clearer; keep the public helper surface and all behaviour stable.

## Consolidation applied

**`diff_encode.cljc` — `validate-patches!` + `validate-sections!`.** The two private Malli-gate fns were structurally identical: the same `(when validate-patches? (when-let [validate (resolve-malli-validate)] (when-not (validate schema data) (throw (ex-info ...)))))` skeleton, differing only in schema, error-id, reason string, and the ex-data slot key (`:patches` vs `:sections`). The shared skeleton + the `ex-info` throw-construction were copy-pasted.

Extracted a single private `validate-against!` core holding the gate + throw, parameterised by `[schema data where error-id reason data-key]`. The two named wrappers stay (both are referenced privately by `diff_encode_test` via `#'de/validate-patches!`, and the docstrings document the encoder/decoder `:where` threading) and now delegate in one line each. Net: the gate skeleton is named once; the wrappers become a clear difference table.

Behaviour-preserving: ex-info message string (`(str error-id)` == the prior literal), `:rf.error/id`, `:where`, `:recovery :no-recovery`, `:reason`, `:schema`, and the `:patches` / `:sections` data slot are all emitted byte-identically.

## Public helper surface

Unchanged. `validate-patches!` / `validate-sections!` are private; their arglists, behaviour, and test entry points are preserved. No public def in any mcp-base ns changed — the surface the two MCP servers + conformance consume is stable.

## Candidates noted, deliberately NOT applied (clearer inline)

- **`cap.cljc` `sum-text-tokens` / `sum-text-chars`** — same transduce skeleton, differing inner map (`token-estimate` vs `count`). Both are tiny, public, separately tested, and `apply-cap`'s hot path deliberately folds both in one walk rather than calling them — a shared higher-order helper would add indirection without clarity. Left + noted.
- **`args.cljc` `safe-keyword` / `fresh-keyword`** — share the `normalise-keyword-string` + ns-part branch, but the load-bearing distinction is exactly the intern posture (`find-keyword` no-intern vs `keyword` intern). Consolidating would obscure the rf2-ih7g4 DoS-gate intent. Left.
- **`sensitive.cljc` counter helpers** — idiomatic `#?(:clj AtomicLong :cljs atom)` platform-split, clear inline. Left.
- **Cross-slice:** the cursor/cap/envelope hooks already parameterise the consumer-side shape differences; no further cross-slice dedup belongs in mcp-base.

## Quality gates

- `tools/mcp-base` JVM `clojure -M:test`: **157 tests / 419 assertions, 0 failures**.
- `tools/mcp-base` CLJS build `npm run test:cljs`: **8 tests / 39 assertions, 0 failures** (covers the soft-pass-when-Malli-absent + goog-define branches that route through the new `validate-against!`).
- `implementation/` `npm run test:mcp-conformance`: **ALL 6 GATES GREEN** (story-mcp JVM + Node stdio, re-frame2-pair-mcp server-test, both-MCP conformance, wire-vocab 48 tests / 615 assertions).
- clj-kondo on the changed file: **0 errors, 0 warnings**.
