### PR TITLE
fix(pair-mcp): read-dom envelope + round-trippable build-ids + sticky per-session selection (rf2-r5erl, rf2-8t3ct, rf2-fmho5)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -150,6 +150,19 @@ runWithWatchdog(
       { name: 'subscribe', arguments: { topic: 'trace' } },
       { name: 'list-subscriptions', arguments: {} },
       { name: 'list-streams', arguments: {} },
+      // rf2-r5erl — read-dom (and its read-ui sibling + orient) MUST
+      // produce an SDK-valid result envelope, never a null
+      // structuredContent that the SDK's outputSchema validation rejects
+      // at the transport layer (`expected record at structuredContent,
+      // received null`). The bug surfaced on a LIVE read-dom whose
+      // browser eval came back blank; degraded mode exercises the same
+      // envelope-assembly path (the eval short-circuits at
+      // :nrepl-port-not-found through wire/err-text). Including them here
+      // pins the read-family envelope shape at the authoritative SDK
+      // layer, not just a unit proxy.
+      { name: 'read-dom', arguments: { selector: 'body', limit: 1 } },
+      { name: 'read-ui', arguments: { selector: 'body' } },
+      { name: 'orient', arguments: {} },
     ];
 
     // Call one tool and assert the shared degraded envelope. Returns the
@@ -194,6 +207,11 @@ runWithWatchdog(
       'snapshot',
       'subscribe',
       'list-subscriptions',
+      // rf2-r5erl — the read-family envelopes must carry a non-null
+      // object structuredContent through the SDK like every other tool.
+      'read-dom',
+      'read-ui',
+      'orient',
     ]) {
       const resp = degradedResp[label];
       if (resp.structuredContent === undefined || resp.structuredContent === null) {

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -351,10 +351,18 @@ a build cached by a prior discover-app) is honoured verbatim and skips
 auto-selection.
 
 **Returns**: an `:ok? true` map with `:debug-enabled?`, `:frames`,
-`:coord-annotation-enabled?`, `:build-id`. On success the resolved
-build-id is cached on the conn-atom (`:resolved-build-id`, rf2-l9ixp);
+`:coord-annotation-enabled?`, `:build-id`, and a canonical `:build`
+(rf2-8t3ct — the same value as `:build-id`, echoed under the **input
+arg name** so a caller copies it straight back into a later tool's
+`:build` slot; round-trippable, since `:build`-arg coercion reads both
+`"examples/step-deck"` and `":examples/step-deck"` back to the same
+keyword). On success the resolved build-id is cached on the conn-atom
+(`:resolved-build-id`, rf2-l9ixp) — the session-sticky target;
 subsequent tool calls may omit the `:build` arg — see
-[`API.md` §Build-id resolution](./API.md#build-id-resolution).
+[`API.md` §Build-id resolution](./API.md#build-id-resolution). The
+read-family ops (`orient`, `read-dom`, `read-ui`, `eval-cljs`) echo the
+resolved `:build` on their result so the operating target stays visible
+even when implicitly selected (rf2-fmho5).
 
 **Id representation (rf2-cg37y).** Every build/frame id discover-app
 surfaces — `:build-id`, `:frames`, and the diagnostic `:running-builds`
@@ -1735,12 +1743,26 @@ view-plane idiom for surfacing rendered state), `build` (string).
 When nothing matched (no app mounted, or the selector matched no
 element): `{:ok? true :count 0 :nodes []}`.
 
+Every `:ok? true` result also echoes the resolved `:build` keyword
+(rf2-8t3ct / rf2-fmho5) so the operating target stays visible even when
+implicitly selected from the session-sticky cache.
+
 `:reason :missing-selector` if `selector` was omitted / blank (no
 nREPL round-trip);
 `:reason :rf.error/read-dom-bad-selector` (with `:message`) when
 `querySelectorAll` throws on a malformed selector;
 `:reason :rf.error/read-dom-no-document` when the eval target has no
 `js/document` (headless / server-side);
+`:reason :rf.error/read-dom-blank-result` (rf2-r5erl) when the browser
+eval came back **blank** (no map envelope — the runtime didn't answer,
+e.g. a dropped WebSocket). This is returned as a normal `{:ok? false}`
+tool result; it is NEVER a host-level transport failure. (Earlier a
+blank eval threaded `nil` into the result envelope, whose `null`
+`structuredContent` failed the SDK's `outputSchema` validation with
+`expected record at structuredContent, received null` — bypassing this
+error contract entirely. `wire/ok-text` / `err-text` now guarantee a
+non-null `structuredContent` record, and read-dom maps a blank result
+to this reason.);
 `:reason :runtime-not-preloaded` if the preload hasn't run;
 `:reason :read-dom-failed` (with `:message`) on any other failure.
 

--- a/tools/re-frame2-pair-mcp/spec/API.md
+++ b/tools/re-frame2-pair-mcp/spec/API.md
@@ -122,6 +122,31 @@ explicit `:build` both routes that call and re-points the sticky
 default. Multi-build workspaces re-specify `:build` when switching the
 target.
 
+**Round-trippable canonical ids (rf2-8t3ct).** The canonical build id
+is the **keyword** (`:examples/step-deck`). `discover-app` echoes it
+under both `:build-id` and `:build` (the latter matching the *input arg
+name*), and the read-family ops (`orient`, `read-dom`, `read-ui`,
+`eval-cljs`) echo the resolved `:build` on their result. A value copied
+out of any of those slots works unchanged as a later `:build` arg — the
+only alias axis is colon-tolerance (source (1) above), which is
+deterministic: both the bare-qualified and colon-prefixed string forms
+read back to the same keyword. There is no fuzzy build-alias surface to
+disambiguate; the registry is the finite set of shadow-cljs running
+builds, addressed by exact keyword.
+
+**Per-session scope, never a process-global (rf2-fmho5).** The sticky
+`:resolved-build-id` lives on the **conn-atom**, which is created
+per-server-instance (`nrepl/make-conn`, held in `server.cljs`'s
+`session-state`). Under the MCP stdio model each client spawns its own
+server process — so the sticky target is scoped to that one
+connection/session and can never leak across clients. When no session
+target exists and the bare `:app` default isn't running while several
+builds are, the eval-path resolver (`probe/resolve-build!`) rejects with
+a structured `:no-runtime-for-build` enumerating `:running-builds`, and
+the plain read path surfaces the same candidate list via the diagnostic
+ladder's `:build-not-running` rung — a clear ambiguous-target error
+listing candidates, never a silent wrong-build pick or a host failure.
+
 Distinct from the per-session **response** cache (rf2-3rt1f, see
 [`Principles.md`](./Principles.md) § Per-session response cache) —
 that one memoises full response payloads by (tool, args) hash within a

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
@@ -208,6 +208,15 @@
                 ;; `:app` env-var fallback. Invalidates on nREPL reconnect.
                 (wire/mark-resolved-build-id! conn build-id)
                 (with-freshness conn build-id
-                  (with-frame-resolution (assoc health :ok? true :build-id build-id))
+                  ;; rf2-8t3ct — echo the CANONICAL `:build` keyword
+                  ;; alongside the historical `:build-id`. The two carry
+                  ;; the same value; `:build` matches the INPUT arg name so
+                  ;; an agent copies it straight back into a later tool's
+                  ;; `:build` slot (round-trippable). `fresh-keyword` reads
+                  ;; both `"examples/step-deck"` and `":examples/step-deck"`
+                  ;; back to this same keyword.
+                  (with-frame-resolution (assoc health :ok? true
+                                                       :build-id build-id
+                                                       :build    build-id))
                   (fn [h] (wire/ok-text (with-auto-selection h auto-selected? build-id))))))))
         (.catch (fn [err] (probe/err->result :discover-failed err)))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/orient.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/orient.cljs
