### PR TITLE
fix(testbed-support): trim ?project-root= query override to match its documented contract (rf2-5t8mr.23)

### DIFF
--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -69,7 +69,8 @@
   [param-name]
   (when (exists? js/window)
     (let [params (-> js/window .-location .-search (js/URLSearchParams.))]
-      (non-blank (.get params param-name)))))
+      (when-let [raw (non-blank (.get params param-name))]
+        (str/trim raw)))))
 
 (defn- strip-trailing-slash
   "Return `s` without a single trailing slash, leaving a lone `\"/\"` intact."


### PR DESCRIPTION
Adversarial correctness review of `tools/testbed-support/` (bead **rf2-5t8mr.23**, child of EPIC rf2-5t8mr). Single-file slice: `tools/testbed-support/src/re_frame/testbed/config.cljs` — `resolve-project-root` + the `non-blank` / `query-param` / `strip-trailing-slash` helpers.

## Finding (fixed here)

**`query-param` returns an untrimmed value, contradicting its own docstring.** `tools/testbed-support/src/re_frame/testbed/config.cljs:65-72`.

- The docstring promises "a **trimmed** non-blank string". The implementation returned `(non-blank (.get params param-name))`, and `non-blank` returns its *original* (untrimmed) argument — it only `str/trim`s for the blank check. So the `?project-root=` override was returned verbatim, untrimmed.
- Repro: a session override `?project-root=%20C:/repo%20` (URL-encoded surrounding whitespace) reaches the project-root atom as `" C:/repo "`. The downstream join `compose-path` (`implementation/core/src/re_frame/source_coords/editor_uri.cljc`) strips trailing path-separators (`#"[/\]+$"`) but **not** whitespace, so the spaces survive into the composed on-disk path and break the editor URI.
- Severity: **LOW** (requires a hand-crafted override with encoded whitespace; the normal goog-define tier already re-trims the root via `str/trim`). But it is a clear implementation-vs-contract mismatch and the fix is small, safe, and makes the override tier match the root tier's normalisation.

Fix: trim the override before returning it.

## What else was checked (verified — no further correctness issues)

- **Cross-platform join / forward-slash-only strip+replace.** `strip-trailing-slash` and the subdir `#"^/+"` strip handle only `/`, not `\`. This is correct for every reachable caller: the dev launcher `implementation/scripts/dev-testbed.cjs` forward-slash-normalises the repo root before seeding the goog-define, all six consuming testbeds pass author-controlled forward-slash subdir constants (`"tools/xray/testbeds"` / `"tools/story/testbeds"`), and `compose-path` re-normalises both separators at join time. A leading-backslash subdir is unreachable.
- **Trailing/leading slash + doubled-slash.** `strip-trailing-slash` single-strip contract is fine: `path.resolve`-derived roots never carry trailing slashes, and downstream `compose-path` strips `[/\]+$` regardless. Lone `"/"` is preserved by the `count > 1` guard.
- **Blank / nil edges.** Blank/whitespace/nil root → `nil` (graceful no-op, matching `set-project-root!`'s blank-input contract in both Xray and Story). Blank/nil/whitespace/slash-only subdir → root verbatim.
- **Query-override precedence.** Override wins over the goog-define tier; blank override correctly falls through; no `js/window` (node) degrades to `nil`. Correct.
- **Drive-letter / UNC (Windows).** The override is documented as "used verbatim" and the absolute-path detection (drive letter / UNC / `file:`) lives downstream in `absolute-path?`; this file does not mishandle them.

## Quality gates

- `npm run test:cljs` (from `implementation/`): **5151 tests, 17385 assertions, 0 failures, 0 errors** — includes `config_cljs_test.cljs` and compiles all 6 consuming testbeds through `config.cljs` (0 warnings across 1124 files).
- clj-kondo on the changed file: **0 errors, 0 warnings**.

Verdict: 1 LOW finding, fixed. No HIGH/MED. Otherwise the slice is correct.