### PR TITLE
test(pair-mcp): coverage & rigour pass (rf2-ynjts.19)

### DIFF
--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
@@ -118,3 +118,75 @@
   ;; agent host.
   (let [a (args-js {:include-sensitive "true"})]
     (is (true? (args/parse-bool-arg a :include-sensitive)))))
+
+;; ---------------------------------------------------------------------------
+;; read-edn-arg — the [:ok parsed] / [:err reason] EDN-arg helper
+;; (rf2-jkake.19). Factored out of reset-frame-db (:db),
+;; restore-epoch (:epoch-id) and handler-meta (:id); each passes its own
+;; per-tool reason keywords so the error envelope stays specific. The
+;; three outcomes (missing / invalid / ok) were only exercised
+;; indirectly via the conformance corpus; pin the helper directly so a
+;; regression surfaces at the unit it lives in (rf2-ynjts.19).
+;; ---------------------------------------------------------------------------
+
+(deftest read-edn-arg-absent-returns-missing-reason
+  ;; nil / blank value yields the caller's `missing` reason keyword.
+  (is (= [:err :missing-db] (args/read-edn-arg nil :missing-db :invalid-db)))
+  (is (= [:err :missing-db] (args/read-edn-arg "" :missing-db :invalid-db)))
+  (is (= [:err :missing-db] (args/read-edn-arg "   " :missing-db :invalid-db))))
+
+(deftest read-edn-arg-unreadable-returns-invalid-reason
+  ;; Unbalanced delimiters → the caller's `invalid` reason keyword, NOT
+  ;; the missing one (the discriminator is read-string success/failure).
+  (is (= [:err :invalid-db] (args/read-edn-arg "{:k" :missing-db :invalid-db)))
+  (is (= [:err :invalid-db] (args/read-edn-arg "(((" :missing-db :invalid-db))))
+
+(deftest read-edn-arg-parses-valid-edn
+  ;; A readable value rides back under [:ok parsed] with the EDN shape
+  ;; preserved — maps, vectors, scalars, keywords.
+  (is (= [:ok {:counter 0}] (args/read-edn-arg "{:counter 0}" :missing :invalid)))
+  (is (= [:ok 7] (args/read-edn-arg "7" :missing :invalid)))
+  (is (= [:ok 7] (args/read-edn-arg "  7  " :missing :invalid))
+      "leading/trailing whitespace trimmed before read")
+  (is (= [:ok :user/login] (args/read-edn-arg ":user/login" :missing :invalid)))
+  (is (= [:ok [:a :b 0]] (args/read-edn-arg "[:a :b 0]" :missing :invalid))))
+
+(deftest read-edn-arg-reason-keywords-are-caller-specific
+  ;; Each consumer passes distinct reason keywords; the helper forwards
+  ;; them verbatim so the envelope stays per-tool specific (the whole
+  ;; point of taking them as args rather than hard-coding).
+  (is (= [:err :missing-epoch-id]
+         (args/read-edn-arg nil :missing-epoch-id :invalid-epoch-id-edn)))
+  (is (= [:err :invalid-epoch-id-edn]
+         (args/read-edn-arg "{:unterminated" :missing-epoch-id :invalid-epoch-id-edn))))
+
+(deftest read-edn-arg-reads-only-the-first-form
+  ;; read-string reads exactly ONE form and stops — trailing tokens are
+  ;; NOT a parse error. `"nope("` reads as the symbol `nope` (the
+  ;; dangling `(` is never consumed), so the helper reports [:ok nope],
+  ;; not an :invalid error. Pinning this documents the read-string
+  ;; contract the helper inherits: only an UNTERMINATED first form
+  ;; (`"{:k"`, `"((("`) trips the :invalid arm.
+  (is (= [:ok 'nope] (args/read-edn-arg "nope(" :missing :invalid))))
+
+;; ---------------------------------------------------------------------------
+;; parse-filter-arg — the streaming filter map (rf2-hq49). The nil /
+;; string / map arms are covered in subscribe_test; the `:else` arm
+;; (a JS object that is neither a string nor a CLJS map — the shape an
+;; MCP host sends a structured filter as) routes through
+;; `js->clj :keywordize-keys true` and was untested. Pin it (rf2-ynjts.19).
+;; ---------------------------------------------------------------------------
+
+(deftest parse-filter-arg-js-object-keywordizes
+  (let [obj #js {"op-type" "error" "frame" "rf/default"}
+        out (args/parse-filter-arg obj)]
+    (is (= {:op-type "error" :frame "rf/default"} out)
+        "JS-object keys keywordized; values left as-is")))
+
+(deftest parse-filter-arg-nested-js-object-keywordizes-deep
+  ;; `:keywordize-keys true` recurses — a nested JS object's keys are
+  ;; keywordized too.
+  (let [obj #js {"touches-path" #js ["cart" "items"]
+                 "meta" #js {"min-ms" 50}}
+        out (args/parse-filter-arg obj)]
+    (is (= {:touches-path ["cart" "items"] :meta {:min-ms 50}} out))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cljs_eval_value_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cljs_eval_value_test.cljs
@@ -1,0 +1,281 @@
+(ns re-frame2-pair-mcp.cljs-eval-value-test
+  "Unit tests for `nrepl/cljs-eval-value` — the value-unwrap seam every
+  tool's runtime read flows through (rf2-ynjts.19).
+
+  ## Why this suite exists
+
+  `cljs-eval-value` is the single most load-bearing fn in the artefact:
+  every tool that reads from the runtime (`snapshot`, `get-path`,
+  `dispatch`, `eval-cljs`, the probe, …) calls it to turn shadow-cljs's
+  string-encoded `cljs-eval` response into the actual CLJS value. Yet
+  the whole existing corpus STUBS `cljs-eval-value` itself (see
+  `test_utils/with-stubbed-eval!`, `eval_cljs_test`, `conformance_test`)
+  — so its own unwrap logic was never exercised by a unit test. A
+  regression in any of its branches (the `:results` peek, the
+  `:ex`-reject, the inner `:err`-reject, the blank→nil short-circuit, or
+  the `read-edn-safe` parse-failure fallback) would slip past 707
+  green tests because every one of them mocks the very fn under test.
+
+  ## Seam
+
+  `cljs-eval-value` calls the lower-level `nrepl/cljs-eval` and `.then`s
+  the resolved combined-response map `{:value :out :err :status :ex}`.
+  We `set!` `nrepl/cljs-eval` (one layer below the SUT) to canned
+  response maps and assert the unwrapped value / rejection. The real
+  `cljs-eval-value` runs unmocked — this is the inverse posture to the
+  rest of the corpus.
+
+  ## shadow's response shape
+
+  shadow-cljs's `cljs-eval` API returns a string-encoded EDN map like
+  `{:results [\"42\"] :ns user}` in the `:value` slot of the nREPL
+  combined response. `cljs-eval-value` reads the outer EDN, peeks the
+  LAST `:results` entry (itself an EDN-encoded string), and reads THAT
+  to get the value. Two EDN reads, nested."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]))
+
+;; ---------------------------------------------------------------------------
+;; Seam — stub the lower-level `cljs-eval` so the real `cljs-eval-value`
+;; runs its unwrap logic against a canned combined-response map.
+;; ---------------------------------------------------------------------------
+
+(defn- with-stubbed-cljs-eval!
+  "Install a stub `nrepl/cljs-eval` that resolves to `resp` (the combined
+  nREPL response map the real fn would build). Run `body-fn` (returns a
+  Promise) and restore the original in `.finally` so cleanup outlives
+  async resolution. Both 3- and 4-arity are spelled out — CLJS direct-
+  arity dispatch calls `...$arity$3` / `...$arity$4`, which a
+  rest-arg fn would not expose."
+  [resp body-fn]
+  (let [orig nrepl/cljs-eval
+        stub (fn
+               ([_conn _build _form] (js/Promise.resolve resp))
+               ([_conn _build _form _opts] (js/Promise.resolve resp)))]
+    (set! nrepl/cljs-eval stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval orig))))))
+
+(defn- fresh-conn [] (nrepl/make-conn 0 "127.0.0.1"))
+
+;; ---------------------------------------------------------------------------
+;; Happy path — the nested-EDN unwrap shadow actually produces.
+;; ---------------------------------------------------------------------------
+
+(deftest unwraps-shadow-results-vector-to-value
+  ;; shadow wraps the eval result as `{:results ["<edn>"] :ns user}` in
+  ;; the :value string. The LAST :results entry is re-read as EDN. A
+  ;; scalar 42 rides as the string "42" inside the results vector inside
+  ;; the outer map string.
+  (async done
+    (-> (with-stubbed-cljs-eval! {:value "{:results [\"42\"] :ns user}"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "(+ 40 2)")))
+        (.then (fn [v]
+                 (is (= 42 v) "scalar unwrapped from the nested :results EDN")
+                 (done))))))
+
+(deftest unwraps-nested-collection-value
+  ;; A map value round-trips through both EDN reads intact.
+  (async done
+    (-> (with-stubbed-cljs-eval!
+          {:value "{:results [\"{:a 1 :b [2 3]}\"] :ns user}"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [v]
+                 (is (= {:a 1 :b [2 3]} v) "nested collection unwrapped")
+                 (done))))))
+
+(deftest peeks-last-results-entry
+  ;; Multiple :results entries (multi-form eval) — only the LAST is the
+  ;; value the caller wants; the earlier ones are intermediate. `peek`
+  ;; on the vector returns the final entry.
+  (async done
+    (-> (with-stubbed-cljs-eval!
+          {:value "{:results [\"1\" \"2\" \"99\"] :ns user}"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [v]
+                 (is (= 99 v) "last :results entry wins")
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Blank value → nil. shadow returns a blank :value for a build with no
+;; live runtime; the caller (eval-cljs / probe) discriminates this from a
+;; genuine nil via the runtime sentinel preflight, but the unwrap itself
+;; collapses blank → nil.
+;; ---------------------------------------------------------------------------
+
+(deftest blank-value-resolves-nil
+  (async done
+    (-> (with-stubbed-cljs-eval! {:value ""}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [v]
+                 (is (nil? v) "empty :value string resolves to nil")
+                 (done))))))
+
+(deftest absent-value-resolves-nil
+  ;; No :value key at all (e.g. a status-only frame). `(str nil)` is
+  ;; blank, so the same short-circuit fires.
+  (async done
+    (-> (with-stubbed-cljs-eval! {:out "" :err "" :status #{"done"}}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [v]
+                 (is (nil? v) "missing :value resolves to nil")
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
+;; :ex present → reject. An nREPL-level eval exception (compile error,
+;; thrown form) must surface as a rejected Promise, never a resolved nil
+;; or partial value — the caller's .catch turns it into the transport
+;; error envelope.
+;; ---------------------------------------------------------------------------
+
+(deftest ex-rejects-with-error
+  (async done
+    (-> (with-stubbed-cljs-eval!
+          {:ex "class clojure.lang.ExceptionInfo" :err "Unable to resolve symbol: foo"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "foo")))
+        (.then (fn [_]
+                 (is false "an :ex response MUST reject, not resolve")
+                 (done)))
+        (.catch (fn [err]
+                  (is (instance? js/Error err))
+                  (let [m (.-message err)]
+                    (is (re-find #"nREPL eval error" m) "structured eval-error prefix")
+                    (is (re-find #"ExceptionInfo" m) ":ex text carried into the message")
+                    (is (re-find #"Unable to resolve symbol" m)
+                        ":err detail appended when present"))
+                  (done))))))
+
+(deftest ex-without-err-still-rejects
+  ;; :ex present but :err blank — the message omits the " — <err>" suffix
+  ;; but still rejects with the :ex text.
+  (async done
+    (-> (with-stubbed-cljs-eval! {:ex "boom" :err ""}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [_]
+                 (is false "an :ex response MUST reject even with blank :err")
+                 (done)))
+        (.catch (fn [err]
+                  (let [m (.-message err)]
+                    (is (re-find #"nREPL eval error: boom" m))
+                    (is (not (re-find #" — " m)) "no err-suffix when :err is blank"))
+                  (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Inner :err map → reject. When the OUTER EDN parses to a map carrying
+;; an :err key (a shadow-side cljs-eval error, distinct from an nREPL :ex),
+;; the unwrap rejects rather than returning the error map as a "value".
+;; ---------------------------------------------------------------------------
+
+(deftest inner-err-map-rejects
+  (async done
+    (-> (with-stubbed-cljs-eval!
+          {:value "{:err \"Cannot infer target type\"}"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [_]
+                 (is false "an outer map with :err MUST reject")
+                 (done)))
+        (.catch (fn [err]
+                  (is (re-find #"cljs eval error: Cannot infer target type"
+                               (.-message err))
+                      "inner :err surfaced as a distinct cljs-eval-error message")
+                  (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Non-:results map → returned as-is. A :value that parses to a map
+;; WITHOUT a :results vector (and without :err) is the value itself —
+;; some lower-level callers eval forms whose result is a bare map. The
+;; `:else` arm returns `outer` unchanged.
+;; ---------------------------------------------------------------------------
+
+(deftest non-results-map-returned-verbatim
+  (async done
+    (-> (with-stubbed-cljs-eval! {:value "{:custom :shape :n 7}"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [v]
+                 (is (= {:custom :shape :n 7} v)
+                     "outer map without :results returned verbatim")
+                 (done))))))
+
+(deftest scalar-outer-value-returned-verbatim
+  ;; A :value that parses to a bare scalar (not a map) takes the :else
+  ;; arm too and rides back unchanged.
+  (async done
+    (-> (with-stubbed-cljs-eval! {:value "123"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [v]
+                 (is (= 123 v) "bare scalar outer value returned verbatim")
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
+;; read-edn-safe fallback — an unparseable :value must NOT throw the
+;; whole pipeline. The contract (nrepl/read-edn-safe) is: log to stderr,
+;; return the raw string. Exercised here through the public SUT so the
+;; private fn's behaviour is pinned without reaching for its var.
+;; ---------------------------------------------------------------------------
+
+(deftest unparseable-outer-value-falls-back-to-raw-string
+  (async done
+    ;; Silence the expected stderr log from read-edn-safe so the
+    ;; otherwise-quiet run stays clean (the log is SUT behaviour, not a
+    ;; failure).
+    (let [orig-err (.-error js/console)]
+      (set! (.-error js/console) (fn [& _] nil))
+      (-> (with-stubbed-cljs-eval! {:value "#unbalanced ((("}
+            (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+          (.then (fn [v]
+                   (is (= "#unbalanced (((" v)
+                       "unparseable outer EDN falls back to the raw string, never throws")))
+          (.finally (fn []
+                      (set! (.-error js/console) orig-err)
+                      (done)))))))
+
+(deftest unparseable-inner-results-entry-falls-back-to-raw-string
+  ;; The OUTER parses fine to a :results vector, but the inner entry is
+  ;; itself unparseable EDN. The inner read-edn-safe returns the raw
+  ;; string rather than throwing — the value the caller gets is the
+  ;; unparseable text, surfaced (not silently dropped).
+  (async done
+    (let [orig-err (.-error js/console)]
+      (set! (.-error js/console) (fn [& _] nil))
+      (-> (with-stubbed-cljs-eval!
+            {:value "{:results [\"((( nope\"] :ns user}"}
+            (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+          (.then (fn [v]
+                   (is (= "((( nope" v)
+                       "unparseable inner :results entry falls back to its raw string")))
+          (.finally (fn []
+                      (set! (.-error js/console) orig-err)
+                      (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; Empty :results vector → nil. `peek` on `[]` is nil; the `when-let`
+;; guards the inner read so the call resolves nil rather than reading
+;; `(read-edn-safe nil)`.
+;; ---------------------------------------------------------------------------
+
+(deftest empty-results-vector-resolves-nil
+  (async done
+    (-> (with-stubbed-cljs-eval! {:value "{:results [] :ns user}"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [v]
+                 (is (nil? v) "empty :results vector resolves to nil")
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
+;; :ex takes precedence over a present :value — even if shadow somehow
+;; returned both, the exception path wins (fail loud over a partial
+;; value).
+;; ---------------------------------------------------------------------------
+
+(deftest ex-precedence-over-value
+  (async done
+    (-> (with-stubbed-cljs-eval!
+          {:ex "thrown" :err "detail" :value "{:results [\"42\"] :ns user}"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
+        (.then (fn [_]
+                 (is false ":ex must win over a present :value")
+                 (done)))
+        (.catch (fn [err]
+                  (is (re-find #"nREPL eval error: thrown" (.-message err)))
+                  (done))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -61,6 +61,41 @@
     (is (= 3 (count fs)))
     (is (zero? (.-length rst)))))
 
+(deftest incomplete-frame-retained-as-trailer
+  ;; rf2-ynjts.19 — the partial-frame branch directly on the public
+  ;; seam. A truncated bencode frame can't decode; `decode-all-frames`
+  ;; MUST return zero frames and hand the partial bytes back as the
+  ;; trailer so the next TCP chunk can complete them. This is the
+  ;; contract `attach-handlers!` relies on for its partial-frame
+  ;; buffering — pinned here directly on the walker.
+  (let [full     (js/Buffer.from "d3:foo3:bare" "utf8")
+        partial  (.slice full 0 (dec (.-length full)))   ; drop the closing 'e'
+        [fs rst] (decode-all partial)]
+    (is (zero? (count fs)) "a truncated frame yields no complete frames")
+    (is (= (.-length partial) (.-length rst))
+        "the partial bytes are retained verbatim as the trailer")))
+
+(deftest complete-frame-then-incomplete-tail-splits
+  ;; One complete frame followed by the start of a second. The first
+  ;; dispatches; the incomplete tail is retained for the next chunk —
+  ;; the exact multi-frame-chunk-with-partial-tail shape a busy socket
+  ;; produces.
+  (let [whole    (js/Buffer.from "d3:foo3:bare" "utf8")
+        head     (js/Buffer.from "d3:baz" "utf8")          ; start of a 2nd frame
+        chunk    (js/Buffer.concat #js [whole head])
+        [fs rst] (decode-all chunk)]
+    (is (= 1 (count fs)) "exactly the one complete frame is returned")
+    (is (= "bar" (j/get (first fs) "foo")))
+    (is (= (.-length head) (.-length rst))
+        "the incomplete second frame's bytes are held as the trailer")))
+
+(deftest empty-buffer-yields-no-frames
+  ;; The loop's base case — a zero-length buffer returns no frames and
+  ;; an empty trailer (never loops).
+  (let [[fs rst] (decode-all (js/Buffer.alloc 0))]
+    (is (zero? (count fs)))
+    (is (zero? (.-length rst)))))
+
 ;; ===========================================================================
 ;; Port discovery — `read-port-from-fs` (rf2-wnrpi, finding G2).
 ;;


### PR DESCRIPTION
Testing coverage & rigour review of `tools/re-frame2-pair-mcp/` (bead rf2-ynjts.19, epic rf2-ynjts). Test-only, behaviour-preserving, deterministic. The existing `:server-test` suite is already strong (707 tests, 2041 assertions across the 22-tool catalogue, conformance corpus, pipeline orchestration, per-tool shapers, degraded-mode/preload ladders, write gates, await/frame modes). This PR closes three concrete gaps rather than padding.

## Quality gates

| Gate | Before | After |
|------|--------|-------|
| `:server-test` (`npm test`) | 707 tests / 2041 assertions / 0 fail | **731 tests / 2081 assertions / 0 fail** |
| clj-kondo (changed files) | — | 0 errors, 0 warnings (pre-existing unused-`testing` warning in `args_test` left untouched) |
| `npm run test:mcp-conformance` | — | left to CI (heavy multi-dir + Playwright + JVM gate; this change touches no production source or server bundle) |

## Gaps found + what each new test covers

1. **`nrepl/cljs-eval-value` — the value-unwrap seam EVERY tool flows through — had ZERO direct coverage.** The whole existing corpus stubs `cljs-eval-value` *itself* (`test_utils/with-stubbed-eval!`, `eval_cljs_test`, `conformance_test`, …), so its own unwrap logic was never exercised by a unit test — a regression in any branch would slip past all 707 green tests because they mock the very fn under test. New `cljs_eval_value_test.cljs` stubs the lower-level `cljs-eval` and runs the *real* `cljs-eval-value`, pinning: the nested-`:results` EDN peek (single + multi-entry → last wins), nested-collection round-trip, `blank`/absent `:value` → nil, empty `:results` → nil, `:ex` → reject (with/without `:err` suffix, and `:ex` precedence over a present `:value`), inner `:err` map → distinct cljs-eval-error reject, non-`:results` map / bare scalar → verbatim, and the `read-edn-safe` parse-failure fallback at BOTH nesting levels (raw-string return, never a throw).

2. **`decode-all-frames` partial-frame retention not pinned on the public seam.** Covered only indirectly via `attach-handlers!`. Added 4 tests directly on the walker: truncated frame → 0 frames + bytes retained as trailer; complete-frame-then-incomplete-tail split; empty-buffer base case.

3. **`args/read-edn-arg` (the rf2-jkake.19 shared EDN-arg helper for `reset-frame-db`/`restore-epoch`/`handler-meta`) and `parse-filter-arg`'s `:else` arm had no direct unit coverage.** Added to `args_test`: the helper's `[:ok parsed]` / `[:err missing]` / `[:err invalid]` outcomes, caller-specific reason keywords, and its inherited read-string-reads-only-the-first-form contract (`"nope("` → `[:ok nope]`, not an error — informative real behaviour the test now documents); plus `parse-filter-arg`'s JS-object `:keywordize-keys` arm (flat + nested).

## MCP contract / behaviour

Unchanged. No production source touched — edits are confined to `tools/re-frame2-pair-mcp/test/`. Tool names, input schemas, and runtime behaviour are identical; no testability seam was needed (the production code already exposes `cljs-eval` / `decode-all-frames` / `read-edn-arg` as the right stub points).
