### PR TITLE
feat(xray): render the structured machine cascade under EVENT HANDLER (rf2-52u5n)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -2,6 +2,18 @@
 
 > **See also**: [`021-Dynamic-Panel-Designs.md` §6](021-Dynamic-Panel-Designs.md#6-the-machines-panel-topology--overlay) for the canonical content design layered onto the topology view.
 
+> **The EVENT HANDLER machine cascade (rf2-52u5n) lives in the Epoch
+> panel, not here.** Spec 005 §The structured transition cascade names
+> "Xray's epoch panel" as the consumer of the `:cascade` tag on the
+> `:rf.machine/transition` trace (rf2-n9f4z); the step-by-step
+> entry/exit cascade render — the ordered exit/action/entry steps +
+> `:always` microsteps, grouped per-region for parallel machines —
+> is specified in
+> [`021-Dynamic-Panel-Designs.md` §Transition row — STRUCTURED entry/exit cascade](021-Dynamic-Panel-Designs.md#machine-cascade-rf2-u69j7).
+> This file (003) covers the Machines TAB's topology chart + focused-
+> transition lens; the Epoch panel's EVENT HANDLER section is the
+> cascade narration.
+
 > **2026-05-19 collapse note (rf2-y9xmf):** the Dynamic Machines panel
 > is now **event-driven only**. The panel is BLANK when the currently
 > focused event triggered no machine transitions; it renders one

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1676,6 +1676,60 @@ structured before→after state object.
   false — only `:data` or `:rf/*` bookkeeping moved), the box is elided
   entirely; the headline verb stays.
 
+**Transition row — STRUCTURED entry/exit cascade (rf2-52u5n).** Below
+the logical-state delta box, the transition row renders the **structured
+cascade** — the step-by-step explanation of HOW the macrostep reached
+its after-state, replacing the old "`{from}→{to}` + `{n} microstep(s)`"
+opacity. The data is the `:cascade` tag the substrate emits on the
+`:rf.machine/transition` trace (rf2-n9f4z; Spec 005 §The structured
+transition cascade) — a vector of self-describing step maps
+`{:kind <:exit|:action|:entry|:microstep> :state <path> :region
+<name-or-nil> :action <id-or-nil> :data-delta <changed-keys>}` in
+EXECUTION order (exit deepest-first → transition `:action` @ LCA → entry
+shallowest-first + initial-descent → one `:microstep` per `:always`
+iteration). The projection (`machine-transition-row` /
+`transition-cascade-row`) threads this onto the transition row's
+`:cascade` slot; `projection/cascade-regions` / `cascade-microsteps` /
+`parallel-cascade?` / `cascade-step-count` group it for the view.
+
+Rendered shape (`view/structured-cascade-body`):
+
+- **The ordered ENTRY/EXIT CASCADE.** One row per structural step:
+  `<kind-glyph> <state-path> <action-id | (no action)> <data Δ>`. The
+  glyph reads the boundary kind (`↑` exit / `•` action / `↓` entry); the
+  state-path is the LCA-relative path exited/entered (the action's
+  decl-path for `:action`); the action-id names the fired action, or an
+  explicit muted `(no action)` for an action-free boundary (so the
+  COMPLETE configuration walk is legible — the per-EMIT
+  `:rf.machine/action-ran` stream above can NOT show these, since an
+  action-free `:idle` / `:off` exit declares no action and emits no
+  trace). The `:data-delta` (changed `:data` keys only — never the whole
+  snapshot, so no large-payload leak) renders inline through the
+  edn-inspector when non-empty.
+- **Per-`:region` grouping (parallel machines).** When the cascade spans
+  more than one `:region` (`parallel-cascade?`), the steps render in
+  per-region columns (each headed `region <name>`) in declaration order
+  (climate before fan), so a parallel broadcast reads region-by-region
+  rather than as one opaque map diff. A flat / compound machine's steps
+  all carry `:region nil` → one ungrouped column, no region label.
+- **`:always` microsteps sectioned.** Each eventless microstep renders
+  as its OWN section headed `microstep N · <from> → <to>` over its
+  nested exit/action/entry `:steps`, so the `:always` stream is
+  EXPLAINABLE (not just a count). This composes with the per-microstep
+  `:rf.machine.microstep/transition` stream (that stays the per-microstep
+  marker; `:cascade` is the macrostep-level structured rollup).
+- **Fallback.** A `:rf.machine/transition` trace with NO structured
+  `:cascade` (older traces / non-structured fixtures) renders no
+  structured body — the `{from}→{to}` headline verb + the logical-state
+  delta box remain (graceful degradation). The grouping helpers degrade
+  to `[]` / `nil` on a nil cascade.
+
+This removes the need for the app-level `:data :trail` workaround the
+`machine_epochs` testbed previously used to make the cascade observable
+by hand (rf2-52u5n live finding, machine-epochs :8033). It is the
+consumer of the rf2-n9f4z instrumentation contract per
+[003-Machine-Inspector §The EVENT HANDLER machine cascade](003-Machine-Inspector.md).
+
 Timer rows surface only the header + click-to-source chip (no inline
 body — cancellations are housekeeping; the chip routes to the
 `:after`-bearing state node).

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -465,7 +465,15 @@
   the full machine snapshot maps (`:state` + `:data` + …); the row
   hoists `:data-before` / `:data-after` for the rf2-9c27r DATA
   REDUCTION sub-section so the view layer doesn't re-walk the
-  snapshot map."
+  snapshot map.
+
+  rf2-52u5n — the row also carries the STRUCTURED `:cascade` (the
+  ordered exit/action/entry/microstep step vector the substrate
+  emits on the `:rf.machine/transition` trace per rf2-n9f4z) so the
+  view can render the step-by-step entry/exit cascade under EVENT
+  HANDLER rather than only `{from}→{to} + {n} microstep(s)`. Absent
+  (`nil`) for older traces / non-structured fixtures — the view
+  falls back to the summary in that case."
   [events]
   (when-let [ev (find-op events :rf.machine/transition)]
     (let [before (common/tag-of ev :before)
@@ -476,7 +484,8 @@
        :after        after
        :data-before  (when (map? before) (:data before))
        :data-after   (when (map? after)  (:data after))
-       :microsteps   (common/tag-of ev :microsteps)})))
+       :microsteps   (common/tag-of ev :microsteps)
+       :cascade      (common/tag-of ev :cascade)})))
 
 (defn- machine-guard-rows
   "Project the `:rf.machine/guard-evaluated` stream into rows. Each
@@ -685,7 +694,15 @@
   Per Spec 005 §Trace events the substrate fires ONE transition emit
   per macrostep — so the cascade carries at most one `:transition`
   row, and it lands AFTER the exit-phase actions + the transition-
-  phase actions (substrate emit order)."
+  phase actions (substrate emit order).
+
+  rf2-52u5n — the row threads the STRUCTURED `:cascade` (the ordered
+  exit/action/entry/microstep step vector the substrate emits on the
+  `:rf.machine/transition` trace per rf2-n9f4z) through to the view so
+  the transition row's body renders the step-by-step entry/exit
+  cascade — per-region grouped, with the `:always` microsteps
+  sectioned — rather than only `{from}→{to} + {n} microstep(s)`.
+  Absent (`nil`) for older traces / non-structured fixtures."
   [ev]
   (let [before (common/tag-of ev :before)
         after  (common/tag-of ev :after)]
@@ -699,6 +716,7 @@
      :data-before  (when (map? before) (:data before))
      :data-after   (when (map? after)  (:data after))
      :microsteps   (common/tag-of ev :microsteps)
+     :cascade      (common/tag-of ev :cascade)
      :duration-ms  (common/tag-of ev :duration-ms)}))
 
 (defn- timer-cascade-row
@@ -1048,6 +1066,103 @@
   (let [nums (keep :duration-ms cascade-rows)]
     (when (seq nums)
       (reduce + 0 nums))))
