### PR TITLE
fix(xray): stop :fuse/box on-boot throw + declutter exception-row rendering (rf2-4yrr6)

### DIFF
--- a/implementation/machines/test/re_frame/guard_action_traces_test.clj
+++ b/implementation/machines/test/re_frame/guard_action_traces_test.clj
@@ -220,3 +220,75 @@
           "guard-evaluated picks up the cascade dispatch-id from *handler-scope*")
       (is (= cascade-id (-> a :tags :rf.trace/dispatch-id))
           "action-ran picks up the same cascade dispatch-id"))))
+
+;; ---- rf2-4yrr6 — the `:*`-wildcard-throws machine (machine-epochs :fuse/box)
+;; ----------------------------------------------------------------------------
+;;
+;; The machine-epochs testbed's `:fuse/box` is `:armed` with a `:*` wildcard
+;; whose `:blow-fuse` action throws (the xstate-v5 'fail loudly on unknown'
+;; idiom). Two facts pin the testbed fix:
+;;
+;;   1. The `[:rf.machine/bootstrap]` EVENT, processed as an inner machine
+;;      event, hits the `:*` wildcard (no `:on :rf.machine/bootstrap` entry)
+;;      and THROWS. This is why the testbed's reset handler must NOT dispatch
+;;      `[:fuse/box [:rf.machine/bootstrap]]` — it would throw ON BOOT.
+;;   2. A machine that was NEVER explicitly bootstrapped STILL throws on its
+;;      first real unhandled event: it lazily bootstraps (needs-bootstrap?
+;;      fires when no snapshot exists) then the wildcard fires. So dropping the
+;;      explicit bootstrap from reset keeps Button 11 working.
+
+(defn- fuse-machine-spec []
+  {:initial :armed
+   :data    {}
+   :actions {:note-inspect (fn [{data :data}]
+                             {:data (update data :inspections (fnil inc 0))})
+             :blow-fuse    (fn [{:keys [event]}]
+                             (throw (ex-info "unhandled machine event"
+                                             {:event event :where :fuse-wildcard})))}
+   :states  {:armed {:on {:fuse/inspect {:action :note-inspect}
+                          :*            {:action :blow-fuse}}}}})
+
+(deftest fuse-bootstrap-event-hits-throwing-wildcard
+  (testing "rf2-4yrr6 — a `[:rf.machine/bootstrap]` inner event has no `:on`
+            entry on `:armed`, so it hits the `:*` wildcard and THROWS. This is
+            the on-boot throw the testbed's reset handler caused by explicitly
+            dispatching `[:fuse/box [:rf.machine/bootstrap]]` — and why that
+            dispatch was dropped."
+    (rf/reg-machine :ga/fuse-bootstrap (fuse-machine-spec))
+    (let [evs  (record-traces!
+                 (fn [] (rf/dispatch-sync [:ga/fuse-bootstrap [:rf.machine/bootstrap]])))
+          errs (ops evs :rf.error/machine-action-exception)]
+      (is (= 1 (count errs))
+          "the explicit bootstrap dispatch fires the throwing `:*` wildcard")
+      (is (= :blow-fuse (-> errs first :tags :action-id))
+          "attributed to the wildcard's `:blow-fuse` action"))))
+
+(deftest fuse-unhandled-event-throws-via-lazy-bootstrap
+  (testing "rf2-4yrr6 — with NO explicit bootstrap dispatch, the FIRST real
+            unhandled event still throws: the machine lazily bootstraps then
+            the `:*` wildcard fires. Button 11 keeps working after the testbed
+            dropped the explicit `[:fuse/box [:rf.machine/bootstrap]]` from
+            reset."
+    (rf/reg-machine :ga/fuse-lazy (fuse-machine-spec))
+    ;; No `[:rf.machine/bootstrap]` dispatch first — straight to the
+    ;; Button-11-style unhandled event against a never-bootstrapped machine.
+    (let [evs  (record-traces!
+                 (fn [] (rf/dispatch-sync [:ga/fuse-lazy [:fuse/short-circuit]])))
+          errs (ops evs :rf.error/machine-action-exception)]
+      (is (= 1 (count errs))
+          "the unhandled event lazily boots `:armed` then fires the wildcard")
+      (is (= :blow-fuse (-> errs first :tags :action-id))
+          "attributed to the wildcard's `:blow-fuse` action")
+      (is (= [:fuse/short-circuit] (-> errs first :tags :event))
+          "the triggering unhandled event rides the trace"))))
+
+(deftest fuse-explicit-inspect-does-not-throw
+  (testing "rf2-4yrr6 — the `:fuse/inspect` event matches the explicit `:on`
+            entry (a normal `:note-inspect` action), so it does NOT hit the
+            throwing wildcard — only otherwise-unhandled events do."
+    (rf/reg-machine :ga/fuse-inspect (fuse-machine-spec))
+    (let [evs  (record-traces!
+                 (fn [] (rf/dispatch-sync [:ga/fuse-inspect [:fuse/inspect]])))
+          errs (ops evs :rf.error/machine-action-exception)]
+      (is (zero? (count errs))
+          "an explicitly-handled event does not fire the throwing wildcard"))))

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1458,7 +1458,9 @@ a plain `reg-event-db` handler.
   `projection/long-step-threshold-ms` (16ms — one 60Hz frame).
 - **Outcome chip** — kind-specific:
   - `:guard` → `✓ pass / ▲ fail / ✗ threw`
