### PR TITLE
feat(xray): tab-ribbon Reset-to-event + relabel 'selected' + error-row selection visibility (rf2-hga49)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -117,8 +117,15 @@
    ;; light-pink wash Xray paints behind an L2 event row whose epoch
    ;; contains an issue. machines-viz never paints it, but the drift gate
    ;; (rf2-z7ms8) requires the dark-palette key set to match Xray's, so the
-   ;; token is mirrored here at its Xray value.
-   :bg-issue-row   "#f8514926"
+   ;; token is mirrored here at its Xray value. rf2-hga49 paled it (~15% →
+   ;; ~10%) so Xray's darker selected-row-bg reads through it — mirrored.
+   :bg-issue-row   "#f851491a"
+
+   ;; L2 selected-row background (rf2-hga49 · key parity mirror with Xray).
+   ;; Xray's darker-than-hover selected-row fill. machines-viz never paints
+   ;; it, but the dark drift gate (rf2-z7ms8) asserts full key-set parity,
+   ;; so the key is mirrored here at its Xray value.
+   :selected-row-bg "#3a3a3a"
 
    ;; functional categorical hues (spec/022 carve-out)
    ;; Two pink/violet-family hues — see Xray's `dark-palette` block for
@@ -221,7 +228,14 @@
    ;; light-theme mirror of Xray's `:bg-issue-row`. machines-viz never
    ;; paints it; mirrored here at its Xray value so the two light palettes
    ;; stay symmetric (the dark drift gate asserts full key-set parity).
-   :bg-issue-row   "#c844442e"
+   ;; rf2-hga49 paled it (~18% → ~12%) in lock-step with Xray.
+   :bg-issue-row   "#c844441f"
+
+   ;; L2 selected-row background (rf2-hga49 · key parity mirror with Xray).
+   ;; Light-theme mirror of Xray's darker-than-hover selected-row fill.
+   ;; machines-viz never paints it; mirrored so its own light/dark key sets
+   ;; stay symmetric and the Xray↔machines-viz dark drift gate passes.
+   :selected-row-bg "#d4d4d4"
 
    ;; functional categorical hues
    ;; Two pink/violet-family hues — see Xray's `light-palette` block for

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -317,11 +317,16 @@ below remains the canonical shape; this callout records what the
 
 **rf2-pjjwh — clean Figma mock layout.** ONE row shape, four columns,
 matching the Figma EventList exactly. The active (selected) row is marked
-by BACKGROUND ONLY (`bg-[var(--devtools-hover)]`):
+by a darker `:selected-row-bg` background **plus a leading `>` caret**
+(rf2-hga49 — see [Selected-row visibility](#selected-row-visibility-rf2-hga49)
+below; the background-only mock failed on issue rows). A fixed-width 10px
+caret gutter leads every row (empty when not selected) so selecting never
+shifts the columns:
 
 ```
 │ Col          │ Width        │ Content                              │
 ├──────────────┼──────────────┼──────────────────────────────────────┤
+│ (caret)      │ 10px         │ > when selected, else empty          │
 │ Event id     │ flex mono    │ :order/submit (accent keyword colour)│
 │ Source       │ 52px         │ ui / fx / timer / router (muted)     │
 │ Timestamp    │ ≥76px        │ 12:30:05.123 (right-aligned)         │
@@ -329,7 +334,11 @@ by BACKGROUND ONLY (`bg-[var(--devtools-hover)]`):
 ```
 
 rf2-pjjwh RETIRED these decorations the mock did not carry: the leading
-focus gutter (+ its glyph `● ◉ x ▥`), the origin-prefix glyph before the
+focus gutter (+ its glyph `● ◉ x ▥`) — note rf2-hga49 later reintroduced a
+narrower 10px caret gutter carrying a single `>` selection glyph (a
+deliberate override of the background-only mock, which was indistinguishable
+on a selected issue row; see [Selected-row visibility](#selected-row-visibility-rf2-hga49)) —
+the origin-prefix glyph before the
 source tag, the activity badges (`⚠ 🌐 🤖`), the trailing 2px lifecycle
 status stripe, the redaction marker, and the out-of-focus dimming. The
 dropped fields (full event vector + args, sequence number, frame, source
@@ -398,6 +407,29 @@ glyph-free post-rf2-pjjwh).
   whether focused or not, with the focus state intact underneath), the LIVE
   head-pulse, and any cross-epoch perf-budget chrome. A clean (non-issue)
   row carries no wash.
+
+#### Selected-row visibility (rf2-hga49)
+
+The selection signal and the issue wash share the background channel, and a
+low-opacity pink wash painted over the (old) `:hover`-grey selection drowned
+the grey — a **selected error row was indistinguishable** from an unselected
+one. The contract is now a **three-part, coordinated treatment** so selection
+is unmistakable on any row state (clean / issue, focused / not):
+
+1. **Leading `>` caret** — a fixed-width 10px gutter leads every row,
+   carrying a single `>` glyph (accent colour) when the row is selected and
+   empty otherwise. Background-INDEPENDENT, so it reads through the wash.
+   The matching header carries an empty 10px gutter spacer so columns never
+   drift.
+2. **Darker `:selected-row-bg` background** — the selected background is the
+   dedicated `:selected-row-bg` token (a step darker than `:hover`) rather
+   than `:hover` itself, so selection reads as a state distinct from hover
+   AND shows through the wash.
+3. **Paler `:bg-issue-row` wash** — the issue wash alpha is lowered (dark
+   ~10%, light ~12%, moved in lock-step) so the darker grey reads through it.
+
+See [`022-Design-Tokens.md`](022-Design-Tokens.md) for the
+`:selected-row-bg` token + the paled `:bg-issue-row` values.
 
 ### Row variants
 
@@ -539,6 +571,40 @@ rf2-q7who Thread B):
 
 The `data-testid="rf-xray-tab-bar"` selector remains the canonical
 test addressing surface; ARIA is the user-facing assistive contract.
+
+### Tab-ribbon chrome — context label + Reset (rf2-hga49)
+
+The L3 tab ribbon (the dark band carrying the tab buttons) carries two
+chrome affordances besides the tabs:
+
+- **Context label (LEFT):** a `↳ selected` label (corner-down-right glyph
+  + muted text) signalling that the tabs below project the
+  currently-selected L2 event. (rf2-hga49 shortened the earlier
+  `for selected event` copy to `selected` — the glyph already carries the
+  sense.)
+- **`Reset` button (FAR RIGHT, after a `margin-left:auto` spacer):** the UI
+  half of the **inspect-vs-rewind** principle. Xray can inspect a past
+  epoch (passive); the `Reset` button (`↺`) **rewinds the live app** to it
+  (active). It dispatches `:rf.xray/reset-to-epoch` with the **observed**
+  frame (`:rf.xray/observed-frame` — the frame-switcher selection, NEVER
+  `:rf/xray`) and the **focused** epoch-id (`:rf.xray/focus-epoch-id`),
+  which trampolines into the `:rf.xray.fx/restore-epoch` effect →
+  `(rf/restore-epoch <observed-frame> <epoch-id>)`. The target is the
+  epoch's `:db-after` ("if the event still exists, app state must be as if
+  the event happened" — matches the shipped runtime, zero framework
+  change).
+  - **No dialog, no confirmation** — the button just does it (programmers
+    are power users). This is a deliberate departure from the deleted Time
+    Travel panel's modal-confirmation flow ([`002-Time-Travel.md`](002-Time-Travel.md)
+    §Restore failure modes / §Failure surfacing described the now-removed
+    panel's modal).
+  - **Disabled** (dimmed, `not-allowed` cursor) when no epoch is focused.
+  - **Failure** (the rare framework cases — epoch aged out of the buffer,
+    or a restore-during-drain rejection → `rf/restore-epoch` returns
+    `false`) sets `:rf.xray/reset-flash`, a brief **inline** message left of
+    the button (`role=status`), NEVER a modal — and never a silent lie. The
+    framework's structured `:rf.epoch/*` failure row also lands on the trace
+    bus, which the Trace tab surfaces.
 
 ### Detail panel layout
 

