### PR TITLE
fix(pair-mcp): retry nREPL discovery instead of replaying a sticky error (rf2-r6yly)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -104,17 +104,49 @@
        :port           <int | nil>         ;; the port last seen
        :conn           <atom | nil>        ;; the persistent nREPL conn
        :discovered?    <bool>              ;; have we run discovery yet?
-       :discovery-error <ex-info | nil>}   ;; sticky error from prior attempt
+       :discovery-error <ex-info | nil>}   ;; LAST failure, diagnostic only
 
   Resetting `:discovered? false` triggers a full re-discovery on the
   next tool call — used by the operator-initiated re-attach branch
-  (deferred to a follow-up bead)."
+  (deferred to a follow-up bead).
+
+  `:discovery-error` records the most recent failed-discovery rejection
+  for diagnostics; it does NOT gate (rf2-r6yly). While `:discovered?` is
+  false, every tool call re-runs the cascade, so a recoverable failure
+  (shadow not up at the first call) self-heals on a later call once the
+  operator starts the build."
   (atom {:project-home    nil
          :port-file       nil
          :port            nil
          :conn            nil
          :discovered?     false
          :discovery-error nil}))
+
+(defn session-state-snapshot
+  "Deref the private `session-state` for tests — read-only window onto
+  the resolved-endpoint cache (rf2-r6yly retry regression)."
+  []
+  @session-state)
+
+(defn reset-session-state-for-tests!
+  "Reset `session-state` to the pristine pre-discovery shape. Exposed for
+  tests so the lazy-discovery retry contract can be exercised from a
+  known slate (rf2-r6yly)."
+  []
+  (reset! session-state {:project-home    nil
+                         :port-file       nil
+                         :port            nil
+                         :conn            nil
+                         :discovered?     false
+                         :discovery-error nil}))
+
+(defn mark-discovered-for-tests!
+  "Stand in for `discover-and-cache!`'s success side effect — record a
+  resolved conn (no port-file, so the per-call re-read fast-path returns
+  it verbatim) and flip `:discovered?`. Exposed so a stub discovery thunk
+  can mimic a successful attach without the npm SDK (rf2-r6yly)."
+  [conn]
+  (swap! session-state assoc :conn conn :discovered? true :discovery-error nil))
 
 ;; The Server instance is captured here when `build-server` returns it,
 ;; so the discovery flow can reach `listRoots()` and `elicitInput()`
@@ -266,7 +298,7 @@
                                :reason   port-not-found-hint
                                :hint     port-not-found-hint}))))))))
 
