### PR TITLE
fix(xray/epoch): one-line interceptor row + single go-to-source glyph + grey phase badge + flat error block (rf2-rvxem rf2-iizhe)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -2418,27 +2418,35 @@ captured by rf2-mszrz now drives placement.) Each step carries its own
 the step matching its phase (`interceptor-exception-target`). Both are
 **CONDITIONAL** — the substrate emits no per-interceptor "ran" trace (the
 chain runs as one unit; only a throw surfaces a trace), so a phase's step
-renders ONLY when an interceptor threw in that phase this cascade. Each
-row is a throwing interceptor: the interceptor `:id` (click-to-source) +
-the shared open-in-editor coord-chip glyph + a `:before` / `:after`
-phase chip + the shared "Exception Thrown" card. **rf2-siheh** — the
+renders ONLY when an interceptor threw in that phase this cascade.
+**rf2-rvxem** — each row is ONE inline line, in this order:
+`[INTERCEPTOR badge] [grey BEFORE/AFTER phase badge] <interceptor :id>
+<single ↗ go-to-source glyph>`. The `:INTERCEPTOR` badge LEADS the row
+(it is no longer a step-header above the rows — that painted a second,
+content-free badge); the **phase badge** sits right after it, BEFORE the
+name, rendered UPPERCASE (`BEFORE` / `AFTER`) as a grey chip
+(`:bg-3` / `:text-tertiary`) so it reads as a badge. **rf2-siheh** — the
 jump-to-source coord rides the projection row's `:coord` slot, resolved
 from the `:rf.error/interceptor-exception` trace's `:source-coord` tag
 (threaded by the router from the throwing interceptor's map). The
 **`->interceptor` macro** (framework, rf2-siheh) captures that coord from
 `(meta &form)` — before rf2-siheh `->interceptor` was a plain fn and the
 row had no coord to render (yz57h's `handler-meta :interceptor` lookup was
-unsatisfiable: interceptors are not a registry kind). The id label
-hyperlinks + the coord-chip mounts when a coord is present (parity with
-the EVENT HANDLER / SUBSCRIPTIONS / VIEWS rows); both degrade to plain
-text + no chip when the interceptor was built via the `->interceptor*` fn,
-is a framework interceptor, or the bundle elided the coord in production.
-rf2-oqi0c
-**DROPPED** the badge's "N interceptor(s) threw" summary verb — redundant
-with the per-row id + the inline card below; the `:INTERCEPTOR` badge
-stands alone (it pulls the `:accent` token — the chain WRAPS the handler;
-they read as one identity family). A `:before` throw skips the handler;
-an `:after` throw runs the handler first, then throws on the way out.
+unsatisfiable: interceptors are not a registry kind). The id renders via
+the shared **`coord-link`**, which ALREADY emits `name ↗` — **a SINGLE
+go-to-source glyph** (rf2-rvxem FIX 1: the row formerly ALSO appended a
+standalone `coord-chip`, producing TWO `↗`; the HANDLER / COEFFECTS rows
+use `coord-link` alone, and only the plain-label SUBS / VIEWS /
+SIDE-EFFECTS rows pair a label with a `coord-chip` — the interceptor row
+had conflated the two). The id hyperlinks when a coord is present and
+degrades to plain text + no glyph when the interceptor was built via the
+`->interceptor*` fn, is a framework interceptor, or the bundle elided the
+coord in production. rf2-oqi0c **DROPPED** the badge's "N interceptor(s)
+threw" summary verb — redundant with the per-row id + the inline card
+below; the `:INTERCEPTOR` badge stands alone (it pulls the `:accent`
+token — the chain WRAPS the handler; they read as one identity family).
+A `:before` throw skips the handler; an `:after` throw runs the handler
+first, then throws on the way out.
 
 **SKIPPED steps (rf2-yz57h).** When an UPSTREAM `:before`-chain throw
 aborts the cascade — a coeffect injector (`:rf.error/coeffect-exception`)
