### PR TITLE
feat(ssr): client hydration boot helper + ssr-ring payload-opt consolidation + on-error/error-view signpost (rf2-lq2ou rf2-pffil rf2-s2ndr)

### DIFF
--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -145,18 +145,18 @@
                       :failed? failed?}))
                  continuations)
            render-hash (rf/with-frame fid (ssr/render-tree-hash hiccup))
-           ;; Hydration-payload policy is explicit + fail-closed. This
-           ;; example's app-db is structurally safe to
-           ;; expose end-to-end (every key the dashboard handlers
-           ;; populate is intended for the client), so we opt in with
-           ;; `:payload-policy :rf.ssr.payload/whole-app-db`. A real
-           ;; production deployment would normally pass `:payload-keys`
-           ;; with an explicit allowlist of top-level app-db keys.
+           ;; Hydration-payload policy is explicit + fail-closed, carried
+           ;; by the single `:payload` opt. This example's app-db is
+           ;; structurally safe to expose end-to-end (every key the
+           ;; dashboard handlers populate is intended for the client), so
+           ;; we opt in with `:payload :rf.ssr.payload/whole-app-db`. A
+           ;; real production deployment would normally pass `:payload`
+           ;; with an explicit vector allowlist of top-level app-db keys.
            final-payload (rf/with-frame fid
                            (ssr/streaming-build-final-payload
                              fid render-hash
-                             {:version        1
-                              :payload-policy :rf.ssr.payload/whole-app-db}))
+                             {:version 1
+                              :payload :rf.ssr.payload/whole-app-db}))
            _ (rf/destroy-frame! fid)]
        {:shell shell-html
         :resolved-chunks resolved-chunks

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -16,7 +16,7 @@
   for this adapter: the hydration payload built from `app-db` cannot
   carry server-only response data (Set-Cookie auth tokens, internal
   `X-*` headers, redirect targets) by accident — the boundary is
-  enforced at the storage layer rather than via `:payload-keys`
+  enforced at the storage layer rather than via `:payload` allowlist
   filtering on every host endpoint. `build-payload` (in
   `re-frame.ssr.ring.payload`) ships the app-db slice exactly because
   the accumulator is structurally outside app-db.
@@ -164,32 +164,71 @@
     :version        — hydration payload's `:rf/version` (default 1).
     :schema-digest  — hydration payload's `:rf/schema-digest`, when
                       the app participates in the digest check.
-    :payload-keys   — Allowlist (recommended): a non-empty sequential
-                      coll of top-level app-db keys to ship in the
-                      payload's `:rf/app-db`. Other keys are dropped,
-                      including any keys added later as the app evolves.
-                      The recommended primary mechanism per the
-                      explicit fail-closed policy contract (rf2-gtgf9).
-    :payload-policy — Explicit policy keyword. The only currently-
-                      recognised value is
-                      `:rf.ssr.payload/whole-app-db`, which opts into
-                      shipping the whole `app-db`. Use only when the
-                      app's `app-db` is structurally safe to expose
-                      end-to-end. Mutually exclusive with
-                      `:payload-keys` (allowlist wins when both are
-                      passed; that's not a contradiction since the
-                      allowlist is a more-restrictive policy choice).
-                      One of `:payload-keys` or `:payload-policy`
-                      MUST be passed; absence of both throws
-                      `:rf.error/ssr-missing-payload-policy` at
-                      handler-construction time.
+    :payload        — Hydration-payload policy — REQUIRED, fail-closed
+                      (rf2-gtgf9; single-opt consolidation rf2-pffil).
+                      One opt, two shapes:
+                        • a non-empty VECTOR of top-level app-db keys —
+                          an allowlist (recommended). Only the listed
+                          keys ship in the payload's `:rf/app-db`; every
+                          other key is dropped, including keys added
+                          later as the app evolves.
+                        • the KEYWORD `:rf.ssr.payload/whole-app-db` —
+                          opts into shipping the whole `app-db`. Use only
+                          when the app's `app-db` is structurally safe to
+                          expose end-to-end.
+                      Absence throws `:rf.error/ssr-missing-payload-policy`
+                      at handler-construction time; an unrecognised
+                      keyword throws `:rf.error/ssr-unknown-payload-policy`.
+                      The single opt removes the prior surface's
+                      precedence/silent-ignore ambiguity — one value holds
+                      exactly one policy; the allowlist-vs-whole choice is
+                      the value's shape, not a contest between two opts.
     :html-shell     — (body-html payload-edn opts) → string. Defaults
                       to `default-html-shell`. Replace to inject custom
                       <head>, scripts, JSON-LD, etc.
     :content-type   — Content-Type header for HTML responses. Default
                       \"text/html; charset=utf-8\" (matches the SSR
                       runtime's default in the response accumulator).
-    :on-error       — (request throwable) → ring-response. Called when
+
+  ---- :on-error vs :error-view — the error-handling division (rf2-s2ndr) ----
+
+  TWO error opts handle TWO different failures. They are NOT alternatives;
+  a robust deployment usually wires BOTH. Pick by asking \"which failure
+  am I handling?\":
+
+  | Question                          | :error-view             | :on-error                        |
+  |-----------------------------------|-------------------------|----------------------------------|
+  | WHICH failure?                    | An exception INSIDE the | A transport / Ring-layer failure |
+  |                                   | re-frame drain or the   | the projector CANNOT see —       |
+  |                                   | render walk — something | per-request frame setup throw,   |
+  |                                   | the error PROJECTOR     | a render-time CLJ exception,     |
+  |                                   | catches.                | a header/cookie materialise      |
+  |                                   |                         | throw, a thrown `:on-create`.    |
+  | WHAT does it produce?             | The PROJECTED ERROR     | A raw Ring response map          |
+  |                                   | PAGE body (hiccup) — a  | `{:status … :headers … :body …}` |
+  |                                   | view keyword or         | returned verbatim to the server. |
+  |                                   | `(public-error)→hiccup` |                                  |
+  |                                   | fn, rendered through    |                                  |
+  |                                   | the SSR emitter.        |                                  |
+  | WHAT is its INPUT?                | The PUBLIC-ERROR map    | The raw `(request throwable)` —  |
+  |                                   | (sanitised by the       | the UNSANITISED throwable. The   |
+  |                                   | projector — safe to     | locked default NEVER reads it    |
+  |                                   | render).                | (rf2-kzvwq `.getMessage` leak).  |
+  | WHICH HTTP path?                  | Normal response with    | Last-resort net OUTSIDE the      |
+  |                                   | the projector's status  | normal pipeline (the projector   |
+  |                                   | (typically 500) + the   | never ran / can't run).          |
+  |                                   | rendered page.          |                                  |
+  | DEFAULT when omitted?             | Minimal default error   | Minimal locked 500 (\"Internal   |
+  |                                   | template.               | error\", topology-leak-safe).    |
+
+  Mnemonic: `:error-view` is the PROJECTED page (drain-time, sanitised,
+  hiccup); `:on-error` is the TRANSPORT net (Ring-layer, raw throwable,
+  outside the projector). A buggy `:error-view` falls back to the default
+  error template; a buggy `:on-error` falls back to `default-on-error`
+  (`safe-on-error`, rf2-ljjh0) — NEITHER bypasses the error boundary.
+
+    :on-error       — (request throwable) → ring-response. The TRANSPORT/
+                      Ring-layer error net (see table above). Called when
                       the per-request frame setup OR a Ring-layer /
                       transport failure the projector can't see throws.
                       Defaults to a minimal 500 response. NOTE: normal

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -295,11 +295,12 @@
        `:on-create` would otherwise fail per-request inside
        `setup-request-frame!`; one without `:root-view` would fail inside
        the writer thread, truncating the chunked response (rf2-ee38b.11).
-    2. hydration-payload policy (`:payload-keys` / `:payload-policy`) via
+    2. hydration-payload policy (the single `:payload` opt — vector
+       allowlist or whole-app-db keyword) via
        `payload-policy/validate-policy-opts!` — throws
        `:rf.error/ssr-missing-payload-policy` (or
        `:rf.error/ssr-unknown-payload-policy` on a typo'd policy) per
-       rf2-gtgf9.
+       rf2-gtgf9 / rf2-pffil.
     3. trusted-shell-hook shape (`:head` / `:body-end` / `:script-src` /
        `:app-element-id` are strings or nil) via
        `trust/validate-trusted-shell-opts!` — both shells inject these

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
@@ -32,10 +32,11 @@
   and client read from the same source.
 
   The `:rf/app-db` slice is projected per the explicit, fail-closed
-  policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9):
-  callers MUST declare `:payload-keys` (allowlist, recommended) or
-  `:payload-policy :rf.ssr.payload/whole-app-db` (explicit opt-in to
-  shipping the whole `app-db`). Absence of both throws
+  policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9,
+  rf2-pffil single-opt consolidation): callers MUST declare `:payload`
+  as either a vector allowlist of top-level keys (recommended) or the
+  keyword `:rf.ssr.payload/whole-app-db` (explicit opt-in to shipping
+  the whole `app-db`). Absence throws
   `:rf.error/ssr-missing-payload-policy`. The host adapter validates
   at handler-construction time so misconfigured deployments fail at
   boot, not at first request.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -245,8 +245,8 @@
   doesn't need the binding; it sits outside the block to keep that
   explicitness visible."
   [frame-id resp
-   {:keys [root-view emit-hash? version schema-digest payload-keys
-           payload-policy html-shell content-type]
+   {:keys [root-view emit-hash? version schema-digest payload
+           html-shell content-type]
     :as   opts}]
   (let [;; Single `with-frame` block covers the three frame-aware
         ;; stages: root-view resolution (a 0-arity fn may close over
@@ -293,12 +293,11 @@
         ;; load-bearing (a continuation drain inside the walker may
         ;; mutate app-db; the payload must reflect the post-walk value).
         app-db      (rf/frame-db frame-id)
-        payload     (payload/build-payload frame-id app-db hash-str
-                                           {:version        version
-                                            :schema-digest  schema-digest
-                                            :payload-keys   payload-keys
-                                            :payload-policy payload-policy})
-        payload-edn (pr-str payload)
+        rf-payload  (payload/build-payload frame-id app-db hash-str
+                                           {:version       version
+                                            :schema-digest schema-digest
+                                            :payload       payload})
+        payload-edn (pr-str rf-payload)
         shell-opts  (assoc opts
                            :head        head-html
                            :html-attrs  html-attrs

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -130,8 +130,8 @@
   stream cleanly so the Ring server can EOF the response."
   [^OutputStream out frame-id resp opts]
   (try
-    (let [{:keys [root-view emit-hash? version schema-digest payload-keys
-                  payload-policy content-type]} opts
+    (let [{:keys [root-view emit-hash? version schema-digest payload
+                  content-type]} opts
           hiccup     (rf/with-frame frame-id
                        (lifecycle/resolve-root-view root-view))
           {:keys [head-html html-attrs body-attrs]}
@@ -161,10 +161,9 @@
             final-payload (rf/with-frame frame-id
                             (streaming/build-final-payload
                               frame-id final-hash
-                              {:version        version
-                               :schema-digest  schema-digest
-                               :payload-keys   payload-keys
-                               :payload-policy payload-policy}))]
+                              {:version       version
+                               :schema-digest schema-digest
+                               :payload       payload}))]
         ;; Shared id-pinned, `</script>`-escaped payload <script>
         ;; (rf2-7ksyr) — same helper the non-streaming shell uses.
         (write-chunk! out (shell/payload-script-tag (pr-str final-payload))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
@@ -264,7 +264,7 @@
     (let [handler (ssr-ring/stream-handler
                     {:on-create [:rf.test.ozhy9/init]
                      :root-view [:rf.test.ozhy9/root]
-                     :payload-policy :rf.ssr.payload/whole-app-db})]
+                     :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client     (new-http-client)
               latch      (CountDownLatch. 1)
@@ -400,7 +400,7 @@
     (let [handler (ssr-ring/stream-handler
                     {:on-create [:rf.test.ozhy9/init]
                      :root-view [:rf.test.ozhy9/root]
-                     :payload-policy :rf.ssr.payload/whole-app-db})]
+                     :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client     (new-http-client)
               latch      (CountDownLatch. 1)
@@ -478,7 +478,7 @@
     (let [handler (ssr-ring/stream-handler
                     {:on-create [:rf.test.ozhy9/init]
                      :root-view [:rf.test.ozhy9/root]
-                     :payload-policy :rf.ssr.payload/whole-app-db})]
+                     :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client     (new-http-client)
               latch      (CountDownLatch. 1)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -293,7 +293,7 @@
           app ((ssr-ring/ssr-middleware
                  {:on-create      [:init/mw-blank]
                   :root-view      [:pages/mw-blank]
-                  :payload-policy :rf.ssr.payload/whole-app-db})
+                  :payload :rf.ssr.payload/whole-app-db})
                wrapped)
           response (app {:uri "/" :request-method :get})]
       (is (= 200 (:status response)) "GET matched the default predicate → SSR rendered")
@@ -311,7 +311,7 @@
           app ((ssr-ring/ssr-middleware
                  {:on-create      [:init/mw-blank]
                   :root-view      [:pages/mw-blank]
-                  :payload-policy :rf.ssr.payload/whole-app-db})
+                  :payload :rf.ssr.payload/whole-app-db})
                wrapped)]
       (doseq [method [:post :put :delete :head]]
         (reset! wrapped-called false)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -307,7 +307,7 @@
     (let [handler (ssr-ring/stream-handler
                     {:on-create [:rf.test.server/init]
                      :root-view [:test/root]
-                     :payload-policy :rf.ssr.payload/whole-app-db})]
+                     :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client   (new-http-client)
               req      (http-get-request port "/")
@@ -375,7 +375,7 @@
           handler        (ssr-ring/stream-handler
                            {:on-create [:rf.test.server/init-min]
                             :root-view throwing-root
-                            :payload-policy :rf.ssr.payload/whole-app-db})]
+                            :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client   (new-http-client)
               req      (http-get-request port "/")
@@ -447,7 +447,7 @@
       (let [handler  (ssr-ring/stream-handler
                        {:on-create [:rf.test.server/init]
                         :root-view [:test/parking-root]
-                        :payload-policy :rf.ssr.payload/whole-app-db})
+                        :payload :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/" :request-method :get})
             drain    (future (with-open [^InputStream is (:body response)] (slurp is)))]
         (try
@@ -542,7 +542,7 @@
     (let [handler   (ssr-ring/stream-handler
                       {:on-create [:rf.test.server/init-bad-cookie]
                        :root-view [:test/big-root]
-                       :payload-policy :rf.ssr.payload/whole-app-db})
+                       :payload :rf.ssr.payload/whole-app-db})
           ;; Direct handler call (no Jetty needed — the throw is on the
           ;; request thread during head materialisation, before any
           ;; transport hand-off).

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -127,7 +127,7 @@
           handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.writer/init]
                       :root-view throwing-root
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           ;; Frame ids BEFORE the request — baseline.
           baseline-fids (disj (frame/frame-ids) :rf/default)
           response (handler {:uri "/" :request-method :get})

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
@@ -209,7 +209,7 @@
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/ok-bad-tag]
                      :root-view [:pages/bad-tag]
-                     :payload-policy :rf.ssr.payload/whole-app-db})]
+                     :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [{:keys [status body headers]} (http-get port "/")]
           (is (= 500 status)
@@ -264,7 +264,7 @@
     (let [handler-a (ssr-ring/ssr-handler
                       {:on-create [:init/ok-render-throw]
                        :root-view [:pages/render-throw]
-                       :payload-policy :rf.ssr.payload/whole-app-db})]
+                       :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler-a]
         (let [{status-a :status body-a :body} (http-get port "/")]
           (is (= 500 status-a))
@@ -282,7 +282,7 @@
           (let [handler-b (ssr-ring/ssr-handler
                             {:on-create [:init/drain-throw]
                              :root-view [:pages/drain-throw]
-                             :payload-policy :rf.ssr.payload/whole-app-db})]
+                             :payload :rf.ssr.payload/whole-app-db})]
             (with-jetty [port-b handler-b]
               (let [{status-b :status body-b :body} (http-get port-b "/")]
                 (is (= 500 status-b))
@@ -348,7 +348,7 @@
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/bad-cookie]
                      :root-view [:pages/bad-cookie-page]
-                     :payload-policy :rf.ssr.payload/whole-app-db})]
+                     :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [{:keys [status headers]} (http-get port "/")]
           (is (= 500 status)
@@ -394,7 +394,7 @@
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/bad-header]
                      :root-view [:pages/bad-header-page]
-                     :payload-policy :rf.ssr.payload/whole-app-db})]
+                     :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [{:keys [status headers]} (http-get port "/")]
           (is (= 500 status)
@@ -446,7 +446,7 @@
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/ok]
                      :root-view [:pages/greeting]
