### PR TITLE
feat(machines-viz): adopt structured topology visual grammar (rf2-az6e2)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -111,6 +111,26 @@ xstate/SCXML semantics.
   ([stately.ai/docs/parallel-states](https://stately.ai/docs/parallel-states) §history,
   [state-machines-and-statecharts](https://stately.ai/docs/state-machines-and-statecharts)).
   **(re-frame2 has no `:history` in Spec 005 v1 — see §3 divergences.)**
+  **rf2-az6e2 — VISUAL HOOK ONLY.** The structured grammar defines how a
+  history pseudo-state *renders* (shallow `H` / deep `H*`, a small
+  symbolic node inside the owning compound at the same child level, NOT
+  a normal state box, with direct incoming transitions and no default
+  fallback edge unless the topology explicitly carries one). The
+  renderer (`chart.nodes/history-marker`) is registered in the
+  node-types map, but `chart.layout/parse-definition` emits **no**
+  history pseudo-state node today (the parsed node shape carries no
+  `:history` data), so the projector never produces one. This bead adds
+  the VISUAL rendering for parsed pseudo-state data that already exists —
+  it does **not** add statechart history semantics. When Spec 005 history
+  semantics + the parse land, flip the projector to emit a
+  `{:type "history-marker" :data {:deep? …}}` node and `history-marker`
+  paints it; file the follow-on render-wiring bead then.
+
+> **rf2-az6e2 final-state glyph decision.** The final-state marker is the
+> quiet **doubled border** (the UML/SCXML convention) — the previously-
+> shipped `✓` check glyph is **dropped**. The doubled border is the
+> unambiguous final-state signal; the glyph competed with the state
+> title for attention against the structure-first grammar.
 
 ### 1.5 Event labels
 
@@ -301,29 +321,40 @@ The dimensions each topology element MUST be distinguishable on. Figma
 owns the palette; the table is the contract for **what must differ**,
 not **which colour**.
 
+**rf2-az6e2 — structured visual grammar.** The baselines below reflect
+the structured topology grammar: structure-first reading (neutral by
+default), runtime state on the **border + header + glow** (not the
+fill), and colours resolved through the active-theme **chart-tokens**
+(see [`API.md` §Theme](API.md#theme-rf2-az6e2)). The contract is still
+*what must differ*, not *which colour*.
+
 | Element | Must be distinguished by | Shipped baseline (replaceable) |
 |---|---|---|
-| **State (resting)** | rounded-rect body, mono label, neutral fill + 1px border | *`bg-2` fill, `border-default` stroke* |
-| **State (active / live)** | tinted fill + **emphasised** stroke (one notch heavier) + soft outer glow | *`info` (cyan) tint + 2px-box-shadow* |
-| **State (FROM — focused-event origin)** | distinct hue from active + **dashed** stroke (reads as "we left here") | *`accent` (violet), dashed* |
-| **State (TO — focused-event landing)** | the **active** affordance, heavier than FROM (reads as "we arrived") | *`info` (cyan), heaviest stroke* |
-| **State (sim — what-if, not live)** | a hue **reserved** for "informational, not a real event" — visually distinct from live | *`yellow` (amber) tint + stroke* |
-| **Final state** | **doubled** border (outer ring proud of corner) + `✓` glyph | *`green` ring + glyph* |
-| **Initial marker** | small **filled dot** + unlabelled arrow into the initial state, at every compound level | *`accent` dot* |
-| **Compound container** | translucent box, **dashed** border, header-strip title | *`accent` 6% fill, dashed `accent`* |
-| **Parallel region container** | **distinct dashed boundary per region** (rotation so adjacent regions differ) + `∥` glyph + uppercased region label | *`region-boundary-palette` rotation* |
-| **Parallel region (ACTIVE) — G1/G4** | region header + boundary carry an **active affordance**; **every** active leaf inside lights with the active dimension **simultaneously**; the set reads as "all active at once," not N independent picks | ✅ shipped (rf2-80rm2): solid emphasised boundary + emphasised header tint + `info` glow ring (the state-node active token). Figma may re-key the region-active palette |
-| **Edge (resting transition)** | thin stroke + arrowhead + label backplate | *`border-default`* |
-| **Edge (active — touches active state)** | mid-weight stroke + arrow tinted to active hue | *`info`, midweight* |
-| **Edge (focused — the fired FROM→TO)** | **emphasised** stroke + **animated glow** | *`info` + `mv-chart-transition-glow`* |
-| **Edge (fired THIS epoch) — G3** | matched by **edge-id** (not endpoint), the **heaviest** stroke + **animated glow** + a hue **distinct from focused/active**; `data-fired` DOM hook; lights **every** traversed arm (microsteps, guard-fork candidates) | *`accent` + `mv-chart-transition-glow`* — distinct from the focused/active `info` |
+| **State (resting)** | **title/body box** — full-width left-aligned title strip (sans), hairline divider when body exists, neutral body band; low-radius square-ish box | *`:state-body-bg` fill, `:state-border` 1px, `:state-header-bg` strip* |
+| **State (active / live)** | runtime accent **border** + faint **header** wash + soft outer **glow** — NOT a whole-fill tint | *`:active` border + `:active-wash` header + `:glow` ring* |
+| **State (FROM — focused-event origin)** | distinct accent on the border (reads as "we left here") | *`:focus` border + `:focus-wash` header* |
+| **State (TO — focused-event landing)** | the **active** affordance, heavier than FROM | *`:active`, heaviest stroke* |
+| **State (sim — what-if, not live)** | a hue reserved for informational/not-live | *`:sim` border + `:sim-wash` header* |
+| **Final state** | **quiet doubled** border (outer ring proud of corner). **No glyph** (rf2-az6e2 dropped the ✓) | *outer ring in the resting/runtime border colour* |
+| **Initial marker** | small **neutral** filled dot + unlabelled arrow into the initial state, at every compound level (NOT accent-blue) | *`:pseudo-marker` dot* |
+| **History pseudo-state (HOOK)** | small symbolic node — shallow `H` / deep `H*` — inside the owning compound; NOT a state box. **Renderer registered as a hook; projector emits none until parsed history topology exists** (this bead adds no statechart history semantics) | *`history-marker` node-type registered; `:pseudo-*` constants carry the variant* |
+| **Compound container** | **solid subtle-neutral** box + full-width title strip; NO dashed border, NO accent wash by default | *`:container-body-bg` fill, `:container-border` solid, `:container-header-bg` strip* |
+| **Parallel region container** | **dashed neutral** boundary + full-width region title strip + subtle `∥` glyph + uppercased label. Region identity from **containment/layout**, NOT a rotating border colour | *`:region-border` dashed (same for every region — rotation removed)* |
+| **Parallel region (ACTIVE) — G1/G4** | region boundary firms to **solid** + header carries an **active affordance**; **every** active leaf inside lights **simultaneously** | ✅ shipped (rf2-80rm2 / rf2-az6e2): solid `:active` boundary + `:active-wash` header + `:glow` ring |
+| **Edge (source→event — quiet half)** | **thinner** stroke + **small** arrowhead in the quiet colour | *`:edge-quiet`, ~−0.5 stroke, 10px arrowhead* |
+| **Edge (event→target — primary half)** | standard stroke + **full** arrowhead — the pair reads as ONE route | *`:edge-quiet` resting, 18px arrowhead* |
+| **Edge (active — touches active state)** | mid-weight stroke + arrow tinted to active hue | *`:edge-active`, midweight* |
+| **Edge (focused — the fired FROM→TO)** | **emphasised** stroke + **animated glow**; lights **both** segments together | *`:edge-active` + `mv-chart-transition-glow`* |
+| **Edge (fired THIS epoch) — G3** | matched by **edge-id** (not endpoint), **heaviest** stroke + **animated glow** + a hue distinct from focused/active; `data-fired` hook; both segments | *`:edge-fired` + `mv-chart-transition-glow`* |
 | **Edge (self-loop)** | a small loop off the node edge (not a degenerate bezier) | shipped path |
-| **Edge (internal self-transition)** | **dashed** loop + **no arrowhead** (no exit/entry re-trigger) | shipped dash |
-| **Edge (`:after` timer)** | `after(<ms>)` label + `data-after-ms` hook for the countdown-ring overlay | shipped |
-| **Edge (`:always` eventless)** | `always` label segment | shipped |
-| **Edge (machine-level fallback)** | `data-machine-level` hook (inherited-fallback affordance the host may style) | shipped flag |
-| **Edge label** | `event [guard] / action`; clickable form (host sim) gets a button affordance + distinct border | *`yellow` border when clickable* |
-| **Event label segments** | `after(ms)` / `always` / `* (any)` render in the event slot | shipped |
+| **Edge (internal self-transition)** | terminal **route chip** (dashed border ring) + **no outgoing target segment** | shipped (event-node, no `__out` edge) |
+| **Edge (`:after` timer)** | `⌚ <ms>` event chip + `data-after-ms` hook for the countdown-ring overlay | shipped |
+| **Edge (`:always` eventless)** | `∞` event chip | shipped |
+| **Edge (machine-level fallback)** | `data-machine-level` hook only — the loud "machine-level" label is **muted** by default (rf2-az6e2) | shipped flag |
+| **Event chip** | subordinate route chip, **no title bar**; event + guard on the first line as **`IF <guard>`**; action row only when present (subdued bolt chip); clickable (host sim) gets a button affordance + distinct border | *`:event-chip-bg` / `:event-chip-border`; `:sim` border when clickable* |
+| **State tags** | **one neutral chip style** (structure wins over annotation colour — rotation dropped); identity preserved in `data-tag` / `title` / `data-tags` | *`:container-header-bg` fill, `:state-border`* |
+| **Root machine chrome** | a **root title strip** pinned in the chart frame; subtle `∥` glyph for root-parallel machines; optional Context section from `:machine-data` | shipped (`<testid>-root-title`) |
+| **Event label segments** | `⌚ <ms>` / `∞` / `* (any)` render in the event slot | shipped |
 
 ### 4.3 G2 / G5 — edge routing through nesting
 

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -61,7 +61,8 @@ registry).
 | `:read-only?` | no | `nil` | When `true`, all `:on-*` callbacks are no-op'd. The viewer page sets this. |
 | `:direction` | no | `:tb` | Layout axis. `:tb` lays the chart top-to-bottom; `:lr` left-to-right. Fed to elkjs as `elk.direction`. |
 | `:layout-options` | no | `nil` | Host-side elkjs `layoutOptions` overrides merged on top of `default-elk-options` (`chart.cljs/default-elk-options`). `default-elk-options` carries `elk.edgeRouting ORTHOGONAL` + `elk.json.edgeCoords ROOT` (G2 bend-point routing) plus the edge-clearance keys (`elk.spacing.edgeNode` / `elk.layered.spacing.edgeNodeBetweenLayers` / `elk.spacing.edgeEdge`) and label-placement keys (`elk.edgeLabels.placement CENTER` / `elk.spacing.edgeLabel`) so ELK routes edges *around* nodes and *places* labels in reserved channels (rf2-rlq97). The `:direction` arg drives `elk.direction`, and the chart auto-sets `elk.hierarchyHandling INCLUDE_CHILDREN` on the root layout whenever the graph nests (parallel regions or compound substates) so elk routes edges ACROSS nesting levels (parity gap G5 / rf2-gpa9k — see `chart.cljs/elk-layout-options`). |
-| `:density` | no | `:regular` | Density variant — `:compact` / `:regular` / `:cosy`. Resolves the geometry + typography map via `visual-constants/chart-for-density`; the resolved map is threaded through the projector onto every node/edge `:data` so the xyflow node/edge components render at the chosen density. The chart root surfaces the resolved density as `data-density`. `nil` ≡ `:regular`; an unknown density throws at render time. Per [§Density](#density) and rf2-32gw5. |
+| `:density` | no | `:regular` | Density variant — `:compact` / `:regular` / `:cosy`. Resolves the geometry + typography map via `visual-constants/chart-for-density`; the resolved map is threaded through the projector onto every node/edge `:data` so the xyflow node/edge components render at the chosen density. The chart root surfaces the resolved density as `data-density`. `nil` ≡ `:regular`; an unknown density throws at render time. Per [§Density](#density) and rf2-32gw5. **Independent of `:theme`** (geometry vs colour are orthogonal knobs). |
+| `:theme` | no | `:dark` | rf2-az6e2. `:dark` / `:light`. Resolves the chart palette + the chart-semantic token map ONCE per render (`theme/tokens/theme-palette` + `chart-tokens`); the token map is threaded through the projector onto every node/edge `:data` so the renderers paint the **active theme** — not the dark-tokens alias. The chart's own chrome (canvas surface, root title strip, Context panel, dot-grid, minimap, layout-error banner) reads the same palette. The resolved theme surfaces on the root as `data-theme`. `nil` / unknown → `:dark`. **Independent of `:density`.** This bead builds no light/dark toggle UI — hosts pass the prop. Per [§Theme](#theme-rf2-az6e2). |
 | `:height` | no | `"100%"` | Outer wrapper height (CSS string). xyflow requires a non-zero parent height. |
 | `:show-minimap?` | no | `false` | When `true`, render xyflow's built-in MiniMap. |
 | `:show-controls?` | no | `true` | When `true`, render xyflow's built-in zoom/pan/fit Controls. |
@@ -889,6 +890,109 @@ forward-promise; naming settled on compact / regular / cosy per the
 bead title — `regular` is the load-bearing default name now that the
 chart-floor lift (rf2-gg7ws) put the previous-default size at the
 floor of three rungs rather than the only rung).
+
+## Theme (rf2-az6e2)
+
+`MachineChart` accepts a `:theme` prop — `:dark` (default) or `:light`
+— and **theme support is real**: the chart resolves the active palette
+ONCE per render and the renderers paint that palette, rather than
+reading a hardwired dark-tokens alias.
+
+### Theme vs density — orthogonal knobs
+
+`:theme` (colour) and `:density` (geometry + typography) are
+**independent**. A host picks a density for its surface (Story grid →
+`:compact`, Xray tab → `:regular`/`:cosy`) and a theme for its surround
+(dark Xray → `:dark`, a light embed → `:light`) without either knob
+constraining the other.
+
+### Chart-semantic tokens
+
+Rather than grow the palette (the Xray↔machines-viz dark-palette
+**key-set drift gate** — rf2-z7ms8 — asserts the two dark palettes share
+an identical key set), the structured grammar's semantic roles are
+**derived** from the existing palette entries by
+`theme/tokens/chart-tokens`, parameterised by the active palette:
+
+| Role | Resolves to |
+|------|-------------|
+| `:state-header-bg` / `:state-body-bg` / `:state-border` | leaf-state title strip / body / resting border |
+| `:divider` | title/body hairline |
+| `:container-header-bg` / `:container-body-bg` / `:container-border` | compound chrome (solid neutral, no accent wash) |
+| `:region-border` / `:region-header-bg` | parallel-region chrome (dashed neutral) |
+| `:event-chip-bg` / `:event-chip-border` | route-chip fill / border (subordinate) |
+| `:pseudo-marker` | initial / history pseudo-state (neutral, NOT accent) |
+| `:edge-quiet` / `:edge-active` / `:edge-fired` | source→event quiet / event→target+active / fired-epoch |
+| `:active` / `:focus` / `:sim` / `:final` | runtime-state accents (reserved for runtime, NOT static structure) |
+
+### Resolution rules
+
+- `:theme nil` or an unrecognised value ≡ `:dark` (the Xray default
+  surface). Unlike `:density` (which throws on an unknown value),
+  `:theme` degrades to dark — a colour fallback is graceful, a geometry
+  fallback would silently mis-size.
+- The resolved theme surfaces on the chart's root wrapper as
+  `data-theme="<dark|light>"`.
+
+### Implementation notes
+
+- `MachineChart` resolves `:theme` ONCE per render via
+  `theme/tokens/theme-palette` → `chart-tokens`. The token map is
+  threaded through the projector (`chart.projection/xyflow-graph`) onto
+  every node + edge `:data` as `{:palette <chart-tokens-map>}`.
+- The xyflow node + edge components recover the map off `:data`
+  (`chart.nodes.xyflow-node/palette-of`) — xyflow invokes them OUTSIDE
+  any dynamic-binding scope, so the palette travels in the data, not a
+  dynamic Var (the same discipline `:chart` uses for density).
+- A node/edge payload without a `:palette` entry falls back to
+  `chart-tokens` of the dark palette, so a theme-less / directly-
+  constructed node still renders the dark grammar.
+- The chart's own chrome (root canvas surface, the **root title strip**,
+  the Context panel, dot-grid, minimap, layout-error banner) reads the
+  resolved `theme-palette` directly.
+
+## Visual grammar (rf2-az6e2)
+
+The structured topology grammar reads STRUCTURE first; **annotation
+colour is subordinate to structure**.
+
+- **Leaf states** render as title/body boxes — a full-width, left-
+  aligned **title strip** (sans `chart-label-stack`), a hairline divider
+  when body content exists, and a body band carrying **one neutral tag
+  chip style** + quiet "Entry actions" / "Exit actions" rows with
+  subdued bolt-glyph action chips. Square-ish, low radius (the 6px
+  `corner-radius` lock). Runtime state (active / focus lens / sim) rides
+  the **border + header + glow**, never the whole fill. A **final state**
+  is a quiet double border (the ✓ check glyph is **dropped** —
+  rf2-az6e2 decision).
+- **Event/transition nodes** stay synthetic layout nodes (source-state →
+  event-node → target-state) but render as **subordinate route chips** —
+  no title bar, event + guard on the first line as **`IF <guard>`**, an
+  action row only when an action exists, machine-level **muted** (data-
+  attr only). An internal / action-only transition is a terminal chip
+  with a dashed border ring and no outgoing target segment.
+- **Compound containers** render as **solid subtle-neutral** title-strip
+  containers (no dashed border, no saturated accent wash by default).
+- **Parallel regions** render as **dashed neutral** title-strip
+  containers; region identity comes from **containment + layout**, NOT a
+  rotating border colour (the prior `region-boundary-palette` rotation is
+  removed). Active / focus colour is reserved for runtime state.
+- **Pseudo-states**: initial markers are small **neutral** dots (not
+  accent-blue). A **history** pseudo-state renderer (shallow `H` / deep
+  `H*`, small symbolic node) is registered as a **hook** — the projector
+  emits no history node until parsed history-pseudo-state topology data
+  exists (this bead does not add statechart history semantics). See
+  [`001-Topology-Parity.md`](001-Topology-Parity.md) §History.
+- **Arrow/routing**: the two-edge event-node route reads as **one
+  transition** — a quiet source→event segment (thinner stroke, small
+  arrowhead, `:edge-quiet`) and a primary event→target segment (full
+  arrowhead). Fired/focused lights **both** segments together.
+- **Root chrome**: a **root machine title strip** is pinned in the chart
+  frame (a subtle `∥` glyph for root-parallel machines). A static
+  Context section under the title is rendered from the optional
+  `:machine-data` overlay when supplied; a static **context-shape**
+  derivation from the definition is a follow-on (current definitions
+  expose no static context schema).
 
 ## Performance invariants
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -717,6 +717,20 @@
                          time (per `spec/API.md` §Density resolution
                          rules) — picking outside the closed set is a
                          programmer error, not a runtime fallback.
+    :theme             — rf2-az6e2. `:dark` (default) / `:light`.
+                         Resolves the chart palette + semantic token map
+                         ONCE per render (`theme/tokens/theme-palette` +
+                         `chart-tokens`), threaded through the projector
+                         onto every node/edge `:data {:palette}` so the
+                         renderers paint the ACTIVE theme — NOT the dark
+                         alias. The chart's own chrome (canvas surface,
+                         root title strip, Context panel, dot-grid,
+                         minimap, layout-error banner) reads the same
+                         palette. The resolved theme surfaces on the root
+                         as `data-theme`. INDEPENDENT of `:density`
+                         (geometry vs colour are orthogonal knobs). nil /
+                         unknown → `:dark`. This bead builds no light/dark
+                         toggle UI — hosts pass the prop.
     :layout-options    — host-side elk.js `layoutOptions` overrides
                          merged on top of `default-elk-options`.
     :height            — outer wrapper height (CSS string; default
@@ -878,12 +892,13 @@
     (fn [{:keys [machine-id definition current-state from-highlight to-highlight
                  fired-edge-ids
                  sim? on-state-click on-edge-click read-only?
-                 direction layout-options density
+                 direction layout-options density theme
                  height show-minimap? show-controls? show-background?
                  overlays
                  machine-data
                  testid]
           :or   {direction         :tb
+                 theme             :dark
                  height            "100%"
                  show-minimap?     false
                  show-controls?    true
@@ -1023,6 +1038,17 @@
           ;; the root as `data-density`.
           (let [chart-vc          (vc/chart-for-density density)
                 density-name      (name (or density :regular))
+                ;; rf2-az6e2 — resolve the `:theme` prop to its palette
+                ;; + the chart-semantic token map ONCE per render
+                ;; (independent of `:density`). The token map threads
+                ;; through the projector onto every node/edge `:data` so
+                ;; the renderers paint the ACTIVE theme; the chart's own
+                ;; chrome (below) reads `theme-palette` / `ct` too. The
+                ;; resolved theme name surfaces on the root as
+                ;; `data-theme`.
+                theme-palette     (tokens/theme-palette theme)
+                ct                (tokens/chart-tokens theme-palette)
+                theme-name        (name (or theme :dark))
                 ;; rf2-g2svr (G1) — `highlight-ids` resolves the WHOLE
                 ;; `:current-state` to the SET of active leaves, so a
                 ;; PARALLEL snapshot's N simultaneously-active leaves
@@ -1059,7 +1085,12 @@
                                ;; edge-id set; the projector marks each
                                ;; matching edge :fired. nil → #{} default.
                                :fired-edge-ids    (set fired-edge-ids)
-                               :chart             chart-vc})
+                               :chart             chart-vc
+                               ;; rf2-az6e2 — the resolved chart-semantic
+                               ;; token map for the active theme; the
+                               ;; projector threads it onto every node/edge
+                               ;; `:data {:palette}`.
+                               :palette           ct})
                 aria-label (str "State machine"
                                 (when machine-id
                                   (str ": " (name machine-id)))
@@ -1123,6 +1154,11 @@
                    ;; re-reading the bound prop (per spec/API.md
                    ;; §Density resolution rules).
                    :data-density density-name
+                   ;; rf2-az6e2 — the resolved theme surfaces here so
+                   ;; hosts + tests read the active theme without
+                   ;; re-reading the bound prop. Dark remains the Xray
+                   ;; default. Independent of `data-density`.
+                   :data-theme theme-name
                    ;; rf2-g2svr (G1) — the FULL active set surfaces as a
                    ;; sorted, space-joined attr so hosts + DOM tests can
                    ;; read every active leaf (N for a parallel snapshot).
@@ -1152,7 +1188,9 @@
                    :style {:position "relative"
                            :width    "100%"
                            :height   height
-                           :background (:bg-1 tokens/tokens)
+                           ;; rf2-az6e2 — the chart canvas reads the
+                           ;; ACTIVE theme's surface, not the dark alias.
+                           :background (:bg-1 theme-palette)
                            :border-radius "4px"
                            :overflow "hidden"}}
              ;; Inline keyframes + reduced-motion seam — mirrors the
@@ -1219,7 +1257,10 @@
                 [:> Background {:variant (.-Dots BackgroundVariant)
                                 :gap (:dot-grid-spacing-px chart-vc)
                                 :size (:dot-grid-radius-px chart-vc)
-                                :color (tokens/with-alpha :accent 0.4)}])
+                                ;; rf2-az6e2 — dot colour resolves through
+                                ;; the active theme's accent (light hosts
+                                ;; get a darker dot).
+                                :color (tokens/with-alpha :accent 0.4 theme-palette)}])
               (when show-controls?
                 [:> Controls {:showZoom true
                               :showFitView true
@@ -1227,8 +1268,47 @@
               (when show-minimap?
                 [:> MiniMap {:zoomable true
                              :pannable true
-                             :nodeColor (fn [_] (:bg-3 tokens/tokens))
-                             :maskColor (tokens/with-alpha :bg-0 0.6)}])]
+                             :nodeColor (fn [_] (:bg-3 theme-palette))
+                             :maskColor (tokens/with-alpha :bg-0 0.6 theme-palette)}])]
+             ;; rf2-az6e2 — ROOT MACHINE CHROME. A title strip pinned to
+             ;; the top of the chart frame integrates the root machine
+             ;; into the grammar (it was previously only the aria-label).
+             ;; A root PARALLEL machine shows a subtle ∥ glyph in the
+             ;; strip. The optional static "Context" section is rendered
+             ;; from the `:machine-data` overlay below (kept as an opt-in
+             ;; diagnostic; static context-shape derivation is a follow-on
+             ;; — current definitions expose no static context schema).
+             (when machine-id
+               [:div {:data-testid (str testid "-root-title")
+                      :data-parallel (str (boolean (:parallel? parsed)))
+                      :style {:position       "absolute"
+                              :top            0
+                              :left           0
+                              :right          0
+                              :z-index        4
+                              :display        "flex"
+                              :align-items    "center"
+                              :gap            "6px"
+                              :height         (str (:root-title-height chart-vc) "px")
+                              :padding        (str "0 " (:root-context-pad chart-vc) "px")
+                              :pointer-events "none"
+                              :font-family    tokens/sans-stack
+                              :font-size      (str (:root-title-px chart-vc) "px")
+                              :font-weight    700
+                              :letter-spacing "0.02em"
+                              :color          (:text-primary theme-palette)
+                              :background      (tokens/with-alpha :bg-2 0.82 theme-palette)
+                              :border-bottom   (str "1px solid "
+                                                    (tokens/with-alpha :border-default 0.6 theme-palette))}}
+                (when (:parallel? parsed)
+                  [:span {:data-testid (str testid "-root-parallel-glyph")
+                          :style {:opacity 0.6
+                                  :font-family tokens/mono-stack}}
+                   "∥"])
+                [:span {:style {:white-space "nowrap"
+                                :overflow "hidden"
+                                :text-overflow "ellipsis"}}
+                 (name machine-id)]])
              ;; rf2-7w4qr — host-fed overlays, composed through the
              ;; single `:overlays` slot. Each descriptor map (keyed on
              ;; `:id`) is dispatched to its rendering namespace by
