### PR TITLE
feat(xray): edn_inspector testdeck — extract from standard_epochs + feature ladder (rf2-74u2s)

### DIFF
--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -64,12 +64,13 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 // Build-ids confirmed against implementation/shadow-cljs.edn :builds.
 // ---------------------------------------------------------------------------
 
-// The five Xray driving surfaces (the _epochs trio + the two-frame
-// isolation surface + the panel gallery).
+// The six Xray driving surfaces (the _epochs trio + the edn-inspector
+// widget driver + the two-frame isolation surface + the panel gallery).
 const XRAY_BUILDS = [
   ':examples/standard-epochs',
   ':examples/routes-epochs',
   ':examples/machine-epochs',
+  ':examples/edn-inspector',
   ':examples/two-frame-isolation',
   ':testbeds/panel-gallery',
 ];
@@ -107,6 +108,7 @@ const DEV_HTTP = {
   ':examples/standard-epochs': { port: 8031 },
   ':examples/routes-epochs': { port: 8032 },
   ':examples/machine-epochs': { port: 8033 },
+  ':examples/edn-inspector': { port: 8034 },
   ':testbeds/panel-gallery': { port: 8765 },
   ':examples/nine-states-with-stories': { port: 8040, story: true },
   ':examples/login-with-stories': { port: 8041, story: true },

--- a/implementation/scripts/dev-testbed.test.cjs
+++ b/implementation/scripts/dev-testbed.test.cjs
@@ -39,6 +39,7 @@ it('a group name expands to its build-ids', () => {
     ':examples/standard-epochs',
     ':examples/routes-epochs',
     ':examples/machine-epochs',
+    ':examples/edn-inspector',
     ':examples/two-frame-isolation',
     ':testbeds/panel-gallery',
   ]);

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -275,6 +275,18 @@
             ;; 8032).
             8033 ["../tools/xray/testbeds/machine_epochs"
                   "out/examples/machine-epochs"]
+            ;; Single-frame edn-inspector testbed (rf2-74u2s) — the
+            ;; WIDGET sibling of standard-epochs. Same numbered-button
+            ;; shape (one frame · one rung per press), but each rung
+            ;; seeds a value-shape into the edn-inspector widget mounted
+            ;; below the column, driving the renderer DIRECTLY rather than
+            ;; the Xray panels. Same source-dir-first cascade as 8031-8033;
+            ;; compiled main.js falls through to out/examples/edn-inspector.
+            ;; Port 8034 is the next free testbed slot above the _epochs
+            ;; trio (standard-epochs 8031, routes-epochs 8032,
+            ;; machine-epochs 8033).
+            8034 ["../tools/xray/testbeds/edn_inspector"
+                  "out/examples/edn-inspector"]
             ;; --- Story showcases (rf2-xz4zn) -------------------------
             ;; The four Story-enabled builds, on the 804x band (the Xray
             ;; testbeds own 803x + 8765). Each is hash-routed: `/#/` is
@@ -774,6 +786,43 @@
    :modules          {:main {:init-fn machine-epochs.core/run}}
    :devtools         {:preloads [re-frame2-pair.runtime
                                  day8.re-frame2-xray.preload]}}
+
+  ;; Single-frame edn-inspector testbed (rf2-74u2s) — the WIDGET sibling
+  ;; of standard-epochs. Same numbered-button shape (a tall column in ONE
+  ;; plainly-mounted frame, one rung per press), but each rung seeds a
+  ;; value-shape into the Xray edn-inspector widget
+  ;; (day8.re-frame2-xray.views.edn-inspector) mounted BELOW the column,
+  ;; driving the single CLJS-value RENDERER directly — the renderer behind
+  ;; every Xray panel — across a progressive 13-rung ladder (resting render
+  ;; → elision → nesting/collapse → the three diff ops → redaction +
+  ;; large-elided sentinels → zoom → popup affordance → tagged literals →
+  ;; card/header chrome). Extracted from the edn-inspector test that was
+  ;; mixed into standard_epochs (its old button 9). A TEST surface — no
+  ;; deliberate bugs (feedback_testbeds_are_test_surfaces).
+  ;;
+  ;; The value shapes are REUSED from the panel_gallery edn-inspector +
+  ;; diff-mode-3 fixtures; the ladder drives them live. Sources live under
+  ;; tools/xray/testbeds/edn_inspector/.
+  ;;
+  ;; NOTE the preload set differs from the _epochs trio above: this deck
+  ;; mounts the widget DIRECTLY (no Xray shell), so it does NOT wire
+  ;; day8.re-frame2-xray.preload (which auto-mounts the inline shell). The
+  ;; deck's own `run` registers Xray's handlers + installs the theme CSS
+  ;; vars for the bare widget mount (mirrors the panel_gallery boot). Only
+  ;; the pair runtime preload is wired (rf2-54jz4) so the pair-MCP can
+  ;; probe the live runtime.
+  ;; Served at http://localhost:8034 via the top-level `:dev-http` map.
+  :examples/edn-inspector
+  {:target           :browser
+   :output-dir       "out/examples/edn-inspector"
+   :asset-path       "."
+   ;; rf2-5dphw — build-env project-root for open-in-editor (see
+   ;; :examples/two-frame-isolation above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn edn-inspector.core/run}}
+   :devtools         {:preloads [re-frame2-pair.runtime]}}
 
   ;; Xray panel-gallery testbed (rf2-1o7mp) — visual gallery of Xray
   ;; panels under varying state magnitude. Sources live under

--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -268,7 +268,7 @@ reports `covered` across every row at the unit/helper/view tier.
 
 Browser testbeds live under `tools/xray/testbeds/` —
 `two_frame_isolation`, `standard_epochs`, `routes_epochs`, `machine_epochs`,
-`feature_matrix`, `panel_gallery` — covering the canonical
+`edn_inspector`, `feature_matrix`, `panel_gallery` — covering the canonical
 multi-frame isolation surface
 (`two_frame_isolation`: one app · two frames · Counter / Machine
 (websocket) / Routing / Async&errors tabs navigated as routes ·
@@ -295,6 +295,18 @@ exercises its topology highlight · focused-transition lens · guards /
 actions · snapshot drill-in · transition history · parallel-region
 surfaces; owns its own `:door/main` + `:traffic/light` machines and does
 NOT touch the `deep_machine` gate substrate; served on port 8033), the
+WIDGET sibling (`edn_inspector`, rf2-74u2s: the same numbered-button
+shape — one frame · one rung per press — but each rung seeds a value
+shape into the edn-inspector WIDGET
+(`day8.re-frame2-xray.views.edn-inspector`) mounted below the column,
+driving the single CLJS-value RENDERER behind every panel directly
+across a progressive 13-rung ladder — resting render · elision · nesting
++ collapse/expand · the three diff ops (added / removed-to-empty /
+changed) · redaction + large-elided sentinels · zoom · the popup
+affordance · tagged literals · card/header chrome; reuses the
+`panel_gallery` edn-inspector + diff-mode-3 fixtures as its value shapes;
+extracted from the edn-inspector test that was mixed into
+`standard_epochs` as its old button 9; served on port 8034), the
 deterministic
 feature-matrix sweep across panels + shell + launch modes + redaction
 + 20-event load, the Panel-view gallery, and the performance probe.

