### PR TITLE
fix(machines-viz): ELK-route edges + clearance + place labels (rf2-rlq97)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -212,7 +212,23 @@ convention while keeping every event independently click-addressable.
 later **retired** in rf2-0xbgx — events-as-nodes (rf2-qo5xy) moved
 labels onto event-nodes, leaving the edge-label sweep inert; elk
 layout + events-as-nodes makes label-on-node-body collisions a
-non-issue.)
+non-issue.) **rf2-rlq97** then closed the remaining d9ro2 follow-on
+class — d9ro2 sized the node BOXES from their measured DOM, but the
+edges + their clearances were not yet fully ELK-budgeted, so arrows
+could still clip node boxes and densely-packed event-nodes could crowd.
+The fix fed the edges into the ELK graph through the pure
+`chart.projection/->elk-edges` and added edge-to-node / edge-to-edge
+clearance + edge-label-placement keys to `default-elk-options`
+(`elk.spacing.edgeNode`, `elk.layered.spacing.edgeNodeBetweenLayers`,
+`elk.spacing.edgeEdge`, `elk.edgeLabels.placement CENTER`,
+`elk.spacing.edgeLabel`), so ORTHOGONAL routes go AROUND node boxes and
+ELK places any labelled edge's text in a reserved channel — the
+renderer reads ELK's computed label position (`:edge-labels` →
+`:data {:labelPos}`) instead of the middle-segment-midpoint heuristic.
+This stays the deterministic d9ro2 two-pass (measure → one relayout); no
+convergence loop. Self-loops are already dissolved by events-as-nodes
+(a spec self-transition is `state → event-node → state`, two ordinary
+ELK-routed edges), so the renderer-side self-loop fan is fallback-only.
 
 ## §3 — Gap analysis + deliberate divergences
 
@@ -224,7 +240,7 @@ new), and the parity-bar row it serves.
 | # | Gap | Severity | Serves bar | Bead |
 |---|---|---|---|---|
 | **G1** | ✅ **CLOSED (rf2-yoe6e / rf2-g2svr).** Was: a parallel snapshot's `:state` is a region-map `{region path}` with **N active leaves**; `highlight-id` returned nil for a map, so the chart highlighted **none** (or only a degenerate single id). Now: `highlight-ids` resolves the whole `:state` (flat / compound / region-map, nested values → deepest leaf) to the **set** of active-leaf node-ids; `xyflow-graph` threads `:highlight-ids` and marks **every** active leaf, so all N regions light up at once — Stately's §1.2 read. | **High** | §1.2, §1.9 | **contract:** rf2-yoe6e ✅ · **impl:** rf2-g2svr ✅ |
-| **G2** | ✅ **CLOSED (rf2-cz8v6).** Was: edges were beziers between handles; elk's Layered bend-points were discarded (§1.7), so in deep nesting an edge could cut **across** a region/compound container instead of routing **around** it. Now: elk runs `ORTHOGONAL` routing with `elk.json.edgeCoords ROOT`; `compute-layout!` lifts each edge's `sections` bend-points (absolute coords) into the projection (`:edge-points` → `:data {:points}`), and `edges.cljs/edge-path` draws a smooth poly-path THROUGH them — routing around non-incident containers (the [`000-Vision.md`](000-Vision.md) §Quality-bar "no edge-crossing collapse" floor). Self-loops keep their loop path; no-route edges fall back to the bezier; G1's active-edge highlight survives the new path. | **Medium** | §1.7, §1.9 | **impl:** rf2-cz8v6 ✅ |
+| **G2** | ✅ **CLOSED (rf2-cz8v6) → HARDENED (rf2-rlq97).** Was: edges were beziers between handles; elk's Layered bend-points were discarded (§1.7), so in deep nesting an edge could cut **across** a region/compound container instead of routing **around** it. rf2-cz8v6: elk runs `ORTHOGONAL` routing with `elk.json.edgeCoords ROOT`; `compute-layout!` lifts each edge's `sections` bend-points (absolute coords) into the projection (`:edge-points` → `:data {:points}`), and `edges.cljs/edge-path` draws a smooth poly-path THROUGH them — routing around non-incident containers (the [`000-Vision.md`](000-Vision.md) §Quality-bar "no edge-crossing collapse" floor). rf2-rlq97 (d9ro2 follow-on): the edges are fed into the ELK graph through the pure `chart.projection/->elk-edges`, and `default-elk-options` gained edge-to-node / edge-to-edge **clearance** (`elk.spacing.edgeNode`, `elk.layered.spacing.edgeNodeBetweenLayers`, `elk.spacing.edgeEdge`) so routes keep a gap from node boxes (kills the "arrows over states" residue) **plus** label-placement keys (`elk.edgeLabels.placement CENTER`, `elk.spacing.edgeLabel`) so ELK *places* any labelled edge's text in a reserved channel (`:edge-labels` → `:data {:labelPos}`), the renderer painting ELK's position instead of the midpoint heuristic. Self-loops are dissolved by events-as-nodes (`state → event-node → state`), so the renderer-side loop path is fallback-only; no-route edges fall back to the bezier; G1's active-edge highlight survives. | **Medium** | §1.7, §1.9 | **impl:** rf2-cz8v6 ✅ · **harden:** rf2-rlq97 ✅ |
 | **G3** | ✅ **CLOSED (rf2-8jzm1 + rf2-qeemm).** Was: to highlight "the edge that fired this epoch" on the live chart, the host's trace→edge-id mapping had to mint the **same** `edge-id` `chart.layout` mints, and the ids weren't wired through to the canvas. Now: `extract-fired-edge-ids` (rf2-8jzm1) projects the definition through the public `parse-definition` and reads ids off the projected edges — they agree with the live chart **by construction**; rf2-qeemm threads them as `:fired-edge-ids` (set) into `MachineChart`, the projector marks each matching edge `:fired`, and `transition-edge` paints the FIRED treatment (emphasised + animated stroke + `data-fired`) on the live canvas. Matches the EDGE directly so every traversed arm (microsteps, guard-fork candidates) lights up. **Palette delegated to Figma.** | **Medium** | §1.3, §1.8 | **helpers:** rf2-8jzm1 ✅ · **wire:** rf2-qeemm ✅ |
 | **G4** | ✅ **CLOSED (rf2-80rm2).** Was: once G1 lit N region LEAVES, the **region CONTAINER** still read structural-only — an active region was indistinguishable from an inactive one at the zone level. Now: `xyflow-graph` folds a container (region OR compound) into `:active` when any descendant leaf is active — walked UP the `:parent-id` chain every node already carries (reuses the G1 active set; no path-prefix reimplementation). `parallel-region-node` / `compound-node` paint active chrome (solid emphasised boundary + the `:info` active-token glow ring, the same affordance state nodes use), so each active region reads as active at a glance and the N active regions read as a set. **Palette delegated to Figma.** | **Low–Medium** | §1.2 | **impl:** rf2-80rm2 ✅ |
 | **G5** | ✅ **CLOSED (rf2-gpa9k).** Was: elk routes cross-hierarchy edges only when the switch is activated on the top level (§1.7), and while `->elk-input` already set it, **nothing asserted it** — drop the line and no test would catch the regression. Now: the cross-hierarchy switch is `elk.hierarchyHandling INCLUDE_CHILDREN` on the root `layoutOptions`, set by the pure `chart.cljs/elk-layout-options` whenever the graph nests (`:parallel?` OR some node has a `:parent-id` — compound substate or parallel-region leaf); it is what lets the Layered algorithm route edges ACROSS nesting levels (its default `SEPARATE_CHILDREN` lays each level out independently and never routes cross-hierarchy edges). So an edge from a deeply-nested leaf to a top-level state routes cleanly, and G2's bend-points (rf2-cz8v6) come back as legible absolute coords. The capability rode in with G2; rf2-gpa9k extracted the option-computation into the assertable `elk-layout-options` and added the regression guard (nested/parallel ⇒ switch present, flat ⇒ absent, G2 routing keys pinned). | **Low** | §1.7 | **impl:** rf2-cz8v6 ✅ (capability) · **assert:** rf2-gpa9k ✅ |
