### PR TITLE
fix(story): promotion provenance link preserves :network for replay re-derivation (rf2-87duu)

### DIFF
--- a/tools/story/src/re_frame/story/promotion.cljc
+++ b/tools/story/src/re_frame/story/promotion.cljc
@@ -51,10 +51,13 @@
   so provenance reads the same everywhere. The link is a TRIMMED
   provenance view (`provenance-link`): the replayable + identifying core
   (`:artifact/kind`, `:seed`, `:event-program`, `:fx-decisions`,
-  `:shrink-path`, `:created-at`, `:source`) WITHOUT the bulky captured
-  evidence (`:epoch-tape`, `:trace`, `:result`). A curated variant can
-  explain where it came from and re-derive the run; it does not drag a
-  full epoch tape into the registrar side-table.
+  `:network`, `:shrink-path`, `:created-at`, `:source`) WITHOUT the bulky
+  captured evidence (`:epoch-tape`, `:trace`, `:result`). `:network`
+  rides the core (not the evidence) because replay RE-INSTALLS the
+  per-route stubs from it; without it a `:network`-stubbed run cannot be
+  re-derived (rf2-tymyh, rf2-87duu). A curated variant can explain where
+  it came from and re-derive the run; it does not drag a full epoch tape
+  into the registrar side-table.
 
   ## Purity / elision
 
@@ -80,8 +83,21 @@
   AND to re-derive the run. Deliberately EXCLUDES the bulky captured
   evidence (`:epoch-tape`, `:trace`, `:result`) — a registered variant
   body is a curation surface, not an evidence dump; the full evidence
-  lives on the original artifact the tool keeps."
-  #{:artifact/kind :seed :event-program :fx-decisions
+  lives on the original artifact the tool keeps.
+
+  `:network` is in the core because it is load-bearing for re-derivation,
+  not bulk: the `:fx-decisions` managed-stub REDIRECT
+  (`{:rf.http/managed :rf.http/managed-test-stub}`) survives on its own,
+  but `replay-run-artifact` / `with-network-stubs!` RE-INSTALL the actual
+  per-route stubs from the artifact's `:network` map (rf2-tymyh,
+  spec/017 §The network surface). Drop it and a variant promoted from a
+  `:network`-stubbed run carries a link that fail-closes on every managed
+  HTTP request (\"no stub matched\") — a DIFFERENT run than the one
+  promoted, breaking the docstring's re-derivability promise. Route
+  replies are part of run identity (already in `:world :network` /
+  artifact `:network`), so the slot is replayable + identifying, not
+  evidence."
+  #{:artifact/kind :seed :event-program :fx-decisions :network
     :shrink-path :created-at :source})
 
 (defn provenance-link

--- a/tools/story/test/re_frame/story/promotion_test.cljc
+++ b/tools/story/test/re_frame/story/promotion_test.cljc
@@ -19,8 +19,16 @@
   fresh side-table per test via the fixture, and an explicit `:lookup`
   for `:extends` resolution where needed."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.epoch :as epoch]
+            [re-frame.frame :as frame]
+            [re-frame.http-managed]       ;; production managed-HTTP fx surface (:rf.http/managed)
+            [re-frame.http-test-support]  ;; stub install seam + canned-stub handlers
+            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story :as story]
             [re-frame.story.artifact :as artifact]
+            [re-frame.story.determinism :as determinism]
+            [re-frame.story.plan :as plan]
             [re-frame.story.promotion :as promotion]
             [re-frame.story.registrar :as registrar]))
 
@@ -32,8 +40,18 @@
 ;; Matches the `artifact_test` fixture shape — the function form runs on
 ;; both the JVM `clojure -M:test` runner and the node CLJS build.
 
+;; The headless run-artifact replay test (rf2-87duu) dispatches into a live
+;; frame, so the fixture installs the plain-atom adapter + a default frame and
+;; clears the epoch surface between tests (mirroring `artifact_test`). The pure
+;; materialize/promote tests are unaffected by the extra setup.
+
 (defn reset-side-table! [t]
   (registrar/clear-all!)
+  (epoch/clear-history!)
+  (epoch/clear-epoch-listeners!)
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (frame/ensure-default-frame!)
   (t))
 
 (use-fixtures :each reset-side-table!)
