### PR TITLE
fix(schemas): redact :sensitive? values nested in collections (rf2-g5auo)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -325,6 +325,97 @@
              (= (nth prefix i) (nth path i)) (recur (inc i))
              :else                         false)))))
 
+;; Schema ops whose `:in` segment is a COLLECTION INDEX / KEY, not an
+;; app-db path segment. Malli's explainer reports a value-relative `:in`
+;; path that descends INTO collection elements (`[1 :token]` for a
+;; vector-of-maps, `["a" :secret]` for a map-of), but the walker builds
+;; its `{path declaration}` map at INDEX-FREE base-paths — positional /
+;; keyed containers descend at the same base-path (walker comment lines
+;; ~144-147) because the element index is not a declarable app-db slot.
+;; Aligning the two coordinate systems means dropping the collection-
+;; navigation segment that these ops contribute. `:map-of` descends into
+;; its VALUE schema (child index 1); the positional ops descend into
+;; their element/Nth-element schema. Per rf2-g5auo — without this
+;; alignment a `:sensitive?` slot nested in a collection leaks verbatim.
+(def ^:private index-bearing-ops
+  #{:vector :sequential :set :tuple :map-of})
+
+(defn- align-in-path
+  "Translate Malli's value-relative `:in` path (carrying collection
+  indices / map-of keys) into the walker's index-free declaration-path
+  coordinate system, walking `schema` in lockstep with `in-path`.
+
+  Per rf2-g5auo: the `:sensitive?` redaction lookup
+  (`schema-sensitive-at?`) compares `:in` against the walker's decl
+  paths via `prefix?`, but a collection index segment (`1` in
+  `[1 :token]`, `\"a\"` in `[\"a\" :secret]`) blocks the element-wise
+  match because the walker never emits index segments. Dropping each
+  index-bearing op's segment while descending re-aligns the two.
+
+  Returns `[:ok aligned-path]` when the whole path resolves against
+  recognised ops, or `[:fallback subschema]` when an unrecognised /
+  opaque op is hit with path remaining — the caller then redacts
+  fail-SAFE iff that subschema carries any sensitive declaration.
+  `:map` segments are kept (real app-db keys); index-bearing-op
+  segments are dropped."
+  [schema in-path]
+  (loop [schema  schema
+         in      (vec in-path)
+         aligned []]
+    (if (empty? in)
+      [:ok aligned]
+      (if-not (and (vector? schema) (pos? (count schema)))
+        ;; Path remains but the schema is a bare keyword / opaque leaf —
+        ;; cannot descend further; hand the leaf to the conservative
+        ;; fallback.
+        [:fallback schema]
+        (let [op       (nth schema 0)
+              children (children-of schema)
+              seg      (nth in 0)]
+          (cond
+            ;; `:map` — the `:in` segment is a real app-db key. Keep it
+            ;; and descend into the named child's tail schema.
+            (contains? name-bearing-ops op)
+            (if-let [child (some (fn [c]
+                                   (when (and (vector? c) (>= (count c) 2)
+                                              (= (nth c 0) seg))
+                                     c))
+                                 children)]
+              (let [has-prop? (and (>= (count child) 2) (map? (nth child 1)))
+                    tail      (if has-prop?
+                                (when (>= (count child) 3) (nth child 2))
+                                (nth child 1))]
+                (recur tail (subvec in 1) (conj aligned seg)))
+              ;; Key not found in the schema (shape drift) — fail-SAFE.
+              [:fallback schema])
+
+            ;; Index-bearing container — drop the index/key segment and
+            ;; descend into the element (or `:map-of` value) schema.
+            (contains? index-bearing-ops op)
+            (let [child (if (= op :tuple)
+                          (when (and (int? seg) (< seg (count children)))
+                            (nth children seg))
+                          ;; :vector/:sequential/:set have one element
+                          ;; schema; :map-of's value schema is child 1.
+                          (nth children (if (= op :map-of) 1 0) nil))]
+              (if (some? child)
+                (recur child (subvec in 1) aligned)
+                [:fallback schema]))
+
+            ;; Transparent wrappers contribute NO `:in` segment — descend
+            ;; into the (single) inner schema without consuming a segment.
+            (#{:maybe} op)
+            (if-let [child (first children)]
+              (recur child in aligned)
+              [:fallback schema])
+
+            ;; Any other op (`:and`/`:or`/`:multi`/`:orn`/registry refs/
+            ;; opaque values) — we can't reliably resolve the segment;
+            ;; redact fail-SAFE iff this subschema declares anything
+            ;; sensitive.
+            :else
+            [:fallback schema]))))))
+
 (defn schema-sensitive-at?
   "Path-targeted sensitivity check (rf2-oh4se). Returns true when the
   slot at `in-path` inside `schema` is sensitive under Spec 010
@@ -354,15 +445,32 @@
   `schema-has-sensitive?` (the failing slot IS the whole registered
   schema, so any sensitive declaration anywhere counts).
 
+  Malli's `:in` carries collection indices / `:map-of` keys
+  (`[1 :token]`, `[\"a\" :secret]`) whereas the walker's decl paths are
+  index-free (`[:token]`, `[:secret]`) — positional/keyed containers
+  descend at the same base-path. Per rf2-g5auo the raw `:in` is first
+  aligned to the walker's coordinate system (`align-in-path`) before the
+  prefix match, so a `:sensitive?` slot nested inside a `:vector` /
+  `:sequential` / `:set` / `:tuple` / `:map-of` is matched (and
+  redacted) just like a top-level one. When the path cannot be fully
+  aligned (opaque / unrecognised op with path remaining) the check is
+  fail-SAFE: it redacts iff the unresolved subschema declares anything
+  sensitive.
+
   Returns boolean. Pure; same `(schema, in-path)` always produces the
   same output."
   [schema in-path]
   (if (or (nil? in-path) (empty? in-path))
     (schema-has-sensitive? schema)
-    (let [decls (extract-sensitive-paths-from-schema schema [])
-          in-v  (vec in-path)]
-      (boolean
-        (some (fn [decl-path]
-                (or (prefix? decl-path in-v)   ;; ancestor sensitive
-                    (prefix? in-v decl-path))) ;; descendant sensitive
-              (keys decls))))))
+    (let [[outcome aligned-or-sub] (align-in-path schema in-path)]
+      (if (= outcome :fallback)
+        ;; Couldn't prove non-sensitivity for the unresolved subtree —
+        ;; redact iff it carries any sensitive declaration.
+        (schema-has-sensitive? aligned-or-sub)
+        (let [decls   (extract-sensitive-paths-from-schema schema [])
+              in-v    aligned-or-sub]
+          (boolean
+            (some (fn [decl-path]
+                    (or (prefix? decl-path in-v)   ;; ancestor sensitive
+                        (prefix? in-v decl-path))) ;; descendant sensitive
+                  (keys decls))))))))

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -227,6 +227,167 @@
         (is (some? (-> v :tags :explain))
             ":explain is present (Malli's structural explanation)")))))
 
