### PR TITLE
feat(xray): second-window pop-out — inject stylesheet + visible launch button, drop settings path (rf2-czcg5)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -204,8 +204,10 @@ default). The resize handle is a worked example of "non-obvious
 affordance with iconographic alternative": discovery is via cursor
 change on edge hover, not via prose label.
 
-In `:popout` panel-position the browser's window controls govern size
-(no in-panel handle renders). In `:fullscreen` position the handle is
+In the second-window pop-out (`:popout` shell mode — launched from the
+chrome `⛶` button or `(xray/popout!)`, no longer a panel-position
+value per `rf2-czcg5`) the browser's window controls govern size, so no
+in-panel handle renders. In `:fullscreen` position the handle is
 suppressed — the panel fills the viewport.
 
 #### Auto-inject contract (rf2-70u8q)

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -316,17 +316,44 @@ optional debug mode and must not be described as the primary path.
 
 ### Pop-out to a second window
 
-Programmatic entry: `(xray/popout!)` from CLJS, or
-`window.day8.re_frame2_xray.popout_BANG_()` from a devtools console.
-A right-click → `Pop out` affordance on the launcher pill is the
-canonical chrome-side path. No keybinding is wired pre-alpha; the
-programmatic call is the contract.
+**Launch affordances.** The canonical chrome-side path is a **visible
+pop-out button** (`⛶`) in the panel top-bar / chrome ribbon's
+right-icons cluster (`data-testid="rf-xray-icon-popout"`). Clicking it
+dispatches `:rf.xray/popout-shell`, which lowers — via the
+`:rf.xray.fx/popout-shell` effect — to `popout!`; the event/fx bridge
+keeps the shell view free of a direct mount dependency, mirroring the
+`✕` close button's `:rf.xray/close-shell` → `:rf.xray.fx/hide-shell`
+bridge. The programmatic entry — `(xray/popout!)` from CLJS, or
+`window.day8.re_frame2_xray.popout_BANG_()` from a devtools console —
+is the secondary path. No keybinding is wired pre-alpha. (Pre-`rf2-czcg5`
+the only chrome path was an indirect Settings → panel-position →
+`:popout` radio; that radio has been removed — the visible button is
+the chrome launch, not a panel-position.)
 
 Mechanism: `window.open` whose JS realm is connected to the opener's
 via `window.opener`. The pop-out renders into the new window but
 **reads and dispatches against the opener's runtime atoms directly**
 — no `BroadcastChannel`, no `postMessage`, no structured-clone
 serialisation. Same JS realm, no protocol cost.
+
+**Styling (the second-window stylesheet hand-off).** The pop-out window
+is a distinct `document` whose `<head>` does NOT inherit the opener's
+injected Xray stylesheet. The shell's inline styles and class rules all
+resolve colours through `var(--rf-xray-…)` custom properties, so the
+pop-out **MUST** carry Xray's stylesheet + the `:root --rf-xray-*`
+custom-property definitions (and any font links) so the shell renders
+identically to the inline panel rather than unstyled. Per `rf2-czcg5`
+the implementation injects the full global-styles set into the pop-out's
+own document (`theme/global-styles/install-into!` — fonts, motion seam,
+React-Flow base sheet, the per-theme `:root` palette blocks, grain) and
+mirrors the persisted theme class onto the pop-out's `<html>` so the
+matching `.rf-xray-theme-*` palette (not merely the `:root` light
+default) resolves. The single accent token rides in those theme palette
+blocks, so the inject + theme-class write keep accent and theme in sync
+in the pop-out window. The opener-gone overlay deliberately keeps reading
+literal `dark-palette` hex (not `var(--rf-xray-*)`) so it remains legible
+as a broken-opener fallback even on the path where injection never ran or
+the substrate tree threw before the vars resolved.
 
 Constraints inherited from the `window.opener` posture:
 

