### PR TITLE
refactor(privacy): canonicalise :rf/redacted to re-frame.privacy (rf2-qe237)

### DIFF
--- a/implementation/http/src/re_frame/http_url.cljc
+++ b/implementation/http/src/re_frame/http_url.cljc
@@ -33,23 +33,30 @@
   (app-readable state — `declare-sensitive-query-param!` writes
   through), but no walker runs without the trace surface."
   (:require [clojure.set :as set]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [re-frame.privacy :as privacy]))
 
-;; ---- canonical redaction sentinel -----------------------------------------
+;; ---- redaction sentinel ---------------------------------------------------
 ;;
-;; rf2-ee38b.7 — single source of truth for the framework-reserved
-;; redaction sentinel per Spec 009 §Privacy. Sits in the `:rf/` reserved-
-;; keyword namespace so apps cannot legitimately produce it as a payload
-;; value. `http-url` is the natural owner: it is the privacy leaf with no
-;; intra-privacy dependencies, so `http-privacy` and `http-privacy-headers`
-;; can both refer to it without creating a leaf→parent cycle. Consumers
-;; wanting "was this redacted?" check `(= :rf/redacted v)`.
+;; The framework-reserved redaction sentinel per Spec 009 §Privacy sits in
+;; the `:rf/` reserved-keyword namespace so apps cannot legitimately produce
+;; it as a payload value. Consumers wanting "was this redacted?" check
+;; `(= :rf/redacted v)`.
+;;
+;; rf2-qe237 — the single source of truth is now `re-frame.privacy/
+;; redacted-sentinel` in core (already consumed by elision / marks). Core is
+;; on the http classpath, so this artefact refers to the canonical def
+;; rather than re-declaring the keyword literal. `http-url` remains the
+;; http-side re-export anchor — it is the privacy leaf with no intra-privacy
+;; dependencies, so `http-privacy` and `http-privacy-headers` can both refer
+;; to it without creating a leaf→parent cycle (rf2-ee38b.7 intra-http shape).
 
 (def redacted-sentinel
   "The framework-reserved redaction sentinel keyword per Spec 009 §Privacy.
-  Canonical home (rf2-ee38b.7) — `http-privacy` re-exports it and
-  `http-privacy-headers` refers to it."
-  :rf/redacted)
+  Re-exported from the canonical `re-frame.privacy/redacted-sentinel` in
+  core (rf2-qe237) — `http-privacy` re-exports it and `http-privacy-headers`
+  refers to it."
+  privacy/redacted-sentinel)
 
 ;; ---- query-param denylist (rf2-2p8wr) -------------------------------------
 

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -25,6 +25,7 @@
   (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.privacy :as privacy]
             [re-frame.schemas.validator :as validator]
             [re-frame.schemas.walker :as walker]
             [re-frame.source-coords :as source-coords]))
@@ -225,12 +226,13 @@
 ;; value fails the new schema. A no-op re-eval with the same schema does
 ;; nothing; a re-eval that the live value still satisfies does nothing.
 
-(def ^:private redacted-sentinel
-  "The `:rf/redacted` privacy sentinel — Spec 009 §Privacy. Stamped in
-  place of `:mismatching-value` when the new schema declares the slot
-  sensitive, mirroring the `:rf.error/schema-validation-failure`
-  redaction posture so the hot-reload trace never re-leaks a credential."
-  :rf/redacted)
+;; The `:rf/redacted` privacy sentinel — Spec 009 §Privacy. Stamped in
+;; place of `:mismatching-value` when the new schema declares the slot
+;; sensitive, mirroring the `:rf.error/schema-validation-failure`
+;; redaction posture so the hot-reload trace never re-leaks a credential.
+;; rf2-qe237 — refer to the canonical core def rather than a local copy so
+;; the keyword can never drift across artefacts.
+(def ^:private redacted-sentinel privacy/redacted-sentinel)
 
 (defn- maybe-emit-schema-violation!
   "Emit `:rf.schema/violation` when a re-registration changes the schema

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -78,6 +78,7 @@
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.privacy :as privacy]
             [re-frame.schemas.storage :as storage]
             [re-frame.schemas.validator :as validator]
             [re-frame.schemas.walker :as walker]
@@ -85,12 +86,12 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(def ^:private redacted-sentinel
-  "The `:rf/redacted` privacy sentinel emitted by validation traces
-  for slots matching the `:sensitive?` predicate. Per Spec 009
-  §Privacy — the framework-reserved keyword that cannot
-  collide with an app-defined value."
-  :rf/redacted)
+;; The `:rf/redacted` privacy sentinel emitted by validation traces for
+;; slots matching the `:sensitive?` predicate. Per Spec 009 §Privacy —
+;; the framework-reserved keyword that cannot collide with an app-defined
+;; value. rf2-qe237 — refer to the canonical core def rather than a local
+;; copy so the keyword can never drift across artefacts.
+(def ^:private redacted-sentinel privacy/redacted-sentinel)
 
 ;; NOTE: the handler-meta `:sensitive?` annotation has been removed.
 ;; Sensitivity is now path-marked at the schema slot — `walk-schema?`


### PR DESCRIPTION
## Quality gates

All green from `implementation/`:

| Gate | Result |
|------|--------|
| `clj-kondo` (3 changed files) | 0 errors, 0 warnings |
| schemas JVM `clojure -M:test` | 207 tests / 18291 assertions — 0 failures, 0 errors |
| http JVM `clojure -M:test` | 280 tests / 1442 assertions — 0 failures, 0 errors |
| core JVM `clojure -M:test` | 813 tests / 3625 assertions — 0 failures, 0 errors |
| `npm run test:cljs` (cross-artefact ripple detector) | 5121 tests / 17281 assertions — 0 failures, 0 errors |

## Consolidation

The `:rf/redacted` sentinel (Spec 009 §Privacy) was re-declared as a local keyword literal in three slices instead of referencing the canonical `re-frame.privacy/redacted-sentinel` in core (already consumed by `re-frame.elision` and `re-frame.marks`). `re-frame.privacy` is on both the schemas and http classpaths (both `:local/root` depend on core), so the duplicates now reference the single canonical def.

Defs now referencing the canonical:

- **`implementation/schemas/src/re_frame/schemas/validate.cljc`** — `^:private redacted-sentinel` → `privacy/redacted-sentinel` (added `[re-frame.privacy :as privacy]` require).
- **`implementation/schemas/src/re_frame/schemas/storage.cljc`** — `^:private redacted-sentinel` → `privacy/redacted-sentinel` (added require).
- **`implementation/http/src/re_frame/http_url.cljc`** — `redacted-sentinel` → `privacy/redacted-sentinel` (added require). `http-url` stays the http-side re-export anchor that `http-privacy` re-exports and `http-privacy-headers` refers to (the intra-http leaf shape from rf2-ee38b.7 is preserved — no leaf→parent cycle); it now derives from core's canonical rather than a literal.

No def needed to stay a literal for elision DCE: `elision.cljc` already references `privacy/redacted-sentinel` in its production path, proving the canonical def inlines safely under Closure. The URL string form (`redacted-url-token`) still derives from the local `redacted-sentinel` var, so it tracks the canonical automatically.

## Invariants

- Keyword **value** `:rf/redacted` is byte-identical — every duplicate def held the same literal; consolidation only changes where the value is sourced.
- Public API stable — `re-frame.http-privacy/redacted-sentinel` and `re-frame.http-url/redacted-sentinel` remain exported with the same value.
- Behaviour-preserving single-source-of-truth refactor; no value change.
