### PR TITLE
feat(pair-mcp): reserved-frame-aware operating-frame resolution + echo (rf2-3bu3d.4)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -169,7 +169,9 @@ If you want a refresher on the MCP surface before the first real op, optionally 
 
 ## Multi-frame model — set the operating frame
 
-re-frame2 supports multiple, named frames (Spec 002). Most apps run with one frame (`:rf/default`); larger apps may run several (a stories build, an SSR slot, a sub-app island). Every read/write op resolves an operating frame through a four-tier cascade: explicit per-call `frame` arg (tier 1) → session pin (tier 2) → the sole registered frame (tier 3) → nil/ambiguous (tier 4). On the canonical MCP transport you override per-call with the `frame` arg, e.g. `{frame: ":foo"}` (the legacy bash-shim flag form `--frame :foo` is the back-compat appendix's equivalent — see [references/ops.md §Frames](references/ops.md#frames)).
+re-frame2 supports multiple, named frames (Spec 002). Most apps run with one app frame (`:rf/default`); larger apps may run several (a stories build, an SSR slot, a sub-app island). Every read/write op resolves an operating frame through a four-tier cascade: explicit per-call `frame` arg (tier 1) → session pin (tier 2) → the sole registered **app frame** (tier 3) → nil/ambiguous (tier 4). On the canonical MCP transport you override per-call with the `frame` arg, e.g. `{frame: ":foo"}` (the legacy bash-shim flag form `--frame :foo` is the back-compat appendix's equivalent — see [references/ops.md §Frames](references/ops.md#frames)).
+
+**Reserved tool frames don't count toward ambiguity (rf2-3bu3d.4).** An Xray-instrumented app carries a `:rf/xray` **tool frame** alongside its one app frame — and stories / SSR builds add their own `:rf/*` frames. These framework-reserved `:rf/*` frames are devtool surfaces, not the app you are pairing against, so tier 3 / 4 exclude them: a single-app session that *also* runs Xray resolves to its one app frame **automatically — no `frames/select` needed**. Only two-plus genuine *app* frames are ambiguous. (`:rf/default` is the universal default app frame — it shares the `:rf/*` root but is always counted as an app frame.) A `get-operating-frame` read surfaces both `:frames` (all registered) and `:app-frames` (tool frames removed).
 
 **Set the session pin with the dedicated operating-frame tools (rf2-zomfq).** Three MCP tools surface tier 2 directly — no eval round-trip:
 
@@ -179,7 +181,7 @@ re-frame2 supports multiple, named frames (Spec 002). Most apps run with one fra
 
 These three are NOT subject to the `:ambiguous-frame` refusal themselves — they are how you *resolve* the ambiguity. (The eval-based `frames-list` / `select-frame!` / `frames-meta` runtime helpers in [references/ops.md §Frames](references/ops.md#frames) are the lower-level surface the tools wrap; reach for them only for `frames/meta`, which has no dedicated tool.)
 
-When the operating frame is ambiguous (more than one is registered and the session hasn't pinned one), **every other frame-targeted op refuses with `:ambiguous-frame`** rather than guess — a write that lands in the wrong frame is unrecoverable without `restore-epoch`. (Read ops via the eval helpers warn-and-default to `:rf/default`; the dedicated `snapshot` / `get-path` tools refuse like the writes do.) This mirrors the Spec 002 §Frame presets / lifecycle convention.
+When the operating frame is ambiguous (two-plus **app** frames registered and the session hasn't pinned one), **every other frame-targeted op refuses with `:ambiguous-frame`** rather than guess — a write that lands in the wrong frame is unrecoverable without `restore-epoch`. (Read ops via the eval helpers warn-and-default to `:rf/default`; the dedicated `snapshot` / `get-path` tools refuse like the writes do.) This mirrors the Spec 002 §Frame presets / lifecycle convention.
 
 ---
 

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -216,9 +216,34 @@
 ;;
 ;; re-frame2 is multi-frame (Spec 002). Every read/write op resolves an
 ;; *operating frame* — the session-cached default, overridable per call.
-;; Mutating ops refuse with :ambiguous-frame when more than one frame is
-;; registered and the session hasn't selected one. Reads proceed against
-;; :rf/default and emit a warning.
+;; Mutating ops refuse with :ambiguous-frame when more than one APP frame
+;; is registered and the session hasn't selected one.
+;;
+;; Reserved-frame-aware resolution (rf2-3bu3d.4)
+;; ---------------------------------------------
+;;
+;; A pairing session almost always runs against an app that ALSO carries
+;; a `:rf/*` TOOL frame — Xray's `:rf/xray` inspector frame, a stories
+;; build, an SSR slot. Those frames live under the framework-reserved
+;; `:rf/*` root (spec/Conventions.md §Reserved namespaces). They are NOT
+;; the app the operator is pairing against; they are devtool surfaces the
+;; tooling itself mounted. Counting them toward ambiguity meant every
+;; Xray-instrumented app (the common case) was "ambiguous" on the first
+;; mutating op — forcing a `frames/select` + retry up front for no real
+;; choice (there is exactly one APP frame; the other is a tool frame).
+;;
+;; So the resolver is RESERVED-FRAME-AWARE: a `:rf/*`-namespaced frame is
+;; a tool frame and is EXCLUDED from the ambiguity count, with ONE
+;; deliberate exception — `:rf/default`, which Conventions.md §The
+;; single-root reserved set names as "the universal default frame id". It
+;; is the canonical APP frame, not a tool frame, despite sharing the
+;; `:rf/*` root. We key off the reserved-namespace RULE (namespace = "rf",
+;; minus the `:rf/default` carve-out), never a literal `:rf/xray`, so the
+;; behaviour holds for any tool frame any project mounts under `:rf/*`.
+;;
+;; When exactly one APP frame remains after excluding tool frames, tier 3
+;; AUTO-SELECTS it: single-app + Xray is unambiguous with no `frames/
+;; select` tax. Two-plus app frames stay genuinely ambiguous (tier 4).
 
 (defonce ^:private selected-frame (atom nil))
 
@@ -229,30 +254,68 @@
   (reset! selected-frame frame-id)
   {:ok? true :frame frame-id})
 
+(defn reserved-tool-frame?
+  "True when `frame-id` names a framework-reserved `:rf/*` TOOL frame —
+   a devtool surface (Xray's `:rf/xray`, an SSR slot, …) the tooling
+   mounted, NOT an app frame the operator is pairing against.
+
+   The rule is the reserved-namespace convention (spec/Conventions.md
+   §Reserved namespaces — framework-owned ids live under the single `:rf/*`
+   root), NOT a hardcoded id, so it holds for every `:rf/*` tool frame any
+   project mounts. The SOLE carve-out is `:rf/default`: Conventions.md §The
+   single-root reserved set names it \"the universal default frame id\" —
+   it shares the `:rf/*` root but IS the canonical app frame, so it is
+   never treated as a tool frame.
+
+   Non-keyword / un-namespaced ids (a user's `:stories`, `:sandbox`) are
+   app frames and return false."
+  [frame-id]
+  (and (keyword? frame-id)
+       (= "rf" (namespace frame-id))
+       (not= :rf/default frame-id)))
+
+(defn app-frame-ids
+  "The registered frame ids with `:rf/*` reserved TOOL frames removed —
+   the frames the operator is actually pairing against (rf2-3bu3d.4).
+   `:rf/default` is retained (it is an app frame; see
+   `reserved-tool-frame?`). The order/source mirrors `(rf/frame-ids)`."
+  []
+  (vec (remove reserved-tool-frame? (rf/frame-ids))))
+
 (defn current-frame
   "Resolve the operating frame: explicit override -> session pin ->
-   the sole registered frame -> nil (ambiguous).
+   the sole registered APP frame -> nil (ambiguous).
 
-   Returns nil whenever more than one frame is registered AND the
-   session hasn't selected one (and the caller didn't pass an override).
-   Mutating ops then refuse via the `:ambiguous-frame` path in
-   `pair-dispatch-sync!`. Reads that nil-default to `:rf/default` would
-   silently land in the wrong frame, so the resolver is deliberately
-   conservative — callers either pin via `select-frame!`, pass an
-   explicit override, or get a clear refusal."
+   Tier 3 is reserved-frame-aware (rf2-3bu3d.4): `:rf/*` TOOL frames
+   (Xray's `:rf/xray`, SSR slots, …) are EXCLUDED before counting, so a
+   single-app session that ALSO carries an Xray frame resolves to the one
+   app frame instead of refusing. `:rf/default` is an app frame and is
+   retained (see `reserved-tool-frame?`). When two-plus APP frames remain
+   the resolver yields nil and mutating ops refuse via the
+   `:ambiguous-frame` path — reads that nil-default to `:rf/default` would
+   silently land in the wrong frame, so the resolver stays conservative:
+   callers either pin via `select-frame!`, pass an explicit override, or
+   get a clear refusal."
   ([] (current-frame nil))
   ([override]
    (or override
        @selected-frame
-       (let [fids (rf/frame-ids)]
-         (when (= 1 (count fids))
-           (first fids))))))
+       (let [app-fids (app-frame-ids)]
+         (when (= 1 (count app-fids))
+           (first app-fids))))))
 
 (defn frames-list
-  "All registered, non-destroyed frame ids plus the operating frame."
+  "All registered, non-destroyed frame ids plus the operating frame.
+
+   `:app-frames` exposes the reserved-frame-aware view (rf2-3bu3d.4):
+   the registered frames with `:rf/*` tool frames removed. When it holds
+   exactly one id while `:frames` holds more, the session is
+   single-app-plus-tool-frame and `:operating` auto-resolved to that lone
+   app frame (no `select-frame!` was needed)."
   []
   {:ok?              true
    :frames           (vec (rf/frame-ids))
+   :app-frames       (app-frame-ids)
    :selected         @selected-frame
    :operating        (current-frame)})
 
@@ -3523,7 +3586,8 @@
   (install-last-click-capture!)
   (ensure-trace-listener!)
   (ensure-epoch-listener!)
-  (let [fids (rf/frame-ids)]
+  (let [fids     (rf/frame-ids)
+        app-fids (app-frame-ids)]
     {:ok?                       true
      :session-id                session-id
      ;; rf2-ertqw — the browser half of the freshness token rides on
@@ -3539,9 +3603,21 @@
      :coord-annotation-enabled? (coord-annotation-enabled?)
      :last-click-capture?       true
      :frames                    (vec fids)
+     ;; rf2-3bu3d.4 — the reserved-frame-aware view: registered frames
+     ;; with `:rf/*` TOOL frames (Xray's `:rf/xray`, SSR slots, …)
+     ;; removed. `:rf/default` is retained (it is an app frame). When
+     ;; this holds exactly one id while `:frames` holds more, the session
+     ;; is single-app-plus-tool-frame and resolution auto-selects the
+     ;; lone app frame — see `:ambiguous-frame?` below.
+     :app-frames                app-fids
      :selected-frame            @selected-frame
      :operating-frame           (current-frame)
-     :ambiguous-frame?          (and (> (count fids) 1)
+     ;; rf2-3bu3d.4 — ambiguity counts APP frames, not raw frames. A
+     ;; single-app session that ALSO carries an Xray (or other `:rf/*`
+     ;; tool) frame has exactly one app frame, so it is NOT ambiguous and
+     ;; pays no `frames/select` tax. Genuinely multi-app sessions (two-plus
+     ;; non-tool frames) stay ambiguous until the session pins one.
+     :ambiguous-frame?          (and (> (count app-fids) 1)
                                      (nil? @selected-frame))
      :epoch-history-depth       (try
                                   (let [requiring (resolve 're-frame.epoch/current-config)]

--- a/skills/re-frame2-pair/references/ops.md
+++ b/skills/re-frame2-pair/references/ops.md
@@ -35,13 +35,15 @@ Most ops wrap a call into `re-frame2-pair.runtime`; for those, the MCP form is `
 
 ## Frames
 
-Set and inspect the operating frame (SKILL.md §Multi-frame model). Every read/write op resolves an operating frame: an explicit per-call `frame: ":foo"` arg wins, else the session pin, else the sole registered frame, else `:ambiguous-frame` for mutating ops.
+Set and inspect the operating frame (SKILL.md §Multi-frame model). Every read/write op resolves an operating frame: an explicit per-call `frame: ":foo"` arg wins, else the session pin, else the sole registered **app frame**, else `:ambiguous-frame` for mutating ops.
+
+**Reserved tool frames are excluded from the ambiguity count (rf2-3bu3d.4).** `:rf/*` reserved tool frames — Xray's `:rf/xray`, an SSR slot, … (per [Conventions.md §Reserved namespaces](../../../spec/Conventions.md)) — are devtool surfaces the tooling mounted, not the app you are pairing against, so they are removed before counting. A single-app session that *also* carries an `:rf/xray` frame (the common Xray-instrumented case) has exactly one app frame and resolves to it automatically — **no `frames/select` is needed**. Only a session with two-plus genuine *app* frames is ambiguous. The carve-out is `:rf/default`: it shares the `:rf/*` root but IS the universal default app frame, so it is always counted as an app frame.
 
 **Prefer the dedicated operating-frame tools (rf2-zomfq)** to set and read the session pin — `set-operating-frame {frame: ":foo"}` / `reset-operating-frame {}` / `get-operating-frame {}`. They are the wire-level surfacing of the pin and the escape from the tier-4 `:ambiguous-frame` refusal (see SKILL.md §Multi-frame model). The eval-based helpers below wrap the same preload functions (`select-frame!` / `current-frame` / `frame-meta`); reach for them only for `frames/meta`, which has no dedicated tool, or when you want the raw runtime return shape.
 
 | Op | Invocation | Returns |
 |---|---|---|
-| `frames/list` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/frames-list)"}` | `{:ok? true :frames [...] :selected <pinned-or-nil> :operating <resolved-or-nil>}` — registered, non-destroyed frame ids plus the resolved operating frame (`rf/frame-ids`). |
+| `frames/list` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/frames-list)"}` | `{:ok? true :frames [...] :app-frames [...] :selected <pinned-or-nil> :operating <resolved-or-nil>}` — `:frames` is every registered, non-destroyed frame (`rf/frame-ids`); `:app-frames` is the reserved-frame-aware view (`:frames` minus `:rf/*` tool frames like `:rf/xray`). When `:app-frames` holds one id while `:frames` holds more, `:operating` auto-resolved to that sole app frame (rf2-3bu3d.4). |
 | `frames/select` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/select-frame! :stories)"}` | Pin the session's default operating frame; subsequent ops use it unless they pass an explicit `frame` arg. `{:ok? true :frame :stories}`. |
 | `frames/meta` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/frames-meta :stories)"}` | Flat metadata map for one frame (`rf/frame-meta`): `:id`, `:created-at`, the preset-expansion keys (`:preset`, `:fx-overrides`, `:drain-depth`, …) and lifecycle fields (`:destroyed?`, `:listeners`) at the top level. `{:ok? false :reason :no-such-frame :frame-id id}` when unregistered. See `:rf/frame-meta` in Spec-Schemas. |
 

--- a/skills/re-frame2-pair/tests/runtime/multi_frame_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/multi_frame_test.clj
@@ -87,14 +87,29 @@
   (reset! selected-frame frame-id)
   {:ok? true :frame frame-id})
 
+;; rf2-3bu3d.4 — reserved-frame-aware resolution. KEEP IN SYNC with
+;; `reserved-tool-frame?` / `app-frame-ids` / `current-frame` in
+;; preload/re_frame2_pair/runtime.cljs. A `:rf/*` frame is a TOOL frame
+;; (Xray's `:rf/xray`, SSR slots) EXCLUDED from the ambiguity count, with
+;; the sole `:rf/default` carve-out (the universal default APP frame per
+;; Conventions.md §The single-root reserved set).
+
+(defn reserved-tool-frame? [frame-id]
+  (and (keyword? frame-id)
+       (= "rf" (namespace frame-id))
+       (not= :rf/default frame-id)))
+
+(defn app-frame-ids []
+  (vec (remove reserved-tool-frame? (frame-ids))))
+
 (defn current-frame
   ([] (current-frame nil))
   ([override]
    (or override
        @selected-frame
-       (let [fids (frame-ids)]
-         (when (= 1 (count fids))
-           (first fids))))))
+       (let [app-fids (app-frame-ids)]
+         (when (= 1 (count app-fids))
+           (first app-fids))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Mirror of `subs-sample` — threads the resolved frame through
@@ -197,6 +212,64 @@
 (deftest current-frame-explicit-override-with-no-frames-registered
   (testing "explicit override returns even if frame isn't registered (resolver is naive)"
     (is (= :ghost (current-frame :ghost)))))
+
+;; ---------------------------------------------------------------------------
+;; Reserved-frame-aware resolution (rf2-3bu3d.4)
+;;
+;; A `:rf/*` TOOL frame (`:rf/xray`, an SSR slot) is excluded from the
+;; ambiguity count; the sole remaining APP frame auto-selects. `:rf/default`
+;; is an APP frame (the universal default), NOT a tool frame.
+;; ---------------------------------------------------------------------------
+
+(deftest reserved-tool-frame-predicate
+  (testing ":rf/* tool frames are reserved; :rf/default and user frames are not"
+    (is (true?  (reserved-tool-frame? :rf/xray)))
+    (is (true?  (reserved-tool-frame? :rf/ssr)))
+    (is (false? (reserved-tool-frame? :rf/default))
+        ":rf/default is the universal default APP frame, not a tool frame")
+    (is (false? (reserved-tool-frame? :stories)))
+    (is (false? (reserved-tool-frame? :rf-default))
+        "un-namespaced lookalike is a user frame")))
+
+(deftest current-frame-single-app-plus-xray-auto-resolves
+  (testing "single app frame (:rf/default) + :rf/xray tool frame -> auto-selects :rf/default (NO :ambiguous-frame)"
+    (register-frame! :rf/default {:count 0})
+    (register-frame! :rf/xray {})
+    (is (= [:rf/default] (app-frame-ids))
+        ":rf/xray excluded from the app-frame view")
+    (is (= :rf/default (current-frame))
+        "the sole app frame auto-resolves — no frames/select tax")))
+
+(deftest current-frame-single-user-app-plus-xray-auto-resolves
+  (testing "single non-default app frame + :rf/xray -> auto-selects the app frame"
+    (register-frame! :my-app {:count 0})
+    (register-frame! :rf/xray {})
+    (is (= :my-app (current-frame)))))
+
+(deftest current-frame-two-app-frames-plus-xray-stays-ambiguous
+  (testing "two app frames + :rf/xray -> still ambiguous (excluding the tool frame leaves two app frames)"
+    (register-frame! :rf/default {})
+    (register-frame! :stories {})
+    (register-frame! :rf/xray {})
+    (is (= 2 (count (app-frame-ids))))
+    (is (nil? (current-frame))
+        "two genuine app frames remain after excluding the tool frame — ambiguous")))
+
+(deftest current-frame-only-reserved-tool-frames
+  (testing "only :rf/* tool frames registered (no app frame) -> nil (no app frame to resolve)"
+    (register-frame! :rf/xray {})
+    (is (empty? (app-frame-ids)))
+    (is (nil? (current-frame)))))
+
+(deftest pair-dispatch-sync-single-app-plus-xray-succeeds
+  (testing "single-app + :rf/xray: pair-dispatch-sync! resolves the app frame WITHOUT select-frame!"
+    (register-frame! :rf/default {:count 0})
+    (register-frame! :rf/xray {})
+    (let [result (pair-dispatch-sync! [:counter/inc])]
+      (is (:ok? result)
+          "no :ambiguous-frame refusal — the tool frame is excluded")
+      (is (= :rf/default (:frame result))
+          "the resolved operating frame is echoed and is the app frame"))))
 
 ;; ---------------------------------------------------------------------------
 ;; pair-dispatch-sync! refuses on :ambiguous-frame

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -393,12 +393,16 @@ Pair-shaped tools (re-frame-pair, re-frame2-pair, [re-frame-pair-improver](https
 |---|---|---|
 | 1 | **Explicit per-call override** | The caller passes a frame-id with the op (e.g. `(rf/app-db-value :stories)`, `(subs-sample [:cart/total] :stories)`, `{:frame :stories}` on dispatch opts). |
 | 2 | **Session-pinned selection** | The tool's session has called `select-frame!` (or its equivalent) since the last reset; the pinned id is the resolved frame. |
-| 3 | **Sole-registered frame** | The framework's `(rf/frame-ids)` returns exactly one frame. That frame is the resolved frame, regardless of whether it is `:rf/default` or some other id. |
-| 4 | **Nil** (ambiguous) | More than one frame is registered, the session has not pinned a selection, and the caller did not pass an override. The resolver yields nil; the op routes via the §Ambiguity surface below. |
+| 3 | **Sole-registered app frame** | After excluding `:rf/*` reserved **tool frames** (see below), exactly one **app frame** remains registered. That frame is the resolved frame, regardless of whether it is `:rf/default` or some other id. |
+| 4 | **Nil** (ambiguous) | Two or more **app frames** are registered, the session has not pinned a selection, and the caller did not pass an override. The resolver yields nil; the op routes via the §Ambiguity surface below. |
 
-**Single-frame applications never reach tier 4.** A re-frame2 application with only `:rf/default` registered always resolves at tier 3; the pair tool's UX is identical to single-frame re-frame. The contract is structurally backwards-compatible — a single-frame consumer sees no ambiguity prompt.
+**Single-app applications never reach tier 4.** A re-frame2 application with only `:rf/default` registered always resolves at tier 3; the pair tool's UX is identical to single-frame re-frame. The contract is structurally backwards-compatible — a single-app consumer sees no ambiguity prompt.
 
-**`:rf/default` is not a special-case fallback.** A common naïve implementation would fall back to `:rf/default` at tier 4 (since it's always pre-registered per [002 §`:rf/default`](002-Frames.md#rfdefault)). The hybrid contract **rejects** that fallback: a multi-frame app's `:rf/default` is one frame among many, and silently landing reads or writes there masks the ambiguity rather than surfacing it. Tier 3 picks `:rf/default` only when it is **uniquely** registered.
+**Reserved tool frames are excluded from the ambiguity count.** A pairing session almost always runs against an app that *also* carries a framework-reserved `:rf/*` **tool frame** — Xray's `:rf/xray` inspector frame ([009 §Per-frame trace rings](009-Instrumentation.md#per-frame-trace-rings-cascade-keyed-dev-only) registers it with `:rf.trace/frame-no-emit? true`), a stories build, an SSR slot. These frames live under the framework-reserved `:rf/*` root ([Conventions.md §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)); they are devtool surfaces the *tooling* mounted, not the application the operator is pairing against. The resolver is therefore **reserved-frame-aware**: tiers 3 and 4 count only **app frames** — `(rf/frame-ids)` with the `:rf/*` tool frames removed. A single-app session that *also* carries an `:rf/xray` frame (the common Xray-instrumented case) has exactly one app frame and resolves at tier 3 — it does **not** pay a tier-4 `:ambiguous-frame` tax for a choice that doesn't exist. A two-plus-app-frame session stays genuinely ambiguous at tier 4 regardless of any tool frames present.
+
+The exclusion keys off the **reserved-namespace rule** (a frame-id whose namespace is `rf`), never a hardcoded `:rf/xray`, so it holds for every `:rf/*` tool frame any project mounts. The **sole carve-out is `:rf/default`**: [Conventions.md §The single-root reserved set](Conventions.md#the-single-root-reserved-set) names it "the universal default frame id" — it shares the `:rf/*` root but *is* the canonical app frame, so it is never treated as a tool frame and is counted as an app frame at tiers 3 and 4. A `frames/list` (or `get-operating-frame`) read surfaces both `:frames` (all registered) and `:app-frames` (the reserved-frame-aware view) so a tool UI can show the distinction.
+
+**`:rf/default` is not a special-case fallback.** A common naïve implementation would fall back to `:rf/default` at tier 4 (since it's always pre-registered per [002 §`:rf/default`](002-Frames.md#rfdefault)). The hybrid contract **rejects** that fallback: a multi-app application's `:rf/default` is one app frame among many, and silently landing reads or writes there masks the ambiguity rather than surfacing it. Tier 3 picks `:rf/default` only when it is the **unique** app frame.
 
 **Session-pin lifecycle.** A `select-frame!` call binds the operating frame for the session and persists across subsequent calls (the "implicit-until-reset" half of the hybrid posture). The selection is cleared by either a `reset-operating-frame!` (or equivalent) call, a runtime reload (the session sentinel changes, per [§How AI tools attach](#how-ai-tools-attach)), or destroying the pinned frame (the next resolution falls through to tier 3 or 4). Pair tools that surface a "current operating frame" indicator in their UI read the session pin directly; tools that want to show the *resolved* frame call the resolver and display its result (or "ambiguous" when nil).
 
@@ -425,13 +429,14 @@ Pair-shaped tools that implement the operating-frame contract MUST expose three 
 - **Inspect the operating frame.** A read returning the **resolved** operating frame (or nil when ambiguous) plus the **pinned** selection (when distinct from resolved) plus the **all-registered** frame list (so callers can pick a target). The reference impl shape:
 
 ```clojure
-{:ok?       true
- :frames    [<frame-id> ...]   ;; (rf/frame-ids)
- :selected  <frame-id|nil>     ;; tier-2 session pin
- :operating <frame-id|nil>}    ;; result of full resolution (nil = ambiguous)
+{:ok?        true
+ :frames     [<frame-id> ...]   ;; (rf/frame-ids) — all registered
+ :app-frames [<frame-id> ...]   ;; (rf/frame-ids) minus :rf/* tool frames
+ :selected   <frame-id|nil>     ;; tier-2 session pin
+ :operating  <frame-id|nil>}    ;; result of full resolution (nil = ambiguous)
 ```
 
-The triple-shape lets a tool UI render both "you have pinned X" (the selection) and "writes will go to X" (the resolved frame) — useful when the two diverge (e.g. tier-1 override on the current call, or sole-registered tier-3 fallthrough that the user hasn't explicitly chosen).
+The shape lets a tool UI render "you have pinned X" (the selection), "writes will go to X" (the resolved frame), and "these are the app frames vs the tool frames present" (`:app-frames` ⊆ `:frames`). When `:app-frames` holds exactly one id while `:frames` holds more, the session is single-app-plus-tool-frame and `:operating` auto-resolved to that lone app frame (no `select-frame!` was needed). The selection and resolved frame diverge on a tier-1 override on the current call, or a sole-app tier-3 fallthrough the user hasn't explicitly chosen.
 
 **MCP / RPC surfacing.** Tools that expose pair surfaces over MCP / RPC SHOULD enumerate the three ops in their tool catalogue under stable names (typically `set-operating-frame`, `reset-operating-frame`, `get-operating-frame`). The runtime contract does not pin the wire names — only the semantics — but cross-tool consistency lets a user trained on re-frame2-pair carry the mental model to re-frame-pair-improver, Xray, or Story without relearning the resolver.
 
@@ -465,7 +470,27 @@ The triple-shape lets a tool UI render both "you have pinned X" (the selection) 
 ;; => {:ok? false :reason :ambiguous-frame ...}
 ```
 
-The example exercises every tier — explicit override (tier 1), session pin (tier 2 binding and re-use, plus tier-1 supersession), and tier-4 refusal both before and after reset. Single-frame apps never reach the refusal path.
+The example exercises every tier — explicit override (tier 1), session pin (tier 2 binding and re-use, plus tier-1 supersession), and tier-4 refusal both before and after reset. Single-app apps never reach the refusal path.
+
+```clojure
+;; Reserved-frame-aware resolution: an Xray-instrumented single-app
+;; session. Two frames are registered — the app's :rf/default and Xray's
+;; :rf/xray tool frame — but only ONE is an app frame, so resolution is
+;; unambiguous WITHOUT a select-frame!.
+(frames-list)
+;; => {:ok? true
+;;     :frames     [:rf/default :rf/xray]   ;; both registered
+;;     :app-frames [:rf/default]            ;; :rf/xray excluded (a :rf/* tool frame)
+;;     :selected   nil
+;;     :operating  :rf/default}             ;; tier-3 auto-resolved the sole app frame
+
+;; The first mutating op proceeds against :rf/default — no :ambiguous-frame tax.
+(pair-dispatch-sync! [:counter/inc])
+;; => {:ok? true :epoch-id ... :frame :rf/default}
+
+;; Targeting the tool frame still works via an explicit override (tier 1).
+(app-db-value :rf/xray)                    ;; reads the Xray frame explicitly
+```
 
 ## How AI tools attach
 
@@ -818,4 +843,4 @@ The runtime contract above is fixed; the notes below capture open design questio
 
 ### Multi-frame operating-frame resolution — hybrid posture
 
-Resolved: pair-shaped tools resolve a multi-frame application's operating frame via the four-tier rule pinned at [§Operating frame — multi-frame resolution](#operating-frame). The shipped impl in `re-frame2-pair.runtime` (per [rf2-19xl](https://github.com/day8/re-frame2/pull/190)) is the canonical reference — `current-frame-id` walks **explicit override → session pin → sole-registered frame → nil**, and both read-shaped (`subs-sample`, `snapshot`, `epoch-history`, …) and mutating-shaped (`pair-dispatch-sync!`, `app-db-reset!`, `restore-epoch`) ops refuse with `{:ok? false :reason :ambiguous-frame}` when resolution yields nil. `:rf/default` is not a tier-4 fallback — silently routing to it would mask the ambiguity in a multi-frame session. The hybrid posture (explicit-context-set, implicit-until-reset) supersedes the earlier "Lean" note in §Design notes; single-frame applications never reach the refusal path. The tool surface MUST expose `set-operating-frame` / `reset-operating-frame` / `get-operating-frame` ops (names illustrative; semantics normative) so multi-frame users can pin a target, clear the pin, and inspect the resolver's view. See [§Operating frame — multi-frame resolution](#operating-frame) for the full contract.
+Resolved: pair-shaped tools resolve a multi-frame application's operating frame via the four-tier rule pinned at [§Operating frame — multi-frame resolution](#operating-frame). The shipped impl in `re-frame2-pair.runtime` (per [rf2-19xl](https://github.com/day8/re-frame2/pull/190)) is the canonical reference — `current-frame` walks **explicit override → session pin → sole-registered app frame → nil**, and both read-shaped (`subs-sample`, `snapshot`, `epoch-history`, …) and mutating-shaped (`pair-dispatch-sync!`, `app-db-reset!`, `restore-epoch`) ops refuse with `{:ok? false :reason :ambiguous-frame}` when resolution yields nil. The resolver is **reserved-frame-aware** (rf2-3bu3d.4): tiers 3 and 4 count only app frames — `(rf/frame-ids)` with `:rf/*` reserved tool frames (Xray's `:rf/xray`, SSR slots) removed, the sole carve-out being `:rf/default` (the universal default app frame). So a single-app session that also carries an `:rf/xray` frame resolves at tier 3 without a `frames/select`. `:rf/default` is not a tier-4 fallback — silently routing to it would mask the ambiguity in a multi-app session. The hybrid posture (explicit-context-set, implicit-until-reset) supersedes the earlier "Lean" note in §Design notes; single-frame applications never reach the refusal path. The tool surface MUST expose `set-operating-frame` / `reset-operating-frame` / `get-operating-frame` ops (names illustrative; semantics normative) so multi-frame users can pin a target, clear the pin, and inspect the resolver's view. See [§Operating frame — multi-frame resolution](#operating-frame) for the full contract.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
@@ -88,6 +88,31 @@
           (update :note (fn [existing]
                           (if existing (str sentence " " existing) sentence)))))))
 
+(defn- with-frame-resolution
+  "Annotate a healthy (non-ambiguous) discover-app payload with the
+  resolved operating frame and, when applicable, the auto-resolution
+  fact (rf2-3bu3d.4).
+
+  `health` carries `:operating-frame` (the runtime's resolved frame),
+  `:frames` (all registered), and `:app-frames` (frames with `:rf/*`
+  tool frames removed). When a tool frame was excluded — `:app-frames`
+  shorter than `:frames` — AND resolution auto-landed on the sole
+  remaining app frame, seed a note so the operator sees that ops resolve
+  to that frame WITHOUT a `frames/select`, and which frames the tooling
+  excluded. The resolved frame is also echoed under `:operating-frame`
+  (already on `health`) so every op's frame target is never a guess."
+  [health]
+  (let [{:keys [frames app-frames operating-frame]} health
+        excluded (vec (remove (set app-frames) frames))]
+    (if (and (seq excluded) operating-frame)
+      (let [sentence (str "Operating frame auto-resolved to " operating-frame
+                          " — the sole app frame. Excluded :rf/* tool frame(s): "
+                          excluded ". No frames/select needed; pass --frame to "
+                          "target a tool frame explicitly.")]
+        (update health :note (fn [existing]
+                               (if existing (str sentence " " existing) sentence))))
+      health)))
+
 (defn- with-freshness
   "Attach the assembled freshness/liveness token to an `:ok? true`
   health payload (rf2-ertqw). Async — reads the JVM-side build worker
@@ -147,10 +172,19 @@
                 (with-freshness conn build-id
                   (assoc health :ok? true
                                 :warning :ambiguous-frame
-                                :note (str "Multiple frames registered: "
-                                           (vec (:frames health))
+                                ;; rf2-3bu3d.4 — point the operator at the
+                                ;; APP frames (the real choices). `:rf/*`
+                                ;; tool frames (`:rf/xray`, …) were already
+                                ;; excluded from the ambiguity count, so
+                                ;; naming them here as candidates would
+                                ;; mislead. Genuine ambiguity = two-plus
+                                ;; app frames.
+                                :note (str "Multiple app frames registered: "
+                                           (vec (or (:app-frames health) (:frames health)))
                                            ". Mutating ops require --frame :foo "
-                                           "or run `frames/select` first."))
+                                           "or run `frames/select` first. "
+                                           "(`:rf/*` tool frames are excluded "
+                                           "from this list.)"))
                   (fn [h] (wire/ok-text (with-auto-selection h auto-selected? build-id)))))
 
               (not (:coord-annotation-enabled? health))
@@ -174,6 +208,6 @@
                 ;; `:app` env-var fallback. Invalidates on nREPL reconnect.
                 (wire/mark-resolved-build-id! conn build-id)
                 (with-freshness conn build-id
-                  (assoc health :ok? true :build-id build-id)
+                  (with-frame-resolution (assoc health :ok? true :build-id build-id))
                   (fn [h] (wire/ok-text (with-auto-selection h auto-selected? build-id))))))))
         (.catch (fn [err] (probe/err->result :discover-failed err)))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_reserved_frame_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/discover_app_reserved_frame_test.cljs
@@ -1,0 +1,121 @@
+(ns re-frame2-pair-mcp.discover-app-reserved-frame-test
+  "Pin discover-app's reserved-frame-aware operating-frame resolution
+  (rf2-3bu3d.4).
+
+  ROOT CAUSE this fixes: any app instrumented with Xray carries a
+  `:rf/xray` TOOL frame alongside its one app frame. The pre-fix
+  ambiguity logic counted ALL frames, so EVERY Xray-instrumented app (the
+  common pairing case) was reported `:ambiguous-frame` on discover-app —
+  forcing a `frames/select` + retry up front for a choice that didn't
+  exist (there is exactly ONE app frame).
+
+  CONTRACT these tests pin (the runtime's `health` computes the
+  reserved-frame-aware `:ambiguous-frame?` + `:app-frames`; discover-app
+  shapes them):
+
+   1. Single app frame (`:rf/default`) + `:rf/xray` tool frame is NOT
+      ambiguous — discover-app returns the healthy success payload with
+      the operating frame ECHOED and a note that the tool frame was
+      excluded and the app frame auto-resolved (no `frames/select` tax).
+   2. Two app frames + `:rf/xray` IS still ambiguous — the ambiguity
+      note names the APP frames (the real choices), not the tool frame.
+
+  `:rf/default` is the universal default APP frame (Conventions.md §The
+  single-root reserved set) and is NEVER excluded, despite sharing the
+  `:rf/*` root."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [clojure.string :as str]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.discover-app :as discover-app]
+            [re-frame2-pair-mcp.test-utils :as tu]))
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{} :resolved-build-id nil)
+    conn))
+
+(defn- prime! [conn build-id]
+  (swap! conn update :probed-builds (fnil conj #{}) build-id))
+
+;; A single-app-plus-Xray health payload: one app frame (:rf/default), one
+;; :rf/* tool frame (:rf/xray). The runtime's reserved-frame-aware
+;; `health` reports NOT ambiguous and surfaces the app-frame view +
+;; resolved operating frame.
+(def ^:private single-app-plus-xray-health
+  {:ok?                        true
+   :debug-enabled?             true
+   :coord-annotation-enabled?  true
+   :frames                     [:rf/default :rf/xray]
+   :app-frames                 [:rf/default]
+   :operating-frame            :rf/default
+   :ambiguous-frame?           false})
+
+;; Two genuine app frames plus a tool frame: still ambiguous.
+(def ^:private two-app-frames-plus-xray-health
+  {:ok?                        true
+   :debug-enabled?             true
+   :coord-annotation-enabled?  true
+   :frames                     [:rf/default :stories :rf/xray]
+   :app-frames                 [:rf/default :stories]
+   :operating-frame            nil
+   :ambiguous-frame?           true})
+
+(deftest single-app-plus-xray-is-not-ambiguous
+  ;; The headline case: an Xray-instrumented single-app session resolves
+  ;; unambiguously — no :ambiguous-frame warning, the operating frame is
+  ;; echoed, and the note explains the auto-resolution + the excluded
+  ;; tool frame.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime! conn :examples/my-app)
+          args (tu/args->js {:build "examples/my-app"})]
+      (-> (tu/with-stubbed-freshness! {:compile-cycle 1 :build-flushed-at 100
+                                       :runtime-count 1 :heartbeat-age-ms 50}
+            (fn []
+              (tu/with-stubbed-eval! single-app-plus-xray-health
+                (fn [] (discover-app/discover-app conn args)))))
+          (.then
+            (fn [result]
+              (let [edn  (tu/extract-edn result)
+                    text (tu/extract-text result)]
+                (is (true? (:ok? edn)))
+                (is (not= :ambiguous-frame (:warning edn))
+                    "single-app + :rf/xray must NOT warn :ambiguous-frame")
+                (is (= :rf/default (:operating-frame edn))
+                    "the resolved operating frame is echoed (never a guess)")
+                (is (str/includes? (:note edn) ":rf/default")
+                    "the note echoes the auto-resolved app frame")
+                (is (str/includes? (:note edn) ":rf/xray")
+                    "the note names the excluded :rf/* tool frame")
+                (is (str/includes? text "auto-resolved")
+                    "the canonical text states the frame auto-resolved"))
+              (done)))))))
+
+(deftest two-app-frames-plus-xray-stays-ambiguous
+  ;; Genuine ambiguity survives: two app frames are a real choice. The
+  ;; ambiguity note names the APP frames, not the excluded tool frame.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime! conn :examples/multi)
+          args (tu/args->js {:build "examples/multi"})]
+      (-> (tu/with-stubbed-freshness! {:compile-cycle 1 :build-flushed-at 100
+                                       :runtime-count 1 :heartbeat-age-ms 50}
+            (fn []
+              (tu/with-stubbed-eval! two-app-frames-plus-xray-health
+                (fn [] (discover-app/discover-app conn args)))))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                (is (= :ambiguous-frame (:warning edn))
+                    "two app frames is genuinely ambiguous")
+                (is (str/includes? (:note edn) ":stories")
+                    "the note names the candidate APP frames")
+                (is (str/includes? (:note edn) ":rf/default")
+                    "...both of them")
+                ;; The note must frame the choice as APP frames and flag
+                ;; that tool frames were excluded.
+                (is (str/includes? (:note edn) "app frames")
+                    "the note frames the choice as APP frames")
+                (is (str/includes? (:note edn) "tool frames are excluded")
+                    "the note states :rf/* tool frames were excluded"))
+              (done)))))))


### PR DESCRIPTION
## What

Closes the LAST item of EPIC rf2-3bu3d. Builds on the merged pair-MCP stack (#2791/#2793/#2794/#2795).

**Root cause.** Any app instrumented with Xray (the common pairing case) carries an `:rf/xray` tool frame alongside its one app frame. The operating-frame resolver counted ALL frames, so it landed at tier-4 `:ambiguous-frame` on the first mutating op — forcing a `frames/select` + retry for a choice that didn't exist (there is exactly one app frame).

**Fix — reserved-frame-aware resolution.** Tiers 3/4 now count only **app frames**, excluding `:rf/*` reserved **tool frames** (Xray's `:rf/xray`, SSR slots, stories builds — per [Conventions.md §Reserved namespaces](../blob/main/spec/Conventions.md)). The sole carve-out is `:rf/default`, which Conventions.md names "the universal default frame id" — it shares the `:rf/*` root but IS the canonical app frame, so it is never excluded. The exclusion keys off the **reserved-namespace rule** (frame-id namespace = `rf`), never a literal `:rf/xray`, so it holds for every `:rf/*` tool frame any project mounts.

- Single-app + `:rf/xray` now **auto-resolves** the lone app frame at tier 3 — no `frames/select` tax.
- Two-plus app frames stay genuinely ambiguous (tier 4).
- The resolved operating frame is **echoed** in op results (most ops already echo `:frame`; discover-app now echoes `:operating-frame` + a note naming the excluded tool frame).

## Changes

- **runtime** (`preload/re_frame2_pair/runtime.cljs`): add `reserved-tool-frame?` + `app-frame-ids`; `current-frame` tier 3 and `health` `:ambiguous-frame?` count app frames; `frames-list` + `health` expose `:app-frames`.
- **discover-app** (`tools/discover_app.cljs`): `with-frame-resolution` echoes the auto-resolved operating frame + seeds a note on the success path; the ambiguity note names the candidate APP frames and flags that `:rf/*` tool frames were excluded.
- **spec/docs**: Tool-Pair.md (hot-zone — owned) documents the reserved-frame-aware tier 3, the `:app-frames` slot, a worked Xray example, and the resolved-decisions note. SKILL.md + references/ops.md updated to match.
- **tests**: babashka mirror (`multi_frame_test.clj`) proves single-app+`:rf/xray` resolves unambiguously (`reserved-tool-frame?` predicate, auto-resolve, two-app-stays-ambiguous, dispatch-without-select); new server-side `discover_app_reserved_frame_test.cljs` pins the discover-app shape (echo + note + ambiguity-vs-not).

No tool descriptor changed (adding `:resolved-frame`/`:app-frames` to op RESULTS doesn't touch input-keys/output?/annotations) — confirmed via check:descriptors (26 tools, in sync).

## Quality gates

- `npm run check:descriptors` — **exit 0** (tool-descriptors.edn in sync, 26 tools).
- **live-hermetic conformance GREEN** — `npm run test:re-frame2-pair-live-overflow-hermetic` (the actual CI `mcp-conformance-re-frame2-pair` hermetic step, boots shadow-cljs + Chromium against the fixture): `RE-FRAME2-PAIR-MCP live hermetic conformance passed (3 inner tests)`, exit 0.
- `npm run test:mcp-conformance` — ALL 6 gates GREEN (incl. end-to-end re-frame2-pair, story-mcp, wire-vocab 49 tests/637 assertions).
- pair-mcp `:server-test` (`npm test`) — 803 tests / 2401 assertions, 0 failures/0 errors.
- single-app+`:rf/xray` resolves unambiguously (no `:ambiguous-frame`) + resolved-frame echo — proven by `multi_frame_test.clj` (23 tests/39 assertions, bb) + `discover_app_reserved_frame_test.cljs` (server-test).
- `clj-kondo --fail-level error` — **0 errors** (pre-existing warnings only; none in changed files).
- `mkdocs build --strict` — **exit 0**.

Do NOT merge.