### PR TITLE
feat(dev): curated dev-testbed group aliases (xray/stories) + URL discoverability (rf2-jooy3)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -257,6 +257,52 @@ the harness logs a warning and falls back to a free OS-chosen port.
 Set `BROWSER_TEST_PORT` to pin a specific port (CI determinism); the
 harness still falls back if that port is busy too.
 
+## Running the dev testbeds
+
+`npm run dev` (`scripts/dev-testbed.cjs`) is the cross-platform launcher
+for the Xray / Story driving surfaces. It seeds `RF2_TESTBED_PROJECT_ROOT`
+(so "open in editor" works on a fresh clone at any path, on any OS) and
+spawns `shadow-cljs watch` for the builds you name. Curated **group
+aliases** (rf2-jooy3) expand a single short name to a whole surface and
+print each watched build's served URL on start:
+
+```sh
+cd implementation
+npm run dev -- xray       # the 5 Xray driving surfaces
+npm run dev -- stories    # the 4 Story showcases
+npm run dev -- epochs     # the standard / routes / machine epochs trio
+npm run dev -- all        # xray + stories
+# package.json shortcuts (no `--` needed):
+npm run dev:xray
+npm run dev:stories
+```
+
+Anything that is not a group name passes through unchanged, so explicit
+build-ids and extra `shadow-cljs watch` flags keep working, and groups
+may be mixed with explicit builds (the launcher de-dupes builds while
+preserving first-seen order):
+
+```sh
+npm run dev -- :examples/standard-epochs
+npm run dev -- stories :examples/standard-epochs
+npm run dev -- xray --verbose
+```
+
+| Group | Build id | URL |
+|---|---|---|
+| `xray` | `:examples/standard-epochs` | http://localhost:8031/ |
+| `xray` | `:examples/routes-epochs` | http://localhost:8032/ |
+| `xray` | `:examples/machine-epochs` | http://localhost:8033/ |
+| `xray` | `:examples/two-frame-isolation` | http://localhost:8030/ |
+| `xray` | `:testbeds/panel-gallery` | http://localhost:8765/ |
+| `stories` | `:examples/nine-states-with-stories` | http://localhost:8040/ · `/#/stories` |
+| `stories` | `:examples/login-with-stories` | http://localhost:8041/ · `/#/stories` |
+| `stories` | `:examples/counter-with-stories` | http://localhost:8042/ · `/#/stories` |
+| `stories` | `:examples/login-form` | http://localhost:8043/ · `/#/stories` |
+
+(`epochs` is the first three `xray` rows; `all` is `xray` + `stories`.)
+The build→port table mirrors the `:dev-http` map in `shadow-cljs.edn`.
+
 ## Vocabulary — commonly confused public concepts
 
 When in doubt, the canonical reference is [`../spec/Conventions.md`](../spec/Conventions.md)

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -16,6 +16,8 @@
   },
   "scripts": {
     "dev": "node scripts/dev-testbed.cjs",
+    "dev:xray": "node scripts/dev-testbed.cjs xray",
+    "dev:stories": "node scripts/dev-testbed.cjs stories",
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
     "test:cljs-perf-emit-nightly": "shadow-cljs compile node-test-perf-nightly && node out/node-test-perf-nightly.js",
     "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs",
@@ -34,7 +36,7 @@
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
     "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs",
-    "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs",
+    "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs && node scripts/dev-testbed.test.cjs",
     "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }
 }

