### PR TITLE
feat(xray): single named safe-egress fn + sensitive-guard example + spec/008 panel-enum fix (rf2-rcogp rf2-nqugc rf2-7b1z4)

### DIFF
--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -438,13 +438,14 @@ Conventional keys: `:my-app/recorder`, `:my-app/timing-monitor`, etc.
 
 **Re-registration semantics.** `register-listener!` called with a key already in the registry replaces the previous callback atomically — the swap from old to new happens between two emits, never mid-emit. No trace event is emitted for the replacement (the listener registry is itself dev-only metadata; mutating it does not feed the trace stream); no events delivered to the previous callback are re-delivered to the new one, and no events emitted after the swap are dropped. Hot-reload tools that re-register their listener on every code reload see exactly one stream of events with the swap point invisible to the runtime. The same semantics apply to `register-epoch-listener!` re-registration under an existing key.
 
-**Worked example.** A minimal recorder that prints every error trace to the console:
+**Worked example.** A minimal recorder that prints every error trace to the console. The `(when-not (:sensitive? trace-event) …)` guard is the load-bearing line: listeners receive **every** event regardless of `:sensitive?` (per [§Listener filtering semantics](#listener-filtering-semantics)), so any listener body that egresses a payload off-box — and `println` to a console that may be captured into a log IS an off-box sink — MUST gate on the flag. Teaching the safe shape here, at the copy site, is deliberate: the worked example is the first thing a tool author copies (per the egress-ergonomics ruling rf2-rcogp / rf2-nqugc).
 
 ```clojure
 (rf/register-listener!
   :my-app/error-logger
   (fn [trace-event]
-    (when (= :error (:op-type trace-event))
+    (when (and (= :error (:op-type trace-event))
+               (not (:sensitive? trace-event)))  ;; gate any off-box egress on :sensitive?
       (println (:operation trace-event)
                (-> trace-event :tags :reason)))))
 ```

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -194,7 +194,7 @@ panel/beat/path is [the new surface]."
 
 ```clojure
 {:frame       <frame-id>   ; the HOST frame Xray should observe (optional)
- :panel       <tab-id>     ; which L4 tab to surface (one of the 7 below)
+ :panel       <tab-id>     ; which L4 tab to surface (one of the 6 below)
  :epoch-id    <epoch-id>   ; settling epoch to pin the spine to
  :dispatch-id <id>         ; cascade root to pin the spine to
  :path        [<k> ...]    ; app-db path to highlight in the App-db panel
@@ -203,13 +203,21 @@ panel/beat/path is [the new surface]."
 ```
 
 Every field is optional; an empty command is a well-formed no-op focus.
-`:panel` accepts the 7 canonical tab ids (the
-`day8.re-frame2-xray.focus/valid-panels` set, also re-exported as
-`core/valid-focus-panels`):
+`:panel` accepts the canonical tab ids. The **shipped**
+`day8.re-frame2-xray.focus/valid-panels` set (also re-exported as
+`core/valid-focus-panels`) is the single source of truth for this
+enum — this doc must match it exactly, not hand-restate a divergent
+list:
 
 ```
-#{:epoch :app-db :views :trace :machines :routes :issues}
+#{:epoch :app-db :views :trace :machines :routes}
 ```
+
+(Six tabs. The `:issues` tab was removed per rf2-gbz39 — issues now
+surface inline in the Epoch panel + the L2 event-row pink-wash + the
+always-on issues ribbon signal, so `:issues` is no longer a focusable
+panel. A host that validates a focus command against `:issues` gets
+`{:ok? false :reason :unknown-panel}` from `focus!`.)
 
 (internal registry keys per [`007-UX-IA.md`](./007-UX-IA.md) §The
 4-layer chrome L3). The `:source` map is host-agnostic provenance —

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -184,7 +184,7 @@ implementation reality — ~40 symbols across 6 namespaces).
               :path [:checkout :state]
               :source {:kind :story/assertion}})
 (xray/focus! :checkout {:panel :trace})   ;; positional host-frame form
