### PR TITLE
refactor(xray/epoch): drop redundant "N microsteps" summary from TRANSITION row (rf2-cdgva)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1629,7 +1629,13 @@ rather than collapsing to a plain `reg-event-db` handler.
     outcome detail), not a chip. (rf2-4yrr6 had already dropped the threw
     chip; item 7 drops the success `:ok` chip too, so the action row's
     outcome reads purely off presence/absence of the exception box.)
-  - `:transition` → `N microstep(s)` (the headline)
+  - `:transition` → **NO outcome chip** (rf2-cdgva — the prior
+    `N microstep(s)` summary was REDUNDANT: every `:always` microstep
+    (N>0) is itself a first-class cascade row in this same mini-pipeline
+    — its own `:rf.machine/transition` + nested exit/action/entry rows,
+    post akvfe/2hj0h — so the count merely tallied rows already present;
+    when N=0, the common case, it was pure noise. The prominent
+    `<before> → <after>` header verb is the transition's whole story.)
   - `:timer` → `· cancelled (<reason>)`
   - `:no-op` → NO outcome chip (rf2-iu3no — the `NO OP` pill + the
     `staying in {state}` verb carry the whole notice; the rf2-ugdas

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -351,10 +351,12 @@
 ;; ---- Outcome chip resolver (rf2-u69j7) ----------------------------------
 ;;
 ;; Each cascade row carries a thin outcome chip — `pass | fail | threw`
-;; for guards, `ok | threw` for actions, `cancelled (<reason>)` for
-;; timers, `N microstep(s)` for transitions. The chip colour rides
-;; the outcome keyword (success / warning / error) so the operator can
-;; eye-scan a long cascade for failures without reading every label.
+;; for guards and `cancelled (<reason>)` for timers. Actions carry no
+;; chip (rf2-2hj0h item 7) and `:transition` rows carry no chip
+;; (rf2-cdgva — the prior `N microstep(s)` summary was redundant with
+;; the per-microstep cascade rows). The chip colour rides the outcome
+;; keyword (success / warning / error) so the operator can eye-scan a
+;; long cascade for failures without reading every label.
 
 (defn cascade-outcome-token-key
   "Theme-token keyword for a cascade row's outcome glyph + chip

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -7,7 +7,7 @@
   epoch-record → ordered vector of pipeline-step rows (data-in /
   data-out). These fns are the OTHER side of that boundary: they turn
   a projected row's slots into the display STRINGS the view paints
-  (`0.1ms` / `:my-ns/foo` / `guard :x` / `2 microsteps`). Parking them
+  (`0.1ms` / `:my-ns/foo` / `guard :x` / `cancelled (on-exit)`). Parking them
   in the projection ns blurred the data/presentation line — a reader
   could not tell load-bearing derivation from cosmetic formatting, and
   the projection ns carried two jobs.
@@ -390,10 +390,16 @@
     :guard       → `pass | fail | threw`
     :action      → `ok | threw` (the action's outcome map is rich;
                                  the chip carries only the headline)
-    :transition  → `→ N microstep(s)` (the headline reads off
-                                       `:microsteps`)
-    :timer       → `cancelled (<reason>)`"
-  [{:keys [kind outcome threw? microsteps reason]}]
+    :timer       → `cancelled (<reason>)`
+
+  rf2-cdgva — the `:transition` row no longer carries an outcome label.
+  The prior `N microstep(s)` summary was redundant: every `:always`
+  microstep (N>0) is itself a first-class cascade row in the same
+  mini-pipeline (post akvfe/2hj0h), so the count merely tallied rows
+  already present; when N=0 (the common case) it was pure noise. The
+  prominent `<before> → <after>` header verb is the transition's whole
+  story, so a `:transition` row returns nil here (the no-op default)."
+  [{:keys [kind outcome threw? reason]}]
   (case kind
     :guard      (if (keyword? outcome) (name outcome) nil)
     :action     (cond
@@ -402,9 +408,6 @@
                   (map? outcome)        "ok"
                   (keyword? outcome)    (name outcome)
                   :else                 nil)
-    :transition (when (number? microsteps)
-                  (str microsteps " microstep"
-                       (when (not= 1 microsteps) "s")))
     :timer      (str "cancelled"
                      (when reason (str " (" (name reason) ")")))
     ;; rf2-iu3no — the benign no-op carries NO outcome chip. The "[NO OP]"

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2521,8 +2521,10 @@
 ;;   - Duration chip (right-aligned, with long-step warning when
 ;;     `:duration-ms > 16ms` per rf2-nqt3d).
 ;;   - Outcome chip — `✓ pass / ▲ fail / ✗ threw` for guards;
-;;     `✓ ok / ✗ threw` for actions; `→ N microstep(s)` for the
-;;     transition; `· cancelled (<reason>)` for timers.
+;;     `· cancelled (<reason>)` for timers. Actions carry NO chip
+;;     (rf2-2hj0h item 7); the `:transition` row carries NO chip
+;;     (rf2-cdgva — the prior `N microstep(s)` summary was redundant
+;;     with the per-microstep cascade rows).
 ;;   - Body: source code (ALWAYS VISIBLE per the bead body's
 ;;     "interleaved source code" requirement) + outcome detail
 ;;     (per-action fx attribution + data-write delta for actions;
@@ -3261,13 +3263,20 @@
            ;; presence/absence of the exception box.
            (= :action kind)     nil
            (= :timer kind)      :cancelled
+           ;; rf2-cdgva — the `:transition` row carries NO outcome chip. The
+           ;; prior `N microstep(s)` summary was redundant: every `:always`
+           ;; microstep (N>0) is itself a FIRST-CLASS cascade row in this same
+           ;; mini-pipeline (its own `:rf.machine/transition` + nested
+           ;; exit/action/entry rows, post akvfe/2hj0h), so the count merely
+           ;; tallied rows already present; when N=0 (the common case) it was
+           ;; pure noise. The prominent `<before> → <after>` header verb is the
+           ;; transition's whole story.
            ;; rf2-iu3no — the benign no-op carries NO outcome chip. The
            ;; "[NO OP]" kind-pill + the "staying in {state}" verb already
            ;; tell the whole story; the prior "ignored" chip was a third
            ;; restatement of the same fact.
            :else                nil)
-         (when (= :transition kind)
-           outcome-lbl))]]
+         nil)]]
      ;; Source code body (always visible per rf2-u69j7) — actions + guards
      ;; render their source (or the rf2-iwy0c machine-def link when none
      ;; was captured); the `:transition` row renders the rf2-iwy0c

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
@@ -345,13 +345,17 @@
 (deftest quiz-answer-below-mark-settles-zero-microsteps
   (testing "rung #12 — an :answer below the pass mark bumps :score; the
             guarded :always does NOT fire. (a) the transition row's
-            :microsteps is 0 / nil; (c) the quiz stays :asking."
+            :microsteps is 0 / nil; (c) the quiz stays :asking.
+            rf2-cdgva — at N=0 (the common case) the TRANSITION row renders
+            NO `0 microsteps` summary (the prior pure-noise affordance)."
     (setup!)
     (let [record (drive! :quiz/scorer [:quiz/answer])
           tx     (first (rows-of-kind (cascade record) :transition))]
       (is (some? tx) "(c) the :answer action transition row renders")
       (is (contains? #{0 nil} (:microsteps tx))
           "(a) below the mark → ZERO microsteps (the :always guard failed)")
+      (is (nil? (fmt/cascade-outcome-label tx))
+          "(c) rf2-cdgva — N=0 renders NO '0 microsteps' summary (pure noise)")
       (is (= :asking (:state (snapshot :quiz/scorer))))
       (is (= 1 (get-in (snapshot :quiz/scorer) [:data :score]))))))
 
@@ -361,7 +365,10 @@
             (a) the transition row's :microsteps > 0 AND the structured
             :cascade carries a :microstep step whose nested :steps explain the
             eventless transition (the :award action → :passed); (c) the quiz
-            lands in :passed."
+            lands in :passed.
+            rf2-cdgva — the TRANSITION row renders NO `N microstep(s)`
+            outcome summary; the microstep is surfaced as its own cascade
+            row instead, so no signal is lost by dropping the count."
     (setup!)
     (drive! :quiz/scorer [:quiz/answer])                ; score → 1
     (drive! :quiz/scorer [:quiz/answer])                ; score → 2
@@ -374,9 +381,16 @@
           microstep  (first microsteps)]
       ;; (a) the macrostep settled over at least one eventless microstep.
       (is (and (number? (:microsteps tx)) (pos? (:microsteps tx)))
-          "(a) :always settled over N>0 microsteps (Xray renders 'N microstep(s)')")
+          "(a) :always settled over N>0 microsteps (projection preserves the count)")
+      ;; rf2-cdgva — the transition row NO LONGER renders an outcome summary;
+      ;; the redundant `N microstep(s)` count is gone (the microstep below
+      ;; carries the signal). The projection still preserves :microsteps as a
+      ;; legacy pure-data slot; only the RENDERED summary is removed.
+      (is (nil? (fmt/cascade-outcome-label tx))
+          "(c) rf2-cdgva — the TRANSITION row renders NO 'N microstep(s)' summary")
       (is (seq microsteps)
-          "(a) the structured :cascade carries a :microstep step (n9f4z/52u5n)")
+          "(a/c) the microstep is surfaced as its own cascade step — the
+                 signal the dropped count summarised (n9f4z/52u5n)")
       (is (= :asking (:from microstep)))
       (is (= :passed (:to microstep))
           "(a) the microstep transitions :asking → :passed")

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1535,12 +1535,20 @@
     (is (= "ok"    (fmt/cascade-outcome-label {:kind :action :outcome :ok})))
     (is (= "threw" (fmt/cascade-outcome-label
                      {:kind :action :threw? true :outcome :rf.error/action-threw})))
