### PR TITLE
docs(spec): name the no-silent-swallow API principle (rf2-3nbl5.1)

### DIFF
--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -352,6 +352,38 @@ This rule is `reg-event-*`-specific. `reg-frame`'s metadata-map *does* recognise
 
 **The three-form family is deliberately preserved.** The three-form family (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`) is deliberately preserved from re-frame v1 for migration ergonomics. The noise is acknowledged; the cost of breaking v1 muscle memory exceeds the readability win of collapsing.
 
+## No silent swallow — recognised input MUST signal
+
+This is the repo-level honest-signal rule the [§`:interceptors` is positional](#interceptors-is-positional-not-metadata-reg-event-) warning above is one instance of. It is the normative realisation of [Principles §No silent swallow](Principles.md#no-silent-swallow) — that principle names the *why*; this section is the MUST.
+
+> **Rule.** A user-supplied value that is **recognised as input** but **cannot be honoured** MUST produce a structured warning or error. Silent ignore is allowed **only** for explicitly namespaced extension keys in an extension map.
+
+"Recognised as input" means the value reached a slot the runtime reads — an opts key in a known opts position, an fx-override of a reserved fx-id, a callback whose return the runtime consumes, one of a pair of explicit options. "Cannot be honoured" means the runtime declines to act on it: it's an unknown key, the override is ignored, the return is dropped, the two options conflict. In every such case the runtime MUST signal — a dev-gated `:rf.warning/*` advisory (per [§Error-id and warning-id grammar](#error-id-and-warning-id-grammar)) when the cascade can continue safely, or a `:rf.error/*` when it cannot. **Silence is a dishonest signal**: the caller observes success, the value vanishes, and the defect surfaces far from its cause with no breadcrumb to follow.
+
+### The extension-key carve-out is load-bearing
+
+The single exception — silent ignore of **explicitly namespaced extension keys in an open extension map** — is what makes the rule compatible with [§Reserved namespaces](#reserved-namespaces-framework-owned)' open-map accretion and [Principles §Spec-ulation](Principles.md#spec-ulation). An open map (registration metadata, a machine snapshot's `:data`, a spawn-spec, a frame config) tolerates user-namespaced keys it does not recognise *by design* — that is how a producer adds vocabulary without a coordinated breaking change. Those keys are **not "recognised input the runtime declined to honour"**; they are foreign keys the runtime was never asked to interpret. The discriminator is recognition: a key in the framework's known set that the runtime drops is a silent swallow (banned); a user-namespaced key in an explicitly open map that the runtime never claims to read is accretion (allowed). A *bare* or *framework-namespaced* key the runtime does not recognise is on the wrong side of the line — it reads as a typo of a real key and MUST warn (the `:rf.warning/interceptors-in-metadata-map` and `:rf.warning/unknown-dispatch-opt` cases).
+
+### Pre-alpha is the window to be strict
+
+Pre-alpha re-frame2 carries no in-flight consumers a strict signal would break, so the rule ships at full strictness: every recognised-but-unhonourable input warns or errors today, with no tolerance grace period. The **only** sanctioned future relaxation is an opt-in `:allow-unknown? true` escape hatch on the relevant surface — a caller who deliberately wants forward-compatibility against a newer producer's vocabulary can suppress the unknown-key warning for that call. The escape hatch is **not shipped pre-1.0** and is recorded here only to fix the one forward-compat lever so a later relaxation is additive (a new opt) rather than a contract change to the rule itself. Absent the opt, the default is strict.
+
+### Per-surface applications
+
+The rule is cross-cutting; each surface applies it in its own spec and registrar, NOT here. The concrete instances that motivated naming the rule (each fixed in its own change, each an application of this principle):
+
+| Surface | Recognised-but-unhonourable input | Instance bead |
+|---|---|---|
+| Core dispatch | unknown opts key in the dispatch opts map (`:rf.warning/unknown-dispatch-opt`) | rf2-jbzhj |
+| Core fx | reserved-fx fn-override that was silently ignored while `:rf.fx/override-applied` lied that it applied | rf2-nnma3 |
+| Managed HTTP | `:on-failure nil` swallowing a real (non-aborted) failure with no dev-time signal | rf2-rl5tt |
+| SSR | conflicting `:payload-keys` + `:payload-policy` explicit opts (consolidated to one `:payload`, fail-closed) | rf2-pffil |
+| State machines | `:on-spawn` callback return silently dropped while the teaching surface implied it was recorded | rf2-g72p8 |
+| pair-mcp | `:unknown-tool` error envelope that dead-ended an agent with no `:hint` / `tools/list` pointer | rf2-tkmik |
+| Schemas | `reg-app-schema` silently accepting a bare keyword as opts and registering against the default frame | rf2-52dfy |
+
+New surfaces apply the rule by mechanism: if a recognised input cannot be honoured, signal it — and reach for the extension-key carve-out only when the dropped key is a user-namespaced key in an explicitly open map. A surface that seems to *need* silent-ignore of a recognised input is evidence of a missing warning, not an exception to the rule — file a bead against the owning spec rather than swallowing.
+
 ## Implementation note — persistent data structures
 
 Conformant implementations need a structural-sharing persistent collection library for `app-db` and frame state. CLJS gets this free; other in-scope JS-cross-compile-language ports pick a host-idiomatic library (Immer or Immutable.js for TypeScript / Squint; im.kt or `kotlinx.collections.immutable` for Kotlin/JS; native PDS from the source language for Fable (F#) / Scala.js / PureScript / Melange / ReScript / Reason). For the per-host options, why this is pattern-required, and how it composes with [Goal 2 — Frame state revertibility](000-Vision.md#frame-state-revertibility), see [000-Vision §Host-profile matrix — Note on persistent data structures](000-Vision.md#note-on-persistent-data-structures).

--- a/spec/Principles.md
+++ b/spec/Principles.md
@@ -7,7 +7,7 @@
 
 Each principle below is a one-line statement followed by one paragraph of guidance. The longer arguments — *why* the discipline principles are worth their cost — live in §Rationale essays at the end. Goals (the *what we're optimising for*) are owned by [000 §Goals](000-Vision.md#goals); this doc names the *how*.
 
-The 9 discipline principles, 2 foundational essays, and 1 deliverable principle below break into three groups:
+The 10 discipline principles, 2 foundational essays, and 1 deliverable principle below break into three groups:
 
 - **Discipline principles** — properties an individual EP can be graded against. The [AI-First Audit](AI-Audit.md) does exactly that grading.
 - **Foundational essays** — the deeper arguments for *why* the discipline principles are worth the cost. Live in §Rationale essays below.
@@ -76,6 +76,12 @@ Run-to-completion drain semantics, explicit effect boundaries, and inspectable s
 
 The [009 §Error contract](009-Instrumentation.md#error-contract) defines the structured shape; every error category carries a stable `:operation` keyword and a documented `:tags` payload.
 
+### No silent swallow
+
+**Principle:** a recognised input that cannot be honoured produces a signal — never silence.
+
+When the runtime *recognises* a user-supplied value as input but cannot act on it — an unknown opts key, a reserved-fx override it ignores, a callback whose return it drops, a conflicting pair of explicit options — it MUST emit a structured warning or error rather than continue as if the value were never supplied. Silent ignore is a *dishonest signal*: the caller sees success, the value vanishes, and the bug surfaces far from its cause with no breadcrumb. The carve-out is narrow and load-bearing — silent ignore is allowed **only** for explicitly namespaced extension keys in an open extension map, which is exactly what [§Spec-ulation](#spec-ulation)'s open-map accretion depends on. The normative MUST, the carve-out, and the pre-alpha-strictness rationale (with the `:allow-unknown?` forward-compat escape hatch) live in [Conventions §No silent swallow](Conventions.md#no-silent-swallow--recognised-input-must-signal); this principle names the *why* behind that rule. It is the honest-signal sibling of *machine-readable errors* — that principle governs the *shape* of a failure; this one governs *that a recognised-but-unhonourable input fails loudly at all*.
+
 ### Low hidden context
 
 **Principle:** behaviour is determined by visible inputs.
@@ -128,6 +134,7 @@ Templates per kind — add an event handler, add a schema-bound view, scaffold a
 - [AI-Audit.md](AI-Audit.md) — applies the discipline principles as a grading rubric to each Spec.
 - [Construction-Prompts.md](Construction-Prompts.md) — the "construction prompts" deliverable.
 - [009 §Error contract](009-Instrumentation.md#error-contract) — the structured-errors realisation of "machine-readable errors."
+- [Conventions §No silent swallow](Conventions.md#no-silent-swallow--recognised-input-must-signal) — the normative rule realising "no silent swallow," with the extension-key carve-out and the `:allow-unknown?` escape hatch.
 
 ---
 


### PR DESCRIPTION
Adopts **"no silent swallow / dishonest signal"** as a named repo-level API principle — the #1 cross-cutting theme of the API review (rf2-3nbl5.1, parent epic rf2-3nbl5).

## What landed

**`spec/Principles.md`** — new discipline principle **"No silent swallow"** (anchor `#no-silent-swallow`), slotted directly after *Machine-readable errors* as its honest-signal sibling: machine-readable-errors governs the *shape* of a failure; this governs *that a recognised-but-unhonourable input fails loudly at all*. Names the *why*; cross-links to the normative rule. Discipline-principle count bumped 9 → 10; cross-references updated.

**`spec/Conventions.md`** — the normative MUST rule **"No silent swallow — recognised input MUST signal"** (anchor `#no-silent-swallow--recognised-input-must-signal`), placed right after the `:interceptors`-is-positional section (itself a worked instance). Exact normative wording:

> A user-supplied value that is **recognised as input** but **cannot be honoured** MUST produce a structured warning or error. Silent ignore is allowed **only** for explicitly namespaced extension keys in an extension map.

Includes: the **load-bearing extension-key carve-out** (preserves open-map accretion / Spec-ulation while banning silent-ignore of recognised inputs; the recognition discriminator is spelled out); the **pre-alpha-is-the-window-to-be-strict** rationale with the **`:allow-unknown? true`** forward-compat escape hatch noted as the only sanctioned future relaxation (not shipped pre-1.0); and a **per-surface applications table** citing the seven instance beads as applications (NOT fixed here).

Bidirectional cross-link between principle (why) and rule (MUST); verified resolving in the built HTML.

## Instance beads cited (per-surface applications)

rf2-jbzhj (core unknown-opts) · rf2-nnma3 (reserved-fx lying trace) · rf2-rl5tt (http `:on-failure nil`) · rf2-pffil (ssr payload-policy conflict) · rf2-g72p8 (machines `:on-spawn` drop) · rf2-tkmik (pair-mcp unknown-tool dead-end) · rf2-52dfy (schemas `reg-app-schema` bad-arg).

## Quality gates

- `mkdocs build --strict` — **PASS** (built in ~10s, no warnings/errors; only a pre-existing unrelated INFO on `the-mayor-method` link).
- New anchors + cross-links verified in built HTML: `id="no-silent-swallow"` and `id="no-silent-swallow--recognised-input-must-signal"` both exist; inbound hrefs (`../Principles/#no-silent-swallow`, `../Conventions/#no-silent-swallow--recognised-input-must-signal`) resolve. No broken internal links.
- Instance beads cited: yes (table above).

Scope held to the principle + its entries; no per-surface fixes (those are the cited beads). Surface = `spec/Conventions.md` + `spec/Principles.md` only.