### PR TITLE
feat(routing): ship :nav-token cofx promised by spec (rf2-8fnwq)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -38,7 +38,8 @@
   - `re-frame.routing.history`        — popstate listener install/remove + current-url
   - `re-frame.routing.subs`           — framework-shipped subs over the slice
   - `re-frame.routing.link`           — :route/link registered view"
-  (:require [re-frame.error-emit :as error-emit]
+  (:require [re-frame.cofx :as cofx]
+            [re-frame.error-emit :as error-emit]
             [re-frame.events :as events]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
@@ -138,6 +139,17 @@
                      url-change/transitioned-handler)
 (events/reg-event-fx :rf.route/handle-url-change
                      url-change/handle-url-change-handler)
+
+;; :nav-token cofx — Spec 012 §Navigation tokens — stale-result
+;; suppression step 2. Injects the current navigation epoch token under
+;; `:coeffects :nav-token` for any `:on-match`-reached handler that
+;; declares `(inject-cofx :nav-token)`, so the documented
+;; `(fn [{:keys [db nav-token]} _] ...)` shape resolves the live token
+;; (not nil). Registered in the façade so a `:reload` re-wires it on a
+;; fresh registrar.
+(cofx/reg-cofx :nav-token
+               nav-token/nav-token-cofx-meta
+               nav-token/nav-token-cofx)
 
 ;; :rf.test/simulate-http-resolution + :rf.route/with-nav-token — Spec
 ;; 012 §Navigation tokens — stale-result suppression.

--- a/implementation/routing/src/re_frame/routing/nav_token.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_token.cljc
@@ -2,6 +2,10 @@
   "Navigation-token stale-result suppression for re-frame2 routing.
 
   Per Spec 012 §Navigation tokens — stale-result suppression. Owns:
+    - `:nav-token` cofx — injects the current navigation epoch token
+      (`[:rf/runtime :routing :current :nav-token]`) into an `:on-match`
+      handler's `:coeffects` under key `:nav-token`, so the handler can
+      capture it and thread it into an async continuation;
     - `:rf.test/simulate-http-resolution` — the test-only fixture
       analogue of the production-grade fx below;
     - `:rf.route/with-nav-token` fx — wraps an async-completion fx
@@ -18,6 +22,46 @@
             [re-frame.fx :as fx]
             [re-frame.interop :as interop]
             [re-frame.trace :as trace]))
+
+(def nav-token-cofx-meta
+  "Metadata for the `:nav-token` cofx registration. Per Spec 012
+  §Navigation tokens — stale-result suppression step 2: the cofx
+  injects the current navigation epoch token so an `:on-match`-reached
+  handler can capture the token live at scheduling time and thread it
+  into an async continuation (via `:rf.route/with-nav-token` or its own
+  follow-up event payload).
+
+  Universal platform: the route slice exists on both client and server,
+  so the cofx resolves under SSR and browser alike."
+  {:doc "The current navigation epoch token, read from
+`[:rf/runtime :routing :current :nav-token]` and injected under
+`:coeffects :nav-token`. Declare with `(inject-cofx :nav-token)` on an
+`:on-match`-reached handler; capture the value and thread it into an
+async continuation so a superseding navigation suppresses the stale
+result. Per Spec 012 §Navigation tokens — stale-result suppression."})
+
+(defn nav-token-cofx
+  "Handler fn for the `:nav-token` cofx. Reads the current navigation
+  epoch token from the injected `:db` coeffect (the runtime pre-populates
+  `:coeffects :db` with the frame's `app-db` value before the
+  interceptor chain runs) and injects it under `:coeffects :nav-token`.
+
+  1-arity is the canonical form. 2-arity accepts an explicit value
+  override — useful in tests / conformance harnesses that want to assert
+  the threading shape without standing up a route slice.
+
+  Meaningful only inside a handler reached via an `:on-match` drain (or a
+  follow-up of one), where `[:rf/runtime :routing :current :nav-token]`
+  holds the epoch the navigation cascade allocated. Read from any other
+  handler it reflects whatever navigation is currently active — which is
+  the correct \"is this still the live navigation?\" reading the
+  stale-suppression pattern wants."
+  ([ctx]
+   (let [db    (get-in ctx [:coeffects :db])
+         token (get-in db [:rf/runtime :routing :current :nav-token])]
+     (assoc-in ctx [:coeffects :nav-token] token)))
+  ([ctx token]
+   (assoc-in ctx [:coeffects :nav-token] token)))
 
 (defn simulate-http-resolution-handler
   "`:rf.test/simulate-http-resolution` event-fx handler. Registered by

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -362,6 +362,118 @@
                               @traces)))
           "exactly one stale-suppressed trace fired — the fresh :do did NOT trip the validation"))))
 
