### PR TITLE
refactor(xray): epoch-panel hygiene — delete retired-step code, drop discarded db-diff, extract formatters (rf2-btt0s, rf2-sp0n9, rf2-qkygs)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -2088,9 +2088,12 @@ Vanilla sources carry no enrichment; the renderer falls through to
 the pre-rf2-5qp4g call-site link.
 
 **Parent-epoch resolution.** The view layer resolves
-`:parent-dispatch-id → :parent-epoch-id` against the Xray
-`:epoch-history` slice threaded through `pipeline-view`'s `ctx`
-(`(proj/find-parent-epoch epoch-history parent-dispatch-id)`). When
+`:parent-dispatch-id → :parent-epoch-id` against a precomputed
+`{dispatch-id → epoch-id}` index (rf2-x25e0 — built once per render
+via `proj/dispatch-id->epoch-id-index` over the Xray `:epoch-history`
+slice and threaded through `pipeline-view`'s `ctx` as
+`:dispatch-id->epoch-id`; `(proj/find-parent-epoch index
+parent-dispatch-id)` is an O(1) lookup). When
 the parent epoch is in the buffer the chip renders as a clickable
 `<button>` carrying `parent epoch #N`; when not (root cascade, or
 the parent was evicted from the ring) the chip renders as a muted
@@ -2146,6 +2149,14 @@ exercise the algebra without spinning a CLJS runtime. The view
 layer (`panels/epoch/view.cljs`) consumes the projection's output
 verbatim; no DOM concern bleeds into the data layer.
 
+The view-presentation string formatters (`format-duration-ms`,
+`event-display`, `ns-keyword`, `cascade-row-label`,
+`cascade-outcome-label`, `cascade-row-source-key`,
+`handler-flavour-label`, …) live in the sibling
+`panels/epoch/format.cljc` (rf2-qkygs) — also `.cljc` and JVM-testable
+— so the projection ns stays the pure step-derivation engine and the
+presentation boundary reads as one named ns the view imports.
+
 ### §9.1.9 Queries
 
 | Sub | Reads | Yields |
@@ -2191,7 +2202,9 @@ and silently rendered empty rows. The binding inventory:
 Each step row carries `:duration-ms` (a number when the substrate
 stamped it; nil otherwise). The view paints it as a right-aligned
 monospace chip on every step's header — pure-data via
-`projection/format-duration-ms`, which formats `0.1ms` / `12ms` /
+`format/format-duration-ms` (rf2-qkygs extracted the view-presentation
+string formatters out of the pure-data `projection` ns into the
+sibling `panels/epoch/format.cljc`), which formats `0.1ms` / `12ms` /
 `1.2s` per scale.
 
 Per-row predicate driving long-step chrome:

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -82,10 +82,6 @@
   violation sub-block lives inline now. Hot-reload drift carries
   on a standalone SCHEMA-HOT-RELOAD tail step (same `:warning`
   token; renamed badge to flag the narrowed scope).
-  rf2-yx1ae — CHILD-DISPATCHES pulls `:text-tertiary` (the same muted
-  grey as DISPATCH — same hue family, same cascade-link semantics).
-  rf2-rrykz — APP-DB-DIFF pulls `:accent` (the same blue as HANDLER /
-  FLOW — same state-mutation lens semantics).
   rf2-yz57h — INTERCEPTOR pulls `:accent` (the same blue as HANDLER —
   the interceptor chain WRAPS the handler; they read as one identity
   family in the cascade, the chain around the handler body)."
@@ -97,9 +93,7 @@
    :SIDE-EFFECTS      :orange
    :SUBSCRIPTIONS     :magenta-pink
    :VIEWS             :success
-   :SCHEMA-HOT-RELOAD :warning
-   :CHILD-DISPATCHES  :text-tertiary
-   :APP-DB-DIFF       :accent})
+   :SCHEMA-HOT-RELOAD :warning})
 
 (def ^:private badge->label
   "Map from badge keyword → uppercase label rendered in the badge
@@ -112,9 +106,7 @@
    :SIDE-EFFECTS      "EFFECT HANDLERS"
    :SUBSCRIPTIONS     "SUBSCRIPTIONS"
    :VIEWS             "VIEWS"
-   :SCHEMA-HOT-RELOAD "SCHEMA HOT-RELOAD"
-   :CHILD-DISPATCHES  "DISPATCHED EVENTS"
-   :APP-DB-DIFF       "APP-DB DIFF"})
+   :SCHEMA-HOT-RELOAD "SCHEMA HOT-RELOAD"})
 
 (defn token-key
   "Return the theme-token KEYWORD for `badge` (e.g. `:accent` for

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -1,0 +1,240 @@
+(ns day8.re-frame2-xray.panels.epoch.format
+  "View-presentation string formatters for the Epoch panel (rf2-qkygs).
+
+  ## Why a separate ns from `projection`
+
+  `panels.epoch.projection` is the PURE-DATA step-derivation engine —
+  epoch-record → ordered vector of pipeline-step rows (data-in /
+  data-out). These fns are the OTHER side of that boundary: they turn
+  a projected row's slots into the display STRINGS the view paints
+  (`0.1ms` / `:my-ns/foo` / `guard :x` / `2 microsteps`). Parking them
+  in the projection ns blurred the data/presentation line — a reader
+  could not tell load-bearing derivation from cosmetic formatting, and
+  the projection ns carried two jobs.
+
+  This matches the rest of the codebase's pure-data / helpers split
+  (`spec/Conventions.md` §Pure-data helpers as `.cljc`; the
+  `*_helpers.cljc` per-theme convention). The view requires this ns
+  for its per-row labels; the projection ns now reads as the pure
+  step-derivation engine only.
+
+  ## Pure-data + JVM-portable
+
+  No DOM, no substrate runtime — display-string builders over already-
+  projected row data. JVM-testable via `clojure -M:test`."
+  (:require [day8.re-frame2-xray.panels.epoch.projection :as proj]))
+
+(defn format-duration-ms
+  "Render a duration in ms as a short string (`0.1ms` / `12ms` /
+  `1.2s`). Returns nil for non-numbers so the view can render an
+  em-dash on a missing duration without guarding the call site."
+  [ms]
+  (when (number? ms)
+    (cond
+      (>= ms 1000) (str (/ (Math/round (double (* (/ ms 1000.0) 10))) 10.0) "s")
+      (>= ms 10)   (str (Math/round (double ms)) "ms")
+      :else        (let [rounded (/ (Math/round (double (* ms 10))) 10.0)]
+                     (str rounded "ms")))))
+
+(defn event-display
+  "Render the dispatched event vector as a one-line monospace string
+  for the DISPATCH row's target slot."
+  [event-vec]
+  (when (vector? event-vec)
+    (str event-vec)))
+
+(defn path-display
+  "Render a db path vector as the `[:foo :bar 0]` repr used by every
+  diff-style row. Returns `\"\"` for nil/empty."
+  [path]
+  (if (sequential? path)
+    (str (vec path))
+    ""))
+
+(defn ns-keyword
+  "Render an id as a clojure-style keyword string (`:my-ns/foo` or
+  `:foo`). Falls through `str` for non-keywords."
+  [id]
+  (cond
+    (qualified-keyword? id) (str ":" (namespace id) "/" (name id))
+    (keyword? id)           (str ":" (name id))
+    :else                   (str id)))
+
+(defn truncate
+  "Truncate a string to `n` chars with an ellipsis. Pure fn used by
+  the view layer for long arg displays in the FX table."
+  ([s] (truncate s 60))
+  ([s n]
+   (let [s (str s)]
+     (if (<= (count s) n)
+       s
+       (str (subs s 0 n) "…")))))
+
+(defn coeffect-row-display
+  "Render a coeffect row's id → value pair as a one-liner for the
+  view's diff-style add row (`+ [:session] {:user-id 42 …}`)."
+  [{:keys [id value]}]
+  (let [head (str "+ [" (ns-keyword id) "] ")
+        tail (truncate (pr-str value) 80)]
+    (str head tail)))
+
+(defn phase-label
+  "Render a machine action-ran `:phase` keyword as a UI label string."
+  [phase]
+  (case phase
+    :exit            "exit"
+    :transition      "transition"
+    :entry           "entry"
+    :always          "always"
+    :after-action    "after-action"
+    :initial-entry   "initial-entry"
+    :destroy-exit    "destroy-exit"
+    (when (keyword? phase) (name phase))))
+
+(defn timer-reason-label
+  "Render a timer-cancelled `:reason` keyword as a UI label string."
+  [reason]
+  (case reason
+    :on-exit          "on-exit"
+    :on-destroy       "on-destroy"
+    :on-resolution    "on-resolution"
+    :on-supersede     "on-supersede"
+    :on-frame-destroy "on-frame-destroy"
+    (when (keyword? reason) (name reason))))
+
+(defn cascade-row-label
+  "Render a cascade row's human-readable verb (rf2-u69j7). Used by the
+  view's per-row header. Pure-data; the view never reaches into a
+  row's slots to compute its label."
+  [{:keys [kind action-id guard-id phase from-state to-state state reason]}]
+  (case kind
+    :guard       (str "guard " (ns-keyword guard-id))
+    :action      (str (when phase (str (name phase) " "))
+                      "action " (ns-keyword action-id))
+    ;; rf2-ge6uj ISSUE 3 — the TRANSITION row's verb is JUST the state
+    ;; change `<before> → <after>`, made the focal point. The redundant
+    ;; leading "transition" word (the KIND pill already says TRANSITION)
+    ;; and the machine-name echo (`:door/main` — already the cascade
+    ;; context) are DROPPED; the lower-line state/event repetition is
+    ;; dropped in the view (`cascade-row-transition-details`).
+    :transition  (str (if from-state (pr-str from-state) "?")
+                      " → "
+                      (if to-state (pr-str to-state) "?"))
+    :timer       (str "timer " (when state (pr-str state))
+                      (when reason (str " · " (name reason))))
+    (str (when kind (name kind)))))
+
+(defn cascade-row-source-key
+  "Spec-path tuple used to look up a cascade row's source-coord on the
+  registered machine's `:rf.machine/source-coords` index (rf2-8bp3).
+  Pure-data; the view layer reuses this for the coord lookup so the
+  source-link affordance reads off ONE authoritative key.
+
+  Dispatch (rf2-u69j7 baseline + rf2-wwc3j inline-fn extensions):
+
+  - `:action` with a keyword `:action-id` → `[:actions <id>]`
+    (definition-site stamp; the named-handler path).
+  - `:action` with an inline `:action-id` (fn) — derive from the row's
+    `:phase` + state slot (`:source-state` / `:target-state`, stamped
+    by `enrich-cascade-rows`):
+    - `:entry` / `:initial-entry` → `[:states <state>... :entry]`
+      (target-state)
+    - `:exit` / `:destroy-exit`   → `[:states <state>... :exit]`
+      (source-state)
+    - `:transition`               → `[:states <state>... :on <event> :action]`
+      (source-state + event-id)
+    - `:always`                   → `[:states <state>... :always 0 :action]`
+      (best-effort: index 0; richer index resolution requires
+      substrate-side carrier of the always-index, deferred)
+    - `:after-action`             → `[:states <state>... :after :action]`
+      (best-effort: timer fn-form path; the macro doesn't yet stamp
+      per-delay `:after` coords; D2 follow-on bead handles richer index).
+  - `:guard` with a keyword `:guard-id` → `[:guards <id>]`
+    (definition-site stamp; the named-guard path).
+  - `:guard` with an inline `:guard-id` (fn) — derive from state +
+    event-id:
+    `[:states <state>... :on <event> :guard]` (best-effort: no vector
+    transition-option index — for the common single-map transition).
+  - `:transition` → `[:states <from-state>... :on <event>]`
+    (the transition map's spec-path; opens the operator on the
+    transition literal in the spec).
+  - `:timer` → `[:states <state>...]`
+    (D1 minimum-viable: the parent state's source-coord chip; richer
+    per-`:after` coord is the D2 follow-on bead's surface)."
+  [{:keys [kind action-id guard-id phase source-state target-state event-id]
+    timer-state :state}]
+  (let [source-prefix (proj/state-spec-path-prefix source-state)
+        target-prefix (proj/state-spec-path-prefix target-state)
+        timer-prefix  (proj/state-spec-path-prefix timer-state)]
+    (case kind
+      :action
+      (cond
+        ;; Named-handler path (keyword id) — definition-site stamp.
+        (keyword? action-id) [:actions action-id]
+        ;; Inline-fn path — slot stamp under the relevant state.
+        (contains? #{:entry :initial-entry} phase)
+        (when target-prefix (conj target-prefix :entry))
+        (contains? #{:exit :destroy-exit} phase)
+        (when source-prefix (conj source-prefix :exit))
+        (= :transition phase)
+        (when (and source-prefix event-id)
+          (conj source-prefix :on event-id :action))
+        (= :always phase)
+        (when source-prefix (conj source-prefix :always 0 :action))
+        (= :after-action phase)
+        (when source-prefix (conj source-prefix :after :action))
+        :else nil)
+
+      :guard
+      (cond
+        (keyword? guard-id) [:guards guard-id]
+        :else
+        (when (and source-prefix event-id)
+          (conj source-prefix :on event-id :guard)))
+
+      :transition
+      (when (and source-prefix event-id)
+        (conj source-prefix :on event-id))
+
+      :timer
+      ;; The row's `:state` is the cancelled state vector (substrate
+      ;; payload). D1 minimum-viable shape: point at the parent state's
+      ;; spec-path so the operator orients on the `:after`-bearing node.
+      (or timer-prefix source-prefix target-prefix)
+
+      nil)))
+
+(defn cascade-outcome-label
+  "Render a cascade row's outcome for the view's outcome chip
+  (rf2-u69j7). Pure-data.
+
+    :guard       → `pass | fail | threw`
+    :action      → `ok | threw` (the action's outcome map is rich;
+                                 the chip carries only the headline)
+    :transition  → `→ N microstep(s)` (the headline reads off
+                                       `:microsteps`)
+    :timer       → `cancelled (<reason>)`"
+  [{:keys [kind outcome threw? microsteps reason]}]
+  (case kind
+    :guard      (if (keyword? outcome) (name outcome) nil)
+    :action     (cond
+                  threw?                "threw"
+                  (= :ok outcome)       "ok"
+                  (map? outcome)        "ok"
+                  (keyword? outcome)    (name outcome)
+                  :else                 nil)
+    :transition (when (number? microsteps)
+                  (str microsteps " microstep"
+                       (when (not= 1 microsteps) "s")))
+    :timer      (str "cancelled"
+                     (when reason (str " (" (name reason) ")")))
+    nil))
+
+(defn handler-flavour-label
+  "Human-readable label for a handler flavour keyword."
+  [flavour]
+  (case flavour
+    :reg-event-db  "reg-event-db"
+    :reg-event-fx  "reg-event-fx"
+    :reg-machine   "machine-event-handler"
+    (str flavour)))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/icons.cljc
@@ -61,30 +61,9 @@
 ;; SCHEMA-VIOLATIONS step's header (rf2-17vxj). With rf2-xgeag's
 ;; inline sub-block + tail-step shape the title row uses the Unicode
 ;; `⚠` glyph inline; no SVG required.
-
-;; ---- Arrow right (cascade-link) -----------------------------------------
-
-(def ^:private arrow-right-svg
-  "Lucide `arrow-right` icon as a hiccup-shaped svg. 13×13 square,
-  `viewBox 0 0 24 24`, `stroke: currentColor`. Used by the
-  CHILD-DISPATCHES section (rf2-yx1ae) for the per-child 'jump to'
-  affordance — the arrow signals 'follow this dispatch to the
-  child cascade'."
-  [:svg {:width            "13"
-         :height           "13"
-         :viewBox          "0 0 24 24"
-         :fill             "none"
-         :stroke           "currentColor"
-         :stroke-width     "2"
-         :stroke-linecap   "round"
-         :stroke-linejoin  "round"
-         :aria-hidden      "true"
-         :focusable        "false"}
-   [:line     {:x1 "5" :y1 "12" :x2 "19" :y2 "12"}]
-   [:polyline {:points "12 5 19 12 12 19"}]])
-
-(defn arrow-right
-  "Render the lucide `arrow-right` glyph (rf2-yx1ae). Inherits
-  colour from the enclosing element via `currentColor`."
-  []
-  arrow-right-svg)
+;;
+;; ---- Arrow right (retired with rf2-zkiu5) -------------------------------
+;;
+;; The `arrow-right` SVG drove the CHILD-DISPATCHES section's per-child
+;; 'jump to' affordance (rf2-yx1ae). rf2-zkiu5 retired that step (the FX
+;; step already surfaces dispatch-family fx), so the glyph is gone.

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -45,8 +45,7 @@
   `tools/xray/spec/Conventions.md` §Pure-data helpers as `.cljc` — the
   projection is data-in / data-out and runs under both targets.
   `feedback_jvm_interop_must_work.md` is binding."
-  (:require [day8.re-frame2-xray.diff.engine :as diff-engine]
-            [day8.re-frame2-xray.panels.common-helpers :as common]))
+  (:require [day8.re-frame2-xray.panels.common-helpers :as common]))
 
 ;; ---- trace-event lookups -------------------------------------------------
 
