### PR TITLE
docs(scripts): comment-review sweep implementation/scripts (rf2-kdoai.15)

### DIFF
--- a/implementation/scripts/lib/browser-test-report.cjs
+++ b/implementation/scripts/lib/browser-test-report.cjs
@@ -1,3 +1,26 @@
+// Shared cljs.test summary-parsing + diagnostic-buffering for the
+// browser-test runners (#1196).
+//
+// cljs.test's `Ran N tests containing M assertions.` / `K failures, L
+// errors.` lines arrive interleaved with arbitrary browser-console
+// noise (app logs, `[browser:log]`-prefixed forwards, …). The RegExps
+// below pluck just those two summary lines out of the stream so a
+// runner can print a one-line compact result and decide pass/fail from
+// the failure/error counts — without echoing the whole noisy log on a
+// green run.
+//
+//   summaryPartsFromText(text)  → { ran, failErr } (each the matched
+//                                  line or null).
+//   parseFailureCounts(failErr) → { failures, errors } or null. A gate
+//                                  is green only when both are 0 AND a
+//                                  `Ran ...` line was seen.
+//   formatCompactSummary(parts) → the one-line `<label>: <ran> <failErr>`.
+//   createDiagnosticBuffer()    → an ordered stdout/stderr line buffer
+//                                  flushed verbatim (with stream routing)
+//                                  only when the runner needs the trail.
+// isVerboseTests(env) is the RF2_VERBOSE_TESTS=1 escape hatch shared
+// with lib/gate-report.cjs.
+
 const RAN_RE = /Ran\s+(\d+)\s+tests?\s+containing\s+(\d+)\s+assertions?\./;
 const FAIL_RE = /(\d+)\s+failures?,\s*(\d+)\s+errors?\.?/;
 

--- a/implementation/scripts/lib/gate-report.cjs
+++ b/implementation/scripts/lib/gate-report.cjs
@@ -1,3 +1,22 @@
+// Shared gate-reporter for the check-* JS gate scripts (#1197).
+//
+// A gate's normal output is exactly one `PASS <label>` line; the noisy
+// per-check detail is buffered, not printed, unless either (a)
+// RF2_VERBOSE_TESTS=1, or (b) the gate fails and the caller calls
+// flushDetails() to dump the buffer (to stderr by default) for triage.
+// This keeps a green CI run to one line per gate while preserving the
+// full diagnostic trail on red.
+//
+// createGateReporter(opts) → { detail, flushDetails, pass, isVerbose,
+//                              bufferedLineCount }
+//   detail(line)        buffer a detail line (printed immediately when
+//                       verbose; multi-line strings are split).
+//   flushDetails({stream}) emit the buffered lines (no-op when verbose,
+//                       since they were already printed) and clear them.
+//   pass(label, summary)   print the one-line `PASS <label>[: <summary>]`.
+// `verbose` defaults to isVerboseTests(env); stdout/stderr are injectable
+// for the unit tests (_gate-report.test.cjs).
+
 'use strict';
 
 const { isVerboseTests } = require('./browser-test-report.cjs');


### PR DESCRIPTION
Slice of the kdoai commenting sweep — surface: `implementation/scripts/` only. Conservative, behaviour-preserving (comments/docstrings only).

## What changed

Added file-header docstrings to the two `lib/` helper modules that lacked one, while every other substantive module in the surface already carried a WHAT+contract banner:

- **`lib/gate-report.cjs`** — documents the buffer-on-green / flush-on-red reporting model (one `PASS <label>` line on a green run; full detail only when `RF2_VERBOSE_TESTS=1` or the gate fails and the caller `flushDetails()`) and the `createGateReporter` surface. Consumed by 8 `check-*` gate scripts.
- **`lib/browser-test-report.cjs`** — documents the cljs.test summary-line extraction from noisy browser-console output, the green-iff-both-counts-0 rule, and the diagnostic-buffer surface. Consumed by the browser-test runners.

Brings these in line with their documented siblings (`read-release-bundle.cjs`, the `check-*` probes).

## Drift audit (no changes needed)

- No stale value-accessor `frame-db` references — all `reset-frame-db!` / `:rf.epoch/reset-frame-db-*` hits are the legitimate sentinel strings the bundle-isolation + elision probes search for (correct, left as-is).
- `:rf/hydrate` in check-bundle-isolation.cjs is the live SSR event-id (distinct from the folded `:rf/hydration` runtime key) — accurate.
- Splint shim version `v1.24.0` matches `deps.edn` — no count drift.
- All "future"/"planned" comments are forward-looking guard rationale, not stale shipped-feature markers.

The rest of the surface is exemplary — thorough headers, accurate spec/bead cross-refs, well-placed why-comments.

## Quality gates

- `node -e require(...)` on both modules → require OK (comment-only, but confirms no banner-comment syntax breakage).
- `node _gate-report.test.cjs` → 4 passed.
- `node _browser-test-report.test.cjs` → 12 passed.
- Other npm gates (test:bundle-isolation, test:elision, test:perf-bundle, browser runners) N/A — no `.cjs` *logic* changed; the touched files are require-only helper modules whose own unit tests are the direct coverage and pass.