### PR TITLE
refactor(core): remove stale grace-timer refs + dead memo bindings + spine subvec drain (rf2-esfz4, rf2-zy689, rf2-5fmj3)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -635,9 +635,8 @@
   clear-fx    fx/clear-fx)
 
 (def ^{:doc "Dispose every cached entry in a frame's runtime sub-cache
-  and clear the cache. Cancels any pending grace-period timers before
-  disposing. For tests and hot-reload. Per spec/API.md §Clearing
-  registrations."}
+  and clear the cache. Disposal is synchronous and unconditional. For
+  tests and hot-reload. Per spec/API.md §Clearing registrations."}
   clear-sub-cache! subs-cache/clear-sub-cache!)
 
 ;; ---- dispatch and subscribe ----------------------------------------------

--- a/implementation/core/src/re_frame/interop.cljs
+++ b/implementation/core/src/re_frame/interop.cljs
@@ -99,11 +99,10 @@
 ;; / `now-ms` in `re-frame.interop`. These are the spec-canonical names
 ;; the machines timer layer (`re-frame.machines.timer`) reaches for; the
 ;; generic `set-timeout!` / `clear-timeout!` above stay the host-timeout
-;; primitive every other core surface (`:dispatch-later`, the sub-cache
-;; grace timer, the spine dispose timer, HTTP retry) uses. Same
-;; setTimeout / clearTimeout realisation; distinct, intention-named
-;; surfaces so an AI re-implementing the machines clock from Spec 005
-;; finds the names the spec promises.
+;; primitive every other core surface (`:dispatch-later`, HTTP retry)
+;; uses. Same setTimeout / clearTimeout realisation; distinct,
+;; intention-named surfaces so an AI re-implementing the machines clock
+;; from Spec 005 finds the names the spec promises.
 (def schedule-after!  set-timeout!)
 (def cancel-scheduled! clear-timeout!)
 

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -375,8 +375,7 @@
           ;; first cached value happens to be `nil`. The
           ;; `validate-and-trace` emit then stamps `:rf.sub/first-run?`
           ;; from `(= unset prev-value)`.
-          (let [first-run?  (= ::unset @last-db)
-                prev-result (if first-run? unset @last-result)
+          (let [prev-result (if (= ::unset @last-db) unset @last-result)
                 computed    (validate-and-trace
                               body-fn (list db) query-id query-v
                               frame-id [] sub-meta prev-result unset)]
@@ -437,8 +436,7 @@
           ;; the `::unset` sentinel here). `last-result` is `nil` then
           ;; too but keying on `last-v0` keeps the discriminator well-
           ;; defined regardless of the first cached value's shape.
-          (let [first-run?   (= ::unset @last-v0)
-                prev-result  (if first-run? unset @last-result)
+          (let [prev-result  (if (= ::unset @last-v0) unset @last-result)
                 prev-v0      @last-v0
                 prev-in-vals (if (= unset prev-v0)
                                unset
@@ -496,8 +494,7 @@
           ;; still the `::unset` sentinel here). Keying on `last-in-vals`
           ;; rather than `last-result` so a sub whose first cached value
           ;; is `nil` still flags as `:first-run?` true.
-          (let [first-run?   (= ::unset @last-in-vals)
-                prev-result  (if first-run? unset @last-result)
+          (let [prev-result  (if (= ::unset @last-in-vals) unset @last-result)
                 prev-in-vals @last-in-vals
                 computed     (validate-and-trace
                                body-fn in-vals query-id query-v

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -115,16 +115,36 @@
   [{:keys [flushing? queue queued] :as _scheduler}]
   (when-not @flushing?
     (vreset! flushing? true)
-    (try
-      (loop []
-        (when (seq @queue)
-          (let [thunk (nth @queue 0)]
-            (vreset! queue (subvec @queue 1))
-            (vswap! queued disj thunk)
-            (thunk))
-          (recur)))
-      (finally
-        (vreset! flushing? false)))))
+    ;; Walk the live `@queue` by index rather than re-slicing the head: a
+    ;; thunk may `schedule-flush!` downstream thunks, which `conj` onto the
+    ;; same vector, so re-reading `(count @queue)` each step keeps the
+    ;; running loop observing newly-enqueued thunks in enqueue order —
+    ;; identical to the previous incremental-`subvec` drain, but without
+    ;; building a chain of nested subvec views per cascade step. The
+    ;; cursor advances and the entry leaves `queued` BEFORE the thunk runs,
+    ;; so a thunk that throws is already considered consumed (matching the
+    ;; old head-pop-before-call ordering); the `finally` then compacts
+    ;; `@queue` to exactly the not-yet-drained tail on every exit path.
+    (let [cursor (volatile! 0)]
+      (try
+        (loop []
+          (when (< @cursor (count @queue))
+            (let [thunk (nth @queue @cursor)]
+              (vswap! queued disj thunk)
+              (vswap! cursor inc)
+              (thunk))
+            (recur)))
+        (finally
+          ;; Drop the drained prefix in ONE pass (a single fresh vector,
+          ;; not a per-step subvec chain): normally the tail is empty so
+          ;; this releases the backing vector for the next epoch; on a
+          ;; thunk throw it leaves the un-drained remainder, exactly as the
+          ;; incremental-subvec drain did.
+          (let [q @queue]
+            (vreset! queue (if (< @cursor (count q))
+                             (into [] (subvec q @cursor))
+                             [])))
+          (vreset! flushing? false))))))
 
 (defn- schedule-flush!
   "Enqueue `thunk` on the scheduler (dedup by identity within the current


### PR DESCRIPTION
Three localized Core senior-review cleanups, all in `implementation/core` (disjoint surfaces from in-flight workers). Pre-alpha masterpiece stance — CLARITY + GOOD PRACTICE; the review flagged these as shallow, localized debt.

## rf2-esfz4 — stale grace-timer references (CLARITY)
`rf2-cmfln` replaced sub-cache disposal with synchronous-on-ref-count-zero and removed the deferred grace-period / spine-dispose timers, but two sites still referenced them as if live:
- `interop.cljs` — the `set-timeout!` caller inventory listed "the sub-cache grace timer, the spine dispose timer" among its callers. Removed; the real callers (`:dispatch-later` + HTTP retry) remain.
- `core.cljc` — the `clear-sub-cache!` docstring claimed it "Cancels any pending grace-period timers before disposing." Replaced with "Disposal is synchronous and unconditional."
Cache entry shape deliberately untouched (left for rf2-spnfk).

## rf2-zy689 — dead `first-run?` let-bindings (CLARITY)
Inlined the `first-run?` local in all three memo wrappers (`subs/memo.cljc` layer-1 / layer-n-1 / layer-n). It was bound then read exactly once on the next line for `prev-result` — a name carrying no further significance. The downstream `:rf.sub/first-run?` trace slot is derived independently in `validate-and-trace` from `(= unset prev-value)` and is unaffected. No behaviour change.

## rf2-5fmj3 — spine subvec drain (PERF watch, P4)
Converted `drain-scheduler!` from repeated head-`subvec` to an index cursor over the live `@queue`, so wide cascades no longer build a chain of nested subvec views (the old code rebound `@queue` to `(subvec @queue 1)` per step → wrapper-chain depth = cascade width).

**Behaviour-preserving — proof:**
- The loop still re-reads `(count @queue)` each step, so downstream thunks that `schedule-flush!` (`conj` onto the same live vector) are observed in enqueue order — identical FIFO + topological-order semantics.
- The cursor advances and the entry leaves `queued` **before** the thunk runs, matching the old pop-before-call ordering: a thunk that throws is already considered consumed.
- A single `finally` pass compacts `@queue` to exactly the not-yet-drained tail on **every** exit path — `[]` on normal completion (releases the backing vector), the un-drained remainder on a thunk throw. This matches the old incremental-subvec post-throw state exactly (verified entry-by-entry: same remaining queue, same `queued` set).
- Re-entrancy guard (`flushing?`) and dirty-flag dedup are untouched; glitch-free single-recompute-against-settled-inputs semantics are identical.
- Allocation win is the only observable difference: O(1) cursor increments + one final compaction vs. an N-deep subvec view chain.

No spec files touched (those are rf2-spnfk's).

## Quality gates
- `npm run test:cljs` — **5221 tests / 17872 assertions, 0 failures, 0 errors** (covers the spine glitch-free epoch / diamond / chain dedup tests, plus interop.cljs + memo on CLJS).
- JVM core (`clojure -M:test` from `implementation/core`) — **843 tests / 3765 assertions, 0 failures, 0 errors** (covers core.cljc + memo.cljc on JVM).
- clj-kondo — no new warnings on any of the four files; memo.cljc warning count unchanged (2 pre-existing classpath-isolation `Unresolved var: interop/*` notices). The dead-binding removal is a clarity reduction (kondo did not flag `first-run?` since it was read once), not a kondo-count drop.
- `npm run test:elision` — **PASS: production 40/40 absent, control 40/40 present** (substrate-sensitive gate green).
- Micro-bench: none run — the win is allocation/retention only and below the perf-budget noise floor for typical cascades; the gain is asymptotic under wide fan-out.

Closes rf2-esfz4, rf2-zy689, rf2-5fmj3. Do not merge — mayor merges.