### PR TITLE
fix(story): redact DOM-capture in snippets + promote runnable :network/:fx-decisions + large-int canon (rf2-0qoi0, rf2-vf8es, rf2-7w1vp)

### DIFF
--- a/tools/story/src/re_frame/story/fingerprint.cljc
+++ b/tools/story/src/re_frame/story/fingerprint.cljc
@@ -421,9 +421,24 @@
 ;;
 ;; THE NORMALISATION POLICY (host-portable canonical number form):
 ;;
-;; - INTEGERS pass through verbatim — `Long` / `BigInt` / `BigInteger` on the
-;;   JVM, integer-valued `number` on CLJS. Their `pr-str` is already host-
-;;   identical, so ordinary-value hashes are UNCHANGED (no golden rebase).
+;; - INTEGERS WITHIN the IEEE-754 safe-integer range (±2^53-1) pass through
+;;   verbatim — `Long` / `BigInt` / `BigInteger` on the JVM, integer-valued
+;;   `number` on CLJS. Their `pr-str` is host-identical, so ordinary-value
+;;   hashes are UNCHANGED (no golden rebase).
+;; - 3. LARGE INTEGERS (rf2-7w1vp). An integer whose magnitude EXCEEDS the
+;;   safe-integer range (2^53-1) is NOT host-portable: JavaScript's `Number`
+;;   cannot represent it exactly, so CLJS rounds it to the nearest double,
+;;   while a JVM `Long` / `BigInt` keeps full precision and `pr-str`s it
+;;   verbatim ("100000000000000000000N"). The same logical integer therefore
+;;   canonicalised to a bare integer string on the JVM but `[:rf/double <hex>]`
+;;   on CLJS → divergent hash. POLICY: route such an integer through the SAME
+;;   lossy IEEE-754 `double->bits-hex` path on BOTH hosts. Both agree on the
+;;   double approximation (CLJS has no other option; the JVM converts via
+;;   `(double x)`), so the canonical form is host-stable. The deliberate cost
+;;   is that two distinct large integers that round to the SAME double share a
+;;   canonical form — acceptable because CLJS cannot tell them apart anyway,
+;;   and a 64-bit-id / nanoTime / BigInt riding a hashed slice now diffs
+;;   cross-host stably rather than spuriously.
 ;; - A NUMBER WITH A FRACTIONAL VALUE, or an integer-valued double too large
 ;;   for a 64-bit integer (e.g. 1e21), canonicalises to
 ;;   `[double-tag "<16-hex IEEE-754 bits>"]`. The raw IEEE-754 64-bit pattern
@@ -462,6 +477,15 @@
   `=`-reflexive and would otherwise give a comparator-unstable order)."
   :rf/nan)
 
+(def ^:const max-safe-integer
+  "The largest integer JavaScript's `Number` represents EXACTLY — 2^53-1
+  (`js/Number.MAX_SAFE_INTEGER`). An integer of greater magnitude has no
+  exact `js/Number` representation, so CLJS rounds it to the nearest double
+  and the canonical form must take the lossy IEEE-754 bit path on BOTH hosts
+  to agree (rf2-7w1vp). Integers within ±this range `pr-str` host-identically
+  and pass through verbatim — no golden rebase."
+  9007199254740991)
+
 (defn- double->bits-hex
   "Return the 16-char lowercase hex of the IEEE-754 64-bit pattern of double
   `d`, identically on JVM + CLJS. The bit pattern of a given logical double
@@ -486,12 +510,17 @@
          (str (hx hi) (hx lo))))))
 
 (defn- canon-number
-  "Canonicalise a number to a host-portable form (rf2-vvqeo). Integers pass
-  through verbatim; a fractional / out-of-integer-range double becomes
-  `[double-tag <16-hex bits>]`; an integer-valued double within 64-bit
-  integer range folds to that integer (CLJS cannot distinguish it from the
-  integer anyway); a ratio is coerced to its double first; NaN folds to
-  `nan-tag`. See the policy comment above."
+  "Canonicalise a number to a host-portable form (rf2-vvqeo + rf2-7w1vp).
+  An integer WITHIN the IEEE-754 safe-integer range (±2^53-1, `max-safe-
+  integer`) passes through verbatim — its `pr-str` is host-identical. An
+  integer OUTSIDE that range (a large `Long` / `BigInt` / `BigInteger` /
+  `js/Number`) takes the SAME lossy `[double-tag <16-hex bits>]` IEEE-754
+  path on BOTH hosts (rf2-7w1vp — CLJS cannot represent it exactly anyway,
+  so JVM exactness is traded for cross-host agreement). A fractional / out-
+  of-integer-range double becomes `[double-tag <16-hex bits>]`; an integer-
+  valued double within 64-bit integer range folds to that integer (CLJS
+  cannot distinguish it from the integer anyway); a ratio is coerced to its
+  double first; NaN folds to `nan-tag`. See the policy comment above."
   [x]
   #?(:clj
      (cond
@@ -508,7 +537,19 @@
                 (<= (double Long/MIN_VALUE) d (double Long/MAX_VALUE)))
            (long d)
            :else [double-tag (double->bits-hex d)]))