--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -1,0 +1,316 @@
+(ns edn-inspector.core
+  "EDN-INSPECTOR testbed (rf2-74u2s) — a standard-epochs-style driving
+  surface for the Xray edn-inspector WIDGET, extracted from the
+  edn-inspector test(s) that were mixed into `standard_epochs`.
+
+  ## Shape
+
+  ONE tall column of NUMBERED buttons down the left, top to bottom.
+  Beside each button a one-line caption says WHAT the case exercises.
+  Pressing a button seeds that case into the single frame's app-db;
+  the edn-inspector widget mounted BELOW the column renders it live.
+  Each button is ONE rung of a progressive feature ladder — rung 1 is
+  the trivial resting render; each later rung layers one more
+  edn-inspector capability.
+
+  This is the WIDGET counterpart of `standard_epochs` (which drives the
+  Xray PANELS). Where standard-epochs presses buttons to make Xray's
+  Epoch / App-db / Views / Trace / Issues panels light up, this deck
+  presses buttons to drive the single CLJS-value renderer
+  (`day8.re-frame2-xray.views.edn-inspector`) DIRECTLY — the renderer
+  behind every one of those panels.
+
+  ## North star (acceptance)
+
+  Click the buttons top to bottom: every edn-inspector capability — a
+  resting render, elision past threshold, deep nesting + collapse /
+  expand, the three diff ops (added / removed incl. remove-to-empty /
+  changed), redaction + large-elided sentinels, zoom, the popup
+  affordance, tagged literals, and the card / header chrome — is
+  exercised in turn, each in isolation.
+
+  ## Direct-widget mount (no Xray shell)
+
+  Unlike standard-epochs (which auto-mounts the full Xray shell inline
+  via the `day8.re-frame2-xray.preload`), this deck mounts the
+  edn-inspector widget DIRECTLY — the bead's `press-button → the
+  edn-inspector below renders that case` shape. So we mirror the
+  `panel_gallery` boot for a bare widget mount: register Xray's
+  handlers (the widget reads its own expansion / zoom slots through
+  them) and install the Xray theme CSS variables on `:root` so the
+  widget paints with the themed palette — but we do NOT mount the
+  shell. The widget resolves dispatch / subscribe against the single
+  default frame (it is `reg-view`-registered, so it inherits whatever
+  frame is in scope; here that is the plainly-mounted default frame).
+
+  ## Fixture reuse
+
+  Per rf2-74u2s the value shapes are REUSED from the `panel_gallery`
+  edn-inspector + diff-mode-3 fixtures (the pure builder fns under
+  `panel-gallery.fixtures-edn-inspector` /
+  `panel-gallery.fixtures-diff-mode-3`) rather than re-authored. The
+  ladder drives them LIVE: a button seeds the chosen fixture's
+  `{:value :before :opts}` into app-db; the widget renders it with diff
+  mode engaged when a `:before` is present.
+
+  ## Test surface, not tutorial
+
+  Per `feedback_testbeds_are_test_surfaces`: NO deliberate bugs, NO
+  teaching layers, NO anti-pattern demos. Each rung exercises a REAL
+  edn-inspector capability cleanly. Captions are guidance, not lessons.
+
+  ## Test-free + self-contained
+
+  Per rf2-8cevm this testbed carries no spec.cjs; the edn-inspector's
+  regression coverage lives in the `panel_gallery` Story gallery
+  (`story.xray.edn-inspector` + `story.xray.diff-mode-3`) gated by the
+  Xray feature-matrix gate. This deck is the manual LIVE-driver for the
+  same widget — the human-eye companion to the automated gate."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; The widget under test — the single CLJS-value renderer.
+            [day8.re-frame2-xray.views.edn-inspector :as edn-inspector]
+            ;; Xray's `:rf.xray/*` handlers — the widget reads its own
+            ;; expansion / zoom slots through them.
+            [day8.re-frame2-xray.registry :as xray-registry]
+            ;; Xray's `:root` CSS-variable installer — required for a bare
+            ;; widget mount (the shell normally installs these from its
+            ;; own `shell-view` body; we bypass the shell, so we call it).
+            [day8.re-frame2-xray.theme.global-styles :as global-styles]
+            [day8.re-frame2-xray.config :as xray-config]
+            ;; REUSED fixtures (rf2-74u2s) — pure builder fns; no
+            ;; re-authoring of the value shapes.
+            [panel-gallery.fixtures-edn-inspector :as fx]
+            [panel-gallery.fixtures-diff-mode-3 :as fx3]
+            ;; Shared testbed-config helper (rf2-5dphw): derives the
+            ;; open-in-editor project-root from the build env.
+            [re-frame.testbed.config :as testbed-config])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; APP-DB SEED
+;; ============================================================================
+;;
+;; The deck holds exactly one slot: `:fixture`, the active fixture map
+;; `{:value :before :opts}`. A button seeds it; the widget reads it. No
+;; baseline counter (this deck drives the WIDGET, not the panels — there
+;; is no Epoch / App-db delta to make visible).
+
+(def fixture-slot :edn-inspector/fixture)
+
+(def initial-db
+  {fixture-slot nil})
+
+(rf/reg-event-db :edn-inspector/reset
+  {:doc "Button 0 — clear the active fixture; the widget shows its empty
+         resting state."}
+  (fn handler-reset [_db _ev]
+    initial-db))
+
+(rf/reg-event-db :edn-inspector/seed!
+  {:doc "Seed the active fixture map `{:value :before :opts}`. Every
+         ladder button dispatches this with one fixture builder's
+         result; the widget below renders it (diff mode engages when a
+         `:before` is present)."}
+  (fn handler-seed! [db [_ fixture]]
+    (assoc db fixture-slot fixture)))
+
+(rf/reg-sub fixture-slot
+  (fn [db _] (get db fixture-slot)))
+
+;; ============================================================================
+;; THE LADDER — 13 rungs (rf2-74u2s)
+;; ============================================================================
+;;
+;; Each row: [n label caption fixture-fn]. `fixture-fn` is a 0-arg fn
+;; returning `{:value :before :opts}` (the REUSED panel_gallery
+;; fixtures, occasionally composed with extra opts for a rung). `:section`
+;; rows are separators (label only).
+;;
+;; The progression mirrors the bead's enumerated ladder exactly:
+;;
+;;   1  resting render (tiny scalar / small map)
+;;   2  elision past threshold (the extracted standard-epochs button-9 case)
+;;   3  deep nesting → path rendering + collapse / expand
+;;   4  collapse / expand toggle (a wide map; click triangles)
+;;   5  diff: ADDED (green +)
+;;   6  diff: REMOVED incl. remove-only-key → empty (the rf2-8pfkk case)
+;;   7  diff: CHANGED in place (diff-mode-3 grammar)
+;;   8  sensitive paths → :rf/redacted markers
+;;   9  large-elided sentinels → :rf.size/large-elided
+;;   10 zoom (re-root into a subtree) + back
+;;   11 popup affordance (the ↗ open-in-new-pane)
+;;   12 tagged literals / mixed types (nil / boolean / keyword / inst / uuid)
+;;   13 card / header section chrome
+
+;; Rung 6's remove-to-empty case (rf2-8pfkk): dissoc the only key so the
+;; after-tree is `{}`. A struck-through removal — NOT a `:added ::missing`
+;; leak (the bug rf2-8pfkk fixed).
+(defn- remove-to-empty []
+  {:before {:only-key {:label "removed" :n 42}}
+   :value  {}
+   :opts   {:full-with-diff? true}})
+
+(def ^:private ladder
+  [[:section "Resting / elision / nesting"]
+   [1  "Tiny scalar + small map"
+    "Resting render — a 3-key map renders inline; the syntax palette is visible"
+    fx/map-small]
+   [2  "Large collection → elision"
+    "Elision past threshold — a 50-key map; the expanded body scrolls (the extracted standard-epochs button-9 case)"
+    fx/map-large]
+   [3  "Deeply nested → path + collapse"
+    "Six-level nested map — path rendering; deep nodes render `▸ {…N keys}` summaries"
+    fx/map-nested]
+   [4  "Collapse / expand toggle"
+    "A twelve-key map past `:max-inline-width` — click the triangles to collapse / expand"
+    fx/map-medium]
+
+   [:section "Diff ops — added / removed / changed"]
+   [5  "Diff: ADDED (green +)"
+    "Wholly-new `:flash` subtree — the `+` glyph + green wash (diff-mode-3 R5)"
+    fx3/r5-wholly-new-subtree]
+   [6  "Diff: REMOVED → empty"
+    "Remove the ONLY key → after-tree is `{}` — a struck-through `−` removal, NOT a `:added ::missing` leak (rf2-8pfkk)"
+    remove-to-empty]
+   [7  "Diff: CHANGED in place"
+    "Scalar bump `{:counter 5} → {:counter 6}` — the value-side `~` glyph + `← was 5` (diff-mode-3 R1)"
+    fx3/r1-modified-scalar]
+
+   [:section "Sentinels — redaction / size-elision"]
+   [8  "Sensitive → :rf/redacted"
+    "A `:rf/redacted` sentinel three levels deep renders as a `redacted` chip, never the raw value"
+    fx/diff-redacted-context]
+   [9  "Large-elided sentinel"
+    "A `:rf.size/large-elided` sentinel (Spec 015) routes through the size-chip renderer, not the regular map path"
+    fx/map-large-elided]
+
+   [:section "Affordances — zoom / popup"]
+   [10 "Zoomable (re-root into a subtree)"
+    "`:zoomable? true` — double-click a container (or Enter while focused) to re-root the inspector onto it; breadcrumb back"
+    fx/opts-zoomable]
+   [11 "Popup affordance (↗)"
+    "`:popup-affordance? true` — the `↗` open-in-new-pane button sits at the widget's top-right corner"
+    fx/opts-popup-affordance]
+
+   [:section "Tagged literals / chrome"]
+   [12 "Tagged literals / mixed types"
+    "Every scalar kind — nil / boolean / int / float / string / keyword / symbol — plus uuid + inst tagged literals"
+    fx/scalar-mix]
+   [13 "Card + header chrome"
+    "`:card?` + `:header` — the inspector-card surface chrome with a labelled ribbon (rf2-63ie5 / rf2-okq7p)"
+    fx/opts-header]])
+
+;; ============================================================================
+;; VIEWS — the button ladder + the live widget below
+;; ============================================================================
+
+(reg-view ladder-button
+  "One numbered ladder row: a numbered button on the left, its caption on
+  the right. Pressing it seeds the row's fixture into the widget."
+  [n label caption fixture-fn]
+  [:div {:style {:display "grid" :grid-template-columns "auto 1fr"
+                 :gap "0.75em" :align-items "center" :margin "0.35em 0"}}
+   [:button {:data-testid (str "edn-inspector-button-" n)
+             :on-click    #(dispatch [:edn-inspector/seed! (fixture-fn)])
+             :style {:min-width "18em" :text-align "left"
+                     :padding "0.4em 0.6em" :cursor "pointer"
+                     :border "1px solid #cfc8ff" :border-radius "6px"
+                     :background "#fff"}}
+    [:span {:style {:font-weight "bold" :color "#7C5CFF" :margin-right "0.5em"}}
+     (str n ".")]
+    label]
+   [:span {:style {:color "#666" :font-size "12px"}} caption]])
+
+(reg-view section-heading
+  "A section separator inside the ladder."
+  [label]
+  [:div {:style {:margin "1em 0 0.25em 0" :font-size "11px" :font-weight "bold"
+                 :color "#7C5CFF" :text-transform "uppercase"
+                 :letter-spacing "0.04em" :border-top "1px dashed #ddd"
+                 :padding-top "0.5em"}}
+   label])
+
+(reg-view inspector-stage
+  "The live widget below the ladder. Reads the active fixture slot,
+  destructures `{:value :before :opts}`, and renders the edn-inspector
+  with diff mode engaged when `:before` is present. Empty until a button
+  is pressed."
+  []
+  (let [fixture @(subscribe [:edn-inspector/fixture])
+        {:keys [value before opts]} fixture
+        merged-opts (cond-> (or opts {})
+                      (some? before) (assoc :before before))]
+    [:div {:data-testid "edn-inspector-stage"
+           :style {:margin-top "1em" :border-top "2px solid #7C5CFF"
+                   :padding-top "1em"}}
+     [:div {:style {:font-size "11px" :font-weight "bold" :color "#7C5CFF"
+                    :text-transform "uppercase" :letter-spacing "0.04em"
+                    :margin-bottom "0.5em"}}
+      "edn-inspector — live"]
+     (if (some? fixture)
+       [edn-inspector/edn-inspector value merged-opts]
+       [:div {:style {:color "#888" :font-size "13px" :font-style "italic"}}
+        "Press a numbered button above — the chosen case renders here."])]))
+
+(reg-view root []
+  [:div {:data-testid "edn-inspector-root"
+         :style {:font-family "system-ui, sans-serif" :padding "1em"
+                 :max-width "760px"}}
+   [:header {:style {:margin-bottom "0.5em"}}
+    [:h2 {:style {:margin 0}} "edn-inspector"]
+    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
+     "One frame, one tall column of test buttons. Each button seeds one "
+     "case into the "
+     [:strong "edn-inspector"]
+     " widget below — the single CLJS-value renderer behind every Xray "
+     "panel. Click top to bottom and every renderer capability is "
+     "exercised: resting render, elision, nesting + collapse / expand, "
+     "the three diff ops, redaction + size sentinels, zoom, the popup "
+     "affordance, tagged literals, and card / header chrome."]]
+   ;; Button 0 — Reset.
+   [:button {:data-testid "edn-inspector-reset"
+             :on-click #(dispatch [:edn-inspector/reset])
+             :style {:padding "0.4em 0.8em" :cursor "pointer"
+                     :border "1px solid #cfc8ff" :border-radius "6px"
+                     :background "#f4f1ff" :margin "0.5em 0"}}
+    "0. Reset — clear the active fixture"]
+   ;; The ladder.
+   (for [row ladder]
+     (if (= :section (first row))
+       ^{:key (second row)} [section-heading (second row)]
+       (let [[n label caption fixture-fn] row]
+         ^{:key n} [ladder-button n label caption fixture-fn])))
+   ;; The live widget.
+   [inspector-stage]])
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+;; rf2-5dphw — open-in-editor project-root is derived from the build
+;; environment, not a hardcoded personal path (mirrors standard_epochs).
+(defn- resolve-project-root []
+  (testbed-config/resolve-project-root "tools/xray/testbeds"))
+
+(defn ^:export run []
+  ;; Configure Xray BEFORE `rf/init!` so any source-coord chip the widget
+  ;; surfaces resolves its classpath-relative `:file` to an on-disk URI.
+  (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
+  (rf/init! reagent-adapter/adapter)
+  ;; Register Xray's `:rf.xray/*` handlers once — the widget reads its
+  ;; own expansion / zoom slots through them. We do NOT mount the Xray
+  ;; shell (this deck drives the widget directly).
+  (xray-registry/register-xray-handlers!)
+  ;; Install the Xray theme CSS variables on `:root` so the bare widget
+  ;; paints with the themed palette (the shell normally does this; we
+  ;; bypass the shell). Idempotent (defonce-guarded + DOM-probed).
+  (global-styles/install!)
+  ;; Single, plain frame — no URL machinery, no shell.
+  (rf/dispatch-sync [:edn-inspector/reset])
+  (rdc/render react-root [root]))

--- a/tools/xray/testbeds/edn_inspector/index.html
+++ b/tools/xray/testbeds/edn_inspector/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: edn-inspector (widget driver)</title>
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; }
+    /* The deck mounts the edn-inspector widget DIRECTLY below the button
+       column (no inline Xray shell host). A single `#app` root is all the
+       page needs. The widget paints with the Xray theme palette installed
+       on `:root` by `global-styles/install!` at boot. */
+    :root { --rf-xray-accent: #7C5CFF; }
+    #app { min-height: 100vh; padding: 0; }
+  </style>
+</head>
+<body>
+  <main id="app"></main>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -32,31 +32,32 @@
               #2 adds a coeffect to the event detail, #4 a one-shot fx,
               #5 a cascade dispatch-id tree.
     App-db  — #1 scalar bump · #6 added key · #7 removed key · #8 changed
-              nested value (diff-mode-3) · #9 large collection · #5 flow
-              writes a derived slot.
+              nested value (diff-mode-3) · #5 flow writes a derived slot.
+              (The dedicated large-collection / edn-inspector case lives
+              in the sibling `edn_inspector` deck — rf2-74u2s.)
     Views   — two children make re-render CAUSES separable. Child A is
               SUBSCRIPTION-driven (an own L1→L2→L3 chain + the arg-keyed
               `[:standard-epochs/greater-than? N]` sub); Child B is
-              PROPS-driven (a prop, NO subs). #10 mount A (node + the
-              sub-cache entries appear) · #11 change the arg N (a NEW
-              [:gt? N] cache entry — cache keyed by arg) · #12 change a
+              PROPS-driven (a prop, NO subs). #9 mount A (node + the
+              sub-cache entries appear) · #10 change the arg N (a NEW
+              [:gt? N] cache entry — cache keyed by arg) · #11 change a
               chain input (L1→L2→L3 invalidation recompute; A re-renders
-              ← a SUB changed) · #13 unmount A (node gone, ALL of A's
-              subs disposed, the unmount recorded) · #14 mount B (props
-              view, NO subs created) · #15 change B's prop (B re-renders
-              ← PROPS changed — the foil to #12). The section lives on
+              ← a SUB changed) · #12 unmount A (node gone, ALL of A's
+              subs disposed, the unmount recorded) · #13 mount B (props
+              view, NO subs created) · #14 change B's prop (B re-renders
+              ← PROPS changed — the foil to #11). The section lives on
               its OWN slots (`:views/*`), so mount/unmount/sub state is
               exercised DIRECTLY — no start-at-button-1 sequencing, no
               :base/flow confound.
     Trace   — every button emits trace; #3 a managed fx, #4 a cascade,