@@ -319,6 +335,34 @@ not **which colour**.
   renders a **rounded poly-path** through the bend points instead of a
   single bezier between handles. This is what stops an edge cutting
   across a nested container at machine sizes (§1.7).
+- ✅ **Feed edges + clear + place labels in ELK (rf2-rlq97/G2 harden —
+  DONE; d9ro2 follow-on).** The edges are projected into the ELK graph
+  by the pure `chart.projection/->elk-edges` (lifted out of the inline
+  JS-side `mapcat` so the edge-feed is JVM-pinnable, mirroring
+  `->elk-children`), and `default-elk-options` gained the **clearance**
+  keys `elk.spacing.edgeNode` / `elk.layered.spacing.edgeNodeBetweenLayers`
+  / `elk.spacing.edgeEdge`. ORTHOGONAL routing alone draws Manhattan
+  routes but, with no edge-to-node spacing, lets a passing route hug or
+  clip a node box — the "arrows route OVER state nodes" residue d9ro2's
+  node-measure (node↔node sizing) could not converge. The clearance keys
+  reserve the channel so routes go AROUND nodes. For LABELS, ELK now owns
+  placement (`elk.edgeLabels.placement CENTER` + `elk.spacing.edgeLabel`):
+  `->elk-edge` feeds each edge a `:labels` entry carrying the **measured**
+  label box (the edge-label analogue of d9ro2's node measure) when an
+  edge renders its own label; `elk-result->positions` lifts ELK's
+  computed position into `:edge-labels` (`{elk-edge-id {:x :y}}`, the
+  LABEL analogue of `:edge-points`); the projector threads it onto
+  `:data {:labelPos}`; and `edges.cljs/edge-path` anchors the label at
+  ELK's position rather than the middle-segment-midpoint heuristic.
+  **Under events-as-nodes the transition text is on the event-NODE**
+  (already ELK-measured + -placed by d9ro2's measure pass), so the
+  `__in` / `__out` edges carry empty labels, `:edge-labels` is empty, and
+  the midpoint heuristic survives only as the no-ELK-label fallback —
+  but the clearance keys still apply to every route. Stays the
+  deterministic d9ro2 two-pass (measure → one relayout); no convergence
+  loop. The renderer-side self-loop fan is fallback-only (a spec
+  self-transition routes as `state → event-node → state`, two ordinary
+  ELK edges).
 - ✅ **Assert cross-hierarchy edge routing (rf2-gpa9k/G5 — DONE).** The
   top-level cross-hierarchy switch is `elk.hierarchyHandling
   INCLUDE_CHILDREN` on the root `layoutOptions`, set by

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -60,7 +60,7 @@ registry).
 | `:on-state-click` | no | `nil` | `(fn [path] ...)`. Fires when the user clicks a state node; `path` is the clicked node's path. No-op'd when `:read-only?` is true. |
 | `:read-only?` | no | `nil` | When `true`, all `:on-*` callbacks are no-op'd. The viewer page sets this. |
 | `:direction` | no | `:tb` | Layout axis. `:tb` lays the chart top-to-bottom; `:lr` left-to-right. Fed to elkjs as `elk.direction`. |
-| `:layout-options` | no | `nil` | Host-side elkjs `layoutOptions` overrides merged on top of `default-elk-options` (`chart.cljs/default-elk-options`). The `:direction` arg drives `elk.direction`, and the chart auto-sets `elk.hierarchyHandling INCLUDE_CHILDREN` on the root layout whenever the graph nests (parallel regions or compound substates) so elk routes edges ACROSS nesting levels (parity gap G5 / rf2-gpa9k — see `chart.cljs/elk-layout-options`). |
+| `:layout-options` | no | `nil` | Host-side elkjs `layoutOptions` overrides merged on top of `default-elk-options` (`chart.cljs/default-elk-options`). `default-elk-options` carries `elk.edgeRouting ORTHOGONAL` + `elk.json.edgeCoords ROOT` (G2 bend-point routing) plus the edge-clearance keys (`elk.spacing.edgeNode` / `elk.layered.spacing.edgeNodeBetweenLayers` / `elk.spacing.edgeEdge`) and label-placement keys (`elk.edgeLabels.placement CENTER` / `elk.spacing.edgeLabel`) so ELK routes edges *around* nodes and *places* labels in reserved channels (rf2-rlq97). The `:direction` arg drives `elk.direction`, and the chart auto-sets `elk.hierarchyHandling INCLUDE_CHILDREN` on the root layout whenever the graph nests (parallel regions or compound substates) so elk routes edges ACROSS nesting levels (parity gap G5 / rf2-gpa9k — see `chart.cljs/elk-layout-options`). |
 | `:density` | no | `:regular` | Density variant — `:compact` / `:regular` / `:cosy`. Resolves the geometry + typography map via `visual-constants/chart-for-density`; the resolved map is threaded through the projector onto every node/edge `:data` so the xyflow node/edge components render at the chosen density. The chart root surfaces the resolved density as `data-density`. `nil` ≡ `:regular`; an unknown density throws at render time. Per [§Density](#density) and rf2-32gw5. |
 | `:height` | no | `"100%"` | Outer wrapper height (CSS string). xyflow requires a non-zero parent height. |
 | `:show-minimap?` | no | `false` | When `true`, render xyflow's built-in MiniMap. |
@@ -342,6 +342,34 @@ falls back to the bezier. *(Before rf2-r636q the consumer looked up the
 bare `<spec-edge-id>`, which the producer never emits post-rf2-qo5xy, so
 G2 routing was silently dead — every edge fell back to a straight
 bezier.)*
+
+**Edges + labels are ELK-routed/-placed, not renderer-drawn
+(rf2-rlq97).** The edges are *fed into* the ELK graph
+(`chart.projection/->elk-edges` — the pure projector lifted out of
+`chart.cljs/->elk-input`, JVM-pinnable like the node feed), and the root
+`default-elk-options` carry the edge-clearance keys
+(`elk.spacing.edgeNode` / `elk.layered.spacing.edgeNodeBetweenLayers` /
+`elk.spacing.edgeEdge`) so the `ORTHOGONAL` routing goes *around* node
+boxes instead of clipping them (closes the "arrows route over states"
+class d9ro2's node-measure did not). ELK also owns edge-LABEL
+PLACEMENT: `default-elk-options` sets `elk.edgeLabels.placement CENTER`
++ `elk.spacing.edgeLabel`, `->elk-edge` feeds each edge a `:labels`
+entry (carrying the MEASURED label box — the edge-label analogue of
+d9ro2's node measure — when an edge renders its own label), and
+`elk-result->positions` lifts ELK's computed position into the
+`:edge-labels` map (`{elk-edge-id {:x :y}}`, the LABEL analogue of
+`:edge-points`). The projector threads it onto the edge `:data
+{:labelPos}` and `chart.edges/edge-path` anchors the label THERE
+instead of the old middle-segment-midpoint heuristic. **Under
+events-as-nodes the transition text rides on the event-NODE** (already
+ELK-measured + -placed via `elk-event-child` + the d9ro2 measure pass),
+so the `__in` / `__out` edges carry an empty label, `:edge-labels` is
+empty, and the geometric midpoint anchor remains only as the
+no-ELK-label fallback. There is also no live self-loop edge to special-
+case: a spec self-transition projects as `state → event-node → state`
+(two ordinary edges, both ELK-routed), so the renderer-side self-loop
+fan + the cross-hierarchy source-bend anchor in `chart.edges` are
+fallback-only paths, never hit by the live chart.
 
 elkjs lays out event-nodes as siblings of their source state's
 parent container: an event declared inside a compound substate nests

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -107,14 +107,52 @@
       per-container origin. xyflow hands the custom edge component
       ABSOLUTE `sourceX`/`sourceY`/… so the lifted bend-points must be
       in the same frame; `ROOT` makes elk do that rebasing for us
-      (added ELK 0.9; elkjs 0.11 wraps a newer core)."
+      (added ELK 0.9; elkjs 0.11 wraps a newer core).
+
+  rf2-rlq97 — edge-CLEARANCE + label-placement keys. ORTHOGONAL routing
+  (above) computes Manhattan routes, but without dedicated edge-to-node
+  spacing elk lets a route hug — or clip — a node box it passes, which
+  is the 'arrows route OVER state nodes' symptom Mike reported. Three
+  spacing knobs reserve the channels:
+
+    - `elk.spacing.edgeNode` (24) — the minimum gap elk keeps between an
+      edge segment and ANY node box it routes past. This is the key that
+      pushes a passing route AROUND a node instead of across it.
+    - `elk.layered.spacing.edgeNodeBetweenLayers` (24) — the same
+      clearance applied between layers (the Layered algorithm's
+      per-layer analogue of `spacing.edgeNode`).
+    - `elk.spacing.edgeEdge` (16) — minimum gap between two parallel
+      edge segments so bundled routes (several transitions between the
+      same layers) read as distinct lines, not one fused thick stroke.
+
+  And the label-placement keys (the edge-label analogue of d9ro2's
+  node-measure feed; today the transition text is on the event-NODE so
+  edges carry empty labels, but the keys make elk reserve a channel for
+  any MEASURED edge label `projection/->elk-edge` feeds in future):
+
+    - `elk.edgeLabels.placement` (CENTER) — elk places a non-empty edge
+      label on the route, centred, and budgets space for it so two
+      labels never overlap (the renderer then reads elk's computed label
+      position instead of the old middle-segment-midpoint heuristic).
+    - `elk.spacing.edgeLabel` (6) — gap between a label box and its
+      edge."
   {"elk.algorithm"                              "layered"
    "elk.direction"                              "DOWN"
    "elk.spacing.nodeNode"                       "40"
    "elk.layered.spacing.nodeNodeBetweenLayers"  "70"
    "elk.layered.crossingMinimization.strategy"  "LAYER_SWEEP"
    "elk.edgeRouting"                            "ORTHOGONAL"
-   "elk.json.edgeCoords"                        "ROOT"})
+   "elk.json.edgeCoords"                        "ROOT"
+   ;; rf2-rlq97 — edge-to-node + edge-to-edge clearance so ORTHOGONAL
+   ;; routes go AROUND node boxes (kills arrows-over-states) and bundled
+   ;; edges stay visually distinct.
+   "elk.spacing.edgeNode"                       "24"
+   "elk.layered.spacing.edgeNodeBetweenLayers"  "24"
+   "elk.spacing.edgeEdge"                       "16"
+   ;; rf2-rlq97 — elk places + reserves space for any non-empty edge
+   ;; label (the renderer reads back elk's position; see `chart.edges`).
+   "elk.edgeLabels.placement"                   "CENTER"
+   "elk.spacing.edgeLabel"                      "6"})
 
 (defn elk-direction-str
   "Map the chart's `:lr` / `:tb` direction keyword to elk's
@@ -178,30 +216,29 @@
   render) is threaded into `projection/->elk-children` so leaf states +
   event-nodes lay out at their REAL size, floored by the min constants.
   nil on the first pass; the measure-then-relayout lifecycle in
-  `MachineChart` supplies it on the second pass."
-  [{:keys [edges] :as parsed} direction layout-options measured-dims]
+  `MachineChart` supplies it on the second pass.
+
+  rf2-rlq97 — the EDGES are projected by the pure
+  `projection/->elk-edges` (lifted out of an inline `mapcat` here so the
+  JVM corpus pins the edge-feed). They carry the events-as-nodes
+  `__in` / `__out` split + optional MEASURED edge-label dims (the
+  edge-label analogue of d9ro2's node measure; nil today since the
+  transition text rides on the event-NODE — see `projection/->elk-edge`).
+  Feeding edges INTO elk (alongside the spacing + label-placement keys in
+  `default-elk-options`) is what makes elk's Layered algorithm route the
+  edges AROUND node boxes instead of the renderer drawing geometric paths
+  that cut across states."
+  [parsed direction layout-options measured-dims]
   #js {:id "root"
        :layoutOptions (clj->js (elk-layout-options parsed layout-options
                                                    direction))
        :children (clj->js (projection/->elk-children parsed measured-dims))
-       :edges (clj->js
-                (vec
-                  (mapcat
-                    (fn [e]
-                      (let [ev-id (projection/event-node-id e)]
-                        (cond-> [{:id      (str (:id e) "__in")
-                                  :sources [(:source e)]
-                                  :targets [ev-id]
-                                  :labels  [{:text ""}]}]
-                          ;; Internal self-transitions (omit :target) have
-                          ;; no outgoing edge — the event-node 'hangs and
-                          ;; ends' per the Stately convention.
-                          (not (:internal? e))
-                          (conj {:id      (str (:id e) "__out")
-                                 :sources [ev-id]
-                                 :targets [(:target e)]
-                                 :labels  [{:text ""}]}))))
-                    edges)))})
+       ;; rf2-rlq97 — edge-label dims share the `measured-dims` map (it is
+       ;; keyed by elk-edge-id for any labelled edge); under events-as-nodes
+       ;; the transition text is on the event-node so this is normally a
+       ;; no-op, but threading it keeps the edge-feed symmetric with the
+       ;; node-feed and ready for a labelled edge type.
+       :edges (clj->js (projection/->elk-edges parsed measured-dims))})
 
 (defn elk-edge-points
   "rf2-cz8v6 (G2) — lift one elk edge's routed bend-points into a flat
@@ -237,9 +274,40 @@
     (when (> (count pts) 1)
       (vec pts))))
 