@@ -2461,27 +2469,33 @@ failure, so it does NOT inflate the epoch outcome (the failing COEFFECT /
 INTERCEPTOR step is the load-bearing `:error` signal).
 
 **Inline error card (rf2-ahhgn · refined rf2-wnvid · sophistication pass
-rf2-ynvv7).** `view/error-block` renders a RAISED card (sibling to the
-amber schema-violation card) for ALL exception kinds. **rf2-ynvv7** lifts
-the card out of the flat violation skeleton it formerly borrowed and sits
-it in the design system the way the surrounding pipeline-step cards do —
-every colour / spacing value resolves through the theme token ns (`theme/
-tokens`), no hardcoded hex:
+rf2-ynvv7 · flattened rf2-iizhe).** `view/error-block` renders the
+exception card (sibling to the amber schema-violation card) for ALL
+exception kinds. **rf2-ynvv7** lifts the card out of the flat violation
+skeleton it formerly borrowed and sits it in the design system the way
+the surrounding pipeline-step cards do — every colour / spacing value
+resolves through the theme token ns (`theme/tokens`), no hardcoded hex.
+**rf2-iizhe** then makes it **FLAT** (no elevation): every other Xray
+surface is flat, so the prior drop shadow read as off; the failure tone
+is carried by the fill + edge + glyph, not a lift:
 
 - **Surface (rf2-ksl5m)** — a **very-light-red** fill: `:error` mixed ~7%
   over the raised `:bg-2` panel surface (an opaque 2-token `color-mix`, so
   it paints cleanly on light + dark). Still **quiet** — a subtle tint, NOT
   the saturated `:bg-violation` rose wash — but the error now reads on the
-  fill at a glance, joining the same `:error` tone the edge, rail, glow +
+  fill at a glance, joining the same `:error` tone the edge, rail +
   glyph already carry.
 - **Border + rail** — a refined hairline keyed to the error token via
   `tokens/with-alpha` (a tinted edge, not a solid-red box) plus a solid
   `:error` **left rail** (the same accented-left-edge language as the L4
   panel header stripe + the diff stripes), so severity reads at the
   column-1 anchor.
-- **Elevation** — a layered `box-shadow`: a soft neutral drop shadow (the
-  card lifts off the cascade) plus a faint `:error`-tinted ring so the
-  lift is keyed to the failure tone without flooding the fill.
+- **Flat — no elevation (rf2-iizhe)** — the card carries **no
+  `:box-shadow`**. The earlier layered shadow (a neutral drop shadow + a
+  faint `:error`-tinted `0 0 0 1px` ring) read as off against the flat
+  Xray UI, and the ring was redundant with the `:border` hairline; the
+  card sits flat like every other surface while staying clearly
+  error-keyed.
 - **Spacing + radius** — padding from the 4px `tokens/spacing` scale
   (`:gap-2` / `:gap-3`); radius matches the surrounding cards.
 - **Typographic hierarchy** — the `✗ Exception Thrown` headline (sans,

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1197,8 +1197,10 @@
 ;; verbatim).
 ;;
 ;; rf2-ynvv7 — the card no longer borrows the violation block's flat
-;; skeleton. It now sits in the design system the way the surrounding
-;; pipeline-step cards do, sophisticated rather than basic:
+;; skeleton. It sits in the design system the way the surrounding
+;; pipeline-step cards do, sophisticated rather than basic — and, per
+;; rf2-iizhe, FLAT (no elevation): every other Xray surface is flat, so
+;; the failure tone is carried by the fill + edge + glyph, NOT a lift:
 ;;
 ;;   - SURFACE — a VERY-LIGHT-RED fill (rf2-ksl5m): `:error` mixed ~7%
 ;;     over the raised `:bg-2` surface the other step cards read. Still
@@ -1210,9 +1212,6 @@
 ;;     `:error` LEFT RAIL — the same "accented left edge" language the
 ;;     panel header stripe (`accent-stripe-style`) + the diff stripes
 ;;     use, so the severity reads at the column-1 anchor.
-;;   - ELEVATION — a layered `box-shadow`: a soft neutral drop shadow
-;;     (the card lifts off the cascade) plus a faint error-tinted glow so
-;;     the lift is keyed to the failure tone without flooding the fill.
 ;;   - SPACING — padding from the 4px `spacing` scale (`:gap-2` /
 ;;     `:gap-3`), consistent with every other panel surface.
 ;;
@@ -1230,9 +1229,9 @@
    ;; raised `:bg-2` surface. The card still reads QUIET per rf2-ynvv7
    ;; (a subtle tint, NOT a saturated rose wash), but the failure tone
    ;; now joins the fill the same way it already keys the hairline, the
