### PR TITLE
feat(xray/epoch): drop data-delta caption + align step content to badge left (rf2-32kyr + rf2-4b6im)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1719,13 +1719,18 @@ the defmachine DEFINITION:
 
 **Per-row outcome detail.** Action rows surface inline:
 
-- **`↳ data Δ`** — when the action returned a `:data` map, the delta
-  the action contributed rendered through the **edn-inspector in DIFF
-  mode** (rf2-5hjb5). The action's RETURNED `:data` (`:data-write`, the
-  AFTER) renders with inline diff annotations against the action's
-  INPUT `:data` (`:data-before`, lifted off the `:input {:data …}`
-  snapshot), reusing the same `{:before <prior>}` posture the App-db
-  panel ships (cf. `handler-db-diff-block`). A data-mutating action
+- **`↳ <edn-inspector value>`** — when the action returned a `:data`
+  map, the delta the action contributed rendered through the
+  **edn-inspector in DIFF mode** (rf2-5hjb5). The row reads
+  `<arrow> <edn-inspector value>`: a light-grey `↳` arrow (rf2-fg3c4)
+  into the inspector value, with **NO `data Δ` caption** (rf2-32kyr —
+  the literal "data Δ" label was redundant chrome; the arrow into the
+  inspector value carries the reading). The action's RETURNED `:data`
+  (`:data-write`, the AFTER) renders with inline diff annotations
+  against the action's INPUT `:data` (`:data-before`, lifted off the
+  `:input {:data …}` snapshot), reusing the same `{:before <prior>}`
+  posture the App-db panel ships (cf. `handler-db-diff-block`). A
+  data-mutating action
   shows its delta inline (entry `:count-open`: `{:opened-count 0}` →
   `{:opened-count 1}` paints the changed leaf with the `~ … ← was 0`
   gutter chrome); a no-op action whose `:data` is unchanged (exit
@@ -1777,6 +1782,27 @@ heading — `[TRIGGER] ‹vec› for [MACHINE] ‹id› in [STATE]
 >   The **thin HORIZONTAL inter-step lines** are removed too (item 1 — the
 >   cascade row's `border-bottom` + the rows-host `border-top`). The ordinal
 >   numbering is retained.
+
+> **Step content aligns to the BADGE left edge (rf2-2hj0h item 3, corrected
+> by rf2-4b6im).** ALL of a step's subsequent content — the source body, the
+> per-action outcome details (the `↳` data-delta + the `↳ fx` chips), any
+> exception box, and any sub-line — left-aligns to the **LEFT EDGE of the
+> badge** (e.g. the left of `[EXIT ACTION]` / `[GUARD]`), forming one
+> left-aligned column under the badge. The `[N]` ordinal chip sits outdented
+> to the badge's LEFT; the badge defines the content column for the whole
+> step. This holds for **every** mini-step kind (`[EXIT ACTION]` /
+> `[ENTRY ACTION]` / `[TRANSITION ACTION]` / `[TRANSITION]` / `[GUARD]` /
+> `[NO OP]` / …). The indent (`view/cascade-info-indent`) equals the ordinal
+> chip's outer width (`cascade-ordinal-box-width`, 21px — the chip carries
+> `box-sizing: border-box` so its rendered width is exactly its declared
+> width) **+** the header `:gap` (`cascade-header-gap`, 6px) = 27px.
+>
+> rf2-4b6im CORRECTS item 3's as-rendered behaviour: item 3 already specified
+> the badge left edge, but the ordinal chip rendered ~29px wide under the
+> default `content-box` (its 8px horizontal padding sat outside the 21px
+> `min-width`), so the prior 27px constant under-shot — content hung at the
+> ordinal RIGHT edge instead of the badge left. Pinning the chip to
+> `border-box` makes 21px + 6px gap land exactly on the badge left edge.
 
 A THREW action surfaces NO per-row threw chrome (rf2-4yrr6 retired the prior
 `✗ threw — <message>` outcome-detail line AND the duplicate `✗ threw`

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -474,11 +474,33 @@
          :color  warning-colour
          :border (str "1px solid " warning-colour)))
 
+;; rf2-4b6im — the `[N]` ordinal chip's outer width + the header `:gap` are
+;; the two constituents of the badge-left content column (`cascade-info-indent`
+;; below). Hoisted as named px so the indent arithmetic stays in lockstep with
+;; the chip geometry rather than a hand-tuned magic number. The ordinal carries
+;; `box-sizing: border-box` so its RENDERED outer width is EXACTLY
+;; `cascade-ordinal-box-width` (21px) regardless of the `:padding` — under the
+;; default `content-box` the 8px horizontal padding pushed the real outer width
+;; to ~29px, so the prior 27px indent under-shot the badge left edge (the bug
+;; rf2-4b6im observed: sub-content hung at the ordinal RIGHT edge, not the badge
+;; left). `border-box` pins the box so 21px + 6px gap lands on the badge edge.
+(def ^:private cascade-ordinal-box-width
+  "Outer width of the `[N]` ordinal chip (`box-sizing: border-box`, so this
+  is the actual rendered width). The badge that follows sits one header `:gap`
+  to its right."
+  21)
+
+(def ^:private cascade-header-gap
+  "The `cascade-row-header-style` flex `:gap` between the ordinal chip and the
+  badge that follows it."
+  6)
+
 (def ^:private cascade-ordinal-style
   {:display         "inline-flex"
    :align-items     "center"
    :justify-content "center"
-   :min-width       "21px"
+   :box-sizing      "border-box"
+   :min-width       (str cascade-ordinal-box-width "px")
    :height          "16px"
    :padding         "0 4px"
    :background      bg-3-colour
@@ -514,19 +536,27 @@
    :font-weight 600
    :white-space "nowrap"})
 
-;; rf2-2hj0h item 2 + 3 — the per-step left connector (`:border-left`) is
-;; REMOVED (one of the two left vertical lines the bead retires; the
-;; full-height rail is the other). The source body now ALIGNS to the
-;; `[EXIT ACTION]` / `[TRANSITION]` badge's left edge (item 3) — past the
-;; `[N]` ordinal chip (min-width 21px) + the header gap (6px) — so the code
-;; sits under the badge rather than indented behind a connector line.
+;; rf2-2hj0h item 2 + 3 / rf2-4b6im — the per-step left connector
+;; (`:border-left`) is REMOVED (one of the two left vertical lines rf2-2hj0h
+;; retires; the full-height rail is the other). ALL of a step's subsequent
+;; content (source body, outcome, data-delta, sub-lines) ALIGNS to the
+;; `[EXIT ACTION]` / `[GUARD]` / `[TRANSITION]` badge's LEFT edge — the `[N]`
+;; ordinal chip sits outdented to its left.
+;;
+;; rf2-4b6im CORRECTS rf2-2hj0h item 3's as-rendered behaviour. item 3 intended
+;; the badge left edge but the ordinal chip rendered ~29px wide (default
+;; `content-box` + 8px padding), so the 27px constant under-shot — content hung
+;; at the ordinal RIGHT edge instead. The fix pins the ordinal box to
+;; `border-box` (outer width = exactly `cascade-ordinal-box-width`) and computes
+;; the indent from its constituents, so it tracks the chip geometry.
 (def ^:private cascade-info-indent
-  "Left-edge alignment for a cascade row's subsequent info lines (rf2-2hj0h
-  item 3) — the source body + the per-action outcome details. Equals the
-  `[N]` ordinal chip width (21px) + the header `:gap` (6px), so the info
-  lines start at the LEFT EDGE of the merged action / kind badge that
-  follows the ordinal."
-  "27px")
+  "Left-edge alignment for ALL of a cascade row's subsequent content
+  (rf2-2hj0h item 3, corrected by rf2-4b6im) — the source body, the per-action
+  outcome details, the data-delta, and any sub-lines. Equals the `[N]` ordinal
+  chip's outer width (`cascade-ordinal-box-width`) + the header `:gap`
+  (`cascade-header-gap`), so every line starts at the LEFT EDGE of the merged
+  action / kind badge that follows the ordinal."
+  (str (+ cascade-ordinal-box-width cascade-header-gap) "px"))
 
 (def ^:private cascade-row-source-style
   {:margin       "5px 0 3px 0"
@@ -703,9 +733,12 @@
    :padding        "5px 0 5px 0"})
 
 (def ^:private cascade-row-header-style
+  ;; `:gap` is `cascade-header-gap` (rf2-4b6im) — the same constant
+  ;; `cascade-info-indent` adds to the ordinal-box width so the sub-content
+  ;; column tracks the badge left edge exactly.
   {:display     "flex"
    :align-items "center"
-   :gap         "6px"
+   :gap         (str cascade-header-gap "px")
    :flex-wrap   "wrap"})
 
 (def ^:private cascade-row-right-style
@@ -2989,10 +3022,12 @@
   mounts in browse mode (no `:before`), still surfacing the written
   value."
   [{:keys [data-write data-before step] :as _row}]
+  ;; rf2-32kyr — the redundant "data Δ" CAPTION text is dropped; the row reads
+  ;; `<arrow> <edn-inspector value>` (just the light-grey arrow into the delta
+  ;; value, no label). The arrow + the inspector value are otherwise unchanged.
   [:div {:data-testid (str "rf-xray-epoch-machine-cascade-data-write-" step)
          :style cascade-detail-row-style}
    [:span {:style cascade-detail-data-arrow-style} "↳"]
-   [:span {:style cascade-detail-label-style} "data Δ"]
    [:span {:style cascade-detail-value-style}
     [ei/edn-inspector data-write
      (cond-> {:site-id                [:rf.xray.epoch/machine-cascade-data step]
@@ -3136,12 +3171,13 @@
 ;; convey. The box elides on a self/internal transition (no logical change).
 
 (defn- cascade-row-view
-  "Render one cascade row (rf2-u69j7). Layout:
+  "Render one cascade row (rf2-u69j7). Layout — all sub-content
+  left-aligns to the BADGE left edge (rf2-2hj0h item 3 / rf2-4b6im):
 
       [#step] [KIND] [phase?] verb (↗ source)    duration · outcome
-      ─┐ source code (always visible, monospace, syntax-highlighted)
-        ↳ data Δ  …
-        ↳ fx …
+              source code (always visible, monospace, syntax-highlighted)
+              ↳ <data-delta value>   (rf2-32kyr — no `data Δ` caption)
+              ↳ fx …
 
   The row's `:kind` keys all the chrome variants: `:action` rides the
   full layout (phase chip + source body + outcome details — incl. the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1396,18 +1396,31 @@
       ;; the SAME token the NORMAL (non-machine) handler's `↳ :db diff` arrow
       ;; (`sub-header-glyph-style`) uses — NOT the prior `:success` green. The
       ;; arrow is the first `↳` span inside the data-write subtree.
-      (let [arrow-colour (some-> tree-m
-                                 (th/find-by-testid "rf-xray-epoch-machine-cascade-data-write-1")
-                                 (->> (tree-seq vector? seq)
-                                      (filter #(and (vector? %) (= "↳" (last %))))
-                                      first
-                                      th/attrs
-                                      :style
-                                      :color))]
+      (let [data-write-node (th/find-by-testid tree-m "rf-xray-epoch-machine-cascade-data-write-1")
+            arrow-colour    (some-> data-write-node
+                                    (->> (tree-seq vector? seq)
+                                         (filter #(and (vector? %) (= "↳" (last %))))
+                                         first
+                                         th/attrs
+                                         :style
+                                         :color))]
         (is (= (:text-tertiary tokens/tokens) arrow-colour)
             "the machine EVENT HANDLER `data Δ` arrow uses the light-grey
              `:text-tertiary` token (matching the normal-handler arrow), not
-             the `:success` green (rf2-fg3c4)")))
+             the `:success` green (rf2-fg3c4)")
+        ;; rf2-32kyr — the redundant "data Δ" CAPTION text is GONE; the row
+        ;; reads `<arrow> <edn-inspector value>`. The arrow (`↳`) and the
+        ;; inspector value remain; only the label literal is removed.
+        (is (some? data-write-node)
+            "rf2-32kyr — the data-delta row (arrow + edn-inspector value) still renders")
+        (is (some #(and (vector? %) (= "↳" (last %)))
+                  (tree-seq vector? seq data-write-node))
+            "rf2-32kyr — the `↳` arrow is KEPT")
+        (is (not (string/includes? (or (th/text-content data-write-node) "") "data Δ"))
+            "rf2-32kyr — the redundant `data Δ` caption text is REMOVED")
+        ;; The edn-inspector value still renders (the written `:opened-count`).
+        (is (string/includes? (or (th/text-content data-write-node) "") "opened-count")
+            "rf2-32kyr — the edn-inspector value is KEPT (arrow → value, no caption)")))
     ;; A no-op exit action whose :data is unchanged still surfaces the
     ;; slot (the inspector renders the value with no delta).
     (let [noop {:step :handler :badge :HANDLER :step-number 3
@@ -1422,6 +1435,46 @@
           tree-n (view/render-handler-step noop)]
       (is (some? (th/find-by-testid tree-n "rf-xray-epoch-machine-cascade-data-write-1"))
           "DATA Δ slot renders even for a no-op action (no delta shown)"))))
+
+(deftest machine-handler-cascade-step-content-aligns-to-badge-left-test
+  (testing "rf2-4b6im — ALL of a step's subsequent content (source body +
+            outcome details, which carries the data-delta + fx sub-lines)
+            left-aligns to the BADGE left edge, NOT the `[N]` ordinal right
+            edge. The badge sits one header `:gap` (6px) past the ordinal
+            chip's outer width; the ordinal carries `box-sizing: border-box`
+            so its rendered width is EXACTLY its declared `min-width` (21px),
+            making the `padding-left` (21 + 6 = 27px) land on the badge left
+            edge. Corrects rf2-2hj0h item 3, whose 27px constant under-shot
+            because the content-box ordinal rendered ~29px wide (the bug Mike
+            observed: content hung at the ordinal right edge)."
+    (let [step {:step :handler :badge :HANDLER :step-number 3
+                :flavour :reg-machine :event-id :door/main
+                :fx []
+                :machine {:cascade [{:kind :action :step 1
+                                     :action-id :count-open
+                                     :phase :entry
+                                     :source-code "(fn count-open [ctx] ...)"
+                                     :data-before {:opened-count 0}
+                                     :data-write  {:opened-count 1}}]
+                          :transition nil :guards [] :lifecycle [] :timers []}}
+          tree (view/render-handler-step step)
+          ;; The ordinal box: deterministic outer width via border-box.
+          ordinal-style  (style-of tree "rf-xray-epoch-machine-cascade-ordinal-1")
+          ;; The two sub-content slots that must align to the badge left.
+          source-style   (style-of tree "rf-xray-epoch-machine-cascade-source-1")
+          outcome-style  (style-of tree "rf-xray-epoch-machine-cascade-outcome-1")
+          ;; The expected badge-left indent: ordinal-box-width (21) + gap (6).
+          expected-indent "27px"]
+      (is (some? ordinal-style) "the ordinal chip renders")
+      (is (= "border-box" (:box-sizing ordinal-style))
+          "the ordinal box is `border-box` so its outer width == min-width")
+      (is (= "21px" (:min-width ordinal-style))
+          "the ordinal box width is 21px (the indent's ordinal constituent)")
+      (is (= expected-indent (:padding-left source-style))
+          "the SOURCE BODY aligns to the badge left edge (21px ordinal + 6px gap)")
+      (is (string/includes? (str (:padding outcome-style)) expected-indent)
+          "the OUTCOME DETAILS (data-delta + fx sub-lines) align to the SAME
+           badge left edge as the source body — one left-aligned column"))))
 
 (deftest machine-handler-cascade-transition-row-renders-states-test
   (testing "rf2-ge6uj ISSUE 3 — the `:transition` row collapses to ONE


### PR DESCRIPTION
Two Epoch mini-pipeline (machine-cascade) tweaks on the same render path (`tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs`). Branched off post-`h710p` `origin/main`.

## rf2-32kyr — remove the data-delta CAPTION label
Action cascade rows showed the per-action data-delta as `↳ data Δ → <edn-inspector value>`. The redundant **"data Δ" caption text** is removed; the row now reads `<arrow> <edn-inspector value>` — the light-grey `↳` arrow into the inspector value, no label. The arrow (rf2-fg3c4 light-grey) and the edn-inspector value are otherwise unchanged.

## rf2-4b6im — left-align ALL step content to the BADGE left edge
Corrects rf2-2hj0h item 3. item 3 specified the badge left edge, but the `[N]` ordinal chip rendered ~29px wide under the default `content-box` (its 8px horizontal padding sat outside the 21px `min-width`), so the prior **27px** constant under-shot — content hung at the ordinal RIGHT edge (the bug Mike observed live). Fix:
- The ordinal chip carries `box-sizing: border-box`, so its rendered outer width == its declared width (exactly 21px).
- `cascade-info-indent` is now computed from named constituents — `cascade-ordinal-box-width` (21) + `cascade-header-gap` (6) = **27px** — so it lands exactly on the badge left edge and tracks the chip geometry rather than being a hand-tuned magic number. `cascade-row-header-style`'s `:gap` reads the same `cascade-header-gap` constant, keeping gap + indent coupled.

ALL of a step's subsequent content (source body, outcome details, data-delta, fx sub-lines) now forms one left-aligned column under the badge, for every mini-step kind.

## Spec
`tools/xray/spec/021-Dynamic-Panel-Designs.md`: the `↳ data Δ` bullet notes the caption removal (rf2-32kyr); a new layout note documents the badge-left alignment and supersedes rf2-2hj0h item 3's as-rendered behaviour (rf2-4b6im).

## Tests
- `machine-handler-cascade-action-data-diff-test` extended: asserts the `data Δ` caption text is gone while the `↳` arrow and the edn-inspector value (the written `:opened-count`) remain.
- New `machine-handler-cascade-step-content-aligns-to-badge-left-test`: asserts the ordinal box is `border-box` / `min-width 21px`, and that the source body + outcome details `padding-left` equal the badge-left indent (27px).

## Gates (cold)
- xray JVM `clojure -M:test` — 1095 tests, 4561 assertions, 0 failures.
- `npm run test:cljs` — 5473 tests, 19044 assertions, 0 failures.
- `npx shadow-cljs compile :examples/machine-epochs` — 0 warnings.
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures.

Visual sign-off is Mike's.

Closes rf2-32kyr. Closes rf2-4b6im.