### PR TITLE
feat(xray/machines): auto fit-to-view the topology on Machine tab entry (rf2-6tw7t)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -67,6 +67,7 @@ registry).
 | `:show-minimap?` | no | `false` | When `true`, render xyflow's built-in MiniMap. |
 | `:show-controls?` | no | `true` | When `true`, render xyflow's built-in zoom/pan/fit Controls. |
 | `:show-background?` | no | `true` | When `true`, render xyflow's dot-pattern Background. |
+| `:fit-signal` | no | `nil` | rf2-6tw7t. Opaque value (any `=`-comparable nonce). When its value **changes** between renders the chart re-fits the viewport to frame the whole topology — **orthogonal** to the layout-key auto-fit. Hosts bump it on **panel-entry / tab-activation** so re-entering a panel re-frames the graph rather than restoring a stale (possibly off-screen) zoom/pan. A **steady** signal across ordinary re-renders is a no-op, so the operator's manual zoom/pan still survives non-entry re-renders. See [§Fit-on-entry signal](#fit-on-entry-signal-rf2-6tw7t). |
 | `:overlays` | no | `nil` | rf2-7w4qr. A **vector of host-fed overlay descriptor maps**, each keyed on `:id`. The single slot through which hosts compose the host-fed, spec+tick+callbacks overlay family (after-rings / spawn-all-join / cancellation-cascade) — collapses the former flat per-overlay props so a new overlay adds **one descriptor variant**, not 3–5 trunk props. The chart dispatches each descriptor to its already-modular rendering namespace by `:id` (`chart.cljs/render-overlay`); the renderers are unchanged. A per-descriptor `:tick` unifies the former `:after-ring-tick` + `:overlay-tick` (one rAF clock per chart stays host-owned — Lock #8 — just delivered per-overlay). A descriptor whose `:id` is outside the recognised set is **ignored** (a host data error, not a runtime fallback; dev builds emit a `js/console.warn`). Non-map entries are skipped. `nil` / `[]` → no overlays. See [§`:overlays` slot descriptor schema](#overlays-slot-descriptor-schema-rf2-7w4qr) for the multispec. |
 | `:testid` | no | `"rf-mv-chart"` | Root wrapper `data-testid` so tests + hosts can find the chart. |
 
@@ -1196,6 +1197,41 @@ runs in the frame AFTER React's commit AND xyflow's measurement
 pass — the same trick xyflow's own examples use for post-load fit
 calls. Test runtimes without rAF (Node) MAY fire the fit
 immediately as a fallback.
+
+### Fit-on-entry signal (rf2-6tw7t)
+
+The layout-key auto-fit above deliberately **preserves** the operator's
+manual zoom/pan across non-layout re-renders. That is the right
+behaviour while the operator stays on the chart — but it leaves a chart
+**re-entered** from a panel/tab switch at its prior viewport even though
+the operator's intent on re-entry is "show me the whole graph again."
+xyflow's one-shot `:fitView` mount prop does not help (it fires only on
+the *initial* mount, and a reconciled-in-place chart never re-mounts).
+
+`MachineChart` therefore accepts an optional **`:fit-signal`** prop — an
+opaque, `=`-comparable nonce. When the prop's value **changes** between
+renders the chart MUST re-fit the viewport, **independent** of the
+layout-key gate. The re-fit reuses the same `schedule-fit!`
+(double-rAF) deferral and the same preconditions as the layout-settle
+fit:
+
+- A ReactFlowInstance MUST have been captured (`:onInit`); a signal that
+  arrives before the instance is deferred to `:onInit` (which re-checks
+  the signal once the instance + settled positions are both present).
+- Positions MUST be non-empty and there MUST be no `:layout-error` — a
+  fit on empty positions would frame the degenerate origin cluster.
+- The chart records the value it last fit on; a **steady** signal across
+  ordinary re-renders is a no-op, so manual zoom/pan still survives
+  non-entry re-renders. The recorded value starts at a sentinel distinct
+  from every host value (including `nil`) so the **first** observed
+  signal fits once.
+
+This is the **orthogonal escape hatch** to the layout-key gate: a host
+(e.g. the Xray Machine tab) bumps a monotonic counter on
+panel-entry / tab-activation and forwards it as `:fit-signal`. A host
+that never supplies the prop (the standalone viewer / Story path) leaves
+it at `nil`; the value never changes, so the entry-fit is inert and only
+the layout-key auto-fit runs.
 
 ### One chart-level, visibility-gated animation clock
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -842,6 +842,20 @@
                          the chart (Stately graph view convention). nil
                          → no panel. The panel is purely presentation —
                          the host owns the data projection.
