### PR TITLE
refactor(dx): remove xray/stories/all dev-testbed group aliases (rf2-trlj7)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -262,45 +262,44 @@ harness still falls back if that port is busy too.
 `npm run dev` (`scripts/dev-testbed.cjs`) is the cross-platform launcher
 for the Xray / Story driving surfaces. It seeds `RF2_TESTBED_PROJECT_ROOT`
 (so "open in editor" works on a fresh clone at any path, on any OS) and
-spawns `shadow-cljs watch` for the builds you name. Curated **group
-aliases** (rf2-jooy3) expand a single short name to a whole surface and
-print each watched build's served URL on start:
+spawns `shadow-cljs watch` for the **explicit build-ids you name**,
+printing each watched build's served URL on start:
 
 ```sh
 cd implementation
-npm run dev -- xray       # the 5 Xray driving surfaces
-npm run dev -- stories    # the 4 Story showcases
-npm run dev -- epochs     # the standard / routes / machine epochs trio
-npm run dev -- all        # xray + stories
-# package.json shortcuts (no `--` needed):
-npm run dev:xray
-npm run dev:stories
-```
-
-Anything that is not a group name passes through unchanged, so explicit
-build-ids and extra `shadow-cljs watch` flags keep working, and groups
-may be mixed with explicit builds (the launcher de-dupes builds while
-preserving first-seen order):
-
-```sh
 npm run dev -- :examples/standard-epochs
-npm run dev -- stories :examples/standard-epochs
-npm run dev -- xray --verbose
+npm run dev -- :testbeds/panel-gallery
+# watch a handful at once — keep the count modest (see the note below):
+npm run dev -- :examples/standard-epochs :examples/routes-epochs
+npm run dev -- :examples/login-form --verbose
 ```
 
-| Group | Build id | URL |
-|---|---|---|
-| `xray` | `:examples/standard-epochs` | http://localhost:8031/ |
-| `xray` | `:examples/routes-epochs` | http://localhost:8032/ |
-| `xray` | `:examples/machine-epochs` | http://localhost:8033/ |
-| `xray` | `:examples/two-frame-isolation` | http://localhost:8030/ |
-| `xray` | `:testbeds/panel-gallery` | http://localhost:8765/ |
-| `stories` | `:examples/nine-states-with-stories` | http://localhost:8040/ · `/#/stories` |
-| `stories` | `:examples/login-with-stories` | http://localhost:8041/ · `/#/stories` |
-| `stories` | `:examples/counter-with-stories` | http://localhost:8042/ · `/#/stories` |
-| `stories` | `:examples/login-form` | http://localhost:8043/ · `/#/stories` |
+Name the build(s) you actually want to watch; extra `shadow-cljs watch`
+flags pass straight through, and duplicate build-ids are de-duped while
+preserving first-seen order.
 
