### PR TITLE
test(mcp-base): coverage & rigour pass (rf2-ynjts.17)

### DIFF
--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -220,6 +220,44 @@
   (is (nil? (args/safe-keyword "" #{:diff :full})))
   (is (nil? (args/safe-keyword ":" #{:diff :full}))))
 
+(deftest safe-keyword-disallowed-NAMESPACED-string-returns-nil-and-does-not-intern
+  ;; Coverage gap (rf2-ynjts.17): the existing no-intern pin
+  ;; (`safe-keyword-disallowed-string-returns-nil-and-does-not-intern`)
+  ;; exercises only the BARE-name arm (`find-keyword name-part`). The
+  ;; NAMESPACED arm (`find-keyword ns-part name-part`) is a distinct
+  ;; branch in `normalise-keyword-string` → `safe-keyword`, and it is
+  ;; the branch the registry-backed frame-id / `:rf.assert/*` coercions
+  ;; actually hit — those keys are namespaced. The DoS-gate guarantee
+  ;; (a rejected agent string MUST NOT intern a fresh JVM keyword) has
+  ;; to hold on the namespaced arm too, or the never-shrinking keyword
+  ;; table grows one slot per arbitrary `"ns/name"` an agent sends.
+  (let [novel-ns   "rf2-ynjts-novel-ns-do-not-intern"
+        novel-name "rf2-ynjts-novel-name-do-not-intern"
+        novel-kw   "rf2-ynjts-novel-ns-do-not-intern/rf2-ynjts-novel-name-do-not-intern"]
+    (is (nil? (find-keyword novel-ns novel-name))
+        "precondition: the novel namespaced keyword is not in the table")
+    (is (nil? (args/safe-keyword novel-kw #{:rf/foo :rf/bar}))
+        "out-of-allowlist namespaced string ⇒ nil")
+    (is (nil? (args/safe-keyword (str ":" novel-kw) #{:rf/foo :rf/bar}))
+        "leading-colon form also rejected")
+    (is (nil? (find-keyword novel-ns novel-name))
+        "safe-keyword MUST NOT intern a fresh NAMESPACED keyword on rejection — DoS gate")))
+
+(deftest safe-keyword-resolves-pre-interned-namespaced-keyword
+  ;; The positive companion: a namespaced keyword that DOES exist in the
+  ;; allowlist (and was therefore interned at allowlist-definition time)
+  ;; resolves from its string form via the namespaced `find-keyword`
+  ;; arm. Pins that the namespaced arm isn't merely a rejection path —
+  ;; it correctly returns the interned member when the input matches.
+  (is (= :rf.assert/path-equals
+         (args/safe-keyword "rf.assert/path-equals"
+                            #{:rf.assert/path-equals :rf.assert/path-absent}))
+      "an in-allowlist namespaced string resolves to its interned keyword")
+  (is (= :rf.assert/path-equals
+         (args/safe-keyword ":rf.assert/path-equals"
+                            #{:rf.assert/path-equals :rf.assert/path-absent}))
+      "leading-colon namespaced form resolves too"))
+
 (deftest safe-keyword-non-keyword-non-string-input-returns-nil
   (is (nil? (args/safe-keyword 42 #{:diff :full})))
   (is (nil? (args/safe-keyword [:diff] #{:diff :full})))

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -51,6 +51,20 @@
   (is (= overflow/default-max-tokens (cap/max-tokens :not-a-number)))
   (is (= overflow/default-max-tokens (cap/max-tokens [1 2 3]))))
 
+(deftest max-tokens-only-zero-disables-not-other-numbers
+  ;; Coverage gap (rf2-ynjts.17): the docstring is precise — ONLY a
+  ;; literal `0` disables the cap (returns nil); every other number is
+  ;; passed through as `(long raw)`. The existing tests pin nil-cap on
+  ;; `0` and passthrough on positives, but never pin that a NEGATIVE
+  ;; number is passed through (not treated as "disabled" and not
+  ;; defaulted). A regression that broadened the disable check to
+  ;; `(not (pos? raw))` would silently disable the cap for a negative
+  ;; arg — pin the exact `(zero? raw)` boundary.
+  (is (= -5 (cap/max-tokens -5))
+      "a negative number is NOT a disable signal — only 0 is")
+  (is (= 1 (cap/max-tokens 1)) "smallest positive passes through")
+  (is (integer? (cap/max-tokens -5)) "coerced to long like every numeric arm"))
+
 (deftest max-tokens-coerces-double-to-long
   (is (= 1000 (cap/max-tokens 1000.0)))
   (is (integer? (cap/max-tokens 1000.0))))

--- a/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
@@ -74,6 +74,68 @@
     (is (= ::cursor/malformed
            (cursor/decode-cursor (cursor/encode-cursor {:wrong :shape}) offset-cursor?)))))
 
+(deftest decode-cursor-non-map-edn-is-malformed-without-consulting-predicate
+  ;; Coverage gap (rf2-ynjts.17): a cursor that base64+EDN-decodes to a
+  ;; well-formed but NON-MAP value (`"5"` ⇒ 5, `"[1 2 3]"` ⇒ vector,
+  ;; `":kw"` ⇒ keyword) hits the `(map? v)` short-circuit in
+  ;; `decode-cursor` — `valid?` is never consulted. The existing tests
+  ;; only exercised a map that FAILS `valid?`; the non-map arm (where
+  ;; `valid?` would throw if called on, say, a number) had no pin. We
+  ;; pass a `valid?` that THROWS on non-map input to prove the guard
+  ;; runs first: a throw here would mean `valid?` was reached.
+  (let [strict-map-pred (fn [m]
+                          ;; would explode on a non-map if reached
+                          (and (map? m) (pos? (count m))))
+        num-token  (cursor/b64-encode "5")
+        vec-token  (cursor/b64-encode "[1 2 3]")
+        kw-token   (cursor/b64-encode ":some-keyword")
+        str-token  (cursor/b64-encode "\"a string\"")]
+    (is (= ::cursor/malformed (cursor/decode-cursor num-token strict-map-pred))
+        "numeric EDN cursor ⇒ ::malformed (map? guard, valid? not consulted)")
+    (is (= ::cursor/malformed (cursor/decode-cursor vec-token strict-map-pred))
+        "vector EDN cursor ⇒ ::malformed")
+    (is (= ::cursor/malformed (cursor/decode-cursor kw-token strict-map-pred))
+        "keyword EDN cursor ⇒ ::malformed")
+    (is (= ::cursor/malformed (cursor/decode-cursor str-token strict-map-pred))
+        "string EDN cursor ⇒ ::malformed")))
+
+(deftest decode-cursor-at-inclusive-size-boundary-is-not-rejected
+  ;; Coverage gap (rf2-ynjts.17): the size guard is a STRICT `>`
+  ;; (`(> (count s) max-cursor-bytes)` ⇒ ::malformed). The existing
+  ;; oversize test only feeds `(inc max-cursor-bytes)` chars — the
+  ;; over-limit side. The INCLUSIVE side (a real cursor whose token
+  ;; length is `<= max-cursor-bytes`) was never pinned. A regression
+  ;; that flipped the guard to `>=` would reject a legitimate at-or-near-
+  ;; cap cursor; this test trips on that flip.
+  ;;
+  ;; Build the largest real, decodable cursor whose token length is
+  ;; still `<= max-cursor-bytes` (grow the payload's `:sig` to the cap).
+  ;; Under strict `>` it round-trips; under `>=` (if the token landed
+  ;; exactly on the cap) it would size-reject. The round-trip is the
+  ;; load-bearing assertion.
+  (let [grow      (fn [n] {:v 1 :offset 0 :total 1
+                           :sig (apply str (repeat n \s))})
+        token-len (fn [n] (count (cursor/encode-cursor (grow n))))
+        ;; largest sig length whose token is still within the cap.
+        max-n     (loop [n 0]
+                    (if (> (token-len (inc n)) cursor/max-cursor-bytes)
+                      n
+                      (recur (inc n))))
+        payload   (grow max-n)
+        token     (cursor/encode-cursor payload)]
+    (is (<= (count token) cursor/max-cursor-bytes)
+        "constructed cursor sits AT or just under the inclusive boundary")
+    (is (> (token-len (inc max-n)) cursor/max-cursor-bytes)
+        "one more sig char would push the token over the cap — boundary is tight")
+    (is (= payload (cursor/decode-cursor token offset-cursor?))
+        "a cursor at the inclusive size boundary is NOT size-rejected (strict >)"))
+  ;; Unconditional companion: a realistic small cursor is well under cap.
+  (let [payload {:v 1 :offset 25 :total 137 :sig "abc123"}
+        token   (cursor/encode-cursor payload)]
+    (is (< (count token) cursor/max-cursor-bytes)
+        "a realistic cursor is well under the byte cap")
+    (is (= payload (cursor/decode-cursor token offset-cursor?)))))
+
 (deftest decode-cursor-rejects-tagged-literals
   ;; The hardening contract: a cursor smuggling a tagged literal must
   ;; be rejected by the reader's :default handler → ::malformed, never

--- a/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
@@ -62,6 +62,39 @@
   (is (some #(= % "#:rf.mcp{:overflow") envelope/marker-prefixes))
   (is (some #(= % "#:rf.mcp{:cache-hit") envelope/marker-prefixes)))
 
+(deftest marker-text?-only-matches-leading-marker-not-embedded-key
+  ;; Coverage gap (rf2-ynjts.17): `marker-text?` is `starts-with?`, not
+  ;; `includes?` — the marker key must be the LEADING top-level key for
+  ;; the text to count as a boundary marker. The comment block in
+  ;; envelope.cljc justifies the prefix-match precisely on this ground:
+  ;; an ordinary payload that merely CONTAINS `:rf.mcp/overflow` as a
+  ;; nested value must NOT be mistaken for a boundary-step marker (which
+  ;; would make a later boundary step skip re-walking a real payload).
+  ;; A regression that loosened `starts-with?` to `includes?` would
+  ;; trip this test.
+  (testing "marker key as a nested value ⇒ NOT a marker"
+    (is (false? (envelope/marker-text?
+                  (pr-str {:trace [{:note "saw :rf.mcp/overflow once"}]})))
+        "the key appearing as string content is not a leading marker")
+    (is (false? (envelope/marker-text?
+                  (pr-str {:result :ok :detail {vocab/overflow-key {:limit :reached}}})))
+        "an overflow marker nested under :detail is not a LEADING marker"))
+  (testing "marker key as a non-first top-level key ⇒ NOT a marker"
+    ;; pr-str of an array-map preserves insertion order, so :a prints
+    ;; first; the overflow key is present but not leading.
+    (let [s (pr-str (array-map :a 1 vocab/overflow-key {:limit :reached}))]
+      (is (false? (envelope/marker-text? s))
+          "overflow key present but not the leading key ⇒ not a marker"))))
+
+(deftest marker-text?-empty-and-blank-strings-are-not-markers
+  ;; Boundary pin (rf2-ynjts.17): the empty string and whitespace are
+  ;; strings (so they pass the `string?` guard) but match no prefix.
+  (is (false? (envelope/marker-text? "")))
+  (is (false? (envelope/marker-text? "   ")))
+  (is (false? (envelope/marker-text? "{")))
+  (is (false? (envelope/marker-text? "#:rf.mcp"))
+      "the namespaced-map prefix STEM alone (no key) is not a complete marker prefix"))
+
 (deftest marker-text?-handles-both-print-forms
   ;; JVM `pr-str` emits the namespaced-map shorthand for a single-ns
   ;; map; CLJS emits the flat form. Both MUST be detected so the cap /

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -172,6 +172,61 @@
     (is (nil? out))
     (is (zero? dropped))))
 
+(deftest scrub-snapshot-non-map-frame-values-pass-through-untouched
+  ;; Coverage gap (rf2-ynjts.17): `scrub-snapshot`'s per-frame reduce-kv
+  ;; only scrubs a frame value when `(map? v)`; a non-map value rides
+  ;; the `:else v` arm untouched. The runtime snapshot is a map of
+  ;; frame-id → frame-map, but the helper is defensive against a slot
+  ;; whose value isn't a frame map (a scalar marker, a nil sentinel).
+  ;; That else-arm had ZERO executing coverage — a regression that
+  ;; mangled non-map slots (e.g. `(scrub-frame v)` unconditionally)
+  ;; would NPE/throw rather than pass through, and no test would catch
+  ;; it. Pin the leave-alone guarantee for every non-map shape.
+  (let [snap {:rf/default {:traces [{:id 1 :sensitive? true} {:id 2}]}
+              :meta-count  7              ;; scalar — must survive verbatim
+              :flag        :rf.size/large-elided ;; keyword — survives
+              :nilslot     nil            ;; nil — survives
+              :listslot    [1 2 3]}       ;; vector (non-map) — survives
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (= 1 dropped) "the one map frame's sensitive trace is still dropped")
+    (is (= [{:id 2}] (get-in out [:rf/default :traces]))
+        "map frame scrubbed")
+    (is (= 7 (:meta-count out))   "scalar frame value untouched")
+    (is (= :rf.size/large-elided (:flag out)) "keyword frame value untouched")
+    (is (contains? out :nilslot)  "nil frame value key preserved")
+    (is (nil? (:nilslot out))     "nil frame value untouched")
+    (is (= [1 2 3] (:listslot out)) "vector frame value untouched")))
+
+(deftest scrub-snapshot-frame-without-trace-or-epoch-slices-is-no-op
+  ;; Coverage gap (rf2-ynjts.17): `scrub-frame`'s `cond->` only updates
+  ;; `:traces` / `:epochs` when present. A frame map carrying NEITHER
+  ;; slice (an `:app-db`-only frame, or a frame whose only slices are
+  ;; the left-alone `:sub-cache` / `:machines`) must return byte-equal
+  ;; — the `cond->` falls through both clauses. The existing
+  ;; strip-from-traces test always carried at least one of the two
+  ;; slices, so the both-absent fall-through was never exercised.
+  (let [snap {:rf/default {:app-db    {:user/name "ada"}
+                           :sub-cache {:user/profile {:data "x"}}
+                           :machines  {:auth {:state :idle}}}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (zero? dropped) "no trace / epoch slices ⇒ nothing dropped")
+    (is (= snap out)
+        "a frame with neither :traces nor :epochs is returned unchanged")))
+
+(deftest scrub-snapshot-frame-with-only-epochs-slice-scrubbed
+  ;; Companion to the existing :stories-only-:traces frame in
+  ;; `scrub-snapshot-strips-sensitive-from-traces`: pin the symmetric
+  ;; `cond->` arm where ONLY `:epochs` is present (no `:traces`). Both
+  ;; single-slice arms now have positive coverage.
+  (let [snap {:rf/default {:epochs [{:event-id :foo}
+                                    {:event-id :auth/sign-in :sensitive? true}
+                                    {:event-id :bar}]}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (= 1 dropped))
+    (is (= [{:event-id :foo} {:event-id :bar}]
+           (get-in out [:rf/default :epochs]))
+        "only-:epochs frame has its epoch slice scrubbed")))
+
 (deftest scrub-snapshot-handles-lazy-seq-slice-values
   ;; Regression pin (rf2-cwqc8 / round-2 F17): `:traces` and `:epochs`
   ;; arrive as vectors in the typical runtime emission, but the


### PR DESCRIPTION
## Quality gates

| Gate | Before | After |
|---|---|---|
| `tools/mcp-base` JVM `clojure -M:test` | 157 tests / 419 assertions, 0 fail | 167 tests / 455 assertions, 0 fail |
| `implementation/` `npm run test:cljs` | green | 5094 tests / 17225 assertions, 0 fail |
| clj-kondo (changed files) | 0 errors (1 pre-existing warning) | 0 errors (same pre-existing warning, no new) |

Test-only pass. **No `src/` change** — public helper surface and behaviour are unchanged; every consumer (re-frame2-pair-mcp, story-mcp) sees identical shapes.

## Review finding

`tools/mcp-base/` already carries a strong, rigorous, behaviour-asserting suite (no vacuous/tautological/over-mocked tests; cross-host JVM+CLJS contract pins; Malli grammar gates; DoS-gate no-intern pins). The review surfaced a handful of genuinely-untested branches — defensive "leave-alone" guarantees and inclusive boundary directions — not weak existing tests. Conservative additions only.

## Gaps closed (each new test is deterministic + asserts a real outcome)

- **`sensitive/scrub-snapshot`** — three untested branches in the privacy filter:
  - non-map frame values ride the `(if (map? v) … :else v)` arm untouched (scalar / keyword / nil / vector all survive verbatim);
  - a frame with **neither** `:traces` nor `:epochs` is byte-equal (the `cond->` falls through both clauses);
  - the **only-`:epochs`** `cond->` arm (companion to the existing only-`:traces` `:stories` frame).
- **`cursor/decode-cursor`** — two branches:
  - a well-formed **non-map** EDN value (number / vector / keyword / string) hits the `(map? v)` short-circuit so `valid?` is never consulted (proven by a `valid?` that would explode on a non-map);
  - the **inclusive size boundary** — a real cursor whose token length is `<= max-cursor-bytes` is NOT rejected (strict `>`; trips on a `>=` flip). Existing test only covered the over-limit side.
- **`cap/max-tokens`** — only literal `0` disables the cap; a **negative** number passes through as `(long raw)` rather than being mistaken for a disable signal (guards against a `(not (pos? raw))` broadening).
- **`args/safe-keyword`** — the **namespaced** rejection arm does not intern a fresh JVM keyword (the DoS gate's existing pin covered only the bare-name arm; namespaced is the form frame-id / `:rf.assert/*` keys actually take), plus the positive namespaced-resolve companion.
- **`envelope/marker-text?`** — `starts-with?` (not `includes?`): a marker key embedded as a nested value or non-leading top-level key is **not** flagged a boundary marker (a false-positive would make a later boundary step skip re-walking a real payload); empty / blank / partial-prefix strings are not markers.

Public helper surface + behaviour confirmed unchanged (test-only diff, +202 / -0).
