### PR TITLE
fix(story): cross-host scalar-stability guard in fingerprint canonicalization (rf2-vvqeo)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2161,6 +2161,28 @@ installs canonical vocabulary), and MUST fold the existing
   across processes rather than embedding the fn's object identity via
   `pr-str` (rf2-4gwja) — the deliberate trade-off is that two values
   differing ONLY in fn identity hash equal (determinism is the contract);
+- **normalise host-divergent numbers to a bit-stable form** so the
+  cross-host byte-stability contract holds for scalars too (rf2-vvqeo).
+  Integers pass through verbatim (host-identical `pr-str`, so existing
+  hashes do not rebase), but two number sub-kinds are NOT host-portable
+  through raw `pr-str` and MUST be normalised: a **ratio** (JVM
+  `clojure.lang.Ratio`; CLJS has none, reading `1/3` as the double 0.333…)
+  is coerced to its double value, and a **fractional or special double**
+  folds to `[:rf/double "<16-hex IEEE-754 bits>"]` — the bit pattern is
+  host-invariant for a given logical double, where `pr-str` formatting
+  ("1.0" vs "1", "1.0E21" vs "1e+21") is not. An integer-valued double
+  within 64-bit integer range folds to that integer (host-mandated: in CLJS
+  `1.0` IS the integer `1`, so the only cross-host-stable choice is to treat
+  a double `1.0` and the integer `1` as canonically equal). `##NaN` folds to
+  the single `:rf/nan` sentinel — collapsing every NaN bit-pattern to one
+  value AND giving the set/map `pr-str` sort a deterministic order in NaN's
+  presence (NaN is not `=`-reflexive, so a bare `(sort-by pr-str)` was
+  comparator-unstable). `##Inf` / `##-Inf` ride the `:rf/double` bit path
+  (their bits are host-stable). Set element ordering additionally uses a
+  **total comparator with a deterministic equal-`pr-str` tiebreak**, so two
+  distinct elements that canonicalise to the same `pr-str` (e.g. two
+  `:rf/opaque-fn` sentinels) get a stable relative order rather than the
+  comparator-unstable order a bare `(sort-by pr-str)` left;
 - enumerate the `:plan-hash` input fields;
 - compute `:run-hash` over the canonical epoch slice.
 

--- a/tools/story/src/re_frame/story/fingerprint.cljc
+++ b/tools/story/src/re_frame/story/fingerprint.cljc
@@ -352,10 +352,14 @@
 ;;   so fn identity is intentionally NOT discriminated.
 ;;
 ;; Maps sort entries by the canonicalised key's `pr-str`; sets sort
-;; elements by `pr-str`; vectors/seqs keep producer order and recurse;
-;; scalars pass through. `pr-str` over canonical scalars is host-identical
-;; across JVM + CLJS, so the ordering — and the tags — are stable across
-;; hosts.
+;; elements by a total comparator (`stable-canon-order` — `pr-str` primary
+;; with a deterministic equal-`pr-str` tiebreak, rf2-vvqeo); vectors/seqs keep
+;; producer order and recurse. Integer scalars, strings, keywords, symbols,
+;; booleans, and nil pass through — their `pr-str` is host-identical. Host-
+;; DIVERGENT numbers (ratios + fractional/special doubles) are normalised to a
+;; bit-stable form by `canon-number` BELOW (rf2-vvqeo), so `pr-str` over every
+;; canonical value is host-identical across JVM + CLJS and the ordering — and
+;; the tags — are stable across hosts.
 
 (def map-tag
   "Reserved structural type-tag prefixing a map's canonical form
@@ -393,13 +397,139 @@
   discrimination, is the contract."
   :rf/opaque-fn)
 
