### PR TITLE
fix(epoch): materialise ring-cap window to release evicted records (rf2-rkbil)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -197,20 +197,36 @@
       history)))
 
 (defn- append-record
-  "Conj `record` onto the frame's history vector, cap to `d` via
-  `subvec` (cheap structural reuse — no copy), then elide the just-
-  crossed record's `:trace-events` per `keep`.
+  "Conj `record` onto the frame's history vector, cap to `d` by
+  MATERIALISING the most-recent-`d` window into a fresh vector, then
+  elide the just-crossed record's `:trace-events` per `keep`.
+
+  The cap MUST materialise — a bare `(subvec history+ ...)` view does
+  NOT release the evicted records. `SubVector.cons` keeps appending to
+  the SAME growing underlying vector and `subvec` of a `SubVector`
+  re-wraps that same backing vector, so over a long session the
+  depth-`d` view's backing PersistentVector accretes every record ever
+  appended (each carrying its full `:db-before` / `:db-after` /
+  `:trace-events` payload) — an unbounded heap leak that defeats the
+  bounded-ring contract even though `history-for` correctly returns
+  only `d` records. `(into [] (subvec ...))` copies the `d`-element
+  window into a concrete PersistentVector whose backing is exactly `d`,
+  so the evicted records become GC-eligible.
 
   HOT PATH: fires once per cascade settle, i.e. once per dispatched
-  user event under steady state. Cost is O(1) in both the depth cap
-  and the trace-events elision — the vector grows by one, optionally
-  drops its leftmost element via `subvec`, and at most one record's
-  `:trace-events` slot is dissoc'd."
+  user event under steady state. Below the cap the append is O(1) (a
+  plain `conj`); once the ring is full each append is O(d) — a `d`-wide
+  copy of the retained window (d defaults to 50, fired once per
+  user-facing event, not per trace emit). The bounded copy is the
+  necessary cost of bounded heap; the prior O(1) `subvec` view was O(1)
+  in time but O(session-length) in retained heap. The trace-events
+  elision stays O(1) — at most one record's `:trace-events` slot is
+  dissoc'd."
   [history record d keep]
   (let [history+ (conj (or history []) record)
         n        (count history+)
         capped   (if (and (pos? d) (> n d))
-                   (subvec history+ (- n d))
+                   (into [] (subvec history+ (- n d)))
                    history+)]
     (elide-just-crossed-trace-events capped keep)))
 

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -318,6 +318,49 @@
       (is (= [{:n 3} {:n 4} {:n 5}] dbs)
           "the three most-recent are kept; oldest evicted"))))
 
