### PR TITLE
docs: sync README + CLAUDE.md project-layout maps to current repo structure (rf2-trvnl)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Top-level layout:
 
 - `spec/` — the specification (primary artefact; AI-targeted)
 - `implementation/` — CLJS reference: `core/` + per-substrate `adapters/` (Reagent, UIx, Helix) + per-feature artefacts (machines, schemas, …). The top-level `implementation/shadow-cljs.edn` + `implementation/deps.edn` coordinate the cross-artefact classpath.
-- `tools/` — dev/inspection tools that consume the Spec 009 instrumentation API and Tool-Pair contract (`story/`, `story-mcp/`, `re-frame2-pair-mcp/`, `xray/`, `template/`). Bundle-isolated from production builds; nothing in `implementation/` may `:require` from `tools/`.
+- `tools/` — dev/inspection tools that consume the Spec 009 instrumentation API and Tool-Pair contract (`template/`, `story/`, `story-mcp/`, `re-frame2-pair-mcp/`, `xray/`, `machines-viz/`, `testbed-support/`, `mcp-base/`, `mcp-conformance/`). Bundle-isolated from production builds; nothing in `implementation/` may `:require` from `tools/`.
 - `examples/` — worked examples per substrate.
 - `docs/` — human-facing guide (`docs/guide/`) and operational docs.
 - `skills/` — Claude Code skills for re-frame2 workflows.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ spec/                          Full specification (AI-targeted; the primary arte
   012-Routing.md               URL ↔ frame state contract
   013-Flows.md                 Registered, toggleable computed-state declarations
   014-HTTPRequests.md          Managed HTTP effect — retry, abort, taxonomy
+  015-Data-Classification.md   Path-marked sensitive/large declarations; redaction sentinels
   Principles.md                The 9 AI-first practical principles
   Conventions.md               Reserved namespaces, fx-ids, app-db keys
   Ownership.md                 Contract-surface → owning-Spec map (the "where does X live?" reference)
@@ -192,7 +193,9 @@ docs/
   guide/                       Human-facing guide (marketing voice)
   release-process.md           Operational doc — multi-artefact release pipeline
   quiet-tests.md               Recipe for silent-on-success cljs.test / clojure.test reporters
-examples/                      Tutorial-only worked examples (counter, etc.)
+examples/                      Worked examples grouped per substrate (reagent canonical full
+                               set — counter, todomvc, realworld, 7GUIs; uix + helix curated
+                               subsets; reagent-slim slim-bundle demo). Test-free.
 testbeds/                      Shared framework-behavior testbed surfaces (consumed by Xray + Story
                                + MCP servers). Bundle-isolated from production builds.
   deliberate_throw/            4 :rf.error/* trigger sites (handler / fx / flow / machine)
@@ -211,8 +214,12 @@ implementation/                CLJS reference implementation — per-artefact su
                                frame-provider, trace, source-coords, substrate, elision
   adapters/
     reagent/                   day8/re-frame2-reagent — the Reagent adapter (browser default)
+    reagent-slim/              day8/reagent-slim — slim Reagent fork (reagent2.core); same view
+                               semantics, smaller footprint, capped Form-3 surface
     uix/                       day8/re-frame2-uix — the UIx adapter
     helix/                     day8/re-frame2-helix — the Helix adapter
+    test-react/                day8/re-frame2-test-react — pure-CLJC React-lifecycle simulator;
+                               catches lifecycle bugs at unit-test speed (no React/DOM/jsdom)
   schemas/                     day8/re-frame2-schemas — Malli boundary-validation artefact
   machines/                    day8/re-frame2-machines — state-machine artefact (xstate-flavoured)
   flows/                       day8/re-frame2-flows — registered computed-state declarations
@@ -222,6 +229,8 @@ implementation/                CLJS reference implementation — per-artefact su
   ssr-ring/                    day8/re-frame2-ssr-ring — Ring adapter for SSR pipeline
   epoch/                       day8/re-frame2-epoch — epoch ring-buffer + partial-record contract
   test-quiet/                  Quiet-on-success reporter shared across 17 test runners
+  security/                    Cross-cutting security regression tests (MCP egress, schema
+                               redaction, SSR escaping) — test-only, no shipped namespace
   scripts/                     Build / release scripts
   shadow-cljs.edn              Top-level build coordinator: pulls all artefacts onto one classpath
   deps.edn                     Top-level build coordinator (clojure-tools): :local/root deps for all
@@ -251,12 +260,14 @@ tools/                         CLJS dev/inspection tools that consume re-frame2'
   mcp-conformance/             Cross-server MCP conformance harness — gates wire-vocabulary parity
                                in CI
 skills/                        Claude skills
+  README.md                    Skill routing — single source disambiguating which skill to use
   re-frame2/                   Authoring skill — canonical patterns + reference docs
   re-frame2-setup/             Greenfield-app scaffolding skill
   re-frame2-implementor/       Skill for porting re-frame2 to a new host language
   re-frame2-improver/          Critique-mode skill for existing re-frame2 code
   re-frame2-pair/              Runtime pair-programming skill (nREPL + MCP companion)
   re-frame2-pair-retro/        Retrospective skill — reviews pair sessions, drafts improvements
+  re-frame2-xray/              Xray devtools-panel skill (launch modes, panels, components)
   re-frame-migration/          re-frame v1.x → re-frame2 migration skill
   shared/                      Cross-skill protocols (retro-protocol, evidence discipline)
 ```


### PR DESCRIPTION
Closes rf2-trvnl. Full top-to-bottom diff of the repo-root README `#project-layout` map against the actual tree (`git ls-files` per top-level area), synced to reality; CLAUDE.md's staler top-level-layout tools list brought into agreement so the two maps don't drift independently. Marketing voice + format preserved; only the layout-map sections changed.

## Deltas fixed

**README.md (project-layout map only)**
- `spec/`: added `015-Data-Classification.md` — a numbered capability spec the map stopped short of (it listed 000-014).
- `implementation/`: added `security/` — cross-cutting security regression tests (MCP egress, schema redaction, SSR escaping), test-only, no shipped namespace. `SECURITY.md` did NOT move; it remains as the file entry it already was.
- `implementation/adapters/`: added `reagent-slim/` (`day8/reagent-slim`, slim Reagent fork) and `test-react/` (`day8/re-frame2-test-react`, pure-CLJC React-lifecycle simulator). Map had listed only reagent/uix/helix.
- `examples/`: replaced the stale `Tutorial-only worked examples (counter, etc.)` one-liner with the per-substrate reality (reagent canonical full set; uix/helix subsets; reagent-slim demo; test-free).
- `skills/`: added `README.md` (skill-routing single source) and `re-frame2-xray/` (has SKILL.md).

**CLAUDE.md (Architecture Overview tools/ list only)**
- Synced the staler 5-tool list (story/story-mcp/re-frame2-pair-mcp/xray/template) to the full 9 tools, matching the corrected README.

## Quality gates

Tree-match verification (`git ls-files <area> | second-level | sort -u` vs map claims) — no omissions, no phantoms:
- `implementation/` subdirs: actual 13 == map 13.
- `implementation/adapters/`: actual {reagent, reagent-slim, uix, helix, test-react} == map.
- `tools/`: actual 9 == map 9.
- `skills/`: actual {README.md + 8 skills + shared} == map.
- `spec/` numbered specs: 000-002, 004-015 (003 reserved) — map now includes 015.
- `examples/`, `testbeds/`, `docs/`: verified; `docs/` retains its curated highlight (full mkdocs site is the canonical inventory; out of map-scope by design).

`mkdocs build --strict`: N/A — `mkdocs.yml` has `docs_dir: docs`; the repo-root `README.md` is not in the nav (nav only references files under `docs/`).

No behavioral/rule text changed — diff is confined to the layout-map code block in README and the single tools/ layout line in CLAUDE.md. Doc-only; no code tests.

```
 CLAUDE.md | 2 +-
 README.md | 13 ++++++++++++-
```