### PR TITLE
docs(skills/re-frame2): comment & explanation clarity pass (rf2-kdoai.38)

### DIFF
--- a/skills/re-frame2/references/cross-cutting/testing.md
+++ b/skills/re-frame2/references/cross-cutting/testing.md
@@ -115,7 +115,7 @@ For a sub graph under test, **prefer `compute-sub`** — it runs the registered 
 (is (= 60 (rf/compute-sub [:item-sum] {:items [10 20 30]})))
 ```
 
-`compute-sub` supports the `:<-` chain shape exactly like `subscribe` does and validates the return value against any `:spec` metadata on the sub.
+`compute-sub` supports the `:<-` chain shape exactly like `subscribe` does and validates the return value against any output `:schema` metadata on the sub.
 
 When the test is exercising the live cache (e.g. layer-2 sub on top of a real dispatch), use `subscribe-once`:
 

--- a/skills/re-frame2/references/fundamentals/cofx.md
+++ b/skills/re-frame2/references/fundamentals/cofx.md
@@ -20,10 +20,10 @@ Registering a `reg-cofx` handler that injects an input (current time, localStora
 (rf/inject-cofx :cofx-id value)
 ```
 
-Verified in `implementation/core/src/re_frame/cofx.cljc:77` (`reg-cofx`) and `cofx.cljc:134` (`inject-cofx`). Metadata may carry:
+Verified in `implementation/core/src/re_frame/cofx.cljc` (the `reg-cofx` and `inject-cofx` fns). Metadata may carry:
 
 - `:doc` — one-sentence what-and-why
-- `:spec` — Malli schema for the injected value (Spec 010 §Validation order step 2)
+- `:schema` — Malli schema for the injected value (Spec 010 §Validation order step 2)
 - `:platforms` — `#{:client :server}`; defaults to both. Cofx with mismatched platforms emit `:rf.cofx/skipped-on-platform` instead of running. Mirrors the `reg-fx` contract per `spec/011-SSR.md` §Effect handling on the server — a client-only cofx (browser locale, localStorage, navigator-info) silently no-ops when injected under an SSR-server frame so it neither blows up under JVM render nor injects nonsense values. The event handler still runs; only the injection is skipped. Example: `^{:platforms #{:client}} (rf/reg-cofx :browser-locale (fn [ctx] (assoc-in ctx [:coeffects :browser-locale] js/navigator.language)))` is safe to register on both platforms; under an `:ssr-server` frame the injection is skipped and the handler sees `nil` for `:browser-locale`.
 
 `inject-cofx` returns an **interceptor** — pass it in the event's interceptors vector (the positional slot, not the metadata-map):