+    :fit-signal        — rf2-6tw7t. Optional opaque value (a nonce — any
+                         `=`-comparable). When its value CHANGES between
+                         renders the chart re-fits the viewport to frame
+                         the whole topology, ORTHOGONAL to the layout-key
+                         auto-fit (rf2-set3x). Hosts bump it on panel-
+                         entry / tab-activation so re-entering a panel
+                         frames the graph rather than restoring a stale
+                         (possibly off-screen) zoom/pan. A STEADY signal
+                         across ordinary re-renders is a no-op, so the
+                         operator's manual zoom/pan still survives non-
+                         entry re-renders. nil (the default) with no host
+                         supplying it means the prop never changes, so the
+                         entry-fit is inert and only the layout-key auto-
+                         fit runs (the standalone viewer / Story path).
     :testid            — root wrapper `data-testid`; defaults to
                          `\"rf-mv-chart\"` so tests + hosts find it."
   [_initial-props]
@@ -876,7 +890,22 @@
         ;; change — the load-bearing tuple per API.md §Layout-
         ;; invalidation boundary, AND the manual `Fit` Controls
         ;; button) is the only thing that re-fits.
-        fit-state     (r/atom {:instance nil :fit-key nil})
+        ;;
+        ;; rf2-6tw7t — `:fit-sig` records the host-supplied `:fit-signal`
+        ;; value we last fit on. The layout-key gate above deliberately
+        ;; PRESERVES the operator's manual zoom/pan across non-layout
+        ;; re-renders (tab re-entry with the SAME machine doesn't change
+        ;; the layout-key). `:fit-signal` is the ORTHOGONAL escape hatch:
+        ;; a host bumps an opaque nonce on panel-entry / tab-activation
+        ;; and the chart re-fits the framed topology even though the
+        ;; layout shape is unchanged — so re-entering the Machine tab
+        ;; always frames the graph rather than restoring a stale (possibly
+        ;; off-screen) viewport. Starts `::unfit` (a sentinel distinct
+        ;; from any host value incl. nil) so the FIRST observed signal,
+        ;; even nil, is treated as "fit once"; thereafter only a CHANGE
+        ;; re-fits, so a steady signal across non-entry re-renders is a
+        ;; no-op (manual zoom/pan still survives those).
+        fit-state     (r/atom {:instance nil :fit-key nil :fit-sig ::unfit})
         ;; rf2-d9ro2 — measure-then-relayout lifecycle state.
         ;;
         ;; The bug: ELK was fed CONSTANT node dimensions (the
@@ -937,6 +966,7 @@
                  height show-minimap? show-controls? show-background?
                  overlays
                  machine-data
+                 fit-signal
                  testid]
           :or   {direction         :tb
                  theme             :dark
@@ -1030,7 +1060,32 @@
                       changed? (or fresh? (not= dims measured))]
                   (when (and ready? changed?)
                     (reset! relayout-state {:key this-key :measured dims})
-                    (run-layout! dims)))))]
+                    (run-layout! dims)))))
+            ;; rf2-6tw7t — fit-on-entry. Orthogonal to the layout-key
+            ;; auto-fit (rf2-set3x): that gate intentionally PRESERVES the
+            ;; operator's manual zoom/pan across non-layout re-renders, so
+            ;; re-entering the Machine tab with the SAME machine does NOT
+            ;; refit and the graph can sit off-screen / wrongly scaled. The
+            ;; host bumps `:fit-signal` (an opaque nonce) on panel-entry /
+            ;; tab-activation; when it differs from the value we last fit on
+            ;; we re-fit the framed topology through the same
+            ;; `schedule-fit!` (double-rAF) path the layout settle uses. The
+            ;; gate requires a captured instance + non-empty positions + no
+            ;; layout-error — the same preconditions the settle fit checks —
+            ;; so an entry that arrives before the first layout settles is
+            ;; deferred to the settle/onInit fit (which frames the same
+            ;; viewport). `::unfit` sentinel start means the first observed
+            ;; signal fits once; a steady signal across ordinary re-renders
+            ;; is a no-op.
+            maybe-fit-on-signal!
+            (fn []
+              (let [{:keys [instance fit-sig]} @fit-state]
+                (when (and instance
+                           (not= fit-signal fit-sig)
+                           (seq (:positions @layout-state))
+                           (nil? (:layout-error @layout-state)))
+                  (swap! fit-state assoc :fit-sig fit-signal)
+                  (schedule-fit! instance))))]
         (when (and (seq (:nodes parsed))
                    (not= this-key @layout-key))
           (reset! layout-key this-key)
@@ -1039,6 +1094,11 @@
           ;; first measurement of the new machine as a change.
           (reset! relayout-state {:key this-key :measured nil})
           (run-layout! nil))
