### PR TITLE
fix(mcp-base+ssr-ring): correct stale :include-sensitive docstring + dev-warn on non-string header (rf2-0hynd rf2-b0jlr)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -8,7 +8,9 @@
   pairs into vectors so multi-valued headers (Set-Cookie, Vary,
   Link, ...) round-trip correctly."
   (:require [clojure.string :as str]
-            [re-frame.ssr.ring.cookie :as cookie]))
+            [re-frame.interop :as interop]
+            [re-frame.ssr.ring.cookie :as cookie]
+            [re-frame.trace :as trace]))
 
 (set! *warn-on-reflection* true)
 
@@ -24,8 +26,37 @@
   the `string?` arm does (existing scalar → `[existing v]`); without it
   the `cond` would return `nil`, silently wiping the ENTIRE accumulated
   header map mid-fold (Content-Type, Set-Cookie, everything folded so
-  far) — a silent-failure header-loss bug."
+  far) — a silent-failure header-loss bug.
+
+  ## Dev-gated non-string warning (rf2-b0jlr)
+
+  The fold tolerates a non-string value (the `:else` arm above) so a
+  scalar that slipped past the fx-boundary name/value gates can't take
+  down the whole header map. But a non-string value here is host-
+  dependent and almost certainly a CALLER bug — Ring's `:headers`
+  contract is string OR vector-of-strings, and a number / keyword /
+  boolean reaching the wire is undefined behaviour at the servlet
+  layer. Rather than silently coercing (`(str v)`) or silently passing
+  it through, we surface it: a dev-gated `:warning` trace naming the
+  offending header key and the value's type. Production builds elide
+  the whole check (the `interop/debug-enabled?` gate + `trace/emit!`'s
+  own Closure-DCE gate), keeping the hot fold branchless on the wire.
+  Aligns with the no-silent-swallow posture (cf. the redirect-no-target
+  warning in `pipeline`)."
   [m [k v]]
+  (when (and interop/debug-enabled? (not (string? v)))
+    (trace/emit! :warning :rf.ssr/ssr-non-string-header-value
+                 {:where      :ssr-ring/merge-pair-into-header-map
+                  :header     k
+                  :value-type (some-> v class .getName)
+                  :reason     (str "header " (pr-str k) " carries a non-string "
+                                   "value of type "
+                                   (or (some-> v class .getName) "nil")
+                                   " — Ring header values must be strings (or a "
+                                   "vector of strings); the fold passes it through "
+                                   "verbatim, but this is host-dependent and almost "
+                                   "certainly a caller bug")
+                  :recovery   :warned-and-passed-through}))
   (let [existing (get m k)]
     (cond
       (nil? existing)        (assoc m k v)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -236,6 +236,61 @@
       (is (= "text/html" (get result "Content-Type"))
           "the defaulted Content-Type survives — the map was never nulled"))))
 