-                     :payload-policy :rf.ssr.payload/whole-app-db})]
+                     :payload :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [{:keys [status body headers]} (http-get port "/")]
           (is (= 200 status))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -66,7 +66,7 @@
     (let [handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.server/init]
                       :root-view [:test/root]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (drain-stream (:body response))
           ;; Indices into the body string — the wire-order invariant
@@ -103,7 +103,7 @@
     (let [handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.server/init]
                       :root-view [:test/multi-root]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (drain-stream (:body response))
           ;; Extract the order of resolved chunks by finding each id's
@@ -134,7 +134,7 @@
     (let [handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.server/init]
                       :root-view [:test/fragile-root]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (drain-stream (:body response))]
       (is (= 200 (:status response)) "stream still 200 — failure is partial-render-safe")
@@ -151,7 +151,7 @@
     (let [handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.server/init]
                       :root-view [:test/static-root]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (drain-stream (:body response))]
       (is (str/includes? body "<h1>Just static</h1>") "static content emitted")
@@ -188,7 +188,7 @@
     (let [handler       (ssr-ring/stream-handler
                           {:on-create [:rf.test.stream/redirect]
                            :root-view [:test/should-not-stream]
-                           :payload-policy :rf.ssr.payload/whole-app-db})
+                           :payload :rf.ssr.payload/whole-app-db})
           baseline-fids (disj (frame/frame-ids) :rf/default)
           response      (handler {:uri "/secret" :request-method :get})]
       ;; Redirect response shape — status + Location, empty body, no
@@ -227,7 +227,7 @@
     (let [handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.stream/redirect-ct]
                       :root-view [:test/redirect-ct-root]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/secret" :request-method :get})
           headers  (:headers response)
           ct       (or (get headers "Content-Type") (get headers "content-type"))]
@@ -241,7 +241,7 @@
       (let [ns-handler (ssr-ring/ssr-handler
                          {:on-create [:rf.test.stream/redirect-ct]
                           :root-view [:test/redirect-ct-root]
-                          :payload-policy :rf.ssr.payload/whole-app-db})
+                          :payload :rf.ssr.payload/whole-app-db})
             ns-resp    (ns-handler {:uri "/secret" :request-method :get})
             ns-ct      (or (get (:headers ns-resp) "Content-Type")
                            (get (:headers ns-resp) "content-type"))]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -206,7 +206,7 @@
                     {:on-create    [:rf/server-init]
                      :root-view    [:pages/articles]
                      :fx-overrides {:http/get :http/get.canned}
-                     :payload-policy :rf.ssr.payload/whole-app-db})
+                     :payload :rf.ssr.payload/whole-app-db})
           request {:uri            "/articles"
                    :request-method :get
                    :headers        {"user-agent" "test"}}
@@ -245,7 +245,7 @@
                     {:on-create    [:rf/server-init]
                      :root-view    [:pages/articles]
                      :fx-overrides {:http/get :http/get.canned}
-                     :payload-policy :rf.ssr.payload/whole-app-db})
+                     :payload :rf.ssr.payload/whole-app-db})
           frames-before (set (rf/frame-ids))
           response (handler {:uri "/" :request-method :get})
           frames-after (set (rf/frame-ids))]
@@ -277,7 +277,7 @@
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/redirect]
                      :root-view [:pages/should-not-render]
-                     :payload-policy :rf.ssr.payload/whole-app-db})
+                     :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/secret" :request-method :get})]
       (is (= 302 (:status response)))
       (let [headers (:headers response)
@@ -307,7 +307,7 @@
       (let [handler  (ssr-ring/ssr-handler
                        {:on-create [:init/redirect-no-target]
                         :root-view [:pages/noop-rt]
-                        :payload-policy :rf.ssr.payload/whole-app-db})
+                        :payload :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/secret" :request-method :get})
             headers  (:headers response)]
         (rf/unregister-listener! ::redirect-no-target-watch)
@@ -343,7 +343,7 @@
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/with-cookies]
                       :root-view [:pages/cookied]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           headers  (:headers response)
           set-cookie (or (get headers "Set-Cookie") (get headers "set-cookie"))]
@@ -380,7 +380,7 @@
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/ok]
                      :root-view [:pages/broken]
-                     :payload-policy :rf.ssr.payload/whole-app-db})
+                     :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/broken" :request-method :get})]
       (is (= 500 (:status response))
           "rf2-zwgsv: default projector's `:internal-error` shape →
@@ -434,7 +434,7 @@
                     {:on-create [:init/ok]
                      :root-view [:pages/broken-2]
                      :ssr       {:public-error-id :myapp/teapot}
-                     :payload-policy :rf.ssr.payload/whole-app-db})
+                     :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/broken" :request-method :get})]
       (is (= 418 (:status response))
           "the custom projector's :status overrides the default 500
@@ -475,7 +475,7 @@
                      {:on-create  [:init/ok]
                       :root-view  [:pages/broken-ev]
                       :error-view :myapp/error-page
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/broken" :request-method :get})
           body     (:body response)]
       (is (= 500 (:status response)) "projector status rides the response")
@@ -503,7 +503,7 @@
                                     [:section.fn-error
                                      [:h2 "fn error view"]
                                      [:span (:message public)]])
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/broken" :request-method :get})
           body     (:body response)]
       (is (= 500 (:status response)))
@@ -527,7 +527,7 @@
                         :root-view  [:pages/broken-evt]
                         :error-view (fn [_public]
                                       (throw (ex-info "error-view itself broke" {})))
-                        :payload-policy :rf.ssr.payload/whole-app-db})
+                        :payload :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/broken" :request-method :get})
             body     (:body response)]
         (rf/unregister-listener! ::error-view-throw-watch)
@@ -572,7 +572,7 @@
                         :root-view (fn []
                                      (swap! call-count inc)
                                      [:pages/once])
