### PR TITLE
docs(readme): fix root README tools-layout/coord + impl reagent-slim status (rf2-rim2n, rf2-pod7v)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,12 +237,15 @@ tools/                         CLJS dev/inspection tools that consume re-frame2'
                                the rebuild settles; see tools/template/spec/005-Repo-Split.md).
   story/                       day8/re-frame2-story — Storybook-flavoured playground
   story-mcp/                   day8/re-frame2-story-mcp — MCP agent surface for story
-  re-frame2-pair-mcp/                   day8/re-frame2-re-frame2-pair-mcp — MCP agent surface for the re-frame2-pair
+  re-frame2-pair-mcp/          @day8/re-frame2-pair-mcp — MCP agent surface for the re-frame2-pair
                                nREPL companion
-  xray/                       day8/re-frame2-xray — Xray, the re-frame2 devtools panel;
+  xray/                        day8/re-frame2-xray — Xray, the re-frame2 devtools panel;
                                the structural successor to re-frame-10x
-  machines-viz-mcp/            day8/re-frame2-machines-viz-mcp — MCP agent surface for machines-viz
-                               (spec-only)
+  machines-viz/                day8/re-frame2-machines-viz — substrate-agnostic MachineChart
+                               component + read-only viewer surfaces (the chart extracted out of
+                               Xray; also hosts the pure Mermaid emitter)
+  testbed-support/             Shared testbed-config helper (single ns re-frame.testbed.config);
+                               consumed by the framework testbed builds
   mcp-base/                    Shared CLJC library for the MCP servers (arg parsing, redaction,
                                cap, overflow); bundle-isolated boundary helpers
   mcp-conformance/             Cross-server MCP conformance harness — gates wire-vocabulary parity

--- a/implementation/README.md
+++ b/implementation/README.md
@@ -91,11 +91,14 @@ implementation/
       src/re_frame/adapter/helix.cljs
                              The Helix adapter.
     reagent-slim/            day8/reagent-slim — Reagent rewrite for React 19
-                             (rf2-5djt; Stage 4 rf2-6hyy). Stage 4-A landed: reactive
-                             primitives in src/reagent2/ratom.{clj,cljs}. Subsequent
-                             sub-stages add render scheduler, component-shape detection,
-                             hiccup translation, render-to-static-markup, throw-on-call
-                             shims, examples + MIGRATION.
+                             (rf2-5djt; Stage 4 rf2-6hyy). Stage 4 landed: the full
+                             reagent2.* rewrite on disk — reactive primitives
+                             (ratom), render scheduler (impl/batching), component-shape
+                             detection (impl/component), hiccup translation
+                             (impl/template), DOM Root API (dom + dom/client) and
+                             pure-CLJS render-to-string (dom/server), plus the
+                             re-frame.adapter.reagent-slim adapter and its own CLJS
+                             test suite (~20 test files).
 
   schemas/                   day8/re-frame2-schemas — schemas (Spec 010, rf2-p7va).
     deps.edn                 :local/root dep on ../core; pulls Malli for runtime validation.