-  - `:action` → `✓ ok / ✗ threw`
+  - `:action` → `✓ ok` (a THREW action carries NO outcome chip — rf2-4yrr6;
+    the pink "Exception Thrown" card + the row pink-wash are the single
+    threw signal)
   - `:transition` → `N microstep(s)` (the headline)
   - `:timer` → `· cancelled (<reason>)`
   - `:no-op` → `· ignored` (the benign unhandled-event no-op — muted, not red)
@@ -1557,8 +1559,12 @@ the defmachine DEFINITION:
 - **`↳ fx`** — per-action fx-id chips for each effect the action
   emitted (same data the FX step's `:attributed-to` chip surfaces,
   now visible IN the action's row).
-- **`✗ threw`** — when the action threw, an error chip + exception
-  message.
+
+A THREW action surfaces NO per-row threw chrome (rf2-4yrr6 retired the
+prior `✗ threw — <message>` outcome-detail line AND the duplicate `✗ threw`
+outcome chip above). The pink "Exception Thrown" card + the row pink-wash
+(the `issue-event?` predicate) already flag the throw; the verbatim message
+rides the card. One signal is enough.
 
 **Transition row — prominent header verb + logical-state DELTA box
 (rf2-ge6uj header · rf2-iwy0c body).** The transition zone is a SINGLE
@@ -2259,7 +2265,7 @@ and silently rendered empty rows. The binding inventory:
 | `:dispatch` | `:rf.event/dispatched` | `:rf.event/v` (event vector — rf2-93a7s), `:source` (closed set per rf2-hxj0d + rf2-ejtpd + rf2-c3990; substrate-internal values drive the §9.1.6.3 per-kind enrichment), `:rf.trace/call-site`, `:rf.trace/parent-dispatch-id` (rf2-5qp4g — fx-dispatch parent-epoch link), `:rf.event/source-detail` (rf2-5qp4g — optional per-source-kind detail map; `:dispatch-later` rides `{:ms <delay>}` so the renderer surfaces the original scheduled delay) |
 | `:coeffect` | `:rf.cofx/run` (preferred) or `:rf.event/run-end` `:rf.event/coeffects` (fallback) | `:rf.cofx/id`, `:rf.cofx/value`, `:rf.cofx/elapsed-ms` (rf2-w2r4p aligned the per-cofx duration read against the substrate's canonical name + threaded `:duration-ms` through the `cofx-steps` flattening) — SYSTEM defaults `:db / :event / :frame / :source / :trace-id` are filtered (rf2-cq0ch). **Projection splits each surviving cofx into its own numbered step** (rf2-s1jw4 · pair-debug 2026-05-26): `cofx-steps` is a `mapv` over `cofx-rows` producing `{:step :coeffect :badge :COEFFECT :id <kw> :value <v> :duration-ms <ms>}` per entry, spliced into the steps vec before HANDLER. |
 | `:handler` duration | `:rf.event/run-end` `:rf.event/elapsed-ms` (rf2-slnce aligned the per-handler duration read against the substrate's canonical name — see `re-frame.router/emit-run-end-trace`) |
-| `:handler` source | `(rf/handler-meta :event id)` → `:rf.handler/source` (rf2-66wis · NOT a trace read — registrar meta). The `{:file :line}` coord on the same meta drives the HANDLER verb-as-link affordance (§9.1.6.1 · rf2-ehd8v + pair-debug 2026-05-26). |
+| `:handler` source | `(rf/handler-meta :event id)` → `:rf.handler/source` (rf2-66wis · NOT a trace read — registrar meta). The `{:file :line}` coord on the same meta drives the HANDLER verb-as-link affordance (§9.1.6.1 · rf2-ehd8v + pair-debug 2026-05-26). **EVENT handlers only:** a MACHINE handler renders NO HANDLER source block (rf2-4yrr6 — `handler-source-block` returns nil for `:reg-machine`). The machine CASCADE below is the content; the defmachine / reg-machine value stays reachable via the HANDLER verb link (rf2-ge6uj) + the per-element machine-def source-links (rf2-iwy0c). Dumping the whole machine spec via `edn/inspect` under the HANDLER step was noise, and the machine case does NOT fall through to the `<source not yet captured>` placeholder (that slot is for event handlers whose source the substrate didn't stamp). |
 | `:handler` machine cascade (rf2-u69j7) | `:rf.machine/guard-evaluated` · `:rf.machine/action-ran` · `:rf.machine/transition` · `:rf.machine.timer/cancelled` (closed set: `machine-cascade-trace-ops`) | guard rows read `:guard-id`, `:outcome` (closed set `:pass / :fail / :threw` — rf2-82a0u); action rows read `:action-id`, `:phase` (closed set `:exit / :transition / :entry / :always / :after-action / :initial-entry / :destroy-exit` — rf2-82a0u), `:outcome` (rich map; `:fx` + `:data` hoisted onto the row), `:input`, `:exception`; transition rows read `:machine-id`, `:event`, `:before`, `:after`, `:microsteps` (state vectors hoisted off `:before`/`:after`); timer rows read `:state`, `:delay`, `:reason` (closed set `:on-exit / :on-destroy / :on-resolution / :on-supersede / :on-frame-destroy` — rf2-82a0u). Source-coord lookup reads `(rf/handler-meta :event id) → :rf/machine`, then the co-located entry `:source-coords` for a named `[:actions <id>] | [:guards <id>]` key, or the spec's `:rf.machine/state-coords` index for a reference-site `[:states ...]` key (rf2-npvsx). |
 | `:flow` | `:rf.flow/computed` (NOT `:rf.flow/recomputed` — rf2-yhgk8 aligned the read against `re-frame.flows`'s canonical emit) | `:flow-id`, `:path`, `:before`, `:result` (the view-side `:after` slot maps to the substrate's `:result`), `:elapsed-ms` |
 | `:fx` | `:rf.fx/handled` / `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` | `:rf.fx/id`, `:rf.fx/args`, `:rf.fx/elapsed-ms` (rf2-ipaza aligned the duration read against the substrate's canonical name) |
@@ -2582,7 +2588,7 @@ mis-render):
 | `:rf.error/fx-handler-exception` | SIDE EFFECTS, row whose `:fx-id` = `:failing-id` | row-level (fallback step-level) |
 | `:rf.error/no-such-fx` | SIDE EFFECTS | step-level (fallback) |
 | `:rf.error/flow-eval-exception` | FLOW | step-level (fallback HANDLER when no FLOW step) |
-| `:rf.error/machine-action-exception` (rf2-e7yhv) | HANDLER | step-level. A machine action threw during a transition; the machine handler IS an event handler so its cascade renders under HANDLER. The card adds a machine-attribution line — `[in machine <id> (action <id>) threw on unhandled event <ev>]` — and, when the throw fired from a `:*` WILDCARD action (the xstate-v5 fail-loudly idiom; `:rf/via-wildcard?` rides the trace's `:transition` slot, stamped by `transition/match-on-clause`), names it `a :* wildcard action … fired by the :* wildcard, not a named transition`. The event row goes pink (the trace is op-type `:error`), the inverse of the benign `:no-op` row above |
+| `:rf.error/machine-action-exception` (rf2-e7yhv) | HANDLER | step-level. A machine action threw during a transition; the machine handler IS an event handler so its cascade renders under HANDLER. The card adds a single collapsed machine-attribution line — `action <id> threw an exception` (rf2-4yrr6, replacing the earlier `in machine <id> (action <id>) threw on unhandled event <ev> … fired by the :* wildcard …` run-on that repeated `:*`/`wildcard`/`unhandled`/`action` and re-stated the event right above the verbatim message). The machine is obvious from cascade context; the triggering event + `:where` ride the ex-data; the user's message renders verbatim below; `:data-via-wildcard` still rides the line so consumers can distinguish a `:*` WILDCARD throw (`:rf/via-wildcard?` on the trace's `:transition` slot, stamped by `transition/match-on-clause`) from a named-transition throw. The event row goes pink (the trace is op-type `:error`), the inverse of the benign `:no-op` row above |
 
 The error MESSAGE rides `[:tags :exception-message]` ONLY (handler / fx
 throws — `re-frame.router/emit-handler-exception!` stamps the

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -548,18 +548,11 @@
   {:color        accent-colour
    :margin-right "6px"})
 
-(def ^:private cascade-detail-threw-row-style
-  {:display     "flex"
-   :gap         "6px"
-   :align-items "flex-start"
-   :color       error-colour})
-
-(def ^:private cascade-threw-glyph-style {:font-weight 700})
-(def ^:private cascade-threw-label-style {:font-weight 600})
-
-(def ^:private cascade-threw-message-style
-  {:color      text-secondary-colour
-   :font-style "italic"})
+;; rf2-4yrr6 — `cascade-detail-threw-row-style` / `cascade-threw-glyph-style`
+;; / `cascade-threw-label-style` / `cascade-threw-message-style` RETIRED with
+;; the per-action "✗ threw — <message>" detail line (the duplicate threw
+;; signal). The pink 'Exception Thrown' card + the row pink-wash are the
+;; single threw signal now.
 
 ;; rf2-ge6uj ISSUE 3 — the TRANSITION row's verb (`<before> → <after>`,
 ;; now the focal point) renders VISUALLY PRIMARY: larger + bolder than
@@ -641,8 +634,8 @@
   {:margin-top "8px"
    :min-width  "0"})
 
-(def ^:private handler-source-spec-style
-  {:padding-left "16px"})
+;; rf2-4yrr6 — `handler-source-spec-style` retired with the machine SPEC
+;; dump (the `(edn/inspect spec)` branch of `handler-source-block`).
 
 (def ^:private handler-source-placeholder-style
   {:font-style   "italic"
@@ -1804,10 +1797,9 @@
     ;; and `handler-source-block` already read `:event`).
     (let [machine-meta (try (rf/handler-meta :event machine-id)
                             (catch :default _ nil))
-          ;; Resolve the machine spec the same way `machine-spec-value`
-          ;; (defined later in this ns) does: the stamped spec lives under
-          ;; `:rf/machine`, with fixture-shape fallbacks for unit tests.
-          ;; Inlined here because the var is declared below this fn.
+          ;; Resolve the machine spec: the stamped spec lives under
+          ;; `:rf/machine`, with fixture-shape fallbacks for unit tests
+          ;; (mirrors the cascade path's `projection/machine-spec-from-meta`).
           spec         (or (:rf/machine machine-meta)
                            (:machine-spec machine-meta)
                            (:spec machine-meta)
@@ -2670,7 +2662,7 @@
 
 (defn- cascade-row-action-outcome-details
   "Render the per-action outcome details for an `:action` cascade row
-  (rf2-u69j7). Three slots ride below the row's source body:
+  (rf2-u69j7). Two slots ride below the row's source body:
 
   - DATA Δ — when the action returned a `:data` write, surface the
     delta the action contributed as an edn-inspector DIFF (rf2-5hjb5 —
@@ -2679,14 +2671,19 @@
   - FX — when the action returned a `:fx` list, surface each emitted
     fx-id (per-action attribution; same data as the FX step's
     `:attributed-to` chip, now visible IN the action's row).
-  - EXCEPTION — when the action threw, surface the exception message
-    (the cascade halts on the first throw — Spec 005 §Errors).
+
+  rf2-4yrr6 — the EXCEPTION slot (the `✗ threw — <message>` line) is
+  REMOVED. A threw action row already carries the pink 'Exception Thrown'
+  card + the row's pink-wash (the `issue-event?` predicate); the duplicate
+  threw line here (and the duplicate `:threw` outcome chip in
+  `cascade-row-view`) were redundant — one signal is enough. The verbatim
+  message rides the card.
 
   Each slot elides cleanly when the underlying data is absent so the
   row stays minimal for actions that ran without side-effects."
   [row]
-  (let [{:keys [data-write fx threw? exception]} row]
-    (when (or (some? data-write) (seq fx) threw?)
+  (let [{:keys [data-write fx]} row]
+    (when (or (some? data-write) (seq fx))
       [:div {:data-testid (str "rf-xray-epoch-machine-cascade-outcome-"
                                (:step row))
              :style cascade-outcome-details-style}
@@ -2714,22 +2711,7 @@
             [:span {:data-testid (str "rf-xray-epoch-machine-cascade-fx-"
                                       (:step row) "-" j)
                     :style cascade-detail-fx-chip-style}
-             (fmt/ns-keyword fx-id)])])
-       ;; Threw path — the action halted the cascade. Surface a
-       ;; compact error chip so the operator can pivot to the
-       ;; exception body via the Issues panel.
-       (when threw?
-         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-threw-"
-                                  (:step row))
-                :style cascade-detail-threw-row-style}
-          [:span {:style cascade-threw-glyph-style} "✗"]
-          [:span {:style cascade-threw-label-style} "threw"]
-          (when exception
-            [:span {:style cascade-threw-message-style}
-             (str " — "
-                  (or (when (some? exception)
-                        (.-message ^js exception))
-                      (str exception)))])])])))
+             (fmt/ns-keyword fx-id)])])])))
 
 ;; rf2-ge6uj ISSUE 3 — the transition zone is collapsed to ONE prominent
 ;; row. The TRANSITION row's header carries `[#step] [TRANSITION badge]
