### PR TITLE
docs(xray): comment & docstring quality pass (rf2-kdoai.24)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/epoch.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/epoch.cljs
@@ -13,8 +13,10 @@
   - `panels.reactive-panel-subs` reads `:rf.xray/epoch-history` to
     project the focused cascade's `:trace-events` into the Reactive
     panel's sub-cascade + view-re-render rendering (rf2-wyvf2).
-  - `core/active-frame` + `core/set-target-frame!` read / dispatch the
-    target-frame slot and `:rf.xray/set-target-frame` event.
+  - `core/target-frame` + `core/set-target-frame!` read / dispatch the
+    target-frame slot and `:rf.xray/set-target-frame` event. (Pre
+    rf2-kmhvg the reader was `core/active-frame`; the rename eliminated
+    the `active` / `target` split.)
   - `preload/install-epoch-listener!` dispatches `:rf.xray/epoch-
     recorded` whenever the framework records a new epoch (any frame).
   - `mount.cljs` seeds `:rf.xray/sync-epoch-history` at first open.

--- a/tools/xray/src/day8/re_frame2_xray/self_noise.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/self_noise.cljc
@@ -30,8 +30,9 @@
      cascades whose `:event` vector's head is a keyword in the
      `rf.xray` namespace (`:rf.xray/focus-cascade`,
      `:rf.xray/select-tab`, `:rf.xray/open-settings`, etc.). These
-     can be dispatched WITHOUT a `{:frame :rf/xray}` option (the
-     palette's quick-actions, the headless `core/select-panel!` helper);
+     can be dispatched WITHOUT a `{:frame :rf/xray}` option (e.g. the
+     palette's quick-actions, whose `:palette/select-panel` verb lowers
+     into a plain `[:dispatch [:rf.xray/select-tab …]]` with no `:frame`);
      the framework chain-resolves them onto `:rf/default` and the
      trace envelope carries `:frame :rf/default` — so the frame gate +
      `xray-internal-event?` both miss them. The data-layer filter at


### PR DESCRIPTION
Comment & docstring quality pass over `tools/xray` (rf2-kdoai.24, slice = tools/xray). **Behaviour-preserving: docstrings/comments only, no logic change.**

## What changed

Two genuine stale why-comments (drift — worse than none) fixed:

1. **`epoch.cljs`** ns docstring referenced `core/active-frame`, which was renamed to `core/target-frame` (rf2-kmhvg eliminated the `active`/`target` split — documented in `core.cljs`). Updated the cross-ref + noted the rename.
2. **`self_noise.cljc`** ns docstring cited a non-existent `core/select-panel!` helper as a headless-dispatch example. No such fn exists. Replaced with the real mechanism: the palette's `:palette/select-panel` verb lowers into a plain `[:dispatch [:rf.xray/select-tab …]]` with no `:frame`, which is the actual frame-less chain-resolve-to-`:rf/default` path the predicate guards against.

## What was verified clean (no edit — already accurate)

The slice has had four prior doc passes land (kdoai.1/.7/.12/.23). I verified the charter's called-out surfaces are already accurately documented and left them untouched:

- Public surface: `core` / `mount` / `panels` / `focus` / `runtime` docstrings (init!/open!/popout!/the panels mount API).
- Safe-egress `self-noise` predicates + `trace-collector`.
- The 59hx3 view-unmount + L2 sub-dispose teardown signal — the Xray *consumer* side (`reactive_panel_subs`, `trace_helpers`) reads `:rf.view/unmounted` / `:rf.sub/dispose` and is well-commented incl. the rf2-uo4e2 dispose-singular fix; the 59hx3 fix itself was framework-side (`implementation/`, out of slice).
- Machine-trace sub-namespacing (`:rf.machine.spawn/spawned`, `:rf.machine.lifecycle/spawned`) in `epoch/projection`.
- The 6-panel focus enum (7b1z4), `mount-panel!` internal-but-stable (jw2ny), interceptor-row one-line layout + flat error block (rvxem/iizhe in `epoch/view`).

## Follow-up filed

**rf2-7g5f1** — the keybindings-help table in `settings/view.cljs` lists stale `h Handler tab` + `i Issues tab` rows (should be `e Epoch tab` + `r Routes tab` per the current `reg-l4-tab!` registry). Deferred because that is rendered modal UI content (data), not a code comment — outside this comment-only sweep's behaviour-preserving mandate.

## Quality gates

- xray `clojure -M:test`: **PASS** — 1038 tests, 4146 assertions, 0 failures, 0 errors (behaviour UNCHANGED).
- clj-kondo on changed files: **PASS** — 0 errors, 0 warnings (`epoch.cljs`, `self_noise.cljc`).
- `npm run test:cljs`: not run locally — full `implementation/` install + node runtime; comment-only change provably behaviour-neutral (loaded clean under the JVM suite above).
- `npm run test:xray-feature-gate`: not runnable in this worktree — Playwright not installed (`Cannot find module 'playwright'`); browser gate, env-setup not a test result. Comment-only change cannot affect it.

Behaviour-preserving: docstrings/comments only, no logic change. Xray spec unchanged (no spec-visible behaviour touched).