### PR TITLE
fix(routing): authoring-boundary metadata validation + navigate-arity schema + route-url nil-policy docs (rf2-45b95 rf2-1os1c rf2-b3rzz)

### DIFF
--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -11,12 +11,48 @@
   facade owns the `events/reg-event-fx :rf.route/navigate` call so a
   `:reload` re-wires it on a fresh registrar. Per the rf2-2yabr cohesion
   split: NAVIGATE-EVENT seam."
-  (:require [re-frame.registrar :as registrar]
+  (:require [clojure.string :as str]
+            [re-frame.registrar :as registrar]
             [re-frame.routing.can-leave :as can-leave]
             [re-frame.routing.events :as routing-events]
             [re-frame.routing.registry :as registry]
             [re-frame.routing.scroll :as scroll]
             [re-frame.trace :as trace]))
+
+;; Per Spec 012 §Navigation is an event — the arity contract:
+;;   [:rf.route/navigate target]              ;; no path-params, no opts
+;;   [:rf.route/navigate target params]       ;; params 2nd, opts absent
+;;   [:rf.route/navigate target params opts]  ;; params 2nd, OPTS THIRD
+;; The two trailing maps are positionally ambiguous to a reader
+;; (rf2-1os1c): the likely mistake is dropping an OPTS-shaped map into
+;; the PARAMS slot — `[:rf.route/navigate :route/x {:replace? true}]`
+;; reads as "navigate with these path-params" but the author meant opts.
+;; `opts-only-keys` names the keys that ONLY ever belong in the opts map.
+(def ^:private opts-only-keys
+  "Keys the trailing `opts` map recognises (Spec 012 §Navigation is an
+  event) that are NOT path-param names. An occurrence of one of these in
+  the PARAMS slot — and not as a declared path-param of the target route
+  — is the classic params/opts swap and is rejected (rf2-1os1c)."
+  #{:replace? :scroll :fragment :bypass-leave-guard?})
+
+(defn- misplaced-opts-keys
+  "Disambiguate the params/opts positional swap (rf2-1os1c). Returns the
+  seq of opts-only keys present in the PARAMS slot that the target route
+  does NOT declare as path-params — i.e. keys that can only sensibly be
+  opts. Empty (falsy via `seq`) when `params` is clean. Route-id form
+  only; the `{:url ...}` form has no positional params slot.
+
+  Declared path-param names are read from the compiled pattern's
+  `:names` (string capture names), so a route that legitimately captures
+  a segment named `:scroll`/`:fragment`/… is never false-flagged."
+  [route-meta params]
+  (when (and (map? params) (seq params))
+    (let [declared (into #{}
+                         (map keyword)
+                         (:names (:rf.route/compiled route-meta)))]
+      (seq (filter (fn [k] (and (contains? opts-only-keys k)
+                                (not (contains? declared k))))
+                   (keys params))))))
 
 (defn navigate-handler
   "`:rf.route/navigate` event-fx handler. Registered by the façade so a
@@ -53,6 +89,11 @@
                           (and (map? target) (:fragment target))
                           matched-fragment)
           route-meta  (registrar/lookup :route route-id)
+          ;; rf2-1os1c: catch the params/opts positional swap at the
+          ;; event boundary. Route-id form only — the `{:url ...}` form
+          ;; has no positional params slot.
+          misplaced   (when (keyword? target)
+                        (misplaced-opts-keys route-meta params))
           ;; Per Spec 012 §Query strings and fragments: `:query-retain`
           ;; on the TARGET route names the keys that should be carried
           ;; through from the current `:rf.route/query` slice when the
@@ -63,6 +104,24 @@
           ;; automatically preserve `?theme=dark` / `?locale=en`
           ;; without explicitly threading those keys through every call
           ;; site (rf2-u8t3s). Caller-supplied values always win.
