### PR TITLE
refactor(pair-mcp): reduce duplication (rf2-jkake.19)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
@@ -296,6 +296,31 @@
               m)))
         {} as-clj))))
 
+(defn read-edn-arg
+  "Read a single-value EDN MCP arg into the `[:ok parsed]` / `[:err reason]`
+  shape the write/introspection tools branch on (rf2-jkake.19).
+
+  Trims, then `read-string`s the value; an absent / blank value yields
+  `[:err missing]`, an unreadable one `[:err invalid]`. `missing` /
+  `invalid` are the per-tool reason keywords (e.g. `:missing-db` /
+  `:invalid-db-edn`) so each tool's error envelope stays specific.
+
+  Factors out the trim+read+sentinel core shared verbatim by
+  `reset-frame-db` (`:db`), `restore-epoch` (`:epoch-id`), and
+  `handler-meta` (`:id`). The richer `dispatch` / `dispatch-dry-run`
+  event parsers are deliberately NOT routed through here — they layer a
+  vector-shape contract + parsed-type classification on top, and their
+  ns docstrings pin them as separately-evolving surfaces."
+  [raw missing invalid]
+  (let [trimmed (some-> raw str/trim)]
+    (if (or (nil? trimmed) (str/blank? trimmed))
+      [:err missing]
+      (let [parsed (try (cljs.reader/read-string trimmed)
+                        (catch :default _ ::reader-fail))]
+        (if (= ::reader-fail parsed)
+          [:err invalid]
+          [:ok parsed])))))
+
 (defn parse-filter-arg
   "MCP-side filter arg can be either a JS object or an EDN string. We
   accept both for ergonomic parity with the bash-shim chain (`pred`

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -264,7 +264,6 @@
                            (await-render-callbacks mode))))
                 (.catch (fn [err] (probe/err->result :dispatch-failed err)))))
           (let [form (ef/emit (ef/rt-call fn-sym event-vec opts-form))]
-            (-> (probe/ensure-runtime! conn build-id)
-                (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-                (.then (fn [v] (runtime-envelope->result mode v)))
-                (.catch (fn [err] (probe/err->result :dispatch-failed err))))))))))
+            (probe/eval-after-runtime!
+              conn build-id form :dispatch-failed
+              (fn [v] (runtime-envelope->result mode v)))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
@@ -34,7 +34,6 @@
   losing the dry-run's roll-back guarantee."
   (:require [cljs.reader]
             [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
@@ -93,17 +92,15 @@
                         frame        (assoc :frame frame)
                         fx-overrides (assoc :fx-overrides fx-overrides))
             form (ef/emit (ef/rt-call 'dispatch-dry-run event-vec opts-form))]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [v]
-                     ;; The runtime returns a structured envelope
-                     ;; carrying :ok? / :dry-run? / :rolled-back? /
-                     ;; :cascade-summary / :would-fire-effects /
-                     ;; :db-state-after-simulation on the happy path
-                     ;; (or a structured failure envelope on the
-                     ;; :no-epoch-recorded / :no-new-epoch paths).
-                     (wire/ok-text
-                       (if (map? v)
-                         v
-                         {:ok? false :reason :unexpected-shape :value v}))))
-            (.catch (fn [err] (probe/err->result :dispatch-dry-run-failed err))))))))
+        (probe/eval-after-runtime!
+          conn build-id form :dispatch-dry-run-failed
+          (fn [v]
+            ;; The runtime returns a structured envelope carrying :ok? /
+            ;; :dry-run? / :rolled-back? / :cascade-summary /
+            ;; :would-fire-effects / :db-state-after-simulation on the
+            ;; happy path (or a structured failure envelope on the
+            ;; :no-epoch-recorded / :no-new-epoch paths).
+            (wire/ok-text
+              (if (map? v)
+                v
+                {:ok? false :reason :unexpected-shape :value v}))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
@@ -56,7 +56,7 @@
   the agent can rely on across runtimes and editor-config postures."
   (:require [clojure.string :as str]
             [cljs.reader :as edn]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
@@ -107,23 +107,14 @@
   `\"[:rf/composite \\\"x\\\"]\"`) so callers can pass any registered
   id shape, including composite vectors used for sub-graph keys.
 
-  Returns `[:ok parsed]` on success or `[:err msg]` on a read failure.
-  A bare keyword-shaped string (leading `:`) round-trips through
-  `read-string`; a plain word like `\"foo\"` reads as a symbol — we
-  reject that to surface the contract clearly (registered ids are
-  keywords, not symbols)."
+  Returns `[:ok parsed]` on success or `[:err reason]` on a read
+  failure (`:missing-id` / `:invalid-id-edn`) — the shared
+  `args/read-edn-arg` readability core (rf2-jkake.19). A bare
+  keyword-shaped string (leading `:`) round-trips through `read-string`;
+  a plain word like `\"foo\"` reads as a symbol — the caller's
+  `:not-registered` lookup then surfaces that it isn't a registered id."
   [s]
-  (cond
-    (or (nil? s) (and (string? s) (str/blank? s)))
-    [:err :missing-id]
-
-    :else
-    (let [trimmed (str/trim s)
-          parsed  (try (cljs.reader/read-string trimmed)
-                       (catch :default _ ::reader-fail))]
-      (cond
-        (= ::reader-fail parsed) [:err :invalid-id-edn]
-        :else                    [:ok parsed]))))
+  (args/read-edn-arg s :missing-id :invalid-id-edn))
 
 (defn- kinds-hint
   "Comma-joined list of the supported kinds — used in error envelopes
@@ -194,9 +185,9 @@
       (let [form (if (= :machine kind)
                    (machine-form id-val)
                    (registrar-form kind id-val))]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [v]
+        (probe/eval-after-runtime!
+          conn build-id form :handler-meta-failed
+          (fn [v]
                      ;; Three envelope shapes resolve into one shape
                      ;; agents can rely on:
                      ;;   - hit (map with no :reason): merge :ok? true
@@ -233,8 +224,7 @@
                            (assoc v* :kind kind :id id-val)
 
                            :else
-                           (assoc v* :ok? true :kind kind :id id-val))))))
-            (.catch (fn [err] (probe/err->result :handler-meta-failed err))))))))
+                           (assoc v* :ok? true :kind kind :id id-val))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Tool — list-handlers.
@@ -265,12 +255,11 @@
 
       :else
       (let [form (list-form kind)]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [v]
-                     (wire/ok-text
-                       {:ok?   true
-                        :kind  kind
-                        :ids   (vec v)
-                        :count (count v)})))
-            (.catch (fn [err] (probe/err->result :list-handlers-failed err))))))))
+        (probe/eval-after-runtime!
+          conn build-id form :list-handlers-failed
+          (fn [v]
+            (wire/ok-text
+              {:ok?   true
+               :kind  kind
+               :ids   (vec v)
+               :count (count v)})))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_streams.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_streams.cljs
@@ -39,7 +39,6 @@
   :created-at}]}`. Empty `:subs` vector when no streams are open (or
   when the filter matches nothing)."
   (:require [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
@@ -68,7 +67,6 @@
                                'subs (ef/rt-raw "(:subs r)")]
                               (ef/rt-raw
                                 (str "(assoc r :subs " (filter-form topic sub-id) ")"))))]
-    (-> (probe/ensure-runtime! conn build-id)
-        (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-        (.then (fn [v] (wire/ok-text (if (map? v) v {:ok? true :subs []}))))
-        (.catch (fn [err] (probe/err->result :list-streams-failed err))))))
+    (probe/eval-after-runtime!
+      conn build-id form :list-streams-failed
+      (fn [v] (wire/ok-text (if (map? v) v {:ok? true :subs []}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
@@ -53,8 +53,7 @@
   (or, with `:include-values true`,
   `:subs [{:query-v <v> :value v :ref-count n} ...]`). Empty `:subs`
   vector when nothing is subscribed in the frame."
-  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.eval-form :as ef]
+  (:require [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.probe :as probe]))
@@ -70,7 +69,6 @@
                    frame (assoc :frame frame)
                    incl? (assoc :include-values? true))
         form     (ef/emit (ef/rt-call 'sub-cache-info opts))]
-    (-> (probe/ensure-runtime! conn build-id)
-        (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-        (.then (fn [v] (wire/ok-text (if (map? v) v {:ok? true :subs []}))))
-        (.catch (fn [err] (probe/err->result :list-subscriptions-failed err))))))
+    (probe/eval-after-runtime!
+      conn build-id form :list-subscriptions-failed
+      (fn [v] (wire/ok-text (if (map? v) v {:ok? true :subs []}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -525,3 +525,49 @@
   (if-let [data (ex-data err)]
     (wire/ok-text (merge {:ok? false} data))
     (wire/ok-text {:ok? false :reason fallback-reason :message (.-message err)})))
+
+;; ---------------------------------------------------------------------------
+;; Shared eval-prelude (rf2-jkake.19).
+;;
+;; The single-eval read/write tools all wear the SAME four-step promise
+;; chain: confirm the runtime is preloaded, send ONE form over nREPL,
+;; shape the resolved value into an MCP envelope, and translate any
+;; rejection through `err->result`. Only the middle `.then` (how the
+;; resolved value becomes an envelope) and the `:fail-reason` keyword
+;; differ per tool. `eval-after-runtime!` factors out the invariant
+;; prelude/postlude so each tool body reads as just "what form do I
+;; send, and how do I shape the response" — the prelude stops obscuring
+;; the per-tool logic.
+;;
+;; Tools that DON'T use this helper, and why:
+;;   - snapshot / get-path / subscribe — insert a `signal-runtime!` step
+;;     between `ensure-runtime!` and the eval (the raw-state tap gate,
+;;     rf2-c2dtu), so their prelude is a different shape.
+;;   - eval-cljs — uses `resolve-and-preflight!` (fail-loud build
+;;     resolution), not the plain `ensure-runtime!` probe.
+;;   - watch-until / tail-build — poll a form on a cadence, not a single
+;;     eval.
+;;   - dispatch (`:await-render`) — threads the await-promise mailbox
+;;     between the eval and the result.
+;;   - discover-app — chains a `runtime-health!` read after the probe.
+;; ---------------------------------------------------------------------------
+
+(defn eval-after-runtime!
+  "The shared single-eval prelude (rf2-jkake.19). Confirm the runtime is
+  preloaded for `(conn, build-id)`, eval `form` over nREPL, pass the
+  resolved value to `on-value` (which returns the MCP envelope), and
+  translate any rejection via `err->result` keyed by `fail-reason`.
+
+  `on-value` is a 1-arity fn `(fn [v] => js-mcp-result)` carrying the
+  tool's own response-shaping — the part that genuinely differs per
+  tool. Returns the Promise of the MCP result.
+
+  `nrepl/cljs-eval-value` is resolved per-call (a plain var reference),
+  so the `set!`-based test seam — every per-tool test stubs that var —
+  keeps working through this helper exactly as it did at the inline
+  call-sites."
+  [conn build-id form fail-reason on-value]
+  (-> (ensure-runtime! conn build-id)
+      (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+      (.then on-value)
+      (.catch (fn [err] (err->result fail-reason err)))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
@@ -96,7 +96,6 @@
   No DOM at all (server-side / headless eval target) →
   {:ok? false :reason :rf.error/read-dom-no-document}."
   (:require [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
@@ -234,8 +233,6 @@
 
       :else
       (let [form (read-dom-form selector sub-selector limit max-text attrs)]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [envelope]
-                     (wire/ok-text envelope)))
-            (.catch (fn [err] (probe/err->result :read-dom-failed err))))))))
+        (probe/eval-after-runtime!
+          conn build-id form :read-dom-failed
+          (fn [envelope] (wire/ok-text envelope)))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
@@ -47,7 +47,6 @@
   runtime's recording registry, but no app-state mutation)."
   (:require [cljs.reader]
             [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
@@ -229,10 +228,9 @@
 
       :else
       (let [form (start-recording-form signals stop frame max-entries)]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [envelope] (wire/ok-text envelope)))
-            (.catch (fn [err] (probe/err->result :record-failed err))))))))
+        (probe/eval-after-runtime!
+          conn build-id form :record-failed
+          (fn [envelope] (wire/ok-text envelope)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; read-recording — read back the change-log.
@@ -259,7 +257,6 @@
                    (ef/rt-call 'read-recording
                                (str recording-id)
                                {:drain drain? :stop stop?}))]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [envelope] (wire/ok-text envelope)))
-            (.catch (fn [err] (probe/err->result :read-recording-failed err))))))))
+        (probe/eval-after-runtime!
+          conn build-id form :read-recording-failed
+          (fn [envelope] (wire/ok-text envelope)))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reset_frame_db.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reset_frame_db.cljs
@@ -31,33 +31,17 @@
   spec/Tool-Pair.md §Pair-tool write failure modes). The runtime's
   `app-db-reset!` already returns a structured `{:ok? false :reason
   :reset-rejected ...}` on those soft failures; we pass it through."
-  (:require [cljs.reader]
-            [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.args :as args]
+  (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.writes :as writes]))
 
-(defn- parse-db-edn
-  "Parse the `db` MCP arg as EDN. Returns `[:ok parsed]` on success or
-  `[:err reason]` on an absent / unreadable value. Unlike `dispatch`'s
-  event arg there is NO shape constraint — a frame's app-db is
-  conventionally a map but the runtime accepts any value the frame's
-  app-schema admits, so we only require readability."
-  [db-str]
-  (let [trimmed (some-> db-str str/trim)]
-    (cond
-      (or (nil? trimmed) (str/blank? trimmed))
-      [:err :missing-db]
-
-      :else
-      (let [parsed (try (cljs.reader/read-string trimmed)
-                        (catch :default _ ::reader-fail))]
-        (if (= ::reader-fail parsed)
-          [:err :invalid-db-edn]
-          [:ok parsed])))))
+;; The `db` arg has NO shape constraint — a frame's app-db is
+;; conventionally a map but the runtime accepts any value the frame's
+;; app-schema admits, so we only require readability. That's exactly the
+;; shared `args/read-edn-arg` core (rf2-jkake.19); the richer
+;; vector-shape `dispatch` parser is deliberately not shared with it.
 
 (defn reset-frame-db-tool [conn raw-args]
   (if-not (writes/writes-allowed?)
@@ -65,7 +49,7 @@
     (let [db-str   (wire/arg raw-args :db)
           build-id (wire/arg-build conn raw-args)
           frame    (some-> (wire/arg raw-args :frame) args/->frame-keyword)
-          [tag payload] (parse-db-edn db-str)]
+          [tag payload] (args/read-edn-arg db-str :missing-db :invalid-db-edn)]
       (case tag
         :err
         (js/Promise.resolve
@@ -84,16 +68,15 @@
                      (ef/rt-call 'app-db-reset! new-db frame)
                      (ef/rt-call 'app-db-reset! new-db))
               form (ef/emit call)]
-          (-> (probe/ensure-runtime! conn build-id)
-              (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-              (.then (fn [v]
-                       ;; app-db-reset! returns a structured envelope
-                       ;; ({:ok? true :frame ...} / {:ok? false :reason
-                       ;; :reset-rejected ...}). Pass it through; default
-                       ;; to a generic shape if the runtime returned a
-                       ;; non-map (degraded / pre-rf2-c2dtu runtime).
-                       (wire/ok-text
-                         (if (map? v)
-                           v
-                           {:ok? false :reason :unexpected-shape :value v :frame frame}))))
-              (.catch (fn [err] (probe/err->result :reset-frame-db-failed err)))))))))
+          (probe/eval-after-runtime!
+            conn build-id form :reset-frame-db-failed
+            (fn [v]
+              ;; app-db-reset! returns a structured envelope
+              ;; ({:ok? true :frame ...} / {:ok? false :reason
+              ;; :reset-rejected ...}). Pass it through; default to a
+              ;; generic shape if the runtime returned a non-map
+              ;; (degraded / pre-rf2-c2dtu runtime).
+              (wire/ok-text
+                (if (map? v)
+                  v
+                  {:ok? false :reason :unexpected-shape :value v :frame frame})))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
@@ -28,31 +28,15 @@
   failure modes). The runtime primitive returns `false` on any failure
   (the frame's app-db is unchanged); we surface that as
   `{:ok? false :reason :restore-rejected}`."
-  (:require [cljs.reader]
-            [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.args :as args]
+  (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.writes :as writes]))
 
-(defn- parse-epoch-id
-  "Parse the `epoch-id` MCP arg as EDN. Returns `[:ok parsed]` for any
-  present, readable value (integer / keyword / string — `:epoch-id` is
-  `:any`); `[:err reason]` for an absent or unreadable value."
-  [epoch-id-str]
-  (let [trimmed (some-> epoch-id-str str/trim)]
-    (cond
-      (or (nil? trimmed) (str/blank? trimmed))
-      [:err :missing-epoch-id]
-
-      :else
-      (let [parsed (try (cljs.reader/read-string trimmed)
-                        (catch :default _ ::reader-fail))]
-        (if (= ::reader-fail parsed)
-          [:err :invalid-epoch-id]
-          [:ok parsed])))))
+;; The `epoch-id` arg is parsed as EDN with NO shape constraint — any
+;; readable value (integer / keyword / string; `:epoch-id` is `:any`) is
+;; accepted, exactly the shared `args/read-edn-arg` core (rf2-jkake.19).
 
 (defn restore-epoch-tool [conn raw-args]
   (if-not (writes/writes-allowed?)
@@ -60,7 +44,7 @@
     (let [epoch-id-str (wire/arg raw-args :epoch-id)
           build-id     (wire/arg-build conn raw-args)
           frame        (some-> (wire/arg raw-args :frame) args/->frame-keyword)
-          [tag payload] (parse-epoch-id epoch-id-str)]
+          [tag payload] (args/read-edn-arg epoch-id-str :missing-epoch-id :invalid-epoch-id)]
       (case tag
         :err
         (js/Promise.resolve
@@ -78,35 +62,32 @@
                      (ef/rt-call 'restore-epoch epoch-id frame)
                      (ef/rt-call 'restore-epoch epoch-id))
               form (ef/emit call)]
-          (-> (probe/ensure-runtime! conn build-id)
-              (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-              (.then (fn [v]
-                       ;; Per rf2-6yqdl: the runtime now returns a
-                       ;; structured envelope on success carrying
-                       ;; `:ok? :restored? :epoch-id :frame
-                       ;; :cascade-summary :unreplayable-effects`.
-                       ;; Failure remains the legacy `false` so older
-                       ;; runtimes still surface as a clean reject
-                       ;; envelope here.
-                       (wire/ok-text
-                         (cond
-                           (map? v)
-                           v
+          (probe/eval-after-runtime!
+            conn build-id form :restore-epoch-failed
+            (fn [v]
+              ;; Per rf2-6yqdl: the runtime now returns a structured
+              ;; envelope on success carrying `:ok? :restored? :epoch-id
+              ;; :frame :cascade-summary :unreplayable-effects`. Failure
+              ;; remains the legacy `false` so older runtimes still
+              ;; surface as a clean reject envelope here.
+              (wire/ok-text
+                (cond
+                  (map? v)
+                  v
 
-                           v
-                           {:ok?       true
-                            :restored? true
-                            :epoch-id  epoch-id
-                            :frame     frame}
+                  v
+                  {:ok?       true
+                   :restored? true
+                   :epoch-id  epoch-id
+                   :frame     frame}
 
-                           :else
-                           {:ok?       false
-                            :restored? false
-                            :reason    :restore-rejected
-                            :epoch-id  epoch-id
-                            :frame     frame
-                            :hint      (str "restore-epoch returned false — the epoch-id is not in the "
-                                            "ring, or a drain is in flight. Read the structured reason "
-                                            "with (re-frame.trace.tooling/trace-buffer {:op-type :error}) "
-                                            "filtered to :rf.epoch/*.")}))))
-              (.catch (fn [err] (probe/err->result :restore-epoch-failed err)))))))))
+                  :else
+                  {:ok?       false
+                   :restored? false
+                   :reason    :restore-rejected
+                   :epoch-id  epoch-id
+                   :frame     frame
+                   :hint      (str "restore-epoch returned false — the epoch-id is not in the "
+                                   "ring, or a drain is in flight. Read the structured reason "
+                                   "with (re-frame.trace.tooling/trace-buffer {:op-type :error}) "
+                                   "filtered to :rf.epoch/*.")})))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -22,8 +22,7 @@
   \"the MCP isn't capturing my events\". The advisory names the
   history count and points to `snapshot` as the historical-inspection
   surface."
-  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.args :as args]
+  (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]
@@ -96,69 +95,67 @@
                             " :next-id next-id"
                             " :history-count (count hist)"
                             " :remaining (max 0 (- (count filtered) (count page)))}"))))]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then
-              (fn [v]
-                (let [v          (if (map? v) v {})
-                      aged-out?  (:id-aged-out? v)
-                      raw-epochs (vec (:epochs v))]
-                  (if aged-out?
-                    (cursor/cursor-stale-result "trace-window"
-                                                {:requested-id (:requested-id v)
-                                                 :head-id      (:head-id v)})
-                    (let [{:keys [value indicators]}
-                          (wp/run-wire-pipeline raw-epochs
-                                                {:kind   :epoch-vector
-                                                 :incl?  incl?
-                                                 :mode   mode
-                                                 :dedup? dedup?})
-                          {:keys [dropped elided count]} indicators
-                          next-id     (:next-id v)
-                          next-cursor (cursor/encode-cursor
-                                        (when next-id
-                                          {:v        1
-                                           :after-id next-id
-                                           :ms       window-ms
-                                           :until-ms until-ms
-                                           :frame    sticky-frame}))
-                          has-more?     (some? next-cursor)
-                          remaining     (or (:remaining v) 0)
-                          history-count (or (:history-count v) 0)
-                          ;; Advisory fires only when the window
-                          ;; surfaced ZERO epochs but the per-frame
-                          ;; history holds events that just fell
-                          ;; outside the time slice. Two ratchets:
-                          ;;   - count = 0 (the slot operators read
-                          ;;     to decide \"nothing happened\")
-                          ;;   - history-count > 0 (the underlying
-                          ;;     ring isn't empty — events exist).
-                          advisory      (when (and (zero? count)
-                                                   (pos? history-count))
-                                          {:reason            :window-excludes-history
-                                           :frame             sticky-frame
-                                           :epochs-in-history history-count
-                                           :window-ms         window-ms
-                                           :hint              (str history-count
-                                                                   " epochs exist in the per-frame "
-                                                                   "history but none fell inside the "
-                                                                   "last " window-ms "ms window. "
-                                                                   "Widen :ms (e.g. 60000), or use "
-                                                                   "`snapshot :include [:epochs]` to "
-                                                                   "inspect the full history.")})
-                          envelope      (cond-> {:ok?                 true
-                                                 :window-ms           window-ms
-                                                 :until-ms            until-ms
-                                                 :count               count
-                                                 :limit               limit
-                                                 :epochs-mode         mode
-                                                 :dedup               dedup?
-                                                 :epochs              value
-                                                 :has-more?           has-more?
-                                                 :estimated-remaining remaining
-                                                 :next-cursor         next-cursor}
-                                          advisory (assoc :advisory advisory))]
-                      (wire/ok-text (wire/with-indicators
-                                      envelope
-                                      {:dropped dropped :elided elided})))))))
-            (.catch (fn [err] (probe/err->result :trace-failed err))))))))
+        (probe/eval-after-runtime!
+          conn build-id form :trace-failed
+          (fn [v]
+            (let [v          (if (map? v) v {})
+                  aged-out?  (:id-aged-out? v)
+                  raw-epochs (vec (:epochs v))]
+              (if aged-out?
+                (cursor/cursor-stale-result "trace-window"
+                                            {:requested-id (:requested-id v)
+                                             :head-id      (:head-id v)})
+                (let [{:keys [value indicators]}
+                      (wp/run-wire-pipeline raw-epochs
+                                            {:kind   :epoch-vector
+                                             :incl?  incl?
+                                             :mode   mode
+                                             :dedup? dedup?})
+                      {:keys [dropped elided count]} indicators
+                      next-id     (:next-id v)
+                      next-cursor (cursor/encode-cursor
+                                    (when next-id
+                                      {:v        1
+                                       :after-id next-id
+                                       :ms       window-ms
+                                       :until-ms until-ms
+                                       :frame    sticky-frame}))
+                      has-more?     (some? next-cursor)
+                      remaining     (or (:remaining v) 0)
+                      history-count (or (:history-count v) 0)
+                      ;; Advisory fires only when the window
+                      ;; surfaced ZERO epochs but the per-frame
+                      ;; history holds events that just fell
+                      ;; outside the time slice. Two ratchets:
+                      ;;   - count = 0 (the slot operators read
+                      ;;     to decide \"nothing happened\")
+                      ;;   - history-count > 0 (the underlying
+                      ;;     ring isn't empty — events exist).
+                      advisory      (when (and (zero? count)
+                                               (pos? history-count))
+                                      {:reason            :window-excludes-history
+                                       :frame             sticky-frame
+                                       :epochs-in-history history-count
+                                       :window-ms         window-ms
+                                       :hint              (str history-count
+                                                               " epochs exist in the per-frame "
+                                                               "history but none fell inside the "
+                                                               "last " window-ms "ms window. "
+                                                               "Widen :ms (e.g. 60000), or use "
+                                                               "`snapshot :include [:epochs]` to "
+                                                               "inspect the full history.")})
+                      envelope      (cond-> {:ok?                 true
+                                             :window-ms           window-ms
+                                             :until-ms            until-ms
+                                             :count               count
+                                             :limit               limit
+                                             :epochs-mode         mode
+                                             :dedup               dedup?
+                                             :epochs              value
+                                             :has-more?           has-more?
+                                             :estimated-remaining remaining
+                                             :next-cursor         next-cursor}
+                                      advisory (assoc :advisory advisory))]
+                  (wire/ok-text (wire/with-indicators
+                                  envelope
+                                  {:dropped dropped :elided elided})))))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/unsubscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/unsubscribe.cljs
@@ -1,7 +1,6 @@
 (ns re-frame2-pair-mcp.tools.unsubscribe
   "Tool: unsubscribe — close a streaming subscription."
   (:require [clojure.string :as str]
-            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
@@ -17,8 +16,7 @@
 
       :else
       (let [form (ef/emit (ef/rt-call 'unsubscribe! sub-id))]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [v] (wire/ok-text (merge {:ok? true :sub-id sub-id}
-                                                (when (map? v) v)))))
-            (.catch (fn [err] (probe/err->result :unsubscribe-failed err))))))))
+        (probe/eval-after-runtime!
+          conn build-id form :unsubscribe-failed
+          (fn [v] (wire/ok-text (merge {:ok? true :sub-id sub-id}
+                                       (when (map? v) v)))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -27,8 +27,7 @@
       epochs landed after it. Calmly says \"nothing new\".
     - `:pred-excludes-history` — the predicate filtered every epoch
       out. Says the history exists; the pred is the gate."
-  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.args :as args]
+  (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]
@@ -99,88 +98,86 @@
                             " :history-count history-count"
                             " :since-count since-count"
                             " :remaining (max 0 (- (count matches) (count page)))}"))))]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then
-              (fn [v]
-                (let [v          (if (map? v) v {})
-                      aged-out?  (:id-aged-out? v)]
-                  (if (and aged-out? (some? effective-after))
-                    (cursor/cursor-stale-result "watch-epochs"
-                                                {:requested-id (or (:requested-id v) effective-after)
-                                                 :head-id      (:head-id v)})
-                    (let [matches (vec (:matches v))
-                          {:keys [value indicators]}
-                          (wp/run-wire-pipeline matches
-                                                {:kind   :epoch-vector
-                                                 :incl?  incl?
-                                                 :mode   mode
-                                                 :dedup? dedup?})
-                          {:keys [dropped elided count]} indicators
-                          next-id       (:next-id v)
-                          next-cursor   (cursor/encode-cursor
-                                          (when next-id
-                                            {:v        1
-                                             :after-id next-id
-                                             :ms       nil
-                                             :until-ms nil
-                                             :frame    sticky-frame}))
-                          remaining     (or (:remaining v) 0)
-                          history-count (or (:history-count v) 0)
-                          since-count   (or (:since-count v) 0)
-                          ;; rf2-fb4hn: two distinct empty-result
-                          ;; explainers, picked by the runtime data:
-                          ;;
-                          ;;   - since-count = 0 + history-count > 0
-                          ;;     → caller's :since-id is at (or past)
-                          ;;     the head; calmly say \"nothing new
-                          ;;     yet\".
-                          ;;
-                          ;;   - since-count > 0 + count = 0
-                          ;;     → events landed since the id but the
-                          ;;     :pred filtered them all out — point
-                          ;;     at the predicate, not the buffer.
-                          advisory
-                          (cond
-                            (and (zero? count)
-                                 (zero? since-count)
-                                 (pos? history-count))
-                            {:reason            :no-events-since-id
-                             :frame             sticky-frame
-                             :epochs-in-history history-count
-                             :requested-id      effective-after
-                             :hint              (str "Per-frame history holds "
-                                                     history-count
-                                                     " epochs but none have landed since the "
-                                                     "supplied :since-id. Dispatch an event "
-                                                     "to advance the head, or omit :since-id "
-                                                     "to see the full ring.")}
+        (probe/eval-after-runtime!
+          conn build-id form :watch-failed
+          (fn [v]
+            (let [v          (if (map? v) v {})
+                  aged-out?  (:id-aged-out? v)]
+              (if (and aged-out? (some? effective-after))
+                (cursor/cursor-stale-result "watch-epochs"
+                                            {:requested-id (or (:requested-id v) effective-after)
+                                             :head-id      (:head-id v)})
+                (let [matches (vec (:matches v))
+                      {:keys [value indicators]}
+                      (wp/run-wire-pipeline matches
+                                            {:kind   :epoch-vector
+                                             :incl?  incl?
+                                             :mode   mode
+                                             :dedup? dedup?})
+                      {:keys [dropped elided count]} indicators
+                      next-id       (:next-id v)
+                      next-cursor   (cursor/encode-cursor
+                                      (when next-id
+                                        {:v        1
+                                         :after-id next-id
+                                         :ms       nil
+                                         :until-ms nil
+                                         :frame    sticky-frame}))
+                      remaining     (or (:remaining v) 0)
+                      history-count (or (:history-count v) 0)
+                      since-count   (or (:since-count v) 0)
+                      ;; rf2-fb4hn: two distinct empty-result
+                      ;; explainers, picked by the runtime data:
+                      ;;
+                      ;;   - since-count = 0 + history-count > 0
+                      ;;     → caller's :since-id is at (or past)
+                      ;;     the head; calmly say \"nothing new
+                      ;;     yet\".
+                      ;;
+                      ;;   - since-count > 0 + count = 0
+                      ;;     → events landed since the id but the
+                      ;;     :pred filtered them all out — point
+                      ;;     at the predicate, not the buffer.
+                      advisory
+                      (cond
+                        (and (zero? count)
+                             (zero? since-count)
+                             (pos? history-count))
+                        {:reason            :no-events-since-id
+                         :frame             sticky-frame
+                         :epochs-in-history history-count
+                         :requested-id      effective-after
+                         :hint              (str "Per-frame history holds "
+                                                 history-count
+                                                 " epochs but none have landed since the "
+                                                 "supplied :since-id. Dispatch an event "
+                                                 "to advance the head, or omit :since-id "
+                                                 "to see the full ring.")}
 
-                            (and (zero? count)
-                                 (pos? since-count))
-                            {:reason            :pred-excludes-history
-                             :frame             sticky-frame
-                             :epochs-in-history history-count
-                             :epochs-since-id   since-count
-                             :hint              (str since-count
-                                                     " epochs landed since the requested id but "
-                                                     "the :pred filter excluded all of them. "
-                                                     "Drop / widen :pred, or use trace-window for "
-                                                     "an unfiltered view.")})
-                          base          (cond-> {:ok?          true
-                                                 :head-id      (:head-id v)
-                                                 :id-aged-out? (boolean aged-out?)}
-                                          (:requested-id v) (assoc :requested-id (:requested-id v))
-                                          advisory          (assoc :advisory advisory))]
-                      (wire/ok-text (wire/with-indicators
-                                      (assoc base
-                                             :matches             value
-                                             :limit               limit
-                                             :count               count
-                                             :epochs-mode         mode
-                                             :dedup               dedup?
-                                             :has-more?           (some? next-cursor)
-                                             :estimated-remaining remaining
-                                             :next-cursor         next-cursor)
-                                      {:dropped dropped :elided elided})))))))
-            (.catch (fn [err] (probe/err->result :watch-failed err))))))))
+                        (and (zero? count)
+                             (pos? since-count))
+                        {:reason            :pred-excludes-history
+                         :frame             sticky-frame
+                         :epochs-in-history history-count
+                         :epochs-since-id   since-count
+                         :hint              (str since-count
+                                                 " epochs landed since the requested id but "
+                                                 "the :pred filter excluded all of them. "
+                                                 "Drop / widen :pred, or use trace-window for "
+                                                 "an unfiltered view.")})
+                      base          (cond-> {:ok?          true
+                                             :head-id      (:head-id v)
+                                             :id-aged-out? (boolean aged-out?)}
+                                      (:requested-id v) (assoc :requested-id (:requested-id v))
+                                      advisory          (assoc :advisory advisory))]
+                  (wire/ok-text (wire/with-indicators
+                                  (assoc base
+                                         :matches             value
+                                         :limit               limit
+                                         :count               count
+                                         :epochs-mode         mode
+                                         :dedup               dedup?
+                                         :has-more?           (some? next-cursor)
+                                         :estimated-remaining remaining
+                                         :next-cursor         next-cursor)
+                                  {:dropped dropped :elided elided})))))))))))


### PR DESCRIPTION
## Quality gates

- `npm test` (tools/re-frame2-pair-mcp, shadow-cljs `:server-test`): **707 tests / 2041 assertions, 0 failures, 0 errors, 0 compiler warnings**.
- `npm run build` (production `:server` bundle): compiles clean, 0 warnings.
- `npm run test:re-frame2-pair` (MCP-conformance, SDK Client driver against compiled `out/server.js`): **GREEN** — 22 tools advertised with stable names/schemas/annotations; degraded-path error envelopes verified across the refactored tools (`list-subscriptions`, `list-streams`, `snapshot`, `subscribe`, `watch-epochs`, `dispatch`).
- clj-kondo on changed files: **0 errors** (one pre-existing `unused binding e` warning in `dispatch/parse-event-edn`, untouched by this PR).

## Consolidations

**1. `probe/eval-after-runtime!` — the single-eval prelude.** Thirteen tool bodies wore the identical four-step promise chain `(ensure-runtime! -> cljs-eval-value -> shape -> err->result)`, which obscured each tool's actual logic (its response-shaping `.then`). Factored the invariant prelude/postlude into one helper; each tool now passes its `form`, a `:fail-reason`, and an inline `on-value` shaper.

Applied to: `dispatch` (non-await branch), `dispatch-dry-run`, `handler-meta` + `list-handlers`, `list-streams`, `list-subscriptions`, `read-dom`, `record` + `read-recording`, `reset-frame-db`, `restore-epoch`, `trace-window`, `unsubscribe`, `watch-epochs`.

Deliberately left parallel (different prelude shape, enumerated in the helper docstring): `snapshot` / `get-path` / `subscribe` (insert a `signal-runtime!` raw-state-gate step), `eval-cljs` (`resolve-and-preflight!` fail-loud resolution), `watch-until` / `tail-build` (poll loops, not a single eval), `dispatch :await-render` (await-promise mailbox), `discover-app` (chains `runtime-health!`).

**2. `args/read-edn-arg` — the EDN-readability core.** The trim + `read-string` + `::reader-fail` sentinel → `[:ok parsed]` / `[:err reason]` body was repeated verbatim in `reset-frame-db` (`:db`), `restore-epoch` (`:epoch-id`), and `handler-meta` (`:id`). One shared helper; each call passes its own `missing` / `invalid` reason keywords so error envelopes stay tool-specific.

Deliberately NOT shared: the richer `dispatch` / `dispatch-dry-run` event parsers (they layer a vector-shape contract + parsed-type classification and are pinned by their ns docstrings as separately-evolving surfaces).

## MCP tool contract + behaviour

Unchanged. The helper resolves `nrepl/cljs-eval-value` per-call (a plain var reference), so the `set!`-based test seam every per-tool test relies on keeps working; per-tool response shaping stays inline. Tool names, input/output schemas, and the Tool-Pair contract are byte-stable (conformance gate green). No back-compat shims (pre-alpha).

Closes rf2-jkake.19.
