### PR TITLE
refactor(story+mcp): migrate to frame-affordance redesign API (rf2-kkut0.5)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/000-Vision.md
+++ b/tools/re-frame2-pair-mcp/spec/000-Vision.md
@@ -1,7 +1,7 @@
 # 000-Vision: re-frame2-pair MCP server
 
 > Implements the [Tool-Pair contract](../../../spec/Tool-Pair.md) —
-> re-frame2-pair-mcp is the canonical consumer of `get-frame-db`,
+> re-frame2-pair-mcp is the canonical consumer of `frame-db`,
 > `epoch-history`, `register-listener!`, `register-epoch-listener!`,
 > `restore-epoch`, `reset-frame-db!`, `dispatch`, `dispatch-sync`,
 > plus the destroyed-frame and operating-frame rules.

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -2,7 +2,7 @@
 
 > Implements the [Tool-Pair contract](../../../spec/Tool-Pair.md) —
 > each MCP tool below routes through one or more of the Tool-Pair
-> primitives (`get-frame-db`, `epoch-history`, `register-listener!`,
+> primitives (`frame-db`, `epoch-history`, `register-listener!`,
 > `register-epoch-listener!`, `restore-epoch`, `reset-frame-db!`,
 > `dispatch`, `dispatch-sync`).
 
@@ -529,15 +529,15 @@ form in `(re-frame.core/with-frame <frame> <user-form>)` before
 sending it over nREPL. `with-frame` is the framework's lexical frame-
 binding macro (Spec 002 §with-frame); `*current-frame*` is bound to
 the named frame for the form's dynamic extent, so any
-`(rf/subscribe ...)` / `(rf/dispatch ...)` / `(rf/current-frame)`
+`(rf/subscribe ...)` / `(rf/dispatch ...)` / `(rf/current-frame-id)`
 inside the form resolves against the requested frame.
 
 **Composes with `:await`.** The `with-frame` wrap is the outer-most
 form; the await mailbox sentinel rides through the wrap unchanged.
 Note that `with-frame`'s lexical binding only lasts for the form's
 SYNCHRONOUS evaluation — once a Promise resolves on a later tick, the
-binding is gone (Spec 002 §with-frame: async closures must capture via
-`bound-fn` / `dispatcher` / `subscriber`). Most ad-hoc probes don't
+binding is gone (Spec 002 §with-frame: async closures must capture a
+`frame-handle`, or wrap via `frame-bound-fn` / `frame-bound-fn*`). Most ad-hoc probes don't
 hit this; long-running async forms that need to dispatch in a `.then`
 callback should capture the frame explicitly.
 
@@ -1281,7 +1281,7 @@ lines 79-137):
 Coarse-grained per-frame state read in **one round-trip**. The mega-op
 for investigate-X workflows that would otherwise chain 5-10 individual
 reads. Server-side composition over the existing per-slice runtime
-readers (`get-frame-db`, `sub-cache`, `machines` + frame-local
+readers (`frame-db`, `sub-cache`, `machines` + frame-local
 `[:rf/runtime :machines :snapshots]`, `epoch-history`, `trace-buffer`); no parallel
 implementation.
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
@@ -111,7 +111,8 @@
   for the form's synchronous evaluation — once the Promise resolves
   on a later tick, the original lexical frame is gone (this matches
   the macro's contract per Spec 002, where async closures must
-  capture via `bound-fn` / `dispatcher` / `subscriber`).
+  capture a `frame-handle` (or wrap via `frame-bound-fn` /
+  `frame-bound-fn*`) so the captured ops survive the boundary).
 
   ## Mailbox machinery extracted (rf2-gfu33)
 
@@ -204,10 +205,10 @@
   / namespaced keyword survives the round-trip without quoting
   surprises. `with-frame` is the framework's lexical frame-binding
   macro (Spec 002 §with-frame); per its contract, async closures
-  inside the form must capture via `bound-fn` / `dispatcher` /
-  `subscriber` for the binding to survive later ticks. We document
-  that asymmetry in the ns docstring rather than enforcing it here —
-  the body is opaque user-supplied source."
+  inside the form must capture a `frame-handle` (or wrap via
+  `frame-bound-fn` / `frame-bound-fn*`) for the binding to survive
+  later ticks. We document that asymmetry in the ns docstring rather
+  than enforcing it here — the body is opaque user-supplied source."
   [form-str frame-kw]
   (str "(re-frame.core/with-frame " (pr-str frame-kw) " " form-str ")"))
 

--- a/tools/story/spec/Migration-Audit.md
+++ b/tools/story/spec/Migration-Audit.md
@@ -64,7 +64,7 @@ Same shape as helix. All 3 assertions = (B). KEEP IN PLACE.
 | 6 | `expectTextEquals(below-clock-ticks, '0 ticks')` | A | Same. → same target. |
 | 7 | `expectTextEquals(above-title-state, ':idle')` | A | Machine initial state per frame. → same target. |
 | 8 | `expectTextEquals(below-title-state, ':idle')` | A | Same. → same target. |
