### PR TITLE
docs(xray/spec): reconcile stale panel docs to live src (rf2-wkhbg + rf2-83leo + rf2-zerqv + rf2-s4n8d + rf2-2uodn)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -111,6 +111,30 @@ below; the three render states are:
       `[guard]` chip + `+ <action>` pills inside the event box; `⌚`
       glyph for `:after`, `∞` for `:always`). `:after` countdown
       rings overlay armed timer states.
+    - **Chart-collapse toggle** (rf2-3d987 issue #4). An inline
+      `▾` / `▸` button in the chart's nested header collapses the
+      topology chart to give the BEFORE / AFTER snapshot pair more
+      vertical room; expanded is the default (so a first-time operator
+      always sees the topology). The collapsed/expanded choice is
+      **persisted per-machine** so one machine's chart can rest
+      collapsed while another's stays expanded. State contract:
+        - App-db slot — `[:rf.xray/machine-canvas :chart-collapsed-by-id
+          <machine-id>]` (`true` = collapsed; absent / `false` =
+          expanded, the default).
+        - localStorage key — `xray.machine-canvas.chart-collapsed-by-id`
+          (one EDN map keyed by machine-id; round-trips the slot).
+        - Event — `:rf.xray.machine-canvas/set-chart-collapsed`
+          `{:machine-id <id> :mode <:collapsed | :expanded | :toggle>}`
+          (the `▾`/`▸` button dispatches `:toggle`); it writes the slot
+          and fires the persist fx.
+        - Subs — `:rf.xray.machine-canvas/chart-collapsed-for`
+          (per-machine boolean) + `:rf.xray.machine-canvas/chart-collapsed-by-id`
+          (the whole map).
+        - Fx — `:rf.xray.machine-canvas/persist-chart-collapsed` writes
+          the map to localStorage.
+        - Hydration — `:rf.xray.machine-canvas/hydrate-chart-collapsed`
+          replays the persisted map into app-db at boot (same posture as
+          the Canvas/List view-mode hydration).
     - Guards list (when the trace carried guard-evaluated events for
       this transition).
     - Actions list (when the trace carried action-ran events).

--- a/tools/xray/spec/005-Schema-Timeline.md
+++ b/tools/xray/spec/005-Schema-Timeline.md
@@ -29,8 +29,32 @@ actions: open source, filter timeline to just this schema.
 
 ## Affordance
 
-Issues tab — schema-violation timeline (today as its own panel; future
-folds into Issues per [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md)).
+**v1 status — UNBUILT (post-v1).** The horizontal schema-violation
+timeline described in this doc is the destination, not a shipped
+surface: none of its driving subs/events exist in `tools/xray/src`
+(`:rf.xray/schema-violation-timeline`, `…/schema-timeline-window`,
+`…/select-violation`, `…/set-schema-filter`, the
+`:rf.xray/schema-timeline-prev-rows` flash-cue cache, etc. — zero
+hits), and the Issues tab it names as its host was removed (rf2-gbz39
+Option (c); see [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md)
+§Issues and [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md)).
+Read the rest of this doc as the future design.
+
+**Today** schema-fail surfacing ships across two real surfaces:
+
+1. **Inline in the Epoch panel** — a schema validation failure shows
+   inline in the cascade's effect-handlers step (rf2-kt6js), so a
+   `:db` schema-fail is read where the dispatch produced it rather
+   than in a separate timeline.
+2. **The Static Schemas catalogue** — a flat browse-all of every
+   *registered* schema (app-db / event / sub) at
+   `tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs`,
+   reached via the Static surface's Schemas sub-tab. It is a
+   registry browser, not a violation/recovery/timeline view.
+
+When the timeline lands post-v1 it folds into the kept surfaces per
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md), not a
+re-introduced Issues tab.
 
 ---
 
@@ -165,7 +189,9 @@ issues. After that, the label rests until cleared.
 
 The flash-cue is the schema timeline's only motion affordance and
 the panel's primary "look here" signal for regressions. Its
-mechanics are normative.
+mechanics are normative **for the post-v1 timeline panel** (per the
+§Affordance v1-status note above — this panel is unbuilt today); they
+become live contract when the panel ships.
 
 **Trigger.** A row's label MUST flash on the
 **empty→non-empty transition** of its in-window violation set —

--- a/tools/xray/spec/006-Hydration-Debugger.md
+++ b/tools/xray/spec/006-Hydration-Debugger.md
@@ -28,16 +28,40 @@ divergent value on each side**, names the **upstream `app-db` slice**
 each side observed, and emits a **heuristic "likely cause" hypothesis**
 that links to the source.
 
-This is the **hero SSR feature**. Xray is the only re-frame2-shaped tool
-that can do this — the framework already emits the structured data; this
-spec turns it into the picture.
+This is the **hero SSR feature** of the destination design. Xray is
+the only re-frame2-shaped tool that can do this — the framework already
+emits the structured data; this spec turns it into the picture.
 
 ## Affordance
 
