### PR TITLE
refactor(xray/machine-epochs): drop the :trail order-oracle (rf2-2a4i9)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1544,6 +1544,6 @@ action-attribution half.
   shallow/deep restore). Each step is
   backed by a CLJS-unit assertion in
   `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test` (BOTH
-  the machine outcome via the per-machine `:data :trail` order-oracle AND the
-  cascade-render projection it lights up), complemented by
-  `…hard-machine-fidelity-cljs-test` for the HVAC HARD machine.
+  the machine outcome AND the cascade-render projection it lights up — cascade
+  ORDER is read off the structured `:cascade` steps, not an app-level oracle),
+  complemented by `…hard-machine-fidelity-cljs-test` for the HVAC HARD machine.

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1795,10 +1795,10 @@ Rendered shape (`view/structured-cascade-body`):
   delta box remain (graceful degradation). The grouping helpers degrade
   to `[]` / `nil` on a nil cascade.
 
-This removes the need for the app-level `:data :trail` workaround the
-`machine_epochs` testbed previously used to make the cascade observable
-by hand (rf2-52u5n live finding, machine-epochs :8033). It is the
-consumer of the rf2-n9f4z instrumentation contract per
+This makes the cascade observable WITHOUT any app-level workaround the
+`machine_epochs` testbed once used to read the order by hand (rf2-52u5n live
+finding, machine-epochs :8033). It is the consumer of the rf2-n9f4z
+instrumentation contract per
 [003-Machine-Inspector §The EVENT HANDLER machine cascade](003-Machine-Inspector.md).
 
 The `machine_epochs` testbed (:8033) is now the **assertion-backed render
@@ -1819,11 +1819,11 @@ shallow + deep restore** steps (first-class history per rf2-mle6e). Each step
 is backed by a CLJS-unit assertion in
 `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test` that
 drives the step through the live substrate and pins BOTH the machine outcome
-(via the generalized per-machine `:data :trail` order-oracle) AND the Xray
-cascade-render projection it lights up — so re-driving the deck is a real
-regression test of this render contract. The `:data :trail` is no longer a
-workaround; every machine carries it as a legible cross-check the harness
-keys its order assertions off.
+AND the Xray cascade-render projection it lights up — so re-driving the deck
+is a real regression test of this render contract. Cascade ORDER is read off
+the structured `:cascade` steps (the `cascade-regions` projection), so the
+harness keys its order assertions directly off the Xray-surface projection —
+there is no app-level order-oracle to keep in sync.
 
 Timer rows surface only the header + click-to-source chip (no inline
 body — cancellations are housekeeping; the chip routes to the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
@@ -27,8 +27,9 @@
 
   Per rf2-k08ay + the rf2-hhkbb drive-through finding, EACH rung asserts THREE
   layers:
-    (a) TRACE shape — the machine cascade kinds + order (the generalized
-        `:trail` is the order-oracle; also the `:cascade` kinds + `:microsteps`).
+    (a) TRACE shape — the machine cascade kinds + order, read off the
+        structured `:cascade` (its `:kind` / `:state` / `:action` steps in
+        execution order + the `:microsteps`).
     (b) STRUCTURED outcome — the Xray-surface analogue of the rf2-hhkbb
         cascade-summary `:outcome` / `:no-op?`: a thrown `:*` action shows
         `:threw? true` on its cascade row (catching hhkbb); the unhandled rung
@@ -86,8 +87,6 @@
   (get-in (rf/app-db-value :rf/default)
           [:rf/runtime :machines :snapshots machine-id]))
 
