### PR TITLE
refactor(machines): reduce-kv the machine-data schema validator (rf2-mpuu9)

### DIFF
--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -121,32 +121,27 @@
   Per Spec 009 §Production builds the body lives inside a
   `(when interop/debug-enabled? ...)` gate so production builds
   return `true` unconditionally."
-  [db event-id frame-id]
+  [db _event-id _frame-id]
+  ;; `event-id` and `frame-id` are accepted but unused at this boundary
+  ;; (the per-snapshot emit already names the machine); the arity matches
+  ;; `validate-app-schema!` so the late-bind hook the router consumes can
+  ;; be invoked uniformly.
   (if interop/debug-enabled?
     (if-let [machine-meta (late-bind/get-fn-cached :machines/machine-meta)]
-      (let [snapshots (get-in db (paths/snapshot-path))]
-        (loop [entries (seq snapshots)
-               ok?     true]
-          (if-let [[machine-id snapshot] (first entries)]
-            (if-let [spec (machine-meta machine-id)]
-              (if-let [schema (:schema spec)]
-                (if (validate-snapshot-data! machine-id snapshot schema
-                                             :macrostep)
-                  (recur (next entries) ok?)
-                  ;; Per the validate-app-schema! pattern (rf2-wkxng): keep
-                  ;; walking so EVERY failing machine surfaces its own trace
-                  ;; (consumers see the full set), and return the conjoined
-                  ;; boolean so the router decides rollback deterministically.
-                  (recur (next entries) false))
-                (recur (next entries) ok?))
-              (recur (next entries) ok?))
-            ;; `event-id` and `frame-id` are accepted but unused at this
-            ;; boundary; the per-snapshot emit already names the machine.
-            ;; Same arity as `validate-app-schema!` so the late-bind hook
-            ;; the router consumes can be invoked uniformly (Clojure
-            ;; doesn't warn on unused fn args — no defensive marker
-            ;; needed).
-            ok?)))
+      ;; Per the validate-app-schema! pattern (rf2-wkxng): validate EVERY
+      ;; snapshot (no short-circuit) so each failing machine surfaces its
+      ;; own trace (consumers see the full set), AND-conjoining the per-
+      ;; snapshot conform decision so the router decides rollback
+      ;; deterministically. A snapshot whose machine declares no `:schema`
+      ;; (or whose spec `machine-meta` can't resolve) conforms vacuously.
+      (reduce-kv
+        (fn [ok? machine-id snapshot]
+          (and (if-let [schema (some-> (machine-meta machine-id) :schema)]
+                 (validate-snapshot-data! machine-id snapshot schema :macrostep)
+                 true)
+               ok?))
+        true
+        (get-in db (paths/snapshot-path)))
       true)
     true))
 


### PR DESCRIPTION
## What

FP-technique review of `implementation/machines/src/**` (bead rf2-mpuu9). The slice's machine engine is already designed as a pure `[machine snapshot event] -> Result`, so genuine imperative offenders were expected to be rare — and they were. **One** real offender found and functionalized; the rest of the slice is already idiomatic.

### The one offender

`re-frame.machines.data-validation/validate-machine-data!` walked the per-snapshot schema validation as a `loop`/`recur` ladder of nested `if-let`s, each arm ending in `(recur (next entries) ...)`. The shape obscured that this is a **non-short-circuiting fold** over the snapshots map, AND-conjoining each snapshot's conform decision while always running the (side-effecting, trace-emitting) per-snapshot validator.

Rewritten as a `reduce-kv` over the snapshots map. The validator call sits in the **left** arm of an `and` so it always fires before the conjunction — preserving the "surface every failing machine's trace, then conjoin for the router's rollback decision" semantic (rf2-wkxng pattern). Vacuous-conform for a no-`:schema` / unresolvable-spec snapshot collapses from three separate `recur` arms to one `(if-let [schema ...] ... true)`.

Behaviour-preserving: `reduce-kv` over the nil/absent snapshots slot returns the `true` init exactly as the old `(seq snapshots)` -> nil -> `ok?` path did. Unused `event-id` / `frame-id` args renamed `_`-prefixed.

`-24 / +19` LoC.

## Why nothing else changed

Full read of all 23 source files. Every other construct is sound FP:

- **9 `loop`/`recur`** — all genuine tree-walks (`chase-ref`, `node-at`, `nodes-along-path`, `initial-cascade`, `resolve-path-nodes`, `walk-path-leaf-to-root`, `ref-resolves?`, `node-at-states`) or bounded drains / fixed-point loops with early termination (`drain-raises`, the `:always` microstep loop, `reduce-regions`'s 8-accumulator region thread). None are mutation-as-loop; none reduce cleanly to `reduce`/`map`.
- **~20 `doseq`** — all genuine per-element side effects: trace emission, validation `throw`, host-clock timer cancellation, actor teardown, fx firing. Correct imperative use.
- **2 module-level `atom`s** (`timer/after-timers`, `spawn-order/spawn-order`) + the parallel region-cache atom — documented runtime-owned state (host-clock handle table / disposal-order channel / memoization cache), not local-mutable-as-loop.
- **1 `volatile!`** (`destroy-single-actor!`) — side-channel to extract a second value from inside a `swap!` callback; appropriate idiom.

No perf carve-outs needed (the existing `transient` in `resolve-path-nodes` and `subvec` zero-copy slices are already in place and untouched).

## Scope / spec

`implementation/machines/src/**` only. No `spec/005` change — this is a behaviour-preserving style refactor of an internal validator; no documented contract moved.

## Gates (cold)

- machines `clojure -M:test` — **390 tests / 1307 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **5482 tests / 19091 assertions, 0 failures, 0 errors**

The engine's purity-dependent revertibility is unaffected (the changed fn is a post-commit validator, not on the pure-transition path).