### PR TITLE
fix(pair-mcp): actionable liveness on a quiet runtime + pin sticky-build end-to-end (rf2-jkwu4)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -140,6 +140,8 @@ discover-app
 
 This locates the shadow-cljs nREPL port, connects, switches the session to `:cljs` mode for the running build, verifies re-frame2 is loaded with `interop/debug-enabled?` true, and confirms the `re-frame2-pair.runtime` namespace was loaded by the consumer's `:devtools :preloads` (see §Setup above).
 
+**Connect once — the resolved build sticks (rf2-jkwu4).** A successful `discover-app` records the build it resolved as the **session-sticky default** on the connection, for *every* resolution path — auto-selected single build, explicit `:build`, *and* `:port`. So after one `discover-app` you call every other tool (`orient`, `read-dom`, `read-ui`, `snapshot`, `get-path`, …) with **no `build` arg** and it targets the resolved build — even with several builds running. You only pass `build` again to *switch* builds (an explicit `:build` on any later call wins and re-sticks as the new default). The sticky default resets on an nREPL reconnect (a shadow restart), where the next `discover-app` re-establishes it.
+
 **Arg forms (don't guess; rf2-cg37y).** Each arg has one expected shape:
 
 | Arg | Form | Examples |
@@ -150,9 +152,18 @@ This locates the shadow-cljs nREPL port, connects, switches the session to `:clj
 
 **Single-build auto-selection (rf2-v70kv).** You usually don't need to pass `build` at all. When exactly one shadow-cljs build is running, a no-arg `discover-app` selects it and reports `:auto-selected-build` plus an explanatory `:note`. When several run, it errors with the running-builds list so you can pick — it never silently guesses.
 
-**Connecting from a URL (rf2-fyf0h).** When you only know the browser URL of the open tab (e.g. `http://localhost:8031/counter`) and several builds are running, pass the port instead of hunting for the build id: `discover-app {port: 8031}`. discover-app reads the shadow-cljs `:dev-http` map and resolves the build whose `:output-dir` is served on that port (8031 → `:examples/step-deck` in this repo) — no manual grep of `shadow-cljs.edn`. A `:port` that matches no build returns `{:ok? false :reason :port-unresolved}` rather than silently falling back. An explicit `:build` arg wins over `:port` if you pass both.
+**Connecting from a URL (rf2-fyf0h).** When you only know the browser URL of the open tab (e.g. `http://localhost:8031/counter`) and several builds are running, pass the port instead of hunting for the build id: `discover-app {port: 8031}`. discover-app reads the shadow-cljs `:dev-http` map and resolves the build whose `:output-dir` is served on that port (8031 → `:examples/step-deck` in this repo) — no manual grep of `shadow-cljs.edn`. A `:port` that matches no build returns `{:ok? false :reason :port-unresolved}` rather than silently falling back. An explicit `:build` arg wins over `:port` if you pass both. The port-resolved build **sticks** as the session default just like the other paths — every following no-`build` tool call lands on it (rf2-jkwu4).
 
 **Output representation.** discover-app reports every build/frame id (`:build-id`, `:frames`, `:running-builds`) as a **full keyword** (`:rf/default`, `:examples/step-deck`) in the canonical EDN result, and its `:note` / `:hint` prose uses the same colon form — one representation throughout. (Hosts that surface the `:structuredContent` JSON view will show the colon stripped — `"rf/default"` — that's the documented lossy JSON projection; read the EDN text for the id exactly as you'd type it back into a `:frame` arg.)
+
+**Read the `:freshness` token before you trust a read (rf2-ertqw, rf2-jkwu4).** Every `:ok? true` discover-app payload carries `:freshness {:liveness <verdict> :hint <str> ...}`. Pattern-match `:liveness` first:
+
+- `:fresh` — runtime connected, heartbeat recent, build not recompiled since load. Read away.
+- `:stale-build` — the tab is serving OLD code (a recompile landed the runtime never picked up). The `:hint` tells the user the exact URL to reload.
+- `:no-runtime` — no live CLJS runtime is connected (WS dropped, no tab open) — reads will come back blank. The `:hint` names the exact `http://localhost:<port>` to reload, then "re-run discover-app".
+- `:unknown` — the JVM-side build-worker state couldn't be read even after a retry. **This is not a green light.** The `:hint` is actionable: reload the named URL if reads come back blank, and if it stays `:unknown`, restart `shadow-cljs watch <build>` — the build worker isn't answering.
+
+You **cannot reload a browser yourself** — so when the verdict is non-`:fresh`, relay the `:freshness :hint` to the user as the single next step rather than firing reads that will return blank.
 
 If any precondition fails, the script returns a structured edn error like `{:ok? false :reason :runtime-not-preloaded}`. Report the failing check to the user verbatim; do *not* guess at workarounds. See [references/errors.md](references/errors.md) for the common error reasons and the recovery each one calls for.
 

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -371,6 +371,24 @@ read-family ops (`orient`, `read-dom`, `read-ui`, `eval-cljs`) echo the
 resolved `:build` on their result so the operating target stays visible
 even when implicitly selected (rf2-fmho5).
 
+**Freshness / liveness token (rf2-ertqw, rf2-jkwu4).** Every `:ok? true`
+discover-app payload carries `:freshness {:liveness <verdict> :hint <str>
+…}` — the browser-half (runtime-instance-id + load time) merged with the
+JVM-half build-worker state (monotonic compile-cycle + last-flush + WS
+heartbeat age), cross-checked to one `:liveness` verdict:
+`:fresh` / `:stale-build` / `:no-runtime` / `:unknown`. The JVM-half read
+is **retried once** before a `:unknown` degrade — a nil first read is
+most often a transient socket hiccup, not a genuinely-unreadable old
+shadow (rf2-jkwu4). For every **non-`:fresh`** verdict the `:hint` is
+**actionable**: it names the EXACT `http://localhost:<port>` the human
+reloads (when discover-app was called with a `:port`, which also rides on
+the token), and for `:unknown` escalates to restarting
+`shadow-cljs watch <build>` when the worker stays unreadable. The agent
+cannot reload a browser itself, so a non-`:fresh` verdict is an early,
+crisp human-in-the-loop instruction — relay the `:hint` rather than
+firing reads that will return blank. A `:stale-build` verdict is also
+promoted to a top-level `:warning :stale-build`.
+
 **Id representation (rf2-cg37y).** Every build/frame id discover-app
 surfaces — `:build-id`, `:frames`, and the diagnostic `:running-builds`
 — is a **full keyword** (`:rf/default`, `:examples/step-deck`) in the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
@@ -120,9 +120,15 @@
   payload-shaping fn `shape` takes the freshness-annotated health map
   and returns the final MCP envelope. On a stale-BUILD verdict the
   `:warning` is promoted to `:stale-build` (unless a louder warning is
-  already set) so the alarm rides at the top level too."
-  [conn build-id health shape]
-  (-> (freshness/token-from-health conn build-id health)
+  already set) so the alarm rides at the top level too.
+
+  `opts` carries the optional `:port` (the browser URL port discover-app
+  resolved the build from, rf2-jkwu4) so a non-fresh hint names the EXACT
+  `http://localhost:<port>` the human reloads to wake / refresh a quiet
+  runtime — the agent can't reload a browser, so this is the early,
+  actionable, human-in-the-loop signal."
+  [conn build-id health opts shape]
+  (-> (freshness/token-from-health conn build-id health opts)
       (.then
         (fn [token]
           (let [stale?     (freshness/stale-build? token)
@@ -136,7 +142,23 @@
                              (assoc :warning :stale-build))]
             (shape annotated))))))
 
