### PR TITLE
test(adapters/reagent-slim): coverage & rigour pass (rf2-ynjts.3)

### DIFF
--- a/implementation/adapters/reagent-slim/test/reagent2/core_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/core_cljs_test.cljs
@@ -8,8 +8,21 @@
       rf2-okpsr — :deep? has no React 19 analogue and no audited
       caller relied on it).
 
-  Other reagent2.core surfaces are exercised through their dedicated
-  per-impl tests (component / template / ratom / batching / dom-throw).
+    - Form-3 component-state surface (rf2-ynjts.3 coverage pass): the
+      PUBLIC `reagent2.core` wrappers `state-atom` / `state` /
+      `set-state` / `replace-state` and the argv accessors `argv` /
+      `props` / `children`. These are the symbols downstream code
+      imports as `reagent.core/state` etc. (re-com / Day8). The
+      underlying `reagent2.impl.component/*` fns are pinned in
+      component_cljs_test; what was UNVERIFIED before this pass is the
+      `reagent2.core`-level wiring — that `state` derefs the cached
+      cell, `set-state` MERGES while `replace-state` RESETS (a real,
+      distinguishable invariant a key-swap bug would otherwise slip),
+      and that the accessor wrappers route to the right impl fn. The
+      `reagent2.core` re-export `atom`, the `reaction` function form,
+      `create-class`, `current-component`, `after-render`, and
+      `as-element` keep their dedicated per-impl coverage
+      (ratom / component / template / batching).
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
@@ -53,3 +66,131 @@
           ":arglists declares exactly one signature")
       (is (= '[^js this] (first arglists))
           ":arglists is [this] only"))))
