### PR TITLE
refactor(http): consolidate reply tail + too-many-keys ex-info (rf2-k67u3)

### DIFF
--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -39,7 +39,9 @@
 
   `canned-success-handler` / `canned-failure-handler` live here because
   the machine-shape wrapper's reply walk is symmetric with the stubs'
-  reply walk — both feed `encoding/dispatch-reply-via-late-bind!`. The
+  reply walk — both feed `middleware/run-after-then-dispatch!` (the
+  shared run-`:after`-then-late-bind reply tail, also used by the real-
+  transport path in `http-transport/dispatch-reply!`). The
   fx registrations that bind the `:rf.http/managed-canned-*` ids to
   these handlers live in `re-frame.http-test-support` (per rf2-cdmle —
   test-only require gate). The `with-managed-request-stubs*` helper —
@@ -50,10 +52,11 @@
             [re-frame.http-middleware :as middleware]
             [re-frame.late-bind       :as late-bind]))
 
-;; rf2-2utlm — the canned stubs delegate to `encoding/dispatch-reply-
-;; via-late-bind!`, the same helper `http-transport/dispatch-reply!`
-;; uses, so the build-reply-event + late-bind lookup pattern lives in
-;; one place.
+;; rf2-2utlm / rf2-k67u3 — the canned stubs delegate to
+;; `middleware/run-after-then-dispatch!`, the shared run-`:after`-then-
+;; late-bind reply tail `http-transport/dispatch-reply!` also uses, so
+;; the `:after`-chain + build-reply-event + late-bind lookup pattern
+;; lives in one place.
 
 ;; ---- canned stub handlers (used by the `:rf.http/managed-canned-*` fxs
 ;; registered in `re-frame.http-test-support` AND the per-call stub
@@ -112,15 +115,21 @@
   stamped a correlation-id can read its own work back in the `:after`.
   An `:after` throw propagates as `:rf.error/http-interceptor-failed`
   (per `run-after-chain!`), matching the real path; the reply is then
-  not dispatched."
+  not dispatched.
+
+  rf2-k67u3 — the run-`:after`-then-dispatch tail is shared with the
+  real-transport reply path (`http-transport/dispatch-reply!`) via
+  `middleware/run-after-then-dispatch!`. The canned path always supplies
+  a `:middleware-ctx` (produced by `run-request-chain`), so the `:after`
+  chain always runs here."
   [{:keys [origin-event explicit-on reply-payload kind frame middleware-ctx]}]
-  (let [final-payload (middleware/run-after-chain! frame middleware-ctx reply-payload)]
-    (encoding/dispatch-reply-via-late-bind!
-      {:origin-event  origin-event
-       :explicit-on   explicit-on
-       :reply-payload final-payload
-       :kind          kind}
-      frame)))
+  (middleware/run-after-then-dispatch!
+    {:frame          frame
+     :middleware-ctx middleware-ctx
+     :origin-event   origin-event
+     :explicit-on    explicit-on
+     :reply-payload  reply-payload
+     :kind           kind}))
 
 (defn canned-success-handler
   "Stub fx — synthesises a success reply per Spec 014 §Testing.

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -69,7 +69,8 @@
   `re-frame.flows.registry`'s private `flows` atom + the
   `flows-snapshot` accessor). Frame-scoped: an interceptor registered
   against frame A does not fire for a request dispatched from frame B."
-  (:require [re-frame.http-privacy :as privacy]
+  (:require [re-frame.http-encoding :as encoding]
+            [re-frame.http-privacy :as privacy]
             [re-frame.interop      :as interop]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace        :as trace]))
@@ -347,3 +348,35 @@
      :phase      :after
      :slot-noun  ":after did not return a response map"}
     response))
