### PR TITLE
refactor(xray): reduce duplication (rf2-jkake.24)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/filters/persistence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/persistence.cljs
@@ -42,7 +42,8 @@
   than throwing at boot."
   (:require [cljs.reader :as reader]
             [re-frame.core :as rf]
-            [day8.re-frame2-xray.config :as config]))
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.local-storage :as ls]))
 
 (def default-storage-key
   "Default localStorage key Xray writes filter state under. Hosts
@@ -73,44 +74,29 @@
   (config/get-filters-storage-key))
 
 ;; ---- localStorage helpers ------------------------------------------------
-
-(defn- storage-available?
-  "True when `js/window.localStorage` is reachable. Tests that drive the
-  registry without a browser environment (node + no jsdom) need the
-  load path to no-op silently."
-  []
-  (and (exists? js/window)
-       (some? (.-localStorage js/window))))
+;; Raw browser access + the no-op-when-unavailable / swallow-throws
+;; posture live in the shared `local-storage` seam (rf2-jkake.24). The
+;; key is resolved per call through `get-storage-key` so a runtime
+;; `configure!` re-key takes effect immediately.
 
 (defn read-raw
   "Read the raw EDN string Xray wrote under `storage-key`. Returns nil
   when the slot is empty or localStorage is unavailable."
   []
-  (when (storage-available?)
-    (try
-      (.getItem (.-localStorage js/window) (get-storage-key))
-      (catch :default _ nil))))
+  (ls/get-item (get-storage-key)))
 
 (defn write-raw!
   "Write `s` (an EDN string) under `storage-key`. No-op when
   localStorage is unavailable. Swallows any throw — a quota error must
   not poison the dispatch chain."
   [s]
-  (when (storage-available?)
-    (try
-      (.setItem (.-localStorage js/window) (get-storage-key) s)
-      (catch :default _ nil)))
-  nil)
+  (ls/set-item! (get-storage-key) s))
 
 (defn clear!
   "Remove the persisted filter state. No-op when localStorage is
   unavailable."
   []
-  (when (storage-available?)
-    (try
-      (.removeItem (.-localStorage js/window) (get-storage-key))
-      (catch :default _ nil)))
-  nil)
+  (ls/remove-item! (get-storage-key)))
 
 ;; ---- (de)serialisation ---------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
@@ -81,6 +81,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.local-storage :as ls]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale sans-stack]]))
 
@@ -169,43 +170,30 @@
   []
   @storage-key)
 
