### PR TITLE
test(react-suite): :key parity contract + hoist react-element-attr + clarify probe/cfg names (3 beads incl. rf2-hhb1r)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_source_coord_dom_elision_prod_test.cljs
@@ -26,21 +26,17 @@
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.helix :as helix-adapter]
+            ;; rf2-5g21s — the react-element-attr accessor is hoisted into
+            ;; the dependency-free shared test home (out of cross-suite
+            ;; duplication with the UIx twin); reference it rather than
+            ;; carry a copy. Kept separate from react-shared-suite so this
+            ;; prod-elision build does not pull the suite's heavy deps.
+            [re-frame.adapter.react-test-support :refer [react-element-attr]]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter helix-adapter/adapter}))
-
-(defn- react-element-attr
-  "Pull `attr` off a React element's `.-props`, or nil. Defensively
-  returns nil on every branch so the test assertions can use `nil?`.
-  Both prod-elision attrs (`data-rf2-source-coord` + `data-rf-view`)
-  ride the same `interop/debug-enabled?` gate, so one reader covers
-  both."
-  [el attr]
-  (when (and el (.-props el))
-    (aget (.-props el) attr)))
 
 ;; ---- annotation elides under :advanced + goog.DEBUG=false ----------------
 

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -44,10 +44,10 @@
 ;; and close over these atoms; the suite `reset!`s the atom each assertion
 ;; cares about at the top of its body.
 
-(def ^:private probe-observed    (atom []))
-(def ^:private probe-fp-observed (atom []))
-(def ^:private refcount-target   (atom nil))
-(def ^:private mwft2-set-tick    (atom nil))
+(def ^:private probe-observed                (atom []))
+(def ^:private probe-frame-provider-observed (atom []))
+(def ^:private refcount-target               (atom nil))
+(def ^:private stable-deps-set-tick          (atom nil))
 
 (defnc Probe []
   (let [target @refcount-target
@@ -55,44 +55,44 @@
     (swap! probe-observed conj v)
     (d/div (str "n=" v))))
 
-(defnc ProbeFp []
+(defnc ProbeFrameProvider []
   (let [v (helix-adapter/use-subscribe [:rf.helix-use-subscribe-test/k])]
-    (swap! probe-fp-observed conj v)
+    (swap! probe-frame-provider-observed conj v)
     (d/div (str "k=" v))))
 
-(defnc ProbeRc []
+(defnc ProbeRefcount []
   (let [target @refcount-target
         v (helix-adapter/use-subscribe target [:rf.helix-use-subscribe-test/m])]
     (d/div (str "m=" v))))
 
-;; ---- rf2-y0db2 2-arg explicit-pin probes ----------------------------------
+;; ---- 2-arg explicit-pin probes (rf2-y0db2 — parity with UIx's rf2-rcgsc) --
 
 (def ^:private probe-2arg-a-observed (atom []))
 (def ^:private probe-2arg-b-observed (atom []))
 
 (defnc Probe2ArgA []
-  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-a [:rf.helix-rcgsc/n])]
+  (let [v (helix-adapter/use-subscribe :rf.helix-explicit-pin/tenant-a [:rf.helix-explicit-pin/n])]
     (swap! probe-2arg-a-observed conj v)
     (d/div (str "a=" v))))
 
 (defnc Probe2ArgB []
-  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-b [:rf.helix-rcgsc/n])]
+  (let [v (helix-adapter/use-subscribe :rf.helix-explicit-pin/tenant-b [:rf.helix-explicit-pin/n])]
     (swap! probe-2arg-b-observed conj v)
     (d/div (str "b=" v))))
 
-;; ---- rf2-mwft2 stable-deps-key probes -------------------------------------
+;; ---- stable-deps-key probes (rf2-mwft2) -----------------------------------
 ;; A parent that owns a tick state (used to force re-renders) plus a child
 ;; that reads a fixed query-v via use-subscribe. The literal
-;; `[:rf.helix-mwft2/p]` vector evaluates to a fresh JS object each render —
-;; exactly the shape the bug-without-fix walks into. The parent stashes its
-;; set-tick fn into a side-channel atom so the suite can drive forced
-;; re-renders from outside.
+;; `[:rf.helix-stable-deps/p]` vector evaluates to a fresh JS object each
+;; render — exactly the shape the bug-without-fix walks into. The parent
+;; stashes its set-tick fn into a side-channel atom so the suite can drive
+;; forced re-renders from outside.
 
