### PR TITLE
feat(xray/epoch): EVENT HANDLER mini-pipeline visual polish (rf2-2hj0h)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1564,18 +1564,34 @@ rather than collapsing to a plain `reg-event-db` handler.
 - **Step ordinal** (1..N) — left-rail compact monospace chip.
   Suppressed for the single-row `:no-op` notice (rf2-iu3no — the lone
   "1" was unexplained noise).
-- **Kind pill** — colour-coded (`:start / :guard / :action / :transition /
-  :timer / :no-op`) — see `badge.cljc` for the hue assignments. The
-  `:no-op` pill reads `NO OP` (space, not hyphen — rf2-iu3no); the `:start`
-  pill reads `START` in the `:success` (green) tone (rf2-it4vt — a clean
-  birth is a GOOD event).
+- **Kind pill / merged action badge** — colour-coded. For `:guard` /
+  `:transition` / `:timer` / `:no-op` / `:start` it is a single KIND pill
+  (`badge/cascade-kind-label` — see `badge.cljc` for the hue assignments;
+  the `:no-op` pill reads `NO OP` (space, not hyphen — rf2-iu3no); the
+  `:start` pill reads `START` in the `:success` (green) tone, rf2-it4vt).
+  **For `:action` rows the KIND pill + the separate phase chip MERGE into
+  ONE descriptive badge** (rf2-2hj0h item 5 — `badge/cascade-action-badge-
+  label`): `[EXIT ACTION]` / `[ENTRY ACTION]` / `[TRANSITION ACTION]` /
+  `[ALWAYS ACTION]` / `[AFTER-ACTION ACTION]` / `[INITIAL-ENTRY ACTION]` /
+  `[DESTROY-EXIT ACTION]`, painted in the ACTION-kind hue. A
+  `TRANSITION ACTION` (the LCA action — a REAL action per Spec 005, running
+  between exit + entry; resolved by Mike 2026-06-04) is DISTINCT from the
+  state-change **TRANSITION ROW** (kind = `:transition`), which keeps its
+  own single `[TRANSITION]` pill — both can appear in one cascade.
 - **Cause tag** (`:start` rows only — rf2-it4vt) — `explicit` / `lazy` /
   `spawned`, off the `:rf.machine/started` trace's `:cause`. The `lazy`
   cause is the ordering-smell flag (warning tone); `explicit` / `spawned`
   ride the muted neutral tone.
