### PR TITLE
fix(xray): clear stale reset-flash on every reset attempt (rf2-wa7tk)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/epoch.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/epoch.cljs
@@ -51,8 +51,9 @@
   ;; message string when a `rf/restore-epoch` rewind fails (epoch aged
   ;; out of the buffer, or a restore-during-drain rejection). nil =
   ;; nothing to show. The flash is INLINE on the tab ribbon — never a
-  ;; modal — and self-clears (the Reset event schedules the clear). A
-  ;; failure must never be a silent lie; it must also never block.
+  ;; modal — and clears on the next reset attempt (`:rf.xray/reset-to-
+  ;; epoch` dissocs the slot before re-running the restore, rf2-wa7tk).
+  ;; A failure must never be a silent lie; it must also never block.
   (rf/reg-sub :rf.xray/reset-flash
     (fn [db _query]
       (get db :reset-flash)))
@@ -190,9 +191,22 @@
   ;; are power users). A nil frame / epoch-id is a guarded no-op (the
   ;; button is disabled when no epoch is focused, but the event stays
   ;; defensive).
+  ;;
+  ;; rf2-wa7tk — clear any STALE failure flash on every fresh attempt.
+  ;; The flash is set by `:rf.xray/reset-flash-failed` on a failed
+  ;; restore but had no auto-dismiss and no success-path clear, so a
+  ;; later SUCCESSFUL reset left the "Reset failed" message standing —
+  ;; a silent lie (the sub still returned the stale string, the ribbon
+  ;; kept rendering it). Dissoc-ing `:reset-flash` here in the `:db`
+  ;; honours the documented "the next successful reset" clear contract
+  ;; (`:rf.xray/clear-reset-flash` docstring): a fresh attempt wipes the
+  ;; prior failure, and the fx re-sets the flash only when THIS attempt
+  ;; also fails. The dissoc runs before the fx so a failure that fires
+  ;; `:rf.xray/reset-flash-failed` synchronously still wins.
   (rf/reg-event-fx :rf.xray/reset-to-epoch
-    (fn [_cofx [_ frame epoch-id]]
-      {:fx [[:rf.xray.fx/restore-epoch {:frame frame :epoch-id epoch-id}]]}))
+    (fn [{:keys [db]} [_ frame epoch-id]]
+      {:db (dissoc db :reset-flash)
+       :fx [[:rf.xray.fx/restore-epoch {:frame frame :epoch-id epoch-id}]]}))
 
   ;; `:rf.xray/reset-flash-failed` (rf2-hga49) — set the inline failure
   ;; flash. Dispatched from `:rf.xray.fx/restore-epoch` when
@@ -204,8 +218,10 @@
       (assoc db :reset-flash "Reset failed — epoch unavailable (see Trace)")))
 
   ;; `:rf.xray/clear-reset-flash` (rf2-hga49) — clear the inline flash.