@@ -2791,7 +2773,13 @@
        (cascade-outcome-chip
          (cond
            (= :guard kind)      outcome
-           (and (= :action kind) threw?)  :threw
+           ;; rf2-4yrr6 — a threw ACTION row carries NO outcome chip. The
+           ;; pink 'Exception Thrown' card + the row's pink-wash (the
+           ;; `issue-event?` predicate) already say it threw — one signal is
+           ;; enough (the duplicate `:threw` chip + the `cascade-row-action-
+           ;; outcome-details` "✗ threw —" line were both removed). A
+           ;; successful action keeps its `:ok` chip.
+           (and (= :action kind) threw?)  nil
            (= :action kind)     :ok
            (= :timer kind)      :cancelled
            ;; rf2-ugdas — the benign no-op reads "ignored" (event matched
@@ -2915,19 +2903,11 @@
     (when (and (string? s) (seq s))
       s)))
 
-(defn- machine-spec-value
-  "Return the registered machine handler's spec data. A machine is
-  registered as a `reg-event-fx` carrying `:rf/machine? true` + the
-  stamped spec under `:rf/machine` (rf2-ge6uj / rf2-ypu5i); the legacy
-  `:machine-spec` / `:spec` / `:rf.machine/spec` slots are fixture-
-  shape fallbacks used by unit tests. Mirrors the cascade path's
-  `projection/machine-spec-from-meta` resolution so the HANDLER step's
-  machine SPEC reads the SAME spec the cascade source rows read."
-  [meta]
-  (or (:rf/machine meta)
-      (:machine-spec meta)
-      (:spec meta)
-      (:rf.machine/spec meta)))
+;; rf2-4yrr6 — `machine-spec-value` retired. Its sole caller was
+;; `handler-source-block`'s machine branch (the `(edn/inspect spec)` SPEC
+;; dump), which is gone: machine handlers render NO source block now (the
+;; machine CASCADE is the content). `machine-state-path-coord` resolves the
+;; spec inline (it pre-dated this var anyway, being declared above it).
 
 (defn- coord-from-handler-meta
   "Lift a `{:file :line}` source-coord off a registered handler's meta
@@ -2996,55 +2976,43 @@
                             :plain-style handler-verb-plain-style})))
 
 (defn- handler-source-block
-  "Render the source-code block under the HANDLER header. Three
-  cases:
+  "Render the source-code block under the HANDLER header for an EVENT
+  handler. Two cases:
 
-    1. Machine handler — render the machine spec via the canonical
-       `edn/inspect` widget.
-    2. Event handler with a captured source string — render via
+    1. Event handler with a captured source string — render via
        `edn/code-block` (clojure-syntax highlight).
-    3. Otherwise — render a clear `<source not yet captured>`
+    2. Otherwise — render a clear `<source not yet captured>`
        placeholder so the slot is always present (operator learns
        where to look + when the substrate didn't stamp).
 
-  rf2-ehd8v / pair-debug 2026-05-26 — the SOURCE / MACHINE SPEC
-  sub-header is gone; the verb in the HANDLER step header IS the
-  click-to-source affordance now (see `handler-verb-link`). This
-  fn renders only the code body."
+  rf2-4yrr6 — MACHINE handlers render NO source block (this fn returns
+  nil for them). Dumping the whole machine spec via `edn/inspect` under
+  the HANDLER step was noise: the machine CASCADE below (`machine-block`)
+  IS the content, and the defmachine / reg-machine value stays reachable
+  via source-links — the HANDLER verb link (rf2-ge6uj) and the per-element
+  machine-def links (rf2-iwy0c). Nothing is lost. The machine case returns
+  nil (NOT the `<source not yet captured>` placeholder — that slot is for
+  event handlers whose source the substrate didn't stamp).
+
+  rf2-ehd8v / pair-debug 2026-05-26 — the SOURCE sub-header is gone; the
+  verb in the HANDLER step header IS the click-to-source affordance now
+  (see `handler-verb-link`). This fn renders only the code body."
   [flavour event-id]
-  ;; rf2-iwy0c part C — read the registration meta under the `:event`
-  ;; kind for BOTH flavours. A machine is registered as a `reg-event-fx`
-  ;; carrying `:rf/machine? true` + the spec under `:rf/machine` (rf2-ge6uj
-  ;; ISSUE 2 fixed this in the cascade path; `machine-block` reads `:event`
-  ;; too). The prior `(if machine? :machine :event)` lookup resolved nil for
-  ;; the machine spec — there is NO `:machine` registrar kind — so the
-  ;; HANDLER step's machine SPEC rendered the `<source not yet captured>`
-  ;; placeholder. Reading under `:event` + `machine-spec-value`'s `:rf/machine`
-  ;; resolution surfaces the spec.
-  (let [machine? (= :reg-machine flavour)
-        meta     (when (some? event-id)
-                   (try (rf/handler-meta :event event-id)
-                        (catch :default _ nil)))
-        spec     (when machine? (machine-spec-value meta))
-        src      (when-not machine? (handler-source-string meta))]
-    [:div {:data-testid "rf-xray-epoch-handler-source"
-           :style handler-source-root-style}
-     (cond
-       (and machine? (some? spec))
-       [:div {:data-testid "rf-xray-epoch-handler-source-spec"
-              :style handler-source-spec-style}
-        (edn/inspect spec)]
-
-       src
-       (edn/code-block
-         {:source src
-          :lang   :clojure
-          :testid "rf-xray-epoch-handler-source-body"})
-
-       :else
-       [:span {:data-testid "rf-xray-epoch-handler-source-placeholder"
-               :style handler-source-placeholder-style}
-        "<source not yet captured>"])]))
+  (when-not (= :reg-machine flavour)
+    (let [meta (when (some? event-id)
+                 (try (rf/handler-meta :event event-id)
+                      (catch :default _ nil)))
+          src  (handler-source-string meta)]
+      [:div {:data-testid "rf-xray-epoch-handler-source"
+             :style handler-source-root-style}
+       (if src
+         (edn/code-block
+           {:source src
+            :lang   :clojure
+            :testid "rf-xray-epoch-handler-source-body"})
+         [:span {:data-testid "rf-xray-epoch-handler-source-placeholder"
+                 :style handler-source-placeholder-style}
+          "<source not yet captured>"])])))
 
 (defn- handler-db-diff-block
   "Render the HANDLER step's `:db` sub-section (rf2-93436 / design
@@ -4668,24 +4636,23 @@
   step's blast radius right where the work happened — the inline half of
   rf2-ahhgn, polished by rf2-wnvid for ALL exception kinds."
   [step-key idx {:keys [message recovery db-rolled-back? operation
-                        machine-id action-id event via-wildcard?] :as row}]
+                        action-id via-wildcard?] :as row}]
   (let [recovery-label (error-recovery-label recovery db-rolled-back?)
         testid-base    (str "rf-xray-epoch-error-"
                             (name (or step-key :unknown)) "-" idx)
-        ;; rf2-e7yhv — machine-action-exception attribution. Name WHAT
-        ;; threw (the action), in WHICH machine, on WHICH event, and whether
-        ;; it came from a `:*` WILDCARD action (the xstate-v5 fail-loudly
-        ;; idiom) vs a named transition — so the operator reads the cause,
-        ;; not just the message.
-        machine-attr   (when (= :rf.error/machine-action-exception operation)
-                         (str (when via-wildcard? "a :* wildcard action ")
-                              "in machine " (fmt/ns-keyword machine-id)
-                              (when action-id
-                                (str " (action " (fmt/ns-keyword action-id) ")"))
-                              (when event
-                                (str " threw on unhandled event " (pr-str event)))
-                              (when via-wildcard?
-                                " — fired by the :* wildcard, not a named transition")))]
+        ;; rf2-4yrr6 — machine-action-exception attribution. Name WHAT threw
+        ;; (the action) in one clean line: "action :blow-fuse threw an
+        ;; exception". The earlier wording (rf2-e7yhv) repeated ":* wildcard"
+        ;; / "unhandled" / "action" twice and re-stated the triggering event
+        ;; right above the verbatim ex-info message — a confusing run-on. The
+        ;; dropped detail is redundant: the machine is obvious from the
+        ;; cascade context, the triggering event + `:where` ride the ex-data
+        ;; (collapsible below), and the user's message renders verbatim. Reads
+        ;; cleanly for named-action throws too, not just the `:*` wildcard.
+        machine-attr   (when (and (= :rf.error/machine-action-exception operation)
+                                  action-id)
+                         (str "action " (fmt/ns-keyword action-id)
+                              " threw an exception"))]
     [:div {:key (str "error-" step-key "-" idx)
            :data-testid testid-base
            :data-error-op (when (:operation row) (name (:operation row)))
@@ -4708,8 +4675,10 @@
        [:div {:data-testid (str testid-base "-message")
               :style error-block-message-style}
         message])
-     ;; 2b. rf2-e7yhv — machine-action attribution line (machine + action +
-     ;; the unhandled event + whether a `:*` wildcard fired it).
+     ;; 2b. rf2-4yrr6 — machine-action attribution line: "action <id> threw
+     ;; an exception" (collapsed from rf2-e7yhv's run-on). `:data-via-wildcard`
+     ;; still rides the row for downstream consumers / tests that distinguish a
+     ;; `:*` wildcard throw from a named-transition throw.
      (when machine-attr
        [:div {:data-testid (str testid-base "-machine-attribution")
               :data-via-wildcard (str (boolean via-wildcard?))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -3085,3 +3085,154 @@
       ;; rf2-9wq0v — no per-stage glyph; the SKIPPED body is the signal.
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-side-effects-status"))
           "no per-stage status glyph (retired rf2-9wq0v)"))))
