### PR TITLE
refactor(xray-testbeds): roll the queued-step runner across the deferred testbeds (rf2-3xakq)

### DIFF
--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -2661,10 +2661,25 @@ async function runPanelGalleryThemeTokens(page, state) {
 // section reflects the just-clicked button. CURRENT ROUTE + ROUTE TABLE
 // render every epoch. We read each section's stable data-testids.
 
-// Click a deck ladder rung by its per-rung data-testid
-// (`routes-epochs-rung-<n>`, outside Xray chrome).
+// Drive a deck ladder rung by its (1-based) rung number.
+//
+// rf2-3xakq — the deck was converted to the shared queued-step runner
+// (`runner.core`). It no longer mounts a bespoke `routes-epochs-rung-<n>`
+// button per rung; instead the runner renders one step row per step, and
+// each row's index is a RANDOM-ACCESS RUN-THIS-STEP button
+// (`routes-epochs-step-<n>-run`, n = 0-based step index). The runner's
+// per-step run affordance is exactly the random-access addressing this
+// scenario needs — it drives rungs OUT OF ORDER (#3, #1, #4, #5, #7, #10,
+// #11), asserting the Routing panel after each, which the runner's
+// sequential cursor alone could not provide.
+//
+// The scenario keeps the historical 1-based rung vocabulary (rung 1 = the
+// first step) and maps it onto the 0-based runner step index here, so every
+// call site below reads unchanged. The step ORDER is identical to the old
+// ladder (same events, same routing features); only the driving affordance
+// moved to the runner.
 async function clickRung(page, n) {
-  await clickTestId(page, `routes-epochs-rung-${n}`);
+  await clickTestId(page, `routes-epochs-step-${n - 1}-run`);
 }
 
 // Read the Routing panel's projected slice from the DOM. Returns nulls
@@ -2849,8 +2864,10 @@ async function runRoutesEpochs(page, state) {
     try {
       const cljs = window.cljs && window.cljs.core;
       const rf = window.re_frame && window.re_frame.core;
-      // `re-frame.core/get-frame-db` returns the plain db map (no deref).
-      if (cljs && rf && typeof rf.get_frame_db === 'function') {
+      // `re-frame.core/app-db-value` returns the plain db VALUE (no deref)
+      // for the named frame (rf2-003ce renamed the former get-frame-db
+      // container accessor; the value accessor is the public read seam).
+      if (cljs && rf && typeof rf.app_db_value === 'function') {
         const kw = (s) => {
           const t = String(s).replace(/^:/, '');
           const p = t.split('/');
@@ -2858,7 +2875,7 @@ async function runRoutesEpochs(page, state) {
             ? (cljs.keyword.call ? cljs.keyword.call(null, p[0], p[1]) : cljs.keyword(p[0], p[1]))
             : (cljs.keyword.call ? cljs.keyword.call(null, t) : cljs.keyword(t));
         };
-        const db = rf.get_frame_db(kw('rf/default'));
+        const db = rf.app_db_value(kw('rf/default'));
         const path = cljs.PersistentVector.fromArray(
           [kw('rf/runtime'), kw('routing'), kw('pending-navigation')], true);
         const pn = db ? cljs.get_in(db, path) : null;

--- a/tools/xray/testbeds/routes_epochs/core.cljs
+++ b/tools/xray/testbeds/routes_epochs/core.cljs
@@ -1,30 +1,41 @@
 (ns routes-epochs.core
-  "ROUTES-EPOCHS testbed (rf2-5crg4) — the ROUTING sibling of the
-  `standard_epochs` deck. A deliberately simple Xray driving surface
-  aimed squarely at the **Routing panel** (`rf-xray-routing`).
+  "ROUTES-EPOCHS testbed (rf2-5crg4 → rf2-3xakq) — the ROUTING sibling of the
+  `standard_epochs` deck, converted to the shared queued-step RUNNER
+  (`runner.core`, the rf2-8pbjr pilot). A deliberately simple Xray driving
+  surface aimed squarely at the **Routing panel** (`rf-xray-routing`).
 
-  ## Shape
+  ## Shape (rf2-3xakq — adopt the shared queued-step RUNNER)
 
-  ONE tall column of NUMBERED buttons, top to bottom — the same shape as
-  `standard_epochs`. Beside each button a one-line caption says WHAT TO
-  WATCH in Xray's Routing tab when you press it. Each button is ONE test:
-  it fires one event that
+  ONE purple Step button (`routes-epochs-step`) walks the routing ladder
+  top to bottom while the operator watches how Xray's Routing panel renders
+  each rung; EVERY step row's index is ALSO a RANDOM-ACCESS RUN-THIS-STEP
+  button (`routes-epochs-step-<n>-run`, n = 0-based step index) so any rung
+  can be driven directly. The runner (`runner.core`) is the shared harness;
+  this deck supplies a `steps` vector (CODE DATA) + the testid prefix
+  `routes-epochs`. Each step DISPATCHES one event that
 
     (a) bumps a shared baseline counter (so App-db / Epoch always show a
-        delta on every press), and
+        delta on every step), and
     (b) exercises exactly ONE additional ROUTING feature.
 
-  Progressive: button 1 is a plain `navigate`; each later button layers
-  one more routing concept on top. A SINGLE frame, plainly mounted, with
-  the routing artefact booted (`[re-frame.routing]`) and Xray
-  auto-mounting inline on the right (`[data-rf-xray-host]` + the xray
-  preload) reading that one frame. No tabs, no live ACTION→CHECK strip:
-  the static caption is the 'what to look for', and the Routing panel
-  itself is the check.
+  Replaces the bespoke numbered-button ladder (`routes-epochs-rung-<n>`):
+  same events, same routing features, same coverage — but driven by the
+  shared runner. The runner's per-step RUN-THIS-STEP affordance (rf2-kipb5)
+  is exactly the RANDOM-ACCESS addressing the feature-matrix scenario needs
+  — it drives rungs OUT OF ORDER (#3, #1, #4, #5, #7, #10, #11), asserting
+  the Routing panel after each, which the runner's sequential cursor alone
+  could not provide.
+
+  Progressive: step 1 is a plain `navigate`; each later step layers one
+  more routing concept on top. A SINGLE frame, plainly mounted, with the
+  routing artefact booted (`[re-frame.routing]`) and Xray auto-mounting
+  inline on the right (`[data-rf-xray-host]` + the xray preload) reading
+  that one frame. The Routing panel itself is the check; each step's
+  `:watch` note says what to look for.
 
   ## North star (acceptance)
 
-  Click the buttons top to bottom → the Xray **Routing panel** is
+  Step through the ladder top to bottom → the Xray **Routing panel** is
   COMPLETELY exercised: its three sections —
 
     - CURRENT ROUTE         (active id · params · matched path)
@@ -57,25 +68,37 @@
                              route params (transition :loading → :idle).
     #9  back/forward        — push, then a popstate-style back; NAVIGATION
                              THIS EPOCH's FROM ──► TO reverses.
-    #10 guarded/blocked nav— a `:can-leave` guard refuses; outcome
+    #10 guarded/enter       — navigate INTO settings + arm the dirty flag.
+    #11 guarded/blocked nav — a `:can-leave` guard refuses; outcome
                              `blocked` + `:rf/pending-navigation` is set.
+
+  ## Runner state = LOCAL ATOM (rf2-8pbjr contract)
+
+  The runner cursor / status / pace live in `runner-state` — a LOCAL
+  Reagent atom in THIS ns. It is NEVER written to the inspected app-db
+  (that would pollute the App-db / Routing panels under inspection) and is
+  NOT a second frame (only the inspected app frame, `:rf/default`, is
+  Xray-relevant). A Step / per-step click is manual (operator-driven focus
+  — the runner does not pin focus).
 
   ## Test surface, not tutorial
 
   Per `feedback_testbeds_are_test_surfaces`: no deliberate bugs as
   anti-patterns, no teaching layers. The guard / not-found / redirect
-  buttons exercise the REAL routing surface — each is a feature being
-  driven, not a buggy demo. Captions are guidance, not lessons.
+  steps exercise the REAL routing surface — each is a feature being
+  driven, not a buggy demo. `:watch` notes are guidance, not lessons.
 
   ## Test-free + self-contained
 
   Per rf2-8cevm this testbed carries no spec.cjs; regression coverage
   lives in the substrate contract tests + the Xray feature-matrix gate
   (`tools/xray/testbeds/feature_matrix/scenarios.cjs` — the
-  `routes-epochs routing ladder` scenario). The routes / events / subs /
+  `routes-epochs routing ladder` scenario, which drives the ladder via the
+  runner's per-step RUN-THIS-STEP buttons). The routes / events / subs /
   views below are OWNED here — this deck does NOT reuse the shared
   `testdeck.*` modules."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent.core :as r]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Routing artefact — load-time hook so `reg-route`,
             ;; `:rf.route/navigate`, the `:rf.route/*` subs and
@@ -90,8 +113,18 @@
             [day8.re-frame2-xray.config :as xray-config]
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
-            [re-frame.testbed.config :as testbed-config])
+            [re-frame.testbed.config :as testbed-config]
+            ;; The shared queued-step runner (rf2-8pbjr pilot). This deck
+            ;; supplies a `steps` vector + the testid prefix; the runner
+            ;; drives the ONE-button series + the per-step RUN buttons.
+            [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; The inspected app frame (rf2-8pbjr — only the app frame is Xray-relevant)
+;; ============================================================================
+
+(def host-frame :rf/default)
 
 ;; ============================================================================
 ;; ROUTES — the deck OWNS its own route table
@@ -117,13 +150,13 @@
    :path "/"})
 
 (rf/reg-route :routes-epochs/articles
-  {:doc  "Articles list — the nested-route PARENT (button #5's child sits
+  {:doc  "Articles list — the nested-route PARENT (step #5's child sits
           under it, so the ROUTE TABLE draws the indented tree)."
    :path "/articles"})
 
 (rf/reg-route :routes-epochs/article
-  {:doc    "Article detail — carries a `:id` path param (button #3) and is
-            NESTED under `:routes-epochs/articles` (button #5) so the
+  {:doc    "Article detail — carries a `:id` path param (step #3) and is
+            NESTED under `:routes-epochs/articles` (step #5) so the
             ROUTE TABLE indents it and the current-row highlight walks the
             parent chain."
    :path   "/articles/:id"
@@ -132,7 +165,7 @@
 
 (rf/reg-route :routes-epochs/search
   {:doc   "Search — declares a `:query` schema so the query keys round-trip
-           into the route slice (button #4)."
+           into the route slice (step #4)."
    :path  "/search"
    :query [:map
            [:q {:optional true} :string]
@@ -140,27 +173,27 @@
 
 (rf/reg-route :routes-epochs/old-home
   {:doc      "A retired URL that REDIRECTS to `:routes-epochs/home` via its
-              `:on-match` (button #6) — navigating here lands the slice on
+              `:on-match` (step #6) — navigating here lands the slice on
               home, one cascade later."
    :path     "/old-home"
    :on-match [[:routes-epochs/redirect-to-home]]})
 
 (rf/reg-route :routes-epochs/profile
   {:doc      "A profile route whose `:on-match` LOADER writes app-db from
-              the route params (button #8): transition runs :loading → :idle
+              the route params (step #8): transition runs :loading → :idle
               while the loader fills `:profile`."
    :path     "/profile/:user"
    :params   [:map [:user :string]]
    :on-match [[:routes-epochs/load-profile]]})
 
 (rf/reg-route :routes-epochs/settings
-  {:doc       "Settings — GUARDED by a `:can-leave` gate (button #10). The
+  {:doc       "Settings — GUARDED by a `:can-leave` gate (step #11). The
                gate refuses to leave while `:settings-dirty?` is set, so a
                navigation AWAY is blocked and `:rf/pending-navigation` fills."
    :path      "/settings"
    :can-leave :routes-epochs/can-leave-settings?})
 
-;; The runtime emits :rf.route/not-found for unmatched URLs (button #7).
+;; The runtime emits :rf.route/not-found for unmatched URLs (step #7).
 (rf/reg-route :rf.route/not-found
   {:doc  "Fallback page for unmatched URLs — CURRENT ROUTE reads
           `:rf.route/not-found`; NAVIGATION THIS EPOCH's outcome chip
@@ -171,11 +204,11 @@
 ;; APP-DB SEED
 ;; ============================================================================
 ;;
-;; `:baseline` is the shared counter every button bumps (so App-db / Epoch
+;; `:baseline` is the shared counter every step bumps (so App-db / Epoch
 ;; always show a delta). `:articles` feeds the params / nested-route
-;; targets. `:profile` is the slot the route-driven loader (button #8)
+;; targets. `:profile` is the slot the route-driven loader (step #8)
 ;; fills from the route params. `:settings-dirty?` arms the `:can-leave`
-;; guard (button #10).
+;; guard (step #11).
 
 (def initial-db
   {:baseline        0
@@ -185,7 +218,7 @@
    :settings-dirty? false})
 
 (rf/reg-event-fx :routes-epochs/reset
-  {:doc "Button 0 — re-seed app-db AND navigate home. Start clean."}
+  {:doc "Re-seed app-db AND navigate home. Start clean."}
   (fn handler-reset [_ _ev]
     {:db initial-db
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
@@ -197,7 +230,7 @@
 ;; The routing events themselves are FRAMEWORK events (`:rf.route/navigate`
 ;; etc.) we cannot edit, so each rung is a thin deck-owned event-fx that
 ;; (a) bumps `:baseline` via `:db` and (b) dispatches the routing
-;; event/fx. The Epoch / App-db delta on every press comes from the bump;
+;; event/fx. The Epoch / App-db delta on every step comes from the bump;
 ;; the Routing panel lights up from the dispatched routing event.
 
 (defn- bump [db] (update db :baseline inc))
@@ -217,7 +250,7 @@
 ;; ============================================================================
 
 (rf/reg-event-fx :routes-epochs/redirect-to-home
-  {:doc "Button #6's redirect — fired as `:routes-epochs/old-home`'s
+  {:doc "Step #6's redirect — fired as `:routes-epochs/old-home`'s
          `:on-match`. Re-navigates to home so the slice lands on a
          DIFFERENT route one cascade later."}
   (fn handler-redirect [{:keys [db]} _ev]
@@ -225,7 +258,7 @@
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
 
 (rf/reg-event-db :routes-epochs/load-profile
-  {:doc "Button #8's route-driven loader — fired as
+  {:doc "Step #8's route-driven loader — fired as
          `:routes-epochs/profile`'s `:on-match`. Reads the route params
          from the slice and writes `:profile` into app-db (the
          transition runs :loading → :idle around this loader)."}
@@ -234,7 +267,7 @@
       (-> db bump (assoc :profile {:user user :loaded-at-baseline (:baseline db)})))))
 
 ;; ============================================================================
-;; GUARDED NAV (#10) — a :can-leave gate
+;; GUARDED NAV (#10/#11) — a :can-leave gate
 ;; ============================================================================
 ;;
 ;; `:routes-epochs/settings` declares `:can-leave :routes-epochs/can-leave-
@@ -248,14 +281,14 @@
   (fn [db _] (boolean (not (:settings-dirty? db)))))
 
 (rf/reg-event-fx :routes-epochs/enter-dirty-settings
-  {:doc "Button #10a — navigate INTO settings AND arm the dirty flag, so
+  {:doc "Step #10 — navigate INTO settings AND arm the dirty flag, so
          the `:can-leave` guard will block the next attempt to leave."}
   (fn handler-enter-dirty [{:keys [db]} _ev]
     {:db (-> db bump (assoc :settings-dirty? true))
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/settings]]]}))
 
 (rf/reg-event-fx :routes-epochs/try-leave-settings
-  {:doc "Button #10b — attempt to navigate home FROM dirty settings. The
+  {:doc "Step #11 — attempt to navigate home FROM dirty settings. The
          `:can-leave` guard refuses: the slice stays on settings, the
          outcome reads `blocked`, and `:rf/pending-navigation` fills."}
   (fn handler-try-leave [{:keys [db]} _ev]
@@ -272,7 +305,7 @@
 ;; the forward navigation that preceded it.
 
 (rf/reg-event-fx :routes-epochs/back
-  {:doc "Button #9 — emulate the browser Back button by handling a
+  {:doc "Step #9 — emulate the browser Back button by handling a
          url-change back to the articles list (a popstate-style
          transition). NAVIGATION THIS EPOCH's FROM ──► TO reverses."}
   (fn handler-back [{:keys [db]} _ev]
@@ -291,79 +324,87 @@
 (rf/reg-sub :routes-epochs/profile  (fn [db _] (:profile db)))
 
 ;; ============================================================================
-;; THE BUTTON LADDER
+;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
+;; ============================================================================
+;;
+;; Each step: {:event [...] :watch "<what to look for>" :settle-ms N
+;;             :label "<short row label>"}. The runner renders :watch per
+;; STEP (per-occurrence narration), dispatches :event, then waits
+;; :settle-ms before advancing. Navigation cascades through
+;; `:routes-epochs/go` (bump + :rf.route/navigate) settle quickly — a
+;; short pause is enough for the navigation cascade + the Routing panel to
+;; render before the next step. Redirect (#6) is given a longer settle
+;; because its `:on-match` fires a SECOND navigation cascade.
+;;
+;; The ladder order matches the historical numbered rungs 1..11 (1-based):
+;; step index 0 = rung #1, step index N-1 = rung #N. The feature-matrix
+;; scenario keeps the 1-based rung vocabulary and drives the runner's
+;; per-step RUN button at index (rung - 1).
+
+(def steps
+  [;; -- Navigation basics — CURRENT ROUTE + NAVIGATION THIS EPOCH --
+   {:label     "navigate / push"
+    :event     [:routes-epochs/go :routes-epochs/home]
+    :watch     "CURRENT ROUTE → :home · NAVIGATION ──► home · outcome transitioned. The ROUTE TABLE paints the :to overlay on the home row."
+    :settle-ms 400}
+   {:label     "replace (no history push)"
+    :event     [:routes-epochs/go :routes-epochs/home nil {:replace? true}]
+    :watch     "Same slice write via :replace? true (:rf.nav/replace-url, no history push) — the slice lands on :home without a back-stack entry."
+    :settle-ms 400}
+
+   ;; -- Params & query — the slice carries params / query --
+   {:label     "route params (/articles/:id)"
+    :event     [:routes-epochs/go :routes-epochs/article {:id "intro"}]
+    :watch     "CURRENT ROUTE → :article · params {:id \"intro\"} · NAVIGATION ──► :article · transitioned."
+    :settle-ms 400}
+   {:label     "query params (?q&sort)"
+    :event     [:routes-epochs/go :routes-epochs/search nil {:query {:q "routing" :sort "asc"}}]
+    :watch     "CURRENT ROUTE → :search · query {:q \"routing\" :sort \"asc\"} (the :rf.route/query slice)."
+    :settle-ms 400}
+
+   ;; -- ROUTE TABLE — nested tree, redirect, fallback --
+   {:label     "nested route (under :articles)"
+    :event     [:routes-epochs/go :routes-epochs/article {:id "nested"}]
+    :watch     "ROUTE TABLE indents :article under :articles (deeper padding-left) · the destination :to overlay paints on the :article row this navigation epoch."
+    :settle-ms 400}
+   {:label     "redirect (:on-match re-navigates)"
+    :event     [:routes-epochs/go :routes-epochs/old-home]
+    :watch     "Navigate :old-home → its :on-match re-navigates, landing the slice on :home one cascade later. Epoch: the two-navigation cascade."
+    :settle-ms 600}
+   {:label     "not-found / fallback"
+    :event     [:routes-epochs/go {:url "/no-such-page"}]
+    :watch     "Unmatched URL → CURRENT ROUTE :rf.route/not-found · NAVIGATION ──► the registered :rf.route/not-found fallback."
+    :settle-ms 400}
+
+   ;; -- Loaders & transitions — :on-match drives app-db --
+   {:label     "route-driven app-db (:on-match loader)"
+    :event     [:routes-epochs/go :routes-epochs/profile {:user "ada"}]
+    :watch     "Navigate :profile → :on-match writes :profile from params · App-db gains :profile {:user \"ada\" ..} · transition :loading→:idle."
+    :settle-ms 500}
+   {:label     "back / forward (popstate)"
+    :event     [:routes-epochs/back]
+    :watch     "Emulate Back → :articles · NAVIGATION THIS EPOCH's FROM ──► TO reverses relative to the forward navigation."
+    :settle-ms 400}
+
+   ;; -- Guarded navigation — :can-leave blocks --
+   {:label     "enter dirty settings (arm the guard)"
+    :event     [:routes-epochs/enter-dirty-settings]
+    :watch     "Navigate INTO :settings + arm :settings-dirty? so the :can-leave guard will block the next attempt to leave."
+    :settle-ms 400}
+   {:label     "try to leave (blocked by :can-leave)"
+    :event     [:routes-epochs/try-leave-settings]
+    :watch     "Attempt → home FROM dirty settings · the guard refuses · CURRENT ROUTE STAYS :settings · outcome blocked · :rf/pending-navigation fills."
+    :settle-ms 400}])
+
+;; ============================================================================
+;; RUNNER STATE — LOCAL ATOM (rf2-8pbjr: not app-db, not a 2nd frame)
 ;; ============================================================================
 
-(def ^:private ladder
-  "The ordered routing ladder. Each row: [n label caption event]. `event`
-  is the dispatch vector; `:section` rows are separators (label only)."
-  [[:section "Navigation basics — CURRENT ROUTE + NAVIGATION THIS EPOCH"]
-   [1  "navigate / push"
-    "CURRENT ROUTE → :home · NAVIGATION ──► home · outcome transitioned"
-    [:routes-epochs/go :routes-epochs/home]]
-   [2  "replace (no history push)"
-    "Same slice write via :replace? true (:rf.nav/replace-url, no push)"
-    [:routes-epochs/go :routes-epochs/home nil {:replace? true}]]
-   [:section "Params & query — the slice carries params / query"]
-   [3  "route params (/articles/:id)"
-    "CURRENT ROUTE → :article · params {:id \"intro\"}"
-    [:routes-epochs/go :routes-epochs/article {:id "intro"}]]
-   [4  "query params (?q&sort)"
-    "CURRENT ROUTE → :search · query {:q \"routing\" :sort \"asc\"} (:rf.route/query)"
-    [:routes-epochs/go :routes-epochs/search nil {:query {:q "routing" :sort "asc"}}]]
-   [:section "ROUTE TABLE — nested tree, redirect, fallback"]
-   [5  "nested route (under :articles)"
-    "ROUTE TABLE indents :article under :articles · highlight walks the parent chain"
-    [:routes-epochs/go :routes-epochs/article {:id "nested"}]]
-   [6  "redirect (:on-match re-navigates)"
-    "Navigate :old-home → its :on-match lands the slice on :home one cascade later"
-    [:routes-epochs/go :routes-epochs/old-home]]
-   [7  "not-found / fallback"
-    "Unmatched URL → CURRENT ROUTE :rf.route/not-found · outcome not-found"
-    [:routes-epochs/go {:url "/no-such-page"}]]
-   [:section "Loaders & transitions — :on-match drives app-db"]
-   [8  "route-driven app-db (:on-match loader)"
-    "Navigate :profile → :on-match writes :profile from params · transition :loading→:idle"
-    [:routes-epochs/go :routes-epochs/profile {:user "ada"}]]
-   [9  "back / forward (popstate)"
-    "Emulate Back → :articles · NAVIGATION THIS EPOCH's FROM ──► TO reverses"
-    [:routes-epochs/back]]
-   [:section "Guarded navigation — :can-leave blocks"]
-   [10 "enter dirty settings (arm the guard)"
-    "Navigate INTO :settings + arm :settings-dirty? so the guard will block leaving"
-    [:routes-epochs/enter-dirty-settings]]
-   [11 "try to leave (blocked by :can-leave)"
-    "Attempt → home FROM dirty settings · outcome blocked · :rf/pending-navigation fills"
-    [:routes-epochs/try-leave-settings]]])
+(defonce runner-state (r/atom (runner/initial-state)))
 
-(reg-view ladder-button
-  "One numbered ladder row: a numbered button on the left, its caption on
-  the right. Pressing it dispatches the row's event. The button carries a
-  per-rung `data-testid` (`routes-epochs-rung-<n>`) so each rung is
-  uniquely addressable even though several share the `:routes-epochs/go`
-  event-id (the feature-matrix scenario drives them by rung)."
-  [n label caption event]
-  [:div {:style {:display "grid" :grid-template-columns "auto 1fr"
-                 :gap "0.75em" :align-items "center" :margin "0.35em 0"}}
-   [:button {:data-testid (str "routes-epochs-rung-" n)
-             :on-click    #(dispatch event)
-             :style {:min-width "20em" :text-align "left"
-                     :padding "0.4em 0.6em" :cursor "pointer"
-                     :border "1px solid #cfc8ff" :border-radius "6px"
-                     :background "#fff"}}
-    [:span {:style {:font-weight "bold" :color "#7C5CFF" :margin-right "0.5em"}}
-     (str n ".")]
-    label]
-   [:span {:style {:color "#666" :font-size "12px"}} caption]])
-
-(reg-view section-heading
-  "A section separator inside the ladder."
-  [label]
-  [:div {:style {:margin "1em 0 0.25em 0" :font-size "11px" :font-weight "bold"
-                 :color "#7C5CFF" :text-transform "uppercase"
-                 :letter-spacing "0.04em" :border-top "1px dashed #ddd"
-                 :padding-top "0.5em"}}
-   label])
+;; ============================================================================
+;; VIEWS
+;; ============================================================================
 
 (reg-view current-route-strip
   "A small live read-out of the active route slice — mirrors what the
@@ -393,30 +434,31 @@
 (reg-view root []
   [:div {:data-testid "routes-epochs-root"
          :style {:font-family "system-ui, sans-serif" :padding "1em"
-                 :max-width "760px"}}
+                 :max-width "820px"}}
    [:header {:style {:margin-bottom "0.5em"}}
-    [:h2 {:style {:margin 0}} "Routes-epochs"]
+    [:h2 {:data-testid "routes-epochs-title" :style {:margin 0}} "Routes-epochs"]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "One frame, one tall column of routing test buttons. Each button bumps a shared "
-     [:strong "baseline"] " counter (so App-db / Epoch always show a delta) and "
-     "exercises exactly one more routing feature. The caption says what to watch in "
-     "Xray's " [:strong "Routing"] " panel on the right — click top to bottom and the "
-     "panel's three sections (Current route · Navigation this epoch · Route table) are "
-     "fully exercised."]]
+     "One frame, one routing ladder. One button (" [:strong "⏭ Step"] ") "
+     "walks the rungs top to bottom (each row's number is also a "
+     [:strong "RUN-THIS-STEP"] " button for random access). Each step bumps "
+     "a shared " [:strong "baseline"] " counter (so App-db / Epoch always "
+     "show a delta) and exercises exactly one more routing feature. Read "
+     "each step's " [:strong "Watch"] " note, then watch Xray's "
+     [:strong "Routing"] " panel on the right — its three sections (Current "
+     "route · Navigation this epoch · Route table) light up across the "
+     "ladder. The runner cursor lives in a " [:strong "local atom"] " — it "
+     "never touches the inspected app-db."]]
    [current-route-strip]
-   ;; Button 0 — Reset.
+   ;; Reset — re-seed app-db, navigate home, rewind the runner.
    [:button {:data-testid "reset-button"
-             :on-click #(dispatch [:routes-epochs/reset])
+             :on-click (fn []
+                         (dispatch [:routes-epochs/reset])
+                         (runner/reset-runner! runner-state))
              :style {:padding "0.4em 0.8em" :cursor "pointer"
                      :border "1px solid #cfc8ff" :border-radius "6px"
                      :background "#f4f1ff" :margin "0.5em 0"}}
-    "0. Reset — re-seed app-db, navigate home"]
-   ;; The ladder.
-   (for [row ladder]
-     (if (= :section (first row))
-       ^{:key (second row)} [section-heading (second row)]
-       (let [[n label caption event] row]
-         ^{:key n} [ladder-button n label caption event])))])
+    "0. Reset — re-seed app-db, navigate home, rewind runner"]
+   [runner/runner "routes-epochs" runner-state steps host-frame]])
 
 ;; ============================================================================
 ;; ROUTER WIRING
@@ -449,7 +491,7 @@
   (rf/init! reagent-adapter/adapter)
   ;; Seed app-db and pull the current URL into the route slice (what a
   ;; popstate / initial-load handler does). The default frame is the one
-  ;; Xray reads. The browser History listener is installed so button #9's
+  ;; Xray reads. The browser History listener is installed so step #9's
   ;; back/forward emulation has somewhere to land.
   (rf/install-history-listener!)
   (rf/dispatch-sync [:routes-epochs/reset])

--- a/tools/xray/testbeds/runner/core.cljs
+++ b/tools/xray/testbeds/runner/core.cljs
@@ -35,11 +35,24 @@
     is moved on.
 
   - **Runner state = LOCAL ATOM ONLY.** The cursor / status / pace live
-    in a LOCAL Reagent atom OWNED by the runner (the testbed passes it
-    in). It is NEVER written to the inspected app-db (that would pollute
-    the very panels under inspection) and NEVER lives in a second frame
-    (a 2nd frame would appear in Xray's frame surfaces + complicate the
-    observed-frame story). ONLY the inspected app frame is Xray-relevant.
+    in a LOCAL Reagent atom OWNED by the testbed (passed in). It is NEVER
+    written to the inspected app-db (that would pollute the very panels
+    under inspection) and is NOT a Reagent atom that lives in a separate
+    re-frame FRAME — it is a plain component-local atom, invisible to
+    Xray's frame surfaces. A deck supplies ONE atom per runner mount; a
+    deck that mounts the runner more than once (the two-frame isolation
+    testbed mounts the standard-epochs deck once per `:above` / `:below`
+    frame) supplies a DISTINCT local atom per mount, so the two cursors
+    are genuinely independent.
+
+  - **Dispatch is scoped to `host-frame`.** Each step dispatches with an
+    explicit `{:frame host-frame}` opt (see `dispatch+settle!`). A runner
+    control's `on-click` fires OUTSIDE the React frame-provider context,
+    so an un-targeted `(rf/dispatch event)` would land on the ambient
+    `(current-frame-id)` — fine for a single-frame deck (host-frame =
+    `:rf/default`), wrong for a multi-frame mount. Targeting `host-frame`
+    keeps each runner's events scoped to the frame it inspects — the
+    load-bearing rule that lets the two-frame deck stay isolated.
 
   - **Xray focus (manual).** The Step / per-step-run controls dispatch
     WITHOUT moving focus — the operator drives the spine themselves and
@@ -65,12 +78,14 @@
   ## Why a shared ns (the rollout vehicle)
 
   This namespace is the reference RUNNER the managed-http testbed
-  (rf2-6nolv) is the FIRST consumer of. Rolling it across the existing
-  numbered-button decks (machine_epochs, edn_inspector, …) is a
-  SEPARATE follow-up (out of pilot scope); keeping the runner here, in a
-  testbed-shared location, means that rollout is a pure adoption — each
-  deck supplies its own step vector + prefix and drops its bespoke
-  ladder driver.
+  (rf2-6nolv) was the FIRST consumer of. It has since been rolled across
+  the numbered-button decks (machine_epochs, edn_inspector — rf2-rrqku;
+  routes_epochs, standard_epochs — rf2-3xakq); the standard-epochs deck
+  is mounted twice by the two_frame_isolation testbed with a distinct
+  per-frame atom + host-frame. Keeping the runner here, in a testbed-
+  shared location, makes each adoption a pure one — a deck supplies its
+  own step vector + prefix + host-frame and drops its bespoke ladder
+  driver.
 
   ## Boundaries (bundle isolation)
 
@@ -158,18 +173,31 @@
     (swap! state assoc :cursor next-cursor :phase (if more? :idle :done))))
 
 (defn- dispatch+settle!
-  "Dispatch the step's event, mark it the `:active` (last-dispatched) step
-  so the highlight + counter render off it, (optionally) focus the latest
-  host-frame epoch, then schedule the post-dispatch `:settle-ms` wait
-  before advancing. `auto?` controls focus: auto-advance pins focus to
-  latest; a manual single-step leaves focus to the operator."
+  "Dispatch the step's event TO `host-frame`, mark it the `:active` (last-
+  dispatched) step so the highlight + counter render off it, (optionally)
+  focus the latest host-frame epoch, then schedule the post-dispatch
+  `:settle-ms` wait before advancing. `auto?` controls focus: auto-advance
+  pins focus to latest; a manual single-step leaves focus to the operator.
+
+  The dispatch carries an explicit `{:frame host-frame}` opt. A runner
+  control's `on-click` fires OUTSIDE the React render tree's frame-provider
+  context, so `(rf/dispatch event)` alone would resolve to the ambient
+  `(current-frame-id)` — `:rf/default` for a single-frame deck (correct
+  there, since the inspected frame IS `:rf/default`), but the WRONG frame
+  when a deck mounts the runner inside a second frame-provider (e.g. the
+  two-frame isolation testbed mounts the standard-epochs deck once per
+  `:above` / `:below` frame, each with its own runner atom + host-frame).
+  Targeting `host-frame` explicitly keeps each runner's dispatches scoped
+  to the frame it inspects — the load-bearing rule for the per-frame
+  isolation proof. For the single-frame decks this is a no-op (host-frame
+  is `:rf/default`, the same frame the out-of-tree click already targeted)."
   [state steps host-frame {:keys [auto?]}]
   (let [idx (:cursor @state)
         {:keys [event settle-ms] :as step} (nth steps idx)]
     ;; Mark the just-dispatched step active BEFORE the cursor advances, so
     ;; at rest the highlighted row is the one whose epoch is focused.
     (swap! state assoc :active idx :phase :dispatched)
-    (rf/dispatch event)
+    (rf/dispatch event {:frame host-frame})
     (when auto?
       (focus-latest-host-epoch! host-frame))
     (swap! state assoc :phase :settling)

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -1,30 +1,43 @@
 (ns standard-epochs.core
-  "STANDARD-EPOCHS testbed (rf2-gsr6z) — a deliberately simple Xray driving
-  surface that supersedes the step-deck.
+  "STANDARD-EPOCHS testbed (rf2-gsr6z, runner-shaped rf2-3xakq) — a
+  deliberately simple Xray driving surface that supersedes the step-deck.
 
-  ## Shape
+  ## Shape (rf2-3xakq — adopt the shared queued-step RUNNER)
 
-  ONE tall column of NUMBERED buttons, top to bottom. Beside each button
-  a one-line caption says WHAT TO WATCH in Xray when you press it. Each
-  button is ONE test: it fires one event that
+  ONE purple Step button (`<prefix>-step`) walks a step ladder top to
+  bottom while the operator watches how Xray's panels render each step;
+  EVERY step row's index is ALSO a RANDOM-ACCESS RUN-THIS-STEP button
+  (`<prefix>-step-<n>-run`, n = 0-based step index) so any step can be
+  driven directly. The runner (`runner.core`, the rf2-8pbjr pilot) is the
+  shared harness; this deck supplies the `steps` vector (CODE DATA) and is
+  mounted with a runner atom + a host-frame + a testid prefix. Each step
+  DISPATCHES one event that
 
     (a) bumps a shared baseline counter (so App-db / Epoch always show a
-        delta on every press), and
+        delta on every step), and
     (b) exercises exactly ONE additional feature.
 
-  Progressive: button 1 is trivial; each later button layers one more
-  concept. There are NO tabs, NO routing/URL machinery, NO machines, NO
-  SSR — a single frame, plainly mounted, with Xray auto-mounting inline
-  on the right (`[data-rf-xray-host]` + the xray preload) reading that
-  one frame. No frame picker, no action→check meta-strip: the static
-  caption is the 'what to look for', and Xray itself is the check.
+  Progressive: step 1 is trivial; each later step layers one more concept.
+  There are NO tabs, NO routing/URL machinery, NO machines, NO SSR. Read
+  each step's `:watch` note; Xray itself is the check.
+
+  ## Parameterised root (rf2-3xakq — the two-frame mount)
+
+  `root` takes `[runner-state host-frame prefix]`. The single-frame deck
+  (`run`) mounts `[root runner-state :rf/default \"standard-epochs\"]` on
+  the plain default frame, Xray auto-mounting inline. The TWO-FRAME
+  isolation testbed (`two_frame_isolation`) mounts this SAME `root` once
+  per `:above` / `:below` frame-provider, each with its OWN runner atom +
+  host-frame + a DISTINCT prefix — so the two reactive contexts (and the
+  two runner cursors) stay genuinely independent. This is what makes the
+  deck reusable as the two-frame isolation PROOF without sharing a cursor
+  or focusing the wrong frame.
 
   ## North star (acceptance)
 
   Pick ANY ONE Xray panel — Epoch, App-db, Views, Trace, or Issues — and
-  click the buttons top to bottom: that panel is COMPLETELY exercised.
-  The button set is chosen for per-panel coverage completeness, not
-  one-lens-per-button.
+  step through top to bottom: that panel is COMPLETELY exercised. The step
+  set is chosen for per-panel coverage completeness, not one-lens-per-step.
 
   ## Per-panel coverage map
 
@@ -76,7 +89,8 @@
   The events / subs / views below are OWNED here — this deck does NOT
   reuse the shared `testdeck.*` modules (whose coupling to the two-frame
   + routing surfaces is what made the step-deck inflexible)."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent.core :as r]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Flows artefact — load-time hook so `reg-flow` resolves
             ;; (button #5 writes a derived slot via a flow).
@@ -96,7 +110,12 @@
             [day8.re-frame2-xray.config :as xray-config]
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
-            [re-frame.testbed.config :as testbed-config])
+            [re-frame.testbed.config :as testbed-config]
+            ;; The shared queued-step runner (rf2-8pbjr pilot). This deck
+            ;; supplies a `steps` vector; the runner drives the ONE-button
+            ;; series + the per-step RUN buttons. The two-frame testbed
+            ;; mounts `root` twice with a distinct runner atom + host-frame.
+            [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -603,87 +622,141 @@
        "(press #20 once → +1 clean, +2 double-compute)"]]]))
 
 ;; ============================================================================
-;; THE BUTTON LADDER
+;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
 ;; ============================================================================
+;;
+;; Each step: {:event [...] :watch "<what to look for>" :settle-ms N
+;;             :label "<short row label>"}. The runner renders :watch per
+;; STEP, dispatches :event to the deck's host-frame, then waits :settle-ms
+;; before advancing. The ladder walks Events → Views/subscriptions →
+;; Errors/Issues → Reactive (the historical button order 1..20 preserved).
+;;
+;; Settle tuning (rf2-3xakq): most steps are synchronous db transitions —
+;; a short pause is enough for the eye + the panel render. The async steps
+;; get longer settles so the deferred work fires + renders before the
+;; cursor advances:
+;;   - #4 cascade — the follow-on :dispatch lands a second epoch.
+;;   - #6/#9/#10 mount/unmount — a React render tick for the child node
+;;     to appear / disappear + its subs to register / dispose.
+;;   - #17 slow fx (~600ms) — the deferred :standard-epochs/slow-done reply
+;;     must land (status :loading → :loaded) within the settle.
+;;   - #12/#16/#19 exception / rollback steps — a beat for the Issues lens
+;;     to surface the trace + the rolled-back / surviving db to settle.
 
-(def ^:private ladder
-  "The ordered button ladder. Each row: [n label caption event]. `event`
-  is the dispatch vector; nil rows are section separators (label only)."
-  [[:section "Events — Epoch / Trace / App-db scalar"]
-   [1  "Increment"             "App-db :baseline ++ · Epoch: the event, db-before/after"
-    [:standard-epochs/increment]]
-   [2  "Increment + coeffect"  "Epoch event-detail: a `now` coeffect feeds the handler"
-    [:standard-epochs/increment-cofx]]
-   [3  "Increment + effect"    "Effects / Trace: a one-shot fx fires this epoch"
-    [:standard-epochs/increment-fx]]
-   [4  "Increment + cascade"   "Epoch: the dispatch-id tree — a follow-on event"
-    [:standard-epochs/increment-cascade]]
-   [5  "Increment + flow"      "App-db: a reg-flow-derived slot recomputes; Trace shows it"
-    [:standard-epochs/increment-flow]]
-   [:section "Views / subscriptions — sub-driven A vs props-driven B"]
-   [6  "Mount Child A (sub-driven)"  "Views: node + A's sub-cache entries appear (chain L1/L2/L3 + [:gt? 5])"
-    [:standard-epochs/mount-a]]
-   [7  "Change the sub-arg N → 10"   "Views: a NEW cache entry [:gt? 10] (parameterized-sub cache keyed by arg)"
-    [:standard-epochs/set-threshold 10]]
-   [8  "Perturb A's chain input"     "Views: L1→L2→L3 invalidation recompute; A re-renders ← a SUB changed"
-    [:standard-epochs/perturb-chain]]
-   [9  "Unmount Child A"             "Views: node gone; ALL of A's subs disposed (last reader gone); unmount recorded"
-    [:standard-epochs/unmount-a]]
-   [10 "Mount Child B (props-driven)" "Views: node appears with NO subs created"
-    [:standard-epochs/mount-b]]
-   [11 "Change B's prop"             "Views: B re-renders ← PROPS changed (foil to #8's sub-driven re-render)"
-    [:standard-epochs/set-b-prop]]
-   [:section "Errors / Issues — each a real feature, not a buggy demo"]
-   [12 "Exception in the handler"     "Issues: handler-exception + source coord; db rolls back"
-    [:standard-epochs/throw-handler]]
-   [13 "Exception in an interceptor :before" "Issues: interceptor :before exception; handler skipped"
-    [:standard-epochs/throw-interceptor]]
-   [14 "Exception in an interceptor :after"  "Issues: interceptor :after exception; handler ran, threw on the way out (foil to #13)"
-    [:standard-epochs/throw-interceptor-after]]
-   [15 "Exception in a coeffect"      "Issues: cofx error; handler skipped"
-    [:standard-epochs/throw-cofx]]
-   [16 "Exception in an effect"       "Issues: fx error (post-commit, best-effort); db delta survives"
-    [:standard-epochs/throw-fx]]
-   [17 "Slow effect (~600ms)"         "Issues: slow-fx flagged; status loading → loaded"
-    [:standard-epochs/slow]]
-   [18 "Bad event args"               "Issues / Schema-timeline: event-args schema failure"
-    [:standard-epochs/bad-event-args "not-a-number"]]
-   [19 "Bad app-db write"             "Issues: app-db schema failure (survives rollback)"
-    [:standard-epochs/bad-app-db-write]]
-   [:section "Reactive substrate — diamond recompute probe"]
-   [20 "Bump diamond root"            "Diamond c ← a,b ← root: press once; c-recompute count should rise by 1 (clean), 2 = double-compute"
-    [:standard-epochs/bump-diamond]]])
+(def steps
+  [;; -- Events — Epoch / Trace / App-db scalar --
+   {:label     "Increment"
+    :event     [:standard-epochs/increment]
+    :watch     "App-db :baseline ++ · Epoch: the event, db-before/after."
+    :settle-ms 350}
+   {:label     "Increment + coeffect"
+    :event     [:standard-epochs/increment-cofx]
+    :watch     "Epoch event-detail: a `now` coeffect feeds the handler."
+    :settle-ms 350}
+   {:label     "Increment + effect"
+    :event     [:standard-epochs/increment-fx]
+    :watch     "Effects / Trace: a one-shot :standard-epochs/ping fx fires this epoch."
+    :settle-ms 350}
+   {:label     "Increment + cascade"
+    :event     [:standard-epochs/increment-cascade]
+    :watch     "Epoch: the dispatch-id tree — a follow-on :cascade-tail event under one root."
+    :settle-ms 450}
+   {:label     "Increment + flow"
+    :event     [:standard-epochs/increment-flow]
+    :watch     "App-db: the :standard-epochs/derived reg-flow slot recomputes; Trace shows the flow run."
+    :settle-ms 400}
 
-(defn- testid-for [event]
-  (-> (first event) name (str "-button")))
+   ;; -- Views / subscriptions — sub-driven A vs props-driven B --
+   {:label     "Mount Child A (sub-driven)"
+    :event     [:standard-epochs/mount-a]
+    :watch     "Views: the Child-A node + A's sub-cache entries appear (chain L1/L2/L3 + [:gt? 5])."
+    :settle-ms 450}
+   {:label     "Change the sub-arg N → 10"
+    :event     [:standard-epochs/set-threshold 10]
+    :watch     "Views: a NEW cache entry [:gt? 10] (parameterized-sub cache keyed by arg) alongside [:gt? 5]."
+    :settle-ms 400}
+   {:label     "Perturb A's chain input"
+    :event     [:standard-epochs/perturb-chain]
+    :watch     "Views: L1→L2→L3 invalidation recompute; A re-renders ← a SUB changed (not props)."
+    :settle-ms 400}
+   {:label     "Unmount Child A"
+    :event     [:standard-epochs/unmount-a]
+    :watch     "Views: the node is gone; ALL of A's subs are disposed (last reader gone); the unmount is recorded."
+    :settle-ms 450}
+   {:label     "Mount Child B (props-driven)"
+    :event     [:standard-epochs/mount-b]
+    :watch     "Views: the Child-B node appears with NO subs created."
+    :settle-ms 450}
+   {:label     "Change B's prop"
+    :event     [:standard-epochs/set-b-prop]
+    :watch     "Views: B re-renders ← PROPS changed (the foil to step 8's sub-driven re-render)."
+    :settle-ms 400}
 
-(reg-view ladder-button
-  "One numbered ladder row: a numbered button on the left, its caption on
-  the right. Pressing it dispatches the row's event."
-  [n label caption event]
-  [:div {:style {:display "grid" :grid-template-columns "auto 1fr"
-                 :gap "0.75em" :align-items "center" :margin "0.35em 0"}}
-   [:button {:data-testid (testid-for event)
-             :on-click    #(dispatch event)
-             :style {:min-width "16em" :text-align "left"
-                     :padding "0.4em 0.6em" :cursor "pointer"
-                     :border "1px solid #cfc8ff" :border-radius "6px"
-                     :background "#fff"}}
-    [:span {:style {:font-weight "bold" :color "#7C5CFF" :margin-right "0.5em"}}
-     (str n ".")]
-    label]
-   [:span {:style {:color "#666" :font-size "12px"}} caption]])
+   ;; -- Errors / Issues — each a real feature, not a buggy demo --
+   {:label     "Exception in the handler"
+    :event     [:standard-epochs/throw-handler]
+    :watch     "Issues: handler-exception + source coord; the :db (baseline bump) rolls back."
+    :settle-ms 450}
+   {:label     "Exception in an interceptor :before"
+    :event     [:standard-epochs/throw-interceptor]
+    :watch     "Issues: interceptor :before exception; the handler is skipped (chain aborts on the way in)."
+    :settle-ms 450}
+   {:label     "Exception in an interceptor :after"
+    :event     [:standard-epochs/throw-interceptor-after]
+    :watch     "Issues: interceptor :after exception; the handler ran, threw on the way out (foil to step 13)."
+    :settle-ms 450}
+   {:label     "Exception in a coeffect"
+    :event     [:standard-epochs/throw-cofx]
+    :watch     "Issues: cofx error; the handler is skipped (the throw fires during coeffect injection)."
+    :settle-ms 450}
+   {:label     "Exception in an effect"
+    :event     [:standard-epochs/throw-fx]
+    :watch     "Issues: fx error (post-commit, best-effort per the FX atomicity asymmetry); the db delta survives."
+    :settle-ms 450}
+   {:label     "Slow effect (~600ms)"
+    :event     [:standard-epochs/slow]
+    :watch     "Issues: the ~600ms managed fx is flagged slow; status :loading → :loaded once the deferred reply lands."
+    :settle-ms 800}
+   {:label     "Bad event args"
+    :event     [:standard-epochs/bad-event-args "not-a-number"]
+    :watch     "Issues / Schema-timeline: an event-args schema failure (a string where pos-int? is required); the handler is skipped."
+    :settle-ms 450}
+   {:label     "Bad app-db write"
+    :event     [:standard-epochs/bad-app-db-write]
+    :watch     "Issues: an app-db schema failure ([:auth :token] must be a string); the :db rolls back, the issue survives."
+    :settle-ms 450}
 
-(reg-view section-heading
-  "A section separator inside the ladder."
-  [label]
-  [:div {:style {:margin "1em 0 0.25em 0" :font-size "11px" :font-weight "bold"
-                 :color "#7C5CFF" :text-transform "uppercase"
-                 :letter-spacing "0.04em" :border-top "1px dashed #ddd"
-                 :padding-top "0.5em"}}
-   label])
+   ;; -- Reactive substrate — diamond recompute probe --
+   {:label     "Bump diamond root"
+    :event     [:standard-epochs/bump-diamond]
+    :watch     "Diamond c ← a,b ← root: bump the root once; c's recompute count should rise by 1 (clean), 2 = double-compute."
+    :settle-ms 400}])
 
-(reg-view root []
+;; ============================================================================
+;; RUNNER STATE — LOCAL ATOM (rf2-8pbjr: not app-db, not a 2nd frame)
+;; ============================================================================
+;;
+;; The single-frame deck's own runner atom (used by `run`). The two-frame
+;; isolation testbed does NOT use this — it supplies a DISTINCT atom per
+;; frame mount (so the two cursors stay independent), see that testbed's
+;; `core.cljs`.
+
+(defonce runner-state (r/atom (runner/initial-state)))
+
+;; ============================================================================
+;; ROOT — parameterised over (runner-state, host-frame, prefix)
+;; ============================================================================
+;;
+;; rf2-3xakq — `root` takes the runner atom + host-frame + testid prefix so
+;; the deck is mountable BOTH on its own single (`:rf/default`) frame AND
+;; twice (once per `:above` / `:below` frame) by the two-frame isolation
+;; testbed. The reg-view-injected `dispatch` / `subscribe` close over the
+;; surrounding frame-provider's frame id, so the same source drives an
+;; isolated reactive context per mount; the runner dispatches to
+;; `host-frame` explicitly (see runner.core/dispatch+settle!), keeping each
+;; runner's events scoped to the frame it inspects.
+
+(reg-view root [runner-state host-frame prefix]
   [:div {:data-testid "standard-epochs-root"
          :style {:font-family "system-ui, sans-serif" :padding "1em"
                  :max-width "720px"}}
@@ -693,21 +766,22 @@
      "Explore how the " [:code "Epoch"] " panel renders different scenarios. "
      "It is the centerpiece panel, after all."]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "Work your way down the buttons from top to bottom."]]
-   ;; Button 0 — Reset.
-   [:button {:data-testid "reset-button"
-             :on-click #(dispatch [:standard-epochs/reset])
+     "Press " [:strong "⏭ Step"] " to walk the ladder top to bottom (each "
+     "row's number is also a RUN-THIS-STEP button for random access)."]]
+   ;; Reset — re-seed THIS frame's app-db, unmount both child views, rewind
+   ;; this mount's runner. Reset dispatches via the reg-view-injected
+   ;; `dispatch`, so it targets the surrounding frame-provider's frame.
+   [:button {:data-testid (str prefix "-deck-reset")
+             :on-click (fn []
+                         (dispatch [:standard-epochs/reset])
+                         (runner/reset-runner! runner-state))
              :style {:padding "0.4em 0.8em" :cursor "pointer"
                      :border "1px solid #cfc8ff" :border-radius "6px"
                      :background "#f4f1ff" :margin "0.5em 0"}}
-    "0. Reset — re-seed app-db, unmount both child views"]
-   ;; The ladder.
-   (for [row ladder]
-     (if (= :section (first row))
-       ^{:key (second row)} [section-heading (second row)]
-       (let [[n label caption event] row]
-         ^{:key n} [ladder-button n label caption event])))
-   ;; The two children, mounted / unmounted by buttons 6..11. Child A
+    "0. Reset — re-seed app-db, unmount both child views, rewind runner"]
+   ;; The runner — drives the step ladder against this mount's host-frame.
+   [runner/runner prefix runner-state steps host-frame]
+   ;; The two children, mounted / unmounted by steps 6..11. Child A
    ;; (sub-driven) takes the threshold N as a prop — read from
    ;; :views/threshold here so the arg-key is driven by app-db state
    ;; while A owns the actual deref. Child B (props-driven) takes its
@@ -717,7 +791,7 @@
    (when @(subscribe [:standard-epochs/b-mounted?])
      [child-b @(subscribe [:standard-epochs/b-prop])])
    ;; Diamond probe — always mounted so the c ← a,b ← root reaction is live;
-   ;; button #20 bumps the root and the display shows c's recompute count.
+   ;; step #20 bumps the root and the display shows c's recompute count.
    [diamond-display]])
 
 ;; ============================================================================
@@ -735,12 +809,16 @@
 (defn- resolve-project-root []
   (testbed-config/resolve-project-root "tools/xray/testbeds"))
 
+(def host-frame :rf/default)
+
 (defn ^:export run []
   ;; Configure Xray BEFORE `rf/init!` so the preload's auto-open reads the
   ;; right project-root on its first paint of any chip.
   (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
   ;; Single, plain frame — no URL machinery, no history listener (there is
-  ;; no routing here). The default frame is the one Xray reads.
+  ;; no routing here). The default frame is the one Xray reads. Mount the
+  ;; parameterised `root` with this deck's own runner atom, the
+  ;; `:rf/default` host-frame, and the `standard-epochs` testid prefix.
   (rf/dispatch-sync [:standard-epochs/reset])
-  (rdc/render react-root [root]))
+  (rdc/render react-root [root runner-state host-frame "standard-epochs"]))

--- a/tools/xray/testbeds/two_frame_isolation/README.md
+++ b/tools/xray/testbeds/two_frame_isolation/README.md
@@ -12,11 +12,11 @@ left, with a **Xray** instance on the right.
 │  Two-frame isolation             │                  │
 │  ┌────────────────────────────┐  │   Xray          │
 │  │ ABOVE frame  (:above)      │  │   (inline)       │
-│  │ standard-epochs ladder     │  │                  │
+│  │ standard-epochs runner deck│  │                  │
 │  └────────────────────────────┘  │   frame picker   │
 │  ┌────────────────────────────┐  │   switches every │
 │  │ BELOW frame  (:below)      │  │   L2 / L4 panel  │
-│  │ standard-epochs ladder     │  │   between        │
+│  │ standard-epochs runner deck│  │   between        │
 │  └────────────────────────────┘  │   :above /:below │
 └──────────────────────────────────┴──────────────────┘
 ```
@@ -35,7 +35,7 @@ isolated frames.
 
 ## The shared app code path — `standard_epochs` ×2
 
-The app both frames mount is the **standard-epochs button ladder**
+The app both frames mount is the **standard-epochs runner-driven deck**
 (`standard-epochs.core/root`, under
 `tools/xray/testbeds/standard_epochs/`). This testbed
 (`two-frame-isolation.core`) supplies only the two-frame harness: it
@@ -47,6 +47,28 @@ frame-providers — plus the Xray host.
 It does **not** call `standard-epochs.core/run` (which would mount the
 deck once into `#app` on the default frame). It reuses only the
 registrations + the `root` Var.
+
+### Per-frame runner atoms (rf2-3xakq)
+
+`standard-epochs.core/root` was converted to the shared queued-step
+runner (`runner.core`) and parameterised over `[runner-state host-frame
+prefix]`. The runner's cursor lives in a **local Reagent atom** and the
+runner dispatches to its `host-frame` **explicitly** (a runner control's
+`on-click` fires outside the React frame-provider context, so an
+un-targeted dispatch would land on the ambient frame). This testbed
+therefore supplies a **distinct runner atom + the frame's own id + a
+distinct testid prefix per mount**:
+
+| frame    | runner atom          | host-frame | prefix                   |
+| -------- | -------------------- | ---------- | ------------------------ |
+| `:above` | `above-runner-state` | `:above`   | `standard-epochs-above`  |
+| `:below` | `below-runner-state` | `:below`   | `standard-epochs-below`  |
+
+Two genuinely independent runner cursors, each driving events **only**
+into its own frame. Pressing **⏭ Step** (or a numbered RUN-THIS-STEP
+button) in `:above` advances only `:above`'s cursor and moves only
+`:above`'s app-db / sub-cache / epoch history — the load-bearing detail
+that keeps the isolation proof intact under the runner conversion.
 
 > **Why `standard_epochs` ×2 (rf2-wa8my)?** The earlier shape mounted a
 > bespoke `testdeck.*` tabs-as-routes panel. That coupled this testbed
@@ -98,25 +120,33 @@ scenario together cover what the old surface demonstrated.
 
 Open the page; Xray auto-mounts inline on the right. The frame picker
 in the L1 ribbon switches every L2 (Events) and L4 (App-db, Views,
-Trace, …) panel between observing `:above` and `:below`.
+Trace, …) panel between observing `:above` and `:below`. Each frame's
+deck is runner-driven: press **⏭ Step** to walk the ladder, or click a
+numbered **RUN-THIS-STEP** button to drive a specific step directly
+(`standard-epochs-above-step-<n>-run` / `standard-epochs-below-step-<n>-run`,
+n = 0-based).
 
-1. **Frame divergence on the baseline.** Click button **1
-   (Increment)** three times on `:above`. Switch the Xray frame picker
-   to `:below`: the Events list is empty for `:below`; the App-db diff
-   shows no `:baseline` movement.
+1. **Frame divergence on the baseline.** Run step **1 (Increment)**
+   three times on `:above`. Switch the Xray frame picker to `:below`:
+   the Events list is empty for `:below`; the App-db diff shows no
+   `:baseline` movement.
 
-2. **Per-frame Views.** Mount Child A (button **10**) on `:above` only.
-   Switch the picker to `:below`: the Views lens shows no Child-A node
-   and none of its sub-cache entries — A's whole reactive subtree lives
-   only in `:above`'s context.
+2. **Per-frame Views.** Run step **6 (Mount Child A)** on `:above`
+   only. Switch the picker to `:below`: the Views lens shows no Child-A
+   node and none of its sub-cache entries — A's whole reactive subtree
+   lives only in `:above`'s context.
 
-3. **Per-frame Issues.** Press button **16 (throw in the handler)** on
+3. **Per-frame Issues.** Run step **12 (Exception in the handler)** on
    `:below`. The handler-exception surfaces scoped to `:below`; the
    `:above` frame shows no exception.
 
-4. **Per-frame epoch history.** Drive several buttons on `:above`, a
+4. **Per-frame epoch history.** Drive several steps on `:above`, a
    different few on `:below`. The Epoch panel's history differs per
    frame — each frame accumulated only its own dispatches.
+
+5. **Per-frame runner cursor.** Step `:above` three times, `:below`
+   once. Each deck's status chip + highlighted row reflect its OWN
+   cursor — the two runners never share state.
 
 ## Files
 

--- a/tools/xray/testbeds/two_frame_isolation/core.cljs
+++ b/tools/xray/testbeds/two_frame_isolation/core.cljs
@@ -39,11 +39,29 @@
 
   `standard-epochs.core` registers every event / sub / view / cofx / fx /
   flow / schema ONCE globally at namespace load (requiring it below is
-  what installs them); its `root` button-ladder view is the shared app
-  code path both frames render. We do NOT call `standard-epochs.core/run`
-  — that would mount the deck once into `#app` on the default frame. We
+  what installs them); its `root` step-ladder view is the shared app code
+  path both frames render. We do NOT call `standard-epochs.core/run` —
+  that would mount the deck once into `#app` on the default frame. We
   reuse only its registrations + its `root` Var, and supply our own
   two-frame harness + mount here.
+
+  ## Per-frame runner atoms (rf2-3xakq — the isolation-preserving mount)
+
+  `standard-epochs.core/root` was converted to the shared queued-step
+  runner (`runner.core`) and parameterised over `[runner-state host-frame
+  prefix]`. The runner's cursor lives in a LOCAL Reagent atom, and the
+  runner dispatches to its `host-frame` explicitly. So this testbed
+  supplies a DISTINCT runner atom + the frame's own id + a distinct testid
+  prefix per mount:
+
+    :above → (above-runner-state, :above, \"standard-epochs-above\")
+    :below → (below-runner-state, :below, \"standard-epochs-below\")
+
+  Two genuinely independent runner cursors, each driving events ONLY into
+  its own frame — no shared cursor, correct per-frame focus. This is the
+  load-bearing detail that keeps the isolation proof intact under the
+  runner conversion: pressing Step (or a RUN-THIS-STEP button) in `:above`
+  moves ONLY `:above`'s app-db / sub-cache / epoch history.
 
   ## What this proves — per-frame isolation
 
@@ -78,13 +96,15 @@
   (`npm run test:cljs`) + the Xray feature-matrix gate's `multi-frame
   isolation substrate` scenario (on the framework `testbeds/multi_frame`
   surface)."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent.core :as r]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Requiring `standard-epochs.core` installs every handler /
             ;; sub / view / cofx / fx / flow / schema ONCE globally and
-            ;; gives us its `root` button-ladder view. We mount that view
-            ;; twice below; we do NOT call its `run` (which would mount it
-            ;; once into `#app` on the default frame).
+            ;; gives us its `root` step-ladder view. We mount that view
+            ;; twice below (with a distinct per-frame runner atom +
+            ;; host-frame + prefix); we do NOT call its `run` (which would
+            ;; mount it once into `#app` on the default frame).
             [standard-epochs.core :as se]
             [re-frame.adapter.reagent :as reagent-adapter]
             ;; rf2-6jyf6 — Xray's `configure!` to seed `:project-root`
@@ -93,7 +113,12 @@
             [day8.re-frame2-xray.config :as xray-config]
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
-            [re-frame.testbed.config :as testbed-config])
+            [re-frame.testbed.config :as testbed-config]
+            ;; The shared queued-step runner (rf2-8pbjr pilot). We need its
+            ;; `initial-state` to seed a DISTINCT runner atom per frame —
+            ;; the standard-epochs `root` drives the runner, and each
+            ;; mount must own its own cursor for the isolation proof.
+            [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -104,10 +129,24 @@
 (def frame-below :below)
 
 ;; ============================================================================
+;; PER-FRAME RUNNER ATOMS (rf2-3xakq — distinct cursor per mount)
+;; ============================================================================
+;;
+;; The standard-epochs `root` is runner-driven; the runner's cursor lives
+;; in a LOCAL Reagent atom. Each frame mount gets its OWN atom so the two
+;; runner cursors are genuinely independent — pressing Step in `:above`
+;; advances ONLY `:above`'s cursor (and dispatches ONLY into `:above`).
+;; These are NOT app-db, NOT a re-frame frame — plain component-local
+;; atoms invisible to Xray's frame surfaces (the rf2-8pbjr contract).
+
+(defonce above-runner-state (r/atom (runner/initial-state)))
+(defonce below-runner-state (r/atom (runner/initial-state)))
+
+;; ============================================================================
 ;; ROOT VIEW — the standard-epochs ladder mounted twice, one per frame-provider
 ;; ============================================================================
 
-(reg-view frame-card [frame-label]
+(reg-view frame-card [frame-label runner-state host-frame prefix]
   (let [accent (case frame-label
                  "above" "#2b7"
                  "below" "#36c"
@@ -130,11 +169,12 @@
         "(" frame-label ")"]]
       [:span {:style {:font-size "11px" :color "#888"}}
        "isolated reactive context"]]
-     ;; The SHARED app code path: the standard-epochs button ladder. The
-     ;; reg-view-injected dispatch / subscribe close over THIS
+     ;; The SHARED app code path: the standard-epochs runner-driven deck.
+     ;; The reg-view-injected dispatch / subscribe close over THIS
      ;; frame-provider's frame id, so the same view source drives two
-     ;; independent reactive contexts.
-     [se/root]]))
+     ;; independent reactive contexts; the per-frame runner atom +
+     ;; host-frame keep this mount's cursor + dispatches isolated.
+     [se/root runner-state host-frame prefix]]))
 
 (reg-view root []
   [:div {:data-testid "two-frame-isolation-root"
@@ -146,17 +186,18 @@
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
      "Same app — the "
      [:code "standard-epochs"]
-     " button ladder — mounted in two isolated reactive contexts. Each "
+     " step ladder — mounted in two isolated reactive contexts. Each "
      [:code "frame-provider"]
      " below renders the same view source against a separate "
-     [:code "app-db"] " + sub-cache + epoch history. Drive one frame; the "
-     "other stays put. Switch frames in Xray (right) with the frame "
-     "picker to compare trace / events / epochs per frame."]]
+     [:code "app-db"] " + sub-cache + epoch history (and its OWN runner "
+     "cursor). Drive one frame; the other stays put. Switch frames in Xray "
+     "(right) with the frame picker to compare trace / events / epochs per "
+     "frame."]]
    [:div {:style {:display "flex" :flex-direction "column"}}
     [rf/frame-provider {:frame frame-above}
-     [frame-card "above"]]
+     [frame-card "above" above-runner-state frame-above "standard-epochs-above"]]
     [rf/frame-provider {:frame frame-below}
-     [frame-card "below"]]]])
+     [frame-card "below" below-runner-state frame-below "standard-epochs-below"]]]])
 
 ;; ============================================================================
 ;; MOUNT


### PR DESCRIPTION
Completes the `runner.core` rollout begun in rf2-rrqku by converting the two remaining DEFERRED event-deck testbeds. Mike ruled **A — convert both**.

## routes_epochs → runner
- Replaced the bespoke numbered-button ladder (`routes-epochs-rung-<n>`) with a `steps` vector driven by the shared runner. One purple Step button + per-step RUN-THIS-STEP buttons (`routes-epochs-step-<n>-run`).
- Migrated the feature-matrix `routes-epochs routing ladder` scenario to drive rungs OUT OF ORDER (#3, #1, #4, #5, #7, #10, #11) via the runner's per-step buttons — the random-access affordance added by kipb5. Every per-rung mid-series Routing-panel assertion is preserved; the scenario keeps its 1-based rung vocabulary, mapping rung N → step index N-1.
- Fixed the scenario's `:rf/pending-navigation` probe to use the public `re-frame.core/app-db-value` accessor (the former `get-frame-db` was renamed to `app-db-container` in 49c7a6b2b, leaving the guarded probe silently dead).

## standard_epochs + two_frame_isolation → runner (paired)
- Parameterised `standard-epochs.core/root` over `[runner-state host-frame prefix]` so it mounts both on its own single `:rf/default` frame AND twice (once per `:above` / `:below` frame) inside `two_frame_isolation`.
- `two_frame_isolation` supplies a **distinct runner atom + host-frame + testid prefix per mount** (`standard-epochs-above` / `standard-epochs-below`) — two genuinely independent runner cursors.
- The runner now dispatches with an explicit `{:frame host-frame}` opt. A control's `on-click` fires OUTSIDE the React frame-provider context, so an un-targeted `rf/dispatch` would land on the ambient frame; targeting `host-frame` keeps each runner's events scoped to the frame it inspects — the load-bearing rule that keeps the **isolation proof intact**. For the single-frame decks this is a no-op (host-frame = `:rf/default`).
- **The two-frame isolation proof is preserved**: two independent mounts, no shared cursor, correct per-frame focus.
- Settle-ms tuned for the async steps (slow-fx ~600ms → 800ms settle; cascade; mount/unmount; schema rollback).

panel_gallery left untouched (Story gallery, not a runner candidate).

## Quality gates (cold)
- `npx shadow-cljs compile` of all runner-consumer builds (routes-epochs, standard-epochs, two-frame-isolation, machine-epochs, edn-inspector, managed-http) — **0 warnings**.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, 13 matrix rows**. Explicit PASS lines: `routes-epochs routing ladder` (via the runner buttons), `multi-frame isolation substrate` (no regression), `machine-epochs machine ladder`, `managed http and effects rows`, edn-inspector-backed rows. The `:rf/pending-navigation` rung passed (not the known local-only flake).

Closes rf2-3xakq.