### PR TITLE
refactor(xray/testbeds): clean up runner.core step driver (rf2-09kye)

### DIFF
--- a/tools/xray/testbeds/runner/core.cljs
+++ b/tools/xray/testbeds/runner/core.cljs
@@ -1,12 +1,11 @@
 (ns runner.core
-  "SHARED step-driver RUNNER for Xray testbeds (rf2-5sjbg — the app-db /
-  events / subs rewrite of the rf2-8pbjr pilot). A reusable harness an
+  "SHARED step-driver RUNNER for Xray testbeds. A reusable harness an
   Xray testbed mounts to drive a series of INTERESTING events through ONE
   button while an operator watches how the Xray panels (Epoch · Machine
   Inspector · edn-inspector · Trace · …) render each step, with per-step
   commentary on WHAT TO LOOK FOR.
 
-  ## The shape — a proper re-frame2 step driver (rf2-5sjbg)
+  ## The shape — a proper re-frame2 step driver
 
   The runner is NOT a harness around a Reagent atom. It is an ordinary
   re-frame2 app surface: the cursor lives in **app-db** (`:step`), it is
@@ -17,20 +16,17 @@
   - **`:step` lives in app-db.** A deck's app-db carries a top-level
     `:step` slot — the index of the LAST-RUN step (or nil before the
     first step). `:step` changing every step IS the per-step app-db delta
-    the panels show, so it doubles as the deck's per-step counter (it
-    REPLACES the old `:baseline` counter and the old runner-atom cursor —
-    they were the same thing, 'which step are we on'). The cursor in
-    app-db is legitimate deck state, observable in Xray's App-db panel,
-    not pollution.
+    the panels show, so it doubles as the deck's per-step counter ('which
+    step are we on'). The cursor in app-db is legitimate deck state,
+    observable in Xray's App-db panel, not pollution.
 
   - **`[:run-step n]` is an event.** A deck registers its own run-step
     event with `reg-runner!`; the handler `assoc`s `:step = n` into app-db
-    AND fans out the step's `:event`(s) as `:fx :dispatch`es into the
-    deck's host-frame. For a single-event step that is one child dispatch;
-    a deck whose step `:event` is itself a fan-out driver (e.g.
-    `:machine-epochs/send` dispatching several machine events) cascades
-    naturally. The same `assoc :step` delta + the dispatched event(s) are
-    one cascade under the run-step epoch.
+    AND dispatches the step's `:event` into the deck's host-frame. Each
+    step carries exactly one `:event`; a deck whose step `:event` is itself
+    a fan-out driver (e.g. `:machine-epochs/send` dispatching several
+    machine events) cascades naturally. The `assoc :step` delta + the
+    dispatched event are one cascade under the run-step epoch.
 
   - **`:rf.runner/step` is a subscription.** The shared `:rf.runner/step`
     sub reads `:step` from the current frame's app-db. It drives the row
@@ -65,15 +61,14 @@
     `dispatch`; it is NOT threaded down to any leaf row (the leaf gets a
     bound 0-arg thunk).
 
-  ## Why a shared ns (the rollout vehicle)
+  ## Why a shared ns
 
   This namespace is the reference RUNNER all six numbered-button decks
   consume — standard_epochs, routes_epochs, machine_epochs, edn_inspector,
   managed_http, and (via standard-epochs mounted twice) two_frame_isolation.
   The shared dependency makes the app-db/events/subs API atomic by
   construction: every deck adopts it together. A deck supplies its own
-  step vector + prefix + host-frame via `reg-runner!` and drops its bespoke
-  ladder driver.
+  step vector + prefix + host-frame via `reg-runner!`.
 
   ## Boundaries (bundle isolation)
 
@@ -93,22 +88,13 @@
   [{:keys [label event]}]
   (or label (pr-str (first event))))
 
