### PR TITLE
fix(pair-mcp): redact sensitive app-db on epoch + subscription egress (rf2-6wvh5, rf2-f1ose)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -518,7 +518,7 @@
                                             :enum ["diff" "full"]}
                               :dedup knobs/dedup-property
                               :include-sensitive {:type "boolean"
-                                                   :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
+                                                   :description "Opt back in to forwarding `:sensitive? true` items. Default false. Also governs off-box record projection (rf2-6wvh5): default-false routes every egressed epoch through `re-frame.core/projected-record` — declared-sensitive `:db-*`/`:trigger-event`/`:trace-events` slots redact to `:rf/redacted`, declared-large slots elide to `:rf.size/large-elided`. `true` (honoured only when the server was launched with --allow-sensitive-reads) ships the raw records."}
                               :build {:type "string"}}
                  :additionalProperties false}})
 
@@ -565,7 +565,7 @@
                                             :enum ["diff" "full"]}
                               :dedup    knobs/dedup-property
                               :include-sensitive {:type "boolean"
-                                                   :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
+                                                   :description "Opt back in to forwarding `:sensitive? true` items. Default false. Also governs off-box record projection (rf2-6wvh5): default-false routes every egressed epoch through `re-frame.core/projected-record` — declared-sensitive `:db-*`/`:trigger-event`/`:trace-events` slots redact to `:rf/redacted`, declared-large slots elide to `:rf.size/large-elided`. `true` (honoured only when the server was launched with --allow-sensitive-reads) ships the raw records."}
                               :build    {:type "string"}}
                  :additionalProperties false}})
 
