### PR TITLE
refactor(adapters): move frame-provider seam above substrate prop-marshalling (rf2-z7hfp)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -13,7 +13,7 @@
   passes JS-array deps unconditionally). The React frame-context
   comes from `re-frame.adapter.context` so a mixed-substrate app's
   frame-provider chain composes across substrates."
-  (:require [goog.object         :as gobj]
+  (:require [helix.core          :refer-macros [defnc]]
             [helix.hooks         :as helix-hooks]
             [re-frame.substrate.spine   :as spine]))
 
@@ -51,16 +51,10 @@
   `spine/make-react-adapter`) covers that chain. Per rf2-84myk."
   (:use-current-frame spine-fns))
 
-(def ^:private spine-frame-provider
-  "The shared-spine `frame-provider` fn. Destructures a CLJS-map props
-  argument (`{:keys [frame children]}`). The public `frame-provider`
-  below wraps it so the documented `($ frame-provider {...})` call shape
-  works (see that var's docstring)."
-  (:frame-provider spine-fns))
-
-(defn frame-provider
+(defnc frame-provider
   "User-facing component scoping `frame-kw` to its subtree. Wraps
-  children in the shared frame Context Provider. Helix call shape:
+  children in the shared frame Context Provider. Helix call shape
+  (exactly as documented in Spec 002 / Spec 006):
 
       ($ frame-provider {:frame :session
                          :children [($ header) ($ main)]})
@@ -70,33 +64,25 @@
   Decision 2) so a subtree under any frame-provider sees the right frame
   regardless of which substrate rendered the provider.
 
-  Prop normalisation (rf2-9ok1s): the shared-spine `frame-provider` is a
-  plain CLJS fn that destructures a CLJS-map props argument. Helix's `$`
-  routes props through `helix.impl.props/-props`, which hands the
-  component a *raw JS object* (string keys `\"frame\"` / `\"children\"`,
-  with a single child or a JS array under `\"children\"`) — not the CLJS
-  map the spine expects. A bare re-export of the spine fn therefore reads
-  `nil` for both keys under the documented `$` shape: `:frame` silently
-  resolves to `:rf/default` and the subtree renders nothing. This wrapper
-  reads the props via JS interop when React supplies a JS object, and
-  passes a CLJS map through unchanged when invoked directly (the shape
-  the shared test suite uses), so both call shapes reach the spine fn
-  with the same CLJS-map contract."
-  [props]
-  (if (map? props)
-    ;; Direct CLJS-fn invocation (e.g. shared test suite) — pass through.
-    (spine-frame-provider props)
-    ;; `$`-supplied raw JS object — read string keys, normalise children.
-    (let [frame    (gobj/get props "frame")
-          children (gobj/get props "children")]
-      (spine-frame-provider
-        {:frame    frame
-         :children (cond
-                     (nil? children)         []
-                     ;; `$` collapses multiple children into a JS array;
-                     ;; a lone child is passed through unwrapped.
-                     (array? children)       (vec children)
-                     :else                   [children])}))))
+  Native shell above the prop-marshalling seam (rf2-z7hfp — Mike-ruled
+  C, MOVE THE SEAM UP). This is a NATIVE Helix `defnc` component, NOT a
+  re-export of a shared-spine fn handed to `$`. Because it is a real
+  `defnc`, Helix's `$` routes its props through `extract-cljs-props`,
+  which beans the JS object back into a CLJS map with KEYWORD keys (and
+  Helix's `-props` preserves keyword VALUES — only keys are stringified)
+  — so `:frame` / `:children` destructure cleanly with the namespace
+  intact. The body delegates to the substrate-agnostic spine core
+  `build-frame-provider-element` (frame-resolution + element-build).
+
+  This replaces the former bespoke un-mangling wrapper (rf2-9ok1s: a
+  plain re-export plus a `gobj/get` string-key read + children-array
+  normalise, branching on `(map? props)`). With the seam moved ABOVE
+  `$`, the prop-mangling class — Helix's `$` handing a plain fn a raw JS
+  object with string keys — is impossible by construction: there is no
+  plain fn under `$` for the element macro to mangle. No per-substrate
+  un-mangling patch remains to drift."
+  [{:keys [frame children]}]
+  (spine/build-frame-provider-element frame children))
 
 (def use-subscribe
   "Helix hook that reads a re-frame subscription. Returns the current
@@ -159,5 +145,13 @@
   spine — the Helix and UIx adapter wiring is byte-identical, so this
   single call replaces the former hand-copied block (which had drifted in
   prose against the UIx twin). The per-hook rationale lives at
-  `spine/make-react-adapter`."
-  (spine/make-react-adapter spine-fns :rf.adapter/helix))
+  `spine/make-react-adapter`.
+
+  The native `frame-provider` `defnc` component (rf2-z7hfp) is passed in
+  as `:frame-provider` so the spine wires it into the
+  `:register-context-provider` substrate slot — the component shell lives
+  in this ns, above where Helix's `$` marshals props; the spine carries
+  no Helix element-macro dependency."
+  (spine/make-react-adapter spine-fns
+                            {:kind           :rf.adapter/helix
+                             :frame-provider frame-provider}))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_react_shared_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_react_shared_cljs_test.cljs
@@ -57,6 +57,12 @@
   (test-support/make-reset-runtime-fixture
     {:adapter helix-adapter/adapter}))
 
