### PR TITLE
fix(schemas): reg-app-schema bare-keyword reject + honest validator-bundle setter + :sensitive? shipped annotation (rf2-52dfy rf2-13meg rf2-x6q5m)

### DIFF
--- a/docs/api/08-schemas.md
+++ b/docs/api/08-schemas.md
@@ -98,9 +98,17 @@ The default validator ships Malli's `validate` / `explain` pair. These seams let
 - **Signature**:
   ```clojure
   (set-schema-validator! validate-fn)
-  (set-schema-validator! {:validate validate-fn :explain explain-fn})
   ```
-- **Description**: "Install the validator the framework uses at every dev-time schema-validation site." `nil` disables validation entirely. The default ships Malli's pair; this seam is for apps that want to swap to a different validator without forking the framework.
+- **Description**: "Install the validator the framework uses at every dev-time schema-validation site." Swaps ONLY the validator; `nil` disables validation entirely. The default ships Malli's pair; this seam is for apps that want to swap to a different validator without forking the framework. To install the validator/explainer/printer together, use `set-schema-fns!`.
+
+#### `set-schema-fns!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (set-schema-fns! {:validate validate-fn :explain explain-fn :print print-fn})
+  ```
+- **Description**: "Atomically install any subset of the validator / explainer / printer bundle from a single map." The honest bundle setter — named for what it sets, not just the validator. Each key is optional; an absent key leaves the existing registration in place, and a `nil` `:print` coerces to the default EDN canonicaliser. The one-call substitute-Malli boot pattern, so the three fns never drift mid-boot.
 
 #### `set-schema-explainer!`
 

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -494,10 +494,11 @@
 
 (def ^{:doc "Register the validator fn every dev-time schema-validation
   site routes through — `(fn [schema value] truthy?)` (or nil to
-  disable). Map-arity atomically swaps `{:validate :explain}` together.
-  Per Spec 010 §Non-Malli validators. Default ships Malli;
-  callers swap to drop the ~24 KB gzipped Malli surface. Implementation
-  ships in `day8/re-frame2-schemas`."}
+  disable). Swaps ONLY the validator; use `set-schema-fns!` to install
+  the validator/explainer/printer bundle atomically. Per Spec 010
+  §Non-Malli validators. Default ships Malli; callers swap to drop the
+  ~24 KB gzipped Malli surface. Implementation ships in
+  `day8/re-frame2-schemas`."}
   set-schema-validator!  rf-schemas/set-schema-validator!)
 
 (def ^{:doc "Register the explainer fn — `(fn [schema value] explanation)`
@@ -511,6 +512,15 @@
   and cross-runtime deterministic. Per Spec 010 §Digest algorithm.
   Implementation ships in `day8/re-frame2-schemas`."}
   set-schema-printer!    rf-schemas/set-schema-printer!)
+
+(def ^{:doc "Atomically install the validator/explainer/printer bundle
+  from a single map — `(set-schema-fns! {:validate ... :explain ...
+  :print ...})`. The honest bundle setter (rf2-13meg): each key is
+  optional, an absent key leaves the existing registration in place,
+  and a nil `:print` coerces to the default EDN canonicaliser. The
+  one-call substitute-Malli boot pattern. Per Spec 010 §Non-Malli
+  validators. Implementation ships in `day8/re-frame2-schemas`."}
+  set-schema-fns!        rf-schemas/set-schema-fns!)
 
 ;; ---- data classification (Spec 015) -------------------------------------
 

--- a/implementation/core/src/re_frame/core_schemas.cljc
+++ b/implementation/core/src/re_frame/core_schemas.cljc
@@ -61,21 +61,41 @@
   drop the ~24 KB gzipped Malli surface (rf2-qnxf bundle audit) swap
   in their own validator at boot.
 
-  Argument shapes:
-
     (rf/set-schema-validator! validate-fn)
       validate-fn :: (fn [schema value] truthy?)
                    | nil   ;; disables validation entirely
 
-    (rf/set-schema-validator! {:validate validate-fn :explain explain-fn})
-      Atomic swap of both fns at once.
+  Swaps ONLY the validator. The explainer / printer are left untouched
+  — call `set-schema-explainer!` / `set-schema-printer!`, or use
+  `set-schema-fns!` to install all three as one atomic bundle
+  (rf2-13meg).
 
   Default behaviour ships Malli's validate / explain pair; calling
-  this fn replaces them. Returns nil when the schemas artefact is
-  not on the classpath (apps that don't want schemas don't need to
-  pull `day8/re-frame2-schemas`)."
+  this fn replaces the validator. Returns nil when the schemas
+  artefact is not on the classpath (apps that don't want schemas don't
+  need to pull `day8/re-frame2-schemas`)."
   {:hook :schemas/set-schema-validator! :artefact schemas-artefact :on-absent :nil}
-  ([validate-fn-or-map] :delegate))
+  ([validate-fn] :delegate))
+
+(defwrapper set-schema-fns!
+  "Atomically install any subset of the validator / explainer / printer
+  bundle from a single map (rf2-13meg). The honest bundle setter — its
+  name says it sets all three schema-language fns, not just the
+  validator.
+
+    (rf/set-schema-fns! {:validate validate-fn
+                         :explain  explain-fn
+                         :print    print-fn})
+
+  Each key is optional; an absent key leaves the existing registration
+  in place. A `nil` `:print` coerces to the default EDN canonicaliser
+  (the digest is never undefined for a present schema set). This is the
+  one-call substitute-Malli boot pattern — a Zod / clojure.spec port
+  installs its validator, explainer, and digest-printer together so the
+  three never drift mid-boot. Returns nil when the schemas artefact is
+  not on the classpath. See `re-frame.schemas/set-schema-fns!`."
+  {:hook :schemas/set-schema-fns! :artefact schemas-artefact :on-absent :nil}
+  ([fns-map] :delegate))
 
 (defwrapper set-schema-explainer!
   "Register the explainer fn — `(fn [schema value] explanation)` — used

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -254,6 +254,10 @@
     :producer-ns 're-frame.schemas
     :design-bead "rf2-wla45"
     :description "Install a pluggable schema-print companion fn (Spec 010 §Schema digest line 491). The digest pipeline hashes this fn's UTF-8 output; non-Malli ports register their own serialiser so digests reflect the registered validator's serialisation contract."}
+   {:key         :schemas/set-schema-fns!
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-13meg"
+    :description "Install the validator/explainer/printer bundle atomically from a single map (the honest bundle setter — replaces the old set-schema-validator! map-arity)."}
    {:key         :schemas/validate-with-registered-fn
     :producer-ns 're-frame.schemas
     :design-bead "rf2-r2uh"

--- a/implementation/flows/test/re_frame/flows_schema_validation_test.clj
+++ b/implementation/flows/test/re_frame/flows_schema_validation_test.clj
@@ -70,7 +70,7 @@
 ;; This exercises the `:schemas/validate-with-registered-fn` seam without
 ;; pulling Malli onto the test classpath (Spec 010 §Non-Malli validators).
 (defn- install-predicate-validator! []
-  (schemas/set-schema-validator!
+  (schemas/set-schema-fns!
     {:validate (fn [schema value] (boolean (schema value)))
      :explain  (fn [schema value]
                  (when-not (schema value)
@@ -140,7 +140,7 @@
 (deftest absent-schema-skips-validation
   (testing "a flow without :schema never consults the validator (no violation even on a 'bad' value)"
     (let [validator-calls (atom 0)]
-      (schemas/set-schema-validator!
+      (schemas/set-schema-fns!
         {:validate (fn [_ _] (swap! validator-calls inc) false)})
       (rf/reg-event-db :seed (fn [_ _] {:w 3 :h 4}))
       (rf/reg-flow {:id     :area

--- a/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
+++ b/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
@@ -210,7 +210,7 @@
             written (recompute is never gated)."
     ;; Register a validator that REJECTS every value — if validation ran,
     ;; a violation would surface.
-    (schemas/set-schema-validator! {:validate (fn [_ _] false)})
+    (schemas/set-schema-fns! {:validate (fn [_ _] false)})
     (rf/reg-event-db :prod-elision/seed-validate
       (fn [db _] (assoc db :w 3 :h 4)))
     (rf/reg-flow

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -1374,8 +1374,8 @@
         prev-e   @schemas/explainer-fn
         validate (fn [schema value] (boolean (schema value)))
         explain  (fn [_schema value] {:reason :stub-explainer :value value})]
-    (schemas/set-schema-validator! {:validate validate :explain explain})
-    (fn [] (schemas/set-schema-validator! {:validate prev-v :explain prev-e}))))
+    (schemas/set-schema-fns! {:validate validate :explain explain})
+    (fn [] (schemas/set-schema-fns! {:validate prev-v :explain prev-e}))))
 
 (deftest match-url-flags-validation-failure
   (testing "match-url surfaces :validation-failed? + :validation-error

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -61,10 +61,13 @@
 (def explainer-fn     validator/explainer-fn)
 (def printer-fn       validator/printer-fn)
 
-;; Validator / explainer / printer (rf2-froe + rf2-wla45).
+;; Validator / explainer / printer (rf2-froe + rf2-wla45). Each fn has
+;; its own single-purpose setter; `set-schema-fns!` installs the bundle
+;; atomically (rf2-13meg — the honest bundle name).
 (def set-schema-validator!   validator/set-schema-validator!)
 (def set-schema-explainer!   validator/set-schema-explainer!)
 (def set-schema-printer!     validator/set-schema-printer!)
+(def set-schema-fns!         validator/set-schema-fns!)
 (def reset-schema-validator! validator/reset-schema-validator!)
 
 ;; Printer / walker memo clear hooks (rf2-17sqc). Test-support: the
@@ -160,6 +163,7 @@
 (late-bind/set-fn! :schemas/set-schema-validator! set-schema-validator!)
 (late-bind/set-fn! :schemas/set-schema-explainer! set-schema-explainer!)
 (late-bind/set-fn! :schemas/set-schema-printer!   set-schema-printer!)
+(late-bind/set-fn! :schemas/set-schema-fns!       set-schema-fns!)
 
 ;; Schema-walker hooks consumed by `re-frame.elision` to feed the
 ;; unified `[:rf/runtime :elision]` registry without statically depending on the

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -350,10 +350,20 @@
   kind. The authoritative store is keyed by `(frame-id, path)` so that
   registrations against frame A and frame B against the same path are
   independent entries. Pair-tools and source-coord tests read via
-  `app-schema-meta-at`."
+  `app-schema-meta-at`.
+
+  Per rf2-52dfy the `opts` argument is coerced through `coerce-opts`,
+  the SAME contract the read surface (`app-schema-at` /
+  `app-schema-meta-at` / `app-schemas`) uses: a bare keyword is the
+  `{:frame kw}` sugar, an opts map passes through, and any other shape
+  (a string, number, vector, …) throws `:rf.error/bad-app-schemas-arg`.
+  Write and read now AGREE on the opts contract — previously a bare
+  keyword was silently swallowed and the schema registered against the
+  DEFAULT frame, a footgun that disagreed with every read entry point."
   ([path schema] (reg-app-schema path schema {}))
-  ([path schema opts]
-   (let [frame-id     (resolve-frame opts)
+  ([path schema opts-or-frame-id]
+   (let [opts         (coerce-opts opts-or-frame-id)
+         frame-id     (resolve-frame opts)
          ;; Capture the path's prior schema BEFORE the swap so the
          ;; hot-reload `:rf.schema/violation` check (rf2-ee38b.6) can
          ;; compare pre- vs post-reload shapes. nil on first registration.
@@ -432,7 +442,7 @@
   callers that rely on deterministic order should use a singular
   `reg-app-schema` chain instead)."
   ([path->schema] (reg-app-schemas path->schema {}))
-  ([path->schema opts]
+  ([path->schema opts-or-frame-id]
    ;; Defer the per-entry schema-derived elision repopulation (rf2-ee38b.6):
    ;; `populate-elision-for-frame!` walks EVERY registered schema in the
    ;; frame, so running it once per entry is O(n²) in the frame's schema
@@ -446,7 +456,14 @@
    ;; when at least one entry could actually change the elision registry
    ;; (`populate-relevant?` — a batch of flag-free fresh registrations,
    ;; the stress workload, skips the walk entirely).
-   (let [frame-id   (resolve-frame opts)
+   ;;
+   ;; Per rf2-52dfy — `opts` is coerced through the same `coerce-opts`
+   ;; contract the read surface uses (bare keyword → `{:frame kw}`
+   ;; sugar; bad shape → `:rf.error/bad-app-schemas-arg`). Write/read
+   ;; agree; the singular `reg-app-schema` call re-coerces the
+   ;; already-coerced map (idempotent — a map passes through verbatim).
+   (let [opts       (coerce-opts opts-or-frame-id)
+         frame-id   (resolve-frame opts)
          entry-opts (assoc opts :rf/defer-elision-populate? true)
          ;; Snapshot prior schemas BEFORE registering so relevance
          ;; reflects each entry's true re-registration status, matching

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -35,8 +35,12 @@
               EDN canonicaliser, which is the cross-runtime contract
               every Malli-EDN-compatible port shares.
 
-  A combined `(set-schema-validator! {:validate ... :explain ... :print ...})`
-  arity exists for callers who want to install all three atomically.
+  Each fn has a dedicated single-purpose setter — `set-schema-validator!`
+  / `set-schema-explainer!` / `set-schema-printer!`. `set-schema-fns!`
+  installs any subset of the three as one atomic bundle for callers
+  (a port's boot, a substitute-Malli swap) who want all three to land
+  together. The bundle setter is named for what it does — it does NOT
+  pretend to set only the validator (rf2-13meg).
 
   Per rf2-t0hq the CLJS default validator used to reach Malli through
   runtime `resolve` — but CLJS has no runtime resolve (the symbol is
@@ -220,25 +224,17 @@
   swap in their own validator at boot, before the first `reg-app-schema`
   or `:schema`-bearing `reg-*` lands.
 
-  Argument shapes:
-
     (set-schema-validator! validate-fn)
       validate-fn :: (fn [schema value] truthy?)
                    | nil   ;; disables validation entirely
       Same signature as `malli.core/validate` — truthy on conform,
-      falsey on fail. The explainer is left untouched (apps that want
-      to also swap explanations call `set-schema-explainer!`).
+      falsey on fail.
 
-    (set-schema-validator! {:validate validate-fn
-                            :explain  explain-fn
-                            :print    print-fn})
-      Atomic swap of any subset at once. Per rf2-wla45 the `:print`
-      key registers the schema-print companion the digest pipeline
-      hashes (Spec 010 §Schema digest line 491). Any key may be `nil`
-      to disable the corresponding hot path (the printer falls back
-      to the default EDN canonicaliser; the digest is never
-      undefined for a present schema set). Keys not supplied leave
-      the existing registration in place.
+  This setter swaps ONLY the validator. The explainer and printer are
+  left untouched — apps that also want to swap those call
+  `set-schema-explainer!` / `set-schema-printer!`, or use
+  `set-schema-fns!` to install all three as one atomic bundle
+  (rf2-13meg).
 
   Per Spec 010 §Non-Malli validators the validator-fn must be pure
   (same `(schema, value)` returns the same result) and must be
@@ -249,22 +245,50 @@
 
   Last-write-wins on re-registration. Returns the validator that was
   installed (may be nil)."
-  [validate-fn-or-map]
-  (if (map? validate-fn-or-map)
-    (let [m validate-fn-or-map]
-      (when (contains? m :validate) (reset! validator-fn (:validate m)))
-      (when (contains? m :explain)  (reset! explainer-fn (:explain m)))
-      ;; Per rf2-ee38b.6 (clarity P2): coerce `nil` to the default
-      ;; identically to the dedicated `set-schema-printer!` setter, so
-      ;; "printer-fn is never nil" is a true invariant established at the
-      ;; write site — not re-asserted defensively in `run-printer`. The
-      ;; map-arity docstring promises this fallback; the coercion makes
-      ;; it honest.
-      (when (contains? m :print)
-        (reset! printer-fn (or (:print m) default-edn-print)))
-      @validator-fn)
-    (do (reset! validator-fn validate-fn-or-map)
-        @validator-fn)))
+  [validate-fn]
+  (reset! validator-fn validate-fn)
+  @validator-fn)
+
+(defn set-schema-fns!
+  "Atomically install any subset of the validator / explainer / printer
+  bundle from a single map (rf2-13meg). The honest bundle setter — its
+  name says it sets all three schema-language fns, not just the
+  validator.
+
+    (set-schema-fns! {:validate validate-fn
+                      :explain  explain-fn
+                      :print    print-fn})
+
+  Each key is optional; a key that is absent leaves the existing
+  registration in place. Per Spec 010 §Non-Malli validators this is
+  the one-call substitute-Malli boot pattern — a Zod / clojure.spec
+  port installs its validator, explainer, and digest-printer together
+  so the three never drift out of sync mid-boot.
+
+    :validate  (fn [schema value] truthy?) | nil  — nil disables
+               validation (every site soft-passes).
+    :explain   (fn [schema value] explanation) | nil — nil omits the
+               failure trace's `:explain` key.
+    :print     (fn [schema-value] canonical-string) | nil — per
+               rf2-wla45 the schema-print companion the digest pipeline
+               hashes (Spec 010 §Schema digest line 491). nil coerces
+               to the default EDN canonicaliser (the digest is never
+               undefined for a present schema set) — identical to
+               `set-schema-printer!`'s nil fallback, so `printer-fn` is
+               never nil after any write (rf2-ee38b.6).
+
+  Last-write-wins per key. Returns the validator that was installed
+  (may be nil)."
+  [{:keys [validate explain print] :as m}]
+  (when (contains? m :validate) (reset! validator-fn validate))
+  (when (contains? m :explain)  (reset! explainer-fn explain))
+  ;; Per rf2-ee38b.6 (clarity P2): coerce `nil` to the default
+  ;; identically to the dedicated `set-schema-printer!` setter, so
+  ;; "printer-fn is never nil" is a true invariant established at the
+  ;; write site — not re-asserted defensively in `run-printer`.
+  (when (contains? m :print)
+    (reset! printer-fn (or print default-edn-print)))
+  @validator-fn)
 
 (defn set-schema-explainer!
   "Register the explainer fn — `(fn [schema value] explanation)` — that
@@ -349,8 +373,8 @@
   a single schema value. Per Spec 010 §Schema digest line 491 the digest
   pipeline (`re-frame.schemas.digest`) hashes this fn's UTF-8 bytes
   (rf2-wla45). `printer-fn` is never nil: both write sites
-  (`set-schema-printer!` and the `set-schema-validator!` map-arity)
-  coerce a nil `:print` to `default-edn-print` (rf2-ee38b.6), so the
+  (`set-schema-printer!` and `set-schema-fns!`'s `:print` key) coerce
+  a nil `:print` to `default-edn-print` (rf2-ee38b.6), so the
   cross-runtime digest contract holds without a read-site guard."
   [schema-value]
   (@printer-fn schema-value))

--- a/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
+++ b/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
@@ -12,8 +12,8 @@
       digest pipeline).
     - `set-schema-printer!` swaps the printer atom; the digest
       pipeline picks up the new bytes on the next call.
-    - Map-arity `(set-schema-validator! {:print fn})` swaps the
-      printer atomically alongside `:validate` / `:explain`.
+    - Bundle setter `(set-schema-fns! {:print fn})` swaps the
+      printer atomically alongside `:validate` / `:explain` (rf2-13meg).
     - `set-schema-printer! nil` falls back to the default (the
       digest is never undefined for a present schema set).
     - `reset-schema-validator!` restores the default printer
@@ -93,30 +93,30 @@
         "set-schema-printer! nil restores the default — the digest matches
          the rf2-xssfv `single-prim` literal byte-for-byte")))
 
-(deftest set-schema-validator!-map-arity-installs-printer
-  (testing "`(set-schema-validator! {:print fn})` swaps the printer
-            atom atomically alongside `:validate` / `:explain` — the
-            atomic-swap entry point is symmetrical across all three
-            fns (rf2-froe + rf2-wla45)."
-    (let [marker (fn [_] "::FROM-MAP-ARITY::")]
-      (schemas/set-schema-validator! {:print marker})
-      (is (= "::FROM-MAP-ARITY::" (validator/run-printer :int))
+(deftest set-schema-fns!-installs-printer
+  (testing "`(set-schema-fns! {:print fn})` swaps the printer atom
+            atomically alongside `:validate` / `:explain` — the bundle
+            entry point is symmetrical across all three fns (rf2-froe +
+            rf2-wla45 + rf2-13meg)."
+    (let [marker (fn [_] "::FROM-BUNDLE::")]
+      (schemas/set-schema-fns! {:print marker})
+      (is (= "::FROM-BUNDLE::" (validator/run-printer :int))
           "the registered printer reaches the hot path"))))
 
-(deftest set-schema-validator!-map-arity-nil-print-coerces-to-default
-  (testing "rf2-ee38b.6 — `(set-schema-validator! {:print nil})` coerces
-            to the default EDN canonicaliser, identically to
+(deftest set-schema-fns!-nil-print-coerces-to-default
+  (testing "rf2-ee38b.6 — `(set-schema-fns! {:print nil})` coerces to
+            the default EDN canonicaliser, identically to
             `(set-schema-printer! nil)`. Reconciles the two printer-
             setter paths so `printer-fn` is never nil (the read-site
-            guard in `run-printer` was dropped) — the map-arity
-            docstring's 'falls back to the default' promise is now true
-            at the write site."
+            guard in `run-printer` was dropped) — the bundle setter's
+            'falls back to the default' promise is true at the write
+            site (rf2-13meg)."
     ;; Poison first so a no-op would be observable.
     (schemas/set-schema-printer! (fn [_] "::POISONED::"))
     (is (= "::POISONED::" (validator/run-printer :int)))
-    (schemas/set-schema-validator! {:print nil})
+    (schemas/set-schema-fns! {:print nil})
     (is (some? @validator/printer-fn)
-        "printer-fn is never nil after a {:print nil} map-arity swap")
+        "printer-fn is never nil after a {:print nil} bundle swap")
     (is (= ":int" (validator/run-printer :int))
         "{:print nil} falls back to default-edn-print, not 'no printer'")))
 

--- a/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
@@ -232,8 +232,8 @@
     ;; Register a validator/explainer pair where validate fails but
     ;; explain returns no `:in` data — simulates a non-Malli or
     ;; structurally-different explainer.
-    (schemas/set-schema-validator! {:validate (fn [_ _] false)
-                                    :explain  (fn [_ _] nil)})
+    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+                              :explain  (fn [_ _] nil)})
     (try
       (rf/reg-app-schema [:user]
                          [:map [:password {:sensitive? true} :string]])
@@ -258,8 +258,8 @@
   (testing "fallback path with a non-sensitive schema still emits the
             verbatim value — the fallback only conserves the privacy
             posture, not the failure shape"
-    (schemas/set-schema-validator! {:validate (fn [_ _] false)
-                                    :explain  (fn [_ _] nil)})
+    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+                              :explain  (fn [_ _] nil)})
     (try
       (rf/reg-app-schema [:count] [:int])
       (let [traces (capture-trace

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -138,6 +138,70 @@
               (is (= bad-arg (:received data))
                   ":received slot carries the bad input verbatim"))))))))
 
+;; ---- reg-app-schema opts contract symmetry (rf2-52dfy) -------------------
+;;
+;; Pre-rf2-52dfy `reg-app-schema` plucked `(:frame opts)` directly off
+;; whatever was passed as `opts`. A bare keyword (`(reg-app-schema path
+;; schema :tenant/a)`) returned nil for `(:frame …)` and SILENTLY fell
+;; back to the DEFAULT frame — yet every read entry point (`app-schema-at`
+;; / `app-schema-meta-at` / `app-schemas`) routed its opts through
+;; `coerce-opts`, which treats a bare keyword as the `{:frame kw}` sugar.
+;; Write and read disagreed on the same shape: read targeted `:tenant/a`,
+;; write targeted `:rf/default`. rf2-52dfy routes write through the SAME
+;; `coerce-opts` contract so the two agree, and a genuinely bad shape
+;; (string / number / vector) fails loud instead of silently mis-routing.
+
+(deftest reg-app-schema-keyword-opts-matches-read-frame
+  (testing "rf2-52dfy — a bare-keyword opts registers against THAT frame
+            (the read API's `{:frame kw}` sugar), NOT silently against
+            the DEFAULT frame. Write and read agree."
+    (rf/reg-app-schema [:user] [:map [:id :int]] :tenant/a)
+    ;; Read the same way — both target :tenant/a.
+    (is (= [:map [:id :int]] (rf/app-schema-at [:user] :tenant/a))
+        "schema landed in :tenant/a, matching the read sugar")
+    (is (nil? (rf/app-schema-at [:user]))
+        "the DEFAULT frame is untouched — the silent-DEFAULT footgun is gone")
+    (is (nil? (rf/app-schema-at [:user] :rf/default))
+        "explicit DEFAULT-frame read also empty")))
+
+(deftest reg-app-schema-bad-opts-shape-fails-loud
+  (testing "rf2-52dfy — a non-keyword, non-map opts shape throws
+            :rf.error/bad-app-schemas-arg, matching coerce-opts (the read
+            surface's contract). No silent mis-registration."
+    (doseq [bad-arg ["tenant-a" 42 [:tenant :a]]]
+      (let [thrown (try (rf/reg-app-schema [:user] [:map] bad-arg)
+                        (catch clojure.lang.ExceptionInfo e e))]
+        (is (instance? clojure.lang.ExceptionInfo thrown)
+            (str "bad opts " (pr-str bad-arg) " throws ex-info"))
+        (when (instance? clojure.lang.ExceptionInfo thrown)
+          (is (= ":rf.error/bad-app-schemas-arg" (.getMessage ^Exception thrown))
+              "ex-info names the same error category the read surface uses"))))))
+
+(deftest reg-app-schema-valid-opts-map-registers-fine
+  (testing "rf2-52dfy — a valid {:frame ...} opts map still registers
+            against the named frame; the coercion is transparent for the
+            common shape."
+    (rf/reg-app-schema [:user] [:map] {:frame :tenant/b})
+    (is (= [:map] (rf/app-schema-at [:user] :tenant/b)))
+    ;; And the zero-opts arity still defaults to the current frame.
+    (rf/reg-app-schema [:auth] [:string])
+    (is (= [:string] (rf/app-schema-at [:auth]))
+        "two-arg arity registers against the current (default) frame")))
+
+(deftest reg-app-schemas-keyword-opts-matches-read-frame
+  (testing "rf2-52dfy — the bulk form coerces opts identically: a bare
+            keyword registers every entry against THAT frame, not the
+            DEFAULT frame; a bad shape fails loud."
+    (rf/reg-app-schemas {[:user] [:map] [:auth] [:string]} :tenant/c)
+    (is (= [:map]    (rf/app-schema-at [:user] :tenant/c)))
+    (is (= [:string] (rf/app-schema-at [:auth] :tenant/c)))
+    (is (nil? (rf/app-schema-at [:user]))
+        "DEFAULT frame untouched for the bulk form too")
+    (let [thrown (try (rf/reg-app-schemas {[:user] [:map]} "tenant-c")
+                      (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo thrown))
+      (is (= ":rf.error/bad-app-schemas-arg" (.getMessage ^Exception thrown))))))
+
 ;; ---- snapshot / restore / clear (test-support seam) ----------------------
 
 (deftest snapshot-and-restore-roundtrip

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -1075,16 +1075,16 @@
                             @traces))
             "no validation trace fires when validator is nil")))))
 
-(deftest set-schema-validator-map-arity-installs-both-fns
-  (testing "Per Spec 010 §Non-Malli validators — the map arity of
-            set-schema-validator! installs validate and explain
+(deftest set-schema-fns-bundle-installs-both-fns
+  (testing "Per Spec 010 §Non-Malli validators (rf2-13meg) — the bundle
+            setter set-schema-fns! installs validate and explain
             atomically. Apps that want a custom explainer alongside
             their custom validator use this form."
     (let [validate-calls (atom 0)
           explain-calls  (atom 0)
           v-fn (fn [_s v] (swap! validate-calls inc) (= v :good))
           e-fn (fn [s v]  (swap! explain-calls inc) {:my-explanation [s v]})]
-      (rf/set-schema-validator! {:validate v-fn :explain e-fn})
+      (rf/set-schema-fns! {:validate v-fn :explain e-fn})
       (rf/reg-app-schema [:k] :keyword)
       (let [traces (atom [])]
         (rf/register-listener! ::map (fn [ev] (swap! traces conj ev)))
@@ -1099,6 +1099,37 @@
           (is (= {:my-explanation [:keyword :nope]}
                  (-> violations first :tags :explain))
               "the trace's :explain key carries the custom explainer's output"))))))
+
+(deftest set-schema-fns-installs-all-three-atomically
+  (testing "rf2-13meg — the honest bundle setter set-schema-fns! installs
+            validator, explainer, AND printer in one atomic call. The
+            name says it sets the whole schema-language-fn bundle, not
+            just the validator."
+    (let [v-fn (fn [_ _] true)
+          e-fn (fn [_ _] {:explained true})
+          p-fn (fn [_] "::BUNDLE-PRINTER::")]
+      (rf/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})
+      (is (= v-fn @schemas/validator-fn) "validator installed")
+      (is (= e-fn @schemas/explainer-fn) "explainer installed")
+      (is (= p-fn @schemas/printer-fn)   "printer installed")
+      (is (= "::BUNDLE-PRINTER::" (validator/run-printer :int))
+          "printer reaches the hot path"))))
+
+(deftest set-schema-validator-is-honest-validator-only
+  (testing "rf2-13meg — set-schema-validator! sets ONLY the validator.
+            The misleading map-arity that ALSO set explainer + printer is
+            gone: passing a map installs that literal map AS the validator
+            fn-value (a single-purpose setter), it does NOT bundle-install.
+            The explainer/printer are left at their defaults."
+    (let [default-explainer @schemas/explainer-fn
+          default-printer   @schemas/printer-fn
+          v-fn (fn [_ _] true)]
+      (rf/set-schema-validator! v-fn)
+      (is (= v-fn @schemas/validator-fn) "validator installed")
+      (is (= default-explainer @schemas/explainer-fn)
+          "explainer untouched — set-schema-validator! does not touch it")
+      (is (= default-printer @schemas/printer-fn)
+          "printer untouched — set-schema-validator! does not touch it"))))
 
 (deftest set-schema-explainer-only-leaves-validator-untouched
   (testing "set-schema-explainer! swaps just the explainer; the validator
@@ -1269,20 +1300,20 @@
     (is (= ":int" (validator/run-printer :int))
         "nil through the public surface falls back to default-edn-print")))
 
-(deftest printer-set-via-public-api-map-arity-installs-printer
-  (testing "rf2-pk8ur — the public rf/set-schema-validator! map arity
-            installs a `:print` printer alongside `:validate` / `:explain`
-            atomically. End-to-end pin of the documented one-call
-            substitute-Malli boot pattern via the public surface."
+(deftest printer-set-via-public-set-schema-fns-installs-printer
+  (testing "rf2-pk8ur + rf2-13meg — the public rf/set-schema-fns! bundle
+            setter installs a `:print` printer alongside `:validate` /
+            `:explain` atomically. End-to-end pin of the documented
+            one-call substitute-Malli boot pattern via the public surface."
     (let [v-fn (fn [_ _] true)
           e-fn (fn [_ _] {:explained true})
-          p-fn (fn [_] "::FROM-PUBLIC-MAP-ARITY::")]
-      (rf/set-schema-validator! {:validate v-fn :explain e-fn :print p-fn})
+          p-fn (fn [_] "::FROM-PUBLIC-BUNDLE::")]
+      (rf/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})
       (is (= v-fn @schemas/validator-fn))
       (is (= e-fn @schemas/explainer-fn))
       (is (= p-fn @schemas/printer-fn))
-      (is (= "::FROM-PUBLIC-MAP-ARITY::" (validator/run-printer :int))
-          "the printer installed via the map arity reaches the hot path"))))
+      (is (= "::FROM-PUBLIC-BUNDLE::" (validator/run-printer :int))
+          "the printer installed via the bundle setter reaches the hot path"))))
 
 ;; ---- rf2-r2uh — :rf.schema/at-boundary interceptor ---------------------
 ;;

--- a/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
@@ -128,13 +128,14 @@
                                :rf.warning/schema-validator-unavailable))
           "explicit non-default validator suppresses the warning"))))
 
-(deftest warning-suppressed-when-set-schema-validator-map-arity-installs-validate
-  (testing "set-schema-validator! with a {:validate ...} map also counts as
-            'explicit opt-out' — non-default validator-fn after the swap"
-    (let [recorded (record-traces! ::opt-out-map)]
+(deftest warning-suppressed-when-set-schema-fns-installs-validate
+  (testing "set-schema-fns! with a {:validate ...} bundle also counts as
+            'explicit opt-out' — non-default validator-fn after the swap
+            (rf2-13meg)"
+    (let [recorded (record-traces! ::opt-out-bundle)]
       (with-unbound-malli-validate
         (fn []
-          (rf/set-schema-validator! {:validate (fn [_ _] true)})
+          (rf/set-schema-fns! {:validate (fn [_ _] true)})
           (rf/reg-app-schema [:user] [:map])))
       (is (empty? (warnings-of recorded
                                :rf.warning/schema-validator-unavailable))))))

--- a/skills/re-frame2/references/fundamentals/schemas.md
+++ b/skills/re-frame2/references/fundamentals/schemas.md
@@ -84,10 +84,14 @@ The `reg-app-schema` validates `app-db` shape at the `[:flight]` path; the `:sch
 
 ## Swapping the validator
 
