### PR TITLE
fix(xray): correct stale keybindings-help table (Handler/Issues -> Epoch/Routes) (rf2-7g5f1)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -9,13 +9,14 @@ event**:
 
 | Tab | Bug-class it answers |
 |---|---|
-| **Event** (`e`) | "What does this event do?" — the handling pipeline (DISPATCH → COEFFECTS → EVENT HANDLER → FLOWS → DB CHANGES → AFTER INTERCEPTORS → FX; optional sections omitted when absent) + wire-boundary diff per managed fx. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §2.) |
+| **Epoch** (`e`) | "What does this event do?" — the handling pipeline (DISPATCH → COEFFECTS → EVENT HANDLER → FLOWS → DB CHANGES → AFTER INTERCEPTORS → FX; optional sections omitted when absent) + wire-boundary diff per managed fx. Supersedes the retired Event/Handler tab per rf2-5gl5r. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §2.) |
 | **app-db** (`a`) | "What changed because of this event?" — the complete app-db, sectioned by reserved `:rf/*` area, with inline diff annotations. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §4.) |
 | **Views** (`v`) | "Why did these views re-render?" — the left → right reactive-flow graph (app-db → subs → views) + hover-to-highlight on rendered DOM. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §3. Rendered tab label follows the Figma export `Views` (rf2-ad7zx); the spec's rf2-e33ad display label was `View`; key stays `:views`.) |
 | **Trace** (`t`) | "What raw events fired in this cascade?" — readable-line timeline, op-family colour bands, relative timing. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §5; dedicated redesign spec + Figma-handoff target: [`023-Trace-Panel.md`](./023-Trace-Panel.md).) |
 | **Machine** (`m`) | "What did this event do to my machines?" — transitions, cancellation cascade, `:after` rings. **Event-driven only post-rf2-y9xmf** (no picker, no Mode A/B/C; BLANK when the focused event has no machine activity; per-machine prev/next nav walks the spine). (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §6.) |
 | **Routes** (`r`) | "What did this event do to my routes?" — current route + this-epoch navigation + the registered route table. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §7. Promoted to its own L3 tab per rf2-nrbs9.) |
