### PR TITLE
feat(machines): history-state engine — record/restore (rf2-mle6e.3)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -103,6 +103,7 @@
     :fsm/tags
     :fsm/parallel-regions
     :fsm/final-states
+    :fsm/history                                      ;; rf2-mle6e — first-class history pseudo-states (:type :history)
     :fsm/registration-validation                      ;; rf2-vf5cf — registration-error taxonomy via :reg-machine
     :routing/match-url
     :ssr/render-to-string

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -85,6 +85,7 @@
     :fsm/tags                                         ;; rf2-ee0d (Nine States Stage 1)
     :fsm/parallel-regions                             ;; rf2-l67o (Nine States Stage 2)
     :fsm/final-states                                 ;; rf2-gn80 — :final? + :on-done + :output-key
+    :fsm/history                                      ;; rf2-mle6e — first-class history pseudo-states (:type :history — shallow / deep / default-target)
     :fsm/registration-validation                      ;; rf2-vf5cf — registration-error taxonomy (Spec 009 thrown-error shape) via :reg-machine
     :routing/match-url
     :ssr/render-to-string

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -8,6 +8,9 @@
   macro, the registrar, Xray) inspect the `ex-data`. The validators
   in this namespace are:
 
+    - `validate-history!` — `:type :history` pseudo-state shape
+      (rf2-mle6e.3): placement, closed key-set, one-per-compound,
+      `:default-target` resolution.
     - `validate-parallel!` — `:type :parallel` shape (rf2-l67o).
     - `validate-spawn-all!` — `:spawn-all` shape (rf2-6vmw).
     - `validate-no-spawn-timeout-ms!` — rejects the dropped
@@ -248,56 +251,219 @@
       :else
       (walk [] (:states machine)))))
 
-;; Per Spec 005 §Substitutes for skipped features (005:3141) and §Error
-;; category for unclaimed grammar (005:3119-3133): history states remain
-;; post-v1. The v1 CLJS reference claims every OTHER capability, so the
-;; one grammar key it must reject is `:history` — `(rf/reg-machine ...)`
-;; with a `:type :history` node (root or region) or a `:history`
-;; state-node key. Per Spec 009 §Error event catalogue (009:1347,
-;; Ownership.md:48) the canonical recovery is `:no-recovery` —
-;; **registration is rejected** (not the partial-port `:replaced-with-
-;; default` trace-and-ignore path, which only applies to ports that
-;; decline a capability the reference claims). Tags: `:feature`
-;; (the offending key) + `:substitute` (the documented forward pattern).
-(def ^:private history-substitute
-  "snapshot-as-value capture — see Spec 005 §History states → snapshot-as-value capture (CP-5-MachineGuide).")
+;; Per Spec 005 §History states (`:type :history` — shallow / deep /
+;; default-target) §Pseudo-state constraints (rf2-mle6e.1, PR #2863): the
+;; v1 CLJS reference claims `:fsm/history`, so a `:type :history` node is
+;; FIRST-CLASS grammar — no longer rejected. `make-machine-handler`
+;; validates the pseudo-state's shape at registration (the same layer that
+;; rejects malformed compound states):
+;;
+;;   - a `:type :history` node MUST be declared inside a compound state's
+;;     `:states` (it has an owning compound whose configuration it
+;;     records) — a history node at the machine root, or directly under a
+;;     `:type :parallel` root's `:regions` map (no enclosing compound
+;;     region), is a registration error;
+;;   - it declares ONLY `:type` / `:deep?` / `:default-target` — any other
+;;     key (`:states`, `:initial`, `:on`, `:always`, `:after`, `:spawn`,
+;;     `:spawn-all`, `:entry`, `:exit`, `:tags`, `:final?`, …) is a
+;;     registration error;
+;;   - a compound may declare AT MOST ONE history pseudo-state;
+;;   - `:default-target`, when present, MUST resolve to a real state — a
+;;     direct child of the owning compound (keyword form) or an absolute
+;;     path the definition declares (vector form).
+;;
+;; The legacy `:history` state-node KEY form (`{:a {:history {...}}}`) and
+;; a root / region `:type :history` are NOT part of the grammar — they are
+;; misplaced-history registration errors (`:rf.error/machine-history-
+;; misplaced`), the named error every other malformed-placement case uses.
+;; Per Spec 009 §Error contract the recovery is `:no-recovery` (registration
+;; is rejected). The precise error-id catalogue for history-grammar
+;; violations is owned by Spec 009 (mle6e.2); these ids conform to that
+;; family's `:rf.error/machine-history-*` naming.
 
