### PR TITLE
refactor(xray/testbeds): convert machine_epochs to the shared queued-step runner (rf2-kipb5)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1537,14 +1537,16 @@ action-attribution half.
   `:rf.xray/*` registry ids for the Machines tab.
 - [`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) — Sim
   mode + Mode A/B/C dynamic instance test rows.
-- **Render regression harness (rf2-g27vv).** The `machine_epochs` testbed
-  (:8033) is the assertion-backed harness that pins this spec's cascade-render
-  contract against reality — its numbered ladder drives the full feature ×
-  render-surface matrix (plain / entry-exit / guards / internal / fx /
+- **Render regression harness (rf2-g27vv; runner-shaped rf2-kipb5).** The
+  `machine_epochs` testbed (:8033) is the assertion-backed harness that pins
+  this spec's cascade-render contract against reality — driven through the
+  shared queued-step runner (`runner.core`), its step matrix walks the full
+  feature × render-surface matrix (plain / entry-exit / guards / internal / fx /
   unhandled-no-op / root-`:on` resolution; parallel regions + history +
   member-level tag-set delta; `:always` microsteps; `:after` timer + cancel;
   spawn / `:final?` / `:on-done` / destroy lifecycle; `:*` wildcard throw;
-  deep-compound LCA + self-transitions; `:history` reject-now). Each rung is
+  deep-compound LCA + self-transitions; `:history` placement-reject + live
+  shallow/deep restore). Each step is
   backed by a CLJS-unit assertion in
   `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test` (BOTH
   the machine outcome via the per-machine `:data :trail` order-oracle AND the

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1731,19 +1731,21 @@ consumer of the rf2-n9f4z instrumentation contract per
 [003-Machine-Inspector §The EVENT HANDLER machine cascade](003-Machine-Inspector.md).
 
 The `machine_epochs` testbed (:8033) is now the **assertion-backed render
-regression harness** for this whole cascade-render contract (rf2-g27vv). Its
-numbered ladder drives the full FEATURE × RENDER-SURFACE matrix — plain /
+regression harness** for this whole cascade-render contract (rf2-g27vv;
+runner-shaped rf2-kipb5). Driven through the shared queued-step runner
+(`runner.core`), its step matrix drives the full FEATURE × RENDER-SURFACE
+matrix — plain /
 entry-exit / transition-action / guard pass+fail / internal / fx /
 unhandled-no-op / root-`:on` resolution (door); parallel regions + history +
 member-level tag-set delta (traffic); `:always` **microsteps** that settle
 over N>0 microsteps (quiz); `:after` **timer** auto-fire + cancellation
 (brew); **spawn → `:final?` → `:on-done` → auto-destroy** lifecycle
 (session); `:*` wildcard-action **throw** (fuse); deep-compound LCA + self-
-transitions (hvac); and a `:history` **reject-now** rung with ready
-placeholders for shallow/deep restore (deferred per Spec 005 §Substitutes).
-Each rung is backed by a CLJS-unit assertion in
+transitions (hvac); and the `:history` **placement-reject** step plus **live
+shallow + deep restore** steps (first-class history per rf2-mle6e). Each step
+is backed by a CLJS-unit assertion in
 `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test` that
-drives the rung through the live substrate and pins BOTH the machine outcome
+drives the step through the live substrate and pins BOTH the machine outcome
 (via the generalized per-machine `:data :trail` order-oracle) AND the Xray
 cascade-render projection it lights up — so re-driving the deck is a real
 regression test of this render contract. The `:data :trail` is no longer a

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -161,12 +161,13 @@ const STAGED_SURFACES = [
     html: ['tools', 'xray', 'testbeds', 'routes_epochs', 'index.html'],
     servedPath: 'testbeds/routes-epochs',
   },
-  // rf2-w06op — machine-epochs deck (the STATE-MACHINE step-up tester). A
-  // single-frame numbered-button ladder over the real `reg-machine` +
-  // machine-event-routing surface, driving the Xray Machine Inspector
-  // (`rf-xray-machine-inspector`). Served from the deck's own hand-written
-  // index.html (source dir first, like the 8033 :dev-http entry); the
-  // compiled main.js falls through to out/examples/machine-epochs.
+  // rf2-w06op + rf2-kipb5 — machine-epochs deck (the STATE-MACHINE tester),
+  // converted to the shared queued-step runner (`runner.core`). A single-frame
+  // step matrix over the real `reg-machine` + machine-event-routing surface,
+  // driving the Xray Machine Inspector (`rf-xray-machine-inspector`). Served
+  // from the deck's own hand-written index.html (source dir first, like the
+  // 8033 :dev-http entry); the compiled main.js falls through to
+  // out/examples/machine-epochs.
   {
     build: 'examples/machine-epochs',
     bundleDir: ['out', 'examples', 'machine-epochs'],
@@ -2889,10 +2890,14 @@ async function runRoutesEpochs(page, state) {
   };
 }
 
-// rf2-w06op — machine-epochs state-machine step-up deck. Walks the deck's
-// numbered ladder top-to-bottom and asserts each rung's machine feature
-// landed, then opens the Xray Machine Inspector (`rf-xray-machine-
-// inspector`) and confirms the panel mounts on the focused machine event.
+// rf2-w06op + rf2-kipb5 — machine-epochs state-machine deck, converted to the
+// shared queued-step runner (`runner.core`). Walks the deck's step matrix
+// top-to-bottom (via the runner's per-step RUN-THIS-STEP buttons) and asserts
+// each step's machine feature landed, then opens the Xray Machine Inspector
+// (`rf-xray-machine-inspector`) and confirms the panel mounts on the focused
+// machine event. The final handoff re-drives a few steps OUT OF ORDER (the
+// fresh-transition / unhandled-no-op / wildcard-throw contrast) — the random-
+// access addressing the runner's per-step run button provides.
 //
 // What this scenario can / cannot assert:
 // —————————————————————————————————————————————————————————————
@@ -2918,10 +2923,26 @@ async function runRoutesEpochs(page, state) {
 // deck's job is the real-machine-feature step-up surface, asserted through
 // the snapshot mirror + the panel handoff.
 
-// Click a deck ladder rung by its per-rung data-testid
-// (`machine-epochs-rung-<n>`, outside Xray chrome).
+// Drive a deck step by its (1-based) ladder rung number.
+//
+// rf2-kipb5 — the deck was converted to the shared queued-step runner
+// (`runner.core`). It no longer mounts a bespoke `machine-epochs-rung-<n>`
+// button per rung; instead the runner renders one step row per step, and
+// each row's index is a RANDOM-ACCESS RUN-THIS-STEP button
+// (`machine-epochs-step-<n>-run`, n = 0-based step index). The runner's
+// per-step run affordance is exactly the random-access addressing this
+// scenario needs — it drives steps OUT OF ORDER at the end (re-driving the
+// fresh-transition / unhandled-no-op / wildcard-throw steps for the
+// Inspector + throw/no-op-contrast handoff), which the runner's sequential
+// cursor alone could not provide.
+//
+// The scenario keeps the historical 1-based rung vocabulary (rung 1 = the
+// first step) and maps it onto the 0-based runner step index here, so every
+// call site below reads unchanged. The step ORDER is identical to the old
+// ladder (same events, same machine features); only the driving affordance
+// moved to the runner.
 async function clickMachineRung(page, n) {
-  await clickTestId(page, `machine-epochs-rung-${n}`);
+  await clickTestId(page, `machine-epochs-step-${n - 1}-run`);
 }
 
 // Read both machines' state + the door's :data off the deck's status
@@ -3200,7 +3221,11 @@ async function runMachineEpochs(page, state) {
   //     throw and the door stays put. The rejection shape is asserted in the
   //     CLJS harness; here we confirm the rung does not crash the deck.
   await clickMachineRung(page, 24);
-  // #25 / #26 are DISABLED placeholders (history deferred) — not clickable.
+  // #25 (SHALLOW history restore) / #26 (DEEP history restore) are LIVE steps
+  // (rf2-mle6e.5); their full restore-cascade render assertions live in the
+  // CLJS harness (`history-shallow-restore-...` / `history-deep-restore-...`),
+  // which drives the substrate directly. The browser scenario does not need to
+  // re-drive them here — the harness owns that coverage.
 
   // ===== Xray Machine Inspector handoff + the throw/no-op contrast ======
   await openXray(page);
@@ -3440,16 +3465,19 @@ const SCENARIOS = [
     run: runRoutesEpochs,
   },
   {
-    // rf2-w06op + rf2-g27vv — machine-epochs assertion-backed render harness.
-    // Drives the real `reg-machine` + machine-event-routing surface for the
-    // FULL feature x Xray-cascade-render matrix and asserts each rung's
-    // machine FEATURE landed via the host's snapshot mirror: door (plain ·
-    // entry/exit · guards allowed/blocked · internal · effect · unhandled
-    // no-op · root-:on RESOLUTION), traffic (parallel regions · history ·
-    // tag-set member swap), quiz (:always MICROSTEPS), brew (:after TIMER +
-    // cancel), session (SPAWN · child :final · :on-done · DESTROY), fuse (:*
-    // wildcard THROW), hvac (deep compound · LCA cascade · self-transitions),
-    // history (reject-now). Then opens the Xray Machine Inspector
+    // rf2-w06op + rf2-g27vv + rf2-kipb5 — machine-epochs assertion-backed
+    // render harness, runner-shaped (driven through `runner.core`'s per-step
+    // RUN-THIS-STEP buttons). Drives the real `reg-machine` + machine-event-
+    // routing surface for the FULL feature x Xray-cascade-render matrix and
+    // asserts each step's machine FEATURE landed via the host's snapshot
+    // mirror: door (plain · entry/exit · guards allowed/blocked · internal ·
+    // effect · unhandled no-op · root-:on RESOLUTION), traffic (parallel
+    // regions · history · tag-set member swap), quiz (:always MICROSTEPS),
+    // brew (:after TIMER + cancel), session (SPAWN · child :final · :on-done ·
+    // DESTROY), fuse (:* wildcard THROW), hvac (deep compound · LCA cascade ·
+    // self-transitions), history (placement reject + live shallow/deep restore
+    // — the restore-cascade render is asserted in the CLJS harness). Then opens
+    // the Xray Machine Inspector
     // (`rf-xray-machine-inspector`) and confirms the panel mounts on a
     // focused machine event + the no-op/throw trace contrast. The deep
     // RENDER-FIDELITY assertions (cascade kinds/order, microsteps, timer-

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -1,49 +1,53 @@
 (ns machine-epochs.core
-  "MACHINE-EPOCHS testbed (rf2-w06op + rf2-g27vv) — the STATE-MACHINE sibling
-  of the `standard_epochs` + `routes_epochs` decks, redesigned (rf2-g27vv)
-  into a COMPREHENSIVE, ASSERTION-BACKED machine × Xray-cascade-render
-  REGRESSION HARNESS aimed squarely at the **Epoch panel's EVENT HANDLER
-  machine cascade** + the **Machine Inspector** (`rf-xray-machine-inspector`).
+  "MACHINE-EPOCHS testbed (rf2-w06op + rf2-g27vv + rf2-mle6e, runner-shaped
+  rf2-kipb5) — the STATE-MACHINE consumer of the shared queued-step RUNNER
+  (`runner.core`, the rf2-8pbjr pilot). It drives a COMPREHENSIVE,
+  ASSERTION-BACKED machine × Xray-cascade-render REGRESSION SURFACE aimed
+  squarely at the **Epoch panel's EVENT HANDLER machine cascade** + the
+  **Machine Inspector** (`rf-xray-machine-inspector`).
 
-  ## Shape
+  ## Shape (rf2-kipb5 — adopt the shared queued-step RUNNER)
 
-  ONE tall column of NUMBERED buttons, top to bottom — the same shape as
-  `standard_epochs` and `routes_epochs`. Beside each button a one-line
-  caption says WHAT TO WATCH in Xray's Machines tab / Epoch cascade when you
-  press it. Each rung is ONE test: it fires one event that
+  ONE button (`▶ Run series`) walks the full machine × render-surface
+  matrix top to bottom while the operator watches how the Xray panels
+  render each step; a STEP button advances one step at a time; and EVERY
+  step row's index is a RANDOM-ACCESS RUN-THIS-STEP button
+  (`machine-epochs-step-<n>-run`) so any step can be driven directly. The
+  runner (`runner.core`) is the shared harness; this deck supplies a
+  `steps` vector (CODE DATA) + the testid prefix `machine-epochs`. Each
+  step DISPATCHES one event that exercises exactly ONE machine FEATURE ×
+  the Xray cascade-render SURFACE it lights up. Title: `Xray Testbed:
+  Machine Epochs`.
 
-    (a) bumps a shared baseline counter (so App-db / Epoch always show a
-        delta on every press), and
-    (b) sends ONE (or several) machine event(s) that exercise exactly ONE
-        additional machine FEATURE and the Xray cascade-render SURFACE it
-        lights up.
+  Replaces the bespoke numbered-button ladder: same events, same machine
+  features, same coverage — but driven by the shared runner so the
+  operator presses ONE button and reads each step's per-occurrence
+  `:watch` note while the panels render. After each AUTO-advance dispatch
+  the runner pins Xray focus to the latest `:rf/default` epoch; a
+  per-step RUN-THIS-STEP click is manual (operator-driven focus).
 
-  ## The redesign — a FEATURE × RENDER-SURFACE matrix (rf2-g27vv)
+  ## The FEATURE × RENDER-SURFACE matrix (rf2-g27vv)
 
-  Where the original deck covered the common transition surfaces but MISSED
-  several machine features and asserted nothing, this redesign maps every
-  rung to (machine feature) × (the Xray cascade-render surface it lights
-  up), and EACH RUNG IS BACKED BY A CLJS-UNIT ASSERTION so re-driving the
-  deck is a real regression test of Xray rendering — not just a visual deck.
-
-  The data-driven `ladder` table below is the SINGLE SOURCE OF TRUTH: the
-  ladder RENDERS from it and the assertion surface
+  Each step maps (machine feature) × (the Xray cascade-render surface it
+  lights up), and EACH is backed by a CLJS-UNIT ASSERTION in the harness
   (`day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test`)
-  READS the same machine specs (shared via `machine-epochs.machines`) and
-  drives the rung events through the LIVE substrate, asserting BOTH the
-  machine OUTCOME (via the generalized `:trail` order-oracle) AND the Xray
-  cascade-render projection it lights up.
+  so re-driving the deck is a real regression test of Xray rendering, not
+  just a visual deck. The harness drives the IDENTICAL machine specs
+  (shared via `machine-epochs.machines`) through the LIVE substrate and
+  asserts BOTH machine outcome AND the Xray cascade-render projection —
+  it is decoupled from THIS view (it drives `dispatch-sync` directly), so
+  the runner conversion is additive: it neither drops nor relies on the
+  harness's assertions.
 
   ## The generalized `:trail` order-oracle (rf2-g27vv)
 
-  Every machine in this deck carries a `:data :trail` vector and every
-  `:entry` / `:exit` / transition `:action` / `:always` action APPENDS one
-  `<phase>:<state>` label to it (built by `machines/trail-action`). So the
-  post-macrostep `:trail` is the cascade ORDER made visible — the same
-  mechanism the HVAC machine pioneered, now GENERALIZED to door / traffic /
-  quiz / brew / session / fuse. The trail is the testable proxy for 'the
-  cascade renders legibly + in the right order'; the harness keys its
-  assertions off it.
+  Every machine carries a `:data :trail` vector and every `:entry` /
+  `:exit` / transition `:action` / `:always` action APPENDS one
+  `<phase>:<state>` label (built by `machines/trail-action`). So the
+  post-macrostep `:trail` is the cascade ORDER made visible — the order-
+  oracle the harness keys its assertions off. The on-page status strip
+  mirrors each machine's state + tags + trail so the deck is legible
+  standalone; the Inspector / Epoch panel is the actual check.
 
   ## The machine set (each a coherent clean domain; collectively the matrix)
 
@@ -53,65 +57,76 @@
                                    (TRANSITION RESOLUTION, gap 6).
     - traffic  (PARALLEL-FLAT)   — parallel regions · history ribbon ·
                                    TAG-SET delta member-swap (gap 7).
-    - quiz     (MICROSTEP, NEW)  — `:always` EVENTLESS microsteps that settle
-                                   over N>0 microsteps (gap 1 — THE biggest).
-    - brew     (TIMER, NEW)      — `:after` DELAYED transition that auto-fires
-                                   + a path that CANCELS a pending timer
-                                   (gap 2 — `:timer` cascade kind + the
-                                   cancellation-cascade block).
-    - session  (LIFECYCLE, NEW)  — SPAWN a child actor → child reaches
+    - quiz     (MICROSTEP)       — `:always` EVENTLESS microsteps that settle
+                                   over N>0 microsteps (gap 1).
+    - brew     (TIMER)           — `:after` DELAYED transition that auto-fires
+                                   + a path that CANCELS a pending timer (gap 2).
+    - session  (LIFECYCLE)       — SPAWN a child actor → child reaches
                                    `:final?` firing `:on-done` → auto-DESTROY
                                    + exit-cascade-on-destroy (gaps 3, 4, 5).
-    - hvac      (DEEP-COMPOUND)  — compound · initial cascade · LCA cascade ·
+    - hvac     (DEEP-COMPOUND)   — compound · initial cascade · LCA cascade ·
                                    internal/external self-transitions.
-    - fuse      (WILDCARD-THROW) — `:*` wildcard action THROWS (exception
+    - fuse     (WILDCARD-THROW)  — `:*` wildcard action THROWS (exception
                                    card + pink-wash; the foil to the no-op).
-    - media     (HISTORY, gap 8) — a `:player` compound owning a `:type
+    - media    (HISTORY, gap 8)  — a `:player` compound owning a `:type
                                    :history` pseudo-state; shallow + deep
                                    eject/restore drive the
                                    `:rf.machine.history/restored` banner + the
                                    per-`:entry`-step `:source` chip (rf2-mle6e).
 
-  ## HISTORY section (gap 8 — LIVE, rf2-mle6e)
+  ## HISTORY steps (gap 8 — LIVE, rf2-mle6e.5)
 
-  History states are FIRST-CLASS (rf2-mle6e: grammar .1, trace .2, engine .3).
-  The deck drives a live media-player compound (`:media/deep` + `:media/shallow`,
-  shared via `machine-epochs.machines`) whose `:player` compound owns a
-  `:type :history` pseudo-state:
+    - the PLACEMENT rejection step: a ROOT `:type :history` machine is still
+      rejected (`:rf.error/machine-history-misplaced`) — a pseudo-state must
+      have an owning compound.
+    - SHALLOW history restore: position deep into `:player`, eject (records
+      the direct CHILD), re-insert → restores the recorded child then descends
+      its `:initial` chain. The Epoch cascade shows the
+      `:rf.machine.history/restored` banner (source `:recorded`, shallow).
+    - DEEP history restore: same eject/insert dance on `:media/deep` → restores
+      the FULL nested LEAF path. The banner reads DEEP.
 
-    - rung #24 — the PLACEMENT rejection: a ROOT `:type :history` machine is
-      still rejected (`:rf.error/machine-history-misplaced`) because a
-      pseudo-state must have an owning compound. (NOT the old not-in-v1
-      deferral — history itself is supported.)
-    - rung #25 — SHALLOW history restore: position deep into `:player`, eject
-      (records the direct CHILD), re-insert → restores the recorded child then
-      descends its `:initial` chain. The Epoch cascade shows the
-      `:rf.machine.history/restored` banner (source `:recorded`, shallow) + the
-      `:source :recorded` chip on the restored `:entry` steps.
-    - rung #26 — DEEP history restore: same eject/insert dance on `:media/deep`
-      → restores the FULL nested LEAF path. The banner reads DEEP; the entry
-      steps descend to the exact recorded leaf, each chipped `from history`.
+  The `:rf/history` snapshot slot is inspectable in the App-db panel (inside
+  `[:rf/runtime :machines :snapshots <id> :rf/history]`). rf2-mle6e.5.
 
-  The `:rf/history` snapshot slot is inspectable in the App-db panel (it lives
-  inside `[:rf/runtime :machines :snapshots <id> :rf/history]`, rendered by the
-  App-db edn-inspector like any other snapshot slot). rf2-mle6e.5.
+  ## Per-step delta (standard_epochs pattern)
+
+  Every action event bumps a shared `:baseline` counter (`bump`), so the
+  App-db / Epoch panels always show a delta on every step; the per-step
+  machine feature is the ADDITIONAL change layered on top.
+
+  ## Runner state = LOCAL ATOM (rf2-8pbjr contract)
+
+  The runner cursor / status / pace live in `runner-state` — a LOCAL Reagent
+  atom in THIS ns. It is NEVER written to the inspected app-db (that would
+  pollute the panels under inspection) and is NOT a second frame (only the
+  inspected app frame, `:rf/default`, is Xray-relevant).
+
+  ## Inline Xray sidecar (preload)
+
+  Like the `_epochs` trio (standard_epochs / routes_epochs), this deck wires
+  `day8.re-frame2-xray.preload` in shadow-cljs (the `:examples/machine-epochs`
+  build, port 8033); the preload auto-mounts the inline shell into
+  `[data-rf-xray-host]` so every lens reads the single `:rf/default` frame.
 
   ## Test surface, not tutorial (feedback_testbeds_are_test_surfaces)
 
-  No deliberate bugs as anti-patterns, no teaching layers. Every transition
-  is a clean feature being driven; the trail is instrumentation, not an
-  anti-pattern demo. Captions are guidance, not lessons.
+  No deliberate bugs, no teaching layers. Every transition is a clean feature
+  being driven; the trail is instrumentation, not an anti-pattern demo. The
+  `:watch` notes are guidance, not lessons.
 
   ## Test-free + self-contained (rf2-8cevm)
 
   No `spec.cjs` lives here. Regression coverage lives in the Xray test
   surface: the CLJS unit test
   `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test`
-  (each rung's BOTH-layers assertion) + the feature-matrix gate
-  (`tools/xray/testbeds/feature_matrix/scenarios.cjs` — the `machine-epochs
-  machine ladder` scenario). The machine specs live in the sibling ns
+  (each step's BOTH-layers assertion, drives the substrate directly) + the
+  feature-matrix gate (`tools/xray/testbeds/feature_matrix/scenarios.cjs` —
+  the `machine-epochs machine ladder` scenario, which drives the runner's
+  per-step RUN-THIS-STEP buttons). The machine specs live in the sibling ns
   `machine-epochs.machines`, shared with the harness."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent.core :as r]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; State-machines artefact — load-time hook so `reg-machine`,
             ;; the `:rf/machine` framework subs, and machine-event routing
@@ -121,8 +136,18 @@
             [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-xray.config :as xray-config]
             [re-frame.testbed.config :as testbed-config]
+            ;; The shared queued-step runner (rf2-8pbjr pilot). This deck
+            ;; supplies a `steps` vector + the testid prefix; the runner
+            ;; drives the ONE-button series + the per-step run affordance.
+            [runner.core :as runner]
             [machine-epochs.machines :as machines])
   (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; The inspected app frame (rf2-8pbjr — only the app frame is Xray-relevant)
+;; ============================================================================
+
+(def host-frame :rf/default)
 
 ;; ============================================================================
 ;; MACHINE REGISTRATION
@@ -140,7 +165,7 @@
 ;; APP-DB SEED + the shared bump/send driver
 ;; ============================================================================
 ;;
-;; `:baseline` is the shared counter every button bumps (so App-db / Epoch
+;; `:baseline` is the shared counter every step bumps (so App-db / Epoch
 ;; always show a delta). The machines own their own runtime state under
 ;; `[:rf/runtime :machines :snapshots …]`.
 
@@ -148,59 +173,59 @@
 
 (defn- bump [db] (update db :baseline inc))
 
-;; A reusable "bump + send" event-fx: every machine rung routes through here
+;; A reusable "bump + send" event-fx: every machine step routes through here
 ;; so the baseline delta and the machine send are one cascade. `sends` is a
 ;; vector of fully-formed machine-event vectors — pass several to fan out to
 ;; multiple machines in one press.
 (rf/reg-event-fx :machine-epochs/send
   {:doc "Bump the baseline and dispatch the supplied machine event(s). The
-         shared driver behind every machine rung."}
+         shared driver behind every machine step."}
   (fn handler-send [{:keys [db]} [_ sends]]
     {:db (bump db)
      :fx (mapv (fn [send] [:dispatch send]) sends)}))
 
-;; #5 — re-open the door (#4 left it :closed), arm the `:held-open?` flag via
-;; the `:door/hold` internal transition, then attempt the guarded close. The
-;; close fails `:may-close?` because the flag is now armed, so the door STAYS
-;; in `:open` and GUARDS RUN shows the failed guard.
+;; re-open the door (after a close left it :closed), arm the `:held-open?` flag
+;; via the `:door/hold` internal transition, then attempt the guarded close.
+;; The close fails `:may-close?` because the flag is now armed, so the door
+;; STAYS in `:open` and GUARDS RUN shows the failed guard.
 (rf/reg-event-fx :machine-epochs/reopen-then-block
-  {:doc "Button #5 — :door/push (re-open) → :door/hold (arm the guard input)
-         → :door/close. The :may-close? guard FAILS, so the close is blocked
-         and the machine stays in :open."}
+  {:doc ":door/push (re-open) → :door/hold (arm the guard input) → :door/close.
+         The :may-close? guard FAILS, so the close is blocked and the machine
+         stays in :open."}
   (fn handler-reopen-then-block [{:keys [db]} _ev]
     {:db (bump db)
      :fx [[:dispatch [:door/main [:door/push]]]
           [:dispatch [:door/main [:door/hold]]]
           [:dispatch [:door/main [:door/close]]]]}))
 
-;; The acknowledgement event dispatched by :enter-alarm's :fx (#6). A plain
-;; deck event so the cascade has a downstream child epoch the lens links to.
+;; The acknowledgement event dispatched by :enter-alarm's :fx. A plain deck
+;; event so the cascade has a downstream child epoch the lens links to.
 (rf/reg-event-db :machine-epochs/alarm-acknowledged
   {:doc "The downstream event fired by the door's :enter-alarm action :fx.
          Bumps baseline again so the alarm cascade has a child epoch under
          the originating dispatch-id."}
   (fn handler-alarm-acknowledged [db _ev] (bump db)))
 
-;; #16 — re-start the brew (schedules a fresh :after timer) then immediately
+;; re-start the brew (schedules a fresh :after timer) then immediately
 ;; :brew/abort, which exits :brewing BEFORE the timer fires. Exiting the
 ;; :after-bearing state cancels the in-flight timer (:reason :on-exit).
 (rf/reg-event-fx :machine-epochs/cancel-brew
-  {:doc "Button #16 — :brew/start (re-enter :brewing, schedule the :after
-         timer) → :brew/abort (exit :brewing before the timer fires). The
-         exit cancels the pending timer with :reason :on-exit."}
+  {:doc ":brew/start (re-enter :brewing, schedule the :after timer) →
+         :brew/abort (exit :brewing before the timer fires). The exit cancels
+         the pending timer with :reason :on-exit."}
   (fn handler-cancel-brew [{:keys [db]} _ev]
     {:db (bump db)
      :fx [[:dispatch [:brew/machine [:brew/start]]]
           [:dispatch [:brew/machine [:brew/abort]]]]}))
 
-;; #18 — drive the spawned :session/login child to its :final? state. The
-;; child's deterministic spawn-id is read off the runtime spawn-registry slot
-;; the parent's :spawn wrote on entry to :authenticating.
+;; drive the spawned :session/login child to its :final? state. The child's
+;; deterministic spawn-id is read off the runtime spawn-registry slot the
+;; parent's :spawn wrote on entry to :authenticating.
 (rf/reg-event-fx :machine-epochs/finish-login
-  {:doc "Button #18 — resolve the spawned child by reading the parent's
-         spawn-registry slot, then dispatch [:succeed <token>] to drive it to
-         its :final? state. The child fires :on-done (reporting the token to
-         the parent) and auto-destroys."}
+  {:doc "Resolve the spawned child by reading the parent's spawn-registry
+         slot, then dispatch [:succeed <token>] to drive it to its :final?
+         state. The child fires :on-done (reporting the token to the parent)
+         and auto-destroys."}
   (fn handler-finish-login [{:keys [db]} _ev]
     (let [child-id (get-in db [:rf/runtime :machines :spawned
                                :session/flow [:authenticating]])]
@@ -208,35 +233,87 @@
         child-id
         (assoc :fx [[:dispatch [child-id [:succeed :session/token-abc]]]])))))
 
-;; #24 — probe the :history PLACEMENT constraint. History is FIRST-CLASS
-;; (rf2-mle6e), but a :type :history pseudo-state MUST have an owning compound,
-;; so a ROOT :type :history machine throws synchronously at reg-machine time
+;; answer twice more so the running score reaches the `:enough?` pass mark (3)
+;; and the guarded `:always` chain settles `:asking` ──► `:passed` in N>0
+;; microsteps. (The first :quiz/answer step already answered once.) Two answers
+;; in one cascade so the LAST `:answer` is the one whose macrostep carries the
+;; microstep.
+(rf/reg-event-fx :machine-epochs/answer-to-pass
+  {:doc ":quiz/answer ×2 so the score reaches the pass mark and the guarded
+         :always chain fires (microsteps > 0)."}
+  (fn handler-answer-to-pass [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx [[:dispatch [:quiz/scorer [:quiz/answer]]]
+          [:dispatch [:quiz/scorer [:quiz/answer]]]]}))
+
+;; probe the :history PLACEMENT constraint. History is FIRST-CLASS (rf2-mle6e),
+;; but a :type :history pseudo-state MUST have an owning compound, so a ROOT
+;; :type :history machine throws synchronously at reg-machine time
 ;; (:rf.error/machine-history-misplaced). The deck event swallows the throw
-;; (the rung's job is to DRIVE the rejection; the harness asserts the throw
+;; (the step's job is to DRIVE the rejection; the harness asserts the throw
 ;; shape directly). It bumps baseline so the epoch still shows a delta.
 (rf/reg-event-db :machine-epochs/probe-history-rejection
-  {:doc "Button #24 — attempt to register a ROOT :type :history machine and
-         confirm the PLACEMENT constraint rejects it (a pseudo-state needs an
-         owning compound). The throw is swallowed here so the deck does not
-         crash; the harness asserts the misplaced-history rejection shape."}
+  {:doc "Attempt to register a ROOT :type :history machine and confirm the
+         PLACEMENT constraint rejects it (a pseudo-state needs an owning
+         compound). The throw is swallowed here so the deck does not crash;
+         the harness asserts the misplaced-history rejection shape."}
   (fn handler-probe-history [db _ev]
     (-> db bump (assoc :machine-epochs/history-rejected? (machines/history-rejected?)))))
+
+;; the HISTORY restore dance (rf2-mle6e.5). To make the RESTORE the focal
+;; cascade the operator inspects, the step first POSITIONS the player deep
+;; (`:insert` → `:play` → `:seek` lands it at [:player :playing :mid-track]) and
+;; EJECTS it (recording :player's last config into :rf/history), then fires the
+;; final `:insert` — which is the restore whose cascade carries the
+;; :rf.machine.history/restored banner + the :source-chipped :entry steps. The
+;; restore is the LAST dispatch so it is the headline of the step's epoch.
+;;
+;; SHALLOW (:media/shallow) records the direct child (:playing) and restores
+;; [:player :playing :at-start] (the child descended through its :initial).
+;; DEEP (:media/deep) records + restores the exact leaf [:player :playing
+;; :mid-track]. The two share the driver shape; only the machine-id differs.
+(defn- history-restore-fx
+  "The fx vector that positions `machine-id` deep, ejects (records), and
+  re-inserts (restores). The trailing :insert is the focal restore."
+  [machine-id]
+  [[:dispatch [machine-id [:insert]]]   ; first entry → default (records nothing yet)
+   [:dispatch [machine-id [:seek]]]      ; :at-start → :mid-track (deep leaf)
+   [:dispatch [machine-id [:eject]]]     ; exit :player → :tray (RECORDS history)
+   [:dispatch [machine-id [:insert]]]])  ; re-enter via :hist (RESTORES — the headline)
+
+(rf/reg-event-fx :machine-epochs/history-shallow-restore
+  {:doc "Drive :media/shallow through the eject/restore dance so the final
+         :insert restores the recorded CHILD then descends its :initial chain.
+         The restore cascade carries the history banner + :source :recorded
+         entry-step chips (SHALLOW)."}
+  (fn handler-history-shallow [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx (history-restore-fx :media/shallow)}))
+
+(rf/reg-event-fx :machine-epochs/history-deep-restore
+  {:doc "Drive :media/deep through the eject/restore dance so the final :insert
+         restores the EXACT recorded leaf [:player :playing :mid-track]. The
+         restore cascade carries the history banner (DEEP) + :source :recorded
+         entry-step chips down to the exact leaf."}
+  (fn handler-history-deep [{:keys [db]} _ev]
+    {:db (bump db)
+     :fx (history-restore-fx :media/deep)}))
 
 ;; ============================================================================
 ;; RESET
 ;; ============================================================================
 
 (rf/reg-event-fx :machine-epochs/reset
-  {:doc "Button 0 — re-seed app-db and bootstrap every NON-throwing machine
-         to its initial state. Start clean.
+  {:doc "Re-seed app-db and bootstrap every NON-throwing machine to its initial
+         state. Start clean.
 
          :fuse/box is DELIBERATELY NOT bootstrapped: a
          [:fuse/box [:rf.machine/bootstrap]] dispatch would, after the
          initial-entry cascade, process the inner [:rf.machine/bootstrap] as
          a normal event — :armed has no :on entry for it, so it falls to the
-         :* wildcard whose :blow-fuse action THROWS on boot. The fuse box
-         must throw ONLY when its rung presses it (it lazily bootstraps on
-         its first real event). Net: clean boot."}
+         :* wildcard whose :blow-fuse action THROWS on boot. The fuse box must
+         throw ONLY when its step presses it (it lazily bootstraps on its first
+         real event). Net: clean boot."}
   (fn handler-reset [_ _ev]
     {:db initial-db
      :fx (mapv (fn [id] [:dispatch [id [:rf.machine/bootstrap]]])
@@ -291,185 +368,155 @@
   (fn [snap _] (:data snap)))
 
 ;; ============================================================================
-;; THE BUTTON LADDER — the data-driven single source of truth (rf2-g27vv)
+;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
 ;; ============================================================================
 ;;
-;; Each row: [n label caption event]. `:section` rows are separators (label
-;; only). The harness reads the machine specs (shared via
-;; `machine-epochs.machines`) and drives each rung's intent through the live
-;; substrate, asserting BOTH machine outcome + Xray render.
-
-(def ladder
-  [[:section "Door (FLAT) — start · transition · entry/exit · effect"]
-   [1  "Start machine (bootstrap)"
-    "Inspector: the door chart renders; live-highlight lands on :locked. Epoch: :initial-entry, NOT a no-op"
-    [:door/main [:rf.machine/bootstrap]]]
-   [2  "Insert coin (:locked ──► :closed)"
-    "Focused-transition lens: plain FROM → TO, no guard / no action; cascade = exit→TRANSITION→entry rows"
-    [:machine-epochs/send [[:door/main [:door/insert-coin]]]]]
-   [3  "Push (:closed ──► :open) — entry + exit"
-    "ACTIONS RUN: :closed's :exit (:clear-hold) + :open's :entry (:count-open); snapshot :opened-count++"
-    [:machine-epochs/send [[:door/main [:door/push]]]]]
-   [:section "Door — guards (allowed vs blocked) · internal"]
-   [4  "Close (:open ──► :closed) — guard ALLOWED"
-    "GUARDS RUN: :may-close? → pass; transition completes to :closed"
-    [:machine-epochs/send [[:door/main [:door/close]]]]]
-   [5  "Re-open, hold, then close — guard BLOCKED"
-    "GUARDS RUN: :may-close? → fail (held-open?); state STAYS :open (no branch matches)"
-    [:machine-epochs/reopen-then-block]]
-   [:section "Door — effect · ignored · transition RESOLUTION (gap 6)"]
-   [6  "Trip (:open ──► :alarming) — with effect"
-    "ACTIONS RUN: :enter-alarm → :fx :dispatch → [:alarm-acknowledged] (downstream cascade child)"
-    [:machine-epochs/send [[:door/main [:door/trip]]]]]
-   [7  "Insert coin into :alarming — UNHANDLED no-op"
-    "Epoch: ONE [NO OP] staying in :alarming row; NO transition row; event row NOT pink — the foil to the throw"
-    [:machine-epochs/send [[:door/main [:door/insert-coin]]]]]
-   [8  "Audit from :alarming — ROOT :on fallthrough"
-    "Resolution: :alarming has no :door/audit; the ROOT :on handles it → :alarming ──► :locked (deepest-wins fallthrough)"
-    [:machine-epochs/send [[:door/main [:door/audit]]]]]
-   [:section "Traffic (PARALLEL) — regions · history · TAG-SET delta (gap 7)"]
-   [9  "Tick traffic (parallel regions)"
-    "Inspector: ONE event broadcasts to :vehicle + :pedestrian; chart highlights BOTH active leaves; tags swap members"
-    [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]]
-   [10 "Tick traffic ×1 more (history ribbon)"
-    "Transition-history ribbon accumulates state → state entries; logical-state DELTA box shows :tags member swap (rf2-l0us2)"
-    [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]]
-   [11 "Reset door + tick traffic (two machines, one cascade)"
-    "Inspector: one event transitions BOTH machines; instance selection picks the first in trace order; multi-machine no-op names its machine"
-    [:machine-epochs/send [[:door/main [:door/reset]] [:traffic/light [:traffic/tick]]]]]
-   [:section "Quiz (MICROSTEP) — :always EVENTLESS microsteps (gap 1)"]
-   [12 "Answer — score climbs (microsteps 0)"
-    "Cascade: the :answer action bumps :score; the :always guard is NOT yet met → 0 microsteps; quiz stays :asking"
-    [:machine-epochs/send [[:quiz/scorer [:quiz/answer]]]]]
-   [13 "Answer ×2 more — :always SETTLES (microsteps > 0)"
-    "Cascade: :answer reaches the pass mark; the guarded :always chain fires → N microstep(s) + the microstep cascade to :passed"
-    [:machine-epochs/answer-to-pass]]
-   [:section "Brew (TIMER) — :after delayed transition + cancel (gap 2)"]
-   [14 "Start brew — schedules an :after timer"
-    "Cascade: :idle ──► :brewing; the :after timer is SCHEDULED (no fire yet). Watch the AFTER TIMERS sub-section"
-    [:machine-epochs/send [[:brew/machine [:brew/start]]]]]
-   [15 "Let the :after timer ELAPSE (auto-fire)"
-    "Cascade: the synthetic :after-elapsed fires → :brewing ──► :ready; DISPATCH row labels 'from :after timer'"
-    [:machine-epochs/send [[:brew/machine [:rf.machine.timer/after-elapsed 5000 1 [:brewing]]]]]]
-   [16 "Re-start then CANCEL — exit beats the timer"
-    "Cascade: re-enter :brewing (schedule) then :brew/abort exits before fire → :rf.machine.timer/cancelled (:on-exit) — the :cancelled chip"
-    [:machine-epochs/cancel-brew]]
-   [:section "Session (LIFECYCLE) — spawn · child :final · :on-done · destroy (gaps 3,4,5)"]
-   [17 "Open session — SPAWN child actor"
-    "Cascade: :idle ──► :authenticating spawns :session/login child; spawn fx renders; the instance spine spans parent + child"
-    [:machine-epochs/send [[:session/flow [:session/open]]]]]
-   [18 "Child succeeds — :final + :on-done + auto-DESTROY"
-    "Cascade: drive the child to :final? → :on-done reports the token to the parent → child auto-destroys (exit-cascade-on-destroy + destroyed trace)"
-    [:machine-epochs/finish-login]]
-   [:section "Fuse (WILDCARD-THROW) — :* action THROWS (xstate-v5 fail-loudly)"]
-   [19 "Send unhandled event to :fuse/box — :* action THROWS"
-    "Epoch: EXCEPTION card (message + ex-data + coord) attributing a :* WILDCARD action; event row IS pink; cascade-summary :outcome :error"
-    [:machine-epochs/send [[:fuse/box [:fuse/short-circuit]]]]]
-   [:section "Hvac (DEEP-COMPOUND) — compound · LCA cascade · self-transitions"]
-   [20 "Power-cycle (parallel — BOTH regions, deep initial cascade)"
-    "Cascade: ONE event → :climate :idle──►:running (entry+initial cascade to [:running :conditioning :heating]) AND :fan :off──►:on"
-    [:machine-epochs/send [[:hvac/controller [:hvac/power-cycle]]]]]
-   [21 "Mode-toggle (:heating ⇄ :cooling — multi-level LCA cascade)"
-    "Cascade ORDER: exit :heating (deepest-first) → :swap-mode @ LCA :conditioning → entry :cooling (shallowest-first)"
-    [:machine-epochs/send [[:hvac/controller [:hvac/mode-toggle]]]]]
-   [22 "Nudge fan — EXTERNAL self-transition (:target :same-state)"
-    "Cascade: :fan :on re-enters itself — exit :fan-on → :nudge-fan → entry :fan-on; NO spurious {:on}→{:on} no-op row"
-    [:machine-epochs/send [[:hvac/controller [:hvac/nudge]]]]]
-   [23 "Tweak fan — INTERNAL self-transition (omit :target)"
-    "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to #22; NO spurious no-op row"
-    [:machine-epochs/send [[:hvac/controller [:hvac/tweak]]]]]
-   [:section "History (LIVE, gap 8) — first-class shallow + deep restore (rf2-mle6e)"]
-   [24 "Register a ROOT :history machine — REJECTED (placement)"
-    "History is FIRST-CLASS; a ROOT :type :history is still rejected :rf.error/machine-history-misplaced (a pseudo-state needs an owning compound)"
-    [:machine-epochs/probe-history-rejection]]
-   [25 "SHALLOW history restore (:media/shallow eject → re-insert)"
-    "Epoch: the :rf.machine.history/restored banner (source :recorded, SHALLOW); restored :entry steps chip 'from history'; restores the CHILD then its :initial"
-    [:machine-epochs/history-shallow-restore]]
-   [26 "DEEP history restore (:media/deep eject → re-insert)"
-    "Epoch: the banner reads DEEP; the :entry steps descend to the EXACT recorded leaf [:player :playing :mid-track], each chipped 'from history'"
-    [:machine-epochs/history-deep-restore]]])
-
-;; #13 — answer twice more so the running score reaches the `:enough?` pass
-;; mark (3) and the guarded `:always` chain settles `:asking` ──► `:passed`
-;; in N>0 microsteps. (#12 already answered once.) Two answers in one cascade
-;; so the LAST `:answer` is the one whose macrostep carries the microstep.
-(rf/reg-event-fx :machine-epochs/answer-to-pass
-  {:doc "Button #13 — :quiz/answer ×2 so the score reaches the pass mark and
-         the guarded :always chain fires (microsteps > 0)."}
-  (fn handler-answer-to-pass [{:keys [db]} _ev]
-    {:db (bump db)
-     :fx [[:dispatch [:quiz/scorer [:quiz/answer]]]
-          [:dispatch [:quiz/scorer [:quiz/answer]]]]}))
-
-;; #25 / #26 — the HISTORY restore dance (rf2-mle6e.5). To make the RESTORE the
-;; focal cascade the operator inspects, the rung first POSITIONS the player deep
-;; (`:insert` → `:play` → `:seek` lands it at [:player :playing :mid-track]) and
-;; EJECTS it (recording :player's last config into :rf/history), then fires the
-;; final `:insert` — which is the restore whose cascade carries the
-;; :rf.machine.history/restored banner + the :source-chipped :entry steps. The
-;; restore is the LAST dispatch so it is the headline of the press's epoch.
+;; Each step: {:event [...] :watch "<what to look for>" :settle-ms N
+;;             :label "<short row label>"}. The runner renders :watch per STEP
+;; (per-occurrence narration), dispatches :event, focuses the latest
+;; :rf/default epoch (auto-advance), then waits :settle-ms before advancing.
+;; The matrix walks the machine set domain-by-domain; the events are the SAME
+;; ones the bespoke ladder drove (the machine FEATURES are unchanged — only the
+;; driving affordance moved to the runner).
 ;;
-;; SHALLOW (:media/shallow) records the direct child (:playing) and restores
-;; [:player :playing :at-start] (the child descended through its :initial).
-;; DEEP (:media/deep) records + restores the exact leaf [:player :playing
-;; :mid-track]. The two share the driver shape; only the machine-id differs.
-(defn- history-restore-fx
-  "The fx vector that positions `machine-id` deep, ejects (records), and
-  re-inserts (restores). The trailing :insert is the focal restore."
-  [machine-id]
-  [[:dispatch [machine-id [:insert]]]   ; first entry → default (records nothing yet)
-   [:dispatch [machine-id [:seek]]]      ; :at-start → :mid-track (deep leaf)
-   [:dispatch [machine-id [:eject]]]     ; exit :player → :tray (RECORDS history)
-   [:dispatch [machine-id [:insert]]]])  ; re-enter via :hist (RESTORES — the headline)
+;; The `:label` carries the section/domain prefix (Door · Traffic · …) so the
+;; flat runner list stays legible without a section-separator concept.
+;;
+;; Step indices are 0-based; the feature-matrix scenario names each step via
+;; the runner's `machine-epochs-step-<n>-run` button (n = step index). The
+;; CLJS harness is INDEPENDENT of this view (it drives the substrate directly),
+;; so it neither reads these testids nor depends on the step ordering.
 
-(rf/reg-event-fx :machine-epochs/history-shallow-restore
-  {:doc "Button #25 — drive :media/shallow through the eject/restore dance so
-         the final :insert restores the recorded CHILD then descends its
-         :initial chain. The restore cascade carries the history banner +
-         :source :recorded entry-step chips (SHALLOW)."}
-  (fn handler-history-shallow [{:keys [db]} _ev]
-    {:db (bump db)
-     :fx (history-restore-fx :media/shallow)}))
+(def steps
+  [;; -- DOOR (FLAT) — start · transition · entry/exit · effect --
+   {:label     "Door: start machine (bootstrap)"
+    :event     [:door/main [:rf.machine/bootstrap]]
+    :watch     "Inspector: the door chart renders; live-highlight lands on :locked. Epoch: :initial-entry, NOT a no-op."
+    :settle-ms 350}
+   {:label     "Door: insert coin (:locked ──► :closed)"
+    :event     [:machine-epochs/send [[:door/main [:door/insert-coin]]]]
+    :watch     "Focused-transition lens: plain FROM → TO, no guard / no action; cascade = exit→TRANSITION→entry rows."
+    :settle-ms 350}
+   {:label     "Door: push (:closed ──► :open) — entry + exit"
+    :event     [:machine-epochs/send [[:door/main [:door/push]]]]
+    :watch     "ACTIONS RUN: :closed's :exit (:clear-hold) + :open's :entry (:count-open); snapshot :opened-count++."
+    :settle-ms 350}
+   {:label     "Door: close (:open ──► :closed) — guard ALLOWED"
+    :event     [:machine-epochs/send [[:door/main [:door/close]]]]
+    :watch     "GUARDS RUN: :may-close? → pass; transition completes to :closed."
+    :settle-ms 350}
+   {:label     "Door: re-open, hold, then close — guard BLOCKED"
+    :event     [:machine-epochs/reopen-then-block]
+    :watch     "GUARDS RUN: :may-close? → fail (held-open?); state STAYS :open (no branch matches)."
+    :settle-ms 400}
+   {:label     "Door: trip (:open ──► :alarming) — with effect"
+    :event     [:machine-epochs/send [[:door/main [:door/trip]]]]
+    :watch     "ACTIONS RUN: :enter-alarm → :fx :dispatch → [:alarm-acknowledged] (downstream cascade child)."
+    :settle-ms 400}
+   {:label     "Door: insert coin into :alarming — UNHANDLED no-op"
+    :event     [:machine-epochs/send [[:door/main [:door/insert-coin]]]]
+    :watch     "Epoch: ONE [NO OP] staying in :alarming row; NO transition row; event row NOT pink — the foil to the throw."
+    :settle-ms 350}
+   {:label     "Door: audit from :alarming — ROOT :on fallthrough"
+    :event     [:machine-epochs/send [[:door/main [:door/audit]]]]
+    :watch     "Resolution: :alarming has no :door/audit; the ROOT :on handles it → :alarming ──► :locked (deepest-wins fallthrough)."
+    :settle-ms 350}
 
-(rf/reg-event-fx :machine-epochs/history-deep-restore
-  {:doc "Button #26 — drive :media/deep through the eject/restore dance so the
-         final :insert restores the EXACT recorded leaf [:player :playing
-         :mid-track]. The restore cascade carries the history banner (DEEP) +
-         :source :recorded entry-step chips down to the exact leaf."}
-  (fn handler-history-deep [{:keys [db]} _ev]
-    {:db (bump db)
-     :fx (history-restore-fx :media/deep)}))
+   ;; -- TRAFFIC (PARALLEL) — regions · history · TAG-SET delta (gap 7) --
+   {:label     "Traffic: tick (parallel regions)"
+    :event     [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]
+    :watch     "Inspector: ONE event broadcasts to :vehicle + :pedestrian; chart highlights BOTH active leaves; tags swap members."
+    :settle-ms 350}
+   {:label     "Traffic: tick ×1 more (history ribbon)"
+    :event     [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]
+    :watch     "Transition-history ribbon accumulates state → state entries; logical-state DELTA box shows :tags member swap (rf2-l0us2)."
+    :settle-ms 350}
+   {:label     "Reset door + tick traffic (two machines, one cascade)"
+    :event     [:machine-epochs/send [[:door/main [:door/reset]] [:traffic/light [:traffic/tick]]]]
+    :watch     "Inspector: one event transitions BOTH machines; instance selection picks the first in trace order; multi-machine no-op names its machine."
+    :settle-ms 400}
+
+   ;; -- QUIZ (MICROSTEP) — :always EVENTLESS microsteps (gap 1) --
+   {:label     "Quiz: answer — score climbs (microsteps 0)"
+    :event     [:machine-epochs/send [[:quiz/scorer [:quiz/answer]]]]
+    :watch     "Cascade: the :answer action bumps :score; the :always guard is NOT yet met → 0 microsteps; quiz stays :asking."
+    :settle-ms 350}
+   {:label     "Quiz: answer ×2 more — :always SETTLES (microsteps > 0)"
+    :event     [:machine-epochs/answer-to-pass]
+    :watch     "Cascade: :answer reaches the pass mark; the guarded :always chain fires → N microstep(s) + the microstep cascade to :passed."
+    :settle-ms 450}
+
+   ;; -- BREW (TIMER) — :after delayed transition + cancel (gap 2) --
+   {:label     "Brew: start — schedules an :after timer"
+    :event     [:machine-epochs/send [[:brew/machine [:brew/start]]]]
+    :watch     "Cascade: :idle ──► :brewing; the :after timer is SCHEDULED (no fire yet). Watch the AFTER TIMERS sub-section."
+    :settle-ms 400}
+   {:label     "Brew: let the :after timer ELAPSE (auto-fire)"
+    :event     [:machine-epochs/send [[:brew/machine [:rf.machine.timer/after-elapsed 5000 1 [:brewing]]]]]
+    :watch     "Cascade: the synthetic :after-elapsed fires → :brewing ──► :ready; DISPATCH row labels 'from :after timer'."
+    :settle-ms 400}
+   {:label     "Brew: re-start then CANCEL — exit beats the timer"
+    :event     [:machine-epochs/cancel-brew]
+    :watch     "Cascade: re-enter :brewing (schedule) then :brew/abort exits before fire → :rf.machine.timer/cancelled (:on-exit) — the :cancelled chip."
+    :settle-ms 450}
+
+   ;; -- SESSION (LIFECYCLE) — spawn · child :final · :on-done · destroy --
+   {:label     "Session: open — SPAWN child actor"
+    :event     [:machine-epochs/send [[:session/flow [:session/open]]]]
+    :watch     "Cascade: :idle ──► :authenticating spawns :session/login child; spawn fx renders; the instance spine spans parent + child."
+    :settle-ms 400}
+   {:label     "Session: child succeeds — :final + :on-done + auto-DESTROY"
+    :event     [:machine-epochs/finish-login]
+    :watch     "Cascade: drive the child to :final? → :on-done reports the token to the parent → child auto-destroys (exit-cascade-on-destroy + destroyed trace)."
+    :settle-ms 450}
+
+   ;; -- FUSE (WILDCARD-THROW) — :* action THROWS (xstate-v5 fail-loudly) --
+   {:label     "Fuse: unhandled event to :fuse/box — :* action THROWS"
+    :event     [:machine-epochs/send [[:fuse/box [:fuse/short-circuit]]]]
+    :watch     "Epoch: EXCEPTION card (message + ex-data + coord) attributing a :* WILDCARD action; event row IS pink; cascade-summary :outcome :error."
+    :settle-ms 400}
+
+   ;; -- HVAC (DEEP-COMPOUND) — compound · LCA cascade · self-transitions --
+   {:label     "Hvac: power-cycle (parallel — BOTH regions, deep initial cascade)"
+    :event     [:machine-epochs/send [[:hvac/controller [:hvac/power-cycle]]]]
+    :watch     "Cascade: ONE event → :climate :idle──►:running (entry+initial cascade to [:running :conditioning :heating]) AND :fan :off──►:on."
+    :settle-ms 400}
+   {:label     "Hvac: mode-toggle (:heating ⇄ :cooling — multi-level LCA cascade)"
+    :event     [:machine-epochs/send [[:hvac/controller [:hvac/mode-toggle]]]]
+    :watch     "Cascade ORDER: exit :heating (deepest-first) → :swap-mode @ LCA :conditioning → entry :cooling (shallowest-first)."
+    :settle-ms 400}
+   {:label     "Hvac: nudge fan — EXTERNAL self-transition (:target :same-state)"
+    :event     [:machine-epochs/send [[:hvac/controller [:hvac/nudge]]]]
+    :watch     "Cascade: :fan :on re-enters itself — exit :fan-on → :nudge-fan → entry :fan-on; NO spurious {:on}→{:on} no-op row."
+    :settle-ms 400}
+   {:label     "Hvac: tweak fan — INTERNAL self-transition (omit :target)"
+    :event     [:machine-epochs/send [[:hvac/controller [:hvac/tweak]]]]
+    :watch     "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to the nudge; NO spurious no-op row."
+    :settle-ms 400}
+
+   ;; -- HISTORY (LIVE, gap 8) — first-class shallow + deep restore (rf2-mle6e) --
+   {:label     "History: register a ROOT :history machine — REJECTED (placement)"
+    :event     [:machine-epochs/probe-history-rejection]
+    :watch     "History is FIRST-CLASS; a ROOT :type :history is still rejected :rf.error/machine-history-misplaced (a pseudo-state needs an owning compound)."
+    :settle-ms 350}
+   {:label     "History: SHALLOW restore (:media/shallow eject → re-insert)"
+    :event     [:machine-epochs/history-shallow-restore]
+    :watch     "Epoch: the :rf.machine.history/restored banner (source :recorded, SHALLOW); restored :entry steps chip 'from history'; restores the CHILD then its :initial."
+    :settle-ms 500}
+   {:label     "History: DEEP restore (:media/deep eject → re-insert)"
+    :event     [:machine-epochs/history-deep-restore]
+    :watch     "Epoch: the banner reads DEEP; the :entry steps descend to the EXACT recorded leaf [:player :playing :mid-track], each chipped 'from history'."
+    :settle-ms 500}])
+
+;; ============================================================================
+;; RUNNER STATE — LOCAL ATOM (rf2-8pbjr: not app-db, not a 2nd frame)
+;; ============================================================================
+
+(defonce runner-state (r/atom (runner/initial-state)))
 
 ;; ============================================================================
 ;; VIEWS
 ;; ============================================================================
-
-(reg-view ladder-button
-  "One numbered ladder row: a numbered button on the left, its caption on the
-  right. The button carries a per-rung `data-testid`
-  (`machine-epochs-rung-<n>`) so each rung is uniquely addressable."
-  [n label caption event]
-  [:div {:style {:display "grid" :grid-template-columns "auto 1fr"
-                 :gap "0.75em" :align-items "center" :margin "0.35em 0"}}
-   [:button {:data-testid (str "machine-epochs-rung-" n)
-             :on-click    #(dispatch event)
-             :style {:min-width "24em" :text-align "left"
-                     :padding "0.4em 0.6em" :cursor "pointer"
-                     :border "1px solid #cfc8ff" :border-radius "6px"
-                     :background "#fff"}}
-    [:span {:style {:font-weight "bold" :color "#7C5CFF" :margin-right "0.5em"}}
-     (str n ".")]
-    label]
-   [:span {:style {:color "#666" :font-size "12px"}} caption]])
-
-(reg-view section-heading
-  "A section separator inside the ladder."
-  [label]
-  [:div {:style {:margin "1em 0 0.25em 0" :font-size "11px" :font-weight "bold"
-                 :color "#7C5CFF" :text-transform "uppercase"
-                 :letter-spacing "0.04em" :border-top "1px dashed #ddd"
-                 :padding-top "0.5em"}}
-   label])
 
 (reg-view machine-row
   "One line of the status strip: a machine's active state + tags + trail."
@@ -517,26 +564,33 @@
          :style {:font-family "system-ui, sans-serif" :padding "1em"
                  :max-width "880px"}}
    [:header {:style {:margin-bottom "0.5em"}}
-    [:h2 {:style {:margin 0}} "Machine-epochs — assertion-backed render harness"]
+    [:h2 {:data-testid "machine-epochs-title" :style {:margin 0}}
+     "Xray Testbed: Machine Epochs"]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "One frame, one tall column of state-machine test buttons. Each rung bumps a shared "
-     [:strong "baseline"] " counter and sends one machine event exercising exactly one "
-     "machine FEATURE × the Xray cascade-render SURFACE it lights up. Click top to bottom — "
-     "every render surface is exercised. The "
-     [:strong "trail"] " in each snapshot is the cascade ORDER made visible (the order-oracle "
-     "the harness keys its assertions off)."]]
-   [machine-status-strip]
+     "One frame, one state-machine matrix. One button (" [:strong "▶ Run series"]
+     ") walks every machine FEATURE × the Xray cascade-render SURFACE it lights "
+     "up — Door (FLAT) · Traffic (PARALLEL) · Quiz (MICROSTEP) · Brew (TIMER) · "
+     "Session (LIFECYCLE) · Hvac (DEEP-COMPOUND) · Fuse (WILDCARD-THROW) · "
+     "Media (HISTORY). Each step bumps a shared " [:strong "baseline"]
+     " counter and sends one machine event; the " [:strong "trail"]
+     " in each snapshot is the cascade ORDER made visible."]
+    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
+     "After each auto-advance the runner pins Xray focus to the latest "
+     [:code ":rf/default"] " epoch; read each step's " [:strong "Watch"]
+     " note, then watch the Epoch panel + Machine Inspector render the cascade. "
+     "Each step's number is a " [:strong "RUN-THIS-STEP"]
+     " button (drive any step directly). The runner cursor lives in a "
+     [:strong "local atom"] " — it never touches the inspected app-db."]]
    [:button {:data-testid "reset-button"
-             :on-click #(dispatch [:machine-epochs/reset])
+             :on-click (fn []
+                         (dispatch [:machine-epochs/reset])
+                         (runner/reset-runner! runner-state))
              :style {:padding "0.4em 0.8em" :cursor "pointer"
                      :border "1px solid #cfc8ff" :border-radius "6px"
                      :background "#f4f1ff" :margin "0.5em 0"}}
-    "0. Reset — re-seed app-db, bootstrap every machine"]
-   (for [row ladder]
-     (case (first row)
-       :section     ^{:key (str "sec-" (second row))} [section-heading (second row)]
-       (let [[n label caption event] row]
-         ^{:key n} [ladder-button n label caption event])))])
+    "0. Reset — re-seed app-db, bootstrap every machine + rewind runner"]
+   [machine-status-strip]
+   [runner/runner "machine-epochs" runner-state steps host-frame]])
 
 ;; ============================================================================
 ;; MOUNT

--- a/tools/xray/testbeds/runner/core.cljs
+++ b/tools/xray/testbeds/runner/core.cljs
@@ -51,7 +51,16 @@
   - **Per-step addressing.** Every rendered step row carries a stable,
     unique `data-testid` (`<prefix>-step-<n>`, plus the run / pause /
     reset / step controls) so a feature-matrix scenario can name each
-    rung. The prefix is the testbed's, passed via `opts`.
+    rung. The prefix is the testbed's, passed via `opts`. Each row's
+    index is ALSO a clickable RUN-THIS-STEP button
+    (`<prefix>-step-<n>-run`) that drives that step directly via
+    `run-step-at!` — RANDOM-ACCESS addressing alongside the sequential
+    run / step controls. A deck whose feature-matrix assertions need to
+    re-drive a NAMED step out of cursor order (a routing / machine
+    ladder asserting a panel render after a specific rung) names each
+    step through that button rather than keeping a parallel bespoke
+    button ladder. The sequential one-button contract is unchanged; the
+    per-step run is purely additive.
 
   ## Why a shared ns (the rollout vehicle)
 
@@ -218,6 +227,26 @@
   (swap! state assoc :running? false)
   (run-step! state steps host-frame {:auto? false}))
 
+(defn run-step-at!
+  "RANDOM-ACCESS manual step: move the cursor to step `n` and run THAT
+  step (dispatch + settle + advance), WITHOUT pinning focus (manual mode
+  — the operator drives the spine). Stops any in-flight auto series first.
+  No-op for an out-of-range `n`.
+
+  This is the per-step affordance the runner exposes alongside the
+  sequential run / step controls: each rendered step row carries a
+  clickable `<prefix>-step-<n>-run` button so an operator (or a feature-
+  matrix scenario) can drive ANY step directly, not only the next one in
+  the cursor's path. The sequential run-series + step-once contract is
+  unchanged; this is purely additive — a deck whose assertions need to
+  re-drive a specific step out of order (a routing / machine ladder that
+  asserts a panel render AFTER a NAMED rung) can name each step here
+  rather than keeping a parallel bespoke button ladder."
+  [state steps host-frame n]
+  (when (and (integer? n) (<= 0 n) (< n (count steps)))
+    (swap! state assoc :running? false :cursor n)
+    (run-step! state steps host-frame {:auto? false})))
+
 (defn reset-runner!
   "Reset the runner to the top, idle, no pending timer."
   [state]
@@ -291,16 +320,28 @@
 (reg-view step-row
   "One step row: its index, label, and `:watch` commentary. The CURRENT
   step (the one just-run or about-to-run) is highlighted. Carries a
-  stable per-step `data-testid` (`<prefix>-step-<n>`)."
-  [prefix n step current? done?]
+  stable per-step `data-testid` (`<prefix>-step-<n>`).
+
+  The index is a clickable RUN-THIS-STEP button (`<prefix>-step-<n>-run`)
+  that drives exactly this step via `run-step-at!` (random-access, manual
+  — no focus pinning). The sequential run / step / reset controls remain
+  the primary affordances; this lets an operator (or a scenario) drive any
+  step directly without a parallel bespoke button ladder."
+  [prefix state steps host-frame n step current? done?]
   [:div {:data-testid (str prefix "-step-" n)
          :style {:display "grid" :grid-template-columns "auto 1fr"
                  :gap "0.75em" :align-items "baseline" :margin "0.25em 0"
                  :padding "0.4em 0.6em" :border-radius "6px"
                  :border (if current? "1px solid #7C5CFF" "1px solid #eee")
                  :background (cond current? "#f1ecff" done? "#fafafa" :else "#fff")}}
-   [:span {:style {:font-weight "bold"
-                   :color (cond current? "#7C5CFF" done? "#aaa" :else "#555")}}
+   [:button {:data-testid (str prefix "-step-" n "-run")
+             :title "Run this step"
+             :on-click #(run-step-at! state steps host-frame n)
+             :style {:font-weight "bold" :cursor "pointer"
+                     :padding "0.1em 0.45em" :border-radius "5px"
+                     :border (if current? "1px solid #7C5CFF" "1px solid #e3def9")
+                     :background (if current? "#7C5CFF" "#fff")
+                     :color (cond current? "#fff" done? "#aaa" :else "#7C5CFF")}}
     (str (inc n) ".")]
    [:div
     [:div {:style {:font-weight "600" :color "#333"}}
@@ -329,5 +370,5 @@
       (map-indexed
         (fn [n step]
           ^{:key n}
-          [step-row prefix n step (= n cursor) (< n cursor)])
+          [step-row prefix state steps host-frame n step (= n cursor) (< n cursor)])
         steps)]]))


### PR DESCRIPTION
## What

Mike ruled `machine_epochs` "should be runner-shaped." This converts the deck from its bespoke numbered-button ladder to the shared queued-step runner (`runner.core`, the rf2-8pbjr pilot):

- step-vector of `{:event :watch :settle-ms}` **code data**
- ONE `▶ Run series` button + a `⏭ Step once` button + `↺ Reset`
- runner state in a **local atom** (never app-db, never a 2nd frame)
- focus-latest-host-epoch after each auto-advance
- stable per-step `data-testid`s (`machine-epochs-step-<n>`)
- title `Xray Testbed: Machine Epochs`

## Coverage preserved (this is the richest testbed)

1. **The g27vv 26-rung assertion harness passes UNCHANGED.** The harness (`machine_epochs_harness_cljs_test`) drives the substrate **directly** (`dispatch-sync` over the shared `machine-epochs.machines` specs) and is decoupled from the deck's view — so the runner conversion is *additive*: it neither drops nor relies on the harness assertions. The harness was not modified (driving it through the DOM would have been a regression; the direct-substrate drive is the robust pattern and already pins every per-step assertion).
2. **The mle6e.5 live history coverage stays as live steps** — shallow restore, deep restore, and the placement-rejection probe.
3. **The feature_matrix `machine-epochs machine ladder` scenario is migrated in this same PR.** `clickMachineRung` now drives the runner's per-step RUN-THIS-STEP button instead of the retired `machine-epochs-rung-<n>` buttons; the scenario **name** and the `machine-epochs-status-strip` testid contract are unchanged.

## The random-access decision (constraint 4)

The scenario drive order is **sequential for the main pass** (rungs 1→24) but **random-access at the end**: the Inspector + throw/no-op-contrast handoff re-fires the fresh-transition / unhandled-no-op / wildcard-throw steps *out of cursor order*. That is exactly the `routes_epochs` failure mode the sequential runner cursor cannot serve.

Rather than back out (losing per-step assertions) or keep a parallel bespoke button ladder (defeating the one-button contract), the shared runner gains a **purely-additive random-access affordance**: `run-step-at!` + a clickable per-step index button (`<prefix>-step-<n>-run`). This implements the rf2-3xakq option (a) "jump to step N" the runner needed, and benefits every consumer (`managed_http`, `edn_inspector`) *without changing their sequential one-button contract*.

## Scope notes

- Reuses the existing `:examples/machine-epochs` build-id (port 8033) — **no hot-zone `shadow-cljs.edn` change**.
- `tools/xray/spec/003` + `/021` refreshed for the runner shape + live history (per the Xray-specs-kept-current rule).
- Disjoint from the in-flight workers (#2872 repo-root spec/005+009+README; avb5k docs/guide).

## Quality gates (COLD)

- `npx shadow-cljs compile :examples/machine-epochs` — **0 warnings**
- `npm run test:cljs` — **5440 tests / 18770 assertions / 0 failures** (incl. the machine_epochs harness)
- `npm run test:xray-feature-gate` — **16 scenarios / 0 failures** (`machine-epochs machine ladder` + `routes-epochs routing ladder` both green)

Closes rf2-kipb5.