-(defn- step-events
-  "The machine/app event(s) a step dispatches. A step carries a single
-  `:event` (one event vector); the run-step handler fans it out as one
-  child `:dispatch`. Returns a one-element seq so the handler's fan-out is
-  uniform (a step that itself drives several machines does so via its OWN
-  event-fx, e.g. `:machine-epochs/send`)."
-  [{:keys [event]}]
-  (when event [event]))
-
 ;; ============================================================================
 ;; THE STEP DRIVER — app-db `:step`, a run-step event, a step sub
 ;; ============================================================================
 ;;
 ;; `:step` is a TOP-LEVEL app-db slot: the index of the last-run step (or
-;; nil before the first step). The run-step event `assoc`s it and fans out
-;; the step's event(s) into `host-frame`. The `:rf.runner/step` sub reads
+;; nil before the first step). The run-step event `assoc`s it and dispatches
+;; the step's `:event` into `host-frame`. The `:rf.runner/step` sub reads
 ;; it back to drive the highlight + counter. Nothing here is a Reagent atom
 ;; or a timer.
 
@@ -125,25 +111,28 @@
   The registered `event-fx` handler, on `[:run-step n]`:
     - `assoc`s `:step = n` into the deck's app-db (the per-step delta the
       panels show), and
-    - fans out step n's `:event`(s) as `:fx :dispatch`es targeting
-      `host-frame`, so each step's machine/app event lands on the inspected
+    - dispatches step n's `:event` as one `:fx :dispatch` targeting
+      `host-frame`, so the step's machine/app event lands on the inspected
       frame in the same cascade as the `:step` write.
 
