### PR TITLE
refactor(routing): dedup nav-fx/route-url/commit paths (rf2-m8a5s)

### DIFF
--- a/implementation/routing/src/re_frame/routing/events.cljc
+++ b/implementation/routing/src/re_frame/routing/events.cljc
@@ -14,6 +14,9 @@
       `[:rf/runtime :routing :current]` (encodes the slice-shape
       contract once for both the programmatic-nav and URL-driven paths,
       rf2-g8tzb);
+    - `commit-navigation` — the shared successful-commit assembler
+      (nav-token alloc + allocated/activation traces + slice publish +
+      fx vector) used by both nav entry points;
     - `:rf.route.internal/settle-transition` — the FIFO-drain
       `:loading → :idle` settle (nav-token-aware so a newer navigation
       mid-drain bumps `:nav-token` and the stale settle becomes a no-op).
@@ -130,6 +133,58 @@
               :transition transition
               :error      nil
               :nav-token  nav-token}))
+
+;; Per Spec 012 §Navigation is an event / §URL changes are events: a
+;; successful navigation commit is identical across the two entry points
+;; (programmatic `:rf.route/navigate` and URL-driven `:rf.route/
+;; transitioned` / `:rf.route/handle-url-change`) once the target slice
+;; fields have been resolved. Both:
+;;   1. allocate a fresh per-frame nav-token (the cascade-begin marker);
+;;   2. emit `:rf.route.nav-token/allocated`, then `emit-activation-
+;;      traces!` — IN THAT ORDER so trace consumers see
+;;      {allocated → deactivated? → activated?} (rf2-dn26r);
+;;   3. publish the seven-key slice via `merge-route-slice`;
+;;   4. assemble the fx vector: capture-scroll (the leaving route's
+;;      position) → [push-fx, when the programmatic path must drive the
+;;      browser URL] → the `:on-match` dispatches → the FIFO
+;;      `settle-transition` (only when an `:on-match` drain exists,
+;;      Spec 012 §Per-route data loading §2) → the scroll fx.
+;; The URL-driven path passes no `push-fx` (the browser URL already
+;; changed); the programmatic path passes `[:rf.nav/push-url ...]` /
+;; `[:rf.nav/replace-url ...]`. Holding the commit shape in ONE place
+;; keeps the trace ordering, the slice contract, and the fx assembly
+;; from drifting between the two callers.
+(defn commit-navigation
+  "Pure navigation-commit assembler shared by the programmatic-nav and
+  URL-driven paths. `db` is the pre-token-allocation db. `slice` carries
+  `{:id :params :query :fragment :transition}` (the published fields
+  minus `:nav-token`, which this fn allocates). `on-match-vec` is the
+  resolved `:on-match` event vector (possibly empty). `capture-fx` /
+  `scroll-fx` are the pre-built fx entries (or nil) and `push-fx` is the
+  optional history-mutation fx entry (nil on the URL-driven path).
+  Returns the event-fx cofx map `{:db :fx}`."
+  [db {:keys [id params query fragment transition]} on-match-vec
+   {:keys [prev-id capture-fx scroll-fx push-fx]}]
+  (let [[db' token] (alloc-nav-token db)]
+    (trace/emit! :rf.event :rf.route.nav-token/allocated
+                 {:route-id id :nav-token token})
+    (emit-activation-traces! prev-id id)
+    {:db (merge-route-slice db' {:id         id
+                                 :params     params
+                                 :query      query
+                                 :fragment   fragment
+                                 :transition transition
+                                 :nav-token  token})
+     :fx (vec (concat (when capture-fx [capture-fx])
+                      (when push-fx    [push-fx])
+                      (mapv (fn [ev] [:dispatch ev]) on-match-vec)
+                      ;; Per Spec 012 §Per-route data loading §2: settle
+                      ;; :loading → :idle after the on-match drain. FIFO
+                      ;; order means the settle runs after every on-match
+                      ;; event already queued above.
+                      (when (seq on-match-vec)
+                        [[:dispatch [:rf.route.internal/settle-transition token]]])
+                      (when scroll-fx [scroll-fx])))}))
 
 ;; Per Spec 012 §Per-route data loading §2. FIFO drain queues
 ;; :rf.route.internal/settle-transition after the :on-match events so

--- a/implementation/routing/src/re_frame/routing/nav_fx.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_fx.cljc
@@ -58,6 +58,35 @@
   [frame-id]
   (= (or frame-id :rf/default) (url-owner-frame-id)))
 
