### PR TITLE
fix(xray): comprehensive edn-inspector diff audit — full datatype matrix, unit coverage, testbed rework (rf2-yucxn)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -202,6 +202,54 @@ taken only for sets.
 > fixes: all three close gaps where the wholly-changed uniformity walk
 > disagreed with the per-leaf op classification.
 
+### Vectors and lists diff member-level at the empty edge (rf2-yucxn)
+
+A **vector or list** that goes empty with its **key intact** (`{:a [1]}
+→ {:a []}`, `{:a '(1)} → {:a '()}`) is an **element removal**, not a
+wholesale value mutation — and going **populated from empty** (`{:a []}
+→ {:a [1]}`) is an **element addition**. Editscript emits a whole-value
+`:r` for the sequential empty edge (`[1] → []` ⇒ `[[] :r []]`), exactly
+as it does for the empty map (rf2-9d4j8) and empty set (rf2-l0us2). Left
+alone that `:r` classifies as a single `:modified` at the sequential's
+path — a whole-key `~` modify — which reads **inconsistently** with the
+set/map empty edges (which expand member-level with the key intact).
+
+The projection **pre-expands the sequential empty-edge `:r`** into
+per-index `:-` (going empty) / `:+` (filling from empty), bringing
+vectors and lists to member-level parity with sets and maps. The
+expansion is scoped to the empty edge **and to same-family
+sequentials** — both sides must be sequentials (neither set nor map), so
+a vector↔map (or vector↔set) flip at the empty edge stays an R7
+`:modified` type-change rather than a spurious member delta. A
+populated↔populated vector swap never collapses to a whole-value `:r`
+(Editscript emits per-index edits), so there is no `:r` to intercept
+there.
+
+A vector/list `:-` removal flows through the off-path
+`:vector-removals` channel (a removed before-index has no stable
+after-side path — the survivors shift up). **Multiple `:-` edits at one
+sequential are recovered by replaying the edit-indices against the
+progressively-shrinking before-sequence**, because Editscript applies
+`:-` edits *sequentially*: each `:-` at edit-index `i` removes the
+element *currently* at index `i` after all prior `:-` at this parent.
+A contiguous tail deletion therefore repeats the same edit-index (`[1 2
+3] → [1]` ⇒ `[[1] :-] [[1] :-]`) and a scattered deletion uses
+post-shift indices (`[:a :b :c :d] → [:a :c]` ⇒ `[[1] :-] [[2] :-]`).
+Resolving each `:-` against the *original* before-vector independently
+(the pre-fix approach) read the wrong element for every edit after the
+first — reporting one before-value repeatedly and dropping the rest.
+The replay recovers the true before-index + before-value for every
+removed element regardless of contiguity or multiplicity.
+
+> **Renderer note (rf2-vu42n, deferred).** The engine's
+> `:vector-removals` channel is now correct for scattered/mid-vector
+> removals, but the inline vector body renderer still index-aligns the
+> before/after vectors via `children-of-pair` rather than consuming
+> `:vector-removals` + `:same-shifted`. Contiguous *tail* removals
+> render correctly; mid/scattered removals mis-render which members are
+> struck. Tracked separately so the renderer rework does not balloon the
+> engine fix.
+
 ### Removed slots render in place; the absence marker never escapes (rf2-8pfkk)
 
 The diff renders the **union of `before ∪ after`** — a slot present in

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -224,9 +224,27 @@
   the membership delta regardless of member count — the empty↔populated
   edge is just the degenerate case where the in-both intersection is empty.
 
+  ## Vectors / lists — empty↔populated edge (rf2-yucxn)
+
+  Editscript emits a whole-value `:r` for the vector/list empty edge too
+  (`[1] → []` ⇒ `[[] :r []]`; `{:a [1]} → {:a []}` ⇒ `[[:a] :r []]`; and
+  symmetrically for `[] → [1]`). Left alone this classifies as a single
+  `:modified` at the sequential's path — a whole-key `~` modify — which
+  reads inconsistently with the set/map empty edges (which expand to
+  member-level `:removed` / `:added` with the key intact). A vector/list
+  going empty is an ELEMENT REMOVAL (and going populated-from-empty an
+  ELEMENT ADD), not a wholesale value mutation. We expand the empty edge to
+  per-index `:-` / `:+` edits so it renders member-level, matching set/map.
+  Only the EMPTY edge is expanded: a populated↔populated vector swap is
+  handled by Editscript's per-index `:+` / `:-` / `:r` edits already (it does
+  NOT collapse to a whole-value `:r`), so there is no `:r` to intercept
+  there. Per-index `:-` edits then flow through `project`'s
+  `:vector-removals` channel exactly like ordinary tail deletions.
+
   This expansion runs over the raw edit script BEFORE classification so
   every downstream artefact (`:path-ops`, `:container-ops`,
-  `:flat-rows`, `:wholly-changed-roots`) sees per-member granularity.
+  `:flat-rows`, `:wholly-changed-roots`, `:vector-removals`) sees
+  member-level granularity.
 
   Rule:
     - SET↔SET `:r` (both sides sets) → membership-delta expansion, any
@@ -235,8 +253,13 @@
       (Multi-key populated↔populated MAP swaps are NOT a known Editscript
       `:r` pathology — A* emits per-key edits for maps — so this branch
       stays scoped to the empty edge.)
-    - Type changes (nil↔map, scalar↔set, map↔vector, set↔map) are LEFT
-      ALONE so R7's `:rf.xray.diff/type-change?` branch still fires.
+    - VECTOR/LIST/SEQ `:r` where ONE side is the EMPTY sequential → per-
+      index `:-` (going empty) / `:+` (filling from empty). Scoped to the
+      empty edge — populated↔populated sequentials never collapse to a
+      whole-value `:r` (rf2-yucxn).
+    - Type changes (nil↔map, scalar↔set, map↔vector, set↔map, vector↔map)
+      are LEFT ALONE so R7's `:rf.xray.diff/type-change?` branch still
+      fires (both sides must be the SAME sequential kind to expand).
 
   Pure; non-matching edits pass through unchanged."
   [edit before after]
@@ -261,6 +284,32 @@
           (and (map? before-at) (seq before-at)
                (map? after-at)  (empty? after-at))
           (mapv (fn [[k _v]] [(conj (vec path) k) :-]) before-at)
+
+          ;; rf2-yucxn — sequential (vector / list / seq) empty edge. BOTH
+          ;; sides must be sequentials of the same family (neither a set nor
+          ;; a map) so a vector↔map type flip stays an R7 `:modified`.
+          ;; `[] → [populated]`: per-index :+ at the AFTER indices.
+          ;; `[populated] → []`: per-index :- at the BEFORE indices (each
+          ;; flows through `project`'s `:vector-removals` channel).
+          ;; Indices descend for the removal so the renderer surfaces them
+          ;; in before order; `resolve-vector-removals` recovers the true
+          ;; before-index regardless.
+          (let [seq? (fn [v] (and (sequential? v) (not (map? v)) (not (set? v))))]
+            (and (seq? before-at) (seq? after-at)
+                 (or (empty? before-at) (empty? after-at))))
+          (let [bvec (vec before-at)
+                avec (vec after-at)]
+            (cond
+              (and (empty? bvec) (seq avec))
+              (mapv (fn [i] [(conj (vec path) i) :+ (nth avec i)])
+                    (range (count avec)))
+
+              (and (seq bvec) (empty? avec))
+              (mapv (fn [i] [(conj (vec path) i) :-])
+                    (range (count bvec)))
+
+              ;; both empty (shouldn't reach — `:r` implies a value change)
+              :else [edit]))
 
           :else
           [edit])))))
@@ -767,6 +816,51 @@
        (sort-by :path compare-path)
        vec))
 
+(defn- resolve-vector-removals
+  "rf2-yucxn — recover the true `{:before-index :before-value}` for every
+  `:-` edit Editscript emits at a single vector/list parent.
+
+  Editscript applies `:-` edits SEQUENTIALLY against a progressively-
+  shrinking sequence: each `:-` at edit-index `i` removes the element
+  CURRENTLY occupying index `i`, AFTER all prior `:-` at this parent have
+  already been applied. A contiguous tail deletion therefore repeats the
+  SAME edit-index (`[1 2 3] → [1]` ⇒ `[[1] :-] [[1] :-]`), and a scattered
+  deletion uses post-shift indices (`[:a :b :c :d] → [:a :c]` ⇒ `[[1] :-]
+  [[2] :-]`). Resolving `(value-at before [parent i])` independently per
+  edit (the pre-fix approach) read the WRONG element for every edit after
+  the first — reporting one before-value repeatedly and dropping the
+  genuinely-removed tail elements.
+
+  We replay the edits against a live mutable index map: `survivors` is the
+  vector of ORIGINAL before-indices still present; each `:-` at edit-index
+  `i` removes (and records) `survivors[i]`, then drops it from `survivors`.
+  The recorded original index resolves the before-value via `(nth bvec _)`.
+
+  `edits` are the raw `:-` edits at THIS parent in Editscript order; `bvec`
+  is the parent's before-side sequence as a vector. Returns a vector of
+  `{:before-index :before-value}` in before-index order. Pure."
+  [edits bvec]
+  (let [edit-idxs (mapv (fn [e] (peek (first e))) edits)
+        recovered (loop [survivors (vec (range (count bvec)))
+                         [i & more] edit-idxs
+                         acc        []]
+                    (if (nil? i)
+                      acc
+                      (if (and (>= i 0) (< i (count survivors)))
+                        (let [orig (nth survivors i)]
+                          (recur (into (subvec survivors 0 i)
+                                       (subvec survivors (inc i)))
+                                 more
+                                 (conj acc orig)))
+                        ;; Defensive: an out-of-range edit-index (should not
+                        ;; happen for well-formed Editscript output) is
+                        ;; skipped rather than crashing the projection.
+                        (recur survivors more acc))))]
+    (->> recovered
+         sort
+         (mapv (fn [orig] {:before-index orig
+                           :before-value (nth bvec orig)})))))
+
 (defn project
   "Compute the diff projection for `(before, after)`. Returns a map per
   the namespace docstring. Pure."
@@ -792,17 +886,28 @@
               (let [parent (value-at before (vec (butlast path)))]
                 (or (vector? parent)
                     (and (sequential? parent) (not (map? parent)) (not (set? parent)))))))