+;; rf2-7kjz8 / rf2-z7hfp — the frame-provider branch assertions now target
+;; the substrate-agnostic spine core (`build-frame-provider-element`)
+;; directly, so no `:frame-provider` cfg key is needed here. The
+;; native-shell-under-`$` behaviour is pinned by the use-subscribe DOM
+;; twin + the dollar-shape regression test (folded from the prior
+;; per-adapter helix_frame_provider_children_cljs_test.cljs).
 (def ^:private cfg
   {:adapter          helix-adapter/adapter
    :substrate-kw     :helix
@@ -65,12 +71,7 @@
    :wrap-view        helix-adapter/wrap-view
    :clear-warn!      helix-adapter/clear-warned-non-dom-roots!
    :set-emitter!     helix-adapter/set-hiccup-emitter!
-   :render-to-string (:render-to-string helix-adapter/adapter)
-   ;; rf2-7kjz8 — adapter's frame-provider re-export of the shared spine
-   ;; fn. Folded from the prior per-adapter
-   ;; helix_frame_provider_children_cljs_test.cljs / uix_frame_provider_
-   ;; branches_cljs_test.cljs files (two files merged into the suite).
-   :frame-provider   helix-adapter/frame-provider})
+   :render-to-string (:render-to-string helix-adapter/adapter)})
 
 ;; Emit one (deftest name (re-frame.adapter.react-shared-suite/assert-name cfg))
 ;; per row in `react-shared-suite-tests/test-specs`. The macro ns owns

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -113,7 +113,11 @@
 (def ^:private cfg
   {:adapter               helix-adapter/adapter
    :name                  "Helix"
-   :frame-provider        helix-adapter/frame-provider
+   ;; rf2-z7hfp — mount the NATIVE frame-provider component via Helix's
+   ;; `$` (the documented shape), not a direct CLJS-fn invocation.
+   :frame-provider-mount-element
+   (fn [frame-kw child-el]
+     ($ helix-adapter/frame-provider {:frame frame-kw :children [child-el]}))
    ;; tracks-app-db
    :probe-element         (fn [] ($ Probe))
    :probe-observed        probe-observed
@@ -170,20 +174,25 @@
   (suite/assert-view-unmount-emits-on-react-hook-teardown
     {:substrate-kw :helix :name "Helix"}))
 
-;; ---- regression: frame-provider under the documented `$` shape (rf2-9ok1s) -
+;; ---- regression: frame-provider under the documented `$` shape (rf2-9ok1s / rf2-z7hfp) -
 ;;
-;; The shared-suite `assert-use-subscribe-frame-provider-resolution`
-;; invokes `frame-provider` DIRECTLY as a CLJS fn (with a real CLJS map)
-;; — see its comment "invoke it directly rather than via the substrate's
-;; `$`". That path NEVER exercises Helix's `$`, which routes props through
-;; `helix.impl.props/-props` and hands the component a *raw JS object*
-;; (string keys "frame"/"children"). The bare spine re-export read `nil`
-;; for both keys under that shape: `:frame` silently resolved to
-;; `:rf/default` and the subtree rendered nothing. This test mounts the
-;; provider via the EXACT documented `($ frame-provider {...})` shape and
-;; asserts the descendant `use-subscribe` reads the WRAPPED frame's value
-;; (proving the frame propagated). Fails before the helix.cljs prop-
-;; normalisation wrapper; passes after.
+;; Pins the moved-up seam (rf2-z7hfp). HISTORY: `frame-provider` used to
+;; be a plain re-exported spine CLJS fn (not a `defnc`), so Helix's `$`
+;; routed props through `helix.impl.props/-props` and handed the fn a
+;; *raw JS object* with string keys "frame"/"children" — the fn read
+;; `nil` for both, `:frame` silently resolved to `:rf/default`, and the
+;; subtree rendered nothing. A bespoke `gobj/get` un-mangling wrapper
+;; patched it per-adapter.
+;;
+;; rf2-z7hfp MOVED THE SEAM UP: `frame-provider` is now a NATIVE Helix
+;; `defnc` component. `$` therefore routes its props through
+;; `extract-cljs-props`, which beans the JS object back into a CLJS map
+;; with keyword keys (and Helix preserves keyword VALUES) — so `:frame`
+;; destructures cleanly by construction, with no per-adapter patch. This
+;; test mounts the provider via the EXACT documented `($ frame-provider
+;; {...})` shape and asserts the descendant `use-subscribe` reads the
+;; WRAPPED frame's value — the structural guarantee that the prop-mangling
+;; class cannot reopen.
 
 (defn- browser? []
   (and (exists? js/document)

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -11,8 +11,7 @@
   configuration: gensym prefixes, substrate name (used in warn-once
   text), and the runtime hook fns from `uix.hooks.alpha` (the
   `uix.core` macros expand to these)."
-  (:require [goog.object       :as gobj]
-            [uix.core          :as uix]
+  (:require [uix.core          :as uix :refer-macros [defui]]
             [uix.hooks.alpha   :as uix-hooks]
             [re-frame.substrate.spine   :as spine]))
 
@@ -49,28 +48,10 @@
   that chain. Per rf2-84myk."
   (:use-current-frame spine-fns))
 
-(def ^:private spine-frame-provider
-  "The shared-spine `frame-provider` fn. Destructures a CLJS-map props
-  argument (`{:keys [frame children]}`). The public `frame-provider`
-  below wraps it so the documented `($ frame-provider {...})` call shape
-  works (see that var's docstring)."
-  (:frame-provider spine-fns))
-
-(defn- glue-uix-props
-  "Reconstruct the CLJS props map from the JS object UIx's `$` hands a
-  component down the lossless `uix-component-element` path. Mirrors
-  `uix.core/glue-args`: the original CLJS props map is stashed under
-  `argv`, and any `$`-trailing children React appended sit under
-  `children`. Reading `argv` (rather than the React-level string keys)
-  preserves keyword *values* losslessly — see `frame-provider`'s
-  docstring for why that matters."
-  [^js props]
-  (cond-> (gobj/get props "argv")
-    (gobj/get props "children") (assoc :children (gobj/get props "children"))))
-
-(defn frame-provider
+(defui frame-provider
   "User-facing component scoping `frame-kw` to its subtree. Wraps
-  children in the shared frame Context Provider. UIx call shape:
+  children in the shared frame Context Provider. UIx call shape (exactly
+  as documented in Spec 002 / Spec 006):
 
       ($ frame-provider {:frame :session
                          :children [($ header) ($ main)]})
@@ -80,42 +61,26 @@
   Decision 2) so a subtree under any frame-provider sees the right
   frame regardless of which substrate rendered the provider.
 
-  Prop normalisation (rf2-8svnm — the UIx twin of the Helix rf2-9ok1s
-  defect, with a UIx-specific twist). The shared-spine `frame-provider`
-  is a plain CLJS fn that destructures a CLJS-map props argument. A bare
-  re-export breaks under the documented `($ frame-provider {...})` shape:
-  because the re-exported fn carries no `.-uix-component?` marker, UIx's
-  `$` routes it through `uix.compiler.alpha/react-component-element` →
-  `interpret-attrs`, which (a) hands the component a *raw JS object* with
-  string keys, and — the UIx-specific twist Helix's `$` does NOT share —
-  (b) *stringifies keyword prop values to their bare name*, dropping the
-  namespace (`:my.ns/frame` → `\"frame\"`). So even reading the string key
-  yields a namespace-less string that no longer matches the registered
-  frame keyword: `:frame` effectively resolves to `:rf/default` and the
-  subtree renders nothing. No throw, no warning.
+  Native shell above the prop-marshalling seam (rf2-z7hfp — Mike-ruled
+  C, MOVE THE SEAM UP). This is a NATIVE UIx `defui` component, NOT a
+  re-export of a shared-spine fn handed to `$`. Because it is a real
+  `defui`, UIx's `$` stamps it `.-uix-component?` and routes its props
+  through the LOSSLESS `uix-component-element` (`argv`) path — `glue-args`
+  reconstructs the original CLJS props map with keyword values intact
+  (namespace preserved). The body then reads `:frame` / `:children`
+  off that clean CLJS map and delegates to the substrate-agnostic spine
+  core `build-frame-provider-element` (frame-resolution + element-build).
 
-  Fix (UIx-local; does not touch the shared spine): mark `frame-provider`
-  with `.-uix-component?` so `$` routes it through the *lossless*
-  `uix-component-element` path instead. That path stashes the original
-  CLJS props map under the JS object's `argv` slot (the same channel a
-  real `defui` uses) — keyword values survive intact. The body then
-  reconstructs the CLJS map via `glue-uix-props` (mirroring
-  `uix.core/glue-args`) and delegates to the spine. When invoked directly
-  as a CLJS fn with a real map (the shape the shared test suite uses),
-  it passes through unchanged. Both call shapes reach the spine fn with
-  the same CLJS-map contract, keywords intact."
-  [props]
-  (if (map? props)
-    ;; Direct CLJS-fn invocation (e.g. shared test suite) — pass through.
-    (spine-frame-provider props)
-    ;; `$`-supplied JS object on the lossless uix-component path — the
-    ;; original CLJS map (keywords intact) lives under `argv`.
-    (spine-frame-provider (glue-uix-props props))))
-
-;; Route `$` through UIx's lossless `uix-component-element` (`argv`) path
-;; rather than the keyword-stringifying `react-component-element` path.
-;; See `frame-provider`'s docstring (rf2-8svnm).
-(set! (.-uix-component? frame-provider) true)
+  This replaces the former bespoke un-mangling wrapper (rf2-8svnm: a
+  plain re-export plus a manual `.-uix-component?` marker and a
+  `glue-uix-props` reconstruction branching on `(map? props)`). With the
+  seam moved ABOVE `$`, the prop-mangling class — UIx's
+  `react-component-element` → `interpret-attrs` stringifying keyword prop
+  values and dropping the namespace — is impossible by construction:
+  there is no plain fn under `$` for the element macro to mangle. No
+  per-substrate un-mangling patch remains to drift."
+  [{:keys [frame children]}]
+  (spine/build-frame-provider-element frame children))
 
 (def use-subscribe
   "UIx hook that reads a re-frame subscription. Returns the current
@@ -177,5 +142,13 @@
   chained installs (warn-once clear + SSR emitter) all live once in the
   spine — the UIx and Helix adapter wiring is byte-identical, so this
   single call replaces the former hand-copied block. The per-hook
-  rationale lives at `spine/make-react-adapter`."
-  (spine/make-react-adapter spine-fns :rf.adapter/uix))
+  rationale lives at `spine/make-react-adapter`.
+
+  The native `frame-provider` `defui` component (rf2-z7hfp) is passed in
+  as `:frame-provider` so the spine wires it into the
+  `:register-context-provider` substrate slot — the component shell lives
+  in this ns, above where UIx's `$` marshals props; the spine carries no
+  UIx element-macro dependency."
+  (spine/make-react-adapter spine-fns
+                            {:kind           :rf.adapter/uix
+                             :frame-provider frame-provider}))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs
@@ -56,6 +56,12 @@
   (test-support/make-reset-runtime-fixture
     {:adapter uix-adapter/adapter}))
 
