### PR TITLE
docs(adapters/reagent): comment & docstring quality pass (rf2-kdoai.2)

### DIFF
--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -66,11 +66,17 @@
   `register-context-provider` is passed in (NOT spine-built) because it
   is the Reagent-component-shaped frame-provider from `re-frame.views`,
   distinct from the React-hook spine's hook-shaped one — keeping the core
-  spine free of a spine→views dependency edge. The `:hook-ops` are
-  injected stock-`reagent.*` impls so the spine never names a reactive-
-  atom ns (bundle isolation, identical to `make-ratom-spine`'s
-  `:ratom-ops` contract). Per-hook rationale lives at
-  `spine/make-ratom-adapter`."
+  spine free of a spine→views dependency edge. That provider keeps
+  children as trailing-positional hiccup (`[provider frame-kw & children]`)
+  — Reagent's idiomatic shape and the cross-substrate baseline the UIx /
+  Helix `$`-trailing-children providers were aligned toward (rf2-7kii2,
+  which moved only those React-hook adapters; the Reagent shape is
+  unchanged).
+
+  The `:hook-ops` are injected stock-`reagent.*` impls so the spine
+  never names a reactive-atom ns (bundle isolation, identical to
+  `make-ratom-spine`'s `:ratom-ops` contract). Per-hook rationale lives
+  at `spine/make-ratom-adapter`."
   (spine/make-ratom-adapter
     spine-fns
     {:kind :rf.adapter/reagent


### PR DESCRIPTION
Commenting & explanation review of `implementation/adapters/reagent/` (rf2-kdoai.2, EPIC rf2-kdoai).

## Findings

The Reagent adapter (`src/re_frame/adapter/reagent.cljs`) was already excellently documented — accurate docstrings on every public Var (ns, `set-hiccup-emitter!`, `adapter`) and thorough why-comments on `spine-fns` (gensym-prefix attribution, call-through-lambda rationale for `with-redefs` test observability) and the inline `:hook-ops` map (frame-keyword-ignored, dual-IDisposable dispatch). All spec/bead cross-refs (rf2-rzex9, rf2-ee38b.1, rf2-agql, rf2-4y60, rf2-jicu2, rf2-l4dmr, rf2-uo7v) verified against the actual spine code — no drift. The testbed (`testbed/.../core.cljs`) and `deps.edn` are likewise clear.

## Change

One conservative additive note: the `register-context-provider` paragraph in the `adapter` docstring explained the Reagent-component-vs-React-hook shape distinction but did not record that the Reagent frame-provider keeps children as trailing-positional hiccup — the idiomatic shape and the cross-substrate baseline the UIx/Helix `$`-trailing-children providers were aligned toward (rf2-7kii2 moved only those React-hook adapters; the Reagent shape is unchanged). This mirrors the back-reference the UIx adapter's `frame-provider` docstring already carries ("mirroring Reagent's trailing-hiccup mental model (rf2-7kii2)"), making the cross-substrate relationship legible from both sides.

## Quality gates

Behaviour-preserving: docstrings/comments only, no logic change.

- clj-kondo on the changed file: errors 0, warnings 0.
- adapters JVM matrix / `npm run test:cljs`: not re-run. The single edit is inside a docstring string literal — it cannot alter runtime behaviour, and clj-kondo confirms the file still reads/parses. A fresh `npm install` + full CLJS sweep in this worktree offers no signal for a docstring-only change.