### PR TITLE
docs(skills): add FormAction/ReusableComponents/StatefulComponents/SSR-Loaders pattern leaves to authoring skill (rf2-s6bud)

### DIFF
--- a/docs/skills/re-frame2.md
+++ b/docs/skills/re-frame2.md
@@ -14,7 +14,7 @@ Load this skill when the prompt is about **writing or editing re-frame2 applicat
 
 - References to `reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`.
 - Mentions of `dispatch`, `subscribe`, `app-db`, frames, regions, tags, the nine UI states.
-- Pattern names: RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection.
+- Pattern names: RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection, ReusableComponents, StatefulComponents, FormAction, SSR-Loaders.
 - "Write a test for a re-frame2 handler / sub / machine."
 
 Do **not** use this skill for:

--- a/skills/README.md
+++ b/skills/README.md
@@ -23,7 +23,8 @@ re-frame2 ships **eight** skills, grouped by the situation they cover:
   application code. Events, subscriptions, effects, frames, state machines,
   schemas, stories, routing, and the canonical patterns (RemoteData, Forms,
   Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork,
-  StaleDetection). Scaffolding, leaf content under `reference/`,
+  StaleDetection, ReusableComponents, StatefulComponents, FormAction,
+  SSR-Loaders). Scaffolding, leaf content under `reference/`,
   `patterns/`, and `decision-trees/`, and the integration pass have all
   landed — the skill is alpha-ready.
 

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -5,7 +5,8 @@ description: >
   effects, flows, frames, state machines (reg-machine, parallel regions,
   tags, spawn), schemas, stories, routing, tests, and the canonical patterns
   (RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP,
-  AsyncEffect, LongRunningWork, StaleDetection). Use whenever the user
+  AsyncEffect, LongRunningWork, StaleDetection, ReusableComponents,
+  StatefulComponents, FormAction, SSR-Loaders). Use whenever the user
   mentions re-frame2, reg-event-db, reg-event-fx, reg-sub, reg-fx,
   reg-cofx, reg-flow, reg-view, reg-machine, reg-route, reg-story,
   reg-app-schema, dispatch, subscribe, app-db, flows, frames, regions,
