### PR TITLE
fix(machines): atomic schema-rejected spawn + idempotent destroy in spawn-all cascade (rf2-f3kp7, rf2-ndfjo)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -38,6 +38,38 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+(defn- actor-live?
+  "Per rf2-lbjnz — the silent-idempotent liveness probe, shared by the
+  keyword/tracked `destroy-single!` path and the per-actor
+  `destroy-single-actor!` path (rf2-ndfjo). An actor with a resolved
+  `actor-id` is live iff ANY of the following survive:
+
+    - **Handler still registered** at `actor-id` in the event
+      registrar (final-state auto-destroy + prior explicit destroys
+      both unregister; a still-registered handler reliably means
+      \"not yet destroyed\").
+    - **Snapshot present** at `[:rf/runtime :machines :snapshots actor-id]`
+      (covers the mid-drain handler-replaced window + hand-crafted call
+      sites).
+    - **Spawn-order entry present** for `actor-id` in the per-frame
+      spawn-order channel (the dedicated signal for spec-less spawns
+      whose handler+snapshot were both skipped at spawn time).
+
+  A truly-already-destroyed actor has all three gone — the unified
+  teardown projection + `registrar/unregister!` + `spawn-order/forget!`
+  run atomically per `destroy-single-actor!` / `destroy-single!` /
+  `finalize-machine`. See [Spec 005 §Destroy is silent-idempotent
+  (rf2-lbjnz)] for the normative paragraph.
+
+  The tracked-slot signal `destroy-single!` additionally consults is
+  resolved-actor-id agnostic and so stays local to that call site."
+  [frame-id actor-id db]
+  (and actor-id
+       (or (some? (registrar/lookup :event actor-id))
+           (and (some? db)
+                (contains? (get-in db (paths/snapshot-path)) actor-id))
+           (some #(= actor-id %) (spawn-order/frame-order frame-id)))))
+
 (defn destroy-single-actor!
   "Destroy a single spawned actor against the frame's container: run
   the active configuration's `:exit` cascade (rf2-nahfm), apply the
@@ -54,9 +86,18 @@
   Per Spec 005 §Declarative `:spawn` §Composition with explicit
   `:entry` / `:exit`: the actor's `:exit` action runs BEFORE the
   teardown clears the snapshot, so `:exit`-time side effects (HTTP
-  requests, logs, dispatches) execute against the live snapshot."
+  requests, logs, dispatches) execute against the live snapshot.
+
+  Per rf2-ndfjo — silent-idempotent guard: an already-destroyed actor
+  (all liveness signals gone) is a no-op. Returns `true` iff the actor
+  was live and torn down this call, `false` for the silent no-op — so
+  callers (notably `destroy-spawn-all-children!`) can gate their
+  `:rf.machine/destroyed` emit on the actor having actually been live,
+  preventing a double-destroyed trace for join-cancelled survivors the
+  resolution cascade already tore down. Mirrors the `live?` gate
+  `destroy-single!` carries (rf2-lbjnz)."
   [frame-id actor-id]
-  (when actor-id
+  (when (actor-live? frame-id actor-id (frame/frame-app-db-value frame-id))
     ;; (rf2-nahfm) Run the active configuration's `:exit` cascade
     ;; BEFORE any teardown work. This fires `:exit`-emitted fx via
     ;; do-fx and writes any `:data` updates back to the snapshot —
@@ -87,8 +128,12 @@
       (spawn-order/forget! frame-id actor-id)
       (when db-swapped?
         (traces/emit-system-id-released! frame-id @sid actor-id)
-        (registrar/unregister! :event actor-id)
-        @sid))))
+        (registrar/unregister! :event actor-id)))
+    ;; rf2-ndfjo — signal to callers (`destroy-spawn-all-children!`) that
+    ;; this actor was live and torn down this call, so they emit
+    ;; `:rf.machine/destroyed` exactly once. The `when` returns nil for
+    ;; an already-destroyed actor (silent no-op).
+    true))
 
 (defn- destroy-spawn-all-children!
   "Per rf2-6vmw — the declarative-`:spawn-all` exit-cascade form.
@@ -105,16 +150,27 @@
       ;; cascade before teardown; we fire `:rf.machine/destroyed` AFTER it
       ;; so the trace lands after `:exit` — the same exit-then-destroyed
       ;; ordering `destroy-single!` and `finalize-machine` use.
-      (destroy-single-actor! frame-id spawned-id)
+      ;;
+      ;; rf2-ndfjo — silent-idempotent destroy contract (rf2-lbjnz):
+      ;; `:cancel-on-decision?` join resolution (join.cljc/build-resolution-fx)
+      ;; already tore down surviving children via the guarded
+      ;; `destroy-single!` keyword form (one `:destroyed` each) BEFORE the
+      ;; parent's exit cascade re-reads the still-uncleared join-state here.
+      ;; `destroy-single-actor!` now returns falsey for those
+      ;; already-destroyed survivors (its liveness guard short-circuits), so
+      ;; gating the emit on its return value keeps each survivor's
+      ;; `:rf.machine/destroyed` to EXACTLY ONE — no phantom double-destroy.
+      ;;
       ;; rf2-gn80 D6 — `:reason :explicit` discriminates "the parent cascade
       ;; tore the child down" from `:rf.machine/finished` (the auto-destroy
       ;; on `:final?`). Per-child fires omit `:system-id` (the join-state's
       ;; children aren't system-id-bound through the parent's slot).
