### PR TITLE
fix(xray): re-seed :epoch-history on cross-frame focus-cascade click (rf2-q8hvw)

### DIFF
--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1349,8 +1349,34 @@ reducer so the App-db diff renders the diff body for the picked frame
 on the next render-frame, and the Views panel's `:has-cascade?`
 guard does not flip to `false` between picks.
 
+**Cross-frame L2-row click re-seed (rf2-q8hvw).** With the picker
+**untouched** the view scope is nil, so the L2 list spans EVERY frame's
+cascades (`matcher/filter-cascades-by-view-scope` is a no-op on a nil
+scope). Clicking a row for a cascade that settled in a NON-head frame
+must therefore resolve its settling epoch against THAT frame's ring —
+but `:rf.xray/epoch-history` is keyed on `:rf.xray/target-frame`, which
+is re-seeded only by the PICKER (`set-frame`) and the
+`:rf.xray/epoch-recorded` listener (which appends only when the
+recording frame IS the current target). So the three focus handlers
+that resolve an epoch-id from the slot —
+`:rf.xray/focus-cascade`, `:rf.xray/focus-epoch`,
+`:rf.xray/preview-cascade` — first call
+`spine/reseed-epoch-history-for-frame`, which re-keys
+`:rf.xray/target-frame` + `:rf.xray/epoch-history` onto the clicked
+cascade's frame (resolved via `rf/epoch-history`) BEFORE the epoch-id
+lookup runs. The re-seed is a no-op when the clicked frame already
+equals `:target-frame` (a same-frame click), and a no-op when the
+frame is unknown (nil). This makes the line above — "click-on-row
+picker-less navigation also rebinds" — true for a cross-frame click,
+not just a same-frame one: pre-fix the clicked cascade's epoch
+resolved to nil and the epoch-keyed panels (App-DB diff, Views'
+focused-cascade-pair, Machine Inspector) rendered empty/stale.
+
 Test gates: `spine_cljs_test.cljs` pins the `:target-frame` +
-`:epoch-history` writes on both arities of the reducer; the
+`:epoch-history` writes on both arities of `set-frame-reducer`, the
+`reseed-epoch-history-for-frame` no-op / re-key cases, and the
+end-to-end cross-frame `:rf.xray/focus-cascade` / `:rf.xray/focus-epoch`
+resolution (multi-frame, picker untouched); the
 `app_db_diff_cljs_test.cljs` + `views_subs_cljs_test.cljs` regression
 suites pin the panel render bodies post-reseed.
 

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -54,6 +54,7 @@
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
@@ -618,6 +619,63 @@
        (assoc :target-frame  frame-id
               :epoch-history (vec epoch-history-for-frame)))))
 