-- **Phase chip** (`:action` rows only) — one of the rf2-82a0u closed
-  set `:exit / :transition / :entry / :always / :after-action /
-  :initial-entry / :destroy-exit`.
+- **`for <state>` clause** (`:action` rows only — rf2-2hj0h item 6) — after
+  the merged action badge the header reads ` for <state> ` then the action
+  name (the verb), e.g. `[EXIT ACTION] for :closed :clear-hold` /
+  `[ENTRY ACTION] for :open :count-open`. `<state>` is the state the action
+  BELONGS TO — the EXITED (`:source-state`) state for an exit-phase action,
+  the ENTERED (`:target-state`) state for an entry-phase action (the LCA
+  `:transition`-phase action anchors on the source state). It reads off the
+  `:source-state` / `:target-state` slots `enrich-cascade-rows` stamps
+  (`format/cascade-action-for-state`); the clause is OMITTED (no dangling
+  `for`) when no state was stamped.
 - **Verb** — the action-id / guard-id / transition headline / timer
   state, rendered as a click-to-source button when a `{:file :line}`
   coord resolves for the row (a named guard/action reads its co-located
@@ -1588,9 +1604,12 @@ rather than collapsing to a plain `reg-event-db` handler.
   `projection/long-step-threshold-ms` (16ms — one 60Hz frame).
 - **Outcome chip** — kind-specific:
   - `:guard` → `✓ pass / ▲ fail / ✗ threw`
-  - `:action` → `✓ ok` (a THREW action carries NO outcome chip — rf2-4yrr6;
-    the pink "Exception Thrown" card + the row pink-wash are the single
-    threw signal)
+  - `:action` → **NO outcome chip** (rf2-2hj0h item 7 — success is CLEAN, no
+    `✓ ok` tick; the prior tick was redundant chrome in the normal case).
+    Failure is the **EXCEPTION BOX** below the code (item 8 — see §Per-row
+    outcome detail), not a chip. (rf2-4yrr6 had already dropped the threw
+    chip; item 7 drops the success `:ok` chip too, so the action row's
+    outcome reads purely off presence/absence of the exception box.)
   - `:transition` → `N microstep(s)` (the headline)
   - `:timer` → `· cancelled (<reason>)`
   - `:no-op` → NO outcome chip (rf2-iu3no — the `NO OP` pill + the
@@ -1698,6 +1717,20 @@ the defmachine DEFINITION:
 - **`↳ fx`** — per-action fx-id chips for each effect the action
   emitted (same data the FX step's `:attributed-to` chip surfaces,
   now visible IN the action's row).
+- **EXCEPTION BOX** (`:action` / `:guard` rows that THREW — rf2-2hj0h
+  item 8) — when a guard or action body throws, an exception box renders
+  directly below that step's code, **modeled on the OUTER pipeline's inline
+  exception card** (`view/error-block` / `error-block-details`) and the way
+  the fuse `:*` throw surfaces on the HANDLER step: the same `error-block-*`
+  chrome — a `✗` glyph + the `Exception Thrown` title, the verbatim message
+  (`ex-message` on the row's raw `:exception`), and the collapsible stack /
+  ex-data disclosure (`<details>`). It lands IN the throwing cascade row so
+  the operator reads the code AND its exception at one vertical position.
+  The throwing step's verb-link already carries the click-to-source
+  `<file:line>` (so the box does not re-render a coord line — matching the
+  outer card, which dropped its redundant jump-to-source link in rf2-wnvid).
+  Together with item 7 this defines the action/guard outcome display:
+  **success = clean (no tick); failure = exception box.**
 
 > **No-info-loss anchor (rf2-akvfe).** The `↳ data Δ` on the entry-action
 > row (`:count-open` → `{:opened-count 1}`) is exactly the data-delta the
@@ -1707,23 +1740,30 @@ the defmachine DEFINITION:
 > no-info-loss guard (the exit action, the entry action, and the data-delta
 > all live on their own numbered pipeline rows).
 
-**EVENT HANDLER section layout (rf2-akvfe).** The machine EVENT HANDLER
-section renders as: (1) the structured **orientation line** under the
-heading — `Processing [TRIGGER] ‹vec› for [MACHINE] ‹id› in [STATE]
+**EVENT HANDLER section layout (rf2-akvfe · rf2-2hj0h).** The machine EVENT
+HANDLER section renders as: (1) the structured **orientation line** under the
+heading — `[TRIGGER] ‹vec› for [MACHINE] ‹id› in [STATE]
 ‹pre-transition-state›`, grey chip-labels + code-formatted values
-(§9.1.6.4) — over (2) the cascade rows laid out as a **nested
-pipeline-of-boxes** mirroring the OUTER stage pipeline (`[DISPATCH] →
-[EVENT HANDLER] → …`): a vertical rail (`machine-cascade-rail-style`) runs
-behind the numbered `[1][2][3]` ordinal chips so the inner steps read as
-one connected pipeline rather than a flat stack. The ordinal numbering is
-retained; the rail is the inner analogue of `pipeline-view`'s rail + step
-wrappers.
+(§9.1.6.4) — over (2) the cascade rows laid out as a **flat numbered stack**.
 
-A THREW action surfaces NO per-row threw chrome (rf2-4yrr6 retired the
-prior `✗ threw — <message>` outcome-detail line AND the duplicate `✗ threw`
-outcome chip above). The pink "Exception Thrown" card + the row pink-wash
-(the `issue-event?` predicate) already flag the throw; the verbatim message
-rides the card. One signal is enough.
+> **rf2-2hj0h (Mike door-deck review, 2026-06-04).** Two refinements over
+> the akvfe layout:
+> - The orientation line **DROPS the leading "Processing" word** (item 4) —
+>   the chips + values are self-orienting; the verb was filler.
+> - akvfe's nested-pipeline **vertical RAIL is REMOVED** (item 2) — the line
+>   that ran behind the `[1][2][3]` ordinals (`machine-cascade-rail-style`),
+>   together with the per-step source-body left **CONNECTOR** (the source
+>   body's `border-left`), were the **two left vertical lines** this bead
+>   retires. The numbered ordinal chips alone now carry the pipeline reading.
+>   The **thin HORIZONTAL inter-step lines** are removed too (item 1 — the
+>   cascade row's `border-bottom` + the rows-host `border-top`). The ordinal
+>   numbering is retained.
+
+A THREW action surfaces NO per-row threw chrome (rf2-4yrr6 retired the prior
+`✗ threw — <message>` outcome-detail line AND the duplicate `✗ threw`
+outcome chip). Its failure is rendered by the **per-row EXCEPTION BOX**
+(rf2-2hj0h item 8 — see §Per-row outcome detail below) directly under the
+throwing step's code. One signal: the box.
 
 **Transition row — prominent header verb + logical-state DELTA box
 (rf2-ge6uj header · rf2-iwy0c body).** The transition zone is a SINGLE
@@ -2448,9 +2488,10 @@ processes the trigger) and a more scannable shape that also carries the
 **starting STATE** the gloss never showed.
 
 **The orientation line.** Immediately under the EVENT HANDLER heading,
-ONE structured line:
+ONE structured line (rf2-2hj0h item 4 — the leading "Processing" word is
+DROPPED; the chips + values are self-orienting):
 
-> Processing `[TRIGGER]` *‹trigger-vector›* for `[MACHINE]` *‹machine-id›*
+> `[TRIGGER]` *‹trigger-vector›* for `[MACHINE]` *‹machine-id›*
 > in `[STATE]` *‹pre-transition-state›*
 
 where `[TRIGGER]` / `[MACHINE]` / `[STATE]` render as small **grey
@@ -2469,7 +2510,7 @@ real trigger (see
 `ai/findings/2026-06-03.machine-creation-bootstrap-review.md` §1) —
 produces a cascade with only a `[START]` row (no transition / no-op), so
 the orientation line is **suppressed**: the birth story rides the
-`[START]` cascade row, not a "Processing …" line.
+`[START]` cascade row, not an orientation line.
 
 **Projection.** `projection/machine-event-orientation` (pure-data,
 `panels/epoch/projection.cljc`) reads the orientation triple directly off

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -311,6 +311,43 @@
   [phase]
   (contains? cascade-phase-set phase))
 
+;; ---- merged ACTION badge (rf2-2hj0h) ------------------------------------
+;;
+;; rf2-2hj0h item 5 — the per-`:action` row formerly carried TWO chips: the
+;; `ACTION` kind pill + a separate phase pill (`exit` / `entry` / …). They
+;; MERGE into ONE descriptive badge that names the phase AND the kind in a
+;; single token:
+;;
+;;   ACTION + :exit          → `EXIT ACTION`
+;;   ACTION + :entry         → `ENTRY ACTION`
+;;   ACTION + :transition    → `TRANSITION ACTION`   (the LCA action — a REAL
+;;                             action that runs between exit + entry per
+;;                             Spec 005; resolved by Mike 2026-06-04)
+;;   ACTION + :always        → `ALWAYS ACTION`
+;;   ACTION + :after-action  → `AFTER-ACTION ACTION`
+;;   ACTION + :initial-entry → `INITIAL-ENTRY ACTION`
+;;   ACTION + :destroy-exit  → `DESTROY-EXIT ACTION`
+;;
+;; A state-change TRANSITION ROW (kind = `:transition`) is a DISTINCT thing
+;; (not an action) and keeps its own single `TRANSITION` pill — both can
+;; appear in one cascade (the LCA action AND the state change). See
+;; `cascade-kind-label`; this fn governs only the `:action` kind.
+
+(defn cascade-action-badge-label
+  "Merged ACTION-badge label for an `:action` cascade row (rf2-2hj0h item
+  5). Folds the action's `:phase` and the `ACTION` kind into ONE token —
+  `EXIT ACTION` / `ENTRY ACTION` / `TRANSITION ACTION` / `ALWAYS ACTION` /
+  `AFTER-ACTION ACTION` / `INITIAL-ENTRY ACTION` / `DESTROY-EXIT ACTION`.
+
+  Falls back to the bare `ACTION` label when no phase was stamped (an
+  anonymous / phase-less action — defensive; the substrate always stamps a
+  phase off the rf2-82a0u closed set). Pure-data; the view reads off this
+  for the merged kind pill."
+  [phase]
+  (if (cascade-phase? phase)
+    (str (str/upper-case (name phase)) " ACTION")
+    (cascade-kind-label :action)))
+
 ;; ---- Outcome chip resolver (rf2-u69j7) ----------------------------------
 ;;
 ;; Each cascade row carries a thin outcome chip — `pass | fail | threw`

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -407,6 +407,39 @@
     ;; the whole story; the rf2-ugdas "ignored" chip was a third restatement.
     nil))
 
+;; rf2-2hj0h item 6 — the merged ACTION badge is followed by ` for <state> `
+;; then the action name, so an action row's header reads
+;; `[EXIT ACTION] for :closed :clear-hold` / `[ENTRY ACTION] for :open
+;; :count-open`. `<state>` is the state the action BELONGS TO:
+;;
+;;   :exit / :destroy-exit                       → the EXITED state
+;;                                                 (`:source-state`)
+;;   :entry / :initial-entry / :always /
+;;   :after-action                               → the ENTERED state
+;;                                                 (`:target-state`)
+;;   :transition (the LCA action)                → the source state
+;;                                                 (the change anchors there)
+;;
+;; The state slots are stamped by `enrich-cascade-rows` (the same
+;; `:source-state` / `:target-state` slots `cascade-row-source-key` reads),
+;; so the view never re-walks the trace. The state renders via `pr-str` (it
+;; may be a keyword OR a path vector / region→state map for compound /
+;; parallel machines), matching the transition headline's state rendering.
+
+(defn cascade-action-for-state
+  "The state an `:action` cascade row belongs to (rf2-2hj0h item 6), for
+  the ` for <state> ` clause of the merged-action-badge header. Reads the
+  row's `:phase` to pick `:source-state` (exit phases) vs `:target-state`
+  (entry / post-entry phases); falls back across the two when the
+  phase-preferred slot is absent (best-effort enrichment). Returns nil when
+  neither state was stamped — the view then omits the ` for <state> `
+  clause and renders just the action name. Pure-data."
+  [{:keys [phase source-state target-state]}]
+  (let [exit-phase? (contains? #{:exit :destroy-exit :transition} phase)]
+    (if exit-phase?
+      (or source-state target-state)
+      (or target-state source-state))))
+
 (defn history-kind-label
   "Render a history `:kind` keyword (`:shallow` / `:deep`) as a UI label."
   [kind]

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -414,19 +414,26 @@
    :font-weight 600
    :white-space "nowrap"})
 
-(def ^:private cascade-phase-style
-  {:display        "inline-flex"
-   :align-items    "center"
-   :background     bg-3-colour
-   :color          text-tertiary-colour
-   :border         (str "1px solid " border-subtle-colour)
-   :border-radius  "2px"
-   :padding        "1px 5px"
-   :font-family    mono-stack
-   :font-size      "10px"
-   :font-weight    600
-   :letter-spacing "0.3px"
-   :white-space    "nowrap"})
+;; rf2-2hj0h item 5 — `cascade-phase-style` (the standalone muted phase chip)
+;; is RETIRED: the phase now rides the MERGED action badge
+;; (`cascade-action-pill`, painted with the ACTION-kind hue), not a separate
+;; pill. Kept removed (pre-alpha, no shim).
+
+;; rf2-2hj0h item 6 — the ` for <state> ` clause after the merged action
+;; badge. The `for` connective is muted (`orientation-connective-style`);
+;; the state value is code-formatted mono.
+(def ^:private cascade-action-for-state-style
+  {:display     "inline-flex"
+   :align-items "baseline"
+   :gap         "4px"
+   :white-space "nowrap"})
+
+(def ^:private cascade-action-for-state-value-style
+  {:color       text-primary-colour
+   :font-family mono-stack
+   :font-size   "11px"
+   :font-weight 600
+   :white-space "nowrap"})
 
 (def ^:private cascade-kind-pill-base-style
   {:display        "inline-flex"
@@ -507,10 +514,23 @@
    :font-weight 600
    :white-space "nowrap"})
 
+;; rf2-2hj0h item 2 + 3 — the per-step left connector (`:border-left`) is
+;; REMOVED (one of the two left vertical lines the bead retires; the
+;; full-height rail is the other). The source body now ALIGNS to the
+;; `[EXIT ACTION]` / `[TRANSITION]` badge's left edge (item 3) — past the
+;; `[N]` ordinal chip (min-width 21px) + the header gap (6px) — so the code
+;; sits under the badge rather than indented behind a connector line.
+(def ^:private cascade-info-indent
+  "Left-edge alignment for a cascade row's subsequent info lines (rf2-2hj0h
+  item 3) — the source body + the per-action outcome details. Equals the
+  `[N]` ordinal chip width (21px) + the header `:gap` (6px), so the info
+  lines start at the LEFT EDGE of the merged action / kind badge that
+  follows the ordinal."
+  "27px")
+
 (def ^:private cascade-row-source-style
   {:margin       "5px 0 3px 0"
-   :padding-left "8px"
-   :border-left  (str "2px solid " border-subtle-colour)
+   :padding-left cascade-info-indent
    :min-width    0})
 
 ;; rf2-iwy0c — the source-not-captured fallback now LINKS to the machine
@@ -540,8 +560,12 @@
    :font-size   "11px"
    :color       text-tertiary-colour})
 
+;; rf2-2hj0h item 3 — the per-action outcome details (`↳ data Δ` / `↳ fx`)
+;; align to the SAME badge left edge (`cascade-info-indent`) as the source
+;; body, so a row's subsequent info lines form one left-aligned column under
+;; the badge rather than the prior 21px ordinal-only indent.
 (def ^:private cascade-outcome-details-style
-  {:padding        "2px 0 4px 21px"
+  {:padding        (str "2px 0 4px " cascade-info-indent)
    :display        "flex"
    :flex-direction "column"
    :gap            "2px"
@@ -669,11 +693,14 @@
    :font-weight 700
    :white-space "nowrap"})
 
+;; rf2-2hj0h item 1 — the thin HORIZONTAL line between mini-pipeline steps
+;; (`:border-bottom`) is REMOVED. The steps read as one pipeline via the
+;; ordinal chips + vertical rhythm; inter-step rules added visual noise the
+;; outer pipeline does not carry.
 (def ^:private cascade-row-style
   {:display        "flex"
    :flex-direction "column"
-   :padding        "5px 0 5px 0"
-   :border-bottom  border-subtle-1px})
+   :padding        "5px 0 5px 0"})
 
 (def ^:private cascade-row-header-style
   {:display     "flex"
@@ -700,38 +727,23 @@
    :font-style  "italic"
    :color       text-tertiary-colour})
 
-;; rf2-akvfe — the EVENT HANDLER inner cascade rows render as a NESTED
-;; pipeline-of-boxes, mirroring the OUTER stage pipeline ([DISPATCH] →
-;; [EVENT HANDLER] → …): a single vertical rail runs behind the numbered
-;; [1][2][3] ordinal chips so the inner steps read as one connected
-;; pipeline rather than a flat stack. The rail is `position: relative` on
-;; the rows host + an absolutely-positioned line behind the ordinals;
-;; `padding-left` opens the gutter the rail + ordinals sit in.
+;; rf2-2hj0h item 1 + 2 — the rows host carries NO chrome lines: the
+;; `:border-top` horizontal rule (item 1) and the nested-pipeline vertical
+;; RAIL + its `padding-left` gutter (item 2) are REMOVED. akvfe added the
+;; rail (a line behind the [N] ordinals) to make the inner steps read as one
+;; pipeline; Mike's door-deck review (2026-06-04) retires it — the numbered
+;; ordinal chips alone carry the pipeline reading, and the rail + the
+;; per-step source-body connector were the two left vertical lines this bead
+;; removes. The host is now a plain vertical stack.
 (def ^:private machine-cascade-rows-style
-  {:position       "relative"
-   :display        "flex"
+  {:display        "flex"
    :flex-direction "column"
-   :border-top     border-subtle-1px
-   :margin-top     "3px"
-   :padding-left   "14px"})
+   :margin-top     "3px"})
 
-;; The nested-pipeline vertical rail — a thin line behind the [N] ordinal
-;; chips, the inner counterpart to `pipeline-rail-style`. Sits in the
-;; padding-left gutter, spanning the row stack so the numbered steps read
-;; as one pipeline. `top` / `bottom` inset it to the first / last ordinal.
-(def ^:private machine-cascade-rail-style
-  {:position       "absolute"
-   :left           "4px"
-   :top            "12px"
-   :bottom         "12px"
-   :width          "1px"
-   :background     border-default-colour
-   :pointer-events "none"})
-
-;; Each cascade row is position-relative so its leading [N] ordinal chip
-;; anchors on the rail (the inner analogue of `pipeline-step-style`).
-(def ^:private machine-cascade-row-wrap-style
-  {:position "relative"})
+;; rf2-2hj0h item 2 — `machine-cascade-rail-style` (the absolutely-positioned
+;; vertical rail behind the [N] ordinals) and `machine-cascade-row-wrap-style`
+;; (the per-row `position: relative` rail anchor) RETIRED with the rail
+;; itself. The rows render as a flat numbered stack; no wrapper is needed.
 
 ;; -- EVENT HANDLER orientation line (rf2-akvfe) ---------------------------
 ;;
@@ -1764,6 +1776,12 @@
 (declare violation-block)
 (declare error-blocks)
 (declare error-block)
+;; rf2-2hj0h item 8 — the per-cascade-row EXCEPTION BOX
+;; (`cascade-row-exception-box`) reuses the outer pipeline's collapsible
+;; `error-block-details` (stack + ex-data disclosure), which is defined
+;; later in source order; forward-declared so the cascade renderer compiles
+;; without an undeclared-var warning.
+(declare error-block-details)
 
 (defn- numbered-circle
   "Render the numbered circle — 21px diameter, painted in the step's
@@ -2578,17 +2596,53 @@
        [:span {:aria-hidden true :style diff-glyph-bold-style} glyph]
        (when label-string label-string)])))
 
-(defn- cascade-phase-chip
-  "Render the phase pill for an `:action` cascade row (rf2-u69j7).
-  Renders nothing for non-action rows. The pill is intentionally
-  muted (`:text-tertiary` + 10px) — the action verb is the headline;
-  the phase is refinement."
+;; rf2-2hj0h item 5 — the separate `[ACTION]` kind pill + `[exit]` phase
+;; chip MERGE into ONE descriptive badge (`[EXIT ACTION]` / `[ENTRY ACTION]`
+;; / `[TRANSITION ACTION]` / …). `cascade-phase-chip` is RETIRED; the merged
+;; `cascade-action-pill` below replaces both. The `…-phase-<phase>` testid
+;; is preserved ON the merged pill so existing phase-targeting selectors
+;; still resolve (the phase is still discoverable; it just rides one badge
+;; now alongside the `…-kind-action` stem).
+(defn- cascade-action-pill
+  "Render the MERGED action badge for an `:action` cascade row (rf2-2hj0h
+  item 5) — `[EXIT ACTION]` / `[ENTRY ACTION]` / `[TRANSITION ACTION]` /
+  `[ALWAYS ACTION]` / … — folding the `ACTION` kind + the row's `:phase`
+  into one token. Painted with the ACTION-kind hue (the same pill chrome
+  the prior `[ACTION]` kind pill used), so it reads as a single badge.
+
+  Carries BOTH the `…-kind-action` and the `…-phase-<phase>` testid stems
+  (the merged badge is the sole carrier of each now), so selectors that
+  targeted either the old kind pill or the old phase chip still resolve."
   [phase]
-  (when (badge/cascade-phase? phase)
-    [:span {:data-testid (str "rf-xray-epoch-machine-cascade-phase-"
-                              (name phase))
-            :style cascade-phase-style}
-     (badge/cascade-phase-label phase)]))
+  [:span {:data-testid (str "rf-xray-epoch-machine-cascade-kind-action")
+          :data-cascade-phase-badge (when (keyword? phase) (name phase))
+          :style (assoc cascade-kind-pill-base-style
+                        :background (badge/cascade-kind-colour :action))}
+   ;; A nested span carrying the phase testid so `…-phase-<phase>`
+   ;; selectors (and the merged-badge text assertion) resolve on one node.
+   [:span {:data-testid (str "rf-xray-epoch-machine-cascade-phase-"
+                             (when (keyword? phase) (name phase)))}
+    (badge/cascade-action-badge-label phase)]])
+
+;; rf2-2hj0h item 6 — after the merged action badge the header reads
+;; ` for <state> ` then the action name. `for` is a muted connective; the
+;; state renders code-formatted (it may be a keyword OR a path vector /
+;; region→state map). Elides cleanly when no state was stamped.
+(defn- cascade-action-for-state-clause
+  "Render the ` for <state> ` clause that follows the merged action badge
+  (rf2-2hj0h item 6). `<state>` is `format/cascade-action-for-state` — the
+  exited state for an exit-phase action, the entered state for an
+  entry-phase action. Returns nil (renders nothing) when no state was
+  stamped on the row, so the header falls back to `[<PHASE> ACTION]
+  <action-name>` with no dangling `for`."
+  [row]
+  (when-let [state (fmt/cascade-action-for-state row)]
+    [:span {:data-testid (str "rf-xray-epoch-machine-cascade-for-state-"
+                              (:step row))
+            :style cascade-action-for-state-style}
+     [:span {:style orientation-connective-style} "for"]
+     [:span {:style cascade-action-for-state-value-style}
+      (pr-str state)]]))
 
 (defn- cascade-start-cause-chip
   "Render the `[START]` row's CAUSE tag (rf2-it4vt) — `explicit` / `lazy` /
@@ -2954,12 +3008,12 @@
     fx-id (per-action attribution; same data as the FX step's
     `:attributed-to` chip, now visible IN the action's row).
 
-  rf2-4yrr6 — the EXCEPTION slot (the `✗ threw — <message>` line) is
-  REMOVED. A threw action row already carries the pink 'Exception Thrown'
-  card + the row's pink-wash (the `issue-event?` predicate); the duplicate
-  threw line here (and the duplicate `:threw` outcome chip in
-  `cascade-row-view`) were redundant — one signal is enough. The verbatim
-  message rides the card.
+  rf2-4yrr6 / rf2-2hj0h — the EXCEPTION slot (the `✗ threw — <message>`
+  line) is REMOVED. A threw action row's failure is now rendered by the
+  per-row EXCEPTION BOX (`cascade-row-exception-box`, item 8) directly below
+  the code; the duplicate threw line here (and the duplicate `:threw`
+  outcome chip in `cascade-row-view`, plus the success `:ok` tick — item 7)
+  are gone. One signal: the exception box.
 
   Each slot elides cleanly when the underlying data is absent so the
   row stays minimal for actions that ran without side-effects."
@@ -2994,6 +3048,71 @@
                                       (:step row) "-" j)
                     :style cascade-detail-fx-chip-style}
              (fmt/ns-keyword fx-id)])])])))
+
+;; rf2-2hj0h item 8 — the per-row EXCEPTION BOX. When a GUARD or ACTION
+;; THREW, render an exception box directly below that step's code —
+;; modeled on the OUTER pipeline's inline exception card (`error-block`):
+;; the same `error-block-*` chrome (✗ glyph + 'Exception Thrown' title +
+;; verbatim message + the collapsible stack / ex-data via
+;; `error-block-details`). This is the cascade row's FAILURE outcome
+;; display (paired with item 7: success = clean / no ok-tick; failure =
+;; this box). It mirrors how the fuse `:*` throw surfaces on the outer
+;; HANDLER step, but lands IN the cascade row where the throwing step ran,
+;; so the operator reads the code AND its exception at one vertical
+;; position.
+
+(defn- cascade-row-exception-message
+  "Lift the verbatim exception message for a throwing cascade row's box
+  (rf2-2hj0h item 8). Prefers a pre-projected `:message` string; falls back
+  to `ex-message` on the raw `:exception` object (the substrate stamps the
+  raw Throwable per rf2-wnvid). nil when neither is present."
+  [{:keys [message exception]}]
+  (cond
+    (and (string? message) (not (str/blank? message))) message
+    (some? exception) (let [m (try (ex-message exception) (catch :default _ nil))]
+                        (when (and (string? m) (not (str/blank? m))) m))
+    :else nil))
+
+(defn- cascade-row-exception-box
+  "Render the EXCEPTION BOX for a throwing GUARD / ACTION cascade row
+  (rf2-2hj0h item 8). Returns nil — renders nothing — for a clean row (the
+  common case: a successful action / passing guard shows no chrome here per
+  item 7). A throwing row carries `:exception` (the raw Throwable) and/or a
+  threw outcome (`:threw? true` for an action; `:outcome :threw` for a
+  guard); the box reuses the OUTER pipeline's `error-block-*` chrome so the
+  inner exception reads identically to a handler / fx / interceptor throw:
+  ✗ 'Exception Thrown' title, the verbatim message, and the collapsible
+  stack / ex-data disclosure (`error-block-details`).
+
+  The `<source-coord>` the bead names is carried by the row's verb-link (the
+  click-to-source affordance already lands the operator on the throwing
+  guard/action's `file:line`), so the box itself does not re-render a coord
+  line — matching the outer card, which dropped its redundant jump-to-source
+  link in rf2-wnvid for the same reason."
+  [{:keys [kind threw? outcome exception step] :as row}]
+  (let [threw? (or (true? threw?)
+                   (= :threw outcome)
+                   (= :rf.error/action-threw outcome))]
+    (when (and (contains? #{:action :guard} kind)
+               (or threw? (some? exception)))
+      (let [testid-base (str "rf-xray-epoch-machine-cascade-exception-" step)
+            message     (cascade-row-exception-message row)]
+        [:div {:data-testid testid-base
+               :data-cascade-exception-kind (when (keyword? kind) (name kind))
+               :style error-block-style}
+         ;; Title bar — ✗ glyph + 'Exception Thrown' (the outer card's anatomy).
+         [:div {:style error-block-title-style}
+          [:span {:aria-hidden true :style error-block-glyph-style} "✗"]
+          [:span {:data-testid (str testid-base "-title")} "Exception Thrown"]]
+         ;; Verbatim message (the punchline) — monospace, primary text.
+         (when message
+           [:div {:data-testid (str testid-base "-message")
+                  :style error-block-message-style}
+            message])
+         ;; Collapsible stack + ex-data — the SAME disclosure the outer card
+         ;; uses (`error-block-details`), so the `ex-data` / source depth
+         ;; reads one click away exactly as on a handler throw.
+         (error-block-details testid-base {:exception exception})]))))
 
 ;; rf2-ge6uj ISSUE 3 — the transition zone is collapsed to ONE prominent
 ;; row. The TRANSITION row's header carries `[#step] [TRANSITION badge]
@@ -3045,7 +3164,7 @@
            :data-cascade-phase (when (keyword? phase) (name phase))
            :data-cascade-long-step (str (boolean long?))
            :style cascade-row-style}
-     ;; Header row: ordinal + kind pill + phase chip + verb + duration + outcome
+     ;; Header row: ordinal + badge + (for <state>) + verb + duration + outcome
      [:div {:style cascade-row-header-style}
       ;; rf2-iu3no — the `:no-op` row is a SINGLE muted notice (the cascade
       ;; collapses to one row when nothing transitioned), so its 1..N
@@ -3053,9 +3172,17 @@
       ;; it for the no-op; every other kind keeps its scannability ordinal.
       (when-not (= :no-op kind)
         (cascade-row-ordinal step))
-      (cascade-kind-pill kind)
+      ;; rf2-2hj0h item 5 — an `:action` row renders ONE merged badge
+      ;; (`[EXIT ACTION]` / `[ENTRY ACTION]` / `[TRANSITION ACTION]` / …);
+      ;; every other kind keeps its single kind pill (the state-change
+      ;; `:transition` ROW keeps its own `[TRANSITION]` pill — distinct from
+      ;; a `TRANSITION ACTION`).
+      (if (= :action kind)
+        (cascade-action-pill phase)
+        (cascade-kind-pill kind))
+      ;; rf2-2hj0h item 6 — ` for <state> ` after the merged action badge.
       (when (= :action kind)
-        (cascade-phase-chip phase))
+        (cascade-action-for-state-clause row))
       (cascade-row-verb-link row coord verb)
       ;; rf2-it4vt — the `[START]` row's CAUSE tag (explicit / lazy /
       ;; spawned) rides right after the verb. The `lazy` cause is the
@@ -3068,14 +3195,14 @@
        (cascade-outcome-chip
          (cond
            (= :guard kind)      outcome
-           ;; rf2-4yrr6 — a threw ACTION row carries NO outcome chip. The
-           ;; pink 'Exception Thrown' card + the row's pink-wash (the
-           ;; `issue-event?` predicate) already say it threw — one signal is
-           ;; enough (the duplicate `:threw` chip + the `cascade-row-action-
-           ;; outcome-details` "✗ threw —" line were both removed). A
-           ;; successful action keeps its `:ok` chip.
-           (and (= :action kind) threw?)  nil
-           (= :action kind)     :ok
+           ;; rf2-2hj0h item 7 — an ACTION row carries NO outcome ok-tick.
+           ;; SUCCESS is clean (no `✓ ok` chip — the prior tick was redundant
+           ;; chrome in the normal case); FAILURE is the EXCEPTION BOX below
+           ;; the code (item 8), NOT a chip. A threw action already dropped
+           ;; its chip under rf2-4yrr6; item 7 drops the success `:ok` chip
+           ;; too, so the action row's outcome is signalled purely by
+           ;; presence/absence of the exception box.
+           (= :action kind)     nil
            (= :timer kind)      :cancelled
            ;; rf2-iu3no — the benign no-op carries NO outcome chip. The
            ;; "[NO OP]" kind-pill + the "staying in {state}" verb already
@@ -3090,6 +3217,13 @@
      ;; was captured); the `:transition` row renders the rf2-iwy0c
      ;; logical-state DELTA box (`{:state :tags}` before → after).
      (cascade-row-source-body machine-meta row source-form)
+     ;; rf2-2hj0h item 8 — when a GUARD or ACTION THREW, render the EXCEPTION
+     ;; BOX directly below the step's code, modeled on the OUTER pipeline's
+     ;; inline exception card (`error-block`): ✗ 'Exception Thrown' title +
+     ;; verbatim message + collapsible stack / ex-data. This is the row's
+     ;; failure outcome display (paired with item 7: success = clean, no
+     ;; tick; failure = exception box). A clean row renders nothing here.
+     (cascade-row-exception-box row)
      ;; Per-row outcome details — kind-specific. rf2-ge6uj ISSUE 3 — the
      ;; `:transition` row carries NO extra detail body: the prominent
      ;; header verb (`<before> → <after>`) is the focal point and the
@@ -3116,11 +3250,12 @@
   the steps plainly. That line also carried the cascade total-ms —
   re-surface the total elsewhere later if wanted.)
 
-  rf2-akvfe — the rows render as a NESTED pipeline-of-boxes mirroring
-  the outer stage pipeline: a vertical rail (`machine-cascade-rail-style`)
-  runs behind the numbered [1][2][3] ordinal chips, and each row is wrapped
-  position-relative so the ordinals read as connected pipeline nodes (the
-  inner analogue of `pipeline-view`'s rail + step wrappers)."
+  rf2-2hj0h item 1 + 2 — the rows render as a FLAT numbered stack. akvfe's
+  nested-pipeline vertical RAIL (the line behind the [1][2][3] ordinals) and
+  its `:border-top` rule are REMOVED (Mike door-deck review 2026-06-04); the
+  numbered ordinal chips alone carry the pipeline reading. The per-row
+  `position: relative` rail-anchor wrapper is gone with the rail, so each
+  row renders directly (no wrapper div)."
   [machine-meta cascade-rows]
   (let [n (count cascade-rows)]
     [:div {:data-testid "rf-xray-epoch-handler-machine-cascade"
@@ -3131,16 +3266,10 @@
               :style machine-cascade-empty-style}
         "— (no machine cascade events fired)"]
        (into [:div {:data-testid "rf-xray-epoch-handler-machine-cascade-rows"
-                    :style machine-cascade-rows-style}
-              ;; The nested pipeline rail — runs behind the [N] ordinals so
-              ;; the inner steps read as one connected pipeline (rf2-akvfe).
-              [:div {:data-testid "rf-xray-epoch-handler-machine-cascade-rail"
-                     :aria-hidden true
-                     :style machine-cascade-rail-style}]]
+                    :style machine-cascade-rows-style}]
              (for [row cascade-rows]
-               ^{:key (str "cascade-wrap-" (:step row))}
-               [:div {:style machine-cascade-row-wrap-style}
-                (cascade-row-view machine-meta row)])))]))
+               ^{:key (str "cascade-row-wrap-" (:step row))}
+               (cascade-row-view machine-meta row))))]))
 
 (defn- event-handler-orientation-line
   "Render the EVENT HANDLER orientation line (rf2-akvfe) — ONE structured
@@ -3166,7 +3295,9 @@
              (proj/machine-event-orientation cascade event-id)]
     [:div {:data-testid "rf-xray-epoch-event-handler-orientation"
            :style orientation-line-style}
-     [:span {:style orientation-connective-style} "Processing"]
+     ;; rf2-2hj0h item 4 — the leading "Processing" word is DROPPED. The line
+     ;; reads `[TRIGGER] <vec> for [MACHINE] <id> in [STATE] <state>` — the
+     ;; chips + values are self-orienting; the verb was filler.
      [:span {:style orientation-chip-style} "trigger"]
      [:span {:data-testid "rf-xray-epoch-event-handler-orientation-trigger"
              :style orientation-value-style}

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/badge_cljs_test.cljc
@@ -169,6 +169,29 @@
         (is (string? l))
         (is (seq l))))))
 
