### PR TITLE
feat(xray/epoch): GUARD row drop redundant word + inline pass/fail (rf2-h710p)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1582,28 +1582,47 @@ rather than collapsing to a plain `reg-event-db` handler.
   `spawned`, off the `:rf.machine/started` trace's `:cause`. The `lazy`
   cause is the ordering-smell flag (warning tone); `explicit` / `spawned`
   ride the muted neutral tone.
-- **`for <state>` clause** (`:action` rows only — rf2-2hj0h item 6) — after
-  the merged action badge the header reads ` for <state> ` then the action
-  name (the verb), e.g. `[EXIT ACTION] for :closed :clear-hold` /
-  `[ENTRY ACTION] for :open :count-open`. `<state>` is the state the action
-  BELONGS TO — the EXITED (`:source-state`) state for an exit-phase action,
-  the ENTERED (`:target-state`) state for an entry-phase action (the LCA
-  `:transition`-phase action anchors on the source state). It reads off the
-  `:source-state` / `:target-state` slots `enrich-cascade-rows` stamps
-  (`format/cascade-action-for-state`); the clause is OMITTED (no dangling
-  `for`) when no state was stamped.
+- **`for <state>` clause** (`:action` AND `:guard` rows — rf2-2hj0h item 6
+  + rf2-h710p item B) — after the kind pill / merged action badge the header
+  reads ` for <state> ` then the verb (the action-id / guard-id), e.g.
+  `[EXIT ACTION] for :closed :clear-hold` / `[ENTRY ACTION] for :open
+  :count-open` / `[GUARD] for :open :may-close?`. `<state>` is the state the
+  row BELONGS TO:
+  - For an `:action` row — the EXITED (`:source-state`) state for an
+    exit-phase action, the ENTERED (`:target-state`) state for an
+    entry-phase action (the LCA `:transition`-phase action anchors on the
+    source state); `format/cascade-action-for-state`.
+  - For a `:guard` row — the GATED state, i.e. the transition's
+    `:source-state` (the state whose `:on` map carries the guard);
+    `format/cascade-guard-for-state`.
+
+  Both read off the `:source-state` / `:target-state` slots
+  `enrich-cascade-rows` stamps off the surrounding `:transition` row. The
+  clause is OMITTED (no dangling `for`) when no state was stamped. Rendered
+  by the kind-agnostic `cascade-for-state-clause` (the caller picks the
+  resolved state per kind).
 - **Verb** — the action-id / guard-id / transition headline / timer
   state, rendered as a click-to-source button when a `{:file :line}`
   coord resolves for the row (a named guard/action reads its co-located
   `:source-coords`; a reference-site `[:states ...]` key reads the
   `:source-coords` off the nearest enclosing `:states`-tree map node —
   rf2-vqja2). Falls back to a plain coloured span when no coord was
-  captured.
+  captured. **For a `:guard` row the verb is the bare guard-id** (rf2-h710p
+  item B) — the leading `guard` word that prefixed it pre-rf2-h710p was
+  redundant (the `[GUARD]` kind pill already names the kind), so it is
+  dropped; the gated state rides the `for <state>` clause above.
 - **Duration chip** — right-aligned monospace; paints long-step
   warning chrome (`▲` + warning tone) when `:duration-ms` exceeds
   `projection/long-step-threshold-ms` (16ms — one 60Hz frame).