+(defn elk-edge-label-pos
+  "rf2-rlq97 — lift an elk edge's COMPUTED label position into a
+  `{:x :y}` map (absolute / flow coords under `elk.json.edgeCoords
+  ROOT`), or nil when elk placed no label (the events-as-nodes default,
+  where the transition text rides on the event-NODE so the edge's label
+  is empty and elk reserves no slot for it).
+
+  elk attaches the placed label as the first entry of the edge's
+  `labels` array with an `x` / `y` it computed (centred on the route per
+  `elk.edgeLabels.placement CENTER`). A label with no `x` (elk did not
+  place it — empty text) lifts to nil so the renderer keeps its
+  geometric anchor. This is the LABEL analogue of `elk-edge-points`: elk
+  owns label PLACEMENT, the renderer just paints where elk says, killing
+  the old middle-segment-midpoint heuristic for any labelled edge."
+  [^js edge]
+  (let [labels (or (.-labels edge) #js [])]
+    (when (pos? (alength labels))
+      (let [^js l (aget labels 0)
+            x     (.-x l)
+            y     (.-y l)]
+        (when (and (number? x) (number? y))
+          {:x x :y y})))))
+
 (defn elk-result->positions
   "Adapter: elk.js JS result → `{:positions {node-id {:x :y :width
-  :height}} :edge-points {edge-id [{:x :y} …]}}`.
+  :height}} :edge-points {edge-id [{:x :y} …]} :edge-labels {edge-id
+  {:x :y}}}`.
+
+  rf2-rlq97 — `:edge-labels` carries elk's COMPUTED label position per
+  edge (the LABEL analogue of `:edge-points`'s routed bend-points). It is
+  empty under events-as-nodes (the transition text rides on the
+  event-NODE so edges carry no label for elk to place); a labelled edge
+  type would populate it and the renderer would paint at elk's position
+  instead of the geometric midpoint.
 
   Public-by-convention as a test seam (mirrors `elk-edge-points` /
   `invoke-elk-layout!`): the rf2-r636q regression bridges this PRODUCER
@@ -277,15 +345,25 @@
   path."
   [elk-result]
   (let [positions   (atom {})
-        edge-points (atom {})]
+        edge-points (atom {})
+        ;; rf2-rlq97 — elk's COMPUTED edge-label positions (keyed by elk
+        ;; edge id), the label analogue of `:edge-points`. Empty under
+        ;; events-as-nodes (the transition text is on the event-node so
+        ;; edges carry no label for elk to place); populated for any
+        ;; labelled edge so the renderer reads elk's position rather than
+        ;; the geometric midpoint heuristic.
+        edge-labels (atom {})]
     (letfn [(collect-edges! [^js node]
               (let [edges (or (.-edges node) #js [])
                     n     (alength edges)]
                 (dotimes [i n]
                   (let [e   (aget edges i)
-                        pts (elk-edge-points e)]
+                        pts (elk-edge-points e)
+                        lp  (elk-edge-label-pos e)]
                     (when pts
-                      (swap! edge-points assoc (.-id e) pts))))))
+                      (swap! edge-points assoc (.-id e) pts))
+                    (when lp
+                      (swap! edge-labels assoc (.-id e) lp))))))
             (walk! [^js node]
               (collect-edges! node)
               (let [children (or (.-children node) #js [])
@@ -300,7 +378,8 @@
                     (walk! c)))))]
       (walk! elk-result))
     {:positions   @positions
-     :edge-points @edge-points}))
+     :edge-points @edge-points
+     :edge-labels @edge-labels}))
 
 ;; ---- error reporting (rf2-4lyvh) ----------------------------------------
 ;;