-xray/valid-focus-panels                   ;; the 7 valid :panel ids
+xray/valid-focus-panels                   ;; the 6 valid :panel ids (see 008 §Host-facing focus API; :issues removed rf2-gbz39)
 
 (xray/load-theme css-string)
 ;; Programmatically swap the palette: injects `css-string` as a dedicated
@@ -672,16 +672,32 @@ silently picking one. The MCP server's tool-arg layer is the right
 place to refuse mutations against an ambiguous resolution; reads
 degrade through the documented `:no-frame-resolved` fallback.
 
-### Privacy egress (single emission site)
+### Privacy egress — the single named safe-egress entry point
 
-Every direct-read accessor routes returned values through
-`re-frame.core/elide-wire-value` before egress. The single normative
-emission site lives in the framework; the runtime's job is to call
-it with `:include-sensitive?` and `:include-large?` defaulting
-`false` and to honour the caller's opt-in (per MUST-inventory rows
-#2 / #15 / #17 / #19). Callers pass plain `:include-sensitive?` /
-`:include-large?` opts; the runtime translates to the framework's
-`:rf.size/*` namespaced opt keys.
+Every direct-read accessor routes returned values through one named
+off-box safe-egress fn before egress, so **the safe path is the short
+path** (rf2-rcogp). The framework owns the normative walker
+(`re-frame.core/elide-wire-value`) and the normative epoch projection
+(`re-frame.core/projected-record`); the runtime wraps each with the
+off-box defaults BAKED IN so a forwarder author never re-derives the
+opt-juggling per call site:
+
+```clojure
+(day8.re-frame2-xray.runtime/egress-value value)   ;; arbitrary value (app-db slice, sub, trace event, …)
+(day8.re-frame2-xray.runtime/egress-record record) ;; one :rf/epoch-record
+```
+
+Off-box defaults: `:include-sensitive?` and `:include-large?` both
+default `false` — sensitive slots become `:rf/redacted`, large slots
+become the `:rf.size/large-elided` marker. A caller that is itself the
+trust boundary opts back in per call
+(`{:include-sensitive? true}` / `{:include-large? true}`). `egress-record`
+routes through `projected-record` on the safe default path (bookkeeping
+slots pass through unchanged) and through `egress-value` when the
+caller opts in (the projection has no opt-in arg). This is the runtime's
+half of MUST-inventory rows #2 / #15 / #17 / #19; callers pass plain
+`:include-sensitive?` / `:include-large?` opts, the fns translate to the
+framework's `:rf.size/*` namespaced opt keys.
 
 ### Inspection band (9 accessors — read-only)
 

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -180,35 +180,94 @@
   (vec (rf/frame-ids)))
 
 ;; ---------------------------------------------------------------------------
-;; Privacy egress — single emission site
+;; Privacy egress — the single named safe-egress entry point
 ;; ---------------------------------------------------------------------------
 ;;
 ;; Per MUST-inventory rows #15 / #17 / #19: every direct-read accessor
-;; routes returned values through `re-frame.core/elide-wire-value`
-;; before egress. The single normative emission site lives in the
-;; framework; the runtime's job is to call it with both
-;; `:include-sensitive?` and `:include-large?` defaulting `false` and
-;; to honour the caller's opt-in. The opt-in lives in the MCP-server
-;; side's tool args; the runtime accepts the bools as plain args so
-;; the eval form is one shape per call.
+;; routes returned values through the framework's wire-elision walker
+;; (`re-frame.core/elide-wire-value`) before egress. The walker is the
+;; framework's single normative emission site; what was missing — and
+;; what rf2-rcogp fixes — is a single NAMED off-box egress fn here so
+;; THE SAFE PATH IS THE SHORT PATH.
+;;
+;; The threat model (Tool-Pair §Privacy egress, Security.md §Off-box
+;; egress): this runtime hands values to an AI/MCP boundary and to
+;; logs, both of which are sensitive sinks. The danger the senior-dev
+;; API critique (rf2-814or) flagged is that `elide-wire-value` does
+;; NOT bake off-box defaults — a forwarder author must KNOW to pass
+;; `:rf.size/include-sensitive? false` + `:rf.size/include-large?
+;; false`, and the unsafe path (`pr-str` the raw value you already
+;; hold) is the same length or shorter. The fix: `egress-value` /
+;; `egress-record` apply the off-box defaults already, so the
+;; forwarder author's shortest call is the safe one and the verbose
+;; opt-juggling never has to be re-derived per call site.
+;;
+;; Off-box default polarity: both `include-sensitive?` and
+;; `include-large?` default `false` (the walker substitutes the slot —
+;; sensitive ⇒ `:rf/redacted`, large ⇒ `:rf.size/large-elided`). A
+;; caller passing `true` opts back in to seeing the raw value. The
+;; runtime API uses plain-keyword opts; these fns translate to the
+;; framework's `:rf.size/*` namespaced opt keys.
 
