### PR TITLE
fix(adapters/uix): frame-provider reads JS-object props under documented ($ ...) shape (rf2-8svnm)

### DIFF
--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -11,7 +11,8 @@
   configuration: gensym prefixes, substrate name (used in warn-once
   text), and the runtime hook fns from `uix.hooks.alpha` (the
   `uix.core` macros expand to these)."
-  (:require [uix.core          :as uix]
+  (:require [goog.object       :as gobj]
+            [uix.core          :as uix]
             [uix.hooks.alpha   :as uix-hooks]
             [re-frame.substrate.spine   :as spine]))
 
@@ -48,7 +49,26 @@
   that chain. Per rf2-84myk."
   (:use-current-frame spine-fns))
 
-(def frame-provider
+(def ^:private spine-frame-provider
+  "The shared-spine `frame-provider` fn. Destructures a CLJS-map props
+  argument (`{:keys [frame children]}`). The public `frame-provider`
+  below wraps it so the documented `($ frame-provider {...})` call shape
+  works (see that var's docstring)."
+  (:frame-provider spine-fns))
+
+(defn- glue-uix-props
+  "Reconstruct the CLJS props map from the JS object UIx's `$` hands a
+  component down the lossless `uix-component-element` path. Mirrors
+  `uix.core/glue-args`: the original CLJS props map is stashed under
+  `argv`, and any `$`-trailing children React appended sit under
+  `children`. Reading `argv` (rather than the React-level string keys)
+  preserves keyword *values* losslessly — see `frame-provider`'s
+  docstring for why that matters."
+  [^js props]
+  (cond-> (gobj/get props "argv")
+    (gobj/get props "children") (assoc :children (gobj/get props "children"))))
+
+(defn frame-provider
   "User-facing component scoping `frame-kw` to its subtree. Wraps
   children in the shared frame Context Provider. UIx call shape:
 
@@ -58,8 +78,44 @@
   Per rf2-sixo: missing or `nil` `:frame` falls through to `:rf/default`.
   The three React-shaped adapters share one React Context (per rf2-3yij
   Decision 2) so a subtree under any frame-provider sees the right
-  frame regardless of which substrate rendered the provider."
-  (:frame-provider spine-fns))
+  frame regardless of which substrate rendered the provider.
+
+  Prop normalisation (rf2-8svnm — the UIx twin of the Helix rf2-9ok1s
+  defect, with a UIx-specific twist). The shared-spine `frame-provider`
+  is a plain CLJS fn that destructures a CLJS-map props argument. A bare
+  re-export breaks under the documented `($ frame-provider {...})` shape:
+  because the re-exported fn carries no `.-uix-component?` marker, UIx's
+  `$` routes it through `uix.compiler.alpha/react-component-element` →
+  `interpret-attrs`, which (a) hands the component a *raw JS object* with
+  string keys, and — the UIx-specific twist Helix's `$` does NOT share —
+  (b) *stringifies keyword prop values to their bare name*, dropping the
+  namespace (`:my.ns/frame` → `\"frame\"`). So even reading the string key
+  yields a namespace-less string that no longer matches the registered
+  frame keyword: `:frame` effectively resolves to `:rf/default` and the
+  subtree renders nothing. No throw, no warning.
+
+  Fix (UIx-local; does not touch the shared spine): mark `frame-provider`
+  with `.-uix-component?` so `$` routes it through the *lossless*
+  `uix-component-element` path instead. That path stashes the original
+  CLJS props map under the JS object's `argv` slot (the same channel a
+  real `defui` uses) — keyword values survive intact. The body then
+  reconstructs the CLJS map via `glue-uix-props` (mirroring
+  `uix.core/glue-args`) and delegates to the spine. When invoked directly
+  as a CLJS fn with a real map (the shape the shared test suite uses),
+  it passes through unchanged. Both call shapes reach the spine fn with
+  the same CLJS-map contract, keywords intact."
+  [props]
+  (if (map? props)
+    ;; Direct CLJS-fn invocation (e.g. shared test suite) — pass through.
+    (spine-frame-provider props)
+    ;; `$`-supplied JS object on the lossless uix-component path — the
+    ;; original CLJS map (keywords intact) lives under `argv`.
+    (spine-frame-provider (glue-uix-props props))))
+
+;; Route `$` through UIx's lossless `uix-component-element` (`argv`) path
+;; rather than the keyword-stringifying `react-component-element` path.
+;; See `frame-provider`'s docstring (rf2-8svnm).
+(set! (.-uix-component? frame-provider) true)
 
 (def use-subscribe
   "UIx hook that reads a re-frame subscription. Returns the current

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -25,8 +25,11 @@
   (ns-regexp `-dom-cljs-test$`) discovers it for the real DOM assertions;
   `:node-test`'s `cljs-test$` regex also matches, where every suite fn
   self-gates on `(browser?)` and no-ops cleanly."
-  (:require [cljs.test :refer-macros [deftest use-fixtures]]
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
             [uix.core :as uix :refer-macros [defui $]]
+            [re-frame.core :as rf]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.adapter.react-shared-suite :as suite]
             [re-frame.test-support :as test-support]))
@@ -162,3 +165,61 @@
 (deftest view-unmount-emits-on-react-hook-teardown
   (suite/assert-view-unmount-emits-on-react-hook-teardown
     {:substrate-kw :uix :name "UIx"}))
