### PR TITLE
feat(story/xray): inline event spine in the Story RHS Xray embed for in-place past-event navigation (rf2-9k43e)

### DIFF
--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -257,7 +257,7 @@ The RHS stacks four regions vertically:
    the contract between Story (the host) and Xray (the panel
    provider).
 
-   The region renders three things:
+   The region renders four things:
 
    - **Chip-row picker.** A horizontal strip of chips
      `[Event] [App-db] [Views] [Trace] [Machines] [Routing] [Issues]`
@@ -270,6 +270,30 @@ The RHS stacks four regions vertically:
      chip — clicking it opens the full Xray 4-layer shell in a
      second window via `day8.re-frame2-xray.mount/popout!`, the
      escape hatch for the chrome the per-panel embed elides.
+   - **Event spine band (rf2-9k43e).** A COMPACT, clickable
+     recent-events spine sitting BETWEEN the chip-row and the panel
+     host (`<div data-test="story-xray-spine-band">`). It hosts the
+     SAME `shell/event-list` L2 component the full Xray shell
+     composes — via Xray's `panels/mount-event-spine!` (see
+     [`tools/xray/spec/008-Embedding-Contract.md`](../../xray/spec/008-Embedding-Contract.md)
+     §Embeddable event spine) — so a variant's event SEQUENCE is
+     inspectable IN-PLACE, not only the final/focused event. The
+     spine + the chip-selected panel mount in the SAME `:rf/xray`
+     frame; clicking a PAST event in the spine dispatches
+     `:rf.xray/focus-cascade` (the row's own handler, reused
+     verbatim from the full shell), which re-binds the spine sub
+     `:rf.xray/focus` — and the panel below re-renders against the
+     chosen epoch (app-db + epoch panels update to that epoch).
+     **Mike RULED scope = A (2026-06-01):** the embed's inline spine
+     is the compact in-place affordance; the `[Pop out ↗]` /
+     `Ctrl+Shift+C` full-shell stays the deep-history escape hatch
+     (NOT a second full shell). The band is height-capped (the
+     full-shell L2 defaults to ~200px; Story's RHS column is 320px,
+     so the host caps the band to keep it compact and lets the
+     list's own `overflow-y:auto` scroll older events — the host
+     owns the container size). While the embed is collapsed
+     (rf2-ba86n.19 disclosure) the spine drops too — no spine mount,
+     no L2 compute.
    - **Panel host.** A `<div data-rf-xray-panel-host=<panel-id>>`
      into which one of Xray's `panels/mount-<panel>!` fns
      ([`day8.re-frame2-xray.panels`](../../xray/src/day8/re_frame2_xray/panels.cljs))
@@ -347,6 +371,21 @@ the Xray Issues tab per Mike's Option (c) ruling; issues surface inline
 in the Epoch panel + the L2 event-row pink-wash + the always-on issues
 ribbon signal, so there is no standalone Issues panel to embed.)
 
+The RHS additionally mounts one **L2 spine** (rf2-9k43e), the compact
+in-place event navigator — NOT a chip-row panel:
+
+| Pseudo-id       | Mount fn                                                  | Xray view                                        |
+|-----------------|-----------------------------------------------------------|---------------------------------------------------|
+| `:event-spine`  | `(mount-event-spine! mount-point opts) → unmount`         | The L2 `shell/event-list` recent-events timeline (the full shell's spine, mounted standalone) |
+
+`:event-spine` is wired through `mount-fn-for` like every chip panel,
+but it does NOT appear in `panel-catalog` (it is a persistent band, not
+a chip-selected lens). The same `panel-host-component` class-3 driver
+mounts it — with the spine host-style + `data-test="story-xray-spine-host"`
+— so it inherits the rf2-4l7t2 React-18 deferred-unmount lifecycle. Its
+panel-id never changes, so the host mounts the spine once; focus changes
+flow through the spine's own subs, not a remount.
+
 Each mount fn:
 
 1. Installs Xray's handler registry (idempotent).
@@ -385,8 +424,9 @@ guarantees no state leaks across Xray-internal bugs).
 `mount-fn-for` does a compile-time symbol → fn lookup against the
 canonical six panel ids (e.g. `:epoch` → `day8.re-frame2-xray.
 panels/mount-epoch-panel!` post rf2-5gl5r; rf2-gbz39 dropped `:issues`
-with the Xray Issues tab) — a nil result is a clean no-op render, so
-Xray absence never throws.
+with the Xray Issues tab) **plus the `:event-spine` pseudo-id**
+(rf2-9k43e — → `panels/mount-event-spine!`, the L2 spine band) — a nil
+result is a clean no-op render, so Xray absence never throws.
 
 ### Chip-click → swap sequence
 