+
+(defn run-after-then-dispatch!
+  "The shared reply tail: thread `reply-payload` through the per-frame
+  `:after` interceptor chain, then hand the result to the late-bind
+  reply router (`encoding/dispatch-reply-via-late-bind!`).
+
+  Single source of truth for the two reply paths that were previously
+  byte-identical save for the `:after`-guard:
+   - `http-transport/dispatch-reply!` — the real-transport completion
+     path. Synthetic / test-path callers may carry NO `:middleware-ctx`
+     (they built a ctx directly without going through `managed-handler`);
+     the `(if middleware-ctx …)` guard skips the `:after` chain and
+     passes the payload through unchanged — the chain's contract is to
+     see the `:before`'s ctx, not a synthesised one.
+   - `http-machine-wrapper/dispatch-canned-reply!` — the canned-stub
+     path, which always produces a `:middleware-ctx` via
+     `run-request-chain` and therefore always runs the `:after` chain.
+
+  `opts` carries `:frame`, `:middleware-ctx`, and the three keys
+  `dispatch-reply-via-late-bind!` consumes (`:origin-event`,
+  `:explicit-on`, `:kind`). No-op when the router is absent / the reply
+  is silenced (delegated to `dispatch-reply-via-late-bind!`)."
+  [{:keys [frame middleware-ctx origin-event explicit-on reply-payload kind]}]
+  (let [final-payload (if middleware-ctx
+                        (run-after-chain! frame middleware-ctx reply-payload)
+                        reply-payload)]
+    (encoding/dispatch-reply-via-late-bind!
+      {:origin-event  origin-event
+       :explicit-on   explicit-on
+       :reply-payload final-payload
+       :kind          kind}
+      frame)))

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -562,21 +562,21 @@
   synthesised one."
   [{:keys [origin-event explicit-on-success explicit-on-failure
            kind reply-payload frame middleware-ctx]}]
-  (let [explicit       (case kind
-                         :success explicit-on-success
-                         :failure explicit-on-failure)
-        ;; rf2-uheqq — `:after` chain. Reverse-order threading of the
-        ;; response through registered interceptors' `:after`s. Skipped
-        ;; when no middleware-ctx is present (synthetic callers).
-        final-payload  (if middleware-ctx
-                         (middleware/run-after-chain! frame middleware-ctx reply-payload)
-                         reply-payload)]
-    (encoding/dispatch-reply-via-late-bind!
-      {:origin-event  origin-event
-       :explicit-on   explicit
-       :reply-payload final-payload
-       :kind          kind}
-      frame)))
+  (let [explicit (case kind
+                   :success explicit-on-success
+                   :failure explicit-on-failure)]
+    ;; rf2-uheqq — `:after` chain + late-bind dispatch. Shared with the
+    ;; canned-stub reply path (`http-machine-wrapper/dispatch-canned-
+    ;; reply!`) via `middleware/run-after-then-dispatch!` (rf2-k67u3): the
+    ;; `:after` chain is skipped when no middleware-ctx is present
+    ;; (synthetic / test-path callers).
+    (middleware/run-after-then-dispatch!
+      {:frame          frame
+       :middleware-ctx middleware-ctx
+       :origin-event   origin-event
+       :explicit-on    explicit
+       :reply-payload  reply-payload
+       :kind           kind})))
 
 ;; rf2-ee38b.7 — the failure-reply and success-reply dispatch shapes were
 ;; spelled out inline at four / two sites across finalise-success!,

--- a/implementation/http/src/re_frame/util_json.cljc
+++ b/implementation/http/src/re_frame/util_json.cljc
@@ -62,6 +62,23 @@
   #?(:clj  (cheshire/generate-string v)
      :cljs (js/JSON.stringify (clj->js v))))
 
