### PR TITLE
docs(http): comment & docstring quality pass (rf2-kdoai.9)

### DIFF
--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -42,6 +42,14 @@
 ;; ---- query string + URL helpers -------------------------------------------
 
 (defn url-encode
+  "Percent-encode `s` for safe splicing into a URL query string.
+
+  JVM `URLEncoder/encode` is an `application/x-www-form-urlencoded`
+  encoder — it renders a space as `+`. We rewrite `+` → `%20` so the
+  output is also correct in non-form contexts (and matches the CLJS
+  `js/encodeURIComponent` path, which percent-encodes spaces as `%20`).
+  Keeping the two hosts byte-identical means `params->query` produces
+  the same wire string everywhere."
   [s]
   #?(:clj  (-> (URLEncoder/encode (str s) "UTF-8")
                (.replace "+" "%20"))

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -123,7 +123,12 @@
      (remove-from-actor-index! (:actor-id handle) handle))
    nil))
 
-(defn lookup-in-flight [request-id]
+(defn lookup-in-flight
+  "Return the request-handle currently registered under `request-id`, or
+  nil (when absent, or when `request-id` is nil). The handle carries the
+  `:abort-fn` the abort / supersede paths fire. Read-only — does not
+  mutate either index."
+  [request-id]
   (when request-id
     (get @in-flight request-id)))
 

--- a/implementation/http/src/re_frame/http_test_support.cljc
+++ b/implementation/http/src/re_frame/http_test_support.cljc
@@ -250,6 +250,10 @@
   stub-fx-id)
 
 (defn uninstall-managed-request-stubs!
+  "Tear down the per-call stub fx-override `install-managed-request-stubs!`
+  registered. Idempotent — clearing an already-absent fx id is a no-op,
+  so a teardown that runs without a matching install (or twice) is safe.
+  Test-time helper."
   []
   (fx/clear-fx stub-fx-id)
   nil)

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -342,6 +342,16 @@
 
 #?(:clj
    (defn- jvm-build-request
+     "Build a JDK `HttpRequest` for one attempt from the encoded request
+     map. Selects the body publisher by `body` shape (none / String /
+     bytes / stringified-else), applies the per-attempt `:timeout-ms`
+     (the `(pos? …)` guard treats both `nil` and `0` as the no-timeout
+     opt-out — see the inline note), and sets each header individually
+     so a JDK header-validation throw can be isolated to the offending
+     header (surfaced as a `:rf.warning/http-header-invalid` trace rather
+     than sinking the whole request — rf2-9lun0). `sensitive?` is carried
+     only so that warning's `:url` can be routed through the privacy
+     composer (rf2-1jcpm)."
      [{:keys [method url headers body timeout-ms sensitive?]}]
      (let [b (HttpRequest/newBuilder (URI/create url))
            publisher (cond


### PR DESCRIPTION
Behaviour-preserving commenting & explanation pass over `implementation/http` (rf2-kdoai.9 — comment-review sweep). **Docstrings/comments only — no logic change.**

## Findings

The http slice is already extensively and accurately commented — ns docstrings state contract + spec refs, why-comments carry bead-id provenance, and the recent honesty fixes (rf2-rl5tt swallowed-failure trace, rf2-xuvj7 one-shot decode latch) are reflected correctly in the current comments. No drift or stale comments found.

Conservative additions: filled **four** genuine docstring gaps — public-surface (or densest-interop) fns whose contract was non-obvious and whose sibling fns already carried docstrings:

- `http-encoding/url-encode` (public) — contract + the JVM `+`→`%20` rewrite (form-encoder normalised to match the CLJS `encodeURIComponent` path so both hosts emit byte-identical wire strings).
- `http-registry/lookup-in-flight` (public) — read-only handle-lookup contract; all sibling registry fns had docstrings.
- `http-test-support/uninstall-managed-request-stubs!` (public) — idempotent teardown; its install/with-* siblings had docstrings.
- `http-transport/jvm-build-request` (private, densest JVM-interop ns) — WHAT it builds + per-header isolation rationale (rf2-9lun0) + the nil/0 no-timeout guard; its four interop siblings all had docstrings.

Everything else was deliberately left untouched (conservative — self-explanatory code and already-thorough inline comment blocks were not padded).

## Quality gates

Behaviour-preserving: docstrings/comments only.

- http `clojure -M:test`: **292 tests / 1486 assertions, 0 failures, 0 errors** (behaviour UNCHANGED).
- `npm run test:cljs`: **5175 tests / 17575 assertions, 0 failures, 0 errors**.
- clj-kondo on the 4 changed files: **errors 0, warnings 2** — both pre-existing on the base (verified via stash), not introduced by this PR.