### PR TITLE
feat(xray/history): render history restore/record traces in Epoch cascade + Machine Inspector (rf2-mle6e.5)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -966,7 +966,38 @@ Per Spec 005 and Spec 009:
 | `:rf.machine.spawn/spawned` (fx-substrate) · `:rf.machine.lifecycle/spawned` (registrar-substrate) / `:rf.machine/destroyed` · `:rf.machine.lifecycle/destroyed` | Render spawn/destroy lifecycle in the parent's chart. The inspector keys on the `:rf.machine.lifecycle/*` axis for "actor appeared/disappeared" and on the `:rf.machine.spawn/*` / `:rf.machine/*` axis when correlating the causing fx (per [009 §Two-axis machine observation](../../../spec/009-Instrumentation.md#two-axis-machine-observation--registrar-substrate-vs-fx-substrate)). |
 | `:rf.machine/done` | Mark `:final?`-state entry, before the auto-destroy. |
 | `:rf.machine/system-id-bound` / `-released` | Surface `:system-id` reverse-index activity in a sidebar. |
+| `:rf.machine.history/restored` / `:rf.machine.history/recorded` | Render the history restore / record banner + the per-`:entry`-step `:source` chip — see [§History restore rendering](#history-restore-rendering-rf2-mle6e5) below. |
 | Source-coord stamping | Every clickable element jumps to source. |
+
+<!-- ============================================================ -->
+<!--  HISTORY RESTORE RENDERING  (rf2-mle6e.5)                     -->
+<!-- ============================================================ -->
+
+## History restore rendering (rf2-mle6e.5)
+
+History pseudo-states ([Spec 005 §History states](../../../spec/005-StateMachines.md#history-states-type-history--shallow--deep--default-target)) record a compound's last-active configuration on exit and restore it on re-entry. The two activity traces ([Spec 009 §History trace events](../../../spec/009-Instrumentation.md#history-trace-events-rfmachinehistory)) make the record/restore observable; Xray renders them so a viewer reads **why** a re-entry landed where it did rather than only `{from}→{to}`.
+
+A history restore is **not** a separate cascade mechanism — it **is** the entry cascade whose target leaf came from `:rf/history` (Spec 009 §Composition with the entry cascade). So Xray composes the rendering, never duplicates it:
+
+### Where it renders — the EVENT HANDLER machine cascade (Epoch panel)
+
+The history surface rides the **EVENT HANDLER machine cascade** in the Epoch panel (the rf2-52u5n structured-cascade render — see [`021-Dynamic-Panel-Designs.md` §machine-cascade](021-Dynamic-Panel-Designs.md#machine-cascade-rf2-u69j7)), keyed to the macrostep's `:rf.machine/transition` row. Two additive renderings:
+
+1. **The history banner** (above the structured cascade, under the `{from}→{to}` verb + logical-state delta). The Xray-brand-violet (informational, never the error/pink wash — a restore/record is benign observability, op-type `:rf.machine`) banner carries the headline a viewer reads BEFORE walking the per-level entry steps:
+   - **restored** (`⟲`): `restored <compound-path> from <DEEP|SHALLOW> history · <restored-config> → <resolved-leaf>` on the `:recorded` path; `restored <compound-path> from DEFAULT (no recording) via :<fallback> → <resolved-leaf>` on the `:default` path (the compound was never exited, or the recorded path was dangling after a hot reload — Spec 005 §Dangling recorded paths).
+   - **recorded** (`✎`): `history advanced <compound-path> from <prev-config> to <recorded-config>` on an overwrite; `history recorded <compound-path> = <recorded-config>` on the first-ever write (no `:prev-config`).
+
+   A parallel macrostep that restores / records per region renders one banner line per record (the traces are region-qualified by `:compound-path` head segment).
+
+2. **The per-`:entry`-step `:source` chip.** Each structured-cascade `:entry` step produced by a history restore additively carries `:source :recorded | :default` (Spec 009 line 291 — the only addition history makes to the rf2-n9f4z step shape; absent on every non-history step). Xray renders a small chip — **`from history`** (`:recorded`) or **`default`** (`:default`) — on those `:entry` step rows, so the viewer sees WHICH entry steps came from a history restore vs an ordinary `:initial` descent. The chip's `:source` value matches the banner's `:source`; the consumer reads the headline off the banner, then the per-level origin off the `:source`-tagged entry steps without re-deriving either.
+
+### Inspectable `:rf/history` slot
+
+The recorded configuration lives in the snapshot's `:rf/history` slot (`[:rf/runtime :machines :snapshots <id> :rf/history]`), keyed by the compound's region-qualified declaration path. It is an ordinary snapshot slot, so it renders in the **App-db panel** through the standard edn-inspector — a viewer expands the machine's snapshot and reads the recorded config (keyword for shallow, leaf path for deep) the next restore will resolve. No bespoke panel chrome; `:rf/history` is EDN-clean (keywords + vectors-of-keywords) so it round-trips through the inspector like any other slot.
+
+### Data contract
+
+The pure projection (`panels/epoch/projection.cljc`) harvests the two ops with `history-restored-rows` / `history-recorded-rows` and stamps `:history-restored` / `:history-recorded` (keyed by `:machine-id`) onto the `:transition` cascade row via `attach-history-to-transition-rows`. The headline strings come from `panels/epoch/format.cljc` (`history-restored-headline` / `history-recorded-headline`). The focused-event Machine Inspector lens (`panels/machine_inspector_helpers.cljc` `project-focused-event-transitions`) attaches the same records per transition record so the lens surfaces the restore alongside the topology highlight. All are pure-data + JVM-tested.
 
 ## Source-coord integration
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -22,7 +22,8 @@
 
   No DOM, no substrate runtime — display-string builders over already-
   projected row data. JVM-testable via `clojure -M:test`."
-  (:require [day8.re-frame2-xray.panels.epoch.projection :as proj]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]))
 
 (defn format-duration-ms
   "Render a duration in ms as a short string (`0.1ms` / `12ms` /
@@ -265,6 +266,57 @@
     ;; kind-pill + the "staying in {state}" verb (`cascade-row-label`) are
     ;; the whole story; the rf2-ugdas "ignored" chip was a third restatement.
     nil))
+
+(defn history-kind-label
+  "Render a history `:kind` keyword (`:shallow` / `:deep`) as a UI label."
+  [kind]
+  (case kind
+    :shallow "shallow"
+    :deep    "deep"
+    (when (keyword? kind) (name kind))))
+
+(defn history-restored-headline
+  "Render the headline string for a `:rf.machine.history/restored` record
+  (rf2-mle6e.5) — the one-line answer to 'why did this re-entry land HERE?':
+
+    :recorded → 'restored [:player] from DEEP history · [:player :paused] → [:player :paused]'
+    :default  → 'restored [:player] from DEFAULT (no recording) via :default-target → [:player :playing]'
+
+  Reads the spec/009 §`:rf.machine.history/restored` shape:
+  `:compound-path` `:kind` `:source` `:fallback` `:restored-config`
+  `:resolved-leaf`. On `:recorded` the headline shows the recorded config
+  that drove the restore → the concrete resolved leaf; on `:default` (the
+  compound was never exited, or the recorded path was dangling after a hot
+  reload) it names the fallback that resolved the leaf. Pure-data."
+  [{:keys [compound-path kind source fallback restored-config resolved-leaf]}]
+  (let [kind-label (history-kind-label kind)
+        compound   (path-display compound-path)
+        leaf       (pr-str resolved-leaf)]
+    (if (= :default source)
+      (str "restored " compound " from DEFAULT (no recording)"
+           (when fallback (str " via :" (name fallback)))
+           " → " leaf)
+      (str "restored " compound " from "
+           (when kind-label (str (str/upper-case kind-label) " "))
+           "history · " (pr-str restored-config) " → " leaf))))
+
+(defn history-recorded-headline
+  "Render the headline string for a `:rf.machine.history/recorded` record
+  (rf2-mle6e.5) — 'this exit wrote the compound's config into :rf/history':
+
+    first write   → 'history recorded [:player] = [:player :paused]'
+    later write   → 'history advanced [:player] from [:player :playing] to [:player :paused]'
+
+  Reads the spec/009 §`:rf.machine.history/recorded` shape: `:compound-path`
+  `:kind` `:recorded-config` `:prev-config` (absent on the first-ever write).
+  Pure-data."
+  [{:keys [compound-path recorded-config prev-config]}]
+  (let [compound (path-display compound-path)]
+    (if (some? prev-config)
+      (str "history advanced " compound
+           " from " (pr-str prev-config)
+           " to " (pr-str recorded-config))
+      (str "history recorded " compound " = " (pr-str recorded-config)))))
 
 (defn handler-flavour-label
   "Human-readable label for a handler flavour keyword."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -761,6 +761,109 @@
     :rf.machine.event/unhandled-no-op (no-op-cascade-row ev)
     nil))
 
+;; ---- history restore / record (rf2-mle6e.5) -----------------------------
+;;
+;; History pseudo-states (Spec 005 §History states) record a compound's
+;; last-active configuration on exit and restore it on re-entry. Spec 009
+;; §History trace events makes the record/restore observable with two
+;; activity traces (op-type `:rf.machine`, NOT severity discriminators —
+;; benign observability, never wash a cascade pink):
+;;
+;;   :rf.machine.history/restored — a transition targeted a `:type :history`
+;;     pseudo-state and re-entry resolved the recorded (or default) config to
+;;     a concrete leaf. Tags: `:compound-path` `:kind` (`:shallow`/`:deep`)
+;;     `:source` (`:recorded`/`:default`) `:fallback` (only on `:default`)
+;;     `:restored-config` (absent on `:default`) `:resolved-leaf`.
+;;   :rf.machine.history/recorded — a history-bearing compound's exit wrote
+;;     the config into `:rf/history`. Tags: `:compound-path` `:kind`
+;;     `:recorded-config` `:prev-config` (absent on the first-ever write).
+;;
+;; These do NOT join `machine-cascade-trace-ops` (they are not exit/action/
+;; entry/timer/no-op cascade ROWS — a restore IS the entry cascade, whose
+;; per-level `:entry` steps already carry the additive `:source` field per
+;; Spec 009 line 291). Instead they ENRICH the macrostep's `:transition`
+;; cascade row, so the view reads "restored <compound> from <source>" off the
+;; headline rather than re-folding the trace stream. They share the cascade's
+;; `:rf.trace/dispatch-id` with the transition; the projection keys them to a
+;; transition row by `:machine-id` (one transition per machine per macrostep,
+;; per Spec 005 §Trace events).
+
+(defn history-restored-rows
+  "Project every `:rf.machine.history/restored` trace event in `events`
+  into a vector of history-restore records (rf2-mle6e.5), trace order
+  preserved. Each record:
+
+      {:machine-id      <kw>
+       :compound-path   [<kw> …]   ;; the `:rf/history` key (declaration path)
+       :kind            :shallow | :deep
+       :source          :recorded | :default
+       :fallback        :default-target | :initial | nil  ;; only on :default
+       :restored-config [<kw> …] | <kw> | nil             ;; nil on :default
+       :resolved-leaf   [<kw> …]}                          ;; the entered leaf
+
+  Returns `[]` when no restore fired (the common non-history macrostep)."
+  [events]
+  (->> events
+       (filter (fn [ev] (= :rf.machine.history/restored (op ev))))
+       (mapv (fn [ev]
+               {:machine-id      (common/tag-of ev :machine-id)
+                :compound-path   (common/tag-of ev :compound-path)
+                :kind            (common/tag-of ev :kind)
+                :source          (common/tag-of ev :source)
+                :fallback        (common/tag-of ev :fallback)
+                :restored-config (common/tag-of ev :restored-config)
+                :resolved-leaf   (common/tag-of ev :resolved-leaf)}))))
+
+(defn history-recorded-rows
+  "Project every `:rf.machine.history/recorded` trace event in `events`
+  into a vector of history-record records (rf2-mle6e.5), trace order
+  preserved. Each record:
+
+      {:machine-id      <kw>
+       :compound-path   [<kw> …]   ;; the `:rf/history` key
+       :kind            :shallow | :deep
+       :recorded-config [<kw> …] | <kw>   ;; the value written
+       :prev-config     [<kw> …] | <kw> | nil}  ;; nil on first-ever write
+
+  Returns `[]` when no recording fired."
+  [events]
+  (->> events
+       (filter (fn [ev] (= :rf.machine.history/recorded (op ev))))
+       (mapv (fn [ev]
+               {:machine-id      (common/tag-of ev :machine-id)
+                :compound-path   (common/tag-of ev :compound-path)
+                :kind            (common/tag-of ev :kind)
+                :recorded-config (common/tag-of ev :recorded-config)
+                :prev-config     (common/tag-of ev :prev-config)}))))
+
+(defn- attach-history-to-transition-rows
+  "Stamp the history restore / record records (keyed by `:machine-id`)
+  onto each `:transition` cascade row (rf2-mle6e.5). A transition row that
+  resolved a history pseudo-state carries `:history-restored [<record> …]`;
+  one whose macrostep exited a history-bearing compound carries
+  `:history-recorded [<record> …]`. Non-history transition rows carry
+  neither key, so the view's history banner is absent for ordinary
+  transitions. Both vectors are dropped when empty so `(seq …)` reads as
+  the view's render gate.
+
+  Keying by `:machine-id` is correct because the substrate fires exactly
+  one `:rf.machine/transition` per machine per macrostep (Spec 005
+  §Trace events) — every restore / record in the window belongs to the
+  one transition that machine took."
+  [rows restored recorded]
+  (let [by-mid     (fn [recs] (group-by :machine-id recs))
+        restored-m (by-mid restored)
+        recorded-m (by-mid recorded)]
+    (mapv (fn [row]
+            (if (= :transition (:kind row))
+              (let [r (get restored-m (:machine-id row))
+                    w (get recorded-m (:machine-id row))]
+                (cond-> row
+                  (seq r) (assoc :history-restored (vec r))
+                  (seq w) (assoc :history-recorded (vec w))))
+              row))
+          rows)))
+
 ;; ---- inline-fn source-path enrichment (rf2-wwc3j) ----------------------
 ;;
 ;; Cascade rows arriving from the substrate carry no `:state-id` / `:event-id`
@@ -1029,6 +1132,15 @@
                            (filter (fn [ev] (contains? machine-cascade-trace-ops (op ev)))
                                    events))))
         enriched (enrich-cascade-rows base)
