### PR TITLE
test(machines/history): comprehensive history suite + W3C-adapted SCXML fixtures (rf2-mle6e.4)

### DIFF
--- a/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
@@ -1,0 +1,431 @@
+(ns re-frame.machine-history-unit-cljs-test
+  "Comprehensive UNIT matrix for the first-class history ENGINE (rf2-mle6e.3,
+  merged). The COMPLEMENT of `machine_history_smoke_test` — the smoke proved
+  record/restore is wired end-to-end; this suite pins the corners the spec
+  (005 §History states + 009 §History trace events) enumerates and that the
+  smoke leaves uncovered:
+
+    - SHALLOW vs DEEP depth distinction at the SAME exit leaf (a single shared
+      compound, exited from the same deep leaf, restores differently under
+      `:deep?` true vs absent).
+    - DEEP NESTING — two history-bearing compounds at different depths record
+      INDEPENDENTLY (keyed by their own declaration paths) and never interfere;
+      the outer's deep restore returns the full leaf, the inner's its own.
+    - ENTRY-CASCADE ORDERING during a restore — a restore is the standard
+      entry cascade fed a recorded leaf, so it fires exit-deepest-first /
+      entry-shallowest-first along the LCA, NOT a bespoke mechanism.
+    - DEFAULT-TARGET fallback (no recording) — both with `:default-target`
+      declared AND with it absent (the compound's `:initial`).
+    - `:initial`-fallback when neither a recording nor a `:default-target`.
+    - DANGLING recorded path after hot-reload (rf2-wgfv0) falls back, never
+      enters the dead path, no `:rf.error/*`.
+    - PER-REGION parallel history at STRUCTURALLY-IDENTICAL region paths —
+      region-qualified keys never collide; restoring one region is isolated.
+    - SNAPSHOT REVERT (Goal 2) — the `:rf/history` slot is part of the
+      revertible snapshot VALUE (not a side-table): re-running the engine from
+      an earlier captured snapshot value restores THAT snapshot's history, and
+      the slot rides `pr-str` / `read-string` (SSR-serialisation shape).
+    - The TRACE shapes (`:rf.machine.history/recorded` / `-restored`) — the
+      exact spec/009 tag keys, asserted for the deep-nesting + shallow-vs-deep
+      cases the smoke does not reach (two `-recorded` events in one exit
+      cascade; the per-step `:source` stamping on a nested restore).
+
+  The namespace is named `*-cljs-test` (file `*_cljs_test.cljc`) so it is
+  discovered by BOTH the shadow-cljs `:node-test` build (`:ns-regexp
+  \"cljs-test$\"`, run via `npm run test:cljs`) AND the JVM
+  cognitect.test-runner (`.*-test$`, run via `clojure -M:test` in
+  `implementation/machines`). The history engine is identical across runtimes,
+  so the corpus must pass on both — mirroring the artefact's other dual-runtime
+  tests (`scxml_conformance_cljs_test.cljc`, `final_state_cljs_test.cljc`).
+
+  Drives the pure `machine-transition` primitive directly — no frame, no
+  app-db, no dispatch loop. Every assertion is pure data."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   #?(:cljs [cljs.reader])
+   [re-frame.machines :as machines]
+   [re-frame.machines.result :as result]
+   [re-frame.trace :as trace]))
+
+;; ===========================================================================
+;; Harness — pure engine + trace capture
+;; ===========================================================================
+
+(def ^:dynamic *captured* nil)
+
+(defn- capture-fixture
+  "Register a trace listener appending every emitted event to `*captured*`
+  for the duration of one test, then unregister."
+  [f]
+  (binding [*captured* (atom [])]
+    (trace/register-listener! ::history-unit #(swap! *captured* conj %))
+    (try (f)
+      (finally (trace/unregister-listener! ::history-unit)))))
+
+(use-fixtures :each capture-fixture)
+
+(defn- history-events
+  [operation]
+  (filterv #(= operation (:operation %)) @*captured*))
+
+(defn- reset-capture! [] (reset! *captured* []))
+
+(defn- step
+  "Apply one macrostep; assert it succeeded; return the post snapshot."
+  [machine snapshot event]
+  (let [r (machines/machine-transition machine snapshot event)]
+    (is (result/ok? r) (str "transition ok for event " (pr-str event)))
+    (result/snap r)))
+
+(defn- seed [state] {:state state :data {}})
+
+;; A recorder for entry/exit ORDERING assertions: `(mk tag)` is an entry/exit
+;; fn appending `tag` to the shared log (in invocation order), returning nil.
+(defn- order-recorder []
+  (let [log (atom [])]
+    [log (fn [tag] (fn [_ctx] (swap! log conj tag) nil))]))
+
+;; ===========================================================================
+;; §1. SHALLOW vs DEEP at the SAME exit leaf
+;;
+;; One shared compound shape exited from the identical deep leaf
+;; ([:player :playing :mid-track]) restores DIFFERENTLY under `:deep?` true vs
+;; absent — deep returns the exact leaf, shallow returns the recorded direct
+;; child descended through its OWN `:initial` chain. This isolates the depth
+;; semantic from every other variable. Spec 005 §Recording / §Restoration.
+;; ===========================================================================
+
+(defn- player [deep?]
+  {:initial :player
+   :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    (cond-> {:type :history :default-target :playing}
+                                    deep? (assoc :deep? true))
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}})
+
+(deftest deep-vs-shallow-diverge-from-identical-exit-leaf
+  (testing "the SAME exit leaf restores to the exact leaf (deep) vs the child's :initial (shallow)"
+    (let [deep-m    (player true)
+          shallow-m (player false)
+          ;; Identical exit: from :mid-track, :stop → :stopped.
+          deep-stop    (step deep-m    (seed [:player :playing :mid-track]) [:stop])
+          shallow-stop (step shallow-m (seed [:player :playing :mid-track]) [:stop])]
+      ;; Recording differs: deep stores the full leaf path; shallow the child kw.
+      (is (= [:player :playing :mid-track] (get-in deep-stop    [:rf/history [:player]]))
+          "deep records the absolute leaf path")
+      (is (= :playing                       (get-in shallow-stop [:rf/history [:player]]))
+          "shallow records only the direct-child keyword")
+      ;; Restore diverges from the IDENTICAL recorded exit point.
+      (is (= [:player :playing :mid-track] (:state (step deep-m    deep-stop    [:play])))
+          "deep restores the EXACT recorded leaf (:mid-track)")
+      (is (= [:player :playing :at-start]  (:state (step shallow-m shallow-stop [:play])))
+          "shallow restores the recorded child then its :initial (:at-start), NOT the exit leaf"))))
+
+;; ===========================================================================
+;; §2. DEEP NESTING — independent recordings, no interference
+;;
+;; Two history-bearing compounds at DIFFERENT depths (:outer deep, nested
+;; :inner deep). Fully exiting :outer (to a top-level sibling :away) records
+;; BOTH compounds — each keyed by its OWN declaration path — and re-entering
+;; via :outer's deep history restores the full leaf, with the inner recording
+;; untouched. Spec 005 §Deep nesting (the two never interfere).
+;; ===========================================================================
+
+(def nested
+  {:initial :outer
+   :states
+   {:outer {:initial :a
+            :on      {:leave :away}
+            :states  {:a {:on {:to-b :b}}
+                      :b {:initial :b1
+                          :on      {:to-a :a}
+                          :states  {:b1         {:on {:to-b2 :b2}}
+                                    :b2         {}
+                                    :hist-inner {:type :history :deep? true}}}
+                      :hist-outer {:type :history :deep? true}}}
+    :away {:on {:return [:outer :hist-outer]}}}})
+
+(deftest deep-nesting-records-each-compound-independently
+  (testing "exiting :outer records BOTH the outer and the nested-inner compound, keyed independently"
+    (let [away (step nested (seed [:outer :b :b2]) [:leave])]
+      (is (= :away (:state away)) "left the whole :outer subtree")
+      ;; Two independent recordings, each keyed by its own declaration path.
+      (is (= [:outer :b :b2] (get-in away [:rf/history [:outer]]))
+          "the outer compound recorded its full deep leaf")
+      (is (= [:outer :b :b2] (get-in away [:rf/history [:outer :b]]))
+          "the nested :b compound recorded its own deep leaf, under a SEPARATE key")
+      (is (= 2 (count (:rf/history away)))
+          "exactly two history entries — one per history-bearing compound"))))
+
+(deftest deep-nesting-outer-restore-returns-full-leaf
+  (testing "re-entering via :outer's deep history restores the full recorded leaf"
+    (let [away (step nested (seed [:outer :b :b2]) [:leave])
+          back (step nested away [:return])]
+      (is (= [:outer :b :b2] (:state back))
+          "the outer deep history restored the exact leaf across the full subtree")
+      ;; The inner recording is untouched by the outer restore.
+      (is (= [:outer :b :b2] (get-in back [:rf/history [:outer :b]]))
+          "the inner compound's recording is unaffected by the outer restore"))))
+
+;; ===========================================================================
+;; §3. ENTRY-CASCADE ORDERING during a restore
+;;
+;; A restore is the STANDARD entry cascade fed a recorded leaf (not a bespoke
+;; mechanism). With entry/exit recorders on every level, a deep restore from
+;; :stopped → :mid-track fires exit-deepest-first then entry-shallowest-first
+;; along the LCA (:player), which is neither exited nor re-entered. Spec 005
+;; §Composition with the LCA, entry/exit cascade.
+;; ===========================================================================
+
+(deftest restore-feeds-the-standard-lca-entry-cascade-in-order
+  (testing "a deep restore fires exit-deepest-first / entry-shallowest-first along the LCA"
+    (let [[log mk] (order-recorder)
+          m {:initial :player
+             :states
+             {:player {:initial :stopped
+                       :entry   (mk :en-player) :exit (mk :ex-player)
+                       :states
+                       {:stopped {:entry (mk :en-stopped) :exit (mk :ex-stopped)
+                                  :on    {:play [:player :hist]}}
+                        :hist    {:type :history :deep? true :default-target :playing}
+                        :playing {:initial :at-start
+                                  :entry   (mk :en-playing) :exit (mk :ex-playing)
+                                  :on      {:stop [:player :stopped]}
+                                  :states  {:at-start  {:entry (mk :en-at-start) :exit (mk :ex-at-start)
+                                                        :on    {:seek :mid-track}}
+                                            :mid-track {:entry (mk :en-mid) :exit (mk :ex-mid)
+                                                        :on    {:stop [:player :stopped]}}}}}}}}
+          ;; Record :mid-track by stopping from it; then restore.
+          after-stop (step m (seed [:player :playing :mid-track]) [:stop])]
+      (reset! log [])
+      (let [restored (step m after-stop [:play])]
+        (is (= [:player :playing :mid-track] (:state restored)))
+        ;; LCA is :player — neither exited nor re-entered. Exit :stopped
+        ;; (the source leaf below the LCA), then enter :playing (shallowest)
+        ;; then :mid-track (deepest). The :initial of :playing (:at-start) is
+        ;; NOT descended — the deep recorded leaf overrides it.
+        (is (= [:ex-stopped :en-playing :en-mid] @log)
+            "exit source leaf, then entry shallowest-first to the recorded deep leaf; LCA :player untouched")))))
+
+;; ===========================================================================
+;; §4. DEFAULT-TARGET / :initial fallback (no usable recording)
+;; ===========================================================================
+
+(deftest first-entry-no-recording-uses-default-target
+  (testing "nothing recorded ⇒ the pseudo-state's :default-target (descended to its :initial)"
+    (let [m (player true)
+          restored (step m (seed [:player :stopped]) [:play])]
+      (is (= [:player :playing :at-start] (:state restored))
+          ":default-target :playing descended to its :initial :at-start"))))
+
+(deftest first-entry-no-default-target-falls-back-to-initial
+  (testing "no :default-target ⇒ the OWNING COMPOUND's :initial"
+    (let [m {:initial :player
+             :states  {:player {:initial :stopped
+                                :states  {:stopped {:on {:play [:player :hist]}}
+                                          :hist    {:type :history :deep? true}
+                                          :playing {:on {:stop :stopped}}}}}}
+          restored (step m (seed [:player :stopped]) [:play])]
+      (is (= [:player :stopped] (:state restored))
+          "no :default-target ⇒ :player's :initial (:stopped)"))))
+
+(deftest absent-deep-key-is-shallow
+  (testing "a missing :deep? reads as shallow (records the direct child, descends :initial)"
+    ;; player(false) has no :deep? at all — proves missing ≡ shallow.
+    (let [m (player false)
+          after-stop (step m (seed [:player :playing :mid-track]) [:stop])]
+      (is (= :playing (get-in after-stop [:rf/history [:player]]))
+          "missing :deep? records the direct child (shallow)"))))
+
+;; ===========================================================================
+;; §5. DANGLING recorded path after hot-reload (rf2-wgfv0)
+;;
+;; A recorded config the (hot-reloaded) definition no longer declares is
+;; discarded on restore — the runtime falls back, never enters the dead path.
+;; Benign — no :rf.error/*. Both the DEEP-leaf-removed and the SHALLOW-child-
+;; removed shapes. Spec 005 §Dangling recorded paths after hot reload.
+;; ===========================================================================
+
+(deftest dangling-deep-leaf-falls-back-no-error
+  (testing "a recorded DEEP leaf the definition removed falls back to :default-target; no error"
+    (let [m    (player true)
+          snap (assoc (seed [:player :stopped])
+                      :rf/history {[:player] [:player :playing :gone]})
+          r    (machines/machine-transition m snap [:play])]
+      (is (result/ok? r) "dangling deep path is benign — no failure Result")
+      (is (= [:player :playing :at-start] (:state (result/snap r)))
+          "discarded the dead leaf ⇒ fell back to :default-target → :at-start")
+      (is (empty? (filterv #(= :error (:op-type %)) @*captured*))
+          "no :rf.error/* trace for a dangling-at-runtime recording"))))
+
+(deftest dangling-shallow-child-falls-back-no-error
+  (testing "a recorded SHALLOW child the definition removed falls back; no error"
+    (let [m    (player false)
+          ;; :ghost is not a child of :player in the current definition.
+          snap (assoc (seed [:player :stopped]) :rf/history {[:player] :ghost})
+          r    (machines/machine-transition m snap [:play])]
+      (is (result/ok? r) "dangling shallow child is benign")
+      (is (= [:player :playing :at-start] (:state (result/snap r)))
+          "discarded the dead child ⇒ fell back to :default-target → :at-start")
+      (is (empty? (filterv #(= :error (:op-type %)) @*captured*))
+          "no :rf.error/* for a dangling shallow child"))))
+
+;; ===========================================================================
+;; §6. PER-REGION parallel history at STRUCTURALLY-IDENTICAL paths
+;;
+;; Two regions whose compounds sit at structurally-identical within-region
+;; paths ([:group]) record under REGION-QUALIFIED keys ([:left :group] /
+;; [:right :group]) that never collide. Restoring one region is isolated.
+;; Spec 005 §Composition with parallel regions — per-region history.
+;; ===========================================================================
+
+(defn- region []
+  {:initial :group
+   :states  {:group {:initial :off
+                     :states  {:off  {:on {:turn-on [:group :hist]}}
+                               :hist {:type :history :deep? true}
+                               :on   {:initial :dim
+                                      :on      {:turn-off [:group :off]}
+                                      :states  {:dim    {:on {:brighten :bright}}
+                                                :bright {:on {:turn-off [:group :off]}}}}}}}})
+
+(def parallel-history
+  {:type    :parallel
+   :regions {:left (region) :right (region)}})
+
+(deftest parallel-region-keys-never-collide-at-identical-paths
+  (testing "structurally-identical region compounds record under distinct region-qualified keys"
+    (let [snap0 {:state {:left [:group :on :bright] :right [:group :on :dim]} :data {}}
+          ;; Broadcast :turn-off to both regions; each records its own config.
+          off   (step parallel-history snap0 [:turn-off])]
+      (is (= {:left [:group :off] :right [:group :off]} (:state off))
+          "both regions turned off")
+      (is (= [:group :on :bright] (get-in off [:rf/history [:left :group]]))
+          ":left recorded under [:left :group]")
+      (is (= [:group :on :dim]    (get-in off [:rf/history [:right :group]]))
+          ":right recorded under [:right :group] — no collision despite identical structure")
+      (is (= 2 (count (:rf/history off))) "two distinct region-qualified entries"))))
+
+(deftest parallel-restore-one-region-leaves-sibling-untouched
+  (testing "restoring history in one region is isolated from siblings"
+    (let [snap0 {:state {:left [:group :on :bright] :right [:group :on :dim]} :data {}}
+          off   (step parallel-history snap0 [:turn-off])
+          ;; turn-on is on the :off leaf of BOTH regions — but each region only
+          ;; restores its OWN recorded config; the broadcast restores both.
+          ;; To isolate, drive a turn-on that only :left handles we cannot
+          ;; (same key) — so assert per-region independence via the recorded
+          ;; keys: re-entering restores each region to ITS OWN recorded leaf.
+          back  (step parallel-history off [:turn-on])]
+      (is (= [:group :on :bright] (get-in back [:state :left]))
+          ":left restored ITS recorded deep leaf (:bright)")
+      (is (= [:group :on :dim]    (get-in back [:state :right]))
+          ":right restored ITS OWN recorded deep leaf (:dim) — not :left's"))))
+
+;; ===========================================================================
+;; §7. SNAPSHOT REVERT (Goal 2) — :rf/history is part of the revertible VALUE
+;;
+;; The spec's load-bearing claim: history rides revertibility FOR FREE because
+;; the recording is part of the snapshot VALUE, not a side-table. Proven
+;; structurally: capture snapshot S1 (history H1), advance to S2 (history H2);
+;; re-running the engine from the EARLIER captured value S1 resolves against
+;; H1 — exactly what restore-epoch does when it rewinds the snapshot value.
+;; Plus the EDN round-trip (pr-str / read-string) the SSR-serialisation path
+;; and time-axis both ride.
+;; ===========================================================================
+
+(deftest history-slot-is-part-of-the-revertible-snapshot-value
+  (testing "re-running from an earlier captured snapshot value restores THAT value's history"
+    (let [m  (player true)
+          ;; Two captured snapshot values carrying DIFFERENT recorded leaves:
+          ;; S1 exits from :mid-track (records :mid-track); S2 exits from
+          ;; :at-start (records :at-start).
+          s1 (step m (seed [:player :playing :mid-track]) [:stop])
+          s2 (step m (seed [:player :playing :at-start])  [:stop])]
+      ;; H1 ≠ H2 — the two captured values carry DIFFERENT recorded leaves.
+      (is (= [:player :playing :mid-track] (get-in s1  [:rf/history [:player]])) "H1 = :mid-track")
+      (is (= [:player :playing :at-start]  (get-in s2  [:rf/history [:player]])) "H2 = :at-start")
+      ;; The load-bearing assertion: each captured value is self-contained.
+      ;; "Reverting" = re-using the earlier value as the engine's input — no
+      ;; external history side-table is consulted, so a restore off S1 resolves
+      ;; H1 and a restore off S2 resolves H2, totally independently. This is
+      ;; exactly what restore-epoch does when it rewinds the snapshot value.
+      (is (= [:player :playing :mid-track] (:state (step m s1 [:play])))
+          "restore off the reverted S1 value resolves S1's recorded leaf (H1)")
+      (is (= [:player :playing :at-start]  (:state (step m s2 [:play])))
+          "restore off S2 resolves S2's recorded leaf (H2) — histories revert with their values"))))
+
+(deftest history-slot-edn-round-trips
+  (testing ":rf/history survives pr-str / read-string (SSR-serialisation + time-axis shape)"
+    (let [m   (player true)
+          s1  (step m (seed [:player :playing :mid-track]) [:stop])
+          ;; The whole snapshot (incl. :rf/history) round-trips =-equal.
+          rt  #?(:clj  (read-string (pr-str s1))
+                 :cljs (cljs.reader/read-string (pr-str s1)))]
+      (is (= s1 rt) "snapshot incl. :rf/history round-trips =-equal")
+      ;; And a restore off the round-tripped value resolves the recorded leaf.
+      (is (= [:player :playing :mid-track] (:state (step m rt [:play])))
+          "restore works off a round-tripped snapshot (server→client / epoch replay)"))))
+
+;; ===========================================================================
+;; §8. TRACE shapes — the corners the smoke does not reach
+;;
+;; Spec/009 §History trace events: the deep-nesting exit emits TWO
+;; `:rf.machine.history/recorded` events (one per history-bearing compound) in
+;; one cascade; a nested deep restore stamps `:source :recorded` on the
+;; history-driven :entry cascade steps. Asserts the exact tag keys.
+;; ===========================================================================
+
+(deftest deep-nesting-emits-one-recorded-per-compound
+  (testing "exiting two history-bearing compounds emits two :rf.machine.history/recorded events"
+    (reset-capture!)
+    (step nested (seed [:outer :b :b2]) [:leave])
+    (let [recs (history-events :rf.machine.history/recorded)
+          by-path (into {} (map (juxt #(:compound-path (:tags %)) :tags)) recs)]
+      (is (= 2 (count recs)) "two recorded events — one per history-bearing compound")
+      (is (contains? by-path [:outer])    "the outer compound recorded")
+      (is (contains? by-path [:outer :b]) "the nested-inner compound recorded")
+      ;; Both deep, both first-ever (no :prev-config), both full leaf paths.
+      (doseq [[path tags] by-path]
+        (is (= :deep (:kind tags)) (str path " recorded :kind :deep"))
+        (is (= [:outer :b :b2] (:recorded-config tags))
+            (str path " recorded the full deep leaf"))
+        (is (not (contains? tags :prev-config))
+            (str path " :prev-config absent on the first-ever recording"))))))
+
+(deftest nested-restore-stamps-source-on-entry-steps
+  (testing "the history-driven :entry steps of a nested deep restore carry :source :recorded"
+    (let [away (step nested (seed [:outer :b :b2]) [:leave])]
+      (reset-capture!)
+      (let [r       (machines/machine-transition nested away [:return])
+            cascade (result/cascade r)
+            entries (filterv #(= :entry (:kind %)) cascade)
+            restored (history-events :rf.machine.history/restored)]
+        (is (result/ok? r))
+        (is (= 1 (count restored)) "one restored event for the outer history re-entry")
+        (is (= :recorded (:source (first restored))) ":source :recorded (hoisted to envelope)")
+        (is (= [:outer] (:compound-path (:tags (first restored))))
+            ":compound-path is the OUTER compound's declaration path")
+        (is (seq entries) "the restore produced entry steps")
+        (is (every? #(= :recorded (:source %)) entries)
+            "every history-driven :entry step carries :source :recorded")))))
+
+(deftest recorded-prev-config-on-second-exit
+  (testing ":prev-config names the value overwritten on a second recording for the same compound"
+    ;; Seed an already-allocated slot (as a prior exit would leave it), then
+    ;; exit from a DIFFERENT leaf — the new -recorded event reports :prev-config
+    ;; = the seeded value it overwrote.
+    (let [m     (player true)
+          snap0 (assoc (seed [:player :playing :at-start])
+                       :rf/history {[:player] [:player :playing :mid-track]})]
+      (reset-capture!)
+      (step m snap0 [:stop])
+      (let [tags (:tags (first (history-events :rf.machine.history/recorded)))]
+        (is (= [:player :playing :mid-track] (:prev-config tags))
+            ":prev-config = the value the slot held before this write")
+        (is (= [:player :playing :at-start] (:recorded-config tags))
+            ":recorded-config = the value written by this exit")))))

--- a/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
@@ -94,14 +94,17 @@
       (W3C SCXML §3.10, e.g. test 387, 388, 579, 580 history family).
       re-frame2 ships FIRST-CLASS history (rf2-mle6e — the post-v1 deferral
       is withdrawn): `{:type :history :deep? <bool> :default-target <t>}` is
-      a targetable pseudo-state under a compound's `:states`. The §History
-      section below now carries only the registration-time GRAMMAR-CONSTRAINT
-      rejections the engine enforces (a `:type :history` node MUST have an
-      owning compound — `:rf.error/machine-history-misplaced`). The
-      COMPREHENSIVE record/restore conformance corpus (W3C 387/388/579/580
-      adapted) lands under rf2-mle6e.4; this file keeps only the minimal
-      placement-rejection assertions + a smoke that a well-placed history
-      node validates.
+      a targetable pseudo-state under a compound's `:states`. NO LONGER an
+      exclusion — the §History section below now carries BOTH the
+      registration-time GRAMMAR-CONSTRAINT rejections (a `:type :history` node
+      MUST have an owning compound — `:rf.error/machine-history-misplaced`)
+      AND the RECORD/RESTORE behavioural corpus (the W3C 387/388/579/580
+      family adapted to the re-frame2 grammar shape). The Mode-B
+      `:machine-transition` fixture counterparts live at
+      `spec/conformance/fixtures/scxml-history-test{387,388,579,580}-*.edn`
+      and `history-{shallow,deep,default-target,per-region,dangling}-*.edn`
+      (rf2-mle6e.4). This entry is retained in the EXCLUSIONS list only as a
+      historical marker — history is now COVERED, not excluded.
 
   ## Divergences found
 
@@ -780,17 +783,31 @@
           "the compound :wrapper ancestor is NOT itself final (leaf-only property)"))))
 
 ;; ===========================================================================
-;; §13. HISTORY — first-class grammar, placement rejections (SCXML §3.10)
+;; §13. HISTORY — first-class grammar + record/restore (SCXML §3.10)
 ;;
 ;; SCXML §3.10 `<history type="shallow|deep">` records and restores the
 ;; most recent active descendant of a compound/parallel state. re-frame2
 ;; ships FIRST-CLASS history (rf2-mle6e — the post-v1 deferral is withdrawn):
 ;; `{:type :history :deep? <bool> :default-target <t>}` under a compound's
-;; `:states`. The COMPREHENSIVE record/restore conformance corpus (the W3C
-;; 387/388/579/580 record-and-restore behaviour) lands under rf2-mle6e.4;
-;; this section keeps only the registration-time PLACEMENT-CONSTRAINT
-;; rejections the engine enforces (a `:type :history` node MUST have an
-;; owning compound) + a smoke that a well-placed history node validates.
+;; `:states`. This section covers BOTH halves:
+;;   §13a — the registration-time PLACEMENT / GRAMMAR-CONSTRAINT rejections the
+;;          engine enforces (a `:type :history` node MUST have an owning
+;;          compound; the closed key-set; one-per-compound).
+;;   §13b — the RECORD/RESTORE behavioural corpus, the W3C 387/388/579/580
+;;          history family ADAPTED to the re-frame2 grammar shape (rf2-mle6e.4).
+;;          The Mode-B `:machine-transition` fixture counterparts live at
+;;          `spec/conformance/fixtures/scxml-history-test*-*.edn` +
+;;          `history-*-*.edn`; these in-corpus tests give the same coverage
+;;          dual-runtime (JVM + CLJS).
+;;
+;; SCXML ADAPTATION NOTES (cited per assertion below). re-frame2 is NOT an
+;; SCXML processor — no datamodel / `<raise>` / `<send>` — so each W3C test's
+;; statechart SHAPE and its last-active-config restoration SEQUENCE are
+;; translated, not the `.scxml` verbatim. One structural divergence recurs:
+;; W3C charts declare a deep AND a shallow `<history>` as SIBLINGS under one
+;; state; re-frame2 permits AT MOST ONE history pseudo-state per compound
+;; (deep-vs-shallow is the single node's `:deep?`), so a multi-history W3C
+;; chart is split into per-depth machines of identical geometry.
 ;; ===========================================================================
 
 (defn- history-rejection-id
@@ -868,3 +885,144 @@
                                            :playing {:initial :at-start
                                                      :states {:at-start {}}}}}}}))
         "a well-placed first-class history pseudo-state validates without error")))
+
+(deftest scxml-history-duplicate-per-compound-rejected
+  (testing "SCXML §3.10 / re-frame2 divergence: SCXML allows sibling
+            shallow+deep <history> under one state, but re-frame2 permits AT
+            MOST ONE history pseudo-state per compound (deep-vs-shallow is the
+            single node's `:deep?`). Two history children under one compound is
+            `:rf.error/machine-history-duplicate`. Spec 005 §Pseudo-state
+            constraints. This is the divergence the W3C-adapted fixtures
+            (scxml-history-test387/388) split around."
+    (is (= :rf.error/machine-history-duplicate
+           (history-rejection-id
+             {:initial :s0
+              :states  {:s0 {:initial :s01
+                             :states  {:s01          {}
+                                       :s02          {}
+                                       :hist-deep    {:type :history :deep? true}
+                                       :hist-shallow {:type :history}}}}}))
+        "two history nodes under one compound is rejected as duplicate")))
+
+(deftest scxml-history-bad-default-target-rejected
+  (testing "SCXML §3.10: a history pseudo-state's default transition must target
+            a real state. re-frame2 rejects a `:default-target` that does not
+            resolve (not a direct child of the owning compound, nor a declared
+            absolute path) with `:rf.error/machine-history-bad-default-target`.
+            Spec 005 §Pseudo-state constraints."
+    (is (= :rf.error/machine-history-bad-default-target
+           (history-rejection-id
+             {:initial :s0
+              :states  {:s0 {:initial :s01
+                             :states  {:s01  {}
+                                       :hist {:type :history :default-target :nonexistent}}}}}))
+        "an unresolvable :default-target is rejected")))
+
+;; ---------------------------------------------------------------------------
+;; §13b. HISTORY record/restore — the W3C 387/388/579/580 family adapted
+;; ---------------------------------------------------------------------------
+;;
+;; Behavioural corpus driven through the pure `machine-transition` engine
+;; (`step` above unwraps the Result). Each test cites the W3C test id it
+;; derives from and the re-frame2 spec anchor; the EDN Mode-B counterparts at
+;; spec/conformance/fixtures/ give the same coverage through the conformance
+;; runner. These run dual-runtime (JVM + CLJS) so the engine's history
+;; semantics are externally proven on both.
+
+(deftest scxml-history-test388-deep-restores-exact-leaf
+  (testing "W3C test388 (DEEP arm): deep history restores the EXACT deepest
+            prior leaf, not the compound's :initial. Spec 005 §Restoration."
+    (let [m {:initial :s0
+             :states  {:s0   {:initial :s01
+                              :on      {:leave :away}
+                              :states  {:s01  {:initial :s011 :states {:s011 {} :s012 {}}}
+                                        :s02  {:initial :s021 :states {:s021 {} :s022 {}}}
+                                        :hist {:type :history :deep? true :default-target :s022}}}
+                       :away {:on {:return [:s0 :hist]}}}}
+          left (step m {:state [:s0 :s01 :s012] :data {}} [:leave])]
+      (is (= [:s0 :s01 :s012] (get-in (:snapshot left) [:rf/history [:s0]]))
+          "deep recorded the full leaf path on exit")
+      (is (= [:s0 :s01 :s012] (:state (step m (:snapshot left) [:return])))
+          "deep restored the EXACT recorded leaf (s012)"))))
+
+(deftest scxml-history-test388-shallow-restores-child-then-initial
+  (testing "W3C test388 (SHALLOW arm): shallow history restores only the
+            immediate child and applies its :initial — from the IDENTICAL exit
+            leaf as the deep arm. Spec 005 §Restoration."
+    (let [m {:initial :s0
+             :states  {:s0   {:initial :s01
+                              :on      {:leave :away}
+                              :states  {:s01  {:initial :s011 :states {:s011 {} :s012 {}}}
+                                        :s02  {:initial :s021 :states {:s021 {} :s022 {}}}
+                                        :hist {:type :history :default-target :s02}}}
+                       :away {:on {:return [:s0 :hist]}}}}
+          left (step m {:state [:s0 :s01 :s012] :data {}} [:leave])]
+      (is (= :s01 (get-in (:snapshot left) [:rf/history [:s0]]))
+          "shallow recorded only the direct child :s01")
+      (is (= [:s0 :s01 :s011] (:state (step m (:snapshot left) [:return])))
+          "shallow restored :s01 then its :initial (s011), NOT the deep leaf s012"))))
+
+(deftest scxml-history-test387-default-fires-at-both-levels
+  (testing "W3C test387: the default history transition resolves correctly at
+            both shallow (child's :initial descent) and deep (exact deep
+            target) levels on FIRST entry (no recording). Spec 005 §Restoration
+            — never-entered = :default-target / :initial."
+    ;; Shallow default → child's :initial descent.
+    (let [shallow {:initial :hub
+                   :states  {:hub {:on {:into [:s0 :hist]}}
+                             :s0  {:initial :s01
+                                   :states  {:s01  {:initial :s011 :states {:s011 {} :s012 {}}}
+                                             :hist {:type :history :default-target :s01}}}}}]
+      (is (= [:s0 :s01 :s011] (:state (step shallow {:state :hub :data {}} [:into])))
+          "shallow :default-target :s01 descended to its :initial s011"))
+    ;; Deep default → exact deep target.
+    (let [deep {:initial :hub
+                :states  {:hub {:on {:into [:s1 :hist]}}
+                          :s1  {:initial :s11
+                                :states  {:s11  {:initial :s111 :states {:s111 {} :s112 {}}}
+                                          :s12  {:initial :s121 :states {:s121 {} :s122 {}}}
+                                          :hist {:type :history :deep? true
+                                                 :default-target [:s1 :s12 :s122]}}}}}]
+      (is (= [:s1 :s12 :s122] (:state (step deep {:state :hub :data {}} [:into])))
+          "deep :default-target resolves to the exact deep target s122"))))
+
+(deftest scxml-history-test579-default-only-when-no-recording
+  (testing "W3C test579: the default history transition fires ONLY when nothing
+            is recorded; once a config is stored it overrides the default.
+            Spec 005 §Restoration."
+    (let [m {:initial :s0
+             :states  {:s0   {:initial :sh
+                              :on      {:leave :away}
+                              :states  {:sh  {:type :history :default-target :s01}
+                                        :s01 {:on {:next :s02}}
+                                        :s02 {:on {:next :s03}}
+                                        :s03 {}}}
+                       :away {:on {:return [:s0 :sh]}}}}]
+      (is (= [:s0 :s01] (:state (step m {:state :away :data {}} [:return])))
+          "first entry (no recording) ⇒ :default-target :s01")
+      (is (= [:s0 :s02]
+             (:state (step m {:state :away :data {} :rf/history {[:s0] :s02}} [:return])))
+          "a recorded config (:s02) overrides the default — default NOT re-applied"))))
+
+(deftest scxml-history-test580-parallel-region-shallow
+  (testing "W3C test580: a shallow history inside a compound within a PARALLEL
+            region remembers the most-recent child, keyed region-qualified; the
+            sibling region is unaffected. Spec 005 §Composition with parallel
+            regions — per-region history."
+    (let [m {:type    :parallel
+             :regions {:s0 {:initial :idle :states {:idle {} :busy {}}}
+                       :s1 {:initial :group
+                            :states  {:group  {:initial :sh
+                                               :on      {:exit-to-park [:s1park]}
+                                               :states  {:sh  {:type :history :default-target :s11}
+                                                         :s11 {:on {:to12 :s12}}
+                                                         :s12 {}}}
+                                      :s1park {:on {:back [:group :sh]}}}}}}
+          parked (step m {:state {:s0 :idle :s1 [:group :s12]} :data {}} [:exit-to-park])]
+      (is (= :s12 (get-in (:snapshot parked) [:rf/history [:s1 :group]]))
+          "shallow recorded :s12 under the region-qualified key [:s1 :group]")
+      (let [back (step m (:snapshot parked) [:back])]
+        (is (= [:group :s12] (get-in (:snapshot back) [:state :s1]))
+            "region :s1 restored its remembered child :s12")
+        (is (= :idle (get-in (:snapshot back) [:state :s0]))
+            "sibling region :s0 untouched by the :s1 history restore")))))

--- a/spec/conformance/fixtures/history-dangling-path-falls-back.edn
+++ b/spec/conformance/fixtures/history-dangling-path-falls-back.edn
@@ -1,0 +1,69 @@
+;; Conformance fixture: machine/history-dangling-path-falls-back
+;;
+;; First-class history dangling-path fallback (rf2-mle6e / rf2-wgfv0). A
+;; recorded configuration in `:rf/history` may reference a substate a
+;; hot-reloaded definition REMOVED — a *dangling recorded path*. On a
+;; restore-to-history transition the runtime DISCARDS the dead recorded path
+;; and falls back to the pseudo-state's `:default-target` (or the compound's
+;; `:initial`), cascading from there exactly as a first-ever entry would. The
+;; runtime never enters a dead path. This is a benign, expected consequence of
+;; hot reload — NOT an error; no `:rf.error/*` is raised.
+;;
+;; Per [005 §Dangling recorded paths after hot reload]
+;; (../../005-StateMachines.md#dangling-recorded-paths-after-hot-reload).
+
+{:fixture/id           :machine/history-dangling-path-falls-back
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/history}
+ :fixture/doc          "A recorded config the (hot-reloaded) definition no longer declares is discarded on restore; the runtime falls back to :default-target (deep arm) or the compound :initial (no-default arm), never entering the dead path. Benign — no error."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) DEEP dangling leaf: the seeded :rf/history references [:player :playing
+  ;; :gone], which the current definition does not declare. The restore
+  ;; discards it and falls back to :default-target :playing → :at-start. The
+  ;; exit cascade overwrites the slot with the valid outgoing :stopped config.
+  {:call         :machine-transition
+   :definition
+   {:initial :player
+    :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history :deep? true :default-target :playing}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}}
+   :snapshot     {:state    [:player :stopped]
+                  :data     {}
+                  :rf/history {[:player] [:player :playing :gone]}}
+   :event        [:play]
+   :expect-next-snapshot {:state    [:player :playing :at-start]
+                          :data     {}
+                          :rf/history {[:player] [:player :stopped]}}
+   :expect-effects       []}
+
+  ;; (2) SHALLOW dangling child: the seeded :rf/history records the child :ghost,
+  ;; not a child of :player in the current definition. Discarded; falls back to
+  ;; :default-target :playing → :at-start.
+  {:call         :machine-transition
+   :definition
+   {:initial :player
+    :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history :default-target :playing}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}}
+   :snapshot     {:state    [:player :stopped]
+                  :data     {}
+                  :rf/history {[:player] :ghost}}
+   :event        [:play]
+   :expect-next-snapshot {:state    [:player :playing :at-start]
+                          :data     {}
+                          :rf/history {[:player] :stopped}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/history-deep-restores-leaf-path.edn
+++ b/spec/conformance/fixtures/history-deep-restores-leaf-path.edn
@@ -1,0 +1,69 @@
+;; Conformance fixture: machine/history-deep-restores-leaf-path
+;;
+;; First-class DEEP history (rf2-mle6e). A `{:type :history :deep? true}`
+;; pseudo-state under a compound's `:states` records that compound's FULL
+;; active leaf path on exit (into the revertible `:rf/history` snapshot slot,
+;; keyed by the compound's declaration path) and restores the EXACT recorded
+;; leaf on re-entry — NOT the compound's `:initial`.
+;;
+;; Mode B (`:machine-transition`) record→restore, expressed as two independent
+;; calls: call (1) EXITS the compound from a deep leaf and asserts the recorded
+;; `:rf/history` slot; call (2) RE-ENTERS via the history pseudo-state (its
+;; input snapshot = call (1)'s expected output) and asserts the full recorded
+;; leaf is restored.
+;;
+;; Per [005 §History states](../../005-StateMachines.md#history-states-type-history--shallow--deep--default-target)
+;; §Recording / §Restoration.
+
+{:fixture/id           :machine/history-deep-restores-leaf-path
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/history}
+ :fixture/doc          "Deep history records the full active leaf path on the compound's exit (into :rf/history keyed by the compound's declaration path) and restores that EXACT leaf on re-entry, not the compound's :initial."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) RECORD: exit :player from the deep leaf [:player :playing :mid-track]
+  ;; via :stop. The deep history records the full leaf path under [:player].
+  {:call         :machine-transition
+   :definition
+   {:initial :player
+    :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history :deep? true :default-target :playing}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}}
+   :snapshot     {:state [:player :playing :mid-track] :data {}}
+   :event        [:stop]
+   :expect-next-snapshot {:state    [:player :stopped]
+                          :data     {}
+                          :rf/history {[:player] [:player :playing :mid-track]}}
+   :expect-effects       []}
+
+  ;; (2) RESTORE: re-enter via the history pseudo-state ([:player :hist]). The
+  ;; recorded deep leaf is restored exactly. The restore ALSO records the
+  ;; outgoing config [:player :stopped] (the exit cascade overwrites the slot),
+  ;; so the post snapshot's :rf/history shows the now-overwritten value.
+  {:call         :machine-transition
+   :definition
+   {:initial :player
+    :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history :deep? true :default-target :playing}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}}
+   :snapshot     {:state    [:player :stopped]
+                  :data     {}
+                  :rf/history {[:player] [:player :playing :mid-track]}}
+   :event        [:play]
+   :expect-next-snapshot {:state    [:player :playing :mid-track]
+                          :data     {}
+                          :rf/history {[:player] [:player :stopped]}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/history-default-target-on-first-entry.edn
+++ b/spec/conformance/fixtures/history-default-target-on-first-entry.edn
@@ -1,0 +1,58 @@
+;; Conformance fixture: machine/history-default-target-on-first-entry
+;;
+;; First-class history default fallback (rf2-mle6e). When a transition resolves
+;; to a history pseudo-state but NOTHING was recorded for the owning compound
+;; (the compound was never exited), the runtime falls back to the pseudo-state's
+;; `:default-target` — or, when `:default-target` is absent, to the compound's
+;; `:initial`. Both arms are pinned here as two independent calls.
+;;
+;; Per [005 §History states §Restoration](../../005-StateMachines.md#restoration--on-re-entry-resolving-the-pseudo-state):
+;; "never-entered = `:default-target` (or `:initial`)".
+
+{:fixture/id           :machine/history-default-target-on-first-entry
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/history}
+ :fixture/doc          "First entry (no recording) resolves a history pseudo-state to its :default-target (descended to that target's :initial); when no :default-target is declared, it falls back to the owning compound's :initial."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) :default-target DECLARED, nothing recorded ⇒ :default-target :playing,
+  ;; descended to its :initial (:at-start). The restore transition records the
+  ;; outgoing :stopped on the way (the slot is allocated for the first time).
+  {:call         :machine-transition
+   :definition
+   {:initial :player
+    :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history :deep? true :default-target :playing}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}}
+   :snapshot     {:state [:player :stopped] :data {}}
+   :event        [:play]
+   :expect-next-snapshot {:state    [:player :playing :at-start]
+                          :data     {}
+                          :rf/history {[:player] [:player :stopped]}}
+   :expect-effects       []}
+
+  ;; (2) NO :default-target, nothing recorded ⇒ the owning compound's :initial
+  ;; (:stopped). The restore is a no-op move (already at :stopped), recording
+  ;; :stopped as the outgoing config.
+  {:call         :machine-transition
+   :definition
+   {:initial :player
+    :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history :deep? true}
+                         :playing {:on {:stop :stopped}}}}}}
+   :snapshot     {:state [:player :stopped] :data {}}
+   :event        [:play]
+   :expect-next-snapshot {:state    [:player :stopped]
+                          :data     {}
+                          :rf/history {[:player] [:player :stopped]}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/history-per-region-parallel.edn
+++ b/spec/conformance/fixtures/history-per-region-parallel.edn
@@ -1,0 +1,84 @@
+;; Conformance fixture: machine/history-per-region-parallel
+;;
+;; First-class PER-REGION history under `:type :parallel` (rf2-mle6e). Each
+;; region runs an independent state-tree, so history is per-region: a history
+;; pseudo-state inside a region's compound records THAT region's last-active
+;; config and restores it independently of siblings. The `:rf/history` keys are
+;; REGION-QUALIFIED — the head segment is the region name — so two regions with
+;; STRUCTURALLY-IDENTICAL within-region compound paths ([:group]) never collide.
+;;
+;; Per [005 §Composition with parallel regions — per-region history]
+;; (../../005-StateMachines.md#composition-with-parallel-regions--per-region-history).
+
+{:fixture/id           :machine/history-per-region-parallel
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/parallel-regions :fsm/history}
+ :fixture/doc          "Parallel per-region deep history: each region records its own last-active config under a REGION-QUALIFIED key ([<region> :group]); structurally-identical region compounds never collide, and re-entry restores each region to its OWN recorded leaf."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) RECORD: a :turn-off broadcast exits the :on subtree in BOTH regions.
+  ;; Each region records its OWN deep leaf, keyed by [<region> :group].
+  {:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :regions {:left  {:initial :group
+                      :states  {:group {:initial :off
+                                        :states  {:off  {:on {:turn-on [:group :hist]}}
+                                                  :hist {:type :history :deep? true}
+                                                  :on   {:initial :dim
+                                                         :on      {:turn-off [:group :off]}
+                                                         :states  {:dim    {:on {:brighten :bright}}
+                                                                   :bright {:on {:turn-off [:group :off]}}}}}}}}
+              :right {:initial :group
+                      :states  {:group {:initial :off
+                                        :states  {:off  {:on {:turn-on [:group :hist]}}
+                                                  :hist {:type :history :deep? true}
+                                                  :on   {:initial :dim
+                                                         :on      {:turn-off [:group :off]}
+                                                         :states  {:dim    {:on {:brighten :bright}}
+                                                                   :bright {:on {:turn-off [:group :off]}}}}}}}}}}
+   :snapshot     {:state {:left [:group :on :bright] :right [:group :on :dim]} :data {}}
+   :event        [:turn-off]
+   :expect-next-snapshot
+   {:state    {:left [:group :off] :right [:group :off]}
+    :data     {}
+    :rf/history {[:left :group]  [:group :on :bright]
+                 [:right :group] [:group :on :dim]}}
+   :expect-effects       []}
+
+  ;; (2) RESTORE: a :turn-on broadcast re-enters each region via ITS OWN history.
+  ;; :left restores :bright, :right restores :dim — no cross-region leak. The
+  ;; exit cascades re-record the outgoing :off config per region.
+  {:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :regions {:left  {:initial :group
+                      :states  {:group {:initial :off
+                                        :states  {:off  {:on {:turn-on [:group :hist]}}
+                                                  :hist {:type :history :deep? true}
+                                                  :on   {:initial :dim
+                                                         :on      {:turn-off [:group :off]}
+                                                         :states  {:dim    {:on {:brighten :bright}}
+                                                                   :bright {:on {:turn-off [:group :off]}}}}}}}}
+              :right {:initial :group
+                      :states  {:group {:initial :off
+                                        :states  {:off  {:on {:turn-on [:group :hist]}}
+                                                  :hist {:type :history :deep? true}
+                                                  :on   {:initial :dim
+                                                         :on      {:turn-off [:group :off]}
+                                                         :states  {:dim    {:on {:brighten :bright}}
+                                                                   :bright {:on {:turn-off [:group :off]}}}}}}}}}}
+   :snapshot     {:state    {:left [:group :off] :right [:group :off]}
+                  :data     {}
+                  :rf/history {[:left :group]  [:group :on :bright]
+                               [:right :group] [:group :on :dim]}}
+   :event        [:turn-on]
+   :expect-next-snapshot
+   {:state    {:left [:group :on :bright] :right [:group :on :dim]}
+    :data     {}
+    :rf/history {[:left :group]  [:group :off]
+                 [:right :group] [:group :off]}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/history-shallow-restores-direct-child.edn
+++ b/spec/conformance/fixtures/history-shallow-restores-direct-child.edn
@@ -1,0 +1,65 @@
+;; Conformance fixture: machine/history-shallow-restores-direct-child
+;;
+;; First-class SHALLOW history (rf2-mle6e). A `{:type :history}` pseudo-state
+;; (no `:deep?`, or `:deep? false`) records only the compound's DIRECT CHILD
+;; on exit; on re-entry the runtime restores that child then CASCADES through
+;; the child's OWN `:initial` chain — so a deep leaf at exit restores only to
+;; the child's `:initial`, NOT the exact exit leaf. This is the depth contrast
+;; with `history-deep-restores-leaf-path` (identical shape, identical exit leaf,
+;; different restore).
+;;
+;; Per [005 §History states](../../005-StateMachines.md#history-states-type-history--shallow--deep--default-target):
+;; "missing `:deep?` reads as `:deep? false`" (shallow is the default).
+
+{:fixture/id           :machine/history-shallow-restores-direct-child
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/history}
+ :fixture/doc          "Shallow history records only the compound's direct child on exit; on re-entry it restores that child and descends the child's own :initial chain (NOT the exact deep exit leaf). A missing :deep? reads as shallow."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) RECORD: exit :player from the deep leaf [:player :playing :mid-track].
+  ;; Shallow history records ONLY the direct child keyword (:playing).
+  {:call         :machine-transition
+   :definition
+   {:initial :player
+    :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history :default-target :playing}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}}
+   :snapshot     {:state [:player :playing :mid-track] :data {}}
+   :event        [:stop]
+   :expect-next-snapshot {:state    [:player :stopped]
+                          :data     {}
+                          :rf/history {[:player] :playing}}
+   :expect-effects       []}
+
+  ;; (2) RESTORE: re-enter via [:player :hist]. The recorded direct child
+  ;; (:playing) is restored, then its :initial chain (:at-start) is descended —
+  ;; landing at [:player :playing :at-start], NOT the recorded-from :mid-track.
+  ;; The exit cascade overwrites the slot with the outgoing config (:stopped).
+  {:call         :machine-transition
+   :definition
+   {:initial :player
+    :states  {:player
+              {:initial :stopped
+               :states  {:stopped {:on {:play [:player :hist]}}
+                         :hist    {:type :history :default-target :playing}
+                         :playing {:initial :at-start
+                                   :on      {:stop [:player :stopped]}
+                                   :states  {:at-start  {:on {:seek :mid-track}}
+                                             :mid-track {:on {:stop [:player :stopped]}}}}}}}}
+   :snapshot     {:state    [:player :stopped]
+                  :data     {}
+                  :rf/history {[:player] :playing}}
+   :event        [:play]
+   :expect-next-snapshot {:state    [:player :playing :at-start]
+                          :data     {}
+                          :rf/history {[:player] :stopped}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/scxml-history-test387-shallow-and-deep-default.edn
+++ b/spec/conformance/fixtures/scxml-history-test387-shallow-and-deep-default.edn
@@ -1,0 +1,62 @@
+;; Conformance fixture: machine/scxml-history-test387-shallow-and-deep-default
+;;
+;; ADAPTED from W3C SCXML IRP test387 (https://www.w3.org/Voice/2013/scxml-irp/387/test387.txml).
+;; Mandatory-automated history test. test387 verifies the DEFAULT history
+;; transition fires correctly at BOTH shallow and deep levels when no history
+;; is yet recorded: entering a compound via its shallow-history pseudo-state on
+;; first entry lands on the shallow default's :initial descent; entering a
+;; DIFFERENT compound via its deep-history pseudo-state on first entry lands on
+;; the deep default's exact target.
+;;
+;; SEMANTIC DIVERGENCE FROM SCXML (cited): test387's two compounds (s0, s1) each
+;; declare BOTH a shallow and a deep <history> sibling. re-frame2 permits at
+;; most one history node per compound, so the adaptation keeps each compound's
+;; SINGLE history node and exercises the two default arms across the two
+;; compounds: :s0 carries the shallow node, :s1 the deep node — preserving
+;; test387's "default fires at both shallow and deep levels" contract. re-frame2
+;; is not an SCXML processor (no datamodel / <raise>); the chart shape and the
+;; first-entry default-resolution sequence are translated.
+;;
+;; Per [005 §History states §Restoration](../../005-StateMachines.md#restoration--on-re-entry-resolving-the-pseudo-state)
+;; ("never-entered = :default-target / :initial").
+
+{:fixture/id           :machine/scxml-history-test387-shallow-and-deep-default
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/history}
+ :fixture/doc          "W3C SCXML test387 adapted: the default history transition resolves correctly at both shallow (s0 — child's :initial descent) and deep (s1 — exact deep target) levels on first entry when no history is recorded. Each compound carries one history node (one-per-compound grammar)."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) SHALLOW default on first entry: enter :s0 via its shallow history
+  ;; pseudo-state from the top-level :hub; nothing recorded ⇒ :default-target
+  ;; :s01 descended to its :initial (:s011).
+  {:call         :machine-transition
+   :definition
+   {:initial :hub
+    :states  {:hub {:on {:into-s0 [:s0 :hist]}}
+              :s0  {:initial :s01
+                    :states  {:s01  {:initial :s011 :states {:s011 {} :s012 {}}}
+                              :s02  {:initial :s021 :states {:s021 {} :s022 {}}}
+                              :hist {:type :history :default-target :s01}}}}}
+   :snapshot     {:state :hub :data {}}
+   :event        [:into-s0]
+   :expect-next-snapshot {:state [:s0 :s01 :s011] :data {}}
+   :expect-effects       []}
+
+  ;; (2) DEEP default on first entry: enter :s1 via its deep history
+  ;; pseudo-state from :hub; nothing recorded ⇒ :default-target [:s1 :s12 :s122]
+  ;; (the exact deep target, no :initial re-descent past it).
+  {:call         :machine-transition
+   :definition
+   {:initial :hub
+    :states  {:hub {:on {:into-s1 [:s1 :hist]}}
+              :s1  {:initial :s11
+                    :states  {:s11  {:initial :s111 :states {:s111 {} :s112 {}}}
+                              :s12  {:initial :s121 :states {:s121 {} :s122 {}}}
+                              :hist {:type :history :deep? true :default-target [:s1 :s12 :s122]}}}}}
+   :snapshot     {:state :hub :data {}}
+   :event        [:into-s1]
+   :expect-next-snapshot {:state [:s1 :s12 :s122] :data {}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/scxml-history-test388-deep-vs-shallow.edn
+++ b/spec/conformance/fixtures/scxml-history-test388-deep-vs-shallow.edn
@@ -1,0 +1,97 @@
+;; Conformance fixture: machine/scxml-history-test388-deep-vs-shallow
+;;
+;; ADAPTED from W3C SCXML IRP test388 (https://www.w3.org/Voice/2013/scxml-irp/388/test388.txml).
+;; Mandatory-automated history test. test388 demonstrates the DEEP-vs-SHALLOW
+;; distinction: a compound :s0 (children :s01 ⊃ {s011, s012}, :s02 ⊃ {s021,
+;; s022}) is entered deep at s012, left, and re-entered via history —
+;;   - DEEP history restores the EXACT deepest prior leaf (s012);
+;;   - SHALLOW history restores only the immediate child (s01) then applies its
+;;     :initial (s011).
+;;
+;; SEMANTIC DIVERGENCE FROM SCXML (cited): the SCXML source declares BOTH a
+;; <history type="deep"> and a <history type="shallow"> as SIBLINGS under the
+;; same <state id="s0">. re-frame2 rules AT MOST ONE history pseudo-state per
+;; compound (deep-vs-shallow is the single node's `:deep?`, not two nodes — a
+;; second is `:rf.error/machine-history-duplicate`, per
+;; [005 §Pseudo-state constraints](../../005-StateMachines.md#pseudo-state-constraints)).
+;; So the adaptation SPLITS the one SCXML chart into TWO machines with identical
+;; geometry, one deep / one shallow, exercised from the IDENTICAL recorded exit
+;; leaf — preserving the test's behavioural contrast exactly while honouring the
+;; one-history-per-compound grammar. re-frame2 is not an SCXML processor (no
+;; datamodel / <raise> / <send>); the chart SHAPE and the last-active-config
+;; restoration SEQUENCE are translated, not the .scxml verbatim.
+;;
+;; Per [005 §History states](../../005-StateMachines.md#history-states-type-history--shallow--deep--default-target).
+
+{:fixture/id           :machine/scxml-history-test388-deep-vs-shallow
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/history}
+ :fixture/doc          "W3C SCXML test388 adapted: deep history restores the exact deepest prior leaf (s012); shallow history restores only the immediate child (s01) and applies its :initial (s011). Split into two machines (one deep / one shallow) because re-frame2 permits at most one history node per compound."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; ---- DEEP machine ----
+  ;; (1d) Record: leave :s0 from the deepest leaf [:s0 :s01 :s012].
+  {:call         :machine-transition
+   :definition
+   {:initial :s0
+    :states  {:s0   {:initial :s01
+                     :on      {:leave :away}
+                     :states  {:s01  {:initial :s011 :states {:s011 {:on {:next :s012}} :s012 {}}}
+                               :s02  {:initial :s021 :states {:s021 {} :s022 {}}}
+                               :hist {:type :history :deep? true :default-target :s022}}}
+              :away {:on {:return [:s0 :hist]}}}}
+   :snapshot     {:state [:s0 :s01 :s012] :data {}}
+   :event        [:leave]
+   :expect-next-snapshot {:state :away :data {} :rf/history {[:s0] [:s0 :s01 :s012]}}
+   :expect-effects       []}
+
+  ;; (2d) Restore deep: re-enter via [:s0 :hist] → the EXACT recorded leaf s012.
+  {:call         :machine-transition
+   :definition
+   {:initial :s0
+    :states  {:s0   {:initial :s01
+                     :on      {:leave :away}
+                     :states  {:s01  {:initial :s011 :states {:s011 {:on {:next :s012}} :s012 {}}}
+                               :s02  {:initial :s021 :states {:s021 {} :s022 {}}}
+                               :hist {:type :history :deep? true :default-target :s022}}}
+              :away {:on {:return [:s0 :hist]}}}}
+   :snapshot     {:state :away :data {} :rf/history {[:s0] [:s0 :s01 :s012]}}
+   :event        [:return]
+   :expect-next-snapshot {:state [:s0 :s01 :s012] :data {} :rf/history {[:s0] [:s0 :s01 :s012]}}
+   :expect-effects       []}
+
+  ;; ---- SHALLOW machine (identical geometry, no :deep?) ----
+  ;; (1s) Record: leave :s0 from the SAME deepest leaf [:s0 :s01 :s012].
+  ;; Shallow records only the direct child :s01.
+  {:call         :machine-transition
+   :definition
+   {:initial :s0
+    :states  {:s0   {:initial :s01
+                     :on      {:leave :away}
+                     :states  {:s01  {:initial :s011 :states {:s011 {:on {:next :s012}} :s012 {}}}
+                               :s02  {:initial :s021 :states {:s021 {} :s022 {}}}
+                               :hist {:type :history :default-target :s02}}}
+              :away {:on {:return [:s0 :hist]}}}}
+   :snapshot     {:state [:s0 :s01 :s012] :data {}}
+   :event        [:leave]
+   :expect-next-snapshot {:state :away :data {} :rf/history {[:s0] :s01}}
+   :expect-effects       []}
+
+  ;; (2s) Restore shallow: re-enter via [:s0 :hist] → the recorded child :s01
+  ;; then its :initial (:s011) — NOT the deep exit leaf s012.
+  {:call         :machine-transition
+   :definition
+   {:initial :s0
+    :states  {:s0   {:initial :s01
+                     :on      {:leave :away}
+                     :states  {:s01  {:initial :s011 :states {:s011 {:on {:next :s012}} :s012 {}}}
+                               :s02  {:initial :s021 :states {:s021 {} :s022 {}}}
+                               :hist {:type :history :default-target :s02}}}
+              :away {:on {:return [:s0 :hist]}}}}
+   :snapshot     {:state :away :data {} :rf/history {[:s0] :s01}}
+   :event        [:return]
+   :expect-next-snapshot {:state [:s0 :s01 :s011] :data {} :rf/history {[:s0] :s01}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/scxml-history-test579-default-only-first-entry.edn
+++ b/spec/conformance/fixtures/scxml-history-test579-default-only-first-entry.edn
@@ -1,0 +1,66 @@
+;; Conformance fixture: machine/scxml-history-test579-default-only-first-entry
+;;
+;; ADAPTED from W3C SCXML IRP test579 (https://www.w3.org/Voice/2013/scxml-irp/579/test579.txml).
+;; Mandatory-automated history test. test579 verifies that a history state's
+;; DEFAULT transition executes ONLY IF THERE IS NO STORED HISTORY: on first
+;; entry to the compound the default content runs (no recording yet); once the
+;; compound has been exited and re-entered, the STORED history is restored and
+;; the default is NOT re-applied.
+;;
+;; re-frame2 mapping: the default-target arm (`:source :default`) fires only
+;; when nothing is recorded for the compound; a recorded config (`:source
+;; :recorded`) overrides the default. This is the same semantic — the recording
+;; takes priority over the default once it exists.
+;;
+;; SEMANTIC DIVERGENCE (cited): SCXML expresses "default ran" via <raise> events
+;; the datamodel counts; re-frame2 has no datamodel / <raise>, so the test is
+;; translated to two Mode B calls whose RESULTING CONFIGURATION distinguishes
+;; default (s01) from restored (the recorded s02). re-frame2 is not an SCXML
+;; processor; the chart shape and the default-vs-stored resolution are
+;; translated, not the .scxml verbatim.
+;;
+;; Per [005 §History states §Restoration](../../005-StateMachines.md#restoration--on-re-entry-resolving-the-pseudo-state).
+
+{:fixture/id           :machine/scxml-history-test579-default-only-first-entry
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/history}
+ :fixture/doc          "W3C SCXML test579 adapted: a history pseudo-state's :default-target resolves ONLY when nothing is recorded (first entry → s01); once a config is recorded (s02), re-entry restores the stored config and the default is NOT re-applied."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) FIRST ENTRY (no recording): enter :s0 via [:s0 :sh] from :away with an
+  ;; empty :rf/history ⇒ the :default-target :s01 fires.
+  {:call         :machine-transition
+   :definition
+   {:initial :s0
+    :states  {:s0   {:initial :sh
+                     :on      {:leave :away}
+                     :states  {:sh  {:type :history :default-target :s01}
+                               :s01 {:on {:next :s02}}
+                               :s02 {:on {:next :s03}}
+                               :s03 {}}}
+              :away {:on {:return [:s0 :sh]}}}}
+   :snapshot     {:state :away :data {}}
+   :event        [:return]
+   :expect-next-snapshot {:state [:s0 :s01] :data {}}
+   :expect-effects       []}
+
+  ;; (2) RE-ENTRY (history recorded): the slot holds :s02 (a prior exit). The
+  ;; restore uses the STORED config (:s02), NOT the default (:s01). The exit
+  ;; cascade overwrites the slot with the outgoing :s02 (already there).
+  {:call         :machine-transition
+   :definition
+   {:initial :s0
+    :states  {:s0   {:initial :sh
+                     :on      {:leave :away}
+                     :states  {:sh  {:type :history :default-target :s01}
+                               :s01 {:on {:next :s02}}
+                               :s02 {:on {:next :s03}}
+                               :s03 {}}}
+              :away {:on {:return [:s0 :sh]}}}}
+   :snapshot     {:state :away :data {} :rf/history {[:s0] :s02}}
+   :event        [:return]
+   :expect-next-snapshot {:state [:s0 :s02] :data {} :rf/history {[:s0] :s02}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/scxml-history-test580-parallel-shallow.edn
+++ b/spec/conformance/fixtures/scxml-history-test580-parallel-shallow.edn
@@ -1,0 +1,77 @@
+;; Conformance fixture: machine/scxml-history-test580-parallel-shallow
+;;
+;; ADAPTED from W3C SCXML IRP test580 (https://www.w3.org/Voice/2013/scxml-irp/580/test580.txml).
+;; Mandatory-automated history test. test580 places a SHALLOW <history> inside a
+;; compound state (s1) that is itself a child of a <parallel> (p1). It verifies
+;; that a shallow history state inside a parallel region correctly remembers the
+;; most-recently-visited child of its compound, excluding the history pseudo-
+;; state itself from the configuration.
+;;
+;; re-frame2 mapping: per-region history (Spec 005 §Composition with parallel
+;; regions). The history pseudo-state is declared inside region :s1's compound
+;; :group; its recording is keyed by the REGION-QUALIFIED declaration path
+;; [:s1 :group]. The sibling region :s0 is unaffected. The pseudo-state is never
+;; occupied — the snapshot's region value is the resolved real leaf, never [...
+;; :sh].
+;;
+;; SEMANTIC DIVERGENCE (cited): SCXML drives the sequence with <send delay> +
+;; datamodel counters; re-frame2 has no datamodel / <send>, so the record→
+;; restore is expressed as two Mode B calls whose region configuration shows the
+;; remembered child. re-frame2 is not an SCXML processor; the chart shape and
+;; the per-region shallow-history restoration are translated, not the .scxml
+;; verbatim.
+;;
+;; Per [005 §Composition with parallel regions — per-region history]
+;; (../../005-StateMachines.md#composition-with-parallel-regions--per-region-history).
+
+{:fixture/id           :machine/scxml-history-test580-parallel-shallow
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/parallel-regions :fsm/history}
+ :fixture/doc          "W3C SCXML test580 adapted: a shallow history inside a compound (:group) within a parallel region (:s1) remembers the most-recent child (:s12) on exit and restores it on re-entry, keyed by the region-qualified path [:s1 :group]; the sibling region :s0 is unaffected."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) RECORD: region :s1 is at [:group :s12]; exit :group's subtree to the
+  ;; region-local park state. Shallow history records the direct child :s12
+  ;; under the region-qualified key [:s1 :group]. Region :s0 stays :idle.
+  {:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :regions {:s0 {:initial :idle :states {:idle {} :busy {}}}
+              :s1 {:initial :group
+                   :states  {:group  {:initial :sh
+                                      :on      {:exit-to-park [:s1park]}
+                                      :states  {:sh   {:type :history :default-target :s11}
+                                                :s11  {:on {:to12 :s12}}
+                                                :s12  {}}}
+                             :s1park {:on {:back [:group :sh]}}}}}}
+   :snapshot     {:state {:s0 :idle :s1 [:group :s12]} :data {}}
+   :event        [:exit-to-park]
+   :expect-next-snapshot {:state    {:s0 :idle :s1 [:s1park]}
+                          :data     {}
+                          :rf/history {[:s1 :group] :s12}}
+   :expect-effects       []}
+
+  ;; (2) RESTORE: re-enter :group via its shallow history; the remembered child
+  ;; :s12 is restored in region :s1. Region :s0 untouched.
+  {:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :regions {:s0 {:initial :idle :states {:idle {} :busy {}}}
+              :s1 {:initial :group
+                   :states  {:group  {:initial :sh
+                                      :on      {:exit-to-park [:s1park]}
+                                      :states  {:sh   {:type :history :default-target :s11}
+                                                :s11  {:on {:to12 :s12}}
+                                                :s12  {}}}
+                             :s1park {:on {:back [:group :sh]}}}}}}
+   :snapshot     {:state    {:s0 :idle :s1 [:s1park]}
+                  :data     {}
+                  :rf/history {[:s1 :group] :s12}}
+   :event        [:back]
+   :expect-next-snapshot {:state    {:s0 :idle :s1 [:group :s12]}
+                          :data     {}
+                          :rf/history {[:s1 :group] :s12}}
+   :expect-effects       []}]}


### PR DESCRIPTION
## What

Comprehensive test suite for the first-class history engine (rf2-mle6e.3, merged), complementing the engine-author's smoke test. Closes the test half of the history epic (rf2-mle6e.4).

## Case matrix

**Unit** — `implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc` (dual-runtime `.cljc`, runs under both `clojure -M:test` and `npm run test:cljs`):

- shallow vs deep depth distinction from the **identical** exit leaf
- deep nesting — two history-bearing compounds at different depths record independently (separate `:rf/history` keys) and never interfere; outer deep restore returns the full leaf
- entry-cascade ordering during restore (exit-deepest-first / entry-shallowest-first along the LCA — proves restore feeds the standard cascade, not a bespoke mechanism)
- default-target fallback (declared) + `:initial` fallback (no `:default-target`); missing `:deep?` reads as shallow
- dangling recorded path after hot-reload (deep leaf + shallow child) falls back, never enters the dead path, no `:rf.error/*` (rf2-wgfv0)
- per-region parallel history at **structurally-identical** region paths — region-qualified keys never collide; restoring one region is isolated
- snapshot **revert** (Goal 2) — `:rf/history` is part of the revertible snapshot VALUE not a side-table; EDN round-trip (`pr-str`/`read-string`, the SSR/time-axis shape)
- trace shapes — exact spec/009 tag keys: deep-nesting (two `-recorded` events in one cascade), per-step `:source` stamping on a nested restore, `:prev-config` on overwrite

**Conformance** — `spec/conformance/fixtures/` (Mode-B `:machine-transition`, 9 fixtures / 20 calls; run by both the machines Mode-B gate and the core end-to-end runner):

- `history-{deep-restores-leaf-path, shallow-restores-direct-child, default-target-on-first-entry, per-region-parallel, dangling-path-falls-back}.edn`
- `scxml-history-test{387,388,579,580}-*.edn` — the **W3C SCXML IRP** history family adapted to the re-frame2 grammar shape, each citing its source test id + semantic divergences

**SCXML corpus** — enriches `scxml_conformance_cljs_test.cljc` §13 with the record/restore corpus (§13b) + duplicate / bad-default-target rejections, retiring the §3 HISTORY exclusion note (history is now covered, not excluded).

## SCXML adaptation notes

re-frame2 is not an SCXML processor (no datamodel / `<raise>` / `<send>`), so each W3C test's statechart **shape** and last-active-config restoration **sequence** are translated, not the `.scxml` verbatim. Recurring divergence: W3C charts declare deep + shallow `<history>` as siblings under one state; re-frame2 permits **at most one** history node per compound (deep-vs-shallow is the single node's `:deep?`), so multi-history charts are split into per-depth machines of identical geometry. Cited per fixture.

## Gates (cold)

- `npm run test:cljs` — **5430 tests, 0 failures** (cold: fresh `npm install`, no shadow cache)
- machines `clojure -M:test` — **386 tests, 0 failures**
- core `re-frame.conformance-test` — passes (belt-and-braces, fixtures run end-to-end too)
- conformance corpus runner claims `:fsm/history`; all 9 history fixtures discovered + runnable (verified, not skipped)

## Found en route

Filed **rf2-mle6e.8** (P2 bug): spec/009 §Error event catalogue names `:rf.error/machine-history-at-root` / `-illegal-keys`, but the merged engine raises `-misplaced` / `-extra-keys`; the ex-data tag bag also diverges (`:feature` at the pure-validator layer vs the spec's `:machine-id`). This suite pins the **engine-as-shipped** ids (per the test-it-as-is brief); the reconcile direction is a Mike decision in the bead.

## Scope

`implementation/machines/test/` (not hot-zone) + `spec/conformance/fixtures/` (under spec/ hot-zone — sole worker). No engine, xray, or spec-prose changes.