@@ -219,3 +237,91 @@
              (story/promote-run-artifact!
                art {:variant/id :story.counter/from-facade})))
       (is (registrar/registered? :variant :story.counter/from-facade)))))
+
+;; ===========================================================================
+;; rf2-87duu — the provenance link of a :network-stubbed run RE-DERIVES it
+;; ===========================================================================
+;;
+;; The whole point of the `:run-artifact` provenance link is re-derivability:
+;; the docstring promises the trimmed core is "enough to … re-derive the run".
+;; For a run promoted from a `:network`-stubbed run, that link must carry
+;; `:network` — the `:fx-decisions` managed-stub REDIRECT
+;; (`{:rf.http/managed :rf.http/managed-test-stub}`) survives, but the actual
+;; per-route stubs are RE-INSTALLED from the artifact's `:network` map by
+;; `with-network-stubs!` / `replay-run-artifact` (rf2-tymyh, artifact.cljc
+;; §44-56). Drop `:network` from `provenance-link-keys` and the link replays a
+;; DIFFERENT run: every managed request fail-closes on "no stub matched"
+;; (`:rf.http/transport`) instead of the recorded `:ok` reply.
+;;
+;; RED (without `:network` in provenance-link-keys): the link-replayed run's
+;;   `:got` is the synthesised "no stub matched" transport FAILURE — a
+;;   different run than the one promoted.
+;; GREEN (with it): the link round-trips to the SAME run — same matched route,
+;;   same recorded `:ok` reply — as a direct replay of the source artifact.
+
+(defn- register-network-event!
+  "Register a test event that issues a managed-HTTP request to `route`
+  ([method url]) and records the reply into app-db under `:got` (the reply
+  rides back to this same origin event as `:rf/reply`, Spec 014 §Reply
+  addressing). Mirrors the artifact_test helper so the round-trip exercises
+  the same managed-HTTP fail-close path."
+  [event-id [method url]]
+  (rf/reg-event-fx event-id
+    (fn [{:keys [db]} [_ msg]]
+      (if-let [reply (:rf/reply msg)]
+        {:db (assoc db :got reply)}
+        {:fx [[:rf.http/managed {:request {:method method :url url}
+                                 :decode  :json}]]}))))
+
+(defn- network-artifact
+  "Compile a `:network` variant plan for `routes` and coerce it through the
+  determinism gate's `->artifact` (the real materialize-to-artifact seam),
+  so the artifact carries both the `:network` route map and the
+  `:fx-decisions` managed-stub redirect — exactly what a recorded HTTP run
+  produces."
+  [routes script]
+  (let [variant-id :story.promo-net/v
+        plan       (plan/variant-plan
+                     variant-id
+                     {:lookup {variant-id {:network routes
+                                           :script  script}}})]
+    (determinism/->artifact plan)))
+
+(deftest promotion-link-of-network-run-re-derives-it
+  (testing "a variant promoted from a :network-stubbed run carries a
+            provenance link that ROUND-TRIPS through replay-run-artifact to
+            the SAME run (rf2-87duu — :network is load-bearing for replay)"
+    (register-network-event! :promo-net/get-cart [:get "/api/cart"])
+    (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
+          art    (network-artifact routes [[:dispatch [:promo-net/get-cart]]])
+          ;; the trimmed provenance link a promotion stores on :run-artifact
+          link   (promotion/provenance-link art)]
+
+      ;; The link must itself carry the network route map — it is the slot
+      ;; replay re-installs the per-route stubs from. (RED without the fix.)
+      (is (= routes (:network link))
+          "the provenance link preserves :network so replay can re-install
+           the route stubs (rf2-87duu — same class as rf2-tymyh)")
+
+      ;; A direct replay of the SOURCE artifact: the route matches and the
+      ;; recorded :ok reply is synthesised. This is the run that was promoted.
+      (let [src (artifact/replay-run-artifact art)]
+        (is (= :pass (:status src)))
+        (is (= :success (:kind (:got (:app-db src))))
+            "the source run matched the route stub"))
+
+      ;; Re-deriving from the LINK alone must reproduce the SAME run — the
+      ;; provenance link is replayable on its own (it carries :artifact/kind,
+      ;; :event-program, :fx-decisions, and — post-fix — :network). Without
+      ;; :network the managed request fail-closes on "no stub matched"
+      ;; (:rf.http/transport), a DIFFERENT run.
+      (let [from-link (artifact/replay-run-artifact link)
+            got       (:got (:app-db from-link))]
+        (is (= :pass (:status from-link))
+            "the link re-derives a passing run — NOT a fail-closed one")
+        (is (= :success (:kind got))
+            "the re-installed route stub matched on the LINK replay — NOT the
+             'no stub matched' transport failure that fail-closes without
+             :network in provenance-link-keys")
+        (is (= {:items [{:sku "A"}]} (:value got))
+            "the link round-trips to the SAME recorded reply as the source run")))))


### PR DESCRIPTION
## The fix (rf2-87duu, story senior-dev review)

`promotion/provenance-link-keys` (promotion.cljc) is the trimmed artifact-slot set a promoted variant preserves under its `:run-artifact` back-link, whose docstring promises it is *enough to re-derive the run*. It **omitted `:network`**.

Per the rf2-tymyh design (artifact.cljc §44-56): the `:fx-decisions` managed-stub REDIRECT (`{:rf.http/managed :rf.http/managed-test-stub}`) survives in the link, but the **actual per-route HTTP stubs are RE-INSTALLED from the artifact's `:network` map** by `with-network-stubs!` / `replay-run-artifact`. So a variant promoted from a `:network`-stubbed run carried a provenance link that **could not re-derive the run** — replay fail-closed on every managed HTTP request ("no stub matched", `:rf.http/transport`), producing a **different run** than the one promoted. Same class as rf2-tymyh.

**One-key fix:** add `:network` to `provenance-link-keys`. It is replayable + identifying (route replies are part of run identity — already in `:world :network` / artifact `:network`) and small versus the deliberately-excluded `:epoch-tape` / `:trace` / `:result` (NOT added). Docstrings updated to record why `:network` rides the replayable core, not the evidence.

## The round-trip test

New `promotion_test` case `promotion-link-of-network-run-re-derives-it`: builds a `:network` artifact via the real `determinism/->artifact` seam, takes the trimmed `provenance-link`, and asserts that replaying **the link alone** through `replay-run-artifact` round-trips to the **SAME run** as a direct replay of the source artifact — same matched route, same recorded `:ok` reply.

red/green proof (toggling `:network` in `provenance-link-keys`):

- **RED** (without `:network`): 3 failures — `(:network link)` is nil; the link-replay's `:got` is `:failure` (the synthesised "no stub matched" transport failure) not `:success`; the recorded reply value is lost. The source-artifact replay still passes, isolating the divergence to the trimmed link.
- **GREEN** (with `:network`): all pass — the link re-derives a passing run with the recorded `{:items [{:sku \"A\"}]}` reply.

## Quality gates

- `clojure -M:test` (full JVM story suite): **1565 tests, 5821 assertions, 0 failures, 0 errors** (includes the new case + existing promotion tests).
- `clojure -M:test -n re-frame.story.promotion-test` GREEN: 8 tests, 43 assertions, 0/0. RED proof (no `:network`): 3 failures as above.
- `npm run test:cljs` (node-runtime CLJS gate): **5212 tests, 17822 assertions, 0 failures, 0 errors** (promotion-test runs on the CLJS build too).
- `clj-kondo` on both changed files: 0 errors. (1 warning — `re-frame.story.artifact is required but never used` in promotion.cljc — is **pre-existing on origin/main**, not introduced here; left untouched to keep the change a focused one-key fix.)
- spec unchanged — no `tools/story/spec/*` touched, so no `mkdocs build --strict`.

Surface is disjoint from the in-flight story PRs #2804 (fingerprint) / #2805 (play/evidence + artifact): touches only `promotion.cljc` + `promotion_test.cljc`. Reads (does not edit) `artifact.cljc`'s `replay-run-artifact` / `with-network-stubs!`.

Closes rf2-87duu.