### PR TITLE
fix(flows): mid-event reg-flow signpost + inputs-are-paths-only doc + encapsulated frame-scoping guidance (rf2-1smwp rf2-4mqfb rf2-ry5ee)

### DIFF
--- a/docs/api/05-flows.md
+++ b/docs/api/05-flows.md
@@ -1,8 +1,8 @@
 # 05 — Flows
 
-A flow is a piece of derived state. You declare its inputs (other paths or subs), its computation (a pure fn over those inputs), and the path in `app-db` it should write its output to. The runtime watches the inputs, recomputes the output when any of them change, and writes the result. It's a sub-with-a-side-effect-on-`app-db` — useful exactly when you want derived state that other code reads via plain `get-in` (or a plain sub), without having to remember to recompute it manually.
+A flow is a piece of derived state. You declare its inputs (a vector of `app-db` **paths** — not subs), its computation (a pure fn over the values at those paths), and the path in `app-db` it should write its output to. The runtime watches the input paths, recomputes the output when any of their values change, and writes the result. It's a sub-with-a-side-effect-on-`app-db` — useful exactly when you want derived state that other code reads via plain `get-in` (or a plain sub over the output path), without having to remember to recompute it manually.
 
-Flows replace v1's `on-changes` interceptor and a chunk of what `reg-sub-raw` was used for. They also replace much of what `enrich` did. The point: derived state is now a *registered, named, observable, restorable* thing, not a closure hidden behind an interceptor.
+Flows replace v1's `on-changes` interceptor — same compute-on-input-change semantics, registered in the runtime rather than wired into individual events. They also replace much of what `enrich` did. The point: derived state is now a *registered, named, observable, restorable* thing, not a closure hidden behind an interceptor.
 
 The normative source is [013-Flows.md](../../spec/013-Flows.md).
 
@@ -59,7 +59,7 @@ The normative source is [013-Flows.md](../../spec/013-Flows.md).
 
 ### Frame-scoping
 
