### PR TITLE
fix(story): wire run-state teardown + guard stepper nil-state pollution (rf2-booyu)

### DIFF
--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -27,6 +27,7 @@
             [re-frame.story.layout-debug :as layout-debug]
             [re-frame.story.loaders      :as loaders]
             [re-frame.story.play         :as play]
+            [re-frame.story.play.runner-events :as runner-events]
             [re-frame.story.registrar    :as registrar]
             [re-frame.story.render       :as render]
             [re-frame.story.runtime      :as runtime]
@@ -52,7 +53,19 @@
   ;; per-frame `pending-exceptions` slot needs frame-teardown eviction.
   (late-bind/set-fn! :drop-assertion-accumulators
     (fn [frame-id]
-      (play/drop-pending-exceptions! frame-id))))
+      (play/drop-pending-exceptions! frame-id)))
+  ;; rf2-booyu — the play-runner's per-frame run-state (`run-state` /
+  ;; `runs-by-play` / `active-play` / `step-boundaries`) must be evicted on
+  ;; frame teardown too. `clear-state!` documented itself as "called from
+  ;; frame teardown" but was never wired, so a destroyed variant frame leaked
+  ;; its terminal play status + the toolbar's focused-play slot, and a
+  ;; re-allocated frame of the same id could observe the prior incarnation's
+  ;; run-state. `frames` cannot `:require` `runner-events` (cycle), so the
+  ;; eviction routes through this late-bind hook the same way the
+  ;; pending-exceptions eviction does.
+  (late-bind/set-fn! :drop-run-state
+    (fn [frame-id]
+      (runner-events/clear-state! frame-id))))
 
 #?(:cljs
    (defn- render-host-scope

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -548,6 +548,11 @@
     (clear-stub-call-log! frame-id)
     (when-let [drop (late-bind/get-fn :drop-assertion-accumulators)]
       (try (drop frame-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
+    ;; rf2-booyu — evict the play-runner's per-frame run-state on teardown
+    ;; (symmetric with `destroy!`); an inline frame that drove a script
+    ;; leaves no stale run-state behind once it is torn down.
+    (when-let [drop (late-bind/get-fn :drop-run-state)]
+      (try (drop frame-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
     (when (seq loaders-teardown)
       (try (apply-loaders-teardown! frame-id loaders-teardown)
         (catch #?(:clj Throwable :cljs :default) _ nil)))
@@ -592,6 +597,13 @@
     (loaders/clear-watchers! variant-id)
     (clear-stub-call-log! variant-id)
     (when-let [drop (late-bind/get-fn :drop-assertion-accumulators)]
+      (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
+    ;; rf2-booyu — evict the play-runner's per-frame run-state on teardown
+    ;; (run-state / runs-by-play / active-play / step-boundaries) so a
+    ;; destroyed frame leaves no stale terminal play status behind. Routed
+    ;; through the `:drop-run-state` late-bind hook (frames cannot :require
+    ;; runner-events — cycle).
+    (when-let [drop (late-bind/get-fn :drop-run-state)]
       (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
     ;; Step 3 (rf2-lqs0b) — variant body :loaders-teardown. Runs BEFORE
     ;; decorator teardown so loader-installed narrower state is cleaned

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -34,6 +34,24 @@
                                      evicts its entry. Signature:
                                      `(f frame-id) → nil`.
 
+  - `:drop-run-state`              — runner-events → frames. Called on
+                                     frame teardown so the play-runner's
+                                     per-frame run-state evicts its entry
+                                     across the four process-global atoms
+                                     (`run-state` / `runs-by-play` /
+                                     `active-play` / `step-boundaries`).
+                                     Without it a destroyed variant frame
+                                     leaks its terminal play status + the
+                                     toolbar's focused-play slot, and a
+                                     re-allocated frame of the same id can
+                                     observe the prior incarnation's
+                                     run-state before its first fresh run
+                                     overwrites it. `frames` cannot
+                                     `:require` `runner-events` (cycle:
+                                     runner-events → play → frames), so the
+                                     teardown call routes through this hook.
+                                     Signature: `(f frame-id) → nil`.
+
   - `:render-host`                 — story (via the canonical
                                      `install-render-host!`) → render. The
                                      CLJS host's view-render seam, consumed

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -433,15 +433,21 @@
   No-op when no step has run. rf2-ee38b.3."
   [frame-id]
   (when config/enabled?
-    (swap! stepper-state update frame-id
-           (fn [s]
-             (if (seq (:ran s))
-               (let [last-step (peek (:ran s))]
-                 (-> s
-                     (update :ran pop)
-                     (update :results (fn [r] (if (seq r) (pop r) r)))
-                     (update :remaining (fn [rem] (into [last-step] rem)))))
-               s))))
+    ;; rf2-booyu — guard against a missing entry: `update` on a missing key
+    ;; would associate the fn's nil/`s` return (a `{frame-id nil}` entry),
+    ;; which flips `play-stepper-active?` (a `contains?` check) to true for a
+    ;; frame whose stepper was never begun. Only touch an existing,
+    ;; non-nil slot.
+    (when (some? (get @stepper-state frame-id))
+      (swap! stepper-state update frame-id
+             (fn [s]
+               (if (seq (:ran s))
+                 (let [last-step (peek (:ran s))]
+                   (-> s
+                       (update :ran pop)
+                       (update :results (fn [r] (if (seq r) (pop r) r)))
+                       (update :remaining (fn [rem] (into [last-step] rem)))))
+                 s)))))
   nil)
 
 (defn stepper-rewind!
@@ -451,11 +457,17 @@
   rf2-ee38b.3."
   [frame-id]
   (when config/enabled?
-    (swap! stepper-state update frame-id
-           (fn [s]
-             (when s
-               (let [full (into (vec (:ran s)) (:remaining s))]
-                 (assoc s :remaining full :ran [] :results []))))))
+    ;; rf2-booyu — guard against a missing entry: the prior `(when s …)`
+    ;; returned nil for a missing key, and `update` then associated that nil
+    ;; (a `{frame-id nil}` entry), making `play-stepper-active?` report true
+    ;; for a frame whose stepper was never begun. Only rewind an existing,
+    ;; non-nil slot.
+    (when (some? (get @stepper-state frame-id))
+      (swap! stepper-state update frame-id
+             (fn [s]
+               (when s
+                 (let [full (into (vec (:ran s)) (:remaining s))]
+                   (assoc s :remaining full :ran [] :results [])))))))
   nil)
 
 (defn end-stepper!

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -171,8 +171,11 @@
   nil)
 
 (defn clear-state!
-  "Wipe the run-state for `frame-id`. Called from frame teardown +
-  before each fresh run."
+  "Wipe the run-state for `frame-id` across all four process-global atoms
+  (`run-state` / `runs-by-play` / `active-play` / `step-boundaries`).
+  Wired into frame teardown via the `:drop-run-state` late-bind hook
+  (`frames/destroy!` + `destroy-inline!`, rf2-booyu) so a destroyed variant
+  frame leaves no stale terminal play status behind."
   [frame-id]
   (swap! run-state dissoc frame-id)
   (swap! runs-by-play (fn [m]

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -266,6 +266,61 @@
       (story/destroy-variant! :story.stepper/full))))
 
 ;; ===========================================================================
+;; Stepper guards on a never-begun frame — rf2-booyu CORRECTNESS
+;;
+;; `stepper-rewind!` / `stepper-step-back!` used `swap! stepper-state update
+;; frame-id (fn [s] (when s …))`. On a MISSING key `update` still associates
+;; the fn's nil return, leaving a `{frame-id nil}` entry. Because
+;; `play-stepper-active?` is a `contains?` check, that nil entry flipped the
+;; stepper to "active" for a frame whose stepper was never begun — a false
+;; activation the UI would render as a live stepper widget. The guard now
+;; only touches an existing, non-nil slot.
+;; ===========================================================================
+
+(deftest stepper-rewind-on-never-begun-frame-does-not-activate
+  (testing "stepper-rewind! against a frame with no stepper session is a
+            no-op — it does NOT insert a nil entry that would flip
+            play-stepper-active? to true (rf2-booyu)"
+    (is (not (play/play-stepper-active? :story.stepper/never)))
+    (play/stepper-rewind! :story.stepper/never)
+    (is (not (play/play-stepper-active? :story.stepper/never))
+        "rewind on a never-begun frame leaves the stepper inactive")
+    (is (not (contains? @play/stepper-state :story.stepper/never))
+        "no {frame-id nil} entry was inserted into stepper-state")))
+
+(deftest stepper-step-back-on-never-begun-frame-does-not-activate
+  (testing "stepper-step-back! against a frame with no stepper session is a
+            no-op — same nil-entry pollution guard as rewind (rf2-booyu)"
+    (is (not (play/play-stepper-active? :story.stepper/never2)))
+    (play/stepper-step-back! :story.stepper/never2)
+    (is (not (play/play-stepper-active? :story.stepper/never2))
+        "step-back on a never-begun frame leaves the stepper inactive")
+    (is (not (contains? @play/stepper-state :story.stepper/never2))
+        "no {frame-id nil} entry was inserted into stepper-state")))
+
+(deftest stepper-rewind-still-rewinds-an-active-session
+  (testing "the guard does not break the real path — rewind on an ACTIVE
+            session still resets the cursor (every step back to :remaining)"
+    (rf/reg-event-db :rw/one (fn [db _] (assoc db :one? true)))
+    (story/reg-variant :story.stepper/rw
+      {:events []
+       :play-script [[:dispatch-sync [:rw/one]]
+                     [:dispatch-sync [:rw/one]]]})
+    (let [decorator-stack (story/resolve-decorators :story.stepper/rw)]
+      (re-frame.story.frames/allocate! :story.stepper/rw decorator-stack)
+      (loaders/start-loaders! :story.stepper/rw)
+      (loaders/finish-loaders! :story.stepper/rw)
+      (play/begin-stepper! :story.stepper/rw)
+      (play/step-once! :story.stepper/rw)
+      (is (= 1 (count (:ran (get @play/stepper-state :story.stepper/rw)))))
+      (play/stepper-rewind! :story.stepper/rw)
+      (let [s (get @play/stepper-state :story.stepper/rw)]
+        (is (= [] (:ran s))      "rewind emptied :ran")
+        (is (= 2 (count (:remaining s))) "every step back to :remaining"))
+      (play/end-stepper! :story.stepper/rw)
+      (story/destroy-variant! :story.stepper/rw))))
+
+;; ===========================================================================
 ;; :loaders-complete-when non-default forms — Stage 5 (rf2-h8et)
 ;; ===========================================================================
 

--- a/tools/story/test/re_frame/story_teardown_test.clj
+++ b/tools/story/test/re_frame/story_teardown_test.clj
@@ -40,6 +40,7 @@
             [re-frame.story.config     :as config]
             [re-frame.story.frames     :as frames]
             [re-frame.story.loaders    :as loaders]
+            [re-frame.story.play.runner-events :as runner-events]
             [re-frame.story.schemas    :as schemas]
             [malli.core                :as m]))
 
@@ -56,6 +57,7 @@
   (loaders/clear-watchers!)
   (config/set-global-args! {})
   (reset! frames/stub-call-log {})
+  (runner-events/clear-all-runs!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
   (test-fn))
@@ -302,3 +304,54 @@
         "destroy returns nil — no-op teardown walk completes cleanly")
     (is (not (contains? (story/variant-frames) :story.teardown.none/v))
         "frame still destroyed")))
+
+;; ===========================================================================
+;; RUN-STATE EVICTION — destroy-variant! clears the play-runner run-state
+;;
+;; rf2-booyu CORRECTNESS: `runner-events/clear-state!` documented itself as
+;; "called from frame teardown" but was never wired into `frames/destroy!`,
+;; so a destroyed variant frame leaked its per-frame run-state across the four
+;; process-global atoms (run-state / runs-by-play / active-play /
+;; step-boundaries). Over a long Story session (every hot-reload reset tears a
+;; frame down) these accumulate; a re-allocated frame of the same id could
+;; also observe the prior incarnation's terminal play status before its first
+;; fresh run overwrote it. The teardown now routes through the
+;; `:drop-run-state` late-bind hook.
+;; ===========================================================================
+
+(deftest destroy-variant-evicts-play-runner-run-state
+  (testing "after a play runs and the variant is destroyed, the play-runner's
+            per-frame run-state is gone from every process-global atom — no
+            leak (rf2-booyu)"
+    (rf/reg-event-db :rs/noop (fn [db _] db))
+    (story/reg-variant :story.runstate/v
+      {:events      []
+       :play-script [[:dispatch-sync [:rs/noop]]]})
+    (let [decorator-stack (story/resolve-decorators :story.runstate/v)]
+      ;; Drive the live-shell path: allocate the frame, then run the play via
+      ;; the runner (the toolbar Re-run / auto-run path that populates
+      ;; run-state).
+      (frames/allocate! :story.runstate/v decorator-stack)
+      (loaders/start-loaders! :story.runstate/v)
+      (loaders/finish-loaders! :story.runstate/v)
+      (let [done (promise)]
+        (runner-events/run! :story.runstate/v (fn [_] (deliver done :ok)))
+        (deref done 5000 :timeout))
+      (is (contains? @runner-events/run-state :story.runstate/v)
+          "run-state populated by the run")
+      (is (contains? @runner-events/runs-by-play [:story.runstate/v nil])
+          "runs-by-play populated by the run")
+      ;; A single :play-script variant's active-play key is legitimately nil
+      ;; (no :plays :name), so assert the ENTRY exists, not that the value is
+      ;; non-nil.
+      (is (contains? @runner-events/active-play :story.runstate/v)
+          "active-play populated by the run")
+      (story/destroy-variant! :story.runstate/v)
+      (is (not (contains? @runner-events/run-state :story.runstate/v))
+          "run-state evicted on destroy — no leak")
+      (is (not (contains? @runner-events/runs-by-play [:story.runstate/v nil]))
+          "runs-by-play evicted on destroy — no leak")
+      (is (not (contains? @runner-events/active-play :story.runstate/v))
+          "active-play evicted on destroy — no leak")
+      (is (nil? (runner-events/settle-boundaries :story.runstate/v))
+          "step-boundaries evicted on destroy — no leak"))))


### PR DESCRIPTION
## What

Correctness review of `tools/story/` (bead **rf2-booyu**). Three confirmed defects fixed, each with a regression test.

### 1. Run-state lifecycle leak (resource lifecycle)
`runner-events/clear-state!` documented itself as *"called from frame teardown"* but was **never wired** into `frames/destroy!` / `destroy-inline!`. Every variant teardown leaked the play-runner's per-frame state across four process-global atoms (`run-state` / `runs-by-play` / `active-play` / `step-boundaries`). Over a long Story session (each hot-reload reset tears a frame down) these accumulate without bound; a re-allocated frame of the same id could also observe the prior incarnation's terminal play status before its first fresh run overwrote it.

**Fix:** new `:drop-run-state` late-bind hook (bound in `canonical/install-late-bind-shims!` → `runner-events/clear-state!`), called from `frames/destroy!` and `destroy-inline!`. `frames` cannot `:require` `runner-events` (cycle: runner-events → play → frames), so the eviction routes through the hub exactly like the existing `:drop-assertion-accumulators` pending-exceptions eviction.

### 2. `stepper-rewind!` nil-state pollution (invariant violation)
`swap! stepper-state update frame-id (fn [s] (when s …))` on a **missing** key still associates the fn's nil return — a `{frame-id nil}` entry. Because `play-stepper-active?` is a `contains?` check, that nil entry flips the stepper to **"active"** for a frame whose stepper was never begun (the UI renders a live stepper widget over a never-started session). Guarded to only touch an existing, non-nil slot.

### 3. `stepper-step-back!` nil-state pollution
Same root cause (`(if (seq (:ran s)) … s)` returns nil `s` on a missing key), same guard.

## Tests
- `story_play_test.clj` — 3 new: the two stepper guards on a never-begun frame + an active-session rewind-still-works guard (proves the guard doesn't break the real path).
- `story_teardown_test.clj` — 1 new: run-state eviction on `destroy-variant!` across all four atoms. Fixture now also resets the runner-events run-state atoms between tests.

## Gates (cold)
- JVM `clojure -M:test` (tools/story): **1587 tests / 5946 assertions, 0 failures**.
- `npm run test:cljs`: **5477 tests / 19066 assertions, 0 failures**.
- `npm run story:build`: **0 warnings** — release `:advanced` elision intact with the new `canonical → runner-events` require.

## Scope notes
- No `spec/*` hot-zone touch. The run-state eviction now matches the already-documented teardown contract (`002-Runtime.md` §Loader teardown contract step 1); no normative change needed.
- Correctness only — did not do the dedup / functional-style passes (sibling beads). No cross-over into `tools/story-mcp/` (nce6f's dir).

## Residual / not actioned here
- A **CLJS-only** play-promise non-resolution hazard exists in `runtime/run-phase-4!`: if `runner-events/run!`'s `run-loop!` aborts silently (frame torn down during a `:wait` `setTimeout` yield, or a concurrent-run token takeover) it never invokes `done-cb`, so the `run-variant` promise can hang. Hard to trigger deterministically (requires teardown precisely during an async yield) and not reproducible on JVM (synchronous `:wait`); filed as a follow-up bug bead rather than fixed in this focused PR.