-   ;; left rail, the glow + the glyph. An OPAQUE 2-token `color-mix`
-   ;; (over `:bg-2`, not `transparent`) so it paints cleanly on both
-   ;; themes regardless of the surface the lifted card sits above.
+   ;; left rail + the glyph. An OPAQUE 2-token `color-mix` (over `:bg-2`,
+   ;; not `transparent`) so it paints cleanly on both themes regardless
+   ;; of the surface the card sits above.
    :background     (str "color-mix(in srgb, " error-colour " 7%, "
                         bg-2-colour ")")
    ;; Refined tinted hairline (not a shouty solid red box) + the solid
@@ -1240,10 +1239,12 @@
    :border         (str "1px solid " (with-alpha :error 38))
    :border-left    (str "3px solid " error-colour)
    :border-radius  "4px"
-   ;; Elevation — neutral drop shadow + a faint error-keyed glow so the
-   ;; lift reads as "failure" without flooding the surface.
-   :box-shadow     (str "0 1px 3px rgba(0,0,0,0.32), "
-                        "0 0 0 1px " (with-alpha :error 10))
+   ;; rf2-iizhe — FLAT, no `:box-shadow`. The rest of the Xray UI is flat,
+   ;; so the prior elevation (a neutral drop shadow + a faint error-tinted
+   ;; glow) read as off. The card stays fully error-keyed without the
+   ;; lift: the tinted hairline, the solid `:error` left rail, the
+   ;; very-light-red fill (rf2-ksl5m) + the ✗ glyph carry the severity,
+   ;; and the dropped `0 0 0 1px` ring was redundant with the `:border`.
    :font-family    mono-stack
    :font-size      (:mono-body type-scale)})
 