-(defn- elide
-  "Route `value` through the framework's wire-elision walker with both
-  privacy + size defaults. Caller passes `:include-sensitive?` /
-  `:include-large?` to opt back in per call (the runtime API uses
-  plain-keyword opts; this wrapper translates to the framework's
-  `:rf.size/*` namespaced opt keys per
-  `re-frame.elision/elide-wire-value`). Tools wrap their ready-to-
-  egress payload with this fn — single emission site per MUST-inventory
-  row #17."
+(defn egress-value
+  "The single named off-box safe-egress fn for an arbitrary value
+  (app-db slice, sub value, machine state, trace event, …). Routes
+  `value` through the framework's wire-elision walker
+  (`re-frame.core/elide-wire-value`) with the off-box privacy + size
+  defaults BAKED IN, so the shortest call is the safe one.
+
+  Off-box defaults: `include-sensitive?` + `include-large?` both
+  `false` — sensitive slots become `:rf/redacted`, large slots become
+  the `:rf.size/large-elided` marker. A caller that is itself the
+  trust boundary opts back in per call:
+
+      (egress-value v)                            ; safe (defaults)
+      (egress-value v {:include-sensitive? true}) ; opt back in
+
+  Every direct-read accessor on this runtime calls this fn before a
+  value crosses the off-box boundary (MUST-inventory rows #15 / #17 /
+  #19). rf2-rcogp — the safe path is the short path."
   ([value]
-   (elide value nil))
+   (egress-value value nil))
   ([value {:keys [include-sensitive? include-large?]
            :or   {include-sensitive? false
                   include-large?     false}}]
    (rf/elide-wire-value value
                         {:rf.size/include-sensitive? include-sensitive?
                          :rf.size/include-large?     include-large?})))
+
+(defn egress-record
+  "The single named off-box safe-egress fn for one epoch record. On the
+  safe default path it routes the `:rf/epoch-record` through the
+  framework's normative epoch projection
+  (`re-frame.core/projected-record`) so payload slots are wire-elided
+  with off-box defaults while bookkeeping slots (`:epoch-id`,
+  `:dispatch-id`, `:outcome`, …) pass through unchanged.
+
+  `projected-record` already bakes the off-box defaults — naming the
+  off-box egress of an epoch record `egress-record` (parallel to
+  `egress-value` for arbitrary values) gives a forwarder author ONE
+  obvious safe entry point for either shape instead of a choice
+  between `elide-wire-value` (and the right opts) and
+  `projected-record` (with no opts) they must first learn the
+  difference between.
+
+  Opt-back-in: when a caller that is itself the trust boundary opts in
+  to seeing sensitive or large slots (`{:include-sensitive? true}` /
+  `{:include-large? true}`), the record is routed through
+  `egress-value` with the opt instead — the normative epoch projection
+  has no opt-in arg, so the value walker carries the per-call override.
+  No opts (or both `false`) ⇒ the normative `projected-record` path.
+  rf2-rcogp — the safe path is the short path."
+  ([record]
+   (egress-record record nil))
+  ([record {:keys [include-sensitive? include-large?]
+            :or   {include-sensitive? false
+                   include-large?     false}}]
+   (if (or include-sensitive? include-large?)
+     (egress-value record {:include-sensitive? include-sensitive?
+                           :include-large?     include-large?})
+     (rf/projected-record record))))
 
 ;; ---------------------------------------------------------------------------
 ;; Inspection band (9 accessors)
@@ -245,8 +304,8 @@
                              (dissoc :frame :include-sensitive? :include-large?)
                              (assoc :flat true))
              events      (trace-tooling/trace-buffer fid filter-opts)