+        ;; rf2-mle6e.5 — stamp history restore / record records onto the
+        ;; `:transition` rows so the view's history banner reads "restored
+        ;; <compound> from <source>" / "history advanced <prev> → <recorded>"
+        ;; off the headline. Order-independent (keyed by machine-id), runs
+        ;; on the trace-ordered rows before the canonical sort.
+        enriched (attach-history-to-transition-rows
+                   enriched
+                   (history-restored-rows events)
+                   (history-recorded-rows events))
         ;; rf2-e6q97 — a no-op cascade carries both the `:no-op` row AND the
         ;; substrate's unconditional `{X}→{X}` 0-microstep `:transition` row;
         ;; the two contradict. Drop the spurious transition row (the `:no-op`

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -640,6 +640,51 @@
    :color       (badge/cascade-kind-colour :transition)
    :margin-bottom "1px"})
 
+;; rf2-mle6e.5 — HISTORY restore / record banner. A history restore/record is
+;; benign observability (Spec 009 §History trace events — op-type :rf.machine,
+;; never a severity discriminator), so the banner is the Xray brand-violet
+;; accent (informational), NOT the error / pink wash. It sits ABOVE the
+;; structured cascade so the operator reads "restored <compound> from <source>"
+;; before walking the per-level entry steps (the `:source`-tagged ones below).
+(def ^:private structured-cascade-history-banner-style
+  {:display        "flex"
+   :flex-direction "column"
+   :gap            "2px"
+   :margin         "4px 0 2px 0"
+   :padding        "4px 8px"
+   :border-left    (str "2px solid " accent-colour)
+   :background     bg-2-colour
+   :border-radius  "3px"})
+
+(def ^:private structured-cascade-history-line-style
+  {:font-family mono-stack
+   :font-size   "11px"
+   :color       accent-colour
+   :display     "flex"
+   :align-items "baseline"
+   :gap         "5px"})
+
+(def ^:private structured-cascade-history-glyph-style
+  {:font-weight 700
+   :min-width   "12px"
+   :text-align  "center"})
+
+;; The per-`:entry`-step history origin chip — `from history` (recorded) or
+;; `default` (the compound was never exited / dangling). Marks WHICH entry
+;; steps in the cascade came from a restore vs an ordinary :initial descent
+;; (Spec 009 line 291 — the additive cascade-step :source field).
+(def ^:private structured-cascade-step-source-chip-style
+  {:font-family    mono-stack
+   :font-size      "9px"
+   :font-weight    700
+   :letter-spacing "0.03em"
+   :margin-left    "4px"
+   :padding        "0 4px"
+   :border-radius  "3px"
+   :border         (str "1px solid " accent-colour)
+   :color          accent-colour
+   :white-space    "nowrap"})
+
 ;; rf2-4yrr6 — `cascade-detail-threw-row-style` / `cascade-threw-glyph-style`
 ;; / `cascade-threw-label-style` / `cascade-threw-message-style` RETIRED with
 ;; the per-action "✗ threw — <message>" detail line (the duplicate threw
@@ -2689,19 +2734,33 @@
     boundaries — e.g. exiting `:idle`);
   - the `:data-delta` (changed `:data` keys only) renders inline through
     the edn-inspector when non-empty, so the operator sees exactly what