+        ;; rf2-6tw7t — react to a host fit-signal bump every render. When
+        ;; the signal changed AND the instance + positions are ready this
+        ;; re-fits the framed topology (panel-entry / tab-activation). When
+        ;; positions aren't ready yet the settle/onInit fit covers it.
+        (maybe-fit-on-signal!)
         (cond
           (nil? definition)
           [:div {:data-testid (str testid "-no-definition")
@@ -1280,7 +1340,14 @@
                                         ;; Kick the measure-then-relayout
                                         ;; check too, in case no further
                                         ;; dimension change fires.
-                                        (maybe-relayout!)))
+                                        (maybe-relayout!)
+                                        ;; rf2-6tw7t — a host `:fit-signal`
+                                        ;; may have been pending BEFORE the
+                                        ;; instance was captured (entry that
+                                        ;; arrived ahead of onInit). Now that
+                                        ;; the instance exists, honour it if
+                                        ;; positions have already settled.
+                                        (maybe-fit-on-signal!)))
                ;; rf2-d9ro2 — measure-then-relayout signal. xyflow emits a
                ;; `dimensions` NodeChange once it measures the rendered
                ;; node DOM; that is our cue to read the real boxes back and

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
@@ -486,3 +486,127 @@
       (gate :K2 {"a" {:width 100 :height 40}})
       (is (= [:K1 :K2] @relayouts)
           "a new layout-key gets its own relayout despite identical boxes"))))
