### PR TITLE
fix(xray): retire :selected-epoch-id shim + re-seed select-dispatch-id cross-frame (rf2-uy7nz + rf2-o1c3r)

### DIFF
--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -144,14 +144,12 @@ Spec: [`002-Time-Travel.md`](./002-Time-Travel.md).
 
 | Sub | Returns | Notes |
 |---|---|---|
-| `:rf.xray/selected-epoch-id` | Epoch-id or `nil` (= newest, no scrub in flight). | Per §The passive-scrubbing rule — scrubbing rebases panels; rewind is opt-in. |
-| `:rf.xray/selected-epoch-record` | `:rf/epoch-record` or `nil`. | Resolved from history + selected-id. |
+| `:rf.xray/selected-epoch-record` | `:rf/epoch-record` or `nil`. | Resolved from history + the spine focus epoch (`:rf.xray/focus-epoch-id`). |
 | `:rf.xray/last-restore-failure` | `{:frame-id :epoch-id}` or `nil`. | Most recent failed confirmed rewind, captured by `:rf.xray.fx/restore-epoch`; exists so the scrubber can render an inline notice without scanning trace events. |
 | `:rf.xray/restore-epoch-tick` | Integer tick, default `0`. | Reactivity anchor for `:rf.xray/last-restore-failure`; bumped after each restore attempt because the fx writes the result to a module-scope atom outside app-db. |
 | `:rf.xray/pin-store` | `{frame-id [<pin> ...]}` map. | Lock 4 session-scoped per §Pinned snapshots — never persisted to disk. |
 | `:rf.xray/pinned-snapshots` | Vector of pins for current target-frame. | Decoupled from pin-store so unrelated frames' pins don't re-render the view. |
 | `:rf.xray/time-travel-label-input` | Current pin-label input string (defaults to `""`). | Drives the scrubber's pin-label entry without flooding the trace bus on each keystroke (the matching event is `:rf.trace/no-emit? true`). |
-| `:rf.xray/time-travel` | Composite — `{:target-frame :history :selected-epoch-id :selected-record :selected-index :pins :chip-states :cap-reached?}`. | Mirrors the per-panel composite pattern. `chip-states` runs chip-state projection over each pin against current history. |
 
 ### Events
 
@@ -167,14 +165,14 @@ Spec: [`002-Time-Travel.md`](./002-Time-Travel.md).
 | `:rf.xray/reset-to-epoch` | `[_ epoch-id]` | `event-fx` — emits `{:fx [[:rf.xray.fx/restore-epoch {:frame-id ... :epoch-id ...}]]}`. The confirmed-rewind branch (per spec §rewind = explicit). |
 | `:rf.xray/reset-to-pinned` | `[_ epoch-id]` | `event-fx` — emits `{:fx [[:rf.xray.fx/reset-frame-db! {:frame-id ... :app-db-value ...}]]}`. Per spec §Why reset-frame-db! not restore-epoch — pins hold the value directly. |
 | `:rf.xray/set-target-frame` | `[_ frame-id]` | Sets the active target frame for the scrubber and refreshes `:epoch-history` from `(rf/epoch-history target)`. `nil` resets to the default target. Mirrored by `core/set-target-frame!` from the public CLJS API. |
-| `:rf.xray/sync-epoch-history` | `[_ history]` | `:rf.trace/no-emit? true`. Replaces the cached `:epoch-history` with the supplied vector AND focuses the LATEST seeded epoch — stamps the spine `[:focus :epoch-id]` (surfaced by `compose-focus` when no live cascade head is present) plus the `:selected-epoch-id` shim to `(:epoch-id (peek history))`; an empty `history` clears both. Pumped from the depth-shrink path so the scrubber reflects the trimmed history without an explicit re-read, and from history-only seeds (the panel-gallery Story variants) where no trace buffer exists for the trace-driven auto-follow to act on — without the head-focus the focus-keyed Dynamic panels (App-db, Epoch, …) would render their "nothing focused" empty-state (rf2-mdpfz). When a live trace buffer IS also seeded, `compose-focus`'s LIVE auto-follow re-derives `:epoch-id` from the head cascade; this stamp is authoritative only for history-only seeds. |
+| `:rf.xray/sync-epoch-history` | `[_ history]` | `:rf.trace/no-emit? true`. Replaces the cached `:epoch-history` with the supplied vector AND focuses the LATEST seeded epoch — stamps the spine `[:focus :epoch-id]` (surfaced by `compose-focus` when no live cascade head is present) to `(:epoch-id (peek history))`; an empty `history` clears it. Pumped from the depth-shrink path so the scrubber reflects the trimmed history without an explicit re-read, and from history-only seeds (the panel-gallery Story variants) where no trace buffer exists for the trace-driven auto-follow to act on — without the head-focus the focus-keyed Dynamic panels (App-db, Epoch, …) would render their "nothing focused" empty-state (rf2-mdpfz). When a live trace buffer IS also seeded, `compose-focus`'s LIVE auto-follow re-derives `:epoch-id` from the head cascade; this stamp is authoritative only for history-only seeds. |
 | `:rf.xray/time-travel-set-label-input` | `[_ text]` | `:rf.trace/no-emit? true`. Updates `:label-input` per keystroke without flooding the trace bus; `nil` normalises to `""`. |
 
 ### Effects
 
 | Fx | Args | Behaviour |
 |---|---|---|
-| `:rf.xray.fx/restore-epoch` | `{:frame-id :epoch-id}` | Calls `rf/restore-epoch`, writes `{:ok? :frame-id :epoch-id}` to the module-scope restore result atom, dispatches `:rf.xray/bump-restore-epoch-tick`, and clears `:rf.xray/selected-epoch-id` on failure. The indirection lets test fixtures stub the write and lets Xray surface failed confirmed rewinds inline. |
+| `:rf.xray.fx/restore-epoch` | `{:frame :epoch-id}` | Calls `rf/restore-epoch`; on failure dispatches `:rf.xray/reset-flash-failed` so the inline tab-ribbon flash surfaces the failed confirmed rewind (the framework also emits a structured `:rf.epoch/*` trace row the Trace panel shows). The fx indirection lets test fixtures stub the framework call. |
 | `:rf.xray.fx/reset-frame-db!` | `{:frame-id :app-db-value}` | Thin delegation to `rf/reset-frame-db!`. |
 
 ## App-DB Diff panel