-                        :payload-policy :rf.ssr.payload/whole-app-db})
+                        :payload :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/once" :request-method :get})]
         (is (= 200 (:status response)))
         (is (= 1 @call-count)
@@ -601,7 +601,7 @@
                        {:on-create [:init/ok-noni]
                         :root-view (fn []
                                      [:pages/noni (swap! counter inc)])
-                        :payload-policy :rf.ssr.payload/whole-app-db})
+                        :payload :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/noni" :request-method :get})
             body     (:body response)
             wire-hash (second (re-find #"data-rf-render-hash=\"([0-9a-f]{8})\""
@@ -654,7 +654,7 @@
       (let [handler  (ssr-ring/ssr-handler
                        {:on-create [:init/capture-request-cofx]
                         :root-view [:pages/blank]
-                        :payload-policy :rf.ssr.payload/whole-app-db})
+                        :payload :rf.ssr.payload/whole-app-db})
             request  {:uri            "/articles/42"
                       :request-method :get
                       :headers        {"user-agent" "ring-adapter-test"
@@ -677,7 +677,7 @@
       (let [handler (ssr-ring/ssr-handler
                       {:on-create [:init/capture-frame-id]
                        :root-view [:pages/blank2]
-                       :payload-policy :rf.ssr.payload/whole-app-db})]
+                       :payload :rf.ssr.payload/whole-app-db})]
         (handler {:uri "/x" :request-method :get})
         (is (some? @captured-fid)
             "the on-create handler captured the per-request frame-id")
@@ -699,7 +699,7 @@
       (let [handler (ssr-ring/ssr-handler
                       {:on-create [:init/observe-request]
                        :root-view [:pages/blank3]
-                       :payload-policy :rf.ssr.payload/whole-app-db})]
+                       :payload :rf.ssr.payload/whole-app-db})]
         (handler {:uri "/a" :request-method :get})
         (handler {:uri "/b" :request-method :get})
         (is (= ["/a" "/b"] @observed)
@@ -733,7 +733,7 @@
                        :root-view [:pages/blank-for-ssr-opt]
                        :ssr       {:dev-error-detail? true
                                    :public-error-id   :myapp/projector}
-                       :payload-policy :rf.ssr.payload/whole-app-db})]
+                       :payload :rf.ssr.payload/whole-app-db})]
         (handler {:uri "/" :request-method :get})
         (is (= {:dev-error-detail? true
                 :public-error-id   :myapp/projector}
@@ -742,11 +742,11 @@
              — the destructure matches the documented key")))))
 
 ;; ===========================================================================
-;; ssr-handler — payload-keys slice
+;; ssr-handler — :payload allowlist slice
 ;; ===========================================================================
 
 (deftest handler-payload-keys-slices-app-db
-  (testing ":payload-keys ships a subset of app-db in the hydration payload"
+  (testing ":payload allowlist ships a subset of app-db in the hydration payload"
     (rf/reg-event-fx :init/many-keys
       {:platforms #{:server}}
       (fn [_ _]
@@ -759,7 +759,7 @@
     (let [handler (ssr-ring/ssr-handler
                     {:on-create    [:init/many-keys]
                      :root-view    [:pages/echo]
-                     :payload-keys [:public/articles]})
+                     :payload [:public/articles]})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -773,7 +773,7 @@
           "payload carries the public/articles key (either as
            qualified-keyword or as namespace-map shorthand)")
       (is (not (str/includes? body "secret-token"))
-          ":payload-keys omits server-only slices from the wire payload")
+          ":payload allowlist omits server-only slices from the wire payload")
       (is (not (str/includes? body "admin-flag"))))))
 
 ;; ===========================================================================
@@ -781,10 +781,10 @@
 ;;
 ;; The wire-level proof that the policy contract is fail-closed:
 ;;
-;;   1. A handler constructed with NEITHER `:payload-keys` NOR
-;;      `:payload-policy` throws at construction time
-;;      (`:rf.error/ssr-missing-payload-policy`). Misconfigured
-;;      deployments fail at boot rather than at first request.
+;;   1. A handler constructed with NO `:payload` opt throws at
+;;      construction time (`:rf.error/ssr-missing-payload-policy`).
+;;      Misconfigured deployments fail at boot rather than at first
+;;      request.
 ;;
 ;;   2. **The fail-closed proof** — when a handler is constructed
 ;;      with an allowlist that does NOT include a server-only key,
@@ -794,21 +794,21 @@
 ;;      (rf2-gtgf9: no default-whole-app-db fallback exists, so
 ;;      server-only keys cannot ride the wire silently).
 ;;
-;;   3. The opt-in branch — `:payload-policy
-;;      :rf.ssr.payload/whole-app-db` ships the whole app-db verbatim
-;;      (apps that genuinely want it can opt in explicitly).
+;;   3. The opt-in branch — `:payload :rf.ssr.payload/whole-app-db`
+;;      ships the whole app-db verbatim (apps that genuinely want it
+;;      can opt in explicitly).
 ;;
-;;   4. A typo'd `:payload-policy` keyword surfaces as
+;;   4. A typo'd `:payload` keyword surfaces as
 ;;      `:rf.error/ssr-unknown-payload-policy` — distinct from the
 ;;      missing-policy bucket so the developer can tell the two
 ;;      failure modes apart.
 ;; ===========================================================================
 
 (deftest handler-construction-fails-closed-when-no-policy-supplied
-  (testing "rf2-gtgf9: ssr-handler with neither :payload-keys nor
-            :payload-policy throws :rf.error/ssr-missing-payload-policy
-            at construction time — the canonical fail-closed pattern.
-            Misconfigured deployments fail at boot, not at first request."
+  (testing "rf2-gtgf9: ssr-handler with no :payload opt throws
+            :rf.error/ssr-missing-payload-policy at construction time —
+            the canonical fail-closed pattern. Misconfigured deployments
+            fail at boot, not at first request."
     (rf/reg-event-fx :init/no-policy {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/no-policy (fn [] [:div "no policy"]))
 
@@ -855,7 +855,7 @@
           #":rf\.error/ssr-ring-missing-on-create"
           (ssr-ring/ssr-handler
             {:root-view [:pages/no-oncreate]
-             :payload-policy :rf.ssr.payload/whole-app-db})))))
+             :payload :rf.ssr.payload/whole-app-db})))))
 
 (deftest stream-handler-construction-fails-closed-when-missing-on-create
   (testing "rf2-ee38b.11: stream-handler with no :on-create throws
@@ -867,7 +867,7 @@
           #":rf\.error/ssr-ring-missing-on-create"
           (ssr-ring/stream-handler
             {:root-view [:pages/no-oncreate-stream]
-             :payload-policy :rf.ssr.payload/whole-app-db})))))
+             :payload :rf.ssr.payload/whole-app-db})))))
 
 (deftest stream-handler-construction-fails-closed-when-missing-root-view
   (testing "rf2-ee38b.11: stream-handler with no :root-view throws
@@ -880,11 +880,11 @@
           #":rf\.error/ssr-ring-missing-root-view"
           (ssr-ring/stream-handler
             {:on-create [:init/no-rootview-stream]
-             :payload-policy :rf.ssr.payload/whole-app-db})))))
+             :payload :rf.ssr.payload/whole-app-db})))))
 
 (deftest fail-closed-proof-unpermitted-slot-not-on-wire
   (testing "rf2-gtgf9 FAIL-CLOSED PROOF: a server-only app-db key NOT in
-            the :payload-keys allowlist MUST NOT appear in the
+            the :payload allowlist MUST NOT appear in the
             hydration-payload script tag's EDN body. Without the
             allowlist gate an unaudited new app-db key would silently
             ride the wire on every request — the allowlist is load-
@@ -910,7 +910,7 @@
                       ;; un-permitted and MUST be dropped.
                       {:on-create    [:init/with-secret]
                        :root-view    [:pages/policy-probe]
-                       :payload-keys [:public/articles]})
+                       :payload [:public/articles]})
           response  (handler {:uri "/" :request-method :get})
           body      (:body response)
           payload-m (re-find #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
@@ -945,9 +945,9 @@
           "rf2-gtgf9: belt-and-braces over multiple un-permitted slots"))))
 
 (deftest payload-policy-whole-app-db-opt-in-ships-everything
-  (testing "rf2-gtgf9: explicit :payload-policy
-            :rf.ssr.payload/whole-app-db is the documented opt-in for
-            apps whose entire app-db is intended for the wire"
+  (testing "rf2-gtgf9: explicit :payload :rf.ssr.payload/whole-app-db is
+            the documented opt-in for apps whose entire app-db is intended
+            for the wire"
     (rf/reg-event-fx :init/wholeapp
       {:platforms #{:server}}
       (fn [_ _]
@@ -961,7 +961,7 @@
     (let [handler   (ssr-ring/ssr-handler
                       {:on-create      [:init/wholeapp]
                        :root-view      [:pages/wholeapp]
-                       :payload-policy :rf.ssr.payload/whole-app-db})
+                       :payload :rf.ssr.payload/whole-app-db})
           response  (handler {:uri "/" :request-method :get})
           body      (:body response)
           payload-m (re-find #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
@@ -976,8 +976,8 @@
           ":public/theme reached the wire under the whole-app-db opt-in"))))
 
 (deftest handler-construction-rejects-unknown-policy-keyword
-  (testing "rf2-gtgf9: a typo'd :payload-policy surfaces as a distinct
-            error so the developer can tell the failure modes apart"
+  (testing "rf2-gtgf9 / rf2-pffil: a typo'd :payload keyword surfaces as a
+            distinct error so the developer can tell the failure modes apart"
     (rf/reg-event-fx :init/typo-policy {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/typo-policy (fn [] [:div]))
 
@@ -985,10 +985,10 @@
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-unknown-payload-policy"
           (ssr-ring/ssr-handler
-            {:on-create      [:init/typo-policy]
-             :root-view      [:pages/typo-policy]
-             :payload-policy :rf.ssr.payload/whole-db})) ; typo
-        "typo'd policy keyword does NOT silently fall into the
+            {:on-create [:init/typo-policy]
+             :root-view [:pages/typo-policy]
+             :payload   :rf.ssr.payload/whole-db})) ; typo
+        "typo'd :payload keyword does NOT silently fall into the
          missing-policy bucket — the developer sees a distinct
          :rf.error/ssr-unknown-payload-policy")))
 
@@ -1020,7 +1020,7 @@
 
     (let [base-opts {:on-create    [:init/trusted-opt-test]
                      :root-view    [:pages/trusted-opt-test]
-                     :payload-keys [:public/x]}]
+                     :payload [:public/x]}]
 
       (testing "each of the four trusted-string opts is rejected when
                 supplied a non-string non-nil value (per the bead's
@@ -1100,7 +1100,7 @@
 
     (let [base-opts {:on-create    [:init/trusted-opt-stream]
                      :root-view    [:pages/trusted-opt-stream]
-                     :payload-keys [:public/x]}]
+                     :payload [:public/x]}]
       (testing "stream-handler rejects non-string non-nil values on
                 each of the four trusted-string opts"
         (doseq [[opt-k bad-val] [[:head            {:title "x"}]
@@ -1145,7 +1145,7 @@
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-route]
                       :root-view [:pages/blank-for-title]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)
           opens    (count (re-seq #"<title" body))
@@ -1167,7 +1167,7 @@
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/noop]
                       :root-view [:pages/blank-no-head]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)
           opens    (count (re-seq #"<title" body))]
@@ -1197,7 +1197,7 @@
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-no-title]
                       :root-view [:pages/blank-no-title]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -1237,7 +1237,7 @@
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-attrs-route]
                       :root-view [:pages/blank-attrs]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -1256,7 +1256,7 @@
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-attrs-route]
                       :root-view [:pages/blank-attrs]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -1274,7 +1274,7 @@
                      {:on-create [:init/seed-attrs-route]
                       :root-view [:pages/blank-attrs]
                       :lang      "ja"
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -1300,7 +1300,7 @@
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-attrs-route]
                       :root-view [:pages/blank-attrs]
-                      :payload-policy :rf.ssr.payload/whole-app-db})
+                      :payload :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -1334,7 +1334,7 @@
                             :root-view    [:pages/articles]
                             :fx-overrides {:http/get :http/get.canned}
                             :match?       (fn [req] (= "/ssr" (:uri req)))
-                            :payload-policy :rf.ssr.payload/whole-app-db})
+                            :payload :rf.ssr.payload/whole-app-db})
           app            (mw wrapped)]
 
       (let [fall-through-response (app {:uri "/api" :request-method :get})]
@@ -1353,7 +1353,7 @@
 ;; Privacy regression — per Spec 011 §Response storage substrate the HTTP
 ;; response accumulator MUST NOT ride `app-db`. Earlier drafts stored the
 ;; accumulator at `[:rf/response]` in the request frame's app-db; without
-;; explicit `:payload-keys` filtering, the hydration payload at
+;; explicit `:payload` allowlist filtering, the hydration payload at
 ;; `build-payload` shipped the whole app-db (with the accumulator's
 ;; server-only Set-Cookie / X-* headers / redirect locations) onto the
 ;; client wire. The rf2-jbcmt fix moved storage to a framework-private
@@ -1406,7 +1406,7 @@
     (let [handler   (ssr-ring/ssr-handler
                       {:on-create [:auth/login]
                        :root-view [:pages/dashboard]
-                       :payload-policy :rf.ssr.payload/whole-app-db})
+                       :payload :rf.ssr.payload/whole-app-db})
           response  (handler {:uri            "/dashboard"
                               :request-method :get
                               :headers        {"user-agent" "rf2-jbcmt-leak-probe"}})
@@ -1534,7 +1534,7 @@
       (let [handler  (ssr-ring/ssr-handler
                        {:on-create [:init/hostile]
                         :root-view [:pages/hostile-page]
-                        :payload-policy :rf.ssr.payload/whole-app-db})
+                        :payload :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/" :request-method :get})
             body     (:body response)]
         (is (= 200 (:status response)))
@@ -1850,7 +1850,7 @@
                         {:on-create      [:rf/server-init]
                          :root-view      [:pages/articles]
                          :fx-overrides   {:http/get :http/get.canned}
-                         :payload-policy :rf.ssr.payload/whole-app-db})
+                         :payload :rf.ssr.payload/whole-app-db})
           response    (handler {:uri "/articles" :request-method :get})
           body        (:body response)
           payload-m   (re-find
@@ -2004,7 +2004,7 @@
                         ;; try/catch — exactly the on-error path.
                         {:on-create '(:rf/server-init)
                          :root-view [:div]
-                         :payload-keys [:x]
+                         :payload [:x]
                          :on-error-fallback {:body custom-body
                                              :content-type "text/html; charset=utf-8"}})
           response    (handler {:uri "/x" :request-method :get})]
