### PR TITLE
docs(epoch): comment & docstring quality pass (rf2-kdoai.7)

### DIFF
--- a/implementation/epoch/deps.edn
+++ b/implementation/epoch/deps.edn
@@ -5,8 +5,9 @@
 ;; epoch surface — the per-frame `:rf/epoch-record` ring buffer
 ;; (`epoch-history`), the `(rf/configure :epoch-history {:depth N})`
 ;; knob, the `register-epoch-listener!` / `unregister-epoch-listener!` listener API, the
-;; `restore-epoch` rewind with its six documented failure modes
+;; `restore-epoch` rewind with its seven documented failure modes
 ;; (`:rf.epoch/restore-unknown-epoch`,
+;; `:rf.epoch/restore-non-ok-record`,
 ;; `:rf.epoch/restore-schema-mismatch`,
 ;; `:rf.epoch/restore-missing-handler`,
 ;; `:rf.epoch/restore-version-mismatch`,


### PR DESCRIPTION
Behaviour-preserving commenting & explanation pass on `implementation/epoch` (rf2-kdoai.7, comment-review sweep). Pre-alpha masterpiece stance: CLARITY + GOOD PRACTICE, docstrings/comments only.

## What changed

One DRIFT fix. The epoch artefact's `deps.edn` header said `restore-epoch` has **six** documented failure modes and enumerated only five `:rf.epoch/*` ops (plus `:rf.error/no-such-handler`). The actual surface has **seven**: it was missing `:rf.epoch/restore-non-ok-record` (added by rf2-v0jwt). The header now reads "seven" and includes the missing mode, matching the authoritative `restore-epoch` docstring (epoch.cljc), the `capture/skip-ops` catalogue, and `epoch_test.clj`.

## Findings (no change needed)

The six source namespaces (`epoch`, `epoch.state`, `epoch.assembly`, `epoch.capture`, `epoch.listeners`, `epoch.write`) are already at masterpiece commenting quality: public docstrings state what + contract + args/return + failure modes + reserved vocab; why-comments explain the per-event epoch model (rf2-nj6p7), trace-events-keep eviction, the seven restore failure modes, the privacy/egress redaction boundary (`projected-record`), epoch boundaries, and considered-and-rejected design notes with spec cross-refs. No padding added; no other drift found. No `get-frame-db` residue (code already uses the renamed `app-db-container`).

## Quality gates

- epoch `clojure -M:test`: **238 tests, 862 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5184 tests, 17655 assertions, 0 failures, 0 errors**
- clj-kondo on changed file (`deps.edn`): **0 errors, 0 warnings**

Behaviour-preserving: docstrings/comments only, no logic change.