### PR TITLE
feat(adapters): add flush-render! (synchronous render flush) to the substrate-adapter protocol (rf2-40a84)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -145,7 +145,13 @@
    :probe-stable-deps-element (fn [] ($ ProbeStableDepsParent))
    :stable-deps-set-tick  stable-deps-set-tick
    :stable-deps-frame     :rf.helix-stable-deps/probe-frame
-   :stable-deps-query     :rf.helix-stable-deps/p})
+   :stable-deps-query     :rf.helix-stable-deps/p
+   ;; rf2-40a84 — flush-render! synchronous-commit proof. Reuses the Probe
+   ;; (reads :refcount-target for its frame, queries :rf.helix-use-subscribe-test/n)
+   ;; under a fresh isolated frame so it can't collide with the use-subscribe
+   ;; cases above.
+   :fr-frame              :rf.helix-flush-render/probe-frame
+   :fr-query              :rf.helix-use-subscribe-test/n})
 
 (deftest use-subscribe-tracks-app-db-changes
   (suite/assert-use-subscribe-tracks-app-db-changes cfg))
@@ -161,6 +167,11 @@
 
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))
+
+;; rf2-40a84 — flush-render! synchronously commits a pending render (the
+;; proof the pair-MCP headless dispatch→render loop depends on).
+(deftest flush-render-synchronously-commits
+  (suite/assert-flush-render-synchronously-commits cfg))
 
 ;; rf2-gizlj — lock the rf2-cmfln 2-arity contract at the spine cleanup
 ;; call site (regression: the 3-arity grace-opts shape sneaking back in

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -12,6 +12,7 @@
   (:require [reagent2.core             :as r]
             [reagent2.ratom            :as ratom]
             [reagent2.dom.client       :as rdc]
+            [reagent2.impl.batching    :as batching]
             [re-frame.substrate.spine   :as spine]
             [re-frame.views            :as views]))
 
