### PR TITLE
refactor(machines): single home for :after delay-source classification (rf2-bx0hm)

### DIFF
--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -96,12 +96,11 @@
    :spawn (vec invoke-id)
    :delay  delay-key})
 
-(defn- classify-delay-source [delay-key]
-  (cond
-    (number? delay-key)  :literal
-    (vector? delay-key)  :sub
-    (fn? delay-key)      :fn
-    :else                :literal))
+;; `:after` delay-source classification (`{:literal :sub :fn}`) lives once
+;; in `re-frame.machines.transition/classify-delay-source` — the leaf engine
+;; that owns the `:after` grammar and already tags the pure-side
+;; `:rf.machine.timer/scheduled` trace from it. The fx side reuses the same
+;; classifier so the two can never disagree on a delay-key's source.
 
 (defn- resolve-delay-ms
   "Resolve an :after map key to a positive-integer ms delay. For pos-int?
@@ -287,7 +286,7 @@
   empty slot is a no-op cancel)."
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
    {:keys [emit-scheduled-trace?]}]
-  (let [delay-source (classify-delay-source delay-key)
+  (let [delay-source (transition/classify-delay-source delay-key)
         k            (after-timer-key parent-id invoke-id delay-key)]
     (cancel-after-timer-entry! frame-id k :on-supersede)
     (cond

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -250,6 +250,28 @@
 ;; [:authenticated :cart :paying]). Flat machines used :state :foo for
 ;; compactness; we accept both and normalise internally.
 
+(defn classify-delay-source
+  "Classify an `:after` delay-key into its source form — the closed set
+  `{:literal :sub :fn}` owned by the `:after` grammar (Spec 005 §Delayed
+  `:after` transitions). A `number?` key is the literal-ms form; a
+  `vector?` key is a subscription-vector (`[:sub-id & args]`); a `fn?`
+  key is the computed-once-at-entry form. Any other shape falls back to
+  `:literal` (the schema constrains the canonical forms; this is
+  defensive).
+
+  The single home for the classification, shared by the pure side
+  (`build-after-fx`, which tags the `:rf.machine.timer/scheduled` /
+  `/skipped-on-server` trace) and the fx side
+  (`re-frame.machines.timer/schedule-after-timer!`, which routes the
+  delay resolution + watcher install) so the two can never disagree on
+  what a given delay-key's source is."
+  [delay-key]
+  (cond
+    (number? delay-key) :literal
+    (vector? delay-key) :sub
+    (fn? delay-key)     :fn
+    :else               :literal))
+
 (defn state-path
   "Coerce a snapshot's :state — either a keyword or a vector path — into
   a normalised vector path."
@@ -1233,11 +1255,7 @@
                     epoch      (node-epoch machine snap-final prefix)]
                 (mapv
                   (fn [[delay-key _target]]
-                    (let [delay-source (cond
-                                         (number? delay-key) :literal
-                                         (vector? delay-key) :sub
-                                         (fn? delay-key)     :fn
-                                         :else               :literal)
+                    (let [delay-source (classify-delay-source delay-key)
                           ;; Pure-context delay value: literal keys ARE the
                           ;; resolved ms; sub-vec / fn are resolved at the fx
                           ;; layer (which emits a fresh /scheduled with the


### PR DESCRIPTION
## What

DUPLICATION-reduction review of the `implementation/machines` slice (bead rf2-bx0hm, P3). One real consolidation found and reduced; the rest of the slice is appropriately DRY.

## Duplication consolidated (file:line evidence)

The `:after` delay-key **source classifier** (`{:literal :sub :fn}`) was spelled twice with byte-identical `cond` logic:

- **transition.cljc** (pure engine, `build-after-fx`) — inline `(cond (number? …) :literal (vector? …) :sub (fn? …) :fn :else :literal)`, tagging the `:rf.machine.timer/scheduled` / `/skipped-on-server` trace's `:delay-source`.
- **timer.cljc:99-104** (fx side) — a private `classify-delay-source` of the same body, routing the fx-side delay resolution + watcher install.

Two homes for one closed-set classification = two chances to disagree on a given delay-key's source. Promoted to a single public `transition/classify-delay-source` — the leaf engine owns the `:after` grammar, and `timer.cljc` already `:require`s `transition`. Both call sites now reach one home. Behaviour-preserving (identical mapping, including the `:else :literal` defensive fallback).

## DRY assessment of the rest of the slice

The slice has had extensive prior dedup (the rf2-ra1he audit, the rf2-aa2rw Result ADT, rf2-fgqs4 unified initial-snapshot, rf2-vqubp `reduce-regions`, rf2-ndfjo `actor-live?`, rf2-ur63f `traces` consolidation, `path-walk`, `paths`, `spawn-one`). Candidates considered and **deliberately left** to avoid trading clarity for a thin abstraction:

- `destroy-single-actor!` vs `destroy-single!` (destroy.cljc) share an ordered teardown sequence but diverge in sid-capture mechanics and trace ordering/count; the shared liveness probe was already extracted (`actor-live?`). Unifying the remainder needs a flag/callback-laden HOF.
- The four state-tree walkers in validation.cljc share a `:states`-descent skeleton but each yields a different shape (`[k n]` / `[path n]` / history-only / `[ck states]`); a generic walker obscures each validator's intent.
- `history-node?` (one-liner `(= :history (:type node))`) duplicated transition/validation — sharing it would couple the registration-time leaf validator to the engine surface for trivial gain.

## Gates (cold)

- machines artefact `clojure -M:test`: **390 tests / 1307 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5477 tests / 19066 assertions, 0 failures, 0 errors**

No `spec/005` hot-zone touch (a documented contract was not changed — the classifier's closed set and behaviour are unchanged).

Closes rf2-bx0hm.