### PR TITLE
fix(adapters/test-react): unmount! evicts the exact record from active-mounts (rf2-5t8mr.6)

### DIFF
--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -187,29 +187,37 @@
   `:rf.error/sync-unmount-during-render` if called while a render is in flight
   ANYWHERE in the tree (the rf2-4l7t2 class) — keyed off the global
   `render-depth`, so a parent re-render that synchronously unmounts a separate
-  sibling/child root trips the guard just as React does."
-  [mount]
+  sibling/child root trips the guard just as React does.
+
+  `self-ref` is an atom that `mount-tree!` fills with the FINAL record (the one
+  it `conj`'d into `active-mounts`). The thunk must `disj` THAT record, not the
+  pre-`assoc` skeleton: a defrecord's equality includes the `:unmount-fn`
+  field, so the skeleton (`:unmount-fn` nil) and the final record (`:unmount-fn`
+  this thunk) are UNEQUAL — `(disj active-mounts skeleton)` would silently fail
+  to remove the registered record and leak it for the adapter's lifetime."
+  [self-ref]
   (fn unmount []
-    (when @(:mounted? mount)
-      (when (rendering?)
-        (throw (ex-info ":rf.error/sync-unmount-during-render"
-                        {:where    'rf/test-react-unmount
-                         :recovery :no-recovery
-                         :reason   (str "Attempted to synchronously unmount a root"
-                                        " while React was already rendering. React"
-                                        " 18+ raises the equivalent runtime error;"
-                                        " the Test-React adapter raises here so the"
-                                        " bug is caught at unit-test speed. See"
-                                        " rf2-4l7t2 for the production manifestation.")
-                         :mount-id (:id mount)})))
-      ;; Children-first teardown (mirrors React). Each child's own thunk runs
-      ;; the same guard + cascade, so a deep tree unwinds leaf-upward.
-      (doseq [child @(:children mount)]
-        ((:unmount-fn child)))
-      (log-phase! mount :will-unmount)
-      (reset! (:mounted? mount) false)
-      (reset! (:render-tree mount) nil)
-      (swap! active-mounts disj mount))
+    (let [mount @self-ref]
+      (when @(:mounted? mount)
+        (when (rendering?)
+          (throw (ex-info ":rf.error/sync-unmount-during-render"
+                          {:where    'rf/test-react-unmount
+                           :recovery :no-recovery
+                           :reason   (str "Attempted to synchronously unmount a root"
+                                          " while React was already rendering. React"
+                                          " 18+ raises the equivalent runtime error;"
+                                          " the Test-React adapter raises here so the"
+                                          " bug is caught at unit-test speed. See"
+                                          " rf2-4l7t2 for the production manifestation.")
+                           :mount-id (:id mount)})))
+        ;; Children-first teardown (mirrors React). Each child's own thunk runs
+        ;; the same guard + cascade, so a deep tree unwinds leaf-upward.
+        (doseq [child @(:children mount)]
+          ((:unmount-fn child)))
+        (log-phase! mount :will-unmount)
+        (reset! (:mounted? mount) false)
+        (reset! (:render-tree mount) nil)
+        (swap! active-mounts disj mount)))
     nil))
 
 (defn- mount-tree!
@@ -224,15 +232,20 @@
   with `*rendering-mount*` bound) the new mount is appended to that parent's
   `:children`, so unmounting the parent later cascades to it."
   [render-tree]
-  (let [base    (->MountedComponent
-                  (gensym "test-react-mount-")
-                  (atom nil)   ; render-tree
-                  (atom [])    ; lifecycle-log
-                  (atom false) ; currently-rendering?
-                  (atom true)  ; mounted?
-                  (atom [])    ; children
-                  nil)         ; unmount-fn — filled in below
-        mount   (assoc base :unmount-fn (unmount-thunk base))]
+  (let [self-ref (atom nil)   ; forward ref so the thunk can disj the FINAL record
+        base     (->MountedComponent
+                   (gensym "test-react-mount-")
+                   (atom nil)   ; render-tree
+                   (atom [])    ; lifecycle-log
+                   (atom false) ; currently-rendering?
+                   (atom true)  ; mounted?
+                   (atom [])    ; children
+                   nil)         ; unmount-fn — filled in below
+        mount    (assoc base :unmount-fn (unmount-thunk self-ref))]
+    ;; The thunk closes over `self-ref`, not `mount`, so it disj's the exact
+    ;; record that was conj'd (see unmount-thunk docstring — equality includes
+    ;; :unmount-fn, so the skeleton would not match the registered record).
+    (reset! self-ref mount)
     (log-phase! mount :constructor)
     (run-render! mount render-tree)
     (log-phase! mount :did-mount)

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
@@ -104,6 +104,31 @@
       (is (zero? (count (test-react/mounted-roots))))
       (is (nil? (test-react/current-render-tree mount))))))
 
