### PR TITLE
feat(governance): Xray panel-enum single-source guard (rf2-rapnr, absorbs rf2-7b1z4 guard-half)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1580,26 +1580,40 @@ only opt is `:frame`) — the v1.0 host-facing embed contract is the
 
 ### Mountable surface inventory
 
-The Xray panel-surface inventory totals **13 panels** across four
-tiers — **11 are independently mountable** as standalone user-facing
-mount targets, and **2 are internal sub-components** that render
-under their owning panel. The 4-tier split is:
+> **Single source of truth (rf2-rapnr).** The mount-fn column of the
+> tables below is a PROJECTION of the authoritative panel enumeration
+> in `day8.re-frame2-xray.panel-enum/panel-enum`. A drift between this
+> inventory, the `mount-<panel>!` facade in
+> `day8.re-frame2-xray.panels`, and the api-manifest `:cljs-only` rows
+> goes RED in CI via the single-source guard
+> (`tools/xray/test/day8/re_frame2_xray/panel_enum_guard_cljs_test.cljs`).
+> Adding / removing / renaming a panel starts with a one-line edit to
+> the enum; this table follows. See the `panel-enum` ns docstring.
 
-- **Tier 1 — L3 tab panels (7):** one per L3 detail-panel tab.
+The Xray panel-surface inventory totals **14 surfaces** across five
+tiers — **12 are independently mountable** via a `mount-<panel>!` fn
+(the panel-enum set), and **2 are internal sub-components** that render
+under their owning panel and expose no standalone mount fn. The split:
+
+- **Tier 1 — L3 tab panels (6):** one per L3 detail-panel tab.
+- **Spine — embeddable event spine (1):** the L2 event list mounted
+  standalone (`008-Embedding-Contract.md` §Embeddable event spine).
 - **Tier 2 — overlay / popup surfaces (3):** modal-light surfaces
   the shell composes at its root.
 - **Tier 3 — inline content surface (1):** the managed-fx
   wire-boundary diff template embedded in the Epoch panel's
   "EFFECTS HANDLERS RAN" section.
+- **Full shell — master entry (1):** `mount-shell!`, the full 4-layer
+  chrome that composes every panel above.
 - **Tier 4 — internal sub-components (2):** auxiliary inspectors
   geometry-coupled to `machine-inspector/Panel` (after-rings
-  overlay, sim side-rail).
+  overlay, sim side-rail) — NOT in the panel-enum set.
 