-(defn- history-grammar-error
-  [extras]
-  (validation-error
-    :rf.error/machine-grammar-not-in-v1
-    (str "history states are post-v1 and not in this implementation's "
-         "claimed capability list — use the snapshot-as-value capture "
-         "substitute. See Spec 005 §Substitutes for skipped features.")
-    (merge {:feature :history :substitute history-substitute} extras)))
+(def ^:private history-pseudo-keys
+  "The closed key-set a `:type :history` pseudo-state may carry. Anything
+  else is `:rf.error/machine-history-extra-keys`."
+  #{:type :deep? :default-target})
 
-(defn- validate-no-history!
-  "Reject any `:history` grammar — a `:type :history` node or a `:history`
-  state-node key — at registration. Per Spec 005:3141 the runtime emits
-  `:rf.error/machine-grammar-not-in-v1` against `:history`; per Spec
-  009:1347 registration is rejected (`:no-recovery`). Covers the root,
-  every state node (flat / compound), and every region body of a
-  parallel-region machine."
+(defn- history-node?
+  "True iff `node` is a history pseudo-state (`:type :history`)."
+  [node]
+  (= :history (:type node)))
+
+(defn- node-at-states
+  "Walk a `:states` map down absolute `path`, returning the leaf
+  state-node (or nil if `path` doesn't resolve). Scope-local resolver —
+  `states` is the flat machine's `:states` or a single region body's
+  `:states`, so `path` is scope-relative (region names are never part of
+  a within-region path)."
+  [states path]
+  (loop [m states, p (vec path)]
+    (cond
+      (empty? p) nil
+      :else      (let [n (get m (first p))]
+                   (cond
+                     (nil? n)        nil
+                     (= 1 (count p)) n
+                     :else           (recur (:states n) (rest p)))))))
+
+(defn- resolves-to-state?
+  "True iff `target` resolves to a real state under `owning-path` within
+  `states`. A keyword names a DIRECT CHILD of the owning compound; a
+  vector is an absolute path from the (region) root."
+  [states owning-path target]
+  (cond
+    (keyword? target) (some? (node-at-states states (conj (vec owning-path) target)))
+    (vector? target)  (and (seq target)
+                           (some? (node-at-states states target)))
+    :else             false))
+
+(defn- history-nodes-with-path
+  "Yield `[absolute-path node]` pairs for every `:type :history`
+  pseudo-state inside `states`, recursing through `:states`. Paths are
+  scope-relative (region names excluded). Only HISTORY nodes are yielded
+  (ordinary states are walked through but not emitted). Used by the history
+  validator."
+  [states]
+  (letfn [(walk [path nodes]
+            (mapcat
+              (fn [[k n]]
+                (let [p (conj path k)]
+                  (concat (when (history-node? n) [[p n]])
+                          (when (:states n)
+                            (walk p (:states n))))))
+              nodes))]
+    (walk [] states)))
+
+(defn- compound-states-pairs
+  "Yield `[compound-key states-map]` for every compound inside `states`
+  (the scope root included as `root-key`). Used to enforce
+  at-most-one-history-per-compound."
+  [root-key states]
+  (letfn [(walk [pairs nodes]
+            (reduce (fn [acc [k n]]
+                      (cond-> acc
+                        (and (map? (:states n)) (seq (:states n)))
+                        (-> (conj [k (:states n)])
+                            (walk (:states n)))))
+                    pairs
+                    nodes))]
+    (walk [[root-key states]] states)))
+
+(defn- validate-history-pseudo-state!
+  "Validate one `:type :history` pseudo-state at `path` (its scope-relative
+  declaration path including its own key) within `states`. The owning
+  compound is at `owning-path` (= `path` minus the last segment). Per Spec
+  005 §History states §Pseudo-state constraints."
+  [states path node]
+  (let [hist-key    (peek path)
+        owning-path (vec (drop-last path))]
+    ;; A history node must have an OWNING COMPOUND — `owning-path` empty
+    ;; means it sits at the machine root (or directly on a region body's
+    ;; `:states` with no enclosing compound, which the path walker yields
+    ;; with a length-1 path).
+    (when (empty? owning-path)
+      (throw (validation-error
+               :rf.error/machine-history-misplaced
+               (str "history pseudo-state " hist-key
+                    " must be declared inside a compound state's :states — "
+                    "it records that compound's last-active configuration. "
+                    "A :type :history node at the machine root (or directly "
+                    "under a parallel :regions body) has no owning compound.")
+               {:state hist-key :feature :history})))
+    ;; It declares only :type / :deep? / :default-target.
+    (let [extra (remove history-pseudo-keys (keys node))]
+      (when (seq extra)
+        (throw (validation-error
+                 :rf.error/machine-history-extra-keys
+                 (str "history pseudo-state " hist-key
+                      " may declare only :type / :deep? / :default-target — "
+                      "it is never occupied, so transition / lifecycle / "
+                      "projection keys are meaningless on it. Offending: "
+                      (pr-str (vec extra)) ".")
+                 {:state hist-key :offending-keys (vec extra) :feature :history}))))
+    ;; :default-target, when present, must resolve to a real state.
+    (when (contains? node :default-target)
+      (let [dt (:default-target node)]
+        (when-not (resolves-to-state? states owning-path dt)
+          (throw (validation-error
+                   :rf.error/machine-history-bad-default-target
+                   (str "history pseudo-state " hist-key
+                        "'s :default-target " (pr-str dt)
+                        " does not resolve to a real state — it must be a "
+                        "direct child (keyword) of the owning compound or an "
+                        "absolute path (vector) the definition declares.")
+                   {:state hist-key :default-target dt :feature :history})))))))
+
+(defn- at-most-one-history-per-compound!
+  "Per Spec 005 §History states §Pseudo-state constraints: a compound may
+  declare AT MOST ONE history pseudo-state. Two `:type :history` children
+  under one compound is `:rf.error/machine-history-duplicate` (deep-vs-
+  shallow is a property of the single node's `:deep?`, not a reason for
+  two nodes). `compound-pairs` yields `[compound-key states-map]` for
+  every compound (scope root + nested)."
+  [compound-pairs]
+  (doseq [[ckey states] compound-pairs]
+    (let [hist-keys (->> states
+                         (keep (fn [[k n]] (when (history-node? n) k)))
+                         vec)]
+      (when (> (count hist-keys) 1)
+        (throw (validation-error
+                 :rf.error/machine-history-duplicate
+                 (str "compound state " ckey
+                      " declares more than one history pseudo-state ("
+                      (pr-str hist-keys) ") — at most one is permitted; "
+                      "deep-vs-shallow is the single node's :deep?.")
+                 {:state ckey :history-keys hist-keys :feature :history}))))))
+
+(defn- validate-history-scope!
+  "Validate every history pseudo-state within one scope — a flat / compound
+  machine's `:states` (root-key `:rf/root`) or a single parallel-region
+  body's `:states` (root-key the region name). Paths and `:default-target`
+  resolution are scope-relative, so region names never enter a within-region
+  path (matching how `:always` / `:spawn` scoping resolves per-region). A
+  history node DIRECTLY under the scope root (length-1 path → empty
+  owning-path) is misplaced — it has no owning compound."
+  [root-key states]
+  (doseq [[path node] (history-nodes-with-path states)]
+    (validate-history-pseudo-state! states path node))
+  (at-most-one-history-per-compound! (compound-states-pairs root-key states)))
+
+(defn- validate-history!
+  "Validate the first-class history grammar at registration. Per Spec 005
+  §History states §Pseudo-state constraints + Spec-Schemas
+  §`:rf/transition-table`. Validates every `:type :history` pseudo-state
+  (flat / compound / parallel-region) — placement (must have an owning
+  compound), the closed key-set, at-most-one-per-compound, and
+  `:default-target` resolution.
+
+  Replaces the withdrawn `:rf.error/machine-grammar-not-in-v1` deferral
+  (rf2-mle6e.1, PR #2863): history is now claimed (`:fsm/history`). A
+  `:type :history` node at the machine root, or directly on a region body
+  with no enclosing compound, is `:rf.error/machine-history-misplaced`."
   [machine]
-  ;; Root-level `:type :history` (a `:history` machine) or a `:history`
-  ;; key declared at the machine root (alongside `:states`).
-  (when (or (= :history (:type machine))
-            (contains? machine :history))
-    (throw (history-grammar-error {:where-key :root})))
-  ;; Region bodies of a parallel machine: a region declaring `:type
-  ;; :history` (distinct from the `:type :parallel` nested check, which
-  ;; only rejects nested parallel) or a `:history` key.
-  (when (parallel/parallel? machine)
+  ;; A root-level `:type :history` (a `:history` machine) has no `:states`
+  ;; to walk and no owning compound — flag it directly.
+  (when (history-node? machine)
+    (throw (validation-error
+             :rf.error/machine-history-misplaced
+             (str "a machine root cannot be a :type :history pseudo-state — "
+                  "history is a child node under a compound's :states.")
+             {:state :rf/root :feature :history})))
+  (if (parallel/parallel? machine)
+    ;; A region body declared as `:type :history`, or with history nodes
+    ;; under its `:states`, is validated per-region (region names are the
+    ;; scope root — a history node directly under the region's `:states`
+    ;; has owning-path empty → misplaced).
     (doseq [[region-name region-body] (:regions machine)]
-      (when (or (= :history (:type region-body))
-                (contains? region-body :history))
-        (throw (history-grammar-error {:region region-name})))))
-  ;; Every state node (flat / compound, including inside regions): a
-  ;; `:type :history` node or a `:history` state-node key.
-  (doseq [[s n] (walk-state-nodes machine)]
-    (when (or (= :history (:type n))
-              (contains? n :history))
-      (throw (history-grammar-error {:state s})))))
+      (when (history-node? region-body)
+        (throw (validation-error
+                 :rf.error/machine-history-misplaced
+                 (str "parallel region " region-name
+                      " cannot be a :type :history pseudo-state.")
+                 {:region region-name :feature :history})))
+      (validate-history-scope! region-name (:states region-body)))
+    (validate-history-scope! :rf/root (:states machine))))
 
 (defn- validate-final-state!
   "Per Spec 005 §Final states (rf2-gn80) §`:final?` constraints:
@@ -454,6 +620,13 @@
   Composed at the top of `make-machine-handler` so the registered handler
   fn's body is exclusively about request processing.
 
+  Per Spec 005 §History states §Pseudo-state constraints (rf2-mle6e.3):
+  every `:type :history` pseudo-state — placement (must have an owning
+  compound), the closed `:type` / `:deep?` / `:default-target` key-set,
+  at-most-one-per-compound, and `:default-target` resolution. Throws
+  `:rf.error/machine-history-misplaced` / `-extra-keys` / `-duplicate` /
+  `-bad-default-target`.
+
   Per Spec 005 §Parallel regions (rf2-l67o / Stage 2): `:type :parallel`
   shape — `:regions` non-empty, mutually exclusive with `:initial` /
   `:states`, no nested parallel.
@@ -478,7 +651,7 @@
   that targets its own declaring state is rejected. Throws
   `:rf.error/machine-always-self-loop`."
   [machine]
-  (validate-no-history! machine)
+  (validate-history! machine)
   (validate-parallel! machine)
   (doseq [[s n] (walk-state-nodes machine)]
     (validate-spawn-all! s n)

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -273,6 +273,15 @@
     (loop [pending      ordered
            cur-data     (:data snapshot)
            cur-counter  (:rf/spawn-counter snapshot)
+           ;; Per Spec 005 §Composition with parallel regions — per-region
+           ;; history (rf2-mle6e.3): thread the shared `:rf/history` map
+           ;; through regions like `:data`. The slot's keys are REGION-
+           ;; QUALIFIED (head = region name), so per-region recordings never
+           ;; collide — a later region only writes its own qualified keys
+           ;; and never overwrites a sibling's. Seeded from the outer
+           ;; snapshot (so a prior epoch's recordings survive) and merged
+           ;; back below.
+           cur-history  (:rf/history snapshot)
            new-states   state-map
            acc-fx       []
            any-handled? false
@@ -283,7 +292,9 @@
                                  (assoc :state new-states)
                                  (assoc :data  cur-data))
                        (some? cur-counter)
-                       (assoc :rf/spawn-counter cur-counter))]
+                       (assoc :rf/spawn-counter cur-counter)
+                       (some? cur-history)
+                       (assoc :rf/history cur-history))]
           ;; Per Spec 005 §Parallel regions (005:1168-1171): carry the
           ;; aggregate handled flag (true iff at least one region resolved
           ;; the event) so `parallel-machine-transition` warns exactly once
@@ -304,7 +315,13 @@
               region-snap (cond-> {:state (get state-map rn)
                                    :data  cur-data}
                             (some? cur-counter)
-                            (assoc :rf/spawn-counter cur-counter))
+                            (assoc :rf/spawn-counter cur-counter)
+                            ;; Seed the region snapshot with the shared
+                            ;; (region-qualified) `:rf/history` so a restore
+                            ;; reads the prior recording and a record writes
+                            ;; the region's own key (rf2-mle6e.3).
+                            (some? cur-history)
+                            (assoc :rf/history cur-history))
               step-result (step-fn region-spec region-snap)]
           (if (result/fail? step-result)
             step-result
@@ -323,6 +340,10 @@
                 (recur (rest pending)
                        (:data reg-snap)
                        (:rf/spawn-counter reg-snap)
+                       ;; Carry forward this region's `:rf/history` writes
+                       ;; (region-qualified keys) so later regions + the
+                       ;; merge see them (rf2-mle6e.3).
+                       (:rf/history reg-snap)
                        (assoc new-states rn (:state reg-snap))
                        (into acc-fx
                              (map (partial prefix-region-spawn-id rn))

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -708,6 +708,217 @@
 (defn- common-prefix-length [a b]
   (count (take-while true? (map = a b))))
 
+;; ---- history pseudo-states (rf2-mle6e.3) ----------------------------------
+;;
+;; Per Spec 005 §History states (`:type :history` — shallow / deep /
+;; default-target). A `:type :history` node under a compound's `:states` is
+;; a TARGETABLE PSEUDO-STATE: never occupied, it resolves a transition to
+;; the compound's recorded (or default) configuration. The engine:
+;;
+;;   - RESTORES on re-entry — `compute-cascade-paths` swaps the pseudo-state
+;;     target for the resolved leaf BEFORE the LCA geometry, so the standard
+;;     exit/action/entry cascade applies unchanged (46ban's external-self-
+;;     transition LCA fix is the precedent: resolve the real path first,
+;;     then let the geometry run on it);
+;;   - RECORDS on exit — `apply-transition-once` writes the exited compound's
+;;     last-active configuration into the snapshot `:rf/history` slot as part
+;;     of the exit-cascade commit;
+;;   - the `:rf/history` slot is keyed by the compound's DECLARATION PATH,
+;;     region-qualified (head segment = region name) under `:type :parallel`
+;;     so two regions' structurally-identical compound paths never collide.
+;;
+;; `:rf/history` lives inside the snapshot (a revertible value), so the
+;; recording rides `pr-str` round-trip, SSR hydration, and Tool-Pair epoch
+;; replay for free — no side-table.
+
+(defn history-node?
+  "True iff `node` is a history pseudo-state (`:type :history`)."
+  [node]
+  (= :history (:type node)))
+
+(defn- history-child
+  "Return `[hist-key hist-node]` for the (single) history pseudo-state
+  declared directly under compound at `compound-path`, or nil if the
+  compound owns none. Per Spec 005 §History states — a compound owns at
+  most one (registration-validated)."
+  [machine compound-path]
+  (let [compound (if (empty? compound-path)
+                   machine
+                   (node-at machine compound-path))]
+    (some (fn [[k n]] (when (history-node? n) [k n]))
+          (:states compound))))
+
+(defn- history-key
+  "The `:rf/history` map key for compound at `compound-path` — the
+  declaration path, region-qualified (head = region name) under a
+  parallel region. The single-machine engine carries `:rf/region` for a
+  region-spec; flat / compound machines carry none."
+  [machine compound-path]
+  (let [region (:rf/region machine)]
+    (vec (if region (cons region compound-path) compound-path))))
+
+(defn- valid-leaf-path?
+  "True iff `path` resolves to a real (non-history) state-node in the
+  current definition. Used to detect a DANGLING recorded path after hot
+  reload (rf2-wgfv0): a recorded config referencing a removed substate."
+  [machine path]
+  (let [n (node-at machine path)]
+    (and (some? n) (not (history-node? n)))))
+
+(defn- resolve-history-target
+  "Per Spec 005 §Restoring — on transition to the pseudo-state. Resolve a
+  history pseudo-state at `hist-path` (absolute, ending in the history
+  node's key) to a concrete leaf path, given the current `snapshot`'s
+  `:rf/history` slot. `hist-node` is the pseudo-state node.
+
+  Returns `{:leaf <path> :source :recorded|:default}`:
+   - `:recorded` — a recording exists for the owning compound AND it is
+     still a valid path in the current definition. Deep history restores
+     the full recorded leaf path; shallow restores the recorded direct
+     child then `initial-cascade`s its `:initial` chain.
+   - `:default` — no (valid) recording: the owning compound was never
+     entered, or the recorded config is a DANGLING path a hot-reloaded
+     definition removed (rf2-wgfv0). Falls back to the pseudo-state's
+     `:default-target` (initial-cascaded), or — when absent — the owning
+     compound's `:initial` cascade, exactly as a first-ever entry would."
+  [machine snapshot hist-path hist-node]
+  (let [compound-path (vec (drop-last hist-path))
+        hkey          (history-key machine compound-path)
+        recorded      (get-in snapshot [:rf/history hkey])
+        deep?         (true? (:deep? hist-node))
+        default-leaf  (fn []
+                        (let [dt (:default-target hist-node)]
+                          (cond
+                            ;; `:default-target` keyword names a DIRECT CHILD
+                            ;; of the owning compound (not a sibling — unlike
+                            ;; a transition `:target`); build the absolute
+                            ;; child path then descend any `:initial` chain.
+                            (keyword? dt) (initial-cascade machine (conj compound-path dt))
+                            ;; Vector form is an absolute path.
+                            (vector? dt)  (initial-cascade machine dt)
+                            ;; Absent => the owning compound's own `:initial`
+                            ;; cascade (cascade from the compound itself).
+                            :else         (initial-cascade machine compound-path))))]
+    (cond
+      ;; Deep — recorded value is the full absolute leaf path.
+      (and recorded deep? (vector? recorded) (valid-leaf-path? machine recorded))
+      {:leaf recorded :source :recorded}
+
+      ;; Shallow — recorded value is the direct-child KEYWORD; rebuild the
+      ;; absolute child path and cascade its `:initial` chain.
+      (and recorded (not deep?) (keyword? recorded)
+           (let [child-path (conj compound-path recorded)]
+             (valid-leaf-path? machine child-path)))
+      {:leaf (initial-cascade machine (conj compound-path recorded)) :source :recorded}
+
+      ;; No recording, or a DANGLING recorded path (hot-reload removed the
+      ;; substate) — graceful fallback to default-target / :initial.
+      :else
+      {:leaf (default-leaf) :source :default})))
+
+(defn- record-history-config
+  "Per Spec 005 §Recording — on compound-state exit. Given a compound at
+  `compound-path` that owns a history pseudo-state and the FULL active leaf
+  path the machine occupied (`active-path`), compute the recorded
+  configuration: the absolute leaf path beneath the compound for DEEP
+  history, or the direct-child keyword for SHALLOW. Returns `[hkey config]`
+  (the `:rf/history` map entry) or nil when the compound owns no history or
+  the active path doesn't descend through it."
+  [machine compound-path active-path]
+  (when-let [[_ hist-node] (history-child machine compound-path)]
+    (let [depth (count compound-path)]
+      ;; The active leaf must lie beneath this compound (the compound is on
+      ;; the source path AND has at least one substate active below it).
+      (when (and (> (count active-path) depth)
+                 (= compound-path (vec (take depth active-path))))
+        (let [hkey  (history-key machine compound-path)
+              deep? (true? (:deep? hist-node))]
+          (if deep?
+            [hkey (vec active-path)]                  ;; full absolute leaf path
+            [hkey (nth active-path depth)]))))))       ;; direct child keyword
+
+(defn- record-exit-history
+  "Per Spec 005 §Recording — on compound-state exit. Pure. Given the machine,
+  the pre-transition active leaf path (`src-path`), and the transition's
+  `lca-len`, write each history-bearing compound's last-active configuration
+  into the snapshot's `:rf/history` slot.
+
+  A history-owning compound `C` records iff the exit cascade leaves the
+  child subtree beneath `C` — i.e. `C` is a prefix of `src-path` with an
+  active child below it (`(count src-path) > (count C-path)`) AND that
+  child is being exited (`lca-len <= (count C-path)`, so the child at depth
+  `(count C-path)` sits at-or-below the LCA boundary). The compound `C`
+  itself need not be exited — moving between two children of `C` (LCA = C)
+  still tears down `C`'s current child subtree, which is exactly what
+  history captures. A transition staying entirely within `C`'s current
+  child (LCA strictly below `C`'s child) records nothing for `C`.
+
+  Returns `[snapshot recorded]` where `recorded` is the seq of
+  `{:history-key :config :deep?}` maps (for the `:rf.machine.history/
+  recorded` trace). The slot is allocated lazily — a transition leaving no
+  history-bearing compound's child subtree leaves the snapshot untouched."
+  [machine snapshot src-path lca-len]
+  (let [src-path (vec src-path)
+        n        (count src-path)]
+    ;; Walk every prefix of `src-path` that could own history (depth 0..n-1;
+    ;; a leaf at depth n-1 has no child below it). A prefix `C-path` records
+    ;; iff its child at depth `(count C-path)` is exited: `lca-len <= depth`.
+    (reduce
+      (fn [[snap recs] depth]
+        (let [compound-path (subvec src-path 0 depth)
+              entry         (when (<= lca-len depth)
+                              (record-history-config machine compound-path src-path))]
+          (if entry
+            (let [[hkey config] entry
+                  deep?         (true? (:deep? (second (history-child machine compound-path))))]
+              [(assoc-in snap [:rf/history hkey] config)
+               (conj recs {:history-key hkey :config config :deep? deep?})])
+            [snap recs])))
+      [snapshot []]
+      (range 0 n))))
+
+;; ---- history trace events (rf2-mle6e.3; spec/009 contract: rf2-mle6e.2) ----
+;;
+;; Per Spec 005 §History states + Spec 009 §Trace events. The engine emits
+;; observability traces under the machine-activity family `:rf.machine.
+;; history/*` (op-type `:rf.machine`, like `:rf.machine/transition` — NOT a
+;; severity discriminator, so consumers' issue-projection predicates never
+;; classify them as issues):
+;;
+;;   - `:rf.machine.history/restored` — a transition resolved to a history
+;;     pseudo-state. Carries `:source :recorded | :default` (recorded config
+;;     vs first-entry / dangling-path fallback), the owning compound's
+;;     region-qualified `:history-key`, the `:resolved-leaf`, and `:deep?`.
+;;   - `:rf.machine.history/recorded` — a history-bearing compound's exit
+;;     cascade wrote its last-active configuration. Carries the
+;;     `:history-key` and the recorded `:config` (deep leaf path / shallow
+;;     child keyword) + `:deep?`.
+;;
+;; The precise spec/009 shape (tag-key catalogue) is owned by mle6e.2 (in
+;; flight, disjoint surface); these emits conform to that family's naming
+;; and will be reconciled at review if .2's contract differs.
+
+(defn- emit-history-restored!
+  [machine hist-key resolved-leaf source deep?]
+  (trace/emit! :rf.machine :rf.machine.history/restored
+               {:machine-id    (or (:rf/parent-id machine) (:id machine))
+                :region        (:rf/region machine)
+                :history-key   hist-key
+                :resolved-leaf (vec resolved-leaf)
+                :source        source
+                :deep?         deep?
+                :frame         (:rf/frame machine)}))
+
+(defn- emit-history-recorded!
+  [machine hist-key config deep?]
+  (trace/emit! :rf.machine :rf.machine.history/recorded
+               {:machine-id  (or (:rf/parent-id machine) (:id machine))
+                :region      (:rf/region machine)
+                :history-key hist-key
+                :config      config
+                :deep?       deep?
+                :frame       (:rf/frame machine)}))
+
 ;; When an action throws, `run-action` returns a `result/fail` carrying
 ;; `{:action-ref :exception}`. `collect-actions` propagates the failure;
 ;; `apply-transition-once` / `machine-transition-single` enrich it with
@@ -1375,7 +1586,16 @@
                       is neither exited nor entered keeps its epoch (and
                       thus its live timer). Per Spec 005 §Hierarchy
                       interaction (the per-level tracking the normative
-                      external contract requires)."
+                      external contract requires).
+    :history-restore — per Spec 005 §Restoring (rf2-mle6e.3): present iff
+                      this transition resolved to a `:type :history`
+                      pseudo-state — `{:history-key :resolved-leaf :source
+                      :deep?}` (`:source` is `:recorded` | `:default`). The
+                      pseudo-state is swapped for `:resolved-leaf` BEFORE the
+                      LCA geometry above, so `:target-leaf` / `:lca-len` /
+                      `:entered-pairs` already reflect the resolved path.
+                      `apply-transition-once` emits the
+                      `:rf.machine.history/restored` trace from it."
   [machine snapshot transition transition-phase]
   (let [src-path      (state-path (:state snapshot))
         decl-path     (:decl-path transition (vec (take 1 src-path)))
@@ -1385,7 +1605,31 @@
         ;; the external self-transition: a `:target` (the `:same-state`
         ;; sentinel, or a keyword naming the declaring state's own key)
         ;; that resolves to the declaring state itself.
-        target-base   (target-path decl-path raw-target)
+        target-base0  (target-path decl-path raw-target)
+        ;; Per Spec 005 §Restoring — on transition to the pseudo-state: when
+        ;; `target-base0` lands on a history pseudo-state, resolve it to the
+        ;; recorded (or default / dangling-fallback) leaf BEFORE the LCA
+        ;; geometry. The resolved leaf is what the entry cascade enters and
+        ;; what the snapshot's `:state` records — the pseudo-state is never a
+        ;; configuration member (the 46ban precedent: resolve the real path,
+        ;; then run the standard geometry on it). `:history-restore` rides
+        ;; the result so `apply-transition-once` can emit the
+        ;; `:rf.machine.history/restored` trace.
+        hist-node     (when (and (not internal?) target-base0)
+                        (let [n (node-at machine target-base0)]
+                          (when (history-node? n) n)))
+        history-restore (when hist-node
+                          (let [{:keys [leaf source]}
+                                (resolve-history-target machine snapshot
+                                                        target-base0 hist-node)]
+                            {:history-key (history-key machine (vec (drop-last target-base0)))
+                             :resolved-leaf leaf
+                             :source      source
+                             :deep?       (true? (:deep? hist-node))}))
+        ;; The effective base after history resolution: the resolved leaf
+        ;; (already fully cascaded to a leaf) when restoring, else the
+        ;; declared target.
+        target-base   (if history-restore (:resolved-leaf history-restore) target-base0)
         target-leaf   (some->> target-base (initial-cascade machine))
         ;; Per Spec 005 §Self-transitions + §Entry/exit cascading: an
         ;; EXTERNAL self-transition re-enters the declaring state — `:exit`
@@ -1481,7 +1725,12 @@
      :exited-pairs  exited-pairs
      :entered-pairs entered-pairs
      :cascade-steps cascade-steps
-     :after-bump-paths after-bump-paths}))
+     :after-bump-paths after-bump-paths
+     ;; Per Spec 005 §Restoring (rf2-mle6e.3): present iff this transition
+     ;; resolved to a history pseudo-state — `{:history-key :resolved-leaf
+     ;; :source :deep?}`. `apply-transition-once` emits the
+     ;; `:rf.machine.history/restored` trace from it.
+     :history-restore history-restore}))
 
 (defn- run-cascade
   "Phase 2 — run the ordered cascade (`exit` deepest-first → `action`
@@ -1620,7 +1869,28 @@
               ;; that would otherwise drop them) so `machine-transition-single`
               ;; can accumulate the macrostep's full step sequence.
               cascade-steps   (result/cascade cascade-r)
-              snap-final      (commit-snapshot machine snapshot snap-after cascade)
+              snap-committed  (commit-snapshot machine snapshot snap-after cascade)
+              ;; Per Spec 005 §Recording — on compound-state exit
+              ;; (rf2-mle6e.3): as part of the exit-cascade commit, write
+              ;; each history-bearing exited compound's last-active config
+              ;; into `:rf/history`, keyed by the (region-qualified)
+              ;; declaration path. The active config recorded is the
+              ;; PRE-transition source leaf (`:src-path`).
+              [snap-final history-recorded]
+                              (if (:internal? cascade)
+                                [snap-committed []]
+                                (record-exit-history machine snap-committed
+                                                     (:src-path cascade)
+                                                     (:lca-len cascade)))
+              ;; Per Spec 005 §Restoring + Spec 009 (mle6e.2): emit the
+              ;; history traces. `restored` when this transition resolved a
+              ;; history pseudo-state; `recorded` once per history-bearing
+              ;; compound exited.
+              _ (when-let [{:keys [history-key resolved-leaf source deep?]}
+                           (:history-restore cascade)]
+                  (emit-history-restored! machine history-key resolved-leaf source deep?))
+              _ (doseq [{:keys [history-key config deep?]} history-recorded]
+                  (emit-history-recorded! machine history-key config deep?))
               parent-id       (or (:rf/parent-id machine) :rf/transition-pure)
               after-fx        (build-after-fx machine (:entered-pairs cascade)
                                               (:internal? cascade) snap-final)

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -771,21 +771,30 @@
   node's key) to a concrete leaf path, given the current `snapshot`'s
   `:rf/history` slot. `hist-node` is the pseudo-state node.
 
-  Returns `{:leaf <path> :source :recorded|:default}`:
+  Returns `{:leaf <path> :source :recorded|:default ...}`:
    - `:recorded` — a recording exists for the owning compound AND it is
      still a valid path in the current definition. Deep history restores
      the full recorded leaf path; shallow restores the recorded direct
-     child then `initial-cascade`s its `:initial` chain.
+     child then `initial-cascade`s its `:initial` chain. Additionally
+     carries `:restored-config` — the recorded value (per spec/009 the
+     `:rf.machine.history/restored` `:restored-config` tag).
    - `:default` — no (valid) recording: the owning compound was never
      entered, or the recorded config is a DANGLING path a hot-reloaded
      definition removed (rf2-wgfv0). Falls back to the pseudo-state's
      `:default-target` (initial-cascaded), or — when absent — the owning
-     compound's `:initial` cascade, exactly as a first-ever entry would."
+     compound's `:initial` cascade, exactly as a first-ever entry would.
+     Additionally carries `:fallback` — `:default-target` when the
+     pseudo-state declared one, else `:initial` (the spec/009 `:fallback`
+     tag)."
   [machine snapshot hist-path hist-node]
   (let [compound-path (vec (drop-last hist-path))
         hkey          (history-key machine compound-path)
         recorded      (get-in snapshot [:rf/history hkey])
         deep?         (true? (:deep? hist-node))
+        ;; Which fallback resolves the leaf on the `:default` path:
+        ;; `:default-target` when the pseudo-state declared one (keyword or
+        ;; vector form), else the owning compound's `:initial`.
+        fallback      (if (some? (:default-target hist-node)) :default-target :initial)
         default-leaf  (fn []
                         (let [dt (:default-target hist-node)]
                           (cond
@@ -802,19 +811,20 @@
     (cond
       ;; Deep — recorded value is the full absolute leaf path.
       (and recorded deep? (vector? recorded) (valid-leaf-path? machine recorded))
-      {:leaf recorded :source :recorded}
+      {:leaf recorded :source :recorded :restored-config recorded}
 
       ;; Shallow — recorded value is the direct-child KEYWORD; rebuild the
       ;; absolute child path and cascade its `:initial` chain.
       (and recorded (not deep?) (keyword? recorded)
            (let [child-path (conj compound-path recorded)]
              (valid-leaf-path? machine child-path)))
-      {:leaf (initial-cascade machine (conj compound-path recorded)) :source :recorded}
+      {:leaf (initial-cascade machine (conj compound-path recorded))
+       :source :recorded :restored-config recorded}
 
       ;; No recording, or a DANGLING recorded path (hot-reload removed the
       ;; substate) — graceful fallback to default-target / :initial.
       :else
-      {:leaf (default-leaf) :source :default})))
+      {:leaf (default-leaf) :source :default :fallback fallback})))
 
 (defn- record-history-config
   "Per Spec 005 §Recording — on compound-state exit. Given a compound at
@@ -854,9 +864,14 @@
   child (LCA strictly below `C`'s child) records nothing for `C`.
 
   Returns `[snapshot recorded]` where `recorded` is the seq of
-  `{:history-key :config :deep?}` maps (for the `:rf.machine.history/
-  recorded` trace). The slot is allocated lazily — a transition leaving no
-  history-bearing compound's child subtree leaves the snapshot untouched."
+  `{:compound-path :recorded-config :kind :prev-config}` maps (for the
+  `:rf.machine.history/recorded` trace, per spec/009). `:compound-path` is
+  the region-qualified declaration path (the `:rf/history` key); `:kind` is
+  `:deep`/`:shallow`; `:prev-config` is the value the slot held BEFORE this
+  write (omitted on the first-ever recording for the compound — the slot was
+  previously unallocated). The slot is allocated lazily — a transition
+  leaving no history-bearing compound's child subtree leaves the snapshot
+  untouched."
   [machine snapshot src-path lca-len]
   (let [src-path (vec src-path)
         n        (count src-path)]
@@ -870,9 +885,18 @@
                               (record-history-config machine compound-path src-path))]
           (if entry
             (let [[hkey config] entry
-                  deep?         (true? (:deep? (second (history-child machine compound-path))))]
+                  deep?         (true? (:deep? (second (history-child machine compound-path))))
+                  ;; Read the value the slot held BEFORE this write, off the
+                  ;; accumulating snapshot. `contains?` distinguishes a
+                  ;; never-allocated slot (first-ever recording — `:prev-config`
+                  ;; absent per spec) from one holding a value (incl. nil).
+                  had-prev?     (contains? (:rf/history snap) hkey)
+                  prev-config   (get-in snap [:rf/history hkey])]
               [(assoc-in snap [:rf/history hkey] config)
-               (conj recs {:history-key hkey :config config :deep? deep?})])
+               (conj recs (cond-> {:compound-path hkey
+                                   :recorded-config config
+                                   :kind (if deep? :deep :shallow)}
+                            had-prev? (assoc :prev-config prev-config)))])
             [snap recs])))
       [snapshot []]
       (range 0 n))))
