### PR TITLE
feat(xray/epoch): render machine no-op as [TRANSITION] [NO OP] (rf2-yueoa)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1515,24 +1515,43 @@ start is a pure init-kick that never reaches the no-op site as a trigger),
 so this row never stands in for a machine's birth. It ranks WITH the
 `:transition` slot (it stands
 in for "the state change that did not happen") and renders, collapsed to
-the **CONSEQUENCE only** (rf2-iu3no): a muted (`:text-tertiary`) **`NO OP`**
-kind pill as the SOLE marker, plus the verb **`staying in {state}`** — the
-machine matched no transition, so its state is unchanged. The earlier
-rf2-ugdas sentence (`no-op — <machine> received <event> in <state>, no
-transition`) stacked the pill + a `no-op —` prefix + an event echo + a
-`, no transition` suffix — four restatements of one fact; it is collapsed
-away. The focused-epoch **Event header already names the event**, so the
-verb does not echo it; the cascade is a SINGLE muted row, so its `1..N`
-left-rail step ordinal is **suppressed** (it read as an unexplained
-leading "1"); and the row carries **NO outcome chip** (the prior `ignored`
-chip was a third restatement). The **machine name is kept ONLY when >1
-machine is in play this epoch** (a broadcast event hitting parallel regions
-/ sibling machines) so the operator can tell WHICH machine stood pat —
-`machine-cascade-rows` stamps `:show-machine-name?` on the no-op row when
-the cascade spans more than one distinct `:machine-id`; the single-machine
-case drops it (the EVENT HANDLER section names the lone machine above), so
-the multi-machine render reads `[NO OP] :hvac/controller staying in
-{state}`. This is explicitly NOT the red exception card and NOT pink.
+the **CONSEQUENCE only** (rf2-iu3no), as **`[TRANSITION] [NO OP] staying in
+{state}`** (rf2-yueoa). A no-op is still the **TRANSITION step** of the
+cascade — a transition was ATTEMPTED (the door's `:may-close?` guard failed,
+or the event matched no transition); it just produced no state change — so
+the row carries the **SAME filled magenta `[TRANSITION]` badge a real
+transition row uses** (`cascade-kind-pill :transition` — identical chrome +
+hue + testid `rf-xray-epoch-machine-cascade-kind-transition`), then a
+**`[NO OP]` QUALIFIER** chip that marks "this transition step resulted in no
+state change", then the verb **`staying in {state}`** — the machine matched
+no transition, so its state is unchanged. The qualifier is an OUTLINED muted
+(`:text-tertiary`) chip — a refinement on the solid badge beside it, not a
+second filled kind pill — reusing the `badge/cascade-kind-label :no-op`
+string (`NO OP`, space not hyphen — rf2-iu3no) and the same outlined-marker
+grammar skmc7's `[NO-OP]` uses in the Machine tab's focused-event header. It
+carries the testid `rf-xray-epoch-machine-cascade-no-op-qualifier` (distinct
+from a kind pill — it qualifies the transition step, it is NOT the row's
+kind). The earlier rf2-yueoa-predecessor (rf2-iu3no) rendered a BARE `[NO
+OP]` kind pill as the sole marker — but a bare no-op row dropped the
+`[TRANSITION]` reading, making the no-op look like a different KIND of step
+rather than a transition that produced nothing; rf2-yueoa restores the
+`[TRANSITION]` badge so the row reads consistently with a real transition
+(badge first, then the qualifier). The earlier rf2-ugdas sentence (`no-op —
+<machine> received <event> in <state>, no transition`) stacked a pill + a
+`no-op —` prefix + an event echo + a `, no transition` suffix — four
+restatements of one fact; it stays collapsed away. The focused-epoch **Event
+header already names the event**, so the verb does not echo it; the cascade
+is a SINGLE row, so its `1..N` left-rail step ordinal is **suppressed**
+(rf2-iu3no — it read as an unexplained leading "1"); and the row carries
+**NO outcome chip** (the prior `ignored` chip was a third restatement). The
+**machine name is kept ONLY when >1 machine is in play this epoch** (a
+broadcast event hitting parallel regions / sibling machines) so the operator
+can tell WHICH machine stood pat — `machine-cascade-rows` stamps
+`:show-machine-name?` on the no-op row when the cascade spans more than one
+distinct `:machine-id`; the single-machine case drops it (the EVENT HANDLER
+section names the lone machine above), so the multi-machine render reads
+`[TRANSITION] [NO OP] :hvac/controller staying in {state}`. This is
+explicitly NOT the red exception card and NOT pink.
 Because its trace op-type is `:rf.machine`
 (machine-activity, not a severity), the L2 pink-wash / issues-ribbon
 `issue-event?` predicate does not match it, so the event row stays