@@ -1262,7 +1342,10 @@
                       :aria-label (str "Machine context for "
                                        (when machine-id (name machine-id)))
                       :style {:position      "absolute"
-                              :top           "8px"
+                              ;; rf2-az6e2 — tuck the Context panel just
+                              ;; UNDER the root title strip so the two
+                              ;; chrome bands stack rather than overlap.
+                              :top           (str (+ (:root-title-height chart-vc) 6) "px")
                               :left          "8px"
                               :z-index       6
                               :max-width     "260px"
@@ -1272,17 +1355,17 @@
                               :font-family   tokens/mono-stack
                               :font-size     "11px"
                               :line-height   1.4
-                              :color         (:text-primary tokens/tokens)
-                              :background    (tokens/with-alpha :bg-2 0.92)
+                              :color         (:text-primary theme-palette)
+                              :background    (tokens/with-alpha :bg-2 0.92 theme-palette)
                               :border        (str "1px solid "
-                                                  (tokens/with-alpha :border-default 0.6))
+                                                  (tokens/with-alpha :border-default 0.6 theme-palette))
                               :border-radius "4px"}}
                 [:div {:style {:font-family    tokens/sans-stack
                                :font-size      "9px"
                                :font-weight    700
                                :letter-spacing "0.06em"
                                :text-transform "uppercase"
-                               :color          (:text-tertiary tokens/tokens)
+                               :color          (:text-tertiary theme-palette)
                                :margin-bottom  "4px"}}
                  "Context"]
                 (for [[k v] (seq machine-data)]
@@ -1296,12 +1379,12 @@
                                  :white-space "nowrap"
                                  :overflow "hidden"
                                  :text-overflow "ellipsis"}}
-                   [:span {:style {:color (:accent tokens/tokens)
+                   [:span {:style {:color (:accent theme-palette)
                                    :font-weight 600}}
                     (if (keyword? k) (name k) (str k))]
-                   [:span {:style {:color (:text-tertiary tokens/tokens)}}
+                   [:span {:style {:color (:text-tertiary theme-palette)}}
                     ":"]
-                   [:span {:style {:color (:text-secondary tokens/tokens)
+                   [:span {:style {:color (:text-secondary theme-palette)
                                    :overflow "hidden"
                                    :text-overflow "ellipsis"}}
                     (pr-str v)]])])
@@ -1328,16 +1411,16 @@
                               :font-family   tokens/sans-stack
                               :font-size     "12px"
                               :line-height   1.4
-                              :color         (:text-primary tokens/tokens)
-                              :background    (tokens/with-alpha :error 0.15)
+                              :color         (:text-primary theme-palette)
+                              :background    (tokens/with-alpha :error 0.15 theme-palette)
                               :border        (str "1px solid "
-                                                  (:error tokens/tokens))
+                                                  (:error theme-palette))
                               :border-radius "4px"}}
-                [:strong {:style {:color (:error tokens/tokens)
+                [:strong {:style {:color (:error theme-palette)
                                   :margin-right "6px"}}
                  "Layout failed."]
                 [:span (or (get-in layout-error [:error :message])
                            "ELK threw an unknown error.")]
-                [:span {:style {:color (:text-tertiary tokens/tokens)
+                [:span {:style {:color (:text-tertiary theme-palette)
                                 :margin-left "6px"}}
                  "See console / Issues panel."]])]))))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -47,7 +47,7 @@
             [reagent.core :as r]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
-             :refer [mono-stack]]
+             :refer [chart-label-stack]]
             [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 (def ^:private get-bezier-path (.-getBezierPath xyflow))
@@ -319,17 +319,32 @@
       (js->clj c :keywordize-keys true)
       vc/chart-regular)))
 
+(defn- palette-of
+  "rf2-az6e2 — recover the resolved chart-semantic token map off an
+  edge's `:data` (`(.-palette d)`); `(tokens/chart-tokens)` (the dark
+  surface) when absent so a theme-less edge still paints the dark
+  grammar. Mirrors `chart.nodes.xyflow-node/palette-of`."
+  [^js d]
+  (let [p (.-palette d)]
+    (if (some? p)
+      (js->clj p :keywordize-keys true)
+      (tokens/chart-tokens))))
+
 (defn- edge-stroke
   "rf2-qeemm (G3) — `fired?` (the edge traversed THIS epoch) wins over
   `focused?` / `active?` so a fired arm reads as 'what just happened' in
-  the FIRED hue (`:accent`, distinct from the focused/active `:info`).
-  Palette delegated to Figma — `:accent` is the existing token, not a new
-  palette entry."
-  [{:keys [active? focused? fired?]}]
+  the FIRED hue, distinct from the focused/active hue.
+
+  rf2-az6e2 — colours resolve through the active-theme chart-tokens
+  (`ct`): fired = `:edge-fired`, focused/active = `:edge-active`, resting
+  = `:edge-quiet`. The QUIET source→event segment (`quiet?`) paints the
+  quiet colour even when the route is otherwise resting so the pair reads
+  as one transition with the primary arrowhead on the event→target half."
+  [ct {:keys [active? focused? fired?]}]
   (cond
-    fired?               (:accent tokens/tokens)
-    (or focused? active?) (:info tokens/tokens)
-    :else                (:border-default tokens/tokens)))
+    fired?                (:edge-fired ct)
+    (or focused? active?) (:edge-active ct)
+    :else                 (:edge-quiet ct)))
 
 (defn- edge-stroke-width
   "rf2-k647w — edge stroke widths read off the resolved density. The
@@ -338,15 +353,21 @@
   relationship 1.5 / 2.0 / 2.5).
 
   rf2-qeemm (G3) — `fired?` paints at the emphasis width (the heaviest
-  treatment), at least as prominent as `focused?`, so a traversed edge
-  stands out even when it isn't the focused FROM→TO lens (both the fired
-  arm and the focused lens share the emphasis width)."
-  [{:keys [active? focused? fired? chart]
+  treatment), at least as prominent as `focused?`.
+
+  rf2-az6e2 — the QUIET source→event segment (`quiet?`) paints ONE notch
+  THINNER than the resting width (so the pair reads as one route: the
+  quiet inbound half + the primary outbound half). A quiet segment that
+  is itself fired/focused still picks up the emphasis width so a
+  traversed route lights BOTH segments together."
+  [{:keys [active? focused? fired? quiet? chart]
     :or   {chart vc/chart-regular}}]
   (let [{:keys [stroke-width stroke-width-emphasis]} chart]
     (cond
       (or fired? focused?) stroke-width-emphasis
       active?              (/ (+ stroke-width stroke-width-emphasis) 2.0)
+      ;; resting quiet inbound half — one notch under the resting width.
+      quiet?               (max 0.75 (- stroke-width 0.5))
       :else                stroke-width)))
 
 ;; ---- transition-edge ----------------------------------------------------
