### PR TITLE
fix(http): swallowed-failure trace + one-shot decode latch + spec/doc honesty (rf2-rl5tt rf2-xuvj7 rf2-t5mzx rf2-2pymp)

### DIFF
--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -138,6 +138,34 @@
   ;; visible without flooding the trace surface.
   (atom false))
 
+(defonce ^:private decode-defaulted-warned-handlers
+  ;; rf2-xuvj7 — one-shot-PER-HANDLER latch for the `:auto`-fallback
+  ;; warning. Mirrors `malli-absent-warned?` (rf2-ee38b.7) but keys on
+  ;; the originating handler id rather than a single runtime-wide boolean:
+  ;; a happy-path handler that omits `:decode` issues the same defaulted
+  ;; request on EVERY invocation, so a per-request `:rf.warning/decode-
+  ;; defaulted` trace floods the surface with steady-state noise (the
+  ;; finding behind this bead). Latching per-handler keeps the choice
+  ;; visible the FIRST time each call site defaults while staying silent
+  ;; thereafter. A set rather than a boolean so distinct handlers each get
+  ;; their one warning. Falls back to the runtime-wide latch when no
+  ;; handler id is available (synthetic / test-path callers).
+  (atom #{}))
+
+(defn- decode-defaulted-first-for-handler?
+  "Atomic one-shot check for `handler-id`: returns true for exactly the
+  FIRST caller to register a given id, false for every caller thereafter.
+  `swap-vals!` performs the `conj` atomically and hands back `[old new]`;
+  only the caller whose `old` lacked the id (the one that actually added
+  it) returns true, so the warning fires once even under concurrent
+  in-flight replies. When `handler-id` is nil (no origin event in scope)
+  we degrade to the shared `:rf/anonymous` slot so the warning still
+  fires once overall."
+  [handler-id]
+  (let [k             (or handler-id :rf/anonymous)
+        [old _new]    (swap-vals! decode-defaulted-warned-handlers conj k)]
+    (not (contains? old k))))
+
 (defn- warn-malli-absent! [schema]
   ;; Visible-degradation trace per Spec 014 §JSON decoder hardening
   ;; ("no silent fallback"). When a real schema rides `:decode` but
@@ -200,7 +228,7 @@
   surface as `:rf.http/decode-failure`, not be masked behind a malli
   rejection."
   [{:keys [body-text body-binary headers decode decode-supplied? request-id url
-           sensitive? max-decoded-keys]}]
+           sensitive? max-decoded-keys handler-id]}]
   (let [content-type     (content-type-of headers)
         requested-decode (cond
                            (nil? decode)        :auto
@@ -215,12 +243,23 @@
     ;; sniffing. Per rf2-2p8wr the URL passes through
     ;; `privacy/prepare-emit-tags`, which redacts denylisted query-
     ;; string param values and stamps `:sensitive?` when applicable.
+    ;;
+    ;; rf2-xuvj7 — the warning is LATCHED one-shot-per-handler (mirroring
+    ;; the malli-absent latch). A happy-path handler that omits `:decode`
+    ;; re-issues the same defaulted request on every invocation; a per-
+    ;; request trace would flood the surface with steady-state noise. The
+    ;; per-handler latch keeps the choice visible the first time each call
+    ;; site defaults, then stays quiet. The CAS sits INSIDE the
+    ;; `debug-enabled?` gate so production bundles DCE the whole branch
+    ;; (and never mutate the latch).
     (when (and (not decode-supplied?)
                (= :auto requested-decode)
-               interop/debug-enabled?)
+               interop/debug-enabled?
+               (decode-defaulted-first-for-handler? handler-id))
       (trace/emit! :warning :rf.warning/decode-defaulted
                    (privacy/prepare-emit-tags
                      {:request-id       request-id
+                      :handler-id       handler-id
                       :url              url
                       :content-type     content-type
                       :resolved-decoder (if (keyword? resolved) resolved :auto)}

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -232,13 +232,29 @@
 
 ;; ---- backoff --------------------------------------------------------------
 
+(def default-backoff
+  "rf2-t5mzx (F5) — the single source of truth for the exponential-backoff
+  defaults. Previously `:base-ms 250`, `:factor 2`, `:max-ms 5000` were
+  spelled inline in `compute-backoff-ms`'s `:or` map AND restated in
+  Spec 014 §Retry and backoff prose + the §The shape sample; the two
+  copies could silently drift. Naming the def makes the defaults a
+  referenceable constant the spec can point at, and any future change
+  edits one place."
+  {:base-ms 250 :factor 2 :max-ms 5000})
+
 (defn compute-backoff-ms
   "Per Spec 014 §Retry and backoff. Returns the delay in ms before the
   next attempt. `attempt` is the failing attempt number (1-based).
 
-  Per Spec 014 line 250 — `:jitter true` adds random ±25% jitter to
-  each delay (offset uniformly in [-0.25 × capped, +0.25 × capped])."
-  [{:keys [base-ms factor max-ms jitter] :or {base-ms 250 factor 2 max-ms 5000}} attempt]
+  Defaults (`default-backoff`): base-ms 250, factor 2, max-ms 5000.
+
+  Per Spec 014 §Retry and backoff — `:jitter true` adds random ±25%
+  jitter to each delay (offset uniformly in [-0.25 × capped, +0.25 ×
+  capped])."
+  [{:keys [base-ms factor max-ms jitter]
+    :or   {base-ms (:base-ms default-backoff)
+           factor  (:factor default-backoff)
+           max-ms  (:max-ms default-backoff)}} attempt]
   (let [raw      (* base-ms (Math/pow factor (max 0 (dec attempt))))
         capped   (min raw max-ms)
         ;; (- 1.0 (* 2.0 (rand))) is uniform in [-1.0, +1.0]; scaled by

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -510,8 +510,9 @@
        ;; CookieHandler, so cookies are neither sent nor stored regardless
        ;; of the value. Rather than silently no-op, emit the standard
        ;; `:rf.http/cljs-only-key-ignored-on-jvm` trace so the dropped key
-       ;; is visible to off-box monitors. (Spec 014 §JVM degradation table
-       ;; needs the `:credentials` row added — left for the mayor.)
+       ;; is visible to off-box monitors. Spec 014 §JVM degradation table
+       ;; carries the `:credentials` row (rf2-t5mzx) so the table and the
+       ;; shipped behaviour agree.
        (doseq [k [:mode :cache :referrer :integrity :credentials]]
          (when (contains? request k)
            (emit-cljs-only-skipped! k url sensitive?)))
@@ -574,9 +575,66 @@
 ;; the surrounding comments describe visible in code. The load-bearing
 ;; concurrency comments stay at the call sites.
 
+(defonce ^:private failure-swallowed-warned?
+  ;; rf2-rl5tt — one-shot latch so the "real failure swallowed by
+  ;; `:on-failure nil`" warning fires once per runtime, not once per
+  ;; swallowed request. Fire-and-forget telemetry beacons (`:on-failure
+  ;; nil`) are a legitimate steady-state pattern, so a per-request trace
+  ;; would be noise; the single warning makes the FIRST silently-dropped
+  ;; non-aborted failure visible (the no-silent-swallow principle) without
+  ;; flooding the trace surface for callers who knowingly opted out.
+  (atom false))
+
+(defn- warn-failure-swallowed!
+  "rf2-rl5tt — surface a swallowed REAL failure once per runtime.
+
+  When a request fails and the caller passed an explicit `:on-failure
+  nil`, `build-reply-event` legitimately silences the reply (fire-and-
+  forget). But a NON-aborted failure (transport / 5xx / decode / accept /
+  timeout) routed into that silence is a real error the app never sees —
+  the anti-pattern the committed no-silent-swallow principle calls out.
+  Emit a one-shot `:rf.warning/failure-swallowed` so the dropped failure
+  is observable in dev / tooling.
+
+  Aborts (`:rf.http/aborted`, any reason) are EXCLUDED: a cancelled
+  request that no longer wants its reply is correct-by-design silence,
+  not a swallowed error."
+  [failure url sensitive?]
+  (when (and interop/debug-enabled?
+             (not= :rf.http/aborted (:kind failure))
+             (compare-and-set! failure-swallowed-warned? false true))
+    (trace/emit! :warning :rf.warning/failure-swallowed
+                 (privacy/prepare-emit-tags
+                   {:url     url
+                    :failure failure
+                    :reason  (str "an HTTP request failed with `:kind "
+                                  (pr-str (:kind failure))
+                                  "` but `:on-failure nil` silenced the "
+                                  "reply — the failure was dropped with no "
+                                  "handler. If the silence is intentional "
+                                  "(fire-and-forget telemetry), ignore this; "
+                                  "otherwise supply an `:on-failure` target.")}
+                   (true? sensitive?)))))
+
+(defn- on-failure-silenced?
+  "True when the ctx carries an explicit `:on-failure nil` — the exact
+  condition under which `build-reply-event` silences a `:failure` reply
+  (`:supplied?` true with a `nil` `:value`). Mirrors the encoding-side
+  silence branch so the swallow-warning fires for precisely the replies
+  that get dropped."
+  [ctx]
+  (let [explicit (:explicit-on-failure ctx)]
+    (and (:supplied? explicit) (nil? (:value explicit)))))
+
 (defn- dispatch-failure!
-  "Dispatch a `:failure` reply carrying `failure` as its `:failure` slot."
+  "Dispatch a `:failure` reply carrying `failure` as its `:failure` slot.
+
+  rf2-rl5tt — when the reply is silenced by an explicit `:on-failure nil`
+  AND the failure is not an abort, surface it once via
+  `warn-failure-swallowed!` before the (no-op) dispatch."
   [ctx failure]
+  (when (on-failure-silenced? ctx)
+    (warn-failure-swallowed! failure (:url ctx) (:sensitive? ctx)))
   (dispatch-reply! (assoc ctx
                           :kind          :failure
                           :reply-payload {:kind    :failure
@@ -959,6 +1017,12 @@
                           :decode-supplied? decode-supplied?
                           :request-id       request-id
                           :url              url
+                          ;; rf2-xuvj7 — the originating event-id keys the
+                          ;; one-shot-per-handler decode-defaulted latch.
+                          ;; Nil for synthetic / test-path callers with no
+                          ;; origin event; the latch degrades to a shared
+                          ;; runtime-wide slot in that case.
+                          :handler-id       (first (:origin-event ctx))
                           :sensitive?       (:sensitive? ctx)
                           ;; rf2-wu1n5 — thread the keyword-cap from the
                           ;; normalised ctx into the decoder; nil means

--- a/implementation/http/test/re_frame/http_decode_test.clj
+++ b/implementation/http/test/re_frame/http_decode_test.clj
@@ -203,11 +203,22 @@
       (finally
         (trace/unregister-listener! cb-id)))))
 
+;; rf2-xuvj7 — the decode-defaulted warning is latched one-shot-per-handler.
+;; Reach the private set-atom via #' so tests can clear it between bodies
+;; (the latch is a `defonce` that otherwise persists across deftests in the
+;; same JVM and would silence the second test to assert it). Mirrors the
+;; `with-malli-absent` latch-reset discipline below.
+(def ^:private decode-defaulted-warned-handlers @#'decode/decode-defaulted-warned-handlers)
+
+(defn- clear-decode-defaulted-latch! []
+  (reset! decode-defaulted-warned-handlers #{}))
+
 (deftest decode-defaulted-warning-fires-when-decode-omitted
   (testing "rf2-ohwgm — when :decode is omitted (`:decode-supplied? false`)
             and the decoder falls back to :auto, `decode-response-body`
             emits `:rf.warning/decode-defaulted` carrying the resolved
             decoder + content-type tags (Spec 014 §`:auto`)"
+    (clear-decode-defaulted-latch!)
     (with-trace-capture
       (fn [captured]
         (let [v (decode/decode-response-body
@@ -216,6 +227,7 @@
                    :decode           nil
                    :decode-supplied? false
                    :request-id       :req-1
+                   :handler-id       :handler/x
                    :url              "https://example.test/x"})
               warns (filter #(= :rf.warning/decode-defaulted (:operation %))
                             @captured)]
@@ -233,6 +245,8 @@
                   "the response content-type rides the tags")
               (is (= :req-1 (:request-id tags))
                   "the request-id rides the tags for correlation")
+              (is (= :handler/x (:handler-id tags))
+                  "rf2-xuvj7 — the originating handler-id rides the tags (latch key)")
               (is (= "https://example.test/x" (:url tags))
                   "the (privacy-prepared) url rides the tags"))))))))
 
@@ -240,6 +254,7 @@
   (testing "rf2-ohwgm — when the user explicitly supplies :decode the
             warning is suppressed (the default-to-auto signal only fires
             on omission)"
+    (clear-decode-defaulted-latch!)
     (with-trace-capture
       (fn [captured]
         (decode/decode-response-body
@@ -248,6 +263,7 @@
            :decode           :json
            :decode-supplied? true
            :request-id       :req-2
+           :handler-id       :handler/y
            :url              "https://example.test/y"})
         (is (empty? (filter #(= :rf.warning/decode-defaulted (:operation %))
                             @captured))
@@ -256,6 +272,7 @@
 (deftest decode-defaulted-warning-resolved-decoder-text-for-text-ct
   (testing "rf2-ohwgm — the :resolved-decoder tag reflects the sniffed
             decoder, e.g. :text for a text/* content-type"
+    (clear-decode-defaulted-latch!)
     (with-trace-capture
       (fn [captured]
         (decode/decode-response-body
@@ -264,11 +281,78 @@
            :decode           :auto
            :decode-supplied? false
            :request-id       :req-3
+           :handler-id       :handler/z
            :url              "https://example.test/z"})
         (let [w (first (filter #(= :rf.warning/decode-defaulted (:operation %))
                                @captured))]
           (is (= :text (get-in w [:tags :resolved-decoder]))
               "text/* content-type sniffs to :text"))))))
+
+;; ---- decode-defaulted one-shot-per-handler latch (rf2-xuvj7) ---------------
+;;
+;; The `:rf.warning/decode-defaulted` warning previously fired on EVERY
+;; happy-path request that omitted `:decode` — a steady-state handler that
+;; defaults flooded the trace surface once per response. rf2-xuvj7 demotes it
+;; to a one-shot-PER-HANDLER latch (mirroring the malli-absent latch): the
+;; first defaulted request from a given originating handler warns; subsequent
+;; requests from that handler stay quiet; a different handler warns afresh.
+
+(deftest decode-defaulted-warning-is-one-shot-per-handler
+  (testing "rf2-xuvj7 — N happy-path requests through ONE handler emit at
+            most one decode-defaulted warning (the per-handler latch
+            collapses the steady-state repeats), while a SECOND distinct
+            handler still gets its own one warning"
+    (clear-decode-defaulted-latch!)
+    (with-trace-capture
+      (fn [captured]
+        ;; Five defaulted decodes from the SAME handler id.
+        (dotimes [_ 5]
+          (decode/decode-response-body
+            {:body-text        "{\"ok\":true}"
+             :headers          {"content-type" "application/json"}
+             :decode           nil
+             :decode-supplied? false
+             :request-id       :req-loop
+             :handler-id       :handler/loader
+             :url              "https://example.test/loop"}))
+        ;; A different handler defaults once.
+        (decode/decode-response-body
+          {:body-text        "{\"ok\":true}"
+           :headers          {"content-type" "application/json"}
+           :decode           nil
+           :decode-supplied? false
+           :request-id       :req-other
+           :handler-id       :handler/other
+           :url              "https://example.test/other"})
+        (let [warns (filter #(= :rf.warning/decode-defaulted (:operation %))
+                            @captured)
+              by-handler (frequencies (map #(get-in % [:tags :handler-id]) warns))]
+          (is (= 2 (count warns))
+              (str "exactly two warnings expected — one per distinct handler; saw "
+                   (count warns)))
+          (is (= 1 (get by-handler :handler/loader))
+              "the looping handler warns exactly once despite five defaulted requests")
+          (is (= 1 (get by-handler :handler/other))
+              "the second distinct handler gets its own single warning"))))))
+
+(deftest decode-defaulted-warning-degrades-to-shared-slot-when-no-handler
+  (testing "rf2-xuvj7 — when no :handler-id is in scope (synthetic / test-path
+            callers) the latch degrades to a shared slot so the warning still
+            fires at most once overall rather than per-request"
+    (clear-decode-defaulted-latch!)
+    (with-trace-capture
+      (fn [captured]
+        (dotimes [_ 3]
+          (decode/decode-response-body
+            {:body-text        "{\"ok\":true}"
+             :headers          {"content-type" "application/json"}
+             :decode           nil
+             :decode-supplied? false
+             :request-id       :req-anon
+             :url              "https://example.test/anon"}))
+        (is (= 1 (count (filter #(= :rf.warning/decode-defaulted (:operation %))
+                                @captured)))
+            "no-handler-id callers share one latch slot — one warning total")))))
 
 ;; ---- Malli-absent degradation warning (rf2-ee38b.7 / rf2-ynjts.9) ---------
 ;;

--- a/implementation/http/test/re_frame/http_encoding_test.clj
+++ b/implementation/http/test/re_frame/http_encoding_test.clj
@@ -48,6 +48,20 @@
     (is (= 5000 (encoding/compute-backoff-ms {} 20))
         "attempt 20 = very large, clamped to max-ms 5000")))
 
+(deftest default-backoff-is-the-single-source-of-truth
+  (testing "rf2-t5mzx (F5) — `default-backoff` names the exponential-backoff
+            defaults Spec 014 §Retry and backoff documents (base-ms 250,
+            factor 2, max-ms 5000), and `compute-backoff-ms` draws its `:or`
+            defaults from it so the two can't drift"
+    (is (= {:base-ms 250 :factor 2 :max-ms 5000} encoding/default-backoff)
+        "the named def matches the spec-documented defaults")
+    ;; An empty config must produce exactly the curve the named defaults imply.
+    (is (= 250 (encoding/compute-backoff-ms {} 1)))
+    (is (= 500 (encoding/compute-backoff-ms {} 2)))
+    (is (= (:max-ms encoding/default-backoff)
+           (encoding/compute-backoff-ms {} 20))
+        "deep-attempt delay clamps to default-backoff's :max-ms")))
+
 (deftest compute-backoff-ms-custom-base-and-factor
   (testing "rf2-9dro2 — caller-supplied :base-ms and :factor override
             the defaults"

--- a/implementation/http/test/re_frame/http_swallowed_failure_test.clj
+++ b/implementation/http/test/re_frame/http_swallowed_failure_test.clj
@@ -1,0 +1,124 @@
+(ns re-frame.http-swallowed-failure-test
+  "rf2-rl5tt — `:on-failure nil` silences the failure reply (fire-and-forget),
+  but a REAL (non-aborted) failure routed into that silence is an error the
+  app never sees. Per the committed no-silent-swallow principle, the transport
+  emits a ONE-SHOT `:rf.warning/failure-swallowed` dev trace the first time a
+  non-aborted failure is dropped by `:on-failure nil`. Aborts are legitimately
+  silent and MUST NOT warn.
+
+  These exercise the transport's reply-dispatch surface directly via `#'`
+  (the swallow detection is private), so the three contract cases run
+  synchronously and deterministically — no socket, no abort-race timing.
+  `dispatch-reply!` no-ops cleanly when no late-bind router is registered
+  (`encoding/dispatch-reply-via-late-bind!` short-circuits on an absent
+  `:router/dispatch!`), so calling the failure-dispatch helper with a
+  synthetic ctx fires the swallow-detection path without needing a runtime."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.http-transport :as transport]
+            [re-frame.trace :as trace]))
+
+;; Private surface reached via #' (same discipline as http_decode_test.clj).
+(def ^:private dispatch-failure!         @#'transport/dispatch-failure!)
+(def ^:private on-failure-silenced?      @#'transport/on-failure-silenced?)
+(def ^:private failure-swallowed-warned? @#'transport/failure-swallowed-warned?)
+
+(defn- reset-latch [t]
+  ;; The one-shot latch is a `defonce` that persists across deftests in the
+  ;; same JVM; reset it before each so every case starts un-warned.
+  (reset! failure-swallowed-warned? false)
+  (t))
+
+(use-fixtures :each reset-latch)
+
+(defn- with-trace-capture [body-fn]
+  (let [captured (atom [])
+        cb-id    ::http-swallowed-failure-cap]
+    (try
+      (trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
+      (body-fn captured)
+      (finally
+        (trace/unregister-listener! cb-id)))))
+
+(defn- swallowed-warnings [captured]
+  (filter #(= :rf.warning/failure-swallowed (:operation %)) @captured))
+
+;; A synthetic ctx carrying just the slots the dispatch-failure! / swallow
+;; path reads: the explicit-on-failure decision map, :url, :sensitive?. No
+;; :handle (the once-only reply guard no-ops without one) and no router (the
+;; late-bind dispatch no-ops), so the call is side-effect-free apart from the
+;; (intended) swallow-warning trace.
+(defn- ctx-on-failure-nil []
+  {:explicit-on-failure {:supplied? true :value nil}
+   :url                 "https://example.test/data"
+   :sensitive?          false})
+
+(defn- ctx-on-failure-present []
+  {:explicit-on-failure {:supplied? true :value [:api/load-error]}
+   :url                 "https://example.test/data"
+   :sensitive?          false})
+
+(deftest on-failure-silenced?-detects-explicit-nil-only
+  (testing "rf2-rl5tt — the silence predicate mirrors build-reply-event's
+            silence branch: supplied? true AND value nil"
+    (is (true?  (on-failure-silenced? (ctx-on-failure-nil)))
+        "explicit :on-failure nil is silenced")
+    (is (false? (on-failure-silenced? (ctx-on-failure-present)))
+        "an explicit event-vector target is not silenced")
+    (is (false? (on-failure-silenced? {:explicit-on-failure {:supplied? false :value nil}}))
+        "the omitted default (reply-to-origin) is not silenced")))
+
+(deftest swallowed-non-aborted-failure-emits-exactly-one-trace
+  (testing "rf2-rl5tt — a NON-aborted failure dropped by :on-failure nil
+            emits exactly one :rf.warning/failure-swallowed trace carrying
+            the failure + a human :reason"
+    (with-trace-capture
+      (fn [captured]
+        (dispatch-failure! (ctx-on-failure-nil)
+                           {:kind :rf.http/http-5xx :status 500})
+        (let [warns (swallowed-warnings captured)]
+          (is (= 1 (count warns))
+              (str "expected exactly one swallowed-failure warning; saw "
+                   (count warns)))
+          (let [w (first warns)]
+            (is (= :warning (:op-type w)))
+            (is (= "https://example.test/data" (get-in w [:tags :url]))
+                "the (privacy-prepared) url rides the tags")
+            (is (= :rf.http/http-5xx (get-in w [:tags :failure :kind]))
+                "the dropped failure rides the tags for diagnosis")
+            (is (string? (get-in w [:tags :reason]))
+                "a human-readable :reason explains the swallow")))))))
+
+(deftest aborted-failure-emits-no-swallow-trace
+  (testing "rf2-rl5tt — an aborted failure dropped by :on-failure nil emits
+            NO swallow warning: a cancelled request that no longer wants its
+            reply is correct-by-design silence, not a swallowed error. Holds
+            for every abort reason."
+    (with-trace-capture
+      (fn [captured]
+        (doseq [reason [:user :actor-destroyed :timeout]]
+          (dispatch-failure! (ctx-on-failure-nil)
+                             {:kind :rf.http/aborted :reason reason}))
+        (is (empty? (swallowed-warnings captured))
+            "no swallowed-failure warning fires for aborts")))))
+
+(deftest present-on-failure-emits-no-swallow-trace
+  (testing "rf2-rl5tt — a failure routed to a PRESENT :on-failure target is
+            not swallowed, so no warning fires (the reply has a home)"
+    (with-trace-capture
+      (fn [captured]
+        (dispatch-failure! (ctx-on-failure-present)
+                           {:kind :rf.http/http-5xx :status 500})
+        (is (empty? (swallowed-warnings captured))
+            "a present :on-failure target suppresses the swallow warning")))))
+
+(deftest swallow-warning-is-one-shot-per-runtime
+  (testing "rf2-rl5tt — repeated swallowed non-aborted failures collapse to a
+            single warning (the per-runtime latch); fire-and-forget telemetry
+            beacons that knowingly opt out must not flood the trace surface"
+    (with-trace-capture
+      (fn [captured]
+        (dotimes [_ 5]
+          (dispatch-failure! (ctx-on-failure-nil)
+                             {:kind :rf.http/transport :message "boom"}))
+        (is (= 1 (count (swallowed-warnings captured)))
+            "the one-shot latch collapses repeated swallows to a single warning")))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -10,7 +10,7 @@
 
 ## Abstract
 
-`:rf.http/managed` is the canonical HTTP fx for re-frame2 implementations that ship one. Take an args map, get a request issued; the fx handles transport, decoding, retry-with-backoff, and dispatching the reply back into the runtime. Co-located request and reply handling is the default — one event handler can branch on `(:rf/reply msg)` to handle both initial dispatch and async result — but explicit `:on-success` / `:on-failure` targets switch to the separate-handler shape when that fits better.
+`:rf.http/managed` is the canonical HTTP fx for re-frame2 implementations that ship one. Take an args map, get a request issued; the fx handles transport, decoding, retry-with-backoff, and dispatching the reply back into the runtime. The recommended shape is **two explicit handlers** — `:on-success [:article/loaded]` / `:on-failure [:article/load-error]` — one event each for the request, the success, and the failure. Each handler stays small and single-purpose, and the failure path is named rather than folded into a branch. When the request and reply genuinely belong together, the fx also supports a **co-located** form: omit the handlers and one event handler branches on `(:rf/reply msg)` to serve both the initial dispatch and the async result.
 
 The fx specialises [Pattern-AsyncEffect](Pattern-AsyncEffect.md)'s generic six-step shape (register → return `:fx` → post work → reply → dispatch → commit), pins the lifecycle slice from [Pattern-RemoteData](Pattern-RemoteData.md), and inherits the epoch carry from [Pattern-StaleDetection](Pattern-StaleDetection.md). It complements but does not replace the lower-level `:http` fx — apps that need wire-level control (custom transport, raw bytes, idiosyncratic protocols) keep using `:http`; apps that want the common case ergonomic use `:rf.http/managed`.
 
@@ -35,7 +35,54 @@ If an implementation ships ONLY a subset (e.g., no JVM transport), it claims the
 
 ## The shape
 
-Single fx-id, single args map. Co-located request and reply handling is the default; the user can opt out by providing explicit `:on-success` / `:on-failure` targets.
+Single fx-id, single args map. The recommended shape names two explicit reply targets — `:on-success` and `:on-failure` — so each of the three concerns (issue, succeed, fail) is its own small handler and the failure path is impossible to overlook. Omitting them opts into the co-located form below.
+
+```clojure
+;; Issue the request — name where the success and failure replies land.
+(rf/reg-event-fx :article/load
+  (fn [{:keys [db]} [_ {:keys [slug]}]]
+    {:db (-> db
+             (assoc-in [:article :status] :loading)
+             (assoc-in [:article :error]  nil))
+     :fx [[:rf.http/managed
+           {:request    {:method :get
+                         :url    (str "/articles/" slug)}
+            :decode     ArticleResponse
+            :accept     (fn [decoded]
+                          (if-let [article (:article decoded)]
+                            {:ok article}
+                            {:failure {:reason  :missing-article
+                                       :message "Response missing :article"}}))
+            :retry      {:on           #{:rf.http/transport :rf.http/http-5xx}
+                         :max-attempts 4
+                         :backoff      {:base-ms 250
+                                        :factor  2
+                                        :max-ms  5000
+                                        :jitter  true}}
+            :on-success [:article/loaded]
+            :on-failure [:article/load-error]}]]}))
+
+;; Success reply — the payload rides as the last event arg.
+(rf/reg-event-db :article/loaded
+  (fn [db [_ {:keys [value]}]]
+    (-> db
+        (assoc-in [:article :status] :loaded)
+        (assoc-in [:article :data]   value)
+        (assoc-in [:article :error]  nil))))
+
+;; Failure reply — named, not a branch.
+(rf/reg-event-db :article/load-error
+  (fn [db [_ {:keys [failure]}]]
+    (-> db
+        (assoc-in [:article :status] :error)
+        (assoc-in [:article :error]  failure))))
+```
+
+When the request resolves, the runtime dispatches `[:article/loaded {:kind :success :value article}]` (or `[:article/load-error {:kind :failure :failure ...}]`) — the reply payload is appended as the last argument to the named event.
+
+### Co-located form (request and reply in one handler)
+
+When the request and its reply genuinely belong together, omit `:on-success` / `:on-failure` and the reply routes back to the originating event id with the payload merged under `:rf/reply`. One handler then branches on the `(:rf/reply msg)` sentinel to serve both roles:
 
 ```clojure
 (rf/reg-event-fx :article/load
@@ -75,7 +122,9 @@ Single fx-id, single args map. Co-located request and reply handling is the defa
                                        :jitter  true}}}]]})))
 ```
 
-When the request resolves, the runtime dispatches `[:article/load (assoc msg :rf/reply {:kind :success :value article})]` (or `:failure` shape) back to the same event id. The handler's `(if-let [reply ...] ...)` branch handles the result.
+When the request resolves, the runtime dispatches `[:article/load (assoc msg :rf/reply {:kind :success :value article})]` (or `:failure` shape) back to the same event id. The handler's `(if-let [reply ...] ...)` branch handles the result. The co-located form keeps one mental model per feature; the two-handler form keeps each handler single-purpose. Prefer two handlers unless the reply logic is trivial and tightly coupled to the request.
+
+> Future consideration (out of scope here): a `defmanaged-event-fx`-style macro could collapse the three-handler boilerplate into a single declaration. Weighing it is deferred to post-v1 (rf2-2pymp) — it is not part of this spec.
 
 ## The args map
 
@@ -193,18 +242,19 @@ Sniff the response Content-Type header:
 - `text/*` → `:text`.
 - otherwise → `:blob`.
 
-Handles 90% of cases without ceremony. Whenever the runtime falls through to `:auto` (i.e., the user didn't supply `:decode`), it emits a single `:rf.warning/decode-defaulted` trace per request so the choice is visible in tooling and logs:
+Handles 90% of cases without ceremony. Whenever the runtime falls through to `:auto` (i.e., the user didn't supply `:decode`), it emits a `:rf.warning/decode-defaulted` trace so the choice is visible in tooling and logs. The warning is **latched one-shot-per-handler**: a happy-path handler that omits `:decode` re-issues the same defaulted request on every invocation, so emitting once per request would flood the trace surface with steady-state noise. The first defaulted request from a given originating event-id warns; subsequent requests from that handler stay quiet (a fresh handler id warns again). The handler id rides at `:handler-id`:
 
 ```clojure
 {:operation :rf.warning/decode-defaulted
  :op-type   :warning
  :tags      {:request-id  <id-or-nil>
+             :handler-id  <originating-event-id-or-nil>
              :url         <url>
              :content-type <header-value>
              :resolved-decoder <:json | :text | :blob>}}
 ```
 
-The warning is informational, not an error — auto-decode is supported and stable. The trace just lets pair tools and 10x panels surface "this handler is relying on the default" so users can choose to be explicit when they want.
+The warning is informational, not an error — auto-decode is supported and stable. The trace just lets pair tools and 10x panels surface "this handler is relying on the default" once per call site so users can choose to be explicit when they want.
 
 ### Schema reflection (optional, ergonomic)
 
@@ -449,7 +499,22 @@ The two outer-`:kind` values (`:success` / `:failure`) discriminate the reply br
 
 ## Reply addressing
 
-The `:on-success` / `:on-failure` keys default to "the originating event id with `:rf/reply` merged into the original message".
+`:on-success` / `:on-failure` name where the success and failure replies are dispatched. The recommended form supplies them explicitly (separate handlers); omitting them falls back to the co-located default — "the originating event id with `:rf/reply` merged into the original message".
+
+### Explicit target — separate handler (recommended)
+
+```clojure
+{:fx [[:rf.http/managed {... :on-success [:article/loaded] :on-failure [:article/load-error]}]]}
+```
+
+The `:rf/reply` payload is appended as the last argument to the dispatched event vector:
+
+```clojure
+[:article/loaded {:kind :success :value v}]
+[:article/load-error {:kind :failure :failure failure-map}]
+```
+
+Each reply lands on its own single-purpose handler — the failure path is named rather than a branch inside the request handler. This is the shape to reach for by default.
 
 ### Default (omitted) — co-located handler
 
@@ -463,19 +528,7 @@ The fx captures the originating event-id (from the dispatch envelope's cofx). On
 [<originating-event-id> (assoc original-msg :rf/reply {:kind :success :value v})]
 ```
 
-The handler's body is `(if-let [reply (:rf/reply msg)] ...handle... ...request...)`. One handler, two roles, distinguishable by the `:rf/reply` sentinel.
-
-### Explicit target — separate handler
-
-```clojure
-{:fx [[:rf.http/managed {... :on-success [:article/loaded] :on-failure [:article/load-error]}]]}
-```
-
-The `:rf/reply` payload is appended as the last argument to the dispatched event vector:
-
-```clojure
-[:article/loaded {:kind :success :value v}]
-```
+The handler's body is `(if-let [reply (:rf/reply msg)] ...handle... ...request...)`. One handler, two roles, distinguishable by the `:rf/reply` sentinel. Use it when the reply logic is trivial and tightly coupled to the request.
 
 Both addressing modes carry the same shape so handlers can correlate by inspecting either `(:rf/reply msg)` (in the merged form) or the appended last-arg (in the explicit form).
 
@@ -487,6 +540,8 @@ Both addressing modes carry the same shape so handlers can correlate by inspecti
 ```
 
 Fire-and-forget. Useful for telemetry beacons.
+
+A silenced `:on-failure` drops the failure reply with no handler. To keep this honest against the no-silent-swallow principle, the runtime emits a **one-shot `:rf.warning/failure-swallowed`** trace (per runtime, dev-only) the first time a NON-aborted failure (`:rf.http/transport` / `:rf.http/http-5xx` / `:rf.http/timeout` / `:rf.http/decode-failure` / `:rf.http/accept-failure` / …) is dropped by `:on-failure nil` — the silence is observable rather than invisible. Aborted requests (`:rf.http/aborted`, any reason) are excluded: a cancelled request that no longer wants its reply is correct-by-design silence, not a swallowed error. The warning is informational; there is no `:rf.error/*` for the path.
 
 ## Aborts
 
@@ -1184,7 +1239,7 @@ Handler-meta `:sensitive?` is **not** a source — the handler-level `:rf/regist
 
 ### 4. Trace-event redaction + stamping rules
 
-For every `:rf.http/*` trace event the runtime emits (`:rf.http/retry-attempt`, `:rf.http/aborted-on-actor-destroy`, the eight `:rf.http/*` failure categories from [§Failure categories](#failure-categories-closed-set), `:rf.warning/decode-defaulted`), implementations MUST:
+For every `:rf.http/*` trace event the runtime emits (`:rf.http/retry-attempt`, `:rf.http/aborted-on-actor-destroy`, the eight `:rf.http/*` failure categories from [§Failure categories](#failure-categories-closed-set), `:rf.warning/decode-defaulted`, `:rf.warning/failure-swallowed`), implementations MUST:
 
 1. **Redact denylisted headers** in `:headers` slots regardless of the effective `:sensitive?` flag.
 2. **Redact denylisted query-string parameter values** in `:url` slots regardless of the effective `:sensitive?` flag. Param-name + position preserved; the value is replaced inline with the `:rf/redacted` text token.
@@ -1293,7 +1348,7 @@ Per [Pattern-StaleDetection](Pattern-StaleDetection.md) and [§Reply addressing]
 - [Spec 002 §Routing](002-Frames.md#routing-the-dispatch-envelope) — frame-aware fx contract; reply dispatches inherit `:frame`.
 - [Spec 005 §Delayed `:after` transitions](005-StateMachines.md#delayed-after-transitions) — the substrate semantic retry rides on; the machine fires a transition on the failure reply, optionally delays via `:after`, and re-issues the request from the next state's `:spawn`.
 - [Spec 005 §Spawn-and-join via `:spawn-all`](005-StateMachines.md#spawn-and-join-via-spawn-all) — multi-request semantic retry (refresh-then-retry, fan-out-with-conditional-retry) lives here.
-- [Spec 009 §Trace event envelope](009-Instrumentation.md) — trace envelope shape; `:rf.http/retry-attempt`, `:rf.warning/decode-defaulted`, and the `:rf.http/*` failure-category traces follow it.
+- [Spec 009 §Trace event envelope](009-Instrumentation.md) — trace envelope shape; `:rf.http/retry-attempt`, `:rf.warning/decode-defaulted`, `:rf.warning/failure-swallowed`, and the `:rf.http/*` failure-category traces follow it.
 - [Spec 010 §Schemas](010-Schemas.md) — the schema language `:decode <schema>` consumes. Spec 010 standardises the schema-attachment surface (`:schema` metadata, `reg-app-schema`, `app-schemas-digest`) and the pluggable validator seam (Malli is the CLJS reference's default); the `:rf.http/managed` decode step parses the response body and applies the registered schema language's decode-or-validate primitive (on CLJS reference: `malli.core/decode` + `malli.transform/json-transformer`). There is no separate "Spec 010 decode pipeline" — the decode contract belongs to this Spec; Spec 010 provides the schema language.
 - [Pattern-Boot §Worked example — auth-machine and the retry-ownership boundary](Pattern-Boot.md#worked-example--auth-machine-and-the-retry-ownership-boundary) — the canonical end-to-end illustration of [§Boundary — transport vs semantic retry](#boundary--transport-vs-semantic-retry).
 - [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) — the `:rf.http/*` namespace is reserved for this Spec.


### PR DESCRIPTION
Four cohesive HTTP-surface fixes from the API-review sweep. Pre-alpha masterpiece stance: no back-compat shims — delete/replace.

## Fixes

- **rf2-rl5tt (P1)** — `:on-failure nil` swallowed real failures with no dev signal. The transport's `dispatch-failure!` now emits a one-shot-per-runtime `:rf.warning/failure-swallowed` dev trace the first time a NON-aborted failure is dropped by an explicit `:on-failure nil`. Aborts (`:rf.http/aborted`, any reason) are excluded by kind — a cancelled request that no longer wants its reply is correct-by-design silence.
- **rf2-xuvj7 (P2)** — `:rf.warning/decode-defaulted` fired on every happy-path request. Demoted to a one-shot-PER-HANDLER latch keyed on the originating event-id (mirrors the `malli-absent` latch, via `swap-vals!` for atomic first-seen detection). `:handler-id` rides the trace tags; no-handler-id callers share one slot.
- **rf2-t5mzx (P3)** — removed the stale `"left for the mayor"` comment in `check-cljs-only-keys!`; Spec 014 §JVM degradation table already carries the `:credentials` row, so table and shipped behaviour now agree. **Folded F5**: hoisted the exponential-backoff defaults into a named `encoding/default-backoff` so `compute-backoff-ms` and the Spec 014 prose share one source of truth.
- **rf2-2pymp (P3)** — reframed Spec 014 to LEAD with the two-handler (`:on-success` / `:on-failure`) shape over the co-located `(:rf/reply msg)` sentinel branch (Abstract, §The shape, §Reply addressing). `defmanaged-event-fx` noted as an out-of-scope post-v1 future consideration only — not built.

Spec 014 updated to match shipped `:credentials` trace; the new `:rf.warning/failure-swallowed` + the latched/`:handler-id`-tagged `:rf.warning/decode-defaulted` are documented in the trace catalogue. spec/API.md + Conventions untouched.

## Regression tests

- `http_swallowed_failure_test.clj` (new) — swallowed non-aborted failure emits exactly one trace; an abort (`:user` / `:actor-destroyed` / `:timeout`) emits none; a present `:on-failure` emits none; one-shot latch collapses repeats. Plus a `on-failure-silenced?` predicate test.
- `http_decode_test.clj` — extended for the per-handler latch (N requests through one handler = one warning; a second handler warns afresh) + the no-handler-id shared-slot fallback; existing decode-defaulted tests reset the latch and assert the new `:handler-id` tag.
- `http_encoding_test.clj` — pins `default-backoff` coherence with `compute-backoff-ms` and the spec defaults.

## Quality gates

- **http `clojure -M:test`**: 292 tests, 1486 assertions, 0 failures, 0 errors.
- **`npm run test:cljs`**: 5154 tests, 17426 assertions, 0 failures, 0 errors.
- **clj-kondo (changed files)**: errors 0, warnings 1 — the single warning (`unused binding abort-signal`, http_transport.cljc) is pre-existing (verified against the unmodified file), not introduced here.
- **`mkdocs build --strict`**: exit 0, no WARNING/ERROR/anchor lines (spec/014 prose touched; anchors verified).
