### PR TITLE
test(xray): edn-inspector testbed button for the set-member removal case (rf2-ecjsv)

### DIFF
--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -44,6 +44,12 @@
        removal, NOT a `:added ::missing` leak.
     5  Diff: CHANGED in place (diff-mode-3). Bump a nested scalar
        `[:metrics :counter]` — the value-side `~` glyph + `← was N`.
+    5b Diff: SET-MEMBER REMOVED (rf2-l0us2). Remove one member from the
+       set at `[:metrics :tags]` (`#{:a :b :c}` → `#{:a :c}` → … → `#{}`,
+       re-seeding when empty). The removed member renders member-level
+       `−:b` with the set's KEY INTACT — NOT a struck-through whole-key
+       'sea of red'. The last-member → `#{}` press exercises the
+       empty-collection-replacement expansion of the same fix.
     6  Sensitive → :rf/redacted. Write the `:rf/redacted` sentinel three
        levels deep at `[:session-secure :user :password]` — the inspector
        renders a `redacted` chip, never the raw value.
@@ -112,7 +118,8 @@
 
 (def initial-db
   {:baseline      0
-   :metrics       {:counter 5}
+   :metrics       {:counter 5
+                   :tags    #{:a :b :c}}
    :tenant        {}
    :session       {:only-key {:label "removed" :n 42}}
    :session-secure {:user {:id 7}}
@@ -194,6 +201,23 @@
         bump
         (update-in [:metrics :counter] (fnil inc 0)))))
 
+;; -- 5b. diff: SET-MEMBER REMOVED (rf2-l0us2) --------------------------------
+(rf/reg-event-db :edn-inspector/diff-set-member-removed
+  {:doc "Button 5b — remove ONE member from the set at `[:metrics :tags]`
+         (`#{:a :b :c}` → `#{:a :c}` → … → `#{}`), re-seeding the full set
+         once it has been emptied so there is always a member to remove. The
+         App-db diff renders the removed member member-level (`−:b`) with the
+         set's KEY INTACT — NOT a struck-through whole-key removal (the
+         `mark-wholly-changed` 'sea of red' rf2-l0us2 fixed). The
+         last-member → `#{}` press exercises the same fix's
+         empty-collection-replacement expansion."}
+  (fn handler-diff-set-member-removed [db _ev]
+    (let [db   (bump db)
+          tags (get-in db [:metrics :tags])]
+      (if (seq tags)
+        (assoc-in db [:metrics :tags] (disj tags (first (sort tags))))
+        (assoc-in db [:metrics :tags] #{:a :b :c})))))
+
 ;; -- 6. sensitive → :rf/redacted ---------------------------------------------
 (rf/reg-event-db :edn-inspector/redacted
   {:doc "Button 6 — write the `:rf/redacted` sentinel three levels deep at
@@ -268,6 +292,9 @@
    [5 "Diff: CHANGED in place"
     "Increment [:metrics :counter] — see value-side `~` glyph + `← was N`"
     [:edn-inspector/diff-changed]]
+   ["5b" "Remove set member"
+    "Drop one member from the set [:metrics :tags] — removed member renders `−:b`, key intact (not a whole-key strike); last press empties the set"
+    [:edn-inspector/diff-set-member-removed]]
 
    [:section "Sentinels — redaction / size-elision"]
    [6 "Sensitive → :rf/redacted"


### PR DESCRIPTION
## What

Adds a **"Remove set member"** button (5b) to the edn-inspector testbed so an operator can eyeball the **l0us2 set member-diff fix** (#2838) live in the Epoch + App-db panels — specifically for the pure REMOVAL case.

- Seeds a set `#{:a :b :c}` at `[:metrics :tags]` (extends the existing `:metrics` map rather than adding a parallel slot).
- Each press removes one member (`#{:a :b :c}` → `#{:a :c}` → `#{:c}` → `#{}`), then re-seeds the full set once emptied — the same "always something to remove" idiom as button 4.
- **Mid-set removal** (`#{:a :b :c}` → `#{:a :c}`) is rendered by Editscript's native member-level emit (members are value-keyed): the removed member shows member-level `−:b` with the set's KEY INTACT — not a struck-through whole-key "sea of red".
- The **last-member → `#{}`** press exercises l0us2's `expand-empty-collection-replacement` path of the same fix.

Lands entirely in `tools/xray/testbeds/edn_inspector/core.cljs` (seed + event handler + ladder row), in the existing "Diff ops" section. Matches the testbed's existing button/control style. Clean test surface — drives a clean mutation for visual verification; no deliberate bug or teaching layer.

## Quality gates

| Gate | Result |
| --- | --- |
| `npx shadow-cljs compile :examples/edn-inspector` (testbed build) | **PASS** — Build completed (424 files, 423 compiled, 0 warnings) |
| `npm run test:cljs` (shared xray cljs sanity) | **PASS** — 5286 tests / 18135 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` | **N/A** — the feature gate drives the `feature_matrix` + `testbeds/*` staged surfaces; the `examples/edn-inspector` testbed is not a staged surface and has no feature-matrix scenario, so this change is out of its scope. No scenario assertion added. |

**Xray-spec currency:** spec unchanged — testbed-only affordance; no documented contract touched (the set member-diff contract was already documented by l0us2 in `tools/xray/spec/004-App-DB-Diff.md`).

Closes rf2-ecjsv.