@@ -717,7 +796,9 @@
         ;; route edges around nested containers. Starts empty (no
         ;; positions, no routes) — the pre-layout render falls back to
         ;; origin + bezier until the async elk pass resolves.
-        layout-state  (r/atom {:positions {} :edge-points {}})
+        ;; rf2-rlq97 — `:edge-labels` (elk's computed label positions)
+        ;; joins the same atom; empty until the async elk pass resolves.
+        layout-state  (r/atom {:positions {} :edge-points {} :edge-labels {}})
         layout-key    (r/atom nil)
         ;; rf2-set3x — auto-fit lifecycle.
         ;;
@@ -953,7 +1034,8 @@
                 to-highlight-id   (layout/highlight-id to-highlight)
                 callback          (when-not read-only? on-state-click)
                 edge-callback     (when-not read-only? on-edge-click)
-                {:keys [positions edge-points layout-error]} @layout-state
+                {:keys [positions edge-points edge-labels layout-error]}
+                @layout-state
                 {:keys [nodes edges]}
                 (projection/xyflow-graph parsed
                               positions
@@ -967,6 +1049,12 @@
                                ;; points; the projector attaches each
                                ;; edge's route to its :data {:points}.
                                :edge-points       edge-points
+                               ;; rf2-rlq97 — elk's computed label
+                               ;; positions; the projector attaches each
+                               ;; labelled edge's position to :data
+                               ;; {:labelPos} (empty under events-as-nodes,
+                               ;; where the label rides on the event-node).
+                               :edge-labels       edge-labels
                                ;; rf2-qeemm (G3) — the fired-this-epoch
                                ;; edge-id set; the projector marks each
                                ;; matching edge :fired. nil → #{} default.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -9,9 +9,13 @@
 
   ## Edge kinds (per the bead's scope §Custom edges)
 
-    - `transition-edge` — the canonical edge. Renders a curved
-      path between source/target with the event label sitting at
-      the midpoint behind a small backplate rect.
+    - `transition-edge` — the canonical edge. Renders the route ELK
+      computed (a smooth poly-path THROUGH ELK's bend-points, rf2-cz8v6)
+      with the event label sitting where ELK placed it (rf2-rlq97 —
+      `:labelPos`, ELK's reserved label channel) behind a small
+      backplate rect. When ELK placed no label (the events-as-nodes
+      default — the transition text rides on the event-NODE) the anchor
+      falls back to a geometric midpoint heuristic.
     - `after-edge` — `:after`-timer edge. Same path as transition-
       edge but renders the label as `after(<ms>)` and exposes a
       `:data-after-ms` attr so a host-side overlay can find the
@@ -249,15 +253,21 @@
     2. elk route     → when `points` is a JS array of ≥ 2 `#js {:x :y}`,
        a smooth poly-path THROUGH the bends so the edge goes AROUND
        nested containers (`:routed? true`).
-       rf2-shv82 (Issue 3): when `cross-hierarchy?` is true the label
-       anchors near the SOURCE-SIDE first bend point (just outside the
-       container the edge exits) instead of the routed midpoint — the
-       Stately Studio convention for cross-hierarchy edges (whose
-       midpoint can land far from the visual origin).
+       rf2-rlq97: the LABEL anchor is elk's COMPUTED label position
+       (`label-pos` `{:x :y}`, fed from `chart.edges`'s
+       `elk.edgeLabels.placement`) when elk placed one — so a labelled
+       edge's text sits in the collision-free channel elk reserved, NOT
+       at a renderer-side heuristic. When elk placed NO label (the
+       events-as-nodes default — the transition text rides on the
+       event-NODE so the edge carries no label), the anchor falls back
+       to the geometric heuristic:
+         rf2-shv82 (Issue 3): cross-hierarchy edges anchor near the
+         SOURCE-SIDE first bend point (just outside the container the
+         edge exits); other edges use the routed middle-segment midpoint.
     3. bezier        → `getBezierPath` between the handles (`:routed?
        false`) — the no-bend-point fallback."
   [{:keys [src-x src-y tgt-x tgt-y src-pos tgt-pos
-           self-loop? points loop-index cross-hierarchy?]}]
+           self-loop? points loop-index cross-hierarchy? label-pos]}]
   (let [routed? (and (not self-loop?)
                      (some? points)
                      (> (alength points) 1))]
@@ -268,8 +278,16 @@
         {:d d :label-x label-x :label-y label-y :routed? false})
 
       routed?
-      (let [[lx ly] (if cross-hierarchy?
+      (let [[lx ly] (cond
+                      ;; rf2-rlq97 — elk placed the label: paint there.
+                      (and label-pos
+                           (number? (:x label-pos))
+                           (number? (:y label-pos)))
+                      [(:x label-pos) (:y label-pos)]
+                      ;; No elk label (events-as-nodes default): heuristic.
+                      cross-hierarchy?
                       (cross-hierarchy-label-anchor points)
+                      :else
                       (path-midpoint points))]
         {:d (poly-path points) :label-x lx :label-y ly :routed? true})
 
@@ -393,6 +411,13 @@
         ;; multi-point route; nil for a simple edge (bezier fallback)
         ;; and for self-loops (which keep their dedicated loop path).
         points     (.-points d)
+        ;; rf2-rlq97 — elk's COMPUTED label position (a `#js {:x :y}`,
+        ;; absolute coords) for a labelled edge; nil under events-as-nodes
+        ;; (the label rides on the event-node so the edge carries none).
+        ;; When present, `edge-path` anchors the label here — elk's
+        ;; reserved channel — instead of the geometric midpoint heuristic.
+        label-pos  (let [lp (.-labelPos d)]
+                     (when lp {:x (.-x lp) :y (.-y lp)}))
         ;; rf2-j10sm (Phase 2, B) — multi-event same-`[source target]`
         ;; collapse. The projector groups edges by their `[source target]`
         ;; pair and assigns each a `:siblingIndex` 0..N-1 + a
@@ -427,7 +452,10 @@
                     :self-loop? self-loop?
                     :points points
                     :loop-index loop-index
-                    :cross-hierarchy? cross-hierarchy?})
+                    :cross-hierarchy? cross-hierarchy?
+                    ;; rf2-rlq97 — elk's computed label placement (nil →
+                    ;; geometric heuristic fallback).
+                    :label-pos label-pos})
         stroke  (edge-stroke {:active? active? :focused? focused? :fired? fired?})
         stroke-w (edge-stroke-width {:active? active? :focused? focused?
                                      :fired? fired? :chart vc})]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout_error.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout_error.cljc