+
+;; ---- 8. fit-on-entry signal (rf2-6tw7t) -------------------------------
+;;
+;; The layout-key auto-fit (rf2-set3x, tests 1-6 above) deliberately
+;; PRESERVES the operator's manual zoom/pan across non-layout re-renders.
+;; That leaves a chart RE-ENTERED from a panel/tab switch at its prior
+;; viewport — the bug rf2-6tw7t fixes. The orthogonal `:fit-signal` prop
+;; (an opaque nonce the host bumps on panel-entry / tab-activation) forces
+;; a re-fit when its value CHANGES, independent of the layout-key gate.
+;;
+;; This pins the `maybe-fit-on-signal!` gate the chart wires onto every
+;; render verbatim (the live xyflow `.fitView` is browser-pinned /
+;; eval-cljs in the PR body — same reason tests 1-6 are Node-layer pins
+;; of the predicate, not DOM tests).
+
+(deftest fit-on-entry-fits-once-per-signal-change
+  (testing "rf2-6tw7t — the fit-on-entry gate fires exactly once each time
+            the host `:fit-signal` CHANGES (panel re-entry), and is a
+            no-op while the signal is steady (ordinary re-renders, so
+            manual zoom/pan survives). It requires a captured instance +
+            non-empty positions + no :layout-error — the same
+            preconditions the layout-settle fit checks. The `::unfit`
+            sentinel start means the FIRST observed signal (even nil)
+            fits once.
+
+            This mirrors `chart.cljs/maybe-fit-on-signal!` verbatim."
+    (let [;; The chart's `fit-state` shape (sentinel start per chart.cljs).
+          fit-state (atom {:instance fake-instance
+                           :fit-key  nil
+                           :fit-sig  ::chart-unfit})
+          spy       (atom [])
+          ;; Stand-ins for the chart's two render-derived inputs.
+          positions (atom {"idle" {:x 0 :y 0}})  ;; non-empty → ready
+          layout-error (atom nil)
+          ;; The gate, lifted verbatim from chart.cljs/maybe-fit-on-signal!.
+          maybe-fit-on-signal!
+          (fn [fit-signal]
+            (let [{:keys [instance fit-sig]} @fit-state]
+              (when (and instance
+                         (not= fit-signal fit-sig)
+                         (seq @positions)
+                         (nil? @layout-error))
+                (swap! fit-state assoc :fit-sig fit-signal)
+                (swap! spy conj fit-signal))))]
+      ;; First entry — signal 1 differs from the ::chart-unfit sentinel → fit.
+      (maybe-fit-on-signal! 1)
+      (is (= [1] @spy) "first activation fits once")
+      ;; Ordinary re-renders with the SAME signal — manual zoom/pan survives.
+      (maybe-fit-on-signal! 1)
+      (maybe-fit-on-signal! 1)
+      (is (= [1] @spy) "steady signal does NOT re-fit (manual viewport preserved)")
+      ;; Operator leaves + re-enters the tab → host bumps the counter to 2.
+      (maybe-fit-on-signal! 2)
+      (is (= [1 2] @spy) "a fresh activation signal re-fits on entry")
+      ;; And again — every distinct entry re-frames.
+      (maybe-fit-on-signal! 3)
+      (is (= [1 2 3] @spy) "each entry signal fits exactly once")
+      (is (= 3 (:fit-sig @fit-state)) "fit-state records the last signal fit"))))
+
+(deftest fit-on-entry-defers-until-instance-and-positions-ready
+  (testing "rf2-6tw7t — an entry signal that arrives BEFORE the instance
+            is captured (or before the first layout settles) must NOT
+            record the signal as fit — it stays pending so the onInit /
+            next-render re-check honours it once the preconditions hold.
+            Pins the deferral branch: no instance → no fit + signal stays
+            unrecorded; empty positions → no fit + signal stays
+            unrecorded; once both arrive → the SAME pending signal fits."
+    (let [fit-state (atom {:instance nil
+                           :fit-key  nil
+                           :fit-sig  ::chart-unfit})
+          spy       (atom [])
+          positions (atom {})         ;; empty → not ready
+          layout-error (atom nil)
+          maybe-fit-on-signal!
+          (fn [fit-signal]
+            (let [{:keys [instance fit-sig]} @fit-state]
+              (when (and instance
+                         (not= fit-signal fit-sig)
+                         (seq @positions)
+                         (nil? @layout-error))
+                (swap! fit-state assoc :fit-sig fit-signal)
+                (swap! spy conj fit-signal))))]
+      ;; Entry signal 1 arrives but no instance yet → no fit, not recorded.
+      (maybe-fit-on-signal! 1)
+      (is (zero? (count @spy)) "no fit while instance is nil")
+      (is (= ::chart-unfit (:fit-sig @fit-state))
+          "signal stays unrecorded so the next chance still honours it")
+      ;; Instance captured (onInit) but positions still empty → still no fit.
+      (swap! fit-state assoc :instance fake-instance)
+      (maybe-fit-on-signal! 1)
+      (is (zero? (count @spy)) "no fit while positions are empty")
+      (is (= ::chart-unfit (:fit-sig @fit-state))
+          "still unrecorded — degenerate origin cluster not framed")
+      ;; Layout settles (positions arrive) → the SAME pending signal fits.
+      (reset! positions {"idle" {:x 0 :y 0}})
+      (maybe-fit-on-signal! 1)
+      (is (= [1] @spy) "the pending entry signal fits once preconditions hold"))))
+
+(deftest fit-on-entry-skips-layout-error-settle
+  (testing "rf2-6tw7t — a fit-signal bump on a chart whose layout FAILED
+            (the rf2-4lyvh error path: empty positions + :layout-error)
+            must NOT fit — an auto-fit on empty positions re-triggers the
+            degenerate-cluster bug. The chart paints the error banner
+            instead. Pins the :layout-error guard on the entry path
+            (mirrors test 2's gate for the settle path)."
+    (let [fit-state (atom {:instance fake-instance
+                           :fit-key  nil
+                           :fit-sig  ::chart-unfit})
+          spy       (atom [])
+          positions (atom {})
+          layout-error (atom {:elk-error "boom"})  ;; error settle
+          maybe-fit-on-signal!
+          (fn [fit-signal]
+            (let [{:keys [instance fit-sig]} @fit-state]
+              (when (and instance
+                         (not= fit-signal fit-sig)
+                         (seq @positions)
+                         (nil? @layout-error))
+                (swap! fit-state assoc :fit-sig fit-signal)
+                (swap! spy conj fit-signal))))]
+      (maybe-fit-on-signal! 1)
+      (is (zero? (count @spy)) "no entry-fit on a layout-error settle")
+      (is (= ::chart-unfit (:fit-sig @fit-state))
+          "signal unrecorded — banner paints, not a degenerate fit"))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -372,6 +372,13 @@
                               Canvas/List pill in the chart top-left.
     :show-controls?     — when true (default) render xyflow's built-in
                           zoom/pan/fit Controls inside the chart.
+    :fit-signal         — rf2-6tw7t. Opaque fit-on-entry nonce forwarded
+                          verbatim to `mv-chart/MachineChart`'s
+                          `:fit-signal`. Hosts bump it on panel-entry /
+                          tab-activation so the topology re-frames even
+                          when the layout-key is unchanged (re-entering
+                          the same machine). nil → inert (only the layout-
+                          key auto-fit runs).
     :theme              — rf2-az6e2. `:dark` (default) / `:light`.
                           Forwarded to `mv-chart/MachineChart`'s `:theme`
                           prop, which resolves the chart palette + reads
@@ -389,7 +396,8 @@
            fired-edge-ids machine-data
            sim? on-state-click on-edge-click
            show-after-rings? show-view-mode-toggle?
-           show-controls? theme testid inner-testid]
+           show-controls? theme testid inner-testid
+           fit-signal]
     :or   {show-after-rings?       true
            show-view-mode-toggle?  true
            show-controls?          true
@@ -430,6 +438,11 @@
       :theme           theme
       :on-state-click  on-state-click
       :on-edge-click   on-edge-click
+      ;; rf2-6tw7t — fit-on-entry nonce. The host (Machine panel /
+      ;; Static topology) bumps this on panel-entry / tab-activation so
+      ;; the chart re-fits the topology even when the layout-key is
+      ;; unchanged (re-entering the same machine). Forwarded verbatim.
+      :fit-signal      fit-signal
       :show-minimap?   false
       :show-controls?  show-controls?
       :show-background? true

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -691,7 +691,13 @@
         to-id      (when to-state   (chart-layout/highlight-id to-state))
         engine     "xyflow+elkjs"
         collapsed? @(rf/subscribe
-                      [:rf.xray.machine-canvas/chart-collapsed-for machine-id])]
+                      [:rf.xray.machine-canvas/chart-collapsed-for machine-id])
+        ;; rf2-6tw7t — fit-on-entry nonce. Bumped by `:rf.xray/select-tab
+        ;; :machines`; forwarded to the chart's `:fit-signal` so the
+        ;; topology re-frames whenever the operator (re-)enters the
+        ;; Machine tab, even when the focused machine (hence the chart's
+        ;; layout-key) is unchanged.
+        fit-signal @(rf/subscribe [:rf.xray/machine-tab-fit-signal])]
     [:section
      {:data-testid (str "rf-xray-machine-focused-event-section-"
                         (when machine-id
@@ -860,6 +866,11 @@
                  ;; the FIRED treatment on the live chart (canonical ids from
                  ;; `extract-fired-edge-ids`, attached to the section record).
                  :fired-edge-ids     fired-edge-ids
+                 ;; rf2-6tw7t — fit-on-entry nonce so re-entering the
+                 ;; Machine tab re-frames the topology (the layout-key
+                 ;; auto-fit alone leaves a re-entered chart at its
+                 ;; stale pan/zoom).
+                 :fit-signal         fit-signal
                  :on-state-click     (fn [path]
                                        (rf/dispatch
                                          [:rf.xray/machine-state-clicked

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
@@ -144,12 +144,17 @@
                            parent-height requirement satisfied when the
                            container itself is auto-height.
     :show-controls?      — pass-through to wrapper (default true).
+    :fit-signal          — rf2-6tw7t. Opaque fit-on-entry nonce forwarded
+                           to `machine-canvas/Chart`'s `:fit-signal`. A
+                           host bumps it on panel-entry / tab-activation
+                           so the topology re-frames to view. nil → inert.
     :testid              — pass-through wrapper testid (default
                            `'rf-xray-machines-topology'`).
 
   Returns hiccup."
   [{:keys [machine-id definition current-state-path trace-events
-           epoch-history snapshot-state height show-controls? testid]
+           epoch-history snapshot-state height show-controls? testid
+           fit-signal]
     :or   {height          "100%"
            show-controls?  true
            testid          "rf-xray-machines-topology"}}]
@@ -235,4 +240,8 @@
          :show-after-rings?      false
          :show-view-mode-toggle? false
          :show-controls?         show-controls?
+         ;; rf2-6tw7t — fit-on-entry nonce pass-through; hosts that mount
+         ;; this consumer surface inside a tab/panel bump it on entry so
+         ;; the topology re-frames. nil → inert.
+         :fit-signal             fit-signal
          :inner-testid           (str testid "-canvas")}]])))

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -173,6 +173,23 @@
       (fn [db _query]
         (get db :selected-tab :epoch)))
 