@@ -1565,10 +1584,17 @@ rather than collapsing to a plain `reg-event-db` handler.
   Suppressed for the single-row `:no-op` notice (rf2-iu3no — the lone
   "1" was unexplained noise).
 - **Kind pill / merged action badge** — colour-coded. For `:guard` /
-  `:transition` / `:timer` / `:no-op` / `:start` it is a single KIND pill
+  `:transition` / `:timer` / `:start` it is a single KIND pill
   (`badge/cascade-kind-label` — see `badge.cljc` for the hue assignments;
-  the `:no-op` pill reads `NO OP` (space, not hyphen — rf2-iu3no); the
-  `:start` pill reads `START` in the `:success` (green) tone, rf2-it4vt).
+  the `:start` pill reads `START` in the `:success` (green) tone, rf2-it4vt).
+  **A `:no-op` row carries the `[TRANSITION]` KIND pill PLUS a `[NO OP]`
+  QUALIFIER** (rf2-yueoa): a no-op is still the transition STEP of the
+  cascade, so it renders the SAME magenta `[TRANSITION]` pill a real
+  transition uses, followed by an OUTLINED muted `[NO OP]` qualifier chip
+  (`cascade-no-op-qualifier`, testid `…-no-op-qualifier`, reusing the
+  `badge/cascade-kind-label :no-op` `NO OP` string — space not hyphen,
+  rf2-iu3no) — reading `[TRANSITION] [NO OP] staying in {state}`, NOT a bare
+  `[NO OP]` row.
   **For `:action` rows the KIND pill + the separate phase chip MERGE into
   ONE descriptive badge** (rf2-2hj0h item 5 — `badge/cascade-action-badge-
   label`): `[EXIT ACTION]` / `[ENTRY ACTION]` / `[TRANSITION ACTION]` /

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -449,6 +449,22 @@
    :line-height    1
    :white-space    "nowrap"})
 
+;; rf2-yueoa — the `[NO OP]` QUALIFIER chip that follows the `[TRANSITION]`
+;; pill on a no-op row. A no-op IS the transition STEP of the cascade (a
+;; transition was attempted; it produced no state change), so the row carries
+;; the SAME filled magenta `[TRANSITION]` pill a real transition uses, and
+;; this qualifier marks "this transition step resulted in NO state change".
+;; It reads as a refinement on the pill — NOT a second filled kind pill — so
+;; it is an OUTLINED muted chip (the same `text-tertiary` tone badge.cljc
+;; assigns `:no-op`, and the same outlined-marker grammar skmc7's `[NO-OP]`
+;; uses in the Machine tab's focused-event header), distinguishing it from
+;; the solid TRANSITION badge beside it.
+(def ^:private cascade-no-op-qualifier-style
+  (assoc cascade-kind-pill-base-style
+         :color      text-tertiary-colour
+         :background "transparent"
+         :border     (str "1px solid " border-default-colour)))
+
 ;; rf2-it4vt — the `[START]` row's CAUSE tag (`explicit` / `lazy` /
 ;; `spawned`). A small outlined chip next to the verb that tells the
 ;; operator HOW the machine came to life. `:lazy` is the ORDERING SMELL
@@ -2711,6 +2727,25 @@
                         :background (badge/cascade-kind-colour kind))}
    (badge/cascade-kind-label kind)])
 