--- a/tools/story/src/re_frame/story/ui/xray_embed.cljs
+++ b/tools/story/src/re_frame/story/ui/xray_embed.cljs
@@ -151,7 +151,14 @@
   `panel-id` is unknown. Compile-time symbol resolution via the
   `case` dispatch — no runtime namespace walk. (rf2-5gl5r retired
   `:event-detail` in favour of `:epoch`; rf2-gbz39 removed `:issues`
-  alongside the Xray Issues tab per Mike's Option (c) ruling.)"
+  alongside the Xray Issues tab per Mike's Option (c) ruling.)
+
+  rf2-9k43e — `:event-spine` resolves to `mount-event-spine!`, the
+  isolated L2 event list. It is NOT a chip-row panel (it's not in
+  `panel-catalog`); the embed renders it as a persistent compact band
+  ABOVE the chip-selected panel so past events are clickable in-place.
+  The `panel-host-component` class drives its mount via the same
+  contract every chip panel uses."
   [panel-id]
   (case panel-id
     :epoch        xray-panels/mount-epoch-panel!
@@ -160,6 +167,7 @@
     :trace        xray-panels/mount-trace!
     :machines     xray-panels/mount-machine-inspector!
     :routing      xray-panels/mount-routing!
+    :event-spine  xray-panels/mount-event-spine!
     nil))
 
 ;; ---- popout escape hatch -------------------------------------------------
@@ -248,6 +256,34 @@
                    :overflow "hidden"
                    :border-radius "4px"
                    :background (:bg-canvas colors/tokens)}
+   ;; rf2-9k43e — the compact in-place EVENT SPINE band. Sits BETWEEN
+   ;; the chip-row and the chip-selected panel-host so the user reads:
+   ;; pick a lens (chip-row) → scan the variant's recent events (spine)
+   ;; → click a past event → the panel below re-renders against that
+   ;; epoch. It hosts the SAME `shell/event-list` L2 component the full
+   ;; Xray shell composes (via `mount-event-spine!`), not a parallel
+   ;; spine. The band is height-capped (the full-shell L2 defaults to
+   ;; ~200px; the embed is 320px-wide and stacks below the chip-row, so
+   ;; a `max-height` keeps it compact and lets the list's own
+   ;; `overflow-y:auto` scroll older events) — the host owns the
+   ;; container size per spec/008 §Embed props inventory.
+   :spine-host    {:position "relative"
+                   :display "flex"
+                   :flex "0 0 auto"
+                   :flex-direction "column"
+                   :max-height "140px"
+                   :overflow "hidden"
+                   :border-radius "4px"
+                   :background (:bg-canvas colors/tokens)}
+   ;; rf2-9k43e — caption above the spine band so the affordance reads
+   ;; as 'this is the variant's recent-events timeline; click to focus'.
+   :spine-caption {:padding "0 2px 2px"
+                   :color (:text-tertiary colors/tokens)
+                   :font-family sans-stack
+                   :font-size (:caption typography/type-scale)
+                   :letter-spacing "0.02em"
+                   :text-transform "uppercase"
+                   :user-select "none"}
    :empty         {:padding "16px 8px"
                    :color (:text-tertiary colors/tokens)
                    :font-family sans-stack
@@ -369,13 +405,24 @@
 ;; container; only the prior root's release is queued.
 
 (defn- panel-host-component
-  "Reagent class-3 component owning the DOM mount lifecycle for the
-  Xray panel-host `<div>` across an arbitrary number of panel-id
-  swaps. On mount + on panel-id change, mounts the Xray
-  `mount-<panel>!` fn into a fresh child `<div>` of the host; on
-  unmount, releases every still-mounted Xray root via microtask
-  so the React 18+ root API never sees a synchronous unmount
-  inside the parent render cycle.
+  "Reagent class-3 component owning the DOM mount lifecycle for an Xray
+  mount-host `<div>` across an arbitrary number of panel-id swaps. On
+  mount + on panel-id change, mounts the Xray `mount-<panel>!` fn into a
+  fresh child `<div>` of the host; on unmount, releases every
+  still-mounted Xray root via microtask so the React 18+ root API never
+  sees a synchronous unmount inside the parent render cycle.
+
+  Argv: `[<panel-id>]` or `[<panel-id> <opts>]`. `opts` (rf2-9k43e) lets
+  the SAME class serve both the chip-selected panel host AND the compact
+  event-spine band:
+
+  - `:host-style`   — the host `<div>` inline style (defaults to the
+    panel-host style).
+  - `:host-test-id` — the host `<div>` `data-test` attr (defaults to
+    `\"story-xray-panel-host\"`).
+
+  Only the panel-id participates in the mount/swap diff; the opts are
+  pure presentation so a change to them never re-fires the mount.
 
   Lifecycle invariants (rf2-4l7t2):
 
@@ -392,7 +439,7 @@
     of the 'Attempted to synchronously unmount a root while React
     was already rendering' warning that previously fired 17× per
     Story-Xray browser-gate run)."
-  [_panel-id]
+  [_panel-id & _opts]
   (let [host-ref    (atom nil)
         ;; `mounted-ref` holds `{:unmount fn :container <div>}` for the
         ;; currently-mounted Xray root, or nil. Cleared eagerly when
@@ -465,11 +512,11 @@
        (fn [_this]
          (release!))
        :reagent-render
-       (fn [pid]
+       (fn [pid & {:keys [host-style host-test-id]}]
          [:div {:ref (fn [node] (reset! host-ref node))
                 :data-rf-xray-panel-host (name pid)
-                :data-test "story-xray-panel-host"
-                :style (:panel-host styles)}])})))
+                :data-test (or host-test-id "story-xray-panel-host")
+                :style (or host-style (:panel-host styles))}])})))
 
 ;; ---- disclosure toggle (rf2-ba86n.19) ------------------------------------
 