--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /*
- * `dev` — cross-platform testbed dev launcher (rf2-5dphw).
+ * `dev` — cross-platform testbed dev launcher (rf2-5dphw; group
+ * aliases + URL discoverability per rf2-jooy3).
  *
  * Resolves the repo root from THIS script's own location (via node's
  * `path` module, which behaves identically on Windows / macOS / Linux),
@@ -17,16 +18,40 @@
  * therefore works on a fresh clone at any path, on any OS, with no
  * `?project-root=` override needed.
  *
- * Usage:
+ * GROUP ALIASES (rf2-jooy3). A single CLI arg matching a curated group
+ * name expands to that group's build-ids, so "watch the whole Xray
+ * surface" or "watch all the Story showcases" is one short command:
+ *
+ *   npm run dev -- xray       # the 5 Xray driving surfaces
+ *   npm run dev -- stories    # the 4 Story showcases
+ *   npm run dev -- epochs     # the standard / routes / machine epochs trio
+ *   npm run dev -- all        # xray + stories
+ *
+ * Anything that is NOT a group name passes through UNCHANGED, so explicit
+ * build-ids and extra `shadow-cljs watch` flags keep working exactly as
+ * before, and groups may be mixed with explicit build-ids / flags:
  *
  *   npm run dev -- :examples/standard-epochs
  *   npm run dev -- :testbeds/panel-gallery
- *   npm run dev -- :examples/counter-with-stories :examples/login-form
+ *   npm run dev -- stories :examples/standard-epochs
+ *   npm run dev -- xray --verbose
  *
- * Any extra `shadow-cljs watch` args pass straight through. Launching
- * `npx shadow-cljs watch ...` directly still works — the env var is just
- * unset, so the helper falls back to the `?project-root=` query string
- * (or a graceful open-in-editor no-op).
+ * After expansion the build list is de-duplicated while PRESERVING first-
+ * seen order (so `dev -- stories :examples/login-form` watches each build
+ * once). Non-build flags (anything not starting with `:`) pass through in
+ * place and are never treated as builds for URL printing.
+ *
+ * Launching `npx shadow-cljs watch ...` directly still works — the env
+ * var is just unset, so the helper falls back to the `?project-root=`
+ * query string (or a graceful open-in-editor no-op).
+ *
+ * URL DISCOVERABILITY (rf2-jooy3). For every watched build that has a
+ * `:dev-http` port, the launcher prints `http://localhost:<port>/` on
+ * start (Story builds also print the `/#/stories` shell URL) so "how do
+ * I see them" is answered before the compile even finishes. The
+ * build->port map below is kept in sync with the `:dev-http` map in
+ * `implementation/shadow-cljs.edn` (READ-only here — shadow-cljs.edn is
+ * a hot-zone file).
  */
 
 'use strict';
@@ -34,37 +59,165 @@
 const { spawn } = require('child_process');
 const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 
