### PR TITLE
fix(pair-mcp): forgiving suffix-match build-id resolver + round-trippable :running-builds error (rf2-qda59)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -324,7 +324,14 @@ first every session.
 **Args**: `build` (string, optional) and `port` (integer, optional).
 `build` is colon-tolerant (rf2-8ohwv) — `"examples/step-deck"` and
 `":examples/step-deck"` resolve to the same build id; a doubled colon
-never reaches the resolver.
+never reaches the resolver. `build` is also **suffix-forgiving**
+(rf2-qda59): a short tail (`"machine-epochs"`) that uniquely names a
+running build resolves to its canonical namespaced id
+(`:examples/machine-epochs`) — and the same forgiving resolution applies
+to **every** op, not just discover-app, so a name that connected via
+discover-app works verbatim on the read/action ops. Two builds sharing
+the tail stay ambiguous; a no-match id falls through to the diagnostic
+ladder. See [`API.md` §Build-id resolution](./API.md#build-id-resolution).
 
 **URL/port → build (rf2-fyf0h).** A pair session naturally starts from
 the browser URL of the open tab (e.g. `http://localhost:8031/counter`),
@@ -391,14 +398,15 @@ the underlying cause rather than always blaming the preload:
 | `:reason` | Fires when | Hint shape |
 |---|---|---|
 | `:nrepl-unreachable` | JVM `jvm-eval` round-trip fails — the nREPL socket is dead even though the MCP server is up. Most often: the shadow-cljs JVM stopped, or restarted and left the MCP server holding a stale socket. (probe.cljs lines 207-210) | "Restart `shadow-cljs watch` and retry; the MCP server reconnects on the next tool call." |
-| `:build-not-running` | nREPL is reachable but shadow's `active-builds` doesn't include the targeted build. Carries `:running-builds` enumerating what IS up. Almost always a `--build` typo or operator targeted the wrong dev build. (probe.cljs lines 215-219) | "shadow-cljs is running `[<other-build>]` but not `<target>`. Pass `--build=<other-build>` (or set `SHADOW_CLJS_BUILD_ID`)…" |
+| `:build-not-running` | nREPL is reachable but shadow's `active-builds` doesn't include the targeted build (after suffix resolution, rf2-qda59 — so a typo, never a mere short-tail). Carries `:running-builds` enumerating what IS up, plus `:running-builds-arg-forms` — each in the round-trippable `:build` arg form (rf2-qda59). (probe.cljs `diagnose-preload-failure!`) | "shadow-cljs is running `[":other-build"]` but not `:<target>`. Pass `--build=:other-build` (or set `SHADOW_CLJS_BUILD_ID`)…" |
 | `:no-runtime-connected` | Build IS running but the cljs-eval round-trip returns blank — no browser tab has connected, or the tab's WebSocket has dropped. Carries `:running-builds`. (probe.cljs lines 233-237) | "build `<id>` is running but no CLJS runtime is currently connected… Open the app in a browser tab — or if a tab IS open, reload the page so the runtime reconnects." |
 | `:runtime-loaded-but-preload-missing` | A CLJS runtime is alive but the `__re_frame2_pair_runtime` marker is absent. The original meaning of the legacy `:runtime-not-preloaded` reason — the preload entry IS what to add. (probe.cljs lines 242-245) | "re-frame2-pair.runtime is not loaded into this build. Add the preload entry to your shadow-cljs.edn… See skills/re-frame2-pair/SKILL.md (§Setup)." |
 
 Each rung carries `:build` (the targeted id) plus a targeted
 `:hint`; `:build-not-running` and `:no-runtime-connected` also carry
-`:running-builds` so the operator's next move is one keystroke
-away.
+`:running-builds` (and `:build-not-running` a sibling
+`:running-builds-arg-forms` in the paste-ready `:build` arg form,
+rf2-qda59) so the operator's next move is one keystroke away.
 
 The ladder costs one extra JVM round-trip (active-builds
 enumeration) plus a CLJS-eval discriminator on the failure path —

--- a/tools/re-frame2-pair-mcp/spec/API.md
+++ b/tools/re-frame2-pair-mcp/spec/API.md
@@ -91,6 +91,24 @@ impl: [`src/re_frame2_pair_mcp/tools/wire.cljs`](../src/re_frame2_pair_mcp/tools
    before interning. A bare `keyword` on the colon form would mint the
    malformed `::examples/step-deck` and probe a build that doesn't
    exist; that footgun is closed.
+
+   The arg is also **suffix-forgiving** (rf2-qda59). shadow build ids are
+   namespaced keywords (`:examples/machine-epochs`); an operator reading
+   the app — or copying a name out of an error / chat — naturally reaches
+   for the short tail (`machine-epochs`). A `:build` arg that names a
+   running build by a **unique name-suffix** resolves to the canonical
+   running id, so the same forgiving resolution applies to **every** op,
+   not just `discover-app`. The match rule is deterministic — exact
+   keyword match first, then a unique tail match; **two builds sharing
+   the tail stay ambiguous** and a no-match id passes through unchanged so
+   the diagnostic ladder still fires (never a silent wrong-build pick).
+   Resolution runs once per session at the pipeline's first step
+   (`tools.cljs` `canonicalize-build-step`) and caches the
+   suffix→canonical alias on the conn-atom (`:build-alias`), so it costs
+   at most one `active-builds` round-trip per distinct build name and is
+   free for an already-exact / already-resolved id
+   (impl: [`src/.../tools/probe.cljs`](../src/re_frame2_pair_mcp/tools/probe.cljs)
+   `canonicalize-build!` / `match-running-build`).
 2. **Session-scoped `:resolved-build-id` cache on the conn-atom — the
    sticky operating build.** Populated two ways:
    - by `discover-app` after a successful preload probe
@@ -127,12 +145,13 @@ is the **keyword** (`:examples/step-deck`). `discover-app` echoes it
 under both `:build-id` and `:build` (the latter matching the *input arg
 name*), and the read-family ops (`orient`, `read-dom`, `read-ui`,
 `eval-cljs`) echo the resolved `:build` on their result. A value copied
-out of any of those slots works unchanged as a later `:build` arg — the
-only alias axis is colon-tolerance (source (1) above), which is
-deterministic: both the bare-qualified and colon-prefixed string forms
-read back to the same keyword. There is no fuzzy build-alias surface to
-disambiguate; the registry is the finite set of shadow-cljs running
-builds, addressed by exact keyword.
+out of any of those slots works unchanged as a later `:build` arg. The
+alias axes are both **deterministic** (source (1) above): colon-tolerance
+— bare-qualified and colon-prefixed string forms read back to the same
+keyword — and the unique-suffix match, which resolves a short tail to
+exactly one running build or stays ambiguous. The registry is the finite
+set of shadow-cljs running builds; there is no fuzzy / most-recent
+heuristic.
 
 **Per-session scope, never a process-global (rf2-fmho5).** The sticky
 `:resolved-build-id` lives on the **conn-atom**, which is created
@@ -146,6 +165,15 @@ a structured `:no-runtime-for-build` enumerating `:running-builds`, and
 the plain read path surfaces the same candidate list via the diagnostic
 ladder's `:build-not-running` rung — a clear ambiguous-target error
 listing candidates, never a silent wrong-build pick or a host failure.
+
+**Round-trippable candidate list (rf2-qda59).** Both error envelopes
+carry `:running-builds` (the keyword vector) **and** a sibling
+`:running-builds-arg-forms` — each running build rendered in exactly the
+string form the `:build` arg accepts back (`":examples/machine-epochs"`).
+Every hint string uses the same colon form. So an operator can copy a
+build straight out of the error into a `:build` arg and it resolves —
+the list names the valid set in a form that pastes back, closing the
+round-trip trap where the error printed names it then rejected.
 
 Distinct from the per-session **response** cache (rf2-3rt1f, see
 [`Principles.md`](./Principles.md) § Per-session response cache) —

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -312,7 +312,17 @@
   (rf2-l9ixp). Subsequent tool calls without an explicit `:build` arg
   default to it instead of the `SHADOW_CLJS_BUILD_ID` env-var fallback —
   removing the pair-debug friction of re-passing the build on every call.
-  Same reconnect-invalidation lifecycle as `:probed-builds`."
+  Same reconnect-invalidation lifecycle as `:probed-builds`.
+
+  `:build-alias` is the forgiving-resolution cache (rf2-qda59):
+  `{requested-keyword canonical-keyword}`. A `:build` arg that names a
+  running build by a unique SUFFIX (`:machine-epochs` ⇒
+  `:examples/machine-epochs`) resolves to the canonical running id the
+  first time it's seen, and the alias is remembered so every later
+  `arg-build` read returns the same canonical id without re-fetching
+  `active-builds`. Same reconnect-invalidation lifecycle as
+  `:probed-builds` — a page reload / build restart could change the
+  running set, so a stale alias must not survive it."
   [port host]
   (atom {:port              port
          :host              (or host "127.0.0.1")
@@ -322,7 +332,8 @@
          :closed?           true
          :session           nil
          :probed-builds     #{}
-         :resolved-build-id nil}))
+         :resolved-build-id nil
+         :build-alias       {}}))
 
 (defn attach-handlers!
   "Wire up `data` / `error` / `close` on the freshly-connected socket.
@@ -395,7 +406,8 @@
                 ;; reconnects; a stale cache would silently mis-route.
                 (swap! conn-atom assoc :socket sock :closed? false
                        :buf (js/Buffer.alloc 0)
-                       :probed-builds #{} :resolved-build-id nil)
+                       :probed-builds #{} :resolved-build-id nil
+                       :build-alias {})
                 (attach-handlers! conn-atom sock)
                 (resolve conn-atom)))
             (j/call sock :once "error"
@@ -407,13 +419,14 @@
   "Close the persistent socket. Idempotent. Drops the per-socket probe
   cache (`:probed-builds`) so a fresh connect re-probes the preload.
   Also drops `:resolved-build-id` (rf2-l9ixp) — the cached default for
-  tool calls without an explicit `:build` arg — so a reconnect doesn't
-  carry a stale build-id from the previous session."
+  tool calls without an explicit `:build` arg — and `:build-alias`
+  (rf2-qda59), the forgiving suffix→canonical resolution cache — so a
+  reconnect doesn't carry a stale build-id from the previous session."
   [conn-atom]
   (when-let [^js sock (:socket @conn-atom)]
     (try (.end sock) (catch :default _ nil)))
   (swap! conn-atom assoc :socket nil :closed? true :pending {}
-         :probed-builds #{} :resolved-build-id nil))
+         :probed-builds #{} :resolved-build-id nil :build-alias {}))
 
 ;; ---------------------------------------------------------------------------
 ;; Op send / receive — multiplex by request id.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -194,28 +194,62 @@
   so a no-`:build` follow-up call inherits the canonical form rather than
   the suffix `stick-build!` just stored.
 
+  ## Bare-default fast path (rf2-qda59 CI-race repair)
+
+  A no-`:build` call that falls through to the bare env / `:app` default
+  (no explicit `:build` arg AND no sticky `:resolved-build-id`) is NOT
+  canonicalized — it returns `ctx` synchronously with NO `active-builds`
+  round-trip. Two reasons:
+
+    1. **Correctness, not just speed.** The env default
+       (`SHADOW_CLJS_BUILD_ID` / `:app`) is a full build id by
+       construction — never a suffix an operator typed — so it needs no
+       suffix→canonical mapping. A default that isn't running surfaces via
+       the downstream `ensure-runtime!` diagnostic ladder exactly as
+       before; the alias step would only have round-tripped to re-derive
+       the id it was already handed.
+    2. **It un-breaks the streaming subscribe gate.** The pre-fix step
+       prepended a serial `active-builds` jvm-eval to EVERY first tool
+       call — including `subscribe`'s registration path. On a slow
+       hermetic CI runner that extra round-trip pushed `subscribe!`
+       registration past the live-subscribe conformance test's dispatch
+       head-start, so the dispatched cascade landed before the
+       subscription existed and zero `notifications/progress` frames
+       arrived (the bus only queues for already-registered subs). The
+       feature targets an operator who TYPES a build (`:build
+       machine-epochs`); the no-arg default never needed the trip.
+
+  Suffix-forgiveness is fully preserved for the case it was built for:
+  an explicit `:build` arg, or a sticky suffix stuck from a prior
+  explicit `:build`, still routes through `canonicalize-build!`.
+
   Pays one `active-builds` round-trip only the first time a not-yet-probed
-  build name is seen this session; an exact / already-aliased id resolves
-  with no round-trip. Pure-fail-safe: a stub conn (no caches) or a
-  `running-builds` hiccup degrades to the requested id unchanged, so the
-  diagnostic ladder still fires.
+  EXPLICIT build name is seen this session; an exact / already-aliased id
+  (or the bare default) resolves with no round-trip. Pure-fail-safe: a
+  stub conn (no caches) or a `running-builds` hiccup degrades to the
+  requested id unchanged, so the diagnostic ladder still fires.
 
   `discover-app` is INCLUDED here (unlike `stick-build!`): its explicit
   `:build` should be just as forgiving as the read ops', and the alias
   write is harmless — discover-app owns its own success-gated
   `:resolved-build-id` lifecycle separately."
   [{:keys [conn args] :as ctx}]
-  (let [requested (wire/requested-build conn args)]
-    (-> (probe/canonicalize-build! conn requested)
-        (.then (fn [canonical]
-                 ;; Keep the sticky default canonical too — only when a
-                 ;; build was already stuck (don't mint one for a no-build
-                 ;; call that fell through to the env default).
-                 (when (and (some? conn) (satisfies? IDeref conn)
-                            (some? (:resolved-build-id @conn)))
-                   (swap! conn assoc :resolved-build-id canonical))
-                 ctx))
-        (.catch (fn [_] ctx)))))
+  (if-not (wire/arg-build-explicit? conn args)
+    ;; Bare env / `:app` default — already canonical; skip the round-trip
+    ;; so latency-sensitive paths (subscribe registration) are not
+    ;; delayed. See the docstring's bare-default fast path.
+    (js/Promise.resolve ctx)
+    (let [requested (wire/requested-build conn args)]
+      (-> (probe/canonicalize-build! conn requested)
+          (.then (fn [canonical]
+                   ;; Keep the sticky default canonical too — only when a
+                   ;; build was already stuck (don't mint one for a no-build
+                   ;; call that fell through to the env default).
+                   (when (and (some? conn) (satisfies? IDeref conn)
+                              (some? (:resolved-build-id @conn)))
+                     (swap! conn assoc :resolved-build-id canonical))
+                   ctx))
+          (.catch (fn [_] ctx))))))
 
 (defn- precheck-step
   "Step 0 — rf2-36xod cheap-hash short-circuit. For precheck-eligible

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -76,6 +76,7 @@
             [re-frame2-pair-mcp.tools.boundary-step :as bs]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.cap :as cap]
