### PR TITLE
fix(impl-scripts): free-port + ownership for xray-gate; race-safe harness cleanup (rf2-84gzw, rf2-ogpeq)

### DIFF
--- a/implementation/scripts/_local-browser-harness.test.cjs
+++ b/implementation/scripts/_local-browser-harness.test.cjs
@@ -2,12 +2,20 @@
 'use strict';
 
 const assert = require('assert/strict');
+const crypto = require('crypto');
 const http = require('http');
+const net = require('net');
 const {
+  TOKEN_FILE_BASENAME,
   createHarnessCleanup,
+  fetchToken,
+  findFreePort,
+  isPortFree,
+  resolveServePort,
   spawnHarnessProcess,
   terminateProcessTree,
   waitForHttpReady,
+  waitForOwnedHttpReady,
 } = require('./lib/local-browser-harness.cjs');
 
 const tests = [];
@@ -85,6 +93,182 @@ test('terminateProcessTree stops a managed child process', async () => {
   await terminateProcessTree(child, { timeoutMs: 2000 });
   const exit = await exitPromise;
   assert.notEqual(exit, null);
+});
+
+// rf2-ogpeq regression (the core race). The async cleanup() kills tracked
+// children sequentially (last-tracked first), awaiting each. If
+// process.exit() fires the 'exit' handler -> cleanupSync() while cleanup()
+// is still mid-flight — it has reached child[last] and is awaiting its
+// termination, but has NOT yet reached the earlier children — cleanupSync
+// MUST still synchronously terminate those earlier children. Node cannot
+// resume the async cleanup's pending awaits once the process is exiting,
+// so anything cleanupSync skips is ORPHANED.
+//
+// The old code shared a single `cleaned` flag: the async cleanup set it at
+// the start, so cleanupSync saw `cleaned===true` and returned immediately,
+// skipping the un-reached children.
+//
+// We model this deterministically via the injectable terminator seam: the
+// async terminator NEVER resolves (modelling a hard exit that abandons the
+// in-flight cleanup), and the sync terminator records which children it
+// swept. The invariant: after cleanupSync(), EVERY tracked child has been
+// synchronously swept — regardless of the async cleanup being mid-flight.
+test('cleanupSync sweeps every child when async cleanup() is mid-flight (rf2-ogpeq)', async () => {
+  const childA = { id: 'A' };
+  const childB = { id: 'B' };
+  const sweptSync = [];
+
+  const cleanup = createHarnessCleanup({
+    onError: () => {},
+    // Records sync sweeps. Idempotent in spirit: real terminateProcessTreeSync
+    // no-ops on dead children; here we just record the attempt.
+    terminateSync: (child) => { sweptSync.push(child.id); },
+    // Models an in-flight async kill that never completes — i.e. the
+    // process is exiting and these awaits will never resume.
+    terminateAsync: () => new Promise(() => {}),
+  });
+  cleanup.trackProcess(childA);
+  cleanup.trackProcess(childB);
+
+  // Start the async cleanup. Its IIFE runs synchronously up to the first
+  // `await terminateAsync(...)`, which never resolves — cleanup() is now
+  // permanently mid-flight (modelling abandonment by a hard exit).
+  cleanup.cleanup();
+
+  // The 'exit' handler fires. With the bug this returns without sweeping;
+  // with the fix it synchronously sweeps every tracked child.
+  cleanup.cleanupSync();
+
+  assert.deepEqual(
+    [...sweptSync].sort(),
+    ['A', 'B'],
+    'cleanupSync must synchronously terminate every tracked child even when ' +
+      'an async cleanup() is mid-flight (otherwise children are orphaned on hard exit)',
+  );
+});
+
+// End-to-end companion: with REAL child processes, both terminate on the
+// cleanupSync path. Generous timeout because on Windows the kill goes
+// through `taskkill /T /F` (spawnSync), which can take several seconds per
+// child on a loaded machine — we only assert THAT they die, not how fast.
+test('cleanupSync terminates real tracked child processes', async () => {
+  const spawnLongLived = () => spawnHarnessProcess(process.execPath, [
+    '-e',
+    'setInterval(() => {}, 1000)',
+  ], { stdio: ['ignore', 'ignore', 'ignore'] });
+
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  const first = cleanup.trackProcess(spawnLongLived());
+  const second = cleanup.trackProcess(spawnLongLived());
+
+  const firstExit = waitForExit(first, 30000);
+  const secondExit = waitForExit(second, 30000);
+
+  cleanup.cleanupSync();
+
+  await Promise.all([firstExit, secondExit]);
+  assert.ok(true);
+});
+
+test('cleanup runs each addCleanup fn at most once across sync + async paths', async () => {
+  let calls = 0;
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  cleanup.addCleanup(() => { calls += 1; });
+  await cleanup.cleanup();
+  cleanup.cleanupSync();
+  await cleanup.cleanup();
+  assert.equal(calls, 1);
+});
+
+// rf2-84gzw regression — free-port resolution.
+test('resolveServePort returns the preferred port when it is free', async () => {
+  const free = await findFreePort();
+  const resolved = await resolveServePort(free);
+  assert.equal(resolved, free);
+});
+
+test('resolveServePort falls back to a different free port when preferred is busy', async () => {
+  // Occupy a port, then ask resolveServePort to prefer it.
+  const occupied = await findFreePort();
+  const squatter = net.createServer();
+  await new Promise((resolve, reject) => {
+    squatter.once('error', reject);
+    squatter.listen(occupied, '127.0.0.1', resolve);
+  });
+  try {
+    let fellBack = false;
+    const resolved = await resolveServePort(occupied, {
+      onFallback: () => { fellBack = true; },
+    });
+    assert.equal(fellBack, true);
+    assert.notEqual(resolved, occupied);
+    assert.equal(await isPortFree(resolved), true);
+  } finally {
+    await new Promise((r) => squatter.close(r));
+  }
+});
+
+// rf2-84gzw regression — ownership-token verification.
+test('waitForOwnedHttpReady resolves ok when the served token matches', async () => {
+  const token = crypto.randomBytes(8).toString('hex');
+  const server = http.createServer((req, res) => {
+    if (req.url === `/${TOKEN_FILE_BASENAME}`) {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(token);
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('ok');
+  });
+  const port = await listenOnLoopback(server);
+  try {
+    const result = await waitForOwnedHttpReady(port, token, Date.now() + 2000, { pollMs: 10 });
+    assert.deepEqual(result, { ok: true });
+    assert.equal(await fetchToken(port), token);
+  } finally {
+    server.close();
+  }
+});
+
+test('waitForOwnedHttpReady refuses a foreign server (token mismatch)', async () => {
+  // A reachable server that serves a DIFFERENT token — i.e. a port
+  // squatter / stale server from another run. The gate must refuse to
+  // proceed against it.
+  const server = http.createServer((req, res) => {
+    if (req.url === `/${TOKEN_FILE_BASENAME}`) {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('a-foreign-token');
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('ok');
+  });
+  const port = await listenOnLoopback(server);
+  try {
+    const result = await waitForOwnedHttpReady(port, 'our-token', Date.now() + 1000, { pollMs: 10 });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'token-mismatch');
+    assert.equal(result.got, 'a-foreign-token');
+  } finally {
+    server.close();
+  }
+});
+
+test('waitForOwnedHttpReady reports token-never-served for a tokenless responder', async () => {
+  // Reachable, but never serves /.rf-harness-token (404). Must not be
+  // mistaken for "ours".
+  const server = http.createServer((_, res) => {
+    res.writeHead(404);
+    res.end('nope');
+  });
+  const port = await listenOnLoopback(server);
+  try {
+    const result = await waitForOwnedHttpReady(port, 'our-token', Date.now() + 400, { pollMs: 20 });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'token-never-served');
+  } finally {
+    server.close();
+  }
 });
 
 (async () => {

--- a/implementation/scripts/lib/local-browser-harness.cjs
+++ b/implementation/scripts/lib/local-browser-harness.cjs
@@ -2,9 +2,116 @@
 
 const { spawn, spawnSync } = require('child_process');
 const http = require('http');
+const net = require('net');
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// True if the given TCP port is currently free on 127.0.0.1. We bind a
+// temporary listener and immediately release it; EADDRINUSE (or any
+// other bind error) is treated as "not free" so callers fall back to an
+// OS-chosen port. (rf2-84gzw — shared with serve-and-run-browser-tests
+// and check-story-static, which carry their own copies for now.)
+function isPortFree(port) {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once('error', () => resolve(false));
+    srv.once('listening', () => {
+      srv.close(() => resolve(true));
+    });
+    srv.listen(port, '127.0.0.1');
+  });
+}
+
+// Ask the OS for a free port (listen on 0, capture, release).
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// Resolve a port to serve on: prefer `preferredPort` when it is free,
+// otherwise fall back to an OS-chosen free port. `onFallback(preferred,
+// fallback)` is invoked (if provided) when the preferred port is busy so
+// callers can log the substitution.
+async function resolveServePort(preferredPort, opts = {}) {
+  if (Number.isInteger(preferredPort) && (await isPortFree(preferredPort))) {
+    return preferredPort;
+  }
+  const fallback = await findFreePort();
+  if (typeof opts.onFallback === 'function') {
+    opts.onFallback(preferredPort, fallback);
+  }
+  return fallback;
+}
+
+// Fetch the body of a path (default `/.rf-harness-token`) from a local
+// server, trimmed. Resolves null on non-200, error, or timeout — the
+// caller treats "no token yet" as "keep polling" and a present-but-wrong
+// token as a foreign server. (rf2-84gzw / rf2-gkf9 ownership handshake.)
+const TOKEN_FILE_BASENAME = '.rf-harness-token';
+
+function fetchToken(port, opts = {}) {
+  const host = opts.host || '127.0.0.1';
+  const tokenPath = opts.path || `/${TOKEN_FILE_BASENAME}`;
+  const timeout = opts.timeout || 1000;
+  return new Promise((resolve) => {
+    const req = http.get({ host, port, path: tokenPath, timeout }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        resolve(null);
+        return;
+      }
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => resolve(body.trim()));
+      res.on('error', () => resolve(null));
+    });
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+  });
+}
+
+// Readiness wait WITH ownership-token verification (rf2-84gzw). Resolves
+// `{ ok: true }` only once the server on `port` answers AND serves a
+// `/.rf-harness-token` body equal to `expectedToken`. Otherwise resolves
+// `{ ok: false, reason }`:
+//   - 'child-exited'      — opts.isAborted() went true (server died)
+//   - 'token-mismatch'    — a foreign server is bound to this port (its
+//                           token is present but != ours); refuse to run
+//   - 'token-never-served'— reachable but never published our token
+//   - 'timeout'           — never became reachable
+// This positively distinguishes "our server" from a port-squatter / a
+// stale http-server from an aborted run, defeating false-RED and (worse)
+// false-GREEN runs against the wrong asset tree.
+async function waitForOwnedHttpReady(port, expectedToken, deadline, opts = {}) {
+  const pollMs = opts.pollMs || 200;
+  const isAborted = opts.isAborted || (() => false);
+  let sawReachable = false;
+  while (Date.now() < deadline) {
+    if (isAborted()) return { ok: false, reason: 'child-exited' };
+    if (await probeHttp(port, opts)) {
+      sawReachable = true;
+      if (isAborted()) return { ok: false, reason: 'child-exited' };
+      const got = await fetchToken(port, opts);
+      if (got && got === expectedToken) return { ok: true };
+      if (got && got !== expectedToken) {
+        return { ok: false, reason: 'token-mismatch', got };
+      }
+      // Token absent yet — http-server may be up but not yet serving the
+      // sentinel file. Keep polling.
+    }
+    if (isAborted()) return { ok: false, reason: 'child-exited' };
+    await sleep(pollMs);
+  }
+  return { ok: false, reason: sawReachable ? 'token-never-served' : 'timeout' };
 }
 
 function probeHttp(port, opts = {}) {
@@ -112,7 +219,31 @@ function createHarnessCleanup(opts = {}) {
     if (err) console.error(err && err.stack ? err.stack : err);
   });
   const exit = opts.exit || ((code) => process.exit(code));