+;; rf2-7kjz8 / rf2-z7hfp — the frame-provider branch assertions now target
+;; the substrate-agnostic spine core (`build-frame-provider-element`)
+;; directly, so no `:frame-provider` cfg key is needed here. The
+;; native-shell-under-`$` behaviour is pinned by the use-subscribe DOM
+;; twin + the dollar-shape regression test (folded from the prior
+;; per-adapter uix_frame_provider_branches_cljs_test.cljs).
 (def ^:private cfg
   {:adapter          uix-adapter/adapter
    :substrate-kw     :uix
@@ -64,12 +70,7 @@
    :wrap-view        uix-adapter/wrap-view
    :clear-warn!      uix-adapter/clear-warned-non-dom-roots!
    :set-emitter!     uix-adapter/set-hiccup-emitter!
-   :render-to-string (:render-to-string uix-adapter/adapter)
-   ;; rf2-7kjz8 — adapter's frame-provider re-export of the shared spine
-   ;; fn. Folded from the prior per-adapter
-   ;; uix_frame_provider_branches_cljs_test.cljs / helix_frame_provider_
-   ;; children_cljs_test.cljs files (two files merged into the suite).
-   :frame-provider   uix-adapter/frame-provider})
+   :render-to-string (:render-to-string uix-adapter/adapter)})
 
 ;; Emit one (deftest name (re-frame.adapter.react-shared-suite/assert-name cfg))
 ;; per row in `react-shared-suite-tests/test-specs`. The macro ns owns

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -109,7 +109,11 @@
 (def ^:private cfg
   {:adapter               uix-adapter/adapter
    :name                  "UIx"
-   :frame-provider        uix-adapter/frame-provider
+   ;; rf2-z7hfp — mount the NATIVE frame-provider component via UIx's `$`
+   ;; (the documented shape), not a direct CLJS-fn invocation.
+   :frame-provider-mount-element
+   (fn [frame-kw child-el]
+     ($ uix-adapter/frame-provider {:frame frame-kw :children [child-el]}))
    ;; tracks-app-db
    :probe-element         (fn [] (uix/$ Probe))
    :probe-observed        probe-observed
@@ -166,22 +170,25 @@
   (suite/assert-view-unmount-emits-on-react-hook-teardown
     {:substrate-kw :uix :name "UIx"}))
 
-;; ---- regression: frame-provider under the documented `$` shape (rf2-8svnm) -
+;; ---- regression: frame-provider under the documented `$` shape (rf2-8svnm / rf2-z7hfp) -
 ;;
-;; The UIx twin of the Helix rf2-9ok1s defect. The shared-suite
-;; `assert-use-subscribe-frame-provider-resolution` invokes `frame-provider`
-;; DIRECTLY as a CLJS fn (with a real CLJS map) — that path NEVER exercises
-;; UIx's `$`. `frame-provider` is a plain re-exported CLJS fn, NOT a `defui`
-;; component (no `.-uix-component?` marker), so UIx's `$` routes it through
-;; `uix.compiler.alpha/react-component-element` → `interpret-attrs`, handing
-;; the component a *raw JS object* (string keys "frame"/"children") rather
-;; than the `argv`-wrapped shape `glue-args` unwraps for a real `defui`. The
-;; bare spine re-export read `nil` for both keys under that shape: `:frame`
-;; silently resolved to `:rf/default` and the subtree rendered nothing. This
-;; test mounts the provider via the EXACT documented `($ frame-provider {...})`
-;; shape and asserts the descendant `use-subscribe` reads the WRAPPED frame's
-;; value (proving the frame propagated). Fails before the uix.cljs prop-
-;; normalisation wrapper; passes after.
+;; The UIx twin of the Helix rf2-9ok1s defect, now pinning the moved-up
+;; seam (rf2-z7hfp). HISTORY: `frame-provider` used to be a plain
+;; re-exported spine CLJS fn (not a `defui`), so UIx's `$` routed it
+;; through `uix.compiler.alpha/react-component-element` → `interpret-attrs`,
+;; which stringified keyword prop values and DROPPED the namespace —
+;; `:frame` silently resolved to `:rf/default` and the subtree rendered
+;; nothing. A bespoke un-mangling wrapper (manual `.-uix-component?` marker
+;; + `glue-uix-props`) patched it per-adapter.
+;;
+;; rf2-z7hfp MOVED THE SEAM UP: `frame-provider` is now a NATIVE UIx
+;; `defui` component. `$` therefore routes its props through the LOSSLESS
+;; `uix-component-element` (`argv`) path by construction (a `defui` is
+;; stamped `.-uix-component?` automatically), so keyword frame-ids survive
+;; intact with no per-adapter patch. This test mounts the provider via the
+;; EXACT documented `($ frame-provider {...})` shape and asserts the
+;; descendant `use-subscribe` reads the WRAPPED frame's value — the
+;; structural guarantee that the prop-mangling class cannot reopen.
 
 (defn- browser? []
   (and (exists? js/document)

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -641,35 +641,65 @@
                       {:reason      "require re-frame.ssr (the SSR ns-load resolves the :reagent/set-hiccup-emitter! late-bind hook automatically), or call set-hiccup-emitter! directly"
                        :render-tree render-tree})))))
 
