### PR TITLE
fix(xray/machines): render topology + current state for a guard-blocked / no-op machine event (rf2-skmc7)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -403,22 +403,34 @@ one subject, sourced implicitly from event focus.
 
 For the currently-focused event in the L2 event list:
 
-1. **Enumerate the event's `:rf.machine/transition` traces _and its
-   machine-birth `:rf.machine/started` traces_.** The transitions are
-   the from→to moves the event caused (Spec 005 trace contract; one per
-   outer transition, plus `:rf.machine.microstep/transition` for
-   `:always`-driven microsteps). The `:rf.machine/started` traces are
-   machine **births** (rf2-eldze) — a pure start emits no
-   `:rf.machine/transition` (it is an entry into the initial state, not
-   a from→to), so a birth would otherwise be invisible to this lens.
-   Each trace (transition or birth) carries `:tags {:machine-id …}`
-   naming the instance.
+1. **Enumerate the event's `:rf.machine/transition` traces, its
+   machine-birth `:rf.machine/started` traces, _and its guard-blocked /
+   unhandled `:rf.machine.event/unhandled-no-op` traces_.** The
+   transitions are the from→to moves the event caused (Spec 005 trace
+   contract; one per outer transition, plus
+   `:rf.machine.microstep/transition` for `:always`-driven microsteps).
+   The `:rf.machine/started` traces are machine **births** (rf2-eldze) — a
+   pure start emits no `:rf.machine/transition` (it is an entry into the
+   initial state, not a from→to), so a birth would otherwise be invisible
+   to this lens. The `:rf.machine.event/unhandled-no-op` traces are
+   guard-blocked / unhandled **NO-OPs** (rf2-skmc7) — an event that DID
+   target a registered machine but matched no transition (xstate-v5 parity)
+   so the machine stayed in its current state; a no-op emits no
+   `:rf.machine/transition`, so it too would otherwise be invisible. Each
+   trace (transition, birth, or no-op) carries `:tags {:machine-id …}`
+   naming the instance. **Per-machine de-dup (Spec 005 — "a no-op is
+   single-signalled"):** a machine that BOTH transitioned (or was born) AND
+   no-op'd in the same cascade surfaces its transition / birth record only;
+   the redundant no-op for that machine is dropped, so no ghost section.
 2. **If the set is empty** → the panel renders only the verbatim
    placeholder (see [§Empty state — focused event does not target
    a state machine](#empty-state--focused-event-does-not-target-a-state-machine)
-   below). No chart, no lens, no history ribbon, nothing else. (A birth
-   makes the set non-empty — a focused start epoch is NOT this empty
-   state; see [§Machine birth (rf2-eldze)](#machine-birth--the-start--initial-entry-case-rf2-eldze).)
+   below). No chart, no lens, no history ribbon, nothing else. (A birth OR a
+   guard-blocked / unhandled no-op makes the set non-empty — a focused start
+   epoch is NOT this empty state, see [§Machine birth
+   (rf2-eldze)](#machine-birth--the-start--initial-entry-case-rf2-eldze); a
+   focused guard-blocked / no-op epoch is NOT this empty state either, see
+   [§Guard-blocked / no-op (rf2-skmc7)](#guard-blocked--unhandled-no-op--the-no-transition-case-rf2-skmc7).)
 3. **If the set is non-empty** → select **one** instance per the
    tiebreaker below; render the focused-transition lens above the
    chart with that instance as `Target Machine Instance:`, the
@@ -466,15 +478,20 @@ empty-state pattern used by other Xray panels). Worker proposes
 this treatment from the Figma authority; if Figma has no settled
 empty-state pattern yet, this section is the normative reference.
 
-**Unhandled-event no-op is NOT this empty state (rf2-ugdas).** An event
-that DOES target a machine but matches no transition (xstate-v5 parity — a
-benign no-op, op-type `:rf.machine`, emitting `:rf.machine.event/unhandled-no-op`)
-still targets a machine, so the Machines tab renders the machine's topology
-(the "no activity this epoch" Case B shape, [§021 Dynamic-Panel-Designs](021-Dynamic-Panel-Designs.md)),
-not this "does not target a state machine" placeholder. The benign no-op is
-surfaced in the **Epoch panel's** EVENT HANDLER machine cascade as a muted
-`NO OP` row (`[NO OP] staying in {state}`, rf2-iu3no) — see
-[021 §machine-cascade-rows](021-Dynamic-Panel-Designs.md).
+**Unhandled-event no-op is NOT this empty state (rf2-ugdas, impl rf2-skmc7).**
+An event that DOES target a machine but matches no transition (xstate-v5
+parity — a benign no-op, op-type `:rf.machine`, emitting
+`:rf.machine.event/unhandled-no-op`) still targets a machine, so the Machines
+tab renders the machine's topology with the CURRENT state highlighted (the "no
+activity this epoch" Case B shape, [§021
+Dynamic-Panel-Designs](021-Dynamic-Panel-Designs.md)), not this "does not
+target a state machine" placeholder — see [§Guard-blocked / no-op
+(rf2-skmc7)](#guard-blocked--unhandled-no-op--the-no-transition-case-rf2-skmc7)
+for the full render shape. The same no-op is ALSO surfaced in the **Epoch
+panel's** EVENT HANDLER machine cascade as a muted `NO OP` row (`[NO OP]
+staying in {state}`, rf2-iu3no) — see [021
+§machine-cascade-rows](021-Dynamic-Panel-Designs.md); that surface is the
+per-event cascade narration, this section is the Machines TAB's topology read.
 This placeholder is reserved for events that target NO machine at all.
 
 This is the **state 2** branch in
@@ -535,6 +552,72 @@ The Epoch panel's EVENT HANDLER section renders the SAME birth signal as
 a `[START]` cascade-row (rf2-it4vt) — that surface is the per-event
 cascade narration; this section is the Machines TAB's topology read.
 Both key off the one `:rf.machine/started` trace.
+
+### Guard-blocked / unhandled no-op — the no-transition case (rf2-skmc7)
+
+A **no-op** is a machine event that matched no transition and so left the
+machine in its current state. Two causes produce it, indistinguishably at the
+resolution layer:
+
+- an **unhandled** user event — the machine declares no `:on` clause for the
+  event-id at any active state-node (nor at the root `:on`); and
+- a **guard-blocked** transition — a clause for the event-id DOES exist, but
+  its `:guard` returned false. The substrate's `match-on-clause` returns the
+  first candidate _whose guard passes_, so a guard-blocked clause is treated
+  exactly like no clause: resolution yields nil.
+
+In both cases the runtime emits exactly one `:rf.machine.event/unhandled-no-op`
+trace (Spec 009 §`:op-type` vocabulary; the SOLE signal — a no-op macrostep
+emits NO `:rf.machine/transition`), op-type `:rf.machine` (machine-activity
+family, NOT an error / warning — xstate-v5 parity). The trace carries `:tags
+{:machine-id :event :state}` where `:state` is the machine's **current**
+(unchanged) state.
+
+The motivating case (Mike, live machine-epochs, 2026-06-04): the door
+guard-blocked close — `[:door/main [:door/close]]` where the `:may-close?`
+guard FAILS, so the machine stays in `:open` as a no-op. Before rf2-skmc7 the
+focused-event lens filtered to `:rf.machine/transition` / `:rf.machine/started`
+alone, so a focused guard-blocked-close epoch produced zero records and the
+Machine tab rendered the "does not target a state machine" empty state — even
+though the event DID dispatch to `:door/main` and run its guard. This is the
+SAME underlying gap rf2-eldze fixed for the START case, for a different
+no-transition cause; the Machine tab MUST treat
+`:rf.machine.event/unhandled-no-op` as a render-worthy focused-event member.
+
+**Render shape for a no-op.** The no-op renders the SAME per-machine section a
+transition does, with these differences:
+
+- **No from→to edge.** The machine stayed put, so the header renders a
+  `[NO-OP]` marker followed by the unchanged current state (`[NO-OP]
+  <current-state>`) instead of a `<from> → <to>` path. The
+  focused-transition lens renders **NO TRANSITION** (not TRANSITION) with the
+  unchanged current state and a muted `(stayed — no transition matched)`
+  annotation instead of `<from> → <to>`.
+- **Topology highlights the current state.** The chart is fed the current
+  state via `:current-state` (the active-state highlight) with NO
+  from-highlight / to-highlight — so the chart paints a single active-state
+  highlight on the current node rather than a misleading `state → state`
+  self-transition edge.
+- **No snapshot drill-in.** The no-op trace carries no `:before` / `:after`
+  snapshot pair (`:data` did not change), so the drill-in suppresses cleanly.
+- **No guards / actions list.** Today's substrate does not emit
+  `:rf.machine/guard-evaluated` for the declining (guard-blocked) candidate —
+  the no-op trace is the sole signal — so there are no guard / action rows to
+  attach. (A follow-on bead may surface the failing guard in the lens once the
+  substrate emits a guard trace on the no-op path; the record shape stays
+  stable.)
+
+A machine that BOTH transitioned (or was born) AND no-op'd in the same cascade
+surfaces only its transition / birth record — a no-op is single-signalled
+(Spec 005), so no redundant ghost no-op section renders for that machine.
+
+Normal transitions and machine births are unaffected — they continue to render
+exactly as their respective sections specify.
+
+The Epoch panel's EVENT HANDLER section renders the SAME no-op signal as a
+muted `[NO OP] staying in {state}` cascade-row (rf2-iu3no) — that surface is
+the per-event cascade narration; this section is the Machines TAB's topology
+read. Both key off the one `:rf.machine.event/unhandled-no-op` trace.
 
 ### Relationship to the focused-transition lens (rf2-99rhe)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -364,7 +364,7 @@
   operator's eye reads `chart = primary, lens = secondary`. Same body
   background as the rest of the section interior (`bg-2`); padding-only
   separation; section labels carry weight differential per issue #5."
-  [{:keys [machine-id from-state to-state guards actions start? cause]}]
+  [{:keys [machine-id from-state to-state guards actions start? cause no-op?]}]
   [:div {:data-testid "rf-xray-machine-focused-transition-lens"
          :data-machine-id (str machine-id)
          :data-guard-count (str (count guards))
@@ -374,6 +374,11 @@
          ;; transition) when the focused epoch is a machine start.
          :data-start (str (boolean start?))
          :data-cause (str cause)
+         ;; rf2-skmc7 — no-op marker so the forensic block reads NO
+         ;; TRANSITION (the machine stayed in its current state — a
+         ;; guard-blocked / unhandled event) rather than a misleading
+         ;; `state → state` self-transition.
+         :data-no-op (str (boolean no-op?))
          ;; Issue #6 option (b) — secondary-metadata treatment. No
          ;; coloured body (matches the section's `bg-2`); slightly
          ;; smaller mono font; lighter default text colour. The lens
@@ -397,14 +402,19 @@
     ;; Issue #5 — `<strong>` weight differential on the section
     ;; label so the eye picks it out from the path that follows.
     ;; rf2-eldze — a birth is INITIAL ENTRY, not a TRANSITION.
+    ;; rf2-skmc7 — a no-op is NO TRANSITION (the machine stayed put).
     [:strong {:style {:color (:text-tertiary tokens)
                       :text-transform "uppercase"
                       :font-size "10px"
                       :letter-spacing "0.5px"
                       :font-weight 700}}
-     (if start? "Initial entry" "Transition")]
+     (cond
+       start? "Initial entry"
+       no-op? "No transition"
+       :else  "Transition")]
     [:div {:style {:padding-left "16px"}}
-     (if start?
+     (cond
+       start?
        ;; No from-state — render only the resulting initial state, with
        ;; the entry-arrow grammar (`↳ :initial`) the topology's initial-
        ;; state marker mirrors.
@@ -415,6 +425,18 @@
         (when cause
           [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
            (str "(" (name cause) ")")])]
+
+       no-op?
+       ;; rf2-skmc7 — the event matched no transition (unhandled / guard-
+       ;; blocked). Render only the unchanged current state with a muted
+       ;; `(no transition)` annotation — no `→` edge, no destination.
+       [:span {:data-testid "rf-xray-machine-lens-no-op-state"}
+        [:span {:style {:color (:text-primary tokens) :font-weight 600}}
+         (h/format-state to-state)]
+        [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
+         "(stayed — no transition matched)"]]
+
+       :else
        [:span
         [:span {:style {:color (:text-secondary tokens)}}
          (h/format-state from-state)]
@@ -695,7 +717,7 @@
    - issue #8: outer margin bumped to 16px so the section has visible
      breathing room from the panel host edge."
   [{:keys [machine-id from-state to-state on-event event microstep?
-           definition fired-edge-ids start? cause]
+           definition fired-edge-ids start? cause no-op?]
     :as record}]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
   ;; layout dance (layout-or-fallback / ensure-elk! / compute-layout!)
@@ -705,8 +727,14 @@
   (let [;; rf2-nesy9 — render-time frame capture for the deferred
         ;; right-click filter dispatch.
         frame      (rf/current-frame-id)
-        from-id    (when from-state (chart-layout/highlight-id from-state))
-        to-id      (when to-state   (chart-layout/highlight-id to-state))
+        ;; rf2-skmc7 — a NO-OP suppresses the from→to highlight grammar
+        ;; (no edge; the machine stayed put). The wrapper's highlight-id
+        ;; data-attrs therefore read "" for a no-op, matching the chart
+        ;; props below; the current state is surfaced via `:current-state`.
+        from-id    (when (and from-state (not no-op?))
+                     (chart-layout/highlight-id from-state))
+        to-id      (when (and to-state (not no-op?))
+                     (chart-layout/highlight-id to-state))
         engine     "xyflow+elkjs"
         collapsed? @(rf/subscribe
                       [:rf.xray.machine-canvas/chart-collapsed-for machine-id])
@@ -732,6 +760,12 @@
       ;; / :spawned).
       :data-start (str (boolean start?))
       :data-cause (str cause)
+      ;; rf2-skmc7 — guard-blocked / unhandled / NO-OP record marker.
+      ;; `:data-no-op "true"` lets tests + hosts pin that a
+      ;; `:rf.machine.event/unhandled-no-op` epoch renders the topology
+      ;; (CURRENT state highlighted) rather than the 'does not target a
+      ;; state machine' empty state.
+      :data-no-op (str (boolean no-op?))
       :data-chart-collapsed (str collapsed?)
       ;; rf2-zdfbm — the topology is the panel's centrepiece, so the
       ;; section grows to fill the focused-event host's available
@@ -771,7 +805,12 @@
       ;; an entry into the initial state, not a from→to). Render a
       ;; `[START]` marker + the resulting initial state instead of the
       ;; misleading `(uninit) → :initial` path a transition header shows.
-      (if start?
+      ;; rf2-skmc7 — NO-OP path: a guard-blocked / unhandled event matched
+      ;; no transition, so the machine stayed in its current state. Render
+      ;; a `[NO-OP]` marker + the unchanged current state instead of a
+      ;; misleading `state → state` self-transition.
+      (cond
+        start?
         [:<>
          [:span {:data-testid "rf-xray-machine-focused-event-start-badge"
                  :style {:color (:accent tokens)
@@ -786,6 +825,23 @@
          [:span {:style {:color (:accent tokens)}} "→"]
          [:span {:style {:color (:text-primary tokens) :font-weight 600}}
           (h/format-state to-state)]]
+
+        no-op?
+        [:<>
+         [:span {:data-testid "rf-xray-machine-focused-event-no-op-badge"
+                 :style {:color (:text-tertiary tokens)
+                         :font-size "10px"
+                         :font-weight 700
+                         :letter-spacing "0.5px"
+                         :text-transform "uppercase"
+                         :border (str "1px solid " (:border-default tokens))
+                         :border-radius "3px"
+                         :padding "1px 5px"}}
+          "No-op"]
+         [:span {:style {:color (:text-primary tokens) :font-weight 600}}
+          (h/format-state to-state)]]
+
+        :else
         [:<>
          [:span {:style {:color (:text-secondary tokens)}}
           (h/format-state from-state)]
@@ -905,8 +961,13 @@
                [machine-canvas/Chart
                 {:definition         definition
                  :machine-id         machine-id
-                 :from-highlight     from-state
-                 :to-highlight       to-state
+                 ;; rf2-skmc7 — a NO-OP has no from→to edge (the machine
+                 ;; stayed put). Suppress the from/to highlight grammar so
+                 ;; the chart does NOT paint a misleading `state → state`
+                 ;; self-transition; the CURRENT state is surfaced via
+                 ;; `:current-state` below as a single active-state highlight.
+                 :from-highlight     (when-not no-op? from-state)
+                 :to-highlight       (when-not no-op? to-state)
                  ;; rf2-eldze — a machine BIRTH has no from→to edge; the
                  ;; resulting initial state IS the active state. Feed it
                  ;; through `:current-state` so the chart paints the
@@ -915,7 +976,13 @@
                  ;; to) already lands the same node. Belt-and-braces: the
                  ;; node lights up whether the chart keys off to-highlight
                  ;; or current-state.
-                 :current-state      (when start? to-state)
+                 ;; rf2-skmc7 — a NO-OP's current state IS the (unchanged)
+                 ;; `to-state` (== `from-state`); feed it so the topology
+                 ;; highlights the one current node the machine is resting in.
+                 :current-state      (cond
+                                       start? to-state
+                                       no-op? to-state
+                                       :else  nil)
                  ;; rf2-qeemm (G3) — the focused epoch's traversed edges paint
                  ;; the FIRED treatment on the live chart (canonical ids from
                  ;; `extract-fired-edge-ids`, attached to the section record).

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -165,6 +165,53 @@
   (and (map? ev)
        (= started-operation (:operation ev))))
 
+;; ---- no-op / guard-blocked machine event (`:rf.machine.event/unhandled-no-op`) — rf2-skmc7 -----
+;;
+;; A machine event that matched no transition — an UNHANDLED user event, OR
+;; a transition whose GUARD failed (`match-on-clause` returns the first
+;; candidate WHOSE GUARD PASSES, so a guard-blocked clause is indistinguishable
+;; from no clause at the resolution layer) — produces NO `:rf.machine/transition`
+;; (Spec 009: "A no-op macrostep emits NO `:rf.machine/transition` … the benign
+;; `:rf.machine.event/unhandled-no-op` is the SOLE signal for an unhandled /
+;; guard-blocked event"). The machine stays in its current state as a no-op.
+;;
+;; The event STILL targeted a registered machine: the substrate dispatched the
+;; event to the machine's handler and ran its guards. So per spec/003
+;; §Empty state ("Unhandled-event no-op is NOT this empty state") the Machine
+;; tab MUST render the machine's topology with the CURRENT state highlighted —
+;; NOT the "does not target a state machine" placeholder.
+;;
+;; This is the SAME underlying gap rf2-eldze fixed for the machine-START case:
+;; the focused-event lens keyed off a from→to TRANSITION, so any event that
+;; targeted a machine but produced no transition (start, guard-block, unhandled
+;; no-op) was wrongly classified as "does not target a state machine". eldze
+;; folded in `:rf.machine/started`; this folds in
+;; `:rf.machine.event/unhandled-no-op`.
+;;
+;; The no-op trace carries `{:machine-id :event :state :frame}` where `:state`
+;; is the machine's CURRENT state (`(:state snapshot)` at resolution time —
+;; unchanged by the no-op). We project it into the same record shape as a
+;; transition, with `:from-state` == `:to-state` == the current state (a no-op
+;; is a stationary self-loop) and a `:no-op? true` flag so the view renders a
+;; `[NO-OP]` marker + a single highlighted current state rather than a
+;; from→to edge.
+
+(def no-op-operation
+  "The benign no-op / guard-blocked / unhandled trace op (Spec 009
+  §`:op-type` vocabulary). Emitted from `machines/transition.cljc` (flat /
+  compound) and `machines/parallel.cljc` (the parallel-region aggregate)
+  exactly once when an event matched no transition at any level — including
+  a clause whose guard failed. Op-type `:rf.machine` (machine-activity
+  family, NOT an error / warning)."
+  :rf.machine.event/unhandled-no-op)
+
+(defn no-op-event?
+  "True iff `ev` is the benign machine no-op (`:rf.machine.event/unhandled-no-op`)
+  trace. Pure predicate; tolerant of a missing `:operation` key."
+  [ev]
+  (and (map? ev)
+       (= no-op-operation (:operation ev))))
+
 ;; ---- machine-id resolution ----------------------------------------------
 
 (defn machine-id-of
@@ -567,6 +614,57 @@
      :guards      []
      :actions     []}))
 
+(defn- no-op-record-from-trace
+  "Project a `:rf.machine.event/unhandled-no-op` (guard-blocked / unhandled /
+  no-op) trace into the same view-consumed record shape the transition / start
+  projectors produce, so the focused-event lens renders the topology with the
+  CURRENT state highlighted — rather than the 'does not target a state machine'
+  empty state. rf2-skmc7.
+
+  The no-op trace carries `{:machine-id :event :state :frame}` (Spec 009;
+  machines · transition.cljc / parallel.cljc) where `:state` is the machine's
+  CURRENT state at resolution time (unchanged — that's what makes it a no-op).
+  We map:
+
+    :from-state (:state tag)  — the current state == to-state (a stationary
+                                self-loop; the state did not change)
+    :to-state   (:state tag)  — same current state (highlighted on the chart)
+    :before     nil           — the no-op trace carries no snapshot pair; the
+    :after      nil             drill-in suppresses cleanly (no `:data` change)
+    :no-op?     true           — flags the no-op case for the view (the header
+                                renders a `[NO-OP]` marker, the lens reads
+                                NO TRANSITION, the chart highlights the one
+                                current state)
+    :event      (:event tag)  — the inbound user event that produced the no-op
+
+  Guards / actions default empty: a guard-blocked transition's guard DOES run,
+  but today's substrate does not emit `:rf.machine/guard-evaluated` for the
+  declining candidate (the no-op trace is the sole signal), so there is nothing
+  to attach. When the substrate gains guard traces on the no-op path a follow-on
+  bead surfaces the failing guard in the lens; the record shape stays stable.
+
+  The record shape is otherwise identical to a transition record so every
+  downstream consumer (section view, chart highlight, prev/next nav) treats it
+  uniformly."
+  [ev]
+  (let [tags  (get ev :tags {})
+        state (:state tags)
+        event (:event tags)]
+    {:machine-id  (machine-id-of ev)
+     :from-state  state
+     :to-state    state
+     :before      nil
+     :after       nil
+     :no-op?      true
+     :on-event    (when (vector? event) (first event))
+     :event       event
+     :time        (:time ev)
+     :id          (:id ev)
+     :dispatch-id (get-in ev [:tags :rf.trace/dispatch-id])
+     :microstep?  false
+     :guards      []
+     :actions     []}))
+
 (defn- ref-display-id
   "Coerce a guard/action ref to a renderable id for the per-transition
   Guards / Actions list.
@@ -746,6 +844,8 @@
        :dispatch-id  <id|nil>
        :microstep?   <bool>
        :definition   <machine-def-or-nil>
+       :no-op?       <bool>                ;; true iff this is a guard-blocked /
+                                            ;; unhandled / no-op record (rf2-skmc7)
        :guards       [<guard-record>...]
        :actions      [<action-record>...]
        :history-restored [<restore-record>...]  ;; rf2-mle6e.5, only when a
@@ -763,43 +863,88 @@
   = the resulting initial state, so the view highlights the initial state
   on the topology.
 
-  Returns `[]` when no machine-transition / start trace fired in the
+  Per rf2-skmc7 a guard-blocked / unhandled / NO-OP machine event
+  (`:rf.machine.event/unhandled-no-op`) is ALSO surfaced as a first-class
+  record — the SAME gap as the eldze birth case for a DIFFERENT no-transition
+  cause. A no-op emits no `:rf.machine/transition` (the machine stayed put),
+  so without this fold a focused guard-blocked-close epoch produced zero
+  records and the Machine tab wrongly rendered 'does not target a state
+  machine' — even though the event DID dispatch to a registered machine and
+  ran its guard. The no-op record carries `:from-state` == `:to-state` == the
+  current state + `:no-op? true`, so the view highlights the current state on
+  the topology with a `[NO-OP]` marker. A no-op record is folded ONLY for a
+  machine that produced NO transition / start record in the same cascade
+  (Spec 005 — a no-op is single-signalled): a machine that both transitioned
+  and later no-op'd in one cascade surfaces its transition, not a redundant
+  ghost no-op section.
+
+  Returns `[]` when no machine-transition / start / no-op trace fired in the
   cascade — the silent-by-default branch the view honours per rf2-g3ghh.
 
   Pure fn — JVM-runnable."
   ([trace-events]
    (project-focused-event-transitions trace-events nil))
   ([trace-events definitions]
-   (let [defs (or definitions {})
-         events (or trace-events [])]
-     (->> events
-          ;; Transition macrosteps / microsteps AND machine births
-          ;; (rf2-eldze). A birth carries no from-state; it is projected
-          ;; via `started-record-from-trace` rather than the transition
-          ;; projector.
-          (filter (fn [ev] (or (transition-event? ev) (started-event? ev))))
-          ;; Stable cascade order — :id is monotonic per Spec 009;
-          ;; fall back to :time, then 0.
-          (sort-by (fn [ev] (or (:id ev) (:time ev) 0)))
-          (map (fn [ev]
-                 (let [base   (if (started-event? ev)
-                                ;; Birth: no guard/action/history attach —
-                                ;; the initial-entry cascade's actions are
-                                ;; not traced as `:rf.machine/action-ran`
-                                ;; (rf2-n9f4z), so there is nothing to fold.
-                                (started-record-from-trace ev)
-                                (-> (transition-record-from-trace ev)
-                                    (attach-guards-and-actions events)
-                                    (attach-history events)))
-                       mid    (:machine-id base)
-                       defn-> (get defs mid)]
-                   (cond-> base
-                     defn-> (assoc :definition defn->)))))
-          ;; Drop records whose machine-id couldn't be resolved — a
-          ;; malformed trace shouldn't surface a section with no
-          ;; identity. nil :machine-id matches no chart definition so
-          ;; the row would be unrenderable anyway.
-          (filter :machine-id)
+   (let [defs   (or definitions {})
+         events (or trace-events [])
+         attach-def
+         (fn [base]
+           (let [defn-> (get defs (:machine-id base))]
+             (cond-> base
+               defn-> (assoc :definition defn->))))
+         order  (fn [ev] (or (:id ev) (:time ev) 0))
+         ;; (1) Transition macrosteps / microsteps AND machine births
+         ;; (rf2-eldze). A birth carries no from-state; it is projected
+         ;; via `started-record-from-trace` rather than the transition
+         ;; projector.
+         move-records
+         (->> events
+              (filter (fn [ev] (or (transition-event? ev) (started-event? ev))))
+              (sort-by order)
+              (map (fn [ev]
+                     (attach-def
+                       (if (started-event? ev)
+                         ;; Birth: no guard/action/history attach — the
+                         ;; initial-entry cascade's actions are not traced as
+                         ;; `:rf.machine/action-ran` (rf2-n9f4z).
+                         (started-record-from-trace ev)
+                         (-> (transition-record-from-trace ev)
+                             (attach-guards-and-actions events)
+                             (attach-history events))))))
+              (filter :machine-id)
+              vec)
+         ;; (2) Guard-blocked / unhandled / NO-OP machine events (rf2-skmc7).
+         ;; Folded ONLY for a machine that did NOT also produce a transition /
+         ;; start record in this cascade — Spec 005 "a no-op is
+         ;; single-signalled": a machine that transitioned AND no-op'd in the
+         ;; same cascade surfaces the transition, never a duplicate ghost
+         ;; no-op section.
+         moved-machine-ids (set (map :machine-id move-records))
+         no-op-records
+         (->> events
+              (filter no-op-event?)
+              (sort-by order)
+              (map no-op-record-from-trace)
+              (filter :machine-id)
+              ;; Drop a no-op for a machine that already has a move record.
+              (remove (fn [r] (contains? moved-machine-ids (:machine-id r))))
+              ;; Dedup multiple no-op traces for the same machine in one
+              ;; cascade (parallel-region aggregate can only emit one, but
+              ;; belt-and-braces): keep the FIRST in trace order.
+              (reduce (fn [{:keys [seen acc]} r]
+                        (let [mid (:machine-id r)]
+                          (if (contains? seen mid)
+                            {:seen seen :acc acc}
+                            {:seen (conj seen mid) :acc (conj acc r)})))
+                      {:seen #{} :acc []})
+              :acc
+              (map attach-def)
+              vec)]
+     ;; Merge + re-sort by trace order so a no-op interleaves with any
+     ;; transitions in document order (the Dynamic-mode single-instance rule
+     ;; picks `first`, so order is load-bearing).
+     (->> (concat move-records no-op-records)
+          (sort-by order)
           vec))))
 
 (defn focused-epoch-record

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
@@ -647,6 +647,138 @@
       (is (= :idle (:from-state rec)))
       (is (= :authing (:to-state rec))))))
 
+;; ---- (10c) guard-blocked / NO-OP (`:rf.machine.event/unhandled-no-op`) — rf2-skmc7 ----
+;;
+;; A machine event that matched no transition — an UNHANDLED user event OR a
+;; transition whose GUARD failed — emits `:rf.machine.event/unhandled-no-op`
+;; (the SOLE signal; no `:rf.machine/transition`) and leaves the machine in
+;; its current state. The event DID target a registered machine, so the
+;; Machine tab MUST render the topology with the CURRENT state highlighted —
+;; NOT the 'does not target a state machine' empty state (spec/003 §Empty
+;; state: "Unhandled-event no-op is NOT this empty state"). This is the SAME
+;; gap rf2-eldze fixed for the START case, for a different no-transition cause.
+;; These tests pin that a no-op IS surfaced as a first-class record and that
+;; transitions / starts / genuinely-non-machine events are unaffected.
+
+(defn- no-op-event
+  "Build a `:rf.machine.event/unhandled-no-op` (guard-blocked / unhandled)
+  trace event with the substrate shape — `{:machine-id :event :state}` in
+  `:tags`, `:state` being the machine's CURRENT (unchanged) state."
+  ([id mid state event] (no-op-event id mid state event :rf.machine.event/unhandled-no-op))
+  ([id mid state event op]
+   {:id        id
+    :time      (* id 10)
+    :operation op
+    :tags      {:machine-id mid
+                :state      state
+                :event      event
+                :rf.trace/dispatch-id (str "n-" id)}}))
+
+(deftest no-op-event-predicate
+  (is (true?  (h/no-op-event? {:operation :rf.machine.event/unhandled-no-op})))
+  (is (false? (h/no-op-event? {:operation :rf.machine/transition})))
+  (is (false? (h/no-op-event? {:operation :rf.machine/started})))
+  (is (false? (h/no-op-event? nil)))
+  (is (false? (h/no-op-event? {}))))
+
+(deftest project-focused-event-surfaces-guard-blocked-no-op
+  (testing "a focused guard-blocked / no-op machine event (the door
+            `:may-close?`-fail close) yields ONE record with from-state ==
+            to-state == the CURRENT state and `:no-op? true` — so the
+            Machine tab renders the topology (current state highlighted)
+            rather than the 'does not target a state machine' empty state
+            (rf2-skmc7)"
+    (let [events  [(no-op-event 1 :door/main :open [:door/close])]
+          records (h/project-focused-event-transitions events)
+          rec     (first records)]
+      (is (= 1 (count records))
+          "the no-op is a first-class focused-event record — NOT dropped")
+      (is (= :door/main (:machine-id rec)))
+      (is (true? (:no-op? rec))
+          ":no-op? flags the guard-blocked / unhandled case for the view")
+      (is (= :open (:from-state rec))
+          "from-state is the current state — the machine stayed put")
+      (is (= :open (:to-state rec))
+          "to-state == from-state (a stationary self-loop; the chart
+           highlights the one current state)")
+      (is (= [:door/close] (:event rec))
+          "the inbound user event that produced the no-op rides the record")
+      (is (= :door/close (:on-event rec)))
+      (is (nil? (:start? rec))
+          "a no-op is NOT a birth")
+      (is (nil? (:before rec))
+          "the no-op trace carries no snapshot pair — drill-in suppresses")
+      (is (nil? (:after rec))))))
+
+(deftest project-focused-event-no-op-carries-definition
+  (testing "a no-op record gets the registered definition attached so the
+            chart can render the topology"
+    (let [definitions {:door/main {:initial :closed
+                                    :states  {:closed {:on {:push :open}}
+                                              :open   {:on {:close :closed}}}}}
+          events  [(no-op-event 1 :door/main :open [:door/close])]
+          records (h/project-focused-event-transitions events definitions)]
+      (is (= (get definitions :door/main)
+             (-> records first :definition))))))
+
+(deftest project-focused-event-no-op-deduped-against-transition
+  (testing "a machine that BOTH transitioned and later no-op'd in one cascade
+            surfaces ONLY its transition record — a no-op is single-signalled
+            (Spec 005); no redundant ghost no-op section"
+    (let [events  [(t-event 1 :door/main :closed :open [:door/push])
+                   (no-op-event 2 :door/main :open [:door/close])]
+          records (h/project-focused-event-transitions events)]
+      (is (= 1 (count records))
+          "only the transition record survives — the no-op for the same
+           machine is dropped")
+      (is (= [:open] (mapv :to-state records)))
+      (is (nil? (-> records first :no-op?))
+          "the surviving record is the transition, not the no-op"))))
+
+(deftest project-focused-event-no-op-interleaves-with-other-machines
+  (testing "a cascade where machine A transitions and machine B no-ops yields
+            one record per machine in trace order — B's no-op is first-class"
+    (let [events  [(no-op-event 1 :door/main :open [:door/close])
+                   (t-event 2 :auth/login :idle :authing [:auth/submit])]
+          records (h/project-focused-event-transitions events)]
+      (is (= 2 (count records)))
+      (is (= [:door/main :auth/login] (mapv :machine-id records))
+          "records are oldest-first by trace order; the no-op leads")
+      (is (= [true false] (mapv (comp boolean :no-op?) records))
+          "the first is the no-op, the second an ordinary transition"))))
+
+(deftest project-focused-event-no-op-dedup-multiple-for-same-machine
+  (testing "multiple no-op traces for the SAME machine in one cascade collapse
+            to a single record (keep the first in trace order)"
+    (let [events  [(no-op-event 1 :door/main :open [:door/close])
+                   (no-op-event 2 :door/main :open [:door/lock])]
+          records (h/project-focused-event-transitions events)]
+      (is (= 1 (count records)))
+      (is (= [:door/close] (-> records first :event))
+          "the first no-op in trace order wins"))))
+
+(deftest project-focused-event-genuinely-non-machine-still-empty
+  (testing "an event that targets NO machine at all (no transition / start /
+            no-op trace) STILL yields the empty vector — the 'does not target
+            a state machine' placeholder is reserved for that case (rf2-skmc7
+            does NOT widen the gate to non-machine events)"
+    (let [events [{:id 1 :operation :rf.event/dispatched
+                   :tags {:rf.event/v [:foo]}}
+                  {:id 2 :operation :rf.sub/run
+                   :tags {:rf.sub/id ::bar}}]]
+      (is (= [] (h/project-focused-event-transitions events))
+          "no machine trace of any kind → still empty (still 'does not
+           target a state machine')"))))
+
+(deftest project-focused-event-transition-still-not-flagged-no-op
+  (testing "an ordinary transition record carries no :no-op? flag — the
+            no-op fold does not contaminate the transition projector"
+    (let [events  [(t-event 1 :auth/login :idle :authing [:auth/submit])]
+          rec     (-> (h/project-focused-event-transitions events) first)]
+      (is (nil? (:no-op? rec)))
+      (is (= :idle (:from-state rec)))
+      (is (= :authing (:to-state rec))))))
+
 ;; ---- (11) focused-epoch-record (rf2-a9cke) ------------------------------
 
 (deftest focused-epoch-record-empty-history

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -290,6 +290,71 @@
         (is (nil? (find-by-testid tree "rf-xray-machine-inspector-blank"))
             "the blank-state is suppressed — the bug was an empty tab here")))))
 
+(deftest focused-event-guard-blocked-no-op-renders-topology-not-blank-rf2-skmc7
+  (testing "a focused guard-blocked / NO-OP machine event (a
+            `:rf.machine.event/unhandled-no-op` trace, NO
+            `:rf.machine/transition`) renders the topology with the CURRENT
+            state highlighted — NOT the 'does not target a state machine'
+            empty state (rf2-skmc7). This is the SAME gap rf2-eldze fixed for
+            the START case, for a different no-transition cause: the door
+            `:may-close?`-fail close stays in :open as a no-op."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:door/main])
+      (override-definitions! {:door/main {:initial :closed
+                                          :states  {:closed {:on {:push :open}}
+                                                    :open   {:on {:close :closed}}}}})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine.event/unhandled-no-op
+            :tags {:machine-id :door/main
+                   :state      :open
+                   :event      [:door/close]
+                   :rf.trace/dispatch-id "n-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree    (machine-inspector/Panel)
+            section (find-by-testid
+                      tree "rf-xray-machine-focused-event-section-door/main")
+            chart   (find-by-testid
+                      tree "rf-xray-machine-focused-event-chart")]
+        (is (some? (find-by-testid tree "rf-xray-machine-focused-event"))
+            "the focused-event surface mounts for a guard-blocked no-op")
+        (is (some? section)
+            "the per-machine section renders for the no-op'd machine")
+        (is (= "true" (:data-no-op (second section)))
+            "the section is flagged as a no-op record")
+        (is (= ":open" (:data-to-state (second section)))
+            "to-state is the unchanged CURRENT state")
+        (is (= ":open" (:data-from-state (second section)))
+            "from-state == to-state — the machine stayed put")
+        (is (some? chart)
+            "the topology chart renders for the no-op (not the empty state)")
+        ;; The current state is the active state — surfaced via :current-state
+        ;; (NOT a from/to highlight, which would paint a misleading
+        ;; state→state self-transition). The wrapper's highlight-id attrs are
+        ;; suppressed so the chart paints a single active-state highlight.
+        (is (= "" (:data-to-highlight-id (second chart)))
+            "no to-highlight — a no-op is not a from→to landing")
+        (is (= "" (:data-from-highlight-id (second chart)))
+            "no from-highlight — a no-op is not a from→to origin")
+        (is (some? (find-by-testid
+                     tree "rf-xray-machine-focused-event-no-op-badge"))
+            "the header renders a [NO-OP] badge rather than a state→state path")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-focused-event-start-badge"))
+            "a no-op is NOT a birth — no [START] badge")
+        (is (nil? (find-by-testid tree "rf-xray-machine-inspector-blank"))
+            "the blank-state is suppressed — the bug was an empty tab here")
+        ;; The lens reads NO TRANSITION (not a misleading self-transition).
+        (let [lens (find-by-testid
+                     tree "rf-xray-machine-focused-transition-lens")]
+          (is (= "true" (:data-no-op (second lens)))
+              "the forensic lens is flagged no-op")
+          (is (some? (find-by-testid
+                       tree "rf-xray-machine-lens-no-op-state"))
+              "the lens renders the unchanged current state, no → edge"))))))
+
 (deftest gate-reads-the-migrated-rf-machine-transition-op-only
   (testing "the machine-relatedness gate keys on the `:rf.*` migrated op
             `:rf.machine/transition` (post-#1973). A focused epoch whose


### PR DESCRIPTION
## What

On a machine event that produced NO transition — specifically the door guard-blocked close (`[:door/main [:door/close]]` where `:may-close?` FAILS, so the machine stays `:open` as a no-op) — the Machine tab wrongly showed "This event does not target a state machine". The event DID target `:door/main` (dispatched a machine event, ran the guard). This is the **same underlying gap rf2-eldze fixed for the START case**, for a different no-transition cause (guard-blocked / unhandled / no-op).

## Cause

An unhandled / guard-blocked machine event emits exactly one `:rf.machine.event/unhandled-no-op` trace (the SOLE signal — a no-op macrostep emits no `:rf.machine/transition`; a guard-blocked clause is indistinguishable from no clause at resolution, since `match-on-clause` returns the first candidate whose guard passes). The focused-event lens (`project-focused-event-transitions`) filtered to `:rf.machine/transition` / `:rf.machine/started` only, so a focused no-op epoch produced zero records → blank "does not target" state.

## Fix

- **Helpers** (`machine_inspector_helpers.cljc`): add `no-op-operation` / `no-op-event?` predicate + `no-op-record-from-trace`. Fold `:rf.machine.event/unhandled-no-op` traces into `project-focused-event-transitions` as first-class records — `:from-state` == `:to-state` == the current state (from the trace's `:state` tag), `:no-op? true`. Deduped per-machine against transition/start records (a no-op is single-signalled, Spec 005) so a machine that transitioned AND no-op'd in one cascade surfaces only its transition; multiple no-ops for one machine collapse to the first.
- **View** (`machine_inspector.cljs`): `focused-event-section` + `focused-transition-lens` handle `:no-op?` — `[NO-OP]` header marker + unchanged current state (no arrow edge), a **NO TRANSITION** lens, and the chart fed `:current-state` with from/to highlight suppressed so it paints a single active-state highlight (not a misleading `state -> state` self-transition). New `data-no-op` attrs + a `rf-xray-machine-focused-event-no-op-badge` testid.
- **Spec** (`003-Machine-Inspector.md`): new normative section "Guard-blocked / unhandled no-op — the no-transition case (rf2-skmc7)" (parallel to the rf2-eldze birth section) + extended "The rule" (enumerate no-op traces, per-machine de-dup) + "Empty state" callout pointing to the render shape.

## Guarantees

- A guard-blocked / no-op machine event renders the topology with the **current** state highlighted, not "does not target".
- A **genuinely non-machine** event (no transition / start / no-op trace) STILL shows "does not target a state machine" — the gate is NOT widened to non-machine events.
- eldze's START case + normal transitions are **unregressed**.

## Gates (cold)

- xray JVM `clojure -M:test`: **1094 tests, 4558 assertions, 0 failures** (helper suite: 65 tests / 177 assertions, +8 new no-op tests).
- `npm run test:cljs`: **5470 tests, 19021 assertions, 0 failures** (incl. new no-op view test).
- `npx shadow-cljs compile :examples/machine-epochs`: **0 warnings**.
- `npm run test:xray-feature-gate`: **16 scenarios, 0 failures**.

**Visual sign-off is Mike's** — drive the door `:may-close?`-fail close in machine-epochs.