+(deftest cascade-action-badge-label-test
+  (testing "rf2-2hj0h item 5 — the merged ACTION badge folds the phase + the
+            ACTION kind into one token"
+    (is (= "EXIT ACTION"          (badge/cascade-action-badge-label :exit)))
+    (is (= "ENTRY ACTION"         (badge/cascade-action-badge-label :entry)))
+    (is (= "TRANSITION ACTION"    (badge/cascade-action-badge-label :transition)))
+    (is (= "ALWAYS ACTION"        (badge/cascade-action-badge-label :always)))
+    (is (= "AFTER-ACTION ACTION"  (badge/cascade-action-badge-label :after-action)))
+    (is (= "INITIAL-ENTRY ACTION" (badge/cascade-action-badge-label :initial-entry)))
+    (is (= "DESTROY-EXIT ACTION"  (badge/cascade-action-badge-label :destroy-exit))))
+  (testing "rf2-2hj0h — every phase yields a `<PHASE> ACTION` token ending in
+            ` ACTION`; a phase-less action falls back to the bare ACTION label"
+    (doseq [p badge/cascade-phase-set]
+      (let [l (badge/cascade-action-badge-label p)]
+        (is (string? l))
+        (is (str/ends-with? l " ACTION"))))
+    (is (= (badge/cascade-kind-label :action)
+           (badge/cascade-action-badge-label nil))
+        "no phase → bare ACTION label (the kind label)"))
+  (testing "rf2-2hj0h — the state-change TRANSITION ROW keeps its own single
+            `TRANSITION` pill (distinct from a `TRANSITION ACTION`)"
+    (is (= "TRANSITION" (badge/cascade-kind-label :transition)))))
+
 (deftest cascade-outcome-resolver-test
   (testing "rf2-u69j7 — outcome → token-key + glyph mappings"
     (is (= :success       (badge/cascade-outcome-token-key :pass)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
@@ -352,10 +352,13 @@
                                          :lifecycle [] :timers []}}))]
         (is (nil? (th/find-by-testid tree sp))
             "rf2-akvfe — the up/down structured-cascade block no longer renders")
