### PR TITLE
fix(ssr): strip lowercase/any-case on* event-handler attrs — close XSS (rf2-1uex4)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -104,19 +104,89 @@
 (def ^:private reserved-prop-keys
   #{"__proto__" "constructor" "prototype"})
 
-;; `on*` event-handler-prop matcher (rf2-dwds9). Matches the two canonical
-;; handler-prop spellings re-frame hiccup and react-dom/server recognise:
+;; `on*` event-handler-prop matcher (rf2-dwds9 / rf2-1uex4). Two layers,
+;; both applied to the attribute name, together covering every casing a
+;; case-insensitive HTML parser fires:
 ;;
-;;   - camelCase: `on` followed by an UPPERCASE letter — `onClick`,
-;;     `onMouseDown`, `onLoad`. (`on[A-Z]…`)
-;;   - kebab-case: `on-` prefix — `on-click`, `on-mouse-down`. (`on-…`)
+;;   1. STRUCTURAL — framework-shaped custom handler spellings the
+;;      re-frame hiccup adapters and react-dom/server recognise:
+;;        - camelCase: `on` + an upper-case letter — `onClick`,
+;;          `onMouseDown`, `onCustomEvent`. (`on[A-Z]…`)
+;;        - kebab-case: `on-` prefix — `on-click`, `on-custom-event`.
+;;          (`on-…`)
+;;      Only the `on` PREFIX is case-folded (`[Oo][Nn]`), so `OnClick`
+;;      / `ON-CLICK` strip too — but the discriminating class stays a
+;;      strict `[A-Z]`. Making the WHOLE pattern case-insensitive would
+;;      be a bug: `(?i)` over `[A-Z]` matches `[A-Za-z]`, so it would eat
+;;      innocuous English-word keys (`one`, `once`, `online`, `only`)
+;;      AND swallow grammar-breakout payloads (`onclick=alert(1) data-x`)
+;;      that must instead surface at the `validate-attr-name!` gate. A
+;;      structural handler is always `on` + upper-case or `on` + hyphen,
+;;      which discriminates cleanly from `on` + lowercase-word.
 ;;
-;; Deliberately NOT a bare `(starts-with? "on")`: that ate innocuous
-;; English-word attribute names like `one`, `once`, `online`, `only`.
-;; A handler is always `on` + uppercase or `on` + hyphen; ordinary words
-;; are `on` + lowercase with no hyphen, so this discriminates cleanly.
+;;   2. CANONICAL ALLOWLIST — the all-lowercase canonical HTML spellings
+;;      (`onclick`, `onload`, `onerror`, …) that layer 1 cannot catch
+;;      (no upper-case letter, no hyphen) yet are the *exact* names a
+;;      browser fires and the canonical choice of an attacker who
+;;      controls an attribute KEY. HTML attribute names are
+;;      case-insensitive, so we test `(str/lower-case nm)` against the
+;;      WHATWG event-handler-content-attribute set. An allowlist (not a
+;;      `on` + lowercase wildcard) is required so legitimate non-handler
+;;      keys like `online` / `once` / `only` / `on` survive.
 (def ^:private event-handler-name-re
-  #"on(?:[A-Z].*|-.*)")
+  #"[Oo][Nn](?:[A-Z].*|-.*)")
+
+;; WHATWG event-handler content attributes (HTML Living Standard
+;; §"Event handlers on elements, Document objects, and Window objects",
+;; plus the IDL `on*` attributes on Window/Document/Element). All
+;; lower-case; the lookup lower-cases the candidate name first so every
+;; casing (`onload`, `ONLOAD`, `OnLoad`) is covered. Curated to the
+;; event-handler names browsers actually fire — NOT a broad `on`-prefix —
+;; so non-handler keys (`online`, `once`, `only`, `on`) are never eaten.
+(def ^:private event-handler-allowlist
+  #{"onabort" "onafterprint" "onanimationcancel" "onanimationend"
+    "onanimationiteration" "onanimationstart" "onauxclick"
+    "onbeforeinput" "onbeforematch" "onbeforeprint" "onbeforetoggle"
+    "onbeforeunload" "onblur" "oncancel" "oncanplay" "oncanplaythrough"
+    "onchange" "onclick" "onclose" "oncontextlost" "oncontextmenu"
+    "oncontextrestored" "oncopy" "oncuechange" "oncut" "ondblclick"
+    "ondrag" "ondragend" "ondragenter" "ondragleave" "ondragover"
+    "ondragstart" "ondrop" "ondurationchange" "onemptied" "onended"
+    "onerror" "onfocus" "onformdata" "onfullscreenchange"
+    "onfullscreenerror" "ongotpointercapture" "onhashchange" "oninput"
+    "oninvalid" "onkeydown" "onkeypress" "onkeyup" "onlanguagechange"
+    "onload" "onloadeddata" "onloadedmetadata" "onloadstart"
+    "onlostpointercapture" "onmessage" "onmessageerror" "onmousedown"
+    "onmouseenter" "onmouseleave" "onmousemove" "onmouseout"
+    "onmouseover" "onmouseup" "onoffline" "ononline" "onpagehide"
+    "onpagereveal" "onpageshow" "onpageswap" "onpaste" "onpause"
+    "onplay" "onplaying" "onpointercancel" "onpointerdown"
+    "onpointerenter" "onpointerleave" "onpointermove" "onpointerout"
+    "onpointerover" "onpointerrawupdate" "onpointerup" "onpopstate"
+    "onprogress" "onratechange" "onrejectionhandled" "onreset"
+    "onresize" "onscroll" "onscrollend" "onsecuritypolicyviolation"
+    "onseeked" "onseeking" "onselect" "onselectionchange"
+    "onselectstart" "onslotchange" "onstalled" "onstorage" "onsubmit"
+    "onsuspend" "ontimeupdate" "ontoggle" "ontransitioncancel"
+    "ontransitionend" "ontransitionrun" "ontransitionstart"
+    "onunhandledrejection" "onunload" "onvolumechange" "onwaiting"
+    "onwheel"})
+
+(defn- event-handler-name?
+  "True when attribute name `nm` denotes an `on*` event-handler prop that
+  MUST be stripped at SSR static-markup emission (rf2-dwds9 / rf2-1uex4).
+
+  Matches either the structural camelCase/kebab handler spellings
+  (`event-handler-name-re`, case-insensitive) — so framework-shaped
+  custom handlers like `:onCustomEvent` / `:on-custom-event` strip — OR
+  the canonical all-lowercase HTML event-handler names in
+  `event-handler-allowlist`, looked up against `(str/lower-case nm)` so
+  every casing of a real handler (`onload` / `ONLOAD` / `OnLoad`) is
+  caught while non-handler keys (`online` / `once` / `only` / `on`)
+  survive."
+  [nm]
+  (or (some? (re-matches event-handler-name-re nm))
+      (contains? event-handler-allowlist (str/lower-case nm))))
 
 ;; JSX source-coord props. React DevTools' "View source" gesture reads
 ;; `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber` off the
@@ -142,10 +212,12 @@
   "True when the attribute `[k v]` MUST be dropped at SSR static-markup
   emission per Spec 011 rule rf2-dwds9:
 
-    - `on*` event-handler props (`:on-click`, `:onMouseDown`, …). The
-      client-side substrate adapters wire handlers at hydration; the
-      server-rendered string MUST NOT carry them inline. Matched against
-      `event-handler-name-re` (camelCase `on[A-Z]` or kebab `on-`).
+    - `on*` event-handler props (`:on-click`, `:onMouseDown`,
+      `:onclick`, `:ONLOAD`, …). The client-side substrate adapters
+      wire handlers at hydration; the server-rendered string MUST NOT
+      carry them inline. Matched (case-insensitively) by
+      `event-handler-name?` — the structural camelCase/kebab spellings
+      plus the WHATWG canonical all-lowercase event-handler names.
     - function-valued prop values — a fn can only be a handler/callback;
       it has no HTML-attribute serialisation and must never reach output.
     - reserved prototype-pollution keys (`__proto__` / `constructor` /
@@ -163,7 +235,7 @@
   grammar gate (rf2-vl8ir)."
   [[k v]]
   (let [nm (name k)]
-    (or (some? (re-matches event-handler-name-re nm))
+    (or (event-handler-name? nm)
         (fn? v)
         (contains? reserved-prop-keys (str/lower-case nm))
         (contains? jsx-source-prop-names nm))))

--- a/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
@@ -1,9 +1,16 @@
 (ns re-frame.ssr-attr-filter-test
-  "Spec 011 §XSS at output boundaries — rule rf2-dwds9: the SSR static-
-  markup emitter MUST strip, at attribute-emit time:
+  "Spec 011 §XSS at output boundaries — rule rf2-dwds9 (+ rf2-1uex4): the
+  SSR static-markup emitter MUST strip, at attribute-emit time:
 
-    - `on*` event-handler props (matched on the normalised/lower-cased
-      name, so `:on-click` / `:onClick` / `:ONLOAD` all filter out),
+    - `on*` event-handler props. Detection is CASE-INSENSITIVE and covers
+      both the framework-shaped structural spellings (camelCase `on[A-Z]…`
+      and kebab `on-…`) and the WHATWG canonical all-lowercase HTML
+      event-handler names. So `:on-click` / `:onClick` / `:onclick` /
+      `:onload` / `:onerror` / `:ONLOAD` / `:OnClick` ALL filter out,
+      while non-handler keys (`:online` / `:once` / `:only` / `:on`)
+      round-trip (rf2-1uex4 — HTML attribute names are case-insensitive,
+      so the canonical lowercase + arbitrary `on`-prefix casings were the
+      live XSS hole the camelCase/kebab-only regex missed).
     - function-valued prop values, and
     - reserved prototype-pollution keys (`__proto__` / `constructor` /
       `prototype`),
@@ -18,13 +25,13 @@
   the head emitter, and the streaming emitter)."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.ssr.html-helpers :as html]))
+            [re-frame.ssr.html-helpers :as html]
+            [re-frame.ssr.emit :as emit]))
 
 (deftest attr-string-strips-event-handler-props
-  (testing "rf2-dwds9 — `on*` event-handler props are dropped at emit time.
-            Matched forms are the two canonical handler-prop spellings the
-            re-frame hiccup adapters and react-dom/server recognise:
-            camelCase `on[A-Z]…` and kebab `on-…`."
+  (testing "rf2-dwds9 — structural `on*` handler spellings the re-frame
+            hiccup adapters and react-dom/server recognise are dropped at
+            emit time: camelCase `on[A-Z]…` and kebab `on-…`."
     (testing ":on-click (kebab) is stripped"
       (is (= " id=\"x\""
              (html/attr-string {:on-click "alert(1)" :id "x"}))))
@@ -37,22 +44,51 @@
       (is (= " id=\"x\""
              (html/attr-string {:onMouseDown "alert(1)" :id "x"}))))
 
+    (testing ":onCustomEvent (camelCase, framework-shaped non-HTML name)
+              is stripped by the structural matcher"
+      (is (= " id=\"x\""
+             (html/attr-string {:onCustomEvent "alert(1)" :id "x"}))))
+
     (testing "`true`-valued on* boolean prop is also stripped (no bare attr)"
       (is (= " id=\"x\""
              (html/attr-string {:on-load true :id "x"}))))
 
-    (testing "a non-handler attribute starting with the letters `on`
-              survives — only `on[A-Z]` / `on-` discriminate, so innocuous
-              English-word keys like `one` / `once` / `online` are NOT eaten"
-      (let [out (html/attr-string {:data-on "ok" :one "1" :once "2" :online "3"})]
-        (is (str/includes? out "data-on=\"ok\""))
-        (is (str/includes? out "one=\"1\""))
-        (is (str/includes? out "once=\"2\""))
-        (is (str/includes? out "online=\"3\""))))
-
     (testing "a map whose every entry is a stripped on* prop yields the
               empty string — no stray leading space"
-      (is (= "" (html/attr-string {:on-click "f" :onScroll "g"}))))))
+      (is (= "" (html/attr-string {:on-click "f" :onScroll "g"})))))
+
+  (testing "rf2-1uex4 — canonical all-lowercase HTML event-handler names
+            are stripped. HTML attribute names are case-insensitive, so the
+            browser fires `onclick`/`onload`/`onerror` identically; these
+            are the canonical (and attacker-preferred) spellings the old
+            camelCase/kebab-only regex MISSED, emitting a live handler on
+            the wire."
+    (doseq [k [:onclick :onload :onerror :onmouseover :onsubmit :onfocus]]
+      (testing (str k " (lowercase canonical) is stripped")
+        (is (= " id=\"x\""
+               (html/attr-string {k "steal()" :id "x"}))
+            (str (name k) " must not survive to wire output")))))
+
+  (testing "rf2-1uex4 — arbitrary casings of a real handler name are
+            stripped (attribute names are case-insensitive)"
+    (doseq [k [:ONLOAD :OnClick :OnLoad :ONCLICK :onCLICK]]
+      (testing (str k " (mixed/upper casing) is stripped")
+        (is (= " id=\"x\""
+               (html/attr-string {k "steal()" :id "x"}))
+            (str (name k) " must not survive to wire output")))))
+
+  (testing "rf2-1uex4 — the allowlist does NOT over-reach onto innocuous
+            keys that merely begin with the letters `on`. `online` / `once`
+            / `only` / `on` / `data-on` are legitimate attributes and MUST
+            round-trip (a blind `starts-with? \"on\"` would eat them)."
+    (let [out (html/attr-string {:data-on "ok" :one "1" :once "2"
+                                 :online "3" :only "4" :on "5"})]
+      (is (str/includes? out "data-on=\"ok\""))
+      (is (str/includes? out "one=\"1\""))
+      (is (str/includes? out "once=\"2\""))
+      (is (str/includes? out "online=\"3\""))
+      (is (str/includes? out "only=\"4\""))
+      (is (str/includes? out "on=\"5\"")))))
 
 (deftest attr-string-strips-function-valued-props
   (testing "rf2-dwds9 — function-valued props have no HTML serialisation
@@ -90,3 +126,23 @@
     (is (= " id=\"x\""
            (html/attr-string {(keyword "onClick=alert(1) data-x") "v"
                               :id "x"})))))
