### PR TITLE
docs(skills/shared): clarity pass (rf2-kdoai.39)

### DIFF
--- a/skills/shared/tests/README.md
+++ b/skills/shared/tests/README.md
@@ -22,16 +22,18 @@ file contents). The behavioural fixtures are document-runnable; see
 
 ## Why this directory exists
 
-The corpus convention is that **only `re-frame2-pair/` ships a
-`tests/` directory** — see `skills/README.md` §"Test-fixture
-discipline." `re-frame2-pair/` is the exception because it drives a
-live runtime (nREPL attach, app-db mutation, epoch reads).
+The corpus convention is that **only `re-frame2-pair/` and `shared/`
+ship a `tests/` directory** — see `skills/README.md` §"Test-fixture
+discipline." `re-frame2-pair/` qualifies because it drives a live
+runtime (nREPL attach, app-db mutation, epoch reads), so its surface is
+testable in the conventional sense.
 
-`skills/shared/retro-protocol.md` warrants the second exception for a
-different reason: it is a **security boundary**. A prior audit found
-four issues there; three landed prose-only fixes. The audit's Finding
-4 explicitly called for a regression suite so a future drift of the
-prose doesn't silently re-open the boundary.
+`skills/shared/` (this directory) is the second exception, and it earns
+it for a different reason: `retro-protocol.md` is a **security
+boundary**, not just a doc leaf. A prior audit found four issues there;
+three landed prose-only fixes. The audit's Finding 4 explicitly called
+for a regression suite so a future drift of the prose doesn't silently
+re-open the boundary.
 
 The structural test is the cheap class of drift detector (would catch
 "someone deleted §Untrusted-evidence boundary"); the document


### PR DESCRIPTION
Comment/prose clarity pass on `skills/shared` (rf2-kdoai.39, last slice of the kdoai sweep). Behaviour-preserving: prose only, no logic or test change.

## What changed

One genuine drift fixed in `skills/shared/tests/README.md` §"Why this directory exists": it still framed `re-frame2-pair/` as the *only* skill shipping a `tests/` dir and `shared/` as a one-off carve-out against that convention. The canonical `skills/README.md` §"Test-fixture discipline" now recognises **both** `re-frame2-pair/` and `shared/` as the two exceptions. Reworded to state both plainly and keep the two distinct rationales (live-runtime vs security-boundary).

## What was verified clean (no change)

- `tool-pair-surfaces.md` — all API names current against spec (`register-listener!`, `trace-buffer`, registrar query list, `epoch-history`, `restore-epoch`, `register-epoch-listener!`, `app-schemas`, `compute-sub`, `data-rf2-source-coord`/`data-rc-src`, `frame-db`, `reset-frame-db!`). `frame-db` left as-is per brief (rf2-1i168 later). No `:spec`/operating-frame/`:include-sensitive`/run-result drift present.
- `retro-protocol.md`, `issue-filing.md` — cross-ref anchors and consumer paths all resolve; `allowed-tools` factual claims accurate (improver has `Edit` not `gh`; pair-retro has `gh issue` not `Edit`).
- `tests/fixtures/*` + `retro_protocol_test.clj` header — accurate, internally consistent; no change.

## Quality gates

`.md` edited:
- `python scripts/check_skill_mcp_drift.py` — exit 0
- `python scripts/check_doc_slugs.py` — exit 0

Behaviour-preserving: prose/comments only.