-    that step contributed without expanding the whole snapshot."
-  [testid-prefix idx {:keys [kind state action data-delta]}]
+    that step contributed without expanding the whole snapshot;
+  - rf2-mle6e.5 — a HISTORY-driven `:entry` step additively carries
+    `:source :recorded | :default` (Spec 009 line 291); a small chip
+    (`from history` / `default`) marks it so the viewer sees WHICH entry
+    steps came from a history restore vs an ordinary `:initial` descent.
+    Absent on every non-history step (no chip rendered)."
+  [testid-prefix idx {:keys [kind state action data-delta source]}]
   (let [glyph (get structured-cascade-kind->glyph kind "·")
         tone  (get structured-cascade-kind->tone kind text-secondary-colour)]
     [:div {:key         (str testid-prefix "-step-" idx)
            :data-testid (str testid-prefix "-step-" idx)
            :data-cascade-step-kind (when (keyword? kind) (name kind))
+           :data-cascade-step-source (when (keyword? source) (name source))
            :style       structured-cascade-step-row-style}
      [:span {:aria-hidden true
              :style (assoc structured-cascade-kind-glyph-style :color tone)}
       glyph]
      [:span {:style structured-cascade-state-style}
       (pr-str state)]
+     ;; rf2-mle6e.5 — the additive history `:source` on an :entry step.
+     (when (and (= :entry kind) (keyword? source))
+       [:span {:data-testid (str testid-prefix "-step-" idx "-source")
+               :title (if (= :recorded source)
+                        "this leaf came from the recorded history config"
+                        "this leaf came from the :default-target / :initial fallback")
+               :style structured-cascade-step-source-chip-style}
+        (if (= :recorded source) "from history" "default")])
      (if (some? action)
        [:span {:data-testid (str testid-prefix "-step-" idx "-action")
                :style structured-cascade-action-chip-style}
@@ -2734,6 +2793,42 @@
              (structured-cascade-step-row
                (str testid-prefix "-microstep-" microstep-index) i step))
            (filterv #(contains? #{:exit :action :entry} (:kind %)) steps)))])
+
+(defn- structured-cascade-history-banner
+  "Render the HISTORY restore / record banner for a `:transition` cascade row
+  (rf2-mle6e.5). Surfaces the headline the operator reads BEFORE walking the
+  per-level entry steps:
+
+    ⟲  restored [:player] from DEEP history · [:player :paused] → [:player :paused]
+    ✎  history advanced [:player] from [:player :playing] to [:player :paused]
+
+  `:history-restored` (a re-entry resolved a history pseudo-state) and
+  `:history-recorded` (this exit wrote the compound's config) are stamped on
+  the transition row by `projection/attach-history-to-transition-rows` off the
+  `:rf.machine.history/restored` / `-recorded` traces (Spec 009 §History trace
+  events). Both are vectors (a parallel macrostep may restore / record per
+  region). Returns nil when the row carries neither key — the ordinary
+  (non-history) transition renders no banner."
+  [{:keys [step history-restored history-recorded] :as _row}]
+  (when (or (seq history-restored) (seq history-recorded))
+    [:div {:data-testid (str "rf-xray-epoch-machine-cascade-history-" step)
+           :style structured-cascade-history-banner-style}
+     (map-indexed
+       (fn [i rec]
+         ^{:key (str "restored-" i)}
+         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-history-" step "-restored-" i)
+                :style structured-cascade-history-line-style}
+          [:span {:aria-hidden true :style structured-cascade-history-glyph-style} "⟲"]
+          [:span (fmt/history-restored-headline rec)]])
+       history-restored)
+     (map-indexed
+       (fn [i rec]
+         ^{:key (str "recorded-" i)}
+         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-history-" step "-recorded-" i)
+                :style structured-cascade-history-line-style}
+          [:span {:aria-hidden true :style structured-cascade-history-glyph-style} "✎"]
+          [:span (fmt/history-recorded-headline rec)]])
+       history-recorded)]))
 
 (defn- structured-cascade-body
   "Render the STRUCTURED transition cascade (rf2-52u5n) for a `:transition`
@@ -2824,11 +2919,13 @@
     ;; alone when the trace carried no structured `:cascade`.
     (= :transition (:kind row))
     (let [delta      (cascade-row-transition-delta row)
+          history    (structured-cascade-history-banner row)
           structured (structured-cascade-body row)]
-      (when (or delta structured)
+      (when (or delta history structured)
         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-transition-body-"
                                  (:step row))}
          delta
+         history
          structured]))
 
     (contains? #{:action :guard} (:kind row))

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -570,6 +570,60 @@
       (seq guards)  (assoc :guards guards)
       (seq actions) (assoc :actions actions))))
 
+;; ---- history restore / record (rf2-mle6e.5) -----------------------------
+;;
+;; Per Spec 009 §History trace events, a transition that resolves a history
+;; pseudo-state emits `:rf.machine.history/restored`; the exit that wrote a
+;; history-bearing compound's config emits `:rf.machine.history/recorded`.
+;; Both share the cascade's `:rf.trace/dispatch-id` with the macrostep's
+;; `:rf.machine/transition` and carry `:machine-id`. The focused-event lens
+;; surfaces them on the per-machine transition record so the Machine
+;; Inspector renders WHY a re-entry landed where it did — distinguishing a
+;; history restore from an ordinary descent (spec/003 §Machine-Inspector).
+
+(def history-restored-operation :rf.machine.history/restored)
+(def history-recorded-operation :rf.machine.history/recorded)
+
+(defn- history-restored-record [ev]
+  (let [tags (get ev :tags {})]
+    {:compound-path   (:compound-path tags)
+     :kind            (:kind tags)
+     :source          (:source tags)
+     :fallback        (:fallback tags)
+     :restored-config (:restored-config tags)
+     :resolved-leaf   (:resolved-leaf tags)}))
+
+(defn- history-recorded-record [ev]
+  (let [tags (get ev :tags {})]
+    {:compound-path   (:compound-path tags)
+     :kind            (:kind tags)
+     :recorded-config (:recorded-config tags)
+     :prev-config     (:prev-config tags)}))
+
+(defn- attach-history
+  "Attach the history restore / record records for `transition-record`'s
+  machine (keyed by `:machine-id`) off the cascade-window `events`
+  (rf2-mle6e.5). A transition that resolved a history pseudo-state carries
+  `:history-restored [<record> …]`; one whose macrostep exited a
+  history-bearing compound carries `:history-recorded [<record> …]`. Neither
+  key is present on an ordinary (non-history) transition, so the inspector's
+  history surface is absent for those."
+  [transition-record events]
+  (let [mid      (:machine-id transition-record)
+        restored (->> events
+                      (filter (fn [ev]
+                                (and (= history-restored-operation (:operation ev))
+                                     (= mid (machine-id-of ev)))))
+                      (mapv history-restored-record))
+        recorded (->> events
+                      (filter (fn [ev]
+                                (and (= history-recorded-operation (:operation ev))
+                                     (= mid (machine-id-of ev)))))
+                      (mapv history-recorded-record))]
+    (cond-> transition-record
+      (seq restored) (assoc :history-restored restored)
+      (seq recorded) (assoc :history-recorded recorded))))
+
 (defn project-focused-event-transitions
   "Project the focused epoch's cascade window into a vector of
   per-machine-transition records the Machines panel's focused-event
@@ -602,7 +656,11 @@
        :microstep?   <bool>
        :definition   <machine-def-or-nil>
        :guards       [<guard-record>...]
-       :actions      [<action-record>...]}
+       :actions      [<action-record>...]
+       :history-restored [<restore-record>...]  ;; rf2-mle6e.5, only when a
+                                                 ;; history pseudo-state resolved
+       :history-recorded [<record-record>...]}  ;; rf2-mle6e.5, only when a
+                                                 ;; history-bearing compound exited
 
   Returns `[]` when no machine-transition trace fired in the cascade —
   the silent-by-default branch the view honours per rf2-g3ghh.