+(defn- port-opts
+  "Build the freshness `opts` map carrying the browser URL `:port` the
+  caller passed (rf2-jkwu4), or nil when no `:port` arg is present. The
+  port lets a non-fresh liveness hint name the EXACT
+  `http://localhost:<port>` the human reloads to wake a quiet runtime.
+  The port may arrive as a string off the MCP wire; coerce to an int so
+  the hint reads `http://localhost:8033`, not `http://localhost:\"8033\"`."
+  [args]
+  (when-let [raw (wire/arg args :port)]
+    (let [p (cond
+              (number? raw) (long raw)
+              (string? raw) (let [n (js/parseInt raw 10)] (when-not (js/isNaN n) n))
+              :else         nil)]
+      (when (some? p) {:port p}))))
+
 (defn discover-app [conn args]
+  (let [opts (port-opts args)]
   (-> (resolve-build-id conn args)
    (.then
     (fn [{:keys [build-id auto-selected? error]}]
@@ -185,6 +207,7 @@
                                            "or run `frames/select` first. "
                                            "(`:rf/*` tool frames are excluded "
                                            "from this list.)"))
+                  opts
                   (fn [h] (wire/ok-text (with-auto-selection h auto-selected? build-id)))))
 
               (not (:coord-annotation-enabled? health))
@@ -198,6 +221,7 @@
                                            "DOM->source ops will degrade. Enable "
                                            "(rf/configure! :source-coords {:annotate-dom? true}) "
                                            "or use re-com with :src (at)."))
+                  opts
                   (fn [h] (wire/ok-text (with-auto-selection h auto-selected? build-id)))))
 
               :else
@@ -218,5 +242,6 @@
                   (with-frame-resolution (assoc health :ok? true
                                                        :build-id build-id
                                                        :build    build-id))
+                  opts
                   (fn [h] (wire/ok-text (with-auto-selection h auto-selected? build-id))))))))
-        (.catch (fn [err] (probe/err->result :discover-failed err)))))))))
+        (.catch (fn [err] (probe/err->result :discover-failed err))))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/freshness.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/freshness.cljs
@@ -137,6 +137,34 @@
        (let [{:keys [socket closed?]} @conn]
          (and (some? socket) (not closed?)))))
 