@@ -34,7 +34,7 @@
         bloat the bus.
 
     - `(layout-error-result err parsed direction layout-options)`
-        → `{:positions {} :edge-points {}
+        → `{:positions {} :edge-points {} :edge-labels {}
             :layout-error {:error <error-data>
                            :input-summary <summary>}}`
         The callback result-map handed to `done-fn` on failure. The
@@ -90,12 +90,17 @@
 
 (defn layout-error-result
   "Build the result-map the layout callback receives on ELK failure.
-  Empty `:positions` + `:edge-points` (the projector still renders,
-  every node at default origin — same as a pre-layout commit) plus
-  `:layout-error` so the chart can paint the in-panel indicator
-  banner. Pure fn."
+  Empty `:positions` + `:edge-points` + `:edge-labels` (the projector
+  still renders, every node at default origin — same as a pre-layout
+  commit) plus `:layout-error` so the chart can paint the in-panel
+  indicator banner. Pure fn.
+
+  rf2-rlq97 — `:edge-labels` mirrors the success-path
+  `elk-result->positions` shape (elk's computed edge-label positions);
+  empty on failure, same as `:edge-points`."
   [error parsed direction layout-options]
   {:positions    {}
    :edge-points  {}
+   :edge-labels  {}
    :layout-error {:error         (error->data error)
                   :input-summary (input-summary parsed direction layout-options)}})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -237,6 +237,100 @@
                                 (mapv #(dissoc % ::event-parent)))]
     (vec (concat top-state-children top-event-children)))))
 
+;; ---- elk.js EDGE projection (rf2-rlq97) ---------------------------------
+;;
+;; rf2-rlq97 — the elk EDGE descriptors are projected here (pure data),
+;; mirroring `->elk-children` for nodes. Before rf2-rlq97 the elk edge
+;; objects were built inline in `chart.cljs/->elk-input` (a `mapcat` over
+;; the parsed edges) — JS-side and JVM-unloadable, so the edges that ELK
+;; routes the topology AROUND were never pinned at the cheap JVM layer.
+;; Lifting them into `->elk-edge` here lets the projection test corpus
+;; assert the edge-feed (ids + endpoints + label dims) the same way it
+;; pins the node-feed.
+;;
+;; Each parsed transition is decomposed into the events-as-nodes
+;; (rf2-qo5xy) edge pair:
+;;
+;;   source-state ─→ event-node   (`<spec-edge-id>__in`)
+;;   event-node   ─→ target-state (`<spec-edge-id>__out`; omitted for
+;;                                  internal transitions, which have no
+;;                                  `:target`)
+;;
+;; ## Edge labels (rf2-rlq97)
+;;
+;; The xstate-style transition text (`event [guard] / action`) rides on
+;; the event-NODE (`xyflow-graph` event-nodes; the event-node is the
+;; events-as-nodes analogue of a Stately edge label and is ALREADY
+;; measured + ELK-laid-out via `elk-event-child` + the d9ro2 measure
+;; pass). So the `__in` / `__out` edges themselves carry NO visible
+;; label, and ELK must reserve NO label channel for them — feeding label
+;; dims onto BOTH the event-node AND its incident edges would
+;; double-budget the same text.
+;;
+;; `->elk-edge` therefore takes an optional `label-dims` map but uses it
+;; ONLY for an edge that genuinely renders its OWN label in the renderer
+;; (none today under events-as-nodes; the parameter keeps the helper
+;; honest + future-proof — a labelled edge type added later threads its
+;; MEASURED `{:width :height}` here so ELK's `edgeLabels.placement`
+;; reserves space). A nil entry emits an empty zero-size label, which
+;; ELK treats as no label to place. This is the edge-label analogue of
+;; d9ro2's node measure: dims flow from the rendered DOM into the ELK
+;; input rather than being a renderer-side heuristic.
+
+(defn elk-edge-label
+  "rf2-rlq97 — build the elk edge `labels` entry for an edge. `text` is
+  the visible label string (\"\" when the label rides on the event-node,
+  which is the events-as-nodes default). `dims` is the optional MEASURED
+  `{:width :height}` of the rendered label; nil emits a zero-size label
+  ELK treats as nothing to place. Returns a single-label vector (elk's
+  `labels` is always an array)."
+  [text dims]
+  [(cond-> {:text (or text "")}
+     (and dims (pos? (:width dims 0)) (pos? (:height dims 0)))
+     (assoc :width (:width dims) :height (:height dims)))])
+
+(defn ->elk-edge
+  "rf2-rlq97 — project ONE parsed transition into its elk edge
+  descriptor(s) under the events-as-nodes paradigm (rf2-qo5xy):
+
+    [{:id \"<spec-id>__in\"  :sources [src]   :targets [ev]    :labels …}
+     {:id \"<spec-id>__out\" :sources [ev]    :targets [tgt]   :labels …}]
+
+  The `__out` edge is OMITTED for an internal transition (no `:target`)
+  — its event-node hangs with no outgoing arrow per the Stately
+  convention.
+
+  `label-dims` is the optional `{elk-edge-id {:width :height}}` map of
+  MEASURED rendered-label boxes, threaded through from the measure pass
+  the same way `->elk-children` threads node `measured-dims`. Keyed by
+  the elk edge id (`<spec-id>__in` / `__out`). Under events-as-nodes the
+  visible text is on the event-NODE so these entries are normally absent
+  and the edges carry empty labels — see the section comment above."
+  ([e] (->elk-edge e nil))
+  ([e label-dims]
+   (let [ev-id  (event-node-id e)
+         in-id  (str (:id e) "__in")
+         out-id (str (:id e) "__out")]
+     (cond-> [{:id      in-id
+               :sources [(:source e)]
+               :targets [ev-id]
+               :labels  (elk-edge-label "" (get label-dims in-id))}]
+       (not (:internal? e))
+       (conj {:id      out-id
+              :sources [ev-id]
+              :targets [(:target e)]
+              :labels  (elk-edge-label "" (get label-dims out-id))})))))
+
+(defn ->elk-edges
+  "rf2-rlq97 — project ALL parsed edges into the flat elk `edges` vector
+  `chart.cljs/->elk-input` `clj->js`-es onto the elk root graph. The
+  events-as-nodes split (`->elk-edge`) means N parsed transitions emit
+  up to 2N elk edges. `label-dims` (optional measured-label map) is
+  forwarded to every `->elk-edge`."
+  ([parsed] (->elk-edges parsed nil))
+  ([{:keys [edges]} label-dims]
+   (vec (mapcat #(->elk-edge % label-dims) edges))))
+
 ;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
 
 (defn choose-edge-type
@@ -334,6 +428,22 @@
                            emits post-rf2-qo5xy, so every lookup missed
                            and the whole feature silently fell back to
                            beziers — a dead G2.)
+    :edge-labels         — rf2-rlq97. A map `{elk-edge-id {:x :y}}` of
+                           elk's COMPUTED label positions (absolute /
+                           flow coords; the LABEL analogue of
+                           `:edge-points`). Keyed by the same
+                           `<spec-edge-id>__in` / `__out` elk edge ids.
+                           When present for an edge, the projector
+                           attaches it to that edge's `:data {:labelPos}`
+                           and `chart.edges/transition-edge` paints the
+                           label at elk's placement instead of the
+                           geometric middle-segment midpoint — so a
+                           labelled edge's text sits where elk reserved a
+                           collision-free channel. Empty under
+                           events-as-nodes (the transition text rides on
+                           the event-NODE, ELK-placed already), so this
+                           is normally `{}` and the edge keeps its
+                           geometric anchor. Defaults to `{}`.
     :fired-edge-ids      — rf2-qeemm (closes parity gap G3). A SET of
                            canonical edge-ids (the EXACT `:id` scheme
                            `chart.layout` mints) that fired THIS epoch.
@@ -369,8 +479,10 @@
   [{:keys [nodes edges]}
    positions
    {:keys [highlight-id highlight-ids from-highlight-id to-highlight-id sim?
-           on-state-click on-edge-click edge-points fired-edge-ids chart]
-    :or   {chart vc/chart-regular edge-points {} fired-edge-ids #{}}}]
+           on-state-click on-edge-click edge-points edge-labels
+           fired-edge-ids chart]
+    :or   {chart vc/chart-regular edge-points {} edge-labels {}
+           fired-edge-ids #{}}}]
   (let [;; rf2-g2svr (G1) — the active set unifies the single-active
         ;; (`:highlight-id`) and multi-active (`:highlight-ids`) cases.
         ;; A PARALLEL machine's snapshot has N simultaneously-active
@@ -571,7 +683,13 @@
                       ;; every lookup missed and the feature fell back to
                       ;; beziers — silently dead post-rf2-qo5xy.)
                       in-points    (get edge-points (str (:id e) "__in"))
-                      out-points   (get edge-points (str (:id e) "__out"))]
+                      out-points   (get edge-points (str (:id e) "__out"))
+                      ;; rf2-rlq97 — elk's computed label positions for
+                      ;; the two segments (LABEL analogue of the routes).
+                      ;; Empty under events-as-nodes (label is on the
+                      ;; event-node); present for any labelled edge.
+                      in-label-pos  (get edge-labels (str (:id e) "__in"))
+                      out-label-pos (get edge-labels (str (:id e) "__out"))]
                   {:edge      e
                    :event-id  event-id
                    :variant   variant
@@ -584,7 +702,9 @@
                    :internal? internal?
                    :cross-hier? cross-hier?
                    :in-points  in-points
-                   :out-points out-points}))
+                   :out-points out-points
+                   :in-label-pos  in-label-pos
+                   :out-label-pos out-label-pos}))
               edges)
         ;; Event-nodes — one per parsed transition. The xyflow node
         ;; renderer (`chart.nodes.event-node`) paints the event header
@@ -636,7 +756,7 @@
         ;; "this state handles this event".
         inbound-edges
         (mapv (fn [{:keys [edge ev-node-id from-active? focused? fired?
-                           cross-hier? in-points]}]
+                           cross-hier? in-points in-label-pos]}]
                 {:id        (str (:id edge) "__in")
                  :source    (:source edge)
                  :target    ev-node-id
@@ -670,6 +790,10 @@
                              ;; container. nil when elk emitted no route
                              ;; (bezier fallback).
                              :points     in-points
+                             ;; rf2-rlq97 — elk's computed label position
+                             ;; (nil under events-as-nodes; the renderer
+                             ;; falls back to its geometric anchor).
+                             :labelPos   in-label-pos
                              :internal   false
                              :machineLevel (boolean (:machine-level? edge))
                              :eventId    nil
@@ -690,7 +814,7 @@
         (->> edge-descriptors
              (remove (fn [{:keys [internal?]}] internal?))
              (mapv (fn [{:keys [edge ev-node-id focused? fired? from-active?
-                                cross-hier? out-points]}]
+                                cross-hier? out-points out-label-pos]}]
                      {:id        (str (:id edge) "__out")
                       :source    ev-node-id
                       :target    (:target edge)
@@ -722,6 +846,10 @@
                                   ;; the producer actually emits (was the
                                   ;; bare canonical id → always missed).
                                   :points     out-points
+                                  ;; rf2-rlq97 — elk's computed label
+                                  ;; position (nil under events-as-nodes;
+                                  ;; renderer falls back to geometric anchor).
+                                  :labelPos   out-label-pos
                                   :internal   false
                                   :machineLevel (boolean (:machine-level? edge))
                                   :eventId    nil
@@ -793,6 +921,10 @@
                                ;; crosses a container); :points nil so
                                ;; the every-edge :data shape stays whole.
                                :points nil
+                               ;; rf2-rlq97 — entry edges carry no label
+                               ;; (unlabelled marker→state hop), so no elk
+                               ;; label position; nil keeps the shape whole.
+                               :labelPos nil
                                :internal false :machineLevel false
                                :eventId nil :fromPath nil :toPath nil
                                :onClick on-edge-click :chart chart}})

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/edges_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/edges_cljs_test.cljs
@@ -77,6 +77,40 @@
     (let [edge (->edge [(->section (pt 5 5) [] (pt 5 5))])]
       (is (nil? (chart/elk-edge-points edge))))))
 
+;; ---- elk-edge-label-pos: ELK's computed label placement (rf2-rlq97) ----
+;;
+;; ELK owns edge-label PLACEMENT (the label analogue of ELK owning the
+;; route via `elk-edge-points`). `elk-edge-label-pos` lifts the position
+;; ELK computed for an edge's first label into a {:x :y} map (absolute
+;; coords under `edgeCoords ROOT`), or nil when ELK placed no label
+;; (the events-as-nodes default — the edge label is empty, the text is
+;; on the event-NODE).
+
+(defn- ->edge-with-label [sections lbl]
+  #js {:sections (apply array sections)
+       :labels   (array lbl)})
+
+(deftest elk-edge-label-pos-lifts-placed-position
+  (testing "rf2-rlq97 — ELK placed a label at (x,y); lift it to {:x :y}"
+    (let [edge (->edge-with-label
+                 [(->section (pt 0 0) [] (pt 0 100))]
+                 #js {:text "evt" :x 33 :y 77 :width 40 :height 16})]
+      (is (= {:x 33 :y 77} (chart/elk-edge-label-pos edge))))))
+
+(deftest elk-edge-label-pos-nil-without-labels
+  (testing "rf2-rlq97 — no labels array (or empty) → nil (geometric
+            fallback in the renderer)"
+    (is (nil? (chart/elk-edge-label-pos #js {})))
+    (is (nil? (chart/elk-edge-label-pos #js {:labels #js []})))))
+
+(deftest elk-edge-label-pos-nil-when-unplaced
+  (testing "rf2-rlq97 — a label ELK did NOT place (no x/y — empty-text
+            label under events-as-nodes) lifts to nil"
+    (let [edge (->edge-with-label
+                 [(->section (pt 0 0) [] (pt 0 100))]
+                 #js {:text "" :width 0 :height 0})]
+      (is (nil? (chart/elk-edge-label-pos edge))))))
+
 ;; ---- elk-layout-options: the G5 cross-hierarchy switch ------------------
 ;;
 ;; `chart/elk-layout-options` is the pure root `layoutOptions` computation
@@ -202,6 +236,51 @@
       ;; middle segment is (0,100)→(100,100): midpoint (50,100).
       (is (= 50 label-x))
       (is (= 100 label-y)))))
+
+(deftest edge-path-prefers-elk-label-position
+  (testing "rf2-rlq97 — when ELK supplies a computed label position
+            (`:label-pos`), the routed edge anchors the label THERE (the
+            collision-free channel ELK reserved) instead of the geometric
+            middle-segment midpoint"
+    (let [points (array (pt 0 0) (pt 0 100) (pt 100 100) (pt 100 200))
+          ;; The geometric midpoint would be (50,100); ELK placed it at
+          ;; (140, 60) — the label MUST honour ELK's position.
+          {:keys [label-x label-y routed?]}
+          (edges/edge-path (assoc base-coords
+                                  :self-loop? false
+                                  :points points
+                                  :label-pos {:x 140 :y 60}))]
+      (is (true? routed?))
+      (is (= 140 label-x) "label honours ELK's computed x")
+      (is (= 60 label-y) "label honours ELK's computed y"))))
+
+(deftest edge-path-elk-label-position-beats-cross-hierarchy-anchor
+  (testing "rf2-rlq97 — ELK's placement wins even over the cross-hierarchy
+            source-bend heuristic (ELK reserved the channel knowing the
+            full graph; the heuristic is only the no-ELK-label fallback)"
+    (let [points (array (pt 0 0) (pt 0 120) (pt 160 120) (pt 160 200))
+          {:keys [label-x label-y]}
+          (edges/edge-path (assoc base-coords
+                                  :self-loop? false
+                                  :points points
+                                  :cross-hierarchy? true
+                                  :label-pos {:x 200 :y 10}))]
+      (is (= 200 label-x) "ELK position overrides the cross-hierarchy anchor")
+      (is (= 10 label-y)))))
+
+(deftest edge-path-no-elk-label-falls-back-to-geometric
+  (testing "rf2-rlq97 — with NO ELK label position (the events-as-nodes
+            default — label is on the event-node, edge carries none) the
+            routed edge keeps its geometric midpoint anchor (regression
+            guard that the fallback is intact)"
+    (let [points (array (pt 0 0) (pt 0 100) (pt 100 100) (pt 100 200))
+          {:keys [label-x label-y]}
+          (edges/edge-path (assoc base-coords
+                                  :self-loop? false
+                                  :points points
+                                  :label-pos nil))]
+      (is (= 50 label-x) "no ELK label → middle-segment midpoint x")
+      (is (= 100 label-y) "no ELK label → middle-segment midpoint y"))))
 
 (deftest edge-path-two-point-route-is-a-straight-line
   (testing "rf2-cz8v6 — a degenerate two-point route (no interior bend)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_error_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_error_cljs_test.cljc
@@ -128,6 +128,9 @@
       (is (map? result) "result is a map (so `when result` reset!s)")
       (is (= {} (:positions result)) "positions empty on failure")
       (is (= {} (:edge-points result)) "edge-points empty on failure")
+      ;; rf2-rlq97 — :edge-labels mirrors :edge-points (ELK's computed
+      ;; label positions); empty on failure, same as the routes.
+      (is (= {} (:edge-labels result)) "edge-labels empty on failure")
       (is (some? (:layout-error result)) ":layout-error slot present")
       (is (= "bad input"
              (get-in result [:layout-error :error :message]))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -1072,6 +1072,148 @@
         (is (every? #(= projection/state-node-min-width (:width %)) leaves)
             "every leaf at the width floor when unmeasured")))))
 
+;; ---- ->elk-edge / ->elk-edges (rf2-rlq97) ------------------------------
+;;
+;; The edges ARE fed into the ELK graph (this is what lets the Layered
+;; algorithm route them AROUND node boxes instead of the renderer drawing
+;; geometric paths that cut across states). `->elk-edge` is the pure
+;; projector for one transition's `__in` / `__out` ELK edge pair, lifted
+;; out of the inline `mapcat` that used to live JS-side in
+;; `chart.cljs/->elk-input` so the edge-feed is pinnable at the JVM layer.
+
+(deftest elk-edge-emits-in-and-out-for-external-transition
+  (testing "rf2-rlq97 — an external transition (has :target) feeds TWO
+            ELK edges: source-state → event-node (__in) and event-node →
+            target-state (__out), so ELK routes both segments around any
+            intervening node"
+    (let [parsed   (layout/parse-definition idle-loading)
+          idle-id  (layout/node-id [:idle])
+          start    (->> (:edges parsed)
+                        (filter #(= idle-id (:source %)))
+                        first)
+          ev-id    (projection/event-node-id start)
+          elk-eds  (projection/->elk-edge start)]
+      (is (= 2 (count elk-eds)) "external transition → __in + __out")
+      (let [in-e  (first (filter #(= (str (:id start) "__in")  (:id %)) elk-eds))
+            out-e (first (filter #(= (str (:id start) "__out") (:id %)) elk-eds))]
+        (is (some? in-e))  (is (some? out-e))
+        (is (= [idle-id] (:sources in-e)) "__in source is the source state")
+        (is (= [ev-id]   (:targets in-e)) "__in target is the event-node")
+        (is (= [ev-id]   (:sources out-e)) "__out source is the event-node")
+        (is (= [(:target start)] (:targets out-e))
+            "__out target is the transition target state")))))
+
+(deftest elk-edge-omits-out-for-internal-transition
+  (testing "rf2-rlq97 — an internal transition (no :target) feeds ONLY
+            the __in ELK edge; the event-node hangs with no outgoing
+            arrow (Stately convention)"
+    (let [parsed  (layout/parse-definition internal-self-machine)
+          tick    (first (:edges parsed))
+          elk-eds (projection/->elk-edge tick)]
+      (is (true? (:internal? tick)) "fixture is an internal transition")
+      (is (= 1 (count elk-eds)) "internal transition → __in only")
+      (is (= (str (:id tick) "__in") (:id (first elk-eds)))))))
+
+(deftest elk-edge-carries-labels-array
+  (testing "rf2-rlq97 — every ELK edge carries a :labels array (ELK
+            requires one). Under events-as-nodes the transition text is
+            on the event-NODE so the edge label text is empty + carries
+            NO measured dims (feeding dims on both the node AND its edges
+            would double-budget the same text)"
+    (let [parsed   (layout/parse-definition idle-loading)
+          idle-id  (layout/node-id [:idle])
+          start    (->> (:edges parsed)
+                        (filter #(= idle-id (:source %)))
+                        first)
+          elk-eds  (projection/->elk-edge start)]
+      (doseq [e elk-eds]
+        (is (vector? (:labels e)) "labels is a vector")
+        (is (= 1 (count (:labels e))) "exactly one label entry")
+        (is (= "" (:text (first (:labels e)))) "empty text (label on node)")
+        (is (not (contains? (first (:labels e)) :width))
+            "no measured width fed (no double-budget)")))))
+
+(deftest elk-edge-label-feeds-measured-dims-when-present
+  (testing "rf2-rlq97 — a labelled edge (one whose label-dims map carries
+            its elk-edge-id) gets its MEASURED width/height fed into the
+            ELK label so ELK reserves a placement channel — the edge-label
+            analogue of d9ro2's node measure"
+    (let [parsed   (layout/parse-definition idle-loading)
+          idle-id  (layout/node-id [:idle])
+          start    (->> (:edges parsed)
+                        (filter #(= idle-id (:source %)))
+                        first)
+          in-id    (str (:id start) "__in")
+          dims     {in-id {:width 88 :height 18}}
+          elk-eds  (projection/->elk-edge start dims)
+          in-e     (first (filter #(= in-id (:id %)) elk-eds))
+          lbl      (first (:labels in-e))]
+      (is (= 88 (:width lbl)) "measured label width fed to ELK")
+      (is (= 18 (:height lbl)) "measured label height fed to ELK"))))
+
+(deftest elk-edge-label-ignores-zero-dims
+  (testing "rf2-rlq97 — a zero-size measured label (a node still awaiting
+            measurement) is treated as no label so ELK reserves nothing"
+    (is (= [{:text ""}] (projection/elk-edge-label "" {:width 0 :height 0})))
+    (is (= [{:text ""}] (projection/elk-edge-label "" nil)))))
+
+(deftest elk-edges-flattens-all-transitions
+  (testing "rf2-rlq97 — `->elk-edges` flattens every parsed transition's
+            __in/__out pair into the flat ELK `edges` vector
+            `->elk-input` clj->js-es onto the root graph. The id set
+            matches the `:edge-points` producer/consumer key scheme
+            (`<spec-id>__in` / `__out`)"
+    (let [parsed   (layout/parse-definition idle-loading)
+          elk-eds  (projection/->elk-edges parsed)
+          ids      (set (map :id elk-eds))
+          ;; idle-loading: :start (external), :after (external), :always
+          ;; (external) — all have targets, so 3 transitions × 2 = 6 edges.
+          n-ext    (count (remove :internal? (:edges parsed)))
+          n-int    (count (filter :internal? (:edges parsed)))]
+      (is (= (+ (* 2 n-ext) n-int) (count elk-eds))
+          "each external transition → 2 ELK edges, each internal → 1")
+      (is (every? #(or (re-find #"__in$" %) (re-find #"__out$" %)) ids)
+          "every ELK edge id ends in __in or __out (the route key scheme)")
+      (is (= (count elk-eds) (count ids)) "no duplicate edge ids"))))
+
+;; ---- :edge-labels → :data {:labelPos} (rf2-rlq97) ----------------------
+;;
+;; ELK owns edge-label PLACEMENT now (the edge-label analogue of ELK
+;; owning node placement). The projector attaches ELK's computed label
+;; position to the labelled edge's `:data {:labelPos}` so the renderer
+;; paints where ELK reserved a collision-free channel instead of a
+;; renderer-side midpoint heuristic.
+
+(deftest xyflow-graph-attaches-elk-label-position-to-edge-data
+  (testing "rf2-rlq97 — when :edge-labels carries an ELK-computed
+            position for an edge, the projector threads it onto that
+            edge's :data {:labelPos}; an edge with no entry gets nil"
+    (let [parsed   (layout/parse-definition idle-loading)
+          idle-id  (layout/node-id [:idle])
+          start    (->> (:edges parsed)
+                        (filter #(= idle-id (:source %)))
+                        first)
+          in-id    (str (:id start) "__in")
+          out-id   (str (:id start) "__out")
+          graph    (projection/xyflow-graph
+                     parsed {}
+                     {:edge-labels {in-id {:x 42 :y 99}}})
+          xy-in    (edge-by-id graph in-id)
+          xy-out   (edge-by-id graph out-id)]
+      (is (= {:x 42 :y 99} (:labelPos (:data xy-in)))
+          "ELK label position threaded onto the inbound edge")
+      (is (nil? (:labelPos (:data xy-out)))
+          "an edge with no ELK label position gets nil (geometric fallback)"))))
+
+(deftest xyflow-graph-edge-labels-defaults-empty
+  (testing "rf2-rlq97 — omitting :edge-labels (events-as-nodes default)
+            leaves every edge's :labelPos nil so the renderer keeps its
+            geometric anchor"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})]
+      (is (every? #(nil? (:labelPos (:data %))) (:edges graph))
+          "no ELK labels fed → every edge :labelPos nil"))))
+
 ;; ---- initial-state markers + self-loops (rf2-54s5a) --------------------
 
 (deftest xyflow-graph-emits-initial-marker-node-and-entry-edge


### PR DESCRIPTION
Closes rf2-rlq97 (P2, d9ro2 follow-on).

## Problem

Mike observed (2026-06-03) the MachineChart topology still overlaps after d9ro2 (#2875, which sized the NODE boxes from their measured DOM): arrows could route **over** state nodes and event-nodes could crowd. d9ro2 fixed node↔node sizing; this fixes the edge/label class it could not converge.

## Root cause

Edges were already fed to ELK + routed (rf2-cz8v6 ORTHOGONAL bend-points), but:
- ELK was given **no edge-to-node clearance**, so a passing ORTHOGONAL route could hug/clip a node box — the "arrows over states" symptom.
- Edge labels had **no ELK placement** — the renderer anchored them at a geometric middle-segment midpoint heuristic.

## Fix (stays the deterministic d9ro2 two-pass — measure → one relayout, no convergence loop)

1. **Feed edges into ELK as a pure projector.** New `chart.projection/->elk-edge` / `->elk-edges` / `elk-edge-label`, lifted out of the inline JS-side `mapcat` in `chart.cljs/->elk-input` so the edge-feed is JVM-pinnable (mirrors `->elk-children`). They carry the events-as-nodes `__in`/`__out` split + optional **measured** edge-label dims (the edge-label analogue of d9ro2's node measure).
2. **Edge clearance + label placement in `default-elk-options`.** Added `elk.spacing.edgeNode`, `elk.layered.spacing.edgeNodeBetweenLayers`, `elk.spacing.edgeEdge` (routes go *around* nodes) and `elk.edgeLabels.placement CENTER` + `elk.spacing.edgeLabel` (ELK reserves a label channel).
3. **Render ELK's computed label position.** `elk-edge-label-pos` lifts ELK's placed label position; `elk-result->positions` returns `:edge-labels` (the LABEL analogue of `:edge-points`); the projector threads it onto `:data {:labelPos}`; `edges.cljs/edge-path` anchors the label there, falling back to the geometric midpoint only when ELK placed no label.

## Events-as-nodes reconciliation

Under events-as-nodes (rf2-qo5xy) the transition text rides on the event-**NODE** (already ELK-measured + -placed by d9ro2's measure pass), so the `__in`/`__out` edges carry empty labels and `:edge-labels` is empty — but the **clearance keys apply to every route**, which is the live fix for arrows-over-nodes. Self-loops are dissolved by events-as-nodes (`state → event-node → state`, two ordinary ELK edges), so the renderer-side self-loop fan is fallback-only (flagged in the spec). The label-placement machinery is exercised + future-proof for any labelled edge type.

## Spec updates (xray-specs-current rule)

- `001-Topology-Parity.md`: G2 row hardened, §3.2 + §4.3 updated.
- `API.md`: `:edge-points`/`:edge-labels` paragraph + `:layout-options` row.

## Gates (cold)

- `shadow-cljs compile node-test` — clean rebuild, **0 warnings**.
- `npm run test:cljs` — **5469 tests / 18887 assertions, 0 failures**.
- machines-viz JVM `clojure -M:test` — **315 tests / 839 assertions, 0 failures**.
- New unit assertions pin the edge-feed (edges + measured label dims into ELK input) and the `:edge-labels` → `:labelPos` thread + `edge-path` ELK-position preference. Verified executing via a deliberate-fail probe (then reverted).

## Visual check

A real-elkjs probe on an events-as-nodes graph (`A → ev → B` with a non-incident sibling `C`) confirmed: both `__in`/`__out` segments route with bend-point sections and **zero routed points land over a non-incident node box** — arrows route around nodes. With the label-placement keys, any labelled edge's text sits in the ELK-reserved channel rather than the midpoint heuristic, so labels no longer overlap.