--- a/tools/xray/spec/022-Design-Tokens.md
+++ b/tools/xray/spec/022-Design-Tokens.md
@@ -97,6 +97,14 @@ one edit per token.
   alpha so the row text + other row signals stay legible and the wash COMPOSES over the
   selected/focused-row background. Full hex values live in `theme/tokens.cljc` (the source of
   truth for every token).
+- **L2 selected-row background (`selected-row-bg`, rf2-hga49):** the L2 event row's SELECTED
+  (focused) background — a step DARKER than `hover` so selection reads as a state distinct from
+  mere hover AND survives UNDER the `bg-issue-row` pink wash (which previously drowned the
+  `hover`-grey selection on an error row — the selected error row was indistinguishable from an
+  unselected one). The fix is three coordinated parts: this darker `selected-row-bg`, a leading
+  `>` caret in a fixed 10px gutter the focused row paints (background-INDEPENDENT), and a now-PALER
+  `bg-issue-row` (alpha lowered to ~10% dark / ~12% light, moved in lock-step) so the darker grey
+  reads through the wash. See [`018-Event-Spine.md`](018-Event-Spine.md) §Selected-row visibility.
 - **Views / recompute:** changed/recomputed highlight → `changed` (= `accent`); unchanged /
   short-circuited → `unchanged` (= `dim`). Use the accent sparingly (the changed node, not whole
   rows) so the UI doesn't over-saturate.

--- a/tools/xray/src/day8/re_frame2_xray/epoch.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/epoch.cljs
@@ -22,6 +22,9 @@
   - `mount.cljs` seeds `:rf.xray/sync-epoch-history` at first open.
   - `panels.app-db-diff-sections` dispatches `:rf.xray/select-epoch`
     when a section's epoch chip is clicked.
+  - `shell/tab-bar` dispatches `:rf.xray/reset-to-epoch` (rf2-hga49) —
+    the UI rewind affordance — and reads `:rf.xray/reset-flash` for the
+    inline failure flash.
 
   Splitting the plumbing out makes the cross-cutting intent visible:
   the slot is `:rf/xray`-frame state shared across every panel that
@@ -46,6 +49,35 @@
   (rf/reg-sub :rf.xray/selected-epoch-id
     (fn [db _query]
       (get db :selected-epoch-id)))
+
+  ;; rf2-hga49 — transient `reset-to-event` failure flash. Holds a short
+  ;; message string when a `rf/restore-epoch` rewind fails (epoch aged
+  ;; out of the buffer, or a restore-during-drain rejection). nil =
+  ;; nothing to show. The flash is INLINE on the tab ribbon — never a
+  ;; modal — and self-clears (the Reset event schedules the clear). A
+  ;; failure must never be a silent lie; it must also never block.
+  (rf/reg-sub :rf.xray/reset-flash
+    (fn [db _query]
+      (get db :reset-flash)))
+
+  ;; ---- effects -----------------------------------------------------------
+
+  ;; rf2-hga49 — `restore-epoch` is a side-effecting framework call (it
+  ;; rewinds an OBSERVED frame's `app-db` to a past epoch's `:db-after`),
+  ;; so it lives in an fx, not a `reg-event-db` reducer. `rf/restore-epoch`
+  ;; returns `false` on any of the six documented failure modes (per
+  ;; Tool-Pair §Time-travel — Restore) leaving the frame unchanged; on
+  ;; failure we dispatch the inline flash so the operator is told (never
+  ;; a silent lie). The framework also emits a structured `:rf.epoch/*`
+  ;; trace row on the bus — Xray's own Trace panel surfaces the specifics.
+  ;; re-frame2 fx handlers are `(fn [ctx args] …)` — `args` is the value
+  ;; from the `:fx` vector entry (here the `{:frame … :epoch-id …}` map).
+  (rf/reg-fx :rf.xray.fx/restore-epoch
+    (fn [_ctx {:keys [frame epoch-id]}]
+      (when (and frame epoch-id)
+        (let [ok? (rf/restore-epoch frame epoch-id)]
+          (when-not ok?
+            (rf/dispatch [:rf.xray/reset-flash-failed]))))))
 
   ;; ---- events ------------------------------------------------------------
 
