### PR TITLE
refactor(adapters/uix): reduce duplication (rf2-jkake.5)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
@@ -32,21 +32,15 @@
   (test-support/make-reset-runtime-fixture
     {:adapter uix-adapter/adapter}))
 
-(defn- react-element-source-coord
-  "Pull `data-rf2-source-coord` off a React element's `.-props`, or nil.
-  Defensively returns nil on every branch so the test assertions can
-  use `nil?`."
-  [el]
+(defn- react-element-attr
+  "Pull `attr` (a string prop name) off a React element's `.-props`, or
+  nil. Defensively returns nil on every branch so the test assertions
+  can use `nil?`. Both elision attributes (`data-rf2-source-coord` and
+  `data-rf-view`) ride the same `interop/debug-enabled?` gate, so the
+  one accessor covers both."
+  [el attr]
   (when (and el (.-props el))
-    (aget (.-props el) "data-rf2-source-coord")))
-
-(defn- react-element-view-attr
-  "Pull `data-rf-view` off a React element's `.-props`, or nil.
-  Defensively returns nil on every branch so the test assertions can
-  use `nil?`."
-  [el]
-  (when (and el (.-props el))
-    (aget (.-props el) "data-rf-view")))
+    (aget (.-props el) attr)))
 
 ;; ---- annotation elides under :advanced + goog.DEBUG=false ----------------
 
@@ -65,9 +59,9 @@
         (is (some? out))
         (is (= "span" (.-type out))
             "root element's type preserved")
-        (is (nil? (react-element-source-coord out))
+        (is (nil? (react-element-attr out "data-rf2-source-coord"))
             "NO data-rf2-source-coord on the rendered root — elision contract holds")
-        (is (nil? (react-element-view-attr out))
+        (is (nil? (react-element-attr out "data-rf-view"))
             "NO data-rf-view on the rendered root — view-id tagging rides the
              same interop/debug-enabled? gate and elides too (rf2-ihcib)")))))
 


### PR DESCRIPTION
Within-adapter duplication-reduction pass over `implementation/adapters/uix/` (bead rf2-jkake.5, epic rf2-jkake). Conservative: consolidate only where it makes the slice clearer.

## What changed

`implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs` carried two near-identical private accessors — `react-element-source-coord` and `react-element-view-attr` — differing only in the literal prop name they read off a React element's `.-props`. Collapsed into a single attribute-parameterised `react-element-attr`; call sites now pass the explicit prop string, keeping the elision-contract assertions self-documenting in place.

Net: 16 lines removed, 10 added; two single-use helpers → one shared helper.

## Scope notes (NOT actioned — out of slice)

- **Source + test entry-points already deduped.** `src/.../uix.cljs` is a thin wrapper over the shared `re-frame.substrate.spine` (container quartet, derived value, render-root, frame-provider, use-subscribe, wrap-view, warn-once — already factored there per rf2-ee38b.1). The four other test files are thin forwarders into the shared `re-frame.adapter.react-shared-suite`. No within-uix dup to extract there.
- **Cross-suite dup (noted, not touched):** the same two prop accessors exist byte-identically in `helix_source_coord_dom_elision_prod_test.cljs`. The clean fix is hoisting `react-element-attr` into the shared `core/test/.../react_shared_suite.cljs`, which is outside this slice (shared react suite + helix are a separate worker). Flagged for the epic.

## Quality gates

Run from `implementation/` (fresh worktree, `npm install` first):

- uix JVM `clojure -M:test` — 0 tests/0 errors (adapter is CLJS-only; alias is classpath-probe parity, as documented in deps.edn)
- `npm run test:cljs` — 5094 tests, 17225 assertions, 0 failures, 0 errors
- `npm run test:browser` — 130 tests, 367 assertions, 0 failures, 0 errors
- `npm run test:browser-prod-elision` (the build that actually compiles + runs the changed file) — 62 tests, 178 assertions, 0 failures, 0 errors
- clj-kondo on the changed file — errors: 0, warnings: 0

Public API + `:rf.adapter/*` + behaviour unchanged: identical nil-defensive accessor semantics, same two assertions in the same deftests.