-;; ---- context provider -----------------------------------------------------
+;; ---- context provider — substrate-agnostic CORE ---------------------------
 ;;
 ;; Every React-shaped adapter shares the same React.createContext object
-;; (in re-frame.adapter.context). The provider component is identical
-;; across substrates — only `use-current-frame` (the read-side hook)
-;; varies, and only by which hook ns supplies `use-context`.
+;; (in re-frame.adapter.context). The substrate-agnostic CORE is the
+;; frame-resolution + element-build below; the user-facing COMPONENT
+;; SHELL is NATIVE to each substrate (UIx `defui`, Helix `defnc`,
+;; Reagent hiccup) and lives in the adapter ns.
+;;
+;; Seam placement (rf2-z7hfp). Earlier this ns shipped `frame-provider`
+;; as a plain CLJS fn that destructured `{:keys [frame children]}`, and
+;; each React-hook adapter RE-EXPORTED it as the component a user hands to
+;; `$`. That put the abstraction seam BELOW the layer where each
+;; substrate's element macro (`$` in Helix/UIx, hiccup in Reagent)
+;; marshals props: Helix's `$` handed the fn a raw JS object with string
+;; keys; UIx's `$` ALSO stringified keyword prop values (dropping the
+;; namespace), so `:frame` silently fell to `:rf/default`. Each adapter
+;; then carried a bespoke un-mangling wrapper to repair the props before
+;; they reached the shared fn (helix rf2-9ok1s, uix rf2-8svnm) — a
+;; standing per-substrate-patch hazard: a new substrate, or a new prop,
+;; reopens the same class of bug.
+;;
+;; Move the seam UP (Mike-ruled C, rf2-z7hfp). The spine now provides
+;; ONLY the substrate-agnostic core — `build-frame-provider-element`
+;; (frame-resolution + element-build, touching no substrate prop-
+;; marshalling). The COMPONENT SHELL sits ABOVE where `$` marshals: each
+;; React-hook adapter defines its `frame-provider` as a NATIVE
+;; substrate component (`defui` / `defnc`) that reads its props in that
+;; substrate's OWN lossless idiom (UIx's `argv` channel, Helix's
+;; `extract-cljs-props`), then hands a clean frame-kw + children to this
+;; core. The prop-mangling class is impossible by construction — there is
+;; no plain fn under `$` for the element macro to mangle, and no per-
+;; substrate un-mangling patch to drift.
 
