### PR TITLE
docs(machines): first-class :history grammar + delete snapshot-as-value substitute (rf2-mle6e.6)

### DIFF
--- a/docs/guide/12-machines.md
+++ b/docs/guide/12-machines.md
@@ -331,8 +331,9 @@ The flat shape above — plain `:on` transitions, `:entry` / `:exit`, machine-lo
 - **Eventless `:always` transitions** — fire on entry (or after any event) when a guard becomes true, no event needed. (Drain-a-queue-then-advance; classifying a derived state.) Bounded-depth microstep loop.
 - **Delayed `:after` transitions** — "if no event arrives within N ms, transition." (Retry-after-backoff, idle timeouts, debounce.) Carries an epoch so cancelled timers don't fire late.
 - **Declarative `:spawn`** — a state spawns a child machine on entry, destroys it on exit, declared as data; the child's lifetime is bound to the parent state.
+- **History states** — a compound can re-enter at *the substate it was in when control last left it*, instead of restarting from `:initial`. Declared as a `:type :history` pseudo-state under the compound; the runtime records and restores the last-active configuration. (Media player that resumes mid-track; a wizard step you return to; tabs that remember their inner position.)
 
-Each is opt-in per the capability matrix. Port authors: each feature has a capability-flag (`:fsm/hierarchy`, `:fsm/always`, `:fsm/after`, `:fsm/invoke`, `:fsm/parallel-regions`, `:fsm/tags`, `:fsm/final-states`, `:actor/spawn-and-join`); a port declares its claimed set, and using a key the port doesn't claim raises `:rf.error/machine-grammar-not-in-v1` at registration rather than being silently ignored. The v1 CLJS reference claims all of them.
+Each is opt-in per the capability matrix. Port authors: each feature has a capability-flag (`:fsm/hierarchy`, `:fsm/always`, `:fsm/after`, `:fsm/invoke`, `:fsm/parallel-regions`, `:fsm/tags`, `:fsm/final-states`, `:fsm/history`, `:actor/spawn-and-join`); a port declares its claimed set, and using a key the port doesn't claim raises `:rf.error/machine-grammar-not-in-v1` at registration rather than being silently ignored. The v1 CLJS reference claims all of them.
 
 ### Parallel regions: when one screen has several axes of state at once
 