-  let cleaned = false;
+  // Injectable terminators (default: the real process-tree killers).
+  // The seam exists so the rf2-ogpeq race can be unit-tested
+  // deterministically — a test can supply a synchronous terminator that
+  // records which children were swept and an async one that never
+  // resolves (modelling an in-flight cleanup that a hard exit abandons),
+  // without depending on real (and, on Windows, multi-second) taskkill
+  // latency.
+  const terminateSync = opts.terminateSync || terminateProcessTreeSync;
+  const terminateAsync = opts.terminateAsync || terminateProcessTree;
+  // Two independent guards (rf2-ogpeq). The synchronous kill-sweep over
+  // the tracked children and the cleanupFns each gate on their OWN flag,
+  // so the async `cleanup()` setting one cannot suppress the other on a
+  // hard-exit race:
+  //
+  //   - `killed` guards the child-process kill-sweep. cleanupSync() will
+  //     ALWAYS run the synchronous sweep unless a previous sweep already
+  //     ran (the sweep is itself idempotent — terminateProcessTreeSync
+  //     no-ops on already-dead children via hasExited()). This is what
+  //     stops orphaned children when process.exit() fires the 'exit'
+  //     handler while an async cleanup() is mid-flight (awaiting
+  //     terminateProcessTree on child N of M).
+  //   - `cleanupFnsRan` guards the addCleanup callbacks so they run at
+  //     most once across both paths.
+  let killed = false;
+  let cleanupFnsRan = false;
   let cleaning = null;
 
   function trackProcess(child) {
@@ -125,16 +256,24 @@ function createHarnessCleanup(opts = {}) {
     return fn;
   }
 
-  function cleanupSync() {
-    if (cleaned) return;
-    cleaned = true;
+  // Synchronously terminate every tracked child subtree. Idempotent:
+  // the per-child terminateProcessTreeSync no-ops on already-exited
+  // children, and the `killed` flag short-circuits a redundant sweep.
+  function killChildrenSync() {
+    if (killed) return;
+    killed = true;
     for (const child of [...processes].reverse()) {
       try {
-        terminateProcessTreeSync(child);
+        terminateSync(child);
       } catch (err) {
         onError(err);
       }
     }
+  }
+
+  function runCleanupFnsSync() {
+    if (cleanupFnsRan) return;
+    cleanupFnsRan = true;
     for (const fn of [...cleanupFns].reverse()) {
       try {
         fn();
@@ -144,18 +283,35 @@ function createHarnessCleanup(opts = {}) {
     }
   }
 
+  // The process 'exit' handler. Node cannot await here, so a hard exit
+  // racing an in-flight async cleanup() MUST still synchronously kill
+  // any children that cleanup() has not yet reached — otherwise they are
+  // orphaned (rf2-ogpeq). killChildrenSync gates on its own `killed`
+  // flag, never on the async path's state, so this always sweeps unless
+  // a sync sweep already completed.
+  function cleanupSync() {
+    killChildrenSync();
+    runCleanupFnsSync();
+  }
+
   async function cleanup() {
     if (cleaning) return cleaning;
     cleaning = (async () => {
-      if (cleaned) return;
-      cleaned = true;
       for (const child of [...processes].reverse()) {
+        // hasExited() makes this a no-op if cleanupSync() already swept
+        // this child (or it exited on its own).
         try {
-          await terminateProcessTree(child);
+          await terminateAsync(child);
         } catch (err) {
           onError(err);
         }
       }
+      // Mark the synchronous kill-sweep satisfied so a subsequent
+      // 'exit' -> cleanupSync() doesn't redundantly re-sweep children
+      // this async path already awaited to completion.
+      killed = true;
+      if (cleanupFnsRan) return;
+      cleanupFnsRan = true;
       for (const fn of [...cleanupFns].reverse()) {
         try {
           await fn();
@@ -193,11 +349,17 @@ function createHarnessCleanup(opts = {}) {
 }
 
 module.exports = {
+  TOKEN_FILE_BASENAME,
   createHarnessCleanup,
+  fetchToken,
+  findFreePort,
+  isPortFree,
   probeHttp,
+  resolveServePort,
   sleep,
   spawnHarnessProcess,
   terminateProcessTree,
   terminateProcessTreeSync,
   waitForHttpReady,
+  waitForOwnedHttpReady,
 };

--- a/implementation/scripts/serve-and-run-xray-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-xray-feature-gate.cjs
@@ -11,14 +11,18 @@
  */
 
 const { spawnSync } = require('child_process');
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 
 const { isVerboseTests } = require('./lib/browser-test-report.cjs');
 const {
+  TOKEN_FILE_BASENAME,
   createHarnessCleanup,
+  resolveServePort,
   spawnHarnessProcess,
   waitForHttpReady,
+  waitForOwnedHttpReady,
 } = require('./lib/local-browser-harness.cjs');
 const {
   SCENARIOS,
@@ -29,11 +33,40 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
 const OUT_ROOT = path.join(IMPL_ROOT, 'out', 'xray-feature-gate');
 const ARTIFACT_ROOT = path.join(IMPL_ROOT, 'out', 'xray-feature-gate-artifacts');
-const PORT = Number(process.env.XRAY_FEATURE_GATE_PORT || 8037);
-const BASE_URL = process.env.XRAY_FEATURE_GATE_BASE_URL || `http://127.0.0.1:${PORT}`;
+// Preferred port; the gate falls back to an OS-chosen free port when this
+// is busy (rf2-84gzw). The resolved port is threaded into BASE_URL at
+// runtime, so a fixed override here no longer pins the run to a possibly
+// foreign listener. XRAY_FEATURE_GATE_BASE_URL still lets a caller point
+// at an external server entirely (in which case ownership-token
+// verification is skipped — see main()).
+const PREFERRED_PORT = Number(process.env.XRAY_FEATURE_GATE_PORT || 8037);
+const EXTERNAL_BASE_URL = process.env.XRAY_FEATURE_GATE_BASE_URL || null;
 const TIMEOUT_MS = Number(process.env.XRAY_FEATURE_GATE_TIMEOUT_MS || 45000);
 const READY_TIMEOUT_MS = 30000;
 const VERBOSE_TESTS = isVerboseTests();
+
+// Per-run ownership token (rf2-84gzw / rf2-gkf9). Published as
+// `${OUT_ROOT}/.rf-harness-token` before http-server is spawned (OUT_ROOT
+// is a staging dir this script owns — cleanAndStageRoot() recreates it),
+// then verified by waitForOwnedHttpReady before any Playwright scenario
+// runs. Defeats a stale/foreign listener on the chosen port serving a
+// different (possibly stale-but-compatible → FALSE-GREEN) asset tree.
+const TOKEN_PATH = path.join(OUT_ROOT, TOKEN_FILE_BASENAME);
+
+function writeOwnershipToken() {
+  if (!fs.existsSync(OUT_ROOT)) return null;
+  const token = crypto.randomBytes(16).toString('hex');
+  fs.writeFileSync(TOKEN_PATH, token, 'utf8');
+  return token;
+}
+
+function removeOwnershipToken() {
+  try {
+    if (fs.existsSync(TOKEN_PATH)) fs.unlinkSync(TOKEN_PATH);
+  } catch (_) {
+    // best-effort cleanup; never let teardown bookkeeping fail the run.
+  }
+}
 
 // rf2-wa3oo: PR-smoke vs nightly-full split. With `--smoke` (or
 // RF2_GATE_SMOKE=1) the gate runs only the scenarios tagged
@@ -85,6 +118,7 @@ const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
   paths: [IMPL_ROOT],
 });
 const cleanup = createHarnessCleanup();
+cleanup.addCleanup(removeOwnershipToken);
 cleanup.installSignalHandlers();
 
 function relPath(parts) {
@@ -357,7 +391,7 @@ function formatDiagnostics(diag) {
   return lines.join('\n');
 }
 
-async function runScenarios() {
+async function runScenarios(baseUrl) {
   const browser = await chromium.launch({ headless: true });
   cleanup.addCleanup(async () => {
     try {
@@ -391,7 +425,7 @@ async function runScenarios() {
         browserState.requestFailures.push(`${request.method()} ${request.url()} ${failure ? failure.errorText : ''}`);
       });
 
-      const fullUrl = scenario.url.startsWith('http') ? scenario.url : BASE_URL + scenario.url;
+      const fullUrl = scenario.url.startsWith('http') ? scenario.url : baseUrl + scenario.url;
       let passed = false;
       let failure = null;
       let diagnostics = null;
@@ -472,7 +506,46 @@ async function main() {
   compileSurfaces();
   stageSurfaces();
 
-  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(PORT), '-s', '-c-1'], {
+  // Escape hatch: a caller may point the gate at a server it manages
+  // itself (XRAY_FEATURE_GATE_BASE_URL). We cannot publish/verify an
+  // ownership token there, so we only probe for reachability — the
+  // caller owns the asset tree it points us at. The default path below
+  // is the hardened one.
+  if (EXTERNAL_BASE_URL) {
+    const externalPort = portFromBaseUrl(EXTERNAL_BASE_URL);
+    console.log(`Using externally-managed server at ${EXTERNAL_BASE_URL}.`);
+    const reachable = await waitForHttpReady(externalPort, Date.now() + READY_TIMEOUT_MS);
+    if (!reachable) {
+      throw new Error(`External server at ${EXTERNAL_BASE_URL} did not become reachable within ${READY_TIMEOUT_MS}ms.`);
+    }
+    return await runScenarios(EXTERNAL_BASE_URL.replace(/\/+$/, ''));
+  }
+
+  // Publish the per-run ownership token BEFORE spawning http-server so
+  // the sentinel is visible the moment the server starts serving
+  // OUT_ROOT (rf2-84gzw). Cleaned up unconditionally via the registered
+  // cleanup fn.
+  const token = writeOwnershipToken();
+  if (!token) {
+    throw new Error(`Staging root missing: ${OUT_ROOT}. Did staging run?`);
+  }
+
+  // Resolve the port: prefer XRAY_FEATURE_GATE_PORT (default 8037) when
+  // free, else fall back to an OS-chosen free port (rf2-84gzw). This
+  // stops the gate from either failing to bind or — worse — silently
+  // running against a stale/foreign listener already on the fixed port.
+  const port = await resolveServePort(PREFERRED_PORT, {
+    onFallback: (preferred, fallback) => {
+      console.warn(
+        `Preferred port ${preferred} is busy; falling back to free port ${fallback}. ` +
+          `Set XRAY_FEATURE_GATE_PORT to pin a specific port.`,
+      );
+    },
+  });
+  const baseUrl = `http://127.0.0.1:${port}`;
+  console.log(`Serving ${OUT_ROOT} on ${baseUrl}`);
+
+  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(port), '-s', '-c-1'], {
     cwd: IMPL_ROOT,
     stdio: ['ignore', 'inherit', 'inherit'],
   }));
@@ -485,14 +558,51 @@ async function main() {
     }
   });
 
-  const ready = await waitForHttpReady(PORT, Date.now() + READY_TIMEOUT_MS, {
+  // Readiness WITH ownership-token verification: refuse to run scenarios
+  // against any server on `port` that does not serve this run's token
+  // (rf2-84gzw).
+  const ready = await waitForOwnedHttpReady(port, token, Date.now() + READY_TIMEOUT_MS, {
     isAborted: () => serverDown,
   });
-  if (!ready || serverDown) {
-    throw new Error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
+  if (!ready.ok) {
+    if (ready.reason === 'child-exited' || serverDown) {
+      throw new Error(
+        `http-server exited before becoming reachable on :${port}. ` +
+          `Likely cause: port already in use or http-server failed to start.`,
+      );
+    }
+    if (ready.reason === 'token-mismatch') {
+      throw new Error(
+        `A server is reachable on :${port}, but its /${TOKEN_FILE_BASENAME} ` +
+          `does not match this run's ownership token. Refusing to run the Xray ` +
+          `feature gate against a server this harness did not launch ` +
+          `(got "${ready.got}", expected "${token}"). ` +
+          `Set XRAY_FEATURE_GATE_PORT to pin a different port if this is intentional.`,
+      );
+    }
+    if (ready.reason === 'token-never-served') {
+      throw new Error(
+        `http-server on :${port} became reachable but never served ` +
+          `/${TOKEN_FILE_BASENAME} within ${READY_TIMEOUT_MS}ms. ` +
+          `Staging root may be inconsistent.`,
+      );
+    }
+    throw new Error(`http-server did not become reachable on :${port} within ${READY_TIMEOUT_MS}ms.`);
   }
 
-  return await runScenarios();
+  return await runScenarios(baseUrl);
+}
+
+// Extract the TCP port from a base URL, defaulting to 80 (the gate only
+// ever speaks http:// to a local server, so a missing port means 80).
+function portFromBaseUrl(baseUrl) {
+  try {
+    const parsed = new URL(baseUrl);
+    if (parsed.port) return Number(parsed.port);
+    return parsed.protocol === 'https:' ? 443 : 80;
+  } catch (_) {
+    return PREFERRED_PORT;
+  }
 }
 
 main()


### PR DESCRIPTION
Two related local-browser-harness reliability fixes, both in `implementation/scripts/` (dev-only `.cjs`). They share the harness lifecycle so they ship together.

## rf2-84gzw — fixed port, no ownership verification

`serve-and-run-xray-feature-gate.cjs` bound a fixed port (`XRAY_FEATURE_GATE_PORT || 8037`) with **no** free-port fallback and **no** ownership check — `waitForHttpReady` resolved on *any* HTTP responder. A stale/foreign listener on 8037 made the gate either fail to bind or, worse, drive Playwright against the wrong asset tree (false-RED, or false-GREEN against a stale-but-compatible bundle). Every sibling orchestrator (`serve-and-run-browser-tests`, `check-story-static`) was already hardened; this one had been missed.

Fix (mirrors the hardened siblings):
- Resolve a **free port** — prefer `XRAY_FEATURE_GATE_PORT` (default 8037) when free, else fall back to an OS-chosen free port, logging the substitution.
- Publish a per-run **ownership token** (`/.rf-harness-token`) into the staging root the gate already owns, *before* spawning http-server.
- **Verify** the token before any scenario runs — refuse with a clear message on `token-mismatch` (foreign server), `token-never-served`, `child-exited`, or `timeout`.
- Thread the resolved base URL through to `runScenarios(baseUrl)`.
- `XRAY_FEATURE_GATE_BASE_URL` remains an escape hatch for an externally-managed server (reachability-probe only — we can't publish a token there).

## rf2-ogpeq — cleanupSync skips kills during in-flight async cleanup

`createHarnessCleanup` shared a single `cleaned` flag between async `cleanup()` and the sync `cleanupSync()` 'exit' handler. If `process.exit()` fired the 'exit' handler while `cleanup()` was mid-flight (cleaned already true, still awaiting `terminateProcessTree` on child N of M), `cleanupSync` saw `cleaned===true` and returned immediately. Node can't await in 'exit', so the abandoned async awaits never resume → remaining children orphaned.

Fix: split into two independent guards. `cleanupSync` **always** runs the synchronous child kill-sweep (idempotent — `terminateProcessTreeSync` no-ops on dead children via `hasExited`) regardless of async-cleanup state; the `addCleanup` fns still run at most once across both paths. Added an injectable terminator seam (`opts.terminateSync` / `opts.terminateAsync`, defaulting to the real killers) so the race is unit-testable deterministically without depending on real (multi-second, on Windows) `taskkill` latency.

Shared port/token primitives (`isPortFree`, `findFreePort`, `resolveServePort`, `fetchToken`, `waitForOwnedHttpReady`) now live in `lib/local-browser-harness.cjs` so the gate doesn't add a fourth copy. The two existing siblings keep their inline copies (out of scope).

## Quality gates

- `node scripts/_local-browser-harness.test.cjs` — **12 passed** (was 4; +8 new). New: free-port fallback when preferred busy; token-match ok; foreign-token refusal; tokenless-responder rejection; `cleanupSync` sweeps every child during in-flight async cleanup (verified to FAIL against the old single-flag design); `cleanupSync` terminates real child processes.
- `npm run test:script-helpers` — **all green** (browser-test-report 12, gate-report 4, local-browser-harness 12, read-release-bundle 19).
- `node --check` on both changed `.cjs` files — clean.
- No `.cjs` lint exists in the repo (no eslint/prettier config or devDep), so no lint gate applies.
- The full `npm run test:xray-feature-gate` runs a shadow-cljs compile + browser sweep (heavy/occasional, not a PR gate); the gate's port/token path is covered at unit level via the shared-lib helpers it now consumes.