### PR TITLE
test(pair-mcp): faithful no-pre-probe :port-discover sticky regression (rf2-hu6q0)

### DIFF
--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
@@ -26,7 +26,9 @@
     4. nREPL `connect!` / `close!` clear the cache."
   (:require [cljs.test :refer-macros [deftest is async]]
             [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools :as tools]
             [re-frame2-pair-mcp.tools.discover-app :as discover-app]
+            [re-frame2-pair-mcp.tools.get-path :as get-path]
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.test-utils :as tu]))
@@ -514,4 +516,128 @@
                    (is (nil? b))
                    (is (false? auto?))))
           (.finally (fn [] (set! probe/running-builds orig)))
+          (.then (fn [_] (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; :port-discover sticky path — faithful no-pre-probe end-to-end (rf2-hu6q0).
+;;
+;; The live repro (2026-06-03/04, multi-build):
+;;
+;;   discover-app {port 8033} -> OK, resolves :examples/machine-epochs
+;;   orient {}  (NO :build)   -> FAILED :build-not-running :app   (the bug)
+;;
+;; `sticky_build_invoke_test/port-discover-sticks-build-through-invoke`
+;; already drives discover-app{port} then a no-build call through
+;; `tools/invoke` — but it PRE-SEEDS `:probed-builds` with the resolved
+;; build, so `discover-app`'s own `ensure-runtime!` short-circuits without
+;; the real preload probe. In the LIVE flow the `:port`-resolved build is
+;; NOT pre-probed — discover-app must run the actual
+;; `runtime-preloaded?` round-trip (a DISTINCT eval form from the
+;; `(runtime/health)` read) and `mark-conn-probed!` itself before reaching
+;; the cache-writing branch.
+;;
+;; These tests close that gap: a form-DISCRIMINATING stub answers the
+;; preload-probe form with `true` and the health form with the health map
+;; — exactly what a live runtime returns — so the `:port` branch exercises
+;; the real probe-then-mark-then-cache sequence, then a no-build call
+;; THROUGH `tools/invoke` (incl. the `canonicalize-build-step` that reads
+;; the sticky default back) must land on the resolved build, NOT `:app`.
+;; ---------------------------------------------------------------------------
+
+(defn- preload-probe-form?
+  "True for the `runtime-preloaded?` sentinel-probe eval form (it tests
+  the `__re_frame2_pair_runtime` global), false for the
+  `(re-frame2-pair.runtime/health)` read. Lets a single stub mimic a live
+  runtime: `true` to the probe, the health map to the health read — so
+  `discover-app`'s `ensure-runtime!` does the REAL probe + `mark-conn-probed!`
+  instead of being short-circuited by a pre-seeded `:probed-builds`."
+  [form-str]
+  (and (string? form-str)
+       (re-find #"__re_frame2_pair_runtime" form-str)))
+
+(defn- live-like-eval-stub
+  "A `cljs-eval-value` stub that answers like a CONNECTED runtime on a
+  build that was never pre-probed: `true` for the preload-sentinel probe,
+  `health` for the `(runtime/health)` read. Both arities."
+  [health]
+  (fn
+    ([_c _b form] (js/Promise.resolve (if (preload-probe-form? form) true health)))
+    ([_c _b form _o] (js/Promise.resolve (if (preload-probe-form? form) true health)))))
+
+(deftest port-discover-without-pre-probe-still-caches
+  ;; discover-app{port} on a multi-build setup, with NO pre-seeded
+  ;; `:probed-builds` — discover-app must probe the resolved build live,
+  ;; mark it probed, AND write `:resolved-build-id`. The faithful repro of
+  ;; the live first-contact call.
+  (async done
+    (let [conn         (fresh-conn)
+          orig-running probe/running-builds
+          orig-port    probe/resolve-build-by-port
+          orig-eval    nrepl/cljs-eval-value
+          orig-jvm     nrepl/jvm-eval]
+      ;; multi-build workspace; the port resolves to machine-epochs.
+      (set! probe/running-builds
+            (fn [_] (js/Promise.resolve [:examples/machine-epochs :examples/standard-epochs])))
+      (set! probe/resolve-build-by-port (fn [_c _p] (js/Promise.resolve :examples/machine-epochs)))
+      (set! nrepl/cljs-eval-value (live-like-eval-stub healthy-health))
+      ;; freshness JVM-half degrades to :unknown (harmless): this suite's
+      ;; fresh-conn carries no :socket, so jvm-build-freshness short-circuits
+      ;; to nil without a round-trip. The jvm-eval stub is belt-and-braces.
+      (set! nrepl/jvm-eval (fn [& _] (js/Promise.resolve {:value ""})))
+      (-> (discover-app/discover-app conn (tu/args->js {:port 8033}))
+          (.then
+            (fn [result]
+              (let [edn (tu/extract-edn result)]
+                (is (true? (:ok? edn))
+                    "discover-app{port} succeeds against the live-like runtime")
+                (is (= :examples/machine-epochs (:build-id edn))
+                    "resolved the build serving the port")
+                (is (contains? (:probed-builds @conn) :examples/machine-epochs)
+                    "discover-app probed + marked the resolved build live (no pre-seed)")
+                (is (= :examples/machine-epochs (:resolved-build-id @conn))
+                    "the :port-resolved build is cached even without a pre-probe — the live gap"))))
+          (.finally (fn []
+                      (set! probe/running-builds orig-running)
+                      (set! probe/resolve-build-by-port orig-port)
+                      (set! nrepl/cljs-eval-value orig-eval)
+                      (set! nrepl/jvm-eval orig-jvm)))
+          (.then (fn [_] (done)))))))
+
+(deftest port-discover-no-pre-probe-sticks-through-invoke
+  ;; THE acceptance: discover-app{port} (no pre-probe) then a no-build
+  ;; `get-path` THROUGH `tools/invoke` (the single MCP egress, incl.
+  ;; `canonicalize-build-step`) lands on the resolved build, NOT `:app`.
+  (async done
+    (let [conn          (fresh-conn)
+          captured      (atom :NOT-CALLED)
+          orig-running  probe/running-builds
+          orig-port     probe/resolve-build-by-port
+          orig-eval     nrepl/cljs-eval-value
+          orig-jvm      nrepl/jvm-eval
+          orig-get-path get-path/get-path-tool]
+      (set! probe/running-builds
+            (fn [_] (js/Promise.resolve [:examples/machine-epochs :examples/standard-epochs])))
+      (set! probe/resolve-build-by-port (fn [_c _p] (js/Promise.resolve :examples/machine-epochs)))
+      (set! nrepl/cljs-eval-value (live-like-eval-stub healthy-health))
+      (set! nrepl/jvm-eval (fn [& _] (js/Promise.resolve {:value ""})))
+      (set! get-path/get-path-tool
+            (fn [c args]
+              (reset! captured (wire/arg-build c args))
+              (js/Promise.resolve
+                #js {:content #js [#js {:type "text" :text "{:ok? true}"}]})))
+      (-> (discover-app/discover-app conn (tu/args->js {:port 8033}))
+          (.then (fn [_]
+                   ;; second call: NO :build arg, through the invoke egress.
+                   (tools/invoke conn "get-path" (tu/args->js {:path "[:k]"}) nil)))
+          (.then (fn [_]
+                   (is (= :examples/machine-epochs @captured)
+                       "post-discover-app{port} (no pre-probe), a no-build call THROUGH invoke targets the resolved build")
+                   (is (not= :app @captured)
+                       "it must NOT fall back to the :app env default (the live-repro bug)")))
+          (.finally (fn []
+                      (set! probe/running-builds orig-running)
+                      (set! probe/resolve-build-by-port orig-port)
+                      (set! nrepl/cljs-eval-value orig-eval)
+                      (set! nrepl/jvm-eval orig-jvm)
+                      (set! get-path/get-path-tool orig-get-path)))
           (.then (fn [_] (done)))))))


### PR DESCRIPTION
Closes rf2-hu6q0 (cross-ref). Files follow-up rf2-c3dsr.

## What the bead asked

rf2-hu6q0 (P2 BUG) hypothesised that `discover-app {port N}` resolves the build for its own answer but does NOT write the `:resolved-build-id` cache the other tools read — so a subsequent no-`build` `orient {}` / `read-dom {...}` falls back to the hardcoded `:app` default. The ask: verify whether `:build` caches but `:port` does not, then make the `:port` branch write the same cache, plus a `:port`-specific regression.

## Verify result (the bead's first ask): :build AND :port BOTH cache on HEAD

The hypothesis is **disproven** on current `main`. `discover-app`'s `:else` and warning branches call `wire/mark-resolved-build-id! conn build-id` regardless of how `build-id` was resolved (`:build`, `:port`, or AUTO) — the `:port` branch resolves the build via `probe/resolve-build-by-port` and threads that exact id through both the runtime probe AND the cache write. Three tests confirm the `:port`-sticky path end-to-end, all green:

- `port_to_build_test/discover-app-port-resolves-to-the-serving-build` (pre-existing) — `:port` discover writes `:resolved-build-id`.
- `sticky_build_invoke_test/port-discover-sticks-build-through-invoke` (pre-existing, added by rf2-jkwu4 / #2877) — `:port` discover then a no-build call **through `tools/invoke`** resolves the discovered build.
- `build_id_cache_test/port-discover-no-pre-probe-sticks-through-invoke` (**new, this PR**) — the strictly-stronger faithful repro.

## What this PR adds

The two pre-existing `:port` guards PRE-SEED `:probed-builds` with the resolved build, so `discover-app`'s own `ensure-runtime!` short-circuits the real preload probe. The live `:port` flow does NOT pre-probe. This PR adds a form-discriminating eval stub (`true` to the `__re_frame2_pair_runtime` sentinel probe, the health map to the `(runtime/health)` read — exactly what a live runtime returns) so `discover-app {port}` exercises the real probe → `mark-conn-probed!` → cache-write sequence on a multi-build workspace with NO pre-seed, then asserts a no-build `get-path` **through `tools/invoke`** (incl. `canonicalize-build-step`) lands on the `:port`-resolved build, never `:app`.

Test-only change — no production source touched (the `:port` branch is already correct). The new tests lock the path against regression.

## Likely real live root cause (filed separately)

The one mechanism that DOES reproduce the live symptom is `nrepl.cljs/connect!`: every actual socket open (when `:closed?` is true) resets `:resolved-build-id` to nil. `send-op!` calls `connect!` on every op, so a transient socket drop mid-session silently wipes a valid same-session sticky build, and the next no-build call falls back to `:app`. This is path-agnostic and live-only (unit tests never reconnect). The bead scopes reconnect concerns out, so this is filed as **rf2-c3dsr** rather than fixed here. (Alternative explanation: the operator's rebuilt binary predated rf2-jkwu4 / #2877.)

## Quality gates (cold)

- `shadow-cljs compile server-test` + `node out/server-test.js` — **874 tests / 2671 assertions, 0 failures, 0 warnings** (incl. the 2 new `:port`-sticky tests).
- `npm run test:mcp-conformance` — **all 6 gates GREEN** (exit 0).

### Acceptance

After `discover-app {port N}` on a multi-build setup (no pre-probe), a subsequent no-`build` call resolves to the discovered build with no `:app` fallback; a regression test (`port-discover-no-pre-probe-sticks-through-invoke`) covers the `:port`-sticky-through-invoke path specifically, faithfully exercising the real probe/cache sequence the existing pre-probed guards routed around.