@@ -359,6 +360,35 @@ Some pages don't have one axis of state — they have several, running simultane
 ```
 
 The snapshot's `:state` becomes a *map* of region → current state, the `:tags` is the union across every active region, and a dispatch *broadcasts* to all regions (each region's active state checks its own `:on`; matching states transition, the rest stay put). Three regions, three active states, one tag union — not twenty-seven cross-product states. The pattern that makes this sing is a single render-priority table consulted by one `case` in the root view; if no region handles an event a `:rf.warning/machine-unhandled-event` fires, and if any region does, it's suppressed. Reach for parallel regions when the axes are orthogonal, share one `:data` domain, and the flat cross-product would top ~6-8 states. *Don't* when one axis depends on another (that's a hierarchical machine) or when regions don't share data (that's N separate machines). The fully-worked depth example — all nine canonical UI states modelled as one three-region machine — lives at `examples/reagent/nine_states/`.
+
+### History: re-entering a compound where you left it
+
+Some compound states shouldn't restart when you return to them. A media player paused mid-track should *resume* mid-track, not jump back to the start. A wizard you stepped out of should reopen on the step you were on. A tabbed panel should remember each tab's inner position. The shape is always the same: a compound that, on re-entry, should land on *the substate it was in when control last left it* — not its `:initial`. xstate calls this a history state, and re-frame2 ships it directly.
+
+You declare a **history pseudo-state** under the compound's `:states`, alongside its real substates, and transition *to* it to restore:
+
+```clojure
+{:player
+ {:initial :stopped
+  :states {:stopped {:on {:play [:player :hist]}}        ;; :play targets the pseudo-state → restore
+           :hist    {:type :history
+                     :deep? true                          ;; omit ⇒ shallow
+                     :default-target :playing}            ;; omit ⇒ falls back to :player's :initial
+           :playing {:initial :at-start
+                     :states {:at-start  {:on {:seek :mid-track}}
+                              :mid-track {}}}
+           :paused  {:on {:resume [:player :playing]}}}}}
+```
+
+The pseudo-state is never a state the machine *occupies* — a transition to `:hist` resolves to a real leaf, and that leaf is what the snapshot records. It carries exactly three slots:
+
+- **`:type :history`** — marks the node as a history pseudo-state (the discriminator from a real substate).
+- **`:deep?`** — `true` restores the *full* recorded leaf path beneath the compound (`[:playing :mid-track]`); `false` or **absent** is **shallow** — restore the recorded *direct child* (`:playing`), then cascade through its own `:initial` chain. Default is shallow.
+- **`:default-target`** — where to land the *first* time the compound is entered, before anything's recorded. A direct-child keyword or an absolute path. **Absent** falls back to the compound's `:initial`.
+
+The runtime records the compound's last-active configuration on the way out (as part of the ordinary exit cascade) into a reserved `:rf/history` slot *inside the snapshot*. Because it lives in the snapshot — the same revertible value as everything else — recorded history rides undo, time-travel, persistence, and SSR hydration for free; there's no side-table to keep in sync. Under `:type :parallel` each region keeps its own history independently. And if a hot reload removes the substate a recording points at, the runtime quietly falls back to `:default-target` (or `:initial`) rather than entering a dead path.
+
+Reach for history when "resume where you were" is the actual requirement — a non-trivial compound whose substate is worth remembering across a leave/return. *Don't* reach for it when a single flat value (which tab, which step) in `:data` says it just as clearly; that's ordinary modelling, not a named feature. (The full recording/restoring semantics, deep nesting, and per-region keys are in [Spec 005 §History states](https://github.com/day8/re-frame2/blob/main/spec/005-StateMachines.md).)
 
 ## Composing machines, and dynamic actors
 

--- a/migration/from-re-frame-v1/README.md
+++ b/migration/from-re-frame-v1/README.md
@@ -1780,6 +1780,16 @@ Pre-release framing: the snapshot's `:state` slot has a new third arm (Nine Stat
 
 **Cross-references.** [Spec 005 §Snapshot shape](../../spec/005-StateMachines.md#snapshot-shape) for the three-arm `:state` form; [Spec-Schemas §`:rf/machine-snapshot`](../../spec/Spec-Schemas.md#rfmachine-snapshot) for the schema; [M-48](#m-48-parallel-regions-shipped--type-parallel-machines-with-map-shaped-state-additive) above for the registration-side change.
 
+### M-66. History states shipped — first-class `:type :history` pseudo-states (additive)
+
+Pre-release framing: state-machine declarations may now declare a `:type :history` **pseudo-state** under a compound state's `:states` (carrying `:deep?` and `:default-target`). A transition *to* it re-enters the compound at its last-active configuration instead of its `:initial`; the runtime records that configuration on the compound's exit cascade into a reserved `:rf/history` slot inside the snapshot. Shallow by default (restore the recorded direct child, then cascade its `:initial`); `:deep? true` restores the full recorded leaf path. Under `:type :parallel` history is per-region (the `:rf/history` keys are region-qualified).
+
+**Direction.** Additive — no user-side change required. The capability is `:fsm/history`, claimed by the v1 reference. xstate codebases mapping a `type: 'history'` node land directly on `:type :history` now — there is **no substitute pattern** to reach for (the earlier snapshot-as-value capture/restore guidance is withdrawn). The `:rf/state-node` schema gains the optional history-pseudo-state arm and `:rf/machine-snapshot` gains the optional, framework-owned `:rf/history` slot; both are absent for machines that declare no history pseudo-state, so pre-feature machines are unaffected. The slot is EDN-clean (vectors + keywords), so it rides `pr-str`/`read-string`, persistence, SSR hydration, and epoch time-travel exactly as the rest of the snapshot does.
+
+**Why now.** History is the parallel sibling to `:type :parallel` ([M-48](#m-48-parallel-regions-shipped--type-parallel-machines-with-map-shaped-state-additive)) — both were once on the post-v1 substitute list, both are now first-class capabilities claimed by the v1 reference. "Resume where the user was" (media player mid-track, a wizard step, a tab's inner position) is one declarative node rather than per-compound hand-rolled capture/restore wiring.
+
+**Cross-references.** [Spec 005 §History states](../../spec/005-StateMachines.md#history-states-type-history--shallow--deep--default-target) for the full grammar + recording/restoring semantics; [Spec-Schemas §`:rf/transition-table`](../../spec/Spec-Schemas.md#rftransition-table) and [§`:rf/machine-snapshot`](../../spec/Spec-Schemas.md#rfmachine-snapshot) for the schema extensions; [Spec 005 §Capability matrix](../../spec/005-StateMachines.md#capability-matrix) for the `:fsm/history` row.
+
 ### M-50. `with-overrides` macro renamed to `with-fx-overrides`
 
 **Type A** (mechanical, name-rename).

--- a/skills/re-frame2/README.md
+++ b/skills/re-frame2/README.md
@@ -28,7 +28,7 @@ skills/re-frame2/
 │   └── plugin.json                   Claude Code plugin metadata.
 ├── references/
 │   ├── fundamentals/                 events, fx, cofx, subs, flows, frames, schemas, event-state-cycle, project-structure.
-│   ├── state-machines/               reg-machine, regions, tags, spawn, cancellation.
+│   ├── state-machines/               reg-machine, regions, tags, spawn, history, cancellation.
 │   ├── tooling/                      stories, routing, story-recorder, story-mcp-loop, xray.
 │   └── cross-cutting/                testing, api-cheatsheet, privacy-and-elision, production-observability, ssr-authoring.
 ├── patterns/                         One leaf per canonical pattern (9 leaves).

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -110,7 +110,7 @@ Load at most two leaves per task. If a task seems to need three, it likely spans
 
 **Fundamentals — `references/fundamentals/`**: `events.md`, `fx.md`, `cofx.md`, `subs.md`, `flows.md` (`reg-flow` — materialised computed state; the flow-vs-sub decision), `schemas.md`, `frames.md`, `event-state-cycle.md`, `project-structure.md`.
 
-**State machines — `references/state-machines/`**: `reg-machine.md` (declaration + the xstate→re-frame2 translation key), `regions.md` (parallel), `tags.md`, `spawn.md` (child machines), `cancellation.md`. Standing mental model across all of these: think in xstate, then map onto re-frame2 — see `reg-machine.md` for the full mapping table and deliberate-divergence flags.
+**State machines — `references/state-machines/`**: `reg-machine.md` (declaration + the xstate→re-frame2 translation key), `regions.md` (parallel), `tags.md`, `spawn.md` (child machines), `history.md` (`:type :history` re-entry), `cancellation.md`. Standing mental model across all of these: think in xstate, then map onto re-frame2 — see `reg-machine.md` for the full mapping table and deliberate-divergence flags.
 
 **Tooling — `references/tooling/`**: `stories.md`, `routing.md`, `story-recorder.md` (record canvas interactions as `:play-script`), `story-mcp-loop.md` (agent self-healing loop over MCP), `xray.md` (the devtools panel — mount strategy, launch modes, host-CSS-variable resize contract, popout, suppress-auto-open). For anything Story, the standing bridge is **think in Storybook JS, then map onto Story** — `stories.md` carries the verified concept map.
 

--- a/skills/re-frame2/decision-trees/slice-or-machine.md
+++ b/skills/re-frame2/decision-trees/slice-or-machine.md
@@ -128,6 +128,7 @@ If the example contradicts the leaf you'd pick from this tree, **the example win
 - [`../references/state-machines/regions.md`](../references/state-machines/regions.md) — single-region and `:type :parallel` regions.
 - [`../references/state-machines/tags.md`](../references/state-machines/tags.md) — `:tags` on states + `machine-has-tag?` query.
 - [`../references/state-machines/spawn.md`](../references/state-machines/spawn.md) — `:spawn` and `:spawn-all` for child machines.
+- [`../references/state-machines/history.md`](../references/state-machines/history.md) — `:type :history` re-entry (shallow / deep / default).
 - [`../references/state-machines/cancellation.md`](../references/state-machines/cancellation.md) — the actor-destroy cascade.
 - [`../references/fundamentals/events.md`](../references/fundamentals/events.md) — `reg-event-db` / `reg-event-fx` for slice-shaped state.
 - [`../references/fundamentals/schemas.md`](../references/fundamentals/schemas.md) — `reg-app-schema` at boundaries.

--- a/skills/re-frame2/references/state-machines/history.md
+++ b/skills/re-frame2/references/state-machines/history.md
@@ -1,0 +1,75 @@
+# History states — re-entering a compound where you left it
+
+## When to load
+
+Reach for this leaf when a compound state should **resume at the substate it was in when control last left it**, rather than restarting from `:initial` — a media player that resumes mid-track, a wizard step you return to, a tabbed panel that remembers each tab's inner position. This is xstate's history-state concept, shipped first-class in re-frame2 as a `:type :history` pseudo-state. For the basic machine declaration, see `reg-machine.md`; for hierarchical compound states (the prerequisite — history only applies to a compound), see `reg-machine.md` §State-node shape.
+
+## The grammar — a `:type :history` pseudo-state
+
+A history state is a **pseudo-state**: a node declared under a compound's `:states` map, alongside the compound's real substates, whose only role is to be a **transition target** that resolves to a recorded configuration. The machine never *occupies* it — a transition *to* it resolves to a real leaf, and that resolved leaf is what the snapshot's `:state` records.
+
+```clojure
+;; A :player compound that resumes its last substate on :play, instead of
+;; restarting at :playing's :initial.
+{:player
+ {:initial :stopped
+  :states {:stopped {:on {:play [:player :hist]}}        ;; :play targets the pseudo-state → restore
+           :hist    {:type :history
+                     :deep? true                          ;; omit ⇒ SHALLOW
+                     :default-target :playing}            ;; omit ⇒ falls back to :player's :initial
+           :playing {:initial :at-start
+                     :states {:at-start  {:on {:seek :mid-track}}
+                              :mid-track {}}}
+           :paused  {:on {:resume [:player :playing]}}}}}
+```
+
+You target the pseudo-state the way you name any state: an absolute vector `[:player :hist]`, or a bare keyword `:hist` from a sibling inside the compound.
+
+## The three slots — and nothing else
+
+A history pseudo-state carries **exactly** three keys, all owned by the history grammar:
+
+| Slot | Value | Meaning |
+|---|---|---|
+| `:type` | `:history` | The discriminator that marks this node as a history pseudo-state (not a real substate). Required. |
+| `:deep?` | boolean | `true` ⇒ **deep** history (restore the full recorded leaf path beneath the compound). `false` or **absent** ⇒ **shallow** (restore the recorded *direct child*, then cascade through that child's own `:initial` chain). Default is shallow. |
+| `:default-target` | child keyword or absolute vector | Where to land the **first** time the compound is entered, before anything is recorded. A direct-child keyword or an absolute path. **Absent** ⇒ falls back to the owning compound's `:initial`. |
+
+It MUST NOT declare `:on` / `:entry` / `:exit` / `:always` / `:after` / `:spawn` / `:states` / `:tags` / `:final?` — it is never occupied, so transition and lifecycle keys are meaningless on it. Any such key is a registration error.
+
+## Shallow vs deep
+
+The difference is **how much** of the recorded path is restored:
+
+- **Shallow** records only the compound's *direct child* (e.g. `:playing`). On restore the runtime takes that child and cascades through *its* `:initial` chain to a leaf. So a player that was on `[:playing :mid-track]` resumes at `:playing`'s initial substate, not `:mid-track`.
+- **Deep** records the *full leaf path* beneath the compound (e.g. `[:playing :mid-track]`). On restore the runtime re-enters every level down to that exact leaf.
+
+Reach for deep when the precise nested position matters (resume the exact track AND its scrub position); shallow when only the top-level branch matters (which tab, not the tab's inner scroll).
+
+## How recording and restoring work
+
+- **Recording** happens automatically on the way *out*: every time the exit cascade leaves a history-bearing compound, the runtime records that compound's last-active configuration. You write no capture code.
+- **Restoring** happens when a transition resolves to the pseudo-state: if a (still-valid) recording exists, restore it; otherwise fall back to `:default-target`, or — when that's absent — the compound's `:initial`, cascading from there exactly as a first-ever entry would.
+- The recording lives in a reserved **`:rf/history` slot inside the snapshot** — a framework-owned, read-only map keyed by the compound's declaration path. Because it lives *inside* the snapshot (a revertible value), recorded history rides undo, time-travel, persistence, and SSR hydration **for free**; there is no side-table to keep in sync.
+
+## Composition
+
+- **Per region under `:type :parallel`.** Each region keeps its own history independently — the `:rf/history` keys are region-qualified (the region name is the head segment), so two regions declaring structurally-identical history-bearing compounds never collide. Restoring one region leaves its siblings untouched (see `regions.md`).
+- **Deep nesting.** A deep-history compound nested several levels down records and restores its full subtree path relative to itself; an outer compound's own history records independently. The two never interfere.
+- **Hot reload.** If a recorded configuration points at a substate a hot-reloaded definition removed (a *dangling recorded path*), the runtime quietly falls back to `:default-target` / `:initial` rather than entering a dead path. This is benign — no error is raised.
+
+## Common gotchas
+
+- **History only applies to a compound.** A `:type :history` node MUST be declared inside a compound state's `:states`. A history node at the machine root (or under a `:type :parallel` root with no enclosing compound region) is a registration error — there's no configuration for it to record.
+- **At most one history node per compound.** Deep-vs-shallow is a property of the single node's `:deep?`, not a reason for two nodes. Two history children under one compound is a registration error.
+- **The pseudo-state is never in `:state`.** The machine's `:state` is never `[… :hist]`; a transition to `:hist` resolves to a real leaf. Don't write views that `case` on the pseudo-state keyword.
+- **Don't reach for it when a flat value says it.** If "which tab" or "which step" is a single value, keep it in `:data` like any other state — that's ordinary modelling, not a named feature. History earns its keep when a non-trivial compound's substate is worth remembering across a leave/return.
+- **`:default-target` keyword names a direct child** of the owning compound (then cascades any `:initial` chain), not an arbitrary sibling. Use the vector form for an absolute path elsewhere. An unresolvable `:default-target` is a registration error.
+
+## Deeper material
+
+For the full recording / restoring semantics, the `:rf/history` slot schema, the dangling-recorded-path policy, per-region composition, and the capability flag (`:fsm/history`), see `SKILL-REDIRECT.md` → *EP — State machines (005)* §History states.
+
+---
+
+*Derived from the `re-frame.machines.transition` history functions (`resolve-history-target`, `record-history-config`, `record-exit-history`) and `re-frame.machines.lifecycle-fx.validation` (registration-time history-grammar checks). Citations are symbol-level (machines.cljc was split into sub-namespaces); re-verify symbol homes after machine-history changes.*

--- a/skills/re-frame2/references/state-machines/reg-machine.md
+++ b/skills/re-frame2/references/state-machines/reg-machine.md
@@ -2,7 +2,7 @@
 
 ## When to load
 
-Reach for this leaf when authoring a `rf/reg-machine` call: the declaration map's keys, the `:guards` / `:actions` lookup tables, how a machine is dispatched into. For parallel regions, tags, `:spawn`, or cancellation, see the sibling leaves.
+Reach for this leaf when authoring a `rf/reg-machine` call: the declaration map's keys, the `:guards` / `:actions` lookup tables, how a machine is dispatched into. For parallel regions, tags, `:spawn`, history states, or cancellation, see the sibling leaves (`regions.md`, `tags.md`, `spawn.md`, `history.md`, `cancellation.md`).
 
 ## Mental model — think in xstate, then map onto re-frame2
 
@@ -21,6 +21,7 @@ Most concepts map cleanly. A handful of slots re-frame2 **deliberately renames o
 | **`invoke`** (state-bound child actor) | `:spawn` (and `:spawn-all` for fan-out-and-join) | **Divergence (name):** the most semantically-loaded slot is renamed on purpose, to break the "almost-correct xstate code" trap and align with the imperative `:rf.machine/spawn` fx. No `:onError`/`:onSnapshot`/`autoForward`/multiple-`:invoke`-per-state. See `spawn.md`. |
 | **`onDone`** (child→parent completion) | `:final?` leaf + parent `:spawn`'s `:on-done` + `:output-key` | Convergence — re-frame2 ships first-class final-state-with-parent-notification. See `spawn.md`. |
 | **parallel states** (`type: 'parallel'`) | `:type :parallel` + `:regions {...}` | Convergence (name + concept). `:data` shared; `:tags` is the union across active regions. See `regions.md`. |
+| **history states** (`type: 'history'`, `history: 'deep'`) | `:type :history` pseudo-state under a compound's `:states` (`:deep?` / `:default-target`) | Convergence (name + concept). Shallow by default; `:deep? true` for deep. Recording rides the snapshot's `:rf/history` slot — so undo / time-travel / SSR get it free. See `history.md`. |
 | **final states** (`type: 'final'`) | `:final? true` on a leaf state | Convergence on the concept. **Note the divergence:** a `:final?` singleton (or every-region-final parallel machine) **auto-destroys** — "final means final." Omit `:final?` for a persistent terminal state. See `spawn.md`. |
 | **tags** (`tags: [...]`) | `:tags #{...}` on a state node + `machine-has-tag?` | Convergence. See `tags.md`. |
 | **eventless / always transitions** | `:always [{:guard ... :target ...} ...]` | Convergence (re-frame2's term for xstate/SCXML transient transitions). |
@@ -101,6 +102,7 @@ Every state node is a map. Recognised slots (see `implementation/machines/src/re
 - `:spawn-all` — spawn-and-join sugar (see `spawn.md`).
 - `:tags` — a set of keywords describing this state's per-axis intent (see `tags.md`).
 - `:states` + `:initial` — nested compound state (deepest-wins resolution).
+- `:type :history` — a **pseudo-state** sibling under a compound's `:states` (carries `:deep?` / `:default-target`, nothing else); a transition target that restores the compound's last-active configuration. Not an occupiable state. See `history.md`.
 
 ## Transition shape
 

--- a/skills/re-frame2/spec/authoring-prompt.md
+++ b/skills/re-frame2/spec/authoring-prompt.md
@@ -42,6 +42,7 @@ A self-contained prompt that re-authors the `re-frame2` skill from this `spec/` 
 > │   │   ├── regions.md           (single-region + :type :parallel)
 > │   │   ├── tags.md              (state tags, machine-has-tag?)
 > │   │   ├── spawn.md             (:spawn, :spawn-all, child-machine result)
+> │   │   ├── history.md           (:type :history — shallow/deep/default re-entry)
 > │   │   └── cancellation.md      (destroy cascade, cleanup contract)
 > │   ├── tooling/
 > │   │   ├── stories.md           (reg-story, story frames)

--- a/skills/re-frame2/spec/design.md
+++ b/skills/re-frame2/spec/design.md
@@ -93,7 +93,7 @@ skills/re-frame2/
 ├── examples-map.md              (pattern → worked-example cross-ref)
 ├── references/
 │   ├── fundamentals/            (events, fx, cofx, subs, flows, schemas, frames, event-state-cycle, project-structure)
-│   ├── state-machines/          (reg-machine, regions, tags, spawn, cancellation)
+│   ├── state-machines/          (reg-machine, regions, tags, spawn, history, cancellation)
 │   ├── tooling/                 (stories, routing, story-recorder, story-mcp-loop, xray)
 │   └── cross-cutting/           (testing, api-cheatsheet, privacy-and-elision, production-observability, ssr-authoring)
 ├── patterns/                    (one leaf per canonical pattern)

--- a/spec/CP-5-MachineGuide.md
+++ b/spec/CP-5-MachineGuide.md
@@ -1,7 +1,7 @@
 # CP-5 Machine Guide (appendix to Construction Prompts CP-5)
 
 > **Type:** Construction Prompts
-> Detailed machine-construction guidance that supports [Construction-Prompts.md §CP-5](Construction-Prompts.md#cp-5-scaffold-a-state-machine). The CP-5 prompt itself is the build-facing template; this appendix carries the deeper material an AI agent needs when the user asks for non-trivial guards, parallel-region substitutes, history-state substitutes, the v1 grammar subset, or the inline-fn vs named-action escape-hatch test.
+> Detailed machine-construction guidance that supports [Construction-Prompts.md §CP-5](Construction-Prompts.md#cp-5-scaffold-a-state-machine). The CP-5 prompt itself is the build-facing template; this appendix carries the deeper material an AI agent needs when the user asks for non-trivial guards, the N-machines-per-region pattern for conceptually-independent features, the v1 grammar subset, or the inline-fn vs named-action escape-hatch test.
 
 This file is intentionally **kept separate** from Construction-Prompts.md so that CP-5 reads as a parallel sibling to CP-1/CP-2/CP-3/CP-4 rather than a doc-within-a-doc. Read CP-5 first; consult this file when the prompt's checklist sends you here.
 
@@ -98,7 +98,7 @@ Hierarchical compound states, eventless `:always`, delayed `:after`, declarative
 
 Per (Nine States Stage 2), **parallel regions** are now a **first-class capability** (`:fsm/parallel-regions`; see [Spec 005 §Parallel regions](005-StateMachines.md#parallel-regions)). The N-machines-per-region pattern documented in this section remains valid and is the right answer when the regions are **conceptually independent features** that don't share data — multiple tabs each with their own state, boot phases plus diagnostics, an audio/video player whose two regions share nothing but the play/pause event. Parallel regions inside one machine (`:type :parallel`) are the right answer when the regions are **orthogonal axes of one feature** that share a single `:data` blob — one form with three independent axes (data / form / mode), one widget with display + interaction state, one page whose render-mode is a function of three independent inputs. Both patterns ship together; choose by domain shape.
 
-The **history-state** substitute (snapshot-as-value capture exploiting [Goal 3 — Frame state revertibility](000-Vision.md#frame-state-revertibility)) below remains the documented forward path for history-state needs — history states are still post-v1.
+**History states** are likewise a first-class capability now (`:fsm/history`; see [Spec 005 §History states](005-StateMachines.md#history-states-type-history--shallow--deep--default-target)) — declare a `:type :history` pseudo-state under the compound and the runtime records and restores its last-active configuration. There is no substitute pattern to reach for: "remember where the user was" is one node in the transition table, not hand-rolled capture/restore wiring. The first-class grammar is summarised in §History states below.
 
 ### Parallel regions → separate machines per region (independent-features case)
 
@@ -178,58 +178,32 @@ What this gives:
 
 The cost: a coordinating event (`:media/play`) is one extra registration. In exchange the two regions are independently testable, independently inspectable, and independently rolled back. The substrate's machinery does the heavy lifting at no extra cost.
 
-### History states → snapshot-as-value capture
+## History states — first-class `:type :history`
 
-xstate's history states re-enter a compound state at *the substate that was active when it was last left*. The substrate concern is "remember where the user was."
-
-xstate needs history states because its runtime lacks first-class snapshot-as-value semantics — there's no general way to copy a machine's current state and restore it later. re-frame2 has snapshot-as-value as a foundation: every machine's snapshot at `[:rf/runtime :machines :snapshots <id>]` is a value, and copying / restoring values is what re-frame2's persistent data structures do best. The substitute is **capture on leave, restore on re-enter** — a two-line action pattern over the existing snapshot.
-
-#### Worked sketch — remember-last-substate via snapshot capture
+xstate's history states re-enter a compound state at *the substate that was active when it was last left*. re-frame2 ships this directly: a `:type :history` pseudo-state declared under a compound's `:states` is a transition target the runtime resolves to that compound's recorded (or default) configuration. There is no capture/restore code to hand-roll — the recording rides the snapshot for free (it lives in the snapshot's reserved `:rf/history` slot), so undo, time-travel, persistence, and SSR hydration all extend to it without extra machinery.
 
 ```clojure
-;; The flow has a :browsing parent that, when re-entered, should resume at
-;; the substate the user was on (e.g., :browsing.cart vs :browsing.search).
-;; The two helper actions are declared in the machine's :actions map:
-
-(rf/make-machine-handler
-  {:actions
-   {:capture-browsing-position
-    ;; Stash the current browsing-state into :data so we can restore it later.
-    ;; every machine callback receives a single
-    ;; context-map with :data / :event / :state / :meta — destructure the
-    ;; keys you need.
-    (fn [{:keys [state]}]
-      {:data {:last-browsing-state state}})                 ;; the FSM keyword
-
-    :restore-browsing-position
-    ;; Re-enter at the previously-captured state.
-    (fn [{:keys [data]}]
-      {:fx [[:raise [:flow/jump-to (:last-browsing-state data)]]]})}
-   :states
-   {:browsing
-    {:exit  :capture-browsing-position
-     :entry :restore-browsing-position
-     :states {...}}}})
-
-;; The :raise back into the same machine fires before the snapshot commits;
-;; the snapshot lands at the restored state in one externally-observable step.
+;; A :player compound that, when re-entered via :play, resumes the substate
+;; it was on when it last paused/stopped — not :playing's :initial.
+{:player
+ {:initial :stopped
+  :states {:stopped {:on {:play [:player :hist]}}        ;; target the pseudo-state to restore
+           :hist    {:type :history
+                     :deep? true                          ;; omit => SHALLOW (restore direct child, then cascade its :initial)
+                     :default-target :playing}            ;; omit => falls back to :player's :initial when nothing recorded yet
+           :playing {:initial :at-start
+                     :states {:at-start {:on {:seek :mid-track}}
+                              :mid-track {}}}
+           :paused  {:on {:resume [:player :playing]}}}}}
 ```
 
-What this gives:
+The pseudo-state carries exactly three keys: `:type :history`, `:deep?` (boolean; missing reads as shallow), and `:default-target` (used the first time the compound is entered, before anything is recorded; missing falls back to the compound's `:initial`). It is never occupied — a transition *to* it resolves to a real leaf, and that resolved leaf is what the snapshot's `:state` records.
 
-- **No new substrate.** The captured state is just a key in `:data`; the restore is a `:raise` (per [Spec 005 §Action effect map](005-StateMachines.md#action-effect-map--data-fx)).
-- **Inspectable.** `(:last-browsing-state data)` is visible in the machine's snapshot at all times. Visualisers see "the user was last at `:browsing.cart`" as a normal data field, not as opaque history-state plumbing.
-- **Undo / time-travel free.** The captured value rides along with the rest of the snapshot; reverting `app-db` reverts the captured value too.
-- **Per-region independent.** Combine with the parallel-region substitute above and each region captures and restores its own position independently — no cross-region history-state coupling.
+- **Shallow vs deep.** Shallow restores the recorded *direct child* of the compound, then cascades that child's own `:initial` chain. Deep restores the *full recorded leaf path* beneath the compound. Default is shallow.
+- **Per-region under `:type :parallel`.** Each region records and restores its own history independently; the `:rf/history` keys are region-qualified, so sibling regions never collide.
+- **Registration constraints.** A `:type :history` node MUST live inside a compound's `:states`, declares only those three keys (any of `:on` / `:entry` / `:exit` / `:states` / … is a registration error), and a compound declares at most one.
 
-The cost: explicit code for capture / restore, instead of a one-keyword `{:type :history}` in the transition table. In exchange the captured value is *visible* — a data field rather than xstate-runtime-internal state — and re-frame2's existing snapshot-as-value infrastructure does the rest. The trade is consistent with the spec's broader bias toward "data, in app-db, inspectable" over "runtime mechanism, opaque to users."
-
-#### Why xstate needs history but re-frame2 doesn't
-
-- **xstate** treats machine state as runtime objects — `ActorRef` instances with mailboxes and live observers. There is no general "value of this machine right now" you can copy and restore later, so the runtime ships dedicated history-state machinery.
-- **re-frame2** treats machine state as a value at `[:rf/runtime :machines :snapshots <id>]`. Every read is `(get-in db [:rf/runtime :machines :snapshots id])`; every write is `(assoc-in db [:rf/runtime :machines :snapshots id] new-snap)`. Capturing and restoring are *natural ops* on the existing data structure — no dedicated mechanism needed.
-
-The substitute is not a workaround; it is the same answer history states give, expressed in re-frame2's existing primitives. Goal 3 — Frame state revertibility — is what makes this affordable.
+See [Spec 005 §History states](005-StateMachines.md#history-states-type-history--shallow--deep--default-target) for the full recording / restoring semantics, the `:rf/history` slot shape, the dangling-recorded-path policy after hot reload, and per-region composition. The capability flag is `:fsm/history`; the v1 CLJS reference claims it.
 
 ## Lessons from xstate (deliberate divergences)
 

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -511,7 +511,7 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 
 After this action, `(:pending-request data)` is the new actor's id; subsequent transitions can dispatch to it. The spawned actor's snapshot lives at `[:rf/runtime :machines :snapshots <gensym'd-id>]` (runtime-managed; the spawn-spec does not pick a location). The `:on-spawn` callback is an inline fn here — that's appropriate; it's a single non-branching `assoc`.
 
-**Deeper guidance — see the appendix.** When you need the inline-fn vs named-action escape-hatch test, the v1 grammar subset, the parallel-regions decision between `:type :parallel` and the N-machines substitute, or the history-state substitute, consult [CP-5 Machine Guide](CP-5-MachineGuide.md). It's a sibling appendix to keep CP-5 itself a build-facing prompt rather than a second machine spec.
+**Deeper guidance — see the appendix.** When you need the inline-fn vs named-action escape-hatch test, the v1 grammar subset, the parallel-regions decision between `:type :parallel` and N-machines-per-region, or first-class history states (`:type :history`), consult [CP-5 Machine Guide](CP-5-MachineGuide.md). It's a sibling appendix to keep CP-5 itself a build-facing prompt rather than a second machine spec.
 
 **Pattern-level discipline:**
 


### PR DESCRIPTION
Closes the `mle6e` history EPIC's docs/skills/migration surface (rf2-mle6e.6). Documents re-frame2's first-class history states (`:type :history` — shallow / deep / default-target, shipped this session in mle6e.1–.8) and **deletes** the withdrawn snapshot-as-value substitute prose per Mike's `q44uk` ruling (substantive removal, not demote-to-secondary).

Grammar verified against the merged engine (`re_frame/machines/transition.cljc` — `resolve-history-target` / `record-history-config` / `record-exit-history`) and `spec/005-StateMachines.md §History states`; the shipped behaviour is authoritative.

## Per surface

**skills/re-frame2 (authoring)** — generic to any consumer app:
- New leaf `references/state-machines/history.md` — full grammar, shallow vs deep, recording/restoring, per-region under `:type :parallel`, hot-reload dangling-path fallback, registration constraints, gotchas.
- `reg-machine.md` — history row in the xstate→re-frame2 mapping table; `:type :history` entry in the state-node slot list; "When to load" lists the sibling.
- Leaf wired into `SKILL.md`, `README.md`, `spec/design.md`, `spec/authoring-prompt.md`, `decision-trees/slice-or-machine.md`.

**docs/guide/12-machines.md** (Mike's `avb5k` lane — targeted additions, matched voice/structure):
- History bullet in "When the machine gets bigger" + `:fsm/history` capability flag.
- New "History: re-entering a compound where you left it" subsection (sibling to Parallel regions).

**spec/CP-5-MachineGuide.md** (folded in per the bead's `.7`-flagged note):
- Deleted the `### History states → snapshot-as-value capture` section (worked capture/restore sketch + the "why re-frame2 doesn't need history" thesis); replaced with a first-class `:type :history` summary.
- Rewrote the intro + the history paragraph in the substitutes section. **Section heading (and its `#substitutes-for-skipped-features` anchor) preserved** so the 9 cross-refs across spec + migration do not dangle under `--strict`.

**spec/Construction-Prompts.md** — fixed the forward-pointer (line 514) that named the withdrawn history-state substitute (would have dangled once CP-5's section was deleted).

**migration/from-re-frame-v1/README.md** (hot-zone — minimal targeted edit) — additive `M-66` note: history maps directly from xstate now; no substitute pattern to reach for. (Used the free M-66 slot; placed next to the M-48/M-49 parallel-regions additive cluster.)

## Substitute-prose removal
The recommending substitute prose is fully excised. Remaining `snapshot-as-value` mentions in my surfaces are only the new prose stating the substitute is *withdrawn*. (`tools/machines-viz/spec/001-Topology-Parity.md:282` still carries stale "Spec 005 v1 omits the grammar / substitute is snapshot-as-value" text — that's the machines-viz/`.5` lane, out of scope here; flagged for a follow-up.)

## Gates
- `mkdocs build --strict` (CI-equivalent: stage spec/ + migration/ into docs/, run `scripts/check_doc_slugs.py`, then build) — **passes cold, zero warnings, exit 0**.
- Doc-slug check clean.

## Shared nav/index
Did **not** touch `mkdocs.yml` nav or any shared guide index — only skill-internal indices. No coordination needed with `kkut0.9`.