### PR TITLE
fix(xray): surface view-unmount + L2 sub-dispose teardown signal (rf2-59hx3)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -506,6 +506,10 @@
     :producer-ns 're-frame.epoch
     :design-bead "rf2-wi900"
     :description "Subs sibling of :epoch/record-render!. Attribute a post-settle sub-run emit (a :sub/run / :rf.sub/skip op firing at React deref time, after the causing cascade settled, because reactions recompute lazily) back to the cascade that caused it — the frame's most-recently-settled epoch. Called by re-frame.epoch.capture/capture-event! when a sub-run op arrives with no in-flight cascade; back-fills the sub-run (and its :value-changed? / :prev-value / :value attribution) into the causing epoch record and re-fans it to epoch listeners. Fixes the one-epoch :sub-runs lag visible in Xray's per-cascade Views subs table."}
+   {:key         :epoch/record-unmount!
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-59hx3"
+    :description "Teardown sibling of :epoch/record-render! / :epoch/record-sub-run!. Attribute a post-settle view-unmount emit (a :rf.view/unmounted op firing at React componentWillUnmount / useEffect-cleanup time, after the cascade that removed the view settled) back to the cascade that caused the teardown — the frame's most-recently-settled epoch. Called by re-frame.epoch.capture/capture-event! when an unmount op arrives with no in-flight cascade. Pre-rf2-59hx3 the unmount fell through to the orphan-drop branch and was silently dropped, so a view teardown produced NO signal anywhere; this back-fills it into the causing epoch's :trace-events (no structured row — an unmount is neither a :renders nor a :sub-runs entry) and re-fans the record to epoch listeners, where Xray's VIEWS-step unmounted-views-rows surfaces it. Fixes the invisible view-teardown gap (button-deck button 13)."}
    {:key         :epoch/epoch-history
     :producer-ns 're-frame.epoch
     :description "Return the committed-epoch ring buffer (introspection)."}

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -653,6 +653,13 @@
    ;; `:epoch/record-render!`. Same React-deref-time async recompute
    ;; problem; same attribution fix.
    :epoch/record-sub-run!     listeners/record-sub-run!
+   ;; rf2-59hx3: post-settle view-unmount back-fill — the teardown sibling
+   ;; of the two above. A `:rf.view/unmounted` fires at React teardown time,
+   ;; after the cascade that removed the view settled; pre-fix it was
+   ;; silently dropped at the capture seam so the teardown left no signal.
+   ;; Back-fills it into the causing (most-recently-settled) epoch's
+   ;; `:trace-events`, where Xray's VIEWS step surfaces it.
+   :epoch/record-unmount!     listeners/record-unmount!
    :epoch/on-frame-destroyed  listeners/on-frame-destroyed!
 
    ;; ---- introspection + Tool-Pair write surface --------------------

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -106,6 +106,31 @@
   #{:rf.sub/run
     :rf.sub/skip})
 
