### PR TITLE
docs(testbed-support): comment & docstring quality pass (rf2-kdoai.23)

### DIFF
--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -23,10 +23,10 @@
   script) resolves the repo root from its OWN location via node's
   `path` module — which works identically on Windows, macOS, and Linux —
   exports it as the `RF2_TESTBED_PROJECT_ROOT` env var, and spawns
-  `shadow-cljs`. The 6 affected builds in
-  `implementation/shadow-cljs.edn` seed the define from that env var via
-  `#shadow/env`, so the absolute root is the ACTUAL repo root of whatever
-  checkout did the build — never a literal.
+  `shadow-cljs`. Every testbed build in `implementation/shadow-cljs.edn`
+  (the Xray testbeds plus the Story testbeds + static build) seeds the
+  define from that env var via `#shadow/env`, so the absolute root is the
+  ACTUAL repo root of whatever checkout did the build — never a literal.
 
   `resolve-project-root` then joins that root with the tool-relative
   testbed subdir (`\"tools/xray/testbeds\"` /  `\"tools/story/testbeds\"`)


### PR DESCRIPTION
Per-slice commenting & explanation review sweep (rf2-kdoai epic, child .23, slice = `tools/testbed-support`). Behaviour-preserving: docstrings/comments only, no logic change.

## What this slice is

One source namespace (`re-frame.testbed.config`) + its CLJS unit test + a README. The earlier testing sweep (rf2-ynjts.23) left this slice with thorough, accurate docstrings and why-comments. The public surface (`resolve-project-root`, the `repo-root` goog-define), the resolution-order rationale, the cross-platform/build-env-derived design, the `?project-root=` override, and the graceful-no-op contract are all already well explained.

## The one finding (DRIFT fix)

The `config.cljs` ns docstring stated, present-tense, "**The 6 affected builds** in `implementation/shadow-cljs.edn` seed the define". Verified against the codebase: there are now **10** `re-frame.testbed.config/repo-root` `#shadow/env` seed sites (six Xray testbeds + the Story testbeds + the static story build), not six. The "six" was the historical count of hardcoded-string copies removed in rf2-5dphw ("All 6 testbeds updated") — accurate as history, but restating it as a present-tense build count had become stale/misleading (worse than none, per the charter's DRIFT criterion). Reworded to the build-agnostic "every testbed build ... seeds the define".

No other change. The README's "six copies" phrasing is purely historical (describing what rf2-5dphw removed) and makes no present-tense seed-count claim, so it is accurate and left as-is. Did NOT pre-emptively rename frame-db (rf2-1i168 sweeps later).

## Quality gates

- `npm run test:cljs`: **5184 tests / 17655 assertions, 0 failures, 0 errors** (this is the surface that runs `config_cljs_test.cljs` via the `cljs-test$` ns regexp).
- testbed-support `clojure -M:test`: **N/A** — this directory has no `deps.edn`/`:test` alias (consumed purely as an extra source path); its tests run under `npm run test:cljs` above, exactly as documented in the test ns and README.
- clj-kondo on changed file: **0 errors, 0 warnings**.

Behaviour-preserving: docstrings/comments only, no logic change.

Closes rf2-kdoai.23.