-`set-schema-validator!` is the **substitute-Malli seam** (`core.cljc:599-621`). Apps that want to drop the ~24KB gzipped Malli surface in production swap in a hand-written validator at boot:
+`set-schema-validator!` is the **substitute-Malli seam**. Apps that want to drop the ~24KB gzipped Malli surface in production swap in a hand-written validator at boot. `set-schema-validator!` swaps only the validator; `set-schema-fns!` installs the validator/explainer/printer bundle atomically (the honest bundle setter — its name says it sets all three):
 
 ```clojure
-(rf/set-schema-validator!
+;; Validator only — explainer/printer untouched.
+(rf/set-schema-validator! (fn [schema value] (my-validator schema value)))
+
+;; All three at once, atomically.
+(rf/set-schema-fns!
   {:validate (fn [schema value] (my-validator schema value))
    :explain  (fn [schema value] (my-explainer schema value))})
 

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -253,7 +253,7 @@ When the hook is installed, the schemas artefact's `emit-validation-failure!` he
 
 ## Per-slot metadata vocabulary
 
-Inside the schema value passed to `reg-app-schema`, individual slots may carry per-slot metadata maps — the `{...}` properties map Malli accepts on every slot. The reserved per-slot key vocabulary is catalogued normatively in [Spec-Schemas §`:rf/app-schema-meta`](Spec-Schemas.md#rfapp-schema-meta); the reserved set is fixed-and-additive. Today's reserved keys are `:large?`, `:hint`, and (reserved-for-future) `:sensitive?`.
+Inside the schema value passed to `reg-app-schema`, individual slots may carry per-slot metadata maps — the `{...}` properties map Malli accepts on every slot. The reserved per-slot key vocabulary is catalogued normatively in [Spec-Schemas §`:rf/app-schema-meta`](Spec-Schemas.md#rfapp-schema-meta); the reserved set is fixed-and-additive. Today's reserved keys are `:large?`, `:hint`, and `:sensitive?` — all three are shipped (`:sensitive?` drives the validation-failure trace redaction described in [§`:sensitive?` — privacy in schema-validation error traces](#sensitive--privacy-in-schema-validation-error-traces) below).
 
 ### `:large?` — schema-driven size-elision nomination
 
@@ -509,32 +509,37 @@ Validation always goes through a registered **validator fn**. The CLJS reference
 Both fns are registered at boot, before the first `reg-app-schema` or `:schema`-bearing `reg-*` lands:
 
 ```clojure