@@ -2031,7 +2031,7 @@
           handler       (ssr-ring/ssr-handler
                           {:on-create '(:rf/server-init)
                            :root-view [:div]
-                           :payload-keys [:x]
+                           :payload [:x]
                            :on-error (fn [_req _t]
                                        {:status 503
                                         :headers {"Content-Type" "text/plain"}
@@ -2079,7 +2079,7 @@
           handler (ssr-ring/ssr-handler
                     {:on-create '(:rf/server-init) ;; non-vector → setup throws
                      :root-view [:div]
-                     :payload-keys [:x]
+                     :payload [:x]
                      :on-error throwing-on-error})
           ;; Before the fix this call THREW (the throwing on-error
           ;; escaped `setup-request-frame!` uncaught). After the fix it
@@ -2120,7 +2120,7 @@
           handler (ssr-ring/ssr-handler
                     {:on-create [:rf.test/init-bad-cookie]
                      :root-view [:div "hello"]
-                     :payload-policy :rf.ssr.payload/whole-app-db
+                     :payload :rf.ssr.payload/whole-app-db
                      :on-error throwing-on-error})
           ;; Before the fix the throwing :on-error escaped the handler
           ;; body's catch uncaught; after the fix `safe-on-error`

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -41,6 +41,14 @@
             [re-frame.events :as events]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
+            ;; rf2-lq2ou — client-side hydration boot helper. The
+            ;; symmetric counterpart of the server-side
+            ;; `re-frame.ssr.ring/ssr-handler`: reads `__rf_payload` →
+            ;; dispatches `:rf/hydrate` → verifies. Loaded eagerly so the
+            ;; `ssr/hydrate!` / `ssr/read-server-payload` re-exports
+            ;; resolve at the façade. Per Spec 011 §Client-side hydration
+            ;; boot helper.
+            [re-frame.ssr.boot :as boot]
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.error-listener :as error-listener]
             [re-frame.ssr.error-projector :as error-projector]
@@ -84,6 +92,13 @@
 (def ^:private fnv-1a-32             hash/fnv-1a-32)
 (def adapter                         substrate/adapter)
 (def verify-hydration!               hydrate/verify-hydration!)
+;; rf2-lq2ou — client-side hydration boot helper (symmetric with the
+;; server-side `re-frame.ssr.ring/ssr-handler`). `hydrate!` fuses the
+;; read → dispatch `:rf/hydrate` → `verify-hydration!` ordering Spec 011
+;; §Client flow mandates; `read-server-payload` (CLJS-only) is the DOM
+;; `__rf_payload` reader it builds on.
+(def hydrate!                        boot/hydrate!)
+#?(:cljs (def read-server-payload    boot/read-server-payload))
 (def default-response                response/default-response)
 ;; framework-private — Spec 011 §Response storage substrate (rf2-jbcmt).
 ;; The accumulator lives in a side-channel atom keyed by frame-id, NOT

--- a/implementation/ssr/src/re_frame/ssr/boot.cljc
+++ b/implementation/ssr/src/re_frame/ssr/boot.cljc
@@ -1,0 +1,173 @@
+(ns re-frame.ssr.boot
+  "Client-side hydration boot helper — the symmetric counterpart of the
+  server-side `re-frame.ssr.ring/ssr-handler`. Per Spec 011 §Client flow
+  and §Client-side hydration boot helper (rf2-lq2ou).
+
+  ## The symmetry
+
+  The server side ships ONE explicit handler-constructor:
+
+      (ssr-ring/ssr-handler {:on-create … :root-view … :payload …})
+      ;; → a Ring handler that renders, builds the `__rf_payload`
+      ;;   `<script>`, and writes the wire response.
+
+  The client side now ships its mirror — ONE explicit boot call:
+
+      (ssr/hydrate! {:frame :rf/default :render-tree-fn #(…hiccup…)})
+      ;; → reads `__rf_payload`, dispatches `:rf/hydrate`, and (after
+      ;;   the first render) verifies the render-tree hash against the
+      ;;   server's.
+
+  The pair reads as one contract: the server emits the payload under the
+  `re-frame.ssr.constants/payload-script-id` id; the boot helper reads
+  that SAME id (`document.getElementById`), parses the EDN with the same
+  reader the server's `pr-str` round-trips through, and seeds the frame
+  via the framework's `:rf/hydrate` event (locked `:replace-app-db`
+  policy, Spec 011 §The :rf/hydrate event).
+
+  Before this helper every host re-implemented the same five-line read →
+  dispatch → render → verify dance (three testbeds + two worked examples
+  carried byte-identical `read-server-payload` fns). The helper makes the
+  client boot a one-liner and pins the read/dispatch/verify ordering the
+  spec mandates so a host can't get it subtly wrong (e.g. verifying
+  before the first render, or reading a stale id).
+
+  ## Platform split
+
+  - `read-server-payload` is `:cljs`-only — it reaches into the DOM.
+  - `hydrate!` is platform-neutral: it takes an explicit `:payload` (or
+    reads it from the DOM on CLJS when omitted), dispatches `:rf/hydrate`,
+    and runs the post-render `verify-hydration!` step. The JVM test
+    harness drives `hydrate!` with an explicit payload + a `:client`-
+    platform frame so the round-trip (server `build-payload` →
+    `hydrate!` → post-hydrate sub) is exercised without a browser.
+
+  Per the rf2-uo7v shipping convention this namespace lives in the
+  `day8/re-frame2-ssr` artefact alongside the rest of the SSR surface; it
+  is re-exported from the `re-frame.ssr` façade as `ssr/hydrate!` /
+  `ssr/read-server-payload`."
+  (:require [re-frame.router :as router]
+            [re-frame.ssr.hydrate :as hydrate]
+            ;; `constants` + `cljs.reader` are only used by the CLJS-only
+            ;; `read-server-payload` (DOM read); require them on CLJS so a
+            ;; JVM lint of this `.cljc` doesn't flag them unused.
+            #?(:cljs [re-frame.ssr.constants :as constants])
+            #?(:cljs [cljs.reader :as reader])))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+#?(:cljs
+   (defn read-server-payload
+     "Read the EDN hydration payload baked into the page by the server's
+     HTML shell. Reads the `<script>` element whose id is
+     `re-frame.ssr.constants/payload-script-id` (`\"__rf_payload\"`) — the
+     SAME id the host adapter's `default-html-shell` /
+     `payload-script-tag` stamps (Spec 011 §Hydration payload script id).
+
+     Returns the parsed payload map, or `nil` when the page was not
+     server-rendered (no payload script present) — the \"client-only
+     first load\" shape. The server escapes `<` to the EDN `\\u003c`
+     unicode escape before injection (the rf2-7ksyr `</script>` XSS gate);
+     `cljs.reader/read-string` accepts that escape so the payload
+     round-trips unchanged.
+
+     A host that overrode `:html-shell` with a custom payload id must
+     read that id itself rather than calling this fn (the framework's
+     bundled boot reads only the pinned id)."
+     ([] (read-server-payload constants/payload-script-id))
+     ([element-id]
+      (when-let [el (.getElementById js/document element-id)]
+        (reader/read-string (.-textContent el))))))
+
+(defn hydrate!
+  "Boot the client from the server's hydration payload — the symmetric
+  client-side counterpart of `re-frame.ssr.ring/ssr-handler`. Per Spec
+  011 §Client flow.
+
+  Three steps, in the order the spec mandates:
+
+    1. READ    — the payload. Supplied explicitly via `:payload`, or (on
+                 CLJS) read from the DOM's `__rf_payload` `<script>` via
+                 `read-server-payload` when `:payload` is omitted.
+    2. HYDRATE — `dispatch-sync` `[:rf/hydrate payload]` against the
+                 target frame BEFORE the first render, so the frame's
+                 app-db is the server's authoritative slice when the view
+                 first evaluates (locked `:replace-app-db` policy, Spec
+                 011 §The :rf/hydrate event). Skipped when there is no
+                 payload (client-only first load) — the caller renders
+                 against the empty app-db.
+    3. VERIFY  — after the first render, `verify-hydration!` compares the
+                 client render-tree hash against the server hash the
+                 `:rf/hydrate` handler stashed at
+                 `[:rf/runtime :ssr :hydration :server-hash]`. A mismatch
+                 emits `:rf.ssr/hydration-mismatch` (Spec 011
+                 §Hydration-mismatch detection). The render itself is the
+                 HOST's job (Reagent/UIx/Helix `render`) — the helper
+                 cannot mount the DOM for you — so the verify step takes a
+                 `:render-tree-fn` the host supplies: a 0-arity fn the
+                 helper calls AFTER you have rendered, returning the same
+                 render-tree the host just mounted (typically
+                 `#((rf/view :app/root))`). When `:render-tree-fn` is
+                 omitted the verify step is skipped (the host opts out of
+                 hash-mismatch detection, or runs `verify-hydration!`
+                 itself at its own render site).
+
+  Opts:
+
+    :frame          — the target frame id. Default `:rf/default`. Must be
+                      a `:client`-platform frame for the compatibility-
+                      check fxs to fire (Spec 011 §The :rf/hydrate event;
+                      a `:server`-platform frame skips them per rf2-7bcn0).
+    :payload        — the hydration payload map (the `:rf/hydration-payload`
+                      shape). When omitted, read from the DOM on CLJS;
+                      on the JVM it is required (no DOM to read from).
+    :render-tree-fn — (optional) a 0-arity fn returning the client
+                      render-tree to hash for mismatch detection. Called
+                      ONCE, after `:rf/hydrate`, on the verify step. Omit
+                      to skip verification.
+    :element-id     — (CLJS, optional) override the payload `<script>` id
+                      to read when `:payload` is omitted. Default the
+                      pinned `__rf_payload`.
+
+  Returns the payload that was applied (or `nil` on a client-only first
+  load) so the caller can branch on \"was this server-rendered?\" without
+  re-reading the DOM.
+
+  Example (Reagent client boot):
+
+      #?(:cljs
+         (defn ^:export run []
+           (rf/init! reagent-adapter/adapter)
+           (let [payload (ssr/hydrate! {:render-tree-fn #((rf/view :app/root))})]
+             (rdc/render react-root [(rf/view :app/root)])
+             ;; …verify already ran inside hydrate! against render-tree-fn
+             payload)))
+
+  Hosts that need to interleave their own render between hydrate and
+  verify (e.g. async mount) can call `dispatch-sync [:rf/hydrate …]`
+  directly and then `verify-hydration!` at their render site — `hydrate!`
+  is the convenience that fuses the common ordering."
+  [{:keys [frame payload render-tree-fn element-id]
+    :or   {frame :rf/default}}]
+  ;; `element-id` is consumed only by the CLJS DOM read; discard-bind it so
+  ;; a JVM lint of this `.cljc` doesn't flag it as an unused
+  ;; `:clj`-expansion binding (the read itself stays CLJS-only).
+  (let [_       element-id
+        payload (or payload
+                    #?(:cljs (read-server-payload
+                               (or element-id constants/payload-script-id))
+                       :clj nil))]
+    (when payload
+      ;; HOT PATH — seed app-db from the server's slice BEFORE first render.
+      ;; `router/dispatch-sync!` is the fn-form `re-frame.core` re-exports
+      ;; as `dispatch-sync*` (no call-site source-coord capture — this is
+      ;; programmatic boot, not a hand-written call site). Requiring the
+      ;; router directly keeps `boot` on the granular-require convention
+      ;; the other ssr sub-namespaces follow (frame/events/trace, never
+      ;; the `re-frame.core` public façade).
+      (router/dispatch-sync! [:rf/hydrate payload] {:frame frame})
+      ;; HOT PATH — post-render hash-mismatch detection. Symmetric with
+      ;; the server's `:emit-hash?`-stamped `data-rf-render-hash` marker.
+      (when render-tree-fn
+        (hydrate/verify-hydration! frame (render-tree-fn))))
+    payload))

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -9,7 +9,7 @@
   feature flags, server-only working scratch) to every visitor of every
   page.
 
-  A fail-OPEN default (ship whole `app-db` when `:payload-keys` is
+  A fail-OPEN default (ship whole `app-db` when `:payload` is
   nil/empty) would make the privacy decision implicit; the
   `:rf/response`-accumulator-on-app-db trap is one branch of the same
   family (rf2-jbcmt landed the side-channel storage substrate, rf2-gtgf9
@@ -27,14 +27,16 @@
 
   ---- The contract ----
 
-  The policy is one of two shapes:
+  A SINGLE handler opt — `:payload` — carries the policy. It is one of
+  two shapes (rf2-pffil consolidated the prior two-opt `:payload-keys` +
+  `:payload-policy` surface into one — pre-alpha, no back-compat shim):
 
-    `:payload-keys [<kw> <kw> ...]`
-      An **allowlist** of top-level `app-db` keys to ship. Other keys
-      are dropped — including any keys added later as the app evolves.
-      The recommended primary mechanism.
+    `:payload [<kw> <kw> ...]`
+      An **allowlist** of top-level `app-db` keys to ship (a non-empty
+      sequential coll). Other keys are dropped — including any keys added
+      later as the app evolves. The recommended primary mechanism.
 
-    `:payload-policy :rf.ssr.payload/whole-app-db`
+    `:payload :rf.ssr.payload/whole-app-db`
       An explicit opt-in to ship the whole `app-db`. Use only when the
       app's `app-db` is structurally safe to expose end-to-end — e.g.
       a small SPA where every key the server populates is intended
@@ -42,18 +44,21 @@
       (per Conventions §`:rf/*` reserved namespace) so consumers
       reading the opt see the security weight of the choice.
 
-  Absence of both is a structural error
+  Absence of `:payload` is a structural error
   (`:rf.error/ssr-missing-payload-policy`) — fail-closed.
 
-  Both shapes may be combined: when `:payload-keys` is present,
-  `:payload-policy` is ignored (explicit allowlist wins, and presenting
-  both is not a contradiction — the allowlist IS a more-restrictive
-  policy choice). Empty `:payload-keys` (`[]`) is treated as **no
-  allowlist supplied**, since shipping zero keys is almost certainly
-  a programmer error rather than an intent. Callers that genuinely
-  want to ship an empty `:rf/app-db` use `:payload-policy
-  :rf.ssr.payload/whole-app-db` against an empty `app-db` (i.e. don't
-  populate it server-side).
+  The single-opt shape removes the prior surface's ambiguity. The two-opt
+  design had to define a precedence rule (`:payload-keys` wins over
+  `:payload-policy` when both are passed) AND a silent-ignore branch (a
+  `:payload-policy` passed alongside an allowlist was discarded without a
+  word). One opt can hold exactly one value, so there is nothing to
+  arbitrate: the allowlist-vs-whole-app-db choice is the value's SHAPE
+  (vector vs keyword), not a contest between two opts. Empty `:payload`
+  (`[]`) is treated as **no allowlist supplied**, since shipping zero
+  keys is almost certainly a programmer error rather than an intent.
+  Callers that genuinely want to ship an empty `:rf/app-db` use
+  `:payload :rf.ssr.payload/whole-app-db` against an empty `app-db`
+  (i.e. don't populate it server-side).
 
   ---- Where this is consumed ----
 
@@ -92,58 +97,68 @@
 
 ;; ---- policy-spec keyword constants ----------------------------------------
 ;;
-;; Both keywords are reserved under the `:rf.ssr.payload/*` namespace
-;; (per Conventions §`:rf/*` reserved namespaces — `:rf.ssr/*` is the
-;; SSR sub-namespace; `:rf.ssr.payload/*` is the policy slot under it).
+;; The whole-app-db keyword is reserved under the `:rf.ssr.payload/*`
+;; namespace (per Conventions §`:rf/*` reserved namespaces — `:rf.ssr/*`
+;; is the SSR sub-namespace; `:rf.ssr.payload/*` is the policy slot under
+;; it).
 
 (def whole-app-db-policy
   "Opt-in policy keyword for shipping the entire `app-db` in the
-  hydration payload. Set as `:payload-policy` on the handler opts."
+  hydration payload. Set as the `:payload` opt's value on the handler
+  opts (`:payload :rf.ssr.payload/whole-app-db`)."
   :rf.ssr.payload/whole-app-db)
 
 ;; ---- policy resolution ---------------------------------------------------
 
 (defn- valid-allowlist?
-  "An allowlist is a non-empty sequential coll of top-level keys."
+  "An allowlist is a non-empty sequential coll of top-level keys — the
+  vector shape of the `:payload` opt."
   [x]
   (and (sequential? x) (seq x)))
 
 (defn- valid-policy-keyword?
   "Currently the only explicit-policy keyword recognised is the
-  whole-app-db opt-in. New policies (e.g. schema-driven projections)
-  would extend this set."
+  whole-app-db opt-in — the keyword shape of the `:payload` opt. New
+  policies (e.g. schema-driven projections) would extend this set."
   [x]
   (= x whole-app-db-policy))
 
 (defn validate-policy-opts!
-  "Throw a structured `:rf.error/ssr-missing-payload-policy` when the
-  caller declared neither `:payload-keys` nor a recognised
-  `:payload-policy`. Called at handler-construction time by the Ring
-  host adapter so misconfigured deployments fail at boot, not at first
-  request.
+  "Throw a structured error when the caller's `:payload` opt is absent or
+  malformed. Called at handler-construction time by the Ring host adapter
+  so misconfigured deployments fail at boot, not at first request.
+
+    - `:payload [<kws>]` (non-empty sequential) → OK (allowlist)
+    - `:payload :rf.ssr.payload/whole-app-db`   → OK (whole-app-db opt-in)
+    - `:payload <other keyword>`  → `:rf.error/ssr-unknown-payload-policy`
+      (a typo'd policy keyword, e.g. `:rf.ssr.payload/whole-db`, surfaced
+      distinctly so it doesn't silently land in the missing bucket)
+    - `:payload` absent / empty `[]` / nil / any other non-allowlist
+      non-keyword → `:rf.error/ssr-missing-payload-policy` (fail-closed)
 
   Returns `opts` unchanged on success — composes into a `let` /
   threading position cleanly."
-  [{:keys [payload-keys payload-policy] :as opts}]
+  [{:keys [payload] :as opts}]
   (cond
-    (valid-allowlist? payload-keys)
+    (valid-allowlist? payload)
     opts
 
-    (valid-policy-keyword? payload-policy)
+    (valid-policy-keyword? payload)
     opts
 
-    ;; Caller passed `:payload-policy` but not the recognised keyword —
-    ;; surface as a distinct error so a typo (e.g.
+    ;; Caller passed a keyword that isn't the recognised whole-app-db
+    ;; opt-in — surface as a distinct error so a typo (e.g.
     ;; `:rf.ssr.payload/whole-db`) doesn't silently land in the
     ;; missing-policy bucket.
-    (some? payload-policy)
+    (keyword? payload)
     (throw (ex-info ":rf.error/ssr-unknown-payload-policy"
                     {:rf.error/id    :rf.error/ssr-unknown-payload-policy
                      :where          'rf.ssr/payload-policy
-                     :reason         (str "ssr-handler :payload-policy must be "
+                     :reason         (str "ssr-handler :payload keyword must be "
                                           (pr-str whole-app-db-policy)
-                                          " (or omit it and pass :payload-keys instead)")
-                     :got            payload-policy
+                                          " (or pass a vector allowlist of "
+                                          "top-level app-db keys instead)")
+                     :got            payload
                      :recognised     #{whole-app-db-policy}
                      :recovery       :declare-payload-policy}))
 
@@ -152,36 +167,35 @@
                     {:rf.error/id :rf.error/ssr-missing-payload-policy
                      :where    'rf.ssr/payload-policy
                      :reason   (str "ssr-handler requires an explicit hydration-"
-                                    "payload policy: pass :payload-keys "
+                                    "payload policy: pass :payload "
                                     "[<top-level-app-db-keys>] (allowlist, "
-                                    "preferred) OR :payload-policy "
+                                    "preferred) OR :payload "
                                     (pr-str whole-app-db-policy)
                                     " to opt-in to shipping the whole app-db.")
+                     :got      payload
                      :recovery :declare-payload-policy}))))
 
 (defn apply-policy
-  "Project `app-db` to the wire slice per the caller's declared policy.
-  Returns the slice (a map) — the value that lands on the
+  "Project `app-db` to the wire slice per the caller's declared `:payload`
+  policy. Returns the slice (a map) — the value that lands on the
   `:rf/hydration-payload`'s `:rf/app-db` key.
 
   Per the contract:
 
-    - `:payload-keys [<kws>]` (allowlist, recommended) wins when
-      present and non-empty.
-    - `:payload-policy :rf.ssr.payload/whole-app-db` ships `app-db`
-      verbatim.
-    - Absence of both throws `:rf.error/ssr-missing-payload-policy`
-      — the fail-closed default.
+    - `:payload [<kws>]` (allowlist, non-empty sequential) → `select-keys`.
+    - `:payload :rf.ssr.payload/whole-app-db` → ships `app-db` verbatim.
+    - Absence / malformed → throws (`:rf.error/ssr-missing-payload-policy`
+      or `:rf.error/ssr-unknown-payload-policy`) — the fail-closed default.
 
   This is the runtime arm of the contract; the construction-time arm
   is `validate-policy-opts!` (called by the Ring host adapter so
   misconfigured deployments fail at boot)."
-  [app-db {:keys [payload-keys payload-policy] :as opts}]
+  [app-db {:keys [payload] :as opts}]
   (cond
-    (valid-allowlist? payload-keys)
-    (select-keys app-db payload-keys)
+    (valid-allowlist? payload)
+    (select-keys app-db payload)
 
-    (valid-policy-keyword? payload-policy)
+    (valid-policy-keyword? payload)
     app-db
 
     :else

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -504,10 +504,11 @@
   (rf2-via0g, mirroring the non-streaming rf2-asmj1 S8 fix).
 
   The `:rf/app-db` slice is projected per the explicit, fail-closed
-  policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9):
-  callers MUST declare `:payload-keys` (allowlist, recommended) or
-  `:payload-policy :rf.ssr.payload/whole-app-db` (explicit opt-in to
-  shipping the whole `app-db`). Absence of both throws
+  policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9,
+  rf2-pffil single-opt consolidation): callers MUST declare `:payload`
+  as either a vector allowlist of top-level keys (recommended) or the
+  keyword `:rf.ssr.payload/whole-app-db` (explicit opt-in to shipping
+  the whole `app-db`). Absence throws
   `:rf.error/ssr-missing-payload-policy`. The Ring host adapter
   validates at handler-construction time so misconfigured deployments
   fail at boot rather than at first request."

--- a/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
@@ -1,20 +1,28 @@
 (ns re-frame.ssr.payload-policy-cljs-test
-  "Per-leaf smoke tests for `re-frame.ssr.payload-policy` (rf2-gtgf9).
+  "Per-leaf smoke tests for `re-frame.ssr.payload-policy` (rf2-gtgf9,
+  rf2-pffil single-opt consolidation).
 
-  Pins the explicit, fail-closed hydration-payload policy contract:
+  Pins the explicit, fail-closed hydration-payload policy contract, now
+  carried by a SINGLE `:payload` opt (rf2-pffil folded the prior two-opt
+  `:payload-keys` + `:payload-policy` surface into one — pre-alpha, no
+  back-compat shim):
 
     - `apply-policy` returns a `select-keys` slice when the caller
-      passes `:payload-keys`.
+      passes `:payload [<kws>]` (vector → allowlist).
     - `apply-policy` returns the whole `app-db` verbatim when the
-      caller passes `:payload-policy :rf.ssr.payload/whole-app-db`.
+      caller passes `:payload :rf.ssr.payload/whole-app-db` (keyword →
+      whole-app-db opt-in).
     - `apply-policy` THROWS `:rf.error/ssr-missing-payload-policy`
-      when neither opt is present (the **fail-closed proof**).
+      when `:payload` is absent / empty / nil (the **fail-closed proof**).
     - `apply-policy` THROWS `:rf.error/ssr-unknown-payload-policy`
-      when `:payload-policy` is set to a non-recognised keyword.
+      when `:payload` is a non-recognised keyword (typo).
     - `validate-policy-opts!` mirrors the same throw contract at
       construction time + returns opts unchanged on success.
-    - `:payload-keys` wins over `:payload-policy` (the more-restrictive
-      choice) when both are present.
+
+  The two-opt surface's precedence rule (allowlist wins over whole-app-db)
+  and silent-ignore branch are GONE: one opt holds exactly one value, so
+  there is nothing to arbitrate — the allowlist-vs-whole choice is the
+  value's SHAPE (vector vs keyword).
 
   These tests run on both JVM and Node — the policy logic is
   platform-neutral .cljc."
@@ -28,13 +36,13 @@
    :server-only/flag true
    :rf/runtime       {:routing {:current {:id :route/home}}}})
 
-;; ---- apply-policy: allowlist branch --------------------------------------
+;; ---- apply-policy: allowlist branch (:payload vector) --------------------
 
 (deftest apply-policy-allowlist-slices-app-db
-  (testing ":payload-keys ships only the listed keys"
+  (testing ":payload [<kws>] ships only the listed keys"
     (let [slice (payload-policy/apply-policy
                   sample-app-db
-                  {:payload-keys [:public/articles :public/user-id]})]
+                  {:payload [:public/articles :public/user-id]})]
       (is (= {:public/articles [:a :b :c]
               :public/user-id  "u-42"}
              slice)
@@ -47,12 +55,12 @@
             (the policy is a permission, not a guarantee)"
     (let [slice (payload-policy/apply-policy
                   sample-app-db
-                  {:payload-keys [:public/articles :public/no-such-key]})]
+                  {:payload [:public/articles :public/no-such-key]})]
       (is (= {:public/articles [:a :b :c]} slice)
           "missing keys silently absent; matches `select-keys` semantics"))))
 
-(deftest apply-policy-allowlist-as-vector-or-set-or-list
-  (testing "allowlist accepts any sequential / set coll shape"
+(deftest apply-policy-allowlist-as-vector-or-list
+  (testing "allowlist accepts any sequential coll shape"
     (doseq [coll-shape [[:public/articles]
                         '(:public/articles)
                         ;; Sets are NOT sequential — but `select-keys`
@@ -61,23 +69,34 @@
                         ;; (programmer-intent: ordered allowlist; a set
                         ;; would imply unordered which doesn't match how
                         ;; allowlists are used in practice). Sets fail-
-                        ;; closed instead — assert that here so the
-                        ;; contract surface is pinned.
+                        ;; closed instead — asserted in the next test so
+                        ;; the contract surface is pinned.
                         ]]
       (let [slice (payload-policy/apply-policy
                     sample-app-db
-                    {:payload-keys coll-shape})]
+                    {:payload coll-shape})]
         (is (= {:public/articles [:a :b :c]} slice)
             (str "allowlist as " (pr-str coll-shape)
                  " produces the expected slice"))))))
 
-;; ---- apply-policy: whole-app-db branch -----------------------------------
+(deftest apply-policy-set-payload-fails-closed
+  (testing "a SET :payload is not sequential → fails closed (the contract
+            is a narrow ordered-allowlist; a set is rejected rather than
+            silently accepted)"
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #":rf\.error/ssr-missing-payload-policy"
+          (payload-policy/apply-policy
+            sample-app-db
+            {:payload #{:public/articles}})))))
+
+;; ---- apply-policy: whole-app-db branch (:payload keyword) ----------------
 
 (deftest apply-policy-whole-app-db-policy-ships-everything
-  (testing ":payload-policy :rf.ssr.payload/whole-app-db ships app-db verbatim"
+  (testing ":payload :rf.ssr.payload/whole-app-db ships app-db verbatim"
     (let [slice (payload-policy/apply-policy
                   sample-app-db
-                  {:payload-policy :rf.ssr.payload/whole-app-db})]
+                  {:payload :rf.ssr.payload/whole-app-db})]
       (is (= sample-app-db slice)
           "whole-app-db opt-in → identity over app-db"))))
 
@@ -90,9 +109,9 @@
 
 ;; ---- apply-policy: fail-closed (the rf2-gtgf9 lock) ----------------------
 
-(deftest apply-policy-throws-when-no-policy-supplied
-  (testing "rf2-gtgf9 fail-closed: absence of both :payload-keys and
-            :payload-policy throws :rf.error/ssr-missing-payload-policy"
+(deftest apply-policy-throws-when-no-payload-supplied
+  (testing "rf2-gtgf9 fail-closed: absence of :payload throws
+            :rf.error/ssr-missing-payload-policy"
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-missing-payload-policy"
@@ -104,20 +123,20 @@
         "nil opts also throws — same contract")))
 
 (deftest apply-policy-throws-when-allowlist-empty
-  (testing "rf2-gtgf9: an empty :payload-keys is treated as no-allowlist
+  (testing "rf2-gtgf9: an empty :payload vector is treated as no-allowlist
             (shipping zero keys is almost certainly a programmer error,
             not intent) — fail-closed still fires"
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-missing-payload-policy"
-          (payload-policy/apply-policy sample-app-db {:payload-keys []})))
+          (payload-policy/apply-policy sample-app-db {:payload []})))
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-missing-payload-policy"
-          (payload-policy/apply-policy sample-app-db {:payload-keys nil})))))
+          (payload-policy/apply-policy sample-app-db {:payload nil})))))
 
 (deftest apply-policy-throws-on-unknown-policy-keyword
-  (testing "rf2-gtgf9: a typo'd :payload-policy keyword surfaces as
+  (testing "rf2-gtgf9: a typo'd :payload keyword surfaces as
             :rf.error/ssr-unknown-payload-policy — distinct from the
             missing-policy bucket so a typo doesn't silently land in
             the `nothing-supplied` arm"
@@ -126,42 +145,27 @@
           #":rf\.error/ssr-unknown-payload-policy"
           (payload-policy/apply-policy
             sample-app-db
-            {:payload-policy :rf.ssr.payload/whole-db})) ; typo
+            {:payload :rf.ssr.payload/whole-db})) ; typo
         "typo'd policy keyword throws unknown-policy")
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-unknown-payload-policy"
           (payload-policy/apply-policy
             sample-app-db
-            {:payload-policy :myapp/custom-policy})))))
-
-;; ---- precedence: allowlist wins over whole-app-db ------------------------
-
-(deftest apply-policy-allowlist-wins-over-whole-app-db
-  (testing "rf2-gtgf9: when both :payload-keys and :payload-policy are
-            passed, the allowlist wins (it's the more-restrictive
-            policy choice — not a contradiction)"
-    (let [slice (payload-policy/apply-policy
-                  sample-app-db
-                  {:payload-keys   [:public/articles]
-                   :payload-policy :rf.ssr.payload/whole-app-db})]
-      (is (= {:public/articles [:a :b :c]} slice)
-          "allowlist takes precedence; the whole-app-db opt is ignored")
-      (is (not (contains? slice :server-only/auth))
-          "server-only keys still excluded — the allowlist wins"))))
+            {:payload :myapp/custom-policy})))))
 
 ;; ---- validate-policy-opts!: construction-time arm ------------------------
 
 (deftest validate-policy-opts-passes-allowlist
-  (testing "valid :payload-keys passes validation + returns opts unchanged"
-    (let [opts {:on-create [:init] :payload-keys [:public/articles]}]
+  (testing "valid :payload vector passes validation + returns opts unchanged"
+    (let [opts {:on-create [:init] :payload [:public/articles]}]
       (is (= opts (payload-policy/validate-policy-opts! opts))
           "returns opts unchanged on success — composes cleanly into
            threading/let positions"))))
 
 (deftest validate-policy-opts-passes-whole-app-db
-  (testing "valid :payload-policy passes validation"
-    (let [opts {:on-create [:init] :payload-policy :rf.ssr.payload/whole-app-db}]
+  (testing "valid :payload whole-app-db keyword passes validation"
+    (let [opts {:on-create [:init] :payload :rf.ssr.payload/whole-app-db}]
       (is (= opts (payload-policy/validate-policy-opts! opts))))))
 
 (deftest validate-policy-opts-fails-closed
@@ -174,12 +178,12 @@
           (payload-policy/validate-policy-opts! {:on-create [:init]})))))
 
 (deftest validate-policy-opts-throws-on-unknown-policy
-  (testing "construction-time arm also catches typo'd policy keywords"
+  (testing "construction-time arm also catches typo'd :payload keywords"
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-unknown-payload-policy"
           (payload-policy/validate-policy-opts!
-            {:on-create [:init] :payload-policy :rf.ssr.payload/whole-db})))))
+            {:on-create [:init] :payload :rf.ssr.payload/whole-db})))))
 
 (deftest error-ex-data-carries-recovery-tag
   (testing "rf2-gtgf9: the structured error carries `:recovery

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -45,6 +45,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
+            [re-frame.ssr.payload-policy :as payload-policy]
             [re-frame.ssr.test-fixture :as tf]))
 
 (use-fixtures :each tf/reset-runtime)
