### PR TITLE
refactor(story-mcp): reduce duplication (rf2-jkake.20)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
@@ -172,7 +172,12 @@
   The caller assembles the final payload by merging the page-metadata
   into the tool's normal response shape (the metadata slots only land
   when pagination actually kicked in — small registries that fit on
-  one page return `[:ok entries {}]`)."
+  one page return `[:ok entries {}]`).
+
+  Most callers don't touch this directly — they reach for the
+  `paged-result` wrapper below, which folds the `[:ok …]` / `[:err …]`
+  branch + the `result/text-result` build into one call. `page` stays
+  public for the rare caller that wants the raw slice (none today)."
   [entries ids arguments tool-name]
   (let [limit         (parse-limit-arg (:limit arguments))
         cursor        (decode-cursor (:cursor arguments))
@@ -206,3 +211,26 @@
                          :next-cursor next-c}
                         {})]
         [:ok page-vec meta-map]))))
+
+(defn paged-result
+  "Page `entries` and build the tool's `tools/call` result in one step —
+  the shape every Docs `list-*` handler shares (rf2-jkake.20). Pages via
+  `page`; on a malformed/stale cursor returns the `cursor-stale-result`
+  envelope directly; otherwise calls `(page->payload page-vec)` to build
+  the tool-specific base payload, merges in the pagination metadata
+  (`:total` / `:limit` / `:has-more?` / `:next-cursor` — present only
+  when pagination kicked in), and wraps it in the dual-slot
+  `text-result` envelope.
+
+  `page->payload` receives the page slice and returns the base payload
+  map (e.g. `(fn [p] {:stories p})` for `list-stories`, or the
+  bifurcated `{:canonical … :registered p}` for `list-assertions`).
+  This folds the four-line `(let [[res page meta] (page …)] (if (= res
+  :err) …))` boilerplate that previously sat inline in five handlers
+  into a single call, so each handler reads as 'compute entries, then
+  page them under this shape'."
+  [entries ids arguments tool-name page->payload]
+  (let [[res page-vec meta] (page entries ids arguments tool-name)]
+    (if (= res :err)
+      page-vec
+      (result/edn-result (merge (page->payload page-vec) meta)))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -149,7 +149,7 @@
                         :rendered-hiccup (egress/scrub-rendered (:rendered-hiccup outcome) raw-db vk incl?)
                         :snapshot     (egress/scrub-rendered (:snapshot outcome) raw-db vk incl?)
                         :effective-args (egress/scrub-rendered (:effective-args outcome) raw-db vk incl?)}]
