### PR TITLE
docs(schemas): comment & docstring quality pass (rf2-kdoai.12)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/malli.cljc
+++ b/implementation/schemas/src/re_frame/schemas/malli.cljc
@@ -28,22 +28,36 @@
   to whatever's published; absent any publisher they soft-pass per the
   Spec 010 §Recommended soft-pass rule.
 
-  Users opt in by requiring this namespace at app boot — same pattern
-  on both CLJS and the JVM (rf2-qyfie removed the JVM `requiring-resolve`
-  fallback so the contract is symmetrical):
+  Post-rf2-v96fh (schema implies validation) apps do NOT require this
+  namespace explicitly: the `re-frame.schemas` facade `:require`s it for
+  its ns-load side effect, so loading the schemas artefact publishes the
+  Malli hooks automatically and the default validator is LIVE the moment
+  a schema is registered — same on both CLJS and the JVM (rf2-qyfie
+  removed the JVM `requiring-resolve` fallback so the contract is
+  symmetrical):
 
       (ns my-app.core
         (:require [re-frame.core :as rf]
-                  [re-frame.schemas]         ;; load the schemas artefact
-                  [re-frame.schemas.malli])) ;; publish Malli into the hook table
+                  [re-frame.schemas])) ;; transitively loads this adapter
 
-  Apps that want to drop the Malli surface entirely (per rf2-qnxf
-  bundle audit) do NOT require this namespace and either:
+  (A standalone `(:require [re-frame.schemas.malli])` still works and is
+  harmless — the hook publication is idempotent — but is no longer
+  required. Pre-v96fh it WAS the opt-in: the adapter had to be required
+  separately or schemas soft-passed silently.)
 
-    - Leave the default in place (soft-pass; no failure traces fire).
-    - Call `(rf/set-schema-validator! my-validator-fn)` at boot to
-      install a custom validator.
-    - Call `(rf/set-schema-validator! nil)` for a hard no-op."
+  Because the facade pulls Malli in, the only Malli-FREE posture is to
+  not require `re-frame.schemas` at all (per rf2-qnxf bundle audit — the
+  no-feature counter reference app). An app that DOES use schemas but
+  wants to drop Malli's validation *behaviour* (it still pays the bundle
+  cost under static CLJS compilation, since requiring the facade loads
+  this ns's body) either:
+
+    - Calls `(rf/set-schema-validator! my-validator-fn)` at boot to
+      install a custom validator, or
+    - Calls `(rf/set-schema-validator! nil)` for a hard no-op.
+
+  See the `re-frame.schemas` ns docstring (rf2-v96fh) for the full
+  bundle-isolation tradeoff."
   (:require [malli.core]
             [malli.error]
             [re-frame.late-bind :as late-bind]))

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -63,20 +63,35 @@
 ;;
 ;; Per Spec 010 §Recommended soft-pass, the schemas artefact ships with a
 ;; Malli-delegating default validator that returns true ("pass") when the
-;; `:schemas/malli-validate` late-bind hook is unbound — i.e. when the
-;; `re-frame.schemas.malli` adapter ns hasn't been required at app boot.
-;; This is intentional (apps that swap in a non-Malli validator must work),
-;; but it has a footgun: a `reg-app-schema` call WITH the default validator
-;; AND no Malli adapter loaded validates nothing. Boundary-validated
-;; handlers silently accept untrusted input.
+;; `:schemas/malli-validate` late-bind hook is unbound — i.e. when nothing
+;; has published Malli's `validate` into the late-bind table. This is
+;; intentional (apps that swap in a non-Malli validator must work), but a
+;; `reg-app-schema` call WITH the default validator AND that hook unbound
+;; validates nothing — boundary-validated handlers silently accept
+;; untrusted input. This warning is the dev-time nudge for that state.
+;;
+;; Post-rf2-v96fh (schema implies validation) the *common* path can no
+;; longer reach it: the `re-frame.schemas` facade now `:require`s
+;; `re-frame.schemas.malli` itself, so loading the schemas artefact binds
+;; `:schemas/malli-validate` at ns-load and the default validator is LIVE
+;; the moment a schema is registered. The warning therefore fires only in
+;; the two residual cases — symmetric with `validator.cljc`'s soft-pass
+;; fallback doc:
+;;   (1) a non-Malli port / app that installed its own validator via
+;;       `set-schema-validator!` but left the Malli hook unbound (it
+;;       opted out of Malli, so condition 2 below is false — NO warning;
+;;       see the closing note), or
+;;   (2) a test harness that deliberately unbinds `:schemas/malli-validate`
+;;       to exercise the absent-validator path.
 ;;
 ;; The warning fires once per process from `reg-app-schema` /
