### PR TITLE
fix(machines-viz): preserve namespaced tag identity across the xyflow clj->js boundary (rf2-u0du8)

### DIFF
--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -1241,8 +1241,15 @@
   (testing (str name " — a throwing sub recovers to nil + emits :rf.error/sub-exception")
     (rf/reg-event-db :init (fn [_ _] {:items "broken"}))
     (rf/reg-sub :items (fn [db _] (:items db)))
+    ;; Deliberate broken sub: `items` resolves to the string "broken",
+    ;; which has no `.something` method, so the call throws a TypeError
+    ;; at runtime — exercising the :replaced-with-default recovery path.
+    ;; The `^js` hint marks the access as an extern-typed property read so
+    ;; the compiler does not emit an :infer-warning (the throw is the
+    ;; point; the type is intentionally unknowable), keeping the
+    ;; :browser-test compile warning-clean.
     (rf/reg-sub :items-count :<- [:items]
-      (fn [items _] (count (.something items))))
+      (fn [items _] (count (.something ^js items))))
     (rf/dispatch-sync [:init])
     (let [traces (atom [])]
       (trace-tooling/register-listener! ::sub-err (fn [ev] (swap! traces conj ev)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -124,13 +124,30 @@
   PRESERVING the namespace. A `:door/open` tag reads `door/open`, not
   the truncated `open` — the bead's tag-identity fix. The pre-vcnvj
   `(name tag)` dropped the namespace, collapsing `:door/open`,
-  `:lift/open`, … to the same visible `open`."
+  `:lift/open`, … to the same visible `open`.
+
+  The projector (`chart.projection`) already stringifies each tag to
+  its fully-qualified form (`\"door/open\"`) BEFORE xyflow `clj->js`-es
+  the node `:data` (whose default keyword-fn is `name` and would
+  otherwise strip the namespace). By the time the renderer reads tags
+  back they are plain strings, so the string branch carries the live
+  path; the keyword branch is kept defensive for any direct caller."
   [t]
   (cond
     (keyword? t) (if-let [ns (namespace t)]
                    (str ns "/" (name t))
                    (name t))
     :else        (str t)))
+
+(defn- tag-testid-seg
+  "The `data-testid` segment for a tag chip. A `/` in a testid breaks
+  CSS / Playwright selectors, so collapse a namespaced tag to its
+  trailing `name` segment (`door/open` → `open`). The full identity
+  stays on `data-tag` / `title` for host introspection (rf2-vcnvj)."
+  [tag]
+  (let [label (tag-label tag)
+        idx   (.lastIndexOf label "/")]
+    (if (neg? idx) label (subs label (inc idx)))))
 
 (defn- tag-title-attr
   "Compose a state's `:tags` set (Spec 005 user-declared semantic
@@ -175,9 +192,9 @@
   [tag ct {:keys [tag-pill-height tag-pill-pad-x tag-pill-px
                   tag-pill-radius tag-pill-gap]}]
   (let [label      (tag-label tag)
-        testid-seg (if (keyword? tag) (name tag) (str tag))]
+        testid-seg (tag-testid-seg tag)]
     [:span {:key   label
-            :title (str tag)
+            :title label
             :data-testid (str "rf-mv-chart-state-tag-" testid-seg)
             :data-tag    label
             :style {:display          "inline-flex"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -679,7 +679,25 @@
                                           :initial        (boolean (:initial? n))
                                           :final          (boolean (:final? n))
                                           :compound       (boolean (:compound? n))
-                                          :tags           (vec (:tags n))
+                                          ;; rf2-vcnvj — serialise each tag
+                                          ;; to its FULLY-QUALIFIED string
+                                          ;; (`door/open`, not `open`) HERE,
+                                          ;; before xyflow `clj->js`-es the
+                                          ;; `:data` map. `clj->js`'s default
+                                          ;; keyword-fn is `name`, which drops
+                                          ;; the namespace — so a `:door/open`
+                                          ;; tag would arrive at the renderer
+                                          ;; as the truncated `"open"` and the
+                                          ;; `nodes/tag-label` identity fix
+                                          ;; (which runs AFTER the round-trip)
+                                          ;; could never recover it. Stringify
+                                          ;; via `symbol` so the namespace
+                                          ;; survives the boundary intact.
+                                          :tags           (mapv (fn [t]
+                                                                  (if (keyword? t)
+                                                                    (str (symbol t))
+                                                                    (str t)))
+                                                                (:tags n))
                                           ;; rf2-ee38b.21 — :entry / :exit
                                           ;; state actions (Spec 005
                                           ;; §State nodes) ride the payload


### PR DESCRIPTION
@-