### PR TITLE
fix(xray): guard export diff key-sort against mixed-type app-db keys (rf2-5t8mr.24)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/export/cascade.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/export/cascade.cljc
@@ -178,20 +178,33 @@
   (cond
     (and (nil? before) (nil? after)) []
     (and (map? before) (map? after))
-    (let [ks-b   (set (keys before))
-          ks-a   (set (keys after))
+    ;; rf2-5t8mr.24 — sort keys by `pr-str`, NOT raw `clojure.core/sort`.
+    ;; The host app-db is arbitrary user data: a top-level map with
+    ;; MIXED-TYPE keys (e.g. `{:user 1 "session" 2 42 3}` — legal
+    ;; Clojure) makes `(sort #{:user "session" 42})` throw a
+    ;; ClassCastException (the default comparator can't order a keyword
+    ;; against a string against a number). That throw escapes the
+    ;; `:rf.xray/cascade-export` sub and crashes the export surface.
+    ;; `pr-str`-keyed ordering is total over every Clojure value — the
+    ;; SAME mixed-type-safe approach the canonical engines already use
+    ;; (`app-db-diff-helpers/diff-paths` `::sort-key`; `diff.engine/
+    ;; compare-path`). Behaviour-preserving for the homogeneous-keyword
+    ;; common case (keyword pr-str ordering matches natural ordering).
+    (let [ks-b      (set (keys before))
+          ks-a      (set (keys after))
+          sort-keys (fn [ks] (sort-by pr-str ks))
           added  (mapv (fn [k] {:op :added :path [k] :before nil :after (get after k)})
-                       (sort (set/difference ks-a ks-b)))
+                       (sort-keys (set/difference ks-a ks-b)))
           removed (mapv (fn [k] {:op :removed :path [k] :before (get before k) :after nil})
-                        (sort (set/difference ks-b ks-a)))
+                        (sort-keys (set/difference ks-b ks-a)))
           changed (mapv (fn [k] {:op :modified :path [k]
                                  :before (get before k)
                                  :after  (get after k)})
-                        (sort (filter (fn [k]
-                                        (and (contains? ks-b k)
-                                             (contains? ks-a k)
-                                             (not= (get before k) (get after k))))
-                                      ks-a)))]
+                        (sort-keys (filter (fn [k]
+                                             (and (contains? ks-b k)
+                                                  (contains? ks-a k)
+                                                  (not= (get before k) (get after k))))
+                                           ks-a)))]
       (into [] cat [added changed removed]))
     (not= before after)
     [{:op :modified :path [] :before before :after after}]

--- a/tools/xray/test/day8/re_frame2_xray/export/cascade_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/export/cascade_cljs_test.cljc
@@ -197,6 +197,23 @@
     (is (some #(= [:c] (:path %)) (:removed by-op))  ":c removed")
     (is (some #(= [:d] (:path %)) (:added by-op))    ":d added")))
 
+(deftest app-db-diff-mixed-type-top-level-keys-no-crash
+  ;; rf2-5t8mr.24 — the host app-db is arbitrary user data; a top-level
+  ;; map with MIXED-TYPE keys (keyword + string + number) must not throw
+  ;; a ClassCastException out of the export diff's key sort (which would
+  ;; escape the `:rf.xray/cascade-export` sub and crash the export
+  ;; surface). The diff must still classify every changed key correctly.
+  (let [epoch {:epoch-id :e1
+               :db-before {:user 1 "session" :tok-a 42 :old}
+               :db-after  {:user 9 "session" :tok-b 7 :new}}
+        out (export/project-cascade {:dispatch-id 1} {:epoch epoch})
+        diff (get-in out [:app-db :diff])
+        by-op (group-by :op diff)]
+    (is (some #(= [:user] (:path %)) (:modified by-op))     ":user modified")
+    (is (some #(= [42] (:path %)) (:removed by-op))         "42 removed")
+    (is (some #(= [7] (:path %)) (:added by-op))            "7 added")
+    (is (some #(= ["session"] (:path %)) (:modified by-op)) "\"session\" modified")))
+
 (deftest app-db-diff-empty-when-before-equals-after
   (let [epoch {:epoch-id :e1
                :db-before {:a 1}


### PR DESCRIPTION
## What

The per-cascade export's inline `diff-triples` (`tools/xray/src/day8/re_frame2_xray/export/cascade.cljc`) sorted top-level app-db key-set differences with raw `clojure.core/sort`. The host app-db is arbitrary user data: a top-level map with **mixed-type keys** (keyword + string + number — legal Clojure) makes the default comparator throw a `ClassCastException`, which escapes the `:rf.xray/cascade-export` sub and crashes the export surface — a debugger showing the dev a crash instead of data.

## Fix

Switch to `(sort-by pr-str ...)` — the same mixed-type-safe approach the canonical engines already use (`app-db-diff-helpers/diff-paths` `::sort-key`; `diff.engine/compare-path`). Behaviour-preserving for the homogeneous-keyword common case (keyword `pr-str` ordering matches natural ordering); only the previously-crashing mixed-type path changes.

Adds a regression test asserting a mixed keyword/string/number top-level app-db diffs without throwing and classifies every changed key.

## Found by

Adversarial correctness review of `tools/xray/src` (rf2-5t8mr.24, child of the correctness-review sweep rf2-5t8mr).

## Quality gates

- `tools/xray` `clojure -M:test`: 1035 tests, 4138 assertions, **0 failures**
- `implementation` `npm run test:cljs`: 5152 tests, 17389 assertions, **0 failures**
- `implementation` `npm run test:xray-feature-gate`: 16 scenarios, **0 failures**, 13 matrix rows
- clj-kondo on changed files: 0 errors, 0 new warnings (4 pre-existing, none on changed lines)