### PR TITLE
fix(xray): suppress spurious {X}→{X} transition row on a no-op bootstrap (rf2-e6q97)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1433,11 +1433,24 @@ exception card and NOT pink. Because its trace op-type is `:rf.machine`
 un-washed and the ribbon stays empty — the contrast with a `:*`
 wildcard-action throw (`:rf.error/machine-action-exception`, which DOES go
 pink + renders the EXCEPTION card) validates that the predicate correctly
-distinguishes a benign no-op from a real error. A cascade carries either a
-`:transition` OR a `:no-op`, never both. The no-op row also makes the
-cascade's handler-flavour `:reg-machine` even when no action ran, so the
-EVENT HANDLER machine section renders the notice rather than collapsing to
-a plain `reg-event-db` handler.
+distinguishes a benign no-op from a real error. A cascade renders either a
+`:transition` OR a `:no-op`, never both. This is ENFORCED at projection
+time (rf2-e6q97): on a no-op the machine substrate emits BOTH the
+`:rf.machine.event/unhandled-no-op` trace AND — from `commit-or-finalize`'s
+unconditional `:rf.machine/transition` emit — a contradictory `{X}→{X}`
+0-microstep transition trace (`:before` == `:after`). Rendered side-by-side
+those contradict: the no-op row says "no transition — ignored" while the
+transition row borrows external-self-transition vocabulary (`{X} → {X}`)
+implying the `:exit` / `:entry` firing that did NOT happen.
+`machine-cascade-rows` therefore drops every `:transition` row when the
+cascade also carries a `:no-op` row — the no-op row is the authoritative
+signal that no transition was selected. A genuine self-transition
+(`:target :same-state`, EXTERNAL — `:exit` + `:entry` fire; or INTERNAL —
+the action runs) has a real `match`, so the unhandled-no-op branch is never
+reached and NO `:no-op` row fires: its transition row is preserved. The
+no-op row also makes the cascade's handler-flavour `:reg-machine` even when
+no action ran, so the EVENT HANDLER machine section renders the notice
+rather than collapsing to a plain `reg-event-db` handler.
 
 **Per-row chrome.** Each row carries:
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -889,6 +889,48 @@
             (assoc :event-id (event-id-of (:event tx))))))
       rows next-tx)))
 
