### PR TITLE
fix(core): shed dead :dispatched-at, memoise compute-sub, weak-ref JVM dispose registry (rf2-vkey0 + rf2-gyxm3 + rf2-tnnln)

### DIFF
--- a/implementation/core/src/re_frame/interop.clj
+++ b/implementation/core/src/re_frame/interop.clj
@@ -39,23 +39,93 @@
 ;; a tracking graph the way Reagent does. make-reaction returns a thunk that
 ;; recomputes f on every deref. For the headless / SSR use cases this is fine
 ;; — they read once or twice per request, not in a hot reactive loop.
+;;
+;; Per rf2-tnnln: on-dispose callbacks live ON the reaction object (a mutable
+;; field on the `Reaction` deftype), NOT in a process-wide identity-keyed
+;; registry. This mirrors the CLJS plain-atom adapter, whose derived-value
+;; reify closes over an `(atom [])` of callbacks (see
+;; `re-frame.substrate.plain-atom/make-derived-value`): the callbacks' lifetime
+;; is tied to the reaction's lifetime, so an orphaned reaction (one that is
+;; dropped WITHOUT an explicit `dispose!` — a partial-teardown bug, an
+;; exception between `add-on-dispose!` and `dispose!`) is reclaimed by GC along
+;; with its callbacks rather than pinned forever. This is the correct
+;; resource-lifecycle posture for the long-lived JVM SSR profile (Spec 011's
+;; frame-per-request), where the prior global strong-ref `atom`-of-map was a
+;; leak surface: it held strong references to every reaction (and its whole
+;; layer-2+ input chain + compute-fn) until `dispose!` was called with that
+;; exact object, defeating GC for any reaction that escaped its dispose path.
+;;
+;; `dispose!` semantics are unchanged: callbacks are cleared from the reaction
+;; first (re-entrancy / idempotency — a second `dispose!` is a no-op) then
+;; fired in registration order.
+;;
+;; A weak-keyed fallback registry handles objects that are NOT `Reaction`s
+;; (bare `reify clojure.lang.IDeref` test doubles, plain atoms) so the
+;; `add-on-dispose!` / `dispose!` surface still works uniformly for any
+;; deref-able. The fallback is weak-KEYED (a `WeakHashMap`) so even a
+;; non-`Reaction` orphan is reclaimable: the only path on which a fallback
+;; value could strong-ref its key is when a registered callback closes over
+;; the keyed object, and the production sub-cache disposal closure
+;; (`re-frame.subs`) closes over the reaction — which on the JVM is a
+;; `Reaction`, so it takes the on-object storage path, not the fallback.
 