@@ -339,3 +340,134 @@
             (str "no :rf.ssr/hydration-mismatch on the baseline (server-"
                  "hash was nil); saw: "
                  (pr-str (mapv :operation traces))))))))
+
+;; ===========================================================================
+;; rf2-lq2ou — client-side hydration boot helper (ssr/hydrate!)
+;;
+;; The symmetric client-side counterpart of `re-frame.ssr.ring/ssr-handler`.
+;; `hydrate!` fuses the read → dispatch `:rf/hydrate` → `verify-hydration!`
+;; ordering Spec 011 §Client flow mandates. These tests drive it on the JVM
+;; with an EXPLICIT `:payload` (no DOM to read from server-side) on a
+;; `:client`-platform frame, exercising the full server-`build-payload` →
+;; `hydrate!` → post-hydrate-sub round-trip without a browser.
+;; ===========================================================================
+
+(defn- build-server-payload
+  "Mirror the server-side payload build: project app-db per the policy and
+  assemble the canonical `:rf/hydration-payload` — the SAME
+  `re-frame.ssr.payload-policy/build-payload` path
+  `re-frame.ssr.ring.payload/build-payload` uses. `render-hash` is the
+  FNV-1a hash of the render-tree the server stringified."
+  [frame-id app-db render-hash policy-opts]
+  (payload-policy/build-payload
+    frame-id
+    (payload-policy/apply-policy app-db policy-opts)
+    render-hash
+    policy-opts))
+
+(deftest boot-hydrate-round-trips-server-payload-into-app-db
+  (testing "rf2-lq2ou: ssr/hydrate! with an explicit :payload dispatches
+            :rf/hydrate against the target client frame, and a post-hydrate
+            sub reflects the seeded slice — the server-build → hydrate! →
+            sub round-trip. hydrate! returns the applied payload."
+    (register-baseline-handlers!)
+    (let [client-frame (rf/make-frame {:doc "boot-helper client frame"
+                                       :platform :client})
+          ;; Server side: build the payload from the authoritative app-db
+          ;; slice via the same payload-policy path the Ring adapter uses.
+          server-app-db {:count 7 :title "seeded"
+                         :server-only/auth "SECRET"}
+          payload       (build-server-payload
+                          :rf/default server-app-db "deadbeef"
+                          {:version 1 :payload [:count :title]})
+          ;; Client side: the symmetric boot call.
+          returned      (ssr/hydrate! {:frame   client-frame
+                                       :payload payload})]
+      (is (= payload returned)
+          "hydrate! returns the applied payload so the caller can branch
+           on `was this server-rendered?`")
+      (is (= 7 (rf/subscribe-once client-frame [:count]))
+          "post-hydrate :count sub reflects the server-built payload slice")
+      (is (= "seeded" (rf/subscribe-once client-frame [:title]))
+          "post-hydrate :title sub reflects the server-built payload slice")
+      (is (true? (rf/subscribe-once client-frame [:hydrated?]))
+          ":hydrated? true once hydration metadata lands")
+      ;; The allowlist policy used to build the payload dropped the
+      ;; server-only key — the round-trip carries only the permitted slice.
+      (is (nil? (:server-only/auth (rf/frame-db client-frame)))
+          ":payload allowlist kept the server-only key off the wire +
+           thus out of the hydrated client app-db"))))
+
+(deftest boot-hydrate-nil-payload-is-client-only-noop
+  (testing "rf2-lq2ou: ssr/hydrate! with no payload (nil — the client-only
+            first-load shape) does NOT dispatch :rf/hydrate and returns
+            nil. The caller renders against the empty app-db."
+    (register-baseline-handlers!)
+    (let [client-frame (rf/make-frame {:doc "boot-helper client-only frame"
+                                       :platform :client})
+          returned     (ssr/hydrate! {:frame client-frame :payload nil})]
+      (is (nil? returned)
+          "nil payload → hydrate! returns nil (client-only first load)")
+      (is (false? (rf/subscribe-once client-frame [:hydrated?]))
+          "no hydration metadata stashed — :rf/hydrate was never dispatched")
+      (is (= 0 (rf/subscribe-once client-frame [:count]))
+          "app-db is the empty default; the :count sub's fallback applies"))))
+
+(deftest boot-hydrate-verify-step-fires-mismatch-on-divergent-render
+  (testing "rf2-lq2ou: hydrate!'s VERIFY step runs verify-hydration!
+            against the :render-tree-fn AFTER dispatching :rf/hydrate.
+            When the client render-tree hash != the server hash carried on
+            the payload, :rf.ssr/hydration-mismatch fires — the boot helper
+            wires the post-render mismatch detection symmetric with the
+            server's :emit-hash? marker."
+    (register-baseline-handlers!)
+    (rf/reg-view* ::boot-root (fn [] [:div.app [:span "client-render"]]))
+    (let [client-frame (rf/make-frame {:doc "boot-helper verify frame"
+                                       :platform :client
+                                       :ssr {:detect-mismatch? true}})
+          ;; Server hash is a DELIBERATELY divergent value so the verify
+          ;; step's comparison fails — proving the verify step actually ran.
+          payload       (build-server-payload
+                          :rf/default {:count 7 :title "seeded"}
+                          "server00"                 ;; != the client tree hash
+                          {:version 1 :payload [:count :title]})
+          traces        (capture-traces!
+                          (fn []
+                            (ssr/hydrate!
+                              {:frame          client-frame
+                               :payload        payload
+                               :render-tree-fn (fn [] [:div.app [:span "client-render"]])})))]
+      (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) traces)
+          (str "verify step fired a :rf.ssr/hydration-mismatch (server hash "
+               "'server00' != client render-tree hash); saw: "
+               (pr-str (mapv :operation traces)))))))
+
+(deftest boot-hydrate-verify-step-silent-on-matching-render
+  (testing "rf2-lq2ou: when the client render-tree hash MATCHES the server
+            hash, the verify step is silent — no spurious mismatch on a
+            successful hydration. Counter-test to the divergent-render case
+            so the verify step can't be a false-positive generator."
+    (register-baseline-handlers!)
+    (let [client-frame (rf/make-frame {:doc "boot-helper verify-match frame"
+                                       :platform :client
+                                       :ssr {:detect-mismatch? true}})
+          client-tree   [:div.app [:span "client-render"]]
+          ;; Compute the server hash from the SAME tree so the round-trip
+          ;; hashes agree — the happy path.
+          matched-hash  (ssr/render-tree-hash client-tree)
+          payload       (build-server-payload
+                          :rf/default {:count 7 :title "seeded"}
+                          matched-hash
+                          {:version 1 :payload [:count :title]})
+          traces        (capture-traces!
+                          (fn []
+                            (ssr/hydrate!
+                              {:frame          client-frame
+                               :payload        payload
+                               :render-tree-fn (fn [] client-tree)})))]
+      (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) traces)
+          (str "matching hashes → no :rf.ssr/hydration-mismatch; saw: "
+               (pr-str (mapv :operation traces))))
+      ;; Sanity: the seed still landed (the verify step doesn't gate hydrate).
+      (is (= 7 (rf/subscribe-once client-frame [:count]))
+          ":rf/hydrate still applied the seeded slice"))))

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -423,7 +423,7 @@
 
 (deftest build-final-payload-allowlist-drops-unpermitted-keys
   (testing "rf2-u91hb: the streaming build-final-payload MUST honour
-            :payload-keys allowlist projection — same contract as
+            :payload allowlist projection — same contract as
             non-streaming build-payload (the streaming + non-streaming
             payload builders share re-frame.ssr.payload-policy/apply-
             policy per rf2-gtgf9). Pin that an un-permitted key on
@@ -433,8 +433,8 @@
                                   :server-only/admin-flag true})
           payload (streaming/build-final-payload
                     fid "deadbeef"
-                    {:version       1
-                     :payload-keys  [:public/articles]})]
+                    {:version 1
+                     :payload [:public/articles]})]
       (is (= [{:id "a"}] (get-in payload [:rf/app-db :public/articles]))
           "the public slice IS on the wire (sanity)")
       (is (not (contains? (:rf/app-db payload) :server-only/auth-token))

--- a/implementation/ssr/test/re_frame/ssr_streaming_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_test.clj
@@ -198,7 +198,7 @@
           payload (streaming/build-final-payload fid "deadbeef"
                                                  {:version       7
                                                   :schema-digest "abc123"
-                                                  :payload-policy :rf.ssr.payload/whole-app-db})]
+                                                  :payload :rf.ssr.payload/whole-app-db})]
       (is (= 7 (:rf/version payload)))
       (is (= fid (:rf/frame-id payload)))
       (is (= "deadbeef" (:rf/render-hash payload)))
