### PR TITLE
refactor(pair-mcp): share read-dom/read-ui eval plumbing + clarify the layer split (rf2-q0r7e)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -41,6 +41,13 @@
 ;;;;     | `list-subscriptions`    | `sub-cache-info`            |
 ;;;;     | `list-streams`          | `subscription-info`         |
 ;;;;     | `list-handlers`         | `rf/registrations`          |
+;;;;     | `read-dom`              | `dom-read`                  |
+;;;;     | `read-ui`               | `ui-read`                   |
+;;;;
+;;;;   (rf2-q0r7e: `read-dom` and `read-ui` share one DOM-read core —
+;;;;   `node->content` — and both ship a thin `(…/dom-read …)` /
+;;;;   `(…/ui-read …)` call via the same eval-form plumbing, so neither
+;;;;   op's eval form can rot independently.)
 ;;;;
 ;;;;   (rf2-qicji: `list-subscriptions` reads the live reactive
 ;;;;   sub-cache via `sub-cache-info`; the streaming-tap diagnostic it
@@ -2763,6 +2770,17 @@
 ;; ui-read — view-plane RENDERED-CONTENT read + producing ENTITY (rf2-3bu3d.1)
 ;; ---------------------------------------------------------------------------
 ;;
+;; The two DOM-read planes (rf2-q0r7e). `dom-read` (above) is the RAW DOM
+;; plane: a CSS selector → matched nodes, multi-node, NO re-frame2 awareness
+;; — "what does this exact node SAY?". `ui-read` (here) is the re-frame2 VIEW
+;; plane: it rides the `data-rf-view` map → content PLUS the producing ENTITY
+;; (view-id, source-coord, subs-read, render-key) — "what is this view, and
+;; what produced it?". They share the per-node projection core (`node->content`)
+;; so the projection cannot rot on one plane alone, but the planes stay
+;; semantically distinct. Pick `dom-read` when you have a selector and want
+;; raw content across N nodes; pick `ui-read` when you want a view's content
+;; AND its re-frame2 provenance in one round-trip.
+;;
 ;; The DOM-to-source bridge above (dom-source-at / dom-describe /
 ;; dom-find-by-src) answers "where in the SOURCE did this come from?" — a
 ;; gesture/selector → source-coord + registration meta. It does NOT answer
@@ -2841,31 +2859,183 @@
            (some? (.getAttribute n "data-rf-view"))) n
       :else (recur (.-parentNode n)))))
 