-      (traces/emit-destroyed! {:frame     frame-id
-                               :actor-id  spawned-id
-                               :parent-id parent-id
-                               :spawn-id invoke-id
-                               :child-id  child-id}))
+      (when (destroy-single-actor! frame-id spawned-id)
+        (traces/emit-destroyed! {:frame     frame-id
+                                 :actor-id  spawned-id
+                                 :parent-id parent-id
+                                 :spawn-id invoke-id
+                                 :child-id  child-id})))
     ;; Clear the join-state slot via the unified projection (slot-only).
     (frame/swap-frame-db! frame-id
                           (fn [db]
@@ -186,16 +242,15 @@
                     (get-in old-db (paths/spawned-path parent-id invoke-id)))
         actor-id  (if tracked? slot-id args)
         ;; rf2-lbjnz — silent-idempotent guard. `live?` is true iff ANY
-        ;; liveness signal survives (handler registered / snapshot
-        ;; present / spawn-order entry / tracked-slot present). See
-        ;; docstring for the rationale and what each signal covers.
-        live?     (and actor-id
-                       (or (some? (registrar/lookup :event actor-id))
-                           (and (some? old-db)
-                                (contains? (get-in old-db (paths/snapshot-path)) actor-id))
-                           (some #(= actor-id %)
-                                 (spawn-order/frame-order frame-id))
-                           (and tracked? (some? slot-id))))]
+        ;; liveness signal survives. The first three (handler registered /
+        ;; snapshot present / spawn-order entry) are the resolved-actor-id
+        ;; signals shared with `destroy-single-actor!` via `actor-live?`
+        ;; (rf2-ndfjo extracted them so both destroy paths apply the
+        ;; identical probe). The tracked-slot signal is local to this site —
+        ;; belt-and-braces for the declarative-`:spawn` tracked-map form's
+        ;; spec-less spawn case. See docstring for what each signal covers.
+        live?     (or (actor-live? frame-id actor-id old-db)
+                      (and tracked? (some? slot-id)))]
     (when live?
       (let [released-sid (teardown/find-system-id-for-actor old-db actor-id)]
         ;; (rf2-nahfm) Run the active configuration's `:exit` cascade

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -101,61 +101,69 @@
 ;; The spawn path passes `:bootstrap-pending? true` because the actor's
 ;; first dispatch must fire the initial-entry cascade (rf2-0z73).
 
+(defn- spawn-rejected?
+  "Per rf2-jbbp7 + rf2-f3kp7: decide whether a spawn must be rejected by
+  schema validation BEFORE any registration or install side effect runs.
+  When the spawning machine's spec carries a `:schema`, the freshly-built
+  `initial-snap`'s `:data` is validated against it. A failure emits
+  `:rf.error/schema-validation-failure :where :machine-data :phase :spawn`
+  (via `validate-spawn-data!`) and returns `true`; the caller then skips
+  the trace, the handler registration, the snapshot/system-id/spawn-slot
+  install, the spawn-order record, AND the `:start` dispatch — the
+  rejected actor leaves NO half-installed bookkeeping (no registered
+  handler, no actor state, no phantom `(rf/machines)` entry).
+
+  Returns `false` for a no-schema / no-validator / conforming spawn (and
+  for a spec-less spawn — nothing to validate)."
+  [spec spawned-id initial-snap]
+  (and (some? spec)
+       (not (data-validation/validate-spawn-data!
+              spawned-id spec initial-snap))))
+
 (defn- install-spawn!
-  "Atomically install the spawned actor's initial snapshot, system-id
+  "Atomically install the spawned actor's `initial-snap`, system-id
   binding, and runtime-owned spawn registry slot into the frame's
-  app-db. Returns `:ok` on a successful install, `:rejected` when
-  schema validation rejects the spawned actor's initial `:data` (the
-  caller emitted the trace; the install is skipped). Emits the
-  collision and system-id-bound traces when applicable.
+  app-db. Returns `:ok`. Emits the collision and system-id-bound traces
+  when applicable.
+
+  Per rf2-f3kp7 schema-rejection is decided by the caller (`spawn-fx`)
+  via `spawn-rejected?` BEFORE this fn — and BEFORE the handler
+  registration — runs, so by the time `install-spawn!` is reached the
+  spawn is known-accepted and `initial-snap` (built once by the caller)
+  is threaded in rather than re-built here.
 
   `db-after-alloc` is the post-id-allocation db computed by the caller
   (see `spawn-fx`); `swap-frame-db!`'s fn arg is discarded — the merge
   is applied on top of `db-after-alloc` so the caller's counter bump
   survives. Under Spec 002's single-drainer invariant the discarded
-  re-read is value-equal to the snapshot the caller already had.
-
-  Per rf2-jbbp7: when the spawning machine's spec carries a `:schema`,
-  the freshly-built initial snapshot's `:data` is validated against
-  it before the snapshot lands. A failure emits
-  `:rf.error/schema-validation-failure :where :machine-data
-  :phase :spawn` and short-circuits the install — the actor never
-  starts. Sibling `:system-id` / `[:rf/runtime :machines :spawned]` registrations are also
-  skipped so the rejected actor leaves no half-installed bookkeeping."
-  [frame-id db-after-alloc spec spawned-id
+  re-read is value-equal to the snapshot the caller already had."
+  [frame-id db-after-alloc spec spawned-id initial-snap
    {:keys [system-id parent-id track?] invoke-id :spawn-id}]
-  (let [initial-snap (when spec
-                       (parallel/build-initial-snapshot
-                         spec {:bootstrap-pending? true}))
-        existing     (when system-id (get-in db-after-alloc (paths/system-id-path system-id)))]
-    (if (and spec (not (data-validation/validate-spawn-data!
-                         spawned-id spec initial-snap)))
-      :rejected
-      (do
-        (when (and system-id existing (not= existing spawned-id))
-          (trace/emit-error! :rf.error/system-id-collision
-                             {:frame             frame-id
-                              :system-id         system-id
-                              :existing-machine  existing
-                              :rebound-to        spawned-id
-                              :reason            (str ":system-id " system-id
-                                                      " was already bound to "
-                                                      existing
-                                                      "; rebinding to " spawned-id
-                                                      " (last-write-wins).")
-                              :recovery          :warned-and-replaced}))
-        (frame/swap-frame-db! frame-id
-                              (fn [_db]
-                                (cond-> db-after-alloc
-                                  spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
-                                  system-id (assoc-in (paths/system-id-path system-id) spawned-id)
-                                  track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id))))
-        (when system-id
-          (trace/emit! :rf.machine :rf.machine/system-id-bound
-                       {:frame      frame-id
-                        :system-id  system-id
-                        :machine-id spawned-id}))
-        :ok))))
+  (let [existing (when system-id (get-in db-after-alloc (paths/system-id-path system-id)))]
+    (when (and system-id existing (not= existing spawned-id))
+      (trace/emit-error! :rf.error/system-id-collision
+                         {:frame             frame-id
+                          :system-id         system-id
+                          :existing-machine  existing
+                          :rebound-to        spawned-id
+                          :reason            (str ":system-id " system-id
+                                                  " was already bound to "
+                                                  existing
+                                                  "; rebinding to " spawned-id
+                                                  " (last-write-wins).")
+                          :recovery          :warned-and-replaced}))
+    (frame/swap-frame-db! frame-id
+                          (fn [_db]
+                            (cond-> db-after-alloc
+                              spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
+                              system-id (assoc-in (paths/system-id-path system-id) spawned-id)
+                              track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id))))
+    (when system-id
+      (trace/emit! :rf.machine :rf.machine/system-id-bound
+                   {:frame      frame-id
+                    :system-id  system-id
+                    :machine-id spawned-id}))
+    :ok))
 
 ;; ---- :rf.machine/spawn -----------------------------------------------------
 
