### PR TITLE
fix(pair-mcp): connect! reopen preserves session build-id caches (rf2-c3dsr)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -304,15 +304,21 @@
 
   `:probed-builds` is the set of build-ids for which the re-frame2-pair runtime
   preload has been confirmed live on this socket generation (rf2-sjpx0).
-  Cleared on connect / reconnect — a full page reload destroys the CLJS
-  heap (and thus the `__re_frame2_pair_runtime` marker); we re-probe
-  on the first tool call after that boundary.
+  Cleared by `close!` (operator-initiated teardown) and reborn empty
+  whenever `ensure-connection!` builds a fresh conn for a new port — but
+  NOT on a same-port socket reopen (rf2-c3dsr; see `connect!`). The
+  `__re_frame2_pair_runtime` marker lives in the browser CLJS heap, which
+  a JVM-side socket hiccup doesn't destroy, so the cache stays valid
+  across a reopen; a page reload that DID destroy the marker leaves the
+  JVM nREPL socket up, so a negative probe re-runs downstream anyway.
 
   `:resolved-build-id` is the build-id `discover-app` last resolved
   (rf2-l9ixp). Subsequent tool calls without an explicit `:build` arg
   default to it instead of the `SHADOW_CLJS_BUILD_ID` env-var fallback —
   removing the pair-debug friction of re-passing the build on every call.
-  Same reconnect-invalidation lifecycle as `:probed-builds`.
+  Same invalidation lifecycle as `:probed-builds`: cleared by `close!`
+  and by a fresh `ensure-connection!` conn, PRESERVED across a transient
+  same-port reopen (rf2-c3dsr).
 
   `:build-alias` is the forgiving-resolution cache (rf2-qda59):
   `{requested-keyword canonical-keyword}`. A `:build` arg that names a
@@ -320,9 +326,11 @@
   `:examples/machine-epochs`) resolves to the canonical running id the
   first time it's seen, and the alias is remembered so every later
   `arg-build` read returns the same canonical id without re-fetching
