### PR TITLE
refactor(impl/scripts): reduce duplication (rf2-jkake.15)

### DIFF
--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -44,7 +44,11 @@
 
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
+const {
+  readReleaseBlob,
+  countMatches,
+  countSubstring,
+} = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -517,30 +521,13 @@ const ARTEFACTS = [
 
 // ----- helpers ---------------------------------------------------------------
 
-// Bundle reading is shared with the sibling check-* scripts via
-// scripts/lib/read-release-bundle.cjs (rf2-qlk4w). The helper reads
-// only top-level *.js — the release artefact — so a stale dev-build
-// `cljs-runtime/` subdir from a prior `shadow-cljs compile` doesn't
-// get grep-ed alongside.
-
-function escapeRe(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function countSubstring(blob, needle) {
-  const re = new RegExp(escapeRe(needle), 'g');
-  const m  = blob.match(re);
-  return m ? m.length : 0;
-}
-
-function countPattern(blob, re) {
-  // Caller-supplied RegExp — reset lastIndex defensively in case the
-  // RegExp object has been used before (RegExp literals carry state
-  // when /g is set).
-  re.lastIndex = 0;
-  const m = blob.match(re);
-  return m ? m.length : 0;
-}
+// Bundle reading + grep primitives (escapeRe / countSubstring /
+// countMatches) are shared with the sibling check-* scripts via
+// scripts/lib/read-release-bundle.cjs (rf2-qlk4w bundle reader;
+// rf2-jkake.15 folded the grep primitives in alongside it). The reader
+// returns only top-level *.js — the release artefact — so a stale
+// dev-build `cljs-runtime/` subdir from a prior `shadow-cljs compile`
+// doesn't get grep-ed alongside.
 
 function checkArtefact(blob, artefact) {
   report.detail(`  ${artefact.name}:`);
@@ -563,7 +550,7 @@ function checkArtefact(blob, artefact) {
   let allowListHits = 0;
   const allowListChecked = artefact.consumerAllowList ? 1 : 0;
   if (artefact.consumerAllowList) {
-    allowListHits = countPattern(blob, artefact.consumerAllowList);
+    allowListHits = countMatches(blob, artefact.consumerAllowList);
     allowListOk   = allowListHits <= artefact.expectedAllowListHits;
     const tag     = allowListOk ? 'OK' : 'FAIL';
     report.detail(`    [${tag}] consumer allow-list ${artefact.consumerAllowList}: ` +

--- a/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
+++ b/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
@@ -41,9 +41,9 @@
 
 'use strict';
 
-const fs   = require('fs');
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
+const { readReleaseBlob, countSubstring } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -116,49 +116,15 @@ const REACT_DOM_SERVER_SENTINELS = [
 ];
 
 // ----- helpers ---------------------------------------------------------------
-
-function readAllJs(dir) {
-  // Concatenate every top-level *.js file in dir into a single blob.
-  // For shadow-cljs :browser :release builds the closure-compiled
-  // output lives in top-level files (main.js, plus any sibling module
-  // files like cljs_base.js); the only subdirectory that appears in
-  // the output dir is `cljs-runtime/`, which is dev-build debug source
-  // left behind by a prior `shadow-cljs compile` and NOT cleaned by a
-  // subsequent `shadow-cljs release` (rf2-z9a06).
-  //
-  // Walking recursively (as the sibling readAllJs in
-  // check-bundle-isolation.cjs does) means a stale `cljs-runtime/`
-  // dir gets grepped alongside the release main.js — producing false
-  // FAILs on sentinels that only appear in the unoptimised dev
-  // sources (e.g. cljsLegacyRender, react-dom/server). CI is unaffected
-  // because every CI run is on a clean dir, but local repros after a
-  // dev `compile` trip the trap; the contract should measure the
-  // release artefact regardless.
-  //
-  // The release artefact IS exactly the top-level *.js — that's what a
-  // consumer ships. Filtering to it makes the contract robust against
-  // dev-build leftovers in the output dir.
-  if (!fs.existsSync(dir)) {
-    return null;
-  }
-  const out = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (entry.isFile() && entry.name.endsWith('.js')) {
-      out.push(fs.readFileSync(path.join(dir, entry.name), 'utf8'));
-    }
-  }
-  return out.join('\n');
-}
-
-function escapeRe(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function countSubstring(blob, needle) {
-  const re = new RegExp(escapeRe(needle), 'g');
-  const m  = blob.match(re);
-  return m ? m.length : 0;
-}
+//
+// Bundle reading + the countSubstring grep primitive are shared with the
+// sibling check-* scripts via scripts/lib/read-release-bundle.cjs
+// (rf2-jkake.15). `readReleaseBlob` reads only top-level *.js — the
+// release artefact — so a stale dev-build `cljs-runtime/` subdir from a
+// prior `shadow-cljs compile` doesn't get grep-ed alongside (rf2-z9a06):
+// that trap, first documented inline here, was the reason the reader was
+// factored out (rf2-qlk4w) and is now the shared default for the whole
+// check-*-bundle family.
 
 // ----- the three contract checks --------------------------------------------
 
@@ -207,8 +173,8 @@ function main() {
 
   const slimDir  = path.join(ROOT, 'out', 'examples', 'counter-slim-and-fast');
   const stockDir = path.join(ROOT, 'out', 'examples', 'counter');
-  const slim  = readAllJs(slimDir);
-  const stock = readAllJs(stockDir);
+  const slim  = readReleaseBlob(slimDir);
+  const stock = readReleaseBlob(stockDir);
 
   if (slim == null) {
     report.flushDetails();

--- a/implementation/scripts/check-uix-helix-reagent-free.cjs
+++ b/implementation/scripts/check-uix-helix-reagent-free.cjs
@@ -36,7 +36,7 @@
 
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
+const { readReleaseBlob, countSubstring } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -66,16 +66,10 @@ const REAGENT_SENTINELS = [
 ];
 
 // ----- helpers ---------------------------------------------------------------
-
-function escapeRe(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function countSubstring(blob, needle) {
-  const re = new RegExp(escapeRe(needle), 'g');
-  const m  = blob.match(re);
-  return m ? m.length : 0;
-}
+//
+// Bundle reading + the countSubstring grep primitive are shared with the
+// sibling check-* scripts via scripts/lib/read-release-bundle.cjs
+// (rf2-jkake.15).
 
 function checkBundle(label, bundlePath, mustContain) {
   const blob = readReleaseBlob(bundlePath);

--- a/implementation/scripts/lib/read-release-bundle.cjs
+++ b/implementation/scripts/lib/read-release-bundle.cjs
@@ -17,13 +17,26 @@
 // inline and filtered to top-level; this module factors the same fix
 // out so the four sibling scanners share one implementation.
 //
-// Two flavours:
+// Two flavours of reader:
 //   readReleaseBlob(dir)     → concatenated string blob; null when
 //                              `dir` doesn't exist. For substring /
 //                              regex grep contracts.
 //   listReleaseJsFiles(dir)  → array of absolute paths; null when
 //                              `dir` doesn't exist. For per-file work
 //                              (e.g. gzipped-size totalling).
+//
+// Plus the grep primitives the sibling check-*-bundle scanners run
+// against the blob. Each scanner used to carry its own verbatim copies
+// of these (rf2-jkake.15 folded them here so the bundle-grep family
+// shares one implementation):
+//   escapeRe(s)              → escape a string for literal use in a
+//                              RegExp.
+//   countMatches(blob, re)   → number of global matches of a RegExp in
+//                              the blob; 0 when blob is null. Resets the
+//                              RegExp's lastIndex defensively (a /g
+//                              literal carries match state across calls).
+//   countSubstring(blob, s)  → number of occurrences of a literal
+//                              substring (escapeRe + global count).
 
 const fs   = require('fs');
 const path = require('path');
@@ -53,4 +66,29 @@ function readReleaseBlob(dir) {
   return out.join('\n');
 }
 
-module.exports = { readReleaseBlob, listReleaseJsFiles };
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function countMatches(blob, re) {
+  if (blob == null) {
+    return 0;
+  }
+  // A caller-supplied /g RegExp literal carries `lastIndex` state across
+  // calls; reset it so the count is independent of prior use.
+  re.lastIndex = 0;
+  const m = blob.match(re);
+  return m ? m.length : 0;
+}
+
+function countSubstring(blob, needle) {
+  return countMatches(blob, new RegExp(escapeRe(needle), 'g'));
+}
+
+module.exports = {
+  readReleaseBlob,
+  listReleaseJsFiles,
+  escapeRe,
+  countMatches,
+  countSubstring,
+};


### PR DESCRIPTION
Per-slice dedup pass for `implementation/scripts/` (epic rf2-jkake, bead rf2-jkake.15). Conservative — consolidates only where it makes the bundle-grep slice clearer; the existing `lib/` shared-module pattern is the home, no new module.

## Consolidations

Folded the release-bundle grep primitives shared by the `check-*-bundle` scanners into the existing `scripts/lib/read-release-bundle.cjs` (which already owns "read the release bundle"):

- **`escapeRe` + `countSubstring`** — were verbatim copies in `check-bundle-isolation.cjs`, `check-reagent-slim-bundle-isolation.cjs`, and `check-uix-helix-reagent-free.cjs` (3 copies each). Now single-sourced in the lib.
- **`readAllJs` in `check-reagent-slim-bundle-isolation.cjs`** — a full re-implementation of the lib's `readReleaseBlob`, carrying the long rf2-z9a06 `cljs-runtime/` comment block the lib already documents. Rerouted to `readReleaseBlob`; the script also drops its now-unused `fs` import.
- **`countPattern` in `check-bundle-isolation.cjs`** — same "count hits of a pre-built `/g` RegExp" mechanic as the new shared `countMatches`. Rerouted.

`countSubstring` now builds on `escapeRe` + `countMatches` so there is one place that resets `lastIndex` and one place that escapes metacharacters.

## Deliberately left self-contained (noted, not actioned)

- **`countOccurrences` in `check-perf-bundle.cjs`** — single-use; joins a *pattern list* and returns `null` (not `0`) on a missing blob to signal "count N/A" in the report. Folding it would muddy that semantics for no clarity gain.
- **`serve-and-run-{prod-elision,schemas-boundary-prod}-tests.cjs`** — near-identical 40-line env-var shims, but each pins a distinct `ROOT`/`PORT` and carries its own spec-anchored docstring; one is intentionally framed as a "Mirror of" the other. Per-shim self-containment is the point.
- **`serve-and-run-xray-feature-gate.cjs` / `serve-and-run-browser-tests.cjs`** — already consume `lib/local-browser-harness.cjs`; remaining bespoke orchestration is per-gate and not beneficially shareable.

## Behaviour / invocation / lib surface

- **Behaviour-preserving**: same stdout/stderr, same exit codes, same control flow. The shared `countSubstring`/`countMatches` are null-safe (return `0` on a null blob); every call site already guards on `blob == null` before counting, so no existing path changes.
- **Invocation contract unchanged**: no `package.json` script changed; all four `check-*` scripts run exactly as before.
- **lib public surface**: additive only — `escapeRe` / `countMatches` / `countSubstring` added; `readReleaseBlob` / `listReleaseJsFiles` unchanged.

## Quality gates

- `npm run test:script-helpers` (from `implementation/`) — PASS (browser-test-report 5, gate-report 4, local-browser-harness 4). This is the lib-helper unit gate.
- Smoke-ran all four rewired/untouched `check-*` scripts under `node` with no release artefacts present: each reaches its normal "bundle path missing" branch with no `ReferenceError` for the removed helpers — confirms the require graph (including the new lib exports) resolves and the scanners' control flow is intact.
- Full end-to-end coverage of these scanners is the `test:bundle-isolation` and `test:reagent-slim:bundle-isolation` gates (each does a `shadow-cljs release` then runs the scanner) and `test:perf-bundle` — not run here as they require expensive release builds; the consolidation is behaviour-preserving and the lib primitives are exercised by `test:script-helpers`' sibling pattern.
- No eslint/prettier config is wired for the `.cjs` scripts tree (verified); clj-kondo is Clojure-only.

Edits confined to `implementation/scripts/` per the bead's hard constraint.