+
+;; ============================================================================
+;; rf2-4yrr6 — :fuse/box exception-row decluttering (parts 2-4)
+;; ============================================================================
+
+;; ---- Part 2 — machine HANDLER step renders NO source block ----------------
+
+(deftest machine-handler-renders-no-source-block-test
+  (testing "rf2-4yrr6 — a MACHINE handler's HANDLER step renders NO source
+            block (the spec dump under the HANDLER step was noise; the
+            machine CASCADE below is the content and the defmachine /
+            reg-machine value is reachable via the verb / machine-def
+            source-links). It returns nil — NOT the '<source not yet
+            captured>' placeholder (that slot is for event handlers whose
+            source the substrate did not stamp)."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :fuse/box
+                :fx []
+                :machine {:cascade [{:kind :action :step 1
+                                     :action-id :blow-fuse :phase :transition
+                                     :outcome :rf.error/action-threw
+                                     :threw? true}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-source"))
+          "NO source block wrapper for a machine handler")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-source-spec"))
+          "NO machine SPEC dump under the HANDLER step")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
+          "and NOT the '<source not yet captured>' placeholder either")
+      ;; The machine cascade IS the content — confirm it still renders.
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
+          "the machine CASCADE remains the HANDLER step's content")))
+  (testing "rf2-4yrr6 — an EVENT handler (non-machine) STILL renders its
+            source block (only the machine case is suppressed)"
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-event-db :event-id :no-such/handler
+                :fx [] :machine nil}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source"))
+          "the event handler's source block is unaffected"))))
+
+;; ---- Part 3 — a threw ACTION row shows exactly ONE threw signal -----------
+
+(deftest threw-action-row-shows-single-threw-signal-test
+  (testing "rf2-4yrr6 — a threw `:action` cascade row carries NEITHER the
+            duplicate `:threw` outcome chip NOR the '✗ threw — <message>'
+            outcome-detail line. The pink 'Exception Thrown' card + the row
+            pink-wash (the issue-event? predicate) are the single threw
+            signal. Reproduces the throwing-action shape the projection
+            emits (`:threw? true` + `:outcome :rf.error/action-threw` +
+            `:exception`) and asserts the clean shape."
+    (let [exc  (ex-info "unhandled machine event"
+                        {:event [:fuse/short-circuit] :where :fuse-wildcard})
+          step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :fuse/box
+                :fx []
+                :machine {:cascade [{:kind :action :step 1
+                                     :action-id :blow-fuse :phase :transition
+                                     :outcome :rf.error/action-threw
+                                     :threw? true
+                                     :exception exc}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      ;; (a) NO right-aligned `:threw` outcome chip.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-threw"))
+          "no duplicate `:threw` outcome chip on the threw action row")
+      ;; (b) NO '✗ threw — <message>' outcome-detail line.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-threw-1"))
+          "no duplicate '✗ threw — <message>' outcome-detail line")
+      ;; The action row itself still renders (only the threw chrome is gone).
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+          "the action row still renders")))
+  (testing "rf2-4yrr6 — a SUCCESSFUL `:action` row keeps its `:ok` outcome
+            chip (only the threw chip was removed)"
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :door/main
+                :fx []
+                :machine {:cascade [{:kind :action :step 1
+                                     :action-id :count-open :phase :entry
+                                     :outcome {:data {:opened-count 1}}}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ok"))
+          "a successful action keeps its `:ok` outcome chip"))))
+
+;; ---- Part 4 — collapsed exception-card machine attribution ----------------
+
+(deftest machine-action-exception-card-collapsed-attribution-test
+  (testing "rf2-4yrr6 — the EXCEPTION card's machine-attribution line is
+            collapsed to 'action <id> threw an exception'. The earlier
+            run-on (`a :* wildcard action in machine :fuse/box (action
+            :blow-fuse) threw on unhandled event [...] — fired by the :*
+            wildcard, not a named transition`) repeated ':*'/'wildcard'/
+            'unhandled'/'action' and re-stated the event right above the
+            verbatim message — confusing. The collapsed line reads cleanly;
+            the dropped detail rides the ex-data + the verbatim message."
+    (let [exc  (ex-info "unhandled machine event"
+                        {:event [:fuse/short-circuit] :where :fuse-wildcard})
+          tree (view/error-block :handler 0
+                 {:operation     :rf.error/machine-action-exception
+                  :message       "unhandled machine event"
+                  :machine-id    :fuse/box
+                  :action-id     :blow-fuse
+                  :event         [:fuse/short-circuit]
+                  :via-wildcard? true
+                  :exception     exc
+                  :recovery      :no-recovery})
+          base "rf-xray-epoch-error-handler-0"
+          attr (text-of tree (str base "-machine-attribution"))]
+      (is (some? (th/find-by-testid tree (str base "-machine-attribution")))
+          "the machine-attribution line renders")
+      (is (= "action :blow-fuse threw an exception" attr)
+          "the attribution collapses to 'action :blow-fuse threw an exception'")
+      ;; The run-on detail is GONE — none of the repeated phrasing survives.
+      (is (not (string/includes? attr "wildcard"))
+          "no ':* wildcard' phrasing in the collapsed line")
+      (is (not (string/includes? attr "unhandled"))
+          "no 'unhandled event' phrasing in the collapsed line")
+      (is (not (string/includes? attr "in machine"))
+          "no 'in machine :fuse/box' echo (obvious from cascade context)")
+      ;; `:data-via-wildcard` STILL rides the row for downstream consumers.
+      (is (= "true"
+             (-> tree (th/find-by-testid (str base "-machine-attribution"))
+                 th/attrs :data-via-wildcard))
+          "the :data-via-wildcard attribute still distinguishes a wildcard throw")))
+  (testing "rf2-4yrr6 — the collapsed wording reads cleanly for a NAMED-action
+            throw too (not just the :* wildcard)"
+    (let [tree (view/error-block :handler 0
+                 {:operation     :rf.error/machine-action-exception
+                  :message       "boom"
+                  :machine-id    :door/main
+                  :action-id     :enter-alarm
+                  :via-wildcard? false
+                  :recovery      :no-recovery})
+          base "rf-xray-epoch-error-handler-0"]
+      (is (= "action :enter-alarm threw an exception"
+             (text-of tree (str base "-machine-attribution")))
+          "named-action throw reads 'action :enter-alarm threw an exception'")
+      (is (= "false"
+             (-> tree (th/find-by-testid (str base "-machine-attribution"))
+                 th/attrs :data-via-wildcard))
+          "named-transition throw stamps :data-via-wildcard false")))
+  (testing "rf2-4yrr6 — a non-machine exception kind renders NO
+            machine-attribution line (the line is machine-specific)"
+    (let [tree (view/error-block :handler 0
+                 {:operation :rf.error/handler-exception
+                  :message   "boom"
+                  :recovery  :no-recovery})]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-error-handler-0-machine-attribution"))
+          "no machine-attribution line for a plain handler exception"))))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -3061,6 +3061,26 @@ async function runMachineEpochs(page, state) {
   //      above, we assert the panel handoff + trace activity, not the
   //      synthetic-injection chart-render that deep_machine owns.)
   await openXray(page);
+
+  // ---- rf2-4yrr6 — :fuse/box must NOT throw on boot. The reset handler
+  //      DELIBERATELY does not dispatch `[:fuse/box [:rf.machine/bootstrap]]`
+  //      (that inner event would hit the throwing `:*` wildcard ON BOOT). The
+  //      full trace buffer at this point holds the boot cascade + rungs 1-10
+  //      (none of which should throw) — assert no `:rf.error/machine-action-
+  //      exception` is present yet. Button 11 (clicked below) is the SOLE
+  //      trigger; that throw is asserted as the contrast at the end.
+  {
+    const bootTrace = await readTrace(page);
+    const bootThrow = bootTrace.filter((e) =>
+      /:rf\.error\/machine-action-exception/.test(e));
+    if (bootThrow.length > 0) {
+      failWithDetails(
+        'rf2-4yrr6 — :fuse/box (or another machine) threw on boot / rungs 1-10; '
+        + 'Button 11 must be the sole machine-action-exception trigger',
+        { machineActionExceptions: bootThrow });
+    }
+  }
+
   await clearTrace(page);
   await clickMachineRung(page, 2); // :locked ──► :closed — a fresh transition
   await waitForTraceMatch(

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -413,13 +413,25 @@
 ;; ============================================================================
 
 (rf/reg-event-fx :machine-epochs/reset
-  {:doc "Button 0 — re-seed app-db and reset BOTH machines to their initial
-         states. Start clean."}
+  {:doc "Button 0 — re-seed app-db and reset the door + traffic machines to
+         their initial states. Start clean.
+
+         `:fuse/box` is DELIBERATELY NOT bootstrapped here. A
+         `[:fuse/box [:rf.machine/bootstrap]]` dispatch runs the initial-entry
+         cascade (fine) and THEN processes the inner `[:rf.machine/bootstrap]`
+         event as a normal machine event: `:armed` has no `:on` entry for it,
+         so it falls to the `:*` wildcard whose `:blow-fuse` action THROWS — a
+         `:rf.error/machine-action-exception` ON BOOT, every load. The fuse box
+         must throw ONLY when Button 11 presses it, never on boot. The machine
+         lazily bootstraps on its first real event anyway (`needs-bootstrap?`
+         fires when no snapshot exists yet — see
+         `lifecycle-fx.registration/prepare-machine-ctx`), so Button 11's
+         `[:fuse/box [:fuse/short-circuit]]` still boots `:armed` then fires
+         the throwing wildcard. Net: clean boot, Button 11 the sole trigger."}
   (fn handler-reset [_ _ev]
     {:db initial-db
      :fx [[:dispatch [:door/main [:rf.machine/bootstrap]]]
-          [:dispatch [:traffic/light [:rf.machine/bootstrap]]]
-          [:dispatch [:fuse/box [:rf.machine/bootstrap]]]]}))
+          [:dispatch [:traffic/light [:rf.machine/bootstrap]]]]}))
 
 ;; ============================================================================
 ;; THE BUTTON LADDER


