### PR TITLE
fix(epoch): correct :trace-events-keep default drift (5 -> 50) in docs + test pin (rf2-5t8mr.7)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -59,14 +59,20 @@
 ;;
 ;; Design provenance (kept out of the public `configure!` docstring per the
 ;; rf2-ee38b clarity review):
-;;   * `:trace-events-keep` defaults to a FINITE 5 (rf2-mrsck / Security.md
-;;     §Epoch privacy posture): the most-recent five records per frame retain
-;;     raw `:trace-events`; older records keep only the cheap structured
-;;     projections — bounding dev-session heap from accumulated raw traces.
-;;     Apps that need the whole ring's raw streams pass a larger value (or
-;;     one >= the depth cap). `(rf/configure :epoch-history {:trace-events-keep
-;;     nil})` is a no-op against the explicit-value validation; use a numeric
-;;     value or omit the slot.
+;;   * `:trace-events-keep` defaults to a FINITE value equal to `:depth`
+;;     (50 — see `re-frame.epoch.state/default-trace-events-keep`; rf2-mrsck /
+;;     Security.md §Epoch privacy posture). With the default the most-recent
+;;     `:depth` records per frame retain raw `:trace-events`; when an epoch
+;;     evicts from the ring its raw trace evicts with it, so trace + epoch
+;;     stay atomic (Mike pair-debug 2026-05-27 — the prior finite-5 default
+;;     created the discrepancy of 50 retained records but only 5 with their
+;;     `:trace-events`). Older records (beyond the keep-window, when an app
+;;     configures a keep < depth) keep only the cheap structured projections.
+;;     Memory-conscious hosts pass a smaller value (e.g.
+;;     `{:trace-events-keep 5}`); `0` drops every record's `:trace-events`.
+;;     `(rf/configure :epoch-history {:trace-events-keep nil})` is a no-op
+;;     against the explicit-value validation; use a numeric value or omit the
+;;     slot.
 ;;   * Keys are validated at the boundary (refactor-audit r2 rf2-lwn4t
 ;;     §rf2-douii): a `:depth` / `:trace-events-keep` that isn't a
 ;;     non-negative integer is silently dropped rather than stored, so a
@@ -86,7 +92,9 @@
                         `:trace-events` vector. Older records keep the cheap
                         structured projections (`:sub-runs` / `:renders` /
                         `:effects`) but drop `:trace-events` to bound memory.
-                        Default 5.
+                        Defaults to the `:depth` value (50) so trace + epoch
+                        evict atomically; pass a smaller value (e.g. 5) to
+                        bound dev-session heap more aggressively.
     :redact-fn          fn? or nil. When non-nil the runtime invokes the fn
                         once per assembled record between `build-record` and
                         ring-append / listener fan-out, so the ring and every

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -144,8 +144,9 @@
   (epoch/clear-epoch-listeners!)
   ;; Reset the config atom directly so :trace-events-keep / a stale
   ;; :depth from a sibling test can't leak; configure! merges, so a
-  ;; per-test opt-in to elision would otherwise persist. Per rf2-mrsck
-  ;; the default :trace-events-keep is 5 (finite).
+  ;; per-test opt-in to elision would otherwise persist. The fixture
+  ;; forces :trace-events-keep 5 (NOT the shipped default of 50 = :depth,
+  ;; see `re-frame.epoch.state/default-trace-events-keep`).
   (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -66,9 +66,11 @@
   (epoch/clear-epoch-listeners!)
   ;; Reset the config atom directly so :trace-events-keep (rf2-iegsz)
   ;; doesn't leak between tests — `configure!` merges, so a per-test
-  ;; opt-in to elision would otherwise persist. Per rf2-mrsck the
-  ;; default :trace-events-keep is 5 (finite); fixtures restore the
-  ;; default map verbatim.
+  ;; opt-in to elision would otherwise persist. The fixture forces
+  ;; :trace-events-keep 5 (NOT the shipped default of 50 = :depth, see
+  ;; `re-frame.epoch.state/default-trace-events-keep`; Mike pair-debug
+  ;; 2026-05-27) so the keep<depth elision path is reachable with a
+  ;; handful of dispatches.
   (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
@@ -1499,18 +1501,27 @@
         (is (contains? r4 :trace-events)
             "record 4 — :trace-events kept (most-recent)")))))
 
