### PR TITLE
refactor(xray): consolidate static-catalogue empty-state helpers (rf2-trl0t)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -240,28 +240,6 @@
                        :font-style  "italic"}}
          doc])])])
 
-;; ---- empty states --------------------------------------------------------
-
-(defn- empty-state
-  []
-  [:div {:data-testid "rf-xray-static-flows-empty"
-         :style       {:padding     "16px"
-                       :color       (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size   "11px"
-                       :font-style  "italic"}}
-   "No flows registered."])
-
-(defn- empty-filtered
-  [query]
-  [:div {:data-testid "rf-xray-static-flows-empty-filtered"
-         :style       {:padding     "16px"
-                       :color       (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size   "11px"
-                       :font-style  "italic"}}
-   (str "No flows match " (pr-str query) ".")])
-
 ;; ---- root view -----------------------------------------------------------
 
 (rf/reg-view Panel
@@ -285,13 +263,13 @@
      (header)
      (cond
        silent?
-       (empty-state)
+       (search-box/empty-state "rf-xray-static-flows" "flow")
 
        :else
        [:<>
         (search-box query total filtered?)
         (if (empty? flows)
-          (empty-filtered query)
+          (search-box/empty-filtered "rf-xray-static-flows" "flow" query)
           (into [:ul {:data-testid "rf-xray-static-flows-list"
                       :role        "list"
                       :style       {:list-style     "none"

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -195,28 +195,6 @@
                       :font-size   "11px"}}
         doc])]))
 
-;; ---- empty states --------------------------------------------------------
-
-(defn- empty-state
-  []
-  [:div {:data-testid "rf-xray-static-interceptors-empty"
-         :style       {:padding     "16px"
-                       :color       (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size   "11px"
-                       :font-style  "italic"}}
-   "No interceptors registered."])
-
-(defn- empty-filtered
-  [query]
-  [:div {:data-testid "rf-xray-static-interceptors-empty-filtered"
-         :style       {:padding     "16px"
-                       :color       (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size   "11px"
-                       :font-style  "italic"}}
-   (str "No interceptors match " (pr-str query) ".")])
-
 ;; ---- root view -----------------------------------------------------------
 
 (rf/reg-view Panel
@@ -239,13 +217,13 @@
      (header)
      (cond
        silent?
-       (empty-state)
+       (search-box/empty-state "rf-xray-static-interceptors" "interceptor")
 
        :else
        [:<>
         (search-box query total filtered?)
         (if (empty? interceptors)
-          (empty-filtered query)
+          (search-box/empty-filtered "rf-xray-static-interceptors" "interceptor" query)
           (into [:ul {:data-testid "rf-xray-static-interceptors-list"
                       :role        "list"
                       :style       {:list-style     "none"

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
@@ -165,28 +165,6 @@
       {:sim-open?  sim-open?
        :routes-map routes-map}])])
 
-(defn- empty-state
-  "Renders when no routes are registered."
-  []
-  [:div {:data-testid "rf-xray-static-routes-empty"
-         :style       {:padding     "16px"
-                       :color       (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size   "11px"
-                       :font-style  "italic"}}
-   "No routes registered."])
-
-(defn- empty-filtered
-  "Renders when the search query filters out every row."
-  [query]
-  [:div {:data-testid "rf-xray-static-routes-empty-filtered"
-         :style       {:padding     "16px"
-                       :color       (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size   "11px"
-                       :font-style  "italic"}}
-   (str "No routes match " (pr-str query) ".")])
-
 (defn render
   "Top-level renderer for the flat-list area of the Static Routes
   panel. `data` is the projection from
@@ -202,13 +180,13 @@
   ;; component, so it cannot recover the frame itself).
   (cond
     silent?
-    (empty-state)
+    (search-box/empty-state "rf-xray-static-routes" "route")
 
     :else
     [:<>
      (search-box dispatch query total-routes filtered?)
      (if (empty? routes)
-       (empty-filtered query)
+       (search-box/empty-filtered "rf-xray-static-routes" "route" query)
        (into [:ul {:data-testid "rf-xray-static-routes-list"
                    :role        "list"
                    :style       {:list-style     "none"

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -269,28 +269,6 @@
                       :font-size   "11px"}}
         doc])]))
 
-;; ---- empty states --------------------------------------------------------
-
-(defn- empty-state
-  []
-  [:div {:data-testid "rf-xray-static-schemas-empty"
-         :style       {:padding     "16px"
-                       :color       (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size   "11px"
-                       :font-style  "italic"}}
-   "No schemas registered."])
-
-(defn- empty-filtered
-  [query]
-  [:div {:data-testid "rf-xray-static-schemas-empty-filtered"
-         :style       {:padding     "16px"
-                       :color       (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size   "11px"
-                       :font-style  "italic"}}
-   (str "No schemas match " (pr-str query) ".")])
-
 ;; ---- root view -----------------------------------------------------------
 
 (rf/reg-view Panel
@@ -313,13 +291,13 @@
      (header)
      (cond
        silent?
-       (empty-state)
+       (search-box/empty-state "rf-xray-static-schemas" "schema")
 
        :else
        [:<>
         (search-box query total filtered?)
         (if (empty? schemas)
-          (empty-filtered query)
+          (search-box/empty-filtered "rf-xray-static-schemas" "schema" query)
           (into [:ul {:data-testid "rf-xray-static-schemas-list"
                       :role        "list"
                       :style       {:list-style     "none"

--- a/tools/xray/src/day8/re_frame2_xray/static/shared/search_box.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shared/search_box.cljs
@@ -89,6 +89,38 @@
     (= 1 total) (str "1 " noun)
     :else       (str total " " noun "s")))
 
+;; ---- catalogue empty states (Cluster 3) ---------------------------------
+
+(def ^:private empty-state-style
+  "Shared italic-prose style for the catalogue empty / no-match surfaces."
+  {:padding     "16px"
+   :color       (:text-tertiary tokens)
+   :font-family sans-stack
+   :font-size   "11px"
+   :font-style  "italic"})
+
+(defn empty-state
+  "The cold-start empty surface for a flat-catalogue tab: `\"No flows
+  registered.\"` `noun` is the singular form (`\"flow\"` / `\"route\"`
+  / …); the plural appends `\"s\"` — the same convention `count-text`
+  uses (every Static noun pluralises regularly). `testid-prefix` is the
+  tab's `data-testid` stem (e.g. `\"rf-xray-static-flows\"`); the surface
+  suffixes `-empty`. Pure hiccup — no Reagent / UIx / Helix refs."
+  [testid-prefix noun]
+  [:div {:data-testid (str testid-prefix "-empty")
+         :style       empty-state-style}
+   (str "No " noun "s registered.")])
+
+(defn empty-filtered
+  "The no-match surface for a flat-catalogue tab when a query filters
+  every row out: `\"No flows match \\\"foo\\\".\"`. `noun` / `testid-
+  prefix` as in `empty-state` (the surface suffixes `-empty-filtered`).
+  Pure hiccup — no Reagent / UIx / Helix refs."
+  [testid-prefix noun query]
+  [:div {:data-testid (str testid-prefix "-empty-filtered")
+         :style       empty-state-style}
+   (str "No " noun "s match " (pr-str query) ".")])
+
 ;; ---- per-variant style maps ---------------------------------------------
 
 (def ^:private catalogue-container-style


### PR DESCRIPTION
## What

Dedup-review of `tools/xray/src` (rf2-trl0t). The strongest, cleanest duplication in the slice: the four flat-catalogue Static sub-tabs each carried a **byte-identical** private empty-state pair.

| file:line (pre) | `empty-state` | `empty-filtered` |
|---|---|---|
| `static/flows/panel.cljs:245` | "No flows registered." | "No flows match Q." |
| `static/interceptors/panel.cljs:200` | "No interceptors registered." | "No interceptors match Q." |
| `static/schemas/panel.cljs:274` | "No schemas registered." | "No schemas match Q." |
| `static/routes/browse_list.cljs:168` | "No routes registered." | "No routes match Q." |

Each `empty-state`/`empty-filtered` pair shared the **same** `:style` map (`16px` padding · `:text-tertiary` · `sans-stack` · `11px` italic), the same `data-testid` shape (`<prefix>-empty` / `<prefix>-empty-filtered`), and the same copy template — differing only on the `data-testid` prefix and the (regularly-pluralised) noun.

## Change

Folded the eight defns into two shared helpers in `static.shared.search-box` — the ns already documented (rf2-1keg3 / rf2-nesy9) as the home for these catalogue tabs, and already holding the parallel `count-text` pluralisation helper. The new `empty-state` / `empty-filtered` take `testid-prefix` + singular `noun` and reuse the same regular `+s` pluralisation `count-text` applies. Each call-site drops from a ~10-line defn to a one-line call.

Pure presentational hiccup — rendered markup, `data-testid`s, and copy text are preserved verbatim. Behaviour-preserving; net **-56 LoC** (40 insertions, 96 deletions across 5 files).

Scope held to duplication only — no correctness/style rewrites (those are sibling beads). The remaining install-time `set-query`/override event+sub patterns and the `kind-badge`/`meta-badge` near-twins were considered but left: their bodies diverge enough (differing override slot names, badge letter/colour tables) that consolidating them trades clarity for a thin abstraction rather than removing verbatim copy.

## Quality gates (cold)

- xray JVM `clojure -M:test` — **1095 tests / 4563 assertions, 0 failures**
- `npm run test:cljs` — **5477 tests / 19066 assertions, 0 failures** (compiles + exercises all four panels + the shared helper)
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures** (first run flaked on the unrelated `rf-xray-shell` mount-visibility wait — `mounted=true visible=none`, upstream of any static-panel render; clean on re-run)

No spec change — the consolidated helpers are internal presentation; no `tools/xray/spec/*` contract names them.