-        ;; The EVENT HANDLER renders as a nested pipeline — the rail + the
-        ;; orientation line for this real `[:hvac/power-cycle]` macrostep.
-        (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rail"))
-            "the nested-pipeline rail renders")
+        ;; rf2-2hj0h item 2 — the akvfe nested-pipeline RAIL is REMOVED; the
+        ;; rows render as a flat numbered stack (the ordinal chips carry the
+        ;; pipeline reading). The rows host + the orientation line remain.
+        (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rail"))
+            "the nested-pipeline rail is removed (rf2-2hj0h)")
+        (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows"))
+            "the flat rows host still renders")
         (is (some? (th/find-by-testid tree "rf-xray-epoch-event-handler-orientation"))
             "the EVENT HANDLER orientation line renders")
         ;; No-info-loss: the per-EMIT exit/entry action rows survive and carry

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -3326,14 +3326,20 @@
           "the data-delta {:opened-count 1} survives in the pipeline (no info lost)"))))
 
 (deftest event-handler-orientation-line-renders-test
-  (testing "rf2-akvfe item 2 — the structured orientation line renders under
-            EVENT HANDLER: `Processing [TRIGGER] <vec> for [MACHINE] <id> in
-            [STATE] <pre-transition-state>` — trigger vector, machine id, and
-            PRE-transition state, each code-formatted."
+  (testing "rf2-akvfe item 2 + rf2-2hj0h item 4 — the structured orientation
+            line renders under EVENT HANDLER: `[TRIGGER] <vec> for [MACHINE]
+            <id> in [STATE] <pre-transition-state>` — trigger vector, machine
+            id, and PRE-transition state, each code-formatted. The leading
+            'Processing' word is DROPPED (rf2-2hj0h item 4)."
     (let [tree (view/render-handler-step
                  (machine-step-with-rows :door/main door-push-cascade-rows))]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-event-handler-orientation"))
           "the orientation line renders")
+      ;; rf2-2hj0h item 4 — no leading "Processing" word.
+      (is (not (string/includes?
+                 (or (text-of tree "rf-xray-epoch-event-handler-orientation") "")
+                 "Processing"))
+          "the orientation line drops the leading 'Processing' word")
       (is (= "[:door/push]"
              (text-of tree "rf-xray-epoch-event-handler-orientation-trigger"))
           "the TRIGGER value is the full inner trigger vector")
@@ -3352,14 +3358,30 @@
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-event-handler-orientation"))
           "no orientation line for a pure creation kick"))))
 
