### PR TITLE
refactor(ssr-ring): reduce duplication (rf2-jkake.14)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -38,13 +38,15 @@
   default), `shell` (`default-html-shell` + shared envelope helpers),
   `payload` (`build-payload` — the non-streaming wrapper over the
   shared `re-frame.ssr.payload-policy` version-resolution + assembly),
-  `lifecycle` (frame
-  teardown, root-view / head resolution, required-opt validation,
-  `default-on-error`), `pipeline` (the 4-step request pipeline +
-  accumulator → Ring-map materialiser), `trust` (trusted-shell-hook
-  contract), `streaming` (chunked-HTTP counterpart). `handler-defaults`
-  + `validate-handler-opts!` live here so the handler constructor reads
-  top-down as one concept.
+  `lifecycle` (frame teardown, root-view / head resolution, the
+  construction-time validation triple `validate-construction-opts!`, the
+  `:on-error` precedence `resolve-on-error`, and `default-on-error`),
+  `pipeline` (the 4-step request pipeline + accumulator → Ring-map
+  materialiser), `trust` (trusted-shell-hook contract), `streaming`
+  (chunked-HTTP counterpart). `handler-defaults` lives here so the
+  handler constructor reads top-down as one concept; the construction
+  validation + on-error resolution it composes are shared verbatim with
+  `stream-handler`, so they live in `lifecycle`.
 
   This façade re-exposes the public surface (`ssr-handler`,
   `ssr-middleware`, `stream-handler`, `cookie->set-cookie-header`,
@@ -85,12 +87,10 @@
     - Async Ring handler (3-arity) — synchronous-only in v1;
       extension is additive."
   (:require [re-frame.ssr :as ssr]
-            [re-frame.ssr.payload-policy :as payload-policy]
             [re-frame.ssr.ring.cookie :as cookie]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.pipeline :as pipeline]
             [re-frame.ssr.ring.shell :as shell]
-            [re-frame.ssr.ring.trust :as trust]
             ;; rf2-ojakd / rf2-olb64 (a) — streaming SSR adapter. Loaded
             ;; eagerly so `stream-handler` resolves at the façade. The
             ;; streaming surface is the chunked-HTTP counterpart of
@@ -115,12 +115,16 @@
 (def default-streaming-prefix  streaming/default-streaming-prefix)
 (def default-streaming-suffix  streaming/default-streaming-suffix)
 
-;; ---- handler defaults + caller-opt validation -----------------------------
+;; ---- handler defaults + re-exported construction helpers ------------------
 ;;
 ;; Co-located with the handler constructor so the file reads top-down as
 ;; one concept. `default-on-error` is re-exported from `lifecycle`
 ;; (shared with `stream-handler` so the rf2-kzvwq topology-leak contract
-;; lives in one place).
+;; lives in one place). The construction-time validation triple
+;; (`validate-construction-opts!`) and the `:on-error` precedence
+;; (`resolve-on-error`) also live in `lifecycle` — shared verbatim with
+;; `stream-handler` so the fail-closed-at-boot + rf2-c1tac on-error
+;; contracts are single-sourced.
 
 (def default-on-error lifecycle/default-on-error)
 (def make-default-on-error lifecycle/make-default-on-error)
@@ -129,67 +133,6 @@
   {:emit-hash?   true
    :html-shell   shell/default-html-shell
    :content-type "text/html; charset=utf-8"})