@@ -395,40 +394,6 @@
       (when (map? fx)
         {:fx-vec        (:fx fx)
          :other-effects (not-empty (dissoc fx :db :fx))}))))
-
-(defn- db-diff-paths
-  "Compute the changed-paths vector for this cascade JIT from the
-  epoch-record's `:db-before` + `:db-after` snapshots via the canonical
-  Editscript-A* engine (`day8.re-frame2-xray.diff.engine/project`'s
-  `:flat-rows`, rf2-xuyac).
-
-  Pair-debug 2026-05-26 fix: the prior implementation read a
-  `:rf.event/db-changed-paths` tag off the `:rf.event/db-changed`
-  trace event. The framework's emit at `router.cljc:455` does NOT
-  stamp that tag (the framework's design records RAW snapshots —
-  `:db-before` / `:db-after` on the epoch record — and leaves diffs
-  to be computed JIT by consumers; the App-DB panel does the same).
-  Looking for the never-emitted tag meant `db-diff-paths` always
-  returned `[]` and the HANDLER `:db` sub-section always read
-  '— (no changes)' even when the handler mutated state extensively.
-
-  rf2-xuyac migration: the home-grown `app-db-diff-helpers/diff-paths`
-  walker this fn previously called is RETIRED for the HANDLER `:db`
-  surface (kept only for the trace panel `db-changed-diff-triples`,
-  out of scope). The Editscript engine is now the single canonical
-  diff engine for HANDLER `:db` + App-DB Diff + Machine Inspector
-  surfaces — the R-rule chrome the inspector paints is sourced off the
-  same diff engine (spec/021 §9.1.5.2 wholesale replacement). The
-  `[diff][full][full+diff]` mode toggle retired with rf2-vv3m6
-  (2026-05-29); FULL+DIFF is the single rendering.
-
-  Returns a vector of 4-tuples `[path before after change-kind]`.
-  When before == after (the handler returned no `:db` or an identical
-  value), returns `[]` correctly."
-  [db-before db-after]
-  (mapv (fn [{:keys [path op before after]}]
-          [path before after op])
-        (:flat-rows (diff-engine/project db-before db-after))))
 
 (defn- machine-lifecycle-rows
   "Project the `:rf.machine/action-ran` stream into per-phase rows
@@ -1054,24 +1019,26 @@
   dispatched event therefore a handler). Adapts to the trace stream's
   flavour discriminator:
 
-  - `:reg-event-db`  → :db-diff
-  - `:reg-event-fx`  → :db-diff + :fx
-  - `:reg-machine`   → :db-diff + :fx + :machine {transition guards
-                                                  lifecycle timers}
+  - `:reg-event-db`  → :db (post-handler snapshot)
+  - `:reg-event-fx`  → :db + :fx
+  - `:reg-machine`   → :db + :fx + :machine {transition guards
+                                             lifecycle timers}
 
-  `:db-diff` is computed JIT from `db-before` / `db-after` via the
-  Editscript-A* engine at `day8.re-frame2-xray.diff.engine`
-  (rf2-xuyac — see `db-diff-paths` ↑). The framework records raw
-  snapshots on the epoch-record; consumers derive diffs on demand
-  (pair-debug 2026-05-26 fix).
+  The HANDLER `:db` sub-section is rendered from `:db-post-handler`
+  (the effective post-handler / pre-flow snapshot) diffed against the
+  record's `:db-before` by the view's edn-inspector — no flat-row diff
+  is precomputed here (rf2-sp0n9: the prior `:db-diff` Editscript A*
+  slot had no live reader; the view discarded it and re-derived its own
+  render). The framework records raw snapshots on the epoch-record;
+  consumers derive diffs on demand.
 
-  Two arities — the 2-arg form (legacy callers / tests that
-  pre-date the JIT-diff fix) supplies nil/nil for db-before/after,
-  yielding an empty `:db-diff` consistent with the prior
-  trace-tag-based behaviour for the same input shape."
+  Two arities — the 2-arg form (legacy callers / tests) supplies
+  nil/nil for db-before/after. The 4-arg form's `db-after` is no
+  longer read (rf2-sp0n9 removed the flat-row diff that consumed it);
+  the arity is kept stable for existing callers / tests."
   ([events event-id]
    (handler-row events event-id nil nil))
-  ([events event-id db-before db-after]
+  ([events event-id db-before _db-after]
   (let [flavour     (handler-flavour events)
         run-end     (run-end-tags events)
         db-changed  (find-op events :rf.event/db-changed)
@@ -1104,12 +1071,7 @@
         ;;   - nil otherwise (no flow + no `:db`, or pre-rf2-ta0y7), where
         ;;     the slot stays nil and the view falls back to the record's
         ;;     `:db-after`.
-        ;;
-        ;; The `:db-diff` flat-rows are computed against this same
-        ;; effective baseline so non-view consumers + tests read the
-        ;; handler-only change (empty in the no-`:db`-with-flow case).
         db-post-handler (effective-post-handler-db events db-before)
-        db-handler  (if (some? db-post-handler) db-post-handler db-after)
         base        {:step           :handler
                      :badge          :HANDLER
                      :flavour        flavour
@@ -1128,7 +1090,6 @@
                      ;; no-write placeholder rather than the spurious full
                      ;; post-cascade app-db (PHANTOM-`:db` fix).
                      :db-write?      (handler-wrote-db? events)
-                     :db-diff        (db-diff-paths db-before db-handler)
                      ;; :fx — legacy flat-entries slot (kept for non-view
                      ;; consumers; tests + pre-rf2-p2zy0 callers).
                      :fx             (or (fx-entries events) [])
@@ -2594,128 +2555,20 @@
         steps))
     steps))
 
-;; ---- APP-DB DIFF step — REMOVED pair-debug 2026-05-26 --------------------
+;; ---- parent / child epoch correlation ------------------------------------
 ;;
-;; The standalone APP-DB DIFF step (rf2-rrykz) was removed because it
-;; renders the same data as the HANDLER step's `:db` sub-section.
-;; The HANDLER `:db` carries the `[diff][all]` toggle which gives the
-;; operator both the path-changes view AND the full post-cascade
-;; app-db without a separate pipeline step. The `app-db-diff-step` +
-;; `categorise-diff-path` fns are deleted along with the step.
-
-;; ---- CHILD DISPATCHES step (rf2-yx1ae) -----------------------------------
+;; A cascade that returns dispatch-family fx (`:dispatch / :dispatch-n /
+;; :dispatch-later`) triggers child cascades — each child rides its own
+;; epoch-record carrying `:parent-dispatch-id` (the parent's
+;; `:dispatch-id`; Spec-Schemas §`:rf/epoch-record`, rf2-rly4a). The
+;; DISPATCH step's `:fx-dispatch` chrome resolves the PARENT epoch off
+;; that link via the O(1) index below.
 ;;
-;; When a handler returns `:dispatch / :dispatch-n / :dispatch-later`
-;; fx, the cascade triggers child cascades — each child rides its own
-;; epoch-record. The CHILD-DISPATCHES section surfaces those children
-;; off THIS cascade's returned fx so the operator sees them inline.
-;;
-;; Source: the `:rf.event/fx` payload on `:rf.fx/do-fx` (the handler's
-;; returned fx map / vec — Spec 009 §`:rf.fx/do-fx`). We harvest ONLY
-;; the dispatch-family fx (`:dispatch / :dispatch-n / :dispatch-later`);
-;; other fx are the FX step's concern.
-;;
-;; Each row carries the child event vector + optional delay; the view
-;; layer joins this against the epoch-history at render time to find
-;; the child cascade's `:epoch-id` for the "jump to" affordance
-;; (children that have aged out of the ring buffer render with the
-;; "not in buffer" marker — the row still surfaces the event vector).
-
-(defn- normalise-child-dispatch
-  "Coerce a dispatch / dispatch-later fx arg into row fragments. Four
-  substrate shapes per Spec 009 / re-frame.fx:
-
-    1. `:dispatch [:event/x 7]`              → one row
-    2. `:dispatch-n [[:a] [:b]]`             → one row per element
-    3. `:dispatch-later {:ms 250 :dispatch [:retry]}` → one row + delay
-    4. `:dispatch-later [{:ms 250 :dispatch …} {:ms 500 :dispatch …}]`
-                                             → one row per element
-
-  Returns a vec of `{:event vec :delay-ms num-or-nil}` maps."
-  [fx-id value]
-  (case fx-id
-    :dispatch
-    (when (vector? value)
-      [{:event value :delay-ms nil}])
-
-    :dispatch-n
-    (when (sequential? value)
-      (vec (for [e value
-                 :when (vector? e)]
-             {:event e :delay-ms nil})))
-
-    :dispatch-later
-    (cond
-      (map? value)
-      (when (vector? (:dispatch value))
-        [{:event    (:dispatch value)
-          :delay-ms (or (:ms value) (:delay-ms value))}])
-      (sequential? value)
-      (vec (for [e value
-                 :when (and (map? e) (vector? (:dispatch e)))]
-             {:event (:dispatch e) :delay-ms (or (:ms e) (:delay-ms e))})))
-
-    nil))
-
-(def child-dispatch-fx-ids
-  "Closed set of fx-ids that produce child cascades (rf2-yx1ae)."
-  #{:dispatch :dispatch-n :dispatch-later})
-
-(defn child-dispatch-rows
-  "Project this cascade's child dispatches into rows (rf2-yx1ae).
-
-  Walks the `:rf.fx/do-fx` `:rf.event/fx` payload; harvests only the
-  dispatch-family entries. Each row carries:
-
-    :event    — the child's event vector
-    :delay-ms — delay (for `:dispatch-later`) or nil
-    :via      — the fx-id that emitted the row (`:dispatch /
-                 :dispatch-n / :dispatch-later`)
-
-  Empty vec when no dispatch-family fx fired."
-  [events]
-  (let [entries (fx-entries events)]
-    (vec
-      (for [{:keys [fx-id value]} entries
-            :when (contains? child-dispatch-fx-ids fx-id)
-            row (or (normalise-child-dispatch fx-id value) [])
-            :when (vector? (:event row))]
-        (assoc row :via fx-id)))))
-
-(defn child-dispatches-step
-  "Build the CHILD-DISPATCHES step row, or nil when no dispatch-family
-  fx fired (the step is OMITTED — conditional)."
-  [events]
-  (let [rows (child-dispatch-rows events)]
-    (when (seq rows)
-      {:step  :child-dispatches
-       :badge :CHILD-DISPATCHES
-       :rows  rows})))
-
-(defn find-child-epoch
-  "Resolve a child epoch's `:epoch-id` against the epoch-history given
-  THIS cascade's `:dispatch-id` + the child's event vector (rf2-yx1ae).
-
-  The parent→child link is the substrate-canonical
-  `:rf.trace/parent-dispatch-id` slot on the child's
-  `:rf.event/dispatched` trace (carrying THIS cascade's
-  `:dispatch-id` — Spec 009 §Dispatch correlation). The epoch-record
-  pins this on `:parent-dispatch-id` (Spec-Schemas §`:rf/epoch-record`,
-  rf2-rly4a).
-
-  We prefer matches with both `:parent-dispatch-id` AND a matching
-  trigger-event; when the trigger-event doesn't match (a sibling
-  dispatch with the same parent), the row falls back to whichever
-  child rides the same parent dispatch-id. Returns the matched
-  epoch's `:epoch-id` or nil when no child epoch is in the buffer
-  yet (or has aged out)."
-  [epoch-history parent-dispatch-id child-event]
-  (when (and (some? parent-dispatch-id) (vector? child-event))
-    (let [candidates (filter #(= parent-dispatch-id (:parent-dispatch-id %))
-                             epoch-history)
-          exact      (some #(when (= child-event (:trigger-event %)) %)
-                           candidates)]
-      (:epoch-id (or exact (first candidates))))))
+;; rf2-zkiu5 (pair-debug 2026-05-26) retired the standalone
+;; CHILD-DISPATCHES step (and its `child-dispatch-rows` /
+;; `child-dispatches-step` / `find-child-epoch` projection) — the FX
+;; step already surfaces every dispatch-family fx entry per row, so the
+;; cascade-link affordance lives on the FX rows themselves.
 
 (defn dispatch-id->epoch-id-index
   "Build a `{dispatch-id → epoch-id}` map from an `epoch-history` vector.
@@ -2748,8 +2601,8 @@
   `dispatch-id->epoch-id` index given the child's
   `:parent-dispatch-id` (rf2-5qp4g).
 
-  The reverse of `find-child-epoch`: child's `:parent-dispatch-id` →
-  parent's `:dispatch-id` → parent's `:epoch-id`. Returns nil when no
+  Child's `:parent-dispatch-id` → parent's `:dispatch-id` → parent's
+  `:epoch-id`. Returns nil when no
   parent epoch is in the buffer (root cascade, or aged out).
 
   rf2-x25e0 — O(1) lookup. The prior O(N) `some`-walk over
@@ -2989,20 +2842,6 @@
   [epoch-record]
   (number-steps (project epoch-record)))
 
-;; ---- formatting helpers (view-shared) ------------------------------------
-
-(defn format-duration-ms
-  "Render a duration in ms as a short string (`0.1ms` / `12ms` /
-  `1.2s`). Returns nil for non-numbers so the view can render an
-  em-dash on a missing duration without guarding the call site."
-  [ms]
-  (when (number? ms)
-    (cond
-      (>= ms 1000) (str (/ (Math/round (double (* (/ ms 1000.0) 10))) 10.0) "s")
-      (>= ms 10)   (str (Math/round (double ms)) "ms")
-      :else        (let [rounded (/ (Math/round (double (* ms 10))) 10.0)]
-                     (str rounded "ms")))))
-
 ;; ---- timing aggregation (rf2-nqt3d) -------------------------------------
 ;;
 ;; Per-step `:duration-ms` is stamped at projection time (each step row
@@ -3034,71 +2873,7 @@
   (let [ms (:duration-ms step)]
     (and (number? ms) (> ms long-step-threshold-ms))))
 