-       :else x)                          ; Long / BigInt / BigInteger / Integer
+       ;; An INTEGER whose magnitude exceeds the IEEE-754 safe-integer range
+       ;; (2^53-1) is NOT host-portable through `pr-str` (rf2-7w1vp): CLJS has
+       ;; no exact integer past 2^53 — a `js/Number` rounds it to the nearest
+       ;; double, and the CLJS branch below already routes it through
+       ;; `double->bits-hex`. So a JVM `Long` / `BigInt` / `BigInteger` of the
+       ;; same logical magnitude must take the SAME lossy IEEE-754 path to
+       ;; agree cross-host. Within the safe range, integers pass through
+       ;; verbatim (their `pr-str` is host-identical — no golden rebase).
+       (integer? x)
+       (if (<= (- max-safe-integer) x max-safe-integer)
+         x
+         [double-tag (double->bits-hex (double x))])
+       :else x)                          ; non-integer / unrecognised numeric
      :cljs
      (cond
        (js/Number.isNaN x)              nan-tag
@@ -527,7 +568,9 @@
   collection kinds (rf2-lvrqa), function values folded to a stable opaque
   sentinel (rf2-4gwja), host-divergent numbers normalised to a bit-stable
   form (rf2-vvqeo — ratios + fractional/special doubles fold to a `:rf/double`
-  / `:rf/nan` tag; integers are unchanged), and the remaining terminal types
+  / `:rf/nan` tag; safe-range integers are unchanged, integers beyond ±2^53-1
+  take the same lossy `:rf/double` path on both hosts — rf2-7w1vp), and the
+  remaining terminal types
   (strings, keywords, booleans, nil) unchanged. Returns a value that
   round-trips through `pr-str` deterministically across hosts and processes."
   (-canon [x]))

--- a/tools/story/src/re_frame/story/promotion.cljc
+++ b/tools/story/src/re_frame/story/promotion.cljc
@@ -66,11 +66,69 @@
   is the single impure entry; it gates on `re-frame.story.config/enabled?`
   so a production CLJS build short-circuits before touching the side-table
   (mirroring `save-variant`)."
-  (:require [re-frame.story.artifact   :as artifact]
-            [re-frame.story.config     :as config]
+  (:require [re-frame.story.config     :as config]
             [re-frame.story.plan       :as plan]
             [re-frame.story.play.runner :as runner]
             [re-frame.story.registrar  :as registrar]))
