### PR TITLE
chore(shadow): wire re-frame2-pair runtime preload into the 4 Story-showcase dev builds (rf2-qhhxp)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1142,7 +1142,13 @@
    :compiler-options {:closure-defines
                       {re-frame.testbed.config/repo-root
                        #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
-   :modules          {:main {:init-fn counter-with-stories.core/run}}}
+   :modules          {:main {:init-fn counter-with-stories.core/run}}
+   ;; rf2-qhhxp — re-frame2-pair.runtime preload added so pair-MCP can
+   ;; probe this Story showcase's live runtime alongside Xray (the
+   ;; variant-as-frame pairing workflow). Matches the standard-epochs
+   ;; testbed shape (both pair runtime AND the inline Xray panel).
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
 
   ;; Nine States Story + Xray showcase (rf2-rgyia). The
   ;; examples/reagent/nine_states example wired up as a Story showcase:
@@ -1167,7 +1173,10 @@
    :output-dir "out/examples/nine-states-with-stories"
    :asset-path "."
    :modules    {:main {:init-fn nine-states.stories-host/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   ;; rf2-qhhxp — re-frame2-pair.runtime preload added so pair-MCP can
+   ;; probe this Story showcase's live runtime alongside Xray.
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; Login Story + Xray showcase (rf2-p8v0q). The examples/reagent/login
   ;; example wired up as a Story showcase: `login.stories` registers one
@@ -1193,7 +1202,10 @@
    :output-dir "out/examples/login-with-stories"
    :asset-path "."
    :modules    {:main {:init-fn login.stories-host/run}}
-   :devtools   {:preloads [day8.re-frame2-xray.preload]}}
+   ;; rf2-qhhxp — re-frame2-pair.runtime preload added so pair-MCP can
+   ;; probe this Story showcase's live runtime alongside Xray.
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
 
   ;; (removed rf2-9jfo1.2) :examples/xray-rhs-smoke build target —
   ;; the original Playwright `spec.cjs` was deleted by rf2-piucm in
@@ -1223,7 +1235,10 @@
                       {re-frame.testbed.config/repo-root
                        #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
    :modules          {:main {:init-fn login-form.core/run}}
-   :devtools         {:preloads [day8.re-frame2-xray.preload]}}
+   ;; rf2-qhhxp — re-frame2-pair.runtime preload added so pair-MCP can
+   ;; probe this Story showcase's live runtime alongside Xray.
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
 
   ;; Story static-export build (rf2-8wgpm) — see
   ;; tools/story/spec/013-Static-Build.md. Same source tree as


### PR DESCRIPTION
Closes rf2-qhhxp.

## What

Adds the `re-frame2-pair.runtime` preload to the `:devtools :preloads` of all four Story-showcase DEV builds in `implementation/shadow-cljs.edn`, so the re-frame2-pair MCP can attach to their live runtimes. Mike hit `discover-app -> :runtime-loaded-but-preload-missing` pairing on :examples/counter-with-stories (8042); pairing on Story variants (variant-as-frame) is a documented, supported workflow.

| Build | Before | After |
|---|---|---|
| `:examples/counter-with-stories` | **no `:devtools` key at all** | new `:devtools` map with **both** `re-frame2-pair.runtime` AND `day8.re-frame2-xray.preload` (matches the other Story builds + gets the inline Xray panel) |
| `:examples/nine-states-with-stories` | Xray preload only | + `re-frame2-pair.runtime` |
| `:examples/login-with-stories` | Xray preload only | + `re-frame2-pair.runtime` |
| `:examples/login-form` | Xray preload only | + `re-frame2-pair.runtime` |

The preload source dir (`../skills/re-frame2-pair/preload`) is already on `:source-paths`, so each is a one-symbol add (one new `:devtools` map for counter). No other build, port, or source-path touched.

## Open question (does not block)

counter-with-stories was the only Story build with no `:devtools` at all. Per the bead this reads as an **oversight** — the L1133-1135 comment about the `:advanced`+`enabled?=false` elision path is about the PLAIN `examples/counter` build, not this one. I've proceeded treating it as an oversight (added `:devtools`). **Mike: please confirm it isn't a deliberate fixture.**

## Quality gates

- **EDN well-formedness:** `shadow-cljs.edn` parses cleanly via the Clojure reader (with `#shadow/env` reader-tag passthrough) — `EDN-PARSE-OK forms= 1` (single top-level map).
- **Surgical diff:** `git diff` confirms only the 4 build entries changed; no other build/port/source-path modified.
- **Structural parity:** each edited build's `:devtools :preloads` now matches the working testbed shape — diff-compared against `:examples/standard-epochs` (`[re-frame2-pair.runtime day8.re-frame2-xray.preload]`).
- This is a dev `:devtools` preloads-only edn change — no test suite applies; dev `:devtools` preloads are honoured by watch/compile but NEVER ship to release, so no release/bundle-isolation impact (that gate is about release bundles). EDN parses; structural parity with working testbeds verified.
- **Live verification (`discover-app -> :ok? true`) requires a shadow-server restart**, which the mayor does post-merge (per the bead) — it cannot be done from this isolated worktree.