+(defn- jvm-build-freshness-once
+  "One JVM round-trip reading the build-worker freshness half for
+  `build-id`. Resolves to the parsed map or nil (unreadable / blank /
+  non-map / socket hiccup). The single-attempt primitive
+  `jvm-build-freshness` retries over (rf2-jkwu4)."
+  [conn build-id]
+  (-> (try
+        (nrepl/jvm-eval conn (build-state-jvm-form build-id))
+        (catch :default _ (js/Promise.resolve nil)))
+      (.then (fn [resp]
+               (let [v (some-> (:value resp) cljs.reader/read-string)]
+                 (when (map? v) v))))
+      (.catch (fn [_] nil))))
+
+(defn retry-once-on-nil
+  "Run the Promise-returning thunk `read!`; if it resolves to a non-map
+  (nil / blank), run it ONCE more and return that (rf2-jkwu4). A nil read
+  of the build-worker state is most often a TRANSIENT socket hiccup, so
+  one retry recovers the common case before the caller degrades to the
+  non-actionable `:liveness :unknown`. The retry round-trip is paid only
+  on the cold/degraded path — a map-valued first read returns straight
+  away with no second call. Pure combinator (no nREPL coupling) so it's
+  unit-testable without a global var stub."
+  [read!]
+  (-> (read!)
+      (.then (fn [v] (if (map? v) v (read!))))
+      (.catch (fn [_] nil))))
+
 (defn jvm-build-freshness
   "Read the JVM-side freshness half for `build-id`. Returns a Promise
   resolving to the parsed map (see `build-state-jvm-form`) or nil on any
@@ -145,17 +173,25 @@
 
   Short-circuits to nil when the conn has no live socket (no JVM to
   read), so a never-connected / stub conn never triggers a real TCP
-  connect."
+  connect.
+
+  ## One retry before degrading (rf2-jkwu4)
+
+  A `:liveness :unknown` verdict is degraded and non-actionable — the
+  agent can't tell the runtime is live and only finds out when a later
+  read returns blank. A nil first read is most often a TRANSIENT socket
+  hiccup (the bencode round-trip raced a `data` chunk, the worker was
+  mid-flush), not a genuinely-unreadable old shadow. So when the first
+  read comes back nil we retry ONCE before degrading — a single extra
+  ~5-50ms round-trip on the cold/degraded path only, never on the
+  healthy path (the first read already succeeds there). A persistent nil
+  after the retry IS the real `:unknown` (old shadow with no
+  `get-worker`, or a dead worker), and now the caller's hint can name the
+  concrete next step honestly."
   [conn build-id]
   (if-not (conn-has-socket? conn)
     (js/Promise.resolve nil)
-    (-> (try
-          (nrepl/jvm-eval conn (build-state-jvm-form build-id))
-          (catch :default _ (js/Promise.resolve nil)))
-        (.then (fn [resp]
-                 (let [v (some-> (:value resp) cljs.reader/read-string)]
-                   (when (map? v) v))))
-        (.catch (fn [_] nil)))))
+    (retry-once-on-nil #(jvm-build-freshness-once conn build-id))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cross-check verdict.
@@ -204,31 +240,56 @@
     :else
     :fresh))
 
+(defn- reload-target
+  "The concrete thing the human reloads to wake/refresh the runtime
+  (rf2-jkwu4). Prefer the app URL when the port is known (the agent then
+  relays ONE crisp instruction — `reload http://localhost:<port>`);
+  otherwise name the build so `shadow-cljs watch <build>` is unambiguous."
+  [{:keys [port build-id]}]
+  (cond
+    (number? port) (str "http://localhost:" port)
+    (some? port)   (str "http://localhost:" port)
+    (some? build-id) (str "the app served by build " (pr-str build-id))
+    :else          "the app tab"))
+
 (defn- verdict-hint
-  "Operator-facing one-liner for a non-fresh verdict. nil for `:fresh`."
-  [liveness {:keys [build-flushed-at runtime-loaded-at]}]
-  (case liveness
-    :stale-build
-    (str "STALE BUILD: this build recompiled "
-         (when (and (number? build-flushed-at) (number? runtime-loaded-at))
-           (str (- build-flushed-at runtime-loaded-at) "ms "))
-         "AFTER the running browser code loaded — the tab is serving OLD "
-         "code. Reload the page so the runtime picks up the latest build "
-         "before trusting any read or hot-swap.")
+  "Operator-facing one-liner for a non-fresh verdict. nil for `:fresh`.
 
-    :no-runtime
-    (str "NO RUNTIME: no live CLJS runtime is connected to this build "
-         "(the WebSocket dropped, or no browser tab is open). Open / "
-         "reload the app so the runtime reconnects; reads will return "
-         "blank until it does.")
+  `ctx` carries the optional `:port` (the browser URL port discover-app
+  resolved the build from) + `:build-id` so the `:no-runtime` / `:unknown`
+  hints can name the EXACT thing the human reloads — the agent cannot
+  reload a browser itself, so a non-fresh verdict is an early, crisp
+  human-in-the-loop instruction, not a self-heal (rf2-jkwu4)."
+  [liveness {:keys [build-flushed-at runtime-loaded-at build-id] :as ctx}]
+  (let [target (reload-target ctx)]
+    (case liveness
+      :stale-build
+      (str "STALE BUILD: this build recompiled "
+           (when (and (number? build-flushed-at) (number? runtime-loaded-at))
+             (str (- build-flushed-at runtime-loaded-at) "ms "))
+           "AFTER the running browser code loaded — the tab is serving OLD "
+           "code. ACTION: reload " target " so the runtime picks up the "
+           "latest build before trusting any read or hot-swap.")
 
-    :unknown
-    (str "LIVENESS UNKNOWN: could not read the shadow-cljs build worker "
-         "state (old shadow, or a transient socket hiccup). The browser-"
-         "side instance id + load time are still reported; stale-build "
-         "detection is unavailable this call.")
+      :no-runtime
+      (str "NO RUNTIME: no live CLJS runtime is connected to this build "
+           "(the WebSocket dropped, or no browser tab is open) — reads "
+           "will return blank until one reconnects. ACTION (the agent "
+           "cannot do this): open or reload " target ", then re-run "
+           "discover-app to confirm :liveness :fresh.")
 
-    nil))
+      :unknown
+      (str "LIVENESS UNKNOWN: could not read the shadow-cljs build worker "
+           "state after a retry (old shadow without get-worker, or the "
+           "watch worker is down). The browser-side instance id + load "
+           "time are still reported, but stale-build detection is "
+           "unavailable this call. ACTION (the agent cannot do this): if "
+           "reads come back blank, reload " target " then re-run "
+           "discover-app; if it stays unknown, restart `shadow-cljs watch "
+           (if (some? build-id) (pr-str build-id) "<build>") "` — the "
+           "JVM-side build worker is not answering.")
+
+      nil)))
 
 (defn assemble
   "Merge the browser half (`browser`, the `(re-frame2-pair.runtime/
@@ -246,18 +307,26 @@
      :liveness            <:fresh|:stale-build|:no-runtime|:unknown>
      :hint                <str>}      ; only when non-fresh
 
