### PR TITLE
fix(story-mcp): redact sensitive app-db in run-variant narrative egress (rf2-j90sb)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -91,8 +91,12 @@
                         schema-violation selectors (single source of truth)
     :schema-violations / :warnings / :effects / :sub-runs / :renders /
     :narrative          the .4 evidence-slot projections (one tape, one
-                        projection); :schema-violations / :effects /
-                        :renders value-redacted at egress
+                        projection); ALL value-bearing — each is
+                        value-redacted at egress (rf2-j90sb: :narrative's
+                        per-beat :db-before/:db-after, :warnings trace
+                        events, :sub-runs sub :value all carry app-db
+                        slices that would otherwise ship sensitive
+                        values off-box raw)
     :app-db             post-run app-db, elided at egress
     :rendered-hiccup / :snapshot  value-redacted derived trees
     :elapsed-ms         wall-clock run time
@@ -140,18 +144,26 @@
                               :checks             (vec (:checks outcome))
                               :consumed-selectors (:consumed-selectors outcome #{})
                               ;; Evidence-slot projections (.4 — one tape, one
-                              ;; projection). The value-bearing slots
-                              ;; (:schema-violations / :effects / :renders) are
+                              ;; projection). Every value-bearing slot is
                               ;; value-redacted against the frame's declared-
                               ;; sensitive values, same as :rendered-hiccup —
                               ;; a secret reappears there at a non-app-db path
                               ;; the path walker can't reach (rf2-ee38b.17).