-             scrubbed    (mapv #(elide % {:include-sensitive? include-sensitive?
-                                          :include-large?     include-large?})
+             scrubbed    (mapv #(egress-value % {:include-sensitive? include-sensitive?
+                                                 :include-large?     include-large?})
                                events)]
          {:ok?    true
           :frame  fid
@@ -267,8 +326,8 @@
        {:ok? false :reason :no-frame-resolved
         :hint "Pass :frame :foo or register at least one frame."}
        (let [records  (rf/epoch-history fid)
-             scrubbed (mapv #(elide % {:include-sensitive? include-sensitive?
-                                       :include-large?     include-large?})
+             scrubbed (mapv #(egress-record % {:include-sensitive? include-sensitive?
+                                               :include-large?     include-large?})
                             records)]
          {:ok?    true
           :frame  fid
@@ -293,8 +352,8 @@
          {:ok?   true
           :frame fid
           :path  (vec path)
-          :value (elide value {:include-sensitive? include-sensitive?
-                               :include-large?     include-large?})})))))
+          :value (egress-value value {:include-sensitive? include-sensitive?
+                                      :include-large?     include-large?})})))))
 
 (defn get-app-db-diff
   "Tool: `get-app-db-diff`. Slice diff for a named epoch — read
@@ -324,10 +383,10 @@
            :frame fid :epoch-id epoch-id}
           (let [before (:db-before match)
                 after  (:db-after  match)
-                diff   {:before (elide before {:include-sensitive? include-sensitive?
-                                               :include-large?     include-large?})
-                        :after  (elide after  {:include-sensitive? include-sensitive?
-                                               :include-large?     include-large?})}]
+                diff   {:before (egress-value before {:include-sensitive? include-sensitive?
+                                                      :include-large?     include-large?})
+                        :after  (egress-value after  {:include-sensitive? include-sensitive?
+                                                      :include-large?     include-large?})}]
             {:ok?      true
              :frame    fid
              :epoch-id epoch-id
@@ -365,8 +424,8 @@
           {:ok?        true
            :frame      fid
            :machine-id machine-id
-           :state      (elide m {:include-sensitive? include-sensitive?
-                                 :include-large?     include-large?})})))))
+           :state      (egress-value m {:include-sensitive? include-sensitive?
+                                        :include-large?     include-large?})})))))
 
 (defn get-machine-list
   "Tool: `get-machine-list`. List of registered machines per frame
@@ -378,9 +437,9 @@
      {:ok?      true
       :machines (into {}
                       (map (fn [mid]
-                             [mid (elide (rf/machine-meta mid)
-                                         {:include-sensitive? include-sensitive?
-                                          :include-large?     include-large?})]))
+                             [mid (egress-value (rf/machine-meta mid)
+                                                {:include-sensitive? include-sensitive?
+                                                 :include-large?     include-large?})]))
                       ids)
       :count    (count ids)})))
 