@@ -50,7 +51,17 @@
                          :rdc/create-root     (fn [mount-point] (rdc/create-root mount-point))
                          :rdc/render          (fn [root tree] (rdc/render root tree))
                          :rdc/hydrate-root    (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
-                         :rdc/unmount         (fn [root] (rdc/unmount root))}}))
+                         :rdc/unmount         (fn [root] (rdc/unmount root))
+                         ;; rf2-40a84 — synchronous render-flush op. Run `f`
+                         ;; (which may mutate a ratom / dispatch), then
+                         ;; `reagent2.impl.batching/flush!` SYNCHRONOUSLY drains
+                         ;; the rea-queue + forceUpdates every dirty component —
+                         ;; the rewrite's microtask scheduler is bypassed, so
+                         ;; the commit is NOT microtask/rAF-deferred and fires
+                         ;; even in a backgrounded / headless tab. (Distinct
+                         ;; from `reagent2.dom.client/flush-views!`, the
+                         ;; goog.DEBUG-gated act()-composing TEST primitive.)
+                         :rdc/flush-render!   (fn [f] (f) (batching/flush!))}}))
 
 (def set-hiccup-emitter!
   "Install the hiccup → HTML fn used by render-to-string. Last call wins.

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_cljs_test.cljs
@@ -51,8 +51,9 @@
 ;; Adapter map shape (per IMPL-SPEC §2.1 + Spec 006 §CLJS reference)
 ;; ---------------------------------------------------------------------------
 
-(deftest adapter-has-9-canonical-keys
-  (testing "the adapter map carries the 9 substrate-shape keys + :kind discriminator"
+(deftest adapter-has-canonical-keys
+  (testing "the adapter map carries the substrate-shape keys + :kind discriminator
+            (incl. the optional rf2-40a84 :flush-render! slot)"
     (let [k (set (keys reagent-slim/adapter))]
       (is (= #{:kind
               :make-state-container
@@ -63,6 +64,8 @@
               :render
               :render-to-string
               :register-context-provider
+              ;; rf2-40a84 — optional synchronous render-flush contract fn.
+              :flush-render!
               :dispose-adapter!}
              k)
           "every slot named in re-frame.substrate.adapter is present plus :kind")

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -39,7 +39,16 @@
                          :rdc/create-root     (fn [mount-point] (rdc/create-root mount-point))
                          :rdc/render          (fn [root tree] (rdc/render root tree))
                          :rdc/hydrate-root    (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
-                         :rdc/unmount         (fn [root] (rdc/unmount root))}}))
+                         :rdc/unmount         (fn [root] (rdc/unmount root))
+                         ;; rf2-40a84 — synchronous render-flush op. Run `f`
+                         ;; (which may mutate a ratom / dispatch), then
+                         ;; `reagent.core/flush` drains Reagent's render queue
+                         ;; SYNCHRONOUSLY — bypassing the rAF-scheduled
+                         ;; `next-tick` drain — and (on React 19) commits the
+                         ;; forced component re-renders to the DOM via
+                         ;; react-dom/flushSync. NOT rAF-scheduled ⇒ fires even
+                         ;; in a backgrounded / headless tab.
+                         :rdc/flush-render!   (fn [f] (f) (r/flush))}}))
 
 (def set-hiccup-emitter!
   "Install the hiccup → HTML fn used by render-to-string. Last call wins.

--- a/implementation/adapters/reagent/test/re_frame/adapter_flush_render_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_flush_render_dom_cljs_test.cljs
@@ -1,0 +1,88 @@
+(ns re-frame.adapter-flush-render-dom-cljs-test
+  "rf2-40a84 — the Reagent synchronous-commit proof for the substrate-adapter
+  contract fn `flush-render!`.
+
+  WHAT IT PROVES. `(adapter/flush-render! f)` SYNCHRONOUSLY commits the render
+  that `f`'s state change schedules — the rendered DOM reflects the dispatched
+  value by the time `flush-render!` RETURNS, with NO wait for Reagent's
+  `requestAnimationFrame`-scheduled `next-tick` re-render drain. This is the
+  framework capability the re-frame2-pair MCP's headless `dispatch → render →
+  observe-DOM` loop depends on (the rAF drain is throttled to ~never in a
+  backgrounded tab; flushSync-class commits are not — see Spec 006
+  §`flush-render!` + Spec Tool-Pair §Driving the render). The sibling
+  rf2-vk79g dispatch-and-settle op consumes this.
+
+  HOW THE PROOF IS RIGOROUS. After the initial mount commits, we dispatch a
+  state change — under Reagent this only ENQUEUES the dependent component for a
+  re-render on the next rAF/`next-tick` turn, so the committed DOM still shows
+  the OLD value. We then call `(adapter/flush-render! ...)` and assert the DOM
+  shows the NEW value on the very next line: the only thing that could have
+  committed it synchronously is the flush. (`reagent.core/flush` drains the
+  render queue immediately and, on React 19, commits via `react-dom/flushSync`
+  — neither is rAF-scheduled.) The UIx / Helix twins of this proof live in the
+  shared React suite (`assert-flush-render-synchronously-commits`).
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` discovers it;
+  the `:node-test` runner also loads it, where the body gates on `(browser?)`
+  and no-ops cleanly (no DOM)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+(deftest flush-render-synchronously-commits
+  (testing "Reagent — flush-render! synchronously commits a pending render (rf2-40a84)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [frame-kw :rf.reagent-flush-render/probe-frame
+            flush!   (:flush-render! reagent-adapter/adapter)]
+        (is (fn? flush!)
+            "the Reagent adapter map exposes :flush-render! (rf2-40a84 contract slot)")
+        (rf/reg-frame frame-kw {:doc "flush-render! synchronous-commit probe frame"})
+        (rf/reg-event-db ::seed (fn [_ _] {:n 1}))
+        (rf/reg-event-db ::inc  (fn [db _] (update db :n inc)))
+        (rf/dispatch-sync [::seed] {:frame frame-kw})
+        (rf/reg-sub ::n (fn [db _] (:n db)))
+        (rf/reg-view* :rf.reagent-flush-render/probe
+                      (fn probe []
+                        [:div "n=" @(rf/subscribe [::n])]))
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            ;; Initial mount wrapped in flushSync so the first pass commits
+            ;; before render returns (React 19 root.render is otherwise
+            ;; async — mirrors the cross-spec DOM tests' mount shape).
+            (react-dom/flushSync
+              (fn []
+                (rdc/render root [rf/frame-provider {:frame frame-kw}
+                                  [(rf/view :rf.reagent-flush-render/probe)]])))
+            (is (= "n=1" (.-textContent mount-node))
+                "committed DOM shows the seeded value n=1")
+            ;; Dispatch the change WITHOUT a manual flush — under Reagent this
+            ;; only enqueues the dependent component for the next rAF/next-tick
+            ;; re-render, so the committed DOM still reads the OLD value.
+            (rf/dispatch-sync [::inc] {:frame frame-kw})
+            ;; THE PROOF: flush-render! commits the enqueued re-render
+            ;; synchronously. The DOM must reflect n=2 on the next line — no
+            ;; rAF wait, no manual r/flush.
+            (flush!)
+            (is (= "n=2" (.-textContent mount-node))
+                "DOM reflects the dispatched change SYNCHRONOUSLY after
+                 flush-render! returns — no rAF wait (rf2-40a84)")
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))

--- a/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
@@ -36,8 +36,10 @@
         "ns-load does not install the adapter")
     (is (map? reagent-adapter/adapter)
         "the adapter ns exports its spec as the public `adapter` var")
-    (is (= 9 (count (filter fn? (vals reagent-adapter/adapter))))
-        "the exported adapter map carries the full nine-fn contract")
+    (is (= 10 (count (filter fn? (vals reagent-adapter/adapter))))
+        "the exported adapter map carries the full contract — the six required +
+         subscribe-container + register-context-provider + dispose-adapter! +
+         the optional rf2-40a84 flush-render! fn")
     (is (= :rf.adapter/reagent (:kind reagent-adapter/adapter))
         "the adapter map carries its discriminator keyword under :kind")))
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -141,7 +141,13 @@
    :probe-stable-deps-element (fn [] (uix/$ ProbeStableDepsParent))
    :stable-deps-set-tick  stable-deps-set-tick
    :stable-deps-frame     :rf.uix-stable-deps/probe-frame
-   :stable-deps-query     :rf.uix-stable-deps/p})
+   :stable-deps-query     :rf.uix-stable-deps/p
+   ;; rf2-40a84 — flush-render! synchronous-commit proof. Reuses the Probe
+   ;; (reads :refcount-target for its frame, queries :rf.uix-use-subscribe-test/n)
+   ;; under a fresh isolated frame so it can't collide with the use-subscribe
+   ;; cases above.
+   :fr-frame              :rf.uix-flush-render/probe-frame
+   :fr-query              :rf.uix-use-subscribe-test/n})
 
 (deftest use-subscribe-tracks-app-db-changes
   (suite/assert-use-subscribe-tracks-app-db-changes cfg))