@@ -2104,10 +2105,14 @@
 ;;
 ;; CONDITIONAL — the projection emits the step only when an interceptor
 ;; threw this cascade (the substrate emits no per-interceptor "ran" trace,
-;; so a clean chain leaves nothing to show). One row per throwing
-;; interceptor: the interceptor id (click-to-source via `handler-meta`,
-;; degrading to plain text) + a `:before` / `:after` phase chip + the
-;; shared 'Exception Thrown' card (rf2-wnvid).
+;; so a clean chain leaves nothing to show; reversing this to always
+;; enumerate the chain is the open rf2-rvxem change-4 design call). One
+;; row per throwing interceptor, rendered as ONE inline line (rf2-rvxem):
+;; `[INTERCEPTOR badge] [grey BEFORE/AFTER phase badge] <interceptor id>
+;; <single go-to-source glyph>` — the id is click-to-source via the
+;; shared `coord-link` (`name ↗`, one glyph), degrading to plain text
+;; when no coord is captured — with the shared 'Exception Thrown' card
+;; (rf2-wnvid) attaching below the row.
 
 (def ^:private interceptor-row-style
   {:display     "flex"
@@ -2134,46 +2139,57 @@
 
 (defn- interceptor-phase-label
   "Render an interceptor exception row's `:phase` as a UI chip label
-  (rf2-yz57h). `:before` (threw on the way IN — handler skipped) /
-  `:after` (threw on the way OUT — handler ran first). nil → no chip."
+  (rf2-yz57h, UPPERCASED rf2-rvxem so it reads as a grey BADGE alongside
+  the INTERCEPTOR pill). `:before` (threw on the way IN — handler
+  skipped) / `:after` (threw on the way OUT — handler ran first). nil →
+  no chip."
   [phase]
   (case phase
-    :before "before"
-    :after  "after"
-    (when (keyword? phase) (name phase))))
+    :before "BEFORE"
+    :after  "AFTER"
+    (when (keyword? phase) (str/upper-case (name phase)))))
 
 (defn- interceptor-row-view
-  "Render one INTERCEPTOR-step row (rf2-yz57h) — the throwing interceptor's
-  id + a `:before` / `:after` phase chip + the shared inline 'Exception
-  Thrown' card.
+  "Render one INTERCEPTOR-step row (rf2-yz57h) — ONE inline line of
+  `[INTERCEPTOR badge] [phase badge] <name> <go-to-source glyph>`
+  (rf2-rvxem), with the shared inline 'Exception Thrown' card attaching
+  below.
+
+  Order (rf2-rvxem): the INTERCEPTOR badge pill leads, the grey
+  `BEFORE` / `AFTER` phase badge sits RIGHT AFTER it (before the name),
+  then the interceptor name + its single open-in-editor glyph.
 
   rf2-siheh — the jump-to-source coord rides the projection row's
   `:coord` slot (captured by the `->interceptor` macro from `(meta &form)`
-  and threaded onto the trace by the router). The label hyperlinks via
-  `coord-link` when a coord is present AND a shared `coord-chip` glyph
-  is appended (exact parity with the EVENT HANDLER / SUBSCRIPTIONS / VIEWS
-  rows); both drop out cleanly to plain text + no chip when the
-  interceptor was built via the `->interceptor*` fn, is a framework
-  interceptor, or the bundle elided the coord in production."
+  and threaded onto the trace by the router). The name hyperlinks via
+  `coord-link`, which ALREADY emits `name ↗` (one glyph) — the row no
+  longer appends a redundant standalone `coord-chip` (rf2-rvxem FIX 1:
+  the HANDLER / COEFFECTS rows use `coord-link` alone; only the plain-
+  label SUBS / VIEWS / SIDE-EFFECTS rows pair a label with `coord-chip`,
+  and the interceptor row conflated the two). `coord-link` drops cleanly
+  to plain text + no glyph when the interceptor was built via the
+  `->interceptor*` fn, is a framework interceptor, or the bundle elided
+  the coord in production."
   [idx {:keys [interceptor-id phase errors coord]}]
   (let [label (proj/ns-keyword interceptor-id)]
     [:div {:key (str "interceptor-row-" idx)
            :data-testid (str "rf-xray-epoch-interceptor-row-" idx)
            :data-interceptor-phase (when phase (name phase))}
      [:div {:style interceptor-row-style}
-      (coord-link/coord-link coord label
-                             (str "rf-xray-epoch-interceptor-id-" idx)
-                             {:style       coeffect-verb-link-button-style
-                              :plain-style coeffect-verb-plain-style})
-      ;; rf2-siheh — shared open-in-editor glyph (parity with the
-      ;; EVENT HANDLER / SUBSCRIPTIONS / VIEWS rows). Drops out when
-      ;; `coord` is nil (no `:file`).
-      (coord-chip/coord-chip coord
-                             (str "rf-xray-epoch-interceptor-row-coord-" idx))
+      ;; rf2-rvxem — the INTERCEPTOR badge leads the inline row.
+      (badge-pill :INTERCEPTOR)
+      ;; rf2-rvxem — grey phase badge BEFORE the name (right after the
+      ;; INTERCEPTOR pill).
       (when-let [pl (interceptor-phase-label phase)]
         [:span {:data-testid (str "rf-xray-epoch-interceptor-phase-" idx)
                 :style interceptor-phase-chip-style}
-         pl])]
+         pl])
+      ;; rf2-siheh — the name hyperlinks via `coord-link` (`name ↗`, ONE
+      ;; glyph). Drops to plain text when `coord` is nil (no `:file`).
+      (coord-link/coord-link coord label
+                             (str "rf-xray-epoch-interceptor-id-" idx)
+                             {:style       coeffect-verb-link-button-style
+                              :plain-style coeffect-verb-plain-style})]
      ;; rf2-yz57h — the interceptor EXCEPTION attaches here as the shared
      ;; inline 'Exception Thrown' card (button-17 :before / button-18
      ;; :after), under the INTERCEPTOR step where it occurred.
@@ -2182,10 +2198,11 @@
 (defn render-interceptor-step
   "Render the INTERCEPTOR step (rf2-yz57h — present ONLY when a user
   interceptor threw this cascade). One row per throwing interceptor; each
-  carries the interceptor id (click-to-source) + a `:before` / `:after`
-  phase chip + the shared 'Exception Thrown' card. The step's `:errors`
-  slot (attached by `attach-exceptions`) is rendered per-row by matching
-  the exception's `:failing-id` to the row's `:interceptor-id`."
+  row is ONE inline line of `[INTERCEPTOR badge] [phase badge] <name>
+  <go-to-source glyph>` (rf2-rvxem) with the shared 'Exception Thrown'
+  card attaching below it. The step's `:errors` slot (attached by
+  `attach-exceptions`) is rendered per-row by matching the exception's
+  `:failing-id` to the row's `:interceptor-id`."
   [{:keys [rows step-number errors]}]
   ;; The step-level `:errors` (from `attach-exceptions`) carry the exception
   ;; records; thread each onto its matching row by `:failing-id`.
