### PR TITLE
fix(skills): correct obsolete machine action signature in re-frame2-improver (rf2-d0n1e)

### DIFF
--- a/skills/re-frame2-improver/references/manual-loading-flags.md
+++ b/skills/re-frame2-improver/references/manual-loading-flags.md
@@ -48,8 +48,8 @@ Spec source: [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md)
 (rf/reg-machine :items
   {:initial :nothing
    :data    {:items [] :error nil}
-   :actions {:set-items (fn [d [_ items]] {:data (assoc d :items items :error nil)})
-             :set-error (fn [d [_ err]]   {:data (assoc d :error err)})}
+   :actions {:set-items (fn [{d :data [_ items] :event}] {:data (assoc d :items items :error nil)})
+             :set-error (fn [{d :data [_ err]   :event}] {:data (assoc d :error err)})}
    :states
    {:nothing {:tags #{:items/nothing} :on {:load :loading}}
     :loading {:tags #{:items/loading :items/transient}


### PR DESCRIPTION
## Summary

Correctness review of `skills/re-frame2-improver/` (rf2-d0n1e) found one stale API signature in the anti-pattern catalogue and fixed it. Every other API claim across the skill verified current against the spec.

## The fix

In `references/manual-loading-flags.md`, the "After" worked example registered a `reg-machine` whose `:actions` used the obsolete two-positional-arg machine-callback shape:

```clojure
:actions {:set-items (fn [d [_ items]] {:data (assoc d :items items :error nil)})
          :set-error (fn [d [_ err]]   {:data (assoc d :error err)})}
```

Spec 005-StateMachines locks the machine action/guard contract to a **single context-map argument** — `(fn [{:keys [data event state meta]}] effects)` (005 lines 567/606), with strict encapsulation (an action never sees `app-db`). The canonical `skills/re-frame2/patterns/nine-states.md` pattern destructures it as `(fn [{d :data [_ items] :event}] ...)`. The leaf now matches:

```clojure
:actions {:set-items (fn [{d :data [_ items] :event}] {:data (assoc d :items items :error nil)})
          :set-error (fn [{d :data [_ err]   :event}] {:data (assoc d :error err)})}
```

This was the "obsolete-machine-callback-signature staleness class" called out in the review brief.

## What else was checked (all current, no change)

- `manual-retry-loops.md` — `:rf.http/managed`, `:retry {:on :max-attempts :backoff {:base-ms :factor :max-ms :jitter}}`, the closed 8-member `:rf.http/*` failure-category set, co-located reply form: all match Spec 014.
- `boolean-discriminator-subs.md` — `rf/machine-has-tag?` sugar + `reg-machine` `:tags`: match Spec 005 (`@(rf/machine-has-tag? id tag)`).
- `schemaless-events.md` — `reg-app-schema`, `(rf/app-schemas)`, `rf/validate-at-boundary-interceptor`, `:schema` handler metadata: match Spec 010.
- `imperative-effects.md` — `reg-fx` 2-arg `(fn [_ctx args] ...)` + `{:platforms #{:client}}` metadata: match the canonical fx signature.
- `view-side-hook-state.md` — `subscribe`/`reg-sub`/`reg-event-db`, testing surface `compute-sub` + `dispatch-sync` + `app-db-value`: match Spec 008.
- SKILL.md / README.md / spec meta-docs / evals.json / package.json / plugin.json: descriptive only, no stale API; all cross-link targets and shared-protocol anchors resolve.

## Generic-to-any-app

No repo-coupling. The leaves use generic example paths (`src/app/...`, `:article/...`) and a stable consumer-facing API surface only — nothing tied to this dev repo testbeds.

## Verification

- `scripts/check_skill_redirect_anchors.py` — pass
- `scripts/check_skill_mcp_drift.py` — pass (no MCP allow-list in this skill)
- `re-frame.api-manifest.skills-check` — pass: 473 public-var references in skills/ in sync with the API manifest (the definitive API-currency gate)

Closes rf2-d0n1e.
