### PR TITLE
fix(template): correct API.md error-table claim about unqualified :name (rf2-5t8mr.22)

### DIFF
--- a/tools/template/spec/API.md
+++ b/tools/template/spec/API.md
@@ -148,7 +148,7 @@ mirror the chosen `:substrate` + `:include-story?` flags.
 | `:include-story?` not `true` / `false` / `nil` | `:rf.error/template-bad-include-story-flag` | `ex-info` thrown; message gives the offending value. |
 | `:include-story? true` with non-Reagent substrate | `:rf.error/template-include-story-reagent-only` | `ex-info` thrown; message says "Reagent-only in v1" and names the chosen substrate. |
 | `:name` missing | n/a (deps-new) | deps-new's harness rejects before template is invoked. |
-| `:name` not group-qualified | n/a (deps-new) | deps-new's harness rejects (`acme/my-app`, not `my-app`). |
+| `:name` not group-qualified | n/a (deps-new) | **Not rejected.** deps-new doubles a bare name (`my-app` → the symbol `my-app/my-app`), so the generated namespace is `my-app.my-app` and the source nests under `src/my_app/my_app/`. Always pass a group-qualified `:name` (`acme/my-app`); an unqualified one scaffolds, but with a doubled, almost-certainly-unintended namespace. |
 | Target directory already exists | n/a (deps-new) | deps-new's harness aborts to avoid clobbering (unless `:overwrite` is passed). |
 
 ## Cross-references


### PR DESCRIPTION
## What

Adversarial correctness review of `tools/template/` (bead rf2-5t8mr.22, child of the rf2-5t8mr correctness sweep). One genuine defect found and fixed; the rest of the slice verified clean.

### Finding (MED) — API.md error table makes a false claim

`tools/template/spec/API.md` §Errors claimed:

> `:name` not group-qualified → deps-new's harness rejects (`acme/my-app`, not `my-app`).

That is wrong. deps-new's `deconstruct-project-name` doubles a bare name rather than rejecting it: `:name my-app` becomes the symbol `my-app/my-app`, scaffolding namespace `my-app.my-app` under `src/my_app/my_app/`.

Verified empirically against deps-new v0.12.1 (the pinned coord) by emitting an app with `:name "myapp"` — output dir `myapp`, source at `src/myapp/myapp/core.cljs`, `(ns myapp.myapp.core ...)`. No error thrown.

The spec is the project's primary artefact, so a doc promising a guard that does not exist is a correctness defect, not a style nit. Fixed the row to state the real behaviour and steer users to always pass a group-qualified `:name`.

## Scope / what was checked (verified clean)

- **Name derivation** (`->file-path` / `->ns-form` in `hooks.clj`): byte-identical to deps-new's own `->file`/`->ns`; consistent with the deps-new-provided `:top`/`:main`. Exercised dotted-group + multi-dash + `io.github.*` (git-service-stripped `:top` → `day8.my-app`) — all correct.
- **Per-substrate emit** (Reagent/UIx/Helix deps.edn, shadow-cljs.edn, package.json, core.cljs, views.cljs): adapter coords, `:init-fn`, Xray preload, react interop all correct per substrate.
- **`:include-story?` flag-switch**: source-file selection (`core_with_stories.cljs` / `deps_with_story.edn` / `package_with_story.json` + `stories.cljs`), Reagent-only guard, coercion of `true`/`false`/`nil` — all correct.
- **Version lockstep**: `:rf2-version` 0.0.1.alpha / `:shadow-version` 3.4.10 / `:react-version` 19.2.0 all match repo-root VERSION + implementation/package.json. No drift.
- **Coercion guards** (`coerce-substrate`, `coerce-include-story?`): no nil/NPE/edge gaps.
- **npm name with slash** (`acme/my-app` in package.json): investigated, NOT a defect — modern npm tolerates an unscoped slash-name for a `private` package (real `npm install` of the template's react/react-dom/shadow-cljs deps succeeds cleanly).

No template body / hooks change in this PR — doc-only.

## Quality gates

- `tools/template` `clojure -M:test`: **25 tests, 316 assertions, 0 failures, 0 errors** (before and after).
- No `.clj`/`.cljs`/`.edn` changed → clj-kondo N/A on the changed set.