### PR TITLE
feat(governance): CLJS-side manifest enumeration probe for adapter/Xray/pair-MCP surfaces (rf2-2mtte)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -129,7 +129,7 @@
   per Spec 009 §Production builds."
   (:wrap-view spine-fns))
 
-(def clear-warned-non-dom-roots!
+(def ^:no-doc clear-warned-non-dom-roots!
   "Reset the warn-once cache for non-DOM-root warnings. Tests use this
   between cases (via `make-reset-runtime-fixture` and the chained
   `:adapter/clear-warn-once-caches!` hook) so a sibling test's

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -127,7 +127,7 @@
   Spec 009 §Production builds."
   (:wrap-view spine-fns))
 
-(def clear-warned-non-dom-roots!
+(def ^:no-doc clear-warned-non-dom-roots!
   "Reset the warn-once cache for non-DOM-root warnings. Tests use this
   between cases (via `make-reset-runtime-fixture` and the chained
   `:adapter/clear-warn-once-caches!` hook) so a sibling test's

--- a/implementation/scripts/api-manifest/deps.edn
+++ b/implementation/scripts/api-manifest/deps.edn
@@ -13,7 +13,10 @@
 ;; CLJS-only public surfaces (the Reagent / UIx / Helix adapter
 ;; namespaces, the Xray `mount-*!` family, the pair-MCP server) cannot
 ;; be `require`d on the JVM — their rows are carried in the curated
-;; sidecar marked `:runtime-verified? false` and passed through verbatim.
+;; sidecar and passed through verbatim. The CLJS-side enumeration probe
+;; (rf2-2mtte, ../api-manifest/probe/, run by `npm run test:cljs`)
+;; runtime-verifies the covered namespaces; each row carries its own
+;; `:runtime-verified?` flag (true once the probe covers it).
 ;;
 ;; Run from this directory:
 ;;   clojure -M -m re-frame.api-manifest.gen          ; regenerate

--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
@@ -1,0 +1,126 @@
+(ns re-frame.api-manifest.cljs-probe
+  "Reconciliation between the live ClojureScript public surface and the
+  curated `:cljs-only` rows of `spec/api-manifest-metadata.edn`
+  (rf2-2mtte). Pure data — no I/O, no analyzer, no React — so the same
+  logic runs under any shadow-cljs build (the consolidated `:node-test`
+  build for the adapter / Xray surfaces; a tool artefact's own
+  `:server-test` build for the pair-MCP surface) and can be unit-tested
+  on the JVM.
+
+  ## The contract (mirrors the JVM drift-check)
+
+  The JVM generator's drift-check goes RED when a public var is added,
+  removed, or renamed in a JVM-loadable namespace. This is the CLJS-side
+  equivalent for the namespaces that cannot be `require`d on the JVM.
+  Two directions, exactly as the JVM `build-manifest` does
+  (`missing` / `stale`):
+
+    1. STALE ROW (removed / renamed → RED). Every `:cljs-only` row whose
+       namespace the probe covers MUST resolve to a live public var of
+       that namespace. A var renamed or removed in an adapter / Xray
+       surface leaves a row with no live var → RED (the analogue of the
+       generator's stale-sidecar-entries check).
+
+    2. MISSING ROW (added → RED). For namespaces the probe marks
+       `:fully-rowed` (the adapter namespaces, whose entire public
+       surface is the documented adapter API per spec/API.md §UIx/Helix
+       adapter), every live public var MUST have a `:cljs-only` row. A
+       var ADDED to an adapter without a row → RED (the analogue of the
+       generator's missing-classification check).
+
+  ## Why `:kind` is NOT reconciled
+
+  The manifest's `:kind` axis (`:macro` / `:fn` / `:var`) is, on the JVM
+  side, derived at RUNTIME from `(fn? @v)`. The CLJS analyzer runs at
+  COMPILE time and cannot know a `def`'s value is a fn: the adapter
+  surfaces bind their hooks/seams as fn-VALUED `def`s
+  (`(def use-subscribe (:use-subscribe spine-fns))`), which the analyzer
+  reports as `:var` (no `:arglists`) even though they are callable. The
+  curated `:kind :fn` on those rows is the correct human assertion; the
+  analyzer simply cannot reproduce it. Reconciling `:kind` here would
+  fail on an analyzer limitation, not a real drift — so the probe checks
+  EXISTENCE (the contract the bead asks for: added / removed / renamed),
+  not `:kind`. The JVM-loadable kind derivation stays authoritative on
+  the JVM side; for CLJS-only value-defs the sidecar's curated `:kind`
+  stands.
+
+  ## Why the adapters are `:fully-rowed` but the Xray mount surface is not
+
+  spec/API.md tiers the Xray `mount-*!` family `internal-public` and
+  declares the panel-helper functions beneath them \"otherwise
+  unrowed-internal\" (§Tiering of cross-tool surfaces). So the Xray mount
+  surface is a CURATED subset by design — only the rowed reads
+  (`mounted?`) are manifest rows; the open/close/teardown host-embed
+  machinery is intentionally unrowed. The probe therefore verifies
+  direction 1 (the curated rows still resolve) for the Xray surface but
+  not direction 2 (full completeness), matching the spec's intent. The
+  three adapter namespaces ARE their full documented public API, so they
+  earn the stricter bidirectional check."
+  (:require [clojure.string :as str]))
+
+(defn reconcile
+  "Reconcile the live CLJS public surface against the curated `:cljs-only`
+   sidecar rows.
+
+   Args:
+   - `live`  — `{ns-string [[var-string kind-kw] ...]}`, the live publics
+               (minus `^:no-doc`) of every namespace the probe covers,
+               as produced by `cljs-publics/emit-ns-publics`.
+   - `rows`  — the `:cljs-only` rows from the sidecar (each a full
+               manifest row map with `:namespace` / `:var` / `:kind`).
+   - `fully-rowed` — set of namespace strings whose ENTIRE public surface
+               must be rowed (direction 2). Namespaces in `live` but NOT
+               here are checked direction-1 only (curated subsets).
+
+   Returns `{:stale [...] :missing [...]}` — each a sorted vector of
+   human-readable problem maps. Empty everywhere ⇒ in sync (green)."
+  [live rows fully-rowed]
+  (let [covered      (set (keys live))
+        ;; Only reconcile rows for namespaces the probe actually loaded
+        ;; — a `:cljs-only` row for a namespace not in `live` (e.g. the
+        ;; `re-frame.core` `frame-provider` reader-conditional row, which
+        ;; the JVM side owns) is out of this probe's scope.
+        covered-rows (filter #(contains? covered (:namespace %)) rows)
+        rows-by-ns   (group-by :namespace covered-rows)
+        live-vars    (into {} (map (fn [[ns pairs]]
+                                     [ns (set (map first pairs))]))
+                           live)
+        stale        (for [{:keys [namespace var]} covered-rows
+                           :when (not (contains? (get live-vars namespace) var))]
+                       {:namespace namespace :var var})
+        missing      (for [ns-str fully-rowed
+                           :when  (contains? covered ns-str)
+                           :let   [rowed (set (map :var (get rows-by-ns ns-str)))]
+                           [v k]  (get live ns-str)
+                           :when  (not (contains? rowed v))]
+                       {:namespace ns-str :var v :live-kind k})]
+    {:stale   (vec (sort-by (juxt :namespace :var) stale))
+     :missing (vec (sort-by (juxt :namespace :var) missing))}))
+
+(defn in-sync?
+  "True when a `reconcile` result has no problems in any bucket."
+  [result]
+  (every? empty? (vals result)))
+
+(defn report
+  "Render a `reconcile` result to an actionable multi-line string —
+   the message the probe's failing assertion prints. Mirrors the tone of
+   the JVM generator's drift report."
+  [{:keys [stale missing]}]
+  (str/join
+   "\n"
+   (concat
+    ["CLJS manifest probe DRIFT: the live ClojureScript public surface no"
+     "longer matches the :cljs-only rows in spec/api-manifest-metadata.edn."
+     "Reconcile the sidecar (+ regenerate spec/api-manifest.edn via"
+     "clojure -M -m re-frame.api-manifest.gen) until this is green."]
+    (when (seq stale)
+      (cons "  Rows with NO live public var (removed / renamed in source):"
+            (map (fn [{:keys [namespace var]}]
+                   (str "    - " namespace "/" var))
+                 stale)))
+    (when (seq missing)
+      (cons "  Live public vars with NO sidecar row (added to a fully-rowed ns):"
+            (map (fn [{:keys [namespace var live-kind]}]
+                   (str "    + " namespace "/" var " (" live-kind ")"))
+                 missing))))))

--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
@@ -1,0 +1,121 @@
+(ns re-frame.api-manifest.cljs-publics
+  "Compile-time enumeration of a ClojureScript namespace's public vars
+  (rf2-2mtte — the CLJS-side companion to the JVM manifest generator).
+
+  THE PROBLEM. The JVM manifest generator (`re-frame.api-manifest.gen`)
+  introspects every JVM-loadable public namespace with `clojure.core/
+  ns-publics`. The Reagent / UIx / Helix adapter namespaces and the Xray
+  `mount` host-embed surface are ClojureScript-ONLY — they cannot be
+  `require`d on the JVM, so the generator carries their rows verbatim in
+  `spec/api-manifest-metadata.edn` under `:cljs-only` with
+  `:runtime-verified? false`. The existence half of the drift-guard does
+  not reach them.
+
+  THE MECHANISM. CLJS has no *runtime* `ns-publics` (vars are erased to
+  plain JS at `:advanced`). The portable, deterministic, headless way to
+  enumerate a CLJS namespace's public vars is at COMPILE time, off the
+  analyzer's compilation environment: `cljs.analyzer.api/ns-publics`
+  returns the analysed var maps for a namespace, already minus the
+  `:private` ones. We read that env from a CLJC/CLJS-targeting macro and
+  emit a literal vector of `[var-name kind]` pairs into the calling
+  ClojureScript — so the *value* the probe reconciles is fixed at the
+  same compile the adapter/Xray sources are analysed in. No runtime
+  reflection, no React/DOM load needed to read the surface, byte-stable
+  output (the pairs are sorted).
+
+  WHY THIS IS SOUND. A `(emit-ns-publics 'the.ns)` call only resolves to
+  a real surface when `the.ns` has been analysed, which the probe
+  guarantees by `:require`-ing each target namespace before the macro
+  expands (shadow-cljs analyses a dependency before the namespace that
+  requires it). The kind derivation mirrors the JVM generator's
+  `kind-of` exactly (`:macro` / `:fn` / `:var`) so the two sides agree on
+  the third manifest axis the existence-check compares.
+
+  The `^:no-doc` carve-out mirrors `gen.clj`'s `public-vars-of`: a
+  var flagged `^:no-doc` in its source is a documented internal that the
+  manifest deliberately does not row, so the enumeration drops it too."
+  (:require [cljs.analyzer.api :as ana-api]
+            [cljs.env :as env]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(defn- kind-of
+  "Derive the manifest `:kind` for a CLJS analyzer var-info map. Mirrors
+   the JVM generator's `re-frame.api-manifest.gen/kind-of`:
+   `:macro` — a defmacro; `:fn` — a fn (the analyzer flags `:fn-var` or
+   carries `:arglists`); `:var` — a plain value (an adapter map, a
+   canonical-vocabulary set, …)."
+  [info]
+  (let [m (:meta info)]
+    (cond
+      (or (:macro info) (:macro m))                    :macro
+      (or (:fn-var info) (:arglists info) (:arglists m)) :fn
+      :else                                            :var)))
+
+(defn ns-public-pairs
+  "Return a sorted vector of `[var-name-string kind-keyword]` for every
+   public var of `ns-sym` in the analyzer compilation env `state`, minus
+   the `^:no-doc` carve-outs. The driver behind the `emit-ns-publics`
+   macro; exposed as a plain fn so it can be unit-tested off a synthetic
+   compiler-state atom."
+  [state ns-sym]
+  (->> (ana-api/ns-publics state ns-sym)
+       (remove (fn [[_ info]] (:no-doc (:meta info))))
+       (map (fn [[sym info]] [(name sym) (kind-of info)]))
+       (sort-by first)
+       vec))
+
+;; ---------------------------------------------------------------------------
+;; Locating + reading the curated sidecar at compile time.
+;;
+;; The probe reconciles the live CLJS publics against the `:cljs-only`
+;; rows in `spec/api-manifest-metadata.edn`. CLJS has no compile-time
+;; filesystem, so we slurp the sidecar from the JVM side of the macro and
+;; emit the relevant rows as a literal into the ClojureScript. The repo
+;; root is found by walking up from the build's working directory until
+;; the sidecar resolves — robust whether shadow runs from `implementation/`
+;; (the consolidated `:node-test` build) or from a tool artefact dir.
+;; ---------------------------------------------------------------------------
+
+(defn- find-sidecar
+  "Walk up from the build's `user.dir` looking for
+   `spec/api-manifest-metadata.edn`. Throws an actionable error when the
+   sidecar cannot be located (a misconfigured build classpath)."
+  []
+  (loop [dir (io/file (System/getProperty "user.dir"))]
+    (when (nil? dir)
+      (throw (ex-info (str "api-manifest CLJS probe: could not locate "
+                           "spec/api-manifest-metadata.edn walking up from "
+                           (System/getProperty "user.dir"))
+                      {})))
+    (let [candidate (io/file dir "spec" "api-manifest-metadata.edn")]
+      (if (.exists candidate)
+        candidate
+        (recur (.getParentFile dir))))))
+
+(defmacro emit-cljs-only-rows
+  "Expand to a literal vector of the sidecar's `:cljs-only` manifest rows
+   (read from `spec/api-manifest-metadata.edn` at macro-expansion time).
+   These are the curated rows the probe reconciles against the live CLJS
+   public surface — so the value the probe checks is pinned to the same
+   committed sidecar the JVM generator joins against, with no runtime
+   filesystem dependency."
+  []
+  (-> (find-sidecar) slurp edn/read-string :cljs-only vec))
+
+(defmacro emit-ns-publics
+  "Expand to a literal vector of `[var-name kind]` pairs for the public
+   vars of `ns-sym` (a quoted symbol), read from the CLJS analyzer's
+   compilation environment at macro-expansion time. The target namespace
+   must already be analysed — `:require` it from the calling namespace
+   before invoking this macro.
+
+   The emitted form is a vector of `[\"var\" :kind]` literals; this is
+   the live CLJS public surface the probe reconciles against the
+   `:cljs-only` rows of `spec/api-manifest-metadata.edn`."
+  [ns-sym]
+  (let [sym   (if (and (seq? ns-sym) (= 'quote (first ns-sym)))
+                (second ns-sym)
+                ns-sym)
+        pairs (ns-public-pairs env/*compiler* sym)]
+    `[~@(map (fn [[v k]] [v k]) pairs)]))

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -1,0 +1,101 @@
+(ns re-frame.api-manifest.cljs-manifest-probe-cljs-test
+  "CLJS-side public-var enumeration probe for the API manifest (rf2-2mtte;
+  follow-on to the rf2-3nbl5.2 keystone).
+
+  The JVM manifest generator (`re-frame.api-manifest.gen`) runtime-verifies
+  every JVM-loadable public namespace via `ns-publics`. The Reagent / UIx /
+  Helix adapter namespaces and the Xray `mount` host-embed surface are
+  ClojureScript-ONLY — they cannot be `require`d on the JVM — so their rows
+  live in `spec/api-manifest-metadata.edn` under `:cljs-only`. This probe is
+  their runtime verifier: it enumerates each namespace's LIVE public vars at
+  compile time (via the analyzer, `cljs-publics/emit-ns-publics`) and
+  reconciles them against the curated rows. A var added / removed / renamed
+  in any covered surface turns this test RED — exactly the way the JVM
+  drift-check fails for the JVM-loadable surfaces.
+
+  ## Coverage
+
+  - `re-frame.adapter.reagent` / `.uix` / `.helix` — fully-rowed: their
+    entire public surface IS the documented adapter API (spec/API.md
+    §UIx/Helix adapter), so BOTH directions are checked (a var added
+    without a row, or a row with no live var, → RED).
+  - `day8.re-frame2-xray.mount` — curated subset: spec/API.md tiers the
+    mount surface `internal-public` with the host-embed machinery
+    \"otherwise unrowed-internal\", so only the rowed reads are verified to
+    still resolve (direction 1); the surface is not held to full
+    completeness.
+
+  The pair-MCP server (`re-frame2-pair-mcp.server`) is the third
+  CLJS-only surface the keystone names. It compiles under the pair-MCP
+  artefact's OWN shadow-cljs build (`tools/re-frame2-pair-mcp`,
+  `:server-test`) — it is not on the consolidated `:node-test`
+  classpath and pulls the npm MCP SDK — so its probe rides that build;
+  the shared `cljs-publics` + `cljs-probe` namespaces are the reusable
+  mechanism for it (see rf2-2mtte PR notes)."
+  (:require-macros [re-frame.api-manifest.cljs-publics
+                    :refer [emit-ns-publics emit-cljs-only-rows]])
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.api-manifest.cljs-probe :as probe]
+            ;; The covered CLJS-only namespaces. The `:require` forces the
+            ;; analyzer to analyse each before `emit-ns-publics` expands,
+            ;; so the macro reads a real surface. The aliases are unused at
+            ;; runtime (the surface is read at compile time) but the
+            ;; requires are load-bearing.
+            [re-frame.adapter.reagent]
+            [re-frame.adapter.uix]
+            [re-frame.adapter.helix]
+            [day8.re-frame2-xray.mount]))
+
+;; ---------------------------------------------------------------------------
+;; The live CLJS public surface, captured at compile time.
+;; ---------------------------------------------------------------------------
+
+(def live-publics
+  "`{ns-string [[var-string kind-kw] ...]}` for every covered CLJS-only
+   namespace, enumerated off the analyzer at compile time."
+  {"re-frame.adapter.reagent"  (emit-ns-publics re-frame.adapter.reagent)
+   "re-frame.adapter.uix"      (emit-ns-publics re-frame.adapter.uix)
+   "re-frame.adapter.helix"    (emit-ns-publics re-frame.adapter.helix)
+   "day8.re-frame2-xray.mount" (emit-ns-publics day8.re-frame2-xray.mount)})
+
+(def fully-rowed
+  "Namespaces whose ENTIRE public surface must be rowed (direction 2).
+   The three adapter namespaces — their public surface IS the documented
+   adapter API. The Xray mount surface is a curated subset (direction 1
+   only), so it is deliberately absent here."
+  #{"re-frame.adapter.reagent"
+    "re-frame.adapter.uix"
+    "re-frame.adapter.helix"})
+
+(def cljs-only-rows
+  "The `:cljs-only` rows from spec/api-manifest-metadata.edn, embedded at
+   compile time (no runtime filesystem)."
+  (emit-cljs-only-rows))
+
+;; ---------------------------------------------------------------------------
+;; The probe.
+;; ---------------------------------------------------------------------------
+
+(deftest cljs-only-surface-in-sync
+  (testing "live CLJS public surface reconciles with the :cljs-only rows"
+    (let [result (probe/reconcile live-publics cljs-only-rows fully-rowed)]
+      (is (probe/in-sync? result)
+          (probe/report result)))))
+
+(deftest every-covered-namespace-was-analysed
+  (testing "each covered namespace enumerates at least one public var"
+    ;; Guards against a silent empty enumeration (e.g. a require dropped,
+    ;; so the macro reads an un-analysed ns and emits []). An empty surface
+    ;; would make the reconciliation vacuously green.
+    (doseq [[ns-str pairs] live-publics]
+      (is (seq pairs)
+          (str ns-str " enumerated no public vars — the namespace was "
+               "probably not analysed (check the :require) or the analyzer "
+               "env was unavailable.")))))
+
+(deftest fully-rowed-namespaces-are-covered
+  (testing "every fully-rowed namespace is actually loaded by the probe"
+    (doseq [ns-str fully-rowed]
+      (is (contains? live-publics ns-str)
+          (str ns-str " is marked :fully-rowed but is not in live-publics "
+               "— add its :require + emit-ns-publics entry.")))))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -40,11 +40,14 @@
   CLJS-ONLY SURFACES. The Reagent / UIx / Helix adapter namespaces, the
   Xray `mount-*!` family, and the pair-MCP server are ClojureScript-only
   and cannot be `require`d on the JVM. Their rows live in the sidecar
-  under `:cljs-only` and are emitted verbatim with
-  `:runtime-verified? false`. They are part of the manifest (so the
-  spec/API.md projection check covers the adapter rows) but the
-  existence half of the drift-guard does not apply to them — a follow-on
-  bead adds a CLJS-side enumeration probe."
+  under `:cljs-only` and are carried through verbatim. The JVM
+  existence-check does not reach them; instead a CLJS-side enumeration
+  probe (rf2-2mtte, implementation/scripts/api-manifest/probe/, run by
+  `npm run test:cljs`) reconciles each covered namespace's live public
+  vars against its rows. A `:cljs-only` row carries its own
+  `:runtime-verified?` flag — `true` once the probe covers its
+  namespace, `false` otherwise — and the generator emits that flag
+  verbatim (it does not itself run the probe)."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.set :as set]
@@ -233,7 +236,15 @@
            :owner             (:owner r)
            :status            (:status r)
            :facade?           (boolean (:facade? r))
-           :runtime-verified? false})
+           ;; Per-row flag (rf2-2mtte): a `:cljs-only` row is
+           ;; `:runtime-verified? true` once the CLJS-side enumeration
+           ;; probe (implementation/scripts/api-manifest/probe/, run by
+           ;; `npm run test:cljs`) covers its namespace — the probe is the
+           ;; CLJS equivalent of the JVM `ns-publics` existence-check.
+           ;; Rows the probe does not (yet) cover stay `false`. The JVM
+           ;; generator carries the curated flag through verbatim; it does
+           ;; not itself run the CLJS probe.
+           :runtime-verified? (boolean (:runtime-verified? r))})
         rows (->> (concat jvm-rows cljs-rows)
                   (sort-by (juxt :namespace :var))
                   vec)]

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -29,6 +29,22 @@
                 "test-quiet/src"
                 "core/src"
                 "core/test"
+                ;; rf2-2mtte — CLJS-side public-API manifest enumeration
+                ;; probe. The macro (analyzer-driven publics enumeration)
+                ;; + the pure reconciliation ns + the probe `*_cljs_test`
+                ;; live beside the JVM manifest generator under
+                ;; scripts/api-manifest/probe/ (kept OUT of the
+                ;; generator's own src/ so its analyzer-macro classpath
+                ;; never reaches the JVM `gen` build). Listing the paths
+                ;; here puts the probe test on the consolidated
+                ;; `:node-test` classpath so `npm run test:cljs` runs it
+                ;; — the test reconciles the LIVE Reagent/UIx/Helix
+                ;; adapter + Xray mount publics against the `:cljs-only`
+                ;; rows in spec/api-manifest-metadata.edn. Bundle-isolation
+                ;; holds: probe code is test-only and nothing under a
+                ;; production build :requires it.
+                "scripts/api-manifest/probe/src"
+                "scripts/api-manifest/probe/test"
                 "adapters/reagent/src"
                 "adapters/reagent/test"
                 ;; rf2-eceuv — per-adapter testbed (Reagent). Standalone

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -29,44 +29,61 @@
 
  ;; --------------------------------------------------------------------------
  ;; CLJS-ONLY surfaces — public vars in ClojureScript-only namespaces that
- ;; cannot be `require`d on the JVM, so the generator carries them verbatim
- ;; (`:runtime-verified? false`). Each row is the FULL manifest row.
+ ;; cannot be `require`d on the JVM, so the generator carries them verbatim.
+ ;; Each row is the FULL manifest row, and carries its own
+ ;; `:runtime-verified?` flag.
  ;;
- ;; The substrate-adapter surfaces (per spec/API.md §UIx/Helix adapter and
- ;; the Reagent adapter), the Xray `mount-*!` host-embed family (per §Tiering
- ;; of cross-tool surfaces — `internal-public`), plus the panel-mounted? read.
- ;; A follow-on bead adds a CLJS-side enumeration probe so these too become
- ;; runtime-verified (see PR follow-on beads).
+ ;; RUNTIME VERIFICATION (rf2-2mtte). The CLJS-side enumeration probe
+ ;; (implementation/scripts/api-manifest/probe/, run by `npm run test:cljs`)
+ ;; reconciles the LIVE public vars of each covered namespace against these
+ ;; rows — the CLJS equivalent of the JVM `ns-publics` existence-check. A
+ ;; row whose namespace the probe covers is `:runtime-verified? true`:
+ ;;   - the three adapter namespaces (Reagent / UIx / Helix) are
+ ;;     fully-rowed (their public surface IS the documented adapter API per
+ ;;     spec/API.md §UIx/Helix adapter), so a var added / removed / renamed
+ ;;     there turns the probe RED;
+ ;;   - the Xray `mounted?` read is a curated row off the `internal-public`
+ ;;     mount surface (the host-embed machinery is "otherwise unrowed-
+ ;;     internal" per §Tiering of cross-tool surfaces) — the probe verifies
+ ;;     it still resolves to a live var (removed / renamed → RED).
+ ;; The `re-frame.core` `frame-provider` reader-conditional row is owned by
+ ;; the JVM generator's view of re-frame.core, not this probe, so it stays
+ ;; `:runtime-verified? false`. The pair-MCP server (a CLJS-only surface
+ ;; named by the keystone) compiles under its own shadow-cljs build and is
+ ;; a follow-on probe target (see rf2-2mtte PR notes); it carries no rows
+ ;; here yet.
  ;; --------------------------------------------------------------------------
  :cljs-only
  [;; --- re-frame.core CLJS-only front-porch surface ---
   ;; `frame-provider` is a Reagent component re-exported from re-frame.core
   ;; under a `#?(:cljs ...)` reader-conditional, so it is absent from the
   ;; JVM `ns-publics` of re-frame.core. Rowed front-porch in spec/API.md
-  ;; §View ergonomics.
-  {:namespace "re-frame.core" :var "frame-provider" :kind :fn :facade? true :tier :front-porch :owner "002" :status "v1"}
-  ;; --- Reagent adapter (day8/re-frame2-reagent) ---
-  {:namespace "re-frame.adapter.reagent" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.reagent" :var "set-hiccup-emitter!" :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  ;; --- UIx adapter (day8/re-frame2-uix) ---
-  {:namespace "re-frame.adapter.uix" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.uix" :var "use-subscribe"       :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.uix" :var "use-current-frame"   :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.uix" :var "frame-provider"      :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.uix" :var "wrap-view"           :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.uix" :var "flush-views!"        :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.uix" :var "set-hiccup-emitter!" :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  ;; --- Helix adapter (day8/re-frame2-helix) ---
-  {:namespace "re-frame.adapter.helix" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.helix" :var "use-subscribe"       :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.helix" :var "use-current-frame"   :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.helix" :var "frame-provider"      :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.helix" :var "wrap-view"           :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.helix" :var "flush-views!"        :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
-  {:namespace "re-frame.adapter.helix" :var "set-hiccup-emitter!" :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1"}
+  ;; §View ergonomics. Not covered by the CLJS probe (which loads the
+  ;; adapter / Xray namespaces, not re-frame.core's CLJS branch).
+  {:namespace "re-frame.core" :var "frame-provider" :kind :fn :facade? true :tier :front-porch :owner "002" :status "v1" :runtime-verified? false}
+  ;; --- Reagent adapter (day8/re-frame2-reagent) — probe fully-rowed ---
+  {:namespace "re-frame.adapter.reagent" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.reagent" :var "set-hiccup-emitter!" :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  ;; --- UIx adapter (day8/re-frame2-uix) — probe fully-rowed ---
+  {:namespace "re-frame.adapter.uix" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix" :var "use-subscribe"       :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix" :var "use-current-frame"   :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix" :var "frame-provider"      :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix" :var "wrap-view"           :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix" :var "flush-views!"        :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix" :var "set-hiccup-emitter!" :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  ;; --- Helix adapter (day8/re-frame2-helix) — probe fully-rowed ---
+  {:namespace "re-frame.adapter.helix" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix" :var "use-subscribe"       :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix" :var "use-current-frame"   :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix" :var "frame-provider"      :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix" :var "wrap-view"           :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix" :var "flush-views!"        :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix" :var "set-hiccup-emitter!" :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   ;; --- Xray mount family (day8/re-frame2-xray) — host-embed surface,
-  ;;     internal-public per spec/API.md §Tiering of cross-tool surfaces. ---
-  {:namespace "day8.re-frame2-xray.mount" :var "mounted?" :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib"}]
+  ;;     internal-public per spec/API.md §Tiering of cross-tool surfaces.
+  ;;     Curated row (direction-1 only): probe verifies it still resolves. ---
+  {:namespace "day8.re-frame2-xray.mount" :var "mounted?" :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}]
 
  ;; --------------------------------------------------------------------------
  ;; API.md var-rows that are KNOWINGLY absent from the manifest. The

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -16,23 +16,23 @@
   :internal-public
   :deprecated]}
  :vars
- [{:namespace "day8.re-frame2-xray.mount", :var "mounted?", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.helix", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.helix", :var "flush-views!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.helix", :var "frame-provider", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.helix", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.helix", :var "use-current-frame", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.helix", :var "use-subscribe", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.helix", :var "wrap-view", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.reagent", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.reagent", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.uix", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.uix", :var "flush-views!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.uix", :var "frame-provider", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.uix", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.uix", :var "use-current-frame", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.uix", :var "use-subscribe", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
-  {:namespace "re-frame.adapter.uix", :var "wrap-view", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? false}
+ [{:namespace "day8.re-frame2-xray.mount", :var "mounted?", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix", :var "flush-views!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix", :var "frame-provider", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix", :var "use-current-frame", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix", :var "use-subscribe", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.helix", :var "wrap-view", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.reagent", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.reagent", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix", :var "flush-views!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix", :var "frame-provider", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix", :var "use-current-frame", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix", :var "use-subscribe", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.uix", :var "wrap-view", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.core", :var "->interceptor", :tier :front-porch, :kind :macro, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "->interceptor*", :tier :advanced, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "active-head", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
Follow-on to the rf2-3nbl5.2 API-manifest keystone. The JVM generator runtime-verifies only JVM-loadable public namespaces; the **CLJS-only surfaces** (Reagent/UIx/Helix adapters, the Xray `mount` host-embed family) were carried as curated `:cljs-only` rows with `:runtime-verified? false` because they cannot be `require`'d on the JVM. This PR closes that gap with a CLJS-side enumeration probe.

## Approach

- **Enumeration (headless, deterministic).** CLJS has no runtime `ns-publics` (vars erase to plain JS at `:advanced`). The probe enumerates publics at **compile time** off the analyzer: `emit-ns-publics` (a `.clj` macro) reads `cljs.analyzer.api/ns-publics` from the compilation env, drops `^:no-doc`, and emits a sorted literal of `[var kind]` pairs. `emit-cljs-only-rows` slurps the sidecar's `:cljs-only` rows at macro-expansion time, so the probe needs no runtime filesystem. The target namespaces are `:require`'d so the analyzer has analysed them before the macro expands.
- **Reconciliation (pure `.cljc`).** `reconcile` mirrors the JVM `build-manifest`: **STALE** (a row with no live var → removed/renamed) and **MISSING** (a live var with no row in a fully-rowed ns → added).
- **Placement / CI.** Probe lives under `implementation/scripts/api-manifest/probe/` beside the JVM generator (out of its `src/` so the analyzer-macro classpath never reaches the JVM `gen` build). The `*_cljs_test.cljs` rides the consolidated `:node-test` build via `cljs-test$` auto-discovery → run by `npm run test:cljs`. **No `.github/workflows` change** (so lint.yml's api-manifest job + post-merge-workflow-sanity are untouched).

## Coverage / rows flipped to runtime-verified

- **Reagent / UIx / Helix adapters** — fully-rowed (their public surface IS the documented adapter API per spec/API.md §UIx/Helix adapter): added **and** removed/renamed → RED. All adapter rows flipped to `:runtime-verified? true`.
- **`day8.re-frame2-xray.mount` `mounted?`** — curated read off the `internal-public` mount surface (host-embed machinery is "otherwise unrowed-internal" per §Tiering); direction-1 (still resolves) only. Flipped to `true`.
- `re-frame.core/frame-provider` stays `false` (JVM-owned reader-conditional, not loaded by this probe).
- **`:kind` is intentionally not reconciled** — the CLJS analyzer cannot derive `:fn` for fn-valued `def`s (the adapters' `(def use-subscribe (:use-subscribe spine-fns))` hook/seam idiom); the curated `:kind` stands.

### Supporting changes
- `gen.clj` now emits each `:cljs-only` row's own `:runtime-verified?` flag (was hardcoded `false`).
- `clear-warned-non-dom-roots!` (UIx + Helix) marked `^:no-doc` — a test-support seam, not part of the 7-row documented adapter API, so the manifest honestly excludes it.
- `spec/api-manifest.edn` regenerated.

### pair-MCP server (follow-on)
The pair-MCP server is the third CLJS-only surface the keystone names. It compiles under the pair-MCP artefact's OWN shadow-cljs `:server-test` build (not on the consolidated `:node-test` classpath; pulls the npm MCP SDK), so its probe rides that build. The shared `cljs-publics` + `cljs-probe` namespaces are the reusable mechanism for it — a sequenced follow-on (the 3 sibling validators extend this tooling next).

## Quality gates

- **RED-on-drift proof (local).** Renamed `re-frame.adapter.helix/use-subscribe` → `use-subscribe-RENAMED`, recompiled `node-test`, ran: probe went RED with BOTH directions firing —
  ```
  FAIL in (cljs-only-surface-in-sync)
      - re-frame.adapter.helix/use-subscribe            (stale: row, no live var)
      + re-frame.adapter.helix/use-subscribe-RENAMED    (missing: live var, no row)
  ```
  Reverted → green again.
- `npm run test:cljs` (incl. the new probe target): **green — Ran 5191 tests, 17691 assertions, 0 failures, 0 errors.**
- `npm run test:bundle-isolation`: **PASS** (17 artefact entries, 35 internal sentinels absent; `uix-helix-reagent-free` PASS) — the probe is test-only and does not leak into production bundles.
- clj-kondo on changed files: **0 errors, 0 warnings.**
- JVM `api-manifest` drift-check + `api-md-check`: **OK** (438 public vars in sync; 189 API.md var-rows in sync).
- lint.yml: **not touched** — probe rides the existing `test:cljs` gate via auto-discovery.