+(defn- drop-spurious-no-op-transition
+  "Suppress the spurious `{X}→{X}` 0-microstep `:transition` row that the
+  substrate emits beside a genuine no-op (rf2-e6q97).
+
+  WHY THE SUBSTRATE EMITS BOTH. When an event matches no transition at any
+  level, `machine-transition-single` (machines · `transition.cljc`) takes
+  its `:else` branch: it emits ONE benign `:rf.machine.event/unhandled-no-op`
+  trace (Spec 005 §Transition resolution, xstate-v5 parity — an unhandled
+  event is ignored, not an error) and returns the snapshot UNCHANGED. The
+  macrostep then runs `commit-or-finalize` (machines · lifecycle_fx ·
+  `registration.cljc`), which fires `:rf.machine/transition` UNCONDITIONALLY
+  — even when `:before` == `:after` and zero microsteps ran. So a no-op
+  cascade carries BOTH a `:no-op` row AND a `{X}→{X}` 0-microstep
+  `:transition` row. Rendered side-by-side these CONTRADICT: the no-op row
+  says 'no transition — ignored', while the transition row borrows
+  external-self-transition vocabulary (`{X} → {X}`) implying the `:exit` /
+  `:entry` firing that did NOT happen.
+
+  THE DISCRIMINATOR. The presence of a `:no-op` row is the AUTHORITATIVE
+  signal that no transition was selected — `unhandled-no-op` fires from
+  exactly the same `:else` branch (flat machines), and from the
+  every-region-declined aggregate (parallel machines · `parallel.cljc`).
+  A genuine self-transition (`:target :same-state`, EXTERNAL) has a real
+  `match`, so the no-op branch is NEVER reached → no `:no-op` row → its
+  `:transition` row survives untouched (Spec 005 L291-296, L916 — an
+  external self-transition fires `:exit` + `:entry` and IS a real
+  transition). An internal self-transition (omit `:target`) likewise has a
+  `match` and runs its action — also no `:no-op` row.
+
+  So: drop every `:transition` row IFF the cascade also carries a `:no-op`
+  row. We do NOT inspect `:microsteps` / `:from-state` == `:to-state` — the
+  no-op row IS the precise signal, and gating on state-equality would risk
+  suppressing a legitimate self-transition that happens to land on the same
+  state. The `:no-op` row alone remains to tell the story.
+
+  Pure-data; operates on the trace-ordered rows BEFORE the canonical sort
+  so the result is order-independent."
+  [rows]
+  (if (some #(= :no-op (:kind %)) rows)
+    (filterv #(not= :transition (:kind %)) rows)
+    rows))
+
 (defn machine-cascade-rows
   "Project the focused epoch's machine-related trace events into a
   single time-ordered cascade row vector (rf2-u69j7). Each row carries
@@ -916,7 +958,13 @@
      `:target-state` / `:event-id` from the surrounding `:transition`
      emit. This MUST run on the trace-ordered rows (the
      surrounding-transition resolution is emit-order-sensitive).
-  3. Stable-sort by canonical rank, then re-number `:step` 1..N over the
+  3. `drop-spurious-no-op-transition` (rf2-e6q97) — when the cascade
+     carries a `:no-op` row, the substrate's UNCONDITIONAL
+     `:rf.machine/transition` emit produced a contradictory `{X}→{X}`
+     0-microstep transition row beside it; drop it. Genuine self-
+     transitions never carry a `:no-op` row, so their transition row
+     survives (see that fn's docstring).
+  4. Stable-sort by canonical rank, then re-number `:step` 1..N over the
      sorted order so the view's left-rail ordinal reflects the rendered
      order.
 
@@ -938,9 +986,15 @@
                            (filter (fn [ev] (contains? machine-cascade-trace-ops (op ev)))
                                    events))))
         enriched (enrich-cascade-rows base)
+        ;; rf2-e6q97 — a no-op cascade carries both the `:no-op` row AND the
+        ;; substrate's unconditional `{X}→{X}` 0-microstep `:transition` row;
+        ;; the two contradict. Drop the spurious transition row (the `:no-op`
+        ;; row is the authoritative signal that no transition was selected).
+        ;; Order-independent — runs on the trace-ordered rows before the sort.
+        deduped  (drop-spurious-no-op-transition enriched)
         ;; Stable canonical sort: rank first, emit-order (:trace-index)
         ;; as tiebreaker so intra-phase run order is preserved.
-        sorted   (vec (sort-by (juxt cascade-row-rank :trace-index) enriched))]
+        sorted   (vec (sort-by (juxt cascade-row-rank :trace-index) deduped))]
     ;; Re-number :step over the FINAL (canonical) order so the left-rail
     ;; ordinal reads top-to-bottom as rendered.
     (vec (map-indexed (fn [i row] (assoc row :step (inc i))) sorted))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -670,6 +670,99 @@
       (is (some? (:machine r)))
       (is (= [:no-op] (mapv :kind (-> r :machine :cascade)))))))
 