@@ -1061,7 +1061,10 @@
                  :properties {:frame          {:type "string"
                                                :description "Frame to read. Accepts bare names (\"rf/default\") or EDN-shaped strings (\":rf/default\"). Defaults to the operating frame; a multi-frame session with no selection -> :reason :ambiguous-frame."}
                               :include-values {:type "boolean"
-                                               :description "When true, each entry carries :value (current deref) and :ref-count alongside :query-v. Default false (query-vectors only — the cheap 'what's subscribed' read)."}
+                                               :description "When true, each entry carries :value (current deref) and :ref-count alongside :query-v. Default false (query-vectors only — the cheap 'what's subscribed' read). Each :value is run through the size-elision walker server-side before egress (rf2-f1ose): a value over a declared-sensitive app-db slot redacts to :rf/redacted, a declared-large value elides to :rf.size/large-elided, when the --allow-sensitive-reads gate is OFF."}
+                              :elision        knobs/elision-property
+                              :include-sensitive {:type "boolean"
+                                                   :description "Opt declared-sensitive sub `:value`s back in to raw egress (the walker's `:rf.size/include-sensitive?` opt). Default false; honoured only when the server was launched with --allow-sensitive-reads (rf2-f1ose)."}
                               :build          {:type "string"}}
                  :additionalProperties false}})
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_knobs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_knobs.cljs
@@ -62,14 +62,18 @@
 
 (def elision-property
   "Per-tool descriptor slot for the `:elision` opt-out (rf2-urjnc).
-  Applied to surfaces that surface `:app-db` slots (`snapshot` and
-  `get-path`) — the surfaces where a declared-`:large?` slot or an
-  over-threshold leaf can blow the wire cap on its own. Default
-  `true`."
+  Applied to the direct-read app-db surfaces: the `:app-db` slot readers
+  (`snapshot`, `get-path`) and `list-subscriptions :include-values`'
+  per-sub `:value` (rf2-f1ose) — surfaces where a declared-`:large?`
+  slot or a declared-`:sensitive?` leaf would otherwise ride off-box
+  verbatim. Default `true`. (The pull-mode epoch tools egress whole
+  records via `projected-record`, not this per-slot walker — they have
+  no `:elision` knob; their `:include-sensitive` arg governs projection
+  there.)"
   {:type        "boolean"
    :description (str "Apply the size-elision walker "
                      "(`re-frame.core/elide-wire-value`, rf2-v9tw2) "
-                     "to the `:app-db` slot server-side, before the "
+                     "to the egressed app-db value server-side, before the "
                      "EDN crosses the wire. Default true. "
                      "Schema-driven `:large? true` slots get "
                      "substituted with a "

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
@@ -31,6 +31,16 @@
     (rf2-vflrg).
   - `get-path` tool: the value at the requested path is run through
     the walker before pr-str.
+  - `list-subscriptions :include-values` tool: each sub-cache entry's
+    `:value` is run through the walker server-side (rf2-f1ose), mirroring
+    `snapshot`'s `:sub-cache` slice — the two read the same reactive
+    cache source, so both MUST redact alike off-box.
+
+  The pull-mode epoch tools (`trace-window` / `watch-epochs`) egress
+  whole `:rf/epoch-record`s, not bare app-db slices — they route
+  through `re-frame.core/projected-record` (the framework's single
+  normative off-box-egress emission site for epoch records; see
+  `re-frame2-pair-mcp.tools.epoch-egress`), NOT this per-slot walker.
 
   ## `:elision` MCP arg
 
@@ -92,3 +102,27 @@
   ([include-large? include-sensitive?]
    (pr-str {base-vocab/include-large-opt     (boolean include-large?)
             base-vocab/include-sensitive-opt (boolean include-sensitive?)})))
+
+(defn elide-sub-value-src
+  "CLJS source for a fn that walks ONE sub-cache entry's `:value` slot
+  through `re-frame.core/elide-wire-value` (rf2-f1ose).
+
+  Returns a source string for an anonymous fn `(fn [entry] ...)` that
+  runs `entry`'s `:value` (the subscription's current deref) through the
+  walker, leaving `:query-v` / `:ref-count` untouched. A subscription
+  whose value derives from a declared-sensitive app-db slot redacts to
+  `:rf/redacted`; a declared-large value elides to
+  `:rf.size/large-elided` — parity with `snapshot`'s `:sub-cache` slice,
+  which reads the SAME reactive cache source (so both redact alike).
+
+  `frame-edn` is the source for the `:frame` opt (a quoted keyword or a
+  runtime `current-frame` call) so the walker resolves the right
+  `[:rf/runtime :elision]` registry; `elision-opts` is the rendered
+  `elision-opts-edn` map threading the `--allow-sensitive-reads` gate
+  through `:rf.size/include-sensitive?`."
+  [frame-edn elision-opts]
+  (str "(fn [entry]"
+       "  (if (contains? entry :value)"
+       "    (let [opts (merge {:frame " frame-edn "} " elision-opts ")]"
+       "      (update entry :value (fn [v] (re-frame.core/elide-wire-value v opts))))"
+       "    entry))"))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/epoch_egress.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/epoch_egress.cljs
@@ -1,0 +1,82 @@
+(ns re-frame2-pair-mcp.tools.epoch-egress
+  "Off-box projection wrap for the pull-mode epoch tools (rf2-6wvh5).
+
+  `trace-window` and `watch-epochs` egress full epoch records — each
+  carrying `:db-before` / `:db-after` app-db snapshots (plus
+  `:trigger-event` / `:trace-events`) — over the MCP wire. Before
+  rf2-6wvh5 the page of records the runtime shipped rode the nREPL wire
+  verbatim: the `:epoch-vector` wire-pipeline arm
+  (`re-frame2-pair-mcp.tools.wire-pipeline`) only DROPS whole epochs
+  STAMPED `:rf.epoch/sensitive?` and then diff-encodes / dedups the rest
+  — none of which redact a declared-sensitive SLOT (e.g.
+  `[:auth :password]`) sitting inside `:db-before` / `:db-after`. So a
+  schema-declared `:sensitive?` slot rode off-box verbatim even with the
+  `--allow-sensitive-reads` gate OFF (the published default).
+
+  The framework forbids exactly this hand-walk. `re-frame.core`
+  (core.cljc §projected egress, rf2-mrsck) names `projected-record` /
+  `projected-history` the single normative off-box-egress emission site
+  and states that tools egressing the epoch ring MUST route through it
+  rather than walking `(epoch-history frame-id)` and re-wrapping by hand
+  — \"the hand-walk is one missed `mapv projected-record` away from
+  leaking un-elided data across the process boundary.\" Per Spec
+  Security.md §Epoch privacy posture.
+
+  ## What this ns does
+
+  It builds the server-side source that wraps the let-bound page of
+  records the tool egresses, routing each record through
+  `re-frame.core/projected-record`. The projection runs APP-SIDE inside
+  the eval form (where the frame's `[:rf/runtime :elision]` registry is
+  reachable, same as the snapshot / get-path / subscribe walkers), so
+  the records the MCP server receives already carry `:rf/redacted` /
+  `:rf.size/large-elided` markers in their payload slots.
+
+  ## Gate parity with snapshot / get-path / subscribe (rf2-c2dtu)
+
+  The `--allow-sensitive-reads` boot gate (`raw-state/raw-state-allowed?`)
+  governs whether a caller's `:include-sensitive true` is honoured. The
+  pull-mode epoch tools mirror the gate exactly:
+
+  - Gate OFF (default) — `include-sensitive` is forced false, so
+    `project?` is true: every egressed record is routed through
+    `projected-record` (off-box defaults — sensitive slots redact, large
+    slots elide). A hostile per-call `:include-sensitive true` cannot
+    talk an operator who did not pass `--allow-sensitive-reads` into
+    shipping raw state.
+  - Gate ON + caller opts in (`include-sensitive true`) — `project?` is
+    false: records ship raw, exactly as subscribe ships raw on the
+    operator's explicit opt-in. This is the operator's deliberate choice
+    to see verbatim state.
+
+  `projected-record` is the framework's single off-box-default emission
+  site — it carries hard `:include-sensitive? false` / `:include-large?
+  false` defaults and handles all four payload-bearing slots
+  (`:db-before`, `:db-after`, `:trigger-event`, `:trace-events`)
+  including the `:trace-events` per-event re-root (rf2-ta0y7). Using it
+  directly (rather than a per-slot `elide-wire-value` hand-walk) keeps
+  the projection single-sourced in the framework and removes the
+  \"one missed slot\" leak surface the core docstring warns about.")
+
+(defn project-page-src
+  "CLJS source that projects a let-bound vector of epoch records for
+  off-box egress. `page-sym` is the name of the let-bound page (a CLJS
+  symbol or string).
+
+  When `project?` is true (the gate-OFF / not-opted-in posture) the
+  emitted source maps each record through
+  `re-frame.core/projected-record` — sensitive payload slots land as
+  `:rf/redacted`, large slots as `:rf.size/large-elided`. When
+  `project?` is false (operator opted in via `--allow-sensitive-reads`
+  AND passed `:include-sensitive true`) the page passes through
+  verbatim — the raw-egress opt-in, mirroring subscribe's bare-drain
+  path.
+
+  `projected-record` returns `nil` for non-map input; the page is a
+  vector of epoch-record maps, so the `mapv` is total. The fn is a pure
+  data transform with no side effects."
+  [page-sym project?]
+  (let [p (name page-sym)]
+    (if project?
+      (str "(mapv re-frame.core/projected-record " p ")")
+      p)))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
@@ -52,10 +52,29 @@
   Returns `{:ok? true :frame <id> :count N :subs [<query-v> ...]}`
   (or, with `:include-values true`,
   `:subs [{:query-v <v> :value v :ref-count n} ...]`). Empty `:subs`
-  vector when nothing is subscribed in the frame."
+  vector when nothing is subscribed in the frame.
+
+  ## rf2-f1ose — `:include-values` egress redaction
+
+  `:include-values true` ships each subscription's current `:value`
+  (the deref) over the MCP wire. That value reads the SAME reactive
+  sub-cache source `snapshot`'s `:sub-cache` slice reads, and a sub
+  whose value derives from a declared-sensitive app-db slot would
+  otherwise ride off-box verbatim. The eval form wraps each entry's
+  `:value` through `re-frame.core/elide-wire-value` server-side — the
+  SAME redaction `snapshot` applies to its `:sub-cache` slice — so a
+  declared-sensitive value redacts to `:rf/redacted` and a declared-
+  large value elides to `:rf.size/large-elided` when the
+  `--allow-sensitive-reads` gate is OFF (the published-build default).
+  When the gate is ON, the per-call `:include-sensitive` arg wins and
+  raw values may pass — parity with snapshot / get-path / the epoch
+  tools. The cheap query-vectors-only read (`:include-values false`)
+  ships no values and needs no elision."
   (:require [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.args :as args]
+            [re-frame2-pair-mcp.tools.elision :as elision]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
 (defn list-subscriptions-tool [conn raw-args]
@@ -64,11 +83,48 @@
         ;; `:include-values` rides the shared bool-args accept-shape
         ;; contract (rf2-c4fmh) — `true` / `"true"` / `"yes"` / ... all
         ;; resolve; default false.
-        incl?    (args/parse-bool-arg raw-args :include-values)
+        incl-vals? (args/parse-bool-arg raw-args :include-values)
+        ;; rf2-f1ose — the `--allow-sensitive-reads` boot gate forces
+        ;; `:elision true` + `:include-sensitive false` when OFF (the
+        ;; default), mirroring snapshot / get-path. `incl-sensitive?`
+        ;; threads into the walker's `:rf.size/include-sensitive?` opt;
+        ;; `elision?` decides whether the server-side `:value` walk fires
+        ;; at all (a verbatim pass-through is only reachable when the
+        ;; operator opted in via `--allow-sensitive-reads` AND passed
+        ;; `:elision false`).
+        incl-sensitive? (if (raw-state/raw-state-allowed?)
+                          (args/parse-bool-arg raw-args :include-sensitive)
+                          false)
+        elision?        (if (raw-state/raw-state-allowed?)
+                          (args/parse-bool-arg raw-args :elision)
+                          true)
         opts     (cond-> {}
-                   frame (assoc :frame frame)
-                   incl? (assoc :include-values? true))
-        form     (ef/emit (ef/rt-call 'sub-cache-info opts))]
+                   frame      (assoc :frame frame)
+                   incl-vals? (assoc :include-values? true))
+        ;; Frame source for the elision walker's `:frame` opt — a quoted
+        ;; keyword when pinned, else the runtime's `current-frame`
+        ;; resolution (same shape get-path / the epoch tools use).
+        frame-edn     (if frame
+                        (pr-str frame)
+                        (ef/emit (ef/rt-call 'current-frame)))
+        elision-opts  (elision/elision-opts-edn (not elision?) incl-sensitive?)
+        base-call     (ef/emit (ef/rt-call 'sub-cache-info opts))
+        ;; rf2-f1ose — when values ride the wire AND the gate forces
+        ;; elision, map each `:subs` entry's `:value` through
+        ;; `elide-wire-value` server-side before the result ships. The
+        ;; query-vectors-only shape (`:include-values false`) carries no
+        ;; `:value` slots, so the wrap is skipped entirely there.
+        form     (if (and incl-vals? elision?)
+                   (ef/emit
+                     (ef/rt-let
+                       ['res (ef/rt-raw base-call)]
+                       (ef/rt-raw
+                         (str "(if (and (map? res) (vector? (:subs res)))"
+                              "  (update res :subs (fn [ss] (mapv "
+                              (elision/elide-sub-value-src frame-edn elision-opts)
+                              " ss)))"
+                              "  res)"))))
+                   base-call)]
     (probe/eval-after-runtime!
       conn build-id form :list-subscriptions-failed
       (fn [v] (wire/ok-text (if (map? v) v {:ok? true :subs []}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -29,6 +29,7 @@
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.cursor :as cursor]
             [re-frame2-pair-mcp.tools.dedup :as dedup]
+            [re-frame2-pair-mcp.tools.epoch-egress :as egress]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]))
 
 (defn trace-window-tool [conn raw-args]
@@ -41,10 +42,22 @@
         ;; the malformed `::rf/default`, matching no frame. Same fix
         ;; rf2-ldfnx applied to dispatch.
         frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
-        ;; rf2-c2dtu — the `--allow-sensitive-reads` boot gate forces
-        ;; `:include-sensitive false` when OFF (the default). rf2-p1qli:
-        ;; single intention-naming predicate `raw-state-allowed?`
+        ;; rf2-c2dtu / rf2-p1qli — the `--allow-sensitive-reads` boot gate
+        ;; forces `:include-sensitive false` when OFF (the default), via
+        ;; the single intention-naming predicate `raw-state-allowed?`
         ;; (positive sense — true when operator opted in at launch).
+        ;; rf2-6wvh5 — the
+        ;; pull-mode epoch ring egresses full epoch records carrying
+        ;; `:db-before` / `:db-after` (and `:trigger-event` /
+        ;; `:trace-events`) app-db snapshots; before rf2-6wvh5 they rode
+        ;; the wire verbatim, leaking a declared-sensitive / declared-
+        ;; large slot. The fix routes each egressed record through
+        ;; `re-frame.core/projected-record` — the framework's SINGLE
+        ;; normative off-box-egress emission site (Security.md §Epoch
+        ;; privacy posture; core.cljc names the hand-walk an anti-pattern
+        ;; "one missed `mapv projected-record` away from a leak"). When
+        ;; `incl?` is true (only reachable gate-ON + explicit opt-in) the
+        ;; records ship raw, mirroring subscribe's bare-drain opt-in.
         incl?     (if (raw-state/raw-state-allowed?)
                     (args/parse-bool-arg raw-args :include-sensitive)
                     false)
@@ -69,6 +82,15 @@
             history-call (if sticky-frame
                            (ef/rt-call 'epoch-history sticky-frame)
                            (ef/rt-call 'epoch-history))
+            ;; rf2-6wvh5 — the egress slice (`page`) is the ONLY vector
+            ;; that crosses the wire, so projection happens HERE, after
+            ;; the cursor `:limit` cap, before the records ship. Each
+            ;; record routes through `re-frame.core/projected-record`
+            ;; (which reads `:frame` off the record itself and elides all
+            ;; four payload slots) unless the operator opted in to raw
+            ;; egress (`incl?` — gate-ON + `:include-sensitive true`).
+            project?       (not incl?)
+            page-src       (str "(vec (take " limit " filtered))")
             form (ef/emit
                    (ef/rt-let
                      ['hist      (ef/rt-raw (str "(vec " (ef/emit history-call) ")"))
@@ -84,7 +106,14 @@
                                    (str "(filterv #(and (>= (or (:committed-at %) 0) " cutoff-ms ")"
                                         "                (<= (or (:committed-at %) 0) " until-ms "))"
                                         " sliced)"))
-                      'page      (ef/rt-raw (str "(vec (take " limit " filtered))"))
+                      ;; rf2-6wvh5 — `:page` is the egress slice, projected
+                      ;; for off-box egress via `projected-record` (each
+                      ;; record's `:db-before` / `:db-after` /
+                      ;; `:trigger-event` / `:trace-events` slots elide
+                      ;; server-side). `:epoch-id` is a bookkeeping slot
+                      ;; the projection preserves, so `next-id`'s
+                      ;; `(:epoch-id (last page))` still resolves.
+                      'page      (ef/rt-raw (egress/project-page-src page-src project?))
                       'next-id   (ef/rt-raw
                                    "(when (< (count page) (count filtered)) (:epoch-id (last page)))")]
                      (ef/rt-raw

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -34,6 +34,7 @@
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.cursor :as cursor]
             [re-frame2-pair-mcp.tools.dedup :as dedup]
+            [re-frame2-pair-mcp.tools.epoch-egress :as egress]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]))
 
 (defn watch-epochs-tool [conn raw-args]
@@ -44,10 +45,19 @@
         ;; Same fix rf2-ldfnx applied to dispatch.
         frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         since-id  (wire/arg raw-args :since-id)
-        ;; rf2-c2dtu — the `--allow-sensitive-reads` boot gate forces
-        ;; `:include-sensitive false` when OFF (the default). rf2-p1qli:
-        ;; single intention-naming predicate `raw-state-allowed?`
+        ;; rf2-c2dtu / rf2-p1qli — the `--allow-sensitive-reads` boot gate
+        ;; forces `:include-sensitive false` when OFF (the default), via
+        ;; the single intention-naming predicate `raw-state-allowed?`
         ;; (positive sense — true when operator opted in at launch).
+        ;; rf2-6wvh5 — Pull-mode
+        ;; `watch-epochs` egresses full epoch records carrying
+        ;; `:db-before` / `:db-after` (and `:trigger-event` /
+        ;; `:trace-events`) app-db snapshots; before rf2-6wvh5 they rode
+        ;; the wire verbatim. The fix routes each egressed record through
+        ;; `re-frame.core/projected-record` — the framework's single
+        ;; normative off-box-egress emission site (Security.md §Epoch
+        ;; privacy posture). When `incl?` is true (gate-ON + explicit
+        ;; opt-in) the records ship raw, mirroring subscribe's bare-drain.
         incl?     (if (raw-state/raw-state-allowed?)
                     (args/parse-bool-arg raw-args :include-sensitive)
                     false)
@@ -75,11 +85,17 @@
             history-call (if sticky-frame
                            (ef/rt-call 'epoch-history sticky-frame)
                            (ef/rt-call 'epoch-history))
+            ;; rf2-6wvh5 — the `:pred` filter runs on the RAW records
+            ;; server-side (never egressed); the capped `:page` is the
+            ;; egress slice, projected via `projected-record` for off-box
+            ;; egress unless the operator opted in to raw (`incl?`).
+            project?       (not incl?)
+            page-src       (str "(vec (take " limit " matches))")
             form (ef/emit
                    (ef/rt-let
                      ['r             epochs-since-call
                       'matches       (ef/rt-raw matches-form)
-                      'page          (ef/rt-raw (str "(vec (take " limit " matches))"))
+                      'page          (ef/rt-raw (egress/project-page-src page-src project?))
                       'next-id       (ef/rt-raw
                                        "(when (< (count page) (count matches)) (:epoch-id (last page)))")
                       ;; rf2-fb4hn: history-count surfaces the

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/egress_elision_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/egress_elision_test.cljs
@@ -1,0 +1,305 @@
+(ns re-frame2-pair-mcp.egress-elision-test
+  "Regression tests for the app-db egress-redaction fixes (rf2-6wvh5 +
+  rf2-f1ose) — same privacy class, shared fix.
+
+  ## The bugs
+
+  Two pull-mode tools shipped raw slices of a live app's state off-box,
+  bypassing the redaction that snapshot / get-path / the `:epoch`
+  subscribe drain already route through:
+
+    - rf2-6wvh5: `trace-window` / `watch-epochs` egress whole epoch
+      records carrying `:db-before` / `:db-after` (and `:trigger-event`
+      / `:trace-events`) app-db snapshots — a declared-sensitive slot
+      rode off-box verbatim because the pull-mode ring was never routed
+      through the framework's `re-frame.core/projected-record` egress
+      projection (the single normative off-box-egress emission site for
+      epoch records; core.cljc names the per-slot hand-walk an
+      anti-pattern \"one missed `mapv projected-record` away from a
+      leak\").
+    - rf2-f1ose: `list-subscriptions :include-values` ships each sub's
+      current `:value` (deref) raw — a value over a declared-sensitive
+      app-db slot leaked the same way. A sub-cache value is NOT an
+      epoch record, so its egress routes through the same
+      `re-frame.core/elide-wire-value` walker `snapshot`'s `:sub-cache`
+      slice uses (the two read the same reactive cache source).
+
+  ## What these tests pin
+
+  The redaction runs SERVER-SIDE inside the eval form the tool ships
+  over nREPL — `projected-record` / `elide-wire-value` read the live
+  `[:rf/runtime :elision]` registry, which only exists app-side. A unit
+  test can't run them (no live app), so — mirroring the discipline
+  `subscribe_test.cljs` uses for `drain-form` — these tests assert the
+  FORM-LEVEL contract: with the `--allow-sensitive-reads` gate OFF (the
+  published-build default), the epoch eval forms map the egress page
+  through `re-frame.core/projected-record`, and the list-subscriptions
+  eval form wraps each sub `:value` through `re-frame.core/elide-wire-value`
+  with `:rf.size/include-sensitive? false`; with the gate ON and
+  `:include-sensitive true`, the records ship raw (no projection) and the
+  sub-value walker threads `:rf.size/include-sensitive? true`.
+
+  Plus an end-to-end shape check via the stub harness: an
+  already-redacted record (what the live projection would produce)
+  survives the client-side wire-pipeline with its `:rf/redacted`
+  sentinel intact.
+
+  Live end-to-end coverage (a real shadow-cljs runtime running the
+  projection) is the cross-server conformance harness's job; the
+  framework conformance file `epoch_mcp_egress_conformance_test.clj`
+  pins `projected-record`'s semantics directly."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [clojure.string :as str]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
+            [re-frame2-pair-mcp.tools.trace-window :as tw]
+            [re-frame2-pair-mcp.tools.watch-epochs :as we]
+            [re-frame2-pair-mcp.tools.list-subscriptions :as ls]))
+
+;; ---------------------------------------------------------------------------
+;; Gate state is process-global (an atom in raw-state.cljs). Reset to the
+;; published-build default (OFF) after every test so ordering can't leak.
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  {:after (fn [] (raw-state/set-allow-raw-state! false))})
+
+;; ---------------------------------------------------------------------------
+;; Form-capturing stub. The probe form (substring `__re_frame2_pair_runtime`)
+;; resolves truthy so `ensure-runtime!` passes; `configure-raw-state!` (the
+;; raw-state signal) resolves nil; every other eval form is the tool's
+;; SLICE form — captured into `forms` and answered with `canned`.
+;; ---------------------------------------------------------------------------
+
+(defn- with-capture!
+  "Run `body-fn` with a stub `cljs-eval-value` that captures every
+  non-probe / non-signal form into the `forms` atom and answers the
+  slice form with `canned`. Returns the Promise from `body-fn`."
+  [forms canned body-fn]
+  (let [orig nrepl/cljs-eval-value
+        answer (fn [form-str]
+                 (cond
+                   (str/includes? form-str "__re_frame2_pair_runtime")
+                   (js/Promise.resolve true)
+
+                   (str/includes? form-str "configure-raw-state!")
+                   (js/Promise.resolve nil)
+
+                   :else
+                   (do (swap! forms conj form-str)
+                       (js/Promise.resolve canned))))
+        stub (fn
+               ([_conn _build-id form-str]       (answer form-str))
+               ([_conn _build-id form-str _opts] (answer form-str)))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+(defn- slice-form
+  "The first captured non-probe/non-signal form — the slice eval the
+  tool ships to read + redact the egress payload."
+  [forms]
+  (first @forms))
+
+;; The slice form for the epoch tools — runtime returns a ready map for
+;; trace-window's let-body / watch-epochs' epochs-since wrapper. Shape is
+;; irrelevant to the form-contract assertions (we read the captured form,
+;; not the response); we hand back an empty-ish epoch result so the tool
+;; resolves cleanly.
+(def ^:private epoch-canned
+  {:epochs        []
+   :matches       []
+   :id-aged-out?  false
+   :requested-id  nil
+   :head-id       nil
+   :next-id       nil
+   :history-count 0
+   :since-count   0
+   :remaining     0})
+
+;; ===========================================================================
+;; rf2-6wvh5 — trace-window epoch :db-* egress
+;; ===========================================================================
+
+(deftest trace-window-gate-off-projects-records
+  (testing "gate OFF (default): the slice form maps the egress page through projected-record"
+    (async done
+      (raw-state/set-allow-raw-state! false)
+      (let [forms (atom [])]
+        (-> (with-capture! forms epoch-canned
+              (fn [] (tw/trace-window-tool nil (tu/args->js {:ms 1000}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (some? form) "the tool shipped a slice eval form")
+                       (is (str/includes? form "re-frame.core/projected-record")
+                           "gate-off MUST route the egress page through projected-record")
+                       (is (str/includes? form "mapv re-frame.core/projected-record")
+                           "every record in the page is projected")
+                       (done)))))))))
+
+(deftest trace-window-gate-on-include-sensitive-ships-raw
+  (testing "gate ON + include-sensitive true: NO projection — records ship raw (operator opted in)"
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms epoch-canned
+              (fn [] (tw/trace-window-tool nil (tu/args->js {:ms 1000 :include-sensitive true}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (not (str/includes? form "projected-record"))
+                           "gate-on + include-sensitive true bypasses projection — raw egress")
+                       (done)))))))))
+
+(deftest trace-window-gate-on-default-still-projects
+  (testing "gate ON but include-sensitive omitted (default false): records STILL projected"
+    ;; The opt-in is two-key: launch flag AND per-call include-sensitive.
+    ;; The flag alone does not flip the per-call default — a forgetful
+    ;; caller still gets redaction.
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms epoch-canned
+              (fn [] (tw/trace-window-tool nil (tu/args->js {:ms 1000}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (str/includes? form "re-frame.core/projected-record")
+                           "gate-on alone (no per-call opt-in) still projects — fail-safe default")
+                       (done)))))))))
+
+;; ===========================================================================
+;; rf2-6wvh5 — watch-epochs epoch record egress
+;; ===========================================================================
+
+(deftest watch-epochs-gate-off-projects-records
+  (testing "gate OFF (default): watch-epochs maps the matched-page through projected-record"
+    (async done
+      (raw-state/set-allow-raw-state! false)
+      (let [forms (atom [])]
+        (-> (with-capture! forms epoch-canned
+              (fn [] (we/watch-epochs-tool nil (tu/args->js {:pred {:event-id :auth/sign-in}}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (str/includes? form "mapv re-frame.core/projected-record")
+                           "gate-off MUST route the egress page through projected-record")
+                       (done)))))))))
+
+(deftest watch-epochs-gate-on-include-sensitive-ships-raw
+  (testing "gate ON + include-sensitive true: NO projection — raw records ship"
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms epoch-canned
+              (fn [] (we/watch-epochs-tool nil (tu/args->js {:include-sensitive true}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (not (str/includes? form "projected-record"))
+                           "gate-on + include-sensitive true ⇒ raw passes")
+                       (done)))))))))
+
+;; ===========================================================================
+;; rf2-f1ose — list-subscriptions :include-values sub :value egress
+;; ===========================================================================
+
+(def ^:private sub-cache-canned
+  {:ok?   true
+   :frame :rf/default
+   :count 1
+   :subs  [{:query-v ["auth-token"] :value "raw-from-runtime" :ref-count 1}]})
+
+(deftest list-subscriptions-gate-off-elides-values
+  (testing "gate OFF + include-values: the slice form wraps each sub :value through elide-wire-value, redacting"
+    (async done
+      (raw-state/set-allow-raw-state! false)
+      (let [forms (atom [])]
+        (-> (with-capture! forms sub-cache-canned
+              (fn [] (ls/list-subscriptions-tool nil (tu/args->js {:include-values true}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (str/includes? form "re-frame.core/elide-wire-value")
+                           "gate-off + include-values MUST route each sub :value through the walker")
+                       (is (str/includes? form ":value")
+                           "the per-sub :value slot is the elision target")
+                       (is (str/includes? form ":rf.size/include-sensitive? false")
+                           "gate-off forces include-sensitive? false ⇒ sensitive sub values redact")
+                       (done)))))))))
+
+(deftest list-subscriptions-no-include-values-no-elision-wrap
+  (testing "include-values FALSE (default): query-vectors only — no :value ships, so no walker wrap"
+    (async done
+      (raw-state/set-allow-raw-state! false)
+      (let [forms (atom [])]
+        (-> (with-capture! forms {:ok? true :frame :rf/default :count 0 :subs []}
+              (fn [] (ls/list-subscriptions-tool nil (tu/args->js {}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (not (str/includes? form "re-frame.core/elide-wire-value"))
+                           "no values egress ⇒ no elision wrap (the cheap what's-subscribed read)")
+                       (is (str/includes? form "sub-cache-info")
+                           "still routes through the reactive sub-cache reader")
+                       (done)))))))))
+
+(deftest list-subscriptions-gate-on-include-sensitive-passes-raw
+  (testing "gate ON + include-values + include-sensitive true: walker passes declared-sensitive values raw"
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms sub-cache-canned
+              (fn [] (ls/list-subscriptions-tool
+                       nil (tu/args->js {:include-values true :include-sensitive true}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (str/includes? form ":rf.size/include-sensitive? true")
+                           "gate-on + include-sensitive true ⇒ declared-sensitive sub values pass raw")
+                       (done)))))))))
+
+(deftest list-subscriptions-gate-on-elision-false-ships-bare
+  (testing "gate ON + include-values + elision false: NO walker wrap — raw values ship"
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms sub-cache-canned
+              (fn [] (ls/list-subscriptions-tool
+                       nil (tu/args->js {:include-values true :elision false}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (not (str/includes? form "re-frame.core/elide-wire-value"))
+                           "gate-on + elision false bypasses the walker — raw value egress")
+                       (done)))))))))
+
+;; ===========================================================================
+;; End-to-end shape — an already-redacted record (what the live walker
+;; produces) survives the client wire-pipeline with the sentinel intact.
+;; ===========================================================================
+
+(deftest trace-window-preserves-redacted-sentinel-through-pipeline
+  (testing "a :db-after carrying :rf/redacted (post-walker) survives diff-encode/dedup to the wire"
+    (async done
+      (raw-state/set-allow-raw-state! false)
+      (let [;; What the live walker would hand back: the sensitive slot
+            ;; is already the :rf/redacted sentinel.
+            redacted-rec {:epoch-id    :e1
+                          :event-id    :auth/sign-in
+                          :committed-at 100
+                          :db-before   {:auth {:password :rf/redacted}}
+                          :db-after    {:auth {:password :rf/redacted}}}
+            canned       (assoc epoch-canned
+                                :epochs [redacted-rec]
+                                :head-id :e1
+                                :history-count 1)
+            forms        (atom [])]
+        (-> (with-capture! forms canned
+              ;; :epochs-mode full so :db-after isn't diff-collapsed —
+              ;; we want to read the sentinel straight off the wire.
+              (fn [] (tw/trace-window-tool
+                       nil (tu/args->js {:ms 60000 :epochs-mode "full" :dedup false}))))
+            (.then (fn [result]
+                     (let [edn    (tu/extract-edn result)
+                           epoch  (first (:epochs edn))]
+                       (is (true? (:ok? edn)))
+                       (is (= 1 (:count edn)))
+                       (is (= :rf/redacted (get-in epoch [:db-after :auth :password]))
+                           "the redacted sentinel rides the wire — no raw secret")
+                       (is (= :rf/redacted (get-in epoch [:db-before :auth :password])))
+                       (done)))))))))