@@ -622,7 +680,9 @@
                  (let [base (transition-record-from-trace ev)
                        mid  (:machine-id base)
                        defn-> (get defs mid)]
-                   (cond-> (attach-guards-and-actions base events)
+                   (cond-> (-> base
+                               (attach-guards-and-actions events)
+                               (attach-history events))
                      defn-> (assoc :definition defn->)))))
           ;; Drop records whose machine-id couldn't be resolved — a
           ;; malformed trace shouldn't surface a section with no

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
@@ -79,7 +79,7 @@
   (preload/register-trace-collector!)
   (machines/register-all!)
   (doseq [id [:door/main :traffic/light :quiz/scorer :brew/machine
-              :session/flow :hvac/controller]]
+              :session/flow :hvac/controller :media/deep :media/shallow]]
     (rf/dispatch-sync [id [:rf.machine/bootstrap]])))
 
 (defn- snapshot [machine-id]
@@ -547,18 +547,15 @@
     (is (= :on (:fan (:state (snapshot :hvac/controller)))))))
 
 ;; ============================================================================
-;; HISTORY (gap 8, SOON) — the rejection probe + the ready placeholders
+;; HISTORY (gap 8, LIVE) — placement rejection + shallow + deep RESTORE render
 ;; ============================================================================
 
 (deftest history-machine-misplaced-is-rejected
-  (testing "rung #24 (gap 8) — history is now FIRST-CLASS (rf2-mle6e); the
-            engine implements record/restore. A :type :history pseudo-state
-            still has a PLACEMENT constraint: it MUST have an owning compound.
-            A `:type :history` MACHINE ROOT (the probe spec) is rejected with
-            :rf.error/machine-history-misplaced. NOTE: full live-history-deck
-            rendering + the placeholder rungs (#25/#26) activation are
-            rf2-mle6e.5's job; this harness only confirms the placement
-            rejection still holds for the root probe."
+  (testing "rung #24 (gap 8) — history is FIRST-CLASS (rf2-mle6e); the engine
+            implements record/restore. A :type :history pseudo-state still has
+            a PLACEMENT constraint: it MUST have an owning compound. A
+            `:type :history` MACHINE ROOT (the probe spec) is rejected with
+            :rf.error/machine-history-misplaced."
     (let [thrown (try
                    (rf/reg-machine :machine-epochs/history-probe
                                    machines/history-machine-spec)
@@ -572,3 +569,95 @@
           ":feature names the history grammar"))
     (is (true? (machines/history-rejected?))
         "the deck's history-rejected? helper agrees the root probe is still rejected")))
+
+;; The eject/restore dance the deck's #25/#26 rungs drive — positions the
+;; player deep, ejects (records), and returns the FINAL :insert's drive!
+;; record (the restore whose cascade the Epoch panel renders).
+(defn- drive-history-restore!
+  "Position `machine-id` deep into :player, eject (record), then drive + return
+  the FINAL :insert (the restore). Mirrors `history-restore-fx` in the deck."
+  [machine-id]
+  (drive! machine-id [:insert])   ; first entry → default
+  (drive! machine-id [:seek])     ; :at-start → :mid-track (deep leaf)
+  (drive! machine-id [:eject])    ; exit :player → :tray (RECORDS)
+  (drive! machine-id [:insert]))  ; re-enter via :hist (RESTORES — the focal cascade)
+
+(deftest history-deep-restore-renders-restored-banner-and-source-steps
+  (testing "rung #26 (gap 8, rf2-mle6e.5) — :media/deep eject → re-insert
+            RESTORES the exact recorded leaf. (a) a :rf.machine.history/restored
+            trace fires with :source :recorded + :kind :deep; (b) the projection
+            stamps :history-restored on the transition row + every history-driven
+            :entry cascade step carries :source :recorded; (c) the player lands
+            at the exact recorded deep leaf."
+    (setup!)
+    (let [record    (drive-history-restore! :media/deep)
+          rows      (cascade record)
+          tx        (first (rows-of-kind rows :transition))
+          restored  (proj/history-restored-rows (:trace-events record))
+          structured (structured-of record)
+          entries   (filterv #(= :entry (:kind %)) structured)]
+      ;; (a) the trace shape.
+      (is (= 1 (count restored)) "(a) exactly one history-restored record")
+      (is (= :recorded (:source (first restored))) "(a) restored from the RECORDED config")
+      (is (= :deep (:kind (first restored))) "(a) deep history")
+      (is (= [:player :playing :mid-track] (:restored-config (first restored)))
+          "(a) the recorded config that drove the restore is the exact deep leaf")
+      (is (= [:player :playing :mid-track] (:resolved-leaf (first restored)))
+          "(a) deep restore resolved to the exact recorded leaf")
+      ;; (b) the projection enrichment + cascade-step :source.
+      (is (seq (:history-restored tx))
+          "(b) the transition row carries :history-restored (the banner gate)")
+      (is (seq entries) "(b) the restore produced entry cascade steps")
+      (is (some #(= :recorded (:source %)) entries)
+          "(b) at least one history-driven :entry step carries :source :recorded")
+      ;; (c) the live machine landed at the exact recorded leaf.
+      (is (= [:player :playing :mid-track] (:state (snapshot :media/deep)))
+          "(c) deep history restored the exact leaf, not :initial"))))
+
+(deftest history-shallow-restore-renders-restored-banner-shallow
+  (testing "rung #25 (gap 8, rf2-mle6e.5) — :media/shallow eject → re-insert
+            restores the recorded DIRECT CHILD then descends its :initial. (a)
+            the restored record is :source :recorded + :kind :shallow with the
+            child-keyword :restored-config; (b) the transition row carries
+            :history-restored; (c) the player lands at the child's :initial,
+            NOT the exact exit leaf."
+    (setup!)
+    (let [record   (drive-history-restore! :media/shallow)
+          rows     (cascade record)
+          tx       (first (rows-of-kind rows :transition))
+          restored (proj/history-restored-rows (:trace-events record))]
+      (is (= 1 (count restored)) "(a) one history-restored record")
+      (is (= :recorded (:source (first restored))) "(a) restored from the recorded config")
+      (is (= :shallow (:kind (first restored))) "(a) SHALLOW history")
+      (is (= :playing (:restored-config (first restored)))
+          "(a) shallow records + restores the direct-child keyword (:playing)")
+      (is (= [:player :playing :at-start] (:resolved-leaf (first restored)))
+          "(a) shallow restore descends the child's :initial chain")
+      (is (seq (:history-restored tx)) "(b) the transition row carries :history-restored")
+      (is (= [:player :playing :at-start] (:state (snapshot :media/shallow)))
+          "(c) shallow restored the child then its :initial, not the exit leaf"))))
+
+(deftest history-eject-records-and-renders-recorded-banner
+  (testing "gap 8 (rf2-mle6e.5) — ejecting :player (exit to the off-compound
+            :tray) WRITES :player's last config into :rf/history. (a) a
+            :rf.machine.history/recorded trace fires; (b) the projection stamps
+            :history-recorded on the EJECT transition row; (c) the snapshot's
+            inspectable :rf/history slot holds the recorded leaf."
+    (setup!)
+    (drive! :media/deep [:insert])               ; → default :playing :at-start
+    (drive! :media/deep [:seek])                 ; → :mid-track (deep leaf)
+    (let [record   (drive! :media/deep [:eject])  ; exit :player → :tray (RECORDS)
+          rows     (cascade record)
+          tx       (first (rows-of-kind rows :transition))
+          recorded (proj/history-recorded-rows (:trace-events record))]
+      (is (= 1 (count recorded)) "(a) exactly one history-recorded record")
+      (is (= [:player] (:compound-path (first recorded)))
+          "(a) recorded under the compound's declaration path (the :rf/history key)")
+      (is (= [:player :playing :mid-track] (:recorded-config (first recorded)))
+          "(a) deep recording wrote the full exit leaf")
+      (is (seq (:history-recorded tx))
+          "(b) the eject transition row carries :history-recorded (the banner gate)")
+      ;; (c) the inspectable :rf/history snapshot slot.
+      (is (= [:player :playing :mid-track]
+             (get-in (snapshot :media/deep) [:rf/history [:player]]))
+          "(c) the snapshot's :rf/history slot holds the recorded leaf (App-db inspectable)"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -78,6 +78,8 @@
 (def ^:private machine-timer-cancel-ev teb/machine-timer-cancel-ev)
 (def ^:private machine-unhandled-no-op-ev teb/machine-unhandled-no-op-ev)
 (def ^:private machine-action-exception-ev teb/machine-action-exception-ev)
+(def ^:private machine-history-restored-ev  teb/machine-history-restored-ev)
+(def ^:private machine-history-recorded-ev  teb/machine-history-recorded-ev)
 (def ^:private schema-violation-ev     teb/schema-violation-ev)
 (def ^:private schema-hot-reload-ev    teb/schema-hot-reload-ev)
 (def ^:private handler-exception-ev    teb/handler-exception-ev)
@@ -3410,3 +3412,110 @@
 (deftest interceptor-badge-in-badge-set-test
   (testing "rf2-yz57h — :INTERCEPTOR is a valid badge"
     (is (proj/valid-badge? :INTERCEPTOR))))
+
+;; ============================================================================
+;; HISTORY restore / record projection (rf2-mle6e.5, spec/009 §History trace)
+;; ============================================================================
+
+(deftest history-restored-rows-recorded-source-test
+  (testing "rf2-mle6e.5 — `:rf.machine.history/restored` (source :recorded)
+            projects to a restore record carrying the full spec/009 tag bag"
+    (let [evs  [(machine-history-restored-ev
+                  {:machine-id :media/deep :compound-path [:player] :kind :deep
+                   :source :recorded :restored-config [:player :playing :mid-track]
+                   :resolved-leaf [:player :playing :mid-track]})]
+          rows (proj/history-restored-rows evs)
+          r    (first rows)]
+      (is (= 1 (count rows)))
+      (is (= :media/deep (:machine-id r)))
+      (is (= [:player] (:compound-path r)))
+      (is (= :deep (:kind r)))
+      (is (= :recorded (:source r)))
+      (is (= [:player :playing :mid-track] (:restored-config r)))
+      (is (= [:player :playing :mid-track] (:resolved-leaf r)))
+      (is (nil? (:fallback r)) ":fallback absent on the :recorded path"))))
+
+(deftest history-restored-rows-default-source-test
+  (testing "rf2-mle6e.5 — the :default path carries :fallback + nil :restored-config"
+    (let [r (first (proj/history-restored-rows
+                     [(machine-history-restored-ev
+                        {:machine-id :media/deep :compound-path [:player] :kind :deep
+                         :source :default :fallback :default-target
+                         :resolved-leaf [:player :playing :at-start]})]))]
+      (is (= :default (:source r)))
+      (is (= :default-target (:fallback r)))
+      (is (nil? (:restored-config r)) "nothing recorded ⇒ no :restored-config"))))
+
+(deftest history-recorded-rows-test
+  (testing "rf2-mle6e.5 — `:rf.machine.history/recorded` projects to a record
+            with :prev-config present only on an overwrite"
+    (let [first-write (first (proj/history-recorded-rows
+                               [(machine-history-recorded-ev
+                                  {:machine-id :media/deep :compound-path [:player]
+                                   :kind :deep :recorded-config [:player :playing :mid-track]
+                                   :prev-config nil})]))
+          overwrite   (first (proj/history-recorded-rows
+                               [(machine-history-recorded-ev
+                                  {:machine-id :media/deep :compound-path [:player]
+                                   :kind :deep :recorded-config [:player :paused]
+                                   :prev-config [:player :playing :mid-track]})]))]
+      (is (= [:player :playing :mid-track] (:recorded-config first-write)))
+      (is (nil? (:prev-config first-write)) ":prev-config absent on first-ever write")
+      (is (= [:player :playing :mid-track] (:prev-config overwrite))
+          ":prev-config = the overwritten value"))))
+
+(deftest machine-cascade-rows-stamps-history-on-transition-test
+  (testing "rf2-mle6e.5 — `machine-cascade-rows` stamps :history-restored /
+            :history-recorded (keyed by machine-id) onto the :transition row,
+            and an ORDINARY transition carries neither key"
+    (let [before  {:state [:player :stopped] :data {}}
+          after   {:state [:player :playing :mid-track] :data {}}
+          evs     [(machine-transition-ev :media/deep before after [:insert] 0)
+                   (machine-history-restored-ev
+                     {:machine-id :media/deep :compound-path [:player] :kind :deep
+                      :source :recorded :restored-config [:player :playing :mid-track]
+                      :resolved-leaf [:player :playing :mid-track]})]
+          tx      (first (filterv #(= :transition (:kind %))
+                                  (proj/machine-cascade-rows evs)))]
+      (is (seq (:history-restored tx)) "the restore record is stamped on the transition row")
+      (is (= :recorded (:source (first (:history-restored tx))))))
+    ;; the foil — a non-history transition carries no history keys.
+    (let [ordinary (first (filterv #(= :transition (:kind %))
+                                   (proj/machine-cascade-rows
+                                     [(machine-transition-ev
+                                        :door/main {:state :locked} {:state :closed}
+                                        [:door/insert-coin] 0)])))]
+      (is (nil? (:history-restored ordinary)) "non-history transition: no :history-restored")
+      (is (nil? (:history-recorded ordinary)) "non-history transition: no :history-recorded"))))
+
+(deftest history-restored-headline-test
+  (testing "rf2-mle6e.5 — the restored headline reads the recorded config →
+            resolved leaf, NAMES the kind, and on :default names the fallback"
+    (is (= "restored [:player] from DEEP history · [:player :playing :mid-track] → [:player :playing :mid-track]"
+           (fmt/history-restored-headline
+             {:compound-path [:player] :kind :deep :source :recorded
+              :restored-config [:player :playing :mid-track]
+              :resolved-leaf [:player :playing :mid-track]})))
+    (is (= "restored [:player] from SHALLOW history · :playing → [:player :playing :at-start]"
+           (fmt/history-restored-headline
+             {:compound-path [:player] :kind :shallow :source :recorded
+              :restored-config :playing
+              :resolved-leaf [:player :playing :at-start]})))
+    (is (= "restored [:player] from DEFAULT (no recording) via :default-target → [:player :playing :at-start]"
+           (fmt/history-restored-headline
+             {:compound-path [:player] :kind :deep :source :default
+              :fallback :default-target
+              :resolved-leaf [:player :playing :at-start]})))))
+
+(deftest history-recorded-headline-test
+  (testing "rf2-mle6e.5 — the recorded headline reads 'advanced from X to Y'
+            on an overwrite, 'recorded = Y' on the first-ever write"
+    (is (= "history recorded [:player] = [:player :playing :mid-track]"
+           (fmt/history-recorded-headline
+             {:compound-path [:player] :kind :deep
+              :recorded-config [:player :playing :mid-track]})))
+    (is (= "history advanced [:player] from [:player :playing :at-start] to [:player :playing :mid-track]"
+           (fmt/history-recorded-headline
+             {:compound-path [:player] :kind :deep
+              :recorded-config [:player :playing :mid-track]
+              :prev-config [:player :playing :at-start]})))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
@@ -443,6 +443,41 @@
         (is (= :issue-token (-> rec :actions first :action-id)))
         (is (= :ok          (-> rec :actions first :outcome)))))))
 
+(deftest project-focused-event-attaches-history-restore-and-record
+  ;; rf2-mle6e.5 — a transition that resolved a `:type :history` pseudo-state
+  ;; carries `:history-restored`; one whose macrostep exited a history-bearing
+  ;; compound carries `:history-recorded` (spec/009 §History trace events). The
+  ;; lens surfaces them so the Machine Inspector renders WHY a re-entry landed
+  ;; where it did.
+  (testing "history restore/record traces attach to the per-transition record"
+    (let [events [(t-event 1 :media/deep [:player :stopped] [:player :playing :mid-track]
+                           [:insert])
+                  {:id 2 :time 11 :operation :rf.machine.history/restored
+                   :tags {:machine-id :media/deep :compound-path [:player]
+                          :kind :deep :source :recorded
+                          :restored-config [:player :playing :mid-track]
+                          :resolved-leaf [:player :playing :mid-track]}}]
+          rec    (-> (h/project-focused-event-transitions events) first)]
+      (is (= 1 (count (:history-restored rec))))
+      (is (= :recorded (-> rec :history-restored first :source)))
+      (is (= :deep (-> rec :history-restored first :kind)))
+      (is (= [:player :playing :mid-track]
+             (-> rec :history-restored first :restored-config)))))
+  (testing "the recorded trace attaches as :history-recorded"
+    (let [events [(t-event 1 :media/deep [:player :playing :mid-track] [:tray] [:eject])
+                  {:id 2 :time 11 :operation :rf.machine.history/recorded
+                   :tags {:machine-id :media/deep :compound-path [:player]
+                          :kind :deep :recorded-config [:player :playing :mid-track]}}]
+          rec    (-> (h/project-focused-event-transitions events) first)]
+      (is (= 1 (count (:history-recorded rec))))
+      (is (= [:player :playing :mid-track]
+             (-> rec :history-recorded first :recorded-config)))))
+  (testing "an ordinary (non-history) transition carries NEITHER history key"
+    (let [events [(t-event 1 :auth/login :idle :authing [:auth/submit])]
+          rec    (-> (h/project-focused-event-transitions events) first)]
+      (is (nil? (:history-restored rec)))
+      (is (nil? (:history-recorded rec))))))
+
 (deftest project-focused-event-surfaces-before-and-after-snapshots
   ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the per-transition record
   ;; carries the full `:before` / `:after` snapshot maps so the panel's

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -378,6 +378,35 @@
        :event      event
        :state      state}))
 
+(defn machine-history-restored-ev
+  "`:rf.machine.history/restored` trace (rf2-mle6e.5, spec/009 §History trace
+  events) — a transition resolved a `:type :history` pseudo-state. Op-type
+  `:rf.machine` (benign activity, NOT a severity). On the `:recorded` path
+  pass `:restored-config`; on the `:default` path pass `:fallback` and omit
+  `:restored-config`."
+  [{:keys [machine-id compound-path kind source fallback restored-config resolved-leaf]}]
+  (ev :rf.machine :rf.machine.history/restored
+      (cond-> {:machine-id    machine-id
+               :compound-path compound-path
+               :kind          kind
+               :source        source
+               :resolved-leaf resolved-leaf}
+        (= :default source)    (assoc :fallback fallback)
+        (not= :default source) (assoc :restored-config restored-config))))
+
+(defn machine-history-recorded-ev
+  "`:rf.machine.history/recorded` trace (rf2-mle6e.5, spec/009 §History trace
+  events) — a history-bearing compound's exit wrote its config into
+  `:rf/history`. Op-type `:rf.machine`. `:prev-config` is OMITTED on the
+  first-ever recording (pass nil)."
+  [{:keys [machine-id compound-path kind recorded-config prev-config]}]
+  (ev :rf.machine :rf.machine.history/recorded
+      (cond-> {:machine-id      machine-id
+               :compound-path   compound-path
+               :kind            kind
+               :recorded-config recorded-config}
+        (some? prev-config) (assoc :prev-config prev-config))))
+
 (defn machine-action-exception-ev
   "`:rf.error/machine-action-exception` trace (rf2-e7yhv) — a machine
   action threw during a transition. Mirrors the emit shape in

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -66,17 +66,35 @@
                                    internal/external self-transitions.
     - fuse      (WILDCARD-THROW) — `:*` wildcard action THROWS (exception
                                    card + pink-wash; the foil to the no-op).
+    - media     (HISTORY, gap 8) — a `:player` compound owning a `:type
+                                   :history` pseudo-state; shallow + deep
+                                   eject/restore drive the
+                                   `:rf.machine.history/restored` banner + the
+                                   per-`:entry`-step `:source` chip (rf2-mle6e).
 
-  ## HISTORY section (gap 8 — SOON)
+  ## HISTORY section (gap 8 — LIVE, rf2-mle6e)
 
-  re-frame2 currently REJECTS `:history` at registration
-  (`:rf.error/machine-grammar-not-in-v1`, Spec 005 §Substitutes; rf2-rkkag).
-  So the deck is HISTORY-READY: a rung drives the current expected-REJECTION
-  (the harness asserts `reg-machine` of a `:history` machine THROWS the
-  deferred-grammar error), and clearly-marked PLACEHOLDER rungs (disabled
-  buttons) reserve the slots for shallow + deep history RESTORE — when the
-  feature ships, flip the placeholders to live rungs and the harness already
-  has the slots.
+  History states are FIRST-CLASS (rf2-mle6e: grammar .1, trace .2, engine .3).
+  The deck drives a live media-player compound (`:media/deep` + `:media/shallow`,
+  shared via `machine-epochs.machines`) whose `:player` compound owns a
+  `:type :history` pseudo-state:
+
+    - rung #24 — the PLACEMENT rejection: a ROOT `:type :history` machine is
+      still rejected (`:rf.error/machine-history-misplaced`) because a
+      pseudo-state must have an owning compound. (NOT the old not-in-v1
+      deferral — history itself is supported.)
+    - rung #25 — SHALLOW history restore: position deep into `:player`, eject
+      (records the direct CHILD), re-insert → restores the recorded child then
+      descends its `:initial` chain. The Epoch cascade shows the
+      `:rf.machine.history/restored` banner (source `:recorded`, shallow) + the
+      `:source :recorded` chip on the restored `:entry` steps.
+    - rung #26 — DEEP history restore: same eject/insert dance on `:media/deep`
+      → restores the FULL nested LEAF path. The banner reads DEEP; the entry
+      steps descend to the exact recorded leaf, each chipped `from history`.
+
+  The `:rf/history` snapshot slot is inspectable in the App-db panel (it lives
+  inside `[:rf/runtime :machines :snapshots <id> :rf/history]`, rendered by the
+  App-db edn-inspector like any other snapshot slot). rf2-mle6e.5.
 
   ## Test surface, not tutorial (feedback_testbeds_are_test_surfaces)
 
@@ -190,15 +208,17 @@
         child-id
         (assoc :fx [[:dispatch [child-id [:succeed :session/token-abc]]]])))))
 