-  An out-of-range `n` is a no-op (no `:step` write, no dispatch). A deck
-  calls this once at load (the same place it `def`s its steps), then mounts
+  Every step MUST carry an `:event` (asserted) — a step is exactly one
+  event to drive into the frame. An out-of-range `n` is a no-op (no `:step`
+  write, no dispatch). A deck calls this once at load (the same place it
+  `def`s its steps), then mounts
   `[runner/runner {:run-step-event :<deck>/run-step :steps steps :prefix
   \"<deck>\" :host-frame <frame>}]`."
   [{:keys [id steps host-frame]}]
   (rf/reg-event-fx id
-    {:doc "Step driver (rf2-5sjbg): set app-db :step = n and fan out step
-           n's event(s) into the deck's host-frame. The runner's Step button
-           dispatches [<this> (inc current)]; each per-row RUN button
-           dispatches [<this> n]."}
+    {:doc "Step driver: set app-db :step = n and dispatch step n's :event
+           into the deck's host-frame. The runner's Step button dispatches
+           [<this> (inc current)]; each per-row RUN button dispatches
+           [<this> n]."}
     (fn run-step-handler [{:keys [db]} [_ n]]
       (if (and (integer? n) (<= 0 n) (< n (count steps)))
-        {:db (assoc db :step n)
-         :fx (mapv (fn [ev] [:dispatch ev {:frame host-frame}])
-                   (step-events (nth steps n)))}
+        (let [event (:event (nth steps n))]
+          (assert event (str "runner step " n " has no :event"))
+          {:db (assoc db :step n)
+           :fx [[:dispatch event {:frame host-frame}]]})
         {:db db}))))
 
 ;; ============================================================================
@@ -177,39 +166,47 @@
            " / " total)]]))
 
 (reg-view step-row
-  "One step row: its index, label, and `:watch` commentary. The current
-  step (the one whose epoch is focused — the last one run) is highlighted;
-  `current?` is true for exactly that row (none before the first step).
-  Carries a stable per-step `data-testid` (`<prefix>-step-<n>`).
+  "One step row: its index, label, and `:watch` commentary. The row
+  subscribes to `:rf.runner/step` ITSELF and derives `current?` / `done?`
+  from its own static `n`, so only the previously-current and newly-current
+  rows re-render when the cursor moves — the ladder demonstrates the clean
+  per-row reactivity these decks exist to show. The current step (the one
+  whose epoch is focused — the last one run) is highlighted; `current?` is
+  true for exactly that row (none before the first step). Carries a stable
+  per-step `data-testid` (`<prefix>-step-<n>`).
 
   The index is a clickable RUN-THIS-STEP button (`<prefix>-step-<n>-run`)
   that drives exactly this step by invoking the bound `on-run` thunk
   (`#(dispatch [run-step-event n] {:frame host-frame})`, random-access). The
-  leaf carries ONLY what it renders — its own `step` / `n` / `current?` /
-  `done?` plus that bound action — NOT the steps vector, an atom, or the
-  host-frame id (none of which a leaf view should know)."
-  [prefix n step current? done? on-run]
-  [:div {:data-testid (str prefix "-step-" n)
-         :style {:display "grid" :grid-template-columns "auto 1fr"
-                 :gap "0.75em" :align-items "baseline" :margin "0.25em 0"
-                 :padding "0.4em 0.6em" :border-radius "6px"
-                 :border (if current? "1px solid #7C5CFF" "1px solid #eee")
-                 :background (cond current? "#f1ecff" done? "#fafafa" :else "#fff")}}
-   [:button {:data-testid (str prefix "-step-" n "-run")
-             :title "Run this step"
-             :on-click #(on-run)
-             :style {:font-weight "bold" :cursor "pointer"
-                     :padding "0.1em 0.45em" :border-radius "5px"
-                     :border (if current? "1px solid #7C5CFF" "1px solid #e3def9")
-                     :background (if current? "#7C5CFF" "#fff")
-                     :color (cond current? "#fff" done? "#aaa" :else "#7C5CFF")}}
-    (str (inc n) ".")]
-   [:div
-    [:div {:style {:font-weight "600" :color "#333"}}
-     (step-label step)]
-    [:div {:data-testid (str prefix "-step-" n "-watch")
-           :style {:color "#666" :font-size "12px" :margin-top "0.15em"}}
-     "Watch: " (:watch step)]]])
+  thunk is static per row (its `n` and `host-frame` never change), so the
+  parent builds it once. The leaf carries ONLY what it renders — its own
+  `step` / `n` plus that bound action — NOT the cursor, the steps vector,
+  an atom, or the host-frame id (none of which a leaf view should know)."
+  [prefix n step on-run]
+  (let [current  @(subscribe [:rf.runner/step])
+        current? (= n current)
+        done?    (and (some? current) (< n current))]
+    [:div {:data-testid (str prefix "-step-" n)
+           :style {:display "grid" :grid-template-columns "auto 1fr"
+                   :gap "0.75em" :align-items "baseline" :margin "0.25em 0"
+                   :padding "0.4em 0.6em" :border-radius "6px"
+                   :border (if current? "1px solid #7C5CFF" "1px solid #eee")
+                   :background (cond current? "#f1ecff" done? "#fafafa" :else "#fff")}}
+     [:button {:data-testid (str prefix "-step-" n "-run")
+               :title "Run this step"
+               :on-click #(on-run)
+               :style {:font-weight "bold" :cursor "pointer"
+                       :padding "0.1em 0.45em" :border-radius "5px"
+                       :border (if current? "1px solid #7C5CFF" "1px solid #e3def9")
+                       :background (if current? "#7C5CFF" "#fff")
+                       :color (cond current? "#fff" done? "#aaa" :else "#7C5CFF")}}
+      (str (inc n) ".")]
+     [:div
+      [:div {:style {:font-weight "600" :color "#333"}}
+       (step-label step)]
+      [:div {:data-testid (str prefix "-step-" n "-watch")
+             :style {:color "#666" :font-size "12px" :margin-top "0.15em"}}
+       "Watch: " (:watch step)]]]))
 
 (reg-view runner
   "The full runner surface: the control bar + the step list. A testbed
@@ -223,18 +220,19 @@
   The HIGHLIGHT + status counter render off the `:rf.runner/step` sub (the
   current frame's app-db `:step`). The per-row RUN buttons + the Step button
   dispatch the deck's run-step event into `host-frame`. No atom, no steps /
-  host-frame threaded to any leaf — each row gets a bound 0-arg thunk."
+  host-frame threaded to any leaf — each row gets a bound 0-arg thunk.
+
+  The parent does NOT deref the cursor: each `step-row` subscribes to
+  `:rf.runner/step` itself, so a cursor move re-renders only the two
+  affected rows rather than rebuilding the whole ladder. Every arg the
+  parent passes a row is static (its `n` / `step` / bound thunk)."
   [{:keys [run-step-event steps prefix host-frame]}]
-  (let [current @(subscribe [:rf.runner/step])
-        total   (count steps)]
-    [:div {:data-testid (str prefix "-runner")}
-     [runner-controls prefix run-step-event total host-frame]
-     [:div {:data-testid (str prefix "-steps")}
-      (map-indexed
-        (fn [n s]
-          ^{:key n}
-          [step-row prefix n s
-           (= n current)
-           (and (some? current) (< n current))
-           #(rf/dispatch [run-step-event n] {:frame host-frame})])
-        steps)]]))
+  [:div {:data-testid (str prefix "-runner")}
+   [runner-controls prefix run-step-event (count steps) host-frame]
+   [:div {:data-testid (str prefix "-steps")}
+    (map-indexed
+      (fn [n s]
+        ^{:key n}
+        [step-row prefix n s
+         #(rf/dispatch [run-step-event n] {:frame host-frame})])
+      steps)]])


### PR DESCRIPTION
Cleans up the shared Xray testbed runner (`tools/xray/testbeds/runner/core.cljs`) per rf2-09kye. One file, parallel-safe; the testbed decks are untouched.

## Changes

- **ITEM 1 (ELEGANCE) — inline the vestigial fan-out.** Deleted `step-events` (it wrapped a step's single `:event` in a one-element seq so the handler could `mapv` over it — generality the data model never had). The `run-step` handler now dispatches the step's `:event` inline as one `[:dispatch ev {:frame host-frame}]`. `step-label` kept.
- **ITEM 2 (CORRECTNESS) — explicit `:event` contract.** An in-range step now asserts it carries an `:event` (`(assert event "runner step N has no :event")`). The out-of-range branch is still a clean no-op. Every deck already supplies exactly one `:event` per step, so this enforces the existing shape.
- **ITEM 3 (IDIOM) — per-row reactivity.** `step-row` now subscribes to `:rf.runner/step` itself and derives `current?` / `done?` from its static `n`. The parent `runner` no longer derefs the cursor, so a cursor move re-renders only the previously-current and newly-current rows instead of rebuilding the whole ladder. Each row's `on-run` thunk is static (just `n` + `host-frame`) and built once.
- **ITEM 4 (CLARITY) — trim header.** Dropped the backward-looking bead-migration narration (bead ids, REPLACES-`:baseline` comparisons, pre-rewrite before-states). Kept the forward-looking coverage map (the six decks) and the per-step what-to-look-for framing.

## Spec

`tools/xray/spec/*` unchanged. The only spec references to the runner (003-Machine-Inspector.md, 021-Dynamic-Panel-Designs.md) are high-level prose describing the runner shape (cursor in app-db, `[:run-step n]` event) — untouched by this internal cleanup. This is a testbed surface, not an xray feature contract.

## Lane discipline

No deck edited. The tightened `:event` contract required **no** deck change — all six decks already supply one `:event` per step (verified across standard_epochs / routes_epochs / managed_http / machine_epochs / edn_inspector). No deck-contract FLAG.

## Gates (cold)

- `npx shadow-cljs compile :examples/machine-epochs` — Build completed, **0 warnings**.
- `npm run test:cljs` — **5477 tests, 19066 assertions, 0 failures, 0 errors**.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures**, 13 matrix rows; EXIT=0. All runner-driven decks (incl. two-frame isolation) ladder correctly.

Closes rf2-09kye.
