### PR TITLE
feat(xray/epoch): render machine [START] badge (eager + lazy) + retire e6q97 (rf2-it4vt)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1384,11 +1384,16 @@ never win for a macrostep):
 2. `:rf.machine/action-ran` present → `:reg-machine` (subsumed by (1) for any
    real macrostep; retained for fixtures / defence in depth).
 3. `:rf.machine.event/unhandled-no-op` present → `:reg-machine` (rf2-ugdas —
-   see below; once rf2-e6q97 suppresses the spurious `{X}→{X}` commit
-   transition, a no-op-only cascade carries neither a transition nor an
-   action, so it needs its own predicate).
-4. `:rf.fx/do-fx` present → `:reg-event-fx`.
-5. else → `:reg-event-db`.
+   see below; since rf2-coozg suppresses the no-change `{X}→{X}` commit
+   transition at the source, a no-op-only cascade carries neither a
+   transition nor an action, so it needs its own predicate).
+4. `:rf.machine/started` present → `:reg-machine` (rf2-it4vt — an EAGER pure
+   start emits the birth signal but NO transition / action / no-op rows;
+   without this predicate the standalone start would fall through to
+   `:reg-event-fx` (the machine handler always rides its snapshot-write
+   do-fx) and render a raw `:db` diff instead of the `[START]` row).
+5. `:rf.fx/do-fx` present → `:reg-event-fx`.
+6. else → `:reg-event-db`.
 
 #### Machine cascade (rf2-u69j7)
 