+(deftest ring-cap-materialises-and-releases-evicted-records
+  ;; rf2-rkbil correctness review: the ring cap MUST materialise the
+  ;; retained window into a fresh PersistentVector. A bare
+  ;; `(subvec history+ ...)` view does NOT release the evicted records —
+  ;; `SubVector.cons` keeps appending to the same growing underlying
+  ;; vector and `subvec` of a `SubVector` re-wraps that same backing, so
+  ;; the depth-d view's backing vector accretes EVERY record ever
+  ;; appended (each with its full :db-before / :db-after / :trace-events
+  ;; payload) even though `epoch-history` correctly returns only d
+  ;; records — an unbounded heap leak that defeats the bounded-ring
+  ;; contract. This pins that the retained window is a concrete vector
+  ;; whose backing storage is bounded by the configured depth, so
+  ;; evicted records become GC-eligible.
+  (testing "ring cap releases evicted records (no SubVector backing-vector leak)"
+    (let [depth 3]
+      (rf/configure! :epoch-history {:depth depth})
+      (rf/reg-frame :test/main {})
+      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+      (rf/reg-event-db :inc  (fn [db [_ i]] (assoc db :n i)))
+
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      ;; Drive far more events than the depth so the cap fires many times.
+      (dotimes [i 200] (rf/dispatch-sync [:inc i] {:frame :test/main}))
+
+      (let [history (rf/epoch-history :test/main)]
+        (is (= depth (count history))
+            "history is capped at the configured depth")
+        ;; The retained vector must be a concrete PersistentVector, NOT a
+        ;; SubVector view. A SubVector here would mean the backing vector
+        ;; still references all 201 evicted-and-live records.
+        (is (not (instance? clojure.lang.APersistentVector$SubVector history))
+            (str "history must be a materialised PersistentVector, not a "
+                 "SubVector view that retains the evicted records' backing "
+                 "storage; got " (class history)))
+        ;; Belt-and-braces: if a future refactor reintroduces a SubVector,
+        ;; assert its backing vector is bounded by the depth rather than
+        ;; the full append count (the leak signature).
+        (when (instance? clojure.lang.APersistentVector$SubVector history)
+          (let [f (doto (.getDeclaredField clojure.lang.APersistentVector$SubVector "v")
+                    (.setAccessible true))]
+            (is (<= (count (.get f history)) depth)
+                "SubVector backing vector must not retain evicted records")))))))
+
 (deftest depth-zero-disables-recording
   (testing "depth 0 disables ring recording"
     (rf/configure! :epoch-history {:depth 0})


### PR DESCRIPTION
## Summary

Correctness review of the `implementation/epoch/` slice (bead **rf2-rkbil**). One clear defect found and fixed; the rest of the slice is clean.

### Defect: unbounded heap leak in the per-frame ring buffer

`re-frame.epoch.state/append-record` capped the frame's history with a bare `(subvec history+ (- n d))`. `subvec` returns a **SubVector view**, and:

- `SubVector.cons` (the `conj` path) appends to the **same growing underlying vector** rather than materialising,
- `subvec` of a SubVector re-wraps that **same backing vector**.

So over a long dev/pair session the depth-`d` view's backing `PersistentVector` accretes **every record ever appended** — each carrying its full `:db-before` / `:db-after` / `:trace-events` payload — even though `epoch-history` correctly returns only `d` records. The eviction is visually correct but the evicted records are **never released for GC**. Verified empirically: after 100k appends to a depth-50 ring, the backing vector retained all 100k records (CLJS is the primary runtime for this dev surface and exhibits the same SubVector retention).

This defeats the entire purpose of the bounded ring buffer (the docstring claimed "cheap structural reuse — no copy" as a *feature*; that "no copy" was the source of the false bounded-heap invariant).

### Fix

Materialise the retained window via `(into [] (subvec ...))` — a concrete `d`-element `PersistentVector` whose backing is bounded by depth, so evicted records become GC-eligible. Below the cap the append stays O(1); once full each append is an O(`d`) window copy (`d` defaults to 50, fired **once per dequeued event**, not per trace emit) — the necessary cost of bounded heap. Docstring updated to state the true cost/contract.

Correctness-only: output is byte-identical (same `d` records, same order); only the concrete vector type and retained backing storage change.

### Regression test

`ring-cap-materialises-and-releases-evicted-records` (in `epoch_test.clj`): dispatches 200+ events into a depth-3 ring and pins that the history is a materialised `PersistentVector` (not a SubVector view), plus a defensive backing-size assertion (`<= depth`) that fires on the leak signature. Verified it fails against the old code (backing size 201) and passes against the fix (backing size 3).

## Test gate (cold)

`clojure -M:test` from `implementation/epoch/`: **246 tests, 894 assertions, 0 failures** (was 245/892 pre-fix; +1 test). Also green with the JVM concurrency stress scenario included (`RF2_RD7A7_STRESS_ITERS=300`).

## Scope

`implementation/epoch/` only — one source file, one test file. No `spec/*` / hot-zone touch.

## Residual risks (not actioned — see report)

- `back-fill-event!` captures an external atom inside a `swap!` fn; harmless because the back-fill path is React-commit-driven (CLJS, no swap retries) and never runs on the JVM. Stylistic only.
- rf2-7n0kf (cascade-cause `:value-changed-subs` sub-cap docstring) already filed; not duplicated.

Do not merge — queued behind the u0du8/#2922 browser-test fix per dispatch note.
