### PR TITLE
refactor(core): reduce duplication (rf2-jkake.1)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -60,15 +60,16 @@
 (def ^:private cofx-runs-on-platform? fx/runs-on-platform?)
 
 (defn- active-platform-for-frame
-  "Resolve the active platform for a cofx injection. Mirrors the resolution
-  in `router/run-fx-effects!`: the frame's `:config :platform` override (set
-  by the `:ssr-server` preset, or any user-supplied frame config) takes
-  precedence over the host-wide platform marker (`interop/active-platform`,
-  toggled via `re-frame.core/init-platform`)."
+  "Resolve the active platform for a cofx injection from a frame-id.
+  Resolves the frame record, then defers to the shared per-frame
+  platform resolution `fx/platform-for-frame-record` (the same kernel
+  `router/run-fx-effects!` uses on its already-resolved record): the
+  frame's `:config :platform` override (set by the `:ssr-server` preset,
+  or any user-supplied frame config) takes precedence over the host-wide
+  platform marker (`interop/active-platform`, toggled via
+  `re-frame.core/init-platform`)."
   [frame-id]
-  (or (when frame-id
-        (-> (frame/frame frame-id) :config :platform))
-      (interop/active-platform)))
+  (fx/platform-for-frame-record (when frame-id (frame/frame frame-id))))
 
 (defn- maybe-validate-cofx!
   "Per Spec 010 §Validation order step 2 (rf2-7leq) — after the cofx

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -124,6 +124,22 @@
   (let [platforms (:platforms meta #{:client :server})]
     (contains? platforms active-platform)))
 
+(defn platform-for-frame-record
+  "Resolve the active platform for a frame given its (already-resolved)
+  frame record. The frame's `:config :platform` override (set by the
+  `:ssr-server` preset, or any user-supplied frame config) takes
+  precedence over the host-wide platform marker
+  (`interop/active-platform`, toggled via `re-frame.core/init-platform`).
+
+  Single definition of the per-frame platform resolution shared by the
+  router's `:fx` walk (`router/run-fx-effects!`) and the cofx injector
+  (`cofx/active-platform-for-frame`, which resolves the record from a
+  frame-id first). Both sites previously inlined the identical
+  `(or (-> rec :config :platform) (interop/active-platform))` kernel."
+  [frame-record]
+  (or (-> frame-record :config :platform)
+      (interop/active-platform)))
+
 ;; ---- do-fx ----------------------------------------------------------------
 
 (declare dispatch-fx-handler)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -894,8 +894,7 @@
   set of optionals."
   [effects frame frame-record fx-overrides envelope]
   (when-let [fx-vec (:fx effects)]
-    (let [active-platform (or (-> frame-record :config :platform)
-                              (interop/active-platform))
+    (let [active-platform (fx/platform-for-frame-record frame-record)
           event           (:event envelope)]
       (fx/do-fx frame fx-vec active-platform
                 {:overrides       fx-overrides


### PR DESCRIPTION
## Summary

Duplication-reduction pass over `implementation/core/` (rf2-jkake.1, child of the per-slice dedup epic rf2-jkake). Core is already heavily factored from prior passes (the emit-substrate trio, the `defwrapper` artefact macro, `late-bind/require-fn!` / `substrate.adapter/require-adapter!` error-shape choke points, the shared atom-container quartet, `fx/runs-on-platform?` aliased into cofx). One genuine, clarity-improving consolidation remained and is applied here; everything else was reviewed and deliberately left as clearer-inline.

## Consolidation

The per-frame active-platform resolution kernel

```clojure
(or (-> frame-record :config :platform) (interop/active-platform))
```

was inlined identically in two places, with cofx even carrying a comment "Mirrors the resolution in `router/run-fx-effects!`":

- `cofx/active-platform-for-frame` (resolves the record from a frame-id)
- `router/run-fx-effects!` (already holds the resolved record)

Extracted into a single `fx/platform-for-frame-record`, placed next to the existing shared `fx/runs-on-platform?` platform-policy predicate (the natural home — `fx` already owns the platform-policy cluster and is already required by both `cofx` and `router`; it needs only `interop`, which it already requires, so no new dependency edge). The cross-reference comment is now resolved with actual shared code.

## Reviewed and deliberately left as-is (noted, not actioned)

- **event-emit / error-emit listener-registry boilerplate** — the `defonce listeners` + `make-listener-registry` + 3 `def`s pattern repeats across the two siblings, but the shared structure already lives in `emit-substrate/make-listener-registry`; the residual per-`def` shells carry distinct normative-facing docstrings and record shapes. Extracting further would obscure.
- **registrar `:rf.registry/handler-cleared` emit sites** (`unregister!` / `clear-kind!`) — the registrar's own comment block explains the `(when interop/debug-enabled? ...)` gate + literal op-keyword MUST stay at each call site for the Closure elision-probe sentinels; a helper would move the literal behind an unconditional call and defeat elision. Left as-is by design.
- **warn-once caches** (registrar `missing-doc-warned`/`collision-warned`, views.warn-once's two caches) — each has bespoke keying/clearing semantics and distinct docstrings; the "mirrors the warn-once pattern" relationship is a documented convention, not shared code worth extracting.

Cross-slice dedup: none actioned (out of scope for this slice-only bead).

## Quality gates

- Core JVM `clojure -M:test` — **808 tests, 3595 assertions, 0 failures, 0 errors**
- Full cross-artefact `npm run test:cljs` (the ripple detector) — **5094 tests, 17225 assertions, 0 failures, 0 errors**
- clj-kondo on changed files — **0 errors**, no new warnings (4 pre-existing unused-binding warnings in `router.cljc`, all unrelated to the change site, confirmed present on base)

## Surface-stability confirmation

No public API (`rf/*`), reserved vocab (`:rf/*`, `:rf.cofx/*`, `:rf.fx/*`, `:rf.error/*`, …), `*`-suffix macro/fn pair, or late-bind hook key was changed. `cofx/active-platform-for-frame` stays private; the new `fx/platform-for-frame-record` is an internal helper. Behaviour is byte-identical: a nil frame-id yields a nil record, and `(-> nil :config :platform)` falls through to `(interop/active-platform)` exactly as the prior `(or (when frame-id ...) ...)` form did.