### PR TITLE
docs(story): reconcile tools/story/spec with ~36h of Story impl (rf2-guin2)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2164,9 +2164,11 @@ installs canonical vocabulary), and MUST fold the existing
 - enumerate the `:plan-hash` input fields;
 - compute `:run-hash` over the canonical epoch slice.
 
-It MUST reconcile the shipping `:rf/snapshot-canonical-v1` tuple and the
-current `:variant-id` key spelling with any normalized-plan `:variant/id`
-spelling. It MUST be built **before** anything consumes it (else the
+It MUST reconcile the shipping snapshot tuple — whose `:rf/snapshot-canonical`
+data slot reads its value straight from `fingerprint/canonical-version`
+(the single version source, currently `:rf/snapshot-canonical-v2`), NOT a
+hardcoded literal — and the current `:variant-id` key spelling with any
+normalized-plan `:variant/id` spelling. It MUST be built **before** anything consumes it (else the
 metamorphic acceptance gate is vacuous and near-duplicate canonicalizers
 drift), and MUST ship with an adversarial corpus: semantic differences
 must change the hash, volatile fields must not, and existing snapshot


### PR DESCRIPTION
Catch-up reconciliation of `tools/story/spec/*` against Story implementation merged in the ~36h window (~2026-05-31 11:18 .. 2026-06-01). Behaviour-preserving SPEC work only — truing docs to shipped impl, no impl change.

## Method

Enumerated every commit touching `tools/story/src` / `tools/story/testbeds` (+ examples) in the window and cross-referenced each against its spec touch. For every behavioural change, verified `tools/story/spec/*` coverage.

## Reconciled (spec-drift fixed)

- **Snapshot canonical-version** — `017-Testing-Story.md` §Concrete primitive contract cited "the shipping `:rf/snapshot-canonical-v1` tuple". Per **rf2-e8hgr** (`9c9c6e56d`, no spec touch in its PR) the snapshot tuple's `:rf/snapshot-canonical` data slot no longer hardcodes a version literal — it reads straight from `fingerprint/canonical-version` (the single version source, currently `:rf/snapshot-canonical-v2`). Reworded the prose to track ground truth. The §Snapshot-identity migration path body (lines ~2230+) already described the v1→v2 bump accurately; only this one incidental phrase was stale.

## Already-current (spec shipped in the same PR, or internal-only)

- **rf2-5o6yd / -7mj4z / -lh99f / -zaklu** (assertion vocab, `:setup`/`:script` finish, test-support fixture, `story/is :timeout-ms`) — spec updated in-PR (001/004/005/API/Tutorials).
- **rf2-3nbl5.6** frozen run-result / retire `:passing?` — 017 + API correctly state "NO `:passing?` boolean".
- **rf2-9k43e** inline Xray event spine in RHS embed — fully spec'd in 003-Render-Shell (+ Xray 008 cross-link).
- **rf2-blw1q** `:db-seed` fidelity rung — 017 carries schema slot, world slot, runtime phase, `:rf.error/story-db-seed-invalid`.
- **rf2-ffu8t** a11y source-links — 021 §4/§5.
- **rf2-luzky** wall-clock strip + assertion-tape fold — 017/009/001.
- **rf2-kkut0.x** frame-affordance redesign (`e06bec6f6`) — Story teaching swept by **rf2-kkut0.5** (`7895d3be8`); `84a34b8b5` then renamed `frame-db → app-db-value` across spec/docs. Grep confirms Story spec carries no stale `get-frame-db` / `bound-fn` / `dispatcher` / `subscriber` public refs — only `app-db-value`. Projection drift-check (rf2-gkp0t) safe.
- **rf2-qk0h9** `:stack` stderr-leak fix — internal; 002-Runtime already documents the `:stack` slot.
- **rf2-jkake.21 / rf2-18pef.21** dedup + naming passes — behaviour/name-preserving; `ff9f7110a` is docstring-only and its error-id correction matches spec/017.

## Intentional-but-unspecced gaps (none requiring a follow-on bead)

The login / nine_states **showcase examples** (`ec85c3c7c`, `9977abaae`) are example-side wiring, not Story spec contract material (per the examples-are-test-free convention) — correctly absent from `tools/story/spec/*`. No gap to file.

## Quality gates

- `mkdocs build --strict` — PASS (built in 8.92s, no strict escalations). Note: `tools/story/spec/*` is NOT in the mkdocs nav (docs reference it only via external GitHub links); the edited file is unpublished, edit changed no anchor/heading, so no internal-link impact. Confirmed no broken internal links.
- Reconciled spec area: `017-Testing-Story.md` (snapshot canonical-version prose). Verified no test/code parses the edited prose string (grep: only the spec file matches).

Closes rf2-guin2.