### PR TITLE
docs(story-mcp): comment & docstring quality pass (rf2-kdoai.20)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -56,7 +56,7 @@
   "Hard ceiling on a single newline-delimited JSON-RPC frame from the
   stdio transport. 4 MB — well above any legitimate MCP message a
   cooperating client would send (the largest reasonable payload is a
-  `tools/list` response, which Stage 7's nineteen-tool registry
+  `tools/list` response, which Stage 7's twenty-tool registry
   prints in ~15 KB), but small enough that a hostile or runaway
   producer can't OOM the JVM by sending a one-frame `readLine` that
   never terminates. When a frame exceeds the cap, `read-frame` throws
@@ -114,7 +114,9 @@
 
 (defn parse-json
   "Parse a JSON string into a Clojure map. Returns the parsed value, or
-  throws `ex-info` with `:rf.error/parse-error` on a malformed payload.
+  throws `ex-info` with `:rf.error/id :rf.error/story-mcp-json-parse-failure`
+  on a malformed payload (the run-loop catches it and writes a `-32700`
+  parse-error response).
 
   Keys are converted to keywords for ergonomic dispatch — this matches
   what the rest of the namespace expects (`(:method m)`, `(:jsonrpc m)`,

--- a/tools/story-mcp/src/re_frame/story_mcp/server.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/server.cljc
@@ -79,7 +79,7 @@
 
 (defn- handle-tools-list
   "Return the tool registry descriptors. We don't paginate — the
-  registry is small enough (nineteen tools at Stage 7) that a single
+  registry is small enough (twenty tools at Stage 7) that a single
   response is fine."
   [id _params]
   (proto/response id {:tools (registry/tool-descriptors)}))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
@@ -12,7 +12,7 @@
   - `required-arg` — the missing-required-arg shape that returns an
     error-envelope rather than throwing.
   - `with-variant` / `with-variant-id` — the four-line variant-id
-    prelude shared by six handlers (see rf2-f0zxa), routing the agent-
+    prelude shared by ten handlers (see rf2-f0zxa), routing the agent-
     supplied id through the bounded variant-registry allowlist before
     coercing to a keyword (rf2-lqjbk).
   - `read-run-opts` — the `:substrate` / `:active-modes` /
@@ -140,10 +140,10 @@
       caller-supplied string is echoed; we don't have a keyword form
       because the safe-keyword gate refused to intern one).
 
-  Crystallises the four-line prelude shared by six tool handlers
-  (`preview-variant`, `get-variant`, `variant->edn`, `run-variant`,
-  `snapshot-identity`, `record-as-variant`). Tools that tolerate
-  unregistered variants (`run-a11y`, `read-failures`,
+  Crystallises the four-line prelude shared by seven tool handlers
+  (`preview-variant`, `get-variant`, `explain-variant`, `variant->edn`,
+  `run-variant`, `snapshot-identity`, `record-as-variant`). Tools that
+  tolerate unregistered variants (`run-a11y`, `read-failures`,
   `unregister-variant`) reach for `with-variant-id` instead."
   [arguments f]
   (let [[vid err] (required-arg arguments :variant-id)]

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -483,7 +483,7 @@
 
    {:name           "list-assertions"
     :category       :docs
-    :description    (str "The seven canonical `:rf.assert/*` events with payload arity + semantics, plus any project-registered assertion ids. Paginated per rf2-76sf6 — `:canonical` (the 7-entry doc vector) stays full; `:registered` slices per `:limit` / `:cursor`. "
+    :description    (str "The eight canonical `:rf.assert/*` events with payload arity + semantics (the seven dispatched assertions plus the tape-evaluated `:rf.assert/schema-error`), plus any project-registered assertion ids. Paginated per rf2-76sf6 — `:canonical` (the 8-entry doc vector) stays full; `:registered` slices per `:limit` / `:cursor`. "
                          "Examples: "
                          "1. Default: {} -> {:canonical [{:id :rf.assert/path-equals :payload \"[path expected]\" :semantics \"(= (get-in @app-db path) expected)\"} ...] :registered [:rf.assert/dispatched? :rf.assert/effect-emitted ...]}. "
                          "2. With budget knob: {:max-tokens 1000} -> same shape, tighter cap. "

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -130,7 +130,8 @@
                               (rf2-4yuhi).
     :new-variant-id optional — when `:write-back` is true, register the
                               captured recording (translated to a live
-                              `:play-script` body) as a NEW variant with
+                              `:script` body, the public phase-4 play
+                              surface — rf2-7mj4z) as a NEW variant with
                               this id. Defaults to the source
                               `:variant-id` (overwrites in place).
     :doc           optional — docstring to embed in the snippet.
@@ -142,12 +143,13 @@
                               (default `\"story\"`).
     :write-back    optional — when true, also re-register the variant
                               via `reg-variant*` with the captured
-                              recording translated to a live
-                              `:play-script` body. Requires
-                              `allow-writes?` (same gate as
-                              `register-variant`). Wire-key shape per
-                              rf2-pmwgn: no `?` — Anthropic's input-
-                              schema property-name regex rejects it.
+                              recording translated to a live `:script`
+                              body (the public phase-4 play surface —
+                              rf2-7mj4z). Requires `allow-writes?`
+                              (same gate as `register-variant`).
+                              Wire-key shape per rf2-pmwgn: no `?` —
+                              Anthropic's input-schema property-name
+                              regex rejects it.
 
   Output:
     `{:variant-id <source>

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -103,8 +103,8 @@
 (defn- read-edn-body
   "Parse an agent-supplied EDN string into a Clojure value with the
   rf2-g9fje hardening posture. Returns the parsed value on success, or
-  one of two sentinels on failure (caller maps these to
-  `error-result`s):
+  the `::edn-error` sentinel on failure (`coerce-body` maps it to an
+  `error-result`):
 
     `::edn-error` — `edn/read-string` threw (malformed EDN, tagged
                     literal, oversize / over-deep payload).


### PR DESCRIPTION
Per-slice commenting & explanation review of `tools/story-mcp` (epic rf2-kdoai, slice rf2-kdoai.20). The slice is already extensively and accurately documented; this PR fixes the small set of genuine **drift** items found — docstrings/comments that no longer matched the code. No new padding added.

## Drift fixed (behaviour-preserving — docstrings/comments only)

- **`server.cljc` / `protocol.cljc`** — registry-size claim `nineteen` -> `twenty` tools (dev 3 + docs 10 + testing 4 + write 2 + recorder 1 = 20). The live count is asserted green by the `skill-leaf-tool-names-match-registry` count ratchet; the skill leaf already reads 'twenty tools across'.
- **`docs.cljc`** — `list-assertions` descriptor said 'seven canonical' / '7-entry doc vector'; `canonical-assertion-docs` actually has **8** entries (the seven dispatched assertions + the tape-evaluated `:rf.assert/schema-error`). Aligned with the handler docstring, which already said '8-assertion'.
- **`recorder.cljc`** — `tool-record-as-variant` arg docs for `:new-variant-id` / `:write-back` said the write-back body is `:play-script`; the public phase-4 authoring slot is `:script` (rf2-7mj4z), matching `write-back!` and the descriptor schema. (The `:play-script` references that describe the *stored shipping slot* are correct and untouched.)
- **`args.cljc`** — `with-variant` is shared by **seven** handlers (`explain-variant`, added in rf2-ba86n.17, was missing from the enumerated list), not six; the ns summary now says ten preludes total (7 `with-variant` + 3 `with-variant-id`).
- **`protocol.cljc`** — `parse-json` docstring named the wrong ex-info id (`:rf.error/parse-error`); the throw carries `:rf.error/story-mcp-json-parse-failure`. Noted the run-loop maps it to a -32700.
- **`write.cljc`** — `read-edn-body` docstring claimed 'two sentinels' but the fn returns only `::edn-error` (the second sentinel lives in `coerce-body`).

The frozen run-result contract (`:status` verdict, `:passing?` retired), the narrative-egress value-redaction (rf2-j90sb / rf2-ee38b.17), and the `:setup`/`:script` vocab were all reviewed and found already-correct and load-bearing — left as-is.

## Quality gates

Behaviour-preserving: docstrings/comments only, no logic change.

- `cd implementation && npm run test:mcp-conformance` -> **ALL MCP-CONFORMANCE GATES GREEN** (ran because one wire-facing `:description` string was edited). 6/6 gates pass; story-mcp JVM 200 tests / 1029 assertions, wire-vocab 49 tests / 628 assertions, 0 failures.
- `tools/story-mcp` `clojure -M:test` -> Ran 200 tests, 1029 assertions, 0 failures 0 errors (incl. the skill-leaf count ratchet + tool-names.json drift net).
- `clj-kondo` on the 6 changed files -> 0 errors; the 10 warnings are pre-existing `.cljc` reader-conditional false-positives (`Throwable`, `StringBuilder`, `*err*`, …) on lines this PR did not touch.