@@ -50,5 +50,9 @@
       conn build-id form :orient-failed
       (fn [v]
         (if (map? v)
-          (wire/ok-text v)
-          (wire/err-text {:ok? false :reason :unexpected-shape :value v}))))))
+          ;; rf2-8t3ct / rf2-fmho5 — echo the canonical resolved `:build`
+          ;; so the agent sees which build this orientation ran against
+          ;; (the session-sticky target when `:build` was omitted) and can
+          ;; copy it straight into later calls.
+          (wire/ok-text (assoc v :build build-id))
+          (wire/err-text {:ok? false :reason :unexpected-shape :value v :build build-id}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
@@ -235,4 +235,28 @@
       (let [form (read-dom-form selector sub-selector limit max-text attrs)]
         (probe/eval-after-runtime!
           conn build-id form :read-dom-failed
-          (fn [envelope] (wire/ok-text envelope)))))))
+          (fn [envelope]
+            ;; The browser-side form ALWAYS returns a map (a `{:ok? ...}`
+            ;; envelope or the no-document / bad-selector error). A nil /
+            ;; non-map here means the eval came back BLANK —
+            ;; `cljs-eval-value` reads a blank shadow result as `nil`
+            ;; (no runtime answered, or the result slot was empty). Left
+            ;; unguarded, `(wire/ok-text nil)` projected to a `null`
+            ;; structuredContent that the SDK's outputSchema validation
+            ;; rejected at the transport layer with
+            ;; `expected record at structuredContent, received null`
+            ;; (rf2-r5erl) — bypassing the normal error contract. Surface
+            ;; it as a structured `{:ok? false ...}` like `orient` does.
+            (if (map? envelope)
+              (wire/ok-text (assoc envelope :build build-id))
+              (wire/err-text
+                {:ok?      false
+                 :reason   :rf.error/read-dom-blank-result
+                 :build    build-id
+                 :selector selector
+                 :hint     (str "read-dom's browser eval returned a blank "
+                                "value (no map envelope). The runtime "
+                                "likely did not answer the eval — reload "
+                                "the app tab so the re-frame2-pair runtime "
+                                "reconnects, then retry. Run discover-app "
+                                "to confirm :liveness :fresh.")}))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
@@ -154,4 +154,22 @@
             form  (ef/emit (ef/rt-call 'ui-read opts))]
         (probe/eval-after-runtime!
           conn build-id form :rf.error/read-ui-failed
-          (fn [envelope] (wire/ok-text envelope)))))))
+          (fn [envelope]
+            ;; The runtime's `ui-read` ALWAYS returns a map. A nil /
+            ;; non-map means a BLANK eval result (the runtime didn't
+            ;; answer) — guard it so `ok-text` never sees `nil` and
+            ;; emits a `null` structuredContent the SDK rejects
+            ;; (rf2-r5erl, the sibling of read-dom's bug). Echo the
+            ;; resolved `:build` on success for round-trippable
+            ;; selection (rf2-8t3ct / rf2-fmho5).
+            (if (map? envelope)
+              (wire/ok-text (assoc envelope :build build-id))
+              (wire/err-text
+                {:ok?    false
+                 :reason :rf.error/read-ui-blank-result
+                 :build  build-id
+                 :hint   (str "read-ui's browser eval returned a blank "
+                              "value (no map envelope). Reload the app tab "
+                              "so the re-frame2-pair runtime reconnects, "
+                              "then retry; run discover-app to confirm "
+                              ":liveness :fresh.")}))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -45,26 +45,80 @@
 ;; projection (keywords lose their `:`, sets become arrays, etc.).
 ;; The text slot remains the source of truth for cljs-readable round-
 ;; trip; the structured slot is the SDK-friendly view.
+;;
+;; ## structuredContent must never be `null` (rf2-r5erl)
+;;
+;; Every tool descriptor declares a map-shaped `:outputSchema`
+;; (`{:type "object" ...}`, rf2-3l3be). When a descriptor carries an
+;; `:outputSchema`, the npm MCP SDK VALIDATES the result's
+;; `structuredContent` against it — and a `null` is not an object, so
+;; the SDK rejects the whole `tools/call` with a host-level
+;; `Invalid tools/call result: expected record at structuredContent,
+;; received null` BEFORE the EDN ever reaches the agent. That bypasses
+;; re-frame2-pair's `{:ok? false ...}` error contract entirely.
+;;
+;; A `null` reaches here exactly when `v` is `nil` — e.g. a tool that
+;; threads a blank nREPL eval result straight into `ok-text`
+;; (`cljs-eval-value` returns `nil` for a blank value). `read-dom`
+;; hit this in the wild (rf2-r5erl); `read-ui` did not, by luck of
+;; always getting a map back. Rather than rely on every call-site
+;; guarding nil, we make the wire shape TOTAL: a `nil` payload
+;; projects to a structured `{:rf.mcp/null true}` sentinel object so
+;; `structuredContent` is always a record the SDK accepts. The EDN
+;; text slot still carries the verbatim `(pr-str v)` (`"nil"`) so the
+;; cljs-readable round-trip is unchanged for hosts that read the text.
 ;; ---------------------------------------------------------------------------
+
+(def ^:private null-structured-sentinel
+  "JS object substituted for `structuredContent` when the EDN payload is
+  `nil` (rf2-r5erl). A `null` structuredContent fails the SDK's
+  outputSchema validation (`expected record ... received null`); this
+  sub-object keeps the slot a record. Hosts that read the EDN text slot
+  see the verbatim `nil`; hosts that read the structured slot see the
+  sentinel and know the payload was empty."
+  {"rf.mcp/null" true})
+
+(defn- structured-of
+  "Project `v` to the `:structuredContent` JS value, guaranteeing a
+  non-null record (rf2-r5erl). `(clj->js v)` is `null` exactly when
+  `v` is `nil`; substitute the `:rf.mcp/null` sentinel object so the
+  SDK's outputSchema validation (which requires an object) never
+  rejects the result at the transport layer."
+  [v]
+  (if (nil? v)
+    (clj->js null-structured-sentinel)
+    (let [sc (clj->js v)]
+      ;; clj->js of a non-nil scalar can still be a JS primitive (a
+      ;; number / string / boolean), which is also not a record. Wrap
+      ;; any non-object projection in the sentinel-shaped envelope so
+      ;; the slot is always object-typed. (Tool payloads are maps in
+      ;; practice; this is the total-function backstop.)
+      (if (object? sc) sc (clj->js {"rf.mcp/value" v})))))
 
 (defn ok-text
   "Success result envelope. Always emits both `:content` (the
   pr-str EDN text) and `:structuredContent` (the JS-coerced
   projection of the same value). Agent hosts that recognise
   `:structuredContent` read the typed object; others fall back to
-  parsing the text slot."
+  parsing the text slot.
+
+  `:structuredContent` is guaranteed a non-null record (rf2-r5erl) —
+  a `nil` payload projects to the `:rf.mcp/null` sentinel object so the
+  SDK's outputSchema validation never rejects the result for a `null`
+  structuredContent."
   [v]
   #js {:content          #js [#js {:type "text" :text (pr-str v)}]
-       :structuredContent (clj->js v)})
+       :structuredContent (structured-of v)})
 
 (defn err-text
   "Error result envelope. Same dual-slot shape as `ok-text` plus
   `:isError true` so the agent client surfaces the failure to the
-  LLM without aborting the conversation (per MCP §Error Handling)."
+  LLM without aborting the conversation (per MCP §Error Handling).
+  `:structuredContent` is non-null by construction (rf2-r5erl)."
   [v]
   #js {:isError          true
        :content          #js [#js {:type "text" :text (pr-str v)}]
-       :structuredContent (clj->js v)})
+       :structuredContent (structured-of v)})
 
 (defn with-indicators
   "Splice the cross-MCP indicator-field slots (`:dropped-sensitive`,

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
@@ -339,6 +339,159 @@
                     "explicit build is not an auto-selection"))
               (done)))))))
 
