### PR TITLE
chore: tail cleanup — machines-viz docstring + story golden slice-keys + runner atom reset (rf2-amlik, rf2-ursej, rf2-vkdam)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1364,7 +1364,11 @@ and the inverse on the read side.
 (= machine-spec (-> machine-spec scxml/spec->scxml scxml/scxml->spec))
 ```
 
-holds for the supported subset.
+holds for the supported subset. It is **not** exact for the shapes
+listed under [Not supported](#not-supported-lossy-or-omitted) below —
+notably a machine-level (top-level) `:on` fallback, which W3C SCXML
+cannot host as a root `<transition>`, so it is exported as a
+documenting comment and does **not** survive the parse back.
 
 ### Supported grammar subset
 
@@ -1386,6 +1390,11 @@ holds for the supported subset.
 
 - `:spawn-all` rows — omitted; the parent state renders without
   spawn affordances.
+- Machine-level (top-level) `:on` fallback transitions — W3C SCXML
+  has no clean root-fallback slot (`<scxml>` does not host
+  `<transition>` children per the schema, and the import side drops
+  root-level transitions), so these are exported as a documenting XML
+  comment and do **not** round-trip back through `scxml->spec`.
 - `:tags` — re-frame2-specific; not part of W3C SCXML.
 - `:action`s and guard FN bodies — only the *names* survive
   (SCXML `cond="name"` for guards; entry/exit `<script>` would

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -51,6 +51,11 @@
 
   - `:spawn-all` rows — omitted; the parent state renders without
     spawn affordances.
+  - Machine-level (top-level) `:on` fallback transitions — W3C SCXML
+    has no clean root-fallback slot (`<scxml>` does not host
+    `<transition>` children per the schema, and the import side drops
+    root-level transitions), so these are exported as a documenting
+    XML comment and do **not** round-trip back through `scxml->spec`.
   - `:tags` — re-frame2-specific; not part of W3C SCXML.
   - `:action`s and guard FN bodies — only the *names* survive
     (SCXML `cond=\"name\"` for guards; entry/exit `<script>` would
