### PR TITLE
refactor(pair-mcp): fold read-dom/read-ui blank-result projection into one helper (rf2-u4s4x)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -690,3 +690,55 @@
       (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
       (.then on-value)
       (.catch (fn [err] (err->result fail-reason err)))))
+
+;; ---------------------------------------------------------------------------
+;; Map-envelope projection for the "runtime fn always returns a map" tools
+;; (rf2-u4s4x).
+;;
+;; `read-dom` and `read-ui` (rf2-q0r7e) both route a single
+;; `(re-frame2-pair.runtime/<dom-read|ui-read> {...})` form through
+;; `eval-after-runtime!`. The runtime fn ALWAYS returns a map (its own
+;; `{:ok? ...}` envelope, or a structured no-document / bad-selector
+;; error). A nil / non-map value reaching the `on-value` callback therefore
+;; means the eval came back BLANK — `cljs-eval-value` reads a blank shadow
+;; result as `nil` (the runtime didn't answer: a dropped WebSocket, or a
+;; full page refresh wiped the preload marker).
+;;
+;; Left unguarded, `(wire/ok-text nil)` projects to a `null`
+;; structuredContent the npm SDK's outputSchema validation rejects at the
+;; transport layer (`expected record at structuredContent, received null`,
+;; rf2-r5erl) — bypassing the normal `{:ok? false}` error contract. Both
+;; read tools carried a byte-for-byte-identical map?/blank guard; this
+;; helper folds it onto ONE projection so a fix or regression-guard on the
+;; blank-result contract covers both. Only the per-tool `:reason`, `:hint`,
+;; and any extra error slots (read-dom echoes `:selector`) differ — those
+;; ride in as args.
+;; ---------------------------------------------------------------------------
+
+(defn map-result-or-blank
+  "Build the `on-value` callback for a tool whose runtime fn always
+  returns a MAP envelope (rf2-u4s4x — read-dom / read-ui). Returns a
+  1-arity fn suitable as `eval-after-runtime!`'s `on-value`:
+
+    - a MAP envelope ⇒ `(wire/ok-text (assoc envelope :build build-id))`,
+      echoing the canonical resolved `:build` (rf2-8t3ct / rf2-fmho5).
+    - a nil / non-map ⇒ `(wire/err-text {...})` carrying `:ok? false`,
+      `:build`, the per-tool `:reason` / `:hint`, and any `error-extras`
+      (e.g. read-dom's `:selector`) — the rf2-r5erl-safe structured
+      blank-result error (never a `null` structuredContent).
+
+  `blank-reason` / `blank-hint` are the tool-specific blank-result
+  vocabulary; `error-extras` is an optional map of extra slots merged
+  into the error envelope."
+  ([build-id blank-reason blank-hint]
+   (map-result-or-blank build-id blank-reason blank-hint nil))
+  ([build-id blank-reason blank-hint error-extras]
+   (fn [envelope]
+     (if (map? envelope)
+       (wire/ok-text (assoc envelope :build build-id))
+       (wire/err-text
+         (merge {:ok?    false
+                 :reason blank-reason
+                 :build  build-id
+                 :hint   blank-hint}
+                error-extras))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_dom.cljs
@@ -212,35 +212,26 @@
 
       :else
       (let [form (read-dom-form selector sub-selector limit max-text attrs)]
+        ;; The runtime's `dom-read` ALWAYS returns a map, so a non-map at
+        ;; `on-value` means a BLANK eval (rf2-r5erl). The shared
+        ;; `probe/map-result-or-blank` projects a map → `ok-text` with the
+        ;; `:build` echo, or a blank → a structured `:ok? false` error (so
+        ;; `ok-text` never sees `nil` and emits the `null` structuredContent
+        ;; the SDK rejects). read-ui carries the identical projection. The
+        ;; per-tool blank `:reason` / `:hint` / `:selector` echo ride in here.
         (probe/eval-after-runtime!
           conn build-id form :read-dom-failed
-          (fn [envelope]
-            ;; The runtime's `dom-read` ALWAYS returns a map (a `{:ok? ...}`
-            ;; envelope or the no-document / bad-selector error). A nil /
-            ;; non-map here means the eval came back BLANK —
-            ;; `cljs-eval-value` reads a blank shadow result as `nil`
-            ;; (no runtime answered, or the result slot was empty). Left
-            ;; unguarded, `(wire/ok-text nil)` projected to a `null`
-            ;; structuredContent that the SDK's outputSchema validation
-            ;; rejected at the transport layer with
-            ;; `expected record at structuredContent, received null`
-            ;; (rf2-r5erl) — bypassing the normal error contract. Surface
-            ;; it as a structured `{:ok? false ...}` like `orient` does.
-            (if (map? envelope)
-              (wire/ok-text (assoc envelope :build build-id))
-              (wire/err-text
-                {:ok?      false
-                 :reason   :rf.error/read-dom-blank-result
-                 :build    build-id
-                 :selector selector
-                 :hint     (str "read-dom's browser eval returned a blank / "
-                                "non-map value. This is almost always the "
-                                "connection, not the form: read-dom calls the "
-                                "preloaded runtime fn (re-frame2-pair.runtime/"
-                                "dom-read) — the same shared plumbing read-ui "
-                                "uses — so an unresolved-alias miss can no "
-                                "longer nil it out. A blank result means the "
-                                "runtime did not answer the eval (a dropped "
-                                "WebSocket, or the preload was wiped by a full "
-                                "page refresh). Run discover-app to confirm "
-                                ":liveness :fresh, then retry.")}))))))))
+          (probe/map-result-or-blank
+            build-id :rf.error/read-dom-blank-result
+            (str "read-dom's browser eval returned a blank / "
+                 "non-map value. This is almost always the "
+                 "connection, not the form: read-dom calls the "
+                 "preloaded runtime fn (re-frame2-pair.runtime/"
+                 "dom-read) — the same shared plumbing read-ui "
+                 "uses — so an unresolved-alias miss can no "
+                 "longer nil it out. A blank result means the "
+                 "runtime did not answer the eval (a dropped "
+                 "WebSocket, or the preload was wiped by a full "
+                 "page refresh). Run discover-app to confirm "
+                 ":liveness :fresh, then retry.")
+            {:selector selector}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/read_ui.cljs
@@ -193,24 +193,19 @@
                     (let [m (js->clj point :keywordize-keys true)]
                       (when (map? m) (select-keys m [:x :y]))))
             form  (read-ui-form vid pt selector max-text frame)]