-- **Outcome chip** — kind-specific:
-  - `:guard` → `✓ pass / ▲ fail / ✗ threw`
+- **Outcome chip** — kind-specific. Right-aligned (in the duration-chip
+  slot) for `:transition` / `:timer`; **INLINE** (in the header flow,
+  straight after the verb + its click-to-source glyph) for `:guard`:
+  - `:guard` → `✓ pass / ▲ fail / ✗ threw`, rendered **INLINE** after the
+    guard name + source glyph (`[GUARD] for :open :may-close? ↗ pass` —
+    rf2-h710p item C), NOT right-aligned. The guard pass/fail is MEANINGFUL
+    (it decides the branch — distinct from the rf2-2hj0h item-7 ACTION
+    ok-tick that was removed), so it stays; keeping it inline puts the
+    verdict beside the predicate that produced it.
   - `:action` → **NO outcome chip** (rf2-2hj0h item 7 — success is CLEAN, no
     `✓ ok` tick; the prior tick was redundant chrome in the normal case).
     Failure is the **EXCEPTION BOX** below the code (item 8 — see §Per-row

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -243,7 +243,12 @@
   [{:keys [kind action-id guard-id from-state to-state state reason
            machine-id show-machine-name? cause]}]
   (case kind
-    :guard       (str "guard " (ns-keyword guard-id))
+    ;; rf2-h710p item B — the GUARD verb is JUST the guard-id. The leading
+    ;; "guard" word DUPLICATED the `[GUARD]` kind-pill (which already says
+    ;; GUARD), so it is dropped. The state the guard gates rides the
+    ;; `for <state>` clause (the item-6 pattern; `cascade-guard-for-state`)
+    ;; rendered alongside the verb in the view — `[GUARD] for :open :may-close?`.
+    :guard       (ns-keyword guard-id)
     ;; rf2-nhovk — the ACTION kind-pill + phase chip already convey kind +
     ;; phase, so the verb is JUST the action-id (empty for an anonymous
     ;; action — the pill + chip + source body carry it). The redundant
@@ -439,6 +444,20 @@
     (if exit-phase?
       (or source-state target-state)
       (or target-state source-state))))