-(deftest trace-events-keep-default-is-finite-five
-  (testing "default :trace-events-keep is a FINITE 5 — drive >5 cascades
-            and the oldest records lose :trace-events while keeping the
-            structured projections (per rf2-mrsck and Security.md
-            §Epoch privacy posture)"
+(deftest trace-events-keep-finite-cap-elides-older-records
+  (testing "a FINITE :trace-events-keep (the fixture configures 5) — drive
+            >keep cascades and the oldest records lose :trace-events while
+            keeping the structured projections (per rf2-mrsck and Security.md
+            §Epoch privacy posture).
+
+            NOTE: this pins the keep<depth ELISION behaviour against the
+            fixture-configured cap of 5, NOT 'the default'. The real
+            shipped default is 50 (= :depth, see
+            `re-frame.epoch.state/default-trace-events-keep`; Mike pair-debug
+            2026-05-27), at which trace + epoch evict atomically and no
+            retained record drops its :trace-events. The fixture forces 5 so
+            this elision path is reachable with a handful of dispatches."
     (rf/reg-frame :test/main {})
     (rf/reg-event-db :seed (fn [_ _] {:n 0}))
     (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
 
-    ;; Default config — :trace-events-keep is the new finite default (5).
+    ;; Fixture-configured cap (NOT the shipped default of 50). Reset-runtime
+    ;; forces :trace-events-keep 5 so this elision path is exercised cheaply.
     (is (= 5 (:trace-events-keep (epoch/current-config)))
-        "default :trace-events-keep is 5")
+        "fixture-configured :trace-events-keep is 5 (the shipped default is 50)")
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (dotimes [_ 6] (rf/dispatch-sync [:inc] {:frame :test/main}))


### PR DESCRIPTION
## What

Adversarial correctness review of `implementation/epoch/` (bead rf2-5t8mr.7). One behaviour-preserving fix; remaining findings noted in the bead close.

The shipped `:trace-events-keep` default was changed from a finite **5** to **50** (= `:depth`) in `03d027df1` (2026-05-27, Mike pair-debug — keep trace + epoch eviction atomic so the operator's mental model holds: an epoch and its raw trace evict together). The user-facing documentation and a test pin were never updated to match:

- **`epoch.cljc`** — the `configure!` docstring and the design-provenance comment both claimed the default is `5`. A real app that never calls `(rf/configure :epoch-history …)` actually gets `50` (`re-frame.epoch.state/default-trace-events-keep`). This is a documented-contract-vs-implementation divergence on a memory-bounding knob.
- **`trace-events-keep-default-is-finite-five`** — asserted `(= 5 (:trace-events-keep (current-config)))` "default is 5", but it only passed because the test fixture **forces** `:trace-events-keep 5`. It was pinning the fixture value, not the shipped default — a false guard that gave confidence in a contract (5) that diverges from the implementation (50).

## Fix (behaviour-preserving)

Docstring / comment text + test naming/messaging only. No runtime change.

- `epoch.cljc`: docstring + provenance comment now state the default is `50` (= `:depth`), explain the atomic trace+epoch eviction rationale, and point at `state/default-trace-events-keep` as the source of truth.
- Test: renamed `trace-events-keep-default-is-finite-five` → `trace-events-keep-finite-cap-elides-older-records`; it now honestly states it pins the **fixture-configured** cap of 5 (the elision path the fixture makes reachable cheaply), and documents that the **shipped default is 50**. The fixture still forces 5 (so the `keep < depth` elision path stays exercised).
- Fixture comments in `epoch_test.clj` / `epoch_concurrency_stress_test.clj` corrected to say the fixture forces 5, distinct from the shipped 50.

## Out of scope (noted for follow-up)

A parallel spec drift exists in `spec/` (hot-zone, not edited here): `spec/Privacy.md` documents the default as `trace-events-keep nil` (which would mean unbounded retention, violating Security.md's "MUST offer a finite retention cap"); `spec/API.md` / `docs/api/01-core.md` omit `:trace-events-keep` from the default map entirely. These should be reconciled to `50` by the spec owner.

## Quality gates

- epoch JVM `clojure -M:test`: 238 tests, 862 assertions, 0 failures
- `npm run test:cljs`: 5151 tests, 17385 assertions, 0 failures
- clj-kondo on changed files: 0 errors (1 pre-existing unrelated `TimeUnit` unused-import warning, untouched)