### PR TITLE
fix(story-mcp): surface :dropped-sensitive/:elided-large egress indicator counts (rf2-koq5m)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-story.cjs
+++ b/tools/mcp-conformance/test/end-to-end-story.cjs
@@ -329,7 +329,21 @@ runWithWatchdog(
           JSON.stringify(failResp),
       );
     }
-    console.log('OK   read-failures -> total=0, failures=[], :status="pass"');
+    // rf2-koq5m — egress indicator omit-when-zero MUST: a clean read
+    // (no sensitive records dropped, nothing elided) carries NEITHER
+    // `:dropped-sensitive` nor `:elided-large`. The positive-count side
+    // is pinned by the JVM `tools_test.clj` indicator deftests; the live
+    // SDK driver pins the omit-when-zero contract end-to-end.
+    if ('dropped-sensitive' in failStruct || 'elided-large' in failStruct) {
+      throw new Error(
+        'read-failures clean read must OMIT indicator slots when zero ' +
+          '(Conventions §Cross-MCP indicator-field vocabulary, rf2-koq5m); got: ' +
+          JSON.stringify(failResp),
+      );
+    }
+    console.log(
+      'OK   read-failures -> total=0, failures=[], :status="pass", indicators omitted (omit-when-zero)',
+    );
 
     // 7b. explain-variant — the agent mirror of the human Explain panel
     // (rf2-ba86n.17). Assert the source-chain / merge / runner-requirement

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -425,10 +425,25 @@
 ;; ---------------------------------------------------------------------------
 ;; Cross-server posture pin — story-mcp.
 ;;
-;; The sibling `wire_vocab_test.clj` already pins:
-;; - story-mcp emits ZERO cross-MCP markers
-;; - story-mcp emits ZERO envelope indicators (it doesn't walk
-;;   tree-typed payloads today)
+;; The sibling `wire_vocab_test.clj` pins:
+;; - story-mcp emits ZERO UNCONTRACTED cross-MCP markers (it is
+;;   contracted for `:rf.mcp/dedup-table` only)
+;; - story-mcp NOW emits both envelope indicators (rf2-koq5m): its
+;;   `run-variant` / `preview-variant` / `read-failures` payload
+;;   builders drop `:sensitive? true` assertion records and elide
+;;   over-threshold `:app-db` leaves, surfacing the counts via the
+;;   centralised `egress/with-indicators` helper (delegating to
+;;   `re-frame.mcp-base.envelope/with-indicators`) +
+;;   `egress/count-elided` (delegating to
+;;   `re-frame.mcp-base.elision/count-elided-markers`). The
+;;   `envelope-slot-parity-across-emitting-servers` +
+;;   `story-mcp-routes-envelope-through-the-centralised-helper` gates in
+;;   `wire_vocab_test.clj` pin that routing.
+;;
+;; The story-mcp tool sources are CLJC (not CLJS), so the
+;; `re-frame2-pair-mcp-source-files` walker above (CLJS-only) does not
+;; cover them; the story-mcp routing pin lives in `wire_vocab_test.clj`
+;; against the `.cljc` helper + tool sources.
 ;;
 ;; The xray-mcp T-Insp cluster (historic rf2-8xzoe.14..22) was
 ;; reverted in rf2-bu21t — `tools/xray-mcp/` is now absent. Xray

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -1078,15 +1078,22 @@
   parity is the round-2 audit fix this gate enforces)."
   [{:slot     :dropped-sensitive
     :schema   DroppedSensitive
-    :emitters #{:re-frame2-pair-mcp}
+    :emitters #{:re-frame2-pair-mcp :story-mcp}
     :fixtures {:re-frame2-pair-mcp-trace-window
                {:ok? true :epochs [] :dropped-sensitive 3}
                :re-frame2-pair-mcp-snapshot
-               {:ok? true :snapshot {} :dropped-sensitive 1}}}
+               {:ok? true :snapshot {} :dropped-sensitive 1}
+               ;; story-mcp emission (rf2-koq5m): `read-failures` /
+               ;; `run-variant` / `preview-variant` drop `:sensitive? true`
+               ;; assertion records at egress and surface the count via
+               ;; `egress/with-indicators` (→ mcp-base envelope helper).
+               :story-mcp-read-failures
+               {:variant-id :story.button/primary :status :pass
+                :total 1 :failures [] :assertions [] :dropped-sensitive 2}}}
 
    {:slot     :elided-large
     :schema   ElidedLarge
-    :emitters #{:re-frame2-pair-mcp}
+    :emitters #{:re-frame2-pair-mcp :story-mcp}
     :fixtures {:re-frame2-pair-mcp-snapshot
                {:ok? true :snapshot {} :elided-large 2}
                :re-frame2-pair-mcp-get-path
@@ -1098,6 +1105,18 @@
                   :reason :schema
                   :hint "User PDF; fetch via get-path."
                   :handle [:rf.elision/at [:user :pdf]]}}
