### PR TITLE
feat(xray): machine-cascade logical-state delta box + source-not-captured → machine-def links (rf2-iwy0c)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1486,17 +1486,34 @@ macrostep — intermediate-state inline-fns fall back to the
 headline state; source-key resolution degrades to the macrostep's
 source/target.
 
-For `:transition` rows, the body renders the transition map literal
-(EDN). For `:timer` rows, the body is elided (the parent state-node
+For `:transition` rows, the body renders the **logical-state DELTA
+box** (rf2-iwy0c — see "Transition row" below), NOT a source form;
+the `[:states <source-state>... :on <event>]` source-key in the table
+above still resolves the transition's click-to-source coord for the
+verb-link, but the body itself is the `{:state :tags}` before→after
+diff. For `:timer` rows, the body is elided (the parent state-node
 is too verbose to render verbatim); the click-to-source chip on the
 verb is the primary affordance, opening the operator on the state
 that owns the `:after` slot.
 
 Always visible by default per the bead body's "interleaved source
 code" requirement — the operator reads what ran AND its code at the
-same vertical position without expand/collapse gestures. Source-
-missing fallback renders a muted `<source not yet captured>`
-placeholder so the slot is consistently present.
+same vertical position without expand/collapse gestures. **Source-
+missing fallback (rf2-iwy0c part B).** When no source form is captured
+for an `:action` / `:guard` row (production `goog.DEBUG=false` builds,
+value-registered machines), the body renders the **machine id as a
+click-to-source LINK to the machine definition** — NOT a dead `<source
+not yet captured>` literal. The link (shared `coord-link`, `<id> ↗`
+grammar) targets, per Mike's ruling, BOTH the reg-machine CALL-SITE and
+the defmachine DEFINITION:
+
+- **(i) reg-machine call-site** — the `:file` / `:line` captured TODAY
+  on `(rf/handler-meta :event event-id)` (rf2-ge6uj). Implemented now.
+- **(ii) defmachine definition** — RELATES to rf2-gwj8l (definition
+  coord not yet stamped for value-registered machines). The link
+  STRUCTURE lights up automatically once gwj8l stamps the coord; until
+  then it DEGRADES GRACEFULLY to (i) alone, and to a plain
+  non-clickable label when even the call-site coord is absent.
 
 **Per-row outcome detail.** Action rows surface inline:
 
@@ -1520,20 +1537,51 @@ placeholder so the slot is consistently present.
 - **`✗ threw`** — when the action threw, an error chip + exception
   message.
 
-**Transition row — one prominent collapsed row (rf2-ge6uj).** The
-transition zone is a SINGLE prominent row: the header carries `[#step]
-[TRANSITION badge] <before-state → after-state>`, where the verb IS the
-state change (rendered larger / bolder / magenta — the focal point of
-the collapsed zone) and doubles as the click-to-source affordance onto
-the transition map. The redundant leading "transition" word (the KIND
-pill already says TRANSITION), the machine-name echo (already the
-cascade context), and the prior repetitive lower-line `state {:from} →
-{:to}` + `event [...]` detail block are all REMOVED. The transition MAP
-literal still renders as the row's source body (the `{:target :guard
-:action}` rf2-wwc3j delight shape) — that is the source, not a
-repetition. Timer rows surface only the header + click-to-source chip
-(no inline body — cancellations are housekeeping; the chip routes to
-the `:after`-bearing state node).
+**Transition row — prominent header verb + logical-state DELTA box
+(rf2-ge6uj header · rf2-iwy0c body).** The transition zone is a SINGLE
+prominent row: the header carries `[#step] [TRANSITION badge]
+<before-state → after-state>`, where the verb IS the state change
+(rendered larger / bolder / magenta — the focal point of the collapsed
+zone) and doubles as the click-to-source affordance. The redundant
+leading "transition" word (the KIND pill already says TRANSITION), the
+machine-name echo (already the cascade context), and the prior
+repetitive lower-line `state {:from} → {:to}` + `event [...]` detail
+block are all REMOVED.
+
+The row's BODY is the **logical-state DELTA box** (rf2-iwy0c part A) —
+an `ei/edn-inspector` DIFF (the SAME widget + `{:before <prior>}`
+posture the per-action `↳ data Δ` uses, rf2-5hjb5) showing the
+machine's `{:state :tags}` BEFORE → AFTER. This **REVERSES the
+rf2-wwc3j transition-map "delight shape"** (intentional, per Mike): the
+map literal merely restated the target state the headline verb already
+names, whereas the delta box earns its place by carrying `:tags` + the
+structured before→after state object.
+
+- **Scope = `{:state :tags}` ONLY** (`projection/machine-logical-
+  state`). `:data` is EXCLUDED — the per-action `↳ data Δ` already
+  carries it (folding it in double-shows it); the framework-owned
+  `:rf/*` snapshot slots (`:rf/spawn-counter`, after-epoch counters —
+  Spec 005 §Reserved snapshot-internal keys) are EXCLUDED (not user
+  state — a raw snapshot-diff would dump them). `select-keys [:state
+  :tags]` filters everything else by construction.
+- **Data source** — the transition row's `:before` / `:after` snapshots
+  (hoisted off the `:rf.machine/transition` trace's `:before` / `:after`
+  tags, which carry the full machine snapshot on either side per Spec
+  005 §Trace events). Equivalently the epoch record's `:db-before` /
+  `:db-after` at `[:rf/runtime :machines :snapshots <machine-id>]`.
+- **Parallel machines** — `:state` may be a region→state map; the box
+  shows the structured map + the tag-union shift in one object (e.g.
+  `{:vehicle :red :pedestrian :dont-walk}` / `#{:vehicle-stop
+  :ped-stop}`), exactly what the single-region headline verb cannot
+  convey.
+- **Elision** — on a SELF / internal transition where neither `:state`
+  nor `:tags` changed (`projection/machine-logical-state-changed?`
+  false — only `:data` or `:rf/*` bookkeeping moved), the box is elided
+  entirely; the headline verb stays.
+
+Timer rows surface only the header + click-to-source chip (no inline
+body — cancellations are housekeeping; the chip routes to the
+`:after`-bearing state node).
 
 **Empty-state correctness** (acceptance #4 — rf2-u69j7). A vanilla
 `reg-event-db` cascade (or any non-`:reg-machine` flavour) renders
@@ -1555,9 +1603,9 @@ Epoch infrastructure:
 **The legacy category-grouped sub-sections are REPLACED, not
 augmented** (per Mike, pre-alpha posture). The full state-change
 story is now told inline by the cascade: transitions render their
-`from → to` snapshots; actions render their data-write + fx
-attribution + source body; no separate DATA REDUCTION / SNAPSHOT
-DIFF block lands. The FX section's per-action `:attributed-to`
+`from → to` headline verb + the `{:state :tags}` logical-state delta
+box (rf2-iwy0c); actions render their data-write + fx attribution +
+source body; no separate DATA REDUCTION / SNAPSHOT DIFF block lands. The FX section's per-action `:attributed-to`
 chip stays in place (the FX step is the post-commit lens; the
 cascade row is the action-attribution lens — same data, two
 surfaces).

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -894,6 +894,52 @@
     (when (seq nums)
       (reduce + 0 nums))))
 
+;; ---- machine LOGICAL-STATE delta (rf2-iwy0c) ----------------------------
+;;
+;; The `:transition` cascade row carries the machine's FULL before / after
+;; snapshot maps (`:before` / `:after`, hoisted off the
+;; `:rf.machine/transition` trace's `:before` / `:after` tags — the
+;; substrate emits the literal snapshot on either side, per Spec 005
+;; §Trace events). A snapshot is `{:state :data :tags? :meta?}` PLUS the
+;; closed set of framework-owned `:rf/*` slots (`:rf/spawn-counter`,
+;; after-epoch counters — Spec 005 §Reserved snapshot-internal keys).
+;;
+;; The transition-row DELTA box (rf2-iwy0c part A) shows the LOGICAL state
+;; change — `{:state :tags}` ONLY. `:data` is EXCLUDED (the per-action
+;; DATA Δ already carries it — folding it in here double-shows it); the
+;; `:rf/*` bookkeeping slots are EXCLUDED (not user state — a raw
+;; snapshot-diff would dump them). Projecting to exactly `{:state :tags}`
+;; with `select-keys` filters everything else by construction.
+
+(defn machine-logical-state
+  "Project a machine snapshot map down to its LOGICAL state — `{:state
+  :tags}` ONLY (rf2-iwy0c). Excludes `:data` (surfaced by the per-action
+  DATA Δ), `:meta`, and the framework-owned `:rf/*` snapshot slots
+  (`:rf/spawn-counter` etc. — Spec 005 §Reserved snapshot-internal keys).
+
+  `:state` may be a keyword / path-vector (single + compound machines) OR
+  a region→state map (parallel machines); `:tags` is the union tag-set.
+  The select-keys projection preserves whichever shape the snapshot
+  carries — the parallel/compound structure renders verbatim in the
+  delta box.
+
+  Returns nil for a nil snapshot so callers can elide cleanly."
+  [snapshot]
+  (when (map? snapshot)
+    (select-keys snapshot [:state :tags])))
+
+(defn machine-logical-state-changed?
+  "True iff the LOGICAL state (`{:state :tags}`) differs between the
+  before + after snapshots (rf2-iwy0c). A self / internal transition
+  whose `:state` AND `:tags` are both unchanged returns false — the
+  delta box is elided in that case (only `:data` or `:rf/*` bookkeeping
+  moved, which the box does not show). nil snapshots compare as their
+  projected `{}` so a missing side reads as 'changed' only when the
+  other side carries logical state."
+  [before after]
+  (not= (machine-logical-state before)
+        (machine-logical-state after)))
+
 (defn- run-end-tags
   "Tags off the `:rf.event/run-end` trace — carries the handler's
   finalised duration + flavour-discriminating slots. Empty map when no

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -482,7 +482,28 @@
    :border-left  (str "2px solid " border-subtle-colour)
    :min-width    0})
 
-(def ^:private cascade-row-source-missing-style
+;; rf2-iwy0c — the source-not-captured fallback now LINKS to the machine
+;; definition (the reg-machine call-site coord) rather than rendering a
+;; dead `<source not yet captured>` literal. Reads the same `<label> + ↗`
+;; coord-link grammar the cascade verb-link + HANDLER verb-link use.
+(def ^:private cascade-source-machine-link-style
+  {:background            "transparent"
+   :border                "none"
+   :padding               0
+   :margin                0
+   :color                 accent-colour
+   :cursor                "pointer"
+   :font-family           mono-stack
+   :font-size             "11px"
+   :font-style            "italic"
+   :text-decoration       "underline"
+   :text-decoration-style "dotted"
+   :text-underline-offset "2px"
+   :display               "inline-flex"
+   :align-items           "center"
+   :gap                   "4px"})
+
+(def ^:private cascade-source-machine-plain-style
   {:font-style  "italic"
    :font-family mono-stack
    :font-size   "11px"
@@ -2455,6 +2476,85 @@
     (string? source-form) source-form
     :else (pr-str source-form)))
 
+(defn- machine-call-site-coord
+  "Lift the reg-machine CALL-SITE `{:file :line}` off the registered
+  machine's `handler-meta` (rf2-iwy0c part B-i). A machine is registered
+  as an ordinary `:event` handler carrying `:rf/machine? true` + the
+  top-level call-site `:file` / `:line` (rf2-ge6uj). Returns nil when no
+  coord was captured (production builds with `goog.DEBUG=false`,
+  value-registered machines whose definition coord isn't stamped —
+  rf2-gwj8l)."
+  [machine-meta]
+  (when (and machine-meta
+             (string? (:file machine-meta))
+             (seq (:file machine-meta)))
+    {:file (:file machine-meta) :line (:line machine-meta)}))
+
+(defn- cascade-row-machine-def-link
+  "Render the source-not-captured FALLBACK for a cascade row (rf2-iwy0c
+  part B) — replaces the dead `<source not yet captured>` literal. Links
+  the machine id (e.g. `main`) to the machine DEFINITION:
+
+  - (i) the reg-machine CALL-SITE coord — captured TODAY off the
+    registered handler's `:file` / `:line` (rf2-ge6uj). Implemented now.
+  - (ii) the defmachine DEFINITION coord — RELATES to rf2-gwj8l (not yet
+    landed for value-registered machines). The link structure below
+    lights up automatically once gwj8l stamps a definition coord; until
+    then `machine-call-site-coord` resolves only the call-site, so the
+    link degrades GRACEFULLY to (i) alone (and to a plain non-clickable
+    label when even the call-site coord is absent — production elision).
+
+  The id renders through the shared `coord-link` so the `<id> ↗` +
+  open-in-editor grammar matches every other source affordance in the
+  panel."
+  [row machine-meta]
+  (let [coord    (machine-call-site-coord machine-meta)
+        ;; The machine id IS the registering event-id (Spec 005 — the
+        ;; machine is its own event handler). The projection stamps it
+        ;; on every cascade row as `:machine-id`.
+        id       (:machine-id row)
+        label    (if id (fmt/ns-keyword id) "machine")]
+    (coord-link/coord-link
+      coord label
+      (str "rf-xray-epoch-machine-cascade-source-missing-" (:step row))
+      {:style       cascade-source-machine-link-style
+       :plain-style cascade-source-machine-plain-style})))
+
+(defn- cascade-row-transition-delta
+  "Render a `:transition` row's LOGICAL-STATE DELTA box (rf2-iwy0c part
+  A) — REPLACES the prior transition-map source body (the rf2-wwc3j
+  'delight shape'). Shows the machine's `{:state :tags}` BEFORE → AFTER
+  through `ei/edn-inspector` in DIFF mode (the SAME widget + posture the
+  per-action DATA Δ uses, rf2-5hjb5), with the AFTER logical-state
+  rendered against the BEFORE so changed leaves carry inline `← was X`
+  annotations.
+
+  Scope = `{:state :tags}` ONLY (`projection/machine-logical-state`):
+  `:data` is the per-action DATA Δ's job (folding it in double-shows
+  it); the framework `:rf/*` snapshot slots (`:rf/spawn-counter`,
+  after-epoch counters — Spec 005 §Reserved snapshot-internal keys) are
+  not user state. For a PARALLEL machine the box shows the structured
+  region→state map + the tag-union shift in one object — exactly what
+  the single-region headline verb (`<from> → <to>`) cannot convey.
+
+  The headline verb stays the quick read; this box is the structured
+  before→after. ELIDED on a self / internal transition where neither
+  `:state` nor `:tags` changed (`machine-logical-state-changed?`) — the
+  box would otherwise show a no-op diff. Returns nil in that case so the
+  caller renders no source slot at all for the row."
+  [{:keys [step before after] :as _row}]
+  (when (proj/machine-logical-state-changed? before after)
+    (let [before-ls (proj/machine-logical-state before)
+          after-ls  (proj/machine-logical-state after)]
+      [:div {:data-testid (str "rf-xray-epoch-machine-cascade-source-" step)
+             :style cascade-row-source-style}
+       [:div {:data-testid (str "rf-xray-epoch-machine-cascade-transition-delta-" step)}
+        [ei/edn-inspector after-ls
+         (cond-> {:site-id                [:rf.xray.epoch/machine-cascade-transition-delta step]
+                  :card?                  false
+                  :default-expanded-depth 3}
+           (some? before-ls) (assoc :before before-ls))]]])))
+
 (defn- cascade-row-source-body
   "Render the source code body for a cascade row (rf2-u69j7 baseline +
   rf2-wwc3j inline-fn extensions). Always visible per the bead body's
@@ -2463,25 +2563,35 @@
 
   - `:action` / `:guard` rows: render the captured source form (named-
     handler pr-str string OR inline-fn slot value) through the
-    canonical `edn/code-block` widget.
-  - `:transition` rows (rf2-wwc3j): render the transition map literal
-    (renderable EDN). This is the bead's 'delight shape' for the
-    transition cascade — the operator reads the `{:target :guard
-    :action}` form inline.
+    canonical `edn/code-block` widget. When no source form is captured
+    (production builds with `goog.DEBUG=false`, value-registered
+    machines), FALL BACK to a click-to-source link to the machine
+    DEFINITION (rf2-iwy0c part B — `cascade-row-machine-def-link`)
+    rather than a dead placeholder.
+  - `:transition` rows (rf2-iwy0c part A): render the LOGICAL-STATE
+    DELTA box (`{:state :tags}` before → after, `cascade-row-
+    transition-delta`) — REVERSES the rf2-wwc3j transition-map 'delight
+    shape' (intentional per Mike: the map literal merely restated the
+    target state the headline verb already names; the delta box earns
+    its place by carrying `:tags` + the structured parallel/compound
+    state object). Elided when the logical state didn't change.
   - `:timer` rows: no body (the spec value at the parent state path is
     a verbose state-node map; the click-to-source chip on the verb is
     the primary affordance).
-  - When no source form is captured (production builds with
-    `goog.DEBUG=false`, fixture machines that pre-date the source-
-    coord stamping pass), render a muted placeholder so the operator
-    sees the slot consistently.
 
   rf2-66wis / rf2-93jp0 — `edn/code-block` paints clojure-syntax
   tokens with the same per-token palette as the Figma authority's
   `.syntax-*` classes, so the cascade code body matches the HANDLER
   step's source body."
-  [row source-form]
-  (when (contains? #{:action :guard :transition} (:kind row))
+  [machine-meta row source-form]
+  (cond
+    ;; rf2-iwy0c part A — transition rows show the logical-state delta,
+    ;; NOT the transition map literal. Self/internal transitions (no
+    ;; logical change) elide the box entirely.
+    (= :transition (:kind row))
+    (cascade-row-transition-delta row)
+
+    (contains? #{:action :guard} (:kind row))
     (let [src-str (source-form->string source-form)]
       [:div {:data-testid (str "rf-xray-epoch-machine-cascade-source-"
                                (:step row))
@@ -2492,10 +2602,9 @@
             :lang   :clojure
             :testid (str "rf-xray-epoch-machine-cascade-source-body-"
                          (:step row))})
-         [:span {:data-testid (str "rf-xray-epoch-machine-cascade-source-missing-"
-                                   (:step row))
-                 :style cascade-row-source-missing-style}
-          "<source not yet captured>"])])))
+         ;; rf2-iwy0c part B — no captured source → link to the machine
+         ;; definition instead of a dead placeholder.
+         (cascade-row-machine-def-link row machine-meta))])))
 
 (defn- cascade-row-action-data-diff
   "Render an `:action` row's `:data` DELTA through the edn-inspector in
@@ -2597,9 +2706,13 @@
 ;; re-stated the state change on a labelled `state <from> → <to>` line and
 ;; echoed the triggering `event [...]` underneath — both redundant (the
 ;; KIND pill already says TRANSITION; the DISPATCH step + cascade context
-;; already name the event). The transition MAP literal still renders as
-;; the row's source body (`cascade-row-source-body`, rf2-wwc3j) — the
-;; `{:target :guard :action}` delight shape — which is NOT repetitive.
+;; already name the event). rf2-iwy0c — the transition row's source body
+;; is now the LOGICAL-STATE DELTA box (`{:state :tags}` before → after via
+;; `cascade-row-transition-delta`), REVERSING the rf2-wwc3j transition-map
+;; 'delight shape': the map literal merely restated the target state the
+;; headline verb already names, whereas the delta box carries `:tags` + the
+;; structured parallel/compound state object the single-region verb cannot
+;; convey. The box elides on a self/internal transition (no logical change).
 
 (defn- cascade-row-view
   "Render one cascade row (rf2-u69j7). Layout:
@@ -2613,9 +2726,10 @@
   full layout (phase chip + source body + outcome details — incl. the
   rf2-5hjb5 inspector data DIFF); `:guard` rides a thinner layout
   (source body, no phase chip); `:transition` rides the prominent
-  state-change verb (`<before> → <after>`) + the transition-map source
-  body, with NO repetitive detail block (rf2-ge6uj ISSUE 3); `:timer`
-  rides a minimal layout (kind + state + reason, no source body)."
+  state-change verb (`<before> → <after>`) + the rf2-iwy0c logical-state
+  DELTA box (`{:state :tags}` before → after), with NO repetitive detail
+  block (rf2-ge6uj ISSUE 3); `:timer` rides a minimal layout (kind +
+  state + reason, no source body)."
   [machine-meta row]
   (let [{:keys [kind step phase duration-ms outcome threw?]} row
         coord       (cascade-row-coord machine-meta row)
@@ -2650,8 +2764,10 @@
          (when (or (= :transition kind) (and (= :guard kind) outcome-lbl))
            outcome-lbl))]]
      ;; Source code body (always visible per rf2-u69j7) — actions + guards
-     ;; + the transition MAP literal (the rf2-wwc3j delight shape).
-     (cascade-row-source-body row source-form)
+     ;; render their source (or the rf2-iwy0c machine-def link when none
+     ;; was captured); the `:transition` row renders the rf2-iwy0c
+     ;; logical-state DELTA box (`{:state :tags}` before → after).
+     (cascade-row-source-body machine-meta row source-form)
      ;; Per-row outcome details — kind-specific. rf2-ge6uj ISSUE 3 — the
      ;; `:transition` row carries NO extra detail body: the prominent
      ;; header verb (`<before> → <after>`) is the focal point and the
@@ -2744,8 +2860,10 @@
 ;; collapsing silently.
 ;;
 ;; For machine handlers the "source" is the machine spec — read via
-;; `rf/handler-meta :machine event-id`. The spec renders through the
-;; same `edn/inspect` widget every other top-level EDN map uses.
+;; `rf/handler-meta :event event-id` (the machine IS a `reg-event-fx`
+;; with the spec under `:rf/machine`; rf2-iwy0c part C — the prior
+;; `:machine` kind resolved nil). The spec renders through the same
+;; `edn/inspect` widget every other top-level EDN map uses.
 
 (defn- handler-source-string
   "Return the registered event-handler's source string from the
@@ -2758,12 +2876,16 @@
       s)))
 
 (defn- machine-spec-value
-  "Return the registered machine handler's spec data. Read off the
-  `:machine-spec` slot (the substrate stashes the original
-  `(reg-machine id spec ...)` argument here) so the panel can render
-  it via the canonical edn-inspector."
+  "Return the registered machine handler's spec data. A machine is
+  registered as a `reg-event-fx` carrying `:rf/machine? true` + the
+  stamped spec under `:rf/machine` (rf2-ge6uj / rf2-ypu5i); the legacy
+  `:machine-spec` / `:spec` / `:rf.machine/spec` slots are fixture-
+  shape fallbacks used by unit tests. Mirrors the cascade path's
+  `projection/machine-spec-from-meta` resolution so the HANDLER step's
+  machine SPEC reads the SAME spec the cascade source rows read."
   [meta]
-  (or (:machine-spec meta)
+  (or (:rf/machine meta)
+      (:machine-spec meta)
       (:spec meta)
       (:rf.machine/spec meta)))
 
@@ -2850,9 +2972,18 @@
   click-to-source affordance now (see `handler-verb-link`). This
   fn renders only the code body."
   [flavour event-id]
+  ;; rf2-iwy0c part C — read the registration meta under the `:event`
+  ;; kind for BOTH flavours. A machine is registered as a `reg-event-fx`
+  ;; carrying `:rf/machine? true` + the spec under `:rf/machine` (rf2-ge6uj
+  ;; ISSUE 2 fixed this in the cascade path; `machine-block` reads `:event`
+  ;; too). The prior `(if machine? :machine :event)` lookup resolved nil for
+  ;; the machine spec — there is NO `:machine` registrar kind — so the
+  ;; HANDLER step's machine SPEC rendered the `<source not yet captured>`
+  ;; placeholder. Reading under `:event` + `machine-spec-value`'s `:rf/machine`
+  ;; resolution surfaces the spec.
   (let [machine? (= :reg-machine flavour)
         meta     (when (some? event-id)
-                   (try (rf/handler-meta (if machine? :machine :event) event-id)
+                   (try (rf/handler-meta :event event-id)
                         (catch :default _ nil)))
         spec     (when machine? (machine-spec-value meta))
         src      (when-not machine? (handler-source-string meta))]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -649,6 +649,48 @@
                 [{:kind :guard} {:kind :action}]))
         "no row carries a duration → nil")))
 
+(deftest machine-logical-state-test
+  (testing "rf2-iwy0c — `machine-logical-state` projects a snapshot to
+            `{:state :tags}` ONLY, excluding `:data`, `:meta`, and the
+            framework `:rf/*` bookkeeping slots."
+    (is (= {:state :locked :tags #{:locked}}
+           (proj/machine-logical-state
+             {:state :locked
+              :tags #{:locked}
+              :data {:tries 0}
+              :meta {:created 1}
+              :rf/spawn-counter {}}))
+        "select-keys [:state :tags] drops :data / :meta / :rf/* by construction")
+    (testing "parallel machine — the region→state map + tag-union survive verbatim"
+      (is (= {:state {:vehicle :red :pedestrian :dont-walk}
+              :tags #{:vehicle-stop :ped-stop}}
+             (proj/machine-logical-state
+               {:state {:vehicle :red :pedestrian :dont-walk}
+                :tags #{:vehicle-stop :ped-stop}
+                :data {:cycles 0}}))))
+    (testing "a snapshot with no :tags projects just :state"
+      (is (= {:state :idle}
+             (proj/machine-logical-state {:state :idle :data {}}))))
+    (is (nil? (proj/machine-logical-state nil))
+        "nil snapshot → nil (caller elides)")))
+
+(deftest machine-logical-state-changed?-test
+  (testing "rf2-iwy0c — `machine-logical-state-changed?` keys the delta-box
+            elision: true iff `{:state :tags}` differs across before/after."
+    (is (true? (proj/machine-logical-state-changed?
+                 {:state :locked :tags #{:locked} :data {:n 0}}
+                 {:state :open   :tags #{:open}   :data {:n 0}}))
+        ":state changed → changed")
+    (is (true? (proj/machine-logical-state-changed?
+                 {:state :open :tags #{:open}}
+                 {:state :open :tags #{:open :held}}))
+        ":tags changed (same :state) → changed")
+    (testing "self/internal transition — :state + :tags unchanged, only
+              :data + :rf/* moved → NOT changed (delta box elides)"
+      (is (false? (proj/machine-logical-state-changed?
+                    {:state :open :tags #{:open} :data {:n 1} :rf/spawn-counter {}}
+                    {:state :open :tags #{:open} :data {:n 2} :rf/spawn-counter {:a 1}}))))))
+
 (deftest project-machine-populates-cascade-slot-test
   (testing "rf2-u69j7 / rf2-tjqd8 — `(handler-row …)` populates `:machine
             :cascade` with the CANONICALLY-ORDERED cascade the view

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1385,12 +1385,21 @@
           (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
               "inline-guard source slot is present"))))))
 
-(deftest cascade-transition-row-renders-source-body-test
-  (testing "rf2-wwc3j — a `:transition` row renders the transition map
-            literal as a source body (the bead's `:delight shape` for
-            transitions: render the EDN form inline)."
+(deftest cascade-row-source-not-captured-links-to-machine-def-test
+  (testing "rf2-iwy0c part B — a cascade row whose source form could
+            NOT be resolved (no captured source string + no spec value
+            at the source-key) renders a click-to-source LINK to the
+            machine DEFINITION (the reg-machine CALL-SITE coord,
+            part B-i) instead of the dead `<source not yet captured>`
+            literal. The link carries the machine id as its label.
+
+            Reg-event-* macros stamp the call-site `:file`/`:line` at
+            expansion time, so a machine registered here resolves the
+            call-site coord under `:event` (part B-i implemented now);
+            the defmachine-definition coord (part B-ii) DEGRADES to the
+            call-site until rf2-gwj8l stamps it."
     (rf/with-frame :rf/default
-      (rf/reg-event-fx :rf2-wwc3j.view/transition-row
+      (rf/reg-event-fx :rf2-iwy0c.view/no-source-machine
                        {:rf/machine? true
                         :rf/machine {:initial :idle
                                      :states  {:idle {:on {:go {:target :done}}}
@@ -1398,22 +1407,148 @@
                        (fn [_ _] {}))
       (let [step {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-machine
-                  :event-id :rf2-wwc3j.view/transition-row
+                  :event-id :rf2-iwy0c.view/no-source-machine
                   :fx []
-                  :machine {:cascade [{:kind :transition :step 1
-                                       :machine-id :rf2-wwc3j.view/transition-row
-                                       :from-state :idle
-                                       :to-state   :done
-                                       :event [:go]
+                  ;; A guard row whose `:guard-id` keyword has no captured
+                  ;; source-string and no spec value at the source-key →
+                  ;; `cascade-row-source-form` resolves nil → the machine-
+                  ;; def link fallback fires.
+                  :machine {:cascade [{:kind :guard :step 1
+                                       :machine-id :rf2-iwy0c.view/no-source-machine
+                                       :guard-id :never-captured?
+                                       :outcome :pass
                                        :source-state :idle
-                                       :target-state :done
-                                       :event-id :go
-                                       :microsteps 1}]
+                                       :event-id :go}]
                             :transition nil :guards [] :lifecycle [] :timers []}}
-            tree (view/render-handler-step step)]
-        (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
-        (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
-            "transition source slot is present (renders the transition map)")))))
+            tree (view/render-handler-step step)
+            link (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-missing-1")]
+        (is (some? link)
+            "the source-missing slot renders the machine-def link")
+        ;; coord present (macro-stamped call-site) → clickable <button>,
+        ;; NOT a dead <span> placeholder.
+        (is (= :button (first link))
+            "the link is a clickable button (call-site coord resolved — part B-i)")
+        (is (some? (:on-click (th/attrs link)))
+            "clicking dispatches open-in-editor")))))
+
+(deftest cascade-row-source-not-captured-degrades-without-coord-test
+  (testing "rf2-iwy0c part B — when even the call-site coord is absent
+            (production elision / unregistered machine), the machine-def
+            link DEGRADES GRACEFULLY to a plain non-clickable label
+            rather than a dead button — the link STRUCTURE lights up
+            once a coord (call-site today, defmachine via rf2-gwj8l
+            later) is available."
+    (rf/with-frame :rf/default
+      (let [step {:step :handler :badge :HANDLER :step-number 3
+                  :flavour :reg-machine
+                  ;; never-registered → no handler-meta → no coord.
+                  :event-id :rf2-iwy0c.view/unregistered-machine
+                  :fx []
+                  :machine {:cascade [{:kind :guard :step 1
+                                       :machine-id :rf2-iwy0c.view/unregistered-machine
+                                       :guard-id :never-captured?
+                                       :outcome :pass
+                                       :source-state :idle
+                                       :event-id :go}]
+                            :transition nil :guards [] :lifecycle [] :timers []}}
+            tree (view/render-handler-step step)
+            link (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-missing-1")]
+        (is (some? link)
+            "the source-missing slot still renders the (degraded) label")
+        (is (= :span (first link))
+            "no coord → plain non-clickable span (graceful degrade)")))))
+
+(deftest cascade-transition-row-renders-logical-state-delta-test
+  (testing "rf2-iwy0c part A — a `:transition` row renders the
+            LOGICAL-STATE DELTA box (`{:state :tags}` before → after)
+            as its source body, REPLACING the rf2-wwc3j transition-map
+            literal. The box reads the row's `:before` / `:after`
+            snapshots (the substrate emits the full snapshot on either
+            side of the `:rf.machine/transition` trace)."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine
+                :event-id :door/main
+                :fx []
+                :machine {:cascade [{:kind :transition :step 1
+                                     :machine-id :door/main
+                                     :before {:state :locked
+                                              :data {:tries 0}
+                                              :tags #{:locked}
+                                              :rf/spawn-counter {}}
+                                     :after  {:state :open
+                                              :data {:tries 1}
+                                              :tags #{:open}
+                                              :rf/spawn-counter {}}
+                                     :from-state :locked
+                                     :to-state   :open
+                                     :event [:door/open]
+                                     :microsteps 1}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+          "transition source slot is present (the logical-state delta box)")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-delta-1"))
+          "the logical-state delta box renders for a state-changing transition"))))
+
+(deftest cascade-transition-row-elides-delta-on-self-transition-test
+  (testing "rf2-iwy0c part A — a SELF / internal transition where
+            neither `:state` nor `:tags` changed (only `:data` or
+            `:rf/*` bookkeeping moved) ELIDES the delta box entirely —
+            the box would otherwise show a no-op logical diff."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine
+                :event-id :door/main
+                :fx []
+                :machine {:cascade [{:kind :transition :step 1
+                                     :machine-id :door/main
+                                     ;; :state + :tags identical; only :data
+                                     ;; + :rf/spawn-counter differ.
+                                     :before {:state :open :tags #{:open}
+                                              :data {:tries 1}
+                                              :rf/spawn-counter {}}
+                                     :after  {:state :open :tags #{:open}
+                                              :data {:tries 2}
+                                              :rf/spawn-counter {:foo 1}}
+                                     :from-state :open
+                                     :to-state   :open
+                                     :event [:door/poke]
+                                     :microsteps 0}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+          "the transition row still renders (verb headline present)")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+          "the delta box is elided — no logical-state change")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-delta-1"))
+          "no delta box on a self/internal transition"))))
+
+(deftest cascade-transition-row-renders-parallel-state-delta-test
+  (testing "rf2-iwy0c part A — a PARALLEL machine's transition renders
+            the structured region→state map + the tag-union shift in
+            the delta box (the single-region headline verb cannot
+            convey which region moved). The box scope stays `{:state
+            :tags}` — `:data` is excluded."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine
+                :event-id :crossing/light
+                :fx []
+                :machine {:cascade [{:kind :transition :step 1
+                                     :machine-id :crossing/light
+                                     :before {:state {:vehicle :red :pedestrian :dont-walk}
+                                              :tags #{:vehicle-stop :ped-stop}
+                                              :data {:cycles 0}}
+                                     :after  {:state {:vehicle :green :pedestrian :dont-walk}
+                                              :tags #{:vehicle-go :ped-stop}
+                                              :data {:cycles 1}}
+                                     :from-state {:vehicle :red :pedestrian :dont-walk}
+                                     :to-state   {:vehicle :green :pedestrian :dont-walk}
+                                     :event [:crossing/tick]
+                                     :microsteps 1}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-delta-1"))
+          "the delta box renders the structured parallel-state diff"))))
 
 (deftest cascade-timer-row-elides-source-body-test
   (testing "rf2-wwc3j — `:timer` rows render the click-to-source coord


### PR DESCRIPTION
Two enrichments to the Epoch-panel machine cascade (Mike pair-review, machine-epochs deck). Closes rf2-iwy0c.

## A — Transition row → logical-state DELTA box
The `:transition` cascade row's source body now renders an `ei/edn-inspector` DIFF of the machine's `{:state :tags}` **before → after** (same widget + `{:before <prior>}` posture the per-action `↳ data Δ` uses, rf2-5hjb5), **REPLACING** the redundant rf2-wwc3j transition-map literal (intentional reversal per Mike — the map merely restated the target state the headline verb already names).

- **Scope = `{:state :tags}` ONLY** via `projection/machine-logical-state` (`select-keys`). `:data` is the per-action delta's job; the framework `:rf/*` snapshot slots (`:rf/spawn-counter`, after-epoch counters — Spec 005 reserved) are not user state — both excluded by construction.
- **Data source** — the transition trace's `:before`/`:after` snapshots (the full machine snapshot on either side of the macrostep). Equivalent to the epoch record's `:db-before`/`:db-after` at `[:rf/runtime :machines :snapshots <id>]`.
- **Parallel machines** — `:state` may be a region→state map; the box shows the structured map + tag-union shift in one object (the single-region verb cannot convey which region moved).
- **Elision** — on a self/internal transition where neither `:state` nor `:tags` changed (`machine-logical-state-changed?` false), the box is elided; the headline verb stays.

## B — Source-not-captured → link to the machine definition
`:action`/`:guard` rows with no captured source now link the machine id (shared `coord-link`, `<id> ↗` grammar) to the machine **definition** instead of a dead `<source not yet captured>` literal. Per Mike's both-targets ruling:
- **(i) reg-machine CALL-SITE** — `:file`/`:line` captured today via `(rf/handler-meta :event event-id)` (rf2-ge6uj). **Implemented now.**
- **(ii) defmachine DEFINITION** — RELATES to rf2-gwj8l (definition coord not yet stamped). The link structure lights up automatically once gwj8l stamps the coord; until then it **degrades gracefully** to (i) alone, and to a plain non-clickable label when even the call-site coord is absent.

## C (verify) — handler-source-block machine spec
**Confirmed the bug.** `handler-source-block` read `(rf/handler-meta :machine event-id)` — a non-existent registrar kind that resolves nil, so the HANDLER step's machine SPEC rendered `<source not yet captured>`. Fixed to read under `:event` and resolve the spec via `:rf/machine` (mirroring the cascade path / `machine-block`). (Out of scope: `machine-state-path-coord` at view.cljs:~1804 also reads `:machine` but falls back gracefully and is a different surface — left untouched per the bead's Part-C scoping.)

Pure projection helpers live in `projection.cljc`; presentation stays in the view.

## Spec currency
`tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1.5 trued up: transition-row delta box (scope, data source, parallel, elision) + the source-missing → machine-def link design. The xray spec tree is not built into the mkdocs site (referenced only as external GitHub links), so `mkdocs build --strict` is N/A for this change.

## Quality gates
- New **projection** tests: `machine-logical-state` ({:state :tags} projection, parallel case, nil) + `machine-logical-state-changed?` (state change, tag change, self-transition false).
- New **view** tests: delta box renders on a state-changing transition; **elided** on a self-transition; **parallel-machine** structured diff; source-not-captured **call-site link** present (clickable button); **degrades** to plain span when no coord.
- `npm run test:cljs` — **5252 tests / 17967 assertions, 0 failures, 0 errors.**
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, 13 matrix rows.**
- `npm run test:bundle-isolation` — **PASS** (17 artefact entries, 35 sentinels absent; uix/helix/reagent-free PASS).
- clj-kondo — **0 errors** across `tools/xray` (warnings all pre-existing; the one var my change orphaned, `cascade-row-source-missing-style`, was removed).