-;; #24 — probe the current :history REJECTION contract. Registering a
-;; :type :history machine throws synchronously at reg-machine time
-;; (:rf.error/machine-grammar-not-in-v1). The deck event swallows the throw
+;; #24 — probe the :history PLACEMENT constraint. History is FIRST-CLASS
+;; (rf2-mle6e), but a :type :history pseudo-state MUST have an owning compound,
+;; so a ROOT :type :history machine throws synchronously at reg-machine time
+;; (:rf.error/machine-history-misplaced). The deck event swallows the throw
 ;; (the rung's job is to DRIVE the rejection; the harness asserts the throw
 ;; shape directly). It bumps baseline so the epoch still shows a delta.
 (rf/reg-event-db :machine-epochs/probe-history-rejection
-  {:doc "Button #24 — attempt to register a :type :history machine and
-         confirm the v1 deferral REJECTS it. The throw is swallowed here so
-         the deck does not crash; the harness asserts the rejection shape."}
+  {:doc "Button #24 — attempt to register a ROOT :type :history machine and
+         confirm the PLACEMENT constraint rejects it (a pseudo-state needs an
+         owning compound). The throw is swallowed here so the deck does not
+         crash; the harness asserts the misplaced-history rejection shape."}
   (fn handler-probe-history [db _ev]
     (-> db bump (assoc :machine-epochs/history-rejected? (machines/history-rejected?)))))
 
@@ -221,7 +241,7 @@
     {:db initial-db
      :fx (mapv (fn [id] [:dispatch [id [:rf.machine/bootstrap]]])
                [:door/main :traffic/light :quiz/scorer :brew/machine
-                :session/flow :hvac/controller])}))
+                :session/flow :hvac/controller :media/deep :media/shallow])}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS — machine snapshot reads for the live status strip
@@ -249,6 +269,18 @@
 (reg-machine-subs! "brew"    :brew/machine)
 (reg-machine-subs! "session" :session/flow)
 (reg-machine-subs! "hvac"    :hvac/controller)
