### PR TITLE
refactor(xray/testbeds): epochs + edn-inspector intro copy, drop 0.Reset (rf2-7prmj + rf2-c4k20)

### DIFF
--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -5,7 +5,7 @@
 
   ## Shape (rf2-rrqku — adopt the shared queued-step RUNNER)
 
-  ONE button (`▶ Run series`) walks the diff-audit case matrix top to
+  ONE purple `Step` button walks the diff-audit case matrix top to
   bottom while the operator watches how the Xray panels render each
   step. The runner (`runner.core`, the rf2-8pbjr pilot) is the shared
   harness; this deck supplies a `steps` vector (CODE DATA) + a testid
@@ -438,12 +438,6 @@
                    (js/Date.)]))))
 
 ;; ============================================================================
-;; SUBSCRIPTIONS — the on-page mirror of the baseline counter
-;; ============================================================================
-
-(rf/reg-sub :edn-inspector/baseline (fn [db _] (:baseline db)))
-
-;; ============================================================================
 ;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
 ;; ============================================================================
 ;;
@@ -582,21 +576,6 @@
 ;; VIEWS
 ;; ============================================================================
 
-(reg-view baseline-strip
-  "A tiny on-page mirror of the shared baseline counter — keeps the deck
-  legible standalone. The App-db / Epoch panels are the actual check."
-  []
-  (let [baseline @(subscribe [:edn-inspector/baseline])]
-    [:div {:data-testid "edn-inspector-baseline-strip"
-           :style {:border "1px solid #d8d2ff" :border-radius "6px"
-                   :padding "0.5em 0.75em" :margin "0.5em 0"
-                   :background "#fcfbff" :font-size "12px"}}
-     [:span {:style {:font-size "11px" :color "#7C5CFF" :font-weight "bold"
-                     :text-transform "uppercase" :letter-spacing "0.04em"
-                     :margin-right "0.5em"}}
-      "baseline"]
-     [:strong {:data-testid "edn-inspector-baseline"} baseline]]))
-
 (reg-view root []
   [:div {:data-testid "edn-inspector-root"
          :style {:font-family "system-ui, sans-serif" :padding "1em"
@@ -605,26 +584,10 @@
     [:h2 {:data-testid "edn-inspector-title" :style {:margin 0}}
      "Xray Testbed: edn-inspector"]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     [:code "edn-inspector"] " is the value renderer used inside "
-     [:code "xray"] " panels like " [:code "Epoch"] " and " [:code "app-db"]
-     ". One button (" [:strong "▶ Run series"] ") walks its DIFF projection "
-     "across the full datatype matrix — maps · sequentials · empty-vs-removal · "
-     "scalars · multi-adjust · deep/mixed · sentinels · showcase."]
-    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "After each dispatch the runner pins Xray focus to the latest "
-     [:code ":rf/default"] " epoch; read each step's " [:strong "Watch"]
-     " note, then watch the Epoch + App-db panels render the before/after + "
-     "diff through the inspector. The runner cursor lives in a "
-     [:strong "local atom"] " — it never touches the inspected app-db."]]
-   [:button {:data-testid "edn-inspector-deck-reset"
-             :on-click (fn []
-                         (dispatch [:edn-inspector/reset])
-                         (runner/reset-runner! runner-state))
-             :style {:padding "0.4em 0.8em" :cursor "pointer"
-                     :border "1px solid #cfc8ff" :border-radius "6px"
-                     :background "#f4f1ff" :margin "0.25em 0"}}
-    "0. Reset — re-seed the matrix baseline + rewind runner"]
-   [baseline-strip]
+     "This is a test runner for the " [:code "edn-inspector"] " component "
+     "used by " [:code "xray"] " to show data diffs. Click " [:strong "Step"]
+     " below to move from one test case to another, observing the diffs "
+     "shown in xray on the right."]]
    [runner/runner "edn-inspector" runner-state steps host-frame]])
 
 ;; ============================================================================

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -23,15 +23,20 @@
 
   ## Parameterised root (rf2-3xakq — the two-frame mount)
 
