### PR TITLE
fix(xray): machine-state-path-coord resolves :event/:rf/machine, not dead :machine kind (rf2-dcsw1)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -1795,9 +1795,27 @@
   machines, unregistered machine-id)."
   [machine-id state-path]
   (when (and (keyword? machine-id) (vector? state-path) (seq state-path))
-    (let [machine-meta (try (rf/handler-meta :machine machine-id)
+    ;; rf2-dcsw1 (iwy0c-followup) — read the registration meta under the
+    ;; `:event` kind, NOT the non-existent `:machine` kind. A machine is
+    ;; registered as a `reg-event-fx` carrying `:rf/machine? true` + the
+    ;; stamped spec (with `:rf.machine/source-coords`, rf2-8bp3) under
+    ;; `:rf/machine` (rf2-ge6uj ISSUE 2 / rf2-iwy0c part C — `machine-block`
+    ;; and `handler-source-block` already read `:event`). The prior
+    ;; `:machine` lookup resolved nil, so the `:rf.machine/source-coords`
+    ;; index was never found and the `:after`-timer state-path rendered a
+    ;; dead (non-clickable) source link. Reading under `:event` +
+    ;; `machine-spec-value`'s `:rf/machine` resolution surfaces the index.
+    (let [machine-meta (try (rf/handler-meta :event machine-id)
                             (catch :default _ nil))
-          idx          (or (get-in machine-meta [:rf/machine :rf.machine/source-coords])
+          ;; Resolve the machine spec the same way `machine-spec-value`
+          ;; (defined later in this ns) does: the stamped spec lives under
+          ;; `:rf/machine`, with fixture-shape fallbacks for unit tests.
+          ;; Inlined here because the var is declared below this fn.
+          spec         (or (:rf/machine machine-meta)
+                           (:machine-spec machine-meta)
+                           (:spec machine-meta)
+                           (:rf.machine/spec machine-meta))
+          idx          (or (:rf.machine/source-coords spec)
                            (:rf.machine/source-coords machine-meta))
           spec-path    (proj/state-spec-path-prefix state-path)
           c            (or (get idx spec-path)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -178,6 +178,79 @@
             ":active")
           "the state-path chip shows the path the timer fired from"))))
 
+(deftest dispatch-source-after-timer-state-path-resolves-coord-test
+  (testing "rf2-dcsw1 (iwy0c-followup) — when the `:after-timer` source
+            machine is registered with an `:rf.machine/source-coords`
+            index carrying a coord for the state-path, the state-path
+            chip resolves the coord and renders as a CLICKABLE button
+            (open-in-editor link), NOT the dead plain-span placeholder.
+
+            `machine-state-path-coord` previously read the NON-EXISTENT
+            `:machine` registrar kind → resolved nil → every machine
+            state-path link was dead (same latent-nil class rf2-iwy0c
+            part C fixed in `handler-source-block` / `machine-block`,
+            which read `:event` + the `:rf/machine` spec). This pins the
+            fixed path: read `:event` + the spec's
+            `:rf.machine/source-coords`."
+    (rf/with-frame :rf/default
+      ;; A machine is registered as a `reg-event-fx` carrying
+      ;; `:rf/machine? true` + the stamped spec (with
+      ;; `:rf.machine/source-coords`, rf2-8bp3) under `:rf/machine`. The
+      ;; source-coords index keys by the spec-path shape that
+      ;; `projection/state-spec-path-prefix` produces for the state-path:
+      ;; `[:active :authenticating]` → `[:states :active :states
+      ;; :authenticating]`.
+      (rf/reg-event-fx :rf2-dcsw1.view/timer-machine
+                       {:rf/machine? true
+                        :rf/machine {:initial :active
+                                     :rf.machine/source-coords
+                                     {[:states :active :states :authenticating]
+                                      {:file "src/app/auth.cljs" :line 42}}
+                                     :states {:active {}}}}
+                       (fn [_ _] {}))
+      (let [step {:step :dispatch :badge :DISPATCH :step-number 1
+                  :event [:rf2-dcsw1.view/timer-machine
+                          [:rf.machine.timer/after-elapsed
+                           250 7 [:active :authenticating]]]
+                  :source :after-timer
+                  :coord nil
+                  :source-enrichment {:machine-id        :rf2-dcsw1.view/timer-machine
+                                      :delay-ms          250
+                                      :source-state-path [:active :authenticating]}}
+            tree (view/render-dispatch-step step)
+            chip (th/find-by-testid
+                   tree "rf-xray-epoch-dispatch-after-timer-state-path")]
+        (is (some? chip) "the state-path chip slot renders")
+        (is (= :button (first chip))
+            "coord resolved (read off :event + :rf/machine source-coords) →
+             the state-path is a CLICKABLE open-in-editor button, not a
+             dead plain span")
+        (is (some? (:on-click (th/attrs chip)))
+            "the resolved chip carries the open-in-editor click handler")))))
+
+(deftest dispatch-source-after-timer-state-path-degrades-without-coord-test
+  (testing "rf2-dcsw1 — when no machine is registered for the source
+            machine-id (production elision / unregistered), the
+            state-path chip DEGRADES GRACEFULLY to a plain non-clickable
+            span — the link STRUCTURE lights up only once a coord is
+            available. Negative control for the resolution test above."
+    (rf/with-frame :rf/default
+      (let [step {:step :dispatch :badge :DISPATCH :step-number 1
+                  :event [:rf2-dcsw1.view/unregistered
+                          [:rf.machine.timer/after-elapsed
+                           250 7 [:active :authenticating]]]
+                  :source :after-timer
+                  :coord nil
+                  :source-enrichment {:machine-id        :rf2-dcsw1.view/unregistered
+                                      :delay-ms          250
+                                      :source-state-path [:active :authenticating]}}
+            tree (view/render-dispatch-step step)
+            chip (th/find-by-testid
+                   tree "rf-xray-epoch-dispatch-after-timer-state-path")]
+        (is (some? chip) "the state-path chip slot still renders")
+        (is (= :span (first chip))
+            "no coord → plain non-clickable span (graceful degrade)")))))
+
 (deftest dispatch-source-machine-spawn-renders-rich-label-test
   (testing "rf2-5qp4g — `:source :machine-spawn` renders the kind label
             and the spawned actor-id"


### PR DESCRIPTION
## What

`machine-state-path-coord` (`tools/xray/.../panels/epoch/view.cljs`) read the **non-existent `:machine` registrar kind** (`(rf/handler-meta :machine machine-id)`), which always resolved nil. The `:rf.machine/source-coords` index was therefore never found, and the `:after`-timer DISPATCH-source state-path rendered a **dead, non-clickable** source link (degraded gracefully — no crash — hence P3).

This is the same latent-nil class **rf2-iwy0c part C (#2822)** fixed in `handler-source-block`, and that `machine-block` already had via **rf2-ge6uj** (the cascade source path moved off `:machine` to `:event` + `:rf/machine` because `:machine` resolved nil).

## Fix

Mirror the #2822 / `machine-block` reference pattern:

1. Read the registration meta under the `:event` kind (`(rf/handler-meta :event machine-id)`) — a machine is a `reg-event-fx` carrying `:rf/machine? true` + the stamped spec under `:rf/machine`.
2. Resolve the spec the same way `machine-spec-value` does (`:rf/machine` + fixture-shape fallbacks). Inlined here because `machine-spec-value` is declared lower in the ns (forward-ref would be a CLJS `undeclared Var`).
3. Read `:rf.machine/source-coords` off the resolved spec.

The state-path now resolves the coord and renders as a clickable open-in-editor `<button>`; still degrades to a plain `<span>` when no coord was captured (production elision / unregistered machine).

## Quality gates

- New tests in `view_cljs_test.cljs` pinning the fixed path (mirrors the iwy0c part-C structure: positive + degraded control):
  - `dispatch-source-after-timer-state-path-resolves-coord-test` — machine registered with an `:rf.machine/source-coords` index → state-path chip is a clickable `:button` (was a dead `:span` / nil before the fix).
  - `dispatch-source-after-timer-state-path-degrades-without-coord-test` — unregistered machine → plain `:span` (graceful degrade, negative control).
- `npm run test:cljs` — **0 failures** (Ran 5254 tests / 17972 assertions).
- `npm run test:xray-feature-gate` — **0 failures** (nightly-full sweep, 16 scenarios / 13 matrix rows). First run showed one flaky `managed http and effects rows` fail caused by `http-server exited unexpectedly (code=1)` — a teardown-race in the static file server (rf2-84gzw territory), disjoint from this change; a clean re-run passed 0 failures.
- clj-kondo — **0 errors** on both changed files (the 13 warnings are pre-existing unused-private-var / unused-require; none introduced here).
- **Spec unchanged (impl fix).** Spec 021 §2123 already documents the `:after-timer` state-path as click-to-source on the machine spec's `:rf.machine/source-coords` index — the dead `:machine`-kind read was an impl bug, not a spec'd behaviour. This fix brings the impl into line with the existing contract.

Closes rf2-dcsw1.