### PR TITLE
feat(governance): Xray public surface → real :cljs-only manifest rows (off the allowlist) (rf2-jhn46)

### DIFF
--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -19,11 +19,25 @@
     entire public surface IS the documented adapter API (spec/API.md
     §UIx/Helix adapter), so BOTH directions are checked (a var added
     without a row, or a row with no live var, → RED).
-  - `day8.re-frame2-xray.mount` — curated subset: spec/API.md tiers the
-    mount surface `internal-public` with the host-embed machinery
-    \"otherwise unrowed-internal\", so only the rowed reads are verified to
-    still resolve (direction 1); the surface is not held to full
-    completeness.
+  - The Xray public surface (rf2-jhn46) — curated subsets (direction 1
+    only). spec/API.md tiers the Xray surfaces `internal-public` (the
+    `mount` shell lifecycle, the `panels` `mount-<panel>!` family, the
+    panel `Panel` reg-views) and `tooling` (the `config` published
+    constants, the `open-in-editor` chip, the `runtime` Xray↔MCP read
+    seam), with the rest \"otherwise unrowed-internal\". So only the rowed
+    vars are verified to still resolve (a var renamed / removed under a
+    rowed name → RED); the surfaces are NOT held to full completeness.
+    Covered namespaces:
+      - `day8.re-frame2-xray.mount` — `mounted?` read.
+      - `day8.re-frame2-xray.panels` — the `mount-<panel>!` aggregators.
+      - `day8.re-frame2-xray.panels.{epoch-panel,app-db-diff,reactive-panel,
+        trace,machine-inspector,routing}` — the six Dynamic `Panel`s.
+      - `day8.re-frame2-xray.static.{flows,interceptors,routes,schemas}.panel`
+        — the four Static `Panel`s.
+      - `day8.re-frame2-xray.config` — the published layout-host constants.
+      - `day8.re-frame2-xray.open-in-editor` — the editor-URI chip.
+      - `day8.re-frame2-xray.runtime` — the discovery sentinel + safe-egress
+        entry points.
 
   The pair-MCP server (`re-frame2-pair-mcp.server`) is the third
   CLJS-only surface the keystone names. It compiles under the pair-MCP
@@ -44,7 +58,21 @@
             [re-frame.adapter.reagent]
             [re-frame.adapter.uix]
             [re-frame.adapter.helix]
-            [day8.re-frame2-xray.mount]))
+            [day8.re-frame2-xray.mount]
+            [day8.re-frame2-xray.panels]
+            [day8.re-frame2-xray.panels.epoch-panel]
+            [day8.re-frame2-xray.panels.app-db-diff]
+            [day8.re-frame2-xray.panels.reactive-panel]
+            [day8.re-frame2-xray.panels.trace]
+            [day8.re-frame2-xray.panels.machine-inspector]
+            [day8.re-frame2-xray.panels.routing]
+            [day8.re-frame2-xray.static.flows.panel]
+            [day8.re-frame2-xray.static.interceptors.panel]
+            [day8.re-frame2-xray.static.routes.panel]
+            [day8.re-frame2-xray.static.schemas.panel]
+            [day8.re-frame2-xray.config]
+            [day8.re-frame2-xray.open-in-editor]
+            [day8.re-frame2-xray.runtime]))
 
 ;; ---------------------------------------------------------------------------
 ;; The live CLJS public surface, captured at compile time.