--- a/tools/xray/src/day8/re_frame2_xray/epoch.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/epoch.cljs
@@ -7,7 +7,8 @@
   target-frame plumbing is consumed by live panels:
 
   - `panels.app-db-diff-subs` reads `:rf.xray/epoch-history`,
-    `:rf.xray/selected-epoch-id`, `:rf.xray/target-frame`.
+    `:rf.xray/target-frame`, and pivots on the spine focus epoch via
+    `:rf.xray/focus-epoch-id`.
   - `panels.machine-inspector` reads `:rf.xray/epoch-history`,
     `:rf.xray/target-frame`, `:rf.xray/target-frame-db`.
   - `panels.reactive-panel-subs` reads `:rf.xray/epoch-history` to
@@ -45,10 +46,6 @@
   (rf/reg-sub :rf.xray/epoch-history
     (fn [db _query]
       (get db :epoch-history [])))
-
-  (rf/reg-sub :rf.xray/selected-epoch-id
-    (fn [db _query]
-      (get db :selected-epoch-id)))
 
   ;; rf2-hga49 — transient `reset-to-event` failure flash. Holds a short
   ;; message string when a `rf/restore-epoch` rewind fails (epoch aged
@@ -145,14 +142,14 @@
   ;; deliberately fallback-free per rf2-yng0y), so seeding history is
   ;; not enough — focus MUST carry the epoch-id.
   ;;
-  ;; We stamp BOTH the spine `[:focus :epoch-id]` (what `compose-focus`
+  ;; We stamp the spine `[:focus :epoch-id]` (what `compose-focus`
   ;; surfaces as `:rf.xray/focus` `:epoch-id` when no cascade head is
-  ;; present — i.e. history-only seeds) AND the `:selected-epoch-id`
-  ;; shim slot, mirroring `:rf.xray/select-epoch`'s dual-write. The
-  ;; LATEST epoch is the HEAD of the oldest-first ring — `(peek hist)`
-  ;; — matching the natural "show the most recent unless the operator
-  ;; clicks an earlier row" debugging UX (the same head-bias the
-  ;; focus-resolver's rf2-h0120 head-fallback encodes). An empty
+  ;; present — i.e. history-only seeds), the single source of truth the
+  ;; focus-keyed panels follow (rf2-uy7nz retired the `:selected-epoch-
+  ;; id` mirror). The LATEST epoch is the HEAD of the oldest-first ring
+  ;; — `(peek hist)` — matching the natural "show the most recent unless
+  ;; the operator clicks an earlier row" debugging UX (the same head-bias
+  ;; the focus-resolver's rf2-h0120 head-fallback encodes). An empty
   ;; history clears focus so a no-epoch seed renders its empty-state.
   ;;
   ;; When a live trace buffer IS also seeded (the chrome story seeds
@@ -166,22 +163,19 @@
       (let [history    (vec history)
             latest-id  (:epoch-id (peek history))]
         (cond-> (assoc db :epoch-history history)
-          (some? latest-id) (-> (assoc-in [:focus :epoch-id] latest-id)
-                                (assoc :selected-epoch-id latest-id))
-          (nil? latest-id)  (-> (update :focus (fnil dissoc {}) :epoch-id)
-                                (dissoc :selected-epoch-id))))))
+          (some? latest-id) (assoc-in [:focus :epoch-id] latest-id)
+          (nil? latest-id)  (update :focus (fnil dissoc {}) :epoch-id)))))
 
-  ;; `:rf.xray/select-epoch` — spine shim (rf2-adve5). Owns the
-  ;; `:selected-epoch-id` slot that App-DB Diff's `selected-epoch-*`
-  ;; subs read, AND writes through the spine's `[:focus :epoch-id]`
-  ;; slot so the `:rf.xray/focus` sub the spec/018 surfaces consume
-  ;; rebinds when the user picks an epoch. Symmetric with
-  ;; `:rf.xray/select-dispatch-id` (in registry.cljs post rf2-5gl5r).
+  ;; `:rf.xray/select-epoch` — spine shim (rf2-adve5). Writes the
+  ;; spine's `[:focus :epoch-id]` slot — the single source of truth that
+  ;; the spec/018 `:rf.xray/focus` sub surfaces (and that App-DB Diff's
+  ;; `selected-epoch-*` subs rebind on via `:rf.xray/focus-epoch-id`)
+  ;; when the user picks an epoch (rf2-uy7nz retired the `:selected-
+  ;; epoch-id` mirror). Symmetric with `:rf.xray/select-dispatch-id` (in
+  ;; registry.cljs post rf2-5gl5r).
   (rf/reg-event-db :rf.xray/select-epoch
     (fn [db [_ epoch-id]]
-      (-> db
-          (assoc :selected-epoch-id epoch-id)
-          (assoc-in [:focus :epoch-id] epoch-id))))
+      (assoc-in db [:focus :epoch-id] epoch-id)))
 
   ;; `:rf.xray/reset-to-epoch` (rf2-hga49) — the UI rewind affordance.
   ;; The tab ribbon's `Reset` button dispatches this with the OBSERVED

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -389,7 +389,7 @@
     :<- [:rf.xray/selected-epoch-flow-writes]
     :<- [:rf.xray/focus-epoch-id]
     (fn [[target db diff-triples focused-path focused-hits
-          history redacted-modified-count flow-writes selected-epoch-id]
+          history redacted-modified-count flow-writes focus-epoch-id]
          _query]
       (let [{:keys [non-reserved]} (h/partition-reserved
                                      (or diff-triples []))]
@@ -409,7 +409,8 @@
          ;; header with `[fx :db]` / `[flow :flow-id]` / mixed.
          :flow-writes               (or flow-writes [])
          :diff-triples              (or diff-triples [])
-         ;; rf2-5kfxe.2 — surfaced so the renderer can key each
-         ;; section by epoch-id, forcing a React re-mount per cascade
-         ;; and replaying the diff-flash CSS animation.
-         :selected-epoch-id         selected-epoch-id}))))
+         ;; rf2-5kfxe.2 — the focused epoch-id (from the spine focus via
+         ;; `:rf.xray/focus-epoch-id`), surfaced so consumers can key
+         ;; each section by epoch-id, forcing a React re-mount per
+         ;; cascade and replaying the diff-flash CSS animation.
+         :focus-epoch-id            focus-epoch-id}))))

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -459,9 +459,21 @@
     ;; It writes through the spine via the same reducer the spec-018
     ;; `:rf.xray/focus-cascade` event uses. Relocated from the retired
     ;; event-detail panel — multi-panel consumer, lives here.
