### PR TITLE
docs(xray): canonical Reactive-panel label = "Views" (spec<->impl reconcile, rf2-5i8nn)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -417,11 +417,15 @@ Reactive sweep — sub cascade + view re-renders, scoped to the focused epoch.
 
 **Rename history.** Original name: `Views`. Renamed to `Reactive`
 (rf2-wyvf2 · §11.5) to align with the perspective split. Renamed
-again to `View` per rf2-e33ad (Mike-direction 2026-05-21) — the
-panel's primary subject is the rendered **view** (hover a view-row,
-the rendered DOM highlights), with the sub cascade as supporting
-context. The internal panel-registry key stays `:views` (never a
-user contract). The L4 tab label renders as `View`.
+again to `View` per rf2-e33ad — the panel's primary subject is the
+rendered **view** (hover a view-row, the rendered DOM highlights),
+with the sub cascade as supporting context. Settled back on the
+plural `Views` per Mike-direction 2026-05-21 (canonically ratified
+rf2-5i8nn 2026-06-02): the all-plural-domain-noun convention aligns
+the tab vocabulary — Views / Flows / Schemas / Routes / Machines are
+all plural — and the Figma export (rf2-ad7zx) renders `Views`. The
+internal panel-registry key stays `:views` (never a user contract).
+The L4 tab label renders as `Views`.
 
 ### §3.1.1 Layout (rf2-e33ad · rf2-isun6)
 
@@ -4169,15 +4173,20 @@ What the panel design needs from the substrate (per §1.4 captured-not-replayed)
 | Dispatch-origin display on L2 rows | **Short text label prefix** (`user · :checkout/submit`) | No icon-only or coloured chip — keeps L2 row scannable. Matches the existing L1 ribbon density. |
 | Pattern view (4th lens) | **Defer to follow-up bead** | Per super-prompt. The 3-lens model (handling / reactive / state) is sufficient for MVP. |
 
-### §11.5 Views → Reactive rename
+### §11.5 Views → Reactive → Views label history
 
-**Pick: (a) "Reactive".** Pairs with "Event"; accurately captures
-subs+views; reflects perspective split. Implementation note: the L3 tab
-key stays `:views` for backward registry / share-URL compat — only the
-**display label** rebases to "Reactive." (Pre-alpha posture says no
-back-compat shims, but `:views` is an internal id, not a user contract;
-share URLs are local-only dev surface. Keep the key for the smaller diff
-unless a follow-up cleans up display+key together.)
+**Canonical label: "Views"** (Mike-direction 2026-05-21, ratified
+rf2-5i8nn 2026-06-02). The display label briefly considered "Reactive"
+(rf2-wyvf2 — pairs with "Event", captures subs+views, reflects the
+perspective split) and "View" (rf2-e33ad — the rendered view as the
+panel's primary subject), but settled on the plural **"Views"**: the
+all-plural-domain-noun convention aligns the L4 tab vocabulary (Views /
+Flows / Schemas / Routes / Machines) and matches the Figma export
+(rf2-ad7zx). Implementation note: the L3 tab key stays `:views` for
+backward registry / share-URL compat — only the **display label**
+moves. (`:views` is an internal id, not a user contract; share URLs are
+local-only dev surface. Keep the key for the smaller diff unless a
+follow-up cleans up display+key together.)
 
 ---
 

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -277,7 +277,7 @@ tab per Mike's Option (c) ruling. The 4-layer shell switches over the
 L3 tab ids in
 [`018-Event-Spine.md`](./018-Event-Spine.md) §The 6 tabs — these
 six are the surviving `Panel` exports. The L4 display label for
-`reactive-panel/Panel` is **Reactive** (per `spec/021 §11.5`); the
+`reactive-panel/Panel` is **Views** (per `spec/021 §11.5`); the
 panel-registry key stays `:views` for the smaller diff — the
 namespace `panels.reactive-panel` is the post-rf2-wyvf2 spelling
 (rf2-yxw57 corrected the stale `panels.views/Panel` symbol).

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
@@ -62,9 +62,9 @@
   (subs/install!)
   (events/install!)
   ;; rf2-wyvf2 — register with the L4 tab registry. Display label is
-  ;; 'Reactive' per spec/021 §11.5; the tab key stays `:views` (the
-  ;; internal id is not a user contract — pre-alpha posture preserves
-  ;; the slot for the smaller diff).
+  ;; 'Views' per spec/021 §11.5 (rf2-5i8nn); the tab key stays `:views`
+  ;; (the internal id is not a user contract — pre-alpha posture
+  ;; preserves the slot for the smaller diff).
   (panel-registry/reg-l4-tab!
     {:id    :views
      ;; Display label renamed `Reactive` -> `View` -> `Views`. The


### PR DESCRIPTION
Mike ruled 2026-06-02 (rf2-5i8nn): the canonical Xray Reactive-panel L4 display label is **"Views"**. The impl already shipped `:label "Views"` (Mike-direction 2026-05-21); the spec still asserted 'Reactive'/'View' in three places. This is a spec true-up **plus** one stale impl comment fix — no behavior change.

## What changed

Spec ↔ impl now agree the label is **Views**. Panel/namespace identity (`reactive-panel`) and the internal `:views` registry key are unchanged — only the user-facing label string moves.

The 3 references the bead cites, updated:
- **`tools/xray/spec/021` §3.1** (rename history, line ~424): final-state sentence now "The L4 tab label renders as `Views`"; history extended to record View → Views (rf2-5i8nn).
- **`tools/xray/spec/021` §11.5**: decision-record retitled "Views → Reactive → Views label history"; canonical label = Views (the earlier "Reactive" / "View" picks recorded as superseded history).
- **`tools/xray/spec/API.md`** (line ~280): L4 display label for `reactive-panel/Panel` → **Views**.

Plus (impl, comment-only): **`reactive_panel.cljs`** — the stale `;; Display label is 'Reactive' per spec/021` comment now reads 'Views'; the shipped `:label "Views"` was already correct.

**Stray-ref sweep:** grepped `tools/xray/spec` + top-level `spec` for label assertions. `007-UX-IA.md` (§ tab table + §131) and `012-Views.md` already land on "Views" (Figma export wins, rf2-ad7zx) — now fully consistent. `021:~4280` is a historical backlog-bead description, and `021:1771` is an unrelated App-DB FULL/DIFF discoverability label (rf2-fytu4) — both correctly left untouched. Top-level `spec/` only references the `reactive-panel` namespace/var identity, not the label.

## Quality gates
- `mkdocs build --strict` — GREEN (021/API.md anchors intact; tools/xray/spec is not in the docs site, so the top-level build is unaffected).
- gkp0t Xray-spec projection check (`xray-spec-check`) — GREEN (23 public-var references in sync).
- `api-md-check` — GREEN (191 var-rows in sync; label-string change did not trip it).
- `npm run test:xray-feature-gate` — GREEN (16 scenarios, 0 failures, 13 matrix rows).
- clj-kondo on `reactive_panel.cljs` — GREEN (0 errors, 0 warnings).

Scope: spec true-up **+ one impl comment** (the `:label` value itself was already "Views").

Closes rf2-5i8nn.