-(deftest event-handler-nested-pipeline-rail-renders-test
-  (testing "rf2-akvfe item 3 — the EVENT HANDLER inner cascade rows render as a
-            nested pipeline: the numbered [1][2][3] ordinals are retained AND a
-            vertical rail runs behind them (mirroring the outer stage pipeline)."
+(deftest event-handler-flat-numbered-stack-no-rail-test
+  (testing "rf2-2hj0h item 1 + 2 — the EVENT HANDLER inner cascade rows render
+            as a FLAT numbered stack: the akvfe nested-pipeline RAIL is REMOVED
+            (one of the two left vertical lines), the per-step source-body
+            left-connector is REMOVED (the other), and NO `:border-bottom`
+            horizontal line sits between steps. The [1][2][3] ordinals are
+            retained (they carry the pipeline reading)."
     (let [tree (view/render-handler-step
                  (machine-step-with-rows :door/main door-push-cascade-rows))]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rail"))
-          "the nested-pipeline vertical rail renders")
+      ;; item 2 — the full-height rail is GONE.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rail"))
+          "the nested-pipeline vertical rail is removed")
+      ;; The flat rows host still renders.
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows"))
+          "the flat rows host renders")
+      ;; item 1 — NO `:border-bottom` horizontal line between rows.
+      (is (nil? (:border-bottom (style-of tree "rf-xray-epoch-machine-cascade-row-1")))
+          "no horizontal inter-step line (border-bottom) on a cascade row")
+      ;; item 1 — NO `:border-top` horizontal line atop the rows host.
+      (is (nil? (:border-top (style-of tree "rf-xray-epoch-handler-machine-cascade-rows")))
+          "no horizontal line atop the rows host")
+      ;; item 2 — the per-step source-body left CONNECTOR (border-left) is GONE.
+      (is (nil? (:border-left (style-of tree "rf-xray-epoch-machine-cascade-source-1")))
+          "no per-step left connector (source-body border-left)")
       ;; The [1][2][3] ordinals are retained on each row.
       (is (= "1" (text-of tree "rf-xray-epoch-machine-cascade-ordinal-1"))
           "ordinal [1] retained")
@@ -3367,6 +3389,145 @@
           "ordinal [2] retained")
       (is (= "3" (text-of tree "rf-xray-epoch-machine-cascade-ordinal-3"))
           "ordinal [3] retained"))))