-(defn frame-provider
-  "User-facing component scoping `frame-kw` to its subtree. Wraps
-  children in the shared frame Context Provider — inside the subtree,
-  `(rf/frame-handle)` / `reg-view`-registered descendants resolve to
-  the named frame. Per Spec 002 §What `frame-provider` is.
+(defn build-frame-provider-element
+  "Substrate-agnostic CORE of the frame-provider (rf2-z7hfp). Given a
+  resolved frame keyword (or nil/missing) and a children value, returns
+  the shared frame Context Provider React element scoping that frame to
+  its subtree — inside the subtree, `(rf/frame-handle)` /
+  `reg-view`-registered descendants resolve to the named frame. Per
+  Spec 002 §What `frame-provider` is.
 
-  Reads `:frame` from props. When missing or `nil`, falls through to
+  Frame-resolution: when `frame-kw` is missing or `nil`, falls through to
   `:rf/default` — defensive default that matches the no-provider
   behaviour and avoids breaking tooling-generated trees that elide the
-  prop."
-  [{:keys [frame children]}]
-  (let [frame-kw (or frame :rf/default)]
-    (apply adapter-context/provider-element frame-kw
-           (if (sequential? children) children [children]))))
+  frame. Children are normalised to a flat arg list (a single non-
+  sequential child is wrapped) before being handed to
+  `provider-element`.
 
-(defn register-context-provider
-  "Substrate `:register-context-provider` slot. Same shape across all
-  React-shaped adapters: returns the `frame-provider` fn unchanged.
-  The frame-keyword arg is ignored because the frame keyword lives in
-  the Provider's `:value` at render time, not in a build-time closure."
-  [_frame-keyword]
-  frame-provider)
+  This fn touches NO substrate prop-marshalling: the native component
+  shell in each adapter has already read its props in the substrate's
+  idiom and hands this core a clean CLJS frame-kw + children. That is the
+  whole point of the moved seam — the marshalling-sensitive surface
+  (`$`/hiccup → component) lives ABOVE this core, in substrate-native
+  code, so a keyword frame-id survives intact on every substrate by
+  construction."
+  [frame-kw children]
+  (apply adapter-context/provider-element
+         (or frame-kw :rf/default)
+         (if (sequential? children) children [children])))
 
 ;; ---- render flush for tests ----------------------------------------------
 ;;
@@ -1080,15 +1110,23 @@
        :make-derived-value         …
        :render                     …
        :render-to-string           …
-       :register-context-provider  …
        :dispose-adapter!           …
        :set-hiccup-emitter!        …
        :use-current-frame          …
        :use-subscribe              …
-       :frame-provider             …
        :flush-views!               …
        :wrap-view                  …
-       :clear-warned-non-dom-roots! …}"
+       :clear-warned-non-dom-roots! …}
+
+  Note (rf2-z7hfp): the spine no longer produces `:frame-provider` or
+  `:register-context-provider`. The user-facing frame-provider is a
+  NATIVE substrate component (`defui` / `defnc`) defined in the adapter
+  ns above where each substrate's element macro marshals props; the
+  adapter passes that component into `make-react-adapter` as
+  `:frame-provider`, and the spine wires it into the
+  `:register-context-provider` substrate slot. The shared substrate-
+  agnostic core is `build-frame-provider-element`, which the native
+  component shell calls with clean props."
   [{:keys [substrate-name
            gensym-prefix-sub
            gensym-prefix-derived
@@ -1259,13 +1297,11 @@
      :make-derived-value          make-derived
      :render                      render-fn
      :render-to-string            (make-render-to-string emitter-cell)
-     :register-context-provider   register-context-provider
      :dispose-adapter!            dispose-fn
      :set-hiccup-emitter!         (fn set-it! [f]
                                     (set-hiccup-emitter! emitter-cell f))
      :use-current-frame           use-current-frame
      :use-subscribe               use-subscribe
-     :frame-provider              frame-provider
      :flush-views!                flush-views!
      :wrap-view                   wrap-view-fn
      :clear-warned-non-dom-roots! clear-warned
@@ -1324,20 +1360,38 @@
 
 (defn make-react-adapter
   "Assemble a React-hook adapter (UIx / Helix) from a `make-react-spine`
-  result map plus the substrate's `:kind` discriminator keyword.
+  result map plus the substrate's config:
+
+      :kind           — the adapter's `:kind` discriminator keyword
+      :frame-provider — the substrate's NATIVE frame-provider component
+                        (`defui` for UIx, `defnc` for Helix), defined in
+                        the adapter ns ABOVE where that substrate's `$`
+                        marshals props (rf2-z7hfp — the moved seam). The
+                        component reads its props in the substrate's
+                        lossless idiom and delegates to the spine core
+                        `build-frame-provider-element`. Passed in (NOT
+                        spine-built) so the spine carries no substrate
+                        element-macro dependency, mirroring how
+                        `make-ratom-adapter` takes the Reagent-component
+                        `register-context-provider` in.
 
   Builds the 9-key substrate adapter map, routes the five React-hook
   late-bind hooks against it (`substrate-adapter/route-hook!`), and wires
-  the two chained installs (warn-once clear + SSR hiccup-emitter). Returns
-  the adapter map. SIDE-EFFECTING: the route-hook! / chain-fn! calls run
-  at call time (the adapter ns evaluates `(make-react-adapter spine-fns
-  :rf.adapter/uix)` at load), exactly as the hand-written wiring did.
+  the two chained installs (warn-once clear + SSR hiccup-emitter). The
+  `:register-context-provider` substrate slot returns the native
+  `frame-provider` component (the frame-keyword arg is ignored — the
+  keyword lives in the Provider's `:value` at render time, not in a
+  build-time closure). Returns the adapter map. SIDE-EFFECTING: the
+  route-hook! / chain-fn! calls run at call time (the adapter ns
+  evaluates `(make-react-adapter spine-fns {:kind :rf.adapter/uix
+  :frame-provider …})` at load), exactly as the hand-written wiring did.
 
   Single source of truth (rf2-ee38b.1): UIx and Helix call this with the
   same shape — the only inputs are their already-substrate-specific
-  `spine-fns` map and `:kind`. The former hand-copied route-hook block +
-  chained installs (byte-identical across the twins) now live once."
-  [spine-fns kind]
+  `spine-fns` map, `:kind`, and native `:frame-provider`. The former
+  hand-copied route-hook block + chained installs (byte-identical across
+  the twins) now live once."
+  [spine-fns {:keys [kind frame-provider]}]
   (let [adapter {:kind                      kind
                  :make-state-container      (:make-state-container      spine-fns)
                  :read-container            (:read-container            spine-fns)
@@ -1346,7 +1400,10 @@
                  :make-derived-value        (:make-derived-value        spine-fns)
                  :render                    (:render                    spine-fns)
                  :render-to-string          (:render-to-string          spine-fns)
-                 :register-context-provider (:register-context-provider spine-fns)
+                 ;; rf2-z7hfp: the native component IS the provider; the
+                 ;; frame-keyword arg is ignored (frame lives in the
+                 ;; Provider's `:value` at render time).
+                 :register-context-provider (fn [_frame-keyword] frame-provider)
                  :dispose-adapter!          (:dispose-adapter!          spine-fns)}]
     (substrate-adapter/route-hook! adapter :adapter/current-frame
       adapter-context/function-component-current-frame

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -102,6 +102,7 @@
             [re-frame.adapter.context :as adapter-context]
             [re-frame.adapter.react-test-support :as react-test-support]
             [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.spine :as spine]
             [re-frame.trace.tooling :as trace-tooling])
   (:require-macros [re-frame.core :refer [with-frame with-new-frame frame-bound-fn]]))
 
@@ -532,24 +533,38 @@
           (set! (.-_currentValue ^js adapter-context/frame-context) original))))))
 
 ;; ===========================================================================