+  The optional 4-arity `opts` carries `:port` (the browser URL port the
+  caller knows — discover-app's `:port` arg) so a non-fresh hint names
+  the EXACT `http://localhost:<port>` the human reloads (rf2-jkwu4).
+  `:port` rides on the token too, so the agent can relay it.
+
   Best-effort: a nil JVM half degrades to `:liveness :unknown` with the
   browser half intact. Never rejects."
-  [conn build-id browser]
+  ([conn build-id browser] (assemble conn build-id browser nil))
+  ([conn build-id browser opts]
   (-> (jvm-build-freshness conn build-id)
       (.then
         (fn [jvm]
           (let [browser (or browser {})
+                port    (:port opts)
                 jvm?    (map? jvm)
                 merged  (merge {:runtime-instance-id (:runtime-instance-id browser)
                                 :runtime-loaded-at   (:runtime-loaded-at browser)
                                 :read-at             (:read-at browser)
                                 :build-id            build-id}
+                               (when (some? port) {:port port})
                                (when jvm?
                                  (select-keys jvm [:compile-cycle :build-flushed-at
                                                    :runtime-count :heartbeat-age-ms])))
@@ -268,24 +337,35 @@
       (.catch (fn [_]
                 ;; Defensive: even an unexpected throw degrades to the
                 ;; browser half + :unknown rather than failing the tool.
-                (let [browser (or browser {})]
-                  {:runtime-instance-id (:runtime-instance-id browser)
-                   :runtime-loaded-at   (:runtime-loaded-at browser)
-                   :read-at             (:read-at browser)
-                   :build-id            build-id
-                   :liveness            :unknown
-                   :hint                (verdict-hint :unknown browser)})))))
+                (let [browser (or browser {})
+                      port    (:port opts)]
+                  (cond-> {:runtime-instance-id (:runtime-instance-id browser)
+                           :runtime-loaded-at   (:runtime-loaded-at browser)
+                           :read-at             (:read-at browser)
+                           :build-id            build-id
+                           :liveness            :unknown
+                           :hint                (verdict-hint
+                                                  :unknown
+                                                  (assoc browser :build-id build-id
+                                                                 :port port))}
+                    (some? port) (assoc :port port))))))))
 
 (defn token-from-health
   "Convenience: extract the browser half from a `health` map and
   assemble the full token. `health` carries `:runtime-instance-id`,
   `:runtime-loaded-at`, and `:read-at` (rf2-ertqw added them). Returns a
-  Promise of the token map."
-  [conn build-id health]
-  (assemble conn build-id
-            {:runtime-instance-id (:runtime-instance-id health)
-             :runtime-loaded-at   (:runtime-loaded-at health)
-             :read-at             (:read-at health)}))
+  Promise of the token map.
+
+  The optional 4-arity `opts` carries `:port` (rf2-jkwu4) so a non-fresh
+  hint can name `http://localhost:<port>` — the EXACT URL the human
+  reloads to wake / refresh a quiet runtime."
+  ([conn build-id health] (token-from-health conn build-id health nil))
+  ([conn build-id health opts]
+   (assemble conn build-id
+             {:runtime-instance-id (:runtime-instance-id health)
+              :runtime-loaded-at   (:runtime-loaded-at health)
+              :read-at             (:read-at health)}
+             opts)))
 
 (defn stale-build?
   "True when the token's verdict is `:stale-build`. Sugar for callers

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/freshness_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/freshness_test.cljs
@@ -196,3 +196,144 @@
               (is (= :stale-build (:liveness token))
                   "token-from-health threads the browser load time into the stale check")
               (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; Actionable liveness on a quiet runtime (rf2-jkwu4).
+;;
+;; A `:liveness :unknown` / `:no-runtime` verdict is the agent's ONLY
+;; early warning before a later read returns blank — and the agent can't
+;; reload a browser itself. So a non-fresh hint must name the EXACT next
+;; HUMAN step: reload `http://localhost:<port>` when the port is known,
+;; else restart `shadow-cljs watch <build>`. The `:port` rides into
+;; `assemble` (4-arity) / `token-from-health` (4-arity) via the opts map.
+;; ---------------------------------------------------------------------------
+
+(deftest unknown-hint-names-the-port-when-known
+  (async done
+    (-> (with-jvm-half! nil ; nil JVM half ⇒ :unknown
+          (fn [] (fresh/assemble nil :examples/machine-epochs browser-half {:port 8033})))
+        (.then
+          (fn [token]
+            (is (= :unknown (:liveness token)))
+            (is (= 8033 (:port token)) "port rides on the token for the agent to relay")
+            (is (re-find #"LIVENESS UNKNOWN" (:hint token)))
+            (is (re-find #"ACTION" (:hint token)) "the hint is explicitly actionable")
+            (is (re-find #"http://localhost:8033" (:hint token))
+                "names the EXACT URL the human reloads")
+            (is (re-find #"shadow-cljs watch" (:hint token))
+                "names the watch restart as the escalation")
+            (done))))))
+
+(deftest unknown-hint-degrades-to-build-name-without-a-port
+  (async done
+    (-> (with-jvm-half! nil
+          (fn [] (fresh/assemble nil :examples/machine-epochs browser-half)))
+        (.then
+          (fn [token]
+            (is (= :unknown (:liveness token)))
+            (is (not (contains? token :port)) "no port arg ⇒ no :port slot")
+            (is (re-find #"ACTION" (:hint token)))
+            ;; With no port, the hint still names the build for the watch restart.
+            (is (re-find #":examples/machine-epochs" (:hint token))
+                "names the build so `shadow-cljs watch <build>` is unambiguous")
+            (done))))))
+
+(deftest no-runtime-hint-is-actionable-with-the-port
+  ;; The repro's quiet-runtime case: the WS heartbeat went stale → the
+  ;; verdict is :no-runtime. The hint must tell the human to reload the
+  ;; exact URL, then re-run discover-app.
+  (async done
+    (-> (with-jvm-half! {:compile-cycle 3
+                         :build-flushed-at 500
+                         :runtime-count 1
+                         :heartbeat-age-ms 60000} ; stale heartbeat ⇒ :no-runtime
+          (fn [] (fresh/assemble nil :examples/machine-epochs browser-half {:port 8033})))
+        (.then
+          (fn [token]
+            (is (= :no-runtime (:liveness token)))
+            (is (re-find #"NO RUNTIME" (:hint token)))
+            (is (re-find #"http://localhost:8033" (:hint token))
+                ":no-runtime hint names the EXACT URL to reload")
+            (is (re-find #"discover-app" (:hint token))
+                "tells the agent to re-confirm liveness after the reload")
+            (done))))))
+
+(deftest token-from-health-threads-the-port
+  ;; The discover-app path uses token-from-health; its 4-arity must carry
+  ;; the port through to the hint.
+  (async done
+    (let [health {:ok? true :runtime-instance-id "uuid-q" :runtime-loaded-at 1 :read-at 2}]
+      (-> (with-jvm-half! nil
+            (fn [] (fresh/token-from-health nil :examples/machine-epochs health {:port 8033})))
+          (.then
+            (fn [token]
+              (is (= :unknown (:liveness token)))
+              (is (= 8033 (:port token)))
+              (is (re-find #"http://localhost:8033" (:hint token)))
+              (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; retry-once-on-nil — one retry before degrading to :unknown (rf2-jkwu4).
+;;
+;; A nil first read of the build-worker state is most often a transient
+;; socket hiccup, not a genuinely-unreadable old shadow. One retry
+;; recovers the common case so the operator sees the true :fresh /
+;; :stale-build / :no-runtime verdict instead of a degraded :unknown. The
+;; retry pays a single extra round-trip only on the cold/degraded path.
+;;
+;; The combinator is pure (takes a Promise-returning thunk), so these
+;; tests need NO global var stub — sidestepping the rf2-wb06a
+;; .finally-after-done stub-leak race entirely.
+;; ---------------------------------------------------------------------------
+
+(deftest retry-once-recovers-a-transient-blank
+  (async done
+    (let [calls (atom 0)
+          read! (fn []
+                  (swap! calls inc)
+                  (js/Promise.resolve
+                    (if (= 1 @calls)
+                      nil ; blank first read (transient hiccup)
+                      {:compile-cycle 5 :build-flushed-at 100
+                       :runtime-count 1 :heartbeat-age-ms 50})))]
+      (-> (fresh/retry-once-on-nil read!)
+          (.then
+            (fn [half]
+              (is (= 2 @calls) "retried exactly once after a blank first read")
+              (is (map? half) "the retry recovered the JVM half")
+              (is (= 5 (:compile-cycle half)))
+              (done)))))))
+
+(deftest retry-once-no-retry-on-first-success
+  (async done
+    (let [calls (atom 0)
+          read! (fn []
+                  (swap! calls inc)
+                  (js/Promise.resolve {:compile-cycle 7 :runtime-count 1 :heartbeat-age-ms 10}))]
+      (-> (fresh/retry-once-on-nil read!)
+          (.then
+            (fn [half]
+              (is (= 1 @calls) "a map-valued first read pays NO retry round-trip")
+              (is (= 7 (:compile-cycle half)))
+              (done)))))))
+
+(deftest retry-once-persistent-blank-resolves-nil
+  (async done
+    (let [calls (atom 0)
+          read! (fn [] (swap! calls inc) (js/Promise.resolve nil))]
+      (-> (fresh/retry-once-on-nil read!)
+          (.then
+            (fn [half]
+              (is (= 2 @calls) "retried once; a persistent blank then degrades")
+              (is (nil? half) "two blanks ⇒ nil ⇒ caller degrades to :unknown")
+              (done)))))))
+
+(deftest jvm-build-freshness-skips-retry-without-a-socket
+  ;; A conn with no live socket short-circuits to nil with NO round-trip
+  ;; (and so no retry) — preserved from the original contract.
+  (async done
+    (let [conn (atom {:socket nil :closed? true})]
+      (-> (fresh/jvm-build-freshness conn :app)
+          (.then (fn [half]
+                   (is (nil? half) "no socket ⇒ nil, never a TCP connect")
+                   (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sticky_build_invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sticky_build_invoke_test.cljs
@@ -1,0 +1,184 @@
+(ns re-frame2-pair-mcp.sticky-build-invoke-test
+  "End-to-end one-step sticky-build pin (rf2-jkwu4).
+
+  THE NORTH STAR: after a SINGLE `discover-app`, an agent should be able
+  to call EVERY other pair tool with NO `build` arg and have it just
+  work — even with several shadow builds running. The lower-level pieces
+  are pinned elsewhere (`build_id_cache_test` for the `:resolved-build-id`
+  cache + `arg-build` precedence; `port_to_build_test` for the `:port`
+  resolver writing the cache). This suite closes the loop the live repro
+  exercised: drive the REAL `discover-app` then a REAL no-`build` tool
+  call THROUGH `tools/invoke` (the single MCP egress) on the SAME conn,
+  and assert the second call's per-tool body resolves the build
+  `discover-app` stuck — NOT the `:app` env default.
+
+  The live repro (2026-06-03, 5 builds running):
+
+    discover-app {port 8033} -> resolves :examples/machine-epochs, OK
+    orient {}                -> FAILED :build-not-running :app  (the bug)
+    read-dom {selector ...}  -> FAILED :build-not-running :app  (the bug)
+
+  These tests prove the build STICKS across the `invoke` boundary so the
+  follow-up no-`build` calls target the resolved build."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools :as tools]
+            [re-frame2-pair-mcp.tools.discover-app :as discover-app]
+            [re-frame2-pair-mcp.tools.get-path :as get-path]
+            [re-frame2-pair-mcp.tools.probe :as probe]
+            [re-frame2-pair-mcp.tools.wire :as wire]
+            [re-frame2-pair-mcp.test-utils :as tu]))
+
+(def ^:private healthy-health
+  {:ok?                        true
+   :debug-enabled?             true
+   :coord-annotation-enabled?  true
+   :frames                     [:rf/default]
+   :ambiguous-frame?           false})
+
+(defn- fresh-conn
+  "A conn-atom fresh out of connect! — caches cleared, plus a fake live
+  socket so the freshness JVM-half probe doesn't try a real TCP connect."
+  []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{} :resolved-build-id nil
+           :build-alias {} :socket #js {} :closed? false)
+    conn))
+
+(defn- captured-build-from-second-call
+  "Drive `discover-app` with `discover-args`, then a no-`build` `get-path`
+  through `tools/invoke` on the SAME conn. Returns a Promise of the
+  build-id the second call's body resolved via `wire/arg-build`. The
+  build that should stick is `running-build` (the one running in the
+  workspace). All round-trips are stubbed so the test is hermetic:
+
+    - `probe/running-builds`      → [running-build] (canonicalize-build-step
+                                     maps the sticky default to itself).
+    - `probe/resolve-build-by-port` → running-build (the :port resolver).
+    - `nrepl/cljs-eval-value`     → healthy-health (discover-app's probe +
+                                     health read; the freshness JVM-half
+                                     uses jvm-eval, stubbed to nil below).
+    - `nrepl/jvm-eval`            → blank (freshness degrades to :unknown,
+                                     harmless here)."
+  [discover-args running-build]
+  (let [conn          (fresh-conn)
+        captured      (atom :NOT-CALLED)
+        orig-running  probe/running-builds
+        orig-port     probe/resolve-build-by-port
+        orig-eval     nrepl/cljs-eval-value
+        orig-jvm      nrepl/jvm-eval
+        orig-get-path get-path/get-path-tool]
+    ;; Pre-probe so runtime-preloaded? short-circuits without a round-trip.
+    (swap! conn update :probed-builds conj running-build)
+    (set! probe/running-builds (fn [_] (js/Promise.resolve [running-build])))
+    (set! probe/resolve-build-by-port (fn [_c _p] (js/Promise.resolve running-build)))
+    (set! nrepl/cljs-eval-value
+          (fn ([_c _b _f] (js/Promise.resolve healthy-health))
+              ([_c _b _f _o] (js/Promise.resolve healthy-health))))
+    (set! nrepl/jvm-eval (fn [& _] (js/Promise.resolve {:value ""})))
+    ;; The probe of the second call: capture what build the no-`build`
+    ;; get-path resolved. (get-path's real body reads wire/arg-build conn
+    ;; raw-args — we read it the same way the body would.)
+    (set! get-path/get-path-tool
+          (fn [c args]
+            (reset! captured (wire/arg-build c args))
+            (js/Promise.resolve
+              #js {:content #js [#js {:type "text" :text "{:ok? true}"}]})))
+    (-> (discover-app/discover-app conn discover-args)
+        (.then (fn [_disc]
+                 ;; second tool call: NO build arg, through the invoke egress.
+                 (tools/invoke conn "get-path" (tu/args->js {:path "[:k]"}) nil)))
+        (.then (fn [_] @captured))
+        (.finally (fn []
+                    (set! probe/running-builds orig-running)
+                    (set! probe/resolve-build-by-port orig-port)
+                    (set! nrepl/cljs-eval-value orig-eval)
+                    (set! nrepl/jvm-eval orig-jvm)
+                    (set! get-path/get-path-tool orig-get-path))))))
+
+;; ---------------------------------------------------------------------------
+;; Acceptance #1 — multi-build, :port. discover-app {port 8033} then a
+;; no-build call lands on the resolved build, NOT :app.
+;; ---------------------------------------------------------------------------
+
+(deftest port-discover-sticks-build-through-invoke
+  (async done
+    (-> (captured-build-from-second-call
+          (tu/args->js {:port 8033}) :examples/machine-epochs)
+        (.then
+          (fn [resolved]
+            (is (= :examples/machine-epochs resolved)
+                "post-discover-app{port}, a no-build tool call THROUGH invoke targets the resolved build")
+            (is (not= :app resolved)
+                "it must NOT fall back to the :app env default (the live-repro bug)")
+            (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Acceptance #2 — multi-build, explicit. discover-app {build ...} then a
+;; no-build call lands on the resolved build, NOT :app.
+;; ---------------------------------------------------------------------------
+
+(deftest explicit-discover-sticks-build-through-invoke
+  (async done
+    (-> (captured-build-from-second-call
+          (tu/args->js {:build "examples/machine-epochs"}) :examples/machine-epochs)
+        (.then
+          (fn [resolved]
+            (is (= :examples/machine-epochs resolved)
+                "post-discover-app{build}, a no-build tool call THROUGH invoke targets the resolved build")
+            (is (not= :app resolved))
+            (done))))))
+
+;; ---------------------------------------------------------------------------
+;; A later EXPLICIT :build overrides AND updates the sticky default
+;; (rf2-lbm21), so the NEXT no-build call inherits the override.
+;; ---------------------------------------------------------------------------
+
+(deftest later-explicit-build-overrides-and-restickies
+  (async done
+    (let [conn          (fresh-conn)
+          orig-eval     nrepl/cljs-eval-value
+          orig-jvm      nrepl/jvm-eval
+          orig-running  probe/running-builds
+          orig-port     probe/resolve-build-by-port
+          orig-get-path get-path/get-path-tool
+          captured      (atom nil)]
+      (swap! conn update :probed-builds conj :examples/machine-epochs)
+      (set! probe/resolve-build-by-port (fn [_c _p] (js/Promise.resolve :examples/machine-epochs)))
+      (set! probe/running-builds
+            (fn [_] (js/Promise.resolve [:examples/machine-epochs :examples/standard-epochs])))
+      (set! nrepl/cljs-eval-value
+            (fn ([_c _b _f] (js/Promise.resolve healthy-health))
+                ([_c _b _f _o] (js/Promise.resolve healthy-health))))
+      (set! nrepl/jvm-eval (fn [& _] (js/Promise.resolve {:value ""})))
+      (set! get-path/get-path-tool
+            (fn [c args]
+              (reset! captured (wire/arg-build c args))
+              (js/Promise.resolve
+                #js {:content #js [#js {:type "text" :text "{:ok? true}"}]})))
+      (-> (discover-app/discover-app conn (tu/args->js {:port 8033}))
+          (.then (fn [_]
+                   (is (= :examples/machine-epochs (:resolved-build-id @conn))
+                       "discover-app{port} stuck machine-epochs")
+                   ;; A later EXPLICIT build override on a get-path call.
+                   (tools/invoke conn "get-path"
+                                 (tu/args->js {:path "[:k]" :build "examples/standard-epochs"})
+                                 nil)))
+          (.then (fn [_]
+                   (is (= :examples/standard-epochs @captured)
+                       "the explicit :build wins on that call")
+                   (is (= :examples/standard-epochs (:resolved-build-id @conn))
+                       "and stick-build! updates the sticky default to the override")
+                   ;; The NEXT no-build call inherits the new sticky default.
+                   (tools/invoke conn "get-path" (tu/args->js {:path "[:k]"}) nil)))
+          (.then (fn [_]
+                   (is (= :examples/standard-epochs @captured)
+                       "subsequent no-build call inherits the updated sticky default")))
+          (.finally (fn []
+                      (set! nrepl/cljs-eval-value orig-eval)
+                      (set! nrepl/jvm-eval orig-jvm)
+                      (set! probe/running-builds orig-running)
+                      (set! probe/resolve-build-by-port orig-port)
+                      (set! get-path/get-path-tool orig-get-path)))
+          (.then (fn [_] (done)))))))


### PR DESCRIPTION
## What

Closes the rf2-jkwu4 one-step-get-going bug for the re-frame2-pair MCP.

### Problem A — sticky build (already fixed in-tree; this PR adds the missing end-to-end regression guard)

Investigating the code showed the sticky-build mechanism was **already in place** at HEAD across rf2-l9ixp / rf2-lbm21 / rf2-fyf0h: `discover-app` writes the resolved build to the conn-atom (`:resolved-build-id`) for **all** resolution paths — auto-selected single build, explicit `:build`, **and** `:port` — `wire/arg-build` reads it, and `wire/stick-build!` re-points it on a later explicit `:build`. The `:port` caching is even asserted in `port_to_build_test.cljs`. The live-session repro in the bead (`orient {}` → `:build-not-running :app`) was a **stale deployed MCP binary** predating those fixes.

What was missing was a regression guard at the **actual layer the repro exercised**: the second tool call going through `tools/invoke`. Added `sticky_build_invoke_test.cljs` pinning the bead's acceptance #1/#2 end-to-end: after `discover-app {port}` and `discover-app {build}`, a no-`build` tool call **through `invoke`** targets the resolved build (not `:app`); a later explicit `:build` overrides and re-stickies for the next call.

### Problem B — quiet runtime warned late and non-actionably (real defect, fixed)

- `freshness/jvm-build-freshness` now **retries the JVM build-worker read once** before degrading to `:liveness :unknown` (a nil first read is usually a transient socket hiccup). Extracted as the pure `retry-once-on-nil` combinator so it is unit-testable without a global var stub.
- Non-`:fresh` hints are now **actionable**: `:no-runtime` / `:unknown` name the EXACT `http://localhost:<port>` the human reloads (the port rides into the token via discover-app's `:port` arg and onto the token for the agent to relay), and `:unknown` escalates to restarting `shadow-cljs watch <build>` when the worker stays unreadable. The agent can't reload a browser, so this is early, crisp human-in-the-loop signalling.

## Persistence scope chosen

Reused the existing **per-MCP-connection conn-atom** `:resolved-build-id` cache (the rf2-3bu3d/l9ixp/lbm21 holder) — the natural scope under the MCP stdio one-process-per-client model; never a process-global, resets on nREPL reconnect. No new state introduced.

## Changed files

- `tools/re-frame2-pair-mcp/src/.../tools/freshness.cljs` — `retry-once-on-nil` combinator + one-retry in `jvm-build-freshness`; actionable `:no-runtime` / `:unknown` hints naming the port/build; `assemble` / `token-from-health` 4-arity carrying `:port`.
- `tools/re-frame2-pair-mcp/src/.../tools/discover_app.cljs` — threads the `:port` arg into the freshness token via `with-freshness` opts.
- `tools/re-frame2-pair-mcp/test/.../freshness_test.cljs` — retry-combinator + actionable-liveness tests.
- `tools/re-frame2-pair-mcp/test/.../sticky_build_invoke_test.cljs` — NEW end-to-end sticky-build-through-invoke tests.
- `skills/re-frame2-pair/SKILL.md` — "connect once" now reads true for multi-build / `:port`; documents the actionable `:freshness` verdicts.
- `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` — documents the retry + actionable freshness hint.

## Gates (cold)

- `npm test` (pair-mcp `:server-test`): **871 tests, 0 failures** (was 860 baseline; +11).
- `npm run test:mcp-conformance`: **all gates green**.
- `npm run check:descriptors`: in sync (28 tools).

## Residual risks

- The sticky mechanism was confirmed correct by code reading; this PR adds the end-to-end guard but does not exercise a real 5-build live shadow. Acceptance #1/#2 are pinned hermetically through `invoke`.
- The blank-result `read-dom` hint (bead B2) was already substantially rewritten by rf2-r5erl at HEAD (points the agent at discover-app); left as-is — the liveness improvement is the higher-leverage fix for the quiet-runtime class.