+
+;; ---- rf2-2hj0h — merged action badge + for-state + no ok-tick -------------
+
+(deftest event-handler-merged-action-badge-test
+  (testing "rf2-2hj0h item 5 — an `:action` row renders ONE merged badge
+            ([EXIT ACTION] / [ENTRY ACTION]) folding the ACTION kind + the
+            phase, NOT a separate [ACTION] pill + [exit] phase chip."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-rows :door/main door-push-cascade-rows))]
+      ;; The exit action (step 1) badge reads `EXIT ACTION`.
+      (is (= "EXIT ACTION"
+             (text-of tree "rf-xray-epoch-machine-cascade-kind-action"))
+          "the exit action's merged badge reads `EXIT ACTION`")
+      ;; The merged badge is the SOLE phase carrier (the `…-phase-<phase>`
+      ;; testid still resolves — it now rides the merged badge node).
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-phase-exit"))
+          "the exit phase testid still resolves (on the merged badge)")))
+  (testing "rf2-2hj0h item 5 — an ENTRY-phase action reads `ENTRY ACTION`."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-rows :door/main
+                   [{:kind :action :step 1 :phase :entry :machine-id :door/main
+                     :action-id :count-open :outcome :ok
+                     :source-state :closed :target-state :open}]))]
+      (is (= "ENTRY ACTION"
+             (text-of tree "rf-xray-epoch-machine-cascade-kind-action"))
+          "the entry action's merged badge reads `ENTRY ACTION`")))
+  (testing "rf2-2hj0h item 5 (RESOLVED Mike 2026-06-04) — a TRANSITION-phase
+            action (the LCA action) reads `TRANSITION ACTION`; the state-change
+            TRANSITION ROW (kind = :transition) keeps its own `[TRANSITION]`
+            pill. Both are distinct and can co-occur."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-rows :door/main
+                   [{:kind :action :step 1 :phase :transition :machine-id :hvac/c
+                     :action-id :swap-mode :outcome :ok
+                     :source-state :heating :target-state :cooling}
+                    {:kind :transition :step 2 :machine-id :hvac/c
+                     :event [:hvac/mode-toggle]
+                     :from-state :heating :to-state :cooling
+                     :before {:state :heating} :after {:state :cooling}}]))]
+      (is (= "TRANSITION ACTION"
+             (text-of tree "rf-xray-epoch-machine-cascade-kind-action"))
+          "the LCA (transition-phase) action's merged badge reads `TRANSITION ACTION`")
+      ;; The state-change transition ROW keeps the single `[TRANSITION]` pill.
+      (is (= "TRANSITION"
+             (text-of tree "rf-xray-epoch-machine-cascade-kind-transition"))
+          "the state-change transition row keeps its own `[TRANSITION]` pill"))))
+
+(deftest event-handler-action-for-state-test
+  (testing "rf2-2hj0h item 6 — after the merged badge the header reads
+            ` for <state> ` then the action name. The for-state value is the
+            EXITED (source) state for an exit action and the ENTERED (target)
+            state for an entry action (the `:source-state` / `:target-state`
+            slots `enrich-cascade-rows` stamps)."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-rows :door/main
+                   [{:kind :action :step 1 :phase :exit :machine-id :door/main
+                     :action-id :clear-hold :outcome :ok
+                     :source-state :closed :target-state :open}
+                    {:kind :action :step 2 :phase :entry :machine-id :door/main
+                     :action-id :count-open :outcome :ok
+                     :source-state :closed :target-state :open}]))]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
+          "the exit action renders a ` for <state> ` clause")
+      (is (string/includes? (text-of tree "rf-xray-epoch-machine-cascade-for-state-1")
+                            "for")
+          "the clause carries the `for` connective")
+      (is (string/includes? (text-of tree "rf-xray-epoch-machine-cascade-for-state-1")
+                            ":closed")
+          "the EXIT action reads `for :closed` (the exited / source state)")
+      (is (string/includes? (text-of tree "rf-xray-epoch-machine-cascade-for-state-2")
+                            ":open")
+          "the ENTRY action reads `for :open` (the entered / target state)")))
+  (testing "rf2-2hj0h item 6 — the ` for <state> ` clause is OMITTED (no
+            dangling `for`) when no state was stamped on the row."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-rows :door/main
+                   [{:kind :action :step 1 :phase :entry :machine-id :door/main
+                     :action-id :count-open :outcome :ok}]))]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
+          "no ` for <state> ` clause when neither source nor target state is stamped"))))
+
+(deftest event-handler-action-no-ok-tick-test
+  (testing "rf2-2hj0h item 7 — a SUCCESSFUL `:action` row carries NO green
+            ok-tick (the prior `✓ ok` outcome chip is REMOVED — success is
+            clean). The threw chip was already gone (rf2-4yrr6); item 7 drops
+            the success tick too."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-rows :door/main door-push-cascade-rows))]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ok"))
+          "no `✓ ok` outcome chip on a successful action row")
+      ;; The action row + its merged badge still render (only the tick is gone).
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+          "the action row still renders"))))
+
+(deftest event-handler-exception-box-test
+  (testing "rf2-2hj0h item 8 — a THROWING action renders the EXCEPTION BOX
+            below its code (message / ex-data via the collapsible), modeled on
+            the outer pipeline's `error-block` card. Together with item 7:
+            success = clean; failure = exception box."
+    (let [exc  (ex-info "action blew up"
+                        {:event [:fuse/short-circuit] :where :fuse-wildcard})
+          tree (view/render-handler-step
+                 (machine-step-with-rows :fuse/box
+                   [{:kind :action :step 1 :phase :transition :machine-id :fuse/box
+                     :action-id :blow-fuse
+                     :outcome :rf.error/action-threw :threw? true
+                     :exception exc
+                     :source-state :ok :target-state :blown}]))
+          base "rf-xray-epoch-machine-cascade-exception-1"]
+      (is (some? (th/find-by-testid tree base))
+          "the exception box renders below the throwing action's code")
+      (is (= "Exception Thrown" (text-of tree (str base "-title")))
+          "the box carries the 'Exception Thrown' title (outer-card anatomy)")
+      (is (= "action blew up" (text-of tree (str base "-message")))
+          "the box renders the verbatim ex-info message")
+      ;; The ex-data rides the collapsible details disclosure.
+      (is (some? (th/find-by-testid tree (str base "-details")))
+          "the collapsible stack / ex-data disclosure renders")
+      (is (some? (th/find-by-testid tree (str base "-ex-data")))
+          "the ex-data renders inside the disclosure")))
+  (testing "rf2-2hj0h item 8 — a THROWING guard renders the exception box too."
+    (let [exc  (ex-info "guard blew up" {:guard :is-ready?})
+          tree (view/render-handler-step
+                 (machine-step-with-rows :door/main
+                   [{:kind :guard :step 1 :machine-id :door/main
+                     :guard-id :is-ready? :outcome :threw
+                     :exception exc :source-state :closed}]))
+          base "rf-xray-epoch-machine-cascade-exception-1"]
+      (is (some? (th/find-by-testid tree base))
+          "the exception box renders below the throwing guard's code")
+      (is (= "guard blew up" (text-of tree (str base "-message")))
+          "the box renders the guard's verbatim message")))
+  (testing "rf2-2hj0h item 8 — a CLEAN action / guard renders NO exception box."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-rows :door/main door-push-cascade-rows))]
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-exception-1"))
+          "no exception box on a clean (non-throwing) action row")
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-exception-3"))
+          "no exception box on a clean entry action row"))))
 
 ;; ---- Part 3 — a threw ACTION row shows exactly ONE threw signal -----------
 
