### PR TITLE
feat(xray-testbeds): queued-step runner + managed-http pilot (rf2-8pbjr + rf2-6nolv)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -327,6 +327,21 @@
             ;; machine-epochs 8033).
             8034 ["../tools/xray/testbeds/edn_inspector"
                   "out/examples/edn-inspector"]
+            ;; Single-frame managed-http testbed (rf2-6nolv) — the
+            ;; MANAGED-HTTP pilot of the shared queued-step RUNNER
+            ;; (rf2-8pbjr; runner.core). One button walks the
+            ;; :rf.http/managed lifecycle (fire · success · 4xx · 5xx ·
+            ;; abort · concurrent-by-actor · request-outlives-teardown),
+            ;; pinning Xray focus to the latest :rf/default epoch after
+            ;; each dispatch so the operator sees how the Epoch / Trace /
+            ;; App-db panels render each step. Title "Xray Testbed:
+            ;; Managed HTTP". Same source-dir-first cascade as 8031-8034;
+            ;; the source dir resolves the hand-written index.html + the
+            ;; static api/ok.json at `/`, compiled main.js falls through
+            ;; to out/examples/managed-http. Port 8035 is the next free
+            ;; testbed slot above the _epochs trio + edn-inspector.
+            8035 ["../tools/xray/testbeds/managed_http"
+                  "out/examples/managed-http"]
             ;; --- Story showcases (rf2-xz4zn) -------------------------
             ;; The four Story-enabled builds, on the 804x band (the Xray
             ;; testbeds own 803x + 8765). Each is hash-routed: `/#/` is
@@ -886,6 +901,47 @@
                        #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
    :modules          {:main {:init-fn edn-inspector.core/run}}
    :devtools         {:preloads [re-frame2-pair.runtime]}}
+
+  ;; Single-frame managed-http testbed (rf2-6nolv) — the MANAGED-HTTP
+  ;; PILOT of the shared queued-step RUNNER (rf2-8pbjr; runner.core).
+  ;; ONE button (`▶ Run series`) walks the :rf.http/managed lifecycle
+  ;; (fire-in-flight · success · 4xx · 5xx · abort · concurrent-by-actor ·
+  ;; request-outlives-frame-teardown), aimed at how the Xray Epoch /
+  ;; Trace / App-db panels render managed-HTTP effects + traces. After
+  ;; each auto-advance dispatch the runner pins Xray focus to the latest
+  ;; :rf/default epoch (via day8.re-frame2-xray.focus/focus!) so the
+  ;; operator always sees the just-dispatched render. The runner cursor
+  ;; lives in a LOCAL ATOM in managed-http.core — NOT the inspected
+  ;; app-db (would pollute the App-db panel) and NOT a second frame
+  ;; (would appear in Xray's frame surfaces). Title "Xray Testbed:
+  ;; Managed HTTP". A TEST surface — no deliberate bugs, no teaching
+  ;; layers (feedback_testbeds_are_test_surfaces).
+  ;;
+  ;; The events / fxs / subs / step-vector are OWNED in
+  ;; managed_http/core.cljs; it requires the managed-HTTP artefact
+  ;; (`[re-frame.http-managed]`) + its test-support
+  ;; (`[re-frame.http-test-support]` — a testbed IS a test affordance,
+  ;; per rf2-cdmle) + the shared `[runner.core]`. The HOT success path
+  ;; rides a live Fetch against the static api/ok.json shipped beside the
+  ;; testbed (source-dir-first cascade resolves it); the failure / abort
+  ;; paths use the framework canned-stub fxs for determinism (same shape
+  ;; as testbeds/http_toggle). Sources live under
+  ;; tools/xray/testbeds/managed_http/; the Xray preload auto-mounts
+  ;; inline so every lens reads the single :rf/default frame. Served at
+  ;; http://localhost:8035 via the top-level `:dev-http` map (the next
+  ;; free testbed slot above the _epochs trio + edn-inspector 8034).
+  :examples/managed-http
+  {:target           :browser
+   :output-dir       "out/examples/managed-http"
+   :asset-path       "."
+   ;; rf2-5dphw — build-env project-root for open-in-editor (see
+   ;; :examples/two-frame-isolation above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn managed-http.core/run}}
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
 
   ;; Xray panel-gallery testbed (rf2-1o7mp) — visual gallery of Xray
   ;; panels under varying state magnitude. Sources live under

--- a/tools/xray/testbeds/managed_http/api/ok.json
+++ b/tools/xray/testbeds/managed_http/api/ok.json
@@ -1,0 +1,1 @@
+{"ok":true,"value":"managed-http ok"}