-(defonce ^:private on-dispose-callbacks (atom {}))
+(defprotocol IDisposeRegistry
+  "JVM on-dispose callback storage carried ON the reaction object. The
+  CLJS counterpart is `re-frame.disposable/IDisposable`; this is the
+  JVM-local equivalent for the plain-atom / SSR / headless host. Per
+  rf2-tnnln — keeping callbacks on the object (not a global registry)
+  is what makes an un-disposed reaction GC-reclaimable."
+  (-add-on-dispose [this f]
+    "Append a 0-arg on-dispose callback. Registration order is preserved.")
+  (-dispose [this]
+    "Clear the callbacks (idempotent — a second call finds none) then
+     fire them in registration order. Throwing callbacks are NOT
+     swallowed here; the caller owns per-reaction throw containment."))
+
+(deftype Reaction [f ^:unsynchronized-mutable callbacks]
+  clojure.lang.IDeref
+  (deref [_] (f))
+  IDisposeRegistry
+  (-add-on-dispose [_ cb]
+    (set! callbacks (conj callbacks cb))
+    nil)
+  (-dispose [_]
+    (let [cbs callbacks]
+      ;; Clear FIRST so a re-entrant dispose (or a callback that triggers
+      ;; another dispose of this same reaction) is a no-op, matching the
+      ;; prior dissoc-before-fire discipline.
+      (set! callbacks [])
+      (doseq [cb cbs] (cb)))))
+
+;; Weak-keyed fallback for deref-ables that are not `Reaction`s (bare
+;; reify test doubles, plain atoms). Identity is the natural key; a
+;; `WeakHashMap` keys by `.equals`/`.hashCode`, which for these objects
+;; is identity. Synchronized for the concurrent SSR / hot-reload paths.
+(defonce ^:private ^java.util.Map fallback-on-dispose-callbacks
+  (java.util.Collections/synchronizedMap (java.util.WeakHashMap.)))
 
 (defn make-reaction
-  "On the JVM, return a deref-able that recomputes f on every deref."
+  "On the JVM, return a deref-able that recomputes f on every deref and
+  carries its own on-dispose callback storage (per rf2-tnnln)."
   [f]
-  (reify clojure.lang.IDeref
-    (deref [_] (f))))
+  (->Reaction f []))
 
 (defn add-on-dispose! [a-ratom f]
-  (swap! on-dispose-callbacks update a-ratom (fnil conj []) f)
+  (if (instance? Reaction a-ratom)
+    (-add-on-dispose a-ratom f)
+    (locking fallback-on-dispose-callbacks
+      (let [cbs (.get fallback-on-dispose-callbacks a-ratom)]
+        (.put fallback-on-dispose-callbacks a-ratom (conj (or cbs []) f)))))
   nil)
 
 (defn dispose! [a-ratom]
-  (let [callbacks (get @on-dispose-callbacks a-ratom)]
-    (swap! on-dispose-callbacks dissoc a-ratom)
-    (doseq [f callbacks] (f))))
+  (if (instance? Reaction a-ratom)
+    (-dispose a-ratom)
+    (let [callbacks (locking fallback-on-dispose-callbacks
+                      (let [cbs (.get fallback-on-dispose-callbacks a-ratom)]
+                        (.remove fallback-on-dispose-callbacks a-ratom)
+                        cbs))]
+      (doseq [f callbacks] (f)))))
 
 (defn reactive?
   "Always true on the JVM (no reagent reactive context to detect)."

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -143,6 +143,18 @@
         ;; referenced syntactically.
         call-site          (when interop/debug-enabled?
                              (:rf.trace/call-site opts))
+        ;; Per rf2-vkey0: `:dispatched-at` is dev-only envelope metadata —
+        ;; the schema (`:rf/dispatch-envelope` in Spec-Schemas) marks it
+        ;; `{:optional true}` ("CLJS reference may add an impl-specific
+        ;; timestamp; tools tolerate"), so its production absence is spec-
+        ;; valid. A corpus grep finds ZERO consumers; carrying it
+        ;; unconditionally cost one `now-ms` call (`js/performance.now` /
+        ;; `System.currentTimeMillis`) + a map assoc on the hot dispatch
+        ;; allocation path of every production dispatch. Gate it exactly
+        ;; like the adjacent `:dispatch-id` slot so both the `now-ms` call
+        ;; and the assoc DCE under `:advanced` + `goog.DEBUG=false` (and
+        ;; the JVM `-Dre-frame.debug=false` SSR-prod gate).
+        dispatched-at      (when interop/debug-enabled? (interop/now-ms))
         ;; Per rf2-d4sf the 3-tier resolution chain (dynamic var →
         ;; React context → `:rf/default`) is single-sourced through
         ;; `frame/resolve-current-frame` (rf2-jj8xf) — the React-context
@@ -219,8 +231,7 @@
              ;; on `:rf.event/dispatched` (stamped in
              ;; `emit-dispatched-trace`).
              :source-detail          (:source-detail opts)
-             :origin                 (:origin opts :app)
-             :dispatched-at          (interop/now-ms)}
+             :origin                 (:origin opts :app)}
       ;; Per rf2-ts1a: the macro form of `dispatch` / `dispatch-sync`
       ;; stamps an `:rf.trace/call-site` on the opts map. The read in
       ;; `call-site` above is gated on interop/debug-enabled? so this
@@ -228,6 +239,7 @@
       ;; goog.DEBUG=false. fn-form callers (`dispatch*`) supply nil
       ;; and the key is omitted.
       call-site          (assoc :call-site         call-site)
+      dispatched-at      (assoc :dispatched-at      dispatched-at)
       dispatch-id        (assoc :dispatch-id        dispatch-id)
       parent-dispatch-id (assoc :parent-dispatch-id parent-dispatch-id)
       fallthrough?       (assoc :fell-through-to-default? true)

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -558,6 +558,99 @@
      (unsubscribe frame-id query-v)
      v)))
 
