### PR TITLE
fix(skills): correct stale adapter-contract count + :can-leave key in re-frame2-implementor (rf2-8v7ft)

### DIFF
--- a/skills/re-frame2-implementor/references/phase-1-decisions.md
+++ b/skills/re-frame2-implementor/references/phase-1-decisions.md
@@ -93,7 +93,7 @@ Non-React substrates (Vue, Solid, Svelte, vanilla DOM, Replicant, Lit) and non-c
 
 **How to choose.** Pick the host's idiomatic React binding. The reactive container is usually the same library that supplies the binding's reactivity (a ratom, a `useSyncExternalStore`-backed atom-shaped store, a signal cell, a `MutableStateFlow`-shaped cell).
 
-**Trade-offs.** Bindings differ on how subscriptions auto-track (Reagent's deref-during-render vs UIx / Helix `use-subscribe` over `useSyncExternalStore`), but every in-scope binding plugs into the same six required + two optional + one lifecycle function contract from EP 006. The render trigger is uniformly "React re-renders on subscribed-value change."
+**Trade-offs.** Bindings differ on how subscriptions auto-track (Reagent's deref-during-render vs UIx / Helix `use-subscribe` over `useSyncExternalStore`), but every in-scope binding plugs into the same six required + three optional + one lifecycle function contract from EP 006. The render trigger is uniformly "React re-renders on subscribed-value change."
 
 **Where the spec speaks.** [`spec/006-ReactiveSubstrate.md`](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/) — the adapter contract + the React+VDOM commitment. [Implementor-Checklist §F3 Reactive substrate](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f3-reactive-substrate) — options per host. [Host-profile matrix in 000](https://day8.github.io/re-frame2/spec/000-Vision/#host-profile-matrix) — the reactive-tracking row names each host's React binding.
 

--- a/skills/re-frame2-implementor/references/phase-2-impl-order.md
+++ b/skills/re-frame2-implementor/references/phase-2-impl-order.md
@@ -82,7 +82,7 @@ Each EP is multi-day work. Plan one focused session per EP; don't try to land tw
 
 **Read first.** [`spec/006-ReactiveSubstrate.md`](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/). All ~990 lines — this EP is the load-bearing contract between the runtime and the view layer.
 
-**The contract.** Nine entries total — verbatim from [`spec/006-ReactiveSubstrate.md` §The adapter API contract](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#the-adapter-api-contract). The function set is **closed for v1**.
+**The contract.** Ten entries total — verbatim from [`spec/006-ReactiveSubstrate.md` §The adapter API contract](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#the-adapter-api-contract). The function set is **closed for v1**.
 
 - **Six required functions** the adapter must provide:
   - `make-state-container` — create a reactive container holding an `app-db` value.
@@ -91,9 +91,10 @@ Each EP is multi-day work. Plan one focused session per EP; don't try to land tw
   - `make-derived-value` — construct a derived (memoised) container from one or more sources.
   - `render` — render a render-tree onto the substrate's surface; return an unmount fn.
   - `render-to-string` — pure render to an HTML string. **JVM-runnable and required even for Q3=no (no-SSR) ports** — do not treat it as optional.
-- **Two optional functions** (the core falls back when absent):
+- **Three optional functions** (the core falls back, or no-ops, when absent):
   - `subscribe-container` — register a change-listener for invalidation. Fallback: core runs invalidation inline within `replace-container!`.
   - `register-context-provider` — return a context-provider component that scopes a frame to a subtree. Fallback: explicit-frame-as-argument threaded by the user's view code.
+  - `flush-render!` — synchronously commit the substrate's pending renders to the surface (NOT a `requestAnimationFrame`-style tick), so headless tooling can drive a `dispatch → flush-render! → observe-settled-DOM` loop deterministically. Fallback: core no-ops (an adapter that renders without a live commit — plain-atom / SSR — has nothing to flush).
 - **One lifecycle function:** `dispose-adapter!` — tear down: release listeners, caches, host resources. (Boot wiring is `install-adapter!`, a core entry point — not part of the adapter's own surface; there is no "start" function.)
 - **Single-adapter-per-process.** A process binds one adapter at boot via `install-adapter!`; multi-adapter coexistence is post-v1.
 - **Revertibility constraint on adapters.** Adapter-internal state must be derivable from the frame value. No "shadow state" inside the adapter that the frame value can't reproduce on revert. Per [`spec/006-ReactiveSubstrate.md` §Revertibility constraints on adapters](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#revertibility-constraints-on-adapters).
@@ -200,7 +201,7 @@ For each capability the port declared `yes` for in D3, walk the matching EP. Sug
 
 **Read.** [`spec/012-Routing.md`](https://day8.github.io/re-frame2/spec/012-Routing/).
 
-**Contract.** `reg-route`, `match-url`, `route-link`, `:rf.nav/push-url` fx, `[:rf/runtime :routing :current]` + `[:rf/runtime :routing :pending-navigation]` reserved app-db storage, navigation tokens, fragment handling, `:can-leave?` guard.
+**Contract.** `reg-route`, `match-url`, `route-link`, `:rf.nav/push-url` fx, `[:rf/runtime :routing :current]` + `[:rf/runtime :routing :pending-navigation]` reserved app-db storage, navigation tokens, fragment handling, `:can-leave` guard (a sub-id whose boolean value gates navigation away).
 
 ### EP 011 — SSR (if D3 Q3 = yes)
 

--- a/skills/re-frame2-implementor/references/reference-impl-tour.md
+++ b/skills/re-frame2-implementor/references/reference-impl-tour.md
@@ -31,7 +31,7 @@ implementation/
 │       ├── emit.cljc        EP 009 — trace emit sites
 │       ├── error.cljc       EP 009 — structured error contract
 │       ├── substrate/       EP 006 — substrate contract + reference substrate
-│       │   ├── adapter.cljc   the nine-entry substrate contract (6 req + 2 opt + dispose)
+│       │   ├── adapter.cljc   the ten-entry substrate contract (6 req + 3 opt + dispose)
 │       │   └── plain_atom.cljc plain-atom reference substrate (JVM / SSR / headless)
 │       └── test_support.cljc EP 008 — test fixtures + helpers
 ├── adapters/                EP 006 — React-binding substrate adapters
@@ -78,14 +78,14 @@ The per-feature directories ship as **separate artefacts** in the published libr
 
 ### EP 006 — Reactive substrate (`core/src/re_frame/substrate/` + `adapters/`)
 
-**What you'll find.** The substrate contract is defined in-core at `core/src/re_frame/substrate/adapter.cljc`, with a dependency-free reference substrate alongside it at `core/src/re_frame/substrate/plain_atom.cljc` — `clojure.core/atom`, hand-rolled signal graph, no render trigger (JVM / SSR / headless). The React-binding adapters then ship as sibling artefacts under `adapters/` — `reagent`, `reagent-slim`, `uix`, `helix` (plus `test-react` for the test harness). The Reagent-family adapters are browser-facing — `r/atom` as the container, Reagent `r/reaction` for subs, React for the render trigger. The in-core plain-atom substrate and every adapter implement the same nine-entry contract (boot wiring is the core's `install-adapter!` / `dispose-adapter!`).
+**What you'll find.** The substrate contract is defined in-core at `core/src/re_frame/substrate/adapter.cljc`, with a dependency-free reference substrate alongside it at `core/src/re_frame/substrate/plain_atom.cljc` — `clojure.core/atom`, hand-rolled signal graph, no render trigger (JVM / SSR / headless). The React-binding adapters then ship as sibling artefacts under `adapters/` — `reagent`, `reagent-slim`, `uix`, `helix` (plus `test-react` for the test harness). The Reagent-family adapters are browser-facing — `r/atom` as the container, Reagent `r/reaction` for subs, React for the render trigger. The in-core plain-atom substrate and every adapter implement the same ten-entry contract (boot wiring is the core's `install-adapter!` / `dispose-adapter!`).
 
 **What's CLJS-specific.**
 
 - Reagent's auto-tracked deref-during-render dependency capture. Your host's React binding supplies the equivalent over its `useSyncExternalStore` (UIx / Helix: a `use-subscribe` hook; TS-React / Fable.React / Feliz / ReasonReact / Halogen-React / Kotlin-React: the same pattern).
 - The component-lifecycle integration uses Reagent's lifecycle methods. Other substrates plug into their own.
 
-**What's pattern-required.** The six required functions (`make-state-container`, `read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string` — note `render-to-string` is required, JVM-runnable, even for no-SSR ports) + two optional (`subscribe-container`, `register-context-provider`) + one lifecycle (`dispose-adapter!`); install via the core's `install-adapter!`. Single-adapter-per-process. Adapter-internal state derivable from the frame value (revertibility constraint).
+**What's pattern-required.** The six required functions (`make-state-container`, `read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string` — note `render-to-string` is required, JVM-runnable, even for no-SSR ports) + three optional (`subscribe-container`, `register-context-provider`, `flush-render!`) + one lifecycle (`dispose-adapter!`); install via the core's `install-adapter!`. Single-adapter-per-process. Adapter-internal state derivable from the frame value (revertibility constraint).
 
 ### EP 004 — Views (`core/src/re_frame/views.cljs`)
 


### PR DESCRIPTION
## Correctness review: skills/re-frame2-implementor (rf2-8v7ft)

Per-slice CORRECTNESS review of `skills/re-frame2-implementor/` against the current `spec/` + implementation. Scope was the skill only (spec/impl read as ground truth, not edited).

### Inaccuracies fixed

1. **Substrate adapter contract: nine entries → ten.** Spec 006 §The adapter API contract is now authoritatively *"six required functions, three optional functions, and one lifecycle function — ten entries in total"* since `flush-render!` landed as the third optional fn (rf2-40a84). The skill predated that and described it as nine (6 req + 2 opt + dispose), omitting `flush-render!` entirely. Fixed across:
   - `references/phase-2-impl-order.md` EP 006 (count + added the `flush-render!` bullet)
   - `references/reference-impl-tour.md` (layout-tree comment + EP 006 §What you'll find + §What's pattern-required)
   - `references/phase-1-decisions.md` D2 trade-offs
2. **Routing guard key: `:can-leave?` → `:can-leave`.** Spec 012 uses `:can-leave` (no trailing `?`) for the route-metadata navigation guard; the skill carried a spurious `?`. Fixed in `references/phase-2-impl-order.md` EP 012.

### Verified accurate (no change needed)

Closed registrar kind set (`:event :sub :fx :cofx :view :frame :route :head :error-projector :flow`); `:rf/default`; `:rf/runtime` subsystem keys; `:rf/hydrate` event (the rf2-vnapd fold moved the *app-db key*, not the event name); `epoch/restore-epoch` + `epoch/reset-frame-db!`; `[:rf/runtime :machines :snapshots <id>]`; `reg-machine`; `init-platform`; `:schema` vocabulary rename (was `:spec`); closed `{:db :fx}` effect-map; `:on-error` reg-frame slot; `:rf.nav/push-url`; `match-url`/`route-link`/`reg-route`.

### Filed as a separate bead (spec defect, not a skill defect)

**rf2-ftrcv** — spec/001-Registration.md says there is **no** `:machine-guard`/`:machine-action` registry kind, but spec/005-StateMachines.md §490 and `implementation/core/src/re_frame/registrar.cljc` (via rf2-ypu5i) both treat them as real registrar kinds (tooling-only handler-meta). The skill's EP 001 wording faithfully tracks spec 001's contract and is left as-is pending the spec reconciliation; spec is the artefact, so the spec gets fixed first.

### Gate

`scripts/check_skill_mcp_drift.py` → exit 0 (green). No MCP pairing for this workflow skill; `Bash(gh issue *)` allow-list satisfies the cardinal-rule-8 `gh issue create` instruction.

Do not merge — review gate.