@@ -157,6 +163,11 @@
 
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))
+
+;; rf2-40a84 — flush-render! synchronously commits a pending render (the
+;; proof the pair-MCP headless dispatch→render loop depends on).
+(deftest flush-render-synchronously-commits
+  (suite/assert-flush-render-synchronously-commits cfg))
 
 ;; rf2-gizlj — lock the rf2-cmfln 2-arity contract at the spine cleanup
 ;; call site (regression: the 3-arity grace-opts shape sneaking back in

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -10,8 +10,8 @@
     make-state-container, read-container, replace-container!,
     make-derived-value, render, render-to-string
 
-  Optional (2):
-    subscribe-container, register-context-provider
+  Optional (3):
+    subscribe-container, register-context-provider, flush-render!
 
   Lifecycle (1):
     dispose-adapter!
@@ -374,6 +374,36 @@
   [render-tree opts]
   (let [a (require-adapter! 'rf/render-to-string)]
     ((:render-to-string a) render-tree opts)))
+
+(defn flush-render!
+  "Optional. SYNCHRONOUSLY commit the substrate's pending renders to the
+  DOM (per Spec 006 §`flush-render!`). Runs the 1-arity `f` inside the
+  substrate's synchronous-commit path (React `flushSync` for the React-hook
+  substrates; `reagent.core/flush` for the ratom family) so any state change
+  `f` schedules — and any render already pending — is committed before this
+  returns; the 0-arity form flushes already-pending work.
+
+  Why it exists. The reference substrates schedule re-renders through a
+  `requestAnimationFrame`-style tick that fires AFTER an eval'd `dispatch`
+  returns and is throttled to ~never in a backgrounded / unfocused tab.
+  `flush-render!` is NOT rAF-scheduled, so headless tooling (the
+  re-frame2-pair MCP — Spec Tool-Pair) can drive a
+  `dispatch → flush-render! → observe-settled-DOM` loop even when the tab is
+  backgrounded. Distinct from a test-only `act()` flush: this is the
+  production-grade contract surface every adapter implements.
+
+  Optional contract fn — returns nil and is a no-op when the installed
+  adapter ships no `:flush-render!` (the plain-atom / SSR adapters render
+  without a live React commit, so there is nothing to flush). Calling it
+  before `(rf/init! ...)` raises `:rf.error/no-adapter-installed`
+  (rf2-zdfi1) — the optional-fn nil return is reserved for `adapter
+  installed, fn absent`, not for `no adapter installed at all`."
+  ([] (flush-render! (fn [] nil)))
+  ([f]
+   (let [a (require-adapter! 'rf/flush-render!)
+         g (:flush-render! a)]
+     (when g (g f))
+     nil)))
 
 (defn subscribe-container
   "Optional — adapters may omit. Returns nil if the installed adapter

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -34,6 +34,7 @@
   Per Spec 006 §CLJS reference — adapters using this spine remain
   shape-compliant with the 9-fn substrate contract."
   (:require ["react"             :as React]
+            ["react-dom"         :as react-dom]
             ["react-dom/client"  :as react-dom-client]
             [re-frame.disposable :as rf-disposable]
             [re-frame.frame      :as frame]
@@ -746,6 +747,48 @@
      (act f))
    nil))
 
+;; ---- synchronous render flush (rf2-40a84) ---------------------------------
+;;
+;; `flush-render!` is the PRODUCTION-grade synchronous render-commit fn for
+;; the substrate-adapter contract (distinct from `flush-views!`, which is a
+;; test-only `act()` wrapper). It exists because the React-shaped substrates
+;; schedule their re-renders through React's normal lane scheduler, whose
+;; commit lands on a `requestAnimationFrame`-style tick that (a) fires AFTER
+;; an eval'd `dispatch` returns and (b) is throttled to ~never in a
+;; backgrounded / unfocused tab. So tooling that drives the view lifecycle
+;; headless — the re-frame2-pair MCP `dispatch` → observe-the-DOM loop
+;; (rf2-40a84 / consumed by rf2-vk79g's dispatch-and-settle) — cannot rely on
+;; the scheduled commit ever arriving.
+;;
+;; `react-dom/flushSync` runs its callback and SYNCHRONOUSLY flushes every
+;; React update scheduled inside it (and any already-pending work) to the
+;; DOM before returning — it is NOT rAF-scheduled, so it is immune to the
+;; backgrounded-tab throttle and fires even headless. After
+;; `(flush-render! f)` returns, any state change `f` triggered (or any render
+;; already pending) is committed; a caller can then read the settled DOM /
+;; epoch. The 0-arity form flushes already-pending work with an empty
+;; callback.
+;;
+;; This is the React-hook (UIx / Helix) spine impl; the Reagent / reagent-
+;; slim family realises the same contract through `reagent.core/flush` (its
+;; render-queue drain forces the component re-renders synchronously and, on
+;; React 19, commits them via `flushSync`), wired in the ratom adapter.
+
+(defn flush-render!
+  "Synchronously flush pending React renders to the DOM via
+  `react-dom/flushSync` (Spec 006 §`flush-render!`). The 1-arity form runs
+  `f` inside `flushSync` so any state change `f` schedules commits before
+  the call returns; the 0-arity form flushes already-pending work. Unlike
+  `flush-views!` (a test-only `act()` wrapper) this is production-grade and
+  NOT rAF-scheduled, so headless tooling can drive a `dispatch → flush-render!
+  → observe-settled-DOM` loop even in a backgrounded tab (rf2-40a84). Returns
+  nil. No-op-safe when there is nothing pending — `flushSync` with an empty
+  callback is a cheap no-op."
+  ([] (flush-render! (fn [] nil)))
+  ([f]
+   (react-dom/flushSync f)
+   nil))
+
 ;; ---- source-coord wrapper (Spec 006 §Source-coord; rf2-z7f7 / rf2-z9n1) --
 ;;
 ;; Every React-shaped substrate adapter MUST inject
@@ -1129,6 +1172,7 @@
        :use-current-frame          …
        :use-subscribe              …
        :flush-views!               …
+       :flush-render!              …
        :wrap-view                  …
        :clear-warned-non-dom-roots! …}
 
@@ -1317,6 +1361,10 @@
      :use-current-frame           use-current-frame
      :use-subscribe               use-subscribe
      :flush-views!                flush-views!
+     ;; rf2-40a84 — production-grade synchronous render-commit (NOT the
+     ;; test-only act() wrapper above). Wired into the adapter map's
+     ;; :flush-render! contract slot by make-react-adapter.
+     :flush-render!               flush-render!
      :wrap-view                   wrap-view-fn
      :clear-warned-non-dom-roots! clear-warned
      ;; rf2-334d9 — :adapter/after-render impl. Each adapter publishes
@@ -1418,6 +1466,10 @@
                  ;; frame-keyword arg is ignored (frame lives in the
                  ;; Provider's `:value` at render time).
                  :register-context-provider (fn [_frame-keyword] frame-provider)
+                 ;; rf2-40a84 — optional synchronous render-flush contract fn
+                 ;; (react-dom/flushSync). Lets headless tooling commit pending
+                 ;; renders without waiting on React's rAF-scheduled lane.
+                 :flush-render!             (:flush-render! spine-fns)
                  :dispose-adapter!          (:dispose-adapter!          spine-fns)}]
     (substrate-adapter/route-hook! adapter :adapter/current-frame
       adapter-context/function-component-current-frame
@@ -1481,6 +1533,14 @@
                                  walk + `.render`, NOT a bare `.render`)
           :rdc/hydrate-root    — (fn [mount-point tree]) → React root
           :rdc/unmount         — (fn [root]) → unmount the root
