### PR TITLE
fix(story): stamp :rf.story/script-idx for exact narrative attribution (rf2-rkd14)

### DIFF
--- a/tools/story/src/re_frame/story/artifact.cljc
+++ b/tools/story/src/re_frame/story/artifact.cljc
@@ -240,12 +240,31 @@
           (rf/uninstall-managed-request-stubs!)))
       (thunk))))
 
+(defn- epoch-count
+  "The current epoch-history length for `frame-id` — the append-only tape
+  cursor a replay settle boundary snapshots (rf2-rkd14). Tolerant: 0 when
+  the frame has no history / the epoch dep is absent (facade → `[]`)."
+  [frame-id]
+  (try (count (rf/epoch-history frame-id))
+       (catch #?(:clj Throwable :cljs :default) _ 0)))
+
 (defn replay-into-frame!
   "Replay an artifact's `:event-program` into the LIVE `frame-id`,
   reapplying `fx-decisions` and settling each `[:dispatch …]` step through
   `settled-boundary`. Returns a vector of per-step settle outcomes (one
   per dispatch step), in program order — `{:status :settled :boundary …}`
   on success, a `cannot-run-refusal` / `{:status :error …}` otherwise.
+
+  rf2-rkd14 — the returned vector carries an `:attribution` metadata slot:
+  the epoch-history LENGTH snapshotted at the start of each dispatch step's
+  settle, in dispatch-step order. `replay-result` reads it (via
+  `(:attribution (meta outcomes))`) and hands it to `project-evidence` so
+  the replay narrative is attributed EXACTLY (`evidence/spans-from-stamps`)
+  rather than via the EVEN heuristic. The metadata leaves the documented
+  return VALUE (the outcomes vector) unchanged. The boundaries are
+  positional — the Nth element is the Nth dispatch step's settle boundary —
+  so they zip directly onto the dispatch steps of the `:event-program` the
+  narrative spans.
 
   This is the IMPURE seam — it dispatches into a live frame. The caller
   owns frame allocation + teardown + the epoch-tape read; `replay-run-
@@ -258,14 +277,20 @@
    (replay-into-frame! frame-id artifact boundary/headless-flush-hooks))
   ([frame-id artifact hooks]
    (let [fx-decisions (:fx-decisions artifact {})
-         replay-hooks (replay-flush-hooks hooks fx-decisions)]
-     (into []
-           (keep (fn [step]
-                   (when-let [evec (runner/step-event step)]
-                     (let [required (boundary/step-required-boundary step)]
-                       (boundary/dispatch-and-settle!
-                         frame-id evec replay-hooks required step)))))
-           (:event-program artifact)))))
+         replay-hooks (replay-flush-hooks hooks fx-decisions)
+         boundaries   (volatile! [])
+         outcomes     (into []
+                            (keep (fn [step]
+                                    (when-let [evec (runner/step-event step)]
+                                      (let [required (boundary/step-required-boundary step)]
+                                        ;; Snapshot the tape cursor BEFORE the
+                                        ;; settle — this dispatch step owns the
+                                        ;; records committed from here forward.
+                                        (vswap! boundaries conj (epoch-count frame-id))
+                                        (boundary/dispatch-and-settle!
+                                          frame-id evec replay-hooks required step)))))
+                            (:event-program artifact))]
+     (with-meta outcomes {:attribution @boundaries}))))
 
 (defn replay-result
   "Build the replay run-result from the captured `epoch-tape`, the
@@ -289,7 +314,15 @@
   read green while the tape is red."
   [{:keys [epoch-tape artifact outcomes frame-id app-db]}]
   (let [evidence-slots (evidence/project-evidence
-                         epoch-tape {:script (:event-program artifact)})
+                         epoch-tape {:script      (:event-program artifact)
+                                     ;; rf2-rkd14 — the per-dispatch-step
+                                     ;; settle boundaries `replay-into-frame!`
+                                     ;; recorded (on the outcomes vector's
+                                     ;; metadata) light up EXACT narrative
+                                     ;; attribution. Absent (a hand-built
+                                     ;; `outcomes` with no metadata) → EVEN
+                                     ;; fallback, unchanged.
+                                     :attribution (:attribution (meta outcomes))})
         refusal        (some (fn [o] (when (= :cannot-run (:status o)) o)) outcomes)
         errored        (some (fn [o] (when (= :error (:status o)) o)) outcomes)
         tape-red?      (evidence/tape-shows-failure? epoch-tape)

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -531,6 +531,74 @@
     (mapv (fn [j] (+ per-step (if (< j remainder) 1 0)))
           (range n-dispatch))))
 
+;; ---- exact stamping from runner-recorded settle boundaries ---------------
+;;
+;; This is the PRODUCER-side bridge that lights up `explicit-beats?` /
+;; `spans-from-stamps` (rf2-rkd14). The runner / replay path records, per
+;; dispatch-opening step (in executed-script order), the epoch-history
+;; LENGTH at the moment that step's settle began (`settle-boundaries`). The
+;; epoch tape is append-only during a run, so dispatch step K owns the
+;; contiguous run of records `[boundary_K, boundary_{K+1})` — and the LAST
+;; dispatch step owns through the tape end. This naturally rolls any epochs
+;; committed by intervening non-dispatch steps (an `[:assert …]` checkpoint
+;; that dispatches its `:rf.assert/*` verdict, a `:wait-until`) into the
+;; PRECEDING dispatch span, exactly the forward-attribution model the
+;; narrative documents (spec/017 §Epoch tape and narrative). Records before
+;; the first boundary (setup-phase cascades, framework bootstrap) are
+;; stamped nil → the leading span.
+;;
+;; `boundaries` is positional, NOT keyed by step index: its Nth element is
+;; the settle boundary of the Nth DISPATCH step in `script` (in order). This
+;; is what makes the mechanism runtime-agnostic — the live multi-play runner
+;; and the replay path both execute the concatenated dispatch steps in the
+;; same order the boundaries are recorded, so the zip is exact without any
+;; cross-play index arithmetic.
+
+(defn stamp-tape
+  "Stamp each `:rf/epoch-record` in `tape` with the 0-based
+  `:rf.story/script-idx` of the authored `script` step whose settle
+  produced it, using the runner-recorded `boundaries` (the epoch-history
+  length at the start of each dispatch step's settle, in dispatch-step
+  order). Pure data → data; the stamped tape is what the EXACT narrative
+  attribution (`explicit-beats?` / `spans-from-stamps`) consumes.
+
+  The stamp is a `:rf.story/*` accumulator key, so the deterministic
+  projection (`re-frame.story.fingerprint/project`) strips it before the
+  run-hash is taken — it is evidence-fidelity metadata on the narrative
+  projection, NOT a behavioural slice (rf2-rkd14 determinism guard).
+
+  Degrades gracefully: with no `boundaries` (a bare tape — replay/live
+  paths that did not record settle boundaries) the tape is returned
+  verbatim (unstamped), so `narrative` falls back to the EVEN partition
+  exactly as before. A record at or past the last boundary belongs to the
+  last dispatch step; records before the first boundary are stamped nil
+  (the leading setup span)."
+  [script tape boundaries]
+  (let [records       (vec (or tape []))
+        bounds        (vec (or boundaries []))
+        ;; The 0-based script index of each DISPATCH step, in order — the
+        ;; Nth dispatch step's authored position in `script`. `boundaries`
+        ;; is parallel to this vector.
+        dispatch-idxs (vec (keep-indexed (fn [i step] (when (dispatch-step? step) i))
+                                         (or script [])))]
+    (if (empty? bounds)
+      records
+      (mapv
+        (fn [pos record]
+          (let [;; The index into `bounds` of the LAST dispatch step whose
+                ;; settle had already begun at this record's tape position —
+                ;; i.e. the dispatch step that owns this record. A record
+                ;; before the first boundary owns to no step (leading nil).
+                owner (loop [k (dec (count bounds))]
+                        (cond
+                          (neg? k)                  nil
+                          (<= (nth bounds k) pos)    k
+                          :else                     (recur (dec k))))]
+            (assoc record :rf.story/script-idx
+                   (when (some? owner) (nth dispatch-idxs owner nil)))))
+        (range)
+        records))))
+
 (defn narrative
   "Two-level narrative projection (spec/017 §Run result, §Epoch tape and
   narrative): author `:script` steps form the outer spans; the epoch beats
@@ -544,13 +612,19 @@
 
   Attribution has two modes:
 
-  - EXACT — when every record carries a `:rf.story/script-idx` stamp (the
-    runner's per-step settle boundary), each beat lands in the span of the
-    step that produced it; unstamped / setup beats lead under a `nil`
-    span. This is the precise model the runner SHOULD feed.
-  - EVEN — absent stamps (a bare `epoch-history` tape), records are
-    partitioned across the dispatch steps by an even forward split, with
-    re-dispatch surplus front-loaded onto the earliest dispatch spans.
+  - EXACT — when every record carries a `:rf.story/script-idx` stamp, each
+    beat lands in the span of the step that produced it; unstamped / setup
+    beats lead under a `nil` span. This is the precise model the
+    PRODUCER feeds: the runner / replay path records each dispatch step's
+    settle boundary (the epoch-history length at the start of its settle),
+    and `project-evidence` stamps the tape via `stamp-tape` before handing
+    it here (rf2-rkd14). A re-dispatch step that settles to N committed
+    epochs has all N attributed to the one authored step — exactly.
+  - EVEN — absent stamps (a bare `epoch-history` tape with no recorded
+    attribution — e.g. a hand-built tape or a host that did not record
+    settle boundaries), records are partitioned across the dispatch steps
+    by an even forward split, with re-dispatch surplus front-loaded onto
+    the earliest dispatch spans. The deterministic, total fallback.
 
   Pure assertion / wait steps that commit no epoch produce empty spans
   (the step is in the narrative, with no beats). No epoch is ever dropped:
@@ -759,6 +833,15 @@
   - `:script` — the coerced script-step vector, used to build the
     two-level `:narrative` spans. Absent, the narrative is a single
     `nil`-step span over the whole tape.
+  - `:attribution` — the runner-recorded per-dispatch-step settle
+    boundaries (the epoch-history length at the start of each dispatch
+    step's settle, in dispatch-step order). When present, the
+    `:narrative` is attributed EXACTLY via these boundaries
+    (`stamp-tape` → `spans-from-stamps`); absent, the narrative falls
+    back to the EVEN forward partition (rf2-rkd14). The stamp lands ONLY
+    on the records the narrative projection consumes — the verbatim
+    `:epoch-tape` slot stays RAW — and is a `:rf.story/*` key the
+    determinism projection strips, so the run-hash is unaffected.
 
   Returned slots (all spec/017 §Run-result names):
 
@@ -786,7 +869,7 @@
   absent slot correctly refuses a reactive-count assertion the run never
   exercised."
   ([epoch-tape] (project-evidence epoch-tape nil))
-  ([epoch-tape {:keys [script] :as _opts}]
+  ([epoch-tape {:keys [script attribution] :as _opts}]
    (let [tape        (vec (or epoch-tape []))
          ;; Project the structured reactive rows ONCE: they are both the
          ;; `:sub-runs` / `:renders` slots AND the input `reactive-counts`
@@ -794,14 +877,21 @@
          ;; (one tape, one projection).
          sub-rows    (sub-runs tape)
          render-rows (renders tape)
-         rc          (reactive-counts sub-rows render-rows)]
+         rc          (reactive-counts sub-rows render-rows)
+         ;; rf2-rkd14 — when the runner / replay path recorded per-dispatch-
+         ;; step settle boundaries, stamp the tape so the narrative is
+         ;; attributed EXACTLY (`spans-from-stamps`). The stamp lives ONLY on
+         ;; the narrative's input records; the `:epoch-tape` slot below stays
+         ;; the verbatim raw tape. (`stamp-tape` returns the tape unchanged
+         ;; when `attribution` is absent → EVEN fallback.)
+         narr-tape   (stamp-tape script tape attribution)]
      (cond-> {:epoch-tape        tape
               :schema-violations (schema-violations tape)
               :warnings          (warnings tape)
               :effects           (effects tape)
               :sub-runs          sub-rows
               :renders           render-rows
-              :narrative         (narrative script tape)}
+              :narrative         (narrative script narr-tape)}
        (some? rc) (assoc :reactive-counts rc)))))
 
 ;; ===========================================================================

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -45,6 +45,7 @@
             [re-frame.story.play        :as play]
             [re-frame.story.play.browser :as browser]
             [re-frame.story.play.dom    :as dom]
+            [re-frame.story.play.evidence :as evidence]
             [re-frame.story.play.runner :as runner]
             [re-frame.story.play.settled-boundary :as boundary]
             [re-frame.story.predicates  :as pred]
@@ -86,10 +87,53 @@
   #?(:cljs (r/atom {})
      :clj  (atom  {})))
 
+(defonce
+  ^{:doc "frame-id → vector of per-dispatch-step settle boundaries
+         (rf2-rkd14). Each element is the epoch-history LENGTH at the
+         moment a dispatch-opening step's settle began, recorded in
+         dispatch-step execution order. The evidence projection
+         (`runtime/record-result-map`) reads this through
+         `settle-boundaries` and hands it to
+         `evidence/project-evidence` as `:attribution`, lighting up the
+         EXACT narrative attribution (`spans-from-stamps`) instead of the
+         EVEN heuristic. Plain atom on both runtimes — it is read once at
+         result-build time, not a reactive UI input."}
+  step-boundaries
+  (atom {}))
+
 (defn current-state
   "Read the current run-state for `frame-id`, or nil if no run exists."
   [frame-id]
   (get @run-state frame-id))
+
+(defn settle-boundaries
+  "Read the recorded per-dispatch-step settle boundaries for `frame-id`,
+  or nil. rf2-rkd14 — the runner-recorded narrative attribution the
+  evidence projection consumes to stamp `:rf.story/script-idx`."
+  [frame-id]
+  (get @step-boundaries frame-id))
+
+(defn- epoch-count
+  "The current epoch-history length for `frame-id` (the append-only tape
+  cursor the settle boundary snapshots). Tolerant — 0 when the frame has
+  no history / the epoch dep is absent (the facade degrades to `[]`)."
+  [frame-id]
+  (try (count (rf/epoch-history frame-id))
+       (catch #?(:clj Throwable :cljs :default) _ 0)))
+
+(defn- record-settle-boundary!
+  "Snapshot the epoch-history length at the START of a dispatch-opening
+  `step`'s settle (rf2-rkd14). No-op for non-dispatch steps (assert / wait
+  / unknown) — those commit no span of their own; their epochs roll into
+  the preceding dispatch span (the narrative's forward-attribution model).
+  The boundaries accumulate in dispatch-step execution order, which — for
+  both the single-play and multi-play (sequential) runner — is exactly the
+  order the dispatch steps appear in the concatenated executed-script the
+  narrative spans."
+  [frame-id step]
+  (when (evidence/dispatch-step? step)
+    (swap! step-boundaries update frame-id (fnil conj []) (epoch-count frame-id)))
+  nil)
 
 (defn current-state-for-play
   "Read the run-state for `(frame-id, play-key)`, or nil. rf2-tl7zk:
@@ -111,6 +155,14 @@
   (swap! active-play assoc frame-id play-key)
   nil)
 
+(defn clear-step-boundaries!
+  "Reset the per-dispatch-step settle boundaries for `frame-id` (rf2-rkd14).
+  Called at the START of a fresh script run so the narrative attribution
+  windows onto THIS run's epoch tape, not a previous run's boundaries."
+  [frame-id]
+  (swap! step-boundaries dissoc frame-id)
+  nil)
+
 (defn clear-state!
   "Wipe the run-state for `frame-id`. Called from frame teardown +
   before each fresh run."
@@ -120,6 +172,7 @@
                         (into {} (remove (fn [[[fid _]]]
                                            (= fid frame-id)) m))))
   (swap! active-play dissoc frame-id)
+  (swap! step-boundaries dissoc frame-id)
   nil)
 
 (defn clear-all-runs!
@@ -129,9 +182,10 @@
   doesn't observe a previous test's play outcomes; `clear-state!` is
   the per-frame counterpart called from teardown."
   []
-  (reset! run-state    {})
-  (reset! runs-by-play {})
-  (reset! active-play  {})
+  (reset! run-state      {})
+  (reset! runs-by-play   {})
+  (reset! active-play    {})
+  (reset! step-boundaries {})
   nil)
 
 (defn- update-state!
@@ -988,6 +1042,7 @@
   `play.cljc` via the `:run-play-step` late-bind hook to avoid the
   play ↔ runner-events require cycle."
   [frame-id idx step]
+  (record-settle-boundary! frame-id step)
   (let [result (try
                  (exec-step! frame-id idx step)
                  (catch #?(:clj Throwable :cljs :default) e
@@ -1098,7 +1153,8 @@
             (schedule! (or ms 0) #(run-loop! frame-id play-key token done-cb)))
 
           :else
-          (let [result (try
+          (let [_      (record-settle-boundary! frame-id step)
+                result (try
                          (exec-step! frame-id idx step)
                          (catch #?(:clj Throwable :cljs :default) e
                            (runner/step-exception idx step

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -689,10 +689,17 @@
   green while the tape is red, and the verdict is computed from the
   PROJECTED evidence, not a sibling accumulator."
   [{:keys [epoch-tape assertions script check->atoms consumed-selectors
-           schema-expectations causal-expectations unmet app-db]
+           schema-expectations causal-expectations unmet app-db attribution]
     :as   parts}]
   (let [tape           (vec (or epoch-tape []))
-        evidence-slots (evidence/project-evidence tape {:script script})
+        ;; rf2-rkd14 — `:attribution` (the runner / replay-recorded
+        ;; per-dispatch-step settle boundaries) lights up EXACT narrative
+        ;; attribution. Absent → EVEN fallback, unchanged. The stamp rides
+        ;; only the narrative projection; the `:epoch-tape` slot stays raw
+        ;; and the stamp is a `:rf.story/*` key the determinism projection
+        ;; strips, so the run-hash is unaffected.
+        evidence-slots (evidence/project-evidence
+                         tape {:script script :attribution attribution})
         ;; The tape is projected ONCE (`project-evidence` above); the
         ;; schema-violation + effect vectors it already produced are threaded
         ;; into the schema match and the agreement floor below rather than

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -587,12 +587,19 @@
         ;; (per `re-frame.core/epoch-history`'s contract) while the
         ;; `:test`-alias epoch dep makes it the live tape under the gate.
         tape     (vec (rf/epoch-history variant-id))
+        ;; rf2-rkd14 — the runner-recorded per-dispatch-step settle
+        ;; boundaries light up the EXACT narrative attribution
+        ;; (`evidence/spans-from-stamps`) instead of the EVEN heuristic. The
+        ;; stamp is a `:rf.story/*` key the determinism projection strips, so
+        ;; the run-hash is unaffected (the `:epoch-tape` slot stays raw).
+        attribution (runner-events/settle-boundaries variant-id)
         ;; rf2-baah3 — project the tape ONCE here so the post-run evidence
         ;; validation (`requirements-unmet` → `validate-run-evidence`) reads
         ;; the SAME projected slots `result/run-result` derives the result
         ;; slots from. One tape, one projection — a duplicate accumulator
         ;; cannot report a proof present while the tape's slot is empty.
-        evidence (evidence/project-evidence tape {:script executed-script})
+        evidence (evidence/project-evidence tape {:script      executed-script
+                                                  :attribution attribution})
         ;; rf2-q5jw4 — the run-state's `:cannot-run` refusals (a no-DOM
         ;; `[:assert-dom …]` skip, a boundary `:cannot-run?`): steps that
         ;; recorded NO `:rf.story/assertions` entry, so without this fold the
@@ -614,6 +621,10 @@
         unified  (result/run-result
                    {:variant/id          variant-id
                     :epoch-tape          tape
+                    ;; rf2-rkd14 — the runner-recorded per-dispatch-step settle
+                    ;; boundaries (above) so `run-result`'s ONE evidence
+                    ;; projection attributes the `:narrative` EXACTLY.
+                    :attribution         attribution
                     :assertions          (or (:rf.story/assertions app-db) [])
                     :script              executed-script
                     :check->atoms        (plan-checks plan)
@@ -897,7 +908,14 @@
           ;; The folded steps the auto-plays ran, concatenated in order —
           ;; the script the unified result's two-level narrative spans.
           executed   (vec (mapcat :script auto-plays))
-          ctx'       (assoc ctx :executed-script executed)]
+          ctx'       (assoc ctx :executed-script executed)
+          ;; rf2-rkd14 — reset the per-dispatch-step settle boundaries before
+          ;; the auto-plays drive, so the narrative attribution windows onto
+          ;; THIS run's epoch tape. The boundaries snapshot the ABSOLUTE
+          ;; epoch-history length at each dispatch step (setup-phase epochs
+          ;; precede the first boundary → leading nil span), matching the
+          ;; absolute tape `record-result-map` reads.
+          _          (runner-events/clear-step-boundaries! variant-id)]
       (if (empty? auto-plays)
         ;; No script ran, but the world settled (phase-2 setup committed).
         ;; The terminal `:assertions` check the FINAL settled state, so they

--- a/tools/story/test/re_frame/story/artifact_test.cljc
+++ b/tools/story/test/re_frame/story/artifact_test.cljc
@@ -25,6 +25,7 @@
             [re-frame.story.determinism :as determinism]
             [re-frame.story.fingerprint :as fingerprint]
             [re-frame.story.plan :as plan]
+            [re-frame.story.play.evidence :as evidence]
             [re-frame.story.play.settled-boundary :as boundary]))
 
 ;; ===========================================================================
@@ -408,3 +409,99 @@
       (is (= :pass (:status res)))
       (is (true? (:ran (:app-db res))))
       (is (nil? (:network art)) "no :network slot on a non-HTTP artifact"))))
+
+;; ===========================================================================
+;; EXACT narrative attribution from runner-recorded settle boundaries (rf2-rkd14)
+;; ===========================================================================
+;;
+;; The narrative supports EXACT (`:rf.story/script-idx` stamps) and EVEN (an
+;; arbitrary forward partition) beat→step attribution. Before rf2-rkd14 the
+;; stamp was WRITTEN nowhere, so `explicit-beats?` was always false and every
+;; run fell to EVEN — which mis-attributes re-dispatch fan-out. `replay-into-
+;; frame!` now records each dispatch step's settle boundary (the epoch-history
+;; length at the start of its settle) on the outcomes metadata, and
+;; `replay-result` feeds it through `project-evidence` as `:attribution`, so
+;; the narrative is attributed EXACTLY.
+;;
+;; THE DISCRIMINATING CASE. Two dispatch steps where the SECOND re-dispatches:
+;;
+;;   step 0  [:dispatch [:rkd/a]]                 → 1 committed epoch (e0)
+;;   step 1  [:dispatch [:rkd/c]] (re-dispatches  → 2 committed epochs (e1 e2)
+;;                                  :rkd/d)
+;;
+;; Tape = [e0 e1 e2]; 2 dispatch steps. EVEN partitions 3 across 2 as [2 1]
+;; (remainder front-loaded), so it WRONGLY groups {e0 e1} under step 0 and
+;; {e2} under step 1 — e1 belongs to step 1. EXACT groups {e0} under step 0
+;; and {e1 e2} under step 1. This is the RED-before / GREEN-after pin: the
+;; commented assertion below is what the EVEN partition produced (RED for the
+;; correct grouping); the live assertions prove EXACT now fires.
+
+(defn- beats-by-step
+  "Group the flattened narrative beats of run-`result` by their owning
+  `:step`, returning `{step [trigger-event …]}` so a test can assert WHICH
+  authored step each beat (by its `:trigger-event`) landed under."
+  [result]
+  (->> (evidence/narrative-beats (:narrative result))
+       (reduce (fn [m {:keys [step trigger-event]}]
+                 (update m step (fnil conj []) trigger-event))
+               {})))
+
+(deftest replay-narrative-exact-attribution-of-redispatch-fanout
+  (testing "a step that re-dispatches has its fan-out attributed to THAT
+            step's span — EXACT (`:rf.story/script-idx`), not the EVEN
+            forward partition that mis-groups it (rf2-rkd14)"
+    ;; :rkd/a — a plain leaf dispatch (1 epoch).
+    (rf/reg-event-db :rkd/a (fn [db _] (assoc db :a true)))
+    ;; :rkd/c — re-dispatches :rkd/d, so step 1 settles to 2 epochs.
+    (rf/reg-event-fx :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
+    (rf/reg-event-db :rkd/d (fn [db _] (assoc db :d true)))
+    (let [a   (artifact/make-run-artifact
+                {:event-program [[:dispatch [:rkd/a]]
+                                 [:dispatch [:rkd/c]]]})
+          res (artifact/replay-run-artifact a)
+          by  (beats-by-step res)]
+      (is (= :pass (:status res)))
+      ;; THREE committed epochs: a, c, and c's re-dispatched d.
+      (is (= 3 (count (:epoch-tape res)))
+          "the re-dispatch settled to a 3-epoch tape")
+      ;; EXACT: step 0 owns ONLY :rkd/a; step 1 owns BOTH :rkd/c and the
+      ;; re-dispatched :rkd/d (the fan-out attaches to the step that produced
+      ;; it).
+      (is (= [[:rkd/a]] (get by [:dispatch [:rkd/a]]))
+          "step 0's span holds ONLY its own leaf epoch")
+      (is (= [[:rkd/c] [:rkd/d]] (get by [:dispatch [:rkd/c]]))
+          "step 1's span holds its dispatch AND its re-dispatch fan-out — EXACT")
+      ;; RED-before pin: the EVEN forward partition [2 1] would have grouped
+      ;; {:rkd/a :rkd/c} under step 0 and {:rkd/d} under step 1, i.e.
+      ;;   (is (= [[:rkd/a] [:rkd/c]] (get by [:dispatch [:rkd/a]])))  ; EVEN
+      ;; which mis-attributes :rkd/c's epoch to step 0. EXACT corrects it.
+      (is (not= [[:rkd/a] [:rkd/c]] (get by [:dispatch [:rkd/a]]))
+          "step 0 does NOT swallow step 1's epoch (the EVEN mis-grouping)"))))
+
+(deftest replay-narrative-stamp-does-not-perturb-run-hash
+  (testing "the :rf.story/script-idx stamp is a :rf.story/* accumulator key
+            the determinism projection strips — so the EXACT-attributed run
+            and a stamp-free baseline canonicalize + run-hash IDENTICALLY
+            (rf2-rkd14 determinism guard: :narrative is not in
+            run-hash-input-keys AND the :epoch-tape slot stays raw)"
+    (rf/reg-event-db :rkd/a (fn [db _] (assoc db :a true)))
+    (rf/reg-event-fx :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
+    (rf/reg-event-db :rkd/d (fn [db _] (assoc db :d true)))
+    (let [a    (artifact/make-run-artifact
+                 {:event-program [[:dispatch [:rkd/a]]
+                                  [:dispatch [:rkd/c]]]})
+          res  (artifact/replay-run-artifact a)
+          ;; The verbatim :epoch-tape slot must be RAW — no stamp leaked into
+          ;; the hashed slice.
+          tape-keys (into #{} (mapcat keys) (:epoch-tape res))]
+      (is (not (contains? tape-keys :rf.story/script-idx))
+          "the retained :epoch-tape slot is the RAW tape (no stamp leak)")
+      ;; The run-hash over an EXACT-attributed result equals the run-hash over
+      ;; the SAME result with the narrative dropped — proving the stamp (which
+      ;; rides only the narrative projection) is invisible to the hash.
+      (is (= (fingerprint/run-hash res)
+             (fingerprint/run-hash (dissoc res :narrative)))
+          "dropping the stamped :narrative does not change the run-hash")
+      ;; And the run-hash is stable / idempotent on the stamped result.
+      (is (= (fingerprint/run-hash res) (fingerprint/run-hash res))
+          "run-hash is idempotent on the EXACT-attributed result"))))

--- a/tools/story/test/re_frame/story/play/evidence_test.cljc
+++ b/tools/story/test/re_frame/story/play/evidence_test.cljc
@@ -275,6 +275,47 @@
       (is (= [:dispatch [:b]] (:step (nth n 3))))
       (is (= [4] (mapv :epoch-id (:epochs (nth n 3))))))))
 
+(deftest stamp-tape-from-settle-boundaries
+  (testing "stamp-tape maps runner-recorded per-dispatch-step settle
+            boundaries onto the raw tape — the discriminating re-dispatch
+            case the EVEN partition mis-groups (rf2-rkd14)"
+    ;; Two dispatch steps; the SECOND re-dispatches → settles to 2 epochs.
+    ;; Tape = [a c d]; boundaries = [0 1] (e0 committed before step 1's
+    ;; settle began at count 1). EXACT: step 0 owns {a}; step 1 owns {c d}.
+    (let [script     [[:dispatch [:a]] [:dispatch [:c]]]
+          tape       [(epoch 1 {:trigger-event [:a]})
+                      (epoch 2 {:trigger-event [:c]})
+                      (epoch 3 {:trigger-event [:d]})] ; c's re-dispatch
+          stamped    (evidence/stamp-tape script tape [0 1])]
+      (is (= [0 1 1] (mapv :rf.story/script-idx stamped))
+          "a → step 0; c + its re-dispatch d → step 1 (fan-out attaches to
+           the producing step)")
+      ;; The stamped tape lights up EXACT attribution end-to-end.
+      (let [n (evidence/narrative script stamped)]
+        (is (= [[:a]]    (mapv :trigger-event (:epochs (first n)))))
+        (is (= [[:c] [:d]] (mapv :trigger-event (:epochs (second n))))
+            "EXACT — NOT the EVEN [2 1] split that mis-groups c onto step 0"))))
+
+  (testing "records before the first boundary lead under the nil setup span"
+    (let [script  [[:dispatch [:act]]]
+          tape    [(epoch 1 {:trigger-event [:setup]})  ; pre-dispatch cascade
+                   (epoch 2 {:trigger-event [:act]})]
+          ;; The one dispatch step's settle began at count 1 (after setup).
+          stamped (evidence/stamp-tape script tape [1])]
+      (is (= [nil 0] (mapv :rf.story/script-idx stamped))
+          "the setup epoch leads (nil); the dispatched epoch → step 0")))
+
+  (testing "with no boundaries the tape is returned verbatim → EVEN fallback"
+    (let [script [[:dispatch [:a]]]
+          tape   [(epoch 1 {:trigger-event [:a]})]]
+      (is (= tape (evidence/stamp-tape script tape nil))
+          "absent attribution leaves the tape unstamped")
+      (is (= tape (evidence/stamp-tape script tape []))
+          "an empty boundary vector also degrades to the raw tape")
+      (is (not (contains? (first (evidence/stamp-tape script tape nil))
+                          :rf.story/script-idx))
+          "no stamp key is added on the fallback path"))))
+
 (deftest narrative-no-dispatch-steps-leads-whole-tape
   (testing "a script with no dispatch steps puts the whole tape in a leading span"
     (let [script [[:assert-db [:k] 1] [:wait 10]]

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -23,15 +23,26 @@
             [re-frame.story.loaders     :as loaders]
             [re-frame.story.play        :as legacy-play]
             [re-frame.story.play.runner-events :as re]
+            ;; rf2-rkd14 — the EXACT narrative attribution tests read a live
+            ;; epoch tape via `rf/epoch-history`; requiring the epoch artefact
+            ;; installs its late-bind capture hooks so the tape is real (it
+            ;; degrades to `[]` without the dep, mirroring artifact-test). The
+            ;; fixture's `epoch/clear-history!` runs on both runtimes, so this
+            ;; require is unconditional.
+            [re-frame.epoch             :as epoch]
             [re-frame.machines          :as machines]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.registrar         :as registrar]
             ;; `re-frame.story.async/deref-blocking` is JVM-only (it
             ;; blocks a thread) and `config/set-global-args!` is only
             ;; needed by the JVM `reset-all` lineage — the integration
-            ;; tests below that use them are themselves JVM-gated.
+            ;; tests below that use them are themselves JVM-gated. The
+            ;; rf2-rkd14 EXACT-attribution tests are likewise `:clj`-gated, so
+            ;; their `evidence` / `fingerprint` deps ride this block too.
             #?@(:clj [[re-frame.story.async  :as async]
-                      [re-frame.story.config :as config]])))
+                      [re-frame.story.config :as config]
+                      [re-frame.story.play.evidence :as evidence]
+                      [re-frame.story.fingerprint :as fingerprint]])))
 
 ;; ---- CLJS+JVM: the dispatch→assertion outcome-matching bridge -----------
 ;;
@@ -69,6 +80,10 @@
   (story/clear-all!)
   (registrar/clear-all!)
   (reset! frame/frames {})
+  ;; rf2-rkd14 — clear the epoch ring + listeners so each EXACT-attribution
+  ;; test reads only its own freshly-captured tape.
+  (epoch/clear-history!)
+  (epoch/clear-epoch-listeners!)
   (try (rf/init! plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
   #?(:clj (require 're-frame.machines :reload))
@@ -384,6 +399,85 @@
              "the result map's :assertions slot includes the failed assertion")
          (is (false? (story/assertions-passing? result))
              "assertions-passing? on the result map flips to false")))))
+
+;; ---- rf2-rkd14: EXACT narrative attribution on the LIVE run path ---------
+;;
+;; The runtime records each dispatch step's settle boundary
+;; (`runner-events/step-boundaries`) and `record-result-map` feeds it to
+;; `project-evidence` as `:attribution`, so the unified result's `:narrative`
+;; is attributed EXACTLY (`:rf.story/script-idx` stamps) instead of the EVEN
+;; forward partition that mis-groups re-dispatch fan-out. The discriminating
+;; case: a SECOND dispatch step that re-dispatches — EVEN [2 1] mis-groups
+;; the first re-dispatched epoch onto step 0; EXACT keeps the fan-out under
+;; the step that produced it.
+
+#?(:clj
+   (deftest run-variant-narrative-exact-attribution-of-redispatch-fanout
+     (testing "the unified result's :narrative attributes a re-dispatching
+              step's fan-out to THAT step's span — EXACT, not the EVEN
+              partition that mis-groups it (rf2-rkd14, live run path)"
+       (rf/reg-event-db :rkd/a (fn [db _] (assoc db :a true)))
+       ;; :rkd/c re-dispatches :rkd/d, so step 1 settles to 2 epochs.
+       (rf/reg-event-fx :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
+       (rf/reg-event-db :rkd/d (fn [db _] (assoc db :d true)))
+       (story/reg-variant :story.rkd/redispatch
+         {:events      []
+          :play-script {:script [[:dispatch-sync [:rkd/a]]
+                                  [:dispatch-sync [:rkd/c]]]}})
+       (let [result (async/deref-blocking
+                      (story/run-variant :story.rkd/redispatch) 5000)
+             ;; Group the flattened beats by their owning :step. The leading
+             ;; (nil-step) span collects the lifecycle setup-phase epochs the
+             ;; runtime commits before the script runs.
+             by     (->> (evidence/narrative-beats (:narrative result))
+                         (reduce (fn [m {:keys [step trigger-event]}]
+                                   (update m step (fnil conj []) trigger-event))
+                                 {}))]
+         (is (= :pass (:status result)))
+         ;; The two authored steps committed THREE script epochs (a, c, c's
+         ;; re-dispatch d) — the rest of the tape is the leading setup phase.
+         (let [script-beats (concat (get by [:dispatch-sync [:rkd/a]])
+                                    (get by [:dispatch-sync [:rkd/c]]))]
+           (is (= [[:rkd/a] [:rkd/c] [:rkd/d]] (vec script-beats))
+               "the three script epochs land under the two authored steps"))
+         ;; EXACT: step 0 owns ONLY :rkd/a; step 1 owns :rkd/c AND its
+         ;; re-dispatched :rkd/d (the fan-out attaches to the producing step).
+         (is (= [[:rkd/a]] (get by [:dispatch-sync [:rkd/a]]))
+             "step 0's span holds ONLY its own leaf epoch")
+         (is (= [[:rkd/c] [:rkd/d]] (get by [:dispatch-sync [:rkd/c]]))
+             "step 1's span holds its dispatch AND its re-dispatch — EXACT")
+         ;; RED-before pin: the EVEN partition (5 script-attributable epochs
+         ;; split [3 2] front-loaded, or any forward split) front-loads
+         ;; :rkd/c onto step 0; EXACT keeps :rkd/c under step 1.
+         (is (not= [[:rkd/a] [:rkd/c]] (get by [:dispatch-sync [:rkd/a]]))
+             "step 0 does NOT swallow step 1's epoch (the EVEN mis-grouping)")
+         ;; The leading setup epochs are NOT mis-attributed to step 0 — they
+         ;; lead under the nil span (the EXACT model's leading-setup behaviour;
+         ;; the EVEN partition would have front-loaded them onto step 0).
+         (is (seq (get by nil))
+             "the setup-phase epochs lead under the nil span — not step 0")))))
+
+#?(:clj
+   (deftest run-variant-narrative-stamp-does-not-perturb-run-hash
+     (testing "the :rf.story/script-idx stamp is stripped by the determinism
+              projection — the EXACT-attributed result's run-hash equals its
+              narrative-free baseline, and the :epoch-tape slot stays raw
+              (rf2-rkd14 determinism guard)"
+       (rf/reg-event-db :rkd/a (fn [db _] (assoc db :a true)))
+       (rf/reg-event-fx :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
+       (rf/reg-event-db :rkd/d (fn [db _] (assoc db :d true)))
+       (story/reg-variant :story.rkd/hash
+         {:events      []
+          :play-script {:script [[:dispatch-sync [:rkd/a]]
+                                  [:dispatch-sync [:rkd/c]]]}})
+       (let [result    (async/deref-blocking
+                         (story/run-variant :story.rkd/hash) 5000)
+             tape-keys (into #{} (mapcat keys) (:epoch-tape result))]
+         (is (not (contains? tape-keys :rf.story/script-idx))
+             "the retained :epoch-tape slot is the RAW tape (no stamp leak)")
+         (is (= (fingerprint/run-hash result)
+                (fingerprint/run-hash (dissoc result :narrative)))
+             "dropping the stamped :narrative does not change the run-hash")))))
 
 #?(:clj
    (deftest assert-dom-skipped-on-jvm-is-cannot-run


### PR DESCRIPTION
## Summary

The two-level narrative (`re-frame.story.play.evidence/narrative`) supported EXACT (per-epoch `:rf.story/script-idx` stamps -> `spans-from-stamps`) and EVEN (an arbitrary forward partition) beat->step attribution. The stamp key was READ in `explicit-beats?` but WRITTEN nowhere, so `explicit-beats?` was always false and **every** run (live + replayed) silently fell to the EVEN heuristic, which front-loads a re-dispatching step's fan-out onto the wrong authored step.

This is the **masterpiece-track (primary) fix** — exact attribution is now real, not the fallback.

## What changed

- **Producer (live):** `runner-events/run-loop!` + `run-step!` record, per frame, the epoch-history length at the start of each dispatch-opening step's settle (`step-boundaries`). `runtime/run-phase-4!` clears them per run; `record-result-map` reads them and threads `:attribution` into `result/run-result` -> `project-evidence`.
- **Producer (replay):** `artifact/replay-into-frame!` records the same per-dispatch-step boundaries on the returned outcomes vector's metadata (no contract change to the documented return value); `replay-result` reads `(:attribution (meta outcomes))` and threads it through. (Untouched: `replay-run-artifact` / `with-network-stubs!` network slot.)
- **Consumer (pure):** new `evidence/stamp-tape` maps the per-dispatch-step boundaries onto the raw tape, assigning `:rf.story/script-idx` (records before the first boundary -> nil leading setup span; a re-dispatch step's fan-out -> the producing step). `project-evidence` stamps **only** the narrative's input records — the verbatim `:epoch-tape` slot stays raw. `result/run-result` re-projected evidence without attribution, so it was threaded too (otherwise its unstamped `:narrative` overrode the stamped one).
- EVEN remains the documented, deterministic fallback when no boundaries were recorded (bare/hand-built tapes).

**Primary, not fallback** — the dead branch was made live; nothing was deleted.

## Determinism (verified)

`:narrative` is not in `run-hash-input-keys`, AND `:rf.story/script-idx` is a `:rf.story/*` accumulator key that `fingerprint/project` strips recursively at any depth (including inside the hashed `:epoch-tape` slice) — so the stamp cannot perturb the run-hash. The `:epoch-tape` slot is never stamped (only the narrative projection's input is). Two new tests assert `run-hash(result) == run-hash(dissoc result :narrative)` and that `:epoch-tape` carries no stamp key, on both the live and replay paths; the determinism + golden suites pass unchanged.

## Red/green attribution test

Discriminating case — two dispatch steps where the **second** re-dispatches (`[:dispatch-sync [:rkd/c]]` whose handler re-dispatches `:rkd/d`, settling to 2 committed epochs):

- **EVEN (RED):** `step0 = [[:rkd/a] [:rkd/c]]`, `step1 = [[:rkd/d]]` — mis-attributes `:rkd/c` to step 0.
- **EXACT (GREEN):** `step0 = [[:rkd/a]]`, `step1 = [[:rkd/c] [:rkd/d]]` — fan-out attaches to the producing step.

Tests added: `evidence-test/stamp-tape-from-settle-boundaries` (pure, incl. the EVEN-vs-EXACT grouping + leading-setup + no-boundary fallback), `artifact-test/replay-narrative-exact-attribution-of-redispatch-fanout` + `...-stamp-does-not-perturb-run-hash` (replay path, live frame), and `runner-events-cljs-test/run-variant-narrative-exact-attribution-of-redispatch-fanout` + `...-stamp-does-not-perturb-run-hash` (live runtime path). Each carries the RED-before EVEN-mis-grouping as a `not=` pin / inline comment.

## Quality gates

- `npm run test:cljs` — **5213 tests, 17826 assertions, 0 failures, 0 errors**
- Full Story JVM suite (`clojure -M:test`) — **1569 tests, 5838 assertions, 0 failures, 0 errors** (incl. determinism 14/56 + golden 14/68 green -> run-hash unaffected)
- clj-kondo — clean on all changed files (only 3 pre-existing baseline warnings: `pred-label`, `yield?`, `runner` unused-namespace; zero new)
- Determinism re-run — the two `...-stamp-does-not-perturb-run-hash` tests prove the run-hash is invariant to the stamp
- `tools/story/spec/*` untouched -> mkdocs not required

Closes rf2-rkd14. Do not merge (worker PR).