-
-(defn- resolve-on-error
-  "Resolve the effective `:on-error` from `raw-opts`. Precedence:
-
-    1. caller-supplied `:on-error`     — full Ring-fn override; used verbatim.
-    2. caller-supplied `:on-error-fallback` — `{:body … :content-type …}`
-       template; built into a default-shaped fn via
-       `make-default-on-error`. The fn ignores the throwable (rf2-kzvwq
-       no-leak contract preserved).
-    3. neither                          — host-locked `default-on-error`
-       (`\"Internal error\"` plaintext).
-
-  Per rf2-c1tac — splits the templatable-default case from the full-
-  override case so callers can swap the body string without writing a
-  Ring fn AND without inheriting the `.getMessage` topology-leak risk."
-  [{:keys [on-error on-error-fallback]}]
-  (cond
-    on-error          on-error
-    on-error-fallback (make-default-on-error on-error-fallback)
-    :else             default-on-error))
-
-;; ---- trusted-shell-hook contract (rf2-o6ndb) ------------------------------
-;;
-;; The four trusted-shell-hook opts (`:head`, `:body-end`, `:script-src`,
-;; `:app-element-id`) are TRUSTED STRINGS — injected RAW into the
-;; rendered HTML envelope, no escaping, no validation, no sandbox.
-;; Naming, structural validation, and the structured-alternative
-;; recommendation for untrusted-customization use cases live in
-;; `re-frame.ssr.ring.trust` (sibling to `re-frame.ssr.payload-policy`).
-;; See Spec 011 §Trusted shell hook contract for the full surface.
-
-(defn- validate-handler-opts!
-  "Throw a structured `:rf.error/ssr-ring-missing-*` ex-info when a
-  caller omits a required `ssr-handler` opt. Separated from the handler
-  body so `ssr-handler` reads as the lifecycle wiring rather than a
-  validation-then-wire two-step.
-
-  Per rf2-gtgf9 the hydration-payload policy is also validated here so
-  misconfigured deployments fail at handler-construction time (boot)
-  rather than at first request — the canonical fail-closed pattern.
-  Delegates to `re-frame.ssr.payload-policy/validate-policy-opts!`,
-  which throws `:rf.error/ssr-missing-payload-policy` (or
-  `:rf.error/ssr-unknown-payload-policy` on a typo'd
-  `:payload-policy`).
-
-  Per rf2-o6ndb the four trusted-shell-hook opts (`:head`, `:body-end`,
-  `:script-src`, `:app-element-id`) are structural-shape-checked — they
-  are TRUSTED STRINGS injected RAW into the rendered HTML envelope, so
-  a structural error (map / vector / symbol) surfaces here as
-  `:rf.error/ssr-trusted-shell-opt-invalid`. The framework names the
-  trust boundary; the content trust itself remains the caller's per
-  Spec 011 §Trusted shell hook contract.
-
-  The required-opt presence checks (`:on-create` / `:root-view`) and
-  the policy / trusted-shell checks are shared with `stream-handler`
-  (`lifecycle/validate-required-opts!` + `payload-policy` + `trust`) so
-  both handlers fail closed at the same boundary."
-  [opts]
-  (lifecycle/validate-required-opts! opts)
-  (payload-policy/validate-policy-opts! opts)
-  (trust/validate-trusted-shell-opts! opts))
 
 ;; ---- ssr-handler ----------------------------------------------------------
 
@@ -338,18 +281,19 @@
                              :html-shell ssr-ring-app/shell}))
     (jetty/run-jetty handler {:port 3000 :join? false})"
   [raw-opts]
-  (validate-handler-opts! raw-opts)
+  (lifecycle/validate-construction-opts! raw-opts)
   ;; Merge defaults once at construction time so the pipeline helpers
   ;; (`setup-request-frame!`, `build-full-response`) can destructure
   ;; without re-stating the `:or` map. Caller-supplied values win.
   ;;