+          :rdc/flush-render!   — (fn [f]) → run `f` then SYNCHRONOUSLY commit
+                                 the substrate's pending renders to the DOM
+                                 (rf2-40a84; stock Reagent passes
+                                 `reagent.core/flush`, slim passes its
+                                 `reagent2.*` synchronous flush). NOT rAF-
+                                 scheduled — immune to the backgrounded-tab
+                                 throttle, so headless tooling can drive a
+                                 `dispatch → flush-render! → observe-DOM` loop.
 
   The spine MUST NOT `:require` stock `reagent.*`; the ops above are the
   only path to the substrate's reactive primitive, so each adapter's own
@@ -1500,6 +1560,7 @@
        :render                     …
        :render-to-string           …
        :dispose-adapter!           …
+       :flush-render!              …
        :set-hiccup-emitter!        …
        :active-roots-cell          …
        :emitter-cell               …}
@@ -1521,7 +1582,8 @@
          create-root   :rdc/create-root
          render-root   :rdc/render
          hydrate-root  :rdc/hydrate-root
-         unmount-root  :rdc/unmount} ratom-ops
+         unmount-root  :rdc/unmount
+         flush-render-op :rdc/flush-render!} ratom-ops
         active-roots-cell (make-active-roots-cell)
         emitter-cell      (make-hiccup-emitter-cell)
         make-state-container