+(reg-machine-subs! "media-deep"    :media/deep)
+(reg-machine-subs! "media-shallow" :media/shallow)
+
+;; The :rf/history snapshot slot — surfaced in the status strip so the deck is
+;; legible standalone; the App-db panel renders it inside the snapshot too.
+(rf/reg-sub :machine-epochs/media-deep-history
+  :<- [:rf/machine :media/deep]
+  (fn [snap _] (:rf/history snap)))
+
+(rf/reg-sub :machine-epochs/media-shallow-history
+  :<- [:rf/machine :media/shallow]
+  (fn [snap _] (:rf/history snap)))
 
 (rf/reg-sub :machine-epochs/door-data
   :<- [:rf/machine :door/main]
@@ -263,8 +295,7 @@
 ;; ============================================================================
 ;;
 ;; Each row: [n label caption event]. `:section` rows are separators (label
-;; only). `:placeholder` rows are HISTORY-section reservations (disabled —
-;; gap 8). The harness reads the machine specs (shared via
+;; only). The harness reads the machine specs (shared via
 ;; `machine-epochs.machines`) and drives each rung's intent through the live
 ;; substrate, asserting BOTH machine outcome + Xray render.
 
@@ -347,14 +378,16 @@
    [23 "Tweak fan — INTERNAL self-transition (omit :target)"
     "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to #22; NO spurious no-op row"
     [:machine-epochs/send [[:hvac/controller [:hvac/tweak]]]]]
-   [:section "History (SOON) — gap 8: reject-now + ready placeholders"]
-   [24 "Register a :history machine — REJECTED (current contract)"
-    "The harness asserts reg-machine of a :type :history machine THROWS :rf.error/machine-grammar-not-in-v1 (Spec 005 §Substitutes; rf2-rkkag)"
+   [:section "History (LIVE, gap 8) — first-class shallow + deep restore (rf2-mle6e)"]
+   [24 "Register a ROOT :history machine — REJECTED (placement)"
+    "History is FIRST-CLASS; a ROOT :type :history is still rejected :rf.error/machine-history-misplaced (a pseudo-state needs an owning compound)"
     [:machine-epochs/probe-history-rejection]]
-   [:placeholder 25 "Shallow HISTORY restore — PLACEHOLDER (activate when :history lands)"
-    "Reserved slot: re-enter a compound region via :type :history :shallow and assert it restores the last active CHILD"]
-   [:placeholder 26 "Deep HISTORY restore — PLACEHOLDER (activate when :history lands)"
-    "Reserved slot: re-enter via :type :history :deep and assert it restores the full nested LEAF path"]])
+   [25 "SHALLOW history restore (:media/shallow eject → re-insert)"
+    "Epoch: the :rf.machine.history/restored banner (source :recorded, SHALLOW); restored :entry steps chip 'from history'; restores the CHILD then its :initial"
+    [:machine-epochs/history-shallow-restore]]
+   [26 "DEEP history restore (:media/deep eject → re-insert)"
+    "Epoch: the banner reads DEEP; the :entry steps descend to the EXACT recorded leaf [:player :playing :mid-track], each chipped 'from history'"
+    [:machine-epochs/history-deep-restore]]])
 
 ;; #13 — answer twice more so the running score reaches the `:enough?` pass
 ;; mark (3) and the guarded `:always` chain settles `:asking` ──► `:passed`
