### PR TITLE
test(xray): assertion-backed machine-epochs render-regression harness — full feature×surface matrix + :always microsteps (rf2-g27vv)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1506,3 +1506,16 @@ action-attribution half.
   `:rf.xray/*` registry ids for the Machines tab.
 - [`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) — Sim
   mode + Mode A/B/C dynamic instance test rows.
+- **Render regression harness (rf2-g27vv).** The `machine_epochs` testbed
+  (:8033) is the assertion-backed harness that pins this spec's cascade-render
+  contract against reality — its numbered ladder drives the full feature ×
+  render-surface matrix (plain / entry-exit / guards / internal / fx /
+  unhandled-no-op / root-`:on` resolution; parallel regions + history +
+  member-level tag-set delta; `:always` microsteps; `:after` timer + cancel;
+  spawn / `:final?` / `:on-done` / destroy lifecycle; `:*` wildcard throw;
+  deep-compound LCA + self-transitions; `:history` reject-now). Each rung is
+  backed by a CLJS-unit assertion in
+  `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test` (BOTH
+  the machine outcome via the per-machine `:data :trail` order-oracle AND the
+  cascade-render projection it lights up), complemented by
+  `…hard-machine-fidelity-cljs-test` for the HVAC HARD machine.

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1730,6 +1730,26 @@ by hand (rf2-52u5n live finding, machine-epochs :8033). It is the
 consumer of the rf2-n9f4z instrumentation contract per
 [003-Machine-Inspector §The EVENT HANDLER machine cascade](003-Machine-Inspector.md).
 
+The `machine_epochs` testbed (:8033) is now the **assertion-backed render
+regression harness** for this whole cascade-render contract (rf2-g27vv). Its
+numbered ladder drives the full FEATURE × RENDER-SURFACE matrix — plain /
+entry-exit / transition-action / guard pass+fail / internal / fx /
+unhandled-no-op / root-`:on` resolution (door); parallel regions + history +
+member-level tag-set delta (traffic); `:always` **microsteps** that settle
+over N>0 microsteps (quiz); `:after` **timer** auto-fire + cancellation
+(brew); **spawn → `:final?` → `:on-done` → auto-destroy** lifecycle
+(session); `:*` wildcard-action **throw** (fuse); deep-compound LCA + self-
+transitions (hvac); and a `:history` **reject-now** rung with ready
+placeholders for shallow/deep restore (deferred per Spec 005 §Substitutes).
+Each rung is backed by a CLJS-unit assertion in
+`day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test` that
+drives the rung through the live substrate and pins BOTH the machine outcome
+(via the generalized per-machine `:data :trail` order-oracle) AND the Xray
+cascade-render projection it lights up — so re-driving the deck is a real
+regression test of this render contract. The `:data :trail` is no longer a
+workaround; every machine carries it as a legible cross-check the harness
+keys its order assertions off.
+
 Timer rows surface only the header + click-to-source chip (no inline
 body — cancellations are housekeeping; the chip routes to the
 `:after`-bearing state node).

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
@@ -1,0 +1,572 @@
+(ns day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test
+  "ASSERTION-BACKED render-regression harness for the machine-epochs deck
+  (rf2-g27vv). The COMPLEMENT to `hard-machine-fidelity-cljs-test` (rf2-k08ay,
+  which this SUBSUMES + extends deck-wide): where that pins the HVAC HARD
+  machine's render fidelity, THIS pins the FULL machine × Xray-cascade-render
+  SURFACE matrix the redesigned deck drives — every rung backed by an
+  assertion so re-driving the deck is a real regression test of Xray
+  rendering, not just a visual deck.
+
+  ## What it drives + asserts
+
+  It registers the IDENTICAL machine specs the testbed mounts (via
+  `machine-epochs.machines/register-all!` — the SAME values, no drift),
+  drives each rung's event through the LIVE machine substrate
+  (`dispatch-sync`), captures the trace stream Xray's ring buffer recorded,
+  and feeds it through the rendering layers that FEED the devtools render:
+
+    - `proj/machine-cascade-rows`        — the Epoch panel's per-epoch machine
+      cascade (the exit/action/entry/no-op/timer rows; canonical sort;
+      no-op-transition suppression).
+    - the structured `:cascade` off the transition row (`proj/cascade-regions`
+      / `cascade-microsteps` / `cascade-step-count`) — the LCA + microstep
+      walk.
+    - `mih/project-focused-event-transitions` — the inspector's focused-event
+      view-model.
+    - `diff/project` — the snapshot diff (member-level set diff for `:tags`).
+
+  Per rf2-k08ay + the rf2-hhkbb drive-through finding, EACH rung asserts THREE
+  layers:
+    (a) TRACE shape — the machine cascade kinds + order (the generalized
+        `:trail` is the order-oracle; also the `:cascade` kinds + `:microsteps`).
+    (b) STRUCTURED outcome — the Xray-surface analogue of the rf2-hhkbb
+        cascade-summary `:outcome` / `:no-op?`: a thrown `:*` action shows
+        `:threw? true` on its cascade row (catching hhkbb); the unhandled rung
+        shows exactly ONE `:no-op` row + zero transition rows.
+    (c) RENDERED rows — the Epoch-panel projection emits the expected row
+        kinds / verbs.
+
+  Causa/Story-as-CLJS-unit-test (feedback_causa_story_cljs_unit_tests_not_playwright),
+  NOT Playwright. The render facts are pinned against REALITY: drive the
+  substrate, read what the projection produces."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [day8.re-frame2-xray.diff.engine :as diff]
+            [day8.re-frame2-xray.panels.epoch.format :as fmt]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.panels.machine-inspector-helpers :as mih]
+            [day8.re-frame2-xray.preload :as preload]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; The SHARED machine specs the deck mounts — the harness drives
+            ;; the IDENTICAL values (single source of truth, rf2-g27vv).
+            [machine-epochs.machines :as machines]))
+
+;; ============================================================================
+;; fixture + drivers
+;; ============================================================================
+
+(defn- xray-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-collector/reset-for-test!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn xray-init!}))
+
+(defn- setup!
+  "Register the Xray handlers + trace collector, register every (non-throwing)
+  deck machine via the shared specs, and bootstrap each to its initial state.
+  Clears the trace buffer so per-rung captures contain only that macrostep."
+  []
+  (registry/register-xray-handlers!)
+  (preload/register-trace-collector!)
+  (machines/register-all!)
+  (doseq [id [:door/main :traffic/light :quiz/scorer :brew/machine
+              :session/flow :hvac/controller]]
+    (rf/dispatch-sync [id [:rf.machine/bootstrap]])))
+
+(defn- snapshot [machine-id]
+  (get-in (rf/app-db-value :rf/default)
+          [:rf/runtime :machines :snapshots machine-id]))
+
+(defn- trail [machine-id] (get-in (snapshot machine-id) [:data :trail]))
+
+(defn- drive!
+  "Dispatch one event into `machine-id` and return the trace stream it
+  produced as an epoch-record-shaped map. Resets the trace buffer first so
+  the captured cascade is exactly this macrostep."
+  [machine-id event-v]
+  (trace-collector/reset-for-test!)
+  (rf/dispatch-sync [machine-id event-v])
+  {:event-id      machine-id
+   :trigger-event [machine-id event-v]
+   :trace-events  (vec (trace-collector/buffer-for-test))})
+
+(defn- cascade [record] (proj/machine-cascade-rows (:trace-events record)))
+(defn- rows-of-kind [rows kind] (filterv #(= kind (:kind %)) rows))
+(defn- structured-of [record]
+  (-> (cascade record) (rows-of-kind :transition) first :cascade))
+
+;; ============================================================================
+;; DOOR (FLAT) — plain · entry/exit · transition-action · guards · internal ·
+;;               fx · unhandled-no-op · root-:on RESOLUTION (gap 6)
+;; ============================================================================
+
+(deftest door-plain-transition-renders-exit-transition-entry
+  (testing "rung #2 — plain :locked ──► :closed renders an exit / TRANSITION /
+            entry cascade with NO guard, NO action rows, and exactly ONE
+            transition row (no no-op)."
+    (setup!)
+    (let [record (drive! :door/main [:door/insert-coin])
+          rows   (cascade record)]
+      (is (= 1 (count (rows-of-kind rows :transition)))
+          "(c) one transition row")
+      (is (empty? (rows-of-kind rows :no-op)) "(b) not a no-op")
+      (is (empty? (rows-of-kind rows :guard)) "(a) no guard fired")
+      (let [tx (first (rows-of-kind rows :transition))]
+        (is (= :locked (:from-state tx)))
+        (is (= :closed (:to-state tx))))
+      (is (= :closed (:state (snapshot :door/main)))))))
+
+(deftest door-entry-exit-actions-render-with-data-delta
+  (testing "rung #3 — :closed ──► :open runs :closed's :exit (:clear-hold) +
+            :open's :entry (:count-open). (a) the trail records exit→entry
+            order; (c) the cascade carries an :exit + an :entry action row;
+            the entry action's :data-delta bumps :opened-count."
+    (setup!)
+    (drive! :door/main [:door/insert-coin])            ; :locked → :closed
+    (let [record (drive! :door/main [:door/push])       ; :closed → :open
+          rows   (cascade record)
+          phases (mapv :phase (rows-of-kind rows :action))]
+      (is (some #{:exit} phases)  "(c) an exit action row renders")
+      (is (some #{:entry} phases) "(c) an entry action row renders")
+      ;; (a) the trail oracle: exit:closed then entry:open, in that order.
+      (is (= [:exit:closed :entry:open] (trail :door/main))
+          "(a) trail records the exit→entry cascade order")
+      (is (= 1 (get-in (snapshot :door/main) [:data :opened-count]))
+          "(c) the :entry action bumped :opened-count"))))
+
+(deftest door-guard-allowed-then-blocked
+  (testing "rungs #4/#5 — guard ALLOWED completes, guard BLOCKED stays put.
+            (a) the guard row's :outcome is :pass then :fail; (b) the blocked
+            attempt is a no-op (one :no-op row, zero transition rows); (c) the
+            state advances only when the guard passes."
+    (setup!)
+    (drive! :door/main [:door/insert-coin])
+    (drive! :door/main [:door/push])                    ; → :open
+    ;; #4 — guard ALLOWED (:held-open? false).
+    (let [rows (cascade (drive! :door/main [:door/close]))]
+      (is (= :pass (:outcome (first (rows-of-kind rows :guard))))
+          "(a) :may-close? passes")
+      (is (= 1 (count (rows-of-kind rows :transition))) "(c) transition fires"))
+    (is (= :closed (:state (snapshot :door/main))))
+    ;; #5 — re-open, arm the hold (internal), then attempt the BLOCKED close.
+    (drive! :door/main [:door/push])                    ; → :open
+    (drive! :door/main [:door/hold])                    ; arm :held-open?
+    (let [rows (cascade (drive! :door/main [:door/close]))]
+      (is (= :fail (:outcome (first (rows-of-kind rows :guard))))
+          "(a) :may-close? fails when held-open?")
+      (is (= 1 (count (rows-of-kind rows :no-op)))
+          "(b) the blocked guard is a no-op — one [NO OP] row")
+      (is (empty? (rows-of-kind rows :transition))
+          "(c) blocked → NO transition row (suppressed beside the no-op)"))
+    (is (= :open (:state (snapshot :door/main)))
+        "(c) the door STAYS :open — the blocked close did not advance")))
+
+(deftest door-internal-transition-renders-action-only
+  (testing "rung #5 sub — :door/hold is an INTERNAL transition (no :target):
+            it writes :data without changing state, so (c) NO exit/entry/no-op
+            rows, just the action's effect; the state stays :open."
+    (setup!)
+    (drive! :door/main [:door/insert-coin])
+    (drive! :door/main [:door/push])                    ; → :open
+    (let [rows (cascade (drive! :door/main [:door/hold]))]
+      (is (empty? (rows-of-kind rows :no-op))
+          "(b) an internal transition is a REAL transition, not a no-op")
+      (is (empty? (filterv #(and (= :action (:kind %)) (= :exit (:phase %))) rows))
+          "(c) internal transition fires NO exit row"))
+    (is (= :open (:state (snapshot :door/main)))
+        "(c) internal transition leaves the state at :open")
+    (is (true? (get-in (snapshot :door/main) [:data :held-open?]))
+        "(c) the internal action wrote :data")))
+
+(deftest door-transition-with-effect-renders-fx
+  (testing "rung #6 — :open ──► :alarming runs :enter-alarm whose action
+            writes :data (the deck dispatches the downstream child via the
+            deck event-fx). (c) the cascade carries the transition + the
+            :enter-alarm action; the trail records :action:trip."
+    (setup!)
+    (drive! :door/main [:door/insert-coin])
+    (drive! :door/main [:door/push])
+    (let [rows (cascade (drive! :door/main [:door/trip]))]
+      (is (= 1 (count (rows-of-kind rows :transition))))
+      (is (some #(= :action:trip (last (get-in % [:data-write :trail] [])))
+                (rows-of-kind rows :action))
+          "(a)(c) the :enter-alarm action ran (trail appended :action:trip)"))
+    (is (= :alarming (:state (snapshot :door/main))))))
+
+(deftest door-unhandled-event-renders-single-no-op-staying-in-state
+  (testing "rung #7 — :door/insert-coin into :alarming matches no transition →
+            a BENIGN unhandled no-op (settled coozg/e6q97/iu3no pipeline).
+            (b) exactly ONE :no-op row, :no-op? true (zero transition rows);
+            (c) the verb is the bare 'staying in :alarming' (single machine →
+            no machine name)."
+    (setup!)
+    (drive! :door/main [:door/insert-coin])
+    (drive! :door/main [:door/push])
+    (drive! :door/main [:door/trip])                    ; → :alarming
+    (let [record (drive! :door/main [:door/insert-coin])
+          rows   (cascade record)
+          no-ops (rows-of-kind rows :no-op)
+          no-op  (first no-ops)]
+      (is (= 1 (count no-ops)) "(b) exactly one no-op row (coozg: single signal)")
+      (is (empty? (rows-of-kind rows :transition))
+          "(b) NO transition row beside the no-op (e6q97 suppression)")
+      (is (= :alarming (:state no-op)))
+      (is (false? (:show-machine-name? no-op)) "(c) single machine → drop name")
+      (let [verb (fmt/cascade-row-label no-op)]
+        (is (string/starts-with? verb "staying in ") "(c) bare consequence verb")
+        (is (not (string/includes? verb "received")) "(c) no event echo")))
+    (is (= :alarming (:state (snapshot :door/main)))
+        "(b) the door STAYS :alarming — a no-op does not move state")))
+
+(deftest door-audit-resolves-via-root-on-fallthrough
+  (testing "rung #8 (gap 6, RESOLUTION) — :alarming declares no :door/audit;
+            the event falls through to the machine ROOT :on, which targets
+            :locked. (a) the trail records :action:audit (the root clause's
+            action ran); (c) a real transition row attributes :alarming ──►
+            :locked — NOT a no-op."
+    (setup!)
+    (drive! :door/main [:door/insert-coin])
+    (drive! :door/main [:door/push])
+    (drive! :door/main [:door/trip])                    ; → :alarming
+    (let [record (drive! :door/main [:door/audit])
+          rows   (cascade record)
+          tx     (first (rows-of-kind rows :transition))]
+      (is (empty? (rows-of-kind rows :no-op))
+          "(b) the root :on HANDLED it — NOT an unhandled no-op")
+      (is (some? tx) "(c) a real transition row renders")
+      (is (= :alarming (:from-state tx)))
+      (is (= :locked (:to-state tx))
+          "(c) the cascade attributes the root-resolved transition to :locked")
+      (is (= :action:audit (last (trail :door/main)))
+          "(a) the root clause's :record-audit action ran"))
+    (is (= :locked (:state (snapshot :door/main))))))
+
+;; ============================================================================
+;; TRAFFIC (PARALLEL) — regions · history · TAG-SET delta (gap 7)
+;; ============================================================================
+
+(deftest traffic-tick-broadcasts-to-both-regions
+  (testing "rung #9 — ONE :traffic/tick broadcasts to BOTH regions in one
+            macrostep. (c) one aggregate transition row whose :to-state is a
+            region→state map showing both regions advanced; (a) the inspector
+            projects the single macrostep transition with both regions."
+    (setup!)
+    (let [record    (drive! :traffic/light [:traffic/tick])
+          rows      (cascade record)
+          tx        (first (rows-of-kind rows :transition))
+          inspector (mih/project-focused-event-transitions
+                      (:trace-events record)
+                      {:traffic/light machines/traffic-machine})]
+      (is (= 1 (count (rows-of-kind rows :transition)))
+          "(c) a parallel macrostep commits ONE aggregate transition row")
+      (is (= {:vehicle :red :pedestrian :walk} (:from-state tx)))
+      (is (= {:vehicle :green :pedestrian :dont-walk} (:to-state tx))
+          "(c) both regions advanced in one event")
+      (is (empty? (rows-of-kind rows :no-op)) "(b) a handled broadcast is not a no-op")
+      (is (= 1 (count inspector))
+          "(a) the inspector projects the macrostep's single transition record"))
+    (is (= {:vehicle :green :pedestrian :dont-walk} (:state (snapshot :traffic/light))))))
+
+(deftest traffic-tag-set-delta-renders-member-swap
+  (testing "rung #10 (gap 7, rf2-l0us2) — a tick swaps the :tags SET members
+            while a :traffic/shared member stays constant. The snapshot diff
+            must surface per-MEMBER :added / :removed (the joining + leaving
+            tags), NOT a whole-key set replacement; the shared member does NOT
+            churn."
+    (setup!)
+    (let [before (proj/machine-logical-state (snapshot :traffic/light))
+          _      (drive! :traffic/light [:traffic/tick])  ; red→green, walk→dont-walk
+          after  (proj/machine-logical-state (snapshot :traffic/light))
+          {:keys [path-ops]} (diff/project before after)
+          added     (->> path-ops (filter (fn [[_ v]] (= :added (:op v)))) (map first))
+          removed   (->> path-ops (filter (fn [[_ v]] (= :removed (:op v)))) (map first))
+          member-of (fn [tag paths] (some (fn [p] (= tag (last p))) paths))]
+      (is (member-of :traffic/vehicle-go added)
+          "(c) the joining tag renders as a member-level :added (rf2-l0us2)")
+      (is (member-of :traffic/vehicle-stop removed)
+          "(c) the leaving tag renders as a member-level :removed")
+      (is (not (member-of :traffic/shared added))
+          "(c) the constant :traffic/shared member does NOT churn (no spurious add)")
+      (is (not (member-of :traffic/shared removed))
+          "(c) the constant :traffic/shared member does NOT churn (no spurious remove)"))))
+
+(deftest multiple-machines-one-cascade-no-op-names-its-machine
+  (testing "rung #11 (rf2-iu3no) — when >1 machine is in play in one cascade,
+            a no-op row NAMES its machine (the single-machine case drops it).
+            Capture an unhandled no-op on TWO machines in one trace window
+            (door in :alarming + brew in :idle, both unhandled) and assert
+            BOTH no-op rows carry :show-machine-name? true + their machine-id
+            — the multi-machine 'in play' branch of the projection."
+    (setup!)
+    ;; get the door into :alarming first (so :door/insert-coin is unhandled).
+    (rf/dispatch-sync [:door/main [:door/insert-coin]])
+    (rf/dispatch-sync [:door/main [:door/push]])
+    (rf/dispatch-sync [:door/main [:door/trip]])         ; → :alarming
+    ;; capture two machines' unhandled no-ops in one window → 2 distinct
+    ;; machine-ids in play, so each no-op row names its machine (rf2-iu3no).
+    (trace-collector/reset-for-test!)
+    (rf/dispatch-sync [:door/main [:door/insert-coin]])  ; door no-op in :alarming
+    (rf/dispatch-sync [:brew/machine [:brew/abort]])      ; brew no-op in :idle
+    (let [rows   (proj/machine-cascade-rows (vec (trace-collector/buffer-for-test)))
+          no-ops (rows-of-kind rows :no-op)
+          ids    (set (map :machine-id no-ops))]
+      (is (= 2 (count no-ops)) "(b) both machines' unhandled events are no-ops")
+      (is (= #{:door/main :brew/machine} ids) "(c) two distinct machines in play")
+      (is (every? #(true? (:show-machine-name? %)) no-ops)
+          "(c) >1 machine in play → EACH no-op row names its machine (rf2-iu3no)"))))
+
+;; ============================================================================
+;; QUIZ (MICROSTEP) — :always EVENTLESS microsteps (gap 1, THE biggest)
+;; ============================================================================
+
+(deftest quiz-answer-below-mark-settles-zero-microsteps
+  (testing "rung #12 — an :answer below the pass mark bumps :score; the
+            guarded :always does NOT fire. (a) the transition row's
+            :microsteps is 0 / nil; (c) the quiz stays :asking."
+    (setup!)
+    (let [record (drive! :quiz/scorer [:quiz/answer])
+          tx     (first (rows-of-kind (cascade record) :transition))]
+      (is (some? tx) "(c) the :answer action transition row renders")
+      (is (contains? #{0 nil} (:microsteps tx))
+          "(a) below the mark → ZERO microsteps (the :always guard failed)")
+      (is (= :asking (:state (snapshot :quiz/scorer))))
+      (is (= 1 (get-in (snapshot :quiz/scorer) [:data :score]))))))
+
+(deftest quiz-answer-to-pass-fires-always-microstep-cascade
+  (testing "rung #13 (gap 1) — answers reach the pass mark and the guarded
+            :always chain SETTLES :asking ──► :passed over N>0 microsteps.
+            (a) the transition row's :microsteps > 0 AND the structured
+            :cascade carries a :microstep step whose nested :steps explain the
+            eventless transition (the :award action → :passed); (c) the quiz
+            lands in :passed; the trail records the :always action."
+    (setup!)
+    (drive! :quiz/scorer [:quiz/answer])                ; score → 1
+    (drive! :quiz/scorer [:quiz/answer])                ; score → 2
+    ;; the THIRD answer reaches the mark (>=3) and the :always fires.
+    (let [record     (drive! :quiz/scorer [:quiz/answer])
+          rows       (cascade record)
+          tx         (first (rows-of-kind rows :transition))
+          structured (structured-of record)
+          microsteps (proj/cascade-microsteps structured)
+          microstep  (first microsteps)]
+      ;; (a) the macrostep settled over at least one eventless microstep.
+      (is (and (number? (:microsteps tx)) (pos? (:microsteps tx)))
+          "(a) :always settled over N>0 microsteps (Xray renders 'N microstep(s)')")
+      (is (seq microsteps)
+          "(a) the structured :cascade carries a :microstep step (n9f4z/52u5n)")
+      (is (= :asking (:from microstep)))
+      (is (= :passed (:to microstep))
+          "(a) the microstep transitions :asking → :passed")
+      (is (some #(= :award (:action %)) (:steps microstep))
+          "(a) the eventless transition's :award action is EXPLAINABLE inside the microstep")
+      (is (pos? (proj/cascade-step-count structured))
+          "(c) the structured step count includes the microstep's nested steps")
+      ;; (c) the live machine settled.
+      (is (= :passed (:state (snapshot :quiz/scorer))))
+      (is (true? (get-in (snapshot :quiz/scorer) [:data :passed?]))
+          "(c) the :always :award action ran")
+      (is (= :always:passed (last (trail :quiz/scorer)))
+          "(a) the trail oracle records the :always action LAST"))))
+
+;; ============================================================================
+;; BREW (TIMER) — :after delayed transition + cancellation (gap 2)
+;; ============================================================================
+
+(deftest brew-after-timer-schedules-then-auto-fires
+  (testing "rungs #14/#15 (gap 2) — entering :brewing SCHEDULES an :after
+            timer; the synthetic :after-elapsed AUTO-FIRES it. (a) the
+            scheduled trace fires on entry; (c) the timer firing transitions
+            :brewing ──► :ready."
+    (setup!)
+    ;; #14 — start: enter :brewing, schedule the timer.
+    (let [record (drive! :brew/machine [:brew/start])]
+      (is (= :brewing (:state (snapshot :brew/machine))))
+      (is (some #(= :rf.machine.timer/scheduled (:operation %)) (:trace-events record))
+          "(a) entering :brewing scheduled the :after timer"))
+    ;; #15 — let the timer elapse (synthetic, deterministic).
+    (let [epoch  (get-in (snapshot :brew/machine) [:data :rf/after-epoch [:brewing]])
+          record (drive! :brew/machine [:rf.machine.timer/after-elapsed 5000 epoch [:brewing]])
+          tx     (first (rows-of-kind (cascade record) :transition))]
+      (is (some? tx) "(c) the timer firing renders a transition row")
+      (is (= :ready (:state (snapshot :brew/machine)))
+          "(c) the :after timer transitioned :brewing → :ready"))))
+
+(deftest brew-exit-before-fire-cancels-the-timer
+  (testing "rung #16 (gap 2) — exiting :brewing via :brew/abort BEFORE the
+            timer fires CANCELS the pending timer. (c) the cascade carries a
+            :timer row with :reason :on-exit (the :cancelled chip's data); the
+            machine returns to :idle."
+    (setup!)
+    (drive! :brew/machine [:brew/start])                ; enter :brewing (schedule)
+    (let [record (drive! :brew/machine [:brew/abort])    ; exit before fire
+          rows   (cascade record)
+          timer  (first (rows-of-kind rows :timer))]
+      (is (some? timer) "(c) a :timer cascade row renders for the cancellation")
+      (is (= :on-exit (:reason timer))
+          "(c) the cancellation :reason is :on-exit (exit beat the timer)")
+      (is (= "cancelled (on-exit)" (fmt/cascade-outcome-label timer))
+          "(c) the :cancelled chip renders the reason"))
+    (is (= :idle (:state (snapshot :brew/machine))))))
+
+;; ============================================================================
+;; SESSION (LIFECYCLE) — spawn · child :final · :on-done · destroy (gaps 3,4,5)
+;; ============================================================================
+
+(deftest session-open-spawns-child-actor
+  (testing "rung #17 (gap 4) — :idle ──► :authenticating SPAWNS the
+            :session/login child. (a) the spawn fx fires (the
+            :rf.machine.spawn/spawned trace); (c) the runtime spawn-registry
+            slot binds the child's deterministic actor id."
+    (setup!)
+    (let [record (drive! :session/flow [:session/open])]
+      (is (= :authenticating (:state (snapshot :session/flow))))
+      (is (some #(= :rf.machine.spawn/spawned (:operation %)) (:trace-events record))
+          "(a) the spawn fx emitted :rf.machine.spawn/spawned")
+      (is (some? (get-in (rf/app-db-value :rf/default)
+                         [:rf/runtime :machines :spawned :session/flow [:authenticating]]))
+          "(c) the spawn-registry slot binds the child actor id"))))
+
+(deftest session-child-final-fires-on-done-and-auto-destroys
+  (testing "rungs #17→#18 (gaps 3,4,5) — driving the spawned child to its
+            :final? state fires the parent's :on-done (reporting the token)
+            and AUTO-DESTROYS the child. (a) the :rf.machine/destroyed trace
+            fires with :reason :rf.machine/finished; (c) the parent's
+            :data :session-token carries the child's :output-key; the child's
+            snapshot is cleared."
+    (setup!)
+    (drive! :session/flow [:session/open])              ; spawn child
+    (let [child-id (get-in (rf/app-db-value :rf/default)
+                           [:rf/runtime :machines :spawned :session/flow [:authenticating]])
+          record   (drive! child-id [:succeed :session/token-abc])
+          dests    (filterv #(= :rf.machine/destroyed (:operation %)) (:trace-events record))]
+      (is (some #(= :rf.machine/finished (-> % :tags :reason)) dests)
+          "(a) the child auto-destroyed with :reason :rf.machine/finished")
+      (is (= :session/token-abc
+             (get-in (snapshot :session/flow) [:data :session-token]))
+          "(c) the parent's :on-done reported the child's :output-key token")
+      (is (= :action:on-done (last (trail :session/flow)))
+          "(a) the :on-done callback ran on the parent (trail records it)")
+      (is (nil? (snapshot child-id))
+          "(c) the child's snapshot was synchronously dissoc'd (auto-destroy)"))))
+
+;; ============================================================================
+;; FUSE (WILDCARD-THROW) — :* action THROWS (gap b: the unasserted outcome)
+;; ============================================================================
+
+(deftest fuse-wildcard-action-throw-renders-as-error-not-no-op
+  (testing "rung #19 (rf2-hhkbb gap b) — a :* wildcard whose action THROWS is
+            a REAL machine-action exception, NOT a benign no-op. (b) the
+            cascade's action row carries :threw? true + an :exception (the
+            Xray-surface analogue of cascade-summary :outcome :error — the
+            slot rf2-hhkbb found unasserted); (b) NO :no-op row (a throw is
+            never a no-op — the contrast with the door's benign no-op)."
+    (setup!)
+    ;; lazy-bootstrap the fuse (the deck deliberately doesn't boot it).
+    (let [record (drive! :fuse/box [:fuse/short-circuit])
+          rows   (cascade record)
+          thrown (filterv :threw? (rows-of-kind rows :action))
+          err-ops (filterv #(= :rf.error/machine-action-exception (:operation %))
+                           (:trace-events record))]
+      (is (seq err-ops)
+          "(b) a :rf.error/machine-action-exception rode the trace stream")
+      (is (seq thrown)
+          "(b) the cascade action row is marked :threw? true (NOT silently green)")
+      (is (some? (:exception (first thrown)))
+          "(b) the thrown action carries its :exception for the EXCEPTION card")
+      (is (empty? (rows-of-kind rows :no-op))
+          "(b) a thrown :* action is NEVER a no-op — the foil to the benign no-op"))))
+
+;; ============================================================================
+;; HVAC (DEEP-COMPOUND) — the LCA + self-transition headline (subsumes k08ay)
+;; ============================================================================
+
+(deftest hvac-power-cycle-renders-deep-parallel-initial-cascade
+  (testing "rung #20 — :hvac/power-cycle broadcasts to BOTH regions; :climate
+            descends its full initial cascade to [:running :conditioning
+            :heating]. (a) the structured :cascade is a per-region parallel
+            walk; (c) the committed snapshot moved both regions."
+    (setup!)
+    (let [record     (drive! :hvac/controller [:hvac/power-cycle])
+          structured (structured-of record)
+          regions    (proj/cascade-regions structured)]
+      (is (proj/parallel-cascade? structured) "(a) the cascade carries both regions")
+      (is (= [:climate :fan] (mapv :region regions)) "(a) regions in declaration order")
+      (is (= {:climate [:running :conditioning :heating] :fan :on}
+             (:state (snapshot :hvac/controller)))
+          "(c) both regions moved in one macrostep (deep initial cascade)"))))
+
+(deftest hvac-mode-toggle-renders-lca-cascade-order
+  (testing "rung #21 — :hvac/mode-toggle crosses the :conditioning LCA. (a)
+            the trail delta is exactly exit:heating → action:swap-mode →
+            entry:cooling (the LCA cascade order, the LCA itself stays
+            active); (c) the deep compound leaf moved heating → cooling."
+    (setup!)
+    (drive! :hvac/controller [:hvac/power-cycle])       ; → :heating
+    (let [before (count (trail :hvac/controller))
+          _      (drive! :hvac/controller [:hvac/mode-toggle])
+          delta  (vec (drop before (trail :hvac/controller)))]
+      (is (= [:exit:heating :action:swap-mode :entry:cooling] delta)
+          "(a) the LCA cascade order: deepest-exit → action @ LCA → new-leaf-entry"))
+    (is (= [:running :conditioning :cooling] (:climate (:state (snapshot :hvac/controller)))))))
+
+(deftest hvac-self-transitions-external-vs-internal
+  (testing "rungs #22/#23 — EXTERNAL self-transition (:hvac/nudge) fires
+            exit+action+entry; INTERNAL (:hvac/tweak) fires action-only.
+            (a) the trail deltas distinguish them; (c) neither emits a
+            spurious no-op transition row; both stay :fan :on."
+    (setup!)
+    (drive! :hvac/controller [:hvac/power-cycle])       ; fan → :on
+    ;; #22 — external self-transition.
+    (let [before (count (trail :hvac/controller))
+          rows   (cascade (drive! :hvac/controller [:hvac/nudge]))
+          delta  (vec (drop before (trail :hvac/controller)))]
+      (is (= [:exit:fan-on :action:nudge :entry:fan-on] delta)
+          "(a) external self-transition: exit → action → entry")
+      (is (empty? (rows-of-kind rows :no-op))
+          "(c) a genuine self-transition is NOT a no-op")
+      (is (= 1 (count (rows-of-kind rows :transition)))
+          "(c) one real transition row (e6q97: not suppressed)"))
+    ;; #23 — internal self-transition (the foil).
+    (let [before (count (trail :hvac/controller))
+          rows   (cascade (drive! :hvac/controller [:hvac/tweak]))
+          delta  (vec (drop before (trail :hvac/controller)))]
+      (is (= [:action:tweak] delta) "(a) internal self-transition: action ONLY")
+      (is (empty? (filterv #(and (= :action (:kind %)) (= :exit (:phase %))) rows))
+          "(c) internal self-transition fires NO exit row")
+      (is (empty? (rows-of-kind rows :no-op))
+          "(c) internal self-transition is a REAL transition, not a no-op"))
+    (is (= :on (:fan (:state (snapshot :hvac/controller)))))))
+
+;; ============================================================================
+;; HISTORY (gap 8, SOON) — the rejection probe + the ready placeholders
+;; ============================================================================
+
+(deftest history-machine-registration-is-rejected-now
+  (testing "rung #24 (gap 8) — re-frame2 currently REJECTS :history at
+            registration. reg-machine of a :type :history machine THROWS
+            :rf.error/machine-grammar-not-in-v1 (Spec 005 §Substitutes;
+            rf2-rkkag). The deck's history-rejected? helper confirms it. When
+            the feature ships this flips RED and the placeholder rungs (#25/
+            #26) activate."
+    (let [thrown (try
+                   (rf/reg-machine :machine-epochs/history-probe
+                                   machines/history-machine-spec)
+                   nil
+                   (catch :default e e))]
+      (is (some? thrown) "registering a :history machine THROWS today")
+      (is (= :rf.error/machine-grammar-not-in-v1
+             (:rf.error/id (ex-data thrown)))
+          "the throw is the deferred-grammar error (not a generic validator fail)")
+      (is (= :history (:feature (ex-data thrown)))
+          ":feature names the offending key"))
+    (is (true? (machines/history-rejected?))
+        "the deck's history-rejected? helper agrees the contract still rejects")))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -2941,6 +2941,9 @@ async function readMachineStrip(page) {
       stripText: (strip.textContent || '').replace(/\s+/g, ' ').trim(),
       doorState: text('machine-epochs-door-state'),
       trafficState: text('machine-epochs-traffic-state'),
+      quizState: text('machine-epochs-quiz-state'),
+      brewState: text('machine-epochs-brew-state'),
+      sessionState: text('machine-epochs-session-state'),
       hvacState: text('machine-epochs-hvac-state'),
       hvacTrail: text('machine-epochs-hvac-trail'),
     };
@@ -2948,129 +2951,202 @@ async function readMachineStrip(page) {
 }
 
 async function runMachineEpochs(page, state) {
-  // The deck's `run` bootstraps both machines, so the status strip is
-  // populated immediately. Assert the door booted to :locked before
-  // driving the ladder.
+  // The deck's `run` bootstraps every machine, so the status strip is
+  // populated immediately. Assert the door booted to :locked before driving
+  // the ladder. Each rung's machine FEATURE is asserted off the deck's own
+  // snapshot mirror (the status strip reads `[:rf/machine <id>]` after each
+  // cascade); the deep RENDER-FIDELITY assertions (cascade kinds/order,
+  // microsteps, timer-cancel, spawn/destroy, set-diff, throw-as-error) live
+  // in the CLJS unit test
+  // `panels.epoch.machine-epochs-harness-cljs-test` per the Causa/Story-as-
+  // CLJS rule. Here we confirm each rung lands the expected configuration
+  // WITHOUT contradiction (the browser-side legibility sanity check) and the
+  // Machine Inspector mounts on a focused machine event.
   await waitForValue(
     () => readMachineStrip(page),
     (snap) => snap.mounted && /:door\/main state: :locked/.test(snap.stripText || ''),
     { timeoutMs: 10000, description: 'machine-epochs door machine boots to :locked' },
   );
 
-  // ---- #1 start machine — bootstrap re-fires; door stays :locked.
+  // ===== Door (FLAT) =====================================================
+  // #1 start machine — bootstrap re-fires; door stays :locked.
   await clickMachineRung(page, 1);
 
-  // ---- #2 plain transition — :locked ──► :closed (insert-coin).
+  // #2 plain transition — :locked -> :closed.
   await clickMachineRung(page, 2);
   await waitForValue(
     () => readMachineStrip(page),
     (snap) => /:door\/main state: :closed/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#2 insert-coin → door :closed' },
+    { timeoutMs: 10000, description: '#2 insert-coin -> door :closed' },
   );
 
-  // ---- #3 entry + exit actions — :closed ──► :open; :open's :entry
-  //      (:count-open) bumps :opened-count to 1.
+  // #3 entry + exit actions — :closed -> :open; :open's :entry bumps
+  //    :opened-count to 1.
   await clickMachineRung(page, 3);
   await waitForValue(
     () => readMachineStrip(page),
     (snap) =>
       /:door\/main state: :open/.test(snap.stripText || '') &&
       /:opened-count 1/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#3 push → door :open + :opened-count 1 (entry action ran)' },
+    { timeoutMs: 10000, description: '#3 push -> door :open + :opened-count 1' },
   );
 
-  // ---- #4 guard ALLOWED — :open ──► :closed (:may-close? passes; not held).
+  // #4 guard ALLOWED — :open -> :closed.
   await clickMachineRung(page, 4);
   await waitForValue(
     () => readMachineStrip(page),
     (snap) => /:door\/main state: :closed/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#4 close → guard allowed, door :closed' },
+    { timeoutMs: 10000, description: '#4 close -> guard allowed, door :closed' },
   );
 
-  // ---- #5 guard BLOCKED — re-open, arm :held-open?, attempt close. The
-  //      :may-close? guard FAILS, so the door STAYS :open and the hold
-  //      flag remains set (no :on branch matched, nothing advanced).
+  // #5 guard BLOCKED — re-open, arm :held-open?, attempt close. Guard FAILS,
+  //    door STAYS :open + the hold flag remains set.
   await clickMachineRung(page, 5);
   const afterBlocked = await waitForValue(
     () => readMachineStrip(page),
     (snap) =>
       /:door\/main state: :open/.test(snap.stripText || '') &&
       /:held-open\? true/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#5 reopen-hold-close → guard blocked, door STAYS :open + :held-open? true' },
+    { timeoutMs: 10000, description: '#5 reopen-hold-close -> guard blocked, door STAYS :open' },
   );
 
-  // ---- #6 transition-with-effect — :open ──► :alarming; :enter-alarm's
-  //      :fx dispatches :alarm-acknowledged (downstream cascade child).
+  // #6 transition-with-effect — :open -> :alarming; :enter-alarm's :fx
+  //    dispatches :alarm-acknowledged.
   await clickMachineRung(page, 6);
   await waitForValue(
     () => readMachineStrip(page),
     (snap) => /:door\/main state: :alarming/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#6 trip → door :alarming (transition-with-effect)' },
+    { timeoutMs: 10000, description: '#6 trip -> door :alarming' },
   );
 
-  // ---- #7 unhandled → benign no-op (rf2-ugdas) — insert-coin into
-  //      :alarming has no :on entry, so the event resolves to a BENIGN
-  //      no-op (xstate-v5 parity) and the door STAYS :alarming.
+  // #7 unhandled -> benign no-op — insert-coin into :alarming has no :on
+  //    entry; the door STAYS :alarming.
   await clickMachineRung(page, 7);
   await waitForValue(
     () => readMachineStrip(page),
     (snap) => /:door\/main state: :alarming/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#7 insert-coin into :alarming → benign no-op, door STAYS :alarming' },
+    { timeoutMs: 10000, description: '#7 insert-coin into :alarming -> benign no-op' },
   );
 
-  // ---- #8 parallel regions — one :traffic/tick broadcasts to BOTH the
-  //      :vehicle (red ──► green) and :pedestrian (walk ──► dont-walk)
-  //      regions; the snapshot's :state is a region-map carrying both.
+  // #8 ROOT :on fallthrough (gap 6) — :alarming has no :door/audit; the
+  //    machine ROOT :on handles it -> :alarming -> :locked.
   await clickMachineRung(page, 8);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:door\/main state: :locked/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#8 audit -> root :on fallthrough -> door :locked' },
+  );
+
+  // ===== Traffic (PARALLEL) =============================================
+  // #9 parallel regions — one tick broadcasts to BOTH regions.
+  await clickMachineRung(page, 9);
   const afterParallel = await waitForValue(
     () => readMachineStrip(page),
     (snap) => {
       const t = snap.stripText || '';
       return /:vehicle :green/.test(t) && /:pedestrian :dont-walk/.test(t);
     },
-    { timeoutMs: 10000, description: '#8 tick → BOTH regions advanced (vehicle :green + pedestrian :dont-walk)' },
+    { timeoutMs: 10000, description: '#9 tick -> BOTH regions advanced (vehicle :green + pedestrian :dont-walk)' },
   );
 
-  // ---- #9 transition history — a second tick advances both regions again
-  //      (vehicle :green ──► :amber, pedestrian :dont-walk ──► :walk).
-  await clickMachineRung(page, 9);
+  // #10 history ribbon — a second tick advances both regions again; the
+  //     :tags member swap (gap 7) is asserted in the CLJS harness.
+  await clickMachineRung(page, 10);
   await waitForValue(
     () => readMachineStrip(page),
     (snap) => {
       const t = snap.stripText || '';
       return /:vehicle :amber/.test(t) && /:pedestrian :walk/.test(t);
     },
-    { timeoutMs: 10000, description: '#9 second tick → vehicle :amber + pedestrian :walk' },
+    { timeoutMs: 10000, description: '#10 second tick -> vehicle :amber + pedestrian :walk' },
   );
 
-  // ---- #10 multiple machines — one cascade sends to BOTH machines: the
-  //      door resets to :locked AND the traffic vehicle region advances
-  //      (:amber ──► :red).
-  await clickMachineRung(page, 10);
+  // #11 multiple machines — one cascade resets the door AND ticks traffic.
+  await clickMachineRung(page, 11);
   const afterMulti = await waitForValue(
     () => readMachineStrip(page),
     (snap) => {
       const t = snap.stripText || '';
       return /:door\/main state: :locked/.test(t) && /:vehicle :red/.test(t);
     },
-    { timeoutMs: 10000, description: '#10 reset door + tick traffic → door :locked + vehicle :red (two machines, one cascade)' },
+    { timeoutMs: 10000, description: '#11 reset door + tick traffic -> door :locked + vehicle :red' },
   );
 
-  // ---- rf2-k08ay — the HARD machine (:hvac/controller) rungs #12–#15.
-  //      Each rung's render fact is asserted off the deck's own snapshot
-  //      mirror (the status strip reads `[:rf/machine :hvac/controller]`).
-  //      The deep RENDERING-FIDELITY assertions (cascade order, exit/entry
-  //      vs action-only, no spurious no-op row, member-level set diff) live
-  //      in the CLJS unit test `panels.epoch.hard-machine-fidelity-cljs-test`
-  //      per the Causa/Story-as-CLJS rule; here we confirm the hard
-  //      machine's key rungs land the expected configuration WITHOUT
-  //      contradiction (the browser-side legibility sanity check).
-
-  // ---- #12 parallel broadcast — ONE :hvac/power-cycle moves BOTH regions:
-  //      :climate :idle ──► [:running :conditioning :heating] (deep initial
-  //      cascade) AND :fan :off ──► :on. The snapshot's :state is a region
-  //      map carrying both.
+  // ===== Quiz (MICROSTEP — :always eventless settle, gap 1) =============
+  // #12 answer below the mark — score climbs, quiz STAYS :asking (0
+  //     microsteps).
   await clickMachineRung(page, 12);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:quiz\/scorer state: :asking/.test(snap.stripText || '') &&
+              /:score 1/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#12 answer -> :score 1, quiz STAYS :asking (0 microsteps)' },
+  );
+
+  // #13 answer to the pass mark — the guarded :always chain SETTLES the
+  //     quiz :asking -> :passed over N>0 microsteps (THE biggest gap).
+  await clickMachineRung(page, 13);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:quiz\/scorer state: :passed/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#13 answer to mark -> :always settles quiz :asking -> :passed (microsteps > 0)' },
+  );
+
+  // ===== Brew (TIMER — :after + cancel, gap 2) ==========================
+  // #14 start brew — schedules the :after timer; brew enters :brewing.
+  await clickMachineRung(page, 14);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:brew\/machine state: :brewing/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#14 start -> :brewing (:after timer scheduled)' },
+  );
+
+  // #15 let the :after timer elapse — auto-fires :brewing -> :ready.
+  await clickMachineRung(page, 15);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:brew\/machine state: :ready/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#15 :after-elapsed -> :brewing -> :ready (auto-fire)' },
+  );
+
+  // #16 re-start then CANCEL — exit beats the timer -> :rf.machine.timer/
+  //     cancelled (:on-exit); brew returns to :idle.
+  await clickMachineRung(page, 16);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:brew\/machine state: :idle/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#16 start+abort -> :after timer cancelled (:on-exit), brew :idle' },
+  );
+
+  // ===== Session (LIFECYCLE — spawn/final/on-done/destroy, gaps 3,4,5) ==
+  // #17 open session — :idle -> :authenticating SPAWNS the child actor.
+  await clickMachineRung(page, 17);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:session\/flow state: :authenticating/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#17 open -> :authenticating (child :session/login spawned)' },
+  );
+
+  // #18 child succeeds — :final + :on-done reports the token to the parent +
+  //     the child auto-destroys. The strip surfaces the parent's :on-done via
+  //     its trail (:action:on-done appended) — the observable proof the
+  //     callback ran; the reported :session-token (in the parent's :data) +
+  //     the auto-destroy / :rf.machine/finished trace are asserted in the
+  //     CLJS harness.
+  await clickMachineRung(page, 18);
+  await waitForValue(
+    () => readMachineStrip(page),
+    (snap) => /:session\/flow state: :authenticating/.test(snap.stripText || '') &&
+              /:action:on-done/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#18 child :final -> :on-done ran on the parent (trail shows :action:on-done) + child auto-destroyed' },
+  );
+
+  // ===== Fuse (WILDCARD-THROW) — asserted as the throw contrast below ====
+
+  // ===== Hvac (DEEP-COMPOUND) ===========================================
+  // #20 parallel broadcast — ONE :hvac/power-cycle moves BOTH regions;
+  //     :climate descends its deep initial cascade.
+  await clickMachineRung(page, 20);
   const afterHvacPower = await waitForValue(
     () => readMachineStrip(page),
     (snap) => {
@@ -3078,13 +3154,12 @@ async function runMachineEpochs(page, state) {
       return /:climate \[:running :conditioning :heating\]/.test(t) &&
              /:fan :on/.test(t);
     },
-    { timeoutMs: 10000, description: '#12 power-cycle → BOTH regions moved (climate deep leaf + fan :on)' },
+    { timeoutMs: 10000, description: '#20 power-cycle -> BOTH regions moved (climate deep leaf + fan :on)' },
   );
 
-  // ---- #13 multi-level LCA cascade — :heating ──► :cooling crossing the
-  //      LCA :conditioning. The trail records the cascade ORDER:
-  //      exit :heating → :swap-mode @ LCA → entry :cooling.
-  await clickMachineRung(page, 13);
+  // #21 multi-level LCA cascade — :heating -> :cooling crossing the LCA
+  //     :conditioning; the trail records the cascade ORDER.
+  await clickMachineRung(page, 21);
   await waitForValue(
     () => readMachineStrip(page),
     (snap) => {
@@ -3092,13 +3167,12 @@ async function runMachineEpochs(page, state) {
       return /:climate \[:running :conditioning :cooling\]/.test(t) &&
              /:exit:heating :action:swap-mode :entry:cooling/.test(t);
     },
-    { timeoutMs: 10000, description: '#13 mode-toggle → :cooling + trail shows LCA cascade order (exit→action→entry)' },
+    { timeoutMs: 10000, description: '#21 mode-toggle -> :cooling + trail shows LCA cascade order' },
   );
 
-  // ---- #14 EXTERNAL self-transition (:hvac/nudge, :target :same-state):
-  //      :fan :on re-enters itself — exit → action → entry all fire; the
-  //      configuration stays :on (rf2-46ban / #2843).
-  await clickMachineRung(page, 14);
+  // #22 EXTERNAL self-transition (:hvac/nudge) — exit -> action -> entry; fan
+  //     STAYS :on.
+  await clickMachineRung(page, 22);
   await waitForValue(
     () => readMachineStrip(page),
     (snap) => {
@@ -3106,13 +3180,11 @@ async function runMachineEpochs(page, state) {
       return /:fan :on/.test(t) &&
              /:exit:fan-on :action:nudge :entry:fan-on/.test(t);
     },
-    { timeoutMs: 10000, description: '#14 nudge → external self-transition: trail shows exit→action→entry, fan STAYS :on' },
+    { timeoutMs: 10000, description: '#22 nudge -> external self-transition: trail exit->action->entry, fan STAYS :on' },
   );
 
-  // ---- #15 INTERNAL self-transition (:hvac/tweak, omit :target): action
-  //      ONLY — no exit/entry; the foil to #14. The trail gains exactly
-  //      :action:tweak and nothing else; the configuration stays :on.
-  await clickMachineRung(page, 15);
+  // #23 INTERNAL self-transition (:hvac/tweak) — action ONLY; fan STAYS :on.
+  await clickMachineRung(page, 23);
   const afterHvacTweak = await waitForValue(
     () => readMachineStrip(page),
     (snap) => {
@@ -3120,38 +3192,36 @@ async function runMachineEpochs(page, state) {
       return /:fan :on/.test(t) &&
              /:action:nudge :entry:fan-on :action:tweak/.test(t);
     },
-    { timeoutMs: 10000, description: '#15 tweak → internal self-transition: trail gains :action:tweak ONLY (no exit/entry), fan STAYS :on' },
+    { timeoutMs: 10000, description: '#23 tweak -> internal self-transition: trail gains :action:tweak ONLY, fan STAYS :on' },
   );
 
-  // ---- Xray Machine Inspector handoff. Open Xray, fire one more machine
-  //      transition so the spine has a focused machine event, switch to
-  //      the Machines tab, and confirm the inspector mounts + machine
-  //      activity reached the trace bus. (Per the chart-render gap noted
-  //      above, we assert the panel handoff + trace activity, not the
-  //      synthetic-injection chart-render that deep_machine owns.)
+  // ===== History (gap 8 — reject-now) ===================================
+  // #24 register a :history machine — REJECTED today; the deck swallows the
+  //     throw and the door stays put. The rejection shape is asserted in the
+  //     CLJS harness; here we confirm the rung does not crash the deck.
+  await clickMachineRung(page, 24);
+  // #25 / #26 are DISABLED placeholders (history deferred) — not clickable.
+
+  // ===== Xray Machine Inspector handoff + the throw/no-op contrast ======
   await openXray(page);
 
-  // ---- rf2-4yrr6 — :fuse/box must NOT throw on boot. The reset handler
-  //      DELIBERATELY does not dispatch `[:fuse/box [:rf.machine/bootstrap]]`
-  //      (that inner event would hit the throwing `:*` wildcard ON BOOT). The
-  //      full trace buffer at this point holds the boot cascade + rungs 1-10
-  //      (none of which should throw) — assert no `:rf.error/machine-action-
-  //      exception` is present yet. Button 11 (clicked below) is the SOLE
-  //      trigger; that throw is asserted as the contrast at the end.
+  // rf2-4yrr6 — :fuse/box must NOT throw on boot / rungs 1-24. The reset
+  // handler DELIBERATELY does not bootstrap :fuse/box; rung 19 (clicked
+  // below) is the SOLE machine-action-exception trigger.
   {
     const bootTrace = await readTrace(page);
     const bootThrow = bootTrace.filter((e) =>
       /:rf\.error\/machine-action-exception/.test(e));
     if (bootThrow.length > 0) {
       failWithDetails(
-        'rf2-4yrr6 — :fuse/box (or another machine) threw on boot / rungs 1-10; '
-        + 'Button 11 must be the sole machine-action-exception trigger',
+        'rf2-4yrr6 — a machine threw on boot / rungs 1-24; rung 19 must be the '
+        + 'sole machine-action-exception trigger',
         { machineActionExceptions: bootThrow });
     }
   }
 
   await clearTrace(page);
-  await clickMachineRung(page, 2); // :locked ──► :closed — a fresh transition
+  await clickMachineRung(page, 2); // :locked -> :closed — a fresh transition
   await waitForTraceMatch(
     page,
     /:rf\.machine\/transition|:rf\.machine\/guard-evaluated|:door\/main/,
@@ -3161,36 +3231,36 @@ async function runMachineEpochs(page, state) {
   await expectVisible(
     page.locator('[data-testid="rf-xray-machine-inspector"]'), 5000);
 
-  // ---- rf2-ugdas / rf2-e7yhv — the xstate-v5 unhandled-event CONTRAST.
-  //      #7 (unhandled event → benign no-op) emits the benign
-  //      :rf.machine.event/unhandled-no-op trace; #11 (a :* wildcard whose
-  //      action throws) emits the REAL :rf.error/machine-action-exception.
-  //      The Trace panel shows both; the trace stream is the robust,
-  //      non-flaky proof (the inverse pink-wash / epoch-render assertions
-  //      live in the CLJS unit tests, per the Causa/Story-as-CLJS rule).
+  // rf2-ugdas / rf2-e7yhv — the xstate-v5 unhandled-event CONTRAST.
+  // #7 (unhandled event -> benign no-op) emits the benign
+  // :rf.machine.event/unhandled-no-op trace; #19 (a :* wildcard whose action
+  // throws) emits the REAL :rf.error/machine-action-exception. The Trace
+  // panel shows both; the inverse pink-wash / epoch-render assertions live in
+  // the CLJS harness.
   await clickTab(page, 'trace', 'rf-xray-trace');
   await clearTrace(page);
-  await clickMachineRung(page, 7); // unhandled → benign no-op
+  await clickMachineRung(page, 7); // unhandled -> benign no-op
   await waitForTraceMatch(
     page,
     /:rf\.machine\.event\/unhandled-no-op/,
     '#7 unhandled event emits the benign :rf.machine.event/unhandled-no-op trace',
   );
   await clearTrace(page);
-  await clickMachineRung(page, 11); // :* wildcard action THROWS
+  await clickMachineRung(page, 19); // :* wildcard action THROWS
   await waitForTraceMatch(
     page,
     /:rf\.error\/machine-action-exception|unhandled machine event/,
-    '#11 :* wildcard-action throw emits :rf.error/machine-action-exception',
+    '#19 :* wildcard-action throw emits :rf.error/machine-action-exception',
   );
 
   state.machineEpochs = {
     blocked: { doorState: afterBlocked.doorState },
     parallel: { trafficState: afterParallel.trafficState },
     multi: { doorState: afterMulti.doorState, trafficState: afterMulti.trafficState },
-    // rf2-k08ay — the hard machine's landed configuration after the
-    // power-cycle (#12) and the internal self-transition (#15).
-    hard: { powerState: afterHvacPower.hvacState, tweakTrail: afterHvacTweak.hvacTrail },
+    // rf2-g27vv — the redesigned matrix: the microstep / timer / lifecycle
+    // rungs' landed configuration plus the hard machine's.
+    quiz:    { quizState: (await readMachineStrip(page)).quizState },
+    hard:    { powerState: afterHvacPower.hvacState, tweakState: afterHvacTweak.hvacState },
     inspectorMounted: true,
   };
 }
@@ -3370,18 +3440,24 @@ const SCENARIOS = [
     run: runRoutesEpochs,
   },
   {
-    // rf2-w06op — machine-epochs state-machine step-up deck. Drives the
-    // real `reg-machine` + machine-event-routing surface and asserts each
-    // rung's machine FEATURE landed via the host's snapshot mirror: plain
-    // transition · entry/exit data delta · guard ALLOWED vs BLOCKED ·
-    // transition-with-effect · IGNORED event · parallel-region broadcast ·
-    // transition history · multiple machines in one cascade. Then opens
-    // the Xray Machine Inspector (`rf-xray-machine-inspector`) and confirms
-    // the panel mounts on a focused machine event + machine activity
-    // reaches the trace bus. Real Machine-Inspector coverage for the deck
-    // the `Machines` matrix row names (the chart-render shim-survival probe
-    // stays owned by the `deep machine inspector substrate` scenario).
-    name: 'machine-epochs machine ladder (start, transitions, guards allowed/blocked, entry/exit, effect, ignored, parallel, multiple machines, + the HARD machine: deep compound, LCA cascade, internal/external self-transitions)',
+    // rf2-w06op + rf2-g27vv — machine-epochs assertion-backed render harness.
+    // Drives the real `reg-machine` + machine-event-routing surface for the
+    // FULL feature x Xray-cascade-render matrix and asserts each rung's
+    // machine FEATURE landed via the host's snapshot mirror: door (plain ·
+    // entry/exit · guards allowed/blocked · internal · effect · unhandled
+    // no-op · root-:on RESOLUTION), traffic (parallel regions · history ·
+    // tag-set member swap), quiz (:always MICROSTEPS), brew (:after TIMER +
+    // cancel), session (SPAWN · child :final · :on-done · DESTROY), fuse (:*
+    // wildcard THROW), hvac (deep compound · LCA cascade · self-transitions),
+    // history (reject-now). Then opens the Xray Machine Inspector
+    // (`rf-xray-machine-inspector`) and confirms the panel mounts on a
+    // focused machine event + the no-op/throw trace contrast. The deep
+    // RENDER-FIDELITY assertions (cascade kinds/order, microsteps, timer-
+    // cancel, spawn/destroy, set-diff, throw-as-error) live in the CLJS unit
+    // test `panels.epoch.machine-epochs-harness-cljs-test` per the Causa/
+    // Story-as-CLJS rule (the chart-render shim-survival probe stays owned by
+    // the `deep machine inspector substrate` scenario).
+    name: 'machine-epochs machine ladder (rf2-g27vv full feature x render matrix: start/transition/entry-exit/guards/internal/effect/unhandled-no-op/root-:on RESOLUTION; parallel regions + history + TAG-SET delta; :always MICROSTEPS; :after TIMER + cancel; SPAWN/:final/:on-done/DESTROY lifecycle; :* wildcard THROW; deep-compound LCA + self-transitions; :history reject-now)',
     url: '/testbeds/machine-epochs/',
     panels: ['machines'],
     coveredRows: ['Machines'],

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -1,595 +1,154 @@
 (ns machine-epochs.core
-  "MACHINE-EPOCHS testbed (rf2-w06op) — the STATE-MACHINE sibling of the
-  `standard_epochs` + `routes_epochs` decks. A deliberately simple Xray
-  driving surface aimed squarely at the **Machine Inspector**
-  (`rf-xray-machine-inspector`).
+  "MACHINE-EPOCHS testbed (rf2-w06op + rf2-g27vv) — the STATE-MACHINE sibling
+  of the `standard_epochs` + `routes_epochs` decks, redesigned (rf2-g27vv)
+  into a COMPREHENSIVE, ASSERTION-BACKED machine × Xray-cascade-render
+  REGRESSION HARNESS aimed squarely at the **Epoch panel's EVENT HANDLER
+  machine cascade** + the **Machine Inspector** (`rf-xray-machine-inspector`).
 
   ## Shape
 
   ONE tall column of NUMBERED buttons, top to bottom — the same shape as
   `standard_epochs` and `routes_epochs`. Beside each button a one-line
-  caption says WHAT TO WATCH in Xray's Machines tab when you press it.
-  Each button is ONE test: it fires one event that
+  caption says WHAT TO WATCH in Xray's Machines tab / Epoch cascade when you
+  press it. Each rung is ONE test: it fires one event that
 
     (a) bumps a shared baseline counter (so App-db / Epoch always show a
         delta on every press), and
-    (b) sends ONE machine event that exercises exactly ONE additional
-        machine feature.
+    (b) sends ONE (or several) machine event(s) that exercise exactly ONE
+        additional machine FEATURE and the Xray cascade-render SURFACE it
+        lights up.
 
-  Progressive: button 1 starts the machine; each later button layers one
-  more machine concept on top. A SINGLE frame, plainly mounted, with the
-  machines artefact booted (`[re-frame.machines]`) and Xray auto-mounting
-  inline on the right (`[data-rf-xray-host]` + the xray preload) reading
-  that one frame. No tabs, no URL machinery, no SSR — just one frame's
-  machines. The static caption is the 'what to look for', and the Machine
-  Inspector itself is the check.
+  ## The redesign — a FEATURE × RENDER-SURFACE matrix (rf2-g27vv)
 
-  ## North star (acceptance)
+  Where the original deck covered the common transition surfaces but MISSED
+  several machine features and asserted nothing, this redesign maps every
+  rung to (machine feature) × (the Xray cascade-render surface it lights
+  up), and EACH RUNG IS BACKED BY A CLJS-UNIT ASSERTION so re-driving the
+  deck is a real regression test of Xray rendering — not just a visual deck.
 
-  Click the buttons top to bottom → the Xray **Machine Inspector** is
-  COMPLETELY exercised. Per `spec/003-Machine-Inspector.md` the Dynamic
-  Machines panel is EVENT-DRIVEN: for the focused event it renders the
-  focused-transition lens (Target instance · TRANSITION from → to ·
-  GUARDS RUN · ACTIONS RUN) above the topology chart (FROM dashed, TO
-  bold), plus the BEFORE/AFTER snapshot drill-in, the transition history
-  ribbon, and the cancellation-cascade block. Each rung below drives ONE
-  transition shaped to light up one of those surfaces.
+  The data-driven `ladder` table below is the SINGLE SOURCE OF TRUTH: the
+  ladder RENDERS from it and the assertion surface
+  (`day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test`)
+  READS the same machine specs (shared via `machine-epochs.machines`) and
+  drives the rung events through the LIVE substrate, asserting BOTH the
+  machine OUTCOME (via the generalized `:trail` order-oracle) AND the Xray
+  cascade-render projection it lights up.
 
-  ## The machine ladder (per-rung Machine-Inspector coverage)
+  ## The generalized `:trail` order-oracle (rf2-g27vv)
 
-    #1  start machine       — the door machine boots to `:locked`; the
-                              Inspector's chart renders the topology and
-                              the live-highlight lands on the initial
-                              state.
-    #2  send event/transition — `:locked ──► :closed` (insert-coin); the
-                              focused-transition lens shows the plain
-                              FROM → TO with no guard / action.
-    #3  entry + exit actions — `:closed ──► :open` runs `:open`'s `:entry`
-                              and `:closed`'s `:exit`; ACTIONS RUN lists
-                              both, and the BEFORE/AFTER `:data` snapshot
-                              shows the `:opened-count` bump.
-    #4  guarded — ALLOWED   — `:open ──► :closed` is guarded by
-                              `:may-close?` which PASSES; GUARDS RUN shows
-                              the guard with outcome pass and the
-                              transition completes.
-    #5  guarded — BLOCKED   — re-`:open` then attempt to close while the
-                              `:held-open?` flag is set: `:may-close?`
-                              FAILS, no `:on` branch matches, the machine
-                              stays in `:open`; GUARDS RUN shows the failed
-                              guard and the state does NOT advance.
-    #6  transition-with-effect — `:open ──► :alarming` whose `:enter-alarm`
-                              action returns `{:fx [[:dispatch ...]]}`; the
-                              lens's ACTIONS RUN shows the `:fx` output and
-                              the downstream `:dispatch` cascade child.
-    #7  unhandled → no-op   — send `:door/insert-coin` to `:alarming`,
-                              which has no matching `:on` entry: an
-                              unhandled event resolves to a BENIGN no-op
-                              (xstate-v5 parity, rf2-ugdas). The Epoch
-                              panel's EVENT HANDLER machine cascade renders
-                              a muted `NO-OP` row naming machine + event +
-                              state (no-op, :door/main received
-                              [:door/insert-coin] in :alarming, no
-                              transition); the event row is NOT pink (the
-                              trace is op-type :rf.machine, benign) — the
-                              foil to rung #11's `:*`-action throw.
-    #8  parallel regions    — a SECOND machine (`:traffic/light`,
-                              `:type :parallel` with `:vehicle` + `:pedestrian`
-                              regions): one event broadcasts to both
-                              regions and the chart highlights every active
-                              region leaf simultaneously.
-    #9  transition history  — drive a short cycle on the traffic machine so
-                              the transition-history ribbon under the chart
-                              accumulates several `state → state` entries.
-    #10 multiple machines   — one event sends to BOTH machines in a single
-                              cascade; the Inspector's instance selection
-                              picks the first transition in trace order and
-                              the spine's prev/next walks between them.
-    #11 :* wildcard THROWS   — a THIRD machine (`:fuse/box`) whose `:*`
-                              wildcard action THROWS (the xstate-v5 idiomatic
-                              'fail loudly on unknown', rf2-e7yhv). Sending it
-                              an otherwise-unhandled event fires the `:*`
-                              action which throws -> a REAL
-                              `:rf.error/machine-action-exception`. The Epoch
-                              panel renders the EXCEPTION card (thrown message
-                              + ex-data + source coord) naming it came from a
-                              `:*` WILDCARD action; the event row IS pink —
-                              the inverse of rung #7's benign no-op. The
-                              contrast validates that the pink-wash /
-                              issue-event? predicate distinguishes a thrown
-                              `:*` action (error) from a benign no-op.
+  Every machine in this deck carries a `:data :trail` vector and every
+  `:entry` / `:exit` / transition `:action` / `:always` action APPENDS one
+  `<phase>:<state>` label to it (built by `machines/trail-action`). So the
+  post-macrostep `:trail` is the cascade ORDER made visible — the same
+  mechanism the HVAC machine pioneered, now GENERALIZED to door / traffic /
+  quiz / brew / session / fuse. The trail is the testable proxy for 'the
+  cascade renders legibly + in the right order'; the harness keys its
+  assertions off it.
 
-  ## The HARD machine (rf2-k08ay) — rungs #12–#15
+  ## The machine set (each a coherent clean domain; collectively the matrix)
 
-  Where rungs #1–#11 each light up ONE Inspector surface, `:hvac/controller`
-  (a smart climate controller — MACHINE 4 below) is the CANONICAL HARD
-  machine: ONE coherent machine exercising every hard STRUCTURAL case so the
-  devtools have a rich, legible subject. It is the COMPLEMENT to the SCXML
-  semantic corpus (rf2-rkkag · #2842) — that proves SEMANTICS, this proves
-  the devtools RENDER them legibly (the gap the no-op render bug, rf2-e6q97
-  · #2841, exposed).
+    - door     (FLAT)            — plain · entry/exit · transition-action ·
+                                   guard pass/fail · internal · fx ·
+                                   unhandled-no-op · root-`:on` fallthrough
+                                   (TRANSITION RESOLUTION, gap 6).
+    - traffic  (PARALLEL-FLAT)   — parallel regions · history ribbon ·
+                                   TAG-SET delta member-swap (gap 7).
+    - quiz     (MICROSTEP, NEW)  — `:always` EVENTLESS microsteps that settle
+                                   over N>0 microsteps (gap 1 — THE biggest).
+    - brew     (TIMER, NEW)      — `:after` DELAYED transition that auto-fires
+                                   + a path that CANCELS a pending timer
+                                   (gap 2 — `:timer` cascade kind + the
+                                   cancellation-cascade block).
+    - session  (LIFECYCLE, NEW)  — SPAWN a child actor → child reaches
+                                   `:final?` firing `:on-done` → auto-DESTROY
+                                   + exit-cascade-on-destroy (gaps 3, 4, 5).
+    - hvac      (DEEP-COMPOUND)  — compound · initial cascade · LCA cascade ·
+                                   internal/external self-transitions.
+    - fuse      (WILDCARD-THROW) — `:*` wildcard action THROWS (exception
+                                   card + pink-wash; the foil to the no-op).
 
-    #12 power-cycle         — PARALLEL regions: ONE event (`:hvac/power-cycle`)
-                              handled by BOTH the `:climate` and `:fan` regions
-                              simultaneously; `:climate` :idle──►:running fans
-                              out a deep INITIAL CASCADE to the leaf
-                              `[:running :conditioning :heating]`.
-    #13 mode-toggle         — DEEP COMPOUND + LCA cascade: `:heating` ──►
-                              `:cooling` crosses the LCA two levels up
-                              (`:conditioning`). The action ORDER renders:
-                              exit deepest-first → action @ LCA → entry
-                              shallowest-first; the `:trail` is that order made
-                              visible.
-    #14 nudge fan           — EXTERNAL self-transition (`:target :same-state`,
-                              rf2-46ban · #2843): `:fan :on` re-enters itself —
-                              exit + action + entry all fire; NO spurious
-                              `{:on}→{:on}` no-op row (rf2-e6q97).
-    #15 tweak fan           — INTERNAL self-transition (omit `:target`): action
-                              ONLY, no exit/entry — the foil to #14. The
-                              devtools render the distinction.
+  ## HISTORY section (gap 8 — SOON)
 
-  ## Test surface, not tutorial
+  re-frame2 currently REJECTS `:history` at registration
+  (`:rf.error/machine-grammar-not-in-v1`, Spec 005 §Substitutes; rf2-rkkag).
+  So the deck is HISTORY-READY: a rung drives the current expected-REJECTION
+  (the harness asserts `reg-machine` of a `:history` machine THROWS the
+  deferred-grammar error), and clearly-marked PLACEHOLDER rungs (disabled
+  buttons) reserve the slots for shallow + deep history RESTORE — when the
+  feature ships, flip the placeholders to live rungs and the harness already
+  has the slots.
 
-  Per `feedback_testbeds_are_test_surfaces`: no deliberate bugs as
-  anti-patterns, no teaching layers. The blocked-guard / ignored-event
-  rungs exercise the REAL machine surface — each is a feature being
-  driven, not a buggy demo. Captions are guidance, not lessons.
+  ## Test surface, not tutorial (feedback_testbeds_are_test_surfaces)
 
-  ## Test-free + self-contained
+  No deliberate bugs as anti-patterns, no teaching layers. Every transition
+  is a clean feature being driven; the trail is instrumentation, not an
+  anti-pattern demo. Captions are guidance, not lessons.
 
-  Per rf2-8cevm this testbed carries no spec.cjs; regression coverage
-  lives in the substrate contract tests + the Xray feature-matrix gate
-  (`tools/xray/testbeds/feature_matrix/scenarios.cjs` — the
-  `machine-epochs machine ladder` scenario). The machines / events / subs
-  / views below are OWNED here — this deck does NOT reuse the deleted
-  `testdeck.*` modules, and the `deep_machine` framework testbed stays the
-  gate's deterministic machine substrate (this deck does not touch it)."
+  ## Test-free + self-contained (rf2-8cevm)
+
+  No `spec.cjs` lives here. Regression coverage lives in the Xray test
+  surface: the CLJS unit test
+  `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test`
+  (each rung's BOTH-layers assertion) + the feature-matrix gate
+  (`tools/xray/testbeds/feature_matrix/scenarios.cjs` — the `machine-epochs
+  machine ladder` scenario). The machine specs live in the sibling ns
+  `machine-epochs.machines`, shared with the harness."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; State-machines artefact — load-time hook so `reg-machine`,
-            ;; the `:rf/machine` / `:rf/machine-has-tag?` framework subs,
-            ;; and the machine-event routing resolve. Without this require
-            ;; `reg-machine` below throws (the machine substrate ships in
-            ;; the day8/re-frame2-machines artefact).
+            ;; the `:rf/machine` framework subs, and machine-event routing
+            ;; resolve.
             [re-frame.machines]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; Xray's `configure!` to seed `:project-root` so the Event /
-            ;; machine source chips resolve a classpath-relative `:file`
-            ;; to an absolute on-disk URI.
             [day8.re-frame2-xray.config :as xray-config]
-            ;; Shared testbed-config helper (rf2-5dphw): derives the
-            ;; open-in-editor project-root from the build env.
-            [re-frame.testbed.config :as testbed-config])
-  (:require-macros [re-frame.core :refer [reg-view defmachine]]))
+            [re-frame.testbed.config :as testbed-config]
+            [machine-epochs.machines :as machines])
+  (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
-;; MACHINE 1 — :door/main  (a flat machine with guards + entry/exit + fx)
+;; MACHINE REGISTRATION
 ;; ============================================================================
 ;;
-;; A small turnstile-ish door. Chosen for per-surface Machine-Inspector
-;; coverage rather than realism:
-;;
-;;   :locked  → :closed  on :door/insert-coin  (plain transition, #2)
-;;   :closed  → :open    on :door/push         (entry + exit actions, #3)
-;;   :open    → :closed  on :door/close        (guarded, #4 allowed / #5 blocked)
-;;   :open    → :alarming on :door/trip        (transition-with-effect, #6)
-;;   :alarming                                 (no :door/insert-coin entry → #7 ignored)
-;;   :alarming → :locked  on :door/reset
-;;
-;; Guards / actions are NAMED entries in the machine's :guards / :actions
-;; maps (inspectability bias, per the nine_states example) so the
-;; focused-transition lens can render each one's id + fn source.
-;;
-;; VALUE-registered via `defmachine` (rf2-gwj8l): the door spec is `def`'d
-;; here and registered by SYMBOL below. `defmachine` (not plain `def`)
-;; stamps per-element source onto the value at the definition site so the
-;; Epoch machine-cascade renders each guard / action's source — plain `def`
-;; would leave `reg-machine` seeing only the symbol with nothing to capture.
+;; The machine SPECS live in `machine-epochs.machines` (a sibling ns) so the
+;; assertion harness can `:require` and register the IDENTICAL specs without
+;; pulling in this deck's Reagent mount. That keeps the testbed's machines
+;; and the harness's machines literally the SAME values — a drift between
+;; "what the operator sees" and "what the test drives" is impossible.
 
-(defmachine door-machine
-  {:initial :locked
-   :data    {:opened-count 0
-             :held-open?   false}
-
-   :guards
-   {:may-close?
-    ;; Button #4 (allowed) vs #5 (blocked). The door refuses to close
-    ;; while it is being :held-open? — so #5 arms the flag, then the
-    ;; close attempt fails the guard and no :on branch matches.
-    (fn guard-may-close? [{data :data}]
-      (not (:held-open? data)))}
-
-   :actions
-   {:count-open
-    ;; #3 — :open's :entry. Bumps a counter in the machine's :data so the
-    ;; BEFORE/AFTER snapshot drill-in shows a value delta.
-    (fn action-count-open [{data :data}]
-      {:data (update data :opened-count (fnil inc 0))})
-
-    :clear-hold
-    ;; #3 — :closed's :exit. Clears the hold flag on the way OUT of
-    ;; :closed so ACTIONS RUN lists an :exit action distinct from the
-    ;; :entry one.
-    (fn action-clear-hold [{data :data}]
-      {:data (assoc data :held-open? false)})
-
-    :hold-open
-    ;; #5 — arms the guard input. Fired by the `:door/hold` INTERNAL
-    ;; transition on :open (an `:on` entry with an `:action` but NO
-    ;; `:target`, per Spec 005's internal-transition contract): it writes
-    ;; `:data` without changing state, so the very next `:door/close`
-    ;; attempt fails `:may-close?` and the close is blocked.
-    (fn action-hold-open [{data :data}]
-      {:data (assoc data :held-open? true)})
-
-    :enter-alarm
-    ;; #6 — transition-with-effect. Returns an effect map, not a :data
-    ;; write: the lens's ACTIONS RUN shows the :fx output and the
-    ;; downstream :dispatch cascade child.
-    (fn action-enter-alarm [_]
-      {:fx [[:dispatch [:machine-epochs/alarm-acknowledged]]]})}
-
-   :states
-   {:locked
-    {:tags #{:door/locked}
-     :on   {:door/insert-coin :closed}}
-
-    :closed
-    ;; :exit runs on the way OUT (#3) — clears the hold flag.
-    {:tags #{:door/closed}
-     :exit :clear-hold
-     :on   {:door/push :open}}
-
-    :open
-    ;; :entry runs on the way IN (#3) — bumps :opened-count. The close
-    ;; transition is GUARDED (#4 allowed / #5 blocked); :door/hold is an
-    ;; INTERNAL transition (action, no :target) that arms the guard input
-    ;; for #5; :door/trip is the transition-with-effect (#6).
-    {:tags  #{:door/open}
-     :entry :count-open
-     :on    {:door/close {:target :closed
-                          :guard  :may-close?}
-             :door/hold  {:action :hold-open}
-             :door/trip  {:target :alarming
-                          :action :enter-alarm}}}
-
-    :alarming
-    ;; No :door/insert-coin entry here — sending it is an IGNORED / no-op
-    ;; transition (#7). :door/reset cycles back to :locked.
-    {:tags #{:door/alarming}
-     :on   {:door/reset :locked}}}})
-
-(rf/reg-machine :door/main door-machine)
+(machines/register-all!)
 
 ;; ============================================================================
-;; MACHINE 2 — :traffic/light  (a parallel machine — #8 / #9 / #10)
-;; ============================================================================
-;;
-;; Two orthogonal regions, one declaration. One event (`:traffic/tick`)
-;; broadcasts to BOTH regions per Spec 005 §Parallel regions, so the
-;; chart highlights every active region leaf simultaneously (#8). Driving
-;; a short cycle accumulates transition-history ribbon entries (#9), and
-;; sending to this machine alongside the door machine in one cascade
-;; exercises the multiple-machines instance-selection rule (#10).
-
-(defmachine traffic-machine
-  {:type :parallel
-
-   :regions
-   {;; ---- :vehicle region — the classic green → amber → red cycle ----
-    :vehicle
-    {:initial :red
-     :states
-     {:red    {:tags #{:traffic/vehicle-stop}
-               :on   {:traffic/tick :green}}
-      :green  {:tags #{:traffic/vehicle-go}
-               :on   {:traffic/tick :amber}}
-      :amber  {:tags #{:traffic/vehicle-slow}
-               :on   {:traffic/tick :red}}}}
-
-    ;; ---- :pedestrian region — walk / dont-walk, ticked by the SAME event ----
-    :pedestrian
-    {:initial :walk
-     :states
-     {:walk     {:tags #{:traffic/ped-walk}
-                 :on   {:traffic/tick :dont-walk}}
-      :dont-walk {:tags #{:traffic/ped-stop}
-                  :on   {:traffic/tick :walk}}}}}})
-
-(rf/reg-machine :traffic/light traffic-machine)
-
-;; ============================================================================
-;; MACHINE 3 — :fuse/box  (a :* wildcard whose action THROWS — #11, rf2-e7yhv)
-;; ============================================================================
-;;
-;; The xstate-v5 idiomatic "fail loudly on unknown": v5 removed the v4
-;; `strict` flag, so an unhandled event is a benign no-op (#7). To opt INTO
-;; throwing on unknown, you add a `:*` wildcard whose action throws. That is
-;; a REAL `:rf.error/machine-action-exception` (recovery :no-recovery) — the
-;; CONTRAST with #7's benign no-op validates that Xray's pink-wash /
-;; `issue-event?` predicate distinguishes a thrown `:*` action (error, pink,
-;; EXCEPTION card) from a benign unhandled-event no-op (NOT pink).
-;;
-;; `:armed` handles `:fuse/inspect` (a plain self-internal action so the
-;; machine has at least one normal transition to read against), and its `:*`
-;; wildcard's action throws for ANY other event — so sending an
-;; otherwise-unhandled event (#11's button) fires `:*` and throws.
-
-(defmachine fuse-machine
-  {:initial :armed
-   :data    {}
-
-   :actions
-   {:note-inspect
-    ;; A benign named action so `:armed` has a normal transition to contrast
-    ;; the wildcard against (it does NOT throw).
-    (fn action-note-inspect [{data :data}]
-      {:data (update data :inspections (fnil inc 0))})
-
-    :blow-fuse
-    ;; #11 — the `:*` wildcard's action. Throws on ANY unhandled event,
-    ;; xstate-v5 'fail loudly on unknown'. The ex-info message + ex-data are
-    ;; surfaced by the Epoch EXCEPTION card.
-    (fn action-blow-fuse [{:keys [event]}]
-      (throw (ex-info "unhandled machine event"
-                      {:event event :where :fuse-wildcard})))}
-
-   :states
-   {:armed
-    {:tags #{:fuse/armed}
-     :on   {:fuse/inspect {:action :note-inspect}
-            ;; The xstate-v5 fail-loudly wildcard: any otherwise-unhandled
-            ;; event fires this action, which throws.
-            :*            {:action :blow-fuse}}}}})
-
-(rf/reg-machine :fuse/box fuse-machine)
-
-;; ============================================================================
-;; MACHINE 4 — :hvac/controller  (the CANONICAL HARD machine — rf2-k08ay)
-;; ============================================================================
-;;
-;; The capstone of the machine-epochs deck. The first three machines each
-;; light up ONE Machine-Inspector surface; this one exercises every HARD
-;; structural case in ONE coherent domain — a smart climate controller — so
-;; the devtools have a rich, legible subject to render. It is the COMPLEMENT
-;; to the SCXML semantic corpus (rf2-rkkag · #2842): that proves the engine's
-;; SEMANTICS; this fixture + its fidelity assertions prove the devtools RENDER
-;; those semantics legibly. The recent no-op render bug (rf2-e6q97 · #2841)
-;; was a devtools-NARRATION miss — the engine was right, Xray drew it wrong —
-;; and this machine is built to keep that thin spot covered.
-;;
-;; ## The four hard cases it exercises (history-free; `:history` is deferred)
-;;
-;;   1. DEEP COMPOUND NESTING. The `:climate` region is four levels deep:
-;;        [:climate :running :conditioning :heating]
-;;      A transition from `:heating` up-and-over to `:cooling`
-;;      (`:hvac/mode-toggle`) crosses an LCA two levels up (`:conditioning`),
-;;      so the exit cascade + entry cascade each span multiple compound
-;;      levels — the multi-level case the cascade render must order correctly.
-;;
-;;   2. PARALLEL / ORTHOGONAL REGIONS. `:type :parallel` with two regions —
-;;      `:climate` (the deep compound) and `:fan` (a flatter independent
-;;      region). The `:hvac/power-cycle` event is handled by BOTH regions
-;;      SIMULTANEOUSLY (`:climate` swings active⇄idle; `:fan` swings on⇄off)
-;;      so the chart highlights leaves in both regions and the cascade shows
-;;      two transitions from one event.
-;;
-;;   3. ALL ACTION KINDS WITH OBSERVABLE LCA ORDERING. Per Spec 005 §Level 2
-;;      (Compound machines) the action group fires:
-;;        exit cascade (DEEPEST-first) → transition `:action` @ LCA →
-;;        entry cascade (SHALLOWEST-first) → initial cascade.
-;;      Every `:exit` / transition `:action` / `:entry` here APPENDS a labeled
-;;      tag onto a shared `:trail` vector in `:data`. So the post-macrostep
-;;      `:trail` is the cascade order made VISIBLE — the Epoch panel's per-
-;;      action rows (and the snapshot `:data` Δ) render that exact sequence,
-;;      and the fidelity test pins it. The labels carry their depth so the
-;;      deepest-first / shallowest-first directionality is unambiguous.
-;;
-;;   4. INTERNAL vs EXTERNAL SELF-TRANSITIONS — the case the wave just
-;;      debated + fixed (rf2-46ban · #2843). On the `:fan` region's `:on` leaf:
-;;        - `:hvac/nudge`  — EXTERNAL self-transition (`:target :same-state`):
-;;          per #2843 this now fires `:exit` THEN action THEN `:entry` (the
-;;          state re-enters itself), so the trail shows exit + entry tags.
-;;        - `:hvac/tweak`  — INTERNAL self-transition (omit `:target`):
-;;          action ONLY, no exit/entry — the trail shows just the action tag.
-;;      Both land on the SAME state; the devtools must render the DISTINCTION
-;;      (external = exit+entry cascade rows; internal = action-only row; and,
-;;      per #2841, NEITHER produces a spurious `{X}→{X}` no-op transition row).
-;;
-;; ## Why a `:trail` rather than a counter
-;;
-;; A bare counter would prove an action RAN; the ordered `:trail` proves the
-;; SEQUENCE — which is the whole point of the LCA cascade and the internal-vs-
-;; external distinction. The trail is the testable proxy for "the cascade
-;; renders legibly + in the right order". Each label is `<phase>:<state>` so a
-;; reader (human or test) sees both WHAT fired and WHERE without cross-
-;; referencing the spec.
-;;
-;; ## Test surface, not tutorial (feedback_testbeds_are_test_surfaces)
-;;
-;; No deliberate bugs, no teaching layers. Every transition is a clean feature
-;; being driven; the trail is instrumentation, not an anti-pattern demo. The
-;; machine is a believable climate controller, not a grab-bag.
-
-;; A tiny action factory: returns a named action fn that appends one labeled
-;; tag to the shared `:trail` in `:data`. The `:name` metadata survives onto
-;; the fn so `defmachine` stamps per-element source AND the Inspector's
-;; ref-display-id surfaces a legible action id (rf2-ujra6).
-(defn- trail-action
-  "Build a named action that conj's `label` onto `[:data :trail]`. `label`
-  is `<phase>:<state>` (e.g. `:exit:heating`) so the rendered cascade /
-  snapshot-Δ reads as an ordered, self-describing sequence."
-  [nm label]
-  (with-meta
-    (fn [{data :data}]
-      {:data (update data :trail (fnil conj []) label)})
-    {:name nm}))
-
-(defmachine hvac-controller-machine
-  {:type :parallel
-
-   :data {:trail []}
-
-   :regions
-   {;; ---- :climate region — the DEEP COMPOUND (case 1) + the LCA cascade (case 3) ----
-    ;;
-    ;;   :idle
-    ;;   :running
-    ;;     :conditioning
-    ;;       :heating   ← deepest leaf; full path [:climate :running :conditioning :heating]
-    ;;       :cooling
-    ;;
-    ;; `:hvac/mode-toggle` on `:heating` targets `:cooling`. Their LCA is
-    ;; `:conditioning` (the common compound parent), so the cascade is:
-    ;;   exit :heating → (action at the :conditioning boundary) → entry :cooling
-    ;; Each step appends to `:trail`, deepest-exit-first then
-    ;; shallowest-entry-first. `:hvac/power-cycle` (case 2) swings the WHOLE
-    ;; region active⇄idle and is ALSO handled by the `:fan` region.
-    :climate
-    {:initial :idle
-     :states
-     {:idle
-      {:tags #{:climate/idle}
-       :on   {:hvac/power-cycle {:target :running :action :enter-running}}}
-
-      :running
-      ;; Compound level 1. Drops into :conditioning on entry; :conditioning
-      ;; drops into :heating. So `:hvac/power-cycle` from :idle lands the leaf
-      ;; at [:climate :running :conditioning :heating] via the initial cascade
-      ;; (case 3 — the entry + initial cascades both append to the trail).
-      {:tags    #{:climate/running}
-       :initial :conditioning
-       :entry   :enter-running-level
-       :exit    :exit-running-level
-       :on      {:hvac/power-cycle {:target :idle :action :back-to-idle}}
-       :states
-       {:conditioning
-        ;; Compound level 2 — the LCA for the :heating ⇄ :cooling toggle.
-        {:tags    #{:climate/conditioning}
-         :initial :heating
-         :entry   :enter-conditioning
-         :exit    :exit-conditioning
-         :states
-         {:heating
-          ;; Deepest leaf. `:hvac/mode-toggle` crosses the :conditioning LCA
-          ;; to :cooling — exit :heating (deepest-first) → transition action
-          ;; at the LCA → entry :cooling (shallowest-first). All three append
-          ;; to the trail so the order renders.
-          {:tags  #{:climate/heating}
-           :entry :enter-heating
-           :exit  :exit-heating
-           :on    {:hvac/mode-toggle {:target :cooling :action :swap-mode}}}
-
-          :cooling
-          {:tags  #{:climate/cooling}
-           :entry :enter-cooling
-           :exit  :exit-cooling
-           :on    {:hvac/mode-toggle {:target :heating :action :swap-mode}}}}}}}}}
-
-    ;; ---- :fan region — orthogonal (case 2) + the self-transitions (case 4) ----
-    ;;
-    ;; Independent of :climate. `:hvac/power-cycle` swings it off⇄on alongside
-    ;; the climate region (one event, BOTH regions — case 2). The `:on` leaf
-    ;; carries the EXTERNAL (`:hvac/nudge` · `:target :same-state`) and INTERNAL
-    ;; (`:hvac/tweak` · no `:target`) self-transitions side by side (case 4).
-    :fan
-    {:initial :off
-     :states
-     {:off
-      {:tags #{:fan/off}
-       :on   {:hvac/power-cycle {:target :on :action :fan-on}}}
-
-      :on
-      ;; Both self-transitions land HERE and stay HERE; the devtools render
-      ;; the distinction (external = exit+entry; internal = action-only).
-      {:tags  #{:fan/on}
-       :entry :enter-fan-on
-       :exit  :exit-fan-on
-       :on    {:hvac/power-cycle {:target :off :action :fan-off}
-               ;; EXTERNAL self-transition (rf2-46ban · #2843): exit + action
-               ;; + entry all fire; configuration unchanged.
-               :hvac/nudge {:target :same-state :action :nudge-fan}
-               ;; INTERNAL self-transition: action ONLY — no exit, no entry.
-               :hvac/tweak {:action :tweak-fan}}}}}}
-
-   ;; Named actions (inspectability bias, per the nine_states example): every
-   ;; slot is a NAMED entry so the focused-transition lens + the Epoch cascade
-   ;; render each action's id and source. The trail-appending bodies make the
-   ;; LCA cascade ordering observable.
-   :actions
-   {;; :climate entry/exit cascade (case 3) — labels carry depth so the
-    ;; deepest-first exit / shallowest-first entry directionality reads off
-    ;; the trail directly.
-    :enter-running         (trail-action 'enter-running         :action:power-on)
-    :enter-running-level   (trail-action 'enter-running-level   :entry:running)
-    :exit-running-level    (trail-action 'exit-running-level    :exit:running)
-    :back-to-idle          (trail-action 'back-to-idle          :action:power-off)
-    :enter-conditioning    (trail-action 'enter-conditioning    :entry:conditioning)
-    :exit-conditioning     (trail-action 'exit-conditioning     :exit:conditioning)
-    :enter-heating         (trail-action 'enter-heating         :entry:heating)
-    :exit-heating          (trail-action 'exit-heating          :exit:heating)
-    :enter-cooling         (trail-action 'enter-cooling         :entry:cooling)
-    :exit-cooling          (trail-action 'exit-cooling          :exit:cooling)
-    ;; the LCA-boundary transition action for :heating ⇄ :cooling (case 3)
-    :swap-mode             (trail-action 'swap-mode             :action:swap-mode)
-    ;; :fan region (case 2 + case 4)
-    :fan-on                (trail-action 'fan-on                :action:fan-on)
-    :fan-off               (trail-action 'fan-off               :action:fan-off)
-    :enter-fan-on          (trail-action 'enter-fan-on          :entry:fan-on)
-    :exit-fan-on           (trail-action 'exit-fan-on           :exit:fan-on)
-    :nudge-fan             (trail-action 'nudge-fan             :action:nudge)
-    :tweak-fan             (trail-action 'tweak-fan             :action:tweak)}})
-
-(rf/reg-machine :hvac/controller hvac-controller-machine)
-
-;; ============================================================================
-;; APP-DB SEED
+;; APP-DB SEED + the shared bump/send driver
 ;; ============================================================================
 ;;
 ;; `:baseline` is the shared counter every button bumps (so App-db / Epoch
 ;; always show a delta). The machines own their own runtime state under
-;; `[:rf/runtime :machines :snapshots …]`; this deck keeps no machine
-;; mirror in app-db beyond the baseline.
+;; `[:rf/runtime :machines :snapshots …]`.
 
-(def initial-db
-  {:baseline 0})
-
-;; ============================================================================
-;; A small shared helper: every ladder event bumps the baseline counter.
-;; ============================================================================
-;;
-;; The machine events themselves are FRAMEWORK-routed (`[:door/main […]]`
-;; / `[:traffic/light […]]`) — we cannot edit them to bump a counter, so
-;; each rung is a thin deck-owned event-fx that (a) bumps `:baseline` via
-;; `:db` and (b) dispatches the machine event(s). The Epoch / App-db delta
-;; on every press comes from the bump; the Machine Inspector lights up from
-;; the dispatched machine event.
+(def initial-db {:baseline 0})
 
 (defn- bump [db] (update db :baseline inc))
 
-;; A reusable "bump + send" event-fx: every machine rung routes through
-;; here so the baseline delta and the machine send are one cascade. Pass a
-;; vector of machine-event vectors to fan out to several machines in one
-;; press (#10).
+;; A reusable "bump + send" event-fx: every machine rung routes through here
+;; so the baseline delta and the machine send are one cascade. `sends` is a
+;; vector of fully-formed machine-event vectors — pass several to fan out to
+;; multiple machines in one press.
 (rf/reg-event-fx :machine-epochs/send
   {:doc "Bump the baseline and dispatch the supplied machine event(s). The
-         shared driver behind every machine rung. `sends` is a vector of
-         fully-formed machine-event vectors (e.g.
-         `[[:door/main [:door/push]]]`)."}
+         shared driver behind every machine rung."}
   (fn handler-send [{:keys [db]} [_ sends]]
     {:db (bump db)
      :fx (mapv (fn [send] [:dispatch send]) sends)}))
 
-;; #5 — re-open the door (#4 left it :closed), arm the `:held-open?` flag
-;; via the `:door/hold` internal transition, then attempt the guarded
-;; close. Three machine sends in one cascade: the close fails `:may-close?`
-;; because the flag is now armed, so the door STAYS in `:open` and GUARDS
-;; RUN shows the failed guard — the foil to rung #4's passing guard.
+;; #5 — re-open the door (#4 left it :closed), arm the `:held-open?` flag via
+;; the `:door/hold` internal transition, then attempt the guarded close. The
+;; close fails `:may-close?` because the flag is now armed, so the door STAYS
+;; in `:open` and GUARDS RUN shows the failed guard.
 (rf/reg-event-fx :machine-epochs/reopen-then-block
-  {:doc "Button #5 — `:door/push` (re-open) → `:door/hold` (arm the guard
-         input) → `:door/close`. The `:may-close?` guard now FAILS, so the
-         close is blocked and the machine stays in `:open`. GUARDS RUN
-         shows the failed guard; state does NOT advance."}
+  {:doc "Button #5 — :door/push (re-open) → :door/hold (arm the guard input)
+         → :door/close. The :may-close? guard FAILS, so the close is blocked
+         and the machine stays in :open."}
   (fn handler-reopen-then-block [{:keys [db]} _ev]
     {:db (bump db)
      :fx [[:dispatch [:door/main [:door/push]]]
@@ -599,159 +158,230 @@
 ;; The acknowledgement event dispatched by :enter-alarm's :fx (#6). A plain
 ;; deck event so the cascade has a downstream child epoch the lens links to.
 (rf/reg-event-db :machine-epochs/alarm-acknowledged
-  {:doc "The downstream event fired by the door's `:enter-alarm` action
-         `:fx`. Bumps baseline again so the alarm cascade has a child epoch
-         under the originating dispatch-id."}
+  {:doc "The downstream event fired by the door's :enter-alarm action :fx.
+         Bumps baseline again so the alarm cascade has a child epoch under
+         the originating dispatch-id."}
   (fn handler-alarm-acknowledged [db _ev] (bump db)))
 
-;; ============================================================================
-;; SUBSCRIPTIONS — machine snapshot reads for the live status strip
-;; ============================================================================
-;;
-;; The framework ships `:rf/machine` as the layer-3 entry onto
-;; `[:rf/runtime :machines :snapshots <id>]`. The deck chains a couple of
-;; projections for its own status strip; the Machine Inspector is the
-;; actual check.
+;; #16 — re-start the brew (schedules a fresh :after timer) then immediately
+;; :brew/abort, which exits :brewing BEFORE the timer fires. Exiting the
+;; :after-bearing state cancels the in-flight timer (:reason :on-exit).
+(rf/reg-event-fx :machine-epochs/cancel-brew
+  {:doc "Button #16 — :brew/start (re-enter :brewing, schedule the :after
+         timer) → :brew/abort (exit :brewing before the timer fires). The
+         exit cancels the pending timer with :reason :on-exit."}
+  (fn handler-cancel-brew [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx [[:dispatch [:brew/machine [:brew/start]]]
+          [:dispatch [:brew/machine [:brew/abort]]]]}))
 
-(rf/reg-sub :machine-epochs/baseline (fn [db _] (:baseline db)))
+;; #18 — drive the spawned :session/login child to its :final? state. The
+;; child's deterministic spawn-id is read off the runtime spawn-registry slot
+;; the parent's :spawn wrote on entry to :authenticating.
+(rf/reg-event-fx :machine-epochs/finish-login
+  {:doc "Button #18 — resolve the spawned child by reading the parent's
+         spawn-registry slot, then dispatch [:succeed <token>] to drive it to
+         its :final? state. The child fires :on-done (reporting the token to
+         the parent) and auto-destroys."}
+  (fn handler-finish-login [{:keys [db]} _ev]
+    (let [child-id (get-in db [:rf/runtime :machines :spawned
+                               :session/flow [:authenticating]])]
+      (cond-> {:db (bump db)}
+        child-id
+        (assoc :fx [[:dispatch [child-id [:succeed :session/token-abc]]]])))))
 
-(rf/reg-sub :machine-epochs/door-state
-  :<- [:rf/machine :door/main]
-  (fn [snap _] (:state snap)))
-
-(rf/reg-sub :machine-epochs/door-data
-  :<- [:rf/machine :door/main]
-  (fn [snap _] (:data snap)))
-
-(rf/reg-sub :machine-epochs/door-tags
-  :<- [:rf/machine :door/main]
-  (fn [snap _] (:tags snap)))
-
-(rf/reg-sub :machine-epochs/traffic-state
-  :<- [:rf/machine :traffic/light]
-  (fn [snap _] (:state snap)))
-
-(rf/reg-sub :machine-epochs/traffic-tags
-  :<- [:rf/machine :traffic/light]
-  (fn [snap _] (:tags snap)))
-
-;; ---- :hvac/controller — the hard machine's live read-out (rf2-k08ay) ----
-;;
-;; `:state` is a region→state map (parallel); `:tags` is the union tag-set
-;; across both active region leaves; `:trail` is the cascade-order record the
-;; LCA / self-transition buttons grow.
-
-(rf/reg-sub :machine-epochs/hvac-state
-  :<- [:rf/machine :hvac/controller]
-  (fn [snap _] (:state snap)))
-
-(rf/reg-sub :machine-epochs/hvac-tags
-  :<- [:rf/machine :hvac/controller]
-  (fn [snap _] (:tags snap)))
-
-(rf/reg-sub :machine-epochs/hvac-trail
-  :<- [:rf/machine :hvac/controller]
-  (fn [snap _] (get-in snap [:data :trail])))
+;; #24 — probe the current :history REJECTION contract. Registering a
+;; :type :history machine throws synchronously at reg-machine time
+;; (:rf.error/machine-grammar-not-in-v1). The deck event swallows the throw
+;; (the rung's job is to DRIVE the rejection; the harness asserts the throw
+;; shape directly). It bumps baseline so the epoch still shows a delta.
+(rf/reg-event-db :machine-epochs/probe-history-rejection
+  {:doc "Button #24 — attempt to register a :type :history machine and
+         confirm the v1 deferral REJECTS it. The throw is swallowed here so
+         the deck does not crash; the harness asserts the rejection shape."}
+  (fn handler-probe-history [db _ev]
+    (-> db bump (assoc :machine-epochs/history-rejected? (machines/history-rejected?)))))
 
 ;; ============================================================================
 ;; RESET
 ;; ============================================================================
 
 (rf/reg-event-fx :machine-epochs/reset
-  {:doc "Button 0 — re-seed app-db and reset the door + traffic machines to
-         their initial states. Start clean.
+  {:doc "Button 0 — re-seed app-db and bootstrap every NON-throwing machine
+         to its initial state. Start clean.
 
-         `:fuse/box` is DELIBERATELY NOT bootstrapped here. A
-         `[:fuse/box [:rf.machine/bootstrap]]` dispatch runs the initial-entry
-         cascade (fine) and THEN processes the inner `[:rf.machine/bootstrap]`
-         event as a normal machine event: `:armed` has no `:on` entry for it,
-         so it falls to the `:*` wildcard whose `:blow-fuse` action THROWS — a
-         `:rf.error/machine-action-exception` ON BOOT, every load. The fuse box
-         must throw ONLY when Button 11 presses it, never on boot. The machine
-         lazily bootstraps on its first real event anyway (`needs-bootstrap?`
-         fires when no snapshot exists yet — see
-         `lifecycle-fx.registration/prepare-machine-ctx`), so Button 11's
-         `[:fuse/box [:fuse/short-circuit]]` still boots `:armed` then fires
-         the throwing wildcard. Net: clean boot, Button 11 the sole trigger."}
+         :fuse/box is DELIBERATELY NOT bootstrapped: a
+         [:fuse/box [:rf.machine/bootstrap]] dispatch would, after the
+         initial-entry cascade, process the inner [:rf.machine/bootstrap] as
+         a normal event — :armed has no :on entry for it, so it falls to the
+         :* wildcard whose :blow-fuse action THROWS on boot. The fuse box
+         must throw ONLY when its rung presses it (it lazily bootstraps on
+         its first real event). Net: clean boot."}
   (fn handler-reset [_ _ev]
     {:db initial-db
-     :fx [[:dispatch [:door/main [:rf.machine/bootstrap]]]
-          [:dispatch [:traffic/light [:rf.machine/bootstrap]]]
-          ;; rf2-k08ay — the hard machine boots to its initial parallel
-          ;; configuration ({:climate :idle, :fan :off}) with an empty trail.
-          [:dispatch [:hvac/controller [:rf.machine/bootstrap]]]]}))
+     :fx (mapv (fn [id] [:dispatch [id [:rf.machine/bootstrap]]])
+               [:door/main :traffic/light :quiz/scorer :brew/machine
+                :session/flow :hvac/controller])}))
 
 ;; ============================================================================
-;; THE BUTTON LADDER
+;; SUBSCRIPTIONS — machine snapshot reads for the live status strip
 ;; ============================================================================
 
-(def ^:private ladder
-  "The ordered machine ladder. Each row: [n label caption event]. `event`
-  is the dispatch vector; `:section` rows are separators (label only)."
-  [[:section "Door machine — start · transition · entry/exit · effect"]
+(rf/reg-sub :machine-epochs/baseline (fn [db _] (:baseline db)))
+
+(defn- reg-machine-subs!
+  "Register <prefix>-state / -tags / -trail snapshot subs for `machine-id` so
+  the status strip can read them. The trail sub is the order-oracle read-out."
+  [prefix machine-id]
+  (rf/reg-sub (keyword "machine-epochs" (str prefix "-state"))
+    :<- [:rf/machine machine-id]
+    (fn [snap _] (:state snap)))
+  (rf/reg-sub (keyword "machine-epochs" (str prefix "-tags"))
+    :<- [:rf/machine machine-id]
+    (fn [snap _] (:tags snap)))
+  (rf/reg-sub (keyword "machine-epochs" (str prefix "-trail"))
+    :<- [:rf/machine machine-id]
+    (fn [snap _] (get-in snap [:data :trail]))))
+
+(reg-machine-subs! "door"    :door/main)
+(reg-machine-subs! "traffic" :traffic/light)
+(reg-machine-subs! "quiz"    :quiz/scorer)
+(reg-machine-subs! "brew"    :brew/machine)
+(reg-machine-subs! "session" :session/flow)
+(reg-machine-subs! "hvac"    :hvac/controller)
+
+(rf/reg-sub :machine-epochs/door-data
+  :<- [:rf/machine :door/main]
+  (fn [snap _] (:data snap)))
+
+(rf/reg-sub :machine-epochs/quiz-data
+  :<- [:rf/machine :quiz/scorer]
+  (fn [snap _] (:data snap)))
+
+;; ============================================================================
+;; THE BUTTON LADDER — the data-driven single source of truth (rf2-g27vv)
+;; ============================================================================
+;;
+;; Each row: [n label caption event]. `:section` rows are separators (label
+;; only). `:placeholder` rows are HISTORY-section reservations (disabled —
+;; gap 8). The harness reads the machine specs (shared via
+;; `machine-epochs.machines`) and drives each rung's intent through the live
+;; substrate, asserting BOTH machine outcome + Xray render.
+
+(def ladder
+  [[:section "Door (FLAT) — start · transition · entry/exit · effect"]
    [1  "Start machine (bootstrap)"
-    "Inspector: the door chart renders; live-highlight lands on :locked"
+    "Inspector: the door chart renders; live-highlight lands on :locked. Epoch: :initial-entry, NOT a no-op"
     [:door/main [:rf.machine/bootstrap]]]
    [2  "Insert coin (:locked ──► :closed)"
-    "Focused-transition lens: plain FROM → TO, no guard / no action"
+    "Focused-transition lens: plain FROM → TO, no guard / no action; cascade = exit→TRANSITION→entry rows"
     [:machine-epochs/send [[:door/main [:door/insert-coin]]]]]
    [3  "Push (:closed ──► :open) — entry + exit"
     "ACTIONS RUN: :closed's :exit (:clear-hold) + :open's :entry (:count-open); snapshot :opened-count++"
     [:machine-epochs/send [[:door/main [:door/push]]]]]
-   [:section "Door machine — guards (allowed vs blocked)"]
+   [:section "Door — guards (allowed vs blocked) · internal"]
    [4  "Close (:open ──► :closed) — guard ALLOWED"
     "GUARDS RUN: :may-close? → pass; transition completes to :closed"
     [:machine-epochs/send [[:door/main [:door/close]]]]]
    [5  "Re-open, hold, then close — guard BLOCKED"
     "GUARDS RUN: :may-close? → fail (held-open?); state STAYS :open (no branch matches)"
     [:machine-epochs/reopen-then-block]]
-   [:section "Door machine — effect + ignored"]
+   [:section "Door — effect · ignored · transition RESOLUTION (gap 6)"]
    [6  "Trip (:open ──► :alarming) — with effect"
     "ACTIONS RUN: :enter-alarm → :fx :dispatch → [:alarm-acknowledged] (downstream cascade child)"
     [:machine-epochs/send [[:door/main [:door/trip]]]]]
-   [7  "Insert coin into :alarming — IGNORED"
-    "Inspector: no machine activity — the verbatim 'This event does not target a state machine' empty-state"
+   [7  "Insert coin into :alarming — UNHANDLED no-op"
+    "Epoch: ONE [NO OP] staying in :alarming row; NO transition row; event row NOT pink — the foil to the throw"
     [:machine-epochs/send [[:door/main [:door/insert-coin]]]]]
-   [:section "Traffic machine — parallel regions · history · multiple machines"]
-   [8  "Tick traffic (parallel regions)"
-    "Inspector: ONE event broadcasts to :vehicle + :pedestrian; chart highlights BOTH active region leaves"
+   [8  "Audit from :alarming — ROOT :on fallthrough"
+    "Resolution: :alarming has no :door/audit; the ROOT :on handles it → :alarming ──► :locked (deepest-wins fallthrough)"
+    [:machine-epochs/send [[:door/main [:door/audit]]]]]
+   [:section "Traffic (PARALLEL) — regions · history · TAG-SET delta (gap 7)"]
+   [9  "Tick traffic (parallel regions)"
+    "Inspector: ONE event broadcasts to :vehicle + :pedestrian; chart highlights BOTH active leaves; tags swap members"
     [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]]
-   [9  "Tick traffic ×1 more (history)"
-    "Transition-history ribbon under the chart accumulates several state → state entries"
+   [10 "Tick traffic ×1 more (history ribbon)"
+    "Transition-history ribbon accumulates state → state entries; logical-state DELTA box shows :tags member swap (rf2-l0us2)"
     [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]]
-   [10 "Reset door + tick traffic (two machines, one cascade)"
-    "Inspector: one event transitions BOTH machines; instance selection picks the first transition in trace order"
+   [11 "Reset door + tick traffic (two machines, one cascade)"
+    "Inspector: one event transitions BOTH machines; instance selection picks the first in trace order; multi-machine no-op names its machine"
     [:machine-epochs/send [[:door/main [:door/reset]] [:traffic/light [:traffic/tick]]]]]
-   [:section "Fuse box — :* wildcard-action THROWS (xstate-v5 fail-loudly)"]
-   [11 "Send unhandled event to :fuse/box — :* action THROWS"
-    "Epoch: EXCEPTION card (message + ex-data + coord) attributing a :* WILDCARD action; event row IS pink — inverse of #7's benign no-op"
+   [:section "Quiz (MICROSTEP) — :always EVENTLESS microsteps (gap 1)"]
+   [12 "Answer — score climbs (microsteps 0)"
+    "Cascade: the :answer action bumps :score; the :always guard is NOT yet met → 0 microsteps; quiz stays :asking"
+    [:machine-epochs/send [[:quiz/scorer [:quiz/answer]]]]]
+   [13 "Answer ×2 more — :always SETTLES (microsteps > 0)"
+    "Cascade: :answer reaches the pass mark; the guarded :always chain fires → N microstep(s) + the microstep cascade to :passed"
+    [:machine-epochs/answer-to-pass]]
+   [:section "Brew (TIMER) — :after delayed transition + cancel (gap 2)"]
+   [14 "Start brew — schedules an :after timer"
+    "Cascade: :idle ──► :brewing; the :after timer is SCHEDULED (no fire yet). Watch the AFTER TIMERS sub-section"
+    [:machine-epochs/send [[:brew/machine [:brew/start]]]]]
+   [15 "Let the :after timer ELAPSE (auto-fire)"
+    "Cascade: the synthetic :after-elapsed fires → :brewing ──► :ready; DISPATCH row labels 'from :after timer'"
+    [:machine-epochs/send [[:brew/machine [:rf.machine.timer/after-elapsed 5000 1 [:brewing]]]]]]
+   [16 "Re-start then CANCEL — exit beats the timer"
+    "Cascade: re-enter :brewing (schedule) then :brew/abort exits before fire → :rf.machine.timer/cancelled (:on-exit) — the :cancelled chip"
+    [:machine-epochs/cancel-brew]]
+   [:section "Session (LIFECYCLE) — spawn · child :final · :on-done · destroy (gaps 3,4,5)"]
+   [17 "Open session — SPAWN child actor"
+    "Cascade: :idle ──► :authenticating spawns :session/login child; spawn fx renders; the instance spine spans parent + child"
+    [:machine-epochs/send [[:session/flow [:session/open]]]]]
+   [18 "Child succeeds — :final + :on-done + auto-DESTROY"
+    "Cascade: drive the child to :final? → :on-done reports the token to the parent → child auto-destroys (exit-cascade-on-destroy + destroyed trace)"
+    [:machine-epochs/finish-login]]
+   [:section "Fuse (WILDCARD-THROW) — :* action THROWS (xstate-v5 fail-loudly)"]
+   [19 "Send unhandled event to :fuse/box — :* action THROWS"
+    "Epoch: EXCEPTION card (message + ex-data + coord) attributing a :* WILDCARD action; event row IS pink; cascade-summary :outcome :error"
     [:machine-epochs/send [[:fuse/box [:fuse/short-circuit]]]]]
-   [:section "HVAC controller — the HARD machine (deep compound · parallel · LCA cascade · self-transitions)"]
-   [12 "Power-cycle (parallel — BOTH regions, deep initial cascade)"
-    "Cascade: ONE event → :climate :idle──►:running (entry+initial cascade to [:running :conditioning :heating]) AND :fan :off──►:on; trail shows both regions' entries"
+   [:section "Hvac (DEEP-COMPOUND) — compound · LCA cascade · self-transitions"]
+   [20 "Power-cycle (parallel — BOTH regions, deep initial cascade)"
+    "Cascade: ONE event → :climate :idle──►:running (entry+initial cascade to [:running :conditioning :heating]) AND :fan :off──►:on"
     [:machine-epochs/send [[:hvac/controller [:hvac/power-cycle]]]]]
-   [13 "Mode-toggle (:heating ⇄ :cooling — multi-level LCA cascade)"
-    "Cascade ORDER: exit :heating (deepest-first) → :swap-mode @ LCA :conditioning → entry :cooling (shallowest-first); trail = [:exit:heating :action:swap-mode :entry:cooling]"
+   [21 "Mode-toggle (:heating ⇄ :cooling — multi-level LCA cascade)"
+    "Cascade ORDER: exit :heating (deepest-first) → :swap-mode @ LCA :conditioning → entry :cooling (shallowest-first)"
     [:machine-epochs/send [[:hvac/controller [:hvac/mode-toggle]]]]]
-   [14 "Nudge fan — EXTERNAL self-transition (:target :same-state)"
-    "Cascade: :fan :on re-enters itself — exit :fan-on → :nudge-fan → entry :fan-on (per #2843); NO spurious {:on}→{:on} no-op row (per #2841)"
+   [22 "Nudge fan — EXTERNAL self-transition (:target :same-state)"
+    "Cascade: :fan :on re-enters itself — exit :fan-on → :nudge-fan → entry :fan-on; NO spurious {:on}→{:on} no-op row"
     [:machine-epochs/send [[:hvac/controller [:hvac/nudge]]]]]
-   [15 "Tweak fan — INTERNAL self-transition (omit :target)"
-    "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to #14; NO spurious no-op row — state stays :fan :on"
-    [:machine-epochs/send [[:hvac/controller [:hvac/tweak]]]]]])
+   [23 "Tweak fan — INTERNAL self-transition (omit :target)"
+    "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to #22; NO spurious no-op row"
+    [:machine-epochs/send [[:hvac/controller [:hvac/tweak]]]]]
+   [:section "History (SOON) — gap 8: reject-now + ready placeholders"]
+   [24 "Register a :history machine — REJECTED (current contract)"
+    "The harness asserts reg-machine of a :type :history machine THROWS :rf.error/machine-grammar-not-in-v1 (Spec 005 §Substitutes; rf2-rkkag)"
+    [:machine-epochs/probe-history-rejection]]
+   [:placeholder 25 "Shallow HISTORY restore — PLACEHOLDER (activate when :history lands)"
+    "Reserved slot: re-enter a compound region via :type :history :shallow and assert it restores the last active CHILD"]
+   [:placeholder 26 "Deep HISTORY restore — PLACEHOLDER (activate when :history lands)"
+    "Reserved slot: re-enter via :type :history :deep and assert it restores the full nested LEAF path"]])
+
+;; #13 — answer twice more so the running score reaches the `:enough?` pass
+;; mark (3) and the guarded `:always` chain settles `:asking` ──► `:passed`
+;; in N>0 microsteps. (#12 already answered once.) Two answers in one cascade
+;; so the LAST `:answer` is the one whose macrostep carries the microstep.
+(rf/reg-event-fx :machine-epochs/answer-to-pass
+  {:doc "Button #13 — :quiz/answer ×2 so the score reaches the pass mark and
+         the guarded :always chain fires (microsteps > 0)."}
+  (fn handler-answer-to-pass [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx [[:dispatch [:quiz/scorer [:quiz/answer]]]
+          [:dispatch [:quiz/scorer [:quiz/answer]]]]}))
+
+;; ============================================================================
+;; VIEWS
+;; ============================================================================
 
 (reg-view ladder-button
-  "One numbered ladder row: a numbered button on the left, its caption on
-  the right. Pressing it dispatches the row's event. The button carries a
-  per-rung `data-testid` (`machine-epochs-rung-<n>`) so each rung is
-  uniquely addressable even though several share the `:machine-epochs/send`
-  event-id (the feature-matrix scenario drives them by rung)."
+  "One numbered ladder row: a numbered button on the left, its caption on the
+  right. The button carries a per-rung `data-testid`
+  (`machine-epochs-rung-<n>`) so each rung is uniquely addressable."
   [n label caption event]
   [:div {:style {:display "grid" :grid-template-columns "auto 1fr"
                  :gap "0.75em" :align-items "center" :margin "0.35em 0"}}
    [:button {:data-testid (str "machine-epochs-rung-" n)
              :on-click    #(dispatch event)
-             :style {:min-width "22em" :text-align "left"
+             :style {:min-width "24em" :text-align "left"
                      :padding "0.4em 0.6em" :cursor "pointer"
                      :border "1px solid #cfc8ff" :border-radius "6px"
                      :background "#fff"}}
@@ -759,6 +389,25 @@
      (str n ".")]
     label]
    [:span {:style {:color "#666" :font-size "12px"}} caption]])
+
+(reg-view placeholder-button
+  "A HISTORY-section reservation: a DISABLED numbered button (the feature is
+  deferred — Spec 005 §Substitutes). When :history lands, flip this row to a
+  live [n label caption event] rung; the harness already has the slot."
+  [n label caption]
+  [:div {:style {:display "grid" :grid-template-columns "auto 1fr"
+                 :gap "0.75em" :align-items "center" :margin "0.35em 0"
+                 :opacity 0.55}}
+   [:button {:data-testid (str "machine-epochs-rung-" n)
+             :disabled    true
+             :style {:min-width "24em" :text-align "left"
+                     :padding "0.4em 0.6em" :cursor "not-allowed"
+                     :border "1px dashed #cfc8ff" :border-radius "6px"
+                     :background "#f7f5ff"}}
+    [:span {:style {:font-weight "bold" :color "#aaa" :margin-right "0.5em"}}
+     (str n ".")]
+    label]
+   [:span {:style {:color "#999" :font-size "12px" :font-style "italic"}} caption]])
 
 (reg-view section-heading
   "A section separator inside the ladder."
@@ -769,65 +418,66 @@
                  :padding-top "0.5em"}}
    label])
 
+(reg-view machine-row
+  "One line of the status strip: a machine's active state + tags + trail."
+  [machine-label prefix]
+  (let [state @(subscribe [(keyword "machine-epochs" (str prefix "-state"))])
+        tags  @(subscribe [(keyword "machine-epochs" (str prefix "-tags"))])
+        trail @(subscribe [(keyword "machine-epochs" (str prefix "-trail"))])]
+    [:div {:data-testid (str "machine-epochs-" prefix "-state")
+           :style {:margin "0.15em 0"}}
+     [:strong machine-label] " state: " [:strong (pr-str state)]
+     " · tags: " (pr-str tags)
+     (when (seq trail)
+       [:span {:data-testid (str "machine-epochs-" prefix "-trail")}
+        " · trail: " [:strong (pr-str trail)]])]))
+
 (reg-view machine-status-strip
-  "A small live read-out of both machines' active state + tags — mirrors
-  what the Xray Machine Inspector projects, so the deck stays legible
-  standalone. Pure snapshot reads; the Inspector is the actual check."
+  "A small live read-out of every machine's active state + tags + trail —
+  mirrors what the Xray cascade projects, so the deck stays legible
+  standalone. Pure snapshot reads; the Inspector / Epoch panel is the check."
   []
-  (let [door-state    @(subscribe [:machine-epochs/door-state])
-        door-data     @(subscribe [:machine-epochs/door-data])
-        door-tags     @(subscribe [:machine-epochs/door-tags])
-        traffic-state @(subscribe [:machine-epochs/traffic-state])
-        traffic-tags  @(subscribe [:machine-epochs/traffic-tags])
-        hvac-state    @(subscribe [:machine-epochs/hvac-state])
-        hvac-tags     @(subscribe [:machine-epochs/hvac-tags])
-        hvac-trail    @(subscribe [:machine-epochs/hvac-trail])]
-    [:div {:data-testid "machine-epochs-status-strip"
-           :style {:border "1px solid #d8d2ff" :border-radius "6px"
-                   :padding "0.5em 0.75em" :margin "0.75em 0"
-                   :background "#fcfbff" :font-size "12px"}}
-     [:div {:style {:font-size "11px" :color "#7C5CFF" :font-weight "bold"
-                    :text-transform "uppercase" :letter-spacing "0.04em"}}
-      "Machine snapshots"]
-     [:div {:data-testid "machine-epochs-door-state"}
-      ":door/main state: " [:strong (pr-str door-state)]]
-     [:div ":door/main data: " [:strong (pr-str door-data)]]
-     [:div ":door/main tags: " [:strong (pr-str door-tags)]]
-     [:div {:data-testid "machine-epochs-traffic-state"}
-      ":traffic/light state: " [:strong (pr-str traffic-state)]]
-     [:div ":traffic/light tags: " [:strong (pr-str traffic-tags)]]
-     [:div {:data-testid "machine-epochs-hvac-state"}
-      ":hvac/controller state: " [:strong (pr-str hvac-state)]]
-     [:div ":hvac/controller tags: " [:strong (pr-str hvac-tags)]]
-     [:div {:data-testid "machine-epochs-hvac-trail"}
-      ":hvac/controller trail (LCA cascade order): " [:strong (pr-str hvac-trail)]]]))
+  [:div {:data-testid "machine-epochs-status-strip"
+         :style {:border "1px solid #d8d2ff" :border-radius "6px"
+                 :padding "0.5em 0.75em" :margin "0.75em 0"
+                 :background "#fcfbff" :font-size "12px"}}
+   [:div {:style {:font-size "11px" :color "#7C5CFF" :font-weight "bold"
+                  :text-transform "uppercase" :letter-spacing "0.04em"}}
+    "Machine snapshots (trail = cascade order made visible)"]
+   [machine-row ":door/main"       "door"]
+   [:div ":door/main data: " [:strong (pr-str @(subscribe [:machine-epochs/door-data]))]]
+   [machine-row ":traffic/light"   "traffic"]
+   [machine-row ":quiz/scorer"     "quiz"]
+   [:div ":quiz/scorer data: " [:strong (pr-str @(subscribe [:machine-epochs/quiz-data]))]]
+   [machine-row ":brew/machine"    "brew"]
+   [machine-row ":session/flow"    "session"]
+   [machine-row ":hvac/controller" "hvac"]])
 
 (reg-view root []
   [:div {:data-testid "machine-epochs-root"
          :style {:font-family "system-ui, sans-serif" :padding "1em"
-                 :max-width "780px"}}
+                 :max-width "880px"}}
    [:header {:style {:margin-bottom "0.5em"}}
-    [:h2 {:style {:margin 0}} "Machine-epochs"]
+    [:h2 {:style {:margin 0}} "Machine-epochs — assertion-backed render harness"]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "One frame, one tall column of state-machine test buttons. Each button bumps a shared "
-     [:strong "baseline"] " counter (so App-db / Epoch always show a delta) and "
-     "sends one machine event exercising exactly one more machine feature. The caption says "
-     "what to watch in Xray's " [:strong "Machine Inspector"] " on the right — click top to "
-     "bottom and the Inspector's surfaces (topology highlight · focused-transition lens · "
-     "guards / actions · snapshot drill-in · transition history · parallel regions) are "
-     "fully exercised."]]
+     "One frame, one tall column of state-machine test buttons. Each rung bumps a shared "
+     [:strong "baseline"] " counter and sends one machine event exercising exactly one "
+     "machine FEATURE × the Xray cascade-render SURFACE it lights up. Click top to bottom — "
+     "every render surface is exercised. The "
+     [:strong "trail"] " in each snapshot is the cascade ORDER made visible (the order-oracle "
+     "the harness keys its assertions off)."]]
    [machine-status-strip]
-   ;; Button 0 — Reset.
    [:button {:data-testid "reset-button"
              :on-click #(dispatch [:machine-epochs/reset])
              :style {:padding "0.4em 0.8em" :cursor "pointer"
                      :border "1px solid #cfc8ff" :border-radius "6px"
                      :background "#f4f1ff" :margin "0.5em 0"}}
-    "0. Reset — re-seed app-db, reset both machines"]
-   ;; The ladder.
+    "0. Reset — re-seed app-db, bootstrap every machine"]
    (for [row ladder]
-     (if (= :section (first row))
-       ^{:key (second row)} [section-heading (second row)]
+     (case (first row)
+       :section     ^{:key (str "sec-" (second row))} [section-heading (second row)]
+       :placeholder (let [[_ n label caption] row]
+                      ^{:key n} [placeholder-button n label caption])
        (let [[n label caption event] row]
          ^{:key n} [ladder-button n label caption event])))])
 
@@ -838,21 +488,11 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-;; rf2-5dphw — open-in-editor project-root is derived from the build
-;; environment, not a hardcoded personal path. `re-frame.testbed.config`
-;; joins the build-time repo-root goog-define with this testbed's
-;; tool-relative subdir; `?project-root=<path>` still overrides per
-;; session. See that ns for the cross-platform mechanism.
 (defn- resolve-project-root []
   (testbed-config/resolve-project-root "tools/xray/testbeds"))
 
 (defn ^:export run []
-  ;; Configure Xray BEFORE `rf/init!` so the preload's auto-open reads the
-  ;; right project-root on its first paint of any chip.
   (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
-  ;; Single, plain frame — no URL machinery (there is no routing here). The
-  ;; default frame is the one Xray reads. Seed app-db and bootstrap both
-  ;; machines to their initial states.
   (rf/dispatch-sync [:machine-epochs/reset])
   (rdc/render react-root [root]))

--- a/tools/xray/testbeds/machine_epochs/machines.cljs
+++ b/tools/xray/testbeds/machine_epochs/machines.cljs
@@ -1,0 +1,451 @@
+(ns machine-epochs.machines
+  "The MACHINE SPECS for the machine-epochs render harness (rf2-g27vv),
+  split out of `machine-epochs.core` so the ASSERTION harness
+  (`day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test`) can
+  register the IDENTICAL specs without pulling in the deck's Reagent mount.
+
+  This makes 'what the operator sees in the deck' and 'what the test drives'
+  literally the SAME values — a drift between them is impossible (the bead's
+  single-source-of-truth requirement for the machine half of the matrix).
+
+  ## The generalized `:trail` order-oracle
+
+  Every machine here carries a `:data :trail` vector; every `:entry` /
+  `:exit` / transition `:action` / `:always` action APPENDS one
+  `<phase>:<state>` label via `trail-action`. The post-macrostep `:trail` is
+  the cascade ORDER made visible — the order-oracle the harness keys its
+  assertions off. (Spec 005 §The structured transition cascade now exposes
+  the structured `:cascade` directly, so the trail is a legible cross-check,
+  not a workaround.)
+
+  ## Test surface, not tutorial (feedback_testbeds_are_test_surfaces)
+
+  No deliberate bugs, no teaching layers. Every machine is a clean,
+  believable domain exercising real features. The throwing `:fuse/box`
+  models the xstate-v5 idiomatic 'fail loudly on unknown' (a feature), not a
+  bug."
+  (:require [re-frame.core :as rf])
+  (:require-macros [re-frame.core :refer [defmachine]]))
+
+;; ----------------------------------------------------------------------------
+;; trail-action — the generalized order-oracle action factory.
+;; ----------------------------------------------------------------------------
+;;
+;; Returns a NAMED action fn that conj's `label` (`<phase>:<state>`) onto
+;; `[:data :trail]`. The `:name` metadata survives onto the fn so `defmachine`
+;; stamps per-element source AND the Inspector's ref-display-id surfaces a
+;; legible action id (rf2-ujra6). When `extra-fn` is supplied it is applied to
+;; the resulting `:data` map (for actions that ALSO mutate other `:data` keys,
+;; e.g. the door's :count-open or the quiz's :score bump) — so a single
+;; factory covers both the pure trail recorders and the data-mutating actions
+;; while keeping every action trail-appending (the oracle stays complete).
+
+(defn trail-action
+  "Build a named action appending `label` to `[:data :trail]`. Optional
+  `extra-fn` is `(fn [data event] data)` applied AFTER the trail append, to
+  mutate other `:data` keys. `label` is `<phase>:<state>` so the rendered
+  cascade / snapshot-Δ reads as an ordered, self-describing sequence."
+  ([nm label] (trail-action nm label nil))
+  ([nm label extra-fn]
+   (with-meta
+     (fn [{data :data event :event}]
+       (let [data' (update data :trail (fnil conj []) label)]
+         {:data (if extra-fn (extra-fn data' event) data')}))
+     {:name nm})))
+
+;; ============================================================================
+;; MACHINE 1 — :door/main  (FLAT: guards + entry/exit + fx + RESOLUTION)
+;; ============================================================================
+;;
+;;   :locked   → :closed   on :door/insert-coin (plain transition)
+;;   :closed   → :open     on :door/push        (entry + exit actions)
+;;   :open     → :closed   on :door/close        (guarded — allowed / blocked)
+;;   :open                 on :door/hold         (INTERNAL — arms the guard)
+;;   :open     → :alarming on :door/trip          (transition-with-effect)
+;;   :alarming             on :door/insert-coin   (UNHANDLED → benign no-op)
+;;   :alarming → :locked   on :door/reset
+;;   ROOT :on  → :locked   on :door/audit          (RESOLUTION — root-:on
+;;                                                  fallthrough, gap 6)
+;;
+;; gap 6 — TRANSITION RESOLUTION: `:alarming` declares no `:door/audit`
+;; entry, so the event falls through to the ROOT-level `:on` (deepest-wins:
+;; a state-level entry would override a root entry, but absent one the root
+;; handles it). Driving `:door/audit` from `:alarming` exercises that the
+;; cascade attributes the resolved transition to the root clause.
+
+(defmachine door-machine
+  {:initial :locked
+   :data    {:opened-count 0
+             :held-open?   false
+             :trail        []}
+
+   ;; ROOT-level :on — the fallthrough target for any state that does not
+   ;; declare :door/audit locally (gap 6 — transition resolution).
+   :on {:door/audit {:target :locked :action :record-audit}}
+
+   :guards
+   {:may-close?
+    (fn guard-may-close? [{data :data}]
+      (not (:held-open? data)))}
+
+   :actions
+   {:count-open  (trail-action 'count-open  :entry:open
+                               (fn [d _] (update d :opened-count (fnil inc 0))))
+    :clear-hold  (trail-action 'clear-hold  :exit:closed
+                               (fn [d _] (assoc d :held-open? false)))
+    :hold-open   (fn action-hold-open [{data :data}]
+                   ;; INTERNAL transition (no :target): writes :data only;
+                   ;; not part of the entry/exit cascade so it does NOT append
+                   ;; the cascade trail — it records its own marker instead so
+                   ;; the internal-transition action is still observable.
+                   {:data (-> data
+                              (assoc :held-open? true)
+                              (update :trail (fnil conj []) :action:hold))})
+    :enter-alarm (trail-action 'enter-alarm :action:trip
+                               (fn [d _] (assoc d :alarm-fx? true)))
+    :record-audit (trail-action 'record-audit :action:audit)}
+
+   :states
+   {:locked
+    {:tags #{:door/locked}
+     :on   {:door/insert-coin :closed}}
+
+    :closed
+    {:tags #{:door/closed}
+     :exit :clear-hold
+     :on   {:door/push :open}}
+
+    :open
+    {:tags  #{:door/open}
+     :entry :count-open
+     :on    {:door/close {:target :closed :guard :may-close?}
+             :door/hold  {:action :hold-open}
+             :door/trip  {:target :alarming :action :enter-alarm}}}
+
+    :alarming
+    ;; No :door/insert-coin entry → UNHANDLED no-op (#7). No :door/audit
+    ;; entry → falls through to the ROOT :on (#8, gap 6). :door/reset cycles
+    ;; back to :locked.
+    {:tags #{:door/alarming}
+     :on   {:door/reset :locked}}}})
+
+;; ============================================================================
+;; MACHINE 2 — :traffic/light  (PARALLEL: regions · history · TAG-SET delta)
+;; ============================================================================
+;;
+;; Two orthogonal regions, one declaration. ONE event (`:traffic/tick`)
+;; broadcasts to BOTH. The `:tags` SET swaps exactly ONE distinctive member
+;; on each tick: the :vehicle region carries the swappable distinctive tag
+;; (vehicle-stop → vehicle-go → vehicle-slow → …), while the :pedestrian
+;; region's tag (:traffic/crossing) AND the machine-wide :traffic/shared tag
+;; stay CONSTANT across every state. So the union `:tags` set is a SINGLE-
+;; member swap each tick — the snapshot diff must render that as a member-
+;; level :added / :removed (the joining + leaving vehicle tag), NOT a whole-
+;; key set replacement (gap 7 / rf2-l0us2). A single-member swap is the case
+;; the member-level set-diff renders today; keeping the constant members
+;; off the churn proves the diff isolates exactly the member that moved.
+
+(defmachine traffic-machine
+  {:type :parallel
+
+   :regions
+   {:vehicle
+    {:initial :red
+     :states
+     {:red   {:tags #{:traffic/vehicle-stop :traffic/shared}
+              :on   {:traffic/tick :green}}
+      :green {:tags #{:traffic/vehicle-go :traffic/shared}
+              :on   {:traffic/tick :amber}}
+      :amber {:tags #{:traffic/vehicle-slow :traffic/shared}
+              :on   {:traffic/tick :red}}}}
+
+    ;; The pedestrian region still ADVANCES its state on every tick (so the
+    ;; parallel broadcast is genuine — both regions move), but its :tags are
+    ;; CONSTANT (:traffic/crossing) so they do not contribute to the tag-set
+    ;; delta. Only the vehicle region's distinctive member swaps.
+    :pedestrian
+    {:initial :walk
+     :states
+     {:walk      {:tags #{:traffic/crossing}
+                  :on   {:traffic/tick :dont-walk}}
+      :dont-walk {:tags #{:traffic/crossing}
+                  :on   {:traffic/tick :walk}}}}}})
+
+;; ============================================================================
+;; MACHINE 3 — :quiz/scorer  (MICROSTEP: :always eventless settle — gap 1)
+;; ============================================================================
+;;
+;; THE biggest gap: a state with a guarded `:always` chain that settles over
+;; N>0 microsteps once the guard becomes true. `:asking` answers bump
+;; `:score`; once `:score >= 3` the guarded `:always` fires WITHOUT a further
+;; user event → an eventless microstep transitions `:asking` ──► `:passed`.
+;; So `:quiz/answer` at score 2→3 produces `microsteps 1` + the microstep
+;; cascade (the structured `:cascade`'s `:microstep` step). Answers below the
+;; mark settle in 0 microsteps (the guard fails). Mirrors the canonical
+;; `:casc/quiz` fixture in the cascade-instrumentation test.
+
+(defmachine quiz-machine
+  {:initial :asking
+   :data    {:score 0 :trail []}
+
+   :guards
+   {:enough? (fn guard-enough? [{data :data}] (>= (:score data) 3))}
+
+   :actions
+   {:count-answer (trail-action 'count-answer :action:answer
+                                (fn [d _] (update d :score (fnil inc 0))))
+    :award        (trail-action 'award        :always:passed
+                                (fn [d _] (assoc d :passed? true)))}
+
+   :states
+   {:asking {:tags   #{:quiz/asking}
+             :always [{:guard :enough? :target :passed :action :award}]
+             :on     {:quiz/answer {:action :count-answer}}}
+    :passed {:tags #{:quiz/passed}}}})
+
+;; ============================================================================
+;; MACHINE 4 — :brew/machine  (TIMER: :after delayed transition + cancel)
+;; ============================================================================
+;;
+;; gap 2 — a `:after` timer that auto-fires AND a path that CANCELS a pending
+;; timer (exit before it fires). `:brewing` declares `:after {5000 :ready}`:
+;; entering schedules the timer; the synthetic
+;; `[:rf.machine.timer/after-elapsed 5000 1 [:brewing]]` event fires it
+;; (`:brewing` ──► `:ready`). `:brew/abort` exits `:brewing` BEFORE the timer
+;; fires → the in-flight timer is cancelled (`:rf.machine.timer/cancelled`,
+;; `:reason :on-exit`) — the `:timer` cascade kind + the `:cancelled` chip.
+
+(defmachine brew-machine
+  {:initial :idle
+   :data    {:trail []}
+
+   :actions
+   {:start-brewing (trail-action 'start-brewing :entry:brewing)
+    :serve         (trail-action 'serve         :entry:ready)
+    :abort-brewing (trail-action 'abort-brewing :exit:brewing)}
+
+   :states
+   {:idle
+    {:tags #{:brew/idle}
+     :on   {:brew/start :brewing}}
+
+    :brewing
+    {:tags  #{:brew/brewing}
+     :entry :start-brewing
+     :exit  :abort-brewing
+     :after {5000 :ready}
+     :on    {:brew/abort :idle}}
+
+    :ready
+    {:tags  #{:brew/ready}
+     :entry :serve
+     :on    {:brew/start :brewing}}}})
+
+;; ============================================================================
+;; MACHINE 5a — :session/login  (LIFECYCLE child: reaches :final? + reports)
+;; ============================================================================
+;;
+;; The spawned child actor (gaps 3/4/5). `:running` ──► `:done` on
+;; `:succeed`; `:done` is `:final?` with `:output-key :token`, so entering it
+;; fires the parent's `:on-done` (reporting the token) and AUTO-DESTROYS the
+;; child synchronously (exit-cascade-on-destroy + the `:rf.machine/destroyed`
+;; trace, `:reason :rf.machine/finished`).
+
+(defmachine session-login-machine
+  {:initial :running
+   :data    {:trail []}
+   :actions
+   {:capture (trail-action 'capture :action:succeed
+                           (fn [d ev] (assoc d :token (second ev))))}
+   :states
+   {:running {:tags #{:session/running}
+              :on   {:succeed {:target :done :action :capture}}}
+    :done    {:final?     true
+              :output-key :token}}})
+
+;; ============================================================================
+;; MACHINE 5b — :session/flow  (LIFECYCLE parent: SPAWN child → :on-done)
+;; ============================================================================
+;;
+;; gap 4 — `:idle` ──► `:authenticating` SPAWNS the `:session/login` child.
+;; gap 3/5 — when the child reaches `:final?`, its `:on-done` reports the
+;; token back to the parent (`:data :session-token`) and the child auto-
+;; destroys. The instance spine spans parent + child.
+
+(defmachine session-flow-machine
+  {:initial :idle
+   :data    {:trail []}
+   :actions
+   {:open-session (trail-action 'open-session :entry:authenticating)}
+   :states
+   {:idle
+    {:tags #{:session/idle}
+     :on   {:session/open :authenticating}}
+
+    :authenticating
+    {:tags  #{:session/authenticating}
+     :entry :open-session
+     :spawn {:machine-id :session/login
+             :on-done    (fn on-done [{data :data result :result}]
+                           (-> data
+                               (assoc :session-token result)
+                               (update :trail (fnil conj []) :action:on-done)))}
+     :on    {:session/close :idle}}}})
+
+;; ============================================================================
+;; MACHINE 6 — :fuse/box  (WILDCARD-THROW: :* action THROWS — xstate-v5)
+;; ============================================================================
+;;
+;; The xstate-v5 idiomatic 'fail loudly on unknown'. `:armed` handles a plain
+;; `:fuse/inspect` (a benign internal action), and its `:*` wildcard's action
+;; THROWS for any other event → a REAL `:rf.error/machine-action-exception`.
+;; The CONTRAST with the door's benign unhandled-no-op validates that Xray's
+;; pink-wash / `issue-event?` predicate distinguishes a thrown `:*` action
+;; (error, pink, EXCEPTION card, cascade-summary :outcome :error) from a
+;; benign no-op (NOT pink).
+
+(defmachine fuse-machine
+  {:initial :armed
+   :data    {:trail []}
+
+   :actions
+   {:note-inspect (trail-action 'note-inspect :action:inspect
+                                (fn [d _] (update d :inspections (fnil inc 0))))
+    :blow-fuse
+    (fn action-blow-fuse [{:keys [event]}]
+      (throw (ex-info "unhandled machine event"
+                      {:event event :where :fuse-wildcard})))}
+
+   :states
+   {:armed
+    {:tags #{:fuse/armed}
+     :on   {:fuse/inspect {:action :note-inspect}
+            :*            {:action :blow-fuse}}}}})
+
+;; ============================================================================
+;; MACHINE 7 — :hvac/controller  (DEEP-COMPOUND — compound · LCA · self-tx)
+;; ============================================================================
+;;
+;; The canonical HARD machine: deep compound nesting, parallel/orthogonal
+;; regions, observable LCA ordering, internal vs external self-transitions.
+;; Mirrors the `machine_cascade_instrumentation_test` fixture exactly.
+
+(defmachine hvac-controller-machine
+  {:type :parallel
+   :data {:trail []}
+
+   :regions
+   {:climate
+    {:initial :idle
+     :states
+     {:idle
+      {:tags #{:climate/idle}
+       :on   {:hvac/power-cycle {:target :running :action :enter-running}}}
+
+      :running
+      {:tags    #{:climate/running}
+       :initial :conditioning
+       :entry   :enter-running-level
+       :exit    :exit-running-level
+       :on      {:hvac/power-cycle {:target :idle :action :back-to-idle}}
+       :states
+       {:conditioning
+        {:tags    #{:climate/conditioning}
+         :initial :heating
+         :entry   :enter-conditioning
+         :exit    :exit-conditioning
+         :states
+         {:heating
+          {:tags  #{:climate/heating}
+           :entry :enter-heating
+           :exit  :exit-heating
+           :on    {:hvac/mode-toggle {:target :cooling :action :swap-mode}}}
+
+          :cooling
+          {:tags  #{:climate/cooling}
+           :entry :enter-cooling
+           :exit  :exit-cooling
+           :on    {:hvac/mode-toggle {:target :heating :action :swap-mode}}}}}}}}}
+
+    :fan
+    {:initial :off
+     :states
+     {:off
+      {:tags #{:fan/off}
+       :on   {:hvac/power-cycle {:target :on :action :fan-on}}}
+
+      :on
+      {:tags  #{:fan/on}
+       :entry :enter-fan-on
+       :exit  :exit-fan-on
+       :on    {:hvac/power-cycle {:target :off :action :fan-off}
+               :hvac/nudge {:target :same-state :action :nudge-fan}
+               :hvac/tweak {:action :tweak-fan}}}}}}
+
+   :actions
+   {:enter-running         (trail-action 'enter-running         :action:power-on)
+    :enter-running-level   (trail-action 'enter-running-level   :entry:running)
+    :exit-running-level    (trail-action 'exit-running-level    :exit:running)
+    :back-to-idle          (trail-action 'back-to-idle          :action:power-off)
+    :enter-conditioning    (trail-action 'enter-conditioning    :entry:conditioning)
+    :exit-conditioning     (trail-action 'exit-conditioning     :exit:conditioning)
+    :enter-heating         (trail-action 'enter-heating         :entry:heating)
+    :exit-heating          (trail-action 'exit-heating          :exit:heating)
+    :enter-cooling         (trail-action 'enter-cooling         :entry:cooling)
+    :exit-cooling          (trail-action 'exit-cooling          :exit:cooling)
+    :swap-mode             (trail-action 'swap-mode             :action:swap-mode)
+    :fan-on                (trail-action 'fan-on                :action:fan-on)
+    :fan-off               (trail-action 'fan-off               :action:fan-off)
+    :enter-fan-on          (trail-action 'enter-fan-on          :entry:fan-on)
+    :exit-fan-on           (trail-action 'exit-fan-on           :exit:fan-on)
+    :nudge-fan             (trail-action 'nudge-fan             :action:nudge)
+    :tweak-fan             (trail-action 'tweak-fan             :action:tweak)}})
+
+;; ============================================================================
+;; HISTORY (gap 8) — the rejection probe
+;; ============================================================================
+;;
+;; re-frame2 currently REJECTS `:history` at registration time
+;; (`:rf.error/machine-grammar-not-in-v1`, Spec 005 §Substitutes; rf2-rkkag).
+;; This spec is NOT registered at load (it would throw); it is the subject of
+;; the rejection probe. When `:history` lands, this becomes a live machine
+;; and the placeholder rungs activate.
+
+(def history-machine-spec
+  "A `:type :history` machine — REJECTED under the v1 deferral. The rejection
+  probe registers it to confirm the deferred-grammar error fires."
+  {:type    :history
+   :initial :a
+   :states  {:a {}}})
+
+(defn history-rejected?
+  "Attempt to register `history-machine-spec` and return true iff it is
+  REJECTED with `:rf.error/machine-grammar-not-in-v1` (the current v1
+  deferral contract). Returns false if it unexpectedly registered (the
+  feature shipped — flip the placeholder rungs), or rethrows a non-history
+  error. The harness asserts this directly via `reg-machine` too."
+  []
+  (try
+    (rf/reg-machine :machine-epochs/history-probe history-machine-spec)
+    false
+    (catch :default e
+      (= :rf.error/machine-grammar-not-in-v1 (:rf.error/id (ex-data e))))))
+
+;; ============================================================================
+;; REGISTRATION
+;; ============================================================================
+
+(defn register-all!
+  "Register every NON-throwing-at-registration machine in the deck. Called by
+  the deck mount AND by the assertion harness so both drive the identical
+  specs. (The `:history` machine is NOT registered — it throws by design; the
+  rejection probe registers it on demand.)"
+  []
+  (rf/reg-machine :door/main        door-machine)
+  (rf/reg-machine :traffic/light    traffic-machine)
+  (rf/reg-machine :quiz/scorer      quiz-machine)
+  (rf/reg-machine :brew/machine     brew-machine)
+  (rf/reg-machine :session/login    session-login-machine)
+  (rf/reg-machine :session/flow     session-flow-machine)
+  (rf/reg-machine :fuse/box         fuse-machine)
+  (rf/reg-machine :hvac/controller  hvac-controller-machine))


### PR DESCRIPTION
Redesigns the `machine-epochs` testbed (`tools/xray/testbeds/machine_epochs`) from a visual-only deck into a comprehensive, ASSERTION-BACKED machine × Xray-cascade-render regression harness (rf2-g27vv). Re-driving the deck is now a real regression test of Xray rendering, not just a visual walk.

Machine specs are split into `machine-epochs.machines` (a sibling ns) so the CLJS harness registers the IDENTICAL values the deck mounts — no drift between "what the operator sees" and "what the test drives".

## Feature × render-surface matrix (as built)

| Rung(s) | Machine | Feature | Render surface lit + asserted |
|---|---|---|---|
| 1 | door | bootstrap | `:initial-entry`, NOT a no-op (t4582) |
| 2 | door | plain transition | exit→TRANSITION→entry rows; one transition row |
| 3 | door | entry+exit actions | exit + entry action rows; entry `:data-delta` bump |
| 4/5 | door | guard pass / **blocked** | guard row `:pass`/`:fail`; blocked = one `:no-op` row, zero transition rows |
| 5-sub | door | INTERNAL transition | action-only, no exit/entry/no-op |
| 6 | door | transition-with-fx | transition + action; downstream child epoch |
| 7 | door | unhandled **no-op** | ONE `[NO OP] staying in :alarming`, no transition row (coozg/e6q97/iu3no) |
| 8 | door | **root-`:on` RESOLUTION** (gap 6) | transition attributed to the root clause |
| 9 | traffic | parallel regions | one aggregate transition, region→state map; inspector view-model |
| 10 | traffic | history + **TAG-SET delta** (gap 7) | member-level `:added`/`:removed`, constant member doesn't churn (rf2-l0us2) |
| 11 | traffic/brew | multiple machines / no-op naming | `:show-machine-name?` true when >1 machine in play (iu3no) |
| 12 | quiz | `:answer` below mark | `:microsteps` 0, stays `:asking` |
| 13 | quiz | **`:always` MICROSTEPS** (gap 1) | `:microsteps` > 0 + the structured `:cascade` `:microstep` step (n9f4z/52u5n) |
| 14/15 | brew | **`:after` TIMER** auto-fire (gap 2) | `:scheduled` trace, then `:brewing`→`:ready` |
| 16 | brew | **timer CANCEL** (gap 2) | `:timer` cascade row, `:reason :on-exit`, the `:cancelled` chip |
| 17 | session | **SPAWN** child actor (gap 4) | spawn fx + the spawn-registry slot |
| 18 | session | child `:final?` + `:on-done` + auto-**DESTROY** (gaps 3,5) | `:rf.machine/finished` destroy trace; parent `:on-done` token report |
| 19 | fuse | `:*` wildcard **THROW** | action row `:threw? true` + `:exception`, never a no-op (rf2-hhkbb gap b) |
| 20 | hvac | deep parallel initial cascade | per-region parallel `:cascade` walk |
| 21 | hvac | multi-level LCA cascade | trail = exit:heating → swap-mode @ LCA → entry:cooling |
| 22/23 | hvac | external vs internal self-transition | exit+action+entry vs action-only; no spurious no-op |
| 24 | history | **`:history` reject-now** (gap 8) | `reg-machine` throws `:rf.error/machine-grammar-not-in-v1` |
| 25/26 | — | shallow/deep history restore | DISABLED placeholders (activate when `:history` lands) |

## Assertion layer

Each rung is backed by a CLJS-unit assertion in `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test` (Causa/Story-as-CLJS, not Playwright). Each asserts BOTH layers: the machine OUTCOME via the generalized per-machine `:data :trail` order-oracle (now on every machine, not just HVAC), AND the Xray cascade-render projection it lights up (`machine-cascade-rows`, the structured `:cascade`, the inspector view-model, `diff/project`). The `feature_matrix` gate scenario (`runMachineEpochs`) was rewritten for the new ladder + the new rungs (microstep/timer/lifecycle/history) and asserts each rung's configuration via the deck's snapshot mirror + the no-op/throw trace contrast. Spec `tools/xray/spec/{003,021}` updated to document the harness + matrix.

Subsumes + extends rf2-k08ay (the HVAC `hard-machine-fidelity` test stays as the deep-dive complement).

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` (node-test, incl. the new harness ns) | PASS — 5370 tests / 18471 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` (deck + scenario) | PASS — 16 scenarios, 0 failures, 13 matrix rows |
| JVM xray (`clojure -M:test`) | PASS — 1068 tests / 4340 assertions, 0 failures, 0 errors |
| JVM machines (`clojure -M:test`) | PASS — 347 tests / 1129 assertions, 0 failures, 0 errors |
| JVM epoch (`clojure -M:test`) | PASS — 245 tests / 892 assertions, 0 failures, 0 errors |
| `examples/machine-epochs` release build | PASS — compiles clean (0 warnings) |

Known flake (per the bead, confirmed local-env-only, GREEN on CI): `routes-epochs routing ladder` / `static mode chrome and chord` — both PASSED in this run.