-(defnc ProbeMwft2Child []
-  (let [v (helix-adapter/use-subscribe :rf.helix-mwft2/probe-frame [:rf.helix-mwft2/p])]
+(defnc ProbeStableDepsChild []
+  (let [v (helix-adapter/use-subscribe :rf.helix-stable-deps/probe-frame [:rf.helix-stable-deps/p])]
     (d/div (str "p=" v))))
 
-(defnc ProbeMwft2Parent []
+(defnc ProbeStableDepsParent []
   (let [[tick set-tick] (helix-hooks/use-state 0)]
     (helix-hooks/use-effect
       ;; React state-setters have stable identity across renders so an
@@ -100,10 +100,10 @@
       ;; stable" guarantee. The effect runs once on mount to stash the
       ;; setter for the test driver.
       []
-      (reset! mwft2-set-tick set-tick)
+      (reset! stable-deps-set-tick set-tick)
       (fn cleanup [] nil))
     (d/div {:data-tick tick}
-           ($ ProbeMwft2Child))))
+           ($ ProbeStableDepsChild))))
 
 ;; ---- cfg + forwarded deftests ---------------------------------------------
 
@@ -118,26 +118,26 @@
    :us-frame              :rf.helix-use-subscribe-test/probe-frame
    :us-query              :rf.helix-use-subscribe-test/n
    ;; frame-provider 1-arg
-   :probe-fp-element      (fn [] ($ ProbeFp))
-   :probe-fp-observed     probe-fp-observed
-   :fp-frame              :rf.helix-use-subscribe-test/fp-frame
-   :fp-query              :rf.helix-use-subscribe-test/k
+   :probe-frame-provider-element  (fn [] ($ ProbeFrameProvider))
+   :probe-frame-provider-observed probe-frame-provider-observed
+   :frame-provider-frame          :rf.helix-use-subscribe-test/frame-provider-frame
+   :frame-provider-query          :rf.helix-use-subscribe-test/k
    ;; 2-arg explicit pin
    :probe-2arg-element    (fn [] ($ :div ($ Probe2ArgA) ($ Probe2ArgB)))
    :probe-2arg-a-observed probe-2arg-a-observed
    :probe-2arg-b-observed probe-2arg-b-observed
-   :tenant-a-frame        :rf.helix-rcgsc/tenant-a
-   :tenant-b-frame        :rf.helix-rcgsc/tenant-b
-   :rcgsc-query           :rf.helix-rcgsc/n
+   :tenant-a-frame        :rf.helix-explicit-pin/tenant-a
+   :tenant-b-frame        :rf.helix-explicit-pin/tenant-b
+   :explicit-pin-query    :rf.helix-explicit-pin/n
    ;; refcount cleanup
-   :probe-rc-element      (fn [] ($ ProbeRc))
+   :probe-refcount-element (fn [] ($ ProbeRefcount))
    :rc-frame              :rf.helix-use-subscribe-test/refcount-frame
    :rc-query              :rf.helix-use-subscribe-test/m
    ;; stable deps key
-   :probe-mwft2-element   (fn [] ($ ProbeMwft2Parent))
-   :mwft2-set-tick        mwft2-set-tick
-   :mwft2-frame           :rf.helix-mwft2/probe-frame
-   :mwft2-query           :rf.helix-mwft2/p})
+   :probe-stable-deps-element (fn [] ($ ProbeStableDepsParent))
+   :stable-deps-set-tick  stable-deps-set-tick
+   :stable-deps-frame     :rf.helix-stable-deps/probe-frame
+   :stable-deps-query     :rf.helix-stable-deps/p})
 
 (deftest use-subscribe-tracks-app-db-changes
   (suite/assert-use-subscribe-tracks-app-db-changes cfg))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
@@ -26,21 +26,17 @@
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.uix :as uix-adapter]
+            ;; rf2-5g21s — the react-element-attr accessor is hoisted into
+            ;; the dependency-free shared test home (out of cross-suite
+            ;; duplication with the Helix twin); reference it rather than
+            ;; carry a copy. Kept separate from react-shared-suite so this
+            ;; prod-elision build does not pull the suite's heavy deps.
+            [re-frame.adapter.react-test-support :refer [react-element-attr]]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter uix-adapter/adapter}))
-
-(defn- react-element-attr
-  "Pull `attr` (a string prop name) off a React element's `.-props`, or
-  nil. Defensively returns nil on every branch so the test assertions
-  can use `nil?`. Both elision attributes (`data-rf2-source-coord` and
-  `data-rf-view`) ride the same `interop/debug-enabled?` gate, so the
-  one accessor covers both."
-  [el attr]
-  (when (and el (.-props el))
-    (aget (.-props el) attr)))
 
 ;; ---- annotation elides under :advanced + goog.DEBUG=false ----------------
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -41,10 +41,10 @@
 ;; over these atoms; the suite `reset!`s the atom each assertion cares
 ;; about at the top of its body.
 