+(defn- cascade-no-op-qualifier
+  "Render the `[NO OP]` QUALIFIER chip for a `:no-op` cascade row (rf2-yueoa).
+  A no-op is still the TRANSITION step of the cascade — a transition was
+  attempted; it just produced no state change — so the row renders the SAME
+  `[TRANSITION]` kind pill a real transition uses (`cascade-kind-pill
+  :transition`) and this qualifier marks the result: `[TRANSITION] [NO OP]
+  staying in {state}`. The label is `badge/cascade-kind-label :no-op` (`NO OP`,
+  space not hyphen — rf2-iu3no) so the qualifier text stays in lockstep with
+  the kind-label table.
+
+  Outlined muted chip (the `:no-op` `:text-tertiary` tone, same outlined-marker
+  grammar skmc7's `[NO-OP]` uses in the Machine tab) so it reads as a
+  refinement on the filled magenta `[TRANSITION]` badge beside it, not a second
+  solid kind pill."
+  []
+  [:span {:data-testid "rf-xray-epoch-machine-cascade-no-op-qualifier"
+          :style cascade-no-op-qualifier-style}
+   (badge/cascade-kind-label :no-op)])
+
 (defn- cascade-row-ordinal
   "Render the row's 1..N step ordinal on the left rail (rf2-u69j7).
   Compact monospace chip — keeps the cascade scannable across many
@@ -3219,9 +3254,19 @@
       ;; every other kind keeps its single kind pill (the state-change
       ;; `:transition` ROW keeps its own `[TRANSITION]` pill — distinct from
       ;; a `TRANSITION ACTION`).
-      (if (= :action kind)
-        (cascade-action-pill phase)
-        (cascade-kind-pill kind))
+      ;;
+      ;; rf2-yueoa — a `:no-op` row is still the TRANSITION step of the cascade
+      ;; (a transition was ATTEMPTED; it just produced no state change), so it
+      ;; renders the SAME filled magenta `[TRANSITION]` pill a real transition
+      ;; uses (`cascade-kind-pill :transition`) PLUS a `[NO OP]` QUALIFIER chip
+      ;; that marks "this transition step resulted in no state change":
+      ;; `[TRANSITION] [NO OP] staying in {state}`. The verb (`staying in
+      ;; {state}`, rf2-iu3no) follows below as before.
+      (cond
+        (= :action kind) (cascade-action-pill phase)
+        (= :no-op kind)  [:<> (cascade-kind-pill :transition)
+                              (cascade-no-op-qualifier)]
+        :else            (cascade-kind-pill kind))
       ;; rf2-2hj0h item 6 + rf2-h710p item B — ` for <state> ` fronts the
       ;; verb on `:action` (the state the action belongs to) AND `:guard`
       ;; rows (the state whose transition the guard gates), reading the

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -1506,15 +1506,19 @@
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-trigger-1"))
           "the redundant echoed `event [...]` line is gone"))))
 
