### PR TITLE
refactor(machines-viz): consolidate slice duplication (rf2-idx41)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -55,6 +55,7 @@
              :as parallel-region-node]
             [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
              :refer [Handle pos-top pos-right pos-bottom pos-left
+                     four-cardinal-handles
                      chart-constants palette-of]]
             [day8.re-frame2-machines-viz.chart.projection :as projection]
             [day8.re-frame2-machines-viz.theme.tokens
@@ -400,16 +401,7 @@
           (when exit
             (action-row {:kind :exit :name-str exit :vc vc :ct ct}))])
        ;; xyflow attachment points (invisible — edges connect here)
-       [:> Handle {:type "target" :position pos-top
-                   :style {:opacity 0}}]
-       [:> Handle {:type "source" :position pos-bottom
-                   :style {:opacity 0}}]
-       [:> Handle {:type "target" :position pos-left
-                   :id "left"
-                   :style {:opacity 0}}]
-       [:> Handle {:type "source" :position pos-right
-                   :id "right"
-                   :style {:opacity 0}}]])))
+       (four-cardinal-handles)])))
 
 ;; ---- compound node ------------------------------------------------------
 
@@ -503,12 +495,7 @@
                       :text-overflow "ellipsis"}}
         label]
        ;; rf2-shv82 — invisible xyflow attachment points.
-       [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]
-       [:> Handle {:type "source" :position pos-bottom :style {:opacity 0}}]
-       [:> Handle {:type "target" :position pos-left   :id "left"
-                   :style {:opacity 0}}]
-       [:> Handle {:type "source" :position pos-right  :id "right"
-                   :style {:opacity 0}}]])))
+       (four-cardinal-handles)])))
 
 ;; ---- initial marker node ------------------------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
@@ -39,8 +39,7 @@
   appear in this ns; all colour goes through `theme/tokens`."
   (:require [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
-             :refer [Handle pos-top pos-right pos-bottom pos-left
-                     chart-constants palette-of]]
+             :refer [four-cardinal-handles chart-constants palette-of]]
             [day8.re-frame2-machines-viz.theme.tokens
              :refer [chart-label-stack]]))
 
@@ -216,9 +215,4 @@
           action])
        ;; xyflow attachment points. Handles on every side so elkjs can
        ;; pick the cleanest anchor based on the routed direction.
-       [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]
-       [:> Handle {:type "target" :position pos-left   :id "left"
-                   :style {:opacity 0}}]
-       [:> Handle {:type "source" :position pos-bottom :style {:opacity 0}}]
-       [:> Handle {:type "source" :position pos-right  :id "right"
-                   :style {:opacity 0}}]])))
+       (four-cardinal-handles)])))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -54,8 +54,7 @@
   consistency."
   (:require [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.nodes.xyflow-node
-             :refer [Handle pos-top pos-right pos-bottom pos-left
-                     chart-constants palette-of]]
+             :refer [four-cardinal-handles chart-constants palette-of]]
             [day8.re-frame2-machines-viz.theme.tokens
              :refer [sans-stack mono-stack]]))
 
@@ -146,9 +145,4 @@
        ;; whose endpoint is a region container has a handle to anchor
        ;; to. Without them xyflow silently drops the edge (same
        ;; mechanic as the compound-node fix).
-       [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]
-       [:> Handle {:type "source" :position pos-bottom :style {:opacity 0}}]
-       [:> Handle {:type "target" :position pos-left   :id "left"
-                   :style {:opacity 0}}]
-       [:> Handle {:type "source" :position pos-right  :id "right"
-                   :style {:opacity 0}}]])))
+       (four-cardinal-handles)])))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/xyflow_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/xyflow_node.cljs
@@ -37,6 +37,33 @@
 (def pos-bottom (.-Bottom Position))
 (def pos-left   (.-Left Position))
 
