### PR TITLE
refactor(adapters/helix): reduce duplication (rf2-jkake.4)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_source_coord_dom_elision_prod_test.cljs
@@ -32,21 +32,15 @@
   (test-support/make-reset-runtime-fixture
     {:adapter helix-adapter/adapter}))
 
-(defn- react-element-source-coord
-  "Pull `data-rf2-source-coord` off a React element's `.-props`, or nil.
-  Defensively returns nil on every branch so the test assertions can
-  use `nil?`."
-  [el]
+(defn- react-element-attr
+  "Pull `attr` off a React element's `.-props`, or nil. Defensively
+  returns nil on every branch so the test assertions can use `nil?`.
+  Both prod-elision attrs (`data-rf2-source-coord` + `data-rf-view`)
+  ride the same `interop/debug-enabled?` gate, so one reader covers
+  both."
+  [el attr]
   (when (and el (.-props el))
-    (aget (.-props el) "data-rf2-source-coord")))
-
-(defn- react-element-view-attr
-  "Pull `data-rf-view` off a React element's `.-props`, or nil.
-  Defensively returns nil on every branch so the test assertions can
-  use `nil?`."
-  [el]
-  (when (and el (.-props el))
-    (aget (.-props el) "data-rf-view")))
+    (aget (.-props el) attr)))
 
 ;; ---- annotation elides under :advanced + goog.DEBUG=false ----------------
 
@@ -65,9 +59,9 @@
         (is (some? out))
         (is (= "span" (.-type out))
             "root element's type preserved")
-        (is (nil? (react-element-source-coord out))
+        (is (nil? (react-element-attr out "data-rf2-source-coord"))
             "NO data-rf2-source-coord on the rendered root — elision contract holds")
-        (is (nil? (react-element-view-attr out))
+        (is (nil? (react-element-attr out "data-rf-view"))
             "NO data-rf-view on the rendered root — view-id tagging rides the
              same interop/debug-enabled? gate and elides too (rf2-ihcib)")))))
 


### PR DESCRIPTION
Within-adapter duplication-reduction pass over `implementation/adapters/helix/` (bead rf2-jkake.4, parent epic rf2-jkake).

## Consolidations

- **`helix_source_coord_dom_elision_prod_test.cljs`** — folded the two byte-identical prod-elision attr readers (`react-element-source-coord` / `react-element-view-attr`, which differed only in the literal attribute-key string) into a single `react-element-attr` helper parameterised by attr name. Both attrs ride the same `interop/debug-enabled?` gate, so one defensive reader expresses the contract once; call sites pass the attr name. Net `-6` lines, removes the copy-paste.

Conservative by design: the helix source file (`src/.../helix.cljs`) is already maximally consolidated into the shared `re-frame.substrate.spine` (out of scope — core, not helix), and the test entry files are intentionally thin per-adapter shims forwarding into the shared `react-shared-suite` (also out of scope — core). Those were left untouched.

Cross-slice note (NOT actioned here): the shared React test/support machinery in `implementation/core/test/re_frame/adapter/react_shared_suite*` and `implementation/adapters/test-react/` is shared with UIx and reviewed separately — not touched.

## Quality gates

- clj-kondo (changed file): 0 errors, 0 warnings
- helix JVM `clojure -M:test`: 0 failures, 0 errors (CLJS-only artefact; classpath-probe alias)
- `npm run test:browser-prod-elision` (exercises the changed file): 62 tests / 178 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 5094 tests / 17225 assertions, 0 failures, 0 errors
- `npm run test:browser`: 130 tests / 367 assertions, 0 failures, 0 errors

Public API, `:rf.adapter/*` surface, and behaviour unchanged (test-only consolidation).
