### PR TITLE
feat(shadow): wire the four Story builds into :dev-http 8040-8043 (rf2-xz4zn)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -274,7 +274,31 @@
             ;; the trio's machine slot (standard-epochs 8031, routes-epochs
             ;; 8032).
             8033 ["../tools/xray/testbeds/machine_epochs"
-                  "out/examples/machine-epochs"]}
+                  "out/examples/machine-epochs"]
+            ;; --- Story showcases (rf2-xz4zn) -------------------------
+            ;; The four Story-enabled builds, on the 804x band (the Xray
+            ;; testbeds own 803x + 8765). Each is hash-routed: `/#/` is
+            ;; the live app, `/#/stories` mounts the Story shell; the Xray
+            ;; preload is wired (Ctrl+Shift+C). Same source-dir-first
+            ;; cascade as the testbeds above — the hand-written index.html
+            ;; resolves at `/`, the compiled main.js falls through to the
+            ;; build's :output-dir. One command brings all four up:
+            ;;   npx shadow-cljs watch :examples/nine-states-with-stories \
+            ;;     :examples/login-with-stories \
+            ;;     :examples/counter-with-stories :examples/login-form
+            ;; Story shells:
+            ;;   http://localhost:8040/#/stories  nine-states showcase (rf2-rgyia)
+            ;;   http://localhost:8041/#/stories  login showcase (rf2-p8v0q)
+            ;;   http://localhost:8042/#/stories  counter (canonical minimal)
+            ;;   http://localhost:8043/#/stories  login-form (5-state)
+            8040 ["../examples/reagent/nine_states"
+                  "out/examples/nine-states-with-stories"]
+            8041 ["../examples/reagent/login"
+                  "out/examples/login-with-stories"]
+            8042 ["../tools/story/testbeds/counter_with_stories"
+                  "out/examples/counter-with-stories"]
+            8043 ["../tools/story/testbeds/login_form"
+                  "out/examples/login-form"]}
 
  :builds
  {:node-test

--- a/tools/story/README.md
+++ b/tools/story/README.md
@@ -110,6 +110,30 @@ The substantive implementation contract is decomposed into
 | [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | WHY each major decision was made. |
 | [`spec/findings/`](./spec/findings/) | The Phase-1 and Phase-2 research that informed the design (committed audit trail). |
 
+## Running the Story examples
+
+Four Story-enabled builds are wired into the top-level `:dev-http` map
+(`implementation/shadow-cljs.edn`) on the `804x` band, so each runs
+one-command — `npx shadow-cljs watch <build-id>` then open the URL. Each is
+hash-routed: `/#/` is the live app, `/#/stories` mounts the Story shell (the
+Xray preload is wired — press `Ctrl+Shift+C`).
+
+| Build id | Port | Story shell | What it shows |
+|---|---|---|---|
+| `:examples/nine-states-with-stories` | 8040 | http://localhost:8040/#/stories | nine-states showcase (rf2-rgyia) |
+| `:examples/login-with-stories` | 8041 | http://localhost:8041/#/stories | login showcase (rf2-p8v0q) |
+| `:examples/counter-with-stories` | 8042 | http://localhost:8042/#/stories | canonical minimal testbed |
+| `:examples/login-form` | 8043 | http://localhost:8043/#/stories | five-state login-form testbed |
+
+A single watch brings all four up at once:
+
+```bash
+# from implementation/
+npx shadow-cljs watch :examples/nine-states-with-stories \
+  :examples/login-with-stories \
+  :examples/counter-with-stories :examples/login-form
+```
+
 ## Browser testbed guardrails
 
 Story browser tests run in developer worktrees and CI jobs that may overlap.


### PR DESCRIPTION
Wires the four Story-enabled builds into the top-level `:dev-http` map (`implementation/shadow-cljs.edn`) so they run one-command, matching the Xray testbed trio. Closes rf2-xz4zn.

The four builds compiled but had no `:dev-http` port — `npx shadow-cljs watch :examples/nine-states-with-stories` built but served nowhere. Each entry uses the existing source-dir-first cascade (hand-written `index.html` resolves at `/`; compiled `main.js` falls through to the build's `:output-dir`).

## Build -> port mappings

| Port | Build id | `:root` cascade |
|---|---|---|
| 8040 | `:examples/nine-states-with-stories` | `../examples/reagent/nine_states` -> `out/examples/nine-states-with-stories` |
| 8041 | `:examples/login-with-stories` | `../examples/reagent/login` -> `out/examples/login-with-stories` |
| 8042 | `:examples/counter-with-stories` | `../tools/story/testbeds/counter_with_stories` -> `out/examples/counter-with-stories` |
| 8043 | `:examples/login-form` | `../tools/story/testbeds/login_form` -> `out/examples/login-form` |

Each is hash-routed: `/#/` = live app, `/#/stories` = Story shell (Xray preload wired, Ctrl+Shift+C). Port scheme stays coherent: Xray testbeds own `803x` + `8765`; Story builds take `804x`. Adds a "Story showcases" comment sub-header to the `:dev-http` block and a "Running the Story examples" note to `tools/story/README.md`.

Existing entries (8765 / 8030 / 8031 / 8032 / 8033) are **undisturbed** — only the four new keys were added; no renumbering.

## Quality gates

This is a **dev-config change only** — no production bundle, test-suite, or runtime impact. Gate = config parses + builds resolve + no `:dev-http` port collision.

- **EDN parse** — `clojure.edn/read-string` (with a `#shadow/env` reader stub) parses the file; `:dev-http` keys = `(8030 8031 8032 8033 8040 8041 8042 8043 8765)`, all distinct, no duplicate map keys.
- **No `:dev-http` collision** — 8040-8043 were absent from the map before this change; the four new keys are unique within `:dev-http`.
- **Build resolves** — `npx shadow-cljs compile :examples/counter-with-stories` -> *Build completed. (581 files, 580 compiled, 0 warnings)*. shadow read the modified config without error. Verified the 8042 cascade resolves both roots: `out/examples/counter-with-stories/main.js` (compiled) + `tools/story/testbeds/counter_with_stories/index.html` (source, served at `/`). The other three follow the identical pattern with confirmed source `index.html`s and matching `:output-dir`s.
- **Surface confined** — diff touches only `implementation/shadow-cljs.edn` (+26) and `tools/story/README.md` (+24). No `deps.edn`, `.github`, top-level `spec/`, or source/test.

## Note (out of this bead's surface — follow-up filed)

Port 8040 is also the examples-orchestrator default (`examples/scripts/examples-port.cjs` `DEFAULT_PORT`) and the story-static preview port (`implementation/scripts/{check-story-static,story-build}.cjs`), chosen *because* 8040 was previously outside `:dev-http`. Those are separate on-demand `http-server` processes (not the shadow dev server) and the examples resolver pre-flights + scans forward, so nothing hard-fails — but their comments now assert a stale premise. The bead is authoritative on the 8040-8043 ports (Mike enumerated them), and those scripts are outside this bead's edit surface, so reconciliation is deferred to a follow-up bead.