+;; ---- Spec 012 §Navigation tokens step 2 — the `:nav-token` cofx ----------
+;;
+;; rf2-8fnwq: the spec promised an `:on-match`-reachable `:nav-token` cofx
+;; (step 2 / step 4 "validating cofx") but no `reg-cofx :nav-token` was
+;; registered. A handler that followed the spec — declared
+;; `(inject-cofx :nav-token)` and read `{:keys [db nav-token]}` — threaded
+;; `nil`, which mismatched the current token in `:rf.route/with-nav-token`
+;; EVERY time, so the documented stale-suppression pattern silently ate
+;; the result. These tests are the failing-before / passing-after guard.
+
+(deftest nav-token-cofx-injects-the-live-token
+  (testing "(inject-cofx :nav-token) injects the current slice token — not nil"
+    ;; The minimal contract: a handler declaring the cofx sees the live
+    ;; navigation epoch. Pre-fix this was nil (no reg-cofx :nav-token).
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-fx :rf.nav/push-url
+               {:platforms #{:server :client}}
+               (fn [_ _] nil))
+    (let [seen (atom :unset)]
+      ;; An :on-match-reached handler that captures the injected token.
+      (rf/reg-event-fx :article/capture-token
+                       [(rf/inject-cofx :nav-token)]
+                       (fn [{:keys [nav-token]} _]
+                         (reset! seen nav-token)
+                         {}))
+      ;; Land on the route, then fire the on-match-style continuation.
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/A"])
+      (let [current (get-in (rf/frame-db :rf/default)
+                            [:rf/runtime :routing :current :nav-token])]
+        (rf/dispatch-sync [:article/capture-token])
+        (is (= current @seen)
+            "the cofx injected the slice's live :nav-token (pre-fix: nil)")
+        (is (some? @seen)
+            "the injected token is non-nil (pre-fix the documented shape threaded nil)")))))
+
+(deftest nav-token-cofx-drives-documented-stale-suppression
+  (testing "the spec step-2/step-3 example runs: capture via cofx, thread via
+            :rf.route/with-nav-token; stale → suppressed, fresh → applied"
+    ;; This is the documented pattern end-to-end, using ONLY the public
+    ;; surface (no :rf.test/simulate-http-resolution). The :on-match-reached
+    ;; loader declares the cofx and captures `nav-token` live; we stash the
+    ;; captured token so the test can replay the async completion AFTER a
+    ;; superseding navigation (modelling a real out-of-order http race —
+    ;; A's request started first but its response lands after B's). The
+    ;; completion threads the captured token through :rf.route/with-nav-token,
+    ;; which validates against the current slice: stale → suppressed,
+    ;; fresh → applied.
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-fx :rf.nav/push-url
+               {:platforms #{:server :client}}
+               (fn [_ _] nil))
+    ;; Terminal commit handler.
+    (rf/reg-event-db :article/loaded
+                     (fn [db [_ id payload]]
+                       (assoc db :article {:id id :payload payload})))
+    ;; The async completion: threads a captured token through the framework
+    ;; fx, which validates against the current slice.
+    (rf/reg-event-fx :article/completed
+                     (fn [_ctx [_ {:keys [captured-token id payload]}]]
+                       {:fx [[:rf.route/with-nav-token
+                              {:do        [:dispatch [:article/loaded id payload]]
+                               :nav-token captured-token}]]}))
+
+    (let [traces   (atom [])
+          captured (atom {})]
+      (rf/register-listener! ::cofx-flow (fn [ev] (swap! traces conj ev)))
+      ;; The :on-match-reached loader: declares the cofx, captures the live
+      ;; token at scheduling time (exactly the documented step-2 shape).
+      ;; The capture closes over `captured` so the test replays the
+      ;; completion later, out of order.
+      (rf/reg-event-fx :article/load
+                       [(rf/inject-cofx :nav-token)]
+                       (fn [{:keys [nav-token]} [_ id]]
+                         (swap! captured assoc id nav-token)
+                         {}))
+
+      ;; 1. Navigate to A; the loader captures A's token via the cofx.
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/A"])
+      (rf/dispatch-sync [:article/load "A"])
+
+      ;; 2. Navigate to B BEFORE A's response lands — fresh token captured.
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/B"])
+      (rf/dispatch-sync [:article/load "B"])
+
+      ;; 3. A's response lands LATE, carrying the stale cofx-captured token.
+      (rf/dispatch-sync [:article/completed
+                         {:captured-token (@captured "A") :id "A" :payload "A-payload"}])
+      ;; 4. B's response lands, carrying the fresh cofx-captured token.
+      (rf/dispatch-sync [:article/completed
+                         {:captured-token (@captured "B") :id "B" :payload "B-payload"}])
+
+      (rf/unregister-listener! ::cofx-flow)
+
+      (is (not= (@captured "A") (@captured "B"))
+          "the cofx injected DIFFERENT live tokens for the two navigations")
+      (is (every? some? (vals @captured))
+          "both captured tokens are non-nil (pre-fix the cofx threaded nil)")
+      (is (= {:id "B" :payload "B-payload"}
+             (:article (rf/frame-db :rf/default)))
+          "only B committed — A's stale completion was suppressed via the cofx-captured token")
+      (is (some (fn [ev]
+                  (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
+                       (= :article/loaded (-> ev :tags :rf.trace/event-id))))
+                @traces)
+          "A's stale completion produced :rf.route.nav-token/stale-suppressed")
+      (is (= 1 (count (filter #(= :rf.route.nav-token/stale-suppressed
+                                  (:operation %))
+                              @traces)))
+          "exactly one suppression — B's fresh completion applied cleanly"))))
+
 ;; ---- Spec 012 §Scroll restoration -----------------------------------------
 
 (deftest routing-scroll-metadata-preserved

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -596,28 +596,28 @@ When a route is loading and the user navigates away before the load completes, t
 ### Mechanism
 
 1. **Allocation.** When `:rf.route/transitioned` fires (URL-driven) or `:rf.route/navigate` runs (programmatic), the default handler allocates a fresh `:nav-token` (a gensym or monotonic counter) and writes it to the `:rf/route` slice alongside the new id/params/query/fragment.
-2. **Carry.** Each `:on-match` dispatch receives the current `:nav-token` in cofx (under the key `:nav-token`):
+2. **Capture.** An `:on-match`-reached handler declares the framework-supplied `:nav-token` cofx via `(inject-cofx :nav-token)`; the cofx injects the current token (read from `[:rf/runtime :routing :current :nav-token]`) under the key `:nav-token` in the handler's coeffects, so the handler captures the epoch live at scheduling time:
 
    ```clojure
-   ;; cofx of :on-match handlers
-   {:db        ...
-    :event     [:cart/load-items]
-    :nav-token "nav-42"}                       ;; the token at scheduling time
+   (rf/reg-event-fx :cart/load-items
+     [(rf/inject-cofx :nav-token)]              ;; <-- declare the cofx
+     (fn [{:keys [db nav-token]} _]             ;; <-- "nav-42", the token at scheduling time
+       ...))
    ```
 
-3. **Threading.** Async completions either (a) carry the token in their follow-up event payload, or (b) use the framework-supplied `:rf.route/with-nav-token` fx wrapper which threads the token into the dispatched continuation:
+3. **Threading.** Async completions either (a) carry the captured token in their follow-up event payload, or (b) use the framework-supplied `:rf.route/with-nav-token` fx wrapper which threads the token into the dispatched continuation:
 
    ```clojure
    {:fx [[:rf.route/with-nav-token
           {:do        [:dispatch [:cart/items-loaded items]]
-           :nav-token (:nav-token cofx)}]]}
+           :nav-token nav-token}]]}            ;; the token captured in step 2
    ```
 
-4. **Validation.** When the receiving handler runs, the framework-provided `:nav-token` cofx checks the carried token against the *current* `:rf/route` slice's `:nav-token`:
+4. **Validation.** On receipt, the carried token is checked against the *current* `:rf/route` slice's `:nav-token`. Path (b) — `:rf.route/with-nav-token` — performs this check for you; path (a) hands the captured token to the receiving handler, which compares it against its own freshly-injected `:nav-token` cofx and short-circuits on mismatch:
    - **Match.** The token is current; the result is committed normally.
-   - **Mismatch.** The token has been superseded; the runtime emits `:rf.route.nav-token/stale-suppressed` (with `:tags {:carried-token <t1> :current-token <t2> :event-id <id>}`) and the handler does NOT run — no `:db` write, no `:fx`, no transition.
+   - **Mismatch.** The token has been superseded; the runtime emits `:rf.route.nav-token/stale-suppressed` (with `:tags {:carried-token <t1> :current-token <t2> :event-id <id>}`) and the wrapped `:do` (path b) or the receiving handler's commit (path a) does NOT run — no `:db` write, no `:fx`, no transition.
 
-The validating cofx is shared infrastructure: any handler whose registration declares it (or any handler reached via `:rf.route/with-nav-token`) is automatically protected.
+The two halves are shared infrastructure: the `:nav-token` cofx supplies the capture-side token to any handler that declares `(inject-cofx :nav-token)`, and `:rf.route/with-nav-token` performs the receipt-side check for any continuation routed through it. A handler can use both (inject to capture, wrap to validate) or compare the cofx-injected token directly.
 
 ### What the slice looks like over time
 


### PR DESCRIPTION
## What

Spec 012 §Navigation tokens documented a `:nav-token` cofx (step 2 "Each `:on-match` dispatch receives the current `:nav-token` in cofx" + step 4 "the validating cofx is shared infrastructure") but **no `reg-cofx :nav-token` existed** anywhere in the routing artefact. The flagship stale-suppression feature, used exactly as documented, failed closed.

### The gap

A developer who followed the spec — declared `(inject-cofx :nav-token)` and read `(fn [{:keys [db nav-token]} _] ...)` — got `nil`. `nil` then mismatched the current token inside `:rf.route/with-nav-token`, so the wrapped continuation was **suppressed on every navigation**, fresh or stale. The only working path was the undocumented direct slice read `(get-in db [:rf/runtime :routing :current :nav-token])`. Least-surprise violation, fails closed: the documented pattern silently ate results.

### What shipped

- **`:nav-token` cofx** (`re-frame.routing.nav-token/nav-token-cofx` + `nav-token-cofx-meta`): reads the live epoch from `[:rf/runtime :routing :current :nav-token]` in the injected `:db` coeffect and injects it under `:coeffects :nav-token`. 1-arity canonical; 2-arity accepts an explicit override for tests. Universal platform (the slice exists under SSR and browser alike).
- **Façade registration** in `re-frame.routing` via `cofx/reg-cofx` so a `(require 're-frame.routing :reload)` on a fresh registrar re-wires it (matches every other routing handler).
- **Spec reconciliation** — spec/012 §Navigation tokens now matches the shipped cofx exactly:
  - Step 2 is the **capture-side** cofx, declared via `(inject-cofx :nav-token)` (the documented `{:keys [db nav-token]}` shape now resolves the live token).
  - Step 4 is honest that **`:rf.route/with-nav-token`** performs the receipt-side check — the cofx *supplies* the token, it does not itself suppress. The two halves (capture cofx + validate fx) are documented as the shared infrastructure they are.
  - **spec/012 updated to match the shipped `:nav-token` cofx** — no drift between prose and code.

### Tests (failing-before / passing-after)

`implementation/routing/test/re_frame/routing_test.clj`:
- `nav-token-cofx-injects-the-live-token` — a handler declaring `(inject-cofx :nav-token)` sees the live slice token (pre-fix: `nil`).
- `nav-token-cofx-drives-documented-stale-suppression` — the documented step 2→3 example runs end-to-end via the public surface only (no `:rf.test/simulate-http-resolution`): capture via cofx, thread via `:rf.route/with-nav-token`, replay an out-of-order race → stale A suppressed, fresh B applied, exactly one `:rf.route.nav-token/stale-suppressed`.

### Conformance fixture — not added (intentional)

The conformance harness **synthesizes** cofx handlers from the fixture DSL (`[:cofx-key K]` auto-wiring + `realise-cofx-handler`); it does not exercise the real `re-frame.routing` cofx. A fixture would test a DSL stand-in, not this implementation. The existing `route-stale-nav-token-suppression.edn` already covers the suppression contract via `:rf.test/simulate-http-resolution`. The real cofx is covered by the JVM regression tests above. **No conformance fixtures touched** → mcp-conformance gate not required.

### Follow-up (out of owned surface — not touched)

- `spec/API.md` "Standard cofx" table (hot-zone) could gain a `:nav-token` universal row alongside `:rf.server/request`.
- `spec/Spec-Schemas.md` line ~2026 phrasing "the framework-provided `:nav-token` cofx checks the carried token" (hot-zone) should be re-pointed to `:rf.route/with-nav-token` for the receipt-side check.

Both are minor doc-consistency items in hot-zone files outside `implementation/routing + spec/012`; flagged for a follow-up bead.

## Quality gates

| Gate | Result |
|---|---|
| routing `clojure -M:test` | 136 tests, 597 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` | 5154 tests, 17426 assertions, **0 failures, 0 errors** |
| clj-kondo (changed files) | **0 errors**, 0 warnings on changed lines (1 pre-existing `clojure.string` warning in routing_test.clj, line 758 pre-edit — not introduced here) |
| `mkdocs build --strict` | **built OK** (8.22s; no WARNING/ERROR; spec/012 anchors verified — no headings changed) |
| mcp-conformance | not run — no conformance fixtures touched |

Closes rf2-8fnwq.