### PR TITLE
feat(story): freeze the unified schema-backed run-result contract; retire :passing? (rf2-3nbl5.6)

### DIFF
--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -37,6 +37,17 @@ assembles this shape through `re-frame.story.result/run-result`; the MCP
 handlers project its slots (scrubbing the value-bearing ones at egress)
 rather than re-deriving a verdict.
 
+**Frozen, schema-backed contract (rf2-3nbl5.6).** This unified shape is a
+**frozen public contract** — the ONE result language spoken IDENTICALLY
+across the CLJS test surface, the Story UI Test mode, and these MCP tools.
+A result object crosses the MCP boundary with **NO semantic translation**:
+the wire payload is the SAME `:status` / `:assertions` / `:checks` /
+`:consumed-selectors` shape the CLJS boundary minted, validated by the
+SAME Malli schema (`re-frame.story.result/RunResult`, re-exported as
+`story/run-result-schema`). The cross-surface round-trip
+(CLJS → Story UI → MCP) is gated by
+`re-frame.story-mcp.run-result-roundtrip-test`.
+
 **Clean break (pre-alpha, Mike 2026-05-31).** The pre-unification flat
 shape (`:passing?` boolean, the `:lifecycle` *verdict*, a flat
 `:assertions` vector with no `:status`) is REMOVED outright — NO compat