-          [vector-removals other-edits]
+          ;; Split raw edits into vector-`:-` deletions (per parent) and
+          ;; everything else. The deletions are grouped by parent path IN
+          ;; EDIT ORDER so `resolve-vector-removals` can replay them against
+          ;; the live before-sequence (rf2-yucxn — a single post-shift
+          ;; before-index resolution per edit was wrong for multi-element
+          ;; / scattered deletions).
+          [vec-del-edits other-edits]
           (reduce
-            (fn [[vrm oth] [path op value :as edit]]
+            (fn [[dels oth] [path op _value :as edit]]
               (if (and (= op :-) (vector-parent? path))
-                [(update vrm (vec (butlast path)) (fnil conj [])
-                         {:before-index (peek path)
-                          :before-value (value-at before path)})
-                 oth]
-                [vrm (conj oth edit)]))
+                [(update dels (vec (butlast path)) (fnil conj []) edit) oth]
+                [dels (conj oth edit)]))
             [{} []]
             raw)
+          vector-removals
+          (reduce-kv
+            (fn [acc parent-path edits]
+              (let [bvec (vec (value-at before parent-path))]
+                (assoc acc parent-path
+                       (resolve-vector-removals edits bvec))))
+            {}
+            vec-del-edits)
           ;; Step 1 — expand each non-vector-deletion raw edit into
           ;; per-leaf ops at every path the operator can navigate to in
           ;; the AFTER tree.

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -804,3 +804,258 @@
       (is (= :modified (engine/op-at p [:t])))
       (is (engine/type-change? p [:t])))))
 