@@ -2194,21 +2211,20 @@
                              (filterv #(= (:interceptor-id row) (:failing-id %))
                                       errors)))
                     rows)]
+    ;; rf2-rvxem — the INTERCEPTOR badge now LEADS each inline row
+    ;; (`interceptor-row-view`) rather than riding a separate step-header
+    ;; above the rows. So the step-level `step-header` is gone (it would
+    ;; otherwise paint a SECOND, content-free INTERCEPTOR badge on its
+    ;; own line) and the rows sit directly at the content-column anchor
+    ;; next to the cascade numbered-circle — no `margin-top-5` offset.
+    ;; rf2-oqi0c — the "N interceptor(s) threw" summary verb stays DROPPED:
+    ;; redundant with the per-row id + the inline 'Exception Thrown'
+    ;; card(s), which already carry which interceptor threw + on which
+    ;; phase.
     [:div {:data-testid "rf-xray-epoch-step-interceptor"
            :data-step-kw "interceptor"}
      (numbered-circle step-number :INTERCEPTOR)
-     ;; rf2-oqi0c — the "N interceptor(s) threw" summary verb is DROPPED:
-     ;; redundant with the per-interceptor row(s) + the inline 'Exception
-     ;; Thrown' card(s) below, which already carry which interceptor threw
-     ;; and on which phase. The badge stands alone.
-     (step-header
-       {:step :interceptor
-        :badge :INTERCEPTOR
-        :expandable? false
-        :testid "rf-xray-epoch-interceptor"}
-       nil)
-     [:div {:style margin-top-5-style}
-      (map-indexed (fn [i row] (interceptor-row-view i row)) rows*)]]))
+     (map-indexed (fn [i row] (interceptor-row-view i row)) rows*)]))
 
 ;; ---- HANDLER step --------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -2402,12 +2402,13 @@
           "rf2-wnvid — the redundant jump-to-source link is dropped"))))
 
 (deftest error-block-styling-is-token-driven-test
-  (testing "rf2-ynvv7 / rf2-ksl5m — the sophistication pass styles the
-            exception card from the design tokens (a very-light-red
-            `:error`-over-`:bg-2` fill, the solid `:error` left rail, an
-            `:error`-keyed elevation glow, and the `:error`-accent glyph),
-            NOT hardcoded hex. The card sits in the design system like the
-            surrounding step cards."
+  (testing "rf2-ynvv7 / rf2-ksl5m / rf2-iizhe — the sophistication pass
+            styles the exception card from the design tokens (a very-light-
+            red `:error`-over-`:bg-2` fill, the solid `:error` left rail,
+            and the `:error`-accent glyph), NOT hardcoded hex. The card
+            sits in the design system like the surrounding step cards, and
+            is FLAT (no `:box-shadow` elevation — rf2-iizhe) to match the
+            flat Xray UI."
     (let [error-var (:error tokens/tokens)        ; "var(--rf-xray-error)"
           bg-2-var  (:bg-2  tokens/tokens)         ; "var(--rf-xray-bg-2)"
           tree      (view/error-block :handler 0
@@ -2426,7 +2427,7 @@
                                  :style))]
       ;; The card root reads a VERY-LIGHT-RED fill (rf2-ksl5m — `:error`
       ;; mixed lightly over the raised `:bg-2` surface) + a token-keyed
-      ;; left rail + an `:error`-tinted elevation — all from tokens.
+      ;; left rail — all from tokens.
       (is (and (string/includes? (str (:background card)) error-var)
                (string/includes? (str (:background card)) bg-2-var))
           "card surface is a token-driven `:error`-over-`:bg-2` tint
@@ -2435,10 +2436,11 @@
           "the severity left rail is the `:error` token")
       (is (string/includes? (str (:border card)) error-var)
           "the hairline border is a `with-alpha` mix over the `:error` token")
-      (is (string/includes? (str (:box-shadow card)) error-var)
-          "the elevation glow is keyed to the `:error` token")
-      (is (some? (:box-shadow card))
-          "the card carries elevation (box-shadow) — not a flat box")
+      ;; rf2-iizhe — the card is FLAT: NO box-shadow elevation, matching
+      ;; every other (flat) Xray surface. The fill + hairline + left rail
+      ;; + glyph still carry the error severity without a lift.
+      (is (nil? (:box-shadow card))
+          "the card is FLAT — no box-shadow elevation (rf2-iizhe)")
       ;; No hardcoded hex anywhere in the card root style (token discipline).
       (is (not (re-find #"#[0-9A-Fa-f]{3,8}" (pr-str card)))
           "no hardcoded hex in the exception-card root style")
@@ -2645,14 +2647,14 @@
           "the throwing interceptor id renders")
       (is (string/includes?
             (text-of tree "rf-xray-epoch-interceptor-phase-0")
-            "before")
-          "the :before phase chip renders")
+            "BEFORE")
+          "the :before phase badge renders UPPERCASE (rf2-rvxem grey badge)")
       ;; rf2-oqi0c — the "N interceptor(s) threw" summary verb is DROPPED;
-      ;; the per-row id + the inline card carry the signal.
-      (is (not (string/includes?
-                 (or (text-of tree "rf-xray-epoch-interceptor-header-verb") "")
-                 "threw"))
-          "no redundant 'N interceptor threw' summary verb after the badge")
+      ;; the per-row id + the inline card carry the signal. rf2-rvxem —
+      ;; the INTERCEPTOR badge now leads the inline row itself (the
+      ;; step-level `step-header` is gone), so no summary verb can exist.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-interceptor-header-verb"))
+          "no redundant 'N interceptor threw' summary verb (rf2-rvxem: no step-header)")
       ;; the shared card under the interceptor row
       (is (string/includes?
             (text-of tree "rf-xray-epoch-error-interceptor-row-0-0-title")
@@ -2678,13 +2680,15 @@
                               :failing-id :app/auditor :phase :after}]}))]
       (is (string/includes?
             (text-of tree "rf-xray-epoch-interceptor-phase-0")
-            "after"))))
+            "AFTER"))))
 
