### PR TITLE
fix: event-args :schema validation not firing on standard_epochs button 18 (rf2-lo28u)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -199,6 +199,49 @@
                 ":where :event locates the failure at pre-handler validation")
             (is (= :user/register (-> v :tags :failing-id)))))))))
 
+;; ---- rf2-lo28u — `:cat` + bare-predicate event-args schema --------------
+;;
+;; Regression for the standard_epochs button-18 symptom (rf2-lo28u): an
+;; event declared with `:schema [:cat [:= :id] pos-int?]` dispatched
+;; with a string where a `pos-int?` is required MUST fire
+;; `:rf.error/schema-validation-failure :where :event` and SKIP the
+;; handler. This pins the exact schema SHAPE the testbed uses — a
+;; `:cat` whose tail slot is a bare CLJS predicate function (`pos-int?`,
+;; a registered Malli predicate keyed by its function value) — so a
+;; regression that makes the bare-predicate `:cat` form silently
+;; soft-pass (or throw + be swallowed by the router's catch) is caught
+;; in CLJS, not just at the JVM. The earlier
+;; `live-dispatch-validates-event-payload-under-reagent` test uses a
+;; `[:map ...]` tail; this one uses the bare-predicate tail the
+;; testbed's button 18 carries verbatim.
+
+(deftest cat-with-bare-predicate-event-args-fires-where-event
+  (testing "a `:cat` schema with a bare `pos-int?` tail rejects a bad
+            arg, skips the handler, and emits :where :event"
+    (let [calls (atom 0)]
+      (rf/reg-event-db :rf2-lo28u/bad-event-args
+        {:schema [:cat [:= :rf2-lo28u/bad-event-args] pos-int?]}
+        (fn [db _ev] (swap! calls inc) db))
+      (let [traces (atom [])]
+        (trace-tooling/register-listener! ::lo28u (fn [ev] (swap! traces conj ev)))
+        ;; Well-typed arg (a pos-int) — handler runs.
+        (rf/dispatch-sync [:rf2-lo28u/bad-event-args 7])
+        ;; Bad arg (a string where a pos-int is required) — handler must
+        ;; NOT run; a :where :event violation must fire.
+        (rf/dispatch-sync [:rf2-lo28u/bad-event-args "not-a-number"])
+        (trace-tooling/unregister-listener! ::lo28u)
+        (is (= 1 @calls)
+            "handler ran exactly once — the bad arg was rejected pre-handler")
+        (let [violations (filter #(= :rf.error/schema-validation-failure
+                                     (:operation %))
+                                 @traces)]
+          (is (= 1 (count violations))
+              "exactly one schema-validation-failure trace fired for the bad arg")
+          (let [v (first violations)]
+            (is (= :event (-> v :tags :where))
+                ":where :event locates the failure at pre-handler validation")
+            (is (= :rf2-lo28u/bad-event-args (-> v :tags :failing-id)))))))))
+
 ;; ---- rf2-0z1z — app-schemas-digest under CLJS ----------------------------
 
 (deftest app-schemas-digest-cljs-smoke


### PR DESCRIPTION
## Verdict: NOT a framework bug, NOT a testbed source bug — stale-build artifact; regression test added

Mike observed live (standard_epochs / 8031) that button 18 — `dispatch [:standard-epochs/bad-event-args "not-a-number"]` against `:schema [:cat [:= :standard-epochs/bad-event-args] pos-int?]` — skipped validation: the handler ran (bumped `:baseline`), the epoch `:outcome` was `:ok`, and no `:rf.error/schema-validation-failure :where :event` trace fired. Button 19 (app-db schema via `reg-app-schema`) DID fire, so the Malli validator was live.

### Investigation (FRAMEWORK vs TESTBED)
- **Framework path is correct.** The router calls `validate-event! event-id event handler-meta` (`router.cljc` L1304), `handler-meta` carries `:schema` (`events.cljc` `register-event!` `assoc`s the whole metadata-map into the registrar entry), and `schemas/validate-event!` routes through the same `@validator/validator-fn` that app-db validation uses. A new CLJS test exercising the **exact** testbed schema shape through the live Reagent dispatch path passes: bad arg rejected pre-handler, handler skipped, one `:where :event` violation fired.
- **Testbed source is correct.** Single registration of `:standard-epochs/bad-event-args` with the `:schema` on the metadata-map slot; no `set-schema-validator!` override; correct boot order. The build compiles warning-free, so `pos-int?` IS a valid Malli schema element (Malli's `-register-var` registers core predicates by **function value** as well as symbol, on both JVM and CLJS — confirmed in `malli.core/predicate-schemas`).
- **The schema is valid + correctly rejects the bad value.** `(m/validate [:cat [:= :id] pos-int?] [:id "not-a-number"])` => `false`; `[:id 5]` => `true`.
- **rf2-1i168 did NOT regress it.** The flagged `frame-db`->`app-db-value` rename is a pure public read-accessor rename; it does not touch `validate-event!`, the router cascade, or the schemas validation path, and it gated green (incl. `test:cljs`).

**Conclusion:** the committed framework and testbed source are both correct. The live symptom was a transient stale incremental hot-reload build at the moment the standard_epochs runtime recompiled with rf2-1i168 — not a defect in committed source. No source fix is warranted (pre-alpha; CORRECTNESS confirmed). This PR adds a regression test that pins the behavior so the `:cat`+bare-predicate `:where :event` path can never silently regress.

### Test added
`implementation/schemas/test/re_frame/schemas_cljs_test.cljs` — `cat-with-bare-predicate-event-args-fires-where-event`: registers an event with `:schema [:cat [:= :id] pos-int?]` (the testbed's verbatim shape), dispatches a good arg (handler runs once) and a bad string arg through the live Reagent path, and asserts the handler is skipped and exactly one `:rf.error/schema-validation-failure` with `:where :event` + `:failing-id` fires. Complements the existing `live-dispatch-validates-event-payload-under-reagent` test (which uses a `[:map ...]` tail; this pins the bare-predicate `:cat` tail).

## Quality gates
- `npm run test:cljs` (node-test, includes the new test): **green** — Ran 5187 tests, 17671 assertions, 0 failures, 0 errors.
- schemas per-artefact `clojure -M:test` (JVM): **green** — Ran 224 tests, 18353 assertions, 0 failures, 0 errors.
- clj-kondo on changed file: **green** — 0 errors, 0 warnings.
- testbed build `npx shadow-cljs compile examples/standard-epochs`: **green** — 0 warnings (confirms `pos-int?` is a valid schema in the testbed build).
- mkdocs: N/A (no docs changed).