+    ;; ---- Machine tab fit-on-entry signal (rf2-6tw7t) ----
+    ;;
+    ;; A monotonic counter bumped by `:rf.xray/select-tab :machines` and
+    ;; `:rf.xray.static/select-tab :machines`. The Machine panel (Dynamic
+    ;; `machine_inspector` + Static `static.machines` topology) reads it
+    ;; and forwards the value as `MachineChart`'s `:fit-signal` so a
+    ;; CHANGE re-fits the topology to view on panel-entry / tab-
+    ;; activation. The layout-key auto-fit (rf2-set3x) deliberately
+    ;; preserves manual zoom/pan across non-layout re-renders, leaving a
+    ;; re-entered chart at its stale (possibly off-screen) viewport; this
+    ;; signal is the orthogonal entry-fit escape hatch. Defaults to 0 so
+    ;; the first activation (1) is a change from the chart's `::unfit`
+    ;; sentinel and frames the graph once.
+    (rf/reg-sub :rf.xray/machine-tab-fit-signal
+      (fn [db _query]
+        (get db :machine-tab-activations 0)))
+
     ;; ---- Modal positioning (rf2-om6fa) ----
     ;;
     ;; Every Xray modal (Settings popup, auto-filter edit popup,
@@ -532,7 +549,19 @@
     ;; (rf2-2moh1 registry-driven; new tab requires only a reg-l4-tab! call).
     (rf/reg-event-db :rf.xray/select-tab
       (fn [db [_ tab-id]]
-        (assoc db :selected-tab tab-id)))
+        ;; rf2-6tw7t — activating the Machine tab bumps a monotonic
+        ;; fit-signal counter so the Machine panel's topology re-fits to
+        ;; view on entry (xyflow's one-shot `:fitView` + the layout-key
+        ;; auto-fit both leave a re-entered chart at its stale pan/zoom).
+        ;; The counter lands in app-db so the panel can read it via one
+        ;; sub regardless of where the chart mounts; the Machine panel
+        ;; forwards it as `MachineChart`'s `:fit-signal`. Counting (not a
+        ;; boolean) guarantees a fresh value on every re-entry, including
+        ;; the case where the prior selection was already `:machines`
+        ;; (re-clicking the active tab still re-frames).
+        (cond-> (assoc db :selected-tab tab-id)
+          (= tab-id :machines)
+          (update :machine-tab-activations (fnil inc 0)))))
 
     ;; ---- Issues feed composite (rf2-gbz39) ------------------------
     ;;