-(defn- storage-available?
-  "True when `js/window.localStorage` is reachable. JVM / node tests
-  without jsdom land in the no-op branch."
-  []
-  (and (exists? js/window)
-       (some? (.-localStorage js/window))))
+;; Raw browser access + the no-op-when-unavailable / swallow-throws
+;; posture live in the shared `local-storage` seam (rf2-jkake.24). The
+;; key is resolved per call through `get-storage-key` so a runtime
+;; `set-storage-key!` re-key takes effect immediately.
 
 (defn- read-raw
   "Read the raw EDN string Xray wrote under `storage-key`. Returns nil
   when the slot is empty or localStorage is unavailable."
   []
-  (when (storage-available?)
-    (try
-      (.getItem (.-localStorage js/window) (get-storage-key))
-      (catch :default _ nil))))
+  (ls/get-item (get-storage-key)))
 
 (defn- write-raw!
   "Write `s` (an EDN string) under `storage-key`. No-op when
   localStorage is unavailable. Swallows any throw — a quota error
   must not poison the dispatch chain."
   [s]
-  (when (storage-available?)
-    (try
-      (.setItem (.-localStorage js/window) (get-storage-key) s)
-      (catch :default _ nil)))
-  nil)
+  (ls/set-item! (get-storage-key) s))
 
 (defn clear!
   "Remove the persisted selection. No-op when localStorage is
   unavailable. Hosts use this when tearing down per-scenario state in
   Story testbeds."
   []
-  (when (storage-available?)
-    (try
-      (.removeItem (.-localStorage js/window) (get-storage-key))
-      (catch :default _ nil)))
-  nil)
+  (ls/remove-item! (get-storage-key)))
 
 (defn ->edn
   "Serialise `frame-id` (a keyword or nil) into a stable EDN string.

--- a/tools/xray/src/day8/re_frame2_xray/local_storage.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/local_storage.cljs
@@ -1,0 +1,81 @@
+(ns day8.re-frame2-xray.local-storage
+  "Shared `window.localStorage` primitives — the one place Xray touches
+  the browser storage API.
+
+  ## Why this exists (rf2-jkake.24, dedup sweep)
+
+  Seven Xray namespaces persist a slot to localStorage (frame-switcher
+  selection, column widths, command-palette recents, spine mute-set,
+  filter pills, the Static mode flag, the Static-Machines selection +
+  sub-mode map, the machine-canvas view-mode + chart-collapsed maps).
+  Each had carried a copy-pasted trio of private helpers:
+
+      (defn- storage-available? [] (and (exists? js/window)
+                                        (some? (.-localStorage js/window))))
+      (defn- read-raw   [k] (when (storage-available?) (try (.getItem … k)   (catch :default _ nil))))
+      (defn- write-raw! [k v] (when (storage-available?) (try (.setItem … k v) (catch :default _ nil))) nil)
+      (defn- remove-raw! [k] (when (storage-available?) (try (.removeItem … k) (catch :default _ nil))) nil)
+
+  Identical to the byte across every site — only the storage key and
+  the (de)serialisation around it varied. Folding the raw browser
+  access into this seam removes the duplication and makes the
+  no-op-when-unavailable / swallow-throws posture a one-file
+  guarantee. Call-sites keep their own key constants + serialisation +
+  public `read-raw`/`write-raw!`/`clear!` wrappers; those wrappers now
+  delegate here.
+
+  ## Posture (unchanged from the folded copies)
+
+  - **Availability guard.** Node / JVM test runtimes without a jsdom
+    `window.localStorage` land in the no-op branch silently — the
+    registry loads these namespaces transitively, so the load path
+    must not blow up on classpath load.
+  - **Swallow throws.** A quota error or a cross-origin
+    `SecurityError` must never poison the dispatch chain that drove
+    the write; reads degrade to `nil`.
+
+  ## What this is NOT
+
+  `config.cljc`'s storage shim is deliberately separate: it is `.cljc`
+  and falls back to an in-process `memory-storage` atom (not a silent
+  no-op) so the settings round-trip still exercises its get/set code
+  paths under the JVM test corpus. That divergent behaviour stays
+  local to `config.cljc`.")
+
+(defn available?
+  "True when `js/window.localStorage` is reachable. Node / JVM test
+  runtimes without jsdom return false so the read/write/remove
+  primitives no-op silently."
+  []
+  (and (exists? js/window)
+       (some? (.-localStorage js/window))))
+
+(defn get-item
+  "Read the raw string stored under `k`. Returns nil when the slot is
+  empty or localStorage is unavailable; swallows any access throw."
+  [k]
+  (when (available?)
+    (try
+      (.getItem (.-localStorage js/window) k)
+      (catch :default _ nil))))
+
+(defn set-item!
+  "Write `v` under `k`. No-op when localStorage is unavailable.
+  Swallows any throw — a quota error must not poison the dispatch
+  chain. Returns nil."
+  [k v]
+  (when (available?)
+    (try
+      (.setItem (.-localStorage js/window) k v)
+      (catch :default _ nil)))
+  nil)
+
+(defn remove-item!
+  "Remove the slot at `k`. No-op when localStorage is unavailable.
+  Swallows any throw. Returns nil."
+  [k]
+  (when (available?)
+    (try
+      (.removeItem (.-localStorage js/window) k)
+      (catch :default _ nil)))
+  nil)

--- a/tools/xray/src/day8/re_frame2_xray/palette/recents.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/recents.cljs
@@ -33,7 +33,8 @@
   registry) doesn't blow up on classpath load. All writes swallow
   throws so quota / serialisation failures never poison the dispatch
   chain that drove the record."
-  (:require [cljs.reader :as reader]))
+  (:require [cljs.reader :as reader]
+            [day8.re-frame2-xray.local-storage :as ls]))
 
 (def storage-key
   "Canonical localStorage key for the palette's recents list. Versioned
@@ -49,38 +50,22 @@
   3)
 
 ;; ---- localStorage helpers -----------------------------------------------