+;; `:rf.nav/push-url` and `:rf.nav/replace-url` share one body: gate on
+;; the calling frame's URL ownership, then either drive the browser
+;; history (CLJS) or emit the standard `:rf.fx/skipped-on-platform`
+;; trace (JVM / non-owner). The ONLY per-fx variation is the history
+;; method (`history.pushState` vs `history.replaceState`) and the
+;; `:fx-id` tag, so the body lives once in `history-mutation-handler`
+;; and each handler closes over its method + fx-id.
+
+(defn- history-mutation-handler
+  "Shared body for the `:rf.nav/push-url` / `:rf.nav/replace-url` fx
+  handlers. `fx-id` tags the platform-skip / non-owner traces;
+  `mutate!` is the 0-arg thunk that drives `window.history` on CLJS (a
+  no-op on JVM — the caller passes a CLJS-only thunk under a reader
+  conditional). Non-URL-bound frames skip the history mutation: the
+  frame's route slice at `[:rf/runtime :routing :current]` still
+  updates — only the browser-URL sync is suppressed. Per Spec 012
+  §Multi-frame routing this is the right default for story-variant /
+  devcard / per-test fixtures."
+  [fx-id frame url mutate!]
+  (if (url-bound-frame? frame)
+    #?(:cljs (mutate!)
+       :clj  (trace/emit! :rf.fx :rf.fx/skipped-on-platform
+                          {:fx-id fx-id :url url}))
+    (trace/emit! :rf.fx :rf.fx/skipped-on-platform
+                 {:fx-id  fx-id
+                  :url    url
+                  :frame  frame
+                  :reason :frame-not-url-bound})))
+
 (def push-url-meta
   "Metadata for the `:rf.nav/push-url` fx registration. Spec 012
   §Multi-frame routing (rf2-w50qm)."
@@ -71,19 +100,9 @@ no-op the fx so they don't race with the URL-owning frame (per Spec 012
   "`:rf.nav/push-url` fx handler. Registered by the façade so a `:reload`
   re-wires it on a fresh registrar."
   [{:keys [frame]} url]
-  (if (url-bound-frame? frame)
-    #?(:cljs (.pushState js/window.history nil "" url)
-       :clj  (trace/emit! :rf.fx :rf.fx/skipped-on-platform
-                          {:fx-id :rf.nav/push-url :url url}))
-    ;; Non-URL-bound frame: skip the history mutation. Frame's
-    ;; route slice at [:rf/runtime :routing :current] still updates — only the browser-URL sync is
-    ;; suppressed. Per Spec 012 §Multi-frame routing this is the right
-    ;; default for story-variant / devcard / per-test fixtures.
-    (trace/emit! :rf.fx :rf.fx/skipped-on-platform
-                 {:fx-id :rf.nav/push-url
-                  :url   url
-                  :frame frame
-                  :reason :frame-not-url-bound})))
+  (history-mutation-handler
+    :rf.nav/push-url frame url
+    #?(:cljs #(.pushState js/window.history nil "" url) :clj nil)))
 
 (def replace-url-meta
   "Metadata for the `:rf.nav/replace-url` fx registration. Spec 012
@@ -98,12 +117,6 @@ no-op the fx so they don't race with the URL-owning frame (per Spec 012
   "`:rf.nav/replace-url` fx handler. Registered by the façade so a
   `:reload` re-wires it on a fresh registrar."
   [{:keys [frame]} url]
-  (if (url-bound-frame? frame)
-    #?(:cljs (.replaceState js/window.history nil "" url)
-       :clj  (trace/emit! :rf.fx :rf.fx/skipped-on-platform
-                          {:fx-id :rf.nav/replace-url :url url}))
-    (trace/emit! :rf.fx :rf.fx/skipped-on-platform
-                 {:fx-id :rf.nav/replace-url
-                  :url   url
-                  :frame frame
-                  :reason :frame-not-url-bound})))
+  (history-mutation-handler
+    :rf.nav/replace-url frame url
+    #?(:cljs #(.replaceState js/window.history nil "" url) :clj nil)))

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -208,60 +208,40 @@
             ;; changed — leave the slice and the standing nav-token as-is;
             ;; emit no allocation, fire no loaders, push no URL.
             {}
-          (let [push-fx    (if (:replace? opts)
-                             [:rf.nav/replace-url url]
-                             [:rf.nav/push-url    url])
-                ;; Per Spec 012 §Multi-frame routing nav-token allocation
-                ;; bumps the per-frame counter; thread the new db through
-                ;; the slice write below.
-                [db' token] (routing-events/alloc-nav-token db)
-                ;; Per Spec 012 §Scroll restoration: forward navigation
-                ;; defaults to :top. Resolve from opts → route-meta →
-                ;; default.
-                to-route   (scroll/route-descriptor* route-id path-params query-params)
-                strategy   (scroll/resolve-scroll-strategy route-meta opts :top)
-                ;; Per Spec 012 §Multi-frame routing: scroll-position
-                ;; lookup reads the per-frame map under
-                ;; [:rf/runtime :routing :scroll-positions].
-                scroll-fx  (scroll/scroll-fx-entry
-                             {:strategy  strategy
-                              :from      (scroll/route-descriptor
-                                           (get-in db [:rf/runtime :routing :current]))
-                              :to        to-route
-                              :saved-pos (when (= :restore strategy)
-                                           (scroll/lookup-scroll-position db url))
-                              :fragment  fragment})
-                capture-fx (scroll/capture-scroll-fx-entry db)]
-            (trace/emit! :rf.event :rf.route.nav-token/allocated
-                         {:route-id  route-id
-                          :nav-token token})
-            ;; Per rf2-dn26r: route lifecycle pair. Fires after the
-            ;; nav-token allocation (the cascade-begin marker) so trace
-            ;; consumers see {allocated → deactivated? → activated?} in
-            ;; that order for any cross-route transition.
-            (routing-events/emit-activation-traces!
-              (get-in db [:rf/runtime :routing :current :id]) route-id)
-            ;; rf2-g8tzb: shared slice-publish helper — encodes the
-            ;; slice-shape contract once for both nav entry points.
-            ;; Targets `:current`, so sibling routing-runtime keys
-            ;; (`:scroll-positions` / `:scroll-positions-order` /
-            ;; `:nav-token-counter` / `:pending-nav-counter`) are
-            ;; untouched.
-            {:db (routing-events/merge-route-slice
-                   db' {:id         route-id
-                        :params     path-params
-                        :query      query-params
-                        :fragment   fragment
-                        :transition (if (seq on-match-vec) :loading :idle)
-                        :nav-token  token})
-             :fx (vec (concat (when capture-fx [capture-fx])
-                              [push-fx]
-                              (mapv (fn [ev] [:dispatch ev]) on-match-vec)
-                              ;; Per Spec 012 §Per-route data loading §2:
-                              ;; transition :loading → :idle when the
-                              ;; on-match drain completes. FIFO order means
-                              ;; the settle dispatch runs after every
-                              ;; on-match event already queued above.
-                              (when (seq on-match-vec)
-                                [[:dispatch [:rf.route.internal/settle-transition token]]])
-                              (when scroll-fx [scroll-fx])))}))))))
+            (let [push-fx    (if (:replace? opts)
+                               [:rf.nav/replace-url url]
+                               [:rf.nav/push-url    url])
+                  ;; Per Spec 012 §Scroll restoration: forward navigation
+                  ;; defaults to :top. Resolve from opts → route-meta →
+                  ;; default.
+                  to-route   (scroll/route-descriptor* route-id path-params query-params)
+                  strategy   (scroll/resolve-scroll-strategy route-meta opts :top)
+                  ;; Per Spec 012 §Multi-frame routing: scroll-position
+                  ;; lookup reads the per-frame map under
+                  ;; [:rf/runtime :routing :scroll-positions].
+                  scroll-fx  (scroll/scroll-fx-entry
+                               {:strategy  strategy
+                                :from      (scroll/route-descriptor
+                                             (get-in db [:rf/runtime :routing :current]))
+                                :to        to-route
+                                :saved-pos (when (= :restore strategy)
+                                             (scroll/lookup-scroll-position db url))
+                                :fragment  fragment})
+                  capture-fx (scroll/capture-scroll-fx-entry db)]
+              ;; rf2-g8tzb / commit-navigation: nav-token alloc, the
+              ;; allocated/activation traces, the slice publish, and the
+              ;; fx assembly are the shared commit shape. The programmatic
+              ;; path is the only one that drives the browser URL, so it
+              ;; passes `push-fx`.
+              (routing-events/commit-navigation
+                db
+                {:id         route-id
+                 :params     path-params
+                 :query      query-params
+                 :fragment   fragment
+                 :transition (if (seq on-match-vec) :loading :idle)}
+                on-match-vec
+                {:prev-id    (get-in db [:rf/runtime :routing :current :id])
+                 :capture-fx capture-fx
+                 :scroll-fx  scroll-fx
+                 :push-fx    push-fx})))))))

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -687,6 +687,38 @@
           nil
           (route-table))))))
 
