### PR TITLE
fix(machines): external self-transition (:same-state) fires entry per Spec 005 (rf2-46ban)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -376,10 +376,12 @@
 
 (defn- always-self-loop?
   "True iff an `:always` entry's `:target` resolves to its own declaring
-  state at `path` (a self-loop). A keyword target names a sibling at the
-  declaring level — it self-targets when it equals the declaring state's
-  own key (the last element of `path`). A vector target is an absolute
-  path — it self-targets when it equals `path`.
+  state at `path` (a self-loop). The `:same-state` sentinel is an explicit
+  external self-target (it re-enters the declaring state — see Spec 005
+  §Self-transitions, rf2-46ban), so it is always a self-loop. A keyword
+  target names a sibling at the declaring level — it self-targets when it
+  equals the declaring state's own key (the last element of `path`). A
+  vector target is an absolute path — it self-targets when it equals `path`.
 
   An `:always` entry with NO `:target` is an *internal* eventless
   transition (it runs its `:action` without changing state) — the
@@ -392,9 +394,10 @@
   [path entry]
   (let [target (:target entry)]
     (cond
-      (nil? target)     false
-      (keyword? target) (= target (peek path))
-      (vector? target)  (= target path))))
+      (nil? target)          false
+      (= :same-state target) true
+      (keyword? target)      (= target (peek path))
+      (vector? target)       (= target path))))
 
 (defn- validate-always-self-loop!
   "Per Spec 005 §Self-loop forbidden at registration: a state whose

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -636,7 +636,19 @@
 
 (defn- target-path
   "Compute the absolute target path for a transition. Per Spec 005:
+   - `:same-state` sentinel → the declaring state's OWN path (`decl-path`).
+     Marks an EXTERNAL self-transition: the state is exited and re-entered
+     (`:exit` then `:entry` both fire), the configuration unchanged. The
+     self-re-entry geometry — pulling the LCA up to the declaring state's
+     parent so the state appears in both the exit and entry cascades — is
+     `compute-cascade-paths`' job; here `:same-state` simply names the
+     declaring state as the target. Per Spec 005 §Self-transitions +
+     Spec-Schemas TransitionTarget (rf2-46ban).
    - keyword target → sibling at decl-path's level (replace last element).
+     A keyword that names the declaring state's OWN key resolves to
+     `decl-path` too, so it is the same external self-transition as
+     `:same-state` (Spec 005 §Entry/exit cascading — \"if `:target` names
+     the same state as the source, the transition is external\").
    - vector target → absolute path from root.
    - nil target (internal transition) → nil; the caller wraps the call
      in `some->>` so the nil short-circuits the initial-cascade descent.
@@ -646,7 +658,8 @@
   nil, which is the documented internal-transition contract."
   [decl-path target]
   (cond
-    (vector? target)     target
+    (= :same-state target) (vec decl-path)
+    (vector? target)       target
     (keyword? target)
     (let [parent (vec (drop-last decl-path))]
       (conj parent target))))
@@ -1227,12 +1240,30 @@
   (let [src-path      (state-path (:state snapshot))
         decl-path     (:decl-path transition (vec (take 1 src-path)))
         raw-target    (:target transition)
-        target-leaf   (some->> (target-path decl-path raw-target)
-                               (initial-cascade machine))
         internal?     (nil? raw-target)
-        lca-len       (if internal?
-                        (count src-path)
-                        (common-prefix-length src-path target-leaf))
+        ;; The target BEFORE initial-cascade re-descent. Needed to detect
+        ;; the external self-transition: a `:target` (the `:same-state`
+        ;; sentinel, or a keyword naming the declaring state's own key)
+        ;; that resolves to the declaring state itself.
+        target-base   (target-path decl-path raw-target)
+        target-leaf   (some->> target-base (initial-cascade machine))
+        ;; Per Spec 005 §Self-transitions + §Entry/exit cascading: an
+        ;; EXTERNAL self-transition re-enters the declaring state — `:exit`
+        ;; then transition `:action` then `:entry` all fire, the
+        ;; configuration unchanged. The LCA-driven cascade fires `:exit` /
+        ;; `:entry` only on states BELOW the LCA, so a self-target's plain
+        ;; common-prefix LCA (= the full declaring path) would fire neither.
+        ;; Pull the LCA up to the declaring state's PARENT so the declaring
+        ;; state lands in both the exit and entry cascades. A self-target on
+        ;; a compound state re-enters it AND re-runs its `:initial` child
+        ;; cascade (`target-leaf` re-descended above). An INTERNAL
+        ;; self-transition (no `:target`) is untouched — it never reaches
+        ;; here (`internal?` short-circuits exit/entry below). rf2-46ban.
+        self-transition? (and (not internal?) (= target-base decl-path))
+        lca-len       (cond
+                        internal?        (count src-path)
+                        self-transition? (dec (count target-base))
+                        :else            (common-prefix-length src-path target-leaf))
         ;; Walk each path once; reuse the `[prefix node]` pair vectors
         ;; for both the cascade ref derivation AND the spawn/destroy fx
         ;; emission downstream (per audit §T6 #2 — eliminate the double

--- a/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
@@ -177,3 +177,117 @@
       (rf/dispatch-sync [:rf2-fhb9/parent-walk [:unknown]])
       (is (= [:parent-wildcard] @log)
           "no explicit anywhere — parent's :* fires"))))
+
+;; ---- external vs internal self-transitions (rf2-46ban) -------------------
+;; Per Spec 005 §Self-transitions + §Entry/exit cascading: an EXTERNAL
+;; self-transition (`:target :same-state`, or a `:target` naming the
+;; declaring state's own keyword) re-enters the state — `:exit` then the
+;; transition's `:action` then `:entry` all fire, the configuration
+;; unchanged. An INTERNAL self-transition (omit `:target`) fires the action
+;; ONLY, no exit/entry. On a COMPOUND state the external self-transition
+;; also re-runs the `:initial`-child entry cascade. This ns exercises the
+;; live runtime; the pure-engine ordering is pinned in the SCXML conformance
+;; corpus (`scxml-external-self-transition-*`).
+(deftest machine-self-transition-cljs
+  (testing "external self-transition (:target :same-state) on a flat leaf —
+            exit → action → entry, state unchanged"
+    (let [log (atom [])
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
+          machine
+          {:initial :idle
+           :data    {}
+           :actions {:enter-idle (tag :enter-idle)
+                     :exit-idle  (tag :exit-idle)
+                     :poke       (tag :poke)}
+           :states
+           {:idle {:entry :enter-idle
+                   :exit  :exit-idle
+                   :on    {:refresh {:target :same-state :action :poke}}}}}]
+      (rf/reg-machine :self/flat-same-state machine)
+      ;; Prime: the first dispatch fires the bootstrap initial-cascade
+      ;; entry (per rf2-0z73). A benign unhandled event drives that
+      ;; bootstrap without touching :idle, so the reset below leaves only
+      ;; the self-transition's own exit/action/entry in the log.
+      (rf/dispatch-sync [:self/flat-same-state [:rf2-46ban/prime]])
+      (reset! log [])
+      (rf/dispatch-sync [:self/flat-same-state [:refresh]])
+      (is (= :idle (:state (snapshot :self/flat-same-state)))
+          "external self-transition leaves the configuration at the source")
+      (is (= [:exit-idle :poke :enter-idle] @log)
+          "exit → action → entry — the state is re-entered (external semantics)")))
+
+  (testing "external self-transition naming the state's OWN keyword —
+            identical exit → action → entry as :same-state"
+    (let [log (atom [])
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
+          machine
+          {:initial :idle
+           :data    {}
+           :actions {:enter-idle (tag :enter-idle)
+                     :exit-idle  (tag :exit-idle)
+                     :poke       (tag :poke)}
+           :states
+           {:idle {:entry :enter-idle
+                   :exit  :exit-idle
+                   :on    {:refresh {:target :idle :action :poke}}}}}]
+      (rf/reg-machine :self/flat-own-keyword machine)
+      (rf/dispatch-sync [:self/flat-own-keyword [:rf2-46ban/prime]])  ;; consume bootstrap entry
+      (reset! log [])
+      (rf/dispatch-sync [:self/flat-own-keyword [:refresh]])
+      (is (= :idle (:state (snapshot :self/flat-own-keyword)))
+          "a self-naming keyword target stays at the source state")
+      (is (= [:exit-idle :poke :enter-idle] @log)
+          "exit → action → entry — same as the :same-state sentinel")))
+
+  (testing "INTERNAL self-transition (omit :target) — action ONLY, no
+            exit/entry, state unchanged"
+    (let [log (atom [])
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
+          machine
+          {:initial :idle
+           :data    {}
+           :actions {:enter-idle (tag :enter-idle)
+                     :exit-idle  (tag :exit-idle)
+                     :poke       (tag :poke)}
+           :states
+           {:idle {:entry :enter-idle
+                   :exit  :exit-idle
+                   :on    {:refresh {:action :poke}}}}}]    ;; no :target
+      (rf/reg-machine :self/flat-internal machine)
+      (rf/dispatch-sync [:self/flat-internal [:rf2-46ban/prime]])    ;; consume bootstrap entry
+      (reset! log [])
+      (rf/dispatch-sync [:self/flat-internal [:refresh]])
+      (is (= :idle (:state (snapshot :self/flat-internal)))
+          "internal self-transition leaves the configuration unchanged")
+      (is (= [:poke] @log)
+          "ONLY the action fired — no exit, no entry (internal semantics preserved)")))
+
+  (testing "external self-transition on a COMPOUND state — re-runs the
+            state's :entry AND its :initial-child entry cascade"
+    (let [log (atom [])
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
+          machine
+          {:initial :session
+           :data    {}
+           :actions {:enter-session (tag :enter-session)
+                     :exit-session  (tag :exit-session)
+                     :enter-active  (tag :enter-active)
+                     :exit-active   (tag :exit-active)
+                     :renew         (tag :renew)}
+           :states
+           {:session
+            {:initial :active
+             :entry   :enter-session
+             :exit    :exit-session
+             ;; declared ON the compound — :same-state re-enters :session
+             :on      {:reauth {:target :same-state :action :renew}}
+             :states
+             {:active {:entry :enter-active :exit :exit-active}}}}}]
+      (rf/reg-machine :self/compound-same-state machine)
+      (rf/dispatch-sync [:self/compound-same-state [:rf2-46ban/prime]])  ;; consume bootstrap entries
+      (reset! log [])
+      (rf/dispatch-sync [:self/compound-same-state [:reauth]])
+      (is (= [:session :active] (:state (snapshot :self/compound-same-state)))
+          "compound external self-transition re-descends the :initial child")
+      (is (= [:exit-active :exit-session :renew :enter-session :enter-active] @log)
+          "exit cascade leaf→root → action → entry cascade root→leaf (re-runs :initial)"))))

--- a/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
@@ -100,21 +100,19 @@
       ever support history is a SEPARATE post-v1 decision, out of scope for
       this corpus.
 
-  ## Divergences found (reported for follow-up — see §Self-transitions)
+  ## Divergences found
 
-  This corpus PINS one genuine semantic divergence from the SCXML core:
-  **external self-transition semantics are not implemented**. Per Spec 005
-  §Self-transitions and Spec-Schemas TransitionTarget, `:target :same-state`
-  (and a `:target` naming the source state's own keyword) must fire BOTH
-  the source `:exit` and the re-entered `:entry`, leaving the state
-  unchanged. The engine today does neither correctly. The two tests in
-  §Self-transitions are split into the parts that PASS (internal omit-target
-  semantics; the action fires) and a DOCUMENTED-DIVERGENCE test
-  (`scxml-external-self-transition-DIVERGENCE`) that asserts the engine's
-  ACTUAL (non-conformant) behaviour so the gap is pinned and visible rather
-  than hidden behind a skipped assertion. The engine fix is out of this
-  bead's test-authoring scope; the divergence is reported in the PR for a
-  follow-up engine bead."
+  This corpus originally PINNED one semantic divergence from the SCXML
+  core: **external self-transition semantics were not implemented**. That
+  divergence is now RESOLVED by rf2-46ban. Per Spec 005 §Self-transitions
+  and Spec-Schemas TransitionTarget, `:target :same-state` (and a `:target`
+  naming the source state's own keyword) fire BOTH the source `:exit` and
+  the re-entered `:entry`, leaving the state unchanged. The §Self-transitions
+  tests assert the conformant ordering: the INTERNAL omit-target case fires
+  the action only (no exit/entry), and the two EXTERNAL cases
+  (`scxml-external-self-transition-same-state-sentinel` /
+  `…-own-keyword-target`) fire exit → action → entry and stay at the source.
+  No outstanding divergences remain in this corpus."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
@@ -638,16 +636,15 @@
 ;; transitions: `:target :same-state` (external) fires exit+entry; omit
 ;; `:target` (internal) fires neither.
 ;;
-;; FINDING — DIVERGENCE: the engine implements the INTERNAL (omit-target)
-;; case correctly, but does NOT implement EXTERNAL self-transition
-;; semantics. `:target :same-state` is treated as a literal sibling-keyword
-;; target named `:same-state` (no `:same-state` sentinel handling exists in
-;; `re-frame.machines.transition/target-path`), so it fires exit + action
-;; but NOT entry, and lands the snapshot in a bogus `:same-state`. A
-;; `:target` naming the source's own keyword computes LCA = full path, so
-;; neither exit nor entry fires (action only). Pinned below as a documented
-;; divergence; engine fix is out of this bead's scope (reported for a
-;; follow-up engine bead).
+;; RESOLVED BY rf2-46ban: the engine now implements EXTERNAL self-transition
+;; semantics. `re-frame.machines.transition/target-path` resolves the
+;; `:same-state` sentinel (and a `:target` naming the declaring state's own
+;; keyword) to the declaring state's own path, and `compute-cascade-paths`
+;; pulls the LCA up to that state's parent so the state lands in BOTH the
+;; exit and entry cascades — exit → action → entry fire, the configuration
+;; unchanged. The INTERNAL (omit-target) case is unchanged: action only, no
+;; exit/entry. The former DOCUMENTED-DIVERGENCE test below is flipped to
+;; assert the SCXML-conformant ordering + landing state.
 ;; ===========================================================================
 
 (deftest scxml-internal-self-transition-fires-action-only
@@ -667,34 +664,38 @@
       (is (= [:action] @log)
           "ONLY the action fired — no onexit, no onentry (internal semantics, SCXML-conformant)"))))
 
-(deftest ^{:doc "DOCUMENTED DIVERGENCE — see ns docstring §Divergences and §10 FINDING."}
-  scxml-external-self-transition-DIVERGENCE
+(deftest scxml-external-self-transition-same-state-sentinel
   (testing "SCXML §3.13 external self-transition (`:target :same-state`)
-            SHOULD fire onexit THEN onentry of the source, leaving the
-            configuration at the source state. Spec 005 §Self-transitions +
-            Spec-Schemas TransitionTarget (`:same-state` is a documented
-            literal sentinel).
-
-            DIVERGENCE: the engine has NO `:same-state` sentinel handling;
-            it treats `:same-state` as a literal sibling-keyword target.
-            This test asserts the engine's ACTUAL (non-conformant)
-            behaviour so the gap is PINNED and visible. When the engine is
-            fixed (follow-up bead), the SCXML-conformant expectation in the
-            comment below should replace these assertions."
+            fires onexit THEN the transition's action THEN onentry of the
+            source, leaving the configuration at the source state. Spec 005
+            §Self-transitions + Spec-Schemas TransitionTarget (`:same-state`
+            is the documented literal sentinel). Resolved by rf2-46ban."
     (let [[log mk] (order-recorder)
           m {:initial :a :data {}
              :states {:a {:entry (mk :entry) :exit (mk :exit)
                           :on {:self {:target :same-state :action (mk :action)}}}}}
           r (step m {:state :a :data {}} [:self])]
-      ;; SCXML-CONFORMANT expectation (what the engine SHOULD produce):
-      ;;   (is (= :a (:state r)) "external self-transition stays at the source")
-      ;;   (is (= [:exit :action :entry] @log) "onexit → action → onentry")
-      ;; ACTUAL (non-conformant) engine behaviour, pinned to make the
-      ;; divergence loud:
-      (is (= :same-state (:state r))
-          "DIVERGENCE: `:same-state` treated as a literal sibling-keyword target (no sentinel handling)")
-      (is (= [:exit :action] @log)
-          "DIVERGENCE: onexit + action fire, but onentry does NOT (target sibling does not resolve to a real node)"))))
+      (is (= :a (:state r))
+          "external self-transition stays at the source state")
+      (is (= [:exit :action :entry] @log)
+          "onexit → action → onentry (external self-transition re-enters the state)"))))
+
+(deftest scxml-external-self-transition-own-keyword-target
+  (testing "SCXML §3.13 / Spec 005 §Entry/exit cascading: a `:target`
+            naming the declaring state's OWN keyword is ALSO an external
+            self-transition (\"if `:target` names the same state as the
+            source, the transition is external — exit and entry fire\").
+            Same exit → action → entry ordering as `:same-state`.
+            Resolved by rf2-46ban."
+    (let [[log mk] (order-recorder)
+          m {:initial :a :data {}
+             :states {:a {:entry (mk :entry) :exit (mk :exit)
+                          :on {:self {:target :a :action (mk :action)}}}}}
+          r (step m {:state :a :data {}} [:self])]
+      (is (= :a (:state r))
+          "a self-naming keyword target stays at the source state")
+      (is (= [:exit :action :entry] @log)
+          "onexit → action → onentry — identical to the `:same-state` sentinel"))))
 
 ;; ===========================================================================
 ;; §11. :after — delayed transitions (SEMANTIC CORE: fire + stale)


### PR DESCRIPTION
## What

P2 correctness bug in the machine engine, found by the rf2-rkkag SCXML conformance corpus (#2842). An **external self-transition** (`:target :same-state`, or a `:target` naming the source state's own keyword) did not fire `:entry`, violating Spec 005 §Self-transitions + Spec-Schemas `TransitionTarget`.

Before the fix:
- `:target :same-state` → fired `:exit` + transition `:action` but **not** `:entry`, and landed the actor in a bogus literal `:same-state` value (`target-path` had no sentinel handling, so `:same-state` was treated as a sibling keyword).
- `:target` naming the source's own keyword → action only (its common-prefix LCA was the full path, so neither exit nor entry fired).

## The fix

- **`transition/target-path`** resolves the `:same-state` sentinel to the declaring state's own path. A keyword naming the declaring state's own key already resolves to that same path, so both forms are the one external self-transition.
- **`transition/compute-cascade-paths`** detects an external self-transition (resolved `target-base == decl-path`) and pulls the LCA up to that state's **parent**, so the declaring state lands in BOTH the exit and entry cascades. The LCA-driven cascade then fires `:exit` → transition `:action` → `:entry`, configuration unchanged. A compound state's external self-transition re-runs its `:initial`-child entry cascade (`target-leaf` is re-descended through `initial-cascade`).
- **Internal self-transitions stay intact**: omitting `:target` keeps `internal? = true`, which short-circuits the exit/entry cascade — action only, no exit/entry. The self-transition geometry only runs when `(not internal?)`.
- **Parallel regions**: a region self-transition flows through the same `apply-transition-once` path (each region runs as a synthetic single-machine spec via `reduce-regions`), so the fix covers parallel regions with no `parallel.cljc` change.
- **`lifecycle-fx/validation/always-self-loop?`** now recognises `:same-state` as a self-target, so an `:always {:target :same-state}` is still rejected at registration (the sentinel is now live and would otherwise run an external self-loop to depth-exceeded — the exact footgun that validator prevents).

No spec edits: the Spec 005 / Spec-Schemas contract was already correct; the engine was the gap. No back-compat shim (pre-alpha).

## Tests

- **Flipped the rkkag divergence test** `scxml-external-self-transition-DIVERGENCE` → `scxml-external-self-transition-same-state-sentinel`: from documenting the bug (pinned `:state = :same-state`, log `[:exit :action]`) to asserting the conformant `:state = :a` + `[:exit :action :entry]`. Added `scxml-external-self-transition-own-keyword-target` for the keyword-naming-own-state form. Dropped the `^{:doc DIVERGENCE}` marker; updated the ns §Divergences note to "resolved by rf2-46ban".
- **Focused live-runtime unit tests** (`machines_hierarchical_cljs_test`, `machine-self-transition-cljs`): flat `:same-state` (exit→action→entry, state unchanged), flat own-keyword (identical), internal omit-target (action only — internal semantics preserved), and a **compound** external self-transition re-running the initial-child entry cascade (`[:exit-active :exit-session :renew :enter-session :enter-active]`).
- RED→GREEN: with the fix in place the JVM run showed exactly the two old divergence assertions failing (state now `:a` not `:same-state`; log now includes `:entry`) and all other tests green — confirming the fix produces the conformant behaviour the flipped test now asserts.

## Quality gates

| Gate | Result |
| --- | --- |
| `npm run test:cljs` (cold build) | PASS — 5324 tests, 18221 assertions, 0 failures, 0 errors |
| `clojure -M:test` (machines, JVM) | PASS — 326 tests, 1047 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` | PASS — 16 scenarios, 0 failures, 13 matrix rows (machine-epochs deck renders self-transitions — no regression) |
| `mkdocs build --strict` | N/A — no spec/docs files edited (contract already correct) |

The conformance corpus + transition tests are `.cljc`, so both runtimes (JS via test:cljs, JVM via clojure -M:test) exercise the same engine code and agree.

Closes rf2-46ban.