+
+;; ---------------------------------------------------------------------------
+;; Form-3 component-state surface (rf2-ynjts.3)
+;;
+;; `reagent2.core/state-atom` lazily creates a per-component RAtom and
+;; caches it on the instance; `state` derefs it; `set-state` MERGES a map
+;; into it; `replace-state` RESETS it. These public wrappers are the
+;; Form-3 component-local-state API (re-com / Day8). The impl-level
+;; `component/state-atom` is pinned in component_cljs_test; here we pin
+;; the `reagent2.core`-level behaviour — most importantly that `set-state`
+;; and `replace-state` are NOT interchangeable (merge vs replace).
+;; ---------------------------------------------------------------------------
+
+(deftest state-atom-lazily-creates-and-caches
+  (testing "(state-atom this) creates a cell on first call and returns
+            the SAME cell on every subsequent call for that instance"
+    (let [this #js {}
+          a    (r/state-atom this)
+          a2   (r/state-atom this)]
+      (is (some? a) "first call materialised a state cell")
+      (is (identical? a a2)
+          "second call returned the cached cell, not a fresh atom"))))
+
+(deftest state-reads-the-cell
+  (testing "(state this) is nil before any state is set, then reflects
+            the cached state-atom's value"
+    (let [this #js {}]
+      (is (nil? (r/state this))
+          "no state set yet → nil (derefs the freshly-seeded cell)")
+      (reset! (r/state-atom this) {:count 3})
+      (is (= {:count 3} (r/state this))
+          "state derefs the same cell that state-atom returns"))))
+
+(deftest set-state-merges
+  (testing "(set-state this m) MERGES m into the existing state map —
+            sibling keys survive; colliding keys are overwritten"
+    (let [this #js {}]
+      (r/set-state this {:a 1 :b 2})
+      (is (= {:a 1 :b 2} (r/state this))
+          "first set-state seeds the map")
+      (r/set-state this {:b 20 :c 3})
+      (is (= {:a 1 :b 20 :c 3} (r/state this))
+          "second set-state merged: :a survived, :b overwritten, :c added"))))
+
+(deftest replace-state-resets
+  (testing "(replace-state this m) REPLACES the whole state map —
+            prior keys are dropped, NOT merged (the set-state contrast)"
+    (let [this #js {}]
+      (r/set-state this {:a 1 :b 2})
+      (is (= {:a 1 :b 2} (r/state this)) "precondition: state seeded")
+      (r/replace-state this {:only :this})
+      (is (= {:only :this} (r/state this))
+          "replace-state dropped :a and :b — it reset, did not merge"))))
+
+(deftest set-state-and-replace-state-are-distinct
+  (testing "set-state and replace-state are NOT interchangeable on the
+            same starting state — a key-swap bug would fail here"
+    (let [merge-this   #js {}
+          replace-this #js {}
+          seed         {:keep 1}]
+      (r/set-state merge-this seed)
+      (r/replace-state replace-this seed)
+      ;; Apply the same delta via each mutator.
+      (r/set-state merge-this {:add 2})
+      (r/replace-state replace-this {:add 2})
+      (is (= {:keep 1 :add 2} (r/state merge-this))
+          "set-state kept the original :keep")
+      (is (= {:add 2} (r/state replace-this))
+          "replace-state discarded the original :keep")
+      (is (not= (r/state merge-this) (r/state replace-this))
+          "the two mutators produced observably different results"))))
+
+(deftest state-is-per-instance
+  (testing "state cells are keyed per component instance — two instances
+            do not share state"
+    (let [a #js {}
+          b #js {}]
+      (r/set-state a {:who :a})
+      (r/set-state b {:who :b})
+      (is (= {:who :a} (r/state a)))
+      (is (= {:who :b} (r/state b))
+          "instance b's state is independent of instance a's")
+      (is (not (identical? (r/state-atom a) (r/state-atom b)))
+          "distinct instances get distinct state cells"))))
+
+;; ---------------------------------------------------------------------------
+;; Form-3 argv accessors (rf2-ynjts.3)
+;;
+;; `reagent2.core/argv` / `props` / `children` are thin wrappers over the
+;; `component/get-*` fns (impl-pinned in component_cljs_test). Here we pin
+;; the `reagent2.core`-level routing + the props/children convention: the
+;; head is the render fn, argv[1] is the props map iff it is a map, and
+;; children are everything after the head (skipping the props map when
+;; present).
+;; ---------------------------------------------------------------------------
+
+(defn- fake-instance
+  "Minimal stand-in carrying the .-cljsArgv slot the accessors read."
+  [argv]
+  (let [c #js {}]
+    (set! (.-cljsArgv c) argv)
+    c))
+
+(deftest argv-returns-full-arg-vector
+  (testing "(argv this) returns the full hiccup-style argv (head included)"
+    (let [render-fn (fn [_])
+          this      (fake-instance [render-fn {:k :v} :child])]
+      (is (= [render-fn {:k :v} :child] (r/argv this))))))
+
+(deftest props-returns-map-second-arg
+  (testing "(props this) returns argv[1] iff it is a map, else nil"
+    (let [render-fn (fn [_])]
+      (is (= {:k :v}
+             (r/props (fake-instance [render-fn {:k :v} :child])))
+          "map second arg surfaces as props")
+      (is (nil? (r/props (fake-instance [render-fn :child])))
+          "non-map second arg → nil props"))))
+
+(deftest children-skip-props-map
+  (testing "(children this) returns the tail after the head, skipping a
+            leading props map when present"
+    (let [render-fn (fn [_])]
+      (is (= [:a :b]
+             (vec (r/children (fake-instance [render-fn {:k :v} :a :b]))))
+          "props map present → children start after it")
+      (is (= [:a :b]
+             (vec (r/children (fake-instance [render-fn :a :b]))))
+          "no props map → children start right after the head"))))


### PR DESCRIPTION
Testing coverage & rigour review of `implementation/adapters/reagent-slim/` (bead rf2-ynjts.3, epic rf2-ynjts).

## Quality gates

| Gate | Before | After |
|---|---|---|
| `npm run test:cljs` (node) | 5104 tests / 17242 assertions, 0 fail | 5113 tests / 17261 assertions, 0 fail |
| reagent-slim JVM `clojure -M:test` | 11 tests / 12 assertions, 0 fail | 11 tests / 12 assertions, 0 fail (unchanged — `.clj` macro side) |
| `npm run test:reagent-slim:bundle-isolation` | PASS (3 contracts, 19 sentinels) | PASS (3 contracts, 19 sentinels) |
| clj-kondo on changed file | — | 0 errors, 0 warnings |

Delta: +9 deftests / +19 assertions (CLJS), all in the one changed test file.

## Finding: existing coverage is already very strong

reagent-slim is the bundle-isolated twin of the Reagent adapter (vendored `reagent2.*` tree). Unlike UIx/Helix, slim does NOT wire out of `make-react-spine`, so it is NOT covered by `re-frame.adapter.react-shared-suite` — slim's own per-impl + adapter test files ARE its primary coverage. Those files were audited end to end and are comprehensive and rigorous:

- **ratom** — RAtom protocols, validator, watches, Reaction deref-capture / equality-memo / dependency-pruning / dispose / auto-run, `flush!` cascades, the checked-recompute error-preservation regression (rf2-ee38b.15), cross-substrate disposable protocol.
- **component** — 7-key cap, Form-1/2/3 detection (runtime + compile-time fast path), lifecycle plumbing, error-boundary contract (getDerivedStateFromError auto-install, nested isolation, rethrow), `as-element` seam unregistered throw.
- **template** — tag parse, prop-name conversion, narrowed `convert-prop-value`, warn-once, fn-identity preservation (rf2-wyocr), prototype-pollution defence (rf2-dwds9), interop heads, keys.
- **dom.server + parity** — full static-markup serializer incl. XSS event-handler stripping (rf2-dwds9) and byte-for-byte parity against `react-dom/server`.
- **batching / dom.client** — microtask scheduling, dedup, ordering, Suspense composition (rf2-w6ef), deref-capture wiring + render-recompute regression (rf2-u5p5).
- **adapter** — 9-key shape, state-container round-trip, derived-value arity spec, render Root-API pin (rf2-fn5rk), dispose four-MUST (sub-cache walk + root drain + emitter clear + best-effort poison), source-coord / view-id stamping + prod-elision + warn-once, late-bind hook set, derived-container-replaced guard, current-component hook.
- Bundle isolation (the slim-unique concern) is gated by `npm run test:reagent-slim:bundle-isolation` — no stock-Reagent impl + no `react-dom/server` in the slim bundle.

## Gap closed

The one genuine gap: the PUBLIC `reagent2.core` Form-3 surface (`state-atom`, `state`, `set-state`, `replace-state`) and accessor wrappers (`argv`, `props`, `children`) had no direct test. The underlying `component/*` impl fns were pinned in `component_cljs_test`, but the `reagent2.core`-level wiring — the symbols downstream code imports as `reagent.core/state` etc. (re-com / Day8) — was unverified. `core_cljs_test` even documented itself as covering only `force-update`.

New tests added to `reagent2/core_cljs_test.cljs`:

- `state-atom` lazy-creates + caches per instance; `state` derefs the cell.
- `set-state` **merges** vs `replace-state` **resets** — incl. a head-to-head test proving they are NOT interchangeable on the same starting state (a key-swap bug would fail here).
- state is per-instance (distinct cells).
- `argv` / `props` / `children` route correctly and honour the props-map / children convention.

## src behaviour

No src changes — confirmed: the diff touches only `test/reagent2/core_cljs_test.cljs` (test + docstring). Public API and behaviour unchanged.