### PR TITLE
fix(xray/epoch): recolour machine EVENT HANDLER data-delta arrow green→grey (rf2-fg3c4)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -560,8 +560,16 @@
    :align-items "flex-start"
    :flex-wrap   "wrap"})
 
-(def ^:private cascade-detail-success-arrow-style
-  {:color success-colour :font-weight 700})
+;; rf2-fg3c4 — the per-action `↳ data Δ` arrow on the machine EVENT HANDLER
+;; cascade reads LIGHT GREY, matching the NORMAL (non-machine) handler's
+;; `↳ :db diff` arrow (the `sub-header` glyph, `sub-header-glyph-style`).
+;; Both surface the resulting data-delta below a step's body, so both ride
+;; the same muted `text-tertiary` tone — the prior `:success` green made the
+;; machine arrow read as a status signal where the normal handler's is plain
+;; chrome. Reuses the SAME `text-tertiary-colour` token the normal-handler
+;; arrow uses (not a fresh hex) so the two stay in lockstep across themes.
+(def ^:private cascade-detail-data-arrow-style
+  {:color text-tertiary-colour :font-weight 700})
 
 (def ^:private cascade-detail-accent-arrow-style
   {:color accent-colour :font-weight 700})
@@ -2925,7 +2933,7 @@
   [{:keys [data-write data-before step] :as _row}]
   [:div {:data-testid (str "rf-xray-epoch-machine-cascade-data-write-" step)
          :style cascade-detail-row-style}
-   [:span {:style cascade-detail-success-arrow-style} "↳"]
+   [:span {:style cascade-detail-data-arrow-style} "↳"]
    [:span {:style cascade-detail-label-style} "data Δ"]
    [:span {:style cascade-detail-value-style}
     [ei/edn-inspector data-write

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1391,7 +1391,23 @@
       (is (some? (th/find-by-testid tree-m "rf-xray-epoch-machine-cascade-data-write-1"))
           "DATA Δ slot renders for a data-mutating action")
       (is (some? (th/find-by-testid tree-m "rf-xray-epoch-machine-cascade-outcome-1"))
-          "the action outcome-details block is present"))
+          "the action outcome-details block is present")
+      ;; rf2-fg3c4 — the `↳ data Δ` arrow reads LIGHT GREY (`:text-tertiary`),
+      ;; the SAME token the NORMAL (non-machine) handler's `↳ :db diff` arrow
+      ;; (`sub-header-glyph-style`) uses — NOT the prior `:success` green. The
+      ;; arrow is the first `↳` span inside the data-write subtree.
+      (let [arrow-colour (some-> tree-m
+                                 (th/find-by-testid "rf-xray-epoch-machine-cascade-data-write-1")
+                                 (->> (tree-seq vector? seq)
+                                      (filter #(and (vector? %) (= "↳" (last %))))
+                                      first
+                                      th/attrs
+                                      :style
+                                      :color))]
+        (is (= (:text-tertiary tokens/tokens) arrow-colour)
+            "the machine EVENT HANDLER `data Δ` arrow uses the light-grey
+             `:text-tertiary` token (matching the normal-handler arrow), not
+             the `:success` green (rf2-fg3c4)")))
     ;; A no-op exit action whose :data is unchanged still surfaces the
     ;; slot (the inspector renders the value with no delta).
     (let [noop {:step :handler :badge :HANDLER :step-number 3


### PR DESCRIPTION
## What

In the Xray Epoch panel, a **MACHINE** event handler's per-action `↳ data Δ` arrow rendered in the `:success` **green**, while a **NORMAL** (non-machine) handler's `↳ :db diff` arrow renders in **light grey** (`:text-tertiary`, the `sub-header` glyph). Both surface the resulting data-delta below a step's body, so the green read as a spurious status signal where the normal handler's arrow is plain chrome.

This recolours the machine arrow to the **same `:text-tertiary` token** the normal-handler arrow uses (not a fresh hex), so the two stay in lockstep across light/dark themes. **Only the arrow colour changes** — the `↳ data Δ → edn-inspector` display is otherwise unchanged.

## Change

- `cascade-detail-success-arrow-style` (`:success` green) → renamed `cascade-detail-data-arrow-style` (`:text-tertiary` grey) at its sole call-site (`cascade-row-action-data-diff`).
- The `:success` token stays live elsewhere (coeffect `+` glyph, new-sub marker) — no dead code.
- New view-test assertion: the machine `data Δ` arrow's `:color` equals the `:text-tertiary` token (i.e. matches the normal-handler arrow), guarding the green→grey contract.

## Spec

`tools/xray/spec/*` unchanged — `021-Dynamic-Panel-Designs.md` documents the `↳ data Δ` arrow's behaviour/DIFF posture but never its colour; the colour is a pure view-layer styling detail, not a documented contract.

## Gates (cold)

- xray JVM `clojure -M:test` — 1080 tests / 4485 assertions, **0 failures**
- `npm run test:cljs` — 5450 tests / 18897 assertions, **0 failures** (includes the new assertion)
- `npx shadow-cljs compile :examples/machine-epochs` — **0 warnings**

Follow-on to rf2-akvfe (#2902, merged).

Closes rf2-fg3c4.