### PR TITLE
fix(xray): route get-source-coord through egress-value (rf2-j8b0u)

### DIFF
--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -711,7 +711,7 @@ framework's `:rf.size/*` namespaced opt keys.
 | `get-machine-list` | `get-machine-list` | `{:ok? true :machines <map> :count <n>}` | `rf/machines` — map keyed by machine-id. |
 | `get-issues` | `get-issues` | `{:ok? true :issues <vec> :count <n>}` | Projection over the trace buffer filtered to issue-tier op-types (`:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`). |
 | `get-handlers` | `get-handlers` | `{:ok? true :handlers <vec> :count <n>}` | `rf/registrations` per-kind. Optional `:kind` narrows to one of `:event :sub :fx :cofx :machine :flow :reg-machine :frame :view`. |
-| `get-source-coord` | `get-source-coord` | `{:ok? true :kind <kw> :id <any> :source-coord <map>}` | `rf/handler-meta` projected to `:source-coord`. |
+| `get-source-coord` | `get-source-coord` | `{:ok? true :kind <kw> :id <any> :source-coord <map>}` | `rf/handler-meta` projected to `:source-coord`, routed through `egress-value` (rf2-j8b0u — Spec 009's user-supplied `:rf.handler/source` override can stamp arbitrary values into the slot, so the accessor egresses unconditionally rather than judging per-read; `:include-sensitive?` / `:include-large?` opt back in). |
 
 ### Mutation band (3 accessors — write)
 

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -591,9 +591,20 @@
   view, machine state, sub) — projects the `:source-coord` slot off
   the handler's metadata.
 
+  The projected `:source-coord` routes through `egress-value` before
+  the off-box boundary (rf2-j8b0u), holding the runtime's
+  every-read-routes-through-wire-elision invariant with NO exceptions —
+  the safe path is the short path. Source-coord is structurally
+  `{:ns :file :line :column}` today, but Spec 009's user-supplied
+  `:rf.handler/source` override lets a code-gen pipeline stamp arbitrary
+  values into the source slot, so the accessor egresses unconditionally
+  rather than judging per-read whether THIS value happens to be safe.
+  `:include-sensitive?` / `:include-large?` carry the same trust-boundary
+  opt-in the sibling accessors (`get-handlers`) expose.
+
   Returns `{:ok? true :kind <kw> :id <any> :source-coord <map>}` or
   `{:ok? false :reason :no-source-coord ...}`."
-  [{:keys [kind id] :as _opts}]
+  [{:keys [kind id include-sensitive? include-large?] :as _opts}]
   (cond
     (nil? kind) {:ok? false :reason :missing-kind
                  :hint "Pass :kind <registrar-kind>."}
@@ -610,7 +621,9 @@
         {:ok?          true
          :kind         kind
          :id           id
-         :source-coord coord}))))
+         :source-coord (egress-value coord
+                                     {:include-sensitive? include-sensitive?
+                                      :include-large?     include-large?})}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Mutation band (3 accessors)

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -584,3 +584,53 @@
           "the registered handler appears in the projection")
       (is (= :rf/redacted (get-in rec [:meta :auth :password]))
           ":meta routes through egress-value — the sensitive slot is redacted"))))