+(defn reseed-epoch-history-for-frame
+  "Pure reducer: re-key the Xray app-db's per-frame `:epoch-history`
+  slot (and the legacy `:target-frame` axis it is keyed on) onto
+  `frame-id`, supplying that frame's resolved ring contents as
+  `epoch-history-for-frame`.
+
+  ## rf2-q8hvw — cross-frame L2-row clicks must re-seed the slot
+
+  The `:epoch-history` slot is a SINGLE per-frame ring keyed on
+  `:target-frame`. It is seeded at mount from the boot head frame and
+  re-keyed only by the frame PICKER (`set-frame-reducer`) and the
+  `:rf.xray/epoch-recorded` listener (which appends only when the
+  recording frame IS the current `:target-frame`). With the picker
+  UNTOUCHED the L2 list shows cascades from EVERY frame (the cascades
+  sub is whole-buffer, frame-scoped only by the picker), so clicking a
+  row for a cascade that settled in a NON-head frame leaves the slot on
+  the boot frame's ring — `epoch-id-for-cascade` finds no match and the
+  clicked cascade's settling epoch resolves to nil. Every epoch-keyed
+  panel (App-DB diff, Views' focused-cascade-pair, Machine Inspector)
+  then renders empty/stale for a cascade that genuinely settled an
+  epoch. Sibling of the rf2-ug1r6 / rf2-thodq / rf2-lo28u
+  attribution-gap class.
+
+  The focus handlers (`:rf.xray/focus-cascade`, `:rf.xray/focus-epoch`,
+  `:rf.xray/preview-cascade`) call this BEFORE resolving the clicked
+  cascade's epoch-id so the resolution runs against the RIGHT frame's
+  ring. It only fires the write when `frame-id` differs from the
+  current `:target-frame` — a same-frame click is a no-op (the slot
+  already holds that frame's ring, kept fresh by `epoch-recorded`).
+  Unlike `set-frame-reducer` this DOES NOT touch the `:focus` slot:
+  the focus mutation (dispatch-id / mode / epoch-id) stays the
+  responsibility of `focus-cascade-reducer` et al.; this helper only
+  aligns the per-frame history axis the epoch resolver reads from.
+
+  The current target is the `:target-frame` slot, defaulting to
+  `defaults/default-target-frame` when absent — the same resolution
+  `:rf.xray/epoch-recorded` / `:rf.xray/set-target-frame` apply. This
+  matters because the `:epoch-history` slot can be seeded WITHOUT a
+  `:target-frame` write (the `:rf.xray/sync-epoch-history` panel-gallery
+  seed path): treating an absent slot as the default frame keeps a
+  same-default-frame click a no-op so it does NOT clobber a
+  directly-seeded history with an empty framework ring.
+
+  nil `frame-id` (the cascade's frame is unknown — e.g. the 3-arg
+  focus path) is a no-op: there is no frame to re-key onto, and
+  clobbering `:target-frame` to nil would orphan every per-frame sub.
+  The event handlers resolve `epoch-history-for-frame` via
+  `rf/epoch-history` at dispatch time, exactly as the picker path does."
+  [db frame-id epoch-history-for-frame]
+  (let [current-target (get db :target-frame defaults/default-target-frame)]
+    (if (or (nil? frame-id)
+            (= frame-id current-target))
+      db
+      (assoc db
+             :target-frame  frame-id
+             :epoch-history (vec epoch-history-for-frame)))))
+
 (defn preview-cascade-reducer
   "Pure reducer for `:rf.xray/preview-cascade <id>`. Sets `:previewing?
   true` and writes `:dispatch-id` transiently. nil `id` clears the
@@ -733,7 +791,14 @@
 
   (rf/reg-event-db :rf.xray/focus-cascade
     (fn [db [_ dispatch-id frame-id]]
-      (let [cascades       (db->cascades db)
+      ;; rf2-q8hvw — re-key `:epoch-history` onto the clicked cascade's
+      ;; frame BEFORE resolving its settling epoch. With the picker
+      ;; untouched the L2 list spans every frame, so a non-head-frame
+      ;; row's epoch lives outside the boot-frame slot; resolving against
+      ;; the stale slot yields nil. No-op when the frame is unchanged.
+      (let [db             (reseed-epoch-history-for-frame
+                             db frame-id (rf/epoch-history frame-id))
+            cascades       (db->cascades db)
             show-ungrouped? (db->show-ungrouped? db)
             head-id        (focusable-head-id cascades show-ungrouped?)
             epoch-id       (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
@@ -760,7 +825,18 @@
     ;; chip's click dispatches this event with the resolved
     ;; parent-epoch-id.
     (fn [db [_ epoch-id]]
-      (let [epoch-history   (db->epoch-history db)
+      ;; rf2-q8hvw — if the targeted epoch's record lives in a frame
+      ;; other than the slot's current `:target-frame`, re-key
+      ;; `:epoch-history` onto it BEFORE resolving the settling
+      ;; dispatch-id, so the resolution runs against the right frame's
+      ;; ring (the dispatch-id lookup walks `:epoch-history`). The frame
+      ;; is read off the record in the current slot; when the slot
+      ;; already holds that frame the re-seed is a no-op.
+      (let [record-frame    (:frame (some #(when (= epoch-id (:epoch-id %)) %)
+                                          (db->epoch-history db)))
+            db              (reseed-epoch-history-for-frame
+                             db record-frame (rf/epoch-history record-frame))
+            epoch-history   (db->epoch-history db)
             dispatch-id     (dispatch-id-for-epoch epoch-history epoch-id)
             cascades        (db->cascades db)
             show-ungrouped? (db->show-ungrouped? db)
@@ -808,7 +884,18 @@
       ;; preview (the App-DB before-image follows `:epoch-id`). nil
       ;; dispatch-id (preview-clear) resolves to nil and the reducer
       ;; leaves the committed epoch untouched.
-      (let [epoch-id (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
+      ;;
+      ;; rf2-q8hvw — preview carries only a dispatch-id, so resolve the
+      ;; previewed cascade's frame from the cascade list and re-key
+      ;; `:epoch-history` onto it BEFORE resolving the epoch-id. Same
+      ;; whole-buffer cross-frame hazard as `:rf.xray/focus-cascade`:
+      ;; hovering a non-head-frame row with the picker untouched would
+      ;; otherwise resolve the preview epoch against the wrong ring.
+      ;; No-op on preview-clear (nil dispatch-id → nil frame).
+      (let [frame-id (:frame (cascade-by-id (db->cascades db) dispatch-id))
+            db       (reseed-epoch-history-for-frame
+                       db frame-id (rf/epoch-history frame-id))
+            epoch-id (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
         (preview-cascade-reducer db dispatch-id epoch-id))))
 
   nil)

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -20,9 +20,12 @@
      re-frame reactive path."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.epoch :as epoch-api]
+            [re-frame.epoch.state :as epoch-state]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.panels.shared.focus-resolver :as focus-resolver]
             [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.spine :as spine]
@@ -1288,3 +1291,152 @@
       (is (= :c3 (:dispatch-id r)))
       (is (= :live (:mode r))
           "legacy click on head → :live (parity with focus-cascade event)"))))
+
+;; -------------------------------------------------------------------------
+;; (12) rf2-q8hvw — cross-frame L2-row click re-seeds :epoch-history
+;;
+;; Multi-frame app, picker UNTOUCHED. The L2 list spans every frame (the
+;; cascades sub is whole-buffer; frame-scoping only kicks in once the
+;; picker is touched). The `:epoch-history` slot is seeded at boot from
+;; the HEAD frame and re-keyed only by the frame PICKER + the
+;; `:rf.xray/epoch-recorded` listener (which appends only when the
+;; recording frame IS the current `:target-frame`). So clicking an L2
+;; row for a cascade that settled in a NON-head frame used to resolve
+;; its settling epoch against the wrong frame's ring → epoch-id nil →
+;; the App-DB diff / Views / Machine Inspector render empty/stale for a
+;; cascade that genuinely settled an epoch.
+;;
+;; This section drives the ACTUAL failing path (not a single-frame
+;; green test): it seeds two frames' framework rings, leaves the picker
+;; untouched (slot keyed on the boot head frame), then dispatches the
+;; real `:rf.xray/focus-cascade` event for a non-head-frame row and
+;; asserts the clicked cascade's epoch resolves end-to-end — through the
+;; spine focus sub, the App-DB-diff `:selected-epoch-id` shim, and the
+;; `find-epoch-record` lookup the App-DB diff panel runs against the
+;; re-seeded `:epoch-history` slot.
+;; -------------------------------------------------------------------------
+
+(defn- seed-framework-epoch-ring!
+  "Append epoch records into the framework's per-frame ring (the same
+  atom `rf/epoch-history` reads). Each record carries the literal
+  `:dispatch-id` slot `common/dispatch-id-of-epoch` reads, so the
+  spine's epoch-id ⇄ dispatch-id correlation resolves."
+  [frame-id records]
+  (doseq [{:keys [epoch-id dispatch-id]} records]
+    (epoch-state/record! {:frame       frame-id
+                          :epoch-id    epoch-id
+                          :dispatch-id dispatch-id})))
+
+(def ^:private multi-frame-cascades
+  "Head frame `:rf/default` (c3 is the global head); a second frame
+  `:cart-frame` carries its own cascade. Whole-buffer, oldest-first —
+  this is what the L2 list shows with the picker untouched."
+  [(cascade :c1 :rf/default)
+   (cascade :c2 :rf/default)
+   (cascade :cart-c9 :cart-frame)
+   (cascade :c3 :rf/default)])
+
+(defn- mount-multi-frame-picker-untouched! []
+  ;; Fresh framework rings — the runtime-reset fixture does NOT clear
+  ;; the epoch histories, so wipe them so this test owns the slot state.
+  (epoch-api/clear-history!)
+  (setup-xray-frame!)
+  ;; Populate BOTH frames' framework rings.
+  (seed-framework-epoch-ring! :rf/default  [{:epoch-id :e1 :dispatch-id :c1}
+                                            {:epoch-id :e2 :dispatch-id :c2}
+                                            {:epoch-id :e3 :dispatch-id :c3}])
+  (seed-framework-epoch-ring! :cart-frame  [{:epoch-id :cart-e9 :dispatch-id :cart-c9}])
+  ;; Whole-buffer cascade list (picker untouched).
+  (seed-cascades! multi-frame-cascades)
+  ;; Boot seeding: `:target-frame` + `:epoch-history` keyed on the head
+  ;; frame, exactly as `mount.cljs`'s first-mount hook does via
+  ;; `:rf.xray/set-target-frame`. The picker is NEVER touched after this.
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])))
+
+(deftest focus-cascade-cross-frame-click-reseeds-epoch-history-rf2-q8hvw
+  (testing "rf2-q8hvw — clicking an L2 row for a NON-head-frame cascade
+            (picker untouched) re-seeds :epoch-history onto that frame
+            and resolves the clicked cascade's settling epoch (not nil)"
+    (mount-multi-frame-picker-untouched!)
+    ;; Pre-condition guard: with the picker untouched the slot holds the
+    ;; HEAD frame's ring, and the cart cascade's epoch is absent from it.
+    ;; This is the state in which the pre-fix resolution returned nil.
+    (let [boot-history (rf/with-frame :rf/xray
+                         @(rf/subscribe [:rf.xray/epoch-history]))]
+      (is (= :rf/default (rf/with-frame :rf/xray
+                           @(rf/subscribe [:rf.xray/target-frame])))
+          "boot :target-frame is the head frame (picker untouched)")
+      (is (nil? (spine/epoch-id-for-cascade boot-history :cart-c9))
+          "RED baseline: cart cascade's epoch is NOT in the boot
+           head-frame ring — resolving against the un-reseeded slot
+           yields nil (the bug)"))
+    ;; The actual failing path: dispatch the real L2-row-click event for
+    ;; the non-head-frame cascade.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/focus-cascade :cart-c9 :cart-frame]))
+    ;; GREEN: the spine focus now carries the clicked cascade's epoch.
+    (let [r (focus-sub)]
+      (is (= :cart-c9 (:dispatch-id r)))
+      (is (= :cart-e9 (:epoch-id r))
+          "the clicked cross-frame cascade's settling epoch resolves —
+           the spine focus sub carries it (was nil pre-fix)"))
+    ;; The slot itself is now re-keyed onto the clicked cascade's frame.
+    (let [target  (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/target-frame]))
+          history (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/epoch-history]))]
+      (is (= :cart-frame target)
+          ":target-frame re-keyed onto the clicked cascade's frame")
+      (is (= [:cart-e9] (mapv :epoch-id history))
+          ":epoch-history is the clicked frame's ring contents"))
+    ;; End-to-end App-DB-diff facing surfaces resolve the clicked epoch.
+    (let [selected (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/selected-epoch-id]))
+          history  (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/epoch-history]))]
+      (is (= :cart-e9 selected)
+          "App-DB diff's :selected-epoch-id shim pivots to the clicked
+           cascade's epoch")
+      (is (= :cart-e9 (:epoch-id (focus-resolver/find-epoch-record selected history)))
+          "the App-DB diff's find-epoch-record lookup finds the clicked
+           epoch's record in the re-seeded slot — the panel renders the
+           right epoch's diff rather than an empty/stale state"))))
+
+(deftest focus-cascade-same-frame-click-leaves-slot-untouched-rf2-q8hvw
+  (testing "rf2-q8hvw — clicking a row in the CURRENT target frame is a
+            no-op for the slot (the re-seed only fires on a frame change);
+            the head frame's epoch resolves as before"
+    (mount-multi-frame-picker-untouched!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/focus-cascade :c2 :rf/default]))
+    (let [r       (focus-sub)
+          target  (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/target-frame]))
+          history (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/epoch-history]))]
+      (is (= :c2 (:dispatch-id r)))
+      (is (= :e2 (:epoch-id r))
+          "same-frame click resolves the head frame's epoch unchanged")
+      (is (= :rf/default target)
+          ":target-frame stays on the head frame — no spurious re-key")
+      (is (= [:e1 :e2 :e3] (mapv :epoch-id history))
+          ":epoch-history is still the head frame's full ring"))))
+
+(deftest focus-epoch-cross-frame-reseeds-epoch-history-rf2-q8hvw
+  (testing "rf2-q8hvw — :rf.xray/focus-epoch for an epoch whose record
+            lives in a non-target frame re-seeds the slot before
+            resolving the settling dispatch-id"
+    (mount-multi-frame-picker-untouched!)
+    ;; Seed the slot so the cart record is discoverable by the handler's
+    ;; record-frame lookup (the Epoch panel's parent-epoch chip resolves
+    ;; the epoch-id from a record already in view). Then the handler must
+    ;; re-key onto the cart frame and resolve against its full ring.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/sync-epoch-history
+                         [(epoch :e1 :c1) (epoch :e2 :c2)
+                          (assoc (epoch :cart-e9 :cart-c9) :frame :cart-frame)
+                          (epoch :e3 :c3)]])
+      (rf/dispatch-sync [:rf.xray/focus-epoch :cart-e9]))
+    (let [r       (focus-sub)
+          target  (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/target-frame]))]
+      (is (= :cart-e9 (:epoch-id r))
+          "focus-epoch pins the cross-frame epoch")
+      (is (= :cart-c9 (:dispatch-id r))
+          "the settling dispatch-id resolves from the re-seeded ring")
+      (is (= :cart-frame target)
+          ":target-frame re-keyed onto the epoch's frame"))))


### PR DESCRIPTION
## Summary

A multi-frame app with the frame picker **untouched** shows L2 cascade rows from *every* frame (the cascades sub is whole-buffer; the view scope is nil so `filter-cascades-by-view-scope` is a no-op). The Xray `:epoch-history` slot, however, is a **single per-frame ring keyed on `:target-frame`** — seeded at mount from the boot head frame and re-keyed only by the frame **picker** (`set-frame-reducer`) and the `:rf.xray/epoch-recorded` listener (which appends only when the recording frame *is* the current target).

So clicking an L2 row for a cascade that settled in a **non-head frame** fired `:rf.xray/focus-cascade <dispatch-id> <frame-id>`, whose handler resolved the settling epoch-id via `epoch-id-for-cascade` against the *boot head frame's* ring. The clicked cross-frame cascade's epoch was absent from that ring, so epoch-id resolved to **nil** and the epoch-keyed panels (App-DB diff, Views' focused-cascade-pair, Machine Inspector) rendered empty/stale for a cascade that genuinely settled an epoch. Reachable on first contact (picker untouched) in any multi-frame app. Sibling of the rf2-ug1r6 / rf2-thodq / rf2-lo28u attribution-gap class.

This also makes Spec 018 §8's existing claim — "click-on-row picker-less navigation also rebinds" — actually true for a *cross-frame* click, not just a same-frame one.

## The fix

Factor the picker's `:target-frame` + `:epoch-history` re-key into a shared pure helper `spine/reseed-epoch-history-for-frame` (no copy-paste), and call it from the three focus handlers that resolve an epoch-id off the slot — **`:rf.xray/focus-cascade`**, **`:rf.xray/focus-epoch`**, **`:rf.xray/preview-cascade`** — *before* the resolution, re-keying onto the clicked cascade's frame (resolved via `rf/epoch-history`, exactly as the picker path does).

- **No-op when the clicked frame already equals the effective target.** The effective target defaults an absent `:target-frame` to `defaults/default-target-frame` (matching `:rf.xray/epoch-recorded` / `:rf.xray/set-target-frame`), so a direct `:rf.xray/sync-epoch-history` panel-gallery seed (which writes the slot without a `:target-frame`) is **not** clobbered by a same-default-frame click.
- **No-op for a nil frame** (the cascade's frame is unknown — clobbering `:target-frame` to nil would orphan every per-frame sub).
- Unlike `set-frame-reducer` it does **not** touch the `:focus` slot — the focus mutation (dispatch-id / mode / epoch-id) stays the responsibility of `focus-cascade-reducer` et al.; this helper only aligns the per-frame history axis the epoch resolver reads from.

`focus-epoch` reads the targeted epoch's frame off its record in the current slot then re-seeds + re-resolves; `preview-cascade` resolves the previewed cascade's frame from the cascade list (it carries only a dispatch-id).

## Reproduce-then-fix test (the ACTUAL failing path)

New multi-frame, picker-untouched CLJS unit tests in `spine_cljs_test.cljs` (§12):

- `focus-cascade-cross-frame-click-reseeds-epoch-history-rf2-q8hvw` — seeds two frames' framework rings, sets boot `:target-frame` to the head frame, then asserts a **RED baseline** (`epoch-id-for-cascade boot-history :cart-c9` resolves to nil — the bug), dispatches the real `:rf.xray/focus-cascade :cart-c9 :cart-frame`, and asserts **GREEN** end-to-end: the spine focus sub carries `:cart-e9`, the slot re-keys onto `:cart-frame`, the App-DB-diff `:selected-epoch-id` shim pivots, and the App-DB diff's `find-epoch-record` lookup finds the clicked epoch's record.
- `focus-cascade-same-frame-click-leaves-slot-untouched-rf2-q8hvw` — the same-frame no-op case.
- `focus-epoch-cross-frame-reseeds-epoch-history-rf2-q8hvw` — the `:rf.xray/focus-epoch` re-seed path.

## Spec currency

`tools/xray/spec/018-Event-Spine.md` §8 (Multi-frame panel-focus invariant P) documents the cross-frame L2-row-click re-seed and updates the test-gate note.

## Out of scope (follow-up candidate)

`:rf.xray/select-dispatch-id` (in `registry.cljs`, the legacy spine-shim entry used by machine-inspector / cancellation panels) reads the slot via the same `get db :epoch-history` and has the identical cross-frame hazard. The bead scoped the fix to the three `spine.cljs` handlers; this one lives in a different file (registry.cljs) and is left untouched here — worth a follow-up bead.

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` | **PASS** — 5257 tests / 17987 assertions, 0 failures, 0 errors (cold build, 0 warnings) |
| JVM xray (`clojure -M:test` in `tools/xray`) | **PASS** — 1037 tests / 4169 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` | **PASS** — 16 scenarios, 0 failures, 13 matrix rows (exit 0) |

Closes rf2-q8hvw.