-  `active-builds`. Same reconnect-invalidation lifecycle as
-  `:probed-builds` — a page reload / build restart could change the
-  running set, so a stale alias must not survive it."
+  `active-builds`. Same invalidation lifecycle as `:probed-builds`:
+  cleared by `close!` and a fresh conn, preserved across a same-port
+  reopen — a genuine build restart (which changes the running set) lands
+  on a new port (fresh conn) or an operator `close!`, so a stale alias
+  never survives a real build change (rf2-c3dsr)."
   [port host]
   (atom {:port              port
          :host              (or host "127.0.0.1")
@@ -387,7 +395,37 @@
   "Open the persistent socket. Returns a Promise resolving to the
   connection atom once `connect` fires (or rejecting if it errors).
   Idempotent — if a socket is already open and healthy, resolves
-  immediately."
+  immediately.
+
+  ## Why the reopen path does NOT touch the build-id caches (rf2-c3dsr)
+
+  `connect!` is a pure *transport* concern: open the socket, reset the
+  framing buffer, wire the handlers. It must NOT clear the session
+  caches (`:probed-builds` / `:resolved-build-id` / `:build-alias`) on
+  reopen, because `send-op!` calls `connect!` on EVERY op and the
+  close/error handlers (`attach-handlers!`) flip `:closed?` true on a
+  mere transient socket hiccup WITHOUT changing the target build. The
+  next op's `connect!` would then reopen the SAME port and — if it also
+  wiped the caches — silently drop a valid same-session sticky build,
+  so a follow-up no-`:build` call falls back to `:app` (the rf2-c3dsr
+  live symptom: `orient {}` mis-routing after a successful discover).
+
+  The caches' invalidation lives with the layer that actually knows the
+  build *identity* changed:
+
+    - `close!` (operator-initiated teardown) clears all three.
+    - `server.cljs/ensure-connection!` builds a FRESH conn (empty caches)
+      when shadow's nREPL port vanishes or changes — the common shape of
+      the rf2-l9ixp \"operator restarted shadow against a different
+      build\" case (a restart almost always grabs a new ephemeral port).
+
+  A same-port reopen of the SAME conn within one session is, by
+  construction, a reconnect to the SAME build — so preserving the caches
+  across it is correct. `:probed-builds` in particular stays valid: the
+  `__re_frame2_pair_runtime` marker lives in the browser's CLJS heap,
+  which a JVM-side socket drop does not destroy (only a page reload
+  does, and a page reload leaves the JVM nREPL socket — hence
+  `:closed?` — untouched). A negative probe re-runs downstream anyway."
   [conn-atom]
   (let [{:keys [socket closed?]} @conn-atom]
     (if (and socket (not closed?))
@@ -398,16 +436,13 @@
                 sock (net/createConnection #js {:host host :port port})]
             (j/call sock :on "connect"
               (fn []
-                ;; Reset `:probed-builds` on (re)connect — a page reload
-                ;; destroys the CLJS heap and the
-                ;; `__re_frame2_pair_runtime` marker with it (rf2-sjpx0).
-                ;; Drop `:resolved-build-id` too (rf2-l9ixp) — operator may
-                ;; restart shadow against a different build between
-                ;; reconnects; a stale cache would silently mis-route.
+                ;; Transport-only: swap in the live socket, clear the
+                ;; closed flag, and reset the framing buffer. The build-id
+                ;; caches are deliberately PRESERVED across a same-port
+                ;; reopen (rf2-c3dsr) — see the fn docstring for why and
+                ;; for where the genuine-different-build reset lives.
                 (swap! conn-atom assoc :socket sock :closed? false
-                       :buf (js/Buffer.alloc 0)
-                       :probed-builds #{} :resolved-build-id nil
-                       :build-alias {})
+                       :buf (js/Buffer.alloc 0))
                 (attach-handlers! conn-atom sock)
                 (resolve conn-atom)))
             (j/call sock :once "error"

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -272,8 +272,19 @@
   1. First call (or after invalidation) — runs `discover-and-cache!`.
   2. Cached + port-file still resolves to the same port — fast path,
      returns the cached conn atom.
-  3. Cached + port-file content changed — shadow was restarted; close
-     the stale socket, swap in a new conn for the new port.
+  3. Cached + port-file content changed (or vanished) — shadow was
+     restarted; close the stale socket, swap in a NEW conn for the new
+     port (or force re-discovery).
+
+  Path 3 is where the genuine rf2-l9ixp \"operator restarted shadow
+  against a different build\" reset happens: a restart almost always
+  grabs a new ephemeral port, so the new conn from `new-conn-for-port`
+  starts with EMPTY build-id caches (`:probed-builds` /
+  `:resolved-build-id` / `:build-alias`). The transport-layer
+  `nrepl/connect!` deliberately does NOT clear those caches on a
+  same-port reopen (rf2-c3dsr) — that would wipe a valid sticky build on
+  a transient socket hiccup — so this layer (which actually observes the
+  port change) owns the invalidation, alongside operator `close!`.
 
   Returns a Promise resolving to the live conn atom, or rejecting with
   the cached/structured discovery error."

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -19,10 +19,17 @@
   pair, the result is cached on the conn-atom (`:probed-builds`)
   for the lifetime of the socket. Subsequent `ensure-runtime!`
   calls for the same build short-circuit without an nREPL round-trip.
-  The cache resets on (re)connect — `nrepl/connect!` and `nrepl/close!`
-  both blank `:probed-builds` — so a full page reload (which destroys
-  the CLJS heap and the `__re_frame2_pair_runtime` marker) triggers a
-  fresh probe on the next tool call.
+  The cache is cleared by `nrepl/close!` (operator-initiated teardown)
+  and is reborn empty whenever `server.cljs/ensure-connection!` builds a
+  fresh conn for a new shadow port. It is deliberately PRESERVED across a
+  transient same-port socket reopen (rf2-c3dsr) — the
+  `__re_frame2_pair_runtime` marker lives in the browser CLJS heap, which
+  a JVM-side socket hiccup doesn't destroy, so re-probing would be
+  wasteful. (A full page reload DOES destroy the marker, but it leaves
+  the JVM nREPL socket UP — so it never triggered a reconnect-reset
+  before rf2-c3dsr either; this path is unchanged. Negative probes aren't
+  cached, and the diagnostic ladder surfaces a genuinely-dead marker on
+  the next eval against the build.)
 
   Negative results are NOT cached: a missing preload usually surfaces
   on the very first call, and re-probing on each subsequent call

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
@@ -2,8 +2,10 @@
   "Unit tests for the session-scoped `:resolved-build-id` cache (rf2-l9ixp).
 
   Adjacent to `probe_test.cljs`, which pins the `:probed-builds` cache
-  (rf2-sjpx0). The two caches share a lifecycle (reset on (re)connect
-  and `close!`); their semantics differ:
+  (rf2-sjpx0). The two caches share a lifecycle (cleared by `close!` and
+  reborn empty on a fresh `ensure-connection!` conn, but PRESERVED across
+  a transient same-port socket reopen — rf2-c3dsr); their semantics
+  differ:
 
     - `:probed-builds` is a set keyed by build-id, tracking which builds
       have had their `__re_frame2_pair_runtime` marker confirmed live.
@@ -23,7 +25,8 @@
     2. `wire/arg-build` consults the cache before the env-var fallback
        when no explicit `:build` arg is passed.
     3. An explicit `:build` arg always wins (no surprise).
-    4. nREPL `connect!` / `close!` clear the cache."
+    4. nREPL `close!` clears the cache (a transport-only `connect!`
+       reopen of the same port deliberately PRESERVES it — rf2-c3dsr)."
   (:require [cljs.test :refer-macros [deftest is async]]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools :as tools]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -12,6 +12,7 @@
             [applied-science.js-interop :as j]
             ["bencode" :as bencode]
             ["fs" :as fs]
+            ["net" :as net]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.shadow-discovery :as shadow-discovery]))
 
@@ -712,3 +713,213 @@
                          "nil roots-fn falls through to the cwd scan via shadow-fails")
                      (restore!)
                      (done))))))))
