### PR TITLE
docs(mcp-base+story): spec-freshness — 11 contracts, :rf.mcp/result, nine reg-* macros, eight canonical assertions (rf2-rcypv + rf2-d4reo + rf2-4xgzv + rf2-af7yl)

### DIFF
--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Parsers that take an ALREADY-RESOLVED raw value (extracted by the consumer from its platform-specific args object: a JS object for re-frame2-pair-mcp, a Clojure map for story-mcp) and normalise it into the Clojure-side type the tool body expects. Cross-MCP arg-vocabulary convention: an agent that learns `:dedup` defaults true on re-frame2-pair-mcp must see the same default everywhere.
 
-This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/cap.md
+++ b/tools/mcp-base/spec/cap.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the ALGORITHM that drives the overflow marker into a result. Until rf2-eyelu this pipeline was duplicated near-identically in re-frame2-pair-mcp (CLJS, `#js {:content #js [...]}`-shaped results) and story-mcp (CLJ, `{:content [...] :structuredContent ...}`-shaped results). The only structural difference between the two implementations was the SHAPE of the result map and the platform-appropriate accessor used to read its `:text` slots — algorithm identical.
 
-This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the cross-MCP cursor codec, the EDN-with-no-tagged-literals reader, the size cap, the `::malformed` recovery contract, the `:limit` clamp, and the `cursor-stale-result` envelope. The cursor PAYLOAD shape is consumer-side (story carries `{:offset :total :sig}`; pair carries `{:after-id :ms :until-ms :frame}`).
 
-This doc is one of ten per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`envelope.md`](envelope.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/descriptor-manifest.md
+++ b/tools/mcp-base/spec/descriptor-manifest.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The shared, platform-agnostic serialiser + drift-check that lets BOTH MCP servers (`re-frame2-pair-mcp`, `story-mcp`) GENERATE / VALIDATE a committed `tool-descriptors.edn` manifest from their tool registry — so adding / removing / renaming an MCP tool goes RED in CI until the manifest is regenerated. Models the project's API-governance keystone (`rf2-3nbl5.2`, `spec/api-manifest.edn`) on the MCP descriptor surface (`rf2-sofwv`).
 
-This doc is one of the per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`args.md`](args.md), [`cap.md`](cap.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md).
 
 ## The problem it solves
 

--- a/tools/mcp-base/spec/diff-encode.md
+++ b/tools/mcp-base/spec/diff-encode.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Each `:rf/epoch-record` carries `:db-before` and `:db-after` — near-identical full app-db snapshots. `pr-str` doesn't preserve structural sharing, so on the wire the pair is roughly 2× app-db per epoch; a 50-epoch default `:epochs` slice ⇒ up to 100× app-db. This ns replaces `:db-after` with a **path-headed cluster projection** (rf2-qeous) of a path-keyed structural diff against `:db-before` so the wire payload approaches the structural-sharing cost rather than the deep-copy cost. The patch list is grouped into path-breadcrumb sections via [`section-grouping.md`](section-grouping.md).
 
-This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/elision.md
+++ b/tools/mcp-base/spec/elision.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Per [`../../../spec/009-Instrumentation.md` §Size elision in traces](../../../spec/009-Instrumentation.md), the framework's `rf/elide-wire-value` walker substitutes over-threshold leaves with a `{:rf.size/large-elided {…}}` marker before the payload leaves the runtime. Every MCP tool that returns a tree-typed payload surfaces a scalar count of those substitutions on its response envelope (the `:elided-large` slot — see [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots)). This namespace owns the **counter**, not the walker.
 
-This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/envelope.md
+++ b/tools/mcp-base/spec/envelope.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the SHAPE of the indicator-field splice (`with-indicators`) enforcing the MUST-level "omit when zero" rule, plus the wire-bounded `:rf.mcp/*` marker detection used by the cache + cap boundary steps. The indicator KEYS themselves live in [`vocab.md`](vocab.md); this ns owns the splice + detection logic.
 
-This doc is one of ten per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/overflow.md
+++ b/tools/mcp-base/spec/overflow.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the SHAPE of the overflow marker (the `{:rf.mcp/overflow {:limit :reached :token-count … :cap-tokens … :tool … :hint …}}` map). The cap-enforcement glue (counting tokens, replacing the payload) lives in [`cap.md`](cap.md).
 