+;; ---- route-url param-segment emission ------------------------------------
+;; `route-url`'s pattern walk hits a `:name` / `*name` segment in two
+;; places — the top-level loop (params may be absent → throw) and
+;; `emit-group` (an optional group is only entered when all its inner
+;; params are present → read directly). Both share the identical
+;; cursor-advance (`segment-end` to the segment boundary, `keyword` the
+;; captured name) and the same `:` → url-encode / `*` → url-encode-splat
+;; encoder dispatch. The two helpers below carry that shared shape so
+;; the four branch bodies collapse to a bounds-read + an encode call,
+;; and the encoder-vs-segment-kind mapping cannot drift between the two
+;; walk sites.
+
+(defn- param-seg-bounds
+  "Given `pattern` (length `n`) with the cursor `i` sitting on a `:` or
+  `*` sigil, return `[end k]`: `end` is the index just past the param
+  name (the next segment boundary) and `k` is the captured name as a
+  keyword."
+  [^String pattern n i]
+  (let [start (inc i)
+        end   (match/segment-end pattern n start)]
+    [end (keyword (subs pattern start end))]))
+
+(defn- encode-param
+  "Percent-encode a path-param `v` for emission: splat values
+  (`splat?`) preserve literal '/' between captured segments
+  (`url-encode-splat`); a plain named param is a single component
+  (`url-encode`)."
+  [splat? v]
+  (if splat?
+    (url/url-encode-splat v)
+    (url/url-encode v)))
+
 (defn route-url
   "Per Spec 012 §Bidirectional URL ↔ params. Build a URL string from a
   route-id + path-params (+ optional query-params + optional fragment).
@@ -782,6 +814,22 @@
            ;; re-walking the pattern body.
            groups (or (:groups (:rf.route/compiled route-meta))
                       (:groups (match/parse-pattern pattern)))
+           ;; Resolve a REQUIRED path-param value or throw. Per Spec 012
+           ;; §Bidirectional URL ↔ params: an absent or `nil` value
+           ;; raises; a present-but-falsy value (`false`, `0`, `""`) is a
+           ;; legitimate segment and round-trips. `if-some` discriminates
+           ;; falsy-but-present from absent (a plain `(or v throw)` would
+           ;; mis-classify falsy as absent). `kind` ("path"/"splat") only
+           ;; flavours the diagnostic message.
+           require-param
+           (fn [k kind]
+             (if-some [v (get path-params k)]
+               v
+               (throw (route-error
+                        :rf.error/missing-route-param
+                        'rf/route-url
+                        (str "route " route-id " requires " kind " param " k " but it was absent (or nil)")
+                        {:param k :route-id route-id}))))
            ;; Inner loop emits the body of an optional group whose params
            ;; are all present. State threads as (loop [i parts]); returns
            ;; [next-i parts'] when the group's '}' (and optional '?') is
@@ -800,17 +848,13 @@
                         after-close)
                       parts])
 