-(def ^:private probe-observed    (atom []))
-(def ^:private probe-fp-observed (atom []))
-(def ^:private refcount-target   (atom nil))
-(def ^:private mwft2-set-tick    (atom nil))
+(def ^:private probe-observed                (atom []))
+(def ^:private probe-frame-provider-observed (atom []))
+(def ^:private refcount-target               (atom nil))
+(def ^:private stable-deps-set-tick          (atom nil))
 
 (defui Probe []
   (let [target @refcount-target
@@ -52,54 +52,54 @@
     (swap! probe-observed conj v)
     ($ :div (str "n=" v))))
 
-(defui ProbeFp []
+(defui ProbeFrameProvider []
   (let [v (uix-adapter/use-subscribe [:rf.uix-use-subscribe-test/k])]
-    (swap! probe-fp-observed conj v)
+    (swap! probe-frame-provider-observed conj v)
     ($ :div (str "k=" v))))
 
-(defui ProbeRc []
+(defui ProbeRefcount []
   (let [target @refcount-target
         v (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/m])]
     ($ :div (str "m=" v))))
 
-;; ---- rf2-rcgsc 2-arg explicit-pin probes ----------------------------------
+;; ---- 2-arg explicit-pin probes (rf2-rcgsc) --------------------------------
 
 (def ^:private probe-2arg-a-observed (atom []))
 (def ^:private probe-2arg-b-observed (atom []))
 
 (defui Probe2ArgA []
-  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-a [:rf.uix-rcgsc/n])]
+  (let [v (uix-adapter/use-subscribe :rf.uix-explicit-pin/tenant-a [:rf.uix-explicit-pin/n])]
     (swap! probe-2arg-a-observed conj v)
     ($ :div (str "a=" v))))
 
 (defui Probe2ArgB []
-  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-b [:rf.uix-rcgsc/n])]
+  (let [v (uix-adapter/use-subscribe :rf.uix-explicit-pin/tenant-b [:rf.uix-explicit-pin/n])]
     (swap! probe-2arg-b-observed conj v)
     ($ :div (str "b=" v))))
 
-;; ---- rf2-mwft2 stable-deps-key probes -------------------------------------
+;; ---- stable-deps-key probes (rf2-mwft2) -----------------------------------
 ;; A parent that owns a tick state (used to force re-renders) plus a child
 ;; that reads a fixed query-v via use-subscribe. The literal
-;; `[:rf.uix-mwft2/p]` vector evaluates to a fresh JS object each render —
-;; exactly the shape the bug-without-fix walks into. The parent stashes its
-;; set-tick fn into a side-channel atom so the suite can drive forced
-;; re-renders from outside.
+;; `[:rf.uix-stable-deps/p]` vector evaluates to a fresh JS object each
+;; render — exactly the shape the bug-without-fix walks into. The parent
+;; stashes its set-tick fn into a side-channel atom so the suite can drive
+;; forced re-renders from outside.
 
-(defui ProbeMwft2Child []
-  (let [v (uix-adapter/use-subscribe :rf.uix-mwft2/probe-frame [:rf.uix-mwft2/p])]
+(defui ProbeStableDepsChild []
+  (let [v (uix-adapter/use-subscribe :rf.uix-stable-deps/probe-frame [:rf.uix-stable-deps/p])]
     ($ :div (str "p=" v))))
 
-(defui ProbeMwft2Parent []
+(defui ProbeStableDepsParent []
   (let [[tick set-tick] (uix/use-state 0)]
     (uix/use-effect
       ;; React state-setters have stable identity across renders so an
       ;; empty deps vec is correct — silences UIx's lint and matches
       ;; React's "set-state setter is stable" guarantee. The effect runs
       ;; once on mount to stash the setter for the test driver.
-      (fn [] (reset! mwft2-set-tick set-tick) js/undefined)
+      (fn [] (reset! stable-deps-set-tick set-tick) js/undefined)
       [])
     ($ :div {:data-tick tick}
-       ($ ProbeMwft2Child))))
+       ($ ProbeStableDepsChild))))
 
 ;; ---- cfg + forwarded deftests ---------------------------------------------
 
@@ -114,26 +114,26 @@
    :us-frame              :rf.uix-use-subscribe-test/probe-frame
    :us-query              :rf.uix-use-subscribe-test/n
    ;; frame-provider 1-arg