-;; ---- rf2-iu3no — the benign no-op collapses to `[NO OP] staying in {state}` --
+;; ---- rf2-yueoa — the no-op renders `[TRANSITION] [NO OP] staying in {state}` --
+;; (rf2-iu3no established the collapsed verb + dropped ordinal + no outcome
+;; chip; rf2-yueoa adds the `[TRANSITION]` badge in FRONT of a `[NO OP]`
+;; qualifier — a no-op is still the transition STEP of the cascade.)
 
 (deftest machine-handler-cascade-no-op-row-collapses-test
-  (testing "rf2-iu3no — a SINGLE-machine genuine no-op row renders the
-            `NO OP` kind-pill (the SOLE marker) + the verb `staying in
-            {state}`, drops the unexplained leading ordinal '1', and
-            carries NO outcome chip. RED before the fix: a `1` ordinal +
-            a `no-op — … received … no transition` verb + an `ignored`
-            outcome chip — four restatements of one fact."
+  (testing "rf2-yueoa — a SINGLE-machine genuine no-op row renders the SAME
+            `[TRANSITION]` badge a real transition uses, PLUS a `[NO OP]`
+            QUALIFIER chip (NOT a bare NO-OP row), then the verb `staying in
+            {state}`: `[TRANSITION] [NO OP] staying in {state}`. The
+            unexplained leading ordinal '1' stays dropped (rf2-iu3no) and the
+            row carries NO outcome chip. RED before rf2-yueoa: a bare `[NO OP]`
+            kind pill with no `[TRANSITION]` badge."
     (let [step {:step :handler :badge :HANDLER :step-number 3
                 :flavour :reg-machine :event-id :door/main
                 :fx []
@@ -1527,13 +1531,28 @@
           tree (view/render-handler-step step)]
       (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
           "the no-op row renders")
-      ;; The `[NO OP]` pill is the sole marker.
-      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-kind-no-op"))
-          "the NO OP kind-pill is present")
-      (is (string/includes? (text-of tree "rf-xray-epoch-machine-cascade-kind-no-op")
-                            "NO OP")
-          "the pill reads `NO OP` (space, not hyphen)")
-      ;; The stray leading "1" ordinal is SUPPRESSED for the no-op.
+      ;; rf2-yueoa — the `[TRANSITION]` badge renders exactly as a real
+      ;; transition's, using the SAME kind-pill (testid + magenta hue). It is
+      ;; NOT a bare `[NO OP]` kind pill any more.
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-kind-transition"))
+          "the no-op row carries the `[TRANSITION]` badge a real transition uses")
+      (is (= "TRANSITION"
+             (text-of tree "rf-xray-epoch-machine-cascade-kind-transition"))
+          "the badge reads `TRANSITION`")
+      (is (= (badge/cascade-kind-colour :transition)
+             (:background (style-of tree "rf-xray-epoch-machine-cascade-kind-transition")))
+          "the `[TRANSITION]` badge paints the SAME magenta hue a real transition does")
+      ;; rf2-yueoa — the `[NO OP]` QUALIFIER chip follows the badge (a separate
+      ;; testid from a kind pill — it is a qualifier on the transition step,
+      ;; not the row's kind). The old bare `…-kind-no-op` pill is GONE.
+      (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-kind-no-op"))
+          "no bare `[NO OP]` kind pill — the qualifier carries the NO-OP marker now")
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-no-op-qualifier"))
+          "the `[NO OP]` qualifier chip is present")
+      (is (= "NO OP"
+             (text-of tree "rf-xray-epoch-machine-cascade-no-op-qualifier"))
+          "the qualifier reads `NO OP` (space, not hyphen)")
+      ;; The stray leading "1" ordinal is SUPPRESSED for the no-op (rf2-iu3no).
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-ordinal-1"))
           "the unexplained leading '1' ordinal is dropped for the no-op row")
       ;; The verb is the consequence only: `staying in :alarming`.
@@ -1545,7 +1564,7 @@
         (is (not (string/includes? verb "transition")) "no ', no transition' suffix"))
       ;; NO outcome chip — the prior `ignored` chip is gone.
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ignored"))
-          "no `ignored` outcome chip — the pill + verb are the whole notice"))))
+          "no `ignored` outcome chip — the badge + qualifier + verb are the whole notice"))))
 
 (deftest machine-handler-cascade-multi-machine-no-op-keeps-name-test
   (testing "rf2-iu3no — when >1 machine is in play (broadcast / parallel


### PR DESCRIPTION
## What

In the Xray Epoch **EVENT HANDLER** machine-cascade mini-pipeline, a machine no-op (guard-blocked / unhandled / no state change — e.g. the door's `:may-close?` guard fails, the machine stays in `:open`) previously rendered as a bare `[NO OP]` kind pill + `staying in {state}`.

A no-op is still the **TRANSITION step** of the cascade — a transition was *attempted*; it just produced no state change. So render it with the **same magenta `[TRANSITION]` badge a real transition uses**, PLUS a `[NO OP]` **qualifier**:

```
[TRANSITION] [NO OP] staying in :open
```

instead of the old bare:

```
[NO OP] staying in :open
```

## How it reads vs. the old bare row

- **Old:** a bare `[NO OP]` kind pill — the no-op looked like a *different kind of step* rather than a transition that produced nothing.
- **New:** the `[TRANSITION]` badge renders exactly as a real transition's (same `cascade-kind-pill :transition`, same magenta hue, same `…-kind-transition` testid), followed by a `[NO OP]` qualifier marking "this transition step resulted in no state change", then `staying in {state}`. The badge-first reading is consistent with a real transition row.

The qualifier is an **outlined muted** (`:text-tertiary`) chip — a refinement on the solid badge beside it, not a second filled kind pill — reusing `badge/cascade-kind-label :no-op` (`NO OP`, space not hyphen — rf2-iu3no) and the same outlined-marker grammar skmc7's `[NO-OP]` uses in the Machine tab's focused-event header. New testid `rf-xray-epoch-machine-cascade-no-op-qualifier`.

Consistent with the EVENT HANDLER badge grammar (akvfe / 2hj0h / h710p) and skmc7's `[NO-OP]` Machine-tab treatment.

## Scope
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` — the no-op header render + qualifier chip/style.
- `tools/xray/test/.../epoch/view_cljs_test.cljs` — assertion: a no-op row renders the `[TRANSITION]` badge (same hue + testid a real transition uses) + a `[NO OP]` qualifier, NOT a bare `[NO OP]` kind pill.
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — normative description updated.

Branched off post-cdgva `origin/main` (PR #2910 merged); the epoch panel was otherwise quiet.

## Gates (cold)
- xray JVM `clojure -M:test` — **1095 tests, 0 failures**
- `npm run test:cljs` — **5473 tests, 0 failures** (includes the new assertion)
- `npx shadow-cljs compile :examples/machine-epochs` — **0 warnings**
- `npm run test:xray-feature-gate` — **EXIT=0**, 16 scenarios, 0 failures, 13 matrix rows

**Visual sign-off is Mike's.**

Closes rf2-yueoa.