### PR TITLE
docs(skills/xray): comment & explanation clarity pass (rf2-kdoai.37)

### DIFF
--- a/skills/re-frame2-xray/references/launch-modes.md
+++ b/skills/re-frame2-xray/references/launch-modes.md
@@ -163,17 +163,28 @@ guarded so a second call is a no-op.
 
 (xray/init!
  {:default-frame :app/main ; target-frame for the scrubber
- :theme :dark ; / :light / :high-contrast
- :density :compact ; / :cosy
- :ai-provider {:provider :claude}
- :buffer-depths {:trace 200 :epoch 50}})
+ :theme :dark ; / :light (settings persist)
+ :density :compact ; / :cosy (settings persist)
+ :buffer-depths {:epoch 50}}) ; per-frame ring depth
 ```
 
-Pre-alpha posture: `:default-frame` threads through to the
-`:rf.xray/set-target-frame` event. The other keys (`:theme`,
-`:density`, `:ai-provider`, `:buffer-depths`) are accepted today but
-not yet wired at runtime — passing them keeps host code forward-
-compatible. See `core.cljs` docstring for the current frontier.
+All four opts are wired today (the recognised set is exactly
+`:default-frame :theme :density :buffer-depths`, per the `init!` docstring
+in [`core.cljs`](../../../tools/xray/src/day8/re_frame2_xray/core.cljs)):
+
+- `:default-frame` dispatches `:rf.xray/set-target-frame`.
+- `:theme` / `:density` write the persisted Settings shape and apply the
+ matching class / font-size immediately (no reload).
+- `:buffer-depths` honours `{:epoch <n>}` only — it drives the substrate's
+ per-frame ring (depth + trace-keep to the same `n`). A `:trace` axis is
+ **silently dropped** (folded into the one `:epoch` knob per the rf2-3g9nw
+ D1=a ruling — one operator knob, atomic relationship).
+
+Unknown opt keys are silently ignored for forward-compat — so an `init!`
+that worked against a newer Xray won't break an older one. (There is **no**
+`:ai-provider` opt — AI access is the separate `re-frame2-pair-mcp` jar,
+not an `init!` knob.) See the `core.cljs` `init!` docstring for the
+authoritative per-opt contract.
 
 ## Pop-out to a second window
 


### PR DESCRIPTION
Per-slice commenting & explanation review sweep (rf2-kdoai child .37, slice = `skills/re-frame2-xray`). Behaviour-preserving prose-clarity pass.

## What changed

Fixed one genuine API drift in `references/launch-modes.md` §Programmatic `init!`, verified against the authoritative `init!` docstring in `tools/xray/src/day8/re_frame2_xray/core.cljs`:

- **Dropped the non-existent `:ai-provider` opt.** `init!` never destructures it and there is zero `ai-provider` reference anywhere in `tools/xray/src` — the example was advertising a key silently ignored as unknown. AI access is the separate `re-frame2-pair-mcp` jar, not an `init!` knob.
- **Corrected the stale 'accepted today but not yet wired at runtime' claim.** `:theme` / `:density` / `:buffer-depths` ARE wired today (they write the persisted Settings shape and apply class/font-size/ring-depth immediately).
- **`:buffer-depths` honours `{:epoch <n>}` only** — the prior example passed `:trace 200`, which is silently dropped (folded into the one `:epoch` knob per rf2-3g9nw D1=a).
- **Dropped `:high-contrast` from the `:theme` example** — `settings/effects.cljs` flags it as a future theme, not a current valid value.

## Verified-clear (no change)

The rest of the slice is accurate against current Xray code: 6 Dynamic + 5 Static panels (confirmed by the `reg-l4-tab!` registrations); the Dynamic `:order` values (Epoch -1, app-db 1, Views 2, Trace 3, Machine 4, Routes 6); the no-Issues-tab / no-Event-tab / no-Chrome-A11y-tab landings; the `:rf.xray/issues-ribbon` signal + `cascade-has-issue?` + `issue-event?` + `install-auto-open-watcher!`; `popout!` / `open!` / `toggle!`; the L2 badge glyph set. No further edits needed.

## Quality gates

- `python scripts/check_skill_mcp_drift.py` — exit 0 (clean)
- `python scripts/check_doc_slugs.py` — exit 0 (clean)
- clj-kondo — N/A (no `.cljs` changed; the slice has no code, all prose)

Behaviour-preserving: comments/prose clarity only, no logic/tool change.

Closes rf2-kdoai.37.