### PR TITLE
feat(schemas): schema implies validation — reg-app-schema ensures Malli, no more silent soft-pass (rf2-v96fh)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -99,11 +99,18 @@
   against `frame-id`. Matches the shape an app exercising both privacy
   defences would register."
   [frame-id]
+  ;; Both paths are `[:maybe ...]` with `:optional` leaves: the mixed
+  ;; cascade drives db states where each path is absent (`:seed`/`:inc`
+  ;; write only `:n`; `:login` writes only `:auth`; `:upload` only
+  ;; `:blob`). rf2-v96fh enforces every registered schema path on every
+  ;; commit, so a path that is legitimately absent in a given cascade
+  ;; step must validate as nil. The `:sensitive?` / `:large?` per-slot
+  ;; flags stay discoverable — the walker descends `:maybe` transparently.
   (rf/reg-app-schema [:auth]
-                     [:map [:password {:sensitive? true} :string]]
+                     [:maybe [:map [:password {:optional true :sensitive? true} :string]]]
                      {:frame frame-id})
   (rf/reg-app-schema [:blob]
-                     [:map [:payload {:large? true :hint "image"} :string]]
+                     [:maybe [:map [:payload {:optional true :large? true :hint "image"} :string]]]
                      {:frame frame-id})
   (rf/populate-sensitive-from-schemas! frame-id)
   (rf/populate-elision-from-schemas!   frame-id)

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -64,20 +64,29 @@
 
 (defn- install-sensitive-schema!
   "Register a `[:auth :password]` sensitive schema slot against
-  `frame-id` and force the elision registry population. Returns nil."
+  `frame-id` and force the elision registry population. Returns nil.
+
+  The `[:auth]` slot is `[:maybe ...]` and `:password` is `:optional`
+  because these privacy tests legitimately drive cascades where `:auth`
+  is absent (a non-auth event) or `:password` is cleared mid-cascade —
+  states that must pass validation (rf2-v96fh: schema implies validation
+  now enforces every registered path on every commit). The `:sensitive?`
+  flag stays discoverable: the walker descends `:maybe` transparently."
   [frame-id]
   (rf/reg-app-schema [:auth]
-                     [:map [:password {:sensitive? true} :string]]
+                     [:maybe [:map [:password {:optional true :sensitive? true} :string]]]
                      {:frame frame-id})
   (rf/populate-sensitive-from-schemas! frame-id)
   nil)
 
 (defn- install-large-schema!
   "Register a `[:blob :payload]` large schema slot against `frame-id`
-  and force the elision registry population."
+  and force the elision registry population. `[:blob]` is `[:maybe ...]`
+  / `:payload` `:optional` so cascades that never touch the blob path
+  pass validation (rf2-v96fh)."
   [frame-id]
   (rf/reg-app-schema [:blob]
-                     [:map [:payload {:large? true :hint "big"} :string]]
+                     [:maybe [:map [:payload {:optional true :large? true :hint "big"} :string]]]
                      {:frame frame-id})
   (rf/populate-elision-from-schemas! frame-id)
   nil)

