### PR TITLE
fix(mcp-base): reject negative :max-tokens with an actionable error (rf2-5rdit)

### DIFF
--- a/tools/mcp-base/spec/cap.md
+++ b/tools/mcp-base/spec/cap.md
@@ -10,7 +10,7 @@ This doc is one of eight per-namespace contracts indexed from [`README.md`](READ
 `cap` owns:
 
 - The two-stage cap algorithm (sum tokens + chars in one pass → primary token gate OR secondary char gate → pass-through or replace).
-- The `max-tokens` per-call cap resolver (`0` resolves to `nil` = disabled; absent / non-number → `default-max-tokens`).
+- The `max-tokens` per-call cap resolver (`0` resolves to `nil` = disabled; absent / non-number → `default-max-tokens`; **negative → `{:rf.mcp/invalid-arg {...}}` rejection**, rf2-5rdit).
 - The `ResultIO` protocol — the per-consumer specialisation hook.
 - The recursion-safety invariant (the overflow marker itself must fit under the cap).
 
@@ -24,7 +24,7 @@ This doc is one of eight per-namespace contracts indexed from [`README.md`](READ
 
 The pipeline is a **two-stage** gate (rf2-ih7g4) that folds both sums in a **single pass** (rf2-hyp0z) over the content `:text` slots:
 
-1. **Resolve the cap.** `max-tokens` turns the raw `:max-tokens` MCP arg into the per-call cap: `nil` (caller passed `0` → disabled), `default-max-tokens` (5000; absent or non-number), or a positive integer (custom cap). When the resolved cap is `nil`, `apply-cap` short-circuits and returns the result untouched — **the disable mechanism is `max-tokens` resolving to `nil`, not the arg being `0` at the gate**.
+1. **Resolve the cap.** `max-tokens` turns the raw `:max-tokens` MCP arg into the per-call cap: `nil` (caller passed `0` → disabled), `default-max-tokens` (5000; absent or non-number), a positive integer (custom cap), or — for a **negative** number — an `{:rf.mcp/invalid-arg {...}}` rejection (rf2-5rdit; see [§Negative `:max-tokens` is rejected](#negative-max-tokens-is-rejected-rf2-5rdit)). When the resolved cap is `nil`, `apply-cap` short-circuits and returns the result untouched — **the disable mechanism is `max-tokens` resolving to `nil`, not the arg being `0` at the gate**.
 2. **Single-pass token + char sum.** One `transduce` over the `:text`-slot strings folds both `Σ token-estimate` and `Σ (count s)` in one walk (so a story-mcp `:structuredContent` is materialised once, not twice).
 3. **Two-stage over-budget decision** (`over-cap?`): trip when EITHER the token sum `> cap` (primary gate) OR the char sum `> cap * byte-cap-multiplier` (secondary byte gate — defence-in-depth against payloads where `(count s)/4` undercounts: CJK, emoji, base64, dense code). `reported-count` selects which count rides the marker's `:token-count` slot (the char count when the secondary gate is the one that tripped, else the token sum).
 4. **Pass-through or replace.** Under-budget responses pass through unchanged; over-budget responses are replaced with a fresh result carrying the `:rf.mcp/overflow` marker (built via `overflow/overflow-payload`).
@@ -119,6 +119,19 @@ The structural guarantee comes from the marker shape — `:limit`, `:token-count
 2. **Local-host streaming consumers** — agents that stream tool responses (rather than load them into context) may opt out of the cap to receive the full payload.
 
 The default-ON posture matches the agent-ergonomics threat model: a stock install never accidentally floods the agent's context.
+
+## Negative `:max-tokens` is rejected (rf2-5rdit)
+
+A **negative** `:max-tokens` is neither a disable signal nor a valid cap. `max-tokens` rejects it with an `{:rf.mcp/invalid-arg {:arg :max-tokens :value <n> :hint "max-tokens must be >= 0; 0 disables the cap"}}` marker; the consumer surfaces that as an `isError: true` tool-result (the agent reads it and corrects the arg). The handler is never dispatched and the rejection never reaches `apply-cap` as a `:cap`.
+
+Why reject rather than clamp / treat-as-default (Mike ruled A, 2026-06-01): a negative value used to fall through to `(long raw)`, producing a negative ceiling. `over-cap?` (`(> tokens cap)`) is then true for ANY non-negative token count, so **every** response — even a 2-character one — was replaced by the `:rf.mcp/overflow` marker, locking the agent out of all tool data and emitting a nonsensical `:cap-tokens -1`. An honest, recoverable rejection at the AI/MCP boundary is the masterpiece CORRECTNESS posture: a malformed cap is an agent error worth telling the agent about, not a value to silently paper over.
+
+Helpers (in `cap`):
+
+- `invalid-arg-marker` — builds the `{:rf.mcp/invalid-arg {...}}` rejection payload.
+- `invalid-arg?` — the predicate each consumer gates on before threading the cap into `apply-cap`.
+
+The reserved key is `vocab/invalid-arg-key` (`:rf.mcp/invalid-arg`). The wire `:minimum 0` on story-mcp's `:max-tokens` input-schema is the first line of defence for schema-validating hosts; this egress rejection is the backstop for hosts that don't validate (pair-mcp's descriptor carries no `:minimum`).
 
 ## Conformance posture
 

--- a/tools/mcp-base/spec/vocab.md
+++ b/tools/mcp-base/spec/vocab.md
@@ -38,6 +38,7 @@ Unqualified envelope slots — `:dropped-sensitive`, `:elided-large` — are per
 | `cursor-stale-reason` | `:rf.mcp/cursor-stale` | Error-result `:reason` value | rf2-kbqq3 |
 | `cache-hit-key` | `:rf.mcp/cache-hit` | `{:tool … :digest … :hint …}` (content-free; agent host correlates by cache key) | rf2-3rt1f / rf2-36xod |
 | `summary-key` | `:rf.mcp/summary` | `{<tree-summary>}` (lazy-summary projection) | rf2-tygdv / rf2-u2029 |
+| `invalid-arg-key` | `:rf.mcp/invalid-arg` | `{:arg <kw> :value <supplied> :hint <str>}` — top-level wrapper carried as the payload of an `isError: true` result rejecting a malformed per-call arg. First emitter: `cap/max-tokens` on a negative `:max-tokens` (see [`cap.md` §Negative `:max-tokens` is rejected](cap.md#negative-max-tokens-is-rejected-rf2-5rdit)). | rf2-5rdit |
 
 ## Marker catalogue (`:rf.size/*`)
 

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -61,7 +61,8 @@
   reads the same way on both sides. mcp-base stays free of
   platform-specific deps (`js-interop`, JVM reflection, etc); those
   live in the consumer's IO instance."
-  (:require [re-frame.mcp-base.overflow :as overflow]))
+  (:require [re-frame.mcp-base.overflow :as overflow]
+            [re-frame.mcp-base.vocab :as vocab]))
 
 ;; ---------------------------------------------------------------------------
 ;; ResultIO — the per-server specialisation hook.
@@ -96,29 +97,78 @@
 ;; max-tokens — per-call cap resolver.
 ;; ---------------------------------------------------------------------------
 
+(def ^:const invalid-arg-hint
+  "Recovery hint embedded in the `:rf.mcp/invalid-arg` rejection when a
+  caller supplies a negative `:max-tokens` (rf2-5rdit). States the valid
+  domain AND the disable sentinel so the agent's next call is correct."
+  "max-tokens must be >= 0; 0 disables the cap")
+
+(defn invalid-arg-marker
+  "Build the `{:rf.mcp/invalid-arg {...}}` rejection payload (rf2-5rdit)
+  for a malformed per-call argument. `arg` is the offending arg keyword,
+  `value` the rejected value, `hint` the recovery prose.
+
+  The consumer wraps this in its own `isError: true` tool-result shape
+  (story-mcp `result/error-result`, re-frame2-pair-mcp `wire/err-text`) so
+  the agent receives an actionable, recoverable error rather than a
+  server crash or — in the negative-`:max-tokens` case — a silent
+  lock-out where every response is replaced by the overflow marker."
+  [arg value hint]
+  {vocab/invalid-arg-key {:arg   arg
+                          :value value
+                          :hint  hint}})
+
+(defn invalid-arg?
+  "True when `x` is an `{:rf.mcp/invalid-arg {...}}` rejection — the
+  sentinel `max-tokens` returns for an out-of-domain arg. Consumers
+  call this on the `max-tokens` result and, when true, surface `x` as
+  an `isError: true` tool-result INSTEAD of feeding it to `apply-cap`
+  as a `:cap` (a malformed cap must never reach the gate)."
+  [x]
+  (and (map? x) (contains? x vocab/invalid-arg-key)))
+
 (defn max-tokens
   "Resolve the per-call cap from an ALREADY-EXTRACTED raw value.
   Returns the integer cap in tokens, `nil` when the cap is disabled
-  (caller passed `0`), or `overflow/default-max-tokens` when absent or
-  not a number.
+  (caller passed `0`), `overflow/default-max-tokens` when absent or
+  not a number, or — for a NEGATIVE number — an
+  `{:rf.mcp/invalid-arg {...}}` REJECTION marker (rf2-5rdit).
 
   Each consumer extracts the raw value from its platform-specific args
   object — re-frame2-pair-mcp uses `(j/get args \"max-tokens\")` against a JS
   object; story-mcp uses `(get args :max-tokens)` against a CLJ map —
   and feeds the result here. The coercion rules (zero disables,
-  non-number falls back to default) are the cross-MCP convention.
+  negative rejects, non-number falls back to default) are the cross-MCP
+  convention.
 
   ## Disambiguation
 
   - `nil` return ⇒ caller disabled the cap (`max-tokens 0`).
     `apply-cap` skips enforcement entirely.
   - `default-max-tokens` (5000) return ⇒ caller didn't supply a value
-    OR supplied an unrecognised value. The default applies.
-  - positive integer return ⇒ caller supplied a custom cap."
+    OR supplied a non-number. The default applies.
+  - positive integer return ⇒ caller supplied a custom cap.
+  - `{:rf.mcp/invalid-arg {...}}` return ⇒ caller supplied a NEGATIVE
+    number. The consumer surfaces this as an `isError: true` result
+    (test via `invalid-arg?`) and MUST NOT pass it to `apply-cap`.
+
+  ## Why negatives are rejected, not clamped (rf2-5rdit)
+
+  A negative cap used to fall through to `(long raw)`, producing a
+  negative ceiling. `apply-cap`'s `over-cap?` then trips on ANY
+  non-negative token count, so every response — even a 2-character
+  one — was replaced by the `:rf.mcp/overflow` marker, locking the
+  agent out of all tool data until it changed the arg, and emitting a
+  nonsensical `:cap-tokens -1`. Mike ruled (2026-06-01) for an honest,
+  recoverable rejection at the AI/MCP boundary over silently clamping
+  or treating-as-default — the masterpiece CORRECTNESS posture: a
+  malformed cap is an agent error worth telling the agent about, not a
+  value to paper over."
   [raw]
   (cond
     (nil? raw)                       overflow/default-max-tokens
     (and (number? raw) (zero? raw))  nil
+    (and (number? raw) (neg? raw))   (invalid-arg-marker :max-tokens raw invalid-arg-hint)
     (number? raw)                    (long raw)
     :else                            overflow/default-max-tokens))
 

--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -97,6 +97,23 @@
   `get-path` once they know the key of interest."
   :rf.mcp/summary)
 
+(def invalid-arg-key
+  "Top-level marker on an error-result rejecting a malformed per-call
+  argument at the wire boundary (rf2-5rdit). Shape:
+    `{:rf.mcp/invalid-arg {:arg <kw> :value <supplied> :hint <str>}}`.
+
+  Unlike `:rf.mcp/cursor-stale` (a `:reason` value on a generic
+  `{:ok? false}` envelope), this is a TOP-LEVEL wrapper carried as the
+  payload of an `isError: true` tool-result — an honest, recoverable
+  rejection the agent reads and corrects, not a server fault.
+
+  First emitter (rf2-5rdit): `cap/max-tokens` rejects a NEGATIVE
+  `:max-tokens` arg here rather than resolving it to a negative cap
+  (which would over-trip `apply-cap` and lock the agent out of every
+  response). The cross-MCP `:rf.mcp/*` namespace reserves the key for
+  any future per-call arg-validation rejection."
+  :rf.mcp/invalid-arg)
+
 ;; ---------------------------------------------------------------------------
 ;; :rf.size/* — size-elision markers
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -43,6 +43,7 @@
   (is (nil? (cap/max-tokens 0))))
 
 (deftest max-tokens-positive-integer-passed-through
+  (is (= 100 (cap/max-tokens 100)))
   (is (= 1000 (cap/max-tokens 1000)))
   (is (= 50000 (cap/max-tokens 50000))))
 
@@ -52,18 +53,47 @@
   (is (= overflow/default-max-tokens (cap/max-tokens [1 2 3]))))
 
 (deftest max-tokens-only-zero-disables-not-other-numbers
-  ;; Coverage gap (rf2-ynjts.17): the docstring is precise — ONLY a
-  ;; literal `0` disables the cap (returns nil); every other number is
-  ;; passed through as `(long raw)`. The existing tests pin nil-cap on
-  ;; `0` and passthrough on positives, but never pin that a NEGATIVE
-  ;; number is passed through (not treated as "disabled" and not
-  ;; defaulted). A regression that broadened the disable check to
-  ;; `(not (pos? raw))` would silently disable the cap for a negative
-  ;; arg — pin the exact `(zero? raw)` boundary.
-  (is (= -5 (cap/max-tokens -5))
-      "a negative number is NOT a disable signal — only 0 is")
+  ;; ONLY a literal `0` disables the cap (returns nil). A NEGATIVE number
+  ;; is neither a disable signal nor a passthrough cap — per Mike's
+  ;; rf2-5rdit ruling it is REJECTED as an out-of-domain arg (see
+  ;; `max-tokens-negative-rejected-with-invalid-arg` below). Smallest
+  ;; positive passes through unchanged.
+  (is (nil? (cap/max-tokens 0)) "0 is the sole disable signal")
   (is (= 1 (cap/max-tokens 1)) "smallest positive passes through")
-  (is (integer? (cap/max-tokens -5)) "coerced to long like every numeric arm"))
+  (is (cap/invalid-arg? (cap/max-tokens -1))
+      "a negative number is NOT a disable signal and NOT a cap — it is rejected"))
+
+(deftest max-tokens-negative-rejected-with-invalid-arg
+  ;; rf2-5rdit — Mike ruled A (REJECT). A negative `:max-tokens` used to
+  ;; fall through to `(long raw)`, producing a negative cap that
+  ;; over-tripped `apply-cap`'s `over-cap?` so EVERY response (even a
+  ;; 2-char one) was replaced by the overflow marker — locking the agent
+  ;; out of all tool data and emitting a nonsensical `:cap-tokens -1`.
+  ;; The resolver now returns an `{:rf.mcp/invalid-arg {...}}` rejection
+  ;; the consumer surfaces as an `isError: true` result.
+  (let [out (cap/max-tokens -1)]
+    (is (cap/invalid-arg? out)
+        "negative max-tokens resolves to an :rf.mcp/invalid-arg rejection, NOT a negative cap")
+    (is (not (number? out)) "the rejection is a marker map, not a (negative) cap integer")
+    (let [body (get out vocab/invalid-arg-key)]
+      (is (= :max-tokens (:arg body)) "rejection names the offending arg")
+      (is (= -1 (:value body)) "rejection echoes the rejected value")
+      (is (string? (:hint body)) "rejection carries an actionable recovery hint")
+      (is (re-find #"(?i)0 disables" (:hint body))
+          "hint states the disable sentinel so the agent's next call is correct")))
+  (is (cap/invalid-arg? (cap/max-tokens -5)) "larger-magnitude negatives reject too")
+  (is (cap/invalid-arg? (cap/max-tokens -1.5)) "negative doubles reject too"))
+
+(deftest invalid-arg?-predicate-discriminates
+  ;; The predicate consumers gate on. True only for the rejection marker;
+  ;; false for every valid `max-tokens` return (cap int, nil-disable,
+  ;; default) and for unrelated maps.
+  (is (cap/invalid-arg? (cap/max-tokens -1)))
+  (is (not (cap/invalid-arg? (cap/max-tokens 0))) "nil disable is not a rejection")
+  (is (not (cap/invalid-arg? (cap/max-tokens 100))) "a valid cap is not a rejection")
+  (is (not (cap/invalid-arg? (cap/max-tokens nil))) "the default is not a rejection")
+  (is (not (cap/invalid-arg? {:other :map})) "an unrelated map is not a rejection")
+  (is (not (cap/invalid-arg? nil)) "nil is not a rejection"))
 
 (deftest max-tokens-coerces-double-to-long
   (is (= 1000 (cap/max-tokens 1000.0)))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -253,12 +253,23 @@
   ;; here at the single dispatch chokepoint.
   (when (not= name "discover-app")
     (wire/stick-build! conn args))
-  (let [enabled? (args/parse-bool-arg args :cache)
-        ctx      {:conn       conn
-                  :name       name
-                  :args       args
-                  :extra      extra
-                  :result     nil
-                  :cache-opts {:tool name :args args :enabled? enabled?}
-                  :cap-opts   {:tool name :cap (cap/max-tokens-arg args)}}]
-    (bs/run-and-extract wire-boundary-pipeline ctx)))
+  (let [cap (cap/max-tokens-arg args)]
+    (if (cap/invalid-arg? cap)
+      ;; rf2-5rdit — a negative `:max-tokens` resolves to a
+      ;; `{:rf.mcp/invalid-arg {...}}` rejection rather than a negative
+      ;; cap. Short-circuit into an `isError: true` result BEFORE the
+      ;; pipeline runs: the tool is never dispatched and the malformed
+      ;; cap never reaches `apply-cap` (where a negative ceiling would
+      ;; over-trip `over-cap?` and replace every response — even a tiny
+      ;; one — with the overflow marker, locking the agent out). The
+      ;; agent reads the actionable rejection and corrects the arg.
+      (js/Promise.resolve (wire/err-text cap))
+      (let [enabled? (args/parse-bool-arg args :cache)
+            ctx      {:conn       conn
+                      :name       name
+                      :args       args
+                      :extra      extra
+                      :result     nil
+                      :cache-opts {:tool name :args args :enabled? enabled?}
+                      :cap-opts   {:tool name :cap cap}}]
+        (bs/run-and-extract wire-boundary-pipeline ctx)))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
@@ -74,6 +74,17 @@
   (let [raw (when args (j/get args "max-tokens"))]
     (base-cap/max-tokens (when (and (not (undefined? raw)) (some? raw)) raw))))
 
+(defn invalid-arg?
+  "True when `max-tokens-arg` rejected the per-call `:max-tokens` arg
+  (rf2-5rdit) — a negative value resolves to a
+  `{:rf.mcp/invalid-arg {...}}` rejection rather than a cap. The
+  `invoke` chokepoint tests this and short-circuits into an
+  `isError: true` result via `wire/err-text` instead of threading the
+  malformed cap into the wire-boundary pipeline. Delegates to
+  `base-cap/invalid-arg?` (the cross-MCP predicate)."
+  [x]
+  (base-cap/invalid-arg? x))
+
 (def overflow-hints
   "Tool-specific next-step hints for the overflow marker. Generic
   fallback when a tool isn't listed."

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_knobs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_knobs.cljs
@@ -11,12 +11,15 @@
 
 (def max-tokens-property
   {:type        "integer"
+   :minimum     0
    :description (str "Wire-boundary token-budget cap (default "
                      cap/default-max-tokens
                      "). Per spec/Principles.md §Tight token budget, "
                      "responses serialising over this estimate are "
                      "replaced with an `{:rf.mcp/overflow ...}` "
-                     "marker. Pass 0 to disable the cap.")})
+                     "marker. Must be >= 0: pass 0 to disable the cap. "
+                     "A negative value is rejected with an "
+                     "`{:rf.mcp/invalid-arg ...}` error (rf2-5rdit).")})
 
 (def limit-property
   "Per-tool descriptor slot for the `:limit` cursor-pagination knob

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
@@ -112,6 +112,10 @@
   (let [v (extract-edn result)]
     (and (map? v) (contains? v :rf.mcp/overflow))))
 
+(defn- invalid-arg? [result]
+  (let [v (extract-edn result)]
+    (and (map? v) (contains? v :rf.mcp/invalid-arg))))
+
 ;; ---------------------------------------------------------------------------
 ;; set-stubs! — install one or more namespace-slot stubs.
 ;;
@@ -292,6 +296,44 @@
                    (let [marker (-> (extract-edn result) :rf.mcp/overflow)]
                      (is (= "snapshot" (:tool marker)))
                      (is (> (:token-count marker) 100)))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-5rdit — negative :max-tokens is REJECTED at the invoke chokepoint,
+;; BEFORE the pipeline runs. The tool body is never dispatched and the
+;; result is an actionable `{:rf.mcp/invalid-arg ...}` error — NOT the
+;; `:rf.mcp/overflow` lock-out a negative cap used to cause (over-cap?
+;; trips on any non-negative token count against a negative ceiling, so
+;; even a tiny response was replaced by the overflow marker).
+;; ---------------------------------------------------------------------------
+
+(deftest negative-max-tokens-rejected-not-overflow-lockout
+  (async done
+    (let [args        (args-js {"max-tokens" -1})
+          dispatched? (atom false)]
+      (set-stubs!
+        {:snapshot-tool (fn [_conn _args]
+                          (reset! dispatched? true)
+                          ;; A tiny payload — under any sane positive cap.
+                          ;; With the OLD negative-cap bug this still
+                          ;; overflowed; with the fix the tool never runs.
+                          (js/Promise.resolve (mcp-result (pr-str {:ok? true}))))})
+      (-> (tools/invoke nil "snapshot" args nil)
+          (.then (fn [result]
+                   (is (true? (j/get result :isError))
+                       "negative max-tokens surfaces as an isError result")
+                   (is (invalid-arg? result)
+                       "result carries the :rf.mcp/invalid-arg rejection")
+                   (is (not (overflow? result))
+                       "NOT the overflow lock-out a negative cap used to cause")
+                   (is (false? @dispatched?)
+                       "the tool body is never dispatched — rejection short-circuits invoke")
+                   (let [body (-> (extract-edn result) :rf.mcp/invalid-arg)]
+                     (is (= :max-tokens (:arg body)))
+                     (is (= -1 (:value body)))
+                     (is (re-find #"(?i)0 disables" (:hint body))))
+                   (is (zero? (cache/size))
+                       "rejected calls do not touch the cache")
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
@@ -69,6 +69,28 @@
 (deftest max-tokens-arg-non-number-falls-back-to-default
   (is (= cap/default-max-tokens (cap/max-tokens-arg #js {"max-tokens" "bogus"}))))
 
+(deftest max-tokens-arg-negative-rejected-with-invalid-arg
+  ;; rf2-5rdit — a negative `:max-tokens` resolves to an
+  ;; `{:rf.mcp/invalid-arg {...}}` rejection, NOT a negative cap (which
+  ;; would over-trip apply-cap and lock the agent out). The `invoke`
+  ;; chokepoint surfaces it as an isError result via `wire/err-text`.
+  (let [out (cap/max-tokens-arg #js {"max-tokens" -1})]
+    (is (cap/invalid-arg? out)
+        "negative max-tokens-arg is a rejection, not a negative cap")
+    (is (not (number? out)) "rejection is a marker map, not a (negative) cap")
+    (let [body (get out :rf.mcp/invalid-arg)]
+      (is (= :max-tokens (:arg body)))
+      (is (= -1 (:value body)))
+      (is (re-find #"(?i)0 disables" (:hint body)))))
+  (is (cap/invalid-arg? (cap/max-tokens-arg #js {"max-tokens" -5}))))
+
+(deftest invalid-arg?-discriminates
+  (is (cap/invalid-arg? (cap/max-tokens-arg #js {"max-tokens" -1})))
+  (is (not (cap/invalid-arg? (cap/max-tokens-arg #js {"max-tokens" 0}))))
+  (is (not (cap/invalid-arg? (cap/max-tokens-arg #js {"max-tokens" 100}))))
+  (is (not (cap/invalid-arg? (cap/max-tokens-arg #js {}))))
+  (is (not (cap/invalid-arg? nil))))
+
 ;; ---------------------------------------------------------------------------
 ;; sum-text-tokens — sums every `:text` slot.
 ;; ---------------------------------------------------------------------------

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
@@ -14,9 +14,13 @@
   "Recurring fragment — every tool accepts a per-call `:max-tokens`
   override of the wire-boundary cap (rf2-rvyzy / rf2-zavp5). `0`
   disables the cap; default is
-  `re-frame.mcp-base.overflow/default-max-tokens` (5000)."
+  `re-frame.mcp-base.overflow/default-max-tokens` (5000). A NEGATIVE
+  value is rejected (rf2-5rdit): `:minimum 0` constrains it at
+  schema-validating hosts, and the wire-egress backstop surfaces a
+  `{:rf.mcp/invalid-arg {...}}` `isError` result for hosts that don't
+  validate."
   {:type "integer" :minimum 0
-   :description "Per-call wire-boundary token cap. 0 disables; default 5000 (per `spec/Cross-Cutting-Designs.md §3`)."})
+   :description "Per-call wire-boundary token cap. Must be >= 0: 0 disables; default 5000 (per `spec/Cross-Cutting-Designs.md §3`). A negative value is rejected with an `:rf.mcp/invalid-arg` error."})
 
 (def dedup-schema
   "Recurring fragment — every tool accepts a per-call `:dedup` opt-out

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
@@ -199,31 +199,40 @@
   zero compression win."
   [tool-name arguments]
   (when-let [t (registry/tool-by-name tool-name)]
-    (let [args      (or arguments {})
-          cap       (base-cap/max-tokens (get args :max-tokens))
-          ;; Dedup runs only on tools that opt in via `:dedup-eligible?`
-          ;; on the descriptor — and only when the caller leaves the
-          ;; `:dedup` arg at its default `true`. Ineligible tools never
-          ;; carry the `:dedup` slot in their input schema (per
-          ;; `with-dedup` on the descriptor), so any caller-supplied
-          ;; value is silently ignored.
-          eligible? (true? (:dedup-eligible? t))
-          dedup?    (and eligible?
-                         (args/parse-boolean (get args :dedup) true))
-          result    (try
-                      ((:handler t) args)
-                      (catch Throwable e
-                        (result/error-result (str "Tool handler threw: " (ex-message e))
-                                        {:tool      tool-name
-                                         :exception (.getName (class e))
-                                         :data      (ex-data e)})))
-          ;; Skip dedup on error envelopes (small bespoke payload; the
-          ;; flat `:rf.error` shape is more useful unwrapped than under
-          ;; a cache-of-one marker).
-          deduped   (if (true? (:isError result))
-                      result
-                      (apply-dedup result dedup?))]
-      (base-cap/apply-cap result-io deduped
-                          {:tool tool-name
-                           :cap  cap
-                           :hint (get overflow-hints tool-name)}))))
+    (let [args (or arguments {})
+          cap  (base-cap/max-tokens (get args :max-tokens))]
+      (if (base-cap/invalid-arg? cap)
+        ;; rf2-5rdit — a negative `:max-tokens` resolves to a
+        ;; `{:rf.mcp/invalid-arg {...}}` rejection rather than a negative
+        ;; cap. Surface it as an `isError: true` tool-result so the agent
+        ;; gets an actionable, recoverable error — NOT a silent lock-out
+        ;; where the bad cap over-trips `apply-cap`'s `over-cap?` and
+        ;; every response is replaced by the overflow marker. The handler
+        ;; is never dispatched; the malformed cap never reaches the gate.
+        (result/error-result (result/pr-edn cap) cap)
+        (let [;; Dedup runs only on tools that opt in via `:dedup-eligible?`
+              ;; on the descriptor — and only when the caller leaves the
+              ;; `:dedup` arg at its default `true`. Ineligible tools never
+              ;; carry the `:dedup` slot in their input schema (per
+              ;; `with-dedup` on the descriptor), so any caller-supplied
+              ;; value is silently ignored.
+              eligible? (true? (:dedup-eligible? t))
+              dedup?    (and eligible?
+                             (args/parse-boolean (get args :dedup) true))
+              result    (try
+                          ((:handler t) args)
+                          (catch Throwable e
+                            (result/error-result (str "Tool handler threw: " (ex-message e))
+                                            {:tool      tool-name
+                                             :exception (.getName (class e))
+                                             :data      (ex-data e)})))
+              ;; Skip dedup on error envelopes (small bespoke payload; the
+              ;; flat `:rf.error` shape is more useful unwrapped than under
+              ;; a cache-of-one marker).
+              deduped   (if (true? (:isError result))
+                          result
+                          (apply-dedup result dedup?))]
+          (base-cap/apply-cap result-io deduped
+                              {:tool tool-name
+                               :cap  cap
+                               :hint (get overflow-hints tool-name)}))))))

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -1796,6 +1796,33 @@
     (let [r (wire-pipeline/invoke-tool "list-tags" {})]
       (is (not (overflow-marker? r))))))
 
+(deftest cap-negative-max-tokens-rejected-not-overflow-lockout
+  ;; rf2-5rdit — a negative `:max-tokens` resolves to a
+  ;; `{:rf.mcp/invalid-arg {...}}` rejection, NOT a negative cap. The
+  ;; handler is never dispatched and the result is an actionable
+  ;; `isError: true` error — not the `:rf.mcp/overflow` lock-out a
+  ;; negative ceiling used to cause (over-cap? trips on any non-negative
+  ;; token count against a negative cap, so even a tiny response was
+  ;; replaced by the overflow marker). The wire `:minimum 0` schema is the
+  ;; first line of defence for validating hosts; this is the egress
+  ;; backstop for hosts that don't validate.
+  (testing "negative :max-tokens surfaces an :rf.mcp/invalid-arg error, not overflow"
+    (let [r    (wire-pipeline/invoke-tool "list-tags" {:max-tokens -1})
+          body (get-in r [:structuredContent vocab/invalid-arg-key])]
+      (is (true? (:isError r))
+          "negative max-tokens surfaces as an isError tool-result")
+      (is (not (overflow-marker? r))
+          "NOT the overflow lock-out a negative cap used to cause")
+      (is (some? body) "result carries the :rf.mcp/invalid-arg rejection payload")
+      (is (= :max-tokens (:arg body)))
+      (is (= -1 (:value body)))
+      (is (re-find #"(?i)0 disables" (:hint body))
+          "hint states the disable sentinel so the agent's retry is correct")
+      ;; The text slot mirrors the structured payload (round-trips to EDN).
+      (is (= :max-tokens
+             (get-in (edn/read-string (-> r :content first :text))
+                     [vocab/invalid-arg-key :arg]))))))
+
 (deftest cap-honours-default-when-omitted
   (testing "absent `:max-tokens` falls back to `overflow/default-max-tokens` (5000)"
     ;; A tiny payload like `list-tags` is well under 5K tokens; verify


### PR DESCRIPTION
## What

A negative `:max-tokens` used to fall through to `(long raw)` in `cap/max-tokens`, producing a negative cap. `apply-cap`'s `over-cap?` (`(> tokens cap)`) is then true for **any** non-negative token count, so **every** response — even a 2-character one — was replaced by the `:rf.mcp/overflow` marker, locking the agent out of all tool data and emitting a nonsensical `:cap-tokens -1`.

Per Mike's ruling on **rf2-5rdit** (A — REJECT, not clamp / treat-as-default; honest, recoverable errors at the AI/MCP boundary), this rejects a negative `:max-tokens` with a clear, actionable MCP error.

## The fix

`cap/max-tokens` now returns, for a **negative** number, the rejection marker:

```clojure
{:rf.mcp/invalid-arg {:arg   :max-tokens
                      :value <n>
                      :hint  "max-tokens must be >= 0; 0 disables the cap"}}
```

`nil`→default, `0`→disable, positive→cap are all unchanged; only `< 0` becomes the rejection.

New shared pieces in `mcp-base`:
- `vocab/invalid-arg-key` (`:rf.mcp/invalid-arg`) — reserved cross-MCP key.
- `cap/invalid-arg-marker` — builds the rejection payload.
- `cap/invalid-arg?` — the predicate each consumer gates on.

Both consumers detect the rejection and surface it as an `isError: true` tool-result **before** the wire-boundary pipeline runs — the handler is never dispatched and the malformed cap never reaches `apply-cap`:
- **story-mcp** `wire_pipeline/invoke-tool` → `result/error-result` (dual-coded text + `:structuredContent`).
- **re-frame2-pair-mcp** `tools/invoke` → `wire/err-text`, short-circuiting before the four-step boundary pipeline. (`tools/cap.cljs` re-exports `invalid-arg?`.)

Schema descriptors gain `:minimum 0` (first line of defence for schema-validating hosts; the egress rejection is the backstop for hosts that don't validate — pair-mcp's descriptor previously carried no minimum). `cap.md` + `vocab.md` updated.

## Regression tests (failing-before / passing-after)

- mcp-base `cap_test.clj`: `(max-tokens -1)` / `-5` / `-1.5` → `:rf.mcp/invalid-arg` rejection (not a negative cap); `0`→nil-disable; `nil`→default; `100`→100; `invalid-arg?` discriminates. The prior deliberate pin (`max-tokens-only-zero-disables-not-other-numbers`) that asserted `-5`→`-5` passthrough is flipped to assert rejection.
- pair-mcp `wire_cap_test.cljs`: `max-tokens-arg` negative rejection + `invalid-arg?` discrimination.
- pair-mcp `invoke_test.cljs` (end-to-end): a `:max-tokens -1` `tools/call` returns the `:rf.mcp/invalid-arg` `isError` result, **not** `:rf.mcp/overflow`; the tool body is never dispatched; cache untouched.
- story-mcp `tools_test.clj` (end-to-end): `invoke-tool "list-tags" {:max-tokens -1}` returns the `:rf.mcp/invalid-arg` `isError` result, not the overflow lock-out.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| mcp-base JVM | `clojure -M:test` | **169 tests, 470 assertions, 0 failures, 0 errors** |
| story-mcp JVM (`:test`) | `clojure -M:test` | **196 tests, 994 assertions, 0 failures, 0 errors** |
| pair-mcp `:server-test` | `npm test` | **747 tests, 2130 assertions, 0 failures, 0 errors** (185 files compiled, 0 warnings) |
| wire-vocab conformance | `clojure -M:test` | **49 tests, 623 assertions, 0 failures, 0 errors** |
| clj-kondo (changed files) | `clj-kondo --lint …` | **0 errors**; the 6 warnings are pre-existing (verified identical on baseline via stash), none introduced by this change |

These four suites are conformance gates #1, #3, and #6 of the `npm run test:mcp-conformance` chain. The remaining chained gates (#2 stdio roundtrip, #4/#5 SDK-client drivers, hermetic live-overflow) exercise the overflow path live and don't cover the invalid-arg surface, which is covered by the unit + invoke-level suites above.

Closes rf2-5rdit.