+            [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.precheck :as precheck]
             [re-frame2-pair-mcp.tools.registry :as registry]
             [re-frame2-pair-mcp.tools.descriptors :as descriptors]))
@@ -182,6 +183,40 @@
 ;; seam stay unchanged.
 ;; ---------------------------------------------------------------------------
 
+(defn- canonicalize-build-step
+  "Step -1 — forgiving suffix→canonical build resolution (rf2-qda59).
+  Runs BEFORE every other step so the conn's `:build-alias` cache is
+  populated before any per-tool body reads `wire/arg-build`. Resolves the
+  requested build (`wire/requested-build` — explicit `:build` arg, else
+  the sticky default) against shadow's running builds by exact-or-unique-
+  suffix match. The alias write happens inside `probe/canonicalize-build!`;
+  here we ALSO rewrite the sticky `:resolved-build-id` to the canonical id
+  so a no-`:build` follow-up call inherits the canonical form rather than
+  the suffix `stick-build!` just stored.
+
+  Pays one `active-builds` round-trip only the first time a not-yet-probed
+  build name is seen this session; an exact / already-aliased id resolves
+  with no round-trip. Pure-fail-safe: a stub conn (no caches) or a
+  `running-builds` hiccup degrades to the requested id unchanged, so the
+  diagnostic ladder still fires.
+
+  `discover-app` is INCLUDED here (unlike `stick-build!`): its explicit
+  `:build` should be just as forgiving as the read ops', and the alias
+  write is harmless — discover-app owns its own success-gated
+  `:resolved-build-id` lifecycle separately."
+  [{:keys [conn args] :as ctx}]
+  (let [requested (wire/requested-build conn args)]
+    (-> (probe/canonicalize-build! conn requested)
+        (.then (fn [canonical]
+                 ;; Keep the sticky default canonical too — only when a
+                 ;; build was already stuck (don't mint one for a no-build
+                 ;; call that fell through to the env default).
+                 (when (and (some? conn) (satisfies? IDeref conn)
+                            (some? (:resolved-build-id @conn)))
+                   (swap! conn assoc :resolved-build-id canonical))
+                 ctx))
+        (.catch (fn [_] ctx)))))
+
 (defn- precheck-step
   "Step 0 — rf2-36xod cheap-hash short-circuit. For precheck-eligible
   tools (cache enabled AND tool registers a precheck-target), fetches
@@ -229,11 +264,13 @@
        (boolean (j/get result-js :isError))))
 
 (def wire-boundary-pipeline
-  "The four-step wire-boundary pipeline. Order matters — see step
+  "The five-step wire-boundary pipeline. Order matters — see step
   docstrings for the per-step semantics.
 
-  | Step              | When the step is skipped (`:skip-when?`)            |
-  |-------------------|-----------------------------------------------------|
+  | Step                 | When the step is skipped (`:skip-when?`)         |
+  |----------------------|--------------------------------------------------|
+  | `:canonicalize-build`| never — populates the forgiving suffix→canonical |
+  |                      | build alias before any per-tool `arg-build` read |
   | `:precheck`       | never — runs unconditionally; produces a marker     |
   |                   | result ONLY for eligible cacheable tools            |
   | `:dispatch`       | a prior step already produced a `:result` (i.e.     |
@@ -252,7 +289,9 @@
   `:short-circuit?` per rf2-l0isf — the prior name read as
   halt-the-chain semantics; the actual semantics are skip-this-step
   and continue to the next step's own predicate)."
-  [{:name       :precheck
+  [{:name       :canonicalize-build
+    :run        canonicalize-build-step}
+   {:name       :precheck
     :run        precheck-step}
    {:name       :dispatch
     :run        dispatch-step

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -104,6 +104,25 @@
        "MCP server holding a stale socket). Restart `shadow-cljs watch` "
        "and retry; the MCP server reconnects on the next tool call."))
 
+(defn build-arg-form
+  "Render a build-id keyword in EXACTLY the string form the `:build` MCP
+  arg accepts back (rf2-qda59). The arg coercer (`fresh-keyword`) is
+  colon-tolerant, so the canonical round-trippable form is the keyword's
+  own `pr-str` (`:examples/machine-epochs`) — copy-pasting it from an
+  error into `:build` resolves to the same build. Used to keep the
+  `:running-builds` guidance round-trippable: the error names the valid
+  set in a form the operator can paste straight back."
+  [build-id]
+  (pr-str build-id))
+
+(defn running-build-arg-forms
+  "Map the `running` build-id keywords to their round-trippable `:build`
+  arg forms (rf2-qda59) — the copy-paste-ready list for an error's
+  guidance. `[:examples/machine-epochs :panel-gallery]` ⇒
+  `[\":examples/machine-epochs\" \":panel-gallery\"]`."
+  [running]
+  (mapv build-arg-form running))
+
 (defn- build-not-running-hint [build-id running]
   (cond
     (empty? running)
@@ -111,10 +130,12 @@
          "build (`shadow-cljs watch <build>`) before retrying.")
 
     :else
-    (str "shadow-cljs is running " (vec running) " but not "
-         build-id ". Pass --build=" (first running)
+    ;; Render every running id in its round-trippable `:build` arg form
+    ;; (rf2-qda59) so the guidance can be copy-pasted straight back.
+    (str "shadow-cljs is running " (running-build-arg-forms running) " but not "
+         (build-arg-form build-id) ". Pass --build=" (build-arg-form (first running))
          " (or set SHADOW_CLJS_BUILD_ID) — or restart the watch worker "
-         "for " build-id " if you really mean to target it.")))
+         "for " (build-arg-form build-id) " if you really mean to target it.")))
 
 (defn- no-runtime-connected-hint [build-id]
   (str "build " build-id " is running but no CLJS runtime is currently "
@@ -213,10 +234,16 @@
                   (fn [running]
                     (if-not (some #(= build-id %) running)
                       (js/Promise.resolve
-                        {:reason         :build-not-running
-                         :build          build-id
-                         :running-builds running
-                         :hint           (build-not-running-hint build-id running)})
+                        {:reason                  :build-not-running
+                         :build                   build-id
+                         :running-builds          running
+                         ;; rf2-qda59 — the round-trippable copy-paste list:
+                         ;; each running build in EXACTLY the `:build` arg
+                         ;; form. `:running-builds` keeps the keyword vector
+                         ;; (still round-trippable via colon-tolerance); this
+                         ;; sibling makes the paste-ready strings explicit.
+                         :running-builds-arg-forms (running-build-arg-forms running)
+                         :hint                    (build-not-running-hint build-id running)})
                       ;; Build IS running — distinguish "no runtime
                       ;; connected" (cljs-eval returns blank/nil) from
                       ;; "runtime present but marker absent" (cljs-eval
@@ -394,6 +421,88 @@
                      (when (keyword? v) v))))
           (.catch (fn [_] nil))))))
 
