### PR TITLE
fix(impl/scripts): handle runner spawn 'error' in browser-test orchestrator (rf2-5t8mr.15)

### DIFF
--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -321,7 +321,16 @@ async function waitForReady(port, expectedToken, deadline, state) {
     env: { ...process.env, BROWSER_TEST_URL: `http://127.0.0.1:${port}` },
   }));
 
-  const code = await new Promise((resolve) => runner.on('exit', resolve));
+  // Resolve on either 'exit' or 'error'. A spawn failure (e.g. the runner
+  // binary cannot be launched) emits 'error' and NOT 'exit'; without the
+  // 'error' arm this promise would hang until the whole run is killed.
+  const code = await new Promise((resolve) => {
+    runner.once('exit', (exitCode) => resolve(exitCode));
+    runner.once('error', (err) => {
+      console.error(`Failed to launch test runner: ${err && err.message ? err.message : err}`);
+      resolve(1);
+    });
+  });
 
   return code == null ? 1 : code;
 })().then(async (code) => {


### PR DESCRIPTION
## Summary

Adversarial correctness review of `implementation/scripts/` (bead rf2-5t8mr.15). One small, safe, behaviour-preserving fix; two non-trivial findings filed as bug beads (not fixed here).

### Fix in this PR
`serve-and-run-browser-tests.cjs` awaited only the runner child's `'exit'` event. A spawn failure emits `'error'` and NOT `'exit'`, so the promise would hang indefinitely instead of failing cleanly. Added an `'error'` arm that logs and resolves to exit 1. Success path unchanged.

### Findings filed (not in this PR)
- **rf2-84gzw** (MED): `serve-and-run-xray-feature-gate.cjs` uses a fixed port (8037) with no free-port fallback and no ownership-token verification — unlike every sibling orchestrator. A foreign server on the port can be driven against (false-RED, or false-GREEN if it serves stale Xray content).
- **rf2-ogpeq** (LOW-MED): `lib/local-browser-harness.cjs` `cleanupSync` short-circuits on the shared `cleaned` flag set by an in-flight async `cleanup()`, which can leave tracked child processes orphaned on a hard-exit race during teardown.

### Verdict
Scanners (bundle-isolation, elision, perf-bundle, schemas-bundle, reagent-slim, uix-helix-reagent-free) are sound — each pairs its negative grep with a methodology/control assertion that prevents vacuous false-green passes. No false-green gate found.

## Quality gates
- `node --check` on changed file: OK
- `npm run test:script-helpers`: 39 passed
- `npm run test:script-policy`: 42 passed