+
+(defn cascade-guard-for-state
+  "The state a `:guard` cascade row gates (rf2-h710p item B), for the
+  ` for <state> ` clause of the GUARD-row header — `[GUARD] for <state>
+  <guard-name>` (e.g. `[GUARD] for :open :may-close?`). A guard gates the
+  ENTRY into / fire of a transition OUT OF its source state, so the
+  belongs-to state is the transition's `:source-state` (the state whose
+  `:on` map carries the guard — the same slot `enrich-cascade-rows` stamps
+  off the surrounding `:transition`'s `:from-state`). Falls back to
+  `:target-state` when no source was stamped (best-effort enrichment).
+  Returns nil when neither state was stamped — the view then omits the
+  ` for <state> ` clause and renders just the guard name. Pure-data."
+  [{:keys [source-state target-state]}]
+  (or source-state target-state))
 
 (defn history-kind-label
   "Render a history `:kind` keyword (`:shallow` / `:deep`) as a UI label."

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2628,17 +2628,21 @@
 ;; ` for <state> ` then the action name. `for` is a muted connective; the
 ;; state renders code-formatted (it may be a keyword OR a path vector /
 ;; region→state map). Elides cleanly when no state was stamped.
-(defn- cascade-action-for-state-clause
-  "Render the ` for <state> ` clause that follows the merged action badge
-  (rf2-2hj0h item 6). `<state>` is `format/cascade-action-for-state` — the
-  exited state for an exit-phase action, the entered state for an
-  entry-phase action. Returns nil (renders nothing) when no state was
-  stamped on the row, so the header falls back to `[<PHASE> ACTION]
-  <action-name>` with no dangling `for`."
-  [row]
-  (when-let [state (fmt/cascade-action-for-state row)]
-    [:span {:data-testid (str "rf-xray-epoch-machine-cascade-for-state-"
-                              (:step row))
+;;
+;; rf2-h710p item B — the SAME clause shape now also fronts the GUARD row's
+;; verb (`[GUARD] for <state> <guard-name>`); the clause is kind-agnostic,
+;; rendering a resolved `<state>` value the caller picks per kind
+;; (`cascade-action-for-state` / `cascade-guard-for-state`).
+(defn- cascade-for-state-clause
+  "Render the ` for <state> ` clause that fronts a cascade row's verb
+  (rf2-2hj0h item 6 + rf2-h710p item B). `state` is the resolved
+  belongs-to / gated state (caller-picked per kind). Returns nil (renders
+  nothing) for a nil `state`, so the header falls back to the bare badge +
+  verb with no dangling `for`. `step` keys the testid so per-row selectors
+  resolve."
+  [step state]
+  (when (some? state)
+    [:span {:data-testid (str "rf-xray-epoch-machine-cascade-for-state-" step)
             :style cascade-action-for-state-style}
      [:span {:style orientation-connective-style} "for"]
      [:span {:style cascade-action-for-state-value-style}
@@ -3180,21 +3184,38 @@
       (if (= :action kind)
         (cascade-action-pill phase)
         (cascade-kind-pill kind))
-      ;; rf2-2hj0h item 6 — ` for <state> ` after the merged action badge.
+      ;; rf2-2hj0h item 6 + rf2-h710p item B — ` for <state> ` fronts the
+      ;; verb on `:action` (the state the action belongs to) AND `:guard`
+      ;; rows (the state whose transition the guard gates), reading the
+      ;; kind-specific belongs-to/gated state. The bare `[GUARD]` pill no
+      ;; longer needs the redundant "guard" verb word (dropped in
+      ;; `format/cascade-row-label`) — the clause + guard-id carry it.
       (when (= :action kind)
-        (cascade-action-for-state-clause row))
+        (cascade-for-state-clause step (fmt/cascade-action-for-state row)))
+      (when (= :guard kind)
+        (cascade-for-state-clause step (fmt/cascade-guard-for-state row)))
       (cascade-row-verb-link row coord verb)
+      ;; rf2-h710p item C — the GUARD outcome (pass/fail/threw) renders
+      ;; INLINE, straight after the guard name + its click-to-source glyph
+      ;; (`[GUARD] for :open :may-close? ↗ pass`), NOT right-aligned. The
+      ;; guard pass/fail is MEANINGFUL (it decides the branch — distinct from
+      ;; the rf2-2hj0h item-7 ACTION ok-tick, which was removed); keeping it
+      ;; inline puts the verdict beside the predicate that produced it.
+      (when (and (= :guard kind) outcome-lbl)
+        (cascade-outcome-chip outcome outcome-lbl))
       ;; rf2-it4vt — the `[START]` row's CAUSE tag (explicit / lazy /
       ;; spawned) rides right after the verb. The `lazy` cause is the
       ;; ordering-smell flag (warning tone).
       (when (= :start kind)
         (cascade-start-cause-chip cause))
-      ;; Right-aligned: duration + outcome chip
+      ;; Right-aligned: duration + (non-guard) outcome chip
       [:span {:style cascade-row-right-style}
        (duration-chip duration-ms)
        (cascade-outcome-chip
          (cond
-           (= :guard kind)      outcome
+           ;; rf2-h710p item C — the GUARD outcome moved INLINE (above), so it
+           ;; is no longer painted in the right-aligned slot.
+           (= :guard kind)      nil
            ;; rf2-2hj0h item 7 — an ACTION row carries NO outcome ok-tick.
            ;; SUCCESS is clean (no `✓ ok` chip — the prior tick was redundant
            ;; chrome in the normal case); FAILURE is the EXCEPTION BOX below
@@ -3209,8 +3230,7 @@
            ;; tell the whole story; the prior "ignored" chip was a third
            ;; restatement of the same fact.
            :else                nil)
-         (when (or (= :transition kind)
-                   (and (= :guard kind) outcome-lbl))
+         (when (= :transition kind)
            outcome-lbl))]]
      ;; Source code body (always visible per rf2-u69j7) — actions + guards
      ;; render their source (or the rf2-iwy0c machine-def link when none

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1239,7 +1239,11 @@
 
 (deftest cascade-row-label-test
   (testing "rf2-u69j7 — `cascade-row-label` renders a human verb per kind"
-    (is (= "guard :ready?"
+    ;; rf2-h710p item B — the GUARD verb is JUST the guard-id; the leading
+    ;; "guard" word DUPLICATED the `[GUARD]` kind-pill and is dropped (the
+    ;; gated state rides the view's `for <state>` clause). The header reads
+    ;; `[GUARD] for <state> :ready?`, not `[GUARD] guard :ready?`.
+    (is (= ":ready?"
            (fmt/cascade-row-label {:kind :guard :guard-id :ready?})))
     ;; rf2-nhovk — the ACTION verb is JUST the action-id; the kind-pill +
     ;; phase chip already convey kind + phase, so the redundant
@@ -1261,6 +1265,21 @@
                                     :machine-id :ws/conn
                                     :from-state [:idle]
                                     :to-state   [:connecting]})))))
+
+(deftest cascade-guard-for-state-test
+  (testing "rf2-h710p item B — `cascade-guard-for-state` resolves the state a
+            guard gates (the transition's `:source-state`), for the GUARD row's
+            ` for <state> ` clause (`[GUARD] for :open :may-close?`)."
+    (is (= :open
+           (fmt/cascade-guard-for-state {:kind :guard :guard-id :may-close?
+                                         :source-state :open :target-state :closed}))
+        "the gated state is the transition's :source-state (the state whose :on map carries the guard)")
+    (is (= :closed
+           (fmt/cascade-guard-for-state {:kind :guard :guard-id :ready?
+                                         :target-state :closed}))
+        "falls back to :target-state when no :source-state was stamped")
+    (is (nil? (fmt/cascade-guard-for-state {:kind :guard :guard-id :ready?}))
+        "nil when neither state was stamped — the view omits the clause (no dangling `for`)")))
 
 (deftest cascade-row-source-key-test
   (testing "rf2-u69j7 — `cascade-row-source-key` returns the spec-path

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -3470,6 +3470,60 @@
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
           "no ` for <state> ` clause when neither source nor target state is stamped"))))
 
+(deftest event-handler-guard-row-for-state-and-inline-outcome-test
+  (testing "rf2-h710p item B — the GUARD row drops the redundant `guard` verb
+            word (the `[GUARD]` pill already says GUARD) and fronts the
+            guard-id with the item-6 ` for <state> ` clause, so the header
+            reads `[GUARD] for :open :may-close?`."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-rows :door/main
+                   [{:kind :guard :step 1 :machine-id :door/main
+                     :guard-id :may-close? :outcome :pass
+                     :source-state :open :target-state :closed}]))]
+      ;; B — the for-state clause carries the gated (source) state.
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
+          "the guard row renders a ` for <state> ` clause")
+      (is (string/includes? (text-of tree "rf-xray-epoch-machine-cascade-for-state-1")
+                            "for")
+          "the clause carries the `for` connective")
+      (is (string/includes? (text-of tree "rf-xray-epoch-machine-cascade-for-state-1")
+                            ":open")
+          "the gated state is the transition's :source-state — `for :open`")
+      ;; B — the verb is the bare guard-id (no duplicate `guard` word).
+      (let [verb (or (text-of tree "rf-xray-epoch-machine-cascade-verb-link-1") "")]
+        (is (string/includes? verb ":may-close?")
+            "the verb is the bare guard-id")
+        (is (not (string/includes? verb "guard"))
+            "the redundant `guard` word is dropped (the `[GUARD]` pill carries it)"))
+      ;; C — the pass/fail outcome chip renders INLINE in the header (a direct
+      ;; sibling of the verb), NOT inside the right-aligned span. The
+      ;; right-aligned span (`:margin-left auto`) must not contain it.
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-pass"))
+          "the meaningful guard pass/fail chip still renders (it decides the branch)")
+      (let [row    (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")
+            header (first (th/children row))
+            ;; The right-aligned span is the header child carrying margin-left:auto.
+            right  (some (fn [c]
+                           (when (= "auto" (:margin-left (:style (th/attrs c)))) c))
+                         (th/children header))]
+        (is (some? header) "the row header renders")
+        (is (some? right) "the right-aligned span (margin-left:auto) renders")
+        (is (nil? (th/find-by-testid right "rf-xray-epoch-machine-cascade-outcome-pass"))
+            "the guard outcome chip is NOT in the right-aligned span (it moved inline)")
+        (is (some? (th/find-by-testid header "rf-xray-epoch-machine-cascade-outcome-pass"))
+            "the guard outcome chip IS in the header (inline after the verb + glyph)"))))
+  (testing "rf2-h710p item C — a FAILING guard's `fail` marker also renders
+            inline (the guard fail is meaningful — it blocked the transition)."
+    (let [tree (view/render-handler-step
+                 (machine-step-with-rows :door/main
+                   [{:kind :guard :step 1 :machine-id :door/main
+                     :guard-id :may-close? :outcome :fail
+                     :source-state :open :target-state :closed}]))
+          row    (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")
+          header (first (th/children row))]
+      (is (some? (th/find-by-testid header "rf-xray-epoch-machine-cascade-outcome-fail"))
+          "the `fail` chip renders inline in the header"))))
+
 (deftest event-handler-action-no-ok-tick-test
   (testing "rf2-2hj0h item 7 — a SUCCESSFUL `:action` row carries NO green
             ok-tick (the prior `✓ ok` outcome chip is REMOVED — success is


### PR DESCRIPTION
Follow-up to **rf2-2hj0h** (#2905, merged) on the EVENT HANDLER machine-cascade GUARD row. Branched off post-2hj0h `origin/main`.

## Items

**A. `[TRANSITION ACTION]` badge — already done (verified, no change).** 2hj0h shipped this: `badge/cascade-action-badge-label` returns `TRANSITION ACTION` for an action whose phase is `:transition`, and the state-change `:transition` row keeps its own `[TRANSITION]` pill. Covered by existing tests (`badge_cljs_test` + `view_cljs_test` item-5). No edit.

**B. GUARD row — drop the redundant word.** The verb read `guard :may-close?` — "guard" duplicated the `[GUARD]` kind pill. Dropped: the verb is now the bare guard-id, fronted by the item-6 for-state clause → `[GUARD] for :open :may-close?`. New `format/cascade-guard-for-state` resolves the gated state (the transition's `:source-state`, the state whose `:on` map carries the guard).

**C. GUARD outcome — inline, not right-aligned.** The pass/fail marker moved from the right-aligned span to INLINE, straight after the guard name + its click-to-source glyph: `[GUARD] for :open :may-close? ↗ pass`. The guard pass/fail is **kept** (it is meaningful — it decides the branch; distinct from the 2hj0h item-7 ACTION ok-tick that was removed).

## Implementation notes
- `format.cljc` — `:guard` case in `cascade-row-label` now returns the bare guard-id; added `cascade-guard-for-state`.
- `view.cljs` — `cascade-action-for-state-clause` generalised to the kind-agnostic `cascade-for-state-clause` (caller picks the resolved state per kind); GUARD outcome chip rendered inline in the header, removed from the right-aligned span.
- `spec/021` kept current — for-state clause now covers `:action` + `:guard`; verb note for the dropped word; outcome-chip placement (inline for `:guard`).

## Gates (cold)
- xray JVM `clojure -M:test` — **1087 tests / 4533 assertions, 0 failures**.
- `npm run test:cljs` — **5463 tests / 18994 assertions, 0 failures**.
- `npx shadow-cljs compile :examples/machine-epochs` — **0 warnings**.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, 13 matrix rows** (exit 0).

New assertions: GUARD verb is bare guard-id (no "guard"); `for <state>` clause carries the gated source state; pass/fail chip is in the header, NOT in the right-aligned span (both pass + fail).

**Visual sign-off is Mike's.**

Closes rf2-h710p.