-;; (1) Just the validator — the explainer is left untouched.
+;; (1) Just the validator — the explainer and printer are untouched.
 (rf/set-schema-validator! my-validator-fn)
 
-;; (2) Atomic swap of both fns at once.
-(rf/set-schema-validator! {:validate my-validator-fn
-                            :explain  my-explainer-fn})
-
-;; (3) Just the explainer — validator stays at its current value.
+;; (2) Just the explainer — validator stays at its current value.
 (rf/set-schema-explainer! my-explainer-fn)
 
-;; (4) Hard no-op: passing nil disables validation everywhere.
+;; (3) Install the schema-print companion the digest pipeline hashes
+;;     (see §Schema digest below). Non-Malli ports register their own
+;;     serialiser so the digest reflects the port's own validation
+;;     contract. Last-write-wins; passing nil reinstalls the default
+;;     EDN canonicaliser so the digest is never undefined for a present
+;;     schema set.
+(rf/set-schema-printer! my-printer-fn)
+
+;; (4) Atomic bundle: install any subset of validator/explainer/printer
+;;     in one call so the three never drift mid-boot. The honest bundle
+;;     setter — its name says it sets all three fns, not just the
+;;     validator. Absent keys leave the existing registration in place;
+;;     a nil :print coerces to the default EDN canonicaliser.
+(rf/set-schema-fns! {:validate my-validator-fn
+                     :explain  my-explainer-fn
+                     :print    my-printer-fn})
+
+;; (5) Hard no-op: passing nil disables validation everywhere.
 ;;     Every validate-*! site short-circuits without inspecting the
 ;;     schema. Apps that want zero validation surface (and zero
 ;;     schema-library bundle cost) install nil at boot.
 (rf/set-schema-validator! nil)
