### PR TITLE
test(ssr): coverage & rigour pass (rf2-ynjts.13)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -311,3 +311,131 @@
             the fragment head working: children splice with no wrapper."
     (is (= "<p>a</p><p>b</p>"
            (emit/render-to-string [:<> [:p "a"] [:p "b"]] {})))))
+
+;; ===========================================================================
+;; rf2-ynjts.13 — emit-element scalar-child branches (emit.cljc:319-323).
+;; The strip-prop / raw-text / tag-name security gates are well covered, but
+;; the load-bearing scalar emission rules — number stringifies, boolean is
+;; DROPPED, nil is dropped, string is escaped — had no direct behaviour
+;; assertion. These are the leaf rules every render bottoms out at; a
+;; regression (e.g. booleans accidentally stringifying to "true") would
+;; corrupt every server-rendered page and slip past the existing tests.
+;; ===========================================================================
+
+(deftest render-to-string-number-child-stringifies
+  (testing "rf2-ynjts.13 — a number child renders as its `str` form, not
+            dropped, not escaped (emit-element number? branch)."
+    (is (= "<span>42</span>"
+           (emit/render-to-string [:span 42] {}))
+        "integer child stringifies")
+    (is (= "<span>3.14</span>"
+           (emit/render-to-string [:span 3.14] {}))
+        "double child stringifies")
+    (is (= "<p>count=7</p>"
+           (emit/render-to-string [:p "count=" 7] {}))
+        "a number sits inline alongside a string child")))
+
+(deftest render-to-string-boolean-child-is-dropped
+  (testing "rf2-ynjts.13 — a boolean CHILD emits nothing (emit-element
+            boolean? branch → \"\"). The ubiquitous
+            `[:div (when cond? [:p ...])]` shape yields `false`/`nil` for
+            the false arm; both must vanish, not render the word `true`/
+            `false`. Distinct from a boolean ATTR VALUE (which `attr-string`
+            renders as a bare attr name) — this is the child position."
+    (is (= "<div></div>"
+           (emit/render-to-string [:div true] {}))
+        "a lone `true` child is dropped")
+    (is (= "<div></div>"
+           (emit/render-to-string [:div false] {}))
+        "a lone `false` child is dropped")
+    (is (= "<div><p>shown</p></div>"
+           (emit/render-to-string [:div (when true [:p "shown"]) (when false [:p "hidden"])] {}))
+        "the false arm of a (when …) yields nil → dropped; the true arm renders")
+    (is (= "<p>ab</p>"
+           (emit/render-to-string [:p "a" true "b" false nil] {}))
+        "booleans + nil interleaved with strings drop, strings survive")))
+
+(deftest render-to-string-fn-headed-component
+  (testing "rf2-ynjts.13 — a fn-headed component `[component-fn & args]`
+            (emit-element fn? branch) is invoked with its args and its
+            returned hiccup is emitted. The streaming walker's fn-head path
+            is exercised indirectly elsewhere, but the non-streaming
+            emitter's fn-head branch had no direct assertion."
+    (let [greeting (fn [name] [:h1 "Hello, " name])]
+      (is (= "<h1>Hello, world</h1>"
+             (emit/render-to-string [greeting "world"] {}))
+          "the component fn is called with the trailing args; its hiccup emits"))
+    (testing "a fn-headed component nested as a child is resolved too"
+      (let [item (fn [label] [:li label])]
+        (is (= "<ul><li>a</li><li>b</li></ul>"
+               (emit/render-to-string [:ul [item "a"] [item "b"]] {}))
+            "fn-heads in child position resolve via emit-children → emit-element")))
+    (testing "a fn-headed component returning a string renders the string escaped"
+      (let [raw (fn [] "a < b")]
+        (is (= "<p>a &lt; b</p>"
+               (emit/render-to-string [:p [raw]] {}))
+            "the fn's string output flows back through escape-html")))))
+
+;; ===========================================================================
+;; rf2-ynjts.13 — escape-attr / escape-html asymmetry (html_helpers.cljc).
+;; A deliberate, security-relevant correctness invariant: text-node content
+;; escapes `< > & " '` (no raw-tag injection), but attribute VALUES escape
+;; ONLY `& "` because `<`/`>` are legal inside a double-quoted attribute
+;; value per the HTML5 parser. A regression that over-escaped attrs would
+;; corrupt legit values (e.g. a `content` meta carrying `a<b`); one that
+;; under-escaped text nodes would open an XSS. Pinned through the full
+;; `render-to-string` composition, not the helper in isolation.
+;; ===========================================================================
+
+(deftest render-to-string-text-node-escapes-all-five-entities
+  (testing "rf2-ynjts.13 — a text-node child escapes `& < > \" '` so no
+            raw markup or quote can break out of text position."
+    (is (= "<p>&amp;&lt;&gt;&quot;&#39;</p>"
+           (emit/render-to-string [:p "&<>\"'"] {}))
+        "all five escapable entities are rewritten in text position")
+    (is (= "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>"
+           (emit/render-to-string [:p "<script>alert(1)</script>"] {}))
+        "a literal <script> in text cannot inject a real tag")))
+
+(deftest render-to-string-attr-value-escapes-only-amp-and-quote
+  (testing "rf2-ynjts.13 — an attribute VALUE escapes only `&` and `\"`;
+            `<` / `>` / `'` are LEGAL inside a double-quoted attr value and
+            are emitted verbatim (HTML5 parser rule). This asymmetry with
+            text-node escaping is deliberate — over-escaping attrs corrupts
+            legit values."
+    (is (= "<div data-x=\"a&amp;b\"></div>"
+           (emit/render-to-string [:div {:data-x "a&b"}] {}))
+        "`&` in an attr value is escaped to &amp;")
+    (is (= "<div data-x=\"&quot;q&quot;\"></div>"
+           (emit/render-to-string [:div {:data-x "\"q\""}] {}))
+        "a double-quote in an attr value is escaped to &quot; (else it would
+         close the value)")
+    (is (= "<div data-x=\"a<b>c\"></div>"
+           (emit/render-to-string [:div {:data-x "a<b>c"}] {}))
+        "`<` and `>` are NOT escaped in an attr value — legal per HTML5")
+    (is (= "<div data-x=\"it's\"></div>"
+           (emit/render-to-string [:div {:data-x "it's"}] {}))
+        "a single-quote is NOT escaped — the value is double-quoted")))
+
+;; ===========================================================================
+;; rf2-ynjts.13 — boolean ATTR-VALUE branch through the full emitter
+;; (attr-string true → bare name; false/nil → omitted). The head emitter
+;; test pins async/defer, and ssr_attr_filter_test pins the helper in
+;; isolation, but the non-streaming body emitter's boolean-attr composition
+;; (the common `[:input {:disabled true :required false}]` shape) had no
+;; direct render-to-string assertion.
+;; ===========================================================================
+
+(deftest render-to-string-boolean-attr-values
+  (testing "rf2-ynjts.13 — `true` attr value → bare attribute name; `false`
+            and `nil` attr values → omitted entirely, through the full
+            render-to-string composition."
+    (is (= "<input disabled required>"
+           (emit/render-to-string [:input {:disabled true :required true}] {}))
+        "`true` boolean attrs emit as bare names on a void element")
+    (is (= "<input>"
+           (emit/render-to-string [:input {:disabled false :hidden nil}] {}))
+        "`false` and `nil` attrs are omitted — no bare name, no empty value")
+    (is (= "<button disabled>Go</button>"
+           (emit/render-to-string [:button {:disabled true :title nil} "Go"] {}))
+        "boolean + nil attrs compose on a non-void element alongside text")))

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -732,6 +732,105 @@
       (is (= :internal-error (:code public)))
       (is (some #(= :rf.error/sanitised-on-projection (:operation %)) @traces)))))
 
+;; ===========================================================================
+;; rf2-ynjts.13 — default-error-projector-fn pure-unit case-arm coverage.
+;; The end-to-end tests above drive :no-such-handler → 404 and
+;; :handler-exception → 500 through the live cascade, but the default
+;; projector fn's OTHER two enumerated arms — :no-such-route → 404 and
+;; :schema-validation-failure → 400 (documented in error_projector.cljc) —
+;; had no direct assertion. These are pure (trace-event → public-error),
+;; so unit-test the fn directly: deterministic, no frame/drain machinery.
+;; ===========================================================================
+
+(deftest default-error-projector-fn-maps-all-enumerated-categories
+  (testing "rf2-ynjts.13 — the default projector's full case table per
+            Spec 011 §Default projector. Exercises the fn directly (it is a
+            public re-export: ssr/default-error-projector-fn)."
+    (testing ":rf.error/no-such-handler → 404 :not-found"
+      (is (= {:status 404 :code :not-found :message "Page not found" :retryable? false}
+             (ssr/default-error-projector-fn {:operation :rf.error/no-such-handler}))))
+    (testing ":rf.error/no-such-route → 404 :not-found (the second 404 arm —
+              previously untested)"
+      (is (= {:status 404 :code :not-found :message "Page not found" :retryable? false}
+             (ssr/default-error-projector-fn {:operation :rf.error/no-such-route}))
+          "no-such-route shares the 404 :not-found mapping with no-such-handler"))
+    (testing ":rf.error/schema-validation-failure → 400 :bad-request
+              (previously untested)"
+      (is (= {:status 400 :code :bad-request :message "Invalid input" :retryable? false}
+             (ssr/default-error-projector-fn {:operation :rf.error/schema-validation-failure}))
+          "schema-validation-failure is the only 400 arm"))
+    (testing "any other category → the locked generic-500 fallback"
+      (is (= ssr/fallback-public-error
+             (ssr/default-error-projector-fn {:operation :rf.error/handler-exception}))
+          "handler-exception falls through to the 500 default")
+      (is (= ssr/fallback-public-error
+             (ssr/default-error-projector-fn {:operation :totally/unknown-future-category}))
+          "an unenumerated future category also falls through — no case arm needed")
+      (is (= ssr/fallback-public-error
+             (ssr/default-error-projector-fn {}))
+          "an event with no :operation falls through to 500 too"))))
+
+;; ===========================================================================
+;; rf2-ynjts.13 — peek-response (pure) vs flush-response! / get-response
+;; (drain) read-surface contract. error_listener.cljc documents three reads:
+;; peek-response does NOT drain pending error projections; flush-response!
+;; and get-response DO. The drain-on-read is covered by the projector e2e
+;; tests; the pure-read-does-NOT-drain invariant (and the bookkeeping-key
+;; stripping on both) had no direct assertion.
+;; ===========================================================================
+
+(deftest peek-response-does-not-drain-flush-does
+  (testing "rf2-ynjts.13 — a buffered error trace is left intact by
+            peek-response (pure read) and only stamps :status when
+            flush-response! / get-response drains it."
+    (rf/reg-route :route/home {:path "/"})
+    (let [f (rf/make-frame
+              {:platform :server
+               :ssr {:public-error-id   :rf.ssr/default-error-projector
+                     :dev-error-detail? false}})]
+      ;; Fire a :rf.error/no-such-handler so a trace buffers against f.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"] {:frame f})
+
+      (testing "peek-response reads the un-projected response (still 200) and
+                does NOT consume the buffered trace"
+        (is (= 200 (:status (ssr/peek-response f)))
+            "peek leaves :status at the default 200 — the projector buffer
+             is NOT drained by a pure read"))
+
+      (testing "a SECOND peek still sees 200 — peek is idempotent + side-effect-free"
+        (is (= 200 (:status (ssr/peek-response f)))
+            "the pending trace survived the first peek, so the second peek
+             still reads the un-projected status"))
+
+      (testing "flush-response! drains the buffer and stamps the projector's status"
+        (is (= 404 (:status (ssr/flush-response! f)))
+            "flush projects the buffered :no-such-handler → 404 onto :status"))
+
+      (testing "after the drain the buffer is empty — a subsequent peek reads 404
+                (the stamped value persists; nothing left to re-project)"
+        (is (= 404 (:status (ssr/peek-response f)))
+            "the stamped 404 persists on the accumulator post-drain")))))
+
+(deftest peek-and-get-response-strip-bookkeeping-keys
+  (testing "rf2-ynjts.13 — both read surfaces strip the internal
+            `:rf.server/_status-writes` / `:rf.server/_redirect-writes`
+            bookkeeping keys, so a host adapter never sees them on the wire
+            shape."
+    (rf/reg-event-fx :resp/multi-status
+      (fn [_ _]
+        {:fx [[:rf.server/set-status 201]
+              [:rf.server/set-status 202]]}))
+    (let [f (rf/make-frame {:platform :server})]
+      (rf/dispatch-sync [:resp/multi-status] {:frame f})
+      (doseq [[label resp] [["peek-response"  (ssr/peek-response f)]
+                            ["get-response"   (ssr/get-response f)]]]
+        (is (= 202 (:status resp))
+            (str label ": last-write-wins status surfaces"))
+        (is (not (contains? resp :rf.server/_status-writes))
+            (str label ": the internal status-writes bookkeeping key is stripped"))
+        (is (not (contains? resp :rf.server/_redirect-writes))
+            (str label ": the internal redirect-writes bookkeeping key is stripped"))))))
+
 (deftest ssr-error-projection-skips-client-frames
   (testing "client-platform frames don't have their :rf/response stamped on errors"
     ;; A :rf.error/no-such-handler trace inside a CLIENT frame should not


### PR DESCRIPTION
Testing coverage & rigour review of `implementation/ssr/` (rf2-ynjts.13, parent epic rf2-ynjts). Test-only — **no src behaviour changed**; the public API and `:rf.ssr/*` / `:rf.server/*` vocab + behaviour are stable.

## Assessment

The existing ssr suite (~8.6K lines, 238 tests) is genuinely strong — comprehensive, behaviour-asserting (not vacuous/over-mocked), deterministic, well-named. Security gates (tag-name/header/cookie/CRLF/strip-prop/raw-text/scheme), the full `:rf.server/*` response + redirect family, safe-redirect's 5-step gate, hydration + mismatch (strict/detect knobs), streaming (corner matrix), head/meta, request cofx, payload policy, and projector substrate are all well covered. Conservative pass: I only added tests for **genuine gaps in deterministic, public-surface behaviour**, not gold-plating.

## Gaps closed

**`emit-element` scalar + composition branches** (`ssr_emit_test.clj`) — the leaf emission rules every render bottoms out at had no direct assertion:
- number child stringifies; boolean child is **dropped**; nil child dropped (a regression stringifying booleans to `"true"` would corrupt every server-rendered page and slip past existing tests)
- fn-headed component `[component-fn & args]` resolution through the non-streaming `render-to-string` (the `fn?` head branch — previously only exercised indirectly via the streaming walker)
- `escape-attr` vs `escape-html` asymmetry through the full emitter: text nodes escape `& < > " '`; attr **values** escape only `& "` (`< > '` legal in a double-quoted value per HTML5) — a deliberate, security-relevant correctness invariant
- boolean **attr-value** composition through `render-to-string` (`true` → bare name; `false`/`nil` → omitted) on void + non-void elements

**`default-error-projector-fn` pure-unit case table** (`ssr_end_to_end_test.clj`) — only `:no-such-handler`→404 and `:handler-exception`→500 were driven e2e; the other two documented arms were untested:
- `:rf.error/no-such-route` → 404 and `:rf.error/schema-validation-failure` → 400, plus the unenumerated-category and no-`:operation` 500 fallthroughs

**`peek-response` vs `flush-response!` / `get-response` read contract** — the pure-read-does-NOT-drain invariant was undocumented by any test:
- `peek` does not consume the projector buffer (idempotent, side-effect-free); `flush`/`get-response` do stamp the projected status
- both read surfaces strip the internal `_status-writes` / `_redirect-writes` bookkeeping keys

## Quality gates

| Gate | Before | After |
|---|---|---|
| ssr JVM `clojure -M:test` | 238 tests / 818 asserts, 0 fail | **247 / 853, 0 fail** |
| `npm run test:cljs` | green | **5094 / 17225, 0 fail** |
| clj-kondo (changed files) | — | **0 errors** (lone warning is pre-existing, untouched code) |

No src files touched (diff is `+227` across two test files). Behaviour-preserving and deterministic.