### PR TITLE
fix(ssr-ring): header fold no longer wipes the map on a repeated non-string value (rf2-5t8mr.14)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -14,15 +14,23 @@
 
 (defn merge-pair-into-header-map
   "Fold a `[name value]` header pair into the accumulating Ring headers
-  map. The accumulator only ever carries `nil`, `string`, or `vector`
-  values per the contract upstream — no other shapes flow in — so the
-  three arms here are exhaustive."
+  map. The accumulator normally carries `nil`, `string`, or `vector`
+  values — the SSR runtime's `set-header`/`append-header` fxs gate
+  header NAMES (RFC 7230 token grammar) and VALUES (CR/LF/NUL) but do
+  NOT coerce a value to a string, so a non-string scalar (number,
+  keyword, boolean) can reach this fold verbatim. The first occurrence
+  `assoc`s that scalar in; a repeated name must still collapse it into
+  a multi-value vector. The `:else` arm handles that case the same way
+  the `string?` arm does (existing scalar → `[existing v]`); without it
+  the `cond` would return `nil`, silently wiping the ENTIRE accumulated
+  header map mid-fold (Content-Type, Set-Cookie, everything folded so
+  far) — a silent-failure header-loss bug."
   [m [k v]]
   (let [existing (get m k)]
     (cond
       (nil? existing)        (assoc m k v)
-      (string? existing)     (assoc m k [existing v])
-      (vector? existing)     (assoc m k (conj existing v)))))
+      (vector? existing)     (assoc m k (conj existing v))
+      :else                  (assoc m k [existing v]))))
 
 (defn append-set-cookies
   "For every cookie map in the response's :cookies vector, append one

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -212,6 +212,30 @@
                (headers/merge-pair-into-header-map ["Link" "b"])
                (headers/merge-pair-into-header-map ["Link" "c"]))))))
 
+(deftest repeated-non-string-value-does-not-wipe-header-map
+  (testing "rf2-5t8mr.14: a repeated header name whose value is a
+            non-string scalar (the runtime's set/append-header fxs gate
+            CR/LF/NUL but do NOT coerce to string) must collapse into a
+            2-vector via the :else arm — NOT fall through the cond and
+            return nil, which silently wiped the ENTIRE accumulated
+            header map (Content-Type, Set-Cookie, everything)"
+    (is (= {"X-Count" [5 6]}
+           (-> {}
+               (headers/merge-pair-into-header-map ["X-Count" 5])
+               (headers/merge-pair-into-header-map ["X-Count" 6])))
+        "two non-string values under one name collapse to a vector")
+    (let [result (headers/headers->ring-map+default-content-type
+                   [["X-Count" 5]
+                    ["X-Count" 6]
+                    ["X-Other" "keep"]]
+                   "text/html")]
+      (is (= [5 6] (get result "X-Count"))
+          "the repeated non-string header survives as a 2-vector")
+      (is (= "keep" (get result "X-Other"))
+          "headers folded AFTER the repeat are NOT wiped (no nil-map)")
+      (is (= "text/html" (get result "Content-Type"))
+          "the defaulted Content-Type survives — the map was never nulled"))))
+
 (deftest header-fold-collapses-repeated-names-through-full-fold
   (testing "rf2-ynjts.14: the full fold collapses repeated names into a
             vector AND keeps singletons scalar in one pass — the contract


### PR DESCRIPTION
## What

`re-frame.ssr.ring.headers/merge-pair-into-header-map`'s `cond` had no `:else` arm. The SSR runtime's `set-header` / `append-header` fxs validate header names (RFC 7230 token grammar) and reject CR/LF/NUL in values, but do **not** coerce a value to a string — so a non-string scalar (number, keyword, boolean) can reach this fold verbatim.

On a **repeated** header name carrying such a value, `existing` matches neither `nil?`, `string?`, nor `vector?`, so the `cond` returns `nil` — silently nulling the **entire accumulated Ring header map** mid-fold (Content-Type, Set-Cookie, and every header folded so far). Headers folded *after* the repeat survive only because `(assoc nil ...)` rebuilds a fresh map; the repeated header and everything before it are lost.

Repro (pre-fix):
```clojure
(headers/headers->ring-map+default-content-type
  [["X-Count" 5] ["X-Count" 6] ["X-Other" "keep"]] "text/html")
;; => {"X-Other" "keep", "Content-Type" "text/html"}   ; X-Count vanished
```

## Fix

Collapse the `string?` and missing arms into one `:else` that promotes the existing scalar to `[existing v]` — byte-identical to the old `string?` behaviour, and never returns nil. Behaviour-preserving for the documented nil / string / vector cases; adds a regression test pinning the non-string-value collapse and that no prior headers / defaulted Content-Type are wiped.

## Context

Found during the adversarial correctness review of `implementation/ssr-ring` (rf2-5t8mr.14, child of EPIC rf2-5t8mr). Two further (non-trivial / judgment-laden) findings from the same review were filed as separate bug beads rather than fixed here: rf2-z5azc (MED — streaming writer spawned before response materialisation) and rf2-ljjh0 (LOW — caller `:on-error` throw escapes the handler).

## Quality gates

- ssr-ring JVM `clojure -M:test` — 96 tests / 416 assertions, 0 failures, 0 errors
- `npm run test:cljs` — 5151 tests / 17385 assertions, 0 failures, 0 errors
- clj-kondo — 0 new warnings on changed files (the one remaining `unused binding v` warning pre-dates this change)