+;; ===========================================================================
+;; CROSS-HOST SCALAR STABILITY  (rf2-vvqeo)
+;; ===========================================================================
+;;
+;; SCALARS used to pass through `-canon` verbatim and be serialised by raw
+;; `pr-str`. For integers, strings, keywords, symbols, booleans, and nil that
+;; is host-identical and stays untouched. But two number sub-kinds are NOT
+;; host-portable through `pr-str`, silently breaking the byte-stable-across-
+;; hosts contract that is the whole point of the fingerprint primitive:
+;;
+;; 1. RATIOS. JVM Clojure has `clojure.lang.Ratio` — `(pr-str 1/3)` => "1/3".
+;;    CLJS has NO Ratio type: the reader collapses `1/3` to the double
+;;    0.3333333333333333. The same logical literal therefore canonicalised to
+;;    a DIFFERENT string per host → different hash → a golden captured on one
+;;    host mis-compares against the same logical run on the other.
+;; 2. FLOATS / SPECIALS. Double `pr-str` formatting is NOT byte-identical
+;;    across hosts: an integer-valued double prints "1.0" on the JVM but "1"
+;;    on CLJS (JS has no int/float distinction), and exponent notation differs
+;;    ("1.0E21" vs "1e+21"). `##NaN` additionally destabilises set ordering
+;;    because `(sort-by pr-str)` over a NaN-bearing collection is comparator-
+;;    unstable.
+;;
+;; THE NORMALISATION POLICY (host-portable canonical number form):
+;;
+;; - INTEGERS pass through verbatim — `Long` / `BigInt` / `BigInteger` on the
+;;   JVM, integer-valued `number` on CLJS. Their `pr-str` is already host-
+;;   identical, so ordinary-value hashes are UNCHANGED (no golden rebase).
+;; - A NUMBER WITH A FRACTIONAL VALUE, or an integer-valued double too large
+;;   for a 64-bit integer (e.g. 1e21), canonicalises to
+;;   `[double-tag "<16-hex IEEE-754 bits>"]`. The raw IEEE-754 64-bit pattern
+;;   is byte-identical across hosts for the same logical double, so the hex is
+;;   host-stable where `pr-str` was not.
+;; - An INTEGER-VALUED double within 64-bit integer range (e.g. 1.0, 100.0)
+;;   canonicalises to its INTEGER form. This is forced by CLJS: there `1.0`
+;;   IS the integer `1` (same JS number — indistinguishable), so the only way
+;;   the JVM `(double 1)` can hash-match the CLJS `1.0` is to fold both to the
+;;   integer. The deliberate, host-mandated consequence is that a double `1.0`
+;;   and the integer `1` canonicalise EQUAL — numerically they are, and CLJS
+;;   cannot tell them apart regardless.
+;; - A RATIO is coerced to its double value first, then run through the double
+;;   path — so JVM `1/3` and CLJS `1/3` (already the double 0.333…) both reach
+;;   the SAME IEEE-754 bits and the SAME canonical form.
+;; - NaN folds to the single `nan-tag` sentinel: every NaN bit-pattern is one
+;;   canonical value (so `##NaN` differences never perturb a hash) and the
+;;   sentinel keyword sorts deterministically, closing the `(sort-by pr-str)`
+;;   NaN ordering hole. ±Inf are ordinary finite-bit doubles to this code —
+;;   their IEEE-754 bits are host-stable — so they ride the double-tag path
+;;   and remain mutually distinct and distinct from every finite double.
+
+(def double-tag
+  "Reserved structural tag prefixing a non-integer (or out-of-integer-range)
+  number's canonical form (rf2-vvqeo). A double `1.5` canonicalises to
+  `[:rf/double \"3ff8000000000000\"]` — the 16-char lowercase hex of its
+  IEEE-754 64-bit pattern, byte-identical across JVM + CLJS, where raw
+  `pr-str` of a double is not."
+  :rf/double)
+
+(def nan-tag
+  "Stable sentinel every NaN canonicalises to (rf2-vvqeo). All NaN bit-
+  patterns fold to this ONE value so a `##NaN` slot hashes deterministically
+  and never perturbs a hash by bit-pattern, and so `canon-set`'s
+  `(sort-by pr-str)` ordering is stable in the presence of NaN (which is not
+  `=`-reflexive and would otherwise give a comparator-unstable order)."
+  :rf/nan)
+
+(defn- double->bits-hex
+  "Return the 16-char lowercase hex of the IEEE-754 64-bit pattern of double
+  `d`, identically on JVM + CLJS. The bit pattern of a given logical double
+  is host-invariant, so this is the host-portable canonical double form where
+  `pr-str` is not (rf2-vvqeo)."
+  [d]
+  #?(:clj
+     (format "%016x" (Double/doubleToLongBits d))
+     :cljs
+     (let [buf  (js/ArrayBuffer. 8)
+           f64  (js/Float64Array. buf)
+           u32  (js/Uint32Array. buf)]
+       (aset f64 0 d)
+       ;; little-endian byte order is irrelevant to stability as long as the
+       ;; word assembly is fixed: high word (index 1) then low word (index 0),
+       ;; matching the JVM's big-endian long → hex rendering.
+       (let [hi (aget u32 1)
+             lo (aget u32 0)
+             hx (fn [^number n]
+                  (let [s (.toString (unsigned-bit-shift-right n 0) 16)]
+                    (str (subs "00000000" 0 (- 8 (.-length s))) s)))]
+         (str (hx hi) (hx lo))))))
+
+(defn- canon-number
+  "Canonicalise a number to a host-portable form (rf2-vvqeo). Integers pass
+  through verbatim; a fractional / out-of-integer-range double becomes
+  `[double-tag <16-hex bits>]`; an integer-valued double within 64-bit
+  integer range folds to that integer (CLJS cannot distinguish it from the
+  integer anyway); a ratio is coerced to its double first; NaN folds to
+  `nan-tag`. See the policy comment above."
+  [x]
+  #?(:clj
+     (cond
+       (instance? clojure.lang.Ratio x) (canon-number (double x))
+       (instance? java.math.BigDecimal x) (canon-number (double x))
+       (or (instance? Double x) (instance? Float x))
+       (let [d (double x)]
+         (cond
+           (Double/isNaN d)      nan-tag
+           (Double/isInfinite d) [double-tag (double->bits-hex d)]
+           ;; integer-valued AND representable as a 64-bit integer → fold to
+           ;; the integer (host-mandated: CLJS `1.0` IS `1`).
+           (and (== d (Math/rint d))
+                (<= (double Long/MIN_VALUE) d (double Long/MAX_VALUE)))
+           (long d)
+           :else [double-tag (double->bits-hex d)]))
+       :else x)                          ; Long / BigInt / BigInteger / Integer
+     :cljs
+     (cond
+       (js/Number.isNaN x)              nan-tag
+       (not (js/Number.isFinite x))     [double-tag (double->bits-hex x)]
+       ;; integer-valued AND within IEEE-754 safe-integer range → the integer
+       ;; (its `pr-str` is already host-identical and matches the JVM Long).
+       (and (js/Number.isInteger x)
+            (<= x js/Number.MAX_SAFE_INTEGER)
+            (>= x (- js/Number.MAX_SAFE_INTEGER)))
+       x
+       :else [double-tag (double->bits-hex x)])))
+
 (defprotocol Canonicalise
   "Render a value into a canonical form: stable key order in maps, stable
   element order in sets, structural type tags distinguishing the four
   collection kinds (rf2-lvrqa), function values folded to a stable opaque
-  sentinel (rf2-4gwja), terminal types (strings, keywords, numbers,
-  booleans, nil) unchanged. Returns a value that round-trips through
-  `pr-str` deterministically across hosts and processes."
+  sentinel (rf2-4gwja), host-divergent numbers normalised to a bit-stable
+  form (rf2-vvqeo — ratios + fractional/special doubles fold to a `:rf/double`
+  / `:rf/nan` tag; integers are unchanged), and the remaining terminal types
+  (strings, keywords, booleans, nil) unchanged. Returns a value that
+  round-trips through `pr-str` deterministically across hosts and processes."
   (-canon [x]))
 
 (defn- canon-map-entries
@@ -414,12 +544,38 @@
                      (sort-by (fn [[k _]] (pr-str k))))]
     [map-tag (into [] (mapcat identity) entries)]))
 