-;; frame-provider branches (rf2-7kjz8) — folded from UIx's
+;; frame-provider CORE branches (rf2-7kjz8 / rf2-z7hfp) — folded from UIx's
 ;; uix_frame_provider_branches_cljs_test.cljs and Helix's
-;; helix_frame_provider_children_cljs_test.cljs. Same spine code path
-;; (`re-frame.substrate.spine/frame-provider`) is exposed through each
-;; adapter's public `frame-provider` re-export. Naming follows the
-;; UIx-direction per rf2-uqlce: `provider-element-frame-kw` /
-;; `provider-element-children` describe what the slot SEMANTICALLY
-;; MEANS (the frame-kw the Context.Provider hands down vs the children
-;; prop) — Helix's prior `props-value` / `props-children` were
-;; React-level and lost domain meaning.
+;; helix_frame_provider_children_cljs_test.cljs.
 ;;
-;; cfg key required: `:frame-provider` — the adapter's frame-provider
-;; fn, accepting a `{:frame :children}` props map.
+;; rf2-z7hfp — MOVE THE SEAM UP. These assertions pin the substrate-
+;; agnostic frame-resolution + children-coercion logic, which now lives
+;; in `re-frame.substrate.spine/build-frame-provider-element` (the shared
+;; CORE the native per-substrate `frame-provider` component delegates to).
+;; Previously they invoked each adapter's public `frame-provider` DIRECTLY
+;; as a CLJS fn (the cfg `:frame-provider` slot) because that surface WAS a
+;; plain re-exported spine fn. With the seam moved up the public surface is
+;; a NATIVE substrate component (`defui` / `defnc`) that is NOT directly
+;; CLJS-invocable (UIx's `glue-args` would read nil; Helix's
+;; `extract-cljs-props` throws in dev on a map). So the shape assertions
+;; target the core builder directly — and the END-TO-END `$`-shape
+;; propagation (the formerly-bespoke-patched class) is pinned by each
+;; adapter's `frame-provider-dollar-shape-propagates-frame` DOM regression
+;; test (rf2-9ok1s / rf2-8svnm). Both halves are substrate-shared: the core
+;; logic here, the native-shell-under-`$` behaviour in the DOM twins.
+;;
+;; Naming follows the UIx-direction per rf2-uqlce: `provider-element-
+;; frame-kw` / `provider-element-children` describe what the slot
+;; SEMANTICALLY MEANS (the frame-kw the Context.Provider hands down vs the
+;; children prop).
+;;
+;; Substrate-agnostic: no cfg `:frame-provider` needed — `name` only, for
+;; the assertion message.
 ;; ===========================================================================
 
 (defn- provider-element-frame-kw
-  "Pull the `:value` prop off a React element returned by
-  `frame-provider` — this is the frame keyword the surrounding
+  "Pull the `:value` prop off the React element returned by
+  `build-frame-provider-element` — the frame keyword the surrounding
   Context.Provider will hand down to `use-context` consumers."
   [el]
   (when (and el (.-props el))
@@ -557,56 +572,54 @@
 
 (defn- provider-element-children
   "Pull the `children` prop off the React element returned by
-  `frame-provider`. React normalises a single-element children to
-  the element directly; multi-element children come through as a
-  JS array."
+  `build-frame-provider-element`. React normalises a single-element
+  children to the element directly; multi-element children come through
+  as a JS array."
   [el]
   (when (and el (.-props el))
     (aget (.-props el) "children")))
 
 (defn assert-frame-provider-missing-frame-falls-through-to-default
-  "(frame-provider {:children [...]}) — no :frame at all — falls through
-  to :rf/default per rf2-sixo. The provider-element's `:value` slot
-  carries :rf/default."
-  [{:keys [frame-provider name]}]
-  (testing (str name " — frame-provider: missing :frame falls through to :rf/default")
-    (let [el (frame-provider {:children [:fake-child-a :fake-child-b]})]
-      (is (some? el) "frame-provider returned a React element")
+  "(build-frame-provider-element nil [...]) — no frame at all — falls
+  through to :rf/default per rf2-sixo. The provider-element's `:value`
+  slot carries :rf/default."
+  [{:keys [name]}]
+  (testing (str name " — frame-provider core: missing frame falls through to :rf/default")
+    (let [el (spine/build-frame-provider-element nil [:fake-child-a :fake-child-b])]
+      (is (some? el) "build-frame-provider-element returned a React element")
       (is (= :rf/default (provider-element-frame-kw el))
-          "missing :frame defaulted to :rf/default"))))
+          "missing frame defaulted to :rf/default"))))
 
 (defn assert-frame-provider-nil-frame-falls-through-to-default
-  "(frame-provider {:frame nil :children [...]}) — explicit nil :frame
-  — falls through to :rf/default. The `(or frame :rf/default)` clause
-  covers both the missing-key and nil-value cases."
-  [{:keys [frame-provider name]}]
-  (testing (str name " — frame-provider: nil :frame falls through to :rf/default")
-    (let [el (frame-provider {:frame nil :children [:fake-child]})]
+  "(build-frame-provider-element nil [...]) — explicit nil frame — falls
+  through to :rf/default. The `(or frame-kw :rf/default)` clause covers
+  both the missing and nil cases."
+  [{:keys [name]}]
+  (testing (str name " — frame-provider core: nil frame falls through to :rf/default")
+    (let [el (spine/build-frame-provider-element nil [:fake-child])]
       (is (some? el))
       (is (= :rf/default (provider-element-frame-kw el))
-          "nil :frame defaulted to :rf/default"))))
+          "nil frame defaulted to :rf/default"))))
 
 (defn assert-frame-provider-named-frame-preserved
-  "A supplied :frame keyword is preserved on the provider element's
-  value slot. Sanity-check counterpart to the default-fallback
-  assertions."
-  [{:keys [frame-provider name]}]
-  (testing (str name " — frame-provider: named :frame keyword preserved")
-    (let [el (frame-provider {:frame :tenant-a :children [:fake-child]})]
+  "A supplied frame keyword is preserved on the provider element's value
+  slot. Sanity-check counterpart to the default-fallback assertions."
+  [{:keys [name]}]
+  (testing (str name " — frame-provider core: named frame keyword preserved")
+    (let [el (spine/build-frame-provider-element :tenant-a [:fake-child])]
       (is (= :tenant-a (provider-element-frame-kw el))
-          ":frame :tenant-a flows through to the provider's value slot"))))
+          "frame :tenant-a flows through to the provider's value slot"))))
 
 (defn assert-frame-provider-single-child-coerced-to-vector
-  "(frame-provider {:frame :session :children child-a}) — a single child
-  (NOT a vector) — does not throw and is coerced to a one-element
-  children sequence by the `(if (sequential? children) children
-  [children])` branch. Pins the spine's frame-provider single-vs-
-  sequential coercion."
-  [{:keys [frame-provider name]}]
-  (testing (str name " — frame-provider: single :children coerced to vector")
+  "(build-frame-provider-element :session child-a) — a single child (NOT
+  a vector) — does not throw and is coerced to a one-element children
+  sequence by the `(if (sequential? children) children [children])`
+  branch. Pins the core's single-vs-sequential coercion."
+  [{:keys [name]}]
+  (testing (str name " — frame-provider core: single child coerced to vector")
     (let [single-child :fake-single-child-marker
-          el (frame-provider {:frame :session :children single-child})]
-      (is (some? el) "frame-provider didn't throw on a non-sequential :children")
+          el (spine/build-frame-provider-element :session single-child)]
+      (is (some? el) "build-frame-provider-element didn't throw on a non-sequential child")
       (is (= :session (provider-element-frame-kw el)))
       ;; React normalises single-element children to the element value;
       ;; the marker survives the coercion regardless of normalisation.
@@ -615,23 +628,23 @@
                 (and (some? kids)
                      (or (not (.-length kids))
                          (= 1 (.-length kids)))))
-            "single :children produced a one-element children slot")))))
+            "single child produced a one-element children slot")))))
 
 (defn assert-frame-provider-sequential-children-preserved
-  "A sequential :children vector flows through the spine's coercion
-  branch unchanged — multiple children are handed to the Provider as
-  separate args."
-  [{:keys [frame-provider name]}]
-  (testing (str name " — frame-provider: sequential :children preserved")
+  "A sequential children vector flows through the core's coercion branch
+  unchanged — multiple children are handed to the Provider as separate
+  args."
+  [{:keys [name]}]
+  (testing (str name " — frame-provider core: sequential children preserved")
     (let [a :child-a
           b :child-b
-          el (frame-provider {:frame :session :children [a b]})]
+          el (spine/build-frame-provider-element :session [a b])]
       (is (some? el))
       (is (= :session (provider-element-frame-kw el)))
       (let [kids (provider-element-children el)]
         (is (some? kids))
         (is (= 2 (.-length kids))
-            "sequential :children produced a two-element children slot")))))
+            "sequential children produced a two-element children slot")))))
 
 ;; ===========================================================================
 ;; warn-once fires-once (Spec 006 §Documented exemption) — G5
