### PR TITLE
fix(ssr-ring): contain on-error throws + order writer-thread after head-materialisation (rf2-z5azc, rf2-ljjh0)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -307,7 +307,11 @@
                 (pipeline/ssr-response->ring-response resp nil)
                 (pipeline/build-full-response frame-id resp opts)))
             (catch Throwable t
-              (on-error request t))
+              ;; rf2-ljjh0 — `safe-on-error` contains a throwing
+              ;; caller `:on-error`: a bug in the caller's transport-
+              ;; failure handler falls back to the locked
+              ;; `default-on-error` rather than escaping as a raw 500.
+              (lifecycle/safe-on-error on-error request t))
             (finally
               ;; `destroy-frame!` invokes `:ssr/on-frame-destroyed`
               ;; (rf2-fcj33), which clears the per-frame request slot.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -119,6 +119,42 @@
   surface that builds this exact shape via `make-default-on-error`)."
   (make-default-on-error))
 
+(defn safe-on-error
+  "Invoke the resolved `:on-error` Ring-fn under containment and return
+  its Ring response. Shared by `ssr-handler`, `stream-handler`, AND
+  `setup-request-frame!` so EVERY `:on-error` call site is protected.
+
+  rf2-ljjh0 — `:on-error` is the handler's last-resort transport-failure
+  net (Ring-layer / render-time / setup-failure throws the projector
+  can't see). A CALLER-supplied `:on-error` that itself throws must NOT
+  escape the handler: an uncaught throwable handed to the Ring server
+  (Jetty / http-kit) surfaces as a raw container 500 with a stack
+  trace, defeating the rf2-kzvwq topology-leak contract the boundary
+  otherwise upholds (`default-on-error` emits a fixed generic body,
+  never the throwable). When the caller's `:on-error` throws, we surface
+  the secondary throw on the trace bus and fall back to the host-locked
+  `default-on-error` — mirroring the `resolve-error-body` pattern (a
+  buggy `:error-view` must not bypass the error boundary either). The
+  boundary is not bypassable by a bug in the caller's transport-failure
+  handler, exactly as it is not bypassable by a bug in the caller's
+  `:error-view`.
+
+  `on-error` is the ALREADY-RESOLVED fn (rf2-c1tac precedence applied by
+  `resolve-on-error` at construction time): the caller's `:on-error`,
+  the `:on-error-fallback`-templated default, or `default-on-error`.
+  When `on-error` IS `default-on-error` (or the templated default) it
+  cannot throw — the guard is then a free no-op — so this is cheap on
+  the common path."
+  [on-error request t]
+  (try
+    (on-error request t)
+    (catch Throwable on-error-t
+      (trace/emit-error! :rf.error/ssr-ring-on-error-failed
+                         {:exception (.getMessage on-error-t)
+                          :ex-class  (.getName (class on-error-t))
+                          :recovery  :fell-back-to-default-on-error})
+      (default-on-error request t))))
+
 (defn destroy-frame-quietly!
   "Best-effort frame teardown. Exceptions during destroy must not mask
   a real handler error; swallow + emit a `:warning` trace is preferred

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -139,7 +139,15 @@
       (catch Throwable t
         (ssr/clear-request! frame-id)
         (lifecycle/destroy-frame-quietly! frame-id)
-        {:short-circuit (on-error request t)}))))
+        ;; rf2-ljjh0 — the short-circuit response goes through
+        ;; `safe-on-error` so a caller-supplied `:on-error` that THROWS
+        ;; during a setup failure is contained (trace + locked
+        ;; `default-on-error`) rather than escaping `setup-request-frame!`
+        ;; as a raw container 500 with internal topology in the stack
+        ;; trace. The setup-failure path runs OUTSIDE the handler's own
+        ;; try/catch, so without this guard it is the one `:on-error`
+        ;; call site not protected by the handler body's catch.
+        {:short-circuit (lifecycle/safe-on-error on-error request t)}))))
 
 (defn ^:private render-error-body
   "Build a minimal HTML body from a public-error map — the host's

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -198,11 +198,15 @@
       circuits to a non-streamed Location response (Spec 011 §Redirect
       precedence) AND destroys the per-request frame inline (the writer
       thread is never spawned on this branch),
-    - otherwise spawns a streaming writer on a daemon thread that
-      flushes shell → continuations → final payload → close, and
-      destroys the frame in that thread's finally so the per-frame
-      side-channels clear (Spec 011 §Per-request frame teardown
-      contract) without blocking the response close.
+    - otherwise materialises the response head (status / headers /
+      cookies) FIRST — so a header/cookie serialisation throw on a
+      value that escaped the fx boundary's partial validation
+      short-circuits to `:on-error` with no pipe + no thread to orphan
+      (rf2-z5azc) — and only then spawns a streaming writer on a daemon
+      thread that flushes shell → continuations → final payload →
+      close, destroying the frame in that thread's finally so the
+      per-frame side-channels clear (Spec 011 §Per-request frame
+      teardown contract) without blocking the response close.
 
   The response body is a `PipedInputStream` Ring accepts directly; the
   pipe's writer side runs on a daemon thread so Jetty/http-kit/Aleph
@@ -259,12 +263,37 @@
                   (pipeline/ssr-response->ring-response resp nil)
                   (finally
                     (lifecycle/destroy-frame-quietly! frame-id)))
