### PR TITLE
fix(xray/edn-inspector): vector body renderer consumes :vector-removals + :same-shifted (rf2-vu42n)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -241,14 +241,22 @@ first — reporting one before-value repeatedly and dropping the rest.
 The replay recovers the true before-index + before-value for every
 removed element regardless of contiguity or multiplicity.
 
-> **Renderer note (rf2-vu42n, deferred).** The engine's
-> `:vector-removals` channel is now correct for scattered/mid-vector
-> removals, but the inline vector body renderer still index-aligns the
-> before/after vectors via `children-of-pair` rather than consuming
-> `:vector-removals` + `:same-shifted`. Contiguous *tail* removals
-> render correctly; mid/scattered removals mis-render which members are
-> struck. Tracked separately so the renderer rework does not balloon the
-> engine fix.
+> **Renderer note (rf2-vu42n, fixed).** The inline vector / list / seq
+> body renderer **consumes** this `:vector-removals` channel (plus the
+> `:same-shifted` shift projection) via `sequential-diff-children`,
+> rather than index-aligning the raw before/after vectors. The walk
+> reconstructs the body in before-order: each surviving element renders
+> at its *after* index (so the projection resolves its `:same` /
+> `:same-shifted` / `:modified` op) carrying its prior value on the
+> `before` slot; each genuinely-removed element is spliced back in at its
+> true before-index, struck-through, with an `::missing` after-value;
+> purely-added elements append after the before-ordered run. Maps / sets
+> / records keep the `children-of-pair` union walk — their slots are
+> key/member-addressed, so there is no positional shift to recover. The
+> pre-fix index-alignment struck a surviving-*shifted* element (the one
+> that slid up into a vacated slot) and dropped the actually-removed one
+> for scattered / mid-vector removals; contiguous *tail* removals lined
+> up under index alignment, so only mid / scattered removals mis-rendered.
 
 ### Removed slots render in place; the absence marker never escapes (rf2-8pfkk)
 

--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -1109,3 +1109,21 @@
   the sentinel. Drives R8's curated suffix branch. Returns nil otherwise."
   [projection path]
   (:rf.xray.diff/redaction-side (get-in projection [:path-ops (vec path)])))
+
+(defn vector-removals-at
+  "Return the off-path `:-` removals recorded for the vector/list/seq at
+  `path` — a vector of `{:before-index :before-value}` maps in
+  ascending before-index order — or `nil` when no element was removed
+  there.
+
+  A vector/list removal has no stable AFTER-side path (the survivors
+  shift up to fill the gap), so the engine routes it into the off-path
+  `:vector-removals` channel keyed by the PARENT path instead of emitting
+  a `:path-ops` leaf op. The renderer's sequential body walk consumes
+  this channel to splice each genuinely-removed element back into the
+  rendered list at its true before-index, struck-through, rather than
+  index-aligning the raw before/after vectors (rf2-vu42n — index
+  alignment mis-attributes the strike to a surviving-shifted member and
+  drops the actually-removed one for scattered / mid-vector removals)."
+  [projection path]
+  (get-in projection [:vector-removals (vec path)]))

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1173,6 +1173,103 @@
 
     nil))
 
