### PR TITLE
refactor(examples): unify mount pattern to lazy defonce + fix Timer dispatch-sync idiom (rf2-wjk4v, rf2-odc5q, rf2-m6mhb)

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -58,12 +58,19 @@
   ($ counter-buttons))
 
 ;; -- Mount -------------------------------------------------------------------
+;;
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `createRoot` onto the shared `#app`.
 
-(defonce root
-  (react-dom-client/createRoot (js/document.getElementById "app")))
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! helix-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])
-  (.render root ($ counter-app)))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
+    (.render @react-root ($ counter-app))))

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -256,8 +256,11 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce react-root
-  (react-dom-client/createRoot (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `createRoot` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
@@ -269,4 +272,7 @@
   ;; machine handler is self-initialising — its `:initial`/`:data` seed
   ;; [:rf/runtime :machines :snapshots :auth.login/flow] when the flow first runs (per
   ;; Spec 005 §Restore semantics), so no separate :initialise is needed.
-  (.render react-root ($ root-view)))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
+    (.render @react-root ($ root-view))))

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -241,10 +241,17 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
-  (react-dom-client/createRoot (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `createRoot` onto the shared `#app`.
+;; This matches the sibling notebook / dashboard_uix mount shape.
+(defonce react-root (atom nil))
 
 (defn run []
   (rf/init! helix-adapter/adapter)
   (rf/dispatch-sync [:monitor/initialise])
-  (.render root ($ monitor)))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
+    (.render @react-root ($ monitor))))

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -46,9 +46,13 @@
   [counter-buttons])
 
 ;; -- Mount -------------------------------------------------------------------
+;;
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
 
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+(defonce react-root (atom nil))
 
 (defn run []
   ;; rf/init! takes the adapter spec map directly. Each adapter
@@ -56,4 +60,7 @@
   ;; var explicitly. There is no default-adapter registry.
   (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])
-  (rdc/render root [counter-app]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [counter-app])))

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -270,11 +270,17 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:cart/initialise])
-  (rdc/render root [cart-app]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [cart-app])))

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -375,10 +375,11 @@
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 
-;; React root named `react-root` (not `root`) so it does NOT collide
-;; with the `root-view` reg-view above.
-(defonce react-root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
@@ -389,4 +390,7 @@
   (rf/reg-frame :rf/default
     {:doc          "Login demo frame."
      :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}})
-  (rdc/render react-root [root-view]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [root-view])))

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -219,12 +219,19 @@
   [counter-view])
 
 ;; -- Mount -------------------------------------------------------------------
+;;
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
 
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])
-  (rdc/render root [counter-app]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [counter-app])))

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -150,14 +150,19 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is named `react-root`; `reg-view` defs `root-view`,
-;; which is what we render.
-(defonce react-root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+;; (`reg-view` defs `root-view`, which is what we render.)
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:routing.app/initialise])
   (install-router!)
-  (rdc/render react-root [root-view]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [root-view])))

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -269,11 +269,17 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:cells/initialise])
-  (rdc/render root [cells-grid]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [cells-grid])))

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -224,11 +224,17 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:drawer/initialise])
-  (rdc/render root [drawer-view]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [drawer-view])))

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -190,11 +190,17 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:crud/initialise])
-  (rdc/render root [crud-view]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [crud-view])))

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -184,11 +184,17 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:flight/initialise])
-  (rdc/render root [flight-booker]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [flight-booker])))

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -145,11 +145,17 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:temp/initialise])
-  (rdc/render root [temperature-converter]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [temperature-converter])))

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -59,14 +59,9 @@
 ;; never observably show 0.0), each tick carries the :tick-gen value it was
 ;; scheduled with. Reset bumps :tick-gen, so any in-flight tick from the
 ;; previous generation no-ops when it eventually fires. Reset also schedules