-(`epochs` is the first three `xray` rows; `all` is `xray` + `stories`.)
+> **Why explicit build-ids, not a "watch everything" alias?** Each
+> `shadow-cljs watch` build kicks off a Closure externs-prebuild, and
+> several builds compiled simultaneously race on the shared `externs.zip`
+> — intermittent build failures ("Exception parsing externs.zip",
+> "`this.contents` is null"). The old `xray` / `stories` / `all` group
+> aliases fired up to six builds into a single watch and tripped the race
+> reliably on some machines (notably Windows), so they were removed
+> (rf2-trlj7). Watch the build(s) you need; keep any explicit list short.
+
+| Build id | URL |
+|---|---|
+| `:examples/standard-epochs` | http://localhost:8031/ |
+| `:examples/routes-epochs` | http://localhost:8032/ |
+| `:examples/machine-epochs` | http://localhost:8033/ |
+| `:examples/edn-inspector` | http://localhost:8034/ |
+| `:examples/two-frame-isolation` | http://localhost:8030/ |
+| `:testbeds/panel-gallery` | http://localhost:8765/ |
+| `:examples/nine-states-with-stories` | http://localhost:8040/ · `/#/stories` |
+| `:examples/login-with-stories` | http://localhost:8041/ · `/#/stories` |
+| `:examples/counter-with-stories` | http://localhost:8042/ · `/#/stories` |
+| `:examples/login-form` | http://localhost:8043/ · `/#/stories` |
+
 The build→port table mirrors the `:dev-http` map in `shadow-cljs.edn`.
 
 ## Vocabulary — commonly confused public concepts

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -16,8 +16,6 @@
   },
   "scripts": {
     "dev": "node scripts/dev-testbed.cjs",
-    "dev:xray": "node scripts/dev-testbed.cjs xray",
-    "dev:stories": "node scripts/dev-testbed.cjs stories",
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
     "test:security": "shadow-cljs compile node-test-security && node out/node-test-security.js",
     "test:cljs-perf-emit-nightly": "shadow-cljs compile node-test-perf-nightly && node out/node-test-perf-nightly.js",

--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /*
- * `dev` — cross-platform testbed dev launcher (rf2-5dphw; group
- * aliases + URL discoverability per rf2-jooy3).
+ * `dev` — cross-platform testbed dev launcher (rf2-5dphw).
  *
  * Resolves the repo root from THIS script's own location (via node's
  * `path` module, which behaves identically on Windows / macOS / Linux),
@@ -18,28 +17,29 @@
  * therefore works on a fresh clone at any path, on any OS, with no
  * `?project-root=` override needed.
  *
- * GROUP ALIASES (rf2-jooy3). A single CLI arg matching a curated group
- * name expands to that group's build-ids, so "watch the whole Xray
- * surface" or "watch all the Story showcases" is one short command:
- *
- *   npm run dev -- xray       # the 5 Xray driving surfaces
- *   npm run dev -- stories    # the 4 Story showcases
- *   npm run dev -- epochs     # the standard / routes / machine epochs trio
- *   npm run dev -- all        # xray + stories
- *
- * Anything that is NOT a group name passes through UNCHANGED, so explicit
- * build-ids and extra `shadow-cljs watch` flags keep working exactly as
- * before, and groups may be mixed with explicit build-ids / flags:
+ * EXPLICIT BUILD-IDS ONLY (rf2-trlj7). The launcher takes one or more
+ * explicit shadow-cljs build-ids — name the build(s) you actually want to
+ * watch:
  *
  *   npm run dev -- :examples/standard-epochs
  *   npm run dev -- :testbeds/panel-gallery
- *   npm run dev -- stories :examples/standard-epochs
- *   npm run dev -- xray --verbose
+ *   npm run dev -- :examples/standard-epochs :examples/routes-epochs
+ *   npm run dev -- :examples/login-form --verbose
  *
- * After expansion the build list is de-duplicated while PRESERVING first-
- * seen order (so `dev -- stories :examples/login-form` watches each build
- * once). Non-build flags (anything not starting with `:`) pass through in
- * place and are never treated as builds for URL printing.
+ * Group aliases (`xray` / `stories` / `epochs` / `all`) used to expand a
+ * single short name to a whole surface, but a group fired SIX builds into
+ * a single `shadow-cljs watch`, and six concurrent Closure externs-
+ * prebuilds raced on the shared externs.zip — intermittent build failures
+ * ("Exception parsing externs.zip", "this.contents is null"). They were
+ * removed (Mike-ruled 2026-06-03): name explicit build-ids so nobody
+ * accidentally fires a mass-parallel compile. Watch a handful at once by
+ * listing them — keep the count modest to avoid the race.
+ *
+ * Build-ids and extra `shadow-cljs watch` flags pass through unchanged.
+ * Duplicate build-ids are de-duplicated while PRESERVING first-seen order
+ * (so `dev -- :examples/login-form :examples/login-form` watches it once).
+ * Non-build flags (anything not starting with `:`) pass through in place
+ * and are never treated as builds for URL printing.
  *
  * Launching `npx shadow-cljs watch ...` directly still works — the env
  * var is just unset, so the helper falls back to the `?project-root=`
@@ -61,11 +61,11 @@
  * just elements of the args array — they pass through unescaped and
  * unconcatenated, exactly as before.
  *
- * URL DISCOVERABILITY (rf2-jooy3). For every watched build that has a
- * `:dev-http` port, the launcher prints `http://localhost:<port>/` on
- * start (Story builds also print the `/#/stories` shell URL) so "how do
- * I see them" is answered before the compile even finishes. The
- * build->port map below is kept in sync with the `:dev-http` map in
+ * URL DISCOVERABILITY. For every watched build that has a `:dev-http`
+ * port, the launcher prints `http://localhost:<port>/` on start (Story
+ * builds also print the `/#/stories` shell URL) so "how do I see them" is
+ * answered before the compile even finishes. The build->port map below is
+ * kept in sync with the `:dev-http` map in
  * `implementation/shadow-cljs.edn` (READ-only here — shadow-cljs.edn is
  * a hot-zone file).
  */
@@ -74,45 +74,6 @@
 
 const { spawn } = require('child_process');
 const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
-
-// ---------------------------------------------------------------------------
-// Curated group aliases (rf2-jooy3). group-name -> [build-id, ...].
-// Build-ids confirmed against implementation/shadow-cljs.edn :builds.
-// ---------------------------------------------------------------------------
-
-// The six Xray driving surfaces (the _epochs trio + the edn-inspector
-// widget driver + the two-frame isolation surface + the panel gallery).
-const XRAY_BUILDS = [
-  ':examples/standard-epochs',
-  ':examples/routes-epochs',
-  ':examples/machine-epochs',
-  ':examples/edn-inspector',
-  ':examples/two-frame-isolation',
-  ':testbeds/panel-gallery',
-];
-
-// The _epochs trio only (standard / routes / machine).
-const EPOCHS_BUILDS = [
-  ':examples/standard-epochs',
-  ':examples/routes-epochs',
-  ':examples/machine-epochs',
-];
-
-// The four Story showcases (rf2-xz4zn wired their :dev-http ports).
-const STORIES_BUILDS = [
-  ':examples/nine-states-with-stories',
-  ':examples/login-with-stories',
-  ':examples/counter-with-stories',
-  ':examples/login-form',
-];
-
-const GROUPS = {
-  xray: XRAY_BUILDS,
-  stories: STORIES_BUILDS,
-  epochs: EPOCHS_BUILDS,
-  // `all` = xray + stories (deduped in the resolver below).
-  all: [...XRAY_BUILDS, ...STORIES_BUILDS],
-};
 
 // ===========================================================================
 // OWNED-RANGE PORT MAP (rf2-ot0lv). Single source of truth for who-owns-
@@ -164,32 +125,24 @@ const DEV_HTTP = {
 };
 
 /**
- * Expand group aliases in `argv`, de-duplicating builds while preserving
- * first-seen order. Any token that is not a known group name passes
- * through unchanged (explicit build-ids AND extra shadow-cljs flags),
- * but duplicate build-ids (tokens starting with `:`) are dropped. Flags
- * and other non-build tokens are passed through verbatim (never deduped,
- * so e.g. a repeated `--verbose` is the caller's call to make).
+ * De-duplicate build-ids in `argv` while preserving first-seen order.
+ * Tokens pass through unchanged (explicit build-ids AND extra shadow-cljs
+ * flags), but duplicate build-ids (tokens starting with `:`) are dropped.
+ * Flags and other non-build tokens are passed through verbatim (never
+ * deduped, so e.g. a repeated `--verbose` is the caller's call to make).
  *
  * @param {string[]} argv  the raw CLI args (after `node script.cjs`).
- * @returns {string[]}     the expanded, order-preserving, deduped args.
+ * @returns {string[]}     the order-preserving, build-deduped args.
  */
 function resolveArgs(argv) {
   const out = [];
   const seenBuilds = new Set();
-  const push = (token) => {
+  for (const token of argv) {
     if (token.startsWith(':')) {
-      if (seenBuilds.has(token)) return;
+      if (seenBuilds.has(token)) continue;
       seenBuilds.add(token);
     }
     out.push(token);
-  };
-  for (const token of argv) {
-    if (Object.prototype.hasOwnProperty.call(GROUPS, token)) {
-      for (const build of GROUPS[token]) push(build);
-    } else {
-      push(token);
-    }
   }
   return out;
 }
@@ -209,7 +162,7 @@ function urlsForBuild(build) {
   return info.story ? [base, `${base}#/stories`] : [base];
 }
 
-module.exports = { GROUPS, DEV_HTTP, resolveArgs, urlsForBuild };
+module.exports = { DEV_HTTP, resolveArgs, urlsForBuild };
 
 // ---------------------------------------------------------------------------
 // CLI entry-point (skipped when this module is require()'d by a test).
@@ -217,14 +170,12 @@ module.exports = { GROUPS, DEV_HTTP, resolveArgs, urlsForBuild };
 if (require.main === module) {
   const rawArgs = process.argv.slice(2);
   if (rawArgs.length === 0) {
-    const groupList = Object.keys(GROUPS).join(' | ');
     console.error(
-      'Usage: npm run dev -- <group | build> [<build>...] [shadow-cljs flags]\n' +
-        `  groups: ${groupList}\n` +
-        '  e.g. npm run dev -- xray\n' +
-        '       npm run dev -- stories\n' +
-        '       npm run dev -- :examples/standard-epochs\n' +
-        '       npm run dev -- stories :examples/standard-epochs',
+      'Usage: npm run dev -- <build-id> [<build-id>...] [shadow-cljs flags]\n' +
+        '  e.g. npm run dev -- :examples/standard-epochs\n' +
+        '       npm run dev -- :testbeds/panel-gallery\n' +
+        '       npm run dev -- :examples/standard-epochs :examples/routes-epochs\n' +
+        '       npm run dev -- :examples/login-form --verbose',
     );
     process.exit(1);
   }

--- a/implementation/scripts/dev-testbed.test.cjs
+++ b/implementation/scripts/dev-testbed.test.cjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /*
- * Tests for `dev-testbed.cjs` group-alias resolution + URL printing
- * (rf2-jooy3).
+ * Tests for `dev-testbed.cjs` arg resolution + URL printing.
  *
  * Standalone node-runnable suite — no external test framework, mirroring
  * `_path-policy.test.cjs`. Each test logs PASS / FAIL; the process exits
@@ -10,14 +9,17 @@
  *
  * Requiring `dev-testbed.cjs` does NOT spawn shadow-cljs: the CLI body is
  * guarded by `require.main === module`, so importing it here only loads
- * the pure `resolveArgs` / `urlsForBuild` helpers + the GROUPS / DEV_HTTP
- * maps.
+ * the pure `resolveArgs` / `urlsForBuild` helpers + the DEV_HTTP map.
+ *
+ * Group aliases (xray / stories / epochs / all) were removed (rf2-trlj7):
+ * `npm run dev` takes EXPLICIT build-ids only. `resolveArgs` now just
+ * passes tokens through, de-duplicating build-ids in first-seen order.
  */
 
 'use strict';
 
 const assert = require('assert');
-const { GROUPS, DEV_HTTP, resolveArgs, urlsForBuild } = require('./dev-testbed.cjs');
+const { DEV_HTTP, resolveArgs, urlsForBuild } = require('./dev-testbed.cjs');
 
 let failed = 0;
 
@@ -32,77 +34,35 @@ function it(label, f) {
   }
 }
 
-console.log('dev-testbed group-alias tests (rf2-jooy3)');
+console.log('dev-testbed arg-resolution tests (rf2-trlj7)');
 
-it('a group name expands to its build-ids', () => {
-  assert.deepStrictEqual(resolveArgs(['xray']), [
-    ':examples/standard-epochs',
-    ':examples/routes-epochs',
-    ':examples/machine-epochs',
-    ':examples/edn-inspector',
-    ':examples/two-frame-isolation',
-    ':testbeds/panel-gallery',
-  ]);
-  assert.deepStrictEqual(resolveArgs(['stories']), [
-    ':examples/nine-states-with-stories',
-    ':examples/login-with-stories',
-    ':examples/counter-with-stories',
-    ':examples/login-form',
-  ]);
-});
-
-it('the epochs group is the standard/routes/machine trio only', () => {
-  assert.deepStrictEqual(resolveArgs(['epochs']), [
-    ':examples/standard-epochs',
-    ':examples/routes-epochs',
-    ':examples/machine-epochs',
-  ]);
-});
-
-it('the all group is xray + stories, deduped', () => {
-  const expected = [...GROUPS.xray, ...GROUPS.stories];
-  assert.deepStrictEqual(resolveArgs(['all']), expected);
-  // No duplicates survive.
-  assert.strictEqual(new Set(resolveArgs(['all'])).size, resolveArgs(['all']).length);
-});
-
-it('an unknown arg passes through unchanged (back-compat)', () => {
+it('a single explicit build-id passes through unchanged', () => {
   assert.deepStrictEqual(resolveArgs([':examples/standard-epochs']), [
     ':examples/standard-epochs',
   ]);
-  // Extra shadow-cljs flags pass straight through.
+});
+
+it('several explicit build-ids pass through in order', () => {
+  assert.deepStrictEqual(
+    resolveArgs([':examples/standard-epochs', ':examples/routes-epochs']),
+    [':examples/standard-epochs', ':examples/routes-epochs'],
+  );
+});
+
+it('extra shadow-cljs flags pass straight through', () => {
   assert.deepStrictEqual(resolveArgs([':testbeds/panel-gallery', '--verbose']), [
     ':testbeds/panel-gallery',
     '--verbose',
   ]);
 });
 
-it('mixing a group with an explicit build-id works and dedups', () => {
-  // login-form is already in the stories group; the explicit repeat is
-  // dropped, first-seen order preserved.
-  assert.deepStrictEqual(resolveArgs(['stories', ':examples/login-form']), [
-    ':examples/nine-states-with-stories',
-    ':examples/login-with-stories',
-    ':examples/counter-with-stories',
-    ':examples/login-form',
-  ]);
-  // A NOT-yet-present build-id appended after a group is kept, in order.
-  assert.deepStrictEqual(resolveArgs(['stories', ':examples/standard-epochs']), [
-    ':examples/nine-states-with-stories',
-    ':examples/login-with-stories',
-    ':examples/counter-with-stories',
-    ':examples/login-form',
-    ':examples/standard-epochs',
-  ]);
-});
-
-it('preserves first-seen order across two groups (all dedups overlap)', () => {
-  assert.deepStrictEqual(resolveArgs(['xray', 'stories']), resolveArgs(['all']));
-  // Stories-first then xray keeps stories ahead of xray.
-  assert.deepStrictEqual(resolveArgs(['stories', 'xray']), [
-    ...GROUPS.stories,
-    ...GROUPS.xray,
-  ]);
+it('a removed group name is NOT expanded — it passes through as a literal', () => {
+  // Post-removal: `xray` is just a token. It reaches shadow-cljs as an
+  // unknown build-id (which shadow-cljs reports), never a 6-build expansion.
+  assert.deepStrictEqual(resolveArgs(['xray']), ['xray']);
+  assert.deepStrictEqual(resolveArgs(['stories']), ['stories']);
+  assert.deepStrictEqual(resolveArgs(['all']), ['all']);
+  assert.deepStrictEqual(resolveArgs(['epochs']), ['epochs']);
 });
 
 it('duplicate explicit build-ids are deduped, order preserved', () => {
@@ -110,24 +70,21 @@ it('duplicate explicit build-ids are deduped, order preserved', () => {
     resolveArgs([':examples/standard-epochs', ':examples/standard-epochs']),
     [':examples/standard-epochs'],
   );
+  assert.deepStrictEqual(
+    resolveArgs([
+      ':examples/login-form',
+      ':examples/standard-epochs',
+      ':examples/login-form',
+    ]),
+    [':examples/login-form', ':examples/standard-epochs'],
+  );
 });
 
 it('non-build flags are NOT deduped (passed verbatim)', () => {
-  assert.deepStrictEqual(resolveArgs(['xray', '--verbose', '--verbose']), [
-    ...GROUPS.xray,
-    '--verbose',
-    '--verbose',
-  ]);
-});
-
-it('every group build-id has a dev-http port entry', () => {
-  const all = new Set(Object.values(GROUPS).flat());
-  for (const build of all) {
-    assert.ok(
-      Object.prototype.hasOwnProperty.call(DEV_HTTP, build),
-      `${build} should have a DEV_HTTP entry`,
-    );
-  }
+  assert.deepStrictEqual(
+    resolveArgs([':testbeds/panel-gallery', '--verbose', '--verbose']),
+    [':testbeds/panel-gallery', '--verbose', '--verbose'],
+  );
 });
 
 it('urlsForBuild prints the live URL for a plain build', () => {
@@ -153,6 +110,12 @@ it('urlsForBuild prints the live + /#/stories URLs for a Story build', () => {
 it('urlsForBuild returns [] for a build with no dev-http port', () => {
   assert.deepStrictEqual(urlsForBuild(':examples/counter'), []);
   assert.deepStrictEqual(urlsForBuild('--verbose'), []);
+});
+
+it('every DEV_HTTP build-id is a colon-prefixed build coord', () => {
+  for (const build of Object.keys(DEV_HTTP)) {
+    assert.ok(build.startsWith(':'), `${build} should be a :build coord`);
+  }
 });
 
 if (failed > 0) {

--- a/tools/story/README.md
+++ b/tools/story/README.md
@@ -125,24 +125,23 @@ Xray preload is wired — press `Ctrl+Shift+C`).
 | `:examples/counter-with-stories` | 8042 | http://localhost:8042/#/stories | canonical minimal testbed |
 | `:examples/login-form` | 8043 | http://localhost:8043/#/stories | five-state login-form testbed |
 
-A single command brings all four up at once and prints each shell URL
-(via the `stories` group alias in `implementation/scripts/dev-testbed.cjs`,
-rf2-jooy3):
+Name the Story build(s) you want to watch and `npm run dev`
+(`implementation/scripts/dev-testbed.cjs`) prints each shell URL on start
+and seeds `RF2_TESTBED_PROJECT_ROOT` so "open in editor" works:
 
 ```bash
 # from implementation/
-npm run dev -- stories
-# or the package.json shortcut (no `--`):
-npm run dev:stories
+npm run dev -- :examples/login-form
+# watch a couple at once — keep the list short (each build kicks off a
+# Closure externs-prebuild; many at once race on the shared externs.zip):
+npm run dev -- :examples/login-with-stories :examples/counter-with-stories
 ```
 
 Equivalently, the raw watch (no URL printing, no `RF2_TESTBED_PROJECT_ROOT`
 seeding for open-in-editor):
 
 ```bash
-npx shadow-cljs watch :examples/nine-states-with-stories \
-  :examples/login-with-stories \
-  :examples/counter-with-stories :examples/login-form
+npx shadow-cljs watch :examples/login-form
 ```
 
 ## Browser testbed guardrails


### PR DESCRIPTION
## What

Removes the `xray` / `stories` / `epochs` / `all` group aliases from the `npm run dev` testbed launcher. `npm run dev` now takes **explicit build-ids only** (Mike-ruled 2026-06-03, root-caused live).

## Why

`npm run dev -- xray` expanded to a single `shadow-cljs watch` over SIX builds compiled simultaneously. Six concurrent Closure externs-prebuilds raced on the shared `externs.zip`, producing intermittent build failures ("Exception parsing externs.zip", "`this.contents` is null") on a different extern each run. It is a **parallelism race** — not a corrupted jar (all closure jars verified intact) and not a version regression (shadow-cljs 3.4.10 pinned). The group grew to six builds in the 48h before the failures, tipping the latent race into "every time" on some machines (notably Windows).

Mike ruled: remove the group aliases entirely (simpler than staggering/serializing the startup; removes the footgun).

## Changes

- **`implementation/scripts/dev-testbed.cjs`** — removed `XRAY_BUILDS` / `STORIES_BUILDS` / `EPOCHS_BUILDS` / the `all` group + `GROUPS`, the group-name resolution in `resolveArgs` (now a plain build-id dedup passthrough), the GROUP ALIASES header block, and the group-aware usage message. **Kept**: the shell-free spawn (rf2-1ggkn), per-build URL printing, and cross-platform `path`/`REPO_ROOT` handling.
- **`implementation/package.json`** — removed the `dev:xray` / `dev:stories` shortcuts.
- **`implementation/scripts/dev-testbed.test.cjs`** — replaced group-expansion tests with passthrough / dedup / removed-group-is-a-literal coverage.
- **`implementation/README.md`, `tools/story/README.md`** — rewrote the group-alias usage examples to the explicit-build form, with a note explaining why.

## Quality gates

- `npm run test:script-helpers` (incl. `dev-testbed.test.cjs`) — green (47 assertions across helpers; 10 dev-testbed tests pass).
- `resolveArgs` dry-run: `:examples/machine-epochs` → `[":examples/machine-epochs"]` (unchanged); `xray` → `["xray"]` (passes through as a literal — no 6-build expansion; shadow-cljs reports it as an unknown build-id, the intended post-removal behavior).
- No-args usage message prints the explicit-build form.
- `python -m mkdocs build --strict` — pass.
- Scoped repo grep for `npm run dev -- (xray|stories|all|epochs)` / `dev:xray` / `dev:stories` outside `docs/guide` + `.beads` — zero matches.
- No `docs/guide/` references existed (nothing left for the mayor's avb5k lane).

Closes rf2-trlj7. Do not merge — opened per worker protocol.