@@ -494,6 +541,41 @@
    [:span {:style (merge (:disclosure-glyph styles)
                          (when collapsed? (:disclosure-glyph-collapsed styles)))}
     [glyphs/chevron-right 11]]])
+
+;; ---- event-spine band (rf2-9k43e) ----------------------------------------
+
+(defn spine-band
+  "The compact, clickable recent-events SPINE for the Story RHS Xray
+  embed (rf2-9k43e). Renders a labelled band hosting the SAME
+  `shell/event-list` L2 component the full Xray shell composes — via
+  `xray-panels/mount-event-spine!` — so the variant's event SEQUENCE is
+  inspectable IN-PLACE, not only the final/focused event.
+
+  Mike RULED scope = A (2026-06-01): add the inline spine so past
+  events/epochs are focusable in-place; keep the Ctrl+Shift+C / `Pop
+  out` full-shell escape hatch for deep history. Clicking a past event
+  in the spine dispatches `:rf.xray/focus-cascade` (the row's own
+  handler — reused verbatim from the full shell), which re-binds the
+  spine sub `:rf.xray/focus`; the chip-selected panel below — mounted in
+  the SAME `:rf/xray` frame — re-renders against the chosen epoch.
+
+  The band mounts through the SAME `panel-host-component` class the
+  chip-selected panel uses (with the spine host-style + test-id), so it
+  inherits the rf2-4l7t2 React-18 deferred-unmount lifecycle. Its
+  panel-id (`:event-spine`) never changes, so the host class mounts the
+  spine once and leaves it; focus changes flow through the spine's own
+  subs, not a remount.
+
+  Public so the e2e hiccup test can assert the band + its mount slot."
+  []
+  [:div {:data-test "story-xray-spine-band"
+         :style {:display "flex" :flex-direction "column" :flex "0 0 auto"}}
+   [:div {:style (:spine-caption styles)
+          :data-test "story-xray-spine-caption"}
+    "Events — click to focus"]
+   [panel-host-component :event-spine
+    :host-style   (:spine-host styles)
+    :host-test-id "story-xray-spine-host"]])
 
 ;; ---- public surface: the embed panel -------------------------------------
 
