### PR TITLE
docs(skills/pair): correct stale port-discovery cascade (rf2-mwwgo)

### DIFF
--- a/skills/re-frame2-pair/references/mcp-transport.md
+++ b/skills/re-frame2-pair/references/mcp-transport.md
@@ -30,11 +30,16 @@ Then add to your Claude Code settings:
 }
 ```
 
-The server auto-discovers the nREPL port from (in order):
-1. `$SHADOW_CLJS_NREPL_PORT`
-2. `target/shadow-cljs/nrepl.port`
-3. `.shadow-cljs/nrepl.port`
-4. `.nrepl-port`
+On the first tool call the server discovers the live shadow-cljs nREPL
+via a **five-step cascade** (per `tools/re-frame2-pair-mcp/spec/002-nREPL-Transport.md` §Port discovery — discovery is **lazy on first tool call**, not boot, because the `roots/list` request can only fire after the client's `initialize` handshake):
+
+1. `--port-file <abs>` launch flag — explicit, cwd-independent override (rf2-3dbwh).
+2. `$SHADOW_CLJS_NREPL_PORT` env var.
+3. **MCP `roots/list` walk** (rf2-3grub — the zero-config primary path) — ask the agent host for its open workspace roots, walk each (bounded, skipping `node_modules` / `.git` / `target`) for `shadow-cljs.edn` paired with the adjacent `.shadow-cljs/nrepl.port`. One match → silent attach; multiple → an `elicitation/create` prompt so the user picks the project; zero → step 4.
+4. **Shadow HTTP probe** (rf2-umoz2) — `GET http://127.0.0.1:9630/api/project-info` returns the consumer build's `:project-home`, against which the server reads `target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, `.nrepl-port` (in that order). HTTP port overridable via `--http-port <n>` (default 9630). Fallback for hosts that don't expose `roots`.
+5. CWD-relative scan of the same three port-file candidates — legacy fallback for environments without shadow's web server.
+
+The `--port-file` and `$SHADOW_CLJS_NREPL_PORT` escape hatches (steps 1-2) win the cascade — pass one when discovery misses (no running shadow, non-default `:http :port`, exotic setup). Shadow restarts are absorbed transparently: each subsequent tool call re-reads the cached `<project-home>/.shadow-cljs/nrepl.port` and reconnects if the port changed.
 
 ## Stale-binary post-merge hook (rf2-6jj3r)
 


### PR DESCRIPTION
## Summary

Correctness review of `skills/re-frame2-pair/` (bead rf2-mwwgo) against the current pair-MCP tool surface + re-frame2 API. One clear inaccuracy found and fixed; the rest of the slice is a clean bill.

## The fix

`references/mcp-transport.md` §Install/configure documented the **pre-rf2-3grub / pre-rf2-umoz2 four-step** port-file scan as the MCP server's auto-discovery:

```
1. $SHADOW_CLJS_NREPL_PORT
2. target/shadow-cljs/nrepl.port
3. .shadow-cljs/nrepl.port
4. .nrepl-port
```

This contradicted `SKILL.md` §Port discovery (which already documents the current cascade) and the ground-truth `tools/re-frame2-pair-mcp/spec/002-nREPL-Transport.md` + `src/.../nrepl.cljs`, which both document the **five-step** cascade:

1. `--port-file <abs>` launch flag (rf2-3dbwh)
2. `$SHADOW_CLJS_NREPL_PORT` env var
3. MCP `roots/list` walk — the zero-config **primary** path (rf2-3grub)
4. Shadow HTTP probe at `:9630/api/project-info` (rf2-umoz2)
5. CWD-relative port-file scan (legacy fallback)

Replaced the stale list with the verified five-step cascade, plus the lazy-on-first-tool-call timing and the transparent shadow-restart reconnect. The bash-shim transport section in `SKILL.md` / `README.md` / `STATUS.md` legitimately describes the *shim's own* port-file scan (back-compat appendix) and is left unchanged.

## What was verified (clean)

- **28-tool catalogue** matches the live registry (`tools/registry.cljs`): the SKILL.md `allowed-tools` lists 26 `mcp__re-frame2-pair__*` tools; the 2 missing (`restore-epoch`, `reset-frame-db`) are intentionally server-only (gated behind `--allow-writes`, confirmed in the drift gate's `intentional_server_only` set). No phantom or removed tool names.
- **Drift gate green** (cold): `python scripts/check_skill_mcp_drift.py` → exit 0, `server=28 tools, skill=26 allow-listed`.
- **All runtime helper fns** referenced across the references (`orient`, `read-sub!`, `dom-source-at`, `find-where`, `cascade-of`, `epoch-diff`, `frame-diff`, `last-pair-epoch`, `undo-step-back`, `machine-state`, `app-db-at`, …) exist in `preload/re_frame2_pair/runtime.cljs` — no obsolete signatures (the staleness class flagged on the sibling main-skill review).
- **`:rf.error/*` vocabulary** (eval-cljs-rejected/timeout/disabled, writes-disabled, concurrent-stream-limit, stream-abuse-detected, cursor-stale) matches the catalogue spec's three-dialect table.
- **`on-error.md`** return-map contract + closed `:recovery` enum + the two violation categories match Spec 009.
- **Streaming / wire-size / variant-as-frame / recipes / ops** references cross-checked against the catalogue spec — args, modes, predicate vocab, cascade-bundle delivery all current.
- **Generic-to-any-app**: repo-specific values (ports, build ids) appear only as explicitly-labelled illustrative examples; no repo-coupling introduced.

## Residual risk

None material. The single fixed doc was the only contradiction between the skill and the ground-truth MCP surface.

Closes rf2-mwwgo.