+
+;; ===========================================================================
+;; `connect!` reopen preserves the session build-id caches (rf2-c3dsr).
+;;
+;; THE BUG: `connect!` used to blank `:probed-builds` / `:resolved-build-id`
+;; / `:build-alias` every time it OPENED the socket (whenever `:closed?`
+;; was true). `send-op!` calls `connect!` on every nREPL op, and the
+;; close/error handlers flip `:closed? true` on a TRANSIENT socket hiccup
+;; without changing the target build — so the next op's `connect!` reopened
+;; the SAME port AND wiped a valid same-session sticky build. The next
+;; no-`:build` call then fell back to `:app` (the live orient-{} symptom).
+;;
+;; THE FIX (option a): `connect!` is transport-only — it preserves the
+;; caches across a same-port reopen. The genuine "operator restarted shadow
+;; against a DIFFERENT build" reset (rf2-l9ixp) is preserved at the layers
+;; that observe the build identity changing:
+;;   - `close!` (operator-initiated teardown) clears all three; and
+;;   - `server.cljs/ensure-connection!` builds a FRESH conn (empty caches)
+;;     on a shadow port change/vanish — which is how a different build
+;;     almost always manifests (a restart grabs a new ephemeral port).
+;;
+;; These tests drive the ACTUAL `connect!` Promise with a stubbed
+;; `net.createConnection`, firing the recorded `connect` / `close` / `error`
+;; callbacks the way Node's EventEmitter would.
+;; ===========================================================================
+
+(defn- connect-fake-socket
+  "A stand-in for the `net.Socket` `net/createConnection` returns. Records
+  every `on`/`once` callback into `cbs*` keyed by event name so the test
+  can fire `connect` / `close` / `error` synthetically. `write`/`end` are
+  inert no-ops — `connect!` only wires handlers and resolves."
+  [cbs*]
+  (j/lit {:on    (fn [event cb] (swap! cbs* assoc event cb) nil)
+          :once  (fn [event cb] (swap! cbs* assoc event cb) nil)
+          :write (fn [_] nil)
+          :end   (fn [] nil)}))
+
+(defn- with-stubbed-create-connection!
+  "Install a `net.createConnection` stub that records the freshly-built
+  fake socket's event callbacks into `cbs*` and returns the fake socket.
+  Returns a 0-arity restoration thunk. Mirrors the `install-fs-stub!`
+  lifecycle pattern: the caller restores inside the final `.then` before
+  `(done)` so the next test starts pristine."
+  [cbs*]
+  (let [orig (.-createConnection net)]
+    (set! (.-createConnection net) (fn [_opts] (connect-fake-socket cbs*)))
+    (fn restore! [] (set! (.-createConnection net) orig))))
+
+(defn- fire! [cbs* event & args]
+  (apply (get @cbs* event) args))
+
+(defn- connect-then-fire!
+  "Call `connect!` (which registers the `connect` handler synchronously
+  in the Promise executor), then immediately fire the recorded `connect`
+  callback the way Node would once the socket is up. Returns the
+  `connect!` Promise so the caller can chain assertions off its resolve."
+  [conn cbs*]
+  (let [p (nrepl/connect! conn)]
+    (fire! cbs* "connect")
+    p))
+
+(deftest connect!-reopen-preserves-resolved-build-id-after-hiccup
+  ;; rf2-c3dsr core regression: a transient socket close+reopen of the
+  ;; SAME port mid-session PRESERVES the sticky `:resolved-build-id` (and
+  ;; the sibling `:probed-builds` / `:build-alias` caches). The bug wiped
+  ;; them, so a follow-up no-`:build` op fell back to `:app`.
+  (async done
+    (let [cbs*     (atom {})
+          restore! (with-stubbed-create-connection! cbs*)
+          conn     (nrepl/make-conn 6001 "127.0.0.1")]
+      ;; First connect — the socket comes up.
+      (-> (connect-then-fire! conn cbs*)
+          (.then
+            (fn [_]
+              ;; Operator discovered + stuck a build; a unique-suffix alias
+              ;; got cached; the runtime was probed live on this generation.
+              (swap! conn assoc
+                     :resolved-build-id :examples/step-deck
+                     :build-alias       {:step-deck :examples/step-deck}
+                     :probed-builds     #{:examples/step-deck})
+              ;; A transient socket hiccup: the close handler flips :closed?
+              ;; WITHOUT touching the build — shadow is still on the same build.
+              (fire! cbs* "close" nil)
+              (is (true? (:closed? @conn)) "the hiccup marked the conn closed")
+              ;; The NEXT op triggers a reopen of the SAME port.
+              (connect-then-fire! conn cbs*)))
+          (.then
+            (fn [_]
+              (is (false? (:closed? @conn)) "reopened")
+              (is (= :examples/step-deck (:resolved-build-id @conn))
+                  "the sticky build SURVIVES a same-port reopen — the rf2-c3dsr fix")
+              (is (= {:step-deck :examples/step-deck} (:build-alias @conn))
+                  "the forgiving-resolution alias survives the reopen too")
+              (is (= #{:examples/step-deck} (:probed-builds @conn))
+                  "the probe cache survives — the runtime marker outlives a socket hiccup")
+              (restore!)
+              (done)))
+          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+
+(deftest connect!-reopen-resets-framing-buffer-but-keeps-caches
+  ;; The reopen still does its transport job: a stale partial frame left in
+  ;; `:buf` from the dropped socket is cleared (a fresh socket starts a fresh
+  ;; bencode stream), even while the build-id caches are preserved.
+  (async done
+    (let [cbs*     (atom {})
+          restore! (with-stubbed-create-connection! cbs*)
+          conn     (nrepl/make-conn 6001 "127.0.0.1")]
+      (-> (connect-then-fire! conn cbs*)
+          (.then
+            (fn [_]
+              (swap! conn assoc
+                     :resolved-build-id :examples/step-deck
+                     :buf (js/Buffer.from "d3:foo" "utf8"))  ; a stale partial frame
+              (fire! cbs* "close" nil)
+              (connect-then-fire! conn cbs*)))
+          (.then
+            (fn [_]
+              (is (zero? (.-length (:buf @conn)))
+                  "the framing buffer is reset on reopen (fresh socket, fresh stream)")
+              (is (= :examples/step-deck (:resolved-build-id @conn))
+                  "the build-id cache is preserved alongside the buffer reset")
+              (restore!)
+              (done)))
+          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+
+(deftest connect!-fast-path-leaves-caches-untouched
+  ;; When the socket is already open + healthy, `connect!` short-circuits
+  ;; (no createConnection, no swap) — so the caches are trivially untouched.
+  ;; Pins that the fast path didn't acquire a reset side effect.
+  (async done
+    (let [conn (nrepl/make-conn 6001 "127.0.0.1")]
+      (swap! conn assoc :socket #js {} :closed? false
+             :resolved-build-id :examples/step-deck
+             :probed-builds #{:examples/step-deck})
+      (-> (nrepl/connect! conn)
+          (.then (fn [_]
+                   (is (= :examples/step-deck (:resolved-build-id @conn))
+                       "fast path preserves the sticky build")
+                   (is (= #{:examples/step-deck} (:probed-builds @conn)))
+                   (done)))))))
+
+;; ===========================================================================
+;; The l9ixp different-build reset is PRESERVED (rf2-c3dsr).
+;;
+;; The fix preserves the cache across a transient hiccup but must NOT
+;; regress the rf2-l9ixp guarantee that a genuine different-build reconnect
+;; clears the stale cache. That guarantee now lives in two places:
+;;
+;;   1. `close!` (operator-initiated teardown) clears all three caches —
+;;      so a reopen after an explicit close starts clean.
+;;   2. A different build almost always lands on a new shadow ephemeral
+;;      port; `server.cljs/ensure-connection!` then builds a FRESH conn
+;;      (via `make-conn`), which starts with empty caches by construction.
+;;
+;; Both are pinned here at the transport boundary.
+;; ===========================================================================
+
+(deftest different-build-reconnect-after-close-resets-caches
+  ;; The operator-teardown path: `close!` clears the caches, so a SUBSEQUENT
+  ;; reopen of the (possibly same) socket starts with no stale build —
+  ;; exactly the rf2-l9ixp "restarted shadow against a different build" guard.
+  (async done
+    (let [cbs*     (atom {})
+          restore! (with-stubbed-create-connection! cbs*)
+          conn     (nrepl/make-conn 6001 "127.0.0.1")]
+      (-> (connect-then-fire! conn cbs*)
+          (.then
+            (fn [_]
+              (swap! conn assoc
+                     :resolved-build-id :examples/old-build
+                     :build-alias       {:old :examples/old-build}
+                     :probed-builds     #{:examples/old-build})
+              ;; Operator-initiated teardown (NOT a transient hiccup).
+              (nrepl/close! conn)
+              (is (nil? (:resolved-build-id @conn))
+                  "close! cleared the sticky build (l9ixp operator-teardown reset)")
+              (is (= {} (:build-alias @conn)) "close! cleared the alias cache")
+              (is (= #{} (:probed-builds @conn)) "close! cleared the probe cache")
+              ;; Reopen — starts clean; no stale build carried across.
+              (connect-then-fire! conn cbs*)))
+          (.then
+            (fn [_]
+              (is (nil? (:resolved-build-id @conn))
+                  "post-close reopen carries NO stale build — l9ixp preserved")
+              (restore!)
+              (done)))
+          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+
+(deftest fresh-conn-for-new-port-starts-with-empty-caches
+  ;; The port-change path (the common shape of a different-build restart):
+  ;; `ensure-connection!` discards the old conn and builds a fresh one for
+  ;; the new ephemeral port. A fresh conn has empty build-id caches by
+  ;; construction — so the new build is re-discovered, never inheriting the
+  ;; old build's sticky id (l9ixp preserved without relying on connect!).
+  (let [old-conn (nrepl/make-conn 6001 "127.0.0.1")]
+    (swap! old-conn assoc
+           :resolved-build-id :examples/old-build
+           :build-alias       {:old :examples/old-build}
+           :probed-builds     #{:examples/old-build})
+    ;; Shadow restarted on a new port → a brand-new conn (what
+    ;; new-conn-for-port / make-conn yields).
+    (let [new-conn (nrepl/make-conn 6002 "127.0.0.1")]
+      (is (= 6002 (:port @new-conn)) "the new conn targets the new port")
+      (is (nil? (:resolved-build-id @new-conn))
+          "a fresh conn for the new port carries NO sticky build from the old session")
+      (is (= {} (:build-alias @new-conn)))
+      (is (= #{} (:probed-builds @new-conn)))
+      ;; And the old conn is untouched — they're independent atoms.
+      (is (= :examples/old-build (:resolved-build-id @old-conn))
+          "the discarded conn keeps its state — no cross-conn mutation"))))


### PR DESCRIPTION
@
## What

`nrepl/connect!` used to blank the session build-id caches
(`:probed-builds` / `:resolved-build-id` / `:build-alias`) **every time it
opened the socket** (whenever `:closed?` was true). `send-op!` calls
`connect!` on every nREPL op, and the close/error handlers
(`attach-handlers!`) flip `:closed? true` on a **transient socket hiccup
without changing the target build**. So the next ops `connect!` reopened
the **same port** AND wiped a valid same-session sticky build — and the
next no-`:build` call fell back to `:app`. That is the live
`orient {}` → `:app` mis-route symptom traced under rf2-c3dsr
(the root cause behind the rf2-hu6q0 report; the `:port`-discover sticky
path itself was already correct in-tree).

## Fix (option a — relocate the reset, dont gate it)

`connect!` is now a pure **transport** concern: open the socket, reset the
framing buffer, wire the handlers. It no longer touches the build-id
caches on a same-port reopen.

The genuine rf2-l9ixp *"operator restarted shadow against a DIFFERENT
build"* reset is **preserved** at the layers that actually observe the
build identity changing:

- **`close!`** (operator-initiated teardown) clears all three caches.
- **`server.cljs/ensure-connection!`** builds a **fresh conn** (empty
  caches by construction via `make-conn`) when shadows nREPL port
  changes or vanishes — the common shape of a different-build restart (a
  restart almost always grabs a new ephemeral port).

A same-port reopen of the same conn within one session is, by
construction, a reconnect to the **same** build, so preserving the caches
across it is correct. `:probed-builds` in particular stays valid: the
`__re_frame2_pair_runtime` marker lives in the browser CLJS heap, which a
JVM-side socket drop doesnt destroy (and a page reload, which *does*
destroy it, leaves the JVM nREPL socket up — so it never triggered a
reconnect-reset before this change either; that path is unchanged).

## Tests (new regressions in `nrepl_test.cljs`)

Drive the **actual** `connect!` Promise with a stubbed `net.createConnection`,
firing the recorded `connect`/`close` callbacks the way Node would:

- **hiccup preserves** — connect → seed sticky build/alias/probe caches →
  `close` (hiccup) → reopen same port → all three caches **survive**
  (would fail under the old blanket reset).
- **buffer still resets** — a stale partial frame in `:buf` is cleared on
  reopen while the caches are preserved.
- **fast path** untouched.
- **different-build STILL resets (l9ixp preserved)** — `close!`→reopen
  starts clean; a fresh conn for a new port starts with empty caches.

Plus relocated-lifecycle docstring updates in `nrepl/make-conn`,
`nrepl/connect!`, `server/ensure-connection!`, `probe`, and the
`build_id_cache_test` ns doc.

## Gates (cold)

- `tools/re-frame2-pair-mcp` `shadow-cljs compile server-test` + run: **879 tests, 2689 assertions, 0 failures, 0 errors**.
- `npm run test:mcp-conformance`: **all 6 gates green**.

## Operator note

The MCP binary must be **rebuilt + cycled** to pick this up (it drives the
compiled `out/server.js`).
@