### PR TITLE
fix(xray): member-level set diffs in the edn-inspector diff engine (rf2-l0us2)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -139,6 +139,54 @@ testbed epoch-2 `:rf/runtime` allocation (`:messages []` +
 > the FULL+DIFF family alongside rf2-9d4j8 root-container and
 > rf2-fyd8u scalar-sub-cache cases).
 
+### A changed set diffs member-by-member, key intact (rf2-l0us2)
+
+A **set** whose membership changes is a *member-level* diff — the key
+stays intact and each member carries its own `:added` / `:removed`
+chrome (`#{:door/locked}` → `#{:door/closed}` reads as `-:door/locked
++:door/closed`, not a struck-through whole `:tags` entry). Members match
+**by value** — sets are unordered, so there is no positional or key
+identity, only membership: a member present only in `before` is
+`:removed`, present only in `after` is `:added`, present in both is
+`:same`.
+
+Two engine rules make this hold:
+
+- **The wholly-changed uniformity walk takes the UNION of both sides'
+  set members.** Editscript keys set members by *value*, so a swap puts
+  each side's members at **disjoint** paths (`#{:a} → #{:b}` ⇒ `[[:a] :-]
+  [[:b] :+]`). A one-sided uniformity walk would then see the before-set
+  as "all members removed" and the after-set as "all members added" and
+  *both* falsely promote the set — and every ancestor map/vector of it —
+  to a wholly-changed root, which the renderer paints as a whole-key
+  removal (the "sea of red"). Collecting the union of members means a
+  swapped set contributes both a `:removed` and an `:added` leaf, so the
+  uniformity test correctly fails **at the set and at every ancestor**.
+- **An empty↔populated set replace expands per-member.** When one side is
+  the *empty* set Editscript falls back to a whole-value `:r` (the same
+  pathology as the empty map, rf2-9d4j8); the projection pre-expands it
+  into per-member `:+` / `:-` edits so `#{} → #{:a}` and `#{:a} → #{}`
+  classify member-level rather than as a single opaque `:modified`.
+
+A set is therefore only a **wholly-changed root** when the opposite side
+is empty or absent (a genuine cold-boot `#{} → #{…}` or clear `#{…} →
+#{}`, where there is no surviving member to anchor a member-level diff).
+While the opposite side still holds members, the membership delta *is*
+the diff and the per-member chrome shows with the key intact. Maps and
+vectors are unaffected — their slots are keyed by a shared key/index, so
+the one-sided uniformity walk was always correct for them; the union is
+taken only for sets.
+
+> **Why this is a contract, not an edge case.** The misrender hit ANY
+> set whose membership changed — `:tags` on a machine snapshot, a
+> set-valued app-db key, a sub result — reading as "the key vanished"
+> rather than "one member swapped." Surfaced live on the machine-epochs
+> deck (`[:rf/runtime :machines :snapshots :door/main :tags]`, rf2-l0us2,
+> related rf2-iwy0c). This is the FULL+DIFF family's set-keyed counterpart
+> to the rf2-bufw2 empty-collection and rf2-9d4j8 root-container honesty
+> fixes: all three close gaps where the wholly-changed uniformity walk
+> disagreed with the per-leaf op classification.
+
 ### Removed slots render in place; the absence marker never escapes (rf2-8pfkk)
 
 The diff renders the **union of `before ∪ after`** — a slot present in

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -164,32 +164,45 @@
 ;; raw Editscript edit-script walker
 ;; =========================================================================
 