+                :elided-large 1}
+               ;; story-mcp emission (rf2-koq5m): `run-variant` /
+               ;; `preview-variant` elide schema-`:large?` / over-threshold
+               ;; `:app-db` leaves and count the `:rf.size/large-elided`
+               ;; markers via `egress/count-elided` (→ mcp-base
+               ;; `count-elided-markers`).
+               :story-mcp-run-variant
+               {:status :pass :frame :story.button/primary
+                :app-db {:blob {:rf.size/large-elided
+                                {:path [:blob] :bytes 102400 :type :string
+                                 :reason :schema :hint nil
+                                 :handle [:rf.elision/at [:blob]]}}}
                 :elided-large 1}}}])
 
 (deftest envelope-indicator-fixtures-conform
@@ -1114,52 +1133,74 @@
   Restricted to the actual tool source — the spec/docs files may
   mention the slots without emitting them.
 
-  Post-rf2-vrbwx split: re-frame2-pair-mcp's envelope-slot emit point is the
-  centralised `wire/with-indicators` helper (rf2-dfk28); the literals
-  live in `wire.cljs`. Per-tool routing through the helper is pinned
-  in detail by `indicator_field_test.clj`; this gate just asserts the
-  two literals appear in the canonical helper location."
-  {:re-frame2-pair-mcp ["tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs"]
-   :story-mcp []})        ;; doesn't walk tree-typed payloads today
+  Both servers route through a single centralised emit-path that
+  delegates to the shared mcp-base helper
+  (`re-frame.mcp-base.envelope/with-indicators`), so the parity gate
+  pins the two literals at the per-server helper location:
 