-(defn- ensure-connection!
+(defn ensure-connection!
   "Lazy-discovery entry: called before every tool dispatch. Three paths:
 
   1. First call (or after invalidation) — runs `discover-and-cache!`.
@@ -286,18 +318,41 @@
   a transient socket hiccup — so this layer (which actually observes the
   port change) owns the invalidation, alongside operator `close!`.
 
-  Returns a Promise resolving to the live conn atom, or rejecting with
-  the cached/structured discovery error."
-  [launch-flags]
-  (let [{:keys [discovered? discovery-error port-file port conn]} @session-state]
-    (cond
-      (and (not discovered?) (some? discovery-error))
-      (js/Promise.reject discovery-error)
+  ## Discovery failure is RETRIED, never sticky (rf2-r6yly)
 
+  A failed discovery (`discover-and-cache!` rejected: no nREPL port yet,
+  shadow not started, ambiguous-and-declined) leaves `:discovered? false`
+  and records `:discovery-error` for diagnostics — but it does NOT wedge
+  the session. Each subsequent tool call RE-RUNS the cascade. The earlier
+  shape short-circuited on a cached `:discovery-error`, so once discovery
+  failed once (e.g. a tool call landed before `shadow-cljs watch` was up)
+  EVERY later call replayed the stale rejection forever — the operator
+  had to restart the whole MCP server even after starting shadow, because
+  nothing ever re-attempted. The cascade is bounded (sync env/flag steps;
+  the async roots/HTTP probes cap at `shadow-discovery/probe-timeout-ms`),
+  so re-running it per call on the failure path is cheap and is the only
+  thing that lets a session self-heal when the operator fixes the
+  underlying cause. `:discovery-error` is kept purely as a diagnostic
+  breadcrumb of the LAST failure; it no longer gates.
+
+  Returns a Promise resolving to the live conn atom, or rejecting with a
+  fresh structured discovery error when the cascade still can't resolve.
+
+  The 2-arity injects the discovery thunk so the retry contract can be
+  unit-tested without the npm SDK / a live shadow (rf2-r6yly); production
+  uses the 1-arity, which threads in `discover-and-cache!`."
+  ([launch-flags] (ensure-connection! launch-flags discover-and-cache!))
+  ([launch-flags discover-fn]
+  (let [{:keys [discovered? port-file port conn]} @session-state]
+    (cond
       (not discovered?)
-      (-> (discover-and-cache! launch-flags)
+      (-> (discover-fn launch-flags)
           (.then (fn [_] (:conn @session-state)))
           (.catch (fn [e]
+                    ;; Record the last failure for diagnostics only — the
+                    ;; next tool call re-runs discovery (rf2-r6yly); a
+                    ;; recoverable failure (shadow not up yet) must not
+                    ;; permanently wedge the session.
                     (swap! session-state assoc :discovery-error e)
                     (js/Promise.reject e))))
 
@@ -310,7 +365,7 @@
               (nrepl/close! conn)
               (swap! session-state assoc :discovered? false :conn nil
                      :discovery-error nil)
-              (ensure-connection! launch-flags))
+              (ensure-connection! launch-flags discover-fn))
 
           ;; Port changed — shadow restarted on a new ephemeral port.
           (and current-port (not= current-port port))
@@ -322,7 +377,7 @@
 
           ;; Same port (or env/cwd path without project-home) — fast path.
           :else
-          (js/Promise.resolve conn))))))
+          (js/Promise.resolve conn)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; MCP request handlers.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_retry_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_retry_test.cljs
@@ -1,0 +1,88 @@
+(ns re-frame2-pair-mcp.ensure-connection-retry-test
+  "Regression for the sticky-discovery-error wedge (rf2-r6yly).
+
+  THE BUG: `server/ensure-connection!` short-circuited on a cached
+  `:discovery-error`. Once discovery failed ONCE — e.g. a tool call
+  landed before `shadow-cljs watch` was up — EVERY later call replayed
+  the stale rejection forever, with no path to re-attempt. The operator
+  had to restart the whole MCP server even after starting shadow.
+
+  THE FIX: discovery failure records `:discovery-error` for diagnostics
+  ONLY; while `:discovered?` is false, each tool call RE-RUNS the
+  cascade. A recoverable failure (shadow not up at the first call) now
+  self-heals on a later call once the operator starts the build.
+
+  The 2-arity `ensure-connection!` injects the discovery thunk so the
+  retry contract is unit-testable without the npm SDK / a live shadow."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.server :as server]))
+
+(use-fixtures :each
+  {:before (fn [] (server/reset-session-state-for-tests!))
+   :after  (fn [] (server/reset-session-state-for-tests!))})
+
+(deftest discovery-failure-is-retried-not-sticky
+  (testing "a failed discovery does NOT wedge the session — the next call re-attempts and can succeed"
+    (async done
+      (let [calls (atom 0)
+            err   (ex-info ":rf.error/pair-mcp-nrepl-port-not-found"
+                           {:rf.error/id :rf.error/pair-mcp-nrepl-port-not-found})
+            conn  (nrepl/make-conn 6001 "127.0.0.1")
+            ;; First invocation rejects (shadow not up yet); the second
+            ;; succeeds (operator started the build) by recording the
+            ;; discovered conn the way the real `discover-and-cache!` does.
+            discover-fn
+            (fn [_launch-flags]
+              (let [n (swap! calls inc)]
+                (if (= n 1)
+                  (js/Promise.reject err)
+                  (do (server/mark-discovered-for-tests! conn)
+                      (js/Promise.resolve :ok)))))]
+        ;; First tool call: discovery fails. `:discovery-error` recorded.
+        (-> (server/ensure-connection! {} discover-fn)
+            (.then (fn [_]
+                     (is false "first call must REJECT (discovery failed)")
+                     (done)))
+            (.catch
+             (fn [e1]
+               (is (= err e1) "first failure surfaces the structured discovery error")
+               (is (some? (:discovery-error (server/session-state-snapshot)))
+                   "the failure is recorded for diagnostics")
+               (is (false? (:discovered? (server/session-state-snapshot)))
+                   "still not discovered — the session is not wedged")
+               ;; Second tool call: the OLD code replayed the cached error
+               ;; here without re-invoking discovery. The fix re-runs it,
+               ;; so this attempt reaches the (now-succeeding) thunk.
+               (-> (server/ensure-connection! {} discover-fn)
+                   (.then (fn [resolved-conn]
+                            (is (= 2 @calls)
+                                "discovery was RE-INVOKED on the retry (not short-circuited)")
+                            (is (= conn resolved-conn)
+                                "the retry resolves to the freshly-discovered conn")
+                            (is (true? (:discovered? (server/session-state-snapshot)))
+                                "the session is now attached")
+                            (done)))
+                   (.catch (fn [_e2]
+                             (is false "the retry must SUCCEED once discovery recovers")
+                             (done)))))))))))
+
+(deftest repeated-failures-keep-resurfacing-fresh-errors
+  (testing "while discovery keeps failing, each call re-runs it and surfaces a fresh rejection (no permanent wedge)"
+    (async done
+      (let [calls (atom 0)
+            err   (ex-info ":rf.error/pair-mcp-nrepl-port-not-found"
+                           {:rf.error/id :rf.error/pair-mcp-nrepl-port-not-found})
+            discover-fn (fn [_launch-flags]
+                          (swap! calls inc)
+                          (js/Promise.reject err))]
+        (-> (server/ensure-connection! {} discover-fn)
+            (.catch (fn [_e1]
+                      (is (= 1 @calls))
+                      ;; A second call must ALSO re-invoke discovery rather
+                      ;; than replaying the cached error without trying.
+                      (-> (server/ensure-connection! {} discover-fn)
+                          (.catch (fn [_e2]
+                                    (is (= 2 @calls)
+                                        "the second failing call re-ran discovery (not a cached replay)")
+                                    (done)))))))))))


### PR DESCRIPTION
## What

Correctness review of `tools/re-frame2-pair-mcp` (bead **rf2-r6yly**). One clear defect found and fixed; the rest of the slice came back clean.

### Defect: discovery failure permanently wedged the session

`server/ensure-connection!` short-circuited on a cached `:discovery-error`:

```clojure
(and (not discovered?) (some? discovery-error))
(js/Promise.reject discovery-error)
```

Once discovery failed **once** — e.g. a tool call landed before `shadow-cljs watch` was up, or shadow was briefly down — every later call replayed the stale rejection forever, with **no path to re-attempt**. The operator had to restart the whole MCP server even after starting shadow, because nothing ever re-ran discovery.

This is a recoverable, common failure mode (first tool call racing the dev build coming up) turned into a hard wedge.

### Fix

Drop the sticky-error fast path. While `:discovered?` is false, each tool call re-runs the **bounded** discovery cascade (sync env/flag steps; the async roots/HTTP probes cap at `shadow-discovery/probe-timeout-ms`), so a recoverable failure self-heals on a later call once the operator fixes the underlying cause. `:discovery-error` is retained purely as a diagnostic breadcrumb of the last failure — it no longer gates.

`ensure-connection!` gains a 2-arity injecting the discovery thunk (mirroring the existing `discover-port*` injection-seam convention) so the retry contract is unit-testable without the npm SDK / a live shadow; the production 1-arity threads in `discover-and-cache!`.

### Tests

New `ensure_connection_retry_test.cljs`:
- a failed discovery is **re-invoked** on the next call and can succeed once the operator starts the build (the old code asserted `@calls` stays at 1 — the fix drives it to 2);
- repeated failures keep re-running discovery rather than replaying a cached error.

## Scope

`tools/re-frame2-pair-mcp` only. No spec change (the discovery cascade precedence in `spec/002-nREPL-Transport.md` is unchanged; this is failure-path lifecycle, not the precedence contract). No dedup / functional-style passes (sibling beads). `skills/re-frame2-pair/` untouched.

## Quality gates (cold)

- pair-mcp `shadow-cljs compile server-test` — **green**, 881 tests / 2697 assertions, 0 failures, 0 warnings (was 879; +2 new tests).
- pair-mcp MCP-client conformance (`tools/mcp-conformance` SDK Client driver against the compiled `out/server.js`) — **GREEN**. Notably exercises the degraded `nrepl-port-not-found` path my fix touches: many sequential degraded tool calls each return the correct structured `isError` envelope, confirming the per-call retry is a no-op-regression for the error shape while no longer wedging.

## Other findings (reviewed, not actioned — none are correctness defects)

- `reset-frame-db` / `restore-epoch` surface runtime `:ok? false` soft-failures as `ok-text` (not `isError`), unlike `dispatch`'s `runtime-envelope->result`. This asymmetry is **deliberate** and pinned by existing tests ("soft-failure rides as ok-text, not isError") — a consistency call for a sibling pass, not a correctness bug.
- `subscribe` `:max-ms` timer is never cleared on early termination (fires a guarded no-op `terminate` — benign).
- `cache/args->fingerprint` normalizes only top-level object key order, not nested — a possible missed cache *hit*, never wrong data.
- `freshness/reload-target` has a redundant `(number? port)` branch identical to `(some? port)` (dedup territory).