-              #5 a flow recompute, #12 a sub-chain recompute.
-    Issues  — #16 handler exception (db rolls back) · #17 interceptor
-              :before exception (handler skipped) · #18 interceptor :after
-              exception (handler ran, threw on the way out) · #19 coeffect
-              exception · #20 effect exception (post-commit, best-effort) ·
-              #21 slow fx flagged · #22 event-args schema violation · #23
+              #5 a flow recompute, #11 a sub-chain recompute.
+    Issues  — #15 handler exception (db rolls back) · #16 interceptor
+              :before exception (handler skipped) · #17 interceptor :after
+              exception (handler ran, threw on the way out) · #18 coeffect
+              exception · #19 effect exception (post-commit, best-effort) ·
+              #20 slow fx flagged · #21 event-args schema violation · #22
               app-db schema violation (survives rollback).
-    Reactive— #24 diamond probe (c ← a,b ← root): the join sub's recompute
+    Reactive— #23 diamond probe (c ← a,b ← root): the join sub's recompute
               count surfaces whether the substrate double-computes an
               intermediate sub per single root change (rf2-kt5nx).
 
@@ -82,7 +83,7 @@
             ;; Schemas artefact — load-time hook so `reg-app-schema` and
             ;; the `:schema` event metadata resolve. The Malli adapter
             ;; publishes the validator so CLJS schema checks actually