+
+;; ===========================================================================
+;; Runnable reproducibility slots (rf2-vf8es)
+;; ===========================================================================
+;;
+;; A promoted variant must RUN to the same result as the source artifact —
+;; the docstring promises it is "indistinguishable from a hand-authored one
+;; except for its :run-artifact provenance slot." For a `:network`-stubbed
+;; or `:fx-override`-bearing run that promise was FALSE: the variant body
+;; carried only the program (`:setup`/`:script`) + the provenance link, so
+;; the registered variant's `[:world :network]` / `[:world :frame
+;; :fx-overrides]` were EMPTY. Run normally, a managed HTTP request
+;; fail-closed ("no stub matched") and any fx-decision redirect was gone —
+;; a SILENT fidelity gap (the gallery cell renders a degraded run).
+;;
+;; rf2-87duu preserved `:network` on the provenance LINK so
+;; `replay-run-artifact` could re-derive the run from the artifact. That is
+;; a DIFFERENT path: it replays the artifact, not the registered variant.
+;; This fix lifts the runnable inputs onto the variant BODY itself:
+;;
+;;   - the artifact's `:network` route map → the body's `:network` slot
+;;     (the plan compiler keeps it at `[:world :network]` and lowers it to
+;;     the managed-stub fx-override the runner installs);
+;;   - the artifact's `:fx-decisions` → the body's `:fx-overrides` slot
+;;     (the same `{fx-id override}` shape the per-frame `:fx-overrides`
+;;     takes — Spec 002 §`:fx-overrides`).
+;;
+;; THE MANAGED-STUB REDIRECT OVERLAP. A `:network`-stubbed artifact's
+;; `:fx-decisions` ALSO carries the lowered redirect `{:rf.http/managed
+;; :rf.http/managed-test-stub}` (the plan lowered `:network` to it at
+;; capture time). The body's `:network` slot re-derives that SAME redirect
+;; via `plan/lower-network`, and the compiler's `check-network-fx-conflict!`
+;; HARD-FAILS when both `:network` and an explicit `:fx-overrides` target
+;; `:rf.http/managed`. So when `:network` is present we DROP `:rf.http/managed`
+;; from the lifted `:fx-overrides` — `:network` owns that key. Any OTHER
+;; fx-decision (a non-HTTP override) still rides `:fx-overrides`.
+
+(def managed-fx-id
+  "Re-export of the managed-HTTP fx id (`plan/managed-fx-id`,
+  `:rf.http/managed`) the `:network` slot owns. A `:network`-stubbed
+  artifact's `:fx-decisions` carries the lowered redirect for this id; we
+  drop it from the lifted `:fx-overrides` so it does not conflict with the
+  body's `:network` slot (rf2-vf8es)."
+  plan/managed-fx-id)
+
+(defn lift-fx-overrides
+  "Project an artifact's `:fx-decisions` onto a variant body's
+  `:fx-overrides` slot (rf2-vf8es). Pure data → data.
+
+  Drops the `:rf.http/managed` redirect when `network?` is true: the
+  body's `:network` slot re-derives that redirect through
+  `plan/lower-network`, and carrying it on BOTH surfaces is a hard
+  `:rf.error/story-network-fx-conflict`. Returns nil when nothing
+  survives (so the caller omits the slot rather than emitting an empty
+  map)."
+  [fx-decisions network?]
+  (let [fx (cond-> (or fx-decisions {})
+             network? (dissoc managed-fx-id))]
+    (when (seq fx) fx)))
 
 ;; ===========================================================================
 ;; Source-artifact provenance link
@@ -172,6 +230,17 @@
   the primary play); an empty partition omits the slot. The source-artifact
   link rides on `:run-artifact` (see `provenance-link`).
 
+  The RUNNABLE reproducibility inputs are lifted onto the body too
+  (rf2-vf8es) so a promoted variant runs the SAME as the source artifact,
+  not just the artifact's replay:
+  - `:network` — the artifact's per-route HTTP reply map, onto the body's
+    `:network` slot (compiler keeps it at `[:world :network]` and lowers
+    it to the managed-stub fx-override the runner installs);
+  - `:fx-overrides` — the artifact's `:fx-decisions`, onto the body's
+    `:fx-overrides` slot. The `:rf.http/managed` redirect is dropped when
+    `:network` is present (the `:network` slot owns it — see
+    `lift-fx-overrides`), so the two surfaces never conflict.
+
   `opts`:
   - `:setup` / `:script` / `:setup-count` — the program partition policy
     (see `partition-program`).
@@ -188,7 +257,10 @@
   the only provenance."
   ([artifact] (artifact->variant-body artifact nil))
   ([artifact {:keys [doc extends tags args] :as opts}]
-   (let [{:keys [setup script]} (partition-program artifact opts)]
+   (let [{:keys [setup script]} (partition-program artifact opts)
+         network       (:network artifact)
+         has-network?  (boolean (seq network))
+         fx-overrides  (lift-fx-overrides (:fx-decisions artifact) has-network?)]
      (cond-> {:run-artifact (provenance-link artifact)
               :doc          (or doc
                                 (str "Promoted from a "
@@ -196,6 +268,8 @@
                                      " run artifact (spec/017 §Promotion)."))}
        (seq setup)    (assoc :setup setup)
        (seq script)   (assoc :script script)
+       has-network?   (assoc :network network)
+       (some? fx-overrides) (assoc :fx-overrides fx-overrides)
        (some? extends) (assoc :extends extends)
        (some? tags)   (assoc :tags tags)
        (some? args)   (assoc :args args)))))

--- a/tools/story/src/re_frame/story/recorder/dom_capture.cljs
+++ b/tools/story/src/re_frame/story/recorder/dom_capture.cljs
@@ -45,8 +45,37 @@
   would catch chrome interactions (sidebar / toolbar / scrubber)
   and pollute the recording. By scoping to the canvas root we
   only capture interactions the user is making against the
-  variant under test."
-  (:require [re-frame.story.config           :as config]
+  variant under test.
+
+  ## Sensitive input redaction (rf2-0qoi0 — record-but-redact for DOM)
+
+  The dispatched-event rail redacts `:sensitive? true` events
+  (`recorder/trace-listener` → `config/suppress-sensitive?` →
+  `recorder/redacted-event`) per the rf2-hdadz record-but-redact
+  policy. The DOM-capture rail is the SECOND egress and carries the
+  SAME obligation: a user recording a login flow types a real password,
+  and (post rf2-nkjkj, with `:entries` the primary codegen source) that
+  plaintext would otherwise ride verbatim into the generated
+  `:play-script` `[:type selector \"…\"]` step.
+
+  So `handle-input!` / `handle-change!` detect a SENSITIVE input —
+  `<input type=password|email|tel>` or one whose `autocomplete` token
+  is a credential / payment field (`current-password`, `new-password`,
+  `cc-number`, etc.) — and substitute `redacted-type-text`
+  (`\"[:rf/redacted]\"`, the string mirror of the dispatch rail's
+  `[:rf/redacted]` placeholder) for the typed value BEFORE it is
+  buffered, so the secret never reaches the recorder atom. The
+  suppressed-events counter is bumped (`config/note-suppressed!`) so the
+  UI's REDACTED hint reflects the scrubbed rows, exactly as the dispatch
+  rail does. Hosts debugging redaction policy flip
+  `:rf.privacy/show-sensitive?` true via `story/configure!` for the
+  verbatim opt-in path — the SAME flag the dispatch rail honours.
+
+  `<select>` is NOT treated as sensitive (a choice from visible options
+  is not a typed secret); only typed `<input>` fields are scrubbed."
+  (:require [clojure.set                     :as set]
+            [clojure.string                  :as str]
+            [re-frame.story.config           :as config]
             [re-frame.story.recorder         :as recorder]
             [re-frame.story.recorder.selector :as selector]))
 
@@ -188,6 +217,80 @@
   [el]
   (or (.-value el) ""))
 