+(def ^:private removed-key-tag
+  "Path-segment tag wrapping a vector removal's before-index, so a struck-
+  through removed element gets a React `:key` distinct from the surviving
+  element now occupying that integer slot. The removal's op is forced
+  `:removed` by its `::missing` after-value (`render-leaf-with-diff`'s
+  structural override, rf2-8pfkk), so this synthetic segment is never
+  consulted for a projection op lookup — it exists purely for key + testid
+  uniqueness."
+  :rf.xray.edn-inspector/removed)
+
+(defn sequential-diff-children
+  "Projection-aware children walk for a vector / list / seq in diff mode
+  (rf2-vu42n). Returns a seq of `[child-key after-value before-value]`
+  triples — the SAME shape `children-of-pair` returns — but built by
+  CONSUMING the engine's `:vector-removals` + `:same-shifted` projection
+  rather than index-aligning the raw before/after vectors.
+
+  Why not `children-of-pair`: a vector `:-` removal has no stable after-
+  side path (survivors shift up). `children-of-pair` pairs before-index
+  `i` with after-index `i` position-by-position, so for a scattered /
+  mid-vector removal it strikes a SURVIVING-SHIFTED element (the one that
+  slid up into the vacated slot) and never surfaces the genuinely-removed
+  member. Contiguous TAIL removals happen to line up under index
+  alignment, so only mid / scattered removals mis-render — this walk
+  fixes all of them uniformly.
+
+  Reconstruction (pure, projection-driven):
+
+  - Surviving elements come from the AFTER vector at their AFTER index,
+    so the per-element op resolves correctly off the projection (`:same`
+    / `:same-shifted` / `:modified`). Their `before` slot carries the
+    element's PRIOR value (recovered via the survivor's before-index) —
+    NOT `::missing`, because `render-leaf-with-diff` treats a `::missing`
+    before slot as a structural `:added` (rf2-8pfkk), which would override
+    the projection and paint a surviving element green.
+  - Purely-added elements come from the AFTER vector at their AFTER index
+    with a `::missing` before slot (correctly forcing `:added`).
+  - Removed elements come from `:vector-removals` — each carries its true
+    `:before-index` + `:before-value`. They render struck-through with
+    the after-value `::missing` (forcing `:removed`).
+  - Order: the removed elements are spliced back into BEFORE-order
+    position relative to the survivors, so the rendered list reads as the
+    before-sequence with deletions struck IN PLACE; purely-added elements
+    append after the survivors/removals in after-order.
+
+  Falls back to `children-of-pair` when no `projection` is supplied (the
+  test / REPL path that drives `render-container` without a top-level
+  projection compute) — same answer for the no-removal case, graceful for
+  the rest. Pure; `parent-path` is this vector's absolute path.
+
+  Public so tests can probe the reconstruction without re-deriving it."
+  [before after kind parent-path projection]
+  (let [a-vec (when (sequential? after)  (vec after))
+        b-vec (when (sequential? before) (vec before))]
+    (cond
+      ;; No projection (test/REPL path) or one side absent / non-sequential
+      ;; — defer to the index-aligning union walk. With both sides present
+      ;; AND a projection we take the removal-aware reconstruction below.
+      (not (and projection a-vec b-vec))
+      (children-of-pair before after kind)
+
+      :else
+      (let [parent-path (vec parent-path)
+            removals    (vec (engine/vector-removals-at projection parent-path))
+            removed-bis (into #{} (map :before-index) removals)
+            ;; Survivors in after-order = after elements whose op is NOT
+            ;; `:added`. Each maps, in order, to a surviving before-index
+            ;; (ascending) — Editscript preserves survivor relative order.
+            added?      (fn [ai] (= :added (engine/op-at projection
+                                                         (conj parent-path ai))))
+            after-idxs  (range (count a-vec))
+            survivor-ais (vec (remove added? after-idxs))
+            added-ais    (vec (filter added? after-idxs))
+            survivor-bis (vec (remove removed-bis (range (count b-vec))))
+            ;; before-index → surviving after-index (1:1 in order).
+            bi->ai      (zipmap survivor-bis survivor-ais)
+            removal-by-bi (zipmap (map :before-index removals) removals)
+            ;; Walk BEFORE order: removed elements struck in place, survivors
+            ;; rendered at their AFTER index (projection chrome resolves).
+            ;; A survivor's `before` slot carries its PRIOR value (`nth
+            ;; b-vec bi`) — never `::missing`, which `render-leaf-with-diff`
+            ;; would read as a structural `:added`.
+            before-order
+            (mapcat
+              (fn [bi]
+                (if (contains? removed-bis bi)
+                  (let [{:keys [before-value]} (removal-by-bi bi)]
+                    [[[removed-key-tag bi] ::missing before-value]])
+                  (when-let [ai (bi->ai bi)]
+                    [[ai (nth a-vec ai) (nth b-vec bi)]])))
+              (range (count b-vec)))
+            ;; Purely-added elements append after the before-ordered run;
+            ;; `::missing` before slot forces the `:added` render path.
+            added-rows
+            (map (fn [ai] [ai (nth a-vec ai) ::missing]) added-ais)]
+        (concat before-order added-rows)))))
+
 (defn- diff-pair-count
   "Cheap union-aware child count for diff mode. Returns the number of
   rows the union walk will emit so the header logic (`empty?` /
@@ -1852,14 +1949,29 @@
         toggle-fn     (on-toggle dispatch-fn panel-id mount-id path
                                  (boolean (and expanded? (not depth-capped?))))
         ;; rf2-zuh1e — in diff mode the body walks the UNION of BEFORE +
-        ;; AFTER children via `children-of-pair`. Plain browse keeps the
-        ;; original AFTER-only `children-of` walk. The pair-list shape
-        ;; differs (`[k v]` for browse vs `[k v b]` for diff) so the
-        ;; downstream child-pair construction below normalises into a
-        ;; uniform `[k v b]` triple for the recursive render call.
+        ;; AFTER children. Plain browse keeps the original AFTER-only
+        ;; `children-of` walk. The pair-list shape differs (`[k v]` for
+        ;; browse vs `[k v b]` for diff) so the downstream child-pair
+        ;; construction below normalises into a uniform `[k v b]` triple
+        ;; for the recursive render call.
+        ;;
+        ;; rf2-vu42n — vectors / lists / seqs consume the engine's off-path
+        ;; `:vector-removals` + `:same-shifted` projection via
+        ;; `sequential-diff-children` rather than index-aligning the raw
+        ;; before/after vectors. Index alignment (the old `children-of-pair`
+        ;; vector branch) mis-attributed the strike to a surviving-shifted
+        ;; element and dropped the genuinely-removed one for scattered /
+        ;; mid-vector removals; the projection-driven walk strikes the
+        ;; actually-removed members in before-order, in place. Maps / sets /
+        ;; records / map-entries keep the `children-of-pair` union walk
+        ;; (their slots are key/member-addressed — no positional shift).
         children      (when (and (not empty?) (not depth-capped?) expanded? (not inline-fit?))
-                        (if diff?
+                        (cond
+                          (and diff? (#{:vector :list :seq} kind))
+                          (sequential-diff-children before value kind path projection)
+                          diff?
                           (children-of-pair before value kind)
+                          :else
                           (children-of value)))
         ;; rf2-zl4rs — zoom-in is a node-local gesture (double-click /
         ;; Enter) on every non-empty container at a NON-ROOT relative

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -1411,6 +1411,169 @@
     (is (re-find #"data-rf-diff-op.*removed" s)
         "a row carries the removed diff-op marker")))
 
+;; =========================================================================
+;; rf2-vu42n — scattered / mid-vector removals render the genuinely-removed
+;; members struck, and the surviving-shifted members NOT struck. The fixed
+;; renderer consumes the engine's off-path `:vector-removals` + `:same-
+;; shifted` projection instead of index-aligning the raw before/after
+;; vectors via `children-of-pair`.
+;; =========================================================================
+;;
+;; Pre-fix, the vector body renderer index-aligned position-by-position:
+;; for `[:a :b :c :d] -> [:a :c]` it rendered `[ :a :c(was…) -:c -:d ]` —
+;; it struck `:c` (which SURVIVES at after-index 1) and `:d`, and never
+;; surfaced the genuinely-removed `:b`. Contiguous TAIL removals happened
+;; to line up under index alignment, so only mid / scattered removals
+;; mis-rendered. These tests drive `render-node` WITH a projection (the
+;; real diff path; the no-projection test/REPL path still falls back to
+;; `children-of-pair`), and assert which members are struck.
+
+(defn- struck-members
+  "Return the set of value strings the renderer struck through in `tree`.
+  A removed leaf renders via `gutter-row :removed`, whose OUTER span and
+  INNER body span BOTH carry `:data-rf-diff-op \"removed\"`; the outer span
+  also holds the `-` gutter glyph. We collect the text under the
+  shallowest `removed` span and strip a leading gutter glyph + whitespace
+  so the comparison is against the bare value (e.g. `\":b\"`, not `\"-:b\"`)."
+  [tree]
+  (let [out (atom #{})]
+    (letfn [(walk [node]
+              (when (vector? node)
+                (let [attrs (when (map? (second node)) (second node))]
+                  (if (= "removed" (:data-rf-diff-op attrs))
+                    (swap! out conj
+                           (-> (collect-text node)
+                               (str/replace #"^[\s\-−\+~]+" "")
+                               str/trim))
+                    (doseq [c (rest node)] (walk c))))))]
+      (walk tree))
+    @out))
+
+(defn- render-vec-diff
+  "Render `before -> after` as a vector diff THROUGH the real projection
+  path (the production renderer computes `engine/project` once at the top
+  and threads it down via `:projection`). Returns the hiccup tree."
+  [before after]
+  (ei/render-node {:value      after
+                   :before     before
+                   :diff?      true
+                   :projection (engine/project before after)
+                   :panel-id   :p :mount-id "m"
+                   :path [] :depth 0
+                   :expansion-map {}
+                   ;; default-expanded-depth high enough that the root
+                   ;; expands and the body walk runs.
+                   :opts {:default-expanded-depth 4}}))
+
+(deftest diff-vector-scattered-removal-strikes-removed-not-survivors
+  ;; Canonical rf2-vu42n repro: `[:a :b :c :d] -> [:a :c]` removes :b@1
+  ;; and :d@3; :c survives (shifted from index 2 → 1).
+  (let [before [:a :b :c :d]
+        after  [:a :c]
+        h      (render-vec-diff before after)
+        all    (collect-text h)
+        struck (struck-members h)]
+    (testing "the genuinely-removed members ARE struck"
+      (is (contains? struck ":b") ":b (removed@1) is struck")
+      (is (contains? struck ":d") ":d (removed@3) is struck"))
+    (testing "the surviving-shifted member is NOT struck"
+      (is (not (contains? struck ":c"))
+          ":c SURVIVES at after-index 1 — must not be struck")
+      (is (not (contains? struck ":a"))
+          ":a survives at index 0 — must not be struck"))
+    (testing "every member is still visible somewhere in the tree"
+      (is (re-find #":a" all))
+      (is (re-find #":b" all))
+      (is (re-find #":c" all))
+      (is (re-find #":d" all)))
+    (testing "the surviving-shifted :c carries a `(was N)` shift suffix"
+      ;; The engine's R6 shift detector reports :c's before-index for
+      ;; this edit script; the renderer surfaces it verbatim as `(was N)`.
+      ;; We only assert that SOME shift suffix renders for the survivor,
+      ;; not the exact N (that's the engine's contract, tested under
+      ;; rf2-yucxn / the engine suite) — the renderer's job is to PAINT it.
+      (is (re-find #"\(was \d+\)" all)
+          ":c is surviving-shifted → carries a (was N) shift suffix"))))
+
+(deftest diff-vector-single-mid-removal-strikes-only-the-gap
+  ;; A single mid-vector removal: `[:a :b :c] -> [:a :c]` removes :b@1.
+  ;; :c survives (shifted 2 → 1). Pre-fix this struck :c and dropped :b.
+  (let [before [:a :b :c]
+        after  [:a :c]
+        h      (render-vec-diff before after)
+        struck (struck-members h)]
+    (is (contains? struck ":b") ":b (the removed gap) is struck")
+    (is (not (contains? struck ":c"))
+        ":c survives (shifted) — must not be struck")
+    (is (not (contains? struck ":a")) ":a survives in place — not struck")))
+
+(deftest diff-vector-tail-removal-still-correct-with-projection
+  ;; Re-verify the contiguous-tail case under the projection path (it was
+  ;; the ONE case index alignment happened to get right; the projection
+  ;; walk must not regress it). `[:x :y :z] -> [:x]` removes :y@1 + :z@2.
+  (let [before [:x :y :z]
+        after  [:x]
+        h      (render-vec-diff before after)
+        struck (struck-members h)]
+    (is (contains? struck ":y") ":y (tail) is struck")
+    (is (contains? struck ":z") ":z (tail) is struck")
+    (is (not (contains? struck ":x")) ":x survives at index 0 — not struck")))
+
+(deftest diff-vector-numeric-scattered-removal
+  ;; Numeric payload, scattered removal: `[10 20 30 40 50] -> [10 30 50]`
+  ;; removes 20@1 + 40@3; 30 (2→1) and 50 (4→2) survive shifted.
+  (let [before [10 20 30 40 50]
+        after  [10 30 50]
+        h      (render-vec-diff before after)
+        struck (struck-members h)]
+    (is (contains? struck "20") "20 (removed@1) struck")
+    (is (contains? struck "40") "40 (removed@3) struck")
+    (is (not (contains? struck "30")) "30 survives (shifted 2→1) — not struck")
+    (is (not (contains? struck "50")) "50 survives (shifted 4→2) — not struck")
+    (is (not (contains? struck "10")) "10 survives in place — not struck")))
+
+(deftest sequential-diff-children-scattered-removal-shape
+  ;; The pure projection-aware child walk directly: for `[:a :b :c :d] ->
+  ;; [:a :c]` it emits before-ordered triples with the removed members at
+  ;; a synthetic key (forces `:removed` via `::missing` after-value) and
+  ;; the survivors at their AFTER index (projection chrome resolves).
+  (let [before [:a :b :c :d]
+        after  [:a :c]
+        proj   (engine/project before after)
+        pairs  (vec (ei/sequential-diff-children before after :vector [] proj))]
+    (testing "one triple per before-position (survivors + struck removals)"
+      (is (= 4 (count pairs))
+          "[:a :b :c :d] -> [:a :c]: 2 survivors + 2 removed = 4 rows"))
+    (testing "removed members carry ::missing on the AFTER side"
+      ;; :b and :d are the removed before-values; their after slot is ::missing.
+      (let [removed-after (->> pairs
+                               (filter (fn [[_ a _]] (= a ::ei/missing)))
+                               (map (fn [[_ _ b]] b))
+                               set)]
+        (is (= #{:b :d} removed-after)
+            ":b and :d are the struck (after=::missing) members")))
+    (testing "survivors keep their AFTER index as the path key"
+      (let [survivors (->> pairs
+                           (remove (fn [[_ a _]] (= a ::ei/missing)))
+                           (map (fn [[k a _]] [k a]))
+                           set)]
+        ;; :a at after-index 0, :c at after-index 1.
+        (is (= #{[0 :a] [1 :c]} survivors)
+            "survivors rendered at after-index 0 (:a) and 1 (:c)")))
+    (testing "before-order: :a, :b(removed), :c, :d(removed)"
+      (is (= [:a :b :c :d]
+             (mapv (fn [[_ a b]] (if (= a ::ei/missing) b a)) pairs))
+          "rows read in before-order with deletions struck in place"))))
+
+(deftest sequential-diff-children-falls-back-without-projection
+  ;; No projection (test/REPL path) → defer to the index-aligning union
+  ;; walk so the no-removal / tail cases stay deterministic.
+  (let [before [:x :y :z]
+        after  [:x]
+        pairs  (vec (ei/sequential-diff-children before after :vector [] nil))]
+    (is (= (vec (ei/children-of-pair before after :vector)) pairs)
+        "nil projection falls back to children-of-pair")))
+
 (deftest diff-renders-removed-set-member
   ;; Canonical machine-snapshot reproduction (rf2-zuh1e bead body):
   ;; `:tags` set loses `:ws/authenticating`. Before this fix the AFTER

--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -118,6 +118,9 @@
    :queue      [:task-1 :task-2 :task-3]
    :history    '(:login :browse)
    :tags       #{:alpha :beta :gamma}
+   ;; SCATTERED removal repro (rf2-vu42n) — a four-element lane the
+   ;; scattered-removal button thins to [:a :c] (drops :b@1 + :d@3).
+   :lane       [:a :b :c :d]
    ;; EMPTY vs REMOVAL — a single-member of each kind to empty (key intact)
    ;; alongside a sibling key to remove wholesale.
    :one-vec    [:only]
@@ -200,6 +203,19 @@
       (if (> (count (:queue db)) 1)
         (update db :queue pop)
         (assoc db :queue [:task-1 :task-2 :task-3])))))
+
+(rf/reg-event-db :edn-inspector/seq-scattered-removed
+  {:doc "Sequential: SCATTERED / MID-VECTOR removal (rf2-vu42n). Thin :lane
+         `[:a :b :c :d]` → `[:a :c]` — drop :b@1 AND :d@3. The genuinely-
+         removed :b and :d render struck IN PLACE; the surviving-shifted :c
+         (was index 2 → now 1) must NOT be struck and carries a `(was N)`
+         suffix. Pre-fix the index-aligning renderer struck :c and dropped
+         :b. Toggles back to the full lane so the diff alternates."}
+  (fn [db _]
+    (let [db (bump db)]
+      (if (= (:lane db) [:a :b :c :d])
+        (assoc db :lane [:a :c])
+        (assoc db :lane [:a :b :c :d])))))
 
 (rf/reg-event-db :edn-inspector/set-member-changed
   {:doc "Set: a MEMBER CHANGED (swap). Replace one member of :tags — the
@@ -419,7 +435,9 @@
     [:edn-inspector/seq-entry-added]]
    ["2b" "Vector: entry REMOVED" "pop :queue tail — struck member, key intact"
     [:edn-inspector/seq-entry-removed]]
-   ["2c" "Set: member CHANGED"   "swap a :tags member — `−:alpha +:delta`, key intact"
+   ["2c" "Vector: SCATTERED removal" ":lane [:a :b :c :d]→[:a :c] — struck −:b −:d, :c survives (was N)"
+    [:edn-inspector/seq-scattered-removed]]
+   ["2d" "Set: member CHANGED"   "swap a :tags member — `−:alpha +:delta`, key intact"
     [:edn-inspector/set-member-changed]]
 
    [:section "Empty-result vs key-removal (must read DISTINCTLY)"]


### PR DESCRIPTION
## What

Fixes **rf2-vu42n** (P2 BUG): the Xray edn-inspector RENDERER mis-rendered scattered / mid-vector removals.

The diff-mode vector / list / seq body renderer walked diffs via `children-of-pair`, which **index-aligns** the raw before/after vectors position-by-position. For `[:a :b :c :d] -> [:a :c]` (remove `:b@1` + `:d@3`) it rendered `[ :a :c(was N) -:c -:d ]` — it struck `:c` (which **survives** at after-index 1) and `:d`, and never surfaced the genuinely-removed `:b`. Contiguous *tail* removals happened to line up under index alignment, so only mid / scattered removals mis-rendered.

The engine side was already correct + unit-tested under #2860 (rf2-yucxn): the `:vector-removals` channel recovers the true before-index + value of every removed element (incl. scattered / multi). This PR is purely the renderer **consuming** that projection.

## How

- **engine** (`diff/engine.cljc`): add `vector-removals-at` — a projection reader for the off-path `:vector-removals` channel.
- **renderer** (`views/edn_inspector.cljs`): new `sequential-diff-children` reconstructs the vector/list/seq diff body in **before-order** — survivors render at their *after* index (so the projection resolves `:same` / `:same-shifted` / `:modified`) carrying their prior value on the `before` slot; removed elements splice back in at their true before-index, struck-through (`::missing` after-value forces `:removed`); purely-added elements append after. Wired into `render-container` for `:vector` / `:list` / `:seq` diff bodies. Falls back to `children-of-pair` when no projection is present (the test/REPL path). Maps / sets / records keep the `children-of-pair` union walk — their slots are key/member-addressed, no positional shift.
- **tests**: renderer unit tests for scattered, single mid, numeric scattered, and tail-with-projection render cases — asserting the genuinely-removed members ARE struck and surviving-shifted members are NOT. Plus the pure `sequential-diff-children` shape + the no-projection fallback.
- **testbed**: added a scattered-removal rung (2c) to the `edn_inspector` matrix deck (`:lane [:a :b :c :d] → [:a :c]`).
- **spec/004**: flipped the deferred renderer note to **fixed**, documenting the projection-consuming contract.

## Gates (cold build)

- `npm run test:cljs` — **5406 tests / 18630 assertions, 0 failures, 0 errors**.
- `tools/xray` JVM `clojure -M:test` — **1093 tests / 4464 assertions, 0 failures, 0 errors**.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, 13 matrix rows** (all 14 surfaces compiled, 0 warnings). The known `routes-epochs` local flake did not surface.

Closes rf2-vu42n.