-                   (= ch \:)
-                   (let [start (inc i)
-                         end   (match/segment-end pattern n start)
-                         k     (keyword (subs pattern start end))]
-                     (recur end (conj parts (url/url-encode (get path-params k)))))
-
-                   (= ch \*)
-                   (let [start (inc i)
-                         end   (match/segment-end pattern n start)
-                         k     (keyword (subs pattern start end))]
-                     (recur end (conj parts (url/url-encode-splat (get path-params k)))))
+                   ;; `:name` / `*name` inside an optional group — the
+                   ;; group is only entered when all its inner params are
+                   ;; present, so read directly (no require check).
+                   (or (= ch \:) (= ch \*))
+                   (let [[end k] (param-seg-bounds pattern n i)]
+                     (recur end (conj parts (encode-param (= ch \*)
+                                                          (get path-params k)))))
 
                    :else
                    (recur (inc i) (conj parts (str ch)))))))
@@ -829,37 +873,13 @@
                          (recur i' parts'))
                        (recur close-end parts)))
 
-                   (= ch \:)
-                   (let [start (inc i)
-                         end   (match/segment-end pattern n start)
-                         k     (keyword (subs pattern start end))
-                         ;; Per Spec 012 §Bidirectional URL ↔ params: an
-                         ;; absent or `nil` value raises; a present-but-falsy
-                         ;; value (`false`, `0`, `""`) is a legitimate
-                         ;; segment and round-trips through url-encode.
-                         ;; `(or v throw)` mis-classifies falsy as absent;
-                         ;; `if-some` discriminates correctly.
-                         v     (if-some [v (get path-params k)]
-                                 v
-                                 (throw (route-error
-                                          :rf.error/missing-route-param
-                                          'rf/route-url
-                                          (str "route " route-id " requires path param " k " but it was absent (or nil)")
-                                          {:param k :route-id route-id})))]
-                     (recur end (conj parts (url/url-encode v))))
-
-                   (= ch \*)
-                   (let [start (inc i)
-                         end   (match/segment-end pattern n start)
-                         k     (keyword (subs pattern start end))
-                         v     (if-some [v (get path-params k)]
-                                 v
-                                 (throw (route-error
-                                          :rf.error/missing-route-param
-                                          'rf/route-url
-                                          (str "route " route-id " requires splat param " k " but it was absent (or nil)")
-                                          {:param k :route-id route-id})))]
-                     (recur end (conj parts (url/url-encode-splat v))))
+                   ;; `:name` / `*name` in the top-level pattern — the
+                   ;; value is REQUIRED; `require-param` throws on absent.
+                   (or (= ch \:) (= ch \*))
+                   (let [splat?  (= ch \*)
+                         [end k] (param-seg-bounds pattern n i)
+                         v       (require-param k (if splat? "splat" "path"))]
+                     (recur end (conj parts (encode-param splat? v))))
 
                    :else
                    (recur (inc i) (conj parts (str ch)))))))

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -116,7 +116,11 @@
         route-meta        (registrar/lookup :route route-id)
         on-match-vec      (vec (or (:on-match route-meta) []))
         transition        (if (seq on-match-vec) :loading :idle)