-(defn event-display
-  "Render the dispatched event vector as a one-line monospace string
-  for the DISPATCH row's target slot."
-  [event-vec]
-  (when (vector? event-vec)
-    (str event-vec)))
-
-(defn path-display
-  "Render a db path vector as the `[:foo :bar 0]` repr used by every
-  diff-style row. Returns `\"\"` for nil/empty."
-  [path]
-  (if (sequential? path)
-    (str (vec path))
-    ""))
-
-(defn ns-keyword
-  "Render an id as a clojure-style keyword string (`:my-ns/foo` or
-  `:foo`). Falls through `str` for non-keywords."
-  [id]
-  (cond
-    (qualified-keyword? id) (str ":" (namespace id) "/" (name id))
-    (keyword? id)           (str ":" (name id))
-    :else                   (str id)))
-
-(defn truncate
-  "Truncate a string to `n` chars with an ellipsis. Pure fn used by
-  the view layer for long arg displays in the FX table."
-  ([s] (truncate s 60))
-  ([s n]
-   (let [s (str s)]
-     (if (<= (count s) n)
-       s
-       (str (subs s 0 n) "…")))))
-
-(defn coeffect-row-display
-  "Render a coeffect row's id → value pair as a one-liner for the
-  view's diff-style add row (`+ [:session] {:user-id 42 …}`)."
-  [{:keys [id value]}]
-  (let [head (str "+ [" (ns-keyword id) "] ")
-        tail (truncate (pr-str value) 80)]
-    (str head tail)))
-
-(defn phase-label
-  "Render a machine action-ran `:phase` keyword as a UI label string."
-  [phase]
-  (case phase
-    :exit            "exit"
-    :transition      "transition"
-    :entry           "entry"
-    :always          "always"
-    :after-action    "after-action"
-    :initial-entry   "initial-entry"
-    :destroy-exit    "destroy-exit"
-    (when (keyword? phase) (name phase))))
-
-(defn timer-reason-label
-  "Render a timer-cancelled `:reason` keyword as a UI label string."
-  [reason]
-  (case reason
-    :on-exit          "on-exit"
-    :on-destroy       "on-destroy"
-    :on-resolution    "on-resolution"
-    :on-supersede     "on-supersede"
-    :on-frame-destroy "on-frame-destroy"
-    (when (keyword? reason) (name reason))))
+;; ---- lifecycle grouping (view-shared data) ------------------------------
 
 (defn group-lifecycle-by-phase
   "Group machine lifecycle rows by `:phase`. Returns a map from phase
@@ -3109,145 +2884,6 @@
             (update acc (or (:phase row) :unknown) (fnil conj []) row))
           {}
           (or lifecycle-rows [])))
-
-(defn cascade-row-label
-  "Render a cascade row's human-readable verb (rf2-u69j7). Used by the
-  view's per-row header. Pure-data; the view never reaches into a
-  row's slots to compute its label."
-  [{:keys [kind action-id guard-id phase from-state to-state state reason]}]
-  (case kind
-    :guard       (str "guard " (ns-keyword guard-id))
-    :action      (str (when phase (str (name phase) " "))
-                      "action " (ns-keyword action-id))
-    ;; rf2-ge6uj ISSUE 3 — the TRANSITION row's verb is JUST the state
-    ;; change `<before> → <after>`, made the focal point. The redundant
-    ;; leading "transition" word (the KIND pill already says TRANSITION)
-    ;; and the machine-name echo (`:door/main` — already the cascade
-    ;; context) are DROPPED; the lower-line state/event repetition is
-    ;; dropped in the view (`cascade-row-transition-details`).
-    :transition  (str (if from-state (pr-str from-state) "?")
-                      " → "
-                      (if to-state (pr-str to-state) "?"))
-    :timer       (str "timer " (when state (pr-str state))
-                      (when reason (str " · " (name reason))))
-    (str (when kind (name kind)))))
-
-(defn cascade-row-source-key
-  "Spec-path tuple used to look up a cascade row's source-coord on the
-  registered machine's `:rf.machine/source-coords` index (rf2-8bp3).
-  Pure-data; the view layer reuses this for the coord lookup so the
-  source-link affordance reads off ONE authoritative key.
-
-  Dispatch (rf2-u69j7 baseline + rf2-wwc3j inline-fn extensions):
-
-  - `:action` with a keyword `:action-id` → `[:actions <id>]`
-    (definition-site stamp; the named-handler path).
-  - `:action` with an inline `:action-id` (fn) — derive from the row's
-    `:phase` + state slot (`:source-state` / `:target-state`, stamped
-    by `enrich-cascade-rows`):
-    - `:entry` / `:initial-entry` → `[:states <state>... :entry]`
-      (target-state)
-    - `:exit` / `:destroy-exit`   → `[:states <state>... :exit]`
-      (source-state)
-    - `:transition`               → `[:states <state>... :on <event> :action]`
-      (source-state + event-id)
-    - `:always`                   → `[:states <state>... :always 0 :action]`
-      (best-effort: index 0; richer index resolution requires
-      substrate-side carrier of the always-index, deferred)
-    - `:after-action`             → `[:states <state>... :after :action]`
-      (best-effort: timer fn-form path; the macro doesn't yet stamp
-      per-delay `:after` coords; D2 follow-on bead handles richer index).
-  - `:guard` with a keyword `:guard-id` → `[:guards <id>]`
-    (definition-site stamp; the named-guard path).
-  - `:guard` with an inline `:guard-id` (fn) — derive from state +
-    event-id:
-    `[:states <state>... :on <event> :guard]` (best-effort: no vector
-    transition-option index — for the common single-map transition).
-  - `:transition` → `[:states <from-state>... :on <event>]`
-    (the transition map's spec-path; opens the operator on the
-    transition literal in the spec).
-  - `:timer` → `[:states <state>...]`
-    (D1 minimum-viable: the parent state's source-coord chip; richer
-    per-`:after` coord is the D2 follow-on bead's surface)."
-  [{:keys [kind action-id guard-id phase source-state target-state event-id]
-    timer-state :state}]
-  (let [source-prefix (state-spec-path-prefix source-state)
-        target-prefix (state-spec-path-prefix target-state)
-        timer-prefix  (state-spec-path-prefix timer-state)]
-    (case kind
-      :action
-      (cond
-        ;; Named-handler path (keyword id) — definition-site stamp.
-        (keyword? action-id) [:actions action-id]
-        ;; Inline-fn path — slot stamp under the relevant state.
-        (contains? #{:entry :initial-entry} phase)
-        (when target-prefix (conj target-prefix :entry))
-        (contains? #{:exit :destroy-exit} phase)
-        (when source-prefix (conj source-prefix :exit))
-        (= :transition phase)
-        (when (and source-prefix event-id)
-          (conj source-prefix :on event-id :action))
-        (= :always phase)
-        (when source-prefix (conj source-prefix :always 0 :action))
-        (= :after-action phase)
-        (when source-prefix (conj source-prefix :after :action))
-        :else nil)
-
-      :guard
-      (cond
-        (keyword? guard-id) [:guards guard-id]
-        :else
-        (when (and source-prefix event-id)
-          (conj source-prefix :on event-id :guard)))
-
-      :transition
-      (when (and source-prefix event-id)
-        (conj source-prefix :on event-id))
-
-      :timer
-      ;; The row's `:state` is the cancelled state vector (substrate
-      ;; payload). D1 minimum-viable shape: point at the parent state's
-      ;; spec-path so the operator orients on the `:after`-bearing node.
-      (or timer-prefix source-prefix target-prefix)
-
-      nil)))
-
-(defn cascade-outcome-label
-  "Render a cascade row's outcome for the view's outcome chip
-  (rf2-u69j7). Pure-data.
-
-    :guard       → `pass | fail | threw`
-    :action      → `ok | threw` (the action's outcome map is rich;
-                                 the chip carries only the headline)
-    :transition  → `→ N microstep(s)` (the headline reads off
-                                       `:microsteps`)
-    :timer       → `cancelled (<reason>)`"
-  [{:keys [kind outcome threw? microsteps reason]}]
-  (case kind
-    :guard      (if (keyword? outcome) (name outcome) nil)
-    :action     (cond
-                  threw?                "threw"
-                  (= :ok outcome)       "ok"
-                  (map? outcome)        "ok"
-                  (keyword? outcome)    (name outcome)
-                  :else                 nil)
-    :transition (when (number? microsteps)
-                  (str microsteps " microstep"
-                       (when (not= 1 microsteps) "s")))
-    :timer      (str "cancelled"
-                     (when reason (str " (" (name reason) ")")))
-    nil))
-
-;; ---- spec helpers --------------------------------------------------------
-
-(defn handler-flavour-label
-  "Human-readable label for a handler flavour keyword."
-  [flavour]
-  (case flavour
-    :reg-event-db  "reg-event-db"
-    :reg-event-fx  "reg-event-fx"
-    :reg-machine   "machine-event-handler"
-    (str flavour)))
 
 (defn empty-pipeline?
   "True iff `(project record)` would produce zero steps (no dispatch,
@@ -3267,8 +2903,6 @@
   - Original 7 (rf2-sc3r1): DISPATCH · COEFFECT · HANDLER · FLOW · FX ·
     SUBSCRIPTIONS · VIEWS.
   - rf2-17vxj: + SCHEMA-VIOLATIONS (warning chrome, conditional).
-  - rf2-yx1ae: + CHILD-DISPATCHES (cascade-link section, conditional).
-  - rf2-rrykz: + APP-DB-DIFF (state-mutation lens, conditional).
   - rf2-xgeag: SCHEMA-VIOLATIONS retired (violations attach to owning
     pipeline step inline); + SCHEMA-HOT-RELOAD for the hot-reload-only
     standalone tail step (drift has no owning cascade step).
@@ -3277,12 +2911,15 @@
   - rf2-yz57h: + INTERCEPTOR (conditional — present only when a user
     interceptor threw this cascade; the throwing interceptor's :before /
     :after row carries the shared 'Exception Thrown' card).
+  - rf2-zkiu5: CHILD-DISPATCHES + APP-DB-DIFF retired (pair-debug
+    2026-05-26) — both redundant with existing steps (FX surfaces
+    dispatch-family fx; HANDLER `:db` surfaces the post-handler diff).
 
   The view's badge resolver bails to `:text-tertiary` on an unknown
   badge, so adding to this set is purely additive."
   #{:DISPATCH :COEFFECT :INTERCEPTOR :HANDLER :FLOW :SIDE-EFFECTS
     :SUBSCRIPTIONS :VIEWS
-    :SCHEMA-HOT-RELOAD :CHILD-DISPATCHES :APP-DB-DIFF})
+    :SCHEMA-HOT-RELOAD})
 
 (defn valid-badge?
   "Predicate — `:badge` keyword is a member of `badge-set`."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -55,6 +55,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
+            [day8.re-frame2-xray.panels.epoch.format :as fmt]
             [day8.re-frame2-xray.panels.epoch.icons :as icons]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.panels.shared.coord-chip :as coord-chip]
@@ -1464,53 +1465,6 @@
 ;; banner has no caller. Downstream-mute treatment lives on via
 ;; `rolled-back-mute-style` (applied in `render-pipeline-steps`).
 
-;; -- CHILD DISPATCHES -----------------------------------------------------
-
-(def ^:private child-dispatch-row-style
-  {:display     "flex"
-   :align-items "center"
-   :gap         "8px"
-   :padding     "3px 0"
-   :font-family mono-stack
-   :font-size   "12px"
-   :flex-wrap   "wrap"})
-
-(def ^:private child-dispatch-via-style
-  {:color          text-tertiary-colour
-   :font-size      "10px"
-   :text-transform "uppercase"
-   :letter-spacing "0.5px"
-   :font-weight    600})
-
-(def ^:private child-dispatch-event-style
-  {:color      text-primary-colour
-   :min-width  0
-   :flex       1
-   :word-break "break-word"})
-
-(def ^:private child-dispatch-delay-style
-  {:color text-tertiary-colour :font-size "10px"})
-
-(def ^:private child-dispatch-jump-style
-  {:background     "transparent"
-   :border         border-default-1px
-   :border-radius  "3px"
-   :color          accent-colour
-   :cursor         "pointer"
-   :font-family    sans-stack
-   :font-size      "10px"
-   :padding        "2px 8px"
-   :display        "inline-flex"
-   :align-items    "center"
-   :gap            "4px"
-   :text-transform "uppercase"
-   :letter-spacing "0.5px"})
-
-(def ^:private child-dispatch-missing-style
-  {:color      text-tertiary-colour
-   :font-size  "10px"
-   :font-style "italic"})
-
 ;; -- pipeline -------------------------------------------------------------
 
 (def ^:private pipeline-host-style
@@ -1690,7 +1644,7 @@
          [:span {:aria-hidden true
                  :style duration-chip-long-glyph-style}
           "▲"])