@@ -2173,8 +2186,22 @@
   "rf2-518sp: use-subscribe 1-arg form resolves through the surrounding
   frame-provider.
 
+  rf2-z7hfp — MOVE THE SEAM UP. The adapter's `frame-provider` is now a
+  NATIVE substrate component (`defui` / `defnc`), NOT a plain CLJS fn, so
+  it is mounted via the substrate's OWN `$` (the documented call shape)
+  rather than invoked directly. The entry file supplies a
+  `:frame-provider-mount-element` thunk `(fn [frame-kw child-el] ...)`
+  that builds `($ frame-provider {:frame frame-kw :children [child-el]})`
+  in the substrate's idiom — exercising the native shell through `$`, the
+  exact surface the old per-substrate prop-mangling defect (rf2-9ok1s /
+  rf2-8svnm) hid under. This makes the 1-arg-resolution contract a
+  full end-to-end check of the moved-up seam.
+
   cfg keys:
-    :frame-provider                 the adapter's frame-provider fn
+    :frame-provider-mount-element   thunk (fn [frame-kw child-el]) →
+                                    the substrate `($ frame-provider …)`
+                                    element with `child-el` as its only
+                                    child
     :probe-frame-provider-element   thunk → the 1-arg-form
                                     ProbeFrameProvider element
     :probe-frame-provider-observed  atom the ProbeFrameProvider pushes