-        [db' token]       (routing-events/alloc-nav-token db)
+        ;; nav-token allocation moved into `commit-navigation` (reached
+        ;; only in the `:else` commit branch); the `identical-nav?` /
+        ;; `fragment-only?` short-circuits never allocated a usable token
+        ;; (the prior eager alloc was discarded on both), so the
+        ;; observable counter behaviour is unchanged.
         to-route          (cond-> {:id route-id}
                             (seq params) (assoc :params params)
                             (seq query)  (assoc :query  query))
@@ -178,35 +182,23 @@
                                       :recovery :replaced-with-default}
                                frame      (assoc :frame frame)
                                malformed? (assoc :reason :malformed-url))))
-        (trace/emit! :rf.event :rf.route.nav-token/allocated
-                     {:route-id  route-id
-                      :nav-token token})
-        ;; Per rf2-dn26r: route lifecycle pair. Fires after the nav-token
-        ;; allocation so trace consumers see {allocated → deactivated? →
-        ;; activated?} in that order for any cross-route transition.
-        (routing-events/emit-activation-traces!
-          (get-in db [:rf/runtime :routing :current :id]) route-id)
-        ;; rf2-g8tzb: shared slice-publish helper — encodes the
-        ;; slice-shape contract once for both nav entry points.
-        ;; Targets `:current`, so sibling routing-runtime keys
-        ;; (`:scroll-positions` / `:scroll-positions-order` /
-        ;; `:nav-token-counter` / `:pending-nav-counter`) are untouched.
-        {:db (routing-events/merge-route-slice
-               db' {:id         route-id
-                    :params     params
-                    :query      query
-                    :fragment   fragment
-                    :transition transition
-                    :nav-token  token})
-         :fx (vec (concat (when capture-fx [capture-fx])
-                          (mapv (fn [ev] [:dispatch ev]) on-match-vec)
-                          ;; Per Spec 012 §Per-route data loading §2:
-                          ;; settle :loading → :idle after the on-match
-                          ;; drain. FIFO order: settle runs after every
-                          ;; on-match event already queued above.
-                          (when (seq on-match-vec)
-                            [[:dispatch [:rf.route.internal/settle-transition token]]])
-                          (when scroll-fx [scroll-fx])))}))))
+        ;; rf2-g8tzb / commit-navigation: nav-token alloc, the
+        ;; allocated/activation traces, the slice publish (targeting
+        ;; `:current`, so sibling routing-runtime keys are untouched),
+        ;; and the fx assembly are the shared commit shape. The
+        ;; URL-driven path passes NO `push-fx` — the browser URL already
+        ;; changed (popstate / initial / link-click pushState).
+        (routing-events/commit-navigation
+          db
+          {:id         route-id
+           :params     params
+           :query      query
+           :fragment   fragment
+           :transition transition}
+          on-match-vec
+          {:prev-id    (get-in db [:rf/runtime :routing :current :id])
+           :capture-fx capture-fx
+           :scroll-fx  scroll-fx})))))
 
 (defn transitioned-handler
   "`:rf.route/transitioned` event-fx handler. Registered by the façade


### PR DESCRIPTION
## What

Behaviour-preserving duplication-reduction pass over `implementation/routing/src/**`, per the per-slice DRY review (rf2-m8a5s). The slice had already been through the rf2-2yabr / rf2-icrxv cohesion split and was largely DRY (shared `strip-trailing-slashes`, `alloc-counter`, `merge-route-slice`, `route-descriptor*`, `route-error`, `segment-end`, `href-attrs`, `safe-url-decode`, `maybe-block-navigation`). This PR consolidates the three residual copy-paste sites.

### 1. `nav_fx` — push/replace handlers
`push-url-handler` and `replace-url-handler` were byte-identical except for `history.pushState` vs `history.replaceState` and the `:fx-id` tag. Folded into a shared `history-mutation-handler`; each fx closes over its CLJS history-method thunk + `:fx-id`.

### 2. `registry/route-url` — segment emission
The `:name` / `*name` emit logic appeared in **four** near-identical branches (two in `emit-group`, two in the top-level loop), each repeating the `start`/`segment-end`/`keyword` cursor advance and the `:` → `url-encode` / `*` → `url-encode-splat` dispatch. Collapsed onto shared `param-seg-bounds` + `encode-param` helpers plus a single `require-param` resolver. The encoder-vs-segment-kind mapping now lives in one place.

### 3. `events/commit-navigation` — the shared commit shape
`navigate-handler` (programmatic) and `url-change-fx` (URL-driven) duplicated the entire successful-commit tail: nav-token alloc → `:rf.route.nav-token/allocated` trace → `emit-activation-traces!` (rf2-dn26r order) → `merge-route-slice` → the `capture / push / on-match / settle-transition / scroll` fx vector. Extracted to `commit-navigation` in the shared-helpers seam. The only divergence (the programmatic path drives the browser URL) is carried as an optional `:push-fx`. The url-change eager `alloc-nav-token` — already discarded on the `identical-nav?` / `fragment-only?` short-circuits — is now reached only on the commit branch (observable counter behaviour unchanged).

## Contract impact
None. All new symbols are internal/private helpers; the public re-export surface, event/fx ids, trace events, and their ordering are unchanged. **spec/012 unchanged** (no contract surface touched).

## Net
+211 / −151 across 5 files.

## Gates (cold)
- routing `clojure -M:test` — 144 tests / 629 assertions, 0 failures, 0 errors
- `npm run test:cljs` — 5481 tests / 19088 assertions, 0 failures, 0 errors

Closes rf2-m8a5s.