@@ -886,38 +910,49 @@
 ;; classify them as issues):
 ;;
 ;;   - `:rf.machine.history/restored` — a transition resolved to a history
-;;     pseudo-state. Carries `:source :recorded | :default` (recorded config
-;;     vs first-entry / dangling-path fallback), the owning compound's
-;;     region-qualified `:history-key`, the `:resolved-leaf`, and `:deep?`.
+;;     pseudo-state. Tags (spec/009): `:compound-path` (region-qualified
+;;     declaration path — the `:rf/history` key), `:kind` (`:shallow`/
+;;     `:deep`), `:source` (`:recorded` | `:default`), `:fallback`
+;;     (`:default-target`/`:initial`, present ONLY on `:source :default`),
+;;     `:restored-config` (the recorded config that drove the restore,
+;;     ABSENT on `:source :default`), `:resolved-leaf` (the concrete leaf
+;;     entered), `:frame`.
 ;;   - `:rf.machine.history/recorded` — a history-bearing compound's exit
-;;     cascade wrote its last-active configuration. Carries the
-;;     `:history-key` and the recorded `:config` (deep leaf path / shallow
-;;     child keyword) + `:deep?`.
+;;     cascade wrote its last-active configuration. Tags (spec/009):
+;;     `:compound-path`, `:kind`, `:recorded-config` (the value written —
+;;     deep leaf path / shallow child keyword), `:prev-config` (the value
+;;     overwritten; ABSENT on the first-ever recording), `:frame`.
 ;;
