### PR TITLE
docs(xray): rewrite standard_epochs testbed intro — Epoch-panel focus (rf2-jdzz8)

### DIFF
--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -690,11 +690,10 @@
    [:header {:style {:margin-bottom "0.5em"}}
     [:h2 {:style {:margin 0}} "Standard-epochs"]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "One frame, one tall column of test buttons. Each button bumps a shared "
-     [:strong "baseline"] " counter (so App-db / Epoch always show a delta) and "
-     "exercises exactly one more feature. The caption says what to watch in "
-     "Xray on the right — click top to bottom and any one panel is fully "
-     "exercised."]]
+     "Explore how the " [:code "Epoch"] " panel renders different scenarios. "
+     "It is the centerpiece panel, after all."]
+    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
+     "Work your way down the buttons from top to bottom."]]
    ;; Button 0 — Reset.
    [:button {:data-testid "reset-button"
              :on-click #(dispatch [:standard-epochs/reset])


### PR DESCRIPTION
Rewrites the on-screen intro paragraph at the top of the standard_epochs testbed `root` view (the `:p` under the "Standard-epochs" h2). Copy-only; no behaviour change. Closes rf2-jdzz8.

## What changed

The single descriptive paragraph is replaced by two short paragraphs, refocused on the `Epoch` panel:

- P1: "Explore how the `Epoch` panel renders different scenarios. It is the centerpiece panel, after all."
- P2: "Work your way down the buttons from top to bottom."

`Epoch` is rendered as a `[:code "Epoch"]` hiccup span, mirroring the edn_inspector intro treatment (PR #2768). The "Standard-epochs" h2 is untouched. The ns docstring "## Shape" framing was deliberately left alone per the bead (Mike asked only for the on-screen intro).

## Quality gates

Test-free testbed copy edit (copy-only hiccup change, no behaviour change). Ran `clj-kondo --lint tools/xray/testbeds/standard_epochs/core.cljs`: 0 errors, 0 warnings — namespace still reads cleanly. mkdocs N/A (not a doc).