-  ;; rf2-c1tac — `:on-error` resolution moved through `resolve-on-error`:
-  ;; the templatable `:on-error-fallback {:body … :content-type …}` opt
+  ;; rf2-c1tac — `:on-error` resolution goes through
+  ;; `lifecycle/resolve-on-error` (shared with `stream-handler`): the
+  ;; templatable `:on-error-fallback {:body … :content-type …}` opt
   ;; produces a default-shaped fn without forcing the caller to write a
   ;; Ring fn. Resolution happens AFTER merge so handler-defaults can stay
   ;; orthogonal to on-error (no `:on-error` slot in the defaults map).
   (let [opts        (-> (merge handler-defaults raw-opts)
-                        (assoc :on-error (resolve-on-error raw-opts)))
+                        (assoc :on-error (lifecycle/resolve-on-error raw-opts)))
         {:keys [on-error]} opts]
     (fn ring-handler [request]
       (let [{:keys [frame-id short-circuit]}

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -9,6 +9,26 @@
                                  rendered fragment plus `:html-attrs` /
                                  `:body-attrs` bags for the host shell
 
+  Plus the two construction-time contracts shared verbatim by BOTH
+  `re-frame.ssr.ring/ssr-handler` AND
+  `re-frame.ssr.ring.streaming/stream-handler`:
+
+    - `validate-construction-opts!` — the fail-closed-at-boot triple
+                                      (required opts + payload policy +
+                                      trusted-shell shape)
+    - `resolve-on-error`            — the rf2-c1tac `:on-error` /
+                                      `:on-error-fallback` / locked-default
+                                      precedence
+
+  Both lived twice (once in the `ring` façade, once inlined in
+  `streaming`) before — colocating them here, alongside the
+  `validate-required-opts!` / `make-default-on-error` / `default-on-error`
+  pieces they already compose, keeps the boot contract single-sourced.
+  Same sibling-placement rationale as `validate-required-opts!`:
+  `streaming` and the `ring` façade both already require `lifecycle`,
+  so hosting the shared checks here avoids any circular-require between
+  the streaming sub-namespace and the façade.
+
   Per Spec 011 §Request storage substrate + §Head/meta contract.
 
   Note (audit rf2-cegm7 A2 / rf2-j54ee): the prior `on-create-with-request`
@@ -21,6 +41,8 @@
   forgot to destructure ended up with the request riding the unused-arg
   slot). Pre-alpha: one canonical surface, no fallback."
   (:require [re-frame.core :as rf]
+            [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.ssr.ring.trust :as trust]
             [re-frame.trace :as trace]))
 
 (set! *warn-on-reflection* true)
@@ -224,3 +246,57 @@
                      :reason   "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"
                      :recovery :no-recovery})))
   opts)