-This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`cap.md`](cap.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/section-grouping.md
+++ b/tools/mcp-base/spec/section-grouping.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Projects a flat diff patch-list into path-headed cluster **sections** — the same sections-per-cluster decomposition Xray's panel renderer ships (rf2-gfxmk Phase 1 of rf2-abts7), but computed from the patch list rather than the annotated tree. [`diff-encode.md`](diff-encode.md) consumes this to shape the `:db-after` marker's `:sections` slot.
 
-This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The cross-MCP privacy filter. Framework-published forwarders — Sentry / Honeybadger, re-frame2-pair server, Story-MCP, Xray-MCP — MUST default-drop trace events whose registration declared `:sensitive? true`. The runtime stamps the flag at the top level of every emitted trace event inside such a registration's handler scope; the forwarder's job is to gate egress on it before any data crosses the trust boundary.
 
-This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/vocab.md
+++ b/tools/mcp-base/spec/vocab.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The single source of truth for the marker keys an agent learns once and recognises across every MCP server in the re-frame2 pair — `re-frame2-pair-mcp` and `story-mcp`. A rename here is a wire-protocol break; the cross-MCP conformance gate under `tools/mcp-conformance/wire-vocab/` fails loud when that happens.
 
-This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 
 ## Scope
 
@@ -39,6 +39,7 @@ Unqualified envelope slots — `:dropped-sensitive`, `:elided-large` — are per
 | `cache-hit-key` | `:rf.mcp/cache-hit` | `{:tool … :digest … :hint …}` (content-free; agent host correlates by cache key) | rf2-3rt1f / rf2-36xod |
 | `summary-key` | `:rf.mcp/summary` | `{<tree-summary>}` (lazy-summary projection) | rf2-tygdv / rf2-u2029 |
 | `invalid-arg-key` | `:rf.mcp/invalid-arg` | `{:arg <kw> :value <supplied> :hint <str>}` — top-level wrapper carried as the payload of an `isError: true` result rejecting a malformed per-call arg. First emitter: `cap/max-tokens` on a negative `:max-tokens` (see [`cap.md` §Negative `:max-tokens` is rejected](cap.md#negative-max-tokens-is-rejected-rf2-5rdit)). | rf2-5rdit |
+| `result-key` | `:rf.mcp/result` | `{:rf.mcp/result <tag> …}` — top-level discriminator for a wire-**fidelity** typed result envelope. `<tag>` ∈ `:value` (`:value <v>`), `:nil` (no extra slots), `:eval-error` (`:reason :ex :message :ex-data`), `:unserializable` (`:type :preview`). TYPES an evaluation's outcome so a genuine `nil`, a thrown eval-error, and an unserializable value (`#object`/`#js`/Function) stop collapsing to a bare `null`. Emitted by re-frame2-pair-mcp's `tools/result_envelope.cljs` for `eval-cljs` / `handler-meta`; the server projects each tag onto the tool's `:ok?` vocabulary. Composes with — never bypasses — the size machinery: the codec tags the outcome; the elision walker still runs over the `:value` payload. Per [Tool-Pair §Wire fidelity](../../../spec/Tool-Pair.md). (Defined-but-not-yet-cross-gated: the `wire-vocab` conformance corpus does not yet pin this marker.) | rf2-qobqy |
 
 ## Marker catalogue (`:rf.size/*`)
 

--- a/tools/story/README.md
+++ b/tools/story/README.md
@@ -99,10 +99,10 @@ The substantive implementation contract is decomposed into
 | File | Covers |
 |---|---|
 | [`spec/000-Vision.md`](./spec/000-Vision.md) | What Story is, what it isn't, how it relates to `spec/007-Stories.md`. |
-| [`spec/001-Authoring.md`](./spec/001-Authoring.md) | The seven `reg-*` macros; EDN-first variant contract; inclusion tags; source-coord stamping. |
+| [`spec/001-Authoring.md`](./spec/001-Authoring.md) | The nine `reg-*` macros (incl. the `reg-fragment` / `reg-check` composition cohort specced in [`spec/017-Testing-Story.md`](./spec/017-Testing-Story.md)); EDN-first variant contract; inclusion tags; source-coord stamping. |
 | [`spec/002-Runtime.md`](./spec/002-Runtime.md) | Per-variant frame allocation; args precedence; decorator composition; the four-phase loader lifecycle; `run-variant` and friends. |
 | [`spec/003-Render-Shell.md`](./spec/003-Render-Shell.md) | The UI shell (sidebar / canvas / controls / workspace / embedded Xray inspector); the five workspace layouts; multi-substrate side-by-side. |
-| [`spec/004-Assertions.md`](./spec/004-Assertions.md) | The seven canonical `:rf.assert/*` events; record-don't-throw semantics; play-sequence execution; the assertion-side `force-fx-stub` interaction. |
+| [`spec/004-Assertions.md`](./spec/004-Assertions.md) | The eight canonical `:rf.assert/*` ids (seven dispatched + the tape-evaluated `:rf.assert/schema-error`); record-don't-throw semantics; play-sequence execution; the assertion-side `force-fx-stub` interaction. |
 | [`spec/005-SOTA-Features.md`](./spec/005-SOTA-Features.md) | `force-fx-stub` (mock anything, not just the network); layout-debug trio; a11y; share URL (live address-bar surface; QR popover retired in rf2-ymnfx Issue B); multi-substrate; Xray embed; v1.1 deferrals; production elision. |
 | [`spec/006-MCP-Surface.md`](./spec/006-MCP-Surface.md) | The boundary between Story and `tools/story-mcp/`. |
 | [`spec/Principles.md`](./spec/Principles.md) | Design principles (EDN-first, no fn-slots, production-elision strict, etc.). |
@@ -187,5 +187,6 @@ The browser testbeds also depend on a few non-obvious invariants:
 - [Story tutorial](../../docs/story/index.md) — the narrative walkthrough;
   the friendly entry-point for human readers.
 - [`tools/story/testbeds/counter_with_stories/`](testbeds/counter_with_stories/) —
-  the tool-owned testbed wiring the seven `reg-*` macros against the canonical
-  counter app (rf2-p8f2s — relocated from `examples/reagent/`).
+  the tool-owned testbed wiring seven of the nine `reg-*` macros (it does not
+  exercise the `reg-fragment` / `reg-check` composition cohort) against the
+  canonical counter app (rf2-p8f2s — relocated from `examples/reagent/`).

--- a/tools/story/spec/000-Vision.md
+++ b/tools/story/spec/000-Vision.md
@@ -10,8 +10,9 @@
 The framework's normative spec for stories lives at
 [`spec/007-Stories.md`](../../../spec/007-Stories.md). That document
 locks the registration grammar, the three-way Story / Variant /
-Workspace split, the canonical id grammar, the seven `:rf.assert/*`
-events, the snapshot-identity contract, and the variant-as-data rule.
+Workspace split, the canonical id grammar, the seven dispatched
+`:rf.assert/*` events, the snapshot-identity contract, and the
+variant-as-data rule.
 
 `tools/story/spec/` (this folder) sits *below* the framework spec. It
 is the implementation-flavoured contract for the
@@ -190,8 +191,9 @@ The posture is normative across Story's surfaces:
    that reveals the underlying value" (per
    [spec/015 §The display contract](../../../spec/015-Data-Classification.md#the-display-contract--sentinels)).
 3. **Assertion vocabulary — path-marked args resolve to sentinels.**
-   The seven `:rf.assert/*` events (per
-   [`004-Assertions.md`](004-Assertions.md)) build assertion records
+   The seven dispatched `:rf.assert/*` events (per
+   [`004-Assertions.md`](004-Assertions.md); the eighth canonical id
+   `:rf.assert/schema-error` is tape-evaluated) build assertion records
    whose `:actual` / `:expected` / `:payload` slots pass through
    `re-frame.elision/elide-wire-value` at record-build time. An
    assertion of `:rf.assert/path-equals [:auth :token] :rf/redacted`

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -1,9 +1,13 @@
 # Story — Authoring
 
-> The registration surface — the seven `reg-*` macros, the EDN-first
-> variant contract, the inclusion-tag vocabulary, source-coord
-> stamping, and the macro-time validation rules. The contract Stage 2
-> implements and Stages 3–8 consume.
+> The registration surface — the nine `reg-*` macros (`reg-story` /
+> `reg-variant` / `reg-fragment` / `reg-check` / `reg-workspace` /
+> `reg-mode` / `reg-story-panel` / `reg-decorator` / `reg-tag`; the
+> `reg-fragment` / `reg-check` composition cohort is specced in
+> [`017-Testing-Story.md`](017-Testing-Story.md) §Strict composition),
+> the EDN-first variant contract, the inclusion-tag vocabulary,
+> source-coord stamping, and the macro-time validation rules. The
+> contract Stage 2 implements and Stages 3–8 consume.
 
 ## Boot — auto-install of the canonical vocabulary (rf2-p1ydc)
 
@@ -36,11 +40,12 @@ implicit, matching Storybook's ergonomic.
 ### Trigger condition
 
 Per-process. The auto-install gate is a single boolean atom in
-`re-frame.story.canonical`. The first call to ANY of the seven
-runtime helpers — `reg-story*` / `reg-variant*` / `reg-workspace*` /
-`reg-mode*` / `reg-story-panel*` / `reg-decorator*` / `reg-tag*` —
+`re-frame.story.canonical`. The first call to ANY of the nine
+runtime helpers — `reg-story*` / `reg-variant*` / `reg-fragment*` /
+`reg-check*` / `reg-workspace*` / `reg-mode*` / `reg-story-panel*` /
+`reg-decorator*` / `reg-tag*` —
 flips the gate true and runs the canonical installer chain. The
-seven `reg-*` macros expand to those runtime helpers, so the same
+nine `reg-*` macros expand to those runtime helpers, so the same
 gate fires from macro-site or programmatic-site registrations alike.
 
 Frames don't enter into it. The registrar's side-table is per-process
@@ -443,8 +448,10 @@ not a second assertion language. See
 [`004-Assertions.md`](004-Assertions.md) §The `:rf.assert/*` events are
 the ONE assertion vocabulary for the fold table + author guidance.
 
-The canonical seven `:rf.assert/*` assertion events (per
-[`004-Assertions.md`](004-Assertions.md)) ride the `:dispatch-sync`
+The seven **dispatched** `:rf.assert/*` assertion events (per
+[`004-Assertions.md`](004-Assertions.md); the eighth canonical id
+`:rf.assert/schema-error` is tape-evaluated, not dispatched) ride the
+`:dispatch-sync`
 rail: `[:dispatch-sync [:rf.assert/path-equals [:n] 3]]`. The
 assertion handler runs synchronously and records into
 `:rf.story/assertions` on the variant's frame — identical semantics

--- a/tools/story/spec/004-Assertions.md
+++ b/tools/story/spec/004-Assertions.md
@@ -1,7 +1,9 @@
 # Story — Assertions and Play
 
-> The seven canonical `:rf.assert/*` events; their record-don't-throw
-> semantics; play-sequence execution; the assertion-side interaction
+> The canonical `:rf.assert/*` events — seven dispatched as
+> `reg-event-fx` handlers plus one tape-evaluated (`:rf.assert/schema-error`),
+> eight canonical ids in all; their record-don't-throw semantics;
+> play-sequence execution; the assertion-side interaction
 > with `force-fx-stub` (the decorator itself lives in
 > [`005-SOTA-Features.md`](005-SOTA-Features.md) §`force-fx-stub`).
 > The contract Stage 5 implements.
@@ -10,9 +12,12 @@
 
 Per
 [spec/007 §Assertion vocabulary](../../../spec/007-Stories.md) the
-canonical seven register at Story load. Each is a regular
+canonical **dispatched seven** register at Story load. Each is a regular
 `reg-event-fx` against the variant's frame. All **record** results
-into `:assertions` (see below) rather than throwing.
+into `:assertions` (see below) rather than throwing. A net-new eighth
+canonical id — `:rf.assert/schema-error` — is *recognised* but NOT
+dispatched; it is tape-evaluated in the result boundary (see
+[§`:rf.assert/schema-error` — the tape-evaluated eighth](#rfassertschema-error--the-tape-evaluated-eighth) below).
 
 | Event id | Payload | Semantics |
 |---|---|---|
@@ -23,6 +28,22 @@ into `:assertions` (see below) rather than throwing.
 | `:rf.assert/state-is` | `[machine-id state]` | Active state of `reg-machine` machine-id is state. Pairs with the per-variant trace-buffer's `:rf.machine/guard-evaluated` + `:rf.machine/action-ran` ops (rf2-ec52e, per [spec/005-StateMachines.md](../../../spec/005-StateMachines.md) + [spec/009-Instrumentation.md §`:op-type` vocabulary](../../../spec/009-Instrumentation.md)) — failures of this assertion can be diagnosed against the captured guard/action trace via Xray's RHS view. |
 | `:rf.assert/no-warnings` | `[]` | No `:rf.warn/*` events seen during play. |
 | `:rf.assert/effect-emitted` | `[fx-id]` or `[fx-id pred]` | Did the variant's drain emit fx-id? See §`:rf.assert/effect-emitted` payload shape. |
+
+### `:rf.assert/schema-error` — the tape-evaluated eighth
+
+The seven above are dispatched as `reg-event-fx` handlers. One further
+canonical id ships and rounds the canonical set out to **eight**:
+
+| Event id | Payload | Semantics |
+|---|---|---|
+| `:rf.assert/schema-error` | `[path malli-schema]` | EXPECTED-schema-violation declaration. Recognised so plan construction accepts it, but **not** installed as a `reg-event-fx` handler — it is **tape-evaluated in the result boundary** (`re-frame.story.result`) by multiset-consumption match against the run's `:rf.warn/schema` tape, NOT dispatched into the frame. Per [`017-Testing-Story.md`](017-Testing-Story.md) §Schema rule. |
+
+`re-frame.story.assertions/canonical-assertion-ids` is therefore a set
+of **eight** — the dispatched seven plus `:rf.assert/schema-error`.
+story-mcp's `list-assertions` surfaces it as the 8th canonical
+assertion. There is deliberately no `:rf.assert/no-schema-errors`: a
+schema-clean run is the knob-free runner FLOOR, refined by this
+expectation rather than asserted as an opt-in.
 
 Each handler returns a map of the form:
 

--- a/tools/story/spec/006-MCP-Surface.md
+++ b/tools/story/spec/006-MCP-Surface.md
@@ -99,6 +99,7 @@ Vision-level statement.
 ;; Public write primitives — used by MCP's gated write surface
 ;; AND by hot-reload tooling / fixture loaders that synthesise registrations.
 (reg-story*       id body)   (reg-variant*     id body)
+(reg-fragment*    id body)   (reg-check*       id body)
 (reg-workspace*   id body)   (reg-mode*        id body)
 (reg-story-panel* id body)   (reg-decorator*   id body)
 (reg-tag*         id body)
@@ -180,12 +181,12 @@ The MCP jar:
 
 Story core owns:
 
-- The seven `reg-*` macros (and their `*`-suffix runtime helpers).
+- The nine `reg-*` macros (and their nine `*`-suffix runtime helpers).
 - The four-phase runtime.
 - The render shell (when CLJS is the runtime).
 - The trace bus and panel registrations.
 - The snapshot-identity computation.
-- The canonical seven `:rf.assert/*` events.
+- The eight canonical `:rf.assert/*` ids — seven dispatched as `reg-event-fx` plus the tape-evaluated `:rf.assert/schema-error`.
 
 Stage 7's `tools/story-mcp/` is a thin adapter: takes JSON-RPC
 requests, calls Story's public CLJS / CLJC functions, serialises

--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -22,8 +22,9 @@
 re-frame2-story already ships the programmatic test harness:
 `run-variant-as-test` (and the more general `run-variant` →
 `:assertions` round-trip per spec/004) drives a variant through its
-four-phase lifecycle and accumulates the seven canonical
-`:rf.assert/*` records on the variant's frame. What was missing
+four-phase lifecycle and accumulates the seven dispatched
+`:rf.assert/*` records on the variant's frame (the eighth canonical
+id `:rf.assert/schema-error` is evaluated in the result boundary). What was missing
 through the Stage-4 — Stage-6 push: a **chrome-level surface** that
 runs that harness on demand and renders the aggregated pass/fail
 summary inside the playground — the Storybook 8 "Tests" tab
@@ -579,8 +580,10 @@ the lot (per [spec/005 §Production elision](005-SOTA-Features.md)).
 Per the rf2-9hc8 / rf2-rodx / rf2-qmjo / rf2-q0irb / rf2-ulw5m tetrad:
 the `:test` pane, the chrome widget, and the play step-debugger are
 all **leaves** — they consume the foundation (the four-phase runtime,
-the seven canonical `:rf.assert/*` events, the `:assertions` record
-schema, the per-frame epoch history) and surface it. They do not
+the seven dispatched `:rf.assert/*` events — the canonical set is
+eight once the tape-evaluated `:rf.assert/schema-error` is counted,
+per [`004-Assertions.md`](004-Assertions.md) — the `:assertions`
+record schema, the per-frame epoch history) and surface it. They do not
 register new artefact kinds; the only new shell-state surfaces are
 the `:tests` sub-map (`[:tests :runs]` / `[:tests :watch-mode?]` /
 `[:tests :content-hashes]`) and the stepper's per-variant ratom in

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -42,7 +42,7 @@ code migration is not confused with greenfield design.
 | Surface | Status | Note |
 |---|---|---|
 | `reg-story` / `reg-variant`, data-shaped bodies | SHIPS | `tools/story/src/re_frame/story.cljc`, `schemas.cljc` (functions only behind ids). |
-| `:rf.assert/*` family (7 ids) | SHIPS | The canonical seven per [`004-Assertions.md`](004-Assertions.md). |
+| `:rf.assert/*` family (7 dispatched ids) | SHIPS | The seven **dispatched** `reg-event-fx` ids per [`004-Assertions.md`](004-Assertions.md); the canonical set is **eight** once the tape-evaluated `:rf.assert/schema-error` (next row, §Schema rule) is counted. |
 | `:assert-db` / `:assert-dom` script steps | SHIPS | Folded into the one assertion atom (§Assertions — one atom, two positions); do not drop them. |
 | bare event-vector script/setup shorthand | SHIPS (`play/runner.cljc` `coerce-script`) | P1 removes this authoring ambiguity; every setup/script step normalizes to a tagged step (§Script step grammar). |
 | `:events` / `:play-script` / `:plays` | SHIPS | Renamed to `:setup` / `:script` / named-scripts (§Public vocabulary). |

--- a/tools/story/spec/021-Story-UI-Test-And-Evidence.md
+++ b/tools/story/spec/021-Story-UI-Test-And-Evidence.md
@@ -17,9 +17,9 @@
   the chrome-level test widget + sidebar status dots, and the play
   step-debugger. This spec carries that surface forward and supersedes
   only its result-reading shape (see §1).
-- [`004-Assertions.md`](004-Assertions.md) — the seven canonical
-  `:rf.assert/*` events and record-don't-throw semantics that the result
-  presentation reads.
+- [`004-Assertions.md`](004-Assertions.md) — the canonical `:rf.assert/*`
+  events (seven dispatched + the tape-evaluated `:rf.assert/schema-error`)
+  and record-don't-throw semantics that the result presentation reads.
 - [`017-Testing-Story.md`](017-Testing-Story.md) — the unified run
   result, the `:cannot-run` third result state, the runner-capability-set
   model, and the epoch-tape evidence projection. **Source of truth for

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -44,6 +44,8 @@ All under `re-frame.story`. All DCE under `:advanced` (see
 |---|---|---|
 | `reg-story` | `(reg-story id metadata)` | [`001-Authoring.md`](001-Authoring.md) §reg-story |
 | `reg-variant` | `(reg-variant id metadata)` | [`001-Authoring.md`](001-Authoring.md) §reg-variant |
+| `reg-fragment` | `(reg-fragment id body)` | [`017-Testing-Story.md`](017-Testing-Story.md) §Strict composition — reusable setup/script/world mixin pulled into a variant via `:compose`. |
+| `reg-check` | `(reg-check id body)` | [`017-Testing-Story.md`](017-Testing-Story.md) §Strict composition — named, reusable assertion pack pulled into a variant via `:compose`. |
 | `reg-workspace` | `(reg-workspace id metadata)` | [`001-Authoring.md`](001-Authoring.md) §reg-workspace |
 | `reg-decorator` | `(reg-decorator id metadata)` | [`001-Authoring.md`](001-Authoring.md) §reg-decorator |
 | `reg-story-panel` | `(reg-story-panel id metadata)` | [`001-Authoring.md`](001-Authoring.md) §reg-story-panel + [`003-Render-Shell.md`](003-Render-Shell.md) §Panel registration contract |
@@ -119,14 +121,14 @@ run so the runner never sees a key it does not own.
 
 | Fn | Signature | Returns |
 |---|---|---|
-| `registrations` | `(registrations kind)` | All registrations for `kind` (Story kinds: `:story`, `:variant`, `:workspace`, `:story-panel`, `:tag`, `:mode`, `:decorator`). |
+| `registrations` | `(registrations kind)` | All registrations for `kind` (Story kinds: `:story`, `:variant`, `:fragment`, `:check`, `:workspace`, `:story-panel`, `:tag`, `:mode`, `:decorator`). |
 | `handler-meta` | `(handler-meta kind id)` | The registered body for `id`. |
 | `ids` | `(ids kind)` | All registered ids of `kind`. |
 | `registered?` | `(registered? kind id)` | Boolean. |
 | `list-tags` | `(list-tags)` | All registered tags (canonical + project). |
 | `list-modes` | `(list-modes)` | All registered modes. |
 | `canonical-tags` | `canonical-tags` | The seven canonical tags as a set. |
-| `canonical-assertion-ids` | `(canonical-assertion-ids)` | The seven `:rf.assert/*` event ids. |
+| `canonical-assertion-ids` | `(canonical-assertion-ids)` | The eight canonical `:rf.assert/*` ids — the seven dispatched as `reg-event-fx` plus the tape-evaluated `:rf.assert/schema-error` (see [`004-Assertions.md`](004-Assertions.md) §`:rf.assert/schema-error`). |
 | `registered-substrates` | `(registered-substrates)` | CLJS-only. The substrate set as registered via `register-substrate!`. |
 
 ## Write helpers (used by MCP write surface and hot-reload tooling)
@@ -138,6 +140,8 @@ public; their unsuffixed macro counterparts cover authored cases.
 |---|---|---|
 | `reg-story*` | `(reg-story* id body)` | Programmatic story registration. |
 | `reg-variant*` | `(reg-variant* id body)` | Programmatic variant registration. |
+| `reg-fragment*` | `(reg-fragment* id body)` | Programmatic fragment registration (the `:compose` mixin surface, spec/017 §Strict composition). |
+| `reg-check*` | `(reg-check* id body)` | Programmatic check registration (the `:compose` assertion-pack surface, spec/017 §Strict composition). |
 | `reg-workspace*` | `(reg-workspace* id body)` | Programmatic workspace registration. |
 | `reg-mode*` | `(reg-mode* id body)` | Programmatic mode registration. |
 | `reg-story-panel*` | `(reg-story-panel* id body)` | Programmatic panel registration. |
@@ -225,8 +229,10 @@ lowers the transitional `:play-script` spelling to the same shape):
 - Bare vector — `:script [[:dispatch-sync [:foo]] ...]`
 - Map         — `:script {:script [...] :auto-run? bool :name str}`
 
-The canonical seven `:rf.assert/*` events (per
-[`004-Assertions.md`](004-Assertions.md)) ride the `:dispatch-sync`
+The seven **dispatched** `:rf.assert/*` events (per
+[`004-Assertions.md`](004-Assertions.md); the eighth canonical id
+`:rf.assert/schema-error` is tape-evaluated, not dispatched) ride the
+`:dispatch-sync`
 rail: `[:dispatch-sync [:rf.assert/path-equals [:n] 3]]`. The
 assertion handler runs synchronously and records into
 `:rf.story/assertions` on the variant's frame.
@@ -298,8 +304,11 @@ ONE `:rf.assert/*` atom and produces ONE assertion-record shape. There
 is no second assertion vocabulary; `:assert-db` / `:assert-dom` are
 **script-step sugar**, not a parallel surface (see below).
 
-The seven `:rf.assert/*` events register at Story load. All record
-into `:assertions` rather than throwing — see
+The seven **dispatched** `:rf.assert/*` events register at Story load
+(the eighth canonical id, `:rf.assert/schema-error`, is tape-evaluated
+rather than registered as a handler — see
+[`004-Assertions.md`](004-Assertions.md) §`:rf.assert/schema-error`).
+All record into `:assertions` rather than throwing — see
 [`004-Assertions.md`](004-Assertions.md) §Record-don't-throw.
 
 | Event id | Payload | Semantics |

--- a/tools/story/spec/DESIGN-RATIONALE.md
+++ b/tools/story/spec/DESIGN-RATIONALE.md
@@ -131,10 +131,12 @@ persistence.
 
 ### §DCE-dev-only — registration is dev-only
 
-**Decision.** `reg-story`, `reg-variant`, `reg-workspace`, `reg-mode`,
-`reg-story-panel`, `reg-decorator`, and `reg-tag` are **all
-dev-only**. Under `:advanced` compiler builds, all seven macros elide
-to `nil`.
+**Decision.** `reg-story`, `reg-variant`, `reg-fragment`, `reg-check`,
+`reg-workspace`, `reg-mode`, `reg-story-panel`, `reg-decorator`, and
+`reg-tag` are **all dev-only**. Under `:advanced` compiler builds, all
+nine macros elide to `nil` — every one routes through
+`re-frame.story.macros/emit-reg`, the single site that lays down the
+`(when re-frame.story.config/enabled? …)` elision gate.
 
 **Rationale.** Cross-library `:extends` (where lib A registers
 `:story.x/parent` and lib B has `:extends :story.x/parent`) becomes

--- a/tools/story/spec/README.md
+++ b/tools/story/spec/README.md
@@ -3,10 +3,10 @@
 ## Files
 
 - **[000-Vision.md](000-Vision.md)** — What re-frame2-story is for, what it deliberately isn't, and how it relates to the framework's normative [`spec/007-Stories.md`](../../../spec/007-Stories.md).
-- **[001-Authoring.md](001-Authoring.md)** — Registration surface: the seven `reg-*` macros, EDN-first variant contract, inclusion-tag vocabulary, source-coord stamping, macro-time validation.
+- **[001-Authoring.md](001-Authoring.md)** — Registration surface: the nine `reg-*` macros (incl. the `reg-fragment` / `reg-check` composition cohort specced in [`017-Testing-Story.md`](017-Testing-Story.md)), EDN-first variant contract, inclusion-tag vocabulary, source-coord stamping, macro-time validation.
 - **[002-Runtime.md](002-Runtime.md)** — Per-variant frame allocation; args-precedence resolution; decorator composition; four-phase loader lifecycle; `run-variant` / `reset-variant` / `watch-variant` / `snapshot-identity` / `destroy-variant!`.
 - **[003-Render-Shell.md](003-Render-Shell.md)** — The UI: sidebar, canvas, controls, workspaces, embedded Xray inspector; five workspace layouts; hot-reload decorator fingerprinting; `mount-shell!` / `unmount-shell!` / `active-shell`.
-- **[004-Assertions.md](004-Assertions.md)** — The seven canonical `:rf.assert/*` events with record-don't-throw semantics; play-sequence execution; `force-fx-stub` decorator.
+- **[004-Assertions.md](004-Assertions.md)** — The eight canonical `:rf.assert/*` ids (seven dispatched + the tape-evaluated `:rf.assert/schema-error`) with record-don't-throw semantics; play-sequence execution; `force-fx-stub` decorator.
 - **[005-SOTA-Features.md](005-SOTA-Features.md)** — Layout-debug overlays; a11y axe-core panel; per-variant share URL (live address-bar surface; retired QR popover per rf2-ymnfx Issue B); multi-substrate side-by-side; Xray epoch embed stub; production elision under `:advanced`.
 - **[006-MCP-Surface.md](006-MCP-Surface.md)** — The boundary between Story and `tools/story-mcp/`; surfaces Story exposes for the MCP jar; late-bind `reg-story-panel` for tooling embeds.
 - **[007-Mode-Tabs.md](007-Mode-Tabs.md)** — The render-shell's top-of-canvas `:dev` / `:docs` / `:test` switcher; the chrome-level primitive every 2026 component playground ships (rf2-9hc8).

--- a/tools/story/spec/Tutorial-CLJS-Unit.md
+++ b/tools/story/spec/Tutorial-CLJS-Unit.md
@@ -365,8 +365,9 @@ browser teardown.
   shape lines up against.
 - [`002-Runtime.md`](002-Runtime.md) §Programmatic API — the
   `run-variant` / `reset-variant` / `snapshot-identity` reference.
-- [`004-Assertions.md`](004-Assertions.md) — the seven canonical
-  `:rf.assert/*` events and record-don't-throw semantics.
+- [`004-Assertions.md`](004-Assertions.md) — the canonical `:rf.assert/*`
+  events (seven dispatched + the tape-evaluated `:rf.assert/schema-error`)
+  and record-don't-throw semantics.
 - [`Tutorial-Playwright.md`](Tutorial-Playwright.md) — the
   browser-required alternative; secondary path for the surfaces
   named above.

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -57,8 +57,10 @@
 
   ## Elision
 
-  All seven `reg-*` macros expand to a `(when re-frame.story.config/enabled?
-  ...)` wrapper. Production CLJS builds set
+  All nine `reg-*` macros expand to a `(when re-frame.story.config/enabled?
+  ...)` wrapper (every macro routes through `re-frame.story.macros/emit-reg`
+  via `expand-reg-story` / `gen-reg-call`, the single site that lays down
+  the elision gate). Production CLJS builds set
   `:closure-defines {re-frame.story.config/enabled? false}` and every
   registration form elides to `nil`. The public query helpers are plain
   fns; production code calling them sees an empty side-table.
@@ -172,7 +174,7 @@
             ;; is CLJS-only (it feature-detects Xray via `find-ns-obj`).
             #?(:cljs [re-frame.story.xray-preset :as xray-preset])
             #?(:clj [re-frame.story.macros :as macros]))
-  ;; The seven reg-* macros are defined in the #?(:clj ...) blocks
+  ;; The nine reg-* macros are defined in the #?(:clj ...) blocks
   ;; below. Self-refer them via :require-macros so CLJS callers can
   ;; write `story/reg-story` after `(:require [re-frame.story :as story])`
   ;; without an explicit :require-macros clause at the call site.
@@ -182,7 +184,7 @@
                                      reg-check reg-workspace reg-mode
                                      reg-story-panel reg-decorator reg-tag]])))
 