+;; ---------------------------------------------------------------------------
+;; Round-trippable build ids (rf2-8t3ct).
+;;
+;; The canonical build id is a keyword (`:examples/step-deck`). A value
+;; copied out of a discover-app result's `:build` / `:build-id` slot must
+;; resolve back to the SAME build when passed as a later `:build` arg.
+;; The only alias axis is colon-tolerance (the EDN-ish `":foo"` vs bare
+;; `"foo"` an agent might serialise); `fresh-keyword` normalises both to
+;; the canonical keyword.
+;; ---------------------------------------------------------------------------
+
+(deftest discover-app-echoes-canonical-round-trippable-build
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime-probe-cache! conn :examples/step-deck)
+          args (tu/args->js {:build "examples/step-deck"})]
+      (-> (tu/with-stubbed-eval! healthy-health
+            (fn [] (discover-app/discover-app conn args)))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                ;; rf2-8t3ct — both the historical :build-id and the new
+                ;; input-name-matching :build carry the canonical keyword.
+                (is (= :examples/step-deck (:build-id edn)))
+                (is (= :examples/step-deck (:build edn))
+                    "discover-app echoes a canonical :build matching the input arg name")
+                ;; Round-trip: feed the echoed value back as a `:build`
+                ;; arg and confirm it resolves to the same keyword.
+                (is (= (:build edn)
+                       (wire/arg-build conn (tu/args->js {:build (:build edn)})))
+                    "the echoed :build round-trips unchanged through arg-build"))
+              (done)))))))
+
+(deftest canonical-build-round-trips-from-both-alias-forms
+  ;; The echoed canonical keyword, re-serialised either as the bare
+  ;; qualified string or the colon form, resolves identically — the
+  ;; deterministic alias contract (rf2-8t3ct). The two alias forms are
+  ;; exactly the colon-tolerance axis: `subs (str kw) 1` (drop the
+  ;; leading `:`) and `str kw` (keep it) both read back to `kw`.
+  (let [conn      (fresh-conn)
+        canonical :examples/step-deck
+        bare      (subs (str canonical) 1)   ; "examples/step-deck"
+        colon     (str canonical)]           ; ":examples/step-deck"
+    (is (= "examples/step-deck" bare) "sanity: the bare qualified form")
+    (is (= canonical (wire/arg-build conn (tu/args->js {:build bare})))
+        "bare qualified string round-trips to the canonical keyword")
+    (is (= canonical (wire/arg-build conn (tu/args->js {:build colon})))
+        "colon-prefixed form round-trips identically")
+    (is (= (wire/arg-build conn (tu/args->js {:build bare}))
+           (wire/arg-build conn (tu/args->js {:build colon})))
+        "the two alias forms are indistinguishable post-coercion")))
+
+;; ---------------------------------------------------------------------------
+;; Per-session isolation (rf2-fmho5).
+;;
+;; The sticky target lives on the per-connection conn-atom, NOT in a
+;; process-global. The MCP stdio model spawns one server process (and
+;; thus one session-state / conn-atom) per client, so distinct sessions
+;; are distinct conn-atoms by construction. This pins that a write to one
+;; conn's resolved-build-id never leaks into another conn.
+;; ---------------------------------------------------------------------------
+
+(deftest resolved-build-id-does-not-leak-across-sessions
+  (let [session-a (fresh-conn)
+        session-b (fresh-conn)
+        no-build  (tu/args->js {})]
+    ;; Session A discovers / sticks examples/step-deck.
+    (wire/mark-resolved-build-id! session-a :examples/step-deck)
+    ;; Session B sticks a DIFFERENT build.
+    (wire/mark-resolved-build-id! session-b :testbeds/panel-gallery)
+    (is (= :examples/step-deck (wire/arg-build session-a no-build))
+        "session A resolves to ITS sticky target")
+    (is (= :testbeds/panel-gallery (wire/arg-build session-b no-build))
+        "session B resolves to ITS sticky target — no cross-session leak")
+    ;; A fresh, untouched session falls through to the env default — it
+    ;; inherits NOTHING from A or B (no process-global).
+    (is (= :app (wire/arg-build (fresh-conn) no-build))
+        "a fresh session sees no sticky target from other sessions")))
+
+(deftest sticky-target-is-not-a-process-global
+  ;; Belt-and-braces: the sticky state is keyed on the conn-atom identity.
+  ;; Two conns with the same shape are independent atoms; mutating one's
+  ;; :resolved-build-id must not be observable on the other.
+  (let [a (fresh-conn)
+        b (fresh-conn)]
+    (swap! a assoc :resolved-build-id :only-a)
+    (is (= :only-a (:resolved-build-id @a)))
+    (is (nil? (:resolved-build-id @b))
+        "the sticky target is per-conn-atom, never shared across sessions")))
+
+;; ---------------------------------------------------------------------------
+;; Ambiguous-target / no-target structured error (rf2-fmho5).
+;;
+;; "If no session target exists and multiple runtimes are available, fail
+;; with a clear ambiguous-target error listing candidates." The eval-path
+;; resolver (`resolve-build!`, used by eval-cljs) rejects with a
+;; structured `:no-runtime-for-build` ex-info enumerating `:running-builds`
+;; when the build is the bare default (no explicit/cached choice) and
+;; zero-or-many builds run — never a silent wrong-build pick, never a
+;; host-level transport failure. (The plain read path surfaces the same
+;; candidate list via the diagnostic ladder's `:build-not-running` rung,
+;; pinned in probe_test.)
+;; ---------------------------------------------------------------------------
+
+(deftest resolve-build-rejects-with-candidates-when-no-target-and-many-run
+  (async done
+    ;; NB restore `probe/running-builds` INLINE before calling `done` —
+    ;; a `.finally`-scoped restore fires AFTER `done` advances to the next
+    ;; test and would leak the multi-build stub into a neighbour (the
+    ;; rf2-wb06a race the orient/invoke suites document).
+    (let [orig probe/running-builds
+          restore! (fn [] (set! probe/running-builds orig))
+          conn (fresh-conn)]
+      ;; No cached build, no explicit arg → build is the bare :app default
+      ;; (explicit? false). Two builds run → ambiguous.
+      (set! probe/running-builds
+            (fn [_] (js/Promise.resolve [:examples/step-deck :testbeds/panel-gallery])))
+      (-> (probe/resolve-build! conn :app false)
+          (.then (fn [_]
+                   (restore!)
+                   (is false "must reject on an ambiguous target")
+                   (done)))
+          (.catch (fn [err]
+                    (restore!)
+                    (let [data (ex-data err)]
+                      (is (= :no-runtime-for-build (:reason data))
+                          "structured reason, not a host failure")
+                      (is (= [:examples/step-deck :testbeds/panel-gallery]
+                             (:running-builds data))
+                          "the error lists the candidate builds"))
+                    (done)))))))
+
+(deftest resolve-build-honours-cached-session-target-over-ambiguity
+  ;; A session-sticky target (set by a prior discover-app) is treated as
+  ;; deliberate — `resolve-build!` resolves to it verbatim even on a
+  ;; multi-build workspace, so the sticky default actually removes the
+  ;; ambiguity instead of re-triggering it (rf2-fmho5 + rf2-l9ixp).
+  (async done
+    (let [conn (fresh-conn)]
+      ;; Cache a session target, then resolve with explicit? derived from
+      ;; the cache (arg-build-explicit? treats a cache hit as deliberate).
+      (swap! conn assoc :resolved-build-id :examples/step-deck)
+      (let [bid       (wire/arg-build conn (tu/args->js {}))
+            explicit? (wire/arg-build-explicit? conn (tu/args->js {}))]
+        (is (= :examples/step-deck bid))
+        (is (true? explicit?) "a cached session target counts as deliberate")
+        (-> (probe/resolve-build! conn bid explicit?)
+            (.then (fn [resolved]
+                     (is (= :examples/step-deck resolved)
+                         "the sticky session target wins — no ambiguous-target error")
+                     (done)))
+            (.catch (fn [_] (is false "must not reject when a session target is cached") (done))))))))
+
 (deftest auto-select-single-build-returns-pair
   ;; Unit-pin the probe helper directly: exactly-one → [build true];
   ;; zero/many → [nil false].

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/orient_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/orient_test.cljs
@@ -132,3 +132,29 @@
                  (is (err? r))
                  (is (= :unexpected-shape (:reason (read-result-text r))))
                  (done))))))