+;; ---- redaction when the sensitive slot is nested in a collection ---------
+;; Per rf2-g5auo — Malli's explainer reports a value-relative `:in` path
+;; carrying COLLECTION INDICES (`[1 :token]`) / `:map-of` keys
+;; (`["a" :secret]`), while the walker's decl paths are INDEX-FREE
+;; (`[:token]`, `[:secret]`) because positional/keyed containers descend
+;; at the same base-path. Before the fix the `schema-sensitive-at?`
+;; prefix match failed in BOTH directions for collection-nested slots, so
+;; the failing value shipped VERBATIM in the trace's :value / :explain and
+;; the top-level :sensitive? stamp was absent — exactly the leak the
+;; feature exists to prevent. These tests fail before the alignment fix
+;; and pass after.
+
+(defn- app-db-failure-trace
+  "Helper: register `schema` at `path`, validate `db` (which must fail
+  the schema), and return the single schema-validation-failure trace."
+  [path schema db failing-id]
+  (rf/reg-app-schema path schema)
+  (let [traces (atom [])
+        kw     (keyword "rf2-g5auo" (name (gensym "listen")))]
+    (rf/register-listener! kw (fn [ev] (swap! traces conj ev)))
+    (schemas/validate-app-schema! db failing-id)
+    (rf/unregister-listener! kw)
+    (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                   @traces))))
+
+(deftest app-db-validation-redacts-sensitive-slot-nested-in-vector
+  (testing "rf2-g5auo — a :sensitive? slot inside a :vector element redacts
+            even though Malli's :in carries the element index"
+    ;; [:items] => vector of maps; the per-element :token is sensitive.
+    ;; The second element's :token is an int (99) — fails :string.
+    (let [v (app-db-failure-trace
+              [:items]
+              [:vector [:map [:token {:sensitive? true} :string]]]
+              {:items [{:token "ok"} {:token 99}]}
+              :items/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — the index segment no longer blocks the match")
+      (is (= :rf/redacted (-> v :tags :value))
+          ":value redacted — the raw 99 (and the rest of the vector) no longer leaks")
+      (is (= :rf/redacted (-> v :tags :explain))
+          ":explain redacted — Malli's explanation re-carries the value verbatim"))))
+
+(deftest app-db-validation-redacts-sensitive-slot-nested-in-map-of
+  (testing "rf2-g5auo — a :sensitive? slot inside a :map-of value redacts
+            even though Malli's :in carries the map key"
+    (let [v (app-db-failure-trace
+              [:by-id]
+              [:map-of :string [:map [:secret {:sensitive? true} :string]]]
+              {:by-id {"a" {:secret 99}}}
+              :by-id/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — the map-of key segment no longer blocks the match")
+      (is (= :rf/redacted (-> v :tags :value)))
+      (is (= :rf/redacted (-> v :tags :explain))))))
+
+(deftest app-db-validation-redacts-sensitive-slot-nested-in-sequential
+  (testing "rf2-g5auo — :sequential behaves identically to :vector"
+    (let [v (app-db-failure-trace
+              [:log]
+              [:sequential [:map [:pw {:sensitive? true} :string]]]
+              {:log [{:pw 1}]}
+              :log/bad)]
+      (is (some? v))
+      (is (true? (:sensitive? v)))
+      (is (= :rf/redacted (-> v :tags :value)))
+      (is (= :rf/redacted (-> v :tags :explain))))))
+
+(deftest app-db-validation-redacts-sensitive-slot-nested-deeply
+  (testing "rf2-g5auo — a sensitive slot under a map → vector → map chain
+            redacts (mixed map-key + collection-index :in segments)"
+    (let [v (app-db-failure-trace
+              [:accounts]
+              [:map [:items [:vector [:map [:tok {:sensitive? true} :string]]]]]
+              {:accounts {:items [{:tok 99}]}}
+              :accounts/bad)]
+      (is (some? v))
+      (is (true? (:sensitive? v)))
+      (is (= :rf/redacted (-> v :tags :value)))
+      (is (= :rf/redacted (-> v :tags :explain))))))
+
+(deftest app-db-validation-redacts-scalar-sensitive-collection-element
+  (testing "rf2-g5auo — a :vector whose ELEMENT type is itself sensitive
+            (container-level :sensitive? on the element schema) redacts"
+    (let [v (app-db-failure-trace
+              [:tokens]
+              [:vector [:string {:sensitive? true}]]
+              {:tokens ["ok" 99]}
+              :tokens/bad)]
+      (is (some? v))
+      (is (true? (:sensitive? v)))
+      (is (= :rf/redacted (-> v :tags :value)))
+      (is (= :rf/redacted (-> v :tags :explain))))))
+
+(deftest app-db-validation-collection-non-sensitive-not-over-redacted
+  (testing "rf2-g5auo — no regression: a collection failure where NO slot is
+            sensitive still rides verbatim (the alignment must not
+            over-redact)"
+    (let [v (app-db-failure-trace
+              [:rows]
+              [:vector [:map [:name :string]]]
+              {:rows [{:name 99}]}
+              :rows/bad)]
+      (is (some? v))
+      (is (not (contains? v :sensitive?))
+          "no :sensitive? stamp — nothing in the schema is sensitive")
+      (is (not= :rf/redacted (-> v :tags :value))
+          ":value rides verbatim — alignment didn't spuriously redact"))))
+
+(deftest app-db-validation-collection-sibling-sensitive-not-over-redacted
+  (testing "rf2-g5auo + rf2-oh4se — a failure at a NON-sensitive slot inside
+            a collection element must NOT inherit a sibling slot's
+            sensitivity (the precise-narrowing win still holds through
+            collections)"
+    ;; :secret is sensitive, :age is not; only :age fails (string, not int).
+    (let [v (app-db-failure-trace
+              [:people]
+              [:vector [:map
+                        [:secret {:sensitive? true} :string]
+                        [:age :int]]]
+              {:people [{:secret "ok" :age "no"}]}
+              :people/bad)]
+      (is (some? v))
+      (is (not (contains? v :sensitive?))
+          "the failing :age slot is not sensitive; its sibling :secret doesn't taint it")
+      (is (not= :rf/redacted (-> v :tags :value))
+          ":value rides verbatim — only the failing :age leaf is in the path"))))
+
+;; ---- walker unit tests for the :in-path alignment (rf2-g5auo) -------------
+
+(deftest schema-sensitive-at-aligns-collection-index-segments
+  (testing "rf2-g5auo — schema-sensitive-at? matches an index-bearing :in
+            path against the walker's index-free decl path"
+    ;; :vector-of-map, :in = [1 :token]
+    (is (true? (schemas/schema-sensitive-at?
+                 [:vector [:map [:token {:sensitive? true} :string]]]
+                 [1 :token])))
+    ;; :map-of value, :in = ["a" :secret]
+    (is (true? (schemas/schema-sensitive-at?
+                 [:map-of :string [:map [:secret {:sensitive? true} :string]]]
+                 ["a" :secret])))
+    ;; :tuple, :in = [1]
+    (is (true? (schemas/schema-sensitive-at?
+                 [:tuple :int [:string {:sensitive? true}]]
+                 [1])))
+    ;; deep mixed path, :in = [:items 0 :tok]
+    (is (true? (schemas/schema-sensitive-at?
+                 [:map [:items [:vector [:map [:tok {:sensitive? true} :string]]]]]
+                 [:items 0 :tok])))
+    ;; non-sensitive collection failure stays false
+    (is (false? (schemas/schema-sensitive-at?
+                  [:vector [:map [:name :string]]]
+                  [0 :name])))
+    ;; sibling-sensitive does not taint the failing non-sensitive leaf
+    (is (false? (schemas/schema-sensitive-at?
+                  [:vector [:map
+                            [:secret {:sensitive? true} :string]
+                            [:age :int]]]
+                  [0 :age])))))
+
 ;; ---- redaction at event validation site ----------------------------------
 
 (deftest event-validation-ignores-handler-meta-sensitive


### PR DESCRIPTION
## Bug (rf2-g5auo, HIGH/privacy)

A `:sensitive?`-flagged schema slot nested inside a collection
(`:vector` / `:sequential` / `:set` / `:tuple` / `:map-of`) leaked its
failing value **verbatim** into the `:rf.error/schema-validation-failure`
trace (`:value` and `:explain`), and the trace was **not** stamped
`:sensitive? true`. This is exactly the leak the `:sensitive?` feature
exists to prevent (AI/MCP boundary + logs threat surface).

## Root cause

`validate-app-schema!` narrows the failing path via Malli's explainer
`:in` slot, then asks `walker/schema-sensitive-at?` for the redaction
decision. But Malli's `:in` carries **collection indices / map keys**
(`[1 :token]`, `["a" :secret]`) while the walker descends positional/
keyed containers at the **same base-path** (by design for the elision
registry), so its declaration paths are **index-free** (`[:token]`,
`[:secret]`). The `prefix?` test then matched in neither direction and
returned `false` → no redaction. Regression introduced by rf2-oh4se's
precise-narrowing (the pre-rf2-oh4se whole-schema fallback caught it).

## Fix

Align Malli's value-relative `:in` to the walker's index-free
coordinate system before the prefix match (bead option (c) — fully
correct): walk the schema EDN in lockstep with `:in`, dropping each
index-bearing op's collection segment while keeping real `:map` keys.
When the path can't be fully resolved (opaque/unrecognised op with path
remaining) the check is **fail-SAFE** — redact iff the unresolved
subschema declares anything sensitive. No over-redaction: non-sensitive
collection failures and "sibling sensitive, failing leaf isn't" cases
still ride verbatim, preserving the rf2-oh4se precision win.

## Tests

Failing-before/passing-after regression coverage through
`validate-app-schema!` for vector, map-of, sequential, deep-nested
(map→vector→map), and scalar-element sensitive slots; no-over-redaction
guards (non-sensitive + sibling-sensitive); and walker-unit coverage of
the `:in`-path alignment.

## Gates

- schemas JVM `clojure -M:test`: **215 tests / 18323 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5156 tests / 17390 assertions, 0 failures, 0 errors**
- clj-kondo on changed files: **0 errors** (1 pre-existing unrelated warning in an untouched test)

Cross-ref: rf2-5t8mr.12 (review), rf2-oh4se (precise-narrowing), rf2-kj51z (sensitive? walker).
