### PR TITLE
test(machines-viz): coverage & rigour pass (rf2-ynjts.16)

### DIFF
--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -402,6 +402,48 @@
                                :always? true
                                :guard   :ready?})))))
 
+;; ---- name-of (the public guard/action/entry/exit stringifier) ----------
+;;
+;; `name-of` is the single public helper `event-line` / `edge-label` /
+;; `chart.projection` all build on to render a guard / action / entry /
+;; exit value as a short label string. The keyword arms are exercised
+;; transitively by the edge-label tests above, but the two LOAD-BEARING
+;; branches — an inlined `(fn ...)` guard/action, which the docstring
+;; calls out as the `#object[Function]` failure mode it guards — had no
+;; direct pin. These deterministic cases nail each arm.
+
+(deftest name-of-nil-passes-through
+  (testing "nil → nil (cond-> arms upstream skip the segment entirely)"
+    (is (nil? (layout/name-of nil)))))
+
+(deftest name-of-plain-keyword
+  (testing "a plain keyword renders via `name` (no leading colon)"
+    (is (= "authed?" (layout/name-of :authed?)))))
+
+(deftest name-of-namespaced-keyword-preserves-ns
+  (testing "a namespaced keyword renders `ns/name` so a guard like
+            `:auth/admin?` reads in full instead of losing its namespace
+            (the bug the rf2-ee38b.21 collapse of the old `safe-name`
+            duplicate fixed)"
+    (is (= "auth/admin?" (layout/name-of :auth/admin?)))))
+
+(deftest name-of-named-fn-surfaces-name-meta
+  (testing "an inlined `(fn name ...)` / `(defn ...)` guard surfaces its
+            `:name` meta as the label — NOT `#object[Function]`"
+    (is (= "do-thing"
+           (layout/name-of (with-meta (fn [_] true) {:name 'do-thing}))))))
+
+(deftest name-of-anonymous-fn-falls-back-to-fn
+  (testing "an anonymous fn with no `:name` meta renders the literal
+            `\"fn\"` rather than an opaque `#object[Function]` dump"
+    (is (= "fn" (layout/name-of (fn [_] true))))))
+
+(deftest name-of-non-keyword-non-fn-uses-str
+  (testing "any other value falls through to `str` (a symbol, a number)"
+    (is (= "raw"   (layout/name-of "raw")))
+    (is (= "go!"   (layout/name-of 'go!)))
+    (is (= "42"    (layout/name-of 42)))))
+
 (deftest parse-definition-emits-event-label-with-guard-and-action
   (testing "parse-definition emits the full xstate label on every edge"
     (let [m {:initial :idle

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor_cljs_test.cljc
@@ -92,6 +92,27 @@
     (is (false? (anchor/join-resolved?
                   {:join :any :resolved? false :children [{:done? true}]})))))
 
+(deftest join-resolved-fn-join-falls-back-to-all-done-no-failed
+  (testing "a `{:fn ...}` (or otherwise unknown) join condition is opaque
+            to the overlay, so with no host `:resolved?` it falls back to
+            the conservative default: resolved iff every child is done AND
+            none failed AND there is at least one child"
+    ;; all done, none failed → resolved
+    (is (true? (anchor/join-resolved?
+                 {:join {:fn :host-decides}
+                  :children [{:done? true} {:done? true}]})))
+    ;; a failed child blocks the default even when the rest are done
+    (is (false? (anchor/join-resolved?
+                  {:join {:fn :host-decides}
+                   :children [{:done? true} {:failed? true}]})))
+    ;; not every child done → not resolved
+    (is (false? (anchor/join-resolved?
+                  {:join {:fn :host-decides}
+                   :children [{:done? true} {:done? false}]})))
+    ;; no children at all → not resolved (the `pos? total` guard)
+    (is (false? (anchor/join-resolved?
+                  {:join {:fn :host-decides} :children []})))))
+
 ;; ---- join-summary -------------------------------------------------------
 
 (deftest join-summary-counts
@@ -101,6 +122,18 @@
   (is (= "2/2 done"
          (anchor/join-summary
            {:children [{:done? true} {:done? true}]}))))
+
+(deftest join-summary-omits-zero-segments
+  (testing "the `· failed` / `· cancelled` segments appear ONLY when their
+            count is positive — a failed-only join shows the failed
+            segment but no cancelled segment"
+    (is (= "1/2 done · 1 failed"
+           (anchor/join-summary
+             {:children [{:done? true} {:failed? true}]}))
+        "failed present, cancelled absent → only the failed segment")
+    (is (= "0/0 done"
+           (anchor/join-summary {:children []}))
+        "an empty children list still renders the leading done segment")))
 
 ;; ---- cascade-counts + summary -------------------------------------------
 
@@ -116,3 +149,21 @@
                     {:kind :abort} {:kind :abort} {:kind :abort}]})))
   (is (= "no cascade steps"
          (anchor/cascade-summary-line {:steps []}))))
+
+(deftest cascade-summary-line-cleanup-pluralisation
+  (testing "the cleanup segment pluralises on its own axis: `1 cleanup`
+            (singular) vs `2 cleanups` (plural). A cleanup-only cascade
+            still renders the cleanup segment (no destroyed / aborted)."
+    (is (= "1 cleanup"
+           (anchor/cascade-summary-line {:steps [{:kind :cleanup}]})))
+    (is (= "2 cleanups"
+           (anchor/cascade-summary-line
+             {:steps [{:kind :cleanup} {:kind :cleanup}]})))))
+
+(deftest cascade-summary-line-ignores-exit-only-steps
+  (testing "an `:exit` step contributes to no count bucket
+            (`cascade-counts` tracks only destroy / abort / cleanup), so a
+            cascade of only `:exit` steps reads `no cascade steps`"
+    (is (= "no cascade steps"
+           (anchor/cascade-summary-line
+             {:steps [{:kind :exit} {:kind :exit}]})))))


### PR DESCRIPTION
## Quality gates

| Gate | Before | After |
|------|--------|-------|
| machines-viz JVM `clojure -M:test` | 316 tests / 819 assertions, 0 fail | 326 tests / 836 assertions, 0 fail |
| `npm run test:cljs` (node CLJS) | green | 5104 tests / 17242 assertions, 0 fail |
| clj-kondo on changed files | — | 0 errors, 0 warnings |

Test-only, additive (+93 lines, 0 deletions). **No src behaviour changed.**

## Review finding

The `tools/machines-viz/` suite is already strong: the high-value pure layers — the parsed-graph → xyflow projector (`chart.projection`, 1641-line corpus), the substrate-agnostic parse (`chart.layout`), overlay anchor/ring geometry, label-collision math, the SCXML round-trip, ai-generate, share, export, and layout-error — are pinned with deep, behaviour-asserting, deterministic tests against real `parse-definition` output (no hand-mocked node maps). Coverage and rigour are genuinely good. This pass is **conservative**: it closes a handful of concrete gaps in pure, JVM-runnable helpers rather than re-plumbing anything.

## Gaps closed

1. **`layout/name-of`** — the public guard/action/entry/exit → label stringifier had **no direct test** (only one transitive fn-entry case via `parse-definition`). Its two load-bearing branches are the inlined-fn arms: a named `(fn name ...)` / `(defn ...)` must surface its `:name` meta, and an anonymous fn must fall back to the literal `"fn"` — the `#object[Function]` leak the docstring explicitly guards against. Added pins for nil, plain keyword, namespaced keyword (ns preserved), named-fn meta, anonymous-fn fallback, and the `str` fallback (symbol/number).

2. **`overlay-anchor/join-resolved?`** — the `{:fn ...}`/unknown `:else` fallback arm (resolved iff every child done AND none failed AND `pos? total`) was untested. Added the four decision cases: all-done, a failed child blocking, not-all-done, and empty-children.

3. **`overlay-anchor/join-summary`** — pinned the failed-only partial (the `· cancelled` segment correctly omitted when zero) and the empty-children leading-segment case.

4. **`overlay-anchor/cascade-summary-line`** — pinned the cleanup-axis pluralisation (`1 cleanup` vs `2 cleanups`) and the exit-only "no cascade steps" path (`:exit` steps contribute to no count bucket).

All new tests are deterministic, behaviour-asserting (real expected outputs, not tautologies), and dual-target via the existing `_cljs_test.cljc` pattern.

Closes rf2-ynjts.16.