### PR TITLE
feat(pair-mcp): ship set/reset/get operating-frame ops (rf2-zomfq)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -34,6 +34,12 @@ allowed-tools:
   - mcp__re-frame2-pair__list-streams
   - mcp__re-frame2-pair__handler-meta
   - mcp__re-frame2-pair__list-handlers
+  # Operating-frame ops (rf2-zomfq) — read/set/reset the session's
+  # default operating frame for the multi-frame model (Spec 002). See
+  # the "Multi-frame model — set the operating frame" section below.
+  - mcp__re-frame2-pair__get-operating-frame
+  - mcp__re-frame2-pair__set-operating-frame
+  - mcp__re-frame2-pair__reset-operating-frame
   - mcp__re-frame2-pair__get-re-frame2-pair-instructions
   # story-mcp — live-session tools only (HYBRID split). The
   # authoring-side surface (register-variant, get-variant,

--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -39,7 +39,8 @@ covers the catalogue surface.
 | **`dispatch`** | Fire a re-frame2 event. Bare verb, used by re-frame2-pair-mcp. Always tagged with `:origin :<server-name>` on the trace bus. | `dispatch` | Story-mcp does NOT ship `dispatch` — its mutations go through `register-variant` / `unregister-variant` instead. The bare verb is reserved for the framework's primary mutation primitive. |
 | **`eval-cljs`** | The escape hatch — evaluate an arbitrary CLJS form in the connected runtime. Bare verb, used by re-frame2-pair-mcp. Any side-effect the form triggers inherits the server's `:origin` tag. | `eval-cljs` | Story-mcp does NOT ship `eval-cljs` because its server runs JVM-side and there's no browser runtime to eval into. |
 | **`restore-<thing>`** | Time-travel state restore. Mirrors a user-confirmed in-panel affordance. | `restore-epoch` | Mutating; tagged `:origin :<server-name>`. Shipped by re-frame2-pair-mcp behind `--allow-writes` (rf2-ee38b.18). |
-| **`reset-<thing>`** | Replace state, bypassing the normal cascade. Mirrors a "try anyway" affordance. | `reset-frame-db` | Mutating; tagged `:origin :<server-name>`. Shipped by re-frame2-pair-mcp behind `--allow-writes` (rf2-ee38b.18). |
+| **`reset-<thing>`** | Replace state, bypassing the normal cascade. Mirrors a "try anyway" affordance. | `reset-frame-db`, `reset-operating-frame` | Mutating; tagged `:origin :<server-name>`. `reset-frame-db` (re-frame2-pair-mcp) is gated behind `--allow-writes` (rf2-ee38b.18). `reset-operating-frame` (rf2-zomfq) clears the SESSION operating-frame pin — not an app-db write, so ungated. |
+| **`set-<thing>`** | Pin / declare ONE named **session setting** — not a generic mutation surface. Narrowly catalogued for the operating-frame contract only. | `set-operating-frame` | Added by rf2-zomfq (re-frame2-pair). The Tool-Pair §Tool-surface obligations contract mandates a set/reset/get trio for the operating frame and states the stable names are "typically `set-operating-frame` / `reset-operating-frame` / `get-operating-frame`"; the spec-mandated name wins for cross-server mental-model transfer. This is the deliberate carve-out from the `set-` rejection in §"What's NOT a locked verb" below — admissible ONLY because it pins a single named session setting (the operating frame), not arbitrary state. A future generic `set-<arbitrary>` is still rejected. Lock entry: re-frame2-pair-mcp `DESIGN-RATIONALE.md` §Subsequent evolution (rf2-zomfq). |
 | **`register-<thing>` / `unregister-<thing>`** | Registry add / remove, symmetric pair. Both gated behind the server's write-allow flag where applicable. | `register-variant`, `unregister-variant` | Story-mcp only today. If a future tool surfaces "register a handler at the framework level via MCP" it adopts this verb. |
 | **`run-<thing>`** | Execute a definition and report **pass / fail** results. Implies a play sequence, an assertion vocabulary, or some explicit success criterion. | `run-variant`, `run-a11y` | Distinguished from `preview-` (no pass/fail) and `dispatch` (one event, not a sequence). Story-mcp only today. |
 | **`preview-<thing>`** | Execute and report **rendered / resolved state**, but no pass/fail. The "show me what this would look like" call. | `preview-variant` | The symmetric pair of `run-` for the same registry. Story-mcp only today. |
@@ -57,9 +58,15 @@ out in PR review and pick from the table above instead.
 
 - **`fetch-`, `query-`, `find-`, `lookup-`** — verb-soup synonyms for
   `get-`. Pick `get-`.
-- **`update-`, `set-`** — implies a generic mutation surface. Pick a
+- **`update-`** — implies a generic mutation surface. Pick a
   named verb (`dispatch`, `register-`, `restore-`, `reset-`) so the
   agent sees the registry / surface, not the verb tense.
+- **`set-`** — generally rejected for the same generic-mutation-surface
+  reason: pick a named verb. The **sole catalogued exception** is
+  `set-operating-frame` (rf2-zomfq), admitted because it pins ONE named
+  session setting the Tool-Pair contract mandates under that exact name
+  (§The verb table `set-<thing>` row). A generic `set-<arbitrary-slot>`
+  remains rejected.
 - **`enumerate-`, `all-<things>`, `<things>-list`** — verb-soup
   synonyms for `list-`. Pick `list-`.
 - **`call-`, `invoke-`, `run-fn`** — `eval-cljs` is the catalogued
@@ -110,6 +117,9 @@ counts" below.)
 | `record` | bare (mega-op) | Conformant — bare-verb signal recorder spanning app-db / sub / DOM / focus. Lock entry in `DESIGN-RATIONALE.md`. Distinct from the `record-as-` prefix (capture-as-artefact). Added by rf2-zo4b9. |
 | `read-recording` | `read-` | Conformant — diagnostic re-read of a recording's change-log (paired with `record`). Added by rf2-zo4b9. |
 | `watch-until` | `watch-` | Conformant — blocks until a predicate over a signal holds. New `watch-` prefix; Lock entry in `DESIGN-RATIONALE.md`. Added by rf2-zo4b9. |