@@ -411,8 +470,8 @@
                         (mapcat #(trace-tooling/trace-buffer % {:flat true}))
                         (rf/frame-ids))
          issues   (filterv #(contains? issue-op-types (:op-type %)) events)
-         scrubbed (mapv #(elide % {:include-sensitive? include-sensitive?
-                                   :include-large?     include-large?})
+         scrubbed (mapv #(egress-value % {:include-sensitive? include-sensitive?
+                                          :include-large?     include-large?})
                         issues)]
      {:ok?    true
       :issues scrubbed
@@ -672,8 +731,8 @@
 
   This fn is the runtime-side **result shaper** the server's wrapper
   invokes on the eval'd value before egress:
-  `{:ok? true :value (elide value)}` — privacy + size scrubbing applied
-  to the eval'd result with caller's `:include-sensitive?` /
+  `{:ok? true :value (egress-value value)}` — privacy + size scrubbing
+  applied to the eval'd result with caller's `:include-sensitive?` /
   `:include-large?` opt-in.
 
   The synchronous-extent binding of `*current-origin*` per Lock #4 / I6
@@ -682,7 +741,7 @@
   ([value] (eval-form-result value nil))
   ([value opts]
    {:ok?   true
-    :value (elide value opts)}))
+    :value (egress-value value opts)}))
 
 ;; ---------------------------------------------------------------------------
 ;; Meta band (2 accessors)

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -377,3 +377,100 @@
       (is (true? (:ok? result)))
       (is (vector? (:issues result)))
       (is (number? (:count result))))))
+
+;; ---------------------------------------------------------------------------
+;; (11) egress-value / egress-record — the single named safe-egress fn
+;;      (rf2-rcogp: THE SAFE PATH IS THE SHORT PATH).
+;; ---------------------------------------------------------------------------
+;;
+;; The runtime hands values to an off-box AI/MCP boundary and to logs.
+;; rf2-rcogp ships one NAMED off-box egress fn with the off-box defaults
+;; baked in, so the forwarder author's shortest call is the safe one.
+;; These tests are the failing-before / passing-after regression: the
+;; named fn redacts a sensitive value / record on the off-box path, and
+;; the call sites we rerouted (get-app-db / get-epoch-history / …) still
+;; redact end-to-end.
+
+(defn- seed-sensitive-schema! []
+  ;; Mirror the framework's schema-declared sensitive path setup
+  ;; (implementation/core/test/re_frame/elision_test.clj
+  ;; §schema-sensitive-path-redacts): a `{:sensitive? true}` slot
+  ;; hydrates the per-frame `:sensitive-declarations` so the wire walker
+  ;; substitutes `:rf/redacted` for that path on off-box egress.
+  ;;
+  ;; The `:sensitive-declarations` live in app-db at
+  ;; `[:rf/runtime :elision :sensitive-declarations]`, so `populate-…!`
+  ;; MUST run AFTER any whole-db `reg-event-db` reset in a test (a reset
+  ;; that returns a fresh map would otherwise wipe `:rf/runtime`).
+  (rf/reg-app-schema [:auth]
+                     [:map
+                      [:username :string]
+                      [:password {:sensitive? true} :string]])
+  (rf/populate-sensitive-from-schemas!))
+
+(deftest egress-value-redacts-sensitive-on-the-safe-default-path
+  (testing "`egress-value` with no opts (the SHORT path) redacts a
+            schema-declared sensitive slot — the off-box defaults are
+            baked in so a forwarder author never re-derives the opts"
+    (seed-sensitive-schema!)
+    (let [out (runtime/egress-value {:auth {:username "ada" :password "shh"}})]
+      (is (= "ada" (get-in out [:auth :username]))
+          "non-sensitive slots pass through verbatim")
+      (is (= :rf/redacted (get-in out [:auth :password]))
+          "the sensitive slot is redacted on the bare (default) call"))))
+
+(deftest egress-value-opts-back-in-to-sensitive
+  (testing "a caller that is itself the trust boundary opts back in to
+            the raw value with `{:include-sensitive? true}`"
+    (seed-sensitive-schema!)
+    (let [out (runtime/egress-value {:auth {:password "shh"}}
+                                    {:include-sensitive? true})]
+      (is (= "shh" (get-in out [:auth :password]))
+          ":include-sensitive? true ⇒ the raw value passes through"))))
+
+(deftest egress-record-redacts-sensitive-payload-slots
+  (testing "`egress-record` routes an epoch record through the normative
+            epoch projection on the safe default path — payload slots
+            (:db-before / :db-after) are wire-elided while bookkeeping
+            slots pass through unchanged"
+    (seed-sensitive-schema!)
+    (let [record  {:epoch-id    "e1"
+                   :dispatch-id 7
+                   :event-id    :auth/login
+                   :db-before   {:auth {:username "ada" :password "shh"}}
+                   :db-after    {:auth {:username "ada" :password "newpw"}}}
+          out     (runtime/egress-record record)]
+      (is (= "e1" (:epoch-id out)) "bookkeeping :epoch-id passes through")
+      (is (= 7 (:dispatch-id out)) "bookkeeping :dispatch-id passes through")
+      (is (= :rf/redacted (get-in out [:db-before :auth :password]))
+          "the sensitive payload slot is redacted in :db-before")
+      (is (= :rf/redacted (get-in out [:db-after :auth :password]))
+          "the sensitive payload slot is redacted in :db-after")
+      (is (= "ada" (get-in out [:db-before :auth :username]))
+          "non-sensitive payload slots pass through"))))
+
+(deftest egress-record-opts-back-in-to-sensitive
+  (testing "`egress-record` with `{:include-sensitive? true}` routes
+            through `egress-value` so the opt-in reaches the walker
+            (the normative projection has no opt-in arg)"
+    (seed-sensitive-schema!)
+    (let [record {:db-after {:auth {:password "shh"}}}
+          out    (runtime/egress-record record {:include-sensitive? true})]
+      (is (= "shh" (get-in out [:db-after :auth :password]))
+          ":include-sensitive? true ⇒ the raw value passes through"))))
+
+(deftest get-app-db-redacts-sensitive-end-to-end
+  (testing "the rerouted `get-app-db` call site still redacts a
+            sensitive slot end-to-end (regression: the named egress fn
+            is wired into the accessor)"
+    (rf/reg-event-db :test/seed-auth
+      (fn [_ _] {:auth {:username "ada" :password "shh"}}))
+    (rf/dispatch-sync [:test/seed-auth])
+    ;; Populate AFTER the whole-db reset so the declarations survive.
+    (seed-sensitive-schema!)
+    (let [result (runtime/get-app-db)]
+      (is (true? (:ok? result)))
+      (is (= :rf/redacted (get-in result [:value :auth :password]))
+          "get-app-db scrubs the sensitive slot via egress-value")
+      (is (= "ada" (get-in result [:value :auth :username]))
+          "non-sensitive slots survive"))))