-(defn- expand-empty-map-replacement
-  "Expand a single Editscript edit that replaces an EMPTY MAP with a
-  populated map (or vice versa) into per-key `:+` / `:-` edits.
+(defn- expand-empty-collection-replacement
+  "Expand a single Editscript edit that replaces an EMPTY MAP / SET with
+  a populated one (or vice versa) into per-member `:+` / `:-` edits.
 
   Editscript's A* emits a single `[[path] :r new-value]` edit for the
   pathological `{} → {populated}` (and `{populated} → {}`) cases — the
-  whole map replacement is one step in the edit script. Downstream
+  whole collection replacement is one step in the edit script. Downstream
   classification then tags `path` as `:modified` and leaves every
-  PER-KEY path returning `:same` from `op-at`, which the renderer reads
-  as 'no per-key change' — wrong for an absent→present transition
+  PER-MEMBER path returning `:same` from `op-at`, which the renderer reads
+  as 'no per-member change' — wrong for an absent→present transition
   (rf2-9d4j8; related precedent rf2-5j7ch which patched only the
   `:flat-rows` lens).
 
+  ## Sets share the empty-replace pathology (rf2-l0us2)
+
+  For NON-empty sets Editscript already emits member-level `:+` / `:-`
+  edits (members are value-keyed: `#{:a} → #{:b}` ⇒ `[[:a] :-] [[:b] :+]`),
+  so they need no expansion. But when ONE side is the EMPTY set Editscript
+  falls back to the same whole-value `:r` it uses for empty maps
+  (`#{} → #{:a}` ⇒ `[[] :r #{:a}]`). Left alone that classifies as a single
+  `:modified` op at the set's path and the renderer's per-member walk sees
+  every member as `:same`. The set members are keyed by VALUE, mirroring
+  Editscript's own set-edit path scheme, so the per-member expansion uses
+  the member itself as the trailing path segment.
+
   This expansion runs over the raw edit script BEFORE classification so
   every downstream artefact (`:path-ops`, `:container-ops`,
-  `:flat-rows`, `:wholly-changed-roots`) sees per-key granularity.
+  `:flat-rows`, `:wholly-changed-roots`) sees per-member granularity.
 
-  Rule: a `:r` edit at `path` substitutes into per-key edits ONLY when
-  the before-side value at `path` is `{}` AND the after-side value at
-  `path` is a non-empty map (or symmetrically populated→empty). Type
-  changes (nil↔map, scalar↔map, map↔vector) are LEFT ALONE so R7's
-  `:rf.xray.diff/type-change?` branch still fires on them.
+  Rule: a `:r` edit at `path` substitutes into per-member edits ONLY when
+  one side at `path` is an EMPTY collection and the other is a NON-EMPTY
+  collection of the SAME KIND (empty-map↔populated-map or
+  empty-set↔populated-set). Type changes (nil↔map, scalar↔map,
+  map↔vector, set↔map) are LEFT ALONE so R7's `:rf.xray.diff/type-change?`
+  branch still fires on them.
 
   Pure; non-matching edits pass through unchanged."
   [edit before after]
-  (let [[path op value] edit]
+  (let [[path op _value] edit]
     (if (not= op :r)
       [edit]
       (let [before-at (value-at before path)
@@ -205,13 +218,24 @@
                (map? after-at)  (empty? after-at))
           (mapv (fn [[k _v]] [(conj (vec path) k) :-]) before-at)
 
+          ;; #{} → populated set: per-member :+ (member is the path seg)
+          (and (set? before-at) (empty? before-at)
+               (set? after-at)  (seq after-at))
+          (mapv (fn [el] [(conj (vec path) el) :+ el]) after-at)
+
+          ;; populated set → #{}: per-member :-
+          (and (set? before-at) (seq before-at)
+               (set? after-at)  (empty? after-at))
+          (mapv (fn [el] [(conj (vec path) el) :-]) before-at)
+
           :else
           [edit])))))
 
 (defn- raw-edits
   "Return Editscript A* edits for `(before, after)` as a vector of
-  3-tuples `[path op value?]`, with empty↔populated map replacements
-  pre-expanded into per-key `:+` / `:-` edits (rf2-9d4j8). Pure."
+  3-tuples `[path op value?]`, with empty↔populated map/set replacements
+  pre-expanded into per-member `:+` / `:-` edits (rf2-9d4j8, rf2-l0us2).
+  Pure."
   [before after]
   (let [raw (try
               (ee/get-edits (es/diff before after {:algo :a-star}))
@@ -223,7 +247,7 @@
                 ;; reproduces the operator-visible signal ("everything
                 ;; changed") without false sub-tree precision.
                 [[[] :r after]]))]
-    (into [] (mapcat (fn [edit] (expand-empty-map-replacement edit before after))) raw)))
+    (into [] (mapcat (fn [edit] (expand-empty-collection-replacement edit before after))) raw)))
 
 ;; =========================================================================
 ;; per-path op classification (leaves)
@@ -446,10 +470,49 @@
   single root-level reclassification, which contradicts the operator's
   read on a cold-boot diff: each top-level key is a discrete addition
   and wants its own gutter chrome. Nested containers can still qualify