-(deftest envelope-slot-parity-in-re-frame2-pair-mcp
+  - re-frame2-pair-mcp: `wire.cljs` `with-indicators` (rf2-dfk28); the
+    literals live in its docstring + delegation. Per-tool routing is
+    pinned in detail by `indicator_field_test.clj`.
+  - story-mcp (rf2-koq5m): `egress.cljc` `with-indicators` +
+    `count-elided` — the centralised egress helper the
+    `run-variant` / `preview-variant` / `read-failures` payload
+    builders thread through. `tools_test.clj` exercises the live
+    emission end-to-end."
+  {:re-frame2-pair-mcp ["tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs"]
+   :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc"]})
+
+(deftest envelope-slot-parity-across-emitting-servers
   ;; MUST-level pin (Conventions rf2-2499j, Spec 009 §Indicator field
   ;; on tool responses): every server that emits one slot MUST emit
   ;; the other. The round-2 alignment audit (rf2-zjqh8) caught
   ;; re-frame2-pair-mcp emitting only `:dropped-sensitive`; this gate locks
-  ;; in the parity so the regression can't return silently.
-  (let [files (get envelope-emitter-source-files :re-frame2-pair-mcp)]
-    (is (seq files)
-        "No source files registered for re-frame2-pair-mcp envelope emit sites.")
-    (doseq [rel files]
-      (let [src (fx/read-source rel)]
-        (testing (str "re-frame2-pair-mcp " rel " — :dropped-sensitive literal")
-          (is (str/includes? src ":dropped-sensitive")
-              (str ":dropped-sensitive literal missing from " rel)))
-        (testing (str "re-frame2-pair-mcp " rel " — :elided-large literal")
-          (is (str/includes? src ":elided-large")
-              (str ":elided-large literal missing from " rel
-                   " — parity break per Conventions rf2-2499j.")))))))
+  ;; in the parity so the regression can't return silently. As of
+  ;; rf2-koq5m story-mcp is also a contracted emitter — the gate now
+  ;; runs across BOTH servers' helper sources.
+  (doseq [server [:re-frame2-pair-mcp :story-mcp]]
+    (let [files (get envelope-emitter-source-files server)]
+      (is (seq files)
+          (str "No source files registered for " server " envelope emit sites."))
+      (doseq [rel files]
+        (let [src (fx/read-source rel)]
+          (testing (str server " " rel " — :dropped-sensitive literal")
+            (is (str/includes? src ":dropped-sensitive")
+                (str ":dropped-sensitive literal missing from " rel)))
+          (testing (str server " " rel " — :elided-large literal")
+            (is (str/includes? src ":elided-large")
+                (str ":elided-large literal missing from " rel
+                     " — parity break per Conventions rf2-2499j."))))))))
 
-(deftest story-mcp-still-emits-zero-envelope-indicators
-  ;; Tripwire mirroring `story-mcp-still-emits-zero-cross-mcp-markers`.
-  ;; The day story-mcp adopts a tree-typed-payload walker (e.g. wires
-  ;; `elide-wire-value` over the `:app-db` slot in `preview-variant` /
-  ;; `run-variant`), both envelope slots MUST land together. This
-  ;; tripwire flips RED on the FIRST adoption so the reviewer can't
-  ;; merge half the parity.
-  (let [story-files fx/story-mcp-source-files
-        slots       [":dropped-sensitive" ":elided-large"]]
-    (doseq [rel  story-files
-            slot slots]
-      (testing (str "story-mcp source " rel " — " slot " absence")
-        (is (not (str/includes? (fx/read-source rel) slot))
-            (str slot " literal found in " rel
-                 ".\nIf story-mcp now walks a tree-typed payload, "
-                 "the OTHER envelope slot MUST land in the same commit "
-                 "(Conventions rf2-2499j MUST-level parity). Update "
-                 "`envelope-emitter-source-files` and "
-                 "`envelope-indicator-slots`."))))))
+(deftest story-mcp-routes-envelope-through-the-centralised-helper
+  ;; rf2-koq5m: story-mcp adopted the envelope-indicator parity. The
+  ;; centralised emit-path is `egress/with-indicators` (delegating to
+  ;; the shared mcp-base helper) + `egress/count-elided` (delegating to
+  ;; `count-elided-markers`). This pin asserts the helper exists AND
+  ;; that the three tree-walking tools route their payload through it —
+  ;; the structural guarantee that the omit-when-zero MUST lives in one
+  ;; place, mirroring `indicator_field_test.clj`'s pair-mcp routing pin.
+  (let [egress-rel "tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc"
+        egress-src (fx/read-source egress-rel)]
+    (testing "egress.cljc defines the centralised with-indicators helper"
+      (is (str/includes? egress-src "(defn with-indicators")
+          (str "`with-indicators` helper missing from " egress-rel)))
+    (testing "egress.cljc delegates to the shared mcp-base envelope helper"
+      (is (str/includes? egress-src "base-envelope/with-indicators")
+          (str egress-rel " must delegate to "
+               "`re-frame.mcp-base.envelope/with-indicators` — the emit-path "
+               "MUST stay centralised in mcp-base (rf2-koq5m / rf2-ee38b.19).")))
+    (testing "egress.cljc defines count-elided over the mcp-base walker"
+      (is (str/includes? egress-src "base-elision/count-elided-markers")
+          (str egress-rel " must reuse "
+               "`re-frame.mcp-base.elision/count-elided-markers` for the "
+               ":elided-large count (rf2-koq5m)."))))
+  (doseq [rel ["tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc"
+               "tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc"]]
+    (testing (str rel " — routes payload through egress/with-indicators")
+      (is (str/includes? (fx/read-source rel) "egress/with-indicators")
+          (str rel " does not route its payload through "
+               "`egress/with-indicators` — the centralised emit-path is the "
+               "structural contract for the omit-when-zero MUST (rf2-koq5m).")))))
 
 ;; ---------------------------------------------------------------------------
 ;; `:rf.mcp/cursor-stale` reason-value gate (rf2-i3ffz F-GAP-5).

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -64,6 +64,40 @@ Per
 the boundary between Story core and this jar is: Story core exposes
 the read primitives; this jar packages them as MCP tools.
 
+## Egress indicator counts (`:dropped-sensitive` / `:elided-large`, rf2-koq5m)
+
+The three tools that walk a tree-typed payload — `preview-variant`,
+`run-variant`, `read-failures` — drop `:sensitive? true` assertion
+records and replace over-threshold / schema-`:large?` `:app-db` leaves
+with the `:rf.size/large-elided` marker at the wire egress. Per
+[`spec/Conventions.md` §Cross-MCP indicator-field vocabulary][conv]
+(MUST-level) and [Spec 009 §Indicator field on tool responses][s009],
+each of those tools MUST carry a scalar summary of how much the egress
+filtered:
+
+| Slot | Meaning |
+|---|---|
+| `:dropped-sensitive` | count of `:sensitive? true` assertion records dropped at egress |
+| `:elided-large` | count of `:rf.size/large-elided` markers across the response payload |
+
+Both keys are **unqualified** and ride alongside the tool's own
+result slots. Each is **omitted entirely when its count is zero**
+(omit-when-zero) — a clean read carries neither. The counts are spliced
+by the centralised `egress/with-indicators` helper, which delegates to
+the shared `re-frame.mcp-base.envelope/with-indicators`; the
+`:elided-large` count is produced by `egress/count-elided` →
+`re-frame.mcp-base.elision/count-elided-markers`. story-mcp reuses the
+SAME mcp-base primitives the sibling `re-frame2-pair-mcp` wires across
+its tree-walking tools, so the slot bytes stay byte-identical across the
+pair and the cross-MCP conformance gate
+(`tools/mcp-conformance/wire-vocab`) pins the parity. Without the scalar
+summary an agent sees the inline `:rf/redacted` sentinels / vanished
+assertions but no signal that the payload was filtered, or by how much —
+the canonical silent-swallow failure mode this MUST closes.
+
+[conv]: ../../../spec/Conventions.md#cross-mcp-indicator-field-vocabulary-suppression-counters
+[s009]: ../../../spec/009-Instrumentation.md#size-elision-in-traces
+
 ## Dev — for agents helping build new stories
 
 Three tools that help an agent get its bearings before generating

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -135,13 +135,14 @@
                             :checks     []}))
             incl?      (targs/include-sensitive? arguments)
             raw-db     (:app-db outcome)
