### PR TITLE
fix(xray): self-noise filter matches rf.xray.* sub-namespaces (rf2-y8iqe)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/self_noise.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/self_noise.cljc
@@ -28,13 +28,16 @@
 
   2. **`xray-internal-cascade?` / `xray-internal-event-id?`** —
      cascades whose `:event` vector's head is a keyword in the
-     `rf.xray` namespace (`:rf.xray/focus-cascade`,
-     `:rf.xray/select-tab`, `:rf.xray/open-settings`, etc.). These
-     can be dispatched WITHOUT a `{:frame :rf/xray}` option (e.g. the
-     palette's quick-actions, whose `:palette/select-panel` verb lowers
-     into a plain `[:dispatch [:rf.xray/select-tab …]]` with no `:frame`);
-     the framework chain-resolves them onto `:rf/default` and the
-     trace envelope carries `:frame :rf/default` — so the frame gate +
+     `rf.xray` namespace OR any `rf.xray.*` sub-namespace
+     (`:rf.xray/focus-cascade`, `:rf.xray/select-tab`,
+     `:rf.xray.static/select-tab`, `:rf.xray.epoch/toggle-row`, etc.).
+     These can be dispatched WITHOUT a `{:frame :rf/xray}` option (e.g.
+     the palette's quick-actions, whose `:palette/select-panel` /
+     `:palette/select-static-tab` verbs lower into a plain
+     `[:dispatch [:rf.xray/select-tab …]]` / `[:dispatch
+     [:rf.xray.static/select-tab …]]` with no `:frame`); the framework
+     chain-resolves them onto `:rf/default` and the trace envelope
+     carries `:frame :rf/default` — so the frame gate +
      `xray-internal-event?` both miss them. The data-layer filter at
      the `:rf.xray/cascades` sub closes that hole structurally without
      forcing every call site to thread `:frame`.
@@ -53,7 +56,8 @@
   small, focused ns makes them discoverable + cheap to require from
   anywhere (the trace collector, the `:rf.xray/cascades` sub, the
   pre-mount seed in `mount.cljs`). The CLJC shape keeps them JVM-
-  runnable so the JVM test corpus can drive every axis.")
+  runnable so the JVM test corpus can drive every axis."
+  (:require [clojure.string :as str]))
 
 ;; ---- predicates ---------------------------------------------------------
 