+;; ---- unmount op (rf2-59hx3) -----------------------------------------------
+;;
+;; The view-teardown sibling of render-ops. `:rf.view/unmounted`
+;; (`re-frame.views/emit-view-unmounted!`) fires when a registered-view
+;; instance tears down — at React `componentWillUnmount` / `useEffect`
+;; cleanup time, AFTER the cascade that removed the view settled. Like a
+;; render and a reactive sub-run it fires post-settle (no in-flight cascade
+;; for its frame) and carries a `:frame` tag but NO `:rf.trace/dispatch-id`.
+;;
+;; Pre-rf2-59hx3 it fell through to the orphan-drop branch below (no
+;; in-flight cascade AND no `:dispatch-id`) and was SILENTLY DROPPED — so a
+;; view unmount produced NO signal anywhere in the epoch record, and Xray's
+;; VIEWS-step `unmounted-views-rows` (which reads it off `:trace-events`)
+;; had nothing to surface. The teardown was an invisible absence.
+;;
+;; The fix attributes it through the SAME post-settle back-fill mechanism
+;; renders + sub-runs use (no parallel correlate-by-render-key path): it is
+;; back-filled into the cascade that CAUSED the teardown — the frame's
+;; most-recently-settled epoch — via the `:epoch/record-unmount!` hook. The
+;; unmount carries no structured projection row (it is neither a `:renders`
+;; nor a `:sub-runs` entry), so it rides ONLY the `:trace-events` slot,
+;; which is exactly where the Xray VIEWS projection reads it.
+(def ^:private unmount-ops
+  #{:rf.view/unmounted})
+
 (defn in-flight-cascade?
   "True when the frame's in-flight capture buffer already holds an
   `:event/run-start` emit — the canonical signal that a cascade has
@@ -162,7 +187,18 @@
   no in-flight cascade is back-filled into the causing epoch via the
   `:epoch/record-sub-run!` hook (sibling of `:epoch/record-render!`). An
   in-flight sub-run (a handler that subscribes, an SSR render) belongs to
-  the in-flight cascade and is buffered as before."
+  the in-flight cascade and is buffered as before.
+
+  Per rf2-59hx3: the same post-settle timing applies to a view UNMOUNT
+  (`:rf.view/unmounted`) — it fires at React teardown time, AFTER the
+  cascade that removed the view settled. Pre-fix it fell through to the
+  orphan-drop branch (no in-flight cascade + no `:dispatch-id`) and was
+  silently dropped, so a view teardown produced no signal. It is now
+  back-filled into the causing cascade (the most-recently-settled epoch)
+  via the `:epoch/record-unmount!` hook (sibling of the two above), where
+  it rides the epoch's `:trace-events` so Xray's VIEWS step can surface it.
+  An in-flight unmount (a synchronous teardown inside a drain) belongs to
+  that cascade and is buffered as before."
   [event]
   (when interop/debug-enabled?
     (let [op       (:operation event)
@@ -205,6 +241,25 @@
                (not (in-flight-cascade? frame-id)))
           (if-let [record-sub-run! (late-bind/get-fn-cached :epoch/record-sub-run!)]
             (record-sub-run! frame-id event)
+            (state/buffer-event! frame-id event))
+
+          ;; Post-settle view unmount — the teardown sibling (rf2-59hx3).
+          ;; A `:rf.view/unmounted` fires at React teardown time, AFTER the
+          ;; cascade that removed the view settled, so it carries a `:frame`
+          ;; tag but no `:dispatch-id` and arrives with an empty buffer.
+          ;; Pre-fix it hit the orphan-drop branch below and was silently
+          ;; dropped — the view teardown was an invisible absence. Back-fill
+          ;; it into the causing cascade (the most-recently-settled epoch)
+          ;; via `:epoch/record-unmount!` so it lands in that epoch's
+          ;; `:trace-events`, where Xray's VIEWS-step `unmounted-views-rows`
+          ;; reads it. An in-flight unmount (a synchronous teardown inside a
+          ;; drain) is buffered normally by the `:else` arm. Falls through to
+          ;; the normal buffer path during the pre-facade-install load-order
+          ;; window.
+          (and (contains? unmount-ops op)
+               (not (in-flight-cascade? frame-id)))
+          (if-let [record-unmount! (late-bind/get-fn-cached :epoch/record-unmount!)]
+            (record-unmount! frame-id event)
             (state/buffer-event! frame-id event))
 
           ;; Out-of-cascade orphan — drop from the capture buffer (rf2-avvwm).

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -166,6 +166,45 @@
         ;; render back-fill above.
         (notify-listeners! updated)))))
 