+    ;;
+    ;; rf2-o1c3r — re-key `:epoch-history` onto the selected cascade's
+    ;; frame BEFORE resolving its settling epoch, exactly as the sibling
+    ;; `:rf.xray/focus-cascade` handler does (rf2-q8hvw). With the picker
+    ;; untouched the `:epoch-history` slot is keyed on the boot head
+    ;; frame, so selecting a dispatch-id in a NON-head frame would
+    ;; otherwise resolve its epoch against the wrong frame's ring →
+    ;; epoch-id nil → the epoch-keyed panels strand on an empty/stale
+    ;; state. The cross-frame ring is resolved via `rf/epoch-history` at
+    ;; dispatch time; the re-seed is a no-op when the frame is unchanged.
     (rf/reg-event-db :rf.xray/select-dispatch-id
       (fn [db [_ dispatch-id frame-id]]
-        (let [history  (get db :epoch-history [])
+        (let [db       (spine/reseed-epoch-history-for-frame
+                         db frame-id (rf/epoch-history frame-id))
+              history  (get db :epoch-history [])
               epoch-id (spine/epoch-id-for-cascade history dispatch-id)
               head-id  (spine/focusable-head-id (spine/db->cascades db))]
           (spine/focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))))

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -472,13 +472,11 @@
     ;; select event above (rf2-5gl5r).
     (rf/reg-event-db :rf.xray/clear-selected-dispatch-id
       (fn [db _event]
-        (-> db
-            (dissoc :selected-epoch-id)
-            (update :focus (fnil assoc {})
-                    :dispatch-id nil
-                    :epoch-id    nil
-                    :mode        :live
-                    :previewing? false))))
+        (update db :focus (fnil assoc {})
+                :dispatch-id nil
+                :epoch-id    nil
+                :mode        :live
+                :previewing? false)))
 
     ;; ---- L2 relative-time anchor (rf2-vbbq0 / rf2-0s2at) ----------
     ;;
@@ -779,10 +777,10 @@
     ;; Cross-cutting epoch primitives (rf2-qy0nu — extracted from the
     ;; deleted Time Travel panel). MUST install before app-db-diff +
     ;; views + machine-inspector — their composites :<- onto
-    ;; `:rf.xray/epoch-history` / `:rf.xray/target-frame` /
-    ;; `:rf.xray/selected-epoch-id`. Registration order is cosmetic
-    ;; (re-frame resolves :<- lazily), but the top-down dependency read
-    ;; is clearer.
+    ;; `:rf.xray/epoch-history` / `:rf.xray/target-frame` (and pivot on
+    ;; the spine focus epoch via `:rf.xray/focus-epoch-id`). Registration
+    ;; order is cosmetic (re-frame resolves :<- lazily), but the top-down
+    ;; dependency read is clearer.
     (epoch/install!)
     (open-in-editor/install!)
     (palette/install!)

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -39,18 +39,19 @@
   `:dispatch-id` are always derived from the current cascade vector —
   never stale.
 
-  ## `:selected-epoch-id` shim slot
+  ## No mirror slots — focus is the single source of truth
 
-  Spec 018 §6 collapses per-panel selection into the spine. The one
-  surviving mirror is `:selected-epoch-id`: the spine reducers stamp it
-  alongside `:focus`'s `:epoch-id` so the App-DB-diff / Views panels can
-  follow the focused epoch through `epoch.cljs`'s `:selected-epoch-id`
-  sub → `app_db_diff_subs`. The cross-panel `:rf.xray/event-detail`
-  composite (relocated to `registry.cljs` post rf2-5gl5r — the retired
-  Event/Handler panel originally owned it) reads focus directly off
-  the spine, so the former `:selected-dispatch-id` / `:selected-
-  dispatch` mirror slots are gone — there is no longer a dual-write
-  for them."
+  Spec 018 §6 collapses per-panel selection into the spine. There are
+  no mirror slots: the App-DB-diff / Views panels follow the focused
+  epoch through `[:focus :epoch-id]` (surfaced by `:rf.xray/focus` →
+  `:rf.xray/focus-epoch-id` → `app_db_diff_subs`), and the cross-panel
+  `:rf.xray/event-detail` composite (relocated to `registry.cljs` post
+  rf2-5gl5r — the retired Event/Handler panel originally owned it)
+  reads focus directly off the spine. The former `:selected-dispatch-id`
+  / `:selected-dispatch` / `:selected-epoch-id` mirror slots are all
+  gone (the last, `:selected-epoch-id`, was retired by rf2-uy7nz once
+  every production consumer had migrated to the spine focus epoch via
+  rf2-70tkv) — there is no longer any dual-write."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-xray.config :as config]
@@ -309,9 +310,9 @@
   scrubbing) stayed wired into the focus map even after the user
   resumed LIVE — every panel that pivots on focus `:epoch-id`
   (Views' focused-cascade-pair, Machine Inspector's focused-event
-  lens, App-DB diff's selected-epoch chain via the shimmed
-  `:selected-epoch-id` slot) stayed frozen on the old epoch while
-  `:dispatch-id` correctly tracked head. The 3-arity (legacy / pre-
+  lens, App-DB diff's selected-epoch chain via `[:focus :epoch-id]`)
+  stayed frozen on the old epoch while `:dispatch-id` correctly tracked
+  head. The 3-arity (legacy / pre-
   rf2-70tkv callers, test rigs that don't have the history handy)
   preserves the original behaviour: `:epoch-id` stays as stored. The
   reactive `:rf.xray/focus` sub in `install!` uses the 4-arity so
@@ -383,9 +384,9 @@
         ;; `:rf.xray/focus` sub path). Mirrors the `eff-id` auto-
         ;; track above so every panel that pivots on focus
         ;; `:epoch-id` (Views, Machine Inspector, App-DB diff via
-        ;; the `:selected-epoch-id` shim) lights up the head cascade
-        ;; on every new arrival instead of staying pinned to a stale
-        ;; stored value. Retro / LIVE-paused / unsupplied-history
+        ;; `[:focus :epoch-id]`) lights up the head cascade on every
+        ;; new arrival instead of staying pinned to a stale stored
+        ;; value. Retro / LIVE-paused / unsupplied-history
         ;; preserve the stored slot — those modes have explicit
         ;; pinning semantics.
         ;;