@@ -217,7 +217,7 @@
         (try
           (let [payload (streaming/build-final-payload
                           fid "hash"
-                          {:payload-policy :rf.ssr.payload/whole-app-db})]
+                          {:payload :rf.ssr.payload/whole-app-db})]
             (is (= "9.9.9" (:rf/version payload))
                 "runtime-version hook value lands in :rf/version")
             (is (not= 1 (:rf/version payload))
@@ -231,7 +231,7 @@
           (let [payload (streaming/build-final-payload
                           fid "hash"
                           {:version        42
-                           :payload-policy :rf.ssr.payload/whole-app-db})]
+                           :payload :rf.ssr.payload/whole-app-db})]
             (is (= 42 (:rf/version payload))
                 "caller-supplied :version is the highest-priority source"))
           (finally
@@ -241,7 +241,7 @@
         (swap! late-bind/hooks dissoc :rf2/runtime-version)
         (let [payload (streaming/build-final-payload
                         fid "hash"
-                        {:payload-policy :rf.ssr.payload/whole-app-db})]
+                        {:payload :rf.ssr.payload/whole-app-db})]
           (is (= 1 (:rf/version payload))
               "absent hook + absent opt → v1 pattern-protocol stamp"))))))
 

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -81,14 +81,14 @@ The bounded payload is the lock: implementations may emit additional optional ke
 
 #### `:rf/app-db` projection — explicit fail-closed policy
 