+;; ===========================================================================
+;; merge-pair-into-header-map — dev-gated warning on a non-string value
+;;
+;; rf2-b0jlr: a non-string header value reaching the fold is host-dependent
+;; and almost certainly a caller bug (Ring header values must be strings).
+;; The fold still tolerates it (the :else arm), but it surfaces a dev-gated
+;; :warning trace naming the offending key + value-type rather than silently
+;; coercing or passing it through. A string value emits NO warning.
+;; ===========================================================================
+
+(defn- collect-non-string-header-warnings
+  "Run `thunk` while listening for `:rf.ssr/ssr-non-string-header-value`
+  warning traces; return the collected events."
+  [thunk]
+  (let [traces (atom [])]
+    (rf/register-listener! ::non-string-header-watch
+      (fn [ev] (when (= :rf.ssr/ssr-non-string-header-value (:operation ev))
+                 (swap! traces conj ev))))
+    (try
+      (thunk)
+      (finally
+        (rf/unregister-listener! ::non-string-header-watch)))
+    @traces))
+
+(deftest non-string-header-value-emits-exactly-one-dev-warning
+  (testing "rf2-b0jlr: a non-string header value reaching the fold emits
+            exactly one :warning trace naming the offending key + value-type;
+            the value still folds in (the :else-arm tolerance is unchanged)"
+    (let [warnings (collect-non-string-header-warnings
+                     (fn []
+                       (let [result (headers/merge-pair-into-header-map
+                                      {} ["X-Count" 5])]
+                         (is (= {"X-Count" 5} result)
+                             "the non-string value still folds in verbatim"))))]
+      (is (= 1 (count warnings)) "exactly one warning for one non-string value")
+      (let [ev   (first warnings)
+            tags (:tags ev)]
+        (is (= :rf.ssr/ssr-non-string-header-value (:operation ev)))
+        (is (= :warning (:op-type ev)) "emitted at :warning severity")
+        (is (= "X-Count" (:header tags)) "the warning names the offending header key")
+        (is (= "java.lang.Long" (:value-type tags))
+            "the warning names the value's concrete type")))))
+
+(deftest string-header-value-emits-no-warning
+  (testing "rf2-b0jlr: a string header value (the contract-compliant common
+            path) emits NO warning"
+    (let [warnings (collect-non-string-header-warnings
+                     (fn []
+                       (headers/merge-pair-into-header-map {} ["X-Custom" "v"])
+                       (-> {}
+                           (headers/merge-pair-into-header-map ["Vary" "Accept"])
+                           (headers/merge-pair-into-header-map ["Vary" "Cookie"]))))]
+      (is (= [] warnings)
+          "no non-string-header-value warning for string-valued headers"))))
+
 (deftest header-fold-collapses-repeated-names-through-full-fold
   (testing "rf2-ynjts.14: the full fold collapses repeated names into a
             vector AND keeps singletons scalar in one pass — the contract

--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -17,7 +17,7 @@ This doc is one of eight per-namespace contracts indexed from [`README.md`](READ
 
 - Platform-specific argument extraction (each consumer extracts the raw value from its platform's args object before calling these parsers).
 - The argument schemas themselves (each tool's argument schema is owned by the tool's `spec/` folder).
-- The arg-name vocabulary (`:include-sensitive?`, `:dedup`, etc.) — that's a cross-server convention pinned by each consumer's tool catalogue and the conformance gate.
+- The arg-name vocabulary (`:include-sensitive`, `:dedup`, etc.) — that's a cross-server convention pinned by each consumer's tool catalogue and the conformance gate.
 
 ## Cross-server convention
 
@@ -86,5 +86,5 @@ Per-parser fixture tests live in `tools/mcp-base/test/`. Cross-consumer conventi
 
 - [`README.md`](README.md) — the per-namespace index this doc is part of.
 - [`../../../spec/014-HTTPRequests.md` §Keyword-interning cap](../../../spec/014-HTTPRequests.md) — the framework counterpart to this ns's keyword-safety rule.
-- [`../../../spec/Security.md` §Privacy / secret handling](../../../spec/Security.md#privacy--secret-handling) — the broader privacy posture this ns's `:include-sensitive?` convention is part of.
+- [`../../../spec/Security.md` §Privacy / secret handling](../../../spec/Security.md#privacy--secret-handling) — the broader privacy posture this ns's `:include-sensitive` convention is part of.
 - [`vocab.md`](vocab.md) — the marker-key catalogue agents pattern-match on once the parsers have normalised the args.

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -13,7 +13,7 @@ This doc is one of eight per-namespace contracts indexed from [`README.md`](READ
 - The `strip-sensitive` walker (returns `[kept dropped-count]`).
 - The `scrub-snapshot` walker that strips `:traces` / `:epochs` slices from each per-frame snapshot map.
 - The fail-closed malformed-stamp counter (`malformed-count` / `reset-malformed-count!`) — operator-surface observability for the rf2-ih7g4 fail-closed posture; bumped every time a non-boolean truthy `:sensitive?` stamp arrives and is dropped + logged.
-- The fixed cross-server arg-vocabulary name (`:include-sensitive?`) every MCP tool surfacing trace-like data MUST accept.
+- The fixed cross-server arg-vocabulary name (`:include-sensitive`) every MCP tool surfacing trace-like data MUST accept.
 
 `sensitive` does NOT own:
 
@@ -63,13 +63,12 @@ Two arities:
 
 ## Cross-server arg-vocabulary convention
 
-The opt-in arg every MCP tool surfacing trace-like data MUST accept. The semantics are fixed — accept the arg, default it to `false`, feed it to `strip-sensitive` (and any analogous walker that recurses through snapshot slices) — but the **wire-key spelling is in-flight** today:
+The opt-in arg every MCP tool surfacing trace-like data MUST accept. The semantics are fixed — accept the arg, default it to `false`, feed it to `strip-sensitive` (and any analogous walker that recurses through snapshot slices) — and the **wire-key spelling is now uniform** across every server:
 
-- **story-mcp** ships the unqualified `:include-sensitive` (no trailing `?`, per rf2-y710n — the Anthropic tool-input-schema regex `^[a-zA-Z0-9_.-]{1,64}$` rejects `?`).
-- **re-frame2-pair-mcp** still ships `:include-sensitive?` (with `?`) pending rf2-ihq4d.
+- **story-mcp** (rf2-y710n) and **re-frame2-pair-mcp** (rf2-ihq4d) both ship the unqualified `:include-sensitive` (no trailing `?` — the Anthropic tool-input-schema regex `^[a-zA-Z0-9_.-]{1,64}$` rejects `?`).
 - The walker option key inside the framework (`vocab/include-sensitive-opt`) is the namespaced `:rf.size/include-sensitive?` — internal, not a wire-key, so the predicate `?` is retained.
 
-When rf2-ihq4d lands and pair-mcp drops the `?`, this section becomes a single fixed claim again. Until then, treat the cross-server wire-key as a **policy + behaviour** pin, not a literal-spelling pin; the literal each server accepts is documented in its own tool catalogue.
+The cross-server wire-key is a fixed literal-spelling pin: every server accepts `:include-sensitive` (the per-server tool catalogue documents the same literal).
 
 The default-OFF posture aligns with the framework's privacy-by-default stance (per [`../../../spec/Security.md` §Privacy / secret handling](../../../spec/Security.md#privacy--secret-handling) and [`../../../spec/Conventions.md` §Privacy config-knob naming](../../../spec/Conventions.md)).
 
@@ -83,13 +82,13 @@ Consumers that want to bind to the framework primitive (story-mcp does, for code
 
 The `:dropped-sensitive` envelope slot rides alongside `:elided-large` per the indicator-field parity rule (per [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots)). Both slots are MUST-level — the conformance gate at `tools/mcp-conformance/wire-vocab/` asserts parity.
 
-The privacy default — `:include-sensitive?` defaults `false` — is enforced via the per-tool argument schema in each consumer; the conformance harness drives every tool with a payload that includes a `:sensitive? true` event and asserts the response envelope's `:dropped-sensitive` counter is non-zero, with the sensitive event absent from the response body.
+The privacy default — `:include-sensitive` defaults `false` — is enforced via the per-tool argument schema in each consumer; the conformance harness drives every tool with a payload that includes a `:sensitive? true` event and asserts the response envelope's `:dropped-sensitive` counter is non-zero, with the sensitive event absent from the response body.
 
 ## See also
 
 - [`README.md`](README.md) — the per-namespace index this doc is part of.
 - [`../../../spec/009-Instrumentation.md` §Privacy / sensitive data in traces](../../../spec/009-Instrumentation.md) — the framework's `:sensitive?` substrate this filter consumes.
 - [`../../../spec/Security.md` §Privacy / secret handling](../../../spec/Security.md#privacy--secret-handling) — the pattern-level privacy MUSTs the filter enforces.
-- [`../../../spec/Conventions.md` §Privacy config-knob naming](../../../spec/Conventions.md) — the `:include-sensitive?` (wire) vs `:show-sensitive?` (UI) verb split.
+- [`../../../spec/Conventions.md` §Privacy config-knob naming](../../../spec/Conventions.md) — the `include-sensitive?` (off-box wire-egress verb) vs `show-sensitive?` (on-box UI verb) split. Note the verb keeps the `?`; the MCP tool-input *wire-key* drops it (`:include-sensitive`) per the Anthropic schema regex.
 - [`vocab.md`](vocab.md) — the marker keyword + envelope-slot catalogue this filter populates.
 - [`elision.md`](elision.md) — the size-elision counterpart; both indicator slots ride the response envelope together.

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -24,8 +24,9 @@
   predicate-style `?` is rejected there. The predicate FUNCTION name
   `include-sensitive?` retains its `?` (the idiom belongs on the
   predicate, not on a data key whose wire form disallows it).
-  story-mcp ships the renamed wire-key (rf2-y710n); re-frame2-pair-mcp still
-  carries `:include-sensitive?` pending rf2-ihq4d.
+  Both servers now ship the unqualified wire-key: story-mcp (rf2-y710n)
+  and re-frame2-pair-mcp (rf2-ihq4d) — the cross-server arg name is
+  uniform.
 
   ## Why this ns is zero-dep
 

--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -160,9 +160,9 @@
 
 (def include-sensitive-opt
   "The framework opt that controls whether sensitive payloads emit
-  the marker. Surfaced by MCP servers as the `:include-sensitive`
-  arg (story-mcp; re-frame2-pair-mcp still uses `:include-sensitive?` — see
-  rf2-ihq4d). Per the Anthropic tool-input-schema regex
+  the marker. Surfaced by every MCP server uniformly as the
+  `:include-sensitive` wire-arg (story-mcp per rf2-y710n,
+  re-frame2-pair-mcp per rf2-ihq4d). Per the Anthropic tool-input-schema regex
   `^[a-zA-Z0-9_.-]{1,64}$`, wire-keys MUST omit the trailing `?`.
   The walker option keyword (this one, `:rf.size/include-sensitive?`)
   is a NAMESPACED framework key — internal, not a wire-key — so it


### PR DESCRIPTION
Two small clear-fix beads on disjoint free surfaces.

## rf2-0hynd (P4, mcp-base) — doc-only
rf2-ihq4d landed: pair-mcp wire-key already dropped the `?` (`args.cljs` keys it `:include-sensitive`, comment marks rf2-y710n + rf2-ihq4d done). Corrected the stale docs that still claimed pair-mcp ships `:include-sensitive?` pending rf2-ihq4d:
- `sensitive.cljc` docstring (lines 27-28) — now states both servers ship the uniform unqualified `:include-sensitive`.
- `vocab.cljc` `include-sensitive-opt` docstring — same.
- `sensitive.md` §Scope, §Cross-server convention (was "wire-key spelling is in-flight"), §Conformance, §See-also.
- `args.md` §Scope + §See-also arg-name vocabulary examples.

Legit `?`-bearing refs left intact: the namespaced internal walker-opt `:rf.size/include-sensitive?`, the predicate FUNCTION name `include-sensitive?`, and the Conventions wire-egress *verb* (which keeps `?`; the MCP *wire-key* drops it).

## rf2-b0jlr (P4, ssr-ring)
Added a dev-gated `:warning` trace (`:rf.ssr/ssr-non-string-header-value`) in `merge-pair-into-header-map` when a non-string header value reaches the fold — host-dependent, almost certainly a caller bug. Names the offending key + value-type. Gated on `interop/debug-enabled?` (+ `trace/emit!`'s own Closure-DCE gate) so production stays branchless; mirrors the redirect-no-target warning precedent in `pipeline`. The `:else`-arm tolerance is unchanged (value still folds in). No silent swallow.

Regression tests in `pipeline_materialiser_test.clj`: a non-string value emits exactly one warning naming the key + type; a string value emits none.

Surfaces: `tools/mcp-base` (0hynd) + `implementation/ssr-ring` (b0jlr), disjoint. No other surface touched.

## Quality gates
- ssr-ring `clojure -M:test` (b0jlr): 101 tests, 434 assertions, 0 failures, 0 errors.
- `npm run test:cljs`: 5174 tests, 17569 assertions, 0 failures, 0 errors.
- clj-kondo on changed files: 0 errors. (1 warning "unused binding v" at headers.clj:98 is PRE-EXISTING on HEAD in untouched `headers->ring-map+default-content-type` — not introduced here; left per scope discipline.)
- `mkdocs build --strict` (0hynd touched tools/mcp-base/spec prose): built clean (exit 0). Note: `tools/mcp-base/spec/` is intra-tool reference, not part of the `docs_dir: docs` site nav; intra-tree relative links verified consistent.