### PR TITLE
fix(xray): member-level diff for multi-member simultaneous set swaps (rf2-4vp8c)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -162,11 +162,21 @@ Two engine rules make this hold:
   removal (the "sea of red"). Collecting the union of members means a
   swapped set contributes both a `:removed` and an `:added` leaf, so the
   uniformity test correctly fails **at the set and at every ancestor**.
-- **An empty↔populated set replace expands per-member.** When one side is
-  the *empty* set Editscript falls back to a whole-value `:r` (the same
-  pathology as the empty map, rf2-9d4j8); the projection pre-expands it
-  into per-member `:+` / `:-` edits so `#{} → #{:a}` and `#{:a} → #{}`
-  classify member-level rather than as a single opaque `:modified`.
+- **A whole-set `:r` replace expands into the membership delta — for ANY
+  member count (rf2-4vp8c).** Editscript emits per-member `:+` / `:-`
+  edits for a *single*-member swap, but crosses its A* cost threshold and
+  falls back to a whole-value `:r` once *multiple* members change at once
+  (`#{:a :b :c} → #{:a :d :e}` ⇒ `[[] :r #{:a :d :e}]`) — and for the
+  empty↔populated edge (`#{} → #{:a}`, the same pathology as the empty
+  map, rf2-9d4j8). The projection catches every set `:r` and pre-expands
+  it into the membership delta (members only-in-before ⇒ `:-`,
+  only-in-after ⇒ `:+`, in-both ⇒ unchanged) so a multi-member swap reads
+  `-:b -:c +:d +:e` with `:a` intact rather than as a single opaque
+  `:modified` ("sea of red"). The empty↔populated case is the degenerate
+  one where the in-both intersection is empty. Without this, l0us2's
+  single-member fix left the *common* real-world transition — a machine
+  `:tags` set dropping and adding several tags at once — still
+  misrendering as a whole-set replacement.
 
 A set is therefore only a **wholly-changed root** when the opposite side
 is empty or absent (a genuine cold-boot `#{} → #{…}` or clear `#{…} →

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -84,7 +84,8 @@
   budget (millisecond range for typical app-dbs). For pathologically
   large structures the calling code can short-circuit via
   `identical?` BEFORE invoking this engine."
-  (:require [editscript.core :as es]
+  (:require [clojure.set :as set]
+            [editscript.core :as es]
             [editscript.edit :as ee]))
 
 ;; =========================================================================
@@ -164,41 +165,78 @@
 ;; raw Editscript edit-script walker
 ;; =========================================================================
 
-(defn- expand-empty-collection-replacement
-  "Expand a single Editscript edit that replaces an EMPTY MAP / SET with
-  a populated one (or vice versa) into per-member `:+` / `:-` edits.
+(defn- expand-set-replacement
+  "Expand an Editscript whole-set `:r` (replace) at a SET-valued path into
+  the per-member membership delta: members only-in-before ⇒ `:-`, members
+  only-in-after ⇒ `:+`, members in BOTH ⇒ no edit (unchanged). Members
+  match BY VALUE (sets are unordered), mirroring Editscript's own set-edit
+  path scheme (the member itself is the trailing path segment).
+
+  Editscript's A* emits per-member `:+` / `:-` edits for a SINGLE-member
+  swap (`#{:a} → #{:b}` ⇒ `[[:a] :-] [[:b] :+]`, fixed member-level by
+  rf2-l0us2) but crosses its cost threshold and falls back to a WHOLE-SET
+  `:r` once MULTIPLE members change simultaneously
+  (`#{:a :b :c} → #{:a :d :e}` ⇒ `[[] :r #{:a :d :e}]`) — the empty↔populated
+  edge (`#{} → #{:a}`) hits the same `:r`. Left alone the `:r` classifies as
+  a single `:modified` at the set's path and every per-member path returns
+  `:same` from `op-at`, which the renderer paints as a whole-set
+  removal/add ('sea of red') instead of member-level `-removed +added`
+  (rf2-4vp8c, residual of rf2-l0us2 which fixed only the single-member
+  case). Synthesizing the membership delta restores member-level chrome
+  REGARDLESS of how many members changed; this subsumes the empty↔populated
+  set expansion (the in-both set is empty there, so it degenerates to
+  all-`:+` or all-`:-`).
+
+  Pure."
+  [path before-set after-set]
+  (into (mapv (fn [el] [(conj (vec path) el) :-])
+              (set/difference before-set after-set))
+        (mapv (fn [el] [(conj (vec path) el) :+ el])
+              (set/difference after-set before-set))))
+
+(defn- expand-collection-replacement
+  "Expand a single Editscript edit that replaces a collection wholesale
+  (whole-value `:r`) into per-member `:+` / `:-` edits, so downstream
+  classification sees member-level granularity instead of one whole-value
+  `:modified`.
+
+  ## Empty↔populated maps (rf2-9d4j8 / rf2-5j7ch)
 
   Editscript's A* emits a single `[[path] :r new-value]` edit for the
-  pathological `{} → {populated}` (and `{populated} → {}`) cases — the
-  whole collection replacement is one step in the edit script. Downstream
-  classification then tags `path` as `:modified` and leaves every
-  PER-MEMBER path returning `:same` from `op-at`, which the renderer reads
-  as 'no per-member change' — wrong for an absent→present transition
-  (rf2-9d4j8; related precedent rf2-5j7ch which patched only the
-  `:flat-rows` lens).
+  `{} → {populated}` (and `{populated} → {}`) cases — the whole collection
+  replacement is one step in the edit script. Downstream classification
+  then tags `path` as `:modified` and leaves every PER-KEY path returning
+  `:same` from `op-at`, which the renderer reads as 'no per-key change' —
+  wrong for an absent→present transition (rf2-9d4j8; related precedent
+  rf2-5j7ch which patched only the `:flat-rows` lens).
 
-  ## Sets share the empty-replace pathology (rf2-l0us2)
+  ## Sets — empty↔populated AND multi-member swaps (rf2-l0us2 / rf2-4vp8c)
 
-  For NON-empty sets Editscript already emits member-level `:+` / `:-`
-  edits (members are value-keyed: `#{:a} → #{:b}` ⇒ `[[:a] :-] [[:b] :+]`),
-  so they need no expansion. But when ONE side is the EMPTY set Editscript
-  falls back to the same whole-value `:r` it uses for empty maps
-  (`#{} → #{:a}` ⇒ `[[] :r #{:a}]`). Left alone that classifies as a single
-  `:modified` op at the set's path and the renderer's per-member walk sees
-  every member as `:same`. The set members are keyed by VALUE, mirroring
-  Editscript's own set-edit path scheme, so the per-member expansion uses
-  the member itself as the trailing path segment.
+  For a SINGLE-member set swap Editscript already emits member-level
+  `:+` / `:-` edits (`#{:a} → #{:b}` ⇒ `[[:a] :-] [[:b] :+]`), so it needs
+  no expansion. But Editscript falls back to a whole-value `:r` for sets in
+  two cases: when ONE side is EMPTY (`#{} → #{:a}` ⇒ `[[] :r #{:a}]`,
+  rf2-l0us2) AND when MULTIPLE members change simultaneously
+  (`#{:a :b :c} → #{:a :d :e}` ⇒ `[[] :r #{:a :d :e}]`, rf2-4vp8c — its
+  A* cost threshold). Both classify as a single `:modified` at the set's
+  path with every per-member path `:same` ('sea of red'). We catch ALL
+  set `:r` here and delegate to `expand-set-replacement`, which synthesizes
+  the membership delta regardless of member count — the empty↔populated
+  edge is just the degenerate case where the in-both intersection is empty.
 
   This expansion runs over the raw edit script BEFORE classification so
   every downstream artefact (`:path-ops`, `:container-ops`,
   `:flat-rows`, `:wholly-changed-roots`) sees per-member granularity.
 
-  Rule: a `:r` edit at `path` substitutes into per-member edits ONLY when
-  one side at `path` is an EMPTY collection and the other is a NON-EMPTY
-  collection of the SAME KIND (empty-map↔populated-map or
-  empty-set↔populated-set). Type changes (nil↔map, scalar↔map,
-  map↔vector, set↔map) are LEFT ALONE so R7's `:rf.xray.diff/type-change?`
-  branch still fires on them.
+  Rule:
+    - SET↔SET `:r` (both sides sets) → membership-delta expansion, any
+      member count (`expand-set-replacement`).
+    - MAP `:r` where ONE side is the EMPTY map → per-key `:+` / `:-`.
+      (Multi-key populated↔populated MAP swaps are NOT a known Editscript
+      `:r` pathology — A* emits per-key edits for maps — so this branch
+      stays scoped to the empty edge.)
+    - Type changes (nil↔map, scalar↔set, map↔vector, set↔map) are LEFT
+      ALONE so R7's `:rf.xray.diff/type-change?` branch still fires.
 
   Pure; non-matching edits pass through unchanged."
   [edit before after]
@@ -208,6 +246,12 @@
       (let [before-at (value-at before path)
             after-at  (value-at after path)]
         (cond
+          ;; SET↔SET replace — synthesize the membership delta for ANY
+          ;; member count (single swap, multi-member swap, full no-overlap
+          ;; replacement, or the empty↔populated edge). rf2-4vp8c.
+          (and (set? before-at) (set? after-at))
+          (expand-set-replacement path before-at after-at)
+
           ;; {} → populated map: per-key :+
           (and (map? before-at) (empty? before-at)
                (map? after-at)  (seq after-at))
@@ -218,24 +262,15 @@
                (map? after-at)  (empty? after-at))
           (mapv (fn [[k _v]] [(conj (vec path) k) :-]) before-at)
 
-          ;; #{} → populated set: per-member :+ (member is the path seg)
-          (and (set? before-at) (empty? before-at)
-               (set? after-at)  (seq after-at))
-          (mapv (fn [el] [(conj (vec path) el) :+ el]) after-at)
-
-          ;; populated set → #{}: per-member :-
-          (and (set? before-at) (seq before-at)
-               (set? after-at)  (empty? after-at))
-          (mapv (fn [el] [(conj (vec path) el) :-]) before-at)
-
           :else
           [edit])))))
 
 (defn- raw-edits
   "Return Editscript A* edits for `(before, after)` as a vector of
-  3-tuples `[path op value?]`, with empty↔populated map/set replacements
-  pre-expanded into per-member `:+` / `:-` edits (rf2-9d4j8, rf2-l0us2).
-  Pure."
+  3-tuples `[path op value?]`, with whole-value collection replacements
+  pre-expanded into per-member `:+` / `:-` edits: empty↔populated maps
+  (rf2-9d4j8), empty↔populated sets (rf2-l0us2), and multi-member set
+  swaps (rf2-4vp8c). Pure."
   [before after]
   (let [raw (try
               (ee/get-edits (es/diff before after {:algo :a-star}))
@@ -247,7 +282,7 @@
                 ;; reproduces the operator-visible signal ("everything
                 ;; changed") without false sub-tree precision.
                 [[[] :r after]]))]
-    (into [] (mapcat (fn [edit] (expand-empty-collection-replacement edit before after))) raw)))
+    (into [] (mapcat (fn [edit] (expand-collection-replacement edit before after))) raw)))
 
 ;; =========================================================================
 ;; per-path op classification (leaves)

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -464,7 +464,8 @@
 ;; the uniformity walk (`mark-wholly-changed` now collects the UNION of
 ;; both sides' set members so a swap fails uniformity at the set AND every
 ;; ancestor) plus per-member expansion of the empty↔populated `:r` set