+
+(deftest render-to-string-strips-lowercase-handlers-end-to-end
+  (testing "rf2-1uex4 — the canonical lowercase `on*` payload an attacker
+            splats into `:custom-attrs` does NOT survive through the public
+            emitter. The verified repro was `[:img {:src \"x\" :onerror
+            \"alert(document.cookie)\"}]` rendering the live handler on a
+            void element; the wire output MUST carry no `onerror`."
+    (let [out (emit/render-to-string
+               [:img {:src "x" :onerror "alert(document.cookie)"}] {})]
+      (is (str/includes? out "src=\"x\"") "the legitimate attr survives")
+      (is (not (str/includes? (str/lower-case out) "onerror"))
+          "the lowercase event-handler attr must be stripped from the wire")
+      (is (not (str/includes? out "alert(document.cookie)"))
+          "no live handler payload on the wire"))
+
+    (testing "uppercase casing through the emitter is also stripped"
+      (let [out (emit/render-to-string
+                 [:img {:src "x" :ONLOAD "steal()"}] {})]
+        (is (not (str/includes? (str/lower-case out) "onload")))
+        (is (not (str/includes? out "steal()")))))))


### PR DESCRIPTION
## Quality gates

| Gate | Before | After |
|------|--------|-------|
| ssr JVM `clojure -M:test` | 247 tests / 853 assertions / 0 fail (baseline, no fix) | **248 tests / 872 assertions / 0 fail** |
| `npm run test:cljs` (node) | green | **5156 tests / 17390 assertions / 0 fail** |
| clj-kondo (changed files) | — | **0 errors / 0 warnings** |