@@ -3396,11 +3557,16 @@
       ;; (b) NO '✗ threw — <message>' outcome-detail line.
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-threw-1"))
           "no duplicate '✗ threw — <message>' outcome-detail line")
+      ;; rf2-2hj0h item 8 — the threw signal is now the EXCEPTION BOX below
+      ;; the code (the single failure signal, paired with item 7's no-tick).
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-exception-1"))
+          "the throwing action's exception box renders (rf2-2hj0h item 8)")
       ;; The action row itself still renders (only the threw chrome is gone).
       (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
           "the action row still renders")))
-  (testing "rf2-4yrr6 — a SUCCESSFUL `:action` row keeps its `:ok` outcome
-            chip (only the threw chip was removed)"
+  (testing "rf2-2hj0h item 7 — a SUCCESSFUL `:action` row carries NO ok-tick
+            (success is clean — the prior `✓ ok` chip is removed; rf2-4yrr6
+            had already removed the threw chip)"
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :door/main
                 :fx []
@@ -3409,8 +3575,11 @@
                                      :outcome {:data {:opened-count 1}}}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ok"))
-          "a successful action keeps its `:ok` outcome chip"))))
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ok"))
+          "a successful action carries NO `✓ ok` tick (rf2-2hj0h item 7)")
+      ;; A clean action also renders NO exception box.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-exception-1"))
+          "a clean action renders no exception box"))))
 
 ;; ---- Part 4 — collapsed exception-card machine attribution ----------------
 