-| 9 | After 3× above-inc click: above-counter = '3' AND below-counter = '0' | A | The canonical counter-isolation contract. → same target — `(dispatch [::inc])` against frame `:above` × 3 then `(rf.get-frame-db :above) :counter` = 3 and `(rf.get-frame-db :below) :counter` = 0. |
+| 9 | After 3× above-inc click: above-counter = '3' AND below-counter = '0' | A | The canonical counter-isolation contract. → same target — `(dispatch [::inc])` against frame `:above` × 3 then `(rf.frame-db :above) :counter` = 3 and `(rf.frame-db :below) :counter` = 0. |
 | 10 | After below-inc click: above stays 3, below = 1 | A | Same canonical isolation. → same target. |
 | 11 | After 2× above-tick: above-ticks=2, below-ticks=0 | A | Clock-tick handler resolves against originating frame. → same target. |
 | 12 | After below-tick: above stays 2, below=1 | A | Same. → same target. |
@@ -77,8 +77,8 @@ Same shape as helix. All 3 assertions = (B). KEEP IN PLACE.
 | 19 | `:rf.xray/set-target-frame` round-trip on :above | A | Xray-side event + sub roundtrip. → `tools/xray/test/.../target_frame_roundtrip_cljs_test.cljs` (Xray is already heavy in panels_e2e CLJS tests; extend that surface). |
 | 20 | Same on :below | A | Same. → same target. |
 | 21 | Reset away from host frames on nil | A | Same. → same target. |