@@ -150,5 +182,39 @@
       (-> db
           (assoc :selected-epoch-id epoch-id)
           (assoc-in [:focus :epoch-id] epoch-id))))
+
+  ;; `:rf.xray/reset-to-epoch` (rf2-hga49) — the UI rewind affordance.
+  ;; The tab ribbon's `Reset` button dispatches this with the OBSERVED
+  ;; frame (the frame Xray is inspecting — the frame-switcher selection,
+  ;; NOT `:rf/xray` Xray's own chrome frame) and the currently-focused
+  ;; epoch-id. The view supplies both from `:rf.xray/observed-frame` +
+  ;; `:rf.xray/focus-epoch-id` so this event stays a thin trampoline into
+  ;; the `:rf.xray.fx/restore-epoch` effect (which calls the framework's
+  ;; `rf/restore-epoch`, targeting the epoch's `:db-after` — "if the
+  ;; event still exists, app state must be as if the event happened").
+  ;; No dialog, no confirmation — the button just does it (programmers
+  ;; are power users). A nil frame / epoch-id is a guarded no-op (the
+  ;; button is disabled when no epoch is focused, but the event stays
+  ;; defensive).
+  (rf/reg-event-fx :rf.xray/reset-to-epoch
+    (fn [_cofx [_ frame epoch-id]]
+      {:fx [[:rf.xray.fx/restore-epoch {:frame frame :epoch-id epoch-id}]]}))
+
+  ;; `:rf.xray/reset-flash-failed` (rf2-hga49) — set the inline failure
+  ;; flash. Dispatched from `:rf.xray.fx/restore-epoch` when
+  ;; `rf/restore-epoch` returns false. `:rf.trace/no-emit? true` keeps
+  ;; Xray's own chrome event off the trace bus it is inspecting.
+  (rf/reg-event-db :rf.xray/reset-flash-failed
+    {:rf.trace/no-emit? true}
+    (fn [db _event]
+      (assoc db :reset-flash "Reset failed — epoch unavailable (see Trace)")))
+
+  ;; `:rf.xray/clear-reset-flash` (rf2-hga49) — clear the inline flash.
+  ;; Dispatched by the view's auto-dismiss timer / the next successful
+  ;; reset. `:rf.trace/no-emit? true` per the sibling rationale.
+  (rf/reg-event-db :rf.xray/clear-reset-flash
+    {:rf.trace/no-emit? true}
+    (fn [db _event]
+      (dissoc db :reset-flash)))
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -1448,11 +1448,22 @@
         source-tag     (l2-timeline/origin-source-tag source)
         ev-id       (event-id-of-cascade cascade)
         event-vec   (:event cascade)
-        ;; rf2-pjjwh — the active row is marked by BACKGROUND ONLY
-        ;; (Figma EventList's `isActive` → `bg-[var(--devtools-hover)]`).
-        ;; No border ring, no trailing status stripe — those are not in
-        ;; the mock.
-        bg          (if focused? (:hover tokens) "transparent")
+        ;; rf2-pjjwh — the active row is marked by background (Figma
+        ;; EventList's `isActive` → `bg-[var(--devtools-hover)]`). No
+        ;; border ring, no trailing status stripe — those are not in the
+        ;; mock.
+        ;;
+        ;; rf2-hga49 — the selected background is the dedicated
+        ;; `:selected-row-bg` (a step DARKER than `:hover`) rather than
+        ;; `:hover` itself. Two reasons: selection now reads as a state
+        ;; distinct from mere hover, AND the darker grey survives UNDER
+        ;; the issue-row pink wash (a low-opacity rose painted as a
+        ;; `:background-image` layer over this `:background-color`). With
+        ;; the old `:hover` grey + the prior heavier wash, a SELECTED
+        ;; ERROR row was indistinguishable from an unselected one — the
+        ;; wash drowned the selection. The leading ">" caret (below) is
+        ;; the background-independent belt-and-braces selection signal.
+        bg          (if focused? (:selected-row-bg tokens) "transparent")
         ;; rf2-b8guz — light-pink WASH when this event's epoch CONTAINS
         ;; AN ISSUE (any error / warning / schema-violation / … — the
         ;; SAME set the Issues ribbon/feed aggregates, via the canonical
@@ -1600,15 +1611,33 @@
                           :overflow      "hidden"
                           :text-overflow "ellipsis"}}
            ref-fn (assoc :ref ref-fn))
+     ;; rf2-hga49 — leading SELECTION CARET gutter. A small ">" glyph
+     ;; sits in a FIXED-WIDTH leading gutter when the row is focused, and
+     ;; the gutter renders empty (same width) otherwise — so selecting a
+     ;; row never shifts the columns. This is the background-INDEPENDENT
+     ;; selection signal: it reads on any row state (clean / issue) where
+     ;; the grey-vs-pink background channels can fight (the selected error
+     ;; row that prompted the bead). It consciously reintroduces the
+     ;; leading gutter glyph rf2-pjjwh removed for the Figma
+     ;; background-only mock — that mock is exactly what failed on an
+     ;; error row, so the override is deliberate.
+     [:span {:data-testid "rf-xray-row-selection-caret"
+             :aria-hidden "true"
+             :style {:flex-shrink 0
+                     :width "10px"
+                     :display "inline-flex"
+                     :align-items "center"
+                     :justify-content "center"
+                     :color (:accent tokens)
+                     :font-weight 700}}
+      (when focused? ">")]
      ;; rf2-pjjwh — column order: `event id` · `source` · `timestamp` ·
-     ;; `duration` (Figma-Make EventList). No leading focus gutter — that
-     ;; was a Xray affordance the mock didn't carry, retired with the
-     ;; focus feature. The bare event-id keyword leads the row as the
-     ;; primary read; the source tag follows as secondary context. The
-     ;; full event vector with args moves to the row's hover tooltip + the
-     ;; L4 Epoch panel detail. The event-id column is LEFT-aligned (Figma
-     ;; `text-left`) so the keyword sits flush under the header's
-     ;; `event id` label.
+     ;; `duration` (Figma-Make EventList). The bare event-id keyword leads
+     ;; the data columns as the primary read; the source tag follows as
+     ;; secondary context. The full event vector with args moves to the
+     ;; row's hover tooltip + the L4 Epoch panel detail. The event-id
+     ;; column is LEFT-aligned (Figma `text-left`) so the keyword sits
+     ;; flush under the header's `event id` label.
      [:span {:data-testid "rf-xray-row-event-id"
              :style {:flex "1 1 auto" :overflow "hidden"
                      :text-overflow "ellipsis"
@@ -1854,8 +1883,13 @@
                    :border        "1px solid transparent"
                    :background    (:bg-1 tokens)
                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
-     ;; rf2-pjjwh — no leading focus-gutter spacer (the gutter was a Xray
-     ;; affordance the mock didn't carry, retired with the focus feature).
+     ;; rf2-hga49 — empty leading-gutter spacer matching the data rows'
+     ;; 10px selection-caret gutter so the `event id` header label sits
+     ;; flush over the row keywords (no 10px column drift). Shares the
+     ;; row's gutter width + flex-shrink:0 exactly.
+     [:span {:data-testid "rf-xray-event-list-col-caret-gutter"
+             :aria-hidden "true"
+             :style {:flex-shrink 0 :width "10px"}}]
      ;; rf2-xawwb — column order is `event id` FIRST, then `source`
      ;; (Figma-Make surface). The event-id is the primary read; source is
      ;; secondary context, so the id leads. The `event id` column is
@@ -2133,9 +2167,30 @@
   mounted alongside a host nav, every Story integration test using
   the role failed (rf2-q7who Thread B — discovered via rf2-drprn).
   Per-tab buttons carry `role='tab'` + `aria-selected` (see
-  `tab-button`). `data-testid='rf-xray-tab-bar'` is unchanged."
+  `tab-button`). `data-testid='rf-xray-tab-bar'` is unchanged.
+
+  ## rf2-hga49 — `Reset` rewind button (far right)
+
+  The ribbon's far-right (after a `margin-left:auto` spacer) carries
+  the `Reset` button — the UI half of the inspect-vs-rewind principle.
+  It dispatches `:rf.xray/reset-to-epoch` with the OBSERVED frame
+  (`:rf.xray/observed-frame` — the frame-switcher selection, NOT
+  `:rf/xray`) and the currently-focused epoch-id
+  (`:rf.xray/focus-epoch-id`), rewinding that frame's live `app-db` to
+  the epoch's `:db-after`. No dialog, no confirmation. Disabled when
+  no epoch is focused. On the rare framework failure (epoch aged out /
+  restore-during-drain) the effect sets `:rf.xray/reset-flash` — a
+  brief inline message, never a modal, never a silent lie."
   []
-  (let [selected @(rf/subscribe [:rf.xray/selected-tab])]
+  (let [selected     @(rf/subscribe [:rf.xray/selected-tab])
+        ;; rf2-hga49 — rewind target: the OBSERVED app frame + the
+        ;; focused epoch. `:subscribe` (the reg-view-injected handle)
+        ;; resolves both off `:rf/xray`'s own app-db where the spine
+        ;; lives, but the values it returns point at the OBSERVED frame.
+        observed     @(subscribe [:rf.xray/observed-frame])
+        focus-epoch  @(subscribe [:rf.xray/focus-epoch-id])
+        reset-flash  @(subscribe [:rf.xray/reset-flash])
+        can-reset?   (some? focus-epoch)]
     [:div {:data-testid "rf-xray-tab-bar"
            :role        "tablist"
            :aria-label  "Xray panel tabs"
@@ -2169,14 +2224,65 @@
                      :font-size    (:caption type-scale)
                      :white-space  "nowrap"}}
       [:span {:aria-hidden "true"} "↳"]
-      "for selected event"]
+      ;; rf2-hga49 — relabelled from `for selected event` to the terser
+      ;; `selected` (the glyph + styling already carry the "this is the
+      ;; selected event" sense; the long copy was redundant).
+      "selected"]
      ;; rf2-2moh1 — iterate `dynamic-tabs` (registry-derived) rather
      ;; than a literal vector. Tab order follows each entry's `:order`.
      (for [{:keys [id] :as tab} (dynamic-tabs)]
        ^{:key id}
        ;; rf2-r0o63 — thread the captured frame-aware dispatcher so the
        ;; tab click's select-tab write lands on the instance frame.
-       [tab-button (assoc tab :active? (= id selected) :dispatch-fn dispatch)])]))
+       [tab-button (assoc tab :active? (= id selected) :dispatch-fn dispatch)])
+     ;; rf2-hga49 — `margin-left:auto` spacer pushes the Reset cluster to
+     ;; the FAR RIGHT of the ribbon, past the tab buttons.
+     [:span {:data-testid "rf-xray-tab-bar-spacer"
+             :style {:margin-left "auto"}}]
+     ;; rf2-hga49 — the inline failure flash (rendered ONLY on failure).
+     ;; Sits just LEFT of the Reset button so the operator sees it where
+     ;; they clicked. `role=status` so AT announces it; never a modal.
+     (when reset-flash
+       [:span {:data-testid "rf-xray-reset-flash"
+               :role        "status"
+               :style {:align-self  "center"
+                       :margin-right "8px"
+                       :color       (:error tokens)
+                       :font-family sans-stack
+                       :font-size   (:caption type-scale)
+                       :white-space "nowrap"}}
+        reset-flash])
+     ;; rf2-hga49 — `Reset` rewind button. Dispatches
+     ;; `:rf.xray/reset-to-epoch` against the OBSERVED frame + focused
+     ;; epoch. Disabled (and visibly dimmed) when no epoch is focused.
+     ;; The icon is a unicode anticlockwise-arrow (↺) matching the
+     ;; lucide `RotateCcw` rewind glyph used elsewhere; inline SVG isn't
+     ;; idiomatic in this pure-hiccup view (see `ribbon-icons`).
+     [:button {:data-testid "rf-xray-tab-bar-reset"
+               :type        "button"
+               :disabled    (not can-reset?)
+               :title       (if can-reset?
+                              "revert the app to this state"
+                              "select an event to enable Reset")
+               :aria-label  "Reset the app to the selected event's state"
+               :on-click    (when can-reset?
+                              #(dispatch [:rf.xray/reset-to-epoch observed focus-epoch]))
+               :style {:display       "inline-flex"
+                       :align-items   "center"
+                       :gap           "4px"
+                       :align-self    "center"
+                       :background    "rgba(255,255,255,0.12)"
+                       :border        "none"
+                       :border-radius "4px"
+                       :color         (:chrome-ribbon-text-muted tokens)
+                       :cursor        (if can-reset? "pointer" "not-allowed")
+                       :opacity       (if can-reset? 1 0.4)
+                       :padding       "3px 10px"
+                       :font-family   sans-stack
+                       :font-size     (:caption type-scale)
+                       :white-space   "nowrap"}}
+      "Reset"
+      [:span {:aria-hidden "true"} "↺"]]]))
 
 ;; ---- L4 detail panel -----------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -114,6 +114,17 @@
    :dim            "#6e7681"   ; dimmed / inert / unchanged (Figma --devtools-unchanged)
    :hover          "#2a2a2a"   ; hover background (Figma --devtools-hover, = bg-3)
 