-  ;; Dispatched by the view's auto-dismiss timer / the next successful
-  ;; reset. `:rf.trace/no-emit? true` per the sibling rationale.
+  ;; The steady-state clear path is `:rf.xray/reset-to-epoch` dissoc-ing
+  ;; the slot on every fresh attempt (rf2-wa7tk); this event remains the
+  ;; explicit imperative clear (tests + any future dismiss affordance).
+  ;; `:rf.trace/no-emit? true` per the sibling rationale.
   (rf/reg-event-db :rf.xray/clear-reset-flash
     {:rf.trace/no-emit? true}
     (fn [db _event]

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -2714,15 +2714,51 @@
     (rf/with-frame :rf/xray
       (is (string? @(rf/subscribe [:rf.xray/reset-flash]))
           "a false restore sets the inline failure flash"))
-    ;; clear, then success path → no flash
-    (rf/with-frame :rf/xray
-      (rf/dispatch-sync [:rf.xray/clear-reset-flash]))
+    ;; rf2-wa7tk — success path WITHOUT a manual clear: the fresh
+    ;; reset attempt must itself dissoc the stale failure flash (the
+    ;; documented "next successful reset" contract). Pre-fix the stale
+    ;; "Reset failed" string survived a subsequent successful reset —
+    ;; a silent lie on the ribbon.
     (with-redefs [rf/restore-epoch (fn [_frame _epoch-id] true)]
       (rf/with-frame :rf/xray
         (rf/dispatch-sync [:rf.xray/reset-to-epoch :rf/default "epoch-9"])))
     (rf/with-frame :rf/xray
       (is (nil? @(rf/subscribe [:rf.xray/reset-flash]))
-          "a successful restore leaves no flash"))))
+          "a successful restore clears the stale failure flash (rf2-wa7tk)"))))
+
+(deftest reset-to-epoch-clears-stale-flash-before-reattempt
+  (testing "rf2-wa7tk — `:rf.xray/reset-to-epoch` dissocs any stale
+            `:reset-flash` on EVERY fresh attempt, before re-running the
+            restore. A second FAILED reset still shows a flash (the fx
+            re-sets it); the key invariant is that the slot is cleared
+            first, so a stale failure can never outlive the gesture that
+            produced it. Without the clear, the success-path test above
+            would only pass because it manually dispatched
+            `:rf.xray/clear-reset-flash` — papering over the bug."
+    (xray-setup!)
+    ;; first attempt fails → flash set
+    (with-redefs [rf/restore-epoch (fn [_frame _epoch-id] false)]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/reset-to-epoch :rf/default "epoch-1"])))
+    (rf/with-frame :rf/xray
+      (is (string? @(rf/subscribe [:rf.xray/reset-flash]))
+          "first failed reset sets the flash"))
+    ;; second attempt ALSO fails → the fresh attempt clears the old
+    ;; string first, then the fx re-sets a (current) failure flash.
+    (with-redefs [rf/restore-epoch (fn [_frame _epoch-id] false)]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/reset-to-epoch :rf/default "epoch-2"])))
+    (rf/with-frame :rf/xray
+      (is (string? @(rf/subscribe [:rf.xray/reset-flash]))
+          "a second failed reset still surfaces a flash (re-set by the fx)"))
+    ;; third attempt succeeds → no manual clear; the attempt's own
+    ;; dissoc must wipe the flash.
+    (with-redefs [rf/restore-epoch (fn [_frame _epoch-id] true)]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/reset-to-epoch :rf/default "epoch-3"])))
+    (rf/with-frame :rf/xray
+      (is (nil? @(rf/subscribe [:rf.xray/reset-flash]))
+          "a successful reset clears the flash with no manual clear (rf2-wa7tk)"))))
 
 (deftest reset-flash-failed-sets-inline-flash-and-clears
   (testing "rf2-hga49 — a restore failure sets the inline `:rf.xray/reset-


### PR DESCRIPTION
## What

Correctness fix from the **rf2-wa7tk** per-slice review of `tools/xray/src`.

`:rf.xray/reset-flash` is the inline "Reset failed" message the L4 tab ribbon shows when `rf/restore-epoch` (the time-travel rewind) fails. It was **set** on failure (`:rf.xray/reset-flash-failed`) but had **no auto-dismiss and no success-path clear**:

- `:rf.xray/clear-reset-flash` was registered + unit-tested but **never dispatched by any production path** (no view timer, no success hook).
- A subsequent **successful** reset left the stale "Reset failed" string standing on the ribbon — a silent lie, which the feature's own docstring names as the explicit non-goal ("A failure must never be a silent lie").

The existing `reset-to-epoch-fx-flashes-on-restore-failure` test masked this by manually dispatching `:rf.xray/clear-reset-flash` between its failure and success cases.

## Fix

`:rf.xray/reset-to-epoch` now `dissoc`s `:reset-flash` in its `:db` before re-running the restore fx — honouring the documented "the next successful reset" clear contract. A failed attempt re-sets the flash via the fx; a successful one leaves it cleared. Stale docstrings in `epoch.cljs` updated to match.

## Tests

- Removed the manual clear from `reset-to-epoch-fx-flashes-on-restore-failure` so it verifies the real auto-clear.
- Added `reset-to-epoch-clears-stale-flash-before-reattempt` (failure → second failure still flashes via the fx re-set → success clears with no manual clear).

## Gates (cold)

- xray JVM `clojure -M:test`: 1095 tests / 4563 assertions, 0 failures / 0 errors
- `npm run test:cljs`: 5482 tests / 19091 assertions, 0 failures / 0 errors
- `npm run test:xray-feature-gate`: 16 scenarios, 0 failures (one unrelated `static mode chrome and chord` flake cleared on re-run)

## Follow-on beads (not fixed here)

- **rf2-wh33n** (P4) — Trace panel `row-key` collision when `:id` is nil (`"t:nil"`); latent, framework allocates monotonic ids.
- **rf2-fttd3** (P4) — stale `##Inf` comment vs `js/Number.MAX_SAFE_INTEGER` in `trace_collector/snapshot-from-rings` (doc-only).

Reviewed-but-clean: epoch projection, diff engine, focus resolver, spine, machine canvas/trace-state, app-db-diff subs, reactive-panel subs, cancellation-cascade helpers, trace helpers.