### PR TITLE
refactor(ssr): single-source header/cookie wire-grammar validators (rf2-jmss4)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
@@ -21,7 +21,8 @@
   `:name` carries a separate RFC 6265 §4.1.1 token-grammar gate (no
   CTLs, whitespace, or `( ) < > @ , ; : \\ \" / [ ] ? = { }`). Folds in
   the §P2.4 cookie-name grammar finding."
-  (:require [clojure.string :as str])
+  (:require [clojure.string :as str]
+            [re-frame.ssr.http-validation :as http-validation])
   (:import [java.net URLEncoder]
            [java.nio.charset StandardCharsets]
            [java.time Instant ZoneOffset ZonedDateTime]
@@ -56,15 +57,17 @@
 ;; bans CR/LF/NUL inside header values. We reject up front so the
 ;; behaviour is portable across hosts (Jetty 11+ rejects, but earlier
 ;; Jetty / HttpKit / Pedestal don't all defend the same way).
-(def ^:private header-injection-chars-re
-  ;; Java regex: \r, \n, \x00 — the three CTLs RFC 7230 §3.2.4 forbids
-  ;; inside header values.
-  #"[\r\n\x00]")
+;;
+;; The injection-char grammar is single-sourced in
+;; `re-frame.ssr.http-validation/contains-injection-char?` — the SAME
+;; predicate the SSR fx boundary (`re-frame.ssr.response`) enforces, so
+;; the materialiser and the fx-boundary gate can't drift on what counts
+;; as a header-splitting char.
 
 (defn- validate-attribute-string!
   [attr-key v]
   (let [s (str v)]
-    (when (re-find header-injection-chars-re s)
+    (when (http-validation/contains-injection-char? s)
       (throw (ex-info ":rf.error/cookie-invalid-attribute"
                       {:rf.error/id :rf.error/cookie-invalid-attribute
                        :where     'rf.ssr/cookie->set-cookie-header
@@ -80,16 +83,16 @@
 ;; rf2-rpedl / §P2.4 — RFC 6265 §4.1.1 cookie-name = token. The token
 ;; grammar (RFC 7230 §3.2.6) is `1*tchar` where `tchar` is the set of
 ;; visible US-ASCII chars MINUS the separators
-;; `( ) < > @ , ; : \ " / [ ] ? = { }` and whitespace. The regex below
-;; encodes that allowed set explicitly so the grammar is auditable in
-;; place. Empty names are rejected by the `+` quantifier.
-(def ^:private cookie-name-token-grammar
-  #"[!#$%&'*+\-.0-9A-Z\^_`a-z|~]+")
+;; `( ) < > @ , ; : \ " / [ ] ? = { }` and whitespace. Single-sourced in
+;; `re-frame.ssr.http-validation/valid-token-name?` — the SAME predicate
+;; the SSR fx boundary (`re-frame.ssr.response`) enforces on cookie +
+;; header names, so the materialiser and the fx-boundary gate can't drift
+;; on the token grammar.
 
 (defn- validate-cookie-name!
   [n]
   (let [s (clojure.core/name n)]
-    (if (re-matches cookie-name-token-grammar s)
+    (if (http-validation/valid-token-name? s)
       s
       (throw (ex-info ":rf.error/cookie-invalid-name"
                       {:rf.error/id :rf.error/cookie-invalid-name

--- a/implementation/ssr/src/re_frame/ssr/http_validation.cljc
+++ b/implementation/ssr/src/re_frame/ssr/http_validation.cljc
@@ -1,0 +1,80 @@
+(ns re-frame.ssr.http-validation
+  "Shared HTTP header / cookie validation primitives — the wire-grammar
+  predicates the SSR fx-boundary (`re-frame.ssr.response`) and the Ring
+  host adapter's Set-Cookie materialiser (`re-frame.ssr.ring.cookie`)
+  both enforce.
+
+  Per the security audit 2026-05-14 (rf2-hbty2 header-value gate,
+  rf2-z7gor header-name + cookie gates at the fx boundary, rf2-rpedl
+  cookie-attribute gate at the materialiser): the same two grammars are
+  enforced at TWO boundaries — the SSR fx boundary (so non-Ring host
+  adapters get the gate with the dispatching event in scope) AND the Ring
+  materialiser (so the wire write is portable across servers whose own
+  CR/LF defences differ). Both boundaries are deliberate (defence in
+  depth); what is NOT deliberate is the regexes drifting apart. Before
+  this ns the two regexes lived as byte-identical copies in
+  `re-frame.ssr.response` and `re-frame.ssr.ring.cookie`, each carrying a
+  comment that a fix to one MUST track the other — a copy-paste security
+  surface. Single-sourcing them here removes that drift risk.
+
+  Two grammars:
+
+    - `injection-char-re`  — the three control chars RFC 7230 §3.2.4
+                             forbids inside any header value (`\\r` / `\\n`
+                             / `\\x00`). A value carrying one would split
+                             the header on the wire (header-splitting
+                             injection).
+    - `token-name-re`      — RFC 7230 §3.2.6 `token` (= RFC 6265 §4.1.1
+                             cookie-name): `1*tchar` where `tchar` is the
+                             visible US-ASCII set MINUS the separators
+                             `( ) < > @ , ; : \\ \" / [ ] ? = { }` and
+                             whitespace. The set is encoded explicitly so
+                             the grammar is auditable in place; the `+`
+                             quantifier rejects empty names.
+
+  Two predicates (`contains-injection-char?`, `valid-token-name?`) carry
+  the accept/reject decision; the THROW shape stays at each callsite
+  because the two boundaries surface DISTINCT error keywords / `:where`
+  tags that are part of each layer's documented contract — the fx
+  boundary throws `:rf.error/header-invalid-name` /
+  `:rf.error/cookie-invalid-<field>` with `:where 'rf.ssr/response`, the
+  materialiser throws `:rf.error/cookie-invalid-name` /
+  `:rf.error/cookie-invalid-attribute` with
+  `:where 'rf.ssr/cookie->set-cookie-header`. The decision is shared; the
+  diagnostics are local."
+  (:require [clojure.string]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def injection-char-re
+  "RFC 7230 §3.2.4 header-splitting injection chars: CR / LF / NUL. A
+  header value (or any string concatenated verbatim into the wire header
+  shape — cookie `:domain` / `:path` / `:max-age` / `:same-site`, a
+  redirect `:location`) carrying one of these would split the header on
+  the wire and let an attacker forge second-and-later headers."
+  #"[\r\n\x00]")
+
+(def token-name-re
+  "RFC 7230 §3.2.6 `token` grammar (= RFC 6265 §4.1.1 cookie-name):
+  `1*tchar`, where `tchar` is the visible US-ASCII set MINUS the
+  separators `( ) < > @ , ; : \\ \" / [ ] ? = { }` and whitespace. The
+  allowed set is encoded explicitly so the grammar is auditable in place;
+  the `+` quantifier rejects empty names. Shared by the header-name gate
+  and the cookie-name gate."
+  #"[!#$%&'*+\-.0-9A-Z\^_`a-z|~]+")
+
+(defn contains-injection-char?
+  "True when string `s` carries a CR / LF / NUL — the RFC 7230 §3.2.4
+  header-splitting injection chars. Callers `(str v)`-coerce before the
+  check; this fn does NOT coerce so the caller controls how a non-string
+  value is rendered for both the check and the error payload."
+  [s]
+  (boolean (re-find injection-char-re s)))
+
+(defn valid-token-name?
+  "True when string `s` is a non-empty RFC 7230 §3.2.6 `token` (the
+  shared header-name / cookie-name grammar — no CTLs, whitespace, or
+  separators). `re-matches` anchors the whole string, so a name with any
+  illegal char anywhere is rejected."
+  [s]
+  (boolean (re-matches token-name-re s)))

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -58,6 +58,7 @@
 
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [clojure.string]
+            [re-frame.ssr.http-validation :as http-validation]
             [re-frame.trace :as trace])
   #?(:clj (:import [java.net URI URISyntaxException])))
 
@@ -86,8 +87,12 @@
 ;; value with CR/LF has no safe interpretation — strip-and-warn would
 ;; silently mutate the wire shape and leave a CRLF-shaped string-equal
 ;; comparison failing later in tests.
-(def ^:private header-injection-chars-re
-  #"[\r\n\x00]")
+;;
+;; The injection-char grammar is single-sourced in
+;; `re-frame.ssr.http-validation/contains-injection-char?` — the SAME
+;; predicate the Ring materialiser (`re-frame.ssr.ring.cookie`) enforces,
+;; so the two boundaries can't drift on what counts as a header-splitting
+;; char.
 
 (defn- validate-header-value!
   "Throw `:rf.error/header-invalid-value` if the header value `v`
@@ -96,7 +101,7 @@
   deprecated; no CTLs allowed in `field-content`."
   [header-name v]
   (let [s (str v)]
-    (when (re-find header-injection-chars-re s)
+    (when (http-validation/contains-injection-char? s)
       (throw (ex-info ":rf.error/header-invalid-value"
                       {:rf.error/id :rf.error/header-invalid-value
                        :where    'rf.ssr/response
@@ -117,7 +122,7 @@
   into literal CRLF and would split the header on the wire."
   [loc]
   (let [s (str loc)]
-    (when (re-find header-injection-chars-re s)
+    (when (http-validation/contains-injection-char? s)
       (throw (ex-info ":rf.error/redirect-invalid-location"
                       {:rf.error/id :rf.error/redirect-invalid-location
                        :where    'rf.ssr/response
@@ -141,12 +146,10 @@
 ;; RFC 7230 §3.2.6 token grammar (header names + RFC 6265 §4.1.1
 ;; cookie-name): `1*tchar` where `tchar` ∈ the visible US-ASCII set
 ;; MINUS the separators `( ) < > @ , ; : \ " / [ ] ? = { }` and
-;; whitespace. The regex below encodes that set explicitly so the
-;; grammar is auditable in place; empty names are rejected by the `+`
-;; quantifier.
-
-(def ^:private token-grammar-re
-  #"[!#$%&'*+\-.0-9A-Z\^_`a-z|~]+")
+;; whitespace. The grammar is single-sourced in
+;; `re-frame.ssr.http-validation/valid-token-name?` — the SAME predicate
+;; the Ring materialiser (`re-frame.ssr.ring.cookie`) enforces on cookie
+;; names, so the two boundaries can't drift on the token grammar.
 
 (defn- validate-header-name!
   "Throw `:rf.error/header-invalid-name` if the header name violates the
@@ -155,7 +158,7 @@
   Per rf2-z7gor §security-audit-2026-05-14."
   [n]
   (let [s (str n)]
-    (when-not (re-matches token-grammar-re s)
+    (when-not (http-validation/valid-token-name? s)
       (throw (ex-info ":rf.error/header-invalid-name"
                       {:rf.error/id :rf.error/header-invalid-name
                        :where    'rf.ssr/response
@@ -181,7 +184,7 @@
                      :name     n
                      :recovery :no-recovery})))
   (let [s (#?(:clj clojure.core/name :cljs cljs.core/name) n)]
-    (when-not (re-matches token-grammar-re s)
+    (when-not (http-validation/valid-token-name? s)
       (throw (ex-info ":rf.error/cookie-invalid-name"
                       {:rf.error/id :rf.error/cookie-invalid-name
                        :where    'rf.ssr/response
@@ -200,7 +203,7 @@
   Set-Cookie wire form by host adapters. Per rf2-z7gor."
   [field-key v]
   (let [s (str v)]
-    (when (re-find header-injection-chars-re s)
+    (when (http-validation/contains-injection-char? s)
       (let [error-kw (keyword "rf.error" (str "cookie-invalid-" (name field-key)))]
         (throw (ex-info (str error-kw)
                         {:rf.error/id error-kw


### PR DESCRIPTION
## Summary

DRY-reduction review of the `implementation/ssr` + `implementation/ssr-ring` slice (bead rf2-jmss4). The slice is already strongly single-sourced (prior dedup work: rf2-x7g10 html-helpers, rf2-8wrzz.4 payload-policy, the lifecycle/trust consolidations). One genuine cross-boundary duplication remained, and this PR removes it.

## The duplication

The HTTP wire-grammar validators were **byte-identical copies** across the ssr→ssr-ring artefact edge:

| Literal | `ssr/response.cljc` | `ssr-ring/cookie.clj` |
|---|---|---|
| CR/LF/NUL injection-char regex `#"[\r\n\x00]"` | L90 | L62 |
| RFC 7230 §3.2.6 / RFC 6265 §4.1.1 token-name grammar `#"[!#$%&'*+\-.0-9A-Z\^_`a-z\|~]+"` | L149 | L87 |
| cookie-name validator | `validate-cookie-name!` | `validate-cookie-name!` |
| CR/LF/NUL attribute validator | `validate-cookie-attr!` | `validate-attribute-string!` |

Both copies even carried a comment that *"a fix to one MUST track the other"* — exactly the copy-paste security surface this review targets.

## The fix

Extract the two grammars + their accept/reject predicates (`contains-injection-char?`, `valid-token-name?`) into a new shared `re-frame.ssr.http-validation` ns in the `ssr` artefact (sibling to `html-helpers`; `ssr-ring` already depends on `ssr`). Both boundaries consume the SAME predicates, so they can't drift.

**Security boundaries preserved.** The dual-boundary enforcement is deliberate (fx boundary so non-Ring adapters get the gate with the dispatching event in scope; Ring materialiser for wire-portability across servers) and is kept verbatim. The distinct error keywords / `:where` tags / `:reason` text stay at each callsite — *the decision is shared, the diagnostics are local.* No behaviour change.

## Gates (cold)

- ssr artefact: `clojure -M:test` → 254 tests / 890 assertions, 0 failures / 0 errors
- ssr-ring artefact: `clojure -M:test` → 104 tests / 448 assertions, 0 failures / 0 errors
- `npm run test:cljs` → 5477 tests / 19066 assertions, 0 failures / 0 errors

## Scope notes

- No `spec/011` change — the consolidation is internal; the documented contract surface (error keywords, fx surface, materialiser surface) is unchanged.
- Everything else in the slice is appropriately DRY (see review notes in the bead).