-;; ---- macros (the seven reg-* forms) --------------------------------------
+;; ---- macros (the nine reg-* forms) ---------------------------------------
 ;;
 ;; Per IMPL-SPEC §6.1 every macro expansion threads through
 ;; `(when re-frame.story.config/enabled? ...)` so the closure compiler

--- a/tools/story/testbeds/counter_with_stories/README.md
+++ b/tools/story/testbeds/counter_with_stories/README.md
@@ -2,7 +2,9 @@
 
 The canonical worked example for [`tools/story/`](../../../../tools/story/)
 (`day8/re-frame2-story`). The counter the rest of the guide pivots
-around, with the seven Story authoring macros wired up end-to-end:
+around, with seven of the nine Story authoring macros wired up
+end-to-end (the `reg-fragment` / `reg-check` composition cohort is not
+exercised here):
 
 - `reg-tag`         — `:counter-with-stories/canonical`
 - `reg-mode`        — `:Mode.app/dark` + `:Mode.app/light`
@@ -12,7 +14,7 @@ around, with the seven Story authoring macros wired up end-to-end:
 - `reg-variant`     — five variants (empty / loaded / clicked-three-times / save-stubbed / events-only-loaded)
 - `reg-workspace`   — `:Workspace.counter/all-states` (`:grid`) + `:Workspace.counter/auto-grid` (`:variants-grid`)
 