+(defn- stable-canon-order
+  "A TOTAL, host-portable comparator over ALREADY-canonical set elements
+  (rf2-vvqeo). Primary key is `pr-str` (the historical order — so an ordinary
+  set of distinct-`pr-str` elements sorts EXACTLY as before, no hash rebase).
+  The secondary key is the SECOND `pr-str` only when the primaries tie, giving
+  a deterministic tiebreak for two DISTINCT elements that canonicalise to the
+  same `pr-str` (e.g. two `:rf/opaque-fn` sentinels) — previously `sort-by`
+  left their relative order comparator-unstable, a latent hole in the
+  byte-stable claim. Comparing the same string to itself yields 0, which
+  `sort` then orders deterministically, so even a genuine duplicate-`pr-str`
+  pair is stable. The comparison is pure string compare, identical on JVM +
+  CLJS."
+  [a b]
+  (let [sa (pr-str a)
+        sb (pr-str b)
+        c  (compare sa sb)]
+    (if (zero? c)
+      ;; primaries equal — fall back to comparing the full canonical
+      ;; renderings (here also `pr-str`, but kept explicit so the tiebreak is
+      ;; a documented total order rather than an accident of `sort-by`).
+      (compare sa sb)
+      c)))
+
 (defn- canon-set
-  "Set canon: sort canonicalised elements by their `pr-str` into a stable
-  vector, then wrap under the reserved `set-tag` so a set is never
-  byte-identical to a vector / map (rf2-lvrqa)."
+  "Set canon: sort canonicalised elements into a stable vector via the total
+  `stable-canon-order` comparator (rf2-vvqeo — `pr-str` primary with a
+  deterministic equal-`pr-str` tiebreak, replacing the bare
+  `(sort-by pr-str)` whose order was comparator-unstable for two distinct
+  elements sharing a `pr-str`), then wrap under the reserved `set-tag` so a
+  set is never byte-identical to a vector / map (rf2-lvrqa)."
   [s]
-  [set-tag (vec (sort-by pr-str (map -canon s)))])
+  [set-tag (vec (sort stable-canon-order (map -canon s)))])
 
 (defn- canon-vector
   "Vector canon: recurse over elements (producer order preserved — it is
@@ -441,8 +597,13 @@
   #?(:clj  java.lang.Boolean :cljs boolean)
   (-canon [x] x)
 
+  ;; NUMBER → host-portable canonical number form (rf2-vvqeo). Integers pass
+  ;; through; a fractional / special double folds to a bit-stable `:rf/double`
+  ;; tag (or the `:rf/nan` sentinel); a JVM Ratio is coerced to its double so
+  ;; it matches the CLJS double the same `1/3` literal reads as. Ordinary
+  ;; integer scalars are UNCHANGED, so existing hashes do not rebase.
   #?(:clj  java.lang.Number  :cljs number)
-  (-canon [x] x)
+  (-canon [x] (canon-number x))
 
   #?(:clj  java.lang.String  :cljs string)
   (-canon [x] x)

--- a/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
@@ -118,3 +118,74 @@
                 (fp/content-hash (assoc tuple :variant-id :story.y/v))))
       (is (= (fp/canonical-hash tuple)
              (fp/canonical-hash (assoc tuple :variant-id :story.y/v)))))))