@@ -420,11 +421,10 @@
 
 (defn focus-cascade-reducer
   "Pure reducer for the `:rf.xray/focus-cascade <id>` event. Writes
-  `:dispatch-id` into the `:focus` slot, picks the spine `:mode`,
+  `:dispatch-id` into the `:focus` slot, picks the spine `:mode`, and
   stamps `:epoch-id` (the cascade's settling epoch primary key per
-  spec/018 §6 Spine events), and mirrors `:epoch-id` into the
-  `:selected-epoch-id` shim slot the App-DB-diff / Views panels follow
-  (epoch.cljs sub → app_db_diff_subs).
+  spec/018 §6 Spine events) — which the App-DB-diff / Views panels
+  follow through `:rf.xray/focus` → `:rf.xray/focus-epoch-id`.
 
   ## Mode selection (rf2-xzzih)
 
@@ -456,22 +456,14 @@
                           :epoch-id    epoch-id
                           :mode        mode
                           :previewing? false)
-       frame-id   (assoc-in [:focus :frame] frame-id)
-       ;; `:selected-epoch-id` is the live App-DB-diff shim slot
-       ;; (epoch.cljs sub → app_db_diff_subs) — App-DB / Views follow the
-       ;; spine's focused epoch through it. The dispatch-id slots are gone:
-       ;; downstream consumers read focus off the `:rf.xray/event-detail`
-       ;; composite (relocated to `registry.cljs` post rf2-5gl5r when
-       ;; the Event/Handler panel retired), not a mirrored db slot.
-       true       (assoc :selected-epoch-id epoch-id)))))
+       frame-id   (assoc-in [:focus :frame] frame-id)))))
 
 (defn focus-step-reducer
   "Pure reducer for `:rf.xray/focus-cascade-prev` / `-next`. Steps
   the `:dispatch-id` through the cascade vector by `delta` (-1 or
   +1), resolves the cascade's settling `:epoch-id` from
-  `epoch-history` (per spec/018 §6 Spine events), mirrors it into the
-  `:selected-epoch-id` shim slot, and flips mode based on the step's
-  outcome — stepping
+  `epoch-history` (per spec/018 §6 Spine events) into the `:focus`
+  slot, and flips mode based on the step's outcome — stepping
   back from head → :retro; stepping forward back to head → :live (the
   user has scrubbed home).
 
@@ -537,26 +529,20 @@
                             :mode new-mode
                             :previewing? false
                             :paused? false)
-           frame-id (assoc-in [:focus :frame] frame-id)
-           ;; `:selected-epoch-id` is the live App-DB-diff shim (see
-           ;; focus-cascade-reducer); the dispatch-id slots are gone.
-           true     (assoc :selected-epoch-id epoch-id)))))))
+           frame-id (assoc-in [:focus :frame] frame-id)))))))
 
 (defn follow-head-reducer
   "Pure reducer for `:rf.xray/follow-head`. Snaps the spine to LIVE,
-  clears the pinned id (`:dispatch-id nil` means 'track head'), and
-  clears `:paused?` so the LIVE buffer flow resumes. Also clears the
-  `:selected-epoch-id` shim slot so the App-DB / Views panels return to
-  their LIVE-tracking landing views."
+  clears the pinned id (`:dispatch-id nil` means 'track head'), clears
+  `:epoch-id` so the App-DB / Views panels return to their LIVE-tracking
+  landing views, and clears `:paused?` so the LIVE buffer flow resumes."
   [db]
-  (-> db
-      (update :focus (fnil assoc {})
-              :dispatch-id nil
-              :epoch-id    nil
-              :mode :live
-              :paused? false
-              :previewing? false)
-      (dissoc :selected-epoch-id)))
+  (update db :focus (fnil assoc {})
+          :dispatch-id nil
+          :epoch-id    nil
+          :mode :live
+          :paused? false
+          :previewing? false))
 
 (defn toggle-live-pause-reducer
   "Pure reducer for `:rf.xray/toggle-live-pause`. Toggles `:paused?`
@@ -770,8 +756,8 @@
   ;; `:epoch-id` stayed wired to the stored slot (last :rf.xray/
   ;; select-epoch / focus-cascade / focus-step write), and every
   ;; panel pivoting on focus `:epoch-id` (Views, Machine Inspector,
-  ;; App-DB diff via the `:selected-epoch-id` shim) stayed frozen
-  ;; on the old epoch while `:dispatch-id` correctly tracked head.
+  ;; App-DB diff via `[:focus :epoch-id]`) stayed frozen on the old
+  ;; epoch while `:dispatch-id` correctly tracked head.
   (rf/reg-sub :rf.xray/focus
     :<- [:rf.xray/focus-slot]
     :<- [:rf.xray/cascades]
@@ -856,8 +842,7 @@
                           :epoch-id   epoch-id
                           :mode       :retro
                           :previewing? false)