-    (is (= "1 microstep"
-           (fmt/cascade-outcome-label {:kind :transition :microsteps 1})))
-    (is (= "3 microsteps"
-           (fmt/cascade-outcome-label {:kind :transition :microsteps 3})))
     (is (= "cancelled (on-exit)"
-           (fmt/cascade-outcome-label {:kind :timer :reason :on-exit})))))
+           (fmt/cascade-outcome-label {:kind :timer :reason :on-exit}))))
+  (testing "rf2-cdgva — the `:transition` row carries NO outcome label.
+            The prior `N microstep(s)` summary was redundant: every
+            `:always` microstep is itself a first-class cascade row in the
+            same mini-pipeline (post akvfe/2hj0h), so the count tallied
+            rows already present; at N=0 (the common case) it was noise.
+            The headline `<before> → <after>` verb is the whole story."
+    ;; N>0 — the microstep rows themselves carry the signal; no count chip.
+    (is (nil? (fmt/cascade-outcome-label {:kind :transition :microsteps 3})))
+    (is (nil? (fmt/cascade-outcome-label {:kind :transition :microsteps 1})))
+    ;; N=0 — the common (no `:always` follow-up) macrostep; never noisy.
+    (is (nil? (fmt/cascade-outcome-label {:kind :transition :microsteps 0})))
+    (is (nil? (fmt/cascade-outcome-label {:kind :transition})))))
 
 ;; ---- FLOW ---------------------------------------------------------------
 