--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -397,7 +397,7 @@ rf2-ttnst — Mike 2026-05-19 §0ter.4 walkthrough). Shape mirrors the
 
 ```clojure
 {:general   {:text-size              13          ; px; slider range 10–18
-             :panel-position         :right-rail ; :right-rail | :popout | :fullscreen
+             :panel-position         :right-rail ; :right-rail | :fullscreen (rf2-czcg5 dropped :popout — pop-out launches from the chrome ⛶ button)
              :panel-width-px         480         ; number; clamped [320, 0.9 × viewport-width-px]
              :auto-open-on-error?    false
              :density                :cosy       ; #{:cosy :compact} — no :comfy in v1

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -255,7 +255,7 @@ downstream consumers; there is no separate LIVE/RETRO pill widget.
 
 - `⚙` Settings — dispatches `:rf.xray/settings-open`; opens the Settings modal popup (see [§9 Settings popup](#9-settings-popup)).
 - `✕` Close — dispatches **`:rf.xray/close-shell`** (rf2-fq491), an app-db event handled in `mount.cljs` that actually hides the shell (an earlier draft only flipped a CSS class and could leave the shell stuck open). Host can re-open via `Ctrl+Shift+C`.
-- **`⛶` Popout is omitted from the ribbon** (rf2-g3ghh / rf2-yn86j — silent-by-default): the second-window UX ([`011-Launch-Modes.md`](011-Launch-Modes.md)) has not landed, so the ribbon does not show a broken-claim button. The programmatic `(xray/popout!)` API remains the supported pop-out path; the `⛶` slot is reserved for when the second-window UX ships.
+- **`⛶` Popout** — dispatches **`:rf.xray/popout-shell`** (rf2-czcg5), which lowers via the `:rf.xray.fx/popout-shell` effect to `mount/popout!` (mirrors the `✕` close → `:rf.xray.fx/hide-shell` bridge). The second-window UX has landed ([`011-Launch-Modes.md`](011-Launch-Modes.md) §Pop-out), so the ribbon now carries this VISIBLE button as the canonical chrome launch; the programmatic `(xray/popout!)` API remains the secondary path. (Supersedes the prior rf2-g3ghh / rf2-yn86j silent-by-default omission, which held only until the second-window UX shipped.)
 
 ---
 

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -913,7 +913,7 @@
   `:rf.xray/event-list-col-widths` sub so the two surfaces never drift
   out of column alignment."
   {:general   {:text-size              13              ; px — slider range 10–18
-               :panel-position         :right-rail     ; :right-rail | :popout | :fullscreen
+               :panel-position         :right-rail     ; :right-rail | :fullscreen (rf2-czcg5 dropped :popout — pop-out launches from the chrome ⛶ button)
                :panel-width-px         default-panel-width-px ; rf2-x8h9y resize handle
                :events-list-height-px  default-events-list-height-px ; rf2-t2dsh L2/L3 seam handle
                :auto-open-on-error?    false

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -57,6 +57,7 @@
             [day8.re-frame2-xray.spine-filters :as spine-filters]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
             [day8.re-frame2-xray.self-noise :as self-noise]
+            [day8.re-frame2-xray.theme.global-styles :as global-styles]
             [day8.re-frame2-xray.theme.tokens :as tokens]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.views.resizable-table :as resizable-table]))
@@ -99,6 +100,9 @@
   (atom {:started? false :attempts 0}))
 
 (declare ensure-xray-frame!)
+;; rf2-czcg5 — `install-fx!` (below) registers `:rf.xray.fx/popout-shell`
+;; whose handler calls `popout!`, which is defined later in this ns.
+(declare popout!)
 
 (defn mounted?
   "True when the Xray shell has been mounted at least once. The shell
@@ -630,15 +634,27 @@
 ;; `static-persistence/install-fx!`) keeps `registry.cljs` free of any
 ;; direct DOM-toggle call.
 (defn install-fx!
-  "Idempotently register `:rf.xray.fx/hide-shell` — the effect that
-  performs the DOM-side shell hide. re-frame's registrar replaces in
-  place, so repeat calls (shadow-cljs `:after-load`) are harmless.
+  "Idempotently register the DOM-side chrome effects:
 
-  Handler signature `(fn [ctx args])` per the v2 reg-fx contract."
+  - `:rf.xray.fx/hide-shell` — hide the in-app shell (`close!`); fired
+    by the `✕` close button via `:rf.xray/close-shell`.
+  - `:rf.xray.fx/popout-shell` (rf2-czcg5) — open the second-window
+    pop-out (`popout!`); fired by the chrome `⛶` pop-out button via
+    `:rf.xray/popout-shell`. The event/fx bridge keeps `shell.cljs`
+    free of a direct `mount/popout!` call (which would form the
+    mount→shell→…→mount require cycle), mirroring the close-shell
+    bridge.
+
+  re-frame's registrar replaces in place, so repeat calls (shadow-cljs
+  `:after-load`) are harmless. Handler signature `(fn [ctx args])` per
+  the v2 reg-fx contract."
   []
   (rf/reg-fx :rf.xray.fx/hide-shell
     (fn [_ctx _args]
       (close!)))
+  (rf/reg-fx :rf.xray.fx/popout-shell
+    (fn [_ctx _args]
+      (popout!)))
   nil)
 
 (defn- teardown-popout-state!
@@ -796,14 +812,15 @@
 ;; `theme.tokens` has no transitive deps and is the canonical palette.
 
 ;; The overlay paints into the popout window's own document via
-;; imperative `set! style.background` etc. — that document does NOT
-;; carry the Xray `<style>` injection that registers the
-;; `--rf-xray-…` custom properties on `:root`, so reading from
-;; `tokens` (which is a `var(...)` map post rf2-on4cm) would resolve
-;; to the property's default initial value rather than the brand
-;; palette. These constants read `dark-palette` directly so the
-;; literal hex still flows through `theme/tokens` as the single
-;; source of truth.
+;; imperative `set! style.background` etc. Post rf2-czcg5 the popout
+;; document DOES carry the Xray `<style>` injection (the `:root`
+;; `--rf-xray-…` custom properties land via `style-popout-document!`),
+;; but these overlay constants deliberately keep reading `dark-palette`
+;; literal hex: the overlay is the broken-opener fallback and must
+;; remain legible even on the (defensive) path where injection never
+;; ran or the substrate tree threw before the vars resolved. The hex
+;; still flows through `theme/tokens` as the single source of truth, so
+;; the overlay stays in lockstep with the dark palette regardless.
 
 (def ^:private opener-gone-overlay-bg
   (:bg-0 tokens/dark-palette))
@@ -935,6 +952,55 @@
     (reset! id-atom id)
     id))
 
+;; ---- popout stylesheet hand-off (rf2-czcg5) -----------------------------
+;;
+;; Per tools/xray/spec/011-Launch-Modes.md §Pop-out §Styling: the
+;; pop-out window MUST carry Xray's stylesheet + `:root` custom
+;; properties so the shell renders identically to the inline panel.
+;;
+;; The detached window is a DISTINCT document — its `<head>` does not
+;; carry the `<style>` blocks `global-styles/install!` wrote into the
+;; opener's `js/document` (fonts, motion seam, React-Flow base, the
+;; per-theme `--rf-xray-*` `:root` custom properties, grain). Every
+;; inline style + class rule in the shell resolves colours through
+;; `var(--rf-xray-…)`; absent those `:root` declarations the shell
+;; renders unstyled (the opener-gone overlay dodges this by reading
+;; literal `dark-palette` hex — the main shell cannot).
+;;
+;; `style-popout-document!` injects the full stylesheet set into the
+;; pop-out's document (via `global-styles/install-into!`) and mirrors
+;; the persisted theme onto the pop-out's `<html>` (so the matching
+;; `.rf-xray-theme-*` block — not just the `:root` light default —
+;; resolves). Accent rides in the same theme palette blocks (`:accent`
+;; is a palette token), so the single inject + theme-class write covers
+;; accent/theme together. Density / text-size / panel-width are CSS
+;; custom properties the user writes inline on the OPENER's `<html>`
+;; via `settings/effects`; the pop-out inherits the injected `:root`
+;; defaults (13px etc.) — live per-window overrides of those knobs are
+;; out of scope for the second-window mode.
+
+(defn- style-popout-document!
+  "Inject Xray's stylesheet set into the pop-out `doc` and stamp the
+  persisted theme class on its `<html>` so the shell renders identically
+  to the inline panel. Idempotent (the injectors id-probe; the theme
+  write is exclusive). No-op-safe when `doc` lacks a DOM surface."
+  [doc]
+  (when (some? doc)
+    (global-styles/install-into! doc)
+    ;; Mirror the persisted theme onto the pop-out `<html>` so the
+    ;; matching `.rf-xray-theme-*` palette block resolves (the injected
+    ;; `:root` block only carries the light default). Same class spelling
+    ;; `settings/effects/apply-theme!` writes on the opener.
+    (when-let [html (.-documentElement doc)]
+      (let [theme (or (config/get-setting :theme nil) :light)
+            klass (str settings-effects/theme-class-prefix (name theme))
+            cl    (.-classList html)]
+        (doseq [c [(str settings-effects/theme-class-prefix "dark")
+                   (str settings-effects/theme-class-prefix "light")]]
+          (try (.remove cl c) (catch :default _ nil)))
+        (try (.add cl klass) (catch :default _ nil)))))
+  nil)
+
 (defn popout!
   "Open a same-origin Xray pop-out window and render the shell into it.
   The pop-out shares the opener runtime and Xray frame; no
@@ -970,6 +1036,12 @@
                   body (.-body doc)
                   node (.createElement doc "div")]
               (set! (.-title doc) "Xray")
+              ;; rf2-czcg5 — inject Xray's stylesheet set + the `:root`
+              ;; `--rf-xray-*` custom properties into the pop-out's own
+              ;; document and mirror the persisted theme, so the shell
+              ;; renders fully styled (visually identical to the inline
+              ;; panel) rather than unstyled against the bare window.
+              (style-popout-document! doc)
               (set! (.-id node) "rf-xray-popout-root")
               (.setAttribute node "data-rf-xray-mode" "popout")
               (.appendChild body node)

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -642,17 +642,25 @@
           {:db next-db
            :fx [[:rf.xray.filters/persist (get next-db :active-filters)]]})))
 
-    ;; Ribbon right-icon stubs — wired to events so the click round-
-    ;; trips through the registry surface even though the user-facing
-    ;; close behaviour is follow-on work. Per rf2-u3qm1 the pop-out
-    ;; ribbon button + `:rf.xray/popout` stub are gone — pop-out is
-    ;; programmatic-only via `(xray/popout!)` until the second-window
-    ;; UX lands (spec/011-Launch-Modes.md). No broken-claim button in
-    ;; chrome (silent-by-default — rf2-g3ghh / rf2-yn86j).
+    ;; Ribbon right-icon events. Per rf2-czcg5 the second-window UX has
+    ;; landed, so the chrome now carries a VISIBLE `⛶` pop-out button
+    ;; (shell.cljs `ribbon-right-icons`) that dispatches
+    ;; `:rf.xray/popout-shell`. The event fires the DOM-side
+    ;; `:rf.xray.fx/popout-shell` effect (mount/install-fx!) which calls
+    ;; `mount/popout!` — the event/fx bridge keeps shell.cljs free of a
+    ;; direct mount require (mirrors the close-shell bridge below). The
+    ;; programmatic `(xray/popout!)` API remains the secondary path.
     (rf/reg-event-db :rf.xray/open-settings
       (fn [db _event]
         ;; Settings popup lands behind rf2-pending-settings-modal.
         (assoc db :settings-open? true)))
+
+    (rf/reg-event-fx :rf.xray/popout-shell
+      (fn [_cofx _event]
+        ;; rf2-czcg5 — open the second-window pop-out via the DOM-side
+        ;; effect. No db change: the pop-out is a sibling mount surface,
+        ;; not a reactive flag.
+        {:fx [[:rf.xray.fx/popout-shell]]}))
 
     (rf/reg-event-fx :rf.xray/close-shell
       (fn [{:keys [db]} _event]

--- a/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
@@ -21,12 +21,14 @@
     the whole shell in one assignment.
 
   - **panel-position** — routes to existing mount-layer fns:
-    `:right-rail` is the default inline mount; `:popout` opens the
-    popout window via `mount/popout!`; `:fullscreen` mounts as the
-    overlay via `mount/open-overlay!`. Switching position does not
-    tear down the current mount — the user can sit in two surfaces
-    at once if they choose. A follow-on bead can lock the
-    enumeration to single-mount-at-a-time.
+    `:right-rail` is the default inline mount; `:fullscreen` mounts as
+    the overlay via `mount/open-overlay!`. (Per rf2-czcg5 the `:popout`
+    option was removed — the second-window pop-out is launched from the
+    chrome's visible `⛶` button + the programmatic `(xray/popout!)` API,
+    not via panel-position.) Switching position does not tear down the
+    current mount — the user can sit in two surfaces at once if they
+    choose. A follow-on bead can lock the enumeration to
+    single-mount-at-a-time.
 
   - **auto-open-on-error?** — a re-frame subscription watcher set
     up by `install-auto-open-watcher!`. When the issues-ribbon sub
@@ -457,15 +459,20 @@
 
 (defn apply-panel-position!
   "Route to the matching mount-layer fn. `:right-rail` is the default
-  inline mount; `:popout` opens the popout window; `:fullscreen`
-  mounts the overlay. Switching to a position that's already mounted
-  is a no-op via the mount fns' singleton guards. The mount fns are
-  late-bound via the browser API exports (see ns docstring §Why we
-  late-bind mount via the browser API export)."
+  inline mount; `:fullscreen` mounts the overlay. Switching to a
+  position that's already mounted is a no-op via the mount fns'
+  singleton guards. The mount fns are late-bound via the browser API
+  exports (see ns docstring §Why we late-bind mount via the browser
+  API export).
+
+  Per rf2-czcg5 the `:popout` branch was removed: the second-window
+  pop-out is no longer a panel-position; it is launched from the
+  chrome's visible `⛶` button (`:rf.xray/popout-shell` → `mount/popout!`)
+  + the programmatic `(xray/popout!)` API. `apply-panel-position!` now
+  governs only the inline ⇄ fullscreen axis."
   [position]
   (case position
     :right-rail (call-mount-fn! "open_BANG_")
-    :popout     (call-mount-fn! "popout_BANG_")
     :fullscreen (call-mount-fn! "open_overlay_BANG_")
     ;; Unknown — log and skip. The popup's radio enumeration is the
     ;; sole emit point so an unknown value indicates a programmer

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -469,8 +469,11 @@
      ;; ── Panel position radio ────────────────────────────────────
      [:div {:style (field-style)}
       [:span {:style (label-style)} "Panel position"]
+      ;; rf2-czcg5 — the `:popout` "Popout window" option was dropped:
+      ;; the second-window pop-out is now launched from the chrome's
+      ;; visible `⛶` button (canonical) + the programmatic
+      ;; `(xray/popout!)` API, not via this panel-position radio.
       (for [[pos label] [[:right-rail "Right rail (inline)"]
-                         [:popout     "Popout window"]
                          [:fullscreen "Fullscreen overlay"]]]
         ^{:key pos}
         [:label {:style {:display "flex" :align-items "center" :gap "8px"

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -39,9 +39,10 @@
     distinct frames. Excludes `:rf/xray` by default per §8 I1.
   - **Filter pills** — IN (green, `+`) and OUT (magenta, `×`) pills
     + trailing `[+]` add-pill. Click any pill → edit popup.
-  - **Right icons** — `⚙` settings · `✕` close. (Pop-out is a
-    programmatic API only — `(xray/popout!)` — no ribbon affordance
-    until the second-window UX lands per spec/011-Launch-Modes.md.)
+  - **Right icons** — `⛶` pop-out · `⚙` settings · `✕` close. The
+    `⛶` button is the canonical chrome launch for the second-window
+    pop-out mode (rf2-czcg5, spec/011-Launch-Modes.md); `(xray/popout!)`
+    remains the secondary programmatic path.
 
   The REDACTED indicator (`[● REDACTED N]`) renders inline next to
   the right-icons cluster when the suppressed-sensitive count is
@@ -1014,12 +1015,15 @@
      [:span {:aria-hidden "true"} (if dark? "☀" "☾")]]))
 
 (defn- ribbon-right-icons
-  "Right-icons cluster — `⚙` settings · `✕` close. Per spec/018 §3
-  Right-icon behaviour the pop-out (`⛶`) slot is reserved for the
-  second-window UX (spec/011-Launch-Modes.md); the ribbon affordance
-  is omitted until that lands rather than showing a broken-claim
-  button (silent-by-default — rf2-g3ghh / rf2-yn86j). The programmatic
-  `(xray/popout!)` API remains the supported pop-out path.
+  "Right-icons cluster — `⛶` pop-out · `⚙` settings · `✕` close. Per
+  spec/018 §3 Right-icon behaviour + spec/011-Launch-Modes.md §Pop-out:
+  the second-window UX has landed (rf2-czcg5), so the reserved pop-out
+  (`⛶`) slot now carries a VISIBLE button — the canonical chrome launch
+  affordance for the pop-out window (Mike ruled: a visible top-bar
+  button, not the prior right-click-only path). It dispatches
+  `:rf.xray/popout-shell`, which fires the DOM-side
+  `:rf.xray.fx/popout-shell` effect (mount/install-fx!) → `mount/popout!`.
+  The programmatic `(xray/popout!)` API remains the secondary path.
 
   Settings opens the Settings popup modal (rf2-9poxq) via
   `:rf.xray/settings-open`; close dispatches `:rf.xray/close-shell`
@@ -1062,6 +1066,17 @@
                     :padding         "0"}]
     [:div {:data-testid "rf-xray-ribbon-icons"
            :style {:display "flex" :align-items "center" :gap "4px"}}
+     ;; rf2-czcg5 — VISIBLE pop-out (`⛶`) button, the canonical chrome
+     ;; launch affordance for the second-window mode (spec/011 §Pop-out).
+     ;; Dispatches through the captured frame-aware dispatcher so the
+     ;; event lands on the surrounding instance frame, then the event/fx
+     ;; bridge lowers it to `mount/popout!`.
+     [:button {:data-testid "rf-xray-icon-popout"
+               :title       "Pop out to a second window"
+               :aria-label  "Pop out Xray to a second window"
+               :on-click    #(dispatch-fn [:rf.xray/popout-shell])
+               :style       icon-style}
+      [:span {:aria-hidden "true"} "⛶"]]
      [:button {:data-testid "rf-xray-icon-settings"
                :title       "Settings (,)"
                :aria-label  "Open Xray settings"

--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -152,23 +152,46 @@
     "@font-face{font-family:'Fraunces';font-style:normal;font-weight:900;"
     "font-display:swap;src:local('Fraunces Black');}\n"))
 
+;; ---- document-targeted `<style>` write (rf2-czcg5) ----------------------
+;;
+;; Every injector below writes a fixed-id `<style>` node into a target
+;; document's `<head>`. The main inline shell installs into
+;; `js/document`; the second-window pop-out (rf2-czcg5) installs the
+;; SAME stylesheet set into its own `window.document` so the shell's
+;; `var(--rf-xray-*)` reads resolve there too (otherwise the detached
+;; window renders unstyled — the `:root` custom properties live only on
+;; the opener's document). The `doc`-parameterised helper keeps the
+;; idempotent id-keyed DOM probe + the no-DOM guard in one place; the
+;; per-style injectors are thin wrappers that hand it their id + css.
+
+(defn- inject-style-node!
+  "Append a fixed-`id` `<style>` carrying `css` to `doc`'s `<head>`.
+  Idempotent — no-op when `doc` already carries a node with `style-id`,
+  or when `doc` is absent / lacks the DOM surface (node-test). Returns
+  nil. The single seam every per-style injector funnels through so the
+  main-document and pop-out-document install paths share one
+  implementation (rf2-czcg5)."
+  [doc style-id css]
+  (when (and (some? doc)
+             (.-head doc)
+             (.-createElement doc)
+             (.-getElementById doc))
+    (when-not (.getElementById doc style-id)
+      (let [node (.createElement doc "style")]
+        (set! (.-id node) style-id)
+        (.appendChild node (.createTextNode doc css))
+        (.appendChild (.-head doc) node))))
+  nil)
+
 (defn- inject-fonts!
-  "Append the `local()`-only `@font-face` `<style>` block to `<head>`.
-  No-op when the node already exists or when `js/document` is absent
+  "Append the `local()`-only `@font-face` `<style>` block to `doc`'s
+  `<head>`. No-op when the node already exists or when `doc` is absent
   (node-test). No third-party HTTP fetch is initiated — consumer
   projects opt-in to webfont URLs by injecting their own `@font-face`
   rules with `url()` entries (CSS layers candidates by family +
   weight)."
-  []
-  (when (and (exists? js/document)
-             (.-head js/document)
-             (.-createElement js/document)
-             (.-getElementById js/document))
-    (when-not (.getElementById js/document fonts-style-id)
-      (let [node (.createElement js/document "style")]
-        (set! (.-id node) fonts-style-id)
-        (.appendChild node (.createTextNode js/document font-faces-css))
-        (.appendChild (.-head js/document) node)))))
+  [doc]
+  (inject-style-node! doc fonts-style-id font-faces-css))
 
 ;; ---- per-theme CSS custom properties (rf2-5kfxe.6) ---------------------
 ;;
@@ -236,19 +259,10 @@
     "}\n"))
 
 (defn- inject-themes-style!
-  "Append the per-theme `<style>` block to `<head>`. Idempotent —
-  id-keyed DOM probe."
-  [themes]
-  (when (and (exists? js/document)
-             (.-head js/document)
-             (.-createElement js/document)
-             (.-getElementById js/document))
-    (when-not (.getElementById js/document themes-style-id)
-      (let [node (.createElement js/document "style")]
-        (set! (.-id node) themes-style-id)
-        (.appendChild node (.createTextNode js/document
-                                            (themes-css themes)))
-        (.appendChild (.-head js/document) node)))))
+  "Append the per-theme `<style>` block to `doc`'s `<head>`. Idempotent
+  — id-keyed DOM probe."
+  [doc themes]
+  (inject-style-node! doc themes-style-id (themes-css themes)))
 
 ;; ---- atmospheric grain overlay (rf2-5kfxe.7) ---------------------------
 ;;
@@ -332,18 +346,10 @@
     "}\n"))
 
 (defn- inject-grain-style!
-  "Append the grain `<style>` block to `<head>`. Idempotent — id-keyed
-  DOM probe."
-  []
-  (when (and (exists? js/document)
-             (.-head js/document)
-             (.-createElement js/document)
-             (.-getElementById js/document))
-    (when-not (.getElementById js/document grain-style-id)
-      (let [node (.createElement js/document "style")]
-        (set! (.-id node) grain-style-id)
-        (.appendChild node (.createTextNode js/document grain-css))
-        (.appendChild (.-head js/document) node)))))
+  "Append the grain `<style>` block to `doc`'s `<head>`. Idempotent —
+  id-keyed DOM probe."
+  [doc]
+  (inject-style-node! doc grain-style-id grain-css))
 
 ;; ---- motion keyframes (rf2-5kfxe.2 + rf2-5kfxe.3) ----------------------
 ;;
@@ -951,18 +957,10 @@
     "}\n"))
 
 (defn- inject-motion-style!
-  "Append the motion `<style>` block to `<head>`. Idempotent — id-keyed
-  DOM probe before write."
-  []
-  (when (and (exists? js/document)
-             (.-head js/document)
-             (.-createElement js/document)
-             (.-getElementById js/document))
-    (when-not (.getElementById js/document motion-style-id)
-      (let [node (.createElement js/document "style")]
-        (set! (.-id node) motion-style-id)
-        (.appendChild node (.createTextNode js/document motion-css))
-        (.appendChild (.-head js/document) node)))))
+  "Append the motion `<style>` block to `doc`'s `<head>`. Idempotent —
+  id-keyed DOM probe before write."
+  [doc]
+  (inject-style-node! doc motion-style-id motion-css))
 
 ;; ---- React Flow base stylesheet (rf2-5qsxo) -----------------------------
 ;;
@@ -1652,20 +1650,13 @@
 
 (defn- inject-react-flow-style!
   "Append the React Flow base stylesheet + the Xray palette override to
-  `<head>` (rf2-5qsxo). Idempotent — id-keyed DOM probe before write.
-  Dev-only: only ever called from `install!` on the Xray preload path."
-  []
-  (when (and (exists? js/document)
-             (.-head js/document)
-             (.-createElement js/document)
-             (.-getElementById js/document))
-    (when-not (.getElementById js/document react-flow-style-id)
-      (let [node (.createElement js/document "style")]
-        (set! (.-id node) react-flow-style-id)
-        (.appendChild node (.createTextNode js/document
-                                            (str react-flow-base-css
-                                                 react-flow-xray-theme-css)))
-        (.appendChild (.-head js/document) node)))))
+  `doc`'s `<head>` (rf2-5qsxo). Idempotent — id-keyed DOM probe before
+  write. Dev-only: only ever called from `install!` on the Xray preload
+  path."
+  [doc]
+  (inject-style-node! doc react-flow-style-id
+                      (str react-flow-base-css
+                           react-flow-xray-theme-css)))
 
 ;; ---- public entry ------------------------------------------------------
 
@@ -1675,23 +1666,44 @@
   ;; saves the work on every render of the shell.
   (atom false))
 
-(defn install!
-  "Idempotent — call from `shell-view`'s reg-view body. Injects the
-  `local()`-only `@font-face` block + motion keyframes + per-theme
-  CSS custom properties + the atmospheric grain overlay on first
-  paint of the shell. No third-party HTTP fetch is initiated; see
-  `font-faces-css` for consumer opt-in posture on webfont URLs."
-  []
-  (when-not @installed?
-    (inject-fonts!)
-    (inject-motion-style!)
+(defn install-into!
+  "Inject the full Xray stylesheet set into an ARBITRARY document's
+  `<head>` — the `local()`-only `@font-face` block + motion keyframes +
+  the React Flow base sheet + per-theme CSS custom properties + the
+  atmospheric grain overlay. Each injector is idempotent (id-keyed DOM
+  probe) so repeated calls converge to one node per style block.
+
+  `install!` targets `js/document` (the host page); the second-window
+  pop-out (rf2-czcg5) targets its own `window.document` so the shell's
+  `var(--rf-xray-*)` reads resolve in the detached window. Unlike
+  `install!` there is no `defonce` short-circuit here — the per-document
+  DOM probe is the only guard, because a pop-out document is a distinct
+  DOM whose nodes the opener's `@installed?` flag knows nothing about.
+  No third-party HTTP fetch is initiated; see `font-faces-css` for the
+  consumer opt-in posture on webfont URLs."
+  [doc]
+  (when (some? doc)
+    (inject-fonts! doc)
+    (inject-motion-style! doc)
     ;; rf2-5qsxo — React Flow's base stylesheet (the structural node /
     ;; edge / Controls chrome) so the Machines topology charts render the
     ;; Stately/xstate look instead of unstyled stacked boxes. Dev-only —
     ;; this preload path never runs in a production bundle.
-    (inject-react-flow-style!)
-    (inject-themes-style! tokens/themes)
-    (inject-grain-style!)
+    (inject-react-flow-style! doc)
+    (inject-themes-style! doc tokens/themes)
+    (inject-grain-style! doc))
+  nil)
+
+(defn install!
+  "Idempotent — call from `shell-view`'s reg-view body. Injects the
+  full Xray stylesheet set (see `install-into!`) into the host page's
+  `js/document` on first paint of the shell. The `defonce @installed?`
+  guard saves the per-render work; the per-style DOM probe inside each
+  injector is the real idempotency guarantee."
+  []
+  (when-not @installed?
+    (when (exists? js/document)
+      (install-into! js/document))
     (reset! installed? true))
   nil)
 

--- a/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
@@ -596,6 +596,38 @@
                 "re-show is CSS-only — no second substrate render")))))))
 
 ;; -------------------------------------------------------------------------
+;; (5c) popout-shell event — the chrome `⛶` button round-trip (rf2-czcg5)
+;; -------------------------------------------------------------------------
+;;
+;; The chrome `⛶` pop-out button dispatches `:rf.xray/popout-shell`
+;; (shell.cljs). That event returns `:rf.xray.fx/popout-shell`, the fx
+;; bridge `mount/install-fx!` registers, which lowers to `mount/popout!`.
+;; Mirrors the close-shell bridge — the button stays out of a direct
+;; mount require. We redef `popout!` to record the call rather than
+;; standing up a real second window.
+
+(deftest popout-shell-event-fires-popout!
+  (testing "rf2-czcg5 — dispatching :rf.xray/popout-shell lowers through
+            the :rf.xray.fx/popout-shell effect to mount/popout!, the
+            same bridge shape as :rf.xray/close-shell → close!"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)
+              popout-calls (atom 0)]
+          (with-redefs [substrate-adapter/render render-fn
+                        mount/popout! (fn [] (swap! popout-calls inc) nil)]
+            ;; install-fx! is called by register-xray-handlers! in the
+            ;; fixture, but redefine-after-register means the fx closure
+            ;; still resolves the redefined var at call time. Re-install
+            ;; to be explicit about the fx registration under test.
+            (mount/install-fx!)
+            (mount/open!)
+            (rf/with-frame :rf/xray
+              (rf/dispatch-sync [:rf.xray/popout-shell]))
+            (is (= 1 @popout-calls)
+                "popout-shell event drove mount/popout! exactly once")))))))
+
+;; -------------------------------------------------------------------------
 ;; (6) Teardown — full destroy
 ;; -------------------------------------------------------------------------
 
@@ -1542,3 +1574,86 @@
                 "popout-state cleared")
             (finally
               (set! (.-clearInterval js/globalThis) prior-clear))))))))
+
+;; -------------------------------------------------------------------------
+;; (12) Popout stylesheet hand-off (rf2-czcg5)
+;; -------------------------------------------------------------------------
+;;
+;; Per tools/xray/spec/011-Launch-Modes.md §Pop-out §Styling: the
+;; pop-out document MUST carry Xray's stylesheet + the `:root`
+;; `--rf-xray-*` custom properties so the shell renders identically to
+;; the inline panel (the blocker before rf2-czcg5 — the detached window
+;; rendered unstyled). `style-popout-document!` injects the full
+;; stylesheet set into the pop-out's own document and stamps the
+;; persisted theme class on its `<html>`.
+
+(defn- mk-stub-classlist []
+  (let [classes (atom #{})]
+    (js-obj "add"      (fn [c] (swap! classes conj c) nil)
+            "remove"   (fn [c] (swap! classes disj c) nil)
+            "contains" (fn [c] (contains? @classes c))
+            "_classes" classes)))
+
+(defn- mk-stub-popout-doc-with-head
+  "A pop-out document stub carrying the `<head>` surface
+  `global-styles/install-into!` writes through plus a `documentElement`
+  with a stub classList for the theme-class write."
+  []
+  (let [by-id (atom {})
+        head  (js-obj "tagName" "HEAD")
+        html  (js-obj "tagName" "HTML")
+        clist (mk-stub-classlist)]
+    (set! (.-appendChild head)
+          (fn [node] (swap! by-id assoc (.-id node) node) node))
+    (set! (.-classList html) clist)
+    (let [style-node (fn []
+                       (let [n (js-obj "id" "" "tagName" "STYLE")]
+                         (set! (.-appendChild n) (fn [_child] _child))
+                         n))]
+      {:doc   (js-obj "head"            head
+                      "documentElement" html
+                      "createElement"   (fn [_tag] (style-node))
+                      "createTextNode"  (fn [css] (js-obj "text" css))
+                      "getElementById"  (fn [id] (get @by-id id)))
+       :by-id by-id
+       :html  html
+       :classlist clist})))
+
+(defn- style-popout-document!* [doc]
+  ((deref #'mount/style-popout-document!) doc))
+
+(deftest style-popout-document!-injects-stylesheet-and-theme-class
+  (testing "rf2-czcg5: style-popout-document! injects the Xray style
+            blocks into the pop-out document's <head> AND stamps the
+            persisted theme class on its <html> so the matching
+            .rf-xray-theme-* palette resolves."
+    (let [{:keys [doc by-id classlist]} (mk-stub-popout-doc-with-head)]
+      (config/update-setting! :theme nil :dark)
+      (try
+        (style-popout-document!* doc)
+        (is (some? (get @by-id "rf-xray-themes"))
+            "themes <style> injected into the pop-out <head>")
+        (is (some? (get @by-id "rf-xray-fonts"))
+            "fonts <style> injected")
+        (is ((.-contains classlist) "rf-xray-theme-dark")
+            "persisted :dark theme stamped on the pop-out <html>")
+        (is (not ((.-contains classlist) "rf-xray-theme-light"))
+            "the opposite theme class is not present (exclusive toggle)")
+        (finally
+          (config/update-setting! :theme nil :light))))))
+
+(deftest style-popout-document!-defaults-to-light-theme
+  (testing "rf2-czcg5: with no persisted theme override the pop-out
+            <html> carries the :light class (matching the config
+            default + the injected :root light palette)."
+    (let [{:keys [doc classlist]} (mk-stub-popout-doc-with-head)]
+      ;; config default-settings already has :theme :light after the
+      ;; fixture reset.
+      (style-popout-document!* doc)
+      (is ((.-contains classlist) "rf-xray-theme-light")
+          "default :light theme class stamped on the pop-out <html>"))))
+
+(deftest style-popout-document!-is-safe-without-document
+  (testing "rf2-czcg5: a nil document (popup-blocked / no-DOM) no-ops
+            rather than throwing."
+    (is (nil? (style-popout-document!* nil)))))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -566,6 +566,9 @@
    :rf.xray/palette-open
    :rf.xray/palette-set-query
    :rf.xray/palette-toggle
+   ;; rf2-czcg5 — chrome `⛶` pop-out button → lowers to mount/popout!
+   ;; via the :rf.xray.fx/popout-shell effect.
+   :rf.xray/popout-shell
    :rf.xray/preview-cascade
    :rf.xray/remove-filter
    ;; rf2-6ni62 — L2 event-list column-divider double-click reset.
@@ -733,6 +736,10 @@
    ;; by `:rf.xray/close-shell`. Registered via `mount/install-fx!` from
    ;; the orchestrator; calls `mount/close!`.
    :rf.xray.fx/hide-shell
+   ;; rf2-czcg5 — `⛶` pop-out button: the DOM-side second-window launch
+   ;; effect fired by `:rf.xray/popout-shell`. Registered via
+   ;; `mount/install-fx!` alongside hide-shell; calls `mount/popout!`.
+   :rf.xray.fx/popout-shell
    ;; rf2-xzg1y — shared draggable column-widths persistence fx.
    ;; Attached to every `resize-pair` + `reset` event so the
    ;; post-mutation `{table-id {col-id px}}` map round-trips to

--- a/tools/xray/test/day8/re_frame2_xray/settings/persistence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/persistence_cljs_test.cljs
@@ -60,11 +60,14 @@
       "reload from localStorage restores 16"))
 
 (deftest panel-position-round-trips
-  (config/update-setting! :general :panel-position :popout)
-  (is (= :popout (config/get-setting :general :panel-position)))
+  ;; rf2-czcg5 — `:popout` was dropped as a panel-position (pop-out now
+  ;; launches from the chrome ⛶ button). `:fullscreen` is the remaining
+  ;; non-default position; round-trip it through localStorage.
+  (config/update-setting! :general :panel-position :fullscreen)
+  (is (= :fullscreen (config/get-setting :general :panel-position)))
   (reset! config/settings config/default-settings)
   (config/load-settings-from-storage!)
-  (is (= :popout (config/get-setting :general :panel-position))))
+  (is (= :fullscreen (config/get-setting :general :panel-position))))
 
 (deftest auto-open-on-error-round-trips
   (config/update-setting! :general :auto-open-on-error? true)

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -292,26 +292,46 @@
         (is (some? (find-by-testid tree "rf-xray-ribbon-icons"))
             "right-icons cluster present in the chrome ribbon")))))
 
-(deftest ribbon-omits-popout-button
-  (testing "rf2-u3qm1 — the right-icons cluster mounts only Settings +
-            Close. The legacy `⛶` pop-out (`rf-xray-icon-popout`) was
-            a broken-claim affordance (`title 'Pop out (o) — stubbed'`)
-            and is removed. Pop-out is programmatic-only via
-            `(xray/popout!)` until the second-window UX lands per
-            spec/011-Launch-Modes.md."
+(deftest ribbon-mounts-visible-popout-button
+  (testing "rf2-czcg5 — the second-window UX has landed, so the
+            right-icons cluster now mounts a VISIBLE `⛶` pop-out button
+            (the canonical chrome launch per spec/011-Launch-Modes.md)
+            alongside Settings + Close. The prior rf2-u3qm1 'omit the
+            broken-claim button' posture is superseded — the button is
+            now backed by `:rf.xray/popout-shell` → `mount/popout!`."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
-            icons (find-by-testid tree "rf-xray-ribbon-icons")]
+      (let [tree   (shell/shell-view)
+            icons  (find-by-testid tree "rf-xray-ribbon-icons")
+            popout (find-by-testid tree "rf-xray-icon-popout")]
         (is (some? icons) "right-icons cluster still mounts")
+        (is (some? popout)
+            "VISIBLE pop-out button present in the chrome right-icons")
         (is (some? (find-by-testid tree "rf-xray-icon-settings"))
             "Settings icon still present")
         (is (some? (find-by-testid tree "rf-xray-icon-close"))
             "Close icon still present")
-        (is (nil? (find-by-testid tree "rf-xray-icon-popout"))
-            "pop-out ribbon button is absent (silent-by-default)")
         (is (not (re-find #"stubbed" (text-nodes icons)))
-            "no `stubbed` copy in the right-icons cluster")))))
+            "no `stubbed` copy — the button is a real affordance")))))
+
+(deftest popout-icon-dispatches-popout-shell
+  (testing "rf2-czcg5 — the chrome `⛶` button dispatches the
+            `:rf.xray/popout-shell` event (which lowers to mount/popout!
+            via the :rf.xray.fx/popout-shell bridge); it does NOT call
+            mount directly — mirrors the close-icon → close-shell shape."
+    (xray-setup!)
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev]       (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (rf/with-frame :rf/xray
+          (let [tree    (shell/shell-view)
+                popout  (find-by-testid tree "rf-xray-icon-popout")
+                handler (:on-click (second popout))]
+            (is (some? popout) "pop-out icon present in the chrome ribbon")
+            (when handler (handler nil)))))
+      (is (some #(= :rf.xray/popout-shell (first %)) @dispatches)
+          "`⛶` click dispatches :rf.xray/popout-shell"))))
 
 ;; -------------------------------------------------------------------------
 ;; (2b) Two-ribbon redesign — chrome ribbon + events ribbon (rf2-4vp5j)

--- a/tools/xray/test/day8/re_frame2_xray/theme/global_styles_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/theme/global_styles_cljs_test.cljs
@@ -730,6 +730,91 @@
     (is (nil? (gs/install!))
         "second call is also a no-op")))
 
+;; ---- install-into! — second-window pop-out stylesheet hand-off (rf2-czcg5)
+
+(defn- mk-stub-style-node []
+  (let [node (js-obj "id" "" "tagName" "STYLE")]
+    (set! (.-text node) "")
+    (set! (.-appendChild node)
+          (fn [child]
+            ;; createTextNode returns a node whose `.-text` carries the
+            ;; css string; mirror it onto the style node so the test can
+            ;; introspect the injected CSS.
+            (set! (.-text node) (str (.-text node) (.-text child)))
+            child))
+    node))
+
+(defn- mk-stub-document
+  "A minimal stub document with the exact surface `inject-style-node!`
+  touches: `head` (with `appendChild` + a child registry),
+  `createElement` → style stub, `createTextNode` → `{:text css}`,
+  `getElementById` resolving against appended-node ids. Mirrors the
+  `mount_cljs_test` stub pattern. Returns `{:doc … :by-id <atom>}` so
+  the test introspects the appended nodes via the atom directly (rather
+  than a hyphenated JS prop, which CLJS interop would munge)."
+  []
+  (let [by-id (atom {})
+        head  (js-obj "tagName" "HEAD")]
+    (set! (.-appendChild head)
+          (fn [node]
+            (swap! by-id assoc (.-id node) node)
+            node))
+    {:doc   (js-obj
+             "head"          head
+             "createElement" (fn [_tag] (mk-stub-style-node))
+             "createTextNode" (fn [css] (js-obj "text" css))
+             "getElementById" (fn [id] (get @by-id id)))
+     :by-id by-id}))
+
+(deftest install-into!-injects-the-full-stylesheet-set
+  (testing "rf2-czcg5 — install-into! writes every Xray style block
+            into an ARBITRARY document's <head> (the second-window
+            pop-out path), keyed by the fixed style ids so the shell's
+            var(--rf-xray-*) reads resolve in the detached window."
+    (let [{:keys [doc by-id]} (mk-stub-document)]
+      (is (nil? (gs/install-into! doc)) "returns nil for the chained idiom")
+      (doseq [id ["rf-xray-fonts"
+                  "rf-xray-motion-keyframes"
+                  "rf-xray-react-flow-base"
+                  "rf-xray-themes"
+                  "rf-xray-grain"]]
+        (is (some? (get @by-id id))
+            (str "style node injected: " id)))
+      ;; The themes block must carry the :root --rf-xray-* custom
+      ;; properties — the blocker the pop-out was missing.
+      (let [themes-css (.-text (get @by-id "rf-xray-themes"))]
+        (is (re-find #":root\s*\{" themes-css)
+            ":root block present so the var defaults resolve")
+        (is (re-find #"--rf-xray-bg-0:" themes-css)
+            "surface custom properties published")
+        (is (re-find #"--rf-xray-accent:" themes-css)
+            "accent custom property published (theme/accent ride together)")))))
+
+(deftest install-into!-is-idempotent-per-document
+  (testing "rf2-czcg5 — repeated install-into! on the same document
+            converges to one node per style id (the id-keyed DOM probe
+            is the guard, not a defonce — a pop-out document is a
+            distinct DOM the opener's @installed? flag knows nothing
+            about)."
+    (let [{:keys [doc by-id]} (mk-stub-document)
+          create-ct (atom 0)
+          orig      (.-createElement doc)]
+      (set! (.-createElement doc)
+            (fn [tag] (swap! create-ct inc) (orig tag)))
+      (gs/install-into! doc)
+      (let [first-count @create-ct]
+        (is (= 5 first-count) "five style nodes created on first install")
+        (gs/install-into! doc)
+        (is (= first-count @create-ct)
+            "second install creates NO new nodes — id-probe short-circuits")
+        (is (= 5 (count @by-id))
+            "still exactly five style nodes in <head>")))))
+
+(deftest install-into!-is-safe-without-document
+  (testing "rf2-czcg5 — install-into! no-ops on a nil document (the
+            no-DOM / popup-blocked guard) rather than throwing."
+    (is (nil? (gs/install-into! nil)))))
+
 ;; ---- host theme override (rf2-ee38b.2) ---------------------------------
 
 (deftest set-host-theme-css-is-safe-without-document


### PR DESCRIPTION
Finishes the Xray second-window pop-out mode (rf2-czcg5; spec `tools/xray/spec/011-Launch-Modes.md` §Pop-out). Three parts, in order.

## A. Stylesheet hand-off (the blocker)
The detached pop-out window is a distinct `document` whose `<head>` never carried Xray's `<style>` injection — so the shell, whose inline styles + class rules resolve every colour through `var(--rf-xray-*)`, rendered **unstyled**.

- `theme/global-styles`: refactored every injector to take a target `doc` (funnelled through one `inject-style-node!` seam) and added a public `install-into!`. `install!` now delegates to `install-into! js/document` (behaviour unchanged).
- `mount/popout!`: new `style-popout-document!` injects the full stylesheet set (fonts, motion seam, React-Flow base, the per-theme `:root --rf-xray-*` palette blocks, grain) into the pop-out's **own** document and mirrors the persisted theme class onto its `<html>` so the matching `.rf-xray-theme-*` palette (not just the `:root` light default) resolves. The single accent token rides in those palette blocks, so the inject + theme-class write keep **accent and theme in sync** in the pop-out window.
- The opener-gone overlay keeps its literal-`dark-palette`-hex reads on purpose (broken-opener fallback must stay legible even if injection never ran); comment updated.

## B. Visible launch button (Mike: visible button, not the spec right-click)
Un-hid the reserved chrome slot as a **visible `⛶` button** (`data-testid="rf-xray-icon-popout"`) in the ribbon right-icons cluster. It dispatches `:rf.xray/popout-shell`, which lowers via the new `:rf.xray.fx/popout-shell` effect to `mount/popout!` — the event/fx bridge mirrors the `✕` close → `:rf.xray.fx/hide-shell` bridge and keeps `shell.cljs` free of a direct mount require. Programmatic `(xray/popout!)` remains the secondary path.

## C. Remove the settings panel-position popout path (Mike: remove)
Dropped the `[:popout "Popout window"]` radio option (`settings/view`), the `:popout` branch in `apply-panel-position!` (`settings/effects`), and updated the `config.cljc` enumeration comment to `:right-rail | :fullscreen`. No dead handlers or orphaned `:popout` panel-position references remain (the `palette/sources` `:popout?` is an unrelated command-palette flag).

## Specs kept current (`tools/xray/spec`)
- **011 §Pop-out** — visible-button launch (canonical) + programmatic secondary; new Styling clause (stylesheet + `:root` vars MUST be injected); removed the settings-radio description.
- **018 §Right-icon behaviour** — `⛶` Popout is now a wired visible button, no longer "omitted (silent-by-default)".
- **007 / 015** — `:popout` is the pop-out *window mode*, no longer a selectable panel-position value.

## Tests
- `global-styles`: `install-into!` injects all 5 style blocks into an arbitrary doc (incl. `:root --rf-xray-*`), per-document idempotence, nil-doc safety.
- `mount`: `style-popout-document!` injects the set + stamps the theme class (dark + light default + nil-safe); `:rf.xray/popout-shell` → `mount/popout!` bridge fires once.
- `shell`: visible pop-out button present; `⛶` click dispatches `:rf.xray/popout-shell` (the prior `ribbon-omits-popout-button` test is replaced).
- `registry` snapshot + `settings/persistence` updated for the new event/fx and the dropped `:popout` position.

## Quality gates
- `npm run test:cljs` — **PASS** (5232 tests, 17931 assertions, 0 failures, 0 errors)
- `npm run test:xray-feature-gate` — **PASS** (0 failures; first run had a known `http-server` teardown flake on "static mode chrome and chord", clean on re-run — unrelated to this change)
- `npm run test:bundle-isolation` — **PASS** (17 entries, 35 sentinels absent; uix/helix reagent-free)
- clj-kondo — **0 errors, 0 new warnings** (one pre-existing unused-private-var warning in `settings/view` + two pre-existing `str` infos in `shell`, none in edited regions)
- `mkdocs build --strict` — **PASS** (xray specs live under `tools/xray/spec`, outside the mkdocs nav; build clean)