### PR TITLE
docs(scripts): reconcile stale screenshot-generator + dev-http-port comments (rf2-7lylb + rf2-uuxjd)

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -4,9 +4,14 @@ Build-time and content-generation helpers for the docs site.
 
 ## `generate-tutorial-screenshots.cjs`
 
-Drives Playwright through the Xray and Story testbeds and captures the
-annotated screenshots embedded in the [Xray](../xray/index.md) and
-[Story](../story/index.md) tutorials.
+Drives Playwright through the Xray testbed and captures the annotated
+screenshots embedded in the [Xray](../xray/index.md) tutorial.
+
+The [Story](../story/index.md) tutorial's `s00`–`s13` captures are *not*
+produced here — they are hand-committed (see
+[`examples/scripts/capture-story-screenshots.cjs`](../../examples/scripts/capture-story-screenshots.cjs),
+whose shot list is currently empty), so this generator never writes under
+`docs/images/story/`.
 
 ### When to re-run
 
@@ -44,17 +49,13 @@ The script writes:
 
 ```
 docs/images/xray/*.png
-docs/images/story/*.png
 ```
 
 ### Determinism notes
 
 - Viewport pinned to **1280×800**.
-- The Story shell's first-visit help dialog is dismissed via
-  `localStorage` seeding (`re-frame.story/seen-help-v1`).
 - Xray's first paint is gated by waiting for
   `[data-testid="rf-xray-shell"]`.
-- The counter testbed seeds `:count` to a fixed value at boot.
 
 ### Annotations (data-driven)
 

--- a/examples/scripts/examples-port.cjs
+++ b/examples/scripts/examples-port.cjs
@@ -12,9 +12,16 @@
  * gave no hint that the dev's own watch session was the cause.
  *
  * This resolver fixes both halves:
- *   1. DEFAULT_PORT is 8040 — outside the top-level :dev-http set
- *      (8765 / 8031 / 8030), so the common "watch + test:examples"
- *      dev state no longer collides at all.
+ *   1. DEFAULT_PORT is 8040. NOTE (rf2-xz4zn): 8040 now OVERLAPS the
+ *      top-level :dev-http set — that map currently claims
+ *      8765 / 8030-8033 (Xray testbeds) AND 8040-8043 (the four Story
+ *      showcases, on the 804x band). So when a `shadow-cljs watch` is up,
+ *      8040 may already be taken. This is harmless here: the resolver
+ *      PRE-FLIGHTS (step 2) and scans forward, so test:examples just lands
+ *      on the next free port (8044+) instead of hard-failing. The 8040
+ *      default predates the 804x Story band; whether to bump it off the
+ *      band is a deliberate config call (see rf2-uuxjd), kept out of this
+ *      comment-only reconcile.
  *   2. It PRE-FLIGHTS the port (binds-and-releases on 127.0.0.1). If the
  *      preferred port is busy and no explicit EXAMPLES_PORT was set, it
  *      scans forward to the next free port. If an explicit EXAMPLES_PORT
@@ -41,8 +48,11 @@ const {
   portError,
 } = require('./port-resolver.cjs');
 
-// Default outside the top-level :dev-http set (8765 / 8031 / 8030) so a
-// running `shadow-cljs watch` never pre-claims the orchestrator's port.
+// Default port. NOTE (rf2-xz4zn): 8040 now sits INSIDE the top-level
+// :dev-http band (8040-8043 are the Story showcases; 8765 / 8030-8033 are
+// the Xray testbeds), so a running `shadow-cljs watch` CAN pre-claim it.
+// The pre-flight + forward scan (below) keep this harmless — we just land
+// on 8044+. A bump off the 804x band is a deliberate config call (rf2-uuxjd).
 const DEFAULT_PORT = 8040;
 
 const parseExplicitPort = makeParseExplicitPort('EXAMPLES_PORT', { actionable: true });
@@ -78,8 +88,8 @@ async function resolveExamplesPort({ env = process.env } = {}) {
       throw portError(
         `EXAMPLES_PORT=${explicit} is already in use. Is a 'shadow-cljs watch' ` +
           `running? The top-level :dev-http map (implementation/shadow-cljs.edn) ` +
-          `claims 8765 / 8031 / 8030 whenever a watch is up. Stop the watch, or ` +
-          `set EXAMPLES_PORT to a free port.`,
+          `claims 8765 / 8030-8033 / 8040-8043 whenever a watch is up. Stop the ` +
+          `watch, or set EXAMPLES_PORT to a free port.`,
         { actionable: true },
       );
     }

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -14,9 +14,10 @@
  * 1. Compiles each surface's shadow-cljs build (one per smoke).
  * 2. Stages each surface's hand-written index.html into its
  *    out/examples/<name>/ directory next to main.js.