+| `set-operating-frame` | `set-` (carve-out) | Conformant — pins the session operating frame (the tier-2 escape from `:ambiguous-frame`). The one catalogued `set-` exception; the Tool-Pair contract mandates this stable name. Lock entry in `DESIGN-RATIONALE.md`. Added by rf2-zomfq. |
+| `reset-operating-frame` | `reset-` | Conformant — clears the session operating-frame pin. Ungated (session-state, not app-db). Added by rf2-zomfq. |
+| `get-operating-frame` | `get-` | Conformant — single-record read of the `{:frames :selected :operating}` operating-frame triple (Tool-Pair §Tool-surface obligations). Added by rf2-zomfq. |
 
 ### Story-mcp
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/verb_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/verb_vocab_test.clj
@@ -61,6 +61,13 @@
     "discover"
     "restore"
     "reset"
+    "set"         ; rf2-zomfq — the SOLE catalogued `set-` carve-out:
+                  ; `set-operating-frame` (re-frame2-pair) pins ONE named
+                  ; session setting the Tool-Pair contract mandates under
+                  ; that exact name. NAMING.md §"What's NOT a locked verb"
+                  ; still rejects generic `set-<arbitrary-slot>`; this
+                  ; prefix entry is admissible because the only `set-` tool
+                  ; that exists is the spec-mandated operating-frame pin.
     "register"
     "unregister"
     "run"

--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -11,8 +11,10 @@ back-compat, but new sessions should prefer the MCP server.
 ## What it is
 
 A Node-based stdio JSON-RPC server (written in ClojureScript, compiled
-via shadow-cljs to a single `.js` file) that exposes the twenty-two
-re-frame2-pair ops as MCP tools (twenty read/inspect/action ops plus the
+via shadow-cljs to a single `.js` file) that exposes the twenty-five
+re-frame2-pair ops as MCP tools (twenty-three read/inspect/action ops —
+including the operating-frame trio `set-operating-frame` /
+`reset-operating-frame` / `get-operating-frame` (rf2-zomfq) — plus the
 two write tools `restore-epoch` / `reset-frame-db`, which are gated behind
 `--allow-writes`). The authoritative ordered catalogue is `registry/tools`
 ([`src/re_frame2_pair_mcp/tools/registry.cljs`](src/re_frame2_pair_mcp/tools/registry.cljs));
@@ -52,6 +54,9 @@ cljs-eval compile.
 | `list-streams` | _(new — no bash equivalent)_ | List active **streaming-tap** subscriptions with per-sub queue depth, drop counts, and `:overflow-reason`. Diagnostic for "what streams are open?" / "is my probe still alive?" — wraps `subscription-info` directly so AI clients don't need an `eval-cljs` round-trip. Optional `topic` / `sub-id` filters. (rf2-qicji: the streaming diagnostic `list-subscriptions` formerly carried.) |
 | `handler-meta` | _(new — no bash equivalent)_ | Registration metadata for a `(kind, id)` — source-coord (file/line/column/ns), `:doc`, `:tags`, plus an `:rf.source/uri` jump-to-editor link (rf2-pctf8). Eleven supported kinds: event, sub, fx, cofx, view, frame, route, flow, head, error-projector, machine. |
 | `list-handlers` | _(new — no bash equivalent)_ | Every registered id under a kind — the discovery surface (rf2-pctf8; renamed from `registry-list` per rf2-4y595). Same eleven supported kinds as `handler-meta`. |
+| `set-operating-frame` | _(new — no bash equivalent)_ | Pin the session's **operating frame** so frame-targeted ops resolve to it without a per-call `frame` (rf2-zomfq). The escape from `:ambiguous-frame` in multi-frame apps (tier 2 of the resolution table). Validates the frame-id is registered — unknown → `:reason :no-such-frame`. |
+| `reset-operating-frame` | _(new — no bash equivalent)_ | Clear the session's operating-frame pin (rf2-zomfq). Subsequent ops resolve at tier 3 / 4 again. Returns the post-reset triple. |
+| `get-operating-frame` | _(new — no bash equivalent)_ | Report the operating-frame triple `{:frames :selected :operating}` (rf2-zomfq) — all registered frames, the session pin, and the resolved frame (`:operating nil` = ambiguous). Pure read. |
 | `get-re-frame2-pair-instructions` | _(new — no bash equivalent)_ | Return the agent-onboarding prose for re-frame2-pair-mcp (rf2-fnpqg): tool catalogue, EDN posture, tagged-mutation conventions, streaming subscribe semantics, wire-boundary pipeline. Inline text, no nREPL round-trip — call at session start to orient. Mirrors story-mcp's `get-story-instructions`. |
 
 ## Quick start
@@ -525,7 +530,7 @@ tools/re-frame2-pair-mcp/
 │   └── probe-mcp-path.cjs                    ; read-only ~/.claude.json drift probe (rf2-vsxgz)
 └── src/re_frame2_pair_mcp/
     ├── nrepl.cljs                            ; persistent socket + bencode
-    ├── tools/registry.cljs                   ; the authoritative ordered catalogue of the twenty-two MCP tools (single source of truth: tools/list descriptors + tools/call dispatch + cache opt-in)
+    ├── tools/registry.cljs                   ; the authoritative ordered catalogue of the twenty-five MCP tools (single source of truth: tools/list descriptors + tools/call dispatch + cache opt-in)
     ├── tools.cljs                            ; tools/call dispatcher (resolves handlers from registry)
     └── server.cljs                           ; stdio JSON-RPC entry point
 └── test/

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -6,19 +6,24 @@
 > `register-epoch-listener!`, `restore-epoch`, `reset-frame-db!`,
 > `dispatch`, `dispatch-sync`).
 
-The twenty-two MCP tools. All twenty-two are catalogued below; the
+The twenty-five MCP tools. All twenty-five are catalogued below; the
 registrar-introspection pair `handler-meta` + `list-handlers` (rf2-cibp8
 / rf2-pctf8 — `list-handlers` renamed from `registry-list` per
-rf2-4y595 for NAMING.md `list-<things>` conformance), the write pair
-`restore-epoch` + `reset-frame-db` (rf2-ee38b.18 — the Tool-Pair
-time-travel + state-injection primitives, gated behind `--allow-writes`),
-`dispatch-dry-run` (rf2-17hvp — simulate a cascade without
+rf2-4y595 for NAMING.md `list-<things>` conformance), the operating-frame
+trio `set-operating-frame` + `reset-operating-frame` + `get-operating-frame`
+(rf2-zomfq — the [Tool-Pair §Tool-surface obligations][tsobl] ops that
+surface the session frame pin, the escape from tier-4 `:ambiguous-frame`),
+the write pair `restore-epoch` + `reset-frame-db` (rf2-ee38b.18 — the
+Tool-Pair time-travel + state-injection primitives, gated behind
+`--allow-writes`), `dispatch-dry-run` (rf2-17hvp — simulate a cascade without
 committing), the view-plane read `read-dom` (rf2-nfjil), and the signal
 recorder `record` + `read-recording` + `watch-until` (rf2-zo4b9 — the
 first-class recorder for races + watch sessions) live in the live
 registry at
 [`src/re_frame2_pair_mcp/tools/registry.cljs`](../src/re_frame2_pair_mcp/tools/registry.cljs)
 and have full per-tool sections here.