-
-(defn- storage-available?
-  "True when `js/window.localStorage` is reachable. Node test runtimes
-  return false here so the load/save fns no-op silently."
-  []
-  (and (exists? js/window)
-       (some? (.-localStorage js/window))))
+;; Raw browser access lives in the shared `local-storage` seam
+;; (rf2-jkake.24).
 
 (defn- read-raw
   []
-  (when (storage-available?)
-    (try
-      (.getItem (.-localStorage js/window) storage-key)
-      (catch :default _ nil))))
+  (ls/get-item storage-key))
 
 (defn- write-raw!
   [s]
-  (when (storage-available?)
-    (try
-      (.setItem (.-localStorage js/window) storage-key s)
-      (catch :default _ nil)))
-  nil)
+  (ls/set-item! storage-key s))
 
 (defn clear!
   "Remove the persisted slot. Test-only — fixtures reset between
   scenarios."
   []
-  (when (storage-available?)
-    (try
-      (.removeItem (.-localStorage js/window) storage-key)
-      (catch :default _ nil)))
-  nil)
+  (ls/remove-item! storage-key))
 
 ;; ---- public API ---------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -57,6 +57,7 @@
             [cljs.reader :as reader]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.defaults :as defaults]
+            [day8.re-frame2-xray.local-storage :as ls]
             [day8.re-frame2-machines-viz.chart :as mv-chart]
             [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]
             ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the canvas-side
@@ -106,34 +107,16 @@
   Chart stays expanded."
   "xray.machine-canvas.chart-collapsed-by-id")
 
