### PR TITLE
fix(adapters): after-render native-mount parity + flush-views! convergence + StrictMode coverage + drop unused uix.dom dep (rf2-t0x90, rf2-b6nm5, rf2-nymuy, rf2-sl7ml)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
@@ -37,13 +37,28 @@
 (def ^:private cfg
   {:adapter       helix-adapter/adapter
    :name          "Helix"
-   :probe-element (fn [] ($ Probe))})
+   :probe-element (fn [] ($ Probe))
+   ;; rf2-b6nm5 — the canonical test-flush Var for the parity shape pin.
+   :flush-views!  helix-adapter/flush-views!})
 
 (deftest after-render-hook-wired-under-helix
   (suite/assert-after-render-hook-wired cfg))
 
 (deftest after-render-runs-callback-after-next-commit-helix
   (suite/assert-after-render-runs-after-commit cfg))
+
+;; rf2-t0x90 — after-render parity on the NATIVE-mount path (raw
+;; createRoot + .render, the documented boot idiom that bypasses the
+;; spine's Fragment-wrap sentinel). The singleton driver root restores
+;; post-commit timing previously only the :render-slot path got.
+(deftest after-render-fires-on-native-mount-helix
+  (suite/assert-after-render-fires-on-native-mount cfg))
+
+;; rf2-b6nm5 — flush-views! is surfaced from the adapter ns with the
+;; canonical nil-return shape (Decision 6), converged across all four
+;; substrates. Node-safe shape pin.
+(deftest flush-views-canonical-shape-helix
+  (suite/assert-flush-views-canonical-shape cfg))
 
 ;; rf2-ee38b.1 — the spine `make-render` :hydrate? true branch
 ;; (hydrateRoot) had no React-hook coverage; close it for UIx + Helix.

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -165,6 +165,12 @@
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
   (suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
 
+;; rf2-nymuy — StrictMode double-mount: the refcount/disposal dance under
+;; React's default-dev double-invoke (the riskiest seam, previously
+;; untested). Reuses the refcount-probe cfg surface.
+(deftest use-subscribe-strictmode-double-mount-refcount-balances
+  (suite/assert-use-subscribe-strictmode-double-mount-refcount-balances cfg))
+
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))
 

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -70,6 +70,24 @@
   resolves it at load time without a static :require."
   (:set-hiccup-emitter! spine-fns))
 
+(def flush-views!
+  "Flush pending slim renders synchronously. Wraps React's act() —
+  intended for test code only. Calls (act (fn [] (batching/flush!)));
+  with `f`, runs `f` then the synchronous render drain inside act.
+  Returns nil. No-op when act() is unreachable in the current React build.
+
+  Per rf2-3yij Decision 6 / rf2-b6nm5: the canonical test-flush hook,
+  surfaced identically (same name, same ADAPTER-ns location, same
+  nil-return shape) across all four substrates — Reagent, reagent-slim,
+  UIx, Helix — so a test suite ports across substrates touching only the
+  init! Var. This is the canonical convergence: previously the only slim
+  flush-views! lived in the SUBSTRATE ns `reagent2.dom.client` and RETURNED
+  A PROMISE (the goog.DEBUG-gated microtask→act→microtask Suspense-ordering
+  primitive, IMPL-SPEC §4.6), which diverged in both location and return
+  type. That substrate-level primitive remains for Suspense-deterministic
+  callers; this adapter-ns Var is the cross-substrate canonical surface."
+  (:flush-views! spine-fns))
+
 (def adapter
   "The reagent-slim adapter map. Pass to `(rf/init! ...)` to install:
 

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_views_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_views_cljs_test.cljs
@@ -1,0 +1,36 @@
+(ns re-frame.adapter.reagent-slim-flush-views-cljs-test
+  "rf2-b6nm5 — the canonical test-flush hook `flush-views!` is now surfaced
+  from the reagent-slim ADAPTER ns (`re-frame.adapter.reagent-slim`) with
+  the canonical nil-return shape (rf2-3yij Decision 6), converging the
+  test-flush surface across all four substrates.
+
+  Before this convergence the ONLY slim `flush-views!` lived in the
+  SUBSTRATE ns `reagent2.dom.client` and RETURNED A PROMISE (the
+  goog.DEBUG-gated microtask→act→microtask Suspense-ordering primitive,
+  IMPL-SPEC §4.6) — diverging from UIx/Helix in BOTH location (substrate
+  ns vs adapter ns) AND return type (Promise vs nil). This file pins the
+  converged shape on the adapter ns: a fn whose 0-arity call returns nil,
+  matching stock Reagent, UIx, and Helix.
+
+  The substrate-level `reagent2.dom.client/flush-views!` Promise primitive
+  is unchanged (Suspense-deterministic callers keep it); this is the
+  cross-substrate CANONICAL surface, distinct from that lower-level one.
+
+  Node-safe (no DOM, no component): act() is unreachable / gated under the
+  :node-test runner, so the spine degrades to a plain synchronous flush —
+  the SHAPE (fn + nil return) is the cross-substrate contract under test.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.reagent-slim :as reagent-slim]))
+
+(deftest flush-views-canonical-shape
+  (testing "reagent-slim — flush-views! surfaced from the ADAPTER ns with
+            the canonical nil-return shape (rf2-b6nm5 / Decision 6),
+            converged with the substrate-ns Promise-returning primitive"
+    (is (fn? reagent-slim/flush-views!)
+        "the slim adapter ns exposes flush-views! as a fn (previously only the substrate ns did)")
+    (is (nil? (reagent-slim/flush-views!))
+        "0-arity flush-views! returns nil — the converged contract (NOT the substrate-ns Promise)")
+    (is (nil? (reagent-slim/flush-views! (fn [] nil)))
+        "1-arity flush-views! also returns nil")))

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -57,6 +57,20 @@
   resolves it at load time without a static :require."
   (:set-hiccup-emitter! spine-fns))
 
