### PR TITLE
fix(xray): collapse no-op cell to [NO OP] staying in {state} (rf2-iu3no)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -427,7 +427,8 @@ still targets a machine, so the Machines tab renders the machine's topology
 (the "no activity this epoch" Case B shape, [§021 Dynamic-Panel-Designs](021-Dynamic-Panel-Designs.md)),
 not this "does not target a state machine" placeholder. The benign no-op is
 surfaced in the **Epoch panel's** EVENT HANDLER machine cascade as a muted
-`NO-OP` row — see [021 §machine-cascade-rows](021-Dynamic-Panel-Designs.md).
+`NO OP` row (`[NO OP] staying in {state}`, rf2-iu3no) — see
+[021 §machine-cascade-rows](021-Dynamic-Panel-Designs.md).
 This placeholder is reserved for events that target NO machine at all.
 
 This is the **state 2** branch in

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1423,11 +1423,32 @@ The projection walks `:trace-events` and surfaces every member of
 
 The `:no-op` row (rf2-ugdas) surfaces the benign unhandled-event no-op
 (xstate-v5 parity — an event that matched no transition is ignored, NOT an
-error). It ranks WITH the `:transition` slot (it stands in for "the state
-change that did not happen") and renders a muted (`:text-tertiary`) NO-OP
-kind pill, the verb `no-op — <machine> received <event> in <state>, no
-transition`, and an `ignored` outcome chip — explicitly NOT the red
-exception card and NOT pink. Because its trace op-type is `:rf.machine`
+error). It fires ONLY for a genuine unknown **user** event: framework
+lifecycle traffic (`:rf.machine/bootstrap`, `:rf.machine.spawn/spawned`,
+stories-runtime pings, bare reserved-`:rf/*`) is carved out at the
+substrate (rf2-t4582 — bootstrap runs its `:initial-entry` cascade and is
+NOT classified as an unhandled-user-event no-op), so this row never stands
+in for a machine's birth. It ranks WITH the `:transition` slot (it stands
+in for "the state change that did not happen") and renders, collapsed to
+the **CONSEQUENCE only** (rf2-iu3no): a muted (`:text-tertiary`) **`NO OP`**
+kind pill as the SOLE marker, plus the verb **`staying in {state}`** — the
+machine matched no transition, so its state is unchanged. The earlier
+rf2-ugdas sentence (`no-op — <machine> received <event> in <state>, no
+transition`) stacked the pill + a `no-op —` prefix + an event echo + a
+`, no transition` suffix — four restatements of one fact; it is collapsed
+away. The focused-epoch **Event header already names the event**, so the
+verb does not echo it; the cascade is a SINGLE muted row, so its `1..N`
+left-rail step ordinal is **suppressed** (it read as an unexplained
+leading "1"); and the row carries **NO outcome chip** (the prior `ignored`
+chip was a third restatement). The **machine name is kept ONLY when >1
+machine is in play this epoch** (a broadcast event hitting parallel regions
+/ sibling machines) so the operator can tell WHICH machine stood pat —
+`machine-cascade-rows` stamps `:show-machine-name?` on the no-op row when
+the cascade spans more than one distinct `:machine-id`; the single-machine
+case drops it (the EVENT HANDLER section names the lone machine above), so
+the multi-machine render reads `[NO OP] :hvac/controller staying in
+{state}`. This is explicitly NOT the red exception card and NOT pink.
+Because its trace op-type is `:rf.machine`
 (machine-activity, not a severity), the L2 pink-wash / issues-ribbon
 `issue-event?` predicate does not match it, so the event row stays
 un-washed and the ribbon stays empty — the contrast with a `:*`
@@ -1439,7 +1460,8 @@ time (rf2-e6q97): on a no-op the machine substrate emits BOTH the
 `:rf.machine.event/unhandled-no-op` trace AND — from `commit-or-finalize`'s
 unconditional `:rf.machine/transition` emit — a contradictory `{X}→{X}`
 0-microstep transition trace (`:before` == `:after`). Rendered side-by-side
-those contradict: the no-op row says "no transition — ignored" while the
+those contradict: the no-op row says the machine is "staying in {state}"
+(no transition) while the
 transition row borrows external-self-transition vocabulary (`{X} → {X}`)
 implying the `:exit` / `:entry` firing that did NOT happen.
 `machine-cascade-rows` therefore drops every `:transition` row when the