-(defn- storage-available? []
-  (and (exists? js/window)
-       (some? (.-localStorage js/window))))
-
-(defn- read-raw [k]
-  (when (storage-available?)
-    (try (.getItem (.-localStorage js/window) k)
-         (catch :default _ nil))))
-
-(defn- write-raw! [k v]
-  (when (storage-available?)
-    (try (.setItem (.-localStorage js/window) k v)
-         (catch :default _ nil)))
-  nil)
-
-(defn- remove-raw! [k]
-  (when (storage-available?)
-    (try (.removeItem (.-localStorage js/window) k)
-         (catch :default _ nil)))
-  nil)
+;; Raw browser access lives in the shared `local-storage` seam
+;; (rf2-jkake.24); both slots are key-parameterised here.
 
 (defn save-view-mode-by-id!
   "Persist the view-mode-by-id map to localStorage. Empty/nil clears
   the slot."
   [m]
   (if (or (nil? m) (and (map? m) (empty? m)))
-    (remove-raw! storage-key)
-    (write-raw! storage-key (pr-str m)))
+    (ls/remove-item! storage-key)
+    (ls/set-item! storage-key (pr-str m)))
   nil)
 
 (defn load-view-mode-by-id
@@ -141,7 +124,7 @@
   the slot is absent / unparseable. Values normalise to `:canvas`
   by default."
   []
-  (when-let [raw (read-raw storage-key)]
+  (when-let [raw (ls/get-item storage-key)]
     (try
       (let [parsed (reader/read-string raw)]
         (when (map? parsed)
@@ -157,8 +140,8 @@
   issue #4). Empty/nil clears the slot."
   [m]
   (if (or (nil? m) (and (map? m) (empty? m)))
-    (remove-raw! chart-collapsed-storage-key)
-    (write-raw! chart-collapsed-storage-key (pr-str m)))
+    (ls/remove-item! chart-collapsed-storage-key)
+    (ls/set-item! chart-collapsed-storage-key (pr-str m)))
   nil)
 
 (defn load-chart-collapsed-by-id
@@ -166,7 +149,7 @@
   when the slot is absent / unparseable. Values normalise to booleans
   (truthy → `true`, anything else → `false`)."
   []
-  (when-let [raw (read-raw chart-collapsed-storage-key)]
+  (when-let [raw (ls/get-item chart-collapsed-storage-key)]
     (try
       (let [parsed (reader/read-string raw)]
         (when (map? parsed)

--- a/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
@@ -65,6 +65,7 @@
   (:require [cljs.reader :as reader]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [day8.re-frame2-xray.local-storage :as ls]
             [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale sans-stack mono-stack]]))
@@ -121,10 +122,8 @@
   "localStorage key the mute set persists under per bead rf2-ikuwt."
   "xray.spine.muted-event-ids")
 
-(defn- storage-available?
-  []
-  (and (exists? js/window)
-       (some? (.-localStorage js/window))))
+;; Raw browser access lives in the shared `local-storage` seam
+;; (rf2-jkake.24).
 
 (defn ->edn
   "Serialise the muted set into a stable EDN string. Sorting the
@@ -147,27 +146,16 @@
 
 (defn read-raw
   []
-  (when (storage-available?)
-    (try
-      (.getItem (.-localStorage js/window) default-storage-key)
-      (catch :default _ nil))))
+  (ls/get-item default-storage-key))
 
 (defn write-raw!
   [s]
-  (when (storage-available?)
-    (try
-      (.setItem (.-localStorage js/window) default-storage-key s)
-      (catch :default _ nil)))
-  nil)
+  (ls/set-item! default-storage-key s))
 
 (defn clear-raw!
   "Remove the persisted slot. Used by tests."
   []
-  (when (storage-available?)
-    (try
-      (.removeItem (.-localStorage js/window) default-storage-key)
-      (catch :default _ nil)))
-  nil)
+  (ls/remove-item! default-storage-key))
 
 (defn load
   "Read + parse the persisted muted set. Returns `#{}` when localStorage

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/persistence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/persistence.cljs
@@ -39,6 +39,7 @@
   (:require [cljs.reader :as reader]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.defaults :as defaults]
+            [day8.re-frame2-xray.local-storage :as ls]
             [day8.re-frame2-xray.static.machines.helpers :as h]))
 
 (def selection-key
@@ -50,30 +51,8 @@
   "xray.static.machines.sub-mode-by-id")
 
 ;; ---- localStorage helpers -----------------------------------------------
-
-(defn- storage-available? []
-  (and (exists? js/window)
-       (some? (.-localStorage js/window))))
-
-(defn- read-raw [k]
-  (when (storage-available?)
-    (try
-      (.getItem (.-localStorage js/window) k)
-      (catch :default _ nil))))
-
-(defn- write-raw! [k v]
-  (when (storage-available?)
-    (try
-      (.setItem (.-localStorage js/window) k v)
-      (catch :default _ nil)))
-  nil)
-
-(defn- remove-raw! [k]
-  (when (storage-available?)
-    (try
-      (.removeItem (.-localStorage js/window) k)
-      (catch :default _ nil)))
-  nil)
+;; Raw browser access lives in the shared `local-storage` seam
+;; (rf2-jkake.24); both slots are key-parameterised here.
 
 ;; ---- selection round-trip -----------------------------------------------
 
@@ -82,9 +61,9 @@
   the slot."
   [machine-id]
   (if (nil? machine-id)
-    (remove-raw! selection-key)
+    (ls/remove-item! selection-key)
     (when (keyword? machine-id)
-      (write-raw! selection-key (subs (str machine-id) 1))))
+      (ls/set-item! selection-key (subs (str machine-id) 1))))
   nil)
 
 (defn load-selected-id
@@ -92,7 +71,7 @@
   slot is empty / localStorage is unavailable / the value is not a
   valid keyword name."
   []
-  (when-let [raw (read-raw selection-key)]
+  (when-let [raw (ls/get-item selection-key)]
     (try
       (keyword raw)
       (catch :default _ nil))))
@@ -104,8 +83,8 @@
   EDN. Empty / nil map clears the slot."
   [by-id]
   (if (or (nil? by-id) (and (map? by-id) (empty? by-id)))
-    (remove-raw! sub-mode-key)
-    (write-raw! sub-mode-key (pr-str by-id)))
+    (ls/remove-item! sub-mode-key)
+    (ls/set-item! sub-mode-key (pr-str by-id)))
   nil)
 
 (defn load-sub-mode-by-id
@@ -114,7 +93,7 @@
   `helpers/normalise-sub-mode` so a corrupted entry falls back to
   `:topology` rather than crashing the render."
   []
-  (when-let [raw (read-raw sub-mode-key)]
+  (when-let [raw (ls/get-item sub-mode-key)]
     (try
       (let [parsed (reader/read-string raw)]
         (when (map? parsed)
@@ -131,8 +110,8 @@
   "Drop both slots. Used by tests to reset between scenarios. No-op
   when localStorage is unavailable."
   []
-  (remove-raw! selection-key)
-  (remove-raw! sub-mode-key)
+  (ls/remove-item! selection-key)
+  (ls/remove-item! sub-mode-key)
   nil)
 
 ;; ---- re-frame fx + hydration -------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/persistence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/persistence.cljs
@@ -40,7 +40,8 @@
   real browser localStorage call `with-storage-stub` which threads a
   per-call stub through the load/save fns. Standalone tests that need
   a clean slate call `clear!` in their `:each` fixture."
-  (:require [re-frame.core :as rf]))
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.local-storage :as ls]))
 
 (def storage-key
   "Canonical localStorage key for Xray's Dynamic ↔ Static mode
@@ -81,44 +82,27 @@
   (normalise-mode s))
 
 ;; ---- localStorage helpers -----------------------------------------------
-
-(defn- storage-available?
-  "True when `js/window.localStorage` is reachable. Tests that drive
-  the registry without a browser (node-test) need the load path to
-  no-op silently."
-  []
-  (and (exists? js/window)
-       (some? (.-localStorage js/window))))
+;; Raw browser access + the no-op-when-unavailable / swallow-throws
+;; posture live in the shared `local-storage` seam (rf2-jkake.24).
 
 (defn read-raw
   "Read the raw string Xray wrote under `storage-key`. Returns nil
   when the slot is empty or localStorage is unavailable."
   []
-  (when (storage-available?)
-    (try
-      (.getItem (.-localStorage js/window) storage-key)
-      (catch :default _ nil))))
+  (ls/get-item storage-key))
 
 (defn write-raw!
   "Write `s` under `storage-key`. No-op when localStorage is
   unavailable. Swallows any throw — a quota error must not poison
   the dispatch chain."
   [s]
-  (when (storage-available?)
-    (try
-      (.setItem (.-localStorage js/window) storage-key s)
-      (catch :default _ nil)))
-  nil)
+  (ls/set-item! storage-key s))
 
 (defn clear!
   "Remove the persisted mode slot. Used by tests to reset between
   scenarios. No-op when localStorage is unavailable."
   []
-  (when (storage-available?)
-    (try
-      (.removeItem (.-localStorage js/window) storage-key)
-      (catch :default _ nil)))
-  nil)
+  (ls/remove-item! storage-key))
 
 ;; ---- public API ---------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -54,7 +54,8 @@
             [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [day8.re-frame2-xray.defaults :as defaults]))
