### PR TITLE
docs(skills): update re-frame2-pair references to frozen run-result shape — retire :passing? (rf2-54gvq)

### DIFF
--- a/skills/re-frame2-pair/references/recipes.md
+++ b/skills/re-frame2-pair/references/recipes.md
@@ -283,8 +283,8 @@ When a **streaming probe** seems to have gone quiet, call `mcp__re-frame2-pair__
    ```
    mcp__re-frame2-story-mcp__read-failures {variant-id: ":story.counter/loaded"}
    ```
-6. If `:passing? false`, repeat from step 3 with a refined body. re-frame2-pair's subscription stays open across iterations — close it with `unsubscribe` when the loop terminates.
+6. If `:status :fail` (`result-passed?` is false), repeat from step 3 with a refined body. A `:status :cannot-run` is the distinct third verdict — the runner could not attempt the plan; fix the runner/environment rather than the body. re-frame2-pair's subscription stays open across iterations — close it with `unsubscribe` when the loop terminates.
 
-**Expected output shape.** Stream of epoch records on the re-frame2-pair channel (one per play event), plus a `:passing?` boolean + `:assertions` list from `read-failures`. Successful loop ends with `:passing? true`.
+**Expected output shape.** Stream of epoch records on the re-frame2-pair channel (one per play event), plus a `:status` verdict (`:pass`/`:fail`/`:cannot-run`/`:error`, read via `result-status`/`result-passed?`) + `:assertions` list from `read-failures`. Successful loop ends with `:status :pass`.
 
 **Gotcha.** `:reset-frame!` on re-registration wipes any REPL-only state you injected (e.g. an `app-db/reset` you'd done in a prior iteration to set up a corner case). Bake the corner-case setup into `:events` or `:loaders` instead — the play-runner re-runs them each iteration, so the setup is durable across refinements.

--- a/skills/re-frame2-pair/references/stories.md
+++ b/skills/re-frame2-pair/references/stories.md
@@ -16,8 +16,8 @@ The `re-frame2-pair` skill's `allowed-tools` (per the SKILL.md frontmatter) pull
 
 | Tool | What it does | Returns |
 |---|---|---|
-| `mcp__re-frame2-story-mcp__run-variant` | Full four-phase lifecycle against an existing variant — loaders → events → render → play | `{:passing? :app-db :assertions :rendered-hiccup :elapsed-ms :snapshot :lifecycle}` |
-| `mcp__re-frame2-story-mcp__read-failures` | Diagnostic over the variant's `:rf.story/assertions` accumulator (no re-run) | Vector of `{:assertion :path :expected :actual :passed? :source}` |
+| `mcp__re-frame2-story-mcp__run-variant` | Full four-phase lifecycle against an existing variant — loaders → events → render → play | `{:status :app-db :assertions :rendered-hiccup :elapsed-ms :snapshot :narrative}` — `:status` is the verdict (`:pass`/`:fail`/`:cannot-run`/`:error`), read via `result-status`/`result-passed?` |
+| `mcp__re-frame2-story-mcp__read-failures` | Diagnostic over the variant's `:rf.story/assertions` accumulator (no re-run) | `{:variant-id :status :total :failures :assertions}` (each record carries a derived `:status`) |
 | `mcp__re-frame2-story-mcp__snapshot-identity` | Content hash of `(variant × args × decorators × loaders × substrate × modes)` | `{:identity <hash>}` — use to skip cells unchanged since a prior run |
 | `mcp__re-frame2-story-mcp__run-a11y` | axe-core results for the variant's rendered DOM | `{:violations [...]}` (JVM-standalone hosts return `[]` + a hint) |
 | `mcp__re-frame2-story-mcp__record-as-variant` | Records dispatches into the variant's frame for `:duration-ms`, returns a `(reg-variant ...)` snippet via `gen-play-snippet`; optional `:write-back` re-registers | `{:snippet <string> :events <vector>}` |
@@ -71,7 +71,7 @@ The dispatch lands in the variant's app-db; the next `run-variant` calls `reset-
 The four-step loop from [`story-mcp-loop.md`](../../re-frame2/references/tooling/story-mcp-loop.md) — author → run → assert → refine — becomes richer when re-frame2-pair is attached. The re-frame2-pair-augmented loop:
 
 ```
-run-variant fails (:passing? false)
+run-variant fails (:status :fail — result-passed? is false)
    ↓
 read-failures — narrow to the offending :rf.assert/*
    ↓
@@ -83,8 +83,10 @@ dispatch a fix via re-frame2-pair mcp__re-frame2-pair__dispatch {frame: ...}
    ↓
 re-run via run-variant
    ↓
-loop until :passing? true
+loop until :status :pass (result-passed? true)
 ```
+
+A `:status :cannot-run` is the distinct third verdict — the runner could not even attempt the plan. Handle it as "not runnable here", NOT as a fail: fix the runner/environment, don't refine the body.
 
 What re-frame2-pair adds over the bare story-mcp loop: a watch-epochs subscription stays open across iterations so you narrate each play event; `dispatch` lets you probe candidate fixes without re-registering the variant; `trace/last-epoch` shows you the cascade `read-failures` won't (it only reads the assertion accumulator, not the trace stream).
 


### PR DESCRIPTION
Closes rf2-54gvq.

## What

The run-result freeze (rf2-3nbl5.6, just merged) retired the legacy `:passing?` boolean in favour of a `:status` verdict (`:pass` / `:fail` / `:cannot-run` / `:error`), read via `result-status` / `result-passed?`. The `skills/re-frame2-pair/references/` leaves carried stale `:passing?` examples of the old MCP run-result shape. Updated them to the frozen vocabulary per `tools/story/spec/017-Testing-Story.md §Run result` + `tools/story-mcp/spec/002-Tool-Registry.md`.

### Files + example updates

- `skills/re-frame2-pair/references/stories.md`
  - five-tools table: `run-variant` Returns `{:passing? … :lifecycle}` → `{:status … :narrative}` with the `:status` verdict note (`result-status`/`result-passed?`); `read-failures` Returns aligned to the frozen `{:variant-id :status :total :failures :assertions}` shape.
  - self-healing loop diagram: `:passing? false` → `:status :fail (result-passed? is false)`; `loop until :passing? true` → `loop until :status :pass`; added a note on the distinct `:cannot-run` third verdict.
- `skills/re-frame2-pair/references/recipes.md`
  - refine-a-variant loop step 6 + Expected-output-shape paragraph: `:passing?` → `:status` verdict with `:cannot-run` handling.

### Regression check

`git grep -n ":passing?" -- skills/re-frame2-pair/` → clean (exit 1, no matches). Whole-`skills/` grep also clean.

## Quality gates

- `scripts/check_skill_mcp_drift.py` → PASS (exit 0)
- `scripts/check_doc_slugs.py` → PASS (exit 0)
- `scripts/check_readme_links.py` → PASS (exit 0)
- `mkdocs build --strict` → not run locally (mkdocs not installed in worker env). These reference leaves are linked (not transcluded) by the mkdocs nav — the nav references `skills/re-frame2-pair.md`, an aggregated page that hyperlinks to the GitHub-hosted `references/`; example-content edits in the leaves do not change built docs content. CI mkdocs gate will confirm.
- No impl gates (skills doc-only change).