@@ -36,7 +36,7 @@ Verified in `implementation/core/src/re_frame/cofx.cljc:77` (`reg-cofx`) and `co
 
 ## Standard cofx
 
-The runtime ships `:db` and `:event` — both are already populated on the context before the chain runs (`cofx.cljc:92-104`), so explicitly injecting them is a no-op. They exist for symmetry with v1. Everything else (current time, browser language, localStorage values, ids) is user-registered.
+The runtime ships `:db` and `:event` — both are already populated on the context before the chain runs (the standard `:db` / `:event` cofx in `cofx.cljc`), so explicitly injecting them is a no-op. They exist for symmetry with v1. Everything else (current time, browser language, localStorage values, ids) is user-registered.
 
 ## Canonical mini-example
 
@@ -163,7 +163,7 @@ Narrative treatment of the same pattern (for humans): [`docs/guide/07-effects-an
 ## Common gotchas
 
 - **`inject-cofx` returns an interceptor, not the value.** It must go in the positional interceptors vector, not the metadata-map (the metadata-map's `:interceptors` key is silently dropped — see [events.md](events.md)).
-- **The injected key convention is the cofx-id itself.** Stash under `[:coeffects :my/cofx-id]` so destructuring with `{:my/keys [...]}` works cleanly. If `:spec` validation is declared on the cofx metadata, the validator looks up under the cofx-id key (`cofx.cljc:33-36`).
+- **The injected key convention is the cofx-id itself.** Stash under `[:coeffects :my/cofx-id]` so destructuring with `{:my/keys [...]}` works cleanly. If `:schema` validation is declared on the cofx metadata, the validator looks up under the cofx-id key (`maybe-validate-cofx!` in `cofx.cljc`).
 - **Order matters.** Interceptors run in vector order; a cofx that depends on another cofx's value must come after it.
 - **Two-arg form is for parameterised injection.** Use `(inject-cofx :random-int max-value)` when the same cofx-id needs a different value per attachment.
 - **Missing registration is a structured error trace, not a throw.** `inject-cofx` of an unregistered id emits `:rf.error/no-such-cofx` (carrying `:cofx-id`, `:event-id`, and the optional 2-arity `:cofx-value`) and lets the ctx flow through unchanged (`cofx.cljc:~78,88`). Subscribe via `register-listener!` (or watch through Xray / re-frame2-pair) to surface these.
@@ -171,8 +171,8 @@ Narrative treatment of the same pattern (for humans): [`docs/guide/07-effects-an
 
 ## Deeper material
 
-Cofx validation (`:spec`), the late-bind seam for `:schemas/validate-cofx!`, full coeffect-map shape: `SKILL-REDIRECT.md` → **EP — Schemas (010)**, **Definitive API reference**.
+Cofx validation (`:schema`), the late-bind seam for `:schemas/validate-cofx!`, full coeffect-map shape: `SKILL-REDIRECT.md` → **EP — Schemas (010)**, **Definitive API reference**.
 
 ---
 
-*Derived from `implementation/core/src/re_frame/cofx.cljc` @ main `9d548e18`. Re-verify line numbers after cofx-chain, schema-validation, or `:platforms`-gate changes.*
+*Derived from `implementation/core/src/re_frame/cofx.cljc` @ main `9d548e18`. Citations are symbol-level; re-verify symbol homes after cofx-chain, schema-validation, or `:platforms`-gate changes.*

--- a/skills/re-frame2/references/fundamentals/event-state-cycle.md
+++ b/skills/re-frame2/references/fundamentals/event-state-cycle.md
@@ -20,15 +20,15 @@ Sanity-checking a mental model: tracing what happens between `(rf/dispatch ...)`
 
 ## Step by step
 
-**1. Dispatch.** `(rf/dispatch [:event-id args])` builds an envelope `{:event ... :frame ... :dispatch-id ...}` and appends it to the target frame's router queue (`router.cljc:370`). Returns `nil` immediately — non-blocking.
+**1. Dispatch.** `(rf/dispatch [:event-id args])` builds an envelope `{:event ... :frame ... :dispatch-id ...}` and appends it to the target frame's router queue (`dispatch!` / `enqueue-envelope!` in `router.cljc`). Returns `nil` immediately — non-blocking.
 
-**2. Drain scheduled.** The router schedules a drain via the substrate's microtask hook. `dispatch-sync` (`router.cljc:390`) bypasses the queue and drains immediately — outside-the-runtime callers only (tests, REPL, `:on-create`).
+**2. Drain scheduled.** The router schedules a drain via the substrate's microtask hook. `dispatch-sync` (`dispatch-sync!` in `router.cljc`) bypasses the queue and drains immediately — outside-the-runtime callers only (tests, REPL, `:on-create`).
 
 **3. Drain pops envelope.** For each event, the runtime looks up the registered handler's interceptor chain.
 
-**4. Cofx injection.** Each `inject-cofx` interceptor runs in source order; each writes under `[:coeffects :cofx-id]`. The standard `:db` (current `app-db` value) and `:event` (the dispatched vector) are already populated (`cofx.cljc:92-104`).
+**4. Cofx injection.** Each `inject-cofx` interceptor runs in source order; each writes under `[:coeffects :cofx-id]`. The standard `:db` (current `app-db` value) and `:event` (the dispatched vector) are already populated (`cofx.cljc`).
 
-**5. Validation (dev only).** If the handler carries a `:spec`, the runtime validates the event vector against it. Failure sets `:rf/skip-handler?` on the context and the handler short-circuits (`events.cljc:123-128`). `validate-at-boundary-interceptor` runs this same check in production.
+**5. Validation (dev only).** If the handler carries a `:schema`, the runtime validates the event vector against it. Failure sets `:rf/skip-handler?` on the context and the handler short-circuits (the schema check + skip-handler honouring in `spec.cljc` / `events.cljc`). `validate-at-boundary-interceptor` runs this same check in production.
 
 **6. User handler.** The wrapped handler-fn fires:
 
@@ -36,30 +36,30 @@ Sanity-checking a mental model: tracing what happens between `(rf/dispatch ...)`
 - `reg-event-fx` receives `(cofx, event)` → returns `{:db ... :fx [...]}`; runtime stashes both under `(:effects ctx ...)`.
 - `reg-event-ctx` receives `ctx` → returns `ctx` (advanced).
 
-**7. Effect-shape policing.** Non-`:db`/non-`:fx` top-level keys emit `:rf.error/effect-map-shape` and are dropped (`events.cljc:81`). v2's effect map is closed.
+**7. Effect-shape policing.** Non-`:db`/non-`:fx` top-level keys emit `:rf.error/effect-map-shape` and are dropped (`police-effect-map-shape!` in `events.cljc`). v2's effect map is closed.
 
 **8. `:db` commits.** `re-frame.substrate.adapter/replace-container!` writes the new value into the frame's app-db container. **Atomic.**
 
-**9. `:fx` walks.** `do-fx` (`fx.cljc:203`) iterates the `[fx-id args]` pairs in source order, synchronously. Each fx-handler runs to completion before the next begins. Errors and unknown ids trace independently — the walk continues.
+**9. `:fx` walks.** `do-fx` (in `fx.cljc`) iterates the `[fx-id args]` pairs in source order, synchronously. Each fx-handler runs to completion before the next begins. Errors and unknown ids trace independently — the walk continues.
 
 **10. Subs recompute.** The substrate's reaction graph fires off the container change. Layer-1 subs that read changed paths recompute by `=`; layer-2+ subs cascade topologically. Unchanged-by-`=` values short-circuit cascades.
 
 **11. Views re-render.** Reagent components subscribed to dirty subs re-render. Source-coord metadata captured by `reg-view` lets Xray / re-frame2-pair point at the originating Var.
 
-**12. Drain continues.** Any `[:dispatch ...]` entries from step 9 are now on the queue. Drain loops until queue is empty (`router.cljc`). Run-to-completion: one dispatch fully settles before the next outside event starts.
+**12. Drain continues.** Any `[:dispatch ...]` entries from step 9 are now on the queue. Drain loops until the queue is empty (`router.cljc`). Run-to-completion: one dispatch fully settles before the next outside event starts.
 
 ## Per-step reference
 
 | Step | Where it lives | Surface |
 |---|---|---|
-| Dispatch / queue | `router.cljc:370-388` | `rf/dispatch`, `rf/dispatch-sync` |
-| Interceptor chain | `events.cljc:111-167` | metadata `:spec`, interceptors vector |
-| Cofx injection | `cofx.cljc:57-89` | `rf/inject-cofx` |
-| Handler invocation | `events.cljc:111-167` | `reg-event-db` / `-fx` / `-ctx` |
-| Effect-map policing | `events.cljc:81-105` | `:rf.error/effect-map-shape` trace |
+| Dispatch / queue | `router.cljc` (`dispatch!` / `dispatch-sync!`) | `rf/dispatch`, `rf/dispatch-sync` |
+| Interceptor chain | `events.cljc` (handler-wrapping fns) | metadata `:schema`, interceptors vector |
+| Cofx injection | `cofx.cljc` | `rf/inject-cofx` |
+| Handler invocation | `events.cljc` (handler-wrapping fns) | `reg-event-db` / `-fx` / `-ctx` |
+| Effect-map policing | `events.cljc` (`police-effect-map-shape!`) | `:rf.error/effect-map-shape` trace |
 | `:db` commit | `subs.cljc` + substrate adapter | atomic via `replace-container!` |
-| `:fx` walk | `fx.cljc:203-225` | `reg-fx`, `:fx-overrides` |
-| Sub recompute | `subs.cljc:166-285` | reaction graph + deferred ref-count cache |
+| `:fx` walk | `fx.cljc` (`do-fx` / `handle-one-fx`) | `reg-fx`, `:fx-overrides` |
+| Sub recompute | `subs.cljc` | reaction graph + deferred ref-count cache |
 | Render | adapter (`reagent.cljs`, ...) | `reg-view` |
 
 ## Canonical mini-example
@@ -126,4 +126,4 @@ Drain-depth bounds, the `:rf.epoch/*` projection of one full cycle for re-frame2
 
 ---
 
-*Derived from `implementation/core/src/re_frame/{router,events,cofx,fx,subs}.cljc` and the substrate adapters under `implementation/core/src/re_frame/substrate/` @ main `89bd9c3`. Re-verify line numbers after router or interceptor-chain changes.*
+*Derived from `implementation/core/src/re_frame/{router,events,cofx,fx,subs}.cljc` and the substrate adapters under `implementation/core/src/re_frame/substrate/` @ main `89bd9c3`. Citations are symbol-level; re-verify symbol homes after router or interceptor-chain changes.*

--- a/skills/re-frame2/references/fundamentals/events.md
+++ b/skills/re-frame2/references/fundamentals/events.md
@@ -18,14 +18,14 @@ Two surfaces: a CLJ `defmacro` (captures `:ns` / `:line` / `:file`) and a CLJS `
 (rf/reg-event-ctx id          handler-fn)                   ;; (context) -> context  (advanced)
 ```
 
-Verified in `implementation/core/src/re_frame/events.cljc:188-225` (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`) and `implementation/core/src/re_frame/core.cljc:167-224` (the macro layer). `normalise-args` (`events.cljc:171`) accepts:
+Verified in `implementation/core/src/re_frame/events.cljc` (`reg-event-db` / `reg-event-fx` / `reg-event-ctx` fns) and `implementation/core/src/re_frame/core.cljc` (the macro layer). The `normalise-args` helper accepts:
 
 - `(reg-event-db :id handler)`
-- `(reg-event-db :id {:doc "..." :spec ...} handler)`
+- `(reg-event-db :id {:doc "..." :schema ...} handler)`
 - `(reg-event-db :id [icpt1 icpt2] handler)`
 - `(reg-event-db :id {:doc "..."} [icpt1 icpt2] handler)`
 
-The **metadata-map** is reflective-only (`:doc`, `:spec`, `:tags`, `:platforms`, ...). The **interceptors vector** is positional. Putting `:interceptors` inside the metadata-map silently drops the chain — the runtime emits `:rf.warning/interceptors-in-metadata-map` to flag it (`events.cljc:38`).
+The **metadata-map** is reflective-only (`:doc`, `:schema`, `:tags`, `:platforms`, ...). The **interceptors vector** is positional. Putting `:interceptors` inside the metadata-map silently drops the chain — the runtime emits `:rf.warning/interceptors-in-metadata-map` to flag it (see `warn-interceptors-in-metadata-map!` in `events.cljc`).
 
 ## Event vector shape
 
@@ -39,7 +39,7 @@ The dispatched value is a vector `[event-id & args]`. The handler receives the w
 (rf/dispatch [:todo/add "buy milk"])
 ```
 
-Dispatch is non-blocking — events queue and drain run-to-completion. `dispatch-sync` (`router.cljc:390`) drains immediately and is for outside-the-runtime callers (test setup, REPL); calling it from inside a handler raises `:rf.error/dispatch-sync-in-handler`.
+Dispatch is non-blocking — events queue and drain run-to-completion. `dispatch-sync` (`dispatch-sync!` in `router.cljc`) drains immediately and is for outside-the-runtime callers (test setup, REPL); calling it from inside a handler raises `:rf.error/dispatch-sync-in-handler`.
 
 ## Canonical mini-example
 
@@ -70,16 +70,16 @@ The `:db` and `:fx` keys are the **only** legal top-level keys in an `fx`-handle
 
 ## Common gotchas
 
-- **`:dispatch` and `:dispatch-n` are NOT top-level effect keys in v2.** They moved into `:fx` as `[[:dispatch event]]` entries. The runtime emits `:rf.error/effect-map-shape` and drops any non-`:db`/non-`:fx` top-level key (`events.cljc:81`).
+- **`:dispatch` and `:dispatch-n` are NOT top-level effect keys in v2.** They moved into `:fx` as `[[:dispatch event]]` entries. The runtime emits `:rf.error/effect-map-shape` and drops any non-`:db`/non-`:fx` top-level key (`police-effect-map-shape!` in `events.cljc`).
 - **`:interceptors` is not a metadata key.** Pass the chain as the positional third argument, not as `{:interceptors [...]}`.
 - **The event vector's first element is the event id.** Always destructure it as `[_ arg1 arg2]` — the id is in `args` because the whole vector is passed.
 - **`reg-event-ctx` is rarely the right tool.** It hands you the raw interceptor context. Use it only when you need to manipulate the chain itself; otherwise `reg-event-db` or `reg-event-fx`.
-- **Metadata-map fields surface to tooling, not to the runtime.** `:doc`, `:spec`, `:tags`, `:platforms` are read by Xray, re-frame2-pair, and the dev-time validator. They do not affect runtime behaviour except where called out (`:spec` for dev validation; `:platforms` on `reg-fx`).
+- **Metadata-map fields surface to tooling, not to the runtime.** `:doc`, `:schema`, `:tags`, `:platforms` are read by Xray, re-frame2-pair, and the dev-time validator. They do not affect runtime behaviour except where called out (`:schema` for dev validation; `:platforms` on `reg-fx`).
 
 ## Deeper material
 
-Full effect-map contract, interceptor chain composition, dispatch envelope shape, the dev-time `:spec` validator: `SKILL-REDIRECT.md` → **EP — Frames (002)**, **EP — Schemas (010)**, **Definitive API reference**.
+Full effect-map contract, interceptor chain composition, dispatch envelope shape, the dev-time `:schema` validator: `SKILL-REDIRECT.md` → **EP — Frames (002)**, **EP — Schemas (010)**, **Definitive API reference**.
 
 ---
 
-*Derived from `implementation/core/src/re_frame/events.cljc` and `implementation/core/src/re_frame/core.cljc` @ main `89bd9c3`. Re-verify line numbers after substantial registrar / events refactors.*
+*Derived from `implementation/core/src/re_frame/events.cljc` and `implementation/core/src/re_frame/core.cljc` @ main `89bd9c3`. Citations are symbol-level; re-verify symbol homes after substantial registrar / events refactors.*

--- a/skills/re-frame2/references/fundamentals/frames.md
+++ b/skills/re-frame2/references/fundamentals/frames.md
@@ -117,7 +117,7 @@ The metadata map (`reg-frame` in `re-frame.frame`) accepts:
 
 - `:doc` — one-sentence what-and-why.
 - `:preset` — one of `:default :test :story :ssr-server`; expands at registration into a fixed metadata bundle.
-- `:fx-overrides` — `{original-id replacement-id-or-fn}`. Two value shapes are honoured (`fx.cljc:62-142`): a **keyword** redirects the lookup to another registered fx (portable, SSR-safe pattern-level form), and a **function** `(fn [m args] ...)` runs inline with no registry lookup (one-shot CLJS-reference convenience for test fixtures and story decorators). The id-redirect form is preferred when the stub is reused; the fn form when one test wants a bespoke response without registering a parallel fx. Per-call `:fx-overrides` in `dispatch` / `dispatch-sync` opts accepts the same two shapes.
+- `:fx-overrides` — `{original-id replacement-id-or-fn}`. Two active override forms (resolved by `fx/resolve-fx-with-overrides`): a **keyword** redirects the lookup to another registered fx (portable, SSR-safe pattern-level form), and a **function** `(fn [m args] ...)` runs inline with no registry lookup (one-shot CLJS-reference convenience for test fixtures and story decorators). A value that is neither (and an absent key) is treated as no override — the original fx-id flows through. The id-redirect form is preferred when the stub is reused; the fn form when one test wants a bespoke response without registering a parallel fx. Per-call `:fx-overrides` in `dispatch` / `dispatch-sync` opts accepts the same forms.
 - `:platform` — `:client` or `:server`; gates fx whose `:platforms` set excludes the active platform.
 - `:drain-depth` — bound on dispatch-cascade depth (default 100; `:story` preset tightens to 16).
 - `:on-create` / `:on-destroy` — event vectors fired synchronously at lifecycle transitions.
@@ -132,7 +132,7 @@ Wraps a Reagent / Helix / UIx subtree so descendants resolve `current-frame-id` 
 [rf/frame-provider {:frame :stories} [my-story-shell]]
 ```
 
-`reg-view`-wrapped components participate automatically (the wrapper carries `:contextType`). Plain Reagent fns under a non-default `frame-provider` fall through to `:rf/default` — the runtime emits `:rf.warning/plain-fn-under-non-default-frame-once` to flag the footgun (`adapter/reagent.cljs:140-148`).
+`reg-view`-wrapped components participate automatically (the wrapper carries `:contextType`). Plain Reagent fns under a non-default `frame-provider` fall through to `:rf/default` — the runtime emits `:rf.warning/plain-fn-under-non-default-frame-once` to flag the footgun (the Reagent adapter's view-wiring; behaviour locked by `cross_spec_dom_cljs_test`).
 
 ## Common gotchas
 

--- a/skills/re-frame2/references/fundamentals/fx.md
+++ b/skills/re-frame2/references/fundamentals/fx.md
@@ -15,10 +15,10 @@ Authoring a custom effect handler with `reg-fx`, or working out what to put insi
 ;;   args :: whatever the `:fx` entry put in the second slot
 ```
 
-Verified in `implementation/core/src/re_frame/fx.cljc:33`. Metadata may carry:
+Verified in `implementation/core/src/re_frame/fx.cljc` (the `reg-fx` fn). Metadata may carry:
 
 - `:doc` — one-sentence what-and-why
-- `:spec` — Malli schema for `args` (dev-time validation)
+- `:schema` — Malli schema for `args` (dev-time validation)
 - `:platforms` — `#{:client :server}`; defaults to both. Fx with mismatched platforms emit `:rf.fx/skipped-on-platform` instead of running.
 
 ## The fx-map shape
@@ -32,7 +32,7 @@ Verified in `implementation/core/src/re_frame/fx.cljc:33`. Metadata may carry:
       ...]}
 ```
 
-Each `:fx` entry is a 2-vector: `[fx-id args]`. The runtime walks them in source order, synchronously, after `:db` commits (`fx.cljc:4-9`). Any other top-level key — `:dispatch`, `:dispatch-later`, `:http`, etc — emits `:rf.error/effect-map-shape` and is dropped (`events.cljc:81`). v2 deliberately removed v1's auto-routed top-level effect keys.
+Each `:fx` entry is a 2-vector: `[fx-id args]`. The runtime walks them in source order, synchronously, after `:db` commits (`fx.cljc:4-9`). Any other top-level key — `:dispatch`, `:dispatch-later`, `:http`, etc — emits `:rf.error/effect-map-shape` and is dropped (`police-effect-map-shape!` in `events.cljc`). v2 deliberately removed v1's auto-routed top-level effect keys.
 
 The reserved fx-ids the core runtime handles directly (`fx.cljc:10-22`):
 
@@ -85,7 +85,7 @@ Per `fx.cljc:4-9`:
 - **Returning a value from an fx handler does nothing.** Side effects are the point. `:rf.fx/handled` is emitted on success so the epoch projection records the run.
 - **`:platforms #{:client}` makes the fx skip silently on server.** A `:rf.fx/skipped-on-platform` warning fires — fine for browser-only side effects, but check this if a fx mysteriously doesn't run under SSR.
 - **Fx errors are isolated.** A throw inside one fx emits `:rf.error/fx-handler-exception` but does not abort the `:fx` walk. Don't rely on later entries seeing earlier failures.
-- **Override the fx surface per frame**, not globally: `(rf/reg-frame :frame-id {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})`. Used heavily for test stubs and stories (`frame.cljc:115-118`).
+- **Override the fx surface per frame**, not globally: `(rf/reg-frame :frame-id {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})`. Used heavily for test stubs and stories (`:fx-overrides` in `reg-frame`'s metadata, `frame.cljc`).
 
 ## Deeper material
 

--- a/skills/re-frame2/references/fundamentals/schemas.md
+++ b/skills/re-frame2/references/fundamentals/schemas.md
@@ -6,7 +6,7 @@ Registering a Malli schema for a path in `app-db` with `reg-app-schema`, or atta
 
 ## Prerequisite
 
-`reg-app-schema` and the validator surface ship in the optional **`day8/re-frame2-schemas`** artefact (`core.cljc:537-542`). Add it to `deps.edn` and `(:require [re-frame.schemas])` at app boot, otherwise `reg-app-schema` throws `:rf.error/schemas-artefact-missing`.
+`reg-app-schema` and the validator surface ship in the optional **`day8/re-frame2-schemas`** artefact (the `reg-app-schema` macro + schema-query aliases in `re-frame.core` are late-bound to `re-frame.schemas`). Add it to `deps.edn` and `(:require [re-frame.schemas])` at app boot, otherwise `reg-app-schema` throws `:rf.error/schemas-artefact-missing`.
 
 ## Canonical signatures
 
@@ -22,7 +22,7 @@ Registering a Malli schema for a path in `app-db` with `reg-app-schema`, or atta
 (rf/set-schema-explainer!  explain-fn)
 ```
 
-Verified: `reg-app-schema` macro at `implementation/core/src/re_frame/core.cljc:527`; the query fns at `:571-597`; the validator seam at `:599-622`.
+Verified against `implementation/core/src/re_frame/core.cljc`: the `reg-app-schema` macro (and `reg-app-schemas` plural form), the `app-schema-at` / `app-schemas` / `app-schemas-digest` query aliases, and the `set-schema-validator!` / `set-schema-fns!` validator seam — all `def`-aliased onto the `re-frame.schemas` artefact.
 
 Registrations are **frame-scoped** — the schema attaches to a path inside one frame's `app-db`. Default frame is `(current-frame-id)`; pass `{:frame :other}` in `opts` to target another.
 
@@ -37,7 +37,7 @@ Every `reg-*` macro accepts a `:schema` key in its metadata-map:
   (fn [db [_ trip-type]] (assoc-in db [:flight :trip-type] trip-type)))
 ```
 
-In **dev builds** (`re-frame.interop/debug-enabled?` is `true`) the dispatched event vector is validated against the handler's `:schema` before the handler runs. Failure emits `:rf.error/schema-validation-failure` and skips the handler (`spec.cljc:154-238`). In **`:advanced` + `goog.DEBUG=false` production builds** these dev-time call sites are elided.
+In **dev builds** (`re-frame.interop/debug-enabled?` is `true`) the dispatched event vector is validated against the handler's `:schema` before the handler runs. Failure emits `:rf.error/schema-validation-failure` and skips the handler (sets `:rf/skip-handler?`; see `re-frame.spec`). In **`:advanced` + `goog.DEBUG=false` production builds** these dev-time call sites are elided.
 
 ## `validate-at-boundary-interceptor` — opt-in production validation
 
@@ -53,7 +53,7 @@ For handlers that **must** validate even in production (HTTP response ingestion,
   (fn [_ [_ payload]] ...))
 ```
 
-The interceptor reuses the handler's existing `:schema` (or the deprecated `:spec` alias) — it does NOT introduce a parallel schema (`spec.cljc:30-31`).
+The interceptor reuses the handler's existing `:schema` metadata — it does NOT introduce a parallel schema (`re-frame.spec/validate-at-boundary-interceptor`).
 
 Behaviour matrix:
 
@@ -112,4 +112,4 @@ Validation-order spec, per-step recovery, digest algorithm, the schemas artefact
 
 ---
 
-*Derived from `implementation/core/src/re_frame/core.cljc` (macro + validator seam) and `implementation/core/src/re_frame/spec.cljc` (boundary interceptor) @ main `89bd9c3`. Re-verify line numbers after `validate-at-boundary-interceptor` or `set-schema-validator!` changes.*
+*Derived from `implementation/core/src/re_frame/core.cljc` (macro + validator seam) and `implementation/core/src/re_frame/spec.cljc` (boundary interceptor) @ main `89bd9c3`. Citations are symbol-level; re-verify symbol homes after `validate-at-boundary-interceptor` or `set-schema-validator!` changes.*

--- a/skills/re-frame2/references/fundamentals/subs.md
+++ b/skills/re-frame2/references/fundamentals/subs.md
@@ -23,10 +23,10 @@ Authoring `reg-sub`: a layer-1 reader of `app-db`, a layer-2/3 derived sub compo
   (fn [[a b] query-v] ...))
 
 ;; Optional metadata as first positional arg
-(rf/reg-sub :id {:doc "..." :spec ...} <chain> handler)
+(rf/reg-sub :id {:doc "..." :schema ...} <chain> handler)
 ```
 
-Verified in `implementation/core/src/re_frame/subs.cljc:79` (`reg-sub`) and `subs.cljc:49` (`parse-reg-sub-args`). There is **one** registration form in v2 — `reg-sub-raw` is removed (`subs.cljc:80-81`).
+Verified in `implementation/core/src/re_frame/subs.cljc` (the `reg-sub` fn and the `parse-reg-sub-args` helper). There is **one** registration form in v2 — `reg-sub-raw` is removed.
 
 Lookup is via `rf/subscribe`:
 
@@ -72,7 +72,7 @@ Caching is per-frame, keyed by the query-vector. Disposal is **synchronous ref-c
 
 ## Common gotchas
 
-- **No `reg-sub-raw`.** v1's escape-hatch is removed. If you need to compose, layer subs with `:<-`. If you need a one-shot read off `app-db` outside the reactive graph (tests, SSR), use `rf/compute-sub` (`subs.cljc:379`) which returns a value, not a reaction.
+- **No `reg-sub-raw`.** v1's escape-hatch is removed. If you need to compose, layer subs with `:<-`. If you need a one-shot read off `app-db` outside the reactive graph (tests, SSR), use `rf/compute-sub` (the `compute-sub` fn in `subs.cljc`) which returns a value, not a reaction.
 - **Subscribe returns a reaction.** Always deref with `@`. Inside a Reagent view this auto-tracks; outside of a reactive context the deref is a one-shot read and won't update.
 - **The query-vector is the cache key.** `[:my-sub 1]` and `[:my-sub 2]` are distinct cache entries. Re-using the same vector across renders is fine; constructing fresh vectors with identical content is also fine (`=`-equal keys hit the same cache slot).
 - **Signal subs (`:<-`) accept a query-vector, not just an id.** `:<- [:other-sub arg]` is legal and threads the arg through.
@@ -80,8 +80,8 @@ Caching is per-frame, keyed by the query-vector. Disposal is **synchronous ref-c
 
 ## Deeper material
 
-Sub topology inspection (`sub-topology`), cache snapshots, the disposal algorithm under reconcile, validation against `:spec`: `SKILL-REDIRECT.md` → **EP — Reactive substrate (006)**, **Definitive API reference**.
+Sub topology inspection (`sub-topology`), cache snapshots, the disposal algorithm under reconcile, validation against the output `:schema`: `SKILL-REDIRECT.md` → **EP — Reactive substrate (006)**, **Definitive API reference**.
 
 ---
 
-*Derived from `implementation/core/src/re_frame/subs.cljc` @ main `89bd9c3`. Re-verify line numbers after sub-cache disposal-algorithm changes.*
+*Derived from `implementation/core/src/re_frame/subs.cljc` @ main `89bd9c3`. Citations are symbol-level; re-verify symbol homes after sub-cache disposal-algorithm changes.*


### PR DESCRIPTION
Behaviour-preserving comment/explanation clarity pass over the main re-frame2 authoring skill (rf2-kdoai.38, slice = skills/re-frame2). Comments/prose clarity only — no logic, no tool-manifest change.

## What changed (8 reference files)

**Drift fixes (the load-bearing ones):**
- **`:spec` -> `:schema` validation metadata key** across events / cofx / fx / subs / event-state-cycle / testing references. The handler/sub/cofx/fx validation key is `:schema` in current core; no `:spec` keyword is honoured anywhere in core/schemas src. The skill's pervasive `:spec` was stale and would mislead authors.
- **Removed the stale "deprecated `:spec` alias" claim** in schemas.md — that alias no longer exists in source (pre-alpha, no back-compat shims).
- **frames.md fx-override shapes** — aligned the prose with the source's `resolve-fx-with-overrides` (keyword redirect / fn inline / no-override fall-through), and noted the no-override case the doc previously omitted.

**Citation hygiene (drifted/mis-targeted line numbers -> stable symbol anchors):**
- Several precise line citations were wrong or impossible: `spec.cljc:154-238` (file is 206 lines), the reagent-adapter warning cited at `reagent.cljs:140-148` (file is 96 lines), `reg-app-schema` cited at `core.cljc:527` (actually ~252), `compute-sub` at `subs.cljc:379` (actually 559), etc. Demoted to file/symbol anchors matching each doc's own symbol-level footer convention. Accurate in-range citations (e.g. fx.cljc:4-9 ordering rules) were left intact.
- Updated four footers from "Re-verify line numbers" to "Citations are symbol-level" to stay internally honest.

**Not changed (deliberately):** SKILL.md, api-cheatsheet.md, patterns/*, decision-trees/* — verified current and accurate (correct `frame-handle` / `frame-bound-fn` / `frame-db` / `reset-frame-db!` usage; no `get-frame-db` / `bound-fn` / `:rf/hydration` residue; `:rf/runtime` snapshot path correct). One out-of-slice note: stories.md:143 references a Story variant `:rf/schema` slot + "registered view's `:spec`" — left untouched as Story-subsystem semantics owned by another slice/spec; worth a follow-up check by whoever owns Story.

## Quality gates
- `python scripts/check_skill_mcp_drift.py` — exit 0 (pass)
- `python scripts/check_doc_slugs.py` — exit 0 (pass)
- clj-kondo: N/A (no .cljs changed — all 8 edits are .md)
- Behaviour-preserving: comments/prose clarity only, no logic/tool-manifest change.