### PR DESCRIPTION
## What

Two pull-mode pair-mcp tools shipped raw slices of a live app's state off-box, bypassing the redaction the `snapshot` / `get-path` / `:epoch` subscribe-drain surfaces already apply. Both leak at the AI/MCP boundary when `--allow-sensitive-reads` is OFF (the published-build default). Same privacy class, shared fix.

### rf2-6wvh5 — epoch `:db-*` egress (HIGH)
`trace-window` / `watch-epochs` egress whole `:rf/epoch-record`s carrying `:db-before` / `:db-after` (and `:trigger-event` / `:trace-events`) app-db snapshots. The egress page now routes through **`re-frame.core/projected-record`** — the framework's single normative off-box-egress emission site for epoch records (Security.md §Epoch privacy posture; `core.cljc` names the per-slot hand-walk an anti-pattern *"one missed `mapv projected-record` away from a leak"*). `projected-record` elides all four payload slots with hard off-box defaults. Gate-ON + `:include-sensitive true` ships raw (operator's explicit opt-in, mirroring subscribe's bare-drain). Shared emitter in the new `tools.epoch-egress` ns, consumed by both tools.

### rf2-f1ose — sub-cache `:value` egress (MEDIUM-HIGH)
`list-subscriptions :include-values` ships each sub's current `:value` (deref). A sub-cache value isn't an epoch record, so it routes through the same **`re-frame.core/elide-wire-value`** walker `snapshot`'s `:sub-cache` slice uses — the two read the same reactive cache source, so both redact alike. Gated identically: gate-OFF forces the walk with `:rf.size/include-sensitive? false`; gate-ON honours the per-call opt-in.