+            [assertions dropped] (egress/scrub-assertions+count (:assertions outcome) incl?)
             payload    {:variant-id   vk
                         :share-url    share-url
                         :status       (:status outcome)
                         :lifecycle    (:lifecycle outcome)
                         :elapsed-ms   (:elapsed-ms outcome)
                         :app-db       (egress/elide-app-db raw-db vk incl?)
-                        :assertions   (egress/scrub-assertions (:assertions outcome) incl?)
+                        :assertions   assertions
                         :checks       (vec (:checks outcome))
                         ;; Derived trees re-key the same sensitive value at a
                         ;; non-app-db path, so the path-based walker can't
@@ -149,7 +150,14 @@
                         :rendered-hiccup (egress/scrub-rendered (:rendered-hiccup outcome) raw-db vk incl?)
                         :snapshot     (egress/scrub-rendered (:snapshot outcome) raw-db vk incl?)
                         :effective-args (egress/scrub-rendered (:effective-args outcome) raw-db vk incl?)}]
-        (result/edn-result payload)))))
+        ;; Surface the MUST-level egress indicator counts (rf2-koq5m):
+        ;; how many sensitive assertion records were dropped + how many
+        ;; over-threshold leaves were elided across the payload. Omitted
+        ;; when zero (Conventions §Cross-MCP indicator-field vocabulary).
+        (result/edn-result
+          (egress/with-indicators payload
+                                  {:dropped dropped
+                                   :elided  (egress/count-elided payload)}))))))
 
 (defn tool-list-substrates
   "Dev: what substrates can be used. Reads the registered substrate set

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
@@ -46,6 +46,8 @@
   `:include-sensitive` opt-out escape hatch as `:app-db`."
   (:require [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]
+            [re-frame.mcp-base.elision :as base-elision]
+            [re-frame.mcp-base.envelope :as base-envelope]
             [re-frame.mcp-base.sensitive :as sensitive]))
 
 ;; ---------------------------------------------------------------------------
@@ -88,27 +90,40 @@
                     (refresh-elision-from-schemas! variant-id)
                     (rf/elide-wire-value app-db {:frame variant-id}))))
 