-;; `reg-app-schemas` when:
+;; `reg-app-schemas` when BOTH hold:
 ;;   1. `:schemas/malli-validate` late-bind hook is unbound, AND
 ;;   2. `validator-fn` is still the framework default.
 ;;
 ;; Apps that registered a non-default validator (a Zod port, clojure.spec
-;; bridge, etc.) opted out of Malli explicitly — no warning.
+;; bridge, etc.) opted out of Malli explicitly — condition 2 is false, so
+;; no warning.
 
 (defonce ^:private validator-unavailable-warned
   ;; Process-lifecycle one-shot. Reset by `clear-validator-unavailable-warned!`
@@ -371,12 +386,15 @@
          meta         (source-coords/merge-coords
                         {:schema schema :path path :frame frame-id})]
      (swap! schemas-by-frame assoc-in [frame-id path] meta)
-     ;; Per rf2-fq7d2: dev-time nudge when the Malli adapter is unloaded
-     ;; AND the framework-default validator is still installed — the
-     ;; default soft-passes per Spec 010 §Recommended soft-pass, so a
-     ;; reg-app-schema with no validator wired up validates nothing.
-     ;; Production elides via the outer `interop/debug-enabled?` gate
-     ;; (Spec 009 §Production builds).
+     ;; Per rf2-fq7d2: dev-time nudge when `:schemas/malli-validate` is
+     ;; unbound AND the framework-default validator is still installed —
+     ;; the default soft-passes per Spec 010 §Recommended soft-pass, so a
+     ;; reg-app-schema with no validator wired up validates nothing. Note
+     ;; that post-rf2-v96fh the facade auto-requires the Malli adapter, so
+     ;; this only fires for a substitute-validator port or a test that
+     ;; unbinds the hook (see the warning block above). Production elides
+     ;; via the outer `interop/debug-enabled?` gate (Spec 009 §Production
+     ;; builds).
      (when interop/debug-enabled?
        (maybe-warn-validator-unavailable!)
        ;; Per rf2-jsokn: dev-time nudge when the registered schema is

--- a/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
@@ -7,11 +7,16 @@
   Background — Spec 010 §Recommended soft-pass: the schemas artefact
   ships with a Malli-delegating default validator that returns true
   ('pass') when the `:schemas/malli-validate` late-bind hook is
-  unbound — i.e. when `re-frame.schemas.malli` hasn't been required
-  at app boot. This is intentional (apps that swap in a non-Malli
-  validator must work), but it has a footgun: a `reg-app-schema`
-  call with no validator wired up validates nothing. The warning
-  surfaces this misconfiguration once per process.
+  unbound. This is intentional (apps that swap in a non-Malli
+  validator must work), but a `reg-app-schema` call with no validator
+  wired up validates nothing. The warning surfaces this once per
+  process.
+
+  Post-rf2-v96fh the `re-frame.schemas` facade auto-requires the Malli
+  adapter, so the common path keeps the hook bound and the warning is
+  effectively reserved for a substitute-validator port or this test's
+  deliberate unbind (see `with-unbound-malli-validate`, which simulates
+  the unbound state rather than unloading the ns).
 
   The warning is suppressed when:
     - The Malli adapter is loaded (`:schemas/malli-validate` is


### PR DESCRIPTION
Comment & docstring quality pass over `implementation/schemas` (rf2-kdoai.12, comment-review sweep). **Behaviour-preserving: docstrings/comments only, no logic change.**

## What changed

The slice is already exhaustively documented — every public-surface docstring, why-comment (v96fh schema-implies-validation, the :sensitive? per-slot flag, the 52dfy bare-keyword/opts contract, the 13meg validator/explainer/printer bundle split, the walker :maybe descent) is present and accurate in `schemas.cljc`, `validator.cljc`, `walker.cljc`, `validate.cljc`, and `digest.cljc`. No padding added.

The one actionable category was **post-rf2-v96fh drift** — three comment blocks still described the pre-v96fh silent soft-pass ("forgot to require the adapter → validates nothing") as the *current* trigger. Post-v96fh the `re-frame.schemas` facade `:require`s the Malli adapter itself, so the common path always binds the hook and that scenario is no longer reachable normally; the warning is now reserved for the residual cases (substitute-validator port, or a test that unbinds the hook). Fixed to the current contract, symmetric with `validator.cljc`'s already-correct framing:

- `storage.cljc` — validator-unavailable warning block + the inline `reg-app-schema` nudge comment.
- `malli.cljc` — ns docstring: apps no longer require `re-frame.schemas.malli` explicitly (facade pulls it transitively); the only Malli-free posture is not requiring `re-frame.schemas` at all.
- `schemas_validator_unavailable_warning_test.clj` — ns docstring: same post-v96fh clarification (the test already simulates the unbound state correctly).

## Quality gates

Behaviour-preserving: docstrings/comments only, no logic change.

- schemas `clojure -M:test` — **224 tests, 18353 assertions, 0 failures, 0 errors.**
- `npm run test:cljs` — **5184 tests, 17655 assertions, 0 failures, 0 errors.**
- clj-kondo on the 3 changed files — **0 errors.** One pre-existing `re-frame.trace required but never used` warning in the test file (present on HEAD before this change; not touched — out of scope for a comment pass).

Do NOT merge.