-  `root` takes `[runner-state host-frame prefix]`. The single-frame deck
-  (`run`) mounts `[root runner-state :rf/default \"standard-epochs\"]` on
-  the plain default frame, Xray auto-mounting inline. The TWO-FRAME
-  isolation testbed (`two_frame_isolation`) mounts this SAME `root` once
-  per `:above` / `:below` frame-provider, each with its OWN runner atom +
-  host-frame + a DISTINCT prefix — so the two reactive contexts (and the
-  two runner cursors) stay genuinely independent. This is what makes the
-  deck reusable as the two-frame isolation PROOF without sharing a cursor
-  or focusing the wrong frame.
+  `root` is a PURE ladder taking `[runner-state host-frame prefix]` — just
+  the runner + the two children + the diamond probe, NO header, NO reset
+  button (rf2-7prmj). The single-frame deck (`run`) mounts the `standalone`
+  wrapper, which renders the deck's title + intro header ABOVE
+  `[root runner-state :rf/default \"standard-epochs\"]` on the plain default
+  frame, Xray auto-mounting inline. The TWO-FRAME isolation testbed
+  (`two_frame_isolation`) mounts this SAME `root` once per `:above` /
+  `:below` frame-provider, each with its OWN runner atom + host-frame + a
+  DISTINCT prefix — so the two reactive contexts (and the two runner
+  cursors) stay genuinely independent. Keeping the header OUT of `root` is
+  what stops the two-frame cards showing the title twice (mislabel) and
+  leaves them as clean per-frame ladders. This is what makes the deck
+  reusable as the two-frame isolation PROOF without sharing a cursor or
+  focusing the wrong frame.
 
   ## North star (acceptance)
 
@@ -151,7 +156,10 @@
               :diamond-root 0}})
 
 (rf/reg-event-db :standard-epochs/reset
-  {:doc "Button 0 — re-seed app-db and unmount both child views. Start clean."}
+  {:doc "Seed event — re-seed app-db and unmount both child views. Used by
+         `run` (dispatch-sync on load) and by two_frame_isolation's per-frame
+         :on-create. There is no on-page reset button (rf2-7prmj); a reload
+         re-seeds."}
   (fn handler-reset [_db _ev]
     initial-db))
 
@@ -744,15 +752,19 @@
 (defonce runner-state (r/atom (runner/initial-state)))
 
 ;; ============================================================================
-;; ROOT — parameterised over (runner-state, host-frame, prefix)
+;; ROOT — pure ladder, parameterised over (runner-state, host-frame, prefix)
 ;; ============================================================================
 ;;
 ;; rf2-3xakq — `root` takes the runner atom + host-frame + testid prefix so
-;; the deck is mountable BOTH on its own single (`:rf/default`) frame AND
-;; twice (once per `:above` / `:below` frame) by the two-frame isolation
-;; testbed. The reg-view-injected `dispatch` / `subscribe` close over the
-;; surrounding frame-provider's frame id, so the same source drives an
-;; isolated reactive context per mount; the runner dispatches to
+;; the deck is mountable BOTH on its own single (`:rf/default`) frame (via
+;; the `standalone` wrapper below) AND twice (once per `:above` / `:below`
+;; frame) by the two-frame isolation testbed. rf2-7prmj — `root` is now a
+;; PURE ladder (runner + children + diamond): the title + intro header live
+;; in the standalone `run` path only, and there is no deck-reset button, so
+;; the two-frame cards stay clean per-frame ladders (no title duplication,
+;; no per-frame reset). The reg-view-injected `dispatch` / `subscribe` close
+;; over the surrounding frame-provider's frame id, so the same source drives
+;; an isolated reactive context per mount; the runner dispatches to
 ;; `host-frame` explicitly (see runner.core/dispatch+settle!), keeping each
 ;; runner's events scoped to the frame it inspects.
 
@@ -760,25 +772,6 @@
   [:div {:data-testid "standard-epochs-root"
          :style {:font-family "system-ui, sans-serif" :padding "1em"
                  :max-width "720px"}}
-   [:header {:style {:margin-bottom "0.5em"}}
-    [:h2 {:style {:margin 0}} "Standard-epochs"]
-    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "Explore how the " [:code "Epoch"] " panel renders different scenarios. "
-     "It is the centerpiece panel, after all."]
-    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "Press " [:strong "⏭ Step"] " to walk the ladder top to bottom (each "
-     "row's number is also a RUN-THIS-STEP button for random access)."]]
-   ;; Reset — re-seed THIS frame's app-db, unmount both child views, rewind
-   ;; this mount's runner. Reset dispatches via the reg-view-injected
-   ;; `dispatch`, so it targets the surrounding frame-provider's frame.
-   [:button {:data-testid (str prefix "-deck-reset")
-             :on-click (fn []
-                         (dispatch [:standard-epochs/reset])
-                         (runner/reset-runner! runner-state))
-             :style {:padding "0.4em 0.8em" :cursor "pointer"
-                     :border "1px solid #cfc8ff" :border-radius "6px"
-                     :background "#f4f1ff" :margin "0.5em 0"}}
-    "0. Reset — re-seed app-db, unmount both child views, rewind runner"]
    ;; The runner — drives the step ladder against this mount's host-frame.
    [runner/runner prefix runner-state steps host-frame]
    ;; The two children, mounted / unmounted by steps 6..11. Child A
@@ -811,6 +804,28 @@
 
 (def host-frame :rf/default)
 