-(defn scrub-assertions
+(defn scrub-assertions+count
   "Default-drop any assertion records carrying the top-level
   `:sensitive? true` stamp. Reuses `strip-sensitive` (the shared trace-
   event filter from `mcp-base.sensitive`) — assertion records and trace
   events both honour the same convention, so a single primitive covers
   both surfaces.
 
+  Returns `[kept dropped-count]` — the kept vec PLUS the number of
+  sensitive records dropped. The count is the `:dropped-sensitive`
+  indicator the caller threads onto its response envelope via
+  `with-indicators` (Conventions §Cross-MCP indicator-field vocabulary,
+  MUST-level): an agent that sees redacted leaves but no scalar summary
+  cannot tell HOW MUCH the egress filtered. This is the canonical
+  silent-swallow failure mode the indicator count closes (rf2-koq5m).
+
   Two short-circuits avoid pointless work on the opt-in / empty paths:
 
-    - `include? true` returns `(vec (or records []))` directly — the
+    - `include? true` returns `[(vec (or records [])) 0]` directly — the
       walker would yield the input unchanged anyway (no drops with the
       escape hatch open), so we skip the traversal.
-    - `nil`/empty records short-return `[]`.
-
-  Returns the kept-vec (the `dropped-count` second slot is suppressed
-  here; the caller is the wire egress, not an audit surface)."
+    - `nil`/empty records short-return `[[] 0]`."
   [records include?]
   (cond
-    include?       (vec (or records []))
-    (nil? records) []
-    :else          (first (sensitive/strip-sensitive records false))))
+    include?       [(vec (or records [])) 0]
+    (nil? records) [[] 0]
+    :else          (sensitive/strip-sensitive records false)))
+
+(defn scrub-assertions
+  "Kept-vec-only projection of `scrub-assertions+count` — the historical
+  signature for call sites that don't surface the dropped count. New
+  egress paths SHOULD prefer `scrub-assertions+count` and thread the
+  count onto the envelope via `with-indicators` (rf2-koq5m)."
+  [records include?]
+  (first (scrub-assertions+count records include?)))
 
 ;; ---------------------------------------------------------------------------
 ;; Derived-tree value-based redaction (rf2-ee38b.17)
@@ -178,3 +193,48 @@
                       (if (empty? secrets)
                         tree
                         (redact-matching tree secrets)))))
+
+;; ---------------------------------------------------------------------------
+;; Wire-egress indicator counts (rf2-koq5m).
+;;
+;; story-mcp's egress drops `:sensitive? true` assertion records and
+;; replaces over-threshold / schema-`:large?` leaves with the
+;; `:rf.size/large-elided` marker — but until rf2-koq5m it surfaced
+;; NEITHER count. spec/Conventions.md §Cross-MCP indicator-field
+;; vocabulary is MUST-level: a tool that walks a tree-typed payload MUST
+;; carry an `:elided-large` count alongside the `:dropped-sensitive`
+;; count, omitting each slot when zero. The sibling pair-mcp already
+;; wires `re-frame.mcp-base.envelope/with-indicators` +
+;; `re-frame.mcp-base.elision/count-elided-markers` across its tools;
+;; story-mcp now reuses the SAME mcp-base primitives so the omit-when-
+;; zero rule lives in one place and the count bytes stay byte-identical
+;; across the pair.
+;; ---------------------------------------------------------------------------
+
+(defn count-elided
+  "Count the `{:rf.size/large-elided ...}` markers `elide-app-db` /
+  `scrub-rendered` left in `payload`, via the shared mcp-base walker.
+  This is the `:elided-large` indicator the caller threads onto its
+  response envelope. Walk the FINAL payload (post-elision) so every
+  elided slot — `:app-db`, `:rendered-hiccup`, `:snapshot`, the evidence
+  trees — contributes; the marker is the same shape regardless of which
+  slot produced it.
+
+  Returns an integer >= 0; cheap on the common path (no markers => one
+  walk producing zero)."
+  [payload]
+  (base-elision/count-elided-markers payload))
+
+(defn with-indicators
+  "Splice the cross-MCP indicator-field slots (`:dropped-sensitive`,
+  `:elided-large`) onto a tool's payload map, honouring the MUST-level
+  omit-when-zero rule (Conventions §Cross-MCP indicator-field
+  vocabulary; Spec 009 §Indicator field on tool responses).
+
+  Thin pass-through to `re-frame.mcp-base.envelope/with-indicators` —
+  the rule body lives in mcp-base so both servers in the pair re-export
+  the same emit-path (the conformance gate pins the single source). The
+  `counts` map is `{:dropped <n> :elided <n>}`; a zero / nil count omits
+  its slot, so a clean read returns the payload unchanged."
+  [payload counts]
+  (base-envelope/with-indicators payload counts))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -137,10 +137,11 @@
                           :checks     []}))
             incl?    (targs/include-sensitive? arguments)
             raw-db   (:app-db outcome)