+
+;; ---- structured transition cascade (rf2-52u5n / rf2-n9f4z) --------------
+;;
+;; The `:rf.machine/transition` trace carries a STRUCTURED `:cascade` tag
+;; (rf2-n9f4z) — the ordered step sequence that explains HOW the macrostep
+;; reached its after-state. Each step is a self-describing map
+;;
+;;   {:kind   :exit | :action | :entry | :microstep
+;;    :state  <state-path-vector>          ;; LCA-relative for :action
+;;    :region <region-name-or-nil>          ;; parallel region; nil flat/compound
+;;    :action <action-id-or-nil>            ;; nil = boundary fired no action
+;;    :data-delta {<changed :data keys>}}
+;;
+;; in EXECUTION order — exit (deepest-first) → transition `:action` @ LCA →
+;; entry (shallowest-first + initial-descent), then one `:microstep` step
+;; per `:always` iteration (carrying its own nested exit/action/entry
+;; `:steps` + `:microstep-index` / `:from` / `:to`). Spec 005 §The
+;; structured transition cascade is the authoritative contract; the
+;; instrumentation test `re-frame.machine-cascade-instrumentation-test`
+;; pins the exact shape.
+;;
+;; This is the data rf2-52u5n renders under EVENT HANDLER. The pre-existing
+;; `machine-cascade-rows` (rf2-u69j7) is the per-EMIT stream (one row per
+;; `:rf.machine/action-ran` / guard / transition / timer trace) — it cannot
+;; show the ACTION-FREE boundaries (e.g. exiting `:idle` / `:off`, which
+;; declare no `:exit` action so emit no `:rf.machine/action-ran`), so it is
+;; NOT a complete configuration walk. The structured `:cascade` IS the
+;; complete walk; the projection below groups it for legible per-region
+;; rendering without the view re-walking the step vector.
+
+(defn- structural-cascade-step? [step]
+  (and (map? step)
+       (contains? #{:exit :action :entry} (:kind step))))
+
+(defn- microstep-cascade-step? [step]
+  (and (map? step) (= :microstep (:kind step))))
+
+(defn cascade-regions
+  "Group the LCA-cascade steps (`:exit` / `:action` / `:entry`) of a
+  structured `:cascade` step vector by `:region`, preserving FIRST-
+  ENCOUNTER region order (rf2-52u5n). The `:microstep` steps are NOT
+  included here (they ride the `cascade-microsteps` section).
+
+  Returns a vector of `{:region <name-or-nil> :steps [<step> …]}` groups,
+  each group's `:steps` in their original execution order. A flat /
+  compound machine carries one group keyed `nil` (every step's `:region`
+  is nil); a parallel machine carries one group per region in the order
+  the substrate concatenated them (region declaration order).
+
+  Returns `[]` for a nil / empty cascade — the caller's fallback to the
+  `{from}→{to}` summary keys off the empty result."
+  [cascade]
+  (let [steps (filterv structural-cascade-step? cascade)]
+    (->> steps
+         ;; group-by loses order; rebuild in first-encounter order so a
+         ;; parallel cascade reads region-by-region as the substrate
+         ;; concatenated it (climate before fan).
+         (reduce (fn [{:keys [groups] :as acc} step]
+                   (let [r (:region step)]
+                     (-> acc
+                         (update :order (fn [o] (if (contains? groups r) o (conj o r))))
+                         (update :groups update r (fnil conj []) step))))
+                 {:order [] :groups {}})
+         (#(mapv (fn [r] {:region r :steps (get (:groups %) r)}) (:order %))))))
+
+(defn cascade-microsteps
+  "Extract the `:microstep` steps of a structured `:cascade`, ordered by
+  `:microstep-index` (rf2-52u5n). Each retains its `:from` / `:to` /
+  `:microstep-index` / `:region` and its nested `:steps` (the eventless
+  transition's own exit/action/entry cascade) so the view sections them
+  per index. Returns `[]` when the cascade carries no microsteps (the
+  common non-`:always` macrostep)."
+  [cascade]
+  (->> cascade
+       (filterv microstep-cascade-step?)
+       (sort-by (fn [m] (or (:microstep-index m) 0)))
+       vec))
+
+(defn cascade-step-count
+  "Total structural step count across a structured `:cascade` — the
+  top-level exit/action/entry steps PLUS every microstep's own nested
+  steps (rf2-52u5n). Drives the section header's `N step(s)` chip. nil
+  for a nil / empty cascade so the view elides the chip."
+  [cascade]
+  (when (seq cascade)
+    (+ (count (filterv structural-cascade-step? cascade))
+       (reduce + 0 (map (fn [m] (count (filterv structural-cascade-step? (:steps m))))
+                        (cascade-microsteps cascade))))))
+
+(defn parallel-cascade?
+  "True iff the structured `:cascade` carries more than one distinct
+  `:region` (i.e. a parallel-machine broadcast) — the view groups
+  per-region only in that case (rf2-52u5n). A flat / compound machine's
+  steps all carry `:region nil`, so this is false and the view renders
+  one ungrouped column."
+  [cascade]
+  (< 1 (count (into #{} (keep :region) (filter structural-cascade-step? cascade)))))
 
 ;; ---- machine LOGICAL-STATE delta (rf2-iwy0c) ----------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -548,6 +548,98 @@
   {:color        accent-colour
    :margin-right "6px"})
 
+;; ---- structured transition cascade (rf2-52u5n) --------------------------
+;;
+;; The transition row's body renders the STRUCTURED `:cascade` (the ordered
+;; exit/action/entry/microstep step vector off the `:rf.machine/transition`
+;; trace, rf2-n9f4z) under the `{from}→{to}` headline + the logical-state
+;; delta box — the step-by-step "how the machine got there" the operator
+;; previously had to reconstruct from a `:data :trail` workaround. The idiom
+;; mirrors the per-EMIT cascade rows (rf2-u69j7) — a thin left-rail kind
+;; chrome + monospace verb + inline `:data` delta — but rendered from the
+;; COMPLETE configuration walk (action-free boundaries included) and grouped
+;; PER REGION for parallel machines.
+
+(def ^:private structured-cascade-root-style
+  {:margin-top     "6px"
+   :display        "flex"
+   :flex-direction "column"
+   :gap            "6px"})
+
+(def ^:private structured-cascade-region-style
+  {:display        "flex"
+   :flex-direction "column"
+   :border-left    border-subtle-1px
+   :padding-left   "8px"})
+
+(def ^:private structured-cascade-region-label-style
+  {:font-family    mono-stack
+   :font-size      "10px"
+   :font-weight    700
+   :letter-spacing "0.04em"
+   :color          text-tertiary-colour
+   :margin-bottom  "2px"})
+
+(def ^:private structured-cascade-step-row-style
+  {:display     "flex"
+   :align-items "flex-start"
+   :gap         "6px"
+   :padding     "2px 0"
+   :font-family mono-stack
+   :font-size   "11px"})
+
+;; Per-step :kind glyph + tone — exit (leave), action (the change), entry
+;; (arrive). The exit/entry arrows give the cascade an at-a-glance up/down
+;; read; the action dot marks the LCA state-change boundary.
+(def ^:private structured-cascade-kind->glyph
+  {:exit "↑" :action "•" :entry "↓"})
+
+(def ^:private structured-cascade-kind->tone
+  {:exit  text-secondary-colour
+   :action (badge/cascade-kind-colour :transition)
+   :entry  success-colour})
+
+(def ^:private structured-cascade-kind-glyph-style
+  {:font-weight 700
+   :min-width   "10px"
+   :text-align  "center"})
+
+(def ^:private structured-cascade-state-style
+  {:color       text-primary-colour
+   :white-space "nowrap"})
+
+(def ^:private structured-cascade-action-chip-style
+  {:color        accent-colour
+   :margin-left  "4px"})
+
+(def ^:private structured-cascade-noaction-style
+  {:color       text-tertiary-colour
+   :font-style  "italic"
+   :margin-left "4px"})
+
+(def ^:private structured-cascade-delta-style
+  {:flex      1
+   :min-width 0})
+
+(def ^:private structured-cascade-microsteps-style
+  {:display        "flex"
+   :flex-direction "column"
+   :gap            "4px"
+   :margin-top     "2px"})
+
+(def ^:private structured-cascade-microstep-style
+  {:display        "flex"
+   :flex-direction "column"
+   :border-left    (str "2px solid " (badge/cascade-kind-colour :transition))
+   :padding-left   "8px"})
+
+(def ^:private structured-cascade-microstep-header-style
+  {:font-family mono-stack
+   :font-size   "10px"
+   :font-weight 700
+   :color       (badge/cascade-kind-colour :transition)
+   :margin-bottom "1px"})
+
 ;; rf2-4yrr6 — `cascade-detail-threw-row-style` / `cascade-threw-glyph-style`
 ;; / `cascade-threw-label-style` / `cascade-threw-message-style` RETIRED with
 ;; the per-action "✗ threw — <message>" detail line (the duplicate threw
@@ -2581,6 +2673,116 @@
                   :default-expanded-depth 3}
            (some? before-ls) (assoc :before before-ls))]]])))
 
+;; ---- structured transition cascade render (rf2-52u5n) -------------------
+
+(defn- structured-cascade-step-row
+  "Render ONE structural cascade step (`:exit` / `:action` / `:entry`)
+  off the structured `:cascade` (rf2-52u5n). Layout:
+
+      <glyph> <state-path>  <action-id | (no action)>   { :data Δ … }
+
+  - the glyph + tone read the boundary KIND (↑ exit / • action / ↓ entry);
+  - the state-path is the LCA-relative path the step exited/entered (the
+    transition action's decl-path for `:action`);
+  - the action-id chip names the fired action, or a muted '(no action)'
+    when the boundary declared none (the complete-walk action-free
+    boundaries — e.g. exiting `:idle`);
+  - the `:data-delta` (changed `:data` keys only) renders inline through
+    the edn-inspector when non-empty, so the operator sees exactly what
+    that step contributed without expanding the whole snapshot."
+  [testid-prefix idx {:keys [kind state action data-delta]}]
+  (let [glyph (get structured-cascade-kind->glyph kind "·")
+        tone  (get structured-cascade-kind->tone kind text-secondary-colour)]
+    [:div {:key         (str testid-prefix "-step-" idx)
+           :data-testid (str testid-prefix "-step-" idx)
+           :data-cascade-step-kind (when (keyword? kind) (name kind))
+           :style       structured-cascade-step-row-style}
+     [:span {:aria-hidden true
+             :style (assoc structured-cascade-kind-glyph-style :color tone)}
+      glyph]
+     [:span {:style structured-cascade-state-style}
+      (pr-str state)]
+     (if (some? action)
+       [:span {:data-testid (str testid-prefix "-step-" idx "-action")
+               :style structured-cascade-action-chip-style}
+        (fmt/ns-keyword action)]
+       [:span {:style structured-cascade-noaction-style} "(no action)"])
+     (when (seq data-delta)
+       [:span {:data-testid (str testid-prefix "-step-" idx "-delta")
+               :style structured-cascade-delta-style}
+        [ei/edn-inspector data-delta
+         {:site-id                [:rf.xray.epoch/structured-cascade-delta testid-prefix idx]
+          :card?                  false
+          :default-expanded-depth 2}]])]))
+
+(defn- structured-cascade-microstep
+  "Render ONE `:always` microstep section (rf2-52u5n) — a header naming the
+  eventless step (`microstep N · <from> → <to>`) over its OWN nested
+  exit/action/entry steps, so the `:always` stream is explainable
+  alongside the headline transition rather than a bare count."
+  [testid-prefix {:keys [microstep-index from to steps]}]
+  [:div {:key         (str testid-prefix "-microstep-" microstep-index)
+         :data-testid (str testid-prefix "-microstep-" microstep-index)
+         :style       structured-cascade-microstep-style}
+   [:div {:style structured-cascade-microstep-header-style}
+    (str "microstep " microstep-index
+         (when (or (some? from) (some? to))
+           (str " · " (pr-str from) " → " (pr-str to))))]
+   (into [:div]
+         (map-indexed
+           (fn [i step]
+             (structured-cascade-step-row
+               (str testid-prefix "-microstep-" microstep-index) i step))
+           (filterv #(contains? #{:exit :action :entry} (:kind %)) steps)))])
+
+(defn- structured-cascade-body
+  "Render the STRUCTURED transition cascade (rf2-52u5n) for a `:transition`
+  cascade row — the ordered exit/action/entry steps + the `:always`
+  microstep sections, grouped PER REGION for parallel machines.
+
+  This is the headline rf2-52u5n surface: under the `{from}→{to}` verb +
+  the logical-state delta box, the operator reads the step-by-step
+  ENTRY/EXIT CASCADE — states exited (deepest-first) and entered
+  (shallowest-first + initial-descent), each with its action id + that
+  step's `:data` delta — and the `:always` microsteps sectioned per index.
+
+  Falls back to nil (the caller renders only the summary) when the row
+  carries no structured `:cascade` (older traces / non-machine fixtures)."
+  [{:keys [step cascade] :as _row}]
+  (when (seq cascade)
+    (let [regions    (proj/cascade-regions cascade)
+          microsteps (proj/cascade-microsteps cascade)
+          parallel?  (proj/parallel-cascade? cascade)
+          prefix     (str "rf-xray-epoch-machine-cascade-structured-" step)]
+      [:div {:data-testid prefix
+             :data-cascade-parallel (str (boolean parallel?))
+             :data-cascade-step-count (str (or (proj/cascade-step-count cascade) 0))
+             :style structured-cascade-root-style}
+       ;; Per-region (parallel) or single ungrouped (flat/compound) columns.
+       (for [{:keys [region steps]} regions
+             :let [region-prefix (str prefix "-region-"
+                                      (if region (name region) "_"))]]
+         ^{:key region-prefix}
+         [:div {:data-testid region-prefix
+                :data-cascade-region (when region (name region))
+                :style (if parallel?
+                         structured-cascade-region-style
+                         {:display "flex" :flex-direction "column"})}
+          ;; Region label only for genuine parallel machines (a flat/compound
+          ;; machine's single nil region needs no header — noise otherwise).
+          (when (and parallel? region)
+            [:div {:data-testid (str region-prefix "-label")
+                   :style structured-cascade-region-label-style}
+             (str "region " (name region))])
+          (map-indexed
+            (fn [i s] (structured-cascade-step-row region-prefix i s))
+            steps)])
+       ;; The `:always` microstep sections (sectioned per :microstep-index).
+       (when (seq microsteps)
+         (into [:div {:data-testid (str prefix "-microsteps")
+                      :style structured-cascade-microsteps-style}]
+               (map #(structured-cascade-microstep prefix %) microsteps)))])))
+
 (defn- cascade-row-source-body
   "Render the source code body for a cascade row (rf2-u69j7 baseline +
   rf2-wwc3j inline-fn extensions). Always visible per the bead body's
@@ -2614,8 +2816,20 @@
     ;; rf2-iwy0c part A — transition rows show the logical-state delta,
     ;; NOT the transition map literal. Self/internal transitions (no
     ;; logical change) elide the box entirely.
+    ;; rf2-52u5n — under the delta box, render the STRUCTURED entry/exit
+    ;; cascade (the ordered exit/action/entry steps + the `:always`
+    ;; microsteps, per-region for parallel machines) so EVENT HANDLER
+    ;; explains HOW the macrostep reached its after-state — not just
+    ;; `{from}→{to} + {n} microstep(s)`. Falls back to the delta box
+    ;; alone when the trace carried no structured `:cascade`.
     (= :transition (:kind row))
-    (cascade-row-transition-delta row)
+    (let [delta      (cascade-row-transition-delta row)
+          structured (structured-cascade-body row)]
+      (when (or delta structured)
+        [:div {:data-testid (str "rf-xray-epoch-machine-cascade-transition-body-"
+                                 (:step row))}
+         delta
+         structured]))
 
     (contains? #{:action :guard} (:kind row))
     (let [src-str (source-form->string source-form)]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
@@ -56,12 +56,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as string]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
+            [re-frame.test-helpers :as th]
             [day8.re-frame2-xray.diff.engine :as diff]
             [day8.re-frame2-xray.panels.epoch.format :as fmt]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.panels.epoch.view :as view]
             [day8.re-frame2-xray.panels.machine-inspector-helpers :as mih]
             [day8.re-frame2-xray.panels.machines.topology :as topo]
             [day8.re-frame2-xray.preload :as preload]
@@ -210,6 +213,13 @@
 (defn- rows-of-kind [rows kind]
   (filterv #(= kind (:kind %)) rows))
 
+;; rf2-52u5n — the STRUCTURED transition cascade now rides the LIVE
+;; `:rf.machine/transition` trace (rf2-n9f4z); the transition cascade row
+;; threads it through. These read it back off the projected row so the
+;; fidelity test pins what the EVENT HANDLER render shows.
+(defn- structured-cascade-of [record]
+  (-> (cascade record) (rows-of-kind :transition) first :cascade))
+
 ;; ============================================================================
 ;; CASE 2 — PARALLEL regions: one event, BOTH regions render
 ;; ============================================================================
@@ -271,6 +281,79 @@
       (is (= {:climate [:running :conditioning :heating] :fan :on}
              (:state (snapshot)))
           "the committed snapshot moved both regions in one macrostep"))))
+
+;; ============================================================================
+;; rf2-52u5n — the STRUCTURED entry/exit cascade renders legibly under
+;; EVENT HANDLER (the headline render this bead adds)
+;; ============================================================================
+
+(deftest power-cycle-renders-structured-cascade-not-just-summary
+  (testing "rf2-52u5n — the `[:hvac/power-cycle]` macrostep projects the
+            ORDERED structured cascade (exit/action/entry steps + per-region)
+            matching the engine's actual cascade — NOT just `{from}→{to} +
+            count`. This is the gap rf2-52u5n closes: pre-bead, the operator
+            saw one opaque row + '0 microsteps' with no sign of the 8-step
+            entry cascade. Pinned against the LIVE substrate (rf2-n9f4z emits
+            the `:cascade` tag; the projection threads it through)."
+    (setup!)
+    (let [record    (drive! [:hvac/power-cycle])
+          structured (structured-cascade-of record)
+          regions    (proj/cascade-regions structured)]
+      ;; The structured cascade is present + non-empty (RED before n9f4z +
+      ;; this bead: the transition row had only :before/:after/:microsteps).
+      (is (vector? structured) "the structured :cascade rides the transition row")
+      (is (seq structured) "the cascade is non-empty (not just a count)")
+      ;; It is a COMPLETE configuration walk — the action-free :idle / :off
+      ;; exits the per-EMIT stream cannot show (they declare no :exit action).
+      (is (proj/parallel-cascade? structured)
+          "the cascade carries both regions (parallel broadcast)")
+      (is (= [:climate :fan] (mapv :region regions))
+          "regions group in declaration order — climate before fan")
+      (let [climate (:steps (first regions))
+            fan     (:steps (second regions))]
+        (is (= [:exit :action :entry :entry :entry] (mapv :kind climate))
+            ":climate — action-free :idle exit → action @ LCA → 3-level descent")
+        (is (= [nil :enter-running :enter-running-level :enter-conditioning :enter-heating]
+               (mapv :action climate))
+            ":climate action-ids in cascade order (leading nil = action-free exit)")
+        (is (= [[:idle] [:idle] [:running] [:running :conditioning]
+                [:running :conditioning :heating]]
+               (mapv :state climate))
+            ":climate state paths render the deep-compound descent")
+        (is (= [:exit :action :entry] (mapv :kind fan))
+            ":fan — action-free :off exit → action → single entry")
+        (is (= [nil :fan-on :enter-fan-on] (mapv :action fan))
+            ":fan action-ids in cascade order"))
+      ;; The per-step :data delta is the minimal contribution (the trail key
+      ;; only) — proof the render shows what each step changed, not the whole
+      ;; :data map.
+      (let [enter-heating (->> (:steps (first regions))
+                               (filter #(= :enter-heating (:action %)))
+                               first)]
+        (is (contains? (:data-delta enter-heating) :trail)
+            "the entry step carries its :data delta (the trail key)"))
+      ;; And the VIEW renders it — the structured body + per-region groups.
+      ;; The transition body embeds edn-inspectors (the per-step :data delta),
+      ;; which subscribe against the surrounding frame — render under `:rf/xray`.
+      (frame/reg-frame :rf/xray {})
+      (let [rows   (cascade record)
+            tx-row (first (rows-of-kind rows :transition))
+            ;; the transition row's :step is renumbered over the full
+            ;; canonical cascade — the structured-body testids embed it.
+            sp     (str "rf-xray-epoch-machine-cascade-structured-" (:step tx-row))
+            tree   (rf/with-frame :rf/xray
+                     (view/render-handler-step
+                       {:step :handler :badge :HANDLER :step-number 3
+                        :flavour :reg-machine :event-id :hvac/controller
+                        :fx [] :machine {:cascade rows
+                                         :transition nil :guards []
+                                         :lifecycle [] :timers []}}))]
+        (is (some? (th/find-by-testid tree sp))
+            "the structured cascade body renders in the EVENT HANDLER view")
+        (is (some? (th/find-by-testid tree (str sp "-region-climate")))
+            ":climate region group renders")
+        (is (some? (th/find-by-testid tree (str sp "-region-fan")))
+            ":fan region group renders")))))
 
 ;; ============================================================================
 ;; CASE 1 + 3 — DEEP COMPOUND nesting + the multi-level LCA cascade ORDER

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1013,6 +1013,147 @@
       (is (= [:guard :transition :action] (mapv :kind c))
           "rf2-tjqd8 — canonical order: guard → TRANSITION → entry action"))))
 
+;; ---- rf2-52u5n — STRUCTURED transition cascade ------------------------
+;;
+;; The `:rf.machine/transition` trace carries a structured `:cascade` step
+;; vector (rf2-n9f4z) — the ordered exit/action/entry/microstep steps that
+;; explain HOW the macrostep reached its after-state. The projection threads
+;; it through the transition row + groups it per-region for the view.
+;;
+;; The HVAC `[:hvac/power-cycle]` cascade below is the contract shape the
+;; instrumentation test (`re-frame.machine-cascade-instrumentation-test`)
+;; pins: a parallel machine, climate region (deep compound, exits :idle →
+;; action @ LCA → 3-level entry descent) + fan region (exit :off → action →
+;; single entry).
+
+(def ^:private hvac-power-cycle-cascade
+  [{:kind :exit   :state [:idle]   :region :climate :action nil :data-delta {}}
+   {:kind :action :state [:idle]   :region :climate :action :enter-running       :data-delta {:trail [:action:power-on]}}
+   {:kind :entry  :state [:running] :region :climate :action :enter-running-level :data-delta {:trail [:action:power-on :entry:running]}}
+   {:kind :entry  :state [:running :conditioning] :region :climate :action :enter-conditioning :data-delta {:trail [:action:power-on :entry:running :entry:conditioning]}}
+   {:kind :entry  :state [:running :conditioning :heating] :region :climate :action :enter-heating :data-delta {:trail [:action:power-on :entry:running :entry:conditioning :entry:heating]}}
+   {:kind :exit   :state [:off]    :region :fan :action nil :data-delta {}}
+   {:kind :action :state [:off]    :region :fan :action :fan-on        :data-delta {:trail [:action:power-on :entry:running :entry:conditioning :entry:heating :action:fan-on]}}
+   {:kind :entry  :state [:on]     :region :fan :action :enter-fan-on  :data-delta {:trail [:action:power-on :entry:running :entry:conditioning :entry:heating :action:fan-on :entry:fan-on]}}])
+
+(def ^:private flat-go-cascade
+  [{:kind :exit   :state [:a] :region nil :action nil     :data-delta {}}
+   {:kind :action :state [:a] :region nil :action :go-act :data-delta {:went true}}
+   {:kind :entry  :state [:b] :region nil :action nil     :data-delta {}}])
+
+(def ^:private always-quiz-cascade
+  [{:kind :action :state [:asking] :region nil :action :count :data-delta {:correct 10}}
+   {:kind :microstep :region nil :microstep-index 0 :from :asking :to :winner
+    :steps [{:kind :exit   :state [:asking] :region nil :action nil  :data-delta {}}
+            {:kind :action :state [:asking] :region nil :action :win  :data-delta {:won true}}
+            {:kind :entry  :state [:winner] :region nil :action nil  :data-delta {}}]}])
+
+(deftest machine-transition-row-threads-structured-cascade-test
+  (testing "rf2-52u5n — `machine-transition-row` threads the structured
+            `:cascade` step vector off the `:rf.machine/transition` trace
+            so the view can render the step-by-step entry/exit cascade.
+            RED before this bead: the row had only `{:before :after
+            :microsteps :event}` — no `:cascade`."
+    (let [snap-before {:state {:climate :idle :fan :off} :data {}}
+          snap-after  {:state {:climate [:running :conditioning :heating] :fan :on} :data {}}
+          evs [(machine-transition-ev :hvac/controller snap-before snap-after
+                                       [:hvac/power-cycle] 0 hvac-power-cycle-cascade)
+               (machine-action-ev :enter-heating :entry :ok)]
+          r   (proj/handler-row evs :hvac/controller)
+          mt  (-> r :machine :transition)
+          tx  (first (filterv #(= :transition (:kind %)) (-> r :machine :cascade)))]
+      (is (= hvac-power-cycle-cascade (:cascade mt))
+          "the summary transition row carries the structured cascade")
+      (is (= hvac-power-cycle-cascade (:cascade tx))
+          "the transition CASCADE row threads the structured cascade for the view"))))
+
+(deftest cascade-regions-groups-parallel-per-region-test
+  (testing "rf2-52u5n — `cascade-regions` groups the LCA-cascade steps by
+            `:region`, preserving first-encounter (declaration) order, so
+            the view renders climate before fan. Microsteps are excluded."
+    (let [regions (proj/cascade-regions hvac-power-cycle-cascade)]
+      (is (= [:climate :fan] (mapv :region regions))
+          "regions in declaration order (climate first, then fan)")
+      (let [climate (:steps (first regions))
+            fan     (:steps (second regions))]
+        ;; climate: exit :idle (no action) → action @ LCA → 3-level entry
+        (is (= [:exit :action :entry :entry :entry] (mapv :kind climate))
+            "climate: action-free :idle exit → transition action → initial-descent")
+        (is (= [[:idle] [:idle] [:running] [:running :conditioning]
+                [:running :conditioning :heating]]
+               (mapv :state climate))
+            "climate state paths in cascade order (region-relative)")
+        (is (= [nil :enter-running :enter-running-level :enter-conditioning :enter-heating]
+               (mapv :action climate))
+            "climate action-ids (leading nil = action-free :idle exit)")
+        ;; fan: exit :off (no action) → action → single entry
+        (is (= [:exit :action :entry] (mapv :kind fan)))
+        (is (= [nil :fan-on :enter-fan-on] (mapv :action fan)))))))
+
+(deftest cascade-regions-flat-machine-single-nil-region-test
+  (testing "rf2-52u5n — a flat/compound machine's steps all carry `:region
+            nil`, so `cascade-regions` returns ONE group keyed nil (the view
+            renders one ungrouped column, no region label)."
+    (let [regions (proj/cascade-regions flat-go-cascade)]
+      (is (= 1 (count regions)))
+      (is (= [nil] (mapv :region regions)))
+      (is (= [:exit :action :entry] (mapv :kind (:steps (first regions))))
+          "minimal flat cascade: exit → action → entry")
+      (is (false? (proj/parallel-cascade? flat-go-cascade))
+          "a single-region cascade is not parallel"))))
+
+(deftest cascade-microsteps-extracts-and-orders-test
+  (testing "rf2-52u5n — `cascade-microsteps` extracts the `:always`
+            microstep steps, ordered by `:microstep-index`, each carrying
+            its nested `:steps`; structural steps are excluded."
+    (let [ms (proj/cascade-microsteps always-quiz-cascade)]
+      (is (= 1 (count ms)))
+      (is (= 0 (:microstep-index (first ms))))
+      (is (= :asking (:from (first ms))))
+      (is (= :winner (:to (first ms))))
+      (is (some #(= :win (:action %)) (:steps (first ms)))
+          "the eventless transition's :win action is explainable inside the microstep")
+      ;; the headline event-driven action stays out of the microstep stream.
+      (is (= [] (proj/cascade-microsteps flat-go-cascade))
+          "a non-:always cascade has no microsteps"))))
+
+(deftest parallel-cascade-and-step-count-test
+  (testing "rf2-52u5n — `parallel-cascade?` is true only for >1 region;
+            `cascade-step-count` totals structural steps incl. nested
+            microstep steps."
+    (is (true? (proj/parallel-cascade? hvac-power-cycle-cascade))
+        "two regions → parallel")
+    (is (= 8 (proj/cascade-step-count hvac-power-cycle-cascade))
+        "8 structural steps in the power-cycle cascade")
+    (is (= 4 (proj/cascade-step-count always-quiz-cascade))
+        "1 top-level action + 3 nested microstep steps")
+    (is (nil? (proj/cascade-step-count nil))
+        "nil cascade → nil count (view elides the chip)")
+    (is (nil? (proj/cascade-step-count []))
+        "empty cascade → nil count")))
+
+(deftest transition-row-without-cascade-falls-back-test
+  (testing "rf2-52u5n negative guard — a `:rf.machine/transition` trace with
+            NO structured `:cascade` (older trace / 5-arg fixture) leaves the
+            transition row's `:cascade` nil, so the view falls back to the
+            `{from}→{to}` summary. The cascade-grouping helpers degrade to
+            empty / nil."
+    (let [evs [(machine-transition-ev :ws/conn
+                                       {:state [:idle]   :data {}}
+                                       {:state [:active] :data {}}
+                                       [:ws/start] 1) ;; 5-arg: NO :cascade
+               (machine-action-ev :open-socket :entry :ok)]
+          r   (proj/handler-row evs :ws/start)
+          mt  (-> r :machine :transition)
+          tx  (first (filterv #(= :transition (:kind %)) (-> r :machine :cascade)))]
+      (is (nil? (:cascade mt))
+          "no structured cascade on the summary row → fall back to summary")
+      (is (nil? (:cascade tx))
+          "no structured cascade on the transition cascade row")
+      (is (= [] (proj/cascade-regions nil)))
+      (is (= [] (proj/cascade-microsteps nil)))
+      (is (false? (proj/parallel-cascade? nil))))))
+
 (deftest cascade-row-label-test
   (testing "rf2-u69j7 — `cascade-row-label` renders a human verb per kind"
     (is (= "guard :ready?"

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -3188,6 +3188,147 @@
       (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-source"))
           "the event handler's source block is unaffected"))))
 
+;; ---- rf2-52u5n — STRUCTURED transition cascade renders under EVENT HANDLER
+
+(def ^:private view-hvac-power-cycle-cascade
+  [{:kind :exit   :state [:idle]   :region :climate :action nil :data-delta {}}
+   {:kind :action :state [:idle]   :region :climate :action :enter-running       :data-delta {:trail [:action:power-on]}}
+   {:kind :entry  :state [:running] :region :climate :action :enter-running-level :data-delta {:trail [:action:power-on :entry:running]}}
+   {:kind :entry  :state [:running :conditioning] :region :climate :action :enter-conditioning :data-delta {:trail [:action:power-on :entry:running :entry:conditioning]}}
+   {:kind :entry  :state [:running :conditioning :heating] :region :climate :action :enter-heating :data-delta {:trail [:action:power-on :entry:running :entry:conditioning :entry:heating]}}
+   {:kind :exit   :state [:off]    :region :fan :action nil :data-delta {}}
+   {:kind :action :state [:off]    :region :fan :action :fan-on        :data-delta {:trail [:action:power-on :entry:running :entry:conditioning :entry:heating :action:fan-on]}}
+   {:kind :entry  :state [:on]     :region :fan :action :enter-fan-on  :data-delta {:trail [:action:power-on :entry:running :entry:conditioning :entry:heating :action:fan-on :entry:fan-on]}}])
+
+(defn- machine-step-with-cascade
+  "Build a HANDLER step whose machine cascade carries ONE transition row
+  bearing the structured `:cascade` (the rf2-52u5n render surface)."
+  [event-id structured-cascade]
+  {:step :handler :badge :HANDLER :step-number 3
+   :flavour :reg-machine :event-id event-id
+   :fx []
+   :machine {:cascade [{:kind :transition :step 1 :machine-id event-id
+                        :from-state {:climate :idle :fan :off}
+                        :to-state   {:climate [:running :conditioning :heating] :fan :on}
+                        :before {:state {:climate :idle :fan :off}}
+                        :after  {:state {:climate [:running :conditioning :heating] :fan :on}}
+                        :microsteps 0
+                        :cascade structured-cascade}]
+             :transition nil :guards [] :lifecycle [] :timers []}})
+
+(deftest structured-cascade-renders-ordered-per-region-test
+  (testing "rf2-52u5n — the HVAC `[:hvac/power-cycle]` deep-compound+parallel
+            transition renders the STRUCTURED entry/exit cascade under EVENT
+            HANDLER (not just `{from}→{to} + count`): per-region grouped, each
+            step naming its kind / state-path / action-id / data delta."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-cascade :hvac/controller view-hvac-power-cycle-cascade))
+          root (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1")]
+      (is (some? root)
+          "the structured cascade body renders under the transition row")
+      (is (= "true" (-> root th/attrs :data-cascade-parallel))
+          "the parallel flag is set (climate + fan regions)")
+      ;; Per-region grouping — both regions render, climate before fan.
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-region-climate"))
+          "the :climate region group renders")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-region-fan"))
+          "the :fan region group renders")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-region-climate-label"))
+          "a parallel machine labels each region")
+      ;; The ordered steps render — climate exit :idle → action → 3 entries.
+      (let [climate-step0 (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-region-climate-step-0")
+            climate-step0-kind (-> climate-step0 th/attrs :data-cascade-step-kind)]
+        (is (= "exit" climate-step0-kind)
+            "the first climate step is the (action-free) :idle exit"))
+      ;; The deep entry action surfaces with its action-id.
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-machine-cascade-structured-1-region-climate-step-4") "")
+            ":enter-heating")
+          "the deepest entry step names :enter-heating")
+      ;; The fan region's entry action surfaces — proof the broadcast hit both.
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-machine-cascade-structured-1-region-fan-step-2") "")
+            ":enter-fan-on")
+          "the fan region's entry action renders — one event, both regions")
+      ;; Action-free boundaries are explicit (the complete walk).
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-machine-cascade-structured-1-region-climate-step-0") "")
+            "(no action)")
+          "the action-free :idle exit renders an explicit '(no action)' marker")
+      ;; The step-count attribute totals the 8 structural steps.
+      (is (= "8" (-> root th/attrs :data-cascade-step-count))
+          "the cascade step-count totals all 8 structural steps"))))
+
+(deftest structured-cascade-flat-transition-renders-minimal-test
+  (testing "rf2-52u5n — a flat single-step transition renders its minimal
+            cascade (exit → action → entry) ungrouped, with NO region label
+            (the single nil region needs no header)."
+    (let [flat [{:kind :exit   :state [:a] :region nil :action nil     :data-delta {}}
+                {:kind :action :state [:a] :region nil :action :go-act :data-delta {:went true}}
+                {:kind :entry  :state [:b] :region nil :action nil     :data-delta {}}]
+          tree (view/render-handler-step (machine-step-with-cascade :casc/flat flat))
+          root (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1")]
+      (is (some? root) "the structured cascade renders for a flat transition")
+      (is (= "false" (-> root th/attrs :data-cascade-parallel))
+          "a single-region cascade is not parallel")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-region-_-label"))
+          "no region label for the single nil region (would be noise)")
+      (is (= "exit"   (-> (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-region-_-step-0") th/attrs :data-cascade-step-kind)))
+      (is (= "action" (-> (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-region-_-step-1") th/attrs :data-cascade-step-kind)))
+      (is (= "entry"  (-> (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-region-_-step-2") th/attrs :data-cascade-step-kind)))
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-machine-cascade-structured-1-region-_-step-1") "")
+            ":go-act")
+          "the transition action names :go-act"))))
+
+(deftest structured-cascade-always-microsteps-render-test
+  (testing "rf2-52u5n — an `:always`-bearing transition renders its microsteps
+            sectioned per `:microstep-index`, each with its nested steps, so
+            the eventless stream is explainable (not just counted)."
+    (let [always [{:kind :action :state [:asking] :region nil :action :count :data-delta {:correct 10}}
+                  {:kind :microstep :region nil :microstep-index 0 :from :asking :to :winner
+                   :steps [{:kind :exit   :state [:asking] :region nil :action nil :data-delta {}}
+                           {:kind :action :state [:asking] :region nil :action :win :data-delta {:won true}}
+                           {:kind :entry  :state [:winner] :region nil :action nil :data-delta {}}]}]
+          tree (view/render-handler-step (machine-step-with-cascade :casc/quiz always))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-microsteps"))
+          "the microsteps section renders")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1-microstep-0"))
+          "the microstep is sectioned per its index")
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-machine-cascade-structured-1-microstep-0") "")
+            ":win")
+          "the eventless transition's :win action is explainable inside the microstep")
+      ;; The headline event-driven :count action renders in the top column.
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-machine-cascade-structured-1-region-_-step-0") "")
+            ":count")
+          "the headline event-driven action renders above the microstep"))))
+
+(deftest structured-cascade-absent-falls-back-to-summary-test
+  (testing "rf2-52u5n negative guard — a transition row with NO structured
+            `:cascade` (older trace / non-structured fixture) renders NO
+            structured cascade body; the `{from}→{to}` summary + logical-state
+            delta box remain (graceful fallback)."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :ws/conn
+                :fx []
+                :machine {:cascade [{:kind :transition :step 1 :machine-id :ws/conn
+                                     :from-state [:idle] :to-state [:active]
+                                     :before {:state [:idle]} :after {:state [:active]}
+                                     :microsteps 1}] ;; NO :cascade slot
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-1"))
+          "no structured cascade body when the trace carried no :cascade")
+      ;; The transition row itself + its `{from}→{to}` verb still render.
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+          "the transition row still renders (the summary path)")
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-machine-cascade-verb-link-1") "")
+            "→")
+          "the `{from}→{to}` summary verb remains the header"))))
+
 ;; ---- Part 3 — a threw ACTION row shows exactly ONE threw signal -----------
 
 (deftest threw-action-row-shows-single-threw-signal-test

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -306,7 +306,14 @@
   "`:rf.machine/transition` trace — drives the HANDLER step's
   machine TRANSITION sub-section + the DATA-REDUCTION /
   SNAPSHOT-DIFF projections (rf2-u69j7). `before` + `after` are full
-  machine snapshot maps (`:state` + `:data` + …)."
+  machine snapshot maps (`:state` + `:data` + …).
+
+  rf2-52u5n / rf2-n9f4z — the 6-arg form stamps the STRUCTURED
+  `:cascade` step vector (the ordered exit/action/entry/microstep
+  steps the substrate emits per rf2-n9f4z) so the EVENT HANDLER
+  machine-cascade render can be driven from a synth fixture. The
+  5-arg form OMITS `:cascade` (the negative-guard / older-trace
+  shape the view falls back to the summary on)."
   ([machine-id before after]
    (machine-transition-ev machine-id before after nil 0))
   ([machine-id before after event microsteps]
@@ -315,7 +322,15 @@
                 :before     before
                 :after      after}
          event      (assoc :event event)
-         microsteps (assoc :microsteps microsteps)))))
+         microsteps (assoc :microsteps microsteps))))
+  ([machine-id before after event microsteps cascade]
+   (ev :rf.machine :rf.machine/transition
+       (cond-> {:machine-id machine-id
+                :before     before
+                :after      after}
+         event       (assoc :event event)
+         microsteps  (assoc :microsteps microsteps)
+         (some? cascade) (assoc :cascade cascade)))))
 
 (defn machine-guard-ev
   "`:rf.machine/guard-evaluated` trace — drives the HANDLER step's


### PR DESCRIPTION
## What

Under EVENT HANDLER, a deep compound/parallel machine transition rendered only `{from}→{to}` + `"{n} microstep(s)"` — with no sign of the entry/exit cascade that actually produced it (live finding, machine-epochs :8033). rf2-n9f4z (#2852, now on main) emits a structured `:cascade` on the `:rf.machine/transition` trace; this bead renders it under EVENT HANDLER.

## How

**`:cascade` threading (projection.cljc).** `machine-transition-row` + `transition-cascade-row` now thread the structured `:cascade` step vector (off the `:rf.machine/transition` trace's `:cascade` tag) onto the row model. New pure helpers group it for the view:
- `cascade-regions` — groups the LCA-cascade steps (`:exit`/`:action`/`:entry`) by `:region`, preserving first-encounter (declaration) order; a flat/compound machine yields one `nil`-region group, a parallel machine one group per region (climate before fan). Microsteps excluded.
- `cascade-microsteps` — extracts the `:always` `:microstep` steps, ordered by `:microstep-index`, each retaining its nested `:steps`.
- `cascade-step-count` / `parallel-cascade?` — section-header chip + per-region toggle.

**Render layout (view.cljs).** Under the `{from}→{to}` headline verb + the existing logical-state delta box, `structured-cascade-body` renders:
- the ordered **ENTRY/EXIT CASCADE** — one row per step: `<kind glyph ↑/•/↓> <state-path> <action-id | (no action)> <inline :data Δ>`. The explicit `(no action)` marks the action-free boundaries (e.g. exiting `:idle`/`:off`) that the per-emit `:rf.machine/action-ran` stream cannot show — the structured cascade is the **complete configuration walk**;
- **per-`:region` grouping** for parallel machines (each headed `region <name>`, declaration order); a single ungrouped column (no label) for flat/compound;
- the **`:always` microsteps** sectioned per `:microstep-index` (`microstep N · <from> → <to>` over its nested steps).

**Fallback for cascade-less traces.** A `:rf.machine/transition` with no structured `:cascade` (older traces / non-structured fixtures) renders no structured body — the `{from}→{to}` summary + logical-state delta box remain. The grouping helpers degrade to `[]`/`nil` on a nil cascade.

## Tests (CLJS-unit, per Causa/Story = CLJS-unit posture)

- **projection_cljs_test** — `:cascade` threads onto both transition rows; `cascade-regions` groups the HVAC `[:hvac/power-cycle]` cascade per-region in declaration order; flat machine → single nil-region group; `cascade-microsteps` extracts + orders the `:always` stream; `parallel-cascade?`/`cascade-step-count`; **negative guard** — no `:cascade` → row `:cascade` nil + helpers degrade.
- **view_cljs_test** — HVAC power-cycle renders ordered per-region steps (climate exit→action→3 entries, fan exit→action→entry) with action-ids + explicit `(no action)`; flat transition renders minimal ungrouped cascade; `:always`-bearing transition renders sectioned microsteps; **fallback** — cascade-less transition renders no structured body, summary verb remains.
- **hard_machine_fidelity_cljs_test (k08ay extension)** — drives the LIVE substrate; asserts the HVAC `[:hvac/power-cycle]` projects the ordered structured cascade (exit/action/entry + per-region, action-free exits included) matching the engine's actual cascade — and that the EVENT HANDLER view renders it (both region groups).

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` | PASS — 5349 tests, 18373 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` (machine-epochs deck incl. HVAC) | PASS — 16 scenarios, 0 failures, 13 matrix rows |
| xray JVM (`clojure -M:test`, incl. epoch) | PASS — 1068 tests, 4340 assertions, 0 failures, 0 errors |
| clj-kondo (changed sources) | PASS — errors: 0 (no new warnings; the 2 remaining are pre-existing docstring-referenced unused-vars) |

## Spec currency

- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — documents the structured entry/exit cascade render (per-step shape, per-region grouping, microstep sectioning, fallback) under the Transition row.
- `tools/xray/spec/003-Machine-Inspector.md` — cross-reference note clarifying the EVENT HANDLER machine cascade is the Epoch panel's surface (021), distinct from the Machines-tab topology chart.

Closes rf2-52u5n.