+;; ---- post-settle view-unmount back-fill (rf2-59hx3) -----------------------
+
+(defn record-unmount!
+  "Attribute a post-settle view-unmount emit to the cascade that CAUSED the
+  teardown (rf2-59hx3). The view-teardown sibling of `record-sub-run!`: a
+  `:rf.view/unmounted` trace fires at React `componentWillUnmount` /
+  `useEffect`-cleanup time — AFTER the cascade that removed the view settled
+  — so it cannot ride the in-flight cascade buffer (there is none).
+
+  Pre-rf2-59hx3 the unmount fell through `capture-event!`'s orphan-drop
+  branch (no in-flight cascade + no `:dispatch-id`) and was silently
+  dropped, so a view teardown produced NO signal in the epoch record and
+  Xray's VIEWS-step `unmounted-views-rows` — which reads `:rf.view/unmounted`
+  off `:trace-events` — had nothing to surface. The teardown was an
+  invisible absence.
+
+  This back-fills the unmount into the frame's most-recently-settled epoch
+  (the cascade that drove the teardown). Unlike `record-render!` there is NO
+  render-key mount-resolution and NO de-dup: an unmount is a one-shot
+  per-instance teardown that belongs to the settling cascade, exactly like a
+  post-settle sub-run. The unmount carries no structured projection row (it
+  is neither a `:renders` nor a `:sub-runs` entry), so `back-fill-event!` is
+  invoked with `row` nil — it rides ONLY the `:trace-events` slot. The
+  updated record is re-fanned to epoch listeners so snapshot consumers
+  (Xray's Views panel, which caches `epoch-history` at settle time) re-sync.
+
+  No-op when the frame has no settled epoch yet (an unmount before the first
+  cascade — e.g. a fixture teardown) or when the target epoch has been
+  evicted from the ring — `back-fill-unmount!` returns nil and we skip the
+  re-notify."
+  [frame-id event]
+  (when interop/debug-enabled?
+    (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
+      (when-let [updated (state/back-fill-unmount! frame-id epoch-id event)]
+        ;; Re-fan the corrected record so snapshot consumers re-read the
+        ;; ring. Same failure-isolated fan-out + no-loop contract as the
+        ;; render / sub-run back-fill above.
+        (notify-listeners! updated)))))
+
 (defn on-frame-destroyed!
   "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
   and rf2-v0jwt §Outcomes (`:halted-destroy`):

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -563,6 +563,19 @@
   [frame-id epoch-id sub-event sub-run-row]
   (back-fill-event! frame-id epoch-id :sub-runs sub-event sub-run-row))
 
+(defn back-fill-unmount!
+  "Back-fill a `:rf.view/unmounted` `unmount-event` into the already-
+  committed epoch `epoch-id` for `frame-id` (rf2-59hx3). Thin wrapper over
+  `back-fill-event!` — an unmount produces NO structured projection row (it
+  is neither a `:renders` nor a `:sub-runs` entry), so `row` is nil and the
+  event rides ONLY the `:trace-events` slot. That is exactly where Xray's
+  VIEWS-step `unmounted-views-rows` reads view teardowns. The `:slot`
+  argument is irrelevant when `row` is nil; `:renders` is passed for
+  documentary parity with the render sibling. Symmetric with
+  `back-fill-render!` / `back-fill-sub-run!`."
+  [frame-id epoch-id unmount-event]
+  (back-fill-event! frame-id epoch-id :renders unmount-event nil))
+
 ;; ---- per-cascade capture buffer -------------------------------------------
 ;;
 ;; Per Tool-Pair §Per-cascade capture: the drain runs traces through

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -149,6 +149,22 @@
                  {:rf.view/render-key render-key
                   :frame      frame-id})))
 
+(defn- emit-unmount!
+  "Emit a `:rf.view/unmounted` at React-TEARDOWN timing — op-type `:rf.view`,
+  tags carrying `:rf.view/id` + `:rf.view/render-key` + `:frame`, fired
+  post-settle (empty buffer, no `:rf.trace/dispatch-id`). Mirrors
+  `re-frame.views/emit-view-unmounted!`, which fires at React
+  componentWillUnmount / useEffect cleanup AFTER the cascade that removed
+  the view settled (rf2-59hx3). Pass a `view-id` (canonical `[view-id 0]`
+  render-key) or a full render-key tuple."
+  [frame-id view-or-rk]
+  (let [render-key (if (vector? view-or-rk) view-or-rk [view-or-rk 0])
+        view-id    (first render-key)]
+    (trace/emit! :rf.view :rf.view/unmounted
+                 {:rf.view/id         view-id
+                  :rf.view/render-key render-key
+                  :frame              frame-id})))
+
 (defn- emit-sub-run!
   "Emit a reactive `:rf.sub/run` at React-DEREF timing — op-type `:rf.sub/run`,
   tags carrying `:rf.sub/id` + `:rf.sub/query-v` + `:frame` plus the rf2-l1jz8
@@ -1086,3 +1102,136 @@
       ;; reset-mount-attribution! wipes everything left.
       (state/reset-mount-attribution!)
       (is (nil? (state/mount-epoch-for :test/dq2b7-b render-key))))))