@@ -274,7 +279,13 @@
   (= machine-spec (-> machine-spec spec->scxml scxml->spec))
   ```
 
-  for the supported subset documented in the ns docstring."
+  for the supported subset documented in the ns docstring. The
+  equality is *not* exact for the lossy shapes the ns docstring lists
+  under \"Not supported\" — notably a machine-level (top-level) `:on`
+  fallback, which W3C SCXML cannot host as a root `<transition>`, so it
+  is exported as a documenting comment and does **not** survive the
+  parse back (alongside `:spawn-all`, `:tags`, action/guard bodies, and
+  source-coord metadata)."
   [machine-spec]
   (cond
     (= :parallel (:type machine-spec))

--- a/tools/story/src/re_frame/story/golden.cljc
+++ b/tools/story/src/re_frame/story/golden.cljc
@@ -58,9 +58,11 @@
     slice. Pure when handed a run-result; impure (replays into a fresh
     frame) when handed an artifact / plan.
   - `golden-match?` — true iff a new run canonicalizes `=` to the golden's
-    frozen slice. The fast path checks the cheap `:run-hash` first, then
-    confirms with canonical equality (a hash collision can never report a
-    false GREEN — equality is the authority).
+    frozen slice. The fast path first confirms the golden's frozen
+    `:slice-keys` still match the current `run-hash-input-keys` (a
+    slice-surface drift is never a match), then checks the cheap `:run-hash`,
+    then confirms with canonical equality (a hash collision can never report
+    a false GREEN — equality is the authority).
   - `compare-golden` — the READABLE report. On match `{:match? true …}`; on
     mismatch it DELEGATES to `re-frame.story.diff/diff-runs` (NOT a
     reinvented diff) to localise WHERE the run parted from the golden, so a
@@ -70,7 +72,8 @@
 
   The slice + canonical capture + the match / report logic
   (`behavioural-slice`, `slice-canonical`, `make-golden`, `golden?`,
-  `golden-match?`, `compare-golden`) are pure data → data: a run-result in,
+  `slice-keys-current?`, `golden-match?`, `compare-golden`) are pure data →
+  data: a run-result in,
   a golden / verdict out — so they run under `clojure -M:test` with no
   runtime. The only impurity is `->run-result`, which (for an artifact /
   plan input) replays into a fresh frame via `.7`'s `replay-run-artifact`.
@@ -128,8 +131,11 @@
 
   The slice freezes the `canonicalize`d behavioural surface (`:canonical`)
   plus the cheap `:run-hash` discriminator and the `:run-hash-input-keys`
-  the slice was taken over (so a future slice-key change is detectable, not
-  silent).
+  the slice was taken over. `matches?` / `compare-golden` compare that
+  frozen `:slice-keys` against the CURRENT `fingerprint/run-hash-input-keys`
+  (see `slice-keys-current?`), so a future slice-key change is detectable,
+  not silent: a slice-surface drift reads as a distinct `:stale-slice-keys`
+  verdict ('recapture the golden') rather than a confusing fake regression.
 
   `opts` (optional):
 
@@ -286,18 +292,44 @@
     {:canonical canon
      :run-hash  (fingerprint/hash-canonical canon)}))
 
+(defn slice-keys-current?
+  "True iff the `golden`'s frozen `:slice-keys` (the behavioural surface the
+  golden was captured over) match the CURRENT `fingerprint/run-hash-input-keys`
+  (spec/017 §Golden slices). Pure data → data.
+
+  A golden's `:canonical` was taken via `select-keys` over the slice-key set
+  in force AT CAPTURE. If a later revision adds or removes a behavioural slot
+  (changing `run-hash-input-keys`), an old golden's frozen `:canonical` was
+  taken over the OLD surface while an incoming run is sliced over the NEW one
+  — the two no longer compare apples-to-apples. Unlike a canonical-FORM
+  change (version-tagged via `fingerprint/canonical-version`, which forces a
+  hash mismatch), a slice-SURFACE change carries no version tag, so without
+  this guard the drift would read as a confusing fake regression rather than
+  'baseline surface changed — recapture'.
+
+  A golden captured before `:slice-keys` was stored (no slot) is treated as
+  current — there is nothing to compare against, and failing it closed would
+  flag every legacy golden as stale."
+  [golden]
+  (let [frozen (:slice-keys golden)]
+    (or (nil? frozen)
+        (= frozen fingerprint/run-hash-input-keys))))
+
 (defn- matches?
   "The ONE GREEN/RED authority over an ALREADY-coerced run-`result` (spec/017
   §Golden slices). True iff `result` matches the `golden` slice. Pure data →
   data — both `golden-match?` and `compare-golden` route through this so the
   two-stage equality cannot drift between the predicate and the report.
 
-  Two-stage to avoid a false GREEN: the cheap `:run-hash` is checked first
-  (a mismatched hash ⇒ definitely different, short-circuit), then canonical
-  equality is the AUTHORITY (a hash collision can never report a match
-  because the canonical values still differ)."
+  Three-stage to avoid a false GREEN: first the frozen `:slice-keys` MUST
+  match the current `run-hash-input-keys` (a slice-surface drift means the
+  comparison is not apples-to-apples — never a match), then the cheap
+  `:run-hash` is checked (a mismatched hash ⇒ definitely different,
+  short-circuit), then canonical equality is the AUTHORITY (a hash collision
+  can never report a match because the canonical values still differ)."
   [golden {:keys [canonical run-hash]}]
-  (and (= (:run-hash golden) run-hash)
+  (and (slice-keys-current? golden)
+       (= (:run-hash golden) run-hash)
        (= (:canonical golden) canonical)))
 
 (defn golden-match?
@@ -328,6 +360,16 @@
 
   On MATCH: `{:match? true :run-hash <hash>}`.
 
+  On a STALE SLICE-SURFACE: `{:match? false :stale-slice-keys true
+  :golden-slice-keys <frozen> :current-slice-keys <now>}` — the golden's
+  frozen `:slice-keys` no longer match the current
+  `fingerprint/run-hash-input-keys`, so its `:canonical` was taken over a
+  DIFFERENT behavioural surface and the comparison is not apples-to-apples.
+  This is surfaced as a DISTINCT verdict (NOT a `:diff`) so a slice-surface
+  drift reads as 'baseline surface changed — recapture the golden' rather
+  than a confusing fake regression. No `diff/diff-runs` is taken because
+  diffing across two surfaces would mislocalise.
+
   On MISMATCH: `{:match? false :run-hash <new> :golden-run-hash <frozen>
   :diff <readable-diff>}` — the diff DELEGATES to
   `re-frame.story.diff/diff-runs` (the §Semantic-diff facet machinery, NOT
@@ -355,8 +397,17 @@
    (let [result    (->run-result run (dissoc opts :golden-run-result))
          {:keys [run-hash] :as ch} (canonical+hash result)
          base-run  (or golden-run-result (:run-result golden))]
-     (if (matches? golden ch)
+     (cond
+       (not (slice-keys-current? golden))
+       {:match?             false
+        :stale-slice-keys   true
+        :golden-slice-keys  (:slice-keys golden)
+        :current-slice-keys fingerprint/run-hash-input-keys}
+
+       (matches? golden ch)
        {:match? true :run-hash run-hash}
+
+       :else
        (cond-> {:match?          false
                 :run-hash        run-hash
                 :golden-run-hash (:run-hash golden)}

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -375,6 +375,13 @@
   (when config/enabled?
     (swap! pending-exceptions assoc frame-id [])
     (install-trace-listener! frame-id)
+    ;; rf2-vkdam — reset the per-dispatch-step settle boundaries at the START
+    ;; of a fresh stepping session (the stepper analogue of `run!`'s reset),
+    ;; so `step-once!`'s per-step appends window onto THIS session's epoch tape
+    ;; rather than accumulating onto a previous run's boundaries. Fetched via
+    ;; the late-bind seam because `play` cannot `:require` `runner-events`.
+    (when-let [clear! (late-bind/get-fn :clear-step-boundaries)]
+      (clear! frame-id))
     (swap! stepper-state assoc frame-id
            {:remaining (variant-play-steps frame-id)
             :ran       []

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -158,7 +158,14 @@
 (defn clear-step-boundaries!
   "Reset the per-dispatch-step settle boundaries for `frame-id` (rf2-rkd14).
   Called at the START of a fresh script run so the narrative attribution
-  windows onto THIS run's epoch tape, not a previous run's boundaries."
+  windows onto THIS run's epoch tape, not a previous run's boundaries.
+
+  rf2-vkdam — owned by every entry that WRITES boundaries: the public driver
+  `run!`, the orchestrator `runtime/run-phase-4!` (which also covers its
+  no-auto-plays branch), and the stepper start `play/begin-stepper!` (via the
+  `:clear-step-boundaries` late-bind seam). So a non-orchestrator re-run /
+  replay-in-place / stepping session no longer inherits stale accumulated
+  offsets that would mis-attribute the exact narrative."
   [frame-id]
   (swap! step-boundaries dissoc frame-id)
   nil)
@@ -1223,6 +1230,17 @@
                     :cljs (.toString (js/Math.random)))
          started (-> (runner/start init (now-ms))
                      (assoc :run-token token))]
+     ;; rf2-vkdam — reset the per-dispatch-step settle boundaries here, in the
+     ;; SAME public entry that resets run-state and then writes boundaries via
+     ;; `run-loop!`/`record-settle-boundary!`. Previously only the orchestrator
+     ;; (`runtime/run-phase-4!`) cleared, so an interactive re-run / replay-in-
+     ;; place driving `run!` directly accumulated boundaries until teardown.
+     ;; Owning the reset alongside the write keeps the attribution windowed
+     ;; onto THIS run's epoch tape. The leading-nil-span semantics still hold:
+     ;; the boundaries snapshot the ABSOLUTE epoch-history length, so any setup
+     ;; epochs already on the tape precede the first boundary (in the
+     ;; orchestrator path setup runs in phase-2, before phase-4 drives `run!`).
+     (clear-step-boundaries! variant-id)
      (set-state! variant-id pk started)
      (set-active-play! variant-id pk)
      (run-loop! variant-id pk token done-cb)
@@ -1333,3 +1351,10 @@
 ;; available as soon as the play module drives a stepped run.
 
 (late-bind/set-fn! :run-play-step run-step!)
+
+;; rf2-vkdam — the stepper appends a settle boundary per `run-step!`, so a
+;; fresh stepping session (`play/begin-stepper!`) must reset the frame's
+;; boundaries first — the stepper analogue of `run!`'s reset. Exposed via the
+;; same late-bind seam since `play.cljc` cannot `:require` this ns.
+
+(late-bind/set-fn! :clear-step-boundaries clear-step-boundaries!)

--- a/tools/story/test/re_frame/story/golden_test.cljc
+++ b/tools/story/test/re_frame/story/golden_test.cljc
@@ -240,6 +240,54 @@
       (is (= #{:app-db} (:facets (:diff r)))))))
 
 ;; ===========================================================================
+;; PURE: rf2-ursej — the frozen :slice-keys DRIVE compare (drift-detection)
+;; ===========================================================================
+
+(deftest slice-keys-current-predicate
+  (testing "a freshly-captured golden's :slice-keys are current; a golden whose
+            frozen surface differs from run-hash-input-keys is stale; a legacy
+            golden with NO :slice-keys is treated as current"
+    (let [g (golden/make-golden (run-result {:app-db {:n 1}}))]
+      (is (true? (golden/slice-keys-current? g))
+          "the surface a golden was captured over matches the current keys")
+      (is (false? (golden/slice-keys-current?
+                    (assoc g :slice-keys (conj fingerprint/run-hash-input-keys
+                                               :some-new-slot))))
+          "a frozen surface that drifted from the current keys is stale")
+      (is (true? (golden/slice-keys-current? (dissoc g :slice-keys)))
+          "a golden captured before :slice-keys existed is not flagged stale"))))
+
+(deftest compare-golden-stale-slice-keys-distinct-verdict
+  (testing "when a golden's frozen :slice-keys no longer match the current
+            run-hash-input-keys, compare-golden returns a DISTINCT
+            :stale-slice-keys verdict (NOT a fake regression diff) — the stored
+            slice-keys now DRIVE the compare, fulfilling the make-golden promise"
+    (let [run    (run-result {:app-db {:n 1}})
+          ;; Simulate a future slice-surface change: the frozen golden was
+          ;; captured over a DIFFERENT key set than the current one.
+          stale  (assoc (golden/make-golden run {:keep-run-result true})
+                        :slice-keys (conj fingerprint/run-hash-input-keys
+                                          :some-future-slot))
+          r      (golden/compare-golden stale run)]
+      (is (false? (:match? r)) "a slice-surface drift is never a match")
+      (is (true? (:stale-slice-keys r)) "surfaced as the distinct verdict")
+      (is (not (contains? r :diff))
+          "no diff/diff-runs is taken — diffing across surfaces would mislocalise")
+      (is (= (conj fingerprint/run-hash-input-keys :some-future-slot)
+             (:golden-slice-keys r)))
+      (is (= fingerprint/run-hash-input-keys (:current-slice-keys r)))))
+
+  (testing "golden-match? also returns false on a stale slice surface — the
+            three-stage matches? gates slice-keys before canonical equality"
+    (let [run   (run-result {:app-db {:n 1}})
+          stale (assoc (golden/make-golden run)
+                       :slice-keys (conj fingerprint/run-hash-input-keys
+                                         :some-future-slot))]
+      (is (false? (golden/golden-match? stale run))
+          "even the very run the golden was captured from is NOT a match once
+           the frozen surface drifts from the current keys"))))
+
+;; ===========================================================================
 ;; PURE: rf2-9fd9c — golden-match? + compare-golden share ONE authority
 ;; ===========================================================================
 
@@ -247,8 +295,11 @@
   (testing "golden-match? and compare-golden's :match? agree for EVERY run —
             they route through the one shared GREEN/RED predicate, so the
             verdict can never drift between the boolean and the report"
-    (let [g     (golden/make-golden (run-result {:app-db {:n 1} :ops [:a :b]})
-                                    {:keep-run-result true})
+    (let [g      (golden/make-golden (run-result {:app-db {:n 1} :ops [:a :b]})
+                                     {:keep-run-result true})
+          ;; A stale-slice-surface golden: both paths must report a non-match.
+          stale  (assoc g :slice-keys (conj fingerprint/run-hash-input-keys
+                                            :some-future-slot))
           runs  [;; equivalent ⇒ both GREEN
                  (run-result {:app-db {:n 1} :ops [:a :b]})
                  ;; key-order-only ⇒ both GREEN (canonical)
@@ -262,7 +313,11 @@
       (doseq [run runs]
         (is (= (golden/golden-match? g run)
                (:match? (golden/compare-golden g run)))
-            (str "golden-match? and compare-golden disagree for " (pr-str run)))))))
+            (str "golden-match? and compare-golden disagree for " (pr-str run)))
+        (is (= (golden/golden-match? stale run)
+               (:match? (golden/compare-golden stale run)))
+            (str "stale-slice golden: golden-match? and compare-golden disagree for "
+                 (pr-str run)))))))
 
 (deftest compare-golden-run-hash-matches-fingerprint
   (testing "the :run-hash compare-golden reports is the canonical

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -92,6 +92,9 @@
   #?(:clj (config/set-global-args! {}))
   (reset! legacy-play/stepper-state {})
   (reset! re/run-state {})
+  ;; rf2-vkdam — reset the per-dispatch-step settle boundaries so a test
+  ;; observes only its own run's boundaries, not a prior test's accumulation.
+  (reset! re/step-boundaries {})
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
   (frame/reg-frame bridge-frame {:doc "outcome-matching bridge test frame"})
@@ -614,6 +617,45 @@
          (is (= :pass (:status final)))
          (is (= 4 (count (:results final))))
          (is (= [0 1 2 3] (mapv :idx (:results final))))))))
+
+;; ---- rf2-vkdam: the public driver OWNS the boundary reset ----------------
+;;
+;; `record-settle-boundary!` APPENDS a per-dispatch-step settle boundary onto
+;; the process-global `step-boundaries` atom (keyed by frame-id). Previously
+;; only the orchestrator (`runtime/run-phase-4!`) cleared, so a non-orchestrator
+;; re-run via the public `run!` (interactive Re-run / replay-in-place) kept
+;; accumulating boundaries until teardown — a latent hazard for any future
+;; consumer reading `settle-boundaries` after such a run (stale offsets →
+;; mis-attributed narrative). `run!` now resets the frame's boundaries at the
+;; SAME entry that writes them, so two consecutive public `run!`s leave exactly
+;; ONE run's worth — not the doubled accumulation.
+
+#?(:clj
+   (deftest run-resets-step-boundaries-public-driver
+     (testing "two consecutive public `run!`s of the same play leave the
+              frame's settle-boundaries reset to THIS run's worth — `run!`
+              owns the reset, so the count does not accumulate (rf2-vkdam)"
+       (rf/reg-event-db :vk/touch
+         (fn [db _] (update db :touches (fnil inc 0))))
+       (story/reg-variant :story.vkdam/rerun
+         {:events []
+          :play-script {:auto-run? false
+                        :script [[:dispatch-sync [:vk/touch]]
+                                 [:dispatch-sync [:vk/touch]]
+                                 [:dispatch-sync [:vk/touch]]]}})
+       ;; Allocate the frame so `run!` has a live frame to dispatch into.
+       (async/deref-blocking (story/run-variant :story.vkdam/rerun) 5000)
+       ;; First public run via `run!` (NOT the orchestrator).
+       (run-blocking :story.vkdam/rerun)
+       (let [after-first (count (re/settle-boundaries :story.vkdam/rerun))]
+         (is (= 3 after-first)
+             "three dispatch steps record three boundaries")
+         ;; Second public run — an interactive Re-run. WITHOUT the reset this
+         ;; would accumulate to six; WITH it, `run!` clears at start so the
+         ;; frame again holds exactly THIS run's three boundaries.
+         (run-blocking :story.vkdam/rerun)
+         (is (= 3 (count (re/settle-boundaries :story.vkdam/rerun)))
+             "the public driver reset its boundaries — no stale accumulation")))))
 
 #?(:clj
    (deftest bare-vector-with-unknown-event-still-dispatches


### PR DESCRIPTION
Three small, disjoint tail-cleanup fixes (one file each, plus their tests). Pre-alpha masterpiece stance: CLARITY + CORRECTNESS.

## rf2-amlik (P3) — machines-viz scxml docstring overclaim
The `spec->scxml` fn docstring restated the round-trip equality `(= machine-spec (-> machine-spec spec->scxml scxml->spec))` scoped only by a pointer to the ns docstring. But a machine-level (top-level) `:on` fallback — a first-class Spec 005 feature — does NOT round-trip: W3C SCXML has no clean root `<transition>` slot, so `emit-machine-level-on` exports it as a documenting XML comment and the parser drops root-level transitions (the test corpus confirms: `emit-machine-level-on-not-dropped` asserts only the export side, explicitly noting 'this can't round-trip', and there is no `round-trips?` assertion for that shape, unlike the 7 others). Corrected the fn docstring to scope the equality at the point of use, added top-level `:on` to the ns-docstring + `spec/API.md` Not-supported lists. Docstring/doc-only — no behaviour change.

## rf2-ursej (P4) — golden :slice-keys stored-but-unused — DECISION: WIRE (option a)
A golden froze `:slice-keys fingerprint/run-hash-input-keys` and `make-golden` promised drift was 'detectable, not silent', but nothing read it back — `matches?` compared only `:run-hash` + `:canonical`. **Chose (a) wire it, not (b) remove**, because the drift-detection is genuinely valuable, not vestigial: a slice-SURFACE change (a behavioural slot added/removed from `run-hash-input-keys`) is NOT version-tagged — unlike a canonical-FORM change, which is guarded by `fingerprint/canonical-version` and forces a hash mismatch. Without the guard, an old golden's `:canonical` (taken over the OLD key set) mis-compares against a run sliced over the NEW set as a confusing fake RED with no signal the surface itself drifted. Now: `matches?` is three-stage (slice-keys-current? → run-hash → canonical equality); `compare-golden` returns a distinct `:stale-slice-keys` verdict ('recapture the golden') instead of a misleading diff; `golden-match?` returns false on drift. Legacy goldens with no `:slice-keys` are treated as current (nothing to compare). New `slice-keys-current?` predicate; tests prove slice-keys now drive compare.

## rf2-vkdam (P4) — public play driver never resets the boundary atom
`record-settle-boundary!` appends per-dispatch-step epoch offsets onto the process-global `step-boundaries` atom, but the public drivers never reset it — only the orchestrator (`runtime/run-phase-4!`), teardown, and the test fixture cleared. So an interactive re-run / replay-in-place via `run!`, and every stepper session, accumulated boundaries until teardown — a latent hazard for any future consumer reading `settle-boundaries` after a non-orchestrator run (stale offsets → mis-attributed exact narrative). Fix: `run!` now `clear-step-boundaries!` for the frame at the same entry that writes them; the stepper start `begin-stepper!` resets via a new `:clear-step-boundaries` late-bind seam (play.cljc cannot `:require` runner-events). Leading-nil-span semantics preserved — boundaries snapshot the ABSOLUTE epoch-history length, so setup-phase epochs still precede the first boundary. The orchestrator's existing clear stays (it also covers its no-auto-plays branch; idempotent).

## Quality gates
- `npm run test:cljs` — 5252 tests, 17967 assertions, 0 failures, 0 errors
- JVM story suite (`clojure -M:test` in tools/story) — 1583 tests, 5930 assertions, 0 failures, 0 errors (covers golden + runner_events, incl. new `slice-keys-current-predicate`, `compare-golden-stale-slice-keys-distinct-verdict`, extended `match-and-compare-agree`, and `run-resets-step-boundaries-public-driver`)
- JVM machines-viz suite (`clojure -M:test` in tools/machines-viz) — 299 tests, 787 assertions, 0 failures, 0 errors
- clj-kondo on all changed src+test files — 0 errors (6 warnings, all pre-existing, none in changed code)
- ursej: added tests proving `:slice-keys` now drives compare (the stale verdict + the false match). vkdam: added `run-resets-step-boundaries-public-driver` proving the public driver leaves the boundary atom reset (two consecutive `run!`s leave one run's worth, not doubled). amlik: docstring-only, no test.
- `mkdocs build --strict` not run — the machines-viz spec tree is tool-local and not in the mkdocs nav.