@@ -366,6 +387,10 @@
         marker-end (.-markerEnd props)
         d          (.-data props)
         vc         (chart-constants d)
+        ct         (palette-of d)
+        ;; rf2-az6e2 — the quiet source→event half of the events-as-nodes
+        ;; route. Paints thinner so the pair reads as one transition.
+        quiet?     (boolean (.-quietSegment d))
         label      (or (.-eventLabel d) "")
         ;; rf2-a2b55 — Stately graph view convention. `eventLineLabel`
         ;; is the visible-line text (`event [guard]`, no `/ action`);
@@ -431,7 +456,7 @@
         sibling-index   (or (.-siblingIndex d) 0)
         sibling-count   (or (.-siblingCount d) 1)
         sibling-leader? (zero? sibling-index)
-        {:keys [edge-label-px edge-label-backplate-opacity
+        {:keys [edge-label-px
                 action-pill-height action-pill-pad-x action-pill-px
                 action-pill-radius action-pill-row-gap]} vc
         ;; rf2-j10sm (Phase 2, B) — per-sibling label-y offset. Vertical
@@ -456,9 +481,9 @@
                     ;; rf2-rlq97 — elk's computed label placement (nil →
                     ;; geometric heuristic fallback).
                     :label-pos label-pos})
-        stroke  (edge-stroke {:active? active? :focused? focused? :fired? fired?})
+        stroke  (edge-stroke ct {:active? active? :focused? focused? :fired? fired?})
         stroke-w (edge-stroke-width {:active? active? :focused? focused?
-                                     :fired? fired? :chart vc})]
+                                     :fired? fired? :quiet? quiet? :chart vc})]
     (r/as-element
       [:<>
        ;; rf2-j10sm (Phase 2, B) — non-leader siblings (same `[source
@@ -539,31 +564,23 @@
                                             label-x "px," (+ label-y label-y-offset) "px)")
                        :pointer-events "auto"
                        :cursor         (if clickable? "pointer" "default")
-                       :font-family    mono-stack
+                       :font-family    chart-label-stack
                        :font-size      (str edge-label-px "px")
                        :font-weight    (if (and clickable? focused?) 600 400)
-                       ;; rf2-j10sm (Phase 1, D) — padded label backgrounds.
-                       ;; Opaque chart-bg colour matching the canvas
-                       ;; (`:bg-1`, the colour the chart root paints), so
-                       ;; each label "punches through" overlapping nodes /
-                       ;; edges with the surrounding background. Light text
-                       ;; on the dark canvas instead of the previous
-                       ;; white-pill + dark-text chip. Rounded ~4px corners
-                       ;; + ~4px padding give the label breathing room. The
-                       ;; `:edge-label-backplate-opacity` knob is preserved
-                       ;; for hosts that want a semi-transparent backplate
-                       ;; (still applied as the bg alpha; the new default of
-                       ;; 0.94 is high enough to mask underlying ink while
-                       ;; admitting a hint of the canvas so adjacent labels
-                       ;; do not look like solid stacked tiles).
-                       :color          (:text-primary tokens/tokens)
-                       :background     (tokens/with-alpha :bg-1 edge-label-backplate-opacity)
+                       ;; rf2-az6e2 — the rare labelled-edge backplate
+                       ;; (entry / after edges; events ride the event-NODE
+                       ;; under events-as-nodes so most edges carry no
+                       ;; label) reads the neutral event-chip fill/border
+                       ;; from the active-theme tokens so it punches through
+                       ;; overlapping ink with the surrounding background.
+                       :color          (:text-primary ct)
+                       :background     (:event-chip-bg ct)
                        :padding        "2px 6px"
                        :border-radius  "4px"
                        :border         (str "1px solid "
                                             (if clickable?
-                                              (tokens/with-alpha :yellow 0.7)
-                                              (tokens/with-alpha :border-default 0.6)))
+                                              (:sim ct)
+                                              (:event-chip-border ct)))
                        ;; rf2-j10sm (Phase 1, D) — z-index bump. The edge
                        ;; label sits above edges + node borders but below
                        ;; interactive controls (xyflow's Controls render at
@@ -593,12 +610,11 @@
                            :align-items      "center"
                            :height           (str action-pill-height "px")
                            :padding          (str "0 " action-pill-pad-x "px")
-                           :background       (tokens/with-alpha :advisory 0.18)
-                           :border           (str "1px solid "
-                                                  (tokens/with-alpha :advisory 0.6))
+                           :background       (:container-header-bg ct)
+                           :border           (str "1px solid " (:state-border ct))
                            :border-radius    (str action-pill-radius "px")
-                           :color            (:advisory tokens/tokens)
-                           :font-family      mono-stack
+                           :color            (:text-secondary ct)
+                           :font-family      chart-label-stack
                            :font-size        (str action-pill-px "px")
                            :font-weight      500
                            :line-height      "1"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -55,11 +55,10 @@
              :as parallel-region-node]
             [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
              :refer [Handle pos-top pos-right pos-bottom pos-left
-                     chart-constants]]
+                     chart-constants palette-of]]
             [day8.re-frame2-machines-viz.chart.projection :as projection]
             [day8.re-frame2-machines-viz.theme.tokens
-             :as tokens
-             :refer [mono-stack sans-stack]]))
+             :refer [sans-stack chart-label-stack]]))
 
 ;; ---- density-resolved constants -----------------------------------------
 ;;
@@ -87,25 +86,38 @@
 ;; pin) and the renderer reads them via `projection/<name>`.
 
 ;; ---- helpers ------------------------------------------------------------
+;;
+;; rf2-az6e2 — the structured grammar reads STRUCTURE, not annotation
+;; colour: a resting state node is neutral (body bg + neutral border),
+;; and runtime state (active / focused-event lens / sim) drives the
+;; BORDER + HEADER + GLOW, NOT the whole fill. So `node-border` swaps the
+;; resting border for the runtime accent while the body fill stays
+;; neutral; only `state-header-bg` picks up a faint runtime tint so the
+;; title strip reads as "this is where we are".
 
-(defn- node-fill
-  [{:keys [active? from-highlight? to-highlight? sim?]}]
+(defn- node-border
+  "rf2-az6e2 — the resting border is the neutral structural colour; a
+  runtime state (active / focus lens / sim) swaps it for the runtime
+  accent so the border carries the signal, not the fill."
+  [ct {:keys [active? from-highlight? to-highlight? sim?]}]
   (cond
-    sim?            (tokens/with-alpha :yellow         0.18)
-    to-highlight?   (tokens/with-alpha :info           0.22)
-    from-highlight? (tokens/with-alpha :accent  0.14)
-    active?         (tokens/with-alpha :info           0.18)
-    :else           (:bg-2 tokens/tokens)))
+    sim?            (:sim ct)
+    to-highlight?   (:active ct)
+    from-highlight? (:focus ct)
+    active?         (:active ct)
+    :else           (:state-border ct)))
 
-(defn- node-stroke
-  [{:keys [active? from-highlight? to-highlight? sim? final?]}]
+(defn- header-bg
+  "rf2-az6e2 — the title strip's fill. Neutral by default; a faint
+  runtime wash when active / focused so the header reads the runtime
+  signal without flooding the whole node fill."
+  [ct {:keys [active? from-highlight? to-highlight? sim?]}]
   (cond
-    sim?            (:yellow tokens/tokens)
-    to-highlight?   (:info tokens/tokens)
-    from-highlight? (:accent tokens/tokens)
-    active?         (:info tokens/tokens)
-    final?          (:green tokens/tokens)
-    :else           (:border-default tokens/tokens)))
+    sim?            (:sim-wash ct)
+    to-highlight?   (:active-wash ct)
+    from-highlight? (:focus-wash ct)
+    active?         (:active-wash ct)
+    :else           (:state-header-bg ct)))
 
 (defn- tag-title-attr
   "Compose a state's `:tags` set (Spec 005 user-declared semantic
@@ -127,23 +139,20 @@
          (str/join " "))))
 
 (defn- tag-pill
-  "rf2-a2b55 — render a single state-tag pill positioned BELOW the
-  state name per Stately graph view convention. Hiccup. Geometry +
-  typography read off the resolved density `vc` map (height / pad-x
-  / px / radius / gap) so the chrome scales with `:density`. Colour
-  comes from the deterministic `tokens/tag-pill-color` rotation so a
-  given tag id paints the same hue across renders.
+  "rf2-az6e2 — render a single state-tag chip in ONE NEUTRAL style.
+  Structure wins over annotation colour: the prior deterministic colour
+  rotation (rf2-a2b55) is dropped for the topology view so the eye reads
+  the chart's STRUCTURE (containment + transition flow), not a rainbow
+  of tag hues. Tag IDENTITY is preserved in the `data-tag` / `title`
+  attrs + the state-node's `data-tags` + the inspector surfaces, so host
+  introspection + hover still resolve every tag.
 
-  Pre-rf2-so5b0 the pill row sat ABOVE the label and the diagnostic
-  in that bead misread the resulting clutter as ancestor-path tag
-  chips. Stately's graph view paints descriptive tags BELOW the
-  state name as a quiet pill row — rf2-a2b55 follows that pattern."
-  [tag {:keys [tag-pill-height tag-pill-pad-x tag-pill-px
-               tag-pill-radius tag-pill-gap]}]
-  (let [label   (if (keyword? tag) (name tag) (str tag))
-        token-k (tokens/tag-pill-color tag)
-        fill    (tokens/with-alpha token-k 0.18)
-        stroke  (get tokens/tokens token-k)]
+  Geometry + typography read off the resolved density `vc` map; colour
+  is the neutral container-header fill + the structural border + the
+  secondary text colour from the active-theme `ct` map."
+  [tag ct {:keys [tag-pill-height tag-pill-pad-x tag-pill-px
+                  tag-pill-radius tag-pill-gap]}]
+  (let [label (if (keyword? tag) (name tag) (str tag))]
     [:span {:key   label
             :title (str tag)
             :data-testid (str "rf-mv-chart-state-tag-" label)
@@ -153,77 +162,99 @@
                     :height           (str tag-pill-height "px")
                     :padding          (str "0 " tag-pill-pad-x "px")
                     :margin-right     (str tag-pill-gap "px")
-                    :background       fill
-                    :border           (str "1px solid " stroke)
+                    :background       (:container-header-bg ct)
+                    :border           (str "1px solid " (:state-border ct))
                     :border-radius    (str tag-pill-radius "px")
-                    :font-family      sans-stack
+                    :font-family      chart-label-stack
                     :font-size        (str tag-pill-px "px")
-                    :font-weight      600
-                    :color            stroke
+                    :font-weight      500
+                    :color            (:text-secondary ct)
                     :line-height      "1"
                     :white-space      "nowrap"}}
      label]))
 
-(defn- action-pill
-  "rf2-a2b55 — render an entry / exit action as a `+ <name>` (entry)
-  or `- <name>` (exit) pill, the Stately graph view convention for
-  state-actions. Geometry + typography read off the resolved density
-  `vc` map. Colour uses the `:advisory` token so the pill reads as
-  a subordinate annotation against the state name."
-  [{:keys [kind name-str vc]}]
+(defn- action-row
+  "rf2-az6e2 — render an entry / exit action METADATA ROW: a quiet
+  section caption (\"Entry actions\" / \"Exit actions\") plus a subdued
+  action chip carrying a bolt glyph + the action name. The chip stays
+  SUBORDINATE to the state title (quieter colour + smaller type). Reads
+  geometry/typography off the resolved density `vc` map and colour off
+  the active-theme `ct`."
+  [{:keys [kind name-str vc ct]}]
   (let [{:keys [action-pill-height action-pill-pad-x action-pill-px
-                action-pill-radius action-pill-gap]} vc
-        prefix (case kind :entry "+ " :exit "- ")]
-    [:span {:data-testid (case kind
-                           :entry "rf-mv-chart-state-entry"
-                           :exit  "rf-mv-chart-state-exit")
-            (case kind :entry :data-entry :exit :data-exit) name-str
-            :style {:display          "inline-flex"
-                    :align-items      "center"
-                    :height           (str action-pill-height "px")
-                    :padding          (str "0 " action-pill-pad-x "px")
-                    :margin-right     (str action-pill-gap "px")
-                    :background       (tokens/with-alpha :advisory 0.18)
-                    :border           (str "1px solid "
-                                            (tokens/with-alpha :advisory 0.6))
-                    :border-radius    (str action-pill-radius "px")
-                    :font-family      mono-stack
-                    :font-size        (str action-pill-px "px")
-                    :font-weight      500
-                    :color            (:advisory tokens/tokens)
-                    :line-height      "1"
-                    :white-space      "nowrap"}}
-     (str prefix name-str)]))
+                action-pill-radius action-caption-px action-caption-gap]} vc
+        caption (case kind :entry "Entry actions" :exit "Exit actions")]
+    [:div {:data-testid (case kind
+                          :entry "rf-mv-chart-state-entry"
+                          :exit  "rf-mv-chart-state-exit")
+           (case kind :entry :data-entry :exit :data-exit) name-str
+           :style {:display        "flex"
+                   :flex-direction "column"
+                   :gap            (str action-caption-gap "px")}}
+     [:span {:style {:font-family    chart-label-stack
+                     :font-size      (str action-caption-px "px")
+                     :font-weight    600
+                     :letter-spacing "0.04em"
+                     :text-transform "uppercase"
+                     :color          (:text-tertiary ct)
+                     :line-height     "1"}}
+      caption]
+     [:span {:style {:display       "inline-flex"
+                     :align-items   "center"
+                     :gap           "3px"
+                     :align-self    "flex-start"
+                     :height        (str action-pill-height "px")
+                     :padding       (str "0 " action-pill-pad-x "px")
+                     :background    (:container-header-bg ct)
+                     :border        (str "1px solid " (:state-border ct))
+                     :border-radius (str action-pill-radius "px")
+                     :font-family   chart-label-stack
+                     :font-size     (str action-pill-px "px")
+                     :font-weight   500
+                     :color         (:text-secondary ct)
+                     :line-height   "1"
+                     :white-space   "nowrap"}}
+      ;; subordinate bolt/action glyph (text convention — no icon dep)
+      [:span {:style {:opacity 0.7}} "⚡"]
+      name-str]]))
 
 ;; ---- state node ---------------------------------------------------------
 
 (defn state-node
-  "Reagent component for a standard state node. xyflow invokes this
-  via the `nodeTypes={:state state-node}` map. xyflow passes a single
-  `props` argument; we read `:data` off it (an object whose keys are
-  the CLJS payload the projector emitted).
+  "rf2-az6e2 — Reagent component for a leaf state node, rendered as a
+  STRUCTURED TITLE/BODY BOX (not a centred rounded pill). xyflow invokes
+  this via `nodeTypes={:state state-node}`; we read the projected `:data`
+  off the JS props.
 
-  Visual identity:
+  Structure:
 
-    - Rounded-rect body, corner-radius 6 (the rf2-g6cig lock).
-    - Mono state label centred at the top.
-    - User-declared `:tags` (Spec 005) render as a pill row directly
-      BELOW the state name (rf2-a2b55, Stately graph view convention)
-      with deterministic per-tag colours from `tokens/tag-pill-color`.
-      The same set surfaces on the state-node's `:data-tags` +
-      `:title` attrs (rf2-so5b0 contract) so host introspection +
-      hover tooltips still resolve the tag set in bulk.
-    - Active state: cyan tint + emphasised stroke.
-    - From-highlight (focused-event lens origin): violet dashed.
-    - To-highlight (focused-event lens landing): emphasised cyan.
-    - Final state: doubled border + small check glyph.
-    - Entry / exit actions render as `+ <name>` (entry) / `- <name>`
-      (exit) pills BELOW the tag row (rf2-a2b55 — Stately graph view
-      `Entry actions` convention; replaces the prior `entry / <name>`
-      text rows from rf2-ee38b.21)."
+    - Square-ish box, low radius (the rf2-g6cig 6px lock).
+    - A full-width TITLE STRIP carrying the state label, LEFT-aligned,
+      sans font (`chart-label-stack`).
+    - A title/body DIVIDER (hairline) when body content exists.
+    - A BODY area holding neutral tag chips + quiet entry/exit action
+      rows, also left-aligned. Absent entirely when the state has no
+      tags + no actions (then the title strip IS the box).
+
+  Runtime affordance (structure-first — the runtime signal rides the
+  BORDER + HEADER + GLOW, NOT the whole fill):
+
+    - active / to-highlight: runtime accent border + faint header wash +
+      glow ring.
+    - from-highlight (focus lens origin): focus accent border + wash.
+    - sim: amber accent.
+    - final: a QUIET double border (outer ring). The prior ✓ check glyph
+      is DROPPED (rf2-az6e2 decision recorded in the bead) — the doubled
+      border is the unambiguous final-state signal and the glyph competed
+      with the title for attention.
+
+  Tag identity (`data-tags` / per-chip `data-tag` / `title`) + the
+  `data-active*` / `data-state-path` attrs are PRESERVED for the DOM
+  test suite + host introspection."
   [^js props]
   (let [d              (.-data props)
         vc             (chart-constants d)
+        ct             (palette-of d)
         label          (or (.-label d) "")
         path           (.-path d)
         active?        (boolean (.-active d))
@@ -232,44 +263,36 @@
         sim?           (boolean (.-sim d))
         final?         (boolean (.-final d))
         tags           (js->clj (.-tags d))
-        ;; rf2-so5b0 + rf2-a2b55 — tags surface BOTH as a visible pill
-        ;; row BELOW the state name (Stately graph view convention,
-        ;; restored in rf2-a2b55) AND as the sorted space-joined
-        ;; tooltip / data-attr surface rf2-so5b0 added for host
-        ;; introspection. `tags-attr` is nil when the state has no
-        ;; tags so the title attr is simply omitted.
         tags-attr      (tag-title-attr tags)
         entry          (.-entry d)
         exit           (.-exit d)
         on-click       (.-onClick d)
         emphasised?    (or active? from-highlight? to-highlight?)
         active-affordance? (or active? to-highlight?)
-        styled         {:active?        active?
+        styled         {:active?         active?
                         :from-highlight? from-highlight?
-                        :to-highlight?  to-highlight?
-                        :sim?           sim?
-                        :final?         final?}
-        fill           (node-fill styled)
-        stroke         (node-stroke styled)
-        ;; rf2-k647w — stroke widths read off the resolved density.
-        ;; The active-affordance stroke sits one notch above the
-        ;; emphasis stroke (active-affordance = emphasis + 0.75,
-        ;; preserving the shipped regular relationship 2.5 → 3.25).
+                        :to-highlight?   to-highlight?
+                        :sim?            sim?}
+        border-col     (node-border ct styled)
+        header-fill    (header-bg ct styled)
         {:keys [corner-radius stroke-width stroke-width-emphasis
-                state-label-px final-glyph-px]} vc
+                state-title-height state-title-pad-x state-title-px
+                state-body-pad-x state-body-pad-y state-body-gap
+                state-divider-width state-shadow-blur
+                tag-pill-row-gap]} vc
         stroke-w       (cond
                          active-affordance? (+ stroke-width-emphasis 0.75)
                          emphasised?        stroke-width-emphasis
-                         :else              stroke-width)]
+                         :else              stroke-width)
+        has-body?      (or (seq tags) entry exit)]
     (r/as-element
       [:div {:data-testid (str "rf-mv-chart-node-" (.-id props))
              :data-active (str active?)
              :data-from-highlight (str from-highlight?)
              :data-to-highlight (str to-highlight?)
              :data-active-affordance (str active-affordance?)
+             :data-final (str final?)
              :data-state-path (when path (pr-str (js->clj path)))
-             ;; rf2-so5b0 — user-declared `:tags` exposed for DOM tests +
-             ;; host introspection without visible chart chrome.
              :data-tags (or tags-attr "")
              :data-tag-count (count (or tags []))
              :title (or tags-attr (when on-click "Click for details"))
@@ -279,81 +302,72 @@
              :style {:position         "relative"
                      :display          "flex"
                      :flex-direction   "column"
-                     :align-items      "center"
-                     :justify-content  "center"
+                     :align-items      "stretch"
                      :min-width        (str projection/state-node-min-width "px")
                      :min-height       (str projection/state-node-min-height "px")
-                     :padding          "8px 12px"
-                     :background       fill
-                     :border           (str stroke-w "px solid " stroke)
+                     :background       (:state-body-bg ct)
+                     :border           (str stroke-w "px solid " border-col)
                      :border-radius    (str corner-radius "px")
-                     :font-family      mono-stack
-                     :font-size        (str state-label-px "px")
-                     :font-weight      (if emphasised? 600 400)
-                     :color            (if emphasised?
-                                         (:text-primary tokens/tokens)
-                                         (:text-secondary tokens/tokens))
+                     :overflow         "hidden"
+                     :font-family      chart-label-stack
+                     :color            (:text-secondary ct)
                      :cursor           (if on-click "pointer" "default")
                      :user-select      "none"
-                     :box-shadow       (when active-affordance?
-                                         (str "0 0 0 2px "
-                                              (tokens/with-alpha :info 0.18)))
+                     :box-shadow       (if active-affordance?
+                                         (str "0 0 0 2px " (:glow ct))
+                                         (str "0 1px " state-shadow-blur "px rgba(0,0,0,0.25)"))
                      :transition       "border-color 120ms ease, background 120ms ease"}}
-       ;; Final-state double-ring (outer)
+       ;; Final-state QUIET double-ring (outer). The ✓ glyph is dropped.
        (when final?
-         [:div {:style {:position      "absolute"
-                       :top           "-3px"
-                       :left          "-3px"
-                       :right         "-3px"
-                       :bottom        "-3px"
-                       :border        (str "1px solid " (:green tokens/tokens))
-                       ;; outer ring sits 1px proud of the node corner
-                       :border-radius (str (inc corner-radius) "px")
-                       :pointer-events "none"}}])
-       ;; Label
-       [:div {:style {:line-height "1.2"}} label]
-       ;; rf2-a2b55 — tag pill row positioned BELOW the state name
-       ;; (Stately graph view convention). Pre-rf2-so5b0 the row sat
-       ;; ABOVE the label; that bead diagnosed the resulting clutter
-       ;; as ancestor-path tag chips and retired the row. rf2-a2b55
-       ;; reinstates the row in its Stately-canonical position.
-       (when (seq tags)
-         [:div {:data-testid "rf-mv-chart-state-tags"
-                :style {:display        "flex"
-                        :flex-wrap      "wrap"
-                        :justify-content "center"
-                        :align-items    "center"
-                        :margin-top     (str (:tag-pill-row-gap vc) "px")
-                        :gap            "0"}}
-          (->> tags
-               sort
-               (map (fn [t] (tag-pill t vc))))])
-       ;; rf2-a2b55 — :entry / :exit actions render as `+ <name>` /
-       ;; `- <name>` pills BELOW the tag row (Stately graph view
-       ;; `Entry actions` convention; replaces the prior `entry /
-       ;; <name>` text rows shipped by rf2-ee38b.21).
-       (when (or entry exit)
-         [:div {:data-testid "rf-mv-chart-state-actions"
-                :style {:display        "flex"
-                        :flex-direction "row"
-                        :flex-wrap      "wrap"
-                        :justify-content "center"
-                        :align-items    "center"
-                        :margin-top     (str (:action-pill-row-gap vc) "px")
-                        :gap            "0"}}
+         [:div {:data-testid (str "rf-mv-chart-node-final-ring-" (.-id props))
+                :style {:position      "absolute"
+                        :top           "-3px"
+                        :left          "-3px"
+                        :right         "-3px"
+                        :bottom        "-3px"
+                        :border        (str "1px solid " border-col)
+                        :border-radius (str (inc corner-radius) "px")
+                        :pointer-events "none"}}])
+       ;; TITLE STRIP — full-width, left-aligned label.
+       [:div {:data-testid (str "rf-mv-chart-state-title-" (.-id props))
+              :style {:display        "flex"
+                      :align-items    "center"
+                      :min-height     (str state-title-height "px")
+                      :padding        (str "0 " state-title-pad-x "px")
+                      :background      header-fill
+                      :border-bottom   (if has-body?
+                                         (str state-divider-width "px solid "
+                                              (:divider ct))
+                                         "none")
+                      :font-size      (str state-title-px "px")
+                      :font-weight    (if emphasised? 600 500)
+                      :color          (if emphasised?
+                                        (:text-primary ct)
+                                        (:text-secondary ct))
+                      :white-space    "nowrap"
+                      :overflow       "hidden"
+                      :text-overflow  "ellipsis"}}
+        label]
+       ;; BODY — neutral tag chips + quiet entry/exit action rows.
+       (when has-body?
+         [:div {:style {:display         "flex"
+                        :flex-direction  "column"
+                        :gap             (str state-body-gap "px")
+                        :padding         (str state-body-pad-y "px "
+                                              state-body-pad-x "px")}}
+          (when (seq tags)
+            [:div {:data-testid "rf-mv-chart-state-tags"
+                   :style {:display    "flex"
+                           :flex-wrap  "wrap"
+                           :align-items "center"
+                           :row-gap    (str tag-pill-row-gap "px")}}
+             (->> tags
+                  sort
+                  (map (fn [t] (tag-pill t ct vc))))])
           (when entry
-            (action-pill {:kind :entry :name-str entry :vc vc}))
+            (action-row {:kind :entry :name-str entry :vc vc :ct ct}))
           (when exit
-            (action-pill {:kind :exit  :name-str exit  :vc vc}))])
-       ;; Final-state check glyph
-       (when final?
-         [:div {:style {:position    "absolute"
-                       :top         "4px"
-                       :right       "8px"
-                       :font-family mono-stack
-                       :font-size   (str final-glyph-px "px")
-                       :color       (:green tokens/tokens)}}
-          "✓"])
+            (action-row {:kind :exit :name-str exit :vc vc :ct ct}))])
        ;; xyflow attachment points (invisible — edges connect here)
        [:> Handle {:type "target" :position pos-top
                    :style {:opacity 0}}]
@@ -396,17 +410,22 @@
   [^js props]
   (let [d     (.-data props)
         vc    (chart-constants d)
+        ct    (palette-of d)
         label (or (.-label d) "")
         path  (.-path d)
-        ;; rf2-80rm2 (G4) — for self-consistency with the active-region
-        ;; chrome, a compound CONTAINER whose active descendant leaf lit it
-        ;; (the projector folds that into `:active` via the `:parent-id`
-        ;; chain) also gets active chrome: a solid (not dashed) accent border
-        ;; + the `:info` active-token glow ring — the same active affordance
-        ;; state nodes and active regions use. Minimal: only the boundary
-        ;; firms up and the glow appears; inactive compounds are unchanged.
+        ;; rf2-80rm2 (G4) — a compound CONTAINER whose active descendant
+        ;; leaf lit it (the projector folds that into `:active` via the
+        ;; `:parent-id` chain) gets active chrome: the runtime accent
+        ;; border + glow ring. Inactive compounds read NEUTRAL.
         active? (boolean (.-active d))
-        {:keys [compound-pad-y compound-radius compound-title-px]} vc]
+        {:keys [compound-radius container-title-height container-title-pad-x
+                container-title-px container-divider-width
+                stroke-width stroke-width-emphasis]} vc
+        ;; rf2-az6e2 — solid SUBTLE NEUTRAL border by default (no dashed,
+        ;; no accent wash — dashed/accent is reserved for parallel
+        ;; regions + runtime state). Active swaps to the runtime accent.
+        border-col  (if active? (:active ct) (:container-border ct))
+        border-w    (if active? stroke-width-emphasis stroke-width)]
     (r/as-element
       [:div {:data-testid (str "rf-mv-chart-compound-" (.-id props))
              :data-node-id (.-id props)
@@ -417,30 +436,42 @@
                      :height           "100%"
                      :min-width        (str projection/compound-node-min-width "px")
                      :min-height       (str projection/compound-node-min-height "px")
-                     :padding-top      (str compound-pad-y "px")
-                     :background       (tokens/with-alpha :accent (if active? 0.10 0.06))
-                     :border           (str (if active? "1.5px solid " "1px dashed ")
-                                            (:accent tokens/tokens))
+                     :background       (:container-body-bg ct)
+                     :border           (str border-w "px solid " border-col)
                      :border-radius    (str compound-radius "px")
                      :box-shadow       (when active?
-                                         (str "0 0 0 2px "
-                                              (tokens/with-alpha :info 0.18)))
-                     ;; rf2-shv82 — `pointer-events: auto` only on the
-                     ;; handles (set per-handle below). The body stays
-                     ;; pointer-events-transparent so clicks pass through to
-                     ;; nested leaves.
+                                         (str "0 0 0 2px " (:glow ct)))
+                     ;; rf2-shv82 — body stays pointer-transparent so
+                     ;; clicks pass through to nested leaves.
                      :pointer-events   "none"}}
-       [:div {:style {:position    "absolute"
-                     :top         "4px"
-                     :left        "10px"
-                     :font-family sans-stack
-                     :font-size   (str compound-title-px "px")
-                     :font-weight 600
-                     :color       (:accent tokens/tokens)}}
+       ;; FULL-WIDTH TITLE STRIP at top — solid neutral header band.
+       [:div {:data-testid (str "rf-mv-chart-compound-title-" (.-id props))
+              :style {:position    "absolute"
+                      :top         0
+                      :left        0
+                      :right       0
+                      :display     "flex"
+                      :align-items "center"
+                      :height      (str container-title-height "px")
+                      :padding     (str "0 " container-title-pad-x "px")
+                      :background    (if active?
+                                       (:active-wash ct)
+                                       (:container-header-bg ct))
+                      :border-bottom (str container-divider-width "px solid "
+                                          (:divider ct))
+                      :border-top-left-radius  (str compound-radius "px")
+                      :border-top-right-radius (str compound-radius "px")
+                      :font-family sans-stack
+                      :font-size   (str container-title-px "px")
+                      :font-weight 600
+                      :color       (if active?
+                                     (:text-primary ct)
+                                     (:text-secondary ct))
+                      :white-space "nowrap"
+                      :overflow    "hidden"
+                      :text-overflow "ellipsis"}}
         label]
-       ;; rf2-shv82 — invisible xyflow attachment points. Edges with a
-       ;; compound endpoint anchor to one of these; without them xyflow
-       ;; silently drops the edge (the bug rf2-shv82 closes).
+       ;; rf2-shv82 — invisible xyflow attachment points.
        [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]
        [:> Handle {:type "source" :position pos-bottom :style {:opacity 0}}]
        [:> Handle {:type "target" :position pos-left   :id "left"
@@ -451,38 +482,86 @@
 ;; ---- initial marker node ------------------------------------------------
 
 (defn initial-marker
-  "Reagent component for the machine's initial-state marker — a filled
-  dot followed by the `↳` glyph (Stately graph view convention,
-  rf2-qo5xy). Rendered as a tiny xyflow node with an outgoing edge
+  "rf2-az6e2 — Reagent component for the machine's initial-state pseudo-
+  state marker. A small NEUTRAL filled dot (the SCXML/xstate initial
+  pseudo-state convention), NOT an accent-blue runtime marker: the
+  initial pseudo-state is STATIC topology, so it reads in the neutral
+  pseudo-state colour (`:pseudo-marker`), reserving accent/active for
+  runtime state. Rendered as a tiny xyflow node with an outgoing edge
   into the initial state.
 
-  Pre-rf2-qo5xy the marker was JUST the filled dot; the bead's
-  paradigm-shift checklist calls for the `↳` glyph as an additional
-  affordance an operator who knows xstate/Stately reads in 30
-  seconds — 'this is THE initial state' rather than 'a state node
-  with an upstream marker'. Composing the glyph on the marker
-  (rather than as separate node) keeps the topology hop short and
-  the elk layered layout pleasant."
-  [^js _props]
-  (r/as-element
-    [:div {:data-testid "rf-mv-chart-initial-marker"
-           :style {:display          "inline-flex"
-                   :align-items      "center"
-                   :gap              "4px"}}
-     [:div {:data-testid "rf-mv-chart-initial-marker-dot"
-            :style {:width            "10px"
-                    :height           "10px"
-                    :border-radius    "50%"
-                    :background       (:accent tokens/tokens)}}]
-     [:span {:data-testid "rf-mv-chart-initial-marker-glyph"
-             :style {:font-family   mono-stack
-                     :font-size     "14px"
-                     :font-weight   600
-                     :line-height   "1"
-                     :color         (:accent tokens/tokens)}}
-      "↳"]
-     [:> Handle {:type "source" :position pos-right
-                 :style {:opacity 0}}]]))
+  Geometry reads off the resolved density (`:pseudo-size` /
+  `:pseudo-radius`)."
+  [^js props]
+  (let [d   (.-data props)
+        vc  (chart-constants d)
+        ct  (palette-of d)
+        {:keys [pseudo-size]} vc]
+    (r/as-element
+      [:div {:data-testid "rf-mv-chart-initial-marker"
+             :data-pseudo-kind "initial"
+             :style {:display     "inline-flex"
+                     :align-items "center"}}
+       [:div {:data-testid "rf-mv-chart-initial-marker-dot"
+              :style {:width         (str pseudo-size "px")
+                      :height        (str pseudo-size "px")
+                      :border-radius "50%"
+                      :background    (:pseudo-marker ct)}}]
+       [:> Handle {:type "source" :position pos-right
+                   :style {:opacity 0}}]])))
+
+;; ---- history pseudo-state renderer (rf2-az6e2 — HOOK ONLY) --------------
+;;
+;; rf2-az6e2 — the bead defines the VISUAL rendering of history pseudo-
+;; states (shallow `H` / deep `H*`, small symbolic node inside the owning
+;; compound, direct incoming transitions, NO normal state-box styling)
+;; for parsed topology that ALREADY contains pseudo-state data. The
+;; current `chart.layout/parse-definition` does NOT yet emit history
+;; pseudo-state nodes (no `:history` key in the parsed node shape), and
+;; the bead is explicit that it "must not add statechart history
+;; semantics to re-frame2". So this renderer is a HOOK: it is shaped to
+;; the grammar + wired into the node-types map below, but the projector
+;; never emits a `history-marker` node today. When the parse + Spec 005
+;; history semantics land (follow-on bead rf2-az6e2-history-render),
+;; flip the projector to emit `{:type "history-marker" :data {:deep?
+;; …}}` and this renderer paints it. Constants (`:pseudo-*`) already
+;; carry the variant.
+
+(defn history-marker
+  "rf2-az6e2 — small symbolic pseudo-state node for a history marker.
+  Shallow history renders `H`; deep history renders `H*`. Reads
+  `:data {:deep? <bool>}`. NOT a normal state box — a small neutral
+  rounded square so it reads as a pseudo-state inside its owning
+  compound. HOOK ONLY today (see the section comment above): no
+  projector path emits it until history topology data exists."
+  [^js props]
+  (let [d   (.-data props)
+        vc  (chart-constants d)
+        ct  (palette-of d)
+        deep? (boolean (.-deep d))
+        {:keys [pseudo-size pseudo-radius pseudo-px]} vc
+        side (+ pseudo-size 6)]
+    (r/as-element
+      [:div {:data-testid (str "rf-mv-chart-history-" (.-id props))
+             :data-pseudo-kind (if deep? "history-deep" "history-shallow")
+             :style {:display         "inline-flex"
+                     :align-items     "center"
+                     :justify-content "center"
+                     :width           (str side "px")
+                     :height          (str side "px")
+                     :border          (str "1px solid " (:pseudo-marker ct))
+                     :border-radius   (str pseudo-radius "px")
+                     :background      (:state-body-bg ct)
+                     :font-family     chart-label-stack
+                     :font-size       (str pseudo-px "px")
+                     :font-weight     700
+                     :color           (:pseudo-marker ct)
+                     :line-height     "1"
+                     :user-select     "none"}}
+       (if deep? "H*" "H")
+       [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]
+       [:> Handle {:type "target" :position pos-left :id "left"
+                   :style {:opacity 0}}]])))
 
 ;; rf2-ee38b.21 — the dead `final-marker` component + its node-type
 ;; registration were removed. The projector only ever emits
@@ -508,4 +587,8 @@
        "compound"        compound-node
        "parallel-region" parallel-region-node/parallel-region-node
        "initial-marker"  initial-marker
+       ;; rf2-az6e2 — history pseudo-state renderer registered as a HOOK
+       ;; (the projector emits no `history-marker` node until history
+       ;; topology data lands; see `history-marker` docstring).
+       "history-marker"  history-marker
        "rf2-event"       event-node/event-node})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -319,7 +319,7 @@
                      :transition       "border-color 120ms ease, background 120ms ease"}}
        ;; Final-state QUIET double-ring (outer). The ✓ glyph is dropped.
        (when final?
-         [:div {:data-testid (str "rf-mv-chart-node-final-ring-" (.-id props))
+         [:div {:data-testid (str "rf-mv-chart-final-ring-" (.-id props))
                 :style {:position      "absolute"
                         :top           "-3px"
                         :left          "-3px"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
@@ -40,10 +40,9 @@
   (:require [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
              :refer [Handle pos-top pos-right pos-bottom pos-left
-                     chart-constants]]
+                     chart-constants palette-of]]
             [day8.re-frame2-machines-viz.theme.tokens
-             :as tokens
-             :refer [mono-stack sans-stack]]))
+             :refer [chart-label-stack]]))
 
 (defn- variant-glyph
   "rf2-qo5xy — convention-glyph variants for the event-node header. The
@@ -88,6 +87,7 @@
   [^js props]
   (let [d           (.-data props)
         vc          (chart-constants d)
+        ct          (palette-of d)
         event-label (or (.-eventLabel d) "")
         variant     (keyword (or (.-variant d) "on"))
         after-ms    (.-afterMs d)
@@ -105,21 +105,33 @@
         header      (variant-glyph {:variant     variant
                                     :after-ms    after-ms
                                     :event-label event-label})
-        {:keys [corner-radius stroke-width stroke-width-emphasis
-                edge-label-px action-pill-height action-pill-pad-x
-                action-pill-px action-pill-radius action-pill-row-gap]} vc
+        {:keys [event-chip-min-w event-chip-min-h event-chip-pad-x
+                event-chip-pad-y event-chip-radius event-chip-px
+                event-chip-action-px stroke-width stroke-width-emphasis]} vc
         emphasised? (or focused? fired?)
         stroke-w    (if emphasised? stroke-width-emphasis stroke-width)
+        ;; rf2-az6e2 — the route chip is SUBORDINATE to states: a quiet
+        ;; neutral fill + neutral border by default. Runtime state
+        ;; (focused lens / fired-this-epoch) swaps the border to the
+        ;; runtime accent; a clickable (sim) chip gets a faint amber wash.
         stroke-col  (cond
-                      fired?    (:accent tokens/tokens)
-                      focused?  (:info tokens/tokens)
-                      :else     (tokens/with-alpha :border-default 0.7))
+                      fired?    (:edge-fired ct)
+                      focused?  (:edge-active ct)
+                      :else     (:event-chip-border ct))
         fill        (cond
-                      fired?    (tokens/with-alpha :accent 0.12)
-                      focused?  (tokens/with-alpha :info 0.10)
-                      clickable? (tokens/with-alpha :yellow 0.06)
-                      :else      (tokens/with-alpha :bg-3 0.6))]
+                      fired?    (:glow-fired ct)
+                      focused?  (:glow ct)
+                      clickable? (:sim-wash ct)
+                      :else      (:event-chip-bg ct))]
     (r/as-element
+      ;; rf2-az6e2 — route chip / card grammar. NO title bar (the bead is
+      ;; explicit: event nodes must NOT read as peer state boxes). The
+      ;; event label + guard ride the FIRST line; the action row appears
+      ;; only when an action exists; an internal / action-only transition
+      ;; (no outgoing target segment — the projector omits the `__out`
+      ;; edge) keeps a dashed border ring so it reads as "runs an action
+      ;; and hangs here". Machine-level is muted: NO loud label, only the
+      ;; `data-machine-level` attr for host introspection.
       [:div {:data-testid (str "rf-mv-chart-event-" (.-id props))
              :data-node-id (.-id props)
              :data-event-id (when event-id (str event-id))
@@ -148,78 +160,60 @@
              :style {:position       "relative"
                      :display        "inline-flex"
                      :flex-direction "column"
-                     :align-items    "center"
+                     :align-items    "flex-start"
                      :justify-content "center"
-                     :gap            "3px"
-                     :min-width      "84px"
-                     :min-height     "30px"
-                     :padding        "4px 10px"
+                     :gap            (str event-chip-pad-y "px")
+                     :min-width      (str event-chip-min-w "px")
+                     :min-height     (str event-chip-min-h "px")
+                     :padding        (str event-chip-pad-y "px "
+                                          event-chip-pad-x "px")
                      :background     fill
                      :border         (str stroke-w "px "
                                           (if internal? "dashed" "solid")
                                           " " stroke-col)
-                     :border-radius  (str (max 4 (- corner-radius 2)) "px")
-                     :font-family    sans-stack
-                     :font-size      (str edge-label-px "px")
+                     :border-radius  (str event-chip-radius "px")
+                     :font-family    chart-label-stack
+                     :font-size      (str event-chip-px "px")
                      :font-weight    (if emphasised? 600 500)
-                     :color          (:text-primary tokens/tokens)
+                     :color          (:text-secondary ct)
                      :cursor         (if clickable? "pointer" "default")
                      :user-select    "none"
                      :box-shadow     (when emphasised?
                                        (str "0 0 0 2px "
-                                            (tokens/with-alpha
-                                              (if fired? :accent :info) 0.15)))
+                                            (if fired? (:glow-fired ct) (:glow ct))))
                      :animation      (when fired?
                                        "mv-chart-transition-glow 720ms ease-out infinite")
                      :transition     "border-color 120ms ease, background 120ms ease"}}
-       ;; Header line: event name / ⌚ <ms> / ∞ + optional [guard] chip.
+       ;; First line: event name / ⌚ <ms> / ∞ + optional `IF <guard>`.
        [:span {:data-testid (str "rf-mv-chart-event-header-" (.-id props))
                :data-event-line (cond-> header
-                                  guard (str " [" guard "]"))
-               :style {:font-family mono-stack
-                       :white-space "nowrap"
-                       :line-height "1.1"}}
+                                  guard (str " IF " guard))
+               :style {:white-space "nowrap"
+                       :line-height "1.1"
+                       :color (:text-primary ct)}}
         header
         (when guard
           [:span {:data-testid (str "rf-mv-chart-event-guard-" (.-id props))
                   :data-guard guard
-                  :style {:margin-left "4px"
-                          :color (:advisory tokens/tokens)
-                          :font-family mono-stack}}
-           (str "[" guard "]")])]
-       ;; Action pill (`+ <action-name>`) — Stately graph view convention.
+                  :style {:margin-left "5px"
+                          :color (:text-tertiary ct)
+                          :font-weight 600}}
+           (str "IF " guard)])]
+       ;; Action row — appears ONLY when an action exists. Subdued bolt
+       ;; chip, subordinate to the event line.
        (when action
          [:span {:data-testid (str "rf-mv-chart-event-action-" (.-id props))
                  :data-action action
-                 :style {:display          "inline-flex"
-                         :align-items      "center"
-                         :height           (str action-pill-height "px")
-                         :padding          (str "0 " action-pill-pad-x "px")
-                         :margin-top       (str action-pill-row-gap "px")
-                         :background       (tokens/with-alpha :advisory 0.18)
-                         :border           (str "1px solid "
-                                                (tokens/with-alpha :advisory 0.6))
-                         :border-radius    (str action-pill-radius "px")
-                         :font-family      mono-stack
-                         :font-size        (str action-pill-px "px")
-                         :font-weight      500
-                         :color            (:advisory tokens/tokens)
-                         :line-height      "1"
-                         :white-space      "nowrap"}}
-          (str "+ " action)])
-       ;; Machine-level annotation — a small subscript chip so the
-       ;; operator can see at a glance that this event-handler is
-       ;; inherited from the machine's top-level :on (not declared on
-       ;; the source state).
-       (when machine-level?
-         [:span {:data-testid (str "rf-mv-chart-event-machine-level-" (.-id props))
-                 :style {:font-family sans-stack
-                         :font-size   (str (max 8 (- action-pill-px 1)) "px")
-                         :font-weight 600
-                         :color       (tokens/with-alpha :text-tertiary 0.85)
-                         :letter-spacing "0.04em"
-                         :text-transform "uppercase"}}
-          "machine-level"])
+                 :style {:display      "inline-flex"
+                         :align-items  "center"
+                         :gap          "3px"
+                         :font-size    (str event-chip-action-px "px")
+                         :font-weight  500
+                         :color        (:text-tertiary ct)
+                         :line-height  "1"
+                         :white-space  "nowrap"}}
+          [:span {:style {:opacity 0.7}} "⚡"]
+          action])
        ;; xyflow attachment points. Handles on every side so elkjs can
        ;; pick the cleanest anchor based on the routed direction.
        [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -23,20 +23,23 @@
   the header strip. The child state nodes sit inside via xyflow's
   `parentId` positioning; this component only paints the surround.
 
-  ## Distinct boundary per region
+  ## Region identity comes from layout, not colour (rf2-az6e2)
 
-  Each region gets a deterministic accent colour from
-  `region-boundary-color` (a rotation over the token palette) so two
-  adjacent regions read as visually distinct zones — the dashed
-  border + the header label both pick up the region's colour. This is
-  the Stately-parity affordance: a reader sees N orthogonal regions
-  at a glance, each clearly delineated.
+  Regions are distinguished by CONTAINMENT + LAYOUT (side-by-side dashed
+  zones), NOT a rotating border colour. The prior per-region
+  `region-boundary-palette` rotation is removed: static colour rotation
+  is not the topology signal — structure wins. Every region's boundary
+  is the SAME neutral dashed treatment; the dashed style itself (vs the
+  compound container's solid neutral) is what marks a zone as a parallel
+  region.
 
   ## Token integration
 
-  All colours read from `theme/tokens`; no hex literals. The dashed
-  boundary uses the region's rotation colour; the body uses a faint
-  tint of the same so the zone reads as a unit.
+  All colours resolve through the active-theme chart-tokens (`palette-of`
+  off `:data`); no hex literals. The dashed boundary + header use the
+  neutral region tokens; active / focus colour is reserved for RUNTIME
+  state (`:active` accent + glow), so an active region reads live without
+  the static identity competing for the accent.
 
   ## Border handles (rf2-shv82)
 
@@ -51,63 +54,46 @@
   consistency."
   (:require [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
-             :refer [Handle pos-top pos-right pos-bottom pos-left]]
+             :refer [Handle pos-top pos-right pos-bottom pos-left
+                     chart-constants palette-of]]
             [day8.re-frame2-machines-viz.theme.tokens
-             :as tokens
-             :refer [sans-stack]]))
-
-;; ---- region boundary palette --------------------------------------------
-
-(def region-boundary-palette
-  "Deterministic colour rotation for parallel-region boundaries
-  (rf2-lkwev). Regions are STRUCTURAL zones (not per-state badges),
-  so the rotation leads with `:accent` (the structural-container
-  colour the compound-node chrome already uses) and spreads across
-  cool/warm so adjacent regions read as distinct orthogonal zones."
-  [:accent :info :orange :green :magenta :yellow])
-
-(defn region-boundary-color-key
-  "Map a region's index to a stable token key from
-  `region-boundary-palette`. Deterministic — region 0 is always the
-  violet structural colour, region 1 the next, wrapping past the end.
-  Pure data → keyword."
-  [region-index]
-  (nth region-boundary-palette
-       (mod (or region-index 0) (count region-boundary-palette))))
+             :refer [sans-stack mono-stack]]))
 
 ;; ---- parallel-region node ----------------------------------------------
 
 (defn parallel-region-node
-  "Reagent component for a parallel-region container. xyflow invokes
-  this via `nodeTypes={:parallel-region parallel-region-node}`. Reads
-  `:data {:label :regionIndex :regionId ...}` off the xyflow props.
+  "rf2-az6e2 — Reagent component for a parallel-region container. xyflow
+  invokes this via `nodeTypes={:parallel-region parallel-region-node}`.
+  Reads `:data {:label :regionIndex :regionId ...}` off the xyflow props.
 
-  Renders a translucent zone with a distinct dashed boundary (the
-  region's rotation colour) + a header strip carrying the region
-  label. xyflow's `parentId` mechanic places the region's child state
-  nodes inside; this component renders only the surrounding chrome."
+  Grammar (the dashed/accent treatment is reserved for regions — solid
+  neutral is the compound container):
+
+    - DASHED NEUTRAL rounded boundary. Region identity comes from
+      CONTAINMENT + LAYOUT, NOT a rotating border colour (the prior
+      per-region `region-boundary-palette` rotation is REMOVED — static
+      colour rotation is not the topology signal).
+    - A full-width REGION TITLE STRIP carrying the uppercased label, with
+      a subtle `∥` parallel glyph (small, never dominating).
+    - Active / focus colour is reserved for RUNTIME state: an active
+      region (a descendant leaf is active, folded into `:active` via the
+      `:parent-id` chain) firms its dashed boundary to a solid runtime-
+      accent border + glow ring. Inactive regions read fully neutral."
   [^js props]
   (let [d            (.-data props)
+        vc           (chart-constants d)
+        ct           (palette-of d)
         label        (or (.-label d) "")
         region-index (.-regionIndex d)
-        ;; rf2-80rm2 (G4) — the region CONTAINER reads active when any of
-        ;; its descendant leaves is in the active set (the projector folds
-        ;; that into `:active` via the `:parent-id` chain). An active region
-        ;; gets ACTIVE CHROME: a solid (not dashed) boundary, an emphasised
-        ;; header, and the `:info` active-token glow ring — the same
-        ;; active-token convention the state nodes use (no new palette). The
-        ;; region keeps its own rotation colour for zone identity; only the
-        ;; emphasis is added so the active region(s) read as active at the
-        ;; container level, matching Stately's active-region treatment.
         active?      (boolean (.-active d))
-        color-key    (region-boundary-color-key region-index)
-        border-color (get tokens/tokens color-key)
-        body-tint    (tokens/with-alpha color-key (if active? 0.10 0.05))
-        header-tint  (tokens/with-alpha color-key (if active? 0.20 0.12))
-        ;; Active boundary firms up (solid + heavier) so the zone reads as
-        ;; live; inactive keeps the dashed orthogonal-zone delineation.
+        {:keys [compound-radius region-title-height region-title-pad-x
+                container-title-px container-divider-width
+                stroke-width stroke-width-emphasis]} vc
+        ;; rf2-az6e2 — NEUTRAL boundary by default (no rotation colour).
+        ;; Active swaps the dashed neutral to a solid runtime accent.
+        border-color (if active? (:active ct) (:region-border ct))
         border-style (if active? "solid" "dashed")
-        border-width (if active? "2px" "1.5px")]
+        border-w     (if active? stroke-width-emphasis stroke-width)]
     (r/as-element
       [:div {:data-testid    (str "rf-mv-chart-region-" (.-id props))
              :data-node-id    (.-id props)
@@ -117,46 +103,43 @@
              :style {:position       "relative"
                      :width          "100%"
                      :height         "100%"
-                     :padding-top    "26px"
-                     :background     body-tint
-                     ;; Distinct boundary per region — the Stately-parity
-                     ;; orthogonal-zone delineation. Solid + emphasised
-                     ;; when the region is active (rf2-80rm2).
-                     :border         (str border-width " " border-style " " border-color)
-                     :border-radius  "12px"
-                     ;; rf2-80rm2 (G4) — the active-region glow ring uses the
-                     ;; `:info` active token, mirroring the state-node active
-                     ;; box-shadow (`0 0 0 2px info@0.18`) so an active region
-                     ;; reads with the SAME active affordance as an active state.
+                     :background     (:container-body-bg ct)
+                     ;; Dashed NEUTRAL orthogonal-zone delineation; solid
+                     ;; runtime-accent when active (rf2-80rm2 / rf2-az6e2).
+                     :border         (str border-w "px " border-style " " border-color)
+                     :border-radius  (str compound-radius "px")
                      :box-shadow     (when active?
-                                       (str "0 0 0 2px "
-                                            (tokens/with-alpha :info 0.18)))
+                                       (str "0 0 0 2px " (:glow ct)))
                      :pointer-events "none"}}
-       ;; Header strip — the region label, tinted to the region colour.
+       ;; Full-width REGION TITLE STRIP — neutral, with a subtle ∥ glyph.
        [:div {:data-testid (str "rf-mv-chart-regionhdr-" (.-id props))
               :style {:position       "absolute"
                       :top            0
                       :left           0
                       :right          0
-                      :height         "22px"
+                      :height         (str region-title-height "px")
                       :display        "flex"
                       :align-items    "center"
-                      :padding        "0 10px"
-                      :background     header-tint
-                      :border-bottom  (str "1px " border-style " " border-color)
-                      :border-top-left-radius  "11px"
-                      :border-top-right-radius "11px"
+                      :padding        (str "0 " region-title-pad-x "px")
+                      :background     (if active?
+                                        (:active-wash ct)
+                                        (:region-header-bg ct))
+                      :border-bottom  (str container-divider-width "px "
+                                           border-style " " border-color)
+                      :border-top-left-radius  (str compound-radius "px")
+                      :border-top-right-radius (str compound-radius "px")
                       :font-family    sans-stack
-                      :font-size      "11px"
+                      :font-size      (str container-title-px "px")
                       :font-weight    700
                       :letter-spacing "0.04em"
                       :text-transform "uppercase"
-                      :color          border-color}}
-        ;; A small orthogonal-region glyph (parallel bars) precedes the
-        ;; label so the zone reads as "parallel region" at a glance.
+                      :color          (if active?
+                                        (:text-primary ct)
+                                        (:text-secondary ct))}}
+        ;; Subtle orthogonal-region glyph — small, never dominating.
         [:span {:style {:margin-right "6px"
-                        :opacity 0.85
-                        :font-family tokens/mono-stack}}
+                        :opacity 0.6
+                        :font-family mono-stack}}
          "∥"]
         label]
        ;; rf2-shv82 — invisible xyflow attachment points so an edge

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/xyflow_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/xyflow_node.cljs
@@ -18,6 +18,7 @@
   it sits below them and depends only on `@xyflow/react` + the pure
   `visual-constants`."
   (:require ["@xyflow/react" :as xyflow]
+            [day8.re-frame2-machines-viz.theme.tokens :as tokens]
             [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 ;; ---- xyflow Handle adapter ----------------------------------------------
@@ -50,3 +51,16 @@
     (if (some? c)
       (js->clj c :keywordize-keys true)
       vc/chart-regular)))
+
+(defn palette-of
+  "rf2-az6e2 — recover the resolved chart-semantic token map off a
+  node's `:data` (`(.-palette d)`). The projector threads
+  `theme/tokens/chart-tokens` of the active `:theme` palette here; xyflow
+  `clj->js`-es it into a JS object so we `js->clj` it back with keyword
+  keys. Returns `(tokens/chart-tokens)` (the dark surface) when absent so
+  a theme-less / directly-constructed node still paints the dark grammar."
+  [^js d]
+  (let [p (.-palette d)]
+    (if (some? p)
+      (js->clj p :keywordize-keys true)
+      (tokens/chart-tokens))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -48,20 +48,33 @@
 (def state-node-min-width
   "Minimum width in px for a state node body. xyflow lays out nodes
   based on their measured size; this floor gives every node a
-  consistent rhythm without overflowing labels."
-  140)
+  consistent rhythm without overflowing labels.
+
+  rf2-az6e2 — lifted 140 → 152 to match the title/body box grammar (the
+  full-width title strip wants a touch more horizontal rhythm than the
+  prior centred-pill body)."
+  152)
 
 (def state-node-min-height
-  "Minimum height in px for a state node body."
-  44)
+  "Minimum height in px for a state node body.
+
+  rf2-az6e2 — lifted 44 → 58 to match the title-strip + body geometry
+  (title strip ~24px + a body band for tags / action rows)."
+  58)
 
 (def compound-node-min-width
-  "Minimum width for a compound container."
-  220)
+  "Minimum width for a compound container.
+
+  rf2-az6e2 — lifted 220 → 260 so the solid title-strip container has
+  room for the strip label + the body band above its children."
+  260)
 
 (def compound-node-min-height
-  "Minimum height for a compound container."
-  120)
+  "Minimum height for a compound container.
+
+  rf2-az6e2 — lifted 120 → 150 so the title strip + optional metadata
+  band do not crowd the nested children."
+  150)
 
 ;; ---- synthetic event-node helpers --------------------------------------
 ;;
@@ -98,14 +111,26 @@
   "elk.js layout width for an event-node — narrower than a state node
   so two adjacent events do not crowd the state row, but wide enough
   for the `event-segment` text + optional `[guard]` chip + `+ action`
-  pill (rf2-qo5xy)."
-  120)
+  pill (rf2-qo5xy).
+
+  rf2-az6e2 — pulled 120 → 96 so the route chip lays out as a
+  SUBORDINATE node, not a peer state box. The event chip's CSS min-width
+  (`:event-chip-min-w` 92 regular) sits just under this floor; the
+  measure-then-relayout pass still sizes the chip to its real content
+  via `(max measured floor)`, but the LAYOUT WEIGHT (the seed ELK uses
+  before measurement, and the floor a content-light chip lands on) is
+  lower so event chips don't push state rows apart like peers."
+  96)
 
 (def event-node-elk-height
   "elk.js layout height for an event-node — taller than a single text
   line so the action-pill row has space underneath the header
-  (rf2-qo5xy)."
-  46)
+  (rf2-qo5xy).
+
+  rf2-az6e2 — pulled 46 → 34 (the route chip is a compact card, not a
+  title/body box). Subordinate layout weight relative to a state node's
+  58px floor."
+  34)
 
 (defn leaf-elk-size
   "rf2-d9ro2 — the elk.js layout size for a LEAF state node, given the
@@ -230,8 +255,14 @@
                                                     ;; before handing to elk.
                                                     (dissoc k ::event-parent)
                                                     (build k)))))
+                           ;; rf2-az6e2 — the container top padding clears
+                           ;; the solid title strip (26px regular) PLUS a
+                           ;; metadata band for compound tags / entry-exit
+                           ;; rows, so children never collide with the
+                           ;; header. Side/bottom padding tracks the
+                           ;; `:container-body-pad` inset.
                            :layoutOptions {"elk.algorithm" "layered"
-                                           "elk.padding"   "[top=34,left=14,bottom=14,right=14]"}))))
+                                           "elk.padding"   "[top=44,left=16,bottom=16,right=16]"}))))
         top-state-children (mapv build (get by-parent nil))
         top-event-children (->> (get events-by-parent nil [])
                                 (mapv #(dissoc % ::event-parent)))]
@@ -475,15 +506,31 @@
                            `visual-constants/chart-regular` so callers
                            that omit it (the JVM projection tests, a
                            density-less host) get the regular density
-                           pixel-identical to pre-rf2-k647w."
+                           pixel-identical to pre-rf2-k647w.
+    :palette             — rf2-az6e2. The resolved chart-semantic token
+                           map for the active `:theme`
+                           (`theme/tokens/chart-tokens` of the
+                           theme-palette). Threaded into every node/edge
+                           `:data` as `:palette` so the xyflow node/edge
+                           components — invoked OUTSIDE the render's
+                           dynamic scope — read their structured-grammar
+                           colours off the payload, painting the ACTIVE
+                           theme (not the hardwired dark alias). Defaults
+                           to `(chart-tokens)` (dark) so a theme-less
+                           caller still resolves the dark surface."
   [{:keys [nodes edges]}
    positions
    {:keys [highlight-id highlight-ids from-highlight-id to-highlight-id sim?
            on-state-click on-edge-click edge-points edge-labels
-           fired-edge-ids chart]
+           fired-edge-ids chart palette]
     :or   {chart vc/chart-regular edge-points {} edge-labels {}
            fired-edge-ids #{}}}]
-  (let [;; rf2-g2svr (G1) — the active set unifies the single-active
+  (let [;; rf2-az6e2 — resolve the chart-semantic token map for the
+        ;; active theme ONCE. nil → dark chart-tokens (a theme-less
+        ;; caller keeps the dark surface). Threaded onto every node/edge
+        ;; `:data {:palette}` so the renderers paint the active theme.
+        ct (or palette (tokens/chart-tokens))
+        ;; rf2-g2svr (G1) — the active set unifies the single-active
         ;; (`:highlight-id`) and multi-active (`:highlight-ids`) cases.
         ;; A PARALLEL machine's snapshot has N simultaneously-active
         ;; leaves; `:highlight-ids` carries them all so EVERY active
@@ -569,6 +616,7 @@
                                           :entry          (:entry n)
                                           :exit           (:exit n)
                                           :chart          chart
+                                          :palette        ct
                                           :onClick        on-state-click}
                                    region? (assoc :regionId    (:region n)
                                                   :regionIndex (:region-index n)))
@@ -738,7 +786,8 @@
                                        :fromPath    (:from-path edge)
                                        :toPath      (:to-path edge)
                                        :onClick     on-edge-click
-                                       :chart       chart}
+                                       :chart       chart
+                                       :palette     ct}
                            :draggable false
                            :selectable false}
                     ;; rf2-xh1lm — the event-node nests inside the same
@@ -761,14 +810,19 @@
                  :source    (:source edge)
                  :target    ev-node-id
                  :type      "transition"
+                 ;; rf2-az6e2 — the source→event (`__in`) segment is the
+                 ;; QUIET half of the two-edge route: a SMALL arrowhead
+                 ;; (10px, down from 14) in the quiet edge colour, so the
+                 ;; primary arrowhead reads on the event→target (`__out`)
+                 ;; segment and the pair reads as ONE transition route.
                  :markerEnd {:type "arrowclosed"
                              :color (cond
-                                      fired?    (:accent tokens/tokens)
-                                      focused?  (:info tokens/tokens)
-                                      from-active? (:info tokens/tokens)
-                                      :else     (:border-default tokens/tokens))
-                             :width 14
-                             :height 14}
+                                      fired?    (:edge-fired ct)
+                                      focused?  (:edge-active ct)
+                                      from-active? (:edge-active ct)
+                                      :else     (:edge-quiet ct))
+                             :width 10
+                             :height 10}
                  :data      {:eventLabel ""
                              :eventLineLabel ""
                              :active     from-active?
@@ -801,7 +855,14 @@
                              :toPath     (:to-path edge)
                              :onClick    nil
                              :chart      chart
+                             :palette    ct
                              :inbound    true
+                             ;; rf2-az6e2 — the quiet source→event half of
+                             ;; the route. The renderer paints it thinner +
+                             ;; in the quiet colour so the pair reads as one
+                             ;; transition with the primary arrowhead on the
+                             ;; event→target segment.
+                             :quietSegment true
                              :eventNodeId ev-node-id
                              :spec-edge-id (:id edge)}})
               edge-descriptors)
@@ -819,12 +880,17 @@
                       :source    ev-node-id
                       :target    (:target edge)
                       :type      "transition"
+                      ;; rf2-az6e2 — the event→target (`__out`) segment is
+                      ;; the PRIMARY half of the route: it carries the full-
+                      ;; size arrowhead (18px) so the eye reads the
+                      ;; transition's landing. Colour resolves through the
+                      ;; active-theme chart-tokens.
                       :markerEnd {:type "arrowclosed"
                                   :color (cond
-                                           fired?    (:accent tokens/tokens)
-                                           focused?  (:info tokens/tokens)
-                                           from-active? (:info tokens/tokens)
-                                           :else     (:border-default tokens/tokens))
+                                           fired?    (:edge-fired ct)
+                                           focused?  (:edge-active ct)
+                                           from-active? (:edge-active ct)
+                                           :else     (:edge-quiet ct))
                                   :width 18
                                   :height 18}
                       :data      {:eventLabel ""
@@ -857,7 +923,12 @@
                                   :toPath     (:to-path edge)
                                   :onClick    nil
                                   :chart      chart
+                                  :palette    ct
                                   :outbound   true
+                                  ;; rf2-az6e2 — the primary event→target
+                                  ;; half (not quiet); carries the full
+                                  ;; arrowhead + the standard stroke.
+                                  :quietSegment false
                                   :eventNodeId ev-node-id
                                   :spec-edge-id (:id edge)}})))
         proj-edges (vec (concat inbound-edges outbound-edges))
@@ -877,7 +948,8 @@
                            :type      "initial-marker"
                            :position  {:x (- (:x pos) 48)
                                        :y (+ (:y pos) 14)}
-                           :data      {:targetPath (:path n) :chart chart}
+                           :data      {:targetPath (:path n) :chart chart
+                                       :palette ct}
                            :draggable false
                            :selectable false}
                     ;; rf2-xh1lm — see compound substate :parentId
@@ -894,9 +966,9 @@
                  :targetHandle "left"
                  :type        "transition"
                  :markerEnd   {:type "arrowclosed"
-                               :color (:border-default tokens/tokens)
-                               :width 14
-                               :height 14}
+                               :color (:edge-quiet ct)
+                               :width 12
+                               :height 12}
                  ;; Entry edges are non-interactive, but carry the full
                  ;; edge `:data` shape (flags + threaded callback/chart)
                  ;; so the "every edge has X" projection invariants hold.
@@ -927,7 +999,8 @@
                                :labelPos nil
                                :internal false :machineLevel false
                                :eventId nil :fromPath nil :toPath nil
-                               :onClick on-edge-click :chart chart}})
+                               :quietSegment false
+                               :onClick on-edge-click :chart chart :palette ct}})
               initial-nodes)]
     ;; rf2-qo5xy — order matters for xyflow: parent containers must
     ;; precede any node that references them via `:parentId`. State /

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -307,6 +307,16 @@
   compound-container title)."
   "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
 
+(def chart-label-stack
+  "rf2-az6e2 — the chart-label font token. The structured topology
+  visual grammar uses SANS for state / event / tag / action labels
+  (structure-first reading; the prior mono lean was a category-error
+  carryover from data-grid surfaces). Aliases `sans-stack`; a host that
+  wants a different chart-label face overrides this Var. Mono survives
+  ONLY for the raw-EDN context-panel values, where it aids data
+  scanning."
+  sans-stack)
+
 ;; ---- tint helper (rf2-pyvmr) -------------------------------------------
 
 (defn- parse-hex-byte
@@ -352,6 +362,102 @@
        :else (if-let [[r g b] (hex->rgb hex)]
                (str "rgba(" r ", " g ", " b ", " alpha ")")
                hex)))))
+
+;; ---- chart semantic tokens (rf2-az6e2) ---------------------------------
+;;
+;; rf2-az6e2 — the structured topology grammar needs a small set of
+;; SEMANTIC chart roles (neutral container header/body, dividers,
+;; event-chip fill/border, pseudo-state marker, edge quiet/active). The
+;; Xray↔machines-viz dark-palette drift gate (rf2-z7ms8) asserts the two
+;; dark-palette KEY SETS are byte-identical, so we MUST NOT add new keys
+;; to `dark-palette` / `light-palette`. Instead `chart-tokens` DERIVES
+;; the semantic roles from the EXISTING palette entries, parameterised by
+;; the active palette — so theme support is real (a `:light` host resolves
+;; every chart role against `light-palette`) without growing the palette
+;; or breaking the mirror gate.
+
+(defn chart-tokens
+  "rf2-az6e2 — resolve the chart's SEMANTIC role tokens against a base
+  `palette` (`dark-palette` / `light-palette`, or any palette of the
+  same shape). Returns a flat map of hex / rgba strings the node + edge
+  renderers read for the structured visual grammar.
+
+  Roles (structure-first — neutral by default, accent reserved for
+  runtime state):
+
+    :state-header-bg / :state-body-bg / :state-border
+       — leaf-state title strip, body, and resting border.
+    :divider
+       — the hairline between a state's title strip and its body.
+    :container-header-bg / :container-body-bg / :container-border
+       — compound-container chrome (solid neutral, no accent wash).
+    :region-border / :region-header-bg
+       — parallel-region chrome (dashed neutral).
+    :event-chip-bg / :event-chip-border
+       — route-chip fill/border (subordinate to states).
+    :pseudo-marker
+       — initial / history pseudo-state glyph colour (neutral, NOT the
+         accent-blue runtime marker).
+    :edge-quiet / :edge-active / :edge-fired
+       — source→event quiet segment, event→target / active, fired-epoch.
+    :text-primary / :text-secondary / :text-tertiary
+       — re-exported off the palette so a renderer reads one map.
+    :active / :focus / :sim / :final
+       — runtime-state accents (active = :info, focus = :accent, etc.).
+
+  Pure data → map of strings; JVM-portable. Defaults to `dark-palette`
+  so a renderer that never threads a palette still resolves the dark
+  surface."
+  ([] (chart-tokens dark-palette))
+  ([palette]
+   (let [g #(get palette %)]
+     {;; leaf state
+      :state-header-bg (with-alpha :bg-3 0.55 palette)
+      :state-body-bg   (g :bg-2)
+      :state-border    (g :border-default)
+      :divider         (with-alpha :border-default 0.7 palette)
+      ;; compound container — solid neutral, no accent wash
+      :container-header-bg (with-alpha :bg-3 0.65 palette)
+      :container-body-bg   (with-alpha :bg-1 0.4 palette)
+      :container-border    (g :border-default)
+      ;; parallel region — dashed neutral
+      :region-border    (g :border-default)
+      :region-header-bg (with-alpha :bg-3 0.45 palette)
+      ;; event route chip — subordinate
+      :event-chip-bg     (with-alpha :bg-1 0.85 palette)
+      :event-chip-border (with-alpha :border-default 0.7 palette)
+      ;; pseudo-states — neutral, NOT accent
+      :pseudo-marker (g :text-tertiary)
+      ;; edges
+      :edge-quiet  (with-alpha :border-default 0.55 palette)
+      :edge-active (g :info)
+      :edge-fired  (g :accent)
+      ;; text
+      :text-primary   (g :text-primary)
+      :text-secondary (g :text-secondary)
+      :text-tertiary  (g :text-tertiary)
+      ;; runtime-state accents
+      :active (g :info)
+      :focus  (g :accent)
+      :sim    (g :yellow)
+      :final  (g :text-secondary)
+      ;; tints used for runtime washes (kept subtle — border/header/glow
+      ;; carry the runtime signal, not the whole fill, per the bead)
+      :active-wash (with-alpha :info   0.14 palette)
+      :focus-wash  (with-alpha :accent 0.12 palette)
+      :sim-wash    (with-alpha :yellow 0.14 palette)
+      :glow        (with-alpha :info   0.18 palette)
+      :glow-fired  (with-alpha :accent 0.18 palette)})))
+
+(defn theme-palette
+  "rf2-az6e2 — resolve a `:theme` keyword (`:dark` / `:light`) to its
+  base palette via `palettes`. nil / unknown → `dark-palette` (the Xray
+  default surface). The `MachineChart` `:theme` prop flows through here
+  ONCE per render; the resolved palette threads through the projector
+  onto every node/edge `:data` so the renderers paint the active theme
+  (theme support made real, rf2-az6e2). Independent of `:density`."
+  [theme]
+  (get palettes theme dark-palette))
 
 ;; ---- CSS-variable theming (rf2-uv1on) ----------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -153,6 +153,44 @@
    :action-pill-gap        4
    :action-pill-row-gap    4
 
+   ;; ── structured topology grammar (rf2-az6e2) ──────────────────
+   ;; State title/body box geometry.
+   :state-title-height     24    ;; full-width title strip height
+   :state-title-pad-x      10
+   :state-title-px         13    ;; title font-size (sans, structure-first)
+   :state-body-pad-x       10
+   :state-body-pad-y       8
+   :state-body-gap         4     ;; vertical gap between body rows
+   :state-divider-width    1     ;; title/body hairline divider
+   :state-shadow-blur      6     ;; resting drop-shadow blur radius
+   ;; Compound container chrome.
+   :container-title-height 26
+   :container-title-pad-x  12
+   :container-body-pad     14    ;; inset around children below the strip
+   :container-divider-width 1
+   ;; Parallel-region chrome.
+   :region-title-height    24
+   :region-title-pad-x     10
+   ;; Action-section caption ("Entry actions" / "Exit actions").
+   :action-caption-px      8
+   :action-caption-gap     2
+   ;; Event route chip.
+   :event-chip-min-w       92
+   :event-chip-min-h       32
+   :event-chip-pad-x       10
+   :event-chip-pad-y       4
+   :event-chip-radius      5
+   :event-chip-px          11    ;; event label / guard font-size
+   :event-chip-action-px   9     ;; action-row font-size
+   ;; Pseudo-state markers (initial dot, history H/H* hook).
+   :pseudo-size            12
+   :pseudo-radius          6
+   :pseudo-px              8
+   ;; Root chrome (title strip + context panel).
+   :root-title-height      30
+   :root-title-px          14
+   :root-context-pad       8
+
    ;; ── dot-grid background (rf2-m4nj4) ──────────────────────────
    :dot-grid-spacing-px    16
    :dot-grid-radius-px     1.0
@@ -208,6 +246,37 @@
    :action-pill-gap        3
    :action-pill-row-gap    3
 
+   ;; ── structured topology grammar (rf2-az6e2 — ~25% tighter) ───
+   :state-title-height     20
+   :state-title-pad-x      8
+   :state-title-px         11
+   :state-body-pad-x       8
+   :state-body-pad-y       6
+   :state-body-gap         3
+   :state-divider-width    1
+   :state-shadow-blur      4
+   :container-title-height 22
+   :container-title-pad-x  10
+   :container-body-pad     11
+   :container-divider-width 1
+   :region-title-height    20
+   :region-title-pad-x     8
+   :action-caption-px      7
+   :action-caption-gap     2
+   :event-chip-min-w       76
+   :event-chip-min-h       26
+   :event-chip-pad-x       8
+   :event-chip-pad-y       3
+   :event-chip-radius      4
+   :event-chip-px          9
+   :event-chip-action-px   7
+   :pseudo-size            10
+   :pseudo-radius          5
+   :pseudo-px              7
+   :root-title-height      26
+   :root-title-px          12
+   :root-context-pad       6
+
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    12
    :dot-grid-radius-px     0.85
@@ -260,6 +329,37 @@
    :action-pill-radius     8
    :action-pill-gap        5
    :action-pill-row-gap    5
+
+   ;; ── structured topology grammar (rf2-az6e2 — ~25% looser) ────
+   :state-title-height     28
+   :state-title-pad-x      12
+   :state-title-px         15
+   :state-body-pad-x       12
+   :state-body-pad-y       10
+   :state-body-gap         5
+   :state-divider-width    1
+   :state-shadow-blur      8
+   :container-title-height 30
+   :container-title-pad-x  14
+   :container-body-pad     18
+   :container-divider-width 1
+   :region-title-height    28
+   :region-title-pad-x     12
+   :action-caption-px      9
+   :action-caption-gap     3
+   :event-chip-min-w       108
+   :event-chip-min-h       38
+   :event-chip-pad-x       12
+   :event-chip-pad-y       5
+   :event-chip-radius      6
+   :event-chip-px          13
+   :event-chip-action-px   11
+   :pseudo-size            14
+   :pseudo-radius          7
+   :pseudo-px              9
+   :root-title-height      34
+   :root-title-px          16
+   :root-context-pad       10
 
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    20

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -201,16 +201,22 @@
 ;; ---- final-state affordance ---------------------------------------------
 
 (deftest chart-marks-final-states
-  (testing "rf2-y9j79 — final states render with their state-tags
-            scaffolding + final glyph (checkmark)"
+  (testing "rf2-az6e2 — final states render the QUIET DOUBLE BORDER
+            (an outer ring node, testid `rf-mv-chart-final-ring-*`); the
+            prior ✓ check glyph is DROPPED (the doubled border is the
+            unambiguous final-state signal). idle-loading-done has two
+            final states (:done, :failed)."
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises this")
       (with-mounted-chart
         {:machine-id :test/flow :definition idle-loading-done}
         (fn [_root node]
-          ;; The check glyph ✓ is painted inside each :final? node.
-          (let [text (.-textContent node)]
-            (is (re-find #"✓" text) "a final-state checkmark glyph renders")))))))
+          ;; The doubled border renders as an inner ring div per final node.
+          (is (pos? (count-sel node "[data-testid^=\"rf-mv-chart-final-ring-\"]"))
+              "a final-state double-border ring renders")
+          ;; The dropped ✓ glyph must NOT appear.
+          (is (not (re-find #"✓" (.-textContent node)))
+              "the ✓ check glyph is dropped (rf2-az6e2)"))))))
 
 ;; ---- Controls / MiniMap / Background presence ---------------------------
 
@@ -291,6 +297,49 @@
           {:machine-id :test/flow :definition idle-loading-done :density :cosy}
           (fn [root _node]
             (is (= "cosy" (.getAttribute root "data-density")))))))))
+
+;; ---- :theme prop + root chrome (rf2-az6e2) ------------------------------
+
+(deftest chart-data-theme-defaults-to-dark
+  (testing "rf2-az6e2 — omitting :theme surfaces data-theme=\"dark\" on
+            the chart root (Xray default surface)."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [root _node]
+          (is (= "dark" (.getAttribute root "data-theme"))
+              "data-theme defaults to dark"))))))
+
+(deftest chart-data-theme-reflects-prop-and-is-density-independent
+  (testing "rf2-az6e2 — :theme :light surfaces data-theme=\"light\";
+            :theme is INDEPENDENT of :density (both knobs surface their
+            own attr)."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done
+         :theme :light :density :compact}
+        (fn [root _node]
+          (is (= "light" (.getAttribute root "data-theme")))
+          (is (= "compact" (.getAttribute root "data-density"))
+              "density unaffected by theme — orthogonal knobs"))))))
+
+(deftest chart-renders-root-title-strip
+  (testing "rf2-az6e2 — the chart frame renders a ROOT MACHINE TITLE
+            STRIP carrying the machine name; a non-parallel machine
+            reports data-parallel=\"false\"."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [_root node]
+          (let [strip (.querySelector node "[data-testid$=\"-root-title\"]")]
+            (is (some? strip) "root title strip is present")
+            (is (re-find #"flow" (.-textContent strip))
+                "root title strip carries the machine name")
+            (is (= "false" (.getAttribute strip "data-parallel"))
+                "non-parallel machine flagged data-parallel=false")))))))
 
 ;; ---- state-node :tags surface (rf2-so5b0) -------------------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -18,6 +18,7 @@
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.chart.projection :as projection]
+            [day8.re-frame2-machines-viz.theme.tokens :as tokens]
             [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 ;; ---- fixtures ----------------------------------------------------------
@@ -604,6 +605,68 @@
       (is (not= (:color (:markerEnd active))
                 (:color (:markerEnd inactive)))
           "active vs idle arrowheads are distinct colours"))))
+
+;; ---- rf2-az6e2 — structured visual grammar data -----------------------
+
+(deftest xyflow-graph-threads-palette-onto-every-node-and-edge
+  (testing "rf2-az6e2 — the resolved chart-semantic token map (`:palette`
+            option) is threaded onto EVERY node + edge `:data {:palette}`
+            so the renderers paint the active theme. Default (no
+            `:palette`) resolves the dark chart-tokens."
+    (let [parsed (layout/parse-definition idle-loading)
+          ct     (tokens/chart-tokens tokens/light-palette)
+          graph  (projection/xyflow-graph parsed {} {:palette ct})]
+      (is (seq (:nodes graph)))
+      (is (every? #(= ct (:palette (:data %))) (:nodes graph))
+          "every node :data carries the threaded palette")
+      (is (every? #(= ct (:palette (:data %))) (:edges graph))
+          "every edge :data carries the threaded palette"))))
+
+(deftest xyflow-graph-palette-defaults-to-dark-chart-tokens
+  (testing "rf2-az6e2 — a caller that omits `:palette` gets the dark
+            chart-tokens map on every node/edge (theme-less default)."
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          dark   (tokens/chart-tokens tokens/dark-palette)]
+      (is (every? #(= dark (:palette (:data %))) (:nodes graph)))
+      (is (every? #(= dark (:palette (:data %))) (:edges graph))))))
+
+(deftest xyflow-graph-event-route-arrowhead-split
+  (testing "rf2-az6e2 — the two-edge event route reads as ONE transition:
+            the source→event (`__in`) segment carries a SMALL arrowhead
+            (10px) + the quiet-segment flag, while the event→target
+            (`__out`) segment carries the PRIMARY full-size arrowhead
+            (18px). `idle --start--> loading` is a plain external
+            transition so both halves exist."
+    (let [parsed  (layout/parse-definition idle-loading)
+          graph   (projection/xyflow-graph parsed {} {})
+          ;; the plain :on transition edge id
+          on-edge (first (filter #(= :start (:event %)) (:edges parsed)))
+          in-e    (inbound-edge-for graph (:id on-edge))
+          out-e   (outbound-edge-for graph (:id on-edge))]
+      (is (some? in-e) "inbound (__in) segment exists")
+      (is (some? out-e) "outbound (__out) segment exists")
+      (is (= 10 (:width (:markerEnd in-e)))
+          "quiet source→event arrowhead is small (10px)")
+      (is (= 18 (:width (:markerEnd out-e)))
+          "primary event→target arrowhead is full size (18px)")
+      (is (true? (:quietSegment (:data in-e)))
+          "the inbound half is flagged the quiet segment")
+      (is (false? (:quietSegment (:data out-e)))
+          "the outbound half is the primary segment"))))
+
+(deftest xyflow-graph-internal-transition-no-outbound-segment
+  (testing "rf2-az6e2 — an internal / action-only transition (no
+            `:target`) emits the inbound terminal segment but NO outgoing
+            target segment, so the event chip reads as a terminal route."
+    (let [parsed   (layout/parse-definition internal-self-machine)
+          graph    (projection/xyflow-graph parsed {} {})
+          internal (first (filter :internal? (:edges parsed)))]
+      (when internal
+        (is (some? (inbound-edge-for graph (:id internal)))
+            "internal transition keeps the source→event segment")
+        (is (nil? (outbound-edge-for graph (:id internal)))
+            "internal transition has NO event→target segment")))))
 
 ;; ---- xyflow-graph misc payload + style ---------------------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
@@ -115,6 +115,65 @@
     (is (nil? (:pulse-duration-ms tokens/motion))
         "pulse-duration-ms removed (rf2-2sez0)")))
 
+;; ---- chart semantic tokens + theme resolution (rf2-az6e2) --------------
+
+(deftest theme-palette-resolves-dark-and-light
+  (testing "rf2-az6e2 — `theme-palette` maps the `:theme` prop keyword
+            to its base palette; nil / unknown falls back to the dark
+            palette (the Xray default surface)."
+    (is (= tokens/dark-palette  (tokens/theme-palette :dark)))
+    (is (= tokens/light-palette (tokens/theme-palette :light)))
+    (is (= tokens/dark-palette  (tokens/theme-palette nil)))
+    (is (= tokens/dark-palette  (tokens/theme-palette :sepia)))))
+
+(deftest chart-tokens-is-a-map-of-strings
+  (testing "rf2-az6e2 — `chart-tokens` resolves every semantic chart
+            role to a non-nil hex / rgba string. A nil here would
+            propagate a literal 'null' into a node/edge inline style."
+    (doseq [palette [tokens/dark-palette tokens/light-palette]]
+      (let [ct (tokens/chart-tokens palette)]
+        (is (map? ct))
+        (is (every? string? (vals ct))
+            "every chart-token role resolves to a string")))))
+
+(deftest chart-tokens-default-is-dark
+  (testing "rf2-az6e2 — the no-arg arity resolves the dark surface so a
+            renderer that never threads a palette still paints dark."
+    (is (= (tokens/chart-tokens) (tokens/chart-tokens tokens/dark-palette)))))
+
+(deftest chart-tokens-theme-differs-between-palettes
+  (testing "rf2-az6e2 — theme support is REAL: the resolved chart-token
+            map differs between dark and light (a renderer reading the
+            active palette paints the active theme, not a hardwired dark
+            alias). The :state-body-bg role tracks the palette's bg-2,
+            which inverts between themes."
+    (let [dark  (tokens/chart-tokens tokens/dark-palette)
+          light (tokens/chart-tokens tokens/light-palette)]
+      (is (not= (:state-body-bg dark) (:state-body-bg light)))
+      (is (= (:bg-2 tokens/dark-palette)  (:state-body-bg dark)))
+      (is (= (:bg-2 tokens/light-palette) (:state-body-bg light))))))
+
+(deftest chart-tokens-runtime-accents-reserved
+  (testing "rf2-az6e2 — structure wins over annotation colour: the
+            STATIC structural roles (container/region border, state
+            border, event-chip) are neutral (palette border/bg tokens),
+            while the accent (`:focus`) + active (`:active`) roles are
+            reserved for RUNTIME state. The container border MUST NOT be
+            the accent hue (no saturated accent wash on a resting
+            compound)."
+    (let [ct (tokens/chart-tokens tokens/dark-palette)]
+      (is (= (:border-default tokens/dark-palette) (:container-border ct)))
+      (is (= (:border-default tokens/dark-palette) (:region-border ct)))
+      (is (= (:info tokens/dark-palette)   (:active ct)))
+      (is (= (:accent tokens/dark-palette) (:focus ct)))
+      (is (not= (:accent tokens/dark-palette) (:container-border ct))))))
+
+(deftest chart-label-stack-is-sans
+  (testing "rf2-az6e2 — the chart-label font token is sans (structure-
+            first reading); recorded decision: mono retained only for
+            the raw-EDN context panel."
+    (is (= tokens/sans-stack tokens/chart-label-stack))))
+
 ;; ---- tag-pill colour rotation (rf2-m1b88; rf2-a2b55 restored) ----------
 
 (deftest tag-pill-color-is-deterministic

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -84,6 +84,38 @@
     :action-pill-radius
     :action-pill-gap
     :action-pill-row-gap
+    ;; structured topology grammar (rf2-az6e2) — state title/body box,
+    ;; compound container, parallel region, event route chip, pseudo-
+    ;; state markers, action-section caption, root chrome.
+    :state-title-height
+    :state-title-pad-x
+    :state-title-px
+    :state-body-pad-x
+    :state-body-pad-y
+    :state-body-gap
+    :state-divider-width
+    :state-shadow-blur
+    :container-title-height
+    :container-title-pad-x
+    :container-body-pad
+    :container-divider-width
+    :region-title-height
+    :region-title-pad-x
+    :action-caption-px
+    :action-caption-gap
+    :event-chip-min-w
+    :event-chip-min-h
+    :event-chip-pad-x
+    :event-chip-pad-y
+    :event-chip-radius
+    :event-chip-px
+    :event-chip-action-px
+    :pseudo-size
+    :pseudo-radius
+    :pseudo-px
+    :root-title-height
+    :root-title-px
+    :root-context-pad
     ;; dot-grid background (rf2-m4nj4)
     :dot-grid-spacing-px
     :dot-grid-radius-px
@@ -245,6 +277,41 @@
     (is (< (:compound-radius vc/chart-compact)
            (:compound-radius vc/chart-regular)
            (:compound-radius vc/chart-cosy)))))
+
+(deftest structured-grammar-geometry-monotonic
+  (testing "rf2-az6e2 — the structured-topology grammar geometry
+            (state title strip, container title, event chip, region
+            title, root title) is monotonic across the density axis:
+            compact < regular < cosy. Density scales QUANTITY; a key
+            that walked back or up unexpectedly would ship a mislabelled
+            density. The corner-radius lock (6) remains the only
+            non-scaling geometry."
+    (doseq [k [:state-title-height :state-title-px
+               :container-title-height :event-chip-min-w
+               :event-chip-min-h :event-chip-px
+               :region-title-height :pseudo-size :root-title-height
+               :root-title-px]]
+      (is (< (get vc/chart-compact k)
+             (get vc/chart-regular k)
+             (get vc/chart-cosy k))
+          (str "structured-grammar key " k
+               " is monotonic compact < regular < cosy")))))
+
+(deftest structured-grammar-regular-targets
+  (testing "rf2-az6e2 — pin the regular-density targets the bead's
+            §Visual constants names as approximate floors (state title
+            ~24px, container title ~26px, region title ~24px, event chip
+            ~92x32, event text ~11px, action text ~9px). Pinning so a
+            future tweak that drops below the bead's stated grammar
+            geometry fails CI rather than silently regressing the
+            structure-first read."
+    (is (= 24 (:state-title-height vc/chart-regular)))
+    (is (= 26 (:container-title-height vc/chart-regular)))
+    (is (= 24 (:region-title-height vc/chart-regular)))
+    (is (= 92 (:event-chip-min-w vc/chart-regular)))
+    (is (= 32 (:event-chip-min-h vc/chart-regular)))
+    (is (= 11 (:event-chip-px vc/chart-regular)))
+    (is (= 9  (:event-chip-action-px vc/chart-regular)))))
 
 (deftest densities-catalogue-is-closed
   (testing "rf2-32gw5 — the `densities` Var enumerates the closed

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -363,6 +363,14 @@
                               Canvas/List pill in the chart top-left.
     :show-controls?     — when true (default) render xyflow's built-in
                           zoom/pan/fit Controls inside the chart.
+    :theme              — rf2-az6e2. `:dark` (default) / `:light`.
+                          Forwarded to `mv-chart/MachineChart`'s `:theme`
+                          prop, which resolves the chart palette + reads
+                          the ACTIVE-theme tokens (the renderer no longer
+                          hardwires the dark alias). Xray's surface is
+                          dark, so callers leave this at `:dark`; the prop
+                          exists so a future host theme switch flips one
+                          value. No toggle UI is built in this bead.
     :testid             — wrapper testid override.
 
   Returns hiccup. xyflow owns zoom/pan/fit + keyboard shortcuts
@@ -372,10 +380,15 @@
            fired-edge-ids
            sim? on-state-click on-edge-click
            show-after-rings? show-view-mode-toggle?
-           show-controls? testid inner-testid]
+           show-controls? theme testid inner-testid]
     :or   {show-after-rings?       true
            show-view-mode-toggle?  true
            show-controls?          true
+           ;; rf2-az6e2 — Xray's surface is dark; pass `:theme :dark`
+           ;; through to the chart. No light/dark toggle UI in this bead
+           ;; (the chart reads the active-theme tokens for real now, so a
+           ;; future host toggle just flips this prop).
+           theme                   :dark
            testid                  "rf-xray-machine-canvas-host"
            inner-testid            "rf-mv-chart"}}]
   [:div
@@ -404,6 +417,7 @@
       :current-state   current-state
       :fired-edge-ids  fired-edge-ids
       :sim?            sim?
+      :theme           theme
       :on-state-click  on-state-click
       :on-edge-click   on-edge-click
       :show-minimap?   false


### PR DESCRIPTION
Closes rf2-az6e2 (P2 feature). SOTA topology-renderer redesign: the visual grammar now reads STRUCTURALLY — structure wins over annotation colour.

## What changed (component by component)

- **Theme pipeline (made real).** New `:theme` prop (`:dark` default / `:light`). The chart resolves the palette + a semantic `chart-tokens` map ONCE per render and threads it through the projector onto every node/edge `:data {:palette}`; the renderers paint the **active theme** instead of the dark-tokens alias. `data-theme` on the root. `chart-tokens` *derives* its semantic roles from the existing palette keys, so the Xray↔machines-viz dark-palette **key-set drift gate stays green** (no new palette keys). `:density` kept fully independent of `:theme`.
- **Visual constants.** Structured-grammar key set added across `compact`/`regular`/`cosy` (state title/body box, container title/body, region title, event chip, pseudo-state, action caption, root chrome). Density key-parity + monotonicity + regular-target tests updated.
- **State nodes** → title/body **boxes** (full-width left-aligned title strip, hairline divider, body band: one **neutral** tag-chip style + quiet "Entry/Exit actions" rows with a subdued bolt chip). Runtime state rides the **border + header + glow**, not the whole fill. Final state = **quiet double border** (the ✓ glyph is **dropped** — recorded decision).
- **Compound containers** → **solid subtle-neutral** title-strip containers (no dashed, no accent wash by default).
- **Parallel regions** → **dashed neutral** title-strip containers; region identity from **containment/layout**, not a rotating border colour (`region-boundary-palette` removed); subtle `∥` glyph; active = solid accent + glow.
- **Event nodes** → subordinate **route chips** (no title bar); event + guard on the first line as **`IF <guard>`**; action row only when present; machine-level **muted** (attr kept); internal/action-only = terminal chip with no outgoing segment. Synthetic event-node architecture preserved.
- **Edges** → quiet source→event segment (thinner, 10px arrowhead) vs primary event→target segment (18px arrowhead); both light together when fired/focused; colours resolve through the active theme.
- **Pseudo-states** → initial marker is a **neutral** dot (not accent). History `H`/`H*` renderer registered as a **hook** (projector emits none until parse exposes history data — this bead adds no statechart history semantics).
- **Root chrome** → a **root machine title strip** pinned in the chart frame (`∥` glyph for root-parallel); optional static Context section from the `:machine-data` overlay tucked under it.
- **Projection** → floors lifted (state 152×58, compound 260×150); event-node ELK weight pulled to 96×34 (subordinate); container ELK top padding raised to clear the title strip + metadata band.
- **Xray call sites** → `machine_canvas/Chart` forwards `:theme :dark`; `topology_view` inherits the dark default through `Chart`. No light/dark toggle UI (per the bead's non-goal).
- **Specs** → `API.md` gains a `:theme` row + §Theme + §Visual grammar; `001-Topology-Parity.md` visual-distinction table rewritten for the new grammar + a §1.4 history-hook + final-glyph-drop note.

## Keep/drop decisions (recorded in the bead)
- Topology label font = **sans** (`chart-label-stack`); mono kept only for the raw-EDN Context-panel values.
- Final marker = quiet double border **kept**, ✓ glyph **dropped**.
- Loud "machine-level" event label **dropped** (`data-machine-level` attr kept for host introspection).

## Deferred (follow-on beads filed)
- **rf2-qvsuu** (P3): wire history pseudo-state *rendering* once the parse exposes `:history` data (renderer + constants hook already landed).
- **rf2-wto1k** (P3): derive a *static* Context-shape panel from the machine definition (current defs expose runtime `:data` only, no static schema).

## Gates (cold)
- `npx shadow-cljs compile node-test` — 1149 compiled, **0 warnings**.
- `npm run test:cljs` — 5487 tests, **0 failures**.
- machines-viz `clojure -M:test` — 327 tests, **0 failures**.
- Xray `clojure -M:test` — 1103 tests, **0 failures** (incl. the dark-palette drift gate).
- `npm run test:xray-feature-gate` — 16 scenarios, **0 failures** (canvas + topology panels render).
- `npm run test:browser` — 144 tests, **0 failures**.

## Visual sign-off PENDING MIKE
This is a visual redesign: the structural + contract gates are green, but the *visual read* is Mike's call. Drive the machines-viz deck (flat workflow, root context/top-level transition, parallel regions, deep compound, internal/action-only) and sign off.