-        (result/text-result (result/pr-edn payload) payload)))))
+        (result/edn-result payload)))))
 
 (defn tool-list-substrates
   "Dev: what substrates can be used. Reads the registered substrate set
@@ -167,8 +167,7 @@
   `cljs-resolve/registered-substrates` is the single accessor
   (rf2-ee38b.17 removed the duplicate `defonce` that used to live here)."
   [_args]
-  (let [payload {:substrates (vec (cljs-resolve/registered-substrates))}]
-    (result/text-result (result/pr-edn payload) payload)))
+  (result/edn-result {:substrates (vec (cljs-resolve/registered-substrates))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Registry descriptors (assembled in `tools.registry/tool-registry`)

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -67,11 +67,8 @@
                           :tags (vec (:tags body))
                           :variants (sort (get index sid #{}))})
                        sorted)]
-    (let [[res page meta] (cursor/page entries all-ids args "list-stories")]
-      (if (= res :err)
-        page
-        (let [payload (merge {:stories page} meta)]
-          (result/text-result (result/pr-edn payload) payload))))))
+    (cursor/paged-result entries all-ids args "list-stories"
+                         (fn [page] {:stories page}))))
 
 (defn tool-get-story
   "Docs: one story's full body.
@@ -85,7 +82,7 @@
       (if-let [sk (args/safe-keyword sid (story/ids :story))]
         (let [body (story/handler-meta :story sk)
               payload {:id sk :body body :variants (sort (story/variants-of sk))}]
-          (result/text-result (result/pr-edn payload) payload))
+          (result/edn-result payload))
         (result/error-result (str "Story not found: " (pr-str sid)))))))
 
 (defn tool-get-variant
@@ -93,8 +90,7 @@
   [args]
   (targs/with-variant args
     (fn [vk body]
-      (let [payload {:id vk :body body}]
-        (result/text-result (result/pr-edn payload) payload)))))
+      (result/edn-result {:id vk :body body}))))
 
 (defn tool-list-tags
   "Docs: canonical tags + custom tags.
@@ -111,19 +107,15 @@
         canonical  (vec (sort-by str (into story/canonical-tags
                                            story/canonical-state-tags)))
         custom-set (set/difference (set registered) (set canonical))
-        custom     (vec (sort-by str custom-set))
-        [res page meta] (cursor/page custom custom-set args "list-tags")]
-    (if (= res :err)
-      page
-      (let [;; :all is the union of :canonical + the (page-sliced) :custom.
-            ;; When no pagination kicks in (small registry) the result is
-            ;; byte-identical to the pre-rf2-76sf6 shape.
-            all-page (vec (sort-by str (into canonical page)))
-            payload  (merge {:canonical canonical
-                             :custom    page
-                             :all       all-page}
-                            meta)]
-        (result/text-result (result/pr-edn payload) payload)))))
+        custom     (vec (sort-by str custom-set))]
+    (cursor/paged-result custom custom-set args "list-tags"
+                         (fn [page]
+                           ;; :all is the union of :canonical + the (page-sliced)
+                           ;; :custom. When no pagination kicks in (small registry)
+                           ;; the result is byte-identical to the pre-rf2-76sf6 shape.
+                           {:canonical canonical
+                            :custom    page
+                            :all       (vec (sort-by str (into canonical page)))}))))
 
 (defn tool-list-modes
   "Docs: registered modes (from `reg-mode`). Returns each mode's id +
@@ -135,12 +127,9 @@
         sorted  (sort-by (comp str key) modes)
         all-ids (keys modes)
         entries (mapv (fn [[mid body]] {:id mid :doc (:doc body) :args (:args body)})
-                      sorted)
-        [res page meta] (cursor/page entries all-ids args "list-modes")]
-    (if (= res :err)
-      page
-      (let [payload (merge {:modes page} meta)]
-        (result/text-result (result/pr-edn payload) payload)))))
+                      sorted)]
+    (cursor/paged-result entries all-ids args "list-modes"
+                         (fn [page] {:modes page}))))
 
 (defn- decorator-summary
   "Project one decorator body to the EDN-safe shape — id, kind, doc,
@@ -196,12 +185,9 @@
                                                      (= kind-filter (:kind body))))))
         sorted      (sort-by (comp str key) filtered)
         all-ids     (keys filtered)
-        entries     (mapv (fn [[did body]] (decorator-summary did body)) sorted)
-        [res page meta] (cursor/page entries all-ids args "list-decorators")]
-    (if (= res :err)
-      page
-      (let [payload (merge {:decorators page} meta)]
-        (result/text-result (result/pr-edn payload) payload)))))
+        entries     (mapv (fn [[did body]] (decorator-summary did body)) sorted)]
+    (cursor/paged-result entries all-ids args "list-decorators"
+                         (fn [page] {:decorators page}))))
 
 (def canonical-assertion-docs
   "Per spec/007 line 304 + IMPL-SPEC §3.5 the seven dispatched canonical
@@ -251,14 +237,10 @@
   exceeds `:limit`. Small registries see no pagination metadata."
   [args]
   (let [registered (sort-by str (story/canonical-assertion-ids))
-        reg-vec    (vec registered)
-        [res page meta] (cursor/page reg-vec (set reg-vec) args "list-assertions")]
-    (if (= res :err)
-      page
-      (let [payload (merge {:canonical  canonical-assertion-docs
-                            :registered page}
-                           meta)]
-        (result/text-result (result/pr-edn payload) payload)))))
+        reg-vec    (vec registered)]
+    (cursor/paged-result reg-vec (set reg-vec) args "list-assertions"
+                         (fn [page] {:canonical  canonical-assertion-docs
+                                     :registered page}))))
 
 (defn tool-explain-variant
   "Docs: the variant-plan `:explain` projection for a variant — the SAME
@@ -284,10 +266,8 @@
   [args]
   (targs/with-variant args
     (fn [vk _body]
-      (let [explain  (story/explain vk)
-            payload  {:variant-id vk
-                      :explain    explain}]
-        (result/text-result (result/pr-edn payload) payload)))))
+      (result/edn-result {:variant-id vk
+                          :explain    (story/explain vk)}))))
 
 (defn tool-variant->edn
   "Docs: round-trippable EDN of a registered variant. Identical payload
@@ -304,7 +284,7 @@
   [args]
   (targs/with-variant args
     (fn [_vk body]
-      (result/text-result (result/pr-edn body) body))))
+      (result/edn-result body))))
 
 (defn- md-h1 [s] (str "# " s "\n\n"))
 (defn- md-h2 [s] (str "\n## " s "\n\n"))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -96,7 +96,7 @@
                         target-vid
                         (assoc body :play-script play-script :origin config/origin))
           payload     (assoc base :written-back? true :new-variant-id id)]
