### PR TITLE
fix(skills): deploy skills by symlink/junction not stale copy — cross-platform installer (rf2-901lr)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,36 @@ The full test matrix and per-artefact entry-points are documented in
 [`TESTING.md`](TESTING.md). The fast pre-PR gate is `scripts/test-fast-pr.sh`
 from the repo root.
 
+### Skills — link, don't copy
+
+The agent-shaped skills under [`skills/`](skills/) (the `re-frame2-pair`
+pair-programming skill, `re-frame2-setup`, the migration/improver/implementor
+skills, …) are loaded by Claude Code from `~/.claude/skills/<name>/`. **Deploy
+them by link, not by copy.** A one-shot `cp -r` snapshots the skill and then
+silently drifts as the repo is maintained — Claude Code keeps loading a stale
+copy. Link the repo directory in instead, so the active skill *is* the repo
+source by construction and your edits take effect immediately.
+
+A cross-platform installer links **every** `skills/<name>/` directory into
+`~/.claude/skills/`:
+
+```bash
+# macOS / Linux (POSIX symlinks):
+scripts/install-skills.sh
+
+# Windows (PowerShell — directory junctions, no admin needed):
+powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1
+# (Git Bash users can run the .sh; it auto-selects the junction primitive.)
+```
+
+The installer is idempotent (re-run any time to re-link), prints what it
+linked, and **refuses to clobber a non-link directory** — if a target is a
+real copy with local edits, it warns and skips it; pass `--force` (`-Force` on
+PowerShell) to replace the copy with a link. `--check` (`-Check`) reports
+whether everything is linked without changing anything. Run it once after
+cloning, and re-run `--force` once to retire any stale copy a previous
+copy-install left behind.
+
 ## Pull request flow
 
 - Branch from `main`.

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -8,7 +8,14 @@ re-frame2 ships eight skills, colocated under [`skills/`](https://github.com/day
 
 ## How to load a skill
 
-The exact mechanics depend on the agent you're driving. In **Claude Code**, install a skill by copying its directory into a project-level `.claude/skills/<name>/` (or globally into `~/.claude/skills/<name>/`). Once installed, the skill's `description` triggers it whenever the conversation mentions one of its surfaces — you usually don't need to invoke it explicitly. You can also force-load it with `/skill <name>` if the agent's launcher supports slash-commands for skills.
+The exact mechanics depend on the agent you're driving. In **Claude Code**, a skill lives at a project-level `.claude/skills/<name>/` or globally at `~/.claude/skills/<name>/`. **Link the repo directory in rather than copying it** — a copy snapshots the skill and then silently drifts as the repo is maintained, so Claude Code ends up loading a stale skill. From a re-frame2 clone, the cross-platform installer links every skill into `~/.claude/skills/` in one step (symlinks on macOS/Linux, directory junctions on Windows — no admin needed):
+
+```bash
+scripts/install-skills.sh                                              # macOS / Linux
+powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1    # Windows
+```
+
+It is idempotent and refuses to clobber a non-link copy without `--force`/`-Force`. See [`CONTRIBUTING.md`](https://github.com/day8/re-frame2/blob/main/CONTRIBUTING.md#skills--link-dont-copy) for the full setup. Once installed, the skill's `description` triggers it whenever the conversation mentions one of its surfaces — you usually don't need to invoke it explicitly. You can also force-load it with `/skill <name>` if the agent's launcher supports slash-commands for skills.
 
 The repo's [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) is the deep-dive index for the **spec-consuming** skills — they point at it for spec-corpus depth and EP rationale. (Two skills route their deep-dives elsewhere by design: `re-frame2-xray` cites its own `tools/xray/spec/*` tree, and `re-frame2-improver` routes to `skills/re-frame2/patterns/` + `spec/`.)
 

--- a/scripts/install-skills.ps1
+++ b/scripts/install-skills.ps1
@@ -1,0 +1,164 @@
+#requires -Version 5
+# scripts/install-skills.ps1 - Windows-friendly mirror of
+# scripts/install-skills.sh.
+#
+# ASCII-only by design: Windows PowerShell 5.x reads -File scripts as the
+# system ANSI codepage, so a BOM-less UTF-8 multibyte char (e.g. an em-dash)
+# in a code position breaks tokenization. Keep this file pure ASCII.
+#
+# Deploys every skills/<name>/ directory into ~/.claude/skills/<name> BY LINK,
+# not by copy, so the active skill Claude Code loads is the SAME directory as
+# the repo source - edits in either are reflected in the other. This kills the
+# stale-copy drift (rf2-901lr): a one-shot copy froze ~10 days behind the repo
+# and Claude Code loaded the stale skill.
+#
+# Link primitive: a directory JUNCTION via `New-Item -ItemType Junction`. A
+# junction needs NO admin / Developer Mode (a Windows *symlink* does); Claude
+# Code reads through it like a symlink. This is the right primitive for a dir
+# on Windows.
+#
+# Idempotent: re-running re-links. A target already pointing at this repo's
+# skill dir is left alone. A junction pointing elsewhere is re-pointed. A real
+# (non-link) directory is a stale COPY: the installer WARNS and refuses to
+# clobber it unless -Force is given, so local edits to a copy are not lost.
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1
+#   powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1 -Force
+#   powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1 -Check
+#   powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1 -Target DIR
+
+[CmdletBinding()]
+param(
+    [switch]$Check,
+    [switch]$Force,
+    [string]$Target
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot   = (Resolve-Path (Join-Path $scriptDir '..')).Path
+$skillsSrc  = Join-Path $repoRoot 'skills'
+
+# Derive the install target WITHOUT hardcoding a home or username.
+if (-not $Target) {
+    $homeDir = $env:USERPROFILE
+    if (-not $homeDir) { $homeDir = $HOME }
+    if (-not $homeDir) {
+        Write-Error 'install-skills: neither $env:USERPROFILE nor $HOME is set; pass -Target DIR'
+    }
+    $Target = Join-Path (Join-Path $homeDir '.claude') 'skills'
+}
+
+if (-not (Test-Path -LiteralPath $skillsSrc)) {
+    Write-Error "install-skills: no skills directory at $skillsSrc"
+}
+
+# Resolve a directory to its real (target) path so a junction compares equal to
+# its source. ReparsePoint dirs expose .Target (the junction destination).
+function Resolve-RealDir {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return $Path }
+    $item = Get-Item -LiteralPath $Path -Force
+    if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+        $t = $item.Target
+        if ($t) {
+            # .Target may be an array on some PS versions; take the first.
+            if ($t -is [array]) { $t = $t[0] }
+            return ([System.IO.Path]::GetFullPath($t)).TrimEnd('\')
+        }
+    }
+    return ($item.FullName).TrimEnd('\')
+}
+
+# Is $Path a reparse point (junction/symlink)?
+function Test-IsLink {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return $false }
+    $item = Get-Item -LiteralPath $Path -Force
+    return [bool]($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)
+}
+
+$mode    = if ($Check) { 'check' } else { 'install' }
+$linked  = 0
+$skipped = 0
+$rc      = 0
+
+if (-not (Test-Path -LiteralPath $Target)) {
+    if ($mode -eq 'install') {
+        New-Item -ItemType Directory -Force -Path $Target | Out-Null
+    }
+}
+
+# Link whatever skills/<name> dirs exist (audit ALL of skills/, per the bead -
+# including shared/, which carries the retro-protocol doc + tests).
+$entries = Get-ChildItem -LiteralPath $skillsSrc -Directory
+foreach ($entry in $entries) {
+    $name = $entry.Name
+    $src  = ([System.IO.Path]::GetFullPath($entry.FullName)).TrimEnd('\')
+    $dst  = Join-Path $Target $name
+
+    $existsAsLinkToUs = $false
+    if (Test-Path -LiteralPath $dst) {
+        if ((Test-IsLink $dst) -and ((Resolve-RealDir $dst) -eq $src)) {
+            $existsAsLinkToUs = $true
+        }
+    }
+
+    if ($existsAsLinkToUs) {
+        if ($mode -eq 'install') {
+            Write-Output "install-skills: $name already linked -> $src"
+        }
+        continue
+    }
+
+    if ($mode -eq 'check') {
+        if (Test-Path -LiteralPath $dst) {
+            Write-Error "install-skills: $name present but not linked to this repo ($dst)" -ErrorAction Continue
+        } else {
+            Write-Error "install-skills: $name not installed ($dst)" -ErrorAction Continue
+        }
+        $rc = 1
+        continue
+    }
+
+    # install mode
+    if ((Test-Path -LiteralPath $dst) -and -not (Test-IsLink $dst)) {
+        # A real directory == a stale COPY. Do not clobber without -Force.
+        if (-not $Force) {
+            Write-Warning "install-skills: $dst is a real directory (a COPY), not a link."
+            Write-Warning "                Refusing to replace it - your local edits would be lost."
+            Write-Warning "                Re-run with -Force to replace this copy with a link to the repo:"
+            Write-Warning "                  powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1 -Force"
+            $skipped++
+            continue
+        }
+        Remove-Item -LiteralPath $dst -Recurse -Force
+    }
+    elseif (Test-Path -LiteralPath $dst) {
+        # A reparse point pointing elsewhere (or broken) - safe to re-point.
+        # Remove the junction itself (Remove-Item on a junction does not touch
+        # the target's contents).
+        Remove-Item -LiteralPath $dst -Recurse -Force
+    }
+
+    New-Item -ItemType Junction -Path $dst -Target $src | Out-Null
+    Write-Output "install-skills: linked $name -> $src"
+    $linked++
+}
+
+if ($mode -eq 'check') {
+    if ($rc -ne 0) {
+        Write-Output "`nRun scripts/install-skills.ps1 (without -Check) to (re)link."
+    } else {
+        Write-Output 'install-skills: all skills linked and current.'
+    }
+    exit $rc
+}
+
+Write-Output ""
+Write-Output "install-skills: linked $linked, skipped $skipped (copies left intact; use -Force to replace)."
+Write-Output "install-skills: target $Target now mirrors $skillsSrc by link."
+if ($skipped -gt 0) { exit 1 }
+exit 0

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env sh
+# scripts/install-skills.sh — link this repo's skills into ~/.claude/skills.
+#
+# Deploys every `skills/<name>/` directory into `~/.claude/skills/<name>` BY
+# LINK, not by copy, so the active skill Claude Code loads is the SAME FILE as
+# the repo source — edits in either are immediately reflected in the other.
+# This eliminates the stale-copy drift (rf2-901lr) that comes from a one-shot
+# `cp -r`: a copy froze ~10 days behind the maintained repo and Claude Code
+# loaded the stale skill.
+#
+# Link primitive per OS:
+#   - macOS / Linux:        `ln -s` (POSIX symlink to the repo skill dir).
+#   - Windows (Git Bash):   directory JUNCTION via PowerShell's
+#                           `New-Item -ItemType Junction`. A junction needs NO
+#                           admin / Developer Mode (unlike a Windows symlink),
+#                           and Claude Code reads through it like a symlink.
+#
+# Idempotent: re-running re-links. If a target already points at this repo's
+# skill dir, it is left alone. If a target is a link to a DIFFERENT source, it
+# is re-pointed. If a target is a real directory (a stale COPY — the very bug
+# this fixes), the installer WARNS and refuses to clobber it unless --force is
+# given, so a user's local edits to a copied skill are never silently lost.
+#
+# Usage:
+#   scripts/install-skills.sh                 # link all skills (skip+warn on copies)
+#   scripts/install-skills.sh --force         # replace stale COPY dirs with links too
+#   scripts/install-skills.sh --check         # exit 0 if all linked & current, 1 otherwise
+#   scripts/install-skills.sh --target DIR    # link into DIR instead of ~/.claude/skills
+#                                             # (used by the test harness; never needs admin)
+#
+# Cross-platform: POSIX sh. Runs under Git Bash on Windows, macOS, Linux.
+# No bashisms ([[ ]], arrays, <<<). Windows operators who prefer pure
+# PowerShell can use the sibling scripts/install-skills.ps1 (identical behaviour).
+
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+SKILLS_SRC="$REPO_ROOT/skills"
+
+# Derive the install target WITHOUT hardcoding a home or username. $HOME is
+# set on macOS/Linux and under Git Bash on Windows; fall back to $USERPROFILE
+# for the rare shell that exports only the Windows variable.
+HOME_DIR="${HOME:-${USERPROFILE:-}}"
+
+MODE="install"
+FORCE=0
+TARGET_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check)  MODE="check" ;;
+    --force)  FORCE=1 ;;
+    --target)
+      shift
+      [ $# -gt 0 ] || { printf 'install-skills: --target needs a directory argument\n' >&2; exit 2; }
+      TARGET_DIR="$1"
+      ;;
+    *)
+      printf 'install-skills: unknown argument: %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$TARGET_DIR" ]; then
+  if [ -z "$HOME_DIR" ]; then
+    printf 'install-skills: neither $HOME nor $USERPROFILE is set; pass --target DIR\n' >&2
+    exit 2
+  fi
+  TARGET_DIR="$HOME_DIR/.claude/skills"
+fi
+
+if [ ! -d "$SKILLS_SRC" ]; then
+  printf 'install-skills: no skills directory at %s\n' "$SKILLS_SRC" >&2
+  exit 1
+fi
+
+# Detect Windows (Git Bash / MSYS / Cygwin) so we pick junction over symlink.
+is_windows() {
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Resolve a path to its real location for comparison. `cd && pwd -P` is the
+# most portable way (no readlink -f on macOS by default). Echoes the resolved
+# path, or the input unchanged if it does not resolve to a directory.
+resolve_dir() {
+  if [ -d "$1" ]; then
+    (cd "$1" 2>/dev/null && pwd -P) || printf '%s' "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
+
+# Create the link `dst` -> `src` using the right primitive for the OS.
+make_link() {
+  src="$1"
+  dst="$2"
+  if is_windows; then
+    # Junction: no admin needed. PowerShell is present on every supported
+    # Windows. Pass native (back-slashed) paths via `cygpath -w` so the
+    # Windows API accepts them.
+    win_src=$(cygpath -w "$src" 2>/dev/null || printf '%s' "$src")
+    win_dst=$(cygpath -w "$dst" 2>/dev/null || printf '%s' "$dst")
+    powershell.exe -NoProfile -NonInteractive -Command \
+      "New-Item -ItemType Junction -Path '$win_dst' -Target '$win_src' | Out-Null" \
+      >/dev/null
+  else
+    ln -s "$src" "$dst"
+  fi
+}
+
+# Is `path` a link that already points at `want_src`?
+points_at() {
+  path="$1"
+  want_src="$2"
+  # A POSIX symlink: compare readlink target (resolved) to the wanted source.
+  if [ -L "$path" ]; then
+    [ "$(resolve_dir "$path")" = "$(resolve_dir "$want_src")" ]
+    return
+  fi
+  # A Windows junction is NOT seen as a symlink by `test -L` under Git Bash,
+  # but it IS a directory that resolves (via `pwd -P`) to its target. If the
+  # resolved real path equals the source's real path, it is our link.
+  if is_windows && [ -d "$path" ]; then
+    [ "$(resolve_dir "$path")" = "$(resolve_dir "$want_src")" ]
+    return
+  fi
+  return 1
+}
+
+# Is `path` a real (non-link) directory — i.e. a stale COPY we must not clobber
+# without --force?
+#   POSIX: a dir that is not a symlink.
+#   Windows: a dir that is neither a symlink NOR a reparse point (junction). A
+#     junction pointing ELSEWHERE (not at us — that case is caught by
+#     `points_at` first) is still a link, not a copy, so it is safe to
+#     re-point without --force. We detect a reparse point as a directory whose
+#     real path (resolved through `pwd -P`) differs from its own literal path.
+is_real_copy() {
+  path="$1"
+  [ -d "$path" ] || return 1
+  if [ -L "$path" ]; then
+    return 1   # a symlink, not a real copy
+  fi
+  if is_windows; then
+    literal=$(cd "$(dirname "$path")" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$(basename "$path")")
+    real=$(resolve_dir "$path")
+    if [ "$real" != "$literal" ]; then
+      return 1   # a junction (redirects elsewhere) — a link, not a copy
+    fi
+  fi
+  return 0
+}
+
+mkdir -p "$TARGET_DIR"
+
+rc=0
+linked=0
+skipped=0
+
+# Iterate every skills/<name> directory. `shared/` is included: it carries the
+# retro-protocol security doc + tests that re-frame2-pair-retro loads, so it
+# must be linked too. The README index lists eight USER-facing skills; we link
+# whatever dirs exist (audit ALL of skills/, per the bead).
+for entry in "$SKILLS_SRC"/*/; do
+  [ -d "$entry" ] || continue
+  name=$(basename "$entry")
+  src=$(resolve_dir "$entry")
+  dst="$TARGET_DIR/$name"
+
+  if points_at "$dst" "$src"; then
+    [ "$MODE" = "install" ] && printf 'install-skills: %s already linked -> %s\n' "$name" "$src"
+    continue
+  fi
+
+  if [ "$MODE" = "check" ]; then
+    if [ -e "$dst" ]; then
+      printf 'install-skills: %s present but not linked to this repo (%s)\n' "$name" "$dst" >&2
+    else
+      printf 'install-skills: %s not installed (%s)\n' "$name" "$dst" >&2
+    fi
+    rc=1
+    continue
+  fi
+
+  # install mode
+  if is_real_copy "$dst"; then
+    if [ "$FORCE" -eq 0 ]; then
+      printf 'install-skills: WARNING %s is a real directory (a COPY), not a link.\n' "$dst" >&2
+      printf '                Refusing to replace it — your local edits would be lost.\n' >&2
+      printf '                Re-run with --force to replace this copy with a link to the repo:\n' >&2
+      printf '                  scripts/install-skills.sh --force\n' >&2
+      skipped=$((skipped + 1))
+      continue
+    fi
+    rm -rf "$dst"
+  elif [ -e "$dst" ] || [ -L "$dst" ]; then
+    # A link (broken, or pointing elsewhere) — safe to drop and re-point.
+    rm -rf "$dst"
+  fi
+
+  make_link "$src" "$dst"
+  printf 'install-skills: linked %s -> %s\n' "$name" "$src"
+  linked=$((linked + 1))
+done
+
+if [ "$MODE" = "check" ]; then
+  if [ "$rc" -ne 0 ]; then
+    printf '\nRun scripts/install-skills.sh to (re)link.\n' >&2
+  else
+    printf 'install-skills: all skills linked and current.\n'
+  fi
+  exit "$rc"
+fi
+
+printf '\ninstall-skills: linked %s, skipped %s (copies left intact; use --force to replace).\n' \
+  "$linked" "$skipped"
+printf 'install-skills: target %s now mirrors %s by link.\n' "$TARGET_DIR" "$SKILLS_SRC"
+[ "$skipped" -gt 0 ] && exit 1
+exit 0

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,6 +9,24 @@ during the `v0.0.1.alpha` prep — keeping the skill source colocated with the
 re-frame2 surfaces it consumes, so the spec, implementation, and tooling
 travel together.
 
+## Installing (link, never copy)
+
+Claude Code loads skills from `~/.claude/skills/<name>/`. **Link the repo
+directory in; never `cp -r` it.** A copy snapshots the skill and then drifts
+as the repo is maintained — Claude Code keeps loading the stale copy. The
+cross-platform installer links *every* skill below into `~/.claude/skills/`
+so the active skill is the repo source by construction:
+
+```bash
+scripts/install-skills.sh                                              # macOS / Linux (symlinks)
+powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1    # Windows (junctions, no admin)
+```
+
+It is idempotent, refuses to clobber a non-link copy without `--force`
+(`-Force`), and supports `--check` (`-Check`) to verify the links. See
+[`CONTRIBUTING.md`](../CONTRIBUTING.md#skills--link-dont-copy) for the full
+contributor setup.
+
 The docs-site landing page mirrors this index at
 [`docs/skills/index.md`](../docs/skills/index.md) — same eight skills, same
 picking-the-right-one decision flow, hosted on the mkdocs site.

--- a/skills/re-frame2-pair/docs/LOCAL_DEV.md
+++ b/skills/re-frame2-pair/docs/LOCAL_DEV.md
@@ -16,7 +16,29 @@ Same as the README's *Requirements*:
 - [Claude Code](https://docs.claude.com/en/docs/claude-code).
 - A re-frame2 + shadow-cljs app to exercise it against. (Optional: re-com — used as a fallback source-coord source, not required.)
 
-## 1. Symlink (recommended for dev)
+## 0. Repo installer (recommended — links all skills)
+
+From a re-frame2 clone, the cross-platform installer links **every** skill
+(including this one) into `~/.claude/skills/` by symlink (macOS/Linux) or
+directory junction (Windows, no admin needed). Edits in the repo are live
+immediately; nothing to keep in sync.
+
+```bash
+# macOS / Linux:
+scripts/install-skills.sh
+
+# Windows:
+powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1
+```
+
+Idempotent; re-run any time. It refuses to overwrite a non-link copy without
+`--force`/`-Force`, and `--check`/`-Check` verifies the links. See the repo's
+[`CONTRIBUTING.md`](../../../CONTRIBUTING.md#skills--link-dont-copy).
+
+The remaining paths below link this one skill by hand — equivalent for a
+single skill, useful when you are not working from a full re-frame2 clone.
+
+## 1. Symlink one skill by hand
 
 Edits you make in the repo are live immediately — no copy to keep in sync.
 
@@ -37,7 +59,8 @@ New-Item -ItemType SymbolicLink `
   -Target "$env:USERPROFILE\code\re-frame2\skills\re-frame2-pair"
 ```
 
-Without admin, use a directory junction:
+Without admin, use a directory junction (the primitive the repo installer
+uses):
 
 ```cmd
 mklink /J %USERPROFILE%\.claude\skills\re-frame2-pair %USERPROFILE%\code\re-frame2\skills\re-frame2-pair
@@ -45,13 +68,17 @@ mklink /J %USERPROFILE%\.claude\skills\re-frame2-pair %USERPROFILE%\code\re-fram
 
 Junctions behave like symlinks for read purposes; fine for skill loading.
 
-## 2. Copy (snapshot the current state)
+## 2. Copy (snapshot the current state) — drifts; avoid for everyday dev
 
 ```bash
 cp -r ~/code/re-frame2/skills/re-frame2-pair ~/.claude/skills/re-frame2-pair
 ```
 
-Simple, but you have to re-copy after every change. Useful if you want to pin a specific commit and keep iterating on the repo itself without affecting Claude's view of the skill.
+Simple, but you have to re-copy after every change — and if you forget, Claude
+Code silently loads a **stale** skill that drifts from the repo (this is the
+exact failure the link-based installer in §0 was written to prevent). Only use
+a copy when you deliberately want to pin a specific snapshot and keep iterating
+on the repo without affecting Claude's view. For everyday dev, prefer §0/§1.
 
 ## 3. Project-local (only active in one app)
 


### PR DESCRIPTION
## What & why

Claude Code loads skills from `~/.claude/skills/<name>/`. They were deployed by a one-shot `cp -r`, so the active copy **froze ~10 days behind the maintained repo** (35+ files drifted; the repo had tests for ops the copy lacked) and Claude Code loaded a *stale* skill. Concrete harm this cycle: a skill review (rf2-re6as) ran against the stale copy and had to be re-baselined. This is the same hand-maintained-two-copies drift the project fights elsewhere (spec↔impl, doc↔tools), now at the **deployment** level.

**Fix: deploy by LINK, not copy** — the active skill *is* the repo source by construction, so edits in either are the same file.

## Changes

- **`scripts/install-skills.sh`** (POSIX) + **`scripts/install-skills.ps1`** (PowerShell) — a cross-platform installer pair that links **every** `skills/<name>/` dir into `~/.claude/skills/`.
  - **Link primitive per OS:** `ln -s` on macOS/Linux; a directory **junction** via `New-Item -ItemType Junction` on Windows — **no admin / Developer Mode needed** (a Windows *symlink* requires elevation; a junction does not, so it is the right primitive for a directory). The `.sh` auto-selects the junction primitive when run under Git Bash on Windows.
  - **Audited all nine** `skills/*` dirs (incl. `shared/`), not just `re-frame2-pair` — they all hit the same risk.
  - **Idempotent:** re-running re-links; a target already pointing at the repo is left alone; a link pointing elsewhere is re-pointed in place.
  - **Clobber-safe:** a real (non-link) directory is a stale COPY — the installer **warns and refuses to replace it** so local edits are never silently lost; `--force` / `-Force` opts into replacing it with a link.
  - **No hardcoded paths:** target derived from `$HOME` / `$env:USERPROFILE`; repo root from the script's own location. `--check` / `-Check` reports link status without mutating. `--target` / `-Target` aims at an alternate dir (used by the tests below).
- **Docs (dev-setup):**
  - `CONTRIBUTING.md` — new *"Skills — link, don't copy"* section under Project setup.
  - `skills/README.md` + `docs/skills/index.md` (docs-site landing) — now lead with the installer and flag copy-installs as drift-prone. (The old docs-site text literally said *"install a skill by copying its directory"* — fixed.)
  - `skills/re-frame2-pair/docs/LOCAL_DEV.md` — points at the installer as the recommended path; the manual single-skill steps remain as a fallback.

## Quality gates

| Gate | Result |
|---|---|
| Portability — `scripts/check-no-hardcoded-paths.sh` (tracked, both new scripts staged) | **PASS** — "no hardcoded personal/home paths" |
| PowerShell parse (`Parser::ParseFile`) on `install-skills.ps1` | **PASS** — 0 errors; pure ASCII (0 non-ASCII bytes, matching the file's design constraint) |
| `sh -n` syntax check on `install-skills.sh` | **PASS** (shellcheck not on local PATH; CI ubuntu-latest runs it. No bashisms; all expansions quoted) |
| Functional test — `.ps1` against a temp `-Target` dir | **PASS** — fresh install (9 junctions), idempotent re-run, `-Check`=0, stale-copy WARN+skip+exit 1 (copy preserved), `-Force` replaces copy with junction |
| Functional test — `.sh` against a temp `--target` dir (Git Bash) | **PASS** — fresh install, idempotent, `--check`=0, real-junction re-pointed without `--force`, stale-copy protected; verified removing a junction does **not** delete its target (repo skills intact) |
| `mkdocs build --strict` | **NOT RUN locally** (mkdocs not on PATH); the `docs/skills/index.md` edit is plain markdown + a fenced block and the new CONTRIBUTING link is an absolute GitHub URL (matching existing links on that page), so it cannot break relative-link resolution. CI `docs.yml` runs the strict build on this PR. |

Did **not** mutate the operator's real `~/.claude` — all functional tests ran against throwaway temp dirs and cleaned up.

## Operator action (one-time)

The operator must run the installer **once** to retire their current stale copy and link the live repo:

```bash
# macOS / Linux:
scripts/install-skills.sh --force
# Windows:
powershell -ExecutionPolicy Bypass -File scripts/install-skills.ps1 -Force
```

`--force` is needed the first time because the existing `~/.claude/skills/re-frame2-pair` is a real copy dir; afterwards plain re-runs keep the links current.

This PR is #2855.

