### PR TITLE
fix(git-hooks): install -Check correct under core.autocrlf (rf2-ujhpf)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,13 @@
 *.sh text eol=lf
 
+# The git-hook sources (post-merge, pre-commit) are POSIX sh but carry no
+# .sh extension, so the rule above misses them. Pin them to LF so the
+# checked-out source matches the LF-normalised installed hook byte-for-byte
+# on the line-ending axis, and so the `sh -n` parse / `dash` checks never see
+# a stray CR on a Windows (core.autocrlf=true) checkout (rf2-ujhpf).
+scripts/git-hooks/post-merge text eol=lf
+scripts/git-hooks/pre-commit text eol=lf
+
 # The docs/cljs playground bundles are committed, vendored prebuilts that
 # esbuild / shadow-cljs emit with LF endings (rf2-ee38b.22). Pin LF so a
 # Windows checkout / rebuild never CRLF-normalises them — that would make the

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -60,7 +60,17 @@ function Get-MarkerBlock {
         [string]$BeginMark,
         [string]$EndMark
     )
-    $lines = Get-Content -LiteralPath $Path
+    # Read as explicit UTF-8 and split line endings ourselves. Get-Content
+    # decodes with the system ANSI codepage on Windows PowerShell 5.x, which
+    # mangles any non-ASCII byte in the source hook (the comments carry
+    # em-dashes). The installer then writes the block back as UTF-8, so the
+    # ANSI-misread source no longer round-trips equal to the UTF-8 install and
+    # -Check falsely reports the block out of date even on a fresh, correct
+    # install (rf2-ujhpf). Reading both sides as UTF-8 and normalising line
+    # endings makes the comparison encoding- and eol-agnostic without
+    # weakening drift detection.
+    $text  = [System.IO.File]::ReadAllText($Path, (New-Object System.Text.UTF8Encoding $false))
+    $lines = $text -split "`r`n|`n|`r"
     $out = New-Object System.Collections.Generic.List[string]
     $inBlock = $false
     foreach ($line in $lines) {


### PR DESCRIPTION
## Quality gates

- **Fresh-install OK (bug repro now passes).** Clean-room temp git repo, `core.autocrlf=true`, CRLF source hooks (worst case): `install-git-hooks.ps1` (exit 0) then `... -Check` -> exit 0. Before this change `-Check` reported `block out of date` / exit 1 on a fresh correct install.
- **Tamper still stale (drift detection not weakened).** Editing a non-marker line inside the installed block -> `-Check` reports `block out of date`, exit 1.
- **Idempotent re-install.** Second `install-git-hooks.ps1` -> `up to date`, exit 0.
- **Pre-commit hook suite green.** `scripts/git-hooks/test-pre-commit.sh` -> 10 passed, 0 failed.
- **PowerShell parse OK** on the edited installer. shellcheck unavailable locally (hook sources unchanged) -> deferred to CI.

## Root cause

`Get-MarkerBlock` read both the hook **source** (`scripts/git-hooks/{post-merge,pre-commit}`) and the **installed** hook with `Get-Content`, which decodes via the system ANSI codepage on Windows PowerShell 5.x. The source hook comments carry em-dashes (U+2014, 3 UTF-8 bytes); the ANSI misread mangles them. The installer then writes the block back as UTF-8 (`WriteAllText`), so the ANSI-misread source no longer round-trips byte-equal to the UTF-8 install — and `-Check` falsely reports the block stale even on a fresh, correct install under `core.autocrlf=true` (the Windows default).

This is fundamentally an **encoding** mismatch, not a line-ending one: the failing comparison showed zero CR involvement, only mojibake'd em-dash bytes. Only the `.ps1 -Check` path was affected; fresh install worked, and the POSIX `install-git-hooks.sh --check` is unaffected (no ANSI codepage; sed-based).

## Fix

- **`scripts/install-git-hooks.ps1`** — `Get-MarkerBlock` now reads with explicit UTF-8 (`File.ReadAllText` + `UTF8Encoding`) and splits line endings itself (`-split "\r\n|\n|\r"`), so the source-vs-install comparison is **encoding- and eol-agnostic**. This is the actual `-Check` fix.
- **`.gitattributes`** — pin `scripts/git-hooks/post-merge` and `pre-commit` to `text eol=lf` (the existing `*.sh` rule misses them — these hooks have no `.sh` extension). Keeps the working-tree source LF so the `sh -n` / `dash` parse never sees a stray CR on a Windows checkout. The tracked blobs were already LF, so `git add --renormalize` was a no-op.

**Drift detection preserved:** a genuinely out-of-date block (in-block tamper) still reports stale (verified above). The fix only neutralises spurious encoding/eol differences, never real content drift. Hook source files were left untouched (no content edits).

Closes rf2-ujhpf.
