### PR TITLE
docs(examples/reagent): comment & explanation clarity pass (rf2-kdoai.25)

### DIFF
--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -38,7 +38,6 @@
 
    Run from `implementation/`:
 
-     npm run test:examples       (Playwright smoke + headless tests)
      shadow-cljs watch examples/long-running-work
                                   (iterate against a live browser)
 

--- a/examples/reagent/long_running_work/worker.cljs
+++ b/examples/reagent/long_running_work/worker.cljs
@@ -43,7 +43,7 @@
   "How many mock items each child processes per shard. Three shards
    running in parallel at 50ms/item produces a ~5-second job that's
    long enough to demonstrate progress visibly and short enough to
-   keep the Playwright smoke fast."
+   keep the headless test fast."
   100)
 
 (def default-tick-ms

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -20,9 +20,9 @@
   This example is intentionally minimal — the heavy contract testing
   lives in the JVM smoke (re-frame.http-managed-test) and the
   conformance fixtures (spec/conformance/fixtures/
-  http-managed-*.edn). Playwright's role is the cross-substrate sanity
-  check: the same fx, the same reply shape, end-to-end through Reagent
-  and Fetch."
+  http-managed-*.edn). The example itself is the runnable
+  cross-substrate sanity check: the same fx, the same reply shape,
+  end-to-end through Reagent and Fetch."
   (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -77,8 +77,8 @@
 ;; intercepts plain primary-button clicks to dispatch `:rf/url-requested`,
 ;; and defers modifier-key / auxiliary-button (middle-click) clicks to the
 ;; browser so the native open-in-new-tab affordance is preserved. Any
-;; passthrough HTML attrs on the props map (e.g. `:data-testid` used by
-;; the Playwright spec) land on the underlying `<a>`.
+;; passthrough HTML attrs on the props map (e.g. `:data-testid`) land
+;; on the underlying `<a>`.
 
 (reg-view home-page []
   [:div

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -1,8 +1,9 @@
 (ns state-machine-walkthrough.views
   "Browser entry-point for the state-machines walkthrough.
 
-  The pure machine, fxs, subs and headless tests live in `core.cljc`
-  alongside docs/guide/12-machines.md. This namespace is the
+  The pure machine, fxs and subs live in `core.cljc` alongside
+  docs/guide/12-machines.md; the headless tests live in the sibling
+  `test/state_machine_walkthrough/core_test.cljc`. This namespace is the
   CLJS-only browser layer: views + Reagent mount + a `run` fn that
   installs a per-frame `:fx-overrides` redirecting `:rf.http/managed`
   to the canned-failure stub registered in `core.cljc`.
@@ -10,8 +11,9 @@
   Why canned-failure: the chapter's headline scenario is the lockout
   flow — three failed attempts that cycle :submitting → :error-shown
   → :idle, then a fourth submit that fails the `:under-retry-limit`
-  guard and lands at `:locked-out`. The Playwright spec walks through
-  exactly that path, so the stub needs to fail every request."
+  guard and lands at `:locked-out`. That path is exactly what the
+  headless tests under `test/state_machine_walkthrough/` walk
+  through, so the stub needs to fail every request."
   (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
@@ -66,8 +68,8 @@
              "Dismiss"]])]))))
 
 (reg-view ^{:doc "Top banner reflecting the machine's current state. The
-                  Playwright spec watches this element to assert the lockout
-                  transition."}
+                  `data-state` attribute surfaces the state keyword so a
+                  test can assert the lockout transition."}
           status-banner []
   (let [state @(subscribe [:auth.login/state])]
     [:div.banner

--- a/examples/reagent/todomvc/README.md
+++ b/examples/reagent/todomvc/README.md
@@ -15,7 +15,6 @@ The shape deliberately echoes the v1 example's teaching split:
 - The canonical TodoMVC behavior: add, edit, toggle, clear completed, remaining count, and hash-filter routing.
 - Browser-only persistence via a registered fx and a cofx-backed initial load.
 - A v1-style separation of data/events/subs/views, but on the current re-frame2 API surface.
-- Headless browser verification through the Playwright example harness.
 
 ### Why localStorage and not :rf.http/managed?
 
@@ -23,7 +22,9 @@ TodoMVC persists locally so the example stays small and dependency-free. The can
 
 ## Official assets
 
-The example stages the official TodoMVC CSS packages at test/build time:
+The example uses the official TodoMVC CSS packages, pinned in
+`implementation/package.json` (so `npm install` fetches them into
+`node_modules/`) rather than vendored into this repo:
 
 - `todomvc-common` `1.0.5`
 - `todomvc-app-css` `2.4.3`
@@ -32,11 +33,18 @@ That keeps the rendered surface close to the current TodoMVC template without ve
 
 ## Running it
 
-From `implementation/`:
+From `implementation/`, iterate against a live browser:
 
 ```bash
 npm install
-npm run test:examples
+shadow-cljs watch examples/todomvc
 ```
 
-That compiles the example, stages its HTML and TodoMVC CSS assets into `out/examples/todomvc/`, serves the output, and runs the Playwright smoke spec.
+Stage the `index.html` (and the TodoMVC CSS from `node_modules/`) next
+to the build's `main.js` under `out/examples/todomvc/` and serve that
+directory over HTTP.
+
+Per the test-free examples policy this example carries no per-example
+spec; real-regression coverage of the primitives it exercises lives in
+the substrate contract tests (`npm run test:cljs`) and the framework
+gates (see [`examples/README.md`](../../README.md)).

--- a/examples/reagent/websocket/README.md
+++ b/examples/reagent/websocket/README.md
@@ -36,7 +36,7 @@ The example ships with a tiny in-process `WebSocket`-shaped stub in `messages.cl
 - **Auto-echo for `:request` messages** — every outbound `{:type :request ...}` immediately echoes back as `{:type :reply :request-id ... :ok true :echo ...}`, so the request-reply correlation slot lights up.
 - **Auth ack** — `{:type :auth :token ...}` produces `{:type :auth-ok}` for any non-empty token and `{:type :auth-failed :reason "Empty token"}` otherwise.
 - **Subscribe ack** — every `{:type :subscribe :topic ...}` is acked with one synthetic `{:type :push :topic ... :note "subscribed"}` so the example demonstrates the subscribe-then-push shape end-to-end.
-- **`messages/send-server-push!`** — used by the "Trigger server push" button (and the Playwright spec) to deliver a manual server-pushed event.
+- **`messages/send-server-push!`** — used by the "Trigger server push" button (and the headless tests) to deliver a manual server-pushed event.
 - **`messages/simulate-disconnect!`** — used by the "Drop connection" button to force every live mock socket closed, triggering the reconnect cascade.
 
 The mock has two delivery modes — async via `setTimeout(_, 0)` (default, used by the browser) and sync (used by the headless tests via `messages/set-mock-sync!`) so `dispatch-sync` observes the full request/reply round-trip without yielding to the JS event loop.

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -16,7 +16,7 @@
    2. **Mock-server bridge.** A small in-process JS `WebSocket`-shaped
       stub the example uses when no real WebSocket endpoint is
       available — keeps the example standalone for the headless
-      `npm run test:cljs` runs and the Playwright smoke. The stub
+      tests (under `test/websocket/`). The stub
       registers itself as `js/MockWebSocketServer` and a couple of
       `:rf/inject-socket-event` fxs let the headless tests deliver
       `:opened` / `:received` / `:closed` events synchronously without
@@ -56,8 +56,8 @@
 ;; MOCK WEBSOCKET SERVER
 ;; ============================================================================
 ;;
-;; Implements a tiny `js/WebSocket`-shaped object for the headless smoke
-;; and the Playwright spec. Supports two interaction shapes:
+;; Implements a tiny `js/WebSocket`-shaped object for the headless tests
+;; and the example's own buttons. Supports two interaction shapes:
 ;;
 ;;   (1) Auto-echo replies for outbound `{:type :request ...}`. The
 ;;       server immediately echoes a reply on the same socket carrying
@@ -91,8 +91,8 @@
 
 (defn- ^:private later
   "Run `f` synchronously in mock-sync mode; via `setTimeout` otherwise.
-   This is the only knob that separates headless-test mode from the
-   browser-driven Playwright smoke."
+   This is the only knob that separates headless-test mode (sync) from
+   the browser-driven example (async, microtask-delivered)."
   [f]
   (if (:sync? @mock-server-state)
     (f)
@@ -170,7 +170,7 @@
               (later
                 #(deliver-to-actor! actor-id :closed {:code 1000})))}))
 
-;; Exposed seams the views (and the Playwright spec) use to drive the
+;; Exposed seams the views (and the headless tests) use to drive the
 ;; mock without dispatching through the actor.
 
 (defn- ^:private deliver-external!
@@ -187,7 +187,7 @@
 
 (defn send-server-push!
   "Deliver a synthetic server push to every live mock socket. Used by
-   the Playwright spec and the example's 'Trigger server push' button
+   the headless tests and the example's 'Trigger server push' button
    to demonstrate the inbound translation path."
   [body]
   (doseq [[_ {:keys [actor-id open?]}] (:sockets @mock-server-state)]

--- a/examples/reagent/websocket/schema.cljs
+++ b/examples/reagent/websocket/schema.cljs
@@ -116,7 +116,7 @@
    [:received [:vector Message]]
    ;; Last correlated reply landed via :ws.app/request-reply (or via
    ;; :ws/handle-message for server pushes) — handy for the request-reply
-   ;; round-trip view + the Playwright smoke assertion.
+   ;; round-trip view + the headless test assertion.
    [:last-reply [:maybe :any]]
    ;; Monotonic counter feeding each message's stable :rx-seq.
    [:rx-count :int]])

--- a/examples/reagent/websocket/views.cljs
+++ b/examples/reagent/websocket/views.cljs
@@ -35,11 +35,10 @@
                   the multi-tag union to one visible word.
 
                   A sibling `:ws-reconnect-attempts` counter surfaces
-                  the machine's `:retries` slot directly — this lets
-                  the Playwright smoke assert the reconnect counter
-                  advanced after a Drop click without relying on
-                  catching the transient RECONNECTING window in the
-                  pill text."}
+                  the machine's `:retries` slot directly — this lets a
+                  test assert the reconnect counter advanced after a
+                  Drop click without relying on catching the transient
+                  RECONNECTING window in the pill text."}
           status-pill []
   (let [connected?     @(subscribe [:ws/connected?])
         reconnecting?  @(subscribe [:ws/reconnecting?])


### PR DESCRIPTION
Behaviour-preserving commenting/explanation clarity pass on the Reagent worked examples (rf2-kdoai.25; slice = `examples/reagent`).

## What changed

Found and fixed one systematic drift: the per-example Playwright specs were removed under the test-free examples policy (rf2-8cevm), but several inline comments/docstrings still referenced 'the Playwright spec' / 'the Playwright smoke' as a live per-example artefact (worse than no comment). Repointed every stale reference at the accurate current referent — the headless CLJS tests under each example's `test/` tree, the example's own buttons, or a generic 'test'.

Files touched (comments/docstrings/README prose only):
- `websocket/messages.cljs`, `websocket/views.cljs`, `websocket/schema.cljs` — Playwright-spec refs → headless tests / example buttons.
- `long_running_work/worker.cljs` — 'keep the Playwright smoke fast' → 'keep the headless test fast'.
- `long_running_work/core.cljs` — removed the misleading `npm run test:examples (Playwright smoke + headless tests)` run line; the accurate `test:browser` headless-test entry is already listed below it.
- `state_machine_walkthrough/views.cljs` — Playwright-spec refs → headless tests; also corrected the ns docstring (headless tests live in the sibling `test/` tree, not `core.cljc`).
- `routing/core.cljs`, `managed_http_counter/core.cljs` — Playwright-spec / 'Playwright's role' refs → accurate phrasing.
- `todomvc/README.md` — dropped the stale 'Playwright example harness' / `test:examples` run instructions (todomvc has no tests at all); replaced with `shadow-cljs watch` + the test-free-policy coverage note; corrected the CSS-staging description (npm-pinned in package.json, manual copy — the auto-stager is gone).
- `websocket/README.md` — '(and the Playwright spec)' → '(and the headless tests)'.

Left correct negations (`boot/README.md`, `long_running_work/README.md`, `seven_guis/README.md` all already say 'there is no per-example Playwright spec') untouched. Did NOT touch any `data-testid` attributes (those are markup/behaviour). Did NOT rename `rf/frame-db` (per charter — rf2-1i168 owns that). The rest of the slice (counter, flows, login, nine_states, ssr, notebook, realworld cluster, etc.) was reviewed and found accurate and current — no changes needed.

Behaviour-preserving: comments only, no logic change.

## Quality gates

- **Build (compile to confirm examples still compile):** `npx shadow-cljs compile examples/websocket examples/state-machine-walkthrough examples/long-running-work examples/managed-http-counter examples/routing` — all 5 build completed, 0 warnings, 0 errors. (build-ids read from `implementation/shadow-cljs.edn`; shadow-cljs.edn NOT edited.)
- **clj-kondo on changed .cljs:** 0 errors. One pre-existing unused-refer warning in `long_running_work/core.cljs` (`reg-view` referred-but-unused at the require — untouched by this PR's comment-only edits).
- **npm run test:examples (3 adapter smokes):** not run — no adapter-testbed files changed and all edits are behaviour-preserving comments; the compile gate above already proves form integrity.
- Behaviour-preserving: comments only, no logic change.