### PR TITLE
fix(examples): migrate login_uix demo stub off the 3-hop chain (rf2-5xfn6)

### DIFF
--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -18,6 +18,7 @@
   (:require [uix.core :as uix :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
             [re-frame.schemas]
             [re-frame.machines]
             [re-frame.http-managed]
@@ -67,57 +68,40 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
-(rf/reg-event-fx :auth.login.demo/schedule-reply
-  {:doc "Private — entered via dispatch from :auth.login.demo/managed-stub.
-         Uses `:dispatch-later` so framework time controls apply to the
-         demo latency. See examples/reagent/login for the full rationale."}
-  (fn handler-auth-login-demo-schedule-reply [_ [_ outcome args-map]]
-    {:fx [[:dispatch-later
-           {:ms    50
-            :event [:auth.login.demo/deliver-reply outcome args-map]}]]}))
-
-(rf/reg-event-fx :auth.login.demo/deliver-reply
-  {:doc "Private — fired by the :dispatch-later scheduled in
-         :auth.login.demo/schedule-reply. Delegates to the framework-
-         shipped canned-success / canned-failure fxs (Spec 014 §Testing)."}
-  (fn handler-auth-login-demo-deliver-reply [_ [_ outcome args-map]]
-    (case outcome
-      :success
-      {:fx [[:rf.http/managed-canned-success
-             (assoc args-map
-                    :value {:user  {:id    (random-uuid)
-                                    :email (-> args-map :request :body :email)}
-                            :token "demo-token-123"})]]}
-
-      :failure-401
-      {:fx [[:rf.http/managed-canned-failure
-             (assoc args-map
-                    :kind :rf.http/http-4xx
-                    :tags {:status  401
-                           :message "Invalid credentials."})]]}
-
-      :empty-success
-      {:fx [[:rf.http/managed-canned-success (assoc args-map :value {})]]})))
-
 (rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
-               to the Reagent example's stub — dispatches into the
-               private :auth.login.demo/schedule-reply event so the
-               deferred reply rides framework `:dispatch-later` (50 ms)
-               rather than raw `js/setTimeout`. Framework time controls
-               (Tool-Pair time-travel, `:dispatch-later` nil-override)
-               apply automatically."
+               to the Reagent and Helix examples' stub — delegates straight
+               to the framework-shipped canned-success / canned-failure
+               fxs with `:after-ms` (rf2-j1mo4), so the framework defers
+               the reply via `:dispatch-later` (50 ms) — observable in
+               the tape, time-travel-safe, NOT raw `js/setTimeout`. The
+               `:after-ms` parameter collapses the former schedule-reply →
+               `:dispatch-later` → deliver-reply chain into one arg on the
+               same canned effect."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
-          login?  (= "/api/login" url)
-          outcome (cond
-                    (and login? (= good-password (:password body))) :success
-                    login?                                          :failure-401
-                    :else                                           :empty-success)
-          frame   (:frame frame-ctx)]
-      (rf/dispatch [:auth.login.demo/schedule-reply outcome args-map]
-                   {:frame frame}))))
+          login? (= "/api/login" url)]
+      (cond
+        (and login? (= good-password (:password body)))
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx (assoc args-map
+                                 :after-ms 50
+                                 :value {:user  {:id    (random-uuid)
+                                                 :email (:email body)}
+                                         :token "demo-token-123"})))
+
+        login?
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+          (stub frame-ctx (assoc args-map
+                                 :after-ms 50
+                                 :kind :rf.http/http-4xx
+                                 :tags {:status  401
+                                        :message "Invalid credentials."})))
+
+        :else
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx (assoc args-map :after-ms 50 :value {})))))))
 
 ;; ============================================================================
 ;; STATE MACHINE


### PR DESCRIPTION
## Correctness review: examples/uix (rf2-5xfn6)

Per-slice CORRECTNESS review of `examples/uix` — counter_uix, dashboard_uix, login_uix — against current re-frame2 + the UIx adapter.

### Defect found + fixed: stale demo-stub wiring in login_uix

The `:after-ms` canned-stub migration (rf2-j1mo4, commit `2f44b186c`, "migrate 4 examples off the 3-hop chain") migrated `reagent/login`, `helix/login_helix`, `reagent/managed_http_counter`, and `reagent/realworld` — but **`uix/login_uix` was missed**. It was left on the old `:auth.login.demo/schedule-reply` → `:dispatch-later` → `:auth.login.demo/deliver-reply` two-event chain, while its README and the Helix sibling's docstring both claim the dataflow is **identical** to the Reagent reference. The parity claim was false.

**Fix:** rewire `:auth.login.demo/managed-stub` to delegate straight to `:rf.http/managed-canned-success` / `-failure` with `:after-ms 50` (matching Reagent + Helix byte-for-byte), and drop the two now-dead intermediate events. Observable behaviour is unchanged (50 ms deferred reply via framework `:dispatch-later`); the wiring is now the current single-fx contract and cross-substrate parity holds again. Net −16 lines.

### Reviewed, no defects

- **counter_uix** — `use-subscribe` + `(:dispatch (rf/frame-handle))` + `uix-dom/create-root`/`render-root` + lazy `defonce` mount all match the adapter testbed and current API.
- **dashboard_uix** — signal-graph subs, `sparkline-path` (n=1 / empty-series guarded — empty series never reached because empty `visible-metrics` renders no cards), `delta-badge` / `format-value` interop (`Math/abs`, `.toFixed`, `.toLocaleString`) all consistent with sibling examples. No nil/off-by-one hazards.

### Verification

- All three UIx builds compile clean — **0 warnings** (`examples/counter-uix`, `examples/login-uix`, `examples/dashboard-uix`).
- Quality gate `npm run test:examples`: **3 specs, 0 failures, 0 skipped**.

Closes rf2-5xfn6.
