### PR TITLE
docs(skills): bring re-frame2-pair current with shipped MCP ops + framework contract (rf2-f8hzv)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -196,7 +196,11 @@ Read the leaf that matches the task. Each reference file is ≤250 lines.
 
 | Task shape | Reference |
 |---|---|
-| Pick a structured op (read, write, trace, DOM bridge, watch, hot-reload, time-travel) | [references/ops.md](references/ops.md) |
+| Pick a structured op (read, validated sub-read, write, dry-run, trace, DOM/UI read, signal recording, blocking wait, hot-reload, time-travel) | [references/ops.md](references/ops.md) |
+| Orient on an unfamiliar app in one call, or read a single sub's validated value | `orient` / `read-sub` — see [references/ops.md §Read](references/ops.md#read) (and the MCP arg shapes in [references/mcp-transport.md §Orientation + discovery](references/mcp-transport.md#orientation--discovery)) |
+| Read what's actually on screen (rendered content + producing view entity) | `read-ui` / `read-dom` — see [references/ops.md §View → rendered content](references/ops.md#view--rendered-content--producing-entity-uiread) |
+| Simulate an event's consequence WITHOUT committing it (no fx fire) | `dispatch-dry-run` — see [references/recipes.md §"What would this event do?"](references/recipes.md#what-would-this-event-do-dry-run) |
+| Record signals while the human interacts, or block until a condition lands | `record` / `read-recording` / `watch-until` — see [references/ops.md §Signal recording](references/ops.md#signal-recording--blocking-waits) |
 | Run a named procedure the user asked for ("why didn't my view update?", post-mortem, experiment loop, etc.) | [references/recipes.md](references/recipes.md) |
 | Drive a Story variant from a re-frame2-pair session — the variant *is* a frame; variant-id ↔ frame-id identity, per-variant isolation, the four-phase lifecycle, gotchas, discovery | [references/variant-as-frame.md](references/variant-as-frame.md) |
 | Open a push-mode subscription on the trace or epoch bus (topics, filters, termination) | [references/streaming-subscriptions.md](references/streaming-subscriptions.md) |

--- a/skills/re-frame2-pair/references/mcp-transport.md
+++ b/skills/re-frame2-pair/references/mcp-transport.md
@@ -63,23 +63,65 @@ edits.
 
 ## MCP tool reference (args)
 
+The server exposes **28 tools** (catalogued in `tools/re-frame2-pair-mcp/tool-descriptors.edn`, the generated descriptor manifest). 26 are reachable from this skill's `allowed-tools:`; the two write-authority tools (`restore-epoch`, `reset-frame-db`) are gated behind the server's default-OFF `--allow-writes` launch flag and reached via the eval forms in [`ops.md` §Time-travel](ops.md#time-travel-epoch-restore) / [§Write](ops.md#write) — an operator who launches with `--allow-writes` can add the two MCP tools to a deployment's allow-list.
+
+### Orientation + discovery
+
 | MCP tool       | Args |
 |----------------|------|
-| `discover-app` | `{}` (optional `build`) |
-| `eval-cljs`    | `{form: "..."}` |
-| `dispatch`     | `{event: "...", sync: true, frame: ":foo"}` |
-| `trace-window` | `{ms: 1000}` |
-| `watch-epochs` | `{pred: {"event-id-prefix": ":cart"}}` (pull-mode — call repeatedly with `since-id`) |
-| `tail-build`   | `{probe: "..."}` |
-| `snapshot`     | `{frames: "all"\|[":rf/default"...], include: ["app-db","sub-cache","machines","epochs","traces"], path: "[:cart :items]"}` — default `:app-db` mode is **`:summary`** (tree-summary marker, not the full value); pass `path` to slice. Root `path: "[]"` opts back into the full slice. See [`ops.md` §Read](ops.md#read). |
-| `get-path`     | `{path: "[:cart :items 0 :sku]", frame: ":rf/default"}` — targeted-read primitive. Returns `{ok? true :exists? true :value <subtree>}` or `{ok? false :reason :path-not-found :deepest-valid-prefix [...]}`. `:exists?` distinguishes a path that legitimately points at `nil` from a missing path. |
-| `subscribe`    | `{topic: "trace"\|"epoch"\|"fx"\|"error", filter: {...}, max-events: 0, max-ms: 0}` — push-mode; emits `notifications/progress` ticks; resolves on cancel / `max-events` / `max-ms` / `unsubscribe`. See `references/streaming-subscriptions.md`. |
-| `unsubscribe`  | `{sub-id: "<uuid>"}` — idempotent close. |
-| `list-subscriptions` | `{}` (or `{frame: ":rf/default", include-values: true}`) — list the **live reactive sub-cache** for a frame (the answer to "what subscriptions are active?"), reading the same source as `snapshot :sub-cache`. Returns `{:ok? true :frame <id> :count n :subs [<query-v> ...]}`; reflects disposal. NOT the streaming taps — for those use `list-streams`. (rf2-qicji) |
-| `list-streams` | `{}` (or `{topic: "epoch"}` / `{sub-id: "<uuid>"}`) — list active **streaming-tap** subscriptions with `:queue-depth`, `:dropped-events`, `:overflow-reason` without draining queues. Diagnostic for "is my probe still alive?". (The streaming diagnostic `list-subscriptions` formerly carried; rf2-qicji.) |
+| `discover-app` | `{}` (optional `build` / `port`) — connect + health probe. Carries a `:freshness` token (`:liveness :fresh\|:stale-build\|:no-runtime\|:unknown`) — check it before trusting reads. See §Connect-first in SKILL.md. |
+| `orient` | `{}` — **app-shape orientation summary in ONE round-trip** (rf2-3bu3d.8). Composes discover-app + snapshot-top-keys + list-handlers + list-subscriptions + machines for first contact on an unfamiliar app. Returns `:liveness` / `:frames {:all :app :operating}` / `:app-db-top-keys` / `:registry {:counts :events :subs :fx}` / `:machines`. Compact by design; reserved `:rf/*` tool frames excluded from `:app-db-top-keys`. Drill via the reads below. |
+| `get-re-frame2-pair-instructions` | `{}` — inline agent-onboarding text (tool catalogue, EDN posture, tagged-mutation conventions, streaming semantics, wire pipeline). No nREPL round-trip. Optionally call at session start. |
 | `list-handlers` | `{kind: "event"}` — discovery: every id registered under one kind. `{:ok? true :kind :event :ids [...] :count n}`, ids sorted. Kinds: `event` / `sub` / `fx` / `cofx` / `view` / `frame` / `route` / `flow` / `head` / `error-projector` / `machine`. Prefer over a `registrar-list` eval. See [`ops.md` §Read](ops.md#read). |
 | `handler-meta` | `{kind: "event", id: ":user/login"}` — drill: registration metadata for one id (source-coord + `:doc` + `:tags` + an `:rf.source/uri` clickable jump-to-editor link). `{:ok? false :reason :not-registered ...}` on a miss. Composite sub ids pass as the vector-string form. Prefer over a `registrar-describe` eval. See [`ops.md` §Read](ops.md#read). |
-| `get-re-frame2-pair-instructions` | `{}` — inline agent-onboarding text (tool catalogue, EDN posture, tagged-mutation conventions, streaming semantics, wire pipeline). No nREPL round-trip. Optionally call at session start to orient before the first real op. |
+
+### Read (data plane)
+
+| MCP tool       | Args |
+|----------------|------|
+| `snapshot`     | `{frames: "all"\|[":rf/default"...], include: ["app-db","sub-cache","machines","epochs","traces"], path: "[:cart :items]"}` — default `:app-db` mode is **`:summary`** (tree-summary marker, not the full value); pass `path` to slice. Root `path: "[]"` opts back into the full slice. See [`ops.md` §Read](ops.md#read). |
+| `get-path`     | `{path: "[:cart :items 0 :sku]", frame: ":rf/default"}` — targeted-read primitive. Returns `{ok? true :exists? true :value <subtree>}` or `{ok? false :reason :path-not-found :deepest-valid-prefix [...]}`. `:exists?` distinguishes a path that legitimately points at `nil` from a missing path. Batch with `paths: "[[...] [...]]"` (rf2-lbm21). |
+| `read-sub`     | `{sub: "[:cart/total]", frame: ":rf/default"}` — **validated one-shot subscription read** (rf2-3bu3d.7), the #1 read on any app. PREFER over a raw `eval-cljs` `@(rf/subscribe ...)`: the `sub` arg is parsed as EDN once + MUST be a vector, the sub-id is validated against the live `:sub` registrar (unknown → `:reason :unknown-id` + `:nearest`, never a silent nil), the value is elided server-side. `{:ok? true :query-v [...] :frame <id> :value <v> :elision true}` on a hit. |
+| `list-subscriptions` | `{}` (or `{frame: ":rf/default", include-values: true}`) — list the **live reactive sub-cache** for a frame (the answer to "what subscriptions are active?"), reading the same source as `snapshot :sub-cache`. Returns `{:ok? true :frame <id> :count n :subs [<query-v> ...]}`; reflects disposal. NOT the streaming taps — for those use `list-streams`. (rf2-qicji) |
+| `eval-cljs`    | `{form: "...", frame: ":foo", await: true, timeout-ms: 5000}` — escape hatch; evaluates a CLJS form against the runtime. Frame-scopes via `with-frame` (rf2-ntuzf); `await` resolves Promises server-side (rf2-xn4f9). Enabled by default; operator opts out via `--no-eval`. |
+
+### View plane (the rendered DOM)
+
+| MCP tool       | Args |
+|----------------|------|
+| `read-ui`      | `{view-id: ":my.app/counter"}` / `{point: {x: N, y: N}}` / `{selector: "#save"}` — **typed `ui/read`** (rf2-3bu3d.1): rendered subtree as elided data PLUS the producing re-frame2 entity (view-id, source-coord, render-key, the frame's live `subs-read`), in one round-trip. Rides the `data-rf-view` map (Spec 006 §View tagging) — works on any app with ZERO testids. Pass EXACTLY ONE entry point (precedence `view-id` > `point` > `selector`). Read-only. See [`ops.md` §ui/read](ops.md#view--rendered-content--producing-entity-uiread). |
+| `read-dom`     | `{selector: "#app .counter", sub-selector: ".title", attrs: ["value"], max-text: 2000, limit: 50}` — **view-plane read by explicit CSS selector** (rf2-nfjil): matched count + per-node `{:tag :text :attrs}`. The "did the UI actually update / what does the rendered node say?" read. Capped at the source (per-node `:max-text`, matched-node `:limit`); over-cap text → `:rf.size/large-elided`. `:attrs` omitted ⇒ curated default set + a `data-*` / `aria-*` sweep. Read-only. Pairs with `dispatch :await-render`. |
+
+### Write (drive the runtime)
+
+| MCP tool       | Args |
+|----------------|------|
+| `dispatch`     | `{event: "[:foo ...]", sync: true, frame: ":foo", trace: true, await-render: true, settle: true, queued: true, fx-overrides: {...}}` — fire an event tagged `:origin :pair`. DEFAULT returns the **consequence** (`:epoch-id :db-changed? :changed-paths :effects-fired :no-op? :cascade-summary`) — `dispatch → verify` in one call. Event validated against the `:event` registrar (unknown → `:reason :unknown-id` + `:nearest`, NOT dispatched). `settle` flushes renders synchronously + returns the full epoch incl. `:render-events`. See [`ops.md` §Write](ops.md#write). |
+| `dispatch-dry-run` | `{event: "[:cart/checkout]", frame: ":foo", fx-overrides: {...}}` — **simulate a cascade WITHOUT committing** (rf2-17hvp). Full reducer + interceptor + schema + machine + sub/render run; NO fx execute (each redirected to a recording stub) and the framework rolls back via restore-epoch. Returns the same `:cascade-summary` shape as `dispatch` plus `:rolled-back? true` and `:would-fire-effects [{:fx-id :args}...]`. "Experiment without consequences" — NOT gated by `--allow-writes` (its contract IS no observable effect). |
+
+### Trace + epoch (read-only)
+
+| MCP tool       | Args |
+|----------------|------|
+| `trace-window` | `{ms: 1000, limit: 50, cursor: "<b64>"}` — the `:rf/epoch-records` added in the last N ms for the operating frame. Diff-encoded + deduped + cursor-paginated. |
+| `watch-epochs` | `{pred: {"event-id-prefix": ":cart"}, since-id: "...", limit: 50, cursor: "..."}` — pull-mode poll: epochs matching `pred` that landed after `since-id`. Call repeatedly to live-watch. See [`ops.md` §Live watch](ops.md#live-watch-push-mode). |
+| `watch-until`  | `{signals: "[{:app-db [:upload :status]}]", pred: {:signal 0 :equals :done}, timeout-ms: 30000}` — **block until a predicate over a signal holds** (rf2-zo4b9), the blocking counterpart to `record`. Server polls a cheap runtime read (~100ms cadence) until the condition trips or `timeout-ms` elapses. `{:ok? true :held? true :elapsed-ms :sample :t}` or `{:ok? false :reason :watch-timeout :last-sample {...}}`. SIGNAL / PRED vocab shared with `record`. Read-only. |
+| `subscribe`    | `{topic: "trace"\|"epoch"\|"fx"\|"error"\|"frameless", filter: {...}, max-events: 0, max-ms: 0}` — push-mode; emits `notifications/progress` ticks; resolves on cancel / `max-events` / `max-ms` / `unsubscribe`. See `references/streaming-subscriptions.md`. |
+| `unsubscribe`  | `{sub-id: "<uuid>"}` — idempotent close. |
+| `list-streams` | `{}` (or `{topic: "epoch"}` / `{sub-id: "<uuid>"}`) — list active **streaming-tap** subscriptions with `:queue-depth`, `:dropped-events`, `:overflow-reason` without draining queues. Diagnostic for "is my probe still alive?". (The streaming diagnostic `list-subscriptions` formerly carried; rf2-qicji.) |
+| `record`       | `{signals: "[{:focus true} {:dom \"#count\"}]", stop: {:ms 15000}, max-entries: N}` — **first-class signal recorder** (rf2-zo4b9): install a READ-ONLY observer over one-or-more SIGNALS with a STOP condition, let the human interact, then read the change-log with `read-recording`. The canonical move for intermittent / human-in-the-loop bugs (render-timing races under real mouse input). Returns IMMEDIATELY with a `:recording-id`; samples once per animation frame, records each CHANGE, dedups, tears itself down at the stop condition. SIGNAL shapes: `{:app-db [path]}` / `{:sub [query-v]}` / `{:dom "sel" :attr "name"}` / `{:focus true}`. STOP: `{:ms N}` / `{:changes N}` / `{:pred {:signal i :equals v}}`. Read-only. |
+| `read-recording` | `{recording-id: "rec-abc", drain: true, stop: true}` — read back a recording's change-log: `{:ok? true :recording-id :status :stopped-reason :frames-sampled :count :entries [{:i :signal :value :t :frame}...]}`. Each entry is one CHANGE. `drain true` consumes buffered entries + keeps recording (live-watch idiom); `stop true` reads-and-closes. |
+
+### Hot-reload + frames
+
+| MCP tool       | Args |
+|----------------|------|
+| `tail-build`   | `{probe: "...", wait-ms: 5000}` — wait for a hot-reload to land by polling the probe until its value changes. Falls back to a 300ms soft timer (`:soft? true`) when `probe` is omitted. See [`ops.md` §Hot-reload](ops.md#hot-reload-coordination). |
+| `get-operating-frame` | `{}` — read the session's operating-frame triple `{:frames :selected :operating}`. `:operating nil` ⇒ ambiguous (two-plus app frames, no pin). |
+| `set-operating-frame` | `{frame: ":foo"}` — pin the session's operating frame; the escape from the tier-4 `:ambiguous-frame` refusal. Validates the frame is registered. |
+| `reset-operating-frame` | `{}` — clear the pin; ops fall back to tier 3 / 4. Idempotent. |
+
+The three operating-frame tools surface tier 2 of the frame-resolution cascade directly (no eval round-trip) — see SKILL.md §Multi-frame model.
 
 The `subscribe` / `unsubscribe` pair is the **push-mode** counterpart to `watch-epochs`. Each batch of matching events arrives as a `notifications/progress` notification correlated by the call's `progressToken`; the tool's final result is a summary. Use `subscribe` whenever you want a live narration; use `watch-epochs` (pull-mode, polled in a loop) when the agent host doesn't surface progress notifications to the model.
 
@@ -154,6 +196,54 @@ blank value indistinguishable from a genuine `nil`).
 
 The same resolution + preflight logic backs the legacy `scripts/`
 bash shim's `eval` op.
+
+## Build-id resolution (rf2-qda59 + rf2-lbm21 + rf2-8t3ct)
+
+shadow build ids are namespaced keywords (`:examples/machine-epochs`).
+The server resolves a `build` arg through a deterministic, **session-scoped**
+cascade so you rarely repeat it:
+
+1. **Suffix-forgiving match.** Colon-tolerant first (`"examples/step-deck"`
+   and `":examples/step-deck"` resolve identically — the bare `keyword`
+   footgun `::examples/...` is closed). Then **unique name-suffix**: a
+   `build` naming a running build by a unique tail (`"machine-epochs"`)
+   resolves to the canonical running id. The rule is exact-match-first,
+   then unique-tail; **two builds sharing the tail stay ambiguous** and a
+   no-match id passes through unchanged so the diagnostic ladder still
+   fires — never a silent wrong-build pick. Resolution runs once per
+   session and caches the suffix→canonical alias on the conn-atom.
+2. **Sticky per-session selection.** The first call that names a build —
+   `discover-app {build: "my-app"}` after a passing health probe, OR an
+   explicit `:build` on any later tool — sets the session-sticky default
+   (`:resolved-build-id` on the conn-atom). Every subsequent call may
+   omit `:build`. A later explicit `:build` both routes that call and
+   re-points the sticky default. The cache resets on reconnect (relaunch
+   shadow against a different build ⇒ fresh resolution). Per-session,
+   never process-global — each MCP client spawns its own server, so the
+   sticky target can't leak across clients.
+3. **`SHADOW_CLJS_BUILD_ID` env var** (defaulting to `:app`) — the final
+   fallback.
+
+**Round-trippable canonical ids.** The canonical id is the **keyword**.
+`discover-app` echoes it under both `:build-id` and `:build`; the
+read-family ops (`orient`, `read-dom`, `read-ui`, `eval-cljs`) echo the
+resolved `:build`. A value copied out of any of those slots works
+unchanged as a later `:build` arg.
+
+**`:build-not-running` vs `:no-runtime-connected` — distinct rungs.**
+The diagnostic ladder distinguishes two failure shapes the operator fixes
+differently:
+
+| Reason | Means | Fix |
+|---|---|---|
+| `:build-not-running` | shadow's `active-builds` doesn't include the targeted build (or the `:app` default isn't running while several builds are). | Pick a running build — the envelope carries `:running-builds` (keyword vector) **and** a sibling `:running-builds-arg-forms` (each rendered in the exact `":examples/machine-epochs"` string form the `:build` arg accepts back), so you can paste a build straight from the error into `:build`. |
+| `:no-runtime-connected` | the build **IS** running but no CLJS runtime answered the eval (cljs-eval returned blank — no browser tab connected, or its WebSocket dropped). | Open the app in a browser tab — or reload an already-open tab so the runtime reconnects. Also carries `:running-builds`. |
+
+The eval path surfaces the ambiguous-target case as
+`:no-runtime-for-build` (also enumerating `:running-builds`); the plain
+read path surfaces the same candidate list via `:build-not-running`.
+Either way the error names the valid set in a form that pastes back —
+never a silent wrong-build pick or a host failure.
 
 ## When the MCP server is degraded
 

--- a/skills/re-frame2-pair/references/ops.md
+++ b/skills/re-frame2-pair/references/ops.md
@@ -12,6 +12,7 @@ Most ops wrap a call into `re-frame2-pair.runtime`; for those, the MCP form is `
 - [Trace](#trace) — trace stream + epoch history
 - [DOM source bridge](#dom-source-bridge)
 - [Live watch (push-mode)](#live-watch-push-mode)
+- [Signal recording + blocking waits](#signal-recording--blocking-waits)
 - [Hot-reload coordination](#hot-reload-coordination)
 - [Time-travel (epoch restore)](#time-travel-epoch-restore)
 - [Bash-shim appendix (not reachable from this skill)](#bash-shim-appendix-not-reachable-from-this-skill)
@@ -33,7 +34,7 @@ Most ops wrap a call into `re-frame2-pair.runtime`; for those, the MCP form is `
 | `subs/sample` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/subs-sample [:cart/total])"}` | One-shot value via `rf/compute-sub` (no cache mutation) or `@(rf/subscribe ...)`. Unvalidated + un-elided — prefer `subs/read` above. |
 | `machines/list` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/machines-list)"}` | Machine ids (`rf/machines`) |
 | `machines/describe` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/machine-describe :auth)"}` | The registered spec map (`rf/machine-meta`) |
-| `machines/state` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/machine-state :auth)"}` | Current snapshot from `(rf/snapshot-of [:rf/runtime :machines :snapshots :auth])` |
+| `machines/state` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/machine-state :auth)"}` | Current `:rf/machine-snapshot` from `(rf/snapshot-of [:rf/runtime :machines :snapshots :auth])`. The snapshot shape is `{:state :data :tags? :meta?}` (Spec 005 §Snapshot shape): `:state` is the FSM-keyword / compound-path / parallel-region map; `:data` the machine's private memory; `:tags` the runtime-projected union of active states' `:tags` (optional); `:meta` carries `:rf/snapshot-version` (Spec-Schemas §`:rf/machine-snapshot`). The runtime also stamps closed `:rf/*` slots (e.g. `:rf/spawn-counter` at the root) — framework-owned, read-only. |
 
 ## Frames
 
@@ -55,8 +56,9 @@ To target one op at a non-operating frame without pinning the session, pass the 
 
 | Op | Invocation | Notes |
 |---|---|---|
-| `dispatch` | `mcp__re-frame2-pair__dispatch {event: "[:cart/apply-coupon \"SPRING25\"]"}` | Queued by default; pass `sync: true` to force `dispatch-sync`. Skill-issued dispatches carry `:origin :pair` (Spec 002 §Dispatch origin tagging) so `:rf.event/dispatched` traces can be filtered by who fired them. |
+| `dispatch` | `mcp__re-frame2-pair__dispatch {event: "[:cart/apply-coupon \"SPRING25\"]"}` | **Returns the consequence by default** (rf2-3bu3d.2): `{:epoch-id :db-changed? :changed-paths :effects-fired :no-op? :cascade-summary}` — `dispatch → verify` in one call; a no-op visibly returns `:db-changed? false :no-op? true`. The event-id is **validated** against the `:event` registrar (unknown → `:reason :unknown-id` + `:nearest`, NOT dispatched — never a silent no-op). Skill-issued dispatches carry `:origin :pair` (Spec 002 §Dispatch origin tagging). Modes: `sync: true` (force `dispatch-sync`), `queued: true` (async transport-ack), `trace: true` (full epoch), `await-render: true` (resolve after the substrate flushed + next paint scheduled), `settle: true` (the most complete shape — synchronously flush renders + return the full epoch incl. `:render-events`). |
 | `dispatch --frame` | `mcp__re-frame2-pair__dispatch {event: "[:foo]", frame: ":stories"}` | Targets a specific frame via the `:frame` opt on `rf/dispatch`. |
+| `dispatch-dry-run` | `mcp__re-frame2-pair__dispatch-dry-run {event: "[:cart/checkout]"}` | **Simulate a cascade WITHOUT committing** (rf2-17hvp) — "experiment without consequences". Full reducer + interceptor + schema validation + machine transitions + sub-runs + renders all run; **NO fx execute** (each registered fx is redirected to a recording stub) and the framework rolls back the app-db via `restore-epoch`. Returns the same `:cascade-summary` shape as `dispatch` plus `:rolled-back? true` and `:would-fire-effects [{:fx-id :args}...]` enumerating every fx that WOULD have fired (with args) so you reason about real-world impact without paying it. Composes with `:fx-overrides` (user overrides win, e.g. a canned http stub) without losing the rollback guarantee. **NOT** `--allow-writes`-gated — its contract IS "no observable effect". |
 | `reg-event` / `reg-sub` / `reg-fx` | `mcp__re-frame2-pair__eval-cljs {form: "<full reg-* form>"}` | Re-registration replaces; emits `:rf.registry/handler-replaced` trace (Spec 001 §Hot-reload semantics). Ephemeral. |
 | `app-db/reset` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/app-db-reset! ...)"}` | Delegates to `rf/reset-frame-db!` (Tool-Pair §Pair-tool writes) — replaces app-db, records a synthetic `:rf.epoch/db-replaced` epoch, validates against schema, refuses during a drain. Logged explicitly via `tap>` so the user sees what the agent changed. Use sparingly. |
 | `repl/eval` | `mcp__re-frame2-pair__eval-cljs {form: "<arbitrary form>"}` | Escape hatch. Prefer structured ops first. Takes the same `frame: ":foo"` arg as every other op (rf2-ntuzf — see *Frame-scoping an eval form* below): the server wraps the form in `(re-frame.core/with-frame :foo <form>)` so `(rf/subscribe ...)` / `(rf/dispatch ...)` inside it resolve against `:foo` rather than the ambient `:rf/default`. |
@@ -123,6 +125,18 @@ Pass **exactly one** entry point (precedence `view-id` > `point` > `selector`). 
 
 The accepted args (`:additionalProperties false`): `view-id`, `point`, `selector`, `max-text` (per-node char cap, default 2000), `frame`, `build`. Failure modes: `:no-target-arg` (no entry point), `:no-element` (entry point matched nothing), `:rf.error/ui-read-bad-selector` (malformed CSS). A portal / fragment leaf with no tagged view ancestor still returns `:content`, with `:entity {:view-id nil :reason :no-tagged-view-root}`.
 
+### `read-dom` — rendered content by explicit CSS selector (rf2-nfjil)
+
+`read-ui` is the typed view read (it rides the view-id↔DOM map and returns the producing entity). `read-dom` is the **content-only** read by an explicit CSS selector — the answer to *"did the UI update?"* / *"what does the rendered node SAY?"* when you already have a selector and don't need the entity provenance. The data-plane reads (`snapshot` / `get-path` / `read-sub` / `trace-window`) tell you what's in `app-db` and the trace; `read-dom` tells you what the app actually **put on screen**. Read-only by construction (only `querySelectorAll` + `textContent` / attribute strings). Pairs with `dispatch :await-render` / `:settle` for a deterministic *dispatch → settle → read-dom* observe.
+
+| Op | Invocation | Returns |
+|---|---|---|
+| `read-dom` | `mcp__re-frame2-pair__read-dom {selector: "#app .counter"}` | `{:ok? true :selector … :count N :truncated? bool :nodes [{:tag "div" :text "Count: 3" :attrs {"class" "counter" "data-count" "3"}}]}` — `:count` is the full pre-`:limit` tally |
+| `read-dom` scoped | `mcp__re-frame2-pair__read-dom {selector: ".card", sub-selector: ".title"}` | `:sub-selector` runs RELATIVE to each matched node to narrow a coarse match (a card) to its inner parts |
+| `read-dom` specific attrs | `mcp__re-frame2-pair__read-dom {selector: "input[name=email]", attrs: ["value", "data-valid"]}` | Omit `:attrs` and a curated default set rides PLUS a `data-*` / `aria-*` sweep (the re-frame2 view-plane idiom for surfacing rendered state) |
+
+Caps are applied **at the source** (browser-side) so only bounded EDN crosses the wire: `:max-text` (per-node text cap, default 2000 — over-cap → `{:rf.size/large-elided {:type :dom-text :chars N :preview "…"}}`) and `:limit` (matched-node cap, default 50; `:truncated? true` when more matched than returned). Failure modes: `:rf.error/read-dom-bad-selector` (malformed CSS); a no-match returns `{:ok? true :count 0 :nodes []}`.
+
 ## Live watch (push-mode)
 
 Two modes — `subscribe` (push) and `watch-epochs` (poll) — over the same underlying assembled-epoch / trace stream.
@@ -149,6 +163,29 @@ The tool's accepted args (`:additionalProperties false` — anything else is rej
 Predicate keys (any combination, inside `pred`): `event-id`, `event-id-prefix`, `effects`, `timing-ms` (e.g. `">100"`), `touches-path`, `sub-ran`, `render`, `origin` (`:app|:pair|:story|:test`), `frame`.
 
 Each call tracks the last seen `:epoch-id` in the operating frame's history via `since-id` and returns everything matching since. See `docs/initial-spec.md` §4.4.
+
+## Signal recording + blocking waits
+
+The push/poll watch ops above stream *epochs* — the cascade unit. The `record` / `read-recording` / `watch-until` family (rf2-zo4b9) observes arbitrary **signals** (an app-db path, a sub value, a DOM node's text/attribute, the focus slot) across a window of **real human interaction**. The canonical move for catching intermittent / human-in-the-loop bugs (render-timing races reproducible only under real mouse input) — the runtime solves the rAF-sampling / dedup / teardown footguns once. All three are **read-only**: never dispatch, never mutate app-db, never write the DOM.
+
+**SIGNAL shapes** (each a map naming one observable, shared by `record` + `watch-until`):
+
+| Signal | Reads |
+|---|---|
+| `{:app-db [path]}` | `(get-in app-db path)` |
+| `{:sub [query-v]}` | a subscription deref |
+| `{:dom "sel"}` / `{:dom "sel" :attr "name"}` | a node's `textContent` or attribute string |
+| `{:focus true}` | a stable descriptor of `document.activeElement` (the focus slot) |
+
+**PRED shapes** (a DATA predicate map over the positional sample map `{<signal-index> <value>}` — compiled to a pure value-comparison fn, no host source crosses the wire): `{:signal 0 :equals <v>}` / `{:signal 0 :changed true}` / `{:signal 0 :path [...] :equals <v>}` / `{:signal 0 :contains <substr>}` / `{:signal 0}` (any non-nil).
+
+| Op | Invocation | Behaviour |
+|---|---|---|
+| `record` | `mcp__re-frame2-pair__record {signals: "[{:focus true} {:dom \"#count\"}]", stop: {:ms 15000}}` | Returns IMMEDIATELY with a `:recording-id`; the recording runs in the background, samples each signal once per animation frame, records each CHANGE (with a `:t` wall-clock ms + `:frame` rAF-counter), dedups (a steady signal → ONE baseline entry), and tears down at the STOP condition. STOP (first to trip wins; defaults to `{:ms 30000}`): `{:ms N}` / `{:changes N}` / `{:pred {...}}`. |
+| `read-recording` | `mcp__re-frame2-pair__read-recording {recording-id: "rec-abc"}` | Read the change-log: `{:ok? true :recording-id :status :recording\|:stopped :stopped-reason :frames-sampled :count :entries [{:i :signal :value :t :frame}...]}`. Pass `drain: true` for the live-watch idiom (consume buffered entries, recording keeps running) or `stop: true` to read-and-close. Unknown id → `:reason :no-such-recording`. |
+| `watch-until` | `mcp__re-frame2-pair__watch-until {signals: "[{:app-db [:upload :status]}]", pred: {:signal 0 :equals :done}}` | **Blocks** until the predicate holds — the synchronous counterpart to `record`. Like `tail-build`, the server polls a cheap runtime read (~100ms cadence) until the condition trips or `timeout-ms` (default 30000) elapses. `{:ok? true :held? true :elapsed-ms :sample :t}` on success; `{:ok? false :reason :watch-timeout :timed-out? true :last-sample {...}}` on timeout (`:last-sample` shows how close it got). Missing `:pred` → `:reason :missing-pred`. |
+
+Use `record` + `read-recording` when you want to **capture** what happened across an open-ended interaction window (then read it back); use `watch-until` when you want to **block** until a specific condition lands before the next op (e.g. "wait until focus moves into the dialog, then read-dom it").
 
 ## Hot-reload coordination
 
@@ -192,7 +229,7 @@ re-frame2 ships first-class time-travel as part of the Tool-Pair contract — no
 | Unknown epoch | `:rf.epoch/restore-unknown-epoch` | `epoch-id` not in current history (aged out or never recorded) |
 | Schema mismatch | `:rf.epoch/restore-schema-mismatch` | `:db-after` no longer validates against currently-registered schemas (a schema was tightened since the snapshot) |
 | Missing handler | `:rf.epoch/restore-missing-handler` | DB references a registration id no longer in the registrar (e.g. a machine snapshot whose machine was unregistered) |
-| Version mismatch | `:rf.epoch/restore-version-mismatch` | Recorded `:rf/snapshot-version` of an active machine is incompatible with the currently-loaded definition (hot-reload bumped it) |
+| Version mismatch | `:rf.epoch/restore-version-mismatch` | Recorded `:meta :rf/snapshot-version` of an active machine is incompatible with the currently-loaded definition (hot-reload bumped it) |
 | Concurrent drain | `:rf.epoch/restore-during-drain` | Called while the frame's run-to-completion drain is in flight |
 
 When `restore-epoch` returns `false`, read the matching trace event from `(re-frame.trace.tooling/trace-buffer {:op-type :error})` to get the structured `:tags`, then report to the user.

--- a/skills/re-frame2-pair/references/recipes.md
+++ b/skills/re-frame2-pair/references/recipes.md
@@ -19,10 +19,12 @@ Each recipe is expressed in **MCP-tool form** — the only transport this skill 
 - ["Inspect this machine"](#inspect-this-machine)
 - ["Dead code scan"](#dead-code-scan)
 - [Experiment loop](#experiment-loop)
+- ["What would this event do?" (dry-run)](#what-would-this-event-do-dry-run)
 - [Stub an effect for an experiment](#stub-an-effect-for-an-experiment)
 - ["Narrate the next N events"](#narrate-the-next-n-events)
 - ["Alert me on slow events"](#alert-me-on-slow-events)
 - ["Watch for X while I interact"](#watch-for-x-while-i-interact)
+- ["Record while I interact" / "Wait until X happens"](#record-while-i-interact--wait-until-x-happens)
 - ["Drive a Story variant from a re-frame2-pair session"](#drive-a-story-variant-from-a-re-frame2-pair-session)
 - ["Diff two variants of the same component"](#diff-two-variants-of-the-same-component)
 - ["Refine a variant interactively"](#refine-a-variant-interactively)
@@ -39,6 +41,7 @@ Each recipe is expressed in **MCP-tool form** — the only transport this skill 
 3. Walk the epoch's `:sub-runs` projection. **A sub that re-ran appears in the vector; a sub that cache-hit does not** (Spec-Schemas §`:rf/epoch-record` — value-equal recompute suppression is enforced by the runtime, so cache-hit subs do not emit `:rf.sub/run`).
 4. If the sub the view depends on isn't in `:sub-runs` for the cascade, the equality gate held; report the upstream sub whose return value was `=` to its previous value.
 5. If the sub did re-run but the view didn't re-render, check `:renders` — the projection lists every render in the cascade with its `:render-key` and `:triggered-by`.
+6. To confirm whether the DOM actually changed (vs. the projection saying it should have), do a deterministic *dispatch → settle → read* — `mcp__re-frame2-pair__dispatch {event: "...", settle: true}` then `mcp__re-frame2-pair__read-dom {selector: "<the view's node>"}` (or `read-ui {view-id: "..."}`). The data plane (`:sub-runs` / `:renders`) says what *should* have rendered; `read-dom` says what's actually on screen.
 
 ## "Explain this dispatch"
 
@@ -97,12 +100,20 @@ Call `dom/source-at` on the element (or on `:last-clicked`). Return `{:ns :line 
 
 ## "Understand this component" / "What is this thing?"
 
-When the user points at a UI element (CSS selector, *"the thing I last clicked"*, or a description), chain:
+When the user points at a UI element (CSS selector, *"the thing I last clicked"*, or a description), the one-call move is **`read-ui`** (rf2-3bu3d.1) — it returns the rendered content AND the producing re-frame2 entity (view-id, source-coord, render-key, the frame's live `subs-read`) in a single round-trip, riding the `data-rf-view` map so it works with zero testids:
 
-1. `dom/source-at` — resolve to `{:ns :line :file}`.
-2. `Read` the source file at that line, with ~30 lines of context.
-3. Narrate: what the component is, what props it takes, which event(s) its interactions dispatch, and (if you can see them nearby) which subscriptions it reads. Cross-check against `(rf/handler-meta :view <id>)` for registered views.
-4. If the source-coord lookup fails, fall back to `dom/describe` to report tag/class/listeners, and ask the user to point at the source instead.
+```
+mcp__re-frame2-pair__read-ui {selector: "#save"}       ;; or {view-id: ":my.app/toolbar"} or {point: {x, y}}
+```
+
+Then chain:
+
+1. `read-ui` (or, if you want only the source coord, `dom/source-at`) — resolve to `:entity {:view-id :source-coord {:ns :line :file} :subs-read [...]}` and `:content {:tag :text :attrs}`.
+2. `Read` the source file at `:source-coord` `:line`, with ~30 lines of context.
+3. Narrate: what the component is, what props it takes, which event(s) its interactions dispatch, and which subscriptions it reads (`:subs-read` already names them). Cross-check against `(rf/handler-meta :view <id>)` for registered views.
+4. If `read-ui` returns `:entity {:view-id nil :reason :no-tagged-view-root}` (a portal / fragment leaf), fall back to `dom/source-at` then `dom/describe` to report tag/class/listeners, and ask the user to point at the source instead.
+
+To read JUST the rendered content of a node you already have a selector for (no entity provenance needed), use `read-dom {selector: "..."}` — see [ops.md §read-dom](ops.md#read-dom--rendered-content-by-explicit-css-selector-rf2-nfjil).
 
 This is one of the most grounding moves you can make — it turns *"that button"* into *"`re-com/button` at `app/cart/view.cljs:84`, dispatching `[:cart/checkout]`"* in one step.
 
@@ -116,7 +127,7 @@ When the user mentions a state machine (Spec 005), chain:
 
 1. `machines/list` — confirm it's registered.
 2. `machines/describe :auth` — return the spec map (`:initial`, `:states`, `:guards`, `:actions`, source coords).
-3. `machines/state :auth` — current snapshot, including `:rf/snapshot-version`.
+3. `machines/state :auth` — current `:rf/machine-snapshot` (`{:state :data :tags? :meta?}`; `:rf/snapshot-version` lives under `:meta`, per Spec 005 §Snapshot shape).
 4. To watch transitions live: `watch/stream` and inspect each emitted epoch's `:trace-events` for `:rf.machine/transition` entries — `(some #(= :rf.machine/transition (:operation %)) (:trace-events e))`. Arbitrary-predicate filtering at the watch layer is not currently supported; combine `--event-id-prefix` (to narrow by trigger) with caller-side filtering of the streamed epochs.
 5. Subscribe to the canonical machine sub: `subs/sample [:rf/machine :auth]`.
 
@@ -144,6 +155,22 @@ Canonical procedure:
 6. `trace/dispatch-and-collect [:foo ...]` → observe the new behaviour.
 7. Compare the two epochs (`epoch-diff` between their `:db-after` values; cross-check `:sub-runs` and `:renders` projections). Repeat until satisfied.
 8. If the change was REPL-only and the user wants to keep it, *commit via source edit* — REPL changes are lost on full page reload.
+
+## "What would this event do?" (dry-run)
+
+**When the user wants to know the consequence of an event WITHOUT paying for it** — before firing a checkout, a destructive delete, anything that hits the network or navigates. `dispatch-dry-run` (rf2-17hvp) runs the full cascade — reducer, interceptors, schema validation, machine transitions, sub-runs, renders — then rolls the app-db back via `restore-epoch`. No fx execute; every fx that *would* have fired is enumerated with its args.
+
+```
+mcp__re-frame2-pair__dispatch-dry-run {event: "[:cart/checkout]"}
+```
+
+Returns the same `:cascade-summary` shape as `dispatch` (so you read one vocabulary for both) plus:
+
+- `:rolled-back? true` — the app-db is unchanged after the simulation.
+- `:would-fire-effects [{:fx-id :http :args {...}} {:fx-id :navigate :args [...]}]` — the real-world impact, enumerated. Narrate this: *"checkout would POST to `/orders` and navigate to `:order-confirmation` — nothing has actually happened yet."*
+- `:cascade-summary {:db-diff {...} :outcome :ok\|:error ...}` — a schema violation surfaces as `:outcome :error`; the rollback still fires.
+
+Compose with `:fx-overrides` to simulate realistic conditions (a canned http response) without losing the rollback guarantee — user overrides win on conflict. Use this in place of the *baseline → restore → modify → re-dispatch* experiment loop when you only need to **read** the consequence once, not iterate on a handler.
 
 ## Stub an effect for an experiment
 
@@ -185,6 +212,37 @@ Fallback: poll `mcp__re-frame2-pair__watch-epochs {pred: {"event-id-prefix": ":c
 For the **live reactive sub-cache** — "what subscriptions are active in this frame?" — call `mcp__re-frame2-pair__list-subscriptions {frame: ":rf/default"}`. It reads the same source as `snapshot :sub-cache` and returns the cached query-vectors (reflecting disposal); pass `include-values: true` for current values + ref-counts (rf2-qicji).
 
 When a **streaming probe** seems to have gone quiet, call `mcp__re-frame2-pair__list-streams {}` to confirm it's still registered and check its `:queue-depth` before assuming the bus is dry. Full return shape and filters: see [streaming-subscriptions.md §Diagnostics](streaming-subscriptions.md#diagnostics--what-streams-are-currently-registered).
+
+## "Record while I interact" / "Wait until X happens"
+
+**When the bug only reproduces under real human input** — a focus race, a render-timing glitch, a value that only flips after a real mouse drag. `subscribe` / `watch-epochs` stream *epochs*; the `record` / `watch-until` family (rf2-zo4b9) observes arbitrary **signals** (an app-db path, a sub value, a DOM node's text/attribute, the focus slot) across the interaction window. All read-only — never dispatch, never mutate. See [ops.md §Signal recording](ops.md#signal-recording--blocking-waits) for the full SIGNAL / PRED vocabulary.
+
+**Capture across an interaction (record → read-recording).** When the user says *"watch what happens to focus and the count while I click around"*:
+
+1. Start the recorder — it returns immediately with a `:recording-id`, then runs in the background:
+   ```
+   mcp__re-frame2-pair__record {
+     signals: "[{:focus true} {:dom \"#count\"}]",
+     stop: {:ms 15000}
+   }
+   ```
+2. Tell the user to interact now. The runtime samples each signal once per animation frame, records each CHANGE (deduped — a steady signal yields one baseline entry), and tears down at the stop condition (`{:ms N}` / `{:changes N}` / `{:pred {...}}`).
+3. Read the change-log:
+   ```
+   mcp__re-frame2-pair__read-recording {recording-id: "rec-abc"}
+   ```
+   Each entry is `{:i <signal-index> :signal {...} :value <v> :t <ms> :frame <rAF-counter>}` — signals that changed on the same paint share a `:frame`. For a long-running session, poll with `drain: true` (consume buffered entries, keep recording) or close with `stop: true`.
+
+**Block until a condition lands (watch-until).** When the next op should only run *after* something happens — *"wait until the upload finishes, then snapshot"*:
+
+```
+mcp__re-frame2-pair__watch-until {
+  signals: "[{:app-db [:upload :status]}]",
+  pred: {:signal 0 :equals :done}
+}
+```
+
+Blocks (server polls ~100ms cadence) until the predicate holds — `{:ok? true :held? true :elapsed-ms ... :sample {0 :done}}` — or `timeout-ms` (default 30000) elapses, in which case `{:ok? false :reason :watch-timeout :last-sample {...}}` shows how close it got. Then proceed to the next read. PRED shapes are the same data-predicate maps `record`'s `:stop {:pred ...}` accepts.
 
 ## "Drive a Story variant from a re-frame2-pair session"
 

--- a/skills/re-frame2-pair/references/streaming-subscriptions.md
+++ b/skills/re-frame2-pair/references/streaming-subscriptions.md
@@ -32,7 +32,7 @@ Two transports cover the same buses; pick by interaction shape.
 
 ## Topic vocabulary
 
-Four topics, two underlying buses.
+Five topics, two underlying buses.
 
 | Topic | Bus | Returns |
 |---|---|---|
@@ -40,8 +40,11 @@ Four topics, two underlying buses.
 | `:epoch` | assembled-epoch bus | every `:rf/epoch-record` matching `:filter` |
 | `:fx` | raw trace stream | sugar for `:topic :trace :filter {:op-type :rf.fx ...}` |
 | `:error` | raw trace stream | sugar for `:topic :trace :filter {:op-type :error ...}` |
+| `:frameless` | raw trace stream | trace events with **no** `:rf.trace/dispatch-id` — registration emits, REPL evals, lifecycle outside any cascade (per Tool-Pair §Frameless trace events) |
 
 The `:fx` and `:error` topics are convenience sugar — they pre-pin the `:op-type` filter so you can layer additional trace-vocab keys on top.
+
+**Cascade-bundle vs flat delivery (rf2-mscih).** On `:trace` / `:fx` / `:error` each tick's matched events ship **grouped by `:rf.trace/dispatch-id` into cascade bundles** (matching `(rf/trace-buffer frame-id)` shape — `:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other :trace-events :parent-dispatch-id`); the progress payload's load slot is `:cascades`. `:epoch` and `:frameless` ship flat as `:events`. **Frameless events NEVER ride the cascade-bundle topics** — opt into the `:frameless` topic explicitly to see registration / REPL / lifecycle events that belong to no cascade.
 
 Use `:epoch` whenever you want assembled cascades (with their `:sub-runs` / `:renders` / `:effects` projections); use `:trace` (or its sugar) when you need raw trace-event detail (handler timings, registry traces, sub-cache events, the things the projection drops).
 
@@ -49,7 +52,7 @@ Use `:epoch` whenever you want assembled cascades (with their `:sub-runs` / `:re
 
 The filter map is `nil` (no filter) or a topic-specific map. Server-side normalisation happens on the runtime via `compose-trace-filter` (trace family) or `epoch-matches?` (epoch family).
 
-### `:trace` / `:fx` / `:error` — trace-buffer filter vocab
+### `:trace` / `:fx` / `:error` / `:frameless` — trace-buffer filter vocab
 
 Mirrors `(re-frame.trace.tooling/trace-buffer)` per Spec 009. Recognised keys:
 


### PR DESCRIPTION
Currency sync of the re-frame2-pair skill against its sources of truth: `tools/re-frame2-pair-mcp/tool-descriptors.edn` (28-tool manifest), `spec/Tool-Pair.md`, `spec/009-Instrumentation.md`. Structure + voice preserved — facts updated to match the shipped surface. Closes rf2-f8hzv.

## New ops documented (vs tool-descriptors.edn)

The headline drift: the skill's op catalogue predated today's merged ops. Now documented (purpose, args, result shape) + woven into recipes + the SKILL.md loading map:

- **orient** — one-call app-shape orientation (liveness / frames / app-db-top-keys / registry counts / machines).
- **read-sub** — validated one-shot subscription read (registrar-validated, elided; preferred over raw `eval-cljs @(subscribe ...)`).
- **read-ui** / **read-dom** — view-plane reads: read-ui returns rendered content + producing entity via the `data-rf-view` map (zero testids); read-dom is content-by-CSS-selector.
- **record** / **read-recording** / **watch-until** — signal recording + blocking waits (rf2-zo4b9): observe app-db/sub/dom/focus signals across human interaction or block until a predicate holds.
- **dispatch-dry-run** — simulate a cascade without committing (no fx fire; `:would-fire-effects` enumerated; rolled back).
- **get-/set-/reset-operating-frame** — the three operating-frame tools surfacing tier 2 of frame resolution (already in allowed-tools; now in the op tables + loading map).

`mcp-transport.md`'s op table was rebuilt into sectioned tables covering **all 26 skill-reachable tools**. The two write-authority tools (`restore-epoch`, `reset-frame-db`) stay gated behind the server's `--allow-writes` flag (intentional_server_only) and are documented via their eval forms in ops.md.

## Build-id resolution (rf2-qda59)

New `mcp-transport.md` section: forgiving colon-tolerant + unique-suffix match (ambiguous tails stay ambiguous; no silent wrong-build pick), sticky per-session `:resolved-build-id`, round-trippable `:running-builds` / `:running-builds-arg-forms`, and the **`:build-not-running` vs `:no-runtime-connected`** distinction (build absent vs build-running-but-no-tab-connected) with the matching operator fix for each.

## Spec-drift items corrected

- **Machine-snapshot shape**: corrected to `{:state :data :tags? :meta?}` with `:rf/snapshot-version` under **`:meta`** (the skill described it as top-level). Per Spec 005 §Snapshot shape + Spec-Schemas §`:rf/machine-snapshot`. Touched `machines/state` op row + the machine recipe + the restore version-mismatch row.
- **`:rf/hydration → :rf/runtime` fold (rf2-vnapd) + spawn-counter root**: verified — **no change needed**; the skill already uses the `:rf/runtime` root throughout (machine snapshots at `[:rf/runtime :machines :snapshots <id>]`, elision registry at `[:rf/runtime :elision]`). No stale `:rf/hydration` reference exists in the skill.
- **Streaming topics**: 4 → 5 (adds **`:frameless`**) with the cascade-bundle-vs-flat delivery note (rf2-mscih) — `:trace`/`:fx`/`:error` ship `:cascades`, `:epoch`/`:frameless` ship flat `:events`.
- **Tooling integration**: Xray complementarity table + story-mcp 5-tool live-session palette verified against current surfaces — current, no change.
- **Setup/preload + stale-binary post-merge hook**: confirmed current.

## Quality gates

- **Op-catalogue matches tool-descriptors.edn** — clean diff: the mcp-transport.md tables document all 26 skill-reachable tools (28-tool manifest minus 2 write-gated); 0 missing, 0 phantom. `descriptors_data.cljs` (the gate's source) and `tool-descriptors.edn` agree exactly (both 28).
- **skill ↔ MCP allowed-tools drift check** — `python scripts/check_skill_mcp_drift.py` exit **0** (no allowed-tools change needed; the new ops were already in allowed-tools — the drift was prose-only).
- **Skills structural test** — pass: `bb tests/prompts/prompt_regression_test.clj` (8 tests / 28 assertions) + all `tests/runtime/*_test.clj` + `tests/shim/shim_test.clj` (0 failures, 0 errors).
- **No broken links** — all intra-skill links + anchors verified (GitHub slug algorithm).
- **mkdocs build --strict** — **N/A**: no edited file is in the docs site nav. The nav references the hand-maintained `docs/skills/re-frame2-pair.md` proxy, not `skills/re-frame2-pair/SKILL.md` or its `references/`.