### PR TITLE
docs(routing): comment & docstring quality pass (rf2-kdoai.11)

### DIFF
--- a/implementation/routing/src/re_frame/routing/match.cljc
+++ b/implementation/routing/src/re_frame/routing/match.cljc
@@ -143,6 +143,21 @@
     (+ close 2)))
 
 (defn validate-route-pattern!
+  "Validate `pattern` against Spec 012's path-pattern grammar at the
+  authoring boundary (`reg-route` calls this at registration time).
+  Returns `true` on a well-formed pattern; throws
+  `:rf.error/invalid-route-pattern` (canonical thrown-error shape, per
+  Spec 009 — `:where 'rf/reg-route`, `:route-id`, `:pattern`, and the
+  offending `:index`) on the first violation. Enforcing the grammar here
+  means a malformed `:path` fails LOUDLY when the route is registered,
+  naming the bad character position, rather than producing surprising
+  matcher / URL-emitter behaviour later at nav time. Grammar rules
+  enforced: leading `/`; no empty segments; named params (`:name`) and
+  splats (`*name`) occupy a whole segment with bare-identifier names; at
+  most one splat, which must be final; literal segments percent-encode
+  the reserved chars (`: * { } ?`); and `{...}?` optional groups close
+  with `}?`, are non-empty, non-nested, start with `/` or a named param,
+  and contain no splats."
   [route-id pattern]
   (cond
     (not (string? pattern))
@@ -221,9 +236,20 @@
                   (recur end splat-seen?)))))))
       true)))
 
-(defn canonical-route-pattern [pattern]
-  ;; Author-supplied `:path`; gate on `string?` before delegating to the
-  ;; shared `url/strip-trailing-slashes` (a non-string :path is caught by
+(defn canonical-route-pattern
+  "Canonicalise an author-supplied `:path` pattern for registration:
+  strips trailing slashes so `/cart` and `/cart/` register the same
+  route (Spec 012 trailing-slash equivalence), with `/` itself
+  preserved. `reg-route` runs this before parsing so the stored pattern
+  is already canonical; the incoming-URL side normalises identically via
+  `registry/normalize-match-path` (both are thin wrappers over the
+  shared `url/strip-trailing-slashes`, so the two surfaces cannot
+  drift). A non-string `pattern` is returned unchanged — the type error
+  is caught downstream by `validate-route-pattern!`, which names the
+  route."
+  [pattern]
+  ;; Gate on `string?` before delegating to the shared
+  ;; `url/strip-trailing-slashes` (a non-string :path is caught by
   ;; `validate-route-pattern!`).
   (if (string? pattern)
     (url/strip-trailing-slashes pattern)

--- a/implementation/routing/src/re_frame/routing/scroll.cljc
+++ b/implementation/routing/src/re_frame/routing/scroll.cljc
@@ -119,7 +119,15 @@
                           (:fragment route-slice))
       (catch #?(:clj Throwable :cljs :default) _ nil))))
 
-(defn capture-scroll-fx-entry [db]
+(defn capture-scroll-fx-entry
+  "Build the `[:rf.nav/capture-scroll {:url ...}]` fx entry that saves
+  the scroll position of the route the user is LEAVING, keyed by that
+  route's reconstructed URL. Returns nil when the current slice has no
+  reconstructable URL (no active route, or `route-url` throws — e.g. the
+  route was unregistered mid-session), so navigation never fails on a
+  capture miss. Emitted by both nav entry points before the transition
+  commits so a later `:restore` to this URL finds the saved position."
+  [db]
   (when-let [url (current-route-url (get-in db [:rf/runtime :routing :current]))]
     [:rf.nav/capture-scroll {:url url}]))
 


### PR DESCRIPTION
Per-slice commenting & explanation review sweep (rf2-kdoai.11, slice = implementation/routing). Behaviour-preserving: docstrings/comments only, NO logic change.

## What

Reviewed all 18 source files in the routing slice. The slice was already exemplary — every recently-landed subtlety the charter flagged is fully explained in place: the `:nav-token` cofx stale-suppression, the `+`-literal url-decode host symmetry, `reg-route` reserved-metadata-key validation, the navigate params/opts arity-misuse guard, `route-url`'s path/query nil-policy asymmetry, and the `:query-retain` verbatim cross-route carry (incl. its considered-and-rejected re-coercion note).

The only genuine gap: three **public** `defn`s carried no docstring. Added one to each (the sole behaviour-relevant contract surfaces missing them):

- `match/validate-route-pattern!` — the grammar it enforces, the true-on-success / throw-`:rf.error/invalid-route-pattern` contract, and why it runs at the authoring boundary.
- `match/canonical-route-pattern` — trailing-slash canonicalisation contract + the normalise-identically-with-incoming-URLs note (promoted the existing inline comment intent into a docstring).
- `scroll/capture-scroll-fx-entry` — the leave-route capture contract and the nil-on-no-reconstructable-URL fail-soft.

No drift / stale comments found; nothing padded. `frame-db` rename deliberately left to rf2-1i168.

## Quality gates

Behaviour-preserving: docstrings/comments only, no logic change.

- **routing `clojure -M:test`**: 142 tests, 616 assertions, 0 failures, 0 errors (behaviour UNCHANGED).
- **`npm run test:cljs`**: 5175 tests, 17575 assertions, 0 failures, 0 errors.
- **clj-kondo (changed files)**: 0 errors. The 8 warnings are pre-existing single-file reader-conditional analysis artefacts — identical on `origin/main` base, unchanged by these edits (touched no requires/bindings).

Closes rf2-kdoai.11.