+(def flush-views!
+  "Flush pending Reagent renders synchronously. Wraps React's act() —
+  intended for test code only. Calls (act (fn [] (reagent.core/flush)));
+  with `f`, runs `f` then the synchronous render drain inside act. Returns
+  nil. No-op when act() is unreachable in the current React build.
+
+  Per rf2-3yij Decision 6 / rf2-b6nm5: the canonical test-flush hook,
+  surfaced identically (same name, same adapter-ns location, same
+  nil-return shape) across all four substrates — Reagent, reagent-slim,
+  UIx, Helix — so a test suite ports across substrates touching only the
+  init! Var. Previously stock Reagent surfaced no adapter-level flush-views!
+  and tests reached for reagent.core/flush or react/act directly."
+  (:flush-views! spine-fns))
+
 (def adapter
   "The Reagent adapter map. Pass to `(rf/init! ...)` to install:
 

--- a/implementation/adapters/reagent/test/re_frame/adapter_flush_views_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_flush_views_cljs_test.cljs
@@ -1,0 +1,33 @@
+(ns re-frame.adapter-flush-views-cljs-test
+  "rf2-b6nm5 — the canonical test-flush hook `flush-views!` is now surfaced
+  from the Reagent adapter ns with the canonical nil-return shape
+  (rf2-3yij Decision 6), converging the test-flush surface across all four
+  substrates.
+
+  Before this convergence the test-flush surface diverged THREE ways:
+    - UIx / Helix surfaced `flush-views!` in the ADAPTER ns, (act f),
+      returns nil (canonical);
+    - reagent-slim surfaced `flush-views!` only in the SUBSTRATE ns
+      `reagent2.dom.client`, returning a PROMISE;
+    - stock Reagent surfaced NO adapter-level flush-views! at all — tests
+      reached for `reagent.core/flush` / `react/act` directly.
+
+  This file pins the converged shape for stock Reagent: the adapter ns now
+  exposes `flush-views!` as a fn whose 0-arity call returns nil. Node-safe
+  (no DOM, no component): act() is unreachable / gated under the :node-test
+  runner, so the spine degrades to a plain synchronous flush — the SHAPE
+  (fn + nil return) is the cross-substrate contract under test.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.reagent :as reagent-adapter]))
+
+(deftest flush-views-canonical-shape
+  (testing "Reagent — flush-views! surfaced from the adapter ns with the
+            canonical nil-return shape (rf2-b6nm5 / Decision 6)"
+    (is (fn? reagent-adapter/flush-views!)
+        "the Reagent adapter ns exposes flush-views! as a fn (previously absent)")
+    (is (nil? (reagent-adapter/flush-views!))
+        "0-arity flush-views! returns nil — the converged contract across all four substrates")
+    (is (nil? (reagent-adapter/flush-views! (fn [] nil)))
+        "1-arity flush-views! also returns nil")))

--- a/implementation/adapters/uix/deps.edn
+++ b/implementation/adapters/uix/deps.edn
@@ -19,14 +19,29 @@
 ;; CLJS-only. The :test alias exists for classpath-probe parity with
 ;; the other per-adapter artefacts (Reagent's :test alias is also
 ;; classpath-probe-only).
+;; rf2-sl7ml — the SHIPPING :deps declare only what the PUBLISHED src
+;; requires: re-frame.adapter.uix requires `uix.core` + `uix.hooks.alpha`
+;; only. `uix.dom` is NOT required by the shipped adapter (the spine owns
+;; the DOM mount path via react-dom/client directly — see
+;; `re-frame.substrate.spine/make-render`), so it must not land in the
+;; published day8/re-frame2-uix pom and force every downstream consumer to
+;; resolve it. (Helix's deps.edn already declares only lilactown/helix —
+;; no helix.dom — for the same reason.) The ONLY consumer of `uix.dom` is
+;; the non-shipped testbed, which builds from the top-level
+;; implementation/shadow-cljs.edn (that build supplies com.pitch/uix.dom
+;; via its own :dependencies); the :test alias below also carries it for
+;; the per-artefact classpath probe.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../../core"}
-         com.pitch/uix.core {:mvn/version "1.4.4"}
-         com.pitch/uix.dom  {:mvn/version "1.4.4"}}
+         com.pitch/uix.core {:mvn/version "1.4.4"}}
 
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
+         ;; rf2-sl7ml — uix.dom lives here (test/testbed classpath), NOT in
+         ;; the shipping :deps, because the published adapter src never
+         ;; requires it (only the testbed does).
+         :extra-deps  {com.pitch/uix.dom {:mvn/version "1.4.4"}
+                       ;; rf2-try1x — silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
@@ -35,13 +35,28 @@
 (def ^:private cfg
   {:adapter       uix-adapter/adapter
    :name          "UIx"
-   :probe-element (fn [] ($ Probe))})
+   :probe-element (fn [] ($ Probe))
+   ;; rf2-b6nm5 — the canonical test-flush Var for the parity shape pin.
+   :flush-views!  uix-adapter/flush-views!})
 
 (deftest after-render-hook-wired-under-uix
   (suite/assert-after-render-hook-wired cfg))
 
 (deftest after-render-runs-callback-after-next-commit-uix
   (suite/assert-after-render-runs-after-commit cfg))