-       (proj/format-duration-ms duration-ms)])))
+       (fmt/format-duration-ms duration-ms)])))
 
 ;; coord-chip moved to `panels.shared.coord-chip/coord-chip` (rf2-xjgdk
 ;; audit L2 — the icon-only chip was duplicated across panels; one
@@ -2099,7 +2053,7 @@
                           (catch :default _ nil)))
         coord      (when (and cofx-meta (string? (:file cofx-meta)))
                      {:file (:file cofx-meta) :line (:line cofx-meta)})
-        label      (proj/ns-keyword id)]
+        label      (fmt/ns-keyword id)]
     [:div {:key (str "cofx-" idx)
            :data-testid (str "rf-xray-epoch-coeffect-row-" idx)
            :style coeffect-row-style}
@@ -2130,7 +2084,7 @@
                           (catch :default _ nil)))
         coord      (when (and cofx-meta (string? (:file cofx-meta)))
                      {:file (:file cofx-meta) :line (:line cofx-meta)})
-        label      (proj/ns-keyword id)]
+        label      (fmt/ns-keyword id)]
     [:div {:data-testid (str "rf-xray-epoch-step-coeffect-" (name id))
            :data-step-kw "coeffect"
            :data-cofx-id (name id)}
@@ -2163,12 +2117,12 @@
        [:div {:data-testid (str "rf-xray-epoch-coeffect-failed-" (name id))
               :style coeffect-body-style}
         [:span {:style coeffect-body-path-style}
-         (str "injection of [" (proj/ns-keyword id) "] threw")]]
+         (str "injection of [" (fmt/ns-keyword id) "] threw")]]
        [:div {:data-testid (str "rf-xray-epoch-coeffect-value-" (name id))
               :style coeffect-body-style}
         [:span {:style coeffect-body-plus-style} "+"]
         [:span {:style coeffect-body-path-style}
-         (str "[" (proj/ns-keyword id) "]")]
+         (str "[" (fmt/ns-keyword id) "]")]
         [:span {:style coeffect-body-value-style}
          [ei/mini value 80]]])
      ;; rf2-yz57h — a coeffect-injection EXCEPTION attaches here as the
@@ -2257,7 +2211,7 @@
   `->interceptor*` fn, is a framework interceptor, or the bundle elided
   the coord in production."
   [idx {:keys [interceptor-id phase errors coord]}]
