### PR TITLE
fix(mcp-base/cap): correct false char-gate domination claim + pin live reachability (rf2-of2cd)

### DIFF
--- a/tools/mcp-base/spec/cap.md
+++ b/tools/mcp-base/spec/cap.md
@@ -53,9 +53,20 @@ The pipeline is a **two-stage** gate (rf2-ih7g4) that folds both sums in a **sin
 
 The algorithm runs synchronously at the wire boundary, after the response body has been assembled but before the consumer-side transport ships it. The cost is one walk over the `:content` vector — O(content size).
 
-### Why the secondary char gate is structurally dominated today
+### Why the secondary char gate is load-bearing today (rf2-of2cd)
 
-Under the live `token-estimate = (quot count 4)` rule, the two sums are not independent: if `chars > cap*8` then `tokens = (quot chars 4) > 2*cap > cap`, so the token gate has already tripped whenever the char gate would. The char disjunct is therefore intentional **defence-in-depth** against a FUTURE `token-estimate` refinement that decouples chars from tokens (one that recognises base64 / CJK with a lower per-char cost) — not dead code. `over-cap?` / `reported-count` are extracted as pure fns over already-summed counts so the dominated branch is unit-trippable in isolation (`cap_test.clj`).
+A naive reading argues the char gate is structurally dominated: for a SINGLE string of length `L`, `chars = L` and `tokens = (quot L 4)`, so `chars > cap*8` ⇒ `tokens = (quot L 4) > 2*cap > cap` — the token gate would have already tripped. That single-string argument is real but does NOT generalise to the multi-slot sum the pipeline actually folds.
+
+`token-estimate` floors **per string** (`quot` truncates), so the sum of floors is not the floor of the sum:
+
+```
+Σ (quot len_i 4)  ≤  quot (Σ len_i) 4    ; strictly less when the
+                                         ; per-string remainders are sub-4
+```
+
+A content vector of MANY short strings drives the gap to its extreme: 3000 slots of 3 chars each give `tokens = Σ (quot 3 4) = 0` while `chars = 9000`. At `cap = 1` the token gate is quiet (`0 > 1` is false) yet the char gate fires (`9000 > 8`), and `apply-cap` correctly replaces the over-budget payload with the overflow marker. The `watch-epochs` / `trace-window` slices are exactly this shape — a long vector of small per-record text slots. So the secondary char gate is reachable through the **live** `apply-cap` path today, not merely future-proofing.
+
+The branch is doubly justified: load-bearing now AND defence-in-depth against a FUTURE `token-estimate` refinement (one recognising base64 / CJK at a lower per-char cost) that would decouple the sums further. `over-cap?` / `reported-count` are extracted as pure fns over already-summed counts so both disjuncts and the `reported` selector are exercised directly in isolation (`cap_test.clj`) AND through the live many-short-strings `apply-cap` path (`apply-cap-many-short-strings-trips-char-gate`).
 
 ## Per-server specialisation hook — the `ResultIO` protocol
 

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -225,36 +225,51 @@
 ;; Over-budget decision — extracted from `apply-cap`'s inline `let` so the
 ;; two-stage gate is unit-trippable in isolation.
 ;;
-;; ## Why the secondary char gate is structurally dominated today
+;; ## Why the secondary char gate is load-bearing today (rf2-of2cd)
 ;;
 ;; `apply-cap` derives BOTH sums from the SAME `content-texts` seq:
-;; `tokens = Σ (token-estimate s)`, `chars = Σ (count s)`. With the live
-;; rule `token-estimate = (quot count 4)`, the two sums are not
-;; independent — for a single string of length L, `chars = L` and
-;; `tokens = (quot L 4)`. If `chars > cap*8` (i.e. L > 8·cap), then
-;; `tokens = (quot L 4) > (quot (8·cap) 4) = 2·cap > cap` for any cap ≥ 1.
-;; So whenever the char gate would trip, the primary token gate has
-;; ALREADY tripped — the `(> chars byte-cap)` disjunct can never be the
-;; SOLE reason `over?` is true while `tokens`/`chars` ride the same seq.
+;; `tokens = Σ (token-estimate s)`, `chars = Σ (count s)`. A NAIVE reading
+;; argues the char gate can never be the SOLE trip-reason: for a SINGLE
+;; string of length L, `chars = L` and `tokens = (quot L 4)`, so `chars >
+;; cap*8` ⇒ `tokens = (quot L 4) > 2·cap > cap` — the token gate would
+;; have already tripped. That single-string argument is REAL but does NOT
+;; generalise to the multi-slot sum the pipeline actually folds.
 ;;