@@ -1410,14 +1415,15 @@ entry action, which mis-reads the statechart (the operator expects
 therefore RE-SORTS rows into the canonical `(kind, phase)` order:
 
 ```
-guard → exit → TRANSITION → entry → always → after-action → timer
+START → guard → exit → TRANSITION → entry → always → after-action → timer
 ```
 
 via a STABLE sort keyed by `[cascade-row-rank :trace-index]` — rows in
 the same rank keep their substrate emit order (multiple actions in one
-phase keep their run order). The `:transition` KIND sits between the
-exit-phase actions and the entry-phase actions; `:guard` leads (guards
-gate the transition); `:timer` trails (post-commit housekeeping).
+phase keep their run order). The `:start` KIND leads everything (rank -1 —
+the machine's birth — rf2-it4vt); the `:transition` KIND sits between the
+exit-phase actions and the entry-phase actions; `:guard` follows START
+(guards gate the transition); `:timer` trails (post-commit housekeeping).
 `:transition`-phase actions rank WITH the transition (they fire as part
 of the state change); `:initial-entry` ranks with `:entry`,
 `:destroy-exit` with `:exit`. The `:step` ordinal is assigned 1..N over
@@ -1438,11 +1444,65 @@ The projection walks `:trace-events` and surfaces every member of
 
   | Trace op                            | Row `:kind`     |
   |-------------------------------------|------------------|
+  | `:rf.machine/started`               | `:start`         |
   | `:rf.machine/guard-evaluated`       | `:guard`         |
   | `:rf.machine/action-ran`            | `:action`        |
   | `:rf.machine/transition`            | `:transition`    |
   | `:rf.machine.timer/cancelled`       | `:timer`         |
   | `:rf.machine.event/unhandled-no-op` | `:no-op`         |
+
+**The `[START]` row (rf2-it4vt).** The `:start` row surfaces the machine's
+BIRTH — the `:rf.machine/started` trace `maybe-boot` (machines · lifecycle_fx
+· registration.cljc) emits per rf2-gl588 / F‴ on every successful
+initial-entry cascade. It is the machine's single birth signal, in BOTH
+creation paths, and renders the `[START]` badge at the FRONT of the cascade
+(rank -1):
+
+- **EAGER** — an explicit `[:machine-id [:rf.machine/start]]` dispatch gets
+  its own epoch. The start is a PURE init-kick (rf2-gl588 — runs the
+  initial-entry cascade then STOPS, emitting NO transition / action rows),
+  so the `[START]` is the cascade's SOLE row (a standalone birth). The
+  cascade's handler-flavour is forced `:reg-machine` by the
+  `:rf.machine/started` presence even though no transition / action / no-op
+  fired — otherwise the standalone start (which always rides the machine
+  handler's snapshot-write do-fx) would mis-classify `:reg-event-fx` and
+  render a raw `:db` diff instead of the `[START]` row.
+- **LAZY** — when a machine is first reached by a REAL event, init folds
+  into THAT event's epoch (`maybe-boot` runs ahead of the user event in the
+  same handler call). So `[START]` renders at the FRONT of the cascade,
+  AHEAD of the real event's guard / transition / action rows — telling the
+  operator the machine was born THEN took its first step, in one epoch.
+
+The row carries the machine's INITIAL logical `:state` (off the started
+trace's `:state` tag — a keyword / path-vector for flat / compound, a
+region→state map for parallel; rendered verbatim, so the badge covers flat /
+compound / parallel machines uniformly) and INITIAL `:data` (the `:data`
+tag). The header verb reads `<machine-id> started in {state}`; the initial
+`:data` rides the body box (the same `edn-inspector` widget the transition
+delta uses, rendered PLAIN — a birth has no prior state to diff against).
+
+The row also carries a **CAUSE tag** (`format/start-cause-label`) off the
+started trace's `:cause` enum — `explicit` / `lazy` / `spawned` — that tells
+the operator HOW the machine came to life:
+
+- `explicit` — a deliberate eager kick (xstate's `createActor(m).start()`).
+- `lazy` — init folded into the first real event's epoch. This is an
+  **ORDERING SMELL**: something dispatched to the machine before it was
+  explicitly started. The view paints the `lazy` tag in the warning tone to
+  flag it (`format/start-cause-smell?`); `explicit` / `spawned` ride the
+  muted neutral tone (a clean, expected birth).
+- `spawned` — the spawn fx pre-seeded the snapshot; init ran on the actor's
+  first dispatch.
+
+Because its trace op-type is `:rf.machine` (benign birth, not a severity),
+the L2 pink-wash / issues-ribbon `issue-event?` predicate does not match it —
+the event row stays un-washed. The `:start` kind pill reads `START` in the
+`:success` (green) tone — a clean birth is a GOOD event, distinct from the
+muted no-op, the blue action, and the magenta transition. The row carries NO
+outcome chip and NO source-link spec-path key (a birth has no transition
+outcome / spec call-site). A failed initial-entry (a thrown `:entry` action)
+does NOT emit `:rf.machine/started` — `maybe-boot` short-circuits to the
+EXCEPTION card via `trace-action-failure!` instead.
 
 The `:no-op` row (rf2-ugdas) surfaces the benign unhandled-event no-op
 (xstate-v5 parity — an event that matched no transition is ignored, NOT an
@@ -1480,21 +1540,21 @@ un-washed and the ribbon stays empty — the contrast with a `:*`
 wildcard-action throw (`:rf.error/machine-action-exception`, which DOES go
 pink + renders the EXCEPTION card) validates that the predicate correctly
 distinguishes a benign no-op from a real error. A cascade renders either a
-`:transition` OR a `:no-op`, never both. This is ENFORCED at projection
-time (rf2-e6q97): on a no-op the machine substrate emits BOTH the
-`:rf.machine.event/unhandled-no-op` trace AND — from `commit-or-finalize`'s
-unconditional `:rf.machine/transition` emit — a contradictory `{X}→{X}`
-0-microstep transition trace (`:before` == `:after`). Rendered side-by-side
-those contradict: the no-op row says the machine is "staying in {state}"
-(no transition) while the
-transition row borrows external-self-transition vocabulary (`{X} → {X}`)
-implying the `:exit` / `:entry` firing that did NOT happen.
-`machine-cascade-rows` therefore drops every `:transition` row when the
-cascade also carries a `:no-op` row — the no-op row is the authoritative
-signal that no transition was selected. A genuine self-transition
-(`:target :same-state`, EXTERNAL — `:exit` + `:entry` fire; or INTERNAL —
-the action runs) has a real `match`, so the unhandled-no-op branch is never
-reached and NO `:no-op` row fires: its transition row is preserved. The
+`:transition` OR a `:no-op`, never both — and this is now ENFORCED AT THE
+SOURCE (rf2-coozg): on a no-op macrostep (`:before` == `:after`, empty
+cascade, zero microsteps) `commit-or-finalize` (machines · lifecycle_fx ·
+registration.cljc) suppresses the no-change `:rf.machine/transition` emit
+entirely, so the projection never sees a contradictory `{X}→{X}`
+0-microstep transition row beside the `:no-op`. The earlier tool-side
+band-aid `drop-spurious-no-op-transition` (rf2-e6q97 — which dropped that
+spurious row whenever a `:no-op` row was present) is therefore **RETIRED**
+(rf2-it4vt): there is nothing left to drop. With rf2-gl588 the eager start
+is a PURE init-kick that never feeds the marker into the transition step, so
+there is no `before == after` self-transition for creation either. A genuine
+self-transition (`:target :same-state`, EXTERNAL — `:exit` + `:entry` fire;
+or INTERNAL — the action runs) has a real `match`, so the unhandled-no-op
+branch is never reached and NO `:no-op` row fires: its transition row (with
+microsteps > 0 / an action cascade) is preserved untouched. The
 no-op row also makes the cascade's handler-flavour `:reg-machine` even when
 no action ran, so the EVENT HANDLER machine section renders the notice
 rather than collapsing to a plain `reg-event-db` handler.
@@ -1504,9 +1564,15 @@ rather than collapsing to a plain `reg-event-db` handler.
 - **Step ordinal** (1..N) — left-rail compact monospace chip.
   Suppressed for the single-row `:no-op` notice (rf2-iu3no — the lone
   "1" was unexplained noise).
-- **Kind pill** — colour-coded (`:guard / :action / :transition /
+- **Kind pill** — colour-coded (`:start / :guard / :action / :transition /
   :timer / :no-op`) — see `badge.cljc` for the hue assignments. The
-  `:no-op` pill reads `NO OP` (space, not hyphen — rf2-iu3no).
+  `:no-op` pill reads `NO OP` (space, not hyphen — rf2-iu3no); the `:start`
+  pill reads `START` in the `:success` (green) tone (rf2-it4vt — a clean
+  birth is a GOOD event).
+- **Cause tag** (`:start` rows only — rf2-it4vt) — `explicit` / `lazy` /
+  `spawned`, off the `:rf.machine/started` trace's `:cause`. The `lazy`
+  cause is the ordering-smell flag (warning tone); `explicit` / `spawned`
+  ride the muted neutral tone.
 - **Phase chip** (`:action` rows only) — one of the rf2-82a0u closed
   set `:exit / :transition / :entry / :always / :after-action /
   :initial-entry / :destroy-exit`.
@@ -1530,6 +1596,9 @@ rather than collapsing to a plain `reg-event-db` handler.
   - `:no-op` → NO outcome chip (rf2-iu3no — the `NO OP` pill + the
     `staying in {state}` verb carry the whole notice; the rf2-ugdas
     `ignored` chip was a third restatement of the same fact)
+  - `:start` → NO outcome chip (rf2-it4vt — the `START` pill + the
+    `started in {state}` verb + the cause tag carry the whole birth
+    notice; a birth has no transition outcome)
 
 **Per-row body — interleaved source code (always visible).** Every
 cascade row carries source visibility (rf2-wwc3j extends rf2-u69j7's

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -216,7 +216,12 @@
    :timer       :warning
    ;; rf2-ugdas — the benign unhandled-event no-op. Muted/tertiary tone:
    ;; benign, low-signal — explicitly NOT an error/warning hue.
-   :no-op       :text-tertiary})
+   :no-op       :text-tertiary
+   ;; rf2-it4vt — the machine's BIRTH (`[START]`). Green/success tone: a
+   ;; clean creation is a GOOD event (xstate's `createActor(m).start()`),
+   ;; and the green reads as "the machine came alive here" — distinct from
+   ;; the blue ACTION, the magenta TRANSITION, and the muted no-op.
+   :start       :success})
 
 (def ^:private cascade-kind->label
   "Map from machine-cascade row `:kind` keyword → uppercase label
@@ -230,7 +235,11 @@
    ;; "[NO OP] staying in {state}" (`format/cascade-row-label`) — the pill
    ;; carries the one badge; the verb carries the consequence. No "ignored"
    ;; outcome chip, no "no-op —" prefix, no ", no transition" suffix.
-   :no-op       "NO OP"})
+   :no-op       "NO OP"
+   ;; rf2-it4vt — the machine's BIRTH pill. "START" mirrors xstate's
+   ;; `createActor(m).start()` — the machine ran its initial-entry cascade
+   ;; and installed its initial state.
+   :start       "START"})
 
 (defn cascade-kind-token-key
   "Theme-token keyword for a cascade row's `:kind` (rf2-u69j7). Falls
@@ -257,8 +266,9 @@
 (def cascade-kind-set
   "Closed set of cascade row kinds the view paints chrome for
   (rf2-u69j7). New kinds extend the projection's
-  `machine-cascade-trace-ops` AND this set in lockstep."
-  #{:guard :action :transition :timer :no-op})
+  `machine-cascade-trace-ops` AND this set in lockstep.
+  rf2-it4vt — `:start` (the machine's birth `[START]` badge)."
+  #{:guard :action :transition :timer :no-op :start})
 
 (defn cascade-kind?
   "Predicate — `kind` keyword is a member of `cascade-kind-set`."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -103,6 +103,39 @@
     :on-frame-destroy "on-frame-destroy"
     (when (keyword? reason) (name reason))))
 
+(def ^:private start-cause->label
+  "Map a `:rf.machine/started` `:cause` enum → the short tag rendered on
+  the `[START]` badge (rf2-it4vt). The cause tells the operator HOW the
+  machine came to life:
+
+    :explicit — a deliberate eager `[:machine-id [:rf.machine/start]]` kick
+                (xstate's `createActor(m).start()`).
+    :lazy     — init folded into the first REAL event's epoch. Flags an
+                ORDERING SMELL: something dispatched to the machine before
+                it was explicitly started.
+    :spawned  — the spawn fx pre-seeded the snapshot; init ran on the
+                actor's first dispatch."
+  {:explicit "explicit"
+   :lazy     "lazy"
+   :spawned  "spawned"})
+
+(defn start-cause-label
+  "Render a `:rf.machine/started` `:cause` enum as the short tag string the
+  `[START]` badge carries (rf2-it4vt). Falls through `name` for an unknown
+  cause keyword so a future enum value still paints, nil for non-keywords."
+  [cause]
+  (or (get start-cause->label cause)
+      (when (keyword? cause) (name cause))))
+
+(defn start-cause-smell?
+  "True iff a `[START]` row's `:cause` is the ORDERING SMELL `:lazy`
+  (rf2-it4vt) — something dispatched to the machine before it was explicitly
+  started, so init folded into that event's epoch. The view paints the
+  `:lazy` cause tag with a warning tone to flag it; `:explicit` / `:spawned`
+  ride the muted/neutral tone (clean birth)."
+  [cause]
+  (= :lazy cause))
+
 (defn cascade-row-label
   "Render a cascade row's human-readable verb (rf2-u69j7). Used by the
   view's per-row header. Pure-data; the view never reaches into a
@@ -111,7 +144,7 @@
   ;; (the only case that read it) collapsed to "staying in {state}" and no
   ;; longer echoes the event (the focused-epoch Event header names it).
   [{:keys [kind action-id guard-id from-state to-state state reason
-           machine-id show-machine-name?]}]
+           machine-id show-machine-name? cause]}]
   (case kind
     :guard       (str "guard " (ns-keyword guard-id))
     ;; rf2-nhovk — the ACTION kind-pill + phase chip already convey kind +
@@ -147,6 +180,16 @@
     :no-op       (str (when (and show-machine-name? machine-id)
                         (str (ns-keyword machine-id) " "))
                       "staying in "
+                      (if state (pr-str state) "?"))
+    ;; rf2-it4vt — the machine's BIRTH verb: "<machine-id> started in
+    ;; {state}". The `[START]` kind-pill is the badge; the verb names WHICH
+    ;; machine was born and its INITIAL logical state (`:state` off the
+    ;; `:rf.machine/started` trace — a keyword / path-vector for flat /
+    ;; compound, a region→state map for parallel; rendered verbatim). The
+    ;; initial `:data` rides the body box (`cascade-row-source-body`); the
+    ;; `:cause` rides a tag chip (`start-cause-label`).
+    :start       (str (when machine-id (str (ns-keyword machine-id) " "))
+                      "started in "
                       (if state (pr-str state) "?"))
     (str (when kind (name kind)))))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -371,12 +371,22 @@
     (some #(= :rf.machine/action-ran (op %)) events) :reg-machine
     ;; rf2-ugdas — a cascade whose ONLY machine activity is the benign
     ;; unhandled-event no-op (an event that matched no transition, so no
-    ;; action ran AND — once rf2-e6q97 suppresses the spurious {X}→{X}
-    ;; commit transition — no transition row either) is still a machine
-    ;; cascade: classify it :reg-machine so the EVENT HANDLER machine
-    ;; section renders the no-op notice rather than collapsing to a plain
-    ;; reg-event-db handler.
+    ;; action ran AND — since rf2-coozg suppresses the no-change {X}→{X}
+    ;; commit transition at the source — no transition row either) is still
+    ;; a machine cascade: classify it :reg-machine so the EVENT HANDLER
+    ;; machine section renders the no-op notice rather than collapsing to a
+    ;; plain reg-event-db handler.
     (some #(= :rf.machine.event/unhandled-no-op (op %)) events) :reg-machine
+    ;; rf2-it4vt — an EAGER `[:rf.machine/start]` kick is a PURE init
+    ;; (rf2-gl588 / F‴): it runs the initial-entry cascade then STOPS,
+    ;; emitting `:rf.machine/started` but NO `:rf.machine/transition` /
+    ;; `:rf.machine/action-ran` (the initial-entry actions are not traced as
+    ;; action-ran — rf2-n9f4z) / no-op. So a standalone start would fall
+    ;; through to `:reg-event-fx` (the machine handler always rides a
+    ;; do-fx — its snapshot write) and render the raw `:db` diff with NO
+    ;; machine section. Keying on the birth signal closes that gap: the
+    ;; cascade renders the `[START]` row instead.
+    (some #(= :rf.machine/started (op %)) events)    :reg-machine
     (some #(= :rf.fx/do-fx (op %)) events)           :reg-event-fx
     :else                                            :reg-event-db))
 
@@ -564,7 +574,14 @@
     ;; event with no matching transition; the snapshot is unchanged. Op-type
     ;; :rf.machine (NOT an error), so it surfaces in the EVENT HANDLER machine
     ;; cascade as a benign notice — not the red exception card, not pink.
-    :rf.machine.event/unhandled-no-op})
+    :rf.machine.event/unhandled-no-op
+    ;; rf2-it4vt — the machine's BIRTH. `maybe-boot` (machines · lifecycle_fx
+    ;; · registration.cljc) emits ONE `:rf.machine/started` per successful
+    ;; initial-entry cascade (rf2-gl588 / F‴), in BOTH creation paths — the
+    ;; EAGER `[:machine-id [:rf.machine/start]]` kick AND the LAZY
+    ;; first-real-event fold. Op-type :rf.machine (benign birth, not a
+    ;; severity). Renders the `[START]` badge row at the FRONT of the cascade.
+    :rf.machine/started})
 
 (def ^:private op->row-kind
   "Map a machine trace op → cascade-row `:kind` keyword (rf2-u69j7).
@@ -573,7 +590,8 @@
    :rf.machine/action-ran           :action
    :rf.machine/transition           :transition
    :rf.machine.timer/cancelled      :timer
-   :rf.machine.event/unhandled-no-op :no-op})
+   :rf.machine.event/unhandled-no-op :no-op
+   :rf.machine/started              :start})
 
 (def ^:private cascade-rank
   "Canonical (kind, phase) presentation rank for the machine cascade
@@ -589,8 +607,17 @@
   `:timer` trails (rank 6): timer-cancels are post-commit housekeeping.
 
   Bootstrap / lifecycle phases slot beside their nearest sibling:
-  `:initial-entry` ranks with `:entry`, `:destroy-exit` with `:exit`."
-  {;; guards — gate the transition; read first
+  `:initial-entry` ranks with `:entry`, `:destroy-exit` with `:exit`.
+
+  rf2-it4vt — the `:start` row (the machine's birth) ranks AHEAD of
+  everything (rank -1). In the EAGER path it is the cascade's sole row; in
+  the LAZY path the init folds into the SAME epoch as the first real event,
+  so `[START]` renders at the FRONT — ahead of that event's guards /
+  transition / actions — telling the operator the machine was born THEN
+  took its first step, in one epoch."
+  {;; the machine's birth — leads the cascade (rf2-it4vt)
+   [:start nil]              -1
+   ;; guards — gate the transition; read first
    [:guard nil]              0
    ;; exit-phase actions — leave the old state
    [:action :exit]           1
@@ -747,6 +774,37 @@
    :event      (common/tag-of ev :event)
    :state      (common/tag-of ev :state)})
 
+(defn- started-cascade-row
+  "Build a cascade row from a `:rf.machine/started` trace event (rf2-it4vt,
+  the machine BIRTH signal `maybe-boot` emits per rf2-gl588 / F‴). The row
+  is the `[START]` badge — it renders at the FRONT of the cascade (rank -1)
+  in BOTH creation paths:
+
+    - EAGER (`:cause :explicit`) — an explicit `[:machine-id
+      [:rf.machine/start]]` dispatch got its own epoch; the start is a PURE
+      init-kick (no transition / action rows ride alongside), so `[START]`
+      is the cascade's sole row.
+    - LAZY (`:cause :lazy`) — the machine was first reached by a REAL event;
+      init folded into THAT event's epoch, so `[START]` leads the real
+      event's guards / transition / action rows. The `:lazy` cause flags an
+      ordering smell (something dispatched to the machine before it was
+      explicitly started).
+    - SPAWNED (`:cause :spawned`) — the spawn fx pre-seeded the snapshot;
+      init ran on the actor's first dispatch.
+
+  Carries the machine's INITIAL logical `:state` and INITIAL `:data` (off
+  the started trace's `:state` / `:data` tags — the `(:state booted)` /
+  `(:data booted)` snapshot slots), and the `:cause` enum (rendered as a
+  tag on the badge). `:state` may be a keyword / path-vector (flat /
+  compound) OR a region→state map (parallel) — it renders verbatim, so the
+  badge covers flat / compound / parallel machines uniformly."
+  [ev]
+  {:kind       :start
+   :machine-id (common/tag-of ev :machine-id)
+   :state      (common/tag-of ev :state)
+   :data       (common/tag-of ev :data)
+   :cause      (common/tag-of ev :cause)})
+
 (defn- ev->cascade-row
   "Dispatch one trace event to its cascade-row builder. Returns nil for
   events whose op is not in `machine-cascade-trace-ops` (the caller
@@ -759,6 +817,7 @@
     :rf.machine/transition            (transition-cascade-row ev)
     :rf.machine.timer/cancelled       (timer-cascade-row ev)
     :rf.machine.event/unhandled-no-op (no-op-cascade-row ev)
+    :rf.machine/started               (started-cascade-row ev)
     nil))
 
 ;; ---- history restore / record (rf2-mle6e.5) -----------------------------
@@ -1035,47 +1094,20 @@
             (assoc :event-id (event-id-of (:event tx))))))
       rows next-tx)))
 
-(defn- drop-spurious-no-op-transition
-  "Suppress the spurious `{X}→{X}` 0-microstep `:transition` row that the
-  substrate emits beside a genuine no-op (rf2-e6q97).
-
-  WHY THE SUBSTRATE EMITS BOTH. When an event matches no transition at any
-  level, `machine-transition-single` (machines · `transition.cljc`) takes
-  its `:else` branch: it emits ONE benign `:rf.machine.event/unhandled-no-op`
-  trace (Spec 005 §Transition resolution, xstate-v5 parity — an unhandled
-  event is ignored, not an error) and returns the snapshot UNCHANGED. The
-  macrostep then runs `commit-or-finalize` (machines · lifecycle_fx ·
-  `registration.cljc`), which fires `:rf.machine/transition` UNCONDITIONALLY
-  — even when `:before` == `:after` and zero microsteps ran. So a no-op
-  cascade carries BOTH a `:no-op` row AND a `{X}→{X}` 0-microstep
-  `:transition` row. Rendered side-by-side these CONTRADICT: the no-op row
-  says 'no transition — ignored', while the transition row borrows
-  external-self-transition vocabulary (`{X} → {X}`) implying the `:exit` /
-  `:entry` firing that did NOT happen.
-
-  THE DISCRIMINATOR. The presence of a `:no-op` row is the AUTHORITATIVE
-  signal that no transition was selected — `unhandled-no-op` fires from
-  exactly the same `:else` branch (flat machines), and from the
-  every-region-declined aggregate (parallel machines · `parallel.cljc`).
-  A genuine self-transition (`:target :same-state`, EXTERNAL) has a real
-  `match`, so the no-op branch is NEVER reached → no `:no-op` row → its
-  `:transition` row survives untouched (Spec 005 L291-296, L916 — an
-  external self-transition fires `:exit` + `:entry` and IS a real
-  transition). An internal self-transition (omit `:target`) likewise has a
-  `match` and runs its action — also no `:no-op` row.
-
-  So: drop every `:transition` row IFF the cascade also carries a `:no-op`
-  row. We do NOT inspect `:microsteps` / `:from-state` == `:to-state` — the
-  no-op row IS the precise signal, and gating on state-equality would risk
-  suppressing a legitimate self-transition that happens to land on the same
-  state. The `:no-op` row alone remains to tell the story.
-
-  Pure-data; operates on the trace-ordered rows BEFORE the canonical sort
-  so the result is order-independent."
-  [rows]
-  (if (some #(= :no-op (:kind %)) rows)
-    (filterv #(not= :transition (:kind %)) rows)
-    rows))
+;; rf2-it4vt — the `drop-spurious-no-op-transition` band-aid (rf2-e6q97) is
+;; RETIRED. It dropped the spurious `{X}→{X}` 0-microstep `:transition` row
+;; the substrate USED to emit beside a genuine no-op (and beside a redundant
+;; `[:rf.machine/start]` on an already-booted machine). rf2-coozg fixed that
+;; at the SOURCE: `commit-or-finalize` (machines · lifecycle_fx ·
+;; registration.cljc) now suppresses the no-change transition emit for a
+;; no-op macrostep (`:before` == `:after`, empty cascade, zero microsteps) —
+;; so the projection never sees a `{X}→{X}` transition to drop. With rf2-gl588
+;; (F‴) the eager start is a PURE init-kick that never feeds the marker into
+;; the transition step, so there is no `before == after` self-transition for
+;; creation either. The band-aid is fully dead on the creation path; the
+;; no-op path's transition is gone at the source — nothing to suppress
+;; tool-side. (The LIVE no-op / spawn / redundant-bootstrap correctness now
+;; lives core-side in rf2-coozg / rf2-t4582 / rf2-n9f4z, untouched here.)
 
 (defn machine-cascade-rows
   "Project the focused epoch's machine-related trace events into a
@@ -1085,16 +1117,17 @@
   trace stream.
 
   CANONICAL PHASE ORDER (rf2-tjqd8) — the rows are RE-SORTED panel-side
-  into `guard → exit → TRANSITION → entry → always → after-action →
-  timer` rather than rendered in raw substrate emit order. The substrate
-  emits the `:rf.machine/transition` summary LAST (after exit + entry
-  actions accumulate the data), so the verbatim emit order is exit →
-  entry → transition; rendering it that way lands the TRANSITION after
-  the entry action, which mis-reads the statechart. The re-sort is a
+  into `START → guard → exit → TRANSITION → entry → always →
+  after-action → timer` rather than rendered in raw substrate emit order.
+  The substrate emits the `:rf.machine/transition` summary LAST (after
+  exit + entry actions accumulate the data), so the verbatim emit order is
+  exit → entry → transition; rendering it that way lands the TRANSITION
+  after the entry action, which mis-reads the statechart. The re-sort is a
   STABLE sort keyed by `[cascade-row-rank :trace-index]` — rows in the
   same rank keep their substrate emit order (multiple actions in one
   phase keep their run order). This is presentation-only; the substrate
-  trace order is untouched.
+  trace order is untouched. rf2-it4vt — the `:start` row ranks AHEAD of
+  everything (rank -1), so the machine's birth leads the cascade.
 
   Pipeline:
   1. Walk `:trace-events` in trace order; build one row per
@@ -1104,15 +1137,11 @@
      `:target-state` / `:event-id` from the surrounding `:transition`
      emit. This MUST run on the trace-ordered rows (the
      surrounding-transition resolution is emit-order-sensitive).
-  3. `drop-spurious-no-op-transition` (rf2-e6q97) — when the cascade
-     carries a `:no-op` row, the substrate's UNCONDITIONAL
-     `:rf.machine/transition` emit produced a contradictory `{X}→{X}`
-     0-microstep transition row beside it; drop it. Genuine self-
-     transitions never carry a `:no-op` row, so their transition row
-     survives (see that fn's docstring).
-  4. Stable-sort by canonical rank, then re-number `:step` 1..N over the
+  3. Stable-sort by canonical rank, then re-number `:step` 1..N over the
      sorted order so the view's left-rail ordinal reflects the rendered
-     order.
+     order. (The rf2-e6q97 `drop-spurious-no-op-transition` pass is
+     RETIRED — rf2-coozg suppresses the no-change transition at the
+     source, so there is no spurious `{X}→{X}` row to drop here.)
 
   The enrichment slots feed `cascade-row-source-key` so inline-fn
   `:entry` / `:exit` / `:guard` / transition / timer rows can resolve
@@ -1141,15 +1170,14 @@
                    enriched
                    (history-restored-rows events)
                    (history-recorded-rows events))
-        ;; rf2-e6q97 — a no-op cascade carries both the `:no-op` row AND the
-        ;; substrate's unconditional `{X}→{X}` 0-microstep `:transition` row;
-        ;; the two contradict. Drop the spurious transition row (the `:no-op`
-        ;; row is the authoritative signal that no transition was selected).
-        ;; Order-independent — runs on the trace-ordered rows before the sort.
-        deduped  (drop-spurious-no-op-transition enriched)
         ;; Stable canonical sort: rank first, emit-order (:trace-index)
-        ;; as tiebreaker so intra-phase run order is preserved.
-        sorted   (vec (sort-by (juxt cascade-row-rank :trace-index) deduped))
+        ;; as tiebreaker so intra-phase run order is preserved. rf2-it4vt —
+        ;; the `:start` row ranks -1 (ahead of guards), so it leads the
+        ;; cascade in both creation paths (eager standalone / lazy fold).
+        ;; The rf2-e6q97 `drop-spurious-no-op-transition` pass is RETIRED:
+        ;; rf2-coozg suppresses the no-change transition at the source, so
+        ;; there is no spurious `{X}→{X}` row to drop here.
+        sorted   (vec (sort-by (juxt cascade-row-rank :trace-index) enriched))
         ;; rf2-iu3no — the benign no-op row renders "[NO OP] staying in
         ;; {state}". The machine NAME is surfaced ONLY when the epoch has
         ;; >1 machine in play (a broadcast event hitting parallel regions /

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -448,6 +448,31 @@
    :line-height    1
    :white-space    "nowrap"})
 
+;; rf2-it4vt — the `[START]` row's CAUSE tag (`explicit` / `lazy` /
+;; `spawned`). A small outlined chip next to the verb that tells the
+;; operator HOW the machine came to life. `:lazy` is the ORDERING SMELL
+;; (something dispatched to the machine before it was explicitly started) —
+;; painted in the warning tone; `:explicit` / `:spawned` ride the muted
+;; tertiary tone (a clean, expected birth).
+(def ^:private cascade-start-cause-style
+  {:display        "inline-flex"
+   :align-items    "center"
+   :background     bg-3-colour
+   :color          text-tertiary-colour
+   :border         (str "1px solid " border-subtle-colour)
+   :border-radius  "2px"
+   :padding        "1px 5px"
+   :font-family    mono-stack
+   :font-size      "10px"
+   :font-weight    600
+   :letter-spacing "0.3px"
+   :white-space    "nowrap"})
+
+(def ^:private cascade-start-cause-smell-style
+  (assoc cascade-start-cause-style
+         :color  warning-colour
+         :border (str "1px solid " warning-colour)))
+
 (def ^:private cascade-ordinal-style
   {:display         "inline-flex"
    :align-items     "center"
@@ -2623,6 +2648,22 @@
             :style cascade-phase-style}
      (badge/cascade-phase-label phase)]))
 
+(defn- cascade-start-cause-chip
+  "Render the `[START]` row's CAUSE tag (rf2-it4vt) — `explicit` / `lazy` /
+  `spawned`, off the `:rf.machine/started` trace's `:cause`. Tells the
+  operator HOW the machine came to life. The `:lazy` cause is the ORDERING
+  SMELL (something dispatched to the machine before it was explicitly
+  started) — painted in the warning tone; `:explicit` / `:spawned` ride the
+  muted tertiary tone. Renders nothing when no cause was stamped."
+  [cause]
+  (when-let [label (fmt/start-cause-label cause)]
+    [:span {:data-testid (str "rf-xray-epoch-machine-cascade-start-cause-"
+                              (when (keyword? cause) (name cause)))
+            :style (if (fmt/start-cause-smell? cause)
+                     cascade-start-cause-smell-style
+                     cascade-start-cause-style)}
+     label]))
+
 (defn- cascade-kind-pill
   "Render the kind pill (`GUARD / ACTION / TRANSITION / TIMER`) on a
   cascade row's header (rf2-u69j7). Smaller than the top-level badge
@@ -2937,6 +2978,28 @@
                       :style structured-cascade-microsteps-style}]
                (map #(structured-cascade-microstep prefix %) microsteps)))])))
 
+(defn- cascade-row-start-body
+  "Render the `[START]` row's body (rf2-it4vt) — the machine's INITIAL
+  `:data` (off the `:rf.machine/started` trace's `:data` tag), shown through
+  `ei/edn-inspector` (the SAME widget the transition delta + per-action
+  DATA Δ use). NO `:before` (a birth has no prior state — the data is freshly
+  built by the initial-entry cascade), so the inspector renders the initial
+  data map plainly rather than as a diff. The initial logical STATE rides the
+  header verb (`started in {state}`); this box is the initial DATA.
+
+  Returns nil when the machine carries no `:data` (a data-less machine) so
+  the caller renders no body slot — the `[START]` pill + `started in {state}`
+  verb already tell the birth story."
+  [{:keys [step data]}]
+  (when (some? data)
+    [:div {:data-testid (str "rf-xray-epoch-machine-cascade-source-" step)
+           :style cascade-row-source-style}
+     [:div {:data-testid (str "rf-xray-epoch-machine-cascade-start-data-" step)}
+      [ei/edn-inspector data
+       {:site-id                [:rf.xray.epoch/machine-cascade-start-data step]
+        :card?                  false
+        :default-expanded-depth 3}]]]))
+
 (defn- cascade-row-source-body
   "Render the source code body for a cascade row (rf2-u69j7 baseline +
   rf2-wwc3j inline-fn extensions). Always visible per the bead body's
@@ -2967,6 +3030,11 @@
   step's source body."
   [machine-meta row source-form]
   (cond
+    ;; rf2-it4vt — the `[START]` row's body is the machine's INITIAL :data
+    ;; (the initial logical :state rides the header verb).
+    (= :start (:kind row))
+    (cascade-row-start-body row)
+
     ;; rf2-iwy0c part A — transition rows show the logical-state delta,
     ;; NOT the transition map literal. Self/internal transitions (no
     ;; logical change) elide the box entirely.
@@ -3115,9 +3183,12 @@
   state-change verb (`<before> → <after>`) + the rf2-iwy0c logical-state
   DELTA box (`{:state :tags}` before → after), with NO repetitive detail
   block (rf2-ge6uj ISSUE 3); `:timer` rides a minimal layout (kind +
-  state + reason, no source body)."
+  state + reason, no source body); `:start` (rf2-it4vt) rides the
+  `[START]` pill + `started in {state}` verb + a CAUSE tag chip
+  (`explicit` / `lazy` / `spawned`) + the initial-`:data` body box, with
+  NO source-link (a birth has no spec call-site) and NO outcome chip."
   [machine-meta row]
-  (let [{:keys [kind step phase duration-ms outcome threw?]} row
+  (let [{:keys [kind step phase duration-ms outcome threw? cause]} row
         coord       (cascade-row-coord machine-meta row)
         source-form (cascade-row-source-form machine-meta row)
         verb        (fmt/cascade-row-label row)
@@ -3142,6 +3213,11 @@
       (when (= :action kind)
         (cascade-phase-chip phase))
       (cascade-row-verb-link row coord verb)
+      ;; rf2-it4vt — the `[START]` row's CAUSE tag (explicit / lazy /
+      ;; spawned) rides right after the verb. The `lazy` cause is the
+      ;; ordering-smell flag (warning tone).
+      (when (= :start kind)
+        (cascade-start-cause-chip cause))
       ;; Right-aligned: duration + outcome chip
       [:span {:style cascade-row-right-style}
        (duration-chip duration-ms)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -97,15 +97,27 @@
 (deftest cascade-kind-set-test
   (testing "rf2-u69j7 — the cascade-kind inventory matches the
             substrate trace ops the projection harvests (rf2-ugdas adds
-            :no-op for the benign unhandled-event no-op)"
-    (is (= #{:guard :action :transition :timer :no-op}
+            :no-op for the benign unhandled-event no-op; rf2-it4vt adds
+            :start for the machine's birth [START] badge)"
+    (is (= #{:guard :action :transition :timer :no-op :start}
            badge/cascade-kind-set))
     (is (badge/cascade-kind? :guard))
     (is (badge/cascade-kind? :action))
     (is (badge/cascade-kind? :transition))
     (is (badge/cascade-kind? :timer))
     (is (badge/cascade-kind? :no-op))
+    (is (badge/cascade-kind? :start))
     (is (not (badge/cascade-kind? :NOT-A-KIND))))
+
+  (testing "rf2-it4vt — the :start kind resolves to a green/success label +
+            colour (a clean birth is a GOOD event), distinct from the muted
+            no-op tone"
+    (is (= "START" (badge/cascade-kind-label :start)))
+    (is (string? (badge/cascade-kind-colour :start)))
+    (is (re-find #"var\(--rf-xray-" (badge/cascade-kind-colour :start)))
+    (is (not= (badge/cascade-kind-colour :start)
+              (badge/cascade-kind-colour :no-op))
+        "the green birth is distinct from the muted no-op tone"))
 
   (testing "rf2-ugdas / rf2-iu3no — the :no-op kind resolves to a muted (not
             red) label + colour, distinct from the error/warning hues. The

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -77,6 +77,7 @@
 (def ^:private machine-action-ev       teb/machine-action-ev)
 (def ^:private machine-timer-cancel-ev teb/machine-timer-cancel-ev)
 (def ^:private machine-unhandled-no-op-ev teb/machine-unhandled-no-op-ev)
+(def ^:private machine-started-ev      teb/machine-started-ev)
 (def ^:private machine-action-exception-ev teb/machine-action-exception-ev)
 (def ^:private machine-history-restored-ev  teb/machine-history-restored-ev)
 (def ^:private machine-history-recorded-ev  teb/machine-history-recorded-ev)
@@ -780,74 +781,154 @@
       (is (some? (:machine r)))
       (is (= [:no-op] (mapv :kind (-> r :machine :cascade)))))))
 
-;; ---- rf2-e6q97 — a no-op suppresses the spurious {X}→{X} transition row ---
+;; ---- rf2-it4vt — the machine's [START] badge -----------------------------
 
-(deftest no-op-suppresses-spurious-transition-row-test
-  (testing "rf2-e6q97 — on a genuine unknown-user-event no-op the substrate
-            emits BOTH the benign :rf.machine.event/unhandled-no-op AND its
-            unconditional :rf.machine/transition summary ({X}→{X}, 0
-            microsteps). Rendered side-by-side those CONTRADICT. The cascade
-            must show the :no-op row ALONE — the spurious transition row is
-            dropped."
-    ;; rf2-iu3no — the live repro fixture was a `[:rf.machine/start]`
-    ;; no-op, but rf2-t4582 (#2846) carved the start OUT of the no-op
-    ;; classification (start runs :initial-entry, never a no-op). The
-    ;; dedup MECHANISM this asserts is independent of which event no-op'd, so
-    ;; the fixture is rebased onto a genuine unknown USER event (the only
-    ;; thing that still produces an unhandled-no-op post-t4582).
-    (let [state {:vehicle :red :pedestrian :walk}
-          ;; A user dispatched [:traffic/unknown] in a state with no matching
-          ;; transition: unhandled-no-op (event matched no transition)
-          ;; FOLLOWED BY the unconditional commit transition with
-          ;; :before == :after and :microsteps 0.
-          no-op (machine-unhandled-no-op-ev :traffic/light
-                                            [:traffic/unknown] state)
-          tx    (machine-transition-ev :traffic/light
-                                       {:state state :data {}}
-                                       {:state state :data {}}
-                                       [:traffic/unknown] 0)
-          rows  (proj/machine-cascade-rows [no-op tx])]
-      ;; RED before the fix: rows == [:no-op :transition] (the contradiction).
-      ;; GREEN after: the :transition row is gone.
-      (is (= [:no-op] (mapv :kind rows))
-          "only the :no-op row survives — no spurious {X}→{X} transition row")
+(deftest machine-started-projects-to-start-row-test
+  (testing "rf2-it4vt — a :rf.machine/started trace projects to a :start
+            cascade row carrying machine-id / initial state / initial data
+            / cause"
+    (let [ev   (machine-started-ev :door/main :locked {:attempts 0} :explicit)
+          rows (proj/machine-cascade-rows [ev])
+          r    (first rows)]
       (is (= 1 (count rows)))
-      (is (not-any? #(= :transition (:kind %)) rows)
-          "the spurious 0-microstep no-change transition row is suppressed")
-      (is (= 1 (:step (first rows)))
-          ":step renumbered 1..N over the deduped cascade")))
+      (is (= :start (:kind r)))
+      (is (= :door/main (:machine-id r)))
+      (is (= :locked (:state r))      "the initial logical state")
+      (is (= {:attempts 0} (:data r)) "the initial :data")
+      (is (= :explicit (:cause r)))
+      (is (= 1 (:step r)))))
 
-  (testing "rf2-e6q97 — emit-order is irrelevant: even if the transition emit
-            precedes the no-op emit, the transition row is still dropped"
-    (let [state :stable
-          tx    (machine-transition-ev :traffic/light
-                                       {:state state} {:state state}
-                                       [:traffic/unknown] 0)
+  (testing "rf2-it4vt — EAGER (explicit) start: a standalone [START] is the
+            cascade's SOLE row (a pure init-kick — rf2-gl588 — runs the
+            initial-entry cascade then STOPS, emitting no transition / action
+            rows)"
+    (let [evs  [(machine-started-ev :door/main :locked {} :explicit)]
+          rows (proj/machine-cascade-rows evs)]
+      (is (= [:start] (mapv :kind rows))
+          "EAGER → standalone [START], no transition rows")))
+
+  (testing "rf2-it4vt — LAZY start: when a machine is first reached by a REAL
+            event, init folds into the SAME epoch, so [START] renders at the
+            FRONT of the cascade — ahead of that event's transition rows"
+    (let [start (machine-started-ev :door/main :locked {} :lazy)
+          ;; the real first event drove a transition AFTER the fold-in birth
+          tx    (machine-transition-ev :door/main
+                                       {:state :locked :data {}}
+                                       {:state :open   :data {}}
+                                       [:door/unlock] 0)
+          ;; deliberately feed the transition FIRST to prove the canonical
+          ;; sort floats :start to the front regardless of emit order.
+          rows  (proj/machine-cascade-rows [tx start])]
+      (is (= :start (:kind (first rows)))
+          "[START] leads the cascade, ahead of the real event's transition")
+      (is (= [:start :transition] (mapv :kind rows)))
+      (is (= 1 (:step (first rows)))  ":step renumbered 1..N over the sorted order")
+      (is (= :lazy (:cause (first rows))))))
+
+  (testing "rf2-it4vt — the cause tag renders: explicit / lazy / spawned,
+            with :lazy flagged as the ordering smell"
+    (is (= "explicit" (fmt/start-cause-label :explicit)))
+    (is (= "lazy"     (fmt/start-cause-label :lazy)))
+    (is (= "spawned"  (fmt/start-cause-label :spawned)))
+    (is (true?  (fmt/start-cause-smell? :lazy))
+        ":lazy is the ordering smell (something dispatched before explicit start)")
+    (is (false? (fmt/start-cause-smell? :explicit)))
+    (is (false? (fmt/start-cause-smell? :spawned))))
+
+  (testing "rf2-it4vt — the [START] verb names the machine + its initial
+            state; the kind pill reads START; flat / compound / parallel
+            states render verbatim"
+    ;; flat
+    (is (= ":door/main started in :locked"
+           (fmt/cascade-row-label
+             (first (proj/machine-cascade-rows
+                      [(machine-started-ev :door/main :locked {} :explicit)])))))
+    ;; compound (path-vector state)
+    (is (= ":hvac/unit started in [:on :cooling]"
+           (fmt/cascade-row-label
+             (first (proj/machine-cascade-rows
+                      [(machine-started-ev :hvac/unit [:on :cooling] {} :lazy)])))))
+    ;; parallel (region->state map)
+    (is (= ":player/av started in {:audio :muted, :video :playing}"
+           (fmt/cascade-row-label
+             (first (proj/machine-cascade-rows
+                      [(machine-started-ev :player/av
+                                           {:audio :muted :video :playing}
+                                           {} :spawned)])))))
+    (is (= "START" (badge/cascade-kind-label :start))
+        "the kind pill reads START")
+    (is (badge/cascade-kind? :start)
+        ":start is a member of the closed cascade-kind-set"))
+
+  (testing "rf2-it4vt — a [START] carries NO outcome chip and NO source-link
+            spec-path key (a birth has no transition outcome / call-site)"
+    (let [r (first (proj/machine-cascade-rows
+                     [(machine-started-ev :door/main :locked {} :explicit)]))]
+      (is (nil? (fmt/cascade-outcome-label r)))
+      (is (nil? (fmt/cascade-row-source-key r)))))
+
+  (testing "rf2-it4vt — an EAGER pure start makes the cascade :reg-machine
+            (it emits :rf.machine/started but no transition/action/no-op), so
+            handler-row renders the [START] row in the :machine :cascade slot
+            rather than collapsing to a plain reg-event-fx :db diff"
+    (let [r (proj/handler-row
+              [(machine-started-ev :door/main :locked {:attempts 0} :explicit)
+               ;; the machine handler always rides a do-fx (its snapshot write)
+               (do-fx-ev {:db {}})]
+              :door/main)]
+      (is (= :reg-machine (:flavour r)))
+      (is (some? (:machine r)))
+      (is (= [:start] (mapv :kind (-> r :machine :cascade))))))
+
+  (testing "rf2-it4vt — the [START] is benign birth (op-type :rf.machine),
+            so issue-event? is FALSE — no pink wash, no ribbon entry"
+    (let [ev (machine-started-ev :door/main :locked {} :explicit)]
+      (is (= :rf.machine (:op-type ev)))
+      (is (false? (issues/issue-event? ev)))
+      (is (false? (l2/cascade-has-issue? {:other [ev]}))))))
+
+;; ---- rf2-it4vt — the rf2-e6q97 band-aid is RETIRED -----------------------
+
+(deftest no-op-cascade-carries-no-transition-row-test
+  (testing "rf2-it4vt / rf2-coozg — the rf2-e6q97 `drop-spurious-no-op-
+            transition` band-aid is RETIRED. rf2-coozg fixed the
+            double-emit at the SOURCE: a no-op macrostep (`:before` ==
+            `:after`, empty cascade, zero microsteps) no longer emits the
+            redundant `:rf.machine/transition` at all. So a genuine
+            unknown-user-event no-op cascade carries ONLY the
+            `:rf.machine.event/unhandled-no-op` trace — the projection
+            renders the single `:no-op` row with no transition to suppress."
+    (let [state {:vehicle :red :pedestrian :walk}
+          ;; post-coozg the substrate emits the no-op ALONE (no companion
+          ;; {X}->{X} transition); this fixture mirrors that real trace.
           no-op (machine-unhandled-no-op-ev :traffic/light
                                             [:traffic/unknown] state)
-          rows  (proj/machine-cascade-rows [tx no-op])]
-      (is (= [:no-op] (mapv :kind rows)))))
+          rows  (proj/machine-cascade-rows [no-op])]
+      (is (= [:no-op] (mapv :kind rows))
+          "the single :no-op row — coozg emits no companion transition")
+      (is (= 1 (count rows)))
+      (is (not-any? #(= :transition (:kind %)) rows))
+      (is (= 1 (:step (first rows)))
+          ":step renumbered 1..N over the cascade")))
 
-  (testing "rf2-e6q97 — the no-op suppression flows through handler-row into
-            the :machine :cascade slot the view renders (the live surface)"
+  (testing "rf2-it4vt — the no-op flows through handler-row into the
+            :machine :cascade slot the view renders (the live surface)"
     (let [state {:vehicle :red :pedestrian :walk}
           evs   [(machine-unhandled-no-op-ev :traffic/light
-                                             [:traffic/unknown] state)
-                 (machine-transition-ev :traffic/light
-                                        {:state state :data {}}
-                                        {:state state :data {}}
-                                        [:traffic/unknown] 0)]
+                                             [:traffic/unknown] state)]
           r     (proj/handler-row evs :traffic/light)]
       (is (= :reg-machine (:flavour r)))
       (is (= [:no-op] (mapv :kind (-> r :machine :cascade)))
           "the view's :cascade carries the no-op row alone"))))
 
 (deftest genuine-self-transition-keeps-its-row-test
-  (testing "rf2-e6q97 NEGATIVE GUARD — a genuine EXTERNAL self-transition
+  (testing "rf2-it4vt NEGATIVE GUARD — a genuine EXTERNAL self-transition
             (:target :same-state; :exit + :entry FIRE, microsteps > 0) is a
             REAL transition (Spec 005 L291-296). It has a real `match`, so the
             unhandled-no-op branch is never reached — NO :no-op row fires —
-            and the suppression MUST NOT touch its transition row."
+            and its transition row renders untouched (the retired e6q97
+            band-aid never gated on state-equality, only on a :no-op row's
+            presence, which a self-transition never carries)."
     (let [state [:active]
           ;; exit + entry actions fired (the external self-transition
           ;; semantics) and a microstep ran — a real transition, NO no-op.
@@ -866,7 +947,7 @@
         (is (= 1 (:microsteps tx))
             "microsteps > 0 — a real transition, not a no-op"))))
 
-  (testing "rf2-e6q97 NEGATIVE GUARD — an INTERNAL self-transition (omit
+  (testing "rf2-it4vt NEGATIVE GUARD — an INTERNAL self-transition (omit
             :target; action runs, no exit/entry) likewise has a real match,
             so no :no-op row — its transition row is preserved per semantics"
     (let [state :idle

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -378,6 +378,23 @@
        :event      event
        :state      state}))
 
+(defn machine-started-ev
+  "`:rf.machine/started` trace (rf2-it4vt, the machine BIRTH signal
+  `maybe-boot` emits per rf2-gl588 / F-triple-prime). Op-type `:rf.machine`
+  (benign birth, NOT a severity). Carries the machine's INITIAL logical
+  `:state` + INITIAL `:data` + the `:cause` enum (`:explicit` / `:lazy` /
+  `:spawned`). Drives the EVENT HANDLER machine cascade's `[START]` row.
+
+    - EAGER  -> `:explicit` (an explicit `[:machine-id [:rf.machine/start]]`)
+    - LAZY   -> `:lazy`     (init folded into the first real event's epoch)
+    - SPAWN  -> `:spawned`  (the spawn fx pre-seeded the snapshot)"
+  [machine-id state data cause]
+  (ev :rf.machine :rf.machine/started
+      {:machine-id machine-id
+       :state      state
+       :data       data
+       :cause      cause}))
+
 (defn machine-history-restored-ev
   "`:rf.machine.history/restored` trace (rf2-mle6e.5, spec/009 §History trace
   events) — a transition resolved a `:type :history` pseudo-state. Op-type


### PR DESCRIPTION
Closes rf2-it4vt. Renders the machine's birth as a `[START]` cascade row in the Epoch panel's EVENT HANDLER section, keyed on the `:rf.machine/started` trace gl588 / F‴ emits (`#2880`).

## What
- **`[START]` row** — initial logical state (header verb `started in {state}` — flat / compound / parallel render verbatim) + initial `:data` (body box, plain), in BOTH creation paths:
  - **EAGER** (`:cause :explicit`) → standalone `[START]` (pure init-kick, no transition rows).
  - **LAZY** (`:cause :lazy`) → `[START]` at the FRONT of the cascade, ahead of the first real event's transition rows.
- **Start cause tag** on the badge: `explicit` / `lazy` / `spawned`. `lazy` is flagged as the ordering smell (warning tone — something dispatched before explicit start).
- **Retire rf2-e6q97** — the `drop-spurious-no-op-transition` band-aid is removed. rf2-coozg (`#2856`, already merged) eliminated the `{X}→{X}` no-change transition emit at the source, so there is nothing left to drop. The LIVE no-op / spawn / redundant-bootstrap correctness lives core-side (coozg / t4582 / n9f4z), untouched.

## Where
- `panels/epoch/projection.cljc` — `:rf.machine/started` → `:start` row kind (rank -1); `handler-flavour` classifies a standalone start `:reg-machine`; `drop-spurious-no-op-transition` removed.
- `panels/epoch/badge.cljc` — `:start` kind chrome (`START` pill, `:success` green tone).
- `panels/epoch/format.cljc` — `started in {state}` verb + `start-cause-label` / `start-cause-smell?`.
- `panels/epoch/view.cljs` — `[START]` cause chip + initial-`:data` body box; `:start` wired into the row render.
- `spec/021-Dynamic-Panel-Designs.md` — cascade row table, `[START]` subsection, retired-e6q97 paragraph, handler-flavour discriminator, per-row chrome.
- Tests — projection unit assertions (eager standalone / lazy front-of-cascade / cause tag / flat·compound·parallel state); e6q97 test rebased onto the coozg source-fix contract; badge kind-set test + `machine-started-ev` builder.

## Gates (cold)
- `tools/xray` JVM `clojure -M:test` — **1102 tests, 0 failures**.
- `npm run test:cljs` — **5456 tests, 0 failures**.
- `npx shadow-cljs compile :examples/machine-epochs` — **0 warnings**.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures** (machine-epochs included; no routes-epochs flake).

Out of scope (other workers): testbeds (c4k20 / 7prmj own machine_epochs / edn_inspector / standard_epochs). machines-viz (rlq97). The 18oe3 dispatch-gloss in format/view is untouched (different render point).