@@ -1579,7 +1641,25 @@
                  (catch :default _ nil)))
           (reset! active-roots-cell #{})
           (reset! emitter-cell nil)
-          nil)]
+          nil)
+        ;; rf2-40a84 — production synchronous render-flush. Delegates to the
+        ;; injected `:rdc/flush-render!` op (stock `reagent.core/flush` /
+        ;; slim's `reagent2.*` synchronous flush) so the spine never names a
+        ;; reactive-atom ns (bundle isolation). The op runs `f` then drains
+        ;; the substrate's component-render queue synchronously and (on React
+        ;; 19) commits via `flushSync` — NOT rAF-scheduled, so it fires even
+        ;; in a backgrounded tab. No-op-safe when nothing is pending.
+        flush-render!
+        (fn flush-render!
+          ([] (flush-render! (fn [] nil)))
+          ([f]
+           (if flush-render-op
+             (flush-render-op f)
+             ;; Defensive: an adapter that injected no flush op still honours
+             ;; the contract by at least running `f`. Reagent and reagent-slim
+             ;; both inject one, so this branch is dead in the reference.
+             (f))
+           nil))]
     {:make-state-container       make-state-container
      :read-container             read-container
      :replace-container!         replace-container!
@@ -1588,6 +1668,9 @@
      :render                     render
      :render-to-string           (make-render-to-string emitter-cell)
      :dispose-adapter!           dispose-adapter!
+     ;; rf2-40a84 — production synchronous render-commit, wired into the
+     ;; adapter map's :flush-render! contract slot by make-ratom-adapter.
+     :flush-render!              flush-render!
      :set-hiccup-emitter!        (fn set-it! [f]
                                    (set-hiccup-emitter! emitter-cell f))
      :active-roots-cell          active-roots-cell
@@ -1668,6 +1751,11 @@
                  :render                    (:render               spine-fns)
                  :render-to-string          (:render-to-string     spine-fns)
                  :register-context-provider register-context-provider
+                 ;; rf2-40a84 — optional synchronous render-flush contract fn
+                 ;; (reagent.core/flush — drains the render queue + React-19
+                 ;; flushSync commit). Lets headless tooling commit pending
+                 ;; renders without waiting on Reagent's rAF-scheduled drain.
+                 :flush-render!             (:flush-render! spine-fns)
                  :dispose-adapter!          (:dispose-adapter!     spine-fns)}]
     ;; Chained SSR emitter install (rf2-4z7bp / parity rf2-cl1qv): every
     ;; loaded React-shaped adapter contributes its install step so a single

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -2275,6 +2275,75 @@
           (finally
             (try (.unmount root) (catch :default _ nil)))))))))
 