+
+(deftest echoes-resolved-build-for-round-tripping
+  ;; rf2-8t3ct / rf2-fmho5 — orient echoes the canonical resolved :build
+  ;; (the session-sticky target when :build is omitted) so the agent sees
+  ;; which build it oriented against.
+  (async done
+    (stub-eval! nil sample-summary)
+    (-> (orient/orient-tool (fresh-conn) #js {})
+        (.then (fn [r]
+                 (is (= :app (:build (read-result-text r)))
+                     "orient echoes the resolved :build keyword")
+                 (done))))))
+
+(deftest echoes-session-sticky-build-when-omitted
+  ;; With a session target cached (a prior discover-app), orient with no
+  ;; :build arg resolves to AND echoes that sticky target (rf2-fmho5).
+  (async done
+    (stub-eval! nil sample-summary)
+    (let [conn (fresh-conn)]
+      (swap! conn assoc :resolved-build-id :examples/step-deck
+                        :probed-builds #{:examples/step-deck})
+      (-> (orient/orient-tool conn #js {})
+          (.then (fn [r]
+                   (is (= :examples/step-deck (:build (read-result-text r)))
+                       "orient resolves + echoes the session-sticky build")
+                   (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_dom_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_dom_test.cljs
@@ -24,6 +24,7 @@
   form's internal contract."
   (:require [cljs.test :refer-macros [deftest is async testing]]
             [clojure.string :as str]
+            [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.read-dom :as read-dom]))
@@ -165,4 +166,55 @@
                    (let [edn (tu/extract-edn r)]
                      (is (false? (:ok? edn)))
                      (is (= :rf.error/read-dom-bad-selector (:reason edn))))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-r5erl — a BLANK eval result must NOT crash the MCP envelope.
+;;
+;; `cljs-eval-value` resolves to `nil` when shadow returns a blank value
+;; (the runtime didn't answer the eval). The original read-dom threaded
+;; that nil straight into `(wire/ok-text nil)`, whose `(clj->js nil)`
+;; structuredContent is JS `null` — and the SDK's outputSchema validation
+;; rejects a null structuredContent at the TRANSPORT layer
+;; (`expected record at structuredContent, received null`), bypassing the
+;; normal `{:ok? false}` error contract. read-dom now turns a blank
+;; result into a structured error; the envelope's structuredContent is a
+;; non-null record either way.
+;; ---------------------------------------------------------------------------
+
+(deftest blank-eval-result-becomes-structured-error-not-host-failure
+  (async done
+    ;; nil canned value = the blank shadow eval that triggered rf2-r5erl.
+    (-> (tu/with-stubbed-eval! nil
+          (fn []
+            (read-dom/read-dom-tool (fresh-conn) #js {:selector "body" :limit 1})))
+        (.then (fn [r]
+                 (is (tu/error? r)
+                     "a blank eval surfaces as a normal isError tool result, not a thrown host failure")
+                 (let [edn (tu/extract-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :rf.error/read-dom-blank-result (:reason edn))
+                       "structured reason, not a transport exception")
+                   (is (= "body" (:selector edn)) "echoes the selector"))
+                 ;; The load-bearing rf2-r5erl assertion: structuredContent
+                 ;; is a NON-NULL record so the SDK outputSchema check passes.
+                 (is (some? (j/get r :structuredContent))
+                     "structuredContent must NOT be null (the rf2-r5erl crash)")
+                 (is (object? (j/get r :structuredContent))
+                     "structuredContent must be a record")
+                 (done))))))
+
+(deftest happy-result-echoes-canonical-build
+  ;; rf2-8t3ct / rf2-fmho5 — a successful read-dom echoes the canonical
+  ;; resolved :build so the agent sees (and can round-trip) the target.
+  (async done
+    (let [canned {:ok? true :selector "body" :count 0 :truncated? false :nodes []}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (read-dom/read-dom-tool (fresh-conn) #js {:selector "body"})))
+          (.then (fn [r]
+                   (let [edn (tu/extract-edn r)]
+                     (is (true? (:ok? edn)))
+                     (is (= :app (:build edn))
+                         "echoes the resolved :build keyword (round-trippable)"))
                    (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_ui_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_ui_test.cljs
@@ -24,6 +24,7 @@
   read."
   (:require [cljs.test :refer-macros [deftest is async]]
             [clojure.string :as str]
+            [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.read-ui :as read-ui]))
@@ -192,4 +193,35 @@
                    (let [edn (tu/extract-edn r)]
                      (is (false? (:ok? edn)))
                      (is (= :rf.error/ui-read-bad-selector (:reason edn))))
+                   (done)))))))
+
+(deftest blank-eval-result-becomes-structured-error-not-host-failure
+  ;; rf2-r5erl sibling: a blank eval result (nil) must not produce a null
+  ;; structuredContent that the SDK rejects at the transport layer.
+  (async done
+    (-> (tu/with-stubbed-eval! nil
+          (fn []
+            (read-ui/read-ui-tool (fresh-conn) #js {:selector "body"})))
+        (.then (fn [r]
+                 (is (tu/error? r))
+                 (let [edn (tu/extract-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :rf.error/read-ui-blank-result (:reason edn))))
+                 (is (some? (j/get r :structuredContent))
+                     "structuredContent must NOT be null (rf2-r5erl)")
+                 (is (object? (j/get r :structuredContent)))
+                 (done))))))
+
+(deftest happy-result-echoes-canonical-build
+  ;; rf2-8t3ct / rf2-fmho5 — read-ui echoes the resolved :build.
+  (async done
+    (let [canned {:ok? true :via :selector
+                  :entity {:view-id :my.app/x :source-coord nil :render-key 1 :subs-read []}
+                  :content {:tag "div" :text "x" :attrs {}}}]
+      (-> (tu/with-stubbed-eval! canned
+            (fn []
+              (read-ui/read-ui-tool (fresh-conn) #js {:selector "#x"})))
+          (.then (fn [r]
+                   (is (= :app (:build (tu/extract-edn r)))
+                       "echoes the resolved :build keyword")
                    (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/structured_content_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/structured_content_test.cljs
@@ -88,3 +88,49 @@
       ;; is a JS object (the precise shape is pinned in the cache test
       ;; corpus elsewhere).
       (is (object? (j/get result :structuredContent))))))
+
+;; ---------------------------------------------------------------------------
+;; structuredContent is NEVER null (rf2-r5erl).
+;;
+;; Every tool descriptor declares a map-shaped `:outputSchema`
+;; (`{:type "object"}`). The npm MCP SDK validates `structuredContent`
+;; against it, and a `null` is not a record — the SDK rejects the whole
+;; `tools/call` at the transport layer with
+;; `Invalid tools/call result: expected record at structuredContent,
+;; received null`. read-dom hit this in the wild when its browser eval
+;; came back blank (`cljs-eval-value` → nil → `(wire/ok-text nil)` →
+;; `(clj->js nil)` → null). `ok-text` / `err-text` now make the slot a
+;; total non-null record.
+;; ---------------------------------------------------------------------------
+
+(deftest ok-text-nil-payload-never-emits-null-structured-content
+  (testing "wire/ok-text with a nil payload emits a non-null structured record (rf2-r5erl)"
+    (let [result (wire/ok-text nil)]
+      (is (some? (j/get result :structuredContent))
+          ":structuredContent must NOT be null — the SDK outputSchema check rejects null")
+      (is (object? (j/get result :structuredContent))
+          ":structuredContent must be a record (object), not a primitive")
+      (is (true? (j/get-in result [:structuredContent "rf.mcp/null"]))
+          "the nil payload projects to the :rf.mcp/null sentinel object")
+      (is (= "nil" (content-text result))
+          "the EDN text slot still carries the verbatim nil for the cljs round-trip"))))
+
+(deftest err-text-nil-payload-never-emits-null-structured-content
+  (testing "wire/err-text with a nil payload emits a non-null structured record (rf2-r5erl)"
+    (let [result (wire/err-text nil)]
+      (is (true? (j/get result :isError)))
+      (is (some? (j/get result :structuredContent)))
+      (is (object? (j/get result :structuredContent))
+          ":structuredContent must be a record even on the error path"))))
+
+(deftest ok-text-scalar-payload-wraps-to-a-record
+  (testing "a non-map scalar payload still projects to an object structuredContent (rf2-r5erl)"
+    ;; clj->js of a bare scalar (number / string / bool) is a JS
+    ;; primitive — also not a record. The total-function backstop wraps
+    ;; it so the slot is always object-typed.
+    (doseq [v [42 "hi" true]]
+      (let [result (wire/ok-text v)]
+        (is (object? (j/get result :structuredContent))
+            (str "scalar " (pr-str v) " must wrap to an object structuredContent"))
+        (is (= (pr-str v) (content-text result))
+            "the EDN text slot still carries the verbatim scalar")))))


### PR DESCRIPTION
Three pair-review follow-ons in `tools/re-frame2-pair-mcp`. **No new tool, verb, or descriptor** — so the verb-vocab / skill-drift / descriptor gates that bit #2819 stay quiet by construction.

## rf2-r5erl (bug) — read-dom invalid structuredContent envelope
Root cause: every tool declares a map-shaped `:outputSchema`, so the MCP SDK validates `structuredContent` and rejects a `null` at the transport layer (`expected record at structuredContent, received null`). A blank browser eval (`cljs-eval-value` -> nil) threaded straight into `wire/ok-text nil` -> `(clj->js nil)` = null. read-ui escaped only by always getting a map back.
Fix:
- `wire/ok-text` / `err-text` now guarantee a **non-null** structuredContent record (nil -> `{:rf.mcp/null true}` sentinel; scalar -> wrapped). Total function at the boundary.
- read-dom / read-ui map a blank (nil/non-map) eval to a structured `{:ok? false :reason :rf.error/read-*-blank-result}` like `orient` already did — never `ok-text nil`.
- **Conformance-level repro**: `end-to-end-re-frame2-pair.cjs` now drives read-dom / read-ui / orient through the real MCP SDK `Client` and asserts non-null object structuredContent — the authoritative SDK layer, not a unit proxy.

## rf2-8t3ct — round-trippable build ids
Canonical build id is the keyword. discover-app echoes `:build` (input-arg-named) beside `:build-id`; orient/read-dom/read-ui echo the resolved `:build`. Only alias axis is colon-tolerance, which round-trips deterministically (`fresh-keyword`). No fuzzy build-alias surface exists — the registry is the finite set of running shadow builds addressed by exact keyword.

## rf2-fmho5 — sticky per-session selection
The sticky `:resolved-build-id` already lives on the **per-connection conn-atom** (rf2-l9ixp) — per-session by construction under the MCP stdio model (one server process per client), never a process-global `def`. Rounded out: read-family ops echo the resolved target so implicit selection stays visible; no-session-target + many-builds yields a structured `:no-runtime-for-build` / `:build-not-running` error listing candidates, never a host failure.

## Quality gates
- **rf2-r5erl** — RED before / GREEN after. New `structured_content_test`: ok-text/err-text with nil payload emit a non-null `:rf.mcp/null` record (would have been null pre-fix). New `read_dom_test` / `read_ui_test`: a blank eval -> structured `:rf.error/read-*-blank-result`, structuredContent a non-null object. Conformance: read-dom/read-ui/orient validated through the SDK Client.
- **rf2-8t3ct** — GREEN. discover-app echoes canonical `:build`; round-trips from both bare + colon forms; read-dom/read-ui/orient echo `:build`.
- **rf2-fmho5** — GREEN. Per-session isolation (two conns don't leak), not-a-process-global, ambiguous-target structured error listing candidates, sticky target honoured over ambiguity.
- `npm test` (pair-mcp CLJS suite): **835 tests, 2535 assertions, 0 failures**.
- `check:descriptors`: **exit 0** (28 tools, in sync — confirms no tool added).
- skill-MCP drift (`python scripts/check_skill_mcp_drift.py`): **exit 0**.
- verb-vocab / wire-vocab (`clojure -M:test` in tools/mcp-conformance/wire-vocab): **49 tests, 627 assertions, 0 failures** — the gate that killed #2819's `orient` (no new verb here).
- mcp-conformance pair (`end-to-end-re-frame2-pair.cjs`): **GREEN** — incl. `every tool envelope carries :structuredContent` and read-dom/read-ui/orient SDK validation. `end-to-end-flag-gates.cjs`: GREEN.
- clj-kondo on all changed CLJS src + tests: **0 errors, 0 warnings**.

Tool / verb / descriptor additions: **none**. Live-redaction conformance SKIPs without a live nREPL (CI hermetic orchestrator fires it); degraded SDK conformance + unit repro cover r5erl authoritatively.