### PR TITLE
docs(skills): fix stale Xray router inventory + add Redux-DevTools anchor + complete redirect index (rf2-oftd9, rf2-cfsfv, rf2-qs6f8)

### DIFF
--- a/SKILL-REDIRECT.md
+++ b/SKILL-REDIRECT.md
@@ -38,6 +38,11 @@ Find your skill, scan the audience section for lines tagged with it.
 | `re-frame2-pair-retro` | Pair-session retrospective (no URL deps) | — |
 | `re-frame2-implementor` | Building a new impl in another host language | `[impl]` |
 
+> Two of the eight skills are intentionally absent from this table:
+> `re-frame2-xray` cites its own spec tree (`tools/xray/spec/*`), and
+> `re-frame2-improver` routes deep-dives to `skills/re-frame2/patterns/`
+> + `spec/`. Neither consumes the URLs below, so neither gets a row here.
+
 ## Section 1 — Building with the reference implementation
 
 Audience: `[app]` / `[setup]` / `[mig]` / `[pair]`. API + Guide + MIGRATION + Examples.

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -10,7 +10,7 @@ re-frame2 ships eight skills, colocated under [`skills/`](https://github.com/day
 
 The exact mechanics depend on the agent you're driving. In **Claude Code**, install a skill by copying its directory into a project-level `.claude/skills/<name>/` (or globally into `~/.claude/skills/<name>/`). Once installed, the skill's `description` triggers it whenever the conversation mentions one of its surfaces — you usually don't need to invoke it explicitly. You can also force-load it with `/skill <name>` if the agent's launcher supports slash-commands for skills.
 
-The repo's [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) is the single deep-dive index — every skill points at it for spec-corpus depth and EP rationale.
+The repo's [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) is the deep-dive index for the **spec-consuming** skills — they point at it for spec-corpus depth and EP rationale. (Two skills route their deep-dives elsewhere by design: `re-frame2-xray` cites its own `tools/xray/spec/*` tree, and `re-frame2-improver` routes to `skills/re-frame2/patterns/` + `spec/`.)
 
 ## The eight skills
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -69,9 +69,10 @@ re-frame2 ships **eight** skills, grouped by the situation they cover:
   **Xray**, the re-frame2 in-app devtools panel. Answers how to *launch*
   Xray (true-inline panel, pop-out, programmatic `init!`, wired hotkeys,
   the Dynamic ↔ Static mode toggle) and *which tab shows X* — across the
-  7 Dynamic event-spine tabs (Event / App DB / View / Trace / Machines /
-  Routing / Issues) and the 5 Static registry-browse
-  tabs (Machines / Routes / Schemas / Flows / Interceptors). Xray owns
+  6 Dynamic event-spine tabs (Epoch (hero) / app-db / Views / Trace /
+  Machine / Routes) and the 5 Static registry-browse
+  tabs (Machines / Routes / Schemas / Flows / Interceptors). There is no
+  Issues tab — issues surface inline. Xray owns
   the *seeing*; `re-frame2-pair` owns the *driving*.
 
 - **[`re-frame2-pair/`](./re-frame2-pair/)** — pair-program with a live
@@ -124,7 +125,7 @@ of duplicating.
 | Bootstrap a brand-new re-frame2 ClojureScript project from nothing (or an empty CLJS project with shadow-cljs/Clojure but zero re-frame2 wiring) | "start a re-frame2 project", "scaffold re-frame2", "hello-world re-frame2 app", "new re-frame2 app", build failure on a freshly-scaffolded project tracing to missing `re-frame.core` / `re-frame.adapter.reagent` wiring | [`re-frame2-setup/`](./re-frame2-setup/) |
 | Write new application code on a working re-frame2 project | events, subs, fx, cofx, frames, state machines, schemas, stories, routing, canonical patterns; `reg-event-*`, `reg-sub`, `reg-fx`, `reg-machine`, `reg-view`, `reg-route`, `reg-story`, `reg-app-schema`, `dispatch`, `subscribe`, `app-db` | [`re-frame2/`](./re-frame2/) |
 | Migrate an existing re-frame v1.x ClojureScript codebase to re-frame2 | "migrate to re-frame2", "upgrade re-frame", "v1 to v2", "what breaks under re-frame2", or any v1 surface (`re-frame.db`, `dispatch-with`, `reg-global-interceptor`, `reg-sub-raw`, `^:flush-dom`, `re-frame.alpha`, `re-frame-test`, old top-level `:dispatch` / `:dispatch-n` effect-map keys) | [`re-frame-migration/`](./re-frame-migration/) |
-| Tour the **Xray** in-app devtools panel — how to launch it (true-inline, pop-out, programmatic `init!`, hotkeys, the Dynamic ↔ Static mode toggle) or **which tab / mode surfaces X** | "open Xray", "where is X in Xray", "which Xray panel/tab shows…", "Xray Static mode", "browse registered machines/routes/schemas in Xray", "Ctrl+Shift+C", "Xray hotkey", "Xray popout", "Xray machine inspector / issues feed" — the user wants to *read* the panel, not drive a runtime | [`re-frame2-xray/`](./re-frame2-xray/) |
+| Tour the **Xray** in-app devtools panel — how to launch it (true-inline, pop-out, programmatic `init!`, hotkeys, the Dynamic ↔ Static mode toggle) or **which tab / mode surfaces X** | "open Xray", "where is X in Xray", "which Xray panel/tab shows…", "Xray Static mode", "browse registered machines/routes/schemas in Xray", "Ctrl+Shift+C", "Xray hotkey", "Xray popout", "Xray machine inspector", "Xray epoch cascade", "where do Xray issues show up" — the user wants to *read* the panel, not drive a runtime | [`re-frame2-xray/`](./re-frame2-xray/) |
 | Pair-program against a **running** re-frame2 application — attach to a live shadow-cljs nREPL, inspect a frame's `app-db`, dispatch events, hot-swap handlers, walk traces / epochs, time-travel with `restore-epoch` | live runtime is involved; user is operating on (or wants to operate on) a running local app | [`re-frame2-pair/`](./re-frame2-pair/) |
 | Retrospect on a `re-frame2-pair` session and turn it into prioritised improvement ideas for the pair-tool skill, scripts, MCP surface, or upstream `re-frame2` Tool-Pair contract | concrete `re-frame2-pair` session in the conversation **or** a user-supplied recap of one; user explicitly asks for a retro ("retro on this pair session", "review my re-frame2-pair session", "draft a bead about that"), OR a post-error post-mortem trigger fires within a live re-frame2-pair session | [`re-frame2-pair-retro/`](./re-frame2-pair-retro/) |
 | Build a **new re-frame2 implementation** in a different host language or substrate (TypeScript, F# / Fable, Kotlin/JS, Squint, Scala.js, PureScript, ReScript, Python, Rust, native UI, terminal, …) — porting the pattern, not building an app on the CLJS reference | "port re-frame2", "implement re-frame2 in &lt;language&gt;", "second re-frame2 implementation", "implementor checklist", "conformance corpus", or any prompt about building re-frame2 itself | [`re-frame2-implementor/`](./re-frame2-implementor/) |

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -27,12 +27,31 @@ allowed-tools:
 
 # re-frame2-xray
 
-A tour skill for **Xray** — the re-frame2 in-app devtools panel. Xray is
-the structural successor to re-frame-10x: where v1 organised debugging
-around the *epoch panel*, Xray organises it around the *story a cascade
-tells*. Every dispatch is a node in a graph of causes; every state delta
-is a slice you can scrub; every machine transition lands on a chart; every
-schema violation surfaces as an issue you cannot miss.
+A tour skill for **Xray** — the re-frame2 in-app devtools panel. Every
+dispatch is a node in a graph of causes; every state delta is a slice you
+can scrub; every machine transition lands on a chart; every schema
+violation surfaces as an issue you cannot miss.
+
+## Mental model: think in Redux DevTools, map onto Xray
+
+If you know **Redux DevTools** (and **React DevTools Profiler** for the
+re-render-cause surfaces), you already know 80% of Xray: it's the same
+genus — a state-debugging devtools panel with time-travel and an
+inspectable log of state changes — applied to re-frame2's event cascades.
+Anchor on that, then note the deliberate divergences.
+
+| Redux DevTools concept | Xray counterpart | Deliberate divergence |
+|---|---|---|
+| Action log (the left-rail list of dispatched actions) | The **L2 event spine** — one row per dispatched event, live-tailing | Each row is an *epoch* (a full six-domino cascade), not a single reducer call — far richer than an action entry |
+| Inspecting one action's state diff | The **Epoch** tab (hero) — the focused dispatch's numbered cascade, DISPATCH → COEFFECTS → HANDLER → FLOWS → SIDE EFFECTS → SUBSCRIPTIONS → VIEWS | Redux shows action + state diff; the Epoch cascade shows the *whole causal chain* (cofx, interceptors, fx, flows, sub recompute, re-render), not just before/after state |
+| Time-travel / "jump to state" replay | The **scrubber · rewind · pins** chrome | **Passive by default** — scrubbing rebases the panels but does NOT move `app-db`; moving the live app is the explicit, confirmed `r` / `Shift+r` rewind (`restore-epoch`). Redux's slider *replays dispatches* into the store; Xray inverts that. |
+| State tree inspector | The **app-db** tab — sectioned, lazy-tree, inline diff annotations | Sectioned by reserved area (machines, routes, system-ids…) with downstream-subs hover, not a raw single tree |
+| React DevTools Profiler "why did this render?" | The **Views** tab — render-cause chips (`← :sub-id` vs `← props`) on every re-render leaf | Built into the same panel and tied to the epoch, not a separate profiler tab |
+| *(no Redux equivalent)* | **Static mode** — event-INDEPENDENT browse of what's *registered* (machines / routes / schemas / flows / interceptors) | Redux has no "what's registered?" surface; this is the registry-catalogue half Xray adds |
+
+(Xray is also the structural successor to re-frame-10x — re-frame2's own
+v1-internal predecessor — but it does not depend on or reference it; that
+lineage note matters mainly to v1-migrating users.)
 
 This skill answers three questions, and only three:
 


### PR DESCRIPTION
Three related fixes from the expert skills-tree review (skills routing + xray-skill coherence). One PR.

## rf2-oftd9 (P1) — stale Xray router inventory
`skills/README.md`'s single-source router carried a stale Xray inventory: **7 Dynamic tabs incl. the retired Issues tab + the old 'Event' hero**. Corrected to the authoritative **6 Dynamic tabs (Epoch (hero) / app-db / Views / Trace / Machine / Routes)**, dropped Issues (no dedicated tab — issues surface inline, per Mike's ruling rf2-gbz39 #2540), and aligned the router's trigger-phrase row with the xray SKILL.md (`"Xray machine inspector / issues feed"` → `"Xray machine inspector", "Xray epoch cascade", "where do Xray issues show up"`). The router now agrees with `skills/re-frame2-xray/SKILL.md` and `docs/skills/re-frame2-xray.md` (both already correct).

## rf2-cfsfv (P2) — Redux-DevTools anchor
Added a **"Mental model: think in Redux DevTools, map onto Xray"** table near the top of `skills/re-frame2-xray/SKILL.md`, mirroring stories.md's Storybook table shape. Anchors to the dominant training-data-present JS analog (Redux DevTools + React DevTools Profiler for re-render cause) and flags the deliberate divergences: passive-by-default scrubbing (panels rebase; `app-db` does NOT move) vs Redux's dispatch-replay slider; Static registry-browse has no Redux equivalent; the Epoch cascade shows the whole causal chain, richer than a Redux action diff. Kept the re-frame-10x lineage as a secondary note for v1-migrating users.

## rf2-qs6f8 (P3) — redirect-index claim
**Resolution: fix-the-claim** (not add-spurious-rows). The asymmetry is correct — xray + improver legitimately don't consume the redirect's URL table (xray cites `tools/xray/spec/*`; improver routes to `skills/re-frame2/patterns/` + `spec/`). Softened the over-broad "every skill points at it" claim in `docs/skills/index.md` to "the deep-dive index for the **spec-consuming** skills", and added a note to `SKILL-REDIRECT.md`'s index table explaining the two intentional omissions so the 6-of-8 table reads as designed, not as drift. `skills/README.md`'s "single source" claim is about the **routing table** (per-skill SKILL.md files point at the README router) — a different, accurate claim — so it was left as-is.

## Quality gates
- **Skills structural tests (changed skill paths only)** — PASS. `re-frame2-pair` bb suite (prompts + runtime/*_test.clj + shim): 0 failures, 0 errors; `shared` retro-protocol test: 29 tests / 44 assertions, 0 failures.
- **Skill-redirect anchor drift** (`scripts/check_skill_redirect_anchors.py`) — PASS (exit 0; edited SKILL-REDIRECT.md, no label drift).
- **Skill ↔ MCP allowed-tools drift** (`scripts/check_skill_mcp_drift.py --verbose --ci`) — PASS (no drift).
- **Router / redirect-index self-consistency** — verified: all referenced skills exist (8 in `skills/`); redirect index = 6 rows + a note covering the 2 designed omissions = 8 accounted for; no stale "7 Dynamic" / "Issues tab" / "every skill points" residue in tracked skills/docs; no broken intra-skill links.
- **mkdocs build --strict** — PASS (exit 0; `docs/skills/index.md` is a docs-site page). Trailing INFO is a pre-existing unrelated relative-link notice in `the-mayor-method.md`, not an error.

Closes rf2-oftd9, rf2-cfsfv, rf2-qs6f8.