### PR TITLE
docs(flows): comment & docstring quality pass (rf2-kdoai.8)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -296,7 +296,9 @@
                           :frame   frame-id}))
           ;; Per rf2-je5p8: wrap the throw in an ex-info carrying the
           ;; flow-attribution slot `:rf.flow/failed-id`.
-          ;; The router's `run-flows!` catch reads it and stamps
+          ;; The router's `flows-after-interceptor` catch stashes the
+          ;; throw under `:rf/flow-error`, then `emit-flow-eval-exception!`
+          ;; reads `:rf.flow/failed-id` off the ex-data and stamps
           ;; `:flow-id` into the substrate record's `:tags` so ops in
           ;; CLJS production (where `:rf.flow/failed` DCEs) can attribute
           ;; the cascade-level `:rf.error/flow-eval-exception` to a


### PR DESCRIPTION
Behaviour-preserving commenting & explanation review of `implementation/flows` (rf2-kdoai.8, child of the rf2-kdoai sweep). Slice = `implementation/flows` only.

## What changed

The flows slice is already exceptionally well-commented: every public fn carries a complete docstring (WHAT + contract: args/return/side-effects/error-modes/reserved-vocab), every non-obvious decision has a why-comment with spec cross-refs + bead provenance, and considered-and-rejected alternatives are noted. No padding needed, and over-commenting was the dominant risk, so the review was conservative.

**One genuine drift found and fixed** — a single stale why-comment in `evaluate-flow!` (flows.cljc) named a nonexistent router fn `run-flows!` as the consumer that reads `:rf.flow/failed-id`. Verified against the router: there is no `run-flows!` (router.cljc line 1093 even says "rather than an inline `run-flows!` call"). The actual path is the `flows-after-interceptor` catch (stashes the throw under `:rf/flow-error`) → `emit-flow-eval-exception!` (reads `:rf.flow/failed-id` off the ex-data, stamps `:flow-id` into the substrate record's `:tags`). The surrounding comments at lines 149/278/343 already name `flows-after-interceptor` correctly; line 299 was the lone phantom. Described semantics are unchanged — only the function name corrected.

Verified accurate (no change): all other cross-refs — `marks/register-marks!`, `registrar/{register!,unregister!,add-replacement-hook!}`, `frame/app-db-container`, the `schemas/validate|explain-with-registered-fn` late-bind seam, `machines/teardown-on-frame-destroy!` symmetry, and the `rf/frame-db` calls in tests (rename rf2-1i168 sequenced later — not pre-empted here).

## Quality gates

- flows JVM `clojure -M:test`: **124 tests, 525 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5175 tests, 17575 assertions, 0 failures, 0 errors**
- clj-kondo on changed file (flows.cljc): **0 errors, 0 warnings**
- mkdocs: N/A (no .md touched; docstrings live in code)

Behaviour-preserving: docstrings/comments only, no logic change.