### PR TITLE
test(story): coverage & rigour pass (rf2-ynjts.21)

### DIFF
--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -562,6 +562,117 @@
           "an event never dispatched does not appear on the tape → fail"))
     (story/destroy-variant! :story.ssot/dispatched)))
 
+;; ===========================================================================
+;; rf2-ynjts.21 — `dispatched-events` projection: the PRIVACY filter +
+;; the assertion-event exclusion (the two branches the behavioural
+;; `dispatched?-projects-from-tape-trigger-events` test above does not reach).
+;;
+;; `dispatched-events` is the SSOT for `:rf.assert/dispatched?` and the
+;; loaders' vector-form `:loaders-complete-when`. Its docstring (Spec 009
+;; §Privacy) makes two correctness promises beyond "project the trigger
+;; events in tape order":
+;;
+;;   1. PRIVACY: the `:trigger-event` of an epoch flagged
+;;      `:rf.epoch/sensitive?` is DROPPED while `:rf.privacy/show-sensitive?`
+;;      is off, so a sensitive event vector never lands raw on an assertion
+;;      record's `:actual` (which serialises into the test-mode pane, MCP
+;;      `read-assertions`, and JSON-log egress). With the flag ON, sensitive
+;;      trigger-events pass through.
+;;   2. ASSERTION-EVENT EXCLUSION: an `[:assert …]` checkpoint dispatches its
+;;      wrapped `:rf.assert/*` atom, committing an epoch whose `:trigger-event`
+;;      is that verdict — NOT behaviour-under-test. Those are excluded so a
+;;      `[:rf.assert/dispatched? :rf.assert/path-equals]` can never falsely
+;;      pass on a verdict the runner itself dispatched.
+;;
+;; Both are PURE projection branches over the tape, so the tests inject a
+;; synthetic tape through the private `frame-tape` var (the established
+;; `@#'` / `with-redefs` idiom in this file) — deterministic, host-free, no
+;; live dispatch needed. `set-show-sensitive!` is restored in a `finally`
+;; so the flag cannot poison a sibling test (the fixture does not reset it).
+;; ===========================================================================
+
+(defn- with-show-sensitive
+  "Run `thunk` with the `:rf.privacy/show-sensitive?` flag bound to `flag`,
+  restoring the prior value afterwards (the assertions fixture does not
+  reset the flag, so a `set-show-sensitive!` must be unwound by hand)."
+  [flag thunk]
+  (let [prev (config/get-show-sensitive)]
+    (config/set-show-sensitive! flag)
+    (try (thunk)
+         (finally (config/set-show-sensitive! prev)))))
+
+(defn- with-tape
+  "Run `thunk` with the private `frame-tape` projection redefed to return
+  `tape` for any frame (`with-redefs-fn` takes the `#'`-var directly, so a
+  private fn in another ns is redefable without importing it)."
+  [tape thunk]
+  (with-redefs-fn {#'assertions/frame-tape (constantly tape)} thunk))
+
+(deftest dispatched-events-drops-sensitive-trigger-when-flag-off
+  (testing "an epoch flagged :rf.epoch/sensitive? has its :trigger-event
+            DROPPED while show-sensitive? is off (Spec 009 §Privacy) — a
+            sensitive event vector must not reach an assertion record's
+            :actual"
+    ;; A two-epoch tape: one ordinary, one carrying a sensitive payload.
+    (let [tape [{:trigger-event [:auth/login]}
+                {:trigger-event [:auth/submit {:password "hunter2"}]
+                 :rf.epoch/sensitive? true}]]
+      (with-tape tape
+        (fn []
+          (with-show-sensitive false
+            (fn []
+              (let [events (assertions/dispatched-events :any-frame)]
+                (is (= [[:auth/login]] events)
+                    "the sensitive epoch's trigger-event is filtered out — only
+                     the non-sensitive event projects")
+                (is (not-any? #(= :auth/submit (first %)) events)
+                    "the sensitive payload [:auth/submit {:password …}] never
+                     appears in the projection")))))))))
+
+(deftest dispatched-events-keeps-sensitive-trigger-when-flag-on
+  (testing "with show-sensitive? ON the sensitive epoch's :trigger-event
+            PASSES THROUGH — the operator opted in (Spec 009 §Privacy)"
+    (let [tape [{:trigger-event [:auth/login]}
+                {:trigger-event [:auth/submit {:password "hunter2"}]
+                 :rf.epoch/sensitive? true}]]
+      (with-tape tape
+        (fn []
+          (with-show-sensitive true
+            (fn []
+              (let [events (assertions/dispatched-events :any-frame)]
+                (is (= [[:auth/login] [:auth/submit {:password "hunter2"}]] events)
+                    "both trigger-events project when the flag is on — the drop
+                     is gated on the flag, not unconditional")))))))))
+
+(deftest dispatched-events-excludes-assertion-trigger-events
+  (testing "an :rf.assert/* trigger-event is EXCLUDED — a verdict the runner
+            dispatched is not behaviour-under-test, so [:rf.assert/dispatched?
+            <an-assertion-id>] can never falsely pass on it"
+    ;; A tape mixing real behaviour with the assertion-checkpoint epochs the
+    ;; runner commits when it dispatches each [:assert …] atom.
+    (let [tape [{:trigger-event [:cart/add-item {:sku "A"}]}
+                {:trigger-event [:rf.assert/path-equals [:cart] {}]}
+                {:trigger-event [:cart/checkout]}
+                {:trigger-event [:rf.assert/dispatched? [:cart/add-item]]}]]
+      (with-tape tape
+        (fn []
+          (with-show-sensitive false
+            (fn []
+              (let [events (assertions/dispatched-events :any-frame)]
+                (is (= [[:cart/add-item {:sku "A"}] [:cart/checkout]] events)
+                    "only the two real events project; both :rf.assert/* verdict
+                     trigger-events are dropped")
+                (is (not-any? #(= "rf.assert" (namespace (first %))) events)
+                    "no :rf.assert/* head survives the projection")))))))))
+
+(deftest dispatched-events-empty-on-host-free-tape
+  (testing "an empty tape (a production Story jar / host without the epoch
+            artefact, where the late-bound facade degrades to []) projects
+            no events — the host-free floor, not a throw"
+    (with-tape []
+      (fn []
+        (is (= [] (assertions/dispatched-events :any-frame)))))))
+
 (deftest effect-emitted-projects-from-tape-effects
   (testing ":rf.assert/effect-emitted reads the epoch-tape :effects projection
             (the SSOT) for a real (non-stubbed) user fx"


### PR DESCRIPTION
Testing coverage & rigour review of `tools/story/` (rf2-ynjts.21, epic rf2-ynjts).

## Quality gates

| Gate | Before | After |
|------|--------|-------|
| `tools/story` JVM `clojure -M:test` | 1548 tests / 5778 assertions, 0F/0E | 1552 tests / 5784 assertions, 0F/0E |
| `implementation/` `npm run test:cljs` | green | 5094 tests / 17225 assertions, 0F/0E |
| clj-kondo (changed file) | — | 0 errors, 0 warnings |

Net new: +4 tests, +6 assertions. **No src behaviour changed** (`git diff tools/story/src/` is empty).

## Review finding

The `tools/story/` suite is large (200+ test files) and already rigorous: the bead's named focus areas — `result`, `determinism`, `db-seed`, `sub-overrides`, registrar query/memoisation, the unified run-result + agreement floor — are strongly covered with behaviour-asserting, deterministic tests (including documented false-GREEN/false-RED regression guards). No flaky, over-mocked, or tautological tests were found.

One genuine gap: **`re-frame.story.assertions/dispatched-events` has two correctness branches with no direct test.** The existing behavioural test (`dispatched?-projects-from-tape-trigger-events`) only exercises the happy projection path; it never reaches:

1. **The Spec 009 §Privacy filter** — the `:trigger-event` of an epoch flagged `:rf.epoch/sensitive?` is dropped while `:rf.privacy/show-sensitive?` is off, and passes through when on. This is a real data-leak boundary: a dropped filter would surface a sensitive event vector on an assertion record's `:actual`, which serialises into the test-mode pane, MCP `read-assertions`, and JSON-log egress. The sibling `sensitive-trace-cljs-test` covers the *play-runner listener* egress seam — a different capture path — not this projection's own filter.
2. **The assertion-event exclusion** — `:rf.assert/*` verdict trigger-events are excluded (a verdict the runner dispatched is not behaviour-under-test), so `[:rf.assert/dispatched? <an-assertion-id>]` can never falsely pass on a verdict the runner itself committed.

## What the new tests cover

`re_frame/story_assertions_test.clj`, four deterministic JVM unit tests over a synthetic epoch tape injected through the private `frame-tape` var via `with-redefs-fn` (the `@#'`/with-redefs idiom already established in this file). `show-sensitive?` is restored in a `finally` so it cannot poison sibling tests (the fixture does not reset it).

- `dispatched-events-drops-sensitive-trigger-when-flag-off` — sensitive `:trigger-event` filtered out; sensitive payload never appears.
- `dispatched-events-keeps-sensitive-trigger-when-flag-on` — both events project when the operator opts in (drop is flag-gated, not unconditional).
- `dispatched-events-excludes-assertion-trigger-events` — `:rf.assert/*` verdict trigger-events dropped; only real behaviour projects.
- `dispatched-events-empty-on-host-free-tape` — an empty tape (production jar / no epoch artefact) projects `[]`, not a throw.

**Mutation-verified:** stripping either filter from `dispatched-events` fails exactly these tests (4 failures), confirming they assert real outcomes rather than passing vacuously. Source restored byte-identical afterward.

Closes rf2-ynjts.21.