@@ -2182,9 +2209,9 @@
     :frame-provider-frame           frame-id keyword for the wrapped frame
     :frame-provider-query           query-v keyword ProbeFrameProvider
                                     subscribes to"
-  [{:keys [name frame-provider probe-frame-provider-element probe-frame-provider-observed
-           frame-provider-frame frame-provider-query]}]
-  (testing (str name " — use-subscribe 1-arg resolves via frame-provider (rf2-518sp)")
+  [{:keys [name frame-provider-mount-element probe-frame-provider-element
+           probe-frame-provider-observed frame-provider-frame frame-provider-query]}]
+  (testing (str name " — use-subscribe 1-arg resolves via frame-provider (rf2-518sp / rf2-z7hfp)")
     (with-browser-act
      (fn [act-fn]
       (reset! probe-frame-provider-observed [])
@@ -2197,12 +2224,11 @@
         (try
           (act-fn
             (fn []
-              ;; frame-provider is a plain CLJS fn returning a React
-              ;; element (NOT a React-component head), so invoke it
-              ;; directly rather than via the substrate's `$`.
+              ;; The NATIVE frame-provider component mounted via the
+              ;; substrate's documented `$` shape (rf2-z7hfp).
               (.render root
-                (frame-provider
-                  {:frame frame-provider-frame :children [(probe-frame-provider-element)]}))))
+                (frame-provider-mount-element
+                  frame-provider-frame (probe-frame-provider-element)))))
           (is (some #{:wrapped} @probe-frame-provider-observed)
               "use-subscribe 1-arg form read from the wrapped frame, not :rf/default")
           (finally


### PR DESCRIPTION
## What

Mike-ruled **C — MOVE THE SEAM UP** (rf2-z7hfp). Restructures `frame-provider` so the shared substrate spine provides only the substrate-agnostic core (frame-resolution + element-build), and the **component shell is native to each substrate**, sitting ABOVE where each substrate's element macro marshals props.

### The bug class this eliminates

`frame-provider` was a plain CLJS fn in the spine, re-exported by each React-hook adapter and handed to `$`. The seam sat BELOW where `$` marshals props:
- Helix `$` → raw JS object with string keys → `:frame` read as `nil`.
- UIx `$` → ALSO stringified keyword prop values, dropping the namespace → `:frame` fell to `:rf/default`, subtree rendered nothing.

Each adapter carried a bespoke un-mangling wrapper (helix rf2-9ok1s: `gobj/get` + children normalise; uix rf2-8svnm: manual `.-uix-component?` marker + `glue-uix-props`), both branching on `(map? props)`. Two of three React substrates shipped this as a silent late-found bug — and the **pattern** remained: a new substrate or a new prop reopens the class.

## How — the shared-core / native-shell split

- **Shared core (spine):** new `build-frame-provider-element [frame-kw children]` — `(or frame-kw :rf/default)` + children-coercion + `provider-element`. Touches no substrate prop-marshalling. The spine no longer produces `:frame-provider` / `:register-context-provider`.
- **UIx native shell:** `frame-provider` is now a `defui` component. UIx's `$` stamps a `defui` `.-uix-component?` and routes its props through the **lossless `uix-component-element` (`argv`) path** by construction — `glue-args` reconstructs the CLJS map, keyword values + namespace intact. Reads `{:keys [frame children]}`, delegates to the core.
- **Helix native shell:** `frame-provider` is now a `defnc` component. Helix's `$` routes a `defnc`'s props through `extract-cljs-props` (beaned back to keyword keys; Helix's `-props` preserves keyword *values*) — so `:frame` destructures cleanly by construction. Delegates to the core.
- **Wiring:** `make-react-adapter` now takes `{:kind :frame-provider}`; the native component is wired into the `:register-context-provider` substrate slot (mirroring how `make-ratom-adapter` takes the Reagent-component provider in). Reagent (already native hiccup) is unchanged.

**The prop-mangling class is now impossible by construction:** there is no plain fn under `$` for the element macro to mangle, and no per-substrate un-mangling patch to drift.

## Tests

- The five `frame-provider` branch assertions (missing/nil/named frame, single/sequential children) retarget the substrate-agnostic core `build-frame-provider-element` directly — substrate-shared, one source.
- `assert-use-subscribe-frame-provider-resolution` now mounts the native component via the substrate's own `$` (new `:frame-provider-mount-element` cfg thunk) — a full end-to-end check of the moved-up seam.
- The rf2-9ok1s / rf2-8svnm `$`-shape DOM regression tests are **kept** and re-pointed at the structural guarantee (native shell under `$`).

## Spec

**Spec unchanged (call shapes preserved).** Spec 006 §Frame-provider via React context declares prop-passing "port discretion"; the documented `($ frame-provider {...})` / hiccup call shapes are byte-identical to before. The contract — provider value is a frame-id keyword, descendants resolve against it — is preserved on every substrate.

## Quality gates

| Gate | Result |
|------|--------|
| `npm run test:cljs` (node) | **5154 tests, 17426 assertions, 0 failures, 0 errors** (1124 files compiled, 0 warnings) |
| `npm run test:browser` (Playwright DOM — incl. the propagation tests) | **130 tests, 366 assertions, 0 failures, 0 errors** |
| 3-adapter testbed smokes (`EXAMPLES_FILTER=adapters/ npm run test:examples`) | **3 example specs, 0 failures, 0 skipped** (Reagent/UIx/Helix, 0 build warnings) |
| `npm run test:bundle-isolation` (UIx/Helix/Reagent `:advanced` release) | **PASS** — 35 internal sentinels absent; uix/helix Reagent-free; 0 build warnings |
| UIx adapter `clojure -M:test` | 0 tests / 0 errors (classpath-probe alias by design; behaviour runs via shadow-cljs) |
| Helix adapter `clojure -M:test` | 0 tests / 0 errors (classpath-probe alias by design) |
| clj-kondo (8 changed files) | **0 errors, 0 new warnings** (4 pre-existing warnings identical to baseline) |
