### PR TITLE
fix(story): recorder primary snippet captures DOM interactions — :entries single source (rf2-nkjkj)

### DIFF
--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -163,7 +163,19 @@
   [:rf/redacted])
 
 ;; ---------------------------------------------------------------------------
-;; Pure: code-gen — `(reg-variant ... :script {...})` snippet
+;; Pure: dispatch-only code-gen — `(reg-variant ... :script {...})` snippet
+;;
+;; NOTE (rf2-nkjkj): this is the LEGACY dispatch-only codegen. It reads
+;; the bare `:events` stream, so it sees dispatched events + inserted
+;; assertions ONLY — it is BLIND to DOM interactions (which live in
+;; `:entries`). The interactive recorder's PRIMARY save dialog no longer
+;; uses this path; it renders the rich `:play-script` translation off
+;; `:entries` (`recorder.play-export/recording->play-script` +
+;; `render-variant-form`) so canvas clicks/types/submits are never
+;; dropped. `gen-play-snippet` survives ONLY as the codegen for the MCP
+;; `record-as-variant` record-and-sleep flow, whose capture path produces
+;; no DOM entries (so the dispatch-only view is complete there) and for
+;; the `story/gen-play-snippet` public re-export.
 ;;
 ;; rf2-7mj4z: `gen-play-snippet` emits the PUBLIC `:script` authoring slot
 ;; (spec/017 §Public vocabulary), NOT the transitional `:play-script`
@@ -493,22 +505,29 @@
 ;; rf2-d5u89 — per-event timestamps + DOM-event entries
 ;;
 ;; The original recorder model carried `:events` (a vector of event
-;; vectors) — sufficient for the simple `gen-play-snippet` codegen which
-;; wraps each as a `:dispatch-sync` step, but blind to TIMING and DOM
-;; INTERACTION which the rich `:play-script` DSL needs to emit `:click`
-;; / `:type` / `:wait` steps.
+;; vectors) — sufficient for a dispatch-only codegen which wraps each
+;; as a `:dispatch-sync` step, but blind to TIMING and DOM INTERACTION
+;; which the rich `:play-script` DSL needs to emit `:click` / `:type` /
+;; `:wait` steps.
 ;;
-;; The model now carries a parallel `:entries` vector keyed on the
-;; same index as `:events`. Each entry is one of:
+;; `:entries` is the recorder's SINGLE SOURCE OF TRUTH for codegen
+;; (rf2-nkjkj): the primary save dialog renders the `:play-script`
+;; translation off this stream. Each entry is one of:
 ;;
 ;;   {:kind :event/dispatch :event <vec> :t <ms>}
 ;;   {:kind :dom/click      :selector <str> :t <ms>}
 ;;   {:kind :dom/type       :selector <str> :text <str> :t <ms>}
 ;;   {:kind :dom/submit     :selector <str> :t <ms>}
 ;;
-;; `:events` stays canonical for the simple `gen-play-snippet` codegen
-;; (which emits `:dispatch-sync` `:play-script` steps). `:entries` is
-;; the richer surface the rich `:play-script` translator consumes.
+;; `:entries` is a SUPERSET of `:events`: every recordable dispatch
+;; and assertion lands in BOTH streams (via `append` / `append-
+;; assertion`), but DOM interactions (via `append-dom`) land in
+;; `:entries` ONLY — `:events` never sees them. The two streams are
+;; therefore NOT index-aligned the moment any DOM event is captured;
+;; `:entries` carries strictly >= the rows `:events` does. `:events`
+;; survives as the bare-dispatch view consumed by the legacy MCP
+;; record-and-sleep codegen (`gen-play-snippet`), whose capture path
+;; never produces DOM entries, so the asymmetry is invisible there.
 ;;
 ;; `:t` is ms since `:started-ms`; pure helpers accept a `now-ms`
 ;; argument for deterministic testing. (Helper fns `now-ms*`,

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -66,6 +66,7 @@
             [re-frame.story.config                       :as config]
             [re-frame.story.recorder                     :as recorder]
             [re-frame.story.recorder.dom-capture         :as recorder-dom]
+            [re-frame.story.recorder.play-export         :as play-export]
             [re-frame.story.review-dialog                :as review-dialog]
             [re-frame.story.ui.a11y-dialog               :as a11y-dialog]
             [re-frame.story.ui.recorder-export-dialog    :as export-dialog]
@@ -380,8 +381,13 @@
 
                        rec?
                        (let [_     (recorder-dom/flush-type-buffer!)
-                             {:keys [variant-id events]} (recorder/stop-recording!)]
-                         (when (seq events)
+                             {:keys [variant-id events entries]} (recorder/stop-recording!)]
+                         ;; rf2-nkjkj: open the dialog when EITHER stream
+                         ;; captured something — a recording of canvas
+                         ;; clicks/types only lands in :entries, never
+                         ;; :events, so gating on :events alone would
+                         ;; silently swallow DOM-only recordings.
+                         (when (or (seq events) (seq entries))
                            (open-dialog! variant-id events)))))]
     [:button
      {:style        (cond
@@ -732,8 +738,10 @@
                      ;; before sealing the recording so the final
                      ;; :dom/type entry lands in the script.
                      (recorder-dom/flush-type-buffer!)
-                     (let [{:keys [variant-id events]} (recorder/stop-recording!)]
-                       (when (seq events)
+                     (let [{:keys [variant-id events entries]} (recorder/stop-recording!)]
+                       ;; rf2-nkjkj: open on EITHER stream — a DOM-only
+                       ;; recording lands only in :entries.
+                       (when (or (seq events) (seq entries))
                          (open-dialog! variant-id events))))}
         "stop"]])))
 