-The four canonical variants exercise three of the seven canonical
+The four canonical variants exercise four of the seven dispatched
 `:rf.assert/*` events (`path-equals`, `sub-equals`, `dispatched?`,
 `effect-emitted`) plus the built-in `force-fx-stub` decorator for
 the save-flow variant. The fifth variant, `events-only-loaded`, was
@@ -30,7 +32,7 @@ counter_with_stories/
 ├── events.cljs                              ; :counter/initialise, /inc, /dec, /save
 ├── subs.cljs                                ; :count, :count-doubled, :count-parity
 ├── views.cljs                               ; counter-card, counter-buttons, parity-badge
-├── stories.cljs                             ; the seven reg-* calls
+├── stories.cljs                             ; seven of the nine reg-* macros (no fragment/check)
 ├── elision_demo.cljs                        ; :sensitive? + :large? + event-emit (rf2-vw0to)
 ├── stories_cljs_test.cljs                   ; integration tests (npm run test:cljs)
 ├── elision_demo_cljs_test.cljs              ; elision-pipeline tests (npm run test:cljs)

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -1,7 +1,9 @@
 (ns counter-with-stories.stories
-  "Stories for the counter app. Demonstrates the seven `reg-*` macros
-  end-to-end on a deliberately small domain so the patterns are
-  visible rather than buried in business logic.
+  "Stories for the counter app. Demonstrates seven of the nine `reg-*`
+  macros end-to-end on a deliberately small domain so the patterns are
+  visible rather than buried in business logic. (The `reg-fragment` /
+  `reg-check` composition cohort — spec/017 §Strict composition — is
+  not exercised here.)
 
   Per spec/007 §Variants the body of every variant is plain data —
   no fn-slots. The view at the centre of each variant is referenced
@@ -11,7 +13,7 @@
   *registration site* (see `:counter-with-stories/log-decorator`
   below).
 
-  The seven `reg-*` macros each appear at least once:
+  Seven of the nine `reg-*` macros each appear at least once:
 
   - `reg-tag`         — `:counter-with-stories/canonical` (project tag).
   - `reg-mode`        — `:Mode.app/dark` + `:Mode.app/light` (theme tuples).


### PR DESCRIPTION
Doc-accuracy spec-freshness sweep across two disjoint tool spec trees: `tools/mcp-base/spec/` and `tools/story/` (spec/ + API.md + 006 + README + facade docstring/comments + testbed README). All four beads verified against the current code first; no behavioral code change.

## mcp-base

**rf2-rcypv** — per-namespace contract count. 11 src `.cljc` namespaces ship (confirmed), and the README index already listed all 11, but the per-doc line-6 boilerplate was stale: 8 docs said "one of eight", 2 said "one of ten", and descriptor-manifest hedged. All 11 now say "one of eleven" and carry the complete See-also set (cursor / envelope / descriptor-manifest were missing).

**rf2-d4reo** — `vocab.md` `:rf.mcp/*` catalogue omitted `result-key` / `:rf.mcp/result`. It is a live wire-fidelity typed-result envelope discriminator (tags `:value`/`:nil`/`:eval-error`/`:unserializable`, rf2-qobqy, defined at `vocab.cljc:117-134`, emitted by re-frame2-pair-mcp's `tools/result_envelope.cljs`). Added a catalogue row, noted as defined-but-not-yet-cross-gated.

## story

**rf2-4xgzv** — `API.md` + `006-MCP-Surface.md` omitted the two public composition macros. Added `reg-fragment` / `reg-check` to API.md's Registration-macros table, `reg-fragment*` / `reg-check*` to API.md's Write-helpers table and 006's write-primitives block, cross-linked spec/017 §Strict composition. Also added the missing `:fragment` / `:check` kinds to `registrations()`'s kind list (real registry kinds, confirmed in `registrar.cljc`).

**rf2-af7yl** — count-phrasing drift:
- **reg-\* macros**: code ships NINE (verified — nine defmacros, nine `*`-helper exports, all nine elide via `macros/emit-reg`). Reconciled "seven reg-\* macros" → nine across 001, DESIGN-RATIONALE, 006, spec/README, story README, facade docstring + two code comments. Testbed scoped to "seven of the nine".
- **canonical assertions**: `canonical-assertion-ids` is a set of EIGHT (seven dispatched `reg-event-fx` + the tape-evaluated `:rf.assert/schema-error`). Added a `§:rf.assert/schema-error` section/row to 004 and reconciled "seven canonical events" → "seven dispatched + one tape-evaluated = eight" across 004 / 017 / 009 / 001 / 000-Vision / API.md / READMEs / cross-refs. Left genuinely-seven references intact (inclusion TAGS; the seven bundled event HANDLERS in 013; the recorder picker's seven-id `assertion-vocabulary`). Fixed a pre-existing "three of the seven → four" miscount in the counter testbed README.

## Quality gates (COLD)

- `npm run test:mcp-conformance` — **GREEN** (all 6/6 gates; wire-vocab 49 tests / 629 assertions, 0 failures). Doc-only change.
- No story-specific doc/lint step exists (story has only a `:test` alias); tool spec trees are not in the mkdocs nav.
- Grep-confirmed: 11 "eleven per-namespace" / 0 stale eight|ten; `result-key` row present; `reg-fragment`/`reg-check` + `reg-fragment*`/`reg-check*` present; `schema-error` in 004; no stale "seven reg-\*" / "seven macros" phrasing remains.

Closes rf2-rcypv, rf2-d4reo, rf2-4xgzv, rf2-af7yl.