-(defn- trail [machine-id] (get-in (snapshot machine-id) [:data :trail]))
-
 (defn- drive!
   "Dispatch one event into `machine-id` and return the trace stream it
   produced as an epoch-record-shaped map. Resets the trace buffer first so
@@ -103,6 +102,17 @@
 (defn- rows-of-kind [rows kind] (filterv #(= kind (:kind %)) rows))
 (defn- structured-of [record]
   (-> (cascade record) (rows-of-kind :transition) first :cascade))
+
+;; The structured `:cascade` is the order-oracle: each step carries
+;; `:kind` (`:exit` / `:action` / `:entry`), `:state`, `:region`, `:action`
+;; (nil for an action-free boundary) in EXECUTION order (exit-deepest-first →
+;; action @ LCA → entry-shallowest-first). `region-steps` returns the
+;; structural steps of one `:region` (nil for flat/compound) so a test can
+;; assert the cascade ORDER directly off the Xray-surface projection.
+(defn- region-steps [record region]
+  (->> (proj/cascade-regions (structured-of record))
+       (some #(when (= region (:region %)) (:steps %)))
+       vec))
 
 ;; ============================================================================
 ;; DOOR (FLAT) — plain · entry/exit · transition-action · guards · internal ·
@@ -127,19 +137,24 @@
 
 (deftest door-entry-exit-actions-render-with-data-delta
   (testing "rung #3 — :closed ──► :open runs :closed's :exit (:clear-hold) +
-            :open's :entry (:count-open). (a) the trail records exit→entry
-            order; (c) the cascade carries an :exit + an :entry action row;
-            the entry action's :data-delta bumps :opened-count."
+            :open's :entry (:count-open). (a) the structured cascade records
+            the exit→action→entry order; (c) the cascade carries an :exit + an
+            :entry action row; the entry action's :data-delta bumps
+            :opened-count."
     (setup!)
     (drive! :door/main [:door/insert-coin])            ; :locked → :closed
     (let [record (drive! :door/main [:door/push])       ; :closed → :open
           rows   (cascade record)
-          phases (mapv :phase (rows-of-kind rows :action))]
+          phases (mapv :phase (rows-of-kind rows :action))
+          steps  (region-steps record nil)]
       (is (some #{:exit} phases)  "(c) an exit action row renders")
       (is (some #{:entry} phases) "(c) an entry action row renders")
-      ;; (a) the trail oracle: exit:closed then entry:open, in that order.
-      (is (= [:exit:closed :entry:open] (trail :door/main))
-          "(a) trail records the exit→entry cascade order")
+      ;; (a) the structured cascade order-oracle: the :closed exit (:clear-hold)
+      ;; fires before the :open entry (:count-open).
+      (is (= [:exit :entry] (mapv :kind steps))
+          "(a) the structured cascade records the exit→entry order")
+      (is (= [:clear-hold :count-open] (mapv :action steps))
+          "(a) the exit action runs before the entry action")
       (is (= 1 (get-in (snapshot :door/main) [:data :opened-count]))
           "(c) the :entry action bumped :opened-count"))))
 
@@ -191,16 +206,18 @@
   (testing "rung #6 — :open ──► :alarming runs :enter-alarm whose action
             writes :data (the deck dispatches the downstream child via the
             deck event-fx). (c) the cascade carries the transition + the
-            :enter-alarm action; the trail records :action:trip."
+            :enter-alarm action whose :data-write sets :alarm-fx?."
     (setup!)
     (drive! :door/main [:door/insert-coin])
     (drive! :door/main [:door/push])
     (let [rows (cascade (drive! :door/main [:door/trip]))]
       (is (= 1 (count (rows-of-kind rows :transition))))
-      (is (some #(= :action:trip (last (get-in % [:data-write :trail] [])))
+      (is (some #(true? (get-in % [:data-write :alarm-fx?]))
                 (rows-of-kind rows :action))
-          "(a)(c) the :enter-alarm action ran (trail appended :action:trip)"))
-    (is (= :alarming (:state (snapshot :door/main))))))
+          "(a)(c) the :enter-alarm action ran (its :data-write set :alarm-fx?)"))
+    (is (= :alarming (:state (snapshot :door/main))))
+    (is (true? (get-in (snapshot :door/main) [:data :alarm-fx?]))
+        "(c) the :enter-alarm action wrote :alarm-fx? into the snapshot")))
 
 (deftest door-unhandled-event-renders-single-no-op-staying-in-state
   (testing "rung #7 — :door/insert-coin into :alarming matches no transition →
@@ -230,9 +247,8 @@
 (deftest door-audit-resolves-via-root-on-fallthrough
   (testing "rung #8 (gap 6, RESOLUTION) — :alarming declares no :door/audit;
             the event falls through to the machine ROOT :on, which targets
-            :locked. (a) the trail records :action:audit (the root clause's
-            action ran); (c) a real transition row attributes :alarming ──►
-            :locked — NOT a no-op."
+            :locked. (a)(c) a real transition row attributes :alarming ──►
+            :locked — the root-resolved transition, NOT a no-op."
     (setup!)
     (drive! :door/main [:door/insert-coin])
     (drive! :door/main [:door/push])
@@ -245,9 +261,7 @@
       (is (some? tx) "(c) a real transition row renders")
       (is (= :alarming (:from-state tx)))
       (is (= :locked (:to-state tx))
-          "(c) the cascade attributes the root-resolved transition to :locked")
-      (is (= :action:audit (last (trail :door/main)))
-          "(a) the root clause's :record-audit action ran"))
+          "(a)(c) the cascade attributes the root-resolved transition to :locked"))
     (is (= :locked (:state (snapshot :door/main))))))
 
 ;; ============================================================================
@@ -347,7 +361,7 @@
             (a) the transition row's :microsteps > 0 AND the structured
             :cascade carries a :microstep step whose nested :steps explain the
             eventless transition (the :award action → :passed); (c) the quiz
-            lands in :passed; the trail records the :always action."
+            lands in :passed."
     (setup!)
     (drive! :quiz/scorer [:quiz/answer])                ; score → 1
     (drive! :quiz/scorer [:quiz/answer])                ; score → 2
@@ -373,9 +387,7 @@
       ;; (c) the live machine settled.
       (is (= :passed (:state (snapshot :quiz/scorer))))
       (is (true? (get-in (snapshot :quiz/scorer) [:data :passed?]))
-          "(c) the :always :award action ran")
-      (is (= :always:passed (last (trail :quiz/scorer)))
-          "(a) the trail oracle records the :always action LAST"))))
+          "(c) the :always :award action ran"))))
 
 ;; ============================================================================
 ;; BREW (TIMER) — :after delayed transition + cancellation (gap 2)
@@ -452,9 +464,8 @@
           "(a) the child auto-destroyed with :reason :rf.machine/finished")
       (is (= :session/token-abc
              (get-in (snapshot :session/flow) [:data :session-token]))
-          "(c) the parent's :on-done reported the child's :output-key token")
-      (is (= :action:on-done (last (trail :session/flow)))
-          "(a) the :on-done callback ran on the parent (trail records it)")
+          "(a)(c) the parent's :on-done callback ran, reporting the child's
+                  :output-key token into the parent's :data")
       (is (nil? (snapshot child-id))
           "(c) the child's snapshot was synchronously dissoc'd (auto-destroy)"))))
 