@@ -579,7 +661,7 @@
          ;; panel-id changes, and same-panel-id variant changes are absorbed
          ;; by the Xray panel's own subs (`:rf.xray/focus` tracks the
          ;; variant-driven cascade).
-         (if collapsed?
+         (when collapsed?
            [:div {:style (:collapsed-rest styles)
                   :data-test "story-xray-embed-collapsed"
                   :on-click (fn [_]
@@ -587,5 +669,15 @@
             (str (or (some #(when (= active-panel (:panel %)) (:label %))
                            panel-catalog)
                      "Xray")
-                 " panel collapsed — expand to compute diffs.")]
-           [panel-host-component active-panel])]))))
+                 " panel collapsed — expand to compute diffs.")])
+         ;; rf2-9k43e — when expanded, the compact event SPINE band
+         ;; renders ABOVE the chip-selected panel so the variant's recent
+         ;; events are clickable in-place. Clicking a past event re-binds
+         ;; `:rf.xray/focus`; the panel below (same `:rf/xray` frame)
+         ;; re-renders against the chosen epoch. The spine + panel are
+         ;; SIBLINGS of the wrapper (not fragment-nested) so the panel-host
+         ;; slot stays a direct wrapper child for the e2e hiccup walkers.
+         ;; While collapsed neither the spine NOR the panel mounts —
+         ;; lazy-diff compute deferral (rf2-ba86n.19) covers both.
+         (when-not collapsed? [spine-band])
+         (when-not collapsed? [panel-host-component active-panel])]))))