-  (let [label (proj/ns-keyword interceptor-id)]
+  (let [label (fmt/ns-keyword interceptor-id)]
     [:div {:key (str "interceptor-row-" idx)
            :data-testid (str "rf-xray-epoch-interceptor-row-" idx)
            :data-interceptor-phase (when phase (name phase))}
@@ -2353,7 +2307,7 @@
   Returns nil when no coord was captured (production builds, fixture
   fn-form machines)."
   [machine-meta row]
-  (when-let [k (proj/cascade-row-source-key row)]
+  (when-let [k (fmt/cascade-row-source-key row)]
     (let [idx (or (get-in machine-meta [:rf/machine :rf.machine/source-coords])
                   (:rf.machine/source-coords machine-meta))
           c   (get idx k)]
@@ -2395,7 +2349,7 @@
   Returns nil for rows whose source-key is nil (no spec-path could be
   derived — e.g. transition rows with no `:event-id`)."
   [machine-meta row]
-  (when-let [k (proj/cascade-row-source-key row)]
+  (when-let [k (fmt/cascade-row-source-key row)]
     (let [spec        (machine-spec-from-meta machine-meta)
           ;; rf2-ypu5i — named-handler source-string preferred for
           ;; `[:actions <id>]` / `[:guards <id>]`. The macro stamps
@@ -2627,7 +2581,7 @@
             [:span {:data-testid (str "rf-xray-epoch-machine-cascade-fx-"
                                       (:step row) "-" j)
                     :style cascade-detail-fx-chip-style}
-             (proj/ns-keyword fx-id)])])
+             (fmt/ns-keyword fx-id)])])
        ;; Threw path — the action halted the cascade. Surface a
        ;; compact error chip so the operator can pivot to the
        ;; exception body via the Issues panel.
@@ -2647,7 +2601,7 @@
 ;; rf2-ge6uj ISSUE 3 — the transition zone is collapsed to ONE prominent
 ;; row. The TRANSITION row's header carries `[#step] [TRANSITION badge]
 ;; <before-state → after-state>` (the verb IS the state change — see
-;; `projection/cascade-row-label`, which now emits just `<from> → <to>`),
+;; `format/cascade-row-label`, which now emits just `<from> → <to>`),
 ;; rendered visually PRIMARY via `cascade-transition-verb-link-style`. The
 ;; prior repetitive body (`cascade-row-transition-details`) is REMOVED: it
 ;; re-stated the state change on a labelled `state <from> → <to>` line and
@@ -2676,8 +2630,8 @@
   (let [{:keys [kind step phase duration-ms outcome threw?]} row
         coord       (cascade-row-coord machine-meta row)
         source-form (cascade-row-source-form machine-meta row)
-        verb        (proj/cascade-row-label row)
-        outcome-lbl (proj/cascade-outcome-label row)
+        verb        (fmt/cascade-row-label row)
+        outcome-lbl (fmt/cascade-outcome-label row)
         long?       (and (number? duration-ms)
                          (> duration-ms proj/long-step-threshold-ms))]
     [:div {:key (str "cascade-row-" step)
@@ -2748,7 +2702,7 @@
                   (when (number? total)
                     [:span {:data-testid "rf-xray-epoch-machine-cascade-total"
                             :style machine-cascade-total-style}
-                     (str "· " (proj/format-duration-ms total))])])
+                     (str "· " (fmt/format-duration-ms total))])])
      (if (zero? n)
        [:div {:data-testid "rf-xray-epoch-handler-machine-cascade-empty"
               :style machine-cascade-empty-style}
@@ -2891,7 +2845,7 @@
                    (try (rf/handler-meta :event event-id)
                         (catch :default _ nil)))
         coord    (coord-from-handler-meta meta)
-        label    (proj/handler-flavour-label flavour)]
+        label    (fmt/handler-flavour-label flavour)]
     ;; rf2-vw5pi — the HANDLER verb-as-link routes through the shared
     ;; `coord-link`. Single testid across both branches (the prior
     ;; `…-verb-plain` variant was a hand-rolled artefact, not pinned);
@@ -2973,9 +2927,6 @@
   or a pre-rf2-ta0y7 runtime) the block falls back to the record's
   `:db-after` so older epochs still render.
 
-  The `:db-diff` arg is unused under the single rendering but stays in
-  the parent's `handler-body` signature for projection compatibility.
-
   rf2-wnvid — PHANTOM-`:db` fix. When the handler wrote NO `:db` effect
   (`db-write?` false — e.g. it returned only `:fx`), the block renders a
   `— no :db (handler returned no :db)` placeholder instead of falling
@@ -2993,7 +2944,7 @@
   the snapshot IS the db change (at `[:rf/runtime :machines :snapshots <id>]`) so the
   slot folds into SNAPSHOT DIFF rather than carrying a redundant
   standalone slot."
-  [_db-diff db-post-handler db-write?]
+  [db-post-handler db-write?]
   (let [record    @(rf/subscribe [:rf.xray/selected-epoch-record])
         db-before (:db-before record)
         ;; rf2-4wywy — t1 (post-handler, pre-flow) is the authoritative
@@ -3065,7 +3016,7 @@
   Either, both, or neither may render — sections are
   `seq`-conditioned. The `:db` part stays in its own dedicated
   block (the [diff][full][full+diff] toggle) above."
-  [{:keys [flavour event-id db-diff db-post-handler db-write? fx-vec other-effects
+  [{:keys [flavour event-id db-post-handler db-write? fx-vec other-effects
            machine errors] :as _row}]
   (let [machine? (= :reg-machine flavour)
         ;; rf2-wnvid — the handler threw iff a `:rf.error/handler-exception`
@@ -3088,7 +3039,7 @@
      ;; inline 'Exception Thrown' card below is the signal). The slot
      ;; stays present for a clean handler that simply returned no `:db`.
      (when (and (not machine?) (not threw?))
-       (handler-db-diff-block db-diff db-post-handler db-write?))
+       (handler-db-diff-block db-post-handler db-write?))
      ;; :fx — the canonical vector-of-vectors, FULL via edn-inspector.
      ;; rf2-5t8y8 — sub-header carries a trailing entry-count chip ("N
      ;; entr{y,ies}") that the edn-inspector vector-header chrome alone
@@ -3206,7 +3157,7 @@
                           (catch :default _ nil)))
         coord      (when (and flow-meta (string? (:file flow-meta)))
                      {:file (:file flow-meta) :line (:line flow-meta)})
-        label      (proj/ns-keyword flow-id)
+        label      (fmt/ns-keyword flow-id)
         ;; rf2-4wywy / rf2-48oc4 — render a `:db` diff scoped to this
         ;; flow's path. db-pre-flow (effective post-handler db) lacks this
         ;; flow's write; db-post-flow (t2) carries it. Scoping to the path
@@ -3244,7 +3195,7 @@
        ;; flow's path → the inspector paints the flow's slot reshape.
        [:div {:data-testid (str "rf-xray-epoch-flow-db-diff-" (name flow-id))
               :style handler-db-all-style}
-        (sub-header ":db" (proj/path-display path))
+        (sub-header ":db" (fmt/path-display path))
         [ei/edn-inspector diff-after
          {:site-id [:rf.xray.epoch/flow-db-diff flow-id]
           :before  diff-before
@@ -3258,7 +3209,7 @@
           [:span {:style coeffect-body-plus-style}
            (if (some? before) "~" "+")]
           [:span {:style coeffect-body-path-style}
-           (proj/path-display path)]
+           (fmt/path-display path)]
           (when (some? before)
             [:span {:style diff-before-style} [ei/mini before 30]])
           (when (and (some? before) (some? after))
@@ -3357,7 +3308,7 @@
              :title (when skipped? badge/skipped-hover)}
       (badge/fx-row-status-glyph status)]
      [:span {:style fx-row-id-style}
-      (proj/ns-keyword fx-id)
+      (fmt/ns-keyword fx-id)
       ;; rf2-g1mfc — click-to-source via the shared `coord-chip`, exact
       ;; parity with the SUBSCRIPTIONS (~3000) + VIEWS rows + the HANDLER
       ;; verb. The coord lookup keys off `fx-id` and resolves the
@@ -3385,15 +3336,15 @@
                           :default-expanded-depth 1}]])
      (when (number? duration-ms)
        [:span {:style fx-row-duration-style}
-        (proj/format-duration-ms duration-ms)])
+        (fmt/format-duration-ms duration-ms)])
      ;; rf2-uffov — per-action attribution chip (for machine cascades)
      (when-let [{:keys [action-id phase]} attributed-to]
        [:span {:data-testid (str "rf-xray-epoch-fx-row-attribution-" idx)
-               :title (str "emitted by " (proj/ns-keyword action-id)
+               :title (str "emitted by " (fmt/ns-keyword action-id)
                            (when phase (str " (" (name phase) " action)")))
                :style fx-row-attribution-style}
         [:span {:aria-hidden true} "←"]
-        (proj/ns-keyword action-id)
+        (fmt/ns-keyword action-id)
         (when phase
           [:span {:style fx-row-attribution-phase-style}
            (str "(" (name phase) ")")])])]))
@@ -4624,121 +4575,19 @@
 ;; case in `render-step` are removed; the projection no longer
 ;; emits the step (rf2-7gf7v / projection.cljc).
 
-;; ---- APP-DB DIFF step — REMOVED pair-debug 2026-05-26 -------------------
-;;
-;; Replaced by the HANDLER step's `:db` `[diff][all]` toggle which
-;; surfaces the same data in-context. `render-app-db-diff-step` +
-;; `app-db-diff-row-view` deleted along with the step.
-
-
-;; ---- CHILD DISPATCHES step (rf2-yx1ae) ----------------------------------
-
-(defn- child-dispatch-via-label
-  "Render the `:via` slot (the fx-id that emitted the row) as a UI
-  chip label (rf2-yx1ae)."
-  [via]
-  (case via
-    :dispatch        "dispatch"
-    :dispatch-n      "dispatch-n"
-    :dispatch-later  "dispatch-later"
-    (when (keyword? via) (name via))))
-
-(defn- child-dispatch-row-view
-  "Render one child-dispatch row. Carries:
-
-  - child event vector (the operator's primary read)
-  - `:via` chip (which fx-id emitted the row)
-  - `:delay-ms` chip (for `:dispatch-later`)
-  - jump-to button when the child epoch is in the buffer; otherwise
-    a muted `not in buffer` marker
-
-  rf2-yx1ae. The jump-to dispatches `:rf.xray/select-epoch` against
-  the resolved child `:epoch-id`."
-  [{:keys [dispatch-id epoch-history]} idx {:keys [event delay-ms via]}]
-  ;; rf2-nesy9 — render-time frame capture for the deferred jump click.
-  (let [frame          (rf/current-frame-id)
-        child-epoch-id (proj/find-child-epoch epoch-history dispatch-id event)]
-    [:div {:key (str "child-dispatch-" idx)
-           :data-testid (str "rf-xray-epoch-child-dispatch-row-" idx)
-           :data-child-resolved (str (some? child-epoch-id))
-           :style child-dispatch-row-style}
-     ;; via fx-id chip (muted)
-     [:span {:data-testid (str "rf-xray-epoch-child-dispatch-via-" idx)
-             :style child-dispatch-via-style}
-      (child-dispatch-via-label via)]
-     ;; event vector (primary) — rf2-8w8er routes through `mini` so
-     ;; the dispatched event vector carries syntax-token chrome.
-     [:span {:data-testid (str "rf-xray-epoch-child-dispatch-event-" idx)
-             :style child-dispatch-event-style}
-      [ei/mini event 80]]
-     ;; delay chip (for :dispatch-later)
-     (when (number? delay-ms)
-       [:span {:data-testid (str "rf-xray-epoch-child-dispatch-delay-" idx)
-               :style child-dispatch-delay-style}
-        (str "+" delay-ms "ms")])
-     ;; jump-to or "not in buffer"
-     (if child-epoch-id
-       [:button {:data-testid (str "rf-xray-epoch-child-dispatch-jump-" idx)
-                 :data-child-epoch-id (str child-epoch-id)
-                 :aria-label "jump to child cascade"
-                 :on-click (fn [e]
-                             (.stopPropagation e)
-                             (rf/dispatch [:rf.xray/select-epoch child-epoch-id]
-                                          {:frame frame}))
-                 :style child-dispatch-jump-style}
-        (icons/arrow-right)
-        "jump"]
-       [:span {:data-testid (str "rf-xray-epoch-child-dispatch-missing-" idx)
-               :title "the child cascade has aged out of the epoch buffer (or has not yet completed)"
-               :style child-dispatch-missing-style}
-        "not in buffer"])]))
-
-(defn render-child-dispatches-step
-  "Render the CHILD-DISPATCHES step (rf2-yx1ae — only present when
-  the handler returned dispatch-family fx).
-
-  Header: `N events dispatched` (per the bead's acceptance §4).
-  Per-row: event vector + via-fx chip + delay chip + jump-to
-  affordance (resolves child epoch via `proj/find-child-epoch`).
-
-  `ctx` carries this cascade's `:dispatch-id` + the
-  `:epoch-history` slice; the row-view uses both to find the
-  child's `:epoch-id`."
-  [{:keys [rows step-number]} ctx]
-  [:div {:data-testid "rf-xray-epoch-step-child-dispatches"
-         :data-step-kw "child-dispatches"}
-   (numbered-circle step-number :CHILD-DISPATCHES)
-   (step-header
-     {:step :child-dispatches
-      :badge :CHILD-DISPATCHES
-      :verb (str (count rows) " event"
-                 (when (not= 1 (count rows)) "s")
-                 " dispatched")
-      :expandable? false
-      :testid "rf-xray-epoch-child-dispatches"}
-     nil)
-   [:div {:style margin-top-5-style}
-    (map-indexed (fn [idx row]
-                   (child-dispatch-row-view ctx idx row))
-                 rows)]])
-
 ;; ---- step dispatcher -----------------------------------------------------
-
-(declare render-child-dispatches-step)
 
 (defn- render-step
   "Dispatch a step row to its renderer. Returns hiccup; nil for
   unknown step kinds (defensive — every step the projection produces
   is in the canonical inventory; rf2-17vxj added SCHEMA-VIOLATIONS
   later retired by rf2-xgeag in favour of inline attachment + a
-  hot-reload-only tail step; rf2-yx1ae added CHILD-DISPATCHES;
-  rf2-rrykz added APP-DB-DIFF).
+  hot-reload-only tail step; rf2-yx1ae's CHILD-DISPATCHES + rf2-rrykz's
+  APP-DB-DIFF steps were retired by rf2-zkiu5).
 
-  `ctx` carries the cascade-level pieces a row may need (e.g. the
-  parent `:dispatch-id` + the `:epoch-history` slice for the
-  CHILD-DISPATCHES section's child-epoch resolution + rf2-5qp4g
-  DISPATCH `:fx-dispatch` parent-epoch link resolution). Most steps
-  ignore it."
+  `ctx` carries the cascade-level pieces a row may need (the rf2-5qp4g
+  DISPATCH `:fx-dispatch` parent-epoch link resolution index). Most
+  steps ignore it."
   [step ctx]
   (case (:step step)
     :dispatch          (render-dispatch-step step (:dispatch-id->epoch-id ctx))
@@ -4749,10 +4598,6 @@
     :side-effects      (render-side-effects-step step)
     :subscriptions     (render-subscriptions-step step)
     :views             (render-views-step step)
-    ;; :schema-hot-reload case retired per rf2-7gf7v — the
-    ;; projection no longer emits the step.
-    :child-dispatches  (render-child-dispatches-step step ctx)
-    ;; :app-db-diff removed pair-debug 2026-05-26 — see comment above.
     nil))
 
 ;; ---- pipeline view -------------------------------------------------------
@@ -4773,10 +4618,10 @@
       Row spacing: 13px vertical gap between entries
 
   `ctx` is an optional map carrying cascade-level pieces individual
-  step renderers may need (`:dispatch-id`, `:epoch-history` — used
-  by the CHILD-DISPATCHES section to resolve child epochs via
-  `proj/find-child-epoch`). Defaulted to `{}` for back-compat with
-  direct test callers."
+  step renderers may need (`:dispatch-id->epoch-id` — the precomputed
+  index the DISPATCH step's `:fx-dispatch` parent-epoch link reads,
+  rf2-x25e0). Defaulted to `{}` for back-compat with direct test
+  callers."
   ([steps]
    (pipeline-view steps {}))
   ([steps ctx]
@@ -4860,7 +4705,7 @@
   e2e; the pre-rf2-wnvid top banner is retired (it merely restated the
   inline signal)."
   []
-  (let [{:keys [status steps dispatch-id epoch-history outcome]}
+  (let [{:keys [status steps epoch-history outcome]}
         @(rf/subscribe [:rf.xray/epoch-pipeline])]
     [:section {:data-testid "rf-xray-epoch-panel"
                :data-rf-xray-outcome (when outcome (name outcome))
@@ -4876,9 +4721,7 @@
            ;; parent-epoch resolver (O(1) lookup instead of an O(N)
            ;; epoch-history scan per render).
            (pipeline-view steps
-                          {:dispatch-id           dispatch-id
-                           :epoch-history         epoch-history
-                           :dispatch-id->epoch-id (proj/dispatch-id->epoch-id-index
+                          {:dispatch-id->epoch-id (proj/dispatch-id->epoch-id-index
                                                     epoch-history)})]
           (empty-state-view :no-events))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -96,13 +96,12 @@
          ;; by spec, and is NOT the panel's outcome (see
          ;; `projection/epoch-outcome`).
          :outcome        (proj/epoch-outcome steps)
-         ;; rf2-yx1ae — the CHILD-DISPATCHES section's view resolves
-         ;; child epoch-ids via `find-child-epoch` against this cascade's
-         ;; `:dispatch-id` + the epoch-history. Pinning them on the
-         ;; composite sub keeps the view side a pure render — no
-         ;; secondary sub against `:rf.xray/epoch-history` in the
-         ;; per-row hot path.
-         :dispatch-id    (:dispatch-id record)
+         ;; rf2-x25e0 — the DISPATCH step's `:fx-dispatch` parent-epoch
+         ;; link resolves `:parent-dispatch-id → parent epoch-id` off a
+         ;; `{dispatch-id → epoch-id}` index the view builds once per
+         ;; render from this slice. Pinning `:epoch-history` on the
+         ;; composite sub keeps the view side a pure render — no secondary
+         ;; sub against `:rf.xray/epoch-history` in the per-row hot path.
          :epoch-history  epoch-history
          :steps          (vec (or steps []))})))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -33,6 +33,7 @@
         grouping, timer reasons, guard outcomes)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-xray.panels.epoch.format :as fmt]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             ;; rf2-tyivx — canonical trace-event builders shared with
             ;; the panel-gallery synth fixtures + any other projection
@@ -409,21 +410,18 @@
 (deftest handler-row-reg-event-db-test
   (testing "no fx + no machine = reg-event-db flavour.
 
-  Post pair-debug 2026-05-26 (commit ee9def224): `handler-row` reads
-  the JIT-diff off explicit `db-before` / `db-after` snapshots; the
-  2-arg form here supplies nil/nil and yields an empty `:db-diff`
-  regardless of any trace-tag-stamped paths on the events. The
-  `:rrykz`-era assertion `(= 1 (count :db-diff))` against
-  `db-changed-paths` tags is removed — those tags are not what the
-  current `handler-row` reads."
+  rf2-sp0n9 — the prior `:db-diff` Editscript flat-row slot is gone
+  (the view re-derived its own diff and discarded the projection's);
+  the HANDLER `:db` is now rendered from `:db-post-handler` diffed
+  against `:db-before` by the view's edn-inspector."
     (let [r (proj/handler-row [(db-changed-ev [[[:counter] 5 6 :modified]])]
                               :counter-inc)]
       (is (= :handler (:step r)))
       (is (= :HANDLER (:badge r)))
       (is (= :reg-event-db (:flavour r)))
       (is (= :counter-inc (:event-id r)))
-      (is (= [] (:db-diff r))
-          "2-arg form supplies nil db-before/after → empty :db-diff")
+      (is (not (contains? r :db-diff))
+          "rf2-sp0n9 — no precomputed :db-diff slot on the handler row")
       (is (= [] (:fx r))))))
 
 (deftest handler-row-reg-event-fx-test
@@ -671,18 +669,18 @@
 (deftest cascade-row-label-test
   (testing "rf2-u69j7 — `cascade-row-label` renders a human verb per kind"
     (is (= "guard :ready?"
-           (proj/cascade-row-label {:kind :guard :guard-id :ready?})))
+           (fmt/cascade-row-label {:kind :guard :guard-id :ready?})))
     (is (= "entry action :open-socket"
-           (proj/cascade-row-label {:kind :action :action-id :open-socket
+           (fmt/cascade-row-label {:kind :action :action-id :open-socket
                                     :phase :entry})))
     (is (= "timer [:idle] · on-exit"
-           (proj/cascade-row-label {:kind :timer :state [:idle]
+           (fmt/cascade-row-label {:kind :timer :state [:idle]
                                     :reason :on-exit})))
     ;; rf2-ge6uj ISSUE 3 — the transition label is JUST the state change
     ;; `<from> → <to>`; the redundant "transition" word + machine-name
     ;; echo are dropped (the KIND pill + cascade context carry those).
     (is (= "[:idle] → [:connecting]"
-           (proj/cascade-row-label {:kind :transition
+           (fmt/cascade-row-label {:kind :transition
                                     :machine-id :ws/conn
                                     :from-state [:idle]
                                     :to-state   [:connecting]})))))
@@ -691,14 +689,14 @@
   (testing "rf2-u69j7 — `cascade-row-source-key` returns the spec-path
             tuple for source-coord lookup (named cases)"
     (is (= [:actions :open-socket]
-           (proj/cascade-row-source-key
+           (fmt/cascade-row-source-key
              {:kind :action :action-id :open-socket})))
     (is (= [:guards :ready?]
-           (proj/cascade-row-source-key
+           (fmt/cascade-row-source-key
              {:kind :guard :guard-id :ready?})))
-    (is (nil? (proj/cascade-row-source-key {:kind :transition}))
+    (is (nil? (fmt/cascade-row-source-key {:kind :transition}))
         "transitions with no state/event context → nil")
-    (is (nil? (proj/cascade-row-source-key {:kind :timer}))
+    (is (nil? (fmt/cascade-row-source-key {:kind :timer}))
         "timers with no state context → nil")))
 
 ;; ---- rf2-wwc3j — inline-fn / transition / timer source-key extensions -----
@@ -708,17 +706,17 @@
             target-state's `[:states <s> :entry]` slot"
     (let [inline-fn (fn [_] {})]
       (is (= [:states :connected :entry]
-             (proj/cascade-row-source-key
+             (fmt/cascade-row-source-key
                {:kind :action :action-id inline-fn :phase :entry
                 :target-state :connected}))
           "flat machine: entry action under target-state slot")
       (is (= [:states :connected :entry]
-             (proj/cascade-row-source-key
+             (fmt/cascade-row-source-key
                {:kind :action :action-id inline-fn :phase :entry
                 :target-state [:connected]}))
           "vector target-state coerces to the same path")
       (is (= [:states :outer :states :inner :entry]
-             (proj/cascade-row-source-key
+             (fmt/cascade-row-source-key
                {:kind :action :action-id inline-fn :phase :entry
                 :target-state [:outer :inner]}))
           "hierarchical target-state expands to nested :states path"))))
@@ -728,11 +726,11 @@
             source-state's `[:states <s> :exit]` slot"
     (let [inline-fn (fn [_] {})]
       (is (= [:states :idle :exit]
-             (proj/cascade-row-source-key
+             (fmt/cascade-row-source-key
                {:kind :action :action-id inline-fn :phase :exit
                 :source-state :idle})))
       (is (= [:states :idle :exit]
-             (proj/cascade-row-source-key
+             (fmt/cascade-row-source-key
                {:kind :action :action-id inline-fn :phase :destroy-exit
                 :source-state :idle}))
           ":destroy-exit phase also maps to the :exit slot"))))
@@ -742,7 +740,7 @@
             `[:states <src> :on <event> :action]`"
     (let [inline-fn (fn [_] {})]
       (is (= [:states :idle :on :submit :action]
-             (proj/cascade-row-source-key
+             (fmt/cascade-row-source-key
                {:kind :action :action-id inline-fn :phase :transition
                 :source-state :idle :event-id :submit}))))))
 
@@ -751,11 +749,11 @@
             `[:states <src> :on <event> :guard]`"
     (let [inline-fn (fn [_] true)]
       (is (= [:states :idle :on :submit :guard]
-             (proj/cascade-row-source-key
+             (fmt/cascade-row-source-key
                {:kind :guard :guard-id inline-fn
                 :source-state :idle :event-id :submit}))
           "inline guard on a state's :on transition")
-      (is (nil? (proj/cascade-row-source-key
+      (is (nil? (fmt/cascade-row-source-key
                   {:kind :guard :guard-id inline-fn
                    :source-state :idle}))
           "missing event-id → nil (the source-key cannot be built)"))))
@@ -765,14 +763,14 @@
             :on <event>]` so the click-through opens the transition map
             literal in the spec"
     (is (= [:states :idle :on :submit]
-           (proj/cascade-row-source-key
+           (fmt/cascade-row-source-key
              {:kind :transition :source-state :idle :event-id :submit})))
     (is (= [:states :outer :states :inner :on :go]
-           (proj/cascade-row-source-key
+           (fmt/cascade-row-source-key
              {:kind :transition :source-state [:outer :inner]
               :event-id :go}))
         "hierarchical from-state expands to nested :states path")
-    (is (nil? (proj/cascade-row-source-key
+    (is (nil? (fmt/cascade-row-source-key
                 {:kind :transition :source-state :idle}))
         "missing event-id → nil")))
 
@@ -780,12 +778,12 @@
   (testing "rf2-wwc3j — `:timer` row resolves to `[:states <state>]`
             (D1 minimum-viable: parent state's source-coord chip)"
     (is (= [:states :idle]
-           (proj/cascade-row-source-key
+           (fmt/cascade-row-source-key
              {:kind :timer :state :idle})))
     (is (= [:states :idle]
-           (proj/cascade-row-source-key
+           (fmt/cascade-row-source-key
              {:kind :timer :state [:idle]})))
-    (is (nil? (proj/cascade-row-source-key {:kind :timer}))
+    (is (nil? (fmt/cascade-row-source-key {:kind :timer}))
         "missing state → nil")))
 
 (deftest cascade-row-source-key-named-shadows-inline-test
@@ -793,12 +791,12 @@
             inline derivation (the existing definition-site path covers
             the named case end-to-end)"
     (is (= [:actions :open-socket]
-           (proj/cascade-row-source-key
+           (fmt/cascade-row-source-key
              {:kind :action :action-id :open-socket :phase :entry
               :target-state :connected}))
         ":action-id keyword → definition-site path, ignores :phase / :target-state")
     (is (= [:guards :ready?]
-           (proj/cascade-row-source-key
+           (fmt/cascade-row-source-key
              {:kind :guard :guard-id :ready? :source-state :idle
               :event-id :submit}))
         ":guard-id keyword → definition-site path, ignores :source-state / :event-id")))
@@ -895,18 +893,18 @@
 (deftest cascade-outcome-label-test
   (testing "rf2-u69j7 — `cascade-outcome-label` renders kind-specific
             outcome strings"
-    (is (= "pass"  (proj/cascade-outcome-label {:kind :guard :outcome :pass})))
-    (is (= "fail"  (proj/cascade-outcome-label {:kind :guard :outcome :fail})))
-    (is (= "threw" (proj/cascade-outcome-label {:kind :guard :outcome :threw})))
-    (is (= "ok"    (proj/cascade-outcome-label {:kind :action :outcome :ok})))
-    (is (= "threw" (proj/cascade-outcome-label
+    (is (= "pass"  (fmt/cascade-outcome-label {:kind :guard :outcome :pass})))
+    (is (= "fail"  (fmt/cascade-outcome-label {:kind :guard :outcome :fail})))
+    (is (= "threw" (fmt/cascade-outcome-label {:kind :guard :outcome :threw})))
+    (is (= "ok"    (fmt/cascade-outcome-label {:kind :action :outcome :ok})))
+    (is (= "threw" (fmt/cascade-outcome-label
                      {:kind :action :threw? true :outcome :rf.error/action-threw})))
     (is (= "1 microstep"
-           (proj/cascade-outcome-label {:kind :transition :microsteps 1})))
+           (fmt/cascade-outcome-label {:kind :transition :microsteps 1})))
     (is (= "3 microsteps"
-           (proj/cascade-outcome-label {:kind :transition :microsteps 3})))
+           (fmt/cascade-outcome-label {:kind :transition :microsteps 3})))
     (is (= "cancelled (on-exit)"
-           (proj/cascade-outcome-label {:kind :timer :reason :on-exit})))))
+           (fmt/cascade-outcome-label {:kind :timer :reason :on-exit})))))
 
 ;; ---- FLOW ---------------------------------------------------------------
 
@@ -1042,14 +1040,12 @@
       (is (= 2 (:derived (:db-post-handler h)))
           "the HANDLER step's :derived is the PRE-flow value (2), NOT the
            flow's recomputed value (4) — the handler did not touch it")
-      ;; The flat-row `:db-diff` (non-view consumers) is computed against
-      ;; t1, so it shows ONLY the handler's path changes, no :derived.
-      (let [diff-paths (set (map first (:db-diff h)))]
-        (is (contains? diff-paths [:base])
-            ":db-diff carries the handler's :base bump")
-        (is (not (contains? diff-paths [:derived]))
-            ":db-diff must NOT carry the flow's :derived recompute — that
-             belongs to the FLOW step, not the HANDLER step")))))
+      ;; rf2-sp0n9 — the view diffs `:db-post-handler` (t1) against
+      ;; `:db-before`, so the HANDLER step shows ONLY the handler's :base
+      ;; bump; the flow's :derived recompute belongs to the FLOW step.
+      (is (= 2 (:base (:db-post-handler h)))
+          "the HANDLER step's effective post-handler db carries the
+           handler's :base bump (1 → 2)"))))
 
 (deftest flow-step-carries-its-own-db-diff-snapshots-test
   (testing "rf2-4wywy ACCEPTANCE — the FLOW step carries the t1 (pre-flow)
@@ -1088,8 +1084,7 @@
   (testing "rf2-4wywy — graceful fallback: when no t1 fired (handler
             returned no `:db`, or a pre-rf2-ta0y7 runtime) the HANDLER
             step carries no `:db-post-handler`; the view falls back to
-            the record's `:db-after`. The flat `:db-diff` then reads the
-            db-before → db-after change (prior behaviour preserved)."
+            the record's `:db-after` and diffs it against `:db-before`."
     (let [record {:event-id     :legacy/no-t1
                   :db-before    {:counter 1}
                   :db-after     {:counter 2}
@@ -1099,9 +1094,8 @@
           h      (first (filter #(= :handler (:step %)) steps))]
       (is (some? h))
       (is (nil? (:db-post-handler h))
-          "no t1 on the stream → :db-post-handler absent")
-      (is (contains? (set (map first (:db-diff h))) [:counter])
-          "without t1 the :db-diff falls back to db-before → db-after"))))
+          "no t1 on the stream → :db-post-handler absent (view falls
+           back to the record's :db-after)"))))
 
 (deftest flow-step-falls-back-to-scalar-when-no-snapshots-test
   (testing "rf2-4wywy — when no t1/t2 snapshots rode the stream (pre-
@@ -1166,9 +1160,9 @@
 (deftest handler-step-shows-no-db-change-when-handler-wrote-no-db-test
   (testing "rf2-48oc4 ACCEPTANCE (b) — when the handler returned NO `:db`
             but a flow fired, the HANDLER step shows NO `:db` change: the
-            effective post-handler db equals `db-before`, so the `:db-diff`
-            is EMPTY and `:db-post-handler` carries db-before (NOT the
-            flow-augmented post-flow state)."
+            effective post-handler db equals `db-before` (NOT the
+            flow-augmented post-flow state), so the view's diff against
+            `:db-before` is empty."
     (let [db-before {:base 1 :derived 2}
           ;; handler wrote no :db → t1 absent. The flow recomputes
           ;; :derived from :base into app-db → t2 fires with the augmented db.
@@ -1188,11 +1182,9 @@
       (is (= db-before (:db-post-handler h))
           "the HANDLER step's effective post-handler db = db-before (the
            handler wrote nothing); NOT the post-flow t2")
-      (is (= [] (:db-diff h))
-          "HANDLER `:db-diff` is EMPTY — the handler made no :db change;
-           the flow's :derived recompute must NOT surface here")
-      (is (not (contains? (set (map first (:db-diff h))) [:derived]))
-          "the flow's :derived change does NOT leak into the HANDLER step"))))
+      (is (= 2 (:derived (:db-post-handler h)))
+          "rf2-sp0n9 — the flow's :derived recompute (2 → 4) does NOT leak
+           into the HANDLER step's effective db; it stays at the pre-flow 2"))))
 
 (deftest flow-step-diffs-against-db-before-when-handler-wrote-no-db-test
   (testing "rf2-48oc4 ACCEPTANCE (a) — when the handler returned NO `:db`
@@ -1928,48 +1920,59 @@
                          (view-render-ev ::v [:s])])
           steps (proj/project rec)]
       (is (every? proj/valid-badge? (map :badge steps)))
-      (is (= 11 (count proj/badge-set))
-          "rf2-sc3r1 7 + rf2-yx1ae + rf2-rrykz + rf2-xgeag (SCHEMA-HOT-RELOAD,
-           renamed from SCHEMA-VIOLATIONS) + rf2-yz57h (INTERCEPTOR) = 11 badges"))))
+      (is (= 9 (count proj/badge-set))
+          "rf2-sc3r1 7 + rf2-xgeag (SCHEMA-HOT-RELOAD, renamed from
+           SCHEMA-VIOLATIONS) + rf2-yz57h (INTERCEPTOR) = 9 badges.
+           rf2-btt0s deleted :CHILD-DISPATCHES + :APP-DB-DIFF (retired
+           steps the projection can no longer emit).")
+      ;; rf2-btt0s — guard against step-level drift: badge-set must NOT
+      ;; advertise a badge no step can produce. The conditional steps
+      ;; (FLOW / SIDE-EFFECTS / SCHEMA-HOT-RELOAD / INTERCEPTOR) are
+      ;; covered by their own dedicated projection tests; here we pin the
+      ;; two RETIRED badges are gone so the dead-badge class is CI-visible.
+      (is (not (contains? proj/badge-set :CHILD-DISPATCHES))
+          "retired CHILD-DISPATCHES badge removed from badge-set")
+      (is (not (contains? proj/badge-set :APP-DB-DIFF))
+          "retired APP-DB-DIFF badge removed from badge-set"))))
 
 ;; ---- formatting helpers --------------------------------------------------
 
 (deftest format-duration-ms-test
   (testing "duration formatting"
-    (is (= "0.1ms" (proj/format-duration-ms 0.1)))
-    (is (= "9.5ms" (proj/format-duration-ms 9.5)))
-    (is (= "12ms"  (proj/format-duration-ms 12)))
-    (is (= "1.2s"  (proj/format-duration-ms 1234)))
-    (is (nil? (proj/format-duration-ms nil)))))
+    (is (= "0.1ms" (fmt/format-duration-ms 0.1)))
+    (is (= "9.5ms" (fmt/format-duration-ms 9.5)))
+    (is (= "12ms"  (fmt/format-duration-ms 12)))
+    (is (= "1.2s"  (fmt/format-duration-ms 1234)))
+    (is (nil? (fmt/format-duration-ms nil)))))
 
 (deftest ns-keyword-test
   (testing "id rendering"
-    (is (= ":foo"       (proj/ns-keyword :foo)))
-    (is (= ":my/foo"    (proj/ns-keyword :my/foo)))
-    (is (= "non-kw"     (proj/ns-keyword "non-kw")))))
+    (is (= ":foo"       (fmt/ns-keyword :foo)))
+    (is (= ":my/foo"    (fmt/ns-keyword :my/foo)))
+    (is (= "non-kw"     (fmt/ns-keyword "non-kw")))))
 
 (deftest truncate-test
   (testing "truncate keeps short strings + ellipsises long ones"
-    (is (= "abc"  (proj/truncate "abc" 5)))
-    (is (= "abcd…" (proj/truncate "abcdefg" 4)))))
+    (is (= "abc"  (fmt/truncate "abc" 5)))
+    (is (= "abcd…" (fmt/truncate "abcdefg" 4)))))
 
 (deftest phase-label-test
   (testing "phase labels render every closed-set member"
-    (is (= "exit"            (proj/phase-label :exit)))
-    (is (= "transition"      (proj/phase-label :transition)))
-    (is (= "entry"           (proj/phase-label :entry)))
-    (is (= "always"          (proj/phase-label :always)))
-    (is (= "after-action"    (proj/phase-label :after-action)))
-    (is (= "initial-entry"   (proj/phase-label :initial-entry)))
-    (is (= "destroy-exit"    (proj/phase-label :destroy-exit)))))
+    (is (= "exit"            (fmt/phase-label :exit)))
+    (is (= "transition"      (fmt/phase-label :transition)))
+    (is (= "entry"           (fmt/phase-label :entry)))
+    (is (= "always"          (fmt/phase-label :always)))
+    (is (= "after-action"    (fmt/phase-label :after-action)))
+    (is (= "initial-entry"   (fmt/phase-label :initial-entry)))
+    (is (= "destroy-exit"    (fmt/phase-label :destroy-exit)))))
 
 (deftest timer-reason-label-test
   (testing "timer-cancelled reasons render every closed-set member"
-    (is (= "on-exit"          (proj/timer-reason-label :on-exit)))
-    (is (= "on-destroy"       (proj/timer-reason-label :on-destroy)))
-    (is (= "on-resolution"    (proj/timer-reason-label :on-resolution)))
-    (is (= "on-supersede"     (proj/timer-reason-label :on-supersede)))
-    (is (= "on-frame-destroy" (proj/timer-reason-label :on-frame-destroy)))))
+    (is (= "on-exit"          (fmt/timer-reason-label :on-exit)))
+    (is (= "on-destroy"       (fmt/timer-reason-label :on-destroy)))
+    (is (= "on-resolution"    (fmt/timer-reason-label :on-resolution)))
+    (is (= "on-supersede"     (fmt/timer-reason-label :on-supersede)))
+    (is (= "on-frame-destroy" (fmt/timer-reason-label :on-frame-destroy)))))
 
 ;; ---- rf2-nqt3d — per-step elapsed time + cascade total ------------------
 
@@ -2156,95 +2159,23 @@
           out   (proj/mark-rolled-back-downstream steps rows)]
       (is (every? #(nil? (:rolled-back? %)) out)))))
 
-;; ---- rf2-rrykz — app-db diff section — RETIRED 2026-05-26 -------------
+;; ---- rf2-zkiu5 — retired cascade steps (APP-DB DIFF + CHILD DISPATCHES) --
 ;;
-;; The standalone APP-DB DIFF step + `proj/app-db-diff-step` fn were
-;; removed in commit 862288aca / ee9def224. The HANDLER step's `:db`
-;; `[diff][all]` toggle surfaces the same data in-context. Tests for
-;; the retired surface are deleted; HANDLER `:db` coverage rides on
-;; `handler-row-reg-event-db-test` + `view_cljs_test.cljs` HANDLER
-;; tests (rf2-93436 — `:db diff` sub-section always-present).
-
-;; ---- rf2-yx1ae — child dispatches section -----------------------------
-;;
-;; The standalone CHILD-DISPATCHES step was removed from the top-level
-;; cascade in commit eccb6db1b (redundant with FX which already
-;; surfaces every `:dispatch` / `:dispatch-n` / `:dispatch-later` fx
-;; entry). The pure-data fns (`child-dispatch-rows`,
-;; `child-dispatches-step`, `find-child-epoch`) survive as low-level
-;; helpers — their tests remain. The `project-includes-child-
-;; dispatches-step-test` (which asserted the step is part of the
-;; cascade) is retired.
-
-(deftest child-dispatch-rows-from-dispatch-test
-  (testing "rf2-yx1ae — `:dispatch [:e/x]` projects one row"
-    (let [rows (proj/child-dispatch-rows
-                 [(do-fx-ev {:dispatch [:e/x 7]})])]
-      (is (= 1 (count rows)))
-      (is (= [:e/x 7]   (-> rows first :event)))
-      (is (= :dispatch  (-> rows first :via)))
-      (is (nil? (-> rows first :delay-ms))))))
-
-(deftest child-dispatch-rows-from-dispatch-n-test
-  (testing "rf2-yx1ae — `:dispatch-n [[:a] [:b]]` projects one row each"
-    (let [rows (proj/child-dispatch-rows
-                 [(do-fx-ev {:dispatch-n [[:a] [:b 1]]})])]
-      (is (= 2 (count rows)))
-      (is (= [:a]   (-> rows (nth 0) :event)))
-      (is (= [:b 1] (-> rows (nth 1) :event)))
-      (is (every? #(= :dispatch-n (:via %)) rows)))))
-
-(deftest child-dispatch-rows-from-dispatch-later-test
-  (testing "rf2-yx1ae — `:dispatch-later {:ms 250 :dispatch [:retry]}`
-            projects one row with `:delay-ms`"
-    (let [rows (proj/child-dispatch-rows
-                 [(do-fx-ev {:dispatch-later {:ms 250 :dispatch [:retry]}})])]
-      (is (= 1 (count rows)))
-      (is (= [:retry] (-> rows first :event)))
-      (is (= 250 (-> rows first :delay-ms)))
-      (is (= :dispatch-later (-> rows first :via)))))
-
-  (testing "rf2-yx1ae — `:dispatch-later` accepts a vec form too"
-    (let [rows (proj/child-dispatch-rows
-                 [(do-fx-ev {:dispatch-later
-                             [{:ms 100 :dispatch [:a]}
-                              {:ms 500 :dispatch [:b]}]})])]
-      (is (= 2 (count rows)))
-      (is (= 100 (-> rows (nth 0) :delay-ms)))
-      (is (= 500 (-> rows (nth 1) :delay-ms))))))
-
-(deftest child-dispatches-step-conditional-test
-  (testing "rf2-yx1ae — no dispatch fx → step OMITTED"
-    (is (nil? (proj/child-dispatches-step
-                [(do-fx-ev {:http/post {:url "/x"}})]))))
-
-  (testing "rf2-yx1ae — dispatch fx present → step rendered"
-    (let [s (proj/child-dispatches-step
-              [(do-fx-ev {:dispatch [:e/x]})])]
-      (is (= :child-dispatches (:step s)))
-      (is (= :CHILD-DISPATCHES (:badge s)))
-      (is (= 1 (count (:rows s)))))))
-
-(deftest find-child-epoch-by-parent-dispatch-id-test
-  (testing "rf2-yx1ae — find-child-epoch matches on `:parent-dispatch-id`"
-    (let [history [{:epoch-id 11 :parent-dispatch-id 1 :trigger-event [:other]}
-                   {:epoch-id 12 :parent-dispatch-id 1 :trigger-event [:e/x 7]}
-                   {:epoch-id 13 :parent-dispatch-id 2 :trigger-event [:e/x 7]}]]
-      (is (= 12 (proj/find-child-epoch history 1 [:e/x 7]))
-          "exact trigger-event + parent-id match wins")
-      (is (= 11 (proj/find-child-epoch history 1 [:other]))
-          "exact match on a different sibling")
-      (is (nil? (proj/find-child-epoch history 99 [:e/x 7]))
-          "no parent-id match → nil")
-      (is (nil? (proj/find-child-epoch nil 1 [:e/x 7]))
-          "nil history → nil")
-      (is (nil? (proj/find-child-epoch history nil [:e/x 7]))
-          "nil parent-id → nil"))))
+;; The standalone APP-DB DIFF (rf2-rrykz) and CHILD-DISPATCHES
+;; (rf2-yx1ae) steps were retired pair-debug 2026-05-26 — both redundant
+;; with existing steps (HANDLER `:db` surfaces the post-handler diff; the
+;; FX step surfaces every dispatch-family fx entry). rf2-btt0s deleted
+;; the dead projection / view / badge code that lingered after the
+;; cascade-emit was dropped (`child-dispatch-rows`, `child-dispatches-step`,
+;; `find-child-epoch`, the `:CHILD-DISPATCHES` / `:APP-DB-DIFF` badge-set
+;; members) along with their tests. The surviving parent-epoch
+;; correlation (`find-parent-epoch` / `dispatch-id->epoch-id-index`) is
+;; a DIFFERENT, live concern — the DISPATCH step's `:fx-dispatch`
+;; parent-link resolver — and keeps its tests below.
 
 (deftest find-parent-epoch-by-dispatch-id-test
   (testing "rf2-5qp4g — find-parent-epoch resolves a parent epoch's
-            `:epoch-id` from its `:dispatch-id`. Reverse of
-            `find-child-epoch`: looks up the supplied
+            `:epoch-id` from its `:dispatch-id`: looks up the supplied
             parent-dispatch-id in a precomputed
             `{dispatch-id → epoch-id}` index (rf2-x25e0; built once
             per render via `dispatch-id->epoch-id-index`), returning
@@ -2289,11 +2220,6 @@
           "empty history → empty index")
       (is (= {} (proj/dispatch-id->epoch-id-index nil))
           "nil history → empty index"))))
-
-;; `project-includes-child-dispatches-step-test` retired in rf2-xu5iv
-;; (commit eccb6db1b dropped the CHILD-DISPATCHES step from the
-;; top-level cascade). See comment header above the child-dispatch
-;; helpers section.
 
 (deftest project-attaches-app-db-violation-to-fx-db-row-test
   (testing "rf2-8resu / rf2-kt6js / rf2-j630b — top-level `project`

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/real_substrate_projection_cljs_test.cljs
@@ -26,10 +26,9 @@
 
   - DISPATCH row — the substrate's `:rf.event/dispatched` emit.
   - HANDLER     — the substrate's `:rf.event/run-end` emit (carries
-                  the canonical `:rf.event/elapsed-ms` tag); the
-                  HANDLER row's `:db-diff` slot is driven by the
-                  substrate's `:rf.event/db-changed` emit (canonical
-                  `:rf.event/db-changed-paths` tag).
+                  the canonical `:rf.event/elapsed-ms` tag). The
+                  `:rf.event/db-changed` emit is pinned for drift
+                  detection (the projection's `db-write?` reads it).
 
   COEFFECTs / FX / FLOW / SUBSCRIPTIONS / VIEWS are NOT exercised
   here (each would require a non-trivial registration / mount /
@@ -83,11 +82,11 @@
 (deftest real-substrate-emits-project-to-dispatch+handler
   (testing "rf2-tyivx — REAL substrate emits drive the projection.
             One dispatch through a registered handler must produce
-            at least the DISPATCH + HANDLER steps; the HANDLER step's
-            `:db-diff` slot must carry the substrate's
-            `:rf.event/db-changed-paths`. If the substrate rotates an
-            emit name + the reader doesn't follow, the step / slot
-            disappears here."
+            at least the DISPATCH + HANDLER steps, and the substrate
+            must emit the `:rf.event/db-changed` operation the
+            projection's `db-write?` reads. If the substrate rotates an
+            emit name + the reader doesn't follow, the step disappears
+            here."
     (setup!)
     (register-counter-handler!)
     (rf/dispatch-sync [:rf.tyivx/counter-inc 1])
@@ -110,8 +109,8 @@
            duration read; a rename here would drop the handler row")
       (is db-changed?
           "substrate emitted `:rf.event/db-changed` — drives the
-           HANDLER step's `:db-diff` slot; a rename here would drop
-           the diff annotation")
+           HANDLER step's `db-write?` flag; a rename here would drop
+           the :db sub-section's write detection")
       ;; Now feed the captured cascade through the projection. The
       ;; record's :trace-events vector mirrors what the Xray epoch
       ;; recorder would store for this dispatch.
@@ -128,17 +127,16 @@
         (is (contains? steps :handler)
             "HANDLER step present — projection matched the
              substrate's `:rf.event/run-end` operation name")
-        ;; Find the HANDLER step and assert its `:db-diff` slot is
-        ;; populated. The projection reads `:rf.event/db-changed-paths`
-        ;; off the substrate's `:rf.event/db-changed` emit — both
-        ;; canonical names must align with substrate reality.
+        ;; Find the HANDLER step and assert its `db-write?` flag is
+        ;; set. The projection reads the substrate's `:rf.event/db-changed`
+        ;; emit — its canonical name must align with substrate reality.
         (let [handler-step (first (filter #(= :handler (:step %)) projected))]
           (is (some? handler-step) "HANDLER step row exists")
-          (is (some? (:db-diff handler-step))
-              "HANDLER `:db-diff` slot carries data from the
-               substrate's `:rf.event/db-changed-paths` tag. If this
-               fails after a substrate-side rename, the synth fixtures
-               will still be green — pin the canonical names here."))))))
+          (is (true? (:db-write? handler-step))
+              "HANDLER `db-write?` reads the substrate's
+               `:rf.event/db-changed` emit. If this fails after a
+               substrate-side rename, the synth fixtures will still be
+               green — pin the canonical name here."))))))
 
 ;; ---- rf2-4wywy — live t1/t2 db attribution ------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -65,7 +65,7 @@
             header already names it) — that assertion is retired."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-event-db :event-id :no-such/handler
-                :db-diff [] :fx [] :machine nil}
+                :fx [] :machine nil}
           tree (view/render-handler-step step)
           header-text (text-of tree "rf-xray-epoch-handler-header")]
       (is (string/includes? header-text "reg-event-db"))
@@ -563,7 +563,7 @@
                    (view/render-handler-step
                      {:step :handler :badge :HANDLER :step-number 3
                       :flavour :reg-event-db :event-id :nop
-                      :db-diff [] :fx [] :machine nil}))
+                      :fx [] :machine nil}))
             slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
         (is (some? slot)
             ":db diff sub-section is always present even when empty")
@@ -575,7 +575,6 @@
                    (view/render-handler-step
                      {:step :handler :badge :HANDLER :step-number 3
                       :flavour :reg-event-db :event-id :counter/inc
-                      :db-diff [[[:counter :value] 5 6 :modified]]
                       :db-post-handler {:counter {:value 6}} :db-write? true
                       :fx [] :machine nil}))
             slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
@@ -587,7 +586,7 @@
                    (view/render-handler-step
                      {:step :handler :badge :HANDLER :step-number 3
                       :flavour :reg-event-fx :event-id :navigate
-                      :db-diff [] :fx [{:fx-id :navigate :value "/x"}]
+                      :fx [{:fx-id :navigate :value "/x"}]
                       :machine nil}))
             slot (th/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
         (is (some? slot)
@@ -607,7 +606,7 @@
                    (view/render-handler-step
                      {:step :handler :badge :HANDLER :step-number 3
                       :flavour :reg-event-db :event-id :standard-epochs/throw-handler
-                      :db-diff [] :db-write? false :fx [] :machine nil
+                      :db-write? false :fx [] :machine nil
                       :status :error
                       :errors [{:operation :rf.error/handler-exception
                                 :message "boom"}]}))]
@@ -622,7 +621,7 @@
                    (view/render-handler-step
                      {:step :handler :badge :HANDLER :step-number 3
                       :flavour :reg-event-fx :event-id :navigate
-                      :db-diff [] :db-write? false
+                      :db-write? false
                       :fx [{:fx-id :navigate :value "/x"}] :machine nil}))]
         (is (string/includes?
               (text-of tree "rf-xray-epoch-handler-db-no-write")
@@ -638,7 +637,6 @@
     (let [tree (view/render-handler-step
                  {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-machine :event-id :ws/start
-                  :db-diff [[[:rf/runtime :machines :snapshots :ws/conn] {} {} :modified]]
                   :fx []
                   :machine {:transition nil :guards []
                             :lifecycle [] :timers []}})]
@@ -701,7 +699,7 @@
             look and when the substrate hasn't captured."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-event-db :event-id :no-such/handler
-                :db-diff [] :fx [] :machine nil}
+                :fx [] :machine nil}
           tree (view/render-handler-step step)]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source"))
           "the source slot is present even on graceful-degrade")
@@ -1149,69 +1147,14 @@
             (is (nil? chip)
                 "coord chip drops out cleanly when no coord is resolvable")))))))
 