### PR DESCRIPTION
## What

In the Xray Epoch EVENT HANDLER machine-cascade mini-pipeline, the TRANSITION row carried a trailing `N microstep(s)` outcome summary after the `<before> → <after>` verb (e.g. `:closed → :open · 0 microsteps`). This removes that summary affordance.

## Why

The count was redundant at every N:
- **N>0** — each `:always` microstep is itself a FIRST-CLASS cascade row in this same mini-pipeline (its own `:rf.machine/transition` + nested exit/action/entry rows, post akvfe/2hj0h). The count merely tallied rows already present.
- **N=0** (the common case — most transitions have no `:always` follow-ups) — pure noise.

**Guard confirmed:** the microstep steps DO surface as their own visible rows in the mini-pipeline when N>0 (the `machine-cascade-rows` per-emit stream harvests each `:always` microstep's `:rf.machine/transition` + action traces as their own `cascade-row`s). The quiz `answer → pass` cascade is the N>0 example; the harness test pins it. No signal is lost by dropping the count.

## Scope

- `view.cljs` — the `:transition` branch no longer passes `outcome-lbl` to the right-aligned outcome chip (now `nil`). The verb, logical-state delta body, duration chip, and the microstep rows themselves are untouched.
- `format.cljc` — drop the now-dead `:transition` branch of `cascade-outcome-label` (+ the `:microsteps` destructure).
- `projection.cljc` keeps the `:microsteps` data slot (legacy pure-data convenience for pre-cascade-redesign fixtures, per the `machine-cascade-rows` slot contract); only the RENDERED summary is removed.
- `badge.cljc` / `spec/021-Dynamic-Panel-Designs.md` / docstrings — updated to reflect the removal.

## Tests

- `cascade-outcome-label-test` now asserts `:transition` → `nil` at N=0/1/3 (was `"N microstep(s)"`).
- `machine_epochs_harness` quiz tests assert the TRANSITION row renders **no** summary (`(nil? (fmt/cascade-outcome-label tx))`) while the microstep is still surfaced as its own cascade row (N>0) — the signal the dropped count summarised.

## Gates (cold)

- xray JVM `clojure -M:test` — 1095 tests, 0 failures
- `npm run test:cljs` — 5473 tests, 0 failures
- `npx shadow-cljs compile :examples/machine-epochs` — 0 warnings
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures

Closes rf2-cdgva.