### PR TITLE
docs(template): comment & docstring quality pass (rf2-kdoai.22)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/template.edn
+++ b/tools/template/resources/day8/re_frame2_template/template.edn
@@ -1,8 +1,11 @@
-;; deps-new template config for day8/re-frame2-template (rf2-dolpf §2.1).
+;; deps-new template config for day8/re-frame2-template
+;; (rf2-dolpf §2.2-2.4, rf2-c2770).
 ;;
-;; Spike scope: Reagent-only. The full three-substrate matrix lands in
-;; §2.2 (rf2-c2770). See tools/template/spec/003-DepsNew-Rebuild-Plan.md
-;; for the migration plan.
+;; Scope: the full three-substrate matrix (Reagent / UIx / Helix), with
+;; an optional Story playground on Reagent. The matrix is built at run
+;; time by `template-fn` (see the `:transform` note below); this EDN only
+;; declares the hook fns. See tools/template/spec/003-DepsNew-Rebuild-Plan.md
+;; for the migration plan and §-by-§ status.
 ;;
 ;; deps-new resolution mechanics:
 ;;
@@ -13,7 +16,7 @@
 ;;     `day8/re_frame2_template/template.edn`. This file lives at
 ;;     that path under `tools/template/resources/`.
 ;;
-;;   - §2.1 spike — local-dev / smoke:
+;;   - Current (pre-§3-split) local-dev / smoke:
 ;;     `clojure -Sdeps '{:deps {day8/re-frame2-template
 ;;                              {:local/root "./tools/template"}}}'
 ;;       -Tnew create :template day8/re-frame2-template
@@ -35,9 +38,9 @@
 ;;     `io/github/day8/re_frame2_template/template.edn`). §3 moves
 ;;     the resources to the `io/github/day8/...` path inside the
 ;;     extracted `day8/re-frame2-template` repo so the steady-state
-;;     invocation works against the published artefact. §2.1 ships
-;;     the `day8/...` path only — switching to the published path
-;;     is mechanical (a directory rename) once the repo split lands.
+;;     invocation works against the published artefact. The current
+;;     tree ships the `day8/...` path only — switching to the published
+;;     path is mechanical (a directory rename) once the repo split lands.
 ;;
 ;; The static `:transform` is intentionally absent — `template-fn`
 ;; (in `src/day8/re_frame2_template/hooks.clj`) builds the transform


### PR DESCRIPTION
Per-slice commenting & explanation sweep for **tools/template** (rf2-kdoai.22, charter in rf2-kdoai). Behaviour-preserving: docstrings/comments only, no logic change.

## Findings

The slice is exceptionally well-documented already — `hooks.clj`, the four JVM test files, `test_support.clj`, `deps.edn`, and the emitted scaffold (`events.cljs`/`subs.cljs`/`schema.cljs`/`core.cljs`/`scratch.cljs`) all carry accurate, non-padding docstrings + why-comments. No additions warranted there.

**One genuine DRIFT, fixed:** `resources/day8/re_frame2_template/template.edn`'s header described the file as the *§2.1 spike (Reagent-only)* with "the full matrix lands in §2.2" — but the file (its `:description` + the `hooks.clj` it points to) implements the full Reagent/UIx/Helix matrix today (§2.2-2.4 / rf2-c2770, shown ✓ in spec/003). The header told a reader the file was at an earlier stage than it is. Corrected the header scope line and relabelled the "§2.1 spike" local-dev invocation as the current pre-§3-split workflow (the §3-steady-state contrast is load-bearing and kept). The other `Reagent-only` references (the `:include-story?` v1 guard) are accurate and left untouched.

## Quality gates

- template `clojure -M:test`: **25 tests, 316 assertions, 0 failures, 0 errors** (emission unchanged — confirms the comment-only change to template.edn doesn't alter what's emitted).
- `template.edn` parses as a valid map (`clojure.edn/read-string` → map? true).
- clj-kondo on the changed file: **0 errors, 0 warnings**.
- `npm run test:cljs`: **not run** — the only change is a comment block in a `tools/template` deps-new EDN data file; it is not on the `implementation/` CLJS classpath and cannot affect CLJS behaviour. (Worktree `implementation/node_modules` is uninstalled; a fresh install + cold shadow compile would be ~minutes for an orthogonal gate.)

Behaviour-preserving: docstrings/comments only, no logic change. Do not merge.