- * 3. Resolves a free port (default 8040 — outside the top-level
- *    :dev-http set 8765/8031/8030; see examples-port.cjs) and spawns
- *    http-server over out/examples on 127.0.0.1:<port>.
+ * 3. Resolves a free port (default 8040 — now OVERLAPPING the top-level
+ *    :dev-http band; the resolver pre-flights + scans forward so this is
+ *    harmless — see examples-port.cjs for the policy + rf2-xz4zn note) and
+ *    spawns http-server over out/examples on 127.0.0.1:<port>.
  * 4. Waits for it to be reachable, then runs the Playwright runner
  *    (run-examples-tests.cjs).
  * 5. Always tears the server down.
@@ -85,12 +86,13 @@ function parseFilterPatterns(raw) {
 }
 const FILTER_PATTERNS = parseFilterPatterns(FILTER);
 // Port resolution lives in examples-port.cjs (resolveExamplesPort, called
-// at the top of main()). Default is 8040 — outside the top-level
-// :dev-http set (8765/8031/8030) so a running `shadow-cljs watch` no
-// longer pre-claims the orchestrator's port. `EXAMPLES_PORT` overrides
-// the default; when unset the resolver scans forward from 8040 to the
-// next free port, and when set-but-busy it throws an actionable message
-// (no raw EACCES stack). No CLI surface is added.
+// at the top of main()). Default is 8040, which now OVERLAPS the top-level
+// :dev-http band (8040-8043 are the Story showcases; see examples-port.cjs
+// for the full set + rf2-xz4zn note). A running `shadow-cljs watch` can
+// therefore pre-claim it, but harmlessly: `EXAMPLES_PORT` overrides the
+// default; when unset the resolver scans forward from 8040 to the next
+// free port, and when set-but-busy it throws an actionable message (no raw
+// EACCES stack). No CLI surface is added.
 // __dirname is <repo>/examples/scripts. IMPL_ROOT is <repo>/implementation
 // (where shadow-cljs runs and node_modules lives); REPO_ROOT is <repo>.
 const REPO_ROOT = path.resolve(__dirname, '..', '..');


### PR DESCRIPTION
Comment/doc reconciliation only — **no behaviour change**. Two small disjoint beads, two sequenced commits.

## rf2-7lylb — docs/scripts/README.md screenshot-generator staleness
After rf2-azqaq (#2659) + rf2-7h1xm (#2660) retired the Story scenes/PNGs from `generate-tutorial-screenshots.cjs`, the README still claimed the generator covered the Story tutorial and wrote `docs/images/story/*.png`. Verified against the actual script: it now drives only the Xray testbed and writes only `docs/images/xray/*.png`; the Story `s00`–`s13` captures are hand-committed (the sibling `capture-story-screenshots.cjs` machinery exists but its shot list is currently empty). Refreshed the prose accordingly and dropped two stale Determinism bullets (Story first-visit-help `localStorage` seeding, counter `:count` seed) that the current generator no longer performs.

## rf2-uuxjd — examples port-policy comment staleness
rf2-xz4zn (#2662) wired the four Story builds into the top-level `:dev-http` map on 8040-8043. The examples port-resolver comments asserted 8040 is "outside the :dev-http set (8765/8031/8030)" — now stale on both counts: the enumerated set was incomplete (missing 8032/8033) and 8040 now sits **inside** the band. Reconciled the prose in `examples-port.cjs` (docstring, `DEFAULT_PORT` comment, actionable error string) and `serve-and-run-examples-tests.cjs` (pipeline docstring + inline note) to state the overlap honestly, noting the resolver's pre-flight + forward-scan keep it harmless (lands on 8044+ when the band is claimed).

`DEFAULT_PORT` and all control flow are unchanged — comment/string-only.

### ⚠️ Flagged port-bump judgment (NOT actioned)
With all four Story watches up, 8040-8043 are claimed, so the examples resolver now scans to **8044**. Whether to bump the examples default off the 804x band (e.g. to 8050) is a deliberate config call for Mike, out of this comment-only surface. **Recommend a follow-up bead** to decide (the bead rf2-uuxjd itself enumerated this as the open decision). Not filed/actioned here per the brief.

### Scope note
The stale "8040 outside :dev-http" premise also survives as a single line in `examples/scripts/run-examples-tests.cjs:64-65` ("8040 — outside the top-level :dev-http set 8765/8031/8030; see examples-port.cjs"). It was left untouched to honour the one-extra-file edit cap in the brief — **recommend folding it into the same follow-up** (one-line: defer to examples-port.cjs rather than re-enumerating).

## Quality gates
- `node --check examples/scripts/examples-port.cjs` — pass
- `node --check examples/scripts/serve-and-run-examples-tests.cjs` — pass
- `python scripts/check_doc_slugs.py` — pass (exit 0)
- `python scripts/check_readme_links.py` — pass (exit 0)
- `python -m mkdocs build --strict` — pass (exit 0; `mkdocs` not on PATH, ran via module)
- `npm run test:examples` — **Ran 3 example specs. 0 failures, 0 skipped.** (after `npm install`; trailing "http-server exited code=1" is the benign Windows teardown kill, not a test failure)