@@ -224,70 +232,79 @@
           (and old-db machine-id-for-alloc)
                         (allocate-actor-id-in-db old-db machine-id-for-alloc)
           :else         [old-db nil])
-        spec''     (stamp-framework-data spec' spawned-id parent-id invoke-id)]
-    (trace/emit! :rf.machine :rf.machine/spawned
-                 {:frame      frame-id
-                  :machine-id (:machine-id args)
-                  :spawned-id spawned-id
-                  :id-prefix  (:id-prefix args)
-                  :start      (:start args)
-                  :on-spawn   (:on-spawn args)
-                  :system-id  system-id
-                  :parent-id  parent-id
-                  :spawn-id  invoke-id})
-    (when spec''
-      (registration/reg-machine* spawned-id spec''))
-    ;; (3) Initialise the snapshot + (4) bind :system-id + (5) bind the
-    ;; runtime-owned spawn registry (atomically under one app-db swap so
-    ;; observers see consistent state). When the spawned id was allocated
-    ;; from the frame's app-db (the hand-emitted-spawn fallback path),
-    ;; `db-after-alloc` already carries the bumped counter — install the
-    ;; snapshot on top of that.
-    ;;
-    ;; Per rf2-jbbp7 the install path validates the spawned actor's
-    ;; initial `:data` against the machine's `:schema` (when declared)
-    ;; before landing the snapshot. A `:rejected` return short-circuits
-    ;; the spawn-order recording AND the `:start` dispatch — the actor
-    ;; never enters the runtime, and no parent state observes a
-    ;; half-installed child.
-    (let [install-result
-          (when old-db
-            (let [r (install-spawn! frame-id db-after-alloc spec'' spawned-id
-                                    {:system-id system-id
-                                     :parent-id parent-id
-                                     :spawn-id invoke-id
-                                     :track?    track?})]
-              (when (= r :ok)
-                ;; Per rf2-vsigt — record the spawned actor in the frame's
-                ;; spawn-order channel so frame-destroy can walk in reverse-
-                ;; creation order per Spec 005 §Cross-Spec Interactions §1.
-                (spawn-order/record! frame-id spawned-id))
-              r))]
-      (when-not (= install-result :rejected)
-        ;; (6) Fire the :start event into the new actor. Per rf2-ijm7,
-        ;; spawns that don't supply :start receive a synthetic
-        ;; [:rf.machine/spawned] so generic child machines can declare their
-        ;; first transition out of an :initial state at spec-write time.
-        (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-          ;; Per rf2-ejtpd + rf2-1ve9h: stamp `:source :machine-spawn`
-          ;; on the actor-bootstrap dispatch so the Epoch panel's
-          ;; DISPATCH step labels it "from machine spawn" rather than
-          ;; `:unknown` (rf2-hxj0d residual default) or `:fx-dispatch`
-          ;; (which would be the value if the spawn fx routed through
-          ;; `:dispatch`), and Xray's L2 timeline can prefix the row +
-          ;; per-source filter pills can discriminate actor-bootstrap
-          ;; cascades. Per rf2-1ve9h (Mike-approved Option A,
-          ;; 2026-05-28) the prior parallel `:rf/dispatch-origin
-          ;; :internal` axis was collapsed into `:source` —
-          ;; `:machine-spawn` is now the single functional-origin
-          ;; discriminator (closed-enum per Spec-Schemas
-          ;; §`:rf/dispatch-envelope`).
-          (let [start (:start args)
-                opts  {:frame              frame-id
-                       :source             :machine-spawn}]
-            (if (some? start)
-              (dispatch! [spawned-id start] opts)
-              (dispatch! [spawned-id [:rf.machine/spawned]] opts))))))
+        spec''     (stamp-framework-data spec' spawned-id parent-id invoke-id)
+        ;; Build the initial snapshot ONCE here so the schema-rejection
+        ;; decision can gate every side effect below; `install-spawn!`
+        ;; threads the same value rather than re-building it.
+        initial-snap (when spec''
+                       (parallel/build-initial-snapshot
+                         spec'' {:bootstrap-pending? true}))
+        ;; Per rf2-f3kp7: decide schema rejection BEFORE the trace, the
+        ;; handler registration, and the install. The prior code emitted
+        ;; the `:rf.machine/spawned` trace and called `reg-machine*`
+        ;; unconditionally, so a `:schema`-rejected spawn leaked a
+        ;; registered event handler + a phantom `(rf/machines)` entry
+        ;; (the install was correctly skipped, but the registration ran
+        ;; out of step). Gating all three on `(not rejected?)` makes a
+        ;; rejected spawn FULLY atomic — it registers nothing, installs
+        ;; nothing, records no spawn-order entry, dispatches no `:start`,
+        ;; and announces no `:rf.machine/spawned` (only the
+        ;; `:rf.error/schema-validation-failure :phase :spawn` that
+        ;; `validate-spawn-data!` already emitted).
+        rejected?  (spawn-rejected? spec'' spawned-id initial-snap)]
+    (when-not rejected?
+      (trace/emit! :rf.machine :rf.machine/spawned
+                   {:frame      frame-id
+                    :machine-id (:machine-id args)
+                    :spawned-id spawned-id
+                    :id-prefix  (:id-prefix args)
+                    :start      (:start args)
+                    :on-spawn   (:on-spawn args)
+                    :system-id  system-id
+                    :parent-id  parent-id
+                    :spawn-id  invoke-id})
+      (when spec''
+        (registration/reg-machine* spawned-id spec''))
+      ;; (3) Initialise the snapshot + (4) bind :system-id + (5) bind the
+      ;; runtime-owned spawn registry (atomically under one app-db swap so
+      ;; observers see consistent state). When the spawned id was allocated
+      ;; from the frame's app-db (the hand-emitted-spawn fallback path),
+      ;; `db-after-alloc` already carries the bumped counter — install the
+      ;; snapshot on top of that.
+      (when old-db
+        (install-spawn! frame-id db-after-alloc spec'' spawned-id initial-snap
+                        {:system-id system-id
+                         :parent-id parent-id
+                         :spawn-id invoke-id
+                         :track?    track?})
+        ;; Per rf2-vsigt — record the spawned actor in the frame's
+        ;; spawn-order channel so frame-destroy can walk in reverse-
+        ;; creation order per Spec 005 §Cross-Spec Interactions §1.
+        (spawn-order/record! frame-id spawned-id))
+      ;; (6) Fire the :start event into the new actor. Per rf2-ijm7,
+      ;; spawns that don't supply :start receive a synthetic
+      ;; [:rf.machine/spawned] so generic child machines can declare their
+      ;; first transition out of an :initial state at spec-write time.
+      (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+        ;; Per rf2-ejtpd + rf2-1ve9h: stamp `:source :machine-spawn`
+        ;; on the actor-bootstrap dispatch so the Epoch panel's
+        ;; DISPATCH step labels it "from machine spawn" rather than
+        ;; `:unknown` (rf2-hxj0d residual default) or `:fx-dispatch`
+        ;; (which would be the value if the spawn fx routed through
+        ;; `:dispatch`), and Xray's L2 timeline can prefix the row +
+        ;; per-source filter pills can discriminate actor-bootstrap
+        ;; cascades. Per rf2-1ve9h (Mike-approved Option A,
+        ;; 2026-05-28) the prior parallel `:rf/dispatch-origin
+        ;; :internal` axis was collapsed into `:source` —
+        ;; `:machine-spawn` is now the single functional-origin
+        ;; discriminator (closed-enum per Spec-Schemas
+        ;; §`:rf/dispatch-envelope`).
+        (let [start (:start args)
+              opts  {:frame              frame-id
+                     :source             :machine-spawn}]
+          (if (some? start)
+            (dispatch! [spawned-id start] opts)
+            (dispatch! [spawned-id [:rf.machine/spawned]] opts)))))
     spawned-id))
 
 ;; ---- :rf.machine/spawn-all-init -------------------------------------------