## The hole

The SSR static-markup event-handler-prop filter (`re-frame.ssr.html-helpers/strip-prop?`, via `event-handler-name-re`) matched only camelCase (`:onClick`) and kebab (`:on-click`). It MISSED:

- all-lowercase canonical HTML spellings: `:onclick` / `:onload` / `:onerror` / `:onmouseover`
- any non-lowercase casing of the `on` prefix: `:ONLOAD` / `:OnClick`

HTML attribute names are case-insensitive, so a hostile attribute KEY splatted via `:custom-attrs` rendered a **live** event-handler attribute on the wire. Verified repro: `(render-to-string [:img {:src "x" :onerror "alert(document.cookie)"}] {})` → `<img src="x" onerror="alert(document.cookie)">`. Value-escaping (`&`,`"`) does not neutralise a handler context — the handler attribute itself is the vuln. This violated Spec 011 §XSS ("strip `on*` event-handler props"); the fix makes the code MATCH the documented contract.

## The fix (allowlist approach)

Two layers in `strip-prop?` (new private `event-handler-name?`), neither over-reaching onto innocuous `on`-prefixed keys:

1. **Structural matcher** — case-fold *only* the `on` PREFIX (`[Oo][Nn]`), keeping the discriminating class a strict `[A-Z]` / `-`. So framework-shaped custom handlers `:onCustomEvent` / `:OnClick` / `:ON-CLICK` strip. Deliberately NOT `(?i)` over the whole pattern: that turns `[A-Z]` into `[A-Za-z]` and would swallow `one`/`once`/`online`/`only` AND the grammar-breakout payload `onclick=alert(1) data-x` (which must instead surface at the `validate-attr-name!` grammar gate, not be silently dropped).
2. **Canonical allowlist** — the WHATWG event-handler-content-attribute set (`onclick onload onerror onmouseover onsubmit …`), matched against `(str/lower-case nm)`. Catches every casing of a real handler (`onload`/`ONLOAD`/`OnLoad`) while an allowlist (not a bare `on`+lowercase wildcard) lets `online`/`once`/`only`/`on` round-trip.

## No non-handler attr regressed

- Negative tests assert `:online` / `:once` / `:only` / `:on` / `:data-on` round-trip unchanged.
- Existing camelCase (`:onClick`/`:onMouseDown`) + kebab (`:on-click`) cases still strip.
- The grammar-breakout test (`onclick=alert(1) data-x`, lowercase) still THROWS `:rf.error/ssr-invalid-attribute-name` at the grammar gate rather than being silently dropped — the breakout path is preserved.
- Emitter composition order (Spec 011, locked) is untouched; only the regex/predicate changed. No spec prose change needed (the code now matches the documented contract).

Also fixed the `ssr_attr_filter_test` docstring that *claimed* `:ONLOAD` filtered with no real assertion — now backed by real regression + an end-to-end `render-to-string` `:img onerror` wire-level assertion.

Closes rf2-1uex4. Found by adversarial correctness review rf2-5t8mr.13.