@@ -620,7 +649,13 @@
     (rf/reg-event-db :rf.xray.static/select-tab
       (fn [db [_ tab-id]]
         (if (contains? (static-shell/tab-ids) tab-id)
-          (assoc db :rf.xray.static/selected-tab tab-id)
+          ;; rf2-6tw7t — Static shares the same `:machines` tab id +
+          ;; `machine-canvas/Chart`, so activating it bumps the same
+          ;; fit-signal counter the Dynamic select-tab does. The Static
+          ;; topology view forwards it as `:fit-signal` too.
+          (cond-> (assoc db :rf.xray.static/selected-tab tab-id)
+            (= tab-id :machines)
+            (update :machine-tab-activations (fnil inc 0)))
           db)))
 
     ;; The persistence fx installs idempotently — re-frame's registrar

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
@@ -162,12 +162,13 @@
   "Dispatch to the per-mode body renderer. Topology + Sim render a
   body; Instances + Cascade do not (Instances is a JUMP affordance,
   Cascade is dimmed). `dispatch` (rf2-nesy9) is threaded from `detail`."
-  [dispatch {:keys [sub-mode machine-id definition source-coord]}]
+  [dispatch {:keys [sub-mode machine-id definition source-coord fit-signal]}]
   (case sub-mode
     :topology
     [topology/body dispatch {:machine-id   machine-id
                              :definition   definition
-                             :source-coord source-coord}]
+                             :source-coord source-coord
+                             :fit-signal   fit-signal}]
 
     :sim
     [sim/body dispatch {:machine-id machine-id
@@ -221,7 +222,12 @@
         @(rf/subscribe [:rf.xray.static.machines/data])
         row (some #(when (= selected-id (:machine-id %)) %) rows)
         definitions @(rf/subscribe [:rf.xray/machine-definitions])
-        sub-mode @(rf/subscribe [:rf.xray.static.machines/sub-mode selected-id])]
+        sub-mode @(rf/subscribe [:rf.xray.static.machines/sub-mode selected-id])
+        ;; rf2-6tw7t — fit-on-entry nonce (bumped by `:rf.xray.static/
+        ;; select-tab :machines`). Threaded down to the Topology body's
+        ;; `machine-canvas/Chart` `:fit-signal` so entering the Static
+        ;; Machines tab re-frames the topology to view.
+        fit-signal @(rf/subscribe [:rf.xray/machine-tab-fit-signal])]
     (if (nil? row)
       (empty-detail)
       (let [{:keys [machine-id state-count live-count source-coord]} row
@@ -248,4 +254,5 @@
           [body dispatch {:sub-mode     sub-mode
                           :machine-id   machine-id
                           :definition   definition
-                          :source-coord source-coord}]]]))))
+                          :source-coord source-coord
+                          :fit-signal   fit-signal}]]]))))

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
@@ -85,7 +85,7 @@
     :testid                        — overrides the inner SVG testid
                                      so the existing static-panel
                                      tests still match."
-  [dispatch {:keys [definition machine-id]}]
+  [dispatch {:keys [definition machine-id fit-signal]}]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — ELK is now driven
   ;; internally by xyflow inside `mv-chart/MachineChart`; the
   ;; host-side layout-or-fallback dance is gone.
