### PR TITLE
refactor(xray/testbeds): drop 0.Reset button from managed_http + routes_epochs (rf2-oncri)

### DIFF
--- a/tools/xray/testbeds/managed_http/core.cljs
+++ b/tools/xray/testbeds/managed_http/core.cljs
@@ -482,14 +482,6 @@
      [:strong "Watch"] " note, then watch the Epoch / Trace / App-db / "
      "Machine panels render it. The runner cursor lives in a "
      [:strong "local atom"] " — it never touches the inspected app-db."]]
-   [:button {:data-testid "managed-http-deck-reset"
-             :on-click (fn []
-                         (dispatch [::reset])
-                         (runner/reset-runner! runner-state))
-             :style {:padding "0.4em 0.8em" :cursor "pointer"
-                     :border "1px solid #cfc8ff" :border-radius "6px"
-                     :background "#f4f1ff" :margin "0.25em 0"}}
-    "0. Reset — clear registry + re-seed app-db + rewind runner"]
    [status-strip]
    [in-flight-strip]
    [runner/runner "managed-http" runner-state steps host-frame]])

--- a/tools/xray/testbeds/routes_epochs/core.cljs
+++ b/tools/xray/testbeds/routes_epochs/core.cljs
@@ -449,15 +449,6 @@
      "ladder. The runner cursor lives in a " [:strong "local atom"] " — it "
      "never touches the inspected app-db."]]
    [current-route-strip]
-   ;; Reset — re-seed app-db, navigate home, rewind the runner.
-   [:button {:data-testid "reset-button"
-             :on-click (fn []
-                         (dispatch [:routes-epochs/reset])
-                         (runner/reset-runner! runner-state))
-             :style {:padding "0.4em 0.8em" :cursor "pointer"
-                     :border "1px solid #cfc8ff" :border-radius "6px"
-                     :background "#f4f1ff" :margin "0.5em 0"}}
-    "0. Reset — re-seed app-db, navigate home, rewind runner"]
    [runner/runner "routes-epochs" runner-state steps host-frame]])
 
 ;; ============================================================================


### PR DESCRIPTION
Finishes the **0.Reset-button removal sweep** (edn-inspector + standard_epochs landed in #2882; machine_epochs has no deck-reset button — only a step label). Removes the **on-page reset BUTTON only** from the last two runner decks. Mike 2026-06-03: "get rid of 0 buttons on all of them."

## Changes

- **`managed_http/core.cljs`** — delete the `managed-http-deck-reset` button (its `:on-click` dispatched `[::reset]` + `runner/reset-runner!`). **KEPT** `[status-strip]` and the `::reset` `reg-event-fx` (boot re-seed via `run`).
- **`routes_epochs/core.cljs`** — delete the `reset-button` (its `:on-click` dispatched `[:routes-epochs/reset]` + `runner/reset-runner!`) and its describing comment. **KEPT** `[current-route-strip]` and the `:routes-epochs/reset` `reg-event-fx` (boot re-seed via `run`).

Runner (`tools/xray/testbeds/runner/core.cljs`) untouched — that is #2885's surface. `runner/` require stays valid (`runner/initial-state`, `runner/runner` still used). The macro-injected `dispatch` local from `reg-view` is simply no longer referenced — no orphan/unused warning. A human refreshes the browser to reset. Mirrors the #2882 removal exactly.

## Quality gates (cold)

- `npx shadow-cljs compile :examples/managed-http` → Build completed, **0 warnings**.
- `npx shadow-cljs compile :examples/routes-epochs` → Build completed, **0 warnings**.
- `npm run test:xray-feature-gate` → **EXIT 0**; "Ran 16 Xray feature scenarios. 0 failures. Covered 13 matrix rows." The runner drives the decks (not the deleted button), so the gate is unaffected. (The trailing `http-server exited unexpectedly` line is post-summary teardown noise, not a failure.)
- Testbeds test-free (rf2-8cevm): re-confirmed via `git grep` that `managed-http-deck-reset` and the testbed `reset-button` testid are **not** referenced by any `scenarios.cjs`/spec. (The only `reset-button` hits are unrelated Xray *panel* components — `share_modal.cljs`, `static/machines/sim.cljs` — and their tests.)

Closes rf2-oncri.