### PR TITLE
fix(epoch): cascade-summary reports a thrown machine action as :error not :ok/:no-op (rf2-hhkbb)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1807,7 +1807,18 @@
 ;;                          same paths as :event-id)
 ;;   :frame               — the frame-id the cascade settled in
 ;;   :outcome             — the consumer-facing tier (`:ok` / `:blocked`
-;;                          / `:error`, per `outcome->consumer-facing`)
+;;                          / `:error`, per `outcome->consumer-facing`).
+;;                          rf2-hhkbb — forced `:error` when the cascade
+;;                          contained a thrown handler / machine action
+;;                          (a `:rf.error/*` op in `:trace-events`), even
+;;                          though the epoch itself settled `:outcome :ok`
+;;                          (the interceptor seam contained the throw).
+;;   :errors              — vector of compact `{:operation :message?
+;;                          :machine-id? :action-id?}` descriptors, one per
+;;                          contained cascade exception (rf2-hhkbb). Absent
+;;                          when the cascade threw nothing. Present ⇒
+;;                          `:outcome :error` and the downstream
+;;                          `dispatch-consequence!` reports `:no-op? false`.
 ;;   :db-diff             — {:changed-paths [...] :added-paths [...]
 ;;                           :removed-paths [...]} — top-level depth-1
 ;;                          summary computed from `:db-before` /
@@ -1892,6 +1903,70 @@
     :halted-handler-exception :error
     :ok))
 