-            frame-id (assoc-in [:focus :frame] frame-id)
-            true     (assoc :selected-epoch-id epoch-id))))))
+            frame-id (assoc-in [:focus :frame] frame-id))))))
 
   (rf/reg-event-db :rf.xray/follow-head
     (fn [db _event]

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/sync_epoch_focus_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/sync_epoch_focus_e2e_cljs_test.cljs
@@ -8,9 +8,10 @@
   event focused.'.
 
   The fix makes `:rf.xray/sync-epoch-history` ALSO focus the LATEST
-  seeded epoch (stamping `[:focus :epoch-id]` + the `:selected-epoch-id`
-  shim). This test reproduces the gallery scenario exactly — a
-  history-only seed with NO trace buffer — and asserts:
+  seeded epoch (stamping `[:focus :epoch-id]` — the single source of
+  truth; rf2-uy7nz retired the former `:selected-epoch-id` mirror).
+  This test reproduces the gallery scenario exactly — a history-only
+  seed with NO trace buffer — and asserts:
 
     1. the spine `:rf.xray/focus` carries the latest seeded epoch-id;
     2. the App-db panel's `:rf.xray/app-db-current+diff` resolves the

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -187,9 +187,9 @@
    :rf.xray/hidden-by-filters
    :rf.xray/focus
    ;; rf2-70tkv — App-DB diff subs pivot off the spine's focus
-   ;; `:epoch-id` (which auto-tracks head in LIVE mode) instead of
-   ;; the legacy `:selected-epoch-id` slot (which only updates on
-   ;; explicit user clicks). This sub is the thin projection seam.
+   ;; `:epoch-id` (which auto-tracks head in LIVE mode). This sub is
+   ;; the thin projection seam. (rf2-uy7nz retired the legacy
+   ;; `:selected-epoch-id` mirror slot that this superseded.)
    :rf.xray/focus-epoch-id
    :rf.xray/focus-slot
    ;; rf2-iwwou — hardened L1 frame-switcher slot. Public contract
@@ -296,7 +296,6 @@
    ;; rf2-39n8h discovered — selected-epoch composites: per-flow writes
    ;; lens + redacted-modified-count surface for the App-DB diff panel.
    :rf.xray/selected-epoch-flow-writes
-   :rf.xray/selected-epoch-id
    :rf.xray/selected-epoch-record
    :rf.xray/selected-epoch-redacted-modified-count
    :rf.xray/selected-machine-id
@@ -1246,16 +1245,18 @@
       (is (nil? (:dispatch-id @(rf/subscribe [:rf.xray/focus])))))))
 
 (deftest event-select-epoch-passive-scrub
-  (testing ":rf.xray/select-epoch sets selected-epoch-id (passive scrub)"
+  (testing ":rf.xray/select-epoch pins the spine focus epoch (passive
+            scrub) — rf2-uy7nz: the single source of truth is
+            `[:focus :epoch-id]`, surfaced by `:rf.xray/focus-epoch-id`"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/select-epoch :e-7])
-      (is (= :e-7 @(rf/subscribe [:rf.xray/selected-epoch-id])))
-      ;; nil resets the slot — equivalent to the dropped explicit
+      (is (= :e-7 @(rf/subscribe [:rf.xray/focus-epoch-id])))
+      ;; nil resets the focus epoch — equivalent to the dropped explicit
       ;; `:rf.xray/clear-selected-epoch` event (deleted with rf2-qy0nu
       ;; alongside the Time Travel panel).
       (rf/dispatch-sync [:rf.xray/select-epoch nil])
-      (is (nil? @(rf/subscribe [:rf.xray/selected-epoch-id]))))))
+      (is (nil? @(rf/subscribe [:rf.xray/focus-epoch-id]))))))
 
 ;; rf2-ad7zx.9 — `event-toggle-issues-severity-roundtrip` and
 ;; `event-clear-issues-filters` were removed with the Issues panel's
@@ -1440,12 +1441,13 @@
       (is (= :event (:selected-tab xray-db)))
       ;; rf2-ee38b.2 — :rf.xray/select-dispatch-id writes focus to the
       ;; spine `:focus` slot (the dead :selected-dispatch-id mirror is
-      ;; gone); :select-epoch writes the surviving :selected-epoch-id shim.
+      ;; gone); rf2-uy7nz — :select-epoch writes the spine `[:focus
+      ;; :epoch-id]` (the :selected-epoch-id mirror is retired too).
       (is (= 1 (get-in xray-db [:focus :dispatch-id])))
-      (is (= :e (:selected-epoch-id xray-db)))
+      (is (= :e (get-in xray-db [:focus :epoch-id])))
       (is (nil? (:selected-tab default-db)))
       (is (nil? (get-in default-db [:focus :dispatch-id])))
-      (is (nil? (:selected-epoch-id default-db))))))
+      (is (nil? (get-in default-db [:focus :epoch-id]))))))
 
 ;; ---- (9) edge cases over a dormant frame --------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -1443,3 +1443,67 @@
           "the settling dispatch-id resolves from the re-seeded ring")
       (is (= :cart-frame target)
           ":target-frame re-keyed onto the epoch's frame"))))
+
+(deftest select-dispatch-id-cross-frame-reseeds-epoch-history-rf2-o1c3r
+  (testing "rf2-o1c3r — :rf.xray/select-dispatch-id (the legacy
+            machine-inspector / trace / mcp-server entry point) for a
+            cascade that settled in a NON-head frame re-seeds
+            `:epoch-history` onto that frame BEFORE resolving the
+            settling epoch, exactly as the sibling :rf.xray/focus-cascade
+            handler does (rf2-q8hvw). Drives the ACTUAL failing path —
+            picker untouched, slot keyed on the boot head frame — and
+            asserts the clicked dispatch's epoch resolves (not nil)."
+    (mount-multi-frame-picker-untouched!)
+    ;; RED baseline: with the picker untouched the slot holds the HEAD
+    ;; frame's ring, and the cart cascade's epoch is absent from it — the
+    ;; pre-fix `(get db :epoch-history [])` read resolved nil here.
+    (let [boot-history (rf/with-frame :rf/xray
+                         @(rf/subscribe [:rf.xray/epoch-history]))]
+      (is (= :rf/default (rf/with-frame :rf/xray
+                           @(rf/subscribe [:rf.xray/target-frame])))
+          "boot :target-frame is the head frame (picker untouched)")
+      (is (nil? (spine/epoch-id-for-cascade boot-history :cart-c9))
+          "RED baseline: the cart cascade's epoch is NOT in the boot
+           head-frame ring — resolving against the un-reseeded slot
+           yields nil (the o1c3r bug)"))
+    ;; The actual failing path: dispatch the real :rf.xray/select-dispatch-id
+    ;; event for the non-head-frame cascade.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id :cart-c9 :cart-frame]))
+    ;; GREEN: the spine focus now carries the clicked dispatch's epoch.
+    (let [r (focus-sub)]
+      (is (= :cart-c9 (:dispatch-id r)))
+      (is (= :cart-e9 (:epoch-id r))
+          "the clicked cross-frame dispatch's settling epoch resolves —
+           the spine focus sub carries it (was nil pre-fix)"))
+    ;; The slot itself is re-keyed onto the clicked cascade's frame, and
+    ;; the App-DB-diff-facing projection follows.
+    (let [target      (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/target-frame]))
+          history     (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/epoch-history]))
+          focus-epoch (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/focus-epoch-id]))]
+      (is (= :cart-frame target)
+          ":target-frame re-keyed onto the clicked cascade's frame")
+      (is (= [:cart-e9] (mapv :epoch-id history))
+          ":epoch-history is the clicked frame's ring contents")
+      (is (= :cart-e9 focus-epoch)
+          "App-DB diff's :rf.xray/focus-epoch-id projection pivots to the
+           clicked dispatch's epoch — the panel renders the right epoch's
+           diff rather than an empty/stale state"))))
+
+(deftest select-dispatch-id-same-frame-leaves-slot-untouched-rf2-o1c3r
+  (testing "rf2-o1c3r — selecting a dispatch-id in the CURRENT target
+            frame is a no-op for the slot (the re-seed only fires on a
+            frame change); the head frame's epoch resolves as before"
+    (mount-multi-frame-picker-untouched!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id :c2 :rf/default]))
+    (let [r       (focus-sub)
+          target  (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/target-frame]))
+          history (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/epoch-history]))]
+      (is (= :c2 (:dispatch-id r)))
+      (is (= :e2 (:epoch-id r))
+          "same-frame select resolves the head frame's epoch unchanged")
+      (is (= :rf/default target)
+          ":target-frame stays on the head frame — no spurious re-key")
+      (is (= [:e1 :e2 :e3] (mapv :epoch-id history))
+          ":epoch-history is still the head frame's full ring"))))

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -12,10 +12,11 @@
      re-frame machinery needed.
   2. `compose-focus` derives `:head?` + the effective `:dispatch-id`
      correctly across LIVE / RETRO / paused / evicted-cascade states.