+(defn- too-many-keys-ex
+  "rf2-wu1n5 — the keyword-interning DoS-cap overflow ex-info. Platform-
+  agnostic (plain Clojure data), so the two host branches of `json-parse`
+  share one definition rather than carrying byte-identical copies that
+  could drift (`:cause` / `:limit` / `:reason` are security-relevant and
+  asserted on by the caller's `:rf.http/decode-failure` classification).
+  Carries `:rf.error/id :rf.error/malformed-json` + `:cause :too-many-keys`
+  + the configured `:limit`."
+  [max-keys]
+  (ex-info ":rf.error/malformed-json"
+           {:rf.error/id :rf.error/malformed-json
+            :where       'rf.http/json-parse
+            :recovery    :no-recovery
+            :reason      (str "JSON payload exceeded the per-call unique-key cap (" max-keys ") — a keyword-interning DoS guard")
+            :cause       :too-many-keys
+            :limit       max-keys}))
+
 (defn json-parse
   "JSON string → Clojure data with keyword keys for object keys. JVM
   uses Cheshire's `parse-string`; CLJS uses `js/JSON.parse` +
@@ -86,13 +103,7 @@
                                (when-not (.contains seen k)
                                  (.add seen k)
                                  (when (> (.size seen) max-keys)
-                                   (throw (ex-info ":rf.error/malformed-json"
-                                                   {:rf.error/id :rf.error/malformed-json
-                                                    :where       'rf.http/json-parse
-                                                    :recovery    :no-recovery
-                                                    :reason      (str "JSON payload exceeded the per-call unique-key cap (" max-keys ") — a keyword-interning DoS guard")
-                                                    :cause       :too-many-keys
-                                                    :limit       max-keys}))))
+                                   (throw (too-many-keys-ex max-keys))))
                                (keyword k))]
                   (cheshire/parse-string s key-fn)))
         :cljs (when (string? s)
@@ -123,13 +134,7 @@
                                            (when-not (contains? @seen k)
                                              (vswap! seen conj k)
                                              (when (> (count @seen) max-keys)
-                                               (throw (ex-info ":rf.error/malformed-json"
-                                                               {:rf.error/id :rf.error/malformed-json
-                                                                :where       'rf.http/json-parse
-                                                                :recovery    :no-recovery
-                                                                :reason      (str "JSON payload exceeded the per-call unique-key cap (" max-keys ") — a keyword-interning DoS guard")
-                                                                :cause       :too-many-keys
-                                                                :limit       max-keys})))))
+                                               (throw (too-many-keys-ex max-keys)))))
                                          (doseq [k ks] (walk (aget v k))))))]
                              (walk parsed))]
                   (js->clj parsed :keywordize-keys true)))))))


### PR DESCRIPTION
## What

DUPLICATION-reduction review of the `implementation/http` slice (rf2-k67u3, dedup-by-slice partition). The slice was already DRY across most of its surface — prior passes had consolidated the middleware before/after walk + binary-decode arms (jkake.9) and the failure-finalise abort tail (sixs3). Two residual duplications remained; this PR removes both. Dedup only — behaviour-preserving.

## Consolidations

1. **Shared reply tail.** `http-transport/dispatch-reply!` (real-transport path) and `http-machine-wrapper/dispatch-canned-reply!` (canned-stub path) both ran the `:after` interceptor chain then dispatched via `encoding/dispatch-reply-via-late-bind!` — byte-identical save for the `:after`-presence guard and where `:explicit-on` was derived. Extracted `middleware/run-after-then-dispatch!`. Both callers already `:require` `http-middleware`; the new helper `:require`s `http-encoding` for the late-bind dispatch, which is cycle-free (encoding does not require middleware). The transport's `(if middleware-ctx …)` synthetic-caller passthrough is preserved inside the shared helper; the canned path always supplies a `middleware-ctx`, so its behaviour is identical.

2. **`too-many-keys-ex`.** `util-json/json-parse`'s keyword-interning DoS-cap overflow ex-info (`:rf.error/malformed-json` / `:cause :too-many-keys` / `:limit`) was duplicated across the `:clj` and `:cljs` reader-conditional branches. The throw is platform-agnostic Clojure data, so it now lives in one private helper shared by both branches — the security-relevant shape the caller's `:rf.http/decode-failure` classification asserts on can no longer drift.

## Not touched (assessed DRY / out of scope)

- The CLJS-fetch vs JVM-HttpClient transport halves are genuinely platform-specific (Fetch Promise vs CompletableFuture; AbortController vs `.cancel`) and correctly gated under reader conditionals; the shared cascade (`handle-response!`, `maybe-retry!`, finalise-*) is already factored out.
- The once-only finalise CAS + abort-precedence (`aborted-snapshot` / `aborted-failure` / `emit-and-dispatch-failure!`) are already single-sourced (sixs3) and left untouched.
- The `privacy/prepare-emit-*` trace-emit pattern recurs at many call sites but each carries a distinct event id / tag shape; the composer itself is the shared seam.

## Contract / spec

No public API, `:rf.http/*` reserved vocab, or observable behaviour changed. All extracted helpers are private (`defn-` / private). No spec contract touched — Spec 014 unchanged.

## Gates (cold)

- http JVM `clojure -M:test`: **305 tests / 1515 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5477 tests / 19066 assertions, 0 failures, 0 errors**
- clj-kondo on the four changed files: 0 errors, 0 new warnings (the single `abort-signal` warning in `http-transport.cljc` is pre-existing on `origin/main`).