### PR TITLE
fix(pair-mcp): include :epochs/:traces/:sub-cache in snapshot precheck cache key (rf2-3ljsa)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/Principles.md
+++ b/tools/re-frame2-pair-mcp/spec/Principles.md
@@ -855,6 +855,21 @@ Saving the round-trip too needs a server-side hash precheck
 first, only ship the body on miss) — out of scope for
 rf2-3rt1f, filed as a follow-on bead.
 
+**Precheck eligibility (rf2-36xod follow-on; rf2-3ljsa)**. The
+precheck landed: `(re-frame2-pair.runtime/app-db-hash frame)` is
+shipped first, and a match short-circuits the tool eval. Because
+that hash is `(hash app-db@frame)` ONLY, a tool is precheck-eligible
+solely when its result is a pure function of `app-db@frame`. For
+`snapshot` this constrains the resolved `:include` to the app-db-
+derived slices `{:app-db :machines}` — `:sub-cache`/`:epochs`/
+`:traces` accrue without an app-db write (every event cascade
+appends an epoch + trace record, even a no-`:db` handler), so a
+snapshot retaining any of those three (including the default all-
+five `:include`) is NOT precheck-eligible and falls back to the
+post-eval result-hash cache above, which hashes the full text and
+so never serves a stale non-app-db slice. `get-path` reads an
+app-db subtree and so is always eligible.
+
 **Why opt-in by default**. Agent hosts that haven't been
 taught the `:rf.mcp/cache-hit` marker shape would receive a
 sub-100-byte marker instead of the expected payload on the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
@@ -10,12 +10,39 @@
   hit marker WITHOUT running the tool — saving both the wire bytes AND
   the full tool eval.
 
-  Eligibility (today): single-frame `snapshot` and `get-path`. Their
-  result is a function of `(frame, args, app-db@frame)`; same frame +
-  same args + same db-hash ⇒ same result. Multi-frame `snapshot`
+  Eligibility (today): single-frame `snapshot` whose resolved
+  `:include` is app-db-derived only, and `get-path`. Their result is a
+  function of `(frame, args, app-db@frame)`; same frame + same args +
+  same db-hash ⇒ same result. Multi-frame `snapshot`
   (`:frames :all` or a vector) is NOT eligible because we'd need to
   hash every frame's db separately and combine — out of scope; the
   legacy post-eval `apply-cache` path still catches those.
+
+  Snapshot's `:include` slices split by what the precheck hash sees
+  (rf2-3ljsa). The precheck hash is `(re-frame2-pair.runtime/app-db-hash
+  frame)` = `(hash app-db@frame)` only — it tracks `:db-after` at every
+  settled mutation. So a slice is precheck-sound IFF it is a pure
+  function of `app-db@frame`:
+
+    - `:app-db`   — IS the frame db. Sound.
+    - `:machines` — `:state` lives at `[:rf/runtime :machines :snapshots]`
+                    INSIDE app-db; `:ids` is the install-time registrar
+                    list (stable across event cascades). Sound.
+    - `:sub-cache`— reactive cache over external inputs; can move without
+                    an app-db write. NOT sound.
+    - `:epochs`   — the per-frame epoch ring; a record is appended on
+                    EVERY event cascade, including no-`:db` handlers, so
+                    it changes while `app-db-hash` stays constant. NOT
+                    sound.
+    - `:traces`   — the per-frame trace ring; same accrue-without-db-
+                    change behaviour as `:epochs`. NOT sound.
+
+  A default snapshot (no `:include`) resolves to ALL FIVE slices, which
+  contains the unsound three — so the default is NOT precheck-eligible
+  and falls through to the post-eval `apply-cache`, which hashes the
+  full result text and so cannot serve a stale `:epochs`/`:traces`/
+  `:sub-cache` payload. Precheck is taken only when the caller narrows
+  `:include` to the app-db-derived subset.
 
   Trace tools (`trace-window`, `watch-epochs`, `discover-app`) are not
   eligible — their result depends on the epoch ring / health surface,
