### PR TITLE
docs(core): comment & docstring quality pass (rf2-kdoai.1)

### DIFF
--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -4,10 +4,15 @@
   Schema metadata is the canonical path-level privacy declaration:
   `{:sensitive? true}` on an app-schema slot feeds the elision registry
   and the router installs an internal redaction interceptor for matching
-  path-scoped handlers. Path-marked sensitive classification (planned)
-  supersedes the previous handler-meta `:sensitive?` annotation —
-  sensitivity is now a property of the data value at a path, not of the
-  handler that touched it."
+  path-scoped handlers. Path-marked sensitive classification (`add-marks`
+  / `set-marks`, Spec 015 — see `re-frame.marks`) is the live successor
+  to the former handler-meta `:sensitive?` annotation: sensitivity is a
+  property of the data VALUE at a path, not of the handler that touched
+  it. The two declaration sources union at lookup time.
+
+  The helpers here are the schema-path-overlap arm of that scheme — they
+  redact event-payload paths whose path-scoped handler slice overlaps a
+  schema-declared sensitive app-db slot."
   (:require [re-frame.interceptor :as interceptor]
             [re-frame.late-bind :as late-bind]))
 

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -205,11 +205,24 @@
                                         " require an adapter ns and pass its `adapter` Var,"
                                         " e.g. (rf/init! reagent/adapter).")})))))
 
-(defn make-state-container [initial-value]
+(defn make-state-container
+  "Build a fresh, writable substrate state container holding
+  `initial-value` (the per-frame `app-db` cell). Delegates to the
+  installed adapter's `:make-state-container`. Required contract fn —
+  raises `:rf.error/no-adapter-installed` before `(rf/init! ...)` and
+  `:rf.error/adapter-disposed` after teardown (per `require-adapter!`).
+  Per Spec 006."
+  [initial-value]
   (let [a (require-adapter! 'rf/make-state-container)]
     ((:make-state-container a) initial-value)))
 
-(defn read-container [container]
+(defn read-container
+  "Read the current value out of a substrate `container` (deref). Works
+  on both base writable containers and derived values. Delegates to the
+  installed adapter's `:read-container`. Required contract fn — raises
+  `:rf.error/no-adapter-installed` / `:rf.error/adapter-disposed` when no
+  adapter is seated (per `require-adapter!`). Per Spec 006."
+  [container]
   (let [a (require-adapter! 'rf/read-container)]
     ((:read-container a) container)))
 
@@ -329,15 +342,36 @@
                            :reason      reason})))
         ((:replace-container! a) container new-value)))))
 
-(defn make-derived-value [source-containers compute-fn]
+(defn make-derived-value
+  "Build a read-only derived value: a container that recomputes
+  `(compute-fn)` from `source-containers` and is observable via
+  `read-container` but NOT writable via `replace-container!` (the
+  substrate backing for layer-2+ subs). Delegates to the installed
+  adapter's `:make-derived-value`. Required contract fn — raises
+  `:rf.error/no-adapter-installed` / `:rf.error/adapter-disposed` when no
+  adapter is seated (per `require-adapter!`). Per Spec 006
+  §`make-derived-value`."
+  [source-containers compute-fn]
   (let [a (require-adapter! 'rf/make-derived-value)]
     ((:make-derived-value a) source-containers compute-fn)))
 
-(defn render [render-tree mount-point opts]
+(defn render
+  "Mount/render `render-tree` (a hiccup tree) into `mount-point` via the
+  installed adapter's `:render`. The client-side mount entry point.
+  Required contract fn — raises `:rf.error/no-adapter-installed` /
+  `:rf.error/adapter-disposed` when no adapter is seated (per
+  `require-adapter!`). Per Spec 006."
+  [render-tree mount-point opts]
   (let [a (require-adapter! 'rf/render)]
     ((:render a) render-tree mount-point opts)))
 
-(defn render-to-string [render-tree opts]
+(defn render-to-string
+  "Render `render-tree` to an HTML string (server-side / SSR) via the
+  installed adapter's `:render-to-string`. The non-mounting counterpart
+  of `render`. Required contract fn — raises
+  `:rf.error/no-adapter-installed` / `:rf.error/adapter-disposed` when no
+  adapter is seated (per `require-adapter!`). Per Spec 006."
+  [render-tree opts]
   (let [a (require-adapter! 'rf/render-to-string)]
     ((:render-to-string a) render-tree opts)))
 


### PR DESCRIPTION
Commenting & explanation review of `implementation/core` (rf2-kdoai.1, slice = the public-API surface). Conservative pass: the core slice is exemplary already — every one of the 62 source files carries an ns docstring, and the named priority surfaces (`core.cljc` façade, dispatch/subscribe, the frame affordances, `features.cljc`, `fx.cljc` atomicity asymmetry + reserved-fx-id fn-value-override pre-emption (nrpj1), `router.cljc` unknown-dispatch-opt warn (jbzhj), `frame.cljc` app-db-container rename) are accurate and current. No stale references to the deleted `bound-fn`/`dispatcher`/`subscriber` or `get-frame-db`. Two genuine gaps fixed:

## Changes

- **`substrate/adapter.cljc`** — added per-fn contract docstrings to the five undocumented *required* substrate-adapter contract fns (`make-state-container`, `read-container`, `make-derived-value`, `render`, `render-to-string`). They were the only undocumented members of the documented 9-fn Spec 006 contract; each delegates through `require-adapter!` and so carries non-obvious `:rf.error/no-adapter-installed` / `:rf.error/adapter-disposed` error modes worth stating. (Their siblings `replace-container!` / `subscribe-container` already carried full docstrings.)
- **`privacy.cljc`** — fixed stale DRIFT in the ns docstring: path-marked sensitive classification (`add-marks`/`set-marks`, Spec 015 — fully wired in `re-frame.marks`) has shipped, so the "(planned)" parenthetical was misleading. Reworded to name the live successor + cross-ref `re-frame.marks`, and clarified the helpers here are the schema-path-overlap arm.

Everything else: verified clear.

## Quality gates

behaviour-preserving: docstrings/comments only, no logic change.

- core `clojure -M:test`: **841 tests, 3758 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5184 tests, 17655 assertions, 0 failures, 0 errors**
- `npm run test:elision`: **PASS** — production 40/40 absent, control 40/40 present (comments did not perturb elision). The two pre-existing JSDoc `@extras` parse-warnings are in `http/...http_privacy_headers.cljc` (not the core slice, not touched here).
- clj-kondo on changed files: **0 errors, 0 warnings**