### PR DESCRIPTION
Fixes rf2-rcogp + rf2-nqugc + rf2-7b1z4 (xray egress + spec honesty). The PR was opened with a malformed `@-` body by the worker tooling; description reconstructed by the mayor from the worker report + bead close-reasons before merge.

## What
- **rcogp:** shipped two named off-box safe-egress fns in `day8.re-frame2-xray.runtime` — `egress-value` (wraps `elide-wire-value`) + `egress-record` (normative `projected-record` on the safe default path) — so the safe path is the short path; rerouted all 8 direct-read accessors through them, replacing the private hand-rolled elide. tools/xray/spec/API.md §Privacy egress rewritten.
- **nqugc:** added `(not (:sensitive? trace-event))` guard to the canonical `register-listener!` worked example in spec/009 so the copy site teaches the safe pattern.
- **7b1z4:** fixed stale spec/008 focus-panel enum 7→6 (dropped `:issues`, removed in rf2-gbz39); cited `focus.cljc/valid-panels` as single source of truth.

## Scope
tools/xray src + test + tools/xray/spec + spec/008 + spec/009 (worked-example guard, surgical, sole-toucher). No spec/API.md or Conventions.

## Quality gates
- xray `clojure -M:test`: **1038 tests / 4146 assertions, 0F0E**
- `npm run test:cljs`: **5159 / 17438, 0F0E** (incl. new egress regression tests)
- `npm run test:xray-feature-gate`: **16 scenarios, 0 failures**
- clj-kondo: 0 errors, 2 warnings (both pre-existing on baseline)
- `mkdocs build --strict`: clean