@@ -84,6 +85,10 @@ Full skill-disambiguation matrix lives at [`skills/README.md` Â§Skill routing â€
 | Real-time bidirectional connection | `patterns/websocket.md` |
 | View rendering every legal lifecycle state | `patterns/nine-states.md` |
 | Cached resource with freshness checks | `patterns/stale-detection.md` |
+| Parameterised widget rendered N times (entity-id idiom) | `patterns/reusable-components.md` |
+| View wrapping a stateful JS library (chart / map / editor) | `patterns/stateful-components.md` |
+| SSR form POST handling (progressive enhancement) | `patterns/form-action.md` |
+| SSR parallel data fetch before render (fan-out) | `patterns/ssr-loaders.md` |
 
 Patterns compose; a screen can use Forms on submit, RemoteData for the request, and WebSocket for a push.
 

--- a/skills/re-frame2/decision-trees/pick-a-pattern.md
+++ b/skills/re-frame2/decision-trees/pick-a-pattern.md
@@ -22,6 +22,10 @@ Read the prompt for **one** of the following shape-tells. They are mutually excl
 | "Fire-and-forget / log / analytics / telemetry / external side-effect with no observable reply" | AsyncEffect |
 | "CPU-bound / heavy / parses / hashes / pegs the main thread / chunked / yields / progress bar" | LongRunningWork |
 | "Cache / freshness / TTL / since / etag / `stale-after-ms` / async-result arrives after state moved on" | StaleDetection |
+| "Reusable / parameterised widget / customer-card / renders N of the same / works against any X / compare two side by side" | ReusableComponents |
+| "Wrap a JS library / D3 / Mapbox / CodeMirror / Three.js / ag-grid / chart / map / editor / `:ref` + lifecycle / `.setData`" | StatefulComponents |
+| "SSR form POST / progressive enhancement / works without JavaScript / server `action` / POST-redirect-GET / CSRF on submit" | FormAction |
+| "SSR parallel fetch / `Promise.all` server-side / fan-out N requests before render / per-page loader" | SSR-Loaders |
 
 If you see **two** shape-tells, the dominant one is the one the user names first or the one that owns the data. Pattern composition (e.g. "managed-HTTP retries inside a form submit") is normal — pick the primary, plan the secondary as a follow-up.
 
@@ -117,6 +121,10 @@ If the example contradicts the leaf, **the example wins** — re-frame2's cardin
 | AsyncEffect | [`patterns/async-effect.md`](../patterns/async-effect.md) | (inline mini-example) |
 | LongRunningWork | [`patterns/long-running-work.md`](../patterns/long-running-work.md) | `examples/reagent/long_running_work/` |
 | StaleDetection | [`patterns/stale-detection.md`](../patterns/stale-detection.md) | (inline mini-example) |
+| ReusableComponents | [`patterns/reusable-components.md`](../patterns/reusable-components.md) | (inline mini-example) |
+| StatefulComponents | [`patterns/stateful-components.md`](../patterns/stateful-components.md) | (per-adapter README) |
+| FormAction | [`patterns/form-action.md`](../patterns/form-action.md) | (inline mini-example) |
+| SSR-Loaders | [`patterns/ssr-loaders.md`](../patterns/ssr-loaders.md) | `examples/reagent/boot/` |
 
 Load at most two pattern leaves at a time. If three or more seem necessary, the request probably spans features and should be broken up — author each pattern's leaf in its own pass.
 

--- a/skills/re-frame2/patterns/form-action.md
+++ b/skills/re-frame2/patterns/form-action.md
@@ -1,0 +1,104 @@
+# Pattern — Form Action (SSR POST handling)
+
+The standard form-action convention for SSR: a browser submits an HTML form to a URL; the server parses the POST body, validates, dispatches a domain event, and returns either a redirect or a re-rendered page. **Convention, not Spec** — built on the host adapter, the `:rf.server/request` cofx, the `[:rf/response]` accumulator, and Pattern-Forms.
+
+> **Mental-model anchor:** this is the **Next.js Server Actions / Remix `action` export** shape, translated to re-frame2 primitives. The progressive-enhancement guarantee is the same: the form works with JS *off* (the server processes the POST and re-renders), and the identical handler tree runs with JS *on* (the client intercepts `:on-submit`, dispatches the same event, no full-page reload).
+
+## When to load
+
+The prompt mentions: an SSR app handling a form POST, progressive enhancement, "make the form work without JavaScript", a server-side `action`, POST-redirect-GET, CSRF on a form submit, or a multipart file upload in an SSR app. Pattern-Forms covers the *client* lifecycle + form-slice shape; this leaf covers the **server-side POST seam** and the cross-platform handler tree. Load `patterns/forms.md` alongside it.
+
+## The six-step shape
+
+1. **The HTML form** renders `method="POST" action="/<route>"` + a hidden CSRF token. The standard Pattern-Forms slice (server-rendered from `app-db`) drives field values.
+2. **The host adapter receives the POST**, parses the body (form-urlencoded or multipart), binds it under `:form-params`, and creates a per-request frame.
+3. **`:rf/server-init` routes** via `(inject-cofx :rf.server/request)` — on GET dispatch the page loader (Pattern-SSR-Loaders); on POST dispatch the domain event with `form-params`.
+4. **The domain handler validates** `form-params` against the registered schema. On failure → write structured errors into the form slice's `:errors`, let the drain settle, re-render the page with inline errors. On success → run the side effect, then `:rf.server/redirect` (303) or a success re-render.
+5. **The drain settles**, the SSR emitter runs (or is short-circuited by the redirect), the host materialises `[:rf/response]`.
+6. **Once JS hydrates**, the form's `:on-submit` calls `(.preventDefault e)` and dispatches the *same* event. Only the dispatch site differs.
+
+## Canonical declaration
+
+The view runs on both platforms; the `action` attribute is what makes it work JS-off, and `:on-submit` is purely additive:
+
+```clojure
+(rf/reg-view add-to-cart-form [item-id]
+  (let [draft      @(rf/subscribe [:form.cart-add/draft])
+        qty-error  @(rf/subscribe [:form.cart-add/field-error :quantity])
+        csrf-token @(rf/subscribe [:rf.csrf/token])]
+    [:form {:method    "POST"
+            :action    "/cart/add"
+            :on-submit (fn [e] (.preventDefault e)
+                         (rf/dispatch [:cart/add-item (assoc draft :item-id item-id)]))}
+     [:input {:type "hidden" :name "csrf-token" :value csrf-token}]
+     [:input {:type "hidden" :name "item-id"    :value item-id}]
+     [:input {:type "number" :name "quantity" :value (or (:quantity draft) 1) :min 1 :max 99
+              :on-change #(rf/dispatch [:form.cart-add/edit-field :quantity
+                                        (-> % .-target .-value js/parseInt)])}]
+     (when qty-error [:p.error qty-error])
+     [:button {:type "submit"} "Add to cart"]]))
+```
+
+`:rf/server-init` routes GET vs POST; the action handler validates via `:schema` and emits per-platform effects:
+
+```clojure
+(rf/reg-event-fx :rf/server-init
+  {:doc "Per-request boot. GET → page loader; POST → form action."
+   :platforms #{:server}}
+  [(rf/inject-cofx :rf.server/request)]
+  (fn [{:keys [rf.server/request]} _]
+    (let [{:keys [request-method form-params]} request
+          route (match-route (:uri request))]            ;; app-supplied route matcher
+      (case request-method
+        :get  {:fx [[:dispatch [:page/load route]]]}
+        :post {:fx [[:dispatch [(route->action-event route) form-params]]]}))))
+
+(rf/reg-event-fx :cart/add-item
+  {:doc    "Add an item to the cart. Same handler tree both platforms."
+   :schema [:cat [:= :cart/add-item] AddToCartForm]}     ;; server-side schema check, never skipped
+  [(rf/inject-cofx :rf.server/request)
+   (rf/inject-cofx :rf.csrf/active-token)]
+  (fn [{:keys [db rf.csrf/active-token]} [_ form-params]]
+    (if (not= (:csrf-token form-params) active-token)    ;; CSRF first — fail loud
+      {:db (assoc-in db [:cart :add-form :errors :_form] ["Session expired. Refresh and retry."])
+       :fx [[:rf.server/set-status 403]]}
+      {:db (-> db
+               (update-in [:cart :items] (fnil conj []) (select-keys form-params [:item-id :quantity]))
+               (assoc-in  [:cart :add-form :status] :submitted))
+       :fx [[:rf.server/redirect {:status 303 :location "/cart"}]   ;; server only
+             [:rf.nav/navigate "/cart"]]})))                        ;; client only — :platforms no-ops the wrong one
+```
+
+The success/failure effects are the only platform-divergent slot. `:rf.server/redirect` is server-only; `:rf.nav/navigate` is client-only — `:platforms` gating no-ops the one each platform doesn't own.
+
+## CSRF
+
+Every form POST MUST carry a CSRF token; the server MUST reject a mismatched token *before any state mutation*. The session token lives at `[:rf.csrf :session-token]` (seeded by `:rf/server-init` from the request); the view subscribes to `[:rf.csrf/token]` and emits a hidden `csrf-token` field; a `:rf.csrf/active-token` cofx exposes the session token to the handler, which fails-closed with 403 on mismatch. Token rotation, double-submit-vs-sync-pattern, and cookie attributes (`SameSite`/`HttpOnly`/`Secure`) are host concerns — the pattern names *where* the check happens, not *which* scheme.
+
+## File uploads
+
+`enctype="multipart/form-data"` — the host adapter parses files under `:form-params` as `{:filename :content-type :size :tempfile :sensitive?}` maps. The `:tempfile` is host-specific and **opaque**: pass it to a file-storage fx (S3 PUT, disk write); never dereference it in the handler, and write only the resulting URL/storage-id into `app-db`. File **contents** never appear in trace events; a `:sensitive? true` action redacts the whole `:form-params` map (filenames leak too). Mixed sensitive + non-sensitive fields → split into two POSTs (sanitisation is map-level, not field-level).
+
+## Anti-patterns
+
+- **Skipping the `action` attribute.** A JS-only form breaks progressive enhancement. Always emit `method` + `action`; `:on-submit` is additive.
+- **Validating only on the client.** Client validation is UX; the server is the authority. Re-run the schema check via `:schema` on every POST — never trust the body.
+- **`:rf.nav/navigate` for the server redirect.** It is client-only and no-ops server-side; use `:rf.server/redirect` for POST-redirect-GET.
+- **`302 Found` for POST success.** Some clients re-POST on 302; the canonical status is **303 See Other**. Set `:status 303` explicitly.
+- **CSRF token from a hardcoded value or query string.** Sessions rotate tokens; `:rf.csrf/active-token` is the single source of truth. URL-borne tokens leak to referrer logs.
+- **Writing `app-db` from a multipart handler.** The drain runs to fixed point — a long upload inside the handler blocks the request thread. Hand the opaque `:tempfile` to a storage fx.
+
+## Worked example
+
+No standalone example app — the SSR worked apps are `examples/reagent/ssr/core.cljc` (head/hydration baseline). The `/cart/add` shape above is the canonical summary lifted from the spec; substitute the route + form schema.
+
+## Pointers
+
+- Spec: [`spec/Pattern-FormAction.md`](../../../spec/Pattern-FormAction.md) — full worked `/cart/add` page, the failure-path projector hook, multipart privacy, the server-vs-client handler-tree table, conformance checklist.
+- Substrate: `SKILL-REDIRECT.md` → *EP — SSR (011)* (`:rf.server/request` cofx, `[:rf/response]` accumulator, the six server-only fxs, `:platforms` gating, server error projection), *EP — Schemas (010)* (`:schema` boundary check, `:sensitive?`).
+- Cross-cutting: `references/cross-cutting/ssr-authoring.md` (head/meta + the `:rf/hydrate` checks).
+- Compose: `patterns/forms.md` (the form-slice shape this reuses server-side), `patterns/ssr-loaders.md` (the GET-path sibling — a page uses Loaders for the initial render, FormAction for subsequent POSTs).
+
+---
+
+*Derived from `spec/Pattern-FormAction.md` (Convention, not Spec) @ main. Re-verify if the `:rf.server/*` fx set or the SSR response contract changes.*

--- a/skills/re-frame2/patterns/reusable-components.md
+++ b/skills/re-frame2/patterns/reusable-components.md
@@ -1,0 +1,102 @@
+# Pattern — Reusable Components
+
+The entity-id idiom for parameterised widgets — a `customer-card` that works against *any* customer, where the caller supplies the id and the card subscribes and dispatches in terms of it. The same view function instantiates N times against N entities, each reading its own slice, each dispatching its own scoped events. **Convention, not Spec** — built entirely from `reg-sub`'s query-vector, `reg-view`'s positional args, and the standard `dispatch` / `subscribe` surfaces; no new substrate.
+
+> **Mental-model anchor:** this is the **React "prop-as-id, not prop-as-data"** discipline — pass `id`, let the component resolve its own data through a (cached) selector, exactly the shape that lets `<CustomerCard id={42} />` and `<CustomerCard id={43} />` render side by side without sharing state. Map that intuition onto the re-frame2 query-vector below.
+
+## When to load
+
+The prompt mentions: a reusable / parameterised widget, a list rendering N of the same card, a "compare two entities side by side" view, a `customer-card` / `user-avatar` / `line-item` component, "make this work against any X", or a library-shipped widget that must drop into an arbitrary host app. Also load when a single-instance widget needs to become multi-instance (the singleton-sub bottleneck below).
+
+## The three rules
+
+The whole pattern is **identity-as-argument** — the slice lookup happens *inside* the sub handler, never at the call site.
+
+1. **Subs accept the id in the query vector.** Destructure it out of the second arg:
+
+```clojure
+(rf/reg-sub :customer
+  (fn [db [_ id]]
+    (get-in db [:customers id])))
+
+(rf/reg-sub :customer/display-name              ;; derived; id flows through the signal fn
+  (fn [[_ id] _] (rf/subscribe [:customer id]))
+  (fn [customer _] (str (:first-name customer) " " (:last-name customer))))
+```
+
+`(subscribe [:customer 42])` and `(subscribe [:customer 43])` cache as **distinct** entries — two instances run two independent computations against two app-db slices.
+
+2. **Views accept the id as a positional arg.** The view is an ordinary function:
+
+```clojure
+(rf/reg-view customer-card [id]
+  (let [customer @(rf/subscribe [:customer id])]
+    [:div.customer-card
+     [:h3 (:name customer)]
+     [:button {:on-click #(rf/dispatch [:customer/edit id])} "Edit"]]))
+```
+
+Callers splice `[customer-card 42]` and `[customer-card 43]` into the render tree; both render simultaneously.
+
+3. **Dispatches carry the id** in the first payload position, so the handler scopes the same way the sub does:
+
+```clojure
+(rf/reg-event-db :customer/edit
+  (fn [db [_ id]] (assoc-in db [:ui :editing-customer] id)))
+```
+
+Without the id-on-dispatch rule, two cards firing `:customer/edit` are indistinguishable at the handler.
+
+## The unit of reuse
+
+The unit is **the bundle** — the view, the subs it reads, and the events it dispatches. A reusable `customer-card` ships the view plus `:customer` (and `:customer/*` derived subs) plus `:customer/edit` / `:customer/update`. Half-bundles do not compose: a view that derefs `[:customer id]` with no `:customer` sub registered cannot mount.
+
+## Multi-identity
+
+Views that need **more than one id** (a transfer screen with source + destination, a comparison view, a dropdown with an options-list id and a separate selection id) take two positional args, two subs, two dispatch-scope ids:
+
+```clojure
+(rf/reg-view account-transfer [source-id dest-id]
+  (let [source @(rf/subscribe [:account source-id])
+        dest   @(rf/subscribe [:account dest-id])]
+    [:div.transfer
+     [:div.from [:h3 (:name source)] [:p (:balance source)]]
+     [:div.to   [:h3 (:name dest)]   [:p (:balance dest)]]
+     [:button {:on-click #(rf/dispatch [:account/transfer source-id dest-id 100])}
+      "Transfer $100"]]))
+```
+
+Each id is independently substitutable; the transfer handler reads both out of its payload and updates both slices in one `:db` step.
+
+## Placefulness — library-shipped widgets
+
+When a widget is distributed as a *library* across host apps, the slice path may vary (app A stores at `[:customers id]`, app B at `[:entities :crm :customers id]`). Frames change the shape but don't eliminate it:
+
+- Within a frame, document the slice the widget reads from, or accept a `:base-path` argument. The documented-slice convention is shorter than threading a base-path through every call.
+- Across frames, per-frame `app-db` isolation removes one collision class: two cards in two frames against the same id render two independent views. The id selects within a frame; the frame selects which `app-db`.
+- Host apps that already store the entity elsewhere project into the documented slice via a `reg-flow` (see `references/fundamentals/flows.md`) rather than reaching across a foreign boundary.
+
+## Substrate-agnostic
+
+The idiom ports across adapters with **zero changes to the view body**. The view is an ordinary function of its args; Reagent splices `[customer-card 42]`; UIx / Helix read the parameterised sub through the adapter's `use-subscribe` hook with the id as the first prop. Only the surrounding component wrapper differs by adapter.
+
+## Anti-patterns
+
+- **Hardcoded slice path inside a "reusable" component.** `(subscribe [:current-customer])` is by definition single-instance — the moment two entities must render at once, the singleton sub shows the same data in both.
+- **Threading the full entity map through the render tree** (`[customer-card customer-map]`). Defeats the sub-cache: every parent re-render reconstructs the map literal, the cached-sub input-equality check fails, the card re-renders even when its data is unchanged. Pass the **id**; let the card resolve the entity.
+- **Asymmetric dispatches** — reading `[:customer id]` but dispatching `[:customer/edit]` without the id. Broken under multi-instance rendering.
+- **Storing per-instance UI state in the entity slice.** A card's `:expanded?` flag does not belong at `[:customers id :expanded?]` — that conflates the entity with transient view state. Use a separate `[:ui :customer-cards id]` slice (keyed by the same id), or, when the widget wraps a stateful JS thing, the stateful-component idiom (`patterns/stateful-components.md`).
+
+## Worked example
+
+No standalone example app — the idiom appears wherever a list renders the same card N times. The closest worked shape is the RealWorld article list (`examples/reagent/realworld/articles.cljs`), where each article row is an entity-id-parameterised view over the `[:articles]` slice.
+
+## Pointers
+
+- Spec: [`spec/Pattern-ReusableComponents.md`](../../../spec/Pattern-ReusableComponents.md) — the full idiom, the multi-identity forms, the four placefulness answers, the conformance checklist.
+- Substrate: `SKILL-REDIRECT.md` → *EP — Views (004)* (`reg-view` positional args, render-tree splice), *EP — Registration (001)* (`reg-sub` query-vector destructure).
+- Compose: `patterns/stateful-components.md` (a `[customer-chart id]` widget is a reusable component that *also* wraps a charting library — entity-id handles the data, the outer/inner shape handles the lifecycle).
+
+---
+
+*Derived from `spec/Pattern-ReusableComponents.md` (Convention, not Spec) @ main. Re-verify if `reg-view` positional-arg or `reg-sub` query-vector semantics change.*

--- a/skills/re-frame2/patterns/ssr-loaders.md
+++ b/skills/re-frame2/patterns/ssr-loaders.md
@@ -1,0 +1,105 @@
+# Pattern — SSR Loaders (parallel data fetch during drain)
+
+The standard fan-out-then-render shape for server-side rendering that needs N parallel HTTP fetches before HTML emission. **Convention, not Spec** — built on `:spawn-all` (spawn-and-join) and `:rf.http/managed`, primitives the spec already locks.
+
+> **Mental-model anchor:** this is the **Next.js `Promise.all([getArticle, getComments, getRelated])` / Remix parallel-loader** shape. The naive alternative — three loader events in series from `:on-create` — serialises the wall-clock cost of every fetch (the drain is single-threaded; back-to-back blocking JVM transport calls add up). The fan-out moves each fetch into its own spawned actor; total cost falls to `max(fetch-i) + overhead`, not `sum(fetch-i)`.
+
+## When to load
+
+The prompt mentions: SSR that loads several independent pieces of data before render, "fetch product + related + reviews in parallel", a server-side `Promise.all`, a per-page loader, or a navigation-fetch that fans out N requests. The same machine drives client navigation-fetch too — only the spawn site and the rendering moment change.
+
+## The five-step shape
+
+A boot-like state machine spawned at `:on-create` (server) / `:on-match` (client). Its first state fans out N HTTP children via `:spawn-all`; the join-all-complete transition advances to a terminal `:ready`; the drain settles; `render-to-string` runs against the post-drain `app-db`.
+
+1. **`:rf/server-init` (or `:on-create`) reads the URL** and spawns the loader machine with the request-derived params.
+2. **The loader's `:loading` state declares `:spawn-all`** — N children, each a thin machine wrapping `:rf.http/managed` for one fetch.
+3. **Each child dispatches back** `[<parent> [:loaded :child-id <result>]]` (or `[:failed …]`) on terminal.
+4. **The runtime joins** — when every child is `:done`, it fires `:on-all-complete`; the parent transitions to `:ready` and writes results into `app-db`.
+5. **The drain settles, `render-to-string` runs** — views `subscribe` to the slices; the hydration payload carries the same slices to the client.
+
+## Canonical declaration
+
+The loader machine fans out three fetches, joins, writes on `:ready`, and stamps a 502 on failure or deadline:
+
+```clojure
+(rf/reg-machine :pdp/load
+  {:doc     "Parallel loader for /products/:id. Fans out 3 fetches; joins on all-complete."
+   :initial :loading
+   :data    (fn [_ [_ {:keys [product-id]}]] {:product-id product-id})
+   :states
+   {:loading
+    {:spawn-all
+     {:children
+      [{:id :product :machine-id :http/get-one
+        :data (fn [snap _] {:url (str "/api/products/" (-> snap :data :product-id))
+                            :decode ProductSchema})}
+       {:id :related :machine-id :http/get-one
+        :data (fn [snap _] {:url (str "/api/products/" (-> snap :data :product-id) "/related")
+                            :decode RelatedListSchema})}
+       {:id :reviews :machine-id :http/get-one
+        :data (fn [snap _] {:url (str "/api/products/" (-> snap :data :product-id) "/reviews")
+                            :decode ReviewListSchema})}]
+      :join            :all
+      :on-all-complete [:pdp/joined]
+      :on-any-failed   [:pdp/load-failed]}
+     :after {30000 :pdp/timed-out}        ;; phase-level wall-clock guard — mandatory under SSR
+     :on    {:pdp/joined :ready :pdp/load-failed :error :pdp/timed-out :error}}
+
+    :ready {:final? true
+            :entry (fn [{:keys [event]}]
+                     (let [[_ _ {:keys [product related reviews]}] event]
+                       {:db-fx [[:assoc-in [:pdp :product] product]
+                                [:assoc-in [:pdp :related] related]
+                                [:assoc-in [:pdp :reviews] reviews]]}))}
+    :error {:final? true
+            :entry (fn [_ [_ _ reason]]
+                     {:fx [[:rf.server/set-status 502] [:assoc-in [:pdp :error] reason]]})}}})
+```
+
+The per-fetch child is a thin shared machine — one state spawns `:rf.http/managed`; terminal states dispatch `:loaded` / `:failed` back to the parent (the parent-id is stamped at spawn time and read from the child's `:data :env`). Only the spawn-spec `:data` fn differs per sibling.
+
+The SSR request wires it from `:rf/server-init`, reading request-derived values from the `:rf.server/request` cofx **once**, at the spawn site:
+
+```clojure
+(rf/reg-event-fx :rf/server-init
+  {:platforms #{:server}}
+  [(rf/inject-cofx :rf.server/request)]
+  (fn [{:keys [rf.server/request]} _]
+    (let [{:keys [product-id]} (match-route (:url request))    ;; app-supplied route matcher
+          auth-token (-> request :session :token)]
+      {:fx [[:rf.machine/spawn {:machine-id :pdp/load
+                                :data       {:product-id product-id :auth-token auth-token}}]]})))
+```
+
+Children read auth-token/locale from the parent's snapshot at spawn — nothing in the child reaches for the request cofx again, which keeps the child **reusable on the client** (where there is no request cofx).
+
+## The deadline
+
+`:after {30000 :pdp/timed-out}` is the SSR-specific knob. A client can tolerate "spinner for 60 s then resolves"; a server has a single render moment and a request-timeout budget. If one fetch hangs past the deadline, the `:after` exits `:loading`, the exit cascade tears down every surviving child (their `:rf.http/managed` invocations abort via the destroy fx), and `:error` stamps a 502 — no partial render of half-loaded slices. Pick a deadline **shorter** than the host adapter's request timeout.
+
+## Server vs client
+
+The same machine works on both platforms; only the deadline policy and the rendering moment differ. Server: spawned at `:on-create`, drain settles before `render-to-string`, deadline mandatory, no partial render. Client: spawned at the route's `:on-match`, drain settles before the next React tick, deadline optional, *can* render a skeleton mid-fetch (give the parent an `:on :loaded` handler that writes results incrementally). One machine; the platform decides whether to render mid-fetch or only after the join.
+
+## Anti-patterns
+
+- **Three loaders in series from `:on-create`.** Serialises the wall-clock cost — each `:rf.http/managed` blocks the drain thread on the server JVM transport. Use `:spawn-all`.
+- **Hand-rolling the join** with a counter in `app-db` (`(when (= 3 @counter) …)`). Reinvents `:spawn-all`'s join-state without the destroy cascade, deadline composition, or trace events.
+- **Reading `:rf.server/request` from child machines.** The cofx is server-only; a child that reads it becomes server-only too, breaking the "same machine for client navigation" property. Thread request-derived values from the parent's `:data`.
+- **Omitting the deadline.** A loader with no `:after` can hang until the host's outer timeout fires, where the error path is host-specific and unobservable to the trace stream.
+- **Writing results into `app-db` from the child.** The child dispatches back; the parent's `:ready :entry` writes. Keeps the join atomic — partial results never land on failure/deadline short-circuit.
+
+## Worked example
+
+`examples/reagent/boot/boot.cljs` exercises the closest live shape — its `:loading-deps` state fans out three parallel loaders via `:spawn-all`. The `/products/:id` shape above is the per-page SSR analogue; substitute the route + per-fetch schemas.
+
+## Pointers
+
+- Spec: [`spec/Pattern-SSR-Loaders.md`](../../../spec/Pattern-SSR-Loaders.md) — full worked `/products/:id` page, the per-fetch child machine, retry partitioning (transport vs semantic), abort cascade, the server-vs-client semantics table, conformance checklist.
+- Substrate: `SKILL-REDIRECT.md` → *EP — State machines (005)* (`:spawn-all` join, phase-level `:after`, spawn-id tracking, retry-ownership boundary), *EP — SSR (011)* (server flow, `:rf.server/request` cofx), *EP — HTTP requests (014)* (the managed-HTTP fx each child wraps, aborts).
+- Compose: `patterns/boot.md` (the app-wide boot sibling; this is the per-page analogue), `patterns/form-action.md` (the POST-path sibling — a page uses Loaders for GET, FormAction for POST), `patterns/remote-data.md` (the per-slice lifecycle each child's result lands in).
+
+---
+
+*Derived from `spec/Pattern-SSR-Loaders.md` (Convention, not Spec) @ main, with the `:spawn-all` fan-out cross-checked against `examples/reagent/boot/boot.cljs`. Re-verify if `:spawn-all` join semantics change.*

--- a/skills/re-frame2/patterns/stateful-components.md
+++ b/skills/re-frame2/patterns/stateful-components.md
@@ -1,0 +1,111 @@
+# Pattern — Stateful Components
+
+The canonical **outer/inner** shape for a view that bridges a stateful third-party JS library — one that owns its own DOM subtree and exposes an imperative `init / update / dispose` lifecycle (D3, Mapbox, Leaflet, CodeMirror, Monaco, Three.js, ag-grid, Vega-Embed, GSAP, Framer Motion, …). **Convention, not Spec.** Browser-side only (no DOM to bridge on the JVM).
+
+> **Mental-model anchor:** this is the **React "wrap an imperative library in a component with a ref + `useEffect`"** shape — mount the library against a ref'd node, push new props imperatively on update, dispose on unmount. re-frame2 splits that into two views because subscriptions are reactive (read at render) while the library lifecycle is imperative (runs after commit, with no reactive context).
+
+## When to load
+
+The prompt mentions: wrapping a chart / map / code-editor / 3D-scene / grid / animation library, "how do I integrate `<some JS lib>`", a `:ref` + lifecycle hook, "the view needs to call `.setData` / `.panTo` / `.update`", or a Form-3 / `use-effect`-bodied view. Also load for the Animations *Regime C* (library-bridged) case — animation libs are one instance of this pattern.
+
+## The outer/inner split
+
+```
+  outer (reg-view)        reads subs, derives a JSON-shaped props map
+   │
+   ▼
+  inner (Form-3 / use-effect)   owns the library lifecycle: mount / update / unmount
+   │
+   ▼
+  library                 owns its DOM subtree, listeners, internal timers
+```
+
+- **Outer — pure re-frame2 view.** A standard `reg-view`. Reads subscriptions, computes one props map, renders the inner with it. Never touches the DOM; never holds an instance handle. When subs change, the outer re-renders and feeds the inner fresh props.
+- **Inner — Form-3-equivalent lifecycle wrapper.** Owns three phases: **mount** (after first commit, read the DOM node via a ref, hand it to the library constructor, stash the instance in a per-mount closure cell), **update** (push new props into the *already-mounted* instance via its imperative API — never tear down and re-create), **unmount** (call the library's dispose/destroy API, remove listeners, null the closure cells). The inner's render body is trivial — just `[:div {:ref …}]`; the library fills the node.
+
+The split is forced by reactive context: subs want render-time reads; lifecycle callbacks run after commit on a stack with no reactive context. Props are the seam.
+
+## The one cross-adapter discipline — capture the frame at render-time
+
+Capture `(rf/frame-handle)` in the inner's top-level `let` (Reagent: in the closure around `create-class`) and use its `:dispatch` op for any library callback. A bare `(rf/dispatch …)` from inside a lifecycle callback fires on a fresh stack with no `*current-frame*` binding and silently routes to `:rf/default`.
+
+## Canonical declaration (Reagent — a Mapbox-shaped widget)
+
+Pseudo-code; library calls are illustrative. Substitute D3 / Three.js / CodeMirror with no structural change.
+
+```clojure
+(ns my-app.map
+  (:require [re-frame.core :as rf]
+            [reagent.core  :as r]))
+
+;; Inner — Form-3, owns the library lifecycle. Registered via reg-view*
+;; (the reg-view macro rejects Form-3 bodies).
+(rf/reg-view* :my-app.map/map-inner
+  (fn [_initial-pos]
+    (let [el-ref       (atom nil)     ;; mount-point handle
+          map-instance (atom nil)     ;; library instance (per-mount, NOT defonce)
+          dispatch     (:dispatch (rf/frame-handle))]   ;; captured at render — carries frame
+      (r/create-class
+        {:display-name "map-inner"
+         :component-did-mount
+         (fn [this]
+           (let [[_ {:keys [lat lng zoom]}] (r/argv this)
+                 m (js/mapboxgl.Map. (clj->js {:container @el-ref :center [lng lat] :zoom zoom}))]
+             (reset! map-instance m)
+             (.on m "moveend"                       ;; library callback → dispatch into the captured frame
+               (fn [_] (let [c (.getCenter m)]
+                         (dispatch [:map/user-panned (.-lat c) (.-lng c)]))))))
+         :component-did-update
+         (fn [this _ _ _]
+           (let [[_ {:keys [lat lng]}] (r/argv this)]
+             (.panTo @map-instance #js [lng lat])))   ;; push new props; do NOT rebuild
+         :component-will-unmount
+         (fn [_] (some-> @map-instance .remove)        ;; library dispose API — mandatory
+                 (reset! map-instance nil) (reset! el-ref nil))
+         :reagent-render
+         (fn [_pos] [:div {:ref #(reset! el-ref %) :style {:height "400px"}}])}))))
+
+;; Outer — Form-1, reads subs, hands props to the inner.
+(rf/reg-view map-panel []
+  (let [pos @(rf/subscribe [:current-position])]
+    [(rf/view :my-app.map/map-inner) pos]))
+```
+
+Load-bearing points: the outer is trivially small (sub, deref, pass); per-mount state lives in **closure atoms**, not `defonce`/top-level `def` (those leak across mounts + hot-reloads); the render body is stable across renders so the substrate leaves the mount node alone; the library callback dispatches via the captured `dispatch`; **`:component-will-unmount` is mandatory** (skipping it leaks the WebGL context / tile cache / listeners on every navigation). Props are a **map** so `r/argv` / `r/props` can destructure them.
+
+## Per-adapter spelling
+
+The shape is identical; only the lifecycle surface differs.
+
+| Adapter | Inner lifecycle surface | Registration |
+|---|---|---|
+| **Reagent** / **Reagent-slim** | `create-class` Form-3 (`:component-did-mount` / `-did-update` / `-will-unmount` + `:reagent-render`) | `reg-view*` |
+| **UIx** | `use-effect` inside a `defui`, deps vector listing every prop read; cleanup is the returned fn | `reg-view` (plain fn) |
+| **Helix** | `use-effect` inside a `defnc`, deps vector **first**, cleanup is the last expression | `reg-view` (plain fn) |
+
+See the per-adapter README "Imperative escape hatch" sections for the hooks-shaped spelling.
+
+## Animations are a special case
+
+Regime C (library-bridged: Framer Motion, React-Spring, GSAP, AutoAnimate) **is** this pattern — outer derives state-driven props (target opacity, x/y, easing), inner hands them to the library, completion callbacks bridge via the captured `frame-handle`. Regimes A (CSS-driven `:class`) and B (per-frame RAF loop in a registered fx) do *not* use this pattern — no library to wrap.
+
+## Anti-patterns
+
+- **`addEventListener` from a render body.** Fires with no `*current-frame*` (silent `:rf/default` route) and leaks. The right home is the inner's mount hook with cleanup on unmount.
+- **Owning the library lifecycle in a render body.** `(js/MyLib. el opts)` from a Form-1 builds a fresh instance every render — leaking at the rate of reactive updates. Build it once in the mount hook.
+- **`@(subscribe …)` inside a lifecycle hook.** No reactive context after commit. Subscribe in the outer; pass the value as a prop.
+- **Stashing the instance in `defonce` / top-level `def`.** Leaks across mounts and hot-reloads; breaks when the component mounts twice (two frames). The instance is per-mount — closure cell only.
+
+## Worked example
+
+No standalone example app — the per-adapter READMEs carry the worked spelling for each substrate (`implementation/adapters/<name>/README.md` §Imperative escape hatch). The Mapbox shape above is the canonical summary; substitute the library.
+
+## Pointers
+
+- Spec: [`spec/Pattern-StatefulComponents.md`](../../../spec/Pattern-StatefulComponents.md) — the full outer/inner rationale, the per-adapter table, the animations-as-special-case discussion, the antipattern reasons.
+- Substrate: `SKILL-REDIRECT.md` → *EP — Views (004)* §View antipatterns (the normative MUST-NOTs), §Form-3, §Animations Regime C; *EP — Frames (002)* (why `frame-handle` must be captured at render-time).
+- Compose: `patterns/reusable-components.md` (a `[customer-chart id]` is a reusable component that also wraps a library), `patterns/async-effect.md` (when the library exposes its own async callbacks, e.g. a tile-loaded event).
+
+---
+
+*Derived from `spec/Pattern-StatefulComponents.md` (Convention, not Spec) @ main. Re-verify if `reg-view*` Form-3 or the per-adapter lifecycle surfaces change.*

--- a/skills/re-frame2/references/cross-cutting/ssr-authoring.md
+++ b/skills/re-frame2/references/cross-cutting/ssr-authoring.md
@@ -130,7 +130,7 @@ When the page shell + header should render immediately while slow subtrees strea
  [slow-card card-id]]                         ;; renders the fallback until the card's data resolves, then streams in
 ```
 
-Worked example: `examples/reagent/ssr_streaming/core.cljc` (a three-slow-card dashboard) — read it for the `:rf/suspense-boundary` marker, per-card fallback hiccup, inline-fallback failure semantics, and interleaved per-subtree hydration. Spec: [`spec/011-SSR.md §Streaming`](../../../../spec/011-SSR.md#streaming-ssr). For the parallel data-fetch fan-out an SSR request needs, see `Pattern-SSR-Loaders` (reachable via `boot.md`'s `:spawn-all` fan-out shape). Low priority — skip unless the task is explicitly streaming SSR.
+Worked example: `examples/reagent/ssr_streaming/core.cljc` (a three-slow-card dashboard) — read it for the `:rf/suspense-boundary` marker, per-card fallback hiccup, inline-fallback failure semantics, and interleaved per-subtree hydration. Spec: [`spec/011-SSR.md §Streaming`](../../../../spec/011-SSR.md#streaming-ssr). For the parallel data-fetch fan-out an SSR request needs, see [`../../patterns/ssr-loaders.md`](../../patterns/ssr-loaders.md). Low priority — skip unless the task is explicitly streaming SSR.
 
 ## Common gotchas
 
@@ -143,6 +143,7 @@ Worked example: `examples/reagent/ssr_streaming/core.cljc` (a three-slow-card da
 
 ## Cross-references
 
+- SSR patterns: [`../../patterns/form-action.md`](../../patterns/form-action.md) (handling an HTML form POST — progressive enhancement, CSRF, multipart); [`../../patterns/ssr-loaders.md`](../../patterns/ssr-loaders.md) (parallel data fetch via `:spawn-all` before render). A page typically uses Loaders for the GET render and FormAction for subsequent POSTs.
 - Spec normative: [`spec/011-SSR.md §Head/meta contract`](../../../../spec/011-SSR.md) (`reg-head` / `render-head` / `active-head`); [`§The :rf/hydrate event`](../../../../spec/011-SSR.md) (check fxs).
 - API summary: [`spec/API.md §SSR (Spec 011)`](../../../../spec/API.md) — `render-head`, `active-head`, `head-model->html` row; `reg-head` row in §Registration.
 - Guide chapter: [`docs/guide/20-server-side.md`](../../../../docs/guide/20-server-side.md) — narrative walkthrough, head/meta and hydration sections.


### PR DESCRIPTION
## What

The `re-frame2` authoring skill claimed to cover "the canonical patterns" but carried **no leaf and no routing** for four spec-documented patterns. An agent asking "how do I wrap a D3 chart?" or "reusable customer-card widget" got no canonical-shape guidance — the exact failure the skill's "recipes over explanations" rule exists to prevent.

Adds four `patterns/` leaves, each a concise pointer-to-spec teaching aid (progressive disclosure — summarise the when/why/shape, link to the spec):

| Leaf | Spec doc |
|---|---|
| `patterns/reusable-components.md` | `spec/Pattern-ReusableComponents.md` |
| `patterns/stateful-components.md` | `spec/Pattern-StatefulComponents.md` |
| `patterns/form-action.md` | `spec/Pattern-FormAction.md` |
| `patterns/ssr-loaders.md` | `spec/Pattern-SSR-Loaders.md` |

Each mirrors the existing leaf shape exactly: summary + mental-model anchor + when-to-load + canonical declaration + anti-patterns + worked-example + spec pointers + provenance line. All within the leaf-size budget (102-111 lines, <8.7 KB; ceiling 250 lines / 16 KB).

## Routing (discoverability)

- **SKILL.md** — added all four to the "Which pattern fits" table + the frontmatter `description` pattern list.
- **decision-trees/pick-a-pattern.md** — added four shape-tells (Step 1) + four rows to the Step-4 leaf-load table.
- **skills/README.md** + **docs/skills/re-frame2.md** — added the four pattern names to the canonical-patterns enumerations.
- **references/cross-cutting/ssr-authoring.md** — repointed the stale `Pattern-SSR-Loaders` reference at the new leaf, and added a Cross-references entry for both SSR leaves (SSR authors land here).

## Quality gates

- **Skills structural test** — the authoritative authoring-skill validator (`clojure -M -m re-frame.api-manifest.skills-check`, the `skills/` projection gate in lint.yml) passes: `OK: skills/ (excl. re-frame-migration) projection in sync (470 public-var references checked against the manifest).` Every `(rf/<var>` call in the new leaves resolves to a manifest row (reg-sub, reg-view, reg-view*, reg-event-db/fx, reg-machine, reg-app-schema via cheatsheet, frame-handle, inject-cofx, dispatch, subscribe, view). The CI `skills-structural` job (test.yml) only fires on `skills/re-frame2-pair/*` + `skills/shared/*` changes, so it does not gate this PR; the shared retro-protocol structural test was run anyway and passes (29 tests / 44 assertions / 0 failures).
- **Routing self-consistent** — 13 pattern leaves, all 13 present in both the SKILL.md table and the pick-a-pattern Step-4 table; the 4 new leaves reachable from README + SKILL.md + the decision tree + ssr-authoring.md. Counts/links match.
- **Leaf-size budget respected** — all four ≤111 lines / ≤8.7 KB (target ~150 / ~10 KB; ceiling 250 / 16 KB).
- **No broken links** — all spec links (`../../../spec/Pattern-*.md`) and intra-skill links resolve; verified on disk.
- **mkdocs build --strict** — mkdocs not installed locally; the only docs-site edit is a one-line addition to an existing nav-included page (`docs/skills/re-frame2.md`), no new files / nav / links, so it cannot affect `--strict` link/nav validation. The `patterns/*` leaves are not in the mkdocs nav.

Closes rf2-s6bud.