### PR TITLE
test(flows): coverage & rigour pass (rf2-ynjts.8)

### DIFF
--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -139,6 +139,71 @@
         (is (not (contains? db-after :step-2))
             "no spurious `:step-2 nil` parent was created")))))
 
+(deftest clear-flow-noop-dissoc-does-not-rewrite-the-container
+  ;; Regression for rf2-2vpac. `clear-flow` skips `replace-container!`
+  ;; when the dissoc branch was a no-op (the slot was never materialised
+  ;; / already absent). Without the guard, clearing an absent slot would
+  ;; install a value-equal-but-fresh db reference and trigger a needless
+  ;; O(n) reactive sub-graph invalidation walk — costly during teardown,
+  ;; where clearing absent slots is common.
+  ;;
+  ;; The value-equality test above (`...before-first-compute...`) proves
+  ;; the db VALUE is unchanged; this test proves the db REFERENCE is
+  ;; unchanged — i.e. the container was not rewritten at all. On the JVM
+  ;; persistent maps are immutable, so two `get-frame-db` reads return the
+  ;; IDENTICAL object iff no `replace-container!` ran between them.
+  ;; Precondition for the no-op branch: the flow's `:path` must never be
+  ;; materialised. We seed app-db FIRST, then register the flow, then
+  ;; clear it WITHOUT ever dispatching — so its `:output` never runs and
+  ;; its `:path` slot stays absent. (Driving a drain would compute the
+  ;; flow and materialise the slot, turning the clear into a real dissoc.)
+  (testing "clearing a never-materialised nested-path flow leaves the app-db container reference identical (no rewrite, no sub-cache invalidation)"
+    (rf/reg-event-db :seed (fn [_ _] {:other 1}))
+    (rf/dispatch-sync [:seed])
+    (rf/reg-flow {:id     :pending
+                  :inputs [[:n]]
+                  :output (fn [_] "never-runs")
+                  :path   [:step-2 :result]})
+    (let [db-ref-before (rf/get-frame-db :rf/default)]
+      (rf/clear-flow :pending)
+      (let [db-ref-after (rf/get-frame-db :rf/default)]
+        (is (identical? db-ref-before db-ref-after)
+            "the app-db container reference is UNCHANGED — clear-flow skipped replace-container! for the no-op dissoc (rf2-2vpac)"))))
+  (testing "clearing a single-element-path flow whose top-level key is absent also skips the rewrite"
+    ;; The length-1 branch (`(dissoc db (first path))`) is a no-op when the
+    ;; key is absent — `(identical? new-db db)` holds, so the guard skips
+    ;; the write here too. Same precondition: never drive the drain.
+    (rf/reg-event-db :seed2 (fn [_ _] {:other 1}))
+    (rf/dispatch-sync [:seed2])
+    (rf/reg-flow {:id     :absent-top
+                  :inputs [[:n]]
+                  :output (fn [_] "never-runs")
+                  :path   [:never-written]}) ;; single-element path, never materialised
+    (let [db-ref-before (rf/get-frame-db :rf/default)]
+      (rf/clear-flow :absent-top)
+      (is (identical? db-ref-before (rf/get-frame-db :rf/default))
+          "single-element absent key: container reference unchanged (no rewrite)")))
+  (testing "POSITIVE control — clearing a MATERIALISED slot DOES rewrite the container (guard must not over-suppress real clears)"
+    ;; The guard is `(when-not (identical? new-db db) (replace-container! ...))`.
+    ;; When the slot was actually written, the dissoc produces a NEW db
+    ;; reference, so the write MUST fire — otherwise the cleared value
+    ;; would linger in app-db and stale subs would never invalidate.
+    (rf/reg-event-db :seed3 (fn [_ _] {:rect {:w 3 :h 4}}))
+    (rf/reg-flow {:id     :area3
+                  :inputs [[:rect :w] [:rect :h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]})
+    (rf/dispatch-sync [:seed3])
+    (is (= 12 (get-in (rf/get-frame-db :rf/default) [:rect :area]))
+        "precondition: the flow materialised [:rect :area]")
+    (let [db-ref-before (rf/get-frame-db :rf/default)]
+      (rf/clear-flow :area3)
+      (let [db-ref-after (rf/get-frame-db :rf/default)]
+        (is (not (identical? db-ref-before db-ref-after))
+            "the container WAS rewritten — a real dissoc installs a fresh reference")
+        (is (not (contains? (get db-ref-after :rect) :area))
+            "and the leaf is gone from the installed value")))))
+
 (deftest clear-flow-non-map-intermediate-is-noop
   ;; Regression for rf2-q25os Repro 2. When an intermediate path step
   ;; holds a non-map value (e.g. someone wrote a scalar at `:step-2`
@@ -211,6 +276,41 @@
     (is (thrown? Throwable
                  (rf/reg-flow {:id :bad :inputs [[:n]]
                                :output identity :path :not-a-vec})))))
+
+(deftest reg-flow-missing-id-and-bad-output-carry-canonical-error-ids
+  ;; Companion to `reg-flow-error-carries-canonical-rf-error-id-slot`
+  ;; (which pins the :inputs / cycle discriminators) and the dedicated
+  ;; bad-inputs / bad-path tests. The two remaining `validate-flow`
+  ;; rules — `:rf.error/flow-missing-id` and `:rf.error/flow-bad-output`
+  ;; — had only bare `(thrown? Throwable ...)` coverage, so a regression
+  ;; that changed EITHER discriminator id (read by `:on-error` policies
+  ;; and Xray's error widget keyed on `:rf.error/id`, per Spec 009 §The
+  ;; thrown-error shape) would pass silently. Pin both ids + the
+  ;; canonical shape slots so the table's discriminator coverage is
+  ;; total.
+  (testing "a flow with no :id throws :rf.error/flow-missing-id"
+    (let [ex   (try (rf/reg-flow {:inputs [[:n]] :output identity :path [:x]})
+                    (catch Throwable t t))
+          data (ex-data ex)]
+      (is (some? ex) "registration threw")
+      (is (= :rf.error/flow-missing-id (:rf.error/id data))
+          ":rf.error/id carries the missing-id discriminator")
+      (is (= ":rf.error/flow-missing-id" (ex-message ex))
+          "message string is the stringified discriminator kw")
+      (is (= 'rf/reg-flow (:where data))     ":where names the user-facing surface")
+      (is (= :fix-registration (:recovery data)) ":recovery names the disposition")
+      (is (string? (:reason data))           ":reason is a human-readable sentence")))
+  (testing "a flow whose :output is not a fn throws :rf.error/flow-bad-output"
+    (let [ex   (try (rf/reg-flow {:id :bad :inputs [[:n]] :output 42 :path [:x]})
+                    (catch Throwable t t))
+          data (ex-data ex)]
+      (is (some? ex) "registration threw")
+      (is (= :rf.error/flow-bad-output (:rf.error/id data))
+          ":rf.error/id carries the bad-output discriminator")
+      (is (= ":rf.error/flow-bad-output" (ex-message ex))
+          "message string is the stringified discriminator kw")
+      (is (= 'rf/reg-flow (:where data))     ":where names the user-facing surface")
+      (is (= :fix-registration (:recovery data)) ":recovery names the disposition"))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1b. validate-flow well-formedness (rf2-gnl7q)

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -316,7 +316,42 @@
         (is (= :double             (:flow-id tags)))
         (is (= :inputs-value-equal (:reason tags))
             ":reason names the suppression cause (rf2-719e value-equal recompute suppression)")
-        (is (= :rf/default         (:frame tags)))))))
+        (is (= :rf/default         (:frame tags)))
+        ;; Per rf2-931pm: `:input-paths-unchanged` names every input
+        ;; db-path whose value was `=` to the previous run — the cascade
+        ;; DAG consumer reads this to render the "considered, no recompute"
+        ;; branch dimmed. For a value-equal skip every input is by
+        ;; definition unchanged, so the tag carries the FULL input-path
+        ;; vector (the flow's `:inputs`). Pin both the key's presence and
+        ;; its full-vector shape so a regression that drops it, ships a
+        ;; partial vector, or renames the key surfaces here.
+        (is (contains? tags :input-paths-unchanged)
+            ":input-paths-unchanged key present on every :rf.flow/skip trace")
+        (is (= [[:n]] (:input-paths-unchanged tags))
+            ":input-paths-unchanged carries the flow's full :inputs vector (every input unchanged on a value-equal skip)")))))
+
+(deftest flow-skip-input-paths-unchanged-names-all-inputs
+  (testing "Per rf2-931pm: a multi-input flow's :rf.flow/skip carries the
+            FULL :inputs vector under :input-paths-unchanged (not a single
+            path, not a truncated subset)"
+    ;; Two distinct input paths. On a value-equal rewrite the cascade-DAG
+    ;; consumer must learn BOTH inputs were considered-and-unchanged, so
+    ;; the tag must enumerate every declared input path.
+    (rf/reg-event-db :init       (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-event-db :rewrite-wh (fn [db [_ w h]] (assoc db :w w :h h)))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]})
+    (rf/dispatch-sync [:init])
+    (reset! *captured* [])
+    ;; Rewrite both inputs with their SAME values → value-equal skip.
+    (rf/dispatch-sync [:rewrite-wh 3 4])
+    (let [skips (by-op :rf.flow/skip)]
+      (is (= 1 (count skips)) "the value-equal rewrite produced one skip")
+      (let [tags (:tags (first skips))]
+        (is (= [[:w] [:h]] (:input-paths-unchanged tags))
+            ":input-paths-unchanged enumerates BOTH declared input paths in order")))))
 
 (deftest flow-skip-then-computed-on-real-change
   (testing "skip fires on equal rewrite; subsequent real change fires :rf.flow/computed"


### PR DESCRIPTION
## Quality gates

| Gate | Before | After |
|------|--------|-------|
| flows JVM `clojure -M:test` | 117 tests / 489 assertions, 0 fail | 120 tests / 509 assertions, 0 fail |
| `npm run test:cljs` | green | 5094 tests / 17225 assertions, 0 fail |
| clj-kondo (changed files) | — | 0 errors, 0 warnings |

Bead: rf2-ynjts.8 (parent epic rf2-ynjts — testing coverage & rigour sweep).

## Assessment

The `implementation/flows/` suite is already exceptionally strong — 9 test files spanning registration/validation, dirty-check, topological sort, hot-reload invalidation, fx-toggle, frame-scoping, destroy-frame teardown, an 8-thread concurrency stress harness, late-bind-missing contracts, the full `:rf.flow/*` trace vocabulary, t1/t2 db-pending stamping, schema-output validation, CLJS prod elision, atomicity/failure semantics, AND a dedicated flow-`*.edn` conformance runner. No flaky, over-mocked, or tautological tests found. Coverage is broad and rigour is high (real outcome assertions, deterministic).

This is a **conservative** pass: three genuine gaps where a behaviour was implemented but never asserted.

## Gaps filled

1. **`:rf.flow/skip` `:input-paths-unchanged` tag (rf2-931pm).** The skip trace ships the full `:inputs` vector under `:input-paths-unchanged` (the cascade-DAG consumer reads it to dim the "considered, no recompute" branch). The existing skip test pinned only `:flow-id`/`:reason`/`:frame`. Strengthened `flow-skip-fires-on-value-equal-rewrite` to assert key-presence + full-vector shape, and added `flow-skip-input-paths-unchanged-names-all-inputs` for the multi-input case (proves the FULL ordered vector, not a single/truncated path).

2. **`validate-flow` discriminator ids.** The `bad-inputs` / `bad-path` / `cycle` discriminators were pinned by dedicated tests, but `:rf.error/flow-missing-id` and `:rf.error/flow-bad-output` had only bare `(thrown? Throwable ...)`. These ids feed `:on-error` policies and Xray's error widget keyed on `:rf.error/id` (Spec 009 §The thrown-error shape) — a regression renaming either would have passed silently. Added `reg-flow-missing-id-and-bad-output-carry-canonical-error-ids` pinning both ids + the canonical `:where`/`:recovery`/`:reason`/message slots.

3. **`clear-flow` no-op-write guard (rf2-2vpac).** `clear-flow` skips `replace-container!` when the dissoc is a no-op (slot never materialised / already absent), avoiding a needless O(n) reactive sub-graph invalidation walk — common during teardown. Existing tests proved the db VALUE unchanged but not that the write was skipped. Added `clear-flow-noop-dissoc-does-not-rewrite-the-container`, asserting app-db container REFERENCE identity (immutable persistent maps ⇒ identical iff no `replace-container!` ran) for the never-materialised nested-path and single-element-absent-key branches, plus a positive control proving a real (materialised) clear DOES rewrite — pinning both guard branches.

## No src behaviour changed

Test-only edits under `implementation/flows/test/`. Public API, the `:rf.flow/*` vocabulary, and all behaviour are unchanged.