-Tiers 1 + 2 + 3 sum to the **10 independently mountable** surfaces;
-adding Tier 4's 2 internal sub-components reaches the **12-panel**
-total. Modal overlays managed by the shell (Settings dialog,
-command palette, share modal) are NOT counted here — they are shell
-chrome, not panel content.
+The 6 + 1 + 3 + 1 + 1 mountable surfaces sum to the **12** entries of
+`panel-enum`; adding Tier 4's 2 internal sub-components reaches the
+**14-surface** total. Modal overlays managed by the shell (Settings
+dialog, command palette, share modal) are NOT counted here — they are
+shell chrome, not panel content.
 
 **Tier 1 — L3 tab panels (6):** one per `:rf.xray/selected-tab`
 value. (Post rf2-5gl5r the Event/Handler tab was retired in favour
@@ -1614,10 +1628,19 @@ numbered vertical cascade per
 |---|---|---|
 | Epoch tab    | `epoch-panel/Panel`      | `mount-epoch-panel!` |
 | App-db tab   | `app-db-diff/Panel`      | `mount-app-db-diff!` |
-| Views tab    | `views/Panel`            | `mount-views!` |
+| Reactive tab | `reactive-panel/Panel`   | `mount-reactive-panel!` |
 | Trace tab    | `trace/Panel`            | `mount-trace!` |
 | Machines tab | `machine-inspector/Panel`| `mount-machine-inspector!` |
 | Routing tab  | `routing/Panel`          | `mount-routing!` |
+
+**Spine — embeddable event spine (1):** the L2 event list mounted
+standalone — the SAME `shell/event-list` reg-view the full shell
+composes at L2. See [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)
+§Embeddable event spine for the contract.
+
+| Panel | View | Mount fn |
+|---|---|---|
+| Event spine | `shell/event-list` | `mount-event-spine!` |
 
 (rf2-gbz39 — the Issues tab + its `issues-ribbon/Panel` + `mount-issues-ribbon!` were removed per Mike's Option (c) ruling; issues surface inline in the Epoch panel + the L2 event-row pink-wash + the always-on issues ribbon signal. The `:rf.xray/issues-ribbon` projection survives in `registry.cljs` as the ribbon signal's data source.)
 
@@ -1640,6 +1663,17 @@ that want JUST the managed-fx list for the focused cascade.
 | Panel | View | Mount fn |
 |---|---|---|
 | Managed-fx records list | `panels/ManagedFxList` | `mount-managed-fx!` |
+
+**Full shell — master entry (1):** `mount-shell!` mounts the complete
+4-layer chrome (ribbon + event-list + tab-bar + detail-panel),
+composing every panel above. The same mount path `mount.cljs/open!`
+uses for the default in-app `[data-rf-xray-host]` mount; exposed here
+so hosts that own their DOM (Story, custom dev surfaces) mount the full
+shell at any element.
+
+| Panel | View | Mount fn |
+|---|---|---|
+| Full 4-layer shell | `shell/shell-view` | `mount-shell!` |
 
 **Tier 4 — internal sub-components:** auxiliary inspectors that
 depend on `machine-inspector/Panel`'s positioned graph for their

--- a/tools/xray/src/day8/re_frame2_xray/panel_enum.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panel_enum.cljc
@@ -1,0 +1,132 @@
+(ns day8.re-frame2-xray.panel-enum
+  "SINGLE SOURCE OF TRUTH for the Xray panel enumeration — the set of
+  independently-mountable Xray panel surfaces (rf2-rapnr; absorbs the
+  guard-half of rf2-7b1z4; follow-on to the rf2-3nbl5.2 API-governance
+  keystone).
+
+  ## The problem this closes
+
+  \"The set of Xray panels\" had THREE projections that could silently
+  drift apart:
+
+    1. THE MOUNT FACADE — the `mount-<panel>!` fn family in
+       `day8.re-frame2-xray.panels` (the live code a host calls).
+    2. THE XRAY API SPEC — the `mount-<panel>!` names enumerated in
+       `tools/xray/spec/007-UX-IA.md` §Mountable surface inventory +
+       `tools/xray/spec/008-Embedding-Contract.md`.
+    3. THE API MANIFEST — the `:cljs-only` rows for
+       `day8.re-frame2-xray.panels` in `spec/api-manifest-metadata.edn`
+       (rf2-jhn46) that the CLJS enumeration probe (rf2-2mtte)
+       runtime-verifies.
+
+  Before this ns, adding / removing / renaming a panel meant editing
+  each projection by hand and HOPING they stayed aligned — exactly the
+  drift class the keystone exists to kill. (A live example the guard
+  caught: `007-UX-IA.md` named `mount-views!`, a fn that no longer
+  exists, while omitting `mount-event-spine!`, a fn that does.)
+
+  ## The single source
+
+  `panel-enum` below is the ONE authoritative enumeration. Every other
+  projection DERIVES FROM or is VALIDATED AGAINST it:
+
+    - The mount facade — the guard
+      (`panel_enum_guard_cljs_test.cljs`) reconciles the live public
+      `mount-*!` vars of `day8.re-frame2-xray.panels` against this set
+      (bidirectional: a facade fn with no entry, or an entry with no
+      live fn, → RED).
+    - The Xray API spec — the same guard reconciles the `mount-*!`
+      names parsed out of `007-UX-IA.md` + `008-Embedding-Contract.md`
+      against this set (bidirectional → RED on drift).
+    - The api-manifest `:cljs-only` rows — the rf2-2mtte CLJS probe +
+      the rf2-gkp0t `xray_spec_check` already reconcile the manifest's
+      `panels` rows against the live vars; because the live vars are
+      themselves guarded against this enum, the manifest inherits enum
+      coherence transitively.
+
+  A DRIFT between any projection and this source goes RED in CI.
+
+  ## Why `.cljc` + pure data
+
+  Mirrors `panel_registry.cljc`: the JVM test corpus + the api-manifest
+  tooling can read this enumeration without spinning a CLJS runtime,
+  and the CLJS guard reads it as a plain value. The `:mount` / `:view`
+  axes are STRINGS (not the actual vars) so this data file pulls in no
+  view code and carries no substrate dependency — it is a pure
+  catalogue, JVM-portable by construction.
+
+  ## Entry shape
+
+    :id     keyword — stable panel identity.
+    :mount  string  — the public `mount-<panel>!` fn name in
+                      `day8.re-frame2-xray.panels` (the facade var the
+                      guard reconciles).
+    :view   string  — the `reg-view` rendered by the mount fn, as a
+                      `<ns-tail>/<View>` reference (documentation /
+                      cross-check axis; not load-bearing for the guard).
+    :tier   keyword — the 007-UX-IA §Mountable surface inventory tier:
+                      :l3-tab        — Tier 1, an L3 detail-panel tab.
+                      :overlay       — Tier 2, a modal-light popup.
+                      :inline        — Tier 3, inline content surface.
+                      :spine         — the embeddable L2 event spine
+                                       (008 §Embeddable event spine).
+                      :full-shell    — the master `mount-shell!` entry.
+
+  Tier 4 internal sub-components (after-rings overlay, sim side-rail)
+  are NOT in this enum — they are geometry-coupled to
+  `machine-inspector/Panel` and expose no standalone mount fn (per
+  007-UX-IA §Tier 4). The enum carries exactly the mountable surface.")
+
+;; ---------------------------------------------------------------------------
+;; THE SINGLE SOURCE — the mountable Xray panel enumeration.
+;; ---------------------------------------------------------------------------
+
+(def panel-enum
+  "The authoritative vector of mountable Xray panel surfaces. Ordered
+  by tier then by the 007-UX-IA inventory order for readable diffs.
+  Adding / removing / renaming a panel is a ONE-LINE edit here — the
+  guard then forces the mount facade + the Xray API spec to follow."
+  [;; Tier 1 — L3 tab panels (007-UX-IA §Mountable surface inventory).
+   {:id :epoch             :mount "mount-epoch-panel!"      :view "epoch-panel/Panel"      :tier :l3-tab}
+   {:id :app-db-diff       :mount "mount-app-db-diff!"      :view "app-db-diff/Panel"      :tier :l3-tab}
+   {:id :reactive          :mount "mount-reactive-panel!"   :view "reactive-panel/Panel"   :tier :l3-tab}
+   {:id :trace             :mount "mount-trace!"            :view "trace/Panel"            :tier :l3-tab}
+   {:id :machine-inspector :mount "mount-machine-inspector!" :view "machine-inspector/Panel" :tier :l3-tab}
+   {:id :routing           :mount "mount-routing!"          :view "routing/Panel"          :tier :l3-tab}
+   ;; The embeddable L2 event spine (008 §Embeddable event spine).
+   {:id :event-spine       :mount "mount-event-spine!"      :view "shell/event-list"       :tier :spine}
+   ;; Tier 2 — overlay / popup surfaces.
+   {:id :segment-inspector :mount "mount-segment-inspector!" :view "app-db-segment-inspector/Popup" :tier :overlay}
+   {:id :cancellation-cascade-side-panel
+    :mount "mount-cancellation-cascade-side-panel!"
+    :view "cancellation-cascade/SidePanel" :tier :overlay}
+   {:id :cancellation-cascade-popover
+    :mount "mount-cancellation-cascade-popover!"
+    :view "cancellation-cascade/Popover"   :tier :overlay}
+   ;; Tier 3 — inline content surface.
+   {:id :managed-fx        :mount "mount-managed-fx!"       :view "panels/ManagedFxList"   :tier :inline}
+   ;; The master full-shell entry.
+   {:id :shell             :mount "mount-shell!"            :view "shell/shell-view"       :tier :full-shell}])
+
+;; ---------------------------------------------------------------------------
+;; Pure projections off the single source (JVM-portable; the guard reads
+;; these).
+;; ---------------------------------------------------------------------------
+
+(def mount-fn-names
+  "Set of every `mount-<panel>!` fn name the enum declares — the
+  canonical mount-facade surface the guard reconciles the live vars +
+  the spec references against."
+  (into #{} (map :mount) panel-enum))
+
+(def panel-ids
+  "Set of every panel `:id` — stable identity axis."
+  (into #{} (map :id) panel-enum))
+
+(defn ids-by-tier
+  "Map of `tier-kw -> #{panel-id ...}` for assertions over the tier
+  partition."
+  []
+  (reduce (fn [acc {:keys [id tier]}]
+            (update acc tier (fnil conj #{}) id))
+          {} panel-enum))

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -57,6 +57,20 @@
 
       (mount-shell! mount-point opts) → unmount-fn
 
+  ## Single-source panel enumeration (rf2-rapnr)
+
+  The SET of mountable panels — the `mount-<panel>!` family above —
+  is enumerated ONCE in `day8.re-frame2-xray.panel-enum/panel-enum`
+  (the single source of truth). The `mount-*!` fns in this namespace,
+  the Xray API spec's panel inventory (`007-UX-IA.md` +
+  `008-Embedding-Contract.md`), and the api-manifest `:cljs-only` rows
+  are all VALIDATED AGAINST that enum by the single-source guard
+  (`panel_enum_guard_cljs_test.cljs`) — a drift between any projection
+  and the enum goes RED in CI. Adding / removing / renaming a panel
+  starts with a one-line edit to `panel-enum`; the guard then forces
+  the facade fn below + the spec inventory to follow. See the
+  `panel-enum` ns docstring for the contract.
+
   ## What every mount fn does
 
   1. Calls `(registry/register-xray-handlers!)` — idempotent, registers

--- a/tools/xray/test/day8/re_frame2_xray/panel_enum_guard_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panel_enum_guard_cljs_test.cljs
@@ -1,0 +1,174 @@
+(ns day8.re-frame2-xray.panel-enum-guard-cljs-test
+  "SINGLE-SOURCE GUARD for the Xray panel enumeration (rf2-rapnr;
+  absorbs the guard-half of rf2-7b1z4; follow-on to the rf2-3nbl5.2
+  API-governance keystone + rf2-jhn46's #2786 Xray manifest rows + the
+  rf2-2mtte CLJS enumeration probe).
+
+  ## What this guards
+
+  `day8.re-frame2-xray.panel-enum/panel-enum` is the ONE authoritative
+  enumeration of the mountable Xray panel set. Two other projections of
+  \"the set of panels\" must agree with it, or this test goes RED:
+
+    PROJECTION A — THE MOUNT FACADE. The live public `mount-<panel>!`
+      vars of `day8.re-frame2-xray.panels`. Reconciled BIDIRECTIONALLY:
+        - a `mount-*!` facade fn with no enum entry → RED (an orphan
+          mount fn the enum + spec never declared);
+        - an enum `:mount` name with no live facade fn → RED (a renamed
+          / removed fn the enum still claims).
+
+    PROJECTION B — THE XRAY API SPEC. The `mount-<panel>!` names the
+      spec enumerates in `007-UX-IA.md` §Mountable surface inventory +
+      `008-Embedding-Contract.md`. Reconciled BIDIRECTIONALLY:
+        - a spec-named `mount-*!` with no enum entry → RED (the spec
+          drifted ahead / kept a stale name — e.g. the pre-fix
+          `mount-views!` ghost);
+        - an enum `:mount` name the spec never mentions → RED (a panel
+          shipped but undocumented).
+
+  The third projection — the api-manifest `:cljs-only` rows for
+  `day8.re-frame2-xray.panels` — is reconciled against the LIVE vars by
+  the rf2-2mtte CLJS probe and the rf2-gkp0t `xray_spec_check`. Because
+  PROJECTION A pins the live facade to the enum, the manifest inherits
+  enum coherence transitively; this guard adds the enum↔facade and
+  enum↔spec edges those checks did not cover.
+
+  ## Mechanism
+
+  Both extra projections are read at COMPILE time so the test stays a
+  headless pure-data reconciliation (no DOM, no runtime filesystem):
+    - the live facade surface via `emit-ns-publics` (the rf2-2mtte
+      analyzer enumeration macro);
+    - the spec references via `emit-spec-mount-fn-names` (the JVM-side
+      slurp macro in `panel_enum_spec_refs.clj`).
+
+  ## Proving RED-on-drift
+
+  Add a `mount-<panel>!` to ONE projection but not the enum (a new
+  facade fn, or a new spec mention) → the corresponding bidirectional
+  assertion below fails. Add an enum entry whose `:mount` no facade fn
+  / no spec line carries → the reverse direction fails. Reverting the
+  drift returns the test to green."
+  (:require-macros [re-frame.api-manifest.cljs-publics :refer [emit-ns-publics]]
+                   [day8.re-frame2-xray.panel-enum-spec-refs
+                    :refer [emit-spec-mount-fn-names]])
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.set :as set]
+            [day8.re-frame2-xray.panel-enum :as panel-enum]
+            ;; Force the analyzer to analyse the facade ns before
+            ;; `emit-ns-publics` expands so the macro reads a real
+            ;; surface. The alias is unused at runtime (the surface is
+            ;; read at compile time) but the require is load-bearing.
+            [day8.re-frame2-xray.panels]))
+
+;; ---------------------------------------------------------------------------
+;; The three projections, captured as plain sets.
+;; ---------------------------------------------------------------------------
+
+(def ^:private enum-mount-names
+  "PROJECTION SOURCE — the single source of truth's mount-fn set."
+  panel-enum/mount-fn-names)
+
+(def ^:private facade-mount-names
+  "PROJECTION A — the live public `mount-<panel>!` vars of
+  `day8.re-frame2-xray.panels`, captured at compile time. Filtered to
+  the `mount-*!` shape (the ns has other publics — `render-panel!` is
+  private; `ManagedFxList` is a reg-view; the mount fns are the panel
+  facade)."
+  (into #{}
+        (comp (map first)
+              (filter #(re-matches #"mount-[a-z][a-z0-9-]*!" %)))
+        (emit-ns-publics day8.re-frame2-xray.panels)))
+
+(def ^:private spec-mount-names
+  "PROJECTION B — the `mount-<panel>!` names the Xray API spec
+  enumerates, captured at compile time."
+  (emit-spec-mount-fn-names))
+
+;; ---------------------------------------------------------------------------
+;; Sanity — none of the projections is silently empty (a vacuously-green
+;; guard is worse than no guard).
+;; ---------------------------------------------------------------------------
+
+(deftest projections-are-non-empty
+  (testing "each projection enumerated at least one mount fn — guards
+            against a dropped require / unanalysed ns / unreadable spec
+            making a reconciliation vacuously green"
+    (is (seq enum-mount-names)   "the single-source enum is non-empty")
+    (is (seq facade-mount-names) "the live facade surface enumerated mount fns")
+    (is (seq spec-mount-names)   "the spec enumerated mount fns")))
+
+;; ---------------------------------------------------------------------------
+;; PROJECTION A — facade ⟺ enum.
+;; ---------------------------------------------------------------------------
+
+(deftest facade-matches-enum
+  (testing "every live `mount-<panel>!` facade fn is declared in the
+            single-source enum, and every enum `:mount` resolves to a
+            live facade fn — bidirectional. A drift either way is the
+            facade + enum disagreeing on the set of panels."
+    (let [orphan-fns   (set/difference facade-mount-names enum-mount-names)
+          missing-fns  (set/difference enum-mount-names facade-mount-names)]
+      (is (empty? orphan-fns)
+          (str "Live `mount-<panel>!` facade fns with NO `panel-enum` "
+               "entry (add them to day8.re-frame2-xray.panel-enum/panel-enum "
+               "or remove the fn): " (sort orphan-fns)))
+      (is (empty? missing-fns)
+          (str "`panel-enum` `:mount` names with NO live facade fn in "
+               "day8.re-frame2-xray.panels (renamed / removed — update the "
+               "enum): " (sort missing-fns))))))
+
+;; ---------------------------------------------------------------------------
+;; PROJECTION B — spec ⟺ enum.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-matches-enum
+  (testing "every `mount-<panel>!` the Xray API spec names is declared
+            in the single-source enum, and every enum `:mount` is named
+            somewhere in the spec — bidirectional. A drift either way is
+            the spec inventory + enum disagreeing on the set of panels."
+    (let [stale-spec   (set/difference spec-mount-names enum-mount-names)
+          undocumented (set/difference enum-mount-names spec-mount-names)]
+      (is (empty? stale-spec)
+          (str "Xray spec (007-UX-IA.md / 008-Embedding-Contract.md) "
+               "names `mount-<panel>!` fns with NO `panel-enum` entry "
+               "(a stale / drifted spec reference — reconcile the spec or "
+               "the enum): " (sort stale-spec)))
+      (is (empty? undocumented)
+          (str "`panel-enum` `:mount` names the Xray spec never mentions "
+               "(an undocumented panel — add it to 007-UX-IA.md §Mountable "
+               "surface inventory or 008-Embedding-Contract.md): "
+               (sort undocumented))))))
+
+;; ---------------------------------------------------------------------------
+;; Transitive closure — all three projections collapse to ONE set.
+;; ---------------------------------------------------------------------------
+
+(deftest all-projections-agree
+  (testing "the facade, the spec, and the single-source enum all project
+            the SAME mount-fn set — the single-source contract in one
+            assertion"
+    (is (= enum-mount-names facade-mount-names spec-mount-names)
+        (str "Panel-enum projections disagree.\n"
+             "  enum:   " (sort enum-mount-names) "\n"
+             "  facade: " (sort facade-mount-names) "\n"
+             "  spec:   " (sort spec-mount-names)))))
+
+;; ---------------------------------------------------------------------------
+;; Enum well-formedness — the source itself stays coherent.
+;; ---------------------------------------------------------------------------
+
+(deftest enum-entries-are-well-formed
+  (testing "every panel-enum entry has a keyword :id, a `mount-*!`
+            string, and a tier from the closed vocabulary; ids + mount
+            names are unique"
+    (doseq [{:keys [id mount tier] :as entry} panel-enum/panel-enum]
+      (is (keyword? id) (str "entry :id is a keyword: " entry))
+      (is (and (string? mount) (re-matches #"mount-[a-z][a-z0-9-]*!" mount))
+          (str "entry :mount is a `mount-*!` string: " entry))
+      (is (contains? #{:l3-tab :overlay :inline :spine :full-shell} tier)
+          (str "entry :tier is from the closed vocabulary: " entry)))
+    (is (= (count panel-enum/panel-enum) (count panel-enum/panel-ids))
+        "panel :id values are unique")
+    (is (= (count panel-enum/panel-enum) (count panel-enum/mount-fn-names))
+        "panel :mount values are unique")))

--- a/tools/xray/test/day8/re_frame2_xray/panel_enum_spec_refs.clj
+++ b/tools/xray/test/day8/re_frame2_xray/panel_enum_spec_refs.clj
@@ -1,0 +1,95 @@
+(ns day8.re-frame2-xray.panel-enum-spec-refs
+  "Compile-time extractor for the `mount-<panel>!` references the Xray
+  API spec enumerates (rf2-rapnr).
+
+  THE PROBLEM. The panel-enum single-source guard
+  (`panel_enum_guard_cljs_test.cljs`) is a ClojureScript test — it runs
+  under the consolidated `:node-test` build so it can read the live
+  `mount-*!` vars of `day8.re-frame2-xray.panels`. But it must ALSO
+  reconcile the spec's projection of the panel set, and CLJS has no
+  compile-time filesystem.
+
+  THE MECHANISM. Mirrors `re-frame.api-manifest.cljs-publics/
+  emit-cljs-only-rows`: this macro slurps the Xray spec markdown on the
+  JVM side at macro-expansion time and emits the extracted set of
+  `mount-<panel>!` names as a literal into the calling ClojureScript.
+  The value the guard reconciles is therefore pinned to the same
+  committed spec the human reads, with no runtime filesystem dependency
+  and no fragile cross-classpath `require` of the CLJS spec surface.
+
+  SCOPE. The spec is prose-heavy; a bare-token sweep would be all
+  false-positive. We scope to exactly the `mount-<panel>!` lexical
+  shape (`mount-` + kebab name + `!`) — the mountable-panel contract's
+  canonical reference form — across the two spec files that enumerate
+  the panel set:
+    - `007-UX-IA.md` §Mountable surface inventory (the tier tables).
+    - `008-Embedding-Contract.md` §Embeddable event spine + the
+      mount-fn-contract prose.
+  A `mount-<panel>!` named in either file MUST be in the single-source
+  enum, and every enum mount fn MUST be named in the spec — the guard
+  enforces both directions."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private mount-fn-re
+  "The `mount-<panel>!` reference shape (007-UX-IA §The mount-fn
+  contract). Matches `mount-` + a kebab identifier + a trailing `!`."
+  #"\bmount-[a-z][a-z0-9-]*!")
+
+(def ^:private known-removed-names
+  "Curated allowlist of `mount-<panel>!` names the spec DELIBERATELY
+  mentions in removal notes (the panels were retired) but which are NOT
+  in the single-source `panel-enum`. The keystone idiom (see
+  `re-frame.api-manifest.projection` §WHY AN ALLOWLIST): a surface
+  legitimately names a removed old name to document the change; the
+  allowlist silences exactly those, by name, so the guard stays green
+  on the history note yet still goes RED for any OTHER unknown
+  `mount-*!` that drifts into the spec.
+
+    - `mount-issues-ribbon!` — the Issues-tab mount fn, removed under
+      rf2-gbz39 (Mike's Option (c)); 007-UX-IA names it in the
+      removal note that explains where issues surface now."
+  #{"mount-issues-ribbon!"})
+
+(def ^:private spec-files
+  "Repo-relative paths of the Xray spec files that enumerate the
+  mountable panel set. Both are read at macro-expansion time."
+  ["tools/xray/spec/007-UX-IA.md"
+   "tools/xray/spec/008-Embedding-Contract.md"])
+
+(defn- find-repo-root
+  "Walk up from the build's `user.dir` until a directory containing
+  `tools/xray/spec/007-UX-IA.md` resolves — robust whether shadow runs
+  from `implementation/` (the consolidated `:node-test` build) or from
+  the xray artefact dir. Throws an actionable error when not found."
+  []
+  (loop [dir (io/file (System/getProperty "user.dir"))]
+    (when (nil? dir)
+      (throw (ex-info (str "panel-enum spec-refs: could not locate "
+                           "tools/xray/spec/007-UX-IA.md walking up from "
+                           (System/getProperty "user.dir"))
+                      {})))
+    (if (.exists (io/file dir "tools" "xray" "spec" "007-UX-IA.md"))
+      dir
+      (recur (.getParentFile dir)))))
+
+(defn- spec-mount-fn-names
+  "Read every spec file and return the SET of distinct `mount-<panel>!`
+  names referenced across them, minus the curated removed-name
+  allowlist (deliberate removal-note mentions)."
+  []
+  (let [root (find-repo-root)]
+    (->> spec-files
+         (mapcat (fn [rel]
+                   (let [f (apply io/file root (str/split rel #"/"))]
+                     (re-seq mount-fn-re (slurp f)))))
+         (remove known-removed-names)
+         (into #{}))))
+
+(defmacro emit-spec-mount-fn-names
+  "Expand to a literal set of the `mount-<panel>!` names referenced in
+  the Xray API spec (read at macro-expansion time). The set the
+  panel-enum guard reconciles against the single-source enum + the live
+  facade vars."
+  []
+  (spec-mount-fn-names))


### PR DESCRIPTION
## What

Single-source guard for the Xray **panel enumeration**. "The set of Xray panels" had three projections that could silently drift:
1. **The mount facade** — the `mount-<panel>!` fn family in `day8.re-frame2-xray.panels`.
2. **The Xray API spec** — the `mount-<panel>!` names in `007-UX-IA.md` §Mountable surface inventory + `008-Embedding-Contract.md`.
3. **The api-manifest `:cljs-only` rows** for `panels` (rf2-jhn46 #2786), runtime-verified by the rf2-2mtte probe.

This adds ONE authoritative enumeration and validates the others against it. A drift goes RED in CI.

## Single source chosen

`day8.re-frame2-xray.panel-enum/panel-enum` — a `.cljc` pure-data vector (mirrors `panel_registry.cljc`; JVM-portable, no view/substrate deps), one entry per mountable surface (`{:id :mount :view :tier}`), **12 entries**. `:mount`/`:view` are strings so the catalogue pulls in no code.

## The 3 projections it guards

`panel_enum_guard_cljs_test.cljs` (runs under `npm run test:cljs`) reconciles, **bidirectionally**:
- **Facade ⟺ enum** — live public `mount-*!` vars of `panels` (captured via the rf2-2mtte `emit-ns-publics` analyzer macro) vs the enum's `:mount` set. Orphan fn → RED; enum name with no live fn → RED.
- **Spec ⟺ enum** — `mount-*!` references parsed from `007`+`008` (captured via a compile-time slurp macro `panel_enum_spec_refs.clj`, mirroring the keystone's `emit-cljs-only-rows`) vs the enum. Stale spec name → RED; undocumented panel → RED.
- Plus `all-projections-agree` (all three sets equal), vacuous-green sanity, and enum well-formedness.

The api-manifest rows (projection 3) are already reconciled against the live vars by the rf2-2mtte probe + rf2-gkp0t `xray_spec_check`; pinning the facade to the enum gives the manifest enum-coherence transitively. Removed-name `mount-issues-ribbon!` is silenced via a curated allowlist — the keystone idiom for deliberate removal-note mentions.

## Drift the guard caught (and fixed)

`007-UX-IA.md` named `mount-views!` (a fn that no longer exists) and omitted `mount-reactive-panel!` + `mount-event-spine!`; the surface-count prose was internally inconsistent. Reconciled the inventory to the enum and documented the single-source contract (PANEL-ENUM section only — **not** the §021 views-table owned by #2789).

## Red/green proof

- Added `mount-drift-proof!` to the facade (not the enum) → `facade-matches-enum` + `all-projections-agree` RED. Reverted → green.
- Added `mount-spec-drift-proof!` to the 007 inventory (not the enum) → `spec-matches-enum` + `all-projections-agree` RED. Reverted → green.

## Quality gates

- **Guard RED-on-drift proof** — facade-only drift → RED (`facade-matches-enum`); spec-only drift → RED (`spec-matches-enum`); both reverts → green. Proven via fresh node-test rebuilds.
- `npm run test:cljs` — **green** (Ran 5209 tests / 17808 assertions, 0 failures, 0 errors; includes the new guard + the rf2-2mtte CLJS probe).
- `npm run test:xray-feature-gate` — **green** (16 scenarios, 0 failures, 13 matrix rows; smoke EXIT=0).
- api-manifest checks — **green**: `gen --check` (471 vars in sync), `api-md-check` (191 var-rows), `xray-spec-check` (23 refs).
- `npm run test:bundle-isolation` — **green** (17 entries, 35 sentinels absent; uix/helix reagent-free pass).
- clj-kondo — **green** (0 errors, 0 warnings on all new + edited files).

## Files

- `tools/xray/src/day8/re_frame2_xray/panel_enum.cljc` (new — single source)
- `tools/xray/test/day8/re_frame2_xray/panel_enum_guard_cljs_test.cljs` (new — guard)
- `tools/xray/test/day8/re_frame2_xray/panel_enum_spec_refs.clj` (new — compile-time spec-ref macro)
- `tools/xray/src/day8/re_frame2_xray/panels.cljs` (single-source docstring pointer)
- `tools/xray/spec/007-UX-IA.md` (inventory reconcile + contract; PANEL-ENUM section only)

Closes rf2-rapnr.