-;; ---- rf2-rrykz — app-db diff section — RETIRED 2026-05-26 -------------
+;; ---- rf2-zkiu5 — retired cascade steps (APP-DB DIFF + CHILD DISPATCHES) --
 ;;
-;; The `view/render-app-db-diff-step` fn was deleted in commit
-;; 862288aca along with the standalone APP-DB DIFF projection step.
-;; HANDLER `:db` `[diff][all]` toggle covers the same surface
-;; in-context (tests for that ride in the rf2-93436 section above).
-
-;; ---- rf2-yx1ae — child-dispatches section -----------------------------
-
-(deftest child-dispatches-step-renders-rows-test
-  (testing "rf2-yx1ae — CHILD-DISPATCHES step renders one row per child
-            with via-chip + event vector"
-    (let [step {:step :child-dispatches :badge :CHILD-DISPATCHES
-                :step-number 5
-                :rows [{:event [:other/x 1] :via :dispatch :delay-ms nil}
-                       {:event [:retry]     :via :dispatch-later :delay-ms 250}]}
-          ctx  {:dispatch-id   1
-                :epoch-history [{:epoch-id 99 :parent-dispatch-id 1
-                                 :trigger-event [:other/x 1]}]}
-          tree (view/render-child-dispatches-step step ctx)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-child-dispatches")))
-      (is (= 2 (count (th/find-by-testid-prefix
-                        tree "rf-xray-epoch-child-dispatch-row-"))))
-      (let [header (text-of tree "rf-xray-epoch-child-dispatches-header")]
-        (is (string/includes? header "2 events dispatched")))
-      (let [via0 (text-of tree "rf-xray-epoch-child-dispatch-via-0")
-            via1 (text-of tree "rf-xray-epoch-child-dispatch-via-1")
-            ev0  (text-of tree "rf-xray-epoch-child-dispatch-event-0")
-            ev1  (text-of tree "rf-xray-epoch-child-dispatch-event-1")]
-        (is (string/includes? via0 "dispatch"))
-        (is (string/includes? via1 "dispatch-later"))
-        (is (string/includes? ev0  ":other/x"))
-        (is (string/includes? ev1  ":retry")))
-      ;; delay chip on the dispatch-later row only
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-delay-1")))
-      (is (nil? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-delay-0"))))))
-
-(deftest child-dispatches-jump-resolves-when-in-buffer-test
-  (testing "rf2-yx1ae — child epoch in the buffer renders a jump button
-            with the child's :epoch-id"
-    (let [step {:step :child-dispatches :badge :CHILD-DISPATCHES
-                :step-number 5
-                :rows [{:event [:other/x 1] :via :dispatch}]}
-          ctx  {:dispatch-id   1
-                :epoch-history [{:epoch-id 99 :parent-dispatch-id 1
-                                 :trigger-event [:other/x 1]}]}
-          tree (view/render-child-dispatches-step step ctx)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-jump-0"))
-          "jump button is present when child is resolvable")
-      (is (nil? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-missing-0"))
-          "no `not in buffer` marker when child is resolved"))))
-
-(deftest child-dispatches-missing-when-not-in-buffer-test
-  (testing "rf2-yx1ae — child not in buffer (aged out / never landed)
-            renders the muted `not in buffer` marker"
-    (let [step {:step :child-dispatches :badge :CHILD-DISPATCHES
-                :step-number 5
-                :rows [{:event [:other/x 1] :via :dispatch}]}
-          ctx  {:dispatch-id   1
-                :epoch-history []}
-          tree (view/render-child-dispatches-step step ctx)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-missing-0")))
-      (is (nil? (th/find-by-testid tree "rf-xray-epoch-child-dispatch-jump-0"))))))
+;; The `view/render-app-db-diff-step` + `view/render-child-dispatches-step`
+;; renderers were deleted along with the standalone APP-DB DIFF (rf2-rrykz)
+;; + CHILD-DISPATCHES (rf2-yx1ae) projection steps. Both are redundant
+;; with existing steps — HANDLER `:db` (rf2-93436 section above) covers
+;; the post-handler diff; the FX step surfaces every dispatch-family fx
+;; entry. rf2-btt0s deleted the lingering dead code + these renderer tests.
 
 ;; ---- rf2-u69j7 — machine handler section: time-ordered cascade ----------
 ;;
@@ -1226,7 +1169,7 @@
             REPLACED (not augmented)"
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :ws/start
-                :db-diff [] :fx []
+                :fx []
                 :machine {:cascade [{:kind :guard :step 1
                                      :guard-id :ready? :outcome :pass}
                                     {:kind :action :step 2
@@ -1259,7 +1202,7 @@
             assert the kind-sequence."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :ws/start
-                :db-diff [] :fx []
+                :fx []
                 :machine {:cascade [{:kind :guard :step 1
                                      :guard-id :ok? :outcome :pass}
                                     {:kind :action :step 2
@@ -1282,7 +1225,7 @@
             :after-action / :initial-entry / :destroy-exit`) fired."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :ws/start
-                :db-diff [] :fx []
+                :fx []
                 :machine {:cascade [{:kind :action :step 1
                                      :action-id :open-socket
                                      :phase :entry}]
@@ -1299,7 +1242,7 @@
             'action X emitted fx Y' in one place."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :ws/start
-                :db-diff [] :fx []
+                :fx []
                 :machine {:cascade [{:kind :action :step 1
                                      :action-id :open-socket
                                      :phase :entry
@@ -1322,7 +1265,7 @@
           ;; outcome {:opened-count 1}.
           mutating {:step :handler :badge :HANDLER :step-number 3
                     :flavour :reg-machine :event-id :door/main
-                    :db-diff [] :fx []
+                    :fx []
                     :machine {:cascade [{:kind :action :step 1
                                          :action-id :count-open
                                          :phase :entry
@@ -1338,7 +1281,7 @@
     ;; slot (the inspector renders the value with no delta).
     (let [noop {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :door/main
-                :db-diff [] :fx []
+                :fx []
                 :machine {:cascade [{:kind :action :step 1
                                      :action-id :clear-hold
                                      :phase :exit
@@ -1356,7 +1299,7 @@
             (`state <from> → <to>` line + echoed `event [...]`) is GONE."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :ws/start
-                :db-diff [] :fx []
+                :fx []
                 :machine {:cascade [{:kind :transition :step 1
                                      :machine-id :ws/conn
                                      :before {:state [:idle]}
@@ -1401,7 +1344,7 @@
         (let [step {:step :handler :badge :HANDLER :step-number 3
                     :flavour :reg-machine
                     :event-id :rf2-wwc3j.view/inline-entry
-                    :db-diff [] :fx []
+                    :fx []
                     :machine {:cascade [{:kind :action :step 1
                                          :action-id inline-fn
                                          :phase :entry
@@ -1430,7 +1373,7 @@
         (let [step {:step :handler :badge :HANDLER :step-number 3
                     :flavour :reg-machine
                     :event-id :rf2-wwc3j.view/inline-guard
-                    :db-diff [] :fx []
+                    :fx []
                     :machine {:cascade [{:kind :guard :step 1
                                          :guard-id inline-guard
                                          :outcome :pass
@@ -1456,7 +1399,7 @@
       (let [step {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-machine
                   :event-id :rf2-wwc3j.view/transition-row
-                  :db-diff [] :fx []
+                  :fx []
                   :machine {:cascade [{:kind :transition :step 1
                                        :machine-id :rf2-wwc3j.view/transition-row
                                        :from-state :idle
@@ -1487,7 +1430,7 @@
       (let [step {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-machine
                   :event-id :rf2-wwc3j.view/timer-row
-                  :db-diff [] :fx []
+                  :fx []
                   :machine {:cascade [{:kind :timer :step 1
                                        :state :idle :delay 500
                                        :reason :on-exit}]
@@ -1504,7 +1447,7 @@
             least one `:rf.machine/transition`."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :ws/start
-                :db-diff [] :fx []
+                :fx []
                 :machine {:cascade []
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
@@ -1517,11 +1460,10 @@
             machine-specific; non-machine rendering must not regress)."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-event-db :event-id :counter/inc
-                :db-diff [[[:counter] 5 6 :modified]]
                 :fx [] :machine nil}
           tree (view/render-handler-step step)]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-db-diff"))
-          "the standard :db-diff sub-section renders for non-machine handlers")
+          "the standard :db sub-section renders for non-machine handlers")
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-machine"))
           "no machine block on a non-machine handler")
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
@@ -1533,7 +1475,7 @@
     (let [tree (view/render-handler-step
                  {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-event-db :event-id :rf.test.epoch.view/slow-handler
-                  :db-diff [] :fx [] :machine nil
+                  :fx [] :machine nil
                   :duration-ms 42})]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-duration-long"))
           "the long-duration testid is stamped on slow steps")
@@ -1544,7 +1486,7 @@
     (let [tree (view/render-handler-step
                  {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-event-db :event-id :rf.test.epoch.view/fast-handler
-                  :db-diff [] :fx [] :machine nil
+                  :fx [] :machine nil
                   :duration-ms 0.1})]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-duration"))
           "fast step keeps the standard duration testid"))))
@@ -1560,7 +1502,7 @@
       (let [step {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-event-db
                   :event-id :rf.test.epoch.view/srctest-handler
-                  :db-diff [] :fx [] :machine nil}
+                  :fx [] :machine nil}
             tree (view/render-handler-step step)]
         (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source-body"))
             "the code-block widget mounts under the source slot")
@@ -1594,7 +1536,7 @@
       (let [step {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-event-db
                   :event-id :rf.test.epoch.view/ehd8v-never-registered
-                  :db-diff [] :fx [] :machine nil}
+                  :fx [] :machine nil}
             tree (view/render-handler-step step)]
         (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-source-coord"))
             "no coord-row when :file meta is absent")
@@ -1631,7 +1573,7 @@
             event-id keyword + args paint with the canonical
             syntax-token chrome (keyword magenta, number orange,
             string green). Pre-fix the body was plain text via
-            `proj/event-display`."
+            `format/event-display`."
     (let [tree (view/render-dispatch-step
                  {:step :dispatch :badge :DISPATCH :step-number 1
                   :event [:counter/inc 7 "x"] :source :ui :coord nil})]
@@ -1658,7 +1600,6 @@
     (let [tree    (view/render-handler-step
                     {:step :handler :badge :HANDLER :step-number 3
                      :flavour :reg-event-fx :event-id :do/it
-                     :db-diff []
                      :fx-vec  [[:dispatch [:foo 1]]
                                [:http/get {:url "/x"}]]
                      :other-effects {:navigate "/home"}
@@ -1743,23 +1684,12 @@
       (is (>= (count (mini-mounts subs)) 2)
           "subs-read column mounts one mini per consumed sub"))))
 
-;; `app-db-diff-values-route-through-mini-test` retired in rf2-xu5iv
-;; (commit 862288aca dropped `view/render-app-db-diff-step` along with
-;; the projection step). HANDLER `:db` diff mini-mount coverage rides
-;; on `handler-db-diff-values-route-through-mini-test` above.
-
-(deftest child-dispatches-event-routes-through-mini-test
-  (testing "rf2-8w8er — CHILD-DISPATCHES row renders the event vector
-            through `ei/mini`."
-    (let [step {:step :child-dispatches :badge :CHILD-DISPATCHES
-                :step-number 5
-                :rows [{:event [:other/x 1] :via :dispatch}]}
-          ctx  {:dispatch-id 1 :epoch-history []}
-          tree (view/render-child-dispatches-step step ctx)
-          ev   (th/find-by-testid tree "rf-xray-epoch-child-dispatch-event-0")]
-      (is (some? ev))
-      (is (pos? (count (mini-mounts ev)))
-          "the dispatched-event slot mounts a mini-render"))))
+;; `app-db-diff-values-route-through-mini-test` +
+;; `child-dispatches-event-routes-through-mini-test` retired with the
+;; APP-DB DIFF + CHILD-DISPATCHES steps (rf2-zkiu5 / rf2-btt0s). HANDLER
+;; `:db` diff mini-mount coverage rides on
+;; `handler-db-diff-values-route-through-mini-test` above; dispatch-family
+;; fx coverage rides on the FX step's `ei/mini` mounts.
 
 ;; ---- rf2-atqkg — pipeline-view realises step-seq inside reactive scope ---
 ;;
@@ -1821,7 +1751,6 @@
                   :event [:counter/inc] :source :ui :coord nil}
                  {:step :handler :badge :HANDLER :step-number 2
                   :flavour :reg-event-db :event-id :counter/inc
-                  :db-diff [[[:counter :value] 5 6 :modified]]
                   :fx [] :machine nil}]
           tree  (view/pipeline-view steps)
           step-seq (pipeline-steps-seq tree)]
@@ -2698,7 +2627,7 @@
             header's ✗ status glyph"
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-event-db :event-id :standard-epochs/throw-handler
-                :db-diff [] :fx [] :machine nil
+                :fx [] :machine nil
                 :status :error
                 :errors [{:operation :rf.error/handler-exception
                           :message "boom in handler"
@@ -2722,7 +2651,7 @@
             — a clean stage is silent now, not an all-tick row)"
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-event-db :event-id :counter/inc
-                :db-diff [] :fx [] :machine nil}
+                :fx [] :machine nil}
           tree (view/render-handler-step step)]
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-status"))
           "no per-stage status glyph on a clean step (retired rf2-9wq0v)")
@@ -2918,7 +2847,7 @@
                  (view/render-handler-step
                    {:step :handler :badge :HANDLER :step-number 4
                     :flavour :reg-event-db :event-id :standard-epochs/throw-interceptor
-                    :db-diff [] :db-write? true :fx [] :machine nil
+                    :db-write? true :fx [] :machine nil
                     :status :skipped}))]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-skipped"))
           "the SKIPPED body renders")


### PR DESCRIPTION
Three related hygiene fixes from the senior-dev Xray review, all in `tools/xray/src/.../panels/epoch/`. Pre-alpha: dead code deleted, not deprecated. ONE PR; behaviour-preserving for everything still live.

## rf2-btt0s — retired CHILD-DISPATCHES + APP-DB-DIFF steps carried full dead implementations
The cascade-emit for both steps was dropped pair-debug 2026-05-26 (rf2-zkiu5) but the implementations lingered. Verified no live emit path, then deleted:
- **projection.cljc**: `normalise-child-dispatch`, `child-dispatch-fx-ids`, `child-dispatch-rows`, `child-dispatches-step`, `find-child-epoch` (the latter was only called by the dead view renderer).
- **view.cljs**: the six `child-dispatch-*` styles, `child-dispatch-via-label`, `child-dispatch-row-view`, `render-child-dispatches-step`, the `(declare …)`, and the `:child-dispatches` case in `render-step`. Also pruned the now-dead `:dispatch-id` / `:epoch-history` ctx keys (the view only reads the `dispatch-id->epoch-id` index).
- **badge.cljc**: the `:CHILD-DISPATCHES` / `:APP-DB-DIFF` colour + label table entries.
- **icons.cljc**: the `arrow-right` glyph (only used by the deleted jump button).
- **badge-set** (projection.cljc): dropped `:CHILD-DISPATCHES` + `:APP-DB-DIFF` — **11 → 9 badges**, matching spec/021's stated inventory. The view's badge-set could advertise badges `project` can never emit; added a CI-visible drift guard.
- **epoch_panel.cljs**: dropped the vestigial `:dispatch-id` composite-sub slot + fixed the stale `find-child-epoch` comment.

## rf2-sp0n9 — HANDLER :db-diff computed a full Editscript A* diff the view discarded
`handler-row` stamped `:db-diff (db-diff-paths db-before db-handler)` — a full A* diff over the whole pre/post app-db. Its sole consumer, `handler-db-diff-block`, bound it as `_db-diff` and re-derived its own render off `:db-post-handler` + `db-before` via the edn-inspector. Removed the `:db-diff` stamp, the private `db-diff-paths` helper, and the now-unused `diff.engine` require. The `:fx-dispatch` parent-epoch `db-diff-paths` in `app_db_diff_subs.cljs` is a DIFFERENT computation — untouched.

## rf2-qkygs — ~250 lines of view-presentation formatters in the pure-data projection ns
Extracted the 12 display-string formatters (`format-duration-ms`, `event-display`, `path-display`, `ns-keyword`, `truncate`, `coeffect-row-display`, `phase-label`, `timer-reason-label`, `cascade-row-label`, `cascade-row-source-key`, `cascade-outcome-label`, `handler-flavour-label`) into a new sibling **`panels/epoch/format.cljc`** (240 lines, still `.cljc`, JVM-testable). Repointed view + test call sites to `fmt/`. Genuine projection-side derivation (`long-step?`, `group-lifecycle-by-phase`, `empty-pipeline?`, `badge-set`, `state-spec-path-prefix`) stays in projection — `format.cljc` requires projection for `state-spec-path-prefix` (one-directional, no cycle).

LoC: source files **−632** (projection −401, view −194, icons −27, badge −10); new format.cljc **+240** (the relocated formatters). Net deletion ≈ 444 source lines beyond the move.

spec/021 updated: §9.1.8 notes the format.cljc extraction; the duration-chip + parent-epoch-resolution prose reflect `fmt/format-duration-ms` and the index-based `find-parent-epoch` lookup. The retired-step stub sections (§9.1.10.4/.5) + badge-table note already documented the retirement accurately.

## Quality gates
- `npm run test:cljs` — **5204 tests, 17776 assertions, 0 failures, 0 errors**. Updated `badge-set-test` (11→9 + retired-badge drift guard), dropped `:db-diff` assertions (replaced with equivalent `:db-post-handler` coverage), repointed formatter tests to `fmt/`, deleted the 5 child-dispatch projection tests + 4 child-dispatch view tests, updated the real-substrate test's slot assertion to `db-write?`. The ~136 projection tests stay green.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, 13 matrix rows** (panel-gallery testbed incl. the child-dispatches variant compiled 0 warnings).
- `npm run test:bundle-isolation` — **PASS** (17 artefact entries, 35 sentinels absent, 3 budgets ok) + uix-helix-reagent-free PASS.
- **clj-kondo** — 0 errors; the `view/render-child-dispatches-step` unresolved-var warning is **gone** (net reduction); remaining 15 warnings are all pre-existing unused-private-var hoists unrelated to these fixes.
- `mkdocs build --strict` — **PASS** (EXIT 0, built in 8.25s).