+        ;; The runtime's `ui-read` ALWAYS returns a map, so a non-map at
+        ;; `on-value` means a BLANK eval (rf2-r5erl, the sibling of
+        ;; read-dom's bug). The shared `probe/map-result-or-blank` projects
+        ;; a map → `ok-text` with the `:build` echo (rf2-8t3ct / rf2-fmho5),
+        ;; or a blank → a structured `:ok? false` error so `ok-text` never
+        ;; sees `nil` and emits the `null` structuredContent the SDK rejects.
+        ;; read-dom carries the identical projection.
         (probe/eval-after-runtime!
           conn build-id form :rf.error/read-ui-failed
-          (fn [envelope]
-            ;; The runtime's `ui-read` ALWAYS returns a map. A nil /
-            ;; non-map means a BLANK eval result (the runtime didn't
-            ;; answer) — guard it so `ok-text` never sees `nil` and
-            ;; emits a `null` structuredContent the SDK rejects
-            ;; (rf2-r5erl, the sibling of read-dom's bug). Echo the
-            ;; resolved `:build` on success for round-trippable
-            ;; selection (rf2-8t3ct / rf2-fmho5).
-            (if (map? envelope)
-              (wire/ok-text (assoc envelope :build build-id))
-              (wire/err-text
-                {:ok?    false
-                 :reason :rf.error/read-ui-blank-result
-                 :build  build-id
-                 :hint   (str "read-ui's browser eval returned a blank "
-                              "value (no map envelope). Reload the app tab "
-                              "so the re-frame2-pair runtime reconnects, "
-                              "then retry; run discover-app to confirm "
-                              ":liveness :fresh.")}))))))))
+          (probe/map-result-or-blank
+            build-id :rf.error/read-ui-blank-result
+            (str "read-ui's browser eval returned a blank "
+                 "value (no map envelope). Reload the app tab "
+                 "so the re-frame2-pair runtime reconnects, "
+                 "then retry; run discover-app to confirm "
+                 ":liveness :fresh.")))))))