--- a/implementation/machines/test/re_frame/destroy_silent_idempotent_test.cljc
+++ b/implementation/machines/test/re_frame/destroy_silent_idempotent_test.cljc
@@ -162,3 +162,100 @@
           "snapshot is cleared exactly once")
       (is (nil? (registrar/lookup :event :rf2-lbjnz/target))
           "handler is unregistered exactly once"))))
+
+;; ---- Test 3: spawn-all join-cancelled survivor destroyed exactly once ------
+;;
+;; rf2-ndfjo — the destroy-single-actor! / spawn-all exit-cascade path was
+;; unpinned. When a `:spawn-all` join resolves with `:cancel-on-decision?`
+;; true (the default), surviving children are torn down TWICE:
+;;
+;;   1. `build-resolution-fx` (join.cljc) emits `[:rf.machine/destroy
+;;      <survivor>]` (keyword form → guarded `destroy-single!`) — one
+;;      `:rf.machine/destroyed`.
+;;   2. the parent then transitions OUT of the `:spawn-all` state; the
+;;      exit cascade emits `[:rf.machine/destroy {:rf/spawn-all true ...}]`
+;;      → `destroy-spawn-all-children!` re-reads the still-uncleared
+;;      join-state and (pre-fix) fired `destroy-single-actor!` +
+;;      `emit-destroyed!` UNCONDITIONALLY per child — a SECOND
+;;      `:rf.machine/destroyed` for the already-cancelled survivors.
+;;
+;; This violated the silent-idempotent destroy contract (rf2-lbjnz): one
+;; observable Active→Stopped transition ⇒ exactly one `:rf.machine/destroyed`
+;; per actor. The fix gives `destroy-single-actor!` the same liveness guard
+;; `destroy-single!` carries and gates the cascade's emit on it.
+
+(defn- mk-cancel-child
+  "Child that, on `:go`, transitions to `:done` and dispatches
+  `[parent-id [:done <own-id>]]` back to the parent. `:set-id` records
+  the child's own id (supplied via the parent's `:start`)."
+  [parent-id]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:dispatch-done
+             (fn [{data :data}]
+               {:fx [[:dispatch [parent-id [:done (:id data)]]]]})
+             :record-id
+             (fn [{data :data ev :event}]
+               {:data (assoc data :id (second ev))})}
+   :states
+   {:running {:on {:set-id {:action :record-id}
+                   :go     {:target :done :action :dispatch-done}}}
+    :done    {}}})
+
+(deftest spawn-all-join-cancelled-survivor-destroyed-exactly-once
+  (testing "rf2-ndfjo — a join-cancelled survivor in a :spawn-all exit
+            cascade emits :rf.machine/destroyed EXACTLY once (silent-
+            idempotent destroy; no phantom double-destroy)"
+    (let [traces (record-traces! ::ndfjo-cancel)
+          child  (mk-cancel-child :rf2-ndfjo/sup)
+          parent {:initial :idle
+                  :states
+                  {:idle    {:on {:start :working}}
+                   :working
+                   {:spawn-all
+                    {:children         [{:id :a :machine-id :rf2-ndfjo/ca :start [:set-id :a]}
+                                        {:id :b :machine-id :rf2-ndfjo/cb :start [:set-id :b]}
+                                        {:id :c :machine-id :rf2-ndfjo/cc :start [:set-id :c]}
+                                        {:id :d :machine-id :rf2-ndfjo/cd :start [:set-id :d]}
+                                        {:id :e :machine-id :rf2-ndfjo/ce :start [:set-id :e]}]
+                     :join             {:n 3}
+                     :on-child-done    :done
+                     :on-child-error   :failed
+                     :on-some-complete [:phase/three-done]}
+                    ;; The parent transitions OUT of :working on resolution —
+                    ;; this is what fires the exit cascade's spawn-all destroy
+                    ;; over the still-uncleared join-state.
+                    :on    {:phase/three-done :ready}}
+                   :ready  {}}}]
+      (doseq [k [:rf2-ndfjo/ca :rf2-ndfjo/cb :rf2-ndfjo/cc
+                 :rf2-ndfjo/cd :rf2-ndfjo/ce]]
+        (rf/reg-machine k child))
+      (rf/reg-machine :rf2-ndfjo/sup parent)
+      (rf/dispatch-sync [:rf2-ndfjo/sup [:start]])
+      (let [ids (get-in (rf/get-frame-db :rf/default)
+                        [:rf/runtime :machines :spawned :rf2-ndfjo/sup [:working] :children])]
+        (is (= 5 (count ids)) "five children spawned")
+        ;; Complete a, b, c → join resolves at :n 3; d, e are cancelled
+        ;; survivors; parent transitions :working → :ready (exit cascade).
+        (rf/dispatch-sync [(:a ids) [:go]])
+        (rf/dispatch-sync [(:b ids) [:go]])
+        (rf/dispatch-sync [(:c ids) [:go]])
+        (is (= :ready (:state (snapshot :rf2-ndfjo/sup)))
+            "parent resolved to :ready via :on-some-complete")
+        ;; Every child's actor is torn down.
+        (doseq [[_ spawned-id] ids]
+          (is (nil? (snapshot spawned-id))
+              "every child snapshot is cleared"))
+        ;; The contract under test: count :rf.machine/destroyed per actor-id.
+        ;; Each of the five spawned actors — completed (a,b,c) AND cancelled
+        ;; survivors (d,e) — must show EXACTLY ONE destroyed trace.
+        (let [dest-by-actor (frequencies (map (comp :actor-id :tags)
+                                              (destroyed-traces traces)))]
+          (doseq [[_ spawned-id] ids]
+            (is (= 1 (get dest-by-actor spawned-id))
+                (str "actor " spawned-id
+                     " emitted exactly one :rf.machine/destroyed (got "
+                     (get dest-by-actor spawned-id) ") — rf2-ndfjo")))
+          ;; Belt-and-braces: no actor exceeds one destroyed trace.
+          (is (every? #(= 1 %) (vals dest-by-actor))
+              "no actor double-emits :rf.machine/destroyed"))))))

--- a/implementation/machines/test/re_frame/machine_schema_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_test.clj
@@ -34,6 +34,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
             ;; The schemas artefact ships the registered-validator hot
             ;; path the new `:where :machine-data` boundary routes
             ;; through; the `.malli` adapter ns publishes Malli's
@@ -41,8 +42,7 @@
             [re-frame.schemas]
             [re-frame.schemas.malli]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
@@ -189,7 +189,15 @@
         ;; The spawned actor's snapshot was never installed.
         (is (nil? (get-in (rf/get-frame-db :rf/default)
                           [:rf/runtime :machines :snapshots :rf.machine-schema/spawned]))
-            "rejected spawn: snapshot is not in app-db")))))
+            "rejected spawn: snapshot is not in app-db")
+        ;; rf2-f3kp7 — atomic reject. The prior code called `reg-machine*`
+        ;; out of step with the install gate, leaking a registered event
+        ;; handler + a phantom `(rf/machines)` entry for the rejected actor.
+        ;; A schema-rejected spawn must register NOTHING.
+        (is (nil? (registrar/lookup :event :rf.machine-schema/spawned))
+            "rejected spawn: NO event handler is registered (rf2-f3kp7)")
+        (is (not (contains? (set (machines/machines)) :rf.machine-schema/spawned))
+            "rejected spawn: the actor does NOT appear in (rf/machines) (rf2-f3kp7)")))))
 
 ;; ---- (5) no schema → no validation (control) ------------------------------
 