-const builds = process.argv.slice(2);
-if (builds.length === 0) {
-  console.error(
-    'Usage: npm run dev -- <build> [<build>...]\n' +
-      '  e.g. npm run dev -- :examples/standard-epochs',
-  );
-  process.exit(1);
+// ---------------------------------------------------------------------------
+// Curated group aliases (rf2-jooy3). group-name -> [build-id, ...].
+// Build-ids confirmed against implementation/shadow-cljs.edn :builds.
+// ---------------------------------------------------------------------------
+
+// The five Xray driving surfaces (the _epochs trio + the two-frame
+// isolation surface + the panel gallery).
+const XRAY_BUILDS = [
+  ':examples/standard-epochs',
+  ':examples/routes-epochs',
+  ':examples/machine-epochs',
+  ':examples/two-frame-isolation',
+  ':testbeds/panel-gallery',
+];
+
+// The _epochs trio only (standard / routes / machine).
+const EPOCHS_BUILDS = [
+  ':examples/standard-epochs',
+  ':examples/routes-epochs',
+  ':examples/machine-epochs',
+];
+
+// The four Story showcases (rf2-xz4zn wired their :dev-http ports).
+const STORIES_BUILDS = [
+  ':examples/nine-states-with-stories',
+  ':examples/login-with-stories',
+  ':examples/counter-with-stories',
+  ':examples/login-form',
+];
+
+const GROUPS = {
+  xray: XRAY_BUILDS,
+  stories: STORIES_BUILDS,
+  epochs: EPOCHS_BUILDS,
+  // `all` = xray + stories (deduped in the resolver below).
+  all: [...XRAY_BUILDS, ...STORIES_BUILDS],
+};
+
+// ---------------------------------------------------------------------------
+// build-id -> dev-http info. Kept in sync with shadow-cljs.edn :dev-http
+// (READ-only — shadow-cljs.edn is hot-zone). `story: true` marks builds
+// whose Story shell lives at /#/stories.
+// ---------------------------------------------------------------------------
+const DEV_HTTP = {
+  ':examples/two-frame-isolation': { port: 8030 },
+  ':examples/standard-epochs': { port: 8031 },
+  ':examples/routes-epochs': { port: 8032 },
+  ':examples/machine-epochs': { port: 8033 },
+  ':testbeds/panel-gallery': { port: 8765 },
+  ':examples/nine-states-with-stories': { port: 8040, story: true },
+  ':examples/login-with-stories': { port: 8041, story: true },
+  ':examples/counter-with-stories': { port: 8042, story: true },
+  ':examples/login-form': { port: 8043, story: true },
+};
+
+/**
+ * Expand group aliases in `argv`, de-duplicating builds while preserving
+ * first-seen order. Any token that is not a known group name passes
+ * through unchanged (explicit build-ids AND extra shadow-cljs flags),
+ * but duplicate build-ids (tokens starting with `:`) are dropped. Flags
+ * and other non-build tokens are passed through verbatim (never deduped,
+ * so e.g. a repeated `--verbose` is the caller's call to make).
+ *
+ * @param {string[]} argv  the raw CLI args (after `node script.cjs`).
+ * @returns {string[]}     the expanded, order-preserving, deduped args.
+ */
+function resolveArgs(argv) {
+  const out = [];
+  const seenBuilds = new Set();
+  const push = (token) => {
+    if (token.startsWith(':')) {
+      if (seenBuilds.has(token)) return;
+      seenBuilds.add(token);
+    }
+    out.push(token);
+  };
+  for (const token of argv) {
+    if (Object.prototype.hasOwnProperty.call(GROUPS, token)) {
+      for (const build of GROUPS[token]) push(build);
+    } else {
+      push(token);
+    }
+  }
+  return out;
 }
 
-const isWin = process.platform === 'win32';
-const cmd = isWin ? 'npx.cmd' : 'npx';
-const args = ['shadow-cljs', 'watch', ...builds];
+/**
+ * The URLs to print for a watched build, or [] if it has no dev-http
+ * port. Story builds get both the live-app `/` URL and the `/#/stories`
+ * shell URL.
+ *
+ * @param {string} build  a build-id token (e.g. ':examples/login-form').
+ * @returns {string[]}    zero, one, or two URLs.
+ */
+function urlsForBuild(build) {
+  const info = DEV_HTTP[build];
+  if (!info) return [];
+  const base = `http://localhost:${info.port}/`;
+  return info.story ? [base, `${base}#/stories`] : [base];
+}
 
-// Normalise to forward slashes so the value reads identically across
-// platforms when it becomes a string prefix in `re-frame.testbed.config`.
-const repoRoot = REPO_ROOT.split('\\').join('/');
+module.exports = { GROUPS, DEV_HTTP, resolveArgs, urlsForBuild };
 
-console.log(`> RF2_TESTBED_PROJECT_ROOT=${repoRoot}`);
-console.log(`> ${cmd} ${args.join(' ')}`);
-
-const child = spawn(cmd, args, {
-  cwd: IMPL_ROOT,
-  stdio: 'inherit',
-  shell: isWin,
-  env: { ...process.env, RF2_TESTBED_PROJECT_ROOT: repoRoot },
-});
-
-child.on('exit', (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
+// ---------------------------------------------------------------------------
+// CLI entry-point (skipped when this module is require()'d by a test).
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const rawArgs = process.argv.slice(2);
+  if (rawArgs.length === 0) {
+    const groupList = Object.keys(GROUPS).join(' | ');
+    console.error(
+      'Usage: npm run dev -- <group | build> [<build>...] [shadow-cljs flags]\n' +
+        `  groups: ${groupList}\n` +
+        '  e.g. npm run dev -- xray\n' +
+        '       npm run dev -- stories\n' +
+        '       npm run dev -- :examples/standard-epochs\n' +
+        '       npm run dev -- stories :examples/standard-epochs',
+    );
+    process.exit(1);
   }
-  process.exit(code == null ? 0 : code);
-});
+
+  const builds = resolveArgs(rawArgs);
+
+  const isWin = process.platform === 'win32';
+  const cmd = isWin ? 'npx.cmd' : 'npx';
+  const args = ['shadow-cljs', 'watch', ...builds];
+
+  // Normalise to forward slashes so the value reads identically across
+  // platforms when it becomes a string prefix in `re-frame.testbed.config`.
+  const repoRoot = REPO_ROOT.split('\\').join('/');
+
+  console.log(`> RF2_TESTBED_PROJECT_ROOT=${repoRoot}`);
+  console.log(`> ${cmd} ${args.join(' ')}`);
+
+  // Print the served URL(s) for every watched build that has a dev-http
+  // port — answers "how do I see them" up front (rf2-jooy3).
+  const urlLines = [];
+  for (const build of builds) {
+    for (const url of urlsForBuild(build)) {
+      urlLines.push(`>   ${build.padEnd(36)} ${url}`);
+    }
+  }
+  if (urlLines.length > 0) {
+    console.log('> Serving:');
+    for (const line of urlLines) console.log(line);
+  }
+
+  const child = spawn(cmd, args, {
+    cwd: IMPL_ROOT,
+    stdio: 'inherit',
+    shell: isWin,
+    env: { ...process.env, RF2_TESTBED_PROJECT_ROOT: repoRoot },
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code == null ? 0 : code);
+  });
+}