+
+[tsobl]: ../../../spec/Tool-Pair.md#tool-surface-obligations
 
 ## Universal: wire-boundary token cap
 
@@ -2331,6 +2336,131 @@ surface). No back-compat shim; the old name hard-errors with
 `:unknown-tool`.
 
 **Source**: rf2-pctf8.
+
+## set-operating-frame / reset-operating-frame / get-operating-frame
+
+The three operating-frame ops the [Tool-Pair contract][tsobl] mandates
+(§Tool-surface obligations) for any pair-shaped tool surface. They are
+the MCP-side surfacing of the runtime's **session frame pin** — tier 2
+of the [operating-frame resolution table][resolve] — and are the escape
+from the tier-4 `:ambiguous-frame` refusal a multi-frame app otherwise
+traps an agent in.
+
+[resolve]: ../../../spec/Tool-Pair.md#operating-frame-resolution
+
+### Why these ship (rf2-zomfq)
+
+re-frame2 is multi-frame (Spec 002). Every frame-targeted op (`dispatch`,
+`snapshot`, `get-path`, `subscribe`, `list-subscriptions`, …) resolves an
+*operating frame*: explicit per-call `frame` (tier 1) → **session pin
+(tier 2)** → sole-registered frame (tier 3) → nil (tier 4, ambiguous).
+When two-plus frames are registered and the call omits `frame` and no
+session pin is set, resolution lands at tier 4 and the op REFUSES with
+`{:ok? false :reason :ambiguous-frame}` rather than guess (a write that
+lands in the wrong frame is unrecoverable without `restore-epoch`).
+
+Before rf2-zomfq the runtime exposed `select-frame!` / `current-frame` /
+`frames-list`, but **no MCP tool wired them onto the wire** — so tier 2
+was unreachable from the tool surface and a multi-frame agent had to
+thread `frame` through every single call forever, defeating the
+implicit-until-reset UX the contract designed. These three ops close that
+gap.
+
+### set-operating-frame
+
+Pin the session's operating frame.
+
+**Args**: `frame` (string, **required** — bare `"stories"` or EDN-shaped
+`":stories"`), `build` (string, optional).
+
+Per Tool-Pair §Tool-surface obligations, set **validates** that `frame`
+names a currently-registered frame; an unknown frame returns
+`{:ok? false :reason :no-such-frame :frame <id> :frames [...]}` (the
+registered list rides along so the agent can retarget). Validation and
+the pin write are one eval form — the membership check reads
+`(re-frame2-pair.runtime/frames-list)` and, on a hit, calls
+`(select-frame! <id>)` and returns the fresh triple; no check-then-act
+race across round-trips.
+
+**Returns** the resolved triple on success:
+
+```clojure
+{:ok?       true
+ :frames    [<frame-id> ...]   ;; all registered
+ :selected  <frame-id>         ;; the just-pinned frame (tier-2 pin)
+ :operating <frame-id>}        ;; full resolution — now the pinned frame
+```
+
+**Error envelopes**:
+
+- `{:ok? false :reason :missing-frame :hint "..."}` — no `frame` arg.
+- `{:ok? false :reason :no-such-frame :frame <id> :frames [...] :hint "..."}` — `frame` not registered.
+- `{:ok? false :reason :set-operating-frame-failed :message "..."}` — runtime threw.
+
+### reset-operating-frame
+
+Clear the session pin.
+
+**Args**: `build` (string, optional). No `frame`.
+
+Routes through `(select-frame! nil)` then re-reads the triple so the
+returned shape reflects the cleared pin. After reset, subsequent ops
+resolve at tier 3 / 4 again. Idempotent — resetting when nothing is
+pinned is a no-op that returns the same triple.
+
+**Returns**:
+
+```clojure
+{:ok?       true
+ :frames    [<frame-id> ...]
+ :selected  nil                ;; pin cleared
+ :operating <frame-id|nil>}    ;; tier-3 sole-frame, or nil (ambiguous)
+```
+
+### get-operating-frame
+
+Inspect the operating frame — the **read** op. Routes through
+`(re-frame2-pair.runtime/frames-list)`, the same accessor `discover-app`
+consults, so the two never disagree.
+
+**Args**: `build` (string, optional).
+
+**Returns** the normative triple (per [Tool-Pair §Tool-surface
+obligations][tsobl] — `:frames` / `:selected` / `:operating`):
+
+```clojure
+{:ok?       true
+ :frames    [<frame-id> ...]   ;; (rf/frame-ids) — all registered
+ :selected  <frame-id|nil>     ;; tier-2 session pin (nil = unset)
+ :operating <frame-id|nil>}    ;; full resolution (nil = AMBIGUOUS)
+```
+
+`:operating nil` means ambiguous: two-plus frames and no pin, so a
+frame-targeted op without a per-call `frame` WILL refuse. The triple
+lets a caller render both "you have pinned X" (`:selected`) and "writes
+will go to X" (`:operating`) when the two diverge.
+
+### How they escape `:ambiguous-frame`
+
+A frame-consuming op with no per-call `frame` reads the session pin via
+the runtime's `current-frame` resolver. `set-operating-frame` writes that
+pin; from then on `current-frame` returns the pinned id at tier 2 and the
+op proceeds against it instead of refusing. `reset-operating-frame`
+clears the pin, returning the session to the tier-3/4 default posture.
+The pin lives in the runtime preload's `selected-frame` atom — the SAME
+atom every frame-consuming op consults — so set / get / reset can never
+disagree about where it lives.
+
+### Annotations
+
+`set-operating-frame` / `reset-operating-frame` carry
+`:idempotentHint true` + `:openWorldHint true` (they write *session*
+state over nREPL — NOT `:readOnlyHint`, NOT `:destructiveHint`: a wrong
+pin is corrected by another set / reset, never an irreversible app
+effect). `get-operating-frame` is a pure read on the standard
+idempotent-read-only annotation set.
+
+**Source**: rf2-zomfq.
 
 ## get-re-frame2-pair-instructions
 