@@ -743,30 +751,59 @@
 
 (defn save-dialog
   "Modal dialog rendered after the user stops a non-empty recording.
-  Shows the EDN snippet — `(reg-variant <id> {... :play-script {...}})` —
+  Shows the EDN snippet — `(reg-variant <id> {... :script {...}})` —
   and a 'copy to clipboard' affordance.
 
   The user edits the variant id inline; the snippet re-generates on
-  every keystroke. Discard / close drop the captured events.
+  every keystroke. Discard / close drop the captured recording.
 
-  Reads `:events` + `:source-id` from the dialog state itself — the
+  ## Single source of truth — `:entries` (rf2-nkjkj)
+
+  The snippet is rendered from the recorder's RICH `:entries` snapshot
+  via the `recording->play-script` translator, NOT the bare `:events`
+  vector. `:entries` is the only stream that carries DOM interactions
+  (`:dom/click` / `:dom/type` / `:dom/submit`, captured off the canvas
+  root by `recorder.dom-capture`) — `:events` holds dispatched events
+  ONLY. Rendering the primary dialog off `:events` (the historical
+  `gen-play-snippet` path) SILENTLY DROPPED every recorded click /
+  type / submit, producing an incomplete, non-reproducing variant with
+  a misleading count. Consuming `:entries` here means a recording that
+  captured canvas clicks codegens `[:click ...]` / `[:type ...]` /
+  `[:wait ...]` steps in the primary save flow, and the displayed count
+  reflects the full rich recording.
+
+  The `:auto-run?` flag is forced off in the snippet so the pasted
+  variant doesn't replay on mount until the author opts in — the
+  secondary Export dialog owns the auto-run + auto-assert affordances.
+
+  Reads `:entries` + `:source-id` from the dialog state itself — the
   snapshot was taken at `open-dialog!` time so a subsequent
   `start-recording!` cannot mutate the visible snippet (rf2-8x9nb)."
   []
   (let [dialog                                  @ui-dialog
         {:keys [events entries source-id]}      dialog]
     (when (:open? dialog)
-      (let [draft-id (:draft-id dialog)
-            snippet  (recorder/gen-play-snippet
-                       events
-                       {:variant-id (or draft-id :story.recorded/example)
-                        :extends    source-id})]
+      (let [draft-id   (:draft-id dialog)
+            ;; Single source of truth: the rich :entries stream (the
+            ;; only one carrying DOM interactions). Fall back to the
+            ;; bare :events vector only when no rich entries were
+            ;; snapshotted (legacy callers / dispatch-only recordings).
+            src        (if (seq entries) entries events)
+            spec       (play-export/recording->play-script
+                         src
+                         {:auto-run? false})
+            snippet    (play-export/render-variant-form
+                         spec
+                         {:variant-id (or draft-id :story.recorded/example)
+                          :extends    source-id})
+            step-count (count (:script spec))]
         (review-dialog/review-dialog dialog
           {:title             "Test Codegen — save recording as variant"
            :hint              (str "EDN snippet generated from "
-                                   (count events) " captured event"
-                                   (when (not= 1 (count events)) "s")
-                                   " against " (pr-str source-id)
+                                   step-count " recorded step"
+                                   (when (not= 1 step-count) "s")
+                                   " (dispatches + DOM interactions) against "
+                                   (pr-str source-id)
                                    ". Edit the variant id then "
                                    "copy + paste into your stories namespace.")
            :snippet           snippet
@@ -775,10 +812,10 @@
            :on-edit-id        set-draft-id!
            :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
            :on-discard        (fn [] (recorder/clear!) (close-dialog!))
-           ;; rf2-x9zsr — open the :play-script export dialog with the
-           ;; captured snapshot. We DON'T close the parent dialog
-           ;; (user may want to copy the simple :play-script form too); the export
-           ;; dialog stacks on top via a higher z-index.
+           ;; rf2-x9zsr — open the export dialog with the captured
+           ;; snapshot for the auto-run / auto-assert affordances. We
+           ;; DON'T close the parent dialog; the export dialog stacks on
+           ;; top via a higher z-index.
            :on-export         (fn []
                                 (export-dialog/open-from-recorder-dialog!
                                   {:events    events

--- a/tools/story/test/re_frame/story/ui/recorder_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/recorder_cljs_test.cljc
@@ -93,6 +93,85 @@
          (is (str/includes? flat ":story.x/source")
              "the recorded variant-id appears via :extends")))))
 
+;; ---- CLJS-only: rf2-nkjkj — DOM interactions reach the PRIMARY snippet ---
+;;
+;; Before rf2-nkjkj the primary save-dialog rendered via
+;; `gen-play-snippet` over the bare `:events` stream, which holds
+;; dispatched events ONLY — every recorded click / type / submit
+;; (captured into `:entries` by `recorder.dom-capture`) was SILENTLY
+;; DROPPED from the snippet, and the displayed count counted `:events`
+;; (so a recording of three canvas clicks showed "0 captured events").
+;; The fix routes the primary dialog through the rich
+;; `recording->play-script` translation off `:entries`. These tests
+;; drive the FULL capture pipeline (record-event! + record-dom-event!),
+;; snapshot it through the real `open-dialog!`, and assert the rendered
+;; primary snippet carries the `[:click ...]` / `[:type ...]` steps.
+
+#?(:cljs
+   (deftest save-dialog-primary-snippet-includes-dom-interactions
+     (testing "rf2-nkjkj: a recording with DOM clicks/types codegens
+              :click / :type steps in the PRIMARY save dialog snippet —
+              RED before the fix (gen-play-snippet over :events dropped
+              them), GREEN after (recording->play-script over :entries)"
+       ;; Drive the actual capture pipeline so the test exercises the
+       ;; real two-stream model, not a hand-built snapshot.
+       (recorder/clear!)
+       (recorder/start-recording! :story.login/form 0)
+       (recorder/record-event! [:counter/inc])                       ; → :events + :entries
+       (recorder/record-dom-event! [:dom/click "#submit" 10])        ; → :entries ONLY
+       (recorder/record-dom-event! [:dom/type "#email" "a@b.co" 20]) ; → :entries ONLY
+       (let [{:keys [variant-id events entries]} (recorder/stop-recording!)]
+         ;; Sanity: the streams desync exactly as documented — :events
+         ;; has the lone dispatch; :entries has all three interactions.
+         (is (= [[:counter/inc]] events)
+             ":events carries the dispatched event only (no DOM)")
+         (is (= 3 (count entries))
+             ":entries carries the dispatch + both DOM interactions")
+         ;; Open the primary dialog through the real UI entry point.
+         (reset! ui-rec/ui-dialog
+                 (recorder/open-dialog recorder/initial-dialog-state
+                                       variant-id events entries 0))
+         ;; `(str hiccup)` escapes the inner double-quotes of the
+         ;; rendered EDN, so the snippet selector "#submit" appears as
+         ;; \"#submit\" in the flattened tree — assert against that form.
+         (let [flat (str (ui-rec/save-dialog))]
+           (is (str/includes? flat ":dispatch [:counter/inc]")
+               "the dispatched event still appears as a :dispatch step")
+           (is (str/includes? flat "[:click \\\"#submit\\\"]")
+               "the recorded DOM click codegens a :click step (was DROPPED)")
+           (is (str/includes? flat "[:type \\\"#email\\\" \\\"a@b.co\\\"]")
+               "the recorded DOM type codegens a :type step (was DROPPED)")
+           (is (str/includes? flat ":story.login/form")
+               "the recorded variant-id rides into :extends")
+           ;; The displayed count must reflect the RICH entries, not the
+           ;; one-element :events vector. Three recorded steps → the hint
+           ;; reads "3 recorded steps", never "1 captured event".
+           (is (str/includes? flat "3 recorded steps")
+               "the hint count reflects the rich :entries, not :events")
+           (is (not (str/includes? flat "1 captured event"))
+               "the misleading :events-based count is gone"))))))
+
+#?(:cljs
+   (deftest save-dialog-opens-and-renders-dom-only-recording
+     (testing "rf2-nkjkj: a recording of canvas interactions ONLY (no
+              dispatched events) still produces a non-empty primary
+              snippet — :events is empty but :entries carries the clicks"
+       (recorder/clear!)
+       (recorder/start-recording! :story.x/canvas 0)
+       (recorder/record-dom-event! [:dom/click "#a" 5])
+       (recorder/record-dom-event! [:dom/click "#b" 9])
+       (let [{:keys [variant-id events entries]} (recorder/stop-recording!)]
+         (is (empty? events) ":events is empty for a DOM-only recording")
+         (is (= 2 (count entries)))
+         (reset! ui-rec/ui-dialog
+                 (recorder/open-dialog recorder/initial-dialog-state
+                                       variant-id events entries 0))
+         (let [flat (str (ui-rec/save-dialog))]
+           (is (str/includes? flat "[:click \\\"#a\\\"]"))
+           (is (str/includes? flat "[:click \\\"#b\\\"]"))
+           (is (str/includes? flat "2 recorded steps")
+               "the count reflects the two DOM interactions"))))))
+
 ;; ---- CLJS-only: rf2-8x9nb regression ------------------------------------
 
 #?(:cljs


### PR DESCRIPTION
## Problem (rf2-nkjkj, P2 bug, senior-dev Story review)

The recorder kept TWO capture streams: `:events` (bare dispatched event vectors) and `:entries` (rich per-interaction maps incl. DOM kinds). DOM interactions (`:dom/click` / `:dom/type` / `:dom/submit`, captured off the canvas root by `recorder.dom-capture`) land in `:entries` ONLY. The PRIMARY save-as-variant dialog rendered its snippet via `gen-play-snippet` over `:events`, so it emitted `[:dispatch-sync …]` steps and **silently dropped every recorded click / type / submit**, with a misleading `(count events)` count and no warning. A user who clicked on the canvas and saved got an incomplete, non-reproducing variant — a silent data-loss trap on Story's headline record-and-save feature.

## Fix — `:entries` is the single source of truth for the primary save path

- `ui/recorder.cljs` `save-dialog` now renders the rich `recorder.play-export/recording->play-script` translation (consuming `:entries`) via `render-variant-form`, emitting `[:click …]` / `[:type …]` / `[:wait …]` steps. The displayed count reflects the rich entries ("N recorded steps"), not the `:events` length.
- The chip + overlay stop handlers now open the dialog on **either** stream (`(or (seq events) (seq entries))`), so a DOM-only recording (clicks/types, no dispatch) is no longer swallowed by the old `(seq events)` gate.
- `gen-play-snippet` is **demoted, not deleted** — it survives ONLY as the dispatch-only codegen for the MCP `record-as-variant` record-and-sleep flow (whose capture path produces no DOM entries, so the dispatch-only view is complete there) and the `story/gen-play-snippet` public re-export. Deleting it outright would ripple into story-mcp + the public facade + spec, well beyond this bead's scoped surface; the data-loss bug lived entirely in the UI primary path, which is now fixed. The dispatch-only path is documented as legacy and no longer reachable from the data-loss-prone UI.

## Correctness smells fixed
1. The **false** `recorder.cljc` comment claiming `:entries` is "keyed on the same index as `:events`" — false the moment any DOM event is captured. Replaced with an accurate model note: `:entries` is a **superset** of `:events` (both get dispatches + assertions; only `:entries` gets DOM).
2. Documented the coherent stream model: `append` / `append-assertion` write BOTH streams; `append-dom` writes `:entries` ONLY — and why that asymmetry is correct given the single-source decision.

## Quality gates
- **New RED→GREEN CLJS test** (`recorder_cljs_test.cljc`): `save-dialog-primary-snippet-includes-dom-interactions` drives the full capture pipeline (`record-event!` + `record-dom-event!`), snapshots through the real `open-dialog`, and asserts the PRIMARY snippet carries `[:click "#submit"]` / `[:type "#email" …]` steps and the count reads "3 recorded steps". Empirically verified RED: reverting `save-dialog` to the old `gen-play-snippet`-over-`:events` path → 8 failures on exactly the dropped-DOM assertions; GREEN after the fix. A second test covers a DOM-only recording (empty `:events`, non-empty `:entries`).
- `npm run test:cljs` — **5215 tests, 17839 assertions, 0 failures, 0 errors**.
- clj-kondo on changed files — 0 errors (1 pre-existing `.cljc`/`clojure.string` warning, present on baseline).
- `npm run test:bundle-isolation` — PASS (17 artefact entries; 35 sentinels absent; uix/helix reagent-free PASS). No new cross-boundary require edge (ui/recorder already pulled play-export transitively via the export dialog).
- No `tools/story/spec/*` source touched → no mkdocs build needed.

Closes rf2-nkjkj.