### PR TITLE
chore(examples): bump orchestrator port off 804x + documented port-map (rf2-ot0lv)

### DIFF
--- a/examples/reagent/websocket/README.md
+++ b/examples/reagent/websocket/README.md
@@ -58,13 +58,13 @@ The example is wired into the canonical examples harness. From `implementation/`
 npm run test:examples
 ```
 
-That compiles every example (this one builds under shadow-cljs id `examples/websocket`), stages its `index.html` into `out/examples/websocket/`, and serves the lot on `127.0.0.1:8040` (override with `EXAMPLES_PORT`).
+That compiles every example (this one builds under shadow-cljs id `examples/websocket`), stages its `index.html` into `out/examples/websocket/`, and serves the lot on `127.0.0.1:8050` (override with `EXAMPLES_PORT`).
 
 To iterate on the source alone, watch the build directly from `implementation/`:
 
 ```bash
 shadow-cljs watch examples/websocket
-# then visit http://127.0.0.1:8040/websocket/ once the harness is running
+# then visit http://127.0.0.1:8050/websocket/ once the harness is running
 ```
 
 ## Headless tests

--- a/examples/scripts/examples-port.cjs
+++ b/examples/scripts/examples-port.cjs
@@ -12,16 +12,15 @@
  * gave no hint that the dev's own watch session was the cause.
  *
  * This resolver fixes both halves:
- *   1. DEFAULT_PORT is 8040. NOTE (rf2-xz4zn): 8040 now OVERLAPS the
- *      top-level :dev-http set — that map currently claims
- *      8765 / 8030-8033 (Xray testbeds) AND 8040-8043 (the four Story
- *      showcases, on the 804x band). So when a `shadow-cljs watch` is up,
- *      8040 may already be taken. This is harmless here: the resolver
- *      PRE-FLIGHTS (step 2) and scans forward, so test:examples just lands
- *      on the next free port (8044+) instead of hard-failing. The 8040
- *      default predates the 804x Story band; whether to bump it off the
- *      band is a deliberate config call (see rf2-uuxjd), kept out of this
- *      comment-only reconcile.
+ *   1. DEFAULT_PORT is 8050. It sits in the examples-orchestrator's OWNED
+ *      range (805x), clear of the top-level :dev-http set — that map claims
+ *      8765 / 8030-8034 (Xray testbeds) and 8040-8043 (the four Story
+ *      showcases). See the OWNED-RANGE PORT MAP in
+ *      implementation/scripts/dev-testbed.cjs (the single source of truth
+ *      for who-owns-what) for the convention; rf2-ot0lv moved this default
+ *      off the 804x band to keep the bands non-overlapping. The pre-flight
+ *      + forward scan (step 2) still apply, so even an unexpected clash on
+ *      805x lands on the next free port instead of hard-failing.
  *   2. It PRE-FLIGHTS the port (binds-and-releases on 127.0.0.1). If the
  *      preferred port is busy and no explicit EXAMPLES_PORT was set, it
  *      scans forward to the next free port. If an explicit EXAMPLES_PORT
@@ -48,12 +47,14 @@ const {
   portError,
 } = require('./port-resolver.cjs');
 
-// Default port. NOTE (rf2-xz4zn): 8040 now sits INSIDE the top-level
-// :dev-http band (8040-8043 are the Story showcases; 8765 / 8030-8033 are
-// the Xray testbeds), so a running `shadow-cljs watch` CAN pre-claim it.
-// The pre-flight + forward scan (below) keep this harmless — we just land
-// on 8044+. A bump off the 804x band is a deliberate config call (rf2-uuxjd).
-const DEFAULT_PORT = 8040;
+// Default port. The examples orchestrator OWNS the 805x band — clear of
+// the top-level :dev-http set (8765 / 8030-8034 = Xray testbeds; 8040-8043
+// = Story showcases). See the OWNED-RANGE PORT MAP in
+// implementation/scripts/dev-testbed.cjs for the convention (rf2-ot0lv).
+// The pre-flight + forward scan (below) still cover an unexpected clash by
+// landing on the next free port; with the bands now non-overlapping a
+// running `shadow-cljs watch` no longer pre-claims this default.
+const DEFAULT_PORT = 8050;
 
 const parseExplicitPort = makeParseExplicitPort('EXAMPLES_PORT', { actionable: true });
 
@@ -88,8 +89,10 @@ async function resolveExamplesPort({ env = process.env } = {}) {
       throw portError(
         `EXAMPLES_PORT=${explicit} is already in use. Is a 'shadow-cljs watch' ` +
           `running? The top-level :dev-http map (implementation/shadow-cljs.edn) ` +
-          `claims 8765 / 8030-8033 / 8040-8043 whenever a watch is up. Stop the ` +
-          `watch, or set EXAMPLES_PORT to a free port.`,
+          `claims 8765 / 8030-8034 / 8040-8043 whenever a watch is up (the ` +
+          `examples orchestrator owns 805x — see the OWNED-RANGE PORT MAP in ` +
+          `implementation/scripts/dev-testbed.cjs). Stop the watch, or set ` +
+          `EXAMPLES_PORT to a free port.`,
         { actionable: true },
       );
     }

--- a/examples/scripts/run-examples-tests.cjs
+++ b/examples/scripts/run-examples-tests.cjs
@@ -61,9 +61,11 @@ const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] 
 // EXAMPLES_BASE_URL is always set by the orchestrator
 // (serve-and-run-examples-tests.cjs) to the port it actually resolved.
 // The fallback below only applies when this runner is invoked
-// standalone; it tracks the orchestrator's default port (8040 — outside
-// the top-level :dev-http set 8765/8031/8030; see examples-port.cjs).
-const BASE_URL = process.env.EXAMPLES_BASE_URL || 'http://127.0.0.1:8040';
+// standalone; it tracks the orchestrator's default port (8050 — in the
+// examples orchestrator's owned 805x band, clear of the top-level
+// :dev-http set; see examples-port.cjs and the OWNED-RANGE PORT MAP in
+// implementation/scripts/dev-testbed.cjs).
+const BASE_URL = process.env.EXAMPLES_BASE_URL || 'http://127.0.0.1:8050';
 // `EXAMPLES_FILTER` narrows the spec set. When set, only spec files whose
 // path includes the substring are loaded. Composes with the
 // orchestrator's compile/stage filter so a narrow run only exercises

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -14,10 +14,12 @@
  * 1. Compiles each surface's shadow-cljs build (one per smoke).
  * 2. Stages each surface's hand-written index.html into its
  *    out/examples/<name>/ directory next to main.js.
- * 3. Resolves a free port (default 8040 — now OVERLAPPING the top-level
- *    :dev-http band; the resolver pre-flights + scans forward so this is
- *    harmless — see examples-port.cjs for the policy + rf2-xz4zn note) and
- *    spawns http-server over out/examples on 127.0.0.1:<port>.
+ * 3. Resolves a free port (default 8050 — in the examples orchestrator's
+ *    owned 805x band, clear of the top-level :dev-http bands; the resolver
+ *    still pre-flights + scans forward — see examples-port.cjs for the
+ *    policy and the OWNED-RANGE PORT MAP in
+ *    implementation/scripts/dev-testbed.cjs) and spawns http-server over
+ *    out/examples on 127.0.0.1:<port>.
  * 4. Waits for it to be reachable, then runs the Playwright runner
  *    (run-examples-tests.cjs).
  * 5. Always tears the server down.
@@ -86,13 +88,12 @@ function parseFilterPatterns(raw) {
 }
 const FILTER_PATTERNS = parseFilterPatterns(FILTER);
 // Port resolution lives in examples-port.cjs (resolveExamplesPort, called
-// at the top of main()). Default is 8040, which now OVERLAPS the top-level
-// :dev-http band (8040-8043 are the Story showcases; see examples-port.cjs
-// for the full set + rf2-xz4zn note). A running `shadow-cljs watch` can
-// therefore pre-claim it, but harmlessly: `EXAMPLES_PORT` overrides the
-// default; when unset the resolver scans forward from 8040 to the next
-// free port, and when set-but-busy it throws an actionable message (no raw
-// EACCES stack). No CLI surface is added.
+// at the top of main()). Default is 8050 — in the examples orchestrator's
+// owned 805x band, clear of the top-level :dev-http bands (see the
+// OWNED-RANGE PORT MAP in implementation/scripts/dev-testbed.cjs).
+// `EXAMPLES_PORT` overrides the default; when unset the resolver scans
+// forward from 8050 to the next free port, and when set-but-busy it throws
+// an actionable message (no raw EACCES stack). No CLI surface is added.
 // __dirname is <repo>/examples/scripts. IMPL_ROOT is <repo>/implementation
 // (where shadow-cljs runs and node_modules lives); REPO_ROOT is <repo>.
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -264,7 +265,7 @@ function stageHtml() {
 
 async function main() {
   // Pre-flight the port before any compile work: the resolver binds-and-
-  // releases on 127.0.0.1, picks the next free port from 8040 when
+  // releases on 127.0.0.1, picks the next free port from 8050 when
   // EXAMPLES_PORT is unset, and throws an actionable message (caught by
   // the bottom .catch, which prints err.message + exits 1) when an
   // explicit EXAMPLES_PORT is busy. Resolving first means a port clash

--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -98,6 +98,37 @@ const GROUPS = {
   all: [...XRAY_BUILDS, ...STORIES_BUILDS],
 };
 
+// ===========================================================================
+// OWNED-RANGE PORT MAP (rf2-ot0lv). Single source of truth for who-owns-
+// which-localhost-band across the dev/test tooling, so the next port
+// addition can't silently collide. Each owner keeps to its band; adding a
+// surface picks the next free slot WITHIN the owner's band.
+//
+//   Band        Owner                     Notes
+//   ----------  ------------------------  ----------------------------------
+//   8030-8034   Xray testbeds             :dev-http (shadow-cljs.edn):
+//                                           8030 two-frame-isolation
+//                                           8031 standard-epochs
+//                                           8032 routes-epochs
+//                                           8033 machine-epochs
+//                                           8034 edn-inspector
+//   8040-8043   Story showcases           :dev-http (shadow-cljs.edn):
+//                                           8040 nine-states-with-stories
+//                                           8041 login-with-stories
+//                                           8042 counter-with-stories
+//                                           8043 login-form
+//   805x        examples orchestrator     DEFAULT_PORT in
+//                                           examples/scripts/examples-port.cjs
+//                                           (8050; pre-flight + forward scan).
+//   8765        Xray panel-gallery        :dev-http (shadow-cljs.edn).
+//
+// The :dev-http bands (8030-8034 / 8040-8043 / 8765) are mirrored in the
+// DEV_HTTP map below (READ-only — shadow-cljs.edn is hot-zone). The 805x
+// examples band is NOT a :dev-http port — it is the test-orchestrator's
+// http-server default, resolved at runtime — so it lives only here + in
+// examples-port.cjs, not in DEV_HTTP.
+// ===========================================================================
+
 // ---------------------------------------------------------------------------
 // build-id -> dev-http info. Kept in sync with shadow-cljs.edn :dev-http
 // (READ-only — shadow-cljs.edn is hot-zone). `story: true` marks builds


### PR DESCRIPTION
Ruled C (rf2-ot0lv, Mike 2026-06-01): bump the examples-orchestrator default port off the 804x band + add a DOCUMENTED port-map. Behaviour-neutral dev-only `.cjs` + docs tidiness; pre-alpha masterpiece stance (CLARITY).

## What changed

The examples-orchestrator `DEFAULT_PORT` was `8040`, which collided with the Story showcase `:dev-http` band (8040-8043, wired by rf2-xz4zn). The forward-scan resolver kept it harmless, but the overlap was a clarity wart.

- **`examples/scripts/examples-port.cjs`** — `DEFAULT_PORT` 8040 -> **8050** (into an owned 805x band). Rewrote the header + default-port comments and the actionable `EXAMPLES_PORT`-busy message off the stale-overlap premise; pre-flight + forward-scan behaviour unchanged.
- **`examples/scripts/run-examples-tests.cjs`** — folded the residual stale 804x-premise comment (the one uuxjd's 1-extra-file cap left at lines 64-66) + bumped the standalone fallback `BASE_URL` to 8050.
- **`examples/scripts/serve-and-run-examples-tests.cjs`** — reconciled the two port comment blocks + the from-8040 scan comment.
- **`examples/reagent/websocket/README.md`** — updated the served-port mentions (the one example README that cited the orchestrator port).
- **`implementation/scripts/dev-testbed.cjs`** — added an **OWNED-RANGE PORT MAP** block (single who-owns-what source of truth) next to the existing build->port `DEV_HTTP` map (rf2-jooy3, the natural home). Documents all bands read from `shadow-cljs.edn :dev-http`: `8030-8034` Xray testbeds, `8040-8043` Story showcases, `805x` examples orchestrator, `8765` Xray panel-gallery.

`implementation/shadow-cljs.edn` (hot-zone) was READ for the real ports, NOT modified.

## Quality gates

- `node --check` on all 4 changed `.cjs` — PASS (`examples-port.cjs`, `run-examples-tests.cjs`, `serve-and-run-examples-tests.cjs`, `dev-testbed.cjs`).
- `node --test implementation/scripts/dev-testbed.test.cjs` — PASS (12/12; covers the `DEV_HTTP` build->port map + URL printing, the port-resolution surface for testbeds).
- `npm run test:examples` (the 3 adapter smokes: Reagent / UIx / Helix) — PASS on the new port: `Ran 3 example specs. 0 failures, 0 skipped.` (The trailing `http-server exited unexpectedly (code=1)` is the Windows teardown SIGTERM artefact after a green run, pre-existing.)
- Resolver sanity: `resolveExamplesPort({env:{}})` returns `8050` (DEFAULT_PORT=8050, no clash).
- No clj-kondo: no `.clj` touched.
