### PR TITLE
refactor(xray): machine-cascade chrome tidy — reg-machine label + drop summary line + drop action-verb prefix (rf2-nhovk)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -106,11 +106,14 @@
   "Render a cascade row's human-readable verb (rf2-u69j7). Used by the
   view's per-row header. Pure-data; the view never reaches into a
   row's slots to compute its label."
-  [{:keys [kind action-id guard-id phase from-state to-state state reason]}]
+  [{:keys [kind action-id guard-id from-state to-state state reason]}]
   (case kind
     :guard       (str "guard " (ns-keyword guard-id))
-    :action      (str (when phase (str (name phase) " "))
-                      "action " (ns-keyword action-id))
+    ;; rf2-nhovk — the ACTION kind-pill + phase chip already convey kind +
+    ;; phase, so the verb is JUST the action-id (empty for an anonymous
+    ;; action — the pill + chip + source body carry it). The redundant
+    ;; "{phase} action " prefix is dropped.
+    :action      (ns-keyword action-id)
     ;; rf2-ge6uj ISSUE 3 — the TRANSITION row's verb is JUST the state
     ;; change `<before> → <after>`, made the focal point. The redundant
     ;; leading "transition" word (the KIND pill already says TRANSITION)
@@ -236,5 +239,5 @@
   (case flavour
     :reg-event-db  "reg-event-db"
     :reg-event-fx  "reg-event-fx"
-    :reg-machine   "machine-event-handler"
+    :reg-machine   "reg-machine"
     (str flavour)))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -595,16 +595,6 @@
    :display        "flex"
    :flex-direction "column"})
 
-(def ^:private machine-cascade-summary-style
-  {:display     "inline-flex"
-   :align-items "center"
-   :gap         "8px"
-   :font-family mono-stack
-   :font-size   "11px"})
-
-(def ^:private machine-cascade-total-style
-  {:color text-tertiary-colour})
-
 (def ^:private machine-cascade-empty-style
   {:padding     "5px 0 5px 21px"
    :font-family mono-stack
@@ -2682,27 +2672,16 @@
   defensive only (fixtures that synthesise a machine handler without
   any cascade events).
 
-  Header carries:
-  - `N step(s)` count (compact summary at a glance).
-  - Cascade total ms (sum of per-row `:duration-ms`); elides when no
-    row carries a duration.
-
   Each row is rendered via `cascade-row-view` — see its docstring
-  for the per-row layout grammar."
+  for the per-row layout grammar. (rf2-nhovk dropped the redundant
+  `cascade — N step(s)` summary header; the rows below already show
+  the steps plainly. That line also carried the cascade total-ms —
+  re-surface the total elsewhere later if wanted.)"
   [machine-meta cascade-rows]
-  (let [n     (count cascade-rows)
-        total (proj/machine-cascade-total-ms cascade-rows)]
+  (let [n (count cascade-rows)]
     [:div {:data-testid "rf-xray-epoch-handler-machine-cascade"
            :data-cascade-row-count (str n)
            :style machine-cascade-root-style}
-     (sub-header "cascade"
-                 [:span {:style machine-cascade-summary-style}
-                  (str n " step"
-                       (when (not= 1 n) "s"))
-                  (when (number? total)
-                    [:span {:data-testid "rf-xray-epoch-machine-cascade-total"
-                            :style machine-cascade-total-style}
-                     (str "· " (fmt/format-duration-ms total))])])
      (if (zero? n)
        [:div {:data-testid "rf-xray-epoch-handler-machine-cascade-empty"
               :style machine-cascade-empty-style}

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -670,9 +670,15 @@
   (testing "rf2-u69j7 — `cascade-row-label` renders a human verb per kind"
     (is (= "guard :ready?"
            (fmt/cascade-row-label {:kind :guard :guard-id :ready?})))
-    (is (= "entry action :open-socket"
+    ;; rf2-nhovk — the ACTION verb is JUST the action-id; the kind-pill +
+    ;; phase chip already convey kind + phase, so the redundant
+    ;; "{phase} action " prefix is dropped (empty for an anonymous action).
+    (is (= ":open-socket"
            (fmt/cascade-row-label {:kind :action :action-id :open-socket
                                     :phase :entry})))
+    (is (= ""
+           (fmt/cascade-row-label {:kind :action :phase :exit}))
+        "anonymous action → empty verb; pill + chip + source body carry it")
     (is (= "timer [:idle] · on-exit"
            (fmt/cascade-row-label {:kind :timer :state [:idle]
                                     :reason :on-exit})))


### PR DESCRIPTION
Three pure-chrome redundancy/label cleanups to the Epoch-panel machine cascade (Mike pair-review, machine-epochs deck). No behaviour change — CLARITY tidy only. Bead rf2-nhovk.

## Changes

1. **Handler label `reg-machine`** — `format.cljc` `handler-flavour-label`: `:reg-machine` now renders **"reg-machine"** (was "machine-event-handler"). The verb is already a click-to-source link (`handler-verb-link`), so this is a pure label rename — the hyperlink + jump-to-source are unchanged.

2. **Drop the `cascade — N step(s)` summary line** — `view.cljs` `machine-cascade-view`: removed the `(sub-header "cascade" …)` summary line; the cascade rows below already show the steps plainly. That line also carried the cascade total-ms (the only place it surfaced) — dropping the line removes the total too (accepted; re-surface elsewhere later if wanted). Also removed the now-orphaned `machine-cascade-summary-style` / `machine-cascade-total-style` private styles and the unused `total` let-binding so no dead code / kondo warnings remain.

3. **Drop the `{phase} action ` prefix** — `format.cljc` `cascade-row-label` `:action` arm: the verb is now just `(ns-keyword action-id)` (empty for an anonymous action). The kind-pill + phase chip already convey kind + phase. Dropped the now-unused `phase` destructure key.

## Tests updated

- `projection_cljs_test.cljc` `cascade-row-label-test`: `"entry action :open-socket"` → `":open-socket"`, plus a new anonymous-action case asserting `""`.
- No test asserted the old "machine-event-handler" label or the dropped `rf-xray-epoch-machine-cascade-total` testid (verified repo-wide). The `machine-cascade-total-ms` projection fn + its test stay (the total can be re-surfaced later).

## Spec currency

**Spec unchanged.** `tools/xray/spec/021-Dynamic-Panel-Designs.md` was already ahead of the code: §9.1.6.1 lists the flavour label as `reg-machine`, and §Per-row chrome describes the action verb as just the action-id. The machine-cascade section documents the re-sort + per-row chrome but never described a "cascade — N step(s)" summary header. No `mkdocs` build needed.

## Quality gates

- `npm run test:cljs` — **PASS** (5246 tests, 17950 assertions, 0 failures, 0 errors)
- `npm run test:xray-feature-gate` — **PASS** (16 scenarios, 0 failures, 13 matrix rows)
- `npm run test:bundle-isolation` — **PASS** (17 artefact entries; 35 sentinels absent; uix/helix/reagent-free 6 sentinel checks)
- clj-kondo — **0 errors** (12 pre-existing unused-private-var warnings, all confirmed present on `origin/main`; none introduced by this change)