### PR TITLE
docs(adapters/reagent-slim): comment pass (rf2-kdoai.3)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
@@ -1,12 +1,11 @@
 (ns reagent2.dom.client
   "Mount entry + test-flush primitive for the day8/reagent-slim artefact.
 
-  Stage 4-B scope (rf2-6hyy): the `flush-views!` test primitive lands
-  here per IMPL-SPEC §2.4 + §4. The mount entries (`create-root`,
-  `render`, `unmount`, `hydrate-root`) are scaffolded as deferred so
-  Stage 4-D's hiccup interpreter (`reagent2.impl.template`) can wire
-  the render path without re-touching this ns. Their final
-  implementations land with Stage 4-D / 4-E.
+  Per IMPL-SPEC §2.4 + §4. The `flush-views!` test primitive and the
+  mount entries (`create-root`, `render`, `unmount`, `hydrate-root`)
+  all live here. `render` / `hydrate-root` walk the user's hiccup once
+  via the hiccup interpreter `reagent2.impl.template/as-element` and
+  hand the resulting React element tree to React's root.
 
   Public Vars (per IMPL-SPEC §2.4):
 
@@ -60,12 +59,7 @@
     Suspense test in dom_client_cljs_test.cljs.
 
   Production cost: zero. `flush-views!` is gated on `js/goog.DEBUG` and
-  DCEs entirely under `:advanced` + `goog.DEBUG=false`.
-
-  Stage 4-D: `render` and `hydrate-root` are wired to the hiccup
-  interpreter `reagent2.impl.template/as-element`. Both call paths
-  walk the user's hiccup tree once and produce React elements; React
-  then drives its own concurrent rendering through the root."
+  DCEs entirely under `:advanced` + `goog.DEBUG=false`."
   (:require [reagent2.impl.batching :as batching]
             [reagent2.impl.template :as template]
             ["react" :as react]
@@ -87,9 +81,9 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- resolve-act
-  "Look up React's `act`. Returns the fn or nil. Cached across calls
-  in dev — re-resolved once per `flush-views!` so a test fixture that
-  swaps the React module mid-run sees the swap."
+  "Look up React's `act`. Returns the fn or nil. Re-resolved on every
+  call (not cached) so a test fixture that swaps the React module
+  mid-run sees the swap on the next `flush-views!`."
   []
   (or (.-act react)
       ;; Fallback: pre-18.3 lived in react-dom/test-utils. We don't

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.clj
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.clj
@@ -11,19 +11,19 @@
   macro is shipped — `reg-view` is the single canonical view-registration
   surface (per the rf2-yfbx decision).
 
-  Public macros (consumed by `reg-view`'s expansion):
+  Public fns (compile-time helpers, consumed by `reg-view`'s expansion):
 
-    classify-form-body — return a keyword form-tag for the body. Pure
-                         compile-time helper; no runtime cost.
+    classify-form-body — return a keyword form-tag for the body.
+    tag-form-meta      — wrap a form-tag in the `{:reagent2/form ...}`
+                         metadata map `reg-view` stamps onto the
+                         wrapper fn so the runtime can read it.
 
-    form-tagged-fn     — emit `(fn ~argv ~@body)` with the form-tag
-                         attached as meta on the fn-form so the
-                         runtime can read it.
-
-  No CLJ-side runtime code lives here; only the compile-time helpers
-  consumed by CLJS build sites via `:require-macros`. The classification
-  logic is pure-data; both helpers are usable from `re-frame.core`
-  (or any other macro that wants to amortise the runtime detection)."
+  These run at macroexpansion time (CLJ), not at runtime — the macro
+  invoking them folds the result into the emitted CLJS. They are plain
+  `defn`s (the classification logic is pure-data), so any macro that
+  wants to amortise the runtime detection — `re-frame.core/reg-view`
+  or otherwise — can call them directly. No CLJS-side runtime code
+  lives in this ns."
   (:refer-clojure :exclude [fn?]))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -39,10 +39,15 @@
       via protocol — no `instance?` branch in core. The shape of
       `dispose!` and `add-on-dispose!` MUST NOT change.
 
-  Stage-4-A scope: pure reactive primitives, no DOM/component coupling.
-  Stage 4-B will add the microtask render scheduler and wire
-  `(set! batch/ratom-flush flush!)` so the render layer can drain the
-  reactive queue on each commit boundary."
+  Render-layer coupling: this ns stays pure reactive primitives, no
+  DOM/component dependency. The microtask render scheduler
+  (`reagent2.impl.batching`) couples to it in two directions, both via
+  the `rea-schedule` slot below — `batching` installs its `schedule`
+  fn into `rea-schedule` at ns-load so a dependency change schedules a
+  microtask drain, and `batching/flush-queues` calls `(ratom/flush!)`
+  on each commit boundary to drain the reactive queue synchronously.
+  ratom itself never names `batching` — the edge is one-way (batching
+  → ratom), keeping this ns DOM/component-free."
   (:refer-clojure :exclude [atom run!])
   (:require-macros [reagent2.ratom])
   (:require [clojure.set :as set]))
@@ -152,12 +157,12 @@
 ;;
 ;; Reactions whose dependencies have changed get pushed into rea-queue.
 ;; flush! drains the queue, recomputing each Reaction. The render
-;; scheduler (Stage 4-B, reagent2.impl.batching) hooks into this via
-;; the assignable `batch/ratom-flush` slot so the render-commit
-;; boundary drains pending reactive work.
-;;
-;; Stage 4-A ships rea-queue + flush! standalone; the render-side
-;; integration lands with 4-B.
+;; scheduler (reagent2.impl.batching) couples in via the `rea-schedule`
+;; hook below: on the first enqueue rea-enqueue calls the installed
+;; scheduler fn to request a microtask drain, and batching also calls
+;; `(ratom/flush!)` from its own commit-boundary drain. flush! itself
+;; is standalone — callable with no render layer present (the
+;; :node-test path exercises it directly).
 ;; ---------------------------------------------------------------------------
 
 (defonce ^:private rea-queue nil)
@@ -447,9 +452,9 @@
   contract. Loops until the queue is empty (a recompute may itself
   enqueue downstream Reactions).
 
-  Stage 4-A: callable directly. Stage 4-B's reagent2.impl.batching will
-  install this as `batch/ratom-flush` so the render-commit boundary
-  drains automatically."
+  Callable directly. reagent2.impl.batching also drives it from its
+  own commit-boundary drain (`flush-queues` calls `(ratom/flush!)`) so
+  the render layer drains pending reactive work before committing."
   []
   (loop []
     (let [q rea-queue]


### PR DESCRIPTION
Behaviour-preserving comment/docstring pass over `implementation/adapters/reagent-slim` (comment-review slice rf2-kdoai.3). Comments only — no logic change.

The slice was already unusually well-commented (the slim-free SSR contract, render-to-static-markup pipeline, bundle-isolation rationale, prototype-pollution defences are all thoroughly documented). The pass found four genuine-drift items and fixed them; everything else was left untouched.

## Changes (drift fixes only)

- **`reagent2.ratom`** — three sites described a Stage-4-B future that has shipped and named a `batch/ratom-flush` slot that never existed. The real coupling is one-way (`batching` → `ratom`) via the `rea-schedule` hook plus `batching`'s commit-boundary `(ratom/flush!)` call. Rewrote the ns docstring's render-coupling note, the `rea-queue` section comment, and the `flush!` docstring to describe the shipped wiring.
- **`reagent2.impl.component` (CLJ)** — ns docstring said "Public macros" and listed a non-existent `form-tagged-fn`. Actual surface is two compile-time `defn`s: `classify-form-body` + `tag-form-meta`. Corrected.
- **`reagent2.dom.client`** — `resolve-act` docstring was self-contradictory ("Cached across calls ... re-resolved once per call"); the body caches nothing. Stated it re-resolves every call. Also dropped the stale "mount entries scaffolded as deferred" framing from the ns docstring — they are fully implemented in this file (removed the now-redundant trailing Stage-4-D paragraph).

## Quality gates

- `clj-kondo` (changed files, `--fail-level error`): **errors 0**, 1 warning (`unused binding a` in `pr-atom`) confirmed pre-existing (present on base, only line number shifted).
- `npm run test:cljs`: **5186 tests / 17667 assertions, 0 failures, 0 errors**.
- `npm run test:reagent-slim:bundle-isolation`: **PASS** — 3 contracts, 19 sentinel checks.

Behaviour-preserving: comments only.