### PR TITLE
test(mcp-conformance): pin single canonical :registered? spelling in flag-gates (rf2-zewxo)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
+++ b/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
@@ -202,10 +202,19 @@ async function assertWriteGateOpensWithFlag() {
       );
     }
     const struct = resp.structuredContent || {};
-    if (struct.registered !== true && struct['registered?'] !== true) {
+    // Pin the SINGLE canonical key story-mcp emits: `:registered?`
+    // (Cheshire keeps the `?` → JSON key `registered?`; pinned JVM-side
+    // by tools_test.clj and by the sibling end-to-end-story.cjs). The
+    // earlier `registered || registered?` alternation tolerated two
+    // spellings — masking exactly the envelope-key drift this harness
+    // family pins single-spelling (rf2-ee38b.20). A drift to bare
+    // `registered` would slip past here while end-to-end-story.cjs caught
+    // it RED; tighten to the one canonical spelling so this code path
+    // agrees with its sibling.
+    if (struct['registered?'] !== true) {
       throw new Error(
         'story-mcp register-variant with --allow-writes MUST report ' +
-          'registered; got: ' + JSON.stringify(resp),
+          ':registered? true; got: ' + JSON.stringify(resp),
       );
     }
     console.log(


### PR DESCRIPTION
## Correctness review of `tools/mcp-conformance/` (rf2-zewxo)

Systematic CORRECTNESS review of the MCP conformance harness — does the gate validate what it claims, and are there false-confidence assertions where a non-conformant server would pass green?

### Defect fixed (clear, with settled precedent)

`test/end-to-end-flag-gates.cjs` `assertWriteGateOpensWithFlag` tolerated **two** spellings of the `register-variant` success envelope key:

```js
if (struct.registered !== true && struct['registered?'] !== true) { ... }
```

The sibling `test/end-to-end-story.cjs` was deliberately tightened under rf2-ee38b.20 to pin ONLY `registered?`, with an explicit comment that the two-spelling alternation "masks exactly the envelope-key drift the rest of this harness pins single-spelling". `flag-gates` asserts on the **same** `register-variant` envelope, so the dual-spelling here is the exact false-confidence pattern the project already ruled against: a drift to bare `registered` would slip past flag-gates while `end-to-end-story.cjs` caught it RED. Tightened to the one canonical spelling (`registered?`). Verified green against the live story-mcp server.

### Reviewed clean (no defects)

- **Always-on gates** (pair-mcp degraded end-to-end, story-mcp end-to-end, flag-gates, exec-safety, wire-vocab JVM): assertion logic is sound. Every `callTool` routes through the SDK's `CallToolResultSchema`/`ListToolsResultSchema` parse (the load-bearing protocol check), and the structuredContent / catalogue / descriptor-shape assertions pin single canonical key spellings throughout `end-to-end-story.cjs`.
- **Live gates** (overflow / subscribe / redaction): SKIP-gated on `$SHADOW_CLJS_NREPL_PORT`, run hermetically on CI. The redaction gate pins BOTH directions (sentinel ABSENT gate-OFF + `:rf/redacted` PRESENT; sentinel SHIPS gate-ON) so the gate can't silently invert; the "present-redacted, not merely absent" assertion correctly distinguishes "walker fired" from "epoch fell outside the window". The overflow body / progress-params cross-encoding gates (JS table ↔ Malli schema) are pinned from both sides.
- **`_runner.cjs`**: teardown-in-`finally` correctly prevents a `client.close()` throw from inverting a green body to FAIL; watchdog installed before transport construction.
- **`lib/exec-safety.cjs`**: realpath-based workspace-escape + symlink-escape gating is correct.

### Latent (noted, not fixed — constant inputs make them inert)

- `lib/dedup-envelope.cjs` `expandEntry` installs an `undefined` placeholder before recursing; a genuine cyclic cache ref would silently resolve to `undefined` rather than erroring. Comment correctly notes real de-dupe caches are acyclic, so this is defensive-only.
- Hermetic orchestrator's hand-rolled bencode uses `code.length` (UTF-16 char count) as the byte-length prefix; correct only for ASCII. The probe string is a fixed ASCII constant, so inert today.

### Quality gates (COLD, all green)

- `node test/end-to-end-re-frame2-pair.cjs` — GREEN (28 tools)
- `node test/end-to-end-story.cjs` — GREEN (20 tools)
- `node test/end-to-end-flag-gates.cjs` — GREEN (incl. the tightened assertion)
- `node --test test/exec-safety.test.cjs` — GREEN (8 pass, 4 Windows symlink soft-skips)
- `wire-vocab` `clojure -M:test` — GREEN (49 tests / 629 assertions)

Live overflow/subscribe/redaction SKIP without `$SHADOW_CLJS_NREPL_PORT` (as designed).