### PR TITLE
fix(xray): classify machine transitions (not just action-ran) as :reg-machine in handler-flavour (rf2-eue07)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1367,6 +1367,29 @@ from the trace stream:
 - **`:reg-event-fx`** — `:db` diff + per-fx-entry block.
 - **`:reg-machine`** — **TIME-ORDERED MACHINE CASCADE** per rf2-u69j7.
 
+**Flavour discriminator (`handler-flavour`, rf2-eue07).** The classifier is
+a pure-data `cond` over the trace stream, machine-predicates FIRST (a machine
+handler always rides a `:rf.fx/do-fx` for its snapshot write, so `do-fx` must
+never win for a macrostep):
+
+1. `:rf.machine/transition` present → `:reg-machine`. This is the
+   AUTHORITATIVE macrostep marker — `commit-or-finalize` (machines ·
+   lifecycle_fx · registration.cljc) emits ONE transition summary per
+   macrostep UNCONDITIONALLY, for action-firing transitions, pure state
+   moves, **entry-cascade-only transitions** (whose `:entry` actions are NOT
+   traced as `:rf.machine/action-ran` — rf2-n9f4z), AND the bootstrap
+   `:initial-entry` (rf2-t4582). Keying on the transition (not the narrow
+   action-ran check) is what makes those action-less macrosteps render the
+   machine section instead of the raw `:db` diff of the snapshot write.
+2. `:rf.machine/action-ran` present → `:reg-machine` (subsumed by (1) for any
+   real macrostep; retained for fixtures / defence in depth).
+3. `:rf.machine.event/unhandled-no-op` present → `:reg-machine` (rf2-ugdas —
+   see below; once rf2-e6q97 suppresses the spurious `{X}→{X}` commit
+   transition, a no-op-only cascade carries neither a transition nor an
+   action, so it needs its own predicate).
+4. `:rf.fx/do-fx` present → `:reg-event-fx`.
+5. else → `:reg-event-db`.
+
 #### Machine cascade (rf2-u69j7)
 
 **Stance.** The pre-rf2-u69j7 layout grouped machine activity into 7

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -339,20 +339,43 @@
 (defn- handler-flavour
   "Discriminate the handler kind from the trace stream. Three flavours:
 
-      :reg-machine     — at least one `:rf.machine/action-ran` rode
+      :reg-machine     — the cascade carried a machine macrostep
       :reg-event-fx    — a `:rf.fx/do-fx` rode (effects were returned)
       :reg-event-db    — otherwise (default for any non-machine event)
 
   The discriminator is the trace stream — no spec read at projection
-  time. Pure-data; JVM-testable."
+  time. Pure-data; JVM-testable.
+
+  WHAT MARKS A MACHINE MACROSTEP (rf2-eue07). The authoritative signal is
+  `:rf.machine/transition`: the substrate's `commit-or-finalize`
+  (machines · lifecycle_fx · registration.cljc) emits ONE transition
+  summary per macrostep UNCONDITIONALLY — for action-firing transitions,
+  pure state moves, entry-cascade-only transitions (whose `:entry`
+  actions are NOT traced as `:rf.machine/action-ran`, see rf2-n9f4z),
+  AND the post-carve-out bootstrap `:initial-entry` (rf2-t4582). The
+  prior classifier keyed ONLY on `:rf.machine/action-ran`, so any
+  macrostep that fired no action (HVAC `:hvac/power-cycle` entry cascade,
+  bootstrap) fell through to `:reg-event-fx` — the machine handler always
+  rides a `:rf.fx/do-fx` (its snapshot write) — and rendered the raw `:db`
+  diff with NO machine section. Keying on the transition closes that gap.
+
+  The machine predicates MUST precede the `:rf.fx/do-fx` check: a machine
+  handler always rides a do-fx, so do-fx must never win for a macrostep."
   [events]
   (cond
+    ;; rf2-eue07 — a `:rf.machine/transition` summary marks a machine
+    ;; macrostep (action-firing or not, including the bootstrap
+    ;; :initial-entry). This is the authoritative, action-independent
+    ;; signal; it subsumes the narrow action-ran check below.
+    (some #(= :rf.machine/transition (op %)) events) :reg-machine
     (some #(= :rf.machine/action-ran (op %)) events) :reg-machine
     ;; rf2-ugdas — a cascade whose ONLY machine activity is the benign
     ;; unhandled-event no-op (an event that matched no transition, so no
-    ;; action ran) is still a machine cascade: classify it :reg-machine so
-    ;; the EVENT HANDLER machine section renders the no-op notice rather
-    ;; than collapsing to a plain reg-event-db handler.
+    ;; action ran AND — once rf2-e6q97 suppresses the spurious {X}→{X}
+    ;; commit transition — no transition row either) is still a machine
+    ;; cascade: classify it :reg-machine so the EVENT HANDLER machine
+    ;; section renders the no-op notice rather than collapsing to a plain
+    ;; reg-event-db handler.
     (some #(= :rf.machine.event/unhandled-no-op (op %)) events) :reg-machine
     (some #(= :rf.fx/do-fx (op %)) events)           :reg-event-fx
     :else                                            :reg-event-db))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -460,6 +460,75 @@
       (is (= 1 (count (:timers m))))
       (is (= :on-exit (-> m :timers first :reason))))))
 
