### PR TITLE
fix(skills): correctness fixes across skills cluster (rf2-5t8mr.31-39 + rf2-uuwzc/1sq8u/3gv4x)

### DIFF
--- a/skills/re-frame-migration/references/auto-call-site-rewrites.md
+++ b/skills/re-frame-migration/references/auto-call-site-rewrites.md
@@ -53,7 +53,7 @@ See `references/setup.md` for the per-build-tool detail. Applied once, in Phase 
                                  (rf/dispatch-sync [::reset-app-db v])
 (subs/clear-sub-cache!) → (rf/clear-sub-cache! :rf/default)
 (re-frame.core/clear-subscription-cache!) → (rf/clear-sub-cache! :rf/default) ; public v1 no-arg name
-(reg/get-handler kind id) → (rf/get-handler kind id)
+(reg/get-handler kind id) → (rf/handler-meta kind id) ; public registrar query; returns the registration metadata map (no raw handler fn is exposed publicly in v2)
 ```
 
 **Edge case → Type B**: `(reset! re-frame.db/app-db ...)` is intent-sensitive (real bypass vs. test reset vs. seeding); promote to M-15 review.

--- a/skills/re-frame-migration/references/auto-cross-cutting.md
+++ b/skills/re-frame-migration/references/auto-cross-cutting.md
@@ -273,7 +273,7 @@ When a per-feature surface is in use, add the dep AND add the `:require` of the 
 
 | Surface in code | Dep to add | Namespace to require |
 |---|---|---|
-| `reg-app-schema` / `reg-event-schema` | `day8/re-frame2-schemas` | `re-frame.schemas` |
+| `reg-app-schema` / `:spec` metadata | `day8/re-frame2-schemas` | `re-frame.schemas` |
 | `reg-machine` / `sub-machine` | `day8/re-frame2-machines` | `re-frame.machines` |
 | `reg-route` / `:rf.route/*` events | `day8/re-frame2-routing` | `re-frame.routing` |
 | `reg-flow` / `:rf.fx/reg-flow` | `day8/re-frame2-flows` | `re-frame.flows` |

--- a/skills/re-frame-migration/references/breaking-changes.md
+++ b/skills/re-frame-migration/references/breaking-changes.md
@@ -44,7 +44,7 @@ A one-page index keyed to v1 trigger surfaces. The author asks *"is `X` covered 
 | `(rf/h ...)` hiccup walker | **M-24** | A | Var-ref form (`[counter "..."]`) for the common case; `(rf/view :id)` for late-binding; drop the wrapper for HTML-only hiccup. |
 | `(:require [re-frame.test ...])` or `[day8.re-frame.test ...]` | **M-25** | A | Rename to `re-frame.test-support`. `dispatch-sequence` keeps its name; `assert-state` is split into `assert-path-equals` + `assert-db-equals` per **M-62** (so the fn-side shares a name root with the `:rf.assert/*` Story event-family). `run-test-sync` is dropped — hoist body to inline `dispatch-sync` under `make-reset-runtime-fixture` per **M-52**. Drop `day8/re-frame-test` Maven coord — ships in core. |
 | `with-trace`, `merge-trace!`, `finish-trace`, `trace-api-version`, `add-post-event-callback`, `remove-post-event-callback`, `purge-event-queue`, `dispatch-and-settle`, `spawn-machine`, `destroy-machine` | **M-26** | A/B | Drift-sweep drops. Each maps to a v2 surface; see the full table inline. `add-post-event-callback` is Type B; the rest mostly A. |
-| `reg-app-schema` / `reg-event-schema` / `:spec` metadata | **M-27** | A | Add `day8/re-frame2-schemas` artefact; user code's API surface in `re-frame.core` is unchanged. |
+| `reg-app-schema` / `:spec` metadata (incl. `:spec` on `reg-event-*`) | **M-27** | A | Add `day8/re-frame2-schemas` artefact; user code's API surface in `re-frame.core` is unchanged. |
 | `reg-machine` / `make-machine-handler` / `sub-machine` | **M-28** | A | Add `day8/re-frame2-machines` artefact; require `re-frame.machines` in any namespace using machine surfaces. |
 | `reg-route` / `:rf.route/*` events / `:rf/route` subs | **M-29** | A | Add `day8/re-frame2-routing` artefact; require `re-frame.routing` in any namespace using routing surfaces. |
 | `reg-flow` / `:rf.fx/reg-flow` (including post-M-21 `on-changes` rewrites) | **M-30** | A | Add `day8/re-frame2-flows` artefact; require `re-frame.flows` in any namespace using flow surfaces. |
@@ -140,10 +140,10 @@ Xray is a from-scratch reimplementation against re-frame2's trace bus and epoch-
 - `dispatch` / `dispatch-sync` (optional second `opts` arg is additive).
 - `subscribe`; `@(subscribe [...])` deref-to-read pattern.
 - `:<-` chained subs and `reg-sub` sugar variants.
-- `path`, `unwrap`, `inject-cofx` interceptors; `->interceptor` primitive.
+- `path`, `inject-cofx` interceptors; `->interceptor` primitive. (Note: v1's `unwrap` Var is renamed to `unwrap-interceptor` per M-59 — only the name moves; the `:unwrap` interceptor `:id` is unchanged.)
 - The `:fx` slot in effect maps (the inner shape `[[fx-id args] ...]`).
 - `reg-fx` / `reg-cofx` without `:platforms` (defaults to universal).
-- `reg-flow` / `flow<-` / `clear-flow` (in `re-frame.core`; underlying impl ships under `re-frame2-flows`).
+- `reg-flow` / `clear-flow` (in `re-frame.core`; underlying impl ships under `re-frame2-flows`). (v1's `flow<-` / `get-flow` are dropped — there is no `flow<-` surface in v2.)
 - `re-frame.std-interceptors` namespace.
 - JVM interop layer (`re-frame.interop`).
 - Hot-reload semantics on the default frame.

--- a/skills/re-frame-migration/references/sequencing.md
+++ b/skills/re-frame-migration/references/sequencing.md
@@ -96,7 +96,7 @@ The M-rule numbering in [`MIGRATION.md`](../../../migration/from-re-frame-v1/REA
 
 | Order | Rule | Pairs with |
 |---|---|---|
-| 31 | **M-27** | Triggered by `reg-app-schema` / `:spec` keys / `reg-event-schema`. Add `day8/re-frame2-schemas`. |
+| 31 | **M-27** | Triggered by `reg-app-schema` / `:spec` keys (incl. `:spec` on `reg-event-*`). Add `day8/re-frame2-schemas`. |
 | 31a | **M-61** | If the codebase calls `re-frame.schemas/validate-app-db!` / `validate-sub-return!` directly or publishes the matching late-bind hook keys. Rename to `validate-app-schema!` / `validate-sub!`. Pairs with M-27. v2-pre-rename only. |
 | 32 | **M-28** | Triggered by `reg-machine` / `sub-machine`. Add `day8/re-frame2-machines`. |
 | 32a | **M-57** | If the codebase uses `(rf/create-machine-handler ...)`. Rename to `make-machine-handler`. Also rename `:machines/create-machine-handler` late-bind hook key. Pairs with M-28. v2-pre-rename only. |

--- a/skills/re-frame-migration/references/setup.md
+++ b/skills/re-frame-migration/references/setup.md
@@ -138,7 +138,7 @@ re-frame2 splits seven per-feature artefacts out of core. **Add them only when t
 
 | Artefact | Add when codebase uses... |
 |---|---|
-| `day8/re-frame2-schemas` | `reg-app-schema`, `reg-event-schema`, or `:spec` keys in registration metadata (M-27) |
+| `day8/re-frame2-schemas` | `reg-app-schema`, or `:spec` keys in registration metadata (incl. `:spec` on `reg-event-*` for event-payload schemas) (M-27) |
 | `day8/re-frame2-machines` | `reg-machine` (M-28) |
 | `day8/re-frame2-routing` | `reg-route` or dispatches `:rf.route/*` events (M-29) |
 | `day8/re-frame2-flows` | `reg-flow` (M-30) — also where v1's `on-changes` interceptor migrates to |

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -40,7 +40,7 @@
 ;;;;     |-------------------------|-----------------------------|
 ;;;;     | `list-subscriptions`    | `sub-cache-info`            |
 ;;;;     | `list-streams`          | `subscription-info`         |
-;;;;     | `list-handlers`         | `rf/registry-list`          |
+;;;;     | `list-handlers`         | `rf/registrations`          |
 ;;;;
 ;;;;   (rf2-qicji: `list-subscriptions` reads the live reactive
 ;;;;   sub-cache via `sub-cache-info`; the streaming-tap diagnostic it

--- a/skills/re-frame2-pair/tests/e2e/_helpers.cjs
+++ b/skills/re-frame2-pair/tests/e2e/_helpers.cjs
@@ -2,19 +2,19 @@
  * Shared helpers for re-frame2-pair e2e specs.
  *
  * - `runShim(ctx, subcmd, args, env?)` — execute
- * `bb scripts/ops.clj <subcmd> [args]` against the live fixture's
- * nREPL, buffering stdout/stderr into ctx.diagnostics when present.
- * The older positional call shape is still accepted for focused
- * helper tests. Returns { exit, stdout, stderr }. CWD is the fixture
- * dir so ops.clj's port-file lookup finds the live shadow-cljs port.
+ *   `bb scripts/ops.clj <subcmd> [args]` against the live fixture's
+ *   nREPL, buffering stdout/stderr into ctx.diagnostics when present.
+ *   The older positional call shape is still accepted for focused
+ *   helper tests. Returns { exit, stdout, stderr }. CWD is the fixture
+ *   dir so ops.clj's port-file lookup finds the live shadow-cljs port.
  *
  * - `parseEdn(s)` — naive but adequate parser for the structured
- * shapes we assert on (maps, vectors, keywords, strings, ints,
- * booleans, nil). Specs assert on shape, not bytewise equality, so
- * reading the full Clojure reader isn't necessary.
+ *   shapes we assert on (maps, vectors, keywords, strings, ints,
+ *   booleans, nil). Specs assert on shape, not bytewise equality, so
+ *   reading the full Clojure reader isn't necessary.
  *
  * - `openPage(ctx)` — boots a headless Chromium, navigates to the
- * fixture URL, returns { browser, page }.
+ *   fixture URL, returns { browser, page }.
  */
 'use strict';
 