-  (testing "rf2-siheh — the INTERCEPTOR row mounts the shared
-            `coord-chip/coord-chip` go-to-source glyph when the row carries
-            a `:coord` (parity with EVENT HANDLER / SUBSCRIPTIONS / VIEWS).
-            The `->interceptor` macro captures the coord; the projection
-            lifts it onto the row."
+  (testing "rf2-siheh / rf2-rvxem — the INTERCEPTOR row's go-to-source glyph
+            rides the shared `coord-link` (`name ↗`, ONE glyph) when the row
+            carries a `:coord`: the id slot renders as a clickable
+            `<button>`. rf2-rvxem FIX 1 — the redundant standalone
+            `coord-chip` (a SECOND ↗) is GONE; `coord-link` already emits
+            the single glyph. The `->interceptor` macro captures the coord;
+            the projection lifts it onto the row."
     (epoch-orchestrator/install!)
     (frame/reg-frame :rf/xray {})
     (let [tree (rf/with-frame :rf/xray
@@ -2698,12 +2702,18 @@
                                     :line 42}}]
                     :errors [{:operation :rf.error/interceptor-exception
                               :message "before boom"
-                              :failing-id :app/auth :phase :before}]}))]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-interceptor-row-coord-0"))
-          "the go-to-source coord-chip glyph renders for a coord-bearing row")))
+                              :failing-id :app/auth :phase :before}]}))
+          id-node (th/find-by-testid tree "rf-xray-epoch-interceptor-id-0")]
+      (is (= :button (first id-node))
+          "a coord-bearing row renders the id as a clickable coord-link button")
+      (is (fn? (:on-click (second id-node)))
+          "the coord-link button carries the open-in-editor on-click")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-interceptor-row-coord-0"))
+          "rf2-rvxem FIX 1 — NO redundant standalone coord-chip (one glyph only)")))
 
