### PR TITLE
fix(core): honour fn-value :fx-overrides of reserved fx-ids + trace honesty (rf2-nrpj1)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -327,18 +327,25 @@
 
   Returns the resolved fx-id (keyword); for the fn-value branch, returns
   the original-fx-id (used only for trace shape — the actual handler
-  invocation goes through `:rf.fx/override-applied` and the synthesised
-  meta returned by `resolved-fx-meta`)."
+  invocation goes through the synthesised meta returned by
+  `resolved-fx-meta`, and `handle-one-fx` emits the
+  `:rf.fx/override-applied` trace at the point the override fn actually
+  fires so the trace cannot claim an override applied while the original
+  ran; see rf2-nrpj1)."
   [original-fx-id overrides]
   (if (contains? overrides original-fx-id)
     (let [override-target (get overrides original-fx-id)]
       (cond
-        ;; (3) function value — CLJS-reference convenience.
+        ;; (3) function value — CLJS-reference convenience. The
+        ;; `:rf.fx/override-applied` trace is emitted by `handle-one-fx`
+        ;; when the override fn actually fires (not here), because a
+        ;; fn-value override of a *reserved* fx-id must pre-empt the
+        ;; reserved body — emitting the trace here would fire it even on
+        ;; paths that (counterfactually) declined the override. Returns
+        ;; the original-fx-id unchanged; `resolved-fx-meta` synthesises
+        ;; the meta carrying the user's fn.
         (fn? override-target)
-        (do
-          (trace/emit! :rf.fx :rf.fx/override-applied
-                       {:rf.fx/from original-fx-id :rf.fx/to ::fn-value})
-          original-fx-id)
+        original-fx-id
 
         ;; (2) id-redirect to a registered fx.
         (keyword? override-target)
@@ -459,7 +466,23 @@
   ([frame-id [original-fx-id args] active-platform overrides origin-event parent-envelope]
   (let [fx-id (resolve-fx-with-overrides original-fx-id overrides)
         resolved-meta (resolved-fx-meta original-fx-id fx-id overrides)
-        origin-event-id (when (vector? origin-event) (first origin-event))]
+        origin-event-id (when (vector? origin-event) (first origin-event))
+        ;; rf2-nrpj1: a function-value override (`{:dispatch (fn [m args] ...)}`)
+        ;; must run IN PLACE OF the registered/reserved fx — per spec/002
+        ;; §`:fx-overrides` the resolution model consults `:fx-overrides`
+        ;; FIRST and `(fn? override) → override` runs unconditionally. For
+        ;; the four RESERVED fx-ids (`:dispatch`, `:dispatch-later`,
+        ;; `:rf.fx/reg-flow`, `:rf.fx/clear-flow`) `fx-id` is still the
+        ;; reserved keyword (the fn-value branch of
+        ;; `resolve-fx-with-overrides` returns it unchanged), so the
+        ;; `reserved-fx-handlers` lookup below would otherwise fire the
+        ;; reserved body and silently ignore the override. We detect the
+        ;; fn-value override here and route it down the user-fx branch
+        ;; (which invokes `resolved-meta`'s synthesised `:handler-fn`),
+        ;; pre-empting the reserved body for reserved ids and matching the
+        ;; spec resolution order for user ids.
+        fn-value-override? (and (contains? overrides original-fx-id)
+                                (fn? (get overrides original-fx-id)))]
    ;; Per Spec 009 §Performance instrumentation (rf2-du3i): every fx
    ;; invocation — reserved or user-registered — runs inside a perf
    ;; bracket so prod builds with the perf flag enabled produce a
@@ -471,7 +494,8 @@
    ;; emit `:dispatch` produces zero `rf:fx:*` entries even with the perf
    ;; flag on.
    (performance/mark-and-measure :fx fx-id
-    (if-let [reserved-body (get reserved-fx-handlers fx-id)]
+    (if-let [reserved-body (and (not fn-value-override?)
+                                (get reserved-fx-handlers fx-id))]
       ;; Reserved fx-id — dispatch through the table; one uniform
       ;; `:rf.fx/handled` emit follows. The `:rf.machine/spawn` and
       ;; `:rf.machine/destroy` machine fx-ids are NOT in this table —
@@ -602,6 +626,19 @@
           ;; `:dispatch-id` are inherited from the outer scope.
           (trace/with-handler-scope
             (trace/handler-scope-from-meta :fx fx-id meta)
+            ;; rf2-nrpj1: emit `:rf.fx/override-applied` HERE — at the
+            ;; point the fn-value override actually fires — not during
+            ;; resolution. This is the trace-honesty half of the fix: the
+            ;; trace previously fired at resolution time even for reserved
+            ;; fx-ids where the override was then silently ignored and the
+            ;; reserved body ran instead (claiming an override applied
+            ;; while the original ran). It now fires iff the override fn is
+            ;; about to be invoked. `:rf.fx/to ::fn-value` marks the
+            ;; CLJS-reference fn-value form (the keyword form's trace is
+            ;; emitted by `resolve-fx-with-overrides` with its target id).
+            (when fn-value-override?
+              (trace/emit! :rf.fx :rf.fx/override-applied
+                           {:rf.fx/from original-fx-id :rf.fx/to ::fn-value}))
             ;; rf2-hhh92: wall-clock the user fx-handler invoke (dev-only)
             ;; so `:rf.fx/handled` carries `:rf.fx/elapsed-ms`. The
             ;; `now-ms` brackets ride `interop/debug-enabled?` (nil in

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -584,6 +584,111 @@
              (:event @captured-ctx))
           "ctx :event is the originating event vector"))))
 
+;; ---- 7b. :fx-overrides fn-value of a RESERVED fx-id (rf2-nrpj1) ------------
+;;
+;; The four reserved fx-ids (:dispatch, :dispatch-later, :rf.fx/reg-flow,
+;; :rf.fx/clear-flow) live only in fx.cljc's `reserved-fx-handlers` table —
+;; they are NOT in the registrar. Before rf2-nrpj1 a function-value override
+;; of a reserved fx-id was SILENTLY IGNORED: the reserved body ran while the
+;; override fn never fired AND a misleading :rf.fx/override-applied trace was
+;; still emitted. Mike ruled (2026-06-01) Option A — HONOUR fn-value
+;; :fx-overrides of reserved fx-ids: the override fn pre-empts the reserved
+;; body (matches spec/002 §`:fx-overrides` resolution model, where
+;; `(fn? override) → override` runs in place of the registered fx), and the
+;; :rf.fx/override-applied trace fires only when the override actually
+;; applies. This enables reserved-fx stubbing in tests/stories (e.g.
+;; capturing dispatches without queueing them).
+
+(deftest reserved-fx-fn-value-override-pre-empts-reserved-body
+  (testing ":dispatch fn-value override FIRES + the real :dispatch does NOT run"
+    ;; (fn [m args] (record! args)) — the natural test stub that captures the
+    ;; dispatched event vector without round-tripping it through the queue.
+    (let [captured-args (atom nil)
+          captured-ctx  (atom nil)
+          target-ran    (atom 0)]
+      (rf/reg-event-db :fx-test.nrpj1/target
+        (fn [db _] (swap! target-ran inc) db))
+      (rf/reg-event-fx :fx-test.nrpj1/emits-dispatch
+        (fn [_ _] {:fx [[:dispatch [:fx-test.nrpj1/target :payload]]]}))
+      (rf/dispatch-sync
+        [:fx-test.nrpj1/emits-dispatch]
+        {:fx-overrides {:dispatch (fn [m args]
+                                    (reset! captured-ctx m)
+                                    (reset! captured-args args))}})
+      (is (= [:fx-test.nrpj1/target :payload] @captured-args)
+          "the fn-value override fires and receives the :dispatch args (the event vector)")
+      (is (= :rf/default (:frame @captured-ctx))
+          "the override receives the standard fx-handler ctx map (frame, …)")
+      (is (= 0 @target-ran)
+          "the real reserved :dispatch body MUST NOT run — the override pre-empts it")))
+
+  (testing ":dispatch-later fn-value override pre-empts the reserved body too"
+    (let [later-args (atom nil)]
+      (rf/reg-event-fx :fx-test.nrpj1/emits-later
+        (fn [_ _] {:fx [[:dispatch-later {:ms 50 :event [:fx-test.nrpj1/target]}]]}))
+      (rf/dispatch-sync
+        [:fx-test.nrpj1/emits-later]
+        {:fx-overrides {:dispatch-later (fn [_ args] (reset! later-args args))}})
+      (is (= {:ms 50 :event [:fx-test.nrpj1/target]} @later-args)
+          "the fn-value override of :dispatch-later fires with the reserved-fx args"))))
+
+(deftest reserved-fx-fn-value-override-trace-honesty
+  (testing ":rf.fx/override-applied fires only when the reserved-fx override truly applies"
+    ;; rf2-nnma3: the trace previously fired at resolution time even though
+    ;; the reserved body ran instead. It now rides the actual override-fn
+    ;; invocation — fires when the override applies, absent otherwise.
+    (let [traces (collect-traces! ::reserved-override-trace)]
+      (rf/reg-event-db :fx-test.nrpj1/sink (fn [db _] db))
+      (rf/reg-event-fx :fx-test.nrpj1/traced-dispatch
+        (fn [_ _] {:fx [[:dispatch [:fx-test.nrpj1/sink]]]}))
+      (rf/dispatch-sync
+        [:fx-test.nrpj1/traced-dispatch]
+        {:fx-overrides {:dispatch (fn [_ _] :stubbed)}})
+      (rf/unregister-listener! ::reserved-override-trace)
+      (let [applied (filter #(= :rf.fx/override-applied (:operation %)) @traces)]
+        (is (= 1 (count applied))
+            "exactly one :rf.fx/override-applied trace — emitted because the override fired")
+        (is (= :dispatch (get-in (first applied) [:tags :rf.fx/from]))
+            ":rf.fx/from carries the reserved fx-id that was overridden")))))
+
+(deftest reserved-fx-with-no-override-runs-reserved-body
+  (testing "a reserved :dispatch with NO override still queues + runs the real event"
+    ;; Regression guard: the fn-value-override detection must not perturb the
+    ;; ordinary reserved-fx path. With no :fx-overrides, :dispatch runs its
+    ;; reserved body and the target event handler fires.
+    (let [target-ran (atom 0)]
+      (rf/reg-event-db :fx-test.nrpj1/plain-target
+        (fn [db _] (swap! target-ran inc) db))
+      (rf/reg-event-fx :fx-test.nrpj1/plain-dispatch
+        (fn [_ _] {:fx [[:dispatch [:fx-test.nrpj1/plain-target]]]}))
+      (rf/dispatch-sync [:fx-test.nrpj1/plain-dispatch])
+      (is (= 1 @target-ran)
+          "the reserved :dispatch body ran and the queued event drained"))))
+
+(deftest reserved-fx-id-redirect-override-unchanged
+  (testing "id-redirect TO a reserved fx-id still falls through (reserved ids aren't registered)"
+    ;; Per the bead: {:my-fx :dispatch} → (registrar/lookup :fx :dispatch) is
+    ;; nil → :rf.error/override-fallthrough → runs the original :my-fx. The
+    ;; reserved fx-ids live only in `reserved-fx-handlers`, not the registrar,
+    ;; so a keyword-redirect targeting one is a coherent, surfaced no-op. This
+    ;; behaviour is intentionally UNCHANGED by rf2-nrpj1.
+    (let [original-fired (atom 0)
+          traces         (collect-traces! ::redirect-to-reserved)]
+      (rf/reg-fx :fx-test.nrpj1/my-fx
+                 {:platforms #{:client :server}}
+                 (fn [_ _] (swap! original-fired inc)))
+      (rf/reg-event-fx :fx-test.nrpj1/issue-redirect
+        (fn [_ _] {:fx [[:fx-test.nrpj1/my-fx {}]]}))
+      (rf/dispatch-sync
+        [:fx-test.nrpj1/issue-redirect]
+        {:fx-overrides {:fx-test.nrpj1/my-fx :dispatch}})
+      (rf/unregister-listener! ::redirect-to-reserved)
+      (is (= 1 @original-fired)
+          "the original :fx-test.nrpj1/my-fx ran — the redirect to the un-registered :dispatch fell through")
+      (let [fallthrough (filter #(= :rf.error/override-fallthrough (:operation %)) @traces)]
+        (is (= 1 (count fallthrough))
+            "exactly one :rf.error/override-fallthrough trace surfaced the un-registered redirect target")))))
+
 ;; ---- rf2-twt7m Change 2 — :rf.fx/do-fx carries :fx + :db-present? ---------
 ;;
 ;; The handler's return shape is otherwise invisible at the trace level —


### PR DESCRIPTION
Fixes rf2-nrpj1 (Mike-ruled Option A). The PR was opened with a malformed `@-` body by the worker tooling; description reconstructed by the mayor from the bead close-reason + CI rollup before merge.

## What
`handle-one-fx` now routes a fn-value `:fx-overrides` of a reserved fx-id (`:dispatch` / `:dispatch-later` / `:rf.fx/reg-flow` / `:rf.fx/clear-flow`) down the user-fx branch, pre-empting the reserved body — matching the spec/002 §:fx-overrides resolution model (consult overrides first, fall through to the registry only on no-override). Previously a fn-value override of a reserved fx-id was silently ignored while `:rf.fx/override-applied` still fired (dishonest trace). The trace now fires only when the override fn actually runs. Enables reserved-fx stubbing in tests/stories.

## Scope
`implementation/core/src/re_frame/fx.cljc` + `implementation/core/test/re_frame` (regression tests, fx_test.clj §7b). No other surface.

## Quality gates
- core JVM `clojure -M:test`: **825 / 0F0E**
- `npm run test:cljs`: **5147 / 0F0E**
- clj-kondo on changed files: **0 errors**
- CI rollup: 42 SUCCESS / 7 SKIPPED / 0 failing.