@@ -73,22 +77,39 @@
   (= :rf/xray (or (:frame event) (get-in event [:tags :frame]))))
 
 (defn xray-internal-event-id?
-  "True when `event-id` is a keyword in the `rf.xray` namespace
-  (spec/Conventions.md §Reserved namespaces — Xray's canonical
-  devtool prefix).
+  "True when `event-id` is a keyword in the `rf.xray` namespace OR any
+  of its sub-namespaces (`rf.xray.static`, `rf.xray.epoch`,
+  `rf.xray.filters`, `rf.xray.edn-inspector`, `rf.xray.column-widths`,
+  … — spec/Conventions.md §Reserved namespaces, Xray's canonical
+  devtool prefix). Xray registers + dispatches many internal events
+  under sub-namespaces (e.g. the palette's frameless
+  `:rf.xray.static/select-tab`), and those must be filtered out of the
+  host cascade list exactly like the bare-`rf.xray` ones.
+
+  The match is a NAMESPACE SEGMENT prefix, not a naive substring: the
+  ns must be exactly `rf.xray` or start with `rf.xray.` (the dot
+  boundary guards against a host ns that merely shares the leading
+  characters — `:rf.xray-test/x`, `:rf.xray-foo/y`, `:rf.xrayon/z` all
+  stay false).
 
   Pure-data + JVM-runnable; nil-safe.
 
   Examples:
-    (xray-internal-event-id? :rf.xray/focus-cascade)  ;; true
-    (xray-internal-event-id? :rf.xray/select-tab)     ;; true
-    (xray-internal-event-id? :cart/add-item)           ;; false
-    (xray-internal-event-id? :rf/init)                 ;; false
-    (xray-internal-event-id? nil)                      ;; false
-    (xray-internal-event-id? \"rf.xray/x\")           ;; false (non-kw)"
+    (xray-internal-event-id? :rf.xray/focus-cascade)      ;; true
+    (xray-internal-event-id? :rf.xray/select-tab)         ;; true
+    (xray-internal-event-id? :rf.xray.static/select-tab)  ;; true
+    (xray-internal-event-id? :rf.xray.epoch/toggle-row)   ;; true
+    (xray-internal-event-id? :cart/add-item)              ;; false
+    (xray-internal-event-id? :rf/init)                    ;; false
+    (xray-internal-event-id? :rf.xray-test/x)             ;; false (no dot boundary)
+    (xray-internal-event-id? nil)                         ;; false
+    (xray-internal-event-id? \"rf.xray/x\")              ;; false (non-kw)"
   [event-id]
-  (and (keyword? event-id)
-       (= "rf.xray" (namespace event-id))))
+  (boolean
+    (when (keyword? event-id)
+      (when-let [ns (namespace event-id)]
+        (or (= "rf.xray" ns)
+            (str/starts-with? ns "rf.xray."))))))
 
 (defn xray-internal-cascade?
   "True when `cascade`'s `:event` vector's head is a Xray-internal

--- a/tools/xray/test/day8/re_frame2_xray/self_noise_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/self_noise_cljs_test.cljc
@@ -168,20 +168,36 @@
 ;; collect-trace! plumbing).
 
 (deftest xray-internal-event-id?-keyword-namespace
-  (testing "true iff event-id is a keyword in the `rf.xray` namespace"
+  (testing "true iff event-id is a keyword in the `rf.xray` ns or a `rf.xray.*` sub-ns"
     (is (true?  (self-noise/xray-internal-event-id? :rf.xray/focus-cascade)))
     (is (true?  (self-noise/xray-internal-event-id? :rf.xray/select-tab)))
     (is (true?  (self-noise/xray-internal-event-id? :rf.xray/open-settings)))
     (is (true?  (self-noise/xray-internal-event-id? :rf.xray/sync-trace-buffer)))
+    (testing "sub-namespaced internal events also classify (rf2-y8iqe)"
+      ;; Xray registers + dispatches many internal events under
+      ;; SUB-namespaces of rf.xray. The palette lowers
+      ;; `:palette/select-static-tab` into a FRAMELESS
+      ;; `[:dispatch [:rf.xray.static/select-tab …]]`
+      ;; (palette/events.cljs:304) — that chain-resolves onto
+      ;; :rf/default, so the frame gate misses it and this data-layer
+      ;; predicate is the only thing standing between it and the host's
+      ;; user-facing :rf.xray/cascades L2 list. Exact `= "rf.xray"`
+      ;; equality missed it; the segment-prefix match catches it.
+      (is (true?  (self-noise/xray-internal-event-id? :rf.xray.static/select-tab)))
+      (is (true?  (self-noise/xray-internal-event-id? :rf.xray.epoch/toggle-row-expand)))
+      (is (true?  (self-noise/xray-internal-event-id? :rf.xray.filters/persist)))
+      (is (true?  (self-noise/xray-internal-event-id? :rf.xray.edn-inspector/zoom)))
+      (is (true?  (self-noise/xray-internal-event-id? :rf.xray.column-widths/persist))))
     (testing "user-app events stay false"
       (is (false? (self-noise/xray-internal-event-id? :cart/add-item)))
       (is (false? (self-noise/xray-internal-event-id? :checkout/start)))
       (is (false? (self-noise/xray-internal-event-id? :user/click))))
     (testing "framework + sibling reserved namespaces stay false"
-      ;; The filter is narrow: only `rf.xray`. Sibling reserved
-      ;; namespaces (`:rf/init`, `:rf.epoch/*`) are NOT Xray-internal
-      ;; — they're framework / epoch surface and must remain visible
-      ;; in the user-facing cascade list.
+      ;; The filter is narrow: only `rf.xray` + its `rf.xray.*`
+      ;; sub-namespaces. Sibling reserved namespaces (`:rf/init`,
+      ;; `:rf.epoch/*`) are NOT Xray-internal — they're framework /
+      ;; epoch surface and must remain visible in the user-facing
+      ;; cascade list.
       (is (false? (self-noise/xray-internal-event-id? :rf/init)))
       (is (false? (self-noise/xray-internal-event-id? :rf.epoch/begin)))
       (is (false? (self-noise/xray-internal-event-id? :rf.story/something))))
@@ -190,13 +206,18 @@
       (is (false? (self-noise/xray-internal-event-id? "rf.xray/foo")))
       (is (false? (self-noise/xray-internal-event-id? :unnamespaced)))
       (is (false? (self-noise/xray-internal-event-id? 42))))
-    (testing "namespace prefix collision guard"
-      ;; A keyword whose namespace STARTS with `rf.xray` but is not
-      ;; exactly `rf.xray` (e.g. `:rf.xray-test/x`, `:rf.xray-foo/y`)
-      ;; must NOT match. The contract is namespace equality, not
-      ;; prefix matching.
+    (testing "namespace prefix collision guard — segment boundary, not substring"
+      ;; A keyword whose namespace shares the leading characters
+      ;; `rf.xray` but is NOT exactly `rf.xray` nor a `rf.xray.`
+      ;; sub-namespace (e.g. `:rf.xray-test/x`, `:rf.xray-foo/y`,
+      ;; `:rf.xrayon/z`) must NOT match — the match is on the dot
+      ;; segment boundary, not a naive substring/character prefix. An
+      ;; app namespace that merely embeds `rf.xray` mid-string
+      ;; (`:my.rf.xray-ish/foo`) is also a host event, not Xray's.
       (is (false? (self-noise/xray-internal-event-id? :rf.xray-test/x)))
-      (is (false? (self-noise/xray-internal-event-id? :rf.xray-foo/y))))))
+      (is (false? (self-noise/xray-internal-event-id? :rf.xray-foo/y)))
+      (is (false? (self-noise/xray-internal-event-id? :rf.xrayon/z)))
+      (is (false? (self-noise/xray-internal-event-id? :my.rf.xray-ish/foo))))))
 
 (deftest xray-internal-cascade?-event-vector-head
   (testing "true iff the cascade's :event vector's head is xray-internal"
@@ -209,7 +230,20 @@
     (is (true?  (self-noise/xray-internal-cascade?
                   {:dispatch-id 3
                    :event       [:rf.xray/open-settings]}))
-        "single-element event vector (no payload) still classifies"))
+        "single-element event vector (no payload) still classifies")
+    (testing "frameless sub-namespaced internal cascade is filtered (rf2-y8iqe)"
+      ;; The concrete leak path: palette/events.cljs:304 lowers
+      ;; `:palette/select-static-tab` into a FRAMELESS
+      ;; `[:dispatch [:rf.xray.static/select-tab :machines]]`. With the
+      ;; old exact-equality predicate this cascade landed on :rf/default
+      ;; and surfaced as a spurious row in the host's :rf.xray/cascades
+      ;; L2 list. The segment-prefix match closes the hole.
+      (is (true?  (self-noise/xray-internal-cascade?
+                    {:dispatch-id 9
+                     :event       [:rf.xray.static/select-tab :machines]})))
+      (is (true?  (self-noise/xray-internal-cascade?
+                    {:dispatch-id 10
+                     :event       [:rf.xray.epoch/toggle-row-expand 3]})))))
   (testing "user-app cascades stay false"
     (is (false? (self-noise/xray-internal-cascade?
                   {:dispatch-id 4

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -2349,7 +2349,13 @@
     (let [old-ms   1000000
           fresh-ms (+ old-ms 90000)]
       (trace-collector/seed-trace-for-test! (dispatch-trace-ev-with-time 1 [:foo/bar] old-ms))
-      (trace-collector/seed-trace-for-test! (dispatch-trace-ev-with-time 2 [:rf.xray.test/anchor] fresh-ms))
+      ;; Fixture event-id must be a genuine HOST app id — NOT a reserved
+      ;; `rf.xray.*` sub-namespace. Post rf2-y8iqe the self-noise filter
+      ;; correctly classifies any `rf.xray.*` id as xray-internal and
+      ;; drops it from the host cascade list; a `:rf.xray.test/*` fixture
+      ;; would never render its chip, defeating the assertion. `:foo/baz`
+      ;; mirrors the old row's `:foo/bar` host event.
+      (trace-collector/seed-trace-for-test! (dispatch-trace-ev-with-time 2 [:foo/baz] fresh-ms))
       (rf/with-frame :rf/xray
         (let [tree     (shell/shell-view)
               chips    (find-all-by-testid tree "rf-xray-row-time-chip")


### PR DESCRIPTION
## Summary

The self-noise predicate `xray-internal-event-id?` (`tools/xray/src/day8/re_frame2_xray/self_noise.cljc`) classified an event-id as Xray-internal via **exact** namespace equality — `(= "rf.xray" (namespace id))`. But Xray registers + dispatches many internal events under **sub-namespaces** of `rf.xray`: `:rf.xray.static/*`, `:rf.xray.epoch/*`, `:rf.xray.filters/*`, `:rf.xray.edn-inspector/*`, `:rf.xray.column-widths/*`, etc.

**Leak path:** `palette/events.cljs:304` lowers `:palette/select-static-tab` into a FRAMELESS `[:dispatch [:rf.xray.static/select-tab …]]` (no `{:frame :rf/xray}`). It chain-resolves onto `:rf/default`, slips the frame gate + `xray-internal-event?`, and — because the data-layer backstop (`xray-internal-cascade?` → `xray-internal-event-id?`) missed the sub-namespaced id — surfaced as a spurious row in the host's user-facing `:rf.xray/cascades` L2 list. The sibling `:rf.xray/select-tab` (exact ns) WAS caught, so the bug was precisely the sub-namespaced internal events.

## Fix

Match the `rf.xray` namespace **root** as a SEGMENT prefix: ns is exactly `"rf.xray"` OR `(str/starts-with? ns "rf.xray.")`. The trailing-dot boundary avoids over-matching a host ns that merely shares the leading characters:

```clojure
(boolean
  (when (keyword? event-id)
    (when-let [ns (namespace event-id)]
      (or (= "rf.xray" ns)
          (str/starts-with? ns "rf.xray.")))))
```

**Over-match avoidance:** `:rf.xray-test/x`, `:rf.xray-foo/y`, `:rf.xrayon/z`, and `:my.rf.xray-ish/foo` all stay **false** — the match keys on the dot segment boundary, not a naive substring/character prefix.

## Red / green proof

Reverted the predicate to the old exact-equality form and ran the JVM suite — **7 failures** (5 new sub-ns event-id cases + 2 sub-ns cascade cases), while the over-match guards stayed green. Restored the fix → **0 failures**.

```
# WITHOUT fix (exact equality):
Ran 5 tests containing 48 assertions.
7 failures, 0 errors.
  FAIL … (xray-internal-event-id? :rf.xray.static/select-tab)  actual: (not (true? false))
  FAIL … (xray-internal-event-id? :rf.xray.epoch/toggle-row-expand)  actual: (not (true? false))
  … + :rf.xray.filters/persist, :rf.xray.edn-inspector/zoom, :rf.xray.column-widths/persist
  FAIL … (xray-internal-cascade? {… :event [:rf.xray.static/select-tab :machines]})  actual: (not (true? false))
  FAIL … (xray-internal-cascade? {… :event [:rf.xray.epoch/toggle-row-expand 3]})  actual: (not (true? false))

# WITH fix (segment prefix):
Ran 5 tests containing 48 assertions.
0 failures, 0 errors.
```

## Quality gates

- **Regression test (RED→GREEN):** added sub-ns positive cases for `xray-internal-event-id?` (`:rf.xray.static/select-tab`, `:rf.xray.epoch/*`, `:rf.xray.filters/*`, `:rf.xray.edn-inspector/*`, `:rf.xray.column-widths/*`) + `xray-internal-cascade?` (the frameless `[:rf.xray.static/select-tab :machines]` leak path), plus segment-boundary over-match guards (`:rf.xray-test/x`, `:rf.xrayon/z`, `:my.rf.xray-ish/foo` stay false) and the existing host-event-not-mis-filtered assertions. Proof above.
- **`npm run test:cljs`:** PASS — `Ran 5213 tests containing 17835 assertions. 0 failures, 0 errors.`
- **`npm run test:xray-feature-gate`:** PASS — `Ran 16 Xray feature scenarios (nightly-full sweep). 0 failures. Covered 13 matrix rows.`
- **clj-kondo:** PASS — `errors: 0, warnings: 0` on all changed files.
- **`mkdocs build --strict`:** N/A — spec unchanged; this is implementation + test only (no `tools/xray/spec/*` touched).

### Note on the `shell_cljs_test` fixture

One `shell_cljs_test.cljs` fixture seeded a `:rf.xray.test/anchor` event as a stand-in 'fresh app event'. The corrected filter now — **correctly** — classifies any `rf.xray.*` id as xray-internal and drops it from the host cascade list, so that fixture's chip would never render. Retargeted it to a genuine host id (`:foo/baz`, mirroring the row's existing `:foo/bar`), preserving the test's intent.

Closes rf2-y8iqe.