@@ -56,7 +84,22 @@
   {"re-frame.adapter.reagent"  (emit-ns-publics re-frame.adapter.reagent)
    "re-frame.adapter.uix"      (emit-ns-publics re-frame.adapter.uix)
    "re-frame.adapter.helix"    (emit-ns-publics re-frame.adapter.helix)
-   "day8.re-frame2-xray.mount" (emit-ns-publics day8.re-frame2-xray.mount)})
+   "day8.re-frame2-xray.mount" (emit-ns-publics day8.re-frame2-xray.mount)
+   ;; The Xray public surface (rf2-jhn46) — curated subsets (direction 1).
+   "day8.re-frame2-xray.panels"                      (emit-ns-publics day8.re-frame2-xray.panels)
+   "day8.re-frame2-xray.panels.epoch-panel"          (emit-ns-publics day8.re-frame2-xray.panels.epoch-panel)
+   "day8.re-frame2-xray.panels.app-db-diff"          (emit-ns-publics day8.re-frame2-xray.panels.app-db-diff)
+   "day8.re-frame2-xray.panels.reactive-panel"       (emit-ns-publics day8.re-frame2-xray.panels.reactive-panel)
+   "day8.re-frame2-xray.panels.trace"                (emit-ns-publics day8.re-frame2-xray.panels.trace)
+   "day8.re-frame2-xray.panels.machine-inspector"    (emit-ns-publics day8.re-frame2-xray.panels.machine-inspector)
+   "day8.re-frame2-xray.panels.routing"              (emit-ns-publics day8.re-frame2-xray.panels.routing)
+   "day8.re-frame2-xray.static.flows.panel"          (emit-ns-publics day8.re-frame2-xray.static.flows.panel)
+   "day8.re-frame2-xray.static.interceptors.panel"   (emit-ns-publics day8.re-frame2-xray.static.interceptors.panel)
+   "day8.re-frame2-xray.static.routes.panel"         (emit-ns-publics day8.re-frame2-xray.static.routes.panel)
+   "day8.re-frame2-xray.static.schemas.panel"        (emit-ns-publics day8.re-frame2-xray.static.schemas.panel)
+   "day8.re-frame2-xray.config"                      (emit-ns-publics day8.re-frame2-xray.config)
+   "day8.re-frame2-xray.open-in-editor"              (emit-ns-publics day8.re-frame2-xray.open-in-editor)
+   "day8.re-frame2-xray.runtime"                     (emit-ns-publics day8.re-frame2-xray.runtime)})
 
 (def fully-rowed
   "Namespaces whose ENTIRE public surface must be rowed (direction 2).

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -80,10 +80,78 @@
   {:namespace "re-frame.adapter.helix" :var "wrap-view"           :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.helix" :var "flush-views!"        :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.helix" :var "set-hiccup-emitter!" :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
-  ;; --- Xray mount family (day8/re-frame2-xray) — host-embed surface,
-  ;;     internal-public per spec/API.md §Tiering of cross-tool surfaces.
-  ;;     Curated row (direction-1 only): probe verifies it still resolves. ---
-  {:namespace "day8.re-frame2-xray.mount" :var "mounted?" :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}]
+  ;; --- Xray (day8/re-frame2-xray) — the live public surface (rf2-jhn46).
+  ;;     Migrated off the `:xray-spec-known-unmanifested` allowlist into real
+  ;;     :cljs-only rows so the gkp0t Xray-spec projection check resolves them
+  ;;     to manifest rows and the 2mtte CLJS probe runtime-verifies them.
+  ;;     ALL are curated subsets (direction-1 only — the probe verifies each
+  ;;     rowed var still resolves; rename / removal → RED). The mount family is
+  ;;     `internal-public` per spec/API.md §Tiering of cross-tool surfaces (the
+  ;;     standing classification); the published constants + the Xray↔MCP read
+  ;;     seam + the editor-chip are `tooling` (dev/inspection surfaces consumed
+  ;;     by story-mode chrome, docs generators, and the pair-MCP servers — not
+  ;;     application logic). Owner "tools/xray"; status "post-v1 lib". ---
+  ;;
+  ;; day8.re-frame2-xray.mount — the shell lifecycle (only `mounted?` rowed;
+  ;; the open/close/teardown machinery is "otherwise unrowed-internal").
+  {:namespace "day8.re-frame2-xray.mount" :var "mounted?" :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  ;; day8.re-frame2-xray.panels — the `mount-<panel>!` aggregator family
+  ;; (007-UX-IA §Mountable panel contract). internal-public — a host-embed
+  ;; surface; an app never calls these. (`mount-issues-ribbon!` +
+  ;; `mount-inline-panel!` are REMOVED surfaces the spec names in removal
+  ;; prose — they stay on the allowlist, not rowed; `mount-views!` was
+  ;; renamed → `mount-reactive-panel!`.)
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-app-db-diff!"                    :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-cancellation-cascade-popover!"   :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-cancellation-cascade-side-panel!" :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-epoch-panel!"                    :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-event-spine!"                    :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-machine-inspector!"             :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-managed-fx!"                     :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-reactive-panel!"                 :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-routing!"                        :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-segment-inspector!"             :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-shell!"                          :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-trace!"                          :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  ;; The six Dynamic-mode canonical Panel reg-views + the four Static-mode
+  ;; Panel reg-views (spec/API.md §Panel reg-views + §Static-mode Panel
+  ;; reg-views). Each panel namespace exports a single public `Panel` — the
+  ;; bare-var symbol the Xray-spec projection check resolves. internal-public:
+  ;; the leaves the shell composes; NOT a host-facing single-panel embed
+  ;; surface (hosts embed the full shell per 008-Embedding-Contract).
+  {:namespace "day8.re-frame2-xray.panels.app-db-diff"          :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.epoch-panel"          :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.machine-inspector"    :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.reactive-panel"       :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.routing"              :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.trace"                :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.static.flows.panel"          :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.static.interceptors.panel"   :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.static.routes.panel"         :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.static.schemas.panel"        :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  ;; day8.re-frame2-xray.config — the published layout-host constants
+  ;; (spec/API.md §Published layout-host constants). Named CLJS vars so
+  ;; tooling (story-mode chrome, docs generators) refers to the exact
+  ;; spelling without forking the string — `tooling`. (Curated subset: the
+  ;; per-key setters + the settings round-trip are otherwise unrowed-internal.)
+  {:namespace "day8.re-frame2-xray.config" :var "default-accent"                :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config" :var "default-accent-css-var"        :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config" :var "default-layout-host-css-var"   :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config" :var "default-layout-host-selector"  :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config" :var "default-layout-host-snippet"   :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config" :var "default-layout-host-width"     :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  ;; day8.re-frame2-xray.open-in-editor — the editor-URI mirror chip
+  ;; (spec/API.md §Open in editor). A documented panel-author surface — `tooling`.
+  {:namespace "day8.re-frame2-xray.open-in-editor" :var "open-chip" :kind :fn :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  ;; day8.re-frame2-xray.runtime — the Xray ↔ MCP read-and-mutate seam
+  ;; (spec/API.md §Runtime accessor surface). The discovery sentinel
+  ;; (`session-id`) + the two named safe-egress entry points. Public-for-
+  ;; tools, not public-for-host-apps — `tooling`. (Curated subset: the
+  ;; accessor band fns are documented at their tool-name rows in the Xray
+  ;; spec, not the manifest; only the seam's named entry points are rowed.)
+  {:namespace "day8.re-frame2-xray.runtime" :var "egress-record" :kind :fn  :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.runtime" :var "egress-value"  :kind :fn  :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.runtime" :var "session-id"    :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}]
 
  ;; --------------------------------------------------------------------------
  ;; API.md var-rows that are KNOWINGLY absent from the manifest. The
@@ -125,34 +193,20 @@
    "mount-fn-for"            ; re-frame.story.ui.xray-embed sub-ns
    "popout-full-shell!"}     ; re-frame.story.ui.xray-embed sub-ns
 
- ;; tools/xray/spec/API.md public-var references the manifest does not yet
- ;; carry. REPORTED, not fixed (rf2-gkp0t: the Xray spec file is owned by a
- ;; concurrent worker — this check surfaces the drift; the manifest's Xray
- ;; coverage is presently the single `mounted?` read). The whole live Xray
- ;; panel + mount surface is enumerated here so the check is GREEN today but
- ;; goes RED the moment a NEW Xray panel/mount symbol appears in the spec or
- ;; an enumerated one is renamed — the same allowlist discipline as above.
- ;; A manifest-expansion follow-on should migrate these into :cljs-only Xray
- ;; rows and delete them here.
+ ;; tools/xray/spec/API.md public-var references the manifest does not carry.
+ ;; rf2-jhn46 MIGRATED the live Xray public surface (the `Panel` exports, the
+ ;; `mount-<panel>!` aggregator family, the `config` published constants, the
+ ;; `open-in-editor` chip, and the `runtime` discovery-sentinel + safe-egress
+ ;; entry points) into real `:cljs-only` rows above — they now resolve to
+ ;; manifest rows AND are runtime-verified by the 2mtte CLJS probe. The only
+ ;; entries that remain are two `mount-<panel>!` names the Xray spec mentions
+ ;; ONLY in REMOVAL prose: the underlying defns were deleted, so there is no
+ ;; live var to introspect and no honest manifest row — exactly the
+ ;; knowingly-unmanifested case this allowlist exists for. The check still
+ ;; goes RED if any OTHER Xray panel/mount symbol enters the spec unrowed.
  :xray-spec-known-unmanifested
- #{;; Dynamic-mode canonical six Panel reg-views (day8.re-frame2-xray.panels.*)
-   "Panel"                   ; the bare `Panel` export shared across every panel namespace
-   ;; mount-*! panel-host aggregator family (007-UX-IA §Mountable panel contract)
-   "mount-app-db-diff!" "mount-epoch-panel!" "mount-machine-inspector!"
-   "mount-routing!" "mount-trace!" "mount-views!" "mount-event-spine!"
-   "mount-segment-inspector!" "mount-managed-fx!"
-   "mount-cancellation-cascade-popover!" "mount-cancellation-cascade-side-panel!"
-   "mount-shell!" "mount-issues-ribbon!" "mount-inline-panel!"
-   ;; day8.re-frame2-xray.config — published layout-host constants (§Published
-   ;; layout-host constants); named CLJS vars so tooling refers to the exact spelling.
-   "default-layout-host-selector" "default-layout-host-css-var"
-   "default-layout-host-width" "default-accent-css-var" "default-accent"
-   "default-layout-host-snippet"
-   ;; day8.re-frame2-xray.open-in-editor — the editor-URI mirror chip.
-   "open-chip"
-   ;; day8.re-frame2-xray.runtime — the Xray ↔ MCP read seam discovery sentinel
-   ;; + safe-egress entry points (§Runtime accessor surface).
-   "session-id" "egress-value" "egress-record"}
+ #{"mount-issues-ribbon!"    ; spec/API.md §Panel reg-views — REMOVED with the Issues tab (rf2-gbz39, Option (c)); named in removal prose only
+   "mount-inline-panel!"}    ; spec/API.md §What this doesn't expose — REMOVED (rf2-sbfb7, "A — delete both"); named in removal prose only
 
  ;; skills/ (excl. re-frame-migration) call-position `(rf/<var>` references
  ;; the manifest does not carry. The checked skills teach against the LIVE

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 438,
+ :var-count 470,
  :tier-vocab
  [:front-porch
   :advanced
@@ -16,7 +16,39 @@
   :internal-public
   :deprecated]}
  :vars
- [{:namespace "day8.re-frame2-xray.mount", :var "mounted?", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+ [{:namespace "day8.re-frame2-xray.config", :var "default-accent", :tier :tooling, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config", :var "default-accent-css-var", :tier :tooling, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config", :var "default-layout-host-css-var", :tier :tooling, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config", :var "default-layout-host-selector", :tier :tooling, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config", :var "default-layout-host-snippet", :tier :tooling, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.config", :var "default-layout-host-width", :tier :tooling, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.mount", :var "mounted?", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.open-in-editor", :var "open-chip", :tier :tooling, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-app-db-diff!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-cancellation-cascade-popover!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-cancellation-cascade-side-panel!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-epoch-panel!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-event-spine!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-machine-inspector!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-managed-fx!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-reactive-panel!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-routing!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-segment-inspector!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-shell!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-trace!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.app-db-diff", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.epoch-panel", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.machine-inspector", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.reactive-panel", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.routing", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.trace", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.runtime", :var "egress-record", :tier :tooling, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.runtime", :var "egress-value", :tier :tooling, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.runtime", :var "session-id", :tier :tooling, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.static.flows.panel", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.static.interceptors.panel", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.static.routes.panel", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.static.schemas.panel", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.helix", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.helix", :var "flush-views!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.helix", :var "frame-provider", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Follow-on from the merged rf2-gkp0t (#2780); builds on the rf2-2mtte CLJS probe and the rf2-3nbl5.2 keystone.

Migrates the live Xray public surface off the gkp0t `:xray-spec-known-unmanifested` allowlist into REAL `:cljs-only` rows in `spec/api-manifest-metadata.edn`, so:
1. the rf2-gkp0t Xray-spec projection check resolves them to manifest rows instead of riding the allowlist, and
2. the rf2-2mtte CLJS probe runtime-verifies them (`:runtime-verified? true`).

## Rows added (32 — owner `tools/xray`, status `post-v1 lib`, all curated subsets / direction-1)

Tiers per the spec/API.md closed Tier taxonomy + the standing cross-tool classification (§Tiering of cross-tool surfaces):

- **internal-public** (host-embed surface; an app never calls these):
  - `day8.re-frame2-xray.panels` — the `mount-<panel>!` aggregator family (12): `mount-app-db-diff!` · `mount-epoch-panel!` · `mount-trace!` · `mount-machine-inspector!` · `mount-routing!` · `mount-reactive-panel!` · `mount-event-spine!` · `mount-segment-inspector!` · `mount-managed-fx!` · `mount-cancellation-cascade-popover!` · `mount-cancellation-cascade-side-panel!` · `mount-shell!`.
  - The six Dynamic `Panel` reg-views (`panels.{epoch-panel,app-db-diff,reactive-panel,trace,machine-inspector,routing}`) + the four Static `Panel` reg-views (`static.{flows,interceptors,routes,schemas}.panel`).
- **tooling** (dev/inspection surfaces — story-mode chrome, docs generators, pair-MCP):
  - `config` published layout-host constants (6): `default-layout-host-selector` · `default-layout-host-css-var` · `default-layout-host-width` · `default-accent-css-var` · `default-accent` · `default-layout-host-snippet`.
  - `open-in-editor/open-chip`.
  - `runtime` discovery sentinel + safe-egress seam: `session-id` · `egress-value` · `egress-record`.

The pre-existing `day8.re-frame2-xray.mount/mounted?` row is retained.

## Allowlist before → after

- **Before (24 names):** `Panel`; the full `mount-*!` list (incl. `mount-views!`, `mount-issues-ribbon!`, `mount-inline-panel!`); the 6 config constants; `open-chip`; `session-id`/`egress-value`/`egress-record`.
- **After (2 names):** `mount-issues-ribbon!` (REMOVED with the Issues tab, rf2-gbz39) and `mount-inline-panel!` (REMOVED, rf2-sbfb7) — both named in the Xray spec's REMOVAL prose only, so there is no live var and no honest manifest row. `mount-views!` (renamed → `mount-reactive-panel!`) was dead allowlist cruft and dropped.

## Probe coverage

The rf2-2mtte CLJS probe now `:require`s + `emit-ns-publics`-enumerates the 17 covered Xray namespaces as **curated subsets** (direction-1 only — verify each rowed var still resolves; rename/removal → RED). Not added to `fully-rowed` (the surfaces are intentionally curated subsets, matching the spec's `internal-public`/`tooling` + otherwise-unrowed-internal posture and the existing `mount` precedent).

**Red-on-drift proof** (one new Xray var): temporarily renamed `runtime/egress-value` file-wide → probe went RED with `Rows with NO live public var (removed / renamed in source): - day8.re-frame2-xray.runtime/egress-value`; reverted → GREEN.

## Quality gates

- **gkp0t Xray-spec check** — GREEN: `OK: tools/xray/spec/API.md projection in sync (23 public-var references checked against the manifest).` All 23 refs now resolve to real rows; allowlist shrunk 24→2.
- **2mtte CLJS probe** (`npm run test:cljs`) — GREEN: `Ran 5199 tests containing 17737 assertions. 0 failures, 0 errors.` Covers the new namespaces. Red/green drift proof above.
- **JVM api-manifest `--check`** — GREEN: `OK: spec/api-manifest.edn in sync (470 public vars).` (was ~438).
- **api-md-check** — GREEN: `OK: spec/API.md projection in sync (189 var-rows checked).` (story-spec / skills / doc-guide checks also GREEN.)
- **`npm run test:bundle-isolation`** — PASS: `17 artefact entries; 35 internal sentinels absent; 3 allow-list budgets ok` + uix/helix/reagent-free PASS. The probe's Xray requires are test-only and do NOT leak to production.
- **clj-kondo** — 0 errors on the changed files (probe test + api-manifest src). The 2 warnings in `runtime.cljs` are pre-existing and that file is unchanged.

Surface: `spec/api-manifest-metadata.edn` + the regenerated `spec/api-manifest.edn` + the 2mtte probe test. No edits to `tools/xray` src/spec. Do NOT merge.