+          ;; Cross-route coercion-class carry (rf2-b3rzz): retained
+          ;; values are pulled from the CURRENT route's `:query` slice
+          ;; VERBATIM — already coerced to that route's class (a keyword
+          ;; via `[:enum ...]`, an int via `:int`, …) — and carried into
+          ;; the target unchanged. They are NOT re-coerced against the
+          ;; target route's `:query` schema. The target's `:query`
+          ;; validator still runs at the call site (below + in
+          ;; `route-url`), so a class mismatch (current route typed the
+          ;; key `[:enum :a :b]`, target types it `:string`) surfaces as
+          ;; a validation failure rather than silently desyncing. The
+          ;; contract: authors keep a `:query-retain` key's type
+          ;; CONSISTENT across every route that retains it (same trust
+          ;; class as the `:query` schema being author-named intent).
+          ;; Re-coercion was considered + rejected: retained values are
+          ;; runtime values, not URL strings, so re-running
+          ;; string→class coercion is ill-typed; verbatim-carry keeps the
+          ;; merge a pure `select-keys`. See Spec 012 §Query strings and
+          ;; fragments §:query-retain cross-route coercion class.
           retain-keys  (:query-retain route-meta)
           retained     (when (seq retain-keys)
                          (select-keys (get-in db [:rf/runtime :routing :current :query])
@@ -106,6 +165,30 @@
                            (get-in db [:rf/runtime :routing :current])
                            route-id path-params query-params fragment)]
       (cond
+        ;; rf2-1os1c: params/opts positional swap. An opts-only key
+        ;; (`:replace?` / `:scroll` / `:fragment` / `:bypass-leave-guard?`)
+        ;; sits in the PARAMS slot and is not a declared path-param of
+        ;; the target route — the author almost certainly meant to pass
+        ;; it as the THIRD `opts` arg. Reject loudly (caller bug; slice
+        ;; unchanged, no push) so the swap fails at the event boundary
+        ;; rather than navigating with a wrong URL or silently dropping
+        ;; the intended opts. Per Spec 012 §Navigation is an event.
+        (seq misplaced)
+        (do
+          (trace/emit-error! :rf.error/navigate-arity-misuse
+                             {:where    :event
+                              :route-id route-id
+                              :reason   (str "opts-shaped key(s) "
+                                             (str/join ", " (map pr-str misplaced))
+                                             " appeared in the PARAMS slot (2nd arg) of "
+                                             "[:rf.route/navigate " route-id " params opts]. "
+                                             "These belong in the OPTS map (3rd arg): "
+                                             "[:rf.route/navigate " route-id " {} {...opts}]. "
+                                             "Navigation rejected.")
+                              :keys     (vec misplaced)
+                              :recovery :no-recovery})
+          {})
+
         ;; Caller-bug schema failure: reject (slice unchanged, no push).
         (= ::reject url)
         {}

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -16,7 +16,8 @@
   `registry/` alias, but the published API surface remains the
   facade's re-exports. Per the rf2-2yabr cohesion split: REGISTRY +
   MATCH/EMIT seam."
-  (:require [re-frame.registrar :as registrar]
+  (:require [clojure.string :as str]
+            [re-frame.registrar :as registrar]
             [re-frame.late-bind :as late-bind]
             [re-frame.routing.match :as match]
             [re-frame.routing.url :as url]
@@ -119,6 +120,75 @@
 
 (declare compile-query-coercions)
 
+;; ---- authoring-boundary metadata validation ------------------------------
+;; Per Spec 012 §Reserved route-metadata keys. `reg-route` has the
+;; largest registration shape in the v2 surface (twelve reserved keys);
+;; a typo'd key (`:on-matched` for `:on-match`) or an opts-shaped map in
+;; the wrong slot would otherwise pass silently at registration and fail
+;; later at nav-time, or never. We fail LOUDLY at the authoring boundary
+;; (rf2-45b95): bare keys outside the reserved set are rejected; hosts
+;; and apps add their own keys under a namespace (`:myapp/*`), which are
+;; always allowed (per Spec 012 §Other pattern-level requirements — route
+;; metadata is an open map for NAMESPACED keys only).
+
+(def ^:private reserved-route-keys
+  "Route-metadata keys `reg-route` accepts as bare (unqualified) keys;
+  any other bare key is a likely typo and is rejected at registration.
+
+  The first twelve are the routing-owned reserved keys per Spec 012
+  §Reserved route-metadata keys. `:head` is a CROSS-FEATURE reserved
+  key owned by SSR (Spec 011 §Head/meta contract — \"routes name which
+  head to use via `:head` route metadata\"); Spec 012 itself lists it as
+  a valid route-metadata key alongside the routing-owned set (Spec 012
+  §Route-not-found). Cross-feature reserved keys are enumerated here so
+  the authoring guard does not false-flag a legitimate SSR route."
+  #{;; routing-owned (Spec 012 §Reserved route-metadata keys)
+    :doc :path :params :query :query-defaults :query-retain
+    :tags :parent :on-match :on-error :scroll :can-leave
+    ;; cross-feature: SSR head selection (Spec 011 §Head/meta contract)
+    :head})
+
+(defn- validate-route-metadata!
+  "Authoring-boundary guardrail for `reg-route` (rf2-45b95). Throws
+  `:rf.error/invalid-route-metadata` (canonical thrown-error shape, per
+  Spec 009) when `metadata` carries a BARE key outside the reserved set —
+  the common typo case (`:on-matched` for `:on-match`). Namespaced keys
+  (`:myapp/analytics-id`) are host/app extension points and always pass
+  (Spec 012 §Reserved route-metadata keys). A non-map `metadata` is also
+  rejected here so the failure names the route at the authoring boundary
+  rather than NPE-ing downstream.
+
+  The thrown error names every offending key under `:keys` and carries
+  the reserved set under `:reserved` so the message is actionable —
+  authors see exactly which key is wrong and what the valid vocabulary
+  is. Fails in dev AND prod (it is a caller bug, not user input)."
+  [id metadata]
+  (when-not (map? metadata)
+    (throw (route-error
+             :rf.error/invalid-route-metadata
+             'rf/reg-route
+             (str "route " id "'s metadata must be a map, got " (pr-str (type metadata)))
+             {:route-id id :value metadata})))
+  (let [bad (into []
+                  (comp (map key)
+                        (remove qualified-keyword?)
+                        (remove reserved-route-keys))
+                  metadata)]
+    (when (seq bad)
+      (throw (route-error
+               :rf.error/invalid-route-metadata
+               'rf/reg-route
+               (str "route " id " declares unknown metadata "
+                    (if (= 1 (count bad)) "key " "keys ")
+                    (str/join ", " (map pr-str bad))
+                    " — bare keys outside the reserved set are rejected as likely "
+                    "typos (e.g. :on-matched for :on-match). Reserved keys: "
+                    (str/join ", " (map pr-str (sort reserved-route-keys)))
+                    ". Host/app extension keys must be namespaced (e.g. :myapp/analytics-id).")
+               {:route-id id
+                :keys     bad
+                :reserved reserved-route-keys})))))
+
 ;; ---- registration --------------------------------------------------------
 
 (defn reg-route
@@ -132,6 +202,12 @@
   (per Spec 012 §Route ranking algorithm — rule 6) so tooling can flag
   the conflict."
   [id metadata]
+  ;; Authoring-boundary guardrail (rf2-45b95): reject bare metadata keys
+  ;; outside the reserved set BEFORE any computation, so a typo fails
+  ;; loudly at registration naming the bad key. Runs on the
+  ;; user-supplied map (pre-merge-coords) so it never sees the computed
+  ;; `:rf.route/*` / source-coord keys.
+  (validate-route-metadata! id metadata)
   (let [pattern      (match/canonical-route-pattern (:path metadata))
         metadata     (assoc metadata :path pattern)
         idx          (swap! reg-counter inc)
@@ -628,6 +704,27 @@
   the route's `:params` schema, or query-params doesn't conform to the
   route's `:query` schema (caller bug — not user input). The exception
   carries `{:route-id :slot :error}` ex-data (rf2-ug2m1).
+
+  NIL-POLICY ASYMMETRY between PATH params and QUERY params (rf2-b3rzz —
+  deliberate, documented here so the split never costs a debugging
+  session):
+
+  - PATH params: a `nil` (or absent) value for a required `:name` /
+    `*name` segment is a HARD ERROR — throws
+    `:rf.error/missing-route-param`. The URL cannot be built without it.
+    A present-but-FALSY value (`false`, `0`, `\"\"`) is legitimate and
+    round-trips (the `if-some` discipline below discriminates falsy from
+    absent).
+  - QUERY params: a `nil`-valued key is SILENTLY ELIDED — `{:page nil}`
+    omits the key entirely rather than emitting a bare `?page=` or
+    throwing. This is the useful default for absent OPTIONAL query keys
+    (a search form that conditionally adds `?sort=` only when a sort is
+    chosen). A present-but-FALSY query value (`false`, `0`, `\"\"`) is a
+    legitimate value and round-trips, same as the path side.
+
+  So `nil` means \"hard error\" on the path side and \"omit this key\" on
+  the query side — same function, two nil-policies. Authors relying on a
+  query key being present must supply a non-nil value.
 
   Performance (rf2-r1in4): this fn sits on the render path through
   `route-link-render` / `route-link-render-ssr` — large link lists

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -3317,3 +3317,148 @@
                compiled "/users/42/posts/9"))
           "the same pattern DOES match when both captures are present —
            sanity-check the test isn't accepting only the negative cases"))))
+
+;; ---- rf2-45b95: reg-route authoring-boundary metadata validation ----------
+;;
+;; Spec 012 §Reserved route-metadata keys: reg-route has the largest
+;; registration shape in the v2 surface (twelve reserved keys). A typo'd
+;; key (:on-matched for :on-match) used to pass silently at registration
+;; and fail later at nav-time, or never. The authoring-boundary guardrail
+;; (rf2-45b95) rejects bare keys outside the reserved set LOUDLY at
+;; registration, naming the bad key; namespaced host/app keys pass.
+
+(deftest reg-route-rejects-unknown-bare-metadata-key
+  (testing "rf2-45b95: a typo'd bare metadata key (:on-matched for
+            :on-match) throws :rf.error/invalid-route-metadata at
+            registration, naming the bad key"
+    (let [ex (try
+               (rf/reg-route :route/typo {:path "/typo" :on-matched [[:load]]})
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex)
+          "reg-route THROWS on an unknown bare metadata key (no silent accept)")
+      (is (= :rf.error/invalid-route-metadata (:rf.error/id (ex-data ex)))
+          "the canonical thrown-error id discriminates the failure")
+      (is (= 'rf/reg-route (:where (ex-data ex)))
+          ":where names the public surface fn")
+      (is (= [:on-matched] (:keys (ex-data ex)))
+          ":keys names exactly the offending key so the message is actionable")
+      (is (clojure.string/includes? (:reason (ex-data ex)) ":on-matched")
+          "the human-readable :reason names the bad key"))))
+
+(deftest reg-route-accepts-valid-and-namespaced-metadata
+  (testing "rf2-45b95: a route using only reserved keys + namespaced
+            host/app keys registers fine (no false positives)"
+    (is (= :route/ok
+           (rf/reg-route :route/ok
+                         {:doc            "fine"
+                          :path           "/ok/:id"
+                          :params         [:map [:id :string]]
+                          :query          [:map [:q {:optional true} :string]]
+                          :query-defaults {:q "x"}
+                          :query-retain   #{:theme}
+                          :tags           #{:public}
+                          :on-match       [[:load]]
+                          :on-error       [:oops]
+                          :scroll         :top
+                          ;; namespaced host/app extension keys always pass
+                          :myapp/layout   :wide
+                          :myapp/analytics-id "abc"}))
+        "a route with every reserved key + namespaced extension keys registers")
+    (is (some? (rf/handler-meta :route :route/ok))
+        "the route is queryable via handler-meta after a clean registration")))
+
+(deftest reg-route-rejects-non-map-metadata
+  (testing "rf2-45b95: non-map metadata is rejected at the authoring
+            boundary naming the route (no downstream NPE)"
+    (let [ex (try (rf/reg-route :route/bad "/not-a-map")
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/invalid-route-metadata (:rf.error/id (ex-data ex)))
+          "non-map metadata surfaces the same canonical error id"))))
+
+;; ---- rf2-1os1c: :rf.route/navigate params/opts positional swap ------------
+;;
+;; Spec 012 §Navigation is an event: the two trailing maps (params 2nd,
+;; opts 3rd) are positionally ambiguous. The disambiguating guard
+;; (rf2-1os1c) rejects an opts-only key (:replace? / :scroll / :fragment /
+;; :bypass-leave-guard?) sitting in the PARAMS slot when it is not a
+;; declared path-param of the target route, and emits
+;; :rf.error/navigate-arity-misuse.
+
+(deftest navigate-rejects-opts-shaped-map-in-params-slot
+  (testing "rf2-1os1c: [:rf.route/navigate :route/x {:replace? true}]
+            (opts in the params slot) is rejected — slice unchanged, no
+            push, :rf.error/navigate-arity-misuse emitted"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (let [before (get-in (rf/frame-db :rf/default) [:rf/runtime :routing :current])
+            traces (atom [])]
+        (rf/register-listener! ::arity (fn [ev] (swap! traces conj ev)))
+        ;; The classic swap: {:replace? true} meant for the opts (3rd)
+        ;; slot, supplied in the params (2nd) slot.
+        (rf/dispatch-sync [:rf.route/navigate :route/cart {:replace? true}])
+        (rf/unregister-listener! ::arity)
+        (is (= before (get-in (rf/frame-db :rf/default) [:rf/runtime :routing :current]))
+            "the misuse is rejected — the :rf/route slice is UNCHANGED")
+        (is (empty? @pushed)
+            "no URL is pushed for a rejected arity-misuse navigation")
+        (let [err (first (filter #(= :rf.error/navigate-arity-misuse (:operation %))
+                                 @traces))]
+          (is (some? err)
+              ":rf.error/navigate-arity-misuse emitted")
+          (is (= :event (-> err :tags :where))
+              "error tags :where :event (event-boundary path)")
+          (is (= [:replace?] (-> err :tags :keys))
+              ":keys names the misplaced opts key"))))))
+
+(deftest navigate-accepts-the-documented-arities
+  (testing "rf2-1os1c: the three documented arities all navigate cleanly
+            — [target], [target params], [target params opts]"
+    (rf/reg-route :route/home    {:path "/"})
+    (rf/reg-route :route/article {:path "/articles/:id" :params [:map [:id :string]]})
+    (let [pushed   (atom [])
+          replaced (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/reg-fx :rf.nav/replace-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! replaced conj url)))
+      ;; [target] — no path-params, no opts.
+      (rf/dispatch-sync [:rf.route/navigate :route/home])
+      (is (= :route/home (:id (get-in (rf/frame-db :rf/default)
+                                      [:rf/runtime :routing :current])))
+          "[target] arity navigates")
+      ;; [target params] — params 2nd, opts absent.
+      (rf/dispatch-sync [:rf.route/navigate :route/article {:id "intro"}])
+      (is (= {:id "intro"} (:params (get-in (rf/frame-db :rf/default)
+                                            [:rf/runtime :routing :current])))
+          "[target params] arity navigates with path-params")
+      ;; [target params opts] — opts in the THIRD slot (:replace? true →
+      ;; :rf.nav/replace-url, proving the 3rd-slot opts are honoured).
+      (rf/dispatch-sync [:rf.route/navigate :route/article {:id "two"} {:replace? true}])
+      (is (= "/articles/two" (last @replaced))
+          "[target params opts] arity navigates; :replace? opt honoured in the 3rd slot")
+      (is (= {:id "two"} (:params (get-in (rf/frame-db :rf/default)
+                                          [:rf/runtime :routing :current])))
+          "the 3-arity path-params landed in the slice, distinct from opts"))))
+
+(deftest navigate-does-not-false-flag-a-route-with-an-opts-named-path-param
+  (testing "rf2-1os1c: a route that legitimately captures a segment named
+            :fragment is NOT false-flagged — the key is a declared
+            path-param, not a misplaced opt"
+    (rf/reg-route :route/anchor {:path "/anchor/:fragment"})
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/dispatch-sync [:rf.route/navigate :route/anchor {:fragment "intro"}])
+      (is (= :route/anchor (:id (get-in (rf/frame-db :rf/default)
+                                        [:rf/runtime :routing :current])))
+          "a declared :fragment path-param navigates normally (no false reject)")
+      (is (= "/anchor/intro" (last @pushed))
+          "the path-param :fragment populates the URL segment"))))

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -95,6 +95,8 @@ Defined per the [009 Error contract](009-Instrumentation.md#error-contract):
 - `:rf.route/navigation-blocked` — `:can-leave` guard rejected a navigation.
 - `:rf.error/can-leave-non-boolean` — `:can-leave` sub returned a non-boolean value; the runtime BLOCKED the navigation. Closed contract; see [§Navigation blocking — pending-nav protocol](#navigation-blocking--pending-nav-protocol).
 - `:rf.error/duplicate-url-binding` — second frame attempted `:url-bound? true` while another already owns the URL.
+- `:rf.error/invalid-route-metadata` — `reg-route` was passed a bare metadata key outside the reserved set (a likely typo), or non-map metadata. Thrown at registration (caller bug; dev *and* prod). Names the offending `:keys` and the `:reserved` vocabulary. See [§Authoring-boundary key validation](#authoring-boundary-key-validation).
+- `:rf.error/navigate-arity-misuse` — `[:rf.route/navigate target params opts]` was dispatched with an opts-only key (`:replace?` / `:scroll` / `:fragment` / `:bypass-leave-guard?`) in the **params** slot that the target route does not declare as a path-param (the classic params/opts swap). Navigation rejected; `:where :event`. See [§Arities — params is 2nd, opts is 3rd](#arities--params-is-2nd-opts-is-3rd).
 - `:rf.warning/route-shadowed-by-equal-score` — registration-time warning when ranking ties on rule 6.
 - `:rf.warning/no-not-found-route` — runtime fell back to the built-in placeholder because `:rf.route/not-found` is not registered (per [§Route-not-found](#route-not-found--rfroutenot-found-canonical)).
 
@@ -230,6 +232,14 @@ The twelve keys cluster into three axes by what each key controls:
 
 The axes are documentation, not data structure — the keys remain flat on the metadata map. An earlier sketch (audit Finding 1) considered nesting lifecycle hooks under `:hooks {...}`; v1 keeps the flat shape because (a) the registration metadata is read by `(rf/handler-meta :route id)` and tools enumerate top-level keys; nesting would require every consumer to know the nesting; (b) the v1 surface is settled, a nested shape is a v2.x candidate at most. The cluster headings are the carry — a generator scaffolding a route picks the axis first, then the keys.
 
+##### Authoring-boundary key validation
+
+Because `reg-route` carries the largest shape in the surface, a typo'd key (`:on-matched` for `:on-match`, `:querey` for `:query`) would otherwise be silently accepted and fail later at nav-time, or never — a silent-swallow that costs a debugging session. `reg-route` therefore **validates the metadata at the authoring boundary**: a **bare** (unqualified) key outside the twelve reserved keys is rejected at registration with a thrown `:rf.error/invalid-route-metadata` (canonical thrown-error shape per [009 §The thrown-error shape](009-Instrumentation.md#the-thrown-error-shape--the-rferrorid-ex-data-contract); `:where 'rf/reg-route`), whose `:keys` slot names every offending key and `:reserved` slot carries the valid vocabulary. This is a **caller bug**, so it throws in dev *and* prod (it is not user input). Non-map metadata is rejected the same way, naming the route.
+
+**Namespaced keys are exempt.** Route metadata is an open map for host/app extension keys, but only under a namespace (`:myapp/analytics-id`, `:myapp/layout`) — see [§Other pattern-level requirements](#other-pattern-level-requirements). Bare keys are the framework's reserved vocabulary; namespaced keys are the extension surface. The split makes the typo case (a bare key) distinguishable from the extension case (a namespaced key) without a registry of permitted host keys.
+
+**Cross-feature reserved keys.** A small number of bare keys are reserved by *other* framework features that extend route metadata — currently `:head`, owned by SSR ([011 §Head/meta contract](011-SSR.md#headmeta-contract): "routes name which head to use via `:head` route metadata"). These pass the guard because the framework owns them, even though they are not among the twelve routing-owned keys above. The accepted-key set is therefore the routing-owned twelve plus the enumerated cross-feature keys; a new framework feature that adds a bare route-metadata key adds it to that set.
+
 ##### Per-key table
 
 | Key | Axis | Type | Purpose |
@@ -317,7 +327,20 @@ The trailing `opts` map is open. The pattern recognises:
 - `:replace?` (use `replaceState` rather than `pushState` — for redirects, search-as-you-type filters, login-flow returns where the back button should not return to the intermediate URL).
 - `:scroll` (per-call override of the route's `:scroll` metadata; same enum/map shape, see "Scroll restoration").
 - `:fragment` (target `#fragment` for the new URL; see "Fragments" below). May also be supplied as `:fragment` on the target map.
+- `:bypass-leave-guard?` (skip the active route's `:can-leave` gate for this navigation; see [§Navigation blocking](#navigation-blocking--pending-nav-protocol)).
 - Hosts may add their own keys under a chosen namespace.
+
+##### Arities — params is 2nd, opts is 3rd
+
+The event vector has two trailing **maps** in fixed positions — `params` second, `opts` third — which are positionally ambiguous to a reader. The three arities are:
+
+```clojure
+[:rf.route/navigate target]              ;; no path-params, no opts
+[:rf.route/navigate target params]       ;; PATH-PARAMS in the 2nd slot; opts absent
+[:rf.route/navigate target params opts]  ;; path-params 2nd, OPTS THIRD
+```
+
+At a call site `[:rf.route/navigate :route/x {...}]` the `{...}` is **path-params**, not opts. The classic mistake is dropping an opts-shaped map into the params slot — `[:rf.route/navigate :route/cart {:replace? true}]` *reads* like "navigate with these opts" but is parsed as "navigate with path-param `:replace?`". The runtime **rejects this swap**: when an opts-only key (`:replace?`, `:scroll`, `:fragment`, `:bypass-leave-guard?`) appears in the params slot and is **not** a declared path-param of the target route, navigation is rejected (slice unchanged, no URL push) and `:rf.error/navigate-arity-misuse` (`:where :event`) is emitted naming the misplaced key. A route that *legitimately* captures a path segment named `:fragment` (`"/anchor/:fragment"`) is not false-flagged — the key is a declared path-param, not a misplaced opt. To pass opts, use the explicit three-arity form with an empty (or real) params map: `[:rf.route/navigate :route/cart {} {:replace? true}]`.
 
 #### Target form — route-id vs URL-string
 
@@ -478,6 +501,17 @@ Two pure helpers, both registered, both queryable:
   - Throws `:rf.error/route-url-validation` if `path-params` doesn't conform to the route's `:params` schema, or `query-params` doesn't conform to the route's `:query` schema (caller bug; not user input).
 
 Both work against the same registered route table, so adding/removing a route updates both directions automatically.
+
+##### `route-url` nil-policy: path params vs query params
+
+`route-url` applies **two different nil-policies** to the path side and the query side — same function, opposite rules. The split is deliberate, but it is surprising enough to document explicitly (it otherwise costs a debugging session when `{:page nil}` mysteriously vanishes):
+
+| Slot | `nil` (or absent) value | present-but-falsy value (`false`, `0`, `""`) |
+|---|---|---|
+| **Path param** (a `:name` / `*name` segment) | **Hard error** — throws `:rf.error/missing-route-param`. The URL cannot be built without the segment. | **Round-trips.** A falsy-but-present value is a legitimate segment (`/items/0`). |
+| **Query param** (a key in `query-params`) | **Silently elided** — `{:page nil}` omits the key entirely (no bare `?page=`, no throw). | **Round-trips.** A falsy-but-present value emits (`?archived=false`). |
+
+The query-side elision is the useful default for **absent optional query keys**: a search form that conditionally adds `?sort=` only when a sort is chosen passes `{:sort nil}` and gets a clean URL with no `sort` key. The path side cannot elide — a missing path segment has no URL to produce — so it throws. Both sides agree on the present-but-falsy case: a falsy value is real data and round-trips. Authors who need a query key to always be present must supply a non-nil value (use a sentinel string, not `nil`).
 
 #### Param validation at the call site
 
@@ -761,6 +795,14 @@ The path syntax is the *primary* binding. Query strings are bound separately via
 | Defaults | n/a (absence = no match) | `:query-defaults` map |
 
 `:query-defaults` populates absent query keys at match time. `:query-retain` is a set of keys that should be **carried through subsequent navigations** even when the caller didn't supply them — useful for global state encoded in the URL (`:theme`, `:locale`, `:debug`). The merge is performed inside `:rf.route/navigate`'s handler (which has access to `app-db` and reads the current `:rf.route/query` slice) before `route-url` is called; `route-url` itself is pure and does not consult `app-db` (per [§Bidirectional URL ↔ params](#bidirectional-url--params)). The result: a `[:rf.route/navigate :route/cart]` from a search page preserves `?theme=dark`.
+
+#### `:query-retain` cross-route coercion class
+
+Retained query values are pulled from the **current** route's `:query` slice and merged into the **target** route's outgoing query **verbatim** — they are *not* re-coerced against the target route's `:query` schema. This matters because the current route may have coerced a retained value into a specific class: a `[:enum :light :dark]`-typed key arrives in the slice as the **keyword** `:dark` (per [§Keyword-interning cap](#keyword-interning-cap-on-query-keys--values)), an `:int`-typed key as a **number**. Carrying verbatim means that keyword/number flows into the target unchanged.
+
+**The contract: keep a retain key's type consistent across every route that retains it.** Because the merge is a pure `select-keys` (no re-coercion), an author who types `:theme` as `[:enum :light :dark]` on route A and as `:string` on route B will carry a *keyword* `:dark` into B's `:string` slot. This is **caught, not silent**: the target route's `:query` validator runs at the call site (in `:rf.route/navigate`'s handler and in `route-url`), so a class mismatch surfaces as a validation failure (rejecting the navigation per [§Param validation at the call site](#param-validation-at-the-call-site)) rather than desyncing the slice.
+
+Re-coercing retained values against the target schema was considered and rejected: retained values are already-coerced **runtime values**, not URL strings, so re-running the string→class coercion pipeline on them is ill-typed (the coercer's input contract is a raw URL string). Verbatim carry keeps the retain-merge a pure `select-keys` and keeps `route-url` pure (it never sees the merge). Consistency across routes is an author-named-intent invariant, the same trust class as the `:query` schema itself.
 
 Coercion is data-shaped (the `:query` schema is the coercion specification — `:int` coerces `"2"` → `2`); per-key middleware functions are not part of the contract — data over functions.
 


### PR DESCRIPTION
Three cohesive [api] fixes on the routing authoring surface (Shape-2 cluster), all from senior-dev API critique rf2-814or.

## rf2-45b95 (P2) — reg-route rejects unknown/mis-typed metadata keys at the authoring boundary
`reg-route` has the largest registration shape in the v2 surface (twelve reserved keys). A typo'd key (`:on-matched` for `:on-match`) used to be silently accepted and fail later at nav-time, or never. Now bare keys outside the reserved set are rejected at registration with a thrown `:rf.error/invalid-route-metadata` (canonical thrown-error shape, `:where 'rf/reg-route`), whose `:keys` slot names every offending key and `:reserved` carries the valid vocabulary. Namespaced host/app keys (`:myapp/*`) pass; the cross-feature SSR key `:head` is enumerated in the accepted set (Spec 011 §Head/meta contract). Non-map metadata is rejected the same way. Pre-alpha: fail loud, no shim.

## rf2-1os1c (P3) — :rf.route/navigate target/params/opts disambiguation
The two trailing maps (`params` 2nd, `opts` 3rd) are positionally ambiguous. The handler now flags the classic swap: an opts-only key (`:replace?` / `:scroll` / `:fragment` / `:bypass-leave-guard?`) in the PARAMS slot that the target route does not declare as a path-param is rejected (slice unchanged, no push) and emits `:rf.error/navigate-arity-misuse` (`:where :event`). A route that legitimately captures a path segment of that name (`/anchor/:fragment`) is not false-flagged — declared path-param names are read from the compiled pattern. Spec 012 gains an explicit arity table.

## rf2-b3rzz (P2) — route-url nil-policy asymmetry + :query-retain coercion-class carry
Doc-led. The `route-url` docstring + Spec 012 now document the nil-policy split (path `nil` = hard `:rf.error/missing-route-param`; query `nil` = silent elision; present-but-falsy round-trips on both). And the `:query-retain` cross-route coercion-class contract is specified: retained values carry **verbatim** (not re-coerced), the target route's `:query` validator catches a class mismatch, and authors keep a retain key's type consistent across routes. Re-coercion was considered and rejected (retained values are runtime values, not URL strings).

## Quality gates
- routing `clojure -M:test`: **142 tests, 616 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5169 tests, 17558 assertions, 0 failures, 0 errors** (conformance corpus: 137/137 runnable fixtures pass — the validator initially surfaced the SSR `:head` route-metadata key, now enumerated as a cross-feature reserved key)
- clj-kondo (changed files): **0 errors, 0 net-new warnings** (added explicit `[clojure.string :as str]` requires to navigate.cljc + registry.cljc, clearing pre-existing `clojure.string` warnings; the one remaining test-file warning at line 870 is pre-existing, untouched)
- `mkdocs build --strict`: **clean** (spec/012 prose touched; all new anchors + cross-refs resolve)

Public-surface check: no external artefact `:require`s the internal `re-frame.routing.*` namespaces I changed; the facade re-exports (`reg-route` / `route-url`) keep identical signatures (validation is additive/stricter, behaviour-preserving for valid routes).

spec/012 updated; spec/API.md + Conventions untouched.