### PR TITLE
fix(adapters/reagent-slim): SSR style-string appends px to length values + omits nil decls (react-dom/server parity) (rf2-9nyg6)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -839,6 +839,14 @@ Lift the existing implementation from `re-frame.ssr/escape-html` (`ssr.cljc:50-5
 
 The same narrowed `convert-prop-value` rules apply (per S3-005): the static-markup path stringifies keyword values only for HTML-attribute names. (Inside an HTML attribute serialisation, every prop name IS by definition an HTML attribute name — this layer doesn't see React-component props, only DOM-element attrs.)
 
+**Inline-style value serialisation (`emit-style-attr` / `style-string`)** must match `react-dom/server.renderToStaticMarkup`'s `pushStyleAttribute` (rf2-9nyg6):
+
+- A *numeric* value gets a `px` suffix unless the value is `0` or the property is in React's `unitlessNumber` set (`flex`, `flex-grow`, `z-index`, `opacity`, `line-height`, `font-weight`, `order`, the vendor-prefixed entries, …). `{:width 10}` → `width:10px`; `{:flex-grow 1}` → `flex-grow:1`. The `unitless-style-props` set in `reagent2.dom.server` mirrors React 19.2.0's set verbatim — keyed on the *camelCase* property name (the same form the React-element path hands React via `cached-prop-name`), so the hiccup key is camelCased before the lookup, then converted to the kebab CSS name with React's own rule (`([A-Z]) → -$1`, lower-case, `^ms- → -ms-`).
+- An entry whose value is `nil`, a boolean, or `""` is **omitted entirely** (no empty `prop:` declaration).
+- CSS custom properties (`--foo`) are emitted name-and-value verbatim with no `px` logic. (The React-element path's `kv-conv` camelCases all style keys, so it does not itself round-trip `--foo`; the static-markup path handles them directly.)
+
+These rules are pinned by `parity_cljs_test.cljs` against `react-dom/server` (numeric→px, unitless→bare, zero→bare, nil→omitted, string→untouched) per §8.7.
+
 ### §8.4 Boolean attributes + void-tag handling
 
 Boolean attributes (`disabled`, `checked`, `selected`, `readOnly`, `required`, etc.): if `true`, emit just the name (HTML5 short form). If `false`, omit entirely. The list of recognised boolean attributes is a static set:

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -179,11 +179,104 @@
         (symbol? x))      (name x)
     :else                 (str x)))
 
+;; ---------------------------------------------------------------------------
+;; Inline-style serialisation (rf2-9nyg6)
+;;
+;; `react-dom/server.renderToStaticMarkup` serialises a `style` object via
+;; its internal `pushStyleAttribute`. Two behaviours of that path are NOT
+;; captured by a naive `(str k ":" v)` join, and the divergence produces
+;; invalid CSS:
+;;
+;;   1. NUMERIC px SUFFIX. React appends `px` to a *numeric* value unless
+;;      the value is `0` or the property is in its `unitlessNumber` set
+;;      (`flex`, `z-index`, `opacity`, `line-height`, `font-weight`,
+;;      `order`, …). So `{:width 10}` → `width:10px`, but `{:flex-grow 1}`
+;;      → `flex-grow:1` (no `px`). A bare `width:10` is invalid/ignored CSS.
+;;
+;;   2. NIL / BOOLEAN / EMPTY ENTRIES OMITTED. React skips an entry whose
+;;      value is `null`, a boolean, or `""`. The naive join instead emits
+;;      an empty declaration `color:` for `{:color nil}`.
+;;
+;; The unitless-property set below mirrors React 19.2.0's `unitlessNumber`
+;; Set *exactly* (vendor-prefixed entries included). React keys that set on
+;; the *camelCase* style name (`flexGrow`, `zIndex`, `MozBoxFlex`, …) — the
+;; same form the React-element path hands React via `kv-conv`/
+;; `cached-prop-name`. So we camelCase the hiccup key through
+;; `template/cached-prop-name` (the in-artefact transform that path uses)
+;; before the unitless lookup, then convert that camelCase name to the
+;; kebab CSS name with React's own rule (`([A-Z]) → -$1`, lower-case,
+;; `^ms- → -ms-`). Custom properties (`--foo`) are passed through verbatim
+;; with no `px` logic, matching React.
+;; ---------------------------------------------------------------------------
+
+(def ^:private unitless-style-props
+  "camelCase style-property names that take a bare numeric value (no
+  `px` suffix). Mirrors React 19.2.0's `unitlessNumber` Set verbatim,
+  including vendor-prefixed entries."
+  #{"animationIterationCount" "aspectRatio" "borderImageOutset"
+    "borderImageSlice" "borderImageWidth" "boxFlex" "boxFlexGroup"
+    "boxOrdinalGroup" "columnCount" "columns" "flex" "flexGrow"
+    "flexPositive" "flexShrink" "flexNegative" "flexOrder" "gridArea"
+    "gridRow" "gridRowEnd" "gridRowSpan" "gridRowStart" "gridColumn"
+    "gridColumnEnd" "gridColumnSpan" "gridColumnStart" "fontWeight"
+    "lineClamp" "lineHeight" "opacity" "order" "orphans" "scale"
+    "tabSize" "widows" "zIndex" "zoom" "fillOpacity" "floodOpacity"
+    "stopOpacity" "strokeDasharray" "strokeDashoffset" "strokeMiterlimit"
+    "strokeOpacity" "strokeWidth" "MozAnimationIterationCount" "MozBoxFlex"
+    "MozBoxFlexGroup" "MozLineClamp" "msAnimationIterationCount" "msFlex"
+    "msZoom" "msFlexGrow" "msFlexNegative" "msFlexOrder" "msFlexPositive"
+    "msFlexShrink" "msGridColumn" "msGridColumnSpan" "msGridRow"
+    "msGridRowSpan" "WebkitAnimationIterationCount" "WebkitBoxFlex"
+    "WebKitBoxFlexGroup" "WebkitBoxOrdinalGroup" "WebkitColumnCount"
+    "WebkitColumns" "WebkitFlex" "WebkitFlexGrow" "WebkitFlexPositive"
+    "WebkitFlexShrink" "WebkitLineClamp"})
+
+(def ^:private camel-boundary
+  "Match an upper-case char to insert a `-` before — React's
+  `uppercasePattern` (`/([A-Z])/g`)."
+  (js/RegExp. "([A-Z])" "g"))
+
+(defn- camel->css-name
+  "camelCase style-property name → kebab CSS name, matching React's
+  `pushStyleAttribute` conversion: insert `-` before each upper-case
+  char, lower-case, then `^ms- → -ms-` (so `msFlex` → `-ms-flex`)."
+  [camel]
+  (-> camel
+      (str/replace camel-boundary "-$1")
+      (str/lower-case)
+      (str/replace #"^ms-" "-ms-")))
+
+(defn- style-value->str
+  "Serialise one style value to its CSS string, applying React's `px`
+  rule for numbers. `camel` is the camelCase property name (the
+  unitless-lookup key). Numeric values get a `px` suffix unless the
+  value is `0` or the property is unitless."
+  [camel v]
+  (if (number? v)
+    (if (or (zero? v) (contains? unitless-style-props camel))
+      (str v)
+      (str v "px"))
+    (named->str v)))
+
 (defn- style-string
-  "Serialise a style map to an HTML inline-style string."
+  "Serialise a style map to an HTML inline-style string, matching
+  `react-dom/server.renderToStaticMarkup`'s `pushStyleAttribute`:
+  numeric values of non-unitless properties get a `px` suffix; entries
+  whose value is nil / boolean / empty-string are omitted; custom
+  properties (`--foo`) pass through verbatim."
   [m]
   (->> m
-       (map (fn [[k v]] (str (named->str k) ":" (named->str v))))
+       (keep (fn [[k v]]
+               (when (and (some? v)
+                          (not (boolean? v))
+                          (not= "" v))
+                 (let [raw (named->str k)]
+                   (if (str/starts-with? raw "--")
+                     ;; CSS custom property: name + value verbatim, no px.
+                     (str raw ":" (named->str v))
+                     (let [camel    (template/cached-prop-name k)
+                           css-name (camel->css-name camel)]
+                       (str css-name ":" (style-value->str camel v))))))))
        (str/join ";")))
 
 (defn- attr-value-string

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
@@ -255,3 +255,59 @@
   (testing ":div#bar.foo shorthand"
     (let [[a b] (=parity [:div#bar.foo "x"])]
       (is (= a b)))))
+
+;; ---------------------------------------------------------------------------
+;; Inline-style serialisation (rf2-9nyg6)
+;;
+;; `react-dom/server.renderToStaticMarkup` appends `px` to numeric values
+;; of non-unitless CSS properties, keeps unitless properties bare, and
+;; omits entries whose value is nil/boolean/empty. The pure-CLJS rewrite
+;; must match. The =parity assertions below pin against react-dom/server;
+;; the explicit-string assertions document the target output independently
+;; of the React reference so a future React change is easy to spot.
+;; ---------------------------------------------------------------------------
+
+(deftest parity-style-numeric-px
+  (testing "numeric px-property values render with px"
+    (let [[a b] (=parity [:div {:style {:width 10 :height 20}}])]
+      (is (= a b)))
+    (is (= "<div style=\"width:10px;height:20px\"></div>"
+           (via-rewrite [:div {:style {:width 10 :height 20}}])))))
+
+(deftest parity-style-unitless-bare
+  (testing "unitless properties render bare (no px)"
+    (let [[a b] (=parity [:div {:style {:flex-grow 1 :z-index 5 :opacity 0.5}}])]
+      (is (= a b)))
+    (is (= "<div style=\"flex-grow:1;z-index:5;opacity:0.5\"></div>"
+           (via-rewrite [:div {:style {:flex-grow 1 :z-index 5 :opacity 0.5}}])))))
+
+(deftest parity-style-zero-no-px
+  (testing "numeric zero never gets px (matches React)"
+    (let [[a b] (=parity [:div {:style {:width 0}}])]
+      (is (= a b)))
+    (is (= "<div style=\"width:0\"></div>"
+           (via-rewrite [:div {:style {:width 0}}])))))
+
+(deftest parity-style-nil-omitted
+  (testing "nil-valued style entry is omitted entirely"
+    (let [[a b] (=parity [:div {:style {:color nil :width 10}}])]
+      (is (= a b)))
+    (is (= "<div style=\"width:10px\"></div>"
+           (via-rewrite [:div {:style {:color nil :width 10}}])))))
+
+(deftest parity-style-string-value-untouched
+  (testing "string values pass through (px in the string is preserved)"
+    (let [[a b] (=parity [:div {:style {:width "10em" :color "red"}}])]
+      (is (= a b)))
+    (is (= "<div style=\"width:10em;color:red\"></div>"
+           (via-rewrite [:div {:style {:width "10em" :color "red"}}])))))
+
+(deftest style-custom-property-verbatim
+  (testing "CSS custom property (--foo) passes through verbatim, no px"
+    ;; Direct (non-parity) assertion: the React-element path's `kv-conv`
+    ;; camelCases every style key (incl. `--foo` → `Foo`), so it can't
+    ;; serve as a custom-property reference. The rewrite's standalone
+    ;; behaviour (verbatim name, no px) matches React's `pushStyleAttribute`
+    ;; custom-property branch.
+    (is (= "<div style=\"--gap:8\"></div>"
+           (via-rewrite [:div {:style {:--gap 8}}])))))


### PR DESCRIPTION
@-