### PR TITLE
refactor(xray/testbeds): runner builds per-row :on-run thunks for step-row (rf2-9dpqj)

### DIFF
--- a/tools/xray/testbeds/runner/core.cljs
+++ b/tools/xray/testbeds/runner/core.cljs
@@ -332,11 +332,16 @@
   Carries a stable per-step `data-testid` (`<prefix>-step-<n>`).
 
   The index is a clickable RUN-THIS-STEP button (`<prefix>-step-<n>-run`)
-  that drives exactly this step via `run-step-at!` (random-access, manual
-  — no focus pinning). The single Step control remains the primary
+  that drives exactly this step by invoking the bound `on-run` thunk
+  (random-access, manual — no focus pinning). `on-run` is a 0-arg fn the
+  RUNNER builds (closing over `state` / `steps` / `host-frame` / `n`), so
+  the leaf row carries ONLY what it renders — its own `step` / `n` /
+  `current?` / `done?` plus that bound action — NOT the whole `steps`
+  vector, the runner `state` atom, or the `host-frame` id (none of which a
+  leaf view should know). The single Step control remains the primary
   affordance; this lets an operator (or a scenario) drive any step
   directly without a parallel bespoke button ladder."
-  [prefix state steps host-frame n step current? done?]
+  [prefix n step current? done? on-run]
   [:div {:data-testid (str prefix "-step-" n)
          :style {:display "grid" :grid-template-columns "auto 1fr"
                  :gap "0.75em" :align-items "baseline" :margin "0.25em 0"
@@ -345,7 +350,7 @@
                  :background (cond current? "#f1ecff" done? "#fafafa" :else "#fff")}}
    [:button {:data-testid (str prefix "-step-" n "-run")
              :title "Run this step"
-             :on-click #(run-step-at! state steps host-frame n)
+             :on-click #(on-run)
              :style {:font-weight "bold" :cursor "pointer"
                      :padding "0.1em 0.45em" :border-radius "5px"
                      :border (if current? "1px solid #7C5CFF" "1px solid #e3def9")
@@ -379,10 +384,15 @@
       (map-indexed
         (fn [n step]
           ^{:key n}
-          ;; Highlight + 'done' shading render off `:active` (the just-run
-          ;; step), so at rest the highlighted row matches the focused epoch.
-          ;; Before the first step `:active` is nil → no row highlighted.
-          [step-row prefix state steps host-frame n step
+          ;; The runner has `state` / `steps` / `host-frame` in scope, so it
+          ;; binds each row a 0-arg `:on-run` thunk over `run-step-at!` and
+          ;; passes the leaf only what it renders — NOT the whole steps vector,
+          ;; the state atom, or the host-frame id. Highlight + 'done' shading
+          ;; render off `:active` (the just-run step), so at rest the
+          ;; highlighted row matches the focused epoch. Before the first step
+          ;; `:active` is nil → no row highlighted.
+          [step-row prefix n step
            (= n active)
-           (and (some? active) (< n active))])
+           (and (some? active) (< n active))
+           #(run-step-at! state steps host-frame n)])
         steps)]]))


### PR DESCRIPTION
## What

The shared queued-step runner (`tools/xray/testbeds/runner/core.cljs`) threaded its imperative plumbing — the full `steps` vector, the runner `state` atom, AND `host-frame` (`:rf/default`) — all the way down to the leaf `step-row` view, because each row's run-this-step button called `(run-step-at! state steps host-frame n)`. Since `step-row` is rendered ~26× (one per step), each leaf render carried the WHOLE `steps` vector as an arg → the Xray Epoch Views section showed 26 renders each dumping the full vector (enormous + redundant), and `:rf/default` leaked into every leaf view signature (harness plumbing in the view layer).

## Fix

The runner view already has `state` / `steps` / `host-frame` in scope, so it now binds each row a 0-arg `:on-run` thunk closing over `(run-step-at! state steps host-frame n)` and passes the leaf `step-row` only what it renders — its own `step` / `n` / `current?` / `done?` plus that bound action. `step-row`'s signature drops to `[prefix n step current? done? on-run]`: no more `steps` vector, no `state` atom, no `host-frame` id.

This removes the enormous `steps` arg AND the `:rf/default` frame-id AND the state atom from every leaf row in one move, and it is better re-frame practice (pass a leaf component a bound action, not bulk data + a frame id it only needs to build a callback).

## Scope / contract

- Internal to the runner. The **public mount signature `[runner/runner prefix state steps host-frame]` is UNCHANGED** — no runner-consumer testbed deck (machine-epochs / edn-inspector / managed-http / standard-epochs / routes-epochs) needs editing.
- Per-row `<prefix>-step-<n>-run` `data-testid` + behaviour identical (the feature gate drives them).
- xray spec unchanged — the runner is testbed-internal and not documented under `tools/xray/spec/*`.

## Gates (cold)

- `npx shadow-cljs compile :examples/machine-epochs` — Build completed, **0 warnings**.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, 13 matrix rows covered** (1 unrelated pre-existing SKIP: schema-violation timeline → CLJS migration rf2-w1mnq). No `routes-epochs` flake this run. Ran on a pinned port (`XRAY_FEATURE_GATE_PORT`) because the default 8037 was held by a concurrent worker's (it4vt) server.

## Views-section confirmation

Each `step-row` leaf render's args are now just its own `step` map, the small scalars, and an opaque closure — so the Xray Epoch Views section no longer dumps the full `steps` vector per row, and `:rf/default` no longer appears in any leaf view args. Trims the runner-side cause of the sibling Xray Views elision bead (rf2-yi0nr).

Closes rf2-9dpqj.