--- a/tools/story/test/re_frame/story/panels_e2e/xray_embed_spine_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/xray_embed_spine_e2e_cljs_test.cljs
@@ -1,0 +1,186 @@
+(ns re-frame.story.panels-e2e.xray-embed-spine-e2e-cljs-test
+  "Regression coverage for rf2-9k43e — the Story RHS Xray embed showed
+  ONLY the final/focused event: no event spine, no way to navigate to a
+  variant's PAST events in-place. The only workaround was the
+  Ctrl+Shift+C / `Pop out` full-shell escape hatch (which DOES carry the
+  L2 event spine).
+
+  Mike RULED scope = A (2026-06-01): add the COMPACT, clickable
+  recent-events SPINE to the embed so past events/epochs are focusable
+  IN-PLACE; keep the full-shell pop-out for deep history. The spine
+  REUSES the full-shell L2 component (`shell/event-list`) via the new
+  `panels/mount-event-spine!` — NOT a parallel spine.
+
+  This file pins both halves of the ruling:
+
+  ## 1 — the embed RENDERS the spine band (hiccup level)
+
+  The expanded embed's hiccup must carry the `story-xray-spine-band`
+  region + its `:event-spine` mount slot (the `panel-host-component`
+  argv driving `mount-event-spine!`). Pre-fix neither existed. Collapsing
+  the embed drops the spine too (lazy-diff deferral, rf2-ba86n.19).
+
+  ## 2 — selecting a PAST event focuses it IN-PLACE (contract level)
+
+  Per project policy regressions pin at the CLJS contract layer, not
+  Playwright (modelled on `sync_epoch_focus_e2e_cljs_test` for rf2-mdpfz).
+  We seed THREE real host cascades through the trace bus, then dispatch
+  the EXACT event the spine row's body-click fires
+  (`:rf.xray/focus-cascade <past-id> <frame>`) for a PAST cascade — and
+  assert the spine sub `:rf.xray/focus` AND the focus-keyed panel subs
+  (`:rf.xray/app-db-current+diff`, `:rf.xray/epoch-pipeline`) re-bind to
+  the CHOSEN PAST epoch, not the latest. Pre-fix the embed had no
+  affordance to drive that focus from a past row at all; this is the
+  behaviour the inline spine unlocks."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story :as story]
+            [re-frame.story.ui.xray-embed :as xray-embed]
+            [re-frame.story.ui.state :as ui-state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-xray.test-helpers.e2e-multi-frame :as xray-e2e]
+            [day8.re-frame2-xray.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private variant-id :story.counter/loaded)
+
+(defn- register-variant! []
+  (story/reg-story :story.counter
+    {:doc "Counter parent story for the spine e2e tests."})
+  (story/reg-variant variant-id
+    {:doc    "Counter seeded at 5 — exercises the inline spine path."
+     :events [[:counter/initialise]]}))
+
+;; ---- 1 · the embed renders the spine band (hiccup level) ----------------
+
+(deftest mount-event-spine-resolves-to-callable
+  (testing "rf2-9k43e — `:event-spine` resolves to a callable mount-fn
+            (the isolated L2 `shell/event-list` via mount-event-spine!),
+            reusing the same require/case shape every chip panel uses"
+    (is (fn? (xray-embed/mount-fn-for :event-spine))
+        "mount-fn-for :event-spine returned a callable mount-fn")
+    (testing "the spine is NOT a chip-row panel (not in the catalog)"
+      (is (not (contains? xray-embed/panel-ids :event-spine))
+          ":event-spine is a persistent band, not a chip-selected panel"))))
+
+(deftest expanded-embed-renders-spine-band
+  (testing "rf2-9k43e — an EXPANDED embed renders the recent-events spine
+            band ABOVE the chip-selected panel, with the :event-spine
+            mount slot driving mount-event-spine!"
+    (e2e/with-story-and-xray-frames
+      {:register-stories register-variant!}
+      (fn []
+        (e2e/select-variant! variant-id)
+        (let [tree    (xray-embed/xray-embed-panel)
+              band    (e2e/find-by-test-id tree "story-xray-spine-band")
+              caption (e2e/find-by-test-id tree "story-xray-spine-caption")
+              ;; The spine's mount slot is the `[panel-host-component
+              ;; :event-spine …]` vector — fn-headed, with `:event-spine`
+              ;; as the second element (the panel-id argv).
+              spine-slot (some (fn [node]
+                                 (when (and (vector? node)
+                                            (fn? (first node))
+                                            (= :event-spine (second node)))
+                                   node))
+                               (e2e/hiccup-seq band))]
+          (is (some? band)
+              "spine band present in the expanded embed (rf2-9k43e
+               `[data-test=\"story-xray-spine-band\"]`)")
+          (is (some? caption)
+              "spine caption present so the affordance reads as the
+               variant's clickable recent-events timeline")
+          (is (some? spine-slot)
+              "the :event-spine mount slot is present — drives
+               mount-event-spine! (the isolated full-shell L2 list)"))))))
+
+(deftest collapsed-embed-drops-spine-band
+  (testing "rf2-9k43e + rf2-ba86n.19 — collapsing the embed drops the
+            spine band too (no spine mount → no L2 compute) and restores
+            it on expand"
+    (e2e/with-story-and-xray-frames
+      {:register-stories register-variant!}
+      (fn []
+        (e2e/select-variant! variant-id)
+        (is (some? (e2e/find-by-test-id (xray-embed/xray-embed-panel)
+                                        "story-xray-spine-band"))
+            "expanded (default) embed shows the spine band")
+        (ui-state/swap-state! ui-state/set-xray-embed-collapsed true)
+        (is (nil? (e2e/find-by-test-id (xray-embed/xray-embed-panel)
+                                       "story-xray-spine-band"))
+            "COLLAPSED embed renders NO spine band → mount-event-spine!
+             never fires → the L2 list's compute is deferred")
+        (ui-state/swap-state! ui-state/set-xray-embed-collapsed false)
+        (is (some? (e2e/find-by-test-id (xray-embed/xray-embed-panel)
+                                        "story-xray-spine-band"))
+            "expanding restores the spine band")))))
+
+;; ---- 2 · selecting a PAST event focuses it IN-PLACE (contract) ----------
+;;
+;; The spine row's body-click handler (reused verbatim from the full
+;; shell's `event-row`) dispatches `[:rf.xray/focus-cascade <id> <frame>]`.
+;; Driving that event for a PAST cascade IS clicking a past spine row.
+;; We assert the spine sub + the focus-keyed panel subs follow it
+;; in-place to the chosen PAST epoch — the behaviour the inline spine
+;; unlocks (pre-fix the embed only ever surfaced the latest/head event).
+
+(defn- seed-three-host-cascades! []
+  ;; THREE real dispatches through the trace bus → three cascades /
+  ;; three epochs in Xray's `:rf/xray` frame. `:counter/inc` is the head.
+  (xray-e2e/dispatch-host [:counter/inc])   ; value 6
+  (xray-e2e/dispatch-host [:counter/dec])   ; value 5
+  (xray-e2e/dispatch-host [:counter/inc]))  ; value 6 — HEAD
+
+(deftest spine-row-click-focuses-past-event-in-place
+  (testing "rf2-9k43e — dispatching the spine row's focus event for a
+            PAST cascade re-binds :rf.xray/focus to that PAST epoch
+            (NOT the head); the focus-keyed panels follow in-place"
+    (xray-e2e/with-host-and-xray-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (seed-three-host-cascades!)
+        (let [cascades  (xray-e2e/xray-cascades)
+              head      (last cascades)        ; oldest-first → head is last
+              ;; The OLDEST recorded cascade — a PAST event several steps
+              ;; behind the head (the install fixture's `:counter/initialise`
+              ;; lands first, then our three dispatches). This is the row a
+              ;; user would click in the spine to inspect an earlier moment
+              ;; of the run.
+              past      (first cascades)
+              head-id   (:dispatch-id head)
+              past-id   (:dispatch-id past)
+              past-frame (:frame past)]
+          (is (<= 3 (count cascades))
+              "precondition: at least three host cascades recorded through
+               the trace bus (initialise + inc/dec/inc)")
+          (is (not= head-id past-id)
+              "precondition: the chosen PAST cascade is not the head")
+          ;; Baseline: focus tracks the HEAD (LIVE) before any click.
+          (is (= head-id (:dispatch-id (xray-e2e/sub-xray [:rf.xray/focus])))
+              "baseline: the spine focus tracks the latest/head event
+               (the only thing the pre-fix embed ever surfaced)")
+          ;; Click a PAST spine row == dispatch its body-click event.
+          (xray-e2e/dispatch-xray [:rf.xray/focus-cascade past-id past-frame])
+          (let [focus (xray-e2e/sub-xray [:rf.xray/focus])]
+            (is (= past-id (:dispatch-id focus))
+                "spine focus re-bound to the chosen PAST cascade in-place")
+            (is (= :retro (:mode focus))
+                "focusing a non-head row pins the spine to RETRO — the
+                 head no longer steals focus"))
+          ;; The focus-keyed panels follow the chosen PAST epoch in-place.
+          (let [{adb-epoch :epoch-id} (xray-e2e/sub-xray [:rf.xray/app-db-current+diff])
+                {ep-status :status ep-epoch :epoch-id}
+                (xray-e2e/sub-xray [:rf.xray/epoch-pipeline])
+                past-epoch (:epoch-id (xray-e2e/sub-xray [:rf.xray/focus]))]
+            (is (some? past-epoch)
+                "the focused PAST cascade resolves a settling epoch-id")
+            (is (= past-epoch adb-epoch)
+                "App-db panel sub follows the PAST epoch in-place (not the
+                 head) — the embed's app-db view reflects the chosen epoch")
+            (is (= :focused ep-status)
+                "Epoch panel resolves :focused on the chosen PAST epoch
+                 (not :no-focus, not the head)")
+            (is (= past-epoch ep-epoch)
+                "Epoch panel sub follows the PAST epoch in-place")))))))

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -16,6 +16,51 @@ surface is internal-but-stable (the shell composes panels through it;
 tests mount panels through it) rather than a host-facing embed
 contract with its own props vocabulary.
 
+## Embeddable event spine — `mount-event-spine!` (rf2-9k43e)
+
+The per-panel mount family (`007-UX-IA.md` §Mountable panel contract)
+covers the L4 *detail* surfaces. It is joined by one **L2 spine** mount:
+
+```clojure
+(day8.re-frame2-xray.panels/mount-event-spine! mount-point opts) → unmount-fn
+```
+
+`mount-event-spine!` mounts the **same `shell/event-list` reg-view the
+full 4-layer shell composes at L2** — the recent-events timeline
+(single-line rows, latest-on-bottom) that IS Xray's canonical scrubber.
+It is **not a parallel spine**: it reuses the full-shell component
+verbatim, so the embedded spine inherits the row anatomy, the issue-row
+wash (rf2-b8guz), the relative-time chips, virtualisation, the
+ribbon-driven filters, and — load-bearing — the row-click →
+`:rf.xray/focus-cascade` write that drives the single-axis spine sub
+`:rf.xray/focus` (`018-Event-Spine.md` §4 + §6).
+
+It honours the same shape as every other mount fn — installs handlers,
+ensures the `:rf/xray` frame, wraps the view in `[rf/frame-provider
+{:frame :rf/xray} …]`, returns an `unmount`. Per `018-Event-Spine.md`
+§4 the list owns its own height via `:rf.xray/events-list-height-px`;
+the host caps the visible band through its mount-point CSS (the contract
+is "the host owns the container size" — §Embed props inventory).
+
+### Why a spine mount exists — in-place past-event navigation
+
+A host that embeds **only** an L4 detail panel (e.g. Story's RHS, which
+hosts one chip-selected panel at a time) surfaces only the
+final/focused event's cascade — there is no way to navigate a variant's
+PAST events in-place; the workaround was the full-shell pop-out
+(below). `mount-event-spine!` is the **compact in-place affordance**:
+a host mounts the spine ALONGSIDE a focus-keyed detail panel in the
+SAME `:rf/xray` frame; clicking a past event in the spine re-binds
+`:rf.xray/focus`, and the sibling panel re-renders against the chosen
+epoch IN-PLACE. The full-shell pop-out remains the deep-history escape
+hatch (§Full-shell embed contract); the spine mount is the compact
+in-place navigator, not a second full shell.
+
+The spine carries no host-facing props beyond the shared `:frame` opt
+(see §Frame-provider opt in `panels.cljs`'s ns docstring); focus flows
+through the spine's own `:rf.xray/focus-cascade` write surface, not a
+new prop vocabulary.
+
 ## Full-shell embed contract (Xray-as-Story-RHS)
 
 When a host mounts the **full Xray shell** as its right-hand-side

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -21,6 +21,15 @@
       (mount-machine-inspector! mount-point opts) → unmount-fn
       (mount-routing!          mount-point opts) → unmount-fn
 
+      ;; Spine surface — the L2 event list in isolation (rf2-9k43e).
+      ;; The SAME `shell/event-list` reg-view the full 4-layer shell
+      ;; composes at L2; mounted standalone it is the compact,
+      ;; clickable recent-events navigator. Clicking a row dispatches
+      ;; `:rf.xray/focus-cascade`, which re-binds the spine sub
+      ;; `:rf.xray/focus` — so any panel mounted alongside (App-db,
+      ;; Epoch, …) re-renders against the chosen past epoch.
+      (mount-event-spine! mount-point opts) → unmount-fn
+
       ;; Overlay / popup surfaces — same contract.
       (mount-segment-inspector! mount-point opts) → unmount-fn
       (mount-cancellation-cascade-side-panel! mount-point opts) → unmount-fn
@@ -233,6 +242,34 @@
   the registered-routes lens + simulate-URL surface."
   ([mount-point]      (mount-routing! mount-point nil))
   ([mount-point opts] (render-panel! routing/Panel mount-point opts)))
+
+(defn mount-event-spine!
+  "Mount Xray's L2 event spine in isolation at `mount-point` (rf2-9k43e).
+
+  Renders the SAME `shell/event-list` reg-view the full 4-layer shell
+  composes at L2 — the recent-events timeline (single-line rows,
+  latest-on-bottom) that IS the canonical scrubber. This is NOT a
+  parallel spine: it reuses the full-shell component verbatim, so the
+  embedded spine inherits the row anatomy, the issue-row wash
+  (rf2-b8guz), the relative-time chips, virtualisation, filters, and —
+  critically — the row-click → `:rf.xray/focus-cascade` write that
+  drives the single-axis spine sub `:rf.xray/focus` (spec/018 §4 + §6).
+
+  The contract for a host (Story) is: mount this spine ALONGSIDE a
+  focus-keyed panel (`mount-epoch-panel!` / `mount-app-db-diff!` / …)
+  in the SAME `:rf/xray` frame. Clicking a past event in the spine
+  re-binds `:rf.xray/focus`; the sibling panel re-renders against the
+  chosen epoch IN-PLACE — so a variant's event SEQUENCE is inspectable
+  without the full-shell pop-out (which remains the deep-history
+  escape hatch — spec/008 §Full-shell embed contract).
+
+  Per spec/018 §4 the event list owns its own height via
+  `:rf.xray/events-list-height-px`; the host caps the visible band
+  through its mount-point CSS for the compact embed footprint (the
+  contract is 'the host owns the container size' — spec/008 §Embed
+  props inventory)."
+  ([mount-point]      (mount-event-spine! mount-point nil))
+  ([mount-point opts] (render-panel! shell/event-list mount-point opts)))
 
 ;; (rf2-gbz39 — `mount-issues-ribbon!` removed alongside the retired
 ;; Issues tab. Mike RULED Option (c): the dedicated Issues tab + its


### PR DESCRIPTION
## What

The in-Story RHS Xray embed surfaced only the **final/focused event** — no event spine, no way to navigate a variant's PAST events in-place. The only workaround was the `Ctrl+Shift+C` / `Pop out` full-shell escape hatch (which DOES carry the L2 event spine).

**Mike RULED scope = A (2026-06-01, authoritative over the dispatch brief):** add the COMPACT, clickable recent-events SPINE inline so past events/epochs are focusable IN-PLACE; keep the full-shell pop-out for deep history. The embed's spine is the compact in-place affordance, **not** a second full shell.

## How it reuses the full-shell spine

- **Xray side** — new `panels/mount-event-spine!` mounts the **SAME `shell/event-list` L2 component** the full 4-layer shell composes, in isolation. It is NOT a parallel spine: it reuses the full-shell component verbatim, so the embedded spine inherits the row anatomy, the issue-row wash (rf2-b8guz), relative-time chips, virtualisation, ribbon-driven filters, and — load-bearing — the row-click → `:rf.xray/focus-cascade` write that drives the single-axis spine sub `:rf.xray/focus` (spec/018 §4 + §6).
- **Story side** — a compact event-spine band renders between the chip-row and the chip-selected panel host. It mounts the spine through the SAME `panel-host-component` class-3 driver (generalised to take a `:host-style` + `:host-test-id`), so it inherits the rf2-4l7t2 React-18 deferred-unmount lifecycle. Spine + panel mount in the SAME `:rf/xray` frame, so clicking a past event re-binds focus and the panel below re-renders against that epoch IN-PLACE (app-db + epoch panels update to the chosen epoch). Collapsing the embed drops the spine too (lazy-diff deferral, rf2-ba86n.19).

No new `implementation/` → `tools/` requires; the `tools/story` → `tools/xray` arrow already existed (bundle-isolation gate is unaffected — and re-run green below).

## Spec updates (kept current in this PR)

- `tools/xray/spec/008-Embedding-Contract.md` — new §Embeddable event spine documents the `mount-event-spine!` contract + the in-place past-event navigation rationale.
- `tools/story/spec/003-Render-Shell.md` — §Right-hand pane now documents the inline spine band (region count 3→4) + the `:event-spine` pseudo-id in the Mount lifecycle's mount-fn table.

## Regression test (failing-before / passing-after)

`tools/story/test/re_frame/story/panels_e2e/xray_embed_spine_e2e_cljs_test.cljs` — CLJS contract-level (per project policy; modelled on `sync_epoch_focus_e2e_cljs_test` for rf2-mdpfz):

1. `mount-fn-for :event-spine` resolves to a callable (failed before — the mount fn did not exist).
2. The expanded embed renders the `story-xray-spine-band` + its `:event-spine` mount slot (failed before — the band did not exist); collapsing drops it.
3. Seed three real host cascades through the trace bus, then dispatch the EXACT event the spine row's body-click fires (`:rf.xray/focus-cascade <past-id> <frame>`) for a PAST cascade — assert `:rf.xray/focus` AND the focus-keyed panel subs (`:rf.xray/app-db-current+diff`, `:rf.xray/epoch-pipeline`) re-bind to the chosen PAST epoch in-place, not the head.

## Quality gates

- `clojure -M:test` (xray): **1038 tests / 4146 assertions, 0 failures, 0 errors**
- `clojure -M:test` (story): **1553 tests / 5785 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5167 tests / 17437 assertions, 0 failures, 0 errors**
- `clj-kondo` (changed files): **0 errors, 0 warnings**
- `npm run test:bundle-isolation`: **PASS** (17 artefact entries; 35 sentinels absent; uix/helix reagent-free)

Playwright gates not run per project policy. No structural change to the 3-adapter smoke / xray-feature-gate (the chip-row panel set is unchanged; the spine is an additive band).