## Why two redaction surfaces, not one
Epoch records have a dedicated framework projection (`projected-record`) that the spec MANDATES tools route through; it covers slots a per-slot `elide-wire-value` hand-walk would miss (`:trigger-event`, `:trace-events`). Sub-cache values are direct reads, so they use the same `elide-wire-value` surface as `snapshot :sub-cache`. Both honour the `--allow-sensitive-reads` gate identically.

## Tests
New `egress_elision_test.cljs` — form-level contract (mirroring `subscribe_test.cljs`'s `drain-form` discipline): gate-OFF maps the epoch page through `projected-record` and wraps each sub `:value` through `elide-wire-value` with `include-sensitive? false`; gate-ON + opt-in ships raw. Plus an end-to-end shape check that an already-projected record's `:rf/redacted` sentinel survives the client wire-pipeline. **Verified failing-before / passing-after** (7 form-contract assertions fail with the fix reverted).

## Gates
- pair-mcp `:server-test`: **741 tests / 2099 assertions, 0 failures, 0 errors**
- `npm run test:mcp-conformance`: **all 6 gates GREEN** (incl. re-frame2-pair-mcp end-to-end SDK Client driver + production `server.js` bundle compile; wire-vocab 49 tests / 623 assertions)
- clj-kondo on changed files: **0 errors, 0 new warnings** (the 2 `descriptors_data` unused-private-var warnings pre-exist on `origin/main`)

Closes rf2-6wvh5, rf2-f1ose.