+;; ---- sensitive-input redaction (rf2-0qoi0) ------------------------------
+
+(def ^:const redacted-type-text
+  "The placeholder text the DOM rail substitutes for a SENSITIVE input's
+  typed value (rf2-0qoi0). The STRING mirror of the dispatch rail's
+  `recorder/redacted-event` `[:rf/redacted]` placeholder — a string
+  because the `:dom/type` → `[:type selector text]` play-step requires a
+  string `text` slot (the runner's `step-arity-ok?`). Reads the same way
+  the dispatch rail's `[:rf/redacted]` placeholder does, so a recording
+  that scrubbed a password shows `[:type \"[id=pw]\" \"[:rf/redacted]\"]`
+  rather than the plaintext."
+  "[:rf/redacted]")
+
+(def ^:private sensitive-input-types
+  "`<input type=…>` values whose typed value is presumed sensitive
+  (rf2-0qoi0). `password` is the obvious credential field; `email` and
+  `tel` are PII the record-but-redact policy scrubs by default. Compared
+  case-insensitively against the element's `type` attribute."
+  #{"password" "email" "tel"})
+
+(def ^:private sensitive-autocomplete-tokens
+  "`autocomplete` attribute tokens that mark a field as a credential or
+  payment input (rf2-0qoi0, WHATWG autofill detail tokens). A field
+  carrying any of these is scrubbed even when its `type` is plain `text`
+  (e.g. a one-time-code or a card number rendered as `type=text`)."
+  #{"current-password" "new-password" "one-time-code"
+    "cc-number" "cc-csc" "cc-exp" "cc-exp-month" "cc-exp-year"})
+
+(defn- input-type
+  "The lowercased `type` attribute of an `<input>` (`\"text\"` when
+  absent — the HTML default). Non-INPUT tags have no meaningful type."
+  [el]
+  (if (= "INPUT" (.-tagName el))
+    (-> (or (.-type el) "text") str .toLowerCase)
+    ""))
+
+(defn- autocomplete-tokens
+  "The set of whitespace-separated `autocomplete` tokens on `el`,
+  lowercased. Empty when the attribute is absent."
+  [el]
+  (let [raw (or (.getAttribute el "autocomplete") "")]
+    (into #{}
+          (comp (map str/lower-case) (remove empty?))
+          (str/split (str raw) #"\s+"))))
+
+(defn- sensitive-element?
+  "True iff typed input into `el` is presumed sensitive and MUST be
+  redacted out of the recording (rf2-0qoi0): a `<input>` whose `type` is
+  password / email / tel, OR whose `autocomplete` names a credential /
+  payment token. `<select>` / `<textarea>` are NOT sensitive — a choice
+  from visible options or free-form prose is not a typed secret."
+  [el]
+  (boolean
+    (and el
+         (= "INPUT" (.-tagName el))
+         (or (contains? sensitive-input-types (input-type el))
+             (seq (set/intersection sensitive-autocomplete-tokens
+                                    (autocomplete-tokens el)))))))
+
+(defn- capture-value
+  "Read the value to RECORD for `el` (rf2-0qoi0). For a non-sensitive
+  field, the verbatim `.value`. For a SENSITIVE field, the redacted
+  placeholder — UNLESS `:rf.privacy/show-sensitive?` is set (the host's
+  explicit verbatim opt-in, same flag the dispatch rail honours), in
+  which case the verbatim value flows through. Bumps the suppressed
+  counter for the recording's variant when it redacts, so the UI's
+  REDACTED hint stays accurate."
+  [el]
+  (let [v (target-value el)]
+    (if (and (sensitive-element? el) (not (config/get-show-sensitive)))
+      (do (config/note-suppressed! (recorder/recording-variant))
+          redacted-type-text)
+      v)))
+
 (defn- should-capture?
   "Top-level gate: is the recorder running AND DOM capture enabled?"
   []
@@ -212,13 +315,15 @@
 
 (defn- handle-input!
   "input / change handler — stashes the latest value into the
-  per-selector type buffer + (re)arms the debounce timer."
+  per-selector type buffer + (re)arms the debounce timer. A SENSITIVE
+  input's value is redacted at the capture boundary (rf2-0qoi0) via
+  `capture-value`, so the secret never reaches the recorder atom."
   [ev]
   (when (should-capture?)
     (when-let [el (.-target ev)]
       (when (typeable-element? el)
         (when-let [sel (selector/pick-for-element el)]
-          (buffer-type! sel (target-value el)))))))
+          (buffer-type! sel (capture-value el)))))))
 
 (defn- handle-change!
   "change handler — fires on blur for inputs / immediately for
@@ -232,9 +337,11 @@
         (let [sel (selector/pick-for-element el)]
           ;; Stash the most-recent value FIRST (so a `change` on a
           ;; `<select>` — which never fires `input` — still has a
-          ;; value to flush).
+          ;; value to flush). Sensitive `<input>` values are redacted at
+          ;; the capture boundary (rf2-0qoi0); `<select>` is never
+          ;; sensitive, so its choice flows through verbatim.
           (when sel
-            (buffer-type! sel (target-value el))
+            (buffer-type! sel (capture-value el))
             (flush-type-buffer! sel)))))))
 
 (defn- handle-submit!

--- a/tools/story/test/re_frame/story/promotion_test.cljc
+++ b/tools/story/test/re_frame/story/promotion_test.cljc
@@ -325,3 +325,89 @@
              :network in provenance-link-keys")
         (is (= {:items [{:sku "A"}]} (:value got))
             "the link round-trips to the SAME recorded reply as the source run")))))
