### PR TITLE
refactor(examples/scripts): reduce duplication (rf2-jkake.30)

### DIFF
--- a/examples/scripts/examples-port.cjs
+++ b/examples/scripts/examples-port.cjs
@@ -25,65 +25,41 @@
  * Playwright specs only ever hit localhost, and the loopback-only bind
  * also sidesteps the Windows dual-stack EACCES surprise.
  *
- * Shape mirrors examples/scripts/story-feature-load-port.cjs (the Story
- * feature-load gate's resolver) deliberately, so the two sibling
- * orchestrators handle port contention identically.
+ * Mechanism (bind probe / forward scan / actionable errors) is shared
+ * with the Story feature-load resolver via port-resolver.cjs; this file
+ * supplies only the examples-specific POLICY (default port + wording),
+ * so the two sibling orchestrators handle port contention identically.
  */
 
 'use strict';
 
-const net = require('net');
+const {
+  MAX_PORT_ATTEMPTS,
+  canListen,
+  findAvailablePort: findAvailablePortShared,
+  makeParseExplicitPort,
+  portError,
+} = require('./port-resolver.cjs');
 
 // Default outside the top-level :dev-http set (8765 / 8031 / 8030) so a
 // running `shadow-cljs watch` never pre-claims the orchestrator's port.
 const DEFAULT_PORT = 8040;
-const MAX_PORT_ATTEMPTS = 200;
 
-// Build an Error tagged `.actionable = true`. The orchestrator's bottom
-// .catch prints just `err.message` (no stack) for tagged errors, so a
-// port clash surfaces as a clean one-liner instead of a raw EACCES dump.
-function actionableError(message) {
-  const err = new Error(message);
-  err.actionable = true;
-  return err;
-}
+const parseExplicitPort = makeParseExplicitPort('EXAMPLES_PORT', { actionable: true });
 
-function parseExplicitPort(raw) {
-  if (raw == null || String(raw).trim() === '') return null;
-  const n = Number(String(raw).trim());
-  if (!Number.isInteger(n) || n < 1 || n > 65535) {
-    throw actionableError(
-      `EXAMPLES_PORT must be an integer in 1..65535; got ${JSON.stringify(raw)}`,
-    );
-  }
-  return n;
-}
-
-// Bind-and-release probe on 127.0.0.1. Resolves true when the port is
-// free, false when it is taken (any bind error — EADDRINUSE on
-// Mac/Linux, EACCES for a dual-stack listener on Windows).
-function canListen(port, host = '127.0.0.1') {
-  return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once('error', () => resolve(false));
-    server.listen(port, host, () => {
-      server.close(() => resolve(true));
-    });
+// Wrap the shared scanner with the examples-specific exhausted-port
+// wording (actionable, like every error this module raises) so the
+// public signature is unchanged.
+function findAvailablePort(startPort, opts = {}) {
+  return findAvailablePortShared(startPort, {
+    ...opts,
+    exhausted: (start, attempts) =>
+      portError(
+        `No free examples port found from ${start} after ${attempts} attempts. ` +
+          `Set EXAMPLES_PORT to an unused port.`,
+        { actionable: true },
+      ),
   });
-}
-
-async function findAvailablePort(startPort, opts = {}) {
-  const host = opts.host || '127.0.0.1';
-  const attempts = opts.attempts || MAX_PORT_ATTEMPTS;
-  for (let i = 0; i < attempts; i += 1) {
-    const port = startPort + i;
-    if (port > 65535) break;
-    if (await canListen(port, host)) return port;
-  }
-  throw actionableError(
-    `No free examples port found from ${startPort} after ${attempts} attempts. ` +
-      `Set EXAMPLES_PORT to an unused port.`,
-  );
 }
 
 /*
@@ -99,11 +75,12 @@ async function resolveExamplesPort({ env = process.env } = {}) {
   const explicit = parseExplicitPort(env.EXAMPLES_PORT);
   if (explicit != null) {
     if (!(await canListen(explicit))) {
-      throw actionableError(
+      throw portError(
         `EXAMPLES_PORT=${explicit} is already in use. Is a 'shadow-cljs watch' ` +
           `running? The top-level :dev-http map (implementation/shadow-cljs.edn) ` +
           `claims 8765 / 8031 / 8030 whenever a watch is up. Stop the watch, or ` +
           `set EXAMPLES_PORT to a free port.`,
+        { actionable: true },
       );
     }
     return explicit;

--- a/examples/scripts/port-resolver.cjs
+++ b/examples/scripts/port-resolver.cjs
@@ -1,0 +1,95 @@
+/*
+ * Shared port-resolution mechanism for the example/Story orchestrators.
+ *
+ * Two sibling orchestrators each need to pick a free TCP port and serve
+ * `implementation/out/examples` on it:
+ *
+ *   - examples-port.cjs            — the adapter-smoke orchestrator.
+ *   - story-feature-load-port.cjs  — the Story feature-load + play-script
+ *                                    gates.
+ *
+ * Both want IDENTICAL contention handling — a loopback bind-and-release
+ * probe, an explicit-env-var override that fails loud when busy, and a
+ * forward scan to the next free port when no override is set. Only the
+ * POLICY differs between them (default/preferred port, the env-var name,
+ * and the exact user-facing wording). This module owns the shared
+ * mechanism so each resolver file is just its distinguishing policy
+ * expressed over these primitives, rather than a second copy of the
+ * bind-probe loop.
+ *
+ * The `actionable` flag threads through to errors so a caller's bottom
+ * .catch can print `err.message` (no stack) for a port clash. The
+ * examples orchestrator relies on this; the Story orchestrators leave it
+ * off and print full errors.
+ */
+
+'use strict';
+
+const net = require('net');
+
+const MAX_PORT_ATTEMPTS = 200;
+
+// Build an Error optionally tagged `.actionable = true`. A caller whose
+// bottom .catch special-cases tagged errors prints just `err.message`
+// (no stack), so a port clash surfaces as a clean one-liner.
+function portError(message, { actionable = false } = {}) {
+  const err = new Error(message);
+  if (actionable) err.actionable = true;
+  return err;
+}
+
+// Make a strict env-var parser bound to `envVarName` (used only in the
+// "out of range" message). Returns null for unset/blank, throws an
+// (optionally actionable) error for a non-integer or out-of-range value.
+function makeParseExplicitPort(envVarName, { actionable = false } = {}) {
+  return function parseExplicitPort(raw) {
+    if (raw == null || String(raw).trim() === '') return null;
+    const n = Number(String(raw).trim());
+    if (!Number.isInteger(n) || n < 1 || n > 65535) {
+      throw portError(
+        `${envVarName} must be an integer in 1..65535; got ${JSON.stringify(raw)}`,
+        { actionable },
+      );
+    }
+    return n;
+  };
+}
+
+// Bind-and-release probe on 127.0.0.1 (by default). Resolves true when
+// the port is free, false when it is taken (any bind error —
+// EADDRINUSE on Mac/Linux, EACCES for a dual-stack listener on Windows).
+function canListen(port, host = '127.0.0.1') {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.listen(port, host, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+// Scan forward from `startPort` to the first free port. `opts.exhausted`
+// is a `(startPort, attempts) => Error` builder for the all-busy case so
+// each resolver can supply its own actionable wording.
+async function findAvailablePort(startPort, opts = {}) {
+  const host = opts.host || '127.0.0.1';
+  const attempts = opts.attempts || MAX_PORT_ATTEMPTS;
+  for (let i = 0; i < attempts; i += 1) {
+    const port = startPort + i;
+    if (port > 65535) break;
+    if (await canListen(port, host)) return port;
+  }
+  const exhausted =
+    opts.exhausted ||
+    ((start, n) =>
+      portError(`No free port found from ${start} after ${n} attempts.`));
+  throw exhausted(startPort, attempts);
+}
+
+module.exports = {
+  MAX_PORT_ATTEMPTS,
+  canListen,
+  findAvailablePort,
+  makeParseExplicitPort,
+  portError,
+};

--- a/examples/scripts/story-feature-load-port.cjs
+++ b/examples/scripts/story-feature-load-port.cjs
@@ -4,15 +4,26 @@
  * so parallel worktrees (rf2-* worker checkouts) never collide on 8031.
  * Honours STORY_FEATURE_LOAD_PORT if set; otherwise scans forward from
  * the derived preference until an unused port is found.
+ *
+ * The bind probe / forward scan / strict-parse mechanism is shared with
+ * the adapter-smoke resolver via port-resolver.cjs; this file supplies
+ * only the Story-specific POLICY (worktree-hashed preferred port +
+ * wording). Errors are plain (non-actionable) — the Story orchestrators
+ * print full errors, unlike the examples orchestrator.
  */
 
 'use strict';
 
-const net = require('net');
+const {
+  MAX_PORT_ATTEMPTS,
+  canListen,
+  findAvailablePort: findAvailablePortShared,
+  makeParseExplicitPort,
+  portError,
+} = require('./port-resolver.cjs');
 
 const DEFAULT_BASE_PORT = 8031;
 const DERIVED_PORT_SPAN = 2000;
-const MAX_PORT_ATTEMPTS = 200;
 
 function hashString(s) {
   let h = 2166136261;
@@ -23,51 +34,31 @@ function hashString(s) {
   return h >>> 0;
 }
 
-function parseExplicitPort(raw) {
-  if (raw == null || String(raw).trim() === '') return null;
-  const n = Number(String(raw).trim());
-  if (!Number.isInteger(n) || n < 1 || n > 65535) {
-    throw new Error(
-      `STORY_FEATURE_LOAD_PORT must be an integer in 1..65535; got ${JSON.stringify(raw)}`,
-    );
-  }
-  return n;
-}
+const parseExplicitPort = makeParseExplicitPort('STORY_FEATURE_LOAD_PORT');
 
 function preferredPort(repoRoot) {
   const offset = hashString(repoRoot || process.cwd()) % DERIVED_PORT_SPAN;
   return DEFAULT_BASE_PORT + offset;
 }
 
-function canListen(port, host = '127.0.0.1') {
-  return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once('error', () => resolve(false));
-    server.listen(port, host, () => {
-      server.close(() => resolve(true));
-    });
+// Wrap the shared scanner with the Story-specific exhausted-port wording
+// so the public signature (and the per-worktree hint) is unchanged.
+function findAvailablePort(startPort, opts = {}) {
+  return findAvailablePortShared(startPort, {
+    ...opts,
+    exhausted: (start, attempts) =>
+      portError(
+        `No free Story feature-load port found from ${start} after ${attempts} attempts. ` +
+          `Set STORY_FEATURE_LOAD_PORT to an unused port for this worktree.`,
+      ),
   });
-}
-
-async function findAvailablePort(startPort, opts = {}) {
-  const host = opts.host || '127.0.0.1';
-  const attempts = opts.attempts || MAX_PORT_ATTEMPTS;
-  for (let i = 0; i < attempts; i += 1) {
-    const port = startPort + i;
-    if (port > 65535) break;
-    if (await canListen(port, host)) return port;
-  }
-  throw new Error(
-    `No free Story feature-load port found from ${startPort} after ${attempts} attempts. ` +
-      `Set STORY_FEATURE_LOAD_PORT to an unused port for this worktree.`,
-  );
 }
 
 async function resolveStoryFeatureLoadPort({ env = process.env, repoRoot = process.cwd() } = {}) {
   const explicit = parseExplicitPort(env.STORY_FEATURE_LOAD_PORT);
   if (explicit != null) {
     if (!(await canListen(explicit))) {
-      throw new Error(
+      throw portError(
         `STORY_FEATURE_LOAD_PORT=${explicit} is already in use. ` +
           `Choose a unique port for this worktree.`,
       );


### PR DESCRIPTION
## Quality gates

- `npm run test:examples` (from `implementation/`) — **PASS**, 3 adapter smokes (Reagent / UIx / Helix), 0 failures, exit 0. This gate is driven by the very orchestrator (`serve-and-run-examples-tests.cjs`) that consumes the refactored `examples-port.cjs`.
- `npm run test:script-policy` — **PASS**, including `_story-feature-load-port.test.cjs` (the pinned public-API test for `story-feature-load-port.cjs`): `story-feature-load-port tests: 4 passed`.
- Behaviour-preservation sanity check (both resolvers): exports present, `.actionable` tag preserved on examples errors / absent on Story errors, range / busy / exhausted message wording intact per-resolver, forward-scan still skips occupied ports.
- No eslint/clj-kondo config applies to these plain `.cjs` scripts.

## Consolidations

**Extracted the shared port-resolution mechanism into a new `examples/scripts/port-resolver.cjs`.**

`examples-port.cjs` and `story-feature-load-port.cjs` each carried:
- a byte-identical `canListen()` loopback bind-and-release probe,
- a structurally-identical `findAvailablePort()` forward scan, and
- the same `parseExplicitPort()` strict-parse shape.

The `examples-port.cjs` header even documented the mirror as deliberate ("Shape mirrors … so the two sibling orchestrators handle port contention identically"). The new module owns that mechanism — `canListen` / `findAvailablePort` / `makeParseExplicitPort` / `portError` — and each resolver file is now just its distinguishing **policy**:
- examples: `DEFAULT_PORT = 8040`, env-var `EXAMPLES_PORT`, `.actionable`-tagged errors;
- Story: worktree-hash-derived preferred port, env-var `STORY_FEATURE_LOAD_PORT`, plain errors.

Net effect: the two resolvers drop from a second copy of the bind-probe loop to a thin policy layer (-83 lines in the pair; the shared mechanism lives once). This matches the established `implementation/scripts/lib/` shared-module pattern these scripts already consume.

## Left self-contained (noted, not consolidated)

- The identical 10-line `withTimeout` in the two Playwright runners — the runners diverge substantially elsewhere; folding one tiny helper into a new module would add a require for less clarity than the per-script copy.
- The `compileAll`/`compileTestbed` and `stageHtml` helpers across the three orchestrators — each carries subtly different spawn shapes (shell vs capture, single vs multi-build); a parameterised shared helper would need several flags and read **less** clearly than the current self-contained functions. Per-script self-containment is the right call here.

## Behaviour / invocation

Unchanged. Public APIs, exports, error messages, the `.actionable` contract, and the `test:examples` / `test:story-feature-load` / `test:story-play-scripts` invocation paths are all stable.