-(defn- node-attrs
-  "Collect a node's attributes as a `{name value}` map. Always includes
-   the structural identity attrs (id / class / role / type / name / value
-   / href / …) plus every `data-*` / `aria-*` attribute — the view-plane
-   idiom for surfacing rendered state. `data-rf-view` /
-   `data-rf2-source-coord` are dropped: they're framework-internal
-   annotations already surfaced structurally under `:entity`, so leaving
-   them in the raw attr map would be noise."
-  [el]
-  (let [structural #{"id" "class" "role" "type" "name" "value" "href"
-                     "title" "placeholder" "disabled" "checked" "selected"
-                     "hidden"}
-        internal   #{"data-rf-view" "data-rf2-source-coord"}]
+;; ---------------------------------------------------------------------------
+;; Shared DOM-read core — used by BOTH `dom-read` (raw DOM plane) and
+;; `ui-read` (re-frame2 view plane), so the per-node projection cannot rot
+;; on one op alone (rf2-q0r7e).
+;;
+;; Before this share, `dom-read` lived INLINED as a raw eval string in the
+;; MCP tool (`read_dom.cljs`) while `ui-read` called this runtime ns. The
+;; two carried INDEPENDENT copies of "querySelector → {:tag :text :attrs}",
+;; and they rotted apart: rf2-w2mjm — the inlined read-dom form lowered the
+;; tag with `(str/lower-case …)`, but the BARE browser cljs-eval context the
+;; inlined string ran in aliases NOTHING (no `:require`), so `str` was
+;; unresolved, the whole form nilled out, and EVERY read-dom call came back
+;; `:read-dom-blank-result` — while read-ui, calling THIS ns (which DOES
+;; `:require [clojure.string :as str]`), stayed green. Folding read-dom onto
+;; this runtime fn removes that alias trap entirely: both ops now run in a
+;; namespace with real requires, and the projection below is the single
+;; place a fix or a break lands.
+;;
+;; The SEMANTICS stay distinct — `dom-read` is the raw DOM plane (a CSS
+;; selector → matched nodes, multi-node, no re-frame2 awareness) and
+;; `ui-read` is the view plane (rides the `data-rf-view` map → content PLUS
+;; the producing entity). Only the per-node PROJECTION (tag + capped text +
+;; attribute map) is shared.
+
+(def ^:private structural-attrs
+  "The structural identity attributes both planes surface by name when no
+   explicit attr list is supplied. Carries rendered identity / state."
+  #{"id" "class" "role" "type" "name" "value" "href"
+    "title" "placeholder" "disabled" "checked" "selected" "hidden"})
+
+(def ^:private internal-attrs
+  "Framework-internal annotations dropped from the view-plane attr map —
+   they're already surfaced structurally under `:entity`, so leaving them
+   in the raw attr map would be noise."
+  #{"data-rf-view" "data-rf2-source-coord"})
+
+(defn- collect-attrs
+  "Collect a node's attributes as a `{name value}` map.
+
+   `opts`:
+     :names         when a non-nil vector of attribute-name strings, ONLY
+                    those names are read (the caller is in control — the
+                    raw-DOM-plane explicit-`:attrs` mode). When nil, the
+                    curated `structural-attrs` set rides.
+     :prefix-sweep? when true, ALSO sweep every `data-*` / `aria-*`
+                    attribute the node carries (the view-plane idiom for
+                    surfacing rendered state).
+     :drop-internal? when true, omit the framework-internal annotations
+                    (`internal-attrs`) — the view plane drops them; the
+                    raw DOM plane keeps whatever the caller named.
+
+   Implemented as a single attribute walk so both planes share the
+   selection rules."
+  [el {:keys [names prefix-sweep? drop-internal?]}]
+  (let [named (when names (set names))]
     (persistent!
       (reduce
         (fn [acc a]
           (let [nm (.-name a)]
-            (if (and (not (contains? internal nm))
-                     (or (contains? structural nm)
-                         (.startsWith nm "data-")
-                         (.startsWith nm "aria-")))
+            (if (and (or (nil? drop-internal?)
+                         (not (contains? internal-attrs nm)))
+                     (or (if named
+                           (contains? named nm)
+                           (contains? structural-attrs nm))
+                         (and prefix-sweep?
+                              (or (.startsWith nm "data-")
+                                  (.startsWith nm "aria-")))))
               (assoc! acc nm (.-value a))
               acc)))
         (transient {})
         (array-seq (.-attributes el))))))
+
+(defn- cap-text
+  "Read `el`'s `textContent`, capped at `max-text` characters. Over-cap
+   text collapses to the framework size-elision marker shape
+   `{:rf.size/large-elided {:type :dom-text :chars N :preview \"…\"}}` —
+   the SAME shape `get-path` / `snapshot` emit (rf2-urjnc), so an agent
+   recognises an elision uniformly. Under-cap text rides as the raw
+   string. Pure read."
+  [el max-text]
+  (let [t  (let [tc (.-textContent el)] (if (string? tc) tc ""))
+        tn (count t)]
+    (if (> tn max-text)
+      {:rf.size/large-elided
+       {:type :dom-text :chars tn :preview (subs t 0 (min tn 120))}}
+      t)))
+
+(defn- node->content
+  "Project ONE DOM element to the structured `{:tag :text :attrs}` shape
+   both DOM-read planes return. `max-text` caps the text (see `cap-text`);
+   `attr-opts` selects the attribute strategy (see `collect-attrs`). The
+   single place the per-node projection lives — a fix or a break here
+   lands on BOTH `dom-read` and `ui-read`, never one alone (rf2-q0r7e)."
+  [el max-text attr-opts]
+  {:tag   (str/lower-case (or (.-tagName el) ""))
+   :text  (cap-text el max-text)
+   :attrs (collect-attrs el attr-opts)})
+
+;; ---------------------------------------------------------------------------
+;; dom-read — raw DOM plane: CSS selector → matched nodes {:tag :text :attrs}
+;; (rf2-nfjil; folded onto this runtime ns by rf2-q0r7e).
+;;
+;; The complement to `ui-read`: NO re-frame2 awareness. A plain
+;; `querySelectorAll`, optional sub-selector run relative to each match, a
+;; matched-node `:limit`, and the shared per-node projection. Caps run
+;; HERE (browser-side) so only bounded EDN crosses the wire — a 5 MB <pre>
+;; never leaves the tab.
+
+(defn dom-read
+  "Read rendered DOM content by CSS selector — the RAW DOM plane
+   (rf2-nfjil). Returns the matched-node count + per-node
+   `{:tag :text :attrs}`, capped at the source. The view-plane
+   counterpart is `ui-read` (which rides the `data-rf-view` map and also
+   returns the producing re-frame2 entity).
+
+   `opts`:
+     :selector      CSS selector (required) — `querySelectorAll`.
+     :sub-selector  optional CSS selector run RELATIVE to each matched
+                    node (`node.querySelectorAll`) — narrows a coarse
+                    match to its inner parts. When supplied the result's
+                    `:nodes` are the sub-matches.
+     :limit         max matched nodes returned (default 50). Excess nodes
+                    drop and `:truncated?` flips true; `:count` still
+                    reports the full tally.
+     :max-text      per-node `textContent` char cap (default 2000).
+                    Over-cap text → `:rf.size/large-elided` marker.
+     :attrs         optional vector of attribute-name strings. When
+                    supplied ONLY those are read (the caller is in
+                    control). When omitted the curated structural set
+                    rides PLUS a `data-*` / `aria-*` prefix sweep.
+
+   Returns (success):
+     {:ok? true :selector <sel> [:sub-selector <sub>] :count <total>
+      :truncated? <bool> :nodes [{:tag :text :attrs} …]}
+
+   Failure (each :ok? false, never a silent empty):
+     :rf.error/read-dom-no-document   — no DOM (server-side / headless)
+     :rf.error/read-dom-bad-selector  — malformed CSS selector
+
+   Read-only by construction: only `querySelectorAll` / `textContent` /
+   attribute strings are read — never a write, a dispatch, or a node
+   mutation."
+  ([] (dom-read {}))
+  ([opts]
+   (let [{:keys [selector sub-selector limit max-text attrs]} opts
+         limit    (if (and (number? limit) (pos? limit)) (long limit) 50)
+         max-text (if (and (number? max-text) (pos? max-text)) (long max-text) 2000)
+         ;; nil attrs ⇒ curated structural set + data-*/aria- sweep; an
+         ;; explicit vector ⇒ exactly those names, no sweep (the caller is
+         ;; in control). The raw DOM plane keeps whatever the caller named
+         ;; (no internal-annotation drop — that's a view-plane concern).
+         attr-opts (if attrs
+                     {:names attrs :prefix-sweep? false}
+                     {:names nil   :prefix-sweep? true})]
+     (cond
+       (not (exists? js/document))
+       {:ok? false :reason :rf.error/read-dom-no-document}
+
+       :else
+       (try
+         (let [nodes  (array-seq (.querySelectorAll js/document selector))
+               scoped (if (some? sub-selector)
+                        (mapcat (fn [n] (array-seq (.querySelectorAll n sub-selector))) nodes)
+                        nodes)
+               total  (count scoped)
+               want   (take limit scoped)]
+           (cond-> {:ok?        true
+                    :selector   selector
+                    :count      total
+                    :truncated? (> total (count want))
+                    :nodes      (mapv #(node->content % max-text attr-opts) want)}
+             (some? sub-selector) (assoc :sub-selector sub-selector)))
+         (catch :default e
+           {:ok?      false
+            :reason   :rf.error/read-dom-bad-selector
+            :selector selector
+            :message  (.-message e)}))))))
 
 (defn- view-entity
   "Resolve the re-frame2 ENTITY that produced `view-root` — the headline
@@ -2929,10 +3099,17 @@
 (defn ui-read
   "Read the RENDERED content of a view (or the view at a point / selector)
    as structured, ELIDED data, PLUS the re-frame2 entity that produced it
-   (rf2-3bu3d.1). The view-plane counterpart to `snapshot` / `get-path`'s
-   data-plane reads — answers \"what does the thing I'm looking at SHOW,
-   and what produced it?\" in ONE round-trip, on ANY re-frame2 app with
-   zero testids.
+   (rf2-3bu3d.1). The re-frame2 VIEW plane — answers \"what does the thing
+   I'm looking at SHOW, and what produced it?\" in ONE round-trip, on ANY
+   re-frame2 app with zero testids.
+
+   Sibling op `dom-read` is the RAW DOM plane (a CSS selector → matched
+   nodes, multi-node, no re-frame2 awareness). `ui-read` is the VIEW plane:
+   it rides the `data-rf-view` map to return content PLUS provenance
+   (view-id / source-coord / subs-read / render-key). They share the
+   per-node projection core (`node->content`) but stay semantically
+   distinct — pick `dom-read` for raw content by selector, `ui-read` for a
+   view + its re-frame2 entity.
 
    `opts` selects exactly one entry point (`:view-id` wins, then `:point`,
    then `:selector`) and tunes the read:
@@ -2995,26 +3172,27 @@
                    view-root (if (= via :view-id)
                                hit-el
                                (nearest-view-root hit-el))
-                   raw-text  (let [t (.-textContent hit-el)] (if (string? t) t ""))
-                   tn        (count raw-text)
-                   ;; Hard cap BEFORE the elision walker — keeps a 5 MB
-                   ;; <pre> from ever reaching the wire; emits the same
-                   ;; marker shape get-path / snapshot use (rf2-urjnc).
-                   capped    (if (> tn max-text)
-                               {:rf.size/large-elided
-                                {:type :dom-text :chars tn
-                                 :preview (subs raw-text 0 (min tn 120))}}
-                               raw-text)
+                   ;; Shared per-node projection (rf2-q0r7e) — the SAME
+                   ;; tag + capped-text + attr core dom-read uses. The
+                   ;; view plane reads the curated structural set PLUS the
+                   ;; data-*/aria- sweep, and DROPS the framework-internal
+                   ;; annotations (already surfaced under :entity). The
+                   ;; hard text cap (`max-text`) runs HERE, inside the
+                   ;; shared `cap-text`, BEFORE the elision walker — keeps
+                   ;; a 5 MB <pre> from ever reaching the wire.
+                   base      (node->content hit-el max-text
+                                            {:names nil :prefix-sweep? true
+                                             :drop-internal? true})
                    ;; Elide like snapshot / get-path — declared-large /
                    ;; sensitive content collapses, never raw user DOM text
-                   ;; unconditionally (Tool-Pair §Direct-read privacy).
-                   text      (rf/elide-wire-value capped {:frame frame-id})]
+                   ;; unconditionally (Tool-Pair §Direct-read privacy). The
+                   ;; view plane layers this ON TOP of the shared core; the
+                   ;; raw DOM plane (`dom-read`) does not elide.
+                   text      (rf/elide-wire-value (:text base) {:frame frame-id})]
                {:ok?     true
                 :via     via
                 :entity  (view-entity view-root frame-id)
-                :content {:tag   (str/lower-case (or (.-tagName hit-el) ""))
-                          :text  text
-                          :attrs (node-attrs hit-el)}})))
+                :content (assoc base :text text)})))
          (catch :default e
            {:ok?     false
             :reason  :rf.error/ui-read-bad-selector

--- a/skills/re-frame2-pair/references/ops.md
+++ b/skills/re-frame2-pair/references/ops.md
@@ -113,9 +113,18 @@ Read-only from the trace stream + epoch history.
 | `dom/fire-click-at-src` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/dom-fire-click \"view.cljs\" 84)"}` | Synthesise a click on the element rendered by that line |
 | `dom/describe` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/dom-describe \"#save-button\")"}` | Tag, classes, both source-coord attributes, and any registration metadata they resolve to |
 
-## View → rendered content + producing entity (`ui/read`)
+## Reading what's on screen — two planes (`read-dom` vs `read-ui`)
 
-**The most common UI-pairing question, first-classed.** The DOM source bridge above maps a gesture/selector → *source coord*; `read-dom` returns *content* by an explicit CSS selector. `ui/read` (MCP tool `read-ui`, rf2-3bu3d.1) does what neither does: given a **view-id** (or a point / CSS selector), return the **rendered subtree** as structured, elided data **PLUS the re-frame2 entity that produced it** — view-id, source-coord, render-key, and the frame's live `subs-read` — in one round-trip. It rides the **same view-id↔DOM map** the Xray pink hover-highlight uses (every registered view's root carries `data-rf-view="<id>"`, per [Spec 006 §View tagging contract](../../../spec/006-ReactiveSubstrate.md#view-tagging-contract-fallback)), so it works on **any** re-frame2 app with **zero testids** — no more guessing selectors then mapping the node back to a view by hand.
+Two rendered-state reads at **different layers** — NOT duplicates:
+
+- **`read-dom` = the raw DOM plane.** A CSS selector → matched nodes `{:tag :text :attrs}`. Multi-node, exact, **no re-frame2 awareness**. *"What does this exact node SAY?"*
+- **`read-ui` = the re-frame2 view plane.** Rides the `data-rf-view` map → content **PLUS the producing entity** (view-id, source-coord, subs-read, render-key). *"What is this view, and what produced it?"*
+
+**When to use which:** reach for `read-dom` when you already have a CSS selector and want raw content across N matched nodes and don't need provenance; reach for `read-ui` when you want a view's content **and** its re-frame2 entity (which subs feed it, where it's defined) in one round-trip — or when you only have a view-id / a screen point rather than a selector. Both apply per-node text caps at the source and emit the same `:rf.size/large-elided` marker for over-cap text. Under the hood both call the same preloaded runtime ns (`re-frame2-pair.runtime/dom-read` / `…/ui-read`) and share one per-node projection, so their content shapes stay aligned.
+
+### View → rendered content + producing entity (`ui/read`)
+
+**The most common UI-pairing question, first-classed.** The DOM source bridge above maps a gesture/selector → *source coord*; `read-dom` returns raw *content* by an explicit CSS selector. `ui/read` (MCP tool `read-ui`, rf2-3bu3d.1) does what neither does: given a **view-id** (or a point / CSS selector), return the **rendered subtree** as structured, elided data **PLUS the re-frame2 entity that produced it** — view-id, source-coord, render-key, and the frame's live `subs-read` — in one round-trip. It rides the **same view-id↔DOM map** the Xray pink hover-highlight uses (every registered view's root carries `data-rf-view="<id>"`, per [Spec 006 §View tagging contract](../../../spec/006-ReactiveSubstrate.md#view-tagging-contract-fallback)), so it works on **any** re-frame2 app with **zero testids** — no more guessing selectors then mapping the node back to a view by hand.
 
 Pass **exactly one** entry point (precedence `view-id` > `point` > `selector`). The returned `:text` is routed through `re-frame.core/elide-wire-value` (the same elision `snapshot` / `get-path` use), so large/sensitive content collapses to a `:rf.size/large-elided` marker rather than shipping raw user DOM text. Read-only by construction.
 
@@ -127,9 +136,9 @@ Pass **exactly one** entry point (precedence `view-id` > `point` > `selector`). 
 
 The accepted args (`:additionalProperties false`): `view-id`, `point`, `selector`, `max-text` (per-node char cap, default 2000), `frame`, `build`. Failure modes: `:no-target-arg` (no entry point), `:no-element` (entry point matched nothing), `:rf.error/ui-read-bad-selector` (malformed CSS). A portal / fragment leaf with no tagged view ancestor still returns `:content`, with `:entity {:view-id nil :reason :no-tagged-view-root}`.
 
-### `read-dom` — rendered content by explicit CSS selector (rf2-nfjil)
+### `read-dom` — raw DOM content by explicit CSS selector (rf2-nfjil)
 
-`read-ui` is the typed view read (it rides the view-id↔DOM map and returns the producing entity). `read-dom` is the **content-only** read by an explicit CSS selector — the answer to *"did the UI update?"* / *"what does the rendered node SAY?"* when you already have a selector and don't need the entity provenance. The data-plane reads (`snapshot` / `get-path` / `read-sub` / `trace-window`) tell you what's in `app-db` and the trace; `read-dom` tells you what the app actually **put on screen**. Read-only by construction (only `querySelectorAll` + `textContent` / attribute strings). Pairs with `dispatch :await-render` / `:settle` for a deterministic *dispatch → settle → read-dom* observe.
+`read-dom` is the **raw DOM plane** read by an explicit CSS selector — the answer to *"did the UI update?"* / *"what does the rendered node SAY?"* when you already have a selector and don't need the entity provenance (for that, use `read-ui` above). The data-plane reads (`snapshot` / `get-path` / `read-sub` / `trace-window`) tell you what's in `app-db` and the trace; `read-dom` tells you what the app actually **put on screen**. Read-only by construction (only `querySelectorAll` + `textContent` / attribute strings). Pairs with `dispatch :await-render` / `:settle` for a deterministic *dispatch → settle → read-dom* observe.
 
 | Op | Invocation | Returns |
 |---|---|---|

--- a/skills/re-frame2-pair/references/recipes.md
+++ b/skills/re-frame2-pair/references/recipes.md
@@ -165,7 +165,7 @@ Then chain:
 3. Narrate: what the component is, what props it takes, which event(s) its interactions dispatch, and which subscriptions it reads (`:subs-read` already names them). Cross-check against `handler-meta {kind: "view", id: <id>}` for registered views.
 4. If `read-ui` returns `:entity {:view-id nil :reason :no-tagged-view-root}` (a portal / fragment leaf), fall back to `eval-cljs` over `(re-frame2-pair.runtime/dom-source-at "sel")` then `(re-frame2-pair.runtime/dom-describe "sel")` to report tag/class/listeners, and ask the user to point at the source instead.
 
-To read JUST the rendered content of a node you already have a selector for (no entity provenance needed), use `read-dom {selector: "..."}` — see [ops.md §read-dom](ops.md#read-dom--rendered-content-by-explicit-css-selector-rf2-nfjil).
+To read JUST the rendered content of a node you already have a selector for (no entity provenance needed), use `read-dom {selector: "..."}` — see [ops.md §read-dom](ops.md#read-dom--raw-dom-content-by-explicit-css-selector-rf2-nfjil).
 
 This is one of the most grounding moves you can make — it turns *"that button"* into *"`re-com/button` at `app/cart/view.cljs:84`, dispatching `[:cart/checkout]`"* in one step.
 

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -1730,15 +1730,29 @@ Success: `{:ok? true :query-v <v> :frame <id> :value <elided-value>
 
 ## read-dom
 
-View-plane READ (rf2-nfjil): query the **rendered DOM** by CSS selector
-and return matched count + per-node `{:tag :text :attrs}`. The
-data-plane reads (`snapshot` / `get-path` / `trace-window` /
-`list-subscriptions`) answer "what's in app-db and the trace?";
-`read-dom` answers "what did the app actually put on screen?" — the
-read needed for "did the UI update?" and "what does the rendered
+**Raw DOM plane** READ (rf2-nfjil): query the **rendered DOM** by CSS
+selector and return matched count + per-node `{:tag :text :attrs}`.
+Multi-node, exact, **no re-frame2 awareness** — "what does this exact
+node SAY?". The data-plane reads (`snapshot` / `get-path` /
+`trace-window` / `list-subscriptions`) answer "what's in app-db and the
+trace?"; `read-dom` answers "what did the app actually put on screen?" —
+the read needed for "did the UI update?" and "what does the rendered
 node / attribute say?". It generalises the source-coord reads
 (`handler-meta`'s `:rf.source/uri`, which return where a handler is
 *defined*) to rendered-*content* reads (what's on screen *now*).
+
+**The two DOM-read planes** (rf2-q0r7e). `read-dom` (this op) is the
+**raw DOM plane** above; `read-ui` (below) is the **re-frame2 view
+plane** — it rides the `data-rf-view` map to return content PLUS the
+producing entity (view-id / source-coord / subs-read / render-key). They
+are NOT duplicates: pick `read-dom` for raw content across N matched
+nodes by selector, `read-ui` for a view's content AND its re-frame2
+provenance in one round-trip. Both route through the SAME runtime ns
+(`re-frame2-pair.runtime/dom-read` and `…/ui-read`) via the SAME
+`eval-form` plumbing, sharing one per-node projection (`node->content`),
+so a fix or a regression-guard on the shared form covers both — neither
+can silently break alone (the rf2-w2mjm failure, where read-dom's
+separately-inlined eval form nilled out while read-ui stayed green).
 
 Named with the catalogued `read-<thing>` verb (NAMING.md §The verb
 table): a cheap reflection of already-rendered state — the render
@@ -1749,15 +1763,17 @@ resolves only after the substrate has flushed new state to the DOM, so
 `dispatch → settle → read-dom` is a deterministic three-step observe
 with no manual `requestAnimationFrame` dance.
 
-**Read-only by construction.** The browser-side eval form calls
-`querySelectorAll` and reads `textContent` / attribute strings only —
-it never assigns a property, dispatches an event, or mutates a node.
-The descriptor carries the read-only annotations so hosts auto-approve.
+**Read-only by construction.** The runtime fn
+(`re-frame2-pair.runtime/dom-read`) calls `querySelectorAll` and reads
+`textContent` / attribute strings only — it never assigns a property,
+dispatches an event, or mutates a node. The descriptor carries the
+read-only annotations so hosts auto-approve.
 
 **Capped at the source.** The per-node text cap (`max-text`) and the
-matched-node `limit` are applied **browser-side**, so only bounded EDN
-crosses the wire — a 5 MB `<pre>` blob never leaves the tab. Over-cap
-text is replaced with the framework's size-elision marker shape
+matched-node `limit` are applied **browser-side** (inside the runtime
+fn), so only bounded EDN crosses the wire — a 5 MB `<pre>` blob never
+leaves the tab. Over-cap text is replaced with the framework's
+size-elision marker shape
 `{:rf.size/large-elided {:type :dom-text :chars N :preview "..."}}` —
 the same convention `get-path` / `snapshot` emit for over-threshold
 app-db slots (see §Size-elision, rf2-urjnc). The wire-boundary token
@@ -1802,27 +1818,41 @@ nREPL round-trip);
 `js/document` (headless / server-side);
 `:reason :rf.error/read-dom-blank-result` (rf2-r5erl) when the browser
 eval came back **blank** (no map envelope — the runtime didn't answer,
-e.g. a dropped WebSocket). This is returned as a normal `{:ok? false}`
-tool result; it is NEVER a host-level transport failure. (Earlier a
-blank eval threaded `nil` into the result envelope, whose `null`
-`structuredContent` failed the SDK's `outputSchema` validation with
-`expected record at structuredContent, received null` — bypassing this
-error contract entirely. `wire/ok-text` / `err-text` now guarantee a
-non-null `structuredContent` record, and read-dom maps a blank result
-to this reason.);
+e.g. a dropped WebSocket or a preload wiped by a full page refresh).
+Since rf2-q0r7e read-dom calls the preloaded runtime fn (the same shared
+plumbing read-ui uses) rather than inlining an eval string, an
+unresolved-alias miss can no longer nil the form out — a blank result
+now means the runtime genuinely didn't answer, not a form bug. This is
+returned as a normal `{:ok? false}` tool result; it is NEVER a
+host-level transport failure. (Earlier a blank eval threaded `nil` into
+the result envelope, whose `null` `structuredContent` failed the SDK's
+`outputSchema` validation with `expected record at structuredContent,
+received null` — bypassing this error contract entirely. `wire/ok-text`
+/ `err-text` now guarantee a non-null `structuredContent` record, and
+read-dom maps a blank result to this reason.);
 `:reason :runtime-not-preloaded` if the preload hasn't run;
 `:reason :read-dom-failed` (with `:message`) on any other failure.
 
 ## read-ui
 
 The typed **`ui/read`** op (a.k.a. `view/rendered`, rf2-3bu3d.1) — the
-complement to `read-dom`. Where `read-dom` needs an explicit CSS
-selector and returns only content, `read-ui` rides the **view-id↔DOM
-map** and returns the rendered subtree **plus the re-frame2 entity that
-produced it**, in one round-trip: given a **view-id** (or a point / CSS
-selector), `{:via … :entity {…} :content {…}}`. It answers the most
-common UI-pairing question — "what does the thing I'm looking at SHOW,
-and what produced it?" — on **any** re-frame2 app with **zero testids**.
+**re-frame2 view plane**, the sibling of `read-dom`'s raw DOM plane (see
+§read-dom §The two DOM-read planes). Where `read-dom` needs an explicit
+CSS selector and returns only raw content with no re-frame2 awareness,
+`read-ui` rides the **view-id↔DOM map** and returns the rendered subtree
+**plus the re-frame2 entity that produced it**, in one round-trip: given
+a **view-id** (or a point / CSS selector), `{:via … :entity {…} :content
+{…}}`. It answers the most common UI-pairing question — "what does the
+thing I'm looking at SHOW, and what produced it?" — on **any** re-frame2
+app with **zero testids**.
+
+**Shared DOM-read core** (rf2-q0r7e). `read-ui` and `read-dom` route
+through the SAME runtime ns via the SAME `eval-form` plumbing
+(`re-frame2-pair.runtime/ui-read` and `…/dom-read`) and share one
+per-node projection (`node->content`: tag + capped text + attribute
+map). The view plane layers entity-resolution + privacy elision ON TOP
+of that shared core; the raw DOM plane returns the core directly. A fix
+or a regression-guard on the shared form covers both ops.
 
 **Riding the view↔DOM map.** The browser-side work
 (`re-frame2-pair.runtime/ui-read`) reuses the mapping the substrate

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
@@ -1,30 +1,67 @@
 (ns re-frame2-pair-mcp.tools.read-dom
-  "Tool: read-dom — first-class view-plane READ (rf2-nfjil).
+  "Tool: read-dom — the RAW DOM plane read (rf2-nfjil).
 
-  ## Why a view-plane read primitive
+  ## The two DOM-read planes (read-dom vs read-ui)
+
+  re-frame2-pair carries TWO rendered-state reads, at different LAYERS —
+  they are NOT duplicates:
+
+  - `read-dom` (this op) = the **raw DOM plane**: a CSS selector →
+    matched nodes `{:tag :text :attrs}`. Multi-node, exact, NO re-frame2
+    awareness. \"What does this exact node SAY?\"
+  - `read-ui` = the **re-frame2 view plane**: rides the `data-rf-view`
+    map → content PLUS the producing ENTITY (view-id, source-coord,
+    subs-read, render-key). \"What is this view, and what produced it?\"
+
+  Pick `read-dom` when you have a selector and want raw content across N
+  matched nodes; pick `read-ui` when you want a view's content AND its
+  re-frame2 provenance in one round-trip.
+
+  ## Why a raw-DOM read primitive
 
   re-frame2-pair has rich DATA-plane reads — `snapshot` / `get-path`
   (app-db), `trace-window` / `watch-epochs` (epoch history),
-  `list-subscriptions` (the reactive sub-cache). What it lacked: a
-  way to ask what the app actually RENDERED. Answering \"did the UI
-  update?\", \"what does the rendered node / attribute say?\" meant
-  hand-rolling an `eval-cljs` form around `js/document.querySelectorAll`
-  on every call — fiddly, easy to get wrong (text never capped → a
-  multi-megabyte innerText blows the wire cap), and not discoverable in
-  the catalogue. The App-db stale-frame bug (rf2-yng0y) was only
-  diagnosable by reading the DOM repeatedly; this op makes that a
-  first-class gesture.
+  `list-subscriptions` (the reactive sub-cache). What it lacked: a way to
+  ask what the app actually RENDERED, by an explicit selector, with no
+  re-frame2 awareness. Answering \"did the UI update?\", \"what does the
+  rendered node / attribute say?\" meant hand-rolling an `eval-cljs` form
+  around `js/document.querySelectorAll` on every call — fiddly, easy to
+  get wrong (text never capped → a multi-megabyte innerText blows the
+  wire cap), and not discoverable in the catalogue. The App-db
+  stale-frame bug (rf2-yng0y) was only diagnosable by reading the DOM
+  repeatedly; this op makes that a first-class gesture.
 
-  `read-dom` generalises the source-coord reads (`handler-meta`'s
-  `:rf.source/uri`, which return where a handler is DEFINED) to
-  rendered-CONTENT reads — what's on screen NOW.
+  ## One shared DOM-read core with read-ui (rf2-q0r7e)
+
+  Both planes now route through the SAME runtime ns
+  (`re-frame2-pair.runtime`): read-dom emits
+  `(re-frame2-pair.runtime/dom-read {...})` and read-ui emits
+  `(re-frame2-pair.runtime/ui-read {...})`, via the SAME `eval-form` DSL
+  (`tools.eval-form`) and the SAME single-eval prelude
+  (`probe/eval-after-runtime!`). The per-node projection (tag + capped
+  text + attribute map) lives ONCE, in the runtime's `node->content`.
+
+  This folds away a maintenance hazard. read-dom previously INLINED its
+  whole browser-side core as a raw eval string, while read-ui called the
+  runtime fn — two divergent eval forms that rotted apart. rf2-w2mjm: the
+  inlined read-dom form lowered the tag with `(str/lower-case …)`, but
+  the BARE browser cljs-eval context the inlined string ran in aliases
+  NOTHING (no `:require`), so `str` was unresolved, the whole form nilled
+  out, and EVERY read-dom call came back `:read-dom-blank-result` — while
+  read-ui, calling the runtime ns (which DOES require `clojure.string`),
+  stayed green. Both ops gate on the preload runtime being present
+  (`ensure-runtime!`), so the inlining bought nothing; folding read-dom
+  onto the runtime fn removes the alias trap by construction — the core
+  now runs in a namespace with real requires.
 
   ## Naming — the `read-` verb (NAMING.md §The verb table)
 
   Named `read-dom` (not `dom-read`) to ride the catalogued `read-<thing>`
   verb prefix: a cheap reflection of already-rendered state — the render
   already happened; this is a no-recompute read of its output, never a
-  fetch that triggers a render. The verb-vocab conformance linter
+  fetch that triggers a render. (The runtime fn it calls keeps the
+  historical `dom-read` spelling — see the runtime ns's MCP-vs-runtime
+  naming table.) The verb-vocab conformance linter
   (`tools/mcp-conformance/wire-vocab`) classifies tool names by prefix;
   `read-` is conformant with zero catalogue churn.
 
@@ -37,21 +74,20 @@
 
   ## Read-only by construction
 
-  The eval form calls `querySelectorAll` and reads `textContent` /
+  The runtime fn calls `querySelectorAll` and reads `textContent` /
   attribute strings only — it never assigns a property, dispatches an
   event, or mutates a node. The descriptor carries the idempotent
   read-only annotations so agent hosts auto-approve it.
 
   ## Where the work happens — browser-side, capped at the source
 
-  The whole read is composed as a single CLJS form sent over nREPL
-  and evaluated in the browser. Crucially the per-node text cap and
-  the matched-node `:limit` are applied INSIDE that form, so only the
-  already-bounded EDN crosses the wire — a 5 MB `<pre>` blob never
-  leaves the tab. Over-cap text is replaced with the framework's
-  size-elision marker shape `{:rf.size/large-elided {...}}` (the same
-  convention `get-path` / `snapshot` emit, per rf2-urjnc) so the agent
-  recognises an elision at a glance. The wire-boundary cap step
+  The whole read runs in the runtime fn in the tab. Crucially the
+  per-node text cap and the matched-node `:limit` are applied INSIDE that
+  fn, so only the already-bounded EDN crosses the wire — a 5 MB `<pre>`
+  blob never leaves the tab. Over-cap text is replaced with the
+  framework's size-elision marker shape `{:rf.size/large-elided {...}}`
+  (the same convention `get-path` / `snapshot` emit, per rf2-urjnc) so
+  the agent recognises an elision at a glance. The wire-boundary cap step
   (`tools.cljs` §`:apply-cap`) remains the backstop.
 
   ## Wire contract
@@ -97,6 +133,7 @@
   {:ok? false :reason :rf.error/read-dom-no-document}."
   (:require [clojure.string :as str]
             [re-frame2-pair-mcp.tools.wire :as wire]
+            [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
 (def default-limit
@@ -111,20 +148,11 @@
   slots (rf2-urjnc), so the agent recognises an elision uniformly."
   2000)
 
-(def ^:private default-attrs
-  "Curated default attribute set when the caller omits `:attrs`. The
-  structural attrs that carry rendered identity / state, plus a
-  `data-*` / `aria-*` prefix sweep applied browser-side (see
-  `read-dom-form`). Kept small so the common read stays terse; callers
-  wanting an exact set pass `:attrs` explicitly."
-  ["id" "class" "role" "type" "name" "value" "href" "title" "placeholder"
-   "disabled" "checked" "selected" "hidden"])
-
 (defn- parse-attrs-arg
   "Normalise the `:attrs` arg into a vector of attribute-name strings,
-  or nil when omitted (⇒ the curated default set rides browser-side).
-  Accepts a JS array, a CLJS vector, or a comma / whitespace-separated
-  string."
+  or nil when omitted (⇒ the curated default set + a `data-*` / `aria-*`
+  sweep rides runtime-side). Accepts a JS array, a CLJS vector, or a
+  comma / whitespace-separated string."
   [raw]
   (cond
     (nil? raw)        nil
@@ -138,82 +166,33 @@
     :else             nil))
 
 (defn- read-dom-form
-  "Build the browser-side CLJS eval form (rf2-nfjil). The whole read —
-  querySelectorAll, per-node text cap, attribute collection, node
-  `:limit` — runs in the tab so only bounded EDN crosses the wire.
+  "Compose a single `(re-frame2-pair.runtime/dom-read {...})` form via the
+  shared `eval-form` DSL (rf2-q0r7e) — the SAME plumbing read-ui uses. The
+  runtime fn does the whole read (querySelectorAll, per-node text cap,
+  attribute collection, node `:limit`) in the tab, so only bounded EDN
+  crosses the wire.
 
-  `attrs` is either an explicit vector of attribute-name strings or nil
-  (⇒ the default set + a `data-*` / `aria-*` prefix sweep). The form is
-  read-only: it only reads `textContent` and attribute strings."
+  Only present keys ride: an explicit `attrs` vector ⇒ exactly those
+  names (no `data-*`/`aria-*` sweep); omitting it (nil) ⇒ the curated
+  default set + the sweep, resolved runtime-side. The runtime fn is
+  read-only (querySelectorAll + textContent + attribute strings)."
   [selector sub-selector limit max-text attrs]
-  (let [;; Either the explicit attr vector or the curated default. Both
-        ;; emitted as EDN literals via pr-str so the browser-side form
-        ;; gets a clean CLJS vector.
-        attr-list      (or attrs default-attrs)
-        attr-edn       (pr-str (vec attr-list))
-        ;; When no explicit :attrs was passed, also sweep every data-* /
-        ;; aria-* attribute the node carries — the view-plane idiom for
-        ;; surfacing rendered state. With an explicit list the caller is
-        ;; in control, so we do NOT add the sweep.
-        prefix-sweep?  (nil? attrs)]
-    (str
-      "(let [doc (and (exists? js/document) js/document)]"
-      "  (if-not doc"
-      "    {:ok? false :reason :rf.error/read-dom-no-document}"
-      "    (try"
-      "      (let [sel " (pr-str selector)
-      "            nodes (array-seq (.querySelectorAll doc sel))"
-      "            scoped (if " (pr-str (some? sub-selector))
-      "                     (mapcat (fn [n] (array-seq (.querySelectorAll n " (pr-str (or sub-selector "")) "))) nodes)"
-      "                     nodes)"
-      "            total (count scoped)"
-      "            lim " limit
-      "            want (take lim scoped)"
-      "            max-text " max-text
-      "            attr-names " attr-edn
-      "            read-attr (fn [el nm] (when (.hasAttribute el nm) [nm (.getAttribute el nm)]))"
-      "            named-attrs (fn [el] (into {} (keep #(read-attr el %) attr-names)))"
-      "            prefix-attrs (fn [el]"
-      "                           (if-not " (pr-str prefix-sweep?) " {}"
-      "                             (into {}"
-      "                               (keep (fn [a]"
-      "                                       (let [nm (.-name a)]"
-      "                                         (when (or (.startsWith nm \"data-\")"
-      "                                                   (.startsWith nm \"aria-\"))"
-      "                                           [nm (.-value a)])))"
-      "                                     (array-seq (.-attributes el))))))"
-      "            node->edn (fn [el]"
-      "                        (let [t (.-textContent el)"
-      "                              t (if (string? t) t \"\")"
-      "                              tn (count t)"
-      "                              text (if (> tn max-text)"
-      "                                     {:rf.size/large-elided"
-      "                                      {:type :dom-text :chars tn"
-      "                                       :preview (subs t 0 (min tn 120))}}"
-      "                                     t)]"
-      "                          {:tag (.toLowerCase (or (.-tagName el) \"\"))"
-      "                           :text text"
-      "                           :attrs (merge (named-attrs el) (prefix-attrs el))}))]"
-      "        {:ok? true"
-      "         :selector sel"
-      (when sub-selector
-        (str "         :sub-selector " (pr-str sub-selector)))
-      "         :count total"
-      "         :truncated? (> total (count want))"
-      "         :nodes (mapv node->edn want)})"
-      "      (catch :default e"
-      "        {:ok? false"
-      "         :reason :rf.error/read-dom-bad-selector"
-      "         :selector " (pr-str selector)
-      "         :message (.-message e)}))))")))
+  (let [opts (cond-> {:selector selector
+                      :limit    limit
+                      :max-text max-text}
+               (some? sub-selector) (assoc :sub-selector sub-selector)
+               (some? attrs)        (assoc :attrs attrs))]
+    (ef/emit (ef/rt-call 'dom-read opts))))
 
 (defn read-dom-tool
-  "MCP `read-dom` handler. Reads rendered DOM content by CSS selector
-  and returns capped per-node text + attrs as EDN. Read-only.
+  "MCP `read-dom` handler — the raw DOM plane. Reads rendered DOM content
+  by CSS selector and returns capped per-node text + attrs as EDN.
+  Read-only.
 
-  See the ns docstring for the full wire contract. The eval form runs
-  browser-side (caps applied at the source); the wire-boundary cap step
-  in `tools.cljs` is the backstop."
+  See the ns docstring for the full wire contract. The form is a thin
+  `(re-frame2-pair.runtime/dom-read {...})` call (shared `eval-form`
+  plumbing with read-ui); the runtime fn applies caps at the source and
+  the wire-boundary cap step in `tools.cljs` is the backstop."
   [conn raw-args]
   (let [selector     (wire/arg raw-args :selector)
         sub-selector (let [s (wire/arg raw-args :sub-selector)]
@@ -236,7 +215,7 @@
         (probe/eval-after-runtime!
           conn build-id form :read-dom-failed
           (fn [envelope]
-            ;; The browser-side form ALWAYS returns a map (a `{:ok? ...}`
+            ;; The runtime's `dom-read` ALWAYS returns a map (a `{:ok? ...}`
             ;; envelope or the no-document / bad-selector error). A nil /
             ;; non-map here means the eval came back BLANK —
             ;; `cljs-eval-value` reads a blank shadow result as `nil`
@@ -256,14 +235,12 @@
                  :selector selector
                  :hint     (str "read-dom's browser eval returned a blank / "
                                 "non-map value. This is almost always the "
-                                "FORM, not the connection: if the runtime were "
-                                "absent the eval would error rather than return "
-                                "blank, and the form's own no-document / "
-                                "bad-selector branches both return maps. A "
-                                "blank result means the form evaluated to nil — "
-                                "typically an unresolved symbol in the inlined "
-                                "eval string (the browser cljs-eval context "
-                                "aliases nothing beyond cljs.core + JS interop). "
-                                "Reloading the tab will NOT help. If you suspect "
-                                "the connection instead, run discover-app to "
-                                "confirm :liveness :fresh.")}))))))))
+                                "connection, not the form: read-dom calls the "
+                                "preloaded runtime fn (re-frame2-pair.runtime/"
+                                "dom-read) — the same shared plumbing read-ui "
+                                "uses — so an unresolved-alias miss can no "
+                                "longer nil it out. A blank result means the "
+                                "runtime did not answer the eval (a dropped "
+                                "WebSocket, or the preload was wiped by a full "
+                                "page refresh). Run discover-app to confirm "
+                                ":liveness :fresh, then retry.")}))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
@@ -2,21 +2,52 @@
   "Tool: read-ui — the typed `ui/read` (a.k.a. `view/rendered`) op
   (rf2-3bu3d.1).
 
+  ## The two DOM-read planes (read-ui vs read-dom)
+
+  re-frame2-pair carries TWO rendered-state reads, at different LAYERS —
+  they are NOT duplicates:
+
+  - `read-ui` (this op) = the **re-frame2 view plane**: rides the
+    `data-rf-view` map → content PLUS the producing ENTITY (view-id,
+    source-coord, subs-read, render-key). \"What is this view, and what
+    produced it?\"
+  - `read-dom` = the **raw DOM plane**: a CSS selector → matched nodes
+    `{:tag :text :attrs}`. Multi-node, exact, NO re-frame2 awareness.
+    \"What does this exact node SAY?\"
+
+  Pick `read-ui` when you want a view's content AND its re-frame2
+  provenance in one round-trip; pick `read-dom` when you have a selector
+  and want raw content across N matched nodes.
+
   ## Why a view→content+entity read primitive
 
   re-frame2-pair has a rich DOM-to-SOURCE bridge (`dom/source-at`,
   `dom/describe`, `dom/find-by-src`) that maps a gesture/selector →
   source-coord + registration meta — \"where in the code did this come
-  from?\". And `read-dom` returns rendered text/attrs by an explicit CSS
-  selector. What neither answers is the most common UI-pairing question:
-  \"what does the thing I'm looking at SHOW, and which re-frame2 ENTITY
-  produced it?\" — given a VIEW-ID (or a point / selector), in ONE
+  from?\". And `read-dom` returns raw rendered text/attrs by an explicit
+  CSS selector. What neither answers is the most common UI-pairing
+  question: \"what does the thing I'm looking at SHOW, and which re-frame2
+  ENTITY produced it?\" — given a VIEW-ID (or a point / selector), in ONE
   round-trip, return BOTH the rendered subtree AND the producing entity
   (view-id, source-coord, render-key, subs-read).
 
   Before this op, that meant hand-rolling an `eval-cljs` querySelectorAll +
   textContent slice with GUESSED selectors, then a SECOND round-trip to
   map the node back to a view. `read-ui` first-classes the whole gesture.
+
+  ## One shared DOM-read core with read-dom (rf2-q0r7e)
+
+  Both planes route through the SAME runtime ns
+  (`re-frame2-pair.runtime`): read-ui emits
+  `(re-frame2-pair.runtime/ui-read {...})` and read-dom emits
+  `(re-frame2-pair.runtime/dom-read {...})`, via the SAME `eval-form` DSL
+  (`tools.eval-form`) and the SAME single-eval prelude
+  (`probe/eval-after-runtime!`). The per-node projection (tag + capped
+  text + attribute map) lives ONCE, in the runtime's `node->content`; the
+  view plane layers entity-resolution + privacy elision ON TOP of it. A
+  fix or a regression-guard on the shared form covers BOTH ops, so neither
+  can silently break alone (the rf2-w2mjm failure mode, where read-dom's
+  separately-inlined eval form nilled out while read-ui stayed green).
 
   ## Naming — the `ui/read` op, the `read-` verb
 
@@ -105,6 +136,21 @@
   [frame]
   (some-> frame (str/replace #"^:" "") keyword))
 
+(defn- read-ui-form
+  "Compose the single `(re-frame2-pair.runtime/ui-read {...})` form via the
+  shared `eval-form` DSL (rf2-q0r7e) — the SAME plumbing read-dom uses.
+  Only present entry points / knobs ride (the runtime enforces the
+  precedence view-id > point > selector). Pure form-builder, no
+  connection: callable directly by the form-composition regression guard
+  so the alias-trap check covers BOTH ops, not just read-dom."
+  [vid pt selector max-text frame]
+  (let [opts (cond-> {:max-text max-text}
+               (some? vid)      (assoc :view-id vid)
+               (some? pt)       (assoc :point pt)
+               (some? selector) (assoc :selector selector)
+               (some? frame)    (assoc :frame (frame-edn frame)))]
+    (ef/emit (ef/rt-call 'ui-read opts))))
+
 (defn read-ui-tool
   "MCP `read-ui` handler — the typed `ui/read` op. Composes a single
   `(re-frame2-pair.runtime/ui-read {...})` form and forwards the
@@ -146,12 +192,7 @@
             pt    (when (some? point)
                     (let [m (js->clj point :keywordize-keys true)]
                       (when (map? m) (select-keys m [:x :y]))))
-            opts  (cond-> {:max-text max-text}
-                    (some? vid)      (assoc :view-id vid)
-                    (some? pt)       (assoc :point pt)
-                    (some? selector) (assoc :selector selector)
-                    (some? frame)    (assoc :frame (frame-edn frame)))
-            form  (ef/emit (ef/rt-call 'ui-read opts))]
+            form  (read-ui-form vid pt selector max-text frame)]
         (probe/eval-after-runtime!
           conn build-id form :rf.error/read-ui-failed
           (fn [envelope]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -959,24 +959,26 @@
     {:isError? false
      :edn-submap {:ok? false :reason :path-not-found}}}
 
-   ;; ---------- read-dom (rf2-nfjil — view-plane read) --------------------
-   ;; The whole read runs browser-side; the corpus stubs the eval form's
-   ;; canned envelope. Pins the outer wire shape: matched :count +
-   ;; per-node {:tag :text :attrs}, the large-text elision marker, the
-   ;; missing-arg gate, and the bad-selector error reason.
+   ;; ---------- read-dom (rf2-nfjil — raw DOM plane read) -----------------
+   ;; The whole read runs browser-side in the preloaded runtime fn
+   ;; (re-frame2-pair.runtime/dom-read — shared plumbing with read-ui since
+   ;; rf2-q0r7e); the corpus stubs the form's canned envelope, matching on
+   ;; the `dom-read` runtime call. Pins the outer wire shape: matched
+   ;; :count + per-node {:tag :text :attrs}, the large-text elision marker,
+   ;; the missing-arg gate, and the bad-selector error reason.
    {:fixture/id    :read-dom/happy
-    :fixture/doc   "read-dom returns {:ok? true :count N :nodes [{:tag :text :attrs}]} from the browser-side querySelectorAll form."
+    :fixture/doc   "read-dom returns {:ok? true :count N :nodes [{:tag :text :attrs}]} from the browser-side dom-read runtime fn."
     :fixture/tool  "read-dom"
     :fixture/args  {:selector "#app .counter"}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  true]
-     ["querySelectorAll"          {:ok? true :selector "#app .counter"
+     ["dom-read"                  {:ok? true :selector "#app .counter"
                                    :count 1 :truncated? false
                                    :nodes [{:tag "div" :text "Count: 3"
                                             :attrs {"class" "counter" "data-count" "3"}}]}]
      [:default                    nil]]
     :fixture/eval-form-must-contain
-    ["querySelectorAll" "#app .counter" ":rf.size/large-elided"]
+    ["re-frame2-pair.runtime/dom-read" "#app .counter" ":selector"]
     :fixture/expect
     {:isError? false
      :edn-submap {:ok? true :count 1 :truncated? false}
@@ -988,7 +990,7 @@
     :fixture/args  {:selector "pre" :max-text 100}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  true]
-     ["querySelectorAll"          {:ok? true :selector "pre" :count 1 :truncated? false
+     ["dom-read"                  {:ok? true :selector "pre" :count 1 :truncated? false
                                    :nodes [{:tag "pre"
                                             :text {:rf.size/large-elided
                                                    {:type :dom-text :chars 54000 :preview "lorem..."}}
@@ -1009,12 +1011,12 @@
      :reason :missing-selector}}
 
    {:fixture/id    :read-dom/bad-selector
-    :fixture/doc   "read-dom forwards the browser-side :rf.error/read-dom-bad-selector envelope (querySelectorAll threw SyntaxError)."
+    :fixture/doc   "read-dom forwards the browser-side :rf.error/read-dom-bad-selector envelope (querySelectorAll threw SyntaxError inside dom-read)."
     :fixture/tool  "read-dom"
     :fixture/args  {:selector "###"}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  true]
-     ["querySelectorAll"          {:ok? false :reason :rf.error/read-dom-bad-selector
+     ["dom-read"                  {:ok? false :reason :rf.error/read-dom-bad-selector
                                    :selector "###" :message "bad selector"}]
      [:default                    nil]]
     :fixture/expect

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_dom_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/read_dom_test.cljs
@@ -1,14 +1,17 @@
 (ns re-frame2-pair-mcp.read-dom-test
-  "Unit tests for the read-dom view-plane read tool (rf2-nfjil).
+  "Unit tests for the read-dom raw-DOM-plane read tool (rf2-nfjil).
 
   Two layers:
 
     1. Form composition — `read-dom-form` builds the browser-side CLJS
-       source. We assert it carries the load-bearing pieces
-       (`querySelectorAll`, the literal selector, the per-node text cap,
-       the `:rf.size/large-elided` elision marker, the matched-node
-       `:limit`) and stays READ-ONLY (no `.setAttribute` / `set!` /
-       `.dispatchEvent` host-mutation forms).
+       source. Since rf2-q0r7e it is a THIN runtime call —
+       `(re-frame2-pair.runtime/dom-read {...})` — composed via the shared
+       `eval-form` DSL (the SAME plumbing read-ui uses), not an inlined
+       raw eval string. We assert it carries the load-bearing pieces (the
+       runtime `dom-read` call, the literal selector, the `:limit` /
+       `:max-text` knobs, the sub-selector + explicit-attrs slots) and
+       that it depends only on cljs.core + JS interop + the runtime ns
+       (the alias-trap regression guard below).
 
     2. Tool wiring — `read-dom-tool` threads args, runs the preflight,
        and forwards the browser-side envelope. We stub
@@ -18,7 +21,7 @@
        bad-selector error reason.
 
   The browser-side semantics (does querySelectorAll actually find the
-  node? does textContent cap correctly?) are exercised by the eval form
+  node? does textContent cap correctly?) are exercised by the runtime fn
   running in a real tab — out of scope for a node-runtime unit suite;
   the conformance corpus pins the outer wire shape, this suite pins the
   form's internal contract."
@@ -29,95 +32,91 @@
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.nrepl :as nrepl]
-            [re-frame2-pair-mcp.tools.read-dom :as read-dom]))
+            [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.read-dom :as read-dom]
+            [re-frame2-pair-mcp.tools.read-ui :as read-ui]))
 
 ;; ---------------------------------------------------------------------------
 ;; Form composition — the browser-side source contract.
 ;; ---------------------------------------------------------------------------
 
-(deftest form-carries-load-bearing-pieces
+(deftest form-is-thin-runtime-call
+  ;; rf2-q0r7e — read-dom no longer inlines its DOM-read core as a raw
+  ;; eval string; it emits `(re-frame2-pair.runtime/dom-read {...})` via
+  ;; the shared `eval-form` DSL, the SAME plumbing read-ui uses. The
+  ;; per-node projection lives in the runtime's `node->content`, shared
+  ;; with ui-read.
   (let [form (#'read-dom/read-dom-form "#app .counter" nil
                                        read-dom/default-limit
                                        read-dom/default-max-text
                                        nil)]
-    (testing "the query + selector + cap machinery is present"
-      (is (str/includes? form "querySelectorAll"))
+    (testing "the runtime dom-read call + selector + knobs are present"
+      (is (str/includes? form "re-frame2-pair.runtime/dom-read")
+          "calls the shared runtime dom-read fn")
+      (is (str/includes? form ":selector") "selector opt slot present")
       (is (str/includes? form "#app .counter") "literal selector embedded")
-      (is (str/includes? form ":rf.size/large-elided") "text elision marker")
-      (is (str/includes? form (str read-dom/default-max-text)) "per-node text cap")
-      (is (str/includes? form (str read-dom/default-limit)) "matched-node limit"))))
+      (is (str/includes? form (str ":max-text " read-dom/default-max-text)) "per-node text cap rides")
+      (is (str/includes? form (str ":limit " read-dom/default-limit)) "matched-node limit rides"))))
 
 (deftest form-is-read-only
-  ;; READ-ONLY by construction — the form must never carry a DOM
-  ;; mutation host-form. A regression that started writing back to the
-  ;; node (e.g. a normalisation pass) would surface here.
+  ;; READ-ONLY by construction — the THIN form must never carry a DOM
+  ;; mutation host-form. (The runtime fn it calls is itself read-only by
+  ;; construction; this guards the tool-composed form against a future
+  ;; edit slipping a mutation into the opts.)
   (let [form (#'read-dom/read-dom-form "div" ".x" 10 100 ["id" "class"])]
     (doseq [mutator [".setAttribute" ".removeAttribute" ".dispatchEvent"
                      "set! (.-" ".innerHTML" ".click" ".remove("]]
       (is (not (str/includes? form mutator))
           (str "read-dom form must be read-only — found mutator " mutator)))))
 
-(deftest form-uses-js-tolowercase-not-namespaced-alias
-  ;; rf2-5ffuv — REGRESSION GUARD. The inlined eval string is sent over
-  ;; nREPL and evaluated in the BROWSER cljs-eval context, which aliases
-  ;; NOTHING beyond cljs.core + JS interop (it is not a namespace that
-  ;; :requires anything). The original form lowered the tag with
-  ;; `(str/lower-case ...)` — `str` is unresolved there, so the whole form
-  ;; evaluated to nil (a compile-level unresolved-alias miss, NOT a caught
-  ;; error), and EVERY read-dom call came back :read-dom-blank-result. The
-  ;; tag must be lowered with the JS-native `.toLowerCase`, and the form
-  ;; must carry no bare `namespace/sym` alias at all.
-  (let [forms (for [attrs [nil ["id" "class"]]
-                    sub   [nil ".title"]]
-                (#'read-dom/read-dom-form "div" sub 10 100 attrs))]
-    (doseq [form forms]
-      (is (str/includes? form "(.toLowerCase")
-          "tag is lowered via JS .toLowerCase (no clojure.string alias needed)")
-      ;; Broader guard against the latent bug class: the inlined eval
-      ;; string must not lean on ANY require-only SYMBOL alias — those
-      ;; resolve in a namespace that :requires them, but NOT in the bare
-      ;; browser cljs-eval context (it aliases nothing beyond cljs.core +
-      ;; JS interop). Keyword namespaces (`:rf.error/…`, `:rf.size/…`) and
-      ;; JS interop (`js/document`) are legitimate; only a SYMBOL alias is
-      ;; the unresolved-symbol trap. The aliases this ns carries are the
-      ;; suspects worth pinning.
-      (doseq [alias ["str/" "wire/" "probe/" "j/"]]
-        (is (not (str/includes? form alias))
-            (str "the inlined eval form must depend only on cljs.core + JS "
-                 "interop — found require-only alias " alias))))))
-
 ;; ---------------------------------------------------------------------------
-;; rf2-w2mjm — GENERAL unresolved-symbol guard (the alias-trap bug CLASS).
+;; rf2-w2mjm / rf2-q0r7e — the unresolved-symbol-alias guard, now over the
+;; SHARED form (covers BOTH read-dom AND read-ui).
 ;;
-;; rf2-5ffuv pinned the ONE alias that had bitten (`str/lower-case`) via a
-;; substring blocklist of the four aliases this ns happens to carry
-;; (`str/ wire/ probe/ j/`). That blocklist is brittle: a future edit that
-;; reaches for a DIFFERENT require-only symbol — `set/union`,
-;; `walk/postwalk`, a freshly-aliased helper — would sail past it and
-;; re-introduce the exact failure mode (the whole inlined form is sent to
-;; the browser cljs-eval context, which aliases NOTHING beyond cljs.core +
-;; JS interop; an unresolved symbol there makes the entire form evaluate to
-;; nil — a compile-level miss the inner try/catch cannot trap — and EVERY
-;; read-dom call comes back :rf.error/read-dom-blank-result, while read-ui,
-;; which calls a runtime fn rather than inlining source, stays unaffected).
+;; The bug it pins: the inlined eval string is sent over nREPL and
+;; evaluated in the BROWSER cljs-eval context, which aliases NOTHING
+;; beyond cljs.core + JS interop (it is not a namespace that :requires
+;; anything). rf2-5ffuv: the original read-dom form lowered the tag with
+;; `(str/lower-case ...)` — `str` is unresolved there, so the whole form
+;; evaluated to nil (a compile-level miss, NOT a caught error), and EVERY
+;; read-dom call came back :read-dom-blank-result, while read-ui — which
+;; called a runtime fn rather than inlining source — stayed green.
 ;;
-;; This guard parses the generated form and asserts every PLAIN symbol in
-;; it resolves to one of: a special form, a `cljs.core` name, a JS-interop
-;; form (`js/…`, `.method`, `.-field`), or a local binding introduced by
-;; the form's own `let` / `fn` / `fn*`. Any residual symbol is a
-;; require-only alias that will nil the form out at runtime — the test
-;; fails BY NAME on the offender, no blocklist to keep in sync.
+;; rf2-w2mjm generalised the guard from a brittle alias BLOCKLIST to a
+;; PARSE-and-prove approach: parse the generated form, assert every PLAIN
+;; symbol resolves to a special form, a `cljs.core` name, a JS-interop
+;; form, a local binding, OR the runtime-ns-qualified call (the runtime
+;; preload provides that ns). Any residual require-only alias fails the
+;; test BY NAME.
+;;
+;; rf2-q0r7e folded read-dom onto the SAME runtime-call plumbing read-ui
+;; uses, so a SINGLE guard now covers BOTH ops: a fix or a break on the
+;; shared eval-form path cannot diverge between them. The guard runs over
+;; read-dom-form AND read-ui-form variants, and an adversarial case below
+;; proves it FIRES on an alias trap injected into either op's form — so it
+;; cannot silently rot into a no-op.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private cljs-core+special
-  "The special forms + `cljs.core` names the read-dom form may use. A
-  symbol outside this set (and not JS-interop, and not a local binding) is
-  a require-only alias — the unresolved-symbol trap that nils the form."
-  '#{;; special forms / macros the form leans on
-     let if-not if try catch fn fn* when or and do quote recur
-     ;; cljs.core fns/macros used by the form
+  "The special forms + `cljs.core` names a thin runtime-call form may use.
+  A symbol outside this set (and not JS-interop, not a local binding, not
+  the runtime-ns-qualified call) is a require-only alias — the
+  unresolved-symbol trap that nils the form."
+  '#{;; special forms / macros a form may lean on
+     let if-not if try catch fn fn* when or and do quote recur cond
+     ;; cljs.core fns/macros
      exists? array-seq mapcat count take into keep merge mapv
-     string? subs min pr-str = > some? nil? not vec})
+     string? subs min pr-str = > some? nil? not vec assoc cond->})
+
+(defn- runtime-call-symbol?
+  "True for a symbol qualified to the runtime ns the preload provides
+  (`re-frame2-pair.runtime/dom-read`, `…/ui-read`). That ns IS loaded in
+  the eval context (it's the preloaded runtime), so a call into it is
+  legitimate — it is NOT the require-only-alias trap. Pinned to the
+  `eval-form` `runtime-ns` constant so a runtime rename doesn't strand the
+  guard."
+  [s]
+  (= (namespace s) ef/runtime-ns))
 
 (defn- interop-symbol?
   "True for a symbol that resolves in the BARE browser cljs-eval context
@@ -170,51 +169,96 @@
       parsed)
     @acc))
 
+(defn- unresolved-alias-suspects
+  "The core of the guard, factored so the adversarial negative case can
+  drive it directly. Parses `form` and returns the set of symbols that
+  resolve to NOTHING in the bare browser cljs-eval context — i.e. that are
+  neither a special form / `cljs.core` name, JS-interop, a local binding,
+  nor a runtime-ns-qualified call. A non-empty set is the alias trap."
+  [form]
+  (let [;; `cljs.tools.reader` (not `cljs.reader`) — it supports the
+        ;; `#(…)` anonymous-fn literal a form might carry, reading it as
+        ;; `(fn* [p__N] …)`.
+        parsed (tr/read-string form)
+        locals (collect-locals parsed)]
+    (->> (collect-symbols parsed)
+         (remove cljs-core+special)
+         (remove interop-symbol?)
+         (remove runtime-call-symbol?)
+         (remove locals)
+         set)))
+
 (deftest form-carries-no-unresolved-symbol-alias
-  ;; rf2-w2mjm — the bug-class guard. Parses each generated variant and
-  ;; asserts no symbol escapes (cljs.core ∪ special-forms ∪ JS-interop ∪
-  ;; locals). A residual symbol is the alias trap that nils the form.
-  (doseq [[label form] [["default"        (#'read-dom/read-dom-form "#app .counter" nil
-                                                                    read-dom/default-limit
-                                                                    read-dom/default-max-text nil)]
-                        ["explicit-attrs" (#'read-dom/read-dom-form "div" nil 10 100 ["id" "class"])]
-                        ["sub-selector"   (#'read-dom/read-dom-form "div" ".title" 10 100 nil)]]]
-    (let [;; `cljs.tools.reader` (not `cljs.reader`) — it supports the
-          ;; `#(…)` anonymous-fn literal the form carries (`#(read-attr el %)`),
-          ;; reading it as `(fn* [p__N] …)`.
-          parsed   (tr/read-string form)
-          locals   (collect-locals parsed)
-          suspects (->> (collect-symbols parsed)
-                        (remove cljs-core+special)
-                        (remove interop-symbol?)
-                        (remove locals)
-                        set)]
+  ;; The bug-class guard, over the SHARED form for BOTH ops (rf2-q0r7e).
+  ;; A residual symbol is the alias trap that nils the form out.
+  (doseq [[label form]
+          [;; read-dom variants (raw DOM plane).
+           ["read-dom default"        (#'read-dom/read-dom-form "#app .counter" nil
+                                                                read-dom/default-limit
+                                                                read-dom/default-max-text nil)]
+           ["read-dom explicit-attrs" (#'read-dom/read-dom-form "div" nil 10 100 ["id" "class"])]
+           ["read-dom sub-selector"   (#'read-dom/read-dom-form "div" ".title" 10 100 nil)]
+           ;; read-ui variants (re-frame2 view plane) — the SAME guard now
+           ;; covers them, since read-ui rides the same eval-form plumbing.
+           ["read-ui view-id"         (#'read-ui/read-ui-form :my.app/counter nil nil 2000 nil)]
+           ["read-ui point+frame"     (#'read-ui/read-ui-form nil {:x 12 :y 34} nil 100 ":stories")]
+           ["read-ui selector"        (#'read-ui/read-ui-form nil nil "#save" 2000 nil)]]]
+    (let [suspects (unresolved-alias-suspects form)]
       (is (empty? suspects)
-          (str "read-dom-form (" label ") must depend only on cljs.core + JS "
-               "interop — these symbols resolve to NOTHING in the browser "
-               "cljs-eval context and would nil the whole form out "
-               "(:rf.error/read-dom-blank-result on every call): "
+          (str label " form must depend only on cljs.core + JS interop + "
+               "the preloaded runtime ns — these symbols resolve to NOTHING "
+               "in the browser cljs-eval context and would nil the whole "
+               "form out (a :*-blank-result on every call): "
                (sort suspects))))))
+
+(deftest guard-fires-on-injected-alias-trap
+  ;; ADVERSARIAL — proves the guard is not a no-op (rf2-q0r7e). We forge
+  ;; the EXACT rf2-w2mjm failure on the SHARED eval-form path: a require-
+  ;; only alias (`str/lower-case`) reaching into either op's emitted form
+  ;; via the `rt-raw` escape hatch (the realistic vector — a hand-built raw
+  ;; source fragment that reaches for an aliased symbol). The guard MUST
+  ;; surface `str/lower-case` (and the bare `sel`) as suspects for both the
+  ;; dom-read- and ui-read-shaped injections — if it didn't, the live
+  ;; regression guard above would silently pass a nilled form.
+  (doseq [[label rt-fn]
+          [["dom-read-shaped" 'dom-read]
+           ["ui-read-shaped"  'ui-read]]]
+    (let [;; A form that looks like the real thing but smuggles an
+          ;; unresolved alias into the call via the raw escape hatch —
+          ;; `(re-frame2-pair.runtime/<fn> (str/lower-case sel))`. `rt-raw`
+          ;; inlines the fragment verbatim, exactly how an alias would slip
+          ;; into a generated form.
+          poisoned (ef/emit (ef/rt-call rt-fn (ef/rt-raw "(str/lower-case sel)")))
+          suspects (unresolved-alias-suspects poisoned)]
+      (is (contains? suspects 'str/lower-case)
+          (str label ": the guard MUST flag the injected require-only alias "
+               "`str/lower-case` — otherwise it would silently pass the exact "
+               "rf2-w2mjm form-nilling bug. Suspects: " (sort suspects)))
+      ;; `sel` is an unbound symbol here too (not a local in this forged
+      ;; form), so it's also caught — confirming the parse reaches inside
+      ;; the runtime call args, not just the head symbol.
+      (is (contains? suspects 'sel)
+          (str label ": the guard reaches inside the runtime-call args "
+               "(the bare `sel` symbol is flagged).")))))
 
 (deftest form-embeds-sub-selector-when-supplied
   (let [with-sub (#'read-dom/read-dom-form "div" ".title" 10 100 nil)
         no-sub   (#'read-dom/read-dom-form "div" nil 10 100 nil)]
     (is (str/includes? with-sub ".title") "sub-selector embedded")
-    (is (str/includes? with-sub ":sub-selector") "sub-selector slot in result")
+    (is (str/includes? with-sub ":sub-selector") "sub-selector opt slot present")
     (is (not (str/includes? no-sub ":sub-selector"))
-        "no :sub-selector slot when none supplied")))
+        "no :sub-selector opt when none supplied")))
 
-(deftest form-prefix-sweep-only-with-default-attrs
-  ;; When :attrs is omitted (nil), the form sweeps data-*/aria-*. With an
-  ;; explicit attr list the caller is in control — no prefix sweep.
+(deftest form-embeds-attrs-only-when-explicit
+  ;; When :attrs is omitted (nil), the opts carry NO :attrs key — the
+  ;; runtime fn then rides the curated default set + a data-*/aria- sweep.
+  ;; With an explicit attr list the names ride and the runtime reads only
+  ;; those (no sweep).
   (let [default-attrs  (#'read-dom/read-dom-form "div" nil 10 100 nil)
         explicit-attrs (#'read-dom/read-dom-form "div" nil 10 100 ["id"])]
-    (is (str/includes? default-attrs "data-") "default rides the data-* sweep")
-    (is (str/includes? default-attrs "aria-") "default rides the aria-* sweep")
-    ;; The explicit-attrs form still mentions the prefix-attrs fn, but
-    ;; gated by `prefix-sweep?` false, so it returns {} — assert the
-    ;; literal flag is false in the explicit form and true in the default.
-    (is (str/includes? default-attrs "true") "default form enables the sweep")
+    (is (not (str/includes? default-attrs ":attrs"))
+        "no :attrs opt when omitted ⇒ runtime rides the default set + sweep")
+    (is (str/includes? explicit-attrs ":attrs") "explicit :attrs opt rides")
     (is (str/includes? explicit-attrs "\"id\"") "explicit attr name embedded")))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`read-dom` and `read-ui` are two DOM-read ops at **different layers** — but they carried two **independent** browser-eval implementations that rotted apart. This shares the eval **plumbing** (not the semantics), so neither op can silently break alone again, and clarifies the layer split in the docs/docstrings.

Follow-on to #2884 (rf2-w2mjm), where read-dom returned blank on every call (its inlined eval form nilled out via an unresolved `str/` alias) while read-ui worked on the same node.

## The two planes (semantics preserved — NOT duplicates)

- **`read-dom` = raw DOM plane**: CSS selector → matched nodes `{:tag :text :attrs}`. Multi-node, no re-frame2 awareness.
- **`read-ui` = re-frame2 view plane**: rides the `data-rf-view` map → content PLUS the producing entity (view-id, source-coord, subs-read, render-key).

## Shared-plumbing design

Root cause: read-dom **inlined** its whole DOM-read core as a raw string sent to the bare browser cljs-eval context (aliases nothing → an unresolved alias nils it), while read-ui shipped a thin runtime-fn call and stayed green. Both already gate on the preload runtime being present (`eval-after-runtime!` → `ensure-runtime!`), so the inlining bought nothing.

Fold read-dom onto read-ui's architecture:
- Add `dom-read` to the preload runtime, mirroring `ui-read`. read-dom now emits `(re-frame2-pair.runtime/dom-read {...})` via the **same** `eval-form` DSL and the **same** `eval-after-runtime!` prelude read-ui uses. The raw inlined string is gone — there is no second eval form to rot.
- Extract a shared per-node projection (`node->content`: tag + capped text + attrs) in the runtime, called by **both** `dom-read` and `ui-read`. A fix or a break there lands on both ops.
- read-dom stays raw-DOM-plane (multi-node, sub-selector); read-ui layers entity-resolution + privacy elision **on top of** the shared core.

Both public ops are behaviour-identical (conformance green).

## Guard (kept + extended)

The #2884 `form-carries-no-unresolved-symbol-alias` guard now runs over the **shared** form for **both** ops (`read-dom-form` + a new pure `read-ui-form`), keyed to the `eval-form` runtime-ns constant. Added an **adversarial** negative case (`guard-fires-on-injected-alias-trap`) proving the guard fires on an injected `str/lower-case` alias for each op's form shape — so it cannot silently rot into a no-op. The guard was not weakened.

## Docs / naming

- The two-DOM-read-planes split is now explicit in both tool docstrings, the runtime ns header, the Tool-Catalogue spec, and the skill `ops.md` (with a when-to-use-which callout, generic to any consumer app — no repo-specific paths).
- Runtime MCP-vs-runtime naming table gains `read-dom`→`dom-read` / `read-ui`→`ui-read`.
- **No public MCP tool rename** (`read-dom`/`read-ui` unchanged — tool-pair contract intact). No rename flagged as warranted; the names ride the catalogued `read-<thing>` verb and the docstrings now telegraph the layer.

## Gates (cold)

- pair-mcp `shadow-cljs compile server-test`: **872 tests / 0 failures** (incl. the shared-form alias guard + adversarial cases).
- `npm run test:mcp-conformance`: **all 6 gates green** (public tool behaviour of both ops unchanged).

Closes rf2-q0r7e.