### PR TITLE
fix(xray/machines): render topology + initial state for a machine start epoch (rf2-eldze)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -92,9 +92,15 @@ below; the three render states are:
    [§Dynamic mode — single-instance, event-driven (rf2-8og3k)](#dynamic-mode--single-instance-event-driven-rf2-8og3k)
    for the full rule.)
 3. **Focused event targets a machine instance** → one section for that
-   one instance (chosen per the rf2-8og3k selection rule below):
+   one instance (chosen per the rf2-8og3k selection rule below). A
+   machine **birth** (`:rf.machine/started`) is a first-class member of
+   this set per [§Machine birth — the start / initial-entry case
+   (rf2-eldze)](#machine-birth--the-start--initial-entry-case-rf2-eldze)
+   below: it has no from-state (it is an entry INTO the initial state,
+   not a from→to transition), so the section renders a `[START]` marker
+   in place of the from-state and highlights the resulting initial state.
     - Header: `<from-state> → <to-state>` with the event vector right-
-      aligned.
+      aligned (for a birth: `[START] → <initial-state>`).
     - Topology chart (**xyflow + elkjs** primitive — rf2-gpzb4 xyflow
       migration; the prior host-side ELK+SVG render is gone) with the
       FROM state drawn dashed/accent-violet and the TO state bold/cyan;
@@ -397,16 +403,22 @@ one subject, sourced implicitly from event focus.
 
 For the currently-focused event in the L2 event list:
 
-1. **Enumerate the event's `:rf.machine/transition` traces.** These
-   are the transitions the event caused (Spec 005 trace contract;
-   one per outer transition, plus
-   `:rf.machine.microstep/transition` for `:always`-driven
-   microsteps). Each trace carries `:tags {:machine-id …}` naming
-   the instance that transitioned.
+1. **Enumerate the event's `:rf.machine/transition` traces _and its
+   machine-birth `:rf.machine/started` traces_.** The transitions are
+   the from→to moves the event caused (Spec 005 trace contract; one per
+   outer transition, plus `:rf.machine.microstep/transition` for
+   `:always`-driven microsteps). The `:rf.machine/started` traces are
+   machine **births** (rf2-eldze) — a pure start emits no
+   `:rf.machine/transition` (it is an entry into the initial state, not
+   a from→to), so a birth would otherwise be invisible to this lens.
+   Each trace (transition or birth) carries `:tags {:machine-id …}`
+   naming the instance.
 2. **If the set is empty** → the panel renders only the verbatim
    placeholder (see [§Empty state — focused event does not target
    a state machine](#empty-state--focused-event-does-not-target-a-state-machine)
-   below). No chart, no lens, no history ribbon, nothing else.
+   below). No chart, no lens, no history ribbon, nothing else. (A birth
+   makes the set non-empty — a focused start epoch is NOT this empty
+   state; see [§Machine birth (rf2-eldze)](#machine-birth--the-start--initial-entry-case-rf2-eldze).)
 3. **If the set is non-empty** → select **one** instance per the
    tiebreaker below; render the focused-transition lens above the
    chart with that instance as `Target Machine Instance:`, the
@@ -469,6 +481,60 @@ This is the **state 2** branch in
 [§Post-collapse Dynamic panel shape](#post-collapse-dynamic-panel-shape-rf2-y9xmf-rf2-8og3k);
 the rf2-y9xmf prior text "No machine activity in the focused event."
 is superseded by the verbatim string above.
+
+### Machine birth — the start / initial-entry case (rf2-eldze)
+
+A machine **birth** is the moment a machine first comes up into its
+initial state — the eager `[:machine-id [:rf.machine/start]]` kick, the
+lazy first-real-event fold, or a `:spawn`. The runtime emits exactly one
+`:rf.machine/started` trace per successful initial-entry cascade (Spec
+009 §`:op-type` vocabulary; the substrate's `maybe-boot` per Spec 005),
+carrying `:tags {:machine-id :state :data :cause}` where `:state` /
+`:data` are the **initial** snapshot slots and `:cause` is
+`:explicit` / `:lazy` / `:spawned`.
+
+A pure start **does not** emit a `:rf.machine/transition` — the substrate
+deliberately suppresses it because a birth is an entry INTO the initial
+state, not a from→to transition (Spec 005; "a pure start emits no
+`:rf.machine/transition`; `:rf.machine/started` is the sole birth
+signal"). So the Machine tab MUST treat `:rf.machine/started` as a
+render-worthy focused-event member, not only `:rf.machine/transition`.
+Before rf2-eldze the focused-event lens filtered to transitions alone, so
+a focused start epoch produced zero records and the tab rendered the
+state-2 "does not target a state machine" empty state — even though the
+machine had just come up into its initial state. That was the rf2-eldze
+bug.
+
+**Render shape for a birth.** The birth renders the SAME per-machine
+section a transition does, with these differences:
+
+- **No from-state.** The header renders a `[START]` marker in place of
+  the from-state path (`[START] → <initial-state>`), and the
+  focused-transition lens renders **INITIAL ENTRY** (not TRANSITION) with
+  the entry-arrow grammar `↳ <initial-state> (<cause>)` instead of
+  `<from> → <to>`.
+- **Topology highlights the initial state.** The chart is fed the
+  resulting initial state as both the `to-highlight` (the landing-state
+  emphasis grammar) and the `:current-state` (active-state highlight) so
+  the just-born machine's initial state lights up regardless of which
+  highlight the renderer keys off. There is no from-highlight (no prior
+  state).
+- **Snapshot drill-in.** `:before` is nil (the machine did not exist
+  before its birth); `:after` is the synthesized initial snapshot
+  (`{:state <initial> :data <initial-data>}`) so the drill-in renders the
+  just-born machine's `:data`.
+- **No guards / actions list.** The initial-entry cascade's actions are
+  not traced as `:rf.machine/action-ran` (rf2-n9f4z), so there are no
+  guard / action rows to attach.
+
+Normal transitions are unaffected — they continue to render
+`<from> → <to>` with from-dashed / to-bold highlighting exactly as
+before.
+
+The Epoch panel's EVENT HANDLER section renders the SAME birth signal as
+a `[START]` cascade-row (rf2-it4vt) — that surface is the per-event
+cascade narration; this section is the Machines TAB's topology read.
+Both key off the one `:rf.machine/started` trace.
 
 ### Relationship to the focused-transition lens (rf2-99rhe)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -364,11 +364,16 @@
   operator's eye reads `chart = primary, lens = secondary`. Same body
   background as the rest of the section interior (`bg-2`); padding-only
   separation; section labels carry weight differential per issue #5."
-  [{:keys [machine-id from-state to-state guards actions]}]
+  [{:keys [machine-id from-state to-state guards actions start? cause]}]
   [:div {:data-testid "rf-xray-machine-focused-transition-lens"
          :data-machine-id (str machine-id)
          :data-guard-count (str (count guards))
          :data-action-count (str (count actions))
+         ;; rf2-eldze — birth markers on the lens so the forensic block
+         ;; reads INITIAL ENTRY (not a misleading `(uninit) → :initial`
+         ;; transition) when the focused epoch is a machine start.
+         :data-start (str (boolean start?))
+         :data-cause (str cause)
          ;; Issue #6 option (b) — secondary-metadata treatment. No
          ;; coloured body (matches the section's `bg-2`); slightly
          ;; smaller mono font; lighter default text colour. The lens
@@ -391,18 +396,31 @@
           :style {:margin "4px 0"}}
     ;; Issue #5 — `<strong>` weight differential on the section
     ;; label so the eye picks it out from the path that follows.
+    ;; rf2-eldze — a birth is INITIAL ENTRY, not a TRANSITION.
     [:strong {:style {:color (:text-tertiary tokens)
                       :text-transform "uppercase"
                       :font-size "10px"
                       :letter-spacing "0.5px"
                       :font-weight 700}}
-     "Transition"]
+     (if start? "Initial entry" "Transition")]
     [:div {:style {:padding-left "16px"}}
-     [:span {:style {:color (:text-secondary tokens)}}
-      (h/format-state from-state)]
-     [:span {:style {:color (:accent tokens) :margin "0 6px"}} "→"]
-     [:span {:style {:color (:text-primary tokens) :font-weight 600}}
-      (h/format-state to-state)]]]
+     (if start?
+       ;; No from-state — render only the resulting initial state, with
+       ;; the entry-arrow grammar (`↳ :initial`) the topology's initial-
+       ;; state marker mirrors.
+       [:span
+        [:span {:style {:color (:accent tokens) :margin-right "6px"}} "↳"]
+        [:span {:style {:color (:text-primary tokens) :font-weight 600}}
+         (h/format-state to-state)]
+        (when cause
+          [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
+           (str "(" (name cause) ")")])]
+       [:span
+        [:span {:style {:color (:text-secondary tokens)}}
+         (h/format-state from-state)]
+        [:span {:style {:color (:accent tokens) :margin "0 6px"}} "→"]
+        [:span {:style {:color (:text-primary tokens) :font-weight 600}}
+         (h/format-state to-state)]])]]
    (when (seq guards)
      [:div {:data-testid "rf-xray-machine-lens-guards-run"
             :style {:margin "4px 0"}}
@@ -677,7 +695,7 @@
    - issue #8: outer margin bumped to 16px so the section has visible
      breathing room from the panel host edge."
   [{:keys [machine-id from-state to-state on-event event microstep?
-           definition fired-edge-ids]
+           definition fired-edge-ids start? cause]
     :as record}]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
   ;; layout dance (layout-or-fallback / ensure-elk! / compute-layout!)
@@ -707,6 +725,13 @@
       :data-to-state (str to-state)
       :data-on-event (str on-event)
       :data-microstep (str (boolean microstep?))
+      ;; rf2-eldze — machine-BIRTH record markers. `:data-start "true"`
+      ;; lets tests + hosts pin that a `:rf.machine/started` epoch renders
+      ;; the topology (initial state highlighted) rather than the empty
+      ;; state; `:data-cause` surfaces the birth cause (:explicit / :lazy
+      ;; / :spawned).
+      :data-start (str (boolean start?))
+      :data-cause (str cause)
       :data-chart-collapsed (str collapsed?)
       ;; rf2-zdfbm — the topology is the panel's centrepiece, so the
       ;; section grows to fill the focused-event host's available
@@ -742,11 +767,31 @@
          "↳"])
       [:strong {:style {:color (:accent tokens)}}
        (h/format-machine-id machine-id)]
-      [:span {:style {:color (:text-secondary tokens)}}
-       (h/format-state from-state)]
-      [:span {:style {:color (:accent tokens)}} "→"]
-      [:span {:style {:color (:text-primary tokens) :font-weight 600}}
-       (h/format-state to-state)]
+      ;; rf2-eldze — machine BIRTH path: a start has NO from-state (it is
+      ;; an entry into the initial state, not a from→to). Render a
+      ;; `[START]` marker + the resulting initial state instead of the
+      ;; misleading `(uninit) → :initial` path a transition header shows.
+      (if start?
+        [:<>
+         [:span {:data-testid "rf-xray-machine-focused-event-start-badge"
+                 :style {:color (:accent tokens)
+                         :font-size "10px"
+                         :font-weight 700
+                         :letter-spacing "0.5px"
+                         :text-transform "uppercase"
+                         :border (str "1px solid " (:accent tokens))
+                         :border-radius "3px"
+                         :padding "1px 5px"}}
+          "START"]
+         [:span {:style {:color (:accent tokens)}} "→"]
+         [:span {:style {:color (:text-primary tokens) :font-weight 600}}
+          (h/format-state to-state)]]
+        [:<>
+         [:span {:style {:color (:text-secondary tokens)}}
+          (h/format-state from-state)]
+         [:span {:style {:color (:accent tokens)}} "→"]
+         [:span {:style {:color (:text-primary tokens) :font-weight 600}}
+          (h/format-state to-state)]])
       (when event
         [:span {:style {:color (:text-tertiary tokens)
                         :font-size "11px"
@@ -862,6 +907,15 @@
                  :machine-id         machine-id
                  :from-highlight     from-state
                  :to-highlight       to-state
+                 ;; rf2-eldze — a machine BIRTH has no from→to edge; the
+                 ;; resulting initial state IS the active state. Feed it
+                 ;; through `:current-state` so the chart paints the
+                 ;; active-state highlight on the initial node even though
+                 ;; the to-highlight grammar (which `:current-state` defers
+                 ;; to) already lands the same node. Belt-and-braces: the
+                 ;; node lights up whether the chart keys off to-highlight
+                 ;; or current-state.
+                 :current-state      (when start? to-state)
                  ;; rf2-qeemm (G3) — the focused epoch's traversed edges paint
                  ;; the FIRED treatment on the live chart (canonical ids from
                  ;; `extract-fired-edge-ids`, attached to the section record).

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -121,6 +121,50 @@
   (and (map? ev)
        (contains? transition-operations (:operation ev))))
 
+;; ---- machine BIRTH (`:rf.machine/started`) — rf2-eldze ------------------
+;;
+;; A machine's BIRTH (the `[:rf.machine/start]` kick, or the lazy first-
+;; event fold, or a spawn) runs the initial-entry cascade and emits ONE
+;; `:rf.machine/started` trace — NOT a `:rf.machine/transition`. The pure
+;; start is an entry INTO the initial state, not a from→to transition, so
+;; `commit-or-finalize` deliberately suppresses the transition trace
+;; (machines · lifecycle_fx · registration.cljc — "a pure start emits no
+;; `:rf.machine/transition`; `:rf.machine/started` is the sole birth
+;; signal", rf2-gl588 / rf2-coozg). The started trace carries
+;; `{:machine-id :state :data :cause}` — `:state` / `:data` are the
+;; INITIAL snapshot slots (`(:state booted)` / `(:data booted)`).
+;;
+;; Before rf2-eldze the focused-event lens only projected
+;; `transition-event?` traces, so a focused start epoch produced zero
+;; records and the Machine tab rendered the "does not target a state
+;; machine" empty state — even though the machine DID just come up into
+;; its initial state. This is the bug rf2-eldze fixes: surface the start
+;; as a first-class focused-event record (no from-state; to-state = the
+;; resulting initial state) so the topology renders with the initial
+;; state highlighted.
+
+(def started-operation
+  "The machine-birth trace op (Spec 009 §:op-type vocabulary; rf2-it4vt /
+  rf2-gl588). `maybe-boot` emits exactly one per successful initial-entry
+  cascade in BOTH creation paths (eager start-kick + lazy first-event)."
+  :rf.machine/started)
+
+(def start-marker-event
+  "The reserved synthetic creation-marker event vector, surfaced on a
+  birth record's `:event` slot so the section header / lens read it as
+  the machine's birth (xstate parity with `createActor(m).start()`). Per
+  Spec 005 §reserved `:rf/*` lifecycle (the `[:rf.machine/start]` kick).
+  Held as a literal here so the pure-data helper does not reach into the
+  runtime `machines` artefact (tools must not `:require` implementation)."
+  [:rf.machine/start])
+
+(defn started-event?
+  "True iff `ev` is the machine-birth (`:rf.machine/started`) trace.
+  Pure predicate; tolerant of a missing `:operation` key."
+  [ev]
+  (and (map? ev)
+       (= started-operation (:operation ev))))
+
 ;; ---- machine-id resolution ----------------------------------------------
 
 (defn machine-id-of
@@ -477,6 +521,52 @@
      :guards       []
      :actions      []}))
 
+(defn- started-record-from-trace
+  "Project a `:rf.machine/started` (machine BIRTH) trace into the same
+  view-consumed record shape `transition-record-from-trace` produces, so
+  the focused-event lens renders a start exactly like a transition —
+  except there is NO from-state (a birth is an entry into the initial
+  state, not a from→to). rf2-eldze.
+
+  The started trace carries `{:machine-id :state :data :cause}` (Spec 009;
+  machines · lifecycle_fx · registration.cljc) where `:state` / `:data`
+  are the INITIAL snapshot slots. We map:
+
+    :from-state nil           — no prior state (the birth marker)
+    :to-state   (:state tag)  — the resulting INITIAL state (highlighted)
+    :before     nil           — the machine did not exist before
+    :after      {:state :data} — the initial snapshot (for the drill-in)
+    :start?     true          — flags the birth case for the view
+    :cause      (:cause tag)  — :explicit / :lazy / :spawned
+    :event      [:rf.machine/start] — the synthetic creation marker
+
+  Guards / actions default empty — the initial-entry cascade's actions
+  are not traced as `:rf.machine/action-ran` (rf2-n9f4z), so there is
+  nothing to attach. The record shape is otherwise identical to a
+  transition record so every downstream consumer (the section view, the
+  snapshot drill-in, the chart highlight) treats it uniformly."
+  [ev]
+  (let [tags  (get ev :tags {})
+        state (:state tags)
+        data  (:data tags)]
+    {:machine-id  (machine-id-of ev)
+     :from-state  nil
+     :to-state    state
+     :before      nil
+     ;; Synthesize the initial snapshot from the started tags so the
+     ;; snapshot drill-in renders the just-born machine's `{:state :data}`.
+     :after       {:state state :data data}
+     :start?      true
+     :cause       (:cause tags)
+     :on-event    (first start-marker-event)
+     :event       start-marker-event
+     :time        (:time ev)
+     :id          (:id ev)
+     :dispatch-id (get-in ev [:tags :rf.trace/dispatch-id])
+     :microstep?  false
+     :guards      []
+     :actions     []}))
+
 (defn- ref-display-id
   "Coerce a guard/action ref to a renderable id for the per-transition
   Guards / Actions list.
@@ -639,13 +729,16 @@
 
   Returns a vector of records, oldest-first (cascade-document-order),
   one per `:rf.machine/transition` / `:rf.machine.microstep/transition`
-  event in the cascade:
+  OR `:rf.machine/started` (machine BIRTH — rf2-eldze) event in the
+  cascade:
 
       {:machine-id   <kw>
-       :from-state   <kw|vec|nil>
-       :to-state     <kw|vec|nil>
-       :before       <snapshot-map|nil>   ;; full {:state :data} pre-transition
-       :after        <snapshot-map|nil>   ;; full {:state :data} post-transition
+       :from-state   <kw|vec|nil>          ;; nil on a START record (birth)
+       :to-state     <kw|vec|nil>          ;; the resulting INITIAL state on START
+       :before       <snapshot-map|nil>   ;; full {:state :data} pre-transition (nil on START)
+       :after        <snapshot-map|nil>   ;; full {:state :data} post-transition / initial on START
+       :start?       <bool>                ;; true iff this is the machine-birth record
+       :cause        <kw|nil>              ;; :explicit / :lazy / :spawned (START only)
        :on-event     <kw|nil>
        :event        <event-vec|nil>
        :time         <int|nil>
@@ -660,8 +753,18 @@
        :history-recorded [<record-record>...]}  ;; rf2-mle6e.5, only when a
                                                  ;; history-bearing compound exited
 
-  Returns `[]` when no machine-transition trace fired in the cascade —
-  the silent-by-default branch the view honours per rf2-g3ghh.
+  Per rf2-eldze a machine BIRTH (`:rf.machine/started`) is surfaced as a
+  first-class record alongside transitions: a pure start emits no
+  `:rf.machine/transition` (it is an entry into the initial state, not a
+  from→to), so without this fold a focused start epoch produced zero
+  records and the Machine tab rendered the 'does not target a state
+  machine' empty state — even though the machine just came up into its
+  initial state. The start record carries `:from-state nil` + `:to-state`
+  = the resulting initial state, so the view highlights the initial state
+  on the topology.
+
+  Returns `[]` when no machine-transition / start trace fired in the
+  cascade — the silent-by-default branch the view honours per rf2-g3ghh.
 
   Pure fn — JVM-runnable."
   ([trace-events]
@@ -670,17 +773,27 @@
    (let [defs (or definitions {})
          events (or trace-events [])]
      (->> events
-          (filter transition-event?)
+          ;; Transition macrosteps / microsteps AND machine births
+          ;; (rf2-eldze). A birth carries no from-state; it is projected
+          ;; via `started-record-from-trace` rather than the transition
+          ;; projector.
+          (filter (fn [ev] (or (transition-event? ev) (started-event? ev))))
           ;; Stable cascade order — :id is monotonic per Spec 009;
           ;; fall back to :time, then 0.
           (sort-by (fn [ev] (or (:id ev) (:time ev) 0)))
           (map (fn [ev]
-                 (let [base (transition-record-from-trace ev)
-                       mid  (:machine-id base)
+                 (let [base   (if (started-event? ev)
+                                ;; Birth: no guard/action/history attach —
+                                ;; the initial-entry cascade's actions are
+                                ;; not traced as `:rf.machine/action-ran`
+                                ;; (rf2-n9f4z), so there is nothing to fold.
+                                (started-record-from-trace ev)
+                                (-> (transition-record-from-trace ev)
+                                    (attach-guards-and-actions events)
+                                    (attach-history events)))
+                       mid    (:machine-id base)
                        defn-> (get defs mid)]
-                   (cond-> (-> base
-                               (attach-guards-and-actions events)
-                               (attach-history events))
+                   (cond-> base
                      defn-> (assoc :definition defn->)))))
           ;; Drop records whose machine-id couldn't be resolved — a
           ;; malformed trace shouldn't surface a section with no

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
@@ -555,6 +555,98 @@
           records (h/project-focused-event-transitions events)]
       (is (= :issue-token (-> records first :actions first :action-id))))))
 
+;; ---- (10b) machine BIRTH (`:rf.machine/started`) — rf2-eldze ------------
+;;
+;; A pure machine start emits `:rf.machine/started` (the birth signal) but
+;; NO `:rf.machine/transition` (machines · lifecycle_fx · registration.cljc
+;; — rf2-gl588 / rf2-coozg). Before rf2-eldze the focused-event lens only
+;; projected transitions, so a focused start epoch produced zero records
+;; and the Machine tab rendered the "does not target a state machine"
+;; empty state. These tests pin that a start IS surfaced as a first-class
+;; record (no from-state; to-state = the resulting initial state), and
+;; that ordinary transitions are unaffected.
+
+(defn- started-event
+  "Build a `:rf.machine/started` (machine BIRTH) trace event with the
+  registration.cljc shape — `{:machine-id :state :data :cause}` in
+  `:tags`, `:state`/`:data` being the INITIAL snapshot slots."
+  ([id mid state] (started-event id mid state {} :explicit))
+  ([id mid state data cause]
+   {:id        id
+    :time      (* id 10)
+    :operation :rf.machine/started
+    :tags      {:machine-id mid
+                :state      state
+                :data       data
+                :cause      cause
+                :rf.trace/dispatch-id (str "s-" id)}}))
+
+(deftest started-event-predicate
+  (is (true?  (h/started-event? {:operation :rf.machine/started})))
+  (is (false? (h/started-event? {:operation :rf.machine/transition})))
+  (is (false? (h/started-event? nil)))
+  (is (false? (h/started-event? {}))))
+
+(deftest project-focused-event-surfaces-machine-start
+  (testing "a focused machine-start epoch yields ONE record with no
+            from-state and the resulting initial state as to-state — so
+            the Machine tab renders the topology (initial highlighted)
+            rather than the empty state (rf2-eldze)"
+    (let [events  [(started-event 1 :door/main :closed {:open? false} :explicit)]
+          records (h/project-focused-event-transitions events)
+          rec     (first records)]
+      (is (= 1 (count records))
+          "the start is a first-class focused-event record — NOT dropped")
+      (is (= :door/main (:machine-id rec)))
+      (is (nil? (:from-state rec))
+          "a birth has no from-state (entry into the initial state)")
+      (is (= :closed (:to-state rec))
+          "to-state is the resulting INITIAL state — the chart highlights it")
+      (is (true? (:start? rec))
+          ":start? flags the birth case for the view")
+      (is (= :explicit (:cause rec)))
+      (is (= [:rf.machine/start] (:event rec))
+          "the synthetic creation-marker event rides the record")
+      (is (= :rf.machine/start (:on-event rec)))
+      (is (nil? (:before rec))
+          "the machine did not exist before its birth")
+      (is (= {:state :closed :data {:open? false}} (:after rec))
+          "the initial snapshot is synthesized for the drill-in"))))
+
+(deftest project-focused-event-start-carries-definition
+  (testing "a start record gets the registered definition attached so the
+            chart can render the topology"
+    (let [definitions {:door/main {:initial :closed
+                                    :states  {:closed {:on {:push :open}}
+                                              :open   {}}}}
+          events  [(started-event 1 :door/main :closed)]
+          records (h/project-focused-event-transitions events definitions)]
+      (is (= (get definitions :door/main)
+             (-> records first :definition))))))
+
+(deftest project-focused-event-start-and-transition-interleave
+  (testing "a cascade carrying BOTH a birth and a later transition yields
+            both records in cascade order; the transition is unaffected by
+            the start fold (no regression)"
+    (let [events  [(started-event 1 :door/main :closed)
+                   (t-event 2 :door/main :closed :open [:door/push])]
+          records (h/project-focused-event-transitions events)]
+      (is (= 2 (count records)))
+      (is (= [true false] (mapv (comp boolean :start?) records))
+          "the first is the birth, the second an ordinary transition")
+      ;; The ordinary transition still resolves from/to exactly as before.
+      (is (= [nil :closed]  (mapv :from-state records)))
+      (is (= [:closed :open] (mapv :to-state records))))))
+
+(deftest project-focused-event-transition-still-not-flagged-start
+  (testing "an ordinary transition record carries no :start? flag — the
+            birth fold does not contaminate the transition projector"
+    (let [events  [(t-event 1 :auth/login :idle :authing [:auth/submit])]
+          rec     (-> (h/project-focused-event-transitions events) first)]
+      (is (nil? (:start? rec)))
+      (is (= :idle (:from-state rec)))
+      (is (= :authing (:to-state rec))))))
+
 ;; ---- (11) focused-epoch-record (rf2-a9cke) ------------------------------
 
 (deftest focused-epoch-record-empty-history

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -239,6 +239,57 @@
         (is (nil? (find-by-testid tree "rf-xray-machine-inspector-blank"))
             "the blank-state is suppressed when records exist")))))
 
+(deftest focused-event-machine-start-renders-topology-not-blank-rf2-eldze
+  (testing "a focused machine START / initial-entry epoch (a
+            `:rf.machine/started` trace, NO `:rf.machine/transition`)
+            renders the topology with the resulting initial state
+            highlighted — NOT the 'does not target a state machine' empty
+            state (rf2-eldze). Before the fix the focused-event lens only
+            projected transitions, so a pure start produced zero records
+            and the tab went blank."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:door/main])
+      (override-definitions! {:door/main {:initial :closed
+                                          :states  {:closed {:on {:push :open}}
+                                                    :open   {}}}})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/started
+            :tags {:machine-id :door/main
+                   :state      :closed
+                   :data       {:open? false}
+                   :cause      :explicit
+                   :rf.trace/dispatch-id "s-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree    (machine-inspector/Panel)
+            section (find-by-testid
+                      tree "rf-xray-machine-focused-event-section-door/main")
+            chart   (find-by-testid
+                      tree "rf-xray-machine-focused-event-chart")]
+        (is (some? (find-by-testid tree "rf-xray-machine-focused-event"))
+            "the focused-event surface mounts for a machine birth")
+        (is (some? section)
+            "the per-machine section renders for the started machine")
+        (is (= "true" (:data-start (second section)))
+            "the section is flagged as a machine-birth record")
+        (is (= ":closed" (:data-to-state (second section)))
+            "to-state is the resulting initial state")
+        (is (some? chart)
+            "the topology chart renders for the birth (not the empty state)")
+        ;; The initial state is the active state — surfaced as the to-
+        ;; highlight on the chart props (no from-highlight on a birth).
+        (is (= "closed" (:data-to-highlight-id (second chart)))
+            "the initial state is highlighted via to-highlight")
+        (is (= "" (:data-from-highlight-id (second chart)))
+            "a birth has no from-highlight — there was no prior state")
+        (is (some? (find-by-testid
+                     tree "rf-xray-machine-focused-event-start-badge"))
+            "the header renders a [START] badge rather than a (uninit) → path")
+        (is (nil? (find-by-testid tree "rf-xray-machine-inspector-blank"))
+            "the blank-state is suppressed — the bug was an empty tab here")))))
+
 (deftest gate-reads-the-migrated-rf-machine-transition-op-only
   (testing "the machine-relatedness gate keys on the `:rf.*` migrated op
             `:rf.machine/transition` (post-#1973). A focused epoch whose


### PR DESCRIPTION
## Bug (rf2-eldze, P2)

The Xray **Machine tab** showed the "This event does not target a state machine" empty state for a machine **start / initial-entry** epoch (e.g. `[:door/main [:rf.machine/start]]`). Expected: the topology rendered with the resulting **initial** state highlighted.

## Cause

A pure machine start emits `:rf.machine/started` (the birth signal) but **NO** `:rf.machine/transition` — a birth is an entry INTO the initial state, not a from→to transition, so the substrate (`machines · lifecycle_fx · registration.cljc`, rf2-gl588 / rf2-coozg) deliberately suppresses the transition trace. The focused-event lens (`project-focused-event-transitions`) only projected `:rf.machine/transition` traces, so a focused start epoch produced **zero** records and the tab rendered the empty state.

## Fix

Surface `:rf.machine/started` as a first-class focused-event record (no from-state; to-state = the resulting initial state):

- **`machine_inspector_helpers.cljc`** — `started-event?` predicate + `started-record-from-trace` projector (`:from-state` nil, `:to-state` = initial state, `:before` nil, `:after` = synthesized initial snapshot, `:start?` + `:cause`). `project-focused-event-transitions` now folds births in alongside transitions, in cascade order. Births skip the guard/action/history attach (initial-entry actions are not traced as `:rf.machine/action-ran`, rf2-n9f4z).
- **`machine_inspector.cljs`** — the section header renders a `[START]` marker (not the misleading `(uninit) → :initial`); the focused-transition lens reads **INITIAL ENTRY** with the `↳ <initial> (<cause>)` grammar; the chart is fed the initial state as both `:to-highlight` and `:current-state` so it lights up. **Normal transitions render `<from> → <to>` exactly as before** (verified by an explicit regression test).
- **`spec/003-Machine-Inspector.md`** — new §Machine birth section + the Dynamic-mode rule now enumerates `:rf.machine/started` alongside transitions (Xray-specs-kept-current rule).

## Tests added

- Helper: birth surfaced as one record (no from-state, to-state = initial, `:start?`, `:cause`, synthesized `:after`); definition attached; birth+transition interleave in cascade order; an ordinary transition carries no `:start?` (no regression).
- View: a `:rf.machine/started` epoch renders the per-machine section + topology chart with the initial state highlighted (`data-to-highlight-id`), a `[START]` badge, and **no** blank-state — i.e. not an empty tab.

## Gates (cold)

- `clojure -M:test` (xray JVM): **1085 tests, 0 failures**
- `npm run test:cljs`: **5456 tests, 0 failures**
- `npx shadow-cljs compile :examples/machine-epochs`: **0 warnings**
- `npm run test:xray-feature-gate`: **16 scenarios, 0 failures**

Visual confirmation is the operator's (drive the deck on a `[:rf.machine/start]` epoch); gates are green.

Closes rf2-eldze.