-;; The gate is therefore NOT dead code by accident: it is intentional
-;; defence-in-depth against a FUTURE refinement of `token-estimate` (e.g.
-;; one that recognises base64 / CJK with a much lower per-char token
-;; cost). Under such a rule `chars` and `tokens` decouple and the char
-;; gate becomes load-bearing. To keep the branch from being a silently-
-;; dead inline arm, the decision is extracted here as a pure predicate
-;; over already-summed `tokens`/`chars` — so both disjuncts (and the
-;; `reported` selector) are directly exercised in `cap_test.clj` by
-;; feeding decoupled sums the live `apply-cap` path cannot itself
-;; produce. See `over-cap?` / `reported-count` tests.
+;; `token-estimate` floors PER STRING (`quot` truncates), so the sum of
+;; floors is NOT the floor of the sum:
+;;
+;;     Σ (quot len_i 4)  ≤  quot (Σ len_i) 4    — and strictly less when
+;;                                                 the lengths leave
+;;                                                 sub-4-char remainders.
+;;
+;; A content vector of MANY short strings drives this gap to its extreme:
+;; 3000 slots of 3 chars each give `tokens = Σ (quot 3 4) = 0` while
+;; `chars = 9000`. At `cap = 1` the token gate is QUIET (`0 > 1` is false)
+;; yet the char gate FIRES (`9000 > 8`) — `apply-cap` correctly replaces
+;; the over-budget payload with the overflow marker. The secondary char
+;; gate is therefore reachable through the LIVE `apply-cap` path today,
+;; not merely a future-proofing branch. (`watch-epochs` / `trace-window`
+;; slices are exactly this shape: a long vector of small per-record text
+;; slots, each well under 4 chars of net token contribution per fragment.)
+;;
+;; The branch is doubly justified: load-bearing now AND defence-in-depth
+;; against a FUTURE `token-estimate` refinement (one recognising base64 /
+;; CJK at a lower per-char cost) that would decouple the two sums further.
+;; The decision is extracted as a pure predicate over already-summed
+;; `tokens`/`chars` so BOTH disjuncts and the `reported` selector are
+;; exercised directly in `cap_test.clj` (decoupled sums, isolation) AND
+;; through the live `apply-cap` many-short-strings path. See `over-cap?`
+;; / `reported-count` tests + `apply-cap-many-short-strings-trips-char-gate`.
 ;; ---------------------------------------------------------------------------
 
 (defn over-cap?
   "Two-stage over-budget predicate (rf2-ih7g4). True when EITHER the
   token sum exceeds `cap` OR the char sum exceeds `cap *
   byte-cap-multiplier`. Pure over already-summed counts so the
-  dominated char gate is unit-trippable in isolation (see the comment
-  block above for the structural-domination argument)."
+  secondary char gate is unit-trippable in isolation (see the comment
+  block above for why the per-string floor in `token-estimate` makes
+  this gate load-bearing through the live `apply-cap` path today —
+  rf2-of2cd — not merely a future-proofing branch)."
   [tokens chars cap]
   (or (> tokens cap)
       (> chars (* cap byte-cap-multiplier))))
@@ -263,8 +278,9 @@
   "The `:token-count` reported in the overflow marker: the char count
   when the secondary char gate tripped (so the agent sees an actionable
   number for the payload that escaped the token heuristic), else the