+(deftest unmount-actually-evicts-from-the-raw-active-set
+  (testing "unmount! removes the mount from the RAW active-mounts set, not just
+            flips its :mounted? flag. mounted-roots filters by :mounted?, so it
+            reports zero even if the dead record were left in the backing set —
+            this pins the eviction directly. Regression for the
+            base/mount record-identity disj mismatch: the unmount thunk must
+            disj the exact record conj'd, or the dead record leaks for the
+            adapter's lifetime (defrecord equality includes :unmount-fn, so the
+            pre-assoc skeleton would not match)."
+    (let [active @#'test-react/active-mounts]
+      (is (zero? (count @active))
+          "precondition: raw active set starts empty")
+      (let [mount (test-react/mount! [:div "live"])]
+        (is (= 1 (count @active))
+            "mount registered exactly one record in the raw set")
+        (test-react/unmount! mount)
+        (is (zero? (count @active))
+            "unmount! EVICTED the record from the raw set — no leaked dead record"))
+      ;; Many mount/unmount cycles must not grow the raw set (the leak symptom
+      ;; was monotonic growth masked by the :mounted? filter).
+      (dotimes [_ 25]
+        (test-react/unmount! (test-react/mount! [:div "churn"])))
+      (is (zero? (count @active))
+          "25 mount/unmount cycles left the raw active set empty — no accumulation"))))
+
 ;; ---- adapter-disposal drains stranded mounts ------------------------------
 
 (deftest dispose-adapter-drains-stranded-mounts


### PR DESCRIPTION
## What

Adversarial correctness review of `implementation/adapters/test-react` (the shared CLJC React-lifecycle harness backing the uix/helix browser suites), per bead **rf2-5t8mr.6** (epic rf2-5t8mr).

One real defect found and fixed.

## The bug (HIGH — resource leak in the harness's own tracking)

`mount-tree!` builds the unmount thunk from the **pre-`assoc` skeleton** `base` (whose `:unmount-fn` field is `nil`) but registers the **`assoc`'d** `mount` (whose `:unmount-fn` is the thunk) into `active-mounts`:

```clojure
(let [base  (->MountedComponent ... nil)              ; :unmount-fn nil
      mount (assoc base :unmount-fn (unmount-thunk base))]  ; thunk closes over BASE
  ...
  (swap! active-mounts conj mount))                   ; registers MOUNT
```

A defrecord's equality/hash spans **every** field, so `base` (`:unmount-fn` nil) and `mount` (`:unmount-fn` thunk) are **unequal** values. The thunk's `(swap! active-mounts disj mount)` — where `mount` is the closed-over `base` — therefore **never matches** the registered record. Every unmounted mount (root or cascaded child) leaks into `active-mounts` for the adapter's lifetime.

The leak was **masked**: `mounted-roots` and `children` re-filter by the `:mounted?` atom (which IS shared between `base`/`mount`, so the flag flips correctly), so the public surface reported the right counts while the backing set grew monotonically. `dispose-adapter!` reset the set to `#{}` per fixture teardown, so it didn't cross test boundaries — but within a long-running case it accumulated dead records, and the documented `disj`-on-unmount contract was silently a no-op.

Confirmed via REPL: after one mount→unmount, raw `active-mounts` count = 1 (should be 0). Across 25 churn cycles it reached 26.

## The fix

Thread the final record through a forward-ref atom (`self-ref`), set immediately after `assoc`, so the thunk `disj`'s exactly the record that was `conj`'d. Minimal, local, no public-surface change.

## Regression

`unmount-actually-evicts-from-the-raw-active-set` reaches the private `active-mounts` var and pins that the raw set shrinks to zero on unmount and stays flat across 25 mount/unmount cycles. Verified it **fails against the pre-fix code** (`actual: (not (zero? 1))` and `(not (zero? 26))`).

## Other areas reviewed — no defect

- `run-render!` throw path (flags/depth restored via `finally`; render-tree pre-mutation matches React's discard-on-throw semantics).
- `unmount-thunk` guard-before-cascade ordering, idempotency, children-first leaf-upward teardown.
- `dispose-adapter!` forced-drain (flat walk over the forest, `:mounted?`-guarded, emitter deliberately preserved).
- `mount-child!` outside-render guard, the two-entry-point (`render` vs `mount!`) seam, `trigger-update!`/`unmount!`-after-teardown guards, the no-emitter `render-to-string` throw, late-bind hook routing.

A mount whose render body THROWS is never registered in `active-mounts` and keeps `:mounted? true` but is unreachable (the throw discards the caller's reference) — benign and matches React discarding a root that threw mid-render; left as-is.

## Quality gates
- test-react JVM `clojure -M:test`: **20 tests / 62 assertions, 0 failures**
- `npm run test:cljs`: **5151 tests / 17385 assertions, 0 failures**
- `npm run test:browser`: **130 tests / 367 assertions, 0 failures**
- clj-kondo on both changed files: **0 errors, 0 warnings**

Refs rf2-5t8mr.6.
