### PR TITLE
refactor(adapters): mp → mount-point across twins + spine (rf2-0owrc)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -47,9 +47,9 @@
      ;; `with-redefs` rebind). Runtime behaviour is identical.
      :ratom-ops         {:r/atom              (fn [v] (r/atom v))
                          :ratom/make-reaction (fn [thunk] (ratom/make-reaction thunk))
-                         :rdc/create-root     (fn [mp] (rdc/create-root mp))
+                         :rdc/create-root     (fn [mount-point] (rdc/create-root mount-point))
                          :rdc/render          (fn [root tree] (rdc/render root tree))
-                         :rdc/hydrate-root    (fn [mp tree] (rdc/hydrate-root mp tree))
+                         :rdc/hydrate-root    (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
                          :rdc/unmount         (fn [root] (rdc/unmount root))}}))
 
 (def set-hiccup-emitter!

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_render_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_render_cljs_test.cljs
@@ -57,9 +57,9 @@
       ;; lowest arities are exercised by the slim adapter today, but
       ;; covering the published arities keeps the stubs robust.
       (with-redefs [rdc/create-root  (fn
-                                       ([mp]   (swap! calls conj [:create-root mp])
+                                       ([mount-point]   (swap! calls conj [:create-root mount-point])
                                                fake-root)
-                                       ([mp _] (swap! calls conj [:create-root mp])
+                                       ([mount-point _] (swap! calls conj [:create-root mount-point])
                                                fake-root))
                     rdc/render       (fn [root tree]
                                        (swap! calls conj [:render root tree])
@@ -122,11 +122,11 @@
                                        (swap! calls conj [:render])
                                        (throw (ex-info "render must not be called on hydrate path" {})))
                     rdc/hydrate-root (fn
-                                       ([mp tree]
-                                        (swap! calls conj [:hydrate-root mp tree])
+                                       ([mount-point tree]
+                                        (swap! calls conj [:hydrate-root mount-point tree])
                                         fake-root)
-                                       ([mp tree _]
-                                        (swap! calls conj [:hydrate-root mp tree])
+                                       ([mount-point tree _]
+                                        (swap! calls conj [:hydrate-root mount-point tree])
                                         fake-root))
                     rdc/unmount      (fn [arg]
                                        (swap! calls conj [:unmount arg])

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -36,9 +36,9 @@
      ;; `with-redefs` rebind). Runtime behaviour is identical.
      :ratom-ops         {:r/atom              (fn [v] (r/atom v))
                          :ratom/make-reaction (fn [thunk] (ratom/make-reaction thunk))
-                         :rdc/create-root     (fn [mp] (rdc/create-root mp))
+                         :rdc/create-root     (fn [mount-point] (rdc/create-root mount-point))
                          :rdc/render          (fn [root tree] (rdc/render root tree))
-                         :rdc/hydrate-root    (fn [mp tree] (rdc/hydrate-root mp tree))
+                         :rdc/hydrate-root    (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
                          :rdc/unmount         (fn [root] (rdc/unmount root))}}))
 
 (def set-hiccup-emitter!

--- a/implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs
@@ -56,9 +56,9 @@
       ;; covering the published arities keeps the stubs robust against
       ;; passes through reagent internals.
       (with-redefs [rdc/create-root   (fn
-                                        ([mp]   (swap! calls conj [:create-root mp])
+                                        ([mount-point]   (swap! calls conj [:create-root mount-point])
                                                 fake-root)
-                                        ([mp _] (swap! calls conj [:create-root mp])
+                                        ([mount-point _] (swap! calls conj [:create-root mount-point])
                                                 fake-root))
                     rdc/render        (fn
                                         ([root tree]
@@ -133,11 +133,11 @@
                                         (swap! calls conj [:render])
                                         (throw (ex-info "render must not be called on hydrate path" {}))))
                     rdc/hydrate-root (fn
-                                       ([mp tree]
-                                        (swap! calls conj [:hydrate-root mp tree])
+                                       ([mount-point tree]
+                                        (swap! calls conj [:hydrate-root mount-point tree])
                                         fake-root)
-                                       ([mp tree _]
-                                        (swap! calls conj [:hydrate-root mp tree])
+                                       ([mount-point tree _]
+                                        (swap! calls conj [:hydrate-root mount-point tree])
                                         fake-root))
                     rdc/unmount      (fn [arg]
                                        (swap! calls conj [:unmount arg])


### PR DESCRIPTION
## Quality gates
- clj-kondo on changed files: **0 errors, 0 warnings**
- `npm run test:cljs`: **5094 tests / 17225 assertions, 0 failures, 0 errors**
- `npm run test:browser`: **130 tests / 367 assertions, 0 failures, 0 errors**
- `npm run test:reagent-slim:bundle-isolation`: **PASS** (3 contracts, 19 sentinel checks)
- JVM per-artefact (reagent + reagent-slim): **0 failures, 0 errors**

## Rename summary
The cryptic `mp` lambda parameter is renamed to `mount-point` in the `:ratom-ops` call-through lambdas (`:rdc/create-root`, `:rdc/hydrate-root`) of **both adapter twins** and their render test stubs:

- `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs`
- `implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs`
- `implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs`
- `implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_render_cljs_test.cljs`

This aligns the adapter call-sites with the spine contract, which already spells `mount-point` (`implementation/core/src/re_frame/substrate/spine.cljs` ~L413/1408/1481) — **no spine edit was needed**; the spine call-sites the bead names already use `mount-point`.

Every renamed `mp` was a **local lambda parameter binding** — not a public symbol, keyword, or cross-artefact consumed name. Behaviour-preserving.

## Confirmations
- **(a)** Public API + reserved `:rf.adapter/*` vocab unchanged. The `:rdc/*` keywords are untouched; only the internal parameter symbol changed.
- **(b)** reagent ↔ reagent-slim shared `:ratom-ops` block remains **byte-identical** after the rename (verified with `cat -A` before and after; the full files carry pre-existing docstring/require drift unrelated to this change).

Closes rf2-0owrc.