@@ -367,6 +400,45 @@
     {:db (bump db)
      :fx [[:dispatch [:quiz/scorer [:quiz/answer]]]
           [:dispatch [:quiz/scorer [:quiz/answer]]]]}))
+
+;; #25 / #26 — the HISTORY restore dance (rf2-mle6e.5). To make the RESTORE the
+;; focal cascade the operator inspects, the rung first POSITIONS the player deep
+;; (`:insert` → `:play` → `:seek` lands it at [:player :playing :mid-track]) and
+;; EJECTS it (recording :player's last config into :rf/history), then fires the
+;; final `:insert` — which is the restore whose cascade carries the
+;; :rf.machine.history/restored banner + the :source-chipped :entry steps. The
+;; restore is the LAST dispatch so it is the headline of the press's epoch.
+;;
+;; SHALLOW (:media/shallow) records the direct child (:playing) and restores
+;; [:player :playing :at-start] (the child descended through its :initial).
+;; DEEP (:media/deep) records + restores the exact leaf [:player :playing
+;; :mid-track]. The two share the driver shape; only the machine-id differs.
+(defn- history-restore-fx
+  "The fx vector that positions `machine-id` deep, ejects (records), and
+  re-inserts (restores). The trailing :insert is the focal restore."
+  [machine-id]
+  [[:dispatch [machine-id [:insert]]]   ; first entry → default (records nothing yet)
+   [:dispatch [machine-id [:seek]]]      ; :at-start → :mid-track (deep leaf)
+   [:dispatch [machine-id [:eject]]]     ; exit :player → :tray (RECORDS history)
+   [:dispatch [machine-id [:insert]]]])  ; re-enter via :hist (RESTORES — the headline)
+
+(rf/reg-event-fx :machine-epochs/history-shallow-restore
+  {:doc "Button #25 — drive :media/shallow through the eject/restore dance so
+         the final :insert restores the recorded CHILD then descends its
+         :initial chain. The restore cascade carries the history banner +
+         :source :recorded entry-step chips (SHALLOW)."}
+  (fn handler-history-shallow [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx (history-restore-fx :media/shallow)}))
+
+(rf/reg-event-fx :machine-epochs/history-deep-restore
+  {:doc "Button #26 — drive :media/deep through the eject/restore dance so the
+         final :insert restores the EXACT recorded leaf [:player :playing
+         :mid-track]. The restore cascade carries the history banner (DEEP) +
+         :source :recorded entry-step chips down to the exact leaf."}
+  (fn handler-history-deep [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx (history-restore-fx :media/deep)}))
 
 ;; ============================================================================
 ;; VIEWS
@@ -389,25 +461,6 @@
      (str n ".")]
     label]
    [:span {:style {:color "#666" :font-size "12px"}} caption]])