--- a/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
@@ -327,6 +327,37 @@ Post-Lock additions accumulated as follows:
   the `watch-` blocking-predicate prefix (Lock #8). All three are
   read-only observation (no app mutation) and `:cacheable? false` (the
   recording state is volatile, not a function of an app-db hash).
+- **rf2-zomfq** added the **operating-frame triplet** —
+  `set-operating-frame`, `reset-operating-frame`, `get-operating-frame`
+  — the three [Tool-Pair §Tool-surface obligations][tp-tsobl] ops that
+  surface the runtime's session frame pin (tier 2 of the operating-frame
+  resolution table). The MUST shipped unimplemented: the runtime exposed
+  `select-frame!` / `current-frame` / `frames-list` but no MCP tool wired
+  them onto the wire, so tier 2 was unreachable and a multi-frame agent
+  hitting tier-4 `:ambiguous-frame` had no way to declare its operating
+  frame — it had to thread `:frame` through every call forever. The three
+  tools are thin wrappers over the published runtime fns: `set` validates
+  against `frames-list` then `select-frame!`s; `reset` `select-frame!`s
+  `nil` then re-reads; `get` reads `frames-list` (the normative
+  `{:frames :selected :operating}` triple). **Verb note:** the
+  Tool-Pair contract leaves the wire names unpinned ("typically
+  `set-operating-frame` / `reset-operating-frame` / `get-operating-frame`"
+  — §Tool-surface obligations) and these are the spec's stated stable
+  names, so they ship verbatim for cross-tool recognition. `get-` and
+  `reset-` are already catalogued NAMING.md verbs; `set-` was previously
+  on NAMING.md's rejected list (generic-mutation-surface concern) — that
+  rejection is now carved out for the operating-frame case specifically:
+  `set-operating-frame` is NOT a generic mutation surface, it pins ONE
+  named session setting (the operating frame), and the spec-mandated
+  name wins for cross-server mental-model transfer (re-frame-pair-improver
+  / Xray / Story carry the same trio). See Lock #8 + NAMING.md §The verb
+  table for the catalogue addition. `set` / `reset` are `:cacheable? false`
+  (session-state writes); `get` is `:cacheable? true` (a read of the
+  frame registry + pin, caught by the post-eval result-hash cache — the
+  precheck path is `snapshot`/`get-path`-only, so a pin write between two
+  `get`s is never served stale).
+
+[tp-tsobl]: ../../../spec/Tool-Pair.md#tool-surface-obligations
 
 ---
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -183,6 +183,20 @@
   {:readOnlyHint  true
    :openWorldHint true})
 
+(def ^:private session-pin-annotations
+  "Annotations for the session-mutating operating-frame ops
+  (`set-operating-frame`, `reset-operating-frame`, rf2-zomfq). They
+  mutate the per-session frame pin in the runtime preload — NOT app-db,
+  NOT the DOM — so `:readOnlyHint false` (they write *session* state)
+  but NOT `:destructiveHint` (no irreversible app effect; a wrong pin is
+  corrected by another set / reset). `:idempotentHint true`: pinning the
+  same frame twice — or resetting twice — yields the same state.
+  `:openWorldHint true` because they reach the browser runtime over
+  nREPL. `get-operating-frame` is a pure read and rides the plain
+  idempotent-read-only set."
+  {:idempotentHint true
+   :openWorldHint  true})
+
 (def ^:private streaming-final-summary
   "Streaming-tool final-summary envelope (subscribe). The progress
   notifications it emits along the way carry their own shape
@@ -1182,6 +1196,79 @@
                                      :enum ["event" "sub" "fx" "cofx" "view" "frame" "route" "flow" "head" "error-projector" "machine"]}
                               :build {:type "string"}}
                  :required ["kind"]