@@ -109,6 +109,10 @@
        :machine-id             machine-id
        :show-after-rings?      false
        :show-view-mode-toggle? false
+       ;; rf2-6tw7t — fit-on-entry nonce so entering the Static Machines
+       ;; tab re-frames the topology (xyflow's one-shot `:fitView` +
+       ;; the layout-key auto-fit both leave a re-entered chart stale).
+       :fit-signal             fit-signal
        :inner-testid           "rf-xray-static-machines-topology-svg"
        :on-state-click
        (fn [path]
@@ -179,7 +183,7 @@
   `dispatch` (rf2-nesy9) is threaded from `definition_detail/body` so
   the chart's state-click + the toolbar's pop-out land on the
   surrounding instance frame."
-  [dispatch {:keys [machine-id definition source-coord] :as args}]
+  [dispatch {:keys [machine-id definition source-coord fit-signal] :as args}]
   (cond
     (nil? definition)
     [:section {:data-testid     "rf-xray-static-machines-topology"
@@ -202,4 +206,5 @@
                        :color (:text-primary tokens)
                        :font-family sans-stack}}
      [chart-toolbar dispatch {:machine-id machine-id :source-coord source-coord}]
-     [chart dispatch {:definition definition :machine-id machine-id}]]))
+     [chart dispatch {:definition definition :machine-id machine-id
+                      :fit-signal fit-signal}]]))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -332,6 +332,10 @@
    ;; recent cascade; flips on event arrival, not on a per-second tick).
    :rf.xray/relative-time-now-ms
    :rf.xray/selected-tab
+   ;; rf2-6tw7t — Machine tab fit-on-entry nonce (bumped by
+   ;; `:rf.xray/select-tab :machines` + `:rf.xray.static/select-tab
+   ;; :machines`; forwarded to MachineChart's `:fit-signal`).
+   :rf.xray/machine-tab-fit-signal
    ;; rf2-ttnst — Settings popup expansion convenience subs.
    :rf.xray/density
    :rf.xray/long-keyword-threshold
@@ -899,6 +903,80 @@
         (is (some? (rf/subscribe [q-v]))
             (str q-v " must resolve through rf/subscribe after
                  register-xray-handlers!"))))))
+
+;; ---- Machine tab fit-on-entry signal (rf2-6tw7t) ------------------------
+;;
+;; Entering / activating the Machine tab must auto fit-to-view the
+;; topology. The mechanism: `:rf.xray/select-tab :machines` (and the
+;; Static `:rf.xray.static/select-tab :machines`) bump a monotonic
+;; counter at `:machine-tab-activations`; the `:rf.xray/machine-tab-fit-
+;; signal` sub surfaces it; the Machine panel forwards the value as
+;; `MachineChart`'s `:fit-signal`, which re-fits the viewport on every
+;; CHANGE (the chart-side gate is pinned in machines-viz
+;; `auto-fit-view-cljs-test`). These pins guard the host-side wiring: the
+;; activation path bumps the signal, NON-machine activations don't, and
+;; the sub reads it back.
+
+(deftest machine-tab-fit-signal-default-zero
+  (testing "rf2-6tw7t — a fresh :rf/xray frame reports fit-signal 0 (no
+            activation yet). The chart's `::unfit` sentinel start means
+            the FIRST activation (→ 1) is still a change, so the initial
+            entry frames the graph."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (is (= 0 @(rf/subscribe [:rf.xray/machine-tab-fit-signal]))
+          "no Machine-tab activation yet → 0"))))
+
+(deftest machine-tab-fit-signal-bumps-on-dynamic-activation
+  (testing "rf2-6tw7t — `:rf.xray/select-tab :machines` bumps the fit-
+            signal so the Machine panel re-fits on entry; re-clicking the
+            already-active Machine tab still bumps it (re-entry re-frames
+            even without a tab change), and the counter increases
+            monotonically per activation."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-tab :machines])
+      (is (= 1 @(rf/subscribe [:rf.xray/machine-tab-fit-signal]))
+          "first Machine-tab activation → 1")
+      ;; Re-clicking the active Machine tab re-frames (fresh nonce).
+      (rf/dispatch-sync [:rf.xray/select-tab :machines])
+      (is (= 2 @(rf/subscribe [:rf.xray/machine-tab-fit-signal]))
+          "re-activating the same tab still bumps the signal")
+      (is (= :machines @(rf/subscribe [:rf.xray/selected-tab]))
+          "the tab selection itself is unchanged"))))
+
+(deftest machine-tab-fit-signal-steady-on-non-machine-tabs
+  (testing "rf2-6tw7t — activating a NON-Machine tab must NOT bump the
+            fit-signal (only Machine-tab entry re-frames the topology).
+            A round-trip away and back bumps exactly once on the return."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-tab :machines])
+      (is (= 1 @(rf/subscribe [:rf.xray/machine-tab-fit-signal])))
+      ;; Leave the Machine tab — no bump.
+      (rf/dispatch-sync [:rf.xray/select-tab :epoch])
+      (rf/dispatch-sync [:rf.xray/select-tab :app-db])
+      (is (= 1 @(rf/subscribe [:rf.xray/machine-tab-fit-signal]))
+          "non-Machine tabs leave the signal steady")
+      ;; Re-enter the Machine tab — exactly one bump.
+      (rf/dispatch-sync [:rf.xray/select-tab :machines])
+      (is (= 2 @(rf/subscribe [:rf.xray/machine-tab-fit-signal]))
+          "re-entering the Machine tab re-frames (one bump)"))))
+
+(deftest machine-tab-fit-signal-bumps-on-static-activation
+  (testing "rf2-6tw7t — Static shares the `:machines` tab id +
+            `machine-canvas/Chart`, so `:rf.xray.static/select-tab
+            :machines` bumps the SAME fit-signal counter the Dynamic
+            select-tab does. A non-machine Static tab activation does
+            not bump it."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray.static/select-tab :machines])
+      (is (= 1 @(rf/subscribe [:rf.xray/machine-tab-fit-signal]))
+          "Static Machine-tab activation bumps the shared counter")
+      (rf/dispatch-sync [:rf.xray.static/select-tab :routes])
+      (is (= 1 @(rf/subscribe [:rf.xray/machine-tab-fit-signal]))
+          "a non-machine Static tab does not bump the fit-signal"))))
 
 ;; ---- (2) high-value sub contracts: defaults on a fresh frame ------------
 


