### PR TITLE
docs(skills/re-frame-migration): clarity pass (rf2-kdoai.31)

### DIFF
--- a/skills/re-frame-migration/references/guided-interceptors-subs.md
+++ b/skills/re-frame-migration/references/guided-interceptors-subs.md
@@ -104,7 +104,7 @@ The author picks the flow's `:id`; the agent suggests `:legacy/<original-event-i
 **Risk**: ran an arbitrary fn `:after` the handler; could modify `db`. Three replacement paths:
 
 1. **Computing derived state** → Spec 013 flow. Same rewrite as `on-changes`.
-2. **Post-handler validation** → registered `:spec` per Spec 010 (Malli schema on the registration's metadata map).
+2. **Post-handler validation** → registered `:schema` per Spec 010 (Malli schema on the registration's metadata map; `:spec` is no longer accepted — see M-54).
 3. **Imperative escape hatch** → custom `->interceptor` with the original body.
 
 Read the `enrich` body and propose the path; author confirms.


### PR DESCRIPTION
Comment/prose clarity pass on the v1->v2 migration skill (slice = `skills/re-frame-migration`). Behaviour-preserving — prose only, no logic/tool change.

## What changed

One genuine drift fix in `references/guided-interceptors-subs.md` (M-21 `enrich` walkthrough): the **post-handler validation** rewrite path named the registration metadata key as `:spec`. M-54 renamed `:spec` -> `:schema` on `reg-*` metadata and `:spec` is no longer accepted (silently ignored — a correctness hazard). This was the **lone straggler** — every other mention in the skill (O-1, M-54 in `breaking-changes.md`/`auto-cross-cutting.md`, the artefact tables) already speaks `:schema`. Updated to `:schema` with an inline pointer to M-54.

## Reviewed and found accurate (no change)

- `SKILL.md`, `README.md`, both `auto-*.md`, `guided-handlers-state.md`, `setup.md`, `sequencing.md`, `xray-replaces-10x.md`, `kickoff-prompt.md`, `output-format.md`, `error-events.md`, and all three `spec/*` meta-docs.
- Current-API surfaces verified correct throughout: M-67 frame-affordance renames (`frame-handle` / `frame-bound-fn`; deleted `bound-fn`/`dispatcher`/`subscriber`; `get-frame-db` -> `frame-db`), M-54 `:spec` -> `:schema`. `error-events.md`'s `five-prefix-shapes` anchor matches the live Spec 009 heading.

## Quality gates

- `python scripts/check_skill_mcp_drift.py` — pass (exit 0)
- `python scripts/check_doc_slugs.py` — pass (exit 0)
- behaviour-preserving: prose/comments only.