### PR TITLE
docs(skills/re-frame2-implementor): clarity pass (rf2-kdoai.32)

### DIFF
--- a/skills/re-frame2-implementor/references/phase-2-impl-order.md
+++ b/skills/re-frame2-implementor/references/phase-2-impl-order.md
@@ -176,7 +176,7 @@ For each capability the port declared `yes` for in D3, walk the matching EP. Sug
 
 **Read.** [`spec/010-Schemas.md`](https://day8.github.io/re-frame2/spec/010-Schemas/) and [Implementor-Checklist §Schemas](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#schemas-if-q4-is-yes).
 
-**Contract.** `:spec` registration metadata; `reg-app-schema`; validation at boundaries (handler entry, sub return, fx args, app-db at registered paths); validation-failure trace events; production elision per EP 009.
+**Contract.** `:schema` registration metadata (the unified vocabulary term across every surface — v1's `:spec` metadata key was renamed to `:schema` with no back-compat alias, per [`spec/010-Schemas.md` §Vocabulary unified](https://day8.github.io/re-frame2/spec/010-Schemas/)); `reg-app-schema`; validation at boundaries (handler entry, sub return, fx args, app-db at registered paths); validation-failure trace events; production elision per EP 009.
 
 **Common trap.** Open vs closed shapes — open by default is non-negotiable; opt-in `:closed true` per registration.
 

--- a/skills/re-frame2-implementor/references/reference-impl-tour.md
+++ b/skills/re-frame2-implementor/references/reference-impl-tour.md
@@ -135,7 +135,7 @@ EP 012 implementation. Hand-rolled URL matcher with a six-rule precedence cascad
 
 ### `schemas/`
 
-EP 010 implementation. Malli is the wire layer; `reg-app-schema` and `:spec` metadata are the public API. Replace Malli with the host's mechanism per D5 — Zod for the dynamically-typed in-scope hosts (TS / Squint), or the host's own type system for the statically-typed ones.
+EP 010 implementation. Malli is the wire layer; `reg-app-schema` and `:schema` metadata are the public API (the metadata key is `:schema` — v1's `:spec` was renamed with no back-compat alias). Replace Malli with the host's mechanism per D5 — Zod for the dynamically-typed in-scope hosts (TS / Squint), or the host's own type system for the statically-typed ones.
 
 ### `ssr/`
 


### PR DESCRIPTION
## Summary

Comment/prose clarity pass on the `skills/re-frame2-implementor` slice (rf2-kdoai.32, the [comment-review] sweep). The skill is prose/markdown only — no code in this slice. Behaviour-preserving: prose/comments only, no logic/tool change.

The slice is in good shape overall (SKILL.md, README, cardinal-rules, phase-1-decisions, conformance, decision-record, output-format, kickoff-prompt all verified accurate against the current v2 API and recent landings). One genuine drift found and fixed.

## What changed

Stale `:spec` schema-metadata-key references, in two EP 010 descriptions:

- `references/phase-2-impl-order.md` — EP 010 (Schemas) **Contract** line said `:spec registration metadata`.
- `references/reference-impl-tour.md` — `schemas/` artefact tour said `:spec metadata`.

The framework-wide vocabulary unification (MIGRATION M-54, 2026-05-20) renamed the per-`reg-*` schema metadata key from `:spec` to `:schema` **with no back-compat alias** — `spec/API.md` and `spec/010-Schemas.md` both state the framework no longer accepts `:spec` on `reg-*` metadata. The stale references would have misled a port author into emitting the wrong key and failing the `:schemas/*` conformance fixtures — worse than no comment. Both now say `:schema` with a one-clause note on the rename.

## Verified-clean (no change needed)

- Registrar closed-kind set (phase-2 line 35) matches `spec/001-Registration.md` §Registry model exactly (incl. `:flow`).
- Testing surface (`with-frame`/`with-new-frame`, `dispatch-sync`, `compute-sub`, `reset-frame!`, epoch `restore-epoch`/`reset-frame-db!`, `:fx-overrides`/`:interceptor-overrides`) matches `spec/008-Testing.md` + `spec/API.md`.
- Substrate nine-entry contract, `:rf/runtime` reserved-key scheme, reserved-id discipline — all current.
- `frame-db` not renamed (rf2-1i168 owns that later).

## Quality gates

- `python scripts/check_skill_mcp_drift.py` — PASS (exit 0)
- `python scripts/check_doc_slugs.py` — PASS (exit 0)
- behaviour-preserving: prose/comments only