### PR TITLE
test(core): coverage & rigour pass (rf2-ynjts.1)

### DIFF
--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -595,6 +595,115 @@
           "only the one (uncaught) :before error is in the vector —
            skipped :before stages don't synthesize errors"))))
 
+;; ---- context-plumbing helpers (rf2-ynjts.1) -------------------------------
+;;
+;; `get-coeffect` / `assoc-coeffect` / `update-coeffect` / `get-effect` /
+;; `assoc-effect` are the public read/write substrate every custom
+;; interceptor uses (re-exported as `rf/get-coeffect` etc. per
+;; spec/API.md §Interceptors). The chain / dispatch tests above exercise
+;; them obliquely, but nothing pinned their ARITY contracts directly —
+;; in particular the 3-arity `not-found` forms of the two readers and
+;; `update-coeffect`'s trailing-args form had no coverage. These are
+;; pure fns over the context map; pinning them here means an arity
+;; regression surfaces at the source rather than via a far-off cascade
+;; assertion. Driven directly against a literal context map — no runtime.
+
+(deftest get-coeffect-arities
+  (let [ctx {:coeffects {:db {:n 1} :event [:e 7] :now 42} :effects {}}]
+    (testing "1-arity returns the whole :coeffects map"
+      (is (= {:db {:n 1} :event [:e 7] :now 42}
+             (interceptor/get-coeffect ctx))))
+    (testing "2-arity returns the value at k, nil when absent"
+      (is (= {:n 1} (interceptor/get-coeffect ctx :db)))
+      (is (= [:e 7] (interceptor/get-coeffect ctx :event)))
+      (is (nil? (interceptor/get-coeffect ctx :missing))
+          "absent key yields nil under the 2-arity form"))
+    (testing "3-arity returns not-found when the key is absent, the value when present"
+      (is (= ::sentinel (interceptor/get-coeffect ctx :missing ::sentinel))
+          "absent key yields the not-found arg")
+      (is (= {:n 1} (interceptor/get-coeffect ctx :db ::sentinel))
+          "present key wins over not-found"))
+    (testing "3-arity distinguishes a stored nil from absence"
+      (let [ctx-nil {:coeffects {:maybe nil} :effects {}}]
+        (is (nil? (interceptor/get-coeffect ctx-nil :maybe ::sentinel))
+            "a key present with value nil returns nil, NOT the not-found arg")
+        (is (= ::sentinel (interceptor/get-coeffect ctx-nil :absent ::sentinel))
+            "a genuinely absent key still returns the not-found arg")))))
+
+(deftest get-effect-arities
+  (let [ctx {:coeffects {} :effects {:db {:n 2} :fx [[:do-thing]]}}]
+    (testing "1-arity returns the whole :effects map"
+      (is (= {:db {:n 2} :fx [[:do-thing]]} (interceptor/get-effect ctx))))
+    (testing "2-arity returns the value at k, nil when absent"
+      (is (= {:n 2} (interceptor/get-effect ctx :db)))
+      (is (= [[:do-thing]] (interceptor/get-effect ctx :fx)))
+      (is (nil? (interceptor/get-effect ctx :missing))))
+    (testing "3-arity returns not-found when absent"
+      (is (= ::none (interceptor/get-effect ctx :missing ::none)))
+      (is (= {:n 2} (interceptor/get-effect ctx :db ::none))))
+    (testing "3-arity distinguishes a stored nil from absence"
+      (let [ctx-nil {:coeffects {} :effects {:db nil}}]
+        (is (nil? (interceptor/get-effect ctx-nil :db ::none)))
+        (is (= ::none (interceptor/get-effect ctx-nil :fx ::none)))))))
+
+(deftest assoc-coeffect-writes-and-is-readable
+  (testing "assoc-coeffect sets k in :coeffects and returns the updated ctx;
+            the round-trip is observable via get-coeffect"
+    (let [ctx  {:coeffects {:db {:n 1}} :effects {}}
+          ctx' (interceptor/assoc-coeffect ctx :now 99)]
+      (is (= 99 (interceptor/get-coeffect ctx' :now))
+          "the assoc'd value reads back through get-coeffect")
+      (is (= {:n 1} (interceptor/get-coeffect ctx' :db))
+          "sibling coeffects are preserved")
+      (is (= {} (:effects ctx'))
+          ":effects is untouched by a coeffect write")
+      (is (nil? (interceptor/get-coeffect ctx :now))
+          "the original ctx is unchanged (persistent — no in-place mutation)"))))
+
+(deftest assoc-effect-writes-and-is-readable
+  (testing "assoc-effect sets k in :effects and returns the updated ctx"
+    (let [ctx  {:coeffects {:db {:n 1}} :effects {}}
+          ctx' (interceptor/assoc-effect ctx :db {:n 2})]
+      (is (= {:n 2} (interceptor/get-effect ctx' :db))
+          "the assoc'd effect reads back through get-effect")
+      (is (= {:n 1} (interceptor/get-coeffect ctx' :db))
+          ":coeffects :db is independent of :effects :db")
+      (is (= {} (:effects ctx))
+          "the original ctx's :effects is unchanged (persistent)"))))
+
+(deftest update-coeffect-applies-fn-with-trailing-args
+  (testing "update-coeffect applies f to the value at k, threading trailing args"
+    (let [ctx {:coeffects {:n 10} :effects {}}]
+      (is (= 11 (interceptor/get-coeffect
+                  (interceptor/update-coeffect ctx :n inc) :n))
+          "no-arg fn form: inc applied to the value at :n")
+      (is (= 13 (interceptor/get-coeffect
+                  (interceptor/update-coeffect ctx :n + 3) :n))
+          "single trailing arg threaded after the current value")
+      (is (= 16 (interceptor/get-coeffect
+                  (interceptor/update-coeffect ctx :n + 3 2 1) :n))
+          "multiple trailing args threaded in order")))
+  (testing "update-coeffect on an absent key applies f to nil"
+    ;; A fn that records the arg it was handed for the absent key, then
+    ;; returns a deterministic value. Confirms f is invoked with nil
+    ;; (clojure.core/update-in semantics) — not skipped.
+    (let [seen-arg (atom ::unset)
+          result   (interceptor/update-coeffect
+                     {:coeffects {} :effects {}}
+                     :missing
+                     (fn [v] (reset! seen-arg v) :computed))]
+      (is (nil? @seen-arg)
+          "f saw nil for the absent key (matches clojure.core/update-in semantics)")
+      (is (= :computed (interceptor/get-coeffect result :missing))
+          "f's return value is written back at the previously-absent key")))
+  (testing "update-coeffect preserves siblings and leaves :effects untouched"
+    (let [ctx  {:coeffects {:n 10 :keep :me} :effects {:db {}}}
+          ctx' (interceptor/update-coeffect ctx :n inc)]
+      (is (= :me (interceptor/get-coeffect ctx' :keep))
+          "sibling coeffects preserved")
+      (is (= {:db {}} (:effects ctx'))
+          ":effects untouched"))))
+
 ;; ---- pipeline-exception attribution (rf2-mszrz) ---------------------------
 ;;
 ;; The :before/:after chain runs three distinct kinds of component — the


### PR DESCRIPTION
## Quality gates

| Gate | Before | After |
| --- | --- | --- |
| core JVM (`clojure -M:test`) | 808 tests / 3595 assertions, 0 fail | 813 tests / 3625 assertions, 0 fail |
| `npm run test:cljs` (ripple) | — | 5094 tests / 17225 assertions, 0 fail |
| clj-kondo (changed file) | — | 0 errors, 0 warnings |

## Coverage & rigour review — `implementation/core/`

Reviewed the most-consumed core slice — interceptor chain, fx/cofx error taxonomy, sub L1→L2→L3 invalidation + cache lifecycle, frame isolation/lifecycle, registrar cleanup, drain/run-to-completion, platform resolution.

**Finding: the suite is mature and exceptionally strong.** Coverage is behaviour-asserting (not vacuous), deterministic (JVM next-tick races are deliberately tamed with `with-redefs`), and pins real invariants per Spec citation. Areas the bead flagged are already deeply covered:

- Interceptor chain ordering + short-circuit + `:after` teardown + multi-error vector + per-component exception attribution + source-coord (`interceptor_test.clj`).
- fx/cofx error taxonomy, `:isolated` recovery, `:platforms` gating, override precedence, effect-map shape policing (`fx_test.clj`, `cofx_test.clj`).
- Sub ref-count disposal, layer-2/3 cascade decrement, shared/external-held inputs, memo value-equality short-circuit, hot-reload eviction, topology (`sub_cache_test.clj`, `sub_memo_layer_*_test.clj`, `sub_topology_test.clj`).
- Frame surgical update, destroy cascades, drain-interrupt, write-after-destroy guard, presets, reset (`frame_lifecycle_test.clj`).
- Registrar unknown-kind throw, `valid-kind?`, hook isolation, `registrations` 2-arity (`core_contract_guards_test.clj`, `core_api_additions_test.clj`).
- Platform resolution + `init-platform` validation/idempotence (`init_platform_test.clj`); drain depth/isolation/run-to-completion (`drain_test.clj`).

### Gap filled

One genuine, narrow gap on a **public surface**: the interceptor context-plumbing helpers — `get-coeffect` / `assoc-coeffect` / `update-coeffect` / `get-effect` / `assoc-effect` (re-exported as `rf/*` per `spec/API.md §Interceptors`) — were exercised only obliquely through the dispatch path. Their **arity contracts** had no direct pin, in particular:

- the 3-arity `not-found` forms of `get-coeffect` / `get-effect` (incl. stored-`nil`-vs-absent distinction),
- `update-coeffect`'s trailing-args form (none / single / multiple) and its absent-key (`f` sees `nil`) behaviour.

Added 5 `deftest`s to `interceptor_test.clj`:

- `get-coeffect-arities` / `get-effect-arities` — 1/2/3 arities; not-found arg; nil-vs-absent.
- `assoc-coeffect-writes-and-is-readable` / `assoc-effect-writes-and-is-readable` — write + read-back, sibling/slot independence, original-ctx persistence.
- `update-coeffect-applies-fn-with-trailing-args` — no/single/multi trailing args; absent-key applies `f` to `nil`.

Pure-fn unit tests over a literal context map — fully deterministic, no runtime. **No `src/` behaviour changed** (test-only edit).