-;; replace (`expand-empty-collection-replacement`).
+;; replace (`expand-collection-replacement` / `expand-set-replacement`;
+;; rf2-4vp8c later generalised the set branch to multi-member swaps too).
 
 (deftest l0us2-set-member-swap-is-member-level-not-whole-key
   (testing "rf2-l0us2 — RED repro: `#{:a} → #{:b}` member swap projects
@@ -652,4 +653,154 @@
     (let [p (engine/project [:a :b :c :d] [:a :NEW :b :c :d])]
       (is (= :added (engine/op-at p [1])))
       (is (= :same-shifted (engine/op-at p [2]))))))
+
+;; ---- rf2-4vp8c — MULTI-MEMBER simultaneous set swaps -------------------
+;;
+;; Residual of rf2-l0us2. l0us2 made SINGLE-member swaps member-level: for
+;; `#{:a} → #{:b}` (and the 1-in/1-out partial swap `#{:a :b} → #{:a :c}`)
+;; Editscript's A* emits per-member `:-` / `:+` edits, so the engine's
+;; member-keyed path-ops + the union-walk in `mark-wholly-changed` already
+;; render `-:a +:b` with the key intact.
+;;
+;; But when MULTIPLE members change at once (e.g. a machine `:tags` set
+;; dropping two tags + adding two on a state transition) Editscript's A*
+;; crosses its cost threshold and emits a WHOLE-SET `:r` (replace) at the
+;; set's path instead of per-member edits:
+;;
+;;   `#{:a :b :c} → #{:a :d :e}` ⇒ `[[[] :r #{:a :d :e}]]`
+;;
+;; Left alone `project`'s `:r` branch classifies that as a single
+;; `:modified` at the set's path and every per-member path returns `:same`
+;; — the renderer paints a whole-set removal/add ('sea of red'), exactly
+;; the regression l0us2 fixed for the single-member case.
+;;
+;; The fix extends `expand-collection-replacement` (via
+;; `expand-set-replacement`) to the populated↔populated set case: a `:r`
+;; at a SET-valued path where BOTH
+;; sides are sets synthesizes the membership delta (members only-in-before
+;; ⇒ `:-`, only-in-after ⇒ `:+`, in-both ⇒ no edit) regardless of how many
+;; members changed. Members match BY VALUE (sets unordered). The engine's
+;; output shape is unchanged — the renderer needs no edit.
+
+(deftest multimember-set-swap-is-member-level-not-whole-key
+  (testing "rf2-4vp8c — RED repro: `#{:a :b :c} → #{:a :d :e}` (drop :b,:c
+            add :d,:e, keep :a) projects KEY-INTACT member-level
+            `-:b -:c +:d +:e` with `:a` unchanged — NOT a whole-set
+            replace. (Before the fix Editscript's whole-set `:r` made the
+            set read as a single `:modified` with every member `:same`.)"
+    (let [p (engine/project {:tags #{:a :b :c}} {:tags #{:a :d :e}})]
+      ;; The :tags KEY is intact — :children, never :modified/:removed.
+      (is (= :children (engine/op-at p [:tags])))
+      (is (not (contains? (:wholly-changed-roots p) [:tags])))
+      ;; Dropped members are :removed.
+      (is (= :removed (engine/op-at p [:tags :b])))
+      (is (= :removed (engine/op-at p [:tags :c])))
+      ;; Added members are :added.
+      (is (= :added (engine/op-at p [:tags :d])))
+      (is (= :added (engine/op-at p [:tags :e])))
+      ;; The surviving member carries no op (returns :same).
+      (is (= :same (engine/op-at p [:tags :a])))
+      ;; The dropped/added members carry their values for the renderer's
+      ;; per-member suffix.
+      (is (= :b (:before (engine/entry-at p [:tags :b]))))
+      (is (= :d (:after (engine/entry-at p [:tags :d])))))))
+
+(deftest multimember-set-swap-no-overlap
+  (testing "rf2-4vp8c — a set whose members are ALL replaced (no overlap):
+            `#{:a :b :c} → #{:d :e :f}` projects every before-member
+            :removed + every after-member :added, key intact. (Distinct
+            from the empty↔populated path — both sides are populated.)"
+    (let [p (engine/project {:tags #{:a :b :c}} {:tags #{:d :e :f}})]
+      (is (= :children (engine/op-at p [:tags])))
+      (is (not (contains? (:wholly-changed-roots p) [:tags])))
+      (is (= :removed (engine/op-at p [:tags :a])))
+      (is (= :removed (engine/op-at p [:tags :b])))
+      (is (= :removed (engine/op-at p [:tags :c])))
+      (is (= :added (engine/op-at p [:tags :d])))
+      (is (= :added (engine/op-at p [:tags :e])))
+      (is (= :added (engine/op-at p [:tags :f]))))))
+
+(deftest multimember-set-swap-at-root
+  (testing "rf2-4vp8c — the same delta at the ROOT (a bare set, not nested):
+            `#{:a :b :c} → #{:a :d :e}` projects member-level at the root.
+            The set root `[]` is excluded from wholly-changed promotion
+            regardless; the invariant is no whole-set replace."
+    (let [p (engine/project #{:a :b :c} #{:a :d :e})]
+      (is (= :removed (engine/op-at p [:b])))
+      (is (= :removed (engine/op-at p [:c])))
+      (is (= :added (engine/op-at p [:d])))
+      (is (= :added (engine/op-at p [:e])))
+      (is (= :same (engine/op-at p [:a])))
+      (is (= #{} (:wholly-changed-roots p)))
+      ;; The root set is NOT a single :modified.
+      (is (not= :modified (engine/op-at p []))))))
+
+(deftest multimember-machine-tags-transition-repro
+  (testing "rf2-4vp8c — the live repro path: a machine `:tags` set on a
+            state transition drops two tags + adds one
+            (`#{:door/locked :door/secure} → #{:door/open}`). The :tags key
+            stays intact and reads `-:door/locked -:door/secure +:door/open`."
+    (let [p (engine/project {:tags #{:door/locked :door/secure}}
+                            {:tags #{:door/open}})]
+      (is (= :children (engine/op-at p [:tags])))
+      (is (= :removed (engine/op-at p [:tags :door/locked])))
+      (is (= :removed (engine/op-at p [:tags :door/secure])))
+      (is (= :added (engine/op-at p [:tags :door/open])))
+      (is (not (contains? (:wholly-changed-roots p) [:tags]))))))
+
+(deftest multimember-set-swap-feeds-flat-rows
+  (testing "rf2-4vp8c — the multi-member member-level delta also surfaces on
+            the `:diff` (pure-list) flat-rows lens, with the key intact."
+    (let [p (engine/project {:tags #{:a :b :c}} {:tags #{:a :d :e}})
+          rows (:flat-rows p)
+          paths (set (map :path rows))
+          op-at-path (fn [path]
+                       (some (fn [r] (when (= path (:path r)) (:op r))) rows))]
+      (is (contains? paths [:tags :b]))
+      (is (contains? paths [:tags :c]))
+      (is (contains? paths [:tags :d]))
+      (is (contains? paths [:tags :e]))
+      (is (= :removed (op-at-path [:tags :b])))
+      (is (= :added (op-at-path [:tags :d])))
+      ;; The surviving member + the intact key are NOT flat-rows.
+      (is (not (contains? paths [:tags :a])))
+      (is (not (contains? paths [:tags]))))))
+
+(deftest multimember-set-swap-does-not-promote-ancestor-map
+  (testing "rf2-4vp8c — a multi-member-swapped set must not falsely promote
+            an ANCESTOR map (the deeper trap). `{:m {:tags #{:a :b :c}}} →
+            {:m {:tags #{:a :d :e}}}` keeps both `:m` and `:m :tags` intact."
+    (let [p (engine/project {:m {:tags #{:a :b :c}}}
+                            {:m {:tags #{:a :d :e}}})]
+      (is (= :children (engine/op-at p [:m])))
+      (is (= :children (engine/op-at p [:m :tags])))
+      (is (= #{} (:wholly-changed-roots p)))
+      (is (= :removed (engine/op-at p [:m :tags :b])))
+      (is (= :added (engine/op-at p [:m :tags :d])))
+      (is (= :same (engine/op-at p [:m :tags :a]))))))
+
+(deftest multimember-set-of-non-keyword-members
+  (testing "rf2-4vp8c — multi-member match BY VALUE regardless of type. A
+            set of numbers swapping multiple members diffs member-level."
+    (let [p (engine/project {:t #{1 2 3}} {:t #{1 4 5}})]
+      (is (= :children (engine/op-at p [:t])))
+      (is (= :removed (engine/op-at p [:t 2])))
+      (is (= :removed (engine/op-at p [:t 3])))
+      (is (= :added (engine/op-at p [:t 4])))
+      (is (= :added (engine/op-at p [:t 5])))
+      (is (= :same (engine/op-at p [:t 1]))))))
+
+(deftest multimember-set-branch-leaves-type-changes-alone
+  (testing "rf2-4vp8c — regression guard: the broadened SET↔SET `:r`
+            branch must only fire when BOTH sides are sets. A set↔non-set
+            flip (set→vector, scalar→set) stays an R7 `:modified`
+            type-change at the container path, NOT a member-delta."
+    ;; set → vector — R7 type change, key reads :modified, type-change? set.
+    (let [p (engine/project {:t #{:a :b}} {:t [:a :b]})]
+      (is (= :modified (engine/op-at p [:t])))
+      (is (engine/type-change? p [:t])))
+    ;; scalar → set — R7 type change.
+    (let [p (engine/project {:t 5} {:t #{:a}})]
+      (is (= :modified (engine/op-at p [:t])))
+      (is (engine/type-change? p [:t])))))
 


### PR DESCRIPTION
## What

Residual of rf2-l0us2 (#2838). l0us2 made set diffs member-level for the **single-member** swap case — where Editscript's A* emits per-member `:+` / `:-` edits. But once **multiple** set members change in one diff (e.g. a machine `:tags` set dropping two tags + adding one on a state transition — a common real transition), A* crosses its cost threshold and falls back to a **whole-set `:r` (replace)**:

```
#{:a :b :c} → #{:a :d :e}   ⇒   [[[] :r #{:a :d :e}]]
```

`engine/project`'s `:r` branch classified that as a single `:modified` at the set's path, with every per-member path returning `:same` from `op-at`. The renderer then painted a whole-set removal/add (the "sea of red") instead of member-level `-:b -:c +:d +:e` with `:a` intact.

## The fix (engine seam)

Generalise l0us2's empty-set `:r` expansion to **all** set `:r`. The old `expand-empty-collection-replacement` only expanded a `:r` when one side was the *empty* collection. It is renamed `expand-collection-replacement` and now, for any **SET↔SET** `:r` (both sides sets), delegates to a new `expand-set-replacement` that synthesizes the **membership delta** — members only-in-before ⇒ `:-`, only-in-after ⇒ `:+`, in-both ⇒ no edit — **regardless of member count**. The empty↔populated set edge becomes the degenerate case (empty in-both intersection, so it degrades to all-`:+` or all-`:-`).

Untouched:
- MAP empty↔populated expansion (rf2-9d4j8) — populated↔populated map swaps are not an Editscript `:r` pathology, so that branch stays scoped to the empty edge.
- R7 type changes — a set↔non-set flip (`set→vector`, `scalar→set`) has only one side a set, so it skips the new branch and still classifies as `:modified` with `:rf.xray.diff/type-change?` (regression-guarded).

## Renderer

**No change needed.** The renderer's `children-of-pair` `:set` branch already enumerates the **union** of both sides' members and looks up each member's op via `engine/op-at`. The bug was purely that the engine collapsed the multi-member `:r` to a whole-value `:modified` so every member resolved `:same`. With the engine emitting member-level ops, the renderer paints them correctly.

## Tests (reproduce-then-fix)

RED-then-GREEN multi-member tests (8 new, all failed before the fix — the "sea of red"):
- multi-member swap with an overlapping survivor (`#{:a :b :c} → #{:a :d :e}`) → key-intact `-:b -:c +:d +:e`, `:a` unchanged
- full no-overlap replacement (`#{:a :b :c} → #{:d :e :f}`)
- root-level bare set
- the live machine `:tags` transition repro
- flat-rows (`:diff` lens) coverage
- ancestor-map non-promotion (the deeper trap)
- non-keyword members (numbers)
- type-change regression guard (set↔non-set stays R7 `:modified`)

Existing l0us2 single-member + empty↔populated guards stay green (regression guards).

## Spec

`tools/xray/spec/004-App-DB-Diff.md` set-member-diff note generalised from "empty↔populated set replace" to "whole-set `:r` for any member count", citing rf2-4vp8c.

## Quality gates

| Gate | Result |
|------|--------|
| `tools/xray` JVM — `clojure -M:test` | PASS — 1076 tests, 4393 assertions, 0 failures |
| `npm run test:cljs` (COLD, node runtime) | PASS — 5357 tests, 18426 assertions, 0 failures |
| `npm run test:xray-feature-gate` (g27vv traffic rung) | PASS — 16 scenarios, 0 failures |

engine.cljc is CLJC → exercised on both JVM and CLJS runtimes.

Closes rf2-4vp8c.
