### PR TITLE
fix(xray): machine-cascade rendering — canonical phase order + source glyphs + transition zone + action :data diff (rf2-tjqd8, rf2-ge6uj, rf2-5hjb5)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1370,14 +1370,44 @@ category sub-sections (TRANSITION / GUARDS / LIFECYCLE / AFTER-TIMERS
 / DATA REDUCTION / SNAPSHOT DIFF / FX). That was a roll-up — the
 operator had to scroll up/down across categories to reconstruct what
 actually fired in what order. The redesign replaces the category-
-grouped layout with a single **time-ordered cascade view**: one row
-per substrate emit, ordered by the trace buffer's insertion order.
+grouped layout with a single **cascade view**: one row per substrate
+emit, rendered in canonical phase order.
 
-**Order is the substrate's.** The substrate already emits in cascade
-order (guards → exit actions → transition → entry actions → always →
-after-action → timer-cancels — Spec 005 §Trace events + rf2-82a0u).
-The panel never re-sorts; it walks `:trace-events` and surfaces every
-member of `machine-cascade-trace-ops` as a row in the same order:
+**Canonical phase order (rf2-tjqd8).** The rows are NOT rendered in raw
+substrate emit order. The substrate's live emit order is `exit → entry
+→ transition-LAST` — the `:rf.machine/transition` summary emit TRAILS
+the exit + entry actions so its `:after` snapshot reflects the
+accumulated data. Rendered verbatim, the TRANSITION lands AFTER the
+entry action, which mis-reads the statechart (the operator expects
+"leave the old state → change state → enter the new state"). The panel
+therefore RE-SORTS rows into the canonical `(kind, phase)` order:
+
+```
+guard → exit → TRANSITION → entry → always → after-action → timer
+```
+
+via a STABLE sort keyed by `[cascade-row-rank :trace-index]` — rows in
+the same rank keep their substrate emit order (multiple actions in one
+phase keep their run order). The `:transition` KIND sits between the
+exit-phase actions and the entry-phase actions; `:guard` leads (guards
+gate the transition); `:timer` trails (post-commit housekeeping).
+`:transition`-phase actions rank WITH the transition (they fire as part
+of the state change); `:initial-entry` ranks with `:entry`,
+`:destroy-exit` with `:exit`. The `:step` ordinal is assigned 1..N over
+the FINAL sorted order. See `projection/cascade-row-rank` +
+`machine-cascade-rows`.
+
+This is a PANEL-SIDE presentation re-sort ONLY. The substrate trace
+order is untouched — reordering the `:rf.machine/transition` emit would
+change trace order for every consumer (the alternative was considered
+and rejected: the panel re-sort is localized and safe). The
+`enrich-cascade-rows` pass (which stamps `:source-state` /
+`:target-state` / `:event-id` from the surrounding transition) runs on
+the trace-ordered rows BEFORE the re-sort, since that resolution is
+emit-order-sensitive.
+
+The projection walks `:trace-events` and surfaces every member of
+`machine-cascade-trace-ops` as a row, then applies the canonical sort:
 
   | Trace op                          | Row `:kind`     |
   |-----------------------------------|------------------|
@@ -1413,9 +1443,22 @@ cascade row carries source visibility (rf2-wwc3j extends rf2-u69j7's
 named-only coverage to inline-fn / transition / timer rows). The body
 renders the source form pulled from the registered machine spec via
 `edn/code-block` (clojure-syntax highlight; same widget the HANDLER
-source block uses). Source-key dispatch (`projection/cascade-row-
-source-key`) returns the spec-path tuple under which the macro
-stamped the per-element source-coord (rf2-8bp3):
+source block uses).
+
+The machine spec is read off `(rf/handler-meta :event event-id)`'s
+`:rf/machine` slot (rf2-ge6uj ISSUE 2) — the stamped spec carrying
+`:rf.machine/handler-source` (named guard/action fn-form pr-str
+strings, rf2-ypu5i) and `:rf.machine/source-coords` (per-element
+`{:file :line}` index, rf2-8bp3). The prior code read `(rf/handler-meta
+:machine event-id)`, a NON-EXISTENT registrar kind that always resolved
+nil — so `machine-spec-from-meta` saw no spec and every exit / entry
+action + guard row rendered the `<source not yet captured>`
+placeholder. Reading under `:event` (where the machine handler is
+registered) surfaces the stamped spec so the interleaved source code
+resolves for named handlers; inline-fn / transition / timer rows
+resolve via the source-coord index. Source-key dispatch
+(`projection/cascade-row-source-key`) returns the spec-path tuple under
+which the macro stamped the per-element source-coord (rf2-8bp3):
 
 | Row kind | id flavour              | spec-path key                                         |
 |----------|-------------------------|-------------------------------------------------------|
@@ -1454,18 +1497,39 @@ placeholder so the slot is consistently present.
 **Per-row outcome detail.** Action rows surface inline:
 
 - **`↳ data Δ`** — when the action returned a `:data` map, the delta
-  the action contributed (via `ei/mini`).
+  the action contributed rendered through the **edn-inspector in DIFF
+  mode** (rf2-5hjb5). The action's RETURNED `:data` (`:data-write`, the
+  AFTER) renders with inline diff annotations against the action's
+  INPUT `:data` (`:data-before`, lifted off the `:input {:data …}`
+  snapshot), reusing the same `{:before <prior>}` posture the App-db
+  panel ships (cf. `handler-db-diff-block`). A data-mutating action
+  shows its delta inline (entry `:count-open`: `{:opened-count 0}` →
+  `{:opened-count 1}` paints the changed leaf with the `~ … ← was 0`
+  gutter chrome); a no-op action whose `:data` is unchanged (exit
+  `:clear-hold`) renders the value with NO delta (the inspector's
+  `:same` rows carry no gutter glyph). When no pre-image was captured
+  the inspector mounts in browse mode. Supersedes the prior `ei/mini`
+  one-liner.
 - **`↳ fx`** — per-action fx-id chips for each effect the action
   emitted (same data the FX step's `:attributed-to` chip surfaces,
   now visible IN the action's row).
 - **`✗ threw`** — when the action threw, an error chip + exception
   message.
 
-Transition rows surface the `state {:from} → {:to}` chrome with the
-event vector that drove the cascade plus the transition-map source
-body (rf2-wwc3j). Timer rows surface only the header + click-to-
-source chip (no inline body — cancellations are housekeeping; the
-chip routes to the `:after`-bearing state node).
+**Transition row — one prominent collapsed row (rf2-ge6uj).** The
+transition zone is a SINGLE prominent row: the header carries `[#step]
+[TRANSITION badge] <before-state → after-state>`, where the verb IS the
+state change (rendered larger / bolder / magenta — the focal point of
+the collapsed zone) and doubles as the click-to-source affordance onto
+the transition map. The redundant leading "transition" word (the KIND
+pill already says TRANSITION), the machine-name echo (already the
+cascade context), and the prior repetitive lower-line `state {:from} →
+{:to}` + `event [...]` detail block are all REMOVED. The transition MAP
+literal still renders as the row's source body (the `{:target :guard
+:action}` rf2-wwc3j delight shape) — that is the source, not a
+repetition. Timer rows surface only the header + click-to-source chip
+(no inline body — cancellations are housekeeping; the chip routes to
+the `:after`-bearing state node).
 
 **Empty-state correctness** (acceptance #4 — rf2-u69j7). A vanilla
 `reg-event-db` cascade (or any non-`:reg-machine` flavour) renders
@@ -1809,9 +1873,17 @@ the verb so the affordance is read inline with the cascade rhythm
 `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs`:
 
 - **Source-coord read.** Pulls `(rf/handler-meta :event event-id)` for
-  vanilla flavours and `(rf/handler-meta :machine event-id)` for
-  `:reg-machine`. Coord shape: `{:file <string> :line <int>}` (the
-  registrar-meta surface; NOT a trace read).
+  ALL flavours — including `:reg-machine` (rf2-ge6uj ISSUE 1). A machine
+  is registered as a `reg-event-fx` carrying `:rf/machine? true`, so its
+  registration meta (with the top-level `reg-machine` call-site `:file` /
+  `:line`) lives under the `:event` kind. There is NO `:machine`
+  registrar kind (`registrar/kinds` = `:event :sub :fx … :machine-guard
+  :machine-action`); the prior `(rf/handler-meta :machine event-id)`
+  resolved nil, so the machine EVENT HANDLER painted the glyph-less plain
+  span. Reading under `:event` surfaces the call-site coord so the
+  machine EVENT HANDLER carries the same `↗` glyph a plain event does.
+  Coord shape: `{:file <string> :line <int>}` (the registrar-meta
+  surface; NOT a trace read).
 - **Clickable when** `(:file coord)` is non-empty — renders a
   `<button>` carrying the flavour label + lucide `external-link`
   glyph. Underlined-dotted in the accent tone so the hyperlink reads

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -514,9 +514,26 @@
 ;; TIMERS / DATA-REDUCTION / SNAPSHOT-DIFF / FX). That layout buried the
 ;; CASCADE — the operator had to read TRANSITION (top), then scroll down to
 ;; LIFECYCLE, then back up to GUARDS, to reconstruct what actually happened
-;; in what order. The substrate already emits in cascade order (guards →
-;; exit actions → transition → entry actions → always → …); the projection
-;; just needs to thread the same INSERTION ORDER into a single row vector.
+;; in what order. The redesign threads the per-emit stream into a single
+;; row vector.
+;;
+;; CANONICAL PHASE ORDER (rf2-tjqd8). The rows are NOT rendered in raw
+;; trace-INSERTION order. The substrate's live emit order is exit →
+;; entry → transition-LAST (the `:rf.machine/transition` summary emit
+;; trails the exit+entry actions so its `:after` reflects the accumulated
+;; data). Rendered verbatim, the TRANSITION lands AFTER the entry action —
+;; confusing in the centerpiece panel, where the operator expects the
+;; statechart reading "leave the old state → change state → enter the new
+;; state". The projection therefore RE-SORTS rows panel-side into the
+;; canonical `(kind, phase)` order:
+;;
+;;   guard → exit → TRANSITION → entry → always → after-action → timer
+;;
+;; with a STABLE sort (rows in the same rank keep their substrate emit
+;; order — multiple actions in one phase keep their run order). This is a
+;; panel-side presentation re-sort ONLY; the substrate trace order is
+;; untouched (changing it would affect every consumer). See
+;; `cascade-row-rank` + `machine-cascade-rows`.
 ;;
 ;; The cascade row vector replaces the category-grouped `:machine` map
 ;; entirely (rf2-u69j7). One row per substrate emit that participated in
@@ -549,6 +566,53 @@
    :rf.machine/transition       :transition
    :rf.machine.timer/cancelled  :timer})
 
+(def ^:private cascade-rank
+  "Canonical (kind, phase) presentation rank for the machine cascade
+  (rf2-tjqd8). Lower sorts earlier. The order encodes the statechart
+  reading the operator expects:
+
+    guard → exit → TRANSITION → entry → always → after-action → timer
+
+  The `:transition` KIND sits at rank 2 — between the exit-phase actions
+  (rank 1) and the entry-phase actions (rank 3) — even though the
+  substrate emits the `:rf.machine/transition` summary LAST. `:guard`
+  leads (rank 0): guards gate the transition, so they read before it.
+  `:timer` trails (rank 6): timer-cancels are post-commit housekeeping.
+
+  Bootstrap / lifecycle phases slot beside their nearest sibling:
+  `:initial-entry` ranks with `:entry`, `:destroy-exit` with `:exit`."
+  {;; guards — gate the transition; read first
+   [:guard nil]              0
+   ;; exit-phase actions — leave the old state
+   [:action :exit]           1
+   [:action :destroy-exit]   1
+   ;; the state change itself — between exit and entry
+   [:transition nil]         2
+   ;; transition-phase actions ride WITH the transition (between exit
+   ;; and entry, by intent: they fire as part of the state change)
+   [:action :transition]     2
+   ;; entry-phase actions — enter the new state
+   [:action :entry]          3
+   [:action :initial-entry]  3
+   ;; always — intra-macrostep follow-ups after entry settled
+   [:action :always]         4
+   ;; after-action — `:after` timer continuations
+   [:action :after-action]   5
+   ;; timer cancellations — post-commit housekeeping
+   [:timer nil]              6})
+
+(defn cascade-row-rank
+  "Canonical presentation rank for a cascade row (rf2-tjqd8). Reads the
+  row's `[:kind :phase]` against `cascade-rank`; `:phase` participates
+  only for `:action` rows (other kinds key on `[kind nil]`). Unknown
+  combinations fall to a high sentinel rank so a future kind/phase
+  surfaces at the tail rather than silently jumping the canonical
+  order. Pure-data; the stable sort in `machine-cascade-rows` is keyed
+  off this."
+  [{:keys [kind phase]}]
+  (let [k (if (= :action kind) [:action phase] [kind nil])]
+    (get cascade-rank k 99)))
+
 (defn- guard-cascade-row
   "Build a cascade row from a `:rf.machine/guard-evaluated` trace event
   (rf2-u69j7). Outcome is one of `:pass / :fail / :threw` (rf2-82a0u
@@ -570,11 +634,23 @@
   `:exit / :transition / :entry / :always / :after-action /
   :initial-entry / :destroy-exit`), the action-id, the input snapshot,
   per-action fx attribution, the data-write the action returned, and
-  the threw? signal."
+  the threw? signal.
+
+  rf2-5hjb5 — the action's data DELTA is carried as a `[:data-before
+  :data-write]` pair: `:data-before` is the action's INPUT `:data`
+  (lifted off the `:input {:data … :event …}` snapshot the substrate
+  stamps), `:data-write` is the action's RETURNED `:data` (off
+  `:outcome`). The view renders the action body as an edn-inspector DIFF
+  of `:data-before → :data-write`, so a data-mutating action (entry
+  `:count-open`: `{:opened-count 0}` → `{:opened-count 1}`) shows its
+  delta inline, while a no-op action (exit `:clear-hold`, data unchanged)
+  shows no delta."
   [ev]
   (let [outcome     (common/tag-of ev :outcome)
+        input       (common/tag-of ev :input)
         action-fx   (when (map? outcome) (:fx outcome))
-        action-data (when (map? outcome) (:data outcome))]
+        action-data (when (map? outcome) (:data outcome))
+        data-before (when (map? input) (:data input))]
     (cond-> {:kind        :action
              :action-id   (common/tag-of ev :action-id)
              :phase       (common/tag-of ev :phase)
@@ -582,13 +658,18 @@
              :threw?      (= :rf.error/action-threw outcome)
              :duration-ms (common/tag-of ev :duration-ms)
              :machine-id  (common/tag-of ev :machine-id)
-             :input       (common/tag-of ev :input)}
+             :input       input}
       (common/tag-of ev :exception)
       (assoc :exception (common/tag-of ev :exception))
       (seq action-fx)
       (assoc :fx (vec action-fx))
       (some? action-data)
-      (assoc :data-write action-data))))
+      (assoc :data-write action-data)
+      ;; rf2-5hjb5 — the pre-image of the action's `:data` write, lifted
+      ;; off the input snapshot so the view renders an inspector diff
+      ;; without re-walking the trace.
+      (some? data-before)
+      (assoc :data-before data-before))))
 
 (defn- transition-cascade-row
   "Build a cascade row from a `:rf.machine/transition` trace event
@@ -791,33 +872,52 @@
   / duration / interleaved code body WITHOUT a second pass over the
   trace stream.
 
-  ORDER COMES FROM SUBSTRATE INSERTION ORDER — the substrate already
-  emits guards / exit actions / transition / entry actions / always /
-  after-action / timer-cancels in cascade order (Spec 005 §Trace events
-  + rf2-82a0u). We just walk the same `:trace-events` vector in order
-  and surface every `machine-cascade-trace-ops` member as a row. The
-  view layer numbers rows 1..N via `:step` (assigned here, contiguous
-  over only the rows that fired).
+  CANONICAL PHASE ORDER (rf2-tjqd8) — the rows are RE-SORTED panel-side
+  into `guard → exit → TRANSITION → entry → always → after-action →
+  timer` rather than rendered in raw substrate emit order. The substrate
+  emits the `:rf.machine/transition` summary LAST (after exit + entry
+  actions accumulate the data), so the verbatim emit order is exit →
+  entry → transition; rendering it that way lands the TRANSITION after
+  the entry action, which mis-reads the statechart. The re-sort is a
+  STABLE sort keyed by `[cascade-row-rank :trace-index]` — rows in the
+  same rank keep their substrate emit order (multiple actions in one
+  phase keep their run order). This is presentation-only; the substrate
+  trace order is untouched.
 
-  Per rf2-wwc3j: post-build each row is enriched with `:source-state` /
-  `:target-state` / `:event-id` derived from the surrounding `:transition`
-  emit. These slots feed `cascade-row-source-key` so inline-fn `:entry` /
-  `:exit` / `:guard` / transition / timer rows can resolve their spec-
-  path tuple under `:rf.machine/source-coords` (rf2-8bp3).
+  Pipeline:
+  1. Walk `:trace-events` in trace order; build one row per
+     `machine-cascade-trace-ops` member, stamping `:trace-index` (the
+     emit-order tiebreaker for the stable sort).
+  2. `enrich-cascade-rows` (rf2-wwc3j) — stamps `:source-state` /
+     `:target-state` / `:event-id` from the surrounding `:transition`
+     emit. This MUST run on the trace-ordered rows (the
+     surrounding-transition resolution is emit-order-sensitive).
+  3. Stable-sort by canonical rank, then re-number `:step` 1..N over the
+     sorted order so the view's left-rail ordinal reflects the rendered
+     order.
+
+  The enrichment slots feed `cascade-row-source-key` so inline-fn
+  `:entry` / `:exit` / `:guard` / transition / timer rows can resolve
+  their spec-path tuple under `:rf.machine/source-coords` (rf2-8bp3).
 
   Returns an empty vec when no machine-cascade events fired (vanilla
   reg-event-db / reg-event-fx cascades — the redesign is
   machine-specific and the empty vec drives the view's empty-state
   branch off the prior handler-step rendering unchanged)."
   [events]
-  (let [base (vec
-               (map-indexed
-                 (fn [i row]
-                   (assoc row :step (inc i) :trace-index i))
-                 (keep ev->cascade-row
-                       (filter (fn [ev] (contains? machine-cascade-trace-ops (op ev)))
-                               events))))]
-    (enrich-cascade-rows base)))
+  (let [base     (vec
+                   (map-indexed
+                     (fn [i row] (assoc row :trace-index i))
+                     (keep ev->cascade-row
+                           (filter (fn [ev] (contains? machine-cascade-trace-ops (op ev)))
+                                   events))))
+        enriched (enrich-cascade-rows base)
+        ;; Stable canonical sort: rank first, emit-order (:trace-index)
+        ;; as tiebreaker so intra-phase run order is preserved.
+        sorted   (vec (sort-by (juxt cascade-row-rank :trace-index) enriched))]
+    ;; Re-number :step over the FINAL (canonical) order so the left-rail
+    ;; ordinal reads top-to-bottom as rendered.
+    (vec (map-indexed (fn [i row] (assoc row :step (inc i))) sorted))))
 
 (defn machine-cascade-total-ms
   "Sum of every cascade row's `:duration-ms` (rf2-u69j7). nil when no
@@ -2887,16 +2987,18 @@
   "Render a cascade row's human-readable verb (rf2-u69j7). Used by the
   view's per-row header. Pure-data; the view never reaches into a
   row's slots to compute its label."
-  [{:keys [kind action-id guard-id phase from-state to-state state reason
-           machine-id]}]
+  [{:keys [kind action-id guard-id phase from-state to-state state reason]}]
   (case kind
     :guard       (str "guard " (ns-keyword guard-id))
     :action      (str (when phase (str (name phase) " "))
                       "action " (ns-keyword action-id))
-    :transition  (str "transition "
-                      (when machine-id
-                        (str (ns-keyword machine-id) " · "))
-                      (if from-state (pr-str from-state) "?")
+    ;; rf2-ge6uj ISSUE 3 — the TRANSITION row's verb is JUST the state
+    ;; change `<before> → <after>`, made the focal point. The redundant
+    ;; leading "transition" word (the KIND pill already says TRANSITION)
+    ;; and the machine-name echo (`:door/main` — already the cascade
+    ;; context) are DROPPED; the lower-line state/event repetition is
+    ;; dropped in the view (`cascade-row-transition-details`).
+    :transition  (str (if from-state (pr-str from-state) "?")
                       " → "
                       (if to-state (pr-str to-state) "?"))
     :timer       (str "timer " (when state (pr-str state))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -393,9 +393,6 @@
 (def ^:private diff-before-style
   {:color error-colour})
 
-(def ^:private diff-after-success-style
-  {:color success-colour})
-
 (def ^:private diff-glyph-bold-style
   {:font-weight 700})
 
@@ -542,25 +539,36 @@
   {:color      text-secondary-colour
    :font-style "italic"})
 
-(def ^:private cascade-transition-details-style
-  {:padding        "3px 0 4px 21px"
-   :display        "flex"
-   :flex-direction "column"
-   :gap            "2px"
-   :font-family    mono-stack
-   :font-size      "11px"})
+;; rf2-ge6uj ISSUE 3 — the TRANSITION row's verb (`<before> → <after>`,
+;; now the focal point) renders VISUALLY PRIMARY: larger + bolder than
+;; the guard/action verbs so the state change is the headline of the
+;; collapsed transition zone. The hue is the magenta TRANSITION-kind tone
+;; (`badge/cascade-kind-colour :transition`) — the same identity the kind
+;; pill paints — so the eye reads pill + state change as one unit.
+(def ^:private cascade-transition-verb-link-button-style
+  {:background            "transparent"
+   :border                "none"
+   :padding               0
+   :margin                0
+   :color                 (badge/cascade-kind-colour :transition)
+   :cursor                "pointer"
+   :font-family           mono-stack
+   :font-size             "13px"
+   :font-weight           700
+   :text-decoration       "underline"
+   :text-decoration-style "dotted"
+   :text-underline-offset "2px"
+   :display               "inline-flex"
+   :align-items           "center"
+   :gap                   "4px"
+   :white-space           "nowrap"})
 
-(def ^:private cascade-from-to-row-style
-  {:display     "inline-flex"
-   :align-items "center"
-   :gap         "6px"
-   :flex-wrap   "wrap"})
-
-(def ^:private cascade-trigger-row-style
-  {:display     "inline-flex"
-   :align-items "center"
-   :gap         "6px"
-   :color       text-secondary-colour})
+(def ^:private cascade-transition-verb-plain-style
+  {:color       (badge/cascade-kind-colour :transition)
+   :font-family mono-stack
+   :font-size   "13px"
+   :font-weight 700
+   :white-space "nowrap"})
 
 (def ^:private cascade-row-style
   {:display        "flex"
@@ -2414,16 +2422,26 @@
 
   rf2-80u5a / rf2-ehd8v — the affordance reads the same `<label> + ↗`
   shape as the HANDLER step's verb so the operator's eye trains on
-  ONE source-link grammar across the panel."
+  ONE source-link grammar across the panel.
+
+  rf2-ge6uj ISSUE 3 — the `:transition` row's verb (`<before> → <after>`)
+  renders with the PROMINENT transition style (larger / bolder / magenta)
+  so the state change is the focal point of the collapsed transition
+  zone; every other kind keeps the standard verb chrome."
   [row coord verb-string]
   ;; rf2-vw5pi — shared `coord-link`; per-site styles preserved. The
   ;; testid is now a single stem (`…-verb-link-<step>`) across both the
   ;; clickable + plain branches — the prior `…-verb-<step>` plain-only
   ;; variant was a hand-rolled artefact, not pinned by any selector.
-  (coord-link/coord-link coord verb-string
-                         (str "rf-xray-epoch-machine-cascade-verb-link-" (:step row))
-                         {:style       cascade-verb-link-button-style
-                          :plain-style cascade-verb-plain-style}))
+  (let [transition? (= :transition (:kind row))]
+    (coord-link/coord-link coord verb-string
+                           (str "rf-xray-epoch-machine-cascade-verb-link-" (:step row))
+                           {:style       (if transition?
+                                           cascade-transition-verb-link-button-style
+                                           cascade-verb-link-button-style)
+                            :plain-style (if transition?
+                                           cascade-transition-verb-plain-style
+                                           cascade-verb-plain-style)})))
 
 (defn- source-form->string
   "Coerce a cascade-row source-form value into a printable Clojure
@@ -2491,13 +2509,42 @@
                  :style cascade-row-source-missing-style}
           "<source not yet captured>"])])))
 
+(defn- cascade-row-action-data-diff
+  "Render an `:action` row's `:data` DELTA through the edn-inspector in
+  DIFF mode (rf2-5hjb5). The action's RETURNED `:data` (`:data-write`,
+  the AFTER) renders with inline diff annotations against the action's
+  INPUT `:data` (`:data-before`, the BEFORE), reusing the same
+  inspector diff posture the App-db panel ships (`{:before <prior>}`,
+  cf. `handler-db-diff-block`).
+
+  A data-mutating action shows its delta inline (entry `:count-open`:
+  `{:opened-count 0}` → `{:opened-count 1}` paints the changed leaf with
+  the `~ … ← was 0` gutter chrome). A no-op action whose `:data` is
+  unchanged (exit `:clear-hold`) renders the value with NO delta — the
+  inspector's `:same` rows carry no gutter glyph. When no pre-image was
+  captured (`:data-before` absent — e.g. a fixture trace) the inspector
+  mounts in browse mode (no `:before`), still surfacing the written
+  value."
+  [{:keys [data-write data-before step] :as _row}]
+  [:div {:data-testid (str "rf-xray-epoch-machine-cascade-data-write-" step)
+         :style cascade-detail-row-style}
+   [:span {:style cascade-detail-success-arrow-style} "↳"]
+   [:span {:style cascade-detail-label-style} "data Δ"]
+   [:span {:style cascade-detail-value-style}
+    [ei/edn-inspector data-write
+     (cond-> {:site-id                [:rf.xray.epoch/machine-cascade-data step]
+              :card?                  false
+              :default-expanded-depth 3}
+       (some? data-before) (assoc :before data-before))]]])
+
 (defn- cascade-row-action-outcome-details
   "Render the per-action outcome details for an `:action` cascade row
   (rf2-u69j7). Three slots ride below the row's source body:
 
   - DATA Δ — when the action returned a `:data` write, surface the
-    delta the action contributed (rf2-9c27r-style per-action
-    attribution, now inline rather than buried in a category roll-up).
+    delta the action contributed as an edn-inspector DIFF (rf2-5hjb5 —
+    input `:data` → outcome `:data`), reusing the App-db panel's diff
+    posture. Supersedes the prior `ei/mini` one-liner.
   - FX — when the action returned a `:fx` list, surface each emitted
     fx-id (per-action attribution; same data as the FX step's
     `:attributed-to` chip, now visible IN the action's row).
@@ -2508,22 +2555,16 @@
   row stays minimal for actions that ran without side-effects."
   [row]
   (let [{:keys [data-write fx threw? exception]} row]
-    (when (or data-write (seq fx) threw?)
+    (when (or (some? data-write) (seq fx) threw?)
       [:div {:data-testid (str "rf-xray-epoch-machine-cascade-outcome-"
                                (:step row))
              :style cascade-outcome-details-style}
        ;; Per-action DATA Δ — the data the action wrote into the
-       ;; snapshot. Surface as `↳ data Δ <map>` so the cascade
-       ;; row tells the operator 'this action wrote …' without
-       ;; reading the post-cascade snapshot diff.
+       ;; snapshot, rendered as an inspector DIFF (input → outcome) so
+       ;; the cascade row tells the operator 'this action changed X
+       ;; from A to B' inline (rf2-5hjb5).
        (when (some? data-write)
-         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-data-write-"
-                                  (:step row))
-                :style cascade-detail-row-style}
-          [:span {:style cascade-detail-success-arrow-style} "↳"]
-          [:span {:style cascade-detail-label-style} "data Δ"]
-          [:span {:style cascade-detail-value-style}
-           [ei/mini data-write 80]]])
+         (cascade-row-action-data-diff row))
        ;; Per-action FX attribution — each fx-id the action emitted
        ;; in its outcome's `:fx` slot. The view layer already
        ;; surfaces these via the FX step's `:attributed-to` chip;
@@ -2559,31 +2600,18 @@
                         (.-message ^js exception))
                       (str exception)))])])])))
 
-(defn- cascade-row-transition-details
-  "Render the transition's `from → to` chrome under a `:transition`
-  cascade row (rf2-u69j7). Pulls the state vectors off the
-  `:from-state` / `:to-state` slots the projection hoisted from the
-  trace's `:before` / `:after` snapshots."
-  [row]
-  (let [{:keys [from-state to-state event microsteps]} row]
-    (when (or from-state to-state event microsteps)
-      [:div {:data-testid (str "rf-xray-epoch-machine-cascade-transition-"
-                               (:step row))
-             :style cascade-transition-details-style}
-       (when (or from-state to-state)
-         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-from-to-"
-                                  (:step row))
-                :style cascade-from-to-row-style}
-          [:span {:style cascade-detail-label-style} "state"]
-          [:span {:style diff-before-style} [ei/mini from-state 30]]
-          [:span {:style cascade-detail-label-style} "→"]
-          [:span {:style diff-after-success-style} [ei/mini to-state 30]]])
-       (when (vector? event)
-         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-trigger-"
-                                  (:step row))
-                :style cascade-trigger-row-style}
-          [:span {:style cascade-detail-label-style} "event"]
-          [ei/mini event 40]])])))
+;; rf2-ge6uj ISSUE 3 — the transition zone is collapsed to ONE prominent
+;; row. The TRANSITION row's header carries `[#step] [TRANSITION badge]
+;; <before-state → after-state>` (the verb IS the state change — see
+;; `projection/cascade-row-label`, which now emits just `<from> → <to>`),
+;; rendered visually PRIMARY via `cascade-transition-verb-link-style`. The
+;; prior repetitive body (`cascade-row-transition-details`) is REMOVED: it
+;; re-stated the state change on a labelled `state <from> → <to>` line and
+;; echoed the triggering `event [...]` underneath — both redundant (the
+;; KIND pill already says TRANSITION; the DISPATCH step + cascade context
+;; already name the event). The transition MAP literal still renders as
+;; the row's source body (`cascade-row-source-body`, rf2-wwc3j) — the
+;; `{:target :guard :action}` delight shape — which is NOT repetitive.
 
 (defn- cascade-row-view
   "Render one cascade row (rf2-u69j7). Layout:
@@ -2594,11 +2622,12 @@
         ↳ fx …
 
   The row's `:kind` keys all the chrome variants: `:action` rides the
-  full layout (phase chip + source body + outcome details);
-  `:guard` rides a thinner layout (source body, no phase chip);
-  `:transition` rides the state-change layout (no source body,
-  state-vector before/after); `:timer` rides a minimal layout (no
-  source body, no phase chip, just the kind + state + reason)."
+  full layout (phase chip + source body + outcome details — incl. the
+  rf2-5hjb5 inspector data DIFF); `:guard` rides a thinner layout
+  (source body, no phase chip); `:transition` rides the prominent
+  state-change verb (`<before> → <after>`) + the transition-map source
+  body, with NO repetitive detail block (rf2-ge6uj ISSUE 3); `:timer`
+  rides a minimal layout (kind + state + reason, no source body)."
   [machine-meta row]
   (let [{:keys [kind step phase duration-ms outcome threw?]} row
         coord       (cascade-row-coord machine-meta row)
@@ -2632,12 +2661,15 @@
            :else                nil)
          (when (or (= :transition kind) (and (= :guard kind) outcome-lbl))
            outcome-lbl))]]
-     ;; Source code body (always visible per rf2-u69j7) — actions + guards only
+     ;; Source code body (always visible per rf2-u69j7) — actions + guards
+     ;; + the transition MAP literal (the rf2-wwc3j delight shape).
      (cascade-row-source-body row source-form)
-     ;; Per-row outcome details — kind-specific
+     ;; Per-row outcome details — kind-specific. rf2-ge6uj ISSUE 3 — the
+     ;; `:transition` row carries NO extra detail body: the prominent
+     ;; header verb (`<before> → <after>`) is the focal point and the
+     ;; prior repetitive `state … / event …` lines are gone.
      (case kind
        :action     (cascade-row-action-outcome-details row)
-       :transition (cascade-row-transition-details row)
        nil)]))
 
 (defn- machine-cascade-view
@@ -2706,8 +2738,18 @@
   actions render their data-write + fx attribution + source code
   body."
   [{:keys [cascade] :as _machine-row} event-id]
+  ;; rf2-ge6uj ISSUE 2 — read the registration meta under the `:event`
+  ;; kind, NOT a (non-existent) `:machine` kind. A machine is registered
+  ;; as a `reg-event-fx` carrying `:rf/machine? true` + the stamped spec
+  ;; under `:rf/machine` (with `:rf.machine/handler-source` +
+  ;; `:rf.machine/source-coords`, rf2-ypu5i / rf2-8bp3). The prior
+  ;; `:machine` lookup resolved nil, so `cascade-row-source-form` /
+  ;; `cascade-row-coord` saw no spec → every exit / entry action + guard
+  ;; row rendered the `<source not yet captured>` placeholder. Reading
+  ;; under `:event` surfaces the spec so the interleaved source code +
+  ;; click-to-source coords resolve.
   (let [machine-meta (when (some? event-id)
-                       (try (rf/handler-meta :machine event-id)
+                       (try (rf/handler-meta :event event-id)
                             (catch :default _ nil)))]
     [:div {:data-testid "rf-xray-epoch-handler-machine"}
      (machine-cascade-view machine-meta (or cascade []))]))
@@ -2782,12 +2824,27 @@
   rf2-ehd8v / Mike pair-debug 2026-05-26 — the verb itself IS the
   goto-source affordance; the legacy SOURCE sub-header that
   carried the file:line + [open] chrome is gone (handler-source-
-  block now leads with the code body directly)."
+  block now leads with the code body directly).
+
+  rf2-ge6uj ISSUE 1 — the EVENT HANDLER glyph was MISSING for machine
+  events. A machine is registered as an ordinary `:event` handler
+  carrying `:rf/machine? true` + the top-level `reg-machine` call-site
+  `:file` / `:line` (Spec 005 §Querying machines). There is NO
+  `:machine` registrar kind (`registrar/kinds` is `:event :sub :fx …
+  :machine-guard :machine-action`), so the prior `(if machine? :machine
+  :event)` lookup resolved nil for machine events → `coord` nil →
+  `coord-link` painted the plain (glyph-less) span. Reading the meta
+  under `:event` for BOTH flavours surfaces the call-site coord, so the
+  machine EVENT HANDLER carries the same `↗` glyph a plain event does.
+  (Verified machine-specific: a plain-event EVENT HANDLER already
+  resolved its coord under `:event` and had the glyph.)"
   [flavour event-id]
-  (let [machine? (= :reg-machine flavour)
-        meta     (when (some? event-id)
-                   (try (rf/handler-meta
-                          (if machine? :machine :event) event-id)
+  (let [meta     (when (some? event-id)
+                   ;; Machine + plain event handlers BOTH live under the
+                   ;; `:event` kind (the machine is a `reg-event-fx` with
+                   ;; `:rf/machine? true`); the call-site coord rides the
+                   ;; top-level `:file` / `:line` for both.
+                   (try (rf/handler-meta :event event-id)
                         (catch :default _ nil)))
         coord    (coord-from-handler-meta meta)
         label    (proj/handler-flavour-label flavour)]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -516,39 +516,50 @@
 
 ;; ---- rf2-u69j7 — machine cascade (time-ordered) -----------------------
 
-(deftest machine-cascade-rows-preserves-substrate-trace-order-test
-  (testing "rf2-u69j7 — `machine-cascade-rows` returns rows in the
-            SAME ORDER the substrate emitted them in the trace
-            buffer. Order is the cascade's narrative; no re-sort,
-            no per-category re-grouping."
-    (let [;; The substrate emits in cascade order: guards → exit
-          ;; actions → transition → entry actions → always →
-          ;; after-action. We mirror that shape here.
+(deftest machine-cascade-rows-canonical-phase-order-test
+  (testing "rf2-tjqd8 — `machine-cascade-rows` returns rows in CANONICAL
+            phase order (guard → exit → TRANSITION → entry → always →
+            after-action → timer), with a STABLE sort that preserves
+            intra-phase emit order. The substrate emits the
+            :rf.machine/transition LAST, so the panel re-sorts it ahead
+            of the entry/always actions."
+    (let [;; Emit order: guard, exit, transition-phase action, entry,
+          ;; always, transition-LAST, after-action, timer. Two entry
+          ;; actions exercise intra-phase stability.
           evs [(machine-guard-ev :ready? :pass)
                (machine-action-ev :clear-buffer :exit :ok)
                (machine-action-ev :open-socket :transition :ok)
+               (machine-action-ev :arm-heartbeat :entry :ok)
+               (machine-action-ev :seed-cache :entry :ok)
+               (machine-action-ev :pulse :always :ok)
                (machine-transition-ev :ws/conn [:idle] [:connecting]
                                        [:ws/start] 1)
-               (machine-action-ev :arm-heartbeat :entry :ok)
-               (machine-action-ev :pulse :always :ok)
                (machine-timer-cancel-ev :ws/conn [:idle] 500 :on-exit)]
           cascade (proj/machine-cascade-rows evs)]
-      (is (= 7 (count cascade))
+      (is (= 8 (count cascade))
           "one cascade row per substrate emit")
-      (is (= [:guard :action :action :transition :action :action :timer]
+      ;; Canonical: guard(0) exit(1) transition-phase-action(2) +
+      ;; transition-kind(2) [stable: action emitted first] entry(3) ×2
+      ;; always(4) timer(6).
+      (is (= [:guard :action :action :transition :action :action :action :timer]
              (mapv :kind cascade))
-          "rows mirror substrate insertion order — NOT re-sorted by category")
-      (is (= [1 2 3 4 5 6 7] (mapv :step cascade))
-          ":step is contiguous 1..N over the cascade")
-      (is (= [0 1 2 3 4 5 6] (mapv :trace-index cascade))
-          ":trace-index is the input-order index")
-      (is (= [nil :exit :transition nil :entry :always nil]
+          "rf2-tjqd8 — rows in canonical (kind,phase) rank order")
+      (is (= [nil :exit :transition nil :entry :entry :always nil]
              (mapv :phase cascade))
-          "phase is only stamped on :action rows (substrate contract)"))))
+          "the TRANSITION (nil phase) lands between transition-phase and entry actions")
+      (is (= [:ready? :clear-buffer :open-socket nil :arm-heartbeat :seed-cache :pulse nil]
+             (mapv #(or (:guard-id %) (:action-id %)) cascade))
+          "intra-phase emit order preserved (arm-heartbeat before seed-cache)")
+      (is (= [1 2 3 4 5 6 7 8] (mapv :step cascade))
+          ":step renumbered 1..N over the FINAL canonical order"))))
 
 (deftest machine-cascade-row-fields-test
-  (testing "rf2-u69j7 — each cascade row exposes the substrate-canonical
-            slots the view layer consumes"
+  (testing "rf2-u69j7 / rf2-tjqd8 — each cascade row exposes the
+            substrate-canonical slots the view layer consumes; rows are
+            CANONICALLY ORDERED (guard → transition → entry-action →
+            timer), not in raw emit order. The substrate emits the
+            :rf.machine/transition LAST; the panel re-sorts the ENTRY
+            action AFTER the transition."
     (let [g (machine-guard-ev :form-valid? :fail)
           a (ev :rf.machine :rf.machine/action-ran
                 {:action-id :open-socket
@@ -561,24 +572,20 @@
                                     {:state [:active]   :data {:n 1}}
                                     [:ws/start] 0)
           tm (machine-timer-cancel-ev :ws/conn [:idle] 250 :on-supersede)
+          ;; Emit order: guard, ENTRY action, transition, timer. The
+          ;; canonical sort moves the entry action AFTER the transition.
           rows (proj/machine-cascade-rows [g a t tm])]
+      (is (= [:guard :transition :action :timer] (mapv :kind rows))
+          "rf2-tjqd8 — canonical order: guard → TRANSITION → entry action → timer")
+      (is (= [1 2 3 4] (mapv :step rows))
+          ":step renumbered 1..N over the canonical order")
       ;; Guard row
       (let [r (nth rows 0)]
         (is (= :guard (:kind r)))
         (is (= :form-valid? (:guard-id r)))
         (is (= :fail (:outcome r))))
-      ;; Action row
+      ;; Transition row — now BEFORE the entry action (rf2-tjqd8)
       (let [r (nth rows 1)]
-        (is (= :action (:kind r)))
-        (is (= :open-socket (:action-id r)))
-        (is (= :entry (:phase r)))
-        (is (false? (:threw? r)))
-        (is (= 1 (count (:fx r)))
-            "per-action fx attribution is hoisted onto the row")
-        (is (= {:n 1} (:data-write r))
-            "per-action data delta is hoisted onto the row"))
-      ;; Transition row
-      (let [r (nth rows 2)]
         (is (= :transition (:kind r)))
         (is (= :ws/conn (:machine-id r)))
         (is (= [:idle]   (:from-state r))
@@ -588,6 +595,18 @@
         (is (= {:n 0} (:data-before r)))
         (is (= {:n 1} (:data-after r)))
         (is (= [:ws/start] (:event r))))
+      ;; Entry action row — now AFTER the transition (rf2-tjqd8)
+      (let [r (nth rows 2)]
+        (is (= :action (:kind r)))
+        (is (= :open-socket (:action-id r)))
+        (is (= :entry (:phase r)))
+        (is (false? (:threw? r)))
+        (is (= 1 (count (:fx r)))
+            "per-action fx attribution is hoisted onto the row")
+        (is (= {:n 1} (:data-write r))
+            "per-action data delta (outcome :data) is hoisted onto the row")
+        (is (= {} (:data-before r))
+            "rf2-5hjb5 — input :data hoisted as the diff pre-image"))
       ;; Timer row
       (let [r (nth rows 3)]
         (is (= :timer (:kind r)))
@@ -633,8 +652,10 @@
         "no row carries a duration → nil")))
 
 (deftest project-machine-populates-cascade-slot-test
-  (testing "rf2-u69j7 — `(handler-row …)` now populates `:machine
-            :cascade` with the time-ordered cascade view consumes"
+  (testing "rf2-u69j7 / rf2-tjqd8 — `(handler-row …)` populates `:machine
+            :cascade` with the CANONICALLY-ORDERED cascade the view
+            consumes. The entry action emits before the transition but
+            renders AFTER it (canonical guard → TRANSITION → entry)."
     (let [evs [(dispatched-ev [:ws/start] :ui nil)
                (machine-guard-ev :ready? :pass)
                (machine-action-ev :open-socket :entry :ok)
@@ -644,8 +665,8 @@
       (is (vector? c) ":cascade is a vector")
       (is (= 3 (count c))
           "one row per substrate emit (guard + action + transition)")
-      (is (= [:guard :action :transition] (mapv :kind c))
-          "cascade kinds reflect substrate insertion order"))))
+      (is (= [:guard :transition :action] (mapv :kind c))
+          "rf2-tjqd8 — canonical order: guard → TRANSITION → entry action"))))
 
 (deftest cascade-row-label-test
   (testing "rf2-u69j7 — `cascade-row-label` renders a human verb per kind"
@@ -656,7 +677,15 @@
                                     :phase :entry})))
     (is (= "timer [:idle] · on-exit"
            (proj/cascade-row-label {:kind :timer :state [:idle]
-                                    :reason :on-exit})))))
+                                    :reason :on-exit})))
+    ;; rf2-ge6uj ISSUE 3 — the transition label is JUST the state change
+    ;; `<from> → <to>`; the redundant "transition" word + machine-name
+    ;; echo are dropped (the KIND pill + cascade context carry those).
+    (is (= "[:idle] → [:connecting]"
+           (proj/cascade-row-label {:kind :transition
+                                    :machine-id :ws/conn
+                                    :from-state [:idle]
+                                    :to-state   [:connecting]})))))
 
 (deftest cascade-row-source-key-test
   (testing "rf2-u69j7 — `cascade-row-source-key` returns the spec-path

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1238,11 +1238,48 @@
       (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-fx-1-0"))
           "first emitted fx-id is rendered as a chip"))))
 
+(deftest machine-handler-cascade-action-data-diff-test
+  (testing "rf2-5hjb5 — an `:action` row that returned a `:data` write
+            renders the DATA Δ slot (the action's returned data, diffed
+            against its input data via the edn-inspector). The slot is
+            present whenever `:data-write` is present, carrying both the
+            mutating-action and no-op-action cases."
+    (let [;; A mutating entry action: input {:opened-count 0} →
+          ;; outcome {:opened-count 1}.
+          mutating {:step :handler :badge :HANDLER :step-number 3
+                    :flavour :reg-machine :event-id :door/main
+                    :db-diff [] :fx []
+                    :machine {:cascade [{:kind :action :step 1
+                                         :action-id :count-open
+                                         :phase :entry
+                                         :data-before {:opened-count 0}
+                                         :data-write  {:opened-count 1}}]
+                              :transition nil :guards [] :lifecycle [] :timers []}}
+          tree-m (view/render-handler-step mutating)]
+      (is (some? (th/find-by-testid tree-m "rf-xray-epoch-machine-cascade-data-write-1"))
+          "DATA Δ slot renders for a data-mutating action")
+      (is (some? (th/find-by-testid tree-m "rf-xray-epoch-machine-cascade-outcome-1"))
+          "the action outcome-details block is present"))
+    ;; A no-op exit action whose :data is unchanged still surfaces the
+    ;; slot (the inspector renders the value with no delta).
+    (let [noop {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :door/main
+                :db-diff [] :fx []
+                :machine {:cascade [{:kind :action :step 1
+                                     :action-id :clear-hold
+                                     :phase :exit
+                                     :data-before {:held-open? false}
+                                     :data-write  {:held-open? false}}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree-n (view/render-handler-step noop)]
+      (is (some? (th/find-by-testid tree-n "rf-xray-epoch-machine-cascade-data-write-1"))
+          "DATA Δ slot renders even for a no-op action (no delta shown)"))))
+
 (deftest machine-handler-cascade-transition-row-renders-states-test
-  (testing "rf2-u69j7 — `:transition` rows render the `from → to`
-            state-vector chrome alongside `event` + `microsteps` so
-            the operator reads the state change at the row's vertical
-            position."
+  (testing "rf2-ge6uj ISSUE 3 — the `:transition` row collapses to ONE
+            prominent row: the verb-link carries `<from> → <to>` as the
+            focal point; the prior repetitive `transition` detail block
+            (`state <from> → <to>` line + echoed `event [...]`) is GONE."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :ws/start
                 :db-diff [] :fx []
@@ -1257,10 +1294,16 @@
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-1"))
-          "transition detail block renders")
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-from-to-1"))
-          "from → to state chrome renders"))))
+      ;; The prominent verb-link IS the state change (the focal point).
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-verb-link-1"))
+          "the prominent transition verb-link renders the state change")
+      ;; The repetitive detail block is REMOVED (rf2-ge6uj ISSUE 3).
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-1"))
+          "the redundant transition detail block is gone")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-from-to-1"))
+          "the redundant `state from → to` line is gone")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-trigger-1"))
+          "the redundant echoed `event [...]` line is gone"))))
 
 ;; ---- rf2-wwc3j — inline-fn / transition source-body rendering ------------
 


### PR DESCRIPTION
Three tightly-coupled fixes on the Xray Epoch machine-cascade rendering (the rf2-u69j7 surface). One PR per the beads' own notes.

## rf2-tjqd8 — canonical phase order
The substrate emits the `:rf.machine/transition` summary LAST (live emit order is exit → entry → transition), so the TRANSITION rendered AFTER the entry action — mis-reading the statechart. `machine-cascade-rows` now RE-SORTS rows panel-side into canonical `(kind, phase)` order:

```
guard → exit → TRANSITION → entry → always → after-action → timer
```

via a STABLE sort keyed by `[cascade-row-rank :trace-index]` — intra-phase emit order preserved; `:step` renumbered over the final order. `enrich-cascade-rows` still runs on trace-ordered rows (its surrounding-transition resolution is emit-order-sensitive) BEFORE the sort. Panel-side presentation re-sort only — the substrate trace order is untouched (the alternative, reordering the substrate emit, was rejected: it would change trace order for every consumer).

## rf2-ge6uj — 3 rendering issues
1. **EVENT HANDLER glyph missing for machines** — a machine is registered under the `:event` registrar kind (carrying `:rf/machine? true` + the `reg-machine` call-site `:file`/`:line`). There is NO `:machine` registrar kind, so the prior `(rf/handler-meta :machine event-id)` resolved nil → `coord-link` painted the glyph-less plain span. Reading under `:event` surfaces the coord → the machine EVENT HANDLER carries the same `↗` glyph. **Machine-specific vs general finding:** a PLAIN-event EVENT HANDLER already resolved its coord under `:event` and HAD the glyph; only the machine branch (the bogus `:machine` kind) was broken.
2. **No source on exit/entry/guard rows** — SAME root cause. `machine-block` read the spec via the non-existent `:machine` kind, so `cascade-row-source-form` saw no spec → every action/guard rendered `<source not yet captured>`. Reading under `:event`'s `:rf/machine` slot surfaces the stamped `:rf.machine/handler-source` + `:rf.machine/source-coords` (rf2-ypu5i / rf2-8bp3), so named-handler source + click-to-source coords resolve. (Data was always captured; the lookup kind was wrong.)
3. **Repetitive transition zone collapsed to ONE prominent row** — `[TRANSITION badge] <before → after>` as the focal verb (larger/bolder/magenta, click-to-source onto the transition map). Dropped the redundant "transition" word, the machine-name echo, and the repeated `state … / event …` detail block. The transition MAP literal still renders as the source body (rf2-wwc3j delight shape — not repetitive).

## rf2-5hjb5 — action :data via edn-inspector + DIFF
The action DATA Δ slot now renders the returned `:data` through `ei/edn-inspector` in DIFF mode, reusing the App-db panel's `{:before <prior>}` posture. The pre-image is `:data-before` (lifted off the `:input {:data …}` snapshot in `action-cascade-row`). A data-mutating action (entry `:count-open`: `{:opened-count 0}` → `{:opened-count 1}`) shows its delta inline; a no-op action (exit `:clear-hold`, unchanged) shows no delta.

## xray spec
`tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1.5 updated for: the canonical ordering contract, the `:event`-kind lookup correction (both glyph + source), the collapsed transition row, and the inspector data-diff.

## Quality gates
- `npm run test:cljs` — 5192 tests, 17700 assertions, 0 failures (updated the 16 cascade tests that asserted the old raw-emit order / repetitive transition block; added rf2-5hjb5 data-diff + rf2-tjqd8 canonical-order coverage).
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures, 13 matrix rows.
- `npm run test:bundle-isolation` — PASS (no leak; 35 internal sentinels absent).
- clj-kondo on changed files — 0 errors, 0 new warnings (net -1: removed an orphaned style def).

Test-free testbed-verified surface; Mike verifies live on machine-epochs / 8033.

Do NOT merge.