+
+;; ---------------------------------------------------------------------------
+;; (14) get-source-coord routes :source-coord through egress-value — the
+;;      LAST direct-read accessor that bypassed the egress invariant
+;;      (rf2-j8b0u). Source-coord is structurally {:ns :file :line :column}
+;;      today, but Spec 009's user-supplied `:rf.handler/source` override
+;;      lets a code-gen pipeline stamp arbitrary values into the slot, so
+;;      the accessor egresses unconditionally rather than judging per-read.
+;; ---------------------------------------------------------------------------
+
+(defn- register-handler-with-sourcey-coord!
+  "Register an event whose registration metadata carries a `:source-coord`
+  whose value sits at the schema-declared sensitive path. We use the
+  registrar directly (not `reg-event-db`, whose macro emits its own
+  metadata) so the `:source-coord` slot we plant survives to
+  `rf/handler-meta` verbatim. `egress-value` walks the source-coord value
+  from its root and substitutes :rf/redacted for the sensitive path."
+  []
+  (registrar/register! :event :test/coord-with-secret
+                       {:handler-fn   (fn [db _] db)
+                        :source-coord {:auth {:password "leak-me"}}}))
+
+(deftest get-source-coord-redacts-sensitive-on-the-safe-default-path
+  (testing "`get-source-coord` routes the projected :source-coord through
+            egress-value (rf2-j8b0u) — a sensitive-declared slot in the
+            source-coord redacts on the bare (default, opt-out) call,
+            holding the every-read-routes-through-wire-elision invariant
+            with no exceptions"
+    (seed-sensitive-schema!)
+    (register-handler-with-sourcey-coord!)
+    (let [result (runtime/get-source-coord {:kind :event
+                                            :id   :test/coord-with-secret})]
+      (is (true? (:ok? result))
+          "the source-coord resolves for the registered handler")
+      (is (= :rf/redacted (get-in result [:source-coord :auth :password]))
+          ":source-coord routes through egress-value — the sensitive slot is redacted"))))
+
+(deftest get-source-coord-opts-back-in-to-sensitive
+  (testing "`get-source-coord` with `{:include-sensitive? true}` plumbs the
+            trust-boundary opt-in to the walker — the raw source-coord value
+            passes through (negative/opt-in coverage for rf2-j8b0u)"
+    (seed-sensitive-schema!)
+    (register-handler-with-sourcey-coord!)
+    (let [result (runtime/get-source-coord {:kind               :event
+                                            :id                 :test/coord-with-secret
+                                            :include-sensitive? true})]
+      (is (true? (:ok? result))
+          "the source-coord resolves for the registered handler")
+      (is (= "leak-me" (get-in result [:source-coord :auth :password]))
+          ":include-sensitive? true ⇒ the raw value passes through"))))


### PR DESCRIPTION
## Summary

`day8.re-frame2-xray.runtime/get-source-coord` was the ONLY direct-read accessor in `runtime.cljs` that returned its `:source-coord` value verbatim, bypassing the file`s every-read-routes-through-wire-elision invariant. `get-handlers` was specifically fixed (rf2-yl0v8) to route `:meta` through `egress-value`; this closes the last gap.

**Why it matters (boundary = MCP/AI read boundary):** source-coord is structurally `{:ns :file :line :column}` today so the practical leak risk is low, but Spec 009 documents a user-supplied `:rf.handler/source` override letting a code-gen pipeline stamp arbitrary values into the source slot. The egress invariant`s point is that the safe path is the short path -- with NO per-accessor judgement about whether THIS value happens to be safe. A single un-egress`d accessor is the drift rf2-rcogp / yl0v8 set out to eliminate.

## Changes

- **`tools/xray/src/day8/re_frame2_xray/runtime.cljs`** -- `get-source-coord` now routes the projected `:source-coord` through `egress-value` with `:include-sensitive?` / `:include-large?` plumbed exactly like the sibling `get-handlers` accessor (the model). Docstring documents the invariant + the `:rf.handler/source` rationale.
- **`tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs`** -- added a positive/negative test pair mirroring the `get-handlers` egress test: a sensitive-declared slot in the source-coord is elided on the default (opt-out) call, and passes through when the caller opts in with `{:include-sensitive? true}`.
- **`tools/xray/spec/API.md`** -- updated the `get-source-coord` Inspection-band row to match the documented every-direct-read-accessor egress invariant (the row previously described only `rf/handler-meta` projection, contradicting the section`s own "Every direct-read accessor routes returned values through one named off-box safe-egress fn" statement).

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` (node-test, includes the new accessor tests) | PASS -- 5256 tests / 17976 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` (browser) | PASS -- 16 scenarios, 0 failures (incl. "source coordinates and launch-mode availability"). One flaky failure of the unrelated "routes-epochs routing ladder" scenario on the first run did NOT reproduce on two re-runs with no code change; it is a known navigation-guard timing flake, not introduced by this change. |
| JVM xray (`clojure -M:test` in `tools/xray`) | PASS -- 1037 tests / 4169 assertions, 0 failures, 0 errors |

Xray-spec currency: the runtime read-accessor egress invariant lives in `tools/xray/spec/API.md` and is updated in this PR (the `get-source-coord` row).