-Issues tab — hydration mismatch bisector with sub-attribution. Per
+**v1 status — UNBUILT (post-v1; renderer-only fragment present).** The
+hydration-mismatch bisector described in this doc is the destination,
+not a shipped surface. There is **no Hydration L4 tab** in the live
+panel inventory (the mountable surface is enumerated in
+`tools/xray/src/day8/re_frame2_xray/panel_enum.cljc` plus the
+`reg-l4-tab!` call sites — 6 Dynamic + 5 Static tabs, none of them
+Hydration), and none of the panel's state plumbing exists: the subs/
+events [`014-Registry-Catalogue.md`](014-Registry-Catalogue.md)
+catalogues for it (`:rf.xray/hydration-debugger-data`,
+`…/hydration-has-mismatch?`, `…/hydration-reroot-path`,
+`…/selected-mismatch-id`, `…/select-mismatch`,
+`…/clear-mismatch-selection`, `…/reroot-tree-view`) return zero hits in
+`tools/xray/src`. The **only** artefact present is a pure per-pane
+element-diff renderer at
+`tools/xray/src/day8/re_frame2_xray/panels/hydration_pane_render.cljs`
+— it is required by nothing but its own test and is mounted by no
+panel. The README's "Hero SSR feature" framing
+([`README.md`](README.md)) likewise describes the destination, not v1.
+Read the rest of this doc (and its §Affordance below) as the future
+design.
+
+The destination affordance — once built — is the hydration mismatch
+bisector with sub-attribution. Per
 [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.3 the
-canonical bug-class catalogue. The bisector replaces a generic Issues
-row with a dedicated drill-into surface:
+canonical bug-class catalogue. The bisector replaces a generic issue
+row with a dedicated drill-into surface (note: the Issues tab the
+original design hosted it in was removed per rf2-gbz39 Option (c); the
+post-v1 home is the inline/popover surface per 019 §7):
 
 ```
 ┌─ Hydration mismatch  ·  cascade #1  :rf/hydrate ───────────────────────┐
@@ -404,8 +428,9 @@ detail for the same selection is O(1).
 
 The projection hands the panel view a plain map:
 `{:has-mismatch? :mismatch-summary :selected-mismatch-id :detail
-:source-coord :re-root-path :target-frame}` (per
-[`014-Registry-Catalogue.md` §Hydration debugger](./014-Registry-Catalogue.md#hydration-debugger)).
+:source-coord :re-root-path :target-frame}` (the destination shape — per
+[`014-Registry-Catalogue.md` §Hydration debugger — UNBUILT](./014-Registry-Catalogue.md#hydration-debugger--unbuilt-post-v1-renderer-only),
+which records that none of these registrations exist today).
 The `:detail` slot carries the per-mismatch projection record:
 `{:id :path :server-tree :client-tree :server-hash :client-hash
 :frame :view-id :failing-id :divergence-kind :hypothesis

--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -7,19 +7,34 @@ or human reader handed only the Xray spec MUST be able to reconstruct
 the registry's surface from this catalogue alone, without reading
 `tools/xray/src/day8/re_frame2_xray/registry.cljs`.
 
-> **rf2-qy0nu drift notice (2026-05-18).** The 8-dead-panel sweep
-> deleted `mcp-server`, `hydration-debugger`, `performance`, `routes`,
-> `schema-violation-timeline`, `effects`, `flows`, and `time-travel`
-> from the source tree. Their per-panel sections below (and several
-> cross-panel entries that lived inside those panels' install! fns) are
-> now stale. The registry's authoritative shape lives in `registry.cljs`
-> + `tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs`'s
+> **rf2-qy0nu drift notice (2026-05-18) — superseded by the
+> rf2-zerqv reconciliation below.** The 8-dead-panel sweep deleted the
+> standalone `mcp-server`, `hydration-debugger`, `performance`,
+> `schema-violation-timeline`, `effects`, and the dynamic `flows`
+> panels from the source tree, along with `time-travel`'s
+> panel-private rows. Routing and Schemas were NOT deleted — they
+> survive as the Dynamic Routes tab + the Static Routes / Schemas
+> catalogue tabs (`static/<name>/panel.cljs`, registered via
+> `reg-l4-tab!` with `:modes #{:static}`); their sections below are
+> normative. The registry's authoritative shape lives in
+> `registry.cljs` +
+> `tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs`'s
 > `all-sub-names` / `all-event-names` / `all-fx-names` enumerations,
 > which the test suite asserts every registration matches exactly.
-> Rewriting this catalogue against the surviving surface is tracked
-> separately; until then, treat any §MCP server / §Routes / §Schemas /
-> §Hydration / §Effects / §Flows / §Performance subsection as historical
-> reference, not normative spec.
+>
+> **rf2-zerqv reconciliation (2026-06-04).** The stale per-panel
+> sections this notice flagged have now been reconciled against the
+> live source: §Schema-violation timeline + §Hydration debugger are
+> marked UNBUILT (post-v1) with their absent subs/events called out;
+> §Effects + §Performance are marked DROPPED (no live surface);
+> §Flows is marked superseded by the Static Flows catalogue (its
+> registrations live under §Static mode); and §Views tab is
+> re-anchored onto the live `:rf.xray/reactive-data` /
+> `:rf.xray/reactive-show-unchanged?` / `:rf.xray/reactive-toggle-unchanged`
+> surface. The live panel inventory is the 6 Dynamic tabs
+> (Epoch / App-DB / Views / Trace / Machine / Routes) + 5 Static tabs
+> (Machines / Routes / Schemas / Flows / Interceptors) per
+> `panel_enum.cljc` + the `reg-l4-tab!` call sites.
 >
 > **rf2-yhl5v follow-up (2026-06-02).** The §Time-travel scrubber
 > subsection has been reconciled to the surviving live surface: the
@@ -223,80 +238,77 @@ Slice-centric `app-db` inspector. Reads the host frame's `app-db` via
 |---|---|---|
 | `:rf.xray.fx/copy-to-clipboard` | `{:text <string>}` | Best-effort write via `navigator.clipboard.writeText`. No-op on non-browser targets (Node test, JVM). |
 
-## Schema-violation timeline
+## Schema-violation timeline — UNBUILT (post-v1)
 
-Spec: [`005-Schema-Timeline.md`](./005-Schema-Timeline.md).
+Spec: [`005-Schema-Timeline.md`](./005-Schema-Timeline.md) (§Affordance
+v1-status note).
+
+**No registrations exist.** The standalone schema-violation timeline
+panel is unbuilt — `git grep` across `tools/xray/src` returns zero hits
+for every sub/event the original design named
+(`:rf.xray/schema-violation-timeline`, `…/schema-timeline-window`,
+`…/schema-violations-window`, `…/schema-timeline-prev-rows`,
+`…/selected-violation-id`, `…/schema-filter`, `…/select-violation`,
+`…/set-schema-filter`, `…/registered-schemas`,
+`…/clear-violation-selection`, `…/set-schema-timeline-window`). They
+are NOT in `registry.cljs` / `registry_cljs_test`'s enumerations.
+
+**Today** schema-fail surfacing ships inline in the Epoch panel
+(rf2-kt6js) and as the Static Schemas registry catalogue
+(`static/schemas/panel.cljs`, registrations enumerated under §Static
+mode below). When the timeline lands post-v1 its registrations get
+catalogued here against the then-live source.
+
+## Hydration debugger — UNBUILT (post-v1; renderer-only)
+
+Spec: [`006-Hydration-Debugger.md`](./006-Hydration-Debugger.md)
+(§Affordance v1-status note).
+
+**No registrations exist.** The hydration-mismatch bisector panel is
+unbuilt — there is no Hydration L4 tab in the live inventory
+(`panel_enum.cljc` + the `reg-l4-tab!` call sites), and `git grep`
+across `tools/xray/src` returns zero hits for every sub/event the
+original design named (`:rf.xray/hydration-debugger-data`,
+`…/hydration-has-mismatch?`, `…/hydration-reroot-path`,
+`…/selected-mismatch-id`, `…/select-mismatch`,
+`…/clear-mismatch-selection`, `…/reroot-tree-view`). The only present
+artefact is a pure per-pane element-diff renderer
+(`panels/hydration_pane_render.cljs`) that no panel mounts. None of the
+above are in `registry.cljs` / `registry_cljs_test`'s enumerations.
+
+(`:rf.xray/open-in-editor` — the shared jump-to-source event the
+original design listed here — IS live, but it belongs to the shared
+source-coord wiring, not this panel; it is catalogued under §Shared
+infrastructure / the panels that use it.)
+
+## Views tab (reactive perspective)
+
+Spec: [`021-Dynamic-Panel-Designs.md` §3](./021-Dynamic-Panel-Designs.md#3-the-view-panel-reactive-perspective--steps-7-8)
+(the normative Views design; [`012-Views.md`](./012-Views.md) is
+superseded historical exploration). The Views tab renders the focused
+cascade's reactive perspective.
+
+**Re-anchored (rf2-zerqv).** The pre-rewrite Subscriptions-panel family
+this section used to list — `:rf.xray/subscriptions-data`,
+`…/select-sub`, `…/clear-selected-sub`, `…/sub-cache`, `…/sub-filters`,
+`…/sub-chain-open?`, `…/show-invalidation-chain`,
+`…/hide-invalidation-chain`, `…/set-sub-cache-override-for-test` —
+no longer exists (zero hits in `tools/xray/src`). The live Views/
+Reactive panel registers exactly the ids below
+(`reactive_panel_subs.cljs` + `reactive_panel_events.cljs`).
 
 ### Subscriptions
 
 | Sub | Returns |
 |---|---|
-| `:rf.xray/registered-schemas` | Vector of `path-or-id` row keys from `rf/app-schemas`. `[]` when the schemas artefact is not on the classpath. |
-| `:rf.xray/selected-violation-id` | The trace event's `:id` (stable per-process per [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md)). |
-| `:rf.xray/schema-filter` | Schema-id or `nil`. Narrows the rendered rows to one schema. |
-| `:rf.xray/schema-timeline-window` | `{:t0 :t1}` in ms; falls back to the default 60s window ending at now. |
-| `:rf.xray/schema-violations-window` | Vector of projected violation rows in chronological order, filtered to the current window. |
-| `:rf.xray/schema-timeline-prev-rows` | Cache of previously-rendered rows so the panel's flash cue can detect empty→non-empty transitions. |
-| `:rf.xray/schema-violation-timeline` | Composite — `{:rows :window :total-violations :rendered-violations :selected-violation :schema-filter}`. |
+| `:rf.xray/reactive-data` | Composite the view reads — `:<-` over `:rf.xray/focus` + `:rf.xray/epoch-history`; projects the focused cascade's reactive perspective: `{:focus :frame :dispatch-id :triggered-by :seed-paths :has-cascade?}` merged with the per-record projection (L1 / L2+ sub partition, inputs + code columns). JVM/empty-focus paths degrade to the empty projection. |
+| `:rf.xray/reactive-show-unchanged?` | Boolean — panel-local UI toggle reading `:reactive/show-unchanged?` off Xray's db (whether unchanged subs render). |
 
 ### Events
 
 | Event | Vector shape | Behaviour |
 |---|---|---|
-| `:rf.xray/clear-violation-selection` | `[_]` | Closes the detail side panel. |
-| `:rf.xray/select-violation` | `[_ violation-id]` | Selects by trace-event `:id`. Passing `nil` clears. |
-| `:rf.xray/set-schema-filter` | `[_ schema-id]` | Narrows to one schema. Passing `nil` clears the filter. |
-| `:rf.xray/set-schema-timeline-window` | `[_ {:t0 :t1}]` | Sets the window. Invalid maps (`nil`, non-numeric, `t0 >= t1`) revert to the default window. |
-
-## Hydration debugger
-
-Spec: [`006-Hydration-Debugger.md`](./006-Hydration-Debugger.md).
-
-### Subscriptions
-
-| Sub | Returns |
-|---|---|
-| `:rf.xray/selected-mismatch-id` | Mismatch trace event's `:id`, or `nil` (composite picks the latest). |
-| `:rf.xray/hydration-reroot-path` | Re-root path for the side-by-side tree view per spec §Render-tree hash bisector, or `nil`. |
-| `:rf.xray/hydration-has-mismatch?` | Boolean — `true` iff the target-frame's trace stream carries at least one mismatch event. Cheap projection (composite of `:rf.xray/trace-buffer` + `:rf.xray/target-frame`) for chrome indicators (issues-ribbon, navigator badge) that need only the binary status without paying for the full `:rf.xray/hydration-debugger-data` composite. |
-| `:rf.xray/hydration-debugger-data` | Composite — `{:has-mismatch? :mismatch-summary :selected-mismatch-id :detail :source-coord :re-root-path :target-frame}`. |
-
-### Events
-
-| Event | Vector shape | Behaviour |
-|---|---|---|
-| `:rf.xray/select-mismatch` | `[_ mismatch-id]` | Drives the side-by-side rebase. Drops the re-root (subtree-specific). |
-| `:rf.xray/clear-mismatch-selection` | `[_]` | Clears selection + re-root. |
-| `:rf.xray/reroot-tree-view` | `[_ path]` | Re-roots at `path` (per spec §Render-tree hash bisector). Empty path clears. |
-| `:rf.xray/open-in-editor` | `[_ coord]` | Records the attempted source-coord. Full handler lives in `open-in-editor.cljs`; this is the thin record-the-attempt path. |
-
-## Views tab (incl. nested subs — replaces the pre-rewrite Subscriptions panel)
-
-Spec: [`012-Views.md`](./012-Views.md). Subs nest under views per the
-rewrite; the sub-cache + sub-graph primitives below continue to back
-the nested-sub-row renderer in the Views tab.
-
-### Subscriptions
-
-| Sub | Returns |
-|---|---|
-| `:rf.xray/sub-cache` | Target frame's live sub-cache via `rf/sub-cache`. CLJS-only; JVM returns `nil` (panel renders empty state). Test override via `:sub-cache-override` on Xray's db. |
-| `:rf.xray/sub-error-cache` | `{query-v <error-info>}`. v1 wiring keeps it empty until the error-collector plumbing lands. |
-| `:rf.xray/selected-sub` | Query-v of the user's selection (drives the chain affordance). |
-| `:rf.xray/sub-filters` | Set of active filter-chip statuses. |
-| `:rf.xray/sub-chain-open?` | Boolean — is the chain affordance open? |
-| `:rf.xray/subscriptions-data` | Composite — `{:rows :status-counts :total :selected-query-v :active-filters :chain-open? :chain}`. |
-
-### Events
-
-| Event | Vector shape | Behaviour |
-|---|---|---|
-| `:rf.xray/select-sub` | `[_ query-v]` | Sets selection. |
-| `:rf.xray/clear-selected-sub` | `[_]` | Clears selection + chain-open. |
-| `:rf.xray/toggle-sub-filter` | `[_ status]` | Adds / removes a status from the filter set. |
-| `:rf.xray/show-invalidation-chain` | `[_ query-v]` | Opens the chain affordance. Optional `query-v` sets selection in one shot. |
-| `:rf.xray/hide-invalidation-chain` | `[_]` | Closes the chain. |
-| `:rf.xray/set-sub-cache-override-for-test` | `[_ ov]` | Test-only override hook. Production code paths MUST NOT dispatch. `nil` clears. |
+| `:rf.xray/reactive-toggle-unchanged` | `[_]` | Flips the `:reactive/show-unchanged?` UI flag. |
 
 ## Issues ribbon
 
@@ -321,69 +333,49 @@ axis independent; empty / `nil` disables the axis.
 | `:rf.xray.issues/toggle-prefix` | `[_ prefix]` | Toggles a prefix chip in/out. |
 | `:rf.xray.issues/clear-filters` | `[_]` | Clears every chip axis. |
 
-## Flows panel
+## Flows panel — superseded by the Static Flows catalogue
 
 Spec consumer: framework Spec 013 (registered-flow surface) + Spec 009
 (`:rf.flow/*` trace vocabulary).
 
-### Subscriptions
+**The dynamic Flows panel was dropped.** Its sub/event family —
+`:rf.xray/flows-data`, the dynamic `:rf.xray/registered-flows` sub,
+`…/flow-trace-events`, `…/selected-flow-id`, `…/select-flow-id`,
+`…/clear-flow-selection`, `…/set-registered-flows-override-for-test` —
+no longer exists (zero hits in `tools/xray/src`). The live Flows
+surface is the **Static catalogue** (`static/flows/panel.cljs`),
+registered as an `:modes #{:static}` L4 tab and namespaced under
+`:rf.xray.static.flows/*` (`…/query`, `…/set-query`, `…/tab-data`,
+`…/registered-flows`, `…/registered-flows-override`,
+`…/set-registered-flows-override-for-test`), one of the Static
+sub-tabs alongside Machines / Routes / Schemas / Interceptors (see
+§Static mode below). (The bare `:rf.xray/registered-flows` string that
+remains in `static/flows/panel.cljs` is a doc comment describing the
+underlying `(rf/registrations :flow)` read, not a registered sub.)
 
-| Sub | Returns |
-|---|---|
-| `:rf.xray/registered-flows` | `(rf/registrations :flow)` — process-global registry. Test override via `:registered-flows-override`. |
-| `:rf.xray/flow-trace-events` | Trace-buffer's `:op-type :flow` slice. |
-| `:rf.xray/selected-flow-id` | Flow-id or `nil`. |
-| `:rf.xray/flows-data` | Composite — `{:rows :status-counts :total :selected-flow-id}`. |
+## Effects panel — DROPPED (no live surface)
 
-### Events
+**No Effects tab exists.** The dynamic Effects panel was dropped; its
+sub/event family — `:rf.xray/effects-data`, `…/registered-fxs`,
+`…/fx-trace-events`, `…/selected-fx-id`, `…/select-fx-id`,
+`…/clear-fx-selection`, `…/set-registered-fxs-override-for-test` — no
+longer exists (zero hits in `tools/xray/src`) and there is no Effects
+L4 tab in the live inventory (`panel_enum.cljc` + the `reg-l4-tab!`
+call sites). The shipped managed-effects surface is the inline
+`mount-managed-fx!` list (`panel_enum.cljc` `:managed-fx` entry) and
+the per-cascade fx rows in the Epoch/Trace panels — not a standalone
+Effects panel. Interceptors get their own Static sub-tab; see §Static
+mode.
 
-| Event | Vector shape | Behaviour |
-|---|---|---|
-| `:rf.xray/select-flow-id` | `[_ flow-id]` | Sets selection. |
-| `:rf.xray/clear-flow-selection` | `[_]` | Clears selection. |
-| `:rf.xray/set-registered-flows-override-for-test` | `[_ ov]` | Test-only override hook. |
+## Performance panel — DROPPED (use Chrome DevTools)
 
-## Effects panel
-
-Spec consumer: framework Spec 002 §reg-fx + Spec 009 (`:rf.fx/*` trace
-vocabulary).
-
-### Subscriptions
-
-| Sub | Returns |
-|---|---|
-| `:rf.xray/registered-fxs` | `(rf/registrations :fx)` — process-global registry. Test override via `:registered-fxs-override`. |
-| `:rf.xray/fx-trace-events` | Trace-buffer's fx-related slice (`:op-type :fx` + fx-layer error categories). |
-| `:rf.xray/selected-fx-id` | Fx-id or `nil`. |
-| `:rf.xray/effects-data` | Composite — `{:rows :outcome-counts :total :selected-fx-id}`. |
-
-### Events
-
-| Event | Vector shape | Behaviour |
-|---|---|---|
-| `:rf.xray/select-fx-id` | `[_ fx-id]` | Sets selection. |
-| `:rf.xray/clear-fx-selection` | `[_]` | Clears selection. |
-| `:rf.xray/set-registered-fxs-override-for-test` | `[_ ov]` | Test-only override hook. |
-
-## Performance panel
-
-Spec: [`000-Vision.md` L92](./000-Vision.md). Per-cascade duration
-capture, perf-tier colour mapping, budget-warning markers. No
-panel-owned events — reuses `:rf.xray/select-dispatch-id` and
-`:rf.xray/select-panel` for the pivot-into-event-detail affordance.
-
-### Subscriptions
-
-| Sub | Returns |
-|---|---|
-| `:rf.xray/performance-budget-ms` | Over-budget threshold in ms; default per `perf-helpers/default-budget-ms`. |
-| `:rf.xray/performance-data` | Composite — `{:rows :total :tier-counts :over-budget-count :budget-ms :empty?}`. |
-
-### Events
-
-| Event | Vector shape | Behaviour |
-|---|---|---|
-| `:rf.xray/set-performance-budget-ms` | `[_ budget-ms]` | Sets the threshold. `nil` / non-positive resets to default. |
+**No Performance panel exists.** The panel was explicitly dropped (see
+[`016-Auxiliary-Panels.md`](./016-Auxiliary-Panels.md) §Performance —
+"Use Chrome DevTools"); its subs/events —
+`:rf.xray/performance-data`, `…/performance-budget-ms`,
+`…/set-performance-budget-ms` — no longer exist (zero hits in
+`tools/xray/src`) and there is no Performance L4 tab in the live
+inventory.
 
 ## Trace panel
 
@@ -485,7 +477,7 @@ rf2-o5f5f.2 + rf2-o5f5f.3 + rf2-ybjkx + rf2-8l3uk.
 | Sub | Returns | Notes |
 |---|---|---|
 | `:rf.xray/mode` | `:dynamic` / `:static`. | Default `:dynamic`. Hydrated from `xray.mode` localStorage on boot. |
-| `:rf.xray.static/selected-tab` | Keyword sub-tab id (`:machines` / `:routes` / `:schemas` / `:views` / `:events`). | Default `:machines` per `static/shell.cljs`. |
+| `:rf.xray.static/selected-tab` | Keyword sub-tab id — one of the live Static tabs (`:machines` / `:routes` / `:schemas` / `:flows` / `:interceptors`, registered via `reg-l4-tab!` with `:modes #{:static}`). | Default `:machines` per `static/shell.cljs`. |
 | `:rf.xray.static.machines/selected-id` | Selected machine-id keyword for the Static Machines master-detail. | `nil` until first selection; persisted via the Static Machines persistence fx. |
 | `:rf.xray.static.machines/sub-mode` | Effective sub-mode keyword for the focused machine (`:topology` / `:sim` / `:instances` / `:cascade`). | Composite of `:rf.xray.static.machines/sub-mode-by-id` + the focused machine-id; default `:topology`. |
 | `:rf.xray.static.routes/expanded-id` | Set of route-ids whose meta-expander is open (per-row inline expand surface in the Static Routes panel). | Default `#{}`; sourced from the Static Routes panel's UI-state slot. |

--- a/tools/xray/spec/019-Cross-Cutting-Insight.md
+++ b/tools/xray/spec/019-Cross-Cutting-Insight.md
@@ -139,9 +139,12 @@ Malli rejections live in the trace today as `:rf.error/schema-validation-failure
 events with `:explain` payloads. The user shouldn't have to walk the trace
 to find them. Two surfaces:
 
-- **Inline Malli explanation** in the Issues tab — the human-readable
-  variant of `:explain`, with the offending path highlighted, the schema
-  source-coord linked.
+- **Inline Malli explanation** inline in the Epoch panel — the
+  human-readable variant of `:explain`, with the offending path
+  highlighted, the schema source-coord linked. (Pre rf2-gbz39 this
+  lived in the Issues tab; that tab was removed — Option (c) — and
+  issues now surface inline + via the L2 event-row pink-wash + the
+  always-on issues-ribbon signal.)
 - **Per-violation drilldown** — click a schema-violation row → opens the
   Epoch panel for the cascade that produced it; the violating handler's
   `reg-event-*` registration is linked.
@@ -363,7 +366,8 @@ navigations have an animated leading edge.
 Click any bar → spine seeks to that nav-token's allocation cascade.
 
 **Affordance:** Nav-token timeline popover (R-C3); cross-cuts the Trace
-tab and the Issues tab.
+tab and the inline issue surfaces (the issues-ribbon signal + the L2
+event-row pink-wash; the Issues tab was removed per rf2-gbz39 Option (c)).
 
 #### R.2 — "My route's `:on-match` events didn't fire."
 
@@ -469,8 +473,12 @@ The "Likely cause" line is heuristic — Xray suggests "session not
 injected" when the divergent sub depends on `:auth/*` and the server's
 `:auth/*` slice is empty.
 
-**Affordance:** Issues tab — hydration mismatch bisector with
-sub-attribution (S-C2). The hero SSR feature.
+**Affordance:** inline issue surface + dedicated drill-into — hydration
+mismatch bisector with sub-attribution (S-C2). The hero SSR feature.
+(The original design hosted this in the Issues tab; that tab was
+removed per rf2-gbz39 Option (c). The bisector itself is unbuilt
+post-v1 — see [`006-Hydration-Debugger.md`](006-Hydration-Debugger.md)
+§Affordance.)
 
 #### S.2 — "Server rendered a 500 page; what was the internal exception?"
 
@@ -484,8 +492,9 @@ panel — shows the internal trace + the projector's source-coord + the
 public projection map + the rendered client response. The author sees
 exactly what crossed the wire and what did not.
 
-**Affordance:** Issues tab / Epoch panel — server error projection trace
-(S-C5).
+**Affordance:** Epoch panel (inline) — server error projection trace
+(S-C5). (Pre rf2-gbz39 this also surfaced in the Issues tab; that tab
+was removed — Option (c) — and the Epoch panel is now the home.)
 
 #### S.3 — "Streaming SSR shipped a chunk that hydrated incorrectly."
 
@@ -660,7 +669,9 @@ the subsequent flows that did NOT run:
 The "Subsequent flows did not run" list is the killer feature — prevents a
 subtle data-corruption bug class.
 
-**Affordance:** Issues tab — flow cascade-halt alarm (F-C8).
+**Affordance:** inline issue surface — flow cascade-halt alarm (F-C8),
+raised via the issues-ribbon signal + the L2 event-row pink-wash. (Pre
+rf2-gbz39 this lived in the Issues tab; that tab was removed — Option (c).)
 
 #### F.5 — Other managed-effects bug classes (catalogued)
 
@@ -819,8 +830,10 @@ back after reading the spec as the destination:
    deserves more than a row. Options:
    - **(a)** Add Hydration as a **conditional 8th tab** (visible only
      when SSR is detected for the session). Tab count goes from 7 → 7-or-8.
-   - **(b)** Promote it to an inline panel inside the Issues tab. Stays
-     at 7.
+   - **(b)** ~~Promote it to an inline panel inside the Issues tab.~~
+     Moot — the Issues tab was removed per rf2-gbz39 Option (c); the
+     equivalent today is an inline panel reachable from the inline
+     issue surfaces (Epoch panel + issues-ribbon).
    - **(c)** Make it a `h`-keyboard popover (consistent with Nav-token
      `r`).
    - **Lean: (c).** Keeps the chrome at 7 tabs; joins the popover
@@ -837,8 +850,10 @@ back after reading the spec as the destination:
 3. **Security advisor voice (open-redirect, trusted-shell, payload
    leak).**
    - **(a)** Quiet, surface-only. Show the warning if asked; don't push.
-   - **(b)** Loud, push to Issues tab. Make security mistakes a
-     first-class issue.
+   - **(b)** Loud, push to the inline issue surfaces (issues-ribbon
+     signal + L2 event-row pink-wash). Make security mistakes a
+     first-class issue. (Pre rf2-gbz39 this read "push to Issues tab";
+     that tab was removed — Option (c).)
    - **(c)** Configurable via Settings. Default to (a); power-users opt
      into (b).
    - **Lean: (a) for v1; (c) when patterns stabilise.** Xray is a

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1075,6 +1075,18 @@ active-node / dashed compound container / inline guard+action labels +
 the `after: ◴ Ns → :event` countdown ring are the visual elements the
 Figma design fixes; xyflow renders them with the §6.0 palette mapping.
 
+Alongside the Canvas|List view-mode toggle, the chart's nested header
+carries a per-machine **chart-collapse toggle** (`▾` / `▸`, rf2-3d987
+issue #4) that collapses the whole topology chart to give the BEFORE /
+AFTER snapshot pair more room; expanded is the default and the choice
+persists per-machine (slot `[:rf.xray/machine-canvas
+:chart-collapsed-by-id <machine-id>]` + localStorage
+`xray.machine-canvas.chart-collapsed-by-id`). Its full state /
+event / sub / fx contract is normative in
+[`003-Machine-Inspector.md` §Post-collapse Dynamic panel shape](003-Machine-Inspector.md#post-collapse-dynamic-panel-shape-rf2-y9xmf-rf2-8og3k).
+(This is rf2-3d987 issue #4; issue #3 — the retired Before/After
+CSS-grid snapshot layout — is covered in §9.1.5.)
+
 Layout direction: **left-to-right by default** (matches typical state-
 machine convention; xyflow's dagre layout option `rankdir: 'LR'`).
 Operator can flip to top-to-bottom via Settings → View → Machines layout

--- a/tools/xray/spec/README.md
+++ b/tools/xray/spec/README.md
@@ -47,12 +47,19 @@ main read**.
   sim-clones); cross-frame diff; pin-two-epochs side-by-side.
 - **[005-Schema-Timeline.md](005-Schema-Timeline.md)** — Per-schema
   timeline; empty→non-empty flash; full Malli explanation in detail.
+  **Post-v1 (unbuilt):** the standalone timeline panel is the
+  destination — today schema-fail surfacing ships inline in the Epoch
+  panel plus the Static Schemas registry catalogue (see the doc's
+  §Affordance v1-status note).
 - **[006-Hydration-Debugger.md](006-Hydration-Debugger.md)** — The
-  hydration mismatch bisector. Hero SSR feature. Side-by-side server vs
-  client with sub-attribution + likely-cause hypothesis. Future
-  sections: server error projection trace; payload-policy verdict; head
-  model inspector; per-request frame teardown auditor; streaming SSR
-  boundary timeline; side-by-side SSR replay (post-v1 dream).
+  hydration mismatch bisector. The destination **hero SSR feature**.
+  Side-by-side server vs client with sub-attribution + likely-cause
+  hypothesis. Future sections: server error projection trace;
+  payload-policy verdict; head model inspector; per-request frame
+  teardown auditor; streaming SSR boundary timeline; side-by-side SSR
+  replay (post-v1 dream). **Post-v1 (unbuilt):** no Hydration tab
+  ships today; the only present artefact is an unwired per-pane
+  element-diff renderer (see the doc's §Affordance v1-status note).
 - **[007-UX-IA.md](007-UX-IA.md)** — Typography, colour tokens, animation
   timings, keyboard maps, density gradients — the pixels-that-feel-right
   reference.


### PR DESCRIPTION
## Summary

Five spec-freshness fixes for `tools/xray/spec/`, filed by a read-only audit. Each claim was **verified against the live `tools/xray/src/`** (via `git grep` + the `panel_enum.cljc` / `reg-l4-tab!` inventory — **6 Dynamic** tabs Epoch/App-DB/Views/Trace/Machine/Routes + **5 Static** tabs Machines/Routes/Schemas/Flows/Interceptors) before editing. No code change — doc accuracy only.

| Bead | Fix |
|---|---|
| **rf2-wkhbg** (P3) | 005 Schema-Timeline §Affordance dropped the false "ships today as its own panel" claim; the standalone violation-timeline is marked **UNBUILT (post-v1)** with its absent subs/events listed, and "today" now points at the inline Epoch schema-fail surface (rf2-kt6js) + the Static Schemas registry catalogue. Flash-cue (rf2-x2d7c) scoped to the future panel. |
| **rf2-83leo** (P3) | 006 Hydration-Debugger §Affordance marked **UNBUILT (post-v1; renderer-only)** — no Hydration L4 tab exists; the only artefact is the unwired `hydration_pane_render.cljs`. README "Hero SSR feature" reworded as the destination. |
| **rf2-zerqv** (P3) | 014 Registry-Catalogue: §Views re-anchored onto the live `:rf.xray/reactive-data` / `reactive-show-unchanged?` / `reactive-toggle-unchanged`; §Schema-violation timeline + §Hydration debugger marked UNBUILT; §Effects + §Performance marked DROPPED; §Flows marked superseded by the Static Flows catalogue. Stale rf2-qy0nu drift notice reconciled (Routes + Schemas survive as live tabs). |
| **rf2-s4n8d** (P4) | 019 Cross-Cutting-Insight: swept the body "Affordance: Issues tab" lines (inline Malli L142, nav-token popover L366, hydration bisector, server error projection, flow cascade-halt, §7 security-promotion options) onto the kept inline surfaces — the Issues tab was removed per rf2-gbz39 Option (c). |
| **rf2-2uodn** (P4) | Documented the per-machine **chart-collapse toggle** (rf2-3d987 #4) in 003 (full state/event/sub/fx contract) + 021 §6.2. |

## Verification against src

- Schema-timeline + Hydration-debugger subs/events: **zero hits** in `tools/xray/src`.
- `:rf.xray/{performance,effects,flows}-data` + family: **zero hits**; no Performance/Effects/Hydration L4 tab in `panel_enum.cljc` or any `reg-l4-tab!` call site.
- Live Views surface confirmed: `:rf.xray/reactive-data` + `reactive-show-unchanged?` (subs) + `reactive-toggle-unchanged` (event).
- Chart-collapse contract confirmed in `panels/machine_canvas.cljs` (slot `[:rf.xray/machine-canvas :chart-collapsed-by-id <id>]`, key `xray.machine-canvas.chart-collapsed-by-id`, event/subs/fx/hydrate ids all present); UI button in `panels/machine_inspector.cljs`.

## Quality gates (COLD)

- **mkdocs `--strict`: N/A.** `tools/xray/spec/` is not in the mkdocs `docs_dir` (`docs/`); the guide references the spec only via absolute GitHub URLs. Intra-tree anchor links swept — the one inbound anchor (006 -> 014 §Hydration debugger) was updated to the renamed header; all other `014.md#…` links (`#shared-infrastructure`) are unchanged headers.
- **Grep confirmations:** no surviving "today as its own panel" (005), no live `**Affordance:** Issues tab` lines (019), no dead-sub table rows in 014; chart-collapse documented in 003 + 021.

## Scope

`tools/xray/spec/**` only (7 files). No top-level `spec/`, no xray src, no `tools/xray/testbeds/`.