+
+;; rf2-t0x90 — after-render parity on the NATIVE-mount path (raw
+;; createRoot + .render, the documented boot idiom that bypasses the
+;; spine's Fragment-wrap sentinel). The singleton driver root restores
+;; post-commit timing previously only the :render-slot path got.
+(deftest after-render-fires-on-native-mount-uix
+  (suite/assert-after-render-fires-on-native-mount cfg))
+
+;; rf2-b6nm5 — flush-views! is surfaced from the adapter ns with the
+;; canonical nil-return shape (Decision 6), converged across all four
+;; substrates. Node-safe shape pin.
+(deftest flush-views-canonical-shape-uix
+  (suite/assert-flush-views-canonical-shape cfg))
 
 ;; rf2-ee38b.1 — the spine `make-render` :hydrate? true branch
 ;; (hydrateRoot) had no React-hook coverage; close it for UIx + Helix.

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -161,6 +161,12 @@
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
   (suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
 
+;; rf2-nymuy — StrictMode double-mount: the refcount/disposal dance under
+;; React's default-dev double-invoke (the riskiest seam, previously
+;; untested). Reuses the refcount-probe cfg surface.
+(deftest use-subscribe-strictmode-double-mount-refcount-balances
+  (suite/assert-use-subscribe-strictmode-double-mount-refcount-balances cfg))
+
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))
 

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -465,13 +465,38 @@
 ;; is called, the sentinel's stashed `setState` bumps a tick to force a
 ;; commit so its `useLayoutEffect` fires and drains the queue.
 ;;