--- a/tools/xray/testbeds/managed_http/core.cljs
+++ b/tools/xray/testbeds/managed_http/core.cljs
@@ -1,0 +1,511 @@
+(ns managed-http.core
+  "MANAGED-HTTP testbed (rf2-6nolv) — the PILOT consumer of the shared
+  queued-step RUNNER (rf2-8pbjr; `runner.core`).
+
+  An operator visually inspects how the Xray panels (Epoch · Trace ·
+  App-db · Machine Inspector) render the managed-HTTP lifecycle by
+  pressing ONE button (`▶ Run series`) and watching each interesting
+  step play out, with per-step commentary on what to look for. Title:
+  `Xray Testbed: Managed HTTP`.
+
+  ## What it exercises (Spec 014 — `:rf.http/managed` and family)
+
+  The step vector (`steps`, below) is CODE DATA — a `def`ed vector of
+  step maps, each `{:event … :watch … :settle-ms …}`. It walks the
+  managed-HTTP lifecycle:
+
+    1. Fire a request           — in-flight render (`:status :loading`,
+                                  the in-flight registry gains a slot).
+    2. Success response         — 2xx decoded; reply `:kind :success`.
+    3. Error response (4xx)     — status 404; decode skipped; reply
+                                  `:failure :kind :rf.http/http-4xx`.
+    4. Error response (5xx)     — status 500; the `:rf.http/http-5xx`
+                                  error trace.
+    5. Abort in-flight          — fire a deferred request, then abort it
+                                  before the reply lands
+                                  (`:rf.http/aborted`).
+    6. Concurrent by same actor — TWO requests issued under the SAME
+                                  actor-id; the actor-in-flight index
+                                  carries both (Spec 014 §Abort on actor
+                                  destroy, rf2-wvkn).
+    7. Outlives a frame teardown — an in-flight request whose actor is
+                                  destroyed mid-flight is aborted via
+                                  `abort-on-actor-destroy`
+                                  (`:rf.http/aborted-on-actor-destroy`).
+
+  ## Runner state = LOCAL ATOM (rf2-8pbjr contract)
+
+  The runner cursor/phase lives in `runner-state` — a LOCAL Reagent atom
+  in THIS ns. It is NEVER written to the inspected app-db (that would
+  pollute the App-db panel under inspection) and is NOT a second frame
+  (only the inspected app frame, `:rf/default`, is Xray-relevant). After
+  each auto-advance dispatch the runner focuses the latest `:rf/default`
+  epoch so the operator sees the just-dispatched render.
+
+  ## Real registry vs canned replies (deterministic, clean)
+
+  Following the established `testbeds/http_toggle` pattern: the HOT path
+  (success) rides a REAL Fetch against the static `api/ok.json` shipped
+  beside the testbed; the 4xx / 5xx error paths use the framework-shipped
+  canned-stub fx (`:rf.http/managed-canned-failure`) wrapped to replay
+  the live error trace, so the lifecycle is deterministic across CI
+  environments — no flaky outbound network. The in-flight + actor-in-
+  flight registries are seeded with genuine handles in the framework
+  registry (the same atoms the real transport's `run-attempt!` records
+  into) so the pending slots render DETERMINISTICALLY — a real Fetch
+  against a dev-http static server resolves instantly, leaving nothing
+  observably in-flight across a settle window. The abort path resolves a
+  seeded handle through the LIVE `:rf.http/managed-abort` fx. A TEST
+  surface — no deliberate bugs, no teaching layers
+  (feedback_testbeds_are_test_surfaces).
+
+  ## Bundle isolation
+
+  Lives under `tools/xray/testbeds/`; requires the managed-HTTP artefact
+  (`re-frame.http-managed`) + its test-support (`re-frame.http-test-
+  support` — a testbed IS a test affordance) + the shared `runner.core`.
+  Nothing under `implementation/` requires this."
+  (:require [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.trace :as trace]
+            ;; Managed-HTTP ships in day8/re-frame2-http. Requiring at app
+            ;; boot triggers its load-time fx registrations
+            ;; (`:rf.http/managed` / `:rf.http/managed-abort`).
+            [re-frame.http-managed :as http-managed]
+            ;; The actor-in-flight INDEX-WRITE seam (`record-in-flight!`)
+            ;; is not re-exported from re-frame.http-managed (only the
+            ;; read-side snapshots + clear/abort are). The testbed reaches
+            ;; the registry ns directly to seed the actor-in-flight index
+            ;; for the concurrent-by-actor + outlives-teardown steps — the
+            ;; same atom the real transport's run-attempt! records into.
+            [re-frame.http-registry :as http-registry]
+            ;; The canned-stub fx ids (`:rf.http/managed-canned-failure`)
+            ;; register from re-frame.http-test-support per rf2-cdmle. A
+            ;; testbed IS a test affordance, so requiring it is correct.
+            [re-frame.http-test-support]
+            [re-frame.http :as rf.http]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.interop :as interop]
+            [day8.re-frame2-xray.config :as xray-config]
+            [re-frame.testbed.config :as testbed-config]
+            [runner.core :as runner])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; The inspected app frame (rf2-8pbjr — only the app frame is Xray-relevant)
+;; ============================================================================
+
+(def host-frame :rf/default)
+
+;; ============================================================================
+;; APP-DB
+;; ============================================================================
+;;
+;; Minimal — :status is :idle | :loading | :done | :error; :reply carries
+;; the last reply for the operator to read in the DOM mirror; :log is a
+;; short narrative of the last lifecycle events. The Xray Epoch / Trace
+;; panels are the primary surface; the DOM strip is a standalone fall-back.
+
+(rf/reg-event-db ::initialise
+  {:doc "Seed app-db: idle, no reply, empty log."}
+  (fn [_db _ev]
+    {:status :idle :reply nil :log []}))
+
+(defn- log-line [db line]
+  (update db :log (fn [xs] (vec (take-last 8 (conj (or xs []) line))))))
+
+;; ----------------------------------------------------------------------------
+;; Reply addressing — one handler per logical request receives the reply.
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::reply
+  {:doc "Reply sink for the success / failure paths. Receives the reply
+         payload DIRECTLY (explicit `:on-success` / `:on-failure`
+         addressing per Spec 014 §Reply addressing appends the
+         `{:kind …}` payload as the last arg — not wrapped in
+         `:rf/reply`). Files it and narrates the lifecycle outcome
+         (`:done` on success, `:error` + the failure :kind otherwise)."}
+  (fn [db [_ reply]]
+    (let [ok? (= :success (:kind reply))]
+      (-> db
+          (assoc :status (if ok? :done :error))
+          (assoc :reply reply)
+          (log-line (if ok?
+                      (str "✓ success: " (pr-str (:value reply)))
+                      (str "✗ failure: " (pr-str (get-in reply [:failure :kind])))))))))
+
+;; ============================================================================
+;; REQUEST IDS / URLS
+;; ============================================================================
+
+(def ok-request-id     ::ok)
+(def in-flight-id      ::in-flight)
+(def abortable-id      ::abortable)
+(def actor-a          :managed-http/actor-a)
+(def actor-b          :managed-http/actor-b)
+
+;; A placeholder URL stamped on the seeded in-flight handles (for the
+;; registry strip + abort trace). Same-origin so it reads naturally; no
+;; live Fetch is issued for the in-flight / actor steps — those seed the
+;; registry directly so the pending slots are DETERMINISTIC (a real Fetch
+;; against a dev-http static server resolves instantly, leaving nothing
+;; observably in-flight across the settle window).
+(def pending-url "api/pending")
+
+;; ============================================================================
+;; CANNED-FAILURE-WITH-TRACE — the http_toggle pattern (rf2-3g16l)
+;; ============================================================================
+;;
+;; The framework `:rf.http/managed-canned-failure` synthesises a failure
+;; reply but does NOT emit the category-attributed `:rf.http/<kind>`
+;; error trace the live failure path emits. The Xray Trace / Epoch panels
+;; render that trace, so this testbed-local wrapper replays the live
+;; path's `trace/emit-error!` before delegating to the canned stub — so
+;; the panels show the same `:operation :rf.http/<kind>` row a live
+;; failure would. Honours the canned stub's optional `:after-ms`
+;; deferral (rf2-j1mo4) so a deferred failure is observably in-flight.
+
+(rf/reg-fx :managed-http/canned-failure-with-trace
+  {:doc       "Testbed-only wrapper around :rf.http/managed-canned-failure.
+               Emits the category-attributed :rf.http/<kind> error trace
+               (matching the live failure path's finalise-failure! emit),
+               then delegates to the framework canned stub for the reply
+               synthesis. See rf2-3g16l / testbeds/http_toggle."
+   :platforms #{:client}}
+  (fn fx-canned-failure-with-trace [frame-ctx args-map]
+    (let [kind (or (:kind args-map) :rf.http/transport)
+          tags (or (:tags args-map) {})
+          url  (get-in args-map [:request :url])]
+      (trace/emit-error! kind
+                         (assoc tags
+                                :kind       kind
+                                :request-id (:request-id args-map)
+                                :url        url
+                                :recovery   :no-recovery))
+      ((registrar/handler :fx :rf.http/managed-canned-failure)
+       frame-ctx args-map))))
+
+;; ============================================================================
+;; LIFECYCLE EVENTS — one per interesting step
+;; ============================================================================
+
+;; (1) Fire a request that stays IN-FLIGHT across the settle window.
+;; Seeds a genuine request-id-keyed handle in the framework registry —
+;; deterministic, so the in-flight strip shows a pending slot for the
+;; whole settle (a real Fetch against a dev-http static server resolves
+;; instantly, leaving nothing observably in-flight). The handle's
+;; abort-fn dispatches the aborted reply, so the later abort step
+;; resolves it through the LIVE :rf.http/managed-abort path.
+(rf/reg-fx :managed-http/seed-in-flight
+  {:doc       "Testbed-only fx: seed a request-id-keyed in-flight handle
+               in the framework registry whose abort-fn dispatches a
+               :rf.http/aborted reply + clears the slot — so the LIVE
+               :rf.http/managed-abort fx resolves it end-to-end."
+   :platforms #{:client}}
+  (fn fx-seed-in-flight [_frame-ctx {:keys [request-id]}]
+    (http-registry/record-in-flight!
+      request-id nil
+      {:url      pending-url
+       :abort-fn (fn [reason]
+                   (http-registry/clear-in-flight! request-id)
+                   (rf/dispatch [::reply {:kind    :failure
+                                          :failure {:kind   :rf.http/aborted
+                                                    :reason reason}}]))})
+    nil))
+
+(rf/reg-event-fx ::fire-in-flight
+  {:doc "Seed an in-flight request that stays pending across the settle
+         window (deterministic). Populates the in-flight registry;
+         status → :loading."}
+  (fn [{:keys [db]} _ev]
+    {:db (-> db (assoc :status :loading :reply nil) (log-line "→ fired (in-flight)"))
+     :fx [[:managed-http/seed-in-flight {:request-id in-flight-id}]]}))
+
+;; (2) Success — a real Fetch against the static asset api/ok.json.
+(rf/reg-event-fx ::success
+  {:doc "Live GET against the static api/ok.json. 2xx → decoded JSON →
+         reply :kind :success."}
+  (fn [{:keys [db]} _ev]
+    {:db (-> db (assoc :status :loading :reply nil) (log-line "→ GET api/ok.json"))
+     :fx [(rf.http/get "api/ok.json"
+                       {:decode     :json
+                        :request-id ok-request-id
+                        :on-success [::reply]
+                        :on-failure [::reply]})]}))
+
+;; (3) Error response — 4xx. Canned-failure-with-trace synthesises the
+;; same reply envelope + error trace a live 404 would.
+(rf/reg-event-fx ::error-4xx
+  {:doc "Synthesised :rf.http/http-4xx (404, raw body) via the canned-
+         failure-with-trace wrapper. Same reply envelope as a live 4xx."}
+  (fn [{:keys [db]} _ev]
+    {:db (-> db (assoc :status :loading :reply nil) (log-line "→ request (will 404)"))
+     :fx [[:managed-http/canned-failure-with-trace
+           {:request    {:method :get :url "api/items/missing"}
+            :request-id ok-request-id
+            :on-failure [::reply]
+            :kind       :rf.http/http-4xx
+            :tags       {:status 404 :status-text "Not Found"
+                         :body   "<html>not found</html>" :headers {}}}]]}))
+
+;; (4) Error response — 5xx.
+(rf/reg-event-fx ::error-5xx
+  {:doc "Synthesised :rf.http/http-5xx (500, raw body)."}
+  (fn [{:keys [db]} _ev]
+    {:db (-> db (assoc :status :loading :reply nil) (log-line "→ request (will 500)"))
+     :fx [[:managed-http/canned-failure-with-trace
+           {:request    {:method :get :url "api/items"}
+            :request-id ok-request-id
+            :on-failure [::reply]
+            :kind       :rf.http/http-5xx
+            :tags       {:status 500 :status-text "Internal Server Error"
+                         :body   "<html>server error</html>" :headers {}}}]]}))
+
+;; (5a) Abort — seed a fresh in-flight request that stays pending so the
+;; NEXT step can abort it before any reply lands. Self-contained (does
+;; not depend on step 1's slot): a distinct :request-id whose abort-fn
+;; dispatches the :rf.http/aborted reply.
+(rf/reg-event-fx ::fire-abortable
+  {:doc "Seed a fresh abortable in-flight request (status :loading) so the
+         next step aborts it while still pending."}
+  (fn [{:keys [db]} _ev]
+    {:db (-> db (assoc :status :loading :reply nil) (log-line "→ fired (abortable)"))
+     :fx [[:managed-http/seed-in-flight {:request-id abortable-id}]]}))
+
+;; (5b) Abort the in-flight request via the LIVE :rf.http/managed-abort
+;; fx — it resolves the seeded handle and fires its abort-fn, which
+;; dispatches the :rf.http/aborted reply and clears the registry slot.
+(rf/reg-event-fx ::abort
+  {:doc "Abort the in-flight request by :request-id via the live
+         :rf.http/managed-abort fx. The handle's abort-fn dispatches the
+         :rf.http/aborted reply and clears the registry slot."}
+  (fn [{:keys [db]} _ev]
+    {:db (log-line db "→ abort")
+     :fx [[:rf.http/managed-abort abortable-id]]}))
+
+;; (6) Concurrent requests by the SAME actor. Two real :rf.http/managed
+;; requests issued under the same actor-id populate the actor-in-flight
+;; index with TWO entries (Spec 014 §Abort on actor destroy). They never
+;; resolve within the settle window; the reset cleans up.
+(rf/reg-fx :managed-http/issue-as-actor
+  {:doc       "Testbed-only fx: issue a real :rf.http/managed request under a
+               supplied actor-id so the actor-in-flight registry index is
+               populated, exercising the per-actor in-flight surface
+               (rf2-wvkn) without spawning a real machine actor."
+   :platforms #{:client}}
+  (fn fx-issue-as-actor [_frame-ctx {:keys [actor-id request-id]}]
+    (http-registry/record-in-flight!
+      request-id actor-id
+      {:abort-fn (fn [_reason] nil)
+       :url      pending-url})
+    nil))
+
+(rf/reg-event-fx ::concurrent-by-actor
+  {:doc "Issue TWO requests under the SAME actor-id so the actor-in-flight
+         index carries both (Spec 014 §Abort on actor destroy, rf2-wvkn)."}
+  (fn [{:keys [db]} _ev]
+    {:db (log-line db (str "→ two requests as " (pr-str actor-a)))
+     :fx [[:managed-http/issue-as-actor {:actor-id actor-a :request-id ::actor-a-1}]
+          [:managed-http/issue-as-actor {:actor-id actor-a :request-id ::actor-a-2}]
+          [:managed-http/issue-as-actor {:actor-id actor-b :request-id ::actor-b-1}]]}))
+
+;; (7) A request that OUTLIVES a frame/actor teardown. The actor's
+;; in-flight requests are aborted via abort-on-actor-destroy — the same
+;; path a :rf.machine/destroy cascade / frame teardown drives.
+(rf/reg-fx :managed-http/destroy-actor
+  {:doc       "Testbed-only fx: drive the framework abort-on-actor-destroy
+               for the supplied actor-id — the SAME path a state-machine
+               actor destroy / frame teardown takes (Spec 014 §Abort on
+               actor destroy)."
+   :platforms #{:client}}
+  (fn fx-destroy-actor [_frame-ctx {:keys [actor-id]}]
+    (http-managed/abort-on-actor-destroy actor-id)
+    nil))
+
+(rf/reg-event-fx ::actor-teardown
+  {:doc "Tear down actor-a: its in-flight requests outlive the actor and
+         are aborted via abort-on-actor-destroy (:rf.http/aborted-on-
+         actor-destroy). actor-b's slot is untouched."}
+  (fn [{:keys [db]} _ev]
+    {:db (log-line db (str "→ destroy " (pr-str actor-a) " (outliving requests aborted)"))
+     :fx [[:managed-http/destroy-actor {:actor-id actor-a}]]}))
+
+;; ----------------------------------------------------------------------------
+;; RESET — clean the registry + re-seed app-db. Button 0 of the deck.
+;; ----------------------------------------------------------------------------
+
+(rf/reg-fx :managed-http/clear-registry
+  {:doc       "Testbed-only fx: drop both in-flight registries (request-id
+               and actor-id keyed) so a fresh run starts clean."
+   :platforms #{:client}}
+  (fn fx-clear-registry [_frame-ctx _]
+    (http-managed/clear-all-in-flight!)
+    nil))
+
+(rf/reg-event-fx ::reset
+  {:doc "Re-seed app-db (idle, no reply, empty log) and clear the in-flight
+         registries. Start clean."}
+  (fn [_ctx _ev]
+    {:db {:status :idle :reply nil :log []}
+     :fx [[:managed-http/clear-registry]]}))
+
+;; ============================================================================
+;; SUBSCRIPTIONS — live read-out (the standalone-legible status strip)
+;; ============================================================================
+
+(rf/reg-sub ::status (fn [db _] (:status db)))
+(rf/reg-sub ::reply  (fn [db _] (:reply db)))
+(rf/reg-sub ::log    (fn [db _] (:log db)))
+
+;; ============================================================================
+;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
+;; ============================================================================
+;;
+;; Each step: {:event [...] :watch "<what to look for>" :settle-ms N
+;;             :label "<short row label>"}. The runner renders :watch per
+;; STEP (per-occurrence narration, NOT a handler :doc), dispatches :event,
+;; focuses the latest :rf/default epoch, then waits :settle-ms before
+;; advancing. The fire-abortable step (5) seeds a pending request; the
+;; abort step (6) resolves it through the live :rf.http/managed-abort fx.
+
+(def steps
+  [{:label     "Fire request (in-flight)"
+    :event     [::fire-in-flight]
+    :watch     "App-db diff: :status flips to :loading. In-flight registry strip: a pending request-id slot appears (the request is still in flight). Epoch: the fire cascade with NO reply child yet."
+    :settle-ms 700}
+   {:label     "Success response"
+    :event     [::success]
+    :watch     "Epoch: a two-event cascade — :rf.http/managed dispatch → reply lands at ::reply. App-db diff: :status :done, :reply :kind :success, :value decoded from api/ok.json."
+    :settle-ms 700}
+   {:label     "Error response (4xx)"
+    :event     [::error-4xx]
+    :watch     "Trace: an :operation :rf.http/http-4xx error row (:op-type :error, pink-wash on the event row). App-db: :status :error, reply :failure :kind :rf.http/http-4xx, :status 404."
+    :settle-ms 600}
+   {:label     "Error response (5xx)"
+    :event     [::error-5xx]
+    :watch     "Trace: an :operation :rf.http/http-5xx error row. App-db diff: reply :failure :kind :rf.http/http-5xx, :status 500. The Epoch shows the failure cascade attribution."
+    :settle-ms 600}
+   {:label     "Abort: fire an abortable request"
+    :event     [::fire-abortable]
+    :watch     ":status :loading; the in-flight registry strip gains another pending slot. The request stays in flight — the NEXT step aborts it before any reply lands."
+    :settle-ms 500}
+   {:label     "Abort the in-flight request"
+    :event     [::abort]
+    :watch     "Trace/Epoch: the live :rf.http/managed-abort fx resolves the handle → its abort-fn dispatches the :rf.http/aborted reply + clears the slot. App-db: :status :error, reply :kind :failure (:rf.http/aborted). In-flight strip: the abortable slot is gone."
+    :settle-ms 700}
+   {:label     "Concurrent requests by same actor"
+    :event     [::concurrent-by-actor]
+    :watch     "Actor-in-flight strip: actor-a now carries TWO pending entries, actor-b ONE (Spec 014 §Abort on actor destroy). Epoch: the fan-out cascade of three issue fxs."
+    :settle-ms 700}
+   {:label     "Request outlives a frame teardown"
+    :event     [::actor-teardown]
+    :watch     "Trace: two :rf.http/aborted-on-actor-destroy rows for actor-a's outliving requests. Actor-in-flight strip: actor-a's slot is GONE; actor-b's pending entry remains."
+    :settle-ms 700}])
+
+;; ============================================================================
+;; RUNNER STATE — LOCAL ATOM (rf2-8pbjr: not app-db, not a 2nd frame)
+;; ============================================================================
+
+(defonce runner-state (r/atom (runner/initial-state)))
+
+;; ============================================================================
+;; VIEWS
+;; ============================================================================
+
+(reg-view in-flight-strip
+  "A live read-out of the managed-HTTP in-flight registries (request-id-
+  keyed + actor-id-keyed). Pure snapshot reads of the framework atoms —
+  the Xray panels are the primary surface; this keeps the deck legible
+  standalone. Re-derefs the atoms on every render via the :log sub —
+  every lifecycle event appends a log line, so the strip re-renders and
+  re-reads the registry even when :status is unchanged (the
+  concurrent-by-actor step only touches :log)."
+  []
+  (let [_log      @(subscribe [::log])
+        in-flight (http-managed/in-flight-snapshot)
+        per-actor (http-managed/actor-in-flight-snapshot)]
+    [:div {:data-testid "managed-http-registry-strip"
+           :style {:border "1px solid #d8d2ff" :border-radius "6px"
+                   :padding "0.5em 0.75em" :margin "0.5em 0"
+                   :background "#fcfbff" :font-size "12px"}}
+     [:div {:style {:font-size "11px" :color "#7C5CFF" :font-weight "bold"
+                    :text-transform "uppercase" :letter-spacing "0.04em"}}
+      "Managed-HTTP in-flight registry"]
+     [:div {:data-testid "managed-http-in-flight"}
+      "request-id in-flight: " [:strong (pr-str (vec (keys in-flight)))]]
+     [:div {:data-testid "managed-http-actor-in-flight"}
+      "actor in-flight: "
+      [:strong (pr-str (into {} (map (fn [[a hs]] [a (count hs)]) per-actor)))]]]))
+
+(reg-view status-strip
+  "The lifecycle status read-out: current :status, last reply, and a short
+  log of recent lifecycle events. Pure snapshot reads."
+  []
+  (let [status @(subscribe [::status])
+        reply  @(subscribe [::reply])
+        log    @(subscribe [::log])]
+    [:div {:data-testid "managed-http-status-strip"
+           :style {:border "1px solid #d8d2ff" :border-radius "6px"
+                   :padding "0.5em 0.75em" :margin "0.5em 0"
+                   :background "#fcfbff" :font-size "12px"}}
+     [:div {:style {:font-size "11px" :color "#7C5CFF" :font-weight "bold"
+                    :text-transform "uppercase" :letter-spacing "0.04em"}}
+      "Lifecycle status"]
+     [:div "status: " [:strong {:data-testid "managed-http-lifecycle-status"} (name status)]
+      (when reply
+        [:span " · reply.kind: "
+         [:strong {:data-testid "managed-http-reply-kind"} (pr-str (:kind reply))]
+         (when-let [k (get-in reply [:failure :kind])]
+           [:span " · failure.kind: "
+            [:strong {:data-testid "managed-http-failure-kind"} (pr-str k)]])])]
+     (when (seq log)
+       [:ul {:data-testid "managed-http-log"
+             :style {:margin "0.35em 0 0 0" :padding-left "1.2em" :color "#555"}}
+        (for [[i line] (map-indexed vector log)]
+          ^{:key i} [:li line])])]))
+
+(reg-view root []
+  [:div {:data-testid "managed-http-root"
+         :style {:font-family "system-ui, sans-serif" :padding "1em"
+                 :max-width "880px"}}
+   [:header {:style {:margin-bottom "0.5em"}}
+    [:h2 {:data-testid "managed-http-title" :style {:margin 0}}
+     "Xray Testbed: Managed HTTP"]
+    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
+     "One button (" [:strong "▶ Run series"] ") walks the managed-HTTP "
+     "lifecycle — fire · success · 4xx · 5xx · abort · concurrent-by-actor · "
+     "request-outlives-teardown. After each dispatch the runner pins Xray "
+     "focus to the latest " [:code ":rf/default"] " epoch; read each step's "
+     [:strong "Watch"] " note, then watch the Epoch / Trace / App-db / "
+     "Machine panels render it. The runner cursor lives in a "
+     [:strong "local atom"] " — it never touches the inspected app-db."]]
+   [:button {:data-testid "managed-http-deck-reset"
+             :on-click (fn []
+                         (dispatch [::reset])
+                         (runner/reset-runner! runner-state))
+             :style {:padding "0.4em 0.8em" :cursor "pointer"
+                     :border "1px solid #cfc8ff" :border-radius "6px"
+                     :background "#f4f1ff" :margin "0.25em 0"}}
+    "0. Reset — clear registry + re-seed app-db + rewind runner"]
+   [status-strip]
+   [in-flight-strip]
+   [runner/runner "managed-http" runner-state steps host-frame]])
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn- resolve-project-root []
+  (testbed-config/resolve-project-root "tools/xray/testbeds"))
+
+(defn ^:export run []
+  (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [::initialise])
+  (rdc/render react-root [root]))

--- a/tools/xray/testbeds/managed_http/index.html
+++ b/tools/xray/testbeds/managed_http/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: managed-http (Xray Managed-HTTP demo)</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .rf2-testbed-shell { display: flex; min-height: 100vh; }
+    /* `--rf-xray-inline-width` is Xray's documented host-resize knob
+       (rf2-um813; see day8.re-frame2-xray.config/default-layout-host-css-var
+       and spec/011-Launch-Modes.md §Resizing the inline host). Override
+       the property anywhere up the cascade to resize the panel without
+       JS or a fork of this rule. The user-draggable resize handle is
+       auto-injected by Xray (rf2-70u8q; spec/007-UX-IA.md §Resize
+       affordance) — no `resize: horizontal` / `overflow: auto` needed. */
+    :root { --rf-xray-accent: #7C5CFF; }
+    [data-rf-xray-host] { flex: 0 0 var(--rf-xray-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
+    #app { flex: 1; min-width: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div class="rf2-testbed-shell">
+    <main id="app"></main>
+    <aside data-rf-xray-host></aside>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/tools/xray/testbeds/runner/core.cljs
+++ b/tools/xray/testbeds/runner/core.cljs
@@ -1,0 +1,333 @@
+(ns runner.core
+  "SHARED queued-step RUNNER for Xray testbeds (rf2-8pbjr — the pilot
+  redesign). A reusable harness an Xray testbed mounts to drive a
+  series of INTERESTING events through ONE button while an operator
+  watches how the Xray panels (Epoch · Machine Inspector · edn-inspector
+  · Trace · …) render each step, with per-step commentary on WHAT TO
+  LOOK FOR.
+
+  ## The shape (the settled contract — rf2-8pbjr DESCRIPTION is authoritative)
+
+  - **Step vector = CODE DATA.** A testbed `def`s a vector of step maps;
+    each step is
+
+        {:event    [:some/event ...]   ; the event to dispatch
+         :watch     \"what to look for in Epoch / Inspector / …\"
+         :settle-ms 600                ; POST-dispatch pause (ms) so machine
+                                       ;   :after timers + cascades fire
+                                       ;   BEFORE advancing
+         :before-ms 0                  ; OPTIONAL pre-dispatch pause (ms);
+                                       ;   default 0 — only when a step
+                                       ;   explicitly needs to settle the
+                                       ;   PREVIOUS render first
+         :label     \"Fire request\"}  ; OPTIONAL short row label (defaults
+                                       ;   to the event-id)
+
+    `:watch` is PER-OCCURRENCE narration — it lives on the STEP, not on
+    any handler `:doc` (the same event type can appear several times
+    with different watch notes).
+
+  - **Post-dispatch settle.** For each step the runner: renders `:watch`
+    → (optional `:before-ms` pause) → DISPATCHES `:event` → FOCUSES the
+    latest host-frame epoch → WAITS `:settle-ms` → advances. The wait is
+    AFTER the dispatch so a machine `:after` timer / a deferred HTTP
+    reply / a fan-out cascade has fired and rendered before the operator
+    is moved on.
+
+  - **Runner state = LOCAL ATOM ONLY.** The cursor / status / pace live
+    in a LOCAL Reagent atom OWNED by the runner (the testbed passes it
+    in). It is NEVER written to the inspected app-db (that would pollute
+    the very panels under inspection) and NEVER lives in a second frame
+    (a 2nd frame would appear in Xray's frame surfaces + complicate the
+    observed-frame story). ONLY the inspected app frame is Xray-relevant.
+
+  - **Xray focus (pinned).** After EACH auto-advance dispatch the runner
+    focuses the LATEST host-frame epoch via
+    `day8.re-frame2-xray.focus/focus!`, so the operator always sees the
+    just-dispatched render rather than a stale selection. Manual single-
+    step mode dispatches WITHOUT moving focus — the operator drives the
+    spine themselves.
+
+  - **Per-step addressing.** Every rendered step row carries a stable,
+    unique `data-testid` (`<prefix>-step-<n>`, plus the run / pause /
+    reset / step controls) so a feature-matrix scenario can name each
+    rung. The prefix is the testbed's, passed via `opts`.
+
+  ## Why a shared ns (the rollout vehicle)
+
+  This namespace is the reference RUNNER the managed-http testbed
+  (rf2-6nolv) is the FIRST consumer of. Rolling it across the existing
+  numbered-button decks (machine_epochs, edn_inspector, …) is a
+  SEPARATE follow-up (out of pilot scope); keeping the runner here, in a
+  testbed-shared location, means that rollout is a pure adoption — each
+  deck supplies its own step vector + prefix and drops its bespoke
+  ladder driver.
+
+  ## Boundaries (bundle isolation)
+
+  Lives under `tools/xray/testbeds/`; `:require`s only `re-frame.core`
+  (the public API), Reagent, and `day8.re-frame2-xray.focus` (the host-
+  facing focus command — already the Story→Xray focus channel). Nothing
+  under `implementation/` requires this; it is a dev testbed surface."
+  (:require [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [day8.re-frame2-xray.focus :as xray-focus]
+            [day8.re-frame2-xray.defaults :as xray-defaults])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; STEP NORMALISATION
+;; ============================================================================
+
+(defn- step-label
+  "A short human label for a step row. Uses the step's explicit `:label`
+  when present, else the event-id (first of the event vector)."
+  [{:keys [label event]}]
+  (or label (pr-str (first event))))
+
+;; ============================================================================
+;; FOCUS — the pinned 'show the just-dispatched render' contract
+;; ============================================================================
+
+(defn focus-latest-host-epoch!
+  "Focus the LATEST epoch on `host-frame` in the embedded Xray surface,
+  so the operator sees the render the just-dispatched event produced.
+
+  Reads the frame's epoch ring via the public `re-frame.core/epoch-
+  history` (oldest-first; the HEAD is the most recent — `(peek …)`),
+  pulls its `:epoch-id`, and sends a `day8.re-frame2-xray.focus/focus!`
+  command `{:frame host-frame :epoch-id <latest>}`. Degrades to a no-op
+  when there is no recorded epoch yet (empty ring) or the epoch artefact
+  is absent (`epoch-history` returns an empty vector).
+
+  This is the ONE place the runner reaches into Xray — through the same
+  host-facing focus channel Story uses, not a bespoke spine poke."
+  [host-frame]
+  (let [history   (rf/epoch-history host-frame)
+        latest-id (:epoch-id (peek (vec history)))]
+    (when (some? latest-id)
+      (xray-focus/focus! host-frame {:frame    host-frame
+                                     :epoch-id latest-id
+                                     :panel    :epoch}))))
+
+;; ============================================================================
+;; THE SETTLE ENGINE — post-dispatch settle, local-atom cursor
+;; ============================================================================
+;;
+;; `state` is the LOCAL runner atom (a Reagent atom owned by the testbed).
+;; Its shape:
+;;   {:cursor   <int>      ; index of the NEXT step to run (0..count)
+;;    :running? <bool>     ; an auto-advance series is in flight
+;;    :phase    <kw>       ; :idle | :before | :dispatched | :settling | :done
+;;    :timer    <handle>}  ; the in-flight settle/before timer (for pause)
+;;
+;; The cursor/phase drive the row highlight; nothing here touches app-db.
+
+(defn- clear-timer!
+  [state]
+  (when-let [t (:timer @state)]
+    (interop/clear-timeout! t))
+  (swap! state dissoc :timer))
+
+(declare run-step!)
+
+(defn- advance!
+  "After a step settles: bump the cursor, and continue the series if
+  still running and steps remain."
+  [state steps host-frame]
+  (let [next-cursor (inc (:cursor @state))
+        more?       (< next-cursor (count steps))]
+    (swap! state assoc :cursor next-cursor :phase (if more? :idle :done))
+    (when (and (:running? @state) more?)
+      (run-step! state steps host-frame {:auto? true}))
+    (when-not more?
+      (swap! state assoc :running? false))))
+
+(defn- dispatch+settle!
+  "Dispatch the step's event, (optionally) focus the latest host-frame
+  epoch, then schedule the post-dispatch `:settle-ms` wait before
+  advancing. `auto?` controls focus: auto-advance pins focus to latest;
+  a manual single-step leaves focus to the operator."
+  [state steps host-frame {:keys [auto?]}]
+  (let [{:keys [event settle-ms] :as step} (nth steps (:cursor @state))]
+    (swap! state assoc :phase :dispatched)
+    (rf/dispatch event)
+    (when auto?
+      (focus-latest-host-epoch! host-frame))
+    (swap! state assoc :phase :settling)
+    ;; POST-dispatch settle. Framework-native `interop/set-timeout!` —
+    ;; the wait lets a machine :after timer / a deferred HTTP reply / a
+    ;; cascade fire + render before the operator advances. A manual step
+    ;; with settle-ms 0 advances on the next tick.
+    (let [ms (max 0 (or settle-ms 0))
+          t  (interop/set-timeout!
+               (fn []
+                 (swap! state dissoc :timer)
+                 (advance! state steps host-frame))
+               ms)]
+      (swap! state assoc :timer t))))
+
+(defn run-step!
+  "Run the step at the current cursor. Honours the OPTIONAL pre-dispatch
+  `:before-ms` pause (default 0 — most steps dispatch immediately), then
+  dispatches + settles. `opts` carries `:auto?` (auto-advance pins
+  focus). Idempotent against an out-of-range cursor (no-op)."
+  [state steps host-frame opts]
+  (let [cursor (:cursor @state)]
+    (when (< cursor (count steps))
+      (clear-timer! state)
+      (let [{:keys [before-ms]} (nth steps cursor)
+            ms                   (max 0 (or before-ms 0))]
+        (if (pos? ms)
+          (do (swap! state assoc :phase :before)
+              (let [t (interop/set-timeout!
+                        (fn []
+                          (swap! state dissoc :timer)
+                          (dispatch+settle! state steps host-frame opts))
+                        ms)]
+                (swap! state assoc :timer t)))
+          (dispatch+settle! state steps host-frame opts))))))
+
+;; ---- the three public controls -------------------------------------------
+
+(defn run-series!
+  "Start (or resume) the auto-advancing series from the current cursor.
+  If the cursor is at the end, restart from the top. Auto-advance pins
+  Xray focus to the latest host-frame epoch after each dispatch."
+  [state steps host-frame]
+  (when (>= (:cursor @state) (count steps))
+    (swap! state assoc :cursor 0))
+  (swap! state assoc :running? true :phase :idle)
+  (run-step! state steps host-frame {:auto? true}))
+
+(defn pause!
+  "Pause an in-flight series: stop auto-advancing and cancel the pending
+  settle/before timer. The cursor stays put so `run-series!` resumes."
+  [state]
+  (clear-timer! state)
+  (swap! state assoc :running? false :phase :idle))
+
+(defn step-once!
+  "Manual single step: dispatch the current step WITHOUT pinning focus
+  (the operator drives the spine), then advance the cursor. Does not
+  start the auto series."
+  [state steps host-frame]
+  (when (>= (:cursor @state) (count steps))
+    (swap! state assoc :cursor 0))
+  (swap! state assoc :running? false)
+  (run-step! state steps host-frame {:auto? false}))
+
+(defn reset-runner!
+  "Reset the runner to the top, idle, no pending timer."
+  [state]
+  (clear-timer! state)
+  (reset! state {:cursor 0 :running? false :phase :idle}))
+
+(defn initial-state
+  "The runner's initial local-atom value. A testbed `(r/atom (initial-state))`."
+  []
+  {:cursor 0 :running? false :phase :idle})
+
+;; ============================================================================
+;; VIEWS
+;; ============================================================================
+
+(defn- phase-chip-text
+  [{:keys [phase running?]}]
+  (cond
+    (= phase :done)       "done"
+    (= phase :before)     "pausing (pre-dispatch)…"
+    (= phase :dispatched) "dispatched"
+    (= phase :settling)   "settling…"
+    running?              "running…"
+    :else                 "idle"))
+
+(reg-view runner-controls
+  "The ONE-button runner control bar: Run series · Pause · Step · Reset,
+  plus a live phase chip + cursor position. Every control carries a
+  stable `data-testid` (`<prefix>-run` / `-pause` / `-step` / `-reset`)
+  so a feature-matrix scenario can drive the series."
+  [prefix state steps host-frame]
+  (let [snap    @state
+        total   (count steps)
+        cursor  (:cursor snap)]
+    [:div {:data-testid (str prefix "-runner-controls")
+           :style {:display "flex" :gap "0.5em" :align-items "center"
+                   :flex-wrap "wrap" :padding "0.6em 0.75em" :margin "0.5em 0"
+                   :border "1px solid #cfc8ff" :border-radius "8px"
+                   :background "#faf8ff"}}
+     [:button {:data-testid (str prefix "-run")
+               :on-click #(run-series! state steps host-frame)
+               :disabled (:running? snap)
+               :style {:padding "0.45em 0.9em" :cursor "pointer"
+                       :border "1px solid #7C5CFF" :border-radius "6px"
+                       :background "#7C5CFF" :color "#fff" :font-weight "bold"}}
+      "▶ Run series"]
+     [:button {:data-testid (str prefix "-pause")
+               :on-click #(pause! state)
+               :disabled (not (:running? snap))
+               :style {:padding "0.45em 0.8em" :cursor "pointer"
+                       :border "1px solid #cfc8ff" :border-radius "6px"
+                       :background "#fff"}}
+      "⏸ Pause"]
+     [:button {:data-testid (str prefix "-step")
+               :on-click #(step-once! state steps host-frame)
+               :disabled (:running? snap)
+               :style {:padding "0.45em 0.8em" :cursor "pointer"
+                       :border "1px solid #cfc8ff" :border-radius "6px"
+                       :background "#fff"}}
+      "⏭ Step once"]
+     [:button {:data-testid (str prefix "-reset")
+               :on-click #(reset-runner! state)
+               :style {:padding "0.45em 0.8em" :cursor "pointer"
+                       :border "1px solid #cfc8ff" :border-radius "6px"
+                       :background "#fff"}}
+      "↺ Reset"]
+     [:span {:data-testid (str prefix "-status")
+             :style {:color "#666" :font-size "12px" :margin-left "0.25em"}}
+      (str "step " (min (inc cursor) total) " / " total " · " (phase-chip-text snap))]]))
+
+(reg-view step-row
+  "One step row: its index, label, and `:watch` commentary. The CURRENT
+  step (the one just-run or about-to-run) is highlighted. Carries a
+  stable per-step `data-testid` (`<prefix>-step-<n>`)."
+  [prefix n step current? done?]
+  [:div {:data-testid (str prefix "-step-" n)
+         :style {:display "grid" :grid-template-columns "auto 1fr"
+                 :gap "0.75em" :align-items "baseline" :margin "0.25em 0"
+                 :padding "0.4em 0.6em" :border-radius "6px"
+                 :border (if current? "1px solid #7C5CFF" "1px solid #eee")
+                 :background (cond current? "#f1ecff" done? "#fafafa" :else "#fff")}}
+   [:span {:style {:font-weight "bold"
+                   :color (cond current? "#7C5CFF" done? "#aaa" :else "#555")}}
+    (str (inc n) ".")]
+   [:div
+    [:div {:style {:font-weight "600" :color "#333"}}
+     (step-label step)
+     [:span {:style {:color "#999" :font-weight "normal" :margin-left "0.5em"
+                     :font-size "11px"}}
+      (str "settle " (or (:settle-ms step) 0) "ms"
+           (when (pos? (or (:before-ms step) 0))
+             (str " · before " (:before-ms step) "ms")))]]
+    [:div {:data-testid (str prefix "-step-" n "-watch")
+           :style {:color "#666" :font-size "12px" :margin-top "0.15em"}}
+     "Watch: " (:watch step)]]])
+
+(reg-view runner
+  "The full runner surface: the control bar + the step list. A testbed
+  mounts `[runner/runner prefix state steps host-frame]`. `state` is the
+  testbed's LOCAL Reagent atom (`(r/atom (runner/initial-state))`),
+  `steps` the step-vector `def`, `host-frame` the inspected app frame
+  (e.g. `:rf/default`), `prefix` the testid prefix."
+  [prefix state steps host-frame]
+  (let [snap   @state
+        cursor (:cursor snap)]
+    [:div {:data-testid (str prefix "-runner")}
+     [runner-controls prefix state steps host-frame]
+     [:div {:data-testid (str prefix "-steps")}
+      (map-indexed
+        (fn [n step]
+          ^{:key n}
+          [step-row prefix n step (= n cursor) (< n cursor)])
+        steps)]]))


### PR DESCRIPTION
## What

The PILOT of the rf2-8pbjr testbed redesign: a shared **queued-step runner** + the **managed-http testbed** as its reference consumer. Cross-testbed rollout is a separate follow-up (out of pilot scope).

### Shared runner — `tools/xray/testbeds/runner/core.cljs`
- **Step vector = CODE DATA.** A testbed `def`s a vector of `{:event [...] :watch "what to look for" :settle-ms N}` maps (optional `:before-ms`, `:label`). `:watch` is per-occurrence narration on the STEP, not a handler `:doc`.
- **Post-dispatch settle.** One button runs the series; per step: render `:watch` → dispatch `:event` → focus latest host-frame epoch → wait `:settle-ms` → advance. The wait is AFTER dispatch so machine `:after` timers / deferred replies / cascades fire and render before advancing.
- **Runner state = LOCAL ATOM.** Cursor/phase live in a local Reagent atom owned by the testbed — never the inspected app-db (would pollute the App-db panel), never a 2nd frame (would appear in Xray's frame surfaces). Only the inspected app frame is Xray-relevant.
- **Xray focus (pinned).** After each auto-advance dispatch the runner focuses the latest host-frame epoch via `day8.re-frame2-xray.focus/focus!` (the existing host-facing focus channel). Manual single-step leaves focus to the operator.
- **Per-step addressing.** Stable `<prefix>-step-<n>` + control testids (`-run`/`-pause`/`-step`/`-reset`/`-status`) for feature-matrix scenarios.

### Managed-HTTP testbed — `tools/xray/testbeds/managed_http/` (rf2-6nolv)
First consumer of the runner. Walks the `:rf.http/managed` lifecycle so the Xray Epoch/Trace/App-db panels render managed-HTTP effects + traces:
1. Fire request (in-flight) · 2. Success (live Fetch `api/ok.json`) · 3. 4xx · 4. 5xx · 5. Abort: fire abortable · 6. Abort the in-flight request (live `:rf.http/managed-abort`) · 7. Concurrent by same actor (actor-in-flight index) · 8. Request outlives a frame teardown (`abort-on-actor-destroy`).

Live Fetch for success; `canned-failure-with-trace` (the `testbeds/http_toggle` pattern) for 4xx/5xx; genuine framework in-flight + actor-in-flight registry seeds for the in-flight/abort/actor steps so the registry renders DETERMINISTICALLY (a real Fetch against a dev-http static server resolves instantly, leaving nothing observably in-flight). Title `Xray Testbed: Managed HTTP`.

### Hot-zone
- `implementation/shadow-cljs.edn`: new `:examples/managed-http` build-id + `:dev-http` port **8035** (next free above the `_epochs` trio + edn-inspector 8034). Sole worker on this file.

## Gates
- `npx shadow-cljs compile :examples/managed-http` — **0 warnings** (cold build).
- Headless runtime smoke — green: runner walks all 8 steps to `done`, no runtime errors, actor-a torn down while actor-b's in-flight slot remains (proves the concurrent-by-actor + outlives-teardown contract).
- `npm run test:xray-feature-gate` — the only red is the **known local-only `routes-epochs routing ladder` flake** (green on CI); the existing `managed http and effects rows` + `machine-epochs machine ladder` scenarios PASS (no regression).

## Xray spec currency
Unchanged — the runner is **testbed-local** (under `tools/xray/testbeds/`, not the Xray product surface); `017-Test-Coverage-Matrix` enumerates the smoke gate + `feature_matrix`, not per-deck testbeds. The runner framework is documented in its own ns docstring.

## Beads
- Closes **rf2-6nolv** (managed-http testbed delivered).
- **rf2-8pbjr**: pilot (shared runner + managed-http) delivered; cross-testbed rollout is a separate follow-up for the mayor to file. Left open for the mayor.