-
-;; (5) Install the schema-print companion the digest pipeline hashes
-;;     (see §Schema digest below). Parallel to set-schema-validator! —
-;;     non-Malli ports register their own serialiser so the digest
-;;     reflects the port's own validation contract. Last-write-wins;
-;;     passing nil reinstalls the default EDN canonicaliser so the
-;;     digest is never undefined for a present schema set.
-(rf/set-schema-printer! my-printer-fn)
 ```
 
-The three setters — `set-schema-validator!`, `set-schema-explainer!`, `set-schema-printer!` — are the **public** validator-surface seam. Each setter is also rowed in [API.md §Schemas](API.md#schemas). Together they let a port (or an app) swap out Malli wholesale: validator + explainer + printer = the entire schema-language surface the framework consults.
+The three single-purpose setters — `set-schema-validator!`, `set-schema-explainer!`, `set-schema-printer!` — are each rowed in [API.md §Schemas](API.md#schemas); the atomic bundle setter `set-schema-fns!` joins them as the **public** validator-surface seam. Together they let a port (or an app) swap out Malli wholesale: validator + explainer + printer = the entire schema-language surface the framework consults. `set-schema-fns!` is the one-call form for installing all three together (rf2-13meg — the bundle setter is named for what it sets, not misleadingly named after the validator alone).
 
 ### Per-port default
 
@@ -710,4 +715,4 @@ When a sub-path schema changes during dev (file save re-evaluates `reg-app-schem
 
 The four normative claims in [§The four normative claims](#the-four-normative-claims) are the portable contract: apps register via `reg-app-schema` + `:schema`; validation is pluggable via `set-schema-validator!`; the default is implementation-defined; dependency-absent behaviour is implementation-defined with a recommended soft-pass.
 
-The CLJS reference's expression of these claims: `(rf/set-schema-validator! validate-fn)`, `(rf/set-schema-validator! {:validate ... :explain ...})`, and `(rf/set-schema-explainer! explain-fn)` are all live in `re-frame.core` (re-exporting from `re-frame.schemas`). The CLJS reference's chosen default delegates to Malli's `validate` / `explain`; soft-pass when Malli is absent on the classpath; hard no-op when `set-schema-validator!` is called with `nil`. Other ports document their own defaults in their READMEs. The schemas mandate at the framework level (every `reg-*` may attach `:schema`; `reg-app-schema` registers path schemas) is independent of which validator is registered.
+The CLJS reference's expression of these claims: `(rf/set-schema-validator! validate-fn)`, `(rf/set-schema-explainer! explain-fn)`, and the atomic bundle `(rf/set-schema-fns! {:validate ... :explain ... :print ...})` are all live in `re-frame.core` (re-exporting from `re-frame.schemas`). The CLJS reference's chosen default delegates to Malli's `validate` / `explain`; soft-pass when Malli is absent on the classpath; hard no-op when `set-schema-validator!` is called with `nil`. Other ports document their own defaults in their READMEs. The schemas mandate at the framework level (every `reg-*` may attach `:schema`; `reg-app-schema` registers path schemas) is independent of which validator is registered.


### PR DESCRIPTION
Three cohesive [api] hygiene fixes on the SCHEMAS surface (Shape-2 cluster).

## rf2-52dfy — reg-app-schema opts symmetry
`reg-app-schema` / `reg-app-schemas` now route their `opts` through the SAME `coerce-opts` contract every read entry point (`app-schema-at` / `app-schema-meta-at` / `app-schemas`) uses. A bare keyword is the `{:frame kw}` sugar (it no longer silently registers against the DEFAULT frame — the footgun), and a non-keyword/non-map shape (string, number, vector) throws `:rf.error/bad-app-schemas-arg`. Write and read agree; bad shapes fail loud.

## rf2-13meg — honest validator-bundle setter
The `set-schema-validator!` map-arity was dishonest: the name said 'validator' but it also set the explainer + printer. Split: `set-schema-validator!` now sets ONLY the validator (single fn / nil); the new `set-schema-fns!` is the honest atomic bundle setter for validator+explainer+printer. No alias for the old misleading shape (pre-alpha, no back-compat shims). Public re-exports (`re-frame.core`, `re-frame.core-schemas`), the late-bind directory + hook publication, and every consumer (routing/flows tests, skill doc, docs/api) updated.

## rf2-x6q5m — :sensitive? shipped annotation (doc-only)
spec/010 §Per-slot metadata vocabulary marked `:sensitive?` as '(reserved-for-future)' though it is fully shipped (drives validation-failure trace redaction). Corrected to reflect shipped status.

## Notes
- spec/API.md + Conventions untouched; soft-pass default UNCHANGED (v96fh decision pending). The API.md §Schemas row update is deferred (hot-zone, owned outside this surface) and filed as **rf2-8ck66**.
- Public-surface rule honoured: `git grep` swept every `set-schema-validator!` map-arity + `reg-app-schema` consumer; all updated and gated.

## Quality gates
- schemas `clojure -M:test`: Ran 221 tests containing 18346 assertions. 0 failures, 0 errors.
- `npm run test:cljs`: Ran 5174 tests containing 17569 assertions. 0 failures, 0 errors.
- core `clojure -M:test` (late-bind drift gate): Ran 825 tests containing 3662 assertions. 0 failures, 0 errors.
- flows `clojure -M:test`: Ran 124 tests containing 525 assertions. 0 failures, 0 errors.
- routing `clojure -M:test`: Ran 142 tests containing 616 assertions. 0 failures, 0 errors.
- clj-kondo (`--parallel --fail-level error --lint implementation`): errors: 0, warnings: 358 (all pre-existing tree-wide; exit 0).
- `mkdocs build --strict`: Documentation built; 0 warnings, 0 errors (RC=0). spec/010 anchors verified.

## Regression tests
- 52dfy: `reg-app-schema-keyword-opts-matches-read-frame` (bare keyword → that frame, DEFAULT untouched), `reg-app-schema-bad-opts-shape-fails-loud` (string/number/vector throw), `reg-app-schema-valid-opts-map-registers-fine`, `reg-app-schemas-keyword-opts-matches-read-frame`.
- 13meg: `set-schema-fns-installs-all-three-atomically`, `set-schema-validator-is-honest-validator-only` (validator-only; explainer/printer untouched); printer-seam + public-surface bundle tests retargeted to `set-schema-fns!`; old misleading map-arity name gone (grep clean).
- x6q5m: doc-only.