### PR TITLE
fix(xray): subs value column — show unchanged values + app-db-parity modified chrome (rf2-o77z4)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1667,7 +1667,7 @@ rendering — the full data tree with inline diff annotations against
 | Epoch HANDLER step `:db`               | FULL+DIFF via edn-inspector with `:before` threaded |
 | App-DB panel                           | Section list, each section FULL+DIFF |
 | Machine Inspector snapshot drill-in    | Single edn-inspector mount, FULL+DIFF |
-| Epoch SUBSCRIPTIONS step value cells   | Per-row leaf-scalar (rf2-fyd8u) or container FULL+DIFF; a first-run container routes through `:added?` (§10.0.13) for whole-tree `:added` chrome (rf2-kp7bw) |
+| Epoch SUBSCRIPTIONS step value cells   | Per-row leaf-scalar (rf2-fyd8u) or container FULL+DIFF; a first-run container routes through `:added?` (§10.0.13) for whole-tree `:added` chrome (rf2-kp7bw). Leaf-scalar rows fork three ways on `(changed?, first-run?)` — see §9.1.5.3 |
 
 **R-rule applicability across surfaces**: all R1-R8 rules from
 §9.1.5.1 apply uniformly to every surface. Rules that have no work
@@ -1729,6 +1729,42 @@ Editscript-A* engine at `day8.re-frame2-xray.diff.engine/project`
 and consumes the same `:flat-rows` channel. Same `(before, after)`
 → same `:flat-rows` → same chrome → identical R-rule application
 across every surface.
+
+#### §9.1.5.3 SUBSCRIPTIONS leaf-scalar value cell — three-way fork (rf2-fyd8u + rf2-o77z4)
+
+A leaf-scalar sub return (number / string / keyword / nil — no
+container children for the edn-inspector's R1-R8 grammar to paint on)
+has its change signal surfaced at the SUBSCRIPTIONS **row** level,
+since the inspector's leaf surface carries no per-leaf annotation
+hook. `subs-value-cell` (`panels/epoch/view.cljs`) forks three ways on
+`(changed?, first-run?)`, each mirroring the corresponding app-db
+edn-inspector leaf chrome so a sub leaf reads identically to an app-db
+leaf:
+
+| Row state | Chrome | Glyph | Annotation | Mirrors |
+|---|---|---|---|---|
+| **Unchanged** (`changed? false`) | **Current value, NO diff chrome** (no wash, no stripe) | — | — | app-db `:same` leaf |
+| **First-run** (`changed? true`, `first-run? true`) | `:added` — green stripe (`:diff-added-stripe`) + wash (`:diff-added-wash`) | `+` | none (no prior value) | app-db R1 `:added` leaf |
+| **Changed** (`changed? true`, `first-run? false`) | `:modified` — yellow stripe (`:diff-modified-stripe`) + wash (`:diff-modified-wash`) | `~` | `← was <prev>` (prev via `ei/mini`) | app-db R1 `:modified` leaf |
+
+> rf2-o77z4 (Mike pair 2026-06-01) made two corrections. (1) The
+> UNCHANGED row now renders the CURRENT value with no diff chrome —
+> REVERSING the prior 2026-05-27 "empty cell = unchanged indicator"
+> design (rf2-fqcdd follow-up). Row density is governed by the
+> `[all][changed][unchanged]` filter (rf2-tzmmf), so showing values on
+> unchanged rows is no longer a density cost. (2) The CHANGED leaf,
+> previously rendered as a bare inline-flex (no wash / no stripe / no
+> glyph), now mirrors app-db's `:modified` leaf chrome — yellow
+> stripe + wash via the reserved `:diff-modified-*` token family + a
+> leading `~` glyph — bringing it to parity with the already-mirrored
+> `:added` (first-run) branch. The glyph paints in `:diff-gutter`,
+> the same reserved gutter tone the inspector uses for added /
+> removed / modified leaves (`op-gutter-colour`).
+
+The CONTAINER (map / vector / set) value-cell branch is unchanged by
+rf2-o77z4: a changed container threads `:before` (full R1-R8 grammar);
+a first-run container threads `:added?` (§10.0.13); an unchanged
+container mounts plain (current value, no diff opts).
 
 ### §9.1.6 Numbered cascade chrome
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -823,15 +823,20 @@
 ;;                       low-alpha wash) — parity with the inspector's
 ;;                       mode-3 R1 `:added` shape (per `edn-inspector`
 ;;                       `:added` op).
