### PR TITLE
refactor(xray/runner): rewrite the shared runner as a re-frame2 :step driver — all six decks, no atom, no timing (rf2-5sjbg)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1537,11 +1537,13 @@ action-attribution half.
   `:rf.xray/*` registry ids for the Machines tab.
 - [`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) — Sim
   mode + Mode A/B/C dynamic instance test rows.
-- **Render regression harness (rf2-g27vv; runner-shaped rf2-kipb5).** The
-  `machine_epochs` testbed (:8033) is the assertion-backed harness that pins
-  this spec's cascade-render contract against reality — driven through the
-  shared queued-step runner (`runner.core`), its step matrix walks the full
-  feature × render-surface matrix (plain / entry-exit / guards / internal / fx /
+- **Render regression harness (rf2-g27vv; runner-shaped rf2-kipb5;
+  step-driver rewrite rf2-5sjbg).** The `machine_epochs` testbed (:8033) is
+  the assertion-backed harness that pins this spec's cascade-render contract
+  against reality — driven through the shared step-driver runner
+  (`runner.core` — cursor in app-db `:step`, a `[:run-step n]` event, no
+  Reagent atom), its step matrix walks the full feature × render-surface
+  matrix (plain / entry-exit / guards / internal / fx /
   unhandled-no-op / root-`:on` resolution; parallel regions + history +
   member-level tag-set delta; `:always` microsteps; `:after` timer + cancel;
   spawn / `:final?` / `:on-done` / destroy lifecycle; `:*` wildcard throw;

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1803,9 +1803,11 @@ consumer of the rf2-n9f4z instrumentation contract per
 
 The `machine_epochs` testbed (:8033) is now the **assertion-backed render
 regression harness** for this whole cascade-render contract (rf2-g27vv;
-runner-shaped rf2-kipb5). Driven through the shared queued-step runner
-(`runner.core`), its step matrix drives the full FEATURE × RENDER-SURFACE
-matrix — plain /
+runner-shaped rf2-kipb5; step-driver rewrite rf2-5sjbg). Driven through the
+shared step-driver runner (`runner.core` — cursor in app-db `:step`, moved
+by a `[:run-step n]` event that dispatches the step's machine event into the
+host-frame, NO Reagent atom), its step matrix drives the full FEATURE ×
+RENDER-SURFACE matrix — plain /
 entry-exit / transition-action / guard pass+fail / internal / fx /
 unhandled-no-op / root-`:on` resolution (door); parallel regions + history +
 member-level tag-set delta (traffic); `:always` **microsteps** that settle

--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -52,19 +52,18 @@
     SHOWCASE            — large collection (elision) · deep nesting (collapse
                           summary) · mixed scalar + tagged-literal vector
 
-  ## Per-step delta (standard_epochs pattern)
+  ## Per-step delta (rf2-5sjbg — app-db `:step`)
 
-  Every action event bumps a shared `:baseline` counter (the `bump` helper),
-  so the App-db / Epoch panels always show a delta on every step; the
-  per-step matrix case is the ADDITIONAL change layered on top.
+  The runner sets app-db `:step = n` on the run-step epoch; that churn is
+  the per-step App-db / Epoch delta the panels show (it REPLACES the old
+  `:baseline` counter). The per-step matrix case is the ADDITIONAL change
+  the run-step epoch's child event lands.
 
-  ## Runner state = LOCAL ATOM (rf2-8pbjr contract)
+  ## Runner cursor = app-db `:step` (rf2-5sjbg)
 
-  The runner cursor / status / pace live in `runner-state` — a LOCAL
-  Reagent atom in THIS ns. It is NEVER written to the inspected app-db
-  (that would pollute the App-db panel under inspection) and is NOT a
-  second frame (only the inspected app frame, `:rf/default`, is
-  Xray-relevant).
+  The runner cursor lives in app-db's `:step` slot, written by
+  `runner.core`'s run-step event — NOT a Reagent atom. The deck reads as an
+  ordinary re-frame2 app: app-db + events + subs.
 
   ## Inline Xray sidecar (no preload edit)
 
@@ -93,8 +92,7 @@
   inspector inside the real Epoch + App-db panels. The events / subs / views
   are OWNED here. It is NOT referenced by `feature_matrix/scenarios.cjs`, so
   the step `data-testid`s (`edn-inspector-step-<n>`) are deck-internal."
-  (:require [reagent.core :as r]
-            [reagent.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -111,9 +109,10 @@
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared queued-step runner (rf2-8pbjr pilot). This deck
-            ;; supplies a `steps` vector + a testid prefix; the runner
-            ;; drives the ONE-button series.
+            ;; The shared step-driver runner (rf2-5sjbg). This deck supplies
+            ;; a `steps` vector + registers `:edn-inspector/run-step` via
+            ;; `runner/reg-runner!`; the runner drives the ONE-button series
+            ;; + the per-step RUN buttons off app-db `:step`.
             [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -127,11 +126,12 @@
 ;; APP-DB SEED
 ;; ============================================================================
 ;;
-;; One flat, named seed. `:baseline` is the shared counter every step
-;; bumps (so App-db / Epoch always show a delta on every step). The other
-;; slots are the real, meaningful paths the per-step events write the
-;; matrix-case shapes into — the App-db panel renders them (and their diffs)
-;; THROUGH the edn-inspector.
+;; One flat, named seed. `:step` is the runner cursor (rf2-5sjbg) — the
+;; index of the last-run step, written by `runner.core`'s run-step event;
+;; its churn every step IS the per-step App-db / Epoch delta (it REPLACES
+;; the old `:baseline` counter). The other slots are the real, meaningful
+;; paths the per-step events write the matrix-case shapes into — the App-db
+;; panel renders them (and their diffs) THROUGH the edn-inspector.
 ;;
 ;; The seed is chosen so EVERY matrix case has something clean to act on:
 ;; a map with keys to add/remove/change, sequentials with entries, a set,
@@ -139,7 +139,7 @@
 ;; sentinel cases.
 
 (def initial-db
-  {:baseline   0
+  {:step       nil
    ;; MAPS — keys to add / remove / change.
    :profile    {:name "Ada" :role :engineer}
    ;; SEQUENTIALS — a vector, a list, a set with entries.
@@ -175,43 +175,34 @@
     initial-db))
 
 ;; ============================================================================
-;; A small shared helper: every action event bumps the baseline counter.
-;; ============================================================================
-;;
-;; Kept as a plain db->db fn (not an interceptor) so the baseline bump is
-;; visible inline in each handler body — the App-db / Epoch delta on every
-;; step comes from here, and the per-step matrix case is the ADDITIONAL
-;; change layered on top (the standard_epochs pattern).
-
-(defn- bump [db] (update db :baseline inc))
-
-;; ============================================================================
 ;; EVENTS — the step ladder, grouped by the audit matrix
 ;; ============================================================================
+;;
+;; The per-step App-db / Epoch delta is the runner's `:step` write on the
+;; parent run-step epoch (rf2-5sjbg); each event below writes ONLY its
+;; matrix-case shape, the ADDITIONAL change the App-db diff renders.
 
 ;; -- MAPS --------------------------------------------------------------------
 
 (rf/reg-event-db :edn-inspector/map-key-added
   {:doc "Map: a KEY ADDED. assoc a new `:team` key under :profile — the
          App-db diff paints `+:team` (green, key-anchored)."}
-  (fn [db _] (-> db bump (assoc-in [:profile :team] :platform))))
+  (fn [db _] (assoc-in db [:profile :team] :platform)))
 
 (rf/reg-event-db :edn-inspector/map-key-removed
   {:doc "Map: a KEY REMOVED. dissoc `:role` from :profile — the diff paints
          a struck-through `−:role` (red, key-anchored)."}
   (fn [db _]
-    (let [db (bump db)]
-      (if (contains? (:profile db) :role)
-        (update db :profile dissoc :role)
-        (assoc-in db [:profile :role] :engineer)))))
+    (if (contains? (:profile db) :role)
+      (update db :profile dissoc :role)
+      (assoc-in db [:profile :role] :engineer))))
 
 (rf/reg-event-db :edn-inspector/map-value-changed
   {:doc "Map: a VALUE CHANGED in place. Bump :profile/name — the value-side
          `~` glyph + `← was \"…\"` annotation, key intact."}
   (fn [db _]
-    (-> db bump
-        (update-in [:profile :name]
-                   #(if (= % "Ada") "Ada Lovelace" "Ada")))))
+    (update-in db [:profile :name]
+               #(if (= % "Ada") "Ada Lovelace" "Ada"))))
 
 ;; -- SEQUENTIALS (vector / list / set) ---------------------------------------
 
@@ -219,18 +210,16 @@
   {:doc "Sequential: ENTRY ADDED. conj a new task onto the :queue vector —
          the appended entry paints `+` green."}
   (fn [db _]
-    (-> db bump
-        (update :queue conj (keyword (str "task-" (inc (count (:queue db)))))))))
+    (update db :queue conj (keyword (str "task-" (inc (count (:queue db))))))))
 
 (rf/reg-event-db :edn-inspector/seq-entry-removed
   {:doc "Sequential: ENTRY REMOVED. pop the tail off the :queue vector — the
          dropped entry renders struck-through (member-level, not a whole-key
          replace). Re-seeds when down to one so there is always a tail."}
   (fn [db _]
-    (let [db (bump db)]
-      (if (> (count (:queue db)) 1)
-        (update db :queue pop)
-        (assoc db :queue [:task-1 :task-2 :task-3])))))
+    (if (> (count (:queue db)) 1)
+      (update db :queue pop)
+      (assoc db :queue [:task-1 :task-2 :task-3]))))
 
 (rf/reg-event-db :edn-inspector/seq-scattered-removed
   {:doc "Sequential: SCATTERED / MID-VECTOR removal (rf2-vu42n). Thin :lane
@@ -240,18 +229,16 @@
          suffix. Pre-fix the index-aligning renderer struck :c and dropped
          :b. Toggles back to the full lane so the diff alternates."}
   (fn [db _]
-    (let [db (bump db)]
-      (if (= (:lane db) [:a :b :c :d])
-        (assoc db :lane [:a :c])
-        (assoc db :lane [:a :b :c :d])))))
+    (if (= (:lane db) [:a :b :c :d])
+      (assoc db :lane [:a :c])
+      (assoc db :lane [:a :b :c :d]))))
 
 (rf/reg-event-db :edn-inspector/set-member-changed
   {:doc "Set: a MEMBER CHANGED (swap). Replace one member of :tags — the
          diff paints member-level `−:alpha +:delta` with the :tags KEY
          INTACT (not a 'sea of red' whole-key strike). Cycles members."}
   (fn [db _]
-    (let [db   (bump db)
-          tags (:tags db)]
+    (let [tags (:tags db)]
       (assoc db :tags
              (cond
                (contains? tags :alpha) (-> tags (disj :alpha) (conj :delta))
@@ -271,57 +258,52 @@
          removal renders member-level inside the intact (now-empty) vector,
          NOT a whole-key `~` modify (rf2-yucxn BUG A). Re-seeds when empty."}
   (fn [db _]
-    (let [db (bump db)]
-      (assoc db :one-vec (if (seq (:one-vec db)) [] [:only])))))
+    (assoc db :one-vec (if (seq (:one-vec db)) [] [:only]))))
 
 (rf/reg-event-db :edn-inspector/empty-list
   {:doc "Empty a LIST, key intact. `:one-list (:only)` → `()` — member-level
          removal inside the intact list (rf2-yucxn BUG A). Re-seeds."}
   (fn [db _]
-    (let [db (bump db)]
-      (assoc db :one-list (if (seq (:one-list db)) '() '(:only))))))
+    (assoc db :one-list (if (seq (:one-list db)) '() '(:only)))))
 
 (rf/reg-event-db :edn-inspector/empty-set
   {:doc "Empty a SET, key intact. `:one-set #{:only}` → `#{}` — member-level
          removal inside the intact set (l0us2 empty-edge expansion). Re-seeds."}
   (fn [db _]
-    (let [db (bump db)]
-      (assoc db :one-set (if (seq (:one-set db)) #{} #{:only})))))
+    (assoc db :one-set (if (seq (:one-set db)) #{} #{:only}))))
 
 (rf/reg-event-db :edn-inspector/empty-map
   {:doc "Empty a MAP, key intact. `:one-map {:k 1}` → `{}` — member-level
          removal inside the intact map (rf2-9d4j8 empty-map expansion).
          Re-seeds."}
   (fn [db _]
-    (let [db (bump db)]
-      (assoc db :one-map (if (seq (:one-map db)) {} {:k 1})))))
+    (assoc db :one-map (if (seq (:one-map db)) {} {:k 1}))))
 
 (rf/reg-event-db :edn-inspector/remove-key
   {:doc "Remove a KEY wholesale. dissoc `:doomed` — a struck-through removed
          KEY (collapsed removed-ghost), DISTINCT from emptying a collection
          whose key stays. Re-seeds the key when gone."}
   (fn [db _]
-    (let [db (bump db)]
-      (if (contains? db :doomed)
-        (dissoc db :doomed)
-        (assoc db :doomed {:goodbye true})))))
+    (if (contains? db :doomed)
+      (dissoc db :doomed)
+      (assoc db :doomed {:goodbye true}))))
 
 ;; -- SCALARS -----------------------------------------------------------------
 
 (rf/reg-event-db :edn-inspector/scalar-number
   {:doc "Scalar: NUMBER changed in place. Increment :scalar — `~` + `← was N`."}
-  (fn [db _] (-> db bump (update :scalar #(if (number? %) (inc %) 5)))))
+  (fn [db _] (-> db (update :scalar #(if (number? %) (inc %) 5)))))
 
 (rf/reg-event-db :edn-inspector/scalar-nil-toggle
   {:doc "Scalar: NIL ↔ VALUE. Toggle :scalar between a value and nil — both
          transitions are `:modified` leaves (nil is a real value, not absence)."}
-  (fn [db _] (-> db bump (update :scalar #(if (nil? %) 5 nil)))))
+  (fn [db _] (-> db (update :scalar #(if (nil? %) 5 nil)))))
 
 (rf/reg-event-db :edn-inspector/scalar-type-flip
   {:doc "Scalar: TYPE CHANGE. Flip :scalar number↔string (`5` ↔ `\"five\"`)
          and scalar↔map — R7 renders `~` + `← was <type>` type-change suffix."}
   (fn [db _]
-    (-> db bump
+    (-> db
         (update :scalar
                 (fn [v]
                   (cond
@@ -336,7 +318,7 @@
          `{:a 1 :c 3}` — `:b` removed AND `:c` added simultaneously, `:a`
          unchanged."}
   (fn [db _]
-    (-> db bump
+    (-> db
         (update :flags
                 (fn [m]
                   (if (contains? m :b) {:a 1 :c 3} {:a 1 :b 2}))))))
@@ -345,7 +327,7 @@
   {:doc "Vector: CHANGE + APPEND in ONE diff. Swap :slots `[1 2 3]` ↔
          `[1 9 3 4]` — index 1 modified (2→9) AND index 3 appended (4)."}
   (fn [db _]
-    (-> db bump
+    (-> db
         (update :slots
                 (fn [v] (if (= v [1 2 3]) [1 9 3 4] [1 2 3]))))))
 
@@ -354,7 +336,7 @@
          `#{:x :p :q}` — `:y :z` removed AND `:p :q` added, `:x` kept,
          member-level, key intact (rf2-4vp8c)."}
   (fn [db _]
-    (-> db bump
+    (-> db
         (update :labels
                 (fn [s] (if (contains? s :y) #{:x :p :q} #{:x :y :z}))))))
 
@@ -364,7 +346,7 @@
   {:doc "Deep: a scalar change FIVE levels deep at `[:deep :a :b :c :d]`.
          Every ancestor reads `:children` (◴ + rail); none promotes to a
          whole-key replace."}
-  (fn [db _] (-> db bump (update-in [:deep :a :b :c :d] (fnil inc 0)))))
+  (fn [db _] (-> db (update-in [:deep :a :b :c :d] (fnil inc 0)))))
 
 (rf/reg-event-db :edn-inspector/mixed-deep-change
   {:doc "Mixed: a SET swap through map→map→vector→set at
@@ -372,7 +354,7 @@
          (map or vector) is falsely promoted to a whole-key replace
          (the l0us2 ancestor-non-promotion property across kinds). Cycles."}
   (fn [db _]
-    (-> db bump
+    (-> db
         (update-in [:mixed :a :b 0]
                    (fn [s] (if (contains? s :x) #{:y} #{:x}))))))
 
@@ -382,13 +364,13 @@
   {:doc "Sentinel: :rf/redacted. Write the sentinel three levels deep at
          `[:secure :user :password]` — the inspector renders a `redacted`
          chip, never the raw value."}
-  (fn [db _] (-> db bump (assoc-in [:secure :user :password] :rf/redacted))))
+  (fn [db _] (-> db (assoc-in [:secure :user :password] :rf/redacted))))
 
 (rf/reg-event-db :edn-inspector/large-elided
   {:doc "Sentinel: :rf.size/large-elided (Spec 015). Write the sentinel at
          `[:cache :report-42]` — routed through the size-chip renderer."}
   (fn [db _]
-    (-> db bump
+    (-> db
         (assoc-in [:cache :report-42]
                   {:rf.size/large-elided {:source        :app-db
                                           :path          [:cache :report-42]
@@ -404,7 +386,7 @@
          `[:cache :grid]` — the App-db inspector elides past its threshold +
          the body scrolls."}
   (fn [db _]
-    (-> db bump
+    (-> db
         (assoc-in [:cache :grid]
                   (into {} (for [i (range 50)]
                              [(keyword (str "metric-" i)) (str "value-" i)]))))))
@@ -414,7 +396,7 @@
          nested map at `:cache/tenant` — deep nodes render `▸ {…N keys}`
          summaries past the depth ceiling."}
   (fn [db _]
-    (-> db bump
+    (-> db
         (assoc-in [:cache :tenant]
                   {:acme {:department {:engineering {:team {:platform
                                                             {:project :xray
@@ -427,7 +409,7 @@
          every syntax-palette token + the default formatters' compact
          headers."}
   (fn [db _]
-    (-> db bump
+    (-> db
         (assoc-in [:cache :scalar-mix]
                   [nil true false
                    42 -7 3.14159
@@ -438,139 +420,116 @@
                    (js/Date.)]))))
 
 ;; ============================================================================
-;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
+;; THE STEP VECTOR — code data (the single source of truth)
 ;; ============================================================================
 ;;
-;; Each step: {:event [...] :watch "<what to look for>" :settle-ms N
-;;             :label "<short row label>"}. The runner renders :watch per
-;; STEP (per-occurrence narration), dispatches :event, focuses the latest
-;; :rf/default epoch, then waits :settle-ms before advancing. The matrix
-;; walks SIMPLE → COMPLEX; the settle is short (these are synchronous
-;; db-only transitions — no async cascade to wait on), just enough for the
-;; operator's eye to land on the rendered diff before the next step.
+;; Each step: {:event [...] :watch "<what to look for>" :label "<short row
+;; label>"}. The runner renders :watch per STEP; pressing Step (or a per-row
+;; RUN button) dispatches `[:edn-inspector/run-step n]`, which sets app-db
+;; `:step = n` (the per-step delta the panels show) and dispatches the
+;; step's `:event` into the host-frame. The matrix walks SIMPLE → COMPLEX.
+;; These are synchronous db-only transitions — no async cascade, so manual
+;; stepping needs no pacing (rf2-5sjbg dropped the settle machinery).
 
 (def steps
   [;; -- MAPS --
-   {:label     "Map: key ADDED"
-    :event     [:edn-inspector/map-key-added]
-    :watch     "App-db diff: assoc :profile/:team paints `+:team` (green, key-anchored). Epoch: the db-before/db-after of a single key add."
-    :settle-ms 450}
-   {:label     "Map: key REMOVED"
-    :event     [:edn-inspector/map-key-removed]
-    :watch     "App-db diff: dissoc :profile/:role paints a struck-through `−:role` (red, key-anchored) — distinct from emptying a collection."
-    :settle-ms 450}
-   {:label     "Map: value CHANGED"
-    :event     [:edn-inspector/map-value-changed]
-    :watch     "App-db diff: :profile/:name flips in place — the value-side `~` glyph + `← was \"…\"` annotation, the KEY intact."
-    :settle-ms 450}
+   {:label "Map: key ADDED"
+    :event [:edn-inspector/map-key-added]
+    :watch "App-db diff: assoc :profile/:team paints `+:team` (green, key-anchored). Epoch: the db-before/db-after of a single key add."}
+   {:label "Map: key REMOVED"
+    :event [:edn-inspector/map-key-removed]
+    :watch "App-db diff: dissoc :profile/:role paints a struck-through `−:role` (red, key-anchored) — distinct from emptying a collection."}
+   {:label "Map: value CHANGED"
+    :event [:edn-inspector/map-value-changed]
+    :watch "App-db diff: :profile/:name flips in place — the value-side `~` glyph + `← was \"…\"` annotation, the KEY intact."}
 
    ;; -- SEQUENTIALS --
-   {:label     "Vector: entry ADDED"
-    :event     [:edn-inspector/seq-entry-added]
-    :watch     "App-db diff: a task conj'd onto :queue — the appended entry paints `+` green at the tail."
-    :settle-ms 450}
-   {:label     "Vector: entry REMOVED"
-    :event     [:edn-inspector/seq-entry-removed]
-    :watch     "App-db diff: :queue tail popped — the dropped entry renders struck-through (member-level, NOT a whole-key replace)."
-    :settle-ms 450}
-   {:label     "Vector: SCATTERED removal"
-    :event     [:edn-inspector/seq-scattered-removed]
-    :watch     ":lane [:a :b :c :d] → [:a :c]: −:b@1 and −:d@3 render struck IN PLACE; the surviving-shifted :c (was index 2 → 1) is NOT struck and carries a `(was N)` suffix."
-    :settle-ms 450}
-   {:label     "Set: member CHANGED"
-    :event     [:edn-inspector/set-member-changed]
-    :watch     "App-db diff: one :tags member swapped — member-level `−:alpha +:delta` with the :tags KEY intact (not a sea-of-red whole-key strike)."
-    :settle-ms 450}
+   {:label "Vector: entry ADDED"
+    :event [:edn-inspector/seq-entry-added]
+    :watch "App-db diff: a task conj'd onto :queue — the appended entry paints `+` green at the tail."}
+   {:label "Vector: entry REMOVED"
+    :event [:edn-inspector/seq-entry-removed]
+    :watch "App-db diff: :queue tail popped — the dropped entry renders struck-through (member-level, NOT a whole-key replace)."}
+   {:label "Vector: SCATTERED removal"
+    :event [:edn-inspector/seq-scattered-removed]
+    :watch ":lane [:a :b :c :d] → [:a :c]: −:b@1 and −:d@3 render struck IN PLACE; the surviving-shifted :c (was index 2 → 1) is NOT struck and carries a `(was N)` suffix."}
+   {:label "Set: member CHANGED"
+    :event [:edn-inspector/set-member-changed]
+    :watch "App-db diff: one :tags member swapped — member-level `−:alpha +:delta` with the :tags KEY intact (not a sea-of-red whole-key strike)."}
 
    ;; -- EMPTY vs REMOVAL (the subtle one) --
-   {:label     "Empty a VECTOR (key intact)"
-    :event     [:edn-inspector/empty-vector]
-    :watch     ":one-vec [:only] → []: the element removal renders member-level inside the intact (now-empty) vector, NOT a whole-key `~` modify (rf2-yucxn BUG A)."
-    :settle-ms 450}
-   {:label     "Empty a LIST (key intact)"
-    :event     [:edn-inspector/empty-list]
-    :watch     ":one-list (:only) → (): member-level removal inside the intact list — the key stays, the bracket pair goes empty."
-    :settle-ms 450}
-   {:label     "Empty a SET (key intact)"
-    :event     [:edn-inspector/empty-set]
-    :watch     ":one-set #{:only} → #{}: member-level removal inside the intact set (l0us2 empty-edge expansion)."
-    :settle-ms 450}
-   {:label     "Empty a MAP (key intact)"
-    :event     [:edn-inspector/empty-map]
-    :watch     ":one-map {:k 1} → {}: member-level removal inside the intact map (rf2-9d4j8 empty-map expansion)."
-    :settle-ms 450}
-   {:label     "Remove a KEY (wholesale)"
-    :event     [:edn-inspector/remove-key]
-    :watch     "dissoc :doomed: a struck-through removed KEY (collapsed removed-ghost) — read it AGAINST the empty-collection steps above; they must look DISTINCT."
-    :settle-ms 450}
+   {:label "Empty a VECTOR (key intact)"
+    :event [:edn-inspector/empty-vector]
+    :watch ":one-vec [:only] → []: the element removal renders member-level inside the intact (now-empty) vector, NOT a whole-key `~` modify (rf2-yucxn BUG A)."}
+   {:label "Empty a LIST (key intact)"
+    :event [:edn-inspector/empty-list]
+    :watch ":one-list (:only) → (): member-level removal inside the intact list — the key stays, the bracket pair goes empty."}
+   {:label "Empty a SET (key intact)"
+    :event [:edn-inspector/empty-set]
+    :watch ":one-set #{:only} → #{}: member-level removal inside the intact set (l0us2 empty-edge expansion)."}
+   {:label "Empty a MAP (key intact)"
+    :event [:edn-inspector/empty-map]
+    :watch ":one-map {:k 1} → {}: member-level removal inside the intact map (rf2-9d4j8 empty-map expansion)."}
+   {:label "Remove a KEY (wholesale)"
+    :event [:edn-inspector/remove-key]
+    :watch "dissoc :doomed: a struck-through removed KEY (collapsed removed-ghost) — read it AGAINST the empty-collection steps above; they must look DISTINCT."}
 
    ;; -- SCALARS --
-   {:label     "Scalar: NUMBER changed"
-    :event     [:edn-inspector/scalar-number]
-    :watch     "App-db diff: :scalar incremented — `~` + `← was N` on a number leaf."
-    :settle-ms 400}
-   {:label     "Scalar: nil ↔ value"
-    :event     [:edn-inspector/scalar-nil-toggle]
-    :watch     ":scalar toggles value ↔ nil — both transitions are `:modified` leaves (nil is a real value, not absence)."
-    :settle-ms 400}
-   {:label     "Scalar: TYPE change"
-    :event     [:edn-inspector/scalar-type-flip]
-    :watch     ":scalar flips number↔string↔map — R7 renders `~` + `← was <type>` type-change suffix (scalar→collection promotes without a false whole-key strike)."
-    :settle-ms 400}
+   {:label "Scalar: NUMBER changed"
+    :event [:edn-inspector/scalar-number]
+    :watch "App-db diff: :scalar incremented — `~` + `← was N` on a number leaf."}
+   {:label "Scalar: nil ↔ value"
+    :event [:edn-inspector/scalar-nil-toggle]
+    :watch ":scalar toggles value ↔ nil — both transitions are `:modified` leaves (nil is a real value, not absence)."}
+   {:label "Scalar: TYPE change"
+    :event [:edn-inspector/scalar-type-flip]
+    :watch ":scalar flips number↔string↔map — R7 renders `~` + `← was <type>` type-change suffix (scalar→collection promotes without a false whole-key strike)."}
 
    ;; -- MULTI-ADJUST --
-   {:label     "Map: add AND remove"
-    :event     [:edn-inspector/map-multi-adjust]
-    :watch     ":flags {:a 1 :b 2} ↔ {:a 1 :c 3}: `−:b` removed AND `+:c` added in ONE diff, `:a` unchanged."
-    :settle-ms 450}
-   {:label     "Vector: change AND append"
-    :event     [:edn-inspector/vector-multi-adjust]
-    :watch     ":slots [1 2 3] ↔ [1 9 3 4]: index 1 modified (`~`@1: 2→9) AND index 3 appended (`+`@3) in ONE diff."
-    :settle-ms 450}
-   {:label     "Set: multi-member swap"
-    :event     [:edn-inspector/set-multi-adjust]
-    :watch     ":labels #{:x :y :z} ↔ #{:x :p :q}: `−:y −:z +:p +:q` member-level, key intact (rf2-4vp8c)."
-    :settle-ms 450}
+   {:label "Map: add AND remove"
+    :event [:edn-inspector/map-multi-adjust]
+    :watch ":flags {:a 1 :b 2} ↔ {:a 1 :c 3}: `−:b` removed AND `+:c` added in ONE diff, `:a` unchanged."}
+   {:label "Vector: change AND append"
+    :event [:edn-inspector/vector-multi-adjust]
+    :watch ":slots [1 2 3] ↔ [1 9 3 4]: index 1 modified (`~`@1: 2→9) AND index 3 appended (`+`@3) in ONE diff."}
+   {:label "Set: multi-member swap"
+    :event [:edn-inspector/set-multi-adjust]
+    :watch ":labels #{:x :y :z} ↔ #{:x :p :q}: `−:y −:z +:p +:q` member-level, key intact (rf2-4vp8c)."}
 
    ;; -- DEEP / MIXED --
-   {:label     "Deep scalar change"
-    :event     [:edn-inspector/deep-change]
-    :watch     "[:deep :a :b :c :d] bumped FIVE levels deep: every ancestor reads `:children` (◴ + rail); none promotes to a whole-key replace."
-    :settle-ms 450}
-   {:label     "Mixed-kind deep swap"
-    :event     [:edn-inspector/mixed-deep-change]
-    :watch     "Set swap at [:mixed :a :b 0] through map→map→vector→set: diffs member-level at the set; no ancestor (map or vector) is falsely promoted (l0us2 across kinds)."
-    :settle-ms 450}
+   {:label "Deep scalar change"
+    :event [:edn-inspector/deep-change]
+    :watch "[:deep :a :b :c :d] bumped FIVE levels deep: every ancestor reads `:children` (◴ + rail); none promotes to a whole-key replace."}
+   {:label "Mixed-kind deep swap"
+    :event [:edn-inspector/mixed-deep-change]
+    :watch "Set swap at [:mixed :a :b 0] through map→map→vector→set: diffs member-level at the set; no ancestor (map or vector) is falsely promoted (l0us2 across kinds)."}
 
    ;; -- SENTINELS --
-   {:label     "Sensitive → :rf/redacted"
-    :event     [:edn-inspector/redacted]
-    :watch     "[:secure :user :password] := :rf/redacted: the inspector renders a `redacted` chip, NEVER the raw value."
-    :settle-ms 450}
-   {:label     "Large-elided sentinel"
-    :event     [:edn-inspector/large-elided]
-    :watch     "[:cache :report-42] := a :rf.size/large-elided sentinel (Spec 015) — routed through the size-chip renderer, not rendered as a literal map."
-    :settle-ms 450}
+   {:label "Sensitive → :rf/redacted"
+    :event [:edn-inspector/redacted]
+    :watch "[:secure :user :password] := :rf/redacted: the inspector renders a `redacted` chip, NEVER the raw value."}
+   {:label "Large-elided sentinel"
+    :event [:edn-inspector/large-elided]
+    :watch "[:cache :report-42] := a :rf.size/large-elided sentinel (Spec 015) — routed through the size-chip renderer, not rendered as a literal map."}
 
    ;; -- SHOWCASE --
-   {:label     "Large collection → elision"
-    :event     [:edn-inspector/large-collection]
-    :watch     "A 50-key map at [:cache :grid]: the App-db inspector elides past its threshold and the body scrolls."
-    :settle-ms 500}
-   {:label     "Deeply nested → collapse"
-    :event     [:edn-inspector/deeply-nested]
-    :watch     "A six-level nested map at [:cache :tenant]: deep nodes render `▸ {…N keys}` summaries past the depth ceiling."
-    :settle-ms 500}
-   {:label     "Mixed types / tagged literals"
-    :event     [:edn-inspector/mixed-types]
-    :watch     "A vector of every scalar kind + #uuid + #inst at [:cache :scalar-mix]: every syntax-palette token + the default formatters' compact headers."
-    :settle-ms 500}])
+   {:label "Large collection → elision"
+    :event [:edn-inspector/large-collection]
+    :watch "A 50-key map at [:cache :grid]: the App-db inspector elides past its threshold and the body scrolls."}
+   {:label "Deeply nested → collapse"
+    :event [:edn-inspector/deeply-nested]
+    :watch "A six-level nested map at [:cache :tenant]: deep nodes render `▸ {…N keys}` summaries past the depth ceiling."}
+   {:label "Mixed types / tagged literals"
+    :event [:edn-inspector/mixed-types]
+    :watch "A vector of every scalar kind + #uuid + #inst at [:cache :scalar-mix]: every syntax-palette token + the default formatters' compact headers."}])
 
 ;; ============================================================================
-;; RUNNER STATE — LOCAL ATOM (rf2-8pbjr: not app-db, not a 2nd frame)
+;; RUNNER WIRING (rf2-5sjbg) — register the deck's run-step event
 ;; ============================================================================
 
-(defonce runner-state (r/atom (runner/initial-state)))
+(runner/reg-runner! {:id         :edn-inspector/run-step
+                     :steps      steps
+                     :host-frame host-frame})
 
 ;; ============================================================================
 ;; VIEWS
@@ -588,7 +547,10 @@
      "used by " [:code "xray"] " to show data diffs. Click " [:strong "Step"]
      " below to move from one test case to another, observing the diffs "
      "shown in xray on the right."]]
-   [runner/runner "edn-inspector" runner-state steps host-frame]])
+   [runner/runner {:run-step-event :edn-inspector/run-step
+                   :steps          steps
+                   :prefix         "edn-inspector"
+                   :host-frame     host-frame}]])
 
 ;; ============================================================================
 ;; MOUNT

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -88,18 +88,18 @@
   The `:rf/history` snapshot slot is inspectable in the App-db panel (inside
   `[:rf/runtime :machines :snapshots <id> :rf/history]`). rf2-mle6e.5.
 
-  ## Per-step delta (standard_epochs pattern)
+  ## Per-step delta (rf2-5sjbg — app-db `:step`)
 
-  Every action event bumps a shared `:baseline` counter (`bump`), so the
-  App-db / Epoch panels always show a delta on every step; the per-step
-  machine feature is the ADDITIONAL change layered on top.
+  The runner sets app-db `:step = n` on the run-step epoch; that churn is
+  the per-step App-db / Epoch delta the panels show (it REPLACES the old
+  `:baseline` counter). The per-step machine feature is the child event the
+  run-step epoch dispatches into the host-frame.
 
-  ## Runner state = LOCAL ATOM (rf2-8pbjr contract)
+  ## Runner cursor = app-db `:step` (rf2-5sjbg)
 
-  The runner cursor / status / pace live in `runner-state` — a LOCAL Reagent
-  atom in THIS ns. It is NEVER written to the inspected app-db (that would
-  pollute the panels under inspection) and is NOT a second frame (only the
-  inspected app frame, `:rf/default`, is Xray-relevant).
+  The runner cursor lives in app-db's `:step` slot, written by
+  `runner.core`'s run-step event — NOT a Reagent atom. The deck reads as an
+  ordinary re-frame2 app: app-db + events + subs.
 
   ## Inline Xray sidecar (preload)
 
@@ -124,8 +124,7 @@
   the `machine-epochs machine ladder` scenario, which drives the runner's
   per-step RUN-THIS-STEP buttons). The machine specs live in the sibling ns
   `machine-epochs.machines`, shared with the harness."
-  (:require [reagent.core :as r]
-            [reagent.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; State-machines artefact — load-time hook so `reg-machine`,
             ;; the `:rf/machine` framework subs, and machine-event routing
@@ -135,9 +134,10 @@
             [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-xray.config :as xray-config]
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared queued-step runner (rf2-8pbjr pilot). This deck
-            ;; supplies a `steps` vector + the testid prefix; the runner
-            ;; drives the ONE-button series + the per-step run affordance.
+            ;; The shared step-driver runner (rf2-5sjbg). This deck supplies
+            ;; a `steps` vector + registers `:machine-epochs/run-step` via
+            ;; `runner/reg-runner!`; the runner drives the ONE-button series
+            ;; + the per-step run affordance off app-db `:step`.
             [runner.core :as runner]
             [machine-epochs.machines :as machines])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -161,26 +161,26 @@
 (machines/register-all!)
 
 ;; ============================================================================
-;; APP-DB SEED + the shared bump/send driver
+;; APP-DB SEED + the shared send driver
 ;; ============================================================================
 ;;
-;; `:baseline` is the shared counter every step bumps (so App-db / Epoch
-;; always show a delta). The machines own their own runtime state under
+;; `:step` is the runner cursor (rf2-5sjbg) — the index of the last-run
+;; step, written by `runner.core`'s run-step event; its churn every step IS
+;; the per-step App-db / Epoch delta (it REPLACES the old `:baseline`
+;; counter). The machines own their own runtime state under
 ;; `[:rf/runtime :machines :snapshots …]`.
 
-(def initial-db {:baseline 0})
+(def initial-db {:step nil})
 
-(defn- bump [db] (update db :baseline inc))
-
-;; A reusable "bump + send" event-fx: every machine step routes through here
-;; so the baseline delta and the machine send are one cascade. `sends` is a
-;; vector of fully-formed machine-event vectors — pass several to fan out to
-;; multiple machines in one press.
+;; A reusable "send" event-fx: every machine step routes through here so a
+;; step can fan out to one OR several machines in one cascade. `sends` is a
+;; vector of fully-formed machine-event vectors. The per-step App-db delta is
+;; the runner's `:step` write on the parent run-step epoch.
 (rf/reg-event-fx :machine-epochs/send
-  {:doc "Bump the baseline and dispatch the supplied machine event(s). The
-         shared driver behind every machine step."}
+  {:doc "Dispatch the supplied machine event(s). The shared driver behind
+         every machine step (a step may fan out to several machines)."}
   (fn handler-send [{:keys [db]} [_ sends]]
-    {:db (bump db)
+    {:db db
      :fx (mapv (fn [send] [:dispatch send]) sends)}))
 
 ;; re-open the door (after a close left it :closed), arm the `:held-open?` flag
@@ -192,7 +192,7 @@
          The :may-close? guard FAILS, so the close is blocked and the machine
          stays in :open."}
   (fn handler-reopen-then-block [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx [[:dispatch [:door/main [:door/push]]]
           [:dispatch [:door/main [:door/hold]]]
           [:dispatch [:door/main [:door/close]]]]}))
@@ -200,10 +200,9 @@
 ;; The acknowledgement event dispatched by :enter-alarm's :fx. A plain deck
 ;; event so the cascade has a downstream child epoch the lens links to.
 (rf/reg-event-db :machine-epochs/alarm-acknowledged
-  {:doc "The downstream event fired by the door's :enter-alarm action :fx.
-         Bumps baseline again so the alarm cascade has a child epoch under
-         the originating dispatch-id."}
-  (fn handler-alarm-acknowledged [db _ev] (bump db)))
+  {:doc "The downstream event fired by the door's :enter-alarm action :fx —
+         the child epoch under the originating dispatch-id."}
+  (fn handler-alarm-acknowledged [db _ev] db))
 
 ;; re-start the brew (schedules a fresh :after timer) then immediately
 ;; :brew/abort, which exits :brewing BEFORE the timer fires. Exiting the
@@ -213,7 +212,7 @@
          :brew/abort (exit :brewing before the timer fires). The exit cancels
          the pending timer with :reason :on-exit."}
   (fn handler-cancel-brew [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx [[:dispatch [:brew/machine [:brew/start]]]
           [:dispatch [:brew/machine [:brew/abort]]]]}))
 
@@ -228,7 +227,7 @@
   (fn handler-finish-login [{:keys [db]} _ev]
     (let [child-id (get-in db [:rf/runtime :machines :spawned
                                :session/flow [:authenticating]])]
-      (cond-> {:db (bump db)}
+      (cond-> {:db db}
         child-id
         (assoc :fx [[:dispatch [child-id [:succeed :session/token-abc]]]])))))
 
@@ -241,7 +240,7 @@
   {:doc ":quiz/answer ×2 so the score reaches the pass mark and the guarded
          :always chain fires (microsteps > 0)."}
   (fn handler-answer-to-pass [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx [[:dispatch [:quiz/scorer [:quiz/answer]]]
           [:dispatch [:quiz/scorer [:quiz/answer]]]]}))
 
@@ -250,14 +249,14 @@
 ;; :type :history machine throws synchronously at reg-machine time
 ;; (:rf.error/machine-history-misplaced). The deck event swallows the throw
 ;; (the step's job is to DRIVE the rejection; the harness asserts the throw
-;; shape directly). It bumps baseline so the epoch still shows a delta.
+;; shape directly). The per-step delta is the runner's `:step` write.
 (rf/reg-event-db :machine-epochs/probe-history-rejection
   {:doc "Attempt to register a ROOT :type :history machine and confirm the
          PLACEMENT constraint rejects it (a pseudo-state needs an owning
          compound). The throw is swallowed here so the deck does not crash;
          the harness asserts the misplaced-history rejection shape."}
   (fn handler-probe-history [db _ev]
-    (-> db bump (assoc :machine-epochs/history-rejected? (machines/history-rejected?)))))
+    (assoc db :machine-epochs/history-rejected? (machines/history-rejected?))))
 
 ;; the HISTORY restore dance (rf2-mle6e.5). To make the RESTORE the focal
 ;; cascade the operator inspects, the step first POSITIONS the player deep
@@ -286,7 +285,7 @@
          The restore cascade carries the history banner + :source :recorded
          entry-step chips (SHALLOW)."}
   (fn handler-history-shallow [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx (history-restore-fx :media/shallow)}))
 
 (rf/reg-event-fx :machine-epochs/history-deep-restore
@@ -295,7 +294,7 @@
          restore cascade carries the history banner (DEEP) + :source :recorded
          entry-step chips down to the exact leaf."}
   (fn handler-history-deep [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx (history-restore-fx :media/deep)}))
 
 ;; ============================================================================
@@ -324,28 +323,24 @@
                 :session/flow :hvac/controller :media/deep :media/shallow])}))
 
 ;; ============================================================================
-;; SUBSCRIPTIONS
+;; THE STEP VECTOR — code data (the single source of truth)
 ;; ============================================================================
 ;;
 ;; The deck reads NO machine snapshots on-page — the Xray Epoch panel +
 ;; Machine Inspector are the read-out, and the harness drives the substrate
-;; directly. Only the shared baseline counter has a deck sub (the per-step
-;; App-db / Epoch delta). The machines' `:trail` order-oracle is untouched: it
-;; lives in `machine-epochs.machines` and is read by the harness, not the deck.
-
-(rf/reg-sub :machine-epochs/baseline (fn [db _] (:baseline db)))
-
-;; ============================================================================
-;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
-;; ============================================================================
+;; directly. The machines' `:trail` order-oracle lives in
+;; `machine-epochs.machines` and is read by the harness, not the deck. So
+;; this deck registers no on-page subs; the runner reads the shared
+;; `:rf.runner/step` sub for its highlight + counter.
 ;;
-;; Each step: {:event [...] :watch "<what to look for>" :settle-ms N
-;;             :label "<short row label>"}. The runner renders :watch per STEP
-;; (per-occurrence narration), dispatches :event on a Step / per-step click
-;; (manual — focus is the operator's), then waits :settle-ms before advancing.
-;; The matrix walks the machine set domain-by-domain; the events are the SAME
-;; ones the bespoke ladder drove (the machine FEATURES are unchanged — only the
-;; driving affordance moved to the runner).
+;; Each step: {:event [...] :watch "<what to look for>" :label "<short row
+;; label>"}. The runner renders :watch per STEP; pressing Step (or a per-row
+;; RUN button) dispatches `[:machine-epochs/run-step n]`, which sets app-db
+;; `:step = n` (the per-step delta) and dispatches the step's `:event` into
+;; the host-frame. Manual stepping needs no pacing — each machine fires its
+;; own `:after` timers / cascades on its own schedule while the operator
+;; watches (rf2-5sjbg dropped the settle machinery). The events are the SAME
+;; ones the bespoke ladder drove (the machine FEATURES are unchanged).
 ;;
 ;; The `:label` carries the section/domain prefix (Door · Traffic · …) so the
 ;; flat runner list stays legible without a section-separator concept.
@@ -357,130 +352,106 @@
 
 (def steps
   [;; -- DOOR (FLAT) — start · transition · entry/exit · effect --
-   {:label     "Door: start machine (:rf.machine/start)"
-    :event     [:door/main [:rf.machine/start]]
-    :watch     "Inspector: the door chart renders; live-highlight lands on :locked. Epoch: a [START] badge (initial state + data) — a pure init-kick, NOT a transition / no-op."
-    :settle-ms 350}
-   {:label     "Door: insert coin (:locked ──► :closed)"
-    :event     [:machine-epochs/send [[:door/main [:door/insert-coin]]]]
-    :watch     "Focused-transition lens: plain FROM → TO, no guard / no action; cascade = exit→TRANSITION→entry rows."
-    :settle-ms 350}
-   {:label     "Door: push (:closed ──► :open) — entry + exit"
-    :event     [:machine-epochs/send [[:door/main [:door/push]]]]
-    :watch     "ACTIONS RUN: :closed's :exit (:clear-hold) + :open's :entry (:count-open); snapshot :opened-count++."
-    :settle-ms 350}
-   {:label     "Door: close (:open ──► :closed) — guard ALLOWED"
-    :event     [:machine-epochs/send [[:door/main [:door/close]]]]
-    :watch     "GUARDS RUN: :may-close? → pass; transition completes to :closed."
-    :settle-ms 350}
-   {:label     "Door: re-open, hold, then close — guard BLOCKED"
-    :event     [:machine-epochs/reopen-then-block]
-    :watch     "GUARDS RUN: :may-close? → fail (held-open?); state STAYS :open (no branch matches)."
-    :settle-ms 400}
-   {:label     "Door: trip (:open ──► :alarming) — with effect"
-    :event     [:machine-epochs/send [[:door/main [:door/trip]]]]
-    :watch     "ACTIONS RUN: :enter-alarm → :fx :dispatch → [:alarm-acknowledged] (downstream cascade child)."
-    :settle-ms 400}
-   {:label     "Door: insert coin into :alarming — UNHANDLED no-op"
-    :event     [:machine-epochs/send [[:door/main [:door/insert-coin]]]]
-    :watch     "Epoch: ONE [NO OP] staying in :alarming row; NO transition row; event row NOT pink — the foil to the throw."
-    :settle-ms 350}
-   {:label     "Door: audit from :alarming — ROOT :on fallthrough"
-    :event     [:machine-epochs/send [[:door/main [:door/audit]]]]
-    :watch     "Resolution: :alarming has no :door/audit; the ROOT :on handles it → :alarming ──► :locked (deepest-wins fallthrough)."
-    :settle-ms 350}
+   {:label "Door: start machine (:rf.machine/start)"
+    :event [:door/main [:rf.machine/start]]
+    :watch "Inspector: the door chart renders; live-highlight lands on :locked. Epoch: a [START] badge (initial state + data) — a pure init-kick, NOT a transition / no-op."}
+   {:label "Door: insert coin (:locked ──► :closed)"
+    :event [:machine-epochs/send [[:door/main [:door/insert-coin]]]]
+    :watch "Focused-transition lens: plain FROM → TO, no guard / no action; cascade = exit→TRANSITION→entry rows."}
+   {:label "Door: push (:closed ──► :open) — entry + exit"
+    :event [:machine-epochs/send [[:door/main [:door/push]]]]
+    :watch "ACTIONS RUN: :closed's :exit (:clear-hold) + :open's :entry (:count-open); snapshot :opened-count++."}
+   {:label "Door: close (:open ──► :closed) — guard ALLOWED"
+    :event [:machine-epochs/send [[:door/main [:door/close]]]]
+    :watch "GUARDS RUN: :may-close? → pass; transition completes to :closed."}
+   {:label "Door: re-open, hold, then close — guard BLOCKED"
+    :event [:machine-epochs/reopen-then-block]
+    :watch "GUARDS RUN: :may-close? → fail (held-open?); state STAYS :open (no branch matches)."}
+   {:label "Door: trip (:open ──► :alarming) — with effect"
+    :event [:machine-epochs/send [[:door/main [:door/trip]]]]
+    :watch "ACTIONS RUN: :enter-alarm → :fx :dispatch → [:alarm-acknowledged] (downstream cascade child)."}
+   {:label "Door: insert coin into :alarming — UNHANDLED no-op"
+    :event [:machine-epochs/send [[:door/main [:door/insert-coin]]]]
+    :watch "Epoch: ONE [NO OP] staying in :alarming row; NO transition row; event row NOT pink — the foil to the throw."}
+   {:label "Door: audit from :alarming — ROOT :on fallthrough"
+    :event [:machine-epochs/send [[:door/main [:door/audit]]]]
+    :watch "Resolution: :alarming has no :door/audit; the ROOT :on handles it → :alarming ──► :locked (deepest-wins fallthrough)."}
 
    ;; -- TRAFFIC (PARALLEL) — regions · history · TAG-SET delta (gap 7) --
-   {:label     "Traffic: tick (parallel regions)"
-    :event     [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]
-    :watch     "Inspector: ONE event broadcasts to :vehicle + :pedestrian; chart highlights BOTH active leaves; tags swap members."
-    :settle-ms 350}
-   {:label     "Traffic: tick ×1 more (history ribbon)"
-    :event     [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]
-    :watch     "Transition-history ribbon accumulates state → state entries; logical-state DELTA box shows :tags member swap (rf2-l0us2)."
-    :settle-ms 350}
-   {:label     "Reset door + tick traffic (two machines, one cascade)"
-    :event     [:machine-epochs/send [[:door/main [:door/reset]] [:traffic/light [:traffic/tick]]]]
-    :watch     "Inspector: one event transitions BOTH machines; instance selection picks the first in trace order; multi-machine no-op names its machine."
-    :settle-ms 400}
+   {:label "Traffic: tick (parallel regions)"
+    :event [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]
+    :watch "Inspector: ONE event broadcasts to :vehicle + :pedestrian; chart highlights BOTH active leaves; tags swap members."}
+   {:label "Traffic: tick ×1 more (history ribbon)"
+    :event [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]
+    :watch "Transition-history ribbon accumulates state → state entries; logical-state DELTA box shows :tags member swap (rf2-l0us2)."}
+   {:label "Reset door + tick traffic (two machines, one cascade)"
+    :event [:machine-epochs/send [[:door/main [:door/reset]] [:traffic/light [:traffic/tick]]]]
+    :watch "Inspector: one event transitions BOTH machines; instance selection picks the first in trace order; multi-machine no-op names its machine."}
 
    ;; -- QUIZ (MICROSTEP) — :always EVENTLESS microsteps (gap 1) --
-   {:label     "Quiz: answer — score climbs (microsteps 0)"
-    :event     [:machine-epochs/send [[:quiz/scorer [:quiz/answer]]]]
-    :watch     "Cascade: the :answer action bumps :score; the :always guard is NOT yet met → 0 microsteps; quiz stays :asking."
-    :settle-ms 350}
-   {:label     "Quiz: answer ×2 more — :always SETTLES (microsteps > 0)"
-    :event     [:machine-epochs/answer-to-pass]
-    :watch     "Cascade: :answer reaches the pass mark; the guarded :always chain fires → N microstep(s) + the microstep cascade to :passed."
-    :settle-ms 450}
+   {:label "Quiz: answer — score climbs (microsteps 0)"
+    :event [:machine-epochs/send [[:quiz/scorer [:quiz/answer]]]]
+    :watch "Cascade: the :answer action bumps :score; the :always guard is NOT yet met → 0 microsteps; quiz stays :asking."}
+   {:label "Quiz: answer ×2 more — :always SETTLES (microsteps > 0)"
+    :event [:machine-epochs/answer-to-pass]
+    :watch "Cascade: :answer reaches the pass mark; the guarded :always chain fires → N microstep(s) + the microstep cascade to :passed."}
 
    ;; -- BREW (TIMER) — :after delayed transition + cancel (gap 2) --
-   {:label     "Brew: start — schedules an :after timer"
-    :event     [:machine-epochs/send [[:brew/machine [:brew/start]]]]
-    :watch     "Cascade: :idle ──► :brewing; the :after timer is SCHEDULED (no fire yet). Watch the AFTER TIMERS sub-section."
-    :settle-ms 400}
-   {:label     "Brew: let the :after timer ELAPSE (auto-fire)"
-    :event     [:machine-epochs/send [[:brew/machine [:rf.machine.timer/after-elapsed 5000 1 [:brewing]]]]]
-    :watch     "Cascade: the synthetic :after-elapsed fires → :brewing ──► :ready; DISPATCH row labels 'from :after timer'."
-    :settle-ms 400}
-   {:label     "Brew: re-start then CANCEL — exit beats the timer"
-    :event     [:machine-epochs/cancel-brew]
-    :watch     "Cascade: re-enter :brewing (schedule) then :brew/abort exits before fire → :rf.machine.timer/cancelled (:on-exit) — the :cancelled chip."
-    :settle-ms 450}
+   {:label "Brew: start — schedules an :after timer"
+    :event [:machine-epochs/send [[:brew/machine [:brew/start]]]]
+    :watch "Cascade: :idle ──► :brewing; the :after timer is SCHEDULED (no fire yet). Watch the AFTER TIMERS sub-section."}
+   {:label "Brew: let the :after timer ELAPSE (auto-fire)"
+    :event [:machine-epochs/send [[:brew/machine [:rf.machine.timer/after-elapsed 5000 1 [:brewing]]]]]
+    :watch "Cascade: the synthetic :after-elapsed fires → :brewing ──► :ready; DISPATCH row labels 'from :after timer'."}
+   {:label "Brew: re-start then CANCEL — exit beats the timer"
+    :event [:machine-epochs/cancel-brew]
+    :watch "Cascade: re-enter :brewing (schedule) then :brew/abort exits before fire → :rf.machine.timer/cancelled (:on-exit) — the :cancelled chip."}
 
    ;; -- SESSION (LIFECYCLE) — spawn · child :final · :on-done · destroy --
-   {:label     "Session: open — SPAWN child actor"
-    :event     [:machine-epochs/send [[:session/flow [:session/open]]]]
-    :watch     "Cascade: :idle ──► :authenticating spawns :session/login child; spawn fx renders; the instance spine spans parent + child."
-    :settle-ms 400}
-   {:label     "Session: child succeeds — :final + :on-done + auto-DESTROY"
-    :event     [:machine-epochs/finish-login]
-    :watch     "Cascade: drive the child to :final? → :on-done reports the token to the parent → child auto-destroys (exit-cascade-on-destroy + destroyed trace)."
-    :settle-ms 450}
+   {:label "Session: open — SPAWN child actor"
+    :event [:machine-epochs/send [[:session/flow [:session/open]]]]
+    :watch "Cascade: :idle ──► :authenticating spawns :session/login child; spawn fx renders; the instance spine spans parent + child."}
+   {:label "Session: child succeeds — :final + :on-done + auto-DESTROY"
+    :event [:machine-epochs/finish-login]
+    :watch "Cascade: drive the child to :final? → :on-done reports the token to the parent → child auto-destroys (exit-cascade-on-destroy + destroyed trace)."}
 
    ;; -- FUSE (THROW-ON-BOOT) — initial `:entry` action THROWS on lazy boot --
-   {:label     "Fuse: first event to :fuse/box — initial :entry THROWS on boot"
-    :event     [:machine-epochs/send [[:fuse/box [:fuse/short-circuit]]]]
-    :watch     "Epoch: the first event lazily boots :armed, whose :entry action :blow-fuse THROWS. EXCEPTION card (message + ex-data + coord) attributing the initial :entry action; event row IS pink; cascade-summary :outcome :error."
-    :settle-ms 400}
+   {:label "Fuse: first event to :fuse/box — initial :entry THROWS on boot"
+    :event [:machine-epochs/send [[:fuse/box [:fuse/short-circuit]]]]
+    :watch "Epoch: the first event lazily boots :armed, whose :entry action :blow-fuse THROWS. EXCEPTION card (message + ex-data + coord) attributing the initial :entry action; event row IS pink; cascade-summary :outcome :error."}
 
    ;; -- HVAC (DEEP-COMPOUND) — compound · LCA cascade · self-transitions --
-   {:label     "Hvac: power-cycle (parallel — BOTH regions, deep initial cascade)"
-    :event     [:machine-epochs/send [[:hvac/controller [:hvac/power-cycle]]]]
-    :watch     "Cascade: ONE event → :climate :idle──►:running (entry+initial cascade to [:running :conditioning :heating]) AND :fan :off──►:on."
-    :settle-ms 400}
-   {:label     "Hvac: mode-toggle (:heating ⇄ :cooling — multi-level LCA cascade)"
-    :event     [:machine-epochs/send [[:hvac/controller [:hvac/mode-toggle]]]]
-    :watch     "Cascade ORDER: exit :heating (deepest-first) → :swap-mode @ LCA :conditioning → entry :cooling (shallowest-first)."
-    :settle-ms 400}
-   {:label     "Hvac: nudge fan — EXTERNAL self-transition (:target :same-state)"
-    :event     [:machine-epochs/send [[:hvac/controller [:hvac/nudge]]]]
-    :watch     "Cascade: :fan :on re-enters itself — exit :fan-on → :nudge-fan → entry :fan-on; NO spurious {:on}→{:on} no-op row."
-    :settle-ms 400}
-   {:label     "Hvac: tweak fan — INTERNAL self-transition (omit :target)"
-    :event     [:machine-epochs/send [[:hvac/controller [:hvac/tweak]]]]
-    :watch     "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to the nudge; NO spurious no-op row."
-    :settle-ms 400}
+   {:label "Hvac: power-cycle (parallel — BOTH regions, deep initial cascade)"
+    :event [:machine-epochs/send [[:hvac/controller [:hvac/power-cycle]]]]
+    :watch "Cascade: ONE event → :climate :idle──►:running (entry+initial cascade to [:running :conditioning :heating]) AND :fan :off──►:on."}
+   {:label "Hvac: mode-toggle (:heating ⇄ :cooling — multi-level LCA cascade)"
+    :event [:machine-epochs/send [[:hvac/controller [:hvac/mode-toggle]]]]
+    :watch "Cascade ORDER: exit :heating (deepest-first) → :swap-mode @ LCA :conditioning → entry :cooling (shallowest-first)."}
+   {:label "Hvac: nudge fan — EXTERNAL self-transition (:target :same-state)"
+    :event [:machine-epochs/send [[:hvac/controller [:hvac/nudge]]]]
+    :watch "Cascade: :fan :on re-enters itself — exit :fan-on → :nudge-fan → entry :fan-on; NO spurious {:on}→{:on} no-op row."}
+   {:label "Hvac: tweak fan — INTERNAL self-transition (omit :target)"
+    :event [:machine-epochs/send [[:hvac/controller [:hvac/tweak]]]]
+    :watch "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to the nudge; NO spurious no-op row."}
 
    ;; -- HISTORY (LIVE, gap 8) — first-class shallow + deep restore (rf2-mle6e) --
-   {:label     "History: register a ROOT :history machine — REJECTED (placement)"
-    :event     [:machine-epochs/probe-history-rejection]
-    :watch     "History is FIRST-CLASS; a ROOT :type :history is still rejected :rf.error/machine-history-misplaced (a pseudo-state needs an owning compound)."
-    :settle-ms 350}
-   {:label     "History: SHALLOW restore (:media/shallow eject → re-insert)"
-    :event     [:machine-epochs/history-shallow-restore]
-    :watch     "Epoch: the :rf.machine.history/restored banner (source :recorded, SHALLOW); restored :entry steps chip 'from history'; restores the CHILD then its :initial."
-    :settle-ms 500}
-   {:label     "History: DEEP restore (:media/deep eject → re-insert)"
-    :event     [:machine-epochs/history-deep-restore]
-    :watch     "Epoch: the banner reads DEEP; the :entry steps descend to the EXACT recorded leaf [:player :playing :mid-track], each chipped 'from history'."
-    :settle-ms 500}])
+   {:label "History: register a ROOT :history machine — REJECTED (placement)"
+    :event [:machine-epochs/probe-history-rejection]
+    :watch "History is FIRST-CLASS; a ROOT :type :history is still rejected :rf.error/machine-history-misplaced (a pseudo-state needs an owning compound)."}
+   {:label "History: SHALLOW restore (:media/shallow eject → re-insert)"
+    :event [:machine-epochs/history-shallow-restore]
+    :watch "Epoch: the :rf.machine.history/restored banner (source :recorded, SHALLOW); restored :entry steps chip 'from history'; restores the CHILD then its :initial."}
+   {:label "History: DEEP restore (:media/deep eject → re-insert)"
+    :event [:machine-epochs/history-deep-restore]
+    :watch "Epoch: the banner reads DEEP; the :entry steps descend to the EXACT recorded leaf [:player :playing :mid-track], each chipped 'from history'."}])
 
 ;; ============================================================================
-;; RUNNER STATE — LOCAL ATOM (rf2-8pbjr: not app-db, not a 2nd frame)
+;; RUNNER WIRING (rf2-5sjbg) — register the deck's run-step event
 ;; ============================================================================
 
-(defonce runner-state (r/atom (runner/initial-state)))
+(runner/reg-runner! {:id         :machine-epochs/run-step
+                     :steps      steps
+                     :host-frame host-frame})
 
 ;; ============================================================================
 ;; VIEWS
@@ -497,7 +468,10 @@
      "Shows how xray displays state machine activity - particularly the Epoch panel."]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
      "Takes Four different state machines through various transitions"]]
-   [runner/runner "machine-epochs" runner-state steps host-frame]])
+   [runner/runner {:run-step-event :machine-epochs/run-step
+                   :steps          steps
+                   :prefix         "machine-epochs"
+                   :host-frame     host-frame}]])
 
 ;; ============================================================================
 ;; MOUNT

--- a/tools/xray/testbeds/managed_http/core.cljs
+++ b/tools/xray/testbeds/managed_http/core.cljs
@@ -4,14 +4,14 @@
 
   An operator visually inspects how the Xray panels (Epoch · Trace ·
   App-db · Machine Inspector) render the managed-HTTP lifecycle by
-  pressing ONE button (`▶ Run series`) and watching each interesting
-  step play out, with per-step commentary on what to look for. Title:
+  pressing ONE button (`⏭ Step`) and watching each interesting step play
+  out, with per-step commentary on what to look for. Title:
   `Xray Testbed: Managed HTTP`.
 
   ## What it exercises (Spec 014 — `:rf.http/managed` and family)
 
   The step vector (`steps`, below) is CODE DATA — a `def`ed vector of
-  step maps, each `{:event … :watch … :settle-ms …}`. It walks the
+  step maps, each `{:event … :watch … :label …}`. It walks the
   managed-HTTP lifecycle:
 
     1. Fire a request           — in-flight render (`:status :loading`,
@@ -33,14 +33,13 @@
                                   `abort-on-actor-destroy`
                                   (`:rf.http/aborted-on-actor-destroy`).
 
-  ## Runner state = LOCAL ATOM (rf2-8pbjr contract)
+  ## Runner cursor = app-db `:step` (rf2-5sjbg)
 
-  The runner cursor/phase lives in `runner-state` — a LOCAL Reagent atom
-  in THIS ns. It is NEVER written to the inspected app-db (that would
-  pollute the App-db panel under inspection) and is NOT a second frame
-  (only the inspected app frame, `:rf/default`, is Xray-relevant). After
-  each auto-advance dispatch the runner focuses the latest `:rf/default`
-  epoch so the operator sees the just-dispatched render.
+  The runner cursor lives in app-db's `:step` slot, written by
+  `runner.core`'s run-step event — NOT a Reagent atom. `:step` churning
+  every step IS the per-step App-db / Epoch delta the panels show. Each
+  step dispatches its lifecycle `:event` into `:rf/default`. The deck reads
+  as an ordinary re-frame2 app: app-db + events + subs.
 
   ## Real registry vs canned replies (deterministic, clean)
 
@@ -65,8 +64,7 @@
   (`re-frame.http-managed`) + its test-support (`re-frame.http-test-
   support` — a testbed IS a test affordance) + the shared `runner.core`.
   Nothing under `implementation/` requires this."
-  (:require [reagent.core :as r]
-            [reagent.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]
@@ -88,7 +86,6 @@
             [re-frame.http :as rf.http]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.interop :as interop]
             [day8.re-frame2-xray.config :as xray-config]
             [re-frame.testbed.config :as testbed-config]
             [runner.core :as runner])
@@ -104,15 +101,17 @@
 ;; APP-DB
 ;; ============================================================================
 ;;
-;; Minimal — :status is :idle | :loading | :done | :error; :reply carries
-;; the last reply for the operator to read in the DOM mirror; :log is a
-;; short narrative of the last lifecycle events. The Xray Epoch / Trace
-;; panels are the primary surface; the DOM strip is a standalone fall-back.
+;; Minimal — :step is the runner cursor (rf2-5sjbg, written by
+;; runner.core's run-step event; its churn IS the per-step delta); :status
+;; is :idle | :loading | :done | :error; :reply carries the last reply for
+;; the operator to read in the DOM mirror; :log is a short narrative of the
+;; last lifecycle events. The Xray Epoch / Trace panels are the primary
+;; surface; the DOM strip is a standalone fall-back.
 
 (rf/reg-event-db ::initialise
-  {:doc "Seed app-db: idle, no reply, empty log."}
+  {:doc "Seed app-db: no step yet, idle, no reply, empty log."}
   (fn [_db _ev]
-    {:status :idle :reply nil :log []}))
+    {:step nil :status :idle :reply nil :log []}))
 
 (defn- log-line [db line]
   (update db :log (fn [xs] (vec (take-last 8 (conj (or xs []) line))))))
@@ -346,10 +345,10 @@
     nil))
 
 (rf/reg-event-fx ::reset
-  {:doc "Re-seed app-db (idle, no reply, empty log) and clear the in-flight
-         registries. Start clean."}
+  {:doc "Re-seed app-db (no step, idle, no reply, empty log) and clear the
+         in-flight registries. Start clean."}
   (fn [_ctx _ev]
-    {:db {:status :idle :reply nil :log []}
+    {:db {:step nil :status :idle :reply nil :log []}
      :fx [[:managed-http/clear-registry]]}))
 
 ;; ============================================================================
@@ -361,55 +360,52 @@
 (rf/reg-sub ::log    (fn [db _] (:log db)))
 
 ;; ============================================================================
-;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
+;; THE STEP VECTOR — code data (the single source of truth)
 ;; ============================================================================
 ;;
-;; Each step: {:event [...] :watch "<what to look for>" :settle-ms N
-;;             :label "<short row label>"}. The runner renders :watch per
-;; STEP (per-occurrence narration, NOT a handler :doc), dispatches :event,
-;; focuses the latest :rf/default epoch, then waits :settle-ms before
-;; advancing. The fire-abortable step (5) seeds a pending request; the
-;; abort step (6) resolves it through the live :rf.http/managed-abort fx.
+;; Each step: {:event [...] :watch "<what to look for>" :label "<short row
+;; label>"}. The runner renders :watch per STEP; pressing Step (or a per-row
+;; RUN button) dispatches `[:managed-http/run-step n]`, which sets app-db
+;; `:step = n` (the per-step delta the panels show) and dispatches the
+;; step's lifecycle `:event` into `:rf/default`. The fire-abortable step (5)
+;; seeds a pending request; the abort step (6) resolves it through the live
+;; :rf.http/managed-abort fx. Manual stepping needs no pacing — the deferred
+;; replies land + render on their own schedule while the operator watches
+;; (rf2-5sjbg dropped the settle machinery).
 
 (def steps
-  [{:label     "Fire request (in-flight)"
-    :event     [::fire-in-flight]
-    :watch     "App-db diff: :status flips to :loading. In-flight registry strip: a pending request-id slot appears (the request is still in flight). Epoch: the fire cascade with NO reply child yet."
-    :settle-ms 700}
-   {:label     "Success response"
-    :event     [::success]
-    :watch     "Epoch: a two-event cascade — :rf.http/managed dispatch → reply lands at ::reply. App-db diff: :status :done, :reply :kind :success, :value decoded from api/ok.json."
-    :settle-ms 700}
-   {:label     "Error response (4xx)"
-    :event     [::error-4xx]
-    :watch     "Trace: an :operation :rf.http/http-4xx error row (:op-type :error, pink-wash on the event row). App-db: :status :error, reply :failure :kind :rf.http/http-4xx, :status 404."
-    :settle-ms 600}
-   {:label     "Error response (5xx)"
-    :event     [::error-5xx]
-    :watch     "Trace: an :operation :rf.http/http-5xx error row. App-db diff: reply :failure :kind :rf.http/http-5xx, :status 500. The Epoch shows the failure cascade attribution."
-    :settle-ms 600}
-   {:label     "Abort: fire an abortable request"
-    :event     [::fire-abortable]
-    :watch     ":status :loading; the in-flight registry strip gains another pending slot. The request stays in flight — the NEXT step aborts it before any reply lands."
-    :settle-ms 500}
-   {:label     "Abort the in-flight request"
-    :event     [::abort]
-    :watch     "Trace/Epoch: the live :rf.http/managed-abort fx resolves the handle → its abort-fn dispatches the :rf.http/aborted reply + clears the slot. App-db: :status :error, reply :kind :failure (:rf.http/aborted). In-flight strip: the abortable slot is gone."
-    :settle-ms 700}
-   {:label     "Concurrent requests by same actor"
-    :event     [::concurrent-by-actor]
-    :watch     "Actor-in-flight strip: actor-a now carries TWO pending entries, actor-b ONE (Spec 014 §Abort on actor destroy). Epoch: the fan-out cascade of three issue fxs."
-    :settle-ms 700}
-   {:label     "Request outlives a frame teardown"
-    :event     [::actor-teardown]
-    :watch     "Trace: two :rf.http/aborted-on-actor-destroy rows for actor-a's outliving requests. Actor-in-flight strip: actor-a's slot is GONE; actor-b's pending entry remains."
-    :settle-ms 700}])
+  [{:label "Fire request (in-flight)"
+    :event [::fire-in-flight]
+    :watch "App-db diff: :status flips to :loading. In-flight registry strip: a pending request-id slot appears (the request is still in flight). Epoch: the fire cascade with NO reply child yet."}
+   {:label "Success response"
+    :event [::success]
+    :watch "Epoch: a two-event cascade — :rf.http/managed dispatch → reply lands at ::reply. App-db diff: :status :done, :reply :kind :success, :value decoded from api/ok.json."}
+   {:label "Error response (4xx)"
+    :event [::error-4xx]
+    :watch "Trace: an :operation :rf.http/http-4xx error row (:op-type :error, pink-wash on the event row). App-db: :status :error, reply :failure :kind :rf.http/http-4xx, :status 404."}
+   {:label "Error response (5xx)"
+    :event [::error-5xx]
+    :watch "Trace: an :operation :rf.http/http-5xx error row. App-db diff: reply :failure :kind :rf.http/http-5xx, :status 500. The Epoch shows the failure cascade attribution."}
+   {:label "Abort: fire an abortable request"
+    :event [::fire-abortable]
+    :watch ":status :loading; the in-flight registry strip gains another pending slot. The request stays in flight — the NEXT step aborts it before any reply lands."}
+   {:label "Abort the in-flight request"
+    :event [::abort]
+    :watch "Trace/Epoch: the live :rf.http/managed-abort fx resolves the handle → its abort-fn dispatches the :rf.http/aborted reply + clears the slot. App-db: :status :error, reply :kind :failure (:rf.http/aborted). In-flight strip: the abortable slot is gone."}
+   {:label "Concurrent requests by same actor"
+    :event [::concurrent-by-actor]
+    :watch "Actor-in-flight strip: actor-a now carries TWO pending entries, actor-b ONE (Spec 014 §Abort on actor destroy). Epoch: the fan-out cascade of three issue fxs."}
+   {:label "Request outlives a frame teardown"
+    :event [::actor-teardown]
+    :watch "Trace: two :rf.http/aborted-on-actor-destroy rows for actor-a's outliving requests. Actor-in-flight strip: actor-a's slot is GONE; actor-b's pending entry remains."}])
 
 ;; ============================================================================
-;; RUNNER STATE — LOCAL ATOM (rf2-8pbjr: not app-db, not a 2nd frame)
+;; RUNNER WIRING (rf2-5sjbg) — register the deck's run-step event
 ;; ============================================================================
 
-(defonce runner-state (r/atom (runner/initial-state)))
+(runner/reg-runner! {:id         :managed-http/run-step
+                     :steps      steps
+                     :host-frame host-frame})
 
 ;; ============================================================================
 ;; VIEWS
@@ -475,16 +471,19 @@
     [:h2 {:data-testid "managed-http-title" :style {:margin 0}}
      "Xray Testbed: Managed HTTP"]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "One button (" [:strong "▶ Run series"] ") walks the managed-HTTP "
+     "One button (" [:strong "⏭ Step"] ") walks the managed-HTTP "
      "lifecycle — fire · success · 4xx · 5xx · abort · concurrent-by-actor · "
-     "request-outlives-teardown. After each dispatch the runner pins Xray "
-     "focus to the latest " [:code ":rf/default"] " epoch; read each step's "
+     "request-outlives-teardown (each row's number is also a "
+     [:strong "RUN-THIS-STEP"] " button for random access). Read each step's "
      [:strong "Watch"] " note, then watch the Epoch / Trace / App-db / "
-     "Machine panels render it. The runner cursor lives in a "
-     [:strong "local atom"] " — it never touches the inspected app-db."]]
+     "Machine panels render it. The runner cursor is "
+     [:strong ":step"] " in app-db — driven by events + subs, no harness atom."]]
    [status-strip]
    [in-flight-strip]
-   [runner/runner "managed-http" runner-state steps host-frame]])
+   [runner/runner {:run-step-event :managed-http/run-step
+                   :steps          steps
+                   :prefix         "managed-http"
+                   :host-frame     host-frame}]])
 
 ;; ============================================================================
 ;; MOUNT

--- a/tools/xray/testbeds/routes_epochs/core.cljs
+++ b/tools/xray/testbeds/routes_epochs/core.cljs
@@ -14,9 +14,9 @@
   this deck supplies a `steps` vector (CODE DATA) + the testid prefix
   `routes-epochs`. Each step DISPATCHES one event that
 
-    (a) bumps a shared baseline counter (so App-db / Epoch always show a
-        delta on every step), and
-    (b) exercises exactly ONE additional ROUTING feature.
+    (a) lands on the run-step epoch as the `:step` app-db delta the panels
+        show (the runner sets `:step = n`), and
+    (b) exercises exactly ONE additional ROUTING feature via a child dispatch.
 
   Replaces the bespoke numbered-button ladder (`routes-epochs-rung-<n>`):
   same events, same routing features, same coverage — but driven by the
@@ -72,14 +72,13 @@
     #11 guarded/blocked nav — a `:can-leave` guard refuses; outcome
                              `blocked` + `:rf/pending-navigation` is set.
 
-  ## Runner state = LOCAL ATOM (rf2-8pbjr contract)
+  ## Runner cursor = app-db `:step` (rf2-5sjbg)
 
-  The runner cursor / status / pace live in `runner-state` — a LOCAL
-  Reagent atom in THIS ns. It is NEVER written to the inspected app-db
-  (that would pollute the App-db / Routing panels under inspection) and is
-  NOT a second frame (only the inspected app frame, `:rf/default`, is
-  Xray-relevant). A Step / per-step click is manual (operator-driven focus
-  — the runner does not pin focus).
+  The runner cursor lives in app-db's `:step` slot, written by
+  `runner.core`'s run-step event. `:step` churning every step IS the
+  per-step App-db / Epoch delta the panels show (it REPLACES the old
+  `:baseline` counter — same thing). The deck reads as an ordinary
+  re-frame2 app: app-db + events + subs, NO Reagent atom for step state.
 
   ## Test surface, not tutorial
 
@@ -97,8 +96,7 @@
   runner's per-step RUN-THIS-STEP buttons). The routes / events / subs /
   views below are OWNED here — this deck does NOT reuse the shared
   `testdeck.*` modules."
-  (:require [reagent.core :as r]
-            [reagent.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Routing artefact — load-time hook so `reg-route`,
             ;; `:rf.route/navigate`, the `:rf.route/*` subs and
@@ -114,9 +112,10 @@
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared queued-step runner (rf2-8pbjr pilot). This deck
-            ;; supplies a `steps` vector + the testid prefix; the runner
-            ;; drives the ONE-button series + the per-step RUN buttons.
+            ;; The shared step-driver runner (rf2-5sjbg). This deck supplies
+            ;; a `steps` vector + registers `:routes-epochs/run-step` via
+            ;; `runner/reg-runner!`; the runner drives the ONE-button series
+            ;; + the per-step RUN buttons off app-db `:step`.
             [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -204,14 +203,15 @@
 ;; APP-DB SEED
 ;; ============================================================================
 ;;
-;; `:baseline` is the shared counter every step bumps (so App-db / Epoch
-;; always show a delta). `:articles` feeds the params / nested-route
-;; targets. `:profile` is the slot the route-driven loader (step #8)
-;; fills from the route params. `:settings-dirty?` arms the `:can-leave`
-;; guard (step #11).
+;; `:step` is the runner cursor (rf2-5sjbg) — the index of the last-run
+;; step, written by `runner.core`'s run-step event; its churn every step IS
+;; the per-step App-db / Epoch delta (it REPLACES the old `:baseline`
+;; counter). `:articles` feeds the params / nested-route targets.
+;; `:profile` is the slot the route-driven loader (step #8) fills from the
+;; route params. `:settings-dirty?` arms the `:can-leave` guard (step #11).
 
 (def initial-db
-  {:baseline        0
+  {:step            nil
    :articles        [{:id "intro" :title "Intro to re-frame2 routing"}
                      {:id "nested" :title "Nested routes & the route tree"}]
    :profile         nil
@@ -224,25 +224,21 @@
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
 
 ;; ============================================================================
-;; A small shared helper: every ladder event bumps the baseline counter.
+;; A reusable navigate driver
 ;; ============================================================================
 ;;
 ;; The routing events themselves are FRAMEWORK events (`:rf.route/navigate`
-;; etc.) we cannot edit, so each rung is a thin deck-owned event-fx that
-;; (a) bumps `:baseline` via `:db` and (b) dispatches the routing
-;; event/fx. The Epoch / App-db delta on every step comes from the bump;
-;; the Routing panel lights up from the dispatched routing event.
+;; etc.), so each rung is a thin deck-owned event-fx that dispatches the
+;; routing event/fx. The per-step App-db / Epoch delta is the runner's
+;; `:step` write on the parent run-step epoch; the Routing panel lights up
+;; from the dispatched routing event.
 
-(defn- bump [db] (update db :baseline inc))
-
-;; A reusable "bump + navigate" event-fx: every navigation rung routes
-;; through here so the baseline delta and the navigation are one cascade.
+;; A reusable navigate event-fx: every navigation rung routes through here.
 (rf/reg-event-fx :routes-epochs/go
-  {:doc "Bump the baseline and dispatch `:rf.route/navigate` with the
-         supplied target / params / opts. The shared driver behind every
-         navigation rung."}
+  {:doc "Dispatch `:rf.route/navigate` with the supplied target / params /
+         opts. The shared driver behind every navigation rung."}
   (fn handler-go [{:keys [db]} [_ target params opts]]
-    {:db (bump db)
+    {:db db
      :fx [[:dispatch [:rf.route/navigate target params (or opts {})]]]}))
 
 ;; ============================================================================
@@ -254,7 +250,7 @@
          `:on-match`. Re-navigates to home so the slice lands on a
          DIFFERENT route one cascade later."}
   (fn handler-redirect [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
 
 (rf/reg-event-db :routes-epochs/load-profile
@@ -264,7 +260,7 @@
          transition runs :loading → :idle around this loader)."}
   (fn handler-load-profile [db _ev]
     (let [user (get-in db [:rf/runtime :routing :current :params :user])]
-      (-> db bump (assoc :profile {:user user :loaded-at-baseline (:baseline db)})))))
+      (assoc db :profile {:user user :loaded-at-step (:step db)}))))
 
 ;; ============================================================================
 ;; GUARDED NAV (#10/#11) — a :can-leave gate
@@ -284,7 +280,7 @@
   {:doc "Step #10 — navigate INTO settings AND arm the dirty flag, so
          the `:can-leave` guard will block the next attempt to leave."}
   (fn handler-enter-dirty [{:keys [db]} _ev]
-    {:db (-> db bump (assoc :settings-dirty? true))
+    {:db (assoc db :settings-dirty? true)
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/settings]]]}))
 
 (rf/reg-event-fx :routes-epochs/try-leave-settings
@@ -292,7 +288,7 @@
          `:can-leave` guard refuses: the slice stays on settings, the
          outcome reads `blocked`, and `:rf/pending-navigation` fills."}
   (fn handler-try-leave [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
 
 ;; ============================================================================
@@ -309,7 +305,7 @@
          url-change back to the articles list (a popstate-style
          transition). NAVIGATION THIS EPOCH's FROM ──► TO reverses."}
   (fn handler-back [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx [[:dispatch [:rf.route/handle-url-change "/articles"]]]}))
 
 ;; ============================================================================
@@ -318,23 +314,23 @@
 ;;
 ;; The framework ships `:rf.route/id`, `:rf.route/params`, `:rf.route/query`,
 ;; `:rf.route/transition`, `:rf.route/chain` and `:rf/pending-navigation`.
-;; The deck only needs a couple of app-db reads for its own status strip.
+;; The deck only needs one app-db read for its own status strip.
 
-(rf/reg-sub :routes-epochs/baseline (fn [db _] (:baseline db)))
 (rf/reg-sub :routes-epochs/profile  (fn [db _] (:profile db)))
 
 ;; ============================================================================
-;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
+;; THE STEP VECTOR — code data (the single source of truth)
 ;; ============================================================================
 ;;
-;; Each step: {:event [...] :watch "<what to look for>" :settle-ms N
-;;             :label "<short row label>"}. The runner renders :watch per
-;; STEP (per-occurrence narration), dispatches :event, then waits
-;; :settle-ms before advancing. Navigation cascades through
-;; `:routes-epochs/go` (bump + :rf.route/navigate) settle quickly — a
-;; short pause is enough for the navigation cascade + the Routing panel to
-;; render before the next step. Redirect (#6) is given a longer settle
-;; because its `:on-match` fires a SECOND navigation cascade.
+;; Each step: {:event [...] :watch "<what to look for>" :label "<short row
+;; label>"}. The runner renders :watch per STEP; pressing Step (or a per-row
+;; RUN button) dispatches `[:routes-epochs/run-step n]`, which sets app-db
+;; `:step = n` (the per-step delta the panels show) and dispatches the
+;; step's `:event` into the host-frame. Navigation cascades through
+;; `:routes-epochs/go` (→ :rf.route/navigate); the redirect step (#6) fires a
+;; SECOND navigation cascade via its route's `:on-match`. Manual stepping
+;; needs no pacing — each cascade fires + renders while the operator watches
+;; (rf2-5sjbg dropped the settle machinery).
 ;;
 ;; The ladder order matches the historical numbered rungs 1..11 (1-based):
 ;; step index 0 = rung #1, step index N-1 = rung #N. The feature-matrix
@@ -343,64 +339,55 @@
 
 (def steps
   [;; -- Navigation basics — CURRENT ROUTE + NAVIGATION THIS EPOCH --
-   {:label     "navigate / push"
-    :event     [:routes-epochs/go :routes-epochs/home]
-    :watch     "CURRENT ROUTE → :home · NAVIGATION ──► home · outcome transitioned. The ROUTE TABLE paints the :to overlay on the home row."
-    :settle-ms 400}
-   {:label     "replace (no history push)"
-    :event     [:routes-epochs/go :routes-epochs/home nil {:replace? true}]
-    :watch     "Same slice write via :replace? true (:rf.nav/replace-url, no history push) — the slice lands on :home without a back-stack entry."
-    :settle-ms 400}
+   {:label "navigate / push"
+    :event [:routes-epochs/go :routes-epochs/home]
+    :watch "CURRENT ROUTE → :home · NAVIGATION ──► home · outcome transitioned. The ROUTE TABLE paints the :to overlay on the home row."}
+   {:label "replace (no history push)"
+    :event [:routes-epochs/go :routes-epochs/home nil {:replace? true}]
+    :watch "Same slice write via :replace? true (:rf.nav/replace-url, no history push) — the slice lands on :home without a back-stack entry."}
 
    ;; -- Params & query — the slice carries params / query --
-   {:label     "route params (/articles/:id)"
-    :event     [:routes-epochs/go :routes-epochs/article {:id "intro"}]
-    :watch     "CURRENT ROUTE → :article · params {:id \"intro\"} · NAVIGATION ──► :article · transitioned."
-    :settle-ms 400}
-   {:label     "query params (?q&sort)"
-    :event     [:routes-epochs/go :routes-epochs/search nil {:query {:q "routing" :sort "asc"}}]
-    :watch     "CURRENT ROUTE → :search · query {:q \"routing\" :sort \"asc\"} (the :rf.route/query slice)."
-    :settle-ms 400}
+   {:label "route params (/articles/:id)"
+    :event [:routes-epochs/go :routes-epochs/article {:id "intro"}]
+    :watch "CURRENT ROUTE → :article · params {:id \"intro\"} · NAVIGATION ──► :article · transitioned."}
+   {:label "query params (?q&sort)"
+    :event [:routes-epochs/go :routes-epochs/search nil {:query {:q "routing" :sort "asc"}}]
+    :watch "CURRENT ROUTE → :search · query {:q \"routing\" :sort \"asc\"} (the :rf.route/query slice)."}
 
    ;; -- ROUTE TABLE — nested tree, redirect, fallback --
-   {:label     "nested route (under :articles)"
-    :event     [:routes-epochs/go :routes-epochs/article {:id "nested"}]
-    :watch     "ROUTE TABLE indents :article under :articles (deeper padding-left) · the destination :to overlay paints on the :article row this navigation epoch."
-    :settle-ms 400}
-   {:label     "redirect (:on-match re-navigates)"
-    :event     [:routes-epochs/go :routes-epochs/old-home]
-    :watch     "Navigate :old-home → its :on-match re-navigates, landing the slice on :home one cascade later. Epoch: the two-navigation cascade."
-    :settle-ms 600}
-   {:label     "not-found / fallback"
-    :event     [:routes-epochs/go {:url "/no-such-page"}]
-    :watch     "Unmatched URL → CURRENT ROUTE :rf.route/not-found · NAVIGATION ──► the registered :rf.route/not-found fallback."
-    :settle-ms 400}
+   {:label "nested route (under :articles)"
+    :event [:routes-epochs/go :routes-epochs/article {:id "nested"}]
+    :watch "ROUTE TABLE indents :article under :articles (deeper padding-left) · the destination :to overlay paints on the :article row this navigation epoch."}
+   {:label "redirect (:on-match re-navigates)"
+    :event [:routes-epochs/go :routes-epochs/old-home]
+    :watch "Navigate :old-home → its :on-match re-navigates, landing the slice on :home one cascade later. Epoch: the two-navigation cascade."}
+   {:label "not-found / fallback"
+    :event [:routes-epochs/go {:url "/no-such-page"}]
+    :watch "Unmatched URL → CURRENT ROUTE :rf.route/not-found · NAVIGATION ──► the registered :rf.route/not-found fallback."}
 
    ;; -- Loaders & transitions — :on-match drives app-db --
-   {:label     "route-driven app-db (:on-match loader)"
-    :event     [:routes-epochs/go :routes-epochs/profile {:user "ada"}]
-    :watch     "Navigate :profile → :on-match writes :profile from params · App-db gains :profile {:user \"ada\" ..} · transition :loading→:idle."
-    :settle-ms 500}
-   {:label     "back / forward (popstate)"
-    :event     [:routes-epochs/back]
-    :watch     "Emulate Back → :articles · NAVIGATION THIS EPOCH's FROM ──► TO reverses relative to the forward navigation."
-    :settle-ms 400}
+   {:label "route-driven app-db (:on-match loader)"
+    :event [:routes-epochs/go :routes-epochs/profile {:user "ada"}]
+    :watch "Navigate :profile → :on-match writes :profile from params · App-db gains :profile {:user \"ada\" ..} · transition :loading→:idle."}
+   {:label "back / forward (popstate)"
+    :event [:routes-epochs/back]
+    :watch "Emulate Back → :articles · NAVIGATION THIS EPOCH's FROM ──► TO reverses relative to the forward navigation."}
 
    ;; -- Guarded navigation — :can-leave blocks --
-   {:label     "enter dirty settings (arm the guard)"
-    :event     [:routes-epochs/enter-dirty-settings]
-    :watch     "Navigate INTO :settings + arm :settings-dirty? so the :can-leave guard will block the next attempt to leave."
-    :settle-ms 400}
-   {:label     "try to leave (blocked by :can-leave)"
-    :event     [:routes-epochs/try-leave-settings]
-    :watch     "Attempt → home FROM dirty settings · the guard refuses · CURRENT ROUTE STAYS :settings · outcome blocked · :rf/pending-navigation fills."
-    :settle-ms 400}])
+   {:label "enter dirty settings (arm the guard)"
+    :event [:routes-epochs/enter-dirty-settings]
+    :watch "Navigate INTO :settings + arm :settings-dirty? so the :can-leave guard will block the next attempt to leave."}
+   {:label "try to leave (blocked by :can-leave)"
+    :event [:routes-epochs/try-leave-settings]
+    :watch "Attempt → home FROM dirty settings · the guard refuses · CURRENT ROUTE STAYS :settings · outcome blocked · :rf/pending-navigation fills."}])
 
 ;; ============================================================================
-;; RUNNER STATE — LOCAL ATOM (rf2-8pbjr: not app-db, not a 2nd frame)
+;; RUNNER WIRING (rf2-5sjbg) — register the deck's run-step event
 ;; ============================================================================
 
-(defonce runner-state (r/atom (runner/initial-state)))
+(runner/reg-runner! {:id         :routes-epochs/run-step
+                     :steps      steps
+                     :host-frame host-frame})
 
 ;; ============================================================================
 ;; VIEWS
@@ -440,16 +427,19 @@
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
      "One frame, one routing ladder. One button (" [:strong "⏭ Step"] ") "
      "walks the rungs top to bottom (each row's number is also a "
-     [:strong "RUN-THIS-STEP"] " button for random access). Each step bumps "
-     "a shared " [:strong "baseline"] " counter (so App-db / Epoch always "
+     [:strong "RUN-THIS-STEP"] " button for random access). Each step sets "
+     "the " [:strong ":step"] " cursor in app-db (so App-db / Epoch always "
      "show a delta) and exercises exactly one more routing feature. Read "
      "each step's " [:strong "Watch"] " note, then watch Xray's "
      [:strong "Routing"] " panel on the right — its three sections (Current "
      "route · Navigation this epoch · Route table) light up across the "
-     "ladder. The runner cursor lives in a " [:strong "local atom"] " — it "
-     "never touches the inspected app-db."]]
+     "ladder. The runner cursor is " [:strong ":step"] " in app-db — driven "
+     "by events + subs, no harness atom."]]
    [current-route-strip]
-   [runner/runner "routes-epochs" runner-state steps host-frame]])
+   [runner/runner {:run-step-event :routes-epochs/run-step
+                   :steps          steps
+                   :prefix         "routes-epochs"
+                   :host-frame     host-frame}]])
 
 ;; ============================================================================
 ;; ROUTER WIRING

--- a/tools/xray/testbeds/runner/core.cljs
+++ b/tools/xray/testbeds/runner/core.cljs
@@ -1,103 +1,86 @@
 (ns runner.core
-  "SHARED queued-step RUNNER for Xray testbeds (rf2-8pbjr — the pilot
-  redesign). A reusable harness an Xray testbed mounts to drive a
-  series of INTERESTING events through ONE button while an operator
-  watches how the Xray panels (Epoch · Machine Inspector · edn-inspector
-  · Trace · …) render each step, with per-step commentary on WHAT TO
-  LOOK FOR.
+  "SHARED step-driver RUNNER for Xray testbeds (rf2-5sjbg — the app-db /
+  events / subs rewrite of the rf2-8pbjr pilot). A reusable harness an
+  Xray testbed mounts to drive a series of INTERESTING events through ONE
+  button while an operator watches how the Xray panels (Epoch · Machine
+  Inspector · edn-inspector · Trace · …) render each step, with per-step
+  commentary on WHAT TO LOOK FOR.
 
-  ## The shape (the settled contract — rf2-8pbjr DESCRIPTION is authoritative)
+  ## The shape — a proper re-frame2 step driver (rf2-5sjbg)
 
-  - **Step vector = CODE DATA.** A testbed `def`s a vector of step maps;
-    each step is
+  The runner is NOT a harness around a Reagent atom. It is an ordinary
+  re-frame2 app surface: the cursor lives in **app-db** (`:step`), it is
+  moved by an **event** (`[:run-step n]`), and the views render off a
+  **subscription** (`:rf.runner/step`). There is NO Reagent atom for step
+  state, no timer, no settle/auto-advance machinery.
 
-        {:event    [:some/event ...]   ; the event to dispatch
-         :watch     \"what to look for in Epoch / Inspector / …\"
-         :settle-ms 600                ; POST-dispatch pause (ms) so machine
-                                       ;   :after timers + cascades fire
-                                       ;   BEFORE advancing
-         :before-ms 0                  ; OPTIONAL pre-dispatch pause (ms);
-                                       ;   default 0 — only when a step
-                                       ;   explicitly needs to settle the
-                                       ;   PREVIOUS render first
-         :label     \"Fire request\"}  ; OPTIONAL short row label (defaults
-                                       ;   to the event-id)
+  - **`:step` lives in app-db.** A deck's app-db carries a top-level
+    `:step` slot — the index of the LAST-RUN step (or nil before the
+    first step). `:step` changing every step IS the per-step app-db delta
+    the panels show, so it doubles as the deck's per-step counter (it
+    REPLACES the old `:baseline` counter and the old runner-atom cursor —
+    they were the same thing, 'which step are we on'). The cursor in
+    app-db is legitimate deck state, observable in Xray's App-db panel,
+    not pollution.
 
-    `:watch` is PER-OCCURRENCE narration — it lives on the STEP, not on
-    any handler `:doc` (the same event type can appear several times
-    with different watch notes).
+  - **`[:run-step n]` is an event.** A deck registers its own run-step
+    event with `reg-runner!`; the handler `assoc`s `:step = n` into app-db
+    AND fans out the step's `:event`(s) as `:fx :dispatch`es into the
+    deck's host-frame. For a single-event step that is one child dispatch;
+    a deck whose step `:event` is itself a fan-out driver (e.g.
+    `:machine-epochs/send` dispatching several machine events) cascades
+    naturally. The same `assoc :step` delta + the dispatched event(s) are
+    one cascade under the run-step epoch.
 
-  - **Post-dispatch settle.** For each step the runner: renders `:watch`
-    → (optional `:before-ms` pause) → DISPATCHES `:event` → FOCUSES the
-    latest host-frame epoch → WAITS `:settle-ms` → advances. The wait is
-    AFTER the dispatch so a machine `:after` timer / a deferred HTTP
-    reply / a fan-out cascade has fired and rendered before the operator
-    is moved on.
+  - **`:rf.runner/step` is a subscription.** The shared `:rf.runner/step`
+    sub reads `:step` from the current frame's app-db. It drives the row
+    HIGHLIGHT + the 'step n / total' counter — so at rest the highlighted
+    row matches the focused epoch (the just-run step). Before the first
+    step `:step` is nil → no row highlighted, the counter reads 'step 0'.
 
-  - **Runner state = LOCAL ATOM ONLY.** The cursor / status / pace live
-    in a LOCAL Reagent atom OWNED by the testbed (passed in). It is NEVER
-    written to the inspected app-db (that would pollute the very panels
-    under inspection) and is NOT a Reagent atom that lives in a separate
-    re-frame FRAME — it is a plain component-local atom, invisible to
-    Xray's frame surfaces. A deck supplies ONE atom per runner mount; a
-    deck that mounts the runner more than once (the two-frame isolation
-    testbed mounts the standard-epochs deck once per `:above` / `:below`
-    frame) supplies a DISTINCT local atom per mount, so the two cursors
-    are genuinely independent.
+  - **Step button + per-step addressing.** The control bar is ONE purple
+    Step button (`<prefix>-step`) that dispatches `[:run-step (inc
+    current)]` — the NEXT step, wrapping to 0 once it runs off the end.
+    Every rendered step row carries a stable, unique `data-testid`
+    (`<prefix>-step-<n>`); each row's index is ALSO a clickable
+    RUN-THIS-STEP button (`<prefix>-step-<n>-run`) that dispatches
+    `[:run-step n]` directly — RANDOM-ACCESS addressing alongside the
+    sequential Step control. A deck whose feature-matrix assertions need
+    to re-drive a NAMED step out of cursor order names each step through
+    that button.
 
-  - **Dispatch is scoped to `host-frame`.** Each step dispatches with an
-    explicit `{:frame host-frame}` opt (see `dispatch+settle!`). A runner
-    control's `on-click` fires OUTSIDE the React frame-provider context,
-    so an un-targeted `(rf/dispatch event)` would land on the ambient
-    `(current-frame-id)` — fine for a single-frame deck (host-frame =
-    `:rf/default`), wrong for a multi-frame mount. Targeting `host-frame`
-    keeps each runner's events scoped to the frame it inspects — the
-    load-bearing rule that lets the two-frame deck stay isolated.
-
-  - **Xray focus (manual).** The Step / per-step-run controls dispatch
-    WITHOUT moving focus — the operator drives the spine themselves and
-    reads the panels at their own pace. (The dispatch engine still carries
-    an `:auto?` focus-pin opt via `day8.re-frame2-xray.focus/focus!` for a
-    future caller that wants it, but no control sets it today.)
-
-  - **One Step button + per-step addressing.** The control bar is ONE
-    purple Step button (`<prefix>-step`) that dispatches the next step at
-    the cursor and advances. Every rendered step row carries a stable,
-    unique `data-testid` (`<prefix>-step-<n>`); each row's index is ALSO a
-    clickable RUN-THIS-STEP button (`<prefix>-step-<n>-run`) that drives
-    that step directly via `run-step-at!` — RANDOM-ACCESS addressing
-    alongside the sequential Step control. The prefix is the testbed's,
-    passed via `opts`. A deck whose feature-matrix assertions need to
-    re-drive a NAMED step out of cursor order (a routing / machine ladder
-    asserting a panel render after a specific rung) names each step
-    through that button rather than keeping a parallel bespoke button
-    ladder. The HIGHLIGHT + status counter render off the LAST-DISPATCHED
-    step (`:active`), so at rest they match the focused epoch — the step
-    whose result is on screen — not the next-to-run cursor.
+  - **`host-frame` is a CONFIG input, never a view arg.** The runner must
+    know which frame it drives (single-frame `:rf/default` vs the
+    two-frame isolation deck's `:above` / `:below`) so `[:run-step]`'s
+    fan-out `:dispatch`es land in the right frame. With per-frame app-db
+    this is naturally isolated: the same deck mounted in two frames
+    evolves two independent `:step` slots. A runner control's `on-click`
+    fires OUTSIDE the React frame-provider context, so an un-targeted
+    `(rf/dispatch [:run-step n])` would land on the ambient
+    `(current-frame-id)` — fine for a single-frame deck, wrong for a
+    two-frame mount. The Step / per-row buttons therefore dispatch the
+    run-step event with an explicit `{:frame host-frame}` opt, and the
+    handler's child `:dispatch`es target `host-frame` too. host-frame is
+    passed to the runner VIEW only so its buttons can scope their
+    `dispatch`; it is NOT threaded down to any leaf row (the leaf gets a
+    bound 0-arg thunk).
 
   ## Why a shared ns (the rollout vehicle)
 
-  This namespace is the reference RUNNER the managed-http testbed
-  (rf2-6nolv) was the FIRST consumer of. It has since been rolled across
-  the numbered-button decks (machine_epochs, edn_inspector — rf2-rrqku;
-  routes_epochs, standard_epochs — rf2-3xakq); the standard-epochs deck
-  is mounted twice by the two_frame_isolation testbed with a distinct
-  per-frame atom + host-frame. Keeping the runner here, in a testbed-
-  shared location, makes each adoption a pure one — a deck supplies its
-  own step vector + prefix + host-frame and drops its bespoke ladder
-  driver.
+  This namespace is the reference RUNNER all six numbered-button decks
+  consume — standard_epochs, routes_epochs, machine_epochs, edn_inspector,
+  managed_http, and (via standard-epochs mounted twice) two_frame_isolation.
+  The shared dependency makes the app-db/events/subs API atomic by
+  construction: every deck adopts it together. A deck supplies its own
+  step vector + prefix + host-frame via `reg-runner!` and drops its bespoke
+  ladder driver.
 
   ## Boundaries (bundle isolation)
 
   Lives under `tools/xray/testbeds/`; `:require`s only `re-frame.core`
-  (the public API), Reagent, and `day8.re-frame2-xray.focus` (the host-
-  facing focus command — already the Story→Xray focus channel). Nothing
-  under `implementation/` requires this; it is a dev testbed surface."
-  (:require [reagent.core :as r]
-            [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [day8.re-frame2-xray.focus :as xray-focus]
-            [day8.re-frame2-xray.defaults :as xray-defaults])
+  (the public API). Nothing under `implementation/` requires this; it is a
+  dev testbed surface."
+  (:require [re-frame.core :as rf])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -110,237 +93,101 @@
   [{:keys [label event]}]
   (or label (pr-str (first event))))
 
-;; ============================================================================
-;; FOCUS — the pinned 'show the just-dispatched render' contract
-;; ============================================================================
-
-(defn focus-latest-host-epoch!
-  "Focus the LATEST epoch on `host-frame` in the embedded Xray surface,
-  so the operator sees the render the just-dispatched event produced.
-
-  Reads the frame's epoch ring via the public `re-frame.core/epoch-
-  history` (oldest-first; the HEAD is the most recent — `(peek …)`),
-  pulls its `:epoch-id`, and sends a `day8.re-frame2-xray.focus/focus!`
-  command `{:frame host-frame :epoch-id <latest>}`. Degrades to a no-op
-  when there is no recorded epoch yet (empty ring) or the epoch artefact
-  is absent (`epoch-history` returns an empty vector).
-
-  This is the ONE place the runner reaches into Xray — through the same
-  host-facing focus channel Story uses, not a bespoke spine poke."
-  [host-frame]
-  (let [history   (rf/epoch-history host-frame)
-        latest-id (:epoch-id (peek (vec history)))]
-    (when (some? latest-id)
-      (xray-focus/focus! host-frame {:frame    host-frame
-                                     :epoch-id latest-id
-                                     :panel    :epoch}))))
+(defn- step-events
+  "The machine/app event(s) a step dispatches. A step carries a single
+  `:event` (one event vector); the run-step handler fans it out as one
+  child `:dispatch`. Returns a one-element seq so the handler's fan-out is
+  uniform (a step that itself drives several machines does so via its OWN
+  event-fx, e.g. `:machine-epochs/send`)."
+  [{:keys [event]}]
+  (when event [event]))
 
 ;; ============================================================================
-;; THE SETTLE ENGINE — post-dispatch settle, local-atom cursor
+;; THE STEP DRIVER — app-db `:step`, a run-step event, a step sub
 ;; ============================================================================
 ;;
-;; `state` is the LOCAL runner atom (a Reagent atom owned by the testbed).
-;; Its shape:
-;;   {:cursor <int>        ; index of the NEXT step to run (0..count) — the
-;;                         ;   engine's write cursor
-;;    :active <int|nil>    ; index of the LAST-DISPATCHED step, or nil before
-;;                         ;   the first step. The ROW HIGHLIGHT + the status
-;;                         ;   counter render off THIS, so at rest the
-;;                         ;   highlighted row matches the focused epoch (the
-;;                         ;   just-run step), not the next-to-run cursor.
-;;    :phase  <kw>         ; :idle | :before | :dispatched | :settling | :done
-;;    :timer  <handle>}    ; the in-flight settle/before timer
-;;
-;; `:active` (not `:cursor`) drives the row highlight + counter; nothing here
-;; touches app-db.
+;; `:step` is a TOP-LEVEL app-db slot: the index of the last-run step (or
+;; nil before the first step). The run-step event `assoc`s it and fans out
+;; the step's event(s) into `host-frame`. The `:rf.runner/step` sub reads
+;; it back to drive the highlight + counter. Nothing here is a Reagent atom
+;; or a timer.
 
-(defn- clear-timer!
-  [state]
-  (when-let [t (:timer @state)]
-    (interop/clear-timeout! t))
-  (swap! state dissoc :timer))
+(rf/reg-sub :rf.runner/step
+  (fn [db _] (:step db)))
 
-(declare run-step!)
+(defn reg-runner!
+  "Register a deck's run-step event. `config` is
 
-(defn- advance!
-  "After a step settles: bump the cursor to the next-to-run, marking the
-  phase :done once the cursor runs off the end. `:active` (the last-
-  dispatched index, set in `dispatch+settle!`) is left untouched — it is
-  what the highlight + counter render off."
-  [state steps]
-  (let [next-cursor (inc (:cursor @state))
-        more?       (< next-cursor (count steps))]
-    (swap! state assoc :cursor next-cursor :phase (if more? :idle :done))))
+      {:id         :<deck>/run-step   ; the deck-scoped event id the views dispatch
+       :steps      <steps-vector>     ; the deck's CODE-DATA step vector
+       :host-frame <frame-id>}        ; the frame the step events dispatch into
 
-(defn- dispatch+settle!
-  "Dispatch the step's event TO `host-frame`, mark it the `:active` (last-
-  dispatched) step so the highlight + counter render off it, (optionally)
-  focus the latest host-frame epoch, then schedule the post-dispatch
-  `:settle-ms` wait before advancing. `auto?` controls focus: auto-advance
-  pins focus to latest; a manual single-step leaves focus to the operator.
+  The registered `event-fx` handler, on `[:run-step n]`:
+    - `assoc`s `:step = n` into the deck's app-db (the per-step delta the
+      panels show), and
+    - fans out step n's `:event`(s) as `:fx :dispatch`es targeting
+      `host-frame`, so each step's machine/app event lands on the inspected
+      frame in the same cascade as the `:step` write.
 
-  The dispatch carries an explicit `{:frame host-frame}` opt. A runner
-  control's `on-click` fires OUTSIDE the React render tree's frame-provider
-  context, so `(rf/dispatch event)` alone would resolve to the ambient
-  `(current-frame-id)` — `:rf/default` for a single-frame deck (correct
-  there, since the inspected frame IS `:rf/default`), but the WRONG frame
-  when a deck mounts the runner inside a second frame-provider (e.g. the
-  two-frame isolation testbed mounts the standard-epochs deck once per
-  `:above` / `:below` frame, each with its own runner atom + host-frame).
-  Targeting `host-frame` explicitly keeps each runner's dispatches scoped
-  to the frame it inspects — the load-bearing rule for the per-frame
-  isolation proof. For the single-frame decks this is a no-op (host-frame
-  is `:rf/default`, the same frame the out-of-tree click already targeted)."
-  [state steps host-frame {:keys [auto?]}]
-  (let [idx (:cursor @state)
-        {:keys [event settle-ms] :as step} (nth steps idx)]
-    ;; Mark the just-dispatched step active BEFORE the cursor advances, so
-    ;; at rest the highlighted row is the one whose epoch is focused.
-    (swap! state assoc :active idx :phase :dispatched)
-    (rf/dispatch event {:frame host-frame})
-    (when auto?
-      (focus-latest-host-epoch! host-frame))
-    (swap! state assoc :phase :settling)
-    ;; POST-dispatch settle. Framework-native `interop/set-timeout!` —
-    ;; the wait lets a machine :after timer / a deferred HTTP reply / a
-    ;; cascade fire + render before the operator advances. A manual step
-    ;; with settle-ms 0 advances on the next tick.
-    (let [ms (max 0 (or settle-ms 0))
-          t  (interop/set-timeout!
-               (fn []
-                 (swap! state dissoc :timer)
-                 (advance! state steps))
-               ms)]
-      (swap! state assoc :timer t))))
-
-(defn run-step!
-  "Run the step at the current cursor. Honours the OPTIONAL pre-dispatch
-  `:before-ms` pause (default 0 — most steps dispatch immediately), then
-  dispatches + settles. `opts` carries `:auto?` (auto-advance pins
-  focus). Idempotent against an out-of-range cursor (no-op)."
-  [state steps host-frame opts]
-  (let [cursor (:cursor @state)]
-    (when (< cursor (count steps))
-      (clear-timer! state)
-      (let [{:keys [before-ms]} (nth steps cursor)
-            ms                   (max 0 (or before-ms 0))]
-        (if (pos? ms)
-          (do (swap! state assoc :phase :before)
-              (let [t (interop/set-timeout!
-                        (fn []
-                          (swap! state dissoc :timer)
-                          (dispatch+settle! state steps host-frame opts))
-                        ms)]
-                (swap! state assoc :timer t)))
-          (dispatch+settle! state steps host-frame opts))))))
-
-;; ---- the public controls --------------------------------------------------
-;;
-;; The control bar is ONE Step button (`step-once!`); each step row's index is
-;; also a random-access RUN-THIS-STEP button (`run-step-at!`). A deck may also
-;; expose its own Reset (it calls `reset-runner!`).
-
-(defn step-once!
-  "STEP: dispatch the step at the current cursor WITHOUT pinning focus (the
-  operator drives the spine), marking it the `:active` step and advancing
-  the cursor. Wraps back to the top once the cursor has run off the end."
-  [state steps host-frame]
-  (when (>= (:cursor @state) (count steps))
-    (swap! state assoc :cursor 0))
-  (run-step! state steps host-frame {:auto? false}))
-
-(defn run-step-at!
-  "RANDOM-ACCESS step: move the cursor to step `n` and run THAT step
-  (dispatch + settle + advance, marking it `:active`), WITHOUT pinning
-  focus (manual mode — the operator drives the spine). No-op for an
-  out-of-range `n`.
-
-  This is the per-step affordance the runner exposes alongside the single
-  Step control: each rendered step row carries a clickable
-  `<prefix>-step-<n>-run` button so an operator (or a feature-matrix
-  scenario) can drive ANY step directly, not only the next one in the
-  cursor's path. A deck whose assertions need to re-drive a specific step
-  out of order (a routing / machine ladder that asserts a panel render
-  AFTER a NAMED rung) names each step here rather than keeping a parallel
-  bespoke button ladder."
-  [state steps host-frame n]
-  (when (and (integer? n) (<= 0 n) (< n (count steps)))
-    (swap! state assoc :cursor n)
-    (run-step! state steps host-frame {:auto? false})))
-
-(defn initial-state
-  "The runner's initial local-atom value. A testbed `(r/atom (initial-state))`.
-  `:active` is nil — nothing has run, so no row is highlighted yet."
-  []
-  {:cursor 0 :active nil :phase :idle})
-
-(defn reset-runner!
-  "Reset the runner to the top, idle, no pending timer, nothing active.
-  A deck's own Reset button calls this (the runner control bar no longer
-  carries a Reset)."
-  [state]
-  (clear-timer! state)
-  (reset! state (initial-state)))
+  An out-of-range `n` is a no-op (no `:step` write, no dispatch). A deck
+  calls this once at load (the same place it `def`s its steps), then mounts
+  `[runner/runner {:run-step-event :<deck>/run-step :steps steps :prefix
+  \"<deck>\" :host-frame <frame>}]`."
+  [{:keys [id steps host-frame]}]
+  (rf/reg-event-fx id
+    {:doc "Step driver (rf2-5sjbg): set app-db :step = n and fan out step
+           n's event(s) into the deck's host-frame. The runner's Step button
+           dispatches [<this> (inc current)]; each per-row RUN button
+           dispatches [<this> n]."}
+    (fn run-step-handler [{:keys [db]} [_ n]]
+      (if (and (integer? n) (<= 0 n) (< n (count steps)))
+        {:db (assoc db :step n)
+         :fx (mapv (fn [ev] [:dispatch ev {:frame host-frame}])
+                   (step-events (nth steps n)))}
+        {:db db}))))
 
 ;; ============================================================================
-;; VIEWS
+;; VIEWS — subscribe + dispatch only (no atom, no steps/host-frame leaf args)
 ;; ============================================================================
-
-(defn- phase-chip-text
-  "The status chip. `:active` is nil before the first step (ready) and the
-  index of the just-run step otherwise — the chip reads off the active
-  step, not the next-to-run cursor."
-  [{:keys [phase active]}]
-  (cond
-    (nil? active)         "ready"
-    (= phase :done)       "done"
-    (= phase :before)     "pausing (pre-dispatch)…"
-    (= phase :dispatched) "dispatched"
-    (= phase :settling)   "settling…"
-    :else                 "idle"))
 
 (reg-view runner-controls
   "The runner control bar: ONE purple Step button + a status chip reading
-  the LAST-RUN step's position (off `:active`, not the next-to-run cursor,
-  so it matches the focused epoch at rest). The Step button carries a
-  stable `data-testid` (`<prefix>-step`); a deck may render its own Reset
-  alongside (the bar no longer carries Run-series / Pause / Reset)."
-  [prefix state steps host-frame]
-  (let [snap   @state
-        total  (count steps)
-        active (:active snap)]
+  the LAST-RUN step's position (off the `:rf.runner/step` sub, so it
+  matches the focused epoch at rest). The Step button dispatches
+  `[run-step-event (inc current)]` (wrapping to 0 off the end) and carries
+  a stable `data-testid` (`<prefix>-step`); a deck may render its own Reset
+  alongside (the bar carries no Reset)."
+  [prefix run-step-event total host-frame]
+  (let [current @(subscribe [:rf.runner/step])
+        next-n  (if (or (nil? current) (>= (inc current) total)) 0 (inc current))]
     [:div {:data-testid (str prefix "-runner-controls")
            :style {:display "flex" :gap "0.5em" :align-items "center"
                    :flex-wrap "wrap" :padding "0.6em 0.75em" :margin "0.5em 0"
                    :border "1px solid #cfc8ff" :border-radius "8px"
                    :background "#faf8ff"}}
      [:button {:data-testid (str prefix "-step")
-               :on-click #(step-once! state steps host-frame)
+               :on-click #(rf/dispatch [run-step-event next-n] {:frame host-frame})
                :style {:padding "0.45em 0.9em" :cursor "pointer"
                        :border "1px solid #7C5CFF" :border-radius "6px"
                        :background "#7C5CFF" :color "#fff" :font-weight "bold"}}
       "⏭ Step"]
      [:span {:data-testid (str prefix "-status")
              :style {:color "#666" :font-size "12px" :margin-left "0.25em"}}
-      (str (if (nil? active) "step 0" (str "step " (inc active)))
-           " / " total " · " (phase-chip-text snap))]]))
+      (str (if (nil? current) "step 0" (str "step " (inc current)))
+           " / " total)]]))
 
 (reg-view step-row
-  "One step row: its index, label, and `:watch` commentary. The ACTIVE step
-  (the one whose epoch is focused — the last one dispatched) is highlighted;
+  "One step row: its index, label, and `:watch` commentary. The current
+  step (the one whose epoch is focused — the last one run) is highlighted;
   `current?` is true for exactly that row (none before the first step).
   Carries a stable per-step `data-testid` (`<prefix>-step-<n>`).
 
   The index is a clickable RUN-THIS-STEP button (`<prefix>-step-<n>-run`)
   that drives exactly this step by invoking the bound `on-run` thunk
-  (random-access, manual — no focus pinning). `on-run` is a 0-arg fn the
-  RUNNER builds (closing over `state` / `steps` / `host-frame` / `n`), so
-  the leaf row carries ONLY what it renders — its own `step` / `n` /
-  `current?` / `done?` plus that bound action — NOT the whole `steps`
-  vector, the runner `state` atom, or the `host-frame` id (none of which a
-  leaf view should know). The single Step control remains the primary
-  affordance; this lets an operator (or a scenario) drive any step
-  directly without a parallel bespoke button ladder."
+  (`#(dispatch [run-step-event n] {:frame host-frame})`, random-access). The
+  leaf carries ONLY what it renders — its own `step` / `n` / `current?` /
+  `done?` plus that bound action — NOT the steps vector, an atom, or the
+  host-frame id (none of which a leaf view should know)."
   [prefix n step current? done? on-run]
   [:div {:data-testid (str prefix "-step-" n)
          :style {:display "grid" :grid-template-columns "auto 1fr"
@@ -359,40 +206,35 @@
     (str (inc n) ".")]
    [:div
     [:div {:style {:font-weight "600" :color "#333"}}
-     (step-label step)
-     [:span {:style {:color "#999" :font-weight "normal" :margin-left "0.5em"
-                     :font-size "11px"}}
-      (str "settle " (or (:settle-ms step) 0) "ms"
-           (when (pos? (or (:before-ms step) 0))
-             (str " · before " (:before-ms step) "ms")))]]
+     (step-label step)]
     [:div {:data-testid (str prefix "-step-" n "-watch")
            :style {:color "#666" :font-size "12px" :margin-top "0.15em"}}
      "Watch: " (:watch step)]]])
 
 (reg-view runner
   "The full runner surface: the control bar + the step list. A testbed
-  mounts `[runner/runner prefix state steps host-frame]`. `state` is the
-  testbed's LOCAL Reagent atom (`(r/atom (runner/initial-state))`),
-  `steps` the step-vector `def`, `host-frame` the inspected app frame
-  (e.g. `:rf/default`), `prefix` the testid prefix."
-  [prefix state steps host-frame]
-  (let [snap   @state
-        active (:active snap)]
+  registers its run-step event with `reg-runner!`, then mounts
+
+      [runner/runner {:run-step-event :<deck>/run-step
+                      :steps          steps
+                      :prefix         \"<deck>\"
+                      :host-frame     <frame-id>}]
+
+  The HIGHLIGHT + status counter render off the `:rf.runner/step` sub (the
+  current frame's app-db `:step`). The per-row RUN buttons + the Step button
+  dispatch the deck's run-step event into `host-frame`. No atom, no steps /
+  host-frame threaded to any leaf — each row gets a bound 0-arg thunk."
+  [{:keys [run-step-event steps prefix host-frame]}]
+  (let [current @(subscribe [:rf.runner/step])
+        total   (count steps)]
     [:div {:data-testid (str prefix "-runner")}
-     [runner-controls prefix state steps host-frame]
+     [runner-controls prefix run-step-event total host-frame]
      [:div {:data-testid (str prefix "-steps")}
       (map-indexed
-        (fn [n step]
+        (fn [n s]
           ^{:key n}
-          ;; The runner has `state` / `steps` / `host-frame` in scope, so it
-          ;; binds each row a 0-arg `:on-run` thunk over `run-step-at!` and
-          ;; passes the leaf only what it renders — NOT the whole steps vector,
-          ;; the state atom, or the host-frame id. Highlight + 'done' shading
-          ;; render off `:active` (the just-run step), so at rest the
-          ;; highlighted row matches the focused epoch. Before the first step
-          ;; `:active` is nil → no row highlighted.
-          [step-row prefix n step
-           (= n active)
-           (and (some? active) (< n active))
-           #(run-step-at! state steps host-frame n)])
+          [step-row prefix n s
+           (= n current)
+           (and (some? current) (< n current))
+           #(rf/dispatch [run-step-event n] {:frame host-frame})])
         steps)]]))

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -13,30 +13,30 @@
   mounted with a runner atom + a host-frame + a testid prefix. Each step
   DISPATCHES one event that
 
-    (a) bumps a shared baseline counter (so App-db / Epoch always show a
-        delta on every step), and
-    (b) exercises exactly ONE additional feature.
+    (a) lands on the run-step epoch as the `:step` app-db delta the panels
+        show (the runner sets `:step = n`), and
+    (b) exercises exactly ONE additional feature via a child dispatch.
 
   Progressive: step 1 is trivial; each later step layers one more concept.
   There are NO tabs, NO routing/URL machinery, NO machines, NO SSR. Read
   each step's `:watch` note; Xray itself is the check.
 
-  ## Parameterised root (rf2-3xakq — the two-frame mount)
+  ## Parameterised root (rf2-3xakq → rf2-5sjbg — the two-frame mount)
 
-  `root` is a PURE ladder taking `[runner-state host-frame prefix]` — just
-  the runner + the two children + the diamond probe, NO header, NO reset
-  button (rf2-7prmj). The single-frame deck (`run`) mounts the `standalone`
-  wrapper, which renders the deck's title + intro header ABOVE
-  `[root runner-state :rf/default \"standard-epochs\"]` on the plain default
-  frame, Xray auto-mounting inline. The TWO-FRAME isolation testbed
+  `root` is a PURE ladder taking `[host-frame prefix]` — just the runner +
+  the two children + the diamond probe, NO header, NO reset button
+  (rf2-7prmj), NO runner atom (rf2-5sjbg: the runner cursor lives in
+  app-db's `:step`, not a passed atom). The single-frame deck (`run`) mounts
+  the `standalone` wrapper, which renders the deck's title + intro header
+  ABOVE `[root :rf/default \"standard-epochs\"]` on the plain default frame,
+  Xray auto-mounting inline. The TWO-FRAME isolation testbed
   (`two_frame_isolation`) mounts this SAME `root` once per `:above` /
-  `:below` frame-provider, each with its OWN runner atom + host-frame + a
-  DISTINCT prefix — so the two reactive contexts (and the two runner
-  cursors) stay genuinely independent. Keeping the header OUT of `root` is
-  what stops the two-frame cards showing the title twice (mislabel) and
-  leaves them as clean per-frame ladders. This is what makes the deck
-  reusable as the two-frame isolation PROOF without sharing a cursor or
-  focusing the wrong frame.
+  `:below` frame-provider, each with its OWN host-frame + a DISTINCT prefix
+  — so the two reactive contexts (and the two per-frame `:step` cursors)
+  stay genuinely independent (per-frame app-db gives each mount its own
+  `:step`). Keeping the header OUT of `root` is what stops the two-frame
+  cards showing the title twice (mislabel) and leaves them as clean
+  per-frame ladders.
 
   ## North star (acceptance)
 
@@ -46,10 +46,11 @@
 
   ## Per-panel coverage map
 
-    Epoch   — every button is one epoch (db-before/after, dispatch);
-              #2 adds a coeffect to the event detail, #4 a one-shot fx,
-              #5 a cascade dispatch-id tree.
-    App-db  — #1 scalar bump · #5 flow writes a derived slot. (The rich
+    Epoch   — every step is a run-step epoch (the `:step` delta + the
+              dispatched child event); #2 adds a coeffect to the event
+              detail, #4 a one-shot fx, #5 a cascade dispatch-id tree.
+    App-db  — the `:step` cursor churns every step · #5 flow writes a
+              derived slot. (The rich
               App-db DIFF shapes — added / removed-to-empty / changed
               (diff-mode-3) — plus the large-collection / edn-inspector
               cases live in the sibling `edn_inspector` deck, which drives
@@ -94,8 +95,7 @@
   The events / subs / views below are OWNED here — this deck does NOT
   reuse the shared `testdeck.*` modules (whose coupling to the two-frame
   + routing surfaces is what made the step-deck inflexible)."
-  (:require [reagent.core :as r]
-            [reagent.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Flows artefact — load-time hook so `reg-flow` resolves
             ;; (button #5 writes a derived slot via a flow).
@@ -116,10 +116,12 @@
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared queued-step runner (rf2-8pbjr pilot). This deck
-            ;; supplies a `steps` vector; the runner drives the ONE-button
-            ;; series + the per-step RUN buttons. The two-frame testbed
-            ;; mounts `root` twice with a distinct runner atom + host-frame.
+            ;; The shared step-driver runner (rf2-5sjbg). This deck supplies
+            ;; a `steps` vector + registers `:standard-epochs/run-step` via
+            ;; `runner/reg-runner!`; the runner drives the ONE-button series
+            ;; + the per-step RUN buttons off app-db `:step`. The two-frame
+            ;; testbed reuses `root` + `steps` with its own per-frame
+            ;; host-frame + run-step events.
             [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -127,14 +129,16 @@
 ;; APP-DB SEED
 ;; ============================================================================
 ;;
-;; One flat, named seed. `:baseline` is the shared counter every button
-;; bumps. `:base` feeds button #5's flow only.
+;; One flat, named seed. `:step` is the runner cursor (rf2-5sjbg) — the
+;; index of the last-run step, written by `runner.core`'s run-step event.
+;; It REPLACES the old `:baseline` counter: `:step` churning every step IS
+;; the per-step App-db / Epoch delta the panels show. `:base` feeds button
+;; #5's flow only.
 ;;
 ;; `:views` holds the Views/subscriptions section's OWN state — kept on
-;; its own slots, NOT linked to `:baseline`/`:base`, so the section's
-;; mount/unmount/sub behaviour is exercised DIRECTLY (no start-at-button-1
-;; sequencing, no :base/flow confound). It is app-db state (not a
-;; component-local atom) so it is observable in Xray:
+;; its own slots, so the section's mount/unmount/sub behaviour is exercised
+;; DIRECTLY (no start-at-button-1 sequencing, no :base/flow confound). It is
+;; app-db state (not a component-local atom) so it is observable in Xray:
 ;;
 ;;   :a-mounted? / :b-mounted?  — the two children's mount slots.
 ;;   :threshold                 — N, the changeable arg to the dynamic
@@ -145,7 +149,7 @@
 ;;                                Child B (button #11 changes it).
 
 (def initial-db
-  {:baseline 0
+  {:step     nil
    :base     1
    :auth     {:token "seed-token"}
    :views    {:a-mounted?  false
@@ -159,19 +163,9 @@
   {:doc "Seed event — re-seed app-db and unmount both child views. Used by
          `run` (dispatch-sync on load) and by two_frame_isolation's per-frame
          :on-create. There is no on-page reset button (rf2-7prmj); a reload
-         re-seeds."}
+         re-seeds. The runner cursor `:step` re-seeds to nil here."}
   (fn handler-reset [_db _ev]
     initial-db))
-
-;; ============================================================================
-;; A small shared helper: every action event bumps the baseline counter.
-;; ============================================================================
-;;
-;; Kept as a plain db->db fn (not an interceptor) so the baseline bump is
-;; visible inline in each handler body — the App-db / Epoch delta on
-;; every press comes from here.
-
-(defn- bump [db] (update db :baseline inc))
 
 ;; ============================================================================
 ;; APP-DB SCHEMA (button #19)
@@ -294,9 +288,10 @@
 
 ;; -- 1. plain increment ------------------------------------------------------
 (rf/reg-event-db :standard-epochs/increment
-  {:doc "Button 1 — a plain event. App-db :baseline ++ ; Epoch shows the
-         event with db-before / db-after."}
-  (fn handler-increment [db _ev] (bump db)))
+  {:doc "Step 1 — a plain event. The per-step App-db delta is the runner's
+         `:step` write on the parent run-step epoch; Epoch shows THIS event
+         firing with db-before / db-after (no further write)."}
+  (fn handler-increment [db _ev] db))
 
 ;; -- 2. increment + coeffect -------------------------------------------------
 (rf/reg-event-fx :standard-epochs/increment-cofx
@@ -304,14 +299,14 @@
          detail shows the coeffect feeding the handler."}
   [(rf/inject-cofx :standard-epochs/now)]
   (fn handler-increment-cofx [{:keys [db standard-epochs/now]} _ev]
-    {:db (-> db bump (assoc :last-clicked now))}))
+    {:db (assoc db :last-clicked now)}))
 
 ;; -- 3. increment + effect ---------------------------------------------------
 (rf/reg-event-fx :standard-epochs/increment-fx
   {:doc "Button 3 — return a one-shot fx. Effects / Trace show
          `:standard-epochs/ping` fire this epoch."}
   (fn handler-increment-fx [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx [[:standard-epochs/ping {:at (.getTime (js/Date.))}]]}))
 
 ;; -- 4. increment + cascade --------------------------------------------------
@@ -319,26 +314,25 @@
   {:doc "Button 4 — dispatch a follow-on event. Epoch's dispatch-id tree
          shows the cascade (this event → :standard-epochs/cascade-tail)."}
   (fn handler-increment-cascade [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx [[:dispatch [:standard-epochs/cascade-tail]]]}))
 
 (rf/reg-event-db :standard-epochs/cascade-tail
-  {:doc "The follow-on event dispatched by button 4. Bumps baseline again
-         so the cascade has two epochs under one root dispatch-id."}
-  (fn handler-cascade-tail [db _ev] (bump db)))
+  {:doc "The follow-on event dispatched by button 4 — the second epoch in
+         the cascade under one root dispatch-id."}
+  (fn handler-cascade-tail [db _ev] db))
 
 ;; -- 5. increment + flow -----------------------------------------------------
 (rf/reg-event-db :standard-epochs/increment-flow
   {:doc "Button 5 — perturb :base so the `:standard-epochs/derived` flow
          recomputes a derived slot into app-db; App-db / Trace show it."}
   (fn handler-increment-flow [db _ev]
-    (-> db bump (update :base inc))))
+    (update db :base inc)))
 
 ;; -- 6..11. Views / subscriptions — sub-driven Child A + props-driven Child B
 ;;
-;; The whole section lives on the `:views` slots, decoupled from the
-;; counter: a button MAY bump `:baseline`, but mount/unmount/sub state is
-;; never linked to a counter VALUE. Two children separate the re-render
+;; The whole section lives on the `:views` slots: mount/unmount/sub state is
+;; never linked to the runner cursor. Two children separate the re-render
 ;; CAUSE — Child A re-renders ← a SUB changed (#8); Child B re-renders ←
 ;; PROPS changed (#11).
 
@@ -349,14 +343,14 @@
          PLUS the arg-keyed `[:standard-epochs/greater-than? N]` sub — so
          Views shows the node and those sub-cache entries appear."}
   (fn handler-mount-a [db _ev]
-    (-> db bump (assoc-in [:views :a-mounted?] true))))
+    (assoc-in db [:views :a-mounted?] true)))
 
 (rf/reg-event-db :standard-epochs/set-threshold
   {:doc "Button 7 — change the sub-arg N (5 → 10). `[:standard-epochs/
          greater-than? N]` is keyed by its arg, so the new N is a NEW,
          distinct sub-cache entry alongside the old one."}
   (fn handler-set-threshold [db [_ n]]
-    (-> db bump (assoc-in [:views :threshold] n))))
+    (assoc-in db [:views :threshold] n)))
 
 (rf/reg-event-db :standard-epochs/perturb-chain
   {:doc "Button 8 — perturb Child A's chain input (:views/chain-input).
@@ -365,7 +359,7 @@
          and A re-renders BECAUSE A SUB CHANGED (← :standard-epochs/chain-
          labelled), not because its props changed."}
   (fn handler-perturb-chain [db _ev]
-    (-> db bump (update-in [:views :chain-input] inc))))
+    (update-in db [:views :chain-input] inc)))
 
 (rf/reg-event-db :standard-epochs/unmount-a
   {:doc "Button 9 — unmount Child A (sets :views/a-mounted? false). The
@@ -373,7 +367,7 @@
          reader is gone (the chain L1/L2/L3 + every [:gt? N] cache
          entry); the unmount is recorded."}
   (fn handler-unmount-a [db _ev]
-    (-> db bump (assoc-in [:views :a-mounted?] false))))
+    (assoc-in db [:views :a-mounted?] false)))
 
 (rf/reg-event-db :standard-epochs/mount-b
   {:doc "Button 10 — mount the PROPS-driven Child B (sets
@@ -381,23 +375,22 @@
          NOTHING, so Views shows the node appear with NO new sub-cache
          entries."}
   (fn handler-mount-b [db _ev]
-    (-> db bump (assoc-in [:views :b-mounted?] true))))
+    (assoc-in db [:views :b-mounted?] true)))
 
 (rf/reg-event-db :standard-epochs/set-b-prop
   {:doc "Button 11 — change Child B's prop. B re-renders BECAUSE ITS
          PROPS CHANGED (no sub cause) — the foil to button 8's
          sub-driven re-render."}
   (fn handler-set-b-prop [db _ev]
-    (-> db bump (update-in [:views :b-prop]
-                           {"alpha" "beta" "beta" "gamma" "gamma" "alpha"}))))
+    (update-in db [:views :b-prop]
+               {"alpha" "beta" "beta" "gamma" "gamma" "alpha"})))
 
 ;; -- 12. exception in the handler → Issues: handler-exception, db rolls back -
 (rf/reg-event-db :standard-epochs/throw-handler
-  {:doc "Button 12 — throw in the handler. The router catches it; the :db
-         effect (the baseline bump) rolls back; Issues shows
+  {:doc "Button 12 — throw in the handler. The router catches it; the
+         handler's :db never commits; Issues shows
          `:rf.error/handler-exception` with the source coord."}
-  (fn handler-throw [db _ev]
-    (bump db) ;; would bump, but the throw below aborts the commit
+  (fn handler-throw [_db _ev]
     (throw (ex-info "standard-epochs / handler (intentional — exercises the handler error surface)"
                     {:surface :handler-exception}))))
 
@@ -407,7 +400,7 @@
          the way IN; Issues shows the interceptor :before exception and the
          handler never runs."}
   [throwing-interceptor]
-  (fn handler-after-throwing-interceptor [db _ev] (bump db)))
+  (fn handler-after-throwing-interceptor [db _ev] db))
 
 ;; -- 14. exception in an interceptor :after → Issues: interceptor exc. -------
 (rf/reg-event-db :standard-epochs/throw-interceptor-after
@@ -417,23 +410,23 @@
          :after exception; per-step placement renders it under the
          interceptor's :after step, distinct from a handler exception."}
   [throwing-interceptor-after]
-  (fn handler-before-throwing-after-interceptor [db _ev] (bump db)))
+  (fn handler-before-throwing-after-interceptor [db _ev] db))
 
 ;; -- 15. exception in a coeffect handler → Issues: cofx error ----------------
 (rf/reg-event-fx :standard-epochs/throw-cofx
   {:doc "Button 15 — a coeffect throws on injection. Issues shows the
          cofx error; the handler never runs."}
   [(rf/inject-cofx :standard-epochs/throwing-cofx)]
-  (fn handler-after-throwing-cofx [{:keys [db]} _ev] {:db (bump db)}))
+  (fn handler-after-throwing-cofx [{:keys [db]} _ev] {:db db}))
 
 ;; -- 16. exception in an effect handler (post-commit) → Issues: fx error -----
 (rf/reg-event-fx :standard-epochs/throw-fx
-  {:doc "Button 16 — the :db commits (baseline bumps), then a post-commit
-         fx throws. Issues shows the fx error; post-commit fx are
-         best-effort per the FX atomicity asymmetry, so the db delta
-         survives."}
+  {:doc "Button 16 — the :db commits, then a post-commit fx throws. Issues
+         shows the fx error; post-commit fx are best-effort per the FX
+         atomicity asymmetry, so the committed db survives. (The visible
+         per-step delta is the runner's `:step` write on the parent epoch.)"}
   (fn handler-throw-fx [{:keys [db]} _ev]
-    {:db (bump db)
+    {:db db
      :fx [[:standard-epochs/boom {}]]}))
 
 ;; -- 17. slow effect (~600ms managed fx) → Issues: slow-fx flagged -----------
@@ -441,7 +434,7 @@
   {:doc "Button 17 — issue a ~600ms managed fx. Status moves :loading;
          Issues flags the slow fx; the reply lands :loaded ~600ms later."}
   (fn handler-slow [{:keys [db]} _ev]
-    {:db (-> db bump (assoc :slow-status :loading))
+    {:db (assoc db :slow-status :loading)
      :fx [[:standard-epochs/slow-fetch {}]]}))
 
 (rf/reg-event-db :standard-epochs/slow-done
@@ -456,7 +449,7 @@
          is required). The handler is skipped; Issues / Schema-timeline
          shows `:rf.error/schema-validation-failure :where :event`."
    :schema [:cat [:= :standard-epochs/bad-event-args] pos-int?]}
-  (fn handler-bad-event-args [db _ev] (bump db)))
+  (fn handler-bad-event-args [db _ev] db))
 
 ;; -- 19. schema violation, app-db write → Issues: app-db schema failure ------
 (rf/reg-event-db :standard-epochs/bad-app-db-write
@@ -465,7 +458,7 @@
          validation rolls the :db back; Issues shows the app-db schema
          failure, which survives the rollback."}
   (fn handler-bad-app-db-write [db _ev]
-    (-> db bump (assoc-in [:auth :token] 42))))
+    (assoc-in db [:auth :token] 42)))
 
 ;; -- 20. diamond probe — bump the join-sub root once -------------------------
 (rf/reg-event-db :standard-epochs/bump-diamond
@@ -475,14 +468,13 @@
          rise by 1 (clean); a rise of 2 means the diamond double-computes the
          intermediate sub. The count is shown by the diamond-display view."}
   (fn handler-bump-diamond [db _ev]
-    (-> db bump (update-in [:views :diamond-root] (fnil inc 0)))))
+    (update-in db [:views :diamond-root] (fnil inc 0))))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
 ;; L1 — read app-db directly.
-(rf/reg-sub :standard-epochs/baseline    (fn [db _] (:baseline db)))
 (rf/reg-sub :standard-epochs/a-mounted?  (fn [db _] (get-in db [:views :a-mounted?])))
 (rf/reg-sub :standard-epochs/b-mounted?  (fn [db _] (get-in db [:views :b-mounted?])))
 (rf/reg-sub :standard-epochs/threshold   (fn [db _] (get-in db [:views :threshold])))
@@ -630,150 +622,131 @@
        "(press #20 once → +1 clean, +2 double-compute)"]]]))
 
 ;; ============================================================================
-;; THE STEP VECTOR — code data (rf2-8pbjr: the single source of truth)
+;; THE STEP VECTOR — code data (the single source of truth)
 ;; ============================================================================
 ;;
-;; Each step: {:event [...] :watch "<what to look for>" :settle-ms N
-;;             :label "<short row label>"}. The runner renders :watch per
-;; STEP, dispatches :event to the deck's host-frame, then waits :settle-ms
-;; before advancing. The ladder walks Events → Views/subscriptions →
-;; Errors/Issues → Reactive (the historical button order 1..20 preserved).
-;;
-;; Settle tuning (rf2-3xakq): most steps are synchronous db transitions —
-;; a short pause is enough for the eye + the panel render. The async steps
-;; get longer settles so the deferred work fires + renders before the
-;; cursor advances:
-;;   - #4 cascade — the follow-on :dispatch lands a second epoch.
-;;   - #6/#9/#10 mount/unmount — a React render tick for the child node
-;;     to appear / disappear + its subs to register / dispose.
-;;   - #17 slow fx (~600ms) — the deferred :standard-epochs/slow-done reply
-;;     must land (status :loading → :loaded) within the settle.
-;;   - #12/#16/#19 exception / rollback steps — a beat for the Issues lens
-;;     to surface the trace + the rolled-back / surviving db to settle.
+;; Each step: {:event [...] :watch "<what to look for>" :label "<short row
+;; label>"}. The runner renders :watch per STEP; pressing Step (or a per-row
+;; RUN button) dispatches `[:standard-epochs/run-step n]`, which sets app-db
+;; `:step = n` (the per-step delta the panels show) and dispatches the step's
+;; `:event` into the host-frame. The ladder walks Events →
+;; Views/subscriptions → Errors/Issues → Reactive (the historical button
+;; order 1..20 preserved). Manual stepping needs no pacing — each async step
+;; (cascade, mount/unmount, slow fx) fires + renders on its own schedule
+;; while the operator watches (rf2-5sjbg dropped the settle machinery).
 
 (def steps
   [;; -- Events — Epoch / Trace / App-db scalar --
-   {:label     "Increment"
-    :event     [:standard-epochs/increment]
-    :watch     "App-db :baseline ++ · Epoch: the event, db-before/after."
-    :settle-ms 350}
-   {:label     "Increment + coeffect"
-    :event     [:standard-epochs/increment-cofx]
-    :watch     "Epoch event-detail: a `now` coeffect feeds the handler."
-    :settle-ms 350}
-   {:label     "Increment + effect"
-    :event     [:standard-epochs/increment-fx]
-    :watch     "Effects / Trace: a one-shot :standard-epochs/ping fx fires this epoch."
-    :settle-ms 350}
-   {:label     "Increment + cascade"
-    :event     [:standard-epochs/increment-cascade]
-    :watch     "Epoch: the dispatch-id tree — a follow-on :cascade-tail event under one root."
-    :settle-ms 450}
-   {:label     "Increment + flow"
-    :event     [:standard-epochs/increment-flow]
-    :watch     "App-db: the :standard-epochs/derived reg-flow slot recomputes; Trace shows the flow run."
-    :settle-ms 400}
+   {:label "Increment"
+    :event [:standard-epochs/increment]
+    :watch "Epoch: this event, db-before/after. The per-step App-db delta is the runner's :step write on the parent run-step epoch."}
+   {:label "Increment + coeffect"
+    :event [:standard-epochs/increment-cofx]
+    :watch "Epoch event-detail: a `now` coeffect feeds the handler."}
+   {:label "Increment + effect"
+    :event [:standard-epochs/increment-fx]
+    :watch "Effects / Trace: a one-shot :standard-epochs/ping fx fires this epoch."}
+   {:label "Increment + cascade"
+    :event [:standard-epochs/increment-cascade]
+    :watch "Epoch: the dispatch-id tree — a follow-on :cascade-tail event under one root."}
+   {:label "Increment + flow"
+    :event [:standard-epochs/increment-flow]
+    :watch "App-db: the :standard-epochs/derived reg-flow slot recomputes; Trace shows the flow run."}
 
    ;; -- Views / subscriptions — sub-driven A vs props-driven B --
-   {:label     "Mount Child A (sub-driven)"
-    :event     [:standard-epochs/mount-a]
-    :watch     "Views: the Child-A node + A's sub-cache entries appear (chain L1/L2/L3 + [:gt? 5])."
-    :settle-ms 450}
-   {:label     "Change the sub-arg N → 10"
-    :event     [:standard-epochs/set-threshold 10]
-    :watch     "Views: a NEW cache entry [:gt? 10] (parameterized-sub cache keyed by arg) alongside [:gt? 5]."
-    :settle-ms 400}
-   {:label     "Perturb A's chain input"
-    :event     [:standard-epochs/perturb-chain]
-    :watch     "Views: L1→L2→L3 invalidation recompute; A re-renders ← a SUB changed (not props)."
-    :settle-ms 400}
-   {:label     "Unmount Child A"
-    :event     [:standard-epochs/unmount-a]
-    :watch     "Views: the node is gone; ALL of A's subs are disposed (last reader gone); the unmount is recorded."
-    :settle-ms 450}
-   {:label     "Mount Child B (props-driven)"
-    :event     [:standard-epochs/mount-b]
-    :watch     "Views: the Child-B node appears with NO subs created."
-    :settle-ms 450}
-   {:label     "Change B's prop"
-    :event     [:standard-epochs/set-b-prop]
-    :watch     "Views: B re-renders ← PROPS changed (the foil to step 8's sub-driven re-render)."
-    :settle-ms 400}
+   {:label "Mount Child A (sub-driven)"
+    :event [:standard-epochs/mount-a]
+    :watch "Views: the Child-A node + A's sub-cache entries appear (chain L1/L2/L3 + [:gt? 5])."}
+   {:label "Change the sub-arg N → 10"
+    :event [:standard-epochs/set-threshold 10]
+    :watch "Views: a NEW cache entry [:gt? 10] (parameterized-sub cache keyed by arg) alongside [:gt? 5]."}
+   {:label "Perturb A's chain input"
+    :event [:standard-epochs/perturb-chain]
+    :watch "Views: L1→L2→L3 invalidation recompute; A re-renders ← a SUB changed (not props)."}
+   {:label "Unmount Child A"
+    :event [:standard-epochs/unmount-a]
+    :watch "Views: the node is gone; ALL of A's subs are disposed (last reader gone); the unmount is recorded."}
+   {:label "Mount Child B (props-driven)"
+    :event [:standard-epochs/mount-b]
+    :watch "Views: the Child-B node appears with NO subs created."}
+   {:label "Change B's prop"
+    :event [:standard-epochs/set-b-prop]
+    :watch "Views: B re-renders ← PROPS changed (the foil to step 8's sub-driven re-render)."}
 
    ;; -- Errors / Issues — each a real feature, not a buggy demo --
-   {:label     "Exception in the handler"
-    :event     [:standard-epochs/throw-handler]
-    :watch     "Issues: handler-exception + source coord; the :db (baseline bump) rolls back."
-    :settle-ms 450}
-   {:label     "Exception in an interceptor :before"
-    :event     [:standard-epochs/throw-interceptor]
-    :watch     "Issues: interceptor :before exception; the handler is skipped (chain aborts on the way in)."
-    :settle-ms 450}
-   {:label     "Exception in an interceptor :after"
-    :event     [:standard-epochs/throw-interceptor-after]
-    :watch     "Issues: interceptor :after exception; the handler ran, threw on the way out (foil to step 13)."
-    :settle-ms 450}
-   {:label     "Exception in a coeffect"
-    :event     [:standard-epochs/throw-cofx]
-    :watch     "Issues: cofx error; the handler is skipped (the throw fires during coeffect injection)."
-    :settle-ms 450}
-   {:label     "Exception in an effect"
-    :event     [:standard-epochs/throw-fx]
-    :watch     "Issues: fx error (post-commit, best-effort per the FX atomicity asymmetry); the db delta survives."
-    :settle-ms 450}
-   {:label     "Slow effect (~600ms)"
-    :event     [:standard-epochs/slow]
-    :watch     "Issues: the ~600ms managed fx is flagged slow; status :loading → :loaded once the deferred reply lands."
-    :settle-ms 800}
-   {:label     "Bad event args"
-    :event     [:standard-epochs/bad-event-args "not-a-number"]
-    :watch     "Issues / Schema-timeline: an event-args schema failure (a string where pos-int? is required); the handler is skipped."
-    :settle-ms 450}
-   {:label     "Bad app-db write"
-    :event     [:standard-epochs/bad-app-db-write]
-    :watch     "Issues: an app-db schema failure ([:auth :token] must be a string); the :db rolls back, the issue survives."
-    :settle-ms 450}
+   {:label "Exception in the handler"
+    :event [:standard-epochs/throw-handler]
+    :watch "Issues: handler-exception + source coord; the handler's :db never commits."}
+   {:label "Exception in an interceptor :before"
+    :event [:standard-epochs/throw-interceptor]
+    :watch "Issues: interceptor :before exception; the handler is skipped (chain aborts on the way in)."}
+   {:label "Exception in an interceptor :after"
+    :event [:standard-epochs/throw-interceptor-after]
+    :watch "Issues: interceptor :after exception; the handler ran, threw on the way out (foil to step 13)."}
+   {:label "Exception in a coeffect"
+    :event [:standard-epochs/throw-cofx]
+    :watch "Issues: cofx error; the handler is skipped (the throw fires during coeffect injection)."}
+   {:label "Exception in an effect"
+    :event [:standard-epochs/throw-fx]
+    :watch "Issues: fx error (post-commit, best-effort per the FX atomicity asymmetry); the committed db survives."}
+   {:label "Slow effect (~600ms)"
+    :event [:standard-epochs/slow]
+    :watch "Issues: the ~600ms managed fx is flagged slow; status :loading → :loaded once the deferred reply lands."}
+   {:label "Bad event args"
+    :event [:standard-epochs/bad-event-args "not-a-number"]
+    :watch "Issues / Schema-timeline: an event-args schema failure (a string where pos-int? is required); the handler is skipped."}
+   {:label "Bad app-db write"
+    :event [:standard-epochs/bad-app-db-write]
+    :watch "Issues: an app-db schema failure ([:auth :token] must be a string); the :db rolls back, the issue survives."}
 
    ;; -- Reactive substrate — diamond recompute probe --
-   {:label     "Bump diamond root"
-    :event     [:standard-epochs/bump-diamond]
-    :watch     "Diamond c ← a,b ← root: bump the root once; c's recompute count should rise by 1 (clean), 2 = double-compute."
-    :settle-ms 400}])
+   {:label "Bump diamond root"
+    :event [:standard-epochs/bump-diamond]
+    :watch "Diamond c ← a,b ← root: bump the root once; c's recompute count should rise by 1 (clean), 2 = double-compute."}])
 
 ;; ============================================================================
-;; RUNNER STATE — LOCAL ATOM (rf2-8pbjr: not app-db, not a 2nd frame)
-;; ============================================================================
-;;
-;; The single-frame deck's own runner atom (used by `run`). The two-frame
-;; isolation testbed does NOT use this — it supplies a DISTINCT atom per
-;; frame mount (so the two cursors stay independent), see that testbed's
-;; `core.cljs`.
-
-(defonce runner-state (r/atom (runner/initial-state)))
-
-;; ============================================================================
-;; ROOT — pure ladder, parameterised over (runner-state, host-frame, prefix)
+;; THE HOST FRAME + THE RUNNER WIRING (rf2-5sjbg)
 ;; ============================================================================
 ;;
-;; rf2-3xakq — `root` takes the runner atom + host-frame + testid prefix so
-;; the deck is mountable BOTH on its own single (`:rf/default`) frame (via
-;; the `standalone` wrapper below) AND twice (once per `:above` / `:below`
-;; frame) by the two-frame isolation testbed. rf2-7prmj — `root` is now a
-;; PURE ladder (runner + children + diamond): the title + intro header live
-;; in the standalone `run` path only, and there is no deck-reset button, so
-;; the two-frame cards stay clean per-frame ladders (no title duplication,
-;; no per-frame reset). The reg-view-injected `dispatch` / `subscribe` close
-;; over the surrounding frame-provider's frame id, so the same source drives
-;; an isolated reactive context per mount; the runner dispatches to
-;; `host-frame` explicitly (see runner.core/dispatch+settle!), keeping each
-;; runner's events scoped to the frame it inspects.
+;; `host-frame` is the inspected app frame the runner drives. The standalone
+;; deck uses `:rf/default`; the two-frame isolation testbed reuses this deck's
+;; `root` + steps but supplies its OWN host-frame (:above / :below) and
+;; registers its OWN run-step events (see that testbed). Here, the single-frame
+;; deck registers `:standard-epochs/run-step` against `:rf/default`.
 
-(reg-view root [runner-state host-frame prefix]
+(def host-frame :rf/default)
+
+(runner/reg-runner! {:id         :standard-epochs/run-step
+                     :steps      steps
+                     :host-frame host-frame})
+
+;; ============================================================================
+;; ROOT — pure ladder, parameterised over (host-frame, prefix, run-step-event)
+;; ============================================================================
+;;
+;; rf2-3xakq → rf2-5sjbg — `root` takes the host-frame + testid prefix + the
+;; deck's run-step event id so the deck is mountable BOTH on its own single
+;; (`:rf/default`) frame (via the `standalone` wrapper below) AND twice (once
+;; per `:above` / `:below` frame) by the two-frame isolation testbed. rf2-7prmj
+;; — `root` is a PURE ladder (runner + children + diamond): the title + intro
+;; header live in the standalone `run` path only, and there is no deck-reset
+;; button, so the two-frame cards stay clean per-frame ladders. The
+;; reg-view-injected `subscribe` closes over the surrounding frame-provider's
+;; frame id, so the same source drives an isolated reactive context (and an
+;; isolated per-frame `:step`) per mount; the runner dispatches the run-step
+;; event into `host-frame` explicitly, keeping each runner's events scoped to
+;; the frame it inspects. NO runner atom is threaded — the cursor lives in
+;; app-db's `:step`.
+
+(reg-view root [host-frame prefix run-step-event]
   [:div {:data-testid "standard-epochs-root"
          :style {:font-family "system-ui, sans-serif" :padding "1em"
                  :max-width "720px"}}
    ;; The runner — drives the step ladder against this mount's host-frame.
-   [runner/runner prefix runner-state steps host-frame]
+   [runner/runner {:run-step-event run-step-event
+                   :steps          steps
+                   :prefix         prefix
+                   :host-frame     host-frame}]
    ;; The two children, mounted / unmounted by steps 6..11. Child A
    ;; (sub-driven) takes the threshold N as a prop — read from
    ;; :views/threshold here so the arg-key is driven by app-db state
@@ -802,8 +775,6 @@
 (defn- resolve-project-root []
   (testbed-config/resolve-project-root "tools/xray/testbeds"))
 
-(def host-frame :rf/default)
-
 ;; ============================================================================
 ;; STANDALONE WRAPPER — header (title + intro) above the shared `root`
 ;; ============================================================================
@@ -824,7 +795,7 @@
      "The Epoch panel is the centerpiece of xray design. Use the "
      [:strong "⏭ Step"] " button to see how different pipeline scenarios "
      "are rendered."]]
-   [root runner-state host-frame "standard-epochs"]])
+   [root host-frame "standard-epochs" :standard-epochs/run-step]])
 
 (defn ^:export run []
   ;; Configure Xray BEFORE `rf/init!` so the preload's auto-open reads the
@@ -833,8 +804,8 @@
   (rf/init! reagent-adapter/adapter)
   ;; Single, plain frame — no URL machinery, no history listener (there is
   ;; no routing here). The default frame is the one Xray reads. Mount the
-  ;; standalone wrapper (header + the parameterised `root`) with this deck's
-  ;; own runner atom, the `:rf/default` host-frame, and the `standard-epochs`
-  ;; testid prefix.
+  ;; standalone wrapper (header + the parameterised `root`) on the
+  ;; `:rf/default` host-frame with the `standard-epochs` testid prefix and
+  ;; the deck's run-step event. The runner cursor lives in app-db `:step`.
   (rf/dispatch-sync [:standard-epochs/reset])
   (rdc/render react-root [standalone]))

--- a/tools/xray/testbeds/two_frame_isolation/README.md
+++ b/tools/xray/testbeds/two_frame_isolation/README.md
@@ -48,27 +48,29 @@ It does **not** call `standard-epochs.core/run` (which would mount the
 deck once into `#app` on the default frame). It reuses only the
 registrations + the `root` Var.
 
-### Per-frame runner atoms (rf2-3xakq)
+### Per-frame run-step events (rf2-3xakq → rf2-5sjbg)
 
-`standard-epochs.core/root` was converted to the shared queued-step
-runner (`runner.core`) and parameterised over `[runner-state host-frame
-prefix]`. The runner's cursor lives in a **local Reagent atom** and the
-runner dispatches to its `host-frame` **explicitly** (a runner control's
+`standard-epochs.core/root` is the shared step-driver runner
+(`runner.core`), parameterised over `[host-frame prefix run-step-event]`.
+The runner's cursor lives in each frame's **app-db `:step`** slot (NOT a
+Reagent atom) — and per-frame app-db gives each mount its own `:step`, so
+the two cursors are isolated by construction. The runner dispatches its
+run-step event into `host-frame` **explicitly** (a runner control's
 `on-click` fires outside the React frame-provider context, so an
 un-targeted dispatch would land on the ambient frame). This testbed
-therefore supplies a **distinct runner atom + the frame's own id + a
-distinct testid prefix per mount**:
+therefore registers a **distinct run-step event per frame** and supplies
+**the frame's own id + a distinct testid prefix + that event per mount**:
 
-| frame    | runner atom          | host-frame | prefix                   |
-| -------- | -------------------- | ---------- | ------------------------ |
-| `:above` | `above-runner-state` | `:above`   | `standard-epochs-above`  |
-| `:below` | `below-runner-state` | `:below`   | `standard-epochs-below`  |
+| frame    | host-frame | prefix                  | run-step event              |
+| -------- | ---------- | ----------------------- | --------------------------- |
+| `:above` | `:above`   | `standard-epochs-above` | `:two-frame/run-step-above` |
+| `:below` | `:below`   | `standard-epochs-below` | `:two-frame/run-step-below` |
 
-Two genuinely independent runner cursors, each driving events **only**
-into its own frame. Pressing **⏭ Step** (or a numbered RUN-THIS-STEP
-button) in `:above` advances only `:above`'s cursor and moves only
-`:above`'s app-db / sub-cache / epoch history — the load-bearing detail
-that keeps the isolation proof intact under the runner conversion.
+Two genuinely independent cursors, each driving events **only** into its
+own frame. Pressing **⏭ Step** (or a numbered RUN-THIS-STEP button) in
+`:above` writes only `:above`'s `:step` and moves only `:above`'s app-db /
+sub-cache / epoch history — the load-bearing detail that keeps the
+isolation proof intact. There is **no Reagent atom** for step state.
 
 > **Why `standard_epochs` ×2 (rf2-wa8my)?** The earlier shape mounted a
 > bespoke `testdeck.*` tabs-as-routes panel. That coupled this testbed
@@ -126,10 +128,9 @@ numbered **RUN-THIS-STEP** button to drive a specific step directly
 (`standard-epochs-above-step-<n>-run` / `standard-epochs-below-step-<n>-run`,
 n = 0-based).
 
-1. **Frame divergence on the baseline.** Run step **1 (Increment)**
-   three times on `:above`. Switch the Xray frame picker to `:below`:
-   the Events list is empty for `:below`; the App-db diff shows no
-   `:baseline` movement.
+1. **Frame divergence on the step cursor.** Run step **1 (Increment)**
+   on `:above`. Switch the Xray frame picker to `:below`: the Events list
+   is empty for `:below`; the App-db diff shows no `:step` movement.
 
 2. **Per-frame Views.** Run step **6 (Mount Child A)** on `:above`
    only. Switch the picker to `:below`: the Views lens shows no Child-A

--- a/tools/xray/testbeds/two_frame_isolation/core.cljs
+++ b/tools/xray/testbeds/two_frame_isolation/core.cljs
@@ -45,23 +45,25 @@
   reuse only its registrations + its `root` Var, and supply our own
   two-frame harness + mount here.
 
-  ## Per-frame runner atoms (rf2-3xakq — the isolation-preserving mount)
+  ## Per-frame run-step events (rf2-3xakq → rf2-5sjbg — isolation-preserving)
 
-  `standard-epochs.core/root` was converted to the shared queued-step
-  runner (`runner.core`) and parameterised over `[runner-state host-frame
-  prefix]`. The runner's cursor lives in a LOCAL Reagent atom, and the
-  runner dispatches to its `host-frame` explicitly. So this testbed
-  supplies a DISTINCT runner atom + the frame's own id + a distinct testid
-  prefix per mount:
+  `standard-epochs.core/root` is the shared step-driver runner
+  (`runner.core`), parameterised over `[host-frame prefix run-step-event]`.
+  The runner's cursor now lives in app-db's `:step` slot — and per-frame
+  app-db gives EACH frame mount its OWN `:step`, so the two cursors are
+  isolated by construction. This testbed registers a DISTINCT run-step event
+  per frame (each closing over its frame's host-frame so the step's child
+  dispatches land in the right frame) and mounts `root` with the frame's own
+  id + a distinct testid prefix + that event:
 
-    :above → (above-runner-state, :above, \"standard-epochs-above\")
-    :below → (below-runner-state, :below, \"standard-epochs-below\")
+    :above → (:above, \"standard-epochs-above\", :two-frame/run-step-above)
+    :below → (:below, \"standard-epochs-below\", :two-frame/run-step-below)
 
-  Two genuinely independent runner cursors, each driving events ONLY into
-  its own frame — no shared cursor, correct per-frame focus. This is the
-  load-bearing detail that keeps the isolation proof intact under the
-  runner conversion: pressing Step (or a RUN-THIS-STEP button) in `:above`
-  moves ONLY `:above`'s app-db / sub-cache / epoch history.
+  Two genuinely independent cursors, each driving events ONLY into its own
+  frame — no shared cursor, correct per-frame isolation. Pressing Step (or a
+  RUN-THIS-STEP button) in `:above` moves ONLY `:above`'s app-db (including
+  its `:step`) / sub-cache / epoch history. There is NO Reagent atom for step
+  state anywhere (rf2-5sjbg).
 
   ## What this proves — per-frame isolation
 
@@ -77,8 +79,8 @@
   The load-bearing rules this testbed exhibits:
 
     - Trace, events, and epochs are scoped to their frame: pressing a
-      button in `:above` moves ONLY `:above`'s `:baseline` / `:views` /
-      `:shapes`; `:below` stays put (and vice-versa).
+      button in `:above` moves ONLY `:above`'s `:step` / `:views`;
+      `:below` stays put (and vice-versa).
     - Subs do NOT reach across frames — every sub reads the current
       frame's `app-db` only. There is no cross-frame projection helper,
       no shared root state. The cross-frame anti-pattern is structurally
@@ -96,15 +98,16 @@
   (`npm run test:cljs`) + the Xray feature-matrix gate's `multi-frame
   isolation substrate` scenario (on the framework `testbeds/multi_frame`
   surface)."
-  (:require [reagent.core :as r]
-            [reagent.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Requiring `standard-epochs.core` installs every handler /
             ;; sub / view / cofx / fx / flow / schema ONCE globally and
-            ;; gives us its `root` step-ladder view. We mount that view
-            ;; twice below (with a distinct per-frame runner atom +
-            ;; host-frame + prefix); we do NOT call its `run` (which would
-            ;; mount it once into `#app` on the default frame).
+            ;; gives us its `root` step-ladder view + its `steps` vector. We
+            ;; mount that view twice below (with a distinct per-frame
+            ;; host-frame + prefix + run-step event); we do NOT call its
+            ;; `run` (which would mount it once into `#app` on the default
+            ;; frame) and we do NOT reuse its `:standard-epochs/run-step`
+            ;; event (that targets `:rf/default`).
             [standard-epochs.core :as se]
             [re-frame.adapter.reagent :as reagent-adapter]
             ;; rf2-6jyf6 — Xray's `configure!` to seed `:project-root`
@@ -114,10 +117,11 @@
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared queued-step runner (rf2-8pbjr pilot). We need its
-            ;; `initial-state` to seed a DISTINCT runner atom per frame —
-            ;; the standard-epochs `root` drives the runner, and each
-            ;; mount must own its own cursor for the isolation proof.
+            ;; The shared step-driver runner (rf2-5sjbg). We register a
+            ;; DISTINCT run-step event per frame (each targeting that
+            ;; frame's host-frame) so each mount's Step button drives ONLY
+            ;; its own frame — the isolation proof. The cursor itself lives
+            ;; in each frame's app-db `:step`.
             [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -129,24 +133,27 @@
 (def frame-below :below)
 
 ;; ============================================================================
-;; PER-FRAME RUNNER ATOMS (rf2-3xakq — distinct cursor per mount)
+;; PER-FRAME RUN-STEP EVENTS (rf2-5sjbg — distinct driver per mount)
 ;; ============================================================================
 ;;
-;; The standard-epochs `root` is runner-driven; the runner's cursor lives
-;; in a LOCAL Reagent atom. Each frame mount gets its OWN atom so the two
-;; runner cursors are genuinely independent — pressing Step in `:above`
-;; advances ONLY `:above`'s cursor (and dispatches ONLY into `:above`).
-;; These are NOT app-db, NOT a re-frame frame — plain component-local
-;; atoms invisible to Xray's frame surfaces (the rf2-8pbjr contract).
+;; The standard-epochs `root` is the step-driver runner; the cursor lives in
+;; each frame's app-db `:step`. We register a distinct run-step event per
+;; frame, each closing over its frame's id so the step's child dispatches
+;; land in the right frame. Pressing Step in `:above` writes ONLY `:above`'s
+;; `:step` and dispatches ONLY into `:above`. The step vector is the SAME one
+;; standard-epochs owns (`se/steps`); only the frame differs.
 
-(defonce above-runner-state (r/atom (runner/initial-state)))
-(defonce below-runner-state (r/atom (runner/initial-state)))
+(def run-step-above :two-frame/run-step-above)
+(def run-step-below :two-frame/run-step-below)
+
+(runner/reg-runner! {:id run-step-above :steps se/steps :host-frame frame-above})
+(runner/reg-runner! {:id run-step-below :steps se/steps :host-frame frame-below})
 
 ;; ============================================================================
 ;; ROOT VIEW — the standard-epochs ladder mounted twice, one per frame-provider
 ;; ============================================================================
 
-(reg-view frame-card [frame-label runner-state host-frame prefix]
+(reg-view frame-card [frame-label host-frame prefix run-step-event]
   (let [accent (case frame-label
                  "above" "#2b7"
                  "below" "#36c"
@@ -169,12 +176,13 @@
         "(" frame-label ")"]]
       [:span {:style {:font-size "11px" :color "#888"}}
        "isolated reactive context"]]
-     ;; The SHARED app code path: the standard-epochs runner-driven deck.
+     ;; The SHARED app code path: the standard-epochs step-driver deck.
      ;; The reg-view-injected dispatch / subscribe close over THIS
      ;; frame-provider's frame id, so the same view source drives two
-     ;; independent reactive contexts; the per-frame runner atom +
-     ;; host-frame keep this mount's cursor + dispatches isolated.
-     [se/root runner-state host-frame prefix]]))
+     ;; independent reactive contexts; the per-frame host-frame +
+     ;; run-step event keep this mount's `:step` cursor + dispatches
+     ;; isolated.
+     [se/root host-frame prefix run-step-event]]))
 
 (reg-view root []
   [:div {:data-testid "two-frame-isolation-root"
@@ -190,14 +198,14 @@
      [:code "frame-provider"]
      " below renders the same view source against a separate "
      [:code "app-db"] " + sub-cache + epoch history (and its OWN runner "
-     "cursor). Drive one frame; the other stays put. Switch frames in Xray "
-     "(right) with the frame picker to compare trace / events / epochs per "
-     "frame."]]
+     [:code ":step"] " cursor). Drive one frame; the other stays put. "
+     "Switch frames in Xray (right) with the frame picker to compare "
+     "trace / events / epochs per frame."]]
    [:div {:style {:display "flex" :flex-direction "column"}}
     [rf/frame-provider {:frame frame-above}
-     [frame-card "above" above-runner-state frame-above "standard-epochs-above"]]
+     [frame-card "above" frame-above "standard-epochs-above" run-step-above]]
     [rf/frame-provider {:frame frame-below}
-     [frame-card "below" below-runner-state frame-below "standard-epochs-below"]]]])
+     [frame-card "below" frame-below "standard-epochs-below" run-step-below]]]])
 
 ;; ============================================================================
 ;; MOUNT


### PR DESCRIPTION
## What

Rewrites the shared Xray-testbed `runner.core` as a proper re-frame2 step driver and migrates **all six runner decks in one PR** (no shim, no dual API — the shared dependency makes it atomic by construction). Per the rf2-5sjbg ruling: the decks must read as ordinary re-frame2 apps — app-db + events + subs, zero harness atoms.

## The re-architecture

- **app-db `:step`** replaces both `:baseline` and the runner-atom cursor — they were the same thing ("which step are we on"). `:step` churning each step IS the per-step app-db delta the panels show.
- **`[:run-step n]` event** (registered per deck via `runner/reg-runner!`): `assoc :step = n` + fan out the step's `:event`(s) as `:dispatch`es into the deck's `host-frame`.
- **`:rf.runner/step` subscription** drives the row highlight + the "step n / total" counter.
- Step button → `[:run-step (inc current)]` (wraps at the end); each per-row button → `[:run-step n]` (the #2885 thunk is now `#(dispatch [:run-step n] {:frame host-frame})`).
- **No Reagent atom** for step state anywhere. No atom / steps / host-frame / timer passed to any leaf view — the leaf `step-row` carries only `[prefix n step current? done? on-run]`. `host-frame` stays a runner CONFIG input (and a control-bar arg so the out-of-tree Step click scopes its dispatch), never a leaf arg.
- **Deleted the vestigial timing machinery**: `:settle-ms` / `:before-ms` / the `:timer` handle / `clear-timer!` / `advance!` / `run-step!` / `dispatch+settle!` / `run-series!` / `step-once!` / `run-step-at!` / `initial-state`, plus the now-dead `focus-latest-host-epoch!` and the `xray-focus` / `xray-defaults` / `reagent.core` requires. Its only consumer (auto-run-series) was removed by #2876; manual stepping needs no pacing.

## Decks migrated (all six)

standard-epochs · routes-epochs · machine-epochs · edn-inspector · managed-http · two-frame-isolation. Each swaps `:baseline` for `:step` (seed `nil`), drops every `bump` and the `runner-state` atom + now-unused requires, registers `<deck>/run-step`, and mounts the runner via the config map. two-frame-isolation registers a **distinct run-step event per frame** (`:two-frame/run-step-above|below`), each targeting its frame — per-frame app-db gives each mount its own `:step`, so the isolation proof holds with zero atoms.

## Acceptance grep (clean)

```
$ git grep -n "r/atom\|reagent.core/atom" -- <runner + 6 decks>
(no matches)
```

No `r/atom` / `reagent.core/atom` for step state in the runner or any deck; no `runner-state` / `initial-state` / timing fns / atom/steps/host-frame threaded to any leaf view.

## Quality gates (cold)

- Six example builds compile — **0 warnings each** (`:examples/standard-epochs|routes-epochs|machine-epochs|edn-inspector|managed-http|two-frame-isolation`).
- `npm run test:cljs` — **5472 tests / 18948 assertions, 0 failures, 0 errors** (incl. the machine-epochs harness CLJS test).
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures** (Step + per-row `[:run-step n]` buttons drive the routes-epochs + machine-epochs ladders green).
- `tools/xray/spec/*` (021, 003) + the runner docstring updated to document the new app-db/events/subs step-driver contract.

Closes rf2-5sjbg.