-The `:rf/app-db` slice is projected from the request frame's `app-db` per an **explicit, fail-closed** policy. The host adapter MUST receive one of two declarative opts at construction time:
+The `:rf/app-db` slice is projected from the request frame's `app-db` per an **explicit, fail-closed** policy. The host adapter MUST receive a single declarative opt — **`:payload`** — at construction time. It carries the policy in one of two shapes:
 
-- **`:payload-keys [<top-level-app-db-keys>]`** — an **allowlist**. Only the listed keys ride the wire; everything else is dropped, including any keys added later as the app evolves. This is the recommended primary mechanism — a denylist would silently leak each new server-only key as the app evolves; an allowlist forces a deliberate edit per new wire-bound key.
-- **`:payload-policy :rf.ssr.payload/whole-app-db`** — explicit opt-in to ship the whole `app-db` verbatim. Use only when the app's `app-db` is structurally safe to expose end-to-end (e.g. small SPAs where every server-set key is intended for the client).
+- **`:payload [<top-level-app-db-keys>]`** (a non-empty vector) — an **allowlist**. Only the listed keys ride the wire; everything else is dropped, including any keys added later as the app evolves. This is the recommended primary mechanism — a denylist would silently leak each new server-only key as the app evolves; an allowlist forces a deliberate edit per new wire-bound key.
+- **`:payload :rf.ssr.payload/whole-app-db`** (the policy keyword) — explicit opt-in to ship the whole `app-db` verbatim. Use only when the app's `app-db` is structurally safe to expose end-to-end (e.g. small SPAs where every server-set key is intended for the client).
 
-Absence of both is a **structural error** — the host adapter throws `:rf.error/ssr-missing-payload-policy` at handler-construction time so misconfigured deployments fail at boot, not at first request. The contract makes the privacy decision explicit at every host site (no fail-OPEN default at a security boundary). The CLJS reference's projection helper lives in `re-frame.ssr.payload-policy/apply-policy` (consumed by both `re-frame.ssr.ring.payload/build-payload` for non-streaming and `re-frame.ssr.streaming/build-final-payload` for streaming SSR — the policy contract is shared).
+Absence of `:payload` is a **structural error** — the host adapter throws `:rf.error/ssr-missing-payload-policy` at handler-construction time so misconfigured deployments fail at boot, not at first request. The contract makes the privacy decision explicit at every host site (no fail-OPEN default at a security boundary). The CLJS reference's projection helper lives in `re-frame.ssr.payload-policy/apply-policy` (consumed by both `re-frame.ssr.ring.payload/build-payload` for non-streaming and `re-frame.ssr.streaming/build-final-payload` for streaming SSR — the policy contract is shared).
 