-| **Issues** (`i`) | "What's wrong here?" — errors · warnings · advisories (severity-coded rows). (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §8.) |
+
+(The former **Issues** tab (`i`) was removed per rf2-gbz39 — Mike RULED Option (c), 2026-05-31. Errors · warnings · advisories now surface inline in the Epoch panel + the L2 event-row pink-wash + the always-on issues ribbon signal, rather than in a dedicated 7th tab.)
 
 (rf2-4v67l — the Chrome A11y dogfood tab was removed. A11y
 dogfooding is properly Story's domain, where it already ships as
@@ -117,10 +118,10 @@ The four layers, top to bottom:
    The active/focused row takes a subtle background; functional semantic markers
    (redaction / issue / pin) ride as subtle per-row signals (§Event-list rows). The spine
    sub `:rf.xray/focus` reads from this layer.
-3. **L3 — Tab bar (40px).** Seven tabs in the order the Figma export fixes,
-   updated post rf2-5gl5r:
-   **Epoch · app-db · Views · Trace · Machine · Routes · Issues**. Letter mnemonics:
-   `e` `a` `v` `t` `m` `r` `i`. (The original Figma export listed Event/Handler at
+3. **L3 — Tab bar (40px).** Six tabs in the order the Figma export fixes,
+   updated post rf2-5gl5r + rf2-gbz39 (Issues tab removed per Option (c)):
+   **Epoch · app-db · Views · Trace · Machine · Routes**. Letter mnemonics:
+   `e` `a` `v` `t` `m` `r`. (The original Figma export listed Event/Handler at
    `:order 0`; rf2-5gl5r retired that panel in favour of the Epoch panel at
    `:order -1` — same letter mnemonic `e`, same leftmost position.) Each tab
    renders its **label only** (no `◉`/`○` glyph — Figma
@@ -1113,18 +1114,18 @@ active panel). `Esc` always returns focus to the event list.
 
 | Key | Tab |
 |---|---|
-| `1` | Event |
+| `1` | Epoch |
 | `2` | App-db |
 | `3` | Views |
 | `4` | Trace |
 | `5` | Machines |
-| `6` | Issues |
-| `e` | Event (mnemonic) |
+| `6` | Routes |
+| `e` | Epoch (mnemonic) |
 | `a` | App-db (mnemonic) |
 | `v` | Views (mnemonic — incl. subs nested under each view) |
 | `t` | Trace (mnemonic) |
 | `m` | Machines (mnemonic) |
-| `i` | Issues (mnemonic) |
+| `r` | Routes (mnemonic) |
 | `Ctrl+→` / `Ctrl+←` | Next / previous tab |
 
 ### Detail panel (L4)
@@ -1158,8 +1159,10 @@ click-drag pan have no keyboard equivalent.
   `c` unused.
 - `p` (Performance) — Performance panel dropped; `p` unused.
 - `w` (Flows) — Flows folded into Views; `w` unused.
-- `S` (Schemas) — schema violations live in Issues; `S` unused.
-- `h` (Hydration) — hydration mismatches live in Issues; `h` unused.
+- `S` (Schemas) — schema violations surface inline in the Epoch panel
+  (rf2-gbz39 removed the Issues tab per Option (c)); `S` unused.
+- `h` (Hydration) — hydration mismatches surface inline in the Epoch panel
+  (rf2-gbz39 removed the Issues tab per Option (c)); `h` unused.
 
 ## Detail panel renderer
 
@@ -1370,8 +1373,8 @@ on `Esc`, click-outside, or invocation of any item.
 - Registered handlers (id + `:doc`)
 - Frames
 - Machines with current state
-- L4 tab jumps — Dynamic: Event / App DB / Views / Trace / Machines
-  / Routes / Issues; Static: Machines / Routes /
+- L4 tab jumps — Dynamic: Epoch / App DB / Views / Trace / Machines
+  / Routes; Static: Machines / Routes /
   Schemas / Flows / Interceptors (see §Mode-aware command surface below)
 - Command verbs (recents-boosted; see §Command verbs below)
 - Settings entries

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -768,12 +768,12 @@
             ["Ctrl+click" "Copy cascade-id"]]}
    {:group "Tab bar (L3)"
     :rows  [["1-6"             "Switch tab by index"]
-            ["h"               "Handler tab"]
+            ["e"               "Epoch tab"]
             ["a"               "App-db tab"]
             ["v"               "Views tab"]
             ["t"               "Trace tab"]
             ["m"               "Machines tab"]
-            ["i"               "Issues tab"]
+            ["r"               "Routes tab"]
             ["Ctrl+→ / Ctrl+←" "Next / previous tab"]]}
    {:group "Settings popup (modal-only)"
     :rows  [["g" "General tab"]


### PR DESCRIPTION
Closes rf2-7g5f1.

## Problem

The Xray settings keybindings-help modal (`tools/xray/src/day8/re_frame2_xray/settings/view.cljs`, Tab bar (L3) group) listed two retired rows:

- `h` -> "Handler tab" — the Handler/Event tab was retired (rf2-5gl5r); the Epoch panel superseded it (mnem `e`, order -1).
- `i` -> "Issues tab" — the Issues tab was removed (rf2-gbz39, Mike RULED Option (c)).

## Fix

Corrected the two rows to the actual current dynamic-tab mnemonics, verified against each panel's `reg-l4-tab!` registration:

- `h` "Handler tab" -> `e` "Epoch tab" (epoch_panel.cljs :mnem "e")
- `i` "Issues tab" -> `r` "Routes tab" (routing.cljs :mnem "r")

Full current dynamic set: Epoch(e) app-db(a) Views(v) Trace(t) Machines(m) Routes(r).

## Spec sync (tools/xray/spec/007-UX-IA.md)

Per the Xray-specs-kept-current rule, brought the same-drift spec content into line: the L3 Tab-bar keybinding table (`1 Event`->`1 Epoch`, `6 Issues`->`6 Routes`, `e Event`->`e Epoch`, `i Issues`->`r Routes`), the seven-tab narrative (now six), the bug-class tab table (Event->Epoch row; Issues row converted to a removal note), the L4 palette tab-jump list, and the retired-keys notes.

## Quality gates

- xray `clojure -M:test` — 1038 tests, 4146 assertions, 0 failures / 0 errors
- `npm run test:cljs` — 5186 tests, 17667 assertions, 0 failures / 0 errors
- `npm run test:xray-feature-gate` — 16 scenarios (nightly-full), 0 failures, 13 matrix rows; all testbeds (incl. panel-gallery, which builds the settings view) compiled 0 warnings
- clj-kondo on changed `view.cljs` — 0 errors (1 pre-existing unrelated unused-private-var warning at L154)
- Testbed builds confirm the settings panel compiles cleanly