-;; The precise spec/009 shape (tag-key catalogue) is owned by mle6e.2 (in
-;; flight, disjoint surface); these emits conform to that family's naming
-;; and will be reconciled at review if .2's contract differs.
+;; Shapes match spec/009 §History trace events EXACTLY (rf2-mle6e.2).
 
 (defn- emit-history-restored!
-  [machine hist-key resolved-leaf source deep?]
+  "Per spec/009 §`:rf.machine.history/restored`. `source` is `:recorded` |
+  `:default`. On the `:default` path `restored-config` is nil (no recording
+  drove the restore) so it is OMITTED, and `fallback` (`:default-target` |
+  `:initial`) names which fallback resolved the leaf; on the `:recorded`
+  path `fallback` is absent and `restored-config` carries the recorded
+  value."
+  [machine compound-path resolved-leaf source kind restored-config fallback]
   (trace/emit! :rf.machine :rf.machine.history/restored
-               {:machine-id    (or (:rf/parent-id machine) (:id machine))
-                :region        (:rf/region machine)
-                :history-key   hist-key
-                :resolved-leaf (vec resolved-leaf)
-                :source        source
-                :deep?         deep?
-                :frame         (:rf/frame machine)}))
+               (cond-> {:machine-id    (or (:rf/parent-id machine) (:id machine))
+                        :compound-path compound-path
+                        :kind          kind
+                        :source        source
+                        :resolved-leaf (vec resolved-leaf)
+                        :frame         (:rf/frame machine)}
+                 (= :default source) (assoc :fallback fallback)
+                 (not= :default source) (assoc :restored-config restored-config))))
 
 (defn- emit-history-recorded!
-  [machine hist-key config deep?]
+  "Per spec/009 §`:rf.machine.history/recorded`. `recorded` is the per-write
+  map from `record-exit-history` — carries `:compound-path`,
+  `:recorded-config`, `:kind`, and (when not the first-ever recording)
+  `:prev-config`."
+  [machine recorded]
   (trace/emit! :rf.machine :rf.machine.history/recorded
-               {:machine-id  (or (:rf/parent-id machine) (:id machine))
-                :region      (:rf/region machine)
-                :history-key hist-key
-                :config      config
-                :deep?       deep?
-                :frame       (:rf/frame machine)}))
+               (merge {:machine-id (or (:rf/parent-id machine) (:id machine))
+                       :frame      (:rf/frame machine)}
+                      recorded)))
 
 ;; When an action throws, `run-action` returns a `result/fail` carrying
 ;; `{:action-ref :exception}`. `collect-actions` propagates the failure;
@@ -988,10 +1023,17 @@
 ;;    :region <region-name-or-nil>             ;; parallel region (nil flat/compound)
 ;;    :action <action-id-or-nil>               ;; the action that fired (nil = no
 ;;                                             ;;   :exit/:entry/:action declared)
-;;    :data-delta {<k> <new-v>}}               ;; the :data keys THIS step's action
+;;    :data-delta {<k> <new-v>}                ;; the :data keys THIS step's action
 ;;                                             ;;   added/changed (empty when no
 ;;                                             ;;   action, or the action wrote no
 ;;                                             ;;   :data)
+;;    :source :recorded | :default}            ;; ADDITIVE, history-only: present
+;;                                             ;;   on an :entry step produced by a
+;;                                             ;;   history restore (spec/009 line
+;;                                             ;;   291), matching the
+;;                                             ;;   :rf.machine.history/restored
+;;                                             ;;   event's :source; ABSENT on every
+;;                                             ;;   non-history step (rf2-mle6e.3)
 ;;
 ;; The step vector is built in `compute-cascade-paths` (which owns the
 ;; ordered prefix paths + action refs) and the per-step `:data-delta` is