-
-(reg-view placeholder-button
-  "A HISTORY-section reservation: a DISABLED numbered button (the feature is
-  deferred — Spec 005 §Substitutes). When :history lands, flip this row to a
-  live [n label caption event] rung; the harness already has the slot."
-  [n label caption]
-  [:div {:style {:display "grid" :grid-template-columns "auto 1fr"
-                 :gap "0.75em" :align-items "center" :margin "0.35em 0"
-                 :opacity 0.55}}
-   [:button {:data-testid (str "machine-epochs-rung-" n)
-             :disabled    true
-             :style {:min-width "24em" :text-align "left"
-                     :padding "0.4em 0.6em" :cursor "not-allowed"
-                     :border "1px dashed #cfc8ff" :border-radius "6px"
-                     :background "#f7f5ff"}}
-    [:span {:style {:font-weight "bold" :color "#aaa" :margin-right "0.5em"}}
-     (str n ".")]
-    label]
-   [:span {:style {:color "#999" :font-size "12px" :font-style "italic"}} caption]])
 
 (reg-view section-heading
   "A section separator inside the ladder."
@@ -451,7 +504,13 @@
    [:div ":quiz/scorer data: " [:strong (pr-str @(subscribe [:machine-epochs/quiz-data]))]]
    [machine-row ":brew/machine"    "brew"]
    [machine-row ":session/flow"    "session"]
-   [machine-row ":hvac/controller" "hvac"]])
+   [machine-row ":hvac/controller" "hvac"]
+   [machine-row ":media/deep"      "media-deep"]
+   [:div {:data-testid "machine-epochs-media-deep-history"}
+    ":media/deep :rf/history: " [:strong (pr-str @(subscribe [:machine-epochs/media-deep-history]))]]
+   [machine-row ":media/shallow"   "media-shallow"]
+   [:div {:data-testid "machine-epochs-media-shallow-history"}
+    ":media/shallow :rf/history: " [:strong (pr-str @(subscribe [:machine-epochs/media-shallow-history]))]]])
 
 (reg-view root []
   [:div {:data-testid "machine-epochs-root"
@@ -476,8 +535,6 @@
    (for [row ladder]
      (case (first row)
        :section     ^{:key (str "sec-" (second row))} [section-heading (second row)]
-       :placeholder (let [[_ n label caption] row]
-                      ^{:key n} [placeholder-button n label caption])
        (let [[n label caption event] row]
          ^{:key n} [ladder-button n label caption event])))])
 

--- a/tools/xray/testbeds/machine_epochs/machines.cljs
+++ b/tools/xray/testbeds/machine_epochs/machines.cljs
@@ -402,22 +402,106 @@
     :tweak-fan             (trail-action 'tweak-fan             :action:tweak)}})
 
 ;; ============================================================================
-;; HISTORY (gap 8) — the rejection probe
+;; MACHINE 8 — :media/deep + :media/shallow  (HISTORY: shallow + deep restore)
 ;; ============================================================================
 ;;
-;; re-frame2 currently REJECTS `:history` at registration time
-;; (`:rf.error/machine-grammar-not-in-v1`, Spec 005 §Substitutes; rf2-rkkag).
-;; This spec is NOT registered at load (it would throw); it is the subject of
-;; the rejection probe. When `:history` lands, this becomes a live machine
-;; and the placeholder rungs activate.
+;; gap 8 — first-class history states (rf2-mle6e). A media-player compound
+;; `:player` owns a `:type :history` pseudo-state `:hist`. From `:stopped`,
+;; `:play` targets `[:player :hist]` → re-entry RESTORES the recorded (or
+;; default) configuration beneath `:player`. The cascade carries the
+;; `:rf.machine.history/restored` trace + the per-`:entry`-step `:source`
+;; (`:recorded` | `:default`); exiting `:player` (the `:stop` transition to
+;; `:stopped` stays WITHIN `:player`, so it does NOT record — the model exits
+;; the compound by going to the sibling `:stopped`, which is inside `:player`,
+;; so we record on the OUTER `:eject` to the root-sibling `:tray`).
+;;
+;; Two variants, mirroring the engine smoke (`machine_history_smoke_test`):
+;;   :media/deep    — `:deep? true`  → restores the FULL nested leaf path.
+;;   :media/shallow — shallow        → restores the recorded DIRECT CHILD then
+;;                                      descends its `:initial` chain.
+;;
+;; The `:player` compound is nested under a root so an OUTER state (`:tray`)
+;; exists to exit `:player` entirely (recording) and re-enter it via the
+;; history pseudo-state (restoring). `:eject` leaves `:player` → `:tray`
+;; (records `:player`'s last config); `:insert` returns `:tray` →
+;; `[:player :hist]` (restores it).
+
+(defn- media-player-spec
+  "Build a media-player history machine. `deep?` selects deep vs shallow
+  history. The `:player` compound owns the `:hist` pseudo-state; the OUTER
+  `:tray` state is the off-compound resting place so `:eject` / `:insert`
+  exit + re-enter `:player` (record + restore). Every action trail-appends so
+  the harness order-oracle reads the cascade order."
+  [deep?]
+  {:initial :tray
+   :data    {:trail []}
+
+   :actions
+   {:enter-player  (trail-action 'enter-player  :entry:player)
+    :exit-player   (trail-action 'exit-player   :exit:player)
+    :enter-playing (trail-action 'enter-playing :entry:playing)
+    :enter-paused  (trail-action 'enter-paused  :entry:paused)
+    :seek-track    (trail-action 'seek-track    :action:seek)}
+
+   :states
+   {;; OFF-compound resting place — exiting :player to here records history;
+    ;; :insert re-enters :player via the history pseudo-state (restores).
+    :tray
+    {:tags #{:media/tray}
+     :on   {:insert [:player :hist]}}
+
+    :player
+    {:tags    #{:media/player}
+     :initial :stopped
+     :entry   :enter-player
+     :exit    :exit-player
+     :on      {:eject :tray}
+     :states
+     {:stopped {:tags #{:media/stopped}
+                :on   {:play [:player :playing]}}
+
+      :hist    (cond-> {:type :history :default-target :playing}
+                 deep? (assoc :deep? true))
+
+      :playing {:tags    #{:media/playing}
+                :initial :at-start
+                :entry   :enter-playing
+                :on      {:stop  [:player :stopped]
+                          :pause [:player :paused]}
+                :states  {:at-start  {:tags #{:media/at-start}
+                                      :on   {:seek {:target :mid-track :action :seek-track}}}
+                          :mid-track {:tags #{:media/mid-track}
+                                      :on   {:stop [:player :stopped]}}}}
+
+      :paused  {:tags  #{:media/paused}
+                :entry :enter-paused
+                :on    {:resume [:player :playing]}}}}}})
+
+(defmachine media-deep-machine
+  "DEEP history media player — `:insert` from `:tray` restores the FULL nested
+  leaf path the player occupied when last ejected."
+  (media-player-spec true))
+
+(defmachine media-shallow-machine
+  "SHALLOW history media player — `:insert` from `:tray` restores the recorded
+  DIRECT CHILD of `:player`, then descends its `:initial` chain (so a deep
+  exit-leaf restores only to the child's `:initial`)."
+  (media-player-spec false))
+
+;; ----------------------------------------------------------------------------
+;; HISTORY PLACEMENT probe — the misplaced-history rejection (rung #24).
+;; ----------------------------------------------------------------------------
+;;
+;; History is first-class (rf2-mle6e) but a `:type :history` pseudo-state MUST
+;; have an owning compound — a machine ROOT cannot be one. This probe confirms
+;; the placement constraint still fires (NOT the old not-in-v1 deferral).
 
 (def history-machine-spec
-  "A ROOT `:type :history` machine — still rejected, now for PLACEMENT:
-  history is first-class (rf2-mle6e) but a `:type :history` pseudo-state MUST
-  have an owning compound, so a machine root cannot be one. The probe
-  registers it to confirm the misplaced-history error fires. (A WELL-PLACED
-  history machine registers cleanly — wiring the live history deck +
-  placeholder rungs is rf2-mle6e.5's job.)"
+  "A ROOT `:type :history` machine — rejected for PLACEMENT (a pseudo-state
+  must have an owning compound, so a machine root cannot be one). The probe
+  registers it to confirm `:rf.error/machine-history-misplaced` fires. (A
+  WELL-PLACED history machine — `media-deep-machine` / `media-shallow-machine`
+  above — registers cleanly and drives the live history deck.)"
   {:type    :history
    :initial :a
    :states  {:a {}}})
@@ -443,8 +527,8 @@
 (defn register-all!
   "Register every NON-throwing-at-registration machine in the deck. Called by
   the deck mount AND by the assertion harness so both drive the identical
-  specs. (The `:history` machine is NOT registered — it throws by design; the
-  rejection probe registers it on demand.)"
+  specs. (The ROOT `:type :history` probe is NOT registered — it throws by
+  design; the placement-rejection probe registers it on demand.)"
   []
   (rf/reg-machine :door/main        door-machine)
   (rf/reg-machine :traffic/light    traffic-machine)
@@ -453,4 +537,6 @@
   (rf/reg-machine :session/login    session-login-machine)
   (rf/reg-machine :session/flow     session-flow-machine)
   (rf/reg-machine :fuse/box         fuse-machine)
-  (rf/reg-machine :hvac/controller  hvac-controller-machine))
+  (rf/reg-machine :hvac/controller  hvac-controller-machine)
+  (rf/reg-machine :media/deep       media-deep-machine)
+  (rf/reg-machine :media/shallow    media-shallow-machine))


### PR DESCRIPTION
## What

Renders first-class history-state activity (rf2-mle6e: engine .3 + trace .2, both merged on main) in Xray. Bead **rf2-mle6e.5**.

### Epoch panel — EVENT HANDLER machine cascade
- The `:transition` cascade row now carries a **HISTORY banner** above the structured cascade (Xray-brand-violet, informational — a restore/record is benign observability, op-type `:rf.machine`, never the error/pink wash):
  - `⟲ restored <compound> from DEEP|SHALLOW history · <restored-config> → <resolved-leaf>` (recorded) / `restored <compound> from DEFAULT (no recording) via :<fallback> → <leaf>` (default).
  - `✎ history advanced <compound> from <prev> to <recorded>` / `history recorded <compound> = <recorded>` (first write).
- **Per-`:entry`-step `:source` chip** — each history-driven `:entry` step renders `from history` (`:recorded`) / `default` (`:default`), so the viewer sees WHICH entry steps came from a restore vs an ordinary `:initial` descent (spec/009 line 291 — the only addition history makes to the rf2-n9f4z step shape).

### Machine Inspector
- The focused-event lens (`project-focused-event-transitions`) attaches `:history-restored` / `:history-recorded` per transition record (keyed by machine-id).

### Inspectable `:rf/history`
- The recorded config lives at `[:rf/runtime :machines :snapshots <id> :rf/history]` — an ordinary snapshot slot rendered by the App-db edn-inspector. No bespoke chrome; it's EDN-clean.

### Pure data
- `projection.cljc`: `history-restored-rows` / `history-recorded-rows` + `attach-history-to-transition-rows` (keyed by machine-id; one transition per machine per macrostep).
- `format.cljc`: `history-restored-headline` / `history-recorded-headline`.

### machine_epochs testbed (wired the live history deck + rungs #25/#26)
- Replaced the root `:type :history` rejection-only probe with **live, well-placed** history machines: `:media/deep` + `:media/shallow` — a `:player` compound owning a `:type :history` pseudo-state, with an off-compound `:tray` so `:eject`/`:insert` record + restore.
- Activated the former placeholder rungs: **#25** (shallow restore), **#26** (deep restore). **#24** still probes the misplaced-history PLACEMENT rejection (`:rf.error/machine-history-misplaced`).
- Removed the now-dead `placeholder-button` view + `:placeholder` ladder case.
- Harness (`machine_epochs_harness_cljs_test`) asserts restore render + record render + the inspectable `:rf/history` slot — all CLJS-unit (Causa/Story-as-CLJS, not Playwright).

### Spec (xray-spec-currency)
- `tools/xray/spec/003-Machine-Inspector.md` — new **§History restore rendering** + the two history ops added to the Data sources table.

## Gates (cold)
- `npm run test:cljs` — **5417 tests, 0 failures** (incl. new harness #25/#26 + eject-records).
- tools/xray JVM `clojure -M:test` — **1100 tests, 0 failures** (incl. new projection / format / inspector-helper history tests).
- `npx shadow-cljs compile :examples/machine-epochs` — **0 warnings**.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures** (the known `routes-epochs routing ladder` flake did not surface).

## Scope
Touched only `tools/xray/src` (epoch projection/format/view + machine-inspector-helpers), `tools/xray/testbeds/machine_epochs`, `tools/xray/spec`, and the corresponding xray test files. No engine, trace-spec, comprehensive impl tests, or other testbeds touched.

Closes rf2-mle6e.5.