+
+;; ---- regression: frame-provider under the documented `$` shape (rf2-8svnm) -
+;;
+;; The UIx twin of the Helix rf2-9ok1s defect. The shared-suite
+;; `assert-use-subscribe-frame-provider-resolution` invokes `frame-provider`
+;; DIRECTLY as a CLJS fn (with a real CLJS map) — that path NEVER exercises
+;; UIx's `$`. `frame-provider` is a plain re-exported CLJS fn, NOT a `defui`
+;; component (no `.-uix-component?` marker), so UIx's `$` routes it through
+;; `uix.compiler.alpha/react-component-element` → `interpret-attrs`, handing
+;; the component a *raw JS object* (string keys "frame"/"children") rather
+;; than the `argv`-wrapped shape `glue-args` unwraps for a real `defui`. The
+;; bare spine re-export read `nil` for both keys under that shape: `:frame`
+;; silently resolved to `:rf/default` and the subtree rendered nothing. This
+;; test mounts the provider via the EXACT documented `($ frame-provider {...})`
+;; shape and asserts the descendant `use-subscribe` reads the WRAPPED frame's
+;; value (proving the frame propagated). Fails before the uix.cljs prop-
+;; normalisation wrapper; passes after.
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [test-utils (js/require "react-dom/test-utils")]
+          (.-act test-utils))
+        (catch :default _ nil))))
+
+(deftest frame-provider-dollar-shape-propagates-frame
+  (testing "UIx — ($ frame-provider {...}) propagates :frame to descendants (rf2-8svnm)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (let [frame-kw :rf.uix-use-subscribe-test/frame-provider-frame
+                query-v  [:rf.uix-use-subscribe-test/k]]
+            (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+            (reset! probe-frame-provider-observed [])
+            (rf/reg-frame frame-kw {:doc "rf2-8svnm $-shape frame-provider probe"})
+            (rf/reg-event-db ::dollar-shape-seed (fn [_ _] {:k :wrapped}))
+            (rf/dispatch-sync [::dollar-shape-seed] {:frame frame-kw})
+            (rf/reg-sub (first query-v) (fn [db _] (:k db)))
+            (let [mount-node (.createElement js/document "div")
+                  root       (react-dom-client/createRoot mount-node)]
+              (try
+                (act-fn
+                  (fn []
+                    ;; The documented public call shape — props flow
+                    ;; through UIx's `$` as a raw JS object.
+                    (.render root
+                      ($ uix-adapter/frame-provider
+                         {:frame frame-kw :children [($ ProbeFrameProvider)]}))))
+                (is (some #{:wrapped} @probe-frame-provider-observed)
+                    "descendant use-subscribe read the wrapped frame's value, not :rf/default")
+                (finally
+                  (try (.unmount root) (catch :default _ nil)))))))))))


### PR DESCRIPTION
## What

UIx **shares** the Helix rf2-9ok1s `frame-provider` defect — with a UIx-specific twist that makes it worse.

The UIx adapter re-exported the shared-spine `frame-provider` (a plain CLJS fn destructuring `{:keys [frame children]}`). Under the documented public call shape `($ frame-provider {:frame :session :children [...]})`, UIx's `$` routes a non-`defui` component through `uix.compiler.alpha/react-component-element` → `interpret-attrs`, which:

- (a) hands the component a **raw JS object** with string keys, and
- (b) — the UIx-specific twist Helix's `$` does **not** share — **stringifies keyword prop values to their bare name**, dropping the namespace (`:my.ns/frame` → `"frame"`).

So `:frame` keyword-lookup yielded `nil`, and even a `goog.object` string-key read (the Helix fix) would only recover a namespace-less string that no longer matches the registered frame keyword. `:frame` effectively resolved to `:rf/default` and the subtree rendered nothing — no throw, no warning. The bug was latent because every existing test invokes `frame-provider` directly as a CLJS fn (a real CLJS map), never via `$`.

## Fix (UIx-local; shared spine untouched)

Wrap the spine `frame-provider` in a `defn` and mark it with `.-uix-component?` so `$` routes it through the **lossless** `uix-component-element` path. That path stashes the original CLJS props map under the JS object's `argv` slot (the same channel a real `defui` uses) — keyword values survive intact. The body reconstructs the CLJS map via `glue-uix-props` (mirroring `uix.core/glue-args`) and delegates to the spine. A direct CLJS-map call (the shared suite's shape) passes through unchanged. Both call shapes reach the spine with the same CLJS-map contract, keywords intact.

A `goog.object` string-key read (the Helix approach) is **not** sufficient for UIx because the namespace is already lost by that point — hence the lossless-`argv` routing instead.

## Test

`uix_use_subscribe_dom_cljs_test.cljs` — mounts the provider via the exact `($ frame-provider {...})` shape and asserts a descendant `use-subscribe` reads the wrapped frame's value, not `:rf/default`. Verified **failing-before / passing-after** (before-check: marker disabled → 1 failure, `actual: [nil]`; after: 0 failures).

## Spec

Spec unchanged: Spec 006 declares the prop-passing call shape as port-discretion, so this is a defect against the contract, not a spec change.

## Quality gates

| Gate | Result |
|------|--------|
| `npm run test:browser` (real DOM, exercises the new assertion) | 132 tests / 369 assertions — **0 failures, 0 errors** |
| `npm run test:cljs` (node runtime; uix dom test self-gates to no-op) | 5165 tests / 17422 assertions — **0 failures, 0 errors** |
| `clojure -M:test` (uix adapter classpath probe) | 0 tests by design (classpath-probe alias per deps.edn) |
| clj-kondo (changed files) | **0 errors, 0 warnings** |
| Failing-before / passing-after | Confirmed (marker disabled → new test fails with `[nil]`; restored → passes) |