@@ -22,223 +22,223 @@ const { spawnSync } = require('child_process');
 const path = require('path');
 
 function isVerboseTests(env = process.env) {
- return env.RF2_VERBOSE_TESTS === '1';
+  return env.RF2_VERBOSE_TESTS === '1';
 }
 
-function createDiagnostics({ verbose = isVerboseTests } = {}) {
- const entries = [];
+function createDiagnostics({ verbose = isVerboseTests() } = {}) {
+  const entries = [];
 
- const writeLive = (line, stream) => {
- if (!verbose) return;
- const write = stream === 'stderr' ? console.error : console.log;
- write(line);
- };
+  const writeLive = (line, stream) => {
+    if (!verbose) return;
+    const write = stream === 'stderr' ? console.error : console.log;
+    write(line);
+  };
 
- return {
- verbose,
- add(line, stream = 'stdout') {
- if (line == null) return;
- const normalized = String(line).replace(/\r\n/g, '\n');
- for (const part of normalized.split('\n')) {
- entries.push({ stream, text: part });
- writeLive(part, stream);
- }
- },
- isEmpty {
- return entries.length === 0;
- },
- flush({ stdout = console.log, stderr = console.error } = {}) {
- for (const entry of entries) {
- if (entry.stream === 'stderr') stderr(entry.text);
- else stdout(entry.text);
- }
- },
- };
+  return {
+    verbose,
+    add(line, stream = 'stdout') {
+      if (line == null) return;
+      const normalized = String(line).replace(/\r\n/g, '\n');
+      for (const part of normalized.split('\n')) {
+        entries.push({ stream, text: part });
+        writeLive(part, stream);
+      }
+    },
+    isEmpty() {
+      return entries.length === 0;
+    },
+    flush({ stdout = console.log, stderr = console.error } = {}) {
+      for (const entry of entries) {
+        if (entry.stream === 'stderr') stderr(entry.text);
+        else stdout(entry.text);
+      }
+    },
+  };
 }
 
 function flushDiagnostics(diagnostics) {
- if (!diagnostics || diagnostics.verbose || diagnostics.isEmpty) return;
- console.error('--- re-frame2-pair e2e diagnostics ---');
- diagnostics.flush({
- stdout: (line) => console.error(line),
- stderr: (line) => console.error(line),
- });
- console.error('-----------------------------');
+  if (!diagnostics || diagnostics.verbose || diagnostics.isEmpty()) return;
+  console.error('--- re-frame2-pair e2e diagnostics ---');
+  diagnostics.flush({
+    stdout: (line) => console.error(line),
+    stderr: (line) => console.error(line),
+  });
+  console.error('-----------------------------');
 }
 
 function addChunk(diagnostics, prefix, chunk, stream = 'stdout') {
- if (!diagnostics || !chunk) return;
- const normalized = String(chunk).replace(/\r\n/g, '\n');
- for (const line of normalized.split('\n')) {
- if (line.length === 0) continue;
- diagnostics.add(`${prefix}${line}`, stream);
- }
+  if (!diagnostics || !chunk) return;
+  const normalized = String(chunk).replace(/\r\n/g, '\n');
+  for (const line of normalized.split('\n')) {
+    if (line.length === 0) continue;
+    diagnostics.add(`${prefix}${line}`, stream);
+  }
 }
 
 function runShim(ctxOrSkillRoot, fixtureDirOrSubcmd, subcmdOrArgs, argsOrEnv = [], envOrEmpty = {}) {
- let ctx = null;
- let skillRoot;
- let fixtureDir;
- let subcmd;
- let args;
- let env;
+  let ctx = null;
+  let skillRoot;
+  let fixtureDir;
+  let subcmd;
+  let args;
+  let env;
 
- if (ctxOrSkillRoot && typeof ctxOrSkillRoot === 'object') {
- ctx = ctxOrSkillRoot;
- skillRoot = ctx.skillRoot;
- fixtureDir = ctx.fixtureDir;
- subcmd = fixtureDirOrSubcmd;
- args = Array.isArray(subcmdOrArgs) ? subcmdOrArgs : [];
- env = Array.isArray(subcmdOrArgs) ? argsOrEnv : (subcmdOrArgs || {});
- } else {
- skillRoot = ctxOrSkillRoot;
- fixtureDir = fixtureDirOrSubcmd;
- subcmd = subcmdOrArgs;
- args = argsOrEnv;
- env = envOrEmpty;
- }
+  if (ctxOrSkillRoot && typeof ctxOrSkillRoot === 'object') {
+    ctx = ctxOrSkillRoot;
+    skillRoot = ctx.skillRoot;
+    fixtureDir = ctx.fixtureDir;
+    subcmd = fixtureDirOrSubcmd;
+    args = Array.isArray(subcmdOrArgs) ? subcmdOrArgs : [];
+    env = Array.isArray(subcmdOrArgs) ? argsOrEnv : (subcmdOrArgs || {});
+  } else {
+    skillRoot = ctxOrSkillRoot;
+    fixtureDir = fixtureDirOrSubcmd;
+    subcmd = subcmdOrArgs;
+    args = argsOrEnv;
+    env = envOrEmpty;
+  }
 
- args = Array.isArray(args) ? args : [];
- env = env || {};
+  args = Array.isArray(args) ? args : [];
+  env = env || {};
 
- const opsClj = path.join(skillRoot, 'scripts', 'ops.clj');
- const diagnostics = ctx && ctx.diagnostics;
- const label = ctx && ctx.spec ? ctx.spec : subcmd;
- if (diagnostics) {
- diagnostics.add(
- `[re-frame2-pair-e2e:${label}] process: bb ${opsClj} ${subcmd} ${args.join(' ')}`.trim,
-);
- }
- const res = spawnSync('bb', [opsClj, subcmd, ...args], {
- cwd: fixtureDir,
- encoding: 'utf8',
- maxBuffer: 16 * 1024 * 1024,
- env: { ...process.env, ...env },
- });
- if (diagnostics) {
- diagnostics.add(`[re-frame2-pair-e2e:${label}] bb exit ${res.status}`);
- if (res.error) diagnostics.add(`[re-frame2-pair-e2e:${label}] bb error ${res.error.message}`, 'stderr');
- addChunk(diagnostics, `[re-frame2-pair-e2e:${label}:stdout] `, res.stdout);
- addChunk(diagnostics, `[re-frame2-pair-e2e:${label}:stderr] `, res.stderr, 'stderr');
- }
- return {
- exit: res.status,
- stdout: res.stdout || '',
- stderr: res.stderr || '',
- };
+  const opsClj = path.join(skillRoot, 'scripts', 'ops.clj');
+  const diagnostics = ctx && ctx.diagnostics;
+  const label = ctx && ctx.spec ? ctx.spec : subcmd;
+  if (diagnostics) {
+    diagnostics.add(
+      `[re-frame2-pair-e2e:${label}] process: bb ${opsClj} ${subcmd} ${args.join(' ')}`.trim(),
+    );
+  }
+  const res = spawnSync('bb', [opsClj, subcmd, ...args], {
+    cwd: fixtureDir,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    env: { ...process.env, ...env },
+  });
+  if (diagnostics) {
+    diagnostics.add(`[re-frame2-pair-e2e:${label}] bb exit ${res.status}`);
+    if (res.error) diagnostics.add(`[re-frame2-pair-e2e:${label}] bb error ${res.error.message}`, 'stderr');
+    addChunk(diagnostics, `[re-frame2-pair-e2e:${label}:stdout] `, res.stdout);
+    addChunk(diagnostics, `[re-frame2-pair-e2e:${label}:stderr] `, res.stderr, 'stderr');
+  }
+  return {
+    exit: res.status,
+    stdout: res.stdout || '',
+    stderr: res.stderr || '',
+  };
 }
 
 /*
  * Minimal Clojure edn parser. Handles:
  *
- * - nil, true, false
- * - integers (and bigints) — no rationals
- * - keywords (incl. namespaced — :ns/k)
- * - strings (no escapes beyond \" and \\)
- * - vectors [...], maps {...}, lists (...)
+ *   - nil, true, false
+ *   - integers (and bigints) — no rationals
+ *   - keywords (incl. namespaced — :ns/k)
+ *   - strings (no escapes beyond \" and \\)
+ *   - vectors [...], maps {...}, lists (...)
  *
  * Returns the parsed JS value or throws on malformed input. Specs that
  * need full reader fidelity should call out to bb instead.
  */
 function parseEdn(input) {
- const src = String(input || '').trim;
- if (src === '') return null;
+  const src = String(input || '').trim();
+  if (src === '') return null;
 
- let i = 0;
- function skip {
- while (i < src.length) {
- const c = src[i];
- if (c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === ',') {
- i++;
- } else if (c === ';') {
- while (i < src.length && src[i] !== '\n') i++;
- } else {
- break;
- }
- }
- }
- function readToken {
- let j = i;
- while (j < src.length && !/[\s,\(\)\[\]\{\}]/.test(src[j])) j++;
- const tok = src.slice(i, j);
- i = j;
- return tok;
- }
- function readString {
- if (src[i] !== '"') throw new Error('expected "');
- i++;
- let out = '';
- while (i < src.length && src[i] !== '"') {
- if (src[i] === '\\' && i + 1 < src.length) {
- out += src[i + 1] === 'n' ? '\n' : src[i + 1];
- i += 2;
- } else {
- out += src[i++];
- }
- }
- if (src[i] !== '"') throw new Error('unterminated string');
- i++;
- return out;
- }
- function readForm {
- skip;
- if (i >= src.length) throw new Error('unexpected EOF');
- const c = src[i];
- if (c === '"') return readString;
- if (c === '[') {
- i++;
- const out = [];
- while (true) {
- skip;
- if (src[i] === ']') { i++; return out; }
- out.push(readForm);
- }
- }
- if (c === '(') {
- i++;
- const out = [];
- while (true) {
- skip;
- if (src[i] === ')') { i++; return out; }
- out.push(readForm);
- }
- }
- if (c === '{') {
- i++;
- const out = new Map;
- while (true) {
- skip;
- if (src[i] === '}') { i++;
- // Convert pure-keyword-keyed maps to plain JS objects for
- // ergonomic assertion access. Mixed-key maps stay as Map.
- let allKw = true;
- for (const k of out.keys) {
- if (typeof k !== 'string' || !k.startsWith(':')) { allKw = false; break; }
- }
- if (!allKw) return out;
- const obj = {};
- for (const [k, v] of out.entries) obj[k.slice(1)] = v;
- return obj;
- }
- const k = readForm;
- const v = readForm;
- out.set(k, v);
- }
- }
- if (c === ':') {
- const tok = readToken;
- return tok; // keep the leading ':' so callers can disambiguate
- }
- const tok = readToken;
- if (tok === 'nil') return null;
- if (tok === 'true') return true;
- if (tok === 'false') return false;
- if (/^-?\d+$/.test(tok)) return parseInt(tok, 10);
- if (/^-?\d+\.\d+$/.test(tok)) return parseFloat(tok);
- // symbols pass through as strings
- return tok;
- }
- return readForm;
+  let i = 0;
+  function skip() {
+    while (i < src.length) {
+      const c = src[i];
+      if (c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === ',') {
+        i++;
+      } else if (c === ';') {
+        while (i < src.length && src[i] !== '\n') i++;
+      } else {
+        break;
+      }
+    }
+  }
+  function readToken() {
+    let j = i;
+    while (j < src.length && !/[\s,\(\)\[\]\{\}]/.test(src[j])) j++;
+    const tok = src.slice(i, j);
+    i = j;
+    return tok;
+  }
+  function readString() {
+    if (src[i] !== '"') throw new Error('expected "');
+    i++;
+    let out = '';
+    while (i < src.length && src[i] !== '"') {
+      if (src[i] === '\\' && i + 1 < src.length) {
+        out += src[i + 1] === 'n' ? '\n' : src[i + 1];
+        i += 2;
+      } else {
+        out += src[i++];
+      }
+    }
+    if (src[i] !== '"') throw new Error('unterminated string');
+    i++;
+    return out;
+  }
+  function readForm() {
+    skip();
+    if (i >= src.length) throw new Error('unexpected EOF');
+    const c = src[i];
+    if (c === '"') return readString();
+    if (c === '[') {
+      i++;
+      const out = [];
+      while (true) {
+        skip();
+        if (src[i] === ']') { i++; return out; }
+        out.push(readForm());
+      }
+    }
+    if (c === '(') {
+      i++;
+      const out = [];
+      while (true) {
+        skip();
+        if (src[i] === ')') { i++; return out; }
+        out.push(readForm());
+      }
+    }
+    if (c === '{') {
+      i++;
+      const out = new Map();
+      while (true) {
+        skip();
+        if (src[i] === '}') { i++;
+          // Convert pure-keyword-keyed maps to plain JS objects for
+          // ergonomic assertion access. Mixed-key maps stay as Map.
+          let allKw = true;
+          for (const k of out.keys()) {
+            if (typeof k !== 'string' || !k.startsWith(':')) { allKw = false; break; }
+          }
+          if (!allKw) return out;
+          const obj = {};
+          for (const [k, v] of out.entries()) obj[k.slice(1)] = v;
+          return obj;
+        }
+        const k = readForm();
+        const v = readForm();
+        out.set(k, v);
+      }
+    }
+    if (c === ':') {
+      const tok = readToken();
+      return tok; // keep the leading ':' so callers can disambiguate
+    }
+    const tok = readToken();
+    if (tok === 'nil') return null;
+    if (tok === 'true') return true;
+    if (tok === 'false') return false;
+    if (/^-?\d+$/.test(tok)) return parseInt(tok, 10);
+    if (/^-?\d+\.\d+$/.test(tok)) return parseFloat(tok);
+    // symbols pass through as strings
+    return tok;
+  }
+  return readForm();
 }
 
 /*
@@ -247,37 +247,37 @@ function parseEdn(input) {
  * this, others (e.g. discover-only) don't.
  */
 async function openPage(ctx) {
- const playwright = require('playwright');
- const browser = await playwright.chromium.launch({ headless: true });
- const context = await browser.newContext;
- const page = await context.newPage;
- const diagnostics = ctx && ctx.diagnostics;
- const label = ctx && ctx.spec ? ctx.spec : 'open-page';
- if (diagnostics) {
- diagnostics.add(`[re-frame2-pair-e2e:${label}] URL: ${ctx.fixtureUrl}`);
- }
- page.on('console', (msg) => {
- if (diagnostics) diagnostics.add(`[re-frame2-pair-e2e:${label}:browser:${msg.type}] ${msg.text}`);
- });
- page.on('pageerror', (err) => {
- if (!diagnostics) return;
- diagnostics.add(`[re-frame2-pair-e2e:${label}:browser:pageerror] ${err.message}`, 'stderr');
- if (err.stack) diagnostics.add(err.stack, 'stderr');
- });
- page.on('framenavigated', (frame) => {
- if (diagnostics && frame === page.mainFrame) {
- diagnostics.add(`[re-frame2-pair-e2e:${label}:browser:navigation] ${frame.url}`);
- }
- });
- await page.goto(ctx.fixtureUrl, { waitUntil: 'load' });
- return { browser, page };
+  const playwright = require('playwright');
+  const browser = await playwright.chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const diagnostics = ctx && ctx.diagnostics;
+  const label = ctx && ctx.spec ? ctx.spec : 'open-page';
+  if (diagnostics) {
+    diagnostics.add(`[re-frame2-pair-e2e:${label}] URL: ${ctx.fixtureUrl}`);
+  }
+  page.on('console', (msg) => {
+    if (diagnostics) diagnostics.add(`[re-frame2-pair-e2e:${label}:browser:${msg.type()}] ${msg.text()}`);
+  });
+  page.on('pageerror', (err) => {
+    if (!diagnostics) return;
+    diagnostics.add(`[re-frame2-pair-e2e:${label}:browser:pageerror] ${err.message}`, 'stderr');
+    if (err.stack) diagnostics.add(err.stack, 'stderr');
+  });
+  page.on('framenavigated', (frame) => {
+    if (diagnostics && frame === page.mainFrame()) {
+      diagnostics.add(`[re-frame2-pair-e2e:${label}:browser:navigation] ${frame.url()}`);
+    }
+  });
+  await page.goto(ctx.fixtureUrl, { waitUntil: 'load' });
+  return { browser, page };
 }
 
 module.exports = {
- createDiagnostics,
- flushDiagnostics,
- isVerboseTests,
- runShim,
- parseEdn,
- openPage,
+  createDiagnostics,
+  flushDiagnostics,
+  isVerboseTests,
+  runShim,
+  parseEdn,
+  openPage,
 };

--- a/skills/re-frame2-pair/tests/e2e/run.cjs
+++ b/skills/re-frame2-pair/tests/e2e/run.cjs
@@ -4,12 +4,12 @@
  *
  * Sequenced:
  *
- * 1. Skip if RE_FRAME2_PAIR_FIXTURE_URL is unset and the default localhost
- * probe fails — the suite is e2e-only by design; the runtime/shim
- * surfaces cover everything that doesn't need a browser.
- * 2. For each *.e2e.cjs spec next to this file: spawn it as a child,
- * forward env vars, collect exit code.
- * 3. Aggregate; exit non-zero on any failure.
+ *   1. Skip if RE_FRAME2_PAIR_FIXTURE_URL is unset and the default localhost
+ *      probe fails — the suite is e2e-only by design; the runtime/shim
+ *      surfaces cover everything that doesn't need a browser.
+ *   2. For each *.e2e.cjs spec next to this file: spawn it as a child,
+ *      forward env vars, collect exit code.
+ *   3. Aggregate; exit non-zero on any failure.
  *
  * Spec contract: each *.e2e.cjs exports `async function run(ctx)` where
  * ctx = { fixtureDir, fixtureUrl, skillRoot }. Specs throw to signal
@@ -21,99 +21,99 @@ const fs = require('fs');
 const path = require('path');
 const http = require('http');
 const {
- createDiagnostics,
- flushDiagnostics,
- isVerboseTests,
+  createDiagnostics,
+  flushDiagnostics,
+  isVerboseTests,
 } = require('./_helpers.cjs');
 
 const HERE = __dirname;
 const SKILL_ROOT = path.resolve(HERE, '..', '..');
-const VERBOSE_TESTS = isVerboseTests;
+const VERBOSE_TESTS = isVerboseTests();
 
 async function pingFixture(url, timeoutMs = 1500) {
- return new Promise((resolve) => {
- const req = http.get(url, (res) => {
- res.resume;
- resolve(res.statusCode >= 200 && res.statusCode < 500);
- });
- req.on('error',  => resolve(false));
- req.setTimeout(timeoutMs,  => {
- req.destroy;
- resolve(false);
- });
- });
+  return new Promise((resolve) => {
+    const req = http.get(url, (res) => {
+      res.resume();
+      resolve(res.statusCode >= 200 && res.statusCode < 500);
+    });
+    req.on('error', () => resolve(false));
+    req.setTimeout(timeoutMs, () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
 }
 
-function pickFixtureDir {
- if (process.env.RE_FRAME2_PAIR_FIXTURE_DIR) return process.env.RE_FRAME2_PAIR_FIXTURE_DIR;
- const guess = path.join(SKILL_ROOT, 'tests', 'fixture');
- return fs.existsSync(path.join(guess, 'shadow-cljs.edn')) ? guess : null;
+function pickFixtureDir() {
+  if (process.env.RE_FRAME2_PAIR_FIXTURE_DIR) return process.env.RE_FRAME2_PAIR_FIXTURE_DIR;
+  const guess = path.join(SKILL_ROOT, 'tests', 'fixture');
+  return fs.existsSync(path.join(guess, 'shadow-cljs.edn')) ? guess : null;
 }
 
-function pickFixtureUrl {
- return process.env.RE_FRAME2_PAIR_FIXTURE_URL || 'http://localhost:8030';
+function pickFixtureUrl() {
+  return process.env.RE_FRAME2_PAIR_FIXTURE_URL || 'http://localhost:8030';
 }
 
-async function main {
- const fixtureDir = pickFixtureDir;
- const fixtureUrl = pickFixtureUrl;
- const diagnostics = createDiagnostics({ verbose: VERBOSE_TESTS });
- diagnostics.add(`[re-frame2-pair-e2e] fixture URL: ${fixtureUrl}`);
- diagnostics.add(`[re-frame2-pair-e2e] fixture dir: ${fixtureDir || '(not found)'}`);
+async function main() {
+  const fixtureDir = pickFixtureDir();
+  const fixtureUrl = pickFixtureUrl();
+  const diagnostics = createDiagnostics({ verbose: VERBOSE_TESTS });
+  diagnostics.add(`[re-frame2-pair-e2e] fixture URL: ${fixtureUrl}`);
+  diagnostics.add(`[re-frame2-pair-e2e] fixture dir: ${fixtureDir || '(not found)'}`);
 
- const fixtureUp = await pingFixture(fixtureUrl);
- if (!fixtureUp) {
- // Soft-skip — not a CI failure. The e2e gate is opt-in.
- console.log(
- '[re-frame2-pair-e2e] skipped — fixture not available at ' +
- fixtureUrl +
- ' (set RE_FRAME2_PAIR_FIXTURE_URL to override; start the fixture with '
- + '`cd tests/fixture && npx shadow-cljs watch app`).',
-);
- process.exit(0);
- }
- diagnostics.add('[re-frame2-pair-e2e] fixture reachable');
+  const fixtureUp = await pingFixture(fixtureUrl);
+  if (!fixtureUp) {
+    // Soft-skip — not a CI failure. The e2e gate is opt-in.
+    console.log(
+      '[re-frame2-pair-e2e] skipped — fixture not available at ' +
+        fixtureUrl +
+        ' (set RE_FRAME2_PAIR_FIXTURE_URL to override; start the fixture with '
+        + '`cd tests/fixture && npx shadow-cljs watch app`).',
+    );
+    process.exit(0);
+  }
+  diagnostics.add('[re-frame2-pair-e2e] fixture reachable');
 
- const ctx = { fixtureDir, fixtureUrl, skillRoot: SKILL_ROOT, diagnostics };
+  const ctx = { fixtureDir, fixtureUrl, skillRoot: SKILL_ROOT, diagnostics };
 
- const specs = fs
- .readdirSync(HERE)
- .filter((f) => f.endsWith('.e2e.cjs'))
- .sort;
+  const specs = fs
+    .readdirSync(HERE)
+    .filter((f) => f.endsWith('.e2e.cjs'))
+    .sort();
 
- if (specs.length === 0) {
- console.error('[re-frame2-pair-e2e] no spec files found in ' + HERE);
- flushDiagnostics(diagnostics);
- process.exit(1);
- }
+  if (specs.length === 0) {
+    console.error('[re-frame2-pair-e2e] no spec files found in ' + HERE);
+    flushDiagnostics(diagnostics);
+    process.exit(1);
+  }
 
- let failures = 0;
- for (const spec of specs) {
- const specPath = path.join(HERE, spec);
- diagnostics.add('[re-frame2-pair-e2e] running ' + spec);
- try {
- const mod = require(specPath);
- if (typeof mod.run !== 'function') {
- throw new Error('spec did not export `run(ctx)`');
- }
- await mod.run({ ...ctx, spec });
- diagnostics.add('[re-frame2-pair-e2e] ' + spec + ' PASS');
- } catch (err) {
- failures += 1;
- console.error('[re-frame2-pair-e2e] ' + spec + ' FAIL: ' + (err.message || err));
- diagnostics.add('[re-frame2-pair-e2e] ' + spec + ' FAIL: ' + (err.stack || err), 'stderr');
- }
- }
+  let failures = 0;
+  for (const spec of specs) {
+    const specPath = path.join(HERE, spec);
+    diagnostics.add('[re-frame2-pair-e2e] running ' + spec);
+    try {
+      const mod = require(specPath);
+      if (typeof mod.run !== 'function') {
+        throw new Error('spec did not export `run(ctx)`');
+      }
+      await mod.run({ ...ctx, spec });
+      diagnostics.add('[re-frame2-pair-e2e]   ' + spec + ' PASS');
+    } catch (err) {
+      failures += 1;
+      console.error('[re-frame2-pair-e2e]   ' + spec + ' FAIL: ' + (err.message || err));
+      diagnostics.add('[re-frame2-pair-e2e]   ' + spec + ' FAIL: ' + (err.stack || err), 'stderr');
+    }
+  }
 
- if (failures > 0) {
- console.error('[re-frame2-pair-e2e] ' + failures + ' failed');
- flushDiagnostics(diagnostics);
- process.exit(1);
- }
- console.log('[re-frame2-pair-e2e] ' + specs.length + ' passed');
+  if (failures > 0) {
+    console.error('[re-frame2-pair-e2e] ' + failures + ' failed');
+    flushDiagnostics(diagnostics);
+    process.exit(1);
+  }
+  console.log('[re-frame2-pair-e2e] ' + specs.length + ' passed');
 }
 
-main.catch((err) => {
- console.error(err);
- process.exit(1);
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
 });


### PR DESCRIPTION
Read-only correctness review (Shape 3) of the 9 skills under `/skills` — the last slice of the rf2-5t8mr correctness sweep (children .31–.39). Adversarial, defect-only (not a style pass).

## Defects fixed

**rf2-1sq8u (HIGH) — e2e surface non-loadable.** Commit `2c49b87ae`'s "strip bead refs" sweep blanket-stripped zero-arg parens `()` across `tests/e2e/_helpers.cjs` AND `tests/e2e/run.cjs` (`isEmpty()`→`isEmpty`, `new Map()`→`new Map`, `() =>`→`=>`, `function skip()`→`function skip`, …) — a `SyntaxError` that bricked the helper test + all 3 e2e specs that require it. Restored both files from the pre-corruption parent (`2c49b87ae~1`) and re-applied only the intended `(rf2-cxik)` comment strip. The staged blobs differ from the parent by **exactly** the two bead-ref lines.
- Gate: `node --check` passes on both; `_helpers.test.cjs` passes 4/4.

**rf2-uuwzc (MED) — `breaking-changes.md` "stays the same" wrong.** Line 146 listed the dropped v1 `flow<-` (no such surface in v2); line 143 listed `unwrap` (renamed to `unwrap-interceptor` per M-59) as unchanged. Both corrected.

**rf2-3gv4x (MED) — invented `reg-event-schema`.** Cited as a v2 registration/discovery surface in 4 migration leaves (`breaking-changes` / `setup` / `sequencing` / `auto-cross-cutting`). No such fn exists in v1 or v2; event-payload schemas attach via `:spec` metadata on `reg-event-*` (M-27). Replaced with the accurate `:spec` surface.

**+2 same-class defects found during the hunt:**
- `auto-call-site-rewrites.md` M-1 rewrite table claimed `(rf/get-handler kind id)` as the v2 replacement — no public `get-handler` exists. The public registrar query is `rf/handler-meta`. Corrected.
- `re_frame2_pair/runtime.cljs` MCP↔runtime fn table named the `list-handlers` runtime fn `rf/registry-list` (nonexistent); the code itself uses `rf/registrations` (line 349). Corrected the comment. clj-kondo: 0 errors.

## Per-skill verdict

| Skill | Verdict |
|---|---|
| re-frame-migration (.31) | 3 fixed (rf2-3gv4x, rf2-uuwzc, +get-handler) |
| re-frame2-implementor (.32) | clean |
| re-frame2-improver (.33) | clean |
| re-frame2-pair-retro (.34) | clean |
| re-frame2-pair (.35) | 2 fixed (rf2-1sq8u, +registry-list) |
| re-frame2-setup (.36) | clean |
| re-frame2-xray (.37) | clean |
| re-frame2 (.38) | clean — api-cheatsheet fully verified vs core.cljc |
| shared (.39) | clean |

## Verification performed
- `api-cheatsheet.md`: every surface (~90) + the 10 flagged suspect symbols (`reg-app-schemas`, `with-fx-overrides`, `with-new-frame`, `compute-sub`, `subscribe-once`, `frame-bound-fn`/`bound-fn`, `reset-frame-db!`, `validate-at-boundary-interceptor`, `project-error`, `render-tree-hash`) confirmed present in `re-frame.core` and accurately documented.
- No `rf/` symbols outside the public surface in any of the 9 skills (after fixes).
- All 8 `plugin.json` parse; all SKILL.md frontmatter valid; no broken relative markdown links; all SKILL.md leaf refs and `examples/` paths resolve; SSR/routing reserved keywords real.

## Gates
Skill-source markdown is **not** ingested by mkdocs (the `docs/skills/*.md` landing pages are separate hand-written files), so no doc-build code gate applies. Code-touch gates run: `node --check` (both .cjs, pass), `_helpers.test.cjs` (4/4), clj-kondo on `runtime.cljs` (0 errors).

Closes rf2-1sq8u, rf2-uuwzc, rf2-3gv4x.