### PR TITLE
refactor(xray/machine-epochs): drop guard-/action- prefix from machine fn names (rf2-6qciz)

### DIFF
--- a/tools/xray/testbeds/machine_epochs/machines.cljs
+++ b/tools/xray/testbeds/machine_epochs/machines.cljs
@@ -60,19 +60,19 @@
 
    :guards
    {:may-close?
-    (fn guard-may-close? [{data :data}]
+    (fn may-close? [{data :data}]
       (not (:held-open? data)))}
 
    :actions
-   {:count-open  (fn action-count-open [{data :data}]
+   {:count-open  (fn count-open [{data :data}]
                    {:data (update data :opened-count (fnil inc 0))})
-    :clear-hold  (fn action-clear-hold [{data :data}]
+    :clear-hold  (fn clear-hold [{data :data}]
                    {:data (assoc data :held-open? false)})
-    :hold-open   (fn action-hold-open [{data :data}]
+    :hold-open   (fn hold-open [{data :data}]
                    ;; INTERNAL transition (no :target): writes :data only —
                    ;; it is not part of the entry/exit cascade.
                    {:data (assoc data :held-open? true)})
-    :enter-alarm (fn action-enter-alarm [{data :data}]
+    :enter-alarm (fn enter-alarm [{data :data}]
                    {:data (assoc data :alarm-fx? true)})}
 
    :states
@@ -159,12 +159,12 @@
    :data    {:score 0}
 
    :guards
-   {:enough? (fn guard-enough? [{data :data}] (>= (:score data) 3))}
+   {:enough? (fn enough? [{data :data}] (>= (:score data) 3))}
 
    :actions
-   {:count-answer (fn action-count-answer [{data :data}]
+   {:count-answer (fn count-answer [{data :data}]
                     {:data (update data :score (fnil inc 0))})
-    :award        (fn action-award [{data :data}]
+    :award        (fn award [{data :data}]
                     {:data (assoc data :passed? true)})}
 
    :states
@@ -215,7 +215,7 @@
 (defmachine session-login-machine
   {:initial :running
    :actions
-   {:capture (fn action-capture [{data :data event :event}]
+   {:capture (fn capture [{data :data event :event}]
                {:data (assoc data :token (second event))})}
    :states
    {:running {:tags #{:session/running}
@@ -275,7 +275,7 @@
 
    :actions
    {:blow-fuse
-    (fn action-blow-fuse [{:keys [event]}]
+    (fn blow-fuse [{:keys [event]}]
       (throw (ex-info "fuse blown on boot"
                       {:event event :where :fuse-entry})))}
 
@@ -342,7 +342,7 @@
                :hvac/tweak {:action :tweak-fan}}}}}}
 
    :actions
-   {:tweak-fan (fn action-tweak-fan [{data :data}]
+   {:tweak-fan (fn tweak-fan [{data :data}]
                  {:data (update data :tweaks (fnil inc 0))})}})
 
 ;; ============================================================================


### PR DESCRIPTION
## What

Drops the redundant `guard-`/`action-` NAME prefix from the inline named-fn literals in `tools/xray/testbeds/machine_epochs/machines.cljs`. The prefix duplicated the `[ACTION]`/`[GUARD]` badge + cascade context now shown in the Xray Epoch panel, so a fn literally named `guard-may-close?` read doubled next to its `[GUARD]` badge.

11 renames, name-only:

| before | after |
|---|---|
| `(fn guard-may-close? ...)` | `(fn may-close? ...)` |
| `(fn action-count-open ...)` | `(fn count-open ...)` |
| `(fn action-clear-hold ...)` | `(fn clear-hold ...)` |
| `(fn action-hold-open ...)` | `(fn hold-open ...)` |
| `(fn action-enter-alarm ...)` | `(fn enter-alarm ...)` |
| `(fn guard-enough? ...)` | `(fn enough? ...)` |
| `(fn action-count-answer ...)` | `(fn count-answer ...)` |
| `(fn action-award ...)` | `(fn award ...)` |
| `(fn action-capture ...)` | `(fn capture ...)` |
| `(fn action-blow-fuse ...)` | `(fn blow-fuse ...)` |
| `(fn action-tweak-fan ...)` | `(fn tweak-fan ...)` |

## What is unchanged

The action/guard VERB keys (`:clear-hold`, `:may-close?`, `:count-open`, …) were already prefix-free and are left unchanged. These are all inline named-fn literals (no `def`s), referenced by name nowhere else — confirmed by grep across `tools/xray/`. No name collisions.

## Harness

`machine_epochs_harness_cljs_test.cljs` asserts only on the VERB keys (`:action`/guard verb keys like `:clear-hold`, `:tweak-fan`, `:award`), never on fn `:name`/source-coord metadata — so it needs no re-base. The only `guard-`/`action-` occurrences in that file are in test names / comments describing guard/action behaviour, not fn names.

## Quality gates (cold worktree)

- `npx shadow-cljs compile :examples/machine-epochs` — 0 warnings.
- `npm run test:cljs` — 5472 tests, 19035 assertions, 0 failures / 0 errors.
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures, 13 matrix rows.
- Grep-confirmed: no `(fn action-` / `(fn guard-` remain in `machines.cljs`.

Closes rf2-6qciz.