### PR TITLE
fix(xray): very-light-red error-tint background on Epoch exception card (rf2-ksl5m)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -2468,10 +2468,12 @@ it in the design system the way the surrounding pipeline-step cards do —
 every colour / spacing value resolves through the theme token ns (`theme/
 tokens`), no hardcoded hex:
 
-- **Surface** — the raised panel surface (`:bg-2`), the same neutral the
-  other step cards read, NOT the saturated `:bg-violation` rose wash. The
-  card reads **quiet when collapsed**; the severity signal carries on the
-  edge + glyph, not a shouty fill.
+- **Surface (rf2-ksl5m)** — a **very-light-red** fill: `:error` mixed ~7%
+  over the raised `:bg-2` panel surface (an opaque 2-token `color-mix`, so
+  it paints cleanly on light + dark). Still **quiet** — a subtle tint, NOT
+  the saturated `:bg-violation` rose wash — but the error now reads on the
+  fill at a glance, joining the same `:error` tone the edge, rail, glow +
+  glyph already carry.
 - **Border + rail** — a refined hairline keyed to the error token via
   `tokens/with-alpha` (a tinted edge, not a solid-red box) plus a solid
   `:error` **left rail** (the same accented-left-edge language as the L4

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1200,10 +1200,11 @@
 ;; skeleton. It now sits in the design system the way the surrounding
 ;; pipeline-step cards do, sophisticated rather than basic:
 ;;
-;;   - SURFACE — the raised panel surface (`:bg-2`) the other step cards
-;;     read, NOT the saturated rose wash. The card reads QUIET when
-;;     collapsed; the severity signal carries on the edge + glyph, not a
-;;     shouty fill.
+;;   - SURFACE — a VERY-LIGHT-RED fill (rf2-ksl5m): `:error` mixed ~7%
+;;     over the raised `:bg-2` surface the other step cards read. Still
+;;     QUIET, NOT the saturated rose wash — a subtle tint so the error
+;;     reads on the fill at a glance while the edge + glyph carry the
+;;     stronger severity signal.
 ;;   - BORDER + RAIL — a refined hairline keyed to the error token via
 ;;     `with-alpha` (a tinted edge, not a solid red box) plus a solid
 ;;     `:error` LEFT RAIL — the same "accented left edge" language the
@@ -1225,7 +1226,15 @@
    :gap            (:gap-2 spacing)
    :padding        (str (:gap-2 spacing) " " (:gap-3 spacing))
    :margin         (str (:gap-1 spacing) " 0")
-   :background     bg-2-colour
+   ;; A VERY-LIGHT-RED fill (rf2-ksl5m) — `:error` mixed ~7% over the
+   ;; raised `:bg-2` surface. The card still reads QUIET per rf2-ynvv7
+   ;; (a subtle tint, NOT a saturated rose wash), but the failure tone
+   ;; now joins the fill the same way it already keys the hairline, the
+   ;; left rail, the glow + the glyph. An OPAQUE 2-token `color-mix`
+   ;; (over `:bg-2`, not `transparent`) so it paints cleanly on both
+   ;; themes regardless of the surface the lifted card sits above.
+   :background     (str "color-mix(in srgb, " error-colour " 7%, "
+                        bg-2-colour ")")
    ;; Refined tinted hairline (not a shouty solid red box) + the solid
    ;; `:error` left rail carrying the severity at the column-1 anchor.
    :border         (str "1px solid " (with-alpha :error 38))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -2402,11 +2402,12 @@
           "rf2-wnvid — the redundant jump-to-source link is dropped"))))
 
 (deftest error-block-styling-is-token-driven-test
-  (testing "rf2-ynvv7 — the sophistication pass styles the exception card
-            from the design tokens (the raised `:bg-2` surface, the solid
-            `:error` left rail, an `:error`-keyed elevation glow, and the
-            `:error`-accent glyph), NOT hardcoded hex. The card sits in the
-            design system like the surrounding step cards."
+  (testing "rf2-ynvv7 / rf2-ksl5m — the sophistication pass styles the
+            exception card from the design tokens (a very-light-red
+            `:error`-over-`:bg-2` fill, the solid `:error` left rail, an
+            `:error`-keyed elevation glow, and the `:error`-accent glyph),
+            NOT hardcoded hex. The card sits in the design system like the
+            surrounding step cards."
     (let [error-var (:error tokens/tokens)        ; "var(--rf-xray-error)"
           bg-2-var  (:bg-2  tokens/tokens)         ; "var(--rf-xray-bg-2)"
           tree      (view/error-block :handler 0
@@ -2423,10 +2424,13 @@
                                  first
                                  th/attrs
                                  :style))]
-      ;; The card root reads the raised panel surface + a token-keyed
+      ;; The card root reads a VERY-LIGHT-RED fill (rf2-ksl5m — `:error`
+      ;; mixed lightly over the raised `:bg-2` surface) + a token-keyed
       ;; left rail + an `:error`-tinted elevation — all from tokens.
-      (is (= bg-2-var (:background card))
-          "card surface is the raised `:bg-2` token (not the rose wash)")
+      (is (and (string/includes? (str (:background card)) error-var)
+               (string/includes? (str (:background card)) bg-2-var))
+          "card surface is a token-driven `:error`-over-`:bg-2` tint
+           (rf2-ksl5m — very-light-red, not the saturated rose wash)")
       (is (string/includes? (str (:border-left card)) error-var)
           "the severity left rail is the `:error` token")
       (is (string/includes? (str (:border card)) error-var)


### PR DESCRIPTION
Refines rf2-ynvv7 (PR #2696, merged). Mike, live on :8031: the inline Epoch exception card is almost right but its NEUTRAL `:bg-2` fill should be a **very-light-red** to signal the error.

## Change

`error-block-style` `:background` (epoch `view.cljs`): `bg-2-colour` → `color-mix(in srgb, var(--rf-xray-error) 7%, var(--rf-xray-bg-2))`.

- **Token used:** an opaque 2-token `color-mix` of the existing `:error` token (~7%) over the `:bg-2` surface, built from the in-file `error-colour` / `bg-2-colour` var-string bindings — no new token added to `config.cljc`, no hardcoded hex. `with-alpha` was not used because its `transparent` partner produces a wash over the cascade rather than a clean tint over `:bg-2`; the bead's *recommended* form is the opaque mix, which paints correctly on both light + dark.
- Very light + restrained — reads "error" at a glance while staying QUIET per rf2-ynvv7 (not the saturated `:bg-violation` rose wash).
- Every other ynvv7 card style is untouched: `:error` left rail, layered elevation, type-scale hierarchy, ✗ glyph badge. Purely presentational. Collapsible details sub-block (`:bg-1`) and the amber schema-violation card are left as-is.

## Regression

`error-block-styling-is-token-driven-test` kept green — its background assertion now checks the surface is a token-driven `:error`-over-`:bg-2` tint (still token-driven, no literal) instead of exactly `:bg-2`.

## Spec

Spec 021 §Inline error card — the **Surface** bullet (described the neutral `:bg-2` fill / "not a rose wash") updated to the very-light-red posture. One-line surface edit, disjoint from the edn-inspector surfaces.

## Quality gates

- **xray `clojure -M:test`:** 1038 tests / 4146 assertions — **0 failures, 0 errors**.
- **clj-kondo** (changed files `view.cljs` + `view_cljs_test.cljs`): **0 errors, 14 warnings** — all pre-existing (verified identical count on base via stash diff); no new findings on changed lines.
- `npm run test:cljs`: not run — the xray artefact tests run via `clojure -M:test` (above), not bundled into `test:cljs`.

Closes rf2-ksl5m. Do not merge.