-The `:flow` registrar slot is **last-registration-wins across frames** — registering the same id against multiple frames shares one registrar slot keyed by `flow-id` only. For full per-frame discovery use `@re-frame.flows/flows` directly; the per-frame runtime registry is the source of truth for evaluation. See [013 §Frame-scoping](../../spec/013-Flows.md#frame-scoping).
+The `:flow` registrar slot is **last-registration-wins across frames** — registering the same id against multiple frames shares one registrar slot keyed by `flow-id` only. For full per-frame discovery read the encapsulated runtime registry via the public snapshot accessor `re-frame.flows/flows-snapshot` (it returns the `{frame-id {flow-id flow-map}}` shape) — **not** the private `@re-frame.flows/flows` atom, which is an implementation detail behind the snapshot contract. The per-frame runtime registry is the source of truth for evaluation. See [013 §Frame-scoping](../../spec/013-Flows.md#frame-scoping).
 
 ### Frame-destroy teardown
 
@@ -75,6 +75,28 @@ Sometimes you want to register or clear a flow from inside an event handler — 
 | `[:rf.fx/clear-flow id]` | flow id | v1 | Clear a registered flow at runtime via `:fx`. |
 
 The signature mirrors `reg-flow` / `clear-flow` exactly — same opts, same return semantics. Use whichever surface matches your call site.
+
+### The one-event lag — the least-obvious thing about flows
+
+> A flow registered with `:rf.fx/reg-flow` **does not compute its initial output during that event.** It first fires on the **next** drain on the same frame.
+
+This is the single least-obvious flow behaviour, so it is worth internalising before you reach for `:rf.fx/reg-flow`. The reason is structural: the `:fx` walk is the *last* drain stage, and it runs **after** the flow transform has already evaluated this event's flows (see [Spec 013 §Drain integration](../../spec/013-Flows.md#drain-integration)). The newly-registered flow simply was not in the registry when the transform walked, so it has nothing to compute on *this* event. It computes on the next drain on that frame.
+
+In the common case the lag is invisible — you register a flow in an `:enter`-style handler and the user's next interaction materialises the output. When you genuinely need the initial value *now*, dispatch a follow-up no-op event from the same handler to re-trigger the drain (the flow is in the registry by the time that dispatched event drains):
+
+```clojure
+(rf/reg-event-fx :wizard/enter-step-2
+  (fn [_ _]
+    {:fx [[:rf.fx/reg-flow {:id     :step-2/computed
+                            :inputs [[:step-2 :foo] [:step-2 :bar]]
+                            :output (fn [foo bar] (compute foo bar))
+                            :path   [:step-2 :result]}]
+          [:dispatch [:wizard/settle]]]}))   ;; flow computes on THIS drain
+
+(rf/reg-event-db :wizard/settle (fn [db _] db))   ;; no-op; exists only to drain
+```
+
+This is a deliberate, explicit step — not a hidden one — and most apps never need it. The lag is by design: closing it would require a second `app-db` install per event, breaking the one-install-per-event invariant. See [Spec 013 §Sequencing — the one-event lag](../../spec/013-Flows.md#sequencing--the-one-event-lag) for the full rationale.
 
 ## Failure semantics
 

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -300,6 +300,19 @@
    ;; accept `(arg opts)` with opts carrying `:frame`, and
    ;; `call-frame-scoped-hook!` passes `{:frame frame-id}` as the second
    ;; arg, so one hook pair serves both surfaces.
+   ;;
+   ;; ONE-EVENT LAG — THE LEAST-OBVIOUS FLOW BEHAVIOUR (Spec 013
+   ;; §Sequencing). The `:fx` walk is the LAST drain stage — it runs
+   ;; AFTER the flow-transform `:after` has already evaluated this event's
+   ;; flows (Spec 013 §Drain integration: step 4 runs after step 2). So a
+   ;; flow registered HERE was not in the registry when the flow transform
+   ;; walked, and does NOT compute its initial output on THIS event — it
+   ;; first fires on the NEXT drain on the same frame. This lag is
+   ;; structural (a synchronous re-walk would need a second `app-db`
+   ;; install, breaking the one-install-per-event invariant), NOT a bug.
+   ;; Callers needing the initial value immediately dispatch a follow-up
+   ;; no-op event from the SAME handler (see Spec 013 §Sequencing). Do not
+   ;; "fix" this by re-running the flow transform after `:fx`.
    :rf.fx/reg-flow
    (fn [frame-id _parent-envelope args]
      (call-frame-scoped-hook! :flows/reg-flow frame-id args))

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -811,6 +811,48 @@
     (is (not (contains? (get (rf/frame-db :rf/default) :wizard) :result))
         ":rf.fx/clear-flow dissoc-in'd the output path")))
 
+(deftest fx-reg-flow-mid-event-lag-and-followup-dispatch-workaround
+  ;; rf2-1smwp — pin the LEAST-OBVIOUS flow behaviour as an explicit
+  ;; contract: a flow registered mid-event via `:rf.fx/reg-flow` does NOT
+  ;; compute on THAT event's drain (the `:fx` walk runs after the flow
+  ;; transform — Spec 013 §Sequencing / §Drain integration), and the
+  ;; documented workaround (a follow-up no-op `:dispatch` from the SAME
+  ;; handler) materialises the initial value on the dispatched event's
+  ;; drain. Locks the lag so a future "synchronous re-walk" change can't
+  ;; silently alter it without flipping this test.
+  (rf/reg-event-db :init (fn [_ _] {:wizard {:foo 3 :bar 4}}))
+  ;; Bare register — NO follow-up dispatch. Demonstrates the lag.
+  (rf/reg-event-fx :enter-bare
+    (fn [_ _]
+      {:fx [[:rf.fx/reg-flow {:id     :step-2/computed
+                              :inputs [[:wizard :foo] [:wizard :bar]]
+                              :output (fn [foo bar] (+ foo bar))
+                              :path   [:wizard :result]}]]}))
+  ;; Register + a follow-up no-op `:dispatch` on the same handler — the
+  ;; documented "I need the value now" workaround.
+  (rf/reg-event-fx :enter-with-settle
+    (fn [_ _]
+      {:fx [[:rf.fx/reg-flow {:id     :step-2/computed
+                              :inputs [[:wizard :foo] [:wizard :bar]]
+                              :output (fn [foo bar] (+ foo bar))
+                              :path   [:wizard :result]}]
+            [:dispatch [:wizard/settle]]]}))
+  (rf/reg-event-db :wizard/settle (fn [db _] db))   ;; no-op; exists only to drain
+
+  (testing "the lag — a mid-event reg-flow does NOT compute on its own drain"
+    (rf/dispatch-sync [:init])
+    (rf/dispatch-sync [:enter-bare])
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :step-2/computed)
+        "flow IS registered after :enter-bare")
+    (is (nil? (get-in (rf/frame-db :rf/default) [:wizard :result]))
+        "but :result is STILL unset — the flow did not run on the registering event's drain"))
+
+  (testing "the workaround — a follow-up :dispatch materialises the value on the next drain"
+    (rf/dispatch-sync [:init])
+    (rf/dispatch-sync [:enter-with-settle])
+    (is (= 7 (get-in (rf/frame-db :rf/default) [:wizard :result]))
+        "the :dispatch [:wizard/settle] re-triggered the drain, so the flow computed 3 + 4 = 7")))
+
 ;; ---------------------------------------------------------------------------
 ;; 6. clear-all / clean-state interaction with :flow registrar slot
 ;; ---------------------------------------------------------------------------

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -104,7 +104,7 @@ Three consequences follow:
 
 **Registrar slot semantics under multi-frame registration.** The `:flow` registrar kind (per [001-Registration §Registration grammar](001-Registration.md#registration-grammar)) is keyed by `flow-id` only — the same flow id registered against multiple frames shares one registrar slot. The per-frame runtime registry `{frame-id {flow-id flow-map}}` is the source of truth for evaluation; the registrar slot is metadata used for hot-reload tracking and tooling introspection. When the same flow id is registered against two frames with different `:output` fns and `:path` slots, **the registrar slot carries the most-recently-registered frame's flow-map** with `:frame frame-id` stamped into the metadata. Callers reading the slot via the registrar (e.g. a Xray flow panel that wants to enumerate "all flows in the runtime") observe last-registration-wins on the metadata view while every frame's flow walk (`run-flows-on-db`) continues to evaluate against its own slot of the runtime registry unaffected.
 
-This asymmetry is **intentional for v1**: the runtime correctness (each frame's flows compute independently) is the load-bearing property; the registrar metadata is a tooling convenience. A future spec revision MAY introduce a frame-aware query surface (`flow-meta` / `(flows {:frame ...})`) or migrate the registrar slot to a frame-indexed shape, but doing so today would inflate the registrar API surface for a use case (tools enumerating cross-frame flows) that has not surfaced in v1. Apps targeting multi-tenant frames with shared flow ids and per-frame-different definitions should rely on the runtime registry (`@re-frame.flows/flows`), not the registrar slot, for full per-frame discovery.
+This asymmetry is **intentional for v1**: the runtime correctness (each frame's flows compute independently) is the load-bearing property; the registrar metadata is a tooling convenience. A future spec revision MAY introduce a frame-aware query surface (`flow-meta` / `(flows {:frame ...})`) or migrate the registrar slot to a frame-indexed shape, but doing so today would inflate the registrar API surface for a use case (tools enumerating cross-frame flows) that has not surfaced in v1. Apps targeting multi-tenant frames with shared flow ids and per-frame-different definitions should read the runtime registry through the public snapshot accessor `re-frame.flows/flows-snapshot` (returning the `{frame-id {flow-id flow-map}}` shape), **not** the private `@re-frame.flows/flows` atom and **not** the registrar slot, for full per-frame discovery. The `flows-snapshot` accessor is the encapsulation boundary: the per-frame registry atom is private (the facade re-exports only the read accessors `flows-snapshot` / `last-inputs-snapshot` and the reset fns), so consumers depending on the snapshot survive any future change to the atom's internal representation.
 
 Frame defaulting matches the rest of the API: a bare `(reg-flow flow)` resolves the frame via `(current-frame)`, picking up `with-frame` bindings or falling through to `:rf/default`. Tests and per-tenant runtimes that need an explicit frame pass `{:frame ...}` as the second arg.
 
@@ -380,7 +380,33 @@ Two reserved fx-ids let event handlers register and clear flows during normal ev
 
 **Frame routing.** Both fx run inside the standard `:fx` walk and receive the `{:frame frame-id}` cofx from the dispatching frame. They thread the frame through to `reg-flow` / `clear-flow` as the `:frame` opt — there is no explicit `:frame` to set in the fx args. A flow registered via `:rf.fx/reg-flow` from an event dispatched on frame `:left` is registered against `:left`; the same fx invoked from a `:right` dispatch routes to `:right`. This makes fx-driven flow lifecycle (wizard step in / out, feature gating) automatically frame-correct without ceremony.
 
-**Sequencing.** `:rf.fx/reg-flow` and `:rf.fx/clear-flow` run during the standard `:fx` walk (per [002 §`:fx` ordering and atomicity guarantees](002-Frames.md#fx-ordering-and-atomicity-guarantees)) — *after* the flow after-interceptor has already evaluated for the current event. A flow registered mid-event therefore first runs on the *next* event drain on the same frame. Its initial output appears one event after registration. Apps that need the value immediately can dispatch a synthetic re-walk event after registration.
+### Sequencing — the one-event lag
+
+> **This is the single least-obvious thing about flows. Read it before you reach for `:rf.fx/reg-flow`.** A flow registered mid-event does **not** compute its initial output during *that* event — it first fires on the **next** drain on the same frame.
+
+`:rf.fx/reg-flow` and `:rf.fx/clear-flow` run during the standard `:fx` walk (per [002 §`:fx` ordering and atomicity guarantees](002-Frames.md#fx-ordering-and-atomicity-guarantees)) — and the `:fx` walk is the *last* drain stage, **after** the flow-transform `:after` has already evaluated for the current event (per [§Drain integration](#drain-integration), step 4 runs after step 2). The newly-registered flow was not in the per-frame registry when the flow transform walked it, so it cannot have computed. Its initial output therefore appears **one event after registration**, on the next drain on the same frame.
+
+This lag is a **structural consequence of the [§Drain integration](#drain-integration) contract**, not an oversight. The flow transform rewrites the handler's *pending* `:db` effect as the outermost `:after` (step 2); the single deferred `:db` install (step 3) is the cascade's only `app-db` write; `:fx` walks last (step 4). Re-running the flow transform after `:fx` registered a new flow would require a *second* `app-db` install in the same event — breaking the "exactly one `:db` install per event" invariant ([§Drain integration](#drain-integration) property 4), the pending-effect-transform model ([§Resolved decisions §Flows transform the pending `:db` effect](#flows-transform-the-pending-db-effect-as-the-outermost-after-resolved)), and the atomic-commit contract ([§Failure semantics](#failure-semantics)). So the lag stands by design; closing it would mean either a post-install re-walk (the prior design, removed outright) or an async mid-event re-walk (deferred — see [§Open questions §Synchronous re-walk after `:rf.fx/reg-flow`](#synchronous-re-walk-after-rffxreg-flow)).
+
+**Working with the lag.** In the common case the lag is invisible: you register a flow in `:enter` and the user's *next* interaction (which dispatches an event) materialises the output. When you genuinely need the initial value *now*, dispatch a follow-up event from the same handler whose only job is to re-trigger the drain — the flow computes on that drain:
+
+```clojure
+(rf/reg-event-fx :wizard/enter-step-2
+  (fn [_ _]
+    {:fx [[:rf.fx/reg-flow {:id     :step-2/computed
+                            :inputs [[:step-2 :foo] [:step-2 :bar]]
+                            :output (fn [foo bar] (compute foo bar))
+                            :path   [:step-2 :result]}]
+          ;; The flow is in the registry by the time THIS dispatched event
+          ;; drains — so the flow transform on :wizard/settle computes the
+          ;; initial output. Without this, :step-2/result stays unset until
+          ;; the user's next interaction.
+          [:dispatch [:wizard/settle]]]}))
+
+(rf/reg-event-db :wizard/settle (fn [db _] db))   ;; no-op; exists only to drain
+```
+
+This is a deliberate, explicit step — not a hidden one. Most apps never need it.
 
 **`clear-flow` cleanup.** Default behaviour is `dissoc-in` on the flow's `:path` in the owning frame's `app-db` — the slot is vacated when the flow goes away. Stale derived values left behind would confuse downstream consumers. Apps that want to preserve the value should copy it elsewhere before clearing. Sibling frames are unaffected.
 
@@ -440,7 +466,7 @@ The vector form (`:inputs [[:width] [:height]] :output (fn [w h] ...)`) matches 
 
 ### Synchronous re-walk after `:rf.fx/reg-flow`
 
-A flow registered mid-event first fires on the next event drain (one-event lag for the initial value). An opt-in "register and run immediately" effect could close the lag at the cost of mid-event re-walking. Defer until a real use case forces it. **Status:** `:post-v1 tracked` — file a bead when a concrete use case surfaces.
+A flow registered mid-event first fires on the next event drain (one-event lag for the initial value — the structural consequence documented at [§Sequencing — the one-event lag](#sequencing--the-one-event-lag)). An opt-in "register and run immediately" effect could close the lag at the cost of a *second* mid-event `app-db` install, which would break the one-install-per-event invariant ([§Drain integration](#drain-integration) property 4) and the atomic-commit contract ([§Failure semantics](#failure-semantics)) — so it is genuinely deferred design work, not a quick toggle. Until then the lag is loudly signposted (spec §Sequencing, the `:rf.fx/reg-flow` fx-handler docstring, and [docs/api/05-flows.md §The one-event lag](../docs/api/05-flows.md)) and worked around with an explicit follow-up `:dispatch`. Defer until a real use case forces it. **Status:** `:post-v1 tracked` — file a bead when a concrete use case surfaces.
 
 ## Resolved decisions
 


### PR DESCRIPTION
Three cohesive [api] FLOWS-surface hygiene fixes (Shape-2 cluster). Pre-alpha masterpiece stance; no back-compat shims.

## rf2-1smwp (P2) — mid-event `:rf.fx/reg-flow` lag: SIGNPOSTED (not killed)
The one-event lag is the least-obvious flow behaviour: a flow registered during the `:fx` walk does not compute on that event's drain (the `:fx` walk runs *after* the flow-transform `:after` per Spec 013 §Drain integration). **Killing the lag is architecturally unsafe** — a synchronous re-walk needs a *second* `app-db` install per event, breaking the one-install-per-event invariant (§Drain integration property 4), the pending-effect-transform model, and the atomic-commit contract (all RESOLVED/locked decisions). The "synthetic re-walk" was already a `:post-v1 tracked` open question. So per the bead's "kill if safe, else loud signpost" instruction the fix is a **loud signpost**:
- spec/013 §Sequencing elevated from a buried one-liner into a named callout with rationale + the explicit follow-up-`:dispatch` workaround;
- a loud `ONE-EVENT LAG` dev note at the `:rf.fx/reg-flow` fx-handler in `fx.cljc` ("do not 'fix' this by re-running the flow transform after `:fx`");
- a new docs/api §The one-event lag section (the doc had nothing before);
- §Open questions tightened to explain *why* it is deferred design work.

## rf2-4mqfb (P3) — inputs are PATHS ONLY
docs/api/05-flows.md falsely said inputs are "paths or subs". Fixed to "a vector of `app-db` **paths** — not subs" and removed the stale `reg-sub-raw` framing.

## rf2-ry5ee (P3) — encapsulated frame-scoping discovery
Frame-scoping discovery guidance pointed at the private `@re-frame.flows/flows` atom, contradicting the flows-snapshot encapsulation contract. Repointed both spec/013 §Frame-scoping and docs/api at the public `re-frame.flows/flows-snapshot` accessor (with a note that the atom is private behind the snapshot).

## Regression test
`fx-reg-flow-mid-event-lag-and-followup-dispatch-workaround` (flows_test.clj) pins both the lag (mid-event register → `:result` still unset on that drain) and the workaround (follow-up `:dispatch` → value materialises). Locks the behaviour so a future "synchronous re-walk" can't silently change it.

## Quality gates
- flows `clojure -M:test`: **124 tests, 525 assertions, 0 failures, 0 errors** (incl. the new regression test)
- `npm run test:cljs`: **5169 tests, 17558 assertions, 0 failures, 0 errors**
- clj-kondo on changed clj/cljc (`fx.cljc`, `flows_test.clj`): **0 errors, 0 warnings**
- `mkdocs build --strict`: **rc=0, no warnings, all cross-reference anchors resolve**

spec/013 + docs/api/05-flows.md updated; spec/API.md + Conventions untouched. No namespace signatures changed (docstrings/comments/prose/test only) — no consumer gating needed; the only non-test `re-frame.flows` requirers are internal flows files.