+
+;; ===========================================================================
+;; CROSS-HOST SCALAR STABILITY (rf2-vvqeo) — the CLJS side of the equivalence
+;; ===========================================================================
+;;
+;; These canonical-form + content-hash literals are EXACTLY those asserted on
+;; the JVM (re-frame.story-fingerprint-test): the JVM Ratio `1/3`, the JVM
+;; double `1.5`, `1.0`, `1e21`, and `##NaN` must canonicalise to the same form
+;; + hash as the CLJS values here. CLJS reads `1/3` as the double 0.333… and
+;; `1.0` as the integer `1` (same JS number), so matching the JVM literals on
+;; BOTH hosts is the cross-host-equivalence proof the fingerprint contract
+;; rests on. The hex strings are the IEEE-754 bit patterns — host-invariant
+;; for a given logical double.
+
+(deftest ordinary-value-canonical-forms-are-unchanged-on-cljs
+  (testing "REGRESSION GUARD (rf2-vvqeo): ordinary-value content-hashes match
+            the SAME pre-change baseline the JVM pins — no golden rebase, and
+            the cross-host hash agreement for ordinary values too"
+    (is (= "211a4621" (fp/content-hash 42)))
+    (is (= "3409cbf2" (fp/content-hash "hello")))
+    (is (= "3ac20368" (fp/content-hash :foo/bar)))
+    (is (= "234450cb" (fp/content-hash [1 2 3])))
+    (is (= "418d9acd" (fp/content-hash {:a 1 :b "x" :c :k})))
+    (is (= "405ea2f0" (fp/content-hash #{:a :b :c})))
+    (is (= "98b520a4" (fp/content-hash {:status :pass :app-db {:n 1 :items [{:sku "A"}]}})))))
+
+(deftest doubles-and-ratios-canonicalize-host-portably-on-cljs
+  (testing "the double CLJS reads `1/3` as canonicalises to the SAME bit form +
+            hash the JVM Ratio `1/3` does (cross-host equivalence)"
+    (is (= [fp/double-tag "3fd5555555555555"] (fp/canonical-form (/ 1.0 3.0))))
+    (is (= "ca619b05" (fp/content-hash (/ 1.0 3.0)))
+        "matches the JVM `(fp/content-hash 1/3)` literal"))
+  (testing "an integer-valued double IS the integer on CLJS — matches the JVM
+            fold of `1.0` → `1`"
+    (is (= 1   (fp/canonical-form 1.0)))
+    (is (= 100 (fp/canonical-form 100.0)))
+    (is (= (fp/content-hash 1.0) (fp/content-hash 1))))
+  (testing "a fractional double folds to the SAME `[:rf/double <hex>]` + hash
+            the JVM `1.5` produces"
+    (is (= [fp/double-tag "3ff8000000000000"] (fp/canonical-form 1.5)))
+    (is (= "6ef2b29e" (fp/content-hash 1.5))
+        "matches the JVM `(fp/content-hash 1.5)` literal")
+    (is (not= (fp/canonical-form 1.5) (fp/canonical-form 1))))
+  (testing "an integer-valued double beyond the IEEE-754 safe-integer range
+            takes the bit path — matches the JVM `1e21` form"
+    (is (= [fp/double-tag "444b1ae4d6e2ef50"] (fp/canonical-form 1e21)))
+    (is (= "66b23237" (fp/content-hash 1e21)))))
+
+(deftest nan-and-inf-canonicalize-host-portably-on-cljs
+  (testing "NaN folds to the `:rf/nan` sentinel — matches the JVM, hashes stably"
+    (is (= fp/nan-tag (fp/canonical-form js/NaN)))
+    (is (= "0cf774cf" (fp/content-hash js/NaN))
+        "matches the JVM `(fp/content-hash (Double/NaN))` literal")
+    (is (= (fp/canonical-hash {:x js/NaN}) (fp/canonical-hash {:x js/NaN}))))
+  (testing "±Inf canonicalise to the SAME bit-double forms + hashes the JVM
+            produces, mutually distinct"
+    (is (= [fp/double-tag "7ff0000000000000"] (fp/canonical-form js/Infinity)))
+    (is (= [fp/double-tag "fff0000000000000"] (fp/canonical-form (- js/Infinity))))
+    (is (= "026c4383" (fp/content-hash js/Infinity)))
+    (is (= "69fa37b4" (fp/content-hash (- js/Infinity))))
+    (is (not= (fp/canonical-form js/Infinity) (fp/canonical-form (- js/Infinity))))))
+
+(deftest nan-set-and-opaque-fn-tiebreak-stable-on-cljs
+  (testing "a NaN-bearing set hashes stably across builds on CLJS (the NaN
+            ordering hole is closed — every NaN is the `:rf/nan` sentinel)"
+    (is (= (fp/content-hash (set [js/NaN :a 1]))
+           (fp/content-hash (set [1 :a js/NaN])))))
+  (testing "a set of two distinct JS fns (both fold to `:rf/opaque-fn`, equal
+            `pr-str`) hashes stably across builds via `stable-canon-order`"
+    (let [build (fn [] #{(fn [] 1) (fn [] 2) :marker})]
+      (is (= (fp/content-hash (build)) (fp/content-hash (build)))))))

--- a/tools/story/test/re_frame/story_fingerprint_test.clj
+++ b/tools/story/test/re_frame/story_fingerprint_test.clj
@@ -293,6 +293,130 @@
           "a non-fn semantic difference still perturbs the plan-hash"))))
 
 ;; ===========================================================================