@@ -1050,14 +1092,20 @@
   ;; arity (which would churn every caller). `reduced` short-circuits on
   ;; the first throwing action, carrying the bare `:fail` Result.
   (let [acc (reduce
-              (fn [[acc-r cascade] {:keys [kind phase action state region]}]
+              (fn [[acc-r cascade] {:keys [kind phase action state region source]}]
                 (result/with-ok [snap fx] acc-r
                   (let [before-data (:data snap)
                         emit-phase  (or phase kind)
-                        base-step   {:kind   kind
-                                     :state  state
-                                     :region region
-                                     :action action}]
+                        ;; Per spec/009 §History trace events (line 291): a
+                        ;; history-driven `:entry` step additively carries
+                        ;; `:source` (set in `compute-cascade-paths`); a
+                        ;; non-history step has none, so only stamp it when
+                        ;; the input step supplied it.
+                        base-step   (cond-> {:kind   kind
+                                             :state  state
+                                             :region region
+                                             :action action}
+                                      source (assoc :source source))]
                     (if action
                       (let [r (run-action machine snap action event emit-phase)]
                         (if (result/fail? r)
@@ -1589,8 +1637,10 @@
                       external contract requires).
     :history-restore — per Spec 005 §Restoring (rf2-mle6e.3): present iff
                       this transition resolved to a `:type :history`
-                      pseudo-state — `{:history-key :resolved-leaf :source
-                      :deep?}` (`:source` is `:recorded` | `:default`). The
+                      pseudo-state — the spec/009 `:rf.machine.history/
+                      restored` tag bag `{:compound-path :resolved-leaf
+                      :source :kind (+:restored-config|+:fallback)}`
+                      (`:source` is `:recorded` | `:default`). The
                       pseudo-state is swapped for `:resolved-leaf` BEFORE the
                       LCA geometry above, so `:target-leaf` / `:lca-len` /
                       `:entered-pairs` already reflect the resolved path.
@@ -1619,13 +1669,20 @@
                         (let [n (node-at machine target-base0)]
                           (when (history-node? n) n)))
         history-restore (when hist-node
-                          (let [{:keys [leaf source]}
+                          (let [{:keys [leaf source restored-config fallback]}
                                 (resolve-history-target machine snapshot
                                                         target-base0 hist-node)]
-                            {:history-key (history-key machine (vec (drop-last target-base0)))
-                             :resolved-leaf leaf
-                             :source      source
-                             :deep?       (true? (:deep? hist-node))}))
+                            ;; The spec/009 `:rf.machine.history/restored` tag
+                            ;; bag, threaded to `apply-transition-once`'s emit.
+                            ;; `:restored-config` rides only on `:recorded`;
+                            ;; `:fallback` only on `:default` (mirrors the emit's
+                            ;; cond->). `:kind` maps the grammar `:deep?`.
+                            (cond-> {:compound-path (history-key machine (vec (drop-last target-base0)))
+                                     :resolved-leaf leaf
+                                     :source        source
+                                     :kind          (if (true? (:deep? hist-node)) :deep :shallow)}
+                              (= :recorded source) (assoc :restored-config restored-config)
+                              (= :default source)  (assoc :fallback fallback))))
         ;; The effective base after history resolution: the resolved leaf
         ;; (already fully cascaded to a leaf) when restoring, else the
         ;; declared target.
@@ -1700,10 +1757,18 @@
         action-steps  (when (:action transition)
                         [{:kind :action :phase transition-phase :state (vec decl-path)
                           :region region :action (:action transition)}])
+        ;; Per spec/009 §History trace events (line 291): each `:entry` step
+        ;; produced by a history restore additively carries `:source`
+        ;; (`:recorded`|`:default`) matching the `:rf.machine.history/restored`
+        ;; event's `:source`; a step with no `:source` key was not
+        ;; history-driven. All entry steps of a history-driven transition came
+        ;; from the resolved leaf's entry cascade, so all carry the source.
+        hist-source   (:source history-restore)
         entry-steps   (when-not internal?
                         (mapv (fn [[prefix n]]
-                                {:kind :entry :phase entry-phase :state (vec prefix)
-                                 :region region :action (:entry n)})
+                                (cond-> {:kind :entry :phase entry-phase :state (vec prefix)
+                                         :region region :action (:entry n)}
+                                  hist-source (assoc :source hist-source)))
                               entered-pairs))
         cascade-steps (vec (concat exit-steps action-steps entry-steps))
         ;; Per Spec 005 §Hierarchy interaction: bump the per-path epoch
@@ -1727,9 +1792,10 @@
      :cascade-steps cascade-steps
      :after-bump-paths after-bump-paths
      ;; Per Spec 005 §Restoring (rf2-mle6e.3): present iff this transition
-     ;; resolved to a history pseudo-state — `{:history-key :resolved-leaf
-     ;; :source :deep?}`. `apply-transition-once` emits the
-     ;; `:rf.machine.history/restored` trace from it.
+     ;; resolved to a history pseudo-state — the spec/009 `:rf.machine.
+     ;; history/restored` tag bag `{:compound-path :resolved-leaf :source
+     ;; :kind (+:restored-config|+:fallback)}`. `apply-transition-once`
+     ;; emits the `:rf.machine.history/restored` trace from it.
      :history-restore history-restore}))
 
 (defn- run-cascade
@@ -1886,11 +1952,13 @@
               ;; history traces. `restored` when this transition resolved a
               ;; history pseudo-state; `recorded` once per history-bearing
               ;; compound exited.
-              _ (when-let [{:keys [history-key resolved-leaf source deep?]}
+              _ (when-let [{:keys [compound-path resolved-leaf source kind
+                                   restored-config fallback]}
                            (:history-restore cascade)]
-                  (emit-history-restored! machine history-key resolved-leaf source deep?))
-              _ (doseq [{:keys [history-key config deep?]} history-recorded]
-                  (emit-history-recorded! machine history-key config deep?))
+                  (emit-history-restored! machine compound-path resolved-leaf
+                                          source kind restored-config fallback))
+              _ (doseq [rec history-recorded]
+                  (emit-history-recorded! machine rec))
               parent-id       (or (:rf/parent-id machine) :rf/transition-pure)
               after-fx        (build-after-fx machine (:entered-pairs cascade)
                                               (:internal? cascade) snap-final)

--- a/implementation/machines/test/re_frame/machine_history_smoke_test.clj
+++ b/implementation/machines/test/re_frame/machine_history_smoke_test.clj
@@ -1,0 +1,183 @@
+(ns re-frame.machine-history-smoke-test
+  "Minimal smoke for the first-class history ENGINE (rf2-mle6e.3). Drives the
+  pure `machine-transition` primitive directly (no frame / app-db) to prove
+  record-on-exit + restore-on-re-entry work for the shapes the spec pins:
+
+    - SHALLOW record/restore — records the direct child, descends its
+      `:initial` chain on restore.
+    - DEEP record/restore — records and restores the full leaf path.
+    - DEFAULT-TARGET on first entry — nothing recorded yet → `:default-target`
+      (or the compound's `:initial` when absent).
+    - DANGLING recorded path after hot reload (rf2-wgfv0 engine half) — a
+      recorded config the (reloaded) definition removed falls back to the
+      default, never entering the dead path; benign (no `:rf.error/*`).
+    - PER-REGION parallel history — recorded keys are region-qualified;
+      restoring one region leaves siblings untouched.
+    - SNAPSHOT REVERTIBILITY — `:rf/history` rides `pr-str` / `read-string`
+      (it lives inside the snapshot value, like `:rf/machine-type`).
+
+  The COMPREHENSIVE history suite (unit matrix + conformance restore
+  fixtures + the W3C-adapted corpus) is rf2-mle6e.4's job — this is only the
+  engine-author's proof that record/restore is wired end-to-end."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]))
+
+(defn- step
+  "Apply one macrostep and return the post-transition snapshot. Asserts the
+  step did not fail."
+  [machine snapshot event]
+  (let [r (machines/machine-transition machine snapshot event)]
+    (is (result/ok? r) (str "transition ok for event " (pr-str event)))
+    (result/snap r)))
+
+;; A media-player compound with a DEEP history pseudo-state. `:play` from
+;; `:stopped` targets the history node, which restores the recorded leaf
+;; beneath `:player` (or `:default-target` on first entry).
+(def deep-player
+  {:initial :player
+   :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history
+                                   :deep? true
+                                   :default-target :playing}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}
+                         :paused  {:on {:resume [:player :playing]}}}}}})
+
+;; Same shape but SHALLOW (no `:deep?`). On restore the recorded DIRECT CHILD
+;; is descended through its own `:initial` chain — so a deep-leaf at exit
+;; restores only to the child's `:initial`, not the exact leaf.
+(def shallow-player
+  {:initial :player
+   :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history
+                                   :default-target :playing}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}})
+
+(defn- seed
+  "A fresh pure-call snapshot positioned at `state`."
+  [state]
+  {:state state :data {} :rf/spawn-counter {}})
+
+(deftest deep-history-records-and-restores-leaf
+  (testing "DEEP history records the full leaf path on exit and restores it on re-entry"
+    ;; Position deep into the subtree, then leave via :stop (absolute target,
+    ;; so the post-state is the vector [:player :stopped]).
+    (let [after-stop (step deep-player (seed [:player :playing :mid-track]) [:stop])]
+      (is (= [:player :stopped] (:state after-stop)) "exited to :stopped")
+      (is (= [:player :playing :mid-track] (get-in after-stop [:rf/history [:player]]))
+          "deep history recorded the full absolute leaf path under :player")
+      ;; Re-enter via the history pseudo-state.
+      (let [restored (step deep-player after-stop [:play])]
+        (is (= [:player :playing :mid-track] (:state restored))
+            "deep history restored the exact recorded leaf, not :initial")))))
+
+(deftest shallow-history-records-child-and-cascades-initial
+  (testing "SHALLOW history records the direct child + cascades its :initial on restore"
+    (let [after-stop (step shallow-player (seed [:player :playing :mid-track]) [:stop])]
+      (is (= [:player :stopped] (:state after-stop)) "exited to :stopped")
+      (is (= :playing (get-in after-stop [:rf/history [:player]]))
+          "shallow history recorded the direct child keyword (:playing)")
+      (let [restored (step shallow-player after-stop [:play])]
+        ;; Shallow descends :playing's :initial (:at-start), NOT the exact
+        ;; exit leaf (:mid-track).
+        (is (= [:player :playing :at-start] (:state restored))
+            "shallow history restored the recorded child then its :initial chain")))))
+
+(deftest default-target-on-first-entry
+  (testing "first entry (nothing recorded) resolves the pseudo-state's :default-target"
+    ;; No prior exit ⇒ no recording ⇒ :default-target :playing → :at-start.
+    ;; (The restore transition ALSO records :stopped on its way out — leaving
+    ;; :stopped tears down :player's current child subtree — but the RESTORE
+    ;; reads the pre-transition (empty) history, so it falls to default.)
+    (let [restored (step deep-player (seed [:player :stopped]) [:play])]
+      (is (= [:player :playing :at-start] (:state restored))
+          ":default-target :playing descended to its :initial leaf"))))
+
+(deftest default-target-absent-falls-back-to-initial
+  (testing "when :default-target is absent the fallback is the compound's :initial"
+    (let [m {:initial :player
+             :states  {:player
+                        {:initial :stopped
+                         :states  {:stopped {:on {:play [:player :hist]}}
+                                   :hist    {:type :history :deep? true}
+                                   :playing {:on {:stop :stopped}}}}}}
+          restored (step m (seed [:player :stopped]) [:play])]
+      (is (= [:player :stopped] (:state restored))
+          "no :default-target ⇒ compound's :initial (:stopped) cascade"))))
+
+(deftest dangling-recorded-path-falls-back
+  (testing "a recorded leaf the (hot-reloaded) definition removed falls back to default (rf2-wgfv0)"
+    ;; Hand-seed a snapshot whose :rf/history references a substate the
+    ;; CURRENT definition does not declare (:gone), as if a hot reload
+    ;; removed it. Restore must discard it and fall back, never entering the
+    ;; dead path. Benign — no :rf.error/*.
+    (let [snap     (assoc (seed [:player :stopped])
+                          :rf/history {[:player] [:player :playing :gone]})
+          r        (machines/machine-transition deep-player snap [:play])]
+      (is (result/ok? r) "dangling path is benign — no failure")
+      (let [restored (result/snap r)]
+        (is (= [:player :playing :at-start] (:state restored))
+            "dangling recorded path discarded ⇒ fell back to :default-target")))))
+
+(deftest history-rides-pr-str-round-trip
+  (testing ":rf/history is EDN-clean — survives pr-str / read-string (snapshot revertibility)"
+    (let [after-stop (step deep-player (seed [:player :playing :mid-track]) [:stop])
+          round      (read-string (pr-str after-stop))]
+      (is (= after-stop round) "snapshot (incl. :rf/history) round-trips =-equal")
+      ;; Restoring from the round-tripped snapshot resolves the recorded leaf.
+      (let [restored (step deep-player round [:play])]
+        (is (= [:player :playing :mid-track] (:state restored))
+            "history restore works off a round-tripped snapshot")))))
+
+;; A parallel machine with a history-bearing compound in EACH region.
+(def parallel-history
+  {:type    :parallel
+   :regions {:left  {:initial :group
+                     :states  {:group {:initial :off
+                                       :states  {:off {:on {:on-l [:group :hist]}}
+                                                 :hist {:type :history :deep? true}
+                                                 :on   {:initial :dim
+                                                        :on      {:off-l [:group :off]}
+                                                        :states  {:dim    {:on {:bright-l :bright}}
+                                                                  :bright {:on {:off-l [:group :off]}}}}}}}}
+             :right {:initial :group
+                     :states  {:group {:initial :off
+                                       :states  {:off {:on {:on-r [:group :hist]}}
+                                                 :hist {:type :history :deep? true}
+                                                 :on   {:initial :dim
+                                                        :on      {:off-r [:group :off]}
+                                                        :states  {:dim    {:on {:bright-r :bright}}
+                                                                  :bright {:on {:off-r [:group :off]}}}}}}}}}})
+
+(deftest per-region-history-is-region-qualified
+  (testing "parallel history records region-qualified keys; restoring one region leaves siblings"
+    (let [snap0 {:state {:left  [:group :on :bright]
+                         :right [:group :on :dim]}
+                 :data  {}
+                 :rf/spawn-counter {}}
+          ;; Turn both regions off — each records its own region-qualified
+          ;; history.
+          off-l (step parallel-history snap0 [:off-l])
+          off   (step parallel-history off-l [:off-r])]
+      (is (= [:group :on :bright] (get-in off [:rf/history [:left :group]]))
+          ":left region recorded under its region-qualified key")
+      (is (= [:group :on :dim] (get-in off [:rf/history [:right :group]]))
+          ":right region recorded under its region-qualified key (no collision)")
+      (is (= {:left [:group :off] :right [:group :off]} (:state off))
+          "both regions off")
+      ;; Restore ONLY the left region — right stays off.
+      (let [back-l (step parallel-history off [:on-l])]
+        (is (= [:group :on :bright] (get-in back-l [:state :left]))
+            ":left restored its recorded deep leaf")
+        (is (= [:group :off] (get-in back-l [:state :right]))
+            ":right region untouched by the left-region restore")))))

--- a/implementation/machines/test/re_frame/machine_history_smoke_test.clj
+++ b/implementation/machines/test/re_frame/machine_history_smoke_test.clj
@@ -18,10 +18,42 @@
 
   The COMPREHENSIVE history suite (unit matrix + conformance restore
   fixtures + the W3C-adapted corpus) is rf2-mle6e.4's job — this is only the
-  engine-author's proof that record/restore is wired end-to-end."
-  (:require [clojure.test :refer [deftest is testing]]
+  engine-author's proof that record/restore is wired end-to-end.
+
+  TRACE SHAPE — the `:rf.machine.history/restored` + `:rf.machine.history/
+  recorded` emits MUST match spec/009 §History trace events EXACTLY (the
+  tag-key catalogue owned by rf2-mle6e.2). The `*-trace-shape` tests below
+  capture the emitted events via a `re-frame.trace` listener and assert the
+  precise tag bags (`:compound-path` / `:kind` / `:source` / `:fallback` /
+  `:restored-config` / `:recorded-config` / `:prev-config` / `:resolved-leaf`)
+  + the cascade-step `:source` stamping (spec/009 line 291)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.machines :as machines]
-            [re-frame.machines.result :as result]))
+            [re-frame.machines.result :as result]
+            [re-frame.trace :as trace]))
+
+;; ---- trace capture (spec/009 shape proof) --------------------------------
+
+(def ^:dynamic *captured* nil)
+
+(defn- capture-fixture
+  "Register a trace listener that appends every emitted event to `*captured*`
+  for the duration of one test, then unregisters."
+  [f]
+  (binding [*captured* (atom [])]
+    (trace/register-listener! ::history-smoke #(swap! *captured* conj %))
+    (try (f)
+      (finally (trace/unregister-listener! ::history-smoke)))))
+
+(use-fixtures :each capture-fixture)
+
+(defn- history-events
+  "The captured events for the given history `operation`
+  (`:rf.machine.history/restored` | `:rf.machine.history/recorded`)."
+  [operation]
+  (filterv #(= operation (:operation %)) @*captured*))
+
+(defn- reset-capture! [] (reset! *captured* []))
 
 (defn- step
   "Apply one macrostep and return the post-transition snapshot. Asserts the
@@ -181,3 +213,147 @@
             ":left restored its recorded deep leaf")
         (is (= [:group :off] (get-in back-l [:state :right]))
             ":right region untouched by the left-region restore")))))
+
+;; ---- spec/009 trace-shape proofs -----------------------------------------
+;;
+;; These pin the EXACT tag bags spec/009 §History trace events declares — the
+;; reconcile target (rf2-mle6e.2 contract). They assert presence AND absence
+;; (e.g. `:restored-config` absent on `:source :default`, `:fallback` absent
+;; on `:source :recorded`, `:prev-config` absent on the first-ever recording).
+
+(deftest recorded-trace-shape-deep
+  (testing ":rf.machine.history/recorded carries the spec/009 deep tag bag"
+    ;; First-ever recording for [:player] — :prev-config ABSENT.
+    (step deep-player (seed [:player :playing :mid-track]) [:stop])
+    (let [evs (history-events :rf.machine.history/recorded)]
+      (is (= 1 (count evs)) "exactly one recorded event")
+      (let [tags (:tags (first evs))]
+        (is (= :rf.machine (:op-type (first evs))) "machine-activity op-type")
+        (is (= [:player] (:compound-path tags)) ":compound-path = decl path")
+        (is (= :deep (:kind tags)) ":kind :deep (not :deep?)")
+        (is (= [:player :playing :mid-track] (:recorded-config tags))
+            ":recorded-config = full leaf (renamed from :config)")
+        (is (not (contains? tags :prev-config))
+            ":prev-config ABSENT on the first-ever recording")
+        (is (not (contains? tags :history-key)) "old :history-key gone")
+        (is (not (contains? tags :config)) "old :config gone")
+        (is (not (contains? tags :deep?)) "old :deep? gone")
+        (is (not (contains? tags :region)) "old :region gone (folded into path)")))))
+
+(deftest recorded-trace-shape-prev-config-on-overwrite
+  (testing ":prev-config = the value the slot held before this write"
+    ;; Hand-seed an already-allocated history slot (as if a prior exit wrote
+    ;; it), then exit again from a DIFFERENT leaf. The new :recorded event
+    ;; reports :prev-config = the seeded value it overwrote.
+    (let [snap0 (assoc (seed [:player :playing :mid-track])
+                       :rf/history {[:player] [:player :playing :at-start]})]
+      (reset-capture!)
+      (step deep-player snap0 [:stop])
+      (let [tags (:tags (first (history-events :rf.machine.history/recorded)))]
+        (is (contains? tags :prev-config)
+            ":prev-config PRESENT — the slot already held a value")
+        (is (= [:player :playing :at-start] (:prev-config tags))
+            ":prev-config = the value the slot held BEFORE this write")
+        (is (= [:player :playing :mid-track] (:recorded-config tags))
+            ":recorded-config = the value written by THIS exit")))))
+
+(deftest restored-trace-shape-recorded-source
+  (testing ":rf.machine.history/restored on the :recorded path"
+    (let [after-stop (step deep-player (seed [:player :playing :mid-track]) [:stop])]
+      (reset-capture!)
+      (step deep-player after-stop [:play])
+      (let [evs  (history-events :rf.machine.history/restored)
+            ev   (first evs)
+            tags (:tags ev)]
+        (is (= 1 (count evs)) "exactly one restored event")
+        (is (= :rf.machine (:op-type ev)) "machine-activity op-type")
+        (is (= [:player] (:compound-path tags)) ":compound-path region-qualified decl path")
+        (is (= :deep (:kind tags)) ":kind :deep")
+        ;; `:source` is hoisted to the envelope top level on the success path
+        ;; (build-event strips it from :tags) — the spec's documented hoist.
+        (is (= :recorded (:source ev)) ":source :recorded (hoisted to top level)")
+        (is (= [:player :playing :mid-track] (:restored-config tags))
+            ":restored-config = the recorded config that drove the restore")
+        (is (= [:player :playing :mid-track] (:resolved-leaf tags))
+            ":resolved-leaf = the concrete leaf entered")
+        (is (not (contains? tags :fallback))
+            ":fallback ABSENT on the :recorded path")
+        (is (not (contains? tags :history-key)) "old :history-key gone")
+        (is (not (contains? tags :deep?)) "old :deep? gone")
+        (is (not (contains? tags :region)) "old :region gone")))))
+
+(deftest restored-trace-shape-default-source-with-fallback
+  (testing ":rf.machine.history/restored on the :default path names the :fallback"
+    ;; First entry — nothing recorded → :default, :default-target declared.
+    (step deep-player (seed [:player :stopped]) [:play])
+    (let [evs  (history-events :rf.machine.history/restored)
+          ev   (first evs)
+          tags (:tags ev)]
+      (is (= 1 (count evs)) "exactly one restored event")
+      (is (= :default (:source ev)) ":source :default (no recording; hoisted)")
+      (is (= :default-target (:fallback tags))
+          ":fallback :default-target (the pseudo-state declared one)")
+      (is (= [:player :playing :at-start] (:resolved-leaf tags))
+          ":resolved-leaf = :default-target descended to its :initial")
+      (is (not (contains? tags :restored-config))
+          ":restored-config ABSENT on the :default path (nothing recorded)"))))
+
+(deftest restored-trace-shape-default-fallback-initial
+  (testing ":fallback :initial when the pseudo-state declares no :default-target"
+    (let [m {:initial :player
+             :states  {:player
+                        {:initial :stopped
+                         :states  {:stopped {:on {:play [:player :hist]}}
+                                   :hist    {:type :history :deep? true}
+                                   :playing {:on {:stop :stopped}}}}}}]
+      (step m (seed [:player :stopped]) [:play])
+      (let [ev   (first (history-events :rf.machine.history/restored))
+            tags (:tags ev)]
+        (is (= :default (:source ev)))
+        (is (= :initial (:fallback tags))
+            ":fallback :initial — no :default-target declared")
+        (is (not (contains? tags :restored-config)))))))
+
+(deftest restored-trace-shape-shallow-kind
+  (testing "shallow history restore stamps :kind :shallow"
+    (let [after-stop (step shallow-player (seed [:player :playing :mid-track]) [:stop])]
+      (reset-capture!)
+      (step shallow-player after-stop [:play])
+      (let [ev   (first (history-events :rf.machine.history/restored))
+            tags (:tags ev)]
+        (is (= :shallow (:kind tags)) ":kind :shallow (no :deep?)")
+        (is (= :recorded (:source ev)))
+        (is (= :playing (:restored-config tags))
+            ":restored-config = recorded direct-child keyword (shallow)")
+        (is (= [:player :playing :at-start] (:resolved-leaf tags))
+            ":resolved-leaf = recorded child descended through its :initial")))))
+
+(deftest cascade-step-source-stamping
+  (testing "history-driven :entry cascade steps carry :source (spec/009 line 291)"
+    ;; Re-run the restore and read the structured cascade off the transition
+    ;; result — each :entry step must carry :source matching the restored
+    ;; event; non-history steps (exit) carry none.
+    (let [after-stop (step deep-player (seed [:player :playing :mid-track]) [:stop])
+          r          (machines/machine-transition deep-player after-stop [:play])]
+      (is (result/ok? r))
+      (let [cascade (result/cascade r)
+            entries (filterv #(= :entry (:kind %)) cascade)
+            exits   (filterv #(= :exit (:kind %)) cascade)]
+        (is (seq entries) "the restore produced entry steps")
+        (is (every? #(= :recorded (:source %)) entries)
+            "every history-driven :entry step carries :source :recorded")
+        (is (every? #(not (contains? % :source)) exits)
+            "non-history (:exit) steps carry NO :source key")))))
+
+(deftest non-history-transition-has-no-source-on-steps
+  (testing "an ordinary (non-history) transition stamps NO :source on cascade steps"
+    ;; :seek :at-start→:mid-track is a plain leaf transition — no history.
+    (let [r       (machines/machine-transition
+                    deep-player (seed [:player :playing :at-start]) [:seek])
+          cascade (result/cascade r)]
+      (is (result/ok? r))
+      (is (every? #(not (contains? % :source))
+                  (filterv #(= :entry (:kind %)) cascade))
+          "no :source on entry steps of a non-history transition")
+      (is (empty? (history-events :rf.machine.history/restored))
+          "no restored event for a non-history transition"))))

--- a/implementation/machines/test/re_frame/machine_remediation_ee38b_test.clj
+++ b/implementation/machines/test/re_frame/machine_remediation_ee38b_test.clj
@@ -22,8 +22,10 @@
       (Spec 005 §Trace events).
     - P2 `:rf.error/machine-action-wrote-db` hard-disallow (Spec 005:463).
     - P2 `:rf.machine/update-snapshot` reserved fx (Spec 005:489).
-    - P3 `:history` grammar rejected at registration
-      (`:rf.error/machine-grammar-not-in-v1`, Spec 005:3141).
+    - P3 history grammar placement validated at registration — a
+      `:type :history` node MUST have an owning compound
+      (`:rf.error/machine-history-misplaced`); a well-placed node validates
+      (history is first-class per rf2-mle6e, Spec 005 §History states).
     - P3 `:after` + root-`:on` guard/action ref validation at
       registration (Spec 005:1334)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -223,26 +225,35 @@
       (is (= 1 (count (ops evs :rf.error/machine-action-wrote-db)))
           ":db in the patch surfaces the hard-disallow error"))))
 
-;; ---- P3: :history grammar rejected at registration -------------------------
+;; ---- P3: history grammar placement validated at registration ----------------
+;; History is first-class (rf2-mle6e); the registration validator now enforces
+;; the PLACEMENT constraint — a `:type :history` node MUST have an owning
+;; compound — rather than rejecting history wholesale.
 
-(deftest history-grammar-rejected-at-registration
-  (testing ":type :history and a :history state-node key are rejected with
-   :rf.error/machine-grammar-not-in-v1"
-    (doseq [bad [{:initial :c
-                  :states  {:c {:initial :a :states {:a {} :h {:type :history}}}}}
-                 {:initial :c
-                  :states  {:c {:initial :a :history :shallow :states {:a {}}}}}
-                 {:type :history :initial :a :states {:a {}}}]]
+(deftest history-misplaced-rejected-at-registration
+  (testing "a `:type :history` node with NO owning compound (machine root,
+   or a flat top-level state) is rejected with
+   :rf.error/machine-history-misplaced"
+    (doseq [bad [;; root `:type :history`
+                 {:type :history :initial :a :states {:a {}}}
+                 ;; flat top-level `:type :history` (no enclosing compound)
+                 {:initial :a :states {:a {} :h {:type :history}}}]]
       (let [e (try (machines/validate-machine! bad) nil
                    (catch clojure.lang.ExceptionInfo ex ex))]
-        (is (= :rf.error/machine-grammar-not-in-v1
+        (is (= :rf.error/machine-history-misplaced
                (:rf.error/id (ex-data e)))
             (str "rejected: " (pr-str bad)))
-        (is (= :history (:feature (ex-data e))) ":feature names the offending key")))
-    (testing "a well-formed hierarchical machine validates silently"
-      (is (nil? (machines/validate-machine!
-                  {:initial :p
-                   :states  {:p {:initial :a :states {:a {} :b {}}}}}))))))
+        (is (= :history (:feature (ex-data e))) ":feature names the history grammar"))))
+  (testing "a WELL-PLACED `:type :history` node (inside a compound's :states)
+   validates silently"
+    (is (nil? (machines/validate-machine!
+                {:initial :c
+                 :states  {:c {:initial :a
+                               :states  {:a {} :h {:type :history :deep? true}}}}}))))
+  (testing "a well-formed history-free hierarchical machine validates silently"
+    (is (nil? (machines/validate-machine!
+                {:initial :p
+                 :states  {:p {:initial :a :states {:a {} :b {}}}}})))))
 
 ;; ---- P3: :after + root-`:on` ref validation at registration ----------------
 

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -118,6 +118,12 @@
     :fsm/delayed-after
     :fsm/tags
     :fsm/final-states
+    ;; rf2-mle6e: first-class history pseudo-states (`:type :history` —
+    ;; shallow / deep / default-target). The pure `machine-transition`
+    ;; primitive records on exit + restores on re-entry against the
+    ;; in-snapshot `:rf/history` slot, so history fixtures run in this Mode B
+    ;; gate. The comprehensive record/restore corpus lands under mle6e.4.
+    :fsm/history
     ;; rf2-vf5cf: the registration-error taxonomy (Spec 009 thrown-error
     ;; shape) — pinned by the `:reg-machine` Mode-B op against the pure
     ;; `validate-machine!` validator.

--- a/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
@@ -92,13 +92,16 @@
 
    3. **HISTORY pseudo-states** — SCXML `<history type=\"shallow|deep\">`
       (W3C SCXML §3.10, e.g. test 387, 388, 579, 580 history family).
-      re-frame2 DEFERS `:history` to post-v1 (Spec 005 §Substitutes for
-      skipped features). This is NOT a silent gap: the SCXML history tests
-      become EXPECTED-REJECTION assertions here (§History) — the runtime
-      MUST reject `:type :history` (and the `:history` state-node key) at
-      registration with `:rf.error/machine-grammar-not-in-v1`. Whether to
-      ever support history is a SEPARATE post-v1 decision, out of scope for
-      this corpus.
+      re-frame2 ships FIRST-CLASS history (rf2-mle6e — the post-v1 deferral
+      is withdrawn): `{:type :history :deep? <bool> :default-target <t>}` is
+      a targetable pseudo-state under a compound's `:states`. The §History
+      section below now carries only the registration-time GRAMMAR-CONSTRAINT
+      rejections the engine enforces (a `:type :history` node MUST have an
+      owning compound — `:rf.error/machine-history-misplaced`). The
+      COMPREHENSIVE record/restore conformance corpus (W3C 387/388/579/580
+      adapted) lands under rf2-mle6e.4; this file keeps only the minimal
+      placement-rejection assertions + a smoke that a well-placed history
+      node validates.
 
   ## Divergences found
 
@@ -777,16 +780,17 @@
           "the compound :wrapper ancestor is NOT itself final (leaf-only property)"))))
 
 ;; ===========================================================================
-;; §13. HISTORY — expected-rejection (SCXML §3.10, DEFERRED post-v1)
+;; §13. HISTORY — first-class grammar, placement rejections (SCXML §3.10)
 ;;
 ;; SCXML §3.10 `<history type="shallow|deep">` records and restores the
 ;; most recent active descendant of a compound/parallel state. re-frame2
-;; DEFERS history to post-v1 (Spec 005 §Substitutes for skipped features).
-;; The SCXML history tests (W3C test 387/388/579/580) therefore become
-;; EXPECTED-REJECTION assertions: the registration validator MUST reject
-;; any `:history` grammar with `:rf.error/machine-grammar-not-in-v1`. This
-;; is the auditable record that the omission is INTENTIONAL, not a silent
-;; gap. Whether to ever support history is a separate post-v1 decision.
+;; ships FIRST-CLASS history (rf2-mle6e — the post-v1 deferral is withdrawn):
+;; `{:type :history :deep? <bool> :default-target <t>}` under a compound's
+;; `:states`. The COMPREHENSIVE record/restore conformance corpus (the W3C
+;; 387/388/579/580 record-and-restore behaviour) lands under rf2-mle6e.4;
+;; this section keeps only the registration-time PLACEMENT-CONSTRAINT
+;; rejections the engine enforces (a `:type :history` node MUST have an
+;; owning compound) + a smoke that a well-placed history node validates.
 ;; ===========================================================================
 
 (defn- history-rejection-id
@@ -801,46 +805,66 @@
       (:rf.error/id (ex-data e)))))
 
 (deftest scxml-history-root-type-rejected
-  (testing "SCXML §3.10 history (W3C test 387 shallow / 388 deep): a
-            machine declaring `:type :history` at the root is REJECTED at
-            registration — history is deferred post-v1. Spec 005
-            §Substitutes for skipped features; error
-            `:rf.error/machine-grammar-not-in-v1`."
-    (is (= :rf.error/machine-grammar-not-in-v1
+  (testing "SCXML §3.10: a machine ROOT declaring `:type :history` is
+            rejected — a history pseudo-state must be a child node under a
+            compound's `:states`, never the machine root (no owning
+            compound). Spec 005 §History states §Pseudo-state constraints;
+            error `:rf.error/machine-history-misplaced`."
+    (is (= :rf.error/machine-history-misplaced
            (history-rejection-id {:type :history :states {:s {}}}))
-        "root `:type :history` is rejected with the deferred-grammar error")))
+        "root `:type :history` is rejected with the misplaced-history error")))
 
-(deftest scxml-history-state-node-key-rejected
-  (testing "SCXML §3.10: a `:history` state-node key (the per-state history
-            pseudo-state form) is REJECTED at registration. Spec 005
-            §Substitutes for skipped features."
-    (is (= :rf.error/machine-grammar-not-in-v1
+(deftest scxml-history-no-owning-compound-rejected
+  (testing "SCXML §3.10: a `:type :history` node declared at the FLAT
+            machine top-level (a sibling of ordinary states, with no owning
+            compound) is rejected — history records an enclosing compound's
+            last-active config, so it must live inside that compound's
+            `:states`. Spec 005 §History states §Pseudo-state constraints."
+    (is (= :rf.error/machine-history-misplaced
            (history-rejection-id
              {:initial :a
-              :states  {:a {:history {:type :deep}}}}))
-        "a `:history` state-node key is rejected with the deferred-grammar error")))
+              :states  {:a {}
+                        :h {:type :history}}}))
+        "a top-level `:type :history` with no owning compound is misplaced")))
 
-(deftest scxml-history-region-rejected
-  (testing "SCXML §3.10 + §3.4: a history pseudo-state inside a parallel
-            region (W3C test 579/580 history-in-parallel family) is
-            REJECTED at registration. Spec 005 §Substitutes for skipped
-            features (covers root, every state node, and every region body)."
-    (is (= :rf.error/machine-grammar-not-in-v1
+(deftest scxml-history-region-direct-rejected
+  (testing "SCXML §3.10 + §3.4: a `:type :history` declared DIRECTLY on a
+            parallel region body (no enclosing compound region) is rejected.
+            Per-region history must live inside a compound state within the
+            region (W3C test 579/580 history-in-parallel family). Spec 005
+            §Composition with parallel regions §Pseudo-state constraints."
+    (is (= :rf.error/machine-history-misplaced
            (history-rejection-id
              {:type    :parallel
-              :regions {:r {:initial :a
-                            :states  {:a {}}
-                            :history {:type :shallow}}}}))
-        "history grammar inside a parallel region is rejected")))
+              :regions {:r {:type :history :initial :a :states {:a {}}}}}))
+        "a region body declared `:type :history` is misplaced")))
 
-(deftest scxml-history-free-machine-validates
-  (testing "Control: a history-FREE machine using the supported grammar
-            validates cleanly — confirming the rejection is specific to the
-            `:history` grammar, not a blanket validator failure. Spec 005
-            §Capability matrix (every non-history capability is claimed)."
+(deftest scxml-history-extra-keys-rejected
+  (testing "SCXML §3.10: a `:type :history` pseudo-state declaring keys
+            outside the closed `:type` / `:deep?` / `:default-target` set
+            (it is never occupied — `:on` / `:entry` / `:states` are
+            meaningless) is rejected. Spec 005 §History states §Pseudo-state
+            constraints; error `:rf.error/machine-history-extra-keys`."
+    (is (= :rf.error/machine-history-extra-keys
+           (history-rejection-id
+             {:initial :c
+              :states  {:c {:initial :a
+                            :states  {:a {}
+                                      :h {:type :history :on {:go :a}}}}}}))
+        "a history node declaring `:on` is rejected for extra keys")))
+
+(deftest scxml-history-well-placed-validates
+  (testing "Control + first-class smoke: a `:type :history` node correctly
+            placed inside a compound's `:states` validates cleanly — history
+            is a claimed (`:fsm/history`) capability, not a deferred grammar
+            feature. Spec 005 §History states; W3C 387/388 shape."
     (is (= ::no-throw
            (history-rejection-id
-             {:initial :a
-              :states  {:a {:on {:go :b}}
-                        :b {:final? true}}}))
-        "a well-formed history-free machine validates without error")))
+             {:initial :player
+              :states  {:player {:initial :stopped
+                                 :states  {:stopped {:on {:play [:player :hist]}}
+                                           :hist    {:type :history :deep? true
+                                                     :default-target :playing}
+                                           :playing {:initial :at-start
+                                                     :states {:at-start {}}}}}}}))
+        "a well-placed first-class history pseudo-state validates without error")))

--- a/spec/conformance/fixtures/machine-reg-error-grammar-not-in-v1.edn
+++ b/spec/conformance/fixtures/machine-reg-error-grammar-not-in-v1.edn
@@ -1,49 +1,51 @@
 ;; Conformance fixture: machine/reg-error-grammar-not-in-v1
 ;;
-;; Per [005 §Substitutes for skipped features](../../005-StateMachines.md#substitutes-for-skipped-features)
-;; (005:3141) and [005 §Error category for unclaimed grammar]
-;; (../../005-StateMachines.md): history states remain post-v1. The v1
-;; CLJS reference claims every OTHER capability, so the one grammar key it
-;; must reject is `:history` — a `:type :history` node (root, region, or
-;; nested state) or a `:history` state-node key. Per [009 §Error event
-;; catalogue](../../009-Instrumentation.md) the canonical recovery is
-;; `:no-recovery` — registration is REJECTED.
+;; History is now FIRST-CLASS grammar (rf2-mle6e — the post-v1 deferral is
+;; withdrawn; the engine implements record/restore per
+;; [005 §History states](../../005-StateMachines.md#history-states-type-history--shallow--deep--default-target)).
+;; This fixture is RETAINED under its historical id but re-pinned to the
+;; registration-error taxonomy the first-class grammar enforces: a
+;; `:type :history` pseudo-state MUST have an OWNING COMPOUND — a node at the
+;; machine root (or a flat top-level state) is `:rf.error/machine-history-misplaced`.
+;; The COMPREHENSIVE history record/restore conformance corpus (the
+;; W3C-adapted 387/388/579/580 behaviour) lands under rf2-mle6e.4; this
+;; fixture keeps only the placement-rejection taxonomy + a control that a
+;; WELL-PLACED history node (and a history-free machine) validate silently.
 ;;
 ;; Mode-B `:reg-machine` fixture pinning the registration-error taxonomy
-;; (Spec 009 §The thrown-error shape). The `:rf.error/id` discriminator is
-;; `:rf.error/machine-grammar-not-in-v1`.
+;; (Spec 009 §The thrown-error shape).
 
 {:fixture/id           :machine/reg-error-grammar-not-in-v1
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :fsm/registration-validation}
- :fixture/doc          "A machine using the post-v1 :history grammar (a :type :history node or a :history state-node key, at the root or inside a state / region) is rejected at registration with :rf.error/machine-grammar-not-in-v1. Well-formed flat / hierarchical machines validate silently."
+ :fixture/capabilities #{:fsm/flat :fsm/history :fsm/registration-validation}
+ :fixture/doc          "A :type :history pseudo-state with no owning compound (the machine root, or a flat top-level state) is rejected at registration with :rf.error/machine-history-misplaced. A well-placed history node (inside a compound's :states) and a history-free machine validate silently."
 
  :fixture/registry {}
  :fixture/handlers  {}
 
  :fixture/calls
- [;; (1) A `:type :history` state node — rejected.
-  {:call         :reg-machine
-   :definition   {:initial :compound
-                  :states  {:compound {:initial :a
-                                       :states  {:a {}
-                                                 :hist {:type :history}}}}}
-   :expect-error :rf.error/machine-grammar-not-in-v1}
-
-  ;; (2) A `:history` state-node key (the xstate-style shorthand) — rejected.
-  {:call         :reg-machine
-   :definition   {:initial :compound
-                  :states  {:compound {:initial :a
-                                       :history :shallow
-                                       :states  {:a {}}}}}
-   :expect-error :rf.error/machine-grammar-not-in-v1}
-
-  ;; (3) A `:type :history` machine root — rejected.
+ [;; (1) A `:type :history` machine ROOT — no owning compound — rejected.
   {:call         :reg-machine
    :definition   {:type :history :initial :a :states {:a {}}}
-   :expect-error :rf.error/machine-grammar-not-in-v1}
+   :expect-error :rf.error/machine-history-misplaced}
 
-  ;; (4) Control: a well-formed hierarchical machine validates silently.
+  ;; (2) A `:type :history` node at the FLAT top-level (sibling of ordinary
+  ;; states, no enclosing compound) — rejected.
+  {:call         :reg-machine
+   :definition   {:initial :a
+                  :states  {:a    {}
+                            :hist {:type :history}}}
+   :expect-error :rf.error/machine-history-misplaced}
+
+  ;; (3) Control: a WELL-PLACED `:type :history` node inside a compound's
+  ;; `:states` validates silently — history is a claimed capability.
+  {:call       :reg-machine
+   :definition {:initial :compound
+                :states  {:compound {:initial :a
+                                     :states  {:a    {}
+                                               :hist {:type :history :deep? true}}}}}}
+
+  ;; (4) Control: a well-formed history-free hierarchical machine validates silently.
   {:call       :reg-machine
    :definition {:initial :authenticated
                 :states  {:authenticated {:initial :dashboard

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
@@ -550,23 +550,25 @@
 ;; HISTORY (gap 8, SOON) — the rejection probe + the ready placeholders
 ;; ============================================================================
 
-(deftest history-machine-registration-is-rejected-now
-  (testing "rung #24 (gap 8) — re-frame2 currently REJECTS :history at
-            registration. reg-machine of a :type :history machine THROWS
-            :rf.error/machine-grammar-not-in-v1 (Spec 005 §Substitutes;
-            rf2-rkkag). The deck's history-rejected? helper confirms it. When
-            the feature ships this flips RED and the placeholder rungs (#25/
-            #26) activate."
+(deftest history-machine-misplaced-is-rejected
+  (testing "rung #24 (gap 8) — history is now FIRST-CLASS (rf2-mle6e); the
+            engine implements record/restore. A :type :history pseudo-state
+            still has a PLACEMENT constraint: it MUST have an owning compound.
+            A `:type :history` MACHINE ROOT (the probe spec) is rejected with
+            :rf.error/machine-history-misplaced. NOTE: full live-history-deck
+            rendering + the placeholder rungs (#25/#26) activation are
+            rf2-mle6e.5's job; this harness only confirms the placement
+            rejection still holds for the root probe."
     (let [thrown (try
                    (rf/reg-machine :machine-epochs/history-probe
                                    machines/history-machine-spec)
                    nil
                    (catch :default e e))]
-      (is (some? thrown) "registering a :history machine THROWS today")
-      (is (= :rf.error/machine-grammar-not-in-v1
+      (is (some? thrown) "registering a root :type :history machine THROWS (misplaced)")
+      (is (= :rf.error/machine-history-misplaced
              (:rf.error/id (ex-data thrown)))
-          "the throw is the deferred-grammar error (not a generic validator fail)")
+          "the throw is the misplaced-history placement error (not a generic validator fail)")
       (is (= :history (:feature (ex-data thrown)))
-          ":feature names the offending key"))
+          ":feature names the history grammar"))
     (is (true? (machines/history-rejected?))
-        "the deck's history-rejected? helper agrees the contract still rejects")))
+        "the deck's history-rejected? helper agrees the root probe is still rejected")))

--- a/tools/xray/testbeds/machine_epochs/machines.cljs
+++ b/tools/xray/testbeds/machine_epochs/machines.cljs
@@ -412,24 +412,29 @@
 ;; and the placeholder rungs activate.
 
 (def history-machine-spec
-  "A `:type :history` machine — REJECTED under the v1 deferral. The rejection
-  probe registers it to confirm the deferred-grammar error fires."
+  "A ROOT `:type :history` machine — still rejected, now for PLACEMENT:
+  history is first-class (rf2-mle6e) but a `:type :history` pseudo-state MUST
+  have an owning compound, so a machine root cannot be one. The probe
+  registers it to confirm the misplaced-history error fires. (A WELL-PLACED
+  history machine registers cleanly — wiring the live history deck +
+  placeholder rungs is rf2-mle6e.5's job.)"
   {:type    :history
    :initial :a
    :states  {:a {}}})
 
 (defn history-rejected?
-  "Attempt to register `history-machine-spec` and return true iff it is
-  REJECTED with `:rf.error/machine-grammar-not-in-v1` (the current v1
-  deferral contract). Returns false if it unexpectedly registered (the
-  feature shipped — flip the placeholder rungs), or rethrows a non-history
-  error. The harness asserts this directly via `reg-machine` too."
+  "Attempt to register `history-machine-spec` (a ROOT `:type :history`) and
+  return true iff it is REJECTED with `:rf.error/machine-history-misplaced`
+  (the placement constraint — history is first-class per rf2-mle6e, but a
+  pseudo-state must have an owning compound). Returns false if it
+  unexpectedly registered, or rethrows a non-history error. The harness
+  asserts this directly via `reg-machine` too."
   []
   (try
     (rf/reg-machine :machine-epochs/history-probe history-machine-spec)
     false
     (catch :default e
-      (= :rf.error/machine-grammar-not-in-v1 (:rf.error/id (ex-data e))))))
+      (= :rf.error/machine-history-misplaced (:rf.error/id (ex-data e))))))
 
 ;; ============================================================================
 ;; REGISTRATION


### PR DESCRIPTION
Implements the first-class **history-state ENGINE** in `implementation/machines`, to the normative grammar landed by rf2-mle6e.1 (PR #2863). The post-v1 deferral is withdrawn. Closes **rf2-mle6e.3** and the engine half of **rf2-wgfv0** (dangling-recorded-path fallback).

## Engine (`transition.cljc`)
- **Restore on re-entry** — `compute-cascade-paths` swaps a `:type :history` target for the resolved leaf *before* the LCA geometry, so the standard exit/action/entry cascade runs unchanged (the rf2-46ban resolve-real-path-first precedent). Deep → full recorded leaf; shallow → recorded direct child + `:initial` descent; never-entered → `:default-target` (or compound's `:initial`).
- **Record on exit** — `apply-transition-once` writes each history-bearing compound's last-active config into the in-snapshot `:rf/history` slot at exit-cascade commit. A compound records whenever the exit cascade leaves its current child subtree.
- **Region-qualified keys** — `:rf/history` is keyed by the compound declaration path, region-qualified (head = region name) under `:type :parallel`; threaded through `reduce-regions` like `:data` so per-region recordings never collide and restoring one region leaves siblings untouched.
- **Dangling-path fallback (rf2-wgfv0)** — a recorded config the current definition no longer declares is discarded; restore falls back to `:default-target` / `:initial`, never entering the dead path. Benign — no `:rf.error/*`.
- **Revertibility for free** — `:rf/history` rides the snapshot value (round-trips `pr-str`/`read-string`; reverts with SSR / epoch replay).

## Validation (`validation.cljc`)
Removed the blanket `:rf.error/machine-grammar-not-in-v1` rejection. Validate the pseudo-state shape instead: placement (owning compound), closed `:type`/`:deep?`/`:default-target` key-set, one-per-compound, `:default-target` resolution → `:rf.error/machine-history-{misplaced,extra-keys,duplicate,bad-default-target}`.

## Traces emitted (for rf2-mle6e.2 / .5 alignment)
op-type `:rf.machine` (machine-activity family):
- `:rf.machine.history/restored` — `{:machine-id :region :history-key :resolved-leaf :source (:recorded|:default) :deep? :frame}`
- `:rf.machine.history/recorded` — `{:machine-id :region :history-key :config :deep? :frame}`

The precise spec/009 tag-key catalogue is owned by rf2-mle6e.2 (in flight, disjoint surface); reconcile exact shape at review if .2 differs.

## Keep CI green
Flipped the now-incorrect expected-rejection assertions the behaviour change breaks: SCXML §13 conformance tests, the P3 remediation test, the `machine-reg-error-grammar-not-in-v1` corpus fixture, and the machine_epochs xray harness probe — all to the new placement-rejection taxonomy. Added `:fsm/history` to the machines + core conformance claimed-capability sets. Added a minimal record/restore smoke (`machine_history_smoke_test.clj`). **The comprehensive suite is rf2-mle6e.4's job.**

## Gates (cold)
- `npm run test:cljs` — **0 failures, 0 errors** (5407 tests / 18631 assertions)
- machines JVM `clojure -M:test` — **0 failures, 0 errors** (355 tests / 1157 assertions)
- `npm run test:elision` — **PASS** (production 40/40 absent)

## Out of scope (other beads)
- spec/009 `:rf.machine.history/*` trace contract — rf2-mle6e.2
- comprehensive test suite — rf2-mle6e.4
- xray rendering + live history deck / placeholder rungs — rf2-mle6e.5 (this PR only flips the harness probe's expected error-id)
- docs — rf2-mle6e.6 / .kkut0.8