### PR DESCRIPTION
A 4-part polish of the machine-epochs `:fuse/box` `:*`-throws fixture (shipped by #2834 / rf2-e7yhv) and its Xray Epoch-panel rendering. From a Mike pair-review on the machine-epochs deck.

## Part 1 — stop the on-boot throw (`testbeds/machine_epochs/core.cljs`)
The reset handler dispatched `[:fuse/box [:rf.machine/bootstrap]]`. The bootstrap entry cascade is benign, but `run-step` then processes the inner `[:rf.machine/bootstrap]` event against `:armed`, which has no `:on` entry for it → the `:*` wildcard fires `:blow-fuse`, which **throws** → a real `:rf.error/machine-action-exception` **on boot, every load**.

Fix: drop the `:fuse/box` bootstrap-dispatch from reset's `:fx` (door + traffic stay). The machine **lazily bootstraps** on its first real event (`needs-bootstrap?` fires when no snapshot exists — `lifecycle-fx.registration/prepare-machine-ctx`), so Button 11's `[:fuse/box [:fuse/short-circuit]]` still boots `:armed` then fires the throwing wildcard. **Net: clean boot, Button 11 the sole trigger.**

## Part 2 — no machine-spec dump under the HANDLER step (`view.cljs` `handler-source-block`)
A machine handler's HANDLER step rendered the whole machine spec via `(edn/inspect spec)`. Removed — the machine CASCADE below is the content and the defmachine / reg-machine value is reachable via the verb source-link (rf2-ge6uj) + per-element machine-def links (rf2-iwy0c). `handler-source-block` returns **nil** for machines (NOT the `<source not yet captured>` placeholder). Retired the orphaned `machine-spec-value` fn + `handler-source-spec-style`.

## Part 3 — one threw signal on a threw ACTION row (`view.cljs` `cascade-row-view` + `cascade-row-action-outcome-details`)
A threw action row showed TWO "threw" signals: the right-aligned `:threw` outcome chip AND the `✗ threw — <message>` outcome-detail line. **Removed both.** The pink "Exception Thrown" card + the row pink-wash (the `issue-event?` predicate) are the single signal. A successful action keeps its `:ok` chip; the guard `:threw` path is untouched. Retired the orphaned `cascade-*-threw-*` styles.

## Part 4 — collapsed exception-card attribution (`view.cljs` `machine-attr`)
Collapsed the run-on (`a :* wildcard action in machine :fuse/box (action :blow-fuse) threw on unhandled event [...] — fired by the :* wildcard, not a named transition`) to **`action :blow-fuse threw an exception`**. Dropped detail is redundant (machine obvious from cascade context; triggering event + `:where` ride the ex-data; user's message renders verbatim below). `:data-via-wildcard` still rides the line so consumers distinguish a wildcard throw. Reads cleanly for named-action throws too.

## Tests (CLJS unit; no new Playwright)
- **Part 1** (`machines/test/.../guard_action_traces_test.clj`): the `[:rf.machine/bootstrap]` inner event hits the throwing wildcard (the bug); an unhandled event still throws via lazy bootstrap (Button 11 works); `:fuse/inspect` does NOT throw.
- **Parts 2-4** (`tools/xray/test/.../epoch/view_cljs_test.cljs`): machine HANDLER renders no source block (nil, not placeholder); threw action shows neither duplicate signal; a successful action keeps its `:ok` chip; collapsed `machine-attr` wording for wildcard + named-action throws.
- **Feature-matrix scenario** (`feature_matrix/scenarios.cjs`): asserts no `:rf.error/machine-action-exception` in the boot + rungs-1-10 trace buffer; #11 stays the sole throw trigger.
- **Xray spec currency**: `spec/021-Dynamic-Panel-Designs.md` updated for all three render changes (HANDLER source block machine carve-out, action outcome chip / detail, exception-card attribution).

## Quality gates
| Gate | Result |
|------|--------|
| `npm run test:cljs` (node CLJS — Parts 2-4 view tests) | PASS — 5270 tests, 18057 assertions, 0 failures, 0 errors |
| machines JVM suite (`clojure -M:test`, Part 1 tests) | PASS — 292 tests, 987 assertions, 0 failures, 0 errors |
| xray JVM suite (`clojure -M:test`, epoch projection tests) | PASS — 1041 tests, 4202 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` (machine_epochs scenario) | PASS — 16 scenarios, 0 failures (the trailing `http-server exited (code=1)` is the known shutdown flake, AFTER all scenarios passed) |
| clj-kondo (changed files) | 0 errors; 12 unused-private-var warnings, all pre-existing (baseline HEAD also 12 — zero introduced) |