-;; a fresh tick under the new generation, so the chain continues.
-;;
-;; The Reset *click handler* (see view) calls `dispatch-sync`, not
-;; `dispatch`. Under Reagent 2 (flushSync render), this guarantees the
-;; app-db update and DOM commit complete before the next scheduled tick
-;; (or before a polling test observer reads the DOM), so the brief 0.0
-;; reading is observable. The :tick-gen guard above and the synchronous
-;; commit here address two distinct races and are both required.
+;; a fresh tick under the new generation, so the chain continues. This
+;; generation guard makes the 0.0 reading correct regardless of dispatch
+;; timing — Reset uses ordinary `dispatch`, like every other UI handler.
 
 (rf/reg-event-fx :timer/initialise
   {:doc "Seed the timer slice and start the periodic tick."}
@@ -154,24 +149,27 @@
                                       (js/parseInt (.. % -target -value))])}]
       [:span (.toFixed (/ duration 1000.0) 1) " s"]]
      [:div.row
-      ;; dispatch-sync (not dispatch): under Reagent 2's flushSync render
-      ;; model, this guarantees app-db is updated and the DOM commits the
-      ;; 0.0 reading before control returns to the browser — and crucially
-      ;; before the next scheduled :timer/tick can fire. With async dispatch
-      ;; the post-Reset DOM commit could lag the next tick (and the test's
-      ;; 50ms poll), causing the brief 0.0 window to be missed.
+      ;; Ordinary `dispatch` — the idiom for every UI event handler.
+      ;; The 0.0 reading is made observable by the :tick-gen generation
+      ;; guard (see EVENTS header note), not by synchronous dispatch.
       [:button {:data-testid "timer-reset"
-                :on-click #(rf/dispatch-sync [:timer/reset])} "Reset"]]]))
+                :on-click #(dispatch [:timer/reset])} "Reset"]]]))
 
 ;; ============================================================================
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:timer/initialise])
-  (rdc/render root [timer-view]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [timer-view])))

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -97,8 +97,11 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce react-root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
@@ -109,4 +112,7 @@
   (rf/reg-frame :rf/default
     {:doc          "State-machines walkthrough demo frame."
      :fx-overrides {:rf.http/managed :auth.login/canned-failure}})
-  (rdc/render react-root [root-view]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [root-view])))

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -9,8 +9,11 @@
             [todomvc.subs]
             [todomvc.views :as views]))
 
-(defonce react-root
-  (rdc/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 ;; ---- hash → Spec 012 path adapter -----------------------------------------
 ;;
@@ -40,4 +43,7 @@
   (rf/dispatch-sync [:rf.route/handle-url-change (current-path)])
   (.addEventListener js/window "hashchange"
     (fn [_] (rf/dispatch [:rf.route/handle-url-change (current-path)])))
-  (rdc/render react-root [views/root-view]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [views/root-view])))

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -56,12 +56,19 @@
   ($ counter-buttons))
 
 ;; -- Mount -------------------------------------------------------------------
+;;
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
 
-(defonce root
-  (uix-dom/create-root (js/document.getElementById "app")))
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! uix-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])
-  (uix-dom/render-root ($ counter-app) root))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
+    (uix-dom/render-root ($ counter-app) @react-root)))

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -247,10 +247,17 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce react-root
-  (uix-dom/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+;; This matches the sibling notebook / process_monitor_helix mount shape.
+(defonce react-root (atom nil))
 
 (defn run []
   (rf/init! uix-adapter/adapter)
   (rf/dispatch-sync [:dashboard/initialise])
-  (uix-dom/render-root ($ dashboard) react-root))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
+    (uix-dom/render-root ($ dashboard) @react-root)))

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -265,8 +265,11 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce react-root
-  (uix-dom/create-root (js/document.getElementById "app")))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+(defonce react-root (atom nil))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
@@ -278,4 +281,7 @@
   ;; machine handler is self-initialising — its `:initial`/`:data` seed
   ;; [:rf/runtime :machines :snapshots :auth.login/flow] when the flow first runs (per
   ;; Spec 005 §Restore semantics), so no separate :initialise is needed.
-  (uix-dom/render-root ($ root-view) react-root))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
+    (uix-dom/render-root ($ root-view) @react-root)))


### PR DESCRIPTION
## Summary

Makes the worked examples exemplary on the MOUNT + DISPATCH idiom (from the senior-dev /examples review). Three related beads, one PR.

### Canonical mount shape (per `examples/TESTING.md` §Example mount-isolation convention)