-   :probe-fp-element      (fn [] (uix/$ ProbeFp))
-   :probe-fp-observed     probe-fp-observed
-   :fp-frame              :rf.uix-use-subscribe-test/fp-frame
-   :fp-query              :rf.uix-use-subscribe-test/k
+   :probe-frame-provider-element  (fn [] (uix/$ ProbeFrameProvider))
+   :probe-frame-provider-observed probe-frame-provider-observed
+   :frame-provider-frame          :rf.uix-use-subscribe-test/frame-provider-frame
+   :frame-provider-query          :rf.uix-use-subscribe-test/k
    ;; 2-arg explicit pin
    :probe-2arg-element    (fn [] (uix/$ :div (uix/$ Probe2ArgA) (uix/$ Probe2ArgB)))
    :probe-2arg-a-observed probe-2arg-a-observed
    :probe-2arg-b-observed probe-2arg-b-observed
-   :tenant-a-frame        :rf.uix-rcgsc/tenant-a
-   :tenant-b-frame        :rf.uix-rcgsc/tenant-b
-   :rcgsc-query           :rf.uix-rcgsc/n
+   :tenant-a-frame        :rf.uix-explicit-pin/tenant-a
+   :tenant-b-frame        :rf.uix-explicit-pin/tenant-b
+   :explicit-pin-query    :rf.uix-explicit-pin/n
    ;; refcount cleanup
-   :probe-rc-element      (fn [] (uix/$ ProbeRc))
+   :probe-refcount-element (fn [] (uix/$ ProbeRefcount))
    :rc-frame              :rf.uix-use-subscribe-test/refcount-frame
    :rc-query              :rf.uix-use-subscribe-test/m
    ;; stable deps key
-   :probe-mwft2-element   (fn [] (uix/$ ProbeMwft2Parent))
-   :mwft2-set-tick        mwft2-set-tick
-   :mwft2-frame           :rf.uix-mwft2/probe-frame
-   :mwft2-query           :rf.uix-mwft2/p})
+   :probe-stable-deps-element (fn [] (uix/$ ProbeStableDepsParent))
+   :stable-deps-set-tick  stable-deps-set-tick
+   :stable-deps-frame     :rf.uix-stable-deps/probe-frame
+   :stable-deps-query     :rf.uix-stable-deps/p})
 
 (deftest use-subscribe-tracks-app-db-changes
   (suite/assert-use-subscribe-tracks-app-db-changes cfg))

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -2174,20 +2174,24 @@
   frame-provider.
 
   cfg keys:
-    :frame-provider     the adapter's frame-provider fn
-    :probe-fp-element    thunk → the 1-arg-form ProbeFp element
-    :probe-fp-observed   atom the ProbeFp pushes observed values into
-    :fp-frame            frame-id keyword for the wrapped frame
-    :fp-query            query-v keyword ProbeFp subscribes to"
-  [{:keys [name frame-provider probe-fp-element probe-fp-observed fp-frame fp-query]}]
+    :frame-provider                 the adapter's frame-provider fn
+    :probe-frame-provider-element   thunk → the 1-arg-form
+                                    ProbeFrameProvider element
+    :probe-frame-provider-observed  atom the ProbeFrameProvider pushes
+                                    observed values into
+    :frame-provider-frame           frame-id keyword for the wrapped frame
+    :frame-provider-query           query-v keyword ProbeFrameProvider
+                                    subscribes to"
+  [{:keys [name frame-provider probe-frame-provider-element probe-frame-provider-observed
+           frame-provider-frame frame-provider-query]}]
   (testing (str name " — use-subscribe 1-arg resolves via frame-provider (rf2-518sp)")
     (with-browser-act
      (fn [act-fn]
-      (reset! probe-fp-observed [])
-      (rf/reg-frame fp-frame {:doc "use-subscribe fp probe frame"})
-      (rf/reg-event-db ::us-fp-seed (fn [_ _] {:k :wrapped}))
-      (rf/dispatch-sync [::us-fp-seed] {:frame fp-frame})
-      (rf/reg-sub fp-query (fn [db _] (:k db)))
+      (reset! probe-frame-provider-observed [])
+      (rf/reg-frame frame-provider-frame {:doc "use-subscribe frame-provider probe frame"})
+      (rf/reg-event-db ::frame-provider-seed (fn [_ _] {:k :wrapped}))
+      (rf/dispatch-sync [::frame-provider-seed] {:frame frame-provider-frame})
+      (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
       (let [mount-node (make-mount-node!)
             root       (react-dom-client/createRoot mount-node)]
         (try
@@ -2198,8 +2202,8 @@
               ;; directly rather than via the substrate's `$`.
               (.render root
                 (frame-provider
-                  {:frame fp-frame :children [(probe-fp-element)]}))))
-          (is (some #{:wrapped} @probe-fp-observed)
+                  {:frame frame-provider-frame :children [(probe-frame-provider-element)]}))))
+          (is (some #{:wrapped} @probe-frame-provider-observed)
               "use-subscribe 1-arg form read from the wrapped frame, not :rf/default")
           (finally
             (try (.unmount root) (catch :default _ nil)))))))))
