### PR TITLE
refactor(examples): login ratom-correct component state + realworld request docstring (rf2-av8jc, rf2-tln4a)

### DIFF
--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -48,6 +48,7 @@
   ;; stock-vs-slim contrast pair; the rest of the catalogue defaults to
   ;; slim.)
   (:require [reagent.dom.client :as rdc]
+            [reagent.core :as reagent]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             ;; The Spec 010 schema-attachment ns lives in
@@ -329,12 +330,14 @@
 ;; frame (no ambient lookup, survives async callbacks).
 
 ;; Form-2 view: the outer fn captures local component state in `state`
-;; (a Reagent atom kept across renders); the inner fn is the actual
-;; render fn. dispatch / subscribe are auto-injected and visible in
-;; both the outer and inner fn bodies.
+;; — a *reactive* `reagent.core/atom` kept across renders, the idiomatic
+;; Reagent primitive for component-local render state (matching todomvc,
+;; which reserves a bare `(atom ...)` only for non-render refs). The
+;; inner fn is the actual render fn. dispatch / subscribe are
+;; auto-injected and visible in both the outer and inner fn bodies.
 (reg-view ^{:doc "The login form view: email + password + submit button + error display."}
           login-form []
-  (let [state (atom {:email "" :password ""})]
+  (let [state (reagent/atom {:email "" :password ""})]
     (fn []
       (let [busy? @(rf/machine-has-tag? :auth.login/flow :auth/busy)
             err   @(subscribe [:auth.login/error])]

--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -77,9 +77,9 @@
    Body, if a clj coll, is JSON-encoded (`:request-content-type :json`).
    Decode defaults to `:json` (RealWorld returns JSON everywhere).
 
-   Use:
-     (rf/app-db-value ...) reads `:frame` from the cofx; pass through
-     here as `:frame` if you need a non-default frame.
+   The optional `:frame` arg selects which frame's auth slice the token
+   is read from (defaulting to `:rf/default`). In an event handler, pass
+   the cofx `:frame` through here if you need a non-default frame.
 
    Example:
      {:fx [[:rf.http/managed


### PR DESCRIPTION
Two examples-polish fixes from the senior-dev /examples review (CLARITY — examples are teaching artefacts).

## rf2-av8jc — login bare-atom ratom footgun
`login-form` bound component-local form state with a bare `(atom {:email "" :password ""})`. It only worked because the inputs are uncontrolled (no `:value`, only `:on-change` writing into `@state`, read once at submit) — the moment a learner adds `:value` toward a controlled input, the bare atom silently fails to re-render. login is the canonical cross-substrate base (mirrored 1:1 to UIx/Helix), so this is a high-visibility teaching surface.

Fix: switch to a reactive `reagent.core/atom` (added `[reagent.core :as reagent]` require; login is on **stock** Reagent). This matches the **todomvc idiom** — `todomvc/views.cljs` uses `(reagent/atom false)` for render-driving `editing?` state and reserves bare `(atom nil)` for non-render refs (input-node, suppress-blur). Behaviour-preserving; login still works.

## rf2-tln4a — realworld request docstring
`realworld/http.cljs` `request` docstring's 'Use:' clause misdescribed the API: it said `(rf/app-db-value ...) reads :frame from the cofx`, conflating two unrelated things (`app-db-value` takes a *frame-id* and returns the deref'd db value — it does not read `:frame` from the cofx). Rewrote to state plainly that the optional `:frame` arg selects which frame's auth slice the token is read from (defaulting to `:rf/default`), and that in a handler you pass the cofx `:frame` through. Verified against the current API (`re-frame.core/app-db-value` at core.cljc:1183, called as `(rf/app-db-value (or frame :rf/default))` by `token-from-frame`). Docstring-only.

Added **zero** `*.spec.cjs` (examples are test-free, rf2-8cevm).

## Quality gates
- `npm run test:examples` → Ran 3 example specs. 0 failures, 0 skipped. (reagent/uix/helix testbeds compiled, 0 warnings)
- clj-kondo on both edited files → errors: 0, warnings: 0 (0 new)
- Both examples BUILD: `shadow-cljs compile :examples/login :examples/realworld` → both 'Build completed' with 0 warnings
- Added zero `*.spec.cjs`