+;; ---- four-cardinal edge-attachment Handles ------------------------------
+;;
+;; rf2-idx41 — the leaf state, compound container, parallel-region
+;; container, and event nodes all attach edges the SAME way: an invisible
+;; `Handle` on each cardinal side, with the LEFT + TOP as targets and the
+;; RIGHT + BOTTOM as sources (the left/right handles carry the `"left"` /
+;; `"right"` ids the entry-edge `:targetHandle` + the routed sources
+;; address). That four-`Handle` cluster was copy-pasted in each node ns;
+;; this fragment owns it once. Handles are `opacity 0` (xyflow still
+;; measures them for `handleBounds` so an edge has a slot to anchor to —
+;; the rf2-shv82 compound/region drop fix) without adding visible chrome.
+
+(defn four-cardinal-handles
+  "A React fragment of the four invisible cardinal `Handle`s every
+  edge-bearing chart node uses: TOP + LEFT as `target`s (LEFT carries
+  id `\"left\"`), BOTTOM + RIGHT as `source`s (RIGHT carries id
+  `\"right\"`). Spliced into a node component's hiccup as `(four-cardinal-
+  handles)`."
+  []
+  [:<>
+   [:> Handle {:type "target" :position pos-top    :style {:opacity 0}}]
+   [:> Handle {:type "target" :position pos-left   :id "left"
+               :style {:opacity 0}}]
+   [:> Handle {:type "source" :position pos-bottom :style {:opacity 0}}]
+   [:> Handle {:type "source" :position pos-right  :id "right"
+               :style {:opacity 0}}]])
+
 ;; ---- density-resolved constants -----------------------------------------
 
 (defn chart-constants

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
@@ -73,7 +73,9 @@
             [day8.re-frame2-machines-viz.chart.overlays.after-rings-geometry
              :as geo]
             [day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
-             :as anchor]))
+             :as anchor]
+            [day8.re-frame2-machines-viz.chart.overlays.overlay-scaffold
+             :as scaffold]))
 
 ;; ---- DOM measurement ----------------------------------------------------
 
@@ -180,30 +182,12 @@
         remeasure!   (fn []
                        (when-let [root @root-ref]
                          (reset! positioned
-                                 (vec (measure-rings root @latest-specs)))))
-        resize-fn    (fn [_] (remeasure!))]
-    (r/create-class
+                                 (vec (measure-rings root @latest-specs)))))]
+    (scaffold/make-resizing-overlay-class
       {:display-name "MachinesViz.AfterRingsOverlay"
-
-       :component-did-mount
-       (fn [_this]
-         (when (exists? js/window)
-           (.addEventListener js/window "resize" resize-fn))
-         (remeasure!))
-
-       :component-did-update
-       (fn [_this _prev]
-         ;; Props (ring-specs / tick) changed → re-read the DOM. xyflow
-         ;; has already committed its layout by the time React calls
-         ;; did-update, so the node rects are current.
-         (remeasure!))
-
-       :component-will-unmount
-       (fn [_this]
-         (when (exists? js/window)
-           (.removeEventListener js/window "resize" resize-fn)))
-
-       :reagent-render
+       :root-ref     root-ref
+       :remeasure!   remeasure!
+       :render
        (fn [{:keys [ring-specs tick testid on-hover on-leave]
              :or   {testid "rf-mv-chart-after-rings-overlay"}}]
          ;; Keep the latest specs visible to the lifecycle + resize
@@ -212,24 +196,14 @@
          (reset! latest-specs (vec (or ring-specs [])))
          (when (seq ring-specs)
            (let [rings @positioned]
-             [:div {:data-testid testid
-                    :data-ring-count (str (count ring-specs))
-                    :data-tick (when (some? tick) (str tick))
-                    :ref (fn [el]
-                           ;; The overlay's offsetParent is the
-                           ;; position:relative wrapper that ALSO holds
-                           ;; the xyflow chart — query node testids from
-                           ;; there so both share the coordinate origin.
-                           (reset! root-ref
-                                   (when el (.-offsetParent el))))
-                    :style {:position       "absolute"
-                            :top            0
-                            :left           0
-                            :width          "100%"
-                            :height         "100%"
-                            :pointer-events "none"  ;; rings opt back in
-                            :overflow       "visible"
-                            :z-index        3}}
+             ;; rf2-idx41 — the after-rings overlay sits at z-index 3 (one
+             ;; below the card overlays) so the rings tuck under any
+             ;; anchored card; `:pointer-events none` lets clicks fall
+             ;; through to the chart, and individual rings opt back in.
+             [:div (merge (scaffold/overlay-root-props root-ref 3)
+                          {:data-testid     testid
+                           :data-ring-count (str (count ring-specs))
+                           :data-tick       (when (some? tick) (str tick))})
               (into [:svg {:data-testid (str testid "-svg")
                            :data-positioned-count (str (count rings))
                            :width  "100%"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
@@ -39,7 +39,9 @@
   (:require [reagent.core :as r]
             [day8.re-frame2-machines-viz.theme.tokens :as tokens]
             [day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
-             :as anchor]))
+             :as anchor]
+            [day8.re-frame2-machines-viz.chart.overlays.overlay-scaffold
+             :as scaffold]))
 
 ;; ---- DOM measurement ----------------------------------------------------
 ;;
@@ -157,44 +159,21 @@
                        (when-let [spec @latest]
                          (reset! anchored
                                  (anchor/measure-anchor
-                                   anchor/anchor-below root (:node-id spec))))))
-        resize-fn  (fn [_] (remeasure!))]
-    (r/create-class
+                                   anchor/anchor-below root (:node-id spec))))))]
+    (scaffold/make-resizing-overlay-class
       {:display-name "MachinesViz.CancellationCascadeOverlay"
-
-       :component-did-mount
-       (fn [_this]
-         (when (exists? js/window)
-           (.addEventListener js/window "resize" resize-fn))
-         (remeasure!))
-
-       :component-did-update
-       (fn [_this _prev] (remeasure!))
-
-       :component-will-unmount
-       (fn [_this]
-         (when (exists? js/window)
-           (.removeEventListener js/window "resize" resize-fn)))
-
-       :reagent-render
+       :root-ref     root-ref
+       :remeasure!   remeasure!
+       :render
        (fn [{:keys [cascade-spec tick testid]
              :or   {testid "rf-mv-chart-cancellation-cascade-overlay"}}]
          (reset! latest cascade-spec)
          (when (and cascade-spec (:node-id cascade-spec)
                     (seq (:steps cascade-spec)))
            (let [pos @anchored]
-             [:div {:data-testid testid
-                    :data-node-id (:node-id cascade-spec)
-                    :data-tick (when (some? tick) (str tick))
-                    :ref (fn [el]
-                           (reset! root-ref (when el (.-offsetParent el))))
-                    :style {:position       "absolute"
-                            :top            0
-                            :left           0
-                            :width          "100%"
-                            :height         "100%"
-                            :pointer-events "none"
-                            :overflow       "visible"
-                            :z-index        4}}
+             [:div (merge (scaffold/overlay-root-props root-ref)
+                          {:data-testid  testid
+                           :data-node-id (:node-id cascade-spec)
+                           :data-tick    (when (some? tick) (str tick))})
               (when pos
                 (cascade-card (merge cascade-spec pos)))])))})))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_scaffold.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_scaffold.cljs
@@ -1,0 +1,91 @@
+(ns day8.re-frame2-machines-viz.chart.overlays.overlay-scaffold
+  "Shared Reagent form-3 scaffold for the xyflow chart's DOM-measuring
+  overlays (`after-rings`, `spawn-all-join`, `cancellation-cascade`).
+
+  ## Why this exists (rf2-idx41 — dedup)
+
+  Every chart overlay is a Reagent form-3 component with a byte-identical
+  measure-on-mount/update/resize lifecycle and an absolutely-positioned
+  full-bleed root `<div>` that captures its `offsetParent` so the DOM
+  walk shares the chart wrapper's coordinate origin. That scaffold —
+  the `root-ref` atom, the `remeasure!`-on-resize listener, the three
+  `create-class` lifecycle hooks, and the overlay root `<div>` style —
+  was copy-pasted across the three overlay nss. This ns owns it ONCE so
+  each overlay keeps only its measurement strategy + paint.
+
+  CLJS-only: the lifecycle + DOM ref plumbing is browser-specific
+  (`reagent.core/create-class`, `js/window`, `offsetParent`). The PURE
+  anchoring geometry stays in `overlay-anchor.cljc` so the JVM test
+  corpus keeps pinning it without loading Reagent."
+  (:require [reagent.core :as r]))
+
+(defn make-resizing-overlay-class
+  "Build a Reagent form-3 `create-class` component whose `remeasure!`
+  thunk re-reads the chart DOM on mount, on every prop update, and on
+  window resize.
+
+  Args (single map):
+
+    :display-name — the React `:display-name`.
+    :root-ref     — the `r/atom` the render fn populates with the
+                    overlay's `offsetParent` (the shared coordinate
+                    origin). The scaffold reads it only to gate the
+                    resize listener teardown; the caller's `remeasure!`
+                    closure already reads it.
+    :remeasure!   — `(fn [] ...)` the caller supplies; invoked on mount,
+                    every did-update, and every window resize. It reads
+                    the latest props/specs (which the render fn stashes
+                    in atoms) and re-measures the DOM.
+    :render       — the `:reagent-render` fn `(fn [props] hiccup)`.
+
+  Returns the form-3 component. The resize listener is registered on
+  mount and torn down on unmount (the `_root-ref` is unused directly but
+  kept in the arg map so a future scaffold variant can key teardown on
+  it without a signature change)."
+  [{:keys [display-name remeasure! render]}]
+  (let [resize-fn (fn [_] (remeasure!))]
+    (r/create-class
+      {:display-name display-name
+
+       :component-did-mount
+       (fn [_this]
+         (when (exists? js/window)
+           (.addEventListener js/window "resize" resize-fn))
+         (remeasure!))
+
+       :component-did-update
+       (fn [_this _prev]
+         ;; Props changed → re-read the DOM. xyflow has already committed
+         ;; its layout by the time React calls did-update, so the node
+         ;; rects are current.
+         (remeasure!))
+
+       :component-will-unmount
+       (fn [_this]
+         (when (exists? js/window)
+           (.removeEventListener js/window "resize" resize-fn)))
+
+       :reagent-render render})))
+
+(defn overlay-root-props
+  "The shared absolutely-positioned, full-bleed, pointer-transparent
+  root-`<div>` prop map every chart overlay uses. Callers `merge` in the
+  per-overlay `:data-*` attrs (testid, node-id, ring-count, tick) and
+  the `:ref` is wired here to capture the overlay's `offsetParent` into
+  `root-ref` — the shared coordinate origin (the position:relative
+  wrapper that ALSO holds the xyflow chart, so both share the same
+  positioned ancestor for the anchor math).
+
+  `z-index` defaults to 4 (the card overlays); after-rings passes 3 so
+  the rings sit below the cards."
+  ([root-ref] (overlay-root-props root-ref 4))
+  ([root-ref z-index]
+   {:ref   (fn [el] (reset! root-ref (when el (.-offsetParent el))))
+    :style {:position       "absolute"
+            :top            0
+            :left           0
+            :width          "100%"
+            :height         "100%"
+            :pointer-events "none"
+            :overflow       "visible"
+            :z-index        z-index}}))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
@@ -38,7 +38,9 @@
   (:require [reagent.core :as r]
             [day8.re-frame2-machines-viz.theme.tokens :as tokens]
             [day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
-             :as anchor]))
+             :as anchor]
+            [day8.re-frame2-machines-viz.chart.overlays.overlay-scaffold
+             :as scaffold]))
 
 ;; ---- DOM measurement ----------------------------------------------------
 ;;
@@ -194,44 +196,21 @@
                        (when-let [spec @latest]
                          (reset! anchored
                                  (anchor/measure-anchor
-                                   anchor/anchor-right-of root (:node-id spec))))))
-        resize-fn  (fn [_] (remeasure!))]
-    (r/create-class
+                                   anchor/anchor-right-of root (:node-id spec))))))]
+    (scaffold/make-resizing-overlay-class
       {:display-name "MachinesViz.SpawnAllJoinOverlay"
-
-       :component-did-mount
-       (fn [_this]
-         (when (exists? js/window)
-           (.addEventListener js/window "resize" resize-fn))
-         (remeasure!))
-
-       :component-did-update
-       (fn [_this _prev] (remeasure!))
-
-       :component-will-unmount
-       (fn [_this]
-         (when (exists? js/window)
-           (.removeEventListener js/window "resize" resize-fn)))
-
-       :reagent-render
+       :root-ref     root-ref
+       :remeasure!   remeasure!
+       :render
        (fn [{:keys [join-spec tick testid on-child-click]
              :or   {testid "rf-mv-chart-spawn-all-join-overlay"}}]
          (reset! latest join-spec)
          (when (and join-spec (:node-id join-spec))
            (let [pos @anchored]
-             [:div {:data-testid testid
-                    :data-node-id (:node-id join-spec)
-                    :data-tick (when (some? tick) (str tick))
-                    :ref (fn [el]
-                           (reset! root-ref (when el (.-offsetParent el))))
-                    :style {:position       "absolute"
-                            :top            0
-                            :left           0
-                            :width          "100%"
-                            :height         "100%"
-                            :pointer-events "none"
-                            :overflow       "visible"
-                            :z-index        4}}
+             [:div (merge (scaffold/overlay-root-props root-ref)
+                          {:data-testid  testid
+                           :data-node-id (:node-id join-spec)
+                           :data-tick    (when (some? tick) (str tick))})
               (when pos
                 (join-card (merge join-spec pos
                                   {:on-child-click on-child-click})))])))})))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -876,72 +876,86 @@
                     (assoc :parentId parent-id
                            :extent   "parent"))))
               edge-descriptors)
+        ;; rf2-idx41 — the two halves of the events-as-nodes route
+        ;; (source-state → event-node, event-node → target-state) emit
+        ;; structurally-identical xyflow edges: same `:type`, the same
+        ;; resting/active/fired marker COLOUR cond, and a `:data` payload
+        ;; that differs only in its routed `:points` / `:labelPos`, the
+        ;; quiet-vs-primary flag, and the `:inbound`/`:outbound` marker.
+        ;; `events-as-nodes-edge` builds one half from those few
+        ;; differing values so the shared shape lives in ONE place (the
+        ;; two were copy-pasted before, drifting risk on every `:data`
+        ;; key add). `half` is `:in` (quiet source→event, 10px arrowhead)
+        ;; or `:out` (primary event→target, 18px arrowhead).
+        marker-color
+        (fn [{:keys [fired? focused? from-active?]}]
+          (cond
+            fired?       (:edge-fired ct)
+            focused?     (:edge-active ct)
+            from-active? (:edge-active ct)
+            :else        (:edge-quiet ct)))
+        events-as-nodes-edge
+        (fn [half {:keys [edge ev-node-id from-active? focused? fired?
+                          cross-hier?] :as desc} points label-pos]
+          (let [in? (= half :in)
+                w   (if in? 10 18)]
+            {:id        (str (:id edge) (if in? "__in" "__out"))
+             :source    (if in? (:source edge) ev-node-id)
+             :target    (if in? ev-node-id (:target edge))
+             :type      "transition"
+             ;; rf2-az6e2 — the `__in` (source→event) half is the QUIET
+             ;; segment: a SMALL 10px arrowhead in the quiet colour so the
+             ;; PRIMARY 18px arrowhead reads on the `__out` (event→target)
+             ;; half and the pair reads as ONE transition route.
+             :markerEnd {:type   "arrowclosed"
+                         :color  (marker-color desc)
+                         :width  w
+                         :height w}
+             :data      {:eventLabel ""
+                         :eventLineLabel ""
+                         :active     from-active?
+                         :focused    focused?
+                         :fired      fired?
+                         :afterMs    nil
+                         :guard      nil
+                         :action     nil
+                         :selfLoop   false
+                         :loopIndex  nil
+                         :siblingIndex 0
+                         :siblingCount 1
+                         :crossHierarchy cross-hier?
+                         ;; rf2-r636q — the elk route for THIS half
+                         ;; (`__in`: source-state → event-node; `__out`:
+                         ;; event-node → target-state). nil when elk
+                         ;; emitted no route (bezier fallback).
+                         :points     points
+                         ;; rf2-rlq97 — elk's computed label position (nil
+                         ;; under events-as-nodes; renderer falls back to
+                         ;; its geometric anchor).
+                         :labelPos   label-pos
+                         :internal   false
+                         :machineLevel (boolean (:machine-level? edge))
+                         :eventId    nil
+                         :fromPath   (:from-path edge)
+                         :toPath     (:to-path edge)
+                         :onClick    nil
+                         :chart      chart
+                         :palette    ct
+                         :inbound    in?
+                         :outbound   (not in?)
+                         ;; rf2-az6e2 — the `__in` half paints thinner + in
+                         ;; the quiet colour so the pair reads as one
+                         ;; transition with the primary arrowhead on `__out`.
+                         :quietSegment in?
+                         :eventNodeId ev-node-id
+                         :spec-edge-id (:id edge)}}))
         ;; Inbound edges: source-state → event-node. One per parsed
         ;; transition. No label rides on this edge (the event-node holds
         ;; the event/guard/action text); the edge is structural —
         ;; "this state handles this event".
         inbound-edges
-        (mapv (fn [{:keys [edge ev-node-id from-active? focused? fired?
-                           cross-hier? in-points in-label-pos]}]
-                {:id        (str (:id edge) "__in")
-                 :source    (:source edge)
-                 :target    ev-node-id
-                 :type      "transition"
-                 ;; rf2-az6e2 — the source→event (`__in`) segment is the
-                 ;; QUIET half of the two-edge route: a SMALL arrowhead
-                 ;; (10px, down from 14) in the quiet edge colour, so the
-                 ;; primary arrowhead reads on the event→target (`__out`)
-                 ;; segment and the pair reads as ONE transition route.
-                 :markerEnd {:type "arrowclosed"
-                             :color (cond
-                                      fired?    (:edge-fired ct)
-                                      focused?  (:edge-active ct)
-                                      from-active? (:edge-active ct)
-                                      :else     (:edge-quiet ct))
-                             :width 10
-                             :height 10}
-                 :data      {:eventLabel ""
-                             :eventLineLabel ""
-                             :active     from-active?
-                             :focused    focused?
-                             :fired      fired?
-                             :afterMs    nil
-                             :guard      nil
-                             :action     nil
-                             :selfLoop   false
-                             :loopIndex  nil
-                             :siblingIndex 0
-                             :siblingCount 1
-                             :crossHierarchy cross-hier?
-                             ;; rf2-r636q — the elk `__in` route
-                             ;; (source-state → event-node). Was
-                             ;; hardcoded nil, which (with the broken
-                             ;; bare-id lookup) meant the inbound segment
-                             ;; never routed around an intervening
-                             ;; container. nil when elk emitted no route
-                             ;; (bezier fallback).
-                             :points     in-points
-                             ;; rf2-rlq97 — elk's computed label position
-                             ;; (nil under events-as-nodes; the renderer
-                             ;; falls back to its geometric anchor).
-                             :labelPos   in-label-pos
-                             :internal   false
-                             :machineLevel (boolean (:machine-level? edge))
-                             :eventId    nil
-                             :fromPath   (:from-path edge)
-                             :toPath     (:to-path edge)
-                             :onClick    nil
-                             :chart      chart
-                             :palette    ct
-                             :inbound    true
-                             ;; rf2-az6e2 — the quiet source→event half of
-                             ;; the route. The renderer paints it thinner +
-                             ;; in the quiet colour so the pair reads as one
-                             ;; transition with the primary arrowhead on the
-                             ;; event→target segment.
-                             :quietSegment true
-                             :eventNodeId ev-node-id
-                             :spec-edge-id (:id edge)}})
+        (mapv (fn [{:keys [in-points in-label-pos] :as desc}]
+                (events-as-nodes-edge :in desc in-points in-label-pos))
               edge-descriptors)
         ;; Outbound edges: event-node → target-state. Omitted for
         ;; internal transitions (`:internal? true`) — the event-node
@@ -950,64 +964,9 @@
         ;; change").
         outbound-edges
         (->> edge-descriptors
-             (remove (fn [{:keys [internal?]}] internal?))
-             (mapv (fn [{:keys [edge ev-node-id focused? fired? from-active?
-                                cross-hier? out-points out-label-pos]}]
-                     {:id        (str (:id edge) "__out")
-                      :source    ev-node-id
-                      :target    (:target edge)
-                      :type      "transition"
-                      ;; rf2-az6e2 — the event→target (`__out`) segment is
-                      ;; the PRIMARY half of the route: it carries the full-
-                      ;; size arrowhead (18px) so the eye reads the
-                      ;; transition's landing. Colour resolves through the
-                      ;; active-theme chart-tokens.
-                      :markerEnd {:type "arrowclosed"
-                                  :color (cond
-                                           fired?    (:edge-fired ct)
-                                           focused?  (:edge-active ct)
-                                           from-active? (:edge-active ct)
-                                           :else     (:edge-quiet ct))
-                                  :width 18
-                                  :height 18}
-                      :data      {:eventLabel ""
-                                  :eventLineLabel ""
-                                  :active     from-active?
-                                  :focused    focused?
-                                  :fired      fired?
-                                  :afterMs    nil
-                                  :guard      nil
-                                  :action     nil
-                                  :selfLoop   false
-                                  :loopIndex  nil
-                                  :siblingIndex 0
-                                  :siblingCount 1
-                                  :crossHierarchy cross-hier?
-                                  ;; rf2-r636q — the elk `__out` route
-                                  ;; (event-node → target-state). Keyed by
-                                  ;; the `<spec-edge-id>__out` elk edge id
-                                  ;; the producer actually emits (was the
-                                  ;; bare canonical id → always missed).
-                                  :points     out-points
-                                  ;; rf2-rlq97 — elk's computed label
-                                  ;; position (nil under events-as-nodes;
-                                  ;; renderer falls back to geometric anchor).
-                                  :labelPos   out-label-pos
-                                  :internal   false
-                                  :machineLevel (boolean (:machine-level? edge))
-                                  :eventId    nil
-                                  :fromPath   (:from-path edge)
-                                  :toPath     (:to-path edge)
-                                  :onClick    nil
-                                  :chart      chart
-                                  :palette    ct
-                                  :outbound   true
-                                  ;; rf2-az6e2 — the primary event→target
-                                  ;; half (not quiet); carries the full
-                                  ;; arrowhead + the standard stroke.
-                                  :quietSegment false
-                                  :eventNodeId ev-node-id
-                                  :spec-edge-id (:id edge)}})))
+             (remove :internal?)
+             (mapv (fn [{:keys [out-points out-label-pos] :as desc}]
+                     (events-as-nodes-edge :out desc out-points out-label-pos))))
         proj-edges (vec (concat inbound-edges outbound-edges))
 
         ;; Initial-state markers — a small filled dot wired into each


### PR DESCRIPTION
Dedup-only review of `tools/machines-viz/src` (rf2-idx41, P3). Three behaviour-preserving consolidations; no contract / spec changes.

## What was consolidated (file:line evidence is pre-refactor)

1. **Overlay form-3 lifecycle scaffold.** `after_rings.cljs` (L173-204), `spawn_all_join.cljs` (L188-214), `cancellation_cascade.cljs` (L151-177) each carried a byte-identical Reagent form-3 measure-on-mount/update/resize lifecycle plus an absolutely-positioned full-bleed root `<div>` capturing `offsetParent`. Lifted once into a new CLJS-only `chart/overlays/overlay_scaffold.cljs` (`make-resizing-overlay-class` + `overlay-root-props`). The pure `overlay_anchor.cljc` stays JVM-runnable (no Reagent dep added to the .cljc test corpus).

2. **Events-as-nodes edge projection.** `chart/projection.cljc` `xyflow-graph` `inbound-edges` (L883-945) and `outbound-edges` (L951-1010) were two near-identical ~60-line `:data` builders differing only in the `__in`/`__out` id, source/target, marker width (10/18), the quiet/primary flag, and the in/out marker key. Folded into one `events-as-nodes-edge` helper + a shared `marker-color` cond.

3. **Four-cardinal invisible Handles.** `state-node` + `compound-node` (`nodes.cljs`), `parallel-region-node`, and `event-node` repeated the same four invisible cardinal `<Handle>`s (top+left `target`, bottom+right `source`, left/right carrying the `"left"`/`"right"` ids). Lifted to `chart/nodes/xyflow_node.cljs` `four-cardinal-handles`.

Net **~107 fewer lines**; one small new shared ns.

## Left as deliberate (not actioned)
- `transition-candidates` / `target-path?` / `resolve-target-path` triplicated across `chart/layout.cljc`, `mermaid.cljc`, `scxml.cljc` — an **intentional, documented** decoupling (each emitter standalone, "kept local so this ns has no cross-dependency"); the variants also differ subtly. Out of dedup scope.
- `tag-pill` / `action-row` chip / event-node action span share a chip style but differ enough that consolidating risks visual drift (stylistic, not pure dedup).
- `highlight-id` / `highlight-ids` share a 2-line resolution but carry load-bearing contract docstrings; a helper would obscure them.

## Quality gates (cold)
- `npx shadow-cljs compile node-test` — **0 warnings**.
- machines-viz JVM `clojure -M:test` — **334 tests / 940 assertions, 0 failures**.
- `npm run test:cljs` (node-test runtime) — **5477 tests / 19066 assertions, 0 failures**.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, 13 matrix rows** (machine canvas renders); exit 0.