+            [day8.re-frame2-xray.defaults :as defaults]
+            [day8.re-frame2-xray.local-storage :as ls]))
 
 (def ^:private gutter-width-px 4)
 (def ^:private min-col-width-px 24)
@@ -85,37 +86,24 @@
   []
   @storage-key)
 
-(defn- storage-available?
-  "True when `js/window.localStorage` is reachable. JVM / node tests
-  without jsdom land in the no-op branch."
-  []
-  (and (exists? js/window)
-       (some? (.-localStorage js/window))))
+;; Raw browser access lives in the shared `local-storage` seam
+;; (rf2-jkake.24). The key is resolved per call through
+;; `get-storage-key` so a runtime `set-storage-key!` re-key takes
+;; effect immediately.
 
 (defn- read-raw
   []
-  (when (storage-available?)
-    (try
-      (.getItem (.-localStorage js/window) (get-storage-key))
-      (catch :default _ nil))))
+  (ls/get-item (get-storage-key)))
 
 (defn- write-raw!
   [s]
-  (when (storage-available?)
-    (try
-      (.setItem (.-localStorage js/window) (get-storage-key) s)
-      (catch :default _ nil)))
-  nil)
+  (ls/set-item! (get-storage-key) s))
 
 (defn clear!
   "Remove the persisted column-widths slot. Used by tests to reset
   between scenarios. No-op when localStorage is unavailable."
   []
-  (when (storage-available?)
-    (try
-      (.removeItem (.-localStorage js/window) (get-storage-key))
-      (catch :default _ nil)))
-  nil)
+  (ls/remove-item! (get-storage-key)))
 
 (defn ->edn
   "Serialise `widths` (`{table-id {col-id px}}`) into a stable EDN


### PR DESCRIPTION
Duplication-reduction pass over `tools/xray/src/` (rf2-jkake.24, parent epic rf2-jkake). Conservative — one genuine, clear win; behaviour-preserving.

## Consolidation

Seven Xray namespaces each carried a byte-identical copy of the `window.localStorage` access trio (`storage-available?` guard + `read-raw` / `write-raw!` / `remove-raw!`, each wrapping `js/window.localStorage` in a try/catch that swallows throws and no-ops when storage is unavailable). Only the storage key + the (de)serialisation around it varied.

Folded the raw browser access into one dependency-free seam, **`day8.re-frame2-xray.local-storage`** (`available?` / `get-item` / `set-item!` / `remove-item!`). Each call-site keeps its own key constants, serialisation, and **public** `read-raw` / `write-raw!` / `clear!` / `clear-raw!` wrappers (referenced by `mount.cljs` + tests) — those wrappers now delegate to the seam.

Call-sites updated:
- `static/persistence.cljs` (Static mode flag)
- `static/machines/persistence.cljs` (selection + sub-mode map)
- `filters/persistence.cljs` (filter pills; key via `get-storage-key`)
- `palette/recents.cljs` (command-palette recents)
- `frame_switcher.cljs` (frame selection; key via `get-storage-key`)
- `views/resizable_table.cljs` (column widths; key via `get-storage-key`)
- `spine_filters.cljs` (event mute-set)
- `panels/machine_canvas.cljs` (view-mode + chart-collapsed maps)

Net −119 lines across the eight touched files (plus the ~80-line seam).

### Left as-is (noted, not folded)
- **`config.cljc`** storage shim is deliberately separate: it is `.cljc` and falls back to an in-process `memory-storage` atom (not a silent no-op) so the settings round-trip exercises its get/set code paths under the JVM test corpus. Folding it in would change behaviour.
- The two `static/*/browse_list.cljs` panels and the `panels/shared/*` chips are already factored (shared `search-box`, `coord-chip`); their remaining shape-similarity is intentional parallelism between distinct panels — not folded.

## Stability confirmation
- reg-view ids — unchanged
- `:rf.xray/*` reserved vocab — unchanged
- palette command-ids — unchanged
- L4-tab ids — unchanged
- localStorage keys + public fn names — unchanged
- runtime behaviour — unchanged (pure implementation-seam extraction)

## Quality gates
Run from `implementation/`:
- `npm run test:cljs` — 5094 tests / 17225 assertions, 0 failures, 0 errors
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures, 13 matrix rows
- `npm run test:bundle-isolation` — PASS (17 entries, 35 sentinels absent; uix/helix reagent-free PASS)
- clj-kondo — 0 errors on all changed files