+                              ;; :narrative is a two-level evidence tree whose
+                              ;; inner beats carry :db-before/:db-after FULL
+                              ;; app-db snapshots; :warnings are trace-event
+                              ;; records; :sub-runs carry subscription :value —
+                              ;; all three egressed RAW would ship a declared-
+                              ;; sensitive value off-box verbatim (rf2-j90sb,
+                              ;; sibling of pair-mcp's rf2-6wvh5). scrub-rendered
+                              ;; recurses the nested trees and the gate stays
+                              ;; symmetric (incl? true forwards raw).
                               :schema-violations  (egress/scrub-rendered (:schema-violations outcome) raw-db vk incl?)
-                              :warnings           (vec (:warnings outcome))
+                              :warnings           (egress/scrub-rendered (vec (:warnings outcome)) raw-db vk incl?)
                               :effects            (egress/scrub-rendered (:effects outcome) raw-db vk incl?)
-                              :sub-runs           (vec (:sub-runs outcome))
+                              :sub-runs           (egress/scrub-rendered (vec (:sub-runs outcome)) raw-db vk incl?)
                               :renders            (egress/scrub-rendered (:renders outcome) raw-db vk incl?)
-                              :narrative          (:narrative outcome)
+                              :narrative          (egress/scrub-rendered (:narrative outcome) raw-db vk incl?)
                               ;; Derived trees re-key the same sensitive value
                               ;; at a non-app-db path — value-redact (rf2-ee38b.17).
                               :rendered-hiccup    (egress/scrub-rendered (:rendered-hiccup outcome) raw-db vk incl?)
@@ -270,7 +282,7 @@
   "Testing-category descriptors, in IMPL-SPEC §7.2 order."
   [{:name           "run-variant"
     :category       :testing
-    :description    (str "Execute a variant's four-phase lifecycle (loaders → setup → render → script); return the UNIFIED run-result — the same shape the human Story UI reads. The headline is `:status` ∈ {:pass :fail :cannot-run :error}; the result also carries unified `:assertions` records (each with a derived `:status`), `:checks` groups, `:consumed-selectors`, the evidence-slot projections (`:schema-violations :warnings :effects :sub-runs :renders :narrative`), `:app-db`, `:rendered-hiccup`, `:snapshot`, and `:elapsed-ms`. `:cannot-run` means the runner could not even attempt the plan — handle it as 'not runnable here', NOT as a fail. The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/runtime :elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. The derived `:rendered-hiccup` / `:snapshot` / evidence value-slots are value-redacted against the same declared-sensitive values (the secret reappears there at a non-app-db path the path walker can't reach). Pass `:include-sensitive true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture). "
+    :description    (str "Execute a variant's four-phase lifecycle (loaders → setup → render → script); return the UNIFIED run-result — the same shape the human Story UI reads. The headline is `:status` ∈ {:pass :fail :cannot-run :error}; the result also carries unified `:assertions` records (each with a derived `:status`), `:checks` groups, `:consumed-selectors`, the evidence-slot projections (`:schema-violations :warnings :effects :sub-runs :renders :narrative`), `:app-db`, `:rendered-hiccup`, `:snapshot`, and `:elapsed-ms`. `:cannot-run` means the runner could not even attempt the plan — handle it as 'not runnable here', NOT as a fail. The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/runtime :elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. The derived `:rendered-hiccup` / `:snapshot` and ALL evidence value-slots (`:schema-violations :warnings :effects :sub-runs :renders :narrative`) are value-redacted against the same declared-sensitive values (the secret reappears there at a non-app-db path the path walker can't reach — `:narrative` beats carry full `:db-before` / `:db-after` snapshots). Pass `:include-sensitive true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture). "
                          "Examples: "
                          "1. Green run: {:variant-id \":story.cart/full\"} -> {:status :pass :frame :story.cart/full :app-db {...} :assertions [{:assertion :rf.assert/path-equals :passed? true :status :pass}] :checks [] :elapsed-ms 42}. "
                          "2. Red run: {:variant-id \":story.cart/bad\"} -> {:status :fail :assertions [{:assertion :rf.assert/sub-equals :passed? false :status :fail :actual nil :expected 3}]}. "

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -2106,7 +2106,19 @@
    :checks         []
    :rendered-hiccup [:input {:type "password" :value "TOPSECRET"}]
    :effective-args {:label "Save" :token "TOPSECRET"}
-   :snapshot       {:db {:token "TOPSECRET"}}})
+   :snapshot       {:db {:token "TOPSECRET"}}
+   ;; rf2-j90sb — the three evidence slots that previously egressed RAW.
+   ;; :narrative is a two-level evidence tree whose inner beats carry
+   ;; full :db-before / :db-after app-db snapshots (evidence.cljc
+   ;; epoch-beat) — the secret rides those verbatim. :warnings are
+   ;; trace-event records (here one carrying the secret in its data).
+   ;; :sub-runs carry the subscription :value.
+   :narrative      [{:span :epoch
+                     :epochs [{:db-before {:token "TOPSECRET" :public "ok"}
+                               :db-after  {:token "TOPSECRET" :public "ok"}
+                               :trigger-event [:set-token "TOPSECRET"]}]}]
+   :warnings       [{:event :rf.trace/warn :data {:token "TOPSECRET"}}]
+   :sub-runs       [{:sub [:auth/token] :value "TOPSECRET"}]})
 
 (deftest preview-variant-rendered-hiccup-redacts-sensitive-by-default
   (testing "the secret MUST NOT leak through preview-variant's derived trees"
@@ -2160,6 +2172,61 @@
           (is (success? r))
           (is (tree-contains? (:rendered-hiccup s) "TOPSECRET")
               "opt-in surfaces the raw value in rendered-hiccup"))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-j90sb (headline P1, privacy egress) — run-variant's :narrative /
+;; :warnings / :sub-runs evidence slots egressed RAW. :narrative is a
+;; two-level evidence tree whose inner beats carry FULL :db-before /
+;; :db-after app-db snapshots (evidence.cljc epoch-beat), so a declared-
+;; sensitive value — correctly redacted in the top-level :app-db slot —
+;; escaped the MCP wire verbatim inside the narrative tree. :warnings
+;; (trace-event records) and :sub-runs (sub :value) carry the same leak
+;; class. These pin that all three are now value-redacted at egress, with
+;; the same `:include-sensitive` opt-out as the sibling derived slots.
+;; Sibling of pair-mcp's rf2-6wvh5.
+;; ---------------------------------------------------------------------------
+
+(deftest run-variant-narrative-redacts-sensitive-by-default
+  (testing "the secret MUST NOT leak through run-variant's :narrative / :warnings / :sub-runs"
+    (with-clean-frame [vid :story.button/primary]
+      (declare-sensitive! vid [:token])
+      (with-redefs [story/run-variant
+                    (fn [_vk _opts]
+                      (java.util.concurrent.CompletableFuture/completedFuture
+                        (secret-bearing-run-result vid)))]
+        (let [r (invoke "run-variant" {:variant-id "story.button/primary"})
+              s (:structuredContent r)]
+          (is (success? r))
+          (is (= :rf/redacted (get-in s [:app-db :token]))
+              "app-db path-redaction still holds")
+          (is (not (tree-contains? (:narrative s) "TOPSECRET"))
+              ":narrative beats' :db-before/:db-after MUST NOT carry the secret at egress")
+          (is (tree-contains? (:narrative s) :rf/redacted)
+              "the secret in :narrative is replaced by the :rf/redacted sentinel")
+          (is (not (tree-contains? (:warnings s) "TOPSECRET"))
+              ":warnings trace-event data MUST NOT carry the secret at egress")
+          (is (not (tree-contains? (:sub-runs s) "TOPSECRET"))
+              ":sub-runs subscription :value MUST NOT carry the secret at egress"))))))
+
+(deftest run-variant-narrative-forwards-secret-when-opted-in
+  (testing ":include-sensitive true forwards the raw value through :narrative / :warnings / :sub-runs"
+    (config/set-allow-sensitive-reads! true)
+    (with-clean-frame [vid :story.button/primary]
+      (declare-sensitive! vid [:token])
+      (with-redefs [story/run-variant
+                    (fn [_vk _opts]
+                      (java.util.concurrent.CompletableFuture/completedFuture
+                        (secret-bearing-run-result vid)))]
+        (let [r (invoke "run-variant" {:variant-id "story.button/primary"
+                                       :include-sensitive true})
+              s (:structuredContent r)]
+          (is (success? r))
+          (is (tree-contains? (:narrative s) "TOPSECRET")
+              "opt-in surfaces the raw value in :narrative beats")
+          (is (tree-contains? (:warnings s) "TOPSECRET")
+              "opt-in surfaces the raw value in :warnings")
+          (is (tree-contains? (:sub-runs s) "TOPSECRET")
+              "opt-in surfaces the raw value in :sub-runs"))))))
 
 (deftest read-failures-strips-sensitive-assertion-records-by-default
   (testing "an assertion record stamped :sensitive? true is dropped at egress"


### PR DESCRIPTION
## What

`run-variant`'s `:narrative` / `:warnings` / `:sub-runs` evidence slots egressed RAW (no scrub), unlike the sibling value-bearing slots which route through `egress/scrub-rendered`. `:narrative` is a two-level evidence tree whose inner beats (story evidence `epoch-beat`) carry FULL `:db-before` / `:db-after` app-db snapshots per committed epoch, plus `:trigger-event` payloads. So a variant frame's declared-`:sensitive?` app-db value — correctly `:rf/redacted` in the top-level `:app-db` slot — escaped the MCP wire verbatim inside `:narrative → :epochs → {:db-before .. :db-after ..}`. `:warnings` (trace-event records) and `:sub-runs` (subscription `:value`) carry the same leak class.

This is the privacy/AI boundary: the MCP tool boundary IS the egress. Sibling of pair-mcp's rf2-6wvh5 (same leak class in the epoch ring).

## Fix

Route `:narrative`, `:warnings`, and `:sub-runs` through the canonical `egress/scrub-rendered` against the frame's declared-sensitive values — the same value-based redaction the other derived slots already use. `scrub-rendered` recurses through maps/vectors/sets/seqs so the nested narrative tree is handled, and the `:include-sensitive` gate stays symmetric (`incl? true` forwards raw). No new redaction fn forked. Tool-response shape unchanged otherwise. Docstrings + descriptor updated to reflect all evidence slots are now value-redacted.

## Regression test

`run-variant-narrative-redacts-sensitive-by-default` — asserts the declared-sensitive value is `:rf/redacted` in `:narrative` beats and absent from `:warnings`/`:sub-runs` with the gate OFF (default). `run-variant-narrative-forwards-secret-when-opted-in` — asserts raw passthrough with the gate ON. Confirmed failing-before (4 failing assertions on the un-fixed source), passing-after.

## Gates

- story-mcp `clojure -M:test`: 195 tests, 987 assertions, 0 failures, 0 errors
- `npm run test:mcp-conformance`: all 6 gates GREEN (incl. story-mcp end-to-end + wire-vocab 49 tests / 621 assertions)
- clj-kondo on changed files: 0 errors, 4 warnings (all pre-existing, none on changed lines)

Closes rf2-j90sb.
