### PR TITLE
test(xray): canonical hard-machine devtools-legibility fixture + rendering-fidelity assertions (rf2-k08ay)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -182,7 +182,12 @@ taken only for sets.
 > set-valued app-db key, a sub result — reading as "the key vanished"
 > rather than "one member swapped." Surfaced live on the machine-epochs
 > deck (`[:rf/runtime :machines :snapshots :door/main :tags]`, rf2-l0us2,
-> related rf2-iwy0c). This is the FULL+DIFF family's set-keyed counterpart
+> related rf2-iwy0c). The deck's canonical HARD machine (`:hvac/controller`,
+> rf2-k08ay) drives the richer case: a `:hvac/mode-toggle` swaps
+> `:climate/heating` for `:climate/cooling` in the `:tags` set, and the
+> rendering-fidelity test (`panels.epoch.hard-machine-fidelity-cljs-test`)
+> pins that exactly one member joined + one left at member level (no
+> wholly-replaced blob). This is the FULL+DIFF family's set-keyed counterpart
 > to the rf2-bufw2 empty-collection and rf2-9d4j8 root-container honesty
 > fixes: all three close gaps where the wholly-changed uniformity walk
 > disagreed with the per-leaf op classification.

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
@@ -1,0 +1,476 @@
+(ns day8.re-frame2-xray.panels.epoch.hard-machine-fidelity-cljs-test
+  "Rendering-FIDELITY assertions for the canonical HARD machine
+  (`:hvac/controller`, the `machine_epochs` testbed's MACHINE 4 — rf2-k08ay).
+
+  ## Why this test exists — the gap it closes
+
+  The no-op render bug (rf2-e6q97 · #2841) was a devtools-NARRATION miss: the
+  engine semantics were correct and unit-tested, but Xray rendered them
+  misleadingly (a spurious `{X}→{X}` 0-microstep transition row beside the
+  benign no-op). Our machine tests assert what the ENGINE PRODUCES; nothing
+  asserted what the TOOL DISPLAYS. This test closes that thin spot.
+
+  It is the COMPLEMENT to the SCXML semantic corpus (rf2-rkkag · #2842 —
+  `re_frame.scxml_conformance_cljs_test`): that proves the engine's
+  SEMANTICS (external self-transition fires exit+entry, internal fires
+  action-only, the LCA cascade orders deepest-exit-first / shallowest-entry-
+  first); THIS proves the DEVTOOLS RENDER those semantics legibly. Different
+  layers.
+
+  ## What it drives + asserts
+
+  It registers the SAME hard machine the testbed mounts (a self-contained
+  copy so the test is independent of the testbed build), drives it through
+  the LIVE machine substrate (`reg-machine` / `dispatch-sync` — the surface
+  real apps use), captures the trace stream Xray's ring buffer recorded, and
+  feeds it through the rendering layers that FEED the devtools render:
+
+    - `proj/machine-cascade-rows` — the Epoch panel's per-epoch machine
+      cascade (the exit/action/entry rows; the canonical sort; the
+      no-op-transition suppression).
+    - `mih/project-focused-event-transitions` — the Machine Inspector's
+      focused-event view-model (one record per transition; parallel → ≥2).
+    - `topo/parse-definition` — the inspector's topology projection
+      (compound nesting + parallel regions rendered legibly).
+    - `diff/project` — the snapshot diff (member-level set diff for `:tags`,
+      rf2-l0us2).
+
+  Asserting the projected ROWS / LABELS / records are unambiguous is the
+  testable proxy for 'the devtools render legibly' — this is a Causa/Story-
+  style CLJS unit test (per `feedback_causa_story_cljs_unit_tests_not_playwright`),
+  NOT a Playwright spec. The render facts are pinned against REALITY: drive
+  the substrate, read what the projection produces.
+
+  ## The four hard cases (one coherent machine)
+
+    1. DEEP COMPOUND NESTING — `:climate` region four levels deep
+       (`[:running :conditioning :heating]`).
+    2. PARALLEL / ORTHOGONAL REGIONS — `:type :parallel`; `:hvac/power-cycle`
+       handled by BOTH `:climate` and `:fan` simultaneously.
+    3. ALL ACTION KINDS WITH OBSERVABLE LCA ORDERING — every exit/action/entry
+       appends a `<phase>:<state>` tag to a shared `:trail`; the cascade
+       order is the trail order.
+    4. INTERNAL vs EXTERNAL SELF-TRANSITIONS — external (`:target :same-state`,
+       #2843) fires exit+entry; internal (omit `:target`) fires action-only;
+       neither emits a spurious no-op transition row (#2841)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.diff.engine :as diff]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.panels.machine-inspector-helpers :as mih]
+            [day8.re-frame2-xray.panels.machines.topology :as topo]
+            [day8.re-frame2-xray.preload :as preload]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+;; ============================================================================
+;; The hard machine — a self-contained copy of the testbed's :hvac/controller.
+;; ============================================================================
+;;
+;; Kept verbatim-equivalent to `machine_epochs/core.cljs` MACHINE 4 (the
+;; trail-action factory + the parallel/compound/self-transition shape). The
+;; testbed's copy is what an operator SEES; this copy is what the test DRIVES.
+;; A drift between them is acceptable only if the rendered facts asserted
+;; below still hold — those facts are the contract, not the literal source.
+
+(defn- trail-action
+  "Append one labeled tag to `[:data :trail]` — the cascade-order recorder.
+  `label` is `<phase>:<state>`."
+  [nm label]
+  (with-meta
+    (fn [{data :data}]
+      {:data (update data :trail (fnil conj []) label)})
+    {:name nm}))
+
+(def hvac-controller-machine
+  {:type :parallel
+   :data {:trail []}
+   :regions
+   {:climate
+    {:initial :idle
+     :states
+     {:idle
+      {:tags #{:climate/idle}
+       :on   {:hvac/power-cycle {:target :running :action :enter-running}}}
+      :running
+      {:tags    #{:climate/running}
+       :initial :conditioning
+       :entry   :enter-running-level
+       :exit    :exit-running-level
+       :on      {:hvac/power-cycle {:target :idle :action :back-to-idle}}
+       :states
+       {:conditioning
+        {:tags    #{:climate/conditioning}
+         :initial :heating
+         :entry   :enter-conditioning
+         :exit    :exit-conditioning
+         :states
+         {:heating
+          {:tags  #{:climate/heating}
+           :entry :enter-heating
+           :exit  :exit-heating
+           :on    {:hvac/mode-toggle {:target :cooling :action :swap-mode}}}
+          :cooling
+          {:tags  #{:climate/cooling}
+           :entry :enter-cooling
+           :exit  :exit-cooling
+           :on    {:hvac/mode-toggle {:target :heating :action :swap-mode}}}}}}}}}
+    :fan
+    {:initial :off
+     :states
+     {:off
+      {:tags #{:fan/off}
+       :on   {:hvac/power-cycle {:target :on :action :fan-on}}}
+      :on
+      {:tags  #{:fan/on}
+       :entry :enter-fan-on
+       :exit  :exit-fan-on
+       :on    {:hvac/power-cycle {:target :off :action :fan-off}
+               :hvac/nudge {:target :same-state :action :nudge-fan}
+               :hvac/tweak {:action :tweak-fan}}}}}}
+   :actions
+   {:enter-running       (trail-action 'enter-running       :action:power-on)
+    :enter-running-level (trail-action 'enter-running-level :entry:running)
+    :exit-running-level  (trail-action 'exit-running-level  :exit:running)
+    :back-to-idle        (trail-action 'back-to-idle        :action:power-off)
+    :enter-conditioning  (trail-action 'enter-conditioning  :entry:conditioning)
+    :exit-conditioning   (trail-action 'exit-conditioning   :exit:conditioning)
+    :enter-heating       (trail-action 'enter-heating       :entry:heating)
+    :exit-heating        (trail-action 'exit-heating        :exit:heating)
+    :enter-cooling       (trail-action 'enter-cooling       :entry:cooling)
+    :exit-cooling        (trail-action 'exit-cooling        :exit:cooling)
+    :swap-mode           (trail-action 'swap-mode           :action:swap-mode)
+    :fan-on              (trail-action 'fan-on              :action:fan-on)
+    :fan-off             (trail-action 'fan-off             :action:fan-off)
+    :enter-fan-on        (trail-action 'enter-fan-on        :entry:fan-on)
+    :exit-fan-on         (trail-action 'exit-fan-on         :exit:fan-on)
+    :nudge-fan           (trail-action 'nudge-fan           :action:nudge)
+    :tweak-fan           (trail-action 'tweak-fan           :action:tweak)}})
+
+;; ============================================================================
+;; fixture
+;; ============================================================================
+
+(defn- xray-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-collector/reset-for-test!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn xray-init!}))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  ;; Activate the trace-collector so machine `trace/emit!` calls land in
+  ;; Xray's ring buffer (the same surface the Epoch panel reads).
+  (preload/register-trace-collector!)
+  (rf/reg-machine :hvac/controller hvac-controller-machine)
+  ;; Boot to the initial parallel configuration; clear any bootstrap trace so
+  ;; the per-case capture below contains only that case's macrostep.
+  (rf/dispatch-sync [:hvac/controller [:rf.machine/bootstrap]]))
+
+(defn- snapshot
+  "Read the live snapshot for `:hvac/controller` off the default frame."
+  []
+  (get-in (rf/app-db-value :rf/default)
+          [:rf/runtime :machines :snapshots :hvac/controller]))
+
+(defn- drive!
+  "Dispatch one event into the hard machine and return the trace stream it
+  produced as an epoch-record-shaped map. Resets the trace buffer first so
+  the captured cascade is exactly this macrostep."
+  [event-v]
+  (trace-collector/reset-for-test!)
+  (rf/dispatch-sync [:hvac/controller event-v])
+  {:event-id     :hvac/controller
+   :trigger-event [:hvac/controller event-v]
+   :trace-events (vec (trace-collector/buffer-for-test))})
+
+(defn- cascade [record]
+  (proj/machine-cascade-rows (:trace-events record)))
+
+(defn- rows-of-kind [rows kind]
+  (filterv #(= kind (:kind %)) rows))
+
+;; ============================================================================
+;; CASE 2 — PARALLEL regions: one event, BOTH regions render
+;; ============================================================================
+
+(deftest power-cycle-renders-parallel-broadcast-legibly
+  (testing "rf2-k08ay case 2 — `:hvac/power-cycle` is handled by BOTH the
+            `:climate` and `:fan` regions in ONE macrostep. A parallel machine
+            commits ONE snapshot per macrostep, so the Epoch cascade renders a
+            SINGLE aggregate transition row — but its before/after `:state` is
+            a region→state MAP that shows BOTH regions moved, and the action
+            cascade carries action rows from BOTH regions. That is how the
+            operator reads 'one event, both regions advanced'; the chart
+            highlights an active leaf in each region. Pinned against the LIVE
+            substrate."
+    (setup!)
+    (let [record (drive! [:hvac/power-cycle])
+          rows   (cascade record)
+          tx     (rows-of-kind rows :transition)
+          tx-row (first tx)
+          action-ids (set (map :action-id (rows-of-kind rows :action)))
+          ;; the inspector view-model the chart + focused-lens consume
+          inspector (mih/project-focused-event-transitions
+                      (:trace-events record)
+                      {:hvac/controller hvac-controller-machine})]
+      ;; ONE aggregate transition row — the parallel macrostep commits once.
+      (is (= 1 (count tx))
+          "a parallel machine renders ONE aggregate transition row per
+           macrostep (one snapshot commit)")
+      ;; …whose before/after `:state` is a region→state MAP showing BOTH
+      ;; regions moved — the legible parallel render the chart highlights.
+      (is (= {:climate :idle :fan :off} (:from-state tx-row))
+          "the transition's FROM renders both regions' prior leaves")
+      (is (= {:climate [:running :conditioning :heating] :fan :on}
+             (:to-state tx-row))
+          "the transition's TO renders both regions' new leaves — climate
+           descended its full initial cascade to the deepest leaf, fan swung
+           to :on, in one event")
+      ;; Action rows from BOTH regions surface in the cascade (the broadcast
+      ;; hit both): climate's :fan-on counterpart + fan's entry.
+      (is (contains? action-ids :enter-heating)
+          "climate region's deep entry action renders in the cascade")
+      (is (contains? action-ids :enter-fan-on)
+          "fan region's entry action renders in the cascade — proof the one
+           event broadcast to both regions")
+      ;; No `:no-op` row — both regions handled the event (a genuine parallel
+      ;; broadcast is NOT an unhandled no-op).
+      (is (empty? (rows-of-kind rows :no-op))
+          "a handled parallel broadcast renders NO benign-no-op notice")
+      ;; The inspector's focused-event lens projects the macrostep's single
+      ;; transition record — its :after snapshot carries BOTH regions so the
+      ;; chart highlights a leaf in each.
+      (is (= 1 (count inspector))
+          "the inspector projects the macrostep's single transition record")
+      (is (= {:climate [:running :conditioning :heating] :fan :on}
+             (get-in (first inspector) [:after :state]))
+          "the inspector record's :after snapshot carries both regions' leaves
+           — the chart highlights an active leaf in EACH region")
+      ;; The live configuration landed in both regions' target leaves.
+      (is (= {:climate [:running :conditioning :heating] :fan :on}
+             (:state (snapshot)))
+          "the committed snapshot moved both regions in one macrostep"))))
+
+;; ============================================================================
+;; CASE 1 + 3 — DEEP COMPOUND nesting + the multi-level LCA cascade ORDER
+;; ============================================================================
+
+(deftest mode-toggle-renders-lca-cascade-in-canonical-order
+  (testing "rf2-k08ay cases 1+3 — `:hvac/mode-toggle` (`:heating` → `:cooling`)
+            crosses the LCA `:conditioning`. Per Spec 005 §Level 2 the action
+            group fires exit (deepest-first) → transition `:action` @ LCA →
+            entry (shallowest-first). The Epoch cascade RE-SORTS rows into the
+            canonical `guard → exit → TRANSITION → entry` rank (rf2-tjqd8); the
+            rendered order must read as the statechart does. The shared
+            `:trail` is that order made visible — the snapshot `:data` Δ the
+            panel renders shows it directly."
+    (setup!)
+    ;; Get into :heating first (power-cycle descends the initial cascade).
+    (drive! [:hvac/power-cycle])
+    (let [record (drive! [:hvac/mode-toggle])
+          rows   (cascade record)
+          ;; the rendered cascade order, by kind+phase
+          rendered (mapv (fn [r] [(:kind r) (:phase r)]) rows)
+          tx-idx   (->> rendered (keep-indexed (fn [i kp] (when (= :transition (first kp)) i))) first)
+          exit-idxs  (->> rendered (keep-indexed (fn [i [k p]] (when (and (= :action k) (= :exit p)) i))))
+          entry-idxs (->> rendered (keep-indexed (fn [i [k p]] (when (and (= :action k) (= :entry p)) i))))]
+      ;; Structural render order: every exit row sorts BEFORE the transition
+      ;; row, every entry row sorts AFTER it (the canonical statechart read).
+      (is (some? tx-idx) "a transition row renders")
+      (when (and tx-idx (seq exit-idxs))
+        (is (every? #(< % tx-idx) exit-idxs)
+            "exit rows render BEFORE the transition row (leave the old state first)"))
+      (when (and tx-idx (seq entry-idxs))
+        (is (every? #(> % tx-idx) entry-idxs)
+            "entry rows render AFTER the transition row (enter the new state last)"))
+      ;; The trail (the snapshot :data Δ) is the cascade order, made legible.
+      ;; mode-toggle's macrostep appends exactly: exit:heating, action:swap-mode,
+      ;; entry:cooling (LCA :conditioning is NOT exited/entered — it stays
+      ;; active, so :exit-conditioning / :enter-conditioning do NOT fire).
+      (let [trail-before (get-in (snapshot) [:data :trail])]
+        ;; snapshot is already post-toggle; recompute the per-macrostep delta
+        ;; off the transition row's :data-before → :data-after.
+        (let [tx-row     (first (rows-of-kind rows :transition))
+              data-before (:data-before tx-row)
+              data-after  (:data-after tx-row)
+              delta       (vec (drop (count (:trail data-before)) (:trail data-after)))]
+          (is (= [:exit:heating :action:swap-mode :entry:cooling] delta)
+              "the macrostep's trail delta IS the LCA cascade order: exit the
+               deepest leaf → the transition action at the LCA → enter the new
+               leaf. :conditioning (the LCA) stays active, so its exit/entry do
+               NOT fire.")
+          (is (vector? trail-before)))))
+    ;; The live configuration toggled to :cooling under the same compound path.
+    (is (= [:running :conditioning :cooling] (:climate (:state (snapshot))))
+        "the deep compound leaf moved heating → cooling, parent path intact")))
+
+(deftest topology-projection-renders-compound-and-parallel-legibly
+  (testing "rf2-k08ay case 1 — the Machine Inspector's topology projection
+            (`topo/parse-definition`, the layer that feeds the chart) must
+            render the deep compound nesting AND the parallel regions without
+            contradiction: every region's leaves appear, the deepest compound
+            level is reachable, and the parallel root has no single initial
+            path (each region carries its own)."
+    (let [{:keys [nodes edges initial-path]} (topo/parse-definition hvac-controller-machine)
+          paths (set (map :path nodes))]
+      ;; Parallel root → no single initial path (each region owns its own).
+      (is (nil? initial-path)
+          "a parallel machine has no single initial path — the chart shows
+           each region's own initial leaf")
+      ;; Both regions' leaves are present (concatenated, flat per region).
+      (is (contains? paths [:idle])    "climate :idle leaf rendered")
+      (is (contains? paths [:running]) "climate :running compound rendered")
+      (is (contains? paths [:running :conditioning])
+          "the mid compound level rendered")
+      (is (contains? paths [:running :conditioning :heating])
+          "the DEEPEST compound leaf rendered — the four-level path is legible")
+      (is (contains? paths [:running :conditioning :cooling])
+          "its sibling leaf rendered")
+      (is (contains? paths [:off]) "fan :off leaf rendered")
+      (is (contains? paths [:on])  "fan :on leaf rendered")
+      ;; The compound parent is flagged compound so the chart nests it.
+      (let [running (first (filter #(= [:running] (:path %)) nodes))
+            heating (first (filter #(= [:running :conditioning :heating] (:path %)) nodes))]
+        (is (:compound? running) ":running renders as a compound (nestable) node")
+        (is (not (:compound? heating)) ":heating renders as a leaf"))
+      ;; The mode-toggle edge between the deep leaves is present + labeled.
+      (is (some (fn [e] (and (= [:running :conditioning :heating] (:from e))
+                             (= [:running :conditioning :cooling] (:to e))
+                             (= :hvac/mode-toggle (:event e))))
+                edges)
+          "the heating→cooling toggle edge renders with its event label"))))
+
+;; ============================================================================
+;; CASE 4 — INTERNAL vs EXTERNAL self-transitions (the case #2843 fixed)
+;; ============================================================================
+
+(deftest external-self-transition-renders-exit-and-entry
+  (testing "rf2-k08ay case 4 (external) — `:hvac/nudge` is an external
+            self-transition (`:target :same-state`). Per Spec 005 §Self-
+            transitions + rf2-46ban (#2843) it re-enters the state: `:exit`
+            THEN action THEN `:entry` fire, configuration unchanged. The Epoch
+            cascade must render BOTH an exit row and an entry row (so the
+            operator sees the re-entry), and — critically per rf2-e6q97
+            (#2841) — must NOT render a spurious `{:on}→{:on}` no-op transition
+            row (a genuine self-transition is a REAL transition, not an
+            unhandled no-op)."
+    (setup!)
+    (drive! [:hvac/power-cycle]) ; fan → :on
+    (let [record (drive! [:hvac/nudge])
+          rows   (cascade record)
+          exit-rows  (filterv #(and (= :action (:kind %)) (= :exit (:phase %))) rows)
+          entry-rows (filterv #(and (= :action (:kind %)) (= :entry (:phase %))) rows)]
+      (is (seq exit-rows)
+          "external self-transition renders an EXIT row (the state is left)")
+      (is (seq entry-rows)
+          "external self-transition renders an ENTRY row (the state is re-entered)")
+      (is (empty? (rows-of-kind rows :no-op))
+          "a genuine self-transition is NOT a no-op — no benign-no-op notice")
+      ;; The trail delta for this macrostep is exit → action → entry (the
+      ;; re-entry made visible) — the foil to the internal case below.
+      (let [tx-row      (first (rows-of-kind rows :transition))
+            data-before (:data-before tx-row)
+            data-after  (:data-after tx-row)
+            delta       (vec (drop (count (:trail data-before)) (:trail data-after)))]
+        (is (= [:exit:fan-on :action:nudge :entry:fan-on] delta)
+            "external self-transition's trail delta: exit → action → entry —
+             the state re-enters itself"))
+      ;; Configuration unchanged (still :on), even though exit+entry fired.
+      (is (= :on (:fan (:state (snapshot))))
+          "external self-transition leaves the configuration at :on"))))
+
+(deftest internal-self-transition-renders-action-only
+  (testing "rf2-k08ay case 4 (internal) — `:hvac/tweak` omits `:target`: an
+            internal self-transition. Per Spec 005 the action runs but `:exit`
+            / `:entry` do NOT. The Epoch cascade must render the action row and
+            NO exit/entry rows (the foil to `:hvac/nudge`), and — per rf2-e6q97
+            (#2841) — NO spurious no-op transition row. The two self-transition
+            renders together pin the distinction the wave debated."
+    (setup!)
+    (drive! [:hvac/power-cycle]) ; fan → :on
+    (let [record (drive! [:hvac/tweak])
+          rows   (cascade record)
+          action-rows (filterv #(and (= :action (:kind %)) (= :transition (:phase %))) rows)
+          exit-rows   (filterv #(and (= :action (:kind %)) (= :exit (:phase %))) rows)
+          entry-rows  (filterv #(and (= :action (:kind %)) (= :entry (:phase %))) rows)]
+      (is (seq action-rows)
+          "internal self-transition renders the transition ACTION row")
+      (is (empty? exit-rows)
+          "internal self-transition renders NO exit row (the state is not left)")
+      (is (empty? entry-rows)
+          "internal self-transition renders NO entry row (the state is not re-entered)")
+      (is (empty? (rows-of-kind rows :no-op))
+          "internal self-transition is a REAL transition — no benign-no-op notice")
+      ;; The trail delta is the action ONLY — no exit/entry tags.
+      (let [tx-row      (first (rows-of-kind rows :transition))
+            data-before (:data-before tx-row)
+            data-after  (:data-after tx-row)
+            delta       (vec (drop (count (:trail data-before)) (:trail data-after)))]
+        (is (= [:action:tweak] delta)
+            "internal self-transition's trail delta: the action ONLY — the
+             distinction from `:hvac/nudge`'s exit→action→entry"))
+      (is (= :on (:fan (:state (snapshot))))
+          "internal self-transition leaves the configuration at :on"))))
+
+(deftest neither-self-transition-emits-spurious-no-op-transition-row
+  (testing "rf2-k08ay / rf2-e6q97 (#2841) regression guard — the no-op
+            transition-row suppression must NOT over-fire: a GENUINE self-
+            transition (external or internal) carries a real transition row,
+            so the suppression (which drops the substrate's unconditional
+            `{X}→{X}` emit ONLY when a `:no-op` row is present) must leave the
+            transition row intact. Both self-transitions render exactly one
+            transition row and zero no-op rows — the inverse of the unhandled-
+            event case the suppression targets."
+    (setup!)
+    (drive! [:hvac/power-cycle])
+    (doseq [ev [[:hvac/nudge] [:hvac/tweak]]]
+      (let [rows (cascade (drive! ev))]
+        (is (= 1 (count (rows-of-kind rows :transition)))
+            (str ev " renders exactly ONE transition row (a genuine self-"
+                 "transition is a real transition — the row survives)"))
+        (is (empty? (rows-of-kind rows :no-op))
+            (str ev " renders no benign-no-op notice"))))))
+
+;; ============================================================================
+;; SNAPSHOT DIFF — member-level set diff (rf2-l0us2) on the machine's `:tags`
+;; ============================================================================
+
+(deftest snapshot-tags-diff-renders-member-level-set-changes
+  (testing "rf2-k08ay / rf2-l0us2 — the snapshot diff the Xray panel renders
+            must show machine state changes at MEMBER level for sets. The
+            machine's `:tags` snapshot slot is a set; a transition swaps its
+            members. Diffing the before/after snapshot via the panel's diff
+            engine must surface per-member `:added` / `:removed` ops (not a
+            single wholly-replaced blob) so the operator reads exactly which
+            tags joined + left."
+    (setup!)
+    (drive! [:hvac/power-cycle]) ; climate → ... :heating ; fan → :on
+    (let [before (proj/machine-logical-state (snapshot))
+          _      (drive! [:hvac/mode-toggle])
+          after  (proj/machine-logical-state (snapshot))
+          {:keys [path-ops]} (diff/project before after)
+          ;; member-level set ops live at paths whose final segment is the
+          ;; set MEMBER (rf2-l0us2 member-keyed scheme).
+          added   (->> path-ops (filter (fn [[_ v]] (= :added (:op v)))) (map first))
+          removed (->> path-ops (filter (fn [[_ v]] (= :removed (:op v)))) (map first))
+          member-of (fn [tag paths] (some (fn [p] (= tag (last p))) paths))]
+      ;; mode-toggle: :climate/heating tag leaves, :climate/cooling joins.
+      (is (member-of :climate/cooling added)
+          "the joining tag (:climate/cooling) renders as a member-level :added —
+           NOT a wholly-replaced set blob (rf2-l0us2)")
+      (is (member-of :climate/heating removed)
+          "the leaving tag (:climate/heating) renders as a member-level :removed")
+      ;; The unchanged tags (fan/on, climate/running, climate/conditioning) do
+      ;; NOT churn — only the two members that actually moved appear.
+      (is (not (member-of :fan/on added))
+          "an unchanged member does NOT render as added (no spurious churn)")
+      (is (not (member-of :fan/on removed))
+          "an unchanged member does NOT render as removed"))))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -2941,6 +2941,8 @@ async function readMachineStrip(page) {
       stripText: (strip.textContent || '').replace(/\s+/g, ' ').trim(),
       doorState: text('machine-epochs-door-state'),
       trafficState: text('machine-epochs-traffic-state'),
+      hvacState: text('machine-epochs-hvac-state'),
+      hvacTrail: text('machine-epochs-hvac-trail'),
     };
   });
 }
@@ -3054,6 +3056,73 @@ async function runMachineEpochs(page, state) {
     { timeoutMs: 10000, description: '#10 reset door + tick traffic → door :locked + vehicle :red (two machines, one cascade)' },
   );
 
+  // ---- rf2-k08ay — the HARD machine (:hvac/controller) rungs #12–#15.
+  //      Each rung's render fact is asserted off the deck's own snapshot
+  //      mirror (the status strip reads `[:rf/machine :hvac/controller]`).
+  //      The deep RENDERING-FIDELITY assertions (cascade order, exit/entry
+  //      vs action-only, no spurious no-op row, member-level set diff) live
+  //      in the CLJS unit test `panels.epoch.hard-machine-fidelity-cljs-test`
+  //      per the Causa/Story-as-CLJS rule; here we confirm the hard
+  //      machine's key rungs land the expected configuration WITHOUT
+  //      contradiction (the browser-side legibility sanity check).
+
+  // ---- #12 parallel broadcast — ONE :hvac/power-cycle moves BOTH regions:
+  //      :climate :idle ──► [:running :conditioning :heating] (deep initial
+  //      cascade) AND :fan :off ──► :on. The snapshot's :state is a region
+  //      map carrying both.
+  await clickMachineRung(page, 12);
+  const afterHvacPower = await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => {
+      const t = snap.stripText || '';
+      return /:climate \[:running :conditioning :heating\]/.test(t) &&
+             /:fan :on/.test(t);
+    },
+    { timeoutMs: 10000, description: '#12 power-cycle → BOTH regions moved (climate deep leaf + fan :on)' },
+  );
+
+  // ---- #13 multi-level LCA cascade — :heating ──► :cooling crossing the
+  //      LCA :conditioning. The trail records the cascade ORDER:
+  //      exit :heating → :swap-mode @ LCA → entry :cooling.
+  await clickMachineRung(page, 13);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => {
+      const t = snap.stripText || '';
+      return /:climate \[:running :conditioning :cooling\]/.test(t) &&
+             /:exit:heating :action:swap-mode :entry:cooling/.test(t);
+    },
+    { timeoutMs: 10000, description: '#13 mode-toggle → :cooling + trail shows LCA cascade order (exit→action→entry)' },
+  );
+
+  // ---- #14 EXTERNAL self-transition (:hvac/nudge, :target :same-state):
+  //      :fan :on re-enters itself — exit → action → entry all fire; the
+  //      configuration stays :on (rf2-46ban / #2843).
+  await clickMachineRung(page, 14);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => {
+      const t = snap.stripText || '';
+      return /:fan :on/.test(t) &&
+             /:exit:fan-on :action:nudge :entry:fan-on/.test(t);
+    },
+    { timeoutMs: 10000, description: '#14 nudge → external self-transition: trail shows exit→action→entry, fan STAYS :on' },
+  );
+
+  // ---- #15 INTERNAL self-transition (:hvac/tweak, omit :target): action
+  //      ONLY — no exit/entry; the foil to #14. The trail gains exactly
+  //      :action:tweak and nothing else; the configuration stays :on.
+  await clickMachineRung(page, 15);
+  const afterHvacTweak = await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => {
+      const t = snap.stripText || '';
+      return /:fan :on/.test(t) &&
+             /:action:nudge :entry:fan-on :action:tweak/.test(t);
+    },
+    { timeoutMs: 10000, description: '#15 tweak → internal self-transition: trail gains :action:tweak ONLY (no exit/entry), fan STAYS :on' },
+  );
+
   // ---- Xray Machine Inspector handoff. Open Xray, fire one more machine
   //      transition so the spine has a focused machine event, switch to
   //      the Machines tab, and confirm the inspector mounts + machine
@@ -3119,6 +3188,9 @@ async function runMachineEpochs(page, state) {
     blocked: { doorState: afterBlocked.doorState },
     parallel: { trafficState: afterParallel.trafficState },
     multi: { doorState: afterMulti.doorState, trafficState: afterMulti.trafficState },
+    // rf2-k08ay — the hard machine's landed configuration after the
+    // power-cycle (#12) and the internal self-transition (#15).
+    hard: { powerState: afterHvacPower.hvacState, tweakTrail: afterHvacTweak.hvacTrail },
     inspectorMounted: true,
   };
 }
@@ -3309,7 +3381,7 @@ const SCENARIOS = [
     // reaches the trace bus. Real Machine-Inspector coverage for the deck
     // the `Machines` matrix row names (the chart-render shim-survival probe
     // stays owned by the `deep machine inspector substrate` scenario).
-    name: 'machine-epochs machine ladder (start, transitions, guards allowed/blocked, entry/exit, effect, ignored, parallel, multiple machines)',
+    name: 'machine-epochs machine ladder (start, transitions, guards allowed/blocked, entry/exit, effect, ignored, parallel, multiple machines, + the HARD machine: deep compound, LCA cascade, internal/external self-transitions)',
     url: '/testbeds/machine-epochs/',
     panels: ['machines'],
     coveredRows: ['Machines'],

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -98,6 +98,35 @@
                               issue-event? predicate distinguishes a thrown
                               `:*` action (error) from a benign no-op.
 
+  ## The HARD machine (rf2-k08ay) — rungs #12–#15
+
+  Where rungs #1–#11 each light up ONE Inspector surface, `:hvac/controller`
+  (a smart climate controller — MACHINE 4 below) is the CANONICAL HARD
+  machine: ONE coherent machine exercising every hard STRUCTURAL case so the
+  devtools have a rich, legible subject. It is the COMPLEMENT to the SCXML
+  semantic corpus (rf2-rkkag · #2842) — that proves SEMANTICS, this proves
+  the devtools RENDER them legibly (the gap the no-op render bug, rf2-e6q97
+  · #2841, exposed).
+
+    #12 power-cycle         — PARALLEL regions: ONE event (`:hvac/power-cycle`)
+                              handled by BOTH the `:climate` and `:fan` regions
+                              simultaneously; `:climate` :idle──►:running fans
+                              out a deep INITIAL CASCADE to the leaf
+                              `[:running :conditioning :heating]`.
+    #13 mode-toggle         — DEEP COMPOUND + LCA cascade: `:heating` ──►
+                              `:cooling` crosses the LCA two levels up
+                              (`:conditioning`). The action ORDER renders:
+                              exit deepest-first → action @ LCA → entry
+                              shallowest-first; the `:trail` is that order made
+                              visible.
+    #14 nudge fan           — EXTERNAL self-transition (`:target :same-state`,
+                              rf2-46ban · #2843): `:fan :on` re-enters itself —
+                              exit + action + entry all fire; NO spurious
+                              `{:on}→{:on}` no-op row (rf2-e6q97).
+    #15 tweak fan           — INTERNAL self-transition (omit `:target`): action
+                              ONLY, no exit/entry — the foil to #14. The
+                              devtools render the distinction.
+
   ## Test surface, not tutorial
 
   Per `feedback_testbeds_are_test_surfaces`: no deliberate bugs as
@@ -316,6 +345,204 @@
 (rf/reg-machine :fuse/box fuse-machine)
 
 ;; ============================================================================
+;; MACHINE 4 — :hvac/controller  (the CANONICAL HARD machine — rf2-k08ay)
+;; ============================================================================
+;;
+;; The capstone of the machine-epochs deck. The first three machines each
+;; light up ONE Machine-Inspector surface; this one exercises every HARD
+;; structural case in ONE coherent domain — a smart climate controller — so
+;; the devtools have a rich, legible subject to render. It is the COMPLEMENT
+;; to the SCXML semantic corpus (rf2-rkkag · #2842): that proves the engine's
+;; SEMANTICS; this fixture + its fidelity assertions prove the devtools RENDER
+;; those semantics legibly. The recent no-op render bug (rf2-e6q97 · #2841)
+;; was a devtools-NARRATION miss — the engine was right, Xray drew it wrong —
+;; and this machine is built to keep that thin spot covered.
+;;
+;; ## The four hard cases it exercises (history-free; `:history` is deferred)
+;;
+;;   1. DEEP COMPOUND NESTING. The `:climate` region is four levels deep:
+;;        [:climate :running :conditioning :heating]
+;;      A transition from `:heating` up-and-over to `:cooling`
+;;      (`:hvac/mode-toggle`) crosses an LCA two levels up (`:conditioning`),
+;;      so the exit cascade + entry cascade each span multiple compound
+;;      levels — the multi-level case the cascade render must order correctly.
+;;
+;;   2. PARALLEL / ORTHOGONAL REGIONS. `:type :parallel` with two regions —
+;;      `:climate` (the deep compound) and `:fan` (a flatter independent
+;;      region). The `:hvac/power-cycle` event is handled by BOTH regions
+;;      SIMULTANEOUSLY (`:climate` swings active⇄idle; `:fan` swings on⇄off)
+;;      so the chart highlights leaves in both regions and the cascade shows
+;;      two transitions from one event.
+;;
+;;   3. ALL ACTION KINDS WITH OBSERVABLE LCA ORDERING. Per Spec 005 §Level 2
+;;      (Compound machines) the action group fires:
+;;        exit cascade (DEEPEST-first) → transition `:action` @ LCA →
+;;        entry cascade (SHALLOWEST-first) → initial cascade.
+;;      Every `:exit` / transition `:action` / `:entry` here APPENDS a labeled
+;;      tag onto a shared `:trail` vector in `:data`. So the post-macrostep
+;;      `:trail` is the cascade order made VISIBLE — the Epoch panel's per-
+;;      action rows (and the snapshot `:data` Δ) render that exact sequence,
+;;      and the fidelity test pins it. The labels carry their depth so the
+;;      deepest-first / shallowest-first directionality is unambiguous.
+;;
+;;   4. INTERNAL vs EXTERNAL SELF-TRANSITIONS — the case the wave just
+;;      debated + fixed (rf2-46ban · #2843). On the `:fan` region's `:on` leaf:
+;;        - `:hvac/nudge`  — EXTERNAL self-transition (`:target :same-state`):
+;;          per #2843 this now fires `:exit` THEN action THEN `:entry` (the
+;;          state re-enters itself), so the trail shows exit + entry tags.
+;;        - `:hvac/tweak`  — INTERNAL self-transition (omit `:target`):
+;;          action ONLY, no exit/entry — the trail shows just the action tag.
+;;      Both land on the SAME state; the devtools must render the DISTINCTION
+;;      (external = exit+entry cascade rows; internal = action-only row; and,
+;;      per #2841, NEITHER produces a spurious `{X}→{X}` no-op transition row).
+;;
+;; ## Why a `:trail` rather than a counter
+;;
+;; A bare counter would prove an action RAN; the ordered `:trail` proves the
+;; SEQUENCE — which is the whole point of the LCA cascade and the internal-vs-
+;; external distinction. The trail is the testable proxy for "the cascade
+;; renders legibly + in the right order". Each label is `<phase>:<state>` so a
+;; reader (human or test) sees both WHAT fired and WHERE without cross-
+;; referencing the spec.
+;;
+;; ## Test surface, not tutorial (feedback_testbeds_are_test_surfaces)
+;;
+;; No deliberate bugs, no teaching layers. Every transition is a clean feature
+;; being driven; the trail is instrumentation, not an anti-pattern demo. The
+;; machine is a believable climate controller, not a grab-bag.
+
+;; A tiny action factory: returns a named action fn that appends one labeled
+;; tag to the shared `:trail` in `:data`. The `:name` metadata survives onto
+;; the fn so `defmachine` stamps per-element source AND the Inspector's
+;; ref-display-id surfaces a legible action id (rf2-ujra6).
+(defn- trail-action
+  "Build a named action that conj's `label` onto `[:data :trail]`. `label`
+  is `<phase>:<state>` (e.g. `:exit:heating`) so the rendered cascade /
+  snapshot-Δ reads as an ordered, self-describing sequence."
+  [nm label]
+  (with-meta
+    (fn [{data :data}]
+      {:data (update data :trail (fnil conj []) label)})
+    {:name nm}))
+
+(defmachine hvac-controller-machine
+  {:type :parallel
+
+   :data {:trail []}
+
+   :regions
+   {;; ---- :climate region — the DEEP COMPOUND (case 1) + the LCA cascade (case 3) ----
+    ;;
+    ;;   :idle
+    ;;   :running
+    ;;     :conditioning
+    ;;       :heating   ← deepest leaf; full path [:climate :running :conditioning :heating]
+    ;;       :cooling
+    ;;
+    ;; `:hvac/mode-toggle` on `:heating` targets `:cooling`. Their LCA is
+    ;; `:conditioning` (the common compound parent), so the cascade is:
+    ;;   exit :heating → (action at the :conditioning boundary) → entry :cooling
+    ;; Each step appends to `:trail`, deepest-exit-first then
+    ;; shallowest-entry-first. `:hvac/power-cycle` (case 2) swings the WHOLE
+    ;; region active⇄idle and is ALSO handled by the `:fan` region.
+    :climate
+    {:initial :idle
+     :states
+     {:idle
+      {:tags #{:climate/idle}
+       :on   {:hvac/power-cycle {:target :running :action :enter-running}}}
+
+      :running
+      ;; Compound level 1. Drops into :conditioning on entry; :conditioning
+      ;; drops into :heating. So `:hvac/power-cycle` from :idle lands the leaf
+      ;; at [:climate :running :conditioning :heating] via the initial cascade
+      ;; (case 3 — the entry + initial cascades both append to the trail).
+      {:tags    #{:climate/running}
+       :initial :conditioning
+       :entry   :enter-running-level
+       :exit    :exit-running-level
+       :on      {:hvac/power-cycle {:target :idle :action :back-to-idle}}
+       :states
+       {:conditioning
+        ;; Compound level 2 — the LCA for the :heating ⇄ :cooling toggle.
+        {:tags    #{:climate/conditioning}
+         :initial :heating
+         :entry   :enter-conditioning
+         :exit    :exit-conditioning
+         :states
+         {:heating
+          ;; Deepest leaf. `:hvac/mode-toggle` crosses the :conditioning LCA
+          ;; to :cooling — exit :heating (deepest-first) → transition action
+          ;; at the LCA → entry :cooling (shallowest-first). All three append
+          ;; to the trail so the order renders.
+          {:tags  #{:climate/heating}
+           :entry :enter-heating
+           :exit  :exit-heating
+           :on    {:hvac/mode-toggle {:target :cooling :action :swap-mode}}}
+
+          :cooling
+          {:tags  #{:climate/cooling}
+           :entry :enter-cooling
+           :exit  :exit-cooling
+           :on    {:hvac/mode-toggle {:target :heating :action :swap-mode}}}}}}}}}
+
+    ;; ---- :fan region — orthogonal (case 2) + the self-transitions (case 4) ----
+    ;;
+    ;; Independent of :climate. `:hvac/power-cycle` swings it off⇄on alongside
+    ;; the climate region (one event, BOTH regions — case 2). The `:on` leaf
+    ;; carries the EXTERNAL (`:hvac/nudge` · `:target :same-state`) and INTERNAL
+    ;; (`:hvac/tweak` · no `:target`) self-transitions side by side (case 4).
+    :fan
+    {:initial :off
+     :states
+     {:off
+      {:tags #{:fan/off}
+       :on   {:hvac/power-cycle {:target :on :action :fan-on}}}
+
+      :on
+      ;; Both self-transitions land HERE and stay HERE; the devtools render
+      ;; the distinction (external = exit+entry; internal = action-only).
+      {:tags  #{:fan/on}
+       :entry :enter-fan-on
+       :exit  :exit-fan-on
+       :on    {:hvac/power-cycle {:target :off :action :fan-off}
+               ;; EXTERNAL self-transition (rf2-46ban · #2843): exit + action
+               ;; + entry all fire; configuration unchanged.
+               :hvac/nudge {:target :same-state :action :nudge-fan}
+               ;; INTERNAL self-transition: action ONLY — no exit, no entry.
+               :hvac/tweak {:action :tweak-fan}}}}}}
+
+   ;; Named actions (inspectability bias, per the nine_states example): every
+   ;; slot is a NAMED entry so the focused-transition lens + the Epoch cascade
+   ;; render each action's id and source. The trail-appending bodies make the
+   ;; LCA cascade ordering observable.
+   :actions
+   {;; :climate entry/exit cascade (case 3) — labels carry depth so the
+    ;; deepest-first exit / shallowest-first entry directionality reads off
+    ;; the trail directly.
+    :enter-running         (trail-action 'enter-running         :action:power-on)
+    :enter-running-level   (trail-action 'enter-running-level   :entry:running)
+    :exit-running-level    (trail-action 'exit-running-level    :exit:running)
+    :back-to-idle          (trail-action 'back-to-idle          :action:power-off)
+    :enter-conditioning    (trail-action 'enter-conditioning    :entry:conditioning)
+    :exit-conditioning     (trail-action 'exit-conditioning     :exit:conditioning)
+    :enter-heating         (trail-action 'enter-heating         :entry:heating)
+    :exit-heating          (trail-action 'exit-heating          :exit:heating)
+    :enter-cooling         (trail-action 'enter-cooling         :entry:cooling)
+    :exit-cooling          (trail-action 'exit-cooling          :exit:cooling)
+    ;; the LCA-boundary transition action for :heating ⇄ :cooling (case 3)
+    :swap-mode             (trail-action 'swap-mode             :action:swap-mode)
+    ;; :fan region (case 2 + case 4)
+    :fan-on                (trail-action 'fan-on                :action:fan-on)
+    :fan-off               (trail-action 'fan-off               :action:fan-off)
+    :enter-fan-on          (trail-action 'enter-fan-on          :entry:fan-on)
+    :exit-fan-on           (trail-action 'exit-fan-on           :exit:fan-on)
+    :nudge-fan             (trail-action 'nudge-fan             :action:nudge)
+    :tweak-fan             (trail-action 'tweak-fan             :action:tweak)}})
+
+(rf/reg-machine :hvac/controller hvac-controller-machine)
+
+;; ============================================================================
 ;; APP-DB SEED
 ;; ============================================================================
 ;;
@@ -408,6 +635,24 @@
   :<- [:rf/machine :traffic/light]
   (fn [snap _] (:tags snap)))
 
+;; ---- :hvac/controller — the hard machine's live read-out (rf2-k08ay) ----
+;;
+;; `:state` is a region→state map (parallel); `:tags` is the union tag-set
+;; across both active region leaves; `:trail` is the cascade-order record the
+;; LCA / self-transition buttons grow.
+
+(rf/reg-sub :machine-epochs/hvac-state
+  :<- [:rf/machine :hvac/controller]
+  (fn [snap _] (:state snap)))
+
+(rf/reg-sub :machine-epochs/hvac-tags
+  :<- [:rf/machine :hvac/controller]
+  (fn [snap _] (:tags snap)))
+
+(rf/reg-sub :machine-epochs/hvac-trail
+  :<- [:rf/machine :hvac/controller]
+  (fn [snap _] (get-in snap [:data :trail])))
+
 ;; ============================================================================
 ;; RESET
 ;; ============================================================================
@@ -431,7 +676,10 @@
   (fn handler-reset [_ _ev]
     {:db initial-db
      :fx [[:dispatch [:door/main [:rf.machine/bootstrap]]]
-          [:dispatch [:traffic/light [:rf.machine/bootstrap]]]]}))
+          [:dispatch [:traffic/light [:rf.machine/bootstrap]]]
+          ;; rf2-k08ay — the hard machine boots to its initial parallel
+          ;; configuration ({:climate :idle, :fan :off}) with an empty trail.
+          [:dispatch [:hvac/controller [:rf.machine/bootstrap]]]]}))
 
 ;; ============================================================================
 ;; THE BUTTON LADDER
@@ -477,7 +725,20 @@
    [:section "Fuse box — :* wildcard-action THROWS (xstate-v5 fail-loudly)"]
    [11 "Send unhandled event to :fuse/box — :* action THROWS"
     "Epoch: EXCEPTION card (message + ex-data + coord) attributing a :* WILDCARD action; event row IS pink — inverse of #7's benign no-op"
-    [:machine-epochs/send [[:fuse/box [:fuse/short-circuit]]]]]])
+    [:machine-epochs/send [[:fuse/box [:fuse/short-circuit]]]]]
+   [:section "HVAC controller — the HARD machine (deep compound · parallel · LCA cascade · self-transitions)"]
+   [12 "Power-cycle (parallel — BOTH regions, deep initial cascade)"
+    "Cascade: ONE event → :climate :idle──►:running (entry+initial cascade to [:running :conditioning :heating]) AND :fan :off──►:on; trail shows both regions' entries"
+    [:machine-epochs/send [[:hvac/controller [:hvac/power-cycle]]]]]
+   [13 "Mode-toggle (:heating ⇄ :cooling — multi-level LCA cascade)"
+    "Cascade ORDER: exit :heating (deepest-first) → :swap-mode @ LCA :conditioning → entry :cooling (shallowest-first); trail = [:exit:heating :action:swap-mode :entry:cooling]"
+    [:machine-epochs/send [[:hvac/controller [:hvac/mode-toggle]]]]]
+   [14 "Nudge fan — EXTERNAL self-transition (:target :same-state)"
+    "Cascade: :fan :on re-enters itself — exit :fan-on → :nudge-fan → entry :fan-on (per #2843); NO spurious {:on}→{:on} no-op row (per #2841)"
+    [:machine-epochs/send [[:hvac/controller [:hvac/nudge]]]]]
+   [15 "Tweak fan — INTERNAL self-transition (omit :target)"
+    "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to #14; NO spurious no-op row — state stays :fan :on"
+    [:machine-epochs/send [[:hvac/controller [:hvac/tweak]]]]]])
 
 (reg-view ladder-button
   "One numbered ladder row: a numbered button on the left, its caption on
@@ -517,7 +778,10 @@
         door-data     @(subscribe [:machine-epochs/door-data])
         door-tags     @(subscribe [:machine-epochs/door-tags])
         traffic-state @(subscribe [:machine-epochs/traffic-state])
-        traffic-tags  @(subscribe [:machine-epochs/traffic-tags])]
+        traffic-tags  @(subscribe [:machine-epochs/traffic-tags])
+        hvac-state    @(subscribe [:machine-epochs/hvac-state])
+        hvac-tags     @(subscribe [:machine-epochs/hvac-tags])
+        hvac-trail    @(subscribe [:machine-epochs/hvac-trail])]
     [:div {:data-testid "machine-epochs-status-strip"
            :style {:border "1px solid #d8d2ff" :border-radius "6px"
                    :padding "0.5em 0.75em" :margin "0.75em 0"
@@ -531,7 +795,12 @@
      [:div ":door/main tags: " [:strong (pr-str door-tags)]]
      [:div {:data-testid "machine-epochs-traffic-state"}
       ":traffic/light state: " [:strong (pr-str traffic-state)]]
-     [:div ":traffic/light tags: " [:strong (pr-str traffic-tags)]]]))
+     [:div ":traffic/light tags: " [:strong (pr-str traffic-tags)]]
+     [:div {:data-testid "machine-epochs-hvac-state"}
+      ":hvac/controller state: " [:strong (pr-str hvac-state)]]
+     [:div ":hvac/controller tags: " [:strong (pr-str hvac-tags)]]
+     [:div {:data-testid "machine-epochs-hvac-trail"}
+      ":hvac/controller trail (LCA cascade order): " [:strong (pr-str hvac-trail)]]]))
 
 (reg-view root []
   [:div {:data-testid "machine-epochs-root"


### PR DESCRIPTION
## What

The capstone of the machine-epochs pair-review wave. Adds `:hvac/controller`
(a smart climate controller) — the `machine_epochs` testbed's canonical HARD
machine — plus CLJS rendering-fidelity assertions over the layers that feed
the devtools render.

It is the COMPLEMENT to the SCXML semantic corpus (rf2-rkkag, #2842): that
proves the engine's SEMANTICS; this proves the devtools RENDER those
semantics legibly. The no-op render bug (rf2-e6q97, #2841) was a devtools-
NARRATION miss — the engine was correct + unit-tested, but Xray drew it
wrong, and nothing asserted what the TOOL DISPLAYS. This closes that thin
spot with a rich, legible fixture + fidelity assertions.

## The hard machine (one coherent machine, history-free)

`:hvac/controller` exercises every hard structural case:

- **Deep compound nesting** — the `:climate` region is four levels deep
  (`[:running :conditioning :heating]`).
- **Parallel / orthogonal regions** — `:type :parallel`; `:hvac/power-cycle`
  is handled by BOTH `:climate` and `:fan` simultaneously.
- **All action kinds with observable LCA ordering** — every `:exit` /
  transition `:action` / `:entry` appends a `<phase>:<state>` tag to a shared
  `:trail`, so the cascade order (exit deepest-first → action @ LCA → entry
  shallowest-first) is made visible and testable.
- **Internal vs external self-transitions** — external (`:hvac/nudge`,
  `:target :same-state`, #2843) fires exit+entry; internal (`:hvac/tweak`,
  omit `:target`) fires action-only; neither emits a spurious `{X}→{X}` no-op
  transition row (#2841).

Buttons #12–#15 drive each case; the status strip surfaces hvac
state / tags / trail so the deck is legible standalone.

## The fidelity assertions (what devtools-display facts they pin)

`panels/epoch/hard_machine_fidelity_cljs_test.cljs` drives the LIVE machine
substrate, captures the trace, and feeds it through the rendering layers:

- **Epoch cascade** (`proj/machine-cascade-rows`) — parallel power-cycle
  renders one aggregate transition row whose before/after `:state` is a
  region→state map showing both regions moved, plus action rows from both
  regions; the LCA toggle renders exit rows before the transition row and
  entry rows after it (canonical statechart order), with the trail delta
  `[:exit:heating :action:swap-mode :entry:cooling]`; the external self-
  transition renders exit+entry rows, the internal renders action-only;
  neither emits a `:no-op` row, and both keep exactly one transition row
  (the #2841 suppression must not over-fire on genuine self-transitions).
- **Machine Inspector view-model** (`mih/project-focused-event-transitions`)
  — the parallel macrostep's record carries both regions' leaves in `:after`.
- **Topology projection** (`topo/parse-definition`) — the four-level compound
  path + both parallel regions' leaves render; parallel root has no single
  initial path; the heating→cooling edge renders with its event label.
- **Snapshot diff** (`diff/project`) — the `:tags` set swap renders at member
  level (`:climate/cooling` added, `:climate/heating` removed — rf2-l0us2),
  with no spurious churn on unchanged members.

Also extends the `feature_matrix` machine-epochs ladder scenario with rungs
#12–#15 (browser-side legibility sanity check off the snapshot mirror), and
updates `spec/004-App-DB-Diff.md`'s set-member-diff note to cite the hard
machine's `:tags` swap as the canonical multi-member case.

## Quality gates

- **Testbed builds** — `npx shadow-cljs compile :examples/machine-epochs`: PASS (442 files, 0 warnings).
- **`npm run test:cljs`** — PASS (5331 tests, 18266 assertions, 0 failures, 0 errors; includes the 8 new fidelity deftests).
- **`npm run test:xray-feature-gate`** — PASS on re-run (16 scenarios, 0 failures); the machine-epochs ladder scenario passes with the new hard-machine rungs. First run showed the named flake `routes-epochs routing ladder` (unrelated to this change); re-ran green per the bead's known-flake note.
- **JVM xray + machines (`clojure -M:test`)** — N/A: no shared `.cljc` touched (only `.cljs` testbed + a new `.cljs` test + `.cjs` scenario + a spec `.md`).
- **Xray-spec currency** — `spec/004-App-DB-Diff.md` set-member-diff legibility note updated to cite the hard machine; no other `tools/xray/spec/*` documents the machine-epochs fixtures.

Closes rf2-k08ay.