-| 22 | `(rf.get-frame-db :above) :counter` = 3 | A | Same as #9 underlying contract. → same target as #9 (avoid dual coverage). |
-| 23 | `(rf.get-frame-db :below) :counter` = 1 | A | Same as #10. → same target. |
+| 22 | `(rf.frame-db :above) :counter` = 3 | A | Same as #9 underlying contract. → same target as #9 (avoid dual coverage). |
+| 23 | `(rf.frame-db :below) :counter` = 1 | A | Same as #10. → same target. |
 | 24 | `:rf/xray` carries no `:counter` leak | A | Cross-frame app-db isolation (host → Xray direction of Spec 008 §State isolation). → `tools/xray/test/.../embedding_contract_isolation_cljs_test.cljs` (new file). |
 | 25 | `expectVisible` page banner timing | C | DOM mount; keep at Playwright. STAYS (subsumed by #1/#2). |
 | 26 | Polling DOM mirror reflects post-dispatch state | C-residual | Trivial — proves substrate re-renders. After A-migrations land, the 3 substrate-smoke adapters already cover this. DROP from this spec post-migration. |
@@ -288,7 +288,7 @@ One bead per spec.cjs file. Each can dispatch in parallel where target test file
 Each Wave 1 bead is fully isolated to one artefact's test dir + one repo-root spec.cjs file deletion. **Six beads, parallel-dispatchable.**
 
 **Wave 2 (rf2-lcg1z, COMPLETED):**
-- `B7` — `tools/xray/testbeds/parallel_frames/spec.cjs` DELETED. Multi-frame isolation contract migrated to `implementation/core/test/re_frame/multi_frame_isolation_cljs_test.cljs` (six deftests covering: two-frames-mount, counter-isolation, clock-tick-isolation, sub-lens-follows-frame, no-cross-frame-leakage + rf/get-frame-db as the only legitimate cross-frame read, destroy-independence). Xray-side target-frame round-trip + L2 frame-scoped filter were already covered by `tools/xray/test/.../panels_e2e/parallel_frames_e2e_cljs_test.cljs` (rf2-ulpp8 / rf2-1p1j4) and `multi_frame_isolation_e2e_cljs_test.cljs` (cross-frame fan-out via fx). The testbed dir itself stays as the Xray-displayable showcase. **Surface: framework multi-frame.**
+- `B7` — `tools/xray/testbeds/parallel_frames/spec.cjs` DELETED. Multi-frame isolation contract migrated to `implementation/core/test/re_frame/multi_frame_isolation_cljs_test.cljs` (six deftests covering: two-frames-mount, counter-isolation, clock-tick-isolation, sub-lens-follows-frame, no-cross-frame-leakage + rf/frame-db as the only legitimate cross-frame read, destroy-independence). Xray-side target-frame round-trip + L2 frame-scoped filter were already covered by `tools/xray/test/.../panels_e2e/parallel_frames_e2e_cljs_test.cljs` (rf2-ulpp8 / rf2-1p1j4) and `multi_frame_isolation_e2e_cljs_test.cljs` (cross-frame fan-out via fx). The testbed dir itself stays as the Xray-displayable showcase. **Surface: framework multi-frame.**
 
 **Wave 3 (rf2-pxb7t, COMPLETED — single-bundle worker, sequential):**
 - `B8` — `testbeds/ssr_basic/spec.cjs` deleted. Migrated to `implementation/ssr/test/re_frame/ssr_hydration_test.clj` (5 deftests / 11 substantive assertions covering :rf/hydrate replace-app-db + `[:rf/runtime :ssr :hydration]` metadata stash + post-hydrate dispatch round-trip + :rf/response payload echo + :rf.ssr/compatibility-check-skipped trace emit + no-mismatch-on-baseline).

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -68,7 +68,7 @@
   Story is a deterministic fixture / test-driver runtime. Its internal
   helpers (`re-frame.story.runtime`, `re-frame.story.frames`,
   `re-frame.story.async`) use `rf/dispatch-sync` and direct
-  `get-frame-db` reads so a variant settles to a stable result before
+  `rf/frame-db` reads so a variant settles to a stable result before
   the assertions / render-snapshot stage runs. That posture is
   appropriate for Story's role and IS NOT a pattern to copy into normal
   interactive application code — UI event handlers should use

--- a/tools/story/src/re_frame/story/recorder/play_export_events.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export_events.cljc
@@ -15,7 +15,7 @@
 
   The translator itself (`re-frame.story.recorder.play-export`) stays
   pure. This namespace is the thin impure shell — it depends on
-  `re-frame.core` (for `get-frame-db` / `dispatch-sync*`) and the
+  `re-frame.core` (for `frame-db` / `dispatch-sync*`) and the
   runner-events ns (for `run!`), neither of which the translator
   should pull in.
 

--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -224,9 +224,10 @@
   active variant's app-db (e.g. `:counter-with-stories.views/parity-
   badge` reads `:count-parity` from the variant's frame). The panel
   view runs OUTSIDE the canvas's React subtree, so it needs its own
-  `frame-provider` scoped to `variant-id` — otherwise `(subscriber)`
-  captures `:rf/default` and the deref returns nil, throwing in the
-  view. We wrap each panel in `frame-provider {:frame variant-id}`.
+  `frame-provider` scoped to `variant-id` — otherwise the view's
+  ambient `rf/subscribe` resolves `:rf/default` and the deref returns
+  nil, throwing in the view. We wrap each panel in
+  `frame-provider {:frame variant-id}`.
 
   Returns a hiccup vector wrapping the resolved panels."
   [placement variant-id panel-visibility]


### PR DESCRIPTION
## What

Idiomatic migration pass over the three MCP/story tools (`tools/story`, `tools/story-mcp`, `tools/re-frame2-pair-mcp`) for the frame-affordance redesign (rf2-kkut0). Child .5 of the epic; foundation (.1/.2) is merged.

The foundation worker did the mechanical `get-frame-db -> frame-db` renames in runtime/test code for gate-survival. This pass is the substantive cleanup of the remaining stale references to the **deleted/renamed** surface in code docstrings and tool specs:

- **`get-frame-db` -> `frame-db`** in `story.cljc` + `play_export_events.cljc` docstrings, pair-mcp `000-Vision` / `003-Tool-Catalogue` specs (Tool-Pair primitive name + per-slice reader list), and story `Migration-Audit.md` (`rf.get-frame-db` / `rf/get-frame-db` contract references).
- **Async-closure capture guidance**: `bound-fn` / `dispatcher` / `subscriber` (all DELETED in the redesign) -> capture a **`frame-handle`** (or wrap via `frame-bound-fn` / `frame-bound-fn*`) — in `eval_cljs.cljs` docstrings and `003-Tool-Catalogue`.
- **`(rf/current-frame)` -> `(rf/current-frame-id)`** in `003-Tool-Catalogue`'s `with-frame` example.
- **`(subscriber)` -> ambient `rf/subscribe`** in `panels.cljs` docstring.

### What was already idiomatic (no change needed)

The tools' held/explicit-routing **code** routes via `dispatch-sync*` / `dispatch*` with explicit `{:frame ...}` opts and `with-frame` / `frame-provider` scoping — all KEPT and ELEVATED in the new API (`{:frame ...}` is the first-class explicit-routing surface for tools/tests per the epic). No `(dispatcher)` / `(subscriber)` held-op call sites existed.

Two `current-frame` symbols are **intentionally retained** (not in scope of this rename):
- `re-frame2-pair.runtime/current-frame` — the pair runtime's own session-frame *resolver* (distinct semantics; lives in the skills surface, kept by rf2-kkut0.6). The `(ef/rt-call 'current-frame)` emits in `get_path` / `list_subscriptions` correctly target it.
- `re-frame.frame/*current-frame*` — the core dynamic *var* (the rename was the public fn `current-frame` -> `current-frame-id`, not the var).

## Quality gates

| Gate | Result |
|------|--------|
| story `clojure -M:test` | 1553 tests, 5785 assertions, **0 failures, 0 errors** |
| story-mcp `clojure -M:test` | 196 tests, 994 assertions, **0 failures, 0 errors** |
| pair-mcp `npm test` (shadow `:server-test`) | 747 tests, 2130 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` | 5147 tests, 17407 assertions, **0 failures, 0 errors** |
| `npm run test:mcp-conformance` | **ALL GATES GREEN** (6/6; incl. pair-mcp preload + CLI flag-vocab rename-rejection) |
| clj-kondo (4 changed src files) | 0 errors, 1 pre-existing warning (unused `opts` binding, present on clean file) |
| `git grep` residue (deleted/renamed names) | clean — `get-frame-db`, bare `rf/current-frame`, `rf/bound-fn`/`dispatcher`/`subscriber` all gone from the three tools |

Closes rf2-kkut0.5.