### PR DESCRIPTION
## What

Dedup-reduction review of `tools/re-frame2-pair-mcp/src/**` (bead rf2-u4s4x). The slice is already exceptionally DRY — a long history of consolidation beads (eval prelude rf2-jkake.19, the `eval-form` DSL rf2-dpzpe, bool-args rf2-c4fmh, the single-source registry rf2-47g8l, read-dom/read-ui shared eval form rf2-q0r7e, the result-envelope codec rf2-qobqy). One genuine residual copy-paste remained and is consolidated here.

## The duplication (file:line)

`read-dom-tool` (`read_dom.cljs:217-246`) and `read-ui-tool` (`read_ui.cljs:198-216`) carried a **byte-for-byte-identical structural guard** in their `eval-after-runtime!` `on-value` callback:

```clojure
(if (map? envelope)
  (wire/ok-text (assoc envelope :build build-id))
  (wire/err-text {:ok? false :reason <per-tool> :build build-id :hint <per-tool> ...}))
```

q0r7e unified the *eval form* (both call `re-frame2-pair.runtime/{dom-read,ui-read}` via the same DSL + prelude). This was the residual: the *result projection* — the "runtime fn always returns a map; a non-map is a blank eval that must surface as a structured `:ok? false` error so `ok-text` never emits the `null` structuredContent the SDK rejects (rf2-r5erl)" — was still duplicated, including the rf2-r5erl-guard comment.

## The fix

New `probe/map-result-or-blank` (next to its sibling `eval-after-runtime!`) builds the `on-value` callback once. Only the per-tool blank `:reason` / `:hint` / extra error slots (read-dom echoes `:selector`) differ — those ride in as args. Net: +52 in `probe.cljs`, −18/−15 in the two read tools.

## Behaviour-preserving

Same wire `:reason` keywords (`:rf.error/read-dom-blank-result` / `:rf.error/read-ui-blank-result`), same hints, same `:build` echo on success, same rf2-r5erl non-null structuredContent guarantee. **Wire contract (`003-Tool-Catalogue.md`) unchanged** — it pins the `:reason` keyword and trigger, both preserved; the spec describes the contract, not the internal helper, so no spec edit.

## Not consolidated (DRY-assessment)

Deliberately left alone — the apparent overlap is genuine per-tool variation, not copy-paste:
- The `(if (map? v) v {:ok? false :reason :unexpected-shape ...})` idiom recurs (orient / reset-frame-db / operating-frame trio / dispatch-dry-run) but each fallback carries a *different* payload (`:build`, `:frame`, extra `cond` arms), so a rigid shared helper would over-generalize and lose clarity.
- `list-streams` / `list-subscriptions` share `(ok-text (if (map? v) v {:ok? true :subs []}))` — but it's a single short line; a named helper hiding `{:ok? true :subs []}` reduces clarity.
- `discover-app`'s three warning branches already compose extracted helpers (`mark-resolved-build-id!`, `with-freshness`, `with-auto-selection`); the repetition is just composition, with genuinely different `:warning`/`:note` per branch.
- `trace-window` / `watch-epochs` share a `(if (map? v) v {})` + cursor-stale + wire-pipeline skeleton, but the bodies (cursor params, advisory logic) are genuinely distinct.

## Gates (cold)

- `shadow-cljs compile server-test` — 0 warnings, **881 tests / 2697 assertions, 0 failures, 0 errors**.
- `npm run test:mcp-conformance` — **all 6 gates green** (incl. gate [4], the re-frame2-pair-mcp end-to-end SDK-client driver).

Concurrency correctness (nrepl/cache/reconnect — w2mjm/hu6q0/c3dsr) untouched: no change to `probe`'s caching/probe paths, only the post-eval result projection.