### PR TITLE
fix(core): dev-warn on unknown dispatch/subscribe opts key (rf2-jbzhj)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -179,6 +179,16 @@
         ;; ordering guarantee — NOT a trace concern — so the flag is
         ;; carried unconditionally (never gated on interop/debug-enabled?).
         machine-internal?  (true? (:rf.machine/internal? opts))]
+    ;; Per rf2-jbzhj: surface unrecognised opts keys (typically a typo'd
+    ;; opt like `:fram` for `:frame`) rather than silently swallowing
+    ;; them. Dev-only: `unknown-dispatch-opts` returns nil under
+    ;; `interop/debug-enabled? false`, so the whole `when-let` body —
+    ;; including the diagnostics-ns warning fn — DCEs in production. Every
+    ;; dispatch path (`dispatch!`, `dispatch-sync!`, the frame-handle ops)
+    ;; funnels through here, so this is the single chokepoint for the
+    ;; check. The dispatch proceeds unchanged regardless (warn-only).
+    (when-let [unknown (diag/unknown-dispatch-opts opts)]
+      (diag/emit-unknown-dispatch-opts-warning! unknown event))
     (cond-> {:event                  event
              :frame                  (or (:frame opts) default-frame)
              ;; Per rf2-5uwl: merge the lexical-scope `*fx-overrides*`

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -146,6 +146,80 @@
                   id)))))
         (frame/frame-ids)))
 