+
+;; ===========================================================================
+;; rf2-vf8es — the promoted VARIANT BODY carries the runnable :network +
+;; :fx-decisions, so running the variant reproduces the run (NOT just the
+;; provenance-link replay rf2-87duu covers)
+;; ===========================================================================
+;;
+;; rf2-87duu preserved :network on the provenance LINK so `replay-run-artifact`
+;; re-derives the run FROM THE ARTIFACT. But the whole point of promotion is to
+;; RUN THE VARIANT — `artifact->variant-body` builds the body the registrar
+;; stores and the runner executes. Before this fix the body carried only the
+;; program (:setup/:script) + the link, so the registered variant's
+;; [:world :network] / [:world :frame :fx-overrides] were EMPTY: run normally a
+;; managed HTTP request fail-closed ("no stub matched"), a SILENT fidelity gap.
+;;
+;; These tests pin the runnable contract on the VARIANT BODY:
+;;   1. the body carries :network + :fx-overrides (the runnable slots, NOT just
+;;      the :run-artifact link);
+;;   2. compiling the body populates [:world :network] (so the run installs the
+;;      route stubs) + lowers :rf.http/managed to the managed-stub fx;
+;;   3. a full round-trip — body → plan → ->artifact → replay — reproduces the
+;;      SAME :success reply as a direct replay of the source artifact. RED
+;;      (pre-fix, body without :network): the round-trip artifact's :network is
+;;      empty and the request fail-closes. GREEN: it reproduces.
+
+(deftest promoted-variant-body-carries-runnable-network-and-fx
+  (testing "the variant body lifts the artifact's :network + :fx-decisions onto
+            the RUNNABLE :network / :fx-overrides slots (rf2-vf8es)"
+    (register-network-event! :promo-net/get-cart [:get "/api/cart"])
+    (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
+          art    (network-artifact routes [[:dispatch [:promo-net/get-cart]]])
+          body   (promotion/artifact->variant-body art)]
+      (is (= routes (:network body))
+          "the per-route reply map rides the body's runnable :network slot")
+      ;; The artifact's :fx-decisions carries the lowered managed-stub redirect;
+      ;; the body's :network slot OWNS :rf.http/managed (it re-derives the same
+      ;; redirect through plan/lower-network), so the lifted :fx-overrides must
+      ;; NOT also set it — else check-network-fx-conflict! hard-fails.
+      (is (not (contains? (:fx-overrides body) plan/managed-fx-id))
+          ":rf.http/managed is dropped from :fx-overrides — :network owns it"))))
+
+(deftest promoted-variant-body-compiles-to-installed-network
+  (testing "compiling the promoted body keeps the routes at [:world :network]
+            (so the run installs the stubs) + lowers :rf.http/managed to the
+            managed-stub fx — NOT an empty network that fail-closes (rf2-vf8es)"
+    (register-network-event! :promo-net/get-cart [:get "/api/cart"])
+    (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
+          art    (network-artifact routes [[:dispatch [:promo-net/get-cart]]])
+          body   (promotion/artifact->variant-body art)
+          ;; compile the body as an inline plan target (read-only, no register)
+          plan   (plan/variant-plan body)]
+      (is (= routes (get-in plan [:world :network]))
+          "the compiled plan keeps the route map at [:world :network]")
+      (is (= plan/managed-stub-fx-id
+             (get-in plan [:world :frame :fx-overrides plan/managed-fx-id]))
+          ":rf.http/managed is lowered to the managed-stub fx the runner installs"))))
+
+(deftest promoted-network-variant-runs-to-the-same-result
+  (testing "RED→GREEN (rf2-vf8es): running the PROMOTED VARIANT reproduces the
+            source run's :success reply. The body → plan → ->artifact → replay
+            round-trip re-installs the route stubs from the body's :network slot;
+            without the fix the body has no :network, the round-trip artifact's
+            :network is empty, and the managed request fail-closes ('no stub
+            matched') — a DIFFERENT run."
+    (register-network-event! :promo-net/get-cart [:get "/api/cart"])
+    (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
+          art    (network-artifact routes [[:dispatch [:promo-net/get-cart]]])
+          ;; the run the variant was promoted FROM (the source artifact replay).
+          src    (artifact/replay-run-artifact art)
+          ;; the PROMOTED VARIANT: body → compiled plan → run-artifact. Running
+          ;; the variant = compiling its body + executing it; ->artifact is the
+          ;; real materialize-to-run seam, and replay re-installs the body's
+          ;; :network route stubs (with-network-stubs!).
+          body   (promotion/artifact->variant-body art)
+          plan   (plan/variant-plan body)
+          var-art (determinism/->artifact plan)
+          ran    (artifact/replay-run-artifact var-art)]
+      (is (= routes (:network var-art))
+          "the promoted variant's run-artifact carries the route map (NOT empty)")
+      (is (= (:status src) (:status ran) :pass)
+          "the promoted variant runs to the SAME status as the source run")
+      (is (= (:got (:app-db src)) (:got (:app-db ran)))
+          "the promoted variant reproduces the SAME recorded reply")
+      (is (= :success (:kind (:got (:app-db ran))))
+          "the route stub matched on the promoted-variant run — NOT a
+           fail-closed 'no stub matched' transport failure"))))

--- a/tools/story/test/re_frame/story/recorder/dom_capture_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/recorder/dom_capture_cljs_test.cljs
@@ -25,8 +25,10 @@
   IS picked up under both; the gate keeps node-test green without
   any per-test rename/exclude dance."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.config :as config]
             [re-frame.story.recorder :as recorder]
             [re-frame.story.recorder.dom-capture :as dom]
+            [re-frame.story.recorder.play-export :as export]
             [re-frame.story.recorder.selector :as sel]))
 
 ;; ---- runtime gate --------------------------------------------------------
@@ -61,6 +63,8 @@
       (recorder/clear!)
       (dom/set-enabled! true)
       (dom/set-debounce-ms! 0)
+      (config/set-show-sensitive! false)
+      (config/reset-suppressed-count!)
       (let [_ (mount-root!)]
         (dom/install! @test-root)
         (try
@@ -69,6 +73,8 @@
             (dom/remove!)
             (unmount-root!)
             (recorder/clear!)
+            (config/set-show-sensitive! false)
+            (config/reset-suppressed-count!)
             (dom/set-debounce-ms! 250)))))))
 
 (use-fixtures :each reset-all!)
