### PR TITLE
fix(skills): correct stale machine-callback signature in skills/re-frame2 (rf2-6uq5d)

### DIFF
--- a/skills/re-frame2/patterns/boot.md
+++ b/skills/re-frame2/patterns/boot.md
@@ -32,26 +32,26 @@ For trivial boots (≤3 steps, no error states, no progress UI), use the chained
      :data    {:phase :configuring :config nil :user nil :error nil :phase-attempt 0}
 
      :guards
-     {:under-retry-limit? (fn [data _] (< (:phase-attempt data) 3))}
+     {:under-retry-limit? (fn [{:keys [data]}] (< (:phase-attempt data) 3))}
 
      :actions
-     {:record-config (fn [data [_ c]] {:data (assoc data :config c)})
-      :record-user   (fn [data [_ u]] {:data (assoc data :user u)})
-      :record-error  (fn [data [_ e]] {:data (assoc data :error e)})
-      :bump-attempt  (fn [data _]     {:data (update data :phase-attempt inc)})
+     {:record-config (fn [{data :data [_ c] :event}] {:data (assoc data :config c)})
+      :record-user   (fn [{data :data [_ u] :event}] {:data (assoc data :user u)})
+      :record-error  (fn [{data :data [_ e] :event}] {:data (assoc data :error e)})
+      :bump-attempt  (fn [{:keys [data]}]            {:data (update data :phase-attempt inc)})
 
       ;; CONSOLIDATED :entry — :set-phase + :resolve-initial-route in one fn.
       ;; :entry slots accept one fn / id, never a vector; compose by returning
       ;; both :data and :fx from one action.
       :enter-routing
-      (fn [data _]
+      (fn [{:keys [data]}]
         {:data (assoc data :phase :routing :phase-attempt 0)
          :fx   [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})
 
-      :phase-configuring (fn [d _] {:data (assoc d :phase :configuring :phase-attempt 0)})
-      :phase-auth        (fn [d _] {:data (assoc d :phase :authenticating)})
-      :phase-profile     (fn [d _] {:data (assoc d :phase :loading-profile)})
-      :phase-hydrate     (fn [d _] {:data (assoc d :phase :hydrating)})}
+      :phase-configuring (fn [{d :data}] {:data (assoc d :phase :configuring :phase-attempt 0)})
+      :phase-auth        (fn [{d :data}] {:data (assoc d :phase :authenticating)})
+      :phase-profile     (fn [{d :data}] {:data (assoc d :phase :loading-profile)})
+      :phase-hydrate     (fn [{d :data}] {:data (assoc d :phase :hydrating)})}
 
      :states
      {:configuring

--- a/skills/re-frame2/patterns/forms.md
+++ b/skills/re-frame2/patterns/forms.md
@@ -135,23 +135,23 @@ Used when the form's lifecycle is *part of* a larger page's machine (composes wi
              :submitted nil :loaded-at nil}
    :actions
    {:edit-field
-    (fn [d [_ {:keys [field value]}]]
+    (fn [{d :data [_ {:keys [field value]}] :event}]
       {:data (-> d (assoc-in [:draft field] value)
                    (update :touched (fnil conj #{}) field)
                    (update :errors  dissoc field)
                    (assoc  :submit-error nil))})
     :set-errors
-    (fn [d [_ {:keys [errors]}]]
+    (fn [{d :data [_ {:keys [errors]}] :event}]
       {:data (-> d (assoc :errors errors)
                    (update :touched (fnil into #{}) (keys errors)))})
     :begin-submit
-    (fn [d [_ {:keys [submitted]}]]
+    (fn [{d :data [_ {:keys [submitted]}] :event}]
       {:data (-> d (assoc :submitted submitted :errors {} :submit-error nil))})
     :store-user
-    (fn [d [_ {:keys [user]}]]
+    (fn [{d :data [_ {:keys [user]}] :event}]
       {:data (-> d (assoc :draft (draft-from-user user) :errors {} :submit-error nil))})
     :set-submit-error
-    (fn [d [_ {:keys [submit-error]}]] {:data (assoc d :submit-error submit-error)})}
+    (fn [{d :data [_ {:keys [submit-error]}] :event}] {:data (assoc d :submit-error submit-error)})}
    :states
    {:neutral    {:tags #{:settings/neutral}
                  :on {:edit           {:target :neutral    :action :edit-field}

--- a/skills/re-frame2/patterns/long-running-work.md
+++ b/skills/re-frame2/patterns/long-running-work.md
@@ -40,16 +40,16 @@ One parent coordinator spawns N children declaratively via `:spawn-all`. Each ch
 (rf/reg-machine :work/processor
   {:initial :idle
    :data    {:shard nil :total 0 :processed 0 :tick-ms 50}
-   :guards  {:done?      (fn [data _] (>= (:processed data) (:total data)))
-             :more-work? (fn [data _] (<  (:processed data) (:total data)))}
+   :guards  {:done?      (fn [{:keys [data]}] (>= (:processed data) (:total data)))
+             :more-work? (fn [{:keys [data]}] (<  (:processed data) (:total data)))}
    :actions
    {:process-one
-    (fn [data _]
+    (fn [{:keys [data]}]
       (let [new-processed (inc (:processed data))]
         {:data (assoc data :processed new-processed)
          :fx   [[:dispatch [:work/flow [:progress (:shard data) new-processed (:total data)]]]]}))
     :dispatch-done
-    (fn [data _] {:fx [[:dispatch [:work/flow [:work/child-done (:shard data)]]]]})}
+    (fn [{:keys [data]}] {:fx [[:dispatch [:work/flow [:work/child-done (:shard data)]]]]})}
    :states
    {:idle           {:on    {:rf.machine.spawn/spawned :processing}}
     :processing     {:entry :process-one :always [{:target :checking-done}]}
@@ -63,9 +63,9 @@ One parent coordinator spawns N children declaratively via `:spawn-all`. Each ch
   {:initial :idle
    :data    {:shards [:s1 :s2 :s3] :progress {} :outcome nil}
    :actions
-   {:reset-progress  (fn [data _] {:data (assoc data :progress (zipmap (:shards data) (repeat 0)))})
-    :record-progress (fn [data [_ shard processed _]] {:data (assoc-in data [:progress shard] processed)})
-    :stamp-outcome   (fn [data [ev]] {:data (assoc data :outcome
+   {:reset-progress  (fn [{:keys [data]}] {:data (assoc data :progress (zipmap (:shards data) (repeat 0)))})
+    :record-progress (fn [{data :data [_ shard processed _] :event}] {:data (assoc-in data [:progress shard] processed)})
+    :stamp-outcome   (fn [{data :data [ev] :event}] {:data (assoc data :outcome
                                                   (case ev :work/all-done :complete
                                                            :cancel        :cancelled
                                                            :work/any-failed :error

--- a/skills/re-frame2/patterns/nine-states.md
+++ b/skills/re-frame2/patterns/nine-states.md
@@ -30,12 +30,12 @@ Lifted from `examples/reagent/nine_states/core.cljs`. Three regions; tags on eve
   {:type :parallel
    :data {:items [] :error nil}
    :guards
-   {:empty?    (fn [d _] (zero?  (count (:items d))))
-    :one?      (fn [d _] (= 1    (count (:items d))))
-    :too-many? (fn [d _] (> (count (:items d)) too-many-threshold))}
+   {:empty?    (fn [{d :data}] (zero?  (count (:items d))))
+    :one?      (fn [{d :data}] (= 1    (count (:items d))))
+    :too-many? (fn [{d :data}] (> (count (:items d)) too-many-threshold))}
    :actions
-   {:set-items (fn [d [_ {:keys [items]}]] {:data (assoc d :items (vec items) :error nil)})
-    :set-error (fn [d [_ {:keys [failure]}]] {:data (assoc d :error failure)})}
+   {:set-items (fn [{d :data [_ {:keys [items]}] :event}] {:data (assoc d :items (vec items) :error nil)})
+    :set-error (fn [{d :data [_ {:keys [failure]}] :event}] {:data (assoc d :error failure)})}
    :regions
    {:data
     {:initial :nothing

--- a/skills/re-frame2/patterns/remote-data.md
+++ b/skills/re-frame2/patterns/remote-data.md
@@ -80,10 +80,10 @@ Used when the lifecycle is *part of* a larger page's machine (the page already h
   {:initial :idle
    :data    {:tags [] :error nil :loaded-at nil :attempt 0}
    :actions
-   {:bump-attempt (fn [d _] {:data (update d :attempt (fnil inc 0))})
-    :set-tags     (fn [d [_ {:keys [tags now]}]]
+   {:bump-attempt (fn [{d :data}] {:data (update d :attempt (fnil inc 0))})
+    :set-tags     (fn [{d :data [_ {:keys [tags now]}] :event}]
                     {:data (assoc d :tags (vec tags) :error nil :loaded-at now)})
-    :set-error    (fn [d [_ {:keys [failure]}]] {:data (assoc d :error failure)})}
+    :set-error    (fn [{d :data [_ {:keys [failure]}] :event}] {:data (assoc d :error failure)})}
    :states
    {:idle     {:tags #{:tags/idle}
                :on   {:fetch-started {:target :loading :action :bump-attempt}}}

--- a/skills/re-frame2/references/fundamentals/event-state-cycle.md
+++ b/skills/re-frame2/references/fundamentals/event-state-cycle.md
@@ -59,7 +59,7 @@ Sanity-checking a mental model: tracing what happens between `(rf/dispatch ...)`
 | Effect-map policing | `events.cljc` (`police-effect-map-shape!`) | `:rf.error/effect-map-shape` trace |
 | `:db` commit | `subs.cljc` + substrate adapter | atomic via `replace-container!` |
 | `:fx` walk | `fx.cljc` (`do-fx` / `handle-one-fx`) | `reg-fx`, `:fx-overrides` |
-| Sub recompute | `subs.cljc` | reaction graph + deferred ref-count cache |
+| Sub recompute | `subs.cljc` | reaction graph + synchronous ref-count cache |
 | Render | adapter (`reagent.cljs`, ...) | `reg-view` |
 
 ## Canonical mini-example

--- a/skills/re-frame2/references/state-machines/cancellation.md
+++ b/skills/re-frame2/references/state-machines/cancellation.md
@@ -76,7 +76,7 @@ If the parent needs to capture the child's last reported value before tearing it
 ```clojure
 {:authenticating
  {:spawn {:machine-id :auth-flow}
-  :exit   (fn [data _]
+  :exit   (fn [{:keys [data]}]
             ;; The child's snapshot is still at [:rf/runtime :machines :snapshots <id>]; read it.
             {:fx [[:analytics/record [:auth-attempt
                                       (get-in @app-db [:rf/runtime :machines :snapshots :auth-flow#1 :data])]]]})

--- a/skills/re-frame2/references/state-machines/reg-machine.md
+++ b/skills/re-frame2/references/state-machines/reg-machine.md
@@ -14,7 +14,7 @@ Most concepts map cleanly. A handful of slots re-frame2 **deliberately renames o
 |---|---|---|
 | **states** (`state.value`) | `:states` map + the snapshot's `:state` slot | Flat → single keyword; compound → vector path; parallel → region-name→keyword map. Convergence. |
 | **transitions** (`on: { EVENT: ... }`) | `:on {event-keyword transition-spec}` on a state node | Convergence. Bare-target / explicit-map / guarded-vector forms. |
-| **guards** (`guard` / named guards) | `:guard` on a transition + the top-level `:guards` map | Convergence on the *name*. **Divergence:** no `{and: [...]}` compound-guard data form — compose with one fn or one named registered compound. Guards see `:data`, not the whole snapshot. |
+| **guards** (`guard` / named guards) | `:guard` on a transition + the top-level `:guards` map | Convergence on the *name*. **Divergence:** no `{and: [...]}` compound-guard data form — compose with one fn or one named registered compound. Guards receive one context map `{:keys [data event state meta]}` and destructure what they need. |
 | **actions** (`actions` / named actions) | `:action` / `:entry` / `:exit` + the top-level `:actions` map | Convergence on the *name*. **Divergence:** no action-vector `[a1 a2 a3]` per slot — one fn or one named registered compound. `:entry`/`:exit` are a single fn or single keyword, never vectors. |
 | **`assign({...})`** | action returns `{:data new-data}` (and/or `{:fx [...]}`) | **Divergence (name/shape):** no `[:assign {...}]` form. Symmetric with `reg-event-fx`'s `{:db :fx}`. The invariant matches xstate's `assign` though: callbacks may only update `:data` — they cannot nudge the machine into an undeclared state. |
 | **`context`** (extended state) | `:data` (the machine's private map, distinct from `app-db`) | **Divergence (name):** re-frame2 calls the slot `:data`, tracking FSM / `gen_statem` "state data" vocabulary and avoiding re-frame's already-overloaded "context" (interceptor pipeline + React context). |
@@ -58,16 +58,16 @@ The basic (non-parallel, non-hierarchical) form:
 
    :guards
    {:has-input?
-    (fn guard-has-input? [data _event]
+    (fn guard-has-input? [{:keys [data]}]
       (some? (:input data)))}
 
    :actions
    {:bump-attempt
-    (fn action-bump [data _event]
+    (fn action-bump [{:keys [data]}]
       {:data (update data :attempt (fnil inc 0))})
 
     :store-result
-    (fn action-store [data [_ {:keys [value]}]]
+    (fn action-store [{data :data [_ {:keys [value]}] :event}]
       {:data (assoc data :result value :error nil)})}
 
    :states
@@ -92,7 +92,7 @@ The machine map's top-level keys are documented in Spec 005 §Transition table t
 
 ## State-node shape
 
-Every state node is a map. Recognised slots (see `implementation/machines/src/re_frame/machines.cljc` and Spec 005 §State nodes):
+Every state node is a map. Recognised slots (see the `re-frame.machines` façade docstring + `re-frame.machines.transition`, and Spec 005 §State nodes):
 
 - `:on` — a map of `event-keyword → transition-spec` (see Transitions below).
 - `:entry` / `:exit` — singular action references or fns, fired on entering / leaving the node.
@@ -126,7 +126,7 @@ The transition's `:target` may be a single keyword (sibling-level) or a vector p
 
 ```clojure
 ;; Inline — preferred only for one-line trivialities.
-{:on {:start {:guard  (fn [{data :data}] (some? (:input data)))
+{:on {:start {:guard  (fn [{:keys [data]}] (some? (:input data)))
               :target :working}}}
 
 ;; Keyword reference — preferred for anything non-trivial, because the
@@ -138,9 +138,9 @@ Per the inspectability bias (Spec 005 §Inspectability bias): named entries surf
 
 ### Guard / action contract
 
-Both fns receive `(data event)` — `:data` directly, not the snapshot wrapper. Actions return `{:data new-data :fx [...]}` (either key optional); guards return truthy/falsey. See `call-guard` and `call-action` in `re-frame.machines.transition`.
+Every callback receives **one context map** — `(fn [{:keys [data event state meta]}] ...)` — and destructures the keys it needs. `data` is the snapshot's `:data` slot (a plain map); `event` is the inbound event vector; `state` is the discrete FSM keyword; `meta` is any user `:meta` on the snapshot. Actions return `{:data new-data :fx [...]}` (either key optional); guards return truthy/falsey. See `call-guard` and `call-action` in `re-frame.machines.transition`.
 
-A 3-arity escape hatch `^:rf.machine/wants-ctx (fn [data event {:state ... :meta ...}] ...)` exists for introspecting the snapshot's discrete state, but reach for it only when 2-arity cannot express what you need (Spec 005 §3-arity escape hatch). The metadata flag is the explicit opt-in; without it the runtime calls the fn as 2-arity.
+There is **no positional `(data event)` arity and no opt-in 3-arity escape hatch** — the runtime always delivers the full context map and the destructure pattern decides what's bound. `:state` and `:meta` are available for introspection with no flag (Spec 005 §Snapshot introspection — `:state` / `:meta`). The uniform single-map shape is deliberate: it eliminates the paste-from-`:guard`-into-`:on-spawn` trap (an `id` silently bound to the event vector, or vice-versa) that slot-specific positional signatures would create.
 
 ## Subscribing to a machine
 
@@ -187,7 +187,7 @@ When a machine drives a discrete event-fx flow (boot, websocket-connection lifec
 
 - **The artefact must be loaded.** `(:require [re-frame.machines])` at the namespace declaring `rf/reg-machine` (or at app boot before any machine call). Forgetting it throws `:rf.error/machines-artefact-missing` with `:recovery :no-recovery`.
 - **`:rf.machine/*` and `:rf/*` are reserved.** Names like `:rf.machine/spawn` and the reserved app-db root `:rf/runtime` (with the framework parking `:machines`, `:routing`, `:elision`, … under it) belong to the runtime. Pick your own feature prefix for event keywords.
-- **Guards see `:data`, not the snapshot.** `(fn [data event] ...)` — the body inspects `(:input data)`, not `(get-in snap [:data :input])`. Same for actions.
+- **Callbacks receive one context map, not the raw snapshot.** `(fn [{:keys [data event]}] ...)` — the body inspects `(:input data)`, not `(get-in snap [:data :input])`. `data` is already the snapshot's `:data` slot. Same shape for guards, actions, `:entry`, `:exit`.
 - **Actions return an effect map.** `{:data new-data}` (or `{:fx [...]}` or both). Returning a bare data map silently does nothing; `nil` is a no-op.
 - **Use `reg-machine` (macro), not `reg-machine*` (fn).** The macro stamps per-element source coords that tools rely on (`re-frame.core` macro layer, Spec 005 §Source-coord stamping). Reach for `reg-machine*` only for programmatic registration with computed ids.
 - **Re-registration replaces.** Last-write-wins, per the standard registrar semantics; the prior snapshot at `[:rf/runtime :machines :snapshots <id>]` survives (the snapshot is in `app-db`, the spec is in the registrar). Hot-reload survives a machine re-declaration.

--- a/skills/re-frame2/references/state-machines/regions.md
+++ b/skills/re-frame2/references/state-machines/regions.md
@@ -20,7 +20,7 @@ A "region" in re-frame2 has two distinct meanings depending on context:
 
    :actions
    {:set-tags
-    (fn action-set-tags [data [_ {:keys [tags now]}]]
+    (fn action-set-tags [{data :data [_ {:keys [tags now]}] :event}]
       {:data (assoc data :tags (vec tags) :error nil :loaded-at now)})}
 
    :states
@@ -44,7 +44,7 @@ A "region" in re-frame2 has two distinct meanings depending on context:
 (rf/reg-machine :realworld/tags tags-machine)
 ```
 
-Verbatim from `examples/reagent/realworld/tags.cljs:71-142`. The slice's separate `:status` keyword disappears; the state IS the status. The view consumes `:tags/in-flight` via `(rf/machine-has-tag? :realworld/tags :tags/in-flight)` instead of a hand-rolled `(or (= :loading status) (= :fetching status))`.
+Adapted from `examples/reagent/realworld/tags.cljs`. The slice's separate `:status` keyword disappears; the state IS the status. The view consumes `:tags/in-flight` via `(rf/machine-has-tag? :realworld/tags :tags/in-flight)` instead of a hand-rolled `(or (= :loading status) (= :fetching status))`.
 
 ## Parallel regions — the canonical declaration
 
@@ -53,10 +53,10 @@ Verbatim from `examples/reagent/realworld/tags.cljs:71-142`. The slice's separat
   {:type :parallel
    :data {:items [] :error nil :archived-at nil}     ;; shared across regions
 
-   :guards   {:empty?     (fn [data _] (zero? (count (:items data))))
-              :too-many?  (fn [data _] (> (count (:items data)) 7))}
+   :guards   {:empty?     (fn [{:keys [data]}] (zero? (count (:items data))))
+              :too-many?  (fn [{:keys [data]}] (> (count (:items data)) 7))}
 
-   :actions  {:set-items  (fn [data [_ {:keys [items]}]]
+   :actions  {:set-items  (fn [{data :data [_ {:keys [items]}] :event}]
                             {:data (assoc data :items (vec items))})}
 
    :regions

--- a/skills/re-frame2/references/state-machines/spawn.md
+++ b/skills/re-frame2/references/state-machines/spawn.md
@@ -27,8 +27,8 @@ Spec 005 §Declarative `:spawn` §Worked example (verbatim shape). While the par
 |---|---|---|
 | `:machine-id` *or* `:definition` | which machine to spawn (registered id, or inline transition table) | exactly one |
 | `:data` | initial data for the child — literal map or `(fn [snapshot event] data)` | optional |
-| `:on-spawn` | `(fn [data spawned-id] new-data)` — advisory; record the child id in the parent's `:data` if you want | optional |
-| `:on-done` | `(fn [data result] new-data)` — fires when the child enters a `:final?` state; `result` is the child's `:data` slot named by the final state's `:output-key` (or `nil`). See [§Final states](#final-states--final--on-done--output-key) below. | optional |
+| `:on-spawn` | `(fn [{:keys [data id]}] _)` — advisory; record the child id (`id`) in the parent's `:data` if you want (return is dropped) | optional |
+| `:on-done` | `(fn [{:keys [data result]}] new-data)` — fires when the child enters a `:final?` state; `result` is the child's `:data` slot named by the final state's `:output-key` (or `nil`). See [§Final states](#final-states--final--on-done--output-key) below. | optional |
 | `:start` | event vector dispatched to the newborn after spawn | optional |
 | `:spawn-id` | explicit id instead of gensym (per-state singleton) | optional |
 | `:id-prefix` | base for the gensym'd actor id; defaults to `:machine-id` | optional |
@@ -132,7 +132,7 @@ Validation happens at registration (`re-frame.machines.lifecycle-fx.validation`)
 - **`:on-spawn` is advisory.** The runtime tracks the spawn-id at `[:rf/runtime :machines :spawned <parent-id> <invoke-id>]` itself — you no longer need `:on-spawn` to write the id under any specific `:data` slot for destroy to work. Most apps still set `:on-spawn (fn [{data :data id :id}] (assoc data :pending id))` so other transitions can address the child by name.
 - **`:data` is a literal map or `(fn [snap ev] data)` — not arbitrary code.** When the fn form is used, it runs at state entry against the post-action snapshot (spawn desugar in `re-frame.machines.lifecycle-fx.registration`). If it throws, the transition halts with `:rf.error/machine-action-exception` and the snapshot does NOT commit.
 - **`:start` runs after spawn; if absent the runtime dispatches a synthetic `[:rf.machine.spawn/spawned]`.** Every spawned actor receives `[:rf.machine.spawn/spawned]` if no `:start` was declared — generic child machines can declare a leaf `:on :rf.machine.spawn/spawned :target ...` transition that fires the actor's first work on entry.
-- **Path convention for `:on-spawn`:** the callback receives `:data` directly. Write `(assoc data :pending id)`, not `(assoc-in snap [:data :pending] id)`. Uniform with `:guard` and `:action`.
+- **Path convention for `:on-spawn`:** the callback receives one context map `{:keys [data id]}`; `data` is already the parent's `:data` slot. Write `(assoc data :pending id)`, not `(assoc-in snap [:data :pending] id)`. Uniform single-map shape with `:guard` and `:action`.
 - **One `:spawn` per state.** Multiple children per state → refactor into a compound state where each substate invokes one of the actors, or use `:spawn-all`. Validated at registration; `:spawn` + `:spawn-all` together throws `:rf.error/machine-spawn-all-with-spawn` (`re-frame.machines.lifecycle-fx.validation`).
 
 ## Deeper material


### PR DESCRIPTION
## Correctness review of `skills/re-frame2/` (rf2-6uq5d)

Per-slice CORRECTNESS review of the **re-frame2 authoring skill**. One dominant, systematic defect found and fixed; one minor term corrected. Rest of the slice verified accurate against the current `re-frame.core` surface, the optional-artefact sources, and `spec/`.

### Primary finding — stale machine-callback signature (9 files)

Guards, actions, `:entry`/`:exit`, `:on-spawn` and `:on-done` callbacks were taught with the **obsolete positional 2-arity** `(fn [data event] ...)` plus a **removed** `^:rf.machine/wants-ctx` 3-arity escape hatch.

The current contract (Spec 005 §Guards / §Actions / §Spawn-and-join, and `re-frame.machines.transition`'s `call-guard`/`call-action`) is a **single context map**:

```clojure
(fn [{:keys [data event state meta]}] ...)
```

Spec 005 line 614 explicitly names the positional form as the paste-trap the unified shape eliminates ("`id` silently bound to the event vector"). The actual worked examples (`examples/reagent/{nine_states,realworld/tags,realworld/settings}`) and the already-correct `patterns/websocket.md` all use the context-map shape — so the skill contradicted both the spec and its own cited examples, including some `## Canonical declaration` blocks claiming to be "verbatim from"/"lifted from" those files.

Fixed in: `references/state-machines/reg-machine.md`, `regions.md`, `cancellation.md`, `spawn.md`; `patterns/boot.md`, `long-running-work.md`, `forms.md`, `nine-states.md`, `remote-data.md`. Removed the `wants-ctx` 3-arity claim; corrected the false "verbatim"/"lifted from" wording where code had drifted. `:spawn :data` (`(fn [snap ev] ...)`) and `:after` delay-fns (`(fn [snap] ...)`) were already correct and left untouched.

### Secondary finding

`references/fundamentals/event-state-cycle.md` described the sub-cache as a "deferred ref-count cache" — disposal is **synchronous** on derefer-count→0 (`subs/cache.cljc`: "No deferred-grace timer"), which `subs.md` already states correctly. Corrected to "synchronous". Also retargeted `reg-machine.md`'s state-node citation from the (split) `machines.cljc` to the façade docstring + `re-frame.machines.transition`.

### Repo-coupling check

No repo-specific testbed/path coupling introduced; all examples remain generic re-frame2 shapes with `examples/reagent/<x>` cited only as illustration (consistent with the skill's L2 design lock).

### Verified accurate (no change needed)

API cheatsheet, events/fx/cofx/subs/flows/schemas/frames fundamentals, testing, routing, xray — symbol names, error/warning keywords (`:rf.error/*`, `:rf.warning/*`), reserved fx-ids, presets, drain-depth defaults, and artefact-missing taxonomy all cross-checked against `implementation/**`.

### Gates (cold)

- Skill ↔ MCP allowed-tools drift gate (`scripts/check_skill_mcp_drift.py`) — **pass** (exit 0; no frontmatter change).
- `npm run test:cljs` not applicable — skill ships no code.
- mkdocs unaffected — the skill leaves are not in the mkdocs nav (only the hand-authored `docs/skills/re-frame2.md`, untouched).
- Each rewritten signature checked against `spec/005-StateMachines.md` and `re-frame.machines.transition`.

Authoring-skill content only; no shipped runtime code.