+   ;; ── L2 selected-row background (rf2-hga49) ──
+   ;; The L2 event row's SELECTED (focused) background — a step DARKER
+   ;; than `:hover` so selection reads as a distinct state from mere
+   ;; hover AND survives under the issue-row pink wash (which previously
+   ;; drowned the `:hover`-grey selection on an error row — the selected
+   ;; error row was indistinguishable from an unselected one). Paired
+   ;; with the now-paler `:bg-issue-row` below + the leading ">" caret
+   ;; the row paints when focused, so selection is unmistakable on any
+   ;; row state (clean / issue, focused / not).
+   :selected-row-bg "#3a3a3a"  ; darker than :hover (#2a2a2a) — selection (dark)
+
    ;; ── violation wash (rf2-xgeag) ──
    ;; Soft pink wash for the inline SCHEMA VIOLATION sub-block that
    ;; rides under its owning pipeline step. Distinct from the
@@ -134,9 +145,12 @@
    ;; Same rose hue as `:bg-violation` but as an 8-digit-hex wash
    ;; (#RRGGBBAA, mirroring the `:diff-*-wash` pattern) so it COMPOSES
    ;; over the focused-row / hover background without clobbering it.
-   ;; Alpha `26` = 38/255 ≈ 15% — operator-noticeable over the dark
-   ;; canvas while the row text + existing L2 signals stay legible.
-   :bg-issue-row   "#f8514926"  ; :error rose @ ~15% (dark)
+   ;; Alpha `1a` = 26/255 ≈ 10% (rf2-hga49 — paled from the prior `26`
+   ;; ≈ 15% so the darker `:selected-row-bg` grey reads THROUGH the wash
+   ;; on a selected error row; the wash stays an operator-noticeable
+   ;; cross-epoch cue while no longer fighting the selection signal on
+   ;; the same channel).
+   :bg-issue-row   "#f851491a"  ; :error rose @ ~10% (dark)
 
    ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
    ;; These do REAL semantic work — perf tiers, machine state, route
@@ -310,6 +324,12 @@
    :dim            "#8c959f"   ; Figma --devtools-unchanged
    :hover          "#e8e8e8"   ; Figma --devtools-hover
 
+   ;; ── L2 selected-row background (rf2-hga49) ──
+   ;; Light-theme mirror of the dark `:selected-row-bg` — a step DARKER
+   ;; than `:hover` so selection reads distinctly from hover and shows
+   ;; through the paled `:bg-issue-row` wash on a selected error row.
+   :selected-row-bg "#d4d4d4"  ; darker than :hover (#e8e8e8) — selection (light)
+
    ;; ── violation wash (rf2-xgeag) ──
    ;; Light-theme mirror of the dark `:bg-violation`. A soft rose
    ;; pink — alert-grade on white without overpowering the cascade.
@@ -320,9 +340,11 @@
    ;; wash painted behind an L2 row whose epoch contains an issue. An
    ;; 8-digit-hex wash (#RRGGBBAA) so it composes over the focused-row
    ;; / hover background. Light-theme washes need a touch more alpha
-   ;; than dark ones to read over the near-white canvas — alpha `2e` =
-   ;; 46/255 ≈ 18% of the light-error rose.
-   :bg-issue-row   "#c844442e"  ; :error rose @ ~18% (light)
+   ;; than dark ones to read over the near-white canvas — alpha `1f` =
+   ;; 31/255 ≈ 12% (rf2-hga49 — paled from the prior `2e` ≈ 18% so the
+   ;; darker `:selected-row-bg` grey reads through the wash on a selected
+   ;; error row; moves in lock-step with the dark variant above).
+   :bg-issue-row   "#c844441f"  ; :error rose @ ~12% (light)
 
    ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
    :green          "#1a7f37"

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -289,6 +289,9 @@
    :rf.xray.static.interceptors/registry
    :rf.xray.static.interceptors/registry-override
    :rf.xray.static.interceptors/tab-data
+   ;; rf2-hga49 — tab-ribbon Reset rewind affordance: the transient
+   ;; inline failure-flash slot the ribbon reads.
+   :rf.xray/reset-flash
    :rf.xray/selected-epoch-diff
    ;; rf2-39n8h discovered — selected-epoch composites: per-flow writes
    ;; lens + redacted-modified-count surface for the App-DB diff panel.
@@ -441,6 +444,8 @@
    ;; indicator (resets IN/OUT pills + frame pin + mutes).
    :rf.xray/clear-all-filters
    :rf.xray/clear-machine-selection
+   ;; rf2-hga49 — clear the tab-ribbon Reset failure flash.
+   :rf.xray/clear-reset-flash
    :rf.xray/clear-selected-dispatch-id
    :rf.xray/clear-slice-focus
    :rf.xray/clear-trace-buffer
@@ -570,6 +575,11 @@
    ;; rf2-t2dsh — L2/L3 seam-handle double-click reset.
    :rf.xray/reset-events-list-height
    :rf.xray/reset-suppressed-counters
+   ;; rf2-hga49 — tab-ribbon Reset rewind affordance: the event-fx that
+   ;; trampolines into `:rf.xray.fx/restore-epoch`, plus its inline
+   ;; failure-flash setter.
+   :rf.xray/reset-to-epoch
+   :rf.xray/reset-flash-failed
    :rf.xray/restore-from-share-url
    :rf.xray/save-edit-popup
    :rf.xray/select-dispatch-id
@@ -711,6 +721,10 @@
   adding fxs produce rebase-clean diffs."
   (sorted-set
    :rf.xray.fx/copy-to-clipboard
+   ;; rf2-hga49 — tab-ribbon Reset rewind affordance: calls
+   ;; `rf/restore-epoch` against the observed frame + focused epoch, and
+   ;; dispatches the inline failure flash on a false return.
+   :rf.xray.fx/restore-epoch
    ;; rf2-nqw0v Phase 5 — Share affordance: new-tab open fx.
    :rf.xray.fx/open-in-new-tab
    ;; rf2-0us27 — Per-cascade structured export: text-file download fx.

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -2556,12 +2556,13 @@
         (is (= "left" (:text-align (style-of r-event-id)))
             "row event-id keyword is explicitly left-aligned")))))
 
-(deftest focused-row-uses-hover-fill-not-blue-ring
-  (testing "rf2-cplj8 — the selected/active row marks itself with a subtle
-            :hover background fill (Figma EventList `isActive` →
-            `bg-[var(--devtools-hover)]`), NOT a full 1px blue ring. The
-            border stays the transparent border-box base so the columns
-            never drift from the header."
+(deftest focused-row-uses-selected-bg-not-blue-ring
+  (testing "rf2-cplj8 + rf2-hga49 — the selected/active row marks itself
+            with a darker `:selected-row-bg` background fill (rf2-hga49
+            stepped this DARKER than `:hover` so selection reads distinctly
+            from hover AND survives under the issue-row pink wash), NOT a
+            full 1px blue ring. The border stays the transparent border-box
+            base so the columns never drift from the header."
     (xray-setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
@@ -2575,8 +2576,12 @@
         ;; shorthand to an explicit `:background-color` so the issue-row
         ;; wash can ride as a separate `:background-image` layer that
         ;; composes over (not clobbers) the focus highlight.
-        (is (= (:hover tokens) (:background-color style))
-            "focused row background is the subtle :hover fill")
+        ;; rf2-hga49 — the focus fill is now the dedicated darker
+        ;; `:selected-row-bg`, NOT `:hover`.
+        (is (= (:selected-row-bg tokens) (:background-color style))
+            "focused row background is the darker :selected-row-bg fill")
+        (is (not= (:hover tokens) (:background-color style))
+            "focused row background is no longer the :hover grey")
         ;; a clean focused cascade carries NO issue wash — only the
         ;; focus-highlight background-color, no overlay layer.
         (is (nil? (:background-image style))
@@ -2585,3 +2590,198 @@
             "focused row border is the transparent base — NO blue ring")
         (is (not= (str "1px solid " (:accent tokens)) (:border style))
             "focused row does NOT paint the :accent blue ring")))))
+
+;; -------------------------------------------------------------------------
+;; rf2-hga49 — tab-ribbon chrome: relabel + Reset button + selected-error-
+;; row visibility
+;; -------------------------------------------------------------------------
+
+(deftest tab-bar-context-label-reads-selected
+  (testing "rf2-hga49 — the L3 tab-ribbon contextual label reads the terse
+            `selected` (was `for selected event`), keeping the ↳ glyph."
+    (xray-setup!)
+    (rf/with-frame :rf/xray
+      (let [tree  (shell/shell-view)
+            label (find-by-testid tree "rf-xray-tab-bar-context-label")
+            txt   (text-nodes label)]
+        (is (some? label) "the context label renders")
+        (is (re-find #"selected" txt) "label reads `selected`")
+        (is (not (re-find #"for selected event" txt))
+            "the old `for selected event` copy is gone")
+        (is (re-find #"↳" txt) "the corner-down-right glyph is kept")))))
+
+(deftest tab-bar-reset-button-disabled-with-no-focus
+  (testing "rf2-hga49 — with no epoch focused the Reset button renders
+            disabled and carries no on-click (the button is the UI rewind
+            affordance; nothing to rewind to until an event is selected)."
+    (xray-setup!)
+    (rf/with-frame :rf/xray
+      (let [tree  (shell/shell-view)
+            reset (find-by-testid tree "rf-xray-tab-bar-reset")
+            attrs (second reset)]
+        (is (some? reset) "the Reset button renders")
+        (is (true? (:disabled attrs)) "Reset is disabled when no epoch focused")
+        (is (nil? (:on-click attrs))
+            "no on-click wired while disabled (no accidental rewind)")
+        (is (re-find #"Reset" (text-nodes reset)) "button reads `Reset`")))))
+
+(deftest tab-bar-reset-button-dispatches-restore-on-observed-frame
+  (testing "rf2-hga49 — with an epoch focused, clicking Reset dispatches
+            `:rf.xray/reset-to-epoch` with the OBSERVED frame (NOT :rf/xray)
+            and the focused epoch-id, so the live app rewinds to that
+            epoch's :db-after."
+    (xray-setup!)
+    ;; Two cascades on :rf/default. Seed an epoch-history whose records
+    ;; carry literal :dispatch-id ↔ :epoch-id links so the focus resolves
+    ;; an :epoch-id (epoch-id-for-cascade matches the literal slot).
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:baz/qux]))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/sync-epoch-history
+                         [{:epoch-id "epoch-1" :dispatch-id 1}
+                          {:epoch-id "epoch-2" :dispatch-id 2}]])
+      ;; Focus the NON-head cascade (id 1) on :rf/default → RETRO mode,
+      ;; where the focus honours the resolved epoch-id (LIVE auto-follows
+      ;; head, which would mask the pin).
+      (rf/dispatch-sync [:rf.xray/focus-cascade 1 :rf/default]))
+    (rf/with-frame :rf/xray
+      (let [observed @(rf/subscribe [:rf.xray/observed-frame])
+            epoch-id @(rf/subscribe [:rf.xray/focus-epoch-id])]
+        (is (= :rf/default observed) "observed frame is the inspected app frame")
+        (is (= "epoch-1" epoch-id) "the focused cascade's epoch-id resolves")
+        (let [dispatches (atom [])]
+          (with-redefs [rf/dispatch* (fn
+                                       ([ev]       (swap! dispatches conj ev) nil)
+                                       ([ev _opts] (swap! dispatches conj ev) nil))]
+            (let [tree    (shell/shell-view)
+                  reset   (find-by-testid tree "rf-xray-tab-bar-reset")
+                  handler (:on-click (second reset))]
+              (is (false? (:disabled (second reset)))
+                  "Reset is enabled when an epoch is focused")
+              (is (fn? handler) "an on-click is wired when enabled")
+              (handler nil)))
+          (is (some #(and (= :rf.xray/reset-to-epoch (first %))
+                          (= :rf/default (second %))
+                          (= epoch-id (nth % 2)))
+                    @dispatches)
+              ":rf.xray/reset-to-epoch fired with observed frame + epoch-id"))))))
+
+(deftest reset-to-epoch-event-trampolines-into-restore-fx
+  (testing "rf2-hga49 — `:rf.xray/reset-to-epoch` is a thin event-fx that
+            routes into the `:rf.xray.fx/restore-epoch` effect, which calls
+            the framework's `rf/restore-epoch` with the supplied frame +
+            epoch-id (the framework call lives in the fx, not a db
+            reducer)."
+    (xray-setup!)
+    (let [restore-calls (atom [])]
+      (with-redefs [rf/restore-epoch (fn [frame epoch-id]
+                                       (swap! restore-calls conj [frame epoch-id])
+                                       true)]
+        (rf/with-frame :rf/xray
+          (rf/dispatch-sync [:rf.xray/reset-to-epoch :rf/default "epoch-7"])))
+      (is (= [[:rf/default "epoch-7"]] @restore-calls)
+          "the event→fx chain called rf/restore-epoch with frame + epoch-id"))))
+
+(deftest reset-to-epoch-fx-flashes-on-restore-failure
+  (testing "rf2-hga49 — when `rf/restore-epoch` returns false (a documented
+            failure mode), the fx dispatches the inline failure flash; a
+            true return sets no flash."
+    (xray-setup!)
+    ;; failure path → flash set
+    (with-redefs [rf/restore-epoch (fn [_frame _epoch-id] false)]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/reset-to-epoch :rf/default "epoch-9"])))
+    (rf/with-frame :rf/xray
+      (is (string? @(rf/subscribe [:rf.xray/reset-flash]))
+          "a false restore sets the inline failure flash"))
+    ;; clear, then success path → no flash
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/clear-reset-flash]))
+    (with-redefs [rf/restore-epoch (fn [_frame _epoch-id] true)]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/reset-to-epoch :rf/default "epoch-9"])))
+    (rf/with-frame :rf/xray
+      (is (nil? @(rf/subscribe [:rf.xray/reset-flash]))
+          "a successful restore leaves no flash"))))
+
+(deftest reset-flash-failed-sets-inline-flash-and-clears
+  (testing "rf2-hga49 — a restore failure sets the inline `:rf.xray/reset-
+            flash` message (surfaced on the ribbon, never a modal); the
+            clear event dissocs it."
+    (xray-setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/reset-flash-failed]))
+    (rf/with-frame :rf/xray
+      (let [flash @(rf/subscribe [:rf.xray/reset-flash])
+            tree  (shell/shell-view)
+            el    (find-by-testid tree "rf-xray-reset-flash")]
+        (is (string? flash) "the flash message is set after a failure")
+        (is (some? el) "the inline flash renders on the ribbon")
+        (is (= "status" (:role (second el)))
+            "the flash carries role=status (announced, not a modal)")))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/clear-reset-flash]))
+    (rf/with-frame :rf/xray
+      (let [flash @(rf/subscribe [:rf.xray/reset-flash])
+            tree  (shell/shell-view)
+            el    (find-by-testid tree "rf-xray-reset-flash")]
+        (is (nil? flash) "the flash clears")
+        (is (nil? el) "the inline flash is removed from the ribbon")))))
+
+(deftest selected-issue-row-is-distinguishable
+  (testing "rf2-hga49 — the bead's core bug: a SELECTED ERROR row must be
+            visibly distinct from an unselected one. The three coordinated
+            signals — the leading `>` caret, the darker `:selected-row-bg`
+            background-color, and the (paled) issue wash on the
+            `:background-image` layer — all coexist so selection survives
+            the pink wash."
+    (xray-setup!)
+    ;; cascade 1 — clean. cascade 2 — carries an issue trace. Focus row 2.
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:cart/add-item]))
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:boom/throw]))
+    (trace-collector/seed-trace-for-test! (error-trace-ev 2))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/focus-cascade 2 :rf/default]))
+    (rf/with-frame :rf/xray
+      (let [tree      (shell/shell-view)
+            issue-row (find-by-testid tree "rf-xray-event-row-2")
+            style     (style-of issue-row)
+            caret     (find-by-testid issue-row "rf-xray-row-selection-caret")]
+        (is (some? issue-row) "the selected issue row renders")
+        ;; (1) leading caret — background-INDEPENDENT selection signal.
+        (is (some? caret) "the row carries the selection-caret gutter span")
+        (is (re-find #">" (text-nodes caret))
+            "the selected row paints the `>` caret glyph")
+        ;; (2) darker selection background that survives the wash.
+        (is (= (:selected-row-bg tokens) (:background-color style))
+            "selected row paints the darker :selected-row-bg")
+        ;; (3) the issue wash still composes over it.
+        (is (= "true" (:data-rf-xray-issue-row (second issue-row)))
+            "the row is still flagged as an issue row")
+        (is (re-find #"--rf-xray-bg-issue-row"
+                     (str (:background-image style)))
+            "the issue wash still rides the :background-image layer")))))
+
+(deftest unselected-row-caret-gutter-is-empty
+  (testing "rf2-hga49 — the caret gutter is fixed-width on EVERY row but
+            empty (no glyph) when the row is not selected, so selecting a
+            row never shifts the columns."
+    (xray-setup!)
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:older/event]))
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:newer/event]))
+    ;; Focus auto-snaps to head (id 2); row 1 is unselected.
+    (rf/with-frame :rf/xray
+      (let [tree   (shell/shell-view)
+            row1   (find-by-testid tree "rf-xray-event-row-1")
+            caret1 (find-by-testid row1 "rf-xray-row-selection-caret")
+            row2   (find-by-testid tree "rf-xray-event-row-2")
+            caret2 (find-by-testid row2 "rf-xray-row-selection-caret")]
+        (is (some? caret1) "unselected row still reserves the caret gutter")
+        (is (= "10px" (:width (style-of caret1)))
+            "the gutter is a fixed 10px on the unselected row")
+        (is (empty? (text-nodes caret1))
+            "no caret glyph on the unselected row")
+        (is (re-find #">" (text-nodes caret2))
+            "the selected head row DOES paint the caret")
+        (is (= "10px" (:width (style-of caret2)))
+            "selected + unselected gutters share the same fixed width")))))


### PR DESCRIPTION
Closes rf2-hga49. Three Xray L2/tab-ribbon chrome changes (Mike-decided 2026-06-02).

## Part 1 — Reset-to-event button
The UI half of the inspect-vs-rewind principle. A far-right `Reset` (↺) button on the L3 tab ribbon (after a `margin-left:auto` spacer) dispatches `:rf.xray/reset-to-epoch` with the **observed** frame (`:rf.xray/observed-frame` — the frame-switcher selection, NOT `:rf/xray`) + the **focused** epoch-id (`:rf.xray/focus-epoch-id`). It trampolines into the new `:rf.xray.fx/restore-epoch` effect → `rf/restore-epoch` (targets the epoch's `:db-after`; zero framework change). No dialog, no confirmation. Disabled (dimmed) when no epoch focused. A restore failure (`rf/restore-epoch` returns false — epoch aged out / restore-during-drain) sets an inline `:rf.xray/reset-flash` (`role=status`), never a modal, never a silent lie.

## Part 2 — relabel
Tab-ribbon contextual label `for selected event` → `selected` (the ↳ glyph + styling already carry the sense).

## Part 3 — selected error-row visibility (the bug)
**Where the bug was:** `shell.cljs` `event-row` — selection painted `:hover` grey as `:background-color` (L1455) while the issue wash rode `:background-image` over it (rf2-b8guz). Two channels technically, but the low-opacity pink wash drowned the grey, so a **selected error row was indistinguishable** from an unselected one. Fixed with three coordinated signals: (1) a leading `>` caret in a fixed 10px gutter (background-independent; header gains a matching gutter spacer so columns never drift), (2) a darker dedicated `:selected-row-bg` token, (3) a paled `:bg-issue-row` in both themes (dark ~15%→~10%, light ~18%→~12%) so the darker grey reads through the wash.

## Specs (xray-specs-kept-current)
- `018-Event-Spine.md` — row anatomy (caret column), new §Selected-row visibility, new §Tab-ribbon chrome (Reset affordance + relabel).
- `022-Design-Tokens.md` — new `:selected-row-bg` token + paled `:bg-issue-row`.
- `machines-viz` token mirror synced (`:bg-issue-row` + new `:selected-row-bg` key) for the rf2-z7ms8 drift gate.

## Quality gates
- `npm run test:cljs` — **PASS** (5220 tests, 17880 assertions, 0 failures). Added regression tests: relabel, Reset disabled/enabled + dispatch wiring, event→fx→`restore-epoch` chain, failure-flash set/clear, selected-issue-row distinguishability, fixed-width caret gutter; updated the existing focused-row test for the darker bg; updated registry snapshot allowlists (3 events, 1 fx, 1 sub).
- `npm run test:xray-feature-gate` — **PASS** (16 scenarios, 0 failures, 13 matrix rows).
- `npm run test:bundle-isolation` — **PASS** (17 artefact entries, 35 sentinels absent; uix/helix reagent-free OK).
- clj-kondo — **PASS** (0 errors; the 2 pre-existing info/warnings are in untouched code).
- `mkdocs build --strict` — **PASS** (xray spec tree is outside the mkdocs site; build clean).