@@ -1455,8 +1477,11 @@ rather than collapsing to a plain `reg-event-db` handler.
 **Per-row chrome.** Each row carries:
 
 - **Step ordinal** (1..N) — left-rail compact monospace chip.
+  Suppressed for the single-row `:no-op` notice (rf2-iu3no — the lone
+  "1" was unexplained noise).
 - **Kind pill** — colour-coded (`:guard / :action / :transition /
-  :timer`) — see `badge.cljc` for the hue assignments.
+  :timer / :no-op`) — see `badge.cljc` for the hue assignments. The
+  `:no-op` pill reads `NO OP` (space, not hyphen — rf2-iu3no).
 - **Phase chip** (`:action` rows only) — one of the rf2-82a0u closed
   set `:exit / :transition / :entry / :always / :after-action /
   :initial-entry / :destroy-exit`.
@@ -1477,7 +1502,9 @@ rather than collapsing to a plain `reg-event-db` handler.
     threw signal)
   - `:transition` → `N microstep(s)` (the headline)
   - `:timer` → `· cancelled (<reason>)`
-  - `:no-op` → `· ignored` (the benign unhandled-event no-op — muted, not red)
+  - `:no-op` → NO outcome chip (rf2-iu3no — the `NO OP` pill + the
+    `staying in {state}` verb carry the whole notice; the rf2-ugdas
+    `ignored` chip was a third restatement of the same fact)
 
 **Per-row body — interleaved source code (always visible).** Every
 cascade row carries source visibility (rf2-wwc3j extends rf2-u69j7's

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -225,7 +225,12 @@
    :action      "ACTION"
    :transition  "TRANSITION"
    :timer       "TIMER"
-   :no-op       "NO-OP"})
+   ;; rf2-iu3no — "NO OP" (space, not hyphen) is the SOLE marker for the
+   ;; benign unhandled-user-event no-op. The row collapsed to
+   ;; "[NO OP] staying in {state}" (`format/cascade-row-label`) — the pill
+   ;; carries the one badge; the verb carries the consequence. No "ignored"
+   ;; outcome chip, no "no-op —" prefix, no ", no transition" suffix.
+   :no-op       "NO OP"})
 
 (defn cascade-kind-token-key
   "Theme-token keyword for a cascade row's `:kind` (rf2-u69j7). Falls
@@ -326,9 +331,10 @@
     :fail      :warning
     :threw     :error
     :cancelled :text-tertiary
-    ;; rf2-ugdas — the benign unhandled-event no-op: ignored, muted tone
-    ;; (NOT error/warning).
-    :ignored   :text-tertiary
+    ;; rf2-iu3no — the benign no-op no longer renders an outcome chip
+    ;; (`format/cascade-outcome-label` returns nil for it; the "[NO OP]"
+    ;; pill + "staying in {state}" verb carry the whole notice), so the
+    ;; rf2-ugdas `:ignored` outcome value is retired.
     :text-tertiary))
 
 (defn cascade-outcome-glyph
@@ -348,7 +354,7 @@
     :fail      "▲"
     :threw     "✗"
     :cancelled "·"
-    :ignored   "·"
+    ;; rf2-iu3no — `:ignored` retired with the benign-no-op outcome chip.
     "·"))
 
 ;; rf2-9wq0v retired the per-STAGE status glyph primitive that used to

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -106,7 +106,11 @@
   "Render a cascade row's human-readable verb (rf2-u69j7). Used by the
   view's per-row header. Pure-data; the view never reaches into a
   row's slots to compute its label."
-  [{:keys [kind action-id guard-id from-state to-state state reason event machine-id]}]
+  ;; rf2-iu3no — `:event` is no longer destructured: the `:no-op` verb
+  ;; (the only case that read it) collapsed to "staying in {state}" and no
+  ;; longer echoes the event (the focused-epoch Event header names it).
+  [{:keys [kind action-id guard-id from-state to-state state reason
+           machine-id show-machine-name?]}]
   (case kind
     :guard       (str "guard " (ns-keyword guard-id))
     ;; rf2-nhovk — the ACTION kind-pill + phase chip already convey kind +
@@ -125,15 +129,24 @@
                       (if to-state (pr-str to-state) "?"))
     :timer       (str "timer " (when state (pr-str state))
                       (when reason (str " · " (name reason))))
-    ;; rf2-ugdas — the benign unhandled-event no-op. The verb names the
-    ;; machine + the unhandled event + the state it arrived in, e.g.
-    ;; "no-op — :door/main received [:door/insert-coin] in :alarming, no
-    ;; transition". Benign notice, not an error.
-    :no-op       (str "no-op — "
-                      (when machine-id (str (ns-keyword machine-id) " received "))
-                      (when event (pr-str event))
-                      (when state (str " in " (pr-str state)))
-                      ", no transition")
+    ;; rf2-iu3no — the benign unhandled-user-event no-op. The verb is the
+    ;; CONSEQUENCE only: "staying in {state}" (the machine matched no
+    ;; transition, so its state is unchanged). The `[NO OP]` kind-pill is
+    ;; the sole marker; the focused-epoch Event header already names the
+    ;; event — so the rf2-ugdas "no-op — <machine> received <event> in
+    ;; <state>, no transition" sentence (badge + prefix + event echo +
+    ;; suffix, all saying the same thing) is collapsed away.
+    ;;
+    ;; The machine name is kept ONLY when >1 machine is in play this epoch
+    ;; (broadcast event / parallel regions) so the operator can tell WHICH
+    ;; machine stood pat — `machine-cascade-rows` stamps `:show-machine-name?`
+    ;; on the no-op row when the cascade spans multiple machine-ids. The
+    ;; single-machine case drops it (the EVENT HANDLER section names the
+    ;; machine above).
+    :no-op       (str (when (and show-machine-name? machine-id)
+                        (str (ns-keyword machine-id) " "))
+                      "staying in "
+                      (if state (pr-str state) "?"))
     (str (when kind (name kind)))))
 
 (defn cascade-row-source-key
@@ -248,8 +261,9 @@
                        (when (not= 1 microsteps) "s")))
     :timer      (str "cancelled"
                      (when reason (str " (" (name reason) ")")))
-    ;; rf2-ugdas — the benign no-op: the event was ignored (no transition).
-    :no-op      "ignored"
+    ;; rf2-iu3no — the benign no-op carries NO outcome chip. The "[NO OP]"
+    ;; kind-pill + the "staying in {state}" verb (`cascade-row-label`) are
+    ;; the whole story; the rf2-ugdas "ignored" chip was a third restatement.
     nil))
 
 (defn handler-flavour-label

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -696,8 +696,10 @@
   event (rf2-ugdas). A machine received an event with no matching
   transition at any level; the snapshot is unchanged — a benign no-op
   (xstate-v5 parity), NOT an error. Carries the machine-id, the event
-  vector, and the pre-event state so the view can render the benign
-  notice 'no-op — <machine> received <event> in <state>, no transition'."
+  vector, and the pre-event state. rf2-iu3no — the view collapses this to
+  the CONSEQUENCE only ('[NO OP] staying in {state}'); the machine name is
+  surfaced only when >1 machine is in play (the `:show-machine-name?` flag
+  `machine-cascade-rows` stamps below)."
   [ev]
   {:kind       :no-op
    :machine-id (common/tag-of ev :machine-id)
@@ -994,10 +996,25 @@
         deduped  (drop-spurious-no-op-transition enriched)
         ;; Stable canonical sort: rank first, emit-order (:trace-index)
         ;; as tiebreaker so intra-phase run order is preserved.
-        sorted   (vec (sort-by (juxt cascade-row-rank :trace-index) deduped))]
+        sorted   (vec (sort-by (juxt cascade-row-rank :trace-index) deduped))
+        ;; rf2-iu3no — the benign no-op row renders "[NO OP] staying in
+        ;; {state}". The machine NAME is surfaced ONLY when the epoch has
+        ;; >1 machine in play (a broadcast event hitting parallel regions /
+        ;; multiple sibling machines), so the operator can tell WHICH
+        ;; machine stood pat. The single-machine case drops it (the EVENT
+        ;; HANDLER section already names the lone machine). "In play" =
+        ;; distinct `:machine-id` across the whole cascade.
+        multi-machine? (< 1 (count (into #{}
+                                         (keep :machine-id)
+                                         sorted)))]
     ;; Re-number :step over the FINAL (canonical) order so the left-rail
-    ;; ordinal reads top-to-bottom as rendered.
-    (vec (map-indexed (fn [i row] (assoc row :step (inc i))) sorted))))
+    ;; ordinal reads top-to-bottom as rendered, and stamp the no-op rows'
+    ;; machine-name visibility (rf2-iu3no).
+    (vec (map-indexed
+           (fn [i row]
+             (cond-> (assoc row :step (inc i))
+               (= :no-op (:kind row)) (assoc :show-machine-name? multi-machine?)))
+           sorted))))
 
 (defn machine-cascade-total-ms
   "Sum of every cascade row's `:duration-ms` (rf2-u69j7). nil when no

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2762,7 +2762,12 @@
            :style cascade-row-style}
      ;; Header row: ordinal + kind pill + phase chip + verb + duration + outcome
      [:div {:style cascade-row-header-style}
-      (cascade-row-ordinal step)
+      ;; rf2-iu3no — the `:no-op` row is a SINGLE muted notice (the cascade
+      ;; collapses to one row when nothing transitioned), so its 1..N
+      ;; left-rail ordinal was an unexplained leading "1" — pure noise. Drop
+      ;; it for the no-op; every other kind keeps its scannability ordinal.
+      (when-not (= :no-op kind)
+        (cascade-row-ordinal step))
       (cascade-kind-pill kind)
       (when (= :action kind)
         (cascade-phase-chip phase))
@@ -2782,12 +2787,12 @@
            (and (= :action kind) threw?)  nil
            (= :action kind)     :ok
            (= :timer kind)      :cancelled
-           ;; rf2-ugdas — the benign no-op reads "ignored" (event matched
-           ;; no transition). Benign tone, not error/warning.
-           (= :no-op kind)      :ignored
+           ;; rf2-iu3no — the benign no-op carries NO outcome chip. The
+           ;; "[NO OP]" kind-pill + the "staying in {state}" verb already
+           ;; tell the whole story; the prior "ignored" chip was a third
+           ;; restatement of the same fact.
            :else                nil)
          (when (or (= :transition kind)
-                   (= :no-op kind)
                    (and (= :guard kind) outcome-lbl))
            outcome-lbl))]]
      ;; Source code body (always visible per rf2-u69j7) — actions + guards

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -107,9 +107,11 @@
     (is (badge/cascade-kind? :no-op))
     (is (not (badge/cascade-kind? :NOT-A-KIND))))
 
-  (testing "rf2-ugdas — the :no-op kind resolves to a muted (not red) label
-            + colour, distinct from the error/warning hues"
-    (is (= "NO-OP" (badge/cascade-kind-label :no-op)))
+  (testing "rf2-ugdas / rf2-iu3no — the :no-op kind resolves to a muted (not
+            red) label + colour, distinct from the error/warning hues. The
+            label is `NO OP` (space, not hyphen — rf2-iu3no, the sole marker
+            on the collapsed `[NO OP] staying in {state}` cell)"
+    (is (= "NO OP" (badge/cascade-kind-label :no-op)))
     (is (string? (badge/cascade-kind-colour :no-op)))
     ;; The benign no-op uses the tertiary token (same as :guard / :timer's
     ;; muted family) — explicitly NOT the :error / :warning hue.

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
@@ -54,11 +54,13 @@
        #2843) fires exit+entry; internal (omit `:target`) fires action-only;
        neither emits a spurious no-op transition row (#2841)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.diff.engine :as diff]
+            [day8.re-frame2-xray.panels.epoch.format :as fmt]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.panels.machine-inspector-helpers :as mih]
             [day8.re-frame2-xray.panels.machines.topology :as topo]
@@ -190,6 +192,17 @@
   {:event-id     :hvac/controller
    :trigger-event [:hvac/controller event-v]
    :trace-events (vec (trace-collector/buffer-for-test))})
+
+(defn- drive-other!
+  "Like `drive!` but for an arbitrary machine event-id (rf2-iu3no — the
+  bootstrap-scope guard drives a SECOND machine so the captured macrostep
+  is exactly its birth)."
+  [machine-id event-v]
+  (trace-collector/reset-for-test!)
+  (rf/dispatch-sync [machine-id event-v])
+  {:event-id      machine-id
+   :trigger-event [machine-id event-v]
+   :trace-events  (vec (trace-collector/buffer-for-test))})
 
 (defn- cascade [record]
   (proj/machine-cascade-rows (:trace-events record)))
@@ -474,3 +487,82 @@
           "an unchanged member does NOT render as added (no spurious churn)")
       (is (not (member-of :fan/on removed))
           "an unchanged member does NOT render as removed"))))
+
+;; ============================================================================
+;; rf2-iu3no — the benign no-op cell: scope guard + the live no-op render
+;; ============================================================================
+
+;; A minimal machine whose INITIAL state carries an entry action, so its
+;; birth observably runs the `:initial-entry` cascade (the hvac machine's
+;; initial leaves `:idle` / `:off` have no entry handlers, so they'd run
+;; zero action rows on bootstrap — no positive signal to assert against).
+(def initial-entry-machine
+  {:initial :booting
+   :data    {}
+   :states  {:booting {:entry :on-boot}}
+   :actions {:on-boot (fn [{data :data}] {:data (assoc data :booted? true)})}})
+
+(deftest bootstrap-renders-initial-entry-not-no-op
+  (testing "rf2-iu3no / rf2-t4582 (#2846) regression guard — a machine's
+            BIRTH (`[:rf.machine/bootstrap]`) runs its `:initial-entry`
+            cascade and is NOT classified as an unhandled-user-event no-op.
+            The collapsed `[NO OP] staying in {state}` cell renders the
+            CONSEQUENCE of NO state change — it would read FALSE for the
+            machine's birth (which ENTERED its initial config, it did not
+            'stay'). So the no-op cell must NEVER be reached for the
+            bootstrap: the bootstrap macrostep carries the `:initial-entry`
+            phase and ZERO `:no-op` rows. A regression on t4582 (the
+            bootstrap re-mislabelled as a no-op) surfaces RED here."
+    (registry/register-xray-handlers!)
+    (preload/register-trace-collector!)
+    (rf/reg-machine :iu3no/boot initial-entry-machine)
+    ;; The bootstrap macrostep is the machine's birth — capture exactly it.
+    (let [record  (drive-other! :iu3no/boot [:rf.machine/bootstrap])
+          rows    (cascade record)
+          phases  (set (map :phase (rows-of-kind rows :action)))]
+      (is (empty? (rows-of-kind rows :no-op))
+          "the bootstrap renders NO benign-no-op cell — it is the machine's
+           birth, not an ignored event (rf2-t4582)")
+      (is (contains? phases :initial-entry)
+          "the bootstrap runs its :initial-entry cascade — the boot action
+           row carries the :initial-entry phase, NOT a 'staying in {state}'
+           no-op notice")
+      (is (= :booting (-> (rf/app-db-value :rf/default)
+                          (get-in [:rf/runtime :machines :snapshots :iu3no/boot :state])))
+          "the machine ENTERED its initial config (:booting) — it did not
+           'stay' (the no-op cell's premise would read FALSE for a birth)"))))
+
+(deftest genuine-unknown-user-event-renders-no-op-staying-in-state
+  (testing "rf2-iu3no — a GENUINE unknown user event (one this machine's
+            current configuration matches no transition for) renders the
+            collapsed `[NO OP] staying in {state}` cell against the LIVE
+            substrate. In the initial config (climate :idle / fan :off),
+            `:hvac/mode-toggle` is handled only in the deep :heating /
+            :cooling leaves — so from rest it matches no transition: a
+            benign no-op. ONE machine in play → the machine name is DROPPED
+            (the verb is the bare consequence)."
+    (setup!) ; leaves climate :idle / fan :off
+    (let [record   (drive! [:hvac/mode-toggle])
+          rows     (cascade record)
+          no-ops   (rows-of-kind rows :no-op)
+          no-op    (first no-ops)]
+      (is (= 1 (count no-ops))
+          "the unknown user event renders exactly ONE benign no-op cell")
+      (is (= :hvac/controller (:machine-id no-op)))
+      (is (false? (:show-machine-name? no-op))
+          "ONE machine in play → drop the machine name")
+      (is (= "staying in :idle"
+             (fmt/cascade-row-label (assoc no-op :state :idle :show-machine-name? false)))
+          "the collapsed verb is the bare consequence — `staying in {state}`")
+      ;; The verb off the LIVE row (whatever the live :state shape is) carries
+      ;; no prefix/echo/suffix and no machine name.
+      (let [verb (fmt/cascade-row-label no-op)]
+        (is (string/starts-with? verb "staying in ") "verb leads with 'staying in '")
+        (is (not (string/includes? verb "no-op")) "no 'no-op —' prefix")
+        (is (not (string/includes? verb "received")) "no 'received [event]' echo")
+        (is (not (string/includes? verb "transition")) "no ', no transition' suffix")
+        (is (not (string/includes? verb ":hvac/controller"))
+            "single-machine case drops the machine name"))
+      ;; Benign — no transition row beside it, no state change committed.
+      (is (empty? (rows-of-kind rows :transition))
+          "a no-op carries no transition row (rf2-e6q97 suppression)"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -33,6 +33,8 @@
         grouping, timer reasons, guard outcomes)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [day8.re-frame2-xray.panels.epoch.badge :as badge]
             [day8.re-frame2-xray.panels.epoch.format :as fmt]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             ;; rf2-ugdas / rf2-e7yhv — the canonical issue-projection
@@ -651,14 +653,51 @@
       (is (= :alarming (:state r)))
       (is (= 1 (:step r)))))
 
-  (testing "rf2-ugdas — the no-op verb names machine + event + state, and
-            its outcome chip reads 'ignored' (benign, not error)"
+  (testing "rf2-iu3no — a SINGLE-machine genuine no-op collapses to the
+            CONSEQUENCE only: '[NO OP] staying in {state}'. The `NO OP`
+            kind-pill is the sole marker; the verb is just 'staying in
+            <state>' — no 'no-op —' prefix, no 'received [event]' echo
+            (the focused-epoch Event header names it), no ', no transition'
+            suffix, no machine name (the lone machine is named above), and
+            NO 'ignored' outcome chip."
     (let [r (first (proj/machine-cascade-rows
                      [(machine-unhandled-no-op-ev :door/main
-                                                  [:door/insert-coin] :alarming)]))]
-      (is (= "no-op — :door/main received [:door/insert-coin] in :alarming, no transition"
-             (fmt/cascade-row-label r)))
-      (is (= "ignored" (fmt/cascade-outcome-label r)))))
+                                                  [:door/insert-coin] :alarming)]))
+          verb (fmt/cascade-row-label r)]
+      ;; RED before rf2-iu3no: verb == "no-op — :door/main received
+      ;; [:door/insert-coin] in :alarming, no transition" (the four-way
+      ;; restatement) + a non-nil "ignored" outcome label.
+      (is (= "staying in :alarming" verb))
+      (is (= "NO OP" (badge/cascade-kind-label :no-op))
+          "the pill is the sole marker — `NO OP` (space, not hyphen)")
+      (is (not (str/includes? verb "no-op"))   "no 'no-op —' prefix")
+      (is (not (str/includes? verb "received")) "no 'received [event]' echo")
+      (is (not (str/includes? verb "transition")) "no ', no transition' suffix")
+      (is (not (str/includes? verb ":door/main"))
+          "single-machine case drops the machine name")
+      (is (false? (:show-machine-name? r))
+          ":show-machine-name? false for the single-machine no-op")
+      (is (nil? (fmt/cascade-outcome-label r))
+          "no outcome chip — the pill + verb are the whole notice")))
+
+  (testing "rf2-iu3no — a MULTI-MACHINE epoch (broadcast event / parallel
+            regions) keeps the machine name on each no-op row so the
+            operator can tell WHICH machine stood pat:
+            '[NO OP] :hvac/controller staying in {state}'"
+    (let [rows (proj/machine-cascade-rows
+                 [(machine-unhandled-no-op-ev :hvac/controller
+                                              [:hvac/power-cycle] [:off])
+                  (machine-unhandled-no-op-ev :hvac/fan
+                                              [:hvac/power-cycle] [:idle])])
+          by-id (into {} (map (juxt :machine-id identity)) rows)]
+      (is (= 2 (count rows)))
+      (is (every? :show-machine-name? rows)
+          ">1 distinct machine-id in play → surface the name on every no-op")
+      (is (= ":hvac/controller staying in [:off]"
+             (fmt/cascade-row-label (by-id :hvac/controller)))
+          "the multi-machine no-op verb leads with the machine name")
+      (is (= ":hvac/fan staying in [:idle]"
+             (fmt/cascade-row-label (by-id :hvac/fan))))))
 
   (testing "rf2-ugdas — a cascade whose ONLY machine activity is the no-op
             is still :reg-machine flavour, so the EVENT HANDLER machine
@@ -672,24 +711,30 @@
 
 ;; ---- rf2-e6q97 — a no-op suppresses the spurious {X}→{X} transition row ---
 
-(deftest no-op-bootstrap-suppresses-spurious-transition-row-test
-  (testing "rf2-e6q97 — on a no-op bootstrap the substrate emits BOTH the
-            benign :rf.machine.event/unhandled-no-op AND its unconditional
-            :rf.machine/transition summary ({X}→{X}, 0 microsteps). Rendered
-            side-by-side those CONTRADICT. The cascade must show the :no-op
-            row ALONE — the spurious transition row is dropped."
+(deftest no-op-suppresses-spurious-transition-row-test
+  (testing "rf2-e6q97 — on a genuine unknown-user-event no-op the substrate
+            emits BOTH the benign :rf.machine.event/unhandled-no-op AND its
+            unconditional :rf.machine/transition summary ({X}→{X}, 0
+            microsteps). Rendered side-by-side those CONTRADICT. The cascade
+            must show the :no-op row ALONE — the spurious transition row is
+            dropped."
+    ;; rf2-iu3no — the live repro fixture was a `[:rf.machine/bootstrap]`
+    ;; no-op, but rf2-t4582 (#2846) carved the bootstrap OUT of the no-op
+    ;; classification (bootstrap runs :initial-entry, never a no-op). The
+    ;; dedup MECHANISM this asserts is independent of which event no-op'd, so
+    ;; the fixture is rebased onto a genuine unknown USER event (the only
+    ;; thing that still produces an unhandled-no-op post-t4582).
     (let [state {:vehicle :red :pedestrian :walk}
-          ;; Live repro: machine-epochs deck, epoch 3 —
-          ;; [:traffic/light [:rf.machine/bootstrap]] in a stable state.
-          ;; The substrate emit shape: unhandled-no-op (the event matched no
-          ;; transition) FOLLOWED BY the unconditional commit transition with
+          ;; A user dispatched [:traffic/unknown] in a state with no matching
+          ;; transition: unhandled-no-op (event matched no transition)
+          ;; FOLLOWED BY the unconditional commit transition with
           ;; :before == :after and :microsteps 0.
           no-op (machine-unhandled-no-op-ev :traffic/light
-                                            [:rf.machine/bootstrap] state)
+                                            [:traffic/unknown] state)
           tx    (machine-transition-ev :traffic/light
                                        {:state state :data {}}
                                        {:state state :data {}}
-                                       [:rf.machine/bootstrap] 0)
+                                       [:traffic/unknown] 0)
           rows  (proj/machine-cascade-rows [no-op tx])]
       ;; RED before the fix: rows == [:no-op :transition] (the contradiction).
       ;; GREEN after: the :transition row is gone.
@@ -706,9 +751,9 @@
     (let [state :stable
           tx    (machine-transition-ev :traffic/light
                                        {:state state} {:state state}
-                                       [:rf.machine/bootstrap] 0)
+                                       [:traffic/unknown] 0)
           no-op (machine-unhandled-no-op-ev :traffic/light
-                                            [:rf.machine/bootstrap] state)
+                                            [:traffic/unknown] state)
           rows  (proj/machine-cascade-rows [tx no-op])]
       (is (= [:no-op] (mapv :kind rows)))))
 
@@ -716,11 +761,11 @@
             the :machine :cascade slot the view renders (the live surface)"
     (let [state {:vehicle :red :pedestrian :walk}
           evs   [(machine-unhandled-no-op-ev :traffic/light
-                                             [:rf.machine/bootstrap] state)
+                                             [:traffic/unknown] state)
                  (machine-transition-ev :traffic/light
                                         {:state state :data {}}
                                         {:state state :data {}}
-                                        [:rf.machine/bootstrap] 0)]
+                                        [:traffic/unknown] 0)]
           r     (proj/handler-row evs :traffic/light)]
       (is (= :reg-machine (:flavour r)))
       (is (= [:no-op] (mapv :kind (-> r :machine :cascade)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1397,6 +1397,66 @@
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-trigger-1"))
           "the redundant echoed `event [...]` line is gone"))))
 
+;; ---- rf2-iu3no — the benign no-op collapses to `[NO OP] staying in {state}` --
+
+(deftest machine-handler-cascade-no-op-row-collapses-test
+  (testing "rf2-iu3no — a SINGLE-machine genuine no-op row renders the
+            `NO OP` kind-pill (the SOLE marker) + the verb `staying in
+            {state}`, drops the unexplained leading ordinal '1', and
+            carries NO outcome chip. RED before the fix: a `1` ordinal +
+            a `no-op — … received … no transition` verb + an `ignored`
+            outcome chip — four restatements of one fact."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :door/main
+                :fx []
+                :machine {:cascade [{:kind :no-op :step 1
+                                     :machine-id :door/main
+                                     :event [:door/insert-coin]
+                                     :state :alarming
+                                     :show-machine-name? false}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+          "the no-op row renders")
+      ;; The `[NO OP]` pill is the sole marker.
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-kind-no-op"))
+          "the NO OP kind-pill is present")
+      (is (string/includes? (text-of tree "rf-xray-epoch-machine-cascade-kind-no-op")
+                            "NO OP")
+          "the pill reads `NO OP` (space, not hyphen)")
+      ;; The stray leading "1" ordinal is SUPPRESSED for the no-op.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-ordinal-1"))
+          "the unexplained leading '1' ordinal is dropped for the no-op row")
+      ;; The verb is the consequence only: `staying in :alarming`.
+      (let [verb (text-of tree "rf-xray-epoch-machine-cascade-verb-link-1")]
+        (is (= "staying in :alarming" verb)
+            "verb is the consequence — `staying in {state}`")
+        (is (not (string/includes? verb "no-op"))   "no 'no-op —' prefix")
+        (is (not (string/includes? verb "received")) "no 'received [event]' echo")
+        (is (not (string/includes? verb "transition")) "no ', no transition' suffix"))
+      ;; NO outcome chip — the prior `ignored` chip is gone.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ignored"))
+          "no `ignored` outcome chip — the pill + verb are the whole notice"))))
+
+(deftest machine-handler-cascade-multi-machine-no-op-keeps-name-test
+  (testing "rf2-iu3no — when >1 machine is in play (broadcast / parallel
+            regions), the no-op row keeps the machine name so the operator
+            can tell WHICH machine stood pat: `[NO OP] :hvac/controller
+            staying in {state}`."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :hvac/power-cycle
+                :fx []
+                :machine {:cascade [{:kind :no-op :step 1
+                                     :machine-id :hvac/controller
+                                     :event [:hvac/power-cycle]
+                                     :state [:off]
+                                     :show-machine-name? true}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (= ":hvac/controller staying in [:off]"
+             (text-of tree "rf-xray-epoch-machine-cascade-verb-link-1"))
+          "the multi-machine no-op verb leads with the machine name"))))
+
 ;; ---- rf2-wwc3j — inline-fn / transition source-body rendering ------------
 
 (deftest cascade-row-renders-inline-entry-source-body-test


### PR DESCRIPTION
## What

Follow-up to rf2-ugdas. The benign unhandled-user-event no-op cell (machine-epochs :8033, EVENT HANDLER section) over-stacked four restatements of one fact — the NO-OP badge + a `no-op —` prefix + a `received [event]` echo + a `, no transition` suffix — plus an unexplained leading `1`. Collapsed to the CONSEQUENCE only: **`[NO OP] staying in {state}`**.

- **`format/cascade-row-label` `:no-op`** → `staying in {state}`. Dropped the `no-op —` prefix, the `received [event]` echo (the focused-epoch Event header already names it), and the `, no transition` suffix.
- **Machine name** kept ONLY when >1 machine is in play this epoch (broadcast event hitting sibling machines) so the operator can tell which machine stood pat: `[NO OP] :hvac/controller staying in {state}`. Single-machine case drops it (the EVENT HANDLER section names the lone machine). `projection/machine-cascade-rows` stamps `:show-machine-name?` on each no-op row when the cascade spans >1 distinct `:machine-id`.
- **The stray "1"** was the `1..N` cascade row ordinal (`cascade-row-ordinal`). A no-op cascade is a single muted row, so the lone `1` read as noise — the view suppresses the ordinal for `:no-op` rows.
- **`badge` `:no-op` pill** relabelled `NO-OP` to `NO OP` (the sole marker).
- **`ignored` outcome chip dropped** (a third restatement); the dead `:ignored` outcome value + glyph retired from `badge`/`format`.

## Scope (t4582 made this safe)

This cell now only ever fires for a genuine unknown **user**-event no-op. rf2-t4582 (#2846, on main) carved the bootstrap OUT of the no-op classification — a machine's BIRTH runs its `:initial-entry` cascade, never a no-op — so `staying in` never mislabels a birth. A live regression guard pins that the bootstrap renders `:initial-entry` and reaches NO no-op cell (a t4582 regression surfaces RED). The bootstrap is NOT special-cased here; it simply never arrives.

## Quality gates

| Gate | Result |
|------|--------|
| `npm run test:cljs` (node-runtime CLJS) | PASS — 5335 tests / 18299 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` (machine-epochs deck, nightly-full sweep) | PASS — 16 scenarios, 0 failures, 13 matrix rows |
| JVM xray + epoch (`clojure -M:test` in `tools/xray`) | PASS — 1059 tests / 4303 assertions, 0 failures, 0 errors |
| `clj-kondo` on changed sources | 0 errors, 0 new warnings (format.cljc clean; remaining unused-var warnings pre-exist on main) |

rf2-iu3no.