--- a/implementation/scripts/dev-testbed.test.cjs
+++ b/implementation/scripts/dev-testbed.test.cjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/*
+ * Tests for `dev-testbed.cjs` group-alias resolution + URL printing
+ * (rf2-jooy3).
+ *
+ * Standalone node-runnable suite — no external test framework, mirroring
+ * `_path-policy.test.cjs`. Each test logs PASS / FAIL; the process exits
+ * 0 only when every test passes. Wired into `package.json` via
+ * `test:script-helpers`.
+ *
+ * Requiring `dev-testbed.cjs` does NOT spawn shadow-cljs: the CLI body is
+ * guarded by `require.main === module`, so importing it here only loads
+ * the pure `resolveArgs` / `urlsForBuild` helpers + the GROUPS / DEV_HTTP
+ * maps.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { GROUPS, DEV_HTTP, resolveArgs, urlsForBuild } = require('./dev-testbed.cjs');
+
+let failed = 0;
+
+function it(label, f) {
+  try {
+    f();
+    console.log(`  PASS  ${label}`);
+  } catch (err) {
+    failed++;
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${err.message || err}`);
+  }
+}
+
+console.log('dev-testbed group-alias tests (rf2-jooy3)');
+
+it('a group name expands to its build-ids', () => {
+  assert.deepStrictEqual(resolveArgs(['xray']), [
+    ':examples/standard-epochs',
+    ':examples/routes-epochs',
+    ':examples/machine-epochs',
+    ':examples/two-frame-isolation',
+    ':testbeds/panel-gallery',
+  ]);
+  assert.deepStrictEqual(resolveArgs(['stories']), [
+    ':examples/nine-states-with-stories',
+    ':examples/login-with-stories',
+    ':examples/counter-with-stories',
+    ':examples/login-form',
+  ]);
+});
+
+it('the epochs group is the standard/routes/machine trio only', () => {
+  assert.deepStrictEqual(resolveArgs(['epochs']), [
+    ':examples/standard-epochs',
+    ':examples/routes-epochs',
+    ':examples/machine-epochs',
+  ]);
+});
+
+it('the all group is xray + stories, deduped', () => {
+  const expected = [...GROUPS.xray, ...GROUPS.stories];
+  assert.deepStrictEqual(resolveArgs(['all']), expected);
+  // No duplicates survive.
+  assert.strictEqual(new Set(resolveArgs(['all'])).size, resolveArgs(['all']).length);
+});
+
+it('an unknown arg passes through unchanged (back-compat)', () => {
+  assert.deepStrictEqual(resolveArgs([':examples/standard-epochs']), [
+    ':examples/standard-epochs',
+  ]);
+  // Extra shadow-cljs flags pass straight through.
+  assert.deepStrictEqual(resolveArgs([':testbeds/panel-gallery', '--verbose']), [
+    ':testbeds/panel-gallery',
+    '--verbose',
+  ]);
+});
+
+it('mixing a group with an explicit build-id works and dedups', () => {
+  // login-form is already in the stories group; the explicit repeat is
+  // dropped, first-seen order preserved.
+  assert.deepStrictEqual(resolveArgs(['stories', ':examples/login-form']), [
+    ':examples/nine-states-with-stories',
+    ':examples/login-with-stories',
+    ':examples/counter-with-stories',
+    ':examples/login-form',
+  ]);
+  // A NOT-yet-present build-id appended after a group is kept, in order.
+  assert.deepStrictEqual(resolveArgs(['stories', ':examples/standard-epochs']), [
+    ':examples/nine-states-with-stories',
+    ':examples/login-with-stories',
+    ':examples/counter-with-stories',
+    ':examples/login-form',
+    ':examples/standard-epochs',
+  ]);
+});
+
+it('preserves first-seen order across two groups (all dedups overlap)', () => {
+  assert.deepStrictEqual(resolveArgs(['xray', 'stories']), resolveArgs(['all']));
+  // Stories-first then xray keeps stories ahead of xray.
+  assert.deepStrictEqual(resolveArgs(['stories', 'xray']), [
+    ...GROUPS.stories,
+    ...GROUPS.xray,
+  ]);
+});
+
+it('duplicate explicit build-ids are deduped, order preserved', () => {
+  assert.deepStrictEqual(
+    resolveArgs([':examples/standard-epochs', ':examples/standard-epochs']),
+    [':examples/standard-epochs'],
+  );
+});
+
+it('non-build flags are NOT deduped (passed verbatim)', () => {
+  assert.deepStrictEqual(resolveArgs(['xray', '--verbose', '--verbose']), [
+    ...GROUPS.xray,
+    '--verbose',
+    '--verbose',
+  ]);
+});
+
+it('every group build-id has a dev-http port entry', () => {
+  const all = new Set(Object.values(GROUPS).flat());
+  for (const build of all) {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(DEV_HTTP, build),
+      `${build} should have a DEV_HTTP entry`,
+    );
+  }
+});
+
+it('urlsForBuild prints the live URL for a plain build', () => {
+  assert.deepStrictEqual(urlsForBuild(':examples/standard-epochs'), [
+    'http://localhost:8031/',
+  ]);
+  assert.deepStrictEqual(urlsForBuild(':testbeds/panel-gallery'), [
+    'http://localhost:8765/',
+  ]);
+});
+
+it('urlsForBuild prints the live + /#/stories URLs for a Story build', () => {
+  assert.deepStrictEqual(urlsForBuild(':examples/login-form'), [
+    'http://localhost:8043/',
+    'http://localhost:8043/#/stories',
+  ]);
+  assert.deepStrictEqual(urlsForBuild(':examples/nine-states-with-stories'), [
+    'http://localhost:8040/',
+    'http://localhost:8040/#/stories',
+  ]);
+});
+
+it('urlsForBuild returns [] for a build with no dev-http port', () => {
+  assert.deepStrictEqual(urlsForBuild(':examples/counter'), []);
+  assert.deepStrictEqual(urlsForBuild('--verbose'), []);
+});
+
+if (failed > 0) {
+  console.error(`\n${failed} test(s) failed.`);
+  process.exit(1);
+} else {
+  console.log('\nAll dev-testbed tests passed.');
+}

--- a/tools/story/README.md
+++ b/tools/story/README.md
@@ -125,10 +125,21 @@ Xray preload is wired — press `Ctrl+Shift+C`).
 | `:examples/counter-with-stories` | 8042 | http://localhost:8042/#/stories | canonical minimal testbed |
 | `:examples/login-form` | 8043 | http://localhost:8043/#/stories | five-state login-form testbed |
 
-A single watch brings all four up at once:
+A single command brings all four up at once and prints each shell URL
+(via the `stories` group alias in `implementation/scripts/dev-testbed.cjs`,
+rf2-jooy3):
 
 ```bash
 # from implementation/
+npm run dev -- stories
+# or the package.json shortcut (no `--`):
+npm run dev:stories
+```
+
+Equivalently, the raw watch (no URL printing, no `RF2_TESTBED_PROJECT_ROOT`
+seeding for open-in-editor):
+
+```bash
 npx shadow-cljs watch :examples/nine-states-with-stories \
   :examples/login-with-stories \
   :examples/counter-with-stories :examples/login-form


### PR DESCRIPTION
@
Closes rf2-jooy3.

## What

Make "watch interesting projects" one short command. Previously `npm run dev -- :build...` required listing every build-id.

### Group aliases (`scripts/dev-testbed.cjs`)
A curated group-name → build-ids map. A CLI arg matching a group name expands; anything else passes through unchanged (back-compat: explicit build-ids + extra `shadow-cljs watch` flags still work; mixing allowed; builds de-duped, first-seen order preserved). The `RF2_TESTBED_PROJECT_ROOT` open-in-editor seeding is unchanged. Build-ids confirmed against `shadow-cljs.edn :builds`.

- `xray` → `:examples/standard-epochs :examples/routes-epochs :examples/machine-epochs :examples/two-frame-isolation :testbeds/panel-gallery`
- `stories` → `:examples/nine-states-with-stories :examples/login-with-stories :examples/counter-with-stories :examples/login-form`
- `epochs` → the standard/routes/machine trio only
- `all` → xray + stories (deduped)

### URL discoverability
On start, prints `http://localhost:<port>/` for each watched build (Story builds also print `/#/stories`). The build→port map mirrors the `:dev-http` map in `shadow-cljs.edn` (kept READ-only — hot-zone). Ports: Xray 8030/8031/8032/8033/8765; Story 8040–8043.

### package.json shortcuts
`dev:xray` / `dev:stories` (so `npm run dev:stories` with no `--`).

### Docs
- `dev-testbed.cjs` header Usage block expanded with the groups + examples.
- `implementation/README.md` — new "Running the dev testbeds" section with the group commands + URL table.
- `tools/story/README.md` — the rf2-xz4zn "Running the Story examples" note now points at `npm run dev -- stories` (raw `npx shadow-cljs watch` kept as the no-URL/no-env fallback).

## Quality gates

- `node --check scripts/dev-testbed.cjs` — OK
- `node --check scripts/dev-testbed.test.cjs` — OK
- New unit gate `scripts/dev-testbed.test.cjs` (group expansion, unknown pass-through, mixing dedup+order, flag pass-through, URL printing) — 12/12 PASS; wired into `npm run test:script-helpers`.
- `npm run test:script-helpers` (full suite, incl. the new file) — all green (browser-test-report 12, gate-report 4, local-browser-harness 12, read-release-bundle 19, dev-testbed 12).
- Manual run: `npm run dev -- stories` / `-- xray` print the correct watch plan + URLs (incl. `/#/stories` for Story builds) and `--verbose` passes through; verified via the exported resolver.
- mkdocs: N/A (no `docs/` page changed; READMEs only).
@