-      (result/text-result (result/pr-edn payload) payload))
+      (result/edn-result payload))
     (catch #?(:clj Throwable :cljs :default) e
       (result/error-result (str "Write-back failed: " (ex-message e))
                       (merge base
@@ -256,7 +256,7 @@
                                    :captured             events
                                    :written-back?        false}]
                   (if-not write-back?
-                    (result/text-result (result/pr-edn base) base)
+                    (result/edn-result base)
                     (write-back! base body events target-vid))))))))))
 
 (def descriptors

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
@@ -34,6 +34,22 @@
    (cond-> {:content [{:type "text" :text text}]}
      (some? structured) (assoc :structuredContent structured))))
 
+(defn edn-result
+  "Build a success result whose `payload` rides BOTH wire slots: the
+  `pr-edn`-stringified EDN in the `:content` text slot and the raw map
+  in `:structuredContent`. The canonical success envelope for every
+  data-returning story-mcp handler — `(edn-result payload)` is the dual-
+  coded `(text-result (pr-edn payload) payload)` pair the handlers
+  shared at fifteen call sites (rf2-jkake.20), named once so each
+  handler reads as 'return this payload' rather than re-spelling the
+  stringify-into-text-plus-same-map-as-structured dance.
+
+  The two slots are dual-coded on purpose (per `wire-pipeline`): the
+  text slot serves agent hosts that read EDN; the structured slot
+  serves hosts that prefer JSON data — and the cap pipeline sizes both."
+  [payload]
+  (text-result (pr-edn payload) payload))
+
 (defn error-result
   "Build a tool-execution error result. Per MCP §Error Handling these
   use `isError: true` rather than a protocol-level JSON-RPC error so

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -162,7 +162,7 @@
                        ;; attempt some expectation.
                        (contains? outcome :cannot-run)
                        (assoc :cannot-run (:cannot-run outcome)))]
-        (result/text-result (result/pr-edn payload) payload)))))
+        (result/edn-result payload)))))
 
 (defn tool-snapshot-identity
   "Testing: content-hash of the canonicalised variant (for external
@@ -171,8 +171,7 @@
   [arguments]
   (targs/with-variant arguments
     (fn [vk _body]
-      (let [payload (story/snapshot-identity vk (targs/read-run-opts arguments))]
-        (result/text-result (result/pr-edn payload) payload)))))
+      (result/edn-result (story/snapshot-identity vk (targs/read-run-opts arguments))))))
 
 ;; `re-frame.story.ui.a11y/violations-by-frame` is the CLJS-side panel
 ;; atom — resolved once at ns-load via `cljs-resolve/resolve-cljs-var`. JVM-
@@ -210,7 +209,7 @@
                      :violations (vec (or violations []))
                      :note       (when (nil? atomv)
                                    "a11y is CLJS-only; this JVM-standalone deploy can't run axe-core. Run the panel in-browser; the violations atom is read by this tool.")}]