+(def ^:const known-dispatch-opts
+  "Per rf2-jbzhj — the closed set of keys `build-envelope` reads off the
+  `dispatch` / `dispatch-sync` opts map (and therefore the only keys that
+  affect dispatch behaviour). Every other key is silently swallowed, so a
+  typo'd opt (`:fram` for `:frame`, `:src` for `:source`) changes nothing
+  and gives no signal — the no-silent-swallow principle (rf2-3nbl5.1)
+  forbids that quietness. `emit-unknown-dispatch-opts-warning!` warns on
+  any opts key outside this set.
+
+  The set mirrors the reads in `re-frame.router/build-envelope`:
+    :frame                  resolved target frame
+    :fx-overrides           per-call fx-id remapping
+    :interceptor-overrides  per-call interceptor remapping
+    :trace-id               tooling correlation id
+    :source                 closed-enum trigger-kind / functional-origin
+    :source-detail          per-source-kind detail payload
+    :origin                 actor identity tag
+    :rf.trace/call-site     macro-stamped invocation coord (dev-only)
+    :rf.machine/internal?   machine-internal continuation flag (front-queue)"
+  #{:frame :fx-overrides :interceptor-overrides :trace-id :source
+    :source-detail :origin :rf.trace/call-site :rf.machine/internal?})
+
+(defn unknown-dispatch-opts
+  "Return the seq of keys in `opts` that fall OUTSIDE
+  `known-dispatch-opts`, or nil when every key is known (so callers can
+  `when-let` the result). Dev-only — the sole caller gates on
+  `interop/debug-enabled?`."
+  [opts]
+  (when interop/debug-enabled?
+    (seq (remove known-dispatch-opts (keys opts)))))
+
+(defn emit-unknown-dispatch-opts-warning!
+  "Per rf2-jbzhj: emit `:rf.warning/unknown-dispatch-opt` when a
+  `dispatch` / `dispatch-sync` opts map carries one or more keys outside
+  the recognised `known-dispatch-opts` set. The runtime reads only the
+  known keys in `build-envelope`; an unrecognised key (almost always a
+  typo — `:fram` instead of `:frame`) is otherwise silently swallowed and
+  changes nothing, producing wrong behaviour with no signal. Pre-alpha
+  posture: surface it loudly rather than ship a quiet footgun (aligns with
+  the committed no-silent-swallow principle, rf2-3nbl5.1).
+
+  One warning per dispatch call carrying unknown keys: the message names
+  every bad key and the full known set so the fix is obvious. The dispatch
+  proceeds unchanged — this is observational, never refusal (`:recovery
+  :no-recovery`).
+
+  Body gated on `interop/debug-enabled?` so the whole surface — the
+  warning keyword's interned slot, the reason-string allocation, the
+  `unknown-dispatch-opts` walk — DCEs wholesale under `:advanced` +
+  `goog.DEBUG=false` (rf2-gaqwr). The caller in `build-envelope` reads the
+  unknown-key seq inside the same gate so production never walks the opts."
+  [unknown event]
+  (when interop/debug-enabled?
+    (let [event-id (first event)
+          unknown  (vec unknown)
+          reason   (str "Dispatch of `" event-id "` was given unrecognised "
+                        "opts key" (when (> (count unknown) 1) "s") " "
+                        (pr-str unknown) ". The runtime reads only "
+                        (pr-str (vec (sort known-dispatch-opts)))
+                        " — any other key is silently ignored, so a typo "
+                        "(e.g. `:fram` for `:frame`) changes nothing and "
+                        "gives no signal. Check for a misspelt opt; if you "
+                        "intended a custom payload, put it inside the event "
+                        "vector, not the dispatch opts map.")]
+      (trace/emit! :warning
+                   :rf.warning/unknown-dispatch-opt
+                   {:event        event
+                    :event-id     event-id
+                    :unknown-keys unknown
+                    :known-keys   (vec (sort known-dispatch-opts))
+                    :detected-at  (interop/now-ms)
+                    :reason       reason
+                    :recovery     :no-recovery}))))
+
 (defn emit-cross-frame-warning!
   "Per rf2-fp97: emit `:rf.warning/cross-frame-dispatch-sync-during-drain`
   when `dispatch-sync!` lands on frame `target-id` while a different

--- a/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
+++ b/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
@@ -1,0 +1,137 @@
+(ns re-frame.unknown-dispatch-opts-warn-test
+  "Per rf2-jbzhj — emit `:rf.warning/unknown-dispatch-opt` when a
+  `dispatch` / `dispatch-sync` opts map carries a key outside the
+  recognised set (`re-frame.router.diagnostics/known-dispatch-opts`).
+
+  The runtime reads only the known opts keys in `build-envelope`; any
+  other key is silently swallowed, so a typo (`:fram` for `:frame`,
+  `:src` for `:source`) changes nothing and gives no signal — the
+  no-silent-swallow principle (rf2-3nbl5.1) forbids that quietness.
+
+  The warning is observational: the dispatch proceeds unchanged
+  (`:recovery :no-recovery`). It is dev-only — gated on
+  `interop/debug-enabled?`, so production (`:advanced` +
+  `goog.DEBUG=false`) DCEs the whole surface (the elision probe verifies
+  that separately)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.router.diagnostics :as diag]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (trace/clear-listeners!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces!
+  [listener-id]
+  (let [a (atom [])]
+    (rf/register-listener! listener-id (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- unknown-opt-warnings
+  [recorded]
+  (filterv (fn [ev]
+             (and (= :warning (:op-type ev))
+                  (= :rf.warning/unknown-dispatch-opt (:operation ev))))
+           @recorded))
+
+;; ---- tests ----------------------------------------------------------------
+
+(deftest fires-on-unknown-opts-key
+  (testing "an unrecognised opts key emits exactly one warning naming the bad key + the known set"
+    (rf/reg-event-db :app/noop (fn [db _] db))
+    (let [recorded (record-traces! ::unknown)]
+      ;; `:fram` is the classic typo for `:frame` — silently swallowed
+      ;; before this fix.
+      (rf/dispatch-sync [:app/noop] {:fram :rf/default})
+
+      (let [warns (unknown-opt-warnings recorded)]
+        (is (= 1 (count warns))
+            (str "expected exactly one unknown-opt warning, got "
+                 (count warns)))
+        (let [w (first warns)
+              t (:tags w)]
+          (is (= [:app/noop] (:event t)))
+          (is (= :app/noop (:event-id t)))
+          (is (= [:fram] (:unknown-keys t))
+              "the bad key is named verbatim")
+          (is (contains? (set (:known-keys t)) :frame)
+              "the warning enumerates the known opts set")
+          (is (string? (:reason t)))
+          (is (re-find #":fram" (:reason t))
+              "reason names the offending key")
+          (is (re-find #":frame" (:reason t))
+              "reason lists the known keys (incl. the likely intended :frame)")
+          (is (= :no-recovery (:recovery w))))))))
+
+(deftest names-every-unknown-key-in-one-warning
+  (testing "multiple unknown keys → a single warning listing them all"
+    (rf/reg-event-db :app/noop (fn [db _] db))
+    (let [recorded (record-traces! ::multi)]
+      (rf/dispatch-sync [:app/noop] {:fram :rf/default :srce :ui :origin :app})
+
+      (let [warns (unknown-opt-warnings recorded)]
+        (is (= 1 (count warns)) "one warning for the whole call, not one per bad key")
+        (let [t (:tags (first warns))]
+          (is (= #{:fram :srce} (set (:unknown-keys t)))
+              "both typos named; the legitimate :origin opt is NOT flagged"))))))
+
+(deftest no-warning-for-known-opts
+  (testing "a known opts key (:frame) → no warning"
+    (rf/reg-frame :game {:doc "non-default frame target"})
+    (rf/reg-event-db :game/tick {:frame :game} (fn [db _] db))
+    (let [recorded (record-traces! ::known)]
+      (rf/dispatch-sync [:game/tick] {:frame :game})
+      (is (empty? (unknown-opt-warnings recorded))
+          ":frame is a recognised opt — no warning"))))
+
+(deftest no-warning-for-source-and-origin-opts
+  (testing "the full known set is accepted without warning"
+    (rf/reg-event-db :app/noop (fn [db _] db))
+    (let [recorded (record-traces! ::full-known)]
+      (rf/dispatch-sync [:app/noop]
+                        {:source :ui :origin :app :trace-id "t1"
+                         :fx-overrides {} :interceptor-overrides {}
+                         :source-detail {:ms 100}})
+      (is (empty? (unknown-opt-warnings recorded))
+          "every key here is in known-dispatch-opts"))))
+
+(deftest no-warning-for-empty-opts
+  (testing "the no-opts dispatch path emits no warning"
+    (rf/reg-event-db :app/noop (fn [db _] db))
+    (let [recorded (record-traces! ::empty)]
+      (rf/dispatch-sync [:app/noop])
+      (is (empty? (unknown-opt-warnings recorded))
+          "empty opts map has no unknown keys"))))
+
+(deftest async-dispatch-path-also-warns
+  (testing "the queued `dispatch` path (not just dispatch-sync) warns on unknown keys"
+    (rf/reg-event-db :app/noop (fn [db _] db))
+    (let [recorded (record-traces! ::async)]
+      ;; `dispatch` enqueues; the JVM drain runs it synchronously via the
+      ;; router, but `build-envelope` (where the check lives) runs at
+      ;; enqueue time regardless.
+      (rf/dispatch [:app/noop] {:fram :rf/default})
+      (is (= 1 (count (unknown-opt-warnings recorded)))
+          "build-envelope is the single chokepoint — both dispatch paths funnel through it"))))
+
+(deftest known-set-matches-build-envelope-reads
+  (testing "the published known-opts set documents exactly the keys build-envelope honours"
+    ;; A guard against drift: if build-envelope grows/drops an opt the
+    ;; set must move with it. This is the canonical enumeration callers
+    ;; (and the warning message) rely on.
+    (is (= #{:frame :fx-overrides :interceptor-overrides :trace-id :source
+             :source-detail :origin :rf.trace/call-site :rf.machine/internal?}
+           diag/known-dispatch-opts))))


### PR DESCRIPTION
## What

The dispatch opts map silently **swallowed unrecognised keys**: a typo like `(dispatch [:e] {:fram :x})` for `:frame` was ignored with no signal, producing wrong behaviour quietly. This adds a dev-gated, production-elided `:rf.warning/unknown-dispatch-opt` that fires when a `dispatch` / `dispatch-sync` opts map carries a key outside the recognised set, naming the bad key(s) and the full known set. Aligns with the no-silent-swallow principle (rf2-3nbl5.1).

## Where / how

- **Warn site:** `re-frame.router/build-envelope` — the single chokepoint every dispatch path funnels through (`dispatch!`, `dispatch-sync!`, and the `frame-handle` `:dispatch`/`:dispatch-sync` ops, which route through `dispatch*`/`dispatch-sync*`). A dev-gated `when-let` consults `diagnostics/unknown-dispatch-opts`; on any unknown key it calls `emit-unknown-dispatch-opts-warning!`. Warn-only — the dispatch proceeds unchanged (`:recovery :no-recovery`).
- **Known-opts set** (published as `re-frame.router.diagnostics/known-dispatch-opts`, mirrors the keys `build-envelope` actually reads):
  `:frame :fx-overrides :interceptor-overrides :trace-id :source :source-detail :origin :rf.trace/call-site :rf.machine/internal?`
- **subscribe is NOT affected:** the subscribe surface (`subs/subscribe`, `subscribe*`, the macro, the frame-handle `:subscribe`) takes **positional** `frame-id`/`query-v` — there is no opts map to swallow keys. The bead title says dispatch/subscribe; the code shows only dispatch has an opts map, so the fix is dispatch-opts only (stated explicitly in the commit + diagnostics docstring).

## Elision

Whole surface is gated on `interop/debug-enabled?` (the `build-envelope` consult is a `when-let` that returns nil in production, and `emit-unknown-dispatch-opts-warning!`'s body is gated too), so it DCEs under `:advanced` + `goog.DEBUG=false`. Mirrors the sibling `:rf.warning/dispatch-from-async-callback-fell-through-to-default` / `:rf.warning/cross-frame-dispatch-sync-during-drain` diagnostics in the same ns.

## Public surface

`dispatch`/`dispatch-sync`/`subscribe` + their `*` variants are public; the change is **additive / warn-only** — no signatures changed. `git grep -lE "(:require \[.*re-frame\.(core|events|subs))" implementation/ tools/` → 40 consumers, none broken. **spec/API.md + Conventions untouched** (governance epic); spec/002-Frames prose untouched (no mkdocs run needed). `scripts/` untouched (1ggkn's surface).

## Quality gates

- core `clojure -M:test`: **Ran 832 tests, 3675 assertions, 0 failures, 0 errors** (incl. new `unknown-dispatch-opts-warn-test`, 7 deftests)
- `npm run test:cljs`: **Ran 5174 tests, 17569 assertions, 0 failures, 0 errors**
- `npm run test:elision`: **PASS — production 40/40 absent; control 40/40 present** (warning is production-elided)
- clj-kondo (changed files): **0 errors, 0 new warnings** (the 4 pre-existing router.cljc warnings are unrelated, confirmed against baseline)

Regression tests (failing-before / passing-after): unknown key → exactly one warning naming the key + known set; multiple typos → one warning listing them; known opts (`:frame`, full set, empty) → no warning; both `dispatch` and `dispatch-sync` paths covered; a drift-guard pins `known-dispatch-opts` to the keys `build-envelope` honours.

Closes rf2-jbzhj. Do not merge yet.