### PR TITLE
docs(examples/reagent-slim): comment clarity pass (rf2-kdoai.26)

### DIFF
--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -85,9 +85,9 @@
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])
   ;; Exercise the slim's pure-CLJS render-to-static-markup so the
-  ;; bundle DOES compile in the SSR path. The bundle-isolation
-  ;; contract (S3-008) is then non-vacuous: even with SSR pulled in,
-  ;; the bundle still must NOT contain `react-dom/server` symbols,
+  ;; bundle DOES compile in the SSR path. The pure-CLJS-SSR contract
+  ;; (S3-005) is then non-vacuous: even with SSR pulled in, the
+  ;; bundle still must NOT contain `react-dom/server` symbols,
   ;; because reagent2.dom.server is pure-CLJS (no
   ;; `["react-dom/server" :as ...]` import — see IMPL-SPEC §8).
   ;;


### PR DESCRIPTION
Comment/explanation clarity pass on the reagent-slim worked example (slice = `examples/reagent-slim`, child rf2-kdoai.26 of the rf2-kdoai commenting sweep).

## What changed

One genuine drift fix in `examples/reagent-slim/counter_slim_and_fast/core.cljs`. The `run`-fn comment attributed the non-vacuous `react-dom/server`-absence claim to **S3-008** (stock-Reagent impl isolation); it is actually the **S3-005** pure-CLJS-SSR contract. The ns docstring already maps the two IDs correctly, both READMEs say S3-005, and IMPL-SPEC §8 (lines 163, 1067-1068) confirms S3-005 = pure-CLJS SSR / S3-008 = stock-Reagent isolation. A misleading comment is worse than none, so the ID is corrected to match.

## Verified-clear (no other changes)

- The rest of the file's docstrings/comments are accurate to the current API: `reg-view` auto-injects lexical `dispatch`/`subscribe` (re-frame.core §reg-view), `rds/render-to-static-markup [hiccup]` arity matches the call, `re-frame.adapter.reagent-slim/adapter` Var + `rf/init!` signature are current, and the `reagent2.core/current-component` seam claim holds.
- Brief-flagged drift items do NOT apply to this slice: no `get-frame-db`/`app-db-container`, no deleted `bound-fn`/`dispatcher`/`subscriber` references; the SSR §8.7 px-parity is correctly cross-referenced in the READMEs.
- Both READMEs already get the S3-005/S3-008 mapping right — left untouched.

## Quality gates

Behaviour-preserving: comments only, no logic change.

- **clj-kondo** on changed `.cljs`: 0 errors, 0 warnings.
- **reagent-slim bundle/isolation build** (`npm run test:reagent-slim:bundle-isolation`): PASS — both bundles compiled 0 warnings, 3 contracts passed, 19 sentinel checks. (build-id in shadow-cljs.edn untouched.)

Do not merge.