-        (result/text-result (result/pr-edn payload) payload)))))
+        (result/edn-result payload)))))
 
 (defn tool-read-failures
   "Testing: the variant frame's current accumulated assertion records
@@ -261,7 +260,7 @@
                         :total      (count records)
                         :failures   failures
                         :assertions records}]
-        (result/text-result (result/pr-edn payload) payload)))))
+        (result/edn-result payload)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Registry descriptors (assembled in `tools.registry/tool-registry`)

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -162,9 +162,8 @@
     ;; Stamp `:origin :story-mcp` per spec/Cross-Cutting-Designs.md §5
     ;; — every write surface tags its writes so post-mortem queries
     ;; can identify which actor produced the registration.
-    (let [id      (story/reg-variant* vk (assoc body-v :origin config/origin))
-          payload {:variant-id id :registered? true}]
-      (result/text-result (result/pr-edn payload) payload))
+    (let [id (story/reg-variant* vk (assoc body-v :origin config/origin))]
+      (result/edn-result {:variant-id id :registered? true}))
     (catch Throwable e
       (result/error-result (str "Registration failed: " (ex-message e))
                       (merge {:variant-id vk}
@@ -218,8 +217,7 @@
         (fn [vk]
           (let [had? (some? (story/variant->edn vk))]
             (story/unregister! :variant vk)
-            (let [payload {:variant-id vk :unregistered? had?}]
-              (result/text-result (result/pr-edn payload) payload)))))))
+            (result/edn-result {:variant-id vk :unregistered? had?}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Registry descriptors (assembled in `tools.registry/tool-registry`)


### PR DESCRIPTION
Duplication-reduction review of `tools/story-mcp/` (bead rf2-jkake.20, epic rf2-jkake). Two clarifying consolidations; the MCP tool contract (names + schemas, per the Tool-Pair conformance gate) and all handler behaviour are unchanged.

## Consolidations

1. **`result/edn-result`** — the canonical dual-slot EDN success envelope. Every data-returning handler ended in `(result/text-result (result/pr-edn payload) payload)` — the same binding spelled twice, at **15 call sites** across dev/docs/testing/write/recorder/cursor. Extracted as a named helper in `result.cljc` (its natural home, next to `text-result`/`pr-edn`). Each handler now reads "return this payload" rather than re-deriving the stringify-into-text + same-map-as-structured pair. `pr-edn` stays public (wire-pipeline still uses it directly).

2. **`cursor/paged-result`** — the five Docs `list-*` handlers (`list-stories`, `list-tags`, `list-modes`, `list-decorators`, `list-assertions`) each repeated the identical tail: `(let [[res page meta] (cursor/page …)] (if (= res :err) page (… merge meta … text-result)))`. Folded into one wrapper in `cursor.cljc` (already the owner of `page` + `cursor-stale-result`) that takes a `page->payload` fn for the tool-specific base shape and owns the stale-cursor short-circuit + metadata merge. `cursor/page` stays public.

The two `text-result` callsites with a *non-EDN* text slot (`get-story-instructions` ships raw prose; `get-docs-markdown` ships raw markdown) were correctly left on `text-result` — they are not the `edn-result` shape.

Net: 82 insertions / 62 deletions across 7 files.

## Quality gates

- `tools/story-mcp` JVM `clojure -M:test` — **175 tests / 898 assertions, 0 failures, 0 errors** (baseline was identical pre-refactor).
- `npm run test:mcp-conformance` (from `implementation/`) — **ALL MCP-CONFORMANCE GATES GREEN** (all 6 PR-time gates: story-mcp JVM, Node stdio-roundtrip, pair-mcp server-test, pair+story conformance, wire-vocab 48 tests/615 assertions).
- clj-kondo on all 7 changed files — **0 errors**. (5 pre-existing reader-conditional `:clj`-arm warnings on `Throwable`/`class`/`ms` bindings remain; none on changed lines, none introduced by this PR.)

MCP tool contract confirmed stable (tool names + input/output schemas unchanged); behaviour-preserving only.