+                 :additionalProperties false}})
+
+;; ---------------------------------------------------------------------------
+;; set-operating-frame / reset-operating-frame / get-operating-frame
+;; (rf2-zomfq — the three Tool-Pair §Tool-surface-obligations ops)
+;; ---------------------------------------------------------------------------
+
+(def set-operating-frame
+  {:name "set-operating-frame"
+   :description (str "Pin the session's OPERATING FRAME — the frame that frame-targeted ops "
+                     "(dispatch, snapshot, get-path, subscribe, list-subscriptions, …) resolve to "
+                     "when you DON'T pass a per-call :frame. re-frame2 is multi-frame (Spec 002): "
+                     "with two-plus frames registered and no pin, those ops REFUSE with "
+                     ":reason :ambiguous-frame rather than guess a target. Pin once with this op and "
+                     "they resolve to the pinned frame from then on — the escape from :ambiguous-frame "
+                     "(tier 2 of the resolution table). Validates that :frame names a currently-registered "
+                     "frame; an unknown frame returns {:ok? false :reason :no-such-frame :frames [...]}. "
+                     "On success returns the resolved triple {:ok? true :frames [...] :selected <pinned> "
+                     ":operating <resolved>} so you can confirm the pin took. The pin persists for the "
+                     "session (implicit-until-reset); clear it with reset-operating-frame, or a runtime "
+                     "reload clears it automatically. "
+                     "Examples: "
+                     "1. Pin a frame: {:frame \":stories\"} -> {:ok? true :frames [:rf/default :stories] :selected :stories :operating :stories}. "
+                     "2. Unknown frame: {:frame \":nope\"} -> {:ok? false :reason :no-such-frame :frame :nope :frames [:rf/default :stories]}. "
+                     "3. Missing arg: {} -> {:ok? false :reason :missing-frame}.")
+   :typicalTokens 150
+   :annotations session-pin-annotations
+   :outputSchema envelope-or-marker
+   :inputSchema {:type "object"
+                 :properties {:frame {:type "string"
+                                      :description (str "Frame-id to pin as the session operating frame. Accepts bare names "
+                                                        "(\"stories\") or EDN-shaped strings (\":stories\"). MUST name a "
+                                                        "currently-registered frame — call get-operating-frame to list them.")}
+                              :build {:type "string"}}
+                 :required ["frame"]
+                 :additionalProperties false}})
+
+(def reset-operating-frame
+  {:name "reset-operating-frame"
+   :description (str "Clear the session's operating-frame pin set by set-operating-frame. After reset, "
+                     "frame-targeted ops resolve at tier 3 (sole-registered frame) or tier 4 "
+                     "(:ambiguous-frame when two-plus frames are registered and no per-call :frame is "
+                     "passed) again. Returns the post-reset triple {:ok? true :frames [...] :selected nil "
+                     ":operating <resolved-or-nil>}. Idempotent — resetting when nothing is pinned is a "
+                     "no-op that returns the same triple. "
+                     "Examples: "
+                     "1. Clear a pin in a multi-frame app: {} -> {:ok? true :frames [:rf/default :stories] :selected nil :operating nil}. "
+                     "2. Clear in a single-frame app: {} -> {:ok? true :frames [:rf/default] :selected nil :operating :rf/default} (tier-3 sole-frame resolution still applies).")
+   :typicalTokens 150
+   :annotations session-pin-annotations
+   :outputSchema envelope-or-marker
+   :inputSchema {:type "object"
+                 :properties {:build {:type "string"}}
+                 :additionalProperties false}})
+
+(def get-operating-frame
+  {:name "get-operating-frame"
+   :description (str "Report the session's operating-frame state — the normative triple per the Tool-Pair "
+                     "contract (§Tool-surface obligations): :frames (all registered frame-ids, so you can "
+                     "pick a target), :selected (the tier-2 session pin set by set-operating-frame, nil when "
+                     "unset), and :operating (the result of full resolution — nil means AMBIGUOUS: two-plus "
+                     "frames and no pin, so frame-targeted ops without a per-call :frame will refuse). "
+                     "Pure read; reads the SAME frame registry discover-app consults. Call this to find out "
+                     "which frame writes will land in, and whether you need to set-operating-frame first. "
+                     "Examples: "
+                     "1. Single frame, nothing pinned: {} -> {:ok? true :frames [:rf/default] :selected nil :operating :rf/default} (tier-3 sole-frame). "
+                     "2. Multi-frame, nothing pinned (AMBIGUOUS): {} -> {:ok? true :frames [:rf/default :stories] :selected nil :operating nil}. "
+                     "3. Multi-frame with a pin: {} -> {:ok? true :frames [:rf/default :stories] :selected :stories :operating :stories}.")
+   :typicalTokens 150
+   :annotations idempotent-read-only-annotations
+   :outputSchema envelope-or-marker
+   :inputSchema {:type "object"
+                 :properties {:build {:type "string"}}
                  :additionalProperties false}})
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
@@ -1,0 +1,191 @@
+(ns re-frame2-pair-mcp.tools.operating-frame
+  "Tools: set-operating-frame + reset-operating-frame + get-operating-frame
+  (rf2-zomfq).
+
+  The three operating-frame ops the [Tool-Pair contract][1] mandates
+  (§Tool-surface obligations) for any pair-shaped tool surface. They are
+  the MCP-side counterpart of the runtime's *session pin* — the tier-2
+  selection in the operating-frame resolution table — letting an AI
+  consumer escape the tier-4 `:ambiguous-frame` refusal a multi-frame app
+  otherwise traps them in.
+
+  ## The gap these close
+
+  re-frame2 is multi-frame (Spec 002). Every frame-targeted read/write
+  (`dispatch`, `snapshot`, `get-path`, `subscribe`, `list-subscriptions`,
+  …) resolves an *operating frame*: explicit per-call `:frame` (tier 1) →
+  session pin (tier 2) → sole-registered frame (tier 3) → nil
+  (tier 4, ambiguous). When two-plus frames are registered and the call
+  omits `:frame` and no session pin is set, resolution lands at tier 4 and
+  the op REFUSES with `{:ok? false :reason :ambiguous-frame}` rather than
+  guessing (per Tool-Pair §Ambiguity surface — a write that lands in the
+  wrong frame is unrecoverable without `restore-epoch`).
+
+  Before this tool, tier 2 was *unreachable from the MCP surface*: the
+  runtime exposed `select-frame!` / `current-frame` / `frames-list` but no
+  tool wired them onto the wire, so a multi-frame agent had to thread
+  `:frame` through every single call forever — defeating the
+  implicit-until-reset UX the contract designed. These three ops surface
+  the session pin so the agent declares it ONCE and escapes.
+
+  ## The trio
+
+  - **set-operating-frame** `{:frame \":stories\"}` — pin the session's
+    operating frame. Validates the frame-id names a currently-registered
+    frame (Tool-Pair §Tool-surface obligations: \"SHOULD validate … an
+    unknown frame returns `{:ok? false :reason :no-such-frame}`\"). On
+    success returns the resolved triple so the caller sees the pin took.
+  - **reset-operating-frame** `{}` — clear the session pin. Subsequent
+    ops resolve at tier 3 / 4 again. Returns the post-reset triple
+    (`:selected nil`).
+  - **get-operating-frame** `{}` — the read. Returns the normative triple
+    per Tool-Pair lines 394-401: `:frames` (all registered, so the caller
+    can pick a target), `:selected` (the tier-2 session pin, nil when
+    unset), `:operating` (the result of full resolution, nil = ambiguous).
+
+  ## How it escapes `:ambiguous-frame`
+
+  A frame-consuming op with no per-call `:frame` reads the session pin via
+  the runtime's `current-frame` resolver. Set writes that pin; from then
+  on `current-frame` returns the pinned id at tier 2 and the op proceeds
+  against it instead of refusing. Reset clears the pin, returning the
+  session to the tier-3/4 default posture.
+
+  ## All three route through the runtime's session pin
+
+  The session pin lives in the `re-frame2-pair.runtime` preload's
+  `selected-frame` atom — the SAME atom every other frame-consuming op
+  consults via `current-frame`. These tools are thin wrappers over the
+  already-published runtime fns:
+
+  - set   → validate against `(frames-list)` then `(select-frame! id)`.
+  - reset → `(select-frame! nil)` then read back the triple.
+  - get   → `(frames-list)`.
+
+  Composing the validation in the emitted eval form (rather than a new
+  runtime fn) keeps these ops on the pair-mcp surface and reuses the
+  runtime's single source of truth for the pin — set / get / reset can
+  never disagree about where the pin lives.
+
+  [1]: ../../../../spec/Tool-Pair.md"
+  (:require [re-frame2-pair-mcp.tools.args :as args]
+            [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.wire :as wire]
+            [re-frame2-pair-mcp.tools.probe :as probe]))
+
+;; ---------------------------------------------------------------------------
+;; set-operating-frame
+;;
+;; Validate-then-pin as ONE eval form so the membership check and the
+;; pin write happen atomically against the same runtime read — no
+;; check-then-act race across two round-trips. `frames-list` returns the
+;; `{:ok? :frames :selected :operating}` triple; we read `:frames`,
+;; test membership, and either `select-frame!` (returning the fresh
+;; triple) or refuse with `:no-such-frame` (carrying the registered
+;; `:frames` so the caller can pick a valid target).
+;; ---------------------------------------------------------------------------
+
+(defn- set-form
+  "Build the validate-then-pin eval form for `frame-id` (a keyword).
+
+  Reads the current frame list, and IF `frame-id` is registered, pins it
+  and returns the post-pin triple; ELSE returns a `:no-such-frame`
+  envelope carrying the registered frames so the agent can retarget."
+  [frame-id]
+  (ef/emit
+    (ef/rt-let
+      ['fl    (ef/rt-call 'frames-list)
+       'fids  (ef/rt-raw "(:frames fl)")]
+      (ef/rt-raw
+        (str "(if (some #{" (pr-str frame-id) "} fids)"
+             "  (do (re-frame2-pair.runtime/select-frame! " (pr-str frame-id) ")"
+             "      (re-frame2-pair.runtime/frames-list))"
+             "  {:ok? false :reason :no-such-frame"
+             "   :frame " (pr-str frame-id)
+             "   :frames fids})")))))
+
+(defn set-operating-frame-tool [conn raw-args]
+  (let [frame-str (wire/arg raw-args :frame)
+        frame     (some-> frame-str args/->frame-keyword)
+        build-id  (wire/arg-build conn raw-args)]
+    (if (nil? frame)
+      (js/Promise.resolve
+        (wire/err-text
+          {:ok?    false
+           :reason :missing-frame
+           :hint   (str "usage: set-operating-frame {frame \":stories\"}. "
+                        "Pin the session's operating frame so subsequent "
+                        "frame-targeted ops (dispatch, snapshot, get-path, "
+                        "subscribe, …) resolve to it instead of refusing "
+                        "with :ambiguous-frame. Call get-operating-frame "
+                        "to see the registered frames.")}))
+      (let [form (set-form frame)]
+        (probe/eval-after-runtime!
+          conn build-id form :set-operating-frame-failed
+          (fn [v]
+            ;; Two runtime shapes resolve into one the agent can rely on:
+            ;;   - success: `frames-list`'s {:ok? true :frames :selected
+            ;;     :operating} triple. Pass through — `:selected` now
+            ;;     equals the just-pinned frame.
+            ;;   - unknown frame: {:ok? false :reason :no-such-frame
+            ;;     :frame :frames}. Add a corrective hint.
+            (wire/ok-text
+              (cond
+                (not (map? v))
+                {:ok? false :reason :unexpected-shape :frame frame :value v}
+
+                (false? (:ok? v))
+                (assoc v :hint
+                       (str "frame " frame " is not currently registered. "
+                            "Pick one of " (vec (:frames v))
+                            " — call get-operating-frame to list them."))
+
+                :else v))))))))
+
+;; ---------------------------------------------------------------------------
+;; reset-operating-frame
+;;
+;; Clear the session pin (`select-frame! nil`) and read back the triple so
+;; the caller sees the post-reset state (`:selected nil`, `:operating` now
+;; the tier-3/4 resolution). One eval form — clear then re-read — so the
+;; reported triple reflects the cleared pin.
+;; ---------------------------------------------------------------------------
+
+(defn- reset-form []
+  (ef/emit
+    (ef/rt-let
+      ['_ (ef/rt-call 'select-frame! nil)]
+      (ef/rt-call 'frames-list))))
+
+(defn reset-operating-frame-tool [conn raw-args]
+  (let [build-id (wire/arg-build conn raw-args)
+        form     (reset-form)]
+    (probe/eval-after-runtime!
+      conn build-id form :reset-operating-frame-failed
+      (fn [v]
+        (wire/ok-text
+          (if (map? v)
+            v
+            {:ok? false :reason :unexpected-shape :value v}))))))
+
+;; ---------------------------------------------------------------------------
+;; get-operating-frame
+;;
+;; Pure read — the normative triple (Tool-Pair lines 394-401). Routes
+;; through the runtime's `frames-list`, the SAME accessor `discover-app`
+;; consults, so the two never disagree about what's registered or pinned.
+;; ---------------------------------------------------------------------------
+
+(defn- get-form []
+  (ef/emit (ef/rt-call 'frames-list)))
+
+(defn get-operating-frame-tool [conn raw-args]
+  (let [build-id (wire/arg-build conn raw-args)
+        form     (get-form)]
+    (probe/eval-after-runtime!
+      conn build-id form :get-operating-frame-failed
+      (fn [v]
+        (wire/ok-text
+          (if (map? v)
+            v
+            {:ok? false :reason :unexpected-shape :value v}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
@@ -81,6 +81,7 @@
             [re-frame2-pair-mcp.tools.list-subscriptions :as list-subscriptions]
             [re-frame2-pair-mcp.tools.list-streams :as list-streams]
             [re-frame2-pair-mcp.tools.handler-meta :as handler-meta]
+            [re-frame2-pair-mcp.tools.operating-frame :as operating-frame]
             [re-frame2-pair-mcp.tools.get-re-frame2-pair-instructions :as get-re-frame2-pair-instructions]
             [re-frame2-pair-mcp.tools.descriptors-data :as data]))
 
@@ -233,6 +234,29 @@
     :handler    (ignoring-extra #(handler-meta/list-handlers-tool %1 %2))
     :cacheable? true
     :descriptor data/list-handlers}
+   {:name       "set-operating-frame"
+    :handler    (ignoring-extra #(operating-frame/set-operating-frame-tool %1 %2))
+    ;; Mutates the per-session frame pin — NOT cacheable (the result is
+    ;; the outcome of a session-state write, not a function of frame
+    ;; state). Same posture as the action tools.
+    :cacheable? false
+    :descriptor data/set-operating-frame}
+   {:name       "reset-operating-frame"
+    :handler    (ignoring-extra #(operating-frame/reset-operating-frame-tool %1 %2))
+    ;; Clears the session pin — a session-state write. Not cacheable.
+    :cacheable? false
+    :descriptor data/reset-operating-frame}
+   {:name       "get-operating-frame"
+    :handler    (ignoring-extra #(operating-frame/get-operating-frame-tool %1 %2))
+    ;; Pure read of the resolved frame triple — a function of the frame
+    ;; registry + session pin. Cacheable like the other read tools; the
+    ;; precheck-hash short-circuit keys on app-db, but the triple is
+    ;; cheap to recompute and the cache opt-in is per-call, so a stale
+    ;; read after a set/reset is avoided by the :cache default-false
+    ;; posture (rf2-c4fmh). Treating it as cacheable keeps it in the
+    ;; read family for the cache opt-in knob.
+    :cacheable? true
+    :descriptor data/get-operating-frame}
    {:name       "get-re-frame2-pair-instructions"
     :handler    (ignoring-extra #(get-re-frame2-pair-instructions/get-re-frame2-pair-instructions-tool %1 %2))
     :cacheable? true

--- a/tools/re-frame2-pair-mcp/test/fixtures/tool-names.json
+++ b/tools/re-frame2-pair-mcp/test/fixtures/tool-names.json
@@ -1,10 +1,11 @@
 {
-  "_doc": "Canonical tool-name list for re-frame2-pair-mcp (per spec/003-Tool-Catalogue.md). Shared fixture (rf2-drke0, mirrors story-mcp's rf2-36upq TE7) so the upstream stdio-roundtrip and the cross-server `tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs` harness agree on the expected `tools/list` response without two hand-maintained lists drifting. Sorted alphabetically — both consumers compare against the sorted form. `list-subscriptions` / `list-handlers` were renamed from `subscription-info` / `registry-list` per rf2-4y595 (NAMING.md conformance). `list-subscriptions` reads the live reactive sub-cache (rf2-qicji); the streaming-tap diagnostic it formerly carried moved to `list-streams`. `restore-epoch` / `reset-frame-db` are the gated write tools (rf2-ee38b.18) — they appear in tools/list unconditionally; the --allow-writes gate is enforced at tools/call time, not by hiding the descriptor.",
+  "_doc": "Canonical tool-name list for re-frame2-pair-mcp (per spec/003-Tool-Catalogue.md). Shared fixture (rf2-drke0, mirrors story-mcp's rf2-36upq TE7) so the upstream stdio-roundtrip and the cross-server `tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs` harness agree on the expected `tools/list` response without two hand-maintained lists drifting. Sorted alphabetically — both consumers compare against the sorted form. `list-subscriptions` / `list-handlers` were renamed from `subscription-info` / `registry-list` per rf2-4y595 (NAMING.md conformance). `list-subscriptions` reads the live reactive sub-cache (rf2-qicji); the streaming-tap diagnostic it formerly carried moved to `list-streams`. `restore-epoch` / `reset-frame-db` are the gated write tools (rf2-ee38b.18) — they appear in tools/list unconditionally; the --allow-writes gate is enforced at tools/call time, not by hiding the descriptor. `set-operating-frame` / `reset-operating-frame` / `get-operating-frame` are the Tool-Pair §Tool-surface-obligations ops (rf2-zomfq) that surface the session frame pin — the escape from tier-4 :ambiguous-frame.",
   "names": [
     "discover-app",
     "dispatch",
     "dispatch-dry-run",
     "eval-cljs",
+    "get-operating-frame",
     "get-path",
     "get-re-frame2-pair-instructions",
     "handler-meta",
@@ -15,7 +16,9 @@
     "read-recording",
     "record",
     "reset-frame-db",
+    "reset-operating-frame",
     "restore-epoch",
+    "set-operating-frame",
     "snapshot",
     "subscribe",
     "tail-build",

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -308,6 +308,9 @@
     | list-streams           | yes   | n/a         | n/a               |
     | handler-meta           | yes   | yes         | (short-circuit)   |
     | list-handlers          | yes   | yes         | (short-circuit)   |
+    | set-operating-frame    | yes   | yes         | no-such-frame     |
+    | reset-operating-frame  | yes   | n/a         | n/a               |
+    | get-operating-frame    | yes   | n/a         | ambiguous (nil)   |
     | get-re-frame2-pair-instructions | yes   | n/a         | n/a               |
     | (pipeline)             | cache-hit (precheck) ; unknown-tool error  |
 
@@ -940,6 +943,117 @@
     [[:default nil]]
     :fixture/expect
     {:isError? false}}
+
+   ;; ---------- operating-frame trio (rf2-zomfq) --------------------------
+   ;; The three Tool-Pair §Tool-surface-obligations ops. The runtime
+   ;; surfaces them via `frames-list` (the {:frames :selected :operating}
+   ;; triple) and `select-frame!`; the tools compose validate-then-pin /
+   ;; clear-then-reread / read forms over those. The corpus pins the
+   ;; outer wire shape + the escape contract: a SET in a multi-frame
+   ;; session makes the next frame-consuming op resolve to the pinned
+   ;; frame instead of refusing with :ambiguous-frame.
+   {:fixture/id    :set-operating-frame/happy
+    :fixture/doc   "set-operating-frame pins a registered frame and returns the resolved triple with :selected = the pinned frame (the tier-2 escape from :ambiguous-frame)."
+    :fixture/tool  "set-operating-frame"
+    :fixture/args  {:frame ":stories"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ;; The validate-then-pin form reads frames-list, finds :stories
+     ;; registered, pins it, and re-reads the triple — now :selected
+     ;; :stories, :operating :stories.
+     ["select-frame!"             {:ok? true
+                                   :frames [:rf/default :stories]
+                                   :selected :stories
+                                   :operating :stories}]
+     [:default                    nil]]
+    ;; The emitted form MUST validate against the registered list AND
+    ;; pin via select-frame! — the escape mechanism. The keyword rides
+    ;; as a well-formed :stories, never the malformed ::stories.
+    :fixture/eval-form-must-contain
+    ["frames-list" "select-frame!" ":stories"]
+    :fixture/eval-form-must-not-contain
+    ["::stories"]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :selected :stories :operating :stories}
+     :edn-contains-keys #{:frames :selected :operating}}}
+
+   {:fixture/id    :set-operating-frame/no-such-frame
+    :fixture/doc   "set-operating-frame on an unregistered frame refuses with :no-such-frame and lists the registered frames (Tool-Pair §Tool-surface obligations validation)."
+    :fixture/tool  "set-operating-frame"
+    :fixture/args  {:frame ":nope"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ;; :nope is not in frames-list → the form's else branch returns the
+     ;; :no-such-frame envelope WITHOUT calling select-frame!.
+     [:default                    {:ok? false :reason :no-such-frame
+                                   :frame :nope
+                                   :frames [:rf/default :stories]}]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? false :reason :no-such-frame :frame :nope}}}
+
+   {:fixture/id    :set-operating-frame/missing-frame
+    :fixture/doc   "set-operating-frame without :frame surfaces :missing-frame before any nREPL round-trip."
+    :fixture/tool  "set-operating-frame"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :missing-frame}}
+
+   {:fixture/id    :reset-operating-frame/clears-pin
+    :fixture/doc   "reset-operating-frame clears the session pin (select-frame! nil) and returns the post-reset triple with :selected nil."
+    :fixture/tool  "reset-operating-frame"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ;; The clear-then-reread form: select-frame! nil, then frames-list
+     ;; reports :selected nil. In a multi-frame app :operating is now nil
+     ;; (back to tier-4 ambiguous).
+     ["select-frame!"             {:ok? true
+                                   :frames [:rf/default :stories]
+                                   :selected nil
+                                   :operating nil}]
+     [:default                    nil]]
+    :fixture/eval-form-must-contain
+    ["select-frame! nil" "frames-list"]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :selected nil :operating nil}
+     :edn-contains-keys #{:frames :selected :operating}}}
+
+   {:fixture/id    :get-operating-frame/reports-triple
+    :fixture/doc   "get-operating-frame returns the normative {:frames :selected :operating} triple; :selected reflects a prior set."
+    :fixture/tool  "get-operating-frame"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["frames-list"               {:ok? true
+                                   :frames [:rf/default :stories]
+                                   :selected :stories
+                                   :operating :stories}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :selected :stories :operating :stories}
+     :edn-contains-keys #{:frames :selected :operating}}}
+
+   {:fixture/id    :get-operating-frame/ambiguous
+    :fixture/doc   "get-operating-frame reports :operating nil (AMBIGUOUS) when two-plus frames are registered and nothing is pinned — the tier-4 state the trio escapes."
+    :fixture/tool  "get-operating-frame"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["frames-list"               {:ok? true
+                                   :frames [:rf/default :stories]
+                                   :selected nil
+                                   :operating nil}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :selected nil :operating nil}}}
 
    ;; ---------- get-re-frame2-pair-instructions ------------------------------------
    ;; Inline-text tool (rf2-fnpqg). No nREPL round-trip; the result is a


### PR DESCRIPTION
## What

Ships the three operating-frame ops the [Tool-Pair §Tool-surface obligations](../blob/main/spec/Tool-Pair.md#tool-surface-obligations) contract mandates but that shipped **unimplemented** (P1 contract gap, rf2-zomfq):

- **`set-operating-frame`** `{:frame ":stories"}` — validates the frame-id against `frames-list`, then `select-frame!`s it (one atomic validate-then-pin eval form). Unknown frame → `{:ok? false :reason :no-such-frame :frames [...]}`; missing arg → `:missing-frame`. Returns the `{:frames :selected :operating}` triple.
- **`reset-operating-frame`** `{}` — `select-frame! nil` then re-reads the triple (`:selected nil`; back to tier-3/4 resolution).
- **`get-operating-frame`** `{}` — reads `frames-list`; the normative `{:frames :selected :operating}` triple (`:operating nil` = ambiguous).

### How they escape `:ambiguous-frame`

A frame-consuming op (`dispatch`/`snapshot`/`get-path`/`subscribe`/…) with no per-call `:frame` reads the session pin via the runtime's `current-frame` resolver. Before this change, tier 2 (session pin) was unreachable from the MCP surface — the runtime had `select-frame!`/`current-frame`/`frames-list` but no tool wired them onto the wire, so a multi-frame agent hitting tier-4 `:ambiguous-frame` had to thread `:frame` through every call forever. `set-operating-frame` writes the pin → subsequent ops resolve at tier 2 instead of refusing. All three are thin wrappers over the already-published runtime fns; the pin lives in the runtime's `selected-frame` atom that every op consults, so set/get/reset can't disagree.

## Naming

The Tool-Pair contract leaves wire names unpinned but states the stable trio as `set`/`reset`/`get-operating-frame`. `get-`/`reset-` are catalogued NAMING.md verbs; `set-` was on the **rejected** list. Added a single narrow carve-out for the operating-frame pin (one named session setting, not a generic mutation surface): verb-table row + rejection carve-out + verb-vocab linter prefix + a DESIGN-RATIONALE Lock note. A generic `set-<arbitrary>` stays rejected.

## spec/Tool-Pair.md

**UNTOUCHED.** The repo-root MUST was correct — it was purely unimplemented, not a spec error. No hot-zone edit.

## Quality gates

| Gate | Result |
|---|---|
| pair-mcp `npm test` (shadow-cljs `:server-test`) | **747 tests, 2166 assertions, 0 failures, 0 errors** (incl. 7 new operating-frame conformance fixtures) |
| `npm run test:mcp-conformance` (all 6 gates) | **ALL GREEN** — gate [3] pair-mcp server-test, gate [4] pair-mcp end-to-end (live `tools/list` catalogue now advertises 25 tools incl. the trio), gate [6] wire-vocab verb conformance (49 tests, 628 assertions, 0 failures) |
| clj-kondo (changed files) | **0 errors.** New `operating_frame.cljs` + `registry.cljs` + `verb_vocab_test.clj`: 0 warnings. 3 warnings flagged are all pre-existing at HEAD (`streaming-annotations`, `streaming-summary-annotations`, conformance `error?`) |
| `mkdocs build --strict` | **N/A** — no `docs/` prose touched (mkdocs `docs_dir: docs`; all edited spec/README files live under `tools/`, outside the site) |
| `python scripts/check_skill_mcp_drift.py` (skill ↔ MCP drift, rf2-flzdp) | **GREEN** (follow-up fix) — the trio shipped 3 new pair-mcp tools; `skills/re-frame2-pair/SKILL.md` `allowed-tools:` now allow-lists `get`/`set`/`reset-operating-frame`. Re-run: `No skill <-> MCP drift detected` (pair mapping server=25, skill=23 — 2 write-authority tools intentional_server_only). SKILL.md is the skill manifest, not a `docs_dir` input, so `mkdocs --strict` unaffected. |

## Tests (failing-before / passing-after)

7 conformance corpus fixtures pin the wire shapes **and** the form composition: set emits a form containing `frames-list` + `select-frame!` + well-formed `:stories` (never `::stories`); reset emits `select-frame! nil` + `frames-list`; set→triple resolution lands on the pinned frame (the tier-2 escape); reset returns `:selected nil`; get reports the triple incl. the `:operating nil` ambiguous state.

Closes rf2-zomfq.