### PR TITLE
refactor(ssr): reduce duplication (rf2-jkake.13)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -304,6 +304,23 @@
   [headers name value]
   (conj (vec headers) [(str name) value]))
 
+(defn- warn-on-multiple-writes!
+  "Emit `warning-id` (a `:rf.warning/multiple-*` trace) when more than one
+  write to the last-write-wins slot recorded under `writes-key` has landed
+  on `resp`. `final-key` (`:final-status` / `:final-redirect`) names the
+  tag the consumer reads the winning write off. Shared by `set-status-fx`,
+  `redirect-fx`, and `safe-redirect-fx` — all three record every write for
+  the multi-write policy and warn on the second-and-later one while
+  preserving last-write-wins for the public slot."
+  [resp writes-key warning-id final-key frame]
+  (let [writes (get resp writes-key)]
+    (when (and resp (> (count writes) 1))
+      (trace/emit! :warning warning-id
+                   {:writes   writes
+                    final-key (last writes)
+                    :frame    frame
+                    :recovery :warned-and-replaced}))))
+
 ;; ---- handler fns for the six :rf.server/* fxs ----------------------------
 
 (defn set-status-fx
@@ -316,13 +333,8 @@
                  (-> r
                      (update status-writes-key (fnil conj []) status)
                      (assoc :status status))))]
-    (when (and resp (> (count (get resp status-writes-key)) 1))
-      (let [writes (get resp status-writes-key)]
-        (trace/emit! :warning :rf.warning/multiple-status-set
-                     {:writes       writes
-                      :final-status (last writes)
-                      :frame        frame
-                      :recovery     :warned-and-replaced})))))
+    (warn-on-multiple-writes! resp status-writes-key
+                              :rf.warning/multiple-status-set :final-status frame)))
 
 (defn set-header-fx
   "Handler fn for `:rf.server/set-header`. Replaces any existing header
@@ -416,13 +428,8 @@
                      ;; the redirect status on the wire even if no
                      ;; explicit :rf.server/set-status fired.
                      (assoc :status status))))]
-    (when (and resp (> (count (get resp redirect-writes-key)) 1))
-      (let [writes (get resp redirect-writes-key)]
-        (trace/emit! :warning :rf.warning/multiple-redirects
-                     {:writes         writes
-                      :final-redirect (last writes)
-                      :frame          frame
-                      :recovery       :warned-and-replaced})))))
+    (warn-on-multiple-writes! resp redirect-writes-key
+                              :rf.warning/multiple-redirects :final-redirect frame)))
 
 ;; ---- :rf.server/safe-redirect (rf2-zfm8v) --------------------------------
 ;;
@@ -625,10 +632,6 @@
                                          ;; Spec 011 §Redirect precedence step 1:
                                          ;; status flows through.
                                          (assoc :status final-status))))]
-                (when (and resp (> (count (get resp redirect-writes-key)) 1))
-                  (let [writes (get resp redirect-writes-key)]
-                    (trace/emit! :warning :rf.warning/multiple-redirects
-                                 {:writes         writes
-                                  :final-redirect (last writes)
-                                  :frame          frame
-                                  :recovery       :warned-and-replaced})))))))))))
+                (warn-on-multiple-writes! resp redirect-writes-key
+                                          :rf.warning/multiple-redirects
+                                          :final-redirect frame)))))))))


### PR DESCRIPTION
Per-slice duplication-reduction review of `implementation/ssr/` (epic rf2-jkake, bead rf2-jkake.13). Conservative pass — consolidate only where it makes the slice clearer.

## What changed

One consolidation in `re-frame.ssr.response`. The three `:rf.server/*` last-write-wins fxs each inlined a near-identical "warn on the second-and-later write" block:

- `set-status-fx` → `:rf.warning/multiple-status-set` (tag `:final-status`)
- `redirect-fx` → `:rf.warning/multiple-redirects` (tag `:final-redirect`)
- `safe-redirect-fx` → `:rf.warning/multiple-redirects` (tag `:final-redirect`)

The two redirect copies were verbatim; the status copy differed only in the writes-key, warning-id, and the `:final-*` tag-key name. Folded into one `^:private warn-on-multiple-writes!` helper parameterised by those three values. The multi-write policy intent is now named in one place.

## Behaviour / public API

Unchanged. Same warning ids, same `:final-status` / `:final-redirect` tag keys (both asserted by `ssr_end_to_end_test`), same last-write-wins semantics, same `:warned-and-replaced` recovery. No `:rf.ssr/*` / `:rf.server/*` reserved vocab touched — only an internal helper added. The rest of the slice (already heavily deduped by rf2-x7g10 html-helpers split, rf2-8wrzz.4 payload unification, rf2-i3qc0 test fixture, the suspense-template extraction) had no further beneficial consolidation; intentional sibling structures (the streaming walker vs the non-streaming emitter per rf2-muasb) were left as documented.

## Quality gates

- ssr JVM `clojure -M:test`: 238 tests / 818 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 5094 tests / 17225 assertions, 0 failures, 0 errors
- clj-kondo on changed file: 0 errors (the lone `unused binding loc` warning at line ~493 pre-exists in `parse-url-safely`'s CLJS branch, untouched here)

Closes rf2-jkake.13.