+;; ---- flush-render! synchronous-commit proof (rf2-40a84) -------------------
+
+(defn assert-flush-render-synchronously-commits
+  "rf2-40a84: `(adapter/flush-render! f)` SYNCHRONOUSLY commits the render
+  scheduled by `f` to the DOM — the committed text reflects the dispatched
+  state change by the time `flush-render!` RETURNS, with NO `act()` wrapper
+  and NO wait for a `requestAnimationFrame` tick.
+
+  This is the load-bearing proof the bead asks for: it is the synchronous-
+  flush guarantee that lets headless tooling (the pair MCP) drive a
+  `dispatch → flush-render! → observe-settled-DOM` loop in a backgrounded
+  tab where the rAF-scheduled commit would never fire.
+
+  HOW THE PROOF IS RIGOROUS. After the initial mount (done under `act` so
+  the test env is happy), we TURN OFF `IS_REACT_ACT_ENVIRONMENT` and run the
+  dispatch + flush-render! entirely OUTSIDE `act`. flushSync (UIx/Helix) /
+  reagent.core/flush (ratom family) commit synchronously regardless of the
+  act env, so the assertion `(= \"n=2\" textContent)` reads TRUE on the line
+  immediately after `flush-render!` returns — a deferred (rAF/microtask)
+  commit would still read \"n=1\" there. We pass the state-changing dispatch
+  AS the flush thunk so the 1-arity `dispatch → commit` contract is what's
+  proven.
+
+  cfg keys (reuses the use-subscribe probe wiring):
+    :adapter           the installed adapter spec map (for flush-render!)
+    :probe-element     thunk → the 2-arg-form Probe element
+    :refcount-target   atom the Probe reads its target frame-id from
+    :fr-frame          frame-id keyword the Probe's query resolves under
+    :fr-query          query-v keyword the Probe subscribes to"
+  [{:keys [name adapter probe-element refcount-target fr-frame fr-query]}]
+  (testing (str name " — flush-render! synchronously commits a pending render (rf2-40a84)")
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (do
+            (enable-react-act-env!)
+            (reset! refcount-target fr-frame)
+            (rf/reg-frame fr-frame {:doc "flush-render! synchronous-commit probe frame"})
+            (rf/reg-event-db ::fr-seed (fn [_ _] {:n 1}))
+            (rf/reg-event-db ::fr-inc  (fn [db _] (update db :n inc)))
+            (rf/dispatch-sync [::fr-seed] {:frame fr-frame})
+            (rf/reg-sub fr-query (fn [db _] (:n db)))
+            (let [mount-node (make-mount-node!)
+                  root       (react-dom-client/createRoot mount-node)
+                  flush!     (:flush-render! adapter)]
+              (try
+                (is (fn? flush!)
+                    "the adapter map exposes :flush-render! (rf2-40a84 contract slot)")
+                ;; Initial mount under act so the test env commits the
+                ;; seeded value cleanly.
+                (act-fn (fn [] (.render root (probe-element))))
+                (is (= "n=1" (.-textContent mount-node))
+                    "committed DOM shows the seeded value n=1")
+                ;; THE PROOF. Leave the act environment so the next commit
+                ;; cannot be attributed to act()'s flush. Dispatch the state
+                ;; change AS the flush-render! thunk and assert the DOM has
+                ;; the new value the instant flush-render! returns — i.e. the
+                ;; commit was SYNCHRONOUS, not rAF/microtask-deferred.
+                (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+                (flush! (fn [] (rf/dispatch-sync [::fr-inc] {:frame fr-frame})))
+                (is (= "n=2" (.-textContent mount-node))
+                    "DOM reflects the dispatched change SYNCHRONOUSLY after
+                     flush-render! returns — no act(), no rAF wait (rf2-40a84)")
+                (finally
+                  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+                  (try (.unmount root) (catch :default _ nil)))))))))))
+
 (defn assert-use-subscribe-frame-provider-resolution
   "rf2-518sp: use-subscribe 1-arg form resolves through the surrounding
   frame-provider.

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -79,7 +79,7 @@ Every adapter implements the surface below. The contract is **closed for v1** �
 
 > **The adapter contract is the canonical mechanism for bridging external reactive sources** (timers, JS event streams, external pub/sub, signals from other libraries). The v1 `reg-sub-raw` escape hatch — which v1 users sometimes leaned on for non-app-db reactivity — is not shipped in v2 (per [MIGRATION §M-18](../migration/from-re-frame-v1/README.md)). A custom adapter brings the external source into the substrate; subs consume normally via `reg-sub`. State that needs to live across [Goal 2 — Frame state revertibility](000-Vision.md#frame-state-revertibility) must reach `app-db` through an event handler (Pattern-AsyncEffect plus a registered fx), not through an adapter-private side channel — see [§What an adapter MUST NOT do](#what-an-adapter-must-not-do).
 
-The v1 adapter surface is **six required functions, two optional functions, and one lifecycle function** — nine entries in total. The Normative contract section below specifies the call-shape for each; [§Operational semantics](#subscription-cache--contract-and-operational-semantics) covers cache-invalidation behaviour the adapter must respect; [§CLJS reference: Reagent as default adapter](#cljs-reference-reagent-as-default-adapter) covers reference-host implementation notes.
+The adapter surface is **six required functions, three optional functions, and one lifecycle function** — ten entries in total. The Normative contract section below specifies the call-shape for each; [§Operational semantics](#subscription-cache--contract-and-operational-semantics) covers cache-invalidation behaviour the adapter must respect; [§CLJS reference: Reagent as default adapter](#cljs-reference-reagent-as-default-adapter) covers reference-host implementation notes.
 
 ### Normative contract
 
@@ -94,12 +94,13 @@ The v1 adapter surface is **six required functions, two optional functions, and 
 | `render` | Render a render-tree onto the substrate's surface; return an unmount fn. |
 | `render-to-string` | Pure render to an HTML string (JVM-runnable). |
 
-**Optional (2):** adapters may omit; the core falls back when an optional fn is absent.
+**Optional (3):** adapters may omit; the core falls back (or no-ops) when an optional fn is absent.
 
 | Fn | Purpose | Fallback when absent |
 |---|---|---|
 | `subscribe-container` | Register a change-listener for invalidation. | Core runs invalidation inline within `replace-container!`. |
 | `register-context-provider` | Return a context-provider component that scopes a frame to a subtree. | Core falls back to explicit-frame-as-argument; the user's view code threads the frame. |
+| `flush-render!` | Synchronously commit the substrate's pending renders to the surface — NOT scheduled on a `requestAnimationFrame`-style tick. | Core no-ops (an adapter that renders without a live commit — plain-atom / SSR — has nothing to flush). |
 
 **Lifecycle (1):** every adapter must implement.
 
@@ -193,6 +194,27 @@ Pure function. Renders the render-tree to an HTML string. JVM-runnable in the CL
 ```
 
 The implementation is the per-host pure walk of the render-tree (per Spec 011 §The render-tree → HTML emitter).
+
+### `(flush-render! [f]) → nil`
+
+Optional. **Synchronously** commits the substrate's pending renders to the surface. The 1-arity form runs `f` inside the substrate's synchronous-commit path so any state change `f` schedules — and any render already pending — is committed before the call returns; the 0-arity form flushes already-pending work with an empty callback.
+
+```clojure
+(flush-render!)                                         ;; → nil; flush already-pending work
+(flush-render! f)                                       ;; → nil; run f, then flush synchronously
+;; f signature: (fn [] ...) — its return is ignored
+```
+
+**Why this is a contract fn, not a test helper.** The reference substrates schedule re-renders through a `requestAnimationFrame`-style tick that fires *after* an evaluated `dispatch` returns and is throttled to ~never in a backgrounded / unfocused tab. A tool that drives `dispatch` and then wants to observe the *rendered* result therefore cannot rely on the scheduled commit ever arriving. `flush-render!` runs through the host's **synchronous-commit** API (it is NOT rAF-scheduled), so it fires even headless and even when the tab is backgrounded — letting headless tooling drive a `dispatch → flush-render! → observe-settled-DOM` loop deterministically. This is the framework capability the Tool-Pair headless view-lifecycle driving depends on (see [Tool-Pair §Driving the render](Tool-Pair.md), consumed by the pair MCP's *dispatch-and-settle* op).
+
+This is **distinct** from a test-only flush. The CLJS reference also ships `flush-views!` on the React-hook adapters — a wrapper around React's `act()` intended for test code; `flush-render!` is the production-grade contract surface every adapter implements, callable from app or tooling code with no `act()` test-environment opt-in.
+
+`flush-render!` must be **no-op-safe**: calling it when nothing is pending does no harm and returns `nil`. An adapter that renders without a live host commit (the plain-atom / SSR adapters render to a string, never to a live surface) ships no `flush-render!` at all; the core's delegation then no-ops.
+
+CLJS-Reagent: `(f)` then `reagent.core/flush` — Reagent's render-queue drain forces every dirty component to re-render synchronously, bypassing its `requestAnimationFrame` `next-tick` scheduler, and (on React 19) commits via `react-dom/flushSync`.
+CLJS-reagent-slim: `(f)` then `reagent2.impl.batching/flush!` — the rewrite's synchronous rea-queue + dirty-set drain (`forceUpdate` per dirty component), bypassing its microtask scheduler. Distinct from the `goog.DEBUG`-gated, `act()`-composing `reagent2.dom.client/flush-views!` test primitive.
+CLJS-UIx / CLJS-Helix: `react-dom/flushSync` (the React-hook spine) — runs `f` inside `flushSync` so any `useSyncExternalStore` update commits before returning.
+CLJS-headless (plain-atom) / SSR: not implemented — there is no live commit to flush; `render-to-string` is the only render path.
 
 ### `(register-context-provider frame-keyword) → component`
 
@@ -1220,7 +1242,7 @@ The keyword is informational. Behaviour-affecting decisions should be based on `
 
 ### Disposed-vs-never-installed
 
-Runtime delegation calls (`make-state-container`, `read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string`, `subscribe-container`, `register-context-provider`) raise a structured ex-info when no adapter is installed. The throw shape distinguishes two states:
+Runtime delegation calls (`make-state-container`, `read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string`, `subscribe-container`, `register-context-provider`, `flush-render!`) raise a structured ex-info when no adapter is installed. The throw shape distinguishes two states:
 
 - **`:rf.error/no-adapter-installed`** — fresh process, no `(rf/init! …)` has fired yet. Recovery: install an adapter.
 - **`:rf.error/adapter-disposed`** — an adapter was previously installed and torn down by `(rf/destroy-adapter!)` without a subsequent install. Recovery: install a fresh adapter. Common in test fixtures and hot-reload flows.

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -48,6 +48,7 @@ The two parts together form the **consolidated contract** — the complete set o
 | **Read sub values** | `(rf/compute-sub query-v db-value)` runs a sub against an `app-db` value | [008](008-Testing.md) |
 | **Read registry** | `(rf/registrations kind)`, `(rf/handler-meta kind id)`, `(rf/frame-ids)`, `(rf/frame-meta id)` | [001-Registration](001-Registration.md), [002](002-Frames.md) |
 | **Dispatch** | `(rf/dispatch ev opts)`, `(rf/dispatch-sync ev opts)` with `:frame` opt | [002 §Routing](002-Frames.md#routing-the-dispatch-envelope) |
+| **Drive the render** | `flush-render!` on the installed substrate adapter — synchronously commits pending renders so a headless `dispatch → observe-DOM` loop is deterministic | [006 §`flush-render!`](006-ReactiveSubstrate.md#flush-render-f--nil), [§Driving the render](#driving-the-render-headless-view-lifecycle) |
 | **Trace stream** | `(rf/register-listener! key callback)` plus structured trace events | [009](009-Instrumentation.md) |
 | **Hot-swap handlers** | Re-registration replaces; emits `:rf.registry/handler-replaced` trace | [001 §Hot-reload semantics](001-Registration.md#hot-reload-semantics) |
 | **Stub fx** | `:fx-overrides` map (id-valued at the pattern level) on `dispatch` opts or `reg-frame` metadata | [002 §Per-frame and per-call overrides](002-Frames.md#per-frame-and-per-call-overrides) |
@@ -55,9 +56,17 @@ The two parts together form the **consolidated contract** — the complete set o
 | **Inspect registered schemas** | `(rf/app-schemas frame-id)`, `(rf/app-schema-at path opts)`, `(rf/app-schemas-digest opts)` | [010 §Schemas as a tooling and agent surface](010-Schemas.md#schemas-as-a-tooling-and-agent-surface) |
 | **Errors** | Structured `:rf.error/*` trace events with category + tags | [009 §Error contract](009-Instrumentation.md#error-contract) |
 
-This much is **already specified**. A pair tool built against re-frame2 (and conforming with [day8/re-frame-pair](https://github.com/day8/re-frame-pair)) needs nothing more than these surfaces to do everything in the capability list above except time-travel.
+This much is **already specified** (except the render-driving fn `flush-render!`, locked in [§Driving the render](#driving-the-render-headless-view-lifecycle) below and in [006 §`flush-render!`](006-ReactiveSubstrate.md#flush-render-f--nil)). A pair tool built against re-frame2 (and conforming with [day8/re-frame-pair](https://github.com/day8/re-frame-pair)) needs nothing more than these surfaces to do everything in the capability list above except time-travel.
 
-The capability that requires *new* commitments is **time-travel**, addressed below.
+The capabilities requiring *new* commitments are **driving the render** (immediately below) and **time-travel** (after it).
+
+### Driving the render (headless view-lifecycle)
+
+A pair tool can drive the re-frame *layer* (`dispatch`) but, without a commitment here, cannot reliably drive the *substrate render*. The reference substrates schedule re-renders through a `requestAnimationFrame`-style tick that (a) fires *after* an evaluated `dispatch` returns and (b) is throttled to ~never in a **backgrounded / unfocused tab** — exactly the state a headless or remotely-driven browser is usually in. So a tool that dispatches an event and then reads the DOM races the scheduler: the commit may not have happened, and in a backgrounded tab may never happen. Driving the view lifecycle (mount / unmount / re-render) from the MCP was correspondingly unreliable.
+
+The commitment is the optional substrate-adapter contract fn **`flush-render!`** (per [006 §`flush-render!`](006-ReactiveSubstrate.md#flush-render-f--nil)). It runs through the host's **synchronous-commit** path (React `flushSync`; `reagent.core/flush` for the ratom family) rather than the rAF-scheduled tick, so the commit fires even headless and even when the tab is backgrounded. The 1-arity form runs a thunk and then flushes; the 0-arity form flushes already-pending work. It is no-op-safe (nothing pending → returns `nil`).
+
+This is the framework primitive the pair MCP's **dispatch-and-settle** op builds on: dispatch the event, `flush-render!` to synchronously commit the resulting renders, then observe the settled DOM (the `data-rf2-source-coord` / `data-rf-view` annotations per [006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory)) and the settled epoch (per [§Time-travel](#time-travel)). `flush-render!` belongs to the **framework**, not the pair-runtime: it is substrate-specific, but every re-frame2 app installs an adapter, so the capability is universal. A tool reaches it through the installed adapter's `flush-render!` (the `eval-cljs` authority class per [§MCP tool authority classes](#mcp-tool-authority-classes--named-mutation-vs-eval-cljs), or a named dispatch-and-settle op that wraps it). Adapters with no live commit (plain-atom / SSR) ship no `flush-render!`; the call no-ops.
 
 <a name="time-travel"></a>
 ## Time-travel: epoch snapshots and undo


### PR DESCRIPTION
Adds `flush-render!` — a SYNCHRONOUS render-commit fn — to the substrate-adapter contract so headless tooling (the re-frame2-pair MCP) can drive a `dispatch -> flush-render! -> observe-settled-DOM` loop. The reference substrates schedule re-renders on a requestAnimationFrame-style tick that fires *after* an eval'd dispatch returns and is throttled to ~never in a backgrounded/unfocused tab; `flush-render!` runs through the host's synchronous-commit API instead, so the commit fires even headless. Belongs in the framework (substrate-specific, but every re-frame2 app has an adapter -> universal capability).

## Protocol seam

- New optional delegation fn `re-frame.substrate.adapter/flush-render!` (10th contract fn; no-op when the installed adapter ships none — plain-atom / SSR omit it). Contract framing is now **6 required + 3 optional + 1 lifecycle**.
- Spine: `flush-render!` for the React-hook family wired into the `make-react-adapter` map; the ratom family delegates to an injected `:rdc/flush-render!` op wired into `make-ratom-adapter`.

## Per-substrate flushSync impls (faithful to each substrate)

- **UIx / Helix** (spine): `react-dom/flushSync` — runs the thunk inside `flushSync` so any `useSyncExternalStore` update commits before returning.
- **Reagent**: `reagent.core/flush` — drains Reagent's render queue synchronously (bypassing its rAF `next-tick` scheduler) and, on React 19, commits via `react-dom/flushSync`.
- **reagent-slim**: `reagent2.impl.batching/flush!` — synchronous rea-queue + dirty-set drain (forceUpdate per dirty component); distinct from the `goog.DEBUG`-gated, `act()`-composing `reagent2.dom.client/flush-views!` test primitive.

Bundle isolation preserved: the spine names no reactive-atom ns (the ratom flush op is injected); UIx/Helix bundles stay Reagent-free.

## Synchronous-flush proof

New tests mount a sub-driven view, dispatch a state change, call `flush-render!`, and assert the rendered DOM reflects the new value **the instant flush-render! returns** — with NO `act()` wrapper and NO wait for a rAF tick (a deferred commit would still read the old value there). UIx/Helix twins live in the shared React suite (`assert-flush-render-synchronously-commits`, run with `IS_REACT_ACT_ENVIRONMENT` turned OFF for the flush portion); Reagent has a dedicated DOM test (dispatch enqueues the re-render on the rAF turn, `flush-render!` commits it synchronously).

## Spec

- `spec/006-ReactiveSubstrate.md`: new `(flush-render! [f]) -> nil` contract section + optional-fn table row + delegation-throw list.
- `spec/Tool-Pair.md`: new **Driving the render (headless view-lifecycle)** capability + runtime-contract table row.

Unblocks **rf2-vk79g** (dispatch-and-settle), which consumes this.

## Quality gates

- `npm run test:cljs` — PASS (5204 tests, 17762 assertions, 0 failures).
- `npm run test:browser` (Reagent + UIx + Helix) — PASS (133 tests, 377 assertions, 0 failures), including the 3 new synchronous-flush proofs.
- `npm run test:bundle-isolation` — PASS (UIx/Helix bundles Reagent-free; react-dom/flushSync adds no Reagent coupling).
- `npm run test:reagent-slim:bundle-isolation` — PASS (reagent2.impl.batching require stays slim-internal).
- `npm run test:elision` — PASS (production 40/40 absent).
- clj-kondo — clean (0 errors, 0 new warnings; the pre-existing `-notify-watches` warning on the spine's IWatchable reify is unchanged from main).
- `mkdocs build --strict` — PASS (exit 0; spec/006 + Tool-Pair anchors resolve).

**Synchronous-flush proof:** after the initial commit shows `n=1`, the test dispatches `::inc` and calls `flush-render!`; the assertion `(= "n=2" textContent)` reads TRUE on the line immediately after the call returns — proving the commit was synchronous (flushSync / reagent.core/flush), not rAF/microtask-deferred. The UIx/Helix proof additionally disables `IS_REACT_ACT_ENVIRONMENT` so the commit cannot be attributed to `act()`.

Do NOT merge.