+(defn- compute-sub*
+  "Recursive worker for `compute-sub`. Threads a per-call `memo` atom
+  (`{query-v -> value}`) through the `:<-` recursion so each DISTINCT
+  sub in the dependency graph computes — and emits its `:rf.sub/run`
+  trace — at most once per top-level `compute-sub` call (rf2-gyxm3).
+
+  A memo HIT short-circuits to the pinned value: no body re-run, no
+  duplicate `:rf.sub/run` emission. Memoising by the full `query-v`
+  (id + args) is value-identical to re-computing because, for a fixed
+  `db`, a sub's value is a pure function of `db` + its inputs."
+  [query-v db memo]
+  ;; `contains?` (not a sentinel + `identical?`) so a memoised nil value
+  ;; is honoured as a HIT — unregistered subs and recovery-to-nil both
+  ;; memoise nil, and a keyword sentinel is not reliably reference-equal
+  ;; under `identical?` on CLJS.
+  (if (contains? @memo query-v)
+    (get @memo query-v)
+    (let [query-id (first query-v)
+          meta     (registrar/lookup :sub query-id)]
+      (if-not meta
+        ;; Unregistered sub computes to nil; memoise so a repeated
+        ;; reference within the same call is also a single resolution.
+        (do (swap! memo assoc query-v nil) nil)
+        (do
+          ;; Per Spec 009 §:op-type vocabulary: :sub/run marks a sub recompute.
+          ;; The pure compute-sub form fires the same op-type as the reactive
+          ;; recompute path so tools can observe both call sites uniformly.
+          ;;
+          ;; Per rf2-l1jz8 — the reactive recompute path (subs.memo/validate-
+          ;; and-trace) enriches its `:sub/run` tag with value-change +
+          ;; cascade attribution (`:value-changed?` / `:prev-value` /
+          ;; `:value` / `:cascade?` / `:cause-sub`). `compute-sub` deliberately
+          ;; bypasses the per-frame reactive cache (it's the pure-snapshot
+          ;; form per Spec 008 §Testing), so it has NO prior cached value to
+          ;; diff for `:value-changed?` and NO reactive context to attribute a
+          ;; cascade against — each DISTINCT `:<-` input is re-resolved fresh
+          ;; against the supplied `db`, not observed as a changed upstream
+          ;; signal. It therefore emits the BASE `:sub/run` shape only;
+          ;; attribution is a reactive-path concern. Consumers (Xray) read
+          ;; attribution off the reactive epoch records, never off
+          ;; compute-sub emissions.
+          (trace/emit! :rf.sub :rf.sub/run
+                       {:rf.sub/id      query-id
+                        :rf.sub/query-v query-v})
+          (let [body-fn (:handler-fn meta)
+                inputs  (:input-signals meta)
+                ;; Bind n once — `(empty? inputs)` then `(= 1 (count inputs))`
+                ;; counted twice on the multi-input path (rf2-r1rma).
+                n       (count inputs)
+                ;; Per Spec 009 §Error contract — body throws emit
+                ;; :rf.error/sub-exception and recover to nil. Mirrors
+                ;; `subs.memo/validate-and-trace` (the reactive sibling), so
+                ;; SSR + JVM-runnable consumers driving subs through
+                ;; `compute-sub` get the same debuggable signal the reactive
+                ;; path produces. The `:where :compute-sub` tag distinguishes
+                ;; this emission site from the reactive memo path; the rest of
+                ;; the envelope mirrors the sibling exactly (rf2-cos61).
+                v       (try
+                          (let [raw (cond
+                                      (zero? n)
+                                      (body-fn db query-v)
+
+                                      (= 1 n)
+                                      (body-fn (compute-sub* (first inputs) db memo) query-v)
+
+                                      :else
+                                      (body-fn (mapv #(compute-sub* % db memo) inputs) query-v))]
+                            ;; rf2-9cm27 — `compute-sub` is the pure testing form
+                            ;; (Spec 008 §Testing): a compute against a SUPPLIED db,
+                            ;; outside any reactive cascade. No in-flight reaction
+                            ;; frame to attribute to, so `frame-id` is nil — the
+                            ;; `:where :sub-return` trace from this path is not tied
+                            ;; to a per-frame epoch (mirrors the direct-caller
+                            ;; 4-arity contract).
+                            (subs-memo/maybe-validate-sub! raw query-v query-id meta nil))
+                          (catch #?(:clj Throwable :cljs :default) e
+                            (let [msg #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))]
+                              (trace/emit-error!
+                                :rf.error/sub-exception
+                                {:failing-id        query-id
+                                 :rf.sub/id         query-id
+                                 :sub-query         query-v
+                                 :where             :compute-sub
+                                 :exception         e
+                                 :exception-message msg
+                                 :reason            (str "Subscription `" query-id
+                                                         "` threw while computing: "
+                                                         msg ". Returning nil.")
+                                 :recovery          :replaced-with-default}))
+                            nil))]
+            (swap! memo assoc query-v v)
+            v))))))
+
 (defn compute-sub
   "Compute a subscription's value against a supplied db, bypassing the
   reactive cache. Useful in tests that want to inspect what a sub
@@ -569,89 +662,32 @@
   sub's meta — failures emit :rf.error/schema-validation-failure and
   yield nil (default :replaced-with-default recovery).
 
-  ## Cost — N^2 on deep `:<-` chains (rf2-r0zf2)
+  ## Cost — linear in distinct subs per call (rf2-gyxm3 / rf2-r0zf2)
 
-  Each `:<-` input is resolved by RE-CALLING `compute-sub` against the
-  shared `db` — there is no memoisation across the recurse. A diamond
-  dependency (`:c` depends on `:a` and `:b`; both depend on `:root`)
-  computes `:root` twice; a longer reused-leaf chain compounds the
-  cost. The reactive `subscribe` path is immune (the per-frame
-  sub-cache deduplicates layer-2+ inputs across the dependency graph),
-  but `compute-sub` consciously bypasses that cache to stay pure.
+  A per-call memo `{query-v -> value}` is threaded through the `:<-`
+  recursion (see `compute-sub*`) so each DISTINCT sub in the dependency
+  graph computes at most ONCE per top-level `compute-sub` call. A
+  diamond dependency (`:c` depends on `:a` and `:b`; both depend on
+  `:root`) computes `:root` exactly once; a reused-leaf chain no longer
+  compounds multiplicatively. The memo is sound because for a fixed
+  `db` a sub's value is a pure function of `db` + its inputs, so
+  memoising by the full `query-v` (id + args) is value-identical to
+  re-computing.
 
-  Consumers that walk deep chains in tests / SSR / Story expecting
-  'fast pure compute' should pin the sub-result by hand and pass it
-  in instead of re-resolving the same input multiple times. The
-  shallow case (a sub with no `:<-` inputs, or a chain of distinct
-  intermediates) carries no quadratic risk."
+  This stays cache-free at the frame level — the memo is a per-call
+  internal accumulator scoped to one top-level `compute-sub`, NOT the
+  reactive per-frame sub-cache `subscribe` uses. The pure-snapshot
+  contract is unchanged: still purely a function of the supplied `db`,
+  no cross-call state, no reactive context.
+
+  Trace note: the memo elides duplicate `:rf.sub/run` emissions for a
+  shared input within one call — the sub runs (and emits) once; a
+  second reference is a memo hit. This matches the reactive path, where
+  the per-frame cache likewise computes a shared layer-2 input once."
   [query-v db]
-  (let [query-id (first query-v)
-        meta     (registrar/lookup :sub query-id)]
-    (when meta
-      ;; Per Spec 009 §:op-type vocabulary: :sub/run marks a sub recompute.
-      ;; The pure compute-sub form fires the same op-type as the reactive
-      ;; recompute path so tools can observe both call sites uniformly.
-      ;;
-      ;; Per rf2-l1jz8 — the reactive recompute path (subs.memo/validate-
-      ;; and-trace) enriches its `:sub/run` tag with value-change +
-      ;; cascade attribution (`:value-changed?` / `:prev-value` /
-      ;; `:value` / `:cascade?` / `:cause-sub`). `compute-sub` deliberately
-      ;; bypasses the per-frame reactive cache (it's the pure-snapshot
-      ;; form per Spec 008 §Testing), so it has NO prior cached value to
-      ;; diff for `:value-changed?` and NO reactive context to attribute a
-      ;; cascade against — each `:<-` input is re-resolved fresh against
-      ;; the supplied `db`, not observed as a changed upstream signal.
-      ;; It therefore emits the BASE `:sub/run` shape only; attribution is
-      ;; a reactive-path concern. Consumers (Xray) read attribution off
-      ;; the reactive epoch records, never off compute-sub emissions.
-      (trace/emit! :rf.sub :rf.sub/run
-                   {:rf.sub/id      query-id
-                    :rf.sub/query-v query-v})
-      (let [body-fn (:handler-fn meta)
-            inputs  (:input-signals meta)
-            ;; Bind n once — `(empty? inputs)` then `(= 1 (count inputs))`
-            ;; counted twice on the multi-input path (rf2-r1rma).
-            n       (count inputs)]
-        ;; Per Spec 009 §Error contract — body throws emit
-        ;; :rf.error/sub-exception and recover to nil. Mirrors
-        ;; `subs.memo/validate-and-trace` (the reactive sibling), so
-        ;; SSR + JVM-runnable consumers driving subs through
-        ;; `compute-sub` get the same debuggable signal the reactive
-        ;; path produces. The `:where :compute-sub` tag distinguishes
-        ;; this emission site from the reactive memo path; the rest of
-        ;; the envelope mirrors the sibling exactly (rf2-cos61).
-        (try
-          (let [v (cond
-                    (zero? n)
-                    (body-fn db query-v)
-
-                    (= 1 n)
-                    (body-fn (compute-sub (first inputs) db) query-v)
-
-                    :else
-                    (body-fn (mapv #(compute-sub % db) inputs) query-v))]
-            ;; rf2-9cm27 — `compute-sub` is the pure testing form (Spec 008
-            ;; §Testing): a compute against a SUPPLIED db, outside any
-            ;; reactive cascade. No in-flight reaction frame to attribute to,
-            ;; so `frame-id` is nil — the `:where :sub-return` trace from
-            ;; this path is not tied to a per-frame epoch (mirrors the
-            ;; direct-caller 4-arity contract).
-            (subs-memo/maybe-validate-sub! v query-v query-id meta nil))
-          (catch #?(:clj Throwable :cljs :default) e
-            (let [msg #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))]
-              (trace/emit-error!
-                :rf.error/sub-exception
-                {:failing-id        query-id
-                 :rf.sub/id         query-id
-                 :sub-query         query-v
-                 :where             :compute-sub
-                 :exception         e
-                 :exception-message msg
-                 :reason            (str "Subscription `" query-id
-                                         "` threw while computing: "
-                                         msg ". Returning nil.")
-                 :recovery          :replaced-with-default}))
-            nil))))))
+  ;; Seed a fresh per-call memo for the recursion. The public arity is
+  ;; unchanged; the memo is purely an internal accumulator.
+  (compute-sub* query-v db (atom {})))
 
 (defn unsubscribe
   "Decrement the ref-count on the cached subscription for query-v.

--- a/implementation/core/src/re_frame/substrate/plain_atom.cljc
+++ b/implementation/core/src/re_frame/substrate/plain_atom.cljc
@@ -20,11 +20,13 @@
   the parent reaction disposes. Both runtimes must honour that contract
   or input ref-counts leak monotonically until `clear-sub-cache!`.
 
-    - **JVM.** `re-frame.interop` (the `.clj`) implements
-      `add-on-dispose!` / `dispose!` directly, keyed by the reaction
-      object in a process-wide callback registry — so the plain-atom
-      JVM derived value (a bare `IDeref` reify) participates without
-      reifying any disposal protocol.
+    - **JVM.** The plain-atom JVM derived value IS an
+      `re-frame.interop/make-reaction` `Reaction` (per rf2-tnnln), which
+      carries its own on-dispose callback storage on the object. So
+      `re-frame.interop/add-on-dispose!` / `dispose!` store/fire
+      callbacks directly on the reaction — no process-wide registry, and
+      an orphaned reaction is GC-reclaimable along with its callbacks
+      rather than pinned in a global strong-ref map.
 
     - **CLJS.** `re-frame.interop` (the `.cljs`) routes those calls
       through the `:adapter/add-on-dispose!` / `:adapter/dispose!`
@@ -41,7 +43,8 @@
   — see that ns for the rationale on why only the container quartet (not
   `make-derived-value`) is shared."
   (:require [re-frame.substrate.atom-container :as atom-container]
-            #?@(:cljs [[re-frame.disposable :as rf-disposable]
+            #?@(:clj  [[re-frame.interop :as interop]]
+                :cljs [[re-frame.disposable :as rf-disposable]
                        [re-frame.substrate.adapter :as substrate-adapter]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -51,10 +54,12 @@
   ;; sub at most a handful of times per request; caching would add
   ;; complexity for negligible gain.
   ;;
-  ;; JVM: a bare `IDeref` reify suffices — `re-frame.interop` (the .clj)
-  ;; keys its `add-on-dispose!` / `dispose!` callback registry by this
-  ;; object's identity, so disposal participation needs no protocol on
-  ;; the value itself.
+  ;; JVM (rf2-tnnln): the derived value IS an `interop/make-reaction`
+  ;; `Reaction`, which carries its own on-dispose callback storage on the
+  ;; object. `re-frame.interop`'s `add-on-dispose!` / `dispose!` store and
+  ;; fire callbacks directly on it — no process-wide registry — so an
+  ;; un-disposed reaction is GC-reclaimable along with its callbacks
+  ;; rather than pinned in a global strong-ref map.
   ;;
   ;; CLJS (rf2-uatcy): `re-frame.interop` (the .cljs) routes
   ;; `add-on-dispose!` / `dispose!` through the `:adapter/*` hooks, which
@@ -66,9 +71,8 @@
   ;; source watches (it recomputes on deref), so `-dispose` only fires
   ;; the registered on-dispose callbacks.
   #?(:clj
-     (reify
-       clojure.lang.IDeref
-       (deref [_] (apply compute-fn (map deref source-containers))))
+     (interop/make-reaction
+       (fn [] (apply compute-fn (map deref source-containers))))
      :cljs
      (let [on-dispose-fns (atom [])]
        (reify

--- a/implementation/core/test/re_frame/interop_dispose_registry_test.clj
+++ b/implementation/core/test/re_frame/interop_dispose_registry_test.clj
@@ -1,0 +1,139 @@
+(ns re-frame.interop-dispose-registry-test
+  "Per rf2-tnnln — the JVM on-dispose callback storage must not leak
+  reactions in long-lived SSR processes.
+
+  The prior design held on-dispose callbacks in a process-wide
+  strong-ref `atom`-of-map keyed by reaction identity. Correctness
+  relied on PERFECT dispose symmetry: every `add-on-dispose!`'d
+  reaction had to reach `dispose!`, or the reaction (and its whole
+  layer-2+ input chain + compute-fn) was pinned in the registry
+  forever — the GC could not reclaim it even when nothing else
+  referenced it. For Spec 011's frame-per-request SSR profile (a JVM
+  server that churns frames continuously) that is a real leak surface.
+
+  The fix carries the callbacks ON the reaction object (an
+  `interop/make-reaction` `Reaction` deftype with a mutable callbacks
+  field), mirroring the CLJS plain-atom adapter. An orphaned reaction
+  is therefore GC-reclaimable along with its callbacks.
+
+  This suite pins:
+   (a) dispose symmetry / ordering / idempotency behaviour is unchanged;
+   (b) an un-disposed (orphaned) reaction is reclaimed by GC — the
+       behavioural delta the weak storage exists to deliver."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.interop :as interop])
+  (:import [java.lang.ref WeakReference]))
+
+;; ---- dispose symmetry / ordering / idempotency ----------------------------
+
+(deftest callbacks-fire-on-dispose-in-registration-order
+  (testing "add-on-dispose! callbacks fire in registration order on dispose!"
+    (let [r     (interop/make-reaction (fn [] :v))
+          fired (atom [])]
+      (interop/add-on-dispose! r (fn [] (swap! fired conj :a)))
+      (interop/add-on-dispose! r (fn [] (swap! fired conj :b)))
+      (interop/add-on-dispose! r (fn [] (swap! fired conj :c)))
+      (is (= :v @r) "the reaction still derefs to its computed value")
+      (interop/dispose! r)
+      (is (= [:a :b :c] @fired)
+          "callbacks fired in registration order"))))
+
+(deftest dispose-is-idempotent
+  (testing "a second dispose! is a no-op — callbacks cleared on first dispose"
+    (let [r     (interop/make-reaction (fn [] nil))
+          fired (atom 0)]
+      (interop/add-on-dispose! r (fn [] (swap! fired inc)))
+      (interop/dispose! r)
+      (interop/dispose! r)
+      (interop/dispose! r)
+      (is (= 1 @fired)
+          "callback fired exactly once across three dispose! calls"))))
+
+(deftest dispose-clears-before-fire
+  (testing "callbacks are cleared BEFORE firing — a re-entrant dispose! from
+            inside a callback does not re-fire the set"
+    (let [r     (interop/make-reaction (fn [] nil))
+          fired (atom 0)]
+      (interop/add-on-dispose! r (fn []
+                                   (swap! fired inc)
+                                   ;; Re-entrant dispose of the same reaction
+                                   ;; must find an empty callback set.
+                                   (interop/dispose! r)))
+      (interop/dispose! r)
+      (is (= 1 @fired)
+          "the re-entrant dispose! did not re-fire the callback"))))
+
+(deftest dispose-with-no-callbacks-is-a-noop
+  (testing "dispose! on a reaction that never registered a callback is safe"
+    (let [r (interop/make-reaction (fn [] 1))]
+      (is (nil? (interop/dispose! r))
+          "dispose! returns nil and does not throw"))))
+
+;; ---- fallback path for non-Reaction deref-ables ---------------------------
+
+(deftest bare-deref-able-still-participates-via-fallback
+  (testing "a bare reify IDeref (test double) still gets add-on-dispose! /
+            dispose! via the weak-keyed fallback registry"
+    (let [bare  (reify clojure.lang.IDeref (deref [_] nil))
+          fired (atom [])]
+      (interop/add-on-dispose! bare (fn [] (swap! fired conj :x)))
+      (interop/add-on-dispose! bare (fn [] (swap! fired conj :y)))
+      (interop/dispose! bare)
+      (is (= [:x :y] @fired)
+          "fallback registry fires callbacks in registration order")
+      ;; idempotent on the fallback path too
+      (interop/dispose! bare)
+      (is (= [:x :y] @fired)
+          "second dispose! on the fallback path is a no-op"))))
+
+;; ---- the leak fix: an orphaned reaction is GC-reclaimable -----------------
+
+(defn- gc-reclaimed?
+  "Return true when the referent of `wref` is reclaimed within a few GC
+  nudges. We can't force GC deterministically, so we loop a bounded
+  number of times with `System/gc` + a short pause, returning early on
+  reclamation."
+  [^WeakReference wref]
+  (loop [attempts 50]
+    (cond
+      (nil? (.get wref)) true
+      (zero? attempts)   false
+      :else              (do
+                           (System/gc)
+                           (Thread/sleep 20)
+                           (recur (dec attempts))))))
+
+(deftest orphaned-reaction-is-gc-reclaimable
+  (testing "Per rf2-tnnln: a reaction registered with an on-dispose callback
+            (including the production sub-cache shape, where the callback
+            CLOSES OVER the reaction) but NEVER explicitly disposed is still
+            reclaimed by GC. Pre-fix the global strong-ref registry pinned it
+            forever; on-object storage ties its lifetime to the reaction."
+    (let [wref (let [r (interop/make-reaction (fn [] :leaky))]
+                 ;; Register a callback that closes over the reaction itself
+                 ;; — the exact shape `re-frame.subs`'s sub-cache disposal
+                 ;; closure has (it captures `reaction` for an identity
+                 ;; guard). Under the old global strong-ref registry this
+                 ;; pinned the reaction: registry value -> closure -> reaction.
+                 (interop/add-on-dispose! r (fn [] (identical? r r)))
+                 ;; Deliberately DO NOT dispose! — simulate an orphaned
+                 ;; reaction (partial-teardown bug / exception before the
+                 ;; eventual dispose!). Hand back only a weak reference.
+                 (WeakReference. r))]
+      ;; Local strong ref `r` is now out of scope; nothing else references
+      ;; the reaction. It must be reclaimable.
+      (is (gc-reclaimed? wref)
+          "the un-disposed reaction (with a self-referencing on-dispose
+           callback) was reclaimed by GC — no permanent leak"))))
+
+(deftest reaction-strongly-held-is-not-reclaimed
+  (testing "control: while a strong reference is retained, the reaction is
+            NOT reclaimed — confirms `gc-reclaimed?` actually observes
+            reachability rather than always reporting reclamation."
+    (let [r    (interop/make-reaction (fn [] :held))
+          wref (WeakReference. r)]
+      (interop/add-on-dispose! r (fn [] nil))
+      (is (false? (gc-reclaimed? wref))
+          "a live reaction is retained across GC")
+      ;; Keep `r` strongly reachable past the assertion.
+      (is (= :held @r)))))

--- a/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
+++ b/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
@@ -15,9 +15,16 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
+            [re-frame.router :as router]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
+
+(def ^:private build-envelope
+  "Pull the private envelope builder — the dispatch envelope is not
+  exposed to user handlers, so the `:dispatched-at` gating (rf2-vkey0)
+  is asserted directly against `build-envelope`'s output."
+  #'router/build-envelope)
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -71,6 +78,27 @@
         (is (= 1 (count @seen))
             "event-emit substrate fired under disabled debug gate
              — always-on means always-on")))))
+
+(deftest dispatched-at-stamped-only-when-debug-enabled
+  (testing "Per rf2-vkey0: `:dispatched-at` is dev-only envelope
+            metadata gated on `interop/debug-enabled?` — exactly like
+            `:dispatch-id`. When the gate is ON, every envelope carries
+            a fresh `:dispatched-at` timestamp; when OFF (the SSR
+            production posture), the `now-ms` call and the assoc both
+            elide so production envelopes carry no `:dispatched-at`."
+    (rf/reg-frame :rf/default {})
+    (testing "debug ON -> :dispatched-at present"
+      (with-redefs [interop/debug-enabled? true]
+        (let [env (build-envelope [:noop] {})]
+          (is (contains? env :dispatched-at)
+              "envelope carries :dispatched-at under enabled gate")
+          (is (number? (:dispatched-at env))
+              ":dispatched-at is a timestamp"))))
+    (testing "debug OFF -> :dispatched-at elided (key absent, no now-ms call)"
+      (with-redefs [interop/debug-enabled? false]
+        (let [env (build-envelope [:noop] {})]
+          (is (not (contains? env :dispatched-at))
+              "envelope carries NO :dispatched-at under disabled gate"))))))
 
 (deftest always-on-error-emit-still-fires-when-debug-disabled
   (testing "Per Spec 009 §Error-emit + rf2-bacs4 / rf2-hqbeh: the

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -378,6 +378,65 @@
       (is (= 25 (rf/compute-sub [:stable/squared] (rf/app-db-value f)))
           "value still correct after a value-equal app-db replacement"))))
 
+;; ---- compute-sub per-call memoisation (rf2-gyxm3) -------------------------
+;;
+;; `compute-sub` threads a per-call `{query-v -> value}` memo through its
+;; `:<-` recursion so each DISTINCT sub in the dependency graph computes
+;; at most once per top-level call. These tests pin that contract by
+;; counting body invocations against a known graph shape, AND confirm the
+;; memo does not change computed values (it is a pure dedup).
+
+(deftest compute-sub-memoises-shared-input-in-a-diamond-jvm
+  (testing "a diamond (:c <- :a,:b ; :a <- :root ; :b <- :root) resolves
+            :root exactly ONCE per top-level compute-sub call"
+    (let [root-calls (atom 0)]
+      (rf/reg-sub :memo/root (fn [db _] (swap! root-calls inc) (:n db)))
+      (rf/reg-sub :memo/a :<- [:memo/root] (fn [r _] (inc r)))
+      (rf/reg-sub :memo/b :<- [:memo/root] (fn [r _] (dec r)))
+      (rf/reg-sub :memo/c
+        :<- [:memo/a]
+        :<- [:memo/b]
+        (fn [[a b] _] {:a a :b b}))
+      (reset! root-calls 0)
+      (let [v (rf/compute-sub [:memo/c] {:n 10})]
+        (is (= {:a 11 :b 9} v)
+            "value is correct — memo is a pure dedup, never changes the result")
+        (is (= 1 @root-calls)
+            ":root computed exactly once despite two diamond paths reaching it")))))
+
+(deftest compute-sub-memoises-reused-leaf-in-a-deep-graph-jvm
+  (testing "a deeper reused-leaf graph computes the shared leaf once, not
+            multiplicatively"
+    (let [leaf-calls (atom 0)]
+      ;; Graph: top <- {l1,l2} ; l1 <- leaf ; l2 <- leaf ; leaf <- (db).
+      ;; Pre-fix, `leaf` resolves twice (once per l1/l2 path); the memo
+      ;; collapses it to one.
+      (rf/reg-sub :memo/leaf (fn [db _] (swap! leaf-calls inc) (:base db)))
+      (rf/reg-sub :memo/l1 :<- [:memo/leaf] (fn [x _] (* x 2)))
+      (rf/reg-sub :memo/l2 :<- [:memo/leaf] (fn [x _] (* x 3)))
+      (rf/reg-sub :memo/top
+        :<- [:memo/l1]
+        :<- [:memo/l2]
+        (fn [[a b] _] (+ a b)))
+      (reset! leaf-calls 0)
+      (let [v (rf/compute-sub [:memo/top] {:base 5})]
+        (is (= 25 v) "5*2 + 5*3 = 25 — value unaffected by memoisation")
+        (is (= 1 @leaf-calls)
+            "the shared leaf computed exactly once across both intermediate paths")))))
+
+(deftest compute-sub-memo-is-per-call-not-cross-call-jvm
+  (testing "the memo is scoped to ONE top-level compute-sub call — a second
+            call against a different db recomputes (no stale cross-call cache)"
+    (let [calls (atom 0)]
+      (rf/reg-sub :memo/leaf2 (fn [db _] (swap! calls inc) (:v db)))
+      (rf/reg-sub :memo/up :<- [:memo/leaf2] (fn [x _] (inc x)))
+      (reset! calls 0)
+      (is (= 2 (rf/compute-sub [:memo/up] {:v 1})))
+      (is (= 11 (rf/compute-sub [:memo/up] {:v 10}))
+          "second call sees the new db value — memo did not persist across calls")
+      (is (= 2 @calls)
+          "leaf computed once per top-level call (twice total), not memoised across calls"))))
+
 ;; ---- subscription chain ---------------------------------------------------
 
 (deftest layer-1-and-layer-2-subs


### PR DESCRIPTION
Core review-sweep bundle. Three findings from the senior-dev review of `implementation/core/`, all scoped to core.

## rf2-vkey0 — `:dispatched-at` dead data on every prod dispatch (P3)
`build-envelope` (router.cljc) stamped `:dispatched-at (interop/now-ms)` **unconditionally** on every dispatch envelope — unlike its sibling debug keys (`:dispatch-id`, `:call-site`, …) which all ride the `(when interop/debug-enabled? …)` gate. A corpus grep confirms **zero consumers**.

**Fix (option b — gate, not remove):** bind `dispatched-at` under `interop/debug-enabled?` and assoc it via the `cond->`, exactly like the adjacent `:dispatch-id` slot, so the `now-ms` call + assoc DCE under `:advanced` + `goog.DEBUG=false` (and the JVM `-Dre-frame.debug=false` SSR-prod gate). The `:rf/dispatch-envelope` schema already marks `:dispatched-at {:optional true}` ("CLJS reference may add … tools tolerate"), so production absence stays spec-valid — **no hot-zone spec touch required**.

## rf2-gyxm3 — `compute-sub` O(N^2) on diamond/deep `:<-` chains (P4)
`compute-sub` re-resolved each `:<-` input by re-calling itself with no memo, so a diamond computed the shared root twice and reused-leaf chains compounded multiplicatively.

**Fix:** new private `compute-sub*` worker threads a per-call `{query-v -> value}` memo through the recursion; each distinct sub computes — and emits `:rf.sub/run` — at most once per top-level call. Public arity unchanged (the memo is an internal accumulator). Pure-snapshot contract preserved (no frame-level cache; still a pure function of the supplied db). Memo uses `contains?` rather than a keyword sentinel so a memoised `nil` is a valid hit and CLJS keyword identity isn't relied on.

## rf2-tnnln — JVM `interop` dispose registry strong-ref leak (P3)
The JVM held on-dispose callbacks in a process-wide strong-ref `atom`-of-map keyed by reaction identity. Any reaction dropped without an explicit `dispose!` (partial-teardown bug, exception between register and dispose) was pinned forever — a real leak for Spec 011's long-lived frame-per-request SSR profile.

**Fix:** carry callbacks **on the reaction object** (an `interop/make-reaction` `Reaction` deftype with a mutable callbacks field), mirroring the CLJS plain-atom adapter — so an orphaned reaction is GC-reclaimable along with its callbacks. A weak-keyed `WeakHashMap` fallback handles non-`Reaction` deref-ables (bare reify test doubles, plain atoms). The JVM plain-atom `make-derived-value` now produces a `Reaction`. Dispose symmetry / registration-order / idempotency / clear-before-fire all unchanged. (Plain `WeakHashMap` keyed by the reaction would NOT fix the leak: the production sub-cache disposal closure closes over the reaction, so the map value would strong-ref its own key — on-object storage sidesteps this.)

## Tests added
- JVM prod-gate `:dispatched-at` elision regression (`jvm_prod_gate_integration_test.clj`).
- `compute-sub` diamond / reused-leaf / per-call-not-cross-call memo regressions (`smoke_test.clj`).
- New `interop_dispose_registry_test.clj`: dispose symmetry/order/idempotency/clear-before-fire, fallback path, and GC reclamation of an orphaned self-referencing-callback reaction (+ a strong-held control).

## Gates (cold)
- JVM core `clojure -M:test`: **855 tests / 3799 assertions, 0 failures, 0 errors**.
- `npm run test:cljs`: **5477 tests / 19066 assertions, 0 failures, 0 errors**.
- `npm run test:elision`: **PASS** (production 40/40 absent; control 40/40 present).
- `npm run test:bundle-isolation`: **PASS**.
- `npm run test:browser`: 2 pre-existing failures, both in `tools/machines-viz/chart` (`chart-namespaced-tag-preserves-declared-identity`, pill renders `open` not `door/open`) — reproduce on `origin/main` HEAD, unrelated to this PR's core scope. Filed as **rf2-dol5l**.

## Spec
No normative `spec/*` change: `:dispatched-at` is already `{:optional true}` in `:rf/dispatch-envelope`, so gating it (production-absent) is spec-compliant without editing the hot-zone schema docs.

Closes rf2-vkey0, rf2-gyxm3, rf2-tnnln.