### PR DESCRIPTION
## What

Entering / re-entering the **Machine tab** now automatically **fit-to-views** the topology graph. Today xyflow's one-shot `:fitView` mount prop fires only on initial mount, and the layout-key auto-fit (rf2-set3x) deliberately preserves manual zoom/pan across non-layout re-renders — so re-entering the Machine tab (or switching to it) leaves the graph at its prior pan/zoom, where it can sit off-screen or wrongly scaled.

## How

Reuses the existing `invoke-fit-view!` indirection rather than reinventing.

- **machines-viz `MachineChart`** gains an optional opaque **`:fit-signal`** prop. When its value **changes** between renders the chart re-fits the viewport through the existing `schedule-fit!` (double-rAF) + `invoke-fit-view!` path. This is **orthogonal** to the layout-key gate — that gate still preserves manual zoom/pan across non-entry re-renders. A `::unfit` sentinel start fits the first observed signal once; the re-fit honours the same preconditions as the settle fit (captured instance + non-empty `:positions` + no `:layout-error`), and an entry signal that arrives before those are ready defers to `:onInit` / the next render.
- **Xray host** bumps a monotonic `:machine-tab-activations` counter on `:rf.xray/select-tab :machines` and `:rf.xray.static/select-tab :machines`, surfaced via the new `:rf.xray/machine-tab-fit-signal` sub. The Dynamic Machine inspector (`machine_inspector`) and the Static Machines topology (`definition_detail` → `topology` → `machine-canvas/Chart`) forward it as `:fit-signal`. Re-clicking the already-active Machine tab still re-frames (the counter always changes).

The standalone viewer / Story path supplies no signal → the prop stays `nil`, never changes, and the entry-fit is inert (only the layout-key auto-fit runs).

## Tests (gate: panel-entry/activation invokes the fit, not only first mount)

- **machines-viz** `auto_fit_view_cljs_test` — pins `maybe-fit-on-signal!` verbatim: fits once per signal change (steady signal is a no-op so manual zoom/pan survives), defers until instance + positions are ready, skips a `:layout-error` settle.
- **xray** `registry_cljs_test` — pins the host wiring: Dynamic + Static `:machines` activation bumps `:rf.xray/machine-tab-fit-signal`; non-machine tabs leave it steady; re-entry bumps exactly once.
- machines-viz API.md — new **§Fit-on-entry signal (rf2-6tw7t)** + props-table row.

## Gates (cold)

- `npx shadow-cljs compile node-test` — **0 warnings** (1146 compiled).
- `npm run test:cljs` — **0 failures, 0 errors** (5449 tests / 18900 assertions).
- machines-viz `clojure -M:test` — **0 failures, 0 errors** (334 tests / 940 assertions).
- `npm run test:xray-feature-gate` — **0 failures** (16 scenarios; all testbed builds 0 warnings).

Closes rf2-6tw7t.