@@ -510,46 +521,60 @@
           "(c) both regions moved in one macrostep (deep initial cascade)"))))
 
 (deftest hvac-mode-toggle-renders-lca-cascade-order
-  (testing "rung #21 — :hvac/mode-toggle crosses the :conditioning LCA. (a)
-            the trail delta is exactly exit:heating → action:swap-mode →
-            entry:cooling (the LCA cascade order, the LCA itself stays
-            active); (c) the deep compound leaf moved heating → cooling."
+  (testing "rung #21 — :hvac/mode-toggle crosses the :conditioning LCA. (a) the
+            structured cascade is exactly exit [:running :conditioning :heating]
+            → entry [:running :conditioning :cooling] (deepest-exit-first →
+            shallowest-entry-first; the LCA :conditioning stays active, so it is
+            neither exited nor entered); (c) the deep compound leaf moved
+            heating → cooling."
     (setup!)
     (drive! :hvac/controller [:hvac/power-cycle])       ; → :heating
-    (let [before (count (trail :hvac/controller))
-          _      (drive! :hvac/controller [:hvac/mode-toggle])
-          delta  (vec (drop before (trail :hvac/controller)))]
-      (is (= [:exit:heating :action:swap-mode :entry:cooling] delta)
-          "(a) the LCA cascade order: deepest-exit → action @ LCA → new-leaf-entry"))
+    (let [record (drive! :hvac/controller [:hvac/mode-toggle])
+          steps  (region-steps record :climate)]
+      (is (= [:exit :entry] (mapv :kind steps))
+          "(a) the LCA cascade order: deepest leaf exit → new-leaf entry")
+      (is (= [[:running :conditioning :heating]
+              [:running :conditioning :cooling]]
+             (mapv :state steps))
+          "(a) the deepest :heating leaf exits, the :cooling leaf enters; the
+               LCA :conditioning stays active (neither exited nor entered)"))
     (is (= [:running :conditioning :cooling] (:climate (:state (snapshot :hvac/controller)))))))
 
 (deftest hvac-self-transitions-external-vs-internal
-  (testing "rungs #22/#23 — EXTERNAL self-transition (:hvac/nudge) fires
-            exit+action+entry; INTERNAL (:hvac/tweak) fires action-only.
-            (a) the trail deltas distinguish them; (c) neither emits a
-            spurious no-op transition row; both stay :fan :on."
+  (testing "rungs #22/#23 — EXTERNAL self-transition (:hvac/nudge,
+            :target :same-state) fires exit+entry of :fan :on; INTERNAL
+            (:hvac/tweak) fires its :tweak-fan action ONLY. (a) the structured
+            cascade region steps distinguish them; (c) neither emits a spurious
+            no-op transition row; both stay :fan :on."
     (setup!)
     (drive! :hvac/controller [:hvac/power-cycle])       ; fan → :on
-    ;; #22 — external self-transition.
-    (let [before (count (trail :hvac/controller))
-          rows   (cascade (drive! :hvac/controller [:hvac/nudge]))
-          delta  (vec (drop before (trail :hvac/controller)))]
-      (is (= [:exit:fan-on :action:nudge :entry:fan-on] delta)
-          "(a) external self-transition: exit → action → entry")
+    ;; #22 — external self-transition: :target :same-state re-enters :on.
+    (let [record (drive! :hvac/controller [:hvac/nudge])
+          rows   (cascade record)
+          steps  (region-steps record :fan)]
+      (is (= [:exit :entry] (mapv :kind steps))
+          "(a) external self-transition re-enters :on: exit → entry boundary")
+      (is (= [[:on] [:on]] (mapv :state steps))
+          "(a) the exit and entry both land on :on (a genuine self re-entry)")
       (is (empty? (rows-of-kind rows :no-op))
           "(c) a genuine self-transition is NOT a no-op")
       (is (= 1 (count (rows-of-kind rows :transition)))
           "(c) one real transition row (e6q97: not suppressed)"))
-    ;; #23 — internal self-transition (the foil).
-    (let [before (count (trail :hvac/controller))
-          rows   (cascade (drive! :hvac/controller [:hvac/tweak]))
-          delta  (vec (drop before (trail :hvac/controller)))]
-      (is (= [:action:tweak] delta) "(a) internal self-transition: action ONLY")
+    ;; #23 — internal self-transition (the foil): action ONLY, no boundary.
+    (let [record (drive! :hvac/controller [:hvac/tweak])
+          rows   (cascade record)
+          steps  (region-steps record :fan)]
+      (is (= [:action] (mapv :kind steps))
+          "(a) internal self-transition: action ONLY — no exit/entry boundary")
+      (is (= [:tweak-fan] (mapv :action steps))
+          "(a) the internal action that ran is :tweak-fan")
       (is (empty? (filterv #(and (= :action (:kind %)) (= :exit (:phase %))) rows))
           "(c) internal self-transition fires NO exit row")
       (is (empty? (rows-of-kind rows :no-op))
           "(c) internal self-transition is a REAL transition, not a no-op"))
-    (is (= :on (:fan (:state (snapshot :hvac/controller)))))))
+    (is (= :on (:fan (:state (snapshot :hvac/controller)))))
+    (is (= 1 (get-in (snapshot :hvac/controller) [:data :tweaks]))
+        "(c) the internal :tweak-fan action bumped :tweaks once")))
 
 ;; ============================================================================
 ;; HISTORY (gap 8, LIVE) — placement rejection + shallow + deep RESTORE render

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -2965,8 +2965,8 @@ async function clickMachineRung(page, n) {
 }
 
 // Read every machine's snapshot directly from the host's `:rf/default`
-// app-db and reconstruct the same `state … · tags … · trail …` text the
-// deck used to render in its on-page status strip.
+// app-db and reconstruct a `state … · tags …` text for each machine — the
+// robust, non-flaky proof each machine feature landed its configuration.
 //
 // rf2-5sgwn — the deck's `machine-epochs-status-strip` (and the deck subs
 // it consumed) were removed: the Xray Epoch panel + Machine Inspector are
@@ -3019,19 +3019,12 @@ async function readMachineStrip(page) {
     function pr(v) {
       return v == null ? 'nil' : cljs.pr_str(v);
     }
-    // Reconstruct one strip row: "<label> state: <state> · tags: <tags>
-    // [· trail: <trail>]" (trail clause only when non-empty), matching
-    // the deck's removed `machine-row` view.
+    // Reconstruct one strip row: "<label> state: <state> · tags: <tags>".
     function row(label, machineId) {
       const snap = snapshot(machineId);
       const state = field(snap, ':state');
       const tags = field(snap, ':tags');
-      const trail = field(snap, ':data', ':trail');
-      let line = `${label} state: ${pr(state)} · tags: ${pr(tags)}`;
-      if (trail != null && cljs.seq(trail)) {
-        line += ` · trail: ${pr(trail)}`;
-      }
-      return line;
+      return `${label} state: ${pr(state)} · tags: ${pr(tags)}`;
     }
     const doorData = field(snapshot(':door/main'), ':data');
     const quizData = field(snapshot(':quiz/scorer'), ':data');
@@ -3045,6 +3038,7 @@ async function readMachineStrip(page) {
       `:quiz/scorer data: ${pr(quizData)}`,
       row(':brew/machine', ':brew/machine'),
       row(':session/flow', ':session/flow'),
+      `:session/flow data: ${pr(field(snapshot(':session/flow'), ':data'))}`,
       row(':hvac/controller', ':hvac/controller'),
       row(':media/deep', ':media/deep'),
       `:media/deep :rf/history: ${pr(mediaDeepHistory)}`,
@@ -3065,7 +3059,7 @@ async function readMachineStrip(page) {
       brewState: stateText(':brew/machine', ':brew/machine'),
       sessionState: stateText(':session/flow', ':session/flow'),
       hvacState: stateText(':hvac/controller', ':hvac/controller'),
-      hvacTrail: pr(field(snapshot(':hvac/controller'), ':data', ':trail')),
+      sessionData: pr(field(snapshot(':session/flow'), ':data')),
     };
   });
 }
@@ -3249,17 +3243,16 @@ async function runMachineEpochs(page, state) {
   );
 
   // #18 child succeeds — :final + :on-done reports the token to the parent +
-  //     the child auto-destroys. The strip surfaces the parent's :on-done via
-  //     its trail (:action:on-done appended) — the observable proof the
-  //     callback ran; the reported :session-token (in the parent's :data) +
-  //     the auto-destroy / :rf.machine/finished trace are asserted in the
-  //     CLJS harness.
+  //     the child auto-destroys. The strip surfaces the parent's :session-token
+  //     (written into its :data by the :on-done callback) — the observable
+  //     proof the callback ran; the auto-destroy / :rf.machine/finished trace
+  //     is asserted in the CLJS harness.
   await clickMachineRung(page, 18);
   await waitForValue(
     () => readMachineStrip(page),
     (snap) => /:session\/flow state: :authenticating/.test(snap.stripText || '') &&
-              /:action:on-done/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#18 child :final -> :on-done ran on the parent (trail shows :action:on-done) + child auto-destroyed' },
+              /:session-token/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#18 child :final -> :on-done ran on the parent (data carries :session-token) + child auto-destroyed' },
   );
 
   // ===== Fuse (WILDCARD-THROW) — asserted as the throw contrast below ====
@@ -3279,41 +3272,34 @@ async function runMachineEpochs(page, state) {
   );
 
   // #21 multi-level LCA cascade — :heating -> :cooling crossing the LCA
-  //     :conditioning; the trail records the cascade ORDER.
+  //     :conditioning. The deep compound leaf moves to :cooling (the LCA
+  //     cascade ORDER is pinned in the CLJS harness off the structured
+  //     :cascade).
   await clickMachineRung(page, 21);
   await waitForValue(
     () => readMachineStrip(page),
-    (snap) => {
-      const t = snap.stripText || '';
-      return /:climate \[:running :conditioning :cooling\]/.test(t) &&
-             /:exit:heating :action:swap-mode :entry:cooling/.test(t);
-    },
-    { timeoutMs: 10000, description: '#21 mode-toggle -> :cooling + trail shows LCA cascade order' },
+    (snap) => /:climate \[:running :conditioning :cooling\]/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#21 mode-toggle -> deep leaf :cooling (crosses the :conditioning LCA)' },
   );
 
-  // #22 EXTERNAL self-transition (:hvac/nudge) — exit -> action -> entry; fan
-  //     STAYS :on.
+  // #22 EXTERNAL self-transition (:hvac/nudge) — :target :same-state re-enters
+  //     :on (exit -> entry boundary, asserted in the CLJS harness); fan STAYS
+  //     :on.
   await clickMachineRung(page, 22);
   await waitForValue(
     () => readMachineStrip(page),
-    (snap) => {
-      const t = snap.stripText || '';
-      return /:fan :on/.test(t) &&
-             /:exit:fan-on :action:nudge :entry:fan-on/.test(t);
-    },
-    { timeoutMs: 10000, description: '#22 nudge -> external self-transition: trail exit->action->entry, fan STAYS :on' },
+    (snap) => /:fan :on/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#22 nudge -> external self-transition, fan STAYS :on' },
   );
 
-  // #23 INTERNAL self-transition (:hvac/tweak) — action ONLY; fan STAYS :on.
+  // #23 INTERNAL self-transition (:hvac/tweak) — its :tweak-fan action runs
+  //     (bumps :tweaks); no exit/entry boundary (asserted in the CLJS harness);
+  //     fan STAYS :on.
   await clickMachineRung(page, 23);
   const afterHvacTweak = await waitForValue(
     () => readMachineStrip(page),
-    (snap) => {
-      const t = snap.stripText || '';
-      return /:fan :on/.test(t) &&
-             /:action:nudge :entry:fan-on :action:tweak/.test(t);
-    },
-    { timeoutMs: 10000, description: '#23 tweak -> internal self-transition: trail gains :action:tweak ONLY, fan STAYS :on' },
+    (snap) => /:fan :on/.test(snap.stripText || ''),
+    { timeoutMs: 10000, description: '#23 tweak -> internal self-transition (action-only), fan STAYS :on' },
   );
 
   // ===== History (gap 8 — reject-now) ===================================

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -37,15 +37,14 @@
   the runner conversion is additive: it neither drops nor relies on the
   harness's assertions.
 
-  ## The generalized `:trail` order-oracle (rf2-g27vv)
+  ## Cascade order is read off the structured `:cascade` (rf2-g27vv)
 
-  Every machine carries a `:data :trail` vector and every `:entry` /
-  `:exit` / transition `:action` / `:always` action APPENDS one
-  `<phase>:<state>` label (built by `machines/trail-action`). So the
-  post-macrostep `:trail` is the cascade ORDER made visible — the order-
-  oracle the harness keys its assertions off. The deck has no on-page
-  snapshot read-out; the Xray Inspector / Epoch panel is the read-out
-  (and the actual check), and the harness drives the substrate directly.
+  Cascade ORDER (exit-deepest-first → action @ LCA → entry-shallowest-first,
+  microsteps, the per-region walk) is exposed by the engine's structured
+  `:cascade` off the transition row, so the harness keys its order assertions
+  directly off the Xray-surface projection. The deck has no on-page snapshot
+  read-out; the Xray Inspector / Epoch panel is the read-out (and the actual
+  check), and the harness drives the substrate directly.
 
   ## The machine set (each a coherent clean domain; collectively the matrix)
 
@@ -111,8 +110,7 @@
   ## Test surface, not tutorial (feedback_testbeds_are_test_surfaces)
 
   No deliberate bugs, no teaching layers. Every transition is a clean feature
-  being driven; the trail is instrumentation, not an anti-pattern demo. The
-  `:watch` notes are guidance, not lessons.
+  being driven. The `:watch` notes are guidance, not lessons.
 
   ## Test-free + self-contained (rf2-8cevm)
 
@@ -328,10 +326,8 @@
 ;;
 ;; The deck reads NO machine snapshots on-page — the Xray Epoch panel +
 ;; Machine Inspector are the read-out, and the harness drives the substrate
-;; directly. The machines' `:trail` order-oracle lives in
-;; `machine-epochs.machines` and is read by the harness, not the deck. So
-;; this deck registers no on-page subs; the runner reads the shared
-;; `:rf.runner/step` sub for its highlight + counter.
+;; directly. So this deck registers no on-page subs; the runner reads the
+;; shared `:rf.runner/step` sub for its highlight + counter.
 ;;
 ;; Each step: {:event [...] :watch "<what to look for>" :label "<short row
 ;; label>"}. The runner renders :watch per STEP; pressing Step (or a per-row

--- a/tools/xray/testbeds/machine_epochs/machines.cljs
+++ b/tools/xray/testbeds/machine_epochs/machines.cljs
@@ -8,15 +8,15 @@
   literally the SAME values — a drift between them is impossible (the bead's
   single-source-of-truth requirement for the machine half of the matrix).
 
-  ## The generalized `:trail` order-oracle
+  ## Cascade order is read off the structured `:cascade`
 
-  Every machine here carries a `:data :trail` vector; every `:entry` /
-  `:exit` / transition `:action` / `:always` action APPENDS one
-  `<phase>:<state>` label via `trail-action`. The post-macrostep `:trail` is
-  the cascade ORDER made visible — the order-oracle the harness keys its
-  assertions off. (Spec 005 §The structured transition cascade now exposes
-  the structured `:cascade` directly, so the trail is a legible cross-check,
-  not a workaround.)
+  Cascade ORDER (exit-deepest-first → action @ LCA → entry-shallowest-first,
+  microsteps, region walk) is exposed by the engine's structured `:cascade`
+  off the transition row (Spec 005 §The structured transition cascade), so
+  the harness keys its order assertions directly off the Xray-surface
+  projection — there is no app-level order-oracle to keep in sync. Actions
+  here do only their real data mutation (`:opened-count`, `:score`, the
+  spawned token, …); state-only transitions carry no action at all.
 
   ## Test surface, not tutorial (feedback_testbeds_are_test_surfaces)
 
@@ -26,32 +26,6 @@
   bug."
   (:require [re-frame.core :as rf])
   (:require-macros [re-frame.core :refer [defmachine]]))
-
-;; ----------------------------------------------------------------------------
-;; trail-action — the generalized order-oracle action factory.
-;; ----------------------------------------------------------------------------
-;;
-;; Returns a NAMED action fn that conj's `label` (`<phase>:<state>`) onto
-;; `[:data :trail]`. The `:name` metadata survives onto the fn so `defmachine`
-;; stamps per-element source AND the Inspector's ref-display-id surfaces a
-;; legible action id (rf2-ujra6). When `extra-fn` is supplied it is applied to
-;; the resulting `:data` map (for actions that ALSO mutate other `:data` keys,
-;; e.g. the door's :count-open or the quiz's :score bump) — so a single
-;; factory covers both the pure trail recorders and the data-mutating actions
-;; while keeping every action trail-appending (the oracle stays complete).
-
-(defn trail-action
-  "Build a named action appending `label` to `[:data :trail]`. Optional
-  `extra-fn` is `(fn [data event] data)` applied AFTER the trail append, to
-  mutate other `:data` keys. `label` is `<phase>:<state>` so the rendered
-  cascade / snapshot-Δ reads as an ordered, self-describing sequence."
-  ([nm label] (trail-action nm label nil))
-  ([nm label extra-fn]
-   (with-meta
-     (fn [{data :data event :event}]
-       (let [data' (update data :trail (fnil conj []) label)]
-         {:data (if extra-fn (extra-fn data' event) data')}))
-     {:name nm})))
 
 ;; ============================================================================
 ;; MACHINE 1 — :door/main  (FLAT: guards + entry/exit + fx + RESOLUTION)
@@ -76,12 +50,13 @@
 (defmachine door-machine
   {:initial :locked
    :data    {:opened-count 0
-             :held-open?   false
-             :trail        []}
+             :held-open?   false}
 
    ;; ROOT-level :on — the fallthrough target for any state that does not
-   ;; declare :door/audit locally (gap 6 — transition resolution).
-   :on {:door/audit {:target :locked :action :record-audit}}
+   ;; declare :door/audit locally (gap 6 — transition resolution). A plain
+   ;; transition: the structured cascade attributes :alarming ──► :locked to
+   ;; this root clause.
+   :on {:door/audit :locked}
 
    :guards
    {:may-close?
@@ -89,21 +64,16 @@
       (not (:held-open? data)))}
 
    :actions
-   {:count-open  (trail-action 'count-open  :entry:open
-                               (fn [d _] (update d :opened-count (fnil inc 0))))
-    :clear-hold  (trail-action 'clear-hold  :exit:closed
-                               (fn [d _] (assoc d :held-open? false)))
+   {:count-open  (fn action-count-open [{data :data}]
+                   {:data (update data :opened-count (fnil inc 0))})
+    :clear-hold  (fn action-clear-hold [{data :data}]
+                   {:data (assoc data :held-open? false)})
     :hold-open   (fn action-hold-open [{data :data}]
-                   ;; INTERNAL transition (no :target): writes :data only;
-                   ;; not part of the entry/exit cascade so it does NOT append
-                   ;; the cascade trail — it records its own marker instead so
-                   ;; the internal-transition action is still observable.
-                   {:data (-> data
-                              (assoc :held-open? true)
-                              (update :trail (fnil conj []) :action:hold))})
-    :enter-alarm (trail-action 'enter-alarm :action:trip
-                               (fn [d _] (assoc d :alarm-fx? true)))
-    :record-audit (trail-action 'record-audit :action:audit)}
+                   ;; INTERNAL transition (no :target): writes :data only —
+                   ;; it is not part of the entry/exit cascade.
+                   {:data (assoc data :held-open? true)})
+    :enter-alarm (fn action-enter-alarm [{data :data}]
+                   {:data (assoc data :alarm-fx? true)})}
 
    :states
    {:locked
@@ -186,16 +156,16 @@
 
 (defmachine quiz-machine
   {:initial :asking
-   :data    {:score 0 :trail []}
+   :data    {:score 0}
 
    :guards
    {:enough? (fn guard-enough? [{data :data}] (>= (:score data) 3))}
 
    :actions
-   {:count-answer (trail-action 'count-answer :action:answer
-                                (fn [d _] (update d :score (fnil inc 0))))
-    :award        (trail-action 'award        :always:passed
-                                (fn [d _] (assoc d :passed? true)))}
+   {:count-answer (fn action-count-answer [{data :data}]
+                    {:data (update data :score (fnil inc 0))})
+    :award        (fn action-award [{data :data}]
+                    {:data (assoc data :passed? true)})}
 
    :states
    {:asking {:tags   #{:quiz/asking}
@@ -217,12 +187,6 @@
 
 (defmachine brew-machine
   {:initial :idle
-   :data    {:trail []}
-
-   :actions
-   {:start-brewing (trail-action 'start-brewing :entry:brewing)
-    :serve         (trail-action 'serve         :entry:ready)
-    :abort-brewing (trail-action 'abort-brewing :exit:brewing)}
 
    :states
    {:idle
@@ -231,14 +195,11 @@
 
     :brewing
     {:tags  #{:brew/brewing}
-     :entry :start-brewing
-     :exit  :abort-brewing
      :after {5000 :ready}
      :on    {:brew/abort :idle}}
 
     :ready
     {:tags  #{:brew/ready}
-     :entry :serve
      :on    {:brew/start :brewing}}}})
 
 ;; ============================================================================
@@ -253,10 +214,9 @@
 
 (defmachine session-login-machine
   {:initial :running
-   :data    {:trail []}
    :actions
-   {:capture (trail-action 'capture :action:succeed
-                           (fn [d ev] (assoc d :token (second ev))))}
+   {:capture (fn action-capture [{data :data event :event}]
+               {:data (assoc data :token (second event))})}
    :states
    {:running {:tags #{:session/running}
               :on   {:succeed {:target :done :action :capture}}}
@@ -274,9 +234,6 @@
 
 (defmachine session-flow-machine
   {:initial :idle
-   :data    {:trail []}
-   :actions
-   {:open-session (trail-action 'open-session :entry:authenticating)}
    :states
    {:idle
     {:tags #{:session/idle}
@@ -284,12 +241,9 @@
 
     :authenticating
     {:tags  #{:session/authenticating}
-     :entry :open-session
      :spawn {:machine-id :session/login
              :on-done    (fn on-done [{data :data result :result}]
-                           (-> data
-                               (assoc :session-token result)
-                               (update :trail (fnil conj []) :action:on-done)))}
+                           (assoc data :session-token result))}
      :on    {:session/close :idle}}}})
 
 ;; ============================================================================
@@ -318,7 +272,6 @@
 
 (defmachine fuse-machine
   {:initial :armed
-   :data    {:trail []}
 
    :actions
    {:blow-fuse
@@ -341,7 +294,6 @@
 
 (defmachine hvac-controller-machine
   {:type :parallel
-   :data {:trail []}
 
    :regions
    {:climate
@@ -349,66 +301,49 @@
      :states
      {:idle
       {:tags #{:climate/idle}
-       :on   {:hvac/power-cycle {:target :running :action :enter-running}}}
+       :on   {:hvac/power-cycle :running}}
 
       :running
       {:tags    #{:climate/running}
        :initial :conditioning
-       :entry   :enter-running-level
-       :exit    :exit-running-level
-       :on      {:hvac/power-cycle {:target :idle :action :back-to-idle}}
+       :on      {:hvac/power-cycle :idle}
        :states
        {:conditioning
         {:tags    #{:climate/conditioning}
          :initial :heating
-         :entry   :enter-conditioning
-         :exit    :exit-conditioning
          :states
          {:heating
           {:tags  #{:climate/heating}
-           :entry :enter-heating
-           :exit  :exit-heating
-           :on    {:hvac/mode-toggle {:target :cooling :action :swap-mode}}}
+           ;; :mode-toggle crosses the LCA :conditioning (exit :heating →
+           ;; enter :cooling). The structured :cascade surfaces the LCA walk;
+           ;; the transition needs no action.
+           :on    {:hvac/mode-toggle :cooling}}
 
           :cooling
           {:tags  #{:climate/cooling}
-           :entry :enter-cooling
-           :exit  :exit-cooling
-           :on    {:hvac/mode-toggle {:target :heating :action :swap-mode}}}}}}}}}
+           :on    {:hvac/mode-toggle :heating}}}}}}}}
 
     :fan
     {:initial :off
      :states
      {:off
       {:tags #{:fan/off}
-       :on   {:hvac/power-cycle {:target :on :action :fan-on}}}
+       :on   {:hvac/power-cycle :on}}
 
       :on
       {:tags  #{:fan/on}
-       :entry :enter-fan-on
-       :exit  :exit-fan-on
-       :on    {:hvac/power-cycle {:target :off :action :fan-off}
-               :hvac/nudge {:target :same-state :action :nudge-fan}
+       ;; :nudge is an EXTERNAL self-transition (:target :same-state forces a
+       ;; real exit→entry of :on); :tweak is an INTERNAL self-transition
+       ;; (omit :target) — action-only, no exit/entry. :tweak-fan must do real
+       ;; work (bump :tweaks) so the internal transition stays a genuine
+       ;; transition, not a no-op.
+       :on    {:hvac/power-cycle :off
+               :hvac/nudge {:target :same-state}
                :hvac/tweak {:action :tweak-fan}}}}}}
 
    :actions
-   {:enter-running         (trail-action 'enter-running         :action:power-on)
-    :enter-running-level   (trail-action 'enter-running-level   :entry:running)
-    :exit-running-level    (trail-action 'exit-running-level    :exit:running)
-    :back-to-idle          (trail-action 'back-to-idle          :action:power-off)
-    :enter-conditioning    (trail-action 'enter-conditioning    :entry:conditioning)
-    :exit-conditioning     (trail-action 'exit-conditioning     :exit:conditioning)
-    :enter-heating         (trail-action 'enter-heating         :entry:heating)
-    :exit-heating          (trail-action 'exit-heating          :exit:heating)
-    :enter-cooling         (trail-action 'enter-cooling         :entry:cooling)
-    :exit-cooling          (trail-action 'exit-cooling          :exit:cooling)
-    :swap-mode             (trail-action 'swap-mode             :action:swap-mode)
-    :fan-on                (trail-action 'fan-on                :action:fan-on)
-    :fan-off               (trail-action 'fan-off               :action:fan-off)
-    :enter-fan-on          (trail-action 'enter-fan-on          :entry:fan-on)
-    :exit-fan-on           (trail-action 'exit-fan-on           :exit:fan-on)
-    :nudge-fan             (trail-action 'nudge-fan             :action:nudge)
-    :tweak-fan             (trail-action 'tweak-fan             :action:tweak)}})
+   {:tweak-fan (fn action-tweak-fan [{data :data}]
+                 {:data (update data :tweaks (fnil inc 0))})}})
 
 ;; ============================================================================
 ;; MACHINE 8 — :media/deep + :media/shallow  (HISTORY: shallow + deep restore)
@@ -439,18 +374,10 @@
   "Build a media-player history machine. `deep?` selects deep vs shallow
   history. The `:player` compound owns the `:hist` pseudo-state; the OUTER
   `:tray` state is the off-compound resting place so `:eject` / `:insert`
-  exit + re-enter `:player` (record + restore). Every action trail-appends so
-  the harness order-oracle reads the cascade order."
+  exit + re-enter `:player` (record + restore). The eject/restore cascade
+  order is read off the structured `:cascade`."
   [deep?]
   {:initial :tray
-   :data    {:trail []}
-
-   :actions
-   {:enter-player  (trail-action 'enter-player  :entry:player)
-    :exit-player   (trail-action 'exit-player   :exit:player)
-    :enter-playing (trail-action 'enter-playing :entry:playing)
-    :enter-paused  (trail-action 'enter-paused  :entry:paused)
-    :seek-track    (trail-action 'seek-track    :action:seek)}
 
    :states
    {;; OFF-compound resting place — exiting :player to here records history;
@@ -462,8 +389,6 @@
     :player
     {:tags    #{:media/player}
      :initial :stopped
-     :entry   :enter-player
-     :exit    :exit-player
      :on      {:eject :tray}
      :states
      {:stopped {:tags #{:media/stopped}
@@ -474,16 +399,14 @@
 
       :playing {:tags    #{:media/playing}
                 :initial :at-start
-                :entry   :enter-playing
                 :on      {:stop  [:player :stopped]
                           :pause [:player :paused]}
                 :states  {:at-start  {:tags #{:media/at-start}
-                                      :on   {:seek {:target :mid-track :action :seek-track}}}
+                                      :on   {:seek :mid-track}}
                           :mid-track {:tags #{:media/mid-track}
                                       :on   {:stop [:player :stopped]}}}}
 
       :paused  {:tags  #{:media/paused}
-                :entry :enter-paused
                 :on    {:resume [:player :playing]}}}}}})
 
 (defmachine media-deep-machine


### PR DESCRIPTION
Closes rf2-2a4i9.

Removes the `:trail` order-oracle (added by rf2-g27vv) from the machine-epochs Xray testbed. Cascade ORDER is now exposed by the engine's structured `:cascade` (Spec 005), so the app-level `[:data :trail]` workaround is redundant — removed cleanly, no shim.

## Removed
- `machines.cljs`: the `trail-action` factory, every `[:data :trail]` append, the `:trail` `:data` seeds, and all trail docstrings/prose.
- Actions that ONLY recorded the trail: door `:record-audit` (root `:on` is now a plain `:door/audit -> :locked` transition), brew `start`/`serve`/`abort`, session `:open-session`, hvac's 16 boundary recorders, media's `enter`/`exit`/`seek` recorders. The boundaries/transitions themselves stay; the structured `:cascade` surfaces their order (it includes action-free boundary steps with `:action nil`).
- `core.cljs`: the "generalized `:trail` order-oracle" docstring section + the two trail prose lines.
- `feature_matrix/scenarios.cjs`: the trail reconstruction in `readMachineStrip`.
- specs `003-Machine-Inspector.md` / `021-Dynamic-Panel-Designs.md`: the `:data :trail` order-oracle references.

## Preserved (data mutations + transitions intact)
- door `:count-open` (`:opened-count`), `:clear-hold` (`:held-open? false`), `:hold-open` (`:held-open? true`), `:enter-alarm` (`:alarm-fx?`); quiz `:count-answer` (`:score`), `:award` (`:passed?`); session `:capture` (`:token`) + the `:on-done` `:session-token` write — all kept as plain named action fns doing only their real work.
- hvac `:tweak-fan` kept as a real `:tweaks` bump so the INTERNAL self-transition stays a genuine transition (not a no-op); `:nudge` keeps `:target :same-state` (genuine external self-transition, action-free).

## Re-based assertions (not deleted coverage)
- **Harness test**: trail assertions re-based onto the structured `:cascade` via a new `region-steps` helper (asserts `:kind`/`:state`/`:action` step ORDER off `proj/cascade-regions`) + the real data writes (`:opened-count`, `:alarm-fx?`, `:passed?`, `:session-token`, `:tweaks`). Rung #21 (LCA cascade order), #22/#23 (external vs internal self-transition) now read the order off the Xray-surface projection — the same contract, no app-level oracle.
- **feature-matrix scenarios**: #18/#21/#22/#23 waits re-based onto landed state + the parent's `:session-token` (cascade ORDER is pinned in the CLJS harness, per the Causa/Story-as-CLJS rule).

## Gates (cold, all green)
- `npx shadow-cljs compile :examples/machine-epochs` — Build completed, 0 warnings.
- `npm run test:cljs` — 5442 tests / 18880 assertions, 0 failures, 0 errors.
- `npm run test:xray-feature-gate` — Ran 16 Xray feature scenarios, 0 failures (machine-epochs ladder drives correctly without the trail).
- `git grep` confirms zero `:trail` / `trail-action` in the machine-epochs surface + harness.