+
+(defn validate-construction-opts!
+  "Run the full fail-closed-at-boot validation triple shared by
+  `re-frame.ssr.ring/ssr-handler` AND
+  `re-frame.ssr.ring.streaming/stream-handler`. A misconfigured handler
+  MUST refuse to construct rather than fail per-request — the canonical
+  fail-closed pattern (rf2-gtgf9). The three checks:
+
+    1. required-opt presence (`:on-create` / `:root-view`) via
+       `validate-required-opts!` — a streaming handler built without
+       `:on-create` would otherwise fail per-request inside
+       `setup-request-frame!`; one without `:root-view` would fail inside
+       the writer thread, truncating the chunked response (rf2-ee38b.11).
+    2. hydration-payload policy (`:payload-keys` / `:payload-policy`) via
+       `payload-policy/validate-policy-opts!` — throws
+       `:rf.error/ssr-missing-payload-policy` (or
+       `:rf.error/ssr-unknown-payload-policy` on a typo'd policy) per
+       rf2-gtgf9.
+    3. trusted-shell-hook shape (`:head` / `:body-end` / `:script-src` /
+       `:app-element-id` are strings or nil) via
+       `trust/validate-trusted-shell-opts!` — both shells inject these
+       RAW into the HTML envelope, so a structural mistake (map / vector
+       / symbol / number) surfaces here as
+       `:rf.error/ssr-trusted-shell-opt-invalid` at boot rather than as a
+       `ClassCastException` deep in the rendering path (rf2-o6ndb).
+
+  Returns `opts` unchanged on success — composes into a `let` /
+  threading position cleanly."
+  [opts]
+  (validate-required-opts! opts)
+  (payload-policy/validate-policy-opts! opts)
+  (trust/validate-trusted-shell-opts! opts))
+
+(defn resolve-on-error
+  "Resolve the effective `:on-error` Ring-fn from `raw-opts`. Shared by
+  `ssr-handler` AND `stream-handler` so the rf2-c1tac precedence lives
+  in one place. Precedence:
+
+    1. caller-supplied `:on-error`      — full Ring-fn override; used verbatim.
+    2. caller-supplied `:on-error-fallback` — `{:body … :content-type …}`
+       template; built into a default-shaped fn via
+       `make-default-on-error`. The fn ignores the throwable (rf2-kzvwq
+       no-leak contract preserved).
+    3. neither                          — host-locked `default-on-error`
+       (\"Internal error\" plaintext).
+
+  Per rf2-c1tac — splits the templatable-default case from the full-
+  override case so callers can swap the body string without writing a
+  Ring fn AND without inheriting the `.getMessage` topology-leak risk."
+  [{:keys [on-error on-error-fallback]}]
+  (cond
+    on-error          on-error
+    on-error-fallback (make-default-on-error on-error-fallback)
+    :else             default-on-error))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -44,11 +44,9 @@
   (:require [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.html-helpers :as html]
-            [re-frame.ssr.payload-policy :as payload-policy]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.pipeline :as pipeline]
             [re-frame.ssr.ring.shell :as shell]
-            [re-frame.ssr.ring.trust :as trust]
             [re-frame.ssr.streaming :as streaming]
             [re-frame.trace :as trace])
   (:import [java.io PipedInputStream PipedOutputStream OutputStream]
@@ -216,42 +214,26 @@
 
     (fn handler [ring-request] ring-response)"
   [raw-opts]
-  ;; Construction-time validation — identical fail-closed-at-boot
-  ;; contract as `ssr-handler`'s `validate-handler-opts!`. A
-  ;; misconfigured streaming handler MUST refuse to construct, not fail
-  ;; per-request (missing :on-create → per-request 500; missing
-  ;; :root-view → silently-truncated chunked response from the writer
-  ;; thread). The three checks are the same ones the non-streaming
-  ;; handler runs:
-  ;;   - required-opt presence (:on-create / :root-view) per rf2-gtgf9,
-  ;;     shared via `lifecycle/validate-required-opts!`,
-  ;;   - hydration-payload policy (:payload-keys / :payload-policy) per
-  ;;     rf2-gtgf9 — throws `:rf.error/ssr-missing-payload-policy`,
-  ;;   - the four trusted-shell-hook opts are strings (or nil) per
-  ;;     rf2-o6ndb — the streaming prefix/suffix injects these RAW into
-  ;;     the HTML envelope, same trust contract as the non-streaming
-  ;;     `default-html-shell`. Throws
-  ;;     `:rf.error/ssr-trusted-shell-opt-invalid` on a structural
-  ;;     mistake (map / vector / symbol / number).
-  (lifecycle/validate-required-opts! raw-opts)
-  (payload-policy/validate-policy-opts! raw-opts)
-  (trust/validate-trusted-shell-opts! raw-opts)
+  ;; Construction-time validation — the SAME fail-closed-at-boot triple
+  ;; `ssr-handler` runs, shared via `lifecycle/validate-construction-opts!`
+  ;; so both handlers refuse to construct at the same boundary. For
+  ;; streaming specifically, a missing :on-create would otherwise fail
+  ;; per-request (500) and a missing :root-view would silently truncate
+  ;; the chunked response from the writer thread; the four trusted-shell
+  ;; opts are injected RAW by the streaming prefix/suffix, same trust
+  ;; contract as the non-streaming `default-html-shell`. See
+  ;; `validate-construction-opts!` for the per-check rationale.
+  (lifecycle/validate-construction-opts! raw-opts)
   ;; Mirror ssr-handler's defaults so streaming and non-streaming
   ;; handlers feel symmetric to callers. `:on-error` resolves the same
-  ;; way (rf2-c1tac): caller's `:on-error` wins, then
-  ;; `:on-error-fallback {:body … :content-type …}` is templated through
-  ;; `lifecycle/make-default-on-error`, then the locked
-  ;; `lifecycle/default-on-error` (rf2-kzvwq topology-leak contract).
-  (let [resolved-on-error
-        (cond
-          (:on-error raw-opts)          (:on-error raw-opts)
-          (:on-error-fallback raw-opts) (lifecycle/make-default-on-error
-                                          (:on-error-fallback raw-opts))
-          :else                         lifecycle/default-on-error)
-        opts        (-> (merge {:emit-hash?   true
+  ;; way via the shared `lifecycle/resolve-on-error` (rf2-c1tac): caller's
+  ;; `:on-error` wins, then `:on-error-fallback {:body … :content-type …}`
+  ;; is templated through `make-default-on-error`, then the locked
+  ;; `default-on-error` (rf2-kzvwq topology-leak contract).
+  (let [opts        (-> (merge {:emit-hash?   true
                                 :content-type "text/html; charset=utf-8"}
                                raw-opts)
-                        (assoc :on-error resolved-on-error))
+                        (assoc :on-error (lifecycle/resolve-on-error raw-opts)))
         {:keys [on-error content-type]} opts]
     (fn ring-handler [request]
       (let [{:keys [frame-id short-circuit]}


### PR DESCRIPTION
Per-slice duplication-reduction pass over `implementation/ssr-ring/` (epic rf2-jkake, bead rf2-jkake.14). Scope: ssr-ring src only; behaviour-preserving.

## Consolidations

Two construction-time contracts that `ssr-handler` (ring.clj) and `stream-handler` (streaming.clj) carried in two places are folded into `re-frame.ssr.ring.lifecycle` — the ns that already hosts the shared `validate-required-opts!` / `make-default-on-error` / `default-on-error` pieces they compose:

1. **`validate-construction-opts!`** — the fail-closed-at-boot validation triple (`validate-required-opts!` + `payload-policy/validate-policy-opts!` + `trust/validate-trusted-shell-opts!`). Was `validate-handler-opts!` in ring.clj and three inline calls in streaming.clj (whose own comment described it as "identical … contract as ssr-handler's validate-handler-opts!").
2. **`resolve-on-error`** — the rf2-c1tac `:on-error` / `:on-error-fallback` / locked-`default-on-error` precedence. Was a private fn in ring.clj and a byte-for-byte inline `cond` in streaming.clj.

Both handlers now call the single source. `ring.clj` and `streaming.clj` drop their now-unused direct `payload-policy` / `trust` requires (those move behind the lifecycle helper). No circular-require introduced — `lifecycle` picks up `trust` (requires only clojure.string) and `payload-policy` (in the sibling `ssr` artefact), neither of which depends back on `lifecycle`.

## Behaviour / public API

Unchanged. Same error keywords (`:rf.error/ssr-ring-missing-*`, `:rf.error/ssr-missing-payload-policy`, `:rf.error/ssr-unknown-payload-policy`, `:rf.error/ssr-trusted-shell-opt-invalid`), same precedence, same boot-vs-request failure timing. Public surface (`ssr-handler`, `ssr-middleware`, `stream-handler`, `cookie->set-cookie-header`, `default-html-shell`, the re-exported `default-on-error` / `make-default-on-error`) and the `:rf.ssr/*` / `:rf.error/*` reserved vocab are stable.

## Quality gates

- ssr-ring JVM `clojure -M:test`: 76 tests, 364 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 5094 tests, 17225 assertions, 0 failures, 0 errors
- clj-kondo on the 3 changed files: 0 errors, 0 new warnings (3 pre-existing unused-binding warnings in `run-streaming-writer!`, verified identical at baseline — untouched by this change)