+(deftest handler-row-machine-transition-no-action-test
+  (testing "rf2-eue07 — a real macrostep that fires NO `:rf.machine/action-ran`
+            (an entry-cascade-only / pure-state-move transition — the
+            framework does NOT emit `action-ran` for `:entry` actions, see
+            rf2-n9f4z) is STILL a machine cascade. The substrate's
+            `:rf.machine/transition` summary rides the macrostep
+            UNCONDITIONALLY (commit-or-finalize · lifecycle_fx ·
+            registration.cljc), so `:rf.machine/transition` is the
+            authoritative macrostep marker. It MUST classify `:reg-machine`
+            (render the machine section), NOT `:reg-event-fx` / `:reg-event-db`
+            (the raw `:db` diff of the snapshot write).
+
+  RED before the fix: handler-flavour saw only the do-fx (the machine handler
+  always rides one) → fell through to `:reg-event-fx`; `:machine` slot absent."
+    (let [snap-before {:state [:off]      :data {}}
+          snap-after  {:state [:running]  :data {}}
+          ;; A machine handler ALWAYS rides a `:rf.fx/do-fx` (the snapshot
+          ;; write). The pre-fix classifier let that do-fx win → :reg-event-fx.
+          evs [(do-fx-ev {:db {:hvac/controller {:state {:climate [:running]}}}})
+               (machine-transition-ev :hvac/controller snap-before snap-after
+                                       [:hvac/power-cycle] 2)
+               (db-changed-ev [[[:hvac/controller] {} {} :modified]])]
+          r   (proj/handler-row evs :hvac/power-cycle)
+          m   (:machine r)]
+      (is (= :reg-machine (:flavour r))
+          "a transition with NO action-ran still classifies :reg-machine")
+      (is (some? m)
+          "the machine section is populated, not the raw :db diff")
+      (is (= :hvac/controller (-> m :transition :machine-id))
+          "the transition row threads through into the machine block"))))
+
+(deftest handler-row-bootstrap-initial-entry-transition-test
+  (testing "rf2-eue07 — the post-carve-out bootstrap macrostep (rf2-t4582:
+            bootstrap runs `:initial-entry`, never a no-op) emits a
+            `:rf.machine/transition` summary. Even were its `:initial-entry`
+            actions untraced, the transition marks it a machine cascade →
+            `:reg-machine`, so the EVENT HANDLER renders the machine section
+            (the `[INITIAL]` bootstrap), not a raw `:db` diff."
+    (let [snap-before {:state nil          :data {}}
+          snap-after  {:state [:off]       :data {}}
+          evs [(do-fx-ev {:db {:hvac/controller {:state {:climate [:off]}}}})
+               (machine-transition-ev :hvac/controller snap-before snap-after
+                                       [:rf.machine/bootstrap] 1)]
+          r   (proj/handler-row evs :hvac/controller)]
+      (is (= :reg-machine (:flavour r))
+          "the bootstrap transition classifies :reg-machine, not :reg-event-fx")
+      (is (some? (:machine r))
+          "the bootstrap renders the machine section"))))
+
+(deftest handler-flavour-negative-guards-test
+  (testing "rf2-eue07 NEGATIVE GUARD — a genuine reg-event-fx (a do-fx with
+            NO machine trace at all) STILL classifies :reg-event-fx; the new
+            transition predicate must not over-claim"
+    (let [evs [(do-fx-ev {:db {} :navigate "/x"})
+               (db-changed-ev [])]
+          r   (proj/handler-row evs :navigate-to)]
+      (is (= :reg-event-fx (:flavour r))
+          "no machine trace → plain reg-event-fx, unchanged")
+      (is (nil? (:machine r))
+          "no machine section on a plain fx handler")))
+
+  (testing "rf2-eue07 NEGATIVE GUARD — a genuine reg-event-db (no fx, no
+            machine trace) STILL classifies :reg-event-db"
+    (let [r (proj/handler-row [(db-changed-ev [[[:counter] 5 6 :modified]])]
+                              :counter-inc)]
+      (is (= :reg-event-db (:flavour r))
+          "no fx, no machine trace → reg-event-db, unchanged")
+      (is (nil? (:machine r))))))
+
 (deftest machine-transition-row-hoists-data-snapshots-test
   (testing "rf2-9c27r — `machine-transition-row` exposes `:data-before /
             :data-after` from the `:before / :after` snapshots, plus the


### PR DESCRIPTION
@
## Summary

P1 BUG (rf2-eue07): under the Xray Epoch **EVENT HANDLER** step, a real machine TRANSITION that fired NO action rendered as a generic `reg-event-fx` handler with a raw app-db `:db` diff of the snapshot write — NO machine section, no transition/cascade explanation. Confirmed live (:8033) for `:hvac/controller [:hvac/power-cycle]` and the post-carve-out bootstrap.

### Root cause

`panels/epoch/projection.cljc` `handler-flavour` classified `:reg-machine` ONLY when the trace stream carried `:rf.machine/action-ran` (or, per rf2-ugdas, `:rf.machine.event/unhandled-no-op`). An entry-cascade-only transition (HVAC `:hvac/power-cycle` — its `:entry` actions are NOT emitted as `action-ran`, see rf2-n9f4z) or the bootstrap `:initial-entry` (rf2-t4582) emits `:rf.machine/transition` but no `action-ran`. The machine handler always rides a `:rf.fx/do-fx` (its snapshot write), so the `cond` fell through to `:reg-event-fx` → the `:machine` slot is gated on `(= :reg-machine flavour)`, so the whole machine section was skipped and the raw `:db` diff rendered instead.

### The fix — which predicate + why

Added `:rf.machine/transition` as the **first** `:reg-machine` predicate in `handler-flavour` (ahead of the `:rf.fx/do-fx` check). `commit-or-finalize` (machines · lifecycle_fx · registration.cljc) emits the transition summary **once per macrostep, unconditionally** — for action-firing transitions, pure state moves, entry-cascade-only transitions, AND the bootstrap `:initial-entry`. It is therefore the authoritative, action-independent macrostep marker and the natural signal the bead called for. It subsumes the narrow `action-ran?` check, which is retained for fixtures / defence in depth. The `unhandled-no-op?` predicate is retained (a no-op-only cascade, once rf2-e6q97 drops the spurious `{X}→{X}` commit transition, carries neither a transition nor an action). Ordering: machine predicates precede `do-fx`, so a do-fx never wins for a macrostep.

### Tests (reproduce-then-fix)

- **RED → GREEN** `handler-row-machine-transition-no-action-test` — a macrostep with a `:rf.machine/transition` + a (winning, pre-fix) `:rf.fx/do-fx` but NO `action-ran` now classifies `:reg-machine` and populates the machine section (was `:reg-event-fx`, raw `:db` diff).
- **RED → GREEN** `handler-row-bootstrap-initial-entry-transition-test` — the bootstrap `:initial-entry` transition (rf2-t4582) classifies `:reg-machine`.
- **Unchanged (kept green)** `handler-row-reg-machine-test` — an action-firing transition still `:reg-machine`.
- **Negative guards** `handler-flavour-negative-guards-test` — a genuine `reg-event-fx` (do-fx, no machine trace) stays `:reg-event-fx` with no `:machine`; a genuine `reg-event-db` stays `:reg-event-db`. No over-claim.
- The rf2-ugdas no-op handler-row tests stay green (still `:reg-machine`).

Per xray-specs-kept-current, `tools/xray/spec/021-Dynamic-Panel-Designs.md` §9.1.5 gains an explicit flavour-discriminator subsection documenting the `:rf.machine/transition`-first rule.

## Quality gates

| Gate | Result |
|------|--------|
| `npm run test:cljs` | PASS — 5338 tests, 18308 assertions, 0 failures |
| `npm run test:xray-feature-gate` | PASS — 0 failures on re-run; `machine-epochs machine ladder` (HVAC deck) PASS both runs. First run had the documented KNOWN FLAKE `routes-epochs routing ladder`, green on re-run. |
| JVM xray (`clojure -M:test` in tools/xray) | PASS — 1062 tests, 4312 assertions, 0 failures (covers the epoch projection ns) |

Closes #rf2-eue07.
@