### PR TITLE
docs(template): correctness review — fix two stale doc claims (rf2-qsarw)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -53,9 +53,13 @@ causality graph, time-travel scrubber.
 Release builds drop the preload automatically (shadow only runs
 preloads under `watch` / `compile`, never `release`).
 
-Stack traces in dev also get click-to-source via the
-`:rf.trace/trigger-handler` preload — clicking a frame in the dev
-console jumps straight to the offending form.
+Xray's panel also offers click-to-source: each trace row that carries
+a source coordinate (the `:rf.trace/trigger-handler` that re-frame2
+tags onto view-render trace events, plus the `:source-coord` on event
+/ fx / interceptor rows) renders a jump-to-source link, so you can
+click straight from a dispatch in the log to the form that defined the
+handler. No extra preload or wiring — it ships with the Xray preload
+above.
 
 ## Story playground (if scaffolded with `:include-story? true`)
 

--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -91,13 +91,16 @@ choice swaps:
   is added. The `:app` build's `:devtools {:preloads …}` carries
   `day8.re-frame2-xray.preload` identically across variants.
 
-The substrate-agnostic shell — `events.cljs`, `subs.cljs`,
-`schema.cljs`, `README.md`, `.gitignore`,
-`resources/public/index.html` — lives under the `_shared/` resource
-sub-tree and is emitted identically across all three variants.
-`schema.cljs` is substrate-agnostic: the whole-app-db Malli schema
-and `reg-app-schema` registration are the same regardless of view
-library.
+The substrate-agnostic shell is emitted identically across all three
+variants. It splits across two resource sub-trees (see
+[002-Generated-Shape.md §Resource tree](002-Generated-Shape.md#resource-tree-template-side)):
+the renamed-at-emit sources — `events.cljs`, `subs.cljs`,
+`schema.cljs`, and the dotfiles (`.gitignore` etc.) — live under
+`_shared/`; the default-placement files (`README.md`,
+`resources/public/index.html`, `resources/public/css/app.css`,
+`dev/*`) are bulk-copied from `root/`. `schema.cljs` is
+substrate-agnostic: the whole-app-db Malli schema and `reg-app-schema`
+registration are the same regardless of view library.
 
 ## The counter throughline
 


### PR DESCRIPTION
## Summary

CORRECTNESS review of the `tools/template/` slice (rf2-qsarw). The scaffolded deps-new template is in good shape — the runtime API surface, version pins, substrate matrix, and the layered JVM test suite (25 tests / 316 assertions, all green) are correct and current. Two **documentation** correctness defects fixed here; one deeper test/CI drift filed as a follow-up bead.

## Fixed in this PR (docs only — no generated-output change)

1. **Generated `root/README.md`** described a fictitious "`:rf.trace/trigger-handler` preload" delivering click-to-source "in the dev console". There is exactly **one** preload (`day8.re-frame2-xray.preload`); `:rf.trace/trigger-handler` is a *trace-event slot*, not a preload, and the jump-to-source affordance is an **Xray panel** feature (it consumes `:rf.trace/trigger-handler` + `:source-coord`), not a browser-dev-console capability. Reworded to describe it accurately.
2. **`spec/001-Substrate-Variants.md`** claimed `resources/public/index.html` (and `README.md`) "lives under the `_shared/` resource sub-tree". Those default-placement files are bulk-copied from `root/`, not `_shared/` (per `002-Generated-Shape.md`). Corrected to the accurate two-subtree split.

## Filed as a follow-up bead (not fixed here)

- **rf2-cag9a** — the `clojure -P` deps-resolve smoke (rf2-n1ezd) was dropped with the clj-new tree (rf2-40vmd) and never re-ported to the deps-new suite, but `Principles.md §P7`, `DESIGN-RATIONALE.md`, and `.github/workflows/expensive-tests.yml` (`RF2_TEMPLATE_DEPS_RESOLVE: "1"`, a now-dead env var) still reference it. Resolution (restore vs remove) is a judgment call and the CI fix touches hot-zone `.github/workflows/*`, so it's beaded rather than fixed inline.

## What I verified

- Core/adapter API used by all three substrate templates is current: `rf/init!`, `app-db-value`, `reg-view`/`re-frame.views`, `reg-app-schema`, `register-listener!` (`re-frame.trace.tooling`), `re-frame.schemas`/`.malli`, `with-frame`/`with-new-frame`, UIx `use-subscribe`/`render-root`, Helix `use-subscribe`/`createRoot`, Story `mount-shell!`/`unmount-shell!`, `re-frame.story.config/enabled?` — all match the reference impl and the canonical `examples/<substrate>/counter*/`.
- Version pins (react 19.2.0, shadow 3.4.10, helix 0.2.2, uix 1.4.4, cljs 1.12.145, reagent 2.0.1, rf2 0.0.1.alpha) match `implementation/`; the lockstep guard enforces them.
- Traced the deps-new `post-process-fn` data flow (data-fn's coerced `:substrate` string shadows the raw keyword in `final-opts`) — the "Generated … (reagent substrate)" console output is correct, not a defect.
- `clojure -M:test` from `tools/template/` — **25 tests, 316 assertions, 0 failures** (cold), before and after the edits.

## Residual risk

Low. Docs-only changes; no behavioural surface touched. The deeper test/CI drift is captured in rf2-cag9a.

Closes rf2-qsarw.