+;; ---- contained cascade errors (rf2-hhkbb) ---------------------------------
+;;
+;; A handler / machine-action throw does NOT halt the drain: the
+;; interceptor error-capture seam contains it, the epoch settles
+;; `:outcome :ok`, and the throw rides the trace stream under a
+;; `:rf.error/*` op (Spec-Schemas §`:rf/epoch-record` §Outcomes; the
+;; reference runtime never emits `:halted-handler-exception`). So
+;; `outcome-tier` alone reads such an epoch as `:ok` — and because the
+;; aborted action committed no `:db` and fired no fx, the downstream
+;; `:no-op?` heuristic (no db-change AND no fx) also misfires. The result
+;; is a silent-green-on-error trap for any NON-visual consumer triaging
+;; on `:outcome` / `:no-op?` (the human pink-card path, rf2-4yrr6, is
+;; unaffected — it reads the trace directly).
+;;
+;; The structured summary closes the gap by scanning `:trace-events` for
+;; a contained cascade exception and, when one is present, projecting
+;; `:outcome :error` + surfacing the errors under an `:errors` slot
+;; (`:no-op?` exclusion lives downstream in `consequence-from-summary`).
+;;
+;; `cascade-error-ops` MIRRORS the Xray Epoch panel's `cascade-exception-
+;; ops` (`tools/xray/.../panels/epoch/projection.cljc`, rf2-ahhgn /
+;; rf2-mszrz / rf2-e7yhv) — the structured summary and the human panel
+;; agree on exactly which `:rf.error/*` ops count as a cascade-level
+;; throw. Schema-VALIDATION failures (`:rf.error/schema-validation-
+;; failure`) are deliberately NOT here: a rejected-but-rolled-back
+;; cascade is not a thrown action, and its outcome is governed elsewhere.
+
+(def ^:private cascade-error-ops
+  "Closed set of cascade-level `:rf.error/*` trace ops that mark an epoch
+  whose cascade contained a thrown handler / machine action (rf2-hhkbb).
+  Mirrors Xray's `cascade-exception-ops` so the structured summary and the
+  human Epoch panel agree on what counts as a throw."
+  #{:rf.error/coeffect-exception
+    :rf.error/interceptor-exception
+    :rf.error/handler-exception
+    :rf.error/fx-handler-exception
+    :rf.error/no-such-fx
+    :rf.error/flow-eval-exception
+    :rf.error/machine-action-exception})
+
+(defn- cascade-errors
+  "Project the contained cascade-exception trace events out of an epoch's
+  `:trace-events` into a vector of compact descriptors, or nil when the
+  cascade carried no contained throw (rf2-hhkbb).
+
+  Each descriptor carries `:operation` (the `:rf.error/*` op) plus, when
+  the trace event stamped them, `:message` (the exception's `.getMessage`
+  via `:exception-message`) and the machine attribution
+  (`:machine-id` / `:action-id`) a machine-action throw rides. The shape
+  is intentionally compact — an operator who wants the full exception
+  (stack / ex-data) reads the epoch's `:trace-events` directly or opens
+  the Xray Epoch panel."
+  [trace-events]
+  (let [picks (->> trace-events
+                   (filter (fn [ev] (contains? cascade-error-ops (:operation ev))))
+                   (mapv (fn [ev]
+                           (let [t (:tags ev)]
+                             (cond-> {:operation (:operation ev)}
+                               (string? (:exception-message t))
+                               (assoc :message (:exception-message t))
+                               (:machine-id t) (assoc :machine-id (:machine-id t))
+                               (:action-id t)  (assoc :action-id (:action-id t)))))))]
+    (when (seq picks) picks)))
+
 (defn cascade-summary
   "Project an assembled `:rf/epoch-record` into the compact wire shape
   surfaced by dispatch / reset-frame-db / restore-epoch / dispatch-dry-
@@ -1909,10 +1984,15 @@
           fx-fired   (->> effects (map :fx-id) distinct vec)
           transitions (machine-transitions-summary trace-events)
           elapsed    (epoch-elapsed-ms record)
-          sensitive? (:rf.epoch/sensitive? record)]
+          sensitive? (:rf.epoch/sensitive? record)
+          ;; rf2-hhkbb — a contained throw (handler / machine action) rode
+          ;; the trace stream while the epoch settled `:outcome :ok`. When
+          ;; present it OVERRIDES the outcome tier to `:error` and surfaces
+          ;; under `:errors` so a non-visual consumer detects the failure.
+          errors     (cascade-errors trace-events)]
       (cond-> {:epoch-id        epoch-id
                :frame           frame
-               :outcome         (outcome-tier outcome)
+               :outcome         (if errors :error (outcome-tier outcome))
                :db-diff         diff
                :fx-fired        fx-fired
                :subs-recomputed (count (or sub-runs []))
@@ -1921,6 +2001,7 @@
         trigger-event (assoc :event-vector trigger-event)
         transitions   (assoc :machine-transitions transitions)
         elapsed       (assoc :elapsed-ms elapsed)
+        errors        (assoc :errors errors)
         sensitive?    (assoc :sensitive? true)))))
 
 (defn- attach-cascade
@@ -2057,13 +2138,21 @@
    that changed NO app-db path AND fired NO effect is a visible no-op."
   [result]
   (let [{:keys [cascade-summary]} result
-        {:keys [db-diff fx-fired outcome]} cascade-summary
+        {:keys [db-diff fx-fired outcome errors]} cascade-summary
         changed (vec (concat (:changed-paths db-diff)
                              (:added-paths db-diff)
                              (:removed-paths db-diff)))
         effects (vec (or fx-fired []))
         db-changed? (boolean (seq changed))
-        no-op? (and (not db-changed?) (empty? effects))]
+        ;; rf2-hhkbb — a contained throw (handler / machine action) is NOT
+        ;; a no-op even though it committed no db-change and fired no fx:
+        ;; the cascade did nothing PRECISELY BECAUSE the action aborted.
+        ;; The `:errors` slot (set by `cascade-summary` when the trace
+        ;; carried a `:rf.error/*` exception) excludes the epoch from the
+        ;; quiescence heuristic so a non-visual consumer reads the throw,
+        ;; not a clean no-op.
+        threw?  (boolean (seq errors))
+        no-op?  (and (not threw?) (not db-changed?) (empty? effects))]
     (-> result
         (assoc :db-changed?   db-changed?
                :changed-paths changed

--- a/skills/re-frame2-pair/tests/runtime/cascade_summary_outcome_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/cascade_summary_outcome_test.clj
@@ -1,0 +1,341 @@
+;;;; tests/runtime/cascade_summary_outcome_test.clj
+;;;;
+;;;; Babashka-runnable verification of the cascade-summary's CONTAINED-THROW
+;;;; detection (rf2-hhkbb) in `preload/re_frame2_pair/runtime.cljs`:
+;;;;
+;;;;   - `cascade-errors`              — scans an epoch's `:trace-events` for a
+;;;;                                     contained cascade exception (a
+;;;;                                     `:rf.error/*` op in `cascade-error-ops`)
+;;;;                                     and projects compact descriptors.
+;;;;   - `cascade-summary` :outcome    — forced `:error` when the cascade
+;;;;                                     contained a throw, even though the
+;;;;                                     epoch itself settled `:outcome :ok`.
+;;;;   - `consequence-from-summary`    — `:no-op? false` for a thrown-action
+;;;;                                     epoch (a throw is NOT a no-op).
+;;;;
+;;;; THE BUG (rf2-hhkbb): a `:*` wildcard machine action throwing
+;;;; `:rf.error/machine-action-exception` does NOT halt the drain — the
+;;;; interceptor error-capture seam contains it, the epoch settles
+;;;; `:outcome :ok`, and the throw rides the trace stream. Because the
+;;;; aborted action committed no `:db` and fired no fx, the structured
+;;;; cascade-summary read it as `{:outcome :ok :no-op? true}` — a silent-
+;;;; green-on-error trap for any non-visual consumer triaging on those
+;;;; slots. (The human pink-card path, rf2-4yrr6, reads the trace directly
+;;;; and is unaffected.) The fix surfaces the throws under `:errors`, forces
+;;;; `:outcome :error`, and reports `:no-op? false`.
+;;;;
+;;;; Why a parallel implementation lives here:
+;;;;
+;;;; `preload/re_frame2_pair/runtime.cljs` is a CLJS-only file loaded into
+;;;; the consumer app via shadow-cljs `:devtools :preloads`. It depends on
+;;;; the live re-frame2 epoch history / trace buffer, none of which run
+;;;; under bb. This file mirrors the pure projection logic and asserts
+;;;; behaviour against canned epoch records; a structural pin (below) keeps
+;;;; the mirror honest against the source.
+;;;;
+;;;; KEEP IN SYNC WITH preload/re_frame2_pair/runtime.cljs §Cascade summary
+;;;; (`cascade-error-ops` / `cascade-errors` / `cascade-summary` /
+;;;; `consequence-from-summary`).
+;;;;
+;;;; Run: bb tests/runtime/cascade_summary_outcome_test.clj
+;;;; Exit: 0 = pass, non-zero = fail.
+
+(ns cascade-summary-outcome-test
+  (:require [clojure.java.io :as io]
+            [clojure.set]
+            [clojure.test :refer [deftest is run-tests testing]]
+            [clojure.walk :as walk]))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of preload/re_frame2_pair/runtime.cljs §Cascade summary.
+;; KEEP IN SYNC.
+;; ---------------------------------------------------------------------------
+
+(def ^:private cascade-error-ops
+  "Closed set of cascade-level `:rf.error/*` trace ops that mark a contained
+  throw. Mirrors Xray's `cascade-exception-ops`."
+  #{:rf.error/coeffect-exception
+    :rf.error/interceptor-exception
+    :rf.error/handler-exception
+    :rf.error/fx-handler-exception
+    :rf.error/no-such-fx
+    :rf.error/flow-eval-exception
+    :rf.error/machine-action-exception})
+
+(defn- cascade-errors
+  "Project contained cascade-exception trace events into compact descriptors,
+  or nil when the cascade carried no contained throw."
+  [trace-events]
+  (let [picks (->> trace-events
+                   (filter (fn [ev] (contains? cascade-error-ops (:operation ev))))
+                   (mapv (fn [ev]
+                           (let [t (:tags ev)]
+                             (cond-> {:operation (:operation ev)}
+                               (string? (:exception-message t))
+                               (assoc :message (:exception-message t))
+                               (:machine-id t) (assoc :machine-id (:machine-id t))
+                               (:action-id t)  (assoc :action-id (:action-id t)))))))]
+    (when (seq picks) picks)))
+
+(defn- outcome-tier
+  "Project the epoch's detailed `:outcome` cause onto the consumer-facing
+  three-tier summary. Defaults to `:ok` for absent / unknown causes."
+  [outcome]
+  (case outcome
+    :ok                       :ok
+    :halted-depth             :blocked
+    :halted-destroy           :blocked
+    :halted-handler-exception :error
+    :ok))
+
+(defn- db-diff-summary
+  "Depth-1 path summary of the db-before -> db-after delta."
+  [db-before db-after]
+  (cond
+    (and (map? db-before) (map? db-after))
+    (let [ks-b   (set (keys db-before))
+          ks-a   (set (keys db-after))
+          common (clojure.set/intersection ks-b ks-a)]
+      {:added-paths   (vec (sort (map vector (clojure.set/difference ks-a ks-b))))
+       :removed-paths (vec (sort (map vector (clojure.set/difference ks-b ks-a))))
+       :changed-paths (vec (sort (for [k common
+                                       :when (not= (get db-before k) (get db-after k))]
+                                   [k])))})
+    (= db-before db-after)
+    {:added-paths [] :removed-paths [] :changed-paths []}
+    :else
+    {:added-paths [] :removed-paths [] :changed-paths [[]]}))
+
+(defn cascade-summary
+  "Mirror of the cascade-summary projection (slot subset relevant to the
+  contained-throw fix: :outcome / :errors / :db-diff / :fx-fired)."
+  [{:keys [epoch-id frame outcome db-before db-after effects trace-events]
+    :as record}]
+  (when record
+    (let [diff     (db-diff-summary db-before db-after)
+          fx-fired (->> effects (map :fx-id) distinct vec)
+          errors   (cascade-errors trace-events)]
+      (cond-> {:epoch-id epoch-id
+               :frame    frame
+               :outcome  (if errors :error (outcome-tier outcome))
+               :db-diff  diff
+               :fx-fired fx-fired}
+        errors (assoc :errors errors)))))
+
+(defn consequence-from-summary
+  "Mirror of the dispatch-consequence projection (`:db-changed?` /
+  `:effects-fired` / `:no-op?` derivation from the cascade-summary)."
+  [result]
+  (let [{:keys [cascade-summary]} result
+        {:keys [db-diff fx-fired outcome errors]} cascade-summary
+        changed (vec (concat (:changed-paths db-diff)
+                             (:added-paths db-diff)
+                             (:removed-paths db-diff)))
+        effects (vec (or fx-fired []))
+        db-changed? (boolean (seq changed))
+        threw?  (boolean (seq errors))
+        no-op?  (and (not threw?) (not db-changed?) (empty? effects))]
+    (-> result
+        (assoc :db-changed?   db-changed?
+               :changed-paths changed
+               :effects-fired effects
+               :no-op?        no-op?)
+        (cond-> (= :error outcome) (assoc :outcome :error)))))
+
+;; ---------------------------------------------------------------------------
+;; Canned epoch records (the live :8033 machine-epochs deck shapes).
+;; ---------------------------------------------------------------------------
+
+;; Rung 11 — `[:fuse/box [:fuse/short-circuit]]`: the `:*` wildcard action
+;; THROWS `:rf.error/machine-action-exception`. The epoch settles
+;; `:outcome :ok` (the interceptor seam contained the throw), committed NO
+;; db-change and fired NO fx — precisely BECAUSE the action aborted.
+(def thrown-action-epoch
+  {:epoch-id 11
+   :frame    :machine-epochs
+   :outcome  :ok                       ;; the contained-throw epoch settles :ok
+   :db-before {:baseline 5}
+   :db-after  {:baseline 5}            ;; no db-change — the action aborted
+   :effects  []                        ;; no fx — the action aborted
+   :trace-events
+   [{:operation :rf.event/run-start :tags {:frame :machine-epochs}}
+    {:operation :rf.machine/action-ran
+     :tags {:frame :machine-epochs :machine-id :fuse/box
+            :action-id :blow-fuse :outcome :rf.error/action-threw}}
+    {:operation :rf.error/machine-action-exception
+     :tags {:frame :machine-epochs :machine-id :fuse/box :action-id :blow-fuse
+            :exception-message "fuse blew"
+            :transition {:rf/via-wildcard? true}}}
+    {:operation :rf.event/run-end :tags {:frame :machine-epochs}}]})
+
+;; Rung 7 — a benign unhandled-event no-op: the machine has no `:strict`
+;; flag, the event resolves to nothing, NO exception trace fires.
+(def benign-no-op-epoch
+  {:epoch-id 7
+   :frame    :machine-epochs
+   :outcome  :ok
+   :db-before {:baseline 3}
+   :db-after  {:baseline 3}            ;; nothing changed
+   :effects  []                        ;; nothing fired
+   :trace-events
+   [{:operation :rf.event/run-start :tags {:frame :machine-epochs}}
+    {:operation :rf.event/run-end :tags {:frame :machine-epochs}}]})
+
+;; A successful machine action: changes db, no exception trace.
+(def successful-action-epoch
+  {:epoch-id 4
+   :frame    :machine-epochs
+   :outcome  :ok
+   :db-before {:baseline 1 :door :open}
+   :db-after  {:baseline 1 :door :closed}
+   :effects  []
+   :trace-events
+   [{:operation :rf.event/run-start :tags {:frame :machine-epochs}}
+    {:operation :rf.machine/transition
+     :tags {:frame :machine-epochs :machine-id :door/lock :from :open :to :closed}}
+    {:operation :rf.event/run-end :tags {:frame :machine-epochs}}]})
+
+;; A genuine non-machine fx error: a reg-event-fx handler returned an fx-id
+;; whose handler threw. The epoch carries the per-effect :outcome :error AND
+;; the `:rf.error/fx-handler-exception` trace.
+(def fx-error-epoch
+  {:epoch-id 20
+   :frame    :rf/default
+   :outcome  :ok
+   :db-before {:cart {}}
+   :db-after  {:cart {:items 1}}       ;; the db committed before the fx threw
+   :effects  [{:fx-id :http :outcome :error :error-trace 99}]
+   :trace-events
+   [{:operation :rf.event/run-start :tags {:frame :rf/default}}
+    {:operation :rf.error/fx-handler-exception
+     :tags {:frame :rf/default :rf.fx/id :http :exception-message "boom"}}
+    {:operation :rf.event/run-end :tags {:frame :rf/default}}]})
+
+;; ---------------------------------------------------------------------------
+;; Behavioural tests — reproduce-then-fix.
+;; ---------------------------------------------------------------------------
+
+(deftest thrown-action-summary-is-error-not-ok
+  ;; THE bug. RED before the fix: cascade-summary read :outcome :ok.
+  ;; GREEN after: a contained machine-action throw forces :outcome :error
+  ;; and surfaces the throw under :errors.
+  (let [summary (cascade-summary thrown-action-epoch)]
+    (testing "a thrown machine action projects :outcome :error, not :ok"
+      (is (= :error (:outcome summary))
+          "the cascade-summary outcome must be :error for a contained throw"))
+    (testing "the throw is surfaced under :errors so a tool can read it"
+      (is (seq (:errors summary)) ":errors must be present")
+      (let [err (first (:errors summary))]
+        (is (= :rf.error/machine-action-exception (:operation err)))
+        (is (= :fuse/box (:machine-id err)))
+        (is (= :blow-fuse (:action-id err)))
+        (is (= "fuse blew" (:message err)))))))
+
+(deftest thrown-action-consequence-is-not-a-no-op
+  ;; THE bug, second defect. RED before the fix: :no-op? true (no db-change
+  ;; + no fx). GREEN after: a throw is never a no-op.
+  (let [summary (cascade-summary thrown-action-epoch)
+        conseq  (consequence-from-summary {:ok? true :cascade-summary summary})]
+    (testing "a thrown machine action is NOT a no-op"
+      (is (false? (:no-op? conseq))
+          ":no-op? must be false for a thrown-action epoch (the action aborted)"))
+    (testing "the consequence :outcome is promoted to :error"
+      (is (= :error (:outcome conseq))))))
+
+;; ---------------------------------------------------------------------------
+;; Negative guards — the fix must NOT over-fire.
+;; ---------------------------------------------------------------------------
+
+(deftest benign-no-op-stays-a-no-op
+  ;; Rung 7. A genuine unhandled-event no-op carries no exception trace —
+  ;; it must stay :outcome :ok + :no-op? true (the inverse of rung 11).
+  (let [summary (cascade-summary benign-no-op-epoch)
+        conseq  (consequence-from-summary {:ok? true :cascade-summary summary})]
+    (is (= :ok (:outcome summary)) "a benign no-op stays :ok")
+    (is (nil? (:errors summary))   "a benign no-op carries no :errors slot")
+    (is (true? (:no-op? conseq))   "a benign no-op stays :no-op? true")))
+
+(deftest successful-action-stays-ok
+  ;; A successful machine action (db changed, no throw) stays :ok and is
+  ;; not a no-op.
+  (let [summary (cascade-summary successful-action-epoch)
+        conseq  (consequence-from-summary {:ok? true :cascade-summary summary})]
+    (is (= :ok (:outcome summary)) "a successful action stays :ok")
+    (is (nil? (:errors summary))   "a successful action carries no :errors slot")
+    (is (false? (:no-op? conseq))  "a successful action changed db, not a no-op")
+    (is (true? (:db-changed? conseq)))))
+
+(deftest fx-error-surfaces-as-error
+  ;; A genuine non-machine reg-event-fx error: the fx-handler threw. It
+  ;; carries the `:rf.error/fx-handler-exception` trace, so the same
+  ;; contained-throw detection applies — :outcome :error, not a no-op.
+  (let [summary (cascade-summary fx-error-epoch)
+        conseq  (consequence-from-summary {:ok? true :cascade-summary summary})]
+    (is (= :error (:outcome summary))
+        "an fx-handler throw surfaces :outcome :error")
+    (is (some #(= :rf.error/fx-handler-exception (:operation %)) (:errors summary))
+        "the fx-handler exception is surfaced under :errors")
+    (is (false? (:no-op? conseq))
+        "the fx error epoch is not a no-op (db changed AND it threw)")))
+
+;; ---------------------------------------------------------------------------
+;; Structural pin — keep the bb mirror honest against the cljs source.
+;; ---------------------------------------------------------------------------
+
+(def ^:private runtime-cljs-path
+  (some (fn [p] (when (.exists (io/file p)) p))
+        ["preload/re_frame2_pair/runtime.cljs"
+         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
+         "../preload/re_frame2_pair/runtime.cljs"]))
+
+(defn- read-all-forms [^String src]
+  (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
+    (loop [acc []]
+      (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
+                      (catch Exception _ ::eof))]
+        (if (= ::eof form) acc (recur (conj acc form)))))))
+
+(def ^:private all-forms
+  (when runtime-cljs-path (read-all-forms (slurp runtime-cljs-path))))
+
+(defn- top-level-named [kinds sym]
+  (some (fn [form]
+          (when (and (seq? form) (kinds (first form)) (= sym (second form)))
+            form))
+        all-forms))
+
+(defn- form-contains? [pred form]
+  (let [hit? (atom false)]
+    (walk/postwalk (fn [node] (when (pred node) (reset! hit? true)) node) form)
+    @hit?))
+
+(deftest source-defines-cascade-error-ops
+  (is (some? runtime-cljs-path) "runtime.cljs must be locatable")
+  (is (some? (top-level-named #{'def} 'cascade-error-ops))
+      "runtime.cljs must define `cascade-error-ops` — the closed `:rf.error/*` set (rf2-hhkbb).")
+  (let [form (top-level-named #{'def} 'cascade-error-ops)]
+    (is (form-contains? #(= :rf.error/machine-action-exception %) form)
+        "cascade-error-ops MUST include :rf.error/machine-action-exception (the rung-11 throw).")))
+
+(deftest source-cascade-summary-forces-error-and-errors-slot
+  (let [form (top-level-named #{'defn 'defn-} 'cascade-summary)]
+    (is (some? form) "runtime.cljs must define `cascade-summary`")
+    (is (some? (top-level-named #{'defn 'defn-} 'cascade-errors))
+        "runtime.cljs must define `cascade-errors` (rf2-hhkbb).")
+    (is (form-contains? #(= :errors %) form)
+        "cascade-summary MUST surface the :errors slot (rf2-hhkbb).")))
+
+(deftest source-consequence-excludes-thrown-from-no-op
+  (let [form (top-level-named #{'defn 'defn-} 'consequence-from-summary)]
+    (is (some? form) "runtime.cljs must define `consequence-from-summary`")
+    ;; The :no-op? derivation must read the summary's errors so a thrown-
+    ;; action epoch is excluded from the quiescence heuristic. `errors` is
+    ;; bound via `:keys` destructuring (a symbol, not a keyword literal in
+    ;; the form), and the exclusion threads through a `threw?` binding.
+    (is (form-contains? #(= 'errors %) form)
+        "consequence-from-summary MUST read the summary's `errors` so a throw is not a no-op (rf2-hhkbb).")
+    (is (form-contains? #(= 'threw? %) form)
+        "consequence-from-summary MUST exclude a thrown-action epoch from :no-op? via `threw?` (rf2-hhkbb).")))
+
+(let [{:keys [fail error]} (run-tests 'cascade-summary-outcome-test)]
+  (System/exit (if (zero? (+ (or fail 0) (or error 0))) 0 1)))

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -749,15 +749,36 @@ marker so consumers can branch.
 | `:event-id`           | keyword                           | The triggering event-id. Absent on synthetic / halted-trigger-less paths. |
 | `:event-vector`       | vector                            | The original dispatch vector. Absent on synthetic paths. |
 | `:frame`              | keyword                           | The frame-id the cascade settled in. |
-| `:outcome`            | `:ok` / `:blocked` / `:error`     | The consumer-facing tier per `outcome->consumer-facing`. |
+| `:outcome`            | `:ok` / `:blocked` / `:error`     | The consumer-facing tier per `outcome->consumer-facing`. Forced `:error` when the cascade contained a thrown handler / machine action — see §Contained throws below. |
 | `:db-diff`            | `{:changed-paths [...] :added-paths [...] :removed-paths [...]}` | Depth-1 path summary of the db delta. Each path is a one-key vector (e.g. `[:cart]`); drill in via `get-path`. |
 | `:fx-fired`           | vector of fx-ids                  | Distinct fx-ids fired this cascade. Duplicates collapsed. |
+| `:errors`             | vector of `{:operation :message? :machine-id? :action-id?}` | Present only when the cascade contained a thrown handler / machine action (rf2-hhkbb). One compact descriptor per `:rf.error/*` trace op; `:message` carries the exception's `.getMessage` when stamped, `:machine-id` / `:action-id` the machine attribution of a machine-action throw. Drill into the full exception (stack / ex-data) via the epoch's `:trace-events` or the Xray Epoch panel. See §Contained throws below. |
 | `:subs-recomputed`    | integer                           | Count of unique sub-runs in this cascade. |
 | `:renders`            | integer                           | Count of render emits in this cascade. |
 | `:machine-transitions`| vector of `{:machine-id :from :to :phase}` | Absent when no machine activity. |
 | `:elapsed-ms`         | number                            | Wall-clock elapsed-ms from `:rf.event/run-start` to `:rf.event/run-end`. |
 | `:sensitive?`         | `true`                            | Present only when the epoch's `:rf.epoch/sensitive?` rollup is true. Consumers branch on absent-slot patterns in `:db-diff`. |
 | `:restore?`           | `true`                            | Present only on `restore-epoch` responses. Signals the summary projects the TARGET epoch, with `:db-diff` computed from the pre-restore live db. |
+
+### Contained throws (rf2-hhkbb)
+
+A thrown handler or machine action does **not** halt the cascade: the
+interceptor error-capture seam contains the throw, the epoch settles
+`:outcome :ok`, and the exception rides the trace stream under a
+`:rf.error/*` op (e.g. a `:*` wildcard machine action throwing
+`:rf.error/machine-action-exception`, the xstate-v5 "fail loudly on
+unknown" idiom). Because the aborted action commits no `:db` and fires no
+fx, a naïve summary would read the epoch as `:outcome :ok` + a clean
+no-op — a silent-green-on-error trap for any non-visual consumer.
+
+The cascade-summary closes that gap: when `:trace-events` carries a
+contained cascade exception it surfaces the throws under `:errors`,
+forces `:outcome :error`, and `dispatch`'s `dispatch-consequence!`
+projection reports `:no-op? false` (a throw is never a no-op). The set of
+`:rf.error/*` ops that count mirrors Xray's `cascade-exception-ops` so the
+structured summary and the human Epoch panel (rf2-4yrr6 pink card) agree
+on what a throw is. A genuine unhandled-event no-op (no exception trace)
+keeps `:outcome :ok` + `:no-op? true`; a clean cascade stays `:ok`.
 
 ### `:unreplayable-effects` (restore-epoch only)
 


### PR DESCRIPTION
## What

The structured cascade-summary (Spec 003 — the agent/tool triage surface returned by the dispatch tool) reported a THROWN machine action as success. Driving the live machine-epochs deck rung 11 (`[:fuse/box [:fuse/short-circuit]]` — a `:*` wildcard action that throws `:rf.error/machine-action-exception`), the summary read `{:outcome :ok, :no-op? true}`.

A thrown handler / machine action does **not** halt the drain: the interceptor error-capture seam contains it, the epoch settles `:outcome :ok`, and the throw rides the trace stream under a `:rf.error/*` op. Because the aborted action committed no `:db` and fired no fx, the projection read it as a clean `:ok` no-op — a silent-green-on-error trap for any non-visual consumer triaging on `:outcome` / `:no-op?`. (The human pink-card path, rf2-4yrr6, reads the trace directly and was unaffected — this PR fixes only the STRUCTURED side.)

## The fix

`skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs`:

- New `cascade-error-ops` — the closed set of cascade-level `:rf.error/*` ops that count as a contained throw. **Mirrors** Xray's `cascade-exception-ops` (`tools/xray/.../panels/epoch/projection.cljc`) so the structured summary and the human Epoch panel agree on what a throw is.
- New `cascade-errors` — scans an epoch's `:trace-events` for those ops and projects compact `{:operation :message? :machine-id? :action-id?}` descriptors.
- `cascade-summary` — when a contained throw is present, **forces `:outcome :error`** and surfaces the throws under a new **`:errors`** slot.
- `consequence-from-summary` — excludes a thrown-action epoch from the `:no-op?` quiescence heuristic (`threw?` → **`:no-op? false`**). A throw is never a no-op.

Genuine cases preserved: a benign unhandled-event no-op stays `:ok` / `:no-op? true`; a successful action stays `:ok`; an fx-handler throw surfaces `:error`. Schema-validation failures are deliberately NOT in the error set (a rejected-but-rolled-back cascade is not a thrown action).

## Tests (reproduce-then-fix)

`skills/re-frame2-pair/tests/runtime/cascade_summary_outcome_test.clj` (bb-mirrored pure logic + a structural pin against the cljs source, following the established `tests/runtime/` pattern):

- **RED→GREEN**: the rung-11 thrown-action epoch → `:outcome :error` (not `:ok`) + `:no-op? false`; the throw surfaced under `:errors`. (Pre-fix logic verified to report `{:outcome :ok :no-op? true}`.)
- **Negative guards**: rung-7 benign no-op stays `:ok` / `:no-op? true`; a successful action stays `:ok` / not-a-no-op; a non-machine fx-handler throw surfaces `:error`.

## Spec

`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` §Slot inventory documents the new `:errors` slot + a §Contained throws subsection pinning the `:outcome :error` / `:no-op? false` contract.

## Quality gates

| Gate | Result |
|---|---|
| `bb tests/runtime/cascade_summary_outcome_test.clj` (new) | PASS (8 tests / 27 assertions) |
| `bb tests/runtime/*_test.clj` (all re-frame2-pair structural) | PASS |
| JVM epoch `clojure -M:test` | PASS (245 tests / 892 assertions) |
| JVM machines `clojure -M:test` | PASS (340 tests / 1111 assertions) |
| JVM core `clojure -M:test` | PASS (844 tests / 3779 assertions) |
| `npm run test:cljs` (cold) | PASS (5338 tests / 18308 assertions) |
| `npm run test:xray-feature-gate` | PASS except the documented known flake `routes-epochs routing ladder` (`:rf/pending-navigation did not fill` — routing-substrate timing, unrelated to this diff; the `machine-epochs machine ladder` rung-11 surface PASSES). |

Closes rf2-hhkbb.