+;; ============================================================================
+;; STANDALONE WRAPPER — header (title + intro) above the shared `root`
+;; ============================================================================
+;;
+;; rf2-7prmj — the title + intro live HERE, not in the shared `root`, because
+;; `root` is mounted TWICE by `two_frame_isolation` (once per :above / :below
+;; frame). Extracting the header keeps the shared `root` a pure ladder, so the
+;; two-frame cards stay clean (no per-frame title duplication) while the
+;; standalone deck still shows the Epochs header. There is no deck-reset
+;; button: reloading re-seeds via `run` (the frames re-seed via :on-create),
+;; so the manual reset is unnecessary.
+
+(reg-view standalone []
+  [:div {:style {:font-family "system-ui, sans-serif" :max-width "720px"}}
+   [:header {:style {:padding "1em 1em 0 1em"}}
+    [:h2 {:style {:margin 0}} "Xray Testbed: Epochs"]
+    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
+     "The Epoch panel is the centerpiece of xray design. Use the "
+     [:strong "⏭ Step"] " button to see how different pipeline scenarios "
+     "are rendered."]]
+   [root runner-state host-frame "standard-epochs"]])
+
 (defn ^:export run []
   ;; Configure Xray BEFORE `rf/init!` so the preload's auto-open reads the
   ;; right project-root on its first paint of any chip.
@@ -818,7 +833,8 @@
   (rf/init! reagent-adapter/adapter)
   ;; Single, plain frame — no URL machinery, no history listener (there is
   ;; no routing here). The default frame is the one Xray reads. Mount the
-  ;; parameterised `root` with this deck's own runner atom, the
-  ;; `:rf/default` host-frame, and the `standard-epochs` testid prefix.
+  ;; standalone wrapper (header + the parameterised `root`) with this deck's
+  ;; own runner atom, the `:rf/default` host-frame, and the `standard-epochs`
+  ;; testid prefix.
   (rf/dispatch-sync [:standard-epochs/reset])
-  (rdc/render react-root [root runner-state host-frame "standard-epochs"]))
+  (rdc/render react-root [standalone]))


### PR DESCRIPTION
Two cohesive Xray-testbed intro-copy + reset-button cleanups (one PR).

## rf2-7prmj — standard_epochs
`tools/xray/testbeds/standard_epochs/core.cljs`. The shared `root` is mounted **twice** by `two_frame_isolation` (once per `:above`/`:below` frame), so editing its header in place would mislabel the two-frame cards. Per the bead's RECOMMENDED EXTRACT approach:

- Header (title + intro) and the deck-reset button are **extracted OUT** of the shared `root` into a new standalone-only `standalone` wrapper.
- `run` mounts `[standalone]`, which renders the new header — `## Xray Testbed: Epochs` + the one-line intro ("The Epoch panel is the centerpiece of xray design. Use the Step button to see how different pipeline scenarios are rendered.") — above `[root runner-state :rf/default "standard-epochs"]`.
- The shared `root` is now a **pure ladder** (runner + the two children + the diamond probe): no header, no `<prefix>-deck-reset` button.

Net: standalone shows the Epochs header (no reset); the two-frame frame-cards lose the redundant per-frame title + per-frame reset and read as clean per-frame ladders. Frames re-seed via `:on-create`, so the manual reset is unnecessary. Docstrings updated to match; the `:standard-epochs/reset` seed event stays (used by `run`'s `dispatch-sync` + the two-frame `:on-create`).

## rf2-c4k20 — edn_inspector
`tools/xray/testbeds/edn_inspector/core.cljs`.

- New intro copy ("This is a test runner for the edn-inspector component used by xray to show data diffs. Click Step below to move from one test case to another, observing the diffs shown in xray on the right."); retires the stale "Run series" wording (the control is the purple Step button) here and in the ns docstring.
- Remove the `edn-inspector-deck-reset` button — a reload re-seeds via `run`; the `dispatch-sync [:edn-inspector/reset]` on load stays.
- Remove the on-page baseline **widget**: the `baseline-strip` reg-view + its invocation + the now-unused `:edn-inspector/baseline` sub. The app-db `:baseline` counter + the `bump` helper (the per-step delta mechanic) **stay** — only the on-page widget goes.

## Out of scope (held for Mike)
The `0. Reset` removal is **not** extended to the sibling decks (machine_epochs / routes_epochs / managed_http) — that broader sweep is a separate call.

## Quality gates (cold)
- `npx shadow-cljs compile :examples/standard-epochs :examples/edn-inspector :examples/two-frame-isolation` — **0 warnings** each.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures**; the `multi-frame isolation substrate` scenario (two_frame) + edn-inspector rows did not regress. Removed `-deck-reset` testids confirmed unreferenced by any scenario/spec (testbeds test-free per rf2-8cevm).

Closes rf2-7prmj. Closes rf2-c4k20.