### PR DESCRIPTION
Post-akvfe (#2902) / fg3c4 (#2903) visual polish of the Xray Epoch **EVENT HANDLER** machine-cascade mini-pipeline. Branched off post-both `origin/main` so the reworked pipeline (orientation line, grey data-delta arrow) is the baseline.

## The 8 items (per rf2-2hj0h)

1. **Remove horizontal inter-step lines** — dropped the cascade-row `border-bottom` and the rows-host `border-top`.
2. **Remove both left vertical lines** — akvfe's nested-pipeline **rail** (`machine-cascade-rail-style` + its div/wrapper) AND the per-step source-body left **connector** (`cascade-row-source-style`'s `border-left`). Rows now render as a flat numbered stack; the ordinal chips carry the pipeline reading.
3. **Align info lines to the badge left edge** — source body + outcome details now indent to `cascade-info-indent` (21px ordinal + 6px gap = 27px), under the merged badge, not behind a connector.
4. **Drop "Processing"** — the orientation line now reads `[TRIGGER] <vec> for [MACHINE] <id> in [STATE] <state>`.
5. **Merge kind + phase into one action badge** — `[EXIT ACTION]` / `[ENTRY ACTION]` / `[TRANSITION ACTION]` / `[ALWAYS ACTION]` / … (`badge/cascade-action-badge-label`). Per the bead's **RESOLVED #5** (Mike, 2026-06-04): transition ACTIONS are real LCA actions, so the merge applies to all three phases including `TRANSITION ACTION`. The state-change **TRANSITION ROW** (kind `:transition`) keeps its own single `[TRANSITION]` pill — distinct, can co-occur.
6. **`for <state>` + action name** — `[EXIT ACTION] for :closed :clear-hold`. `<state>` = exited (`:source-state`) for exit phases, entered (`:target-state`) for entry phases (`format/cascade-action-for-state`, off the slots `enrich-cascade-rows` already stamps). Omitted when no state was stamped.
7. **Remove the green ok-tick** — a successful action carries no `✓ ok` chip; success is clean.
8. **Exception box** — a throwing guard/action renders an exception box below its code, modeled on the **outer pipeline's** `error-block` (✗ title + verbatim message + collapsible stack/ex-data via `error-block-details`). Paired with item 7: success = clean; failure = box.

## `[TRANSITION]` vs `[TRANSITION ACTION]` — FLAG

My dispatch brief carried the OLD default ("keep single `[TRANSITION]` for transition rows, flag for override"). The **bead's NOTES supersede that**: transition ACTIONS (the LCA action — Spec 005; testbed `hvac :swap-mode`) are real, so a transition-PHASE action badge reads **`TRANSITION ACTION`**, while the state-change **TRANSITION ROW** keeps **`TRANSITION`**. Implemented per the bead. No open flag — surfacing for visibility.

## Exception-box modeling

Reuses the outer card's chrome verbatim (`error-block-style` / `-title-style` / `-glyph-style` / `-message-style` + `error-block-details`), so the inner exception reads identically to a handler/fx/interceptor throw and the fuse `:*` throw. The throwing step's verb-link already carries the click-to-source `file:line` (so no redundant coord line — matching the outer card's rf2-wnvid posture). Message via `ex-message` on the row's raw `:exception`; ex-data rides the collapsible.

## What akvfe already covered vs what changed

akvfe built the orientation line (with "Processing"), the nested rail, the merged-data into per-EMIT rows, and the grey arrow (fg3c4). This PR refines: dropped "Processing" (4), removed the rail it added (2), merged the still-separate kind+phase chips (5), added for-state (6) + exception box (8), removed the ok-tick (7), and removed the inter-step + connector lines (1, 2).

## Assertions added

- **badge** (`badge_cljs_test`): `cascade-action-badge-label` → all phases + `TRANSITION ACTION` + fallback; transition ROW keeps `TRANSITION`.
- **view** (`view_cljs_test`): flat stack / no rail / no border-bottom / no border-top / no source connector; merged `[EXIT/ENTRY/TRANSITION ACTION]` badge text; for-state clause (source vs target, omitted when absent); no `✓ ok` tick; throwing action+guard exception box (title/message/ex-data) + clean rows render none; orientation line drops "Processing".
- **hard fidelity**: updated the HVAC test (rail gone → flat rows host).

## Gates (cold)

- xray JVM `clojure -M:test` — 1081 tests / 4508 assertions, 0 failures.
- `npm run test:cljs` (node-test) — 5455 tests / 18949 assertions, 0 failures, **0 warnings** compile.
- `npx shadow-cljs compile :examples/machine-epochs` — **0 warnings**.
- `npm run test:xray-feature-gate` — 16 scenarios / 13 matrix rows, 0 failures.

**Visual sign-off is Mike's** — implemented per spec + bead, gates green; drive the door deck (machine-epochs :8033) to confirm the read.

Spec kept current: `tools/xray/spec/021` §9.1.5 (per-row chrome: merged badge, for-state, no ok-tick, exception box) + §9.1.6.4 (orientation line drops "Processing") + the EVENT HANDLER section layout (rail/line removal).

Closes rf2-2hj0h.