+            [assertions dropped] (egress/scrub-assertions+count (:assertions outcome) incl?)
             payload  (cond-> {:status             (:status outcome)
                               :frame              (:frame outcome vk)
                               :app-db             (egress/elide-app-db raw-db vk incl?)
-                              :assertions         (egress/scrub-assertions (:assertions outcome) incl?)
+                              :assertions         assertions
                               :checks             (vec (:checks outcome))
                               :consumed-selectors (:consumed-selectors outcome #{})
                               ;; Evidence-slot projections (.4 — one tape, one
@@ -174,7 +175,14 @@
                        ;; attempt some expectation.
                        (contains? outcome :cannot-run)
                        (assoc :cannot-run (:cannot-run outcome)))]
-        (result/edn-result payload)))))
+        ;; Surface the MUST-level egress indicator counts (rf2-koq5m):
+        ;; dropped sensitive assertion records + elided over-threshold
+        ;; leaves across every value-bearing slot. Omitted when zero
+        ;; (Conventions §Cross-MCP indicator-field vocabulary).
+        (result/edn-result
+          (egress/with-indicators payload
+                                  {:dropped dropped
+                                   :elided  (egress/count-elided payload)}))))))
 
 (defn tool-snapshot-identity
   "Testing: content-hash of the canonicalised variant (for external
@@ -262,7 +270,7 @@
     (fn [vk]
       (let [incl?      (targs/include-sensitive? arguments)
             raw        (assertions/read-assertions vk)
-            scrubbed   (egress/scrub-assertions raw incl?)
+            [scrubbed dropped] (egress/scrub-assertions+count raw incl?)
             ;; Stamp the derived :status on every record so the agent reads
             ;; the SAME unified record shape `run-variant` emits.
             records    (story-result/assertion-records scrubbed)
@@ -272,7 +280,14 @@
                         :total      (count records)
                         :failures   failures
                         :assertions records}]
-        (result/edn-result payload)))))
+        ;; Surface the MUST-level egress indicator counts (rf2-koq5m):
+        ;; how many sensitive assertion records were dropped at egress
+        ;; (+ any elided leaves). Omitted when zero (Conventions
+        ;; §Cross-MCP indicator-field vocabulary).
+        (result/edn-result
+          (egress/with-indicators payload
+                                  {:dropped dropped
+                                   :elided  (egress/count-elided payload)}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Registry descriptors (assembled in `tools.registry/tool-registry`)

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -23,6 +23,7 @@
             [re-frame.story-mcp.server :as server]
             [re-frame.story-mcp.tools.wire-pipeline :as wire-pipeline]
             [re-frame.story-mcp.tools.dev :as dev]
+            [re-frame.story-mcp.tools.egress :as egress]
             [re-frame.story-mcp.tools.recorder :as recorder-tool]
             [re-frame.story-mcp.tools.registry :as registry]
             [re-frame.story-mcp.tools.testing :as testing-tool]
@@ -1923,6 +1924,17 @@
   (schemas/reg-app-schema path [:any {:sensitive? true}]
                           {:frame variant-id}))
 
+(defn- declare-large!
+  "Register schema metadata flagging a slot `:large?` on the named
+  variant's frame. The tool egress helper refreshes schema declarations
+  before `elide-wire-value`, which substitutes the slot's value with the
+  `:rf.size/large-elided` marker — the leaf the `:elided-large`
+  indicator counts (rf2-koq5m)."
+  [variant-id path]
+  (ensure-variant-frame! variant-id)
+  (schemas/reg-app-schema path [:any {:large? true}]
+                          {:frame variant-id}))
+
 (defn- seed-app-db!
   "Write `db` into `variant-id`'s frame app-db. Helper for the privacy
   tests so we can populate slots without invoking a full `run-variant`."
@@ -2302,6 +2314,104 @@
         (is (= 2 (:total s)) "both records survive the egress")
         (is (= 1 (count (:failures s))) "the failed sensitive record is visible")
         (is (= :fail (:status s)) "the visible failure drives :status :fail")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-koq5m (headline P1, privacy/observability MUST at the AI boundary) —
+;; egress indicator counts (`:dropped-sensitive` / `:elided-large`).
+;;
+;; story-mcp drops `:sensitive? true` assertion records and elides
+;; over-threshold / schema-`:large?` leaves at the wire egress, but
+;; surfaced NEITHER count — the canonical silent-swallow failure mode.
+;; spec/Conventions.md §Cross-MCP indicator-field vocabulary is MUST-
+;; level: a tool walking a tree-typed payload MUST carry an
+;; `:elided-large` count alongside the `:dropped-sensitive` count,
+;; omitting each slot when zero. The fix reuses the mcp-base primitives
+;; (`envelope/with-indicators` + `elision/count-elided-markers`) the
+;; sibling pair-mcp already wires.
+;;
+;; RED (pre-fix): the response carries no indicator slots even when a
+;; sensitive slot is dropped / a large value is elided.
+;; GREEN (post-fix): `:dropped-sensitive` / `:elided-large` present with
+;; the correct counts; omitted entirely on a clean read.
+;; ---------------------------------------------------------------------------
+
+(deftest read-failures-surfaces-dropped-sensitive-indicator
+  (testing ":dropped-sensitive count rides the envelope when a sensitive record is dropped"
+    (with-clean-frame [vid :story.button/primary]
+      (seed-app-db! vid
+                    {:rf.story/assertions
+                     [{:assertion :rf.assert/path-equals :passed? true :tags [:public]}
+                      {:assertion  :rf.assert/path-equals :passed? false
+                       :sensitive? true :reason "secret mismatch"}
+                      {:assertion  :rf.assert/sub-equals :passed? false
+                       :sensitive? true :reason "another secret mismatch"}]})
+      (let [r (invoke "read-failures" {:variant-id "story.button/primary"})
+            s (:structuredContent r)]
+        (is (success? r))
+        (is (= 1 (:total s)) "only the non-sensitive record survives")
+        (is (= 2 (:dropped-sensitive s))
+            "the count of dropped sensitive records rides the envelope (rf2-koq5m MUST)")))))
+
+(deftest read-failures-omits-indicators-when-nothing-dropped
+  (testing "neither indicator slot appears on a clean read (omit-when-zero MUST)"
+    (with-clean-frame [vid :story.button/primary]
+      (seed-app-db! vid
+                    {:rf.story/assertions
+                     [{:assertion :rf.assert/path-equals :passed? true :tags [:public]}]})
+      (let [r (invoke "read-failures" {:variant-id "story.button/primary"})
+            s (:structuredContent r)]
+        (is (success? r))
+        (is (not (contains? s :dropped-sensitive))
+            ":dropped-sensitive omitted when zero")
+        (is (not (contains? s :elided-large))
+            ":elided-large omitted when zero")))))
+
+(deftest read-failures-includes-sensitive-clears-dropped-indicator
+  (testing ":include-sensitive true keeps the records, so :dropped-sensitive stays absent"
+    (config/set-allow-sensitive-reads! true)
+    (with-clean-frame [vid :story.button/primary]
+      (seed-app-db! vid
+                    {:rf.story/assertions
+                     [{:assertion  :rf.assert/path-equals :passed? false
+                       :sensitive? true :reason "secret mismatch"}]})
+      (let [r (invoke "read-failures" {:variant-id "story.button/primary"
+                                       :include-sensitive true})
+            s (:structuredContent r)]
+        (is (success? r))
+        (is (= 1 (:total s)) "the sensitive record survives the opt-in")
+        (is (not (contains? s :dropped-sensitive))
+            "nothing was dropped, so the slot is omitted (omit-when-zero)")))))
+
+(deftest run-variant-surfaces-elided-large-indicator
+  (testing ":elided-large count rides the envelope when a large value is elided"
+    (with-clean-frame [vid :story.button/primary]
+      ;; A schema-declared `:large?` slot whose value the egress walker
+      ;; substitutes with `:rf.size/large-elided` — the leaf the
+      ;; `:elided-large` indicator counts.
+      (seed-app-db! vid {:public "ok" :blob "a-big-uploaded-blob"})
+      (declare-large! vid [:blob])
+      (let [r (invoke "run-variant" {:variant-id "story.button/primary"})
+            s (:structuredContent r)]
+        (is (success? r))
+        ;; The slot is replaced by the marker in the wire :app-db.
+        (is (contains? (get-in s [:app-db :blob]) :rf.size/large-elided)
+            "the large slot is replaced by the :rf.size/large-elided marker")
+        (is (pos-int? (:elided-large s))
+            "the count of elided leaves rides the envelope (rf2-koq5m MUST)")))))
+
+(deftest egress-with-indicators-honours-omit-when-zero
+  ;; Unit pin on the egress helper itself — the omit-when-zero rule it
+  ;; inherits from mcp-base. Belt-and-braces alongside the tool-level
+  ;; tests above so a drift in the helper wiring trips here directly.
+  (testing "both zero ⇒ payload unchanged"
+    (is (= {:ok? true}
+           (egress/with-indicators {:ok? true} {:dropped 0 :elided 0}))))
+  (testing "positive counts ⇒ both slots spliced"
+    (is (= {:ok? true :dropped-sensitive 3 :elided-large 2}
+           (egress/with-indicators {:ok? true} {:dropped 3 :elided 2}))))
+  (testing "count-elided walks the payload for :rf.size/large-elided markers"
+    (is (= 0 (egress/count-elided {:a 1 :b [2 3]})))
+    (is (= 1 (egress/count-elided {:a {:rf.size/large-elided {:path [:a] :bytes 99}}})))))
 
 (deftest egress-tools-input-schema-carries-include-sensitive
   (testing "every tool surfacing :app-db or assertions accepts :include-sensitive"


### PR DESCRIPTION
## Summary

story-mcp dropped `:sensitive?` assertion records and elided over-threshold / schema-`:large?` `:app-db` leaves at the wire egress (the AI boundary) **without** surfacing the indicator counts that [`spec/Conventions.md` §Cross-MCP indicator-field vocabulary](spec/Conventions.md) makes a **MUST**. An agent saw the inline `:rf/redacted` sentinels / vanished assertions but no scalar summary telling it the payload was filtered, or by how much — the canonical silent-swallow failure mode (CORRECTNESS + privacy/observability at the AI boundary). The sibling `re-frame2-pair-mcp` already honours this MUST.

## The fix — reuse the existing mcp-base primitives (no reinvention)

Wired story-mcp's egress path to the same mcp-base primitives pair-mcp uses:

- `egress/scrub-assertions+count` returns `[kept dropped]` — the count `scrub-assertions` previously **computed and threw away** ('the caller is the wire egress, not an audit surface').
- `egress/count-elided` delegates to `re-frame.mcp-base.elision/count-elided-markers` over the final payload.
- `egress/with-indicators` delegates to `re-frame.mcp-base.envelope/with-indicators` (the omit-when-zero MUST lives in one shared place; thin re-export mirroring pair-mcp's `wire/with-indicators`).

`run-variant` / `preview-variant` / `read-failures` thread `{:dropped :elided}` through `with-indicators` onto the payload before `edn-result`. Both slots are unqualified and **omitted when zero**.

**mcp-base was NOT modified** — read-only reuse of the existing `envelope` + `elision` primitives.

## Conformance + spec

- Added story-mcp to the `wire-vocab` indicator-field emitter contract: per-server fixtures, `envelope-slot-parity-across-emitting-servers` (now runs across both servers), and a new `story-mcp-routes-envelope-through-the-centralised-helper` pin. The old `story-mcp-still-emits-zero-envelope-indicators` tripwire is replaced by the positive routing pin.
- `end-to-end-story.cjs` SDK driver now pins the omit-when-zero side live.
- Registered the indicator-field rows in `tools/story-mcp/spec/002-Tool-Registry.md`.

## Quality gates

- **RED/GREEN test** (`tools_test.clj`): `read-failures-surfaces-dropped-sensitive-indicator` asserts `:dropped-sensitive 2` rides the envelope when 2 sensitive records drop; `run-variant-surfaces-elided-large-indicator` asserts `:elided-large` is a positive int when a `:large?` slot is elided; `read-failures-omits-indicators-when-nothing-dropped` pins omit-when-zero. **RED proven**: temporarily removing the `with-indicators` splice fails `read-failures-surfaces-dropped-sensitive-indicator` (`expected (= 2 (:dropped-sensitive s))`); **GREEN** with the splice restored.
- `clojure -M:test` (story-mcp JVM): **205 tests, 1045 assertions, 0 failures, 0 errors**.
- `node test/stdio-roundtrip.js` (story-mcp Node): **GREEN**.
- mcp-conformance for story-mcp: `npm run test:story` (SDK Client driver, gate [5]) **GREEN** (incl. new omit-when-zero live assertion); `npm run test:flag-gates` **GREEN**.
- wire-vocab conformance (gate [6]): `clojure -M:test` — **49 tests, 621 assertions, 0 failures**.
- `clojure -M:gen --check` (`check:descriptors`): **in sync (20 tools)** — no descriptor changed.
- clj-kondo: **0 errors** on changed files (5 warnings, all pre-existing).
- **mcp-base touched: NO** (read-only reuse of existing `envelope`/`elision` primitives).