+;; ---- rf2-e6q97 — a no-op suppresses the spurious {X}→{X} transition row ---
+
+(deftest no-op-bootstrap-suppresses-spurious-transition-row-test
+  (testing "rf2-e6q97 — on a no-op bootstrap the substrate emits BOTH the
+            benign :rf.machine.event/unhandled-no-op AND its unconditional
+            :rf.machine/transition summary ({X}→{X}, 0 microsteps). Rendered
+            side-by-side those CONTRADICT. The cascade must show the :no-op
+            row ALONE — the spurious transition row is dropped."
+    (let [state {:vehicle :red :pedestrian :walk}
+          ;; Live repro: machine-epochs deck, epoch 3 —
+          ;; [:traffic/light [:rf.machine/bootstrap]] in a stable state.
+          ;; The substrate emit shape: unhandled-no-op (the event matched no
+          ;; transition) FOLLOWED BY the unconditional commit transition with
+          ;; :before == :after and :microsteps 0.
+          no-op (machine-unhandled-no-op-ev :traffic/light
+                                            [:rf.machine/bootstrap] state)
+          tx    (machine-transition-ev :traffic/light
+                                       {:state state :data {}}
+                                       {:state state :data {}}
+                                       [:rf.machine/bootstrap] 0)
+          rows  (proj/machine-cascade-rows [no-op tx])]
+      ;; RED before the fix: rows == [:no-op :transition] (the contradiction).
+      ;; GREEN after: the :transition row is gone.
+      (is (= [:no-op] (mapv :kind rows))
+          "only the :no-op row survives — no spurious {X}→{X} transition row")
+      (is (= 1 (count rows)))
+      (is (not-any? #(= :transition (:kind %)) rows)
+          "the spurious 0-microstep no-change transition row is suppressed")
+      (is (= 1 (:step (first rows)))
+          ":step renumbered 1..N over the deduped cascade")))
+
+  (testing "rf2-e6q97 — emit-order is irrelevant: even if the transition emit
+            precedes the no-op emit, the transition row is still dropped"
+    (let [state :stable
+          tx    (machine-transition-ev :traffic/light
+                                       {:state state} {:state state}
+                                       [:rf.machine/bootstrap] 0)
+          no-op (machine-unhandled-no-op-ev :traffic/light
+                                            [:rf.machine/bootstrap] state)
+          rows  (proj/machine-cascade-rows [tx no-op])]
+      (is (= [:no-op] (mapv :kind rows)))))
+
+  (testing "rf2-e6q97 — the no-op suppression flows through handler-row into
+            the :machine :cascade slot the view renders (the live surface)"
+    (let [state {:vehicle :red :pedestrian :walk}
+          evs   [(machine-unhandled-no-op-ev :traffic/light
+                                             [:rf.machine/bootstrap] state)
+                 (machine-transition-ev :traffic/light
+                                        {:state state :data {}}
+                                        {:state state :data {}}
+                                        [:rf.machine/bootstrap] 0)]
+          r     (proj/handler-row evs :traffic/light)]
+      (is (= :reg-machine (:flavour r)))
+      (is (= [:no-op] (mapv :kind (-> r :machine :cascade)))
+          "the view's :cascade carries the no-op row alone"))))
+
+(deftest genuine-self-transition-keeps-its-row-test
+  (testing "rf2-e6q97 NEGATIVE GUARD — a genuine EXTERNAL self-transition
+            (:target :same-state; :exit + :entry FIRE, microsteps > 0) is a
+            REAL transition (Spec 005 L291-296). It has a real `match`, so the
+            unhandled-no-op branch is never reached — NO :no-op row fires —
+            and the suppression MUST NOT touch its transition row."
+    (let [state [:active]
+          ;; exit + entry actions fired (the external self-transition
+          ;; semantics) and a microstep ran — a real transition, NO no-op.
+          evs   [(machine-action-ev :on-exit  :exit  :ok)
+                 (machine-action-ev :on-entry :entry :ok)
+                 (machine-transition-ev :traffic/light
+                                        {:state state} {:state state}
+                                        [:traffic/tick] 1)]
+          rows  (proj/machine-cascade-rows evs)]
+      (is (= #{:action :transition} (set (mapv :kind rows))))
+      (is (= 1 (count (filterv #(= :transition (:kind %)) rows)))
+          "the self-transition row is PRESERVED — no no-op row to trigger suppression")
+      (let [tx (first (filterv #(= :transition (:kind %)) rows))]
+        (is (= state (:from-state tx)))
+        (is (= state (:to-state tx)))
+        (is (= 1 (:microsteps tx))
+            "microsteps > 0 — a real transition, not a no-op"))))
+
+  (testing "rf2-e6q97 NEGATIVE GUARD — an INTERNAL self-transition (omit
+            :target; action runs, no exit/entry) likewise has a real match,
+            so no :no-op row — its transition row is preserved per semantics"
+    (let [state :idle
+          evs   [(machine-action-ev :tick-counter :transition :ok)
+                 (machine-transition-ev :traffic/light
+                                        {:state state} {:state state}
+                                        [:traffic/tick] 0)]
+          rows  (proj/machine-cascade-rows evs)]
+      (is (some #(= :transition (:kind %)) rows)
+          "internal self-transition row preserved (no no-op row present)")
+      (is (= 1 (count (filterv #(= :transition (:kind %)) rows)))))))
+
 (deftest unhandled-no-op-is-not-an-issue-test
   (testing "rf2-ugdas — the no-op trace's op-type is :rf.machine (NOT a
             severity), so issue-event? returns FALSE — NO pink wash, NO


### PR DESCRIPTION
## The bug

On a no-op / no-change machine bootstrap epoch (live repro: machine-epochs deck, epoch 3 = `[:traffic/light [:rf.machine/bootstrap]]`), the Epoch panel's EVENT HANDLER cascade showed TWO contradictory rows for ONE bootstrap:

1. **NO-OP:** "no-op — :traffic/light received [:rf.machine/bootstrap] in {:vehicle :red, :pedestrian :walk}, no transition — ignored"
2. **TRANSITION:** "{:vehicle :red, :pedestrian :walk} → {:vehicle :red, :pedestrian :walk} — 0 microsteps"

Row 1 says "no transition, ignored"; row 2 says "a transition occurred" — about the same bootstrap that changed nothing.

## Root cause (the projection seam)

The contradictory transition row is a **substrate trace**, not a projection-synthesized row. When an event matches no transition, `machine-transition-single` (machines · `transition.cljc`) emits ONE benign `:rf.machine.event/unhandled-no-op` and returns the snapshot unchanged. The macrostep then runs `commit-or-finalize` (machines · lifecycle_fx · `registration.cljc`), which fires `:rf.machine/transition` **unconditionally** — even when `:before` == `:after` and zero microsteps ran. So a no-op cascade carries BOTH traces, and the Epoch panel rendered both.

## The fix

Fixed in the projection (favouring "the row simply isn't produced" over hiding in the view, per the bead). In `panels/epoch/projection.cljc` `machine-cascade-rows`, a new `drop-spurious-no-op-transition` step drops every `:transition` row **iff** the cascade also carries a `:no-op` row.

The `:no-op` row is the **authoritative discriminator** that no transition was selected — `unhandled-no-op` fires from exactly the same no-match branch (flat machines) and the every-region-declined aggregate (parallel machines · `parallel.cljc`).

**Preserving real self-transitions:** a genuine EXTERNAL self-transition (`:target :same-state` — `:exit`+`:entry` fire) or INTERNAL self-transition (omit `:target` — the action runs) has a real `match`, so the unhandled-no-op branch is never reached → NO `:no-op` row → its transition row is preserved (Spec 005 L291-296, L916). Gating on the no-op row rather than `:from-state` == `:to-state` avoids over-suppressing a legitimate self-transition that lands on the same state.

## Tests (CLJS unit, reproduce-then-fix)

`tools/xray/test/.../panels/epoch/projection_cljs_test.cljc`:

- **`no-op-bootstrap-suppresses-spurious-transition-row-test`** — the `[:traffic/light [:rf.machine/bootstrap]]` no-op projects ONLY the `:no-op` row, no `{X}→{X}` 0-microstep transition row; emit-order-independent; flows through `handler-row`'s `:machine :cascade` slot (the live view surface). **RED proven first:** disabling the suppression fails exactly these 5 assertions.
- **`genuine-self-transition-keeps-its-row-test`** (negative guard) — an EXTERNAL self-transition (exit+entry fired, microsteps>0) and an INTERNAL self-transition (action ran) both KEEP their transition row.

Spec 021 (`021-Dynamic-Panel-Designs.md`) updated to document the projection-time enforcement of the "transition OR no-op, never both" contract.

## Quality gates

| Gate | Result |
|------|--------|
| xray JVM (`clojure -M:test`, covers epoch projection) | PASS — 1059 tests, 4293 assertions, 0 failures |
| `npm run test:cljs` | PASS — 5289 tests, 18157 assertions, 0 failures |
| `npm run test:xray-feature-gate` | PASS — 16 scenarios (nightly-full), 0 failures, 13 matrix rows |
| RED-then-GREEN repro | RED confirmed (5 failures with suppression disabled), GREEN with fix |

Closes #<bead> rf2-e6q97.