+;; ---------------------------------------------------------------------------
+;; Forgiving suffix→canonical build resolution (rf2-qda59).
+;;
+;; shadow-cljs build ids are namespaced keywords (`:examples/machine-epochs`).
+;; An operator reading the app at a glance — or copying a name out of an
+;; error / chat — naturally reaches for the short tail (`machine-epochs`).
+;; Before this, `discover-app` happened to normalise (it auto-selects a
+;; single build or resolves by port), but the read/action ops compared the
+;; requested id against `active-builds` by EXACT `=`, so a suffix form was
+;; rejected with `:build-not-running` even though the build it named was
+;; right there in the error's own `:running-builds` list. One shared
+;; forgiving resolver closes the asymmetry across every op.
+;;
+;; Match rule (deterministic, no most-recent / fuzzy heuristics — those
+;; are the silent-wrong-build footguns Mike rejected for `auto-select`):
+;;
+;;   1. EXACT keyword match            ⇒ that build (the common case).
+;;   2. UNIQUE name-suffix match       ⇒ that build. The requested
+;;      keyword's `name` equals the `name` of EXACTLY ONE running build
+;;      (`:machine-epochs` ⇒ `:examples/machine-epochs`). The requested
+;;      id is itself bare (no namespace) so it can only be a tail.
+;;   3. no / ambiguous match           ⇒ the requested id UNCHANGED, so
+;;      the existing diagnostic ladder fires `:build-not-running` with
+;;      the round-trippable running list. Two builds sharing a tail stays
+;;      ambiguous — never silently pick one.
+;; ---------------------------------------------------------------------------
+
+(defn match-running-build
+  "Resolve `requested` (a build-id keyword) against the `running` vector of
+  build-id keywords by exact-or-unique-suffix match (rf2-qda59). Returns
+  the canonical running keyword on a hit, else `requested` unchanged (so a
+  no/ambiguous match falls through to the diagnostic ladder). Pure."
+  [requested running]
+  (cond
+    (nil? requested) requested
+    (some #(= requested %) running) requested
+    :else
+    (let [tail     (name requested)
+          suffixed (filterv #(= tail (name %)) running)]
+      (if (= 1 (count suffixed))
+        (first suffixed)
+        requested))))
+
+(defn canonicalize-build!
+  "Forgiving suffix→canonical build resolution (rf2-qda59). Resolves a
+  Promise of the canonical running build-id for `requested`:
+
+    - `requested` already in this socket's confirmed `:probed-builds`
+      ⇒ resolve it verbatim with NO round-trip (it's exactly running).
+    - a cached alias on the conn ⇒ resolve the cached canonical id, again
+      with no round-trip.
+    - otherwise fetch `active-builds` once and `match-running-build`;
+      record the resolution (identity included) in `:build-alias` so a
+      later read for the same requested id is round-trip-free.
+
+  A nil `requested` resolves to nil. Defensive against a non-atom `conn`
+  (test stubs) — those have no caches, so it always falls through to the
+  `running-builds` fetch (which itself degrades to `[]` on a stub).
+
+  The resolution is NOT a probe: it only maps the NAME to the canonical
+  running id. The runtime-sentinel check (`runtime-preloaded?`) still runs
+  afterwards, so a name that suffix-resolves to a build with no live
+  runtime still surfaces the real `:no-runtime-connected` diagnostic."
+  [conn requested]
+  (if (nil? requested)
+    (js/Promise.resolve nil)
+    (let [atom?    (and (some? conn) (satisfies? IDeref conn))
+          snap     (when atom? @conn)
+          probed   (:probed-builds snap #{})
+          alias    (:build-alias snap {})]
+      (cond
+        (contains? probed requested) (js/Promise.resolve requested)
+        (contains? alias requested)  (js/Promise.resolve (get alias requested))
+        :else
+        (-> (running-builds conn)
+            (.then (fn [running]
+                     (let [canonical (match-running-build requested running)]
+                       (when atom?
+                         (swap! conn assoc-in [:build-alias requested] canonical))
+                       canonical)))
+            (.catch (fn [_] requested)))))))
+
 (defn auto-select-single-build
   "Resolve a build-id when EXACTLY ONE shadow-cljs build is running, else
   nil (rf2-v70kv). Returns a Promise resolving to `[build-id true]` when
@@ -425,10 +534,11 @@
     (= 1 (count running))
     ;; Shouldn't reach here (a single running build is auto-selected),
     ;; but keep the branch explicit.
-    (str "pass --build=" (first running) " or set SHADOW_CLJS_BUILD_ID.")
+    (str "pass --build=" (build-arg-form (first running)) " or set SHADOW_CLJS_BUILD_ID.")
 
     :else
-    (str "multiple shadow-cljs builds are running " (vec running)
+    ;; Round-trippable copy-paste forms (rf2-qda59).
+    (str "multiple shadow-cljs builds are running " (running-build-arg-forms running)
          "; pass --build=<one-of-them> or set SHADOW_CLJS_BUILD_ID.")))
 
 (defn resolve-build!
@@ -461,12 +571,13 @@
               :else
               (js/Promise.reject
                 (ex-info "cannot auto-detect a single running build"
-                         {:reason         :no-runtime-for-build
-                          :build          (when explicit? build)
-                          :running-builds running
-                          :hint           (str (auto-detect-hint running)
-                                               " The default 'app' build is "
-                                               "not running.")}))))))))
+                         {:reason                   :no-runtime-for-build
+                          :build                    (when explicit? build)
+                          :running-builds           running
+                          :running-builds-arg-forms (running-build-arg-forms running)
+                          :hint                     (str (auto-detect-hint running)
+                                                         " The default 'app' build is "
+                                                         "not running.")}))))))))
 
 (defn resolve-and-preflight!
   "The shared eval-path guard (rf2-ivlb3). Resolves the build then
@@ -502,9 +613,10 @@
                           (fn [running]
                             (js/Promise.reject
                               (ex-info "no re-frame2-pair runtime for build"
-                                       {:reason         :no-runtime-for-build
-                                        :build          build-id
-                                        :running-builds running
+                                       {:reason                   :no-runtime-for-build
+                                        :build                    build-id
+                                        :running-builds           running
+                                        :running-builds-arg-forms (running-build-arg-forms running)
                                         :hint
                                         (str "build " build-id " has no live "
                                              "re-frame2-pair runtime. "

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -177,6 +177,20 @@
   (when (and (some? conn) (satisfies? IDeref conn))
     (:resolved-build-id @conn)))
 
+(defn- canonicalize-via-alias
+  "Map `build-id` through the conn's `:build-alias` forgiving-resolution
+  cache (rf2-qda59). When the requested id has a recorded
+  suffix→canonical alias (populated by `probe/canonicalize-build!` at the
+  pipeline's first step), return the canonical running id; otherwise
+  return `build-id` unchanged. Defensive against a nil / non-atom conn
+  (test stubs carry no cache) and a nil `build-id`."
+  [conn build-id]
+  (if (and (some? build-id)
+           (some? conn)
+           (satisfies? IDeref conn))
+    (get (:build-alias @conn {}) build-id build-id)
+    build-id))
+
 (defn arg-build
   "Resolve the build-id for this tool call. Precedence (highest first):
 
@@ -208,6 +222,14 @@
   runtime-bounded read path resolving against shadow's finite running-
   build registry, so the per-id intern cost is capped.
 
+  The resolved id is finally mapped through the conn's `:build-alias`
+  forgiving-resolution cache (rf2-qda59): when the requested id named a
+  running build by a unique SUFFIX (`:machine-epochs` ⇒
+  `:examples/machine-epochs`), the pipeline's first step recorded the
+  canonical alias, so every op — explicit-arg or sticky-default —
+  resolves to the SAME canonical running id. An un-aliased id passes
+  through unchanged (so a typo still reaches the diagnostic ladder).
+
   1-arity (`(arg-build args)`) is the legacy entry — used by call sites
   that have no `conn` in scope (notably `args.cljs`'s frame/build
   parsing). It SKIPS the conn cache and falls straight through to the
@@ -215,9 +237,22 @@
   2-arity."
   ([args] (arg-build nil args))
   ([conn args]
-   (or (base-args/fresh-keyword (arg args :build))
-       (conn-resolved-build-id conn)
-       (default-build-id))))
+   (->> (or (base-args/fresh-keyword (arg args :build))
+            (conn-resolved-build-id conn)
+            (default-build-id))
+        (canonicalize-via-alias conn))))
+
+(defn requested-build
+  "The build-id this call would resolve to BEFORE the forgiving
+  suffix→canonical alias is applied (rf2-qda59). Mirrors `arg-build`'s
+  precedence (explicit `:build` arg → sticky `:resolved-build-id` →
+  env/`:app` default) but does NOT route through the alias cache — it is
+  the INPUT to `probe/canonicalize-build!`, which the pipeline's first
+  step runs to populate the alias. Returns a keyword."
+  [conn args]
+  (or (base-args/fresh-keyword (arg args :build))
+      (conn-resolved-build-id conn)
+      (default-build-id)))
 
 (defn stick-build!
   "Session-sticky operating build (rf2-lbm21). When `args` carries an

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_resolver_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_resolver_test.cljs
@@ -1,0 +1,253 @@
+(ns re-frame2-pair-mcp.build-id-resolver-test
+  "Forgiving suffix→canonical build-id resolution + round-trippable
+  running-build guidance (rf2-qda59).
+
+  ## The bug (live-reproduced 2026-06-02 on the machine-epochs deck)
+
+  shadow build ids are namespaced keywords (`:examples/machine-epochs`).
+  `discover-app {:build \"examples/machine-epochs\"}` connected fine, but
+  the read ops were STRICT: `snapshot {:build \"machine-epochs\"}` (the
+  short tail an operator naturally reaches for) was rejected
+  `:build-not-running` — even though `machine-epochs` named the build
+  right there in the error's own `:running-builds` list. Four symptoms:
+
+    1. discover-app forgives but read ops are strict — a suffix form that
+       names a unique running build is rejected by the read/action ops.
+    2. The `:running-builds` error list was not round-trippable — it
+       named the valid set in a form the operator couldn't paste back.
+    3. Colon-prepend was non-idempotent (`:examples/…` ⇒ `::examples/…`).
+       (Fixed upstream by #2821's `fresh-keyword` colon-tolerance; pinned
+       here as a regression guard.)
+    4. The selected build did not stick — a discover-app'd build did not
+       transfer to the next read op. (Fixed by #2821's sticky
+       `:resolved-build-id`; pinned here.)
+
+  The fix (rf2-qda59): ONE shared forgiving resolver
+  (`probe/canonicalize-build!` + `probe/match-running-build`) used across
+  EVERY op via the conn `:build-alias` cache that `wire/arg-build`
+  consults; a unique suffix match resolves to the canonical running id,
+  ambiguous/no match falls through to the diagnostic ladder UNCHANGED.
+  Every running-build guidance string is rendered in the round-trippable
+  `:build` arg form."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [clojure.string :as str]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.probe :as probe]
+            [re-frame2-pair-mcp.tools.wire :as wire]
+            [re-frame2-pair-mcp.test-utils :as tu]))
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{} :resolved-build-id nil :build-alias {})
+    conn))
+
+(defn- with-running!
+  "Stub `probe/running-builds` to resolve to `running-vec`, restoring in
+  `.finally`."
+  [running-vec body-fn]
+  (let [orig probe/running-builds]
+    (set! probe/running-builds (fn [_conn] (js/Promise.resolve running-vec)))
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! probe/running-builds orig))))))
+
+;; ---------------------------------------------------------------------------
+;; Pure match rule.
+;; ---------------------------------------------------------------------------
+
+(deftest match-running-build-exact-wins
+  (is (= :examples/machine-epochs
+         (probe/match-running-build :examples/machine-epochs
+                                    [:examples/machine-epochs :testbeds/panel-gallery]))
+      "an exact keyword match resolves to itself"))
+
+(deftest match-running-build-unique-suffix
+  (is (= :examples/machine-epochs
+         (probe/match-running-build :machine-epochs
+                                    [:testbeds/panel-gallery :examples/machine-epochs]))
+      "a unique name-suffix resolves to the canonical running id"))
+
+(deftest match-running-build-ambiguous-suffix-falls-through
+  (is (= :machine-epochs
+         (probe/match-running-build :machine-epochs
+                                    [:examples/machine-epochs :other/machine-epochs]))
+      "two builds sharing the tail stay ambiguous — return the requested id unchanged"))
+
+(deftest match-running-build-no-match-falls-through
+  (is (= :typo
+         (probe/match-running-build :typo [:examples/machine-epochs]))
+      "no match returns the requested id so the diagnostic ladder fires"))
+
+;; ---------------------------------------------------------------------------
+;; canonicalize-build! — the async resolver + alias caching.
+;; ---------------------------------------------------------------------------
+
+(deftest canonicalize-suffix-resolves-and-caches
+  (async done
+    (let [conn  (fresh-conn)
+          calls (atom 0)
+          orig  probe/running-builds]
+      (set! probe/running-builds
+            (fn [_] (swap! calls inc) (js/Promise.resolve [:examples/machine-epochs])))
+      (-> (probe/canonicalize-build! conn :machine-epochs)
+          (.then (fn [c]
+                   (is (= :examples/machine-epochs c) "suffix resolves to canonical")
+                   (is (= :examples/machine-epochs (get-in @conn [:build-alias :machine-epochs]))
+                       "the resolution is cached on the conn")
+                   ;; second call must NOT re-fetch running-builds.
+                   (probe/canonicalize-build! conn :machine-epochs)))
+          (.then (fn [c]
+                   (is (= :examples/machine-epochs c))
+                   (is (= 1 @calls) "the cached alias means no second active-builds round-trip")))
+          (.finally (fn [] (set! probe/running-builds orig)))
+          (.then (fn [_] (done)))))))
+
+(deftest canonicalize-exact-probed-skips-round-trip
+  (async done
+    (let [conn  (fresh-conn)
+          calls (atom 0)
+          orig  probe/running-builds]
+      (swap! conn update :probed-builds conj :examples/machine-epochs)
+      (set! probe/running-builds
+            (fn [_] (swap! calls inc) (js/Promise.resolve [:examples/machine-epochs])))
+      (-> (probe/canonicalize-build! conn :examples/machine-epochs)
+          (.then (fn [c]
+                   (is (= :examples/machine-epochs c))
+                   (is (= 0 @calls)
+                       "an already-probed exact build needs no active-builds round-trip")))
+          (.finally (fn [] (set! probe/running-builds orig)))
+          (.then (fn [_] (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; Symptom 1 — arg-build applies the alias so EVERY op forgives the suffix.
+;; ---------------------------------------------------------------------------
+
+(deftest arg-build-applies-the-suffix-alias
+  ;; After canonicalize-build! has recorded the alias (the pipeline's
+  ;; first step), every op's `arg-build conn args` — explicit suffix arg
+  ;; included — resolves to the canonical running id.
+  (async done
+    (let [conn (fresh-conn)]
+      (-> (with-running! [:examples/machine-epochs]
+            (fn [] (probe/canonicalize-build! conn :machine-epochs)))
+          (.then
+            (fn [_]
+              (is (= :examples/machine-epochs
+                     (wire/arg-build conn (tu/args->js {:build "machine-epochs"})))
+                  "an explicit suffix :build arg resolves to the canonical running id across ops")
+              (is (= :examples/machine-epochs
+                     (wire/arg-build conn (tu/args->js {:build ":machine-epochs"})))
+                  "colon form of the suffix resolves identically")
+              (done)))))))
+
+(deftest arg-build-leaves-un-aliased-ids-unchanged
+  ;; A typo / not-yet-resolved id passes through verbatim so the
+  ;; diagnostic ladder still fires for it.
+  (let [conn (fresh-conn)]
+    (is (= :nope (wire/arg-build conn (tu/args->js {:build "nope"})))
+        "no alias recorded → id passes through unchanged")))
+
+;; ---------------------------------------------------------------------------
+;; Symptom 2 — round-trippable running-build guidance.
+;; ---------------------------------------------------------------------------
+
+(deftest running-build-arg-forms-are-round-trippable
+  ;; Each rendered form, fed back as a :build arg, resolves to the same
+  ;; keyword — the copy-paste-from-error contract.
+  (let [conn    (fresh-conn)
+        running [:examples/machine-epochs :testbeds/panel-gallery]
+        forms   (probe/running-build-arg-forms running)]
+    (is (= [":examples/machine-epochs" ":testbeds/panel-gallery"] forms)
+        "rendered in the EDN keyword form (colon-tolerant, paste-ready)")
+    (doseq [[kw form] (map vector running forms)]
+      (is (= kw (wire/arg-build conn (tu/args->js {:build form})))
+          (str form " round-trips back to " kw))
+      ;; And the colon-stripped form an agent might serialise also works.
+      (is (= kw (wire/arg-build conn (tu/args->js {:build (subs form 1)})))
+          (str "the bare form of " form " round-trips too")))))
+
+(deftest build-not-running-error-list-is-round-trippable
+  ;; End-to-end through the diagnostic ladder: the :build-not-running
+  ;; envelope's running-build guidance must be copy-paste-round-trippable.
+  (async done
+    (let [conn      (fresh-conn)
+          orig-cljs nrepl/cljs-eval-value
+          orig-jvm  nrepl/jvm-eval]
+      ;; Marker probe false (so the ladder runs); JVM reachable; the build
+      ;; the operator targeted (:genuinely-absent) is NOT in active-builds.
+      (set! nrepl/cljs-eval-value
+            (fn ([_ _ _] (js/Promise.resolve false))
+              ([_ _ _ _] (js/Promise.resolve false))))
+      (set! nrepl/jvm-eval
+            (fn ([_ form] (js/Promise.resolve
+                            (if (re-find #"active-builds" form)
+                              {:value "[:examples/machine-epochs]"}
+                              {:value "1"})))
+              ([_ form _] (js/Promise.resolve
+                            (if (re-find #"active-builds" form)
+                              {:value "[:examples/machine-epochs]"}
+                              {:value "1"})))))
+      (-> (probe/ensure-runtime! conn :genuinely-absent)
+          (.then (fn [_] (is false "must reject for a non-running build")))
+          (.catch (fn [err]
+                    (let [data (ex-data err)]
+                      (is (= :build-not-running (:reason data)))
+                      (is (= [":examples/machine-epochs"] (:running-builds-arg-forms data))
+                          "the error carries the round-trippable arg forms")
+                      ;; The hint string names the build in paste-ready form.
+                      (is (str/includes? (:hint data) ":examples/machine-epochs")
+                          "the hint prints the colon form, not a bare short name")
+                      ;; Round-trip: the listed form resolves back.
+                      (is (= :examples/machine-epochs
+                             (wire/arg-build (fresh-conn)
+                                             (tu/args->js {:build (first (:running-builds-arg-forms data))})))
+                          "the listed form pastes straight back into :build"))))
+          (.finally (fn []
+                      (set! nrepl/cljs-eval-value orig-cljs)
+                      (set! nrepl/jvm-eval orig-jvm)))
+          (.then (fn [_] (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; Symptom 3 — colon idempotence (regression guard; fixed by #2821).
+;; ---------------------------------------------------------------------------
+
+(deftest colon-prepend-is-idempotent
+  (let [conn (fresh-conn)]
+    (is (= :examples/machine-epochs
+           (wire/arg-build conn (tu/args->js {:build ":examples/machine-epochs"})))
+        "a leading colon is stripped, never double-prepended into ::examples/…")
+    (is (= (wire/arg-build conn (tu/args->js {:build "examples/machine-epochs"}))
+           (wire/arg-build conn (tu/args->js {:build ":examples/machine-epochs"})))
+        "bare and colon forms are indistinguishable post-coercion")))
+
+;; ---------------------------------------------------------------------------
+;; Symptom 4 — a stuck build transfers to subsequent ops (regression guard).
+;; ---------------------------------------------------------------------------
+
+(deftest stuck-build-transfers-to-subsequent-ops
+  (let [conn     (fresh-conn)
+        no-build (tu/args->js {})]
+    ;; Simulate an explicit :build on a prior op having been stuck.
+    (wire/stick-build! conn (tu/args->js {:build "examples/machine-epochs"}))
+    (is (= :examples/machine-epochs (wire/arg-build conn no-build))
+        "a build stuck on a prior op defaults the next no-:build op")))
+
+(deftest stuck-suffix-build-canonicalised-by-step
+  ;; A suffix form stuck on a prior op, then canonicalized by the pipeline
+  ;; step, becomes the canonical sticky default for follow-up ops.
+  (async done
+    (let [conn (fresh-conn)]
+      ;; stick-build! stores the fresh-keyword'd suffix form.
+      (wire/stick-build! conn (tu/args->js {:build "machine-epochs"}))
+      (is (= :machine-epochs (:resolved-build-id @conn)) "sanity: suffix stuck verbatim")
+      (-> (with-running! [:examples/machine-epochs]
+            (fn []
+              (-> (probe/canonicalize-build! conn :machine-epochs)
+                  (.then (fn [canonical]
+                           ;; the step rewrites :resolved-build-id when one was stuck
+                           (when (some? (:resolved-build-id @conn))
+                             (swap! conn assoc :resolved-build-id canonical)))))))
+          (.then (fn [_]
+                   (is (= :examples/machine-epochs (wire/arg-build conn (tu/args->js {})))
+                       "the canonical id is the sticky default for follow-up no-:build ops")
+                   (done)))))))


### PR DESCRIPTION
## Summary

The re-frame2-pair build-id selection was inconsistent across ops and its error guidance was not round-trippable (live-reproduced 2026-06-02 on the machine-epochs deck). `discover-app` forgave/normalised a build name while the read/action ops compared the requested id against shadow's `active-builds` by exact `=`, so a short tail an operator naturally reaches for (`machine-epochs`) was rejected `:build-not-running` — even though it named the build right there in the error's own `:running-builds` list.

## What #2821 already covered vs what this PR adds

`#2821` (in this PR's base) already fixed **two** of qda59's four symptoms:
- **Colon idempotence** — `fresh-keyword` strips a leading colon, never double-prepends `::examples/…`.
- **Session-stickiness** — a discover-app'd build transfers to read ops via the sticky `:resolved-build-id`.

Both are pinned here as **regression guards**. This PR adds the two **residual** fixes:

1. **Forgiving suffix resolution across ALL ops.** One shared resolver:
   - `probe/match-running-build` — pure exact-or-unique-suffix match (`:machine-epochs` ⇒ `:examples/machine-epochs`). Two builds sharing a tail stay ambiguous; a no-match id passes through unchanged so the diagnostic ladder still fires (never a silent wrong-build pick).
   - `probe/canonicalize-build!` — async; resolves against `active-builds` and caches the suffix→canonical alias on the conn-atom (`:build-alias`). At most one round-trip per distinct build name per session; free for an already-exact / already-resolved id.
   - A new `:canonicalize-build` pipeline step (runs first) populates the alias before any per-tool body reads `wire/arg-build`, and rewrites the sticky `:resolved-build-id` to canonical. `arg-build` maps its resolved id through the alias, so **every** op — explicit-arg or sticky-default — resolves to the same canonical running id, with **zero per-op call-site changes**.
2. **Round-trippable `:running-builds` error list.** `:build-not-running` / `:no-runtime-for-build` now carry `:running-builds-arg-forms` (each build in the exact `:build` arg form, `":examples/machine-epochs"`) and every hint string prints the colon form, so a build copied out of an error pastes straight back into `:build`.

Specs (`API.md`, `003-Tool-Catalogue.md`) updated for the suffix-forgiving arg + the round-trippable candidate list.

## Quality gates

- **rf2-qda59 4-symptom repro test** (`test/.../build_id_resolver_test.cljs`): suffix-match accepted across ops (via `arg-build` alias); `:running-builds` error list copy-paste-round-trippable; colon idempotent; stuck/discover-app'd build transfers + canonicalises — **PASS**
- pair CLJS suite (`npm test`, shadow-cljs :server-test): **848 tests, 2562 assertions, 0 failures, 0 errors**
- `npm run check:descriptors`: **exit 0** (28 tools in sync — no new tool/verb/descriptor added)
- skill-MCP drift (`python scripts/check_skill_mcp_drift.py --verbose --ci`): **exit 0, no drift**
- JVM wire-vocab (`clojure -M:test` in `tools/mcp-conformance/wire-vocab`): **49 tests, 627 assertions, 0 failures**
- mcp-conformance pair (`npm run test:re-frame2-pair`): **GREEN** (28 tools advertised; degraded-path envelopes intact)
- clj-kondo on all changed files: **0 errors, 0 warnings**

No new tool / verb / descriptor — this only refines the shared resolver, so descriptor / skill-drift / verb-vocab gates stay quiet (verified above).

Closes rf2-qda59.