-  (testing "rf2-siheh — NO coord on the row → NO glyph (the ->interceptor*
-            fn / framework-interceptor path; the chip drops out cleanly)"
+  (testing "rf2-siheh / rf2-rvxem — NO coord on the row → the id degrades to
+            a plain `<span>` (the ->interceptor* fn / framework-interceptor
+            path; no clickable affordance, no glyph)"
     (epoch-orchestrator/install!)
     (frame/reg-frame :rf/xray {})
     (let [tree (rf/with-frame :rf/xray
@@ -2714,9 +2724,12 @@
                     :rows [{:interceptor-id :app/auth :phase :before}]
                     :errors [{:operation :rf.error/interceptor-exception
                               :message "before boom"
-                              :failing-id :app/auth :phase :before}]}))]
+                              :failing-id :app/auth :phase :before}]}))
+          id-node (th/find-by-testid tree "rf-xray-epoch-interceptor-id-0")]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-interceptor-row-0"))
           "the interceptor row still renders")
+      (is (= :span (first id-node))
+          "no coord → the id is a plain span (no clickable go-to-source)")
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-interceptor-row-coord-0"))
           "no coord → no go-to-source glyph"))))
 


### PR DESCRIPTION
Two P3 Xray Epoch-panel UI fixes on the same panels/epoch surface.

## rf2-rvxem — INTERCEPTOR step row

The INTERCEPTOR step row now renders as ONE inline line:
`[INTERCEPTOR badge] [grey BEFORE/AFTER phase badge] <name> <single ↗ glyph>`, per Mike's exact instructions.

- **FIX 1 (duplicate glyph).** Dropped the redundant standalone `coord-chip` at the end of the row. `coord-link` already emits `name ↗` (one glyph); the row was appending a second `↗`. Now exactly one go-to-source glyph (HANDLER/COEFFECTS-row shape, not the plain-label + coord-chip SUBS/VIEWS shape).
- **FIX 2 (one-line order).** Restructured `render-interceptor-step` + `interceptor-row-view` so `[badge] [phase] <name> <glyph>` sit on ONE line. The `:INTERCEPTOR` badge pill now LEADS each row (the separate step-level `step-header` is removed — it painted a second content-free badge on its own line); the phase badge sits right after it, BEFORE the name.
- **FIX 3 (phase as grey badge).** The phase chip (already greyish `:bg-3`/`:text-tertiary`) now renders UPPERCASE (`BEFORE`/`AFTER`) so it reads as a badge.

Out of scope: bead Change-4 (show the row exception-or-not by enumerating the cascade chain) is explicitly the open design call Mike flagged; Fixes 1-3 land independently per the bead.

## rf2-iizhe — flat error block

Removed the `:box-shadow` elevation from `error-block-style` (a neutral drop shadow + a faint `:error`-tinted `0 0 0 1px` ring). The rest of the Xray UI is flat, so the lift read as off. The card stays fully error-keyed — the very-light-red fill (rf2-ksl5m), the tinted hairline `:border`, the solid `:error` left rail + the ✗ glyph carry the severity; the dropped ring was redundant with the border. This is THE shared exception block, so it flattens EVERY exception box in the Epoch panel.

## Spec

Updated `tools/xray/spec/021-Dynamic-Panel-Designs.md` (Epoch INTERCEPTOR-step contract + inline error-card chrome) in-PR.

## Quality gates

- xray `clojure -M:test`: **Ran 1038 tests, 4146 assertions. 0 failures, 0 errors.**
- `npm run test:cljs`: **Ran 5175 tests, 17575 assertions. 0 failures, 0 errors.**
- `npm run test:xray-feature-gate`: **Ran 16 Xray feature scenarios (nightly-full sweep). 0 failures. Covered 13 matrix rows.** (1 SKIP — schema-violation timeline migrating to CLJS unit per rf2-w1mnq, pre-existing/unrelated.) All 14 testbeds compiled, 0 warnings.
- clj-kondo on changed .cljs (view.cljs + view_cljs_test.cljs): **errors: 0, warnings: 14** — all 14 are pre-existing unused-private-var / unused-require warnings unrelated to this change (none reference the touched fns).
- xray testbeds build: panel-gallery + deliberate-throw testbeds compiled clean (0 warnings) in the feature-gate sweep.
- `mkdocs build --strict`: N/A — `tools/xray/spec/021` is a tool-local spec not referenced by the mkdocs nav, so the strict build does not process it (mkdocs is also not installed in this env).

Spec changed: yes (021-Dynamic-Panel-Designs.md — interceptor-row + error-card chrome).