### PR TITLE
docs(guide): rebuild 18-frames to the frame-affordance redesign (rf2-kkut0.9)

### DIFF
--- a/docs/guide/18-frames.md
+++ b/docs/guide/18-frames.md
@@ -89,8 +89,7 @@ Two shapes, and you pick between them on one question: will you dispatch into th
 ;; Named, registered up front. You'll address this frame
 ;; from elsewhere using its keyword.
 (rf/reg-frame :left
-  {:doc       "Left-hand counter."
-   :on-create [:counter/initialise]})
+  {:on-create [:counter/initialise]})
 
 ;; Anonymous, gensym'd id. You hold the returned keyword
 ;; and tear it down explicitly.
@@ -99,7 +98,7 @@ Two shapes, and you pick between them on one question: will you dispatch into th
   (rf/destroy-frame! f))
 ```
 
-`reg-frame` is for frames whose identity is fixed at app-load — the two analytics panels, named Story variants, the SSR frame you'll dispatch into from request-handler code. `make-frame` is for frames whose whole lifecycle is owned by the surrounding code — tests, per-mount devcards, a modal stack — where there's no name worth choosing and the gensym is exactly right. Both end in the same place: a frame in the registry, addressable by keyword, its `app-db` seeded by `:on-create`.
+`reg-frame` is for frames whose identity is fixed at app-load — the two analytics panels, named Story variants, the SSR frame you'll dispatch into from request-handler code. `make-frame` is for frames whose whole lifecycle is owned by the surrounding code — tests, per-mount devcards, a modal stack — where there's no name worth choosing and the gensym (a `:rf.frame/`-namespaced keyword) is exactly right. Both end in the same place: a frame in the registry, addressable by keyword, its `app-db` seeded by `:on-create`.
 
 ### `:on-create` — how a frame's state gets seeded
 
@@ -115,20 +114,28 @@ A freshly-created frame's `app-db` is **always `{}`**. There is no `:db` config 
 
 Need to fire several init events? The single `:on-create` handler does it through its effect map — `:fx [[:dispatch [:counter/restore]] [:dispatch [:prefs/load]]]` — and run-to-completion guarantees those cascades fully settle before `reg-frame` returns. There's a symmetric `:on-destroy` slot for teardown effects, and `reg-frame` accepts a broader metadata grammar (`:interceptors`, `:on-error`, `:platform`, and the presets below) that downstream chapters introduce as each surface needs it.
 
+### Re-registering, resetting, destroying
+
+The three lifecycle verbs round out the surface:
+
+- **`reg-frame` on a name that already exists** is a *surgical update*: the config is replaced, but the live runtime state (`app-db`, queue, sub-cache) is **preserved** and the `:on-create` event does **not** re-fire. This is the hot-reload-friendly shape — re-saving a file that re-runs your `reg-frame` calls won't blow away the state you were looking at, exactly the way `app-db` doesn't reset when you save a file today.
+- **`reset-frame!`** is the explicit "I actually do want the init cascade again" verb — equivalent to a `destroy-frame!` followed by a fresh `reg-frame` with the current config, so `:on-create` re-fires against a `{}` `app-db`.
+- **`destroy-frame!`** tears the frame down: it fires `:on-destroy`, then removes the keyword from the registry. A subsequent `dispatch` / `subscribe` against that keyword throws (`:reason :frame-destroyed`) — a destroyed frame is gone, not silently re-defaulted.
+
 ## Targeting a frame — and why you mostly won't have to
 
-From *outside* a view — a REPL session, a test, framework-level code — you name the frame explicitly:
+From *outside* a view — a REPL session, a test, framework-level code — you name the frame explicitly with the `{:frame ...}` opt:
 
 ```clojure
 (rf/dispatch  [:counter/inc] {:frame :left})   ;; dispatch — opts map
 (rf/subscribe :right [:count])                 ;; subscribe — frame-id positional
 ```
 
-(The shapes differ for historical reasons — `dispatch` carries other opts in that map; `subscribe`'s out-of-view callers are tooling-shaped. Don't read meaning into the asymmetry.)
+(The shapes differ for historical reasons — `dispatch` carries other opts in that map; `subscribe`'s out-of-view callers are tooling-shaped. Don't read meaning into the asymmetry.) The `{:frame ...}` opt is the **explicit override** — first-class routing for tools, tests, SSR boot code, and fx handlers. Everything else in this chapter is a more ergonomic way of *not* having to write it at every call site.
 
 But here's the thing you'll actually do day-to-day: *inside* a registered view, you **never write `{:frame ...}`**. Look back at the analytics panels — the whole point was that the view function doesn't know it's been instantiated twice. So how does its `dispatch` know which frame to hit?
 
-The answer is `frame-provider`, and it's the mechanism the entire chapter has been building toward. It wraps a subtree, carries a frame keyword down through React context, and the `dispatch` / `subscribe` that `reg-view` auto-injects into the view's body resolve against it:
+The answer is `frame-provider`, and it's the mechanism the view-side of the chapter is built around. It wraps a subtree, carries a frame keyword down through React context, and the `dispatch` / `subscribe` that `reg-view` auto-injects into the view's body resolve against it:
 
 ```clojure
 [:div.analytics
@@ -140,7 +147,7 @@ The answer is `frame-provider`, and it's the mechanism the entire chapter has be
 
 Two instances of the *same* registered view; two frames; each subtree's `dispatch` / `subscribe` silently routed to its own `app-db`. The view function is frame-blind — it just calls `(dispatch [...])` and `(subscribe [...])` — and the framework routes correctly based on which provider it finds itself under. That frame-blindness is the load-bearing reason to register views with `reg-view` rather than writing bare `defn` functions: a registered view's body can be instantiated under any frame and Just Works.
 
-(`frame-provider` is React-context-driven, so it's Reagent-specific in *mechanism*. The *pattern* — every dispatch and subscribe targets a specific frame, by whatever means the host language offers — is what survives across substrates and ports.)
+(`frame-provider` is React-context-driven, so it's substrate-specific in *mechanism* — every adapter, Reagent / UIx / Helix, reads and writes the same context object. The *pattern* — every dispatch and subscribe targets a specific frame, by whatever means the host language offers — is what survives across substrates and ports.)
 
 ## The split-counter, end to end
 
@@ -173,6 +180,123 @@ That's the whole thing, and I want you to notice what isn't in it. There's no pa
 
 Go back and reread the analytics problem from the top of the chapter. The "but how?" is now a `frame-provider` and a `reg-frame`, and not one line of the feature changed.
 
+## The async-boundary problem — why a bare `dispatch` can leak
+
+The split-counter works because of a quiet bit of magic in the last section, and it's the magic that the rest of this chapter is about. Inside a `reg-view` body the injected `dispatch` knows it's under `:left` because `reg-view` reads the frame from React context **at render time** and bakes it into the `dispatch` closure. The `:on-click` lambda closes over that closure, so when the click fires — long after render unwound — it still dispatches into `:left`. The frame rode along inside the closure.
+
+Now break that. Render time is not the only moment a callback gets created, and React context is **render-only knowledge** — it's gone the instant render returns. The moment your callback is built somewhere *other* than directly in a `reg-view` body — or fires across an async boundary — the ambient "I'm under `:left`" knowledge has evaporated, and a bare `dispatch` falls through to `:rf/default`. That's a state leak: the left panel's WebSocket message lands in the wrong `app-db`.
+
+The cases where this bites:
+
+- A `setTimeout` / `setInterval` callback.
+- A `Promise.then` / `js/await` continuation.
+- A WebSocket / `EventSource` `onmessage` handler.
+- An `IntersectionObserver` / `MutationObserver` callback, a `requestAnimationFrame` tick.
+- A raw `window.addEventListener` handler — a drag flow that registers `pointermove` / `pointerup` on `window` so the move/up fire *outside* the React tree after render unwound.
+- A callback handed to a third-party SDK that calls you back later.
+
+The unifying property: the callback is **constructed in one synchronous moment when the frame is still resolvable, but invoked later, on a fresh stack, after the binding is gone.** The fix is always the same shape — capture the frame at the synchronous moment, carry it into the callback as a closure value. The frame-affordance surface is exactly the set of tools for doing that capture cleanly.
+
+## `frame-handle` — the keystone affordance
+
+`frame-handle` is the answer to "I need to dispatch (or subscribe) from a callback that fires later." It captures the frame **at creation time** and hands you back an **operation bundle** — a map of frame-locked ops:
+
+```clojure
+(rf/frame-handle)            ;; capture the ambient frame (current-frame-id)
+(rf/frame-handle :rf/xray)   ;; bundle locked to an explicit frame-id
+;; =>
+{:frame         <id>
+ :dispatch      (fn ([event] [event opts]))
+ :dispatch-sync (fn ([event] [event opts]))
+ :subscribe     (fn [query-v])}
+```
+
+Build the handle while the frame is still ambient — inside a `reg-view` body, inside an event handler, under a `with-frame` — and from then on every op on the bundle targets the captured frame, no matter when or where it fires. The capture is **locked**: a per-call `:frame` opt cannot override it, so you can't accidentally re-route a handle. (One nuance worth holding: the handle is an *operation bundle*, not a container — to read a frame's `app-db` value you call `(rf/app-db-value (:frame handle))`, not the handle itself.)
+
+The WebSocket case, end to end:
+
+```clojure
+(rf/reg-view stream-view [_]
+  (let [{:keys [dispatch]} (rf/frame-handle)]      ;; captures the render frame
+    (ws/subscribe! (fn [msg] (dispatch [:ws/incoming msg])))
+    [:div "streaming…"]))
+```
+
+`ws/subscribe!`'s callback fires minutes later, on a socket turn with no React context and no dynamic binding — and it still dispatches into the right frame, because the frame was baked into `dispatch` when the handle was built during render. A left-panel stream lands in `:left`; a right-panel stream lands in `:right`; you wrote the view once.
+
+The same handle covers the raw-`addEventListener` drag flow: capture `(rf/frame-handle)` in the `:on-pointer-down`, close over its `dispatch` in the `pointermove` / `pointerup` listeners you attach to `window`, and the move/up dispatches route correctly even though they fire entirely outside the React tree.
+
+## `frame-bound-fn` / `frame-bound-fn*` — when the value is an arbitrary fn
+
+`frame-handle` is the right tool when the thing you're carrying across the boundary is a *dispatch* or *subscribe*. Sometimes it isn't — sometimes the value you must carry is an arbitrary function whose *body* needs to re-establish the frame (a fn that itself calls `current-frame-id`, or makes several dispatches and subscribes, or threads through a helper that does). For that, you want the frame re-bound around the whole fn body, and that's what `frame-bound-fn` and its `*`-twin do:
+
+```clojure
+;; Macro form — `(fn ...)` syntax + frame-capture in one step.
+(rf/frame-bound-fn [msg]
+  (rf/dispatch [:ws/incoming msg]))          ;; closure carries the captured frame
+
+;; *-twin fn form — wrap an existing fn value (HoF / programmatic wrap).
+(rf/frame-bound-fn*
+  (fn [msg] (rf/dispatch [:ws/incoming msg])))
+
+;; *-twin with an EXPLICIT frame-id — no surrounding with-frame / provider
+;; needed at wrap time. The shape for module-level install! routines.
+(rf/frame-bound-fn* :rf/xray
+  (fn [_e mode] (rf/dispatch [:set-mode mode])))
+```
+
+Both produce a fn that runs its body inside a `binding` that re-establishes the captured frame — so plain `dispatch` / `subscribe` *inside* the wrapped body pick up the right frame, however deep the call chain goes and whenever the call fires.
+
+The rule of thumb: **reach for `frame-handle` for the common dispatch/subscribe case; reach for `frame-bound-fn` / `frame-bound-fn*` when you're wrapping an arbitrary fn whose body re-establishes the frame.** Use the macro (`frame-bound-fn`) when you want `(fn ...)` syntax inline; use the `*`-twin (`frame-bound-fn*`) when you already hold a fn value or need to name the frame explicitly at wrap time.
+
+### A look-alike that is *not* this bug
+
+There's an adjacent failure mode worth naming so you don't reach for the wrong tool. "My view doesn't update when I click" sometimes looks like a lost-frame bug but is actually a Reagent reactive-tracking failure — a lazy `(for ...)` in a view body whose elements deref subscriptions, where the deref happens outside the render's tracking scope. The fix for *that* is to realise the seq inside render (`doall` / `mapv` / `into`), not a frame affordance. Reach for `frame-handle` / `frame-bound-fn` only when you have a genuine async boundary (timer, promise, socket, out-of-tree listener); reach for `doall` when a lazy seq is swallowing the deref. The two are not interchangeable.
+
+### The handler-side shortcut: `:fx`
+
+One important case where you *don't* reach for any of the above: dispatching from inside an **event handler**. The router binds the in-flight frame for the duration of a handler, so a synchronous `(rf/dispatch [:child])` from a handler body routes to the handler's own frame automatically. And when a handler wants to schedule a *later* dispatch — an HTTP reply, a timer — it returns effect data rather than calling host async directly:
+
+```clojure
+;; canonical: the fx walker threads the frame through for you
+{:fx [[:dispatch [:next-step]]
+      [:dispatch-later {:ms 500 :event [:tick]}]]}
+```
+
+The `:dispatch` and `:dispatch-later` effects capture the in-flight frame in their closure before the timer or microtask boundary, so the deferred dispatch carries the right frame with zero ceremony. This is *the* multi-frame pattern for handler-emitted work — prefer it over a manual `js/setTimeout` whenever the dispatch originates from a handler. `frame-handle` is for the cases `:fx` can't reach: a callback handed to a non-fx async library, or one set up directly in a view body.
+
+## Scoping a frame from code: `with-frame` and `with-new-frame`
+
+`frame-provider` scopes a frame to a *React subtree*. Outside the view layer — in tests, at the REPL, in framework-level code — you scope a frame **lexically** instead, with two macros that bind the ambient frame for the duration of a body:
+
+```clojure
+;; Pin to a frame that already exists. Not created, not destroyed.
+(rf/with-frame :scratch
+  (rf/dispatch-sync [:counter/inc])      ;; routes to :scratch via the ambient binding
+  @(rf/subscribe [:count]))              ;; also :scratch
+
+;; Create + own + destroy in one block — the common test shape.
+(rf/with-new-frame [f (rf/make-frame {:on-create [:counter/init]})]
+  (rf/dispatch-sync [:counter/inc])      ;; routes to f
+  ;; ... assertions ...
+  )                                      ;; f is destroyed on exit, success or throw
+```
+
+`with-frame` pins the ambient frame to an existing frame-id; the frame outlives the block. `with-new-frame` is the eval-bind-run-destroy form — it evaluates an expression that *creates* a frame (`make-frame`, or a `reg-frame` that returns its keyword), binds the result, runs the body with that frame ambient, and destroys it on the way out regardless of how the body exits. That tear-down-on-exit is exactly the isolation [chapter 13](13-testing.md) leans on — a fresh frame per test, gone before the next one starts, no try/finally.
+
+One sharp edge that ties back to the async section: **the lexical binding these macros establish is render-and-call-time only.** An async closure that fires *after* the body returns has missed it — and with `with-new-frame` the frame has already been destroyed by then. If a body sets up a callback that fires later, capture the frame with `frame-handle` / `frame-bound-fn` *inside* the body, before it returns.
+
+## Reading and listing frames
+
+Rounding out the surface, the read / introspection verbs — what tools, tests, and the REPL use to look at a frame from outside:
+
+- **`(rf/current-frame-id)`** — the active frame at the call site, resolved through the chain (dynamic var → React context → `:rf/default`). A keyword.
+- **`(rf/app-db-value frame-id)`** — the current `app-db` of a frame as a plain map (the deref'd *value*, no container, no reactivity). `nil` if the frame isn't registered. This is how you assert against a frame's state in a test, and how a handle's owner reads the state behind the ops.
+- **`(rf/snapshot-of path)` / `(rf/snapshot-of path {:frame id})`** — convenience over `(get-in (rf/app-db-value frame-id) path)`; resolves the current frame when you don't pass one.
+- **`(rf/frame-ids)`** / **`(rf/frame-meta frame-id)`** — list the registered frames and read a frame's effective metadata. The shape your tooling walks.
+
+There's also `app-db-container` — but it returns the underlying substrate-managed *reactive cell* (an atom under stock Reagent, a different cell under other substrates), and it exists for **framework internals, tools, and adapter code** that need to read or replace the container itself. Application code never wants it: handlers receive `db` through coeffects, views read via subscriptions, and tests assert against `app-db-value`. If you find yourself reaching for `app-db-container` in app code, you've almost certainly taken a wrong turn — the value accessor is what you want.
+
 ## Frames are not "components with state"
 
 There's a failure mode that shows up the moment frames click for someone, and I want to head it off, because it's seductive and it's wrong. The temptation is: *frames give per-instance isolation — so I'll give every reusable widget its own frame and scope all its local state inside it.* A frame per tooltip. A frame per dropdown. A frame as a fancy `useState`.
@@ -195,6 +319,6 @@ Most frames you'll ever register fall into one of four shapes: a normal client a
 (rf/reg-frame :ssr.req/abc123      {:preset :ssr-server})
 ```
 
-The win is legibility: a reader skimming the source can tell at a glance that *this* is a test frame and *that* one is a Story variant, without decoding a metadata map. The expansion is locked — four presets, no more — which keeps the set canonical for AI scaffolding and for cross-codebase recognition. [Chapter 20](20-server-side.md), [chapter 13](13-testing.md), and the [Story tutorial](../story/index.md) each introduce the preset they need in the context that needs it.
+The same `:preset` key works on `make-frame` too, with the same expansion. The win is legibility: a reader skimming the source can tell at a glance that *this* is a test frame and *that* one is a Story variant, without decoding a metadata map. The expansion is locked — four presets, no more — which keeps the set canonical for AI scaffolding and for cross-codebase recognition. [Chapter 20](20-server-side.md), [chapter 13](13-testing.md), and the [Story tutorial](../story/index.md) each introduce the preset they need in the context that needs it.
 
-The chapters that exercise multi-frame in anger are all downstream of this one — [testing](13-testing.md) uses the per-test fixture, [Story](../story/index.md) the frame-per-variant, [the server side](20-server-side.md) the per-request frame. Each of those walks its own surface. This chapter is the substrate they all stand on: a frame is one isolated instance of your app, the framework gives you the first one free, and everything you've already learned runs inside it unchanged.
+The chapters that exercise multi-frame in anger are all downstream of this one — [testing](13-testing.md) uses the per-test fixture and `with-new-frame`, [Story](../story/index.md) the frame-per-variant, [the server side](20-server-side.md) the per-request frame. Each of those walks its own surface. This chapter is the substrate they all stand on: a frame is one isolated instance of your app, the framework gives you the first one free, everything you've already learned runs inside it unchanged, and when a callback has to outlive its render you capture the frame with a handle and carry it across.


### PR DESCRIPTION
Rebuilds the `18-frames` guide chapter (`docs/guide/18-frames.md`) to teach the **frame-affordance redesign** (kkut0 W4), which has landed in-tree. Landing this closes the `kkut0` EPIC dependency (rf2-kkut0.9).

## What changed

The prior chapter taught the frame *model* well but never taught the affordance surface that the redesign introduced — the async-boundary problem and the tools for surviving it. This rebuild keeps the strong existing narrative and adds the missing teaching.

**Preserved** (frame model, unchanged in spirit): the analytics motivating problem, "frames isolate state not behaviour", when-you-need-more-than-one, the `:rf/default` framing, `reg-frame` / `make-frame` / `:on-create`, `frame-provider`, the split-counter, presets, and the "frames are not components with state" warning.

**Added** (the redesign surface, all read from the shipped code + `spec/002-Frames.md`):
- **The async-boundary problem** — why React-context frame knowledge is render-only and a bare `dispatch` from a later callback leaks to `:rf/default`.
- **`frame-handle`** — the keystone operation-bundle affordance (`{:frame :dispatch :dispatch-sync :subscribe}`), frame captured + locked at creation; the WebSocket and out-of-tree-listener cases.
- **`frame-bound-fn` / `frame-bound-fn*`** — frame-capturing closures for wrapping an arbitrary fn whose body re-establishes the frame; the macro-vs-`*`-twin guidance; the look-alike Reagent reactive-tracking failure that is *not* this bug.
- **The `:fx` handler-side shortcut** — `:dispatch` / `:dispatch-later` thread the in-flight frame automatically.
- **`with-frame` / `with-new-frame`** — lexical frame scoping for tests/REPL/framework code, with the binding-unwinds-before-async caveat.
- **Read / lifecycle surface** — `current-frame-id`, `app-db-value`, `snapshot-of`, `frame-ids`, `frame-meta`, plus the internals-only `app-db-container` (the rename of the former `get-frame-db`), and `reset-frame!` / `destroy-frame!` / surgical re-`reg-frame`.

## Quality gates

- `mkdocs build --strict` — **exit 0** (cold). No broken anchors/links introduced by the rewrite; the only build output lines are pre-existing INFO-level pages-not-in-nav notes unrelated to this chapter.
- Grep-confirmed the chapter references only the **shipped** API and carries **no** references to the deleted `bound-fn` / `dispatcher` / `subscriber` / `current-frame` (bare) / `get-frame-db`.

## Scope notes

- Single-file change: `docs/guide/18-frames.md`. **`mkdocs.yml` nav untouched** (it already pointed at the in-place file — no shared nav/index edit needed, no sequencing conflict with `mle6e.6`).
- No `spec/*` touched.