-                ;; Streaming path: build a pipe + spawn the writer thread.
-                ;; 16 KiB pipe buffer — large enough to absorb the shell
-                ;; chunk in one write so the writer thread rarely blocks
-                ;; on a slow consumer, small enough that one stuck client
-                ;; doesn't pin a non-trivial chunk of heap per request.
-                (let [pipe-in  (PipedInputStream. (* 16 1024))
+                ;; Streaming path. rf2-z5azc — MATERIALISE the response
+                ;; head (status / headers / cookies) BEFORE constructing
+                ;; the pipe or spawning the writer thread. Cookie / header
+                ;; serialisation CAN throw at materialise time on a value
+                ;; that escaped the fx boundary's partial validation —
+                ;; e.g. a `:max-age` carrying CR/LF or a non-integer
+                ;; `:expires`, which `cookie->set-cookie-header` rejects
+                ;; but the runtime `validate-cookie!` (name/value/path/
+                ;; domain only) does not. If we spawned the writer first
+                ;; (the old order), that throw would orphan the pipe: the
+                ;; daemon writer keeps pumping the full body into a pipe
+                ;; whose reader is never handed out, blocks forever once
+                ;; the 16 KiB buffer fills, and leaks one live thread per
+                ;; such request — a resource-exhaustion vector. By
+                ;; building `resp-map` first, a head-materialisation
+                ;; failure short-circuits to the outer catch BEFORE any
+                ;; thread or pipe exists → on-error, no detached writer,
+                ;; no orphaned pipe. "We committed to streaming" is now
+                ;; atomic with "the response envelope is materialisable".
+                ;;
+                ;; No body default-stamp here (we pass our own
+                ;; InputStream); `:body` is assoc'd after the writer is
+                ;; wired below.
+                (let [resp-map (pipeline/ssr-response->ring-response
+                                 resp "" content-type)
+                      ;; 16 KiB pipe buffer — large enough to absorb the
+                      ;; shell chunk in one write so the writer thread
+                      ;; rarely blocks on a slow consumer, small enough
+                      ;; that one stuck client doesn't pin a non-trivial
+                      ;; chunk of heap per request.
+                      pipe-in  (PipedInputStream. (* 16 1024))
                       pipe-out (PipedOutputStream. pipe-in)]
                   ;; Daemon thread (rf2-ekwda): a writer blocked on
                   ;; `.write` to the bounded 16 KiB pipe of a slow-loris
@@ -287,16 +316,17 @@
                       ^String (str "rf2-ssr-streaming-" (name frame-id)))
                     (.setDaemon true)
                     (.start))
-                  ;; Build the Ring response off the response
-                  ;; accumulator's status/headers/cookies — no body
-                  ;; default-stamp (we pass our own InputStream).
-                  (let [resp-map
-                        (pipeline/ssr-response->ring-response resp "" content-type)]
-                    (assoc resp-map :body pipe-in)))))
+                  (assoc resp-map :body pipe-in))))
             (catch Throwable t
-              ;; Setup-path throw OR get-response throw — neither happens
-              ;; under the streaming writer's catch arm; destroy the
-              ;; frame inline and respond per on-error.
+              ;; get-response throw, redirect-materialise throw, OR (per
+              ;; rf2-z5azc) a head-materialisation throw raised BEFORE the
+              ;; writer thread is spawned — none happen under the
+              ;; streaming writer's own catch arm. Destroy the frame
+              ;; inline and respond per on-error. rf2-ljjh0 —
+              ;; `safe-on-error` contains a throwing caller `:on-error`:
+              ;; it falls back to the locked `default-on-error` rather
+              ;; than escaping as a raw container 500 with leaked
+              ;; internals.
               (try (lifecycle/destroy-frame-quietly! frame-id)
                    (catch Throwable _ nil))
-              (on-error request t))))))))
+              (lifecycle/safe-on-error on-error request t))))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -479,3 +479,93 @@
           (is (empty? leaked)
               "happy-path streaming also exits without leaking a
                daemon thread"))))))
+
+;; ===========================================================================
+;; Test 5 (rf2-z5azc) — head-materialisation throw must not orphan the pipe
+;;                       or leak a writer thread
+;; ===========================================================================
+;;
+;; `ssr-response->ring-response` folds the response accumulator's
+;; cookies/headers into the Ring head, and cookie/header serialisation
+;; CAN throw at materialise time on a value that escaped the fx
+;; boundary's PARTIAL validation: the runtime `validate-cookie!` checks
+;; only :name / :value / :path / :domain, but `cookie->set-cookie-header`
+;; additionally rejects a CR/LF-bearing :max-age and a non-integer
+;; :expires. So a cookie like {:name "s" :value "v" :max-age "1\r\n2"}
+;; PASSES the fx gate, is stored on the accumulator, and THEN throws when
+;; the host adapter materialises the head.
+;;
+;; The bug (rf2-z5azc): the old streaming branch spawned + started the
+;; daemon writer thread BEFORE materialising the head. When the head
+;; throw fired, the Ring response handed back was the :on-error 500 —
+;; but the writer thread was already pumping the FULL body into a pipe
+;; whose reader (`pipe-in`) was never returned to anyone. With a body
+;; larger than the 16 KiB pipe buffer the writer BLOCKS FOREVER on
+;; `.write` (no consumer) — one live daemon thread leaked per such
+;; request, a resource-exhaustion vector.
+;;
+;; The fix: materialise the head FIRST. A head-materialisation throw then
+;; short-circuits to the outer catch BEFORE any pipe or thread exists —
+;; the handler returns the :on-error 500 and NO `rf2-ssr-streaming-*`
+;; thread is ever spawned.
+;;
+;; This test pins BOTH halves of the contract:
+;;   - the handler returns a contained 500 (not a streamed body), and
+;;   - no orphan `rf2-ssr-streaming-*` daemon thread is alive afterward.
+;; The body is deliberately sized past the 16 KiB pipe buffer so that on
+;; the OLD ordering the orphaned writer would block forever (a detectable
+;; leak), giving the test genuine before/after discriminating power.
+
+(deftest head-materialisation-throw-does-not-orphan-writer
+  (testing "rf2-z5azc — a cookie that throws at head materialisation
+            (escaped the fx boundary) short-circuits to :on-error with
+            NO writer thread spawned + NO orphaned pipe"
+    ;; :on-create sets a cookie whose :max-age carries CR/LF. The fx
+    ;; boundary (`validate-cookie!`) gates only :name/:value/:path/
+    ;; :domain, so this passes the gate and is stored on the response
+    ;; accumulator. The host materialiser's `cookie->set-cookie-header`
+    ;; then throws `:rf.error/cookie-invalid-attribute` on :max-age.
+    (rf/reg-event-fx :rf.test.server/init-bad-cookie
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:db {}
+         :fx [[:rf.server/set-cookie {:name "s" :value "v" :max-age "1\r\n2"}]]}))
+    ;; A root-view emitting a body well past the 16 KiB pipe buffer, so
+    ;; that under the OLD (buggy) ordering the orphaned writer would
+    ;; block forever on `.write` — making the leak deterministic. Under
+    ;; the FIXED ordering this view never renders (the head throws first,
+    ;; before the writer is spawned).
+    (rf/reg-view ^{:rf/id :test/big-root} big-root []
+      (into [:div]
+            (for [i (range 4000)]
+              ^{:key i} [:p (str "row-" i "-padding-padding-padding")])))
+    (let [handler   (ssr-ring/stream-handler
+                      {:on-create [:rf.test.server/init-bad-cookie]
+                       :root-view [:test/big-root]
+                       :payload-policy :rf.ssr.payload/whole-app-db})
+          ;; Direct handler call (no Jetty needed — the throw is on the
+          ;; request thread during head materialisation, before any
+          ;; transport hand-off).
+          response  (handler {:uri "/" :request-method :get})]
+      ;; The response is the contained :on-error 500 — NOT a streamed
+      ;; body. The head throw short-circuited to the outer catch.
+      (is (= 500 (:status response))
+          "head-materialisation throw routed to the :on-error 500
+           (locked default), not a partially-streamed body")
+      (is (not (instance? InputStream (:body response)))
+          "the response body is the :on-error string body, NOT a
+           PipedInputStream — no streaming pipe was ever handed out")
+      (is (= "Internal error" (:body response))
+          "locked default-on-error body — the topology-leak contract
+           holds; no cookie internals reach the wire")
+      ;; The load-bearing assertion: NO writer thread leaked. Under the
+      ;; OLD ordering the writer was spawned before the head throw and,
+      ;; with this oversized body, would block forever on a reader-less
+      ;; pipe — `await-no-streaming-threads!` would time out non-empty.
+      (let [leaked (await-no-streaming-threads! 5000)]
+        (is (empty? leaked)
+            (str "no orphan rf2-ssr-streaming-* daemon thread after a
+                 head-materialisation throw — the writer must not be
+                 spawned until the head is known materialisable
+                 (rf2-z5azc). Live threads observed: "
+                 (mapv (fn [^Thread t] (.getName t)) leaked)))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -2044,3 +2044,93 @@
            templated default's locked 500 — :on-error wins")
       (is (= explicit-body (:body response))
           "explicit :on-error fn body wins over :on-error-fallback :body"))))
+
+;; ===========================================================================
+;; rf2-ljjh0 — a throwing caller :on-error must be CONTAINED, not escape
+;;
+;; `:on-error` is the handler's last-resort transport-failure net. A
+;; caller-supplied `:on-error` that ITSELF throws must not propagate out
+;; of the handler: an uncaught throwable handed to the Ring server
+;; (Jetty / http-kit) surfaces as a raw container 500 with a stack
+;; trace, defeating the rf2-kzvwq topology-leak contract the boundary
+;; otherwise upholds. The exposure is symmetric — the setup-failure path
+;; (`setup-request-frame!`, which runs OUTSIDE the handler's own
+;; try/catch) AND the success path both invoke `:on-error`. Both now
+;; route through `lifecycle/safe-on-error`, which falls back to the
+;; locked `default-on-error` when the caller's fn throws.
+;; ===========================================================================
+
+(deftest ssr-handler-throwing-on-error-during-setup-is-contained
+  (testing "rf2-ljjh0 — a caller :on-error that THROWS during a
+            setup-failure is contained: the handler returns the locked
+            default-on-error 500 rather than letting the throwable
+            escape as a raw container 500 with leaked internals.
+
+            Setup failure is driven by a non-vector :on-create
+            (`validate-on-create!` throws inside `setup-request-frame!`,
+            which runs OUTSIDE the handler body's try/catch). The
+            caller's :on-error then throws — exercising the one
+            :on-error call site that the handler body's catch does not
+            wrap."
+    (let [throwing-on-error
+          (fn [_req _t]
+            (throw (ex-info "boom in the caller's on-error — leaks JDBC URL etc."
+                            {:internal :topology})))
+          handler (ssr-ring/ssr-handler
+                    {:on-create '(:rf/server-init) ;; non-vector → setup throws
+                     :root-view [:div]
+                     :payload-keys [:x]
+                     :on-error throwing-on-error})
+          ;; Before the fix this call THREW (the throwing on-error
+          ;; escaped `setup-request-frame!` uncaught). After the fix it
+          ;; returns the contained locked-default 500.
+          response (handler {:uri "/x" :request-method :get})]
+      (is (map? response)
+          "the handler RETURNED a Ring response — the throwing
+           :on-error did not escape uncaught")
+      (is (= 500 (:status response))
+          "contained via the locked default-on-error (500)")
+      (is (= "Internal error" (:body response))
+          "locked generic body — the secondary throw's internals never
+           reach the wire (rf2-kzvwq topology-leak contract held)")
+      (is (= "text/plain; charset=utf-8"
+             (get (:headers response) "Content-Type"))
+          "locked default-on-error content-type"))))
+
+(deftest ssr-handler-throwing-on-error-on-success-path-is-contained
+  (testing "rf2-ljjh0 — symmetric: a caller :on-error that throws on the
+            SUCCESS path is also contained. Driven by a cookie whose
+            :max-age carries CR/LF — it passes the fx boundary
+            (`validate-cookie!` gates only :name/:value/:path/:domain)
+            but throws at head materialisation. That throw escapes
+            `build-full-response`'s own catch (its error-path materialise
+            re-folds the SAME bad cookie and throws again), reaching the
+            handler body's :on-error catch — the success-path call site."
+    (rf/reg-event-fx :rf.test/init-bad-cookie
+      {:platforms #{:server}}
+      (fn [_ _]
+        ;; CR/LF in :max-age escapes the fx boundary (`validate-cookie!`
+        ;; gates only :name/:value/:path/:domain) and throws at host
+        ;; materialise time in `cookie->set-cookie-header`.
+        {:db {}
+         :fx [[:rf.server/set-cookie {:name "s" :value "v" :max-age "1\r\n2"}]]}))
+    (let [throwing-on-error
+          (fn [_req _t]
+            (throw (ex-info "boom in the caller's on-error" {:internal :topology})))
+          handler (ssr-ring/ssr-handler
+                    {:on-create [:rf.test/init-bad-cookie]
+                     :root-view [:div "hello"]
+                     :payload-policy :rf.ssr.payload/whole-app-db
+                     :on-error throwing-on-error})
+          ;; Before the fix the throwing :on-error escaped the handler
+          ;; body's catch uncaught; after the fix `safe-on-error`
+          ;; contains it → locked default 500.
+          response (handler {:uri "/x" :request-method :get})]
+      (is (map? response)
+          "handler returned a Ring response — throwing :on-error on the
+           success path did not escape uncaught")
+      (is (= 500 (:status response))
+          "contained via the locked default-on-error (500)")
+      (is (= "Internal error" (:body response))
+          "locked generic body — the secondary throw's internals never
+           reach the wire (rf2-kzvwq topology-leak contract held)"))))


### PR DESCRIPTION
Two error/teardown-path correctness fixes in `implementation/ssr-ring`, shipped together because they share the lifecycle try/catch structure.

## rf2-z5azc — writer thread spawned before head materialisation

The streaming branch of `stream-handler` created the pipe, spawned + `.start()`ed the daemon writer thread, and **only then** materialised the Ring response head via `ssr-response->ring-response` (which folds the accumulator's cookies/headers). Cookie/header serialisation **can throw** at that point on a value that escaped the fx boundary's partial validation — the runtime `validate-cookie!` gates only `:name`/`:value`/`:path`/`:domain`, but `cookie->set-cookie-header` additionally rejects a CR/LF-bearing `:max-age` and a non-integer `:expires`. When that throw fired *after* the writer was spawned, the Ring response returned was the `:on-error` 500, but the writer thread kept pumping the full body into a pipe whose reader was never handed out — blocking forever once the 16 KiB buffer filled, leaking **one live daemon thread per such request** (resource-exhaustion vector).

**Fix:** materialise the response head **first**. A head-materialisation throw now short-circuits to the outer catch *before* any pipe or thread exists → `:on-error`, no detached writer, no orphaned pipe. "We committed to streaming" is atomic with "the response envelope is materialisable". Spec 011 emitter/compose order unchanged.

## rf2-ljjh0 — a throwing caller :on-error escaped uncaught

`setup-request-frame!` runs **outside** the handler's per-request try/catch and invoked the caller-supplied `:on-error` directly in its setup-failure catch. If that `:on-error` itself threw, the throwable escaped the handler entirely — a raw container 500 with an internal stack trace, defeating the rf2-kzvwq topology-leak contract. The exposure was symmetric: the success-path `:on-error` catches in both `ssr-handler` and `stream-handler` were unguarded too.

**Fix:** a shared `lifecycle/safe-on-error` guard wraps **every** `:on-error` call site (setup-failure path + both success paths). When the caller's fn throws, it emits a `:rf.error/ssr-ring-on-error-failed` trace and falls back to the host-locked `default-on-error` — mirroring the existing `resolve-error-body` "a buggy `:error-view` must not bypass the boundary" pattern. Honours the rf2-c1tac `:on-error` precedence (the already-resolved fn is passed in).

## Regression tests (failing-before / passing-after)

Verified by reverting only the source files and running against the new tests: 2 failures + 2 errors before; all pass after.

- `streaming_robustness_test/head-materialisation-throw-does-not-orphan-writer` (rf2-z5azc) — a cookie with CR/LF `:max-age` (escaped the fx gate) throws at head materialise; asserts the handler returns the contained `:on-error` 500 (not a `PipedInputStream` body) **and** no `rf2-ssr-streaming-*` daemon thread is spawned. Body sized past 16 KiB so the old ordering leaked deterministically.
- `ring_test/ssr-handler-throwing-on-error-during-setup-is-contained` (rf2-ljjh0) — a throwing caller `:on-error` on the setup-failure path yields the locked default 500, not an uncaught escape.
- `ring_test/ssr-handler-throwing-on-error-on-success-path-is-contained` (rf2-ljjh0) — symmetric containment on the success path (bad-cookie head throw routed to the handler catch).

## Quality gates

- **ssr-ring artefact `clojure -M:test`**: `Ran 99 tests containing 427 assertions. 0 failures, 0 errors.`
- **clj-kondo (changed files)**: 0 errors. The 7 warnings + 1 info are pre-existing baseline (confirmed against `HEAD` — `unused binding resp/emit-hash?/content-type` in the untouched `run-streaming-writer!`, plus prior test-ns warnings); my changes introduce no new findings.
- **`npm run test:cljs`**: not applicable — ssr-ring is JVM-only `.clj`; shadow-cljs ignores `.clj` sources at compile time, so the node CLJS runner does not exercise these paths. The ssr-ring `clojure -M:test` gate above is authoritative.

Closes rf2-z5azc, rf2-ljjh0.