-;; No-sentinel fallback. If `after-render` is invoked before any render
-;; has mounted (or after every root has unmounted), there is no stashed
-;; setter to drive a commit — fall through to `queueMicrotask` so `f`
-;; still fires once the current microtask boundary completes. Honest
-;; under both the "user dispatched a scroll-restore from a one-shot
-;; bootstrap event" path AND the "tests poke `interop/after-render`
-;; without mounting anything" path.
+;; Native-mount parity (rf2-t0x90). The Fragment-wrap sentinel only
+;; enters the tree when an app mounts through the adapter's `:render`
+;; slot. But the documented boot idiom (and all three adapter testbeds)
+;; mounts via the substrate-native renderer directly (`uix-dom/render-
+;; root`, Helix's `(.render root …)`), which bypasses `make-render` —
+;; so a natively-mounted UIx/Helix app NEVER has a sentinel in its tree.
+;; Reagent's `r/after-render` is a global post-flush hook that works
+;; regardless of mount path; without parity, the SAME `(rf/after-render
+;; f)` call has correct post-commit timing on Reagent but degraded
+;; microtask timing on natively-mounted UIx/Helix — a silent substrate
+;; divergence in a public primitive.
+;;
+;; The fix: a per-adapter SINGLETON DRIVER ROOT, mounted lazily the
+;; first time `after-render` is called with no app-tree sentinel
+;; present. The hook mounts the sentinel component into a detached
+;; (never-attached-to-the-document) React root via `createRoot`; the
+;; sentinel's `useEffect` stashes its `set-tick` setter into
+;; `set-tick-ref` exactly as the Fragment-wrap sentinel does, so the
+;; same `set-tick` → commit → `useLayoutEffect`-drain machinery now
+;; drives post-commit timing on the native-mount path too. The driver
+;; root is created once per adapter and reused for the process lifetime
+;; (it renders no DOM — the sentinel returns nil — so a detached host
+;; node is sufficient and never touches the document). An app-tree
+;; sentinel, when present, still wins: it claims `set-tick-ref` and the
+;; driver root simply sits idle.
+;;
+;; Headless / no-DOM fallback. `createRoot` needs `document`; under a
+;; pure-node runner (no jsdom) there is no DOM to mount into. In that
+;; case — and in the historical pre-DOM-API path — fall through to
+;; `queueMicrotask` so `f` still fires once the current microtask
+;; boundary completes. Honest under the "tests poke `interop/after-
+;; render` without a DOM" path.
 
 (defn make-after-render-queue-cell
   "Return a fresh `(atom [])` queue of pending after-render callbacks.
@@ -485,6 +510,17 @@
   setter into on mount and clears on unmount. Each adapter owns its
   own so the after-render hook below can route to the right adapter's
   sentinel."
+  []
+  (atom nil))
+
+(defn make-after-render-driver-root-cell
+  "Return a fresh `(atom nil)` slot holding the per-adapter SINGLETON
+  DRIVER ROOT — the detached React root the after-render hook mounts
+  the sentinel into the first time `after-render` is called with no
+  app-tree sentinel present (rf2-t0x90 native-mount parity). Lazily
+  populated and reused for the adapter's lifetime; each adapter owns
+  its own so multiple React-shaped adapters in a test bundle don't
+  share a driver root. Drained on `dispose-adapter!`."
   []
   (atom nil))
 
@@ -535,20 +571,60 @@
           js/undefined))
       nil)))
 
+(defn- dom-available?
+  "True when a `document` capable of creating elements is reachable —
+  the precondition for mounting the singleton driver root. False under
+  a pure-node runner (no jsdom), where the after-render hook falls
+  through to the microtask drain."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- ensure-after-render-driver-root!
+  "Lazily mount the per-adapter SINGLETON DRIVER ROOT (rf2-t0x90). If
+  `driver-root-cell` is empty, create a detached host node + React root,
+  render `sentinel-cmp` into it inside `react-dom/flushSync` so the
+  sentinel's mount `useEffect` runs SYNCHRONOUSLY and stashes its
+  `set-tick` setter into `set-tick-ref` before this fn returns. The host
+  node is never attached to the document — the sentinel renders nil, so
+  no DOM is produced. Idempotent: a populated cell is left untouched.
+  Returns nil."
+  [driver-root-cell sentinel-cmp]
+  (when (nil? @driver-root-cell)
+    (let [host (.createElement js/document "div")
+          root (react-dom-client/createRoot host)]
+      (reset! driver-root-cell root)
+      ;; flushSync so the sentinel's mount effect (which stashes
+      ;; set-tick into set-tick-ref) runs synchronously — the caller
+      ;; bumps the tick immediately after, expecting the setter present.
+      (react-dom/flushSync
+        (fn [] (.render root (React/createElement sentinel-cmp nil))))))
+  nil)
+
 (defn make-after-render-hook
   "Build the `:adapter/after-render` impl fn. The returned fn:
 
     1. Enqueues `f` on `queue-cell`.
-    2. If the sentinel is mounted (`set-tick-ref` is non-nil), bumps
-       its tick — React schedules a commit, the sentinel's
-       `useLayoutEffect` fires, and the queue drains in
-       post-commit / pre-paint order.
-    3. Otherwise schedules a `queueMicrotask` drain so `f` still fires
-       once the current microtask boundary completes (covers the
-       pre-mount / post-unmount call paths)."
-  [queue-cell set-tick-ref]
+    2. If an app-tree sentinel is mounted (`set-tick-ref` is non-nil —
+       the app mounted through the adapter's `:render` slot), bumps its
+       tick — React schedules a commit, the sentinel's `useLayoutEffect`
+       fires, and the queue drains in post-commit / pre-paint order.
+    3. Otherwise (the documented native-mount path, rf2-t0x90, where the
+       app mounted via the substrate-native renderer and no Fragment-wrap
+       sentinel is in the tree) lazily mounts the per-adapter SINGLETON
+       DRIVER ROOT — a detached React root carrying the same sentinel —
+       and bumps its now-stashed tick, giving the native-mount path the
+       SAME post-commit timing as Reagent's global `r/after-render`.
+    4. If no DOM is reachable (pure-node runner, no jsdom), falls through
+       to a `queueMicrotask` drain so `f` still fires once the current
+       microtask boundary completes."
+  [queue-cell set-tick-ref sentinel-cmp driver-root-cell]
   (fn after-render-hook [f]
     (swap! queue-cell conj f)
+    (when (and (nil? @set-tick-ref) (dom-available?))
+      ;; Native-mount path: no app-tree sentinel claimed the slot — arm
+      ;; the singleton driver root, whose sentinel stashes set-tick.
+      (ensure-after-render-driver-root! driver-root-cell sentinel-cmp))
     (if-let [set-tick @set-tick-ref]
       (set-tick inc)
       (if (exists? js/queueMicrotask)
@@ -624,8 +700,14 @@
   already-unmounted roots; we swallow any unmount throw so one
   misbehaving root does not strand the rest of the drain. The
   sub-cache walk has its own per-entry try/catch (see
-  `dispose-frame-sub-caches!`)."
-  [{:keys [active-roots-cell warn-cache emitter-cell]}]
+  `dispose-frame-sub-caches!`).
+
+  rf2-t0x90: also unmounts the singleton after-render DRIVER ROOT (if
+  one was lazily armed) and clears its `set-tick` slot, so a torn-down
+  adapter releases it and a subsequent `init!` re-arms a fresh one
+  against the new adapter rather than bumping a stale setter."
+  [{:keys [active-roots-cell warn-cache emitter-cell
+           after-render-driver-root-cell after-render-set-tick-ref]}]
   (fn dispose-adapter! []
     (dispose-frame-sub-caches!)
     (doseq [root @active-roots-cell]
@@ -634,6 +716,12 @@
     (reset! active-roots-cell #{})
     (when warn-cache   (reset! warn-cache #{}))
     (when emitter-cell (reset! emitter-cell nil))
+    (when after-render-driver-root-cell
+      (when-let [root @after-render-driver-root-cell]
+        (try (.unmount root) (catch :default _ nil)))
+      (reset! after-render-driver-root-cell nil))
+    (when after-render-set-tick-ref
+      (reset! after-render-set-tick-ref nil))
     nil))
 
 (defn make-hiccup-emitter-cell
@@ -1220,14 +1308,19 @@
         ;; rf2-334d9: after-render queue + sentinel component + the
         ;; routed-hook impl. The adapter publishes the hook by passing
         ;; `:after-render-hook` to `substrate-adapter/route-hook!`.
-        after-render-queue-cell    (make-after-render-queue-cell)
-        after-render-set-tick-ref  (make-after-render-set-tick-ref)
+        after-render-queue-cell       (make-after-render-queue-cell)
+        after-render-set-tick-ref     (make-after-render-set-tick-ref)
+        ;; rf2-t0x90: holds the lazily-mounted singleton driver root so
+        ;; native-mount apps still get post-commit after-render timing.
+        after-render-driver-root-cell (make-after-render-driver-root-cell)
         after-render-sentinel      (make-after-render-sentinel
                                      after-render-queue-cell
                                      after-render-set-tick-ref)
         after-render-hook          (make-after-render-hook
                                      after-render-queue-cell
-                                     after-render-set-tick-ref)
+                                     after-render-set-tick-ref
+                                     after-render-sentinel
+                                     after-render-driver-root-cell)
         subscribe-cont     (make-subscribe-container gensym-prefix-sub)
         ;; rf2-i21f5: one epoch scheduler per adapter, shared by
         ;; `replace-container!` and every `make-derived-value`, so a
@@ -1255,7 +1348,12 @@
         dispose-fn         (make-dispose-adapter!
                              {:active-roots-cell active-roots-cell
                               :warn-cache        warn-cache
-                              :emitter-cell      emitter-cell})
+                              :emitter-cell      emitter-cell
+                              ;; rf2-t0x90: release the singleton
+                              ;; after-render driver root + clear its
+                              ;; set-tick slot so a fresh init! re-arms.
+                              :after-render-driver-root-cell after-render-driver-root-cell
+                              :after-render-set-tick-ref     after-render-set-tick-ref})
         use-current-frame
         (fn use-current-frame []
           (use-context adapter-context/frame-context))
@@ -1679,6 +1777,33 @@
              ;; the contract by at least running `f`. Reagent and reagent-slim
              ;; both inject one, so this branch is dead in the reference.
              (f))
+           nil))
+        ;; rf2-b6nm5 — CANONICAL test-flush hook, converged across all four
+        ;; substrates (Decision 6 anointed `flush-views!`; previously stock
+        ;; Reagent surfaced none, slim surfaced a Promise-returning one in a
+        ;; SUBSTRATE ns). Same name, location (adapter ns, re-exported from
+        ;; here), and SHAPE as the React-hook spine's `flush-views!`: wrap
+        ;; React's `act()` so a subscribe → re-render cycle drives
+        ;; synchronously in test code; with no arg, flushes pending effects;
+        ;; returns nil. Inside `act` we drive the ratom-family synchronous
+        ;; render drain (the injected `:rdc/flush-render!` op — stock
+        ;; `reagent.core/flush` / slim's `reagent2.*` flush) so dirty
+        ;; components forceUpdate and Reactions recompute before `act`
+        ;; returns. No-op when act() is unreachable in the current React
+        ;; build (mirrors the React-hook spine `flush-views!`).
+        flush-views!
+        (fn flush-views!
+          ([] (flush-views! (fn [] nil)))
+          ([f]
+           (if-let [act (resolve-act-fn)]
+             (act (fn act-body []
+                    (if flush-render-op
+                      (flush-render-op f)
+                      (f))))
+             ;; No act() — degrade to a plain synchronous flush so a
+             ;; :node-test runner (no real React render path) still drains
+             ;; the render queue + dirty-set.
+             (if flush-render-op (flush-render-op f) (f)))
            nil))]
     {:make-state-container       make-state-container
      :read-container             read-container
@@ -1691,6 +1816,10 @@
      ;; rf2-40a84 — production synchronous render-commit, wired into the
      ;; adapter map's :flush-render! contract slot by make-ratom-adapter.
      :flush-render!              flush-render!
+     ;; rf2-b6nm5 — canonical nil-return test-flush hook (Decision 6),
+     ;; re-exported by both ratom adapter namespaces so all four substrates
+     ;; surface the SAME `flush-views!` Var with the SAME nil-return shape.
+     :flush-views!               flush-views!
      :set-hiccup-emitter!        (fn set-it! [f]
                                    (set-hiccup-emitter! emitter-cell f))
      :active-roots-cell          active-roots-cell

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -2180,6 +2180,84 @@
             (when-let [u @unmount]
               (try (u) (catch :default _ nil))))))))))
 
+;; ---- flush-views! cross-substrate parity (rf2-b6nm5) ----------------------
+
+(defn assert-flush-views-canonical-shape
+  "rf2-b6nm5: the canonical test-flush hook `flush-views!` is surfaced
+  from this adapter's ns with the canonical nil-return shape (Decision 6).
+  Node-safe (no DOM): pins the SHAPE — the Var is a fn, the 0-arity call
+  returns nil and does not throw under the :node-test runner (act() gated
+  / unreachable there ⇒ the spine degrades to a plain synchronous flush).
+  The cross-substrate convergence (same name + nil-return on all four
+  substrates) is what lets a test suite port touching only the init! Var.
+
+  cfg keys:
+    :flush-views! the adapter ns's flush-views! Var"
+  [{:keys [name flush-views!]}]
+  (testing (str name " — flush-views! surfaced with canonical nil-return shape (rf2-b6nm5)")
+    (is (fn? flush-views!)
+        "the adapter ns exposes flush-views! as a fn (Decision 6 canonical hook)")
+    (is (nil? (flush-views!))
+        "0-arity flush-views! returns nil — the converged contract across all four substrates")))
+
+(defn assert-after-render-fires-on-native-mount
+  "rf2-t0x90: `(interop/after-render f)` fires post-commit even when the
+  app was mounted via the SUBSTRATE-NATIVE renderer (the documented boot
+  idiom: `uix-dom/render-root` / Helix's `(.render root …)`) rather than
+  through the adapter's `:render` slot.
+
+  The defect this pins: the Fragment-wrap after-render sentinel only
+  enters the tree on the `:render`-slot path. The documented idiom mounts
+  natively (createRoot + .render), bypassing `make-render`, so a natively-
+  mounted UIx/Helix app had NO sentinel — `(rf/after-render f)` degraded
+  to a bare microtask FOREVER, defeating the post-commit-timing contract
+  Reagent's global `r/after-render` honours regardless of mount path. The
+  fix arms a per-adapter SINGLETON DRIVER ROOT the first time after-render
+  is called with no app-tree sentinel, restoring post-commit parity.
+
+  This test mounts the probe with a RAW `react-dom-client/createRoot` +
+  `.render` (NOT `substrate-adapter/render`) — exactly the native idiom
+  that bypasses the spine's Fragment-wrap — then asserts after-render
+  still fires.
+
+  cfg keys:
+    :probe-element  a thunk returning a fresh substrate probe ELEMENT
+                    (reused from the :render-slot after-render twin)."
+  [{:keys [name probe-element]}]
+  (testing (str name " — after-render fires on the NATIVE-mount path (rf2-t0x90)")
+    (with-browser-act
+     (fn [act-fn]
+      (let [fired      (atom 0)
+            callback   (fn native-after-render-cb [] (swap! fired inc))
+            mount-node (make-mount-node!)
+            ;; NATIVE mount — raw createRoot + .render, NOT
+            ;; substrate-adapter/render. This is the documented boot idiom
+            ;; (uix-dom/render-root / Helix .render). The spine's
+            ;; Fragment-wrap sentinel is therefore NOT in this tree — the
+            ;; exact gap rf2-t0x90 names.
+            root       (react-dom-client/createRoot mount-node)]
+        (try
+          (act-fn (fn [] (.render root (probe-element))))
+          (is (zero? @fired)
+              "no after-render fn enqueued yet ⇒ no fires")
+          ;; With NO app-tree sentinel present, the after-render hook arms
+          ;; the singleton driver root (a detached React root carrying the
+          ;; sentinel) and bumps its tick — the useLayoutEffect drain fires
+          ;; post-commit. Enqueue + drain under act so the commit lands
+          ;; synchronously in the test env.
+          (act-fn (fn [] (interop/after-render callback)))
+          (is (= 1 @fired)
+              "after-render fired post-commit on the native-mount path —
+               the singleton driver root delivered parity (rf2-t0x90)")
+          ;; A second enqueue + drain — the driver-root sentinel survives
+          ;; (its useLayoutEffect runs every commit), so subsequent
+          ;; after-render calls also fire.
+          (act-fn (fn [] (interop/after-render callback)))
+          (is (= 2 @fired)
+              "subsequent after-render also fires via the driver root")
+          (finally
+            (try (act-fn (fn [] (.unmount root))) (catch :default _ nil)))))))))
+
 ;; ---- hydrate render branch (rf2-ee38b.1 — closes the React-hook spine
 ;;       hydrate test gap that Reagent/reagent-slim already cover) ----------
 
@@ -2568,6 +2646,128 @@
             (is (or (nil? (get @cache cache-key-v))
                     (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
                 "post-unmount cache entry dropped or ref-count at zero")
+            (finally
+              (try (.unmount root) (catch :default _ nil))))))))))
+
+;; ---- StrictMode double-mount refcount (rf2-nymuy) -------------------------
+;;
+;; React 19's createRoot + <StrictMode> is the DEFAULT dev scaffold
+;; (Vite/CRA/Next). StrictMode intentionally double-invokes effects on
+;; mount: run-effect → run-cleanup → run-effect-again. For use-subscribe
+;; that drives subscribe → unsubscribe (refcount 1 → 0, which per
+;; rf2-cmfln disposes the cached reaction SYNCHRONOUSLY) → subscribe again
+;; (fresh cache miss, rebuild). Because StrictMode is the default dev
+;; environment for the substrates these adapters target, a real app hits
+;; this path on literally every mount — but the single-mount tests above
+;; (rf2-7g959, rf2-mwft2) never exercise the double-invoke churn. This
+;; assertion closes that gap: the disposal+refcount dance is exactly the
+;; class of bug that only surfaces under StrictMode double-invoke (a
+;; disposed-then-derefed reaction, a watch leaked because remove-watch ran
+;; against a stale reaction identity, or a ref-count driven below zero).
+
+(defn assert-use-subscribe-strictmode-double-mount-refcount-balances
+  "rf2-nymuy: mount the use-subscribe refcount probe wrapped in
+  `React.StrictMode` under `act()`. StrictMode double-invokes the mount
+  effect (effect → cleanup → effect), driving the spine's
+  subscribe/unsubscribe refcount dance through a momentary 1 → 0 → 1
+  transition. Asserts:
+
+    (a) after the double-invoke settles, exactly one effect is live — the
+        sub-cache ref-count is pinned at 1 (NOT 2 from a leaked first
+        mount, NOT negative);
+    (b) the observed subscribe/unsubscribe spy calls balance — net
+        ref-count never drops below zero across the double-invoke;
+    (c) after unmount the cache entry is dropped or its ref-count is 0;
+    (d) the probe's deref observed a correct (non-throwing) value through
+        the churn — no 'deref of disposed reaction'.
+
+  Reuses the refcount-probe cfg surface (the probe reads its frame from
+  `:refcount-target` and subscribes to `:rc-query` under `:rc-frame`).
+
+  cfg keys:
+    :probe-refcount-element  thunk → the ProbeRefcount element (2-arg form)
+    :refcount-target         atom the ProbeRefcount reads its target
+                             frame-id from
+    :rc-frame                frame-id keyword for the refcount probe
+    :rc-query                query-v keyword ProbeRefcount subscribes to"
+  [{:keys [name probe-refcount-element refcount-target rc-frame rc-query]}]
+  (testing (str name " — use-subscribe StrictMode double-mount keeps refcount balanced (rf2-nymuy)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! refcount-target rc-frame)
+      (rf/reg-frame rc-frame {:doc "rf2-nymuy StrictMode refcount probe frame"})
+      (rf/reg-event-db ::sm-seed (fn [_ _] {:m 7}))
+      (rf/dispatch-sync [::sm-seed] {:frame rc-frame})
+      (rf/reg-sub rc-query (fn [db _] (:m db)))
+      (let [subscribe-calls   (atom 0)
+            unsubscribe-calls (atom 0)
+            real-subscribe    subs/subscribe
+            real-unsubscribe  subs/unsubscribe
+            cache-key-v       [rc-query]
+            cache             (:sub-cache (frame/frame rc-frame))
+            mount-node        (make-mount-node!)
+            root              (react-dom-client/createRoot mount-node)]
+        ;; Spies mirror the rf2-mwft2 stable-deps-key bypass: preserve the
+        ;; 1-/2-arity shape and dispatch straight to the canonical 2-arity
+        ;; REAL so a single logical call is not double-counted through the
+        ;; Var recur.
+        (with-redefs [subs/subscribe
+                      (fn spy-subscribe
+                        ([query-v]
+                         (swap! subscribe-calls inc)
+                         (real-subscribe (frame/resolve-current-frame) query-v))
+                        ([frame-id query-v]
+                         (swap! subscribe-calls inc)
+                         (real-subscribe frame-id query-v)))
+                      subs/unsubscribe
+                      (fn spy-unsubscribe
+                        ([query-v]
+                         (swap! unsubscribe-calls inc)
+                         (real-unsubscribe (frame/resolve-current-frame) query-v))
+                        ([frame-id query-v]
+                         (swap! unsubscribe-calls inc)
+                         (real-unsubscribe frame-id query-v)))]
+          (try
+            ;; Mount the probe wrapped in React.StrictMode — the
+            ;; double-invoke fires effect → cleanup → effect on mount.
+            (act-fn (fn []
+                      (.render root
+                               (React/createElement
+                                 (.-StrictMode React) nil
+                                 (probe-refcount-element)))))
+            ;; After the double-invoke settles exactly ONE effect is live.
+            ;; If the spine leaked the first mount's subscription (a stale
+            ;; reaction identity, an unbalanced refcount) the ref-count
+            ;; would read 2 here, or the entry would have been disposed to
+            ;; 0/nil by a 1 → 0 transition that the re-subscribe failed to
+            ;; restore.
+            (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+                (str "post-StrictMode-double-mount ref-count is exactly 1 "
+                     "(no leaked first-mount subscription, no negative count) "
+                     "— observed subscribe=" @subscribe-calls
+                     " unsubscribe=" @unsubscribe-calls))
+            ;; The double-invoke fires at least one extra subscribe AND one
+            ;; extra unsubscribe vs a single mount — and they BALANCE: the
+            ;; net (subscribe − unsubscribe) is exactly 1 (one live
+            ;; subscription), never negative.
+            (is (>= @subscribe-calls 2)
+                "StrictMode double-invoked the subscribe (mount + remount)")
+            (is (= 1 (- @subscribe-calls @unsubscribe-calls))
+                (str "net subscribe − unsubscribe is exactly 1 across the "
+                     "double-invoke (refcount never driven below zero) — "
+                     "subscribe=" @subscribe-calls
+                     " unsubscribe=" @unsubscribe-calls))
+            ;; The probe's deref survived the disposed-then-rebuilt churn —
+            ;; a working render (DOM present) proves no 'deref of disposed
+            ;; reaction' threw during the StrictMode remount.
+            (is (= "m=7" (.-textContent mount-node))
+                "probe observed the correct subscribed value through the
+                 StrictMode churn (no deref-of-disposed-reaction throw)")
+            ;; Unmount returns the refcount to baseline.
+            (act-fn (fn [] (.unmount root)))
+            (is (or (nil? (get @cache cache-key-v))
+                    (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+                "post-unmount cache entry dropped or ref-count at zero — disposal balanced")
             (finally
               (try (.unmount root) (catch :default _ nil))))))))))
 

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -63,6 +63,7 @@
   {:namespace "re-frame.core" :var "frame-provider" :kind :fn :facade? true :tier :front-porch :owner "002" :status "v1" :runtime-verified? false}
   ;; --- Reagent adapter (day8/re-frame2-reagent) — probe fully-rowed ---
   {:namespace "re-frame.adapter.reagent" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.adapter.reagent" :var "flush-views!"        :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   {:namespace "re-frame.adapter.reagent" :var "set-hiccup-emitter!" :kind :fn  :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}
   ;; --- UIx adapter (day8/re-frame2-uix) — probe fully-rowed ---
   {:namespace "re-frame.adapter.uix" :var "adapter"             :kind :var :facade? false :tier :adapter :owner "006" :status "v1" :runtime-verified? true}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 471,
+ :var-count 472,
  :tier-vocab
  [:front-porch
   :advanced
@@ -57,6 +57,7 @@
   {:namespace "re-frame.adapter.helix", :var "use-subscribe", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.helix", :var "wrap-view", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.reagent", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.adapter.reagent", :var "flush-views!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.reagent", :var "set-hiccup-emitter!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "adapter", :tier :adapter, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "flush-views!", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Four fixes from the adapters review, all in `implementation/adapters/` + the shared `re-frame.substrate.spine` (core).

## rf2-t0x90 (P2 bug) — after-render native-mount parity
`rf/after-render` was a permanent microtask-fallback no-op for **natively-mounted UIx/Helix** apps: the Fragment-wrap `useLayoutEffect` sentinel only enters the tree on the adapter `:render`-slot path, which the documented boot idiom (`uix-dom/render-root`, Helix `.render`) + all testbeds bypass. So `(rf/after-render f)` degraded to a bare `queueMicrotask` forever, defeating post-commit timing — a silent divergence from Reagent's global `r/after-render` (which works regardless of mount path).

**Fix** (shared spine factory, no adapter src change): a per-adapter **singleton driver root** — a detached React root carrying the same sentinel — is armed lazily the first time `after-render` is called with no app-tree sentinel present. Its mount effect (run synchronously via `flushSync`) stashes `set-tick` into the existing slot, so the same set-tick → commit → `useLayoutEffect`-drain machinery drives post-commit timing on the native-mount path too. The app-tree sentinel still wins when present. Driver root unmounted + `set-tick` slot cleared on `dispose-adapter!` so a fresh `init!` re-arms. Headless/no-DOM falls through to the microtask drain.

**Core touch**: only `implementation/core/src/re_frame/substrate/spine.cljs` (the CLJS-only spine), kept surgical — new `make-after-render-driver-root-cell` + reworked `make-after-render-hook`/`make-dispose-adapter!` (new map keys are optional, backward-compatible with existing callers). New shared-suite assertion mounts the probe via raw `createRoot` + `.render` (the native idiom that bypasses the Fragment-wrap) and asserts after-render still fires; wired for UIx + Helix.

## rf2-b6nm5 (P2) — flush-views! convergence
The test-flush surface diverged 3 ways: UIx/Helix adapter-ns `(act f)`/nil; reagent-slim substrate-ns (`reagent2.dom.client`) Promise-return; stock Reagent absent. Converged on Decision 6's canonical `flush-views!`: `make-ratom-spine` now produces an `act()`-wrapping **nil-return** `flush-views!` (driving the injected synchronous flush op inside `act`), re-exported from both `re-frame.adapter.reagent` + `re-frame.adapter.reagent-slim`. All four adapter namespaces now surface the **same Var with the same nil-return shape**. Slim's substrate-ns Suspense-deterministic Promise primitive is left intact for callers that need it.

## rf2-nymuy (P2) — StrictMode double-mount coverage
Added a shared-suite assertion mounting the `use-subscribe` refcount probe under `React.StrictMode` + `act()` (React 19 default-dev double-invoke: effect → cleanup → effect). Asserts (a) sub-cache refcount settles at exactly 1 (no leaked first mount, never negative), (b) subscribe/unsubscribe spies balance (net = 1), (c) the deref survives the disposed-then-rebuilt churn (no deref-of-disposed-reaction). Wired for UIx + Helix.

## rf2-sl7ml (P3) — drop unused uix.dom dep
Removed `com.pitch/uix.dom` from the UIx adapter's shipping `:deps` (the published src requires only `uix.core` + `uix.hooks.alpha`; the spine owns the DOM mount via `react-dom/client`). Moved to the `:test` alias `:extra-deps`. The non-shipped testbed resolves `uix.dom` from `shadow-cljs.edn`'s `:dependencies`, so the testbed build is unaffected. Now matches Helix (declares only `lilactown/helix`). Verified: `uix.dom` absent from the base classpath, present on `:test`.

## API manifest
Adding the new public `re-frame.adapter.reagent/flush-views!` tripped the manifest drift gate (working as intended). Added the sidecar row in `spec/api-manifest-metadata.edn` + regenerated `spec/api-manifest.edn`. (Heads-up: these touch `spec/` data sidecars; coordinate with any in-flight spec-residue work.)

## Quality gates
- `npm run test:cljs` — **5232 tests / 17921 assertions, 0 failures, 0 errors** (incl. the new flush-views! node parity tests + the JVM/CLJS api-manifest probe green)
- `npm run test:browser` — **141 tests / 411 assertions, 0 failures, 0 errors** (adapter testbed smokes + the new after-render native-mount parity, StrictMode double-mount refcount, flush-views! shape asserts for UIx/Helix)
- `npm run test:bundle-isolation` — PASS (17 entries; 35 sentinels absent; 3 budgets ok)
- `npm run test:reagent-slim:bundle-isolation` — PASS (3 contracts; 19 sentinel checks)
- clj-kondo — 0 errors, 0 new warnings (pre-existing suite warnings unchanged)
- JVM `api-manifest.gen --check` — OK, in sync (472 public vars)
- uix.dom classpath probe — absent from shipping `:deps`, present on `:test`

Do NOT merge.