-  3. The `:selected-epoch-id` shim — `:rf.xray/select-dispatch-id` and
-     `:rf.xray/focus-cascade` write `:focus` AND mirror the epoch into
-     `:selected-epoch-id` (the slot App-DB-diff / Views follow). Spine
-     consumers read `:rf.xray/focus`.
+  3. Focus is the single source of truth (rf2-uy7nz) —
+     `:rf.xray/select-dispatch-id` and `:rf.xray/focus-cascade` write
+     the spine `:focus` slot (carrying `:epoch-id`); App-DB-diff / Views
+     follow it through `:rf.xray/focus` → `:rf.xray/focus-epoch-id`.
+     There is no mirror slot.
   4. The registered sub composes the slot + cascades via the standard
      re-frame reactive path."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
@@ -261,7 +262,7 @@
           "global head wins when picker is unset"))))
 
 ;; -------------------------------------------------------------------------
-;; (3) focus-cascade-reducer — writes :focus + legacy shim
+;; (3) focus-cascade-reducer — writes :focus (single source of truth)
 ;; -------------------------------------------------------------------------
 
 (deftest focus-cascade-reducer-writes-focus-slot
@@ -271,13 +272,16 @@
     (is (= :retro (get-in r [:focus :mode])))
     (is (= :rf/default (get-in r [:focus :frame])))))
 
