### PR TITLE
fix(pair-mcp): add recovery :hint + tools/list pointer to :unknown-tool error (rf2-tkmik)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -286,6 +286,28 @@ the common path; the dialect cost would tax the common case.
 - `:rf.mcp/cursor-stale` ⇒ drop the cursor; restart pagination from
   the head (same as cross-MCP cursor-staleness on story-mcp).
 
+#### `:unknown-tool` recovery hint (rf2-tkmik)
+
+The bare `:unknown-tool` reason — emitted when a `tools/call` names a
+tool absent from the registry (a typo, or a removed alias such as the
+pre-rf2-4y595 `registry-list`) — carries the recovery affordances every
+other honest `:ok? false` envelope on this surface does:
+
+```clojure
+{:ok? false
+ :reason :unknown-tool
+ :tool "<the bad name>"
+ :hint "unknown tool `<name>`; did you mean `<nearest>`? call `tools/list` to see the available tools."
+ :available-tools ["discover-app" "eval-cljs" …]   ;; the live catalogue, registry order
+ :did-you-mean "<nearest>"}                         ;; present only when a near edit-distance match exists
+```
+
+`:available-tools` is the same name set `tools/list` enumerates;
+`:did-you-mean` (and the `did you mean …` clause inside `:hint`) appears
+only when the bad name is within a small edit distance of a real tool.
+A model that typo'd a name self-corrects from the envelope without a
+`tools/list` round-trip.
+
 ## discover-app
 
 Verify the shadow-cljs nREPL is reachable, confirm the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -87,6 +87,64 @@
 (def tool-descriptors descriptors/tool-descriptors)
 (def tool-descriptors-js descriptors/tool-descriptors-js)
 
+(defn- edit-distance
+  "Cheap Levenshtein distance between two strings — used only to surface a
+  `did you mean` candidate in the `:unknown-tool` hint. Runs over the
+  ~25-name catalogue on the cold error path, so the naive O(m·n) row-DP
+  is plenty; no dependency for one off-the-happy-path string compare."
+  [a b]
+  (let [m (count a) n (count b)]
+    (loop [i 0 prev (vec (range (inc n)))]
+      (if (> i m)
+        (peek prev)
+        (recur
+          (inc i)
+          (loop [j 0 row [i] p prev]
+            (if (> j n)
+              row
+              (let [cost (if (= (nth a (dec i) nil) (nth b (dec j) nil)) 0 1)
+                    v    (if (zero? j)
+                           i
+                           (min (inc (peek row))           ;; deletion
+                                (inc (nth p j))            ;; insertion
+                                (+ cost (nth p (dec j))))) ;; substitution
+                    row  (if (zero? j) row (conj row v))]
+                (recur (inc j) row p)))))))))
+
+(defn- nearest-tool
+  "Closest registered tool name to `name` by edit distance, or nil when
+  nothing is within a sensible threshold (avoid an actively-misleading
+  suggestion for a wildly-off name). Threshold scales loosely with the
+  typo'd length so short names need a near-exact match."
+  [name]
+  (when (and (string? name) (seq name))
+    (let [[best d] (reduce (fn [[_ bd :as acc] cand]
+                             (let [cd (edit-distance name cand)]
+                               (if (< cd bd) [cand cd] acc)))
+                           [nil js/Infinity]
+                           registry/tool-names)
+          cutoff   (max 2 (quot (count name) 2))]
+      (when (and best (<= d cutoff)) best))))
+
+(defn- unknown-tool-envelope
+  "Build the `:unknown-tool` error envelope. Additive over the historical
+  `{:ok? false :reason :unknown-tool :tool name}` shape: carries a
+  recovery-shaped `:hint` (the surface's honest-error standard — cf.
+  cache.cljs `:rf.mcp/cache-hit` :hint, roots_discovery.cljs discovery
+  hints, server.cljs port hints) pointing the agent at `tools/list` plus
+  the live catalogue, and a `:did-you-mean` when a near name exists."
+  [name]
+  (let [near (nearest-tool name)
+        base (str "unknown tool" (when name (str " `" name "`")) "; "
+                  (when near (str "did you mean `" near "`? "))
+                  "call `tools/list` to see the available tools.")]
+    (cond-> {:ok?           false
+             :reason        :unknown-tool
+             :tool          name
+             :hint          base
+             :available-tools registry/tool-names}
+      near (assoc :did-you-mean near))))
+
 (defn- dispatch-tool*
   "Route a `tools/call` to the per-tool implementation. Unknown tools
   resolve to an isError result rather than throwing — keeps the server
@@ -95,12 +153,17 @@
   Lookup is a single `(get registry/handler-for name)` — the registry
   is the only place tool names are enumerated (rf2-47g8l). Every
   registered handler is a uniform 3-arity `(fn [conn args extra])`; the
-  registry adapts 2-arity per-tool handlers internally."
+  registry adapts 2-arity per-tool handlers internally.
+
+  An unknown name returns the recovery-shaped `:unknown-tool` envelope
+  (`unknown-tool-envelope`) — a `:hint` pointing at `tools/list` plus the
+  live `:available-tools` catalogue and a `:did-you-mean` near-match, so a
+  model that typo'd a name (rf2-tkmik) can recover without a dead end."
   [conn name args extra]
   (if-let [handler (get registry/handler-for name)]
     (handler conn args extra)
     (js/Promise.resolve
-      (wire/err-text {:ok? false :reason :unknown-tool :tool name}))))
+      (wire/err-text (unknown-tool-envelope name)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Wire-boundary pipeline (rf2-3z0zi).

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
@@ -280,6 +280,14 @@
   the `:unknown-tool` error envelope."
   (into {} (map (juxt :name :handler)) tools))
 