-;;   :first-run? false → value + inline `← was <prev>` annotation (prev
-;;                       routes through `ei/mini` for syntax-token
-;;                       chrome; prose stays muted text-tertiary).
+;;   :first-run? false → `:modified` chrome (yellow stripe + `~` glyph +
+;;                       low-alpha wash) + inline `← was <prev>`
+;;                       annotation — parity with the inspector's R1
+;;                       `:modified` leaf shape (`gutter-row :modified`).
+;;                       The prev value routes through `ei/mini` for
+;;                       syntax-token chrome; prose stays muted
+;;                       text-tertiary (rf2-o77z4).
 
 (def ^:private subs-leaf-row-style
-  "Outer wrapper for the leaf-scalar FULL+DIFF branch. `inline-flex`
-  (parity with `gutter-row`'s inline-flex shape per rf2-1bra5) so the
-  value composes inline with the optional `← was X` annotation without
-  forcing a block-level row break inside the table cell."
+  "Outer wrapper for an UNCHANGED-row leaf-scalar value (the all/changed
+  filter shows the current value with NO diff chrome — rf2-o77z4). Bare
+  `inline-flex` (parity with `gutter-row`'s inline-flex shape per
+  rf2-1bra5) so the value composes inline without forcing a block-level
+  row break inside the table cell."
   {:display       "inline-flex"
    :align-items   "baseline"
    :flex-wrap     "wrap"
@@ -874,6 +879,35 @@
   "Leading `+` glyph for the `:first-run?` `:added` chrome. Bold green
   (`:diff-gutter`), parity with the inspector's `gutter-row` glyph cell
   shape."
+  {:flex        "0 0 12px"
+   :color       (:diff-gutter tokens)
+   :font-size   "11px"
+   :font-weight 700
+   :text-align  "center"
+   :user-select "none"})
+
+(def ^:private subs-leaf-modified-row-style
+  "Outer style for the `:first-run?` `false` `:modified` chrome — yellow
+  left-edge stripe + low-alpha wash + leading `~` glyph (rf2-o77z4).
+  Mirrors `subs-leaf-added-row-style` but swaps the diff token family to
+  `:diff-modified-stripe` / `:diff-modified-wash` so a changed leaf-
+  scalar reads visually identical to the inspector's R1 `:modified` leaf
+  shape (`gutter-row :modified`). The `← was <prev>` annotation composes
+  inline as a child via `subs-leaf-was-style`."
+  {:display       "inline-flex"
+   :align-items   "baseline"
+   :flex-wrap     "wrap"
+   :gap           "4px"
+   :padding-left  "6px"
+   :border-left   (str "2px solid " (:diff-modified-stripe tokens))
+   :background    (:diff-modified-wash tokens)
+   :max-width     "100%"})
+
+(def ^:private subs-leaf-modified-glyph-style
+  "Leading `~` glyph for the `:modified` chrome. Bold `:diff-gutter`
+  (the inspector paints `:added` / `:removed` / `:modified` gutter
+  glyphs in the same reserved tone — see `op-gutter-colour`), parity
+  with `subs-leaf-added-glyph-style`."
   {:flex        "0 0 12px"
    :color       (:diff-gutter tokens)
    :font-size   "11px"
@@ -3418,7 +3452,10 @@
                           inspector's R1 `:added` shape). NO `← was`
                           annotation (no prior value existed — the row
                           tells a 'this sub is now alive' story).
-    `:first-run?` false → value + inline `← was <prev>` annotation.
+    `:first-run?` false → `:modified` chrome (yellow stripe / leading
+                          `~` glyph / low-alpha wash, parity with the
+                          inspector's R1 `:modified` leaf shape) + value
+                          + inline `← was <prev>` annotation (rf2-o77z4).
                           The prose stays muted (text-tertiary); the
                           prev value routes through `ei/mini` for the
                           syntax-token chrome (keyword magenta, number
@@ -3428,58 +3465,70 @@
   mount: the inspector paints child-level annotations via the R1-R8
   grammar — no per-row chrome change.
 
-  Unchanged rows (`:changed? false`) render an empty cell — the
-  value column is reserved for diff signal; absence of a row entry
-  in this column is itself the unchanged indicator. Per Mike
-  pair-debug 2026-05-27 (rf2-fqcdd follow-up) the leading ✓/✗
-  ticks were dropped — redundant once the cell is value-only."
+  Unchanged rows (`:changed? false`) now render the CURRENT value with
+  NO diff chrome (rf2-o77z4, Mike pair 2026-06-01 — REVERSES the prior
+  2026-05-27 rf2-fqcdd 'empty cell = unchanged indicator' design). Row
+  density is controlled by the all/changed/unchanged filter, so showing
+  the value on unchanged rows is fine. Leaf-scalar → `ei/mini`;
+  container → a plain `ei/edn-inspector` mount (no `:before`, no
+  `:added?` — no diff signal)."
   [{:keys [sub-id changed? first-run? before after]} idx]
-  (when changed?
-    ;; rf2-fyd8u — leaf-scalar branch: paint the change signal at this
-    ;; row level (the inspector has no leaf-scalar annotation surface).
-    ;; Containers fall through to the inspector mount. Testid naming
-    ;; note: the leaf-* testids deliberately use a prefix DISTINCT from
-    ;; `rf-xray-epoch-sub-row-` (the parent row's testid) so prefix
-    ;; counters like the sibling rf2-tzmmf filter tests don't pick the
-    ;; leaf wrapper up as an additional "row".
-    (if (subs-leaf-scalar? after)
-      (if first-run?
-        ;; first-cache-entry → :added chrome, no "was" annotation.
-        [:div {:data-rf-xray-subs-leaf  "added"
-               :data-rf-diff-op         "added"
-               :data-testid             (str "rf-xray-epoch-subs-leaf-added-" idx)
-               :style                   subs-leaf-added-row-style}
-         [:span {:style subs-leaf-added-glyph-style} "+"]
-         [:span [ei/mini after 40]]]
-        ;; value change → value + inline ← was <prev>.
-        [:div {:data-rf-xray-subs-leaf  "changed"
-               :data-rf-diff-op         "modified"
-               :data-testid             (str "rf-xray-epoch-subs-leaf-changed-" idx)
-               :style                   subs-leaf-row-style}
-         [:span [ei/mini after 40]]
-         [:span {:data-rf-diff-annotation "subs-was"
-                 :style                   subs-leaf-was-style}
-          "← was "
-          [:span {:data-rf-xray-subs-leaf-was "1"}
-           [ei/mini before 40]]]])
-      ;; rf2-kp7bw — a CONTAINER-valued sub return. On a first run
-      ;; (`first-run?`, no prior cache entry) the inspector renders the
-      ;; whole subtree as `:added` via the `:added?` opt (edn-inspector
-      ;; §10.0.13) — parity with the scalar branch's row-level `:added`
-      ;; chrome above. Pre-fix the container branch consulted ONLY
-      ;; `:before`, which is nil on a first run, so the inspector
-      ;; mounted plain (no diff mode, no added signal) while every
-      ;; scalar sibling painted `:added`. Canonical case: the
-      ;; `[:rf/route]` map sub on a /counter view-mount epoch. An
-      ;; explicit prior value (`some? before`) is a genuine diff and
-      ;; takes precedence over the first-run signal.
-      [:div {:style subs-value-cell-fill-style}
-       [ei/edn-inspector after
-        (cond-> {:panel-id :rf.xray.epoch/subs-value
-                 :site-id  [:rf.xray.epoch/subs-value sub-id idx :full+diff]
-                 :default-expanded-depth 3}
-          (some? before)                 (assoc :before before)
-          (and first-run? (nil? before)) (assoc :added? true))]])))
+  ;; rf2-fyd8u — leaf-scalar branch: paint the change signal at this
+  ;; row level (the inspector has no leaf-scalar annotation surface).
+  ;; Containers fall through to the inspector mount. Testid naming
+  ;; note: the leaf-* testids deliberately use a prefix DISTINCT from
+  ;; `rf-xray-epoch-sub-row-` (the parent row's testid) so prefix
+  ;; counters like the sibling rf2-tzmmf filter tests don't pick the
+  ;; leaf wrapper up as an additional "row".
+  (if (subs-leaf-scalar? after)
+    (cond
+      ;; unchanged → current value, no diff chrome (rf2-o77z4).
+      (not changed?)
+      [:div {:data-rf-xray-subs-leaf "unchanged"
+             :data-testid            (str "rf-xray-epoch-subs-leaf-unchanged-" idx)
+             :style                  subs-leaf-row-style}
+       [:span [ei/mini after 40]]]
+      ;; first-cache-entry → :added chrome, no "was" annotation.
+      first-run?
+      [:div {:data-rf-xray-subs-leaf  "added"
+             :data-rf-diff-op         "added"
+             :data-testid             (str "rf-xray-epoch-subs-leaf-added-" idx)
+             :style                   subs-leaf-added-row-style}
+       [:span {:style subs-leaf-added-glyph-style} "+"]
+       [:span [ei/mini after 40]]]
+      ;; value change → :modified chrome + value + inline ← was <prev>.
+      :else
+      [:div {:data-rf-xray-subs-leaf  "changed"
+             :data-rf-diff-op         "modified"
+             :data-testid             (str "rf-xray-epoch-subs-leaf-changed-" idx)
+             :style                   subs-leaf-modified-row-style}
+       [:span {:style subs-leaf-modified-glyph-style} "~"]
+       [:span [ei/mini after 40]]
+       [:span {:data-rf-diff-annotation "subs-was"
+               :style                   subs-leaf-was-style}
+        "← was "
+        [:span {:data-rf-xray-subs-leaf-was "1"}
+         [ei/mini before 40]]]])
+    ;; rf2-kp7bw — a CONTAINER-valued sub return. On a first run
+    ;; (`first-run?`, no prior cache entry) the inspector renders the
+    ;; whole subtree as `:added` via the `:added?` opt (edn-inspector
+    ;; §10.0.13) — parity with the scalar branch's row-level `:added`
+    ;; chrome above. Pre-fix the container branch consulted ONLY
+    ;; `:before`, which is nil on a first run, so the inspector
+    ;; mounted plain (no diff mode, no added signal) while every
+    ;; scalar sibling painted `:added`. Canonical case: the
+    ;; `[:rf/route]` map sub on a /counter view-mount epoch. An
+    ;; explicit prior value (`some? before`) is a genuine diff and
+    ;; takes precedence over the first-run signal. An UNCHANGED
+    ;; container (`changed? false`) mounts plain — current value, no
+    ;; diff opts (rf2-o77z4).
+    [:div {:style subs-value-cell-fill-style}
+     [ei/edn-inspector after
+      (cond-> {:panel-id :rf.xray.epoch/subs-value
+               :site-id  [:rf.xray.epoch/subs-value sub-id idx :full+diff]
+               :default-expanded-depth 3}
+        (and changed? (some? before))           (assoc :before before)
+        (and changed? first-run? (nil? before)) (assoc :added? true))]]))
 
 (defn- sub-coord
   "Pull the registered sub's source coord off

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1778,7 +1778,19 @@
               "row mounts the leaf-changed wrapper (not the container path)")
           (is (some? (th/find-by-attr tree :data-rf-diff-annotation "subs-was"))
               "row carries the `← was <prev>` annotation chip")
+          ;; rf2-o77z4 — the changed leaf now mirrors app-db's :modified
+          ;; leaf chrome: yellow stripe + wash (via the reserved
+          ;; `:diff-modified-*` token family) + leading `~` glyph.
+          (let [style (-> leaf second :style)]
+            (is (= (:diff-modified-wash tokens/tokens) (:background style))
+                "changed leaf wash reads through the diff-modified-wash token")
+            (is (string/includes? (str (:border-left style))
+                                  (:diff-modified-stripe tokens/tokens))
+                "changed leaf stripe reads through the diff-modified-stripe token"))
           (let [txt (th/text-content leaf)]
+            (is (string/includes? txt "~")
+                "leading `~` glyph paints (parity with the inspector's
+                 R1 `:modified` leaf shape)")
             (is (string/includes? txt "← was")
                 "annotation prose includes `← was`")
             (is (string/includes? txt "1")
@@ -1816,6 +1828,48 @@
             (is (string/includes? txt "1779972561856"))
             (is (string/includes? txt "nil")
                 "prev nil renders as `nil` syntax token in the annotation")))))))
+
+(deftest subscriptions-full-diff-leaf-scalar-unchanged-renders-current-value-test
+  (testing "rf2-o77z4 (Mike pair 2026-06-01) — REVERSES the prior
+            2026-05-27 'empty cell = unchanged indicator' design. An
+            UNCHANGED leaf-scalar row (`:changed? false`) now renders the
+            CURRENT value with NO diff chrome — no `← was` annotation, no
+            stripe / wash, no glyph. Density is handled by the
+            all/changed/unchanged filter, so showing the value here is
+            fine. The wrapper carries `:data-rf-xray-subs-leaf
+            \"unchanged\"` and is NOT the changed / added wrapper."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      ;; render in `:all` mode so the unchanged row is in the tree.
+      (rf/dispatch-sync [:rf.xray.epoch/set-subs-filter-mode :all])
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id :counter/value :sub-vec [:counter/value]
+                          :inputs nil :changed? false :first-run? false
+                          :before 7 :after 7}]
+                  :changed 0 :unchanged 1}
+            tree (view/render-subscriptions-step step)
+            leaf (th/find-by-testid tree "rf-xray-epoch-subs-leaf-unchanged-0")]
+        (is (some? leaf)
+            "unchanged leaf mounts the leaf-unchanged wrapper")
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0"))
+            "the changed wrapper is NOT mounted for an unchanged row")
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-subs-leaf-added-0"))
+            "the added wrapper is NOT mounted for an unchanged row")
+        (is (nil? (th/find-by-attr tree :data-rf-diff-annotation "subs-was"))
+            "unchanged row carries NO `← was <prev>` annotation")
+        (let [style (-> leaf second :style)]
+          (is (nil? (:background style))
+              "unchanged leaf paints no wash (no diff chrome)")
+          (is (nil? (:border-left style))
+              "unchanged leaf paints no stripe (no diff chrome)"))
+        (let [txt (th/text-content leaf)]
+          (is (string/includes? txt "7")
+              "the current value renders")
+          (is (not (string/includes? txt "~"))
+              "no `~` modified glyph on an unchanged row")
+          (is (not (string/includes? txt "← was"))
+              "no `← was` annotation on an unchanged row"))))))
 
 (deftest subscriptions-full-diff-leaf-scalar-first-run-renders-added-chrome-test
   (testing "rf2-fyd8u — under the single FULL+DIFF rendering, a


### PR DESCRIPTION
Closes rf2-o77z4.

Two fixes in `subs-value-cell` (`tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs`).

## Change 1 — unchanged rows show the current value
UNCHANGED leaf rows previously rendered an EMPTY value cell (the `(when changed? …)` guard — the deliberate 2026-05-27 'empty cell = unchanged indicator', rf2-fqcdd). Per Mike pair 2026-06-01 this is REVERSED: unchanged rows now render the CURRENT value with no diff chrome. Leaf-scalar → `ei/mini`; container → a plain `ei/edn-inspector` mount (no `:before`, no `:added?`). Row density is already governed by the `[all][changed][unchanged]` filter (rf2-tzmmf), so showing values on unchanged rows is fine.

## Change 2 — changed leaf-scalars get app-db-parity :modified chrome
CHANGED leaf-scalar rows (`first-run? false`) rendered via the bare inline-flex `subs-leaf-row-style` (no wash, no stripe, no glyph). The `:added` (first-run) branch already mirrors app-db; `:modified` was left bare. Added `subs-leaf-modified-row-style` + `subs-leaf-modified-glyph-style` so a changed leaf now matches app-db's `:modified` leaf: yellow stripe + wash + leading `~` glyph + the existing `← was` chip. The bare `subs-leaf-row-style` is repurposed for the unchanged-value branch.

## Diff tokens reused (not hardcoded)
Mirrors the edn-inspector's reserved token family from `theme/tokens.cljc`, exactly as the `:added` branch reuses `:diff-added-*`:
- `:diff-modified-stripe` (yellow solid) → `:border-left`
- `:diff-modified-wash` (yellow @ ~12%) → `:background`
- `:diff-gutter` → the `~` glyph colour (same gutter tone the inspector uses for added/removed/modified leaves via `op-gutter-colour`)

## Spec / test updates
- Spec (xray-specs-kept-current): new **§9.1.5.3** in `tools/xray/spec/021-Dynamic-Panel-Designs.md` documents the leaf-scalar value-cell three-way fork on `(changed?, first-run?)` (unchanged → current value/no chrome; first-run → `:added`; changed → `:modified`), plus a cross-link from the §9.1.5.2 surfaces table. The old 'empty cell' contract lived only in the source docstring (not the spec); it is replaced.
- Tests: new `subscriptions-full-diff-leaf-scalar-unchanged-renders-current-value-test` (value rendered, no `← was`, no wash/stripe, no `~`). The existing changed-leaf test now also asserts the `~` glyph + that the wash/stripe read through the `:diff-modified-*` tokens. No test asserted the old empty-cell behavior, so none was removed.

## Quality gates
- `npm run test:cljs` — PASS (5187 tests / 17679 assertions, 0 failures, 0 errors)
- `npm run test:xray-feature-gate` — PASS (16 scenarios, 0 failures; first run flaked on the unrelated routes-epochs routing-ladder navigation deck, clean on re-run — my diff does not touch routing)
- `npm run test:bundle-isolation` — PASS (xray absent from prod bundles; 35 sentinels absent; uix/helix reagent-free)
- clj-kondo on changed files — 0 errors; 14 pre-existing unused-var warnings unrelated to this change (both new style vars are referenced)