-  token sum. Pure companion to `over-cap?` — unit-tested directly since
-  the live `apply-cap` path can't reach the char-gated arm."
+  token sum. Pure companion to `over-cap?` — unit-tested directly in
+  isolation AND reached through the live `apply-cap` path by a content
+  vector of many sub-4-char strings (rf2-of2cd)."
   [tokens chars cap]
   (if (> chars (* cap byte-cap-multiplier))
     chars
@@ -296,10 +312,12 @@
     (nil? result) result
     :else
     ;; Two-stage gate (`over-cap?`) + single-pass token/char sum — see
-    ;; the `over-cap?` comment block above (rf2-ih7g4) for why the char
-    ;; disjunct is structurally dominated today, and rf2-hyp0z for why
-    ;; both sums fold in ONE walk (avoids materialising story-mcp's
-    ;; `:structuredContent` twice).
+    ;; the `over-cap?` comment block above for why the char disjunct is
+    ;; load-bearing through this very path (the per-string `token-estimate`
+    ;; floor lets many sub-4-char slots trip the char gate while the token
+    ;; sum stays quiet — rf2-of2cd), and rf2-hyp0z for why both sums fold
+    ;; in ONE walk (avoids materialising story-mcp's `:structuredContent`
+    ;; twice).
     (let [{:keys [tokens chars]}
           (transduce (filter string?)
                      (completing

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -241,23 +241,25 @@
     (is (= 25 (cap/sum-text-tokens map-io r)))))
 
 ;; ---------------------------------------------------------------------------
-;; Two-stage gate, unit-trippable in isolation (rf2-80y2h).
+;; Two-stage gate, unit-trippable in isolation (rf2-80y2h) + reachable
+;; through the live `apply-cap` path (rf2-of2cd).
 ;;
-;; The previous test set documented (in a docstring) that the secondary
-;; char gate was un-trippable under the live `(quot c 4)` token rule and
-;; then never executed it — the `(> chars byte-cap)` disjunct and the
-;; `reported = chars` selector inside `apply-cap` had ZERO executing
-;; coverage. A regression that inverted either comparison shipped
-;; unobserved.
+;; The `over-cap?` / `reported-count` predicates are extracted as pure fns
+;; over already-summed tokens/chars so the secondary char gate is
+;; trippable in ISOLATION (feed decoupled sums directly), independent of
+;; how `apply-cap` happens to derive the sums.
 ;;
-;; The decision was NOT genuinely reachable through `apply-cap` + a
-;; custom `ResultIO`: `apply-cap` derives BOTH sums from the same
-;; `content-texts` strings inline, so an IO cannot return chars
-;; without proportional tokens — the two are computed by `apply-cap`
-;; itself, not by the IO. The fix extracts the gate into the pure
-;; `over-cap?` / `reported-count` predicates over already-summed
-;; tokens/chars, which ARE trippable in isolation by feeding the
-;; decoupled sums a future `token-estimate` refinement could produce.
+;; rf2-of2cd CORRECTION: an earlier comment here claimed the char gate was
+;; NOT genuinely reachable through `apply-cap` because "an IO cannot
+;; return chars without proportional tokens". That is WRONG. `token-estimate`
+;; floors PER STRING, so `Σ (quot len_i 4)` collapses toward 0 for a
+;; content vector of many sub-4-char slots while the char sum stays large.
+;; `apply-cap-many-short-strings-trips-char-gate` below exercises the
+;; char-gated arm THROUGH the live `apply-cap` path — no custom-sum trick,
+;; just a realistic many-small-slots payload (the `watch-epochs` /
+;; `trace-window` slice shape). The isolation tests remain valuable (they
+;; pin both disjuncts crisply); the char gate is simply load-bearing now,
+;; not merely future defence-in-depth.
 ;; ---------------------------------------------------------------------------
 
 (deftest over-cap?-primary-token-gate-trips
@@ -297,9 +299,10 @@
   ;; Consistency pin: the extracted predicates are exactly what
   ;; `apply-cap` uses. A token-gated over-budget response reports the
   ;; token count via `reported-count`, and `apply-cap`'s marker carries
-  ;; the same number. (The char-gate arm has no live `apply-cap`
-  ;; counterpart by construction — that asymmetry is the documented
-  ;; structural domination, covered in isolation above.)
+  ;; the same number. (The char-gate arm IS reachable through the live
+  ;; `apply-cap` path too — see
+  ;; `apply-cap-many-short-strings-trips-char-gate` — but this case is a
+  ;; single big string, so the token gate is the one that trips.)
   (let [big (big-string 4000)        ;; 4000 chars ⇒ 1000 tokens
         r   (ok-text-result {:huge big})
         cap-tokens 500
@@ -310,6 +313,34 @@
     (is (true? (cap/over-cap? toks chrs cap-tokens)))
     (is (= (cap/reported-count toks chrs cap-tokens) (:token-count body))
         "apply-cap's reported :token-count matches reported-count over the same sums")))
+
+(deftest apply-cap-many-short-strings-trips-char-gate
+  ;; rf2-of2cd regression pin. The secondary char gate is reachable
+  ;; through the LIVE `apply-cap` path, contradicting the earlier
+  ;; "structurally dominated / not reachable by construction" claim.
+  ;;
+  ;; `token-estimate` floors PER STRING: 3000 slots of 3 chars each give
+  ;; `tokens = Σ (quot 3 4) = 0` while `chars = 9000`. With `cap = 1` the
+  ;; primary token gate is QUIET (`0 > 1` is false) — only the secondary
+  ;; char gate (`9000 > 1*8`) trips. This is the `watch-epochs` /
+  ;; `trace-window` slice shape: a long vector of small text slots.
+  (let [r        {:content (vec (repeat 3000 {:type "text" :text "xxx"}))}
+        cap-toks 1]
+    ;; Confirm the precondition that makes this the SOLE char-gate trip.
+    (is (zero? (cap/sum-text-tokens map-io r))
+        "many sub-4-char slots ⇒ token sum floors to 0 (token gate quiet)")
+    (is (= 9000 (cap/sum-text-chars map-io r))
+        "char sum is large — only the secondary gate can trip")
+    (is (false? (> (cap/sum-text-tokens map-io r) cap-toks))
+        "primary token gate does NOT trip on its own")
+    (let [out  (cap/apply-cap map-io r {:tool "trace-window" :cap cap-toks})
+          body (get-in out [:structuredContent vocab/overflow-key])]
+      (is (contains? (:structuredContent out) vocab/overflow-key)
+          "live apply-cap replaces the payload via the secondary char gate")
+      (is (= :reached (:limit body)))
+      (is (= 9000 (:token-count body))
+          "reported :token-count is the CHAR count — the char-gated arm of reported-count, reached live")
+      (is (= cap-toks (:cap-tokens body))))))
 
 ;; ---------------------------------------------------------------------------
 ;; structuredContent counted toward the budget (rf2-ih7g4) — story-mcp


### PR DESCRIPTION
## Correctness review of `tools/mcp-base` (rf2-of2cd)

Systematic correctness review of the shared MCP-server foundation. The slice is in very good shape — heavily tested (180 JVM tests / 499 assertions + CLJS branch coverage, with explicit regression pins for many subtle edges). One genuine correctness defect found and fixed; the rest is a clean bill.

### The defect: a provably-false rationale in the cap pipeline

The two-stage token-budget cap's **secondary char-byte gate** was documented in three places (`cap.cljc`, `spec/cap.md`, `cap_test.clj`) as *"structurally dominated"* — claimed to be **un-trippable through the live `apply-cap` path** under the `token-estimate = (quot count 4)` rule, reachable only by feeding the extracted `over-cap?` / `reported-count` predicates artificially-decoupled sums.

That argument is **mathematically wrong**. `token-estimate` floors **per string**, so `Σ (quot len_i 4)` is *not* the floor of the sum. A content vector of many sub-4-char slots collapses the token sum toward 0 while the char sum stays large:

```
3000 slots × 3 chars  ⇒  tokens = Σ (quot 3 4) = 0 ,  chars = 9000
at cap = 1: token gate quiet (0 > 1 false), char gate fires (9000 > 8)
⇒ apply-cap correctly emits the overflow marker
```

This is exactly the `watch-epochs` / `trace-window` slice shape (a long vector of small per-record text slots). The char gate is **load-bearing today**, not merely future defence-in-depth.

The *code behaves correctly* — the gate fires when it should. The defect is the **false rationale**, which could mislead a future maintainer into deleting the gate (or its `reported-count` char-arm coverage) as "dead by construction" — a latent silent-truncation correctness hazard in a foundation both MCP servers ride on.

### Changes
- Rewrote the rationale comment block + `over-cap?` / `reported-count` docstrings + the `apply-cap` inline comment in `cap.cljc` (behaviour unchanged — comments/docstrings only).
- Corrected the §"structurally dominated" section in `tools/mcp-base/spec/cap.md` (tool-local spec, not hot-zone).
- Corrected the misleading comments in `cap_test.clj` and added `apply-cap-many-short-strings-trips-char-gate` — a regression pin exercising the char-gated arm **through the live `apply-cap` path** and asserting the marker's `:token-count` is the char count (9000).

### Quality gates (cold)
- `tools/mcp-base` JVM `clojure -M:test`: **181 tests / 506 assertions, 0 failures** (was 180/499; +1 test).
- `tools/mcp-base` CLJS `npm run test:cljs`: **8 tests / 39 assertions, 0 failures**.
- `npm run test:mcp-conformance`: **all 6 gates GREEN** (incl. wire-vocab 49/629, live re-frame2-pair + story-mcp end-to-end).

Do NOT merge yet — pipeline is blocked on u0du8 (browser-test red); this PR queues as expected.