+(def tool-names
+  "Ordered vector of every registered tool name — the catalogue an agent
+  sees via `tools/list`, in the same authoring order as `tools`. The
+  dispatcher in `tools.cljs` folds this into the `:unknown-tool` error
+  `:hint` so a model that typo'd a name (or called a removed alias) can
+  see the live catalogue and recover without a round-trip."
+  (mapv :name tools))
+
 (def ^:private cacheable-set
   "Materialised set of tool names whose `:cacheable?` is truthy.
   Built once at load time so `cacheable?` is an O(1) membership test."

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -1232,14 +1232,15 @@
 
    ;; ---------- pipeline: unknown tool ------------------------------------
    {:fixture/id    :pipeline/unknown-tool
-    :fixture/doc   "invoke against a name not in the registry returns :unknown-tool error."
+    :fixture/doc   "invoke against a name not in the registry returns :unknown-tool error carrying a recovery :hint + the :available-tools catalogue (rf2-tkmik)."
     :fixture/tool  "no-such-tool"
     :fixture/args  {}
     :fixture/eval-script
     [[:default nil]]
     :fixture/expect
     {:isError? true
-     :reason :unknown-tool}}])
+     :reason :unknown-tool
+     :edn-contains-keys #{:hint :available-tools}}}])
 
 ;; ---------------------------------------------------------------------------
 ;; Cache reset between fixtures — `cache` is module-level state shared

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
@@ -415,10 +415,35 @@
         (.then (fn [result]
                  (is (true? (j/get result :isError)))
                  (let [v (extract-edn result)]
+                   ;; Historical shape preserved (additive — rf2-tkmik).
+                   (is (false? (:ok? v)))
                    (is (= :unknown-tool (:reason v)))
-                   (is (= "no-such-tool" (:tool v))))
+                   (is (= "no-such-tool" (:tool v)))
+                   ;; Recovery affordances: a :hint pointing at tools/list
+                   ;; and the live catalogue, matching the surface's
+                   ;; honest-error standard (rf2-tkmik).
+                   (is (string? (:hint v)))
+                   (is (re-find #"tools/list" (:hint v))
+                       "hint must point the agent at tools/list to recover")
+                   (is (vector? (:available-tools v)))
+                   (is (some #{"snapshot"} (:available-tools v))
+                       ":available-tools carries the real catalogue"))
                  (is (zero? (cache/size))
                      "unknown-tool errors do not touch the cache")
+                 (done))))))
+
+(deftest unknown-tool-hint-offers-nearest-match
+  ;; A near-miss typo of a real tool name surfaces a :did-you-mean
+  ;; pointer (rf2-tkmik) so a model can self-correct without a round-trip.
+  (async done
+    (-> (tools/invoke nil "snapsho" (args-js {}) nil)
+        (.then (fn [result]
+                 (let [v (extract-edn result)]
+                   (is (= :unknown-tool (:reason v)))
+                   (is (= "snapshot" (:did-you-mean v))
+                       "near typo `snapsho` suggests `snapshot`")
+                   (is (re-find #"did you mean" (:hint v))
+                       "hint inlines the nearest-match suggestion"))
                  (done))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The `:unknown-tool` error envelope (emitted when a `tools/call` names a tool absent from the registry — a typo, or a removed alias like the pre-rf2-4y595 `registry-list`) returned only `{:ok? false :reason :unknown-tool :tool name}` — no `:hint`, no pointer at `tools/list`. Every *other* `:ok? false` envelope on this surface carries a recovery-shaped `:hint` (cache-hit hint, roots-discovery hints, server port hints). A model that typod a name hit a dead end.

This adds, **additively** (the historical shape is preserved):

- `:hint` — a string of the form: unknown tool NAME; did you mean NEAREST? call tools/list to see the available tools. Matches the established `:hint` convention (cache.cljs:90/249, roots_discovery.cljs:233/241/248, server.cljs:258).
- `:available-tools` — the live catalogue (registry order), so the agent can recover without a round-trip.
- `:did-you-mean` — a nearest-name suggestion via a cheap edit-distance over the ~25-name catalogue, computed only on the cold error path. Present only when within a small threshold (avoids actively-misleading suggestions).

`registry` gains a `tool-names` derived view as the single source for the catalogue. Spec 003-Tool-Catalogue documents the new envelope shape under the recognition-rules section.

## Quality gates

- `pair-mcp npm test` (shadow-cljs :server-test — the canonical entry-point; `clojure -M:test` routes through it): **748 tests, 2174 assertions, 0 failures, 0 errors**. Includes the conformance corpus + the two new `invoke_test` cases.
- `npm run test:mcp-conformance`: **ALL MCP-CONFORMANCE GATES GREEN** (6/6 stages; pair-mcp end-to-end + wire-vocab 49 tests/628 assertions 0 failures). The `:pipeline/unknown-tool` conformance fixture was updated to require `:hint` + `:available-tools` via `:edn-contains-keys` — **conformance fixture changed**.
- `clj-kondo` on the 4 changed cljs files: **0 errors**, 1 warning (`error?` unused private var) — **pre-existing in HEAD**, not introduced here.

## Tests (failing-before / passing-after)

- `invoke_test/unknown-tool-flows-through-pipeline-as-error` extended: asserts `:ok? false` shape preserved AND `:hint` points at `tools/list` AND `:available-tools` carries the real catalogue.
- `invoke_test/unknown-tool-hint-offers-nearest-match` (new): a `snapsho` typo surfaces `:did-you-mean "snapshot"`.
- conformance `:pipeline/unknown-tool` fixture now requires `#{:hint :available-tools}`.

Closes rf2-tkmik.