### PR TITLE
docs(skills): currency sweep — 7 skills synced to live re-frame2 surface (rf2-rzui8)

### DIFF
--- a/skills/re-frame2-setup/references/entry-namespace.md
+++ b/skills/re-frame2-setup/references/entry-namespace.md
@@ -140,4 +140,4 @@ If the author is coming from re-frame v1 (re-frame's first version), three thing
 | `defn` views — re-frame v1 had no view registration | `reg-view` macro registers views in a per-app registry; auto-injects `dispatch` / `subscribe` |
 | Implicit single global `app-db` | One default frame; multi-frame apps are first-class via `frame-provider` |
 
-The full v1→v2 migration story lives in `MIGRATION.md` (linked from `SKILL-REDIRECT.md` at the repo root). This skill is greenfield-only; if the author has a v1 codebase, point them at migration instead.
+The full v1→v2 migration story lives under `migration/from-re-frame-v1/` (linked from `SKILL-REDIRECT.md` at the repo root). This skill is greenfield-only; if the author has a v1 codebase, point them at migration instead.

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -366,6 +366,15 @@ keyframe (1.2s ease-in-out, interpolated through
 `--rf-xray-motion-scale` so reduced-motion collapses it; §021
 §17.4.5).
 
+The focused-epoch **transition row** is a single prominent row: a header
+verb `<before-state → after-state>` (larger / bolder / magenta, doubling
+as click-to-source) over a **logical-state DELTA box** — an
+`edn-inspector` before→after DIFF of the machine's `{:state :tags}` only
+(`:data` excluded — the per-action `↳ data Δ` carries it; `:rf/*` snapshot
+slots excluded). This reverses the older transition-map "delight shape":
+the delta box earns its place by carrying `:tags` + the structured
+before→after object (rf2-ge6uj header · rf2-iwy0c body; §021 §6).
+
 Per-canvas footer lists guards / actions / cancellation cascade chips
 inline (no modal, no popout). Empty state (machines registered, no
 activity this epoch) renders the topology with `current ●` annotation


### PR DESCRIPTION
Currency lens (rf2-rzui8): each of the 7 in-scope skills diffed against its mapped source-of-truth (`spec/*`, `spec/API.md`, Conventions, Implementor-Checklist, 000-Vision, `tools/template/`, `tools/xray/spec/*`, `migration/from-re-frame-v1/`, `skills/shared/`). `re-frame2-pair` skipped (done in rf2-f8hzv #2827). Currency SYNC, not rewrite — structure/voice preserved. Two clear drifts fixed inline; no large rewrites needed (no follow-up beads filed).

## Per-skill drift summary

| Skill | Mapped source | Verdict |
|---|---|---|
| **re-frame2** (authoring) | spec patterns + API.md + Conventions | **Current.** api-cheatsheet already on `app-db-value` / `current-frame-id` / `frame-bound-fn`/`*` / `configure!`; `reset-frame!` vs `reset-frame-db!` both correct (distinct APIs); SKILL-REDIRECT.md convention valid (file exists at repo root). |
| **re-frame2-setup** | `tools/template/` + scaffolding | **Fixed inline.** `entry-namespace.md` named a nonexistent repo-root `MIGRATION.md`; SKILL-REDIRECT routes migration to `migration/from-re-frame-v1/` — corrected. `clojure -Tnew create … :substrate :uix` invocation + `_uix/`/`_helix/` variant dirs verified against template README + spec/002. |
| **re-frame2-implementor** | Implementor-Checklist + 000-Vision | **Current.** 8 in-scope host languages match 000-Vision §Host-profile matrix; D4 sub-numbering (F1-F6/S1-S3/Sub1-Sub2/V1-V3/T1-T3/E1-E2) matches Checklist Part 2 1:1; `spec/conformance/` exists. |
| **re-frame2-improver** | Principles + anti-pattern catalogue | **Current.** 6 anti-pattern leaves; no stale API names; all `patterns/*` cross-links resolve. |
| **re-frame2-pair-retro** | `skills/shared/` retro-protocol | **Current.** shared `retro-protocol.md` / `issue-filing.md` / `tool-pair-surfaces.md` all present + current (`app-db-value`, `reset-frame-db!`, `epoch-history`, `restore-epoch`); seven-step anchor resolves. |
| **re-frame-migration** | `migration/from-re-frame-v1/` | **Current.** Rule citations (M-50/M-51/M-67, O-5→M-51 promotion) verified against the README; the two `rf/dispatcher`/`rf/subscriber` hits are the M-67 legacy→current rename column (correct, required). |
| **re-frame2-xray** | `tools/xray/spec/*` | **Fixed inline.** Already reflected 6-tab Dynamic / 5-tab Static / Epoch-hero / no-Issues-tab (rf2-gbz39) / chrome tidy. Added the missing **logical-state DELTA box** + before→after header verb on the Machine tab transition row (rf2-ge6uj · rf2-iwy0c, spec/021 §6). |

**Stale names corrected:** `MIGRATION.md` → `migration/from-re-frame-v1/` (setup). No stale API call-forms (`get-frame-db`/`dispatcher`/`subscriber`/`bound-fn`/bare-`configure`/`current-frame`-as-fn) existed in any application-facing skill — they were already on the renamed surface.

## Quality gates

- **No stale API names** (swept skills, excl. re-frame2-pair) — `git grep -nE "rf/get-frame-db|rf/dispatcher|rf/subscriber|\(rf/bound-fn|rf/configure[^!]|rf/current-frame[^-]"` over `re-frame2/ re-frame2-setup/ re-frame2-implementor/ re-frame2-improver/ re-frame2-pair-retro/ re-frame2-xray/ shared/` → **0 hits**. (Migration skill's 2 hits are the M-67 rename-doc column — expected/correct.)
- **Skills structural test** (CI gate) — `bb skills/shared/tests/retro_protocol_test.clj` → **29 tests, 44 assertions, 0 failures**.
- **Skill ↔ MCP drift** — `python scripts/check_skill_mcp_drift.py --verbose --ci` → exit 0, **no drift** (no `allowed-tools` touched).
- **Redirect anchors** — `python scripts/check_skill_redirect_anchors.py` → exit 0.
- **No broken intra-skill links** — both edits are prose (setup edit = path string; xray edit = `§021 §6` prose, no link).
- **mkdocs build --strict** — `docs/skills/*` proxies are in nav (hand-written summaries, not auto-generated from the edited leaves) → exit 0 (only pre-existing not-in-nav INFO warnings).

Fixed inline: re-frame2-setup, re-frame2-xray. Verified current (no change): re-frame2, re-frame2-implementor, re-frame2-improver, re-frame2-pair-retro, re-frame-migration. Follow-up beads filed: none.

Closes rf2-rzui8.