--- a/tools/story-mcp/test/re_frame/story_mcp/run_result_roundtrip_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/run_result_roundtrip_test.clj
@@ -1,0 +1,171 @@
+(ns re-frame.story-mcp.run-result-roundtrip-test
+  "The rf2-3nbl5.6 ACCEPTANCE gate — the unified run-result is a FROZEN,
+  schema-backed public contract: ONE result language spoken IDENTICALLY
+  across the CLJS test surface, the Story UI Test mode, and story-mcp.
+
+  This is the cross-surface test the freeze ruling mandates: a result
+  object moves **CLJS test → Story UI → MCP with NO semantic translation**.
+  It lives in the story-mcp test corpus because that is the only artefact
+  on the require graph that can see ALL THREE surfaces at once:
+
+  - the CLJS run boundary — `re-frame.story.result/run-result` (the same
+    pure assembly `story/run` / `story/is` drive);
+  - the Story UI Test mode consumer — `re-frame.story.ui.state.tests`
+    (`aggregate-summary` + `record-test-run`, the `.cljc` the sidebar dot
+    and Test pane read);
+  - the MCP serialisation path — `run-variant` / `read-failures` through
+    the live `wire-pipeline/invoke-tool` boundary.
+
+  The contract: the verdict is `:status` (`result-status` / `result-passed?`);
+  there is NO `:passing?` boolean and NO lifecycle-as-verdict (the clean
+  break, rf2-ba86n.17). Every surface reads `:status` off the SAME object
+  with NO translation shim, and every surface's object conforms to the ONE
+  Malli schema (`story/run-result-schema`)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.schemas :as schemas]
+            [re-frame.story :as story]
+            [re-frame.story.recorder :as recorder]
+            [re-frame.story.result :as result]
+            [re-frame.story.ui.state.tests :as ui-tests]
+            [re-frame.story-mcp.config :as config]
+            [re-frame.story-mcp.tools.wire-pipeline :as wire-pipeline]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; ---- fixture: a booted Story registry with a real failing variant -------
+
+(defn reset-story
+  [t]
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (story/clear-all!)
+  (story/install-canonical-vocabulary!)
+  (config/set-allow-writes! false)
+  (config/set-allow-sensitive-reads! false)
+  (schemas/clear-schemas-by-frame!)
+  (recorder/clear!)
+  (story/reg-story :story.cart
+    {:doc "A cart." :component :app.ui/cart :tags #{:dev :test} :args {}})
+  ;; A variant carrying a REAL failing assertion (a path-equals against a
+  ;; value the run won't produce), so the round-trip exercises a :fail
+  ;; verdict end-to-end, not only the vacuous-green path.
+  (story/reg-variant :story.cart/red
+    {:doc "A failing cart variant."
+     :tags #{:dev :test}
+     :assertions [[:rf.assert/path-equals [:cart/total] 99]]})
+  (t))
+
+(use-fixtures :each reset-story)
+
+(defn- invoke [tool-name args]
+  (wire-pipeline/invoke-tool tool-name (merge {:dedup false} args)))
+
+;; ===========================================================================
+;; STEP 0 — the CLJS run boundary produces a result that IS the contract
+;; ===========================================================================
+
+(deftest cljs-result-conforms-to-the-frozen-schema
+  (testing "the pure CLJS run boundary emits a schema-valid run-result"
+    ;; This is the SAME assembly `story/run` / `story/is` drive — pure
+    ;; data → data, runnable under `clojure -M:test` with no host.
+    (let [green (result/run-result {:epoch-tape []})
+          red   (result/run-result
+                  {:assertions [{:assertion :rf.assert/path-equals
+                                 :payload [[:cart/total] 99]
+                                 :passed? false :expected 99 :actual nil}]})]
+      (is (story/valid-run-result? green)
+          (str "green result must conform; "
+               (story/explain-run-result green)))
+      (is (story/valid-run-result? red)
+          (str "red result must conform; "
+               (story/explain-run-result red)))
+      (is (= :pass (story/result-status green)))
+      (is (= :fail (story/result-status red)))
+      (is (true?  (story/result-passed? green)))
+      (is (false? (story/result-passed? red)))
+      (is (not (contains? green :passing?)) "NO :passing? boolean — the clean break")
+      (is (not (contains? red   :passing?))))))
+
+;; ===========================================================================
+;; THE ROUND-TRIP — ONE object, three surfaces, NO translation
+;; ===========================================================================
+
+(deftest result-moves-cljs-to-ui-to-mcp-with-no-translation
+  (testing "a CLJS run-result is consumed UNCHANGED by Story UI Test mode
+            AND serialised UNCHANGED through the story-mcp run-variant path —
+            same keys, same :status, no shim anywhere"
+    ;; --- Surface 1: the CLJS run-result (the pure boundary). -------------
+    (let [cljs-result
+          (result/run-result
+            {:variant/id :story.cart/red
+             :assertions [{:assertion :rf.assert/path-equals
+                           :payload [[:cart/total] 99]
+                           :passed? false :expected 99 :actual nil}]})]
+
+      (is (story/valid-run-result? cljs-result))
+      (is (= :fail (story/result-status cljs-result)))
+
+      ;; --- Surface 2: Story UI Test mode reads :status off the SAME ------
+      ;; object. No translation: aggregate-summary buckets by each record's
+      ;; unified :status, and record-test-run writes the run-level :status
+      ;; straight through to the sidebar dot.
+      (let [summary (assoc (ui-tests/aggregate-summary (:assertions cljs-result))
+                           :status (:status cljs-result))
+            ui-state (ui-tests/record-test-run {} :story.cart/red summary)
+            ui-status (ui-tests/variant-test-status ui-state :story.cart/red)]
+        (is (= 1 (:failed summary)) "the UI fold sees the failing record")
+        (is (false? (:all-passed? summary)))
+        (is (= :fail ui-status)
+            "Story UI Test mode reports the SAME verdict, read off the same :status"))
+
+      ;; --- Surface 3: story-mcp serialises the SAME shape over the wire. --
+      ;; A live run-variant produces the unified result through the very
+      ;; same `result/run-result` assembly; the MCP handler PROJECTS its
+      ;; slots (no re-derived verdict). We assert the wire payload speaks
+      ;; the identical language: a :status enum, NO :passing?, and the
+      ;; structuredContent conforms to the same frozen schema.
+      (let [wire   (invoke "run-variant" {:variant-id "story.cart/red"})
+            s      (:structuredContent wire)]
+        (is (vector? (:content wire)))
+        (is (= :story.cart/red (:frame s)))
+        (is (= :fail (:status s))
+            "the MCP wire verdict is the SAME :status the CLJS boundary minted")
+        (is (= (story/result-status cljs-result) (:status s))
+            "CLJS :status == MCP :status — one language, no translation")
+        (is (not (contains? s :passing?))
+            "the retired :passing? boolean never appears on the wire")
+        (is (story/valid-run-result? s)
+            (str "the MCP wire payload conforms to the SAME frozen schema; "
+                 (story/explain-run-result s)))))))
+
+;; ===========================================================================
+;; ACCESSOR AGREEMENT — result-passed? agrees with result-status everywhere
+;; ===========================================================================
+
+(deftest result-passed-agrees-with-result-status
+  (testing "result-passed? is true IFF result-status is :pass — for every verdict"
+    (doseq [[status result] [[:pass       {:status :pass       :assertions [] :checks [] :consumed-selectors #{}}]
+                             [:fail       {:status :fail       :assertions [] :checks [] :consumed-selectors #{}}]
+                             [:cannot-run {:status :cannot-run :assertions [] :checks [] :consumed-selectors #{}}]
+                             [:error      {:status :error      :assertions [] :checks [] :consumed-selectors #{}}]]]
+      (is (story/valid-run-result? result) (str status " result must conform"))
+      (is (= status (story/result-status result)))
+      (is (= (= :pass status) (story/result-passed? result))
+          (str "result-passed? must agree with :status for " status)))))
+
+;; ===========================================================================
+;; read-failures rides the SAME contract (the re-read path)
+;; ===========================================================================
+
+(deftest read-failures-speaks-the-same-status-language
+  (testing "a run then read-failures both report :status — no :passing? boolean"
+    (config/set-allow-writes! true)
+    (invoke "run-variant" {:variant-id "story.cart/red"})
+    (let [rf (invoke "read-failures" {:variant-id "story.cart/red"})
+          s  (:structuredContent rf)]
+      (is (contains? s :status) "read-failures carries the unified verdict")
+      (is (not (contains? s :passing?)) "NO :passing? on read-failures either")
+      ;; the re-read aggregates the accumulator (no tape floor), but the
+      ;; failing path-equals record drives :fail through the same rule.
+      (is (= :fail (:status s))
+          "the failing record drives :fail via the same aggregation rule"))))

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1797,6 +1797,26 @@ is API-stable, but the storage/source of truth is one tape so Story UI,
 CI, docs, agents, and future golden/diff tools cannot disagree about what
 happened.
 
+**Schema-backed, frozen contract (rf2-3nbl5.6).** This shape is a
+**frozen public contract** — the ONE result language spoken IDENTICALLY
+across `story/run`, `story/is`, `story/render-variant`, the Story UI Test
+mode, story-mcp `run-variant` / `read-failures`, and generated run
+artifacts. A result object moves **CLJS test → Story UI → MCP with NO
+semantic translation**. The contract is **executable**: the Malli schema
+`re-frame.story.result/RunResult` (with `AssertionRecord` / `CheckRecord`,
+re-exported as `story/run-result-schema` + `story/valid-run-result?` /
+`story/explain-run-result`) is the statement of record, and the
+cross-surface round-trip is gated by
+`re-frame.story-mcp.run-result-roundtrip-test`. The map schema is
+deliberately **open** — the verdict + judgement + agreement-floor slots
+are pinned, while the evidential `.4` projections and the identity /
+timing / provenance slots (`:frame`, `:decorators`, …) ride along. The
+verdict is `:status`, read via `story/result-status` /
+`story/result-passed?`; there is **NO `:passing?` boolean** and **no
+lifecycle-as-verdict** (the clean break, rf2-ba86n.17 — a boolean could
+not express the distinct `:cannot-run` THIRD outcome, and a lifecycle
+state is the frame's mount state, not the run's judgement).
+
 ```clojure
 {:status :pass                          ; :pass | :fail | :cannot-run | :error
  :variant/id optional-keyword

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -1376,6 +1376,37 @@
   [result]
   (result/passed? result))
 
+;; ---- the frozen, schema-backed run-result contract (rf2-3nbl5.6) --------
+;;
+;; The unified run-result is a FROZEN public contract — the ONE result
+;; language spoken IDENTICALLY across `run` / `is` / `render-variant`, the
+;; Story UI Test mode, and story-mcp `run-variant` / `read-failures`. These
+;; re-export the executable Malli schema (`re-frame.story.result/RunResult`)
+;; + its validators so any surface (CI, MCP, the test corpus) can prove a
+;; result conforms without a parallel schema. The verdict is `:status`
+;; (`result-status` / `result-passed?`); there is NO `:passing?` boolean
+;; (the clean break, rf2-ba86n.17).
+
+(def run-result-schema
+  "Per spec/017 §Run result (rf2-3nbl5.6) — the frozen Malli schema for the
+  unified run-result. The ONE schema-backed contract Story UI, CI,
+  `clojure.test`, and story-mcp validate against (see
+  `re-frame.story.result/RunResult`)."
+  result/RunResult)
+
+(defn valid-run-result?
+  "Per spec/017 §Run result (rf2-3nbl5.6) — true iff `result` conforms to
+  the frozen `run-result-schema`. Pure data → data."
+  [result]
+  (result/valid-run-result? result))
+
+(defn explain-run-result
+  "Per spec/017 §Run result (rf2-3nbl5.6) — Malli explanation of why
+  `result` does NOT conform to the frozen `run-result-schema`, or nil when
+  it conforms. Pure data → data."
+  [result]
+  (result/explain-run-result result))
+
 (defn result->reports
   "Per spec/017 §Public execution API — project a unified `result` into the
   ordered vector of clojure.test report maps (`{:type :pass|:fail|:error

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -62,7 +62,8 @@
   `re-frame.core` / the DOM, so the whole assembly runs under
   `clojure -M:test`. The runner reads the tape + the accumulator and hands
   the vectors here; the assembly never touches the runtime."
-  (:require [re-frame.story.assertions    :as assertions]
+  (:require [malli.core                   :as m]
+            [re-frame.story.assertions    :as assertions]
             [re-frame.story.play.evidence :as evidence]
             [re-frame.story.requirements  :as requirements]))
 
@@ -80,6 +81,129 @@
                     not even attempt (the distinct THIRD status, §`:cannot-run`);
   - `:error`      — a handler / fx / step threw."
   #{:pass :fail :cannot-run :error})
+
+;; ===========================================================================
+;; THE SCHEMA-BACKED CONTRACT  (rf2-3nbl5.6 — API governance freeze)
+;; ===========================================================================
+;;
+;; The unified run-result is a FROZEN, schema-backed public contract: the ONE
+;; result language spoken IDENTICALLY across `story/run`, `story/is`,
+;; `story/render-variant`, the Story UI Test mode, story-mcp `run-variant` /
+;; `read-failures`, and generated run artifacts. A result object moves
+;; CLJS test → Story UI → MCP with NO semantic translation — these Malli
+;; schemas are the executable statement of that contract (spec/017 §Run
+;; result). They are plain Malli forms (`metosin/malli`), survive `:advanced`
+;; (plain data), and run on both JVM + CLJS.
+;;
+;; The verdict is `:status` (an `Status` enum) — there is NO `:passing?`
+;; boolean and NO lifecycle-as-verdict (the clean break, rf2-ba86n.17): a
+;; boolean could not express the distinct `:cannot-run` THIRD outcome, and a
+;; lifecycle state (`:ready` / `:error`) is the frame's mount state, not the
+;; run's judgement. The accessors are `result-status` / `result-passed?`
+;; (re-exported from `re-frame.story`); a green/red bit is DERIVED from
+;; `:status`, never stored.
+;;
+;; The map schemas are deliberately OPEN (`{:closed false}`): the load-bearing
+;; contract slots (`:status` + the judgement / evidence slots) are pinned, but
+;; a runner / MCP / artifact layer MAY carry additional provenance slots
+;; (`:frame`, `:decorators`, `:rendered-hiccup`, `:snapshot`, …) without
+;; breaking the contract. What is frozen is the SHARED vocabulary every
+;; surface reads, not an exhaustive key list.
+
+(def Status
+  "The frozen verdict enum (spec/017 §Run result). The ONE field every
+  run / assertion / check carries — `:pass` | `:fail` | `:cannot-run` |
+  `:error`. Replaces the retired `:passing?` boolean (it could not express
+  the `:cannot-run` THIRD status)."
+  (into [:enum] statuses))
+
+(def AssertionRecord
+  "Malli schema for ONE evaluated assertion record (spec/017 §Run result —
+  Assertion record). `:status` is the frozen verdict; `:passed?` is the
+  legacy boolean kept ONLY as a diagnostic mirror (the verdict is
+  `:status`). Open map — the `.18` atom fields and source-coords ride
+  along."
+  [:map {:closed false}
+   [:assertion   {:optional true} :keyword]
+   [:status      Status]
+   [:passed?     {:optional true} [:maybe :boolean]]
+   [:payload     {:optional true} [:sequential :any]]
+   [:expected    {:optional true} :any]
+   [:actual      {:optional true} :any]
+   [:reason      {:optional true} [:maybe [:or :keyword :string]]]
+   [:cannot-run? {:optional true} :boolean]
+   [:source      {:optional true} :any]
+   [:elapsed-ms  {:optional true} [:maybe number?]]])
+
+(def CheckRecord
+  "Malli schema for ONE check record (spec/017 §Run result — Check record)
+  — a named check id grouping the assertion records its assertions
+  produced. `:status` aggregates the group via the ONE aggregation rule."
+  [:map {:closed false}
+   [:check      :keyword]
+   [:status     Status]
+   [:assertions [:vector AssertionRecord]]])
+
+(def RunResult
+  "Malli schema for the ONE unified run-result (spec/017 §Run result) — the
+  FROZEN public contract every Story runner, Test mode, CI, `clojure.test`
+  / `cljs.test`, and story-mcp consume IDENTICALLY. Open map: the verdict
+  + judgement + agreement-floor slots are pinned; the evidential `.4`
+  projections and the identity / timing / provenance slots are optional
+  (a host without the epoch artefact omits the evidential ones; a bare
+  re-read like `read-failures` omits the tape-floor slots).
+
+  The frozen, always-present slots:
+
+  - `:status`             — the verdict (`Status`); the headline every
+                            surface reads.
+  - `:assertions`         — the unified assertion records.
+  - `:checks`             — the named check-record groups.
+  - `:consumed-selectors` — the agreement-floor's exactly-consumed
+                            schema-violation selector set (the single
+                            source of truth Test mode reads, never
+                            re-derives). Always present (`#{}` when empty)."
+  [:map {:closed false}
+   [:status             Status]
+   [:assertions         [:vector AssertionRecord]]
+   [:checks             [:vector CheckRecord]]
+   [:consumed-selectors [:set :any]]
+   ;; identity / timing (the API-stable provenance slots) — optional
+   [:variant/id      {:optional true} :keyword]
+   [:plan-hash       {:optional true} [:maybe :string]]
+   [:run-hash        {:optional true} [:maybe :string]]
+   [:runner          {:optional true} :any]
+   [:required-runner {:optional true} [:maybe [:set :any]]]
+   [:fidelity        {:optional true} [:maybe [:set :any]]]
+   [:elapsed-ms      {:optional true} [:maybe number?]]
+   [:app-db          {:optional true} :any]
+   ;; evidential `.4` projections — optional (a host without the epoch
+   ;; artefact projects empty / omits these)
+   [:epoch-tape        {:optional true} [:sequential :any]]
+   [:narrative         {:optional true} [:sequential :any]]
+   [:schema-violations {:optional true} [:sequential :any]]
+   [:warnings          {:optional true} [:sequential :any]]
+   [:effects           {:optional true} [:sequential :any]]
+   [:sub-runs          {:optional true} [:sequential :any]]
+   [:renders           {:optional true} [:sequential :any]]
+   [:reactive-counts   {:optional true} :map]
+   ;; the run-level :cannot-run refusals, present iff the runner could not
+   ;; attempt some expectation
+   [:cannot-run {:optional true} [:sequential :any]]])
+
+(defn valid-run-result?
+  "True iff `result` conforms to the frozen `RunResult` contract
+  (rf2-3nbl5.6). Pure data → data — the executable check Test mode / CI /
+  MCP / the test corpus run to prove a result speaks the ONE language."
+  [result]
+  (m/validate RunResult result))
+
+(defn explain-run-result
+  "Malli explanation of why `result` does NOT conform to the frozen
+  `RunResult` contract, or nil when it conforms. Pure data → data — the
+  diagnostic companion to `valid-run-result?`."
+  [result]
+  (m/explain RunResult result))
 
 (defn record-status
   "Derive the `:status` for ONE assertion record from its outcome fields.

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -16,6 +16,7 @@
   - schema / warning / effect projections AGREE with the epoch tape;
   - `story/is` reports per assertion (`result->reports`)."
   (:require [clojure.test :refer [deftest is testing]]
+            [malli.core               :as m]
             [re-frame.epoch.capture   :as capture]
             [re-frame.story.result   :as result]
             [re-frame.story.play.evidence :as evidence]
@@ -651,3 +652,46 @@
     (is (false? (result/passed? {:status :fail})))
     (is (false? (result/passed? {:status :cannot-run})))
     (is (false? (result/passed? {:status :error})))))
+
+;; ===========================================================================
+;; THE FROZEN SCHEMA-BACKED CONTRACT  (rf2-3nbl5.6)
+;; ===========================================================================
+
+(deftest run-result-schema-accepts-every-assembled-result
+  (testing "every shape `run-result` assembles conforms to the frozen RunResult"
+    (doseq [parts [{}                                   ; vacuous green
+                   {:epoch-tape []}                     ; clean tape
+                   {:assertions [{:assertion :rf.assert/path-equals
+                                  :payload [[:k] 1] :passed? false}]}
+                   {:variant/id :story.x/y :plan-hash "p" :run-hash "r"
+                    :runner :headless :elapsed-ms 3
+                    :assertions [{:assertion :rf.assert/path-equals
+                                  :payload [[:k] 1] :passed? true}]}
+                   {:epoch-tape [(epoch {:trace-events
+                                         [{:operation :rf.error/schema-validation-failure
+                                           :tags {:where :event :failing-id :x}}]})]}]]
+      (let [r (result/run-result parts)]
+        (is (result/valid-run-result? r)
+            (str "assembled result must conform: " (pr-str (result/explain-run-result r))))))))
+
+(deftest run-result-schema-pins-the-verdict-and-rejects-passing
+  (testing ":status is required and must be one of the four verdicts"
+    (is (result/valid-run-result? {:status :pass :assertions [] :checks [] :consumed-selectors #{}}))
+    (is (not (result/valid-run-result? {:status :green :assertions [] :checks [] :consumed-selectors #{}}))
+        "an unknown verdict is rejected")
+    (is (not (result/valid-run-result? {:assertions [] :checks [] :consumed-selectors #{}}))
+        ":status is required — there is no verdict-less result"))
+  (testing "the load-bearing slots are required"
+    (is (not (result/valid-run-result? {:status :pass}))
+        ":assertions / :checks / :consumed-selectors are part of the contract")))
+
+(deftest assertion-and-check-records-carry-the-frozen-status
+  (testing "assertion records validate with a unified :status"
+    (is (m/validate result/AssertionRecord
+                    {:assertion :rf.assert/path-equals :status :fail :passed? false}))
+    (is (not (m/validate result/AssertionRecord
+                         {:assertion :rf.assert/path-equals :passed? false}))
+        ":status is the verdict — an assertion record without it does not conform"))
+  (testing "check records group assertion records under a :status"
+    (is (m/validate result/CheckRecord
+                    {:check :checks/cart :status :pass :assertions []}))))


### PR DESCRIPTION
## What

Freezes the unified run-result as a **schema-backed public contract** (rf2-3nbl5.6, Mike-ruled A) — the ONE result language spoken IDENTICALLY across `story/run`, `story/is`, `render-variant`, the Story UI Test mode, story-mcp `run-variant` / `read-failures`, and generated run artifacts. A result object moves **CLJS test → Story UI → MCP with NO semantic translation**.

### The schema + accessors

- **`re-frame.story.result/RunResult`** (+ `AssertionRecord` / `CheckRecord`) — the executable Malli statement of the contract, defined in the Story artifact's own result boundary (where the constructors + accessors already live). Open maps: the verdict + judgement + agreement-floor slots are pinned (`:status` / `:assertions` / `:checks` / `:consumed-selectors`); the evidential `.4` projections + identity/timing/provenance slots ride along.
- **`valid-run-result?` / `explain-run-result`** helpers; re-exported from `re-frame.story` as `run-result-schema` / `valid-run-result?` / `explain-run-result`.
- The verdict is **`:status`** read via `result-status` / `result-passed?`. **No `:passing?` boolean, no lifecycle-as-verdict** (the clean break — `:passing?` had already been retired at the MCP boundary by rf2-ba86n.17; this PR adds the schema backing on top and keeps the break clean).

### The end-to-end round-trip test

`tools/story-mcp/test/re_frame/story_mcp/run_result_roundtrip_test.clj` — the acceptance gate. One `result/run-result` object (the same pure assembly `run`/`is` drive) is:
1. validated against the frozen schema at the CLJS boundary;
2. consumed UNCHANGED by Story UI Test mode (`ui.state.tests/aggregate-summary` + `record-test-run`, reading `:status` off the same object);
3. serialised UNCHANGED through the live story-mcp `run-variant` wire path — same keys, same `:status`, payload conforms to the SAME schema. Plus `result-passed?` agrees with `result-status` for all four verdicts, and `read-failures` rides the same `:status` language.

### Spec reflection

Frozen-contract notes added to the **tool specs** only: `tools/story/spec/017-Testing-Story.md` §Run result + `tools/story-mcp/spec/002-Tool-Registry.md` §The unified run-result. **No repo-root hot-zone spec touched** (spec/API.md, spec/Spec-Schemas.md, spec/017 untouched).

## Quality gates

| Gate | Result |
|---|---|
| story `clojure -M:test` | 1556 tests, 5797 assertions, **0 failures, 0 errors** |
| story-mcp `clojure -M:test` | 200 tests, 1028 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` | 5169 tests, 17558 assertions, **0 failures, 0 errors** |
| `npm run test:mcp-conformance` | **ALL GATES GREEN** (6/6, incl. wire-vocab 49 tests / 623 assertions) |
| clj-kondo (changed files) | errors: 0, warnings: 0 |
| `mkdocs build --strict` | built, **no warnings/errors** |
| `git grep -n ":passing?"` | clean — every hit is a negation / historical / absence-assertion; **no live `:passing?` key** anywhere |

### Notes

- `skills/re-frame2-pair/references/stories.md` + `recipes.md` carry stale `:passing?` examples describing the legacy MCP output shape. These are **outside this worker's owned surface** (skills/, not tools/story or tools/story-mcp) — flagged for a separate doc-drift fixup, not edited here.
- Related bead rf2-ch591 (story API.md omits run/is/explain + run-result) is SEPARATE and untouched; this PR does not contradict it.