+
+;; ===========================================================================
+;; INVARIANT 8 — a view UNMOUNT is back-filled into its CAUSING cascade's
+;;                :trace-events, not silently dropped (rf2-59hx3)
+;; ===========================================================================
+;;
+;; The teardown sibling of inv-2 (render) and inv-1 (sub-run). A
+;; `:rf.view/unmounted` fires at React teardown time — AFTER the cascade that
+;; removed the view settled — so it arrives at `capture-event!` with an empty
+;; in-flight buffer and no `:rf.trace/dispatch-id`.
+;;
+;; THE GAP (Mike-confirmed, button-deck button 13): pre-rf2-59hx3 the unmount
+;; was NOT in render-ops / sub-run-ops, so it fell through to the orphan-drop
+;; branch (no in-flight cascade + no dispatch-id) and was SILENTLY DROPPED.
+;; The view teardown produced no signal anywhere in the epoch record, so
+;; Xray's VIEWS-step `unmounted-views-rows` (which reads `:rf.view/unmounted`
+;; off `:trace-events`) had nothing to surface — an invisible absence.
+;;
+;; THE FIX: route the post-settle unmount through the SAME back-fill
+;; mechanism renders + sub-runs use (`:epoch/record-unmount!`), attributing
+;; it to the most-recently-settled epoch (the cascade that caused the
+;; teardown). The unmount carries no structured projection row, so it rides
+;; ONLY `:trace-events` — exactly where Xray reads it.
+
+(defn- unmounted-view-ids
+  "The view-ids carried by `:rf.view/unmounted` ops in a record's
+  :trace-events. nil-safe — a record whose :trace-events was elided
+  returns #{}."
+  [record]
+  (->> (:trace-events record)
+       (filter #(= :rf.view/unmounted (:operation %)))
+       (map #(-> % :tags :rf.view/id))
+       set))
+
+(deftest inv-8-view-unmount-back-filled-into-its-causing-cascade
+  (testing "rf2-59hx3 — a :rf.view/unmounted that fires AFTER the cascade
+            that removed the view settled (React-teardown timing) is
+            back-filled into that causing cascade's :trace-events, NOT
+            silently dropped. THE regression guard: pre-fix the unmount hit
+            the orphan-drop branch and produced no signal, so Xray's VIEWS
+            step had nothing to surface (button-deck button 13)."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed         (fn [_ _] {:show-child? true}))
+    (rf/reg-event-db :hide-child   (fn [db _] (assoc db :show-child? false)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    ;; The cascade that removes the child view from the tree. It settles,
+    ;; THEN (next tick, React teardown) the child instance's unmount fires.
+    (rf/dispatch-sync [:hide-child] {:frame :test/main})
+    (let [hide-epoch (last-epoch :test/main)]
+      (emit-unmount! :test/main :child-view)
+
+      (let [e (epoch-by-id :test/main hide-epoch)]
+        (is (= :hide-child (:event-id e)))
+        (is (contains? (unmounted-view-ids e) :child-view)
+            "the hide-child cascade carries the child-view unmount in its
+             :trace-events — the teardown is OBSERVABLE, not a silent
+             absence (pre-fix it was dropped at the capture seam)")
+        ;; The unmount carries no structured :renders row — it is a teardown,
+        ;; not a render. It rides ONLY :trace-events, where Xray reads it.
+        (is (not (contains? (rendered-view-ids e) :child-view))
+            "an unmount produces NO :renders row — it is a teardown, not a
+             render; it surfaces via :trace-events only")))))
+
+(deftest inv-8-unmount-attributed-to-its-own-cascade-multi-cascade
+  (testing "rf2-59hx3 — two cascades that tear down DIFFERENT views each
+            carry their OWN unmount, attributed to the cascade that caused
+            it (no one-epoch lag, no cross-attribution). The multi-cascade
+            assertion mirroring inv-2 for renders."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed       (fn [_ _] {:a? true :b? true}))
+    (rf/reg-event-db :hide-a     (fn [db _] (assoc db :a? false)))
+    (rf/reg-event-db :hide-b     (fn [db _] (assoc db :b? false)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+
+    (rf/dispatch-sync [:hide-a] {:frame :test/main})
+    (let [epoch-a (last-epoch :test/main)]
+      (emit-unmount! :test/main :view-a)
+
+      (rf/dispatch-sync [:hide-b] {:frame :test/main})
+      (let [epoch-b (last-epoch :test/main)]
+        (emit-unmount! :test/main :view-b)
+
+        (let [a (epoch-by-id :test/main epoch-a)
+              b (epoch-by-id :test/main epoch-b)]
+          (is (= :hide-a (:event-id a)))
+          (is (= :hide-b (:event-id b)))
+          (is (contains? (unmounted-view-ids a) :view-a)
+              "cascade A carries its OWN view-a unmount")
+          (is (not (contains? (unmounted-view-ids a) :view-b))
+              "cascade A does NOT carry cascade B's view-b unmount")
+          (is (contains? (unmounted-view-ids b) :view-b)
+              "cascade B carries its OWN view-b unmount")
+          (is (not (contains? (unmounted-view-ids b) :view-a))
+              "cascade B does NOT carry cascade A's lagged view-a unmount"))))))
+
+(deftest inv-8-in-flight-unmount-rides-current-cascade
+  (testing "rf2-59hx3 — an unmount that fires WITH a cascade in flight (a
+            synchronous teardown inside a drain) belongs to that cascade and
+            is buffered normally, NOT back-filled. Pins that the post-settle
+            routing does not poach an in-flight unmount."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :unmount-during
+      (fn [db _]
+        (trace/emit! :rf.view :rf.view/unmounted
+                     {:rf.view/id         :inline-view
+                      :rf.view/render-key [:inline-view 0]
+                      :frame              :test/main})
+        (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:unmount-during] {:frame :test/main})
+
+    (let [epoch (last-epoch :test/main)]
+      (is (= :unmount-during (:event-id epoch)))
+      (is (contains? (unmounted-view-ids epoch) :inline-view)
+          "an in-flight unmount rides its own cascade (buffered, not
+           back-filled to a prior settled epoch)"))))
+
+(deftest inv-8-orphan-unmount-before-any-cascade-is-noop
+  (testing "rf2-59hx3 — an unmount that fires before any cascade has settled
+            (no last-settled epoch for the frame) is a silent no-op: no
+            record materialises, no listener fan-out, no throw."
+    (rf/reg-frame :test/main {})
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watcher (fn [r] (swap! seen conj r)))
+      (emit-unmount! :test/main :orphan-view)
+      (is (= [] (rf/epoch-history :test/main))
+          "no record materialised from an orphan unmount")
+      (is (= [] @seen)
+          "no listener fan-out for an unmount with no causing cascade"))))


### PR DESCRIPTION
## What

A view unmount (button-deck / standard_epochs **button 13**, `:button-deck/unmount-view`) produced **no signal in Xray** — the teardown was an invisible absence.

## Which surface had the gap

**Neither the Views lens nor the Xray `:renders` projection** — both consumer surfaces were already correct (Xray's VIEWS-step `unmounted-views-rows` reads `:rf.view/unmounted` off `:trace-events`, rf2-gmw1i; the L2 sub-dispose stream `:rf.sub/dispose` was already recorded + tested).

The gap was **framework-side capture (`re-frame.epoch.capture`)**. A `:rf.view/unmounted` op fires at React teardown time, **after** the cascade that removed the view settled, so it arrives with an empty in-flight buffer and no `:rf.trace/dispatch-id`. It was not in `render-ops` / `sub-run-ops`, so it fell through to the **orphan-drop branch** and was **silently dropped** — starving the (already-correct) Xray surface.

## The fix (bead Option 1 — one attribution mechanism, no parallel path)

Route the post-settle unmount through the **same back-fill mechanism renders + sub-runs use**, attributing it to the cascade that caused the teardown (the frame's most-recently-settled epoch). The unmount carries no structured projection row (it is neither a `:renders` nor a `:sub-runs` entry), so it rides **only** `:trace-events` — exactly where Xray reads it. Renders + sub-runs + unmounts are now symmetric.

- `capture.cljc`: new `unmount-ops` set + post-settle routing branch (sibling of render / sub-run).
- `listeners.cljc`: `record-unmount!` (sibling of `record-sub-run!`) — attribute to last-settled epoch, no mount-resolution / no de-dup, re-fan listeners.
- `state.cljc`: `back-fill-unmount!` thin wrapper (row nil → `:trace-events` only).
- `epoch.cljc`: publish `:epoch/record-unmount!` late-bind hook.
- `late_bind/directory.cljc`: sibling directory entry.

## Core touch

Touched `implementation/core/src/re_frame/late_bind/directory.cljc` (the late-bind registry entry). This is **NOT** `re-frame.features` — **no overlap with #2741**. Core `clojure -M:test` green (below).

## Regression test (failing-before / passing-after)

INVARIANT 8 added to `epoch_attribution_test.clj`: unmount back-filled into its causing cascade's `:trace-events`; multi-cascade no-lag / no cross-attribution; in-flight unmount rides current cascade; orphan unmount before any cascade is a no-op. **Verified failing-before**: with the capture routing reverted, the 3 attribution assertions fail (`#{}` — the unmount is dropped); they pass with the fix.

## Xray spec

Unchanged — `012-Views.md` / `018-Event-Spine.md` already specify the VIEWS unmounted-group surface (rf2-gmw1i). The gap was framework-side capture starving it, not an Xray contract change.

## Quality gates

- epoch `clojure -M:test`: **242 tests, 875 assertions, 0 failures, 0 errors** (incl. 4 new inv-8 tests)
- `npm run test:cljs`: **5175 tests, 17575 assertions, 0 failures, 0 errors**
- `npm run test:xray-feature-gate`: **16 scenarios, 0 failures, 13 matrix rows** (one routes-epochs flake on first run — http-server exit; passed clean on re-run; unrelated to this change)
- xray `clojure -M:test`: **1038 tests, 4146 assertions, 0 failures, 0 errors**
- core `clojure -M:test`: **832 tests, 3681 assertions, 0 failures, 0 errors** (late-bind drift green)
- clj-kondo on changed files: **errors 0, warnings 0**
- standard-epochs testbed build: **165 files, 0 warnings**
- mkdocs: N/A (no tools/xray/spec prose touched)