### PR TITLE
docs(adapters): cross-substrate frame affordance table + frame-provider honest-error reconcile (rf2-cmbum rf2-fizli rf2-7kii2)

### DIFF
--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1075,6 +1075,25 @@ Implementation notes:
 
 Every other adapter primitive (read, replace, subscribe-container, dispose) is structurally identical to the Reagent and UIx adapters' — the contract is genuinely substrate-agnostic, and the Helix port surfaces no friction against the decision set.
 
+## Cross-substrate affordance summary
+
+The nine-fn substrate contract is identical across adapters, but the three **view-author-facing** surfaces — *read a subscription*, *scope a frame to a subtree*, *flush pending renders in a test* — differ per substrate because each rides its host's idiom (Reagent's reactive deref vs the React-hooks model). A dev moving between substrates needs the one-glance map; this table is it. It documents the surfaces **after** the rf2-z7hfp restructure, in which each React-shaped adapter's `frame-provider` is a **native substrate component** (UIx `defui`, Helix `defnc`) rather than a re-exported plain fn handed to `$`.
+
+| Affordance | Reagent (`day8/re-frame2-reagent`) | UIx (`day8/re-frame2-uix`) | Helix (`day8/re-frame2-helix`) |
+|---|---|---|---|
+| **Read a subscription** | `@(rf/subscribe [:q …])` — reactive deref inside a `reg-view`/Form-2 render fn. | `(use-subscribe [:q …])` — React hook (re-renders on change via `useSyncExternalStore`). | `(use-subscribe [:q …])` — React hook (same surface as UIx). |
+| **Explicit-frame read** | `@(rf/subscribe frame-id [:q …])` (2-arg). | `(use-subscribe frame-id [:q …])` (2-arg). | `(use-subscribe frame-id [:q …])` (2-arg). |
+| **Frame resolution (1-arg form)** | dynamic-var → React-context (surrounding `frame-provider`) → `:rf/default`. | Same chain; React-context tier read via `use-context`. | Same chain; React-context tier read via `use-context`. |
+| **Scope a frame to a subtree** (`frame-provider`) | Native hiccup component; **trailing-positional children**: `[rf/frame-provider {:frame :f} [header] [main]]`. | Native `defui` component, mounted via `$`; **children passed under `:children` in the props map**: `($ frame-provider {:frame :f :children [($ header) ($ main)]})`. | Native `defnc` component, mounted via `$`; **children under `:children` in props**: `($ frame-provider {:frame :f :children [($ header) ($ main)]})`. |
+| **Missing / `nil` `:frame`** | Falls through to `:rf/default` (deliberate default — matches the no-provider case; see [§Frame-provider via React context](#frame-provider-via-react-context)). | Same — `:rf/default`. | Same — `:rf/default`. |
+| **Frame keyword fidelity under the mount idiom** | `:r>` interop head bypasses Reagent prop conversion, so a namespaced frame keyword survives the React-context round trip. | The native `defui` routes props through UIx's lossless `argv` channel — keyword frame-ids survive intact by construction (rf2-z7hfp; was rf2-8svnm). | The native `defnc` routes props through `extract-cljs-props` (keyword keys + preserved keyword values) — survives by construction (rf2-z7hfp; was rf2-9ok1s). |
+| **Flush pending renders in a test** | No spine `flush-views!`. Classic Reagent uses Reagent's own `r/flush!` / `act` harness; `reagent-slim` ships its own `reagent2.dom.client/flush-views!`. | `(uix-adapter/flush-views!)` — wraps React's `act()` (per-adapter-require entry point). | `(helix-adapter/flush-views!)` — wraps React's `act()` (same surface as UIx). |
+| **`reg-view` macro** | Available (canonical view-registration surface). | `reg-view*` (plain-fn) when registry addressing is needed; most components are bare `defui`. | `reg-view*` (plain-fn) when needed; most components are bare `defnc`. |
+
+All three adapters read the **same** React Context object (`re-frame.adapter.context/frame-context` in core), so a mixed-substrate `frame-provider` chain composes — a UIx subtree under a Reagent provider (or vice versa) resolves the same frame.
+
+> **Known call-shape asymmetry (rf2-7kii2).** `frame-provider`'s children-passing differs across substrates: Reagent takes trailing-positional children (idiomatic hiccup), while UIx/Helix take children under a `:children` key in the props map. The rf2-z7hfp restructure made the keyword-mangling class impossible by construction but deliberately **preserved the documented call shapes**; whether to unify them onto the idiomatic per-substrate `$` trailing-args form is a separate design decision tracked outside this table.
+
 ## Subscription topology vs subscription tracking
 
 A subtle distinction worth pulling out: **the static topology of the sub graph is core; the runtime tracking is adapter**.


### PR DESCRIPTION
Reconciles three Shape-2-cluster [api] beads on the adapters / frame-provider surface against the just-merged **rf2-z7hfp (#2717)** restructure (native `defui`/`defnc`/hiccup frame-provider shells above the prop-marshalling seam, shared substrate-agnostic core).

## Reconcile verdict

- **rf2-fizli (P2) — VERIFIED-RESOLVED-BY-z7hfp.** The honest-error fizli wanted targeted the *recognised-but-dishonoured* `:frame` case — the keyword namespace-mangle that produced rf2-9ok1s (Helix raw-JS-object string keys) and rf2-8svnm (UIx keyword-value stringify). z7hfp made that class **impossible by construction**: `frame-provider` is now a native `defui`/`defnc` component above the marshalling seam, so a keyword frame-id survives intact (UIx `argv` channel; Helix `extract-cljs-props`). The remaining *genuinely-missing/nil* `:frame -> :rf/default` path is **not** a no-silent-swallow violation (rf2-3nbl5.1): the value is *absent*, not recognised-but-dishonoured, and the fall-through is a **deliberate, tested default** (`adapters/reagent/.../runtime_cljs_test.cljs` `deftest frame-provider-default-fallback-no-frame-key` asserts `{}` and `{:frame nil}` -> `:rf/default` as valid; spec/006 §Frame-provider via React context). A warn there would contradict the tested contract + warn on legitimate tooling-elided trees. **No code change.**

- **rf2-7kii2 (P2) — PARTIALLY resolved; residual is a genuine Mike design ruling, KEPT OPEN.** z7hfp resolved the prop-mangle half. NOT resolved: the **call-shape inconsistency** — Reagent takes trailing-positional children (`[rf/frame-provider {:frame :f} c1 c2]`) while UIx/Helix still require children under `:children` in the props map (`($ frame-provider {:frame :f :children [c1 c2]})`), which is not the idiomatic UIx/Helix `$` trailing-args shape. z7hfp's own commit msg: "Spec unchanged (call shapes preserved)". Unifying them (findings Option A/B/C) is a public-API change across two substrates + spec/API.md — beyond a worker clear-fix; needs Mike's option-pick. **Documented** as a "Known call-shape asymmetry" note in the new table; bead left OPEN as a decision.

- **rf2-cmbum (P3) — done.** Added a **§Cross-substrate affordance summary** table to `spec/006-ReactiveSubstrate.md` (after the Helix reference section): read-a-subscription / explicit-frame read / frame resolution / scope-a-frame (`frame-provider`) / missing-frame / keyword fidelity / test-flush / `reg-view` macro, across Reagent / UIx / Helix — accurate to the post-z7hfp native-component shape.

**Net: docs-only.** One file changed: `spec/006-ReactiveSubstrate.md` (+19). No adapter code touched.

## Quality gates

- `python -m mkdocs build --strict` — **PASS** (exit 0; "Documentation built in 8.97 seconds"; no WARNING/ERROR).
- `python scripts/check_doc_slugs.py` — **PASS** (exit 0).
- `python scripts/check_readme_links.py` — **PASS** (exit 0).
- **Docs-only — rf2-7kii2/rf2-fizli verified resolved by z7hfp** (no adapter code changed), so adapters JVM matrix / `npm run test:cljs` / `npm run test:browser` / clj-kondo are N/A this PR.
- **spec/006 touched** (sole-toucher, surgical +19-line append). **spec/API.md and spec/Conventions.md untouched.** docs/guide/ untouched (Mike's avb5k lane).

Do not merge — reconcile review.