### PR TITLE
feat(core): feature-inspection front-porch — features/feature-loaded?/require-feature! + artefact-error-carries-require (rf2-3nbl5.5 G5)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -41,6 +41,7 @@
             [re-frame.privacy :as privacy]
             [re-frame.spec :as spec]
             [re-frame.late-bind :as late-bind]
+            [re-frame.features :as features]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]
@@ -1633,3 +1634,41 @@
                      :received p
                      :recovery :no-recovery
                      :reason   "rf/init-platform takes the platform keyword directly — :server or :client per Spec 011 §Effect handling on the server."}))))
+
+;; ---- feature inspection (rf2-3nbl5.5, API-governance G5) ------------------
+;;
+;; Front-porch for the optional-feature inventory: which `day8/re-frame2-
+;; <feature>` artefacts are on the classpath, and the exact copy-pasteable
+;; coordinate to add when one is missing. These three fns SHIP to
+;; production (runtime queries, not instrumentation — NOT elided). The
+;; feature→coordinate mapping is STATIC DATA in the always-loaded
+;; `re-frame.features` facade ns, never a live require into the optional
+;; impls (which would pull every optional namespace into every production
+;; bundle and break bundle-isolation). Per spec/API.md §Feature inspection
+;; and Conventions §Facade re-export, artefact require.
+
+(def ^{:doc "Return a map of every optional feature keyword to its
+  inspection entry — static coordinate data (`:maven` / `:require` /
+  `:spec`) merged with the live `:loaded?` status. Ships to production
+  (NOT elided). Per spec/API.md §Feature inspection."
+       :arglists '([])}
+  features features/features)
+
+(def ^{:doc "Return `true` when the optional feature's implementation
+  artefact is on the classpath, `false` otherwise (incl. an unknown
+  feature keyword). Detection is a pure keyword lookup in the always-
+  loaded late-bind hooks atom — no require into the optional namespace.
+  Known features: `:schemas` `:machines` `:routing` `:flows` `:http`
+  `:ssr` `:epoch`. Ships to production (NOT elided). Per spec/API.md
+  §Feature inspection."
+       :arglists '([feature])}
+  feature-loaded? features/feature-loaded?)
+
+(def ^{:doc "Assert the optional feature is loaded — returns `true`, or
+  throws `:rf.error/feature-not-loaded` carrying the EXACT copy-pasteable
+  Maven coordinate + require form when the impl artefact is absent (an
+  unknown feature keyword throws `:rf.error/unknown-feature`). Use as a
+  self-explaining early guard before a feature-dependent code path.
+  Ships to production (NOT elided). Per spec/API.md §Feature inspection."
+       :arglists '([feature])}
+  require-feature! features/require-feature!)

--- a/implementation/core/src/re_frame/features.cljc
+++ b/implementation/core/src/re_frame/features.cljc
@@ -1,0 +1,207 @@
+(ns re-frame.features
+  "Feature-inspection front-porch (rf2-3nbl5.5, API-governance G5).
+
+  re-frame2's optional capabilities ship as separate Maven artefacts
+  (`day8/re-frame2-<feature>`) whose implementation namespaces core
+  reaches through the [late-bind hook registry](late_bind.cljc) at call
+  time — see [Conventions §Facade re-export, artefact require](../../../../../spec/Conventions.md#facade-re-export-artefact-require).
+  The upside is bundle-isolation: an app that omits a feature does not
+  carry its code. The downside the front-porch closes: the late-binding
+  is invisible — a developer who forgets to `:require` the impl artefact
+  calls a re-exported fn that *exists* and is met with an opaque
+  artefact-missing error.
+
+  This ns surfaces the optional-feature inventory so the binding is
+  self-explaining:
+
+    `(features)`              — the optional features + their `loaded?`
+                                status, as a map.
+    `(feature-loaded? :epoch)` — boolean: is the feature's impl artefact
+                                on the classpath?
+    `(require-feature! :epoch)` — assert a feature is loaded; throw the
+                                EXACT copy-pasteable Maven coordinate +
+                                require form when it isn't.
+
+  ## These three fns SHIP to production
+
+  They are runtime queries, NOT dev-time instrumentation, so they are
+  deliberately NOT gated on `interop/debug-enabled?` and do NOT elide
+  under `:advanced` + `goog.DEBUG=false`. A production caller may
+  legitimately probe `(feature-loaded? :routing)` before taking a
+  routing-dependent code path.
+
+  ## The coordinate table is STATIC DATA — never a live require
+
+  `feature-registry` is a plain data table mapping each feature keyword
+  to its Maven coordinate, its app-boot require namespace, and a single
+  representative late-bind `:probe-key` the impl publishes at ns-load.
+  It is HARD-CONSTRAINED to be static data living entirely in this
+  always-loaded facade ns: it MUST NOT `:require` any optional impl
+  namespace. A live require would create a hard facade→optionals edge
+  that pulls epoch / machines / schemas / flows / routing / http / ssr
+  into EVERY production bundle, breaking the bundle-isolation contract.
+
+  `feature-loaded?` therefore detects presence by a pure keyword lookup
+  in the always-loaded `late-bind/hooks` atom — `(some? (get-fn
+  probe-key))` — which the impl artefact populates from its own ns-load.
+  No reach into the optional namespace; just an atom read.
+
+  The coordinate strings here are the single source of truth the per-
+  feature `re-frame.core-<feature>` wrappers' `:reason` throws mirror
+  (via `late-bind/require-fn!`); every artefact-missing error in the
+  framework carries the same copy-pasteable require/coordinate this
+  table holds."
+  (:require [re-frame.late-bind :as late-bind]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def feature-registry
+  "Static coordinate table — one entry per optional feature artefact.
+
+  Plain data, NEVER a live `:require` into the optional impls (that would
+  pull every optional namespace into every production bundle and break
+  bundle-isolation — see the ns docstring). Each entry:
+
+    {:maven     Maven coordinate to add to deps    (string)
+     :require   namespace to require at app boot    (string)
+     :spec      owning spec topic                   (string, doc-only)
+     :probe-key a late-bind hook key the impl publishes at ns-load,
+                read to detect the artefact's presence without a
+                static require (keyword)}
+
+  The `:probe-key` for each feature is a stable, always-published hook —
+  the artefact registers it unconditionally from its ns-load `set-fn!` /
+  `set-fns!` block, so its presence in `late-bind/hooks` is a faithful
+  loaded?-signal. Renaming a probe key here without keeping it in step
+  with the producing artefact's publication would silently report a
+  loaded feature as absent; the keys are chosen from the feature's
+  registration surface (`reg-*`) precisely because those never go away."
+  {:schemas  {:maven     "day8/re-frame2-schemas"
+              :require   "re-frame.schemas"
+              :spec      "Spec 010 (Schemas)"
+              :probe-key :schemas/validate-app-schema!}
+   :machines {:maven     "day8/re-frame2-machines"
+              :require   "re-frame.machines"
+              :spec      "Spec 005 (State machines)"
+              :probe-key :machines/reg-machine}
+   :routing  {:maven     "day8/re-frame2-routing"
+              :require   "re-frame.routing"
+              :spec      "Spec 012 (Routing)"
+              :probe-key :routing/reg-route}
+   :flows    {:maven     "day8/re-frame2-flows"
+              :require   "re-frame.flows"
+              :spec      "Spec 013 (Flows)"
+              :probe-key :flows/reg-flow}
+   :http     {:maven     "day8/re-frame2-http"
+              :require   "re-frame.http-managed"
+              :spec      "Spec 014 (Managed HTTP)"
+              :probe-key :http/abort-on-actor-destroy}
+   :ssr      {:maven     "day8/re-frame2-ssr"
+              :require   "re-frame.ssr"
+              :spec      "Spec 011 (SSR & hydration)"
+              :probe-key :ssr/render-to-string}
+   :epoch    {:maven     "day8/re-frame2-epoch"
+              :require   "re-frame.epoch"
+              :spec      "Tool-Pair (Time-travel / epoch)"
+              :probe-key :epoch/settle!}})
+
+(defn feature-loaded?
+  "Return `true` when the optional feature `feature`'s implementation
+  artefact is on the classpath, `false` otherwise (including when
+  `feature` is not a known optional feature keyword).
+
+  Detection is a pure keyword lookup in the always-loaded
+  `late-bind/hooks` atom against the feature's representative
+  `:probe-key` — the artefact publishes that key from its own ns-load,
+  so `(some? (late-bind/get-fn probe-key))` faithfully signals presence
+  WITHOUT a static require into the optional namespace (which would
+  break bundle-isolation). Ships to production — NOT elided.
+
+  Known feature keywords are the keys of `feature-registry`: `:schemas`,
+  `:machines`, `:routing`, `:flows`, `:http`, `:ssr`, `:epoch`. Per
+  spec/API.md §Feature inspection."
+  [feature]
+  (if-let [{:keys [probe-key]} (get feature-registry feature)]
+    (some? (late-bind/get-fn probe-key))
+    false))
+
+(defn features
+  "Return a map of every optional feature keyword to its inspection
+  entry: the feature's static coordinate data (`:maven` / `:require` /
+  `:spec`) merged with its live `:loaded?` status.
+
+      (rf/features)
+      ;=> {:epoch {:maven \"day8/re-frame2-epoch\"
+      ;            :require \"re-frame.epoch\"
+      ;            :spec \"Tool-Pair (Time-travel / epoch)\"
+      ;            :loaded? true}
+      ;    :routing {... :loaded? false}
+      ;    ...}
+
+  The `:probe-key` is internal plumbing and is dropped from the public
+  shape. Ships to production — NOT elided. Per spec/API.md §Feature
+  inspection."
+  []
+  (reduce-kv
+    (fn [acc feature {:keys [maven require spec]}]
+      (assoc acc feature
+             {:maven    maven
+              :require  require
+              :spec     spec
+              :loaded?  (feature-loaded? feature)}))
+    {}
+    feature-registry))
+
+(defn require-feature!
+  "Assert the optional feature `feature` is loaded. Returns `true` when
+  the feature's implementation artefact is on the classpath; throws a
+  structured `:rf.error/feature-not-loaded` ex-info carrying the EXACT
+  copy-pasteable Maven coordinate + require form when it is not.
+
+      (rf/require-feature! :epoch)
+      ;; absent =>
+      ;; ExceptionInfo :rf.error/feature-not-loaded
+      ;;   {:rf.error/id :rf.error/feature-not-loaded
+      ;;    :where 'rf/require-feature!
+      ;;    :feature :epoch
+      ;;    :maven \"day8/re-frame2-epoch\"
+      ;;    :require-ns \"re-frame.epoch\"
+      ;;    :recovery :no-recovery
+      ;;    :reason \"The :epoch feature ... add day8/re-frame2-epoch to
+      ;;             deps and (require 're-frame.epoch) at app boot.\"}
+
+  Use as an early, self-explaining guard at the top of code that depends
+  on an optional feature, so the failure names the fix rather than
+  surfacing an opaque late-bind miss deep in a call chain. An unknown
+  feature keyword throws `:rf.error/unknown-feature` listing the known
+  set. Ships to production — NOT elided. Per spec/API.md §Feature
+  inspection."
+  [feature]
+  (let [entry (get feature-registry feature)]
+    (cond
+      (nil? entry)
+      (throw (ex-info ":rf.error/unknown-feature"
+                      {:rf.error/id :rf.error/unknown-feature
+                       :where       'rf/require-feature!
+                       :feature     feature
+                       :known       (vec (sort (keys feature-registry)))
+                       :recovery    :no-recovery
+                       :reason      (str feature " is not a known optional feature. "
+                                         "Known features: "
+                                         (vec (sort (keys feature-registry))) ".")}))
+
+      (feature-loaded? feature)
+      true
+
+      :else
+      (let [{:keys [maven require]} entry]
+        (throw (ex-info ":rf.error/feature-not-loaded"
+                        {:rf.error/id :rf.error/feature-not-loaded
+                         :where       'rf/require-feature!
+                         :feature     feature
+                         :maven       maven
+                         :require-ns  require
+                         :recovery    :no-recovery
+                         :reason      (str "The " feature " feature's implementation artefact "
+                                           "is not on the classpath. Add " maven
+                                           " to deps and (require '" require ") at app boot.")}))))))

--- a/implementation/core/test/re_frame/features_cljs_test.cljc
+++ b/implementation/core/test/re_frame/features_cljs_test.cljc
@@ -1,0 +1,135 @@
+(ns re-frame.features-cljs-test
+  "Regression coverage for the feature-inspection front-porch
+  (rf2-3nbl5.5, API-governance G5):
+
+    (rf/features)               — lists every optional feature + status
+    (rf/feature-loaded? :epoch) — true/false per loaded / absent feature
+    (rf/require-feature! :epoch) — no-op when present; throws the exact
+                                  copy-pasteable coordinate when absent
+
+  The in-tree test build loads all seven per-feature artefacts (see
+  implementation/core/deps.edn `:test` extra-deps), so every probe key is
+  populated at test time. We simulate an ABSENT feature by flipping its
+  representative late-bind probe key to nil in a try/finally — the same
+  technique re-frame.interop-late-bind-cljs-test uses.
+
+  Named `*-cljs-test` so the shadow-cljs `:node-test` build (ns-regexp
+  `cljs-test$`) discovers it; the `-test` suffix also satisfies the JVM
+  cognitect test-runner, so this one `.cljc` file runs on both runtimes."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [re-frame.features :as features]
+            [re-frame.late-bind :as late-bind]))
+
+(defn- with-probe-absent
+  "Run `f` with `feature`'s representative late-bind probe key
+  temporarily set to nil (simulating an artefact that was never
+  required). Restores the original value afterwards (success or throw)."
+  [feature f]
+  (let [probe-key (get-in features/feature-registry [feature :probe-key])
+        original  (late-bind/get-fn probe-key)]
+    (try
+      (late-bind/set-fn! probe-key nil)
+      (f)
+      (finally
+        (late-bind/set-fn! probe-key original)))))
+
+;; ---- feature-loaded? ------------------------------------------------------
+
+(deftest feature-loaded?-true-when-artefact-present
+  (testing "every per-feature artefact is loaded in the in-tree test build"
+    (doseq [feature (keys features/feature-registry)]
+      (is (true? (features/feature-loaded? feature))
+          (str feature " probe key should be populated in the test build")))))
+
+(deftest feature-loaded?-false-when-artefact-absent
+  (testing "flipping a feature's probe key to nil reports it as not loaded"
+    (with-probe-absent :epoch
+      (fn []
+        (is (false? (features/feature-loaded? :epoch))
+            "absent probe key => feature-loaded? false")))
+    (testing "the flip is isolated — other features stay loaded"
+      (is (true? (features/feature-loaded? :schemas))))))
+
+(deftest feature-loaded?-false-for-unknown-feature
+  (testing "an unknown feature keyword is reported as not loaded, no throw"
+    (is (false? (features/feature-loaded? :not-a-feature)))
+    (is (false? (features/feature-loaded? nil)))))
+
+;; ---- features -------------------------------------------------------------
+
+(deftest features-lists-every-optional-feature-with-status
+  (testing "features returns one entry per registry feature, carrying the
+            static coordinate data + live :loaded? status"
+    (let [m (features/features)]
+      (is (= (set (keys features/feature-registry)) (set (keys m)))
+          "exactly the registry's feature keys")
+      (doseq [[feature entry] m]
+        (is (= #{:maven :require :spec :loaded?} (set (keys entry)))
+            (str feature " entry shape — coordinate data + :loaded?, no :probe-key leak"))
+        (is (string? (:maven entry)))
+        (is (string? (:require entry)))
+        (is (boolean? (:loaded? entry))))
+      (is (true? (get-in m [:epoch :loaded?]))
+          "epoch loaded in the in-tree build")
+      (is (= "day8/re-frame2-epoch" (get-in m [:epoch :maven])))
+      (is (= "re-frame.epoch" (get-in m [:epoch :require]))))))
+
+(deftest features-reflects-absent-feature-status
+  (testing "features :loaded? tracks the live probe state"
+    (with-probe-absent :routing
+      (fn []
+        (is (false? (get-in (features/features) [:routing :loaded?]))
+            "routing reports :loaded? false while its probe is nil")
+        (is (= "day8/re-frame2-routing" (get-in (features/features) [:routing :maven]))
+            "coordinate is static — present regardless of loaded? status")))))
+
+;; ---- require-feature! -----------------------------------------------------
+
+(deftest require-feature!-no-op-when-present
+  (testing "require-feature! returns true when the feature is loaded"
+    (is (true? (features/require-feature! :epoch)))
+    (is (true? (features/require-feature! :schemas)))))
+
+(deftest require-feature!-throws-exact-coordinate-when-absent
+  (testing "require-feature! throws :rf.error/feature-not-loaded with the
+            exact copy-pasteable Maven coordinate + require form"
+    (with-probe-absent :epoch
+      (fn []
+        (let [ex   (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                                (features/require-feature! :epoch)))
+              data (ex-data ex)]
+          (is (= :rf.error/feature-not-loaded (:rf.error/id data)))
+          (is (= :epoch (:feature data)))
+          (is (= "day8/re-frame2-epoch" (:maven data))
+              "exact Maven coordinate to add to deps")
+          (is (= "re-frame.epoch" (:require-ns data))
+              "exact namespace to require at boot")
+          (is (= :no-recovery (:recovery data)))
+          (let [reason (:reason data)]
+            (is (str/includes? reason "day8/re-frame2-epoch")
+                "reason carries the copy-pasteable Maven coordinate")
+            (is (str/includes? reason "re-frame.epoch")
+                "reason carries the copy-pasteable require namespace")))))))
+
+(deftest require-feature!-throws-unknown-feature
+  (testing "require-feature! on an unknown keyword throws :rf.error/unknown-feature
+            listing the known set"
+    (let [ex   (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                            (features/require-feature! :not-a-feature)))
+          data (ex-data ex)]
+      (is (= :rf.error/unknown-feature (:rf.error/id data)))
+      (is (= :not-a-feature (:feature data)))
+      (is (contains? (set (:known data)) :epoch)
+          ":known lists the registry features"))))
+
+;; ---- bundle-isolation invariant (static-data, not a live require) ---------
+
+(deftest feature-registry-is-static-data
+  (testing "the coordinate table is plain data — every value is a static
+            map of strings + a probe keyword, no fn / artefact reach-in"
+    (doseq [[feature entry] features/feature-registry]
+      (is (string? (:maven entry)) (str feature " :maven is a static string"))
+      (is (string? (:require entry)) (str feature " :require is a static string"))
+      (is (keyword? (:probe-key entry)) (str feature " :probe-key is a static keyword")))))

--- a/spec/API.md
+++ b/spec/API.md
@@ -697,6 +697,24 @@ Reserved fx-ids for runtime flow management via `:fx`:
 
 ---
 
+## Feature inspection
+
+re-frame2's optional capabilities ship as separate Maven artefacts (`day8/re-frame2-<feature>`) whose implementation namespaces core reaches through the late-bind hook registry at call time (per [Conventions §Facade re-export, artefact require](Conventions.md#facade-re-export-artefact-require)). The upside is bundle-isolation — an app that omits a feature does not carry its code. The downside this front-porch closes: the late-binding is otherwise invisible, so a developer who forgets to `:require` the impl artefact calls a re-exported fn that *exists* and is met with an opaque artefact-missing error. These three surfaces make the optional-feature inventory self-explaining.
+
+The known optional features are `:schemas`, `:machines`, `:routing`, `:flows`, `:http`, `:ssr`, `:epoch` (the closed per-feature split set per [Conventions §Artefact tiers](Conventions.md#artefact-tiers)).
+
+**These three fns ship to production.** They are runtime queries, not dev-time instrumentation, so — unlike the trace / epoch surfaces — they are NOT gated on `interop/debug-enabled?` and do NOT elide under `:advanced` + `goog.DEBUG=false`. A production caller may legitimately probe `(rf/feature-loaded? :routing)` before taking a routing-dependent path. The feature→coordinate mapping is **static data in the always-loaded `re-frame.core` facade** (a plain table of `{:feature {:maven … :require … :spec …}}` strings), never a live `:require` reaching into the optional impl namespaces — a live reach-in would create a hard facade→optionals reference that pulls every optional artefact into every production bundle, breaking bundle-isolation. `feature-loaded?` detects presence by a pure keyword lookup in the always-loaded late-bind hooks atom against a representative key the impl publishes at ns-load — no reach into the optional namespace.
+
+| API | M/Fn | Signature | Status | Spec |
+|---|---|---|---|---|
+| `features` | Fn | `(features)` → map of every optional feature keyword to its inspection entry: the static coordinate data (`:maven` / `:require` / `:spec`) merged with the live `:loaded?` boolean. E.g. `{:epoch {:maven "day8/re-frame2-epoch" :require "re-frame.epoch" :spec "Tool-Pair (Time-travel / epoch)" :loaded? true} …}`. Ships to production (NOT elided). | v1 | — |
+| `feature-loaded?` | Fn | `(feature-loaded? feature)` → `true` when the feature's impl artefact is on the classpath, `false` otherwise (including for an unknown feature keyword). Pure keyword lookup against the always-loaded late-bind hooks atom — no require into the optional namespace. Ships to production (NOT elided). | v1 | — |
+| `require-feature!` | Fn | `(require-feature! feature)` → `true` when the feature is loaded; otherwise throws `:rf.error/feature-not-loaded` carrying the EXACT copy-pasteable Maven coordinate (`:maven`) + require namespace (`:require-ns`) and a `:reason` string naming both (an unknown feature keyword throws `:rf.error/unknown-feature` with the `:known` set). Use as a self-explaining early guard at the top of feature-dependent code. Ships to production (NOT elided). | v1 | — |
+
+> **Artefact-missing errors carry the require.** This front-porch is paired with a hard rule: *every* artefact-missing error in the framework — including the existing late-bind facade throws (`:rf.error/<feature>-artefact-missing`, raised via `re-frame.late-bind/require-fn!` from the `re-frame.core-<feature>` wrappers) — carries the exact copy-pasteable Maven coordinate and the namespace to require at app boot in its `:reason` slot. The named pattern is documented once at [Conventions §Facade re-export, artefact require](Conventions.md#facade-re-export-artefact-require).
+
+---
+
 ## Configure keys
 
 Runtime configuration is uniformly via `(rf/configure <key> <opts>)`. Every framework-owned key is enumerated here. Keys are plural-noun-shaped; opts are an open map of per-key settings.

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -768,13 +768,31 @@ The independence rule applies to the per-adapter tier too: adapters depend on co
 
 ### Optional-artefact wrapper convention
 
+<a id="facade-re-export-artefact-require"></a>
+
+**The pattern, named — *facade re-export, artefact require*.** This is re-frame2's optional-capability shape: the public-API surface is **re-exported from the always-loaded facade** (`re-frame.core`), but each surface's **implementation lives in a separate, optionally-present Maven artefact** (`day8/re-frame2-<feature>`) that the facade reaches only at call time through the late-bind hook table. The facade carries the name and the contract; the artefact carries the code. The single-import ergonomics of a monolith are preserved while the bundle-isolation of a modular split is kept — but the binding is invisible at the call site, so the pattern carries two paired obligations (the self-explaining front-porch and the require-carrying error, both below) that make the invisibility safe.
+
 Each optional-artefact wrapper lives in core under `re-frame.core-<feature>` (e.g. `re-frame.core-routing`, `re-frame.core-flows`). The wrapper publishes the public-API fns that consumers reach via `re-frame.core` re-exports, but the **implementation** of each fn lives in a separate Maven artefact (`day8/re-frame2-<feature>`).
 
-Core MUST NOT statically `:require` the producing namespace — that would pull the feature's implementation onto every consumer's classpath even when no feature surface is used. Each wrapper fn instead looks the producing fn up through the [late-bind hook table](#) at call time, which the producing artefact populates from its own ns-load.
+Core MUST NOT statically `:require` the producing namespace — that would pull the feature's implementation onto every consumer's classpath even when no feature surface is used. Each wrapper fn instead looks the producing fn up through the [late-bind hook table](../implementation/core/src/re_frame/late_bind/directory.cljc) at call time, which the producing artefact populates from its own ns-load.
 
 The single-import contract is preserved: users continue to write `rf/reg-flow` after `(:require [re-frame.core :as rf])` — the wrapper ns is reached via `re-frame.core`'s re-export. When the producing artefact is absent the wrapper raises a documented `:rf.error/<feature>-artefact-missing` ex-info with `:where 'rf/<surface>`, `:recovery :no-recovery`, and a `:reason` string naming the artefact and the ns to require at boot.
 
 The wrappers live in sibling namespaces rather than in `core.cljc` itself so `core.cljc` stays free of optional-artefact glue. The file naming uses `core_<feature>` rather than `core/<feature>` because CLJS goog.provide for `re-frame.core` overwrites its parent object.
+
+#### Obligation 1 — every artefact-missing error carries the require
+
+The late-binding is invisible at the call site: a developer who forgets to `:require` the impl artefact calls a re-exported fn that *exists*. An opaque "no such hook" failure would leave them stranded. So the pattern is HARD-CONSTRAINED: **every artefact-missing error MUST carry the exact copy-pasteable Maven coordinate and the namespace to require at app boot.** The CLJS reference centralises this in [`re-frame.late-bind/require-fn!`](../implementation/core/src/re_frame/late_bind.cljc) — the single throw skeleton the `re-frame.core-<feature>` wrappers route through. Its `:reason` slot reads `"<where> requires <maven> on the classpath; add it to deps and require <require-ns> at app boot."`, and its ex-data carries `:rf.error/id`, `:where`, `:recovery :no-recovery`. A port MUST mirror this: an artefact-missing error that does not name its fix is a contract break, not a stylistic difference.
+
+#### Obligation 2 — the feature-inspection front-porch
+
+The inverse query — *which* optional features are present, and what to add for the absent ones — is exposed as three production-shipping `re-frame.core` surfaces (per [API §Feature inspection](API.md#feature-inspection)):
+
+- `(rf/features)` → a map of every optional feature keyword to its coordinate data (`:maven` / `:require` / `:spec`) merged with a live `:loaded?` boolean.
+- `(rf/feature-loaded? :epoch)` → boolean presence check.
+- `(rf/require-feature! :epoch)` → asserts presence, throwing the exact copy-pasteable coordinate when absent (an early, self-explaining guard).
+
+**Static-data hard constraint (the production implication).** The feature→coordinate mapping these surfaces read MUST be **static data in the always-loaded facade** — a plain table of `{:feature {:maven … :require … …}}` strings. It MUST NOT `:require` (live-reach) into the optional impl namespaces. A live reach-in would create exactly the hard facade→optionals reference the whole pattern exists to avoid: it would pull every optional artefact (epoch, machines, schemas, flows, routing, http, ssr) onto every production classpath and break [§Bundle-isolation conformance](#bundle-isolation-conformance). Presence is therefore detected without reaching in — `feature-loaded?` does a pure keyword lookup in the always-loaded late-bind hooks atom against a representative key the impl publishes at its own ns-load. These three fns ship to production (runtime queries, not instrumentation — NOT elided), and the CLJS reference proves the static-table claim through the bundle-isolation, elision, and perf-bundle gates.
 
 ### Late-bind hook key grammar
 


### PR DESCRIPTION
## What

Ships the front-porch feature-inspection API (rf2-3nbl5.5, API-governance G5, Mike-ruled **A**):

- `(rf/features)` → map of every optional feature keyword → static coordinate data (`:maven` / `:require` / `:spec`) merged with live `:loaded?`.
- `(rf/feature-loaded? :epoch)` → boolean presence check.
- `(rf/require-feature! :epoch)` → `true` when loaded; throws `:rf.error/feature-not-loaded` carrying the **exact copy-pasteable** `:maven` + `:require-ns` (and a `:reason` naming both) when absent. Unknown keyword → `:rf.error/unknown-feature` with the `:known` set.

New always-loaded `re-frame.features` ns; three thin re-exports from the `re-frame.core` facade.

## Static-coordinate-table (the hard bundle-isolation constraint)

`feature-registry` is **plain static data** in the always-loaded facade — `{:feature {:maven "day8/re-frame2-…" :require "re-frame.…" :probe-key :feat/key}}`. It does **NOT** `:require` any optional impl namespace. `feature-loaded?` detects presence by `(some? (late-bind/get-fn probe-key))` — a pure keyword lookup in the always-loaded `late-bind/hooks` atom that the impl populates at its own ns-load. No facade→optionals reference, so nothing is pulled into production bundles. The bundle-isolation gate below proves it.

These three fns **ship to production** (runtime queries, not instrumentation — NOT gated on `debug-enabled?`, NOT elided). The elision gate (40/40 unchanged) proves they are not wrongly elided.

The existing artefact-missing facade errors already carry the copy-pasteable require via `late-bind/require-fn!`; the named pattern is now documented once in Conventions.

## Docs

- **spec/API.md: only the new §Feature inspection added; other rows untouched (1i168/7kii2 queued on the same hot-zone).**
- spec/Conventions.md: names the pattern *facade re-export, artefact require* (explicit `<a id>` keeps the existing `#optional-artefact-wrapper-convention` inbound links valid) + its two obligations (require-carrying errors; the inspection front-porch + static-data hard constraint).

Public-surface rule: 3 new public fns, purely additive — existing consumers unaffected.

## Quality gates

- core `clojure -M:test`: **Ran 841 tests containing 3758 assertions. 0 failures, 0 errors.**
- `npm run test:cljs`: **Ran 5184 tests containing 17655 assertions. 0 failures, 0 errors.**
- `npm run test:bundle-isolation`: **PASS** — 17 artefact entries; 35 internal sentinels absent; 3 allow-list budgets ok (counter bundle clean — static table pulled NO optional in). uix-helix-reagent-free: PASS.
- `npm run test:elision`: **PASS** — production 40/40 absent; control 40/40 present (3 prod fns correctly NOT elided).
- `npm run test:perf-bundle`: **PASS** — off-count=0; on-count=12 (counter 444502 → 445315 chars).
- clj-kondo (changed files): `features.cljc` + test = **0 warnings, 0 errors**; `core.cljc` 18 warnings all pre-existing on origin/main (macro self-refs + DCE-bridge requires) — zero new.
- `scripts/check_doc_slugs.py`: **no broken links** (387 files).
- `mkdocs build --strict`: **built clean** (no WARNING/ERROR; both anchors resolve).

## Regression tests (`features_cljs_test.cljc`, runs JVM + node)

`feature-loaded?` true (loaded) / false (probe flipped nil) / false (unknown); `features` lists all 7 with status + no `:probe-key` leak + reflects absent status; `require-feature!` true when present, throws exact coordinate when absent, throws `:unknown-feature`; `feature-registry` is static data (all string/keyword values).

Closes rf2-3nbl5.5.