-(deftest focus-cascade-reducer-writes-epoch-shim
-  (testing "rf2-ee38b.2 — the only surviving shim slot is
-            :selected-epoch-id (App-DB-diff / Views follow it). The dead
-            :selected-dispatch-id / :selected-dispatch mirror slots are
-            gone — the Event panel reads focus off the spine composite."
+(deftest focus-cascade-reducer-writes-epoch-into-focus
+  (testing "rf2-uy7nz — the reducer stamps the settling epoch into the
+            spine `[:focus :epoch-id]` slot (the single source of truth
+            App-DB-diff / Views follow via :rf.xray/focus-epoch-id). No
+            mirror slot is written — the dead :selected-epoch-id /
+            :selected-dispatch-id / :selected-dispatch slots are gone."
     (let [r (spine/focus-cascade-reducer {} :c2 :rf/default 77)]
-      (is (= 77 (:selected-epoch-id r)) ":selected-epoch-id mirrors :focus epoch")
+      (is (= 77 (get-in r [:focus :epoch-id])) ":focus :epoch-id carries the epoch")
+      (is (not (contains? r :selected-epoch-id))
+          "dead :selected-epoch-id mirror slot is no longer written")
       (is (not (contains? r :selected-dispatch-id))
           "dead :selected-dispatch-id slot is no longer written")
       (is (not (contains? r :selected-dispatch))
@@ -325,15 +329,14 @@
 ;; -------------------------------------------------------------------------
 
 (deftest follow-head-reducer-snaps-to-live
-  (let [db {:focus {:dispatch-id :c1 :mode :retro :paused? true}
-            :selected-epoch-id 5}
+  (let [db {:focus {:dispatch-id :c1 :epoch-id 5 :mode :retro :paused? true}}
         r  (spine/follow-head-reducer db)]
     (is (nil? (get-in r [:focus :dispatch-id]))
         "follow-head clears :dispatch-id so compose-focus snaps to head")
     (is (= :live (get-in r [:focus :mode])))
     (is (false? (get-in r [:focus :paused?])))
-    (is (nil? (:selected-epoch-id r))
-        ":selected-epoch-id shim cleared in lockstep")))
+    (is (nil? (get-in r [:focus :epoch-id]))
+        ":focus :epoch-id cleared in lockstep")))
 
 ;; -------------------------------------------------------------------------
 ;; (6) toggle-live-pause-reducer
@@ -733,8 +736,8 @@
 ;; "compute `:epoch-id` from cascades". The reducer takes a resolved
 ;; epoch-id (the event handler in `install!` resolves it from the
 ;; Xray `:epoch-history` slot via `epoch-id-for-cascade`), then
-;; stamps both the `:focus :epoch-id` slot and the legacy
-;; `:selected-epoch-id` shim slot the App-db diff panel reads.
+;; stamps the `:focus :epoch-id` slot — the single source of truth the
+;; App-db diff panel reads via :rf.xray/focus-epoch-id (rf2-uy7nz).
 ;; -------------------------------------------------------------------------
 
 (defn- epoch
@@ -813,9 +816,9 @@
 ;; wrote :focus :epoch-id (any click on an L2 row, scrubbing in Time
 ;; Travel, the :rf.xray/select-epoch chip in the diff), every panel
 ;; pivoting on focus :epoch-id (Views' focused-cascade-pair, Machine
-;; Inspector's focused-event lens, App-DB Diff via the
-;; :selected-epoch-id shim slot) stayed wired to the stale epoch
-;; while :dispatch-id correctly tracked head.
+;; Inspector's focused-event lens, App-DB Diff via [:focus :epoch-id])
+;; stayed wired to the stale epoch while :dispatch-id correctly tracked
+;; head.
 ;;
 ;; Fix: a 4-arity `compose-focus` accepts `epoch-history` and re-
 ;; derives :epoch-id from the head cascade in LIVE+unpaused mode,
@@ -914,13 +917,13 @@
            any stale stored id"))))
 
 (deftest focus-cascade-reducer-4-arg-writes-epoch-id
-  (testing "the 4-arg reducer writes :epoch-id into the :focus slot AND
-            the :selected-epoch-id shim slot — App-db pivots
-            from L2-list clicks once this lands (rf2-ak3ty)"
+  (testing "the 4-arg reducer writes :epoch-id into the :focus slot —
+            App-db pivots from L2-list clicks via :rf.xray/focus-epoch-id
+            once this lands (rf2-ak3ty); rf2-uy7nz: no mirror slot"
     (let [r (spine/focus-cascade-reducer {} :c2 :rf/default :e2)]
       (is (= :e2 (get-in r [:focus :epoch-id])))
-      (is (= :e2 (:selected-epoch-id r))
-          "the slot the App-db panel reads pivots in lockstep")
+      (is (not (contains? r :selected-epoch-id))
+          "no :selected-epoch-id mirror slot is written")
       (is (= :c2 (get-in r [:focus :dispatch-id]))))))
 
 (deftest focus-cascade-reducer-3-arg-leaves-epoch-id-nil
@@ -929,7 +932,7 @@
             surfaces won't pivot until a 4-arg call lands"
     (let [r (spine/focus-cascade-reducer {} :c2 :rf/default)]
       (is (nil? (get-in r [:focus :epoch-id])))
-      (is (nil? (:selected-epoch-id r))))))
+      (is (not (contains? r :selected-epoch-id))))))
 
 (deftest focus-cascade-event-resolves-epoch-id-from-history
   (testing "the registered :rf.xray/focus-cascade event resolves
@@ -949,42 +952,42 @@
            load-bearing prereq for rf2-w15el (Views) and the
            App-db pivot fix"))))
 
-(deftest focus-cascade-event-writes-selected-epoch-id-legacy-slot
-  (testing "App-db's :rf.xray/selected-epoch-id sub pivots on L2-list
-            click — proves the spine writes through the legacy shim
-            so App-db (and Time-Travel highlight) rebind from a row
-            click without any per-panel change"
+(deftest focus-cascade-event-pivots-focus-epoch-id
+  (testing "App-db's :rf.xray/focus-epoch-id sub pivots on L2-list
+            click — proves the spine writes the focused epoch into
+            `[:focus :epoch-id]` so App-db rebinds from a row click
+            without any per-panel change (rf2-uy7nz: single source of
+            truth, no mirror slot)"
     (setup-xray-frame!)
     (seed-cascades! fixture-cascades)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/sync-epoch-history
                          [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]])
       (rf/dispatch-sync [:rf.xray/focus-cascade :c1 :rf/default]))
-    (let [legacy (rf/with-frame :rf/xray
-                   @(rf/subscribe [:rf.xray/selected-epoch-id]))]
-      (is (= :e1 legacy)
-          "App-db's :selected-epoch-id sub rebinds to the focused
+    (let [focus-epoch (rf/with-frame :rf/xray
+                        @(rf/subscribe [:rf.xray/focus-epoch-id]))]
+      (is (= :e1 focus-epoch)
+          "App-db's :rf.xray/focus-epoch-id sub rebinds to the focused
            cascade's epoch — pivot now works from L2 list clicks"))))
 
 (deftest focus-step-reducer-4-arg-writes-epoch-id
-  (testing "step events resolve :epoch-id for the new dispatch-id"
+  (testing "step events resolve :epoch-id for the new dispatch-id into
+            the spine `[:focus :epoch-id]` slot (rf2-uy7nz: no mirror)"
     (let [db       {:focus {:dispatch-id :c3 :mode :live}}
           history  [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]
           r        (spine/focus-step-reducer db fixture-cascades history -1)]
       (is (= :c2 (get-in r [:focus :dispatch-id])))
       (is (= :e2 (get-in r [:focus :epoch-id])))
-      (is (= :e2 (:selected-epoch-id r))))))
+      (is (not (contains? r :selected-epoch-id))))))
 
-(deftest follow-head-reducer-clears-selected-epoch-id
-  (testing "follow-head clears the App-db legacy slot in lockstep with
-            the dispatch-id slot — the panel returns to its landing
-            view"
-    (let [db {:focus             {:dispatch-id :c1 :epoch-id :e1
-                                  :mode :retro}
-              :selected-epoch-id :e1}
+(deftest follow-head-reducer-clears-focus-epoch-id
+  (testing "follow-head clears the focus epoch in lockstep with the
+            dispatch-id slot — the App-db panel returns to its landing
+            view (rf2-uy7nz: single source of truth at [:focus :epoch-id])"
+    (let [db {:focus {:dispatch-id :c1 :epoch-id :e1 :mode :retro}}
           r  (spine/follow-head-reducer db)]
       (is (nil? (get-in r [:focus :epoch-id])))
-      (is (nil? (:selected-epoch-id r))))))
+      (is (not (contains? r :selected-epoch-id))))))
 
 ;; -------------------------------------------------------------------------
 ;; (11) rf2-fzbrw — no aggregate-all-events state
@@ -1311,9 +1314,9 @@
 ;; untouched (slot keyed on the boot head frame), then dispatches the
 ;; real `:rf.xray/focus-cascade` event for a non-head-frame row and
 ;; asserts the clicked cascade's epoch resolves end-to-end — through the
-;; spine focus sub, the App-DB-diff `:selected-epoch-id` shim, and the
-;; `find-epoch-record` lookup the App-DB diff panel runs against the
-;; re-seeded `:epoch-history` slot.
+;; spine focus sub, the App-DB-diff `:rf.xray/focus-epoch-id` projection,
+;; and the `find-epoch-record` lookup the App-DB diff panel runs against
+;; the re-seeded `:epoch-history` slot.
 ;; -------------------------------------------------------------------------
 
 (defn- seed-framework-epoch-ring!
@@ -1389,11 +1392,11 @@
       (is (= [:cart-e9] (mapv :epoch-id history))
           ":epoch-history is the clicked frame's ring contents"))
     ;; End-to-end App-DB-diff facing surfaces resolve the clicked epoch.
-    (let [selected (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/selected-epoch-id]))
+    (let [selected (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/focus-epoch-id]))
           history  (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/epoch-history]))]
       (is (= :cart-e9 selected)
-          "App-DB diff's :selected-epoch-id shim pivots to the clicked
-           cascade's epoch")
+          "App-DB diff's :rf.xray/focus-epoch-id projection pivots to the
+           clicked cascade's epoch")
       (is (= :cart-e9 (:epoch-id (focus-resolver/find-epoch-record selected history)))
           "the App-DB diff's find-epoch-record lookup finds the clicked
            epoch's record in the re-seeded slot — the panel renders the


### PR DESCRIPTION
Two-bead cluster in the Xray tool, one PR, commits ordered cleanup → correctness. Sibling of q8hvw (#2832).

## rf2-uy7nz (P3 cleanup — first commit)

Retire the orphaned `:selected-epoch-id` shim. The mirror slot was written by **seven** sites and read by **zero** production consumers — every App-DB-diff / Views surface had already migrated to the spine focus epoch (`[:focus :epoch-id]` surfaced via `:rf.xray/focus-epoch-id`) under rf2-70tkv. Deleted outright, no back-compat shim:

- Deleted the `:rf.xray/selected-epoch-id` sub (`epoch.cljs`).
- Dropped the dual-write arms in `focus-cascade-reducer`, `focus-step-reducer`, `follow-head-reducer`, the `:rf.xray/focus-epoch` no-dispatch-id fallback (`spine.cljs`), `:rf.xray/select-epoch` + `:rf.xray/sync-epoch-history` (`epoch.cljs`), and `:rf.xray/clear-selected-dispatch-id` (`registry.cljs`). (The bead enumerated six sites; the `:rf.xray/focus-epoch` fallback was a seventh dangling write, also removed for full single-source-of-truth.)
- Dropped the dead `:selected-epoch-id` output key from the `:rf.xray/app-db-diff` composite and renamed its local binding to `focus-epoch-id` (it was bound to `:rf.xray/focus-epoch-id` all along).
- Reconciled `spec/014`: removed the `:rf.xray/selected-epoch-id` sub row and the deleted Time-Travel `:rf.xray/time-travel` composite row (panel removed rf2-qy0nu); corrected the `:rf.xray/sync-epoch-history` + `:rf.xray.fx/restore-epoch` rows that referenced the shim (the latter also had a stale `{:frame-id …}` arg shape + a "clears :selected-epoch-id on failure" claim that never matched the implementation).
- Repointed the test-only readers (registry + spine CLJS tests) at `:rf.xray/focus-epoch-id` / `[:focus :epoch-id]`.

**Zero-reader confirmation:** `git grep ':rf.xray/selected-epoch-id'` across `tools/xray/src` shows the sub was referenced only in its own definition + comments; the only `@(rf/subscribe [:rf.xray/selected-epoch-id])` call sites were in `registry_cljs_test.cljs` / `spine_cljs_test.cljs`. `app_db_diff_subs` already pivots on `:rf.xray/focus-epoch-id` (`(:epoch-id focus)`), never the slot.

## rf2-o1c3r (P2 correctness — second commit)

`:rf.xray/select-dispatch-id` (the legacy machine-inspector / trace / mcp-server entry point) resolved the selected cascade's settling epoch against `(get db :epoch-history [])` **without** first re-keying the slot onto the cascade's frame — the same cross-frame strand q8hvw fixed for `:rf.xray/focus-cascade`. With the picker untouched the slot is keyed on the boot head frame, so selecting a dispatch-id for a cascade that settled in a NON-head frame resolved its epoch to `nil` and stranded every epoch-keyed panel.

Fix: call the shared `spine/reseed-epoch-history-for-frame` helper (resolving the cross-frame ring via `rf/epoch-history` at dispatch time) before resolving the epoch-id, matching q8hvw's `:rf.xray/focus-cascade` pattern exactly. No-op when the frame is unchanged or `frame-id` is nil.

**Reproduce-then-fix test** (`spine_cljs_test.cljs`, sibling of the q8hvw cross-frame tests): `select-dispatch-id-cross-frame-reseeds-epoch-history-rf2-o1c3r` seeds two frames' framework rings, leaves the picker untouched (slot on the boot head frame), dispatches the real `:rf.xray/select-dispatch-id :cart-c9 :cart-frame`, and asserts the clicked dispatch's epoch resolves end-to-end (spine focus sub + `:rf.xray/focus-epoch-id` projection). Verified RED with the fix reverted (4 failures — `:epoch-id` nil, `:target-frame` stuck on `:rf/default`, `:epoch-history` un-reseeded, `focus-epoch` nil), GREEN with the fix. A `select-dispatch-id-same-frame-leaves-slot-untouched-rf2-o1c3r` companion asserts the no-op path.

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` | PASS — 5261 tests, 18001 assertions, 0 failures, 0 errors (+2 deftests vs baseline) |
| JVM xray (`clojure -M:test` in `tools/xray`) | PASS — 1037 tests, 4169 assertions, 0 failures, 0 errors |
| `mkdocs build --strict` | PASS — built clean (spec/014 edit) |
| `npm run test:xray-feature-gate` | PASS (modulo known flake) — 15/16 scenarios green, 13 matrix rows covered. The single FAIL is `routes-epochs routing ladder`, one of the two scenarios pre-confirmed flaky on a clean `origin/main` baseline (`http-server exited unexpectedly (code=1)`, not a logic failure). My diff touches no routing code (the `routes_epochs` testbed is outside this cluster's surface). |

Xray-spec currency: `spec/014-Registry-Catalogue.md` updated in-PR (the focus/epoch-history + selected-epoch-id contract). No other `tools/xray/spec/*` doc described the retired slot.

Closes rf2-uy7nz. Closes rf2-o1c3r.