-            ;; fire (without it they soft-pass and buttons #20/#21 would
+            ;; fire (without it they soft-pass and buttons #21/#22 would
             ;; produce no Issues row).
             [re-frame.schemas]
             [re-frame.schemas.malli]
@@ -115,9 +116,9 @@
 ;;   :threshold                 — N, the changeable arg to the dynamic
 ;;                                sub `[:standard-epochs/greater-than? N]`.
 ;;   :chain-input               — the root of Child A's own L1→L2→L3
-;;                                chain (button #12 perturbs it).
+;;                                chain (button #11 perturbs it).
 ;;   :b-prop                    — the prop fed to the props-driven
-;;                                Child B (button #15 changes it).
+;;                                Child B (button #14 changes it).
 
 (def initial-db
   {:baseline 0
@@ -147,10 +148,10 @@
 (defn- bump [db] (update db :baseline inc))
 
 ;; ============================================================================
-;; APP-DB SCHEMA (button #23)
+;; APP-DB SCHEMA (button #22)
 ;; ============================================================================
 ;;
-;; The only constraint: [:auth :token] must be a string. Button #23
+;; The only constraint: [:auth :token] must be a string. Button #22
 ;; writes an int there; the post-handler app-db validation (Spec 010
 ;; §Validation order) rejects it and rolls the :db effect back, while the
 ;; schema-violation issue survives in Xray's Issues lens.
@@ -172,7 +173,7 @@
   (fn cofx-now [ctx]
     (rf/assoc-coeffect ctx :standard-epochs/now (.getTime (js/Date.)))))
 
-;; A coeffect that throws on injection (button #19). A FEATURE being
+;; A coeffect that throws on injection (button #18). A FEATURE being
 ;; exercised — the supported way to light up the cofx error surface.
 (rf/reg-cofx :standard-epochs/throwing-cofx
   {:doc "Throws during coeffect injection so Xray's Issues lens surfaces
@@ -182,8 +183,8 @@
                     {:surface :coeffect-exception}))))
 
 ;; ============================================================================
-;; INTERCEPTORS that throw — one in :before (button #17), one in :after
-;; (button #18)
+;; INTERCEPTORS that throw — one in :before (button #16), one in :after
+;; (button #17)
 ;; ============================================================================
 ;;
 ;; Two throwing interceptors so the per-step placement work can tell the
@@ -193,7 +194,7 @@
 ;; makes the framework's per-step exception attribution (the :before-chain
 ;; vs interceptor-:after distinction) visible live in Xray.
 
-;; Throws in :before — aborts before the handler runs (button #17).
+;; Throws in :before — aborts before the handler runs (button #16).
 (def throwing-interceptor
   (rf/->interceptor
     :id     :standard-epochs/throwing-interceptor
@@ -202,7 +203,7 @@
                               {:surface :interceptor-exception :phase :before})))))
 
 ;; Throws in :after — the handler runs to completion first, THEN this
-;; throws on the way back out of the chain (button #18). The foil to the
+;; throws on the way back out of the chain (button #17). The foil to the
 ;; :before interceptor above: the failing step is the interceptor's :after,
 ;; not the handler, so the per-step placement renders the exception under
 ;; the interceptor's :after step (rf2-yz57h) and the framework attributes
@@ -226,7 +227,7 @@
   (fn fx-ping [_ctx args]
     (swap! ping-log conj args)))
 
-;; A managed slow fx (~600ms, button #21). Resolves later with a
+;; A managed slow fx (~600ms, button #20). Resolves later with a
 ;; follow-on dispatch back onto the originating frame. ~600ms exceeds
 ;; Spec 009's slow-effect threshold, so Xray's Issues lens flags it as a
 ;; (non-bug) slow effect; the status moves :loading -> :loaded.
@@ -237,7 +238,7 @@
       (fn [] (rf/dispatch [:standard-epochs/slow-done] {:frame frame}))
       SLOW-MS)))
 
-;; An fx whose body throws (button #20). The handler's :db commits first;
+;; An fx whose body throws (button #19). The handler's :db commits first;
 ;; the throw fires later, during the post-commit fx walk — best-effort
 ;; per the FX atomicity asymmetry — so Xray's Issues lens shows the fx
 ;; error while the baseline bump survives.
@@ -330,23 +331,16 @@
   (fn handler-change-value [db _ev]
     (-> db bump (update-in [:shapes :counter] (fnil inc 0)))))
 
-;; -- 9. write a large collection → edn-inspector collapse/expand + elision --
-(rf/reg-event-db :standard-epochs/write-large
-  {:doc "Button 9 — write a large collection. The edn-inspector
-         collapses / expands it and elides past its threshold."}
-  (fn handler-write-large [db _ev]
-    (-> db bump (assoc-in [:shapes :large] (vec (range 200))))))
-
-;; -- 10..15. Views / subscriptions — sub-driven Child A + props-driven Child B
+;; -- 9..14. Views / subscriptions — sub-driven Child A + props-driven Child B
 ;;
 ;; The whole section lives on the `:views` slots, decoupled from the
 ;; counter: a button MAY bump `:baseline`, but mount/unmount/sub state is
 ;; never linked to a counter VALUE. Two children separate the re-render
-;; CAUSE — Child A re-renders ← a SUB changed (#12); Child B re-renders ←
-;; PROPS changed (#15).
+;; CAUSE — Child A re-renders ← a SUB changed (#11); Child B re-renders ←
+;; PROPS changed (#14).
 
 (rf/reg-event-db :standard-epochs/mount-a
-  {:doc "Button 10 — mount the SUBSCRIPTION-driven Child A (sets
+  {:doc "Button 9 — mount the SUBSCRIPTION-driven Child A (sets
          :views/a-mounted? true). On mount A subscribes its own
          L1→L2→L3 chain (:chain-root → :chain-doubled → :chain-labelled)
          PLUS the arg-keyed `[:standard-epochs/greater-than? N]` sub — so
@@ -355,14 +349,14 @@
     (-> db bump (assoc-in [:views :a-mounted?] true))))
 
 (rf/reg-event-db :standard-epochs/set-threshold
-  {:doc "Button 11 — change the sub-arg N (5 → 10). `[:standard-epochs/
+  {:doc "Button 10 — change the sub-arg N (5 → 10). `[:standard-epochs/
          greater-than? N]` is keyed by its arg, so the new N is a NEW,
          distinct sub-cache entry alongside the old one."}
   (fn handler-set-threshold [db [_ n]]
     (-> db bump (assoc-in [:views :threshold] n))))
 
 (rf/reg-event-db :standard-epochs/perturb-chain
-  {:doc "Button 12 — perturb Child A's chain input (:views/chain-input).
+  {:doc "Button 11 — perturb Child A's chain input (:views/chain-input).
          With A mounted, Views shows the L1 (:chain-root) → L2
          (:chain-doubled) → L3 (:chain-labelled) invalidation recompute,
          and A re-renders BECAUSE A SUB CHANGED (← :standard-epochs/chain-
@@ -371,7 +365,7 @@
     (-> db bump (update-in [:views :chain-input] inc))))
 
 (rf/reg-event-db :standard-epochs/unmount-a
-  {:doc "Button 13 — unmount Child A (sets :views/a-mounted? false). The
+  {:doc "Button 12 — unmount Child A (sets :views/a-mounted? false). The
          node disappears and ALL of A's subs are disposed once the last
          reader is gone (the chain L1/L2/L3 + every [:gt? N] cache
          entry); the unmount is recorded."}
@@ -379,7 +373,7 @@
     (-> db bump (assoc-in [:views :a-mounted?] false))))
 
 (rf/reg-event-db :standard-epochs/mount-b
-  {:doc "Button 14 — mount the PROPS-driven Child B (sets
+  {:doc "Button 13 — mount the PROPS-driven Child B (sets
          :views/b-mounted? true). B receives a prop and subscribes
          NOTHING, so Views shows the node appear with NO new sub-cache
          entries."}
@@ -387,16 +381,16 @@
     (-> db bump (assoc-in [:views :b-mounted?] true))))
 
 (rf/reg-event-db :standard-epochs/set-b-prop
-  {:doc "Button 15 — change Child B's prop. B re-renders BECAUSE ITS
-         PROPS CHANGED (no sub cause) — the foil to button 12's
+  {:doc "Button 14 — change Child B's prop. B re-renders BECAUSE ITS
+         PROPS CHANGED (no sub cause) — the foil to button 11's
          sub-driven re-render."}
   (fn handler-set-b-prop [db _ev]
     (-> db bump (update-in [:views :b-prop]
                            {"alpha" "beta" "beta" "gamma" "gamma" "alpha"}))))
 
-;; -- 16. exception in the handler → Issues: handler-exception, db rolls back -
+;; -- 15. exception in the handler → Issues: handler-exception, db rolls back -
 (rf/reg-event-db :standard-epochs/throw-handler
-  {:doc "Button 16 — throw in the handler. The router catches it; the :db
+  {:doc "Button 15 — throw in the handler. The router catches it; the :db
          effect (the baseline bump) rolls back; Issues shows
          `:rf.error/handler-exception` with the source coord."}
   (fn handler-throw [db _ev]
@@ -404,34 +398,34 @@
     (throw (ex-info "standard-epochs / handler (intentional — exercises the handler error surface)"
                     {:surface :handler-exception}))))
 
-;; -- 17. exception in an interceptor :before → Issues: interceptor exc. ------
+;; -- 16. exception in an interceptor :before → Issues: interceptor exc. ------
 (rf/reg-event-db :standard-epochs/throw-interceptor
-  {:doc "Button 17 — an interceptor throws in :before. The chain aborts on
+  {:doc "Button 16 — an interceptor throws in :before. The chain aborts on
          the way IN; Issues shows the interceptor :before exception and the
          handler never runs."}
   [throwing-interceptor]
   (fn handler-after-throwing-interceptor [db _ev] (bump db)))
 
-;; -- 18. exception in an interceptor :after → Issues: interceptor exc. -------
+;; -- 17. exception in an interceptor :after → Issues: interceptor exc. -------
 (rf/reg-event-db :standard-epochs/throw-interceptor-after
-  {:doc "Button 18 — an interceptor throws in :after. The foil to button
-         17: the handler runs to completion (the :db is computed), THEN the
+  {:doc "Button 17 — an interceptor throws in :after. The foil to button
+         16: the handler runs to completion (the :db is computed), THEN the
          interceptor throws on the way OUT. Issues shows the interceptor
          :after exception; per-step placement renders it under the
          interceptor's :after step, distinct from a handler exception."}
   [throwing-interceptor-after]
   (fn handler-before-throwing-after-interceptor [db _ev] (bump db)))
 
-;; -- 19. exception in a coeffect handler → Issues: cofx error ----------------
+;; -- 18. exception in a coeffect handler → Issues: cofx error ----------------
 (rf/reg-event-fx :standard-epochs/throw-cofx
-  {:doc "Button 19 — a coeffect throws on injection. Issues shows the
+  {:doc "Button 18 — a coeffect throws on injection. Issues shows the
          cofx error; the handler never runs."}
   [(rf/inject-cofx :standard-epochs/throwing-cofx)]
   (fn handler-after-throwing-cofx [{:keys [db]} _ev] {:db (bump db)}))
 
-;; -- 20. exception in an effect handler (post-commit) → Issues: fx error -----
+;; -- 19. exception in an effect handler (post-commit) → Issues: fx error -----
 (rf/reg-event-fx :standard-epochs/throw-fx
-  {:doc "Button 20 — the :db commits (baseline bumps), then a post-commit
+  {:doc "Button 19 — the :db commits (baseline bumps), then a post-commit
          fx throws. Issues shows the fx error; post-commit fx are
          best-effort per the FX atomicity asymmetry, so the db delta
          survives."}
@@ -439,9 +433,9 @@
     {:db (bump db)
      :fx [[:standard-epochs/boom {}]]}))
 
-;; -- 21. slow effect (~600ms managed fx) → Issues: slow-fx flagged -----------
+;; -- 20. slow effect (~600ms managed fx) → Issues: slow-fx flagged -----------
 (rf/reg-event-fx :standard-epochs/slow
-  {:doc "Button 21 — issue a ~600ms managed fx. Status moves :loading;
+  {:doc "Button 20 — issue a ~600ms managed fx. Status moves :loading;
          Issues flags the slow fx; the reply lands :loaded ~600ms later."}
   (fn handler-slow [{:keys [db]} _ev]
     {:db (-> db bump (assoc :slow-status :loading))
@@ -453,26 +447,26 @@
   (fn handler-slow-done [db _ev]
     (assoc db :slow-status :loaded)))
 
-;; -- 22. schema violation, bad event args → Issues / Schema-timeline ---------
+;; -- 21. schema violation, bad event args → Issues / Schema-timeline ---------
 (rf/reg-event-db :standard-epochs/bad-event-args
-  {:doc "Button 22 — dispatched with a bad arg (a string where a pos-int
+  {:doc "Button 21 — dispatched with a bad arg (a string where a pos-int
          is required). The handler is skipped; Issues / Schema-timeline
          shows `:rf.error/schema-validation-failure :where :event`."
    :schema [:cat [:= :standard-epochs/bad-event-args] pos-int?]}
   (fn handler-bad-event-args [db _ev] (bump db)))
 
-;; -- 23. schema violation, app-db write → Issues: app-db schema failure ------
+;; -- 22. schema violation, app-db write → Issues: app-db schema failure ------
 (rf/reg-event-db :standard-epochs/bad-app-db-write
-  {:doc "Button 23 — write an int into [:auth :token] (the registered
+  {:doc "Button 22 — write an int into [:auth :token] (the registered
          app-schema requires a string). The post-handler app-db
          validation rolls the :db back; Issues shows the app-db schema
          failure, which survives the rollback."}
   (fn handler-bad-app-db-write [db _ev]
     (-> db bump (assoc-in [:auth :token] 42))))
 
-;; -- 24. diamond probe — bump the join-sub root once -------------------------
+;; -- 23. diamond probe — bump the join-sub root once -------------------------
 (rf/reg-event-db :standard-epochs/bump-diamond
-  {:doc "Button 24 — bump :views/diamond-root once. The join sub
+  {:doc "Button 23 — bump :views/diamond-root once. The join sub
          :standard-epochs/diamond-c (c ← a,b ← root) increments a recompute
          counter each time its compute fn runs. Press once: the counter should
          rise by 1 (clean); a rise of 2 means the diamond double-computes the
@@ -492,7 +486,7 @@
 (rf/reg-sub :standard-epochs/b-prop      (fn [db _] (get-in db [:views :b-prop])))
 
 ;; Child A's OWN L1 → L2 → L3 chain, rooted at :views/chain-input (NOT
-;; :base — that feeds button #5's flow). Button #12 perturbs the root;
+;; :base — that feeds button #5's flow). Button #11 perturbs the root;
 ;; with A mounted, Views shows the L1 → L2 → L3 invalidation recompute.
 (rf/reg-sub :standard-epochs/chain-root            ;; L1
   (fn [db _] (get-in db [:views :chain-input])))
@@ -509,7 +503,7 @@
 ;; vector: `[:standard-epochs/greater-than? n]`. It cascades from the chain
 ;; root (a section-owned value, so the sub's behaviour is NOT linked to
 ;; a counter value). A different n is a DISTINCT cache entry over the
-;; same registration — button #11 (5 → 10) creates a new [:gt? 10]
+;; same registration — button #10 (5 → 10) creates a new [:gt? 10]
 ;; entry alongside the original [:gt? 5].
 (rf/reg-sub :standard-epochs/greater-than?
   :<- [:standard-epochs/chain-root]
@@ -527,7 +521,7 @@
 ;;          \        /
 ;;        :diamond-c             (the JOINING sub :<- a,b)
 ;;
-;; Button #24 bumps the root ONCE. The join sub `:diamond-c` increments a
+;; Button #23 bumps the root ONCE. The join sub `:diamond-c` increments a
 ;; counter each time its compute fn RUNS. Press once: the counter should rise
 ;; by exactly 1; a rise of 2 means the substrate recomputes the intermediate
 ;; join sub TWICE per single root change (the push-based diamond redundant-
@@ -572,8 +566,8 @@
 ;; On mount A subscribes its own L1→L2→L3 chain AND the arg-keyed
 ;; `[:standard-epochs/greater-than? threshold]` sub — so the Views lens
 ;; shows the node + those sub-cache entries appear, the chain recompute
-;; (button #12), and a NEW [:gt? N] cache entry when the arg changes
-;; (button #11). `threshold` arrives as a PROP from the root (which
+;; (button #11), and a NEW [:gt? N] cache entry when the arg changes
+;; (button #10). `threshold` arrives as a PROP from the root (which
 ;; reads :views/threshold), so the arg-key is driven by app-db state
 ;; while the deref itself is A's own subscription.
 
@@ -593,7 +587,7 @@
 ;; --- Child B — props-driven ------------------------------------------------
 ;;
 ;; B receives a single prop and subscribes NOTHING. Mounting it (button
-;; #14) creates no sub-cache entries; changing the prop (button #15)
+;; #13) creates no sub-cache entries; changing the prop (button #14)
 ;; re-renders B because its PROPS changed — the foil to A's sub-driven
 ;; re-render.
 
@@ -630,7 +624,7 @@
      [:div "c recompute count: "
       [:strong {:data-testid "diamond-c-runs"} runs]
       [:span {:style {:color "#888" :font-size "11px" :margin-left "0.5em"}}
-       "(press #24 once → +1 clean, +2 double-compute)"]]]))
+       "(press #23 once → +1 clean, +2 double-compute)"]]]))
 
 ;; ============================================================================
 ;; THE BUTTON LADDER
@@ -650,47 +644,45 @@
     [:standard-epochs/increment-cascade]]
    [5  "Increment + flow"      "App-db: a reg-flow-derived slot recomputes; Trace shows it"
     [:standard-epochs/increment-flow]]
-   [:section "App-db shapes — diff modes / edn-inspector"]
+   [:section "App-db shapes — diff modes"]
    [6  "Add a nested key"      "App-db diff: added (assoc-in)"
     [:standard-epochs/add-key]]
    [7  "Remove a key"          "App-db diff: removed (dissoc)"
     [:standard-epochs/remove-key]]
    [8  "Change a nested value" "App-db diff: changed (update-in, diff-mode-3)"
     [:standard-epochs/change-value]]
-   [9  "Write a large collection" "edn-inspector: collapse / expand + elision"
-    [:standard-epochs/write-large]]
    [:section "Views / subscriptions — sub-driven A vs props-driven B"]
-   [10 "Mount Child A (sub-driven)"  "Views: node + A's sub-cache entries appear (chain L1/L2/L3 + [:gt? 5])"
+   [9  "Mount Child A (sub-driven)"  "Views: node + A's sub-cache entries appear (chain L1/L2/L3 + [:gt? 5])"
     [:standard-epochs/mount-a]]
-   [11 "Change the sub-arg N → 10"   "Views: a NEW cache entry [:gt? 10] (parameterized-sub cache keyed by arg)"
+   [10 "Change the sub-arg N → 10"   "Views: a NEW cache entry [:gt? 10] (parameterized-sub cache keyed by arg)"
     [:standard-epochs/set-threshold 10]]
-   [12 "Perturb A's chain input"     "Views: L1→L2→L3 invalidation recompute; A re-renders ← a SUB changed"
+   [11 "Perturb A's chain input"     "Views: L1→L2→L3 invalidation recompute; A re-renders ← a SUB changed"
     [:standard-epochs/perturb-chain]]
-   [13 "Unmount Child A"             "Views: node gone; ALL of A's subs disposed (last reader gone); unmount recorded"
+   [12 "Unmount Child A"             "Views: node gone; ALL of A's subs disposed (last reader gone); unmount recorded"
     [:standard-epochs/unmount-a]]
-   [14 "Mount Child B (props-driven)" "Views: node appears with NO subs created"
+   [13 "Mount Child B (props-driven)" "Views: node appears with NO subs created"
     [:standard-epochs/mount-b]]
-   [15 "Change B's prop"             "Views: B re-renders ← PROPS changed (foil to #12's sub-driven re-render)"
+   [14 "Change B's prop"             "Views: B re-renders ← PROPS changed (foil to #11's sub-driven re-render)"
     [:standard-epochs/set-b-prop]]
    [:section "Errors / Issues — each a real feature, not a buggy demo"]
-   [16 "Exception in the handler"     "Issues: handler-exception + source coord; db rolls back"
+   [15 "Exception in the handler"     "Issues: handler-exception + source coord; db rolls back"
     [:standard-epochs/throw-handler]]
-   [17 "Exception in an interceptor :before" "Issues: interceptor :before exception; handler skipped"
+   [16 "Exception in an interceptor :before" "Issues: interceptor :before exception; handler skipped"
     [:standard-epochs/throw-interceptor]]
-   [18 "Exception in an interceptor :after"  "Issues: interceptor :after exception; handler ran, threw on the way out (foil to #17)"
+   [17 "Exception in an interceptor :after"  "Issues: interceptor :after exception; handler ran, threw on the way out (foil to #16)"
     [:standard-epochs/throw-interceptor-after]]
-   [19 "Exception in a coeffect"      "Issues: cofx error; handler skipped"
+   [18 "Exception in a coeffect"      "Issues: cofx error; handler skipped"
     [:standard-epochs/throw-cofx]]
-   [20 "Exception in an effect"       "Issues: fx error (post-commit, best-effort); db delta survives"
+   [19 "Exception in an effect"       "Issues: fx error (post-commit, best-effort); db delta survives"
     [:standard-epochs/throw-fx]]
-   [21 "Slow effect (~600ms)"         "Issues: slow-fx flagged; status loading → loaded"
+   [20 "Slow effect (~600ms)"         "Issues: slow-fx flagged; status loading → loaded"
     [:standard-epochs/slow]]
-   [22 "Bad event args"               "Issues / Schema-timeline: event-args schema failure"
+   [21 "Bad event args"               "Issues / Schema-timeline: event-args schema failure"
     [:standard-epochs/bad-event-args "not-a-number"]]
-   [23 "Bad app-db write"             "Issues: app-db schema failure (survives rollback)"
+   [22 "Bad app-db write"             "Issues: app-db schema failure (survives rollback)"
     [:standard-epochs/bad-app-db-write]]
    [:section "Reactive substrate — diamond recompute probe"]
-   [24 "Bump diamond root"            "Diamond c ← a,b ← root: press once; c-recompute count should rise by 1 (clean), 2 = double-compute"
+   [23 "Bump diamond root"            "Diamond c ← a,b ← root: press once; c-recompute count should rise by 1 (clean), 2 = double-compute"
     [:standard-epochs/bump-diamond]]])
 
 (defn- testid-for [event]
@@ -757,7 +749,7 @@
    (when @(subscribe [:standard-epochs/b-mounted?])
      [child-b @(subscribe [:standard-epochs/b-prop])])
    ;; Diamond probe — always mounted so the c ← a,b ← root reaction is live;
-   ;; button #24 bumps the root and the display shows c's recompute count.
+   ;; button #23 bumps the root and the display shows c's recompute count.
    [diamond-display]])
 
 ;; ============================================================================


### PR DESCRIPTION
## What

New `tools/xray/testbeds/edn_inspector/` testdeck — a standard-epochs-style **live driver for the Xray edn-inspector WIDGET** (`day8.re-frame2-xray.views.edn-inspector`), the single CLJS-value renderer behind every Xray panel. One frame, a tall column of numbered buttons; pressing a rung seeds a value-shape into the edn-inspector mounted **below** the column.

Extracted from `standard_epochs` (which is a mixture of tests): its old button 9 (`:standard-epochs/write-large`) was the explicit edn-inspector test; it now lives here, expanded into a full ladder.

## The 13-rung ladder

1. tiny scalar + small map (resting render)
2. large collection → elision (the extracted button-9 case)
3. deeply nested → path + collapse/expand
4. collapse / expand toggle
5. diff: ADDED (green `+`)
6. diff: REMOVED → empty (remove-only-key, the rf2-8pfkk case — struck-through `−`, not a `:added ::missing` leak)
7. diff: CHANGED in place (diff-mode-3 R1 grammar)
8. sensitive → `:rf/redacted` chip
9. `:rf.size/large-elided` size sentinel
10. zoomable (re-root into a subtree)
11. popup affordance (`↗`)
12. tagged literals / mixed types (nil / boolean / int / float / string / keyword / symbol + uuid + inst)
13. card + header chrome

Value shapes are **reused** from the `panel_gallery` `fixtures-edn-inspector` + `fixtures-diff-mode-3` builders (driven live), not re-authored. Test-free, no deliberate bugs (`feedback_testbeds_are_test_surfaces`).

The deck mounts the widget **directly** (no Xray shell): its `run` registers Xray's handlers + installs the theme CSS vars for a bare widget mount (mirrors the `panel_gallery` boot), so the only preload wired is `re-frame2-pair.runtime` — **not** `day8.re-frame2-xray.preload`.

## standard_epochs extraction / renumber

- Removed button 9 (`:standard-epochs/write-large`) event handler + its ladder row.
- Renumbered the ladder 10..24 → 9..23 (display numbers, `^{:key}`, and every `#N` cross-reference in docstrings/comments — testids are event-derived so they're stable).
- **Kept** buttons 6-8 (add/remove/change-key) — those are app-db-panel diff tests; the inspector is incidental. Per the bead's recommendation the new deck gets its own diff rungs.

## Hot-zone note — `implementation/shadow-cljs.edn`

Surgical, additions only (no reformatting of unrelated entries):
- new `:examples/edn-inspector` build-id (`:init-fn edn-inspector.core/run`, mirrors the standard_epochs entry but with the pair-only preload set as noted above).
- new `:dev-http` port **8034** (next free testbed slot above the _epochs trio 8031/8032/8033; verified unused).

`implementation/scripts/dev-testbed.cjs`: added the deck to the `xray` group + its build→port entry (8034); updated the group-alias test expectation.

## Spec-inventory update

`tools/xray/README.md` testbed inventory now lists `edn_inspector` + a description paragraph (per the keep-xray-specs-current rule). No feature_matrix change: the deck does not feed the feature gate (`feature_matrix/scenarios.cjs` mounts the full Xray shell, not this widget driver), and the edn-inspector's automated regression coverage already lives in the `panel_gallery` Story gallery (`story.xray.edn-inspector` + `story.xray.diff-mode-3`) gated by the Xray feature-matrix gate — this deck is the human-eye live companion.

## Quality gates

- **shadow-cljs compile `:examples/edn-inspector`** (the core gate for a new testdeck): `Build completed. (406 files, 405 compiled, 0 warnings)`, exit 0.
- **xray `clojure -M:test`**: 1038 tests, 4146 assertions, 0 failures, 0 errors.
- **`npm run test:cljs`**: 5177 tests, 17463 assertions, 0 failures, 0 errors.
- **dev-testbed unit tests** (`node scripts/dev-testbed.test.cjs`): all PASS.
- **clj-kondo** (changed cljs files): 0 errors, 0 warnings.
- `npm run test:xray-feature-gate`: **N/A** — deck does not feed the feature gate (see above).

Fresh worktree required `npm install` in `implementation/`.

Closes rf2-74u2s.