@@ -2215,9 +2219,9 @@
     :probe-2arg-element  thunk → an element wrapping Probe2ArgA + Probe2ArgB
     :probe-2arg-a-observed / :probe-2arg-b-observed   the probes' atoms
     :tenant-a-frame / :tenant-b-frame   the two pinned frame-ids
-    :rcgsc-query         query-v keyword both probes subscribe to"
+    :explicit-pin-query  query-v keyword both probes subscribe to"
   [{:keys [name probe-2arg-element probe-2arg-a-observed probe-2arg-b-observed
-           tenant-a-frame tenant-b-frame rcgsc-query]}]
+           tenant-a-frame tenant-b-frame explicit-pin-query]}]
   (testing (str name " — use-subscribe 2-arg pins explicit frame (rf2-rcgsc)")
     (with-browser-act
      (fn [act-fn]
@@ -2225,10 +2229,10 @@
       (reset! probe-2arg-b-observed [])
       (rf/reg-frame tenant-a-frame {:doc "tenant-a"})
       (rf/reg-frame tenant-b-frame {:doc "tenant-b"})
-      (rf/reg-event-db ::rcgsc-seed (fn [_ [_ n]] {:n n}))
-      (rf/dispatch-sync [::rcgsc-seed 10]  {:frame tenant-a-frame})
-      (rf/dispatch-sync [::rcgsc-seed 100] {:frame tenant-b-frame})
-      (rf/reg-sub rcgsc-query (fn [db _] (:n db)))
+      (rf/reg-event-db ::explicit-pin-seed (fn [_ [_ n]] {:n n}))
+      (rf/dispatch-sync [::explicit-pin-seed 10]  {:frame tenant-a-frame})
+      (rf/dispatch-sync [::explicit-pin-seed 100] {:frame tenant-b-frame})
+      (rf/reg-sub explicit-pin-query (fn [db _] (:n db)))
       (let [mount-node (make-mount-node!)
             root       (react-dom-client/createRoot mount-node)]
         (try
@@ -2250,11 +2254,13 @@
   to 0 (or the entry is dropped) after unmount.
 
   cfg keys:
-    :probe-rc-element  thunk → the ProbeRc element (2-arg form, no observe)
-    :refcount-target   atom the ProbeRc reads its target frame-id from
-    :rc-frame          frame-id keyword for the refcount probe
-    :rc-query          query-v keyword ProbeRc subscribes to"
-  [{:keys [name probe-rc-element refcount-target rc-frame rc-query]}]
+    :probe-refcount-element  thunk → the ProbeRefcount element (2-arg
+                             form, no observe)
+    :refcount-target         atom the ProbeRefcount reads its target
+                             frame-id from
+    :rc-frame                frame-id keyword for the refcount probe
+    :rc-query                query-v keyword ProbeRefcount subscribes to"
+  [{:keys [name probe-refcount-element refcount-target rc-frame rc-query]}]
   (testing (str name " — use-subscribe cleanup decrements sub-cache refcount (rf2-7g959)")
     (with-browser-act
      (fn [act-fn]
@@ -2268,7 +2274,7 @@
             mount-node  (make-mount-node!)
             root        (react-dom-client/createRoot mount-node)]
         (try
-          (act-fn (fn [] (.render root (probe-rc-element))))
+          (act-fn (fn [] (.render root (probe-refcount-element))))
           (is (pos? (or (get-in @cache [cache-key-v :ref-count]) 0))
               "mounted probe pinned a cache entry with ref-count > 0")
           (act-fn (fn [] (.unmount root)))
@@ -2288,28 +2294,28 @@
   and the useEffect cleanup (rf2-7g959) fires only on unmount.
 
   cfg keys:
-    :probe-mwft2-element  thunk → the ProbeMwft2Parent element. The parent
-                          owns a tick state + stashes its set-tick fn into
-                          :mwft2-set-tick on mount; the child reads a
-                          fixed query-v via use-subscribe.
-    :mwft2-set-tick       atom the parent stashes its setter into
-    :mwft2-frame          frame-id keyword the child resolves under
-    :mwft2-query          query-v keyword the child subscribes to"
-  [{:keys [name probe-mwft2-element mwft2-set-tick mwft2-frame mwft2-query]}]
+    :probe-stable-deps-element  thunk → the ProbeStableDepsParent element.
+                          The parent owns a tick state + stashes its
+                          set-tick fn into :stable-deps-set-tick on mount;
+                          the child reads a fixed query-v via use-subscribe.
+    :stable-deps-set-tick atom the parent stashes its setter into
+    :stable-deps-frame    frame-id keyword the child resolves under
+    :stable-deps-query    query-v keyword the child subscribes to"
+  [{:keys [name probe-stable-deps-element stable-deps-set-tick stable-deps-frame stable-deps-query]}]
   (testing (str name " — use-subscribe stable deps key: one subscribe across N renders (rf2-mwft2)")
     (with-browser-act
      (fn [act-fn]
-      (reset! mwft2-set-tick nil)
-      (rf/reg-frame mwft2-frame {:doc "rf2-mwft2 probe frame"})
-      (rf/reg-event-db ::mwft2-seed (fn [_ _] {:p 0}))
-      (rf/dispatch-sync [::mwft2-seed] {:frame mwft2-frame})
-      (rf/reg-sub mwft2-query (fn [db _] (:p db)))
+      (reset! stable-deps-set-tick nil)
+      (rf/reg-frame stable-deps-frame {:doc "rf2-mwft2 stable-deps probe frame"})
+      (rf/reg-event-db ::stable-deps-seed (fn [_ _] {:p 0}))
+      (rf/dispatch-sync [::stable-deps-seed] {:frame stable-deps-frame})
+      (rf/reg-sub stable-deps-query (fn [db _] (:p db)))
       (let [subscribe-calls   (atom 0)
             unsubscribe-calls (atom 0)
             real-subscribe    subs/subscribe
             real-unsubscribe  subs/unsubscribe
-            cache-key-v       [mwft2-query]
-            cache             (:sub-cache (frame/frame mwft2-frame))
+            cache-key-v       [stable-deps-query]
+            cache             (:sub-cache (frame/frame stable-deps-frame))
             mount-node        (make-mount-node!)
             root              (react-dom-client/createRoot mount-node)]
         ;; Spies preserve the multi-arity shape of subs/subscribe and
@@ -2345,7 +2351,7 @@
                          (real-unsubscribe frame-id query-v)))]
           (try
             ;; Mount — one subs/subscribe for the useMemo factory.
-            (act-fn (fn [] (.render root (probe-mwft2-element))))
+            (act-fn (fn [] (.render root (probe-stable-deps-element))))
             (let [mounted-subs @subscribe-calls]
               (is (= 1 mounted-subs)
                   "mount triggered exactly one subs/subscribe call")
@@ -2357,7 +2363,7 @@
               ;; the fix the deps mismatch would re-run useMemo (extra
               ;; subscribe) and useEffect (extra unsubscribe) each render.
               (dotimes [_ 5]
-                (act-fn (fn [] (when-let [set-tick @mwft2-set-tick]
+                (act-fn (fn [] (when-let [set-tick @stable-deps-set-tick]
                                  (set-tick inc)))))
               (is (= 1 @subscribe-calls)
                   "subs/subscribe still called only once after 5 re-renders (no per-render churn)")
@@ -2402,15 +2408,15 @@
 
   cfg keys: re-uses the same stable-deps-key probe surface — the
   cleanup fires on either parent here."
-  [{:keys [name probe-mwft2-element mwft2-set-tick mwft2-frame mwft2-query]}]
+  [{:keys [name probe-stable-deps-element stable-deps-set-tick stable-deps-frame stable-deps-query]}]
   (testing (str name " — use-subscribe cleanup calls subs/unsubscribe with 2 args (rf2-gizlj, rf2-cmfln contract)")
     (with-browser-act
      (fn [act-fn]
-      (reset! mwft2-set-tick nil)
-      (rf/reg-frame mwft2-frame {:doc "rf2-gizlj arity probe frame"})
+      (reset! stable-deps-set-tick nil)
+      (rf/reg-frame stable-deps-frame {:doc "rf2-gizlj arity probe frame"})
       (rf/reg-event-db ::gizlj-seed (fn [_ _] {:p 0}))
-      (rf/dispatch-sync [::gizlj-seed] {:frame mwft2-frame})
-      (rf/reg-sub mwft2-query (fn [db _] (:p db)))
+      (rf/dispatch-sync [::gizlj-seed] {:frame stable-deps-frame})
+      (rf/reg-sub stable-deps-query (fn [db _] (:p db)))
       (let [unsubscribe-arg-counts (atom [])
             real-unsubscribe       subs/unsubscribe
             mount-node             (make-mount-node!)
@@ -2427,7 +2433,7 @@
                          (swap! unsubscribe-arg-counts conj 2)
                          (real-unsubscribe frame-id query-v)))]
           (try
-            (act-fn (fn [] (.render root (probe-mwft2-element))))
+            (act-fn (fn [] (.render root (probe-stable-deps-element))))
             (act-fn (fn [] (.unmount root)))
             ;; The spine's useEffect cleanup is the call site under
             ;; test. There may be additional unsubscribes from layer-2+

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -100,6 +100,7 @@
             [re-frame.views :as views]
             [re-frame.epoch]
             [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.react-test-support :as react-test-support]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.trace.tooling :as trace-tooling])
   (:require-macros [re-frame.core :refer [with-frame with-new-frame bound-fn]]))
@@ -108,11 +109,11 @@
 ;; helpers
 ;; ===========================================================================
 
-(defn- react-element-attr
-  "Pull `attr` (a string key) off a React element's `.-props`, or nil."
-  [el attr]
-  (when (and el (.-props el))
-    (aget (.-props el) attr)))
+;; rf2-5g21s — `react-element-attr` is hoisted into the dependency-free
+;; `re-frame.adapter.react-test-support` so the narrow elision-prod twins
+;; can share it without dragging this heavy suite into their build. The
+;; suite consumes the same single source of truth.
+(def react-element-attr react-test-support/react-element-attr)
 
 (defn- source-coord [el] (react-element-attr el "data-rf2-source-coord"))
 (defn- view-attr     [el] (react-element-attr el "data-rf-view"))

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -428,6 +428,57 @@
               "the explicit {:line 42 :column 7} coords land in the attribute"))))))
 
 ;; ===========================================================================
+;; React `:key` parity (Spec 006 §Source-coord annotation — CRITICAL key
+;; preservation note) — rf2-pt0u2, follow-up to rf2-1anbp
+;;
+;; rf2-1anbp pinned the Reagent path: a call-site ^{:key} propagates to
+;; React. The React-hook substrates (UIx / Helix) take a different route —
+;; the React `:key` rides the substrate's own `createElement` / `$` at the
+;; call site, NOT Reagent's hiccup-metadata extraction. The hazard that
+;; remains is the wrap-view pass itself: `inject-source-coord-attr` and
+;; `append-unmount-sentinel` both `React/cloneElement` the user's root
+;; output, and `cloneElement` is documented to preserve the `key` slot
+;; (see spine.cljs `inject-source-coord-attr` / `append-unmount-sentinel`
+;; docstrings — "SAME `type` and `key` slots"). This assertion pins that
+;; preservation by test rather than by argument: a seq of registered views,
+;; each whose root element carries a distinct per-item key, must emerge from
+;; the wrap-view passes with each key intact and all keys distinct (no
+;; collision). Parameterised ⇒ a gap on UIx is a gap on Helix.
+;; ===========================================================================
+
+(defn assert-reg-view-react-key-preserved
+  "rf2-pt0u2: a registered view whose root React element carries a `:key`
+  emerges from wrap-view's cloneElement passes (source-coord injection +
+  unmount-sentinel append) with that key intact. Across a seq of views
+  carrying distinct per-item keys the keys stay distinct — no collision.
+  Headless: `((rf/view id))` runs the full wrap-view path under node-test
+  (goog.DEBUG true), so the source-coord attribute also lands, proving the
+  cloneElement passes actually executed and the key survived them."
+  [{:keys [substrate-kw name]}]
+  (testing (str name " — React :key: per-item keys survive the wrap-view passes, stay distinct")
+    (let [n        3
+          rendered (for [i (range n)
+                         :let [id      (mint-kw substrate-kw (str "react-key-" i))
+                               item-key (str "rk-" i)
+                               user-fn (fn [] (React/createElement
+                                               "li" #js {:key item-key} (str "item " i)))]]
+                     (do (rf/reg-view* id user-fn)
+                         {:item-key item-key :out ((rf/view id))}))
+          rendered (vec rendered)]
+      (doseq [{:keys [item-key out]} rendered]
+        (is (some? out) "registered view returned a non-nil React element")
+        (is (= "li" (.-type out)) "root element type preserved through the wrap-view passes")
+        (is (= item-key (.-key out))
+            (str "the call-site React :key (" item-key ") survives cloneElement "
+                 "(source-coord injection + unmount-sentinel append)"))
+        (is (string? (source-coord out))
+            "data-rf2-source-coord present — the wrap-view pass ran, so key-preservation is meaningful"))
+      (let [keys (mapv :item-key rendered)]
+        (is (= n (count (distinct keys)))
+            (str "all " n " per-item keys are distinct after the wrap-view passes — no collision; got "
+                 (pr-str keys)))))))
+
+;; ===========================================================================
 ;; frame-context corrupted `_currentValue` (Spec 009 §Error contract) — G4
 ;; ===========================================================================
 

--- a/implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj
@@ -91,6 +91,10 @@
    {:test 'wrap-view-injects-explicit-coords
     :fn   'assert-wrap-view-injects-explicit-coords}
 
+   {:section "React :key parity (rf2-pt0u2 — follow-up to rf2-1anbp)"}
+   {:test 'reg-view-react-key-preserved
+    :fn   'assert-reg-view-react-key-preserved}
+
    {:section "frame-context corrupted (Spec 009)"}
    {:test 'frame-context-corrupted
     :fn   'assert-frame-context-corrupted}

--- a/implementation/core/test/re_frame/adapter/react_test_support.cljs
+++ b/implementation/core/test/re_frame/adapter/react_test_support.cljs
@@ -1,0 +1,28 @@
+(ns re-frame.adapter.react-test-support
+  "Lightweight, dependency-free test helpers shared across the React-shaped
+  adapter test surfaces (UIx, Helix) — rf2-5g21s.
+
+  WHY A SEPARATE NS. The parameterised `re-frame.adapter.react-shared-suite`
+  is the home for shared *assertions*, but it `:require`s the full
+  production surface (SSR, managed-HTTP, routing, react-dom/server, …) so
+  it can drive end-to-end contracts. The narrowly-scoped
+  `*-source-coord-dom-elision-prod-test.cljs` twins only need ONE tiny prop
+  accessor; pulling the whole suite into the `:browser-test-prod-elision`
+  build (`:advanced` + goog.DEBUG=false) just to share that accessor would
+  drag the suite's heavy transitive deps — and its compile warnings — into
+  a build that otherwise compiles two small files. This ns holds only the
+  zero-dependency helpers, so both the suite and the elision-prod twins can
+  reference it without bloating either build."
+  (:refer-clojure :exclude []))
+
+(defn react-element-attr
+  "Pull `attr` (a string prop name) off a React element's `.-props`, or
+  nil. Defensively returns nil on every branch so callers can `nil?`-test
+  the result. The single hoisted home for this accessor: the UIx and Helix
+  `*-source-coord-dom-elision-prod-test.cljs` twins (and the shared suite)
+  reference it instead of each carrying a byte-identical private copy. Both
+  elision attrs (`data-rf2-source-coord` + `data-rf-view`) ride the same
+  `interop/debug-enabled?` gate, so the one accessor covers both."
+  [el attr]
+  (when (and el (.-props el))
+    (aget (.-props el) attr)))


### PR DESCRIPTION
## Quality gates

- `npm run test:cljs` — 5151 tests, 17385 assertions, 0 failures
- `npm run test:browser` — 130 tests, 367 assertions, 0 failures
- `npm run test:browser-prod-elision` — 62 tests, 178 assertions, 0 failures
- clj-kondo — 0 errors on changed files (3 pre-existing unused-require warnings in the suite's require block, untouched by this PR)

Cluster of 3 beads on the shared react-suite + uix/helix test surface, sequenced commits (smallest -> biggest). Test-only / behaviour-preserving.

## Per-bead

- **rf2-pt0u2** (`:key` parity contract) — adds `assert-reg-view-react-key-preserved` to the shared suite + a `_tests.clj` row. Pins that a registered view's call-site React `:key` survives wrap-view's two cloneElement passes (source-coord injection + unmount-sentinel append) and that a seq of distinct per-item keys stays distinct (no collision). Follow-up to rf2-1anbp (Reagent side). Parameterised, so the contract holds for both UIx and Helix by construction.
- **rf2-5g21s** (hoist `react-element-attr`) — the byte-identical prop accessor in uix's + helix's `*-source-coord-dom-elision-prod-test.cljs` is hoisted into a single home: a new dependency-free `re-frame.adapter.react-test-support`. Chosen over `react-shared-suite` so the narrow `:browser-test-prod-elision` build does not pull the suite's heavy transitive deps (SSR, managed-HTTP, react-dom/server) — that pull-in surfaced a stray `:infer-warning` and grew the build from 4 to 209 compiled files; the lightweight home keeps it at 4 compiled, 0 warnings. The suite consumes the same source of truth.
- **rf2-hhb1r** (clarify cryptic probe/cfg names) — `ProbeFp`->`ProbeFrameProvider`, `ProbeRc`->`ProbeRefcount`, `ProbeMwft2*`->`ProbeStableDeps*`; cfg keys `:probe-fp-*`/`:probe-rc-*`/`:probe-mwft2-*`/`:rcgsc-query` and the `-rcgsc`/`-mwft2` ns fragments renamed to intent-revealing forms. Applied identically across the shared suite + both twins. Internal test-name clarity only — no public/contract symbol. `rf2-` bead-id citations kept as provenance.

## Parity + coverage

- uix <-> helix twins stay in structural parity: every rename in rf2-hhb1r and the hoist in rf2-5g21s were applied identically to both adapter test files; the `:key` contract is forwarded to both via the shared-suite macro.
- No coverage weakened — every assertion still checks the same real outcome; the renames are mechanical and the hoist is byte-equivalent.