+;; ---- rf2-yucxn — comprehensive base-case audit ------------------------
+;;
+;; A senior-dev sweep over the full datatype matrix (maps / vectors /
+;; lists / sets · scalars · empty-vs-removal · multi-adjust · deep mixed).
+;; Most rules were already pinned above; this section adds the cases the
+;; audit found uncovered or buggy:
+;;
+;;   BUG A — vector/list emptied (key intact) classified as a WHOLE-KEY
+;;           `:modified` instead of member-level removal (inconsistent
+;;           with the set/map empty edges). Fixed by expanding the
+;;           sequential empty-edge `:r` to per-index `:-` / `:+`.
+;;   BUG B — vector/list multi-element + scattered removal mis-recovered
+;;           the before-index/before-value (Editscript emits sequential
+;;           `:-` at post-shift indices; the pre-fix per-edit resolution
+;;           read one element repeatedly + dropped the rest). Fixed by
+;;           replaying the `:-` edits against the live before-sequence
+;;           (`resolve-vector-removals`).
+
+;; -- Case 3: empty-result (key intact) vs key-removal, ALL collection kinds
+
+(deftest yucxn-vector-emptied-is-member-level-removal
+  (testing "rf2-yucxn BUG A — `{:a [1]} → {:a []}` (vector emptied, key
+            intact) projects member-level: the element removal flows
+            through `:vector-removals` keyed by `[:a]`, NOT a whole-key
+            `:modified`. Matches the set/map empty edges."
+    (let [p (engine/project {:a [1]} {:a []})]
+      ;; No whole-key :modified at [:a].
+      (is (not= :modified (engine/op-at p [:a])))
+      ;; The removed element lives on the vector-removals channel.
+      (is (= [{:before-index 0 :before-value 1}]
+             (get-in p [:vector-removals [:a]])))
+      ;; flat-rows carry the member-level removal, not a [:a] row.
+      (let [paths (set (map :path (:flat-rows p)))]
+        (is (contains? paths [:a 0]))
+        (is (not (contains? paths [:a])))))))
+
+(deftest yucxn-list-emptied-is-member-level-removal
+  (testing "rf2-yucxn BUG A — `{:a (1)} → {:a ()}` (list emptied) behaves
+            like the vector empty edge: member-level, not whole-key."
+    (let [p (engine/project {:a '(1)} {:a '()})]
+      (is (not= :modified (engine/op-at p [:a])))
+      (is (= [{:before-index 0 :before-value 1}]
+             (get-in p [:vector-removals [:a]]))))))
+
+(deftest yucxn-vector-populated-from-empty-is-member-level-add
+  (testing "rf2-yucxn BUG A — symmetric `{:a []} → {:a [1]}` (vector filled
+            from empty) projects `[:a 0] :added` with `[:a]` wholly-changed,
+            mirroring the empty-map / empty-set cold-boot edge."
+    (let [p (engine/project {:a []} {:a [1]})]
+      (is (= :added (engine/op-at p [:a 0])))
+      (is (= 1 (:after (engine/entry-at p [:a 0]))))
+      (is (contains? (:wholly-changed-roots p) [:a])))))
+
+(deftest yucxn-list-populated-from-empty-is-member-level-add
+  (testing "rf2-yucxn BUG A — `{:a ()} → {:a (1)}` mirrors the vector edge."
+    (let [p (engine/project {:a '()} {:a '(1)})]
+      (is (= :added (engine/op-at p [:a 0])))
+      (is (contains? (:wholly-changed-roots p) [:a])))))
+
+(deftest yucxn-root-vector-empty-edges
+  (testing "rf2-yucxn BUG A — the empty edge at the ROOT (a bare vector):
+            `[1] → []` member-removes index 0; `[] → [1]` member-adds it.
+            Neither collapses to a whole-`[]` `:modified`."
+    (let [p (engine/project [1] [])]
+      (is (not= :modified (engine/op-at p [])))
+      (is (= [{:before-index 0 :before-value 1}]
+             (get-in p [:vector-removals []]))))
+    (let [p (engine/project [] [1])]
+      (is (not= :modified (engine/op-at p [])))
+      (is (= :added (engine/op-at p [0]))))))
+
+(deftest yucxn-empty-edge-vector-to-map-still-type-change
+  (testing "rf2-yucxn BUG A regression guard — the sequential empty-edge
+            expansion fires ONLY when BOTH sides are sequentials of the
+            same family. A vector↔map flip at the empty edge stays an R7
+            `:modified` type-change, never a spurious member delta."
+    ;; [] → {} would be identical-empty (no diff); use [] → {:k 1}.
+    (let [p (engine/project {:a []} {:a {:k 1}})]
+      (is (= :modified (engine/op-at p [:a])))
+      (is (engine/type-change? p [:a])))
+    ;; vector → set at the empty edge — R7, not a member-delta.
+    (let [p (engine/project {:a [1]} {:a #{}})]
+      (is (= :modified (engine/op-at p [:a])))
+      (is (engine/type-change? p [:a])))))
+
+(deftest yucxn-key-removed-distinct-from-emptied-all-kinds
+  (testing "rf2-yucxn Case 3 — the KEY-REMOVED transition (`{:a coll} → {}`)
+            must produce a wholly-changed `[:a]` (the renderer paints a
+            removed ghost), DISTINCT from the EMPTIED transition (`{:a coll}
+            → {:a empty-coll}`, key intact). Verified for set / map (which
+            share path-ops shape but differ structurally) and for the
+            vector/list channel split."
+    ;; KEY REMOVED — wholly-changed [:a] for every kind.
+    (doseq [coll [#{:x} {:k 1} [1] '(1)]]
+      (let [p (engine/project {:a coll} {})]
+        (is (contains? (:wholly-changed-roots p) [:a])
+            (str "key-removed " (pr-str coll) " marks [:a] wholly-changed"))))
+    ;; EMPTIED set/map — also wholly-changed [:a] in path-ops, BUT the
+    ;; structural distinction (key present in after) is the renderer's job;
+    ;; the engine correctly surfaces a member-level removal under [:a].
+    (let [p (engine/project {:a #{:x}} {:a #{}})]
+      (is (= :removed (engine/op-at p [:a :x]))))
+    (let [p (engine/project {:a {:k 1}} {:a {}})]
+      (is (= :removed (engine/op-at p [:a :k]))))
+    ;; EMPTIED vector/list — member-removal on the vector-removals channel,
+    ;; [:a] NOT in wholly-changed-roots (off-path, like a tail deletion).
+    (let [p (engine/project {:a [1]} {:a []})]
+      (is (seq (get-in p [:vector-removals [:a]])))
+      (is (not (contains? (:wholly-changed-roots p) [:a]))))))
+
+;; -- Case 2 + 5: vector multi-element / scattered removal (BUG B)
+
+(deftest yucxn-vector-multi-tail-removal-recovers-all-elements
+  (testing "rf2-yucxn BUG B — `{:a [1 2 3]} → {:a [1]}` drops TWO trailing
+            elements. Editscript emits two `:-` at the SAME post-shift
+            index; the engine must recover before-index 1 (value 2) AND
+            before-index 2 (value 3) — NOT value 2 twice with 3 dropped."
+    (let [p (engine/project {:a [1 2 3]} {:a [1]})
+          removals (get-in p [:vector-removals [:a]])]
+      (is (= [{:before-index 1 :before-value 2}
+              {:before-index 2 :before-value 3}]
+             removals)
+          "both removed elements recovered with true before-index + value")
+      ;; flat-rows surface both removed indices, distinct values.
+      (let [paths (set (map :path (:flat-rows p)))]
+        (is (contains? paths [:a 1]))
+        (is (contains? paths [:a 2]))))))
+
+(deftest yucxn-vector-three-element-tail-removal
+  (testing "rf2-yucxn BUG B — three contiguous trailing removals
+            `[1 2 3 4] → [1]` recover before-indices 1,2,3 with values
+            2,3,4 (Editscript emits three `:-` at index 1)."
+    (let [p (engine/project [1 2 3 4] [1])
+          removals (get-in p [:vector-removals []])]
+      (is (= [{:before-index 1 :before-value 2}
+              {:before-index 2 :before-value 3}
+              {:before-index 3 :before-value 4}]
+             removals)))))
+
+(deftest yucxn-vector-scattered-removal
+  (testing "rf2-yucxn BUG B — a SCATTERED (non-contiguous) removal
+            `[:a :b :c :d] → [:a :c]` drops `:b` (before-idx 1) and `:d`
+            (before-idx 3). Editscript emits `[[1] :-] [[2] :-]` (post-
+            shift indices); the replay must recover 1 and 3, not 1 and 2."
+    (let [p (engine/project [:a :b :c :d] [:a :c])
+          removals (get-in p [:vector-removals []])]
+      (is (= [{:before-index 1 :before-value :b}
+              {:before-index 3 :before-value :d}]
+             removals)))))
+
+(deftest yucxn-vector-single-tail-removal-unchanged
+  (testing "rf2-yucxn BUG B regression guard — a single-element removal
+            `[:x :y :z] → [:x :y]` still recovers the one dropped element
+            (before-idx 2, value :z); the replay degenerates correctly."
+    (let [p (engine/project [:x :y :z] [:x :y])]
+      (is (= [{:before-index 2 :before-value :z}]
+             (get-in p [:vector-removals []]))))))
+
+;; -- Case 4: scalar kinds beyond int/string
+
+(deftest yucxn-scalar-kinds-all-modify-at-leaf
+  (testing "rf2-yucxn Case 4 — ratio, float, symbol, boolean, and nil↔value
+            scalar changes all classify as `:modified` at the leaf with the
+            before/after values intact (no type-change false-positive for
+            same-kind numeric changes)."
+    ;; ratio — JVM only (clojure.lang.Ratio is not a valid CLJS constant;
+    ;; CLJS has no rational type, so the ratio case is exercised against
+    ;; the JVM target alone).
+    #?(:clj
+       (let [p (engine/project {:n 1/2} {:n 3/4})]
+         (is (= :modified (engine/op-at p [:n])))
+         (is (= 1/2 (:before (engine/entry-at p [:n]))))
+         (is (= 3/4 (:after (engine/entry-at p [:n]))))
+         (is (not (engine/type-change? p [:n])))))
+    ;; float
+    (let [p (engine/project {:n 1.5} {:n 2.5})]
+      (is (= :modified (engine/op-at p [:n])))
+      (is (not (engine/type-change? p [:n]))))
+    ;; symbol
+    (let [p (engine/project {:s 'foo} {:s 'bar})]
+      (is (= :modified (engine/op-at p [:s])))
+      (is (= 'foo (:before (engine/entry-at p [:s])))))
+    ;; boolean
+    (let [p (engine/project {:b true} {:b false})]
+      (is (= :modified (engine/op-at p [:b]))))
+    ;; nil → value
+    (let [p (engine/project {:n nil} {:n 5})]
+      (is (= :modified (engine/op-at p [:n])))
+      (is (= nil (:before (engine/entry-at p [:n]))))
+      (is (= 5 (:after (engine/entry-at p [:n])))))
+    ;; value → nil
+    (let [p (engine/project {:n 5} {:n nil})]
+      (is (= :modified (engine/op-at p [:n])))
+      (is (= 5 (:before (engine/entry-at p [:n]))))
+      (is (= nil (:after (engine/entry-at p [:n])))))))
+
+(deftest yucxn-number-to-string-is-not-type-change
+  (testing "rf2-yucxn Case 4 — a number→string change is a SCALAR
+            `:modified` (both are scalars; R7 only fires on a container-
+            kind flip). The renderer shows `~` + `← was 5`, not a type-
+            change suffix."
+    (let [p (engine/project {:n 5} {:n "5"})]
+      (is (= :modified (engine/op-at p [:n])))
+      (is (not (engine/type-change? p [:n]))))))
+
+;; -- Case 5: multiple adjustments at once (maps / vectors)
+
+(deftest yucxn-map-add-and-remove-in-one-diff
+  (testing "rf2-yucxn Case 5 — one diff that simultaneously ADDS and
+            REMOVES map keys (`{:a 1 :b 2} → {:a 1 :c 3}`): `:b` removed,
+            `:c` added, `:a` same — generalising 4vp8c's set case to maps."
+    (let [p (engine/project {:a 1 :b 2} {:a 1 :c 3})]
+      (is (= :removed (engine/op-at p [:b])))
+      (is (= :added (engine/op-at p [:c])))
+      (is (= :same (engine/op-at p [:a])))
+      (is (= 2 (:before (engine/entry-at p [:b]))))
+      (is (= 3 (:after (engine/entry-at p [:c])))))))
+
+(deftest yucxn-vector-simultaneous-change-and-append
+  (testing "rf2-yucxn Case 5 — one diff that both MODIFIES an existing slot
+            and APPENDS a new one (`[1 2 3] → [1 9 3 4]`): index 1 modified
+            (2→9), index 3 added (4)."
+    (let [p (engine/project [1 2 3] [1 9 3 4])]
+      (is (= :modified (engine/op-at p [1])))
+      (is (= 2 (:before (engine/entry-at p [1]))))
+      (is (= 9 (:after (engine/entry-at p [1]))))
+      (is (= :added (engine/op-at p [3])))
+      (is (= 4 (:after (engine/entry-at p [3])))))))
+
+;; -- Case 6: deep hierarchy + mixed-type nesting, ancestor non-promotion
+
+(deftest yucxn-deep-mixed-type-nesting-no-ancestor-promotion
+  (testing "rf2-yucxn Case 6 — a set swap THREE levels deep through mixed
+            container kinds (`{:a {:b [#{:x}]}} → {:a {:b [#{:y}]}}` — map →
+            map → vector → set) diffs member-level at the set and promotes
+            NO ancestor: `:a`, `:a :b`, `:a :b 0` all stay `:children`."
+    (let [p (engine/project {:a {:b [#{:x}]}} {:a {:b [#{:y}]}})]
+      (is (= :children (engine/op-at p [:a])))
+      (is (= :children (engine/op-at p [:a :b])))
+      (is (= :children (engine/op-at p [:a :b 0])))
+      (is (= #{} (:wholly-changed-roots p)))
+      (is (= :removed (engine/op-at p [:a :b 0 :x])))
+      (is (= :added (engine/op-at p [:a :b 0 :y]))))))
+
+(deftest yucxn-deep-scalar-change-promotes-no-ancestor
+  (testing "rf2-yucxn Case 6 — a deep scalar change marks the ancestor
+            chain `:children` but promotes none to a whole-key replace
+            (the l0us2 ancestor-non-promotion property across map nesting)."
+    (let [p (engine/project {:a {:b {:c {:d 1}}}} {:a {:b {:c {:d 2}}}})]
+      (is (= :modified (engine/op-at p [:a :b :c :d])))
+      (is (= :children (engine/op-at p [:a])))
+      (is (= :children (engine/op-at p [:a :b])))
+      (is (= :children (engine/op-at p [:a :b :c])))
+      (is (= #{} (:wholly-changed-roots p))))))
+

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -258,7 +258,14 @@
             produces the universal `[path before after op]` 4-tuples
             (rf2-xuyac — routed through `diff/engine.cljc`'s
             `:flat-rows`; the same shape Machine Inspector + HANDLER
-            `:db` `:diff` lenses consume)"
+            `:db` `:diff` lenses consume).
+
+            rf2-yucxn — `{:cart {:items []}} → {:cart {:items [{:id 7}]}}`
+            is the VECTOR populated-from-empty edge: the engine now expands
+            it member-level (the element added at index 0), matching the
+            set/map empty edges, instead of a whole-key `[:cart :items]
+            :modified`. The new tuple anchors at the added leaf
+            `[:cart :items 0 :id]`."
     (seed-xray! {:cart {:items [{:id 7}]}}
                  [(mk-record :e-1 [:cart/add-item]
                              {:cart {:items []}}
@@ -266,7 +273,7 @@
     (rf/with-frame :rf/xray
       (let [diff @(rf/subscribe [:rf.xray/selected-epoch-diff])]
         (is (= 1 (count diff)))
-        (is (= [[:cart :items] [] [{:id 7}] :modified]
+        (is (= [[:cart :items 0 :id] nil 7 :added]
                (first diff)))))))
 
 (deftest selected-epoch-diff-tracks-selected-epoch
@@ -432,8 +439,13 @@
             ;; lens shape); path lives at index 0.
             non-reserved-paths (set (map first (:changed-non-reserved data)))
             reserved-keys-shown (set (map first (:changed-reserved data)))]
-        (is (contains? non-reserved-paths [:cart :items])
-            "non-reserved path lands in :changed-non-reserved")
+        ;; rf2-yucxn — the populated-from-empty vector edge now diffs
+        ;; member-level, so the non-reserved path is `[:cart :items 0 :id]`
+        ;; rather than the whole-key `[:cart :items]`. The segregation
+        ;; contract is what matters: SOME non-reserved path rooted at
+        ;; `:cart` lands here, and no `:rf/runtime` path leaks in.
+        (is (some (fn [p] (= :cart (first p))) non-reserved-paths)
+            "non-reserved :cart-rooted path lands in :changed-non-reserved")
         (is (not (some #(= :rf/runtime (first %)) non-reserved-paths))
             "any :rf/runtime-rooted path filtered out of :changed-non-reserved")
         (is (contains? reserved-keys-shown :rf/route))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1671,6 +1671,138 @@
         "the :tags set is not rendered as a removed ghost (no whole-key strike)")))
 
 ;; =========================================================================
+;; rf2-yucxn — vector/list emptied renders member-level (BUG A) + multi-
+;; element removal shows every removed value distinctly (BUG B)
+;; =========================================================================
+;;
+;; The audit found vector/list empty edges classified as a whole-key
+;; `:modified` (a `~` amber row + `← was [1]`) instead of the member-level
+;; removal the set/map empty edges produce — and multi-element vector
+;; removals reporting one before-value repeatedly while dropping the rest.
+;; These tests drive the LIVE render path (a real `engine/project`
+;; projection) so the renderer's structural handling is exercised.
+
+(deftest yucxn-vector-emptied-renders-member-level-not-whole-key
+  ;; rf2-yucxn BUG A — `{:a [1]} → {:a []}` (vector emptied, key intact):
+  ;; the operator must see `:a [ ]` with the removed `1` struck-through
+  ;; INSIDE it, NOT a whole-key `:a ~ [] ← was [1]`. The `:a` key must not
+  ;; be a removed ghost (its value is still present, just empty).
+  (let [before {:a [1]}
+        after  {:a []}
+        proj   (engine/project before after)
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :projection proj
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 6}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    ;; The removed element is visible + struck.
+    (is (re-find #"\b1\b" all) "the removed element 1 still renders")
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "a row carries the removed diff-op marker (the dropped element)")
+    (is (re-find #"line-through" s)
+        "the dropped element is struck-through, not a whole-key modify")
+    ;; The :a key is NOT a removed ghost (key intact, value just empty).
+    (is (not (re-find #":data-rf-removed-ghost \"1\"" s))
+        "the :a vector is not a removed ghost (key intact)")
+    ;; No `← was [1]` whole-value annotation (that was the BUG A symptom).
+    (is (not (re-find #"← was \[1\]" all))
+        "no whole-key `← was [1]` modify annotation (member-level instead)")))
+
+(deftest yucxn-list-emptied-renders-member-level
+  ;; rf2-yucxn BUG A — the list empty edge mirrors the vector edge.
+  (let [before {:a '(1)}
+        after  {:a '()}
+        proj   (engine/project before after)
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :projection proj
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 6}})
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "the emptied list shows the dropped element as a removed row")
+    (is (not (re-find #":data-rf-removed-ghost \"1\"" s))
+        "the :a list is not a removed ghost (key intact)")))
+
+(deftest yucxn-vector-populated-from-empty-renders-added
+  ;; rf2-yucxn BUG A — symmetric `{:a []} → {:a [1]}` shows the new element
+  ;; in green (`+`), not a whole-key `~` modify.
+  (let [before {:a []}
+        after  {:a [1]}
+        proj   (engine/project before after)
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :projection proj
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 6}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    (is (re-find #"\b1\b" all) "the new element 1 renders")
+    (is (re-find #"data-rf-diff-op.*added" s)
+        "the filled-from-empty vector shows the new element as an added row")))
+
+(deftest yucxn-vector-multi-removal-shows-every-removed-value-distinctly
+  ;; rf2-yucxn BUG B — `{:a [1 2 3]} → {:a [1]}` drops 2 AND 3. The
+  ;; renderer must show BOTH struck-through, with their CORRECT values —
+  ;; not `2` twice (the pre-fix duplication) and not a vanished `3`.
+  (let [before {:a [1 2 3]}
+        after  {:a [1]}
+        proj   (engine/project before after)
+        h (ei/render-node {:value after
+                           :before before
+                           :diff? true
+                           :projection proj
+                           :panel-id :p :mount-id "m"
+                           :path [] :depth 0
+                           :expansion-map {}
+                           :opts {:default-expanded-depth 6}})
+        all (collect-text h)
+        s   (try (pr-str h) (catch :default _ ""))]
+    ;; Engine precondition — the channel carries both with true values.
+    (is (= [{:before-index 1 :before-value 2}
+            {:before-index 2 :before-value 3}]
+           (get-in proj [:vector-removals [:a]]))
+        "precondition: both removed elements recovered with correct values")
+    ;; Both removed values appear in the render (3 is the proof BUG B is gone).
+    (is (re-find #"\b2\b" all) "removed element 2 renders")
+    (is (re-find #"\b3\b" all) "removed element 3 renders (not dropped — BUG B fixed)")
+    (is (re-find #"data-rf-diff-op.*removed" s)
+        "the dropped elements carry the removed marker")))
+
+(deftest yucxn-vector-scattered-removal-engine-channel-correct
+  ;; rf2-yucxn BUG B — a scattered removal `[:a :b :c :d] → [:a :c]` drops
+  ;; :b (before-idx 1) and :d (before-idx 3). The ENGINE's :vector-removals
+  ;; channel now recovers both with true before-index + value (the pre-fix
+  ;; post-shift-index resolution reported :b + :c, dropping :d).
+  ;;
+  ;; The RENDERER side is a KNOWN residual gap (rf2-vu42n): the inline
+  ;; vector body uses an index-aligned `children-of-pair` walk rather than
+  ;; the engine's :vector-removals + :same-shifted projection, so a
+  ;; scattered/mid removal mis-renders which members are struck. Contiguous
+  ;; TAIL removals (the common case) render correctly — see
+  ;; `yucxn-vector-multi-removal-shows-every-removed-value-distinctly`.
+  ;; This test pins the ENGINE contract that rf2-vu42n's renderer fix will
+  ;; consume.
+  (let [before {:v [:a :b :c :d]}
+        after  {:v [:a :c]}
+        proj   (engine/project before after)]
+    (is (= [{:before-index 1 :before-value :b}
+            {:before-index 3 :before-value :d}]
+           (get-in proj [:vector-removals [:v]]))
+        "engine recovers :b (idx 1) + :d (idx 3) — not :b + :c (pre-fix bug)")))
+
+;; =========================================================================
 ;; rf2-e28r3 — single render path: value (always) + before (optional)
 ;; =========================================================================
 ;;

--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -1,67 +1,54 @@
 (ns edn-inspector.core
-  "EDN-INSPECTOR testbed (rf2-74u2s → rf2-1niob) — a standard-epochs-style
-  driving surface that exercises the Xray edn-inspector THROUGH its primary
-  use case: the Epoch and App-db PANELS.
+  "EDN-INSPECTOR testbed (rf2-74u2s → rf2-1niob → rf2-yucxn) — a
+  standard-epochs-style driving surface that exercises the Xray edn-inspector
+  THROUGH its primary use case: the Epoch and App-db PANELS.
 
-  ## Shape (rework — rf2-1niob)
+  ## Shape (rework — rf2-yucxn: the full datatype matrix)
 
-  ONE tall column of NUMBERED buttons, top to bottom — exactly the
-  `standard_epochs` shape. Each button DISPATCHES one event that changes
-  REAL app-db at a meaningful path, and the Xray SIDECAR mounted INLINE on
-  the right (`[data-rf-xray-host]`, like `standard_epochs`) shows the change
-  via the EPOCH panel (db-before / db-after) and the APP-DB panel (the diff).
+  ONE tall column of NUMBERED buttons grouped into the diff-audit case
+  matrix, top to bottom — the `standard_epochs` shape. Each button
+  DISPATCHES one event that makes ONE clean, meaningful app-db transition,
+  and the Xray SIDECAR mounted INLINE on the right (`[data-rf-xray-host]`,
+  like `standard_epochs`) shows the change via the EPOCH panel (db-before /
+  db-after) and the APP-DB panel (the diff).
 
-  Both of those panels render their CLJS values THROUGH the edn-inspector
+  Both panels render their CLJS values THROUGH the edn-inspector
   (`day8.re-frame2-xray.views.edn-inspector`) — the single value renderer
-  behind every Xray panel. So the inspector is demonstrated where it actually
-  earns its keep: a button writes a stressing shape into app-db, and the
-  inspector renders that shape (and its diff) inside the panels.
+  behind every Xray panel. So the inspector + its DIFF projection are
+  demonstrated where they earn their keep: a button writes a stressing shape
+  into app-db, and the inspector renders that shape and its diff inside the
+  panels.
 
-  This SUPERSEDES the earlier widget-first deck (PR #2702), which mounted a
-  standalone `inspector-stage` widget below the buttons and seeded a single
-  `:edn-inspector/fixture` slot. Per Mike (2026-06-01) the inspector is seen
-  ONLY through the Epoch + App-db panels — there is no standalone widget
-  'elsewhere'.
+  ## The matrix (rf2-yucxn — senior-dev base-case audit)
+
+  The deck is organised SIMPLE → COMPLEX along the audit matrix; each
+  control drives ONE case. Press the buttons within a section top-to-bottom
+  to walk the case ladder. `0. Reset` re-seeds the baseline shape.
+
+    MAPS                — key added · key removed · value changed
+    SEQUENTIALS         — vector/list/set: entry added · removed · changed
+    EMPTY vs REMOVAL    — a collection emptied (KEY INTACT) vs the KEY
+                          removed, for set / vector / list / map — these
+                          must render DISTINCTLY (members removed inside an
+                          intact, now-empty container vs a struck-through
+                          removed key)
+    SCALARS             — keyword/string/number/bool/nil/symbol changes;
+                          nil↔value; type changes (number→string, R7
+                          scalar→collection / map→vector)
+    MULTI-ADJUST        — add AND remove in ONE collection in ONE diff
+                          (map, vector, set)
+    DEEP / MIXED        — change several levels deep through mixed container
+                          kinds; ancestors must stay `:children`, never
+                          promote to a whole-key replace
+    SENTINELS           — :rf/redacted · :rf.size/large-elided
+    SHOWCASE            — large collection (elision) · deep nesting (collapse
+                          summary) · mixed scalar + tagged-literal vector
 
   ## Per-press delta (standard_epochs pattern)
 
   Every action event bumps a shared `:baseline` counter (the `bump` helper),
-  so the App-db / Epoch panels always show a delta on every press, and the
-  per-button capability shape is the ADDITIONAL change layered on top.
-
-  ## Button ladder — each a real app-db change exercising one inspector
-  capability AS THE PANELS RENDER IT
-
-    1  Large collection → ELISION. A 50-key map at `:metrics`; the App-db
-       panel's inspector elides past its threshold + the body scrolls.
-    2  Deeply nested → PATH RENDER / COLLAPSE. A six-level nested map at
-       `:tenant`; the inspector renders the path + `▸ {…N keys}` summaries
-       past the depth ceiling.
-    3  Diff: ADDED. A wholly-new `:flash` subtree (assoc-in) — the App-db
-       diff paints `+` / green wash.
-    4  Diff: REMOVED → empty (rf2-8pfkk). Dissoc the ONLY key under
-       `:session` so the after-tree is `{}` — a struck-through `−`
-       removal, NOT a `:added ::missing` leak.
-    5  Diff: CHANGED in place (diff-mode-3). Bump a nested scalar
-       `[:metrics :counter]` — the value-side `~` glyph + `← was N`.
-    5b Diff: SET-MEMBER REMOVED (rf2-l0us2). Remove one member from the
-       set at `[:metrics :tags]` (`#{:a :b :c}` → `#{:a :c}` → … → `#{}`,
-       re-seeding when empty). The removed member renders member-level
-       `−:b` with the set's KEY INTACT — NOT a struck-through whole-key
-       'sea of red'. The last-member → `#{}` press exercises the
-       empty-collection-replacement expansion of the same fix.
-    6  Sensitive → :rf/redacted. Write the `:rf/redacted` sentinel three
-       levels deep at `[:session-secure :user :password]` — the inspector
-       renders a `redacted` chip, never the raw value.
-    7  Large-elided sentinel. Write `{:rf.size/large-elided {…}}` (Spec 015)
-       at `[:report-cache :report-42]` — routed through the size-chip
-       renderer, not the regular map path.
-    8  Mixed types / tagged literals. Write a vector of every scalar kind
-       plus `#uuid` + `#inst` tagged literals at `:scalar-mix` — every
-       syntax-palette token + the default formatters' compact headers.
-
-  Each press: the Epoch panel shows the cascade (db-before/after); the
-  App-db panel shows the inspector rendering the shape / diff.
+  so the App-db / Epoch panels always show a delta on every press; the
+  per-button matrix case is the ADDITIONAL change layered on top.
 
   ## Inline Xray sidecar (no preload edit)
 
@@ -77,16 +64,18 @@
   ## Test surface, not tutorial
 
   Per `feedback_testbeds_are_test_surfaces`: no deliberate bugs, no teaching
-  layers, no anti-pattern demos. Each button writes a clean inspector-
-  stressing shape; captions are guidance, not lessons.
+  layers, no anti-pattern demos. Each button writes a clean, correct
+  inspector-stressing shape; captions are guidance, not lessons.
 
   ## Test-free + self-contained
 
   Per rf2-8cevm this testbed carries no spec.cjs; the edn-inspector's
-  regression coverage lives in the `panel_gallery` Story gallery
-  (gated by the Xray feature-matrix gate) + the substrate contract tests.
-  This deck is the manual LIVE driver of the inspector inside the real
-  Epoch + App-db panels. The events / subs / views are OWNED here."
+  regression coverage lives in the engine + renderer unit tests
+  (`diff/engine_cljs_test`, `views/edn_inspector_cljs_test`) + the
+  `panel_gallery` Story gallery (gated by the Xray feature-matrix gate) +
+  the substrate contract tests. This deck is the manual LIVE driver of the
+  inspector inside the real Epoch + App-db panels. The events / subs / views
+  are OWNED here."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
@@ -113,21 +102,44 @@
 ;; One flat, named seed. `:baseline` is the shared counter every button
 ;; bumps (so App-db / Epoch always show a delta on every press). The other
 ;; slots are the real, meaningful paths the per-button events write the
-;; inspector-stressing shapes into — the App-db panel renders them (and their
-;; diffs) THROUGH the edn-inspector.
+;; matrix-case shapes into — the App-db panel renders them (and their diffs)
+;; THROUGH the edn-inspector.
+;;
+;; The seed is chosen so EVERY matrix case has something clean to act on:
+;; a map with keys to add/remove/change, sequentials with entries, a set,
+;; nested structure for the deep cases, and secure / cache slots for the
+;; sentinel cases.
 
 (def initial-db
-  {:baseline      0
-   :metrics       {:counter 5
-                   :tags    #{:a :b :c}}
-   :tenant        {}
-   :session       {:only-key {:label "removed" :n 42}}
-   :session-secure {:user {:id 7}}
-   :report-cache  {}
-   :scalar-mix    nil})
+  {:baseline   0
+   ;; MAPS — keys to add / remove / change.
+   :profile    {:name "Ada" :role :engineer}
+   ;; SEQUENTIALS — a vector, a list, a set with entries.
+   :queue      [:task-1 :task-2 :task-3]
+   :history    '(:login :browse)
+   :tags       #{:alpha :beta :gamma}
+   ;; EMPTY vs REMOVAL — a single-member of each kind to empty (key intact)
+   ;; alongside a sibling key to remove wholesale.
+   :one-vec    [:only]
+   :one-list   '(:only)
+   :one-set    #{:only}
+   :one-map    {:k 1}
+   :doomed     {:goodbye true}
+   ;; SCALARS — a leaf of each kind to flip in place.
+   :scalar     5
+   ;; MULTI-ADJUST — collections to add-and-remove in one diff.
+   :flags      {:a 1 :b 2}
+   :slots      [1 2 3]
+   :labels     #{:x :y :z}
+   ;; DEEP / MIXED — nested several levels through mixed kinds.
+   :deep       {:a {:b {:c {:d 1}}}}
+   :mixed      {:a {:b [#{:x}]}}
+   ;; SENTINELS — secure + cache slots.
+   :secure     {:user {:id 7}}
+   :cache      {}})
 
 (rf/reg-event-db :edn-inspector/reset
-  {:doc "Button 0 — re-seed app-db."}
+  {:doc "Button 0 — re-seed app-db to the matrix baseline."}
   (fn handler-reset [_db _ev]
     initial-db))
 
@@ -137,129 +149,249 @@
 ;;
 ;; Kept as a plain db->db fn (not an interceptor) so the baseline bump is
 ;; visible inline in each handler body — the App-db / Epoch delta on every
-;; press comes from here, and the per-button capability shape is the
-;; ADDITIONAL change layered on top (the standard_epochs pattern).
+;; press comes from here, and the per-button matrix case is the ADDITIONAL
+;; change layered on top (the standard_epochs pattern).
 
 (defn- bump [db] (update db :baseline inc))
 
 ;; ============================================================================
-;; EVENTS — the button ladder (each a real app-db write the panels render)
+;; EVENTS — the button ladder, grouped by the audit matrix
 ;; ============================================================================
 
-;; -- 1. large collection → elision -------------------------------------------
-(rf/reg-event-db :edn-inspector/large-collection
-  {:doc "Button 1 — write a 50-key map to `:metrics/grid`."}
-  (fn handler-large-collection [db _ev]
-    (-> db
-        bump
-        (assoc-in [:metrics :grid]
-                  (into {} (for [i (range 50)]
-                             [(keyword (str "metric-" i)) (str "value-" i)]))))))
+;; -- MAPS --------------------------------------------------------------------
 
-;; -- 2. deeply nested → path render / collapse -------------------------------
-(rf/reg-event-db :edn-inspector/deeply-nested
-  {:doc "Button 2 — write a six-level nested map to `:tenant`. The inspector
-         renders the path; deep nodes render `▸ {…N keys}` summaries past the
-         depth ceiling, ancestors open under the width-aware heuristic."}
-  (fn handler-deeply-nested [db _ev]
-    (-> db
-        bump
-        (assoc :tenant
-               {:acme {:department {:engineering {:team {:platform
-                                                         {:project :xray
-                                                          :status  :active
-                                                          :leads   ["Ada" "Grace"]}}}}}}))))
+(rf/reg-event-db :edn-inspector/map-key-added
+  {:doc "Map: a KEY ADDED. assoc a new `:team` key under :profile — the
+         App-db diff paints `+:team` (green, key-anchored)."}
+  (fn [db _] (-> db bump (assoc-in [:profile :team] :platform))))
 
-;; -- 3. diff: ADDED (green +) ------------------------------------------------
-(rf/reg-event-db :edn-inspector/diff-added
-  {:doc "Button 3 — assoc-in a wholly-new `:flash` subtree."}
-  (fn handler-diff-added [db _ev]
-    (-> db
-        bump
-        (assoc-in [:metrics :flash] {:level :ok :text "Order placed"}))))
-
-;; -- 4. diff: REMOVED → empty (rf2-8pfkk) ------------------------------------
-(rf/reg-event-db :edn-inspector/diff-removed-to-empty
-  {:doc "Button 4 — dissoc the ONLY key under `:session` so the after-tree is
-         `{}`. The App-db diff shows a struck-through `−` removal, NOT a
-         `:added ::missing` leak (the bug rf2-8pfkk fixed). Re-seeds the key
-         first if it was already removed so there is always something to
-         remove."}
-  (fn handler-diff-removed-to-empty [db _ev]
+(rf/reg-event-db :edn-inspector/map-key-removed
+  {:doc "Map: a KEY REMOVED. dissoc `:role` from :profile — the diff paints
+         a struck-through `−:role` (red, key-anchored)."}
+  (fn [db _]
     (let [db (bump db)]
-      (if (seq (:session db))
-        (assoc db :session {})
-        (assoc db :session {:only-key {:label "removed" :n 42}})))))
+      (if (contains? (:profile db) :role)
+        (update db :profile dissoc :role)
+        (assoc-in db [:profile :role] :engineer)))))
 
-;; -- 5. diff: CHANGED in place (diff-mode-3) ---------------------------------
-(rf/reg-event-db :edn-inspector/diff-changed
-  {:doc "Button 5 — bump the nested scalar `[:metrics :counter]` in place. The
-         App-db diff shows the value-side `~` glyph + `← was N` annotation
-         (diff-mode-3 R1)."}
-  (fn handler-diff-changed [db _ev]
-    (-> db
-        bump
-        (update-in [:metrics :counter] (fnil inc 0)))))
+(rf/reg-event-db :edn-inspector/map-value-changed
+  {:doc "Map: a VALUE CHANGED in place. Bump :profile/name — the value-side
+         `~` glyph + `← was \"…\"` annotation, key intact."}
+  (fn [db _]
+    (-> db bump
+        (update-in [:profile :name]
+                   #(if (= % "Ada") "Ada Lovelace" "Ada")))))
 
-;; -- 5b. diff: SET-MEMBER REMOVED (rf2-l0us2) --------------------------------
-(rf/reg-event-db :edn-inspector/diff-set-member-removed
-  {:doc "Button 5b — remove ONE member from the set at `[:metrics :tags]`
-         (`#{:a :b :c}` → `#{:a :c}` → … → `#{}`), re-seeding the full set
-         once it has been emptied so there is always a member to remove. The
-         App-db diff renders the removed member member-level (`−:b`) with the
-         set's KEY INTACT — NOT a struck-through whole-key removal (the
-         `mark-wholly-changed` 'sea of red' rf2-l0us2 fixed). The
-         last-member → `#{}` press exercises the same fix's
-         empty-collection-replacement expansion."}
-  (fn handler-diff-set-member-removed [db _ev]
+;; -- SEQUENTIALS (vector / list / set) ---------------------------------------
+
+(rf/reg-event-db :edn-inspector/seq-entry-added
+  {:doc "Sequential: ENTRY ADDED. conj a new task onto the :queue vector —
+         the appended entry paints `+` green."}
+  (fn [db _]
+    (-> db bump
+        (update :queue conj (keyword (str "task-" (inc (count (:queue db)))))))))
+
+(rf/reg-event-db :edn-inspector/seq-entry-removed
+  {:doc "Sequential: ENTRY REMOVED. pop the tail off the :queue vector — the
+         dropped entry renders struck-through (member-level, not a whole-key
+         replace). Re-seeds when down to one so there is always a tail."}
+  (fn [db _]
+    (let [db (bump db)]
+      (if (> (count (:queue db)) 1)
+        (update db :queue pop)
+        (assoc db :queue [:task-1 :task-2 :task-3])))))
+
+(rf/reg-event-db :edn-inspector/set-member-changed
+  {:doc "Set: a MEMBER CHANGED (swap). Replace one member of :tags — the
+         diff paints member-level `−:alpha +:delta` with the :tags KEY
+         INTACT (not a 'sea of red' whole-key strike). Cycles members."}
+  (fn [db _]
     (let [db   (bump db)
-          tags (get-in db [:metrics :tags])]
-      (if (seq tags)
-        (assoc-in db [:metrics :tags] (disj tags (first (sort tags))))
-        (assoc-in db [:metrics :tags] #{:a :b :c})))))
+          tags (:tags db)]
+      (assoc db :tags
+             (cond
+               (contains? tags :alpha) (-> tags (disj :alpha) (conj :delta))
+               (contains? tags :delta) (-> tags (disj :delta) (conj :alpha))
+               :else                   #{:alpha :beta :gamma})))))
 
-;; -- 6. sensitive → :rf/redacted ---------------------------------------------
+;; -- EMPTY vs REMOVAL (the subtle one) ---------------------------------------
+;;
+;; Each "empty" button drops the single member of a one-member collection so
+;; the container goes EMPTY with its KEY INTACT — the inspector renders the
+;; now-empty bracket pair with the dropped member struck inside. The
+;; "remove key" button dissocs the :doomed key wholesale — a struck-through
+;; removed KEY (the collapsed removed-ghost). The two must read DISTINCTLY.
+
+(rf/reg-event-db :edn-inspector/empty-vector
+  {:doc "Empty a VECTOR, key intact. `:one-vec [:only]` → `[]` — the element
+         removal renders member-level inside the intact (now-empty) vector,
+         NOT a whole-key `~` modify (rf2-yucxn BUG A). Re-seeds when empty."}
+  (fn [db _]
+    (let [db (bump db)]
+      (assoc db :one-vec (if (seq (:one-vec db)) [] [:only])))))
+
+(rf/reg-event-db :edn-inspector/empty-list
+  {:doc "Empty a LIST, key intact. `:one-list (:only)` → `()` — member-level
+         removal inside the intact list (rf2-yucxn BUG A). Re-seeds."}
+  (fn [db _]
+    (let [db (bump db)]
+      (assoc db :one-list (if (seq (:one-list db)) '() '(:only))))))
+
+(rf/reg-event-db :edn-inspector/empty-set
+  {:doc "Empty a SET, key intact. `:one-set #{:only}` → `#{}` — member-level
+         removal inside the intact set (l0us2 empty-edge expansion). Re-seeds."}
+  (fn [db _]
+    (let [db (bump db)]
+      (assoc db :one-set (if (seq (:one-set db)) #{} #{:only})))))
+
+(rf/reg-event-db :edn-inspector/empty-map
+  {:doc "Empty a MAP, key intact. `:one-map {:k 1}` → `{}` — member-level
+         removal inside the intact map (rf2-9d4j8 empty-map expansion).
+         Re-seeds."}
+  (fn [db _]
+    (let [db (bump db)]
+      (assoc db :one-map (if (seq (:one-map db)) {} {:k 1})))))
+
+(rf/reg-event-db :edn-inspector/remove-key
+  {:doc "Remove a KEY wholesale. dissoc `:doomed` — a struck-through removed
+         KEY (collapsed removed-ghost), DISTINCT from emptying a collection
+         whose key stays. Re-seeds the key when gone."}
+  (fn [db _]
+    (let [db (bump db)]
+      (if (contains? db :doomed)
+        (dissoc db :doomed)
+        (assoc db :doomed {:goodbye true})))))
+
+;; -- SCALARS -----------------------------------------------------------------
+
+(rf/reg-event-db :edn-inspector/scalar-number
+  {:doc "Scalar: NUMBER changed in place. Increment :scalar — `~` + `← was N`."}
+  (fn [db _] (-> db bump (update :scalar #(if (number? %) (inc %) 5)))))
+
+(rf/reg-event-db :edn-inspector/scalar-nil-toggle
+  {:doc "Scalar: NIL ↔ VALUE. Toggle :scalar between a value and nil — both
+         transitions are `:modified` leaves (nil is a real value, not absence)."}
+  (fn [db _] (-> db bump (update :scalar #(if (nil? %) 5 nil)))))
+
+(rf/reg-event-db :edn-inspector/scalar-type-flip
+  {:doc "Scalar: TYPE CHANGE. Flip :scalar number↔string (`5` ↔ `\"five\"`)
+         and scalar↔map — R7 renders `~` + `← was <type>` type-change suffix."}
+  (fn [db _]
+    (-> db bump
+        (update :scalar
+                (fn [v]
+                  (cond
+                    (number? v) "five"
+                    (string? v) {:was :string}
+                    :else       5))))))
+
+;; -- MULTI-ADJUST (add AND remove in one diff) -------------------------------
+
+(rf/reg-event-db :edn-inspector/map-multi-adjust
+  {:doc "Map: ADD + REMOVE in ONE diff. Swap :flags `{:a 1 :b 2}` ↔
+         `{:a 1 :c 3}` — `:b` removed AND `:c` added simultaneously, `:a`
+         unchanged."}
+  (fn [db _]
+    (-> db bump
+        (update :flags
+                (fn [m]
+                  (if (contains? m :b) {:a 1 :c 3} {:a 1 :b 2}))))))
+
+(rf/reg-event-db :edn-inspector/vector-multi-adjust
+  {:doc "Vector: CHANGE + APPEND in ONE diff. Swap :slots `[1 2 3]` ↔
+         `[1 9 3 4]` — index 1 modified (2→9) AND index 3 appended (4)."}
+  (fn [db _]
+    (-> db bump
+        (update :slots
+                (fn [v] (if (= v [1 2 3]) [1 9 3 4] [1 2 3]))))))
+
+(rf/reg-event-db :edn-inspector/set-multi-adjust
+  {:doc "Set: MULTI-MEMBER swap in ONE diff. Swap :labels `#{:x :y :z}` ↔
+         `#{:x :p :q}` — `:y :z` removed AND `:p :q` added, `:x` kept,
+         member-level, key intact (rf2-4vp8c)."}
+  (fn [db _]
+    (-> db bump
+        (update :labels
+                (fn [s] (if (contains? s :y) #{:x :p :q} #{:x :y :z}))))))
+
+;; -- DEEP / MIXED ------------------------------------------------------------
+
+(rf/reg-event-db :edn-inspector/deep-change
+  {:doc "Deep: a scalar change FIVE levels deep at `[:deep :a :b :c :d]`.
+         Every ancestor reads `:children` (◴ + rail); none promotes to a
+         whole-key replace."}
+  (fn [db _] (-> db bump (update-in [:deep :a :b :c :d] (fnil inc 0)))))
+
+(rf/reg-event-db :edn-inspector/mixed-deep-change
+  {:doc "Mixed: a SET swap through map→map→vector→set at
+         `[:mixed :a :b 0]`. Diffs member-level at the set; no ancestor
+         (map or vector) is falsely promoted to a whole-key replace
+         (the l0us2 ancestor-non-promotion property across kinds). Cycles."}
+  (fn [db _]
+    (-> db bump
+        (update-in [:mixed :a :b 0]
+                   (fn [s] (if (contains? s :x) #{:y} #{:x}))))))
+
+;; -- SENTINELS ---------------------------------------------------------------
+
 (rf/reg-event-db :edn-inspector/redacted
-  {:doc "Button 6 — write the `:rf/redacted` sentinel three levels deep at
-         `[:session-secure :user :password]`. The inspector renders a
-         `redacted` chip, never the raw value."}
-  (fn handler-redacted [db _ev]
-    (-> db
-        bump
-        (assoc-in [:session-secure :user :password] :rf/redacted))))
+  {:doc "Sentinel: :rf/redacted. Write the sentinel three levels deep at
+         `[:secure :user :password]` — the inspector renders a `redacted`
+         chip, never the raw value."}
+  (fn [db _] (-> db bump (assoc-in [:secure :user :password] :rf/redacted))))
 
-;; -- 7. large-elided sentinel (Spec 015) -------------------------------------
 (rf/reg-event-db :edn-inspector/large-elided
-  {:doc "Button 7 — write a `:rf.size/large-elided` sentinel (Spec 015) at
-         `[:report-cache :report-42]`. The inspector routes it through the
-         size-chip renderer, not the regular map path."}
-  (fn handler-large-elided [db _ev]
-    (-> db
-        bump
-        (assoc-in [:report-cache :report-42]
+  {:doc "Sentinel: :rf.size/large-elided (Spec 015). Write the sentinel at
+         `[:cache :report-42]` — routed through the size-chip renderer."}
+  (fn [db _]
+    (-> db bump
+        (assoc-in [:cache :report-42]
                   {:rf.size/large-elided {:source        :app-db
-                                          :path          [:report-cache :report-42]
+                                          :path          [:cache :report-42]
                                           :original-size 12480293
                                           :bytes         12480293
                                           :handle        :report/payload-42
                                           :reason        :over-budget}}))))
 
-;; -- 8. mixed types / tagged literals ----------------------------------------
+;; -- SHOWCASE (rendering capabilities the diff matrix doesn't exercise) ------
+
+(rf/reg-event-db :edn-inspector/large-collection
+  {:doc "Showcase: LARGE collection → elision. Write a 50-key map at
+         `[:cache :grid]` — the App-db inspector elides past its threshold +
+         the body scrolls."}
+  (fn [db _]
+    (-> db bump
+        (assoc-in [:cache :grid]
+                  (into {} (for [i (range 50)]
+                             [(keyword (str "metric-" i)) (str "value-" i)]))))))
+
+(rf/reg-event-db :edn-inspector/deeply-nested
+  {:doc "Showcase: DEEP nesting → path render / collapse. Write a six-level
+         nested map at `:cache/tenant` — deep nodes render `▸ {…N keys}`
+         summaries past the depth ceiling."}
+  (fn [db _]
+    (-> db bump
+        (assoc-in [:cache :tenant]
+                  {:acme {:department {:engineering {:team {:platform
+                                                            {:project :xray
+                                                             :status  :active
+                                                             :leads   ["Ada" "Grace"]}}}}}}))))
+
 (rf/reg-event-db :edn-inspector/mixed-types
-  {:doc "Button 8 — write a vector of every scalar kind PLUS `#uuid` + `#inst`
-         tagged literals at `:scalar-mix`. The inspector paints every
-         syntax-palette token + the default formatters' compact headers."}
-  (fn handler-mixed-types [db _ev]
-    (-> db
-        bump
-        (assoc :scalar-mix
-               [nil true false
-                42 -7 3.14159
-                "hello" "with \"escaped\" quotes"
-                :simple :ns/qualified
-                'plain-sym 'my.ns/qualified-sym
-                (random-uuid)
-                (js/Date.)]))))
+  {:doc "Showcase: MIXED scalar kinds + tagged literals. Write a vector of
+         every scalar kind PLUS `#uuid` + `#inst` at `:cache/scalar-mix` —
+         every syntax-palette token + the default formatters' compact
+         headers."}
+  (fn [db _]
+    (-> db bump
+        (assoc-in [:cache :scalar-mix]
+                  [nil true false
+                   42 -7 3.14159
+                   "hello" "with \"escaped\" quotes"
+                   :simple :ns/qualified
+                   'plain-sym 'my.ns/qualified-sym
+                   (random-uuid)
+                   (js/Date.)]))))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS — the on-page mirror of the baseline counter
@@ -268,45 +400,74 @@
 (rf/reg-sub :edn-inspector/baseline (fn [db _] (:baseline db)))
 
 ;; ============================================================================
-;; THE BUTTON LADDER
+;; THE BUTTON LADDER — grouped by the audit matrix
 ;; ============================================================================
 
 (def ^:private ladder
   "The ordered button ladder. Each row: [n label caption event]. `event` is
-  the dispatch vector; `:section` rows are separators (label only)."
-  [[:section "Resting / elision / nesting"]
-   [1 "Large collection → elision"
-    "Add a 50-key map at :metrics/grid"
-    [:edn-inspector/large-collection]]
-   [2 "Deeply nested → path + collapse"
-    "Adds six-level nested map at :tenant — deep nodes shown as summary"
-    [:edn-inspector/deeply-nested]]
+  the dispatch vector; `:section` rows are matrix-group separators."
+  [[:section "Maps — key add / remove / value change"]
+   ["1a" "Map: key ADDED"   "assoc :profile/:team — `+:team`, key-anchored"
+    [:edn-inspector/map-key-added]]
+   ["1b" "Map: key REMOVED" "dissoc :profile/:role — struck `−:role`"
+    [:edn-inspector/map-key-removed]]
+   ["1c" "Map: value CHANGED" "bump :profile/:name — `~` + `← was \"…\"`"
+    [:edn-inspector/map-value-changed]]
 
-   [:section "Diff ops — added / removed / changed"]
-   [3 "Diff: ADDED (green +)"
-    "added new :flash subtree - see the `+` glyph + green wash"
-    [:edn-inspector/diff-added]]
-   [4 "Diff: REMOVED → empty"
-    "remove only key under :session → is `{}`"
-    [:edn-inspector/diff-removed-to-empty]]
-   [5 "Diff: CHANGED in place"
-    "Increment [:metrics :counter] — see value-side `~` glyph + `← was N`"
-    [:edn-inspector/diff-changed]]
-   ["5b" "Remove set member"
-    "Drop one member from the set [:metrics :tags] — removed member renders `−:b`, key intact (not a whole-key strike); last press empties the set"
-    [:edn-inspector/diff-set-member-removed]]
+   [:section "Sequentials — vector / list / set entry"]
+   ["2a" "Vector: entry ADDED"   "conj a task onto :queue — `+` green"
+    [:edn-inspector/seq-entry-added]]
+   ["2b" "Vector: entry REMOVED" "pop :queue tail — struck member, key intact"
+    [:edn-inspector/seq-entry-removed]]
+   ["2c" "Set: member CHANGED"   "swap a :tags member — `−:alpha +:delta`, key intact"
+    [:edn-inspector/set-member-changed]]
+
+   [:section "Empty-result vs key-removal (must read DISTINCTLY)"]
+   ["3a" "Empty a VECTOR (key intact)" ":one-vec [:only] → [] — member removal, key stays"
+    [:edn-inspector/empty-vector]]
+   ["3b" "Empty a LIST (key intact)"   ":one-list (:only) → () — member removal, key stays"
+    [:edn-inspector/empty-list]]
+   ["3c" "Empty a SET (key intact)"    ":one-set #{:only} → #{} — member removal, key stays"
+    [:edn-inspector/empty-set]]
+   ["3d" "Empty a MAP (key intact)"    ":one-map {:k 1} → {} — member removal, key stays"
+    [:edn-inspector/empty-map]]
+   ["3e" "Remove a KEY (wholesale)"    "dissoc :doomed — struck removed KEY (ghost), distinct from emptying"
+    [:edn-inspector/remove-key]]
+
+   [:section "Scalars — value / nil / type change"]
+   ["4a" "Scalar: NUMBER changed" "increment :scalar — `~` + `← was N`"
+    [:edn-inspector/scalar-number]]
+   ["4b" "Scalar: nil ↔ value"    "toggle :scalar value↔nil — both `:modified`"
+    [:edn-inspector/scalar-nil-toggle]]
+   ["4c" "Scalar: TYPE change"    "flip :scalar number↔string↔map — R7 `← was <type>`"
+    [:edn-inspector/scalar-type-flip]]
+
+   [:section "Multiple adjustments in ONE diff"]
+   ["5a" "Map: add AND remove"    "swap :flags {:a 1 :b 2}↔{:a 1 :c 3} — `−:b +:c`"
+    [:edn-inspector/map-multi-adjust]]
+   ["5b" "Vector: change AND append" "swap :slots [1 2 3]↔[1 9 3 4] — `~`@1 + `+`@3"
+    [:edn-inspector/vector-multi-adjust]]
+   ["5c" "Set: multi-member swap"  "swap :labels #{:x :y :z}↔#{:x :p :q} — `−:y −:z +:p +:q`"
+    [:edn-inspector/set-multi-adjust]]
+
+   [:section "Deep hierarchy / mixed-type nesting"]
+   ["6a" "Deep scalar change"     "bump [:deep :a :b :c :d] — ancestors `:children`, none promoted"
+    [:edn-inspector/deep-change]]
+   ["6b" "Mixed-kind deep swap"   "swap set at [:mixed :a :b 0] (map→map→vec→set) — no ancestor promotion"
+    [:edn-inspector/mixed-deep-change]]
 
    [:section "Sentinels — redaction / size-elision"]
-   [6 "Sensitive → :rf/redacted"
-    "Add a :rf/redacted sentinel at [:session-secure :user :password] renders a `redacted` chip, never the raw value"
+   ["7a" "Sensitive → :rf/redacted" "assoc [:secure :user :password] :rf/redacted — `redacted` chip"
     [:edn-inspector/redacted]]
-   [7 "Large-elided sentinel"
-    "Add a :rf.size/large-elided sentinel at [:report-cache :report-42]"
+   ["7b" "Large-elided sentinel"    "assoc [:cache :report-42] a :rf.size/large-elided sentinel"
     [:edn-inspector/large-elided]]
 
-   [:section "Tagged literals / mixed types"]
-   [8 "Mixed types / tagged literals"
-    "Add a vector of scalar kinds — nil, boolean, int, float, string, keyword, symbol, #uuid, #inst tagged literals"
+   [:section "Showcase — elision / collapse / tagged literals"]
+   ["8a" "Large collection → elision" "50-key map at [:cache :grid] — elides past threshold"
+    [:edn-inspector/large-collection]]
+   ["8b" "Deeply nested → collapse"   "six-level nested map at [:cache :tenant] — `▸ {…N keys}` summaries"
+    [:edn-inspector/deeply-nested]]
+   ["8c" "Mixed types / tagged literals" "scalar-kind vector + #uuid + #inst at [:cache :scalar-mix]"
     [:edn-inspector/mixed-types]]])
 
 (defn- testid-for [event]
@@ -321,7 +482,7 @@
                  :gap "0.75em" :align-items "center" :margin "0.35em 0"}}
    [:button {:data-testid (testid-for event)
              :on-click    #(dispatch event)
-             :style {:min-width "18em" :text-align "left"
+             :style {:min-width "20em" :text-align "left"
                      :padding "0.4em 0.6em" :cursor "pointer"
                      :border "1px solid #cfc8ff" :border-radius "6px"
                      :background "#fff"}}
@@ -331,7 +492,7 @@
    [:span {:style {:color "#666" :font-size "12px"}} caption]])
 
 (reg-view section-heading
-  "A section separator inside the ladder."
+  "A matrix-group separator inside the ladder."
   [label]
   [:div {:style {:margin "1em 0 0.25em 0" :font-size "11px" :font-weight "bold"
                  :color "#7C5CFF" :text-transform "uppercase"
@@ -342,24 +503,24 @@
 (reg-view root []
   [:div {:data-testid "edn-inspector-root"
          :style {:font-family "system-ui, sans-serif" :padding "1em"
-                 :max-width "760px"}}
+                 :max-width "820px"}}
    [:header {:style {:margin-bottom "0.5em"}}
-    [:h2 {:style {:margin 0}} "edn-inspector"]
+    [:h2 {:style {:margin 0}} "edn-inspector — diff case matrix"]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     [:code "edn-inspector"] " is a component used within "
+     [:code "edn-inspector"] " is the value renderer used inside "
      [:code "xray"] " panels like " [:code "Epoch"] " and " [:code "app-db"]
-     ". This is a test app for that component."]
+     ". This deck walks its DIFF projection across the full datatype matrix."]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "It is a tall column of buttons. Click them one after the other to "
-     "see a series of " [:code "app-db"] " changes rendered within xray "
-     "on the right."]]
+     "Press the buttons top-to-bottom within each section. Each makes ONE "
+     [:code "app-db"] " change; the Epoch + App-db panels on the right "
+     "render the before/after + diff through the inspector."]]
    ;; Button 0 — Reset.
    [:button {:data-testid "edn-inspector-reset"
              :on-click #(dispatch [:edn-inspector/reset])
              :style {:padding "0.4em 0.8em" :cursor "pointer"
                      :border "1px solid #cfc8ff" :border-radius "6px"
                      :background "#f4f1ff" :margin "0.5em 0"}}
-    "0. Reset — re-seed app-db"]
+    "0. Reset — re-seed the matrix baseline"]
    ;; The ladder.
    (for [row ladder]
      (if (= :section (first row))


### PR DESCRIPTION
Senior-dev correctness audit of the Xray edn-inspector diff engine (`tools/xray/.../diff/engine.cljc`) + renderer (`views/edn_inspector.cljs`), worked SIMPLE → COMPLEX across the full datatype matrix per rf2-yucxn. Audit-first: drove the engine over every base case, marked correct/buggy/untested, fixed small bugs inline, ensured a unit test exists for each interesting case, then reworked the testbed deck.

## Case matrix verdict

| Case | Verdict |
|---|---|
| Maps — add / remove / value-changed | correct (already tested) |
| Sequentials — vector/list/set add / remove / changed | correct; **vector/list multi-removal fixed (BUG B)** |
| Sets — add/remove/swap/multi-swap | correct (l0us2 + 4vp8c), re-verified |
| Empty-result vs key-removal — set / map | correct (l0us2 / 9d4j8) |
| Empty-result vs key-removal — **vector / list** | **fixed (BUG A)** — was a whole-key `~` modify, now member-level like set/map |
| Scalars — kw/str/num(int,float,ratio)/bool/nil/sym, nil↔value, type-change | correct; added ratio/float/symbol/nil↔value coverage |
| Multi-adjust — map / vector / set add+remove in one diff | correct; added map/vector cases |
| Deep hierarchy + mixed-type nesting, ancestor non-promotion | correct (l0us2 union walk), added 3-level mixed-type assertion |

## Bugs fixed inline (engine.cljc)

- **BUG A** — vector/list emptied with key intact (`{:a [1]}→{:a []}`) classified as a whole-key `:modified` instead of member-level removal, inconsistent with the set/map empty edges. `expand-collection-replacement` now expands the sequential empty-edge `:r` into per-index `:-`/`:+` (scoped to the empty edge + same-family sequentials, so vector↔map flips stay R7 type-changes).
- **BUG B** — vector/list multi-element + scattered removals mis-recovered before-index/before-value (Editscript emits sequential `:-` at post-shift indices; the per-edit resolution read one element repeatedly and dropped the rest — e.g. `[1 2 3]→[1]` reported `−2 −2` and lost `3`). `resolve-vector-removals` replays the `:-` edits against the live before-sequence to recover the true index+value for every removed element.

## Deferred to a separate bead

- **rf2-vu42n** (P2) — renderer-side residual of BUG B: the inline vector body uses an index-aligned `children-of-pair` rather than the engine's `:vector-removals` + `:same-shifted` projection, so scattered/mid-vector removals mis-render which members are struck (contiguous tail removals render fine). Deferred to avoid a renderer redesign ballooning this PR; the engine contract is pinned by `yucxn-vector-scattered-removal-engine-channel-correct`.

## Tests added

- Engine (`engine_cljs_test.cljc`, +17 tests): empty-result-vs-removal per kind (both directions), root-level empties, multi-element + scattered vector removal (BUG B), ratio(JVM)/float/symbol/nil↔value scalars, map/vector multi-adjust, 3-level mixed-type ancestor-non-promotion.
- Renderer (`edn_inspector_cljs_test.cljs`, +5 tests): vector/list emptied renders member-level (key intact, not whole-key `~`), populated-from-empty renders `+`, multi-element removal shows every removed value distinctly, scattered-removal engine-channel precondition.
- Two existing `app_db_diff_cljs_test` cases encoded BUG A (whole-key tuple for a populated-from-empty vector); updated to the corrected member-level expectation.

## Testbed rework

`tools/xray/testbeds/edn_inspector/core.cljs` reworked into a progressive, case-by-case deck organised by the matrix (maps · sequentials · empty-vs-removal · scalars · multi-adjust · deep/mixed · sentinels · showcase), one clean control per case driving the Epoch + App-db panels through the inspector. The empty-vs-removal section pairs emptying each collection kind (key intact) against removing a key wholesale so the two render distinctly. Clean test surface — no deliberate bugs/teaching layers.

## Spec

`tools/xray/spec/004-App-DB-Diff.md` documents the vector/list empty-edge member-level parity + the multi-element/scattered removal recovery, with the rf2-vu42n renderer residual noted as deferred.

## Quality gates

- `npm run test:cljs` — PASS (5400 tests, 18605 assertions, 0 failures)
- JVM xray `clojure -M:test` — PASS (1093 tests, 4464 assertions, 0 failures; engine.cljc `.cljc` runs both runtimes incl. the JVM-only ratio case)
- `npm run test:xray-feature-gate` — PASS except the documented known-flake `routes-epochs routing ladder` (green on CI; unrelated routes-epochs nav-guard timing flake — all edn-inspector / app-db scenarios PASS)
- testbed build `npx shadow-cljs compile examples/edn-inspector` — PASS (424 files, 0 warnings)

Closes rf2-yucxn. Do not merge.