-  as wholly-changed (e.g. `{} → {:user {:id 7}}` marks `[:user]`)."
+  as wholly-changed (e.g. `{} → {:user {:id 7}}` marks `[:user]`).
+
+  ## Sets are member-keyed — a swap is NOT wholly-changed (rf2-l0us2)
+
+  Editscript keys SET members by VALUE, not by a positional/key slot
+  shared across both sides (`#{:a} → #{:b}` emits `[[:a] :-] [[:b] :+]`).
+  So a set whose membership SWAPPED has every BEFORE-member at a
+  `:removed` leaf and every AFTER-member at an `:added` leaf — two
+  DISJOINT path-sets. The before-side uniformity walk then sees the set
+  as 'all members removed' and the after-side walk sees it as 'all
+  members added', and BOTH falsely promote the set container to wholly-
+  changed. The renderer paints that as a struck-through whole key (the
+  'sea of red' from the bead repro: `:tags #{:door/locked}` →
+  `#{:door/closed}` rendered as `:tags` removed, not `-:door/locked
+  +:door/closed` with `:tags` intact).
+
+  Concretely: a set is wholly-changed ONLY when the OPPOSITE side is
+  empty or absent — a genuine `#{} → #{…}` cold-boot or `#{…} → #{}`
+  clear, where there is no surviving member to anchor a member-level
+  diff. When the opposite side still holds members, the membership delta
+  IS the diff and the per-member `:added` / `:removed` chrome (which the
+  renderer's `children-of-pair` set union already emits) must show with
+  the key intact.
+
+  Implementation: `collect-leaves` (the walker that feeds the uniformity
+  test) takes the OPPOSITE side too. When it reaches a SET, it collects
+  the UNION of both sides' members. A member-swapped set then contributes
+  BOTH a `:removed` leaf (the gone member) AND an `:added` leaf (the new
+  member), so the uniformity test fails AT THE SET and at every ANCESTOR
+  of it — no false promotion anywhere up the tree (an ancestor MAP whose
+  only changed descendant is a swapped set was the deeper trap a set-only
+  gate missed). When the opposite set is empty/absent the union equals
+  the present side's members (all one op), so cold-boot / clear sets still
+  promote correctly. Maps and vectors are unchanged: their slots are keyed
+  by a shared key/index, so the one-sided walk was always correct for
+  them — the union is taken only for sets."
   [before after path-ops]
   (let [collect-leaves
-        (fn collect-leaves [data path]
+        ;; `opposite` is the value at the SAME path on the other side of
+        ;; the diff (`missing-sentinel` when absent). Only sets consult it
+        ;; (member-keyed → disjoint paths across sides); maps/vectors walk
+        ;; `data` alone exactly as before.
+        (fn collect-leaves [data opposite path]
           (cond
             ;; rf2-bufw2 — an empty container is a terminal leaf (it has
             ;; no descendant slots), exactly as `expand-leaf-paths`
@@ -467,71 +530,99 @@
             [path]
 
             (map? data)
-            (mapcat (fn [[k cv]] (collect-leaves cv (conj (vec path) k))) data)
+            (mapcat (fn [[k cv]]
+                      (collect-leaves cv
+                                      (if (map? opposite)
+                                        (get opposite k missing-sentinel)
+                                        missing-sentinel)
+                                      (conj (vec path) k)))
+                    data)
 
+            ;; rf2-l0us2 — sets are member-keyed, so a swap puts each
+            ;; side's members at DISJOINT paths. Collect the UNION of both
+            ;; sides' members so a swapped set contributes both a removed
+            ;; and an added leaf, breaking the false uniformity at the set
+            ;; AND every ancestor.
             (set? data)
-            (mapcat (fn [el] (collect-leaves el (conj (vec path) el))) data)
+            (let [opposite-set (when (set? opposite) opposite)
+                  members      (into data (or opposite-set #{}))]
+              (mapcat (fn [el]
+                        (collect-leaves el missing-sentinel
+                                        (conj (vec path) el)))
+                      members))
 
             (or (vector? data) (sequential? data))
-            (mapcat (fn [[i cv]] (collect-leaves cv (conj (vec path) i)))
-                    (map-indexed vector data))
+            (let [opp-vec (when (or (vector? opposite) (sequential? opposite))
+                            (vec opposite))]
+              (mapcat (fn [[i cv]]
+                        (collect-leaves cv
+                                        (if (and opp-vec (< i (count opp-vec)))
+                                          (nth opp-vec i)
+                                          missing-sentinel)
+                                        (conj (vec path) i)))
+                      (map-indexed vector data)))
 
             :else
             [path]))
         check-uniform
-        (fn [data root-path target-op]
-          (let [leaves (collect-leaves data root-path)]
+        (fn [data opposite root-path target-op]
+          (let [leaves (collect-leaves data opposite root-path)]
             (and (seq leaves)
                  (every? (fn [lp]
                            (= target-op (:op (get path-ops lp))))
                          leaves))))
+        ;; `opposite-root` is the OTHER side's whole value — the after-
+        ;; side walk (`:added`) threads `before`, the before-side walk
+        ;; (`:removed`) threads `after` — so `check-uniform` can resolve
+        ;; the counterpart at any path via `value-at`.
         walk-containers
-        (fn walk-containers [data path target-op acc]
-          (cond
-            (not (container? data))
-            acc
-
-            ;; Root path `[]` never qualifies as a wholly-changed root —
-            ;; recurse into children instead so nested containers can
-            ;; still be marked (rf2-9d4j8).
-            (and (= [] path) (check-uniform data path target-op))
+        (fn walk-containers [data path target-op opposite-root acc]
+          (let [opposite (value-at opposite-root path)]
             (cond
+              (not (container? data))
+              acc
+
+              ;; Root path `[]` never qualifies as a wholly-changed root —
+              ;; recurse into children instead so nested containers can
+              ;; still be marked (rf2-9d4j8).
+              (and (= [] path) (check-uniform data opposite path target-op))
+              (cond
+                (map? data)
+                (reduce-kv (fn [acc k cv]
+                             (walk-containers cv (conj (vec path) k)
+                                              target-op opposite-root acc))
+                           acc data)
+
+                (or (vector? data) (sequential? data))
+                (reduce (fn [acc [i cv]]
+                          (walk-containers cv (conj (vec path) i)
+                                           target-op opposite-root acc))
+                        acc (map-indexed vector data))
+
+                :else acc)
+
+              (check-uniform data opposite path target-op)
+              (conj acc path)
+
               (map? data)
               (reduce-kv (fn [acc k cv]
                            (walk-containers cv (conj (vec path) k)
-                                            target-op acc))
+                                            target-op opposite-root acc))
                          acc data)
 
               (or (vector? data) (sequential? data))
               (reduce (fn [acc [i cv]]
                         (walk-containers cv (conj (vec path) i)
-                                         target-op acc))
+                                         target-op opposite-root acc))
                       acc (map-indexed vector data))
 
-              :else acc)
-
-            (check-uniform data path target-op)
-            (conj acc path)
-
-            (map? data)
-            (reduce-kv (fn [acc k cv]
-                         (walk-containers cv (conj (vec path) k)
-                                          target-op acc))
-                       acc data)
-
-            (or (vector? data) (sequential? data))
-            (reduce (fn [acc [i cv]]
-                      (walk-containers cv (conj (vec path) i)
-                                       target-op acc))
-                    acc (map-indexed vector data))
-
-            :else acc))
+              :else acc)))
         added-roots
         (when (container? after)
-          (walk-containers after [] :added #{}))
+          (walk-containers after [] :added before #{}))
         removed-roots
         (when (container? before)
-          (walk-containers before [] :removed #{}))
+          (walk-containers before [] :removed after #{}))
         all-roots (into (or added-roots #{}) (or removed-roots #{}))
         ;; Elide deeper roots — when a path is wholly-changed AND its
         ;; ancestor is also wholly-changed, drop the deeper one (the

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -450,3 +450,206 @@
                 [:flow :phases :foo]]
                (mapv :path sorted)))))))
 
+;; ---- rf2-l0us2 — member-level set diffs --------------------------------
+;;
+;; A changed SET must project as a member-level diff (KEY INTACT, per-
+;; member `:removed` / `:added`), NOT as a whole-key removal. The bug:
+;; Editscript keys set members by VALUE, so a member-swap puts each
+;; side's members at DISJOINT paths. The before-side wholly-changed
+;; uniformity walk then saw the set (and every ancestor) as 'all members
+;; removed' and the after-side walk as 'all members added' — BOTH falsely
+;; promoting the container to wholly-changed `:removed` / `:added`, which
+;; the renderer paints as a struck-through whole key (the bead's 'sea of
+;; red'). The engine's `path-ops` were already member-level; the fix is
+;; the uniformity walk (`mark-wholly-changed` now collects the UNION of
+;; both sides' set members so a swap fails uniformity at the set AND every
+;; ancestor) plus per-member expansion of the empty↔populated `:r` set
+;; replace (`expand-empty-collection-replacement`).
+
+(deftest l0us2-set-member-swap-is-member-level-not-whole-key
+  (testing "rf2-l0us2 — RED repro: `#{:a} → #{:b}` member swap projects
+            as member-level `-:a +:b`, NOT a wholly-changed whole-set.
+            (Before the fix the set container was promoted to wholly-
+            changed-removed AND -added — the 'sea of red'.)"
+    (let [p (engine/project #{:a} #{:b})]
+      ;; Member-level ops at the value-keyed member paths.
+      (is (= :removed (engine/op-at p [:a])))
+      (is (= :added   (engine/op-at p [:b])))
+      ;; The set is NOT wholly-changed — root `[]` is the set itself,
+      ;; excluded from promotion regardless, but the key invariant is
+      ;; that no wholly-changed root is logged for a member swap.
+      (is (= #{} (:wholly-changed-roots p))))))
+
+(deftest l0us2-nested-set-swap-keeps-key-intact
+  (testing "rf2-l0us2 — the live repro path: a set nested under a map key
+            (`{:tags #{:a}} → {:tags #{:b}}`) keeps `:tags` INTACT
+            (`:children`, NOT `:removed`) and diffs at the member level."
+    (let [p (engine/project {:tags #{:a}} {:tags #{:b}})]
+      ;; The :tags KEY is intact — :children, never :removed/:added.
+      (is (= :children (engine/op-at p [:tags])))
+      (is (not (contains? (:wholly-changed-roots p) [:tags])))
+      ;; Member-level diff under the intact key.
+      (is (= :removed (engine/op-at p [:tags :a])))
+      (is (= :added   (engine/op-at p [:tags :b]))))))
+
+(deftest l0us2-door-machine-tags-repro
+  (testing "rf2-l0us2 — the exact bead repro: the door machine's `:tags`
+            went `#{:door/locked}` → `#{:door/closed}`. The :tags key
+            must read as `-:door/locked +:door/closed`, not 'tags went
+            away'."
+    (let [p (engine/project {:tags #{:door/locked}}
+                            {:tags #{:door/closed}})]
+      (is (= :children (engine/op-at p [:tags])))
+      (is (= :removed (engine/op-at p [:tags :door/locked])))
+      (is (= :added   (engine/op-at p [:tags :door/closed])))
+      (is (= :door/locked (:before (engine/entry-at p [:tags :door/locked]))))
+      (is (= :door/closed (:after  (engine/entry-at p [:tags :door/closed])))))))
+
+(deftest l0us2-set-add-only
+  (testing "rf2-l0us2 — add-only `#{:a} → #{:a :b}`: only `:b` is added,
+            `:a` is :same, key intact."
+    (let [p (engine/project {:tags #{:a}} {:tags #{:a :b}})]
+      (is (= :children (engine/op-at p [:tags])))
+      (is (= :added (engine/op-at p [:tags :b])))
+      ;; The surviving member carries no op (returns :same).
+      (is (= :same (engine/op-at p [:tags :a])))
+      (is (not (contains? (:wholly-changed-roots p) [:tags]))))))
+
+(deftest l0us2-set-remove-only
+  (testing "rf2-l0us2 — remove-only `#{:a :b} → #{:a}`: only `:b` is
+            removed, `:a` is :same, key intact."
+    (let [p (engine/project {:tags #{:a :b}} {:tags #{:a}})]
+      (is (= :children (engine/op-at p [:tags])))
+      (is (= :removed (engine/op-at p [:tags :b])))
+      (is (= :same (engine/op-at p [:tags :a])))
+      (is (not (contains? (:wholly-changed-roots p) [:tags]))))))
+
+(deftest l0us2-set-partial-swap-keeps-shared-member
+  (testing "rf2-l0us2 — partial swap `#{:a :b} → #{:a :c}`: `:a` survives
+            (:same), `:b` removed, `:c` added — NOT wholly-changed."
+    (let [p (engine/project {:tags #{:a :b}} {:tags #{:a :c}})]
+      (is (= :children (engine/op-at p [:tags])))
+      (is (= :removed (engine/op-at p [:tags :b])))
+      (is (= :added (engine/op-at p [:tags :c])))
+      (is (= :same (engine/op-at p [:tags :a])))
+      (is (not (contains? (:wholly-changed-roots p) [:tags]))))))
+
+(deftest l0us2-empty-to-nonempty-set-expands-member-level
+  (testing "rf2-l0us2 — `{:tags #{}} → {:tags #{:a}}` (the empty↔populated
+            edge Editscript emits as a whole-value `:r`): expands to a
+            per-member `:added`, with the set legitimately wholly-changed
+            (no surviving member to anchor against). Mirrors the empty-map
+            expansion (rf2-9d4j8)."
+    (let [p (engine/project {:tags #{}} {:tags #{:a}})]
+      (is (= :added (engine/op-at p [:tags :a])))
+      ;; Genuine cold-boot of the set → wholly-changed-added, key intact.
+      (is (= :added (engine/op-at p [:tags])))
+      (is (contains? (:wholly-changed-roots p) [:tags])))))
+
+(deftest l0us2-nonempty-to-empty-set-expands-member-level
+  (testing "rf2-l0us2 — symmetric clear `{:tags #{:a}} → {:tags #{}}`
+            expands to a per-member `:removed`, wholly-changed-removed."
+    (let [p (engine/project {:tags #{:a}} {:tags #{}})]
+      (is (= :removed (engine/op-at p [:tags :a])))
+      (is (= :removed (engine/op-at p [:tags])))
+      (is (contains? (:wholly-changed-roots p) [:tags])))))
+
+(deftest l0us2-wholly-new-set-promotes
+  (testing "rf2-l0us2 — a set that appears wholesale under a NEW key
+            (`{} → {:tags #{:a :b}}`) is still wholly-changed-added
+            (opposite side absent → no surviving member)."
+    (let [p (engine/project {} {:tags #{:a :b}})]
+      (is (= :added (engine/op-at p [:tags])))
+      (is (contains? (:wholly-changed-roots p) [:tags]))
+      (is (= :added (engine/op-at p [:tags :a])))
+      (is (= :added (engine/op-at p [:tags :b]))))))
+
+(deftest l0us2-set-swap-does-not-promote-ancestor-map
+  (testing "rf2-l0us2 — a swapped set must not falsely promote an ANCESTOR
+            map. `{:m {:tags #{:a}}} → {:m {:tags #{:b}}}` keeps BOTH `:m`
+            and `:m :tags` intact (the deeper trap a set-only gate missed:
+            the ancestor map's only changed descendant is the swapped
+            set)."
+    (let [p (engine/project {:m {:tags #{:a}}} {:m {:tags #{:b}}})]
+      (is (= :children (engine/op-at p [:m])))
+      (is (= :children (engine/op-at p [:m :tags])))
+      (is (= #{} (:wholly-changed-roots p)))
+      (is (= :removed (engine/op-at p [:m :tags :a])))
+      (is (= :added (engine/op-at p [:m :tags :b]))))))
+
+(deftest l0us2-set-swap-does-not-promote-ancestor-vector
+  (testing "rf2-l0us2 — a swapped set inside a VECTOR must not promote the
+            vector. `{:v [#{:a}]} → {:v [#{:b}]}` keeps `:v` and `:v 0`
+            intact (the index-aligned opposite-side walk for vectors)."
+    (let [p (engine/project {:v [#{:a}]} {:v [#{:b}]})]
+      (is (= :children (engine/op-at p [:v])))
+      (is (= :children (engine/op-at p [:v 0])))
+      (is (= #{} (:wholly-changed-roots p)))
+      (is (= :removed (engine/op-at p [:v 0 :a])))
+      (is (= :added (engine/op-at p [:v 0 :b]))))))
+
+(deftest l0us2-set-of-non-keyword-members
+  (testing "rf2-l0us2 — members match BY VALUE regardless of type. A set
+            of strings + a set of numbers diff member-level just like
+            keywords."
+    (let [ps (engine/project {:t #{"a"}} {:t #{"b"}})]
+      (is (= :children (engine/op-at ps [:t])))
+      (is (= :removed (engine/op-at ps [:t "a"])))
+      (is (= :added (engine/op-at ps [:t "b"]))))
+    (let [pn (engine/project {:t #{1 2}} {:t #{2 3}})]
+      (is (= :children (engine/op-at pn [:t])))
+      (is (= :removed (engine/op-at pn [:t 1])))
+      (is (= :added (engine/op-at pn [:t 3])))
+      (is (= :same (engine/op-at pn [:t 2]))))))
+
+(deftest l0us2-set-of-maps-recurses
+  (testing "rf2-l0us2 — a set of MAPS (members value-keyed by their whole
+            map) recurses into per-member structure sensibly: a swapped
+            element-map surfaces as a removed old-map + added new-map,
+            key intact."
+    (let [p (engine/project {:items #{{:id 1}}} {:items #{{:id 2}}})]
+      ;; The :items key stays intact.
+      (is (= :children (engine/op-at p [:items])))
+      (is (not (contains? (:wholly-changed-roots p) [:items])))
+      ;; Each element-map is keyed by its whole value; the removed map
+      ;; and added map appear at distinct member paths.
+      (is (= :removed (engine/op-at p [:items {:id 1} :id])))
+      (is (= :added (engine/op-at p [:items {:id 2} :id]))))))
+
+(deftest l0us2-set-diff-feeds-flat-rows
+  (testing "rf2-l0us2 — the member-level set diff also surfaces on the
+            `:diff` (pure-list) flat-rows lens, not just FULL+DIFF."
+    (let [p (engine/project {:tags #{:door/locked}}
+                            {:tags #{:door/closed}})
+          rows (:flat-rows p)
+          paths (set (map :path rows))
+          op-at-path (fn [path]
+                       (some (fn [r] (when (= path (:path r)) (:op r))) rows))]
+      (is (contains? paths [:tags :door/locked]))
+      (is (contains? paths [:tags :door/closed]))
+      (is (= :removed (op-at-path [:tags :door/locked])))
+      (is (= :added (op-at-path [:tags :door/closed])))
+      ;; The :tags key itself is NOT a flat-row (it's intact :children).
+      (is (not (contains? paths [:tags]))))))
+
+(deftest l0us2-map-and-vector-diffs-unchanged
+  (testing "rf2-l0us2 — regression guard: the set-aware union walk must
+            leave MAP + VECTOR wholly-changed promotion untouched."
+    ;; Wholly-new map subtree still promotes (R5).
+    (let [p (engine/project {:a 1} {:a 1 :flash {:level :ok :text "hi"}})]
+      (is (contains? (:wholly-changed-roots p) [:flash]))
+      (is (= :added (engine/op-at p [:flash]))))
+    ;; Wholly-removed map subtree still promotes.
+    (let [p (engine/project {:user {:id 7}} {})]
+      (is (contains? (:wholly-changed-roots p) [:user]))
+      (is (= :removed (engine/op-at p [:user]))))
+    ;; Mixed map subtree still does NOT promote.
+    (let [p (engine/project {:user {:id 7 :name "Ada"}}
+                            {:user {:id 7 :name "Ada Lovelace"}})]
+      (is (not (contains? (:wholly-changed-roots p) [:user])))
+      (is (= :modified (engine/op-at p [:user :name]))))
+    ;; Vector insert shift (R6) still works.
+    (let [p (engine/project [:a :b :c :d] [:a :NEW :b :c :d])]
+      (is (= :added (engine/op-at p [1])))
+      (is (= :same-shifted (engine/op-at p [2]))))))
+

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1626,6 +1626,50 @@
     (is (re-find #"← was 2" s)
         "modified leaf still carries the change annotation")))
 
+(deftest l0us2-set-member-swap-renders-member-level-not-whole-key
+  ;; rf2-l0us2 — the bead repro: the door machine's `:tags` went
+  ;; `#{:door/locked}` → `#{:door/closed}`. The renderer must show
+  ;; `-:door/locked +:door/closed` with the `:tags` KEY INTACT, NOT a
+  ;; struck-through whole `:tags` entry (the 'sea of red'). With the
+  ;; engine fix `:tags` classifies `:children` (intact) and the set's
+  ;; member union carries per-member -/+ chrome.
+  (let [before {:tags #{:door/locked}}
+        after  {:tags #{:door/closed}}
+        proj   (engine/project before after)
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :projection proj
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 6}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    ;; Precondition (engine): :tags intact, members diffed.
+    (is (= :children (engine/op-at proj [:tags]))
+        "precondition: :tags key is intact (:children), not wholly removed")
+    (is (= :removed (engine/op-at proj [:tags :door/locked])))
+    (is (= :added (engine/op-at proj [:tags :door/closed])))
+    ;; Renderer: both members visible, member-level chrome present.
+    (is (re-find #":door/locked" all)
+        "the removed member :door/locked still renders")
+    (is (re-find #":door/closed" all)
+        "the added member :door/closed renders")
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "a row carries the removed diff-op marker (the gone member)")
+    (is (re-find #"data-rf-diff-op.*added" s)
+        "a row carries the added diff-op marker (the new member)")
+    (is (re-find #"line-through" s)
+        "the removed member is struck through, not the whole key")
+    ;; The :tags key itself must NOT be inside a removed-ghost wrapper —
+    ;; that would be the 'sea of red' whole-key removal. The
+    ;; `data-rf-removed-ghost` attr is present on every container header
+    ;; but carries the value "1" ONLY for an actual removed ghost; with
+    ;; the fix :tags classifies :children so the marker stays unset.
+    (is (not (re-find #":data-rf-removed-ghost \"1\"" s))
+        "the :tags set is not rendered as a removed ghost (no whole-key strike)")))
+
 ;; =========================================================================
 ;; rf2-e28r3 — single render path: value (always) + before (optional)
 ;; =========================================================================


### PR DESCRIPTION
## Summary

A changed **set** rendered in the edn-inspector diff as a whole-key removal (struck-through key, "sea of red") instead of a member-level diff. Found live on the machine-epochs deck: the door machine's `:tags` went `#{:door/locked}` → `#{:door/closed}` (a member swap) but the inspector painted the whole `:tags` entry as removed — reading as "tags went away" rather than `-:door/locked +:door/closed` with `:tags` intact. Affected ANY set whose membership changed (app-db, sub results, machine snapshots).

## Root cause + the Editscript seam

The root cause was **not** the Editscript representation. Editscript already emits member-level `:+`/`:-` edits for non-empty sets — members are keyed by value (`#{:a}` → `#{:b}` ⇒ `[[:a] :-] [[:b] :+]`) — and the engine's per-leaf `path-ops` were already correct.

The bug was in the **wholly-changed uniformity walk** (`mark-wholly-changed`). Because set members are keyed by VALUE, a swap puts each side's members at **disjoint** paths. The before-side uniformity walk then saw the set as "all members removed" and the after-side walk saw it as "all members added", and **both** falsely promoted the set container — and every ancestor map/vector of it — to a wholly-changed root, which the renderer paints as a whole-key removal.

Seam chosen: **fix the uniformity walk + generalise the empty-collection pre-expander, both inside `engine/project`.** This keeps the engine's output shape identical to what the renderer already consumes for map-keys / vector-slots, so the renderer needed no change.

- `mark-wholly-changed`'s leaf walker now takes the OPPOSITE side and, at a set, collects the **union** of both sides' members → a swapped set contributes both a `:removed` and an `:added` leaf, so uniformity correctly fails at the set AND every ancestor (the deeper trap a set-only gate missed). The vector branch threads the index-aligned opposite element so a set nested in a vector is covered.
- `expand-empty-map-replacement` → `expand-empty-collection-replacement`: empty↔populated SET replaces (which Editscript emits as a whole-value `:r`, the same pathology as empty maps per rf2-9d4j8) now expand to per-member `:+`/`:-`, so `#{} → #{:a}` and `#{:a} → #{}` classify member-level.

A set remains a wholly-changed root only when the opposite side is empty/absent (genuine cold-boot / clear). Maps and vectors are unaffected — their slots are keyed by a shared key/index, so the one-sided walk was always correct for them.

## Changed files

- `tools/xray/src/day8/re_frame2_xray/diff/engine.cljc` — the fix
- `tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc` — 15 new engine unit tests
- `tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs` — 1 renderer integration test
- `tools/xray/spec/004-App-DB-Diff.md` — documents the member-level set-diff contract

The renderer source (`edn_inspector.cljs`) is **unchanged**: its `children-of-pair` set-union walk + per-member `engine/op-at` lookups already paint member-level chrome once the engine emits correct ops.

## Reproduce-then-fix + edge cases

RED repro pinned first (`#{:a} → #{:b}` and the exact `{:tags #{:door/locked}} → {:tags #{:door/closed}}` door-machine path), then GREEN. Edge cases covered: add-only, remove-only, partial-swap-keeping-a-shared-member, empty→non-empty and back, wholly-new set under a new key, **ancestor-map non-promotion** + **ancestor-vector non-promotion** (the deeper trap), set of non-keyword members (strings, numbers), set of maps, the `:diff` flat-rows lens, and a map/vector regression guard (R5/R6 unchanged).

## Quality gates

| Gate | Runtime | Result |
|------|---------|--------|
| `npm run test:cljs` | JS (node) | PASS — 5283 tests / 18117 assertions, 0 failures |
| JVM xray (`clojure -M:test` in tools/xray) | JVM | PASS — 1056 tests / 4271 assertions, 0 failures |
| `npm run test:xray-feature-gate` | browser | PASS — 16 scenarios, 0 failures, 13 matrix rows (trailing `http-server exited code=1` is the known post-assertion flake) |

`engine.cljc` is CLJC, so the engine tests compile + run on **both** JS and JVM (covered by the first two rows).

## Risks

Low. Engine-only change; renderer untouched. The union-walk threading is additive (maps/vectors thread `missing-sentinel` and behave exactly as before); the empty-collection expander is a strict generalisation of the existing empty-map expander. Full JS + JVM + browser-gate suites green.

Closes rf2-l0us2.