### PR TITLE
fix(machines-viz): measure-then-relayout so ELK sizes nodes to the rendered box (rf2-d9ro2)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -165,6 +165,64 @@ visually escape the container. Leaf (non-container) state nodes carry
 NO `:style`; xyflow sizes them from the rendered DOM
 (`state-node-min-{width,height}`).
 
+### Measure-then-relayout — ELK sizes nodes to the rendered box (rf2-d9ro2)
+
+ELK lays the graph out assuming each node is exactly the size its input
+descriptor declares (`projection/elk-child` / `elk-event-child`). A
+state-node, however, renders at CONTENT size — the state label (variable
+length) plus the tag-pill row plus the entry / exit action-pill rows
+(rf2-a2b55) — floored only by CSS `min-{width,height}`. Feeding ELK the
+fixed `state-node-min-{width,height}` floor for EVERY node (the original
+single-pass) understates every node wider/taller than the floor, so ELK
+budgets slots too small and neighbours OVERLAP — the missized/cluttered
+topology rf2-d9ro2 fixes.
+
+The chart therefore runs the canonical React Flow + ELK **two-pass**
+(the same shape the official React Flow ELK example and xstate-viz /
+Stately use):
+
+1. **First pass.** `MachineChart` runs ELK with NO measured dims; every
+   leaf + event-node seeds at its floor. Nodes mount at content size.
+2. **Measure.** xyflow measures each rendered node and populates
+   `node.measured {width height}`. The chart reads them back off the
+   captured ReactFlowInstance (`fit-state :instance`, via `getNodes`)
+   through the `read-measured-dims` seam, driven by xyflow's
+   `:onNodesChange` (a `dimensions` `NodeChange`) and the `:onInit`
+   fast-commit branch.
+3. **Relayout.** The measured `{node-id {:width :height}}` map threads
+   through `compute-layout!` → `->elk-input` → `projection/->elk-children`;
+   each LEAF + event-node lays out at `(max measured floor)` per
+   dimension (`projection/leaf-elk-size`). COMPOUND / region CONTAINERS
+   keep the floor seed — their true extent comes from ELK laying out
+   their measured children (`elk.hierarchyHandling INCLUDE_CHILDREN`), so
+   self-measuring their `100%`-of-the-box DOM would be circular.
+4. **Fit.** The relayout settle re-fits the viewport via the rf2-set3x
+   auto-fit (it shares the `fit-key` gate), framing the corrected
+   topology.
+
+The relayout MUST fire **at most once per layout-key** and MUST NOT
+loop. The `relayout-state` gate stores the measured-dims map ELK was
+last fed for the current layout-key and re-runs ELK only when (a) every
+ELK-measurable node (leaf states + event-nodes — not containers, not
+initial-marker glyphs) has a positive measured box, AND (b) the freshly
+measured map differs from the stored signature. Loop-freedom is
+structural: a relayout moves node POSITIONS only — it does not change
+node CONTENT — so the next measurement reports the SAME boxes, the
+signature matches, and no further pass fires. Position-only
+`onNodesChange` events never reach the comparison (the signature keys on
+measured dimensions, not position), so xyflow applying the new ELK
+positions cannot re-trigger. A new layout-key (new `:definition` /
+`:direction` / `:layout-options`) clears the signature so the new
+topology gets its own single relayout.
+
+This second pass is keyed on the SAME `[:definition :direction
+:layout-options]` layout-key as the first — it does not introduce a new
+layout-invalidation trigger (it is the completion of the existing pass
+once real sizes are known), so the load-bearing
+[layout-invalidation boundary](#layout-invalidation-boundary-is-load-bearing)
+below is unchanged: a decoration-prop change still never reaches the
+relayout path.
+
 ### Sub-flow nesting — `:parentId` (NOT `:parentNode`) (rf2-xh1lm)
 
 Every nested xyflow node (region substate, compound substate, the

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -171,12 +171,19 @@
   the source state's siblings (per `projection/->elk-children`); the
   resulting positions land in `:positions` keyed by the event-node id
   (`projection/event-node-id`) and the chart's xyflow projection picks
-  them up."
-  [{:keys [edges] :as parsed} direction layout-options]
+  them up.
+
+  rf2-d9ro2 — the optional `measured-dims` `{node-id {:width :height}}`
+  map (xyflow's reported `node.measured` rendered boxes from a prior
+  render) is threaded into `projection/->elk-children` so leaf states +
+  event-nodes lay out at their REAL size, floored by the min constants.
+  nil on the first pass; the measure-then-relayout lifecycle in
+  `MachineChart` supplies it on the second pass."
+  [{:keys [edges] :as parsed} direction layout-options measured-dims]
   #js {:id "root"
        :layoutOptions (clj->js (elk-layout-options parsed layout-options
                                                    direction))
-       :children (clj->js (projection/->elk-children parsed))
+       :children (clj->js (projection/->elk-children parsed measured-dims))
        :edges (clj->js
                 (vec
                   (mapcat
@@ -364,6 +371,36 @@
   [^js instance ^js opts]
   (.fitView instance opts))
 
+(defn read-measured-dims
+  "rf2-d9ro2 — read xyflow's measured node boxes off a captured
+  ReactFlowInstance as a pure CLJS `{node-id {:width :height}}` map.
+
+  xyflow v12 populates `node.measured {width height}` once it has
+  measured each rendered node's DOM box (after React commits + the
+  ResizeObserver fires). `instance.getNodes()` returns the current node
+  array; we keep only nodes that carry a positive measured width AND
+  height — a node still awaiting measurement (measured nil / 0) is
+  omitted, so the `measured-then-relayout` caller can tell whether the
+  WHOLE topology has been measured yet (`= (count dims) (count nodes)`).
+
+  Public-by-convention as a test seam (mirrors `invoke-fit-view!` /
+  `invoke-elk-layout!`): the relayout-lifecycle regression rebinds this
+  via `set!` to feed a stubbed measured map without a real xyflow
+  instance. No production code outside `MachineChart` calls it."
+  [^js instance]
+  (let [nodes (.getNodes instance)]
+    (persistent!
+      (reduce
+        (fn [acc ^js n]
+          (let [m (.-measured n)
+                w (and m (.-width m))
+                h (and m (.-height m))]
+            (if (and (number? w) (number? h) (pos? w) (pos? h))
+              (assoc! acc (.-id n) {:width w :height h})
+              acc)))
+        (transient {})
+        nodes))))
+
 (defn compute-layout!
   "Run elk.js layout on `parsed` (the output of
   `chart.layout/parse-definition`); call `done-fn` with a map
@@ -391,13 +428,21 @@
 
   Optional `:machine-id` is threaded onto the error trace's `:tags` so
   consumers (Xray Issues panel) can attribute the failure to a specific
-  machine; nil when called without a machine id (e.g. unit tests)."
+  machine; nil when called without a machine id (e.g. unit tests).
+
+  rf2-d9ro2 — the longest arity takes `measured-dims` (an optional
+  `{node-id {:width :height}}` map of xyflow's reported rendered boxes),
+  fed into `->elk-input` so the second (relayout) pass sizes each node
+  to its real box. The shorter arities pass nil (first pass / unit
+  tests) — identical to the pre-rf2-d9ro2 single-pass."
   ([parsed done-fn]
-   (compute-layout! parsed :tb nil nil done-fn))
+   (compute-layout! parsed :tb nil nil nil done-fn))
   ([parsed direction layout-options done-fn]
-   (compute-layout! parsed direction layout-options nil done-fn))
+   (compute-layout! parsed direction layout-options nil nil done-fn))
   ([parsed direction layout-options machine-id done-fn]
-   (let [input  (->elk-input parsed direction layout-options)
+   (compute-layout! parsed direction layout-options machine-id nil done-fn))
+  ([parsed direction layout-options machine-id measured-dims done-fn]
+   (let [input  (->elk-input parsed direction layout-options measured-dims)
          handle (fn handle-error [e]
                   (report-layout-error! e parsed direction layout-options
                                         machine-id)
@@ -696,6 +741,34 @@
         ;; invalidation boundary, AND the manual `Fit` Controls
         ;; button) is the only thing that re-fits.
         fit-state     (r/atom {:instance nil :fit-key nil})
+        ;; rf2-d9ro2 — measure-then-relayout lifecycle state.
+        ;;
+        ;; The bug: ELK was fed CONSTANT node dimensions (the
+        ;; `state-node-min-{width,height}` floors), not the real rendered
+        ;; box. `chart.nodes/state-node` renders at CONTENT size (label +
+        ;; tag pills + entry/exit action pills, rf2-a2b55), so any node
+        ;; wider/taller than the floor overlapped its neighbours and the
+        ;; topology looked missized. The fix is the canonical React Flow +
+        ;; ELK two-pass: mount nodes at content size, let xyflow measure
+        ;; them (`node.measured`), then re-run ELK with the measured box.
+        ;;
+        ;; `relayout-state` gates the second pass so it runs at most ONCE
+        ;; per layout-key and never loops:
+        ;;
+        ;;   :key      — the layout-key the stored measured signature
+        ;;               belongs to (a new topology resets the signature).
+        ;;   :measured — the `{node-id {:width :height}}` map ELK was last
+        ;;               FED (nil before any relayout). The relayout fires
+        ;;               only when xyflow's freshly-measured map differs
+        ;;               from this AND every node has been measured.
+        ;;
+        ;; Loop-freedom: a relayout only moves node POSITIONS — it does
+        ;; not change node CONTENT, so the next measurement reports the
+        ;; SAME boxes, the signature matches, and no further relayout
+        ;; fires. Position-only `onNodesChange` events never reach the
+        ;; signature comparison (it keys on measured dims, not position),
+        ;; so xyflow applying the new ELK positions cannot re-trigger.
+        relayout-state (r/atom {:key nil :measured nil})
         ;; rf2-s5kyp — double-rAF deferral. A SINGLE rAF races
         ;; xyflow's internal node measurement on the focused-machine-
         ;; change path: by the time the chart re-renders with the new
@@ -746,30 +819,89 @@
             ;; direction, layout-options) tuple changes. Keep the
             ;; previous positions during in-flight layout to avoid an
             ;; empty-chart flash.
-            this-key   [definition direction layout-options]]
+            this-key   [definition direction layout-options]
+            ;; rf2-d9ro2 — one ELK pass. `measured-dims` is nil on the
+            ;; FIRST pass (nodes not yet rendered/measured) and the
+            ;; xyflow-measured `{node-id {:width :height}}` map on the
+            ;; measure-then-relayout SECOND pass. The settle reuses the
+            ;; rf2-set3x auto-fit logic so BOTH passes frame the topology.
+            run-layout!
+            (fn [measured-dims]
+              (compute-layout!
+                parsed direction layout-options machine-id measured-dims
+                (fn [result]
+                  (when result
+                    (reset! layout-state result)
+                    ;; rf2-set3x — after a successful layout settle
+                    ;; (positions present, no error), auto-fit the
+                    ;; viewport ONCE per layout-key change so the operator
+                    ;; sees the real topology framed. Gating on `:fit-key`
+                    ;; differs from `this-key` preserves a manual zoom/pan
+                    ;; across non-layout re-renders, and re-fits on every
+                    ;; layout invalidation (definition / direction /
+                    ;; layout-options change). The relayout pass shares
+                    ;; the same gate — it re-fits the corrected topology
+                    ;; (the measured box, not the floor-sized first pass).
+                    (when-let [^js inst (and (seq (:positions result))
+                                             (nil? (:layout-error result))
+                                             (:instance @fit-state))]
+                      (when (not= this-key (:fit-key @fit-state))
+                        (swap! fit-state assoc :fit-key this-key)
+                        (schedule-fit! inst)))))))
+            ;; rf2-d9ro2 — the ELK-measurable node-id set: leaf states +
+            ;; synthetic event-nodes. ELK sizes these from the rendered
+            ;; box (`->elk-children` consults `measured-dims` for them).
+            ;; CONTAINERS (region / compound) keep the floor seed — their
+            ;; true extent comes from ELK laying out their measured
+            ;; children, so a self-measurement would be circular — and
+            ;; initial-marker glyphs are not ELK children. The relayout
+            ;; signature is `read-measured-dims` RESTRICTED to this set, so
+            ;; container/marker measurement noise never gates or re-fires
+            ;; the relayout.
+            measurable-ids
+            (into (->> (:nodes parsed)
+                       (remove #(or (:region? %) (:compound? %)))
+                       (map :id)
+                       set)
+                  (map projection/event-node-id)
+                  (:edges parsed))
+            ;; rf2-d9ro2 — the measure-then-relayout trigger. xyflow calls
+            ;; this (via `:onNodesChange`) after it measures the rendered
+            ;; node DOM. We read the measured boxes off the captured
+            ;; instance and, when the WHOLE topology has been measured AND
+            ;; the measured map differs from what ELK was last fed for the
+            ;; current layout-key, re-run ELK with the real boxes. The
+            ;; `relayout-state` gate makes this fire at most once per
+            ;; layout-key and never loop (a relayout moves positions, not
+            ;; content → the next measurement matches the stored
+            ;; signature). A new topology (`:key` mismatch) clears the
+            ;; signature so the new machine gets its own single relayout.
+            maybe-relayout!
+            (fn []
+              (when-let [^js inst (:instance @fit-state)]
+                (let [dims    (select-keys (read-measured-dims inst)
+                                           measurable-ids)
+                      {:keys [key measured]} @relayout-state
+                      fresh?  (not= key this-key)
+                      ;; Only relayout once EVERY measurable node has a box
+                      ;; (a partial map would lay out part of the graph at
+                      ;; the floor and re-fire on the next measurement).
+                      ready?  (and (seq measurable-ids)
+                                   (= (count dims) (count measurable-ids)))
+                      ;; On a fresh topology the prior signature belongs to
+                      ;; the OLD key, so any measured map is a change.
+                      changed? (or fresh? (not= dims measured))]
+                  (when (and ready? changed?)
+                    (reset! relayout-state {:key this-key :measured dims})
+                    (run-layout! dims)))))]
         (when (and (seq (:nodes parsed))
                    (not= this-key @layout-key))
           (reset! layout-key this-key)
-          (compute-layout! parsed direction layout-options machine-id
-                           (fn [result]
-                             (when result
-                               (reset! layout-state result)
-                               ;; rf2-set3x — after a successful layout
-                               ;; settle (positions present, no error),
-                               ;; auto-fit the viewport ONCE per layout-
-                               ;; key change so the operator sees the
-                               ;; real topology framed. Gating on
-                               ;; `:fit-key` differs from `this-key`
-                               ;; preserves a manual zoom/pan across
-                               ;; non-layout re-renders, and re-fits on
-                               ;; every layout invalidation (definition
-                               ;; / direction / layout-options change).
-                               (when-let [^js inst (and (seq (:positions result))
-                                                        (nil? (:layout-error result))
-                                                        (:instance @fit-state))]
-                                 (when (not= this-key (:fit-key @fit-state))
-                                   (swap! fit-state assoc :fit-key this-key)
-                                   (schedule-fit! inst)))))))
+          ;; rf2-d9ro2 — a new topology starts a fresh measure cycle: drop
+          ;; the prior measured signature so `maybe-relayout!` treats the
+          ;; first measurement of the new machine as a change.
+          (reset! relayout-state {:key this-key :measured nil})
+          (run-layout! nil))
         (cond
           (nil? definition)
           [:div {:data-testid (str testid "-no-definition")
@@ -974,7 +1106,23 @@
                                         (swap! fit-state assoc :instance instance)
                                         (when should-fit-now?
                                           (swap! fit-state assoc :fit-key key-now)
-                                          (schedule-fit! instance))))}
+                                          (schedule-fit! instance))
+                                        ;; rf2-d9ro2 — xyflow may have
+                                        ;; already measured the nodes by the
+                                        ;; time onInit fires (fast commit).
+                                        ;; Kick the measure-then-relayout
+                                        ;; check too, in case no further
+                                        ;; dimension change fires.
+                                        (maybe-relayout!)))
+               ;; rf2-d9ro2 — measure-then-relayout signal. xyflow emits a
+               ;; `dimensions` NodeChange once it measures the rendered
+               ;; node DOM; that is our cue to read the real boxes back and
+               ;; re-run ELK with them (`maybe-relayout!` gates it to once
+               ;; per layout-key, no loop). We do NOT feed the changes back
+               ;; into `:nodes` (positions are ELK-owned, the chart is
+               ;; non-interactive) — the handler is purely a measurement
+               ;; trigger.
+               :onNodesChange       (fn [^js _changes] (maybe-relayout!))}
               (when show-background?
                 ;; rf2-k647w — dot-grid spacing + radius track the
                 ;; resolved density (`:dot-grid-spacing-px` /

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -107,26 +107,74 @@
   (rf2-qo5xy)."
   46)
 
+(defn leaf-elk-size
+  "rf2-d9ro2 — the elk.js layout size for a LEAF state node, given the
+  optional `measured` `{:width :height}` map xyflow reported for that
+  node on a prior render (`node.measured`).
+
+  The first ELK pass has no measurement yet (`measured` is nil), so the
+  node falls back to the `state-node-min-{width,height}` FLOOR — the same
+  constant the old single-pass used. On the measure-then-relayout second
+  pass (`chart.cljs`) the host hands back the rendered box; we take the
+  MAX of the measured dimension and the floor so a node never lays out
+  SMALLER than its CSS `min-{width,height}`, but a node whose CONTENT
+  (long label + tag pills + entry/exit action pills, rf2-a2b55) exceeds
+  the floor gets the real box ELK must budget for — closing the
+  missized/overlapping-topology bug where ELK assumed every node was
+  exactly the floor.
+
+  Returns a `{:width :height}` map (both positive)."
+  [measured]
+  {:width  (max state-node-min-width  (or (:width  measured) 0))
+   :height (max state-node-min-height (or (:height measured) 0))})
+
 (defn elk-child
   "Build a single elk.js child descriptor for a parsed node (a plain
-  CLJS map; `chart`'s `->elk-input` `clj->js`-es the whole tree)."
-  [n]
-  {:id     (:id n)
-   :width  (if (:compound? n) compound-node-min-width state-node-min-width)
-   :height (if (:compound? n) compound-node-min-height state-node-min-height)
-   :labels [{:text (:label n)}]})
+  CLJS map; `chart`'s `->elk-input` `clj->js`-es the whole tree).
+
+  rf2-d9ro2 — `measured-dims` is the optional `{node-id {:width :height}}`
+  map of xyflow-reported rendered boxes (`node.measured`) from a prior
+  render, threaded through `->elk-children`. A LEAF state takes
+  `(max measured floor)` per dimension (`leaf-elk-size`) so ELK sizes
+  each slot to the node's REAL rendered box rather than the fixed floor.
+  COMPOUND containers keep the compound floor as their SEED size — their
+  true extent comes from ELK laying out their measured children inside
+  (`elk.hierarchyHandling INCLUDE_CHILDREN`), not from a self-measurement
+  (the rendered compound box is `width:100% height:100%` of whatever ELK
+  allocates, so feeding its measured DOM size back would be circular).
+  When `measured-dims` is nil / empty (the first pass) every leaf falls
+  back to the floor — identical to the pre-rf2-d9ro2 single-pass."
+  ([n] (elk-child n nil))
+  ([n measured-dims]
+   (merge
+     {:id     (:id n)
+      :labels [{:text (:label n)}]}
+     (if (:compound? n)
+       {:width  compound-node-min-width
+        :height compound-node-min-height}
+       (leaf-elk-size (get measured-dims (:id n)))))))
 
 (defn elk-event-child
   "rf2-qo5xy — build an elk.js child descriptor for a SYNTHETIC
   event-node. The events-as-nodes paradigm inserts one of these per
   spec transition (between source state and target state); elkjs lays
   it out alongside the source state's siblings inside the source's
-  parent container."
-  [parsed-edge]
-  {:id     (event-node-id parsed-edge)
-   :width  event-node-elk-width
-   :height event-node-elk-height
-   :labels [{:text (or (:event-label parsed-edge) "")}]})
+  parent container.
+
+  rf2-d9ro2 — like a leaf state, an event-node renders at CONTENT size
+  (event header + optional `[guard]` chip + `+ action` pill row), so on
+  the measure-then-relayout second pass we take `(max measured floor)`
+  per dimension against the `event-node-elk-{width,height}` floor.
+  `measured-dims` is the optional `{node-id {:width :height}}` map; nil
+  on the first pass falls back to the floor (pre-rf2-d9ro2 behaviour)."
+  ([parsed-edge] (elk-event-child parsed-edge nil))
+  ([parsed-edge measured-dims]
+   (let [id (event-node-id parsed-edge)
+         m  (get measured-dims id)]
+     {:id     id
+      :width  (max event-node-elk-width  (or (:width  m) 0))
+      :height (max event-node-elk-height (or (:height m) 0))
+      :labels [{:text (or (:event-label parsed-edge) "")}]})))
 
 (defn ->elk-children
   "Project parsed nodes + parsed edges into elk.js's `children` shape.
@@ -147,8 +195,16 @@
   (top-level when the source has no parent). elk then lays them out
   with the layered algorithm — events flow naturally between states
   per the events-as-nodes paradigm. They carry no children of their
-  own."
-  [{:keys [nodes edges]}]
+  own.
+
+  rf2-d9ro2 — the optional `measured-dims` `{node-id {:width :height}}`
+  map (xyflow's `node.measured` from a prior render, threaded by
+  `chart.cljs`'s measure-then-relayout pass) is forwarded to every
+  `elk-child` / `elk-event-child` so leaf states + event-nodes lay out
+  at their REAL rendered box rather than the fixed floor. nil / empty on
+  the first pass — identical to the pre-rf2-d9ro2 single-pass."
+  ([parsed] (->elk-children parsed nil))
+  ([{:keys [nodes edges]} measured-dims]
   (let [node-by-id (into {} (map (juxt :id identity)) nodes)
         ;; The event-node's parent container == the source state's
         ;; parent. Top-level when the source has no `:parent-id`.
@@ -156,7 +212,7 @@
         (mapv (fn [e]
                 (let [src (get node-by-id (:source e))
                       pid (:parent-id src)]
-                  (cond-> (elk-event-child e)
+                  (cond-> (elk-event-child e measured-dims)
                     pid (assoc ::event-parent pid))))
               edges)
         by-parent (group-by :parent-id nodes)
@@ -165,7 +221,7 @@
                 (let [state-kids (get by-parent (:id n) [])
                       event-kids (get events-by-parent (:id n) [])
                       kids       (concat state-kids event-kids)]
-                  (cond-> (elk-child n)
+                  (cond-> (elk-child n measured-dims)
                     (seq kids)
                     (assoc :children (->> kids
                                           (mapv (fn [k]
@@ -179,7 +235,7 @@
         top-state-children (mapv build (get by-parent nil))
         top-event-children (->> (get events-by-parent nil [])
                                 (mapv #(dissoc % ::event-parent)))]
-    (vec (concat top-state-children top-event-children))))
+    (vec (concat top-state-children top-event-children)))))
 
 ;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
@@ -364,3 +364,125 @@
               (set! chart/invoke-fit-view! orig-fit))))
         (finally
           (set! (.-requestAnimationFrame js/globalThis) orig-raf))))))
+
+;; ---- 7. measure-then-relayout (rf2-d9ro2) -----------------------------
+;;
+;; The bug: ELK was fed CONSTANT floor dims, so a node whose content
+;; exceeded the floor overlapped its neighbours. The fix is the canonical
+;; React Flow + ELK two-pass: mount at content size → xyflow measures
+;; (`node.measured`) → re-run ELK with the measured box. These pins guard
+;; the read seam + the loop-free gate at the Node layer (the live xyflow
+;; render is browser-pinned / eval-cljs in the PR body), mirroring why the
+;; auto-fit lifecycle above is a -cljs-test and not a DOM test.
+
+(defn- fake-instance-with-measured
+  "A stand-in ReactFlowInstance whose `.getNodes()` returns nodes
+  carrying `.measured {width height}` — the shape `read-measured-dims`
+  reads. `node-specs` is a vector of `[id width height]` (width/height
+  nil → that node is still awaiting measurement)."
+  [node-specs]
+  #js {:getNodes
+       (fn []
+         (clj->js
+           (mapv (fn [[id w h]]
+                   (cond-> {:id id}
+                     (and w h) (assoc :measured {:width w :height h})))
+                 node-specs)))})
+
+(deftest read-measured-dims-keeps-only-fully-measured-nodes
+  (testing "rf2-d9ro2 — `read-measured-dims` lifts xyflow's `node.measured`
+            into `{id {:width :height}}`, KEEPING only nodes with a
+            positive measured w AND h. A node still awaiting measurement
+            (measured nil / 0) is omitted so the caller can tell when the
+            whole topology has been measured."
+    (let [inst (fake-instance-with-measured
+                 [["idle" 200 60]
+                  ["loading" 260 72]
+                  ["pending" nil nil]      ;; not yet measured
+                  ["zero" 0 0]])           ;; degenerate — omitted
+          dims (chart/read-measured-dims inst)]
+      (is (= {"idle"    {:width 200 :height 60}
+              "loading" {:width 260 :height 72}}
+             dims)
+          "only fully + positively measured nodes survive"))))
+
+(deftest measure-then-relayout-fires-once-and-does-not-loop
+  (testing "rf2-d9ro2 — the relayout gate fires the second ELK pass once
+            (when the whole topology is measured + the boxes differ from
+            what ELK was last fed) and NEVER loops: a relayout moves
+            positions only, so the next measurement reports the SAME
+            boxes, the signature matches, and no further pass fires.
+
+            This mirrors the `maybe-relayout!` gate verbatim (the chart
+            wires the real one onto xyflow's `:onNodesChange` / `:onInit`)
+            so the loop-freedom contract is pinned in isolation from the
+            xyflow render."
+    (let [;; Two measurable leaf nodes; both exceed the floor.
+          measurable-ids #{"idle" "loading"}
+          this-key       :K1
+          relayout-state (atom {:key nil :measured nil})
+          relayouts      (atom [])
+          run-layout!    (fn [dims] (swap! relayouts conj dims))
+          ;; The gate, lifted verbatim from chart.cljs/maybe-relayout!.
+          maybe-relayout!
+          (fn [measured-map]
+            (let [dims (select-keys measured-map measurable-ids)
+                  {:keys [key measured]} @relayout-state
+                  fresh?   (not= key this-key)
+                  ready?   (and (seq measurable-ids)
+                                (= (count dims) (count measurable-ids)))
+                  changed? (or fresh? (not= dims measured))]
+              (when (and ready? changed?)
+                (reset! relayout-state {:key this-key :measured dims})
+                (run-layout! dims))))]
+      ;; New topology → seed the gate (as the layout-key trigger does).
+      (reset! relayout-state {:key this-key :measured nil})
+      ;; First measurement arrives PARTIAL — only one node measured. The
+      ;; gate must NOT fire (a partial relayout would lay the rest at the
+      ;; floor and re-fire endlessly).
+      (maybe-relayout! {"idle" {:width 200 :height 60}})
+      (is (zero? (count @relayouts)) "partial measurement does NOT relayout")
+      ;; Full measurement arrives → exactly one relayout with the real box.
+      (maybe-relayout! {"idle"    {:width 200 :height 60}
+                        "loading" {:width 260 :height 72}})
+      (is (= 1 (count @relayouts)) "full measurement triggers one relayout")
+      (is (= {"idle"    {:width 200 :height 60}
+              "loading" {:width 260 :height 72}}
+             (first @relayouts))
+          "ELK is re-fed the real measured boxes")
+      ;; The relayout moved POSITIONS only — content (hence measured box)
+      ;; is unchanged → the SAME measurement re-arrives. No second pass.
+      (maybe-relayout! {"idle"    {:width 200 :height 60}
+                        "loading" {:width 260 :height 72}})
+      (maybe-relayout! {"idle"    {:width 200 :height 60}
+                        "loading" {:width 260 :height 72}})
+      (is (= 1 (count @relayouts))
+          "stable measurement does NOT re-fire — the loop is closed"))))
+
+(deftest measure-then-relayout-new-topology-resets-signature
+  (testing "rf2-d9ro2 — a NEW layout-key (focused-machine swap / new
+            definition) clears the stored measured signature so the new
+            machine gets its own single relayout, even if its measured
+            boxes coincidentally equal the prior machine's."
+    (let [measurable-ids #{"a"}
+          relayout-state (atom {:key nil :measured nil})
+          relayouts      (atom [])
+          gate (fn [this-key measured-map]
+                 (let [dims (select-keys measured-map measurable-ids)
+                       {:keys [key measured]} @relayout-state
+                       fresh?   (not= key this-key)
+                       ready?   (= (count dims) (count measurable-ids))
+                       changed? (or fresh? (not= dims measured))]
+                   (when (and ready? changed?)
+                     (reset! relayout-state {:key this-key :measured dims})
+                     (swap! relayouts conj this-key))))]
+      ;; Machine K1 measured + relaid out once.
+      (reset! relayout-state {:key :K1 :measured nil})
+      (gate :K1 {"a" {:width 100 :height 40}})
+      (is (= [:K1] @relayouts))
+      ;; Swap to K2 — same measured box, but a fresh key resets the
+      ;; signature so K2 still gets its single relayout.
+      (reset! relayout-state {:key :K2 :measured nil})
+      (gate :K2 {"a" {:width 100 :height 40}})
+      (is (= [:K1 :K2] @relayouts)
+          "a new layout-key gets its own relayout despite identical boxes"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -951,6 +951,127 @@
       (is (every? #(re-find #"top=" (get-in % [:layoutOptions "elk.padding"]))
                   children)))))
 
+;; ---- measure-then-relayout: ELK sizes to the real box (rf2-d9ro2) -------
+;;
+;; The bug: ELK was fed CONSTANT floor dimensions, never the real
+;; rendered box, so any node whose content (long label + tag/action
+;; pills) exceeded the floor overlapped its neighbours. The fix threads
+;; xyflow's measured `{node-id {:width :height}}` into the projection;
+;; a leaf / event-node lays out at `(max measured floor)`. These pins
+;; live at the cheap JVM layer (the live re-layout lifecycle is wired in
+;; chart.cljs + browser-pinned); they fix the producer side of the bug.
+
+(deftest leaf-elk-size-floors-to-min-when-unmeasured
+  (testing "rf2-d9ro2 — with no measurement (first pass) a leaf falls
+            back to the `state-node-min-{width,height}` floor — the
+            pre-fix single-pass behaviour"
+    (is (= {:width  projection/state-node-min-width
+            :height projection/state-node-min-height}
+           (projection/leaf-elk-size nil)))
+    (is (= {:width  projection/state-node-min-width
+            :height projection/state-node-min-height}
+           (projection/leaf-elk-size {})))))
+
+(deftest leaf-elk-size-uses-measured-when-larger
+  (testing "rf2-d9ro2 — a measured box LARGER than the floor wins per
+            dimension (ELK must budget the real rendered size)"
+    (let [big (projection/leaf-elk-size {:width 300 :height 90})]
+      (is (= 300 (:width big)))
+      (is (= 90  (:height big))))))
+
+(deftest leaf-elk-size-floors-each-dimension-independently
+  (testing "rf2-d9ro2 — the floor applies PER dimension: a node wider
+            than the floor but shorter than it keeps the wide measured
+            width AND the floor height"
+    (let [m (projection/leaf-elk-size {:width 320 :height 10})]
+      (is (= 320 (:width m)) "wide measured width wins")
+      (is (= projection/state-node-min-height (:height m))
+          "sub-floor measured height clamps up to the floor"))))
+
+(deftest elk-child-leaf-uses-measured-dims
+  (testing "rf2-d9ro2 — `elk-child` sizes a LEAF to its measured box
+            (floored), looked up by node-id from the measured-dims map"
+    (let [parsed   (layout/parse-definition idle-loading)
+          idle-id  (layout/node-id [:idle])
+          measured {idle-id {:width 260 :height 72}}
+          idle     (first (filter #(= idle-id (:id %)) (:nodes parsed)))
+          child    (projection/elk-child idle measured)]
+      (is (= 260 (:width child)))
+      (is (= 72  (:height child)))))
+  (testing "rf2-d9ro2 — an unmeasured leaf (absent from the map) keeps
+            the floor"
+    (let [parsed   (layout/parse-definition idle-loading)
+          idle     (first (filter #(= (layout/node-id [:idle]) (:id %))
+                                  (:nodes parsed)))
+          child    (projection/elk-child idle {})]
+      (is (= projection/state-node-min-width  (:width child)))
+      (is (= projection/state-node-min-height (:height child))))))
+
+(deftest elk-child-compound-ignores-measured-dims
+  (testing "rf2-d9ro2 — a COMPOUND keeps its floor seed even with a
+            measured entry: its true extent comes from ELK laying out its
+            measured children, so feeding back its `100%`-of-the-box
+            self-measurement would be circular"
+    (let [parsed    (layout/parse-definition compound-machine)
+          cid       (layout/node-id [:authenticated])
+          measured  {cid {:width 999 :height 999}}
+          compound  (first (filter #(= cid (:id %)) (:nodes parsed)))
+          child     (projection/elk-child compound measured)]
+      (is (= projection/compound-node-min-width  (:width child)))
+      (is (= projection/compound-node-min-height (:height child))))))
+
+(deftest elk-event-child-uses-measured-dims
+  (testing "rf2-d9ro2 — an event-node also renders at content size
+            (event header + guard chip + action pill), so it takes
+            `(max measured floor)` like a leaf"
+    (let [edge     {:id "e1" :event :start}
+          ev-id    (projection/event-node-id edge)
+          measured {ev-id {:width 200 :height 80}}
+          child    (projection/elk-event-child edge measured)]
+      (is (= 200 (:width child)))
+      (is (= 80  (:height child))))
+    (testing "unmeasured event-node keeps the event-node floor"
+      (let [child (projection/elk-event-child {:id "e1" :event :start} nil)]
+        (is (= projection/event-node-elk-width  (:width child)))
+        (is (= projection/event-node-elk-height (:height child)))))))
+
+(deftest elk-children-threads-measured-dims-to-leaves-and-events
+  (testing "rf2-d9ro2 — `->elk-children` forwards the measured-dims map
+            so every leaf + event-node in the projected tree lays out at
+            its real box; an unmeasured node falls back to the floor"
+    (let [parsed     (layout/parse-definition idle-loading)
+          idle-id    (layout/node-id [:idle])
+          start-edge (->> (:edges parsed)
+                          (filter #(= idle-id (:source %)))
+                          first)
+          ev-id      (projection/event-node-id start-edge)
+          measured   {idle-id {:width 260 :height 72}
+                      ev-id   {:width 180 :height 60}}
+          children   (projection/->elk-children parsed measured)
+          by-id      (into {} (map (juxt :id identity)) children)]
+      (is (= 260 (:width (get by-id idle-id))) "measured leaf width threaded")
+      (is (= 72  (:height (get by-id idle-id))))
+      (is (= 180 (:width (get by-id ev-id))) "measured event width threaded")
+      (is (= 60  (:height (get by-id ev-id))))
+      ;; A sibling NOT in the measured map stays at the floor.
+      (let [ready-id (layout/node-id [:ready])]
+        (is (= projection/state-node-min-width
+               (:width (get by-id ready-id)))
+            "unmeasured sibling keeps the floor")))))
+
+(deftest elk-children-no-measured-dims-equals-floor-single-pass
+  (testing "rf2-d9ro2 — with no measured-dims (the first pass / nil) the
+            output is identical to the historical single-pass: every leaf
+            at the floor. Guards that the two-pass is purely additive."
+    (let [parsed (layout/parse-definition idle-loading)]
+      (is (= (projection/->elk-children parsed)
+             (projection/->elk-children parsed nil))
+          "the 1-arity and nil-2-arity are identical")
+      (let [children (projection/->elk-children parsed nil)
+            leaves   (remove #(re-find #"^event__" (:id %)) children)]
+        (is (every? #(= projection/state-node-min-width (:width %)) leaves)
+            "every leaf at the width floor when unmeasured")))))
+
 ;; ---- initial-state markers + self-loops (rf2-54s5a) --------------------
 
 (deftest xyflow-graph-emits-initial-marker-node-and-entry-edge


### PR DESCRIPTION
## Problem (rf2-d9ro2, P1)

`MachineChart` rendered missized / overlapping nodes. Root cause: ELK was fed **constant** floor dimensions (`state-node-min-{width,height}`) for every node, but `chart.nodes/state-node` renders at **content** size — the state label (variable length) + tag pills + entry/exit action pills (rf2-a2b55). Any node wider/taller than the floor got an ELK slot too small, so its rendered box overlapped neighbours. The single ELK pass (`compute-layout!`) never re-measured.

## Fix — the canonical React Flow + ELK two-pass

(Same shape as the official React Flow ELK example + xstate-viz / Stately.)

1. **First pass:** ELK runs with no measured dims; every leaf + event-node seeds at its floor. Nodes mount at content size.
2. **Measure:** xyflow populates `node.measured {width height}`. The chart reads it back off the captured `ReactFlowInstance` (`read-measured-dims` seam, via `getNodes`), driven by `:onNodesChange` (a `dimensions` `NodeChange`) and the `:onInit` fast-commit branch.
3. **Relayout:** the measured `{node-id {:width :height}}` map threads `compute-layout!` → `->elk-input` → `->elk-children`; each leaf + event-node lays out at `(max measured floor)` per dimension (`leaf-elk-size`). Compound / region containers keep the floor seed — their extent comes from ELK laying out their measured children, so self-measuring their `100%`-of-box DOM would be circular.
4. **Fit:** the relayout settle re-fits via the existing rf2-set3x auto-fit gate, framing the corrected topology.

### No infinite loop
`relayout-state` stores the measured-dims map ELK was last fed for the current layout-key. It re-runs ELK only when (a) **every** ELK-measurable node (leaf states + event-nodes — not containers, not initial-markers) has a positive measured box, and (b) the fresh map differs from the stored signature. Loop-freedom is structural: a relayout moves node **positions** only — not content — so the next measurement reports the **same** boxes, the signature matches, no further pass fires. Position-only `onNodesChange` events never reach the compare (it keys on measured dims, not position). A new layout-key clears the signature.

No new layout-invalidation trigger — the second pass is keyed on the same `[:definition :direction :layout-options]` tuple; the load-bearing layout-invalidation boundary is unchanged.

## Changed files
- `tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc` — `leaf-elk-size`, measured-dims arity on `elk-child` / `elk-event-child` / `->elk-children`.
- `tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs` — `read-measured-dims` seam, `measured-dims` arg on `compute-layout!` / `->elk-input`, the `run-layout!` / `maybe-relayout!` lifecycle + `relayout-state` gate, `:onNodesChange` / `:onInit` wiring.
- `tools/machines-viz/spec/API.md` — new "Measure-then-relayout" section (per the Xray-specs-kept-current rule).
- `tools/machines-viz/test/.../chart/projection_cljs_test.cljc` — JVM pins for `leaf-elk-size` (floor vs measured, per-dimension), `elk-child` leaf-uses-measured / compound-ignores-measured, `->elk-children` threading, and nil ≡ single-pass.
- `tools/machines-viz/test/.../chart/auto_fit_view_cljs_test.cljs` — pins `read-measured-dims` (keeps only fully-measured nodes) + the relayout gate (fire-once, no-loop on stable measurement, new-topology-resets-signature).

## Quality gates (cold)
- `clojure -M:test` (machines-viz JVM): **307 tests / 810 assertions, 0 failures**.
- `npm run test:cljs` (node): **5454 tests / 18836 assertions, 0 failures**.
- `npm run test:browser`: **141 tests / 411 assertions, 0 failures** (chart DOM mounts the new `:onNodesChange` wiring).
- `shadow-cljs compile` AND `release machines-viz-viewer`: **0 warnings** (the lone browser-test infer-warning is pre-existing in `core/test/.../react_shared_suite.cljs`, untouched).
- `npm run test:bundle-isolation`: **PASS** (tool change does not leak into production bundles).

### Topology overlap sanity (headless ELK)
Two siblings on one layer; A renders wide (320×72), floor 140×44:
- **OLD single-pass:** ELK budgeted A at 140, left a 40px gap, A renders at 320 → rendered-A intrudes **140px** into B → **OVERLAP**.
- **NEW two-pass:** ELK budgets A at measured 320, keeps the full 40px gap → **NO overlap**.

Closes rf2-d9ro2.