@@ -163,9 +166,10 @@ The Reagent adapter is the canonical adapter — every test target (every
 run, every `examples` run, every conformance fixture) executes against
 it. UIx and Helix adapters are smoke-tested via the counter + login
 pair per [Conventions §Adapter test matrix policy](../spec/Conventions.md#adapter-test-matrix-policy).
-The `reagent-slim` adapter is in active development (Stage 4-A landed —
-reactive primitives only); it does not yet participate in the test
-matrix.
+The `reagent-slim` adapter has landed Stage 4 (the full `reagent2.*`
+rewrite) and carries its own CLJS test suite — the `reagent2.*` internals
+plus the slim-adapter substrate-shape, container round-trip, derived-value,
+disposal, render-sequence, and source-coord / view-id contracts.
 
 ## Running tests
 

--- a/implementation/adapters/README.md
+++ b/implementation/adapters/README.md
@@ -11,8 +11,10 @@ This directory groups re-frame2's **substrate adapters** — implementations of 
 | [`reagent/`](reagent/) | Reagent adapter | `day8/re-frame2-reagent` | Reagent 2.x — the canonical CLJS reference adapter |
 | [`uix/`](uix/) | UIx adapter | `day8/re-frame2-uix` | UIx 2.x — modern hooks-based React layer |
 | [`helix/`](helix/) | Helix adapter | `day8/re-frame2-helix` | Helix 0.2.x — minimal React wrapper |
-| [`reagent-slim/`](reagent-slim/) | Reagent-slim adapter | `day8/re-frame2-reagent-slim` (NB: artefact coord is `day8/reagent-slim` per IMPL-SPEC DECISION-1) | Reagent rewrite for React 19 — Stage 4 landed (full `reagent2.*` rewrite) |
+| [`reagent-slim/`](reagent-slim/) | Reagent-slim adapter | `day8/reagent-slim` [^slim-coord] | Reagent rewrite for React 19 — Stage 4 landed (full `reagent2.*` rewrite) |
 | [`test-react/`](test-react/) | Test-React adapter | `day8/re-frame2-test-react` | Pure-CLJC React class-3 lifecycle simulator — unit-testable lifecycle bug catching; carries ported regressions incl. the organic rf2-4l7t2 sync-unmount-during-render repro (rf2-gqyqv skeleton, broadened rf2-n2cuo) |
+
+[^slim-coord]: The `re-frame2-` prefix is dropped on this coord (per IMPL-SPEC DECISION-1); it is the lone adapter artefact published as `day8/reagent-slim` rather than `day8/re-frame2-*`.
 
 A consumer picks one (or more) by adding the matching artefact to their `deps.edn` alongside `day8/re-frame2`. Bundle isolation is **structural** — the wrong adapter is absent from the classpath, not eliminated by dead-code analysis. See [Conventions §Substrate-adapter shipping convention](../../spec/Conventions.md).
 


### PR DESCRIPTION
Two README doc-fix beads from the rf2-mro7d README audit, in one PR.

## rf2-rim2n (P1) — root `README.md` tools/ layout drift
- Fixed the doubled coord `day8/re-frame2-re-frame2-pair-mcp` -> `@day8/re-frame2-pair-mcp` (it is an npm package, confirmed by `tools/re-frame2-pair-mcp/package.json` and README.md:3).
- Removed the non-existent `machines-viz-mcp/ (spec-only)` layout entry — there is no `tools/machines-viz-mcp/` dir on disk; it lives only in `tools/README.md`'s In-design/planned section.
- Added the real `machines-viz/` tool (`day8/re-frame2-machines-viz` — substrate-agnostic MachineChart component + read-only viewer, 40+ src files; also hosts the pure Mermaid emitter).
- Added the omitted `testbed-support/` (shared testbed-config helper, single ns `re-frame.testbed.config`, consumed by the framework testbed builds).

## rf2-pod7v (P2) — implementation README(s) reagent-slim status
- `implementation/README.md` L93-98 + L166-168: corrected the understated reagent-slim status from "Stage 4-A landed — reactive primitives only; does not yet participate in the test matrix" to the on-disk reality: **Stage 4 landed (full `reagent2.*` rewrite)** — core/dom/dom.client/dom.server/impl.{batching,component,template}/ratom + the `re-frame.adapter.reagent-slim` adapter + its own CLJS test suite (~20 test files). Aligns with the sibling `implementation/adapters/README.md` L19 wording.
- `implementation/adapters/README.md` L14: the **Maven artefact** cell now reads `day8/reagent-slim` (the correct coord, no `re-frame2-` prefix per IMPL-SPEC DECISION-1); the prefix-drop note demoted to a footnote.

## What I verified against the repo
- `git ls-files tools/`: real top-level tools = machines-viz, mcp-base, mcp-conformance, re-frame2-pair-mcp, story, story-mcp, template, testbed-support, xray. No `machines-viz-mcp/`.
- pair-mcp coord `@day8/re-frame2-pair-mcp` — `tools/re-frame2-pair-mcp/package.json` + README.md:3.
- machines-viz coord `day8/re-frame2-machines-viz` — `tools/machines-viz/deps.edn` header; testbed-support role — `implementation/shadow-cljs.edn` L128-136.
- reagent-slim coord `day8/reagent-slim` — `tools/../reagent-slim/deps.edn` `:lib` + README.md:3.
- reagent-slim full `reagent2.*` src + ~20 test files on disk via `git ls-files implementation/adapters/reagent-slim/{src,test}`.

## Quality gates
Markdown-only, no code changed -> no clj-kondo. None of the three edited READMEs is in the mkdocs nav (`mkdocs.yml` references only `guide/`, `api/`, and `migration/` READMEs; line 21 notes mkdocs deliberately ignores the README tree), so no `mkdocs build --strict` gate applies.