-When both opts are present the allowlist wins (it's the more-restrictive policy choice; not a contradiction). An empty `:payload-keys` (`[]`) is treated as no-allowlist — shipping zero keys is almost certainly a programmer error, not intent — and falls into the missing-policy bucket. A typo'd `:payload-policy` keyword surfaces as the distinct `:rf.error/ssr-unknown-payload-policy` so the developer can tell the failure modes apart.
+The single-opt shape is deliberate: a single value holds exactly one policy, so there is nothing to arbitrate. The allowlist-vs-whole-app-db choice is the value's SHAPE (vector vs keyword), not a contest between two opts — which removes the prior surface's precedence rule and silent-ignore branch. An empty `:payload` (`[]`) is treated as no-allowlist — shipping zero keys is almost certainly a programmer error, not intent — and falls into the missing-policy bucket. An unrecognised `:payload` keyword surfaces as the distinct `:rf.error/ssr-unknown-payload-policy` so the developer can tell the failure modes apart.
 
 ## SSR flow
 
@@ -317,6 +317,29 @@ The three compatibility-check trace categories — `:rf.ssr/version-mismatch`, `
 Hash-based render-tree mismatch (a separate concern) lives in §Hydration-mismatch detection.
 
 The payload shape is fixed; implementations may emit additive optional keys (per [Spec-Schemas §`:rf/hydration-payload`](Spec-Schemas.md#rfhydration-payload)) but never alter the required keys.
+
+#### Client-side hydration boot helper
+
+The server side ships ONE explicit handler-constructor (`ssr-handler` — [§HTTP response contract](#http-response-contract)) that renders, builds the `__rf_payload` `<script>`, and writes the wire response. The client side ships its **symmetric counterpart** — ONE explicit boot call that reads `__rf_payload`, dispatches `:rf/hydrate`, and verifies. The pair reads as one contract; a host should not have to re-derive the read → dispatch → render → verify ordering by hand at every boot site.
+
+The CLJS reference ships it as `re-frame.ssr/hydrate!` (re-exported from the façade; implemented in `re-frame.ssr.boot`):
+
+```clojure
+#?(:cljs
+   (defn ^:export run []
+     (rf/init! reagent-adapter/adapter)
+     (let [payload (ssr/hydrate! {:render-tree-fn #((rf/view :app/root))})]
+       (rdc/render react-root [(rf/view :app/root)])
+       payload)))
+```
+
+`hydrate!` performs the three steps in the order the [§Client flow](#client-flow-on-page-load) mandates:
+
+1. **READ** — the payload. Supplied explicitly via `:payload`, or read from the DOM's `__rf_payload` `<script>` (via `read-server-payload`, which reads the id pinned in the CLJS reference's `re-frame.ssr.constants/payload-script-id` — the same id the host shell stamps) when `:payload` is omitted. Returns `nil` on a client-only first load (no payload script) — the host renders against the empty app-db.
+2. **HYDRATE** — `dispatch-sync [:rf/hydrate payload]` against the target frame (default `:rf/default`) BEFORE the first render, so the frame's app-db is the server's authoritative slice when the view first evaluates (the locked `:replace-app-db` policy above).
+3. **VERIFY** — after the first render, `verify-hydration!` compares the client render-tree hash against the server hash stashed at `[:rf/runtime :ssr :hydration :server-hash]` (see [§Hydration-mismatch detection](#hydration-mismatch-detection)). The render itself is the host substrate's job (`render`); the helper cannot mount the DOM, so the verify step takes a `:render-tree-fn` — a 0-arity fn returning the render-tree the host just mounted (typically `#((rf/view :app/root))`). Omit `:render-tree-fn` to skip verification (the host opts out of hash-mismatch detection, or runs `verify-hydration!` itself at its own render site).
+
+`hydrate!` returns the applied payload (or `nil`) so the caller can branch on "was this server-rendered?" without re-reading the DOM. It is the convenience that fuses the common ordering; hosts that must interleave their own render between hydrate and verify (async mount) call `dispatch-sync [:rf/hydrate …]` and `verify-hydration!` directly at their own sites. `read-server-payload` is CLJS-only (it reaches into the DOM); `hydrate!` is platform-neutral so a JVM test harness can drive the server-`build-payload` → `hydrate!` → post-hydrate-sub round-trip on a `:client`-platform frame without a browser.
 
 ### Hydration-mismatch detection
 
@@ -718,6 +741,20 @@ A view that throws during `render-to-string` (e.g., a missing key on an attempte
 Hosts that prefer eager exceptions during dev (to surface bugs early) can opt in via the frame's `:ssr {:on-view-exception :throw}` metadata — dev convenience; production should always project. The CLJS reference reads this knob at the render-time projection entry point (`re-frame.ssr/project-render-exception!`,.10): when set to `:throw`, the original throwable is re-thrown unchanged to the host's outer handler instead of being projected to a sanitised public-error.
 
 The JVM reference adapter (`re-frame.ssr.ring`) unifies the two render-side failure surfaces under one pipeline. Render-time throws are caught at the host-adapter render call site and routed through `ssr/project-render-exception!` (synthesises a `:rf.error/ssr-render-failed` trace event and applies the active projector); the wire body is the projector's `:message` / `:code`. The outer `:on-error` hook is reserved for transport-layer / projector-undeliverable failures (no server frame, projector pipeline catastrophically fails) where the fixed-body contract applies.
+
+#### `:on-error` vs `:error-view` — the error-handling division
+
+The host adapter exposes TWO error opts that handle TWO different failures. They are not alternatives — a robust deployment usually wires both. The division (the CLJS reference's `ssr-handler` docstring carries the same decision table verbatim):
+
+| | `:error-view` | `:on-error` |
+|---|---|---|
+| **Which failure** | An exception INSIDE the drain or render walk — something the error PROJECTOR catches (steps 1–5 above). | A transport / Ring-layer failure the projector CANNOT see — per-request frame setup throw, a render-time host exception outside the walker, a header/cookie materialise throw, a thrown `:on-create`. |
+| **What it produces** | The PROJECTED error-page body (hiccup) — a registered-view keyword or a `(public-error) → hiccup` fn, rendered through the SSR emitter. | A raw HTTP response map `{:status … :headers … :body …}` returned verbatim to the server. |
+| **Its input** | The SANITISED `:rf/public-error` map — safe to render. | The raw `(request throwable)`. The locked default NEVER reads the throwable (the `.getMessage` topology-leak boundary). |
+| **HTTP path** | Normal response, projector's status (typically 500) + the rendered page. | Last-resort net OUTSIDE the normal pipeline (the projector never ran / can't run). |
+| **Default when omitted** | Minimal default error template. | Minimal locked 500 (topology-leak-safe generic body). |
+
+Mnemonic: `:error-view` is the **projected page** (drain-time, sanitised, hiccup); `:on-error` is the **transport net** (Ring-layer, raw throwable, outside the projector). Both are bug-contained: a buggy `:error-view` falls back to the default error template; a buggy `:on-error` falls back to the locked default-on-error — neither bypasses the error boundary.
 
 #### Dev vs prod default behaviour
 

--- a/spec/conformance/fixtures/ssr-streaming.edn
+++ b/spec/conformance/fixtures/ssr-streaming.edn
@@ -134,15 +134,17 @@
   ;; render-hash value is pinned by `:ssr/render-to-string` and the
   ;; hash-parity fixture corpus.
   ;;
-  ;; rf2-gtgf9: payload policy is explicit + fail-closed. The
-  ;; conformance fixture opts in to whole-app-db so the payload-keys
-  ;; expectation below covers the full canonical shape rather than a
-  ;; sliced subset.
+  ;; rf2-gtgf9 / rf2-pffil: payload policy is explicit + fail-closed,
+  ;; carried by a single `:payload` opt. The conformance fixture opts in
+  ;; to whole-app-db (`:payload :rf.ssr.payload/whole-app-db`) so the
+  ;; expected-keys set below covers the full canonical shape rather than
+  ;; a sliced subset. (`:expect :payload-keys` is the fixture's
+  ;; expected-top-level-payload-keys assertion, NOT the handler opt.)
   {:call   :ssr.streaming/build-final-payload
-   :input  {:render-hash    "00000000"          ;; placeholder; the implementation
+   :input  {:render-hash "00000000"             ;; placeholder; the implementation
                                                 ;; supplies the real FNV-1a hex here
-            :version        1
-            :payload-policy :rf.ssr.payload/whole-app-db}
+            :version     1
+            :payload     :rf.ssr.payload/whole-app-db}
    :expect {:payload-keys #{:rf/version :rf/frame-id :rf/app-db :rf/render-hash}
             :rf/version   1}}]
 


### PR DESCRIPTION
Three cohesive [api] fixes on the SSR surface.

## rf2-lq2ou (P2) — client hydration boot helper
Ships `re-frame.ssr/hydrate!` (new `re-frame.ssr.boot` ns; re-exported from the façade) — the **symmetric** client-side counterpart of the server-side `ssr-handler`. It fuses the three steps Spec 011 §Client flow mandates into one boot call: READ `__rf_payload` → dispatch `:rf/hydrate` (replace-app-db) → `verify-hydration!` (post-render hash check via a host-supplied `:render-tree-fn`). `read-server-payload` (CLJS-only DOM read) is the reader it builds on; `hydrate!` is platform-neutral so the JVM harness drives the full server-`build-payload` → `hydrate!` → post-hydrate-sub round-trip without a browser. Consolidates the byte-identical `read-server-payload` dance previously duplicated across 3 testbeds + 2 examples.

## rf2-pffil (P3) — payload-opt consolidation (took the CONSOLIDATE path)
Folded the two-opt `:payload-keys` + `:payload-policy` surface into a **single `:payload`** opt — vector → allowlist, `:rf.ssr.payload/whole-app-db` keyword → whole-app-db opt-in. Pre-alpha, **no back-compat shim** (deleted, not deprecated). One value holds exactly one policy, so the prior precedence rule (`:payload-keys` wins) and the silent-ignore branch (a `:payload-policy` discarded alongside an allowlist) are **gone** — the allowlist-vs-whole choice is now the value's shape. Fail-closed preserved: absence → `:rf.error/ssr-missing-payload-policy`, typo keyword → `:rf.error/ssr-unknown-payload-policy`. Updated all call sites (ring + streaming pipeline, both payload builders), the conformance fixture, the example, and the contract test.

## rf2-s2ndr (P3) — `:on-error` vs `:error-view` signpost
Added a decision-table docstring to `ssr-handler` and a normative table to Spec 011 §Server error projection clarifying the division: `:error-view` = the projected error page (drain-time, sanitised public-error, hiccup); `:on-error` = the transport/Ring-layer net (outside the projector, raw throwable, locked topology-leak-safe default). **No rename** (explicitly out of scope).

Per-feature spec touched: `spec/011-SSR.md` + `spec/conformance/fixtures/ssr-streaming.edn` (ssr-family — sole-toucher). **`spec/API.md` + `spec/Conventions.md` untouched.**

## Quality gates
- `implementation/ssr` `clojure -M:test` — **252 tests, 882 assertions, 0 failures, 0 errors** (incl. 4 new boot-helper round-trip tests + the consolidated payload-policy CLJS contract test).
- `implementation/ssr-ring` `clojure -M:test` — **99 tests, 427 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (node runtime) — **5154 tests, 17425 assertions, 0 failures, 0 errors** (exercises the `.cljc` boot helper + payload-policy on CLJS).
- `npm run test:browser` — **N/A**: the hydration helper has NO DOM round-trip test (regression coverage drives `hydrate!` with explicit payloads on JVM + CLJS-node; `read-server-payload`'s DOM read is CLJS-only and not browser-exercised here).
- clj-kondo on changed files — **0 errors, 0 new warnings** (the 6 `Unused private var` warnings in `ssr.cljc` are pre-existing at HEAD; confirmed identical count).
- `mkdocs build --strict` — **clean, exit 0, no anchor/warning issues**.

Regression tests (failing-before / passing-after):
- lq2ou: `boot-hydrate-round-trips-server-payload-into-app-db` (server build → hydrate! → sub), `boot-hydrate-nil-payload-is-client-only-noop`, `boot-hydrate-verify-step-fires-mismatch-on-divergent-render`, `boot-hydrate-verify-step-silent-on-matching-render`.
- pffil: `payload_policy_cljs_test` rewritten for the single `:payload` opt (allowlist slice, whole-app-db, fail-closed, unknown-keyword); ring_test `:payload`-opt wire-level fail-closed proof.

Do NOT merge.