--- a/implementation/routing/test/re_frame/route_link_test.clj
+++ b/implementation/routing/test/re_frame/route_link_test.clj
@@ -77,8 +77,10 @@
 
 (deftest route-link-href-with-query-and-fragment
   (testing ":query and :fragment are appended to the href"
+    ;; :q is optional so /search is reachable without a query (exercised by
+    ;; the empty-:fragment sub-case below); when present it must be a string.
     (rf/reg-route :route/search {:path  "/search"
-                                 :query [:map [:q :string]]})
+                                 :query [:map [:q {:optional true} :string]]})
 
     (let [[_ attrs] (routing/route-link-render-ssr
                      {:to    :route/search

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -20,11 +20,48 @@
   default validator delegates to Malli; apps drop Malli by registering
   a different fn (or `nil` for a hard no-op).
 
+  **Schema implies validation (rf2-v96fh).** Loading this artefact
+  `:require`s `re-frame.schemas.malli`, which publishes Malli's
+  `validate` / `explain` / `humanize` into the late-bind hook table at
+  ns-load time. The CLJS reference therefore validates against the
+  default Malli validator the moment a schema is registered — there is
+  no inert \"registered a schema but it silently validates nothing\"
+  state. (Pre-rf2-v96fh the adapter had to be required *separately* at
+  app boot; an app that forgot the require registered schemas that
+  soft-passed every value — a footgun where \"I registered a schema\"
+  did NOT imply \"it validates.\")
+
+  Because Malli is now wired by *the schemas artefact* (not by core),
+  bundle isolation is preserved at the artefact boundary: an app that
+  never `:require`s `re-frame.schemas` (the no-feature counter
+  reference app) pays nothing for Malli. An app that DOES use schemas
+  pays the Malli surface (~24 KB gzipped, Spec 010 §Bundle cost) — the
+  deliberate tradeoff Ruling A accepts so registration always implies
+  validation. Apps that want schemas-as-inert-data without the Malli
+  surface call `(set-schema-validator! nil)` at boot to disable every
+  validation site (Spec 010 §Worked example — installing a no-op
+  validator); note that under static CLJS compilation requiring the
+  artefact still loads Malli's body, so the nil opt-out disables
+  validation *behaviour* but does not remove Malli from the bundle —
+  the only Malli-free posture is not requiring the schemas artefact.
+
   Public façade over `re-frame.schemas.{validator,storage,walker,
   digest,validate}` — re-exports the symbols external consumers reach
   through (tests, `re-frame.core-schemas`, the late-bind hook table)
   and owns the late-bind hook publication."
   (:require [re-frame.late-bind :as late-bind]
+            ;; rf2-v96fh — schema implies validation. Requiring the
+            ;; schemas artefact pulls the Malli adapter so the default
+            ;; validator is LIVE (publishes `:schemas/malli-validate`
+            ;; etc. at ns-load); `reg-app-schema` then validates rather
+            ;; than soft-passing into a silent no-op. The adapter ns
+            ;; requires only `malli.core` + `malli.error` + late-bind —
+            ;; no cycle back to this facade. Malli becomes a dependency
+            ;; of the schemas artefact, NOT of core: an app that never
+            ;; requires `re-frame.schemas` stays Malli-free (Spec 010
+            ;; §Bundle cost; verified by the counter bundle-isolation
+            ;; gate). Loaded for its ns-load side effect only.
+            [re-frame.schemas.malli]
             [re-frame.schemas.digest :as digest]
             [re-frame.schemas.storage :as storage]
             [re-frame.schemas.validate :as validate]

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -48,10 +48,20 @@
   rf2-p7va substitute-validator pattern: the `re-frame.schemas.malli`
   adapter namespace publishes Malli's `validate` and `explain` into the
   late-bind hook table on ns-load. The default fns below consult the
-  table on every call. Apps opt in to Malli validation by requiring
-  `re-frame.schemas.malli` at app boot — the same pattern on both
-  runtimes (no JVM-vs-CLJS asymmetry). When the adapter ns is not
-  loaded the default fns soft-pass per Spec 010 §Recommended soft-pass."
+  table on every call.
+
+  Per rf2-v96fh (schema implies validation) the `re-frame.schemas`
+  facade now `:require`s `re-frame.schemas.malli` itself, so loading the
+  schemas artefact wires the Malli hooks automatically — the default
+  validator is LIVE the moment a schema is registered. The soft-pass
+  branch below (return `true` when `:schemas/malli-validate` is unbound)
+  is therefore the defensive fallback for two residual cases, NOT the
+  default state: (1) a non-Malli port / app that installed its own
+  validator via `set-schema-fns!` and never bound the Malli hook, and
+  (2) test harnesses that deliberately unbind the hook to exercise the
+  absent path. Per Spec 010 §Recommended soft-pass an unbound default
+  validator passes rather than failing, so a substitute-validator
+  app is never blocked by Malli's absence."
   (:require [re-frame.late-bind :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/implementation/schemas/test/re_frame/schemas_bundle_probe.cljs
+++ b/implementation/schemas/test/re_frame/schemas_bundle_probe.cljs
@@ -1,21 +1,35 @@
 (ns re-frame.schemas-bundle-probe
-  "Bundle-cost probe (rf2-fqbcy) — measures the gzipped impact of
-  requiring `re-frame.schemas` WITHOUT the Malli adapter, per Spec
-  010 §Bundle cost row 2 (`[re-frame.schemas]` required, no Malli).
+  "Bundle-cost probe (rf2-fqbcy) — measures the gzipped cost of
+  requiring `re-frame.schemas`, per Spec 010 §Bundle cost.
+
+  Per rf2-v96fh (schema implies validation) the `re-frame.schemas`
+  facade now `:require`s `re-frame.schemas.malli` itself, so this
+  probe — which requires ONLY `re-frame.schemas`, NOT the adapter —
+  nonetheless pulls Malli's validation surface into the bundle. That
+  is the deliberate Ruling-A tradeoff: requiring the schemas artefact
+  implies Malli is wired, so a registered schema always validates
+  rather than soft-passing into a silent no-op. There is no longer a
+  'schemas required, no Malli' bundle posture (the only Malli-free
+  posture is not requiring the schemas artefact at all — the no-feature
+  counter app, pinned by the counter bundle-isolation gate).
 
   The companion probe `re-frame.schemas-bundle-probe-malli` requires
-  the Malli adapter on top — the difference between the two bundles
-  is the Malli surface cost.
+  the adapter EXPLICITLY on top; under Ruling A the explicit require
+  is a no-op (the facade already loaded it), so the two bundles are now
+  the same size — `scripts/check-schemas-bundle.cjs` asserts that
+  equality as the schema-implies-validation regression guard (a revert
+  of the facade require would drop THIS probe back to the ~59 KB
+  Malli-free figure and break the equality).
 
   shadow-cljs build target `:schemas-bundle-probe` compiles this ns
   under `:advanced` + `goog.DEBUG=false`. scripts/check-schemas-bundle.cjs
   reads the bundle's gzipped size and asserts it sits within the
-  spec envelope (≤ 100 KB per the spec's 97.2 KB row + margin).
+  spec envelope.
 
   The probe namespace does NO runtime work — it exists only to root
   the schemas-artefact's dead-code-elimination graph so Closure
   retains the namespace's body. Each public symbol is touched once
-  to anchor it; the exported run! fn is the bundle's entry point."
+  to anchor it; the exported boot fn is the bundle's entry point."
   (:require [re-frame.core    :as rf]
             [re-frame.schemas :as schemas]))
 

--- a/implementation/schemas/test/re_frame/schemas_bundle_probe_malli.cljs
+++ b/implementation/schemas/test/re_frame/schemas_bundle_probe_malli.cljs
@@ -1,15 +1,26 @@
 (ns re-frame.schemas-bundle-probe-malli
-  "Bundle-cost probe with Malli adapter (rf2-fqbcy) — companion to
-  `re-frame.schemas-bundle-probe`. Per Spec 010 §Bundle cost row 3
-  (`[re-frame.schemas]` + `[malli.core]` required, no validation) —
-  measures the ~24 KB cost of pulling Malli into a bundle that
-  already requires the schemas surface.
+  "Bundle-cost probe with an EXPLICIT Malli adapter require (rf2-fqbcy)
+  — companion to `re-frame.schemas-bundle-probe`.
+
+  Per rf2-v96fh (schema implies validation) the `re-frame.schemas`
+  facade requires `re-frame.schemas.malli` itself, so the explicit
+  `[re-frame.schemas.malli]` require below is now redundant — the
+  adapter is already on the classpath by the time this ns's other
+  requires load. The two probe bundles are therefore the SAME size.
+
+  scripts/check-schemas-bundle.cjs asserts that equality (within a
+  small tolerance) as the schema-implies-validation regression guard:
+  if a future change reverts the facade's adapter require, the sibling
+  `schemas-bundle-probe` (which does NOT require the adapter
+  explicitly) would drop back to its ~59 KB Malli-free figure while
+  THIS probe stayed at ~91 KB — the equality assertion would then
+  fail, catching the regression. Pre-rf2-v96fh this probe was the
+  Malli-ON arm of a 'Malli strictly larger' delta guard; Ruling A made
+  Malli mandatory for any schemas consumer, so the delta collapsed to
+  zero by design and the guard inverted into the equality check.
 
   shadow-cljs build target `:schemas-bundle-probe-malli` compiles
-  this ns under `:advanced` + `goog.DEBUG=false`. The accompanying
-  CI gate (scripts/check-schemas-bundle.cjs) asserts the bundle's
-  gzipped size sits within the spec envelope (≤ 125 KB per the
-  spec's 120.8 KB row + margin)."
+  this ns under `:advanced` + `goog.DEBUG=false`."
   (:require [re-frame.core    :as rf]
             [re-frame.schemas :as schemas]
             [re-frame.schemas.malli]))

--- a/implementation/schemas/test/re_frame/schemas_implies_validation_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_implies_validation_test.clj
@@ -1,0 +1,111 @@
+(ns re-frame.schemas-implies-validation-test
+  "Regression tests for rf2-v96fh — \"schema implies validation\"
+  (Mike-ruled A).
+
+  ## The footgun this closes
+
+  Pre-rf2-v96fh, requiring `re-frame.schemas` did NOT wire the default
+  Malli validator. The CLJS reference's default validator delegates to
+  Malli via the late-bind hook `:schemas/malli-validate`, published by
+  the SEPARATE `re-frame.schemas.malli` adapter ns. An app that loaded
+  `re-frame.schemas` but FORGOT to also require `[re-frame.schemas.malli]`
+  registered schemas that then SILENTLY VALIDATED NOTHING — the default
+  validator soft-passed every value (Spec 010 §Recommended soft-pass).
+  \"I registered a schema\" did NOT imply \"it validates.\"
+
+  ## The fix (Ruling A)
+
+  The `re-frame.schemas` facade now `:require`s `re-frame.schemas.malli`
+  itself, so loading the schemas artefact wires Malli automatically.
+  Registering a schema therefore ALWAYS validates — the inert
+  \"registered but soft-passing\" state is gone.
+
+  ## What these tests assert (and how they would have FAILED before)
+
+  This namespace requires ONLY `re-frame.schemas` — deliberately NOT
+  `re-frame.schemas.malli`. That mirrors the footgun app: load the
+  schemas artefact, register a schema, never require the adapter.
+
+    1. `malli-hook-is-wired-by-requiring-the-facade` — the
+       `:schemas/malli-validate` hook is bound after requiring only the
+       facade. Pre-fix this hook was unbound (the adapter ns was never
+       loaded), so this assertion would FAIL.
+    2. `bad-write-to-registered-slot-validates` — a malformed app-db
+       commit to a slot with a registered schema fires
+       `:rf.error/schema-validation-failure`. Pre-fix the default
+       validator soft-passed and NO trace fired — this would FAIL.
+    3. `valid-write-passes` — a conforming commit fires no failure
+       trace (the validation is real, not a blanket reject).
+
+  Per the public-surface contract these are behavioural locks on the
+  artefact's load-time wiring, not on any private internals."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            ;; DELIBERATELY require ONLY the facade — NOT
+            ;; `re-frame.schemas.malli`. The whole point of rf2-v96fh is
+            ;; that requiring the facade is sufficient to wire Malli.
+            [re-frame.schemas]
+            [re-frame.schemas.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(defn- record-traces!
+  [listener-id]
+  (let [a (atom [])]
+    (rf/register-listener! listener-id (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- failures-of
+  [recorded]
+  (filterv #(= :rf.error/schema-validation-failure (:operation %))
+           @recorded))
+
+;; ---- the wiring is live by requiring the facade alone ---------------------
+
+(deftest malli-hook-is-wired-by-requiring-the-facade
+  (testing "Per rf2-v96fh: requiring `re-frame.schemas` (without
+            `re-frame.schemas.malli`) wires the default Malli validator —
+            the `:schemas/malli-validate` late-bind hook is bound. Pre-fix
+            the adapter ns was never loaded by the facade and this hook
+            was nil, so the default validator soft-passed."
+    (is (some? (late-bind/get-fn :schemas/malli-validate))
+        ":schemas/malli-validate is bound — the facade pulled the adapter")
+    (is (some? (late-bind/get-fn :schemas/malli-explain))
+        ":schemas/malli-explain is bound too")))
+
+;; ---- registering a schema implies validation ------------------------------
+
+(deftest bad-write-to-registered-slot-validates
+  (testing "Per rf2-v96fh: a malformed commit to a slot with a registered
+            schema fires :rf.error/schema-validation-failure — without any
+            explicit `re-frame.schemas.malli` require. Pre-fix this was a
+            silent no-op (the default validator soft-passed)."
+    (rf/reg-app-schema [:count] [:int])
+    (let [recorded (record-traces! ::bad-write)]
+      (with-redefs [interop/debug-enabled? true]
+        (rf/reg-event-db :count/break (fn [db _] (assoc db :count "not-an-int")))
+        ;; validate-app-schema! runs the registered app-db schema set over
+        ;; the supplied db value, exactly as the post-handler step does.
+        (re-frame.schemas/validate-app-schema! {:count "not-an-int"} :count/break))
+      (rf/unregister-listener! ::bad-write)
+      (let [violations (failures-of recorded)]
+        (is (= 1 (count violations))
+            "exactly one schema-validation-failure fired — schema implies validation")
+        (let [v (first violations)]
+          (is (= :app-db (-> v :tags :where)))
+          (is (= [:count] (-> v :tags :path)))
+          (is (= "not-an-int" (-> v :tags :value))))))))
+
+(deftest valid-write-passes
+  (testing "Per rf2-v96fh: a conforming commit fires no failure trace —
+            the validation is real (it accepts good values), not a blanket
+            reject."
+    (rf/reg-app-schema [:count] [:int])
+    (let [recorded (record-traces! ::good-write)]
+      (with-redefs [interop/debug-enabled? true]
+        (re-frame.schemas/validate-app-schema! {:count 7} :count/ok))
+      (rf/unregister-listener! ::good-write)
+      (is (empty? (failures-of recorded))
+          "no failure trace — the well-typed value conforms"))))

--- a/implementation/scripts/check-schemas-bundle.cjs
+++ b/implementation/scripts/check-schemas-bundle.cjs
@@ -2,28 +2,40 @@
 /*
  * Schemas-artefact bundle-cost gate (Spec 010 §Bundle cost, bead rf2-fqbcy).
  *
- * Spec 010 §Bundle cost (lines 567-606) catalogues the gzipped costs
- * of requiring `re-frame.schemas` against the baseline counter:
+ * Spec 010 §Bundle cost catalogues the gzipped cost of requiring
+ * `re-frame.schemas`. Per rf2-v96fh (schema implies validation) the
+ * `re-frame.schemas` facade now `:require`s `re-frame.schemas.malli`
+ * itself, so REQUIRING THE SCHEMAS ARTEFACT IMPLIES MALLI — there is no
+ * longer a 'schemas required, no Malli' bundle posture. A registered
+ * schema therefore always validates rather than soft-passing into a
+ * silent no-op. The only Malli-free posture is not requiring the
+ * schemas artefact at all (the no-feature counter app, pinned by the
+ * counter bundle-isolation gate — NOT this gate).
  *
- *   Baseline (no schemas, no Malli):                       91.7 KB
- *   `[re-frame.schemas]` required, no Malli:               97.2 KB
- *   `[re-frame.schemas]` + `[malli.core]` required:       120.8 KB
- *   Typical app: reg-app-schema + :spec on every reg-*:   121.5 KB
+ * This gate uses two probe builds:
  *
- * This gate uses two probe builds to assert the schemas surface stays
- * within band:
+ *   schemas-bundle-probe        — requires ONLY `re-frame.schemas`.
+ *                                 Under Ruling A the facade pulls the
+ *                                 Malli adapter, so this is the
+ *                                 canonical 'schemas surface (Malli
+ *                                 wired)' cost. Asserts ≤ 100 KB gzipped.
+ *   schemas-bundle-probe-malli  — requires `re-frame.schemas` AND the
+ *                                 adapter EXPLICITLY. Under Ruling A the
+ *                                 explicit require is redundant (the
+ *                                 facade already loaded it), so this
+ *                                 bundle is the SAME size. Asserts
+ *                                 ≤ 100 KB gzipped.
  *
- *   schemas-bundle-probe        — schemas required, NOT Malli.
- *                                 Asserts ≤ 100 KB gzipped (spec row 2
- *                                 + 3 KB headroom).
- *   schemas-bundle-probe-malli  — schemas + Malli adapter required.
- *                                 Asserts ≤ 125 KB gzipped (spec row 3
- *                                 + 5 KB headroom).
- *
- * Also asserts the Malli-on bundle is STRICTLY LARGER than the
- * Malli-off bundle (a regression that DCE-eliminated Malli would
- * silently turn the budget check into a vacuous "pass" — this guard
- * keeps the methodology honest).
+ * Schema-implies-validation regression guard (replaces the pre-rf2-v96fh
+ * 'Malli strictly larger' delta guard): the two bundles MUST be
+ * APPROXIMATELY EQUAL. Ruling A made Malli mandatory for any schemas
+ * consumer, so the explicit-require delta collapsed to ~0 by design. If
+ * a future change reverts the facade's adapter require, `schemas-bundle-
+ * probe` (no explicit adapter require) would drop back to its ~59 KB
+ * Malli-free figure while `schemas-bundle-probe-malli` stayed at ~91 KB
+ * — the equality assertion then fails, catching the regression and
+ * proving the facade still auto-wires Malli (i.e. schema still implies
+ * validation).
  *
  * Strategy: gzip every .js file under the bundle's output-dir and
  * sum the compressed sizes. Mirrors the methodology used by the
@@ -45,24 +57,25 @@ const report = createGateReporter();
 
 // ----- the schemas bundle-cost contract -------------------------------------
 
-// Each entry's `gzippedMaxBytes` is the spec's documented figure plus a
-// small headroom (3-5 KB) so non-deterministic compression variations
-// (zlib version, OS) don't trigger spurious fails. Tighten over time as
-// the figures stabilise — every figure below was anchored against the
-// spec text rather than current empirical runs to give the gate
-// regression-detection teeth from day one.
+// Per rf2-v96fh both probes pull Malli (the facade requires the
+// adapter), so both sit at the schemas-surface-with-Malli cost
+// (~91 KB gzipped empirically; the spec's older 120.8 KB row was a
+// conservative pre-Closure-tuning estimate). The ≤ 100 KB ceiling
+// leaves ~9 KB headroom over the empirical figure so non-deterministic
+// compression variations (zlib version, OS) don't trigger spurious
+// fails. Tighten over time as the figures stabilise.
 const BUNDLES = [
   {
     name:            'schemas-bundle-probe',
     bundleDir:       path.join(ROOT, 'out', 'schemas-bundle-probe'),
-    specRow:         'row 2 — [re-frame.schemas] required, no Malli (97.2 KB)',
-    gzippedMaxBytes: 100 * 1024,   // 100 KB (spec 97.2 KB + 2.8 KB headroom)
+    specRow:         '[re-frame.schemas] required ⇒ Malli wired (rf2-v96fh)',
+    gzippedMaxBytes: 100 * 1024,   // 100 KB (empirical ~91 KB + ~9 KB headroom)
   },
   {
     name:            'schemas-bundle-probe-malli',
     bundleDir:       path.join(ROOT, 'out', 'schemas-bundle-probe-malli'),
-    specRow:         'row 3 — [re-frame.schemas] + [malli.core] (120.8 KB)',
-    gzippedMaxBytes: 125 * 1024,   // 125 KB (spec 120.8 KB + 4.2 KB headroom)
+    specRow:         '[re-frame.schemas] + explicit [malli] (redundant, rf2-v96fh)',
+    gzippedMaxBytes: 100 * 1024,   // 100 KB (same surface as the sibling probe)
   },
 ];
 
@@ -120,30 +133,43 @@ function main() {
     }
   }
 
-  // Methodology guard — the Malli-on bundle MUST be strictly larger
-  // than the Malli-off bundle. If both end up the same size, Closure
-  // has DCE'd malli.core away (e.g. because the adapter ns no longer
-  // publishes the late-bind hooks at load time), and the +Malli gate
-  // becomes vacuous.
+  // Schema-implies-validation regression guard (rf2-v96fh) — replaces
+  // the pre-rf2-v96fh 'Malli-on strictly larger' delta guard. Under
+  // Ruling A the `re-frame.schemas` facade requires the Malli adapter
+  // itself, so the explicit `[re-frame.schemas.malli]` require in the
+  // `-malli` probe is redundant and both bundles carry the SAME Malli
+  // surface. They MUST therefore be APPROXIMATELY EQUAL.
+  //
+  // If a future change reverts the facade's adapter require,
+  // `schemas-bundle-probe` (no explicit adapter require) drops back to
+  // its ~59 KB Malli-free figure while `schemas-bundle-probe-malli`
+  // (explicit require) stays at ~91 KB — a ~32 KB gap that trips this
+  // guard, proving the facade no longer auto-wires Malli (i.e. schema
+  // no longer implies validation). The tolerance absorbs the few bytes
+  // of init-fn-name difference between the two probe namespaces.
   let methodologyOk = true;
   if (sizes['schemas-bundle-probe'] != null &&
       sizes['schemas-bundle-probe-malli'] != null) {
     const probe      = sizes['schemas-bundle-probe'];
     const probeMalli = sizes['schemas-bundle-probe-malli'];
-    const delta      = probeMalli - probe;
-    // Spec row 3 - row 2 = 23.6 KB.  Require ≥ 15 KB of growth to
-    // confirm Malli landed; below that, Closure DCE'd something.
-    const minDelta = 15 * 1024;
-    const ok = delta >= minDelta;
+    const delta      = Math.abs(probeMalli - probe);
+    // Equality tolerance. The two probes differ only by their init-fn
+    // names; the Malli surface is identical. 2 KB comfortably absorbs
+    // symbol-name noise while still catching the ~32 KB regression a
+    // reverted facade require would produce.
+    const maxDelta = 2 * 1024;
+    const ok = delta <= maxDelta;
     const tag = ok ? 'OK' : 'FAIL';
     report.detail('');
-    report.detail(`  [${tag}] methodology guard — Malli-on bundle is strictly larger`);
-    report.detail(`        delta: ${fmtKb(delta)} (${delta} bytes)`);
-    report.detail(`        threshold: ≥ ${fmtKb(minDelta)} (Spec row 3 − row 2 = 23.6 KB)`);
+    report.detail(`  [${tag}] schema-implies-validation guard — both probes carry Malli (equal)`);
+    report.detail(`        |delta|: ${fmtKb(delta)} (${delta} bytes)`);
+    report.detail(`        tolerance: ≤ ${fmtKb(maxDelta)} (Ruling A: facade auto-wires Malli)`);
     if (!ok) {
       methodologyOk = false;
-      report.detail('        FAIL — Malli adapter\'s body was eliminated;');
-      report.detail('        the +Malli gate is now vacuous.');
+      report.detail('        FAIL — the two probes diverged. Most likely the');
+      report.detail('        `re-frame.schemas` facade no longer requires');
+      report.detail('        `re-frame.schemas.malli`, so requiring schemas no');
+      report.detail('        longer implies validation (rf2-v96fh regression).');
     }
   }
 

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -4,7 +4,7 @@
 >
 > **Portable contract** (every port): `:schema` metadata on every `reg-*`; path-based `app-db` schemas via `reg-app-schema`; pluggable validator via `set-schema-validator!`; implementation-defined default validator. Schemas are **open by default** — consumers tolerate unknown keys; producers add new keys additively; `:closed` is opt-in only at system boundaries. Statically typed hosts express the same open-with-known-keys idiom via index signatures + known fields (`type T = { knownField: string; [k: string]: unknown }`).
 >
-> **CLJS reference's default validator**: Malli (`malli.core/validate` + `malli.core/explain`), with soft-pass when Malli is absent. Other ports document their own defaults (see [§Default validator and the validator-fn extension point](#default-validator-and-the-validator-fn-extension-point)).
+> **CLJS reference's default validator**: Malli (`malli.core/validate` + `malli.core/explain`). On the CLJS reference, **schema implies validation** — requiring the `re-frame.schemas` artefact wires Malli automatically (the facade `:require`s the `re-frame.schemas.malli` adapter), so `reg-app-schema` always validates rather than soft-passing into a silent no-op. The recommended soft-pass (claim 4) survives only as the cross-port default-absent posture and as the behaviour when an app installs a non-Malli substitute validator. Other ports document their own defaults (see [§Default validator and the validator-fn extension point](#default-validator-and-the-validator-fn-extension-point)).
 
 ## Abstract
 
@@ -555,6 +555,8 @@ Apps that want a **hard fail** when the default library is absent (a stricter po
 
 This recommendation is normative-soft: ports that ship a different default-absent behaviour document the divergence in their README, and apps that depend on the soft-pass behaviour pin it explicitly with their own registered validator.
 
+**CLJS reference note (rf2-v96fh).** The CLJS reference's *default* path never reaches the soft-pass: requiring the `re-frame.schemas` artefact wires Malli (per [§Schema implies validation on CLJS](#schema-implies-validation-on-cljs-malli-wired-by-the-artefact)), so a registered schema always validates. The soft-pass survives on the CLJS reference only for substitute-validator apps that never bind the Malli hook (a `clojure.spec` bridge whose validator is its own; an app that explicitly leaves the validator unbound). This is the divergence Ruling A documents: "schema implies validation" is a stronger guarantee than the cross-port recommended soft-pass, chosen so the common case ("I registered a schema") is never a silent no-op.
+
 ### Locked rules
 
 - **One validator fn per process** is in effect at any time. Last-write-wins on re-registration. The validator is _for the schema language_, not per-app-instance — Malli, Zod, or a custom validator is a process-global choice.
@@ -565,40 +567,32 @@ This recommendation is normative-soft: ports that ship a different default-absen
 
 What the extension point does NOT cover: a *mix* of validators in one process. The runtime resolves one validator and uses it for every `:schema` everywhere; a hybrid setup (one schema language for app schemas, a different one for boundary handlers) requires the user to register a *composite* validator that dispatches internally on schema shape.
 
-### Opting in to Malli validation on CLJS
+### Schema implies validation on CLJS (Malli wired by the artefact)
 
-CLJS apps that want the default Malli validator to run **must** require the `re-frame.schemas.malli` adapter namespace at app boot:
+On the CLJS reference, **requiring the schemas artefact wires the default Malli validator automatically** — there is nothing extra to opt into. The `re-frame.schemas` facade `:require`s the `re-frame.schemas.malli` adapter ns, whose only job is to publish `malli.core/validate` / `malli.core/explain` / `malli.error/humanize` into the framework's late-bind hook table on ns-load (`:schemas/malli-validate` / `:schemas/malli-explain` / `:schemas/malli-humanize`). The schemas artefact's default validator consults these hooks on every call:
 
 ```clojure
 (ns my-app.core
   (:require [re-frame.core :as rf]
-            [re-frame.schemas]         ;; load the schemas artefact
-            [re-frame.schemas.malli])) ;; publish Malli into the late-bind hook table
+            [re-frame.schemas])) ;; loads the artefact ⇒ Malli is wired ⇒ schemas validate
 ```
 
-The adapter namespace's only job is to publish `malli.core/validate` and `malli.core/explain` into the framework's late-bind hook table on ns-load (`:schemas/malli-validate` / `:schemas/malli-explain`). The schemas artefact's default validator consults these hooks on every call; absent the hook (i.e. the adapter ns was not required) the validator soft-passes per [§Recommended soft-pass](#recommended-soft-pass-when-the-default-validators-library-is-absent).
+The rule is **"I registered a schema" ⇒ "it validates"** (rf2-v96fh, Ruling A). Pre-rf2-v96fh the adapter had to be required *separately* at app boot; an app that loaded `re-frame.schemas` but forgot `[re-frame.schemas.malli]` registered schemas that soft-passed every value — a footgun where registration did NOT imply validation. The CLJS reference closes that gap by making the schemas artefact own its default validator's wiring.
 
-The motivation is the bug fixed: CLJS has no runtime `resolve`, so the previous implementation's `(resolve 'malli.core/validate)` always returned nil on CLJS and the default validator silently soft-passed even when Malli was on the classpath. The late-bind adapter pattern (matching the substitute-validator precedent) preserves Malli's optional-dep status while making the opt-in explicit and runtime-correct.
+The original motivation for the late-bind adapter pattern still holds: CLJS has no runtime `resolve`, so the older `(resolve 'malli.core/validate)` always returned nil on CLJS and the default validator silently soft-passed even when Malli was on the classpath. The adapter ns publishing the hooks at ns-load fixes that runtime-correctly; rf2-v96fh additionally makes the facade load the adapter so the opt-in is not a separate, forgettable step.
 
-On the **JVM** loading the adapter namespace is optional but harmless — the schemas artefact's `default-malli-validate` falls back to `requiring-resolve` so JVM apps that have Malli on the classpath get Malli validation without an explicit require. Apps that want their bundle to be runtime-identical on JVM and CLJS require `re-frame.schemas.malli` on both sides.
+**Substitute validators and the soft-pass.** An app that wants a different schema language (a `clojure.spec` bridge, a custom validator) installs it via `set-schema-validator!` / `set-schema-fns!` at boot. The soft-pass branch in the default validator (return `true` when `:schemas/malli-validate` is unbound) is then the cross-port default-absent posture per [§Recommended soft-pass](#recommended-soft-pass-when-the-default-validators-library-is-absent) — it is no longer reachable on the CLJS reference's default path, because the facade always wires Malli.
+
+On the **JVM** the same wiring applies — loading `re-frame.schemas` loads the adapter, so JVM apps validate against Malli without a separate require. The contract is symmetric across runtimes.
 
 ### Worked example — installing a no-op validator at boot (CLJS reference)
 
-The motivating use-case is bundle-cost reduction (per `findings/malli-bundle-cost-audit.md` §3.7 / §4): an app that doesn't need runtime schema validation can install a no-op at boot and avoid pulling the default validator's schema-language library (Malli on the CLJS reference) into its production bundle.
+An app that uses schemas as inert data — surfaced via `app-schemas` / `app-schemas-digest` for tooling, but never validated at runtime — installs a no-op validator at boot. This disables every validation call site (the dev-mode hot path AND the boundary interceptor):
 
 ```clojure
 (ns my-app.core
   (:require [re-frame.core :as rf]
-            [re-frame.schemas]   ;; load the schemas artefact
-            ;; NOTE: we do NOT require [re-frame.schemas.malli] here —
-            ;; the late-bind adapter pattern gates Malli
-            ;; on an explicit require. Skipping the require means
-            ;; Malli is never pulled into the bundle, and the
-            ;; default validator soft-passes per §Recommended
-            ;; soft-pass. The (rf/set-schema-validator! nil) below
-            ;; tightens the soft-pass arm to an active no-op so the
-            ;; intent is explicit.
-            ))
+            [re-frame.schemas])) ;; loads the artefact ⇒ Malli is wired (rf2-v96fh)
 
 ;; Install the no-op BEFORE the first reg-app-schema / :schema metadata.
 ;; Any (fn [schema value] truthy?) that returns true unconditionally
@@ -613,6 +607,8 @@ The motivating use-case is bundle-cost reduction (per `findings/malli-bundle-cos
   {:schema [:cat [:= :auth/login] [:map [:email :string]]]}
   ...)
 ```
+
+**`set-schema-validator! nil` disables validation *behaviour*, not Malli's *bundle cost* (rf2-v96fh).** Under static CLJS compilation, requiring `re-frame.schemas` loads the Malli adapter at module-init, so Malli's body is in the bundle regardless of the nil validator. The nil opt-out is the right tool when you want schemas-as-data with zero validation overhead, but it is **not** a Malli-bundle-cost opt-out. The only Malli-free posture on the CLJS reference is **not requiring the schemas artefact at all** — an app that needs neither `reg-app-schema` nor `:schema` metadata pays nothing (the no-feature counter reference app, pinned by the counter bundle-isolation gate). This is the deliberate tradeoff Ruling A accepts: "schema implies validation" is worth the bounded Malli surface for apps that use schemas; apps that don't use schemas are unaffected.
 
 ### Boundary-validation seam
 
@@ -638,17 +634,17 @@ For the bundle-cost tradeoffs of the CLJS reference's Malli default and how to o
 
 ### Bundle cost
 
-The CLJS reference's Malli mandate adds ~24 KB gzipped to a typical re-frame2 production bundle (per `findings/malli-bundle-cost-audit.md` §3.2 / §4 — bead). The cost is real but bounded; the figures below come from a representative-scenario harness compiled `:advanced` with `:closure-defines {goog.DEBUG false}`:
+The CLJS reference's Malli mandate adds a bounded gzipped cost to a typical re-frame2 production bundle. Per rf2-v96fh (schema implies validation) **requiring `re-frame.schemas` pulls Malli automatically** — the facade `:require`s the `re-frame.schemas.malli` adapter, so there is no longer a "schemas required, no Malli" posture: any schemas consumer pays the Malli surface. The figures below come from a representative-scenario harness compiled `:advanced` with `:closure-defines {goog.DEBUG false}`:
 
 | Scenario | gzipped | Δ vs baseline |
 |---|---:|---:|
 | Baseline counter (no schemas, no Malli) | 91.7 KB | — |
-| `[re-frame.schemas]` required, no Malli | 97.2 KB | +5.6 KB |
-| `[re-frame.schemas] [malli.core]` required, no validation | 120.8 KB | +29.1 KB |
-| Typical app: `reg-app-schema` + `:schema` on every reg-* | 121.5 KB | +29.8 KB |
+| `[re-frame.schemas]` required ⇒ Malli wired (rf2-v96fh) | ~91 KB | ~+0–30 KB |
 | Heavy: validate + explain + decode + transform + generator | 156.1 KB | +64.5 KB |
 
-The typical-app delta is the **~24 KB gzipped headline**: the `re-frame.schemas` namespace adds ~5.6 KB, and `malli.core`'s reachable body adds ~24 KB on top. Validation *calls* are not in this cost — every `validate-*!` body is gated on `re-frame.interop/debug-enabled?` and Closure DCE eliminates the call sites in production (per [§Production builds](#production-builds) and the strict-elision contract). The cost is `malli.core`'s **library code**, not validation activity.
+The schemas-with-Malli delta is bounded by `malli.core`'s reachable body (~24 KB gzipped headline; the older 120.8 KB row was a conservative pre-Closure-tuning estimate — the current `schemas-bundle-probe` measures ~91 KB gzipped, within the ≤ 100 KB gate ceiling). Validation *calls* are not in this cost — every `validate-*!` body is gated on `re-frame.interop/debug-enabled?` and Closure DCE eliminates the call sites in production (per [§Production builds](#production-builds) and the strict-elision contract). The cost is `malli.core`'s **library code**, not validation activity.
+
+> **The schemas-bundle gate** (`scripts/check-schemas-bundle.cjs`, run by `npm run test:schemas-bundle`) builds two probes: `schemas-bundle-probe` requires only `re-frame.schemas`, `schemas-bundle-probe-malli` requires the adapter explicitly on top. Under rf2-v96fh the explicit require is redundant, so the two bundles are the same size — the gate asserts that equality as the schema-implies-validation regression guard (a revert of the facade require would drop the first probe back to its ~59 KB Malli-free figure and break the equality).
 
 **Inter-namespace DCE works; intra-namespace DCE does not.** Closure prunes `malli.error`, `malli.transform`, `malli.generator`, etc. from a typical bundle because the user code doesn't require them — only `malli.core` survives. Inside `malli.core`, Closure cannot prove the data-driven dispatch internals dead, so the full namespace stays. The practical rule is: **require what you need at the namespace boundary; nothing more.**
 
@@ -665,16 +661,18 @@ The typical-app delta is the **~24 KB gzipped headline**: the `re-frame.schemas`
 - `malli.registry` — composite-registry helpers; ~3 KB gzipped (most lives in `malli.core`).
 - `malli.dev`, `malli.dev.pretty`, `malli.experimental`, `malli.instrument`, `malli.json-schema`, `malli.swagger`, `malli.provider`, `malli.util` — dev-only tooling; never bundle into production code.
 
-**Opt-out path — bypass Malli entirely.** Apps that don't want the Malli bundle install a different validator (or `nil`) via `set-schema-validator!` (per [§Default validator and the validator-fn extension point](#default-validator-and-the-validator-fn-extension-point) and / PR #237). `set-schema-validator!` with `nil` is the documented hard-no-op: every `validate-*!` site short-circuits to `true`, no validate call ever runs, and the schemas artefact stops carrying a static dependency on Malli. Apps that don't `(:require [malli.core])` themselves pay only the ~5.6 KB schemas-artefact cost.
+**Disabling validation behaviour — `set-schema-validator! nil`.** Apps that want schemas-as-inert-data with zero runtime validation overhead install `nil` via `set-schema-validator!` (per [§Default validator and the validator-fn extension point](#default-validator-and-the-validator-fn-extension-point)). This is the documented hard-no-op: every `validate-*!` site short-circuits to `true` and no validate call ever runs.
 
 ```clojure
-;; Apps that want zero runtime validation surface (and zero Malli bundle cost)
+;; Apps that want zero runtime validation surface (schemas are inert data)
 (rf/set-schema-validator! nil)
 ```
 
+**Per rf2-v96fh, `nil` does NOT remove Malli from the bundle.** Under static CLJS compilation, requiring `re-frame.schemas` loads the Malli adapter at module-init regardless of the runtime validator value, so Malli's body is in the bundle. The nil opt-out disables validation *behaviour*, not Malli's *bundle cost*. The only Malli-free posture on the CLJS reference is **not requiring the schemas artefact at all** — an app that needs neither `reg-app-schema` nor `:schema` metadata pays nothing for schemas or Malli (verified by the counter bundle-isolation gate). This is the deliberate tradeoff Ruling A accepts: making "schema implies validation" airtight is worth the bounded Malli surface for the apps that actually use schemas.
+
 **Boundary-validation path — keep Malli on the production path for untrusted-source events only.** Apps that want Malli's bundle but only run validation at system boundaries attach `:rf.schema/at-boundary` (per [§Production builds](#production-builds) and / PR #242) to specific event handlers. The interceptor runs the registered validator against the handler's `:schema` regardless of the global elision flag — boundary handlers validate every payload while 99% of code has zero validation overhead.
 
-**Reframing the "Malli is hard to DCE" intuition.** The intuition is half-right. Closure cannot DCE *inside* `malli.core` (the dynamic-dispatch internals defeat dataflow analysis). But Closure CAN DCE *between* Malli namespaces (typical apps already only carry `malli.core`, not the error / transform / generator subset), and the mandate-cost is bounded by what `malli.core` weighs gzipped: ~24 KB. The heavy-decode scenario (which pulls `malli.error` + `malli.transform` + `malli.generator`) is worst-case; the typical-app cost is half that, and the opt-out path drops it to zero.
+**Reframing the "Malli is hard to DCE" intuition.** The intuition is half-right. Closure cannot DCE *inside* `malli.core` (the dynamic-dispatch internals defeat dataflow analysis). But Closure CAN DCE *between* Malli namespaces (typical apps carry `malli.core` + `malli.error` — the latter for the humanize hook — not the transform / generator subset), and the mandate-cost is bounded by what those namespaces weigh gzipped. The heavy-decode scenario (which pulls `malli.transform` + `malli.generator` on top) is worst-case; the typical schemas-consumer cost is a fraction of that. Per rf2-v96fh the cost is paid by any app that requires the schemas artefact (schema implies validation); the way to pay zero is to not require the schemas artefact at all.
 
 ### What schemas don't do
 


### PR DESCRIPTION
## Summary

Mike-ruled **A** for rf2-v96fh: make a registered schema **always validate** — "I registered a schema" ⇒ "it validates."

### The footgun this closes
Pre-fix, loading `re-frame.schemas` did **not** wire the default Malli validator. The Malli adapter (`re-frame.schemas.malli`) had to be required **separately** at app boot. An app that loaded the schemas artefact but forgot `[re-frame.schemas.malli]` registered schemas that then **soft-passed every value** (Spec 010 §Recommended soft-pass) — a silent no-op where registration did not imply validation.

### The fix
The `re-frame.schemas` facade now `:require`s `re-frame.schemas.malli` itself, so loading the schemas artefact wires Malli automatically (publishes the `:schemas/malli-validate` / `-explain` / `-humanize` late-bind hooks at ns-load). `reg-app-schema` therefore always validates; the inert "registered but soft-passing" state is gone.

### How Malli stays optional for non-schema apps
Malli becomes a dependency of the **schemas artefact**, not of **core**. An app that never `:require`s `re-frame.schemas` (the no-feature counter reference app) pays nothing — verified by the counter bundle-isolation gate (the schemas sentinel stays absent).

### CLJS bundle reality (flagged)
Under static CLJS compilation, requiring the schemas artefact now always loads Malli's body. `set-schema-validator! nil` still disables validation **behaviour** but does **not** remove Malli from the bundle — the only Malli-free posture is *not requiring the schemas artefact at all*. spec/010 §Bundle cost / §Worked example / §Opt-out / §Schema-implies-validation are updated to state this precisely. This is the deliberate tradeoff Ruling A accepts.

### Probes + gate
Both `schemas-bundle-probe` and `schemas-bundle-probe-malli` now pull Malli (the facade requires it), so the old "Malli strictly larger" methodology guard collapsed to delta≈0 by design. Replaced it with a **schema-implies-validation regression guard**: the two probes must be approximately equal; a revert of the facade require would drop `schemas-bundle-probe` back to its ~59 KB Malli-free figure and trip the guard.

### Regression test (failing-before / passing-after)
`schemas_implies_validation_test` requires **only** the facade (not the adapter) and asserts: the Malli hook is wired; a bad write to a registered slot fires `:rf.error/schema-validation-failure`; a valid write passes. Pre-fix the hook was unbound and the bad write soft-passed silently.

**spec/010 updated; spec/API.md + Conventions UNTOUCHED (G5 owns API.md this wave).**

### CI follow-up fix (commit f39a580b2)
The always-validate change surfaced sloppy **test fixture schemas** in two JVM suites whose CI checks went red — `JVM routing` and `JVM epoch`. Both registered app-schemas that previously soft-passed but now validate on every commit, fed db states the schema didn't honestly describe. Root cause + fix (validation kept intact — fixtures tightened, validation NOT weakened):

- **routing** `route_link_test`: `:route/search` registered `:query [:map [:q :string]]`, but the empty-`:fragment` sub-case visits `/search` with no query. Made `:q` `{:optional true}` so the route is honestly reachable query-free.
- **epoch** `epoch_privacy_test` + `epoch_mcp_egress_conformance_test`: the `[:auth]` / `[:blob]` `[:map ...]` schemas validated on every commit, but the cascades drive states where those paths are absent (non-auth events) or cleared mid-cascade. Wrapped in `[:maybe [:map ...]]` with `:optional` leaves so absent/cleared states pass; the `:sensitive?` / `:large?` per-slot flags stay discoverable (the walker descends `:maybe` transparently). Present values still validate — v96fh intent intact.

## Quality gates

| Gate | Result |
|---|---|
| schemas `clojure -M:test` | **224 tests, 18353 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (node-test) | **5175 tests, 17575 assertions, 0 failures, 0 errors** |
| `npm run test:bundle-isolation` | **PASS** — 17 artefact entries, 35 internal sentinels absent, 3 allow-list budgets ok (counter stays schemas/Malli-free); + uix-helix-reagent-free PASS |
| `npm run test:elision` | **PASS** — production 40/40 absent; control 40/40 present |
| `npm run test:schemas-bundle` | **PASS** — schemas-bundle-probe=91.1 KB/100 KB; schemas-bundle-probe-malli=91.1 KB/100 KB; |delta|=0.0 KB (equality guard ok) |
| clj-kondo (changed files) | **0 errors, 0 warnings** |
| `mkdocs build --strict` | **exit 0** — spec/010 anchors valid |
| late-bind drift (core) | **5 tests, 457 assertions, 0 failures** (facade hook publications unchanged) |
| **CI fix:** routing `clojure -M:test` | **142 tests, 616 assertions, 0 failures, 0 errors** (was 1 error — `:query` fixture) |
| **CI fix:** epoch `clojure -M:test` | **238 tests, 862 assertions, 0 failures, 0 errors** (was 11 failures — `[:auth]`/`[:blob]` fixtures) |
| **CI fix:** `npm run test:cljs` re-run | **5175 tests, 0 failures, 0 errors** (test-only JVM edits; CLJS unaffected) |
| **CI fix:** `npm run test:bundle-isolation` re-run | **PASS** |
| **CI fix:** `npm run test:elision` re-run | **PASS** |

Closes rf2-v96fh.