@@ -258,3 +264,100 @@
             ":t is non-negative ms since :started-ms")
         (is (< t 10000)
             "sanity: not an absolute epoch")))))
+
+;; ---- sensitive-input redaction (rf2-0qoi0) -------------------------------
+;;
+;; The DOM-capture rail is the SECOND credential/PII egress (the dispatch
+;; rail being the first, redacted by `recorder/trace-listener`). Post
+;; rf2-nkjkj `:entries` is the PRIMARY codegen source, so a typed password
+;; would otherwise ride verbatim into the generated `:play-script` step.
+;; These tests pin the record-but-redact policy on the DOM rail: a
+;; password field's value is scrubbed at the capture boundary so the
+;; generated snippet carries the placeholder, not the plaintext.
+
+(defn- mk-input!
+  "Create + mount an `<input>` carrying the given attribute map, return it."
+  [attrs]
+  (let [input (.createElement js/document "input")]
+    (doseq [[k v] attrs]
+      (.setAttribute input (name k) v))
+    (.appendChild @test-root input)
+    input))
+
+(deftest password-field-type-is-redacted-in-generated-snippet
+  (when (dom-available?)
+    (testing "RED→GREEN (rf2-0qoi0): a typed <input type=password> value is
+              SCRUBBED — neither the recorded :dom/type entry nor the
+              generated play-script :type step carries the plaintext"
+      (recorder/start-recording! :story.login/flow)
+      (let [pw (mk-input! {:type "password" :id "pw"})]
+        (set! (.-value pw) "hunter2-secret")
+        (.dispatchEvent pw (js/Event. "change" #js {:bubbles true}))
+        (let [{:keys [text] :as entry}
+              (first (filterv #(= :dom/type (:kind %)) (recorder/recorded-entries)))]
+          ;; The recorded entry carries the placeholder, not the password.
+          (is (= dom/redacted-type-text text)
+              "the recorded :dom/type text is the redacted placeholder")
+          (is (not= "hunter2-secret" text)
+              "the plaintext password never reaches the recorder atom")
+          ;; The generated play-script step carries the placeholder too.
+          (let [spec (export/recording->play-script (recorder/recorded-entries))
+                type-steps (filterv #(= :type (first %)) (:script spec))]
+            (is (= [[:type (:selector entry) dom/redacted-type-text]] type-steps)
+                "the generated :type step is scrubbed")
+            (is (not (re-find #"hunter2-secret" (export/render-play-script spec)))
+                "the rendered snippet text leaks no plaintext")))))))
+
+(deftest email-and-tel-and-autocomplete-fields-are-redacted
+  (when (dom-available?)
+    (testing "email / tel inputs + a credential autocomplete token are scrubbed"
+      (doseq [attrs [{:type "email" :id "e"}
+                     {:type "tel" :id "t"}
+                     {:type "text" :autocomplete "current-password" :id "c"}
+                     {:type "text" :autocomplete "cc-number" :id "n"}]]
+        (recorder/clear!)
+        (recorder/start-recording! :story.login/flow)
+        (let [el (mk-input! attrs)]
+          (set! (.-value el) "secret-value")
+          (.dispatchEvent el (js/Event. "change" #js {:bubbles true}))
+          (let [text (:text (first (filterv #(= :dom/type (:kind %))
+                                            (recorder/recorded-entries))))]
+            (is (= dom/redacted-type-text text)
+                (str "scrubbed for attrs " (pr-str attrs)))))))))
+
+(deftest ordinary-text-field-is-not-redacted
+  (when (dom-available?)
+    (testing "a plain <input type=text> + a <select> choice flow through verbatim
+              — only sensitive typed inputs are scrubbed (no over-redaction)"
+      (recorder/start-recording! :story.x/y)
+      (let [name-input (mk-input! {:type "text" :id "name"})]
+        (set! (.-value name-input) "alice")
+        (.dispatchEvent name-input (js/Event. "change" #js {:bubbles true}))
+        (is (= "alice"
+               (:text (first (filterv #(= :dom/type (:kind %))
+                                      (recorder/recorded-entries))))))))))
+
+(deftest show-sensitive-flag-opts-into-verbatim-capture
+  (when (dom-available?)
+    (testing ":rf.privacy/show-sensitive? true → the DOM rail captures the
+              verbatim password (host opt-in, mirrors the dispatch rail)"
+      (config/set-show-sensitive! true)
+      (recorder/start-recording! :story.login/flow)
+      (let [pw (mk-input! {:type "password" :id "pw"})]
+        (set! (.-value pw) "hunter2-secret")
+        (.dispatchEvent pw (js/Event. "change" #js {:bubbles true}))
+        (is (= "hunter2-secret"
+               (:text (first (filterv #(= :dom/type (:kind %))
+                                      (recorder/recorded-entries))))))))))
+
+(deftest redacting-a-password-bumps-the-suppressed-counter
+  (when (dom-available?)
+    (testing "the suppressed-events counter for the recording variant is bumped
+              on redaction so the UI's REDACTED hint stays accurate"
+      (config/reset-suppressed-count!)
+      (recorder/start-recording! :story.login/flow)
+      (let [pw (mk-input! {:type "password" :id "pw"})]
+        (set! (.-value pw) "hunter2-secret")
+        (.dispatchEvent pw (js/Event. "change" #js {:bubbles true}))
+        (is (pos? (config/suppressed-count :story.login/flow))
+            "redaction bumped the per-variant suppressed counter")))))

--- a/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
@@ -166,6 +166,21 @@
     (is (= [fp/double-tag "444b1ae4d6e2ef50"] (fp/canonical-form 1e21)))
     (is (= "66b23237" (fp/content-hash 1e21)))))
 
+(deftest large-integers-canonicalize-host-portably-on-cljs
+  (testing "an integer beyond the IEEE-754 safe-integer range takes the lossy
+            bit-double path on CLJS (rf2-7w1vp) — CLJS has no exact integer
+            past 2^53, so `1e20` (what CLJS reads `100000000000000000000` as)
+            canonicalises to the SAME `[:rf/double <hex>]` form + hash the JVM
+            large bigint reaches. This pairing IS the cross-host proof."
+    (is (= [fp/double-tag "4415af1d78b58c40"] (fp/canonical-form 1e20)))
+    (is (= "8a4b7ac2" (fp/content-hash 1e20))
+        "matches the JVM `(fp/content-hash (bigint 100000000000000000000))`"))
+  (testing "an integer AT max-safe-integer passes through verbatim on CLJS —
+            no golden rebase for safe-range integers"
+    (is (= fp/max-safe-integer (fp/canonical-form fp/max-safe-integer)))
+    (is (= "9f16836d" (fp/content-hash fp/max-safe-integer))
+        "matches the JVM `(fp/content-hash 9007199254740991)` literal")))
+
 (deftest nan-and-inf-canonicalize-host-portably-on-cljs
   (testing "NaN folds to the `:rf/nan` sentinel — matches the JVM, hashes stably"
     (is (= fp/nan-tag (fp/canonical-form js/NaN)))

--- a/tools/story/test/re_frame/story_fingerprint_test.clj
+++ b/tools/story/test/re_frame/story_fingerprint_test.clj
@@ -319,9 +319,13 @@
             primitive BEFORE the fix; if any drifts, an ordinary value's hash
             moved and goldens would silently mis-compare."
     ;; [value  expected-canonical-form  expected-content-hash]
+    ;; NB: the large-bigint case that used to live here (rf2-vvqeo) MOVED to
+    ;; `large-integers-canonicalize-host-portably` (rf2-7w1vp) — a bigint of
+    ;; magnitude > 2^53-1 is NOT an ordinary value; it legitimately changes
+    ;; canonical form (to the lossy `[:rf/double …]`) to agree cross-host.
     (let [cases [[42                    "42"                     "211a4621"]
                  [-7                     "-7"                     "ab492c45"]
-                 [(bigint 100000000000000000000) "100000000000000000000N" "86b7e419"]
+                 [9007199254740991       "9007199254740991"       "9f16836d"]
                  ["hello"                "\"hello\""              "3409cbf2"]
                  [:foo/bar               ":foo/bar"               "3ac20368"]
                  ['sym                   "sym"                    "2bdbe3fa"]
@@ -342,6 +346,42 @@
             (str "canonical form of " (pr-str v) " drifted — golden rebase!"))
         (is (= ch (fp/content-hash v))
             (str "content-hash of " (pr-str v) " drifted — golden rebase!"))))))
+
+(deftest large-integers-canonicalize-host-portably
+  (testing "an INTEGER beyond the IEEE-754 safe-integer range (±2^53-1) takes
+            the SAME lossy `[:rf/double <hex>]` path CLJS is forced onto, so the
+            same logical large integer hashes EQUAL cross-host (rf2-7w1vp). On
+            the JVM a `bigint`/`Long`/`BigInteger` past 2^53 used to `pr-str`
+            verbatim (\"…N\") while CLJS routed it through `double->bits-hex` —
+            divergent canonical form, divergent hash."
+    (let [big (bigint 100000000000000000000)]
+      (is (= [fp/double-tag (#'fp/double->bits-hex (double big))]
+             (fp/canonical-form big))
+          "a large bigint folds to the lossy bit-double form, NOT \"…N\"")
+      ;; the JVM Long path agrees with the bigint path for the same magnitude
+      (is (= (fp/canonical-form big)
+             (fp/canonical-form (.toBigInteger (bigdec big))))
+          "BigInteger of the same magnitude shares the canonical form")
+      ;; cross-host equivalence: the CLJS double `1e20` (what CLJS reads
+      ;; `100000000000000000000` as) reaches the SAME bits — the CLJS companion
+      ;; pins `(fp/canonical-form 1e20)` to this exact form + hash.
+      (is (= (fp/canonical-form big) (fp/canonical-form 1e20))
+          "the large integer and its double approximation share the canonical
+           form — the cross-host agreement point (CLJS has only the double)")))
+  (testing "boundary: an integer AT ±max-safe-integer still passes through
+            verbatim — only STRICTLY out-of-range integers change (rf2-7w1vp)"
+    (is (= fp/max-safe-integer (fp/canonical-form fp/max-safe-integer)))
+    (is (= (- fp/max-safe-integer) (fp/canonical-form (- fp/max-safe-integer))))
+    (is (= 9007199254740992N
+           ;; one past max-safe-integer is out of range → bit-double path
+           (let [over (inc (bigint fp/max-safe-integer))]
+             (is (= [fp/double-tag (#'fp/double->bits-hex (double over))]
+                    (fp/canonical-form over)))
+             over))))
+  (testing "ordinary small integers are untouched — no golden rebase"
+    (is (= 42 (fp/canonical-form 42)))
+    (is (= -7 (fp/canonical-form -7)))
+    (is (= 1000000 (fp/canonical-form 1000000)))))
 
 (deftest ratios-canonicalize-host-portably
   (testing "a JVM Ratio canonicalises to the SAME bit-stable double form its


### PR DESCRIPTION
Three Story 2nd-pass review fixes, one PR, all in `tools/story/` across three disjoint files.

## rf2-0qoi0 (P2 privacy) — the recorder redaction boundary

The dispatched-event rail redacts `:sensitive?` events (`recorder/trace-listener` → `config/suppress-sensitive?` → `recorder/redacted-event`), but the **DOM-capture rail had no equivalent** — and post rf2-nkjkj `:entries` (incl. the DOM rail) is the PRIMARY codegen source, so a password typed against the canvas rode verbatim into the generated `[:type selector "…"]` step.

`recorder/dom_capture.cljs` now redacts at the capture boundary: `handle-input!`/`handle-change!` detect a sensitive `<input>` (`type=password|email|tel` or a credential/payment `autocomplete` token) and substitute `redacted-type-text` (`"[:rf/redacted]"`, a string so the `:type` step stays well-formed) BEFORE the value reaches the recorder atom. The suppressed counter is bumped and `:rf.privacy/show-sensitive?` honoured, mirroring the dispatch rail. `<select>` is never redacted.

## rf2-vf8es (P2) — the runnable variant body

`artifact->variant-body` built the body from only `:setup`/`:script` + the `:run-artifact` provenance link, so a promoted `:network`-stubbed run had EMPTY `[:world :network]` / `[:world :frame :fx-overrides]` and fail-closed ("no stub matched") when RUN. (rf2-87duu fixed the LINK re-derivation, a different path.)

The body now lifts the artifact's `:network` → the runnable `:network` slot and `:fx-decisions` → `:fx-overrides` (`lift-fx-overrides` drops `:rf.http/managed` when `:network` is present — `:network` owns that key, else `check-network-fx-conflict!` hard-fails). New test `promoted-network-variant-runs-to-the-same-result` proves the body→plan→`->artifact`→replay round-trip reproduces the source run's `:success` reply.

## rf2-7w1vp (P3) — large-int host-stable canonicalization

Integers beyond ±2^53-1 canonicalized verbatim on the JVM (`"…N"`) but via the lossy IEEE-754 bit path on CLJS (no exact JS integer past 2^53) → divergent cross-host hash. `canon-number` now routes large JVM integers through the SAME `double->bits-hex` path both hosts agree on (policy (a)); added `max-safe-integer` and corrected the docstring/policy overclaim.

**No golden rebase:** the large-bigint golden MOVED out of the unchanged-ordinary-value regression guard (it legitimately changes); a `+max-safe-integer` boundary value was ADDED to that guard to prove the safe range is byte-identical. JVM `(bigint 1e20)` and CLJS `1e20` both canonicalize to `[:rf/double "4415af1d78b58c40"]` / hash `8a4b7ac2` — the cross-host agreement point.

## Quality gates

- RED/GREEN per fix:
  - 0qoi0: `password-field-type-is-redacted-in-generated-snippet` (RED: plaintext leaks into the entry + snippet / GREEN: placeholder, no plaintext) + email/tel/autocomplete coverage + `show-sensitive?` verbatim opt-in + suppressed-counter bump + no-over-redaction (browser runner).
  - vf8es: `promoted-network-variant-runs-to-the-same-result` (RED: empty `:network`, fail-closed / GREEN: reproduces `:success`) + body-carries-runnable-slots + compiles-to-installed-network.
  - 7w1vp: `large-integers-canonicalize-host-portably` (JVM) + `large-integers-canonicalize-host-portably-on-cljs` (cross-host form+hash) + unchanged-ordinary-value proof (`max-safe-integer` boundary in the regression guard).
- `npm run test:cljs` — Ran 5230 tests, 17911 assertions, 0 failures, 0 errors.
- JVM story suite (`clojure -M:test`) — Ran 1580 tests, 5914 assertions, 0 failures, 0 errors.
- `npm run test:browser` — Ran 135 tests, 391 assertions, 0 failures, 0 errors (the dom_capture redaction RED/GREEN runs here).
- clj-kondo — 0 errors, 0 warnings on all changed files (also removed a pre-existing unused-require warning in promotion.cljc).
- `tools/story/spec/*` unchanged (the spec/017 contract already describes these behaviours; the fixes make the implementation match), so `mkdocs build --strict` not required.