### PR TITLE
test(mcp-conformance): coverage & rigour pass (rf2-ynjts.18)

### DIFF
--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -88,8 +88,10 @@
             [clojure.test    :refer [deftest is testing]]
             [malli.core      :as m]
             [malli.error     :as me]
+            [re-frame.mcp-base.cursor :as mcp-cursor]
             [re-frame.mcp-base.diff-encode :as de]
             [re-frame.mcp-base.overflow :as mcp-overflow]
+            [re-frame.mcp-base.vocab :as mcp-vocab]
             [re-frame.mcp-conformance.fixtures :as fx]))
 
 ;; ---------------------------------------------------------------------------
@@ -1203,6 +1205,57 @@
   (is (not (m/validate CursorStaleResult
                        {:ok? false :reason :rf.mcp/cursor-stales}))
       "CursorStaleResult MUST reject the pluralised near-miss"))
+
+(deftest cursor-stale-reason-emitted-live-by-canonical-builder
+  ;; LIVE-emission gate for `:rf.mcp/cursor-stale` (mirrors
+  ;; `overflow-marker-shape-emitted-live-by-canonical-builder` for
+  ;; `:rf.mcp/overflow`). Both reason/marker builders were hoisted into
+  ;; the shared `mcp-base` ns (rf2-ee38b.19), so both are now
+  ;; JVM-reachable from this pure-JVM gate — `overflow-payload` already
+  ;; got its live counterpart, `cursor-stale-result` did not.
+  ;;
+  ;; The gap this closes: the existing cursor-stale coverage was exactly
+  ;; the two layers rf2-80y2h flagged as insufficient for `diff-from` —
+  ;; (1) an authored fixture validated against `CursorStaleResult`, and
+  ;; (2) a source-text grep that the `:rf.mcp/cursor-stale` literal is
+  ;; DECLARED in `mcp-base/vocab.cljc`. Neither observes the actual
+  ;; BUILDER. A regression that hardcoded a drifted `:reason` literal in
+  ;; `cursor-stale-result` (decoupling it from `vocab/cursor-stale-reason`),
+  ;; or dropped the `:ok? false` posture, would: leave the vocab literal
+  ;; in place (grep passes), leave the authored fixture untouched
+  ;; (fixture passes), and ship a builder whose emission no longer
+  ;; matches the constant agents pattern-match on. Every gate green.
+  ;;
+  ;; Drive the real builder with a minimal `error-result` that merely
+  ;; returns the structured data-map (each server shapes the wire
+  ;; envelope its own way; the cross-MCP contract this builder owns is
+  ;; the `:reason` value + the `:ok? false` posture, per the
+  ;; `cursor-stale-result` docstring) and assert the emitted envelope.
+  (let [emitted (mcp-cursor/cursor-stale-result
+                  (fn [_message data] data)
+                  "watch-epochs"
+                  {:extra {:requested-id "epoch-9001"
+                           :head-id      "epoch-9101"}})]
+    (testing "the builder sources :reason from vocab/cursor-stale-reason"
+      (is (= mcp-vocab/cursor-stale-reason (:reason emitted))
+          (str "cursor-stale-result MUST emit the canonical "
+               ":reason value (vocab/cursor-stale-reason). If this fails, "
+               "the builder hardcoded a literal that drifted from the "
+               "vocab constant agents pattern-match on. Got :reason = "
+               (pr-str (:reason emitted)))))
+    (testing "the emitted :reason is the pinned cross-MCP keyword"
+      (is (= :rf.mcp/cursor-stale (:reason emitted))
+          "the canonical reason keyword is :rf.mcp/cursor-stale"))
+    (testing "the emitted envelope validates against canonical CursorStaleResult"
+      (is (m/validate CursorStaleResult emitted)
+          (str "Live-emitted cursor-stale envelope failed CursorStaleResult "
+               "validation:\n" (me/humanize (m/explain CursorStaleResult emitted)))))
+    (testing "the builder preserves the :ok? false error posture"
+      (is (false? (:ok? emitted))
+          "cursor-stale rides an :ok? false envelope — success never carries a stale-reason"))
+    (testing "the consumer's :extra slots merge through verbatim"
+      (is (= "epoch-9001" (:requested-id emitted)))
+      (is (= "epoch-9101" (:head-id emitted))))))
 
 (deftest cursor-stale-literal-in-re-frame2-pair-mcp-emit-source
   ;; The canonical declaration lives in mcp-base/vocab.cljc — same


### PR DESCRIPTION
## Quality gates

wire-vocab `clojure -M:test` (the slice gate; gate [6/6] of `npm run test:mcp-conformance`):

| | tests | assertions | failures | errors |
|---|---|---|---|---|
| before | 48 | 615 | 0 | 0 |
| after  | 49 | 621 | 0 | 0 |

clj-kondo (changed file): 0 errors, 0 warnings. No `.cjs` touched (eslint N/A).

**All 615 pre-existing assertions unchanged — strictly additive, nothing weakened. Conformance contract + scenario set behaviour stable.**

## Gap closed

`:rf.mcp/cursor-stale` carried exactly the two coverage layers rf2-80y2h flagged as insufficient for `:rf.mcp/diff-from`:

1. an authored fixture validated against `CursorStaleResult`, and
2. a source-text grep that the literal is **declared** in `mcp-base/vocab.cljc`.

Neither observes the actual **builder**. The canonical builder `mcp-base.cursor/cursor-stale-result` was hoisted into the shared pure-CLJC `mcp-base` ns (rf2-ee38b.19) and is now JVM-reachable from this gate — its peer `overflow-payload` already got a live-emission counterpart (`overflow-marker-shape-emitted-live-by-canonical-builder`); `cursor-stale-result` did not.

A regression that hardcoded a drifted `:reason` literal (decoupling it from `vocab/cursor-stale-reason`), or dropped the `:ok? false` posture, would pass the grep (literal still declared) and pass the fixture (authored data untouched) while shipping a builder whose emission no longer matches the constant agents pattern-match on. Every gate green — the exact "emitter silently broke" hole rf2-80y2h was created to close.

## New assertion

`cursor-stale-reason-emitted-live-by-canonical-builder` drives the real builder (with a minimal `error-result` passthrough, since each server shapes its own wire envelope) and asserts:

- the emitted `:reason` equals `vocab/cursor-stale-reason` — proves the builder **sources the canonical constant**, not a drifted literal;
- the reason is the pinned `:rf.mcp/cursor-stale` keyword;
- the emitted envelope validates against the canonical `CursorStaleResult` schema;
- the `:ok? false` error posture is preserved (success never carries a stale-reason);
- the consumer's `:extra` slots merge through verbatim.

## Rest of the slice — assessed as already strong (no changes)

The wire-vocab suite pins six wrapper markers (live **encoder** gate for `diff-from`, live **builder** gate for `overflow`, fixture+schema+grep+near-miss anti-pin for the rest), the `cursor-stale` + `:rf/redacted` scalar sentinels, envelope indicator-field parity, slot-name + verb-vocab linters, and JS↔Malli cross-encoding for overflow + progress params. The Node-side end-to-end harnesses drive both servers through the real MCP SDK (catalogue, descriptor shape, degraded/live envelopes, JSON-RPC error codes, flag-gate default-OFF + hard-rename rejection, dedup-envelope semantic decode); the `exec-safety` unit suite covers the cross-platform exec-resolution + symlink-escape gating. No scenario gaps warranting further additions; no weak/tautological assertions found.

Closes rf2-ynjts.18.