### PR DESCRIPTION
Two spawn/destroy lifecycle-integrity correctness fixes (both found by adversarial review rf2-5t8mr.10), shipped together because they are the same domain — spawn/destroy lifecycle contracts.

## rf2-f3kp7 — atomic schema-rejected spawn
`spawn-fx` (spawn.cljc) called `registration/reg-machine*` and emitted `:rf.machine/spawned` **unconditionally**, before `install-spawn!`'s `:schema` validation gate. A schema-rejected spawn correctly skipped the snapshot install but **left a registered event handler + a phantom `(rf/machines)` entry** — contradicting Spec 005 §Spawn-time validation ("the actor never enters the runtime, and no parent state observes a half-installed child") and the spawn-fx docstring.

**Fix (option a):** hoist the initial-snapshot build + validation verdict (`spawn-rejected?`) ahead of the trace, the registration, the install, the spawn-order record, and the `:start` dispatch; gate all of them on `(not rejected?)`. A rejected spawn now registers nothing, installs nothing, records no spawn-order entry, dispatches no `:start`, and emits no `:rf.machine/spawned` (only the existing `:rf.error/schema-validation-failure :phase :spawn`). `install-spawn!` now threads the pre-built snapshot and no longer re-validates.

## rf2-ndfjo — idempotent destroy in spawn-all exit cascade
A `:spawn-all` join resolving with `:cancel-on-decision? true` (the default) **double-emitted `:rf.machine/destroyed`** for join-cancelled survivors: `build-resolution-fx` (join.cljc) tore them down via the guarded keyword-form `destroy-single!` (one `:destroyed` each), then the parent transitioned out of the `:spawn-all` state and the exit cascade re-read the still-uncleared join-state, firing `destroy-single-actor!` + `emit-destroyed!` **unconditionally** per child. `destroy-single-actor!` had no liveness guard (unlike `destroy-single!`'s rf2-lbjnz `live?` check). This violated Spec 005 §Destroy is silent-idempotent ("one observable Active→Stopped transition").

**Fix (option a):** extract the rf2-lbjnz liveness probe into a shared `actor-live?` helper used by both destroy paths. `destroy-single-actor!` now returns falsey for an already-destroyed actor (silent no-op), and `destroy-spawn-all-children!` gates its `emit-destroyed!` on that return — exactly one `:destroyed` per actor. The rf2-iilco exit-then-destroyed ordering is preserved; `destroy-single!`'s `live?` now delegates to the shared helper (dedup) plus its local tracked-slot signal.

Both fixes bring the implementation into line with the **existing** Spec 005 contracts — no spec change required.

## Regression tests (failing-before / passing-after, both verified)
- `machine_schema_test.clj` `spawn-violation-emits-and-skips-install`: extended to assert a schema-rejected spawn leaves **NO** registered handler (`registrar/lookup`) and **NO** `(rf/machines)` entry. Pre-fix: both leaked (2 failures).
- `destroy_silent_idempotent_test.cljc` `spawn-all-join-cancelled-survivor-destroyed-exactly-once`: a `{:n 3}` join over 5 children cancels survivors d,e; asserts each of the 5 actors emits exactly one `:rf.machine/destroyed`. Pre-fix per-actor frequencies were `2 2 1 1 1` (matching the bead's repro); post-fix all `1`.

## Quality gates
- machines JVM `clojure -M:test`: **285 tests, 950 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node runtime, includes `machines/test`): **5157 tests, 17394 assertions, 0 failures, 0 errors**
- clj-kondo on the 4 changed files: **0 errors, 0 warnings** (also removed a pre-existing unused `re-frame.trace` require in the schema test)

Closes rf2-f3kp7, rf2-ndfjo.