### PR TITLE
fix(xray): gate snapshot-from-rings for sensitive frame-bound events (rf2-0ax6f)

### DIFF
--- a/tools/xray/spec/013-Trace-Consumer.md
+++ b/tools/xray/spec/013-Trace-Consumer.md
@@ -146,6 +146,33 @@ event, so toggling it via `(xray-config/configure!
 {:rf.privacy/show-sensitive? true})` takes effect on the next trace
 event without re-registering the listener. The default is `false`.
 
+### Read-side gate on the snapshot (rf2-0ax6f)
+
+The listener-body gate above stops a sensitive event from entering
+Xray's *secondary* (frameless) ring and from triggering a mirror
+sync — but it CANNOT stop the framework's per-frame rings from
+retaining it. The framework's `push-to-ring!` retains every emitted
+event with no `:sensitive?` check (the ring is a faithful record of
+what the runtime emitted); the per-frame gate is a Xray-read concern,
+not a framework-ring concern. A sensitive **frame-bound** event is
+therefore retained in its frame's ring even though the listener body
+declined to push it, and a *later* non-sensitive event's mirror sync
+reads the ring back — pulling the retained sensitive event into the
+snapshot.
+
+So `snapshot-from-rings` (§Snapshot below) applies the SAME
+`suppress-sensitive?` gate on the read: while `:rf.privacy/show-
+sensitive?` is `false`, every retained-but-sensitive event is
+scrubbed from the snapshot regardless of frame-bound vs frameless
+origin. The two gates are genuinely symmetric — the listener gate
+keeps sensitive events out of the secondary ring + counter path; the
+read gate keeps retained-in-per-frame-ring sensitive events out of
+every downstream surface (`:trace-buffer`, L2, the trace panel, the
+app-db diff, the cascade export, and the MCP/snapshot surface). The
+read gate covers the steady-state read while the flag stays `false`;
+the [retroactive scrub](#retroactive-scrub-on-toggle-off) covers the
+true → false transition by clearing the rings wholesale.
+
 ### The suppressed-events counter
 
 The counter is keyed `frame-id → count` with a `:global` bucket for
@@ -206,6 +233,11 @@ frame's flat trace events (via `(re-frame.trace.tooling/trace-buffer
 fid {:flat true})`) and concatenates the frameless ring's contents,
 sorted by `:id`. The merged vector lands in Xray's app-db
 `:trace-buffer` slot via a `:rf.xray/sync-trace-buffer` dispatch.
+
+`snapshot-from-rings` applies the `suppress-sensitive?` read-side
+gate (see [§Read-side gate](#read-side-gate-on-the-snapshot-rf2-0ax6f))
+to the merged vector, so retained-but-sensitive events never reach
+`:trace-buffer` while `:rf.privacy/show-sensitive?` is `false`.
 
 ## Reactivity — microtask-coalesced mirror sync
 

--- a/tools/xray/src/day8/re_frame2_xray/trace_collector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/trace_collector.cljs
@@ -181,6 +181,26 @@
   alpha posture: drop unconditionally; tool-frame introspection is a
   separate feature surface if needed (rf2-43koh consumer substrate).
 
+  ## Privacy gate (rf2-0ax6f)
+
+  The framework's per-frame rings RETAIN every emitted event with no
+  `:sensitive?` check (`re-frame.trace.tooling/push-to-ring!`) — the
+  ring is a faithful record of what the runtime emitted. Xray's
+  documented policy (Spec 009 §Privacy) is to SUPPRESS THE WHOLE EVENT
+  while `:rf.privacy/show-sensitive?` is false, because non-marked
+  envelope slots can structurally reveal a redacted value. So the read
+  side — not the ring — is where the gate must live for frame-bound
+  events: `collect-trace!` already drops sensitive events on the
+  listener path, but it cannot stop the per-frame ring from retaining
+  them, and a later non-sensitive event's mirror-sync would otherwise
+  pull the retained sensitive event back into the snapshot. We apply
+  `config/suppress-sensitive?` to BOTH the per-frame events and the
+  frameless ring here so the snapshot is scrubbed regardless of
+  frame-bound vs frameless origin — genuinely symmetric with the
+  listener gate. The retroactive scrub (toggle true → false) still
+  clears the rings wholesale; this gate covers the steady-state read
+  while the flag is false.
+
   Public so `mount.cljs` can drive the first-mount seed
   synchronously alongside the `:rf.xray/sync-trace-buffer` dispatch,
   bypassing the microtask coalescer (the seed must commit before the
@@ -198,8 +218,15 @@
         ;; :id only in pathological cases (host produced an envelope
         ;; without one); fall back to ##Inf so they sort to the tail.
         all         (into per-frame frameless)]
-    (into [] (sort-by (fn [ev] (or (:id ev) js/Number.MAX_SAFE_INTEGER))
-                       all))))
+    (into []
+          ;; Privacy gate (rf2-0ax6f): scrub retained-but-sensitive
+          ;; events on the read side so the snapshot never leaks an
+          ;; event the listener gate already suppressed. No-op when
+          ;; :rf.privacy/show-sensitive? is true (opt-in unmask) or the
+          ;; event is non-sensitive.
+          (remove config/suppress-sensitive?)
+          (sort-by (fn [ev] (or (:id ev) js/Number.MAX_SAFE_INTEGER))
+                   all))))
 
 (defn refresh-trace-rings!
   "Synchronously snapshot every per-frame ring + the frameless secondary
@@ -253,8 +280,11 @@
        `re-frame.trace/emit!` source-side gate covers most of these,
        but the listener belt-and-braces against any that slipped past.
     2. Apply the privacy gate — `:sensitive?` events bump the
-       suppressed counter without entering any ring; the framework's
-       own ring honours the gate symmetrically.
+       suppressed counter and skip the frameless secondary ring + the
+       mirror-sync request. The framework's per-frame ring does NOT
+       honour the gate (it retains every emitted event); the matching
+       read-side gate in `snapshot-from-rings` scrubs those retained
+       events so the two halves are genuinely symmetric (rf2-0ax6f).
     3. Frameless events feed the Xray-side secondary ring (per the
        rf2-3g9nw D2=a ruling).
     4. Frame-bound events: no Xray-side push needed — the framework's

--- a/tools/xray/test/day8/re_frame2_xray/sensitive_trace_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/sensitive_trace_cljs_test.cljc
@@ -21,6 +21,8 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test    :refer-macros [deftest is testing use-fixtures]])
             [day8.re-frame2-xray.config :as config]
+            #?(:cljs [re-frame.frame :as frame])
+            #?(:cljs [re-frame.trace :as trace])
             #?(:cljs [day8.re-frame2-xray.trace-collector :as trace-collector])))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -153,13 +155,18 @@
 
 ;; ---- (4) collect-trace! default-suppress + opt-in pass-through ----------
 
-;; Test envelopes deliberately omit `:frame` / `:tags :frame` so the
+;; These envelopes deliberately omit `:frame` / `:tags :frame` so the
 ;; collector routes them to the frameless secondary ring (per rf2-3g9nw
-;; D2=a). Frame-bound events would expect the framework's per-frame
-;; rings to retain them — but that path requires a real `emit!` to
-;; populate, which this unit test does not drive. For the sensitive-
-;; flag gate the frameless-vs-frame-bound distinction is irrelevant —
-;; the gate fires above the ring split.
+;; D2=a). For the LISTENER-path gate the frameless-vs-frame-bound
+;; distinction is irrelevant — `collect-trace!` drops the sensitive
+;; event above the ring split either way.
+;;
+;; The frame-bound path is the OTHER half of the matrix and lives in
+;; the §(7) tests below: a real `trace/emit!` populates the framework's
+;; per-frame ring (which retains EVERY event with no `:sensitive?`
+;; check), and the gate that matters there is the read-side scrub in
+;; `snapshot-from-rings` (rf2-0ax6f). Keeping both halves here pins the
+;; symmetry the `collect-trace!` docstring now claims.
 
 (defn- non-sensitive-event []
   {:op-type :rf.event :operation :rf.event/dispatched
@@ -333,3 +340,103 @@
        (config/set-show-sensitive! false) ; redundant; default is false
        (is (= 2 (count (trace-collector/buffer-for-test)))
            "redundant set-show-sensitive! false must not clear the buffer"))))
+
+;; ---- (7) frame-bound sensitive events — the snapshot-read gate (rf2-0ax6f)
+;;
+;; The §(4) tests drive FRAMELESS events through `collect-trace!` — that
+;; path is gated by the listener-side `suppress-sensitive?` check before
+;; the secondary ring. But a FRAME-BOUND sensitive event takes a
+;; different route: the framework's `trace/emit!` retains it in the
+;; per-frame cascade ring (`re-frame.trace.tooling/push-to-ring!`) with
+;; NO `:sensitive?` check — `collect-trace!` only declines to *push*
+;; it, it cannot un-retain it. `snapshot-from-rings` reads those rings
+;; back directly, so without a read-side gate a later non-sensitive
+;; event's mirror-sync would pull the retained sensitive event into the
+;; buffer (rf2-0ax6f leak). These tests drive a REAL emit → per-frame
+;; ring → `snapshot-from-rings` (`buffer-for-test`) and pin that the
+;; sensitive event is scrubbed on the read when the flag is false, and
+;; passes through only when opted in. This is the missing half of the
+;; matrix (mirrors the rf2-lo28u "green test routed around the gap"
+;; lesson — the assertion hits the ACTUAL failing path, the per-frame
+;; ring read, not the already-covered listener path).
+
+#?(:cljs
+   (def ^:private host-frame ::sensitive-host))
+
+#?(:cljs
+   (defn- emit-frame-bound!
+     "Drive a REAL `re-frame.trace/emit!` into `host-frame`'s per-frame
+     ring. A `:frame` + `:rf.trace/dispatch-id` in `tags` is what
+     `push-to-ring!` keys on to retain the event (frameless emits skip
+     the ring per the B3 ruling). `:sensitive?` in `tags` is hoisted to
+     a top-level `:sensitive? true` stamp by `build-event` — the same
+     stamp a schema-sensitive handler scope produces at runtime. The
+     `dispatch-id` keys the cascade slot; distinct ids = distinct
+     cascades so the count assertions are unambiguous."
+     [dispatch-id sensitive?]
+     (trace/emit! :rf.event :rf.event/run-end
+                  (cond-> {:frame host-frame
+                           :rf.trace/dispatch-id dispatch-id
+                           :rf.trace/event-id :user/login}
+                    sensitive? (assoc :sensitive? true)))))
+
+#?(:cljs
+   (defn- host-ring-buffer
+     "The snapshot every consumer sees, restricted to `host-frame`'s
+     events — `buffer-for-test` merges all frames + the frameless ring;
+     filter to the host frame so the assertions don't depend on
+     incidental cross-frame noise."
+     []
+     (filterv #(= host-frame (get-in % [:tags :frame]))
+              (trace-collector/buffer-for-test))))
+
+#?(:cljs
+   (defn- with-host-frame [test-fn]
+     ;; Register the host frame so `frame/frame-ids` (which
+     ;; `snapshot-from-rings` walks) includes it, run the body, then
+     ;; drop it so the next test starts clean. We `dissoc` from the
+     ;; registry directly rather than `destroy-frame!` — this suite has
+     ;; no installed substrate adapter, and destroy fires the dispatch /
+     ;; teardown machinery a bare frame doesn't need. `reset-for-test!`
+     ;; (in the outer fixture) already clears the per-frame rings.
+     (frame/reg-frame host-frame {})
+     (try (test-fn)
+          (finally (swap! frame/frames dissoc host-frame)))))
+
+#?(:cljs
+   (deftest snapshot-suppresses-sensitive-frame-bound-event-by-default
+     (with-host-frame
+       (fn []
+         (testing "a sensitive FRAME-BOUND event retained in the per-frame
+                   ring is scrubbed from the snapshot when the flag is false
+                   (rf2-0ax6f — the bug: it leaked through snapshot-from-rings)"
+           ;; A non-sensitive event lands first — the leak surfaces
+           ;; precisely when a *later* benign event's mirror-sync reads
+           ;; the ring back and drags the retained sensitive cascade along.
+           (emit-frame-bound! 1 false)
+           (emit-frame-bound! 2 true)   ; sensitive — retained in the ring
+           (let [buf (host-ring-buffer)]
+             (is (= 1 (count buf))
+                 "only the non-sensitive event reaches the snapshot — the
+                  sensitive frame-bound event MUST NOT leak through
+                  snapshot-from-rings while show-sensitive? is false")
+             (is (not-any? :sensitive? buf)
+                 "no sensitive event survives the read-side gate")
+             (is (every? #(= 1 (get-in % [:tags :rf.trace/dispatch-id])) buf)
+                 "the surviving event is the non-sensitive cascade #1")))))))
+
+#?(:cljs
+   (deftest snapshot-passes-sensitive-frame-bound-event-when-opted-in
+     (with-host-frame
+       (fn []
+         (testing "with :rf.privacy/show-sensitive? true the snapshot
+                   surfaces the retained sensitive frame-bound event"
+           (config/configure! {:rf.privacy/show-sensitive? true})
+           (emit-frame-bound! 1 false)
+           (emit-frame-bound! 2 true)
+           (let [buf (host-ring-buffer)]
+             (is (= 2 (count buf))
+                 "opted-in caller sees BOTH the non-sensitive and the
+                  sensitive frame-bound event in the snapshot")
+             (is (some :sensitive? buf)
+                 "the sensitive event passes through under the opt-in")))))))


### PR DESCRIPTION
@
## Summary

P1 privacy bug: the `:sensitive?` privacy gate in `trace-collector/collect-trace!` only covered the listener/frameless path. A sensitive **frame-bound** event bumped the suppressed counter and returned without pushing — but the framework per-frame ring still **retained** it (`re-frame.trace.tooling/push-to-ring!` has no `:sensitive?` check; the ring is a faithful record of what the runtime emitted). `snapshot-from-rings` read those rings back via `trace-buffer {:flat true}` with no gate, so any later non-sensitive event's mirror-sync (or the mount seed, or a frame-picker change) pulled the retained sensitive event into Xray's app-db `:trace-buffer` slot and every surface downstream of it — L2, the trace panel, the app-db diff, the cascade export, and the MCP/snapshot surface.

Xray's documented policy (Spec 009 §Privacy) is to **suppress the whole event** — not merely redact marked payload paths — because non-marked envelope slots can structurally reveal a redacted value. The leak defeated that policy for the entire frame-bound path, which had **zero test coverage** (the existing suite deliberately exercises only frameless envelopes).

## The fix

Gate at the single `snapshot-from-rings` read: apply `config/suppress-sensitive?` to the merged snapshot so **all** retained-but-sensitive events are scrubbed regardless of frame-bound vs frameless origin while `:rf.privacy/show-sensitive?` is `false`. The listener-path gate is unchanged; the two halves are now genuinely symmetric. Dropped the misleading "the framework's own ring honours the gate symmetrically" comment (it does not — the framework ring has no sensitive gate). No change to the framework ring (`tooling.cljc`); the gate lives on the Xray read side per the bead ruling.

## Reproduce-then-fix test

Added the missing half of the matrix to `sensitive_trace_cljs_test.cljc` (§7): two CLJS tests drive a **real** `re-frame.trace/emit!` into a registered frame's per-frame ring (frame-bound, `:sensitive? true` hoisted by `build-event`), then read it back via `buffer-for-test` (`snapshot-from-rings`):

- `snapshot-suppresses-sensitive-frame-bound-event-by-default` — the sensitive event MUST NOT reach the snapshot when the flag is `false`; only the non-sensitive cascade survives.
- `snapshot-passes-sensitive-frame-bound-event-when-opted-in` — both events pass through under `:rf.privacy/show-sensitive? true`.

Verified the suppress test goes **red** with the gate removed (the sensitive `dispatch-id 2` event leaked into the snapshot), then **green** with the fix — the assertion hits the actual failing path (the per-frame ring read), not a route around it.

## Spec currency

Updated `tools/xray/spec/013-Trace-Consumer.md`: added a §Read-side gate subsection under §Privacy gate and a note in §Snapshot. Top-level `spec/009` already specs the suppress-whole-event policy and is owned by another in-flight worker — not touched. See the note below on whether 009 needs a clarifying line.

## Quality gates

| Gate | Result |
| --- | --- |
| `npm run test:cljs` (node-runtime CLJS, cold build) | PASS — 5256 tests, 17977 assertions, 0 failures / 0 errors (includes the new frame-bound tests) |
| JVM xray (`clojure -M:test` in `tools/xray`) | PASS — 1037 tests, 4169 assertions, 0 failures / 0 errors |
| `npm run test:xray-feature-gate` | PASS — 16 scenarios, 0 failures (after confirming pre-existing flakes; see note) |
| Red-check (gate removed) | Confirmed RED — sensitive frame-bound event leaks into the snapshot |

**Feature-gate flake note:** initial runs showed 1–2 intermittent failures in the `static mode chrome and chord` and `routes-epochs routing ladder` scenarios, both unrelated to this change (my diff touches only the sensitive-snapshot gate). Confirmed flaky by: (a) a clean `origin/main` baseline worktree also exhibits the same `http-server exited unexpectedly (code=1)` infrastructure crash and reached 0 failures, and (b) the failures were non-deterministic across three branch runs (2 → 1 → 0). Final branch run: 0 failures.
@