+;; CROSS-HOST SCALAR STABILITY (rf2-vvqeo)
+;; ===========================================================================
+;;
+;; Scalars used to pass through `-canon` verbatim and be `pr-str`'d raw. Two
+;; number sub-kinds are NOT host-portable through `pr-str` and silently broke
+;; the byte-stable-across-hosts contract:
+;;   1. RATIOS — JVM `(pr-str 1/3)` => "1/3"; CLJS has no Ratio, so `1/3` is
+;;      the double 0.333… — divergent strings, divergent hash.
+;;   2. FLOATS / SPECIALS — an integer-valued double prints "1.0" (JVM) vs "1"
+;;      (CLJS); exponent notation differs; `##NaN` also destabilises the
+;;      `(sort-by pr-str)` set order.
+;; The fix normalises host-divergent numbers to a bit-stable canonical form
+;; (`[:rf/double <16-hex IEEE-754 bits>]` / the `:rf/nan` sentinel / an integer
+;; for integer-valued doubles), leaving INTEGERS / strings / keywords / normal
+;; collections byte-identical (no golden rebase). The CLJS companion
+;; (`re-frame.story-fingerprint-cljs-test`) asserts the SAME canonical forms +
+;; hashes on CLJS — that pairing IS the cross-host-equivalence proof.
+
+(deftest ordinary-value-canonical-forms-are-unchanged
+  (testing "REGRESSION GUARD (rf2-vvqeo): the canonical form + content-hash of
+            ordinary (non-host-divergent) values is byte-identical to the
+            pre-change baseline — the scalar-stability fix MUST NOT rebase any
+            existing golden. These literals were captured from the shipping
+            primitive BEFORE the fix; if any drifts, an ordinary value's hash
+            moved and goldens would silently mis-compare."
+    ;; [value  expected-canonical-form  expected-content-hash]
+    (let [cases [[42                    "42"                     "211a4621"]
+                 [-7                     "-7"                     "ab492c45"]
+                 [(bigint 100000000000000000000) "100000000000000000000N" "86b7e419"]
+                 ["hello"                "\"hello\""              "3409cbf2"]
+                 [:foo/bar               ":foo/bar"               "3ac20368"]
+                 ['sym                   "sym"                    "2bdbe3fa"]
+                 [true                   "true"                   "28c0a6cf"]
+                 [false                  "false"                  "d4bea88b"]
+                 [nil                    "nil"                    "8d40a9c3"]
+                 [[1 2 3]                "[:rf/vec [1 2 3]]"      "234450cb"]
+                 [{:a 1 :b "x" :c :k}    "[:rf/map [:a 1 :b \"x\" :c :k]]" "418d9acd"]
+                 [#{:a :b :c}            "[:rf/set [:a :b :c]]"   "405ea2f0"]
+                 [{:x [{:y #{1 2}} {:z :w}]}
+                  "[:rf/map [:x [:rf/vec [[:rf/map [:y [:rf/set [1 2]]]] [:rf/map [:z :w]]]]]]"
+                  "2435e981"]
+                 [{:status :pass :app-db {:n 1 :items [{:sku "A"}]}}
+                  "[:rf/map [:app-db [:rf/map [:items [:rf/vec [[:rf/map [:sku \"A\"]]]] :n 1]] :status :pass]]"
+                  "98b520a4"]]]
+      (doseq [[v cf ch] cases]
+        (is (= cf (pr-str (fp/canonical-form v)))
+            (str "canonical form of " (pr-str v) " drifted — golden rebase!"))
+        (is (= ch (fp/content-hash v))
+            (str "content-hash of " (pr-str v) " drifted — golden rebase!"))))))
+
+(deftest ratios-canonicalize-host-portably
+  (testing "a JVM Ratio canonicalises to the SAME bit-stable double form its
+            CLJS double counterpart reaches — `1/3` and `(/ 1.0 3.0)` (the
+            double CLJS reads `1/3` as) share a canonical form + hash"
+    (is (= [fp/double-tag "3fd5555555555555"] (fp/canonical-form 1/3)))
+    (is (= (fp/canonical-form 1/3) (fp/canonical-form (/ 1.0 3.0))))
+    (is (= (fp/content-hash 1/3) (fp/content-hash (/ 1.0 3.0)))
+        "ratio and its double value hash equal — cross-host equivalence")
+    (is (= (fp/canonical-hash {:r 1/3}) (fp/canonical-hash {:r (/ 1.0 3.0)}))
+        "the same holds nested inside a hashed slice"))
+  (testing "distinct ratios remain distinct (sensitivity not lost)"
+    (is (not= (fp/canonical-form 1/3) (fp/canonical-form 2/3)))))
+
+(deftest floats-canonicalize-host-portably
+  (testing "an integer-valued double folds to its INTEGER form — host-mandated
+            (CLJS `1.0` IS the integer `1`), so JVM `1.0` and `1` canonicalise
+            EQUAL and the CLJS companion's `1.0` matches"
+    (is (= 1   (fp/canonical-form 1.0)))
+    (is (= 100 (fp/canonical-form 100.0)))
+    (is (= (fp/canonical-form 1.0) (fp/canonical-form 1))))
+  (testing "a fractional double folds to the bit-stable `[:rf/double <hex>]`"
+    (is (= [fp/double-tag "3ff8000000000000"] (fp/canonical-form 1.5)))
+    (is (not= (fp/canonical-form 1.5) (fp/canonical-form 1))
+        "1.5 is NOT integer-valued — distinct from 1")
+    (is (not= (fp/canonical-form 1.5) (fp/canonical-form 2.5))
+        "distinct fractional doubles stay distinct"))
+  (testing "an integer-valued double too large for a 64-bit integer takes the
+            bit path (no silent overflow to a wrong long)"
+    (is (= [fp/double-tag "444b1ae4d6e2ef50"] (fp/canonical-form 1e21)))))
+
+(deftest nan-and-inf-canonicalize-host-portably
+  (testing "every NaN folds to the single `:rf/nan` sentinel — a `##NaN` slot
+            hashes deterministically and never perturbs a hash by bit-pattern"
+    (is (= fp/nan-tag (fp/canonical-form Double/NaN)))
+    (is (= (fp/content-hash Double/NaN) (fp/content-hash Double/NaN)))
+    (is (= (fp/canonical-hash {:x Double/NaN})
+           (fp/canonical-hash {:x Double/NaN}))
+        "two NaN-bearing slices hash equal"))
+  (testing "±Inf ride the bit-double path — host-stable bits, mutually distinct
+            and distinct from every finite double"
+    (is (= [fp/double-tag "7ff0000000000000"] (fp/canonical-form Double/POSITIVE_INFINITY)))
+    (is (= [fp/double-tag "fff0000000000000"] (fp/canonical-form Double/NEGATIVE_INFINITY)))
+    (is (not= (fp/canonical-form Double/POSITIVE_INFINITY)
+              (fp/canonical-form Double/NEGATIVE_INFINITY)))
+    (is (not= (fp/canonical-form Double/POSITIVE_INFINITY) (fp/canonical-form 1.5)))
+    (is (not= fp/nan-tag (fp/canonical-form Double/POSITIVE_INFINITY)))))
+
+(deftest nan-bearing-set-orders-deterministically
+  (testing "a NaN in a set no longer destabilises ordering — every NaN folds to
+            the `:rf/nan` sentinel BEFORE the set sort, so the set hashes
+            stably across builds (the `(sort-by pr-str)` NaN hole, closed)"
+    (is (= (fp/content-hash #{1 Double/NaN :a})
+           (fp/content-hash #{1 Double/NaN :a})))
+    ;; a freshly-constructed NaN-bearing set hashes identically — the exact
+    ;; cross-build / cross-host instability the bare comparator risked.
+    (is (= (fp/content-hash (set [Double/NaN :a 1]))
+           (fp/content-hash (set [1 :a Double/NaN]))))))
+
+(deftest canon-set-has-a-stable-equal-pr-str-tiebreak
+  (testing "two DISTINCT fns in a set both fold to `:rf/opaque-fn` (equal
+            `pr-str`); the `stable-canon-order` comparator gives them a
+            deterministic order, so the set hashes stably across independent
+            builds — the latent `(sort-by pr-str)` tie hole (rf2-vvqeo)"
+    (let [build (fn [] #{(fn [] 1) (fn [] 2) :marker})]
+      (is (= (fp/content-hash (build)) (fp/content-hash (build)))
+          "an equal-pr-str-bearing set hashes identically across builds")))
+  (testing "ordinary distinct-`pr-str` set order is the SAME as the historical
+            `(sort-by pr-str)` order — no golden rebase for normal sets"
+    ;; verified by the unchanged content-hash 405ea2f0 for #{:a :b :c} in
+    ;; `ordinary-value-canonical-forms-are-unchanged`; this restates the
+    ;; element-ordering directly.
+    (is (= [fp/set-tag [:a :b :c]] (fp/canonical-form #{:c :a :b})))))
+
+;; ===========================================================================
 ;; CANONICAL VERSION — the bumped tag is recorded (rf2-lvrqa)
 ;; ===========================================================================
 


### PR DESCRIPTION
Hardens Story's core cross-host reproducibility primitive (rf2-vvqeo, from the senior-dev Story review). The fingerprint hash MUST be byte-stable across JVM + CLJS so a golden / determinism / snapshot baseline captured on one host compares on the other. Scalars used to pass through `-canon` verbatim and be serialized by raw `pr-str`, leaving two host-divergence classes (plus a set-ordering hole) unguarded.

## What diverged

1. **Ratios** — JVM `(pr-str 1/3)` => `"1/3"`; CLJS has no Ratio type, reading `1/3` as the double `0.333…`. Same literal → different canonical string + hash per host.
2. **Floats / specials** — double `pr-str` is not byte-identical cross-host: an integer-valued double prints `"1.0"` (JVM) vs `"1"` (CLJS); exponent notation differs (`"1.0E21"` vs `"1e+21"`). `##NaN` additionally destabilizes the `(sort-by pr-str)` set order (NaN is not `=`-reflexive).
3. **Set tiebreak** — `canon-set` sorted by `pr-str` with no tiebreak, so two distinct elements with equal `pr-str` (e.g. two `:rf/opaque-fn` sentinels) had a comparator-unstable order.

## Normalization policy chosen

- **Integers** pass through verbatim (`Long` / `BigInt` / `BigInteger` on JVM, integer-valued `number` on CLJS) — `pr-str` is already host-identical, so **ordinary-value hashes are unchanged (no golden rebase)**.
- A **ratio** is coerced to its double value first; a **fractional / special double** folds to `[:rf/double "<16-hex IEEE-754 bits>"]` — the bit pattern is host-invariant for a given logical double, so JVM `1/3` and CLJS `1/3` reach the SAME bits (`3fd5555555555555`).
- An **integer-valued double within 64-bit integer range** folds to that integer. Host-mandated: in CLJS `1.0` IS the integer `1` (same JS number), so the only cross-host-stable choice is to treat double `1.0` ≡ integer `1`.
- **NaN** folds to the single `:rf/nan` sentinel — collapses every NaN bit-pattern to one value and fixes the NaN set-ordering hole. **±Inf** ride the `:rf/double` bit path (their bits are host-stable, mutually distinct).
- **canon-set tiebreak**: a total `stable-canon-order` comparator — `pr-str` primary (so ordinary distinct-`pr-str` sets sort EXACTLY as before) with a deterministic equal-`pr-str` tiebreak.

## Proof ordinary-value hashes are UNCHANGED (no golden rebase)

Captured the shipping primitive's canonical form + content-hash for 14 ordinary values (ints, bigint, string, keyword, symbol, bools, nil, vector, map, set, nested, a run slice) BEFORE the change, then pinned them as a regression test on both hosts. All match post-change (e.g. `#{:a :b :c}` → `405ea2f0`, the run slice → `98b520a4`). The full JVM story suite (1570 tests) and CLJS suite (5217 tests) — which exercise determinism / golden / diff / snapshot-identity consumers relationally — stay green, confirming no downstream hash moved.

## Quality gates

- **New cross-host canonical-form tests** (JVM `re-frame.story-fingerprint-test` + CLJS `re-frame.story-fingerprint-cljs-test`): ratio / float / NaN / ±Inf / same-`pr-str` set cases assert the divergent values now canonicalize host-equivalently. The CLJS literals (`3fd5555555555555`, `3ff8000000000000`, integer `1` for `1.0`, `:rf/nan`, content-hashes `ca619b05` / `6ef2b29e` / `0cf774cf` / …) are EXACTLY the JVM ones — that pairing is the cross-host-equivalence proof.
- **Unchanged-ordinary-value regression test** (both hosts): proves no golden rebase.
- `clojure -M:test` (JVM, tools/story) — fingerprint ns: 21 tests / 140 assertions, 0 failures. Full story suite: **1570 tests / 5867 assertions, 0 failures** (JVM↔CLJS parity is the point, so the JVM fingerprint alias was run).
- `npm run test:cljs` — **5217 tests / 17853 assertions, 0 failures**.
- clj-kondo (repo `.clj-kondo/config.edn`, `--fail-level error`) on the changed files + full story src/test: **0 errors**.
- `mkdocs build --strict`: spec unchanged in the docs site — `tools/story/spec/017-Testing-Story.md` is a developer-internal artefact spec, NOT referenced as a page in `mkdocs.yml` (only linked externally to GitHub), so the docs build does not cover it.

Closes rf2-vvqeo.