@@ -26,6 +53,16 @@
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.args :as args]))
+
+(def app-db-derived-snapshot-slices
+  "Snapshot slices whose value is a pure function of `app-db@frame`
+  (rf2-3ljsa). Only these are precheck-sound under the
+  `(hash app-db@frame)` precheck hash; `:sub-cache`/`:epochs`/`:traces`
+  can change while that hash stays constant, so a snapshot whose
+  resolved `:include` is NOT a subset of this set is precheck-ineligible
+  and falls back to the post-eval result-hash cache. See the ns
+  docstring for the per-slice rationale."
+  #{:app-db :machines})
 
 (defn precheck-target
   "Resolve the precheck target for a single-frame precheck. Returns a
@@ -42,19 +79,32 @@
   not value-level. Future targets (e.g. multi-frame combined-hash)
   add a new tag without colliding with a reserved keyword.
 
-  `snapshot` is eligible only when `:frames` resolves to a single frame
-  (an explicit one-element vector or a single scalar). `:all` or a
-  multi-element vector returns nil — those callers fall back to the
-  post-eval cache.
+  `snapshot` is eligible only when BOTH (a) `:frames` resolves to a
+  single frame (an explicit one-element vector or a single scalar) AND
+  (b) the resolved `:include` is a subset of
+  `app-db-derived-snapshot-slices` (rf2-3ljsa). `:all` or a
+  multi-element vector — or an `:include` that retains
+  `:sub-cache`/`:epochs`/`:traces` (including the default all-five
+  include) — returns nil so the caller falls back to the post-eval
+  cache, which hashes the full result text and so cannot serve stale
+  non-app-db slices.
 
   `get-path` is always eligible (its `:frame` slot is single-valued by
-  contract; absent means \"operating frame\")."
+  contract; absent means \"operating frame\"; it reads an app-db
+  subtree, so any app-db change flips the precheck hash)."
   [tool raw-args]
   (case tool
     "snapshot"
     (let [raw-frames (when raw-args (j/get raw-args "frames"))
-          frames     (args/parse-frames-arg raw-frames)]
+          frames     (args/parse-frames-arg raw-frames)
+          include    (args/parse-include-arg (wire/arg raw-args :include))
+          app-db-derived? (every? app-db-derived-snapshot-slices include)]
       (cond
+        ;; an :include retaining a non-app-db-derived slice
+        ;; (:sub-cache/:epochs/:traces) — the precheck hash can't see
+        ;; those move, so NOT eligible (rf2-3ljsa).
+        (not app-db-derived?)
+        nil
         ;; explicit single-frame vector
         (and (vector? frames) (= 1 (count frames)))
         [:explicit (first frames)]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
@@ -378,3 +378,104 @@
                  (is (zero? (cache/size))
                      "unknown-tool errors do not touch the cache")
                  (done))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-3ljsa — snapshot precheck eligibility is gated on `:include`.
+;;
+;; The precheck hash is `(hash app-db@frame)` only. `:epochs`/`:traces`
+;; accrue a record on EVERY event cascade (incl. no-`:db` handlers) and
+;; `:sub-cache` can move over external inputs — all WITHOUT an app-db
+;; write, so the precheck hash stays constant while those slices change.
+;; A snapshot whose resolved `:include` keeps any of those three is
+;; therefore NOT precheck-eligible; it must fall back to the post-eval
+;; result-hash cache, which hashes the full text and so recomputes.
+;; ---------------------------------------------------------------------------
+
+;; The MCP wire passes `:frames` / `:include` as JS arrays of strings,
+;; not EDN strings — `parse-frames-arg` / `parse-include-arg` coerce
+;; arrays/sequentials. Build args with JS arrays to match the live shape.
+(deftest precheck-target-snapshot-eligibility-by-include
+  (testing "single-frame snapshot, app-db-only include → eligible"
+    (is (= [:explicit :rf/default]
+           (precheck/precheck-target
+             "snapshot" (args-js {:frames #js ["rf/default"] :include #js ["app-db"]})))
+        ":include [:app-db] is app-db-derived — precheck-eligible")
+    (is (= [:explicit :rf/default]
+           (precheck/precheck-target
+             "snapshot" (args-js {:frames #js ["rf/default"]
+                                  :include #js ["app-db" "machines"]})))
+        ":machines reads app-db only — still eligible"))
+  (testing "single-frame snapshot, default (all-five) include → ineligible"
+    (is (nil? (precheck/precheck-target
+                "snapshot" (args-js {:frames #js ["rf/default"]})))
+        "default include carries :epochs/:traces/:sub-cache — ineligible"))
+  (testing "single-frame snapshot retaining a non-app-db slice → ineligible"
+    (doseq [slice [#js ["app-db" "epochs"]
+                   #js ["app-db" "traces"]
+                   #js ["app-db" "sub-cache"]]]
+      (is (nil? (precheck/precheck-target
+                  "snapshot" (args-js {:frames #js ["rf/default"] :include slice})))
+          (str "include " (vec slice) " retains an unsound slice — ineligible"))))
+  (testing "multi-frame snapshot stays ineligible regardless of include"
+    (is (nil? (precheck/precheck-target
+                "snapshot" (args-js {:frames #js ["a" "b"] :include #js ["app-db"]}))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-3ljsa — END-TO-END staleness guard. A single-frame DEFAULT-include
+;; snapshot is the precise bug shape: precheck would have served a hit
+;; while :epochs/:traces moved. With the fix it is precheck-ineligible,
+;; so the second call re-dispatches (and any change in the result text is
+;; caught by the post-eval cache instead of being silently hidden).
+;; ---------------------------------------------------------------------------
+
+(deftest single-frame-default-snapshot-does-not-precheck-hit
+  (async done
+    (let [args        (args-js {:cache "true" :frames #js ["rf/default"]})
+          fetch-count (atom 0)
+          call-count  (atom 0)]
+      (set-stubs!
+        {;; If precheck WERE consulted it would match and serve a stale
+         ;; hit — so this stub must never fire for the default snapshot.
+         :fetch-precheck-hash (fn [_conn _args _target]
+                                (swap! fetch-count inc)
+                                (js/Promise.resolve 7))
+         :snapshot-tool       (fn [_conn _args]
+                                (swap! call-count inc)
+                                ;; Distinct text per call models :epochs/
+                                ;; :traces accruing while app-db is fixed.
+                                (js/Promise.resolve
+                                  (mcp-result (str "{:epochs " @call-count "}"))))})
+      (-> (tools/invoke nil "snapshot" args nil)
+          (.then (fn [_first] (tools/invoke nil "snapshot" args nil)))
+          (.then (fn [second-result]
+                   (is (zero? @fetch-count)
+                       "precheck NEVER consulted — default include is ineligible (rf2-3ljsa)")
+                   (is (= 2 @call-count)
+                       "second call re-dispatches — no stale precheck hit")
+                   (is (not (cache-hit? second-result))
+                       "differing :epochs text ⇒ fresh result, not a hit")
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-3ljsa — NO over-invalidation. A single-frame APP-DB-ONLY snapshot
+;; is still precheck-eligible: an unchanged app-db hash serves the
+;; precheck hit (the optimisation is preserved for the sound case).
+;; ---------------------------------------------------------------------------
+
+(deftest single-frame-appdb-only-snapshot-still-precheck-hits
+  (async done
+    (let [args (args-js {:cache "true" :frames #js ["rf/default"] :include #js ["app-db"]})]
+      (set-stubs!
+        {:fetch-precheck-hash (fn [_conn _args _target] (js/Promise.resolve 1234))
+         :snapshot-tool       (fn [_conn _args]
+                                (js/Promise.resolve (mcp-result "{:app-db {:k :v}}")))})
+      (-> (tools/invoke nil "snapshot" args nil)
+          (.then (fn [_first] (tools/invoke nil "snapshot" args nil)))
+          (.then (fn [second-result]
+                   (is (cache-hit? second-result)
+                       "unchanged app-db hash ⇒ precheck hit served")
+                   (is (= :precheck
+                          (get-in (extract-edn second-result)
+                                  [:rf.mcp/cache-hit :via]))
+                       "via :precheck — the sound short-circuit is preserved")
+                   (done)))))))


### PR DESCRIPTION
## What

Fixes **rf2-3ljsa** — the rf2-36xod snapshot precheck short-circuit could serve **stale** data.

The precheck hash is `(re-frame2-pair.runtime/app-db-hash frame)` = `(hash app-db@frame)` **only**, but a default `snapshot` returns all five slices (`:app-db :sub-cache :machines :epochs :traces`). `:epochs`/`:traces` accrue a record on **every** event cascade (including a no-`:db` handler), and `:sub-cache` can move over external inputs — all **without** an app-db write. The precheck hash therefore stayed constant while those slices changed, so the precheck wrongly reported `{:rf.mcp/cache-hit :via :precheck}` and the agent reused a stale payload, hiding the fresh epochs/traces. A debugging-trust violation (cache opt-in; default OFF).

## Fix

Gate `snapshot` precheck-eligibility on the resolved `:include`. The fix is on the MCP side (not the runtime hash) so we key precisely on what the precheck hash can actually see, and don't hash volatile non-app-db state.

- New `precheck/app-db-derived-snapshot-slices` = `#{:app-db :machines}` — the slices that are a pure function of `app-db@frame`. (`:machines` reads `[:rf/runtime :machines :snapshots]` **inside** app-db; `:ids` is the install-time registrar list, stable across cascades.)
- `precheck-target` for `"snapshot"` now returns `nil` (precheck-ineligible) whenever the resolved `:include` retains `:sub-cache`/`:epochs`/`:traces` — **including the default all-five include**. Those calls fall back to the post-eval result-hash cache (`apply-cache`), which hashes the full result text and so **cannot** serve a stale payload.
- **No over-invalidation**: a single-frame app-db-only (`:include [:app-db]` / `[:app-db :machines]`) snapshot is still precheck-eligible — an unchanged app-db hash still serves the precheck hit.
- `get-path` unchanged (it reads an app-db subtree; any app-db change flips the hash — already conservative).

### Slices keyed on + why
Sound (kept eligible): `:app-db` (is the frame db), `:machines` (state lives in app-db; ids are install-time). Unsound (force fallback): `:sub-cache` (reactive over external inputs), `:epochs` + `:traces` (accrue on every cascade without a `:db` write).

## Regression tests (failing-before / passing-after)
Verified by temporarily disabling the eligibility branch → the new tests fail (7 failures), restore → green.

- `precheck-target-snapshot-eligibility-by-include` — app-db-only include eligible; default + each unsound-slice include ineligible; multi-frame ineligible.
- `single-frame-default-snapshot-does-not-precheck-hit` — end-to-end: a single-frame **default** snapshot never consults the precheck and re-dispatches (the exact bug shape).
- `single-frame-appdb-only-snapshot-still-precheck-hits` — over-invalidation guard: an app-db-only snapshot **still** hits via `:precheck`.

## Spec
`tools/re-frame2-pair-mcp/spec/Principles.md` — the precheck was out-of-scope/follow-on in rf2-3rt1f and its eligibility contract was unspecified. Added a concise normative note recording the app-db-derived `:include` constraint.

## Quality gates

| Gate | Result |
|------|--------|
| pair-mcp `:server-test` (`npm test`) | **744 tests / 2111 assertions — 0 failures, 0 errors** |
| `npm run test:mcp-conformance` (all 6 gates) | **ALL GREEN** (incl. wire-vocab 49 tests / 623 assertions) |
| clj-kondo (changed cljs files) | **0 errors, 0 warnings** |
| failing-before check (fix disabled) | **7 failures** in the new tests (confirms regression coverage) |
