### PR TITLE
docs(examples/scripts): comment clarity pass (rf2-kdoai.30)

### DIFF
--- a/examples/scripts/capture-story-screenshots.cjs
+++ b/examples/scripts/capture-story-screenshots.cjs
@@ -33,8 +33,11 @@
  *   STORY_BASE=http://127.0.0.1:9876 \
  *     node examples/scripts/capture-story-screenshots.cjs [shotName...]
  *
- * A no-arg run captures every declared shot; an argument filters to the
- * named shots (e.g. `index-overview` `mode-tabs-strip`).
+ * Once SHOTS is re-populated: a no-arg run captures every declared shot;
+ * an argument filters to the named shots (e.g. `index-overview`
+ * `mode-tabs-strip`). With SHOTS currently empty BOTH forms select zero
+ * shots and `main()` exits non-zero ("No shots selected."); see the
+ * empty-SHOTS note above.
  */
 
 'use strict';

--- a/examples/scripts/serve-and-run-story-feature-load-tests.cjs
+++ b/examples/scripts/serve-and-run-story-feature-load-tests.cjs
@@ -2,9 +2,11 @@
 /*
  * Narrow orchestrator for the occasional Story feature/load gate.
  *
- * Compiles only the Story testbeds needed by
- * tools/story/test/story_feature_load.cjs, stages their HTML files,
- * serves implementation/out/examples, and invokes the quiet runner.
+ * Compiles only the Story testbeds (counter-with-stories + login-form)
+ * needed by the quiet runner's specs — tools/story/test/
+ * story_feature_load.cjs AND story_browser_scenarios.cjs — stages their
+ * HTML files, serves implementation/out/examples, and invokes the
+ * runner (run-story-feature-load-tests.cjs).
  */
 
 const { spawnSync } = require('child_process');


### PR DESCRIPTION
## Summary

Commenting & explanation clarity pass over the `examples/scripts` slice (the examples test-runner / serve orchestrator `.cjs` files + helpers), per the rf2-kdoai charter. **Behaviour-preserving: comments only, NO logic change.**

Reviewed all 10 files. The slice is uniformly well-commented (accurate port-clash rationale, OWNED-RANGE PORT MAP cross-refs, the rf2-315cf failure-report rationale, the share-link query-before-hash invariant, etc.). Found and fixed two genuine drift cases; left the other 8 untouched.

### Fixed (drift)

- **`capture-story-screenshots.cjs`** — the Usage note claimed *"a no-arg run captures every declared shot"*, contradicting both the empty-SHOTS note higher in the same header and the actual `main()` path: with `SHOTS = []`, a no-arg run selects zero shots and exits non-zero ("No shots selected."). Reworded to describe current empty-SHOTS behaviour while preserving the future re-populated semantics.
- **`serve-and-run-story-feature-load-tests.cjs`** — header named only `story_feature_load.cjs`, but the paired runner drives BOTH that spec AND `story_browser_scenarios.cjs`. Named both testbeds (counter-with-stories + login-form) and both specs.

### Reviewed, left as-is (already accurate + clear)

`port-resolver.cjs`, `examples-port.cjs`, `story-feature-load-port.cjs`, `spec-helpers.cjs`, `run-examples-tests.cjs`, `serve-and-run-examples-tests.cjs`, `run-story-feature-load-tests.cjs`, `serve-and-run-story-play-scripts.cjs`.

## Quality gates

Behaviour-preserving: comments only.

- `node --check examples/scripts/capture-story-screenshots.cjs` — OK
- `node --check examples/scripts/serve-and-run-story-feature-load-tests.cjs` — OK
- Cross-refs verified against source: `install-ci-hooks!` / `run-play!` / `play-script-summary` exist in `tools/story/.../ci_runner.cljc` + `runner_events.cljc`; both Story specs exist under `tools/story/test/`.
- Smoke: `resolveExamplesPort({env:{}})` resolves 8050 (documented default).

bead: rf2-kdoai.30 (slice = examples/scripts)