```clojure
(defonce react-root (atom nil))

(defn run []
  ;; ... per-example app boot ...
  (when (exists? js/document)
    (when-not @react-root
      (reset! react-root (create-root (js/document.getElementById "app"))))
    (render @react-root [root-view])))
```

The React root is held in an atom and materialised **lazily inside `run`** — ns-load produces no DOM side effects. TESTING.md documents the eager `(defonce root (create-root ...))` form (mount at ns-load) as the **anti-pattern**: under the single-page `:browser-test` bundle every co-required example namespace would race `create-root` onto the shared `#app`.

### rf2-wjk4v — mount-pattern incoherence

The catalogue split arbitrarily between the lazy shape and the eager anti-pattern. The canonical `counter` (reading-order #1) and the whole `seven_guis` cluster used the eager form, propagating the anti-pattern to the first code a newcomer reads. Converted every co-loadable example to the lazy shape. Each substrate keeps its idiomatic root API — Reagent `rdc/create-root` + `render`, UIx `uix-dom/create-root` + `render-root`, Helix `createRoot` + `.render` — only the lazy-vs-eager axis and naming are unified. The `reagent-slim/counter_slim_and_fast` documented exception (release/bundle-isolation fixture, never co-loaded) is **retained**.

Note: `login` / `login_uix` / `login_helix` / `routing` / `todomvc` / `state_machine_walkthrough` were also eager (the bead's 'correct' list conflated the `react-root` *name* with the lazy *shape*; several bound it eagerly). Converted them too — they exhibit exactly the anti-pattern and several are co-loaded into the browser-test bundle.

### rf2-odc5q — design-led trio mount shapes + misleading var name

`notebook` (already lazy) / `dashboard_uix` (eager, **misleadingly** named `react-root` for a live root) / `process_monitor_helix` (eager, named `root`) now share one lazy mount shape, and `dashboard_uix`'s `react-root` now correctly denotes the `(atom nil)` holder. Comments cross-reference the sibling shape.

### rf2-m6mhb — Timer Reset `dispatch-sync` in a click handler

`seven_guis/timer` Reset `:on-click` changed from `(rf/dispatch-sync [:timer/reset])` to ordinary `(dispatch [:timer/reset])`. The `dispatch-sync` was shaped to beat a since-removed 50ms test poll; examples are test-free (rf2-8cevm). The brief 0.0 reading is made correct by the `:tick-gen` generation guard **regardless of dispatch timing** — the EVENTS header note and inline comment now state this. The boot-time `dispatch-sync [:timer/initialise]` (legitimate init use) is retained. No `dispatch-sync` remains in any click/change/submit handler across `examples/`.

## Examples converted (19)

Reagent: counter, flows, managed_http_counter, routing, todomvc, state_machine_walkthrough, login, seven_guis/{cells, circle_drawer, crud, flight_booker, temperature, timer}
UIx: counter_uix, login_uix, dashboard_uix
Helix: counter_helix, login_helix, process_monitor_helix

## Test-free policy

**Added zero `*.spec.cjs`** — examples remain test-free (rf2-8cevm). No teaching-by-anti-pattern; the conversions are behaviour-preserving clean exemplars.

## Quality gates

- `npm run test:examples` — **3 example specs, 0 failures, 0 skipped** (the 3 adapter smokes drive the converted counter dataflow per substrate).
- `npm run test:browser` — **135 tests, 391 assertions, 0 failures, 0 errors** (exercises co-loaded converted example wrappers — routing, todomvc, login, etc. — under the shared single-page bundle; the lazy shape's whole point). One pre-existing `:infer-warning` in untouched `core/test` code.
- **clj-kondo** — 0 errors, 0 new warnings on the 19 changed files (the 2 `unused binding` warnings in circle_drawer are pre-existing on origin/main, in destructuring unrelated to the mount section).
- **Build** — all 19 converted example shadow-cljs builds compile cleanly (0 warnings each).
- Docs: no `examples/` docs reference changed; `docs/guide/03-first-app.md` deliberately teaches the eager shape for a standalone (non-co-loaded) tutorial app with a hot-reload rationale — a separate surface, left untouched. No `mkdocs build --strict` needed.

Closes rf2-wjk4v, rf2-odc5q, rf2-m6mhb.