### PR TITLE
fix(skills/migration): unhandled-machine-event is a benign no-op, not renamed-to-error (rf2-lw950 / rf2-1i2um)

### DIFF
--- a/skills/re-frame-migration/references/error-events.md
+++ b/skills/re-frame-migration/references/error-events.md
@@ -107,7 +107,8 @@ When auditing a v1 codebase, **assume any error-category name not present in the
 
 Specific drift to watch:
 
-- v1 `:rf.warning/machine-unhandled-event` / `:rf.warning/machine-state-not-in-definition` / `:rf.warning/machine-snapshot-version-mismatch` were renamed to `:rf.error/*` form (per the catalogue's "Older drafts spelled this…" notes). User code matching the old `:rf.warning/*` spelling needs updating.
+- v1 `:rf.warning/machine-state-not-in-definition` / `:rf.warning/machine-snapshot-version-mismatch` were renamed to `:rf.error/*` form (per the catalogue's "Older drafts spelled this…" notes). User code matching the old `:rf.warning/*` spelling needs updating.
+- v1 `:rf.warning/machine-unhandled-event` is a **different** case — it was **retired entirely**, not re-keyed. Per rf2-ugdas there is no `:rf.error/machine-unhandled-event` and no warning either: an event a machine declines is now a **benign no-op**, surfaced as the `:rf.machine.event/unhandled-no-op` trace (op-type `:rf.machine`, the machine-activity family — NOT `:error`, NOT `:warning`; xstate-v5 parity, see [`spec/005-StateMachines.md` §Transition resolution](../../../spec/005-StateMachines.md#transition-resolution--deepest-wins-with-parent-fallthrough) + the [Spec 009 §`:op-type` vocabulary](../../../spec/009-Instrumentation.md#op-type-vocabulary) machine-activity entries). User code matching the old `:rf.warning/machine-unhandled-event` (or `:rf.error/machine-unhandled-event`) spelling should **drop** the handling — there is no replacement category to re-key to. To fail loudly on an unknown event, declare a `:*` wildcard whose action throws (a real `:rf.error/machine-action-exception`).
 - v1 prose sometimes named ad-hoc keys like `:rf/error` or `:re-frame/error`. The contract surface is `:rf.error/<category>` — closed set only.
 
 ## When to point an author at this leaf


### PR DESCRIPTION
## Correctness review: `skills/re-frame-migration` (rf2-lw950)

Systematic accuracy/currency review of the re-frame v1 → re-frame2 migration skill against current `implementation/` + `spec/` ground truth. **One inaccuracy found and fixed; the rest of the skill is accurate.**

### Fixed (the rf2-1i2um item)

`references/error-events.md` §"Stale advice the migration agent will encounter" lumped `:rf.warning/machine-unhandled-event` together with two sibling categories as all "renamed to `:rf.error/*` form". That is stale post **rf2-ugdas**:

- `machine-state-not-in-definition` and `machine-snapshot-version-mismatch` **were** renamed to `:rf.error/*` (confirmed at `spec/009-Instrumentation.md` catalogue lines 1699-1700) — these stay.
- `machine-unhandled-event` is a **different** case: it was **retired entirely** (no error, no warning) to the benign `:rf.machine.event/unhandled-no-op` trace, op-type `:rf.machine` (machine-activity family), xstate-v5 parity. There is no `:rf.error/machine-unhandled-event`. Confirmed in `implementation/machines/src/re_frame/machines/transition.cljc` ("rf2-ugdas; retires `:rf.error/machine-unhandled-event`") and `spec/009-Instrumentation.md:147` / `spec/005-StateMachines.md:1393`.

The bullet now splits the two cases: the unhandled-event entry says to **drop** the handling (no replacement category to re-key to), gives the loud-fail-via-`:*`-wildcard idiom, and cross-refs spec/005 §Transition resolution + spec/009 §`:op-type` vocabulary. Both new anchors verified against the heading text.

### Verified accurate (no change needed)

Cross-checked every migration mapping that touches a session-fresh surface against the current API:

- **M-67 frame-affordance redesign** — `frame-handle` (bundle `{:frame :dispatch :dispatch-sync :subscribe}`), `frame-bound-fn` (macro) / `frame-bound-fn*` (fn-twin), `get-frame-db` → `app-db-value` (VALUE), `current-frame` → `current-frame-id`. All match `spec/API.md` + `spec/002-Frames.md`. (Note: the `app-db-container` rename in #2380 is the *internal* container fn, not the public value-read — no conflation in the skill.)
- **M-50** `with-overrides` → `with-fx-overrides`; **M-44** `:timeout-ms` removed (use parent `:after`); **M-15** `:on-create` single-event grammar; **M-59** `validate-at-boundary-interceptor` (Var, `:id` `:rf.schema/at-boundary`); **M-58** `redact-interceptor`; **M-22** `reg-view*`; **O-6** `subscribe-once`; **O-12** `sub-topology` — all match.
- `register-error-listener!` record shape `{:error :event :event-id :frame :time :exception :elapsed-ms}` matches `spec/API.md:479`; `:on-error` recovery-keyword set matches the §Recovery contract.

### Quality gate (cold)

`scripts/check_skill_mcp_drift.py` → EXIT=0 (green).

Closes rf2-lw950. Closes rf2-1i2um.
