### PR TITLE
refactor(mcp-base): collapse two parallel dups in cap + descriptor-manifest (rf2-ddfk8)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -176,6 +176,20 @@
 ;; sum-text-tokens — cumulative token count across the result's :text slots.
 ;; ---------------------------------------------------------------------------
 
+(defn- sum-text-by
+  "Sum `(f s)` across every string `:text` slot in `result`'s content
+  vector, accessed via `io`. The shared fold body under
+  `sum-text-tokens` / `sum-text-chars` — the only thing that differs
+  between them is the per-string measure `f` (`token-estimate` vs
+  `count`). Non-string slots are skipped; a nil / empty content vector
+  folds to zero."
+  [io result f]
+  (transduce (comp (filter string?)
+                   (map f))
+             +
+             0
+             (content-texts io result)))
+
 (defn sum-text-tokens
   "Sum `overflow/token-estimate` across every `:text` slot in `result`'s
   content vector, accessed via `io`. The serialised response's wire size
@@ -185,11 +199,7 @@
   — a single oversize slot or an aggregate of many small slots both
   trip the cap."
   [io result]
-  (transduce (comp (filter string?)
-                   (map overflow/token-estimate))
-             +
-             0
-             (content-texts io result)))
+  (sum-text-by io result overflow/token-estimate))
 
 (defn sum-text-chars
   "Sum the character count across every `:text` slot in `result`'s
@@ -204,11 +214,7 @@
   enough for English / EDN to pass through unchanged, tight enough
   that a payload doubled by undercount still trips the cap)."
   [io result]
-  (transduce (comp (filter string?)
-                   (map count))
-             +
-             0
-             (content-texts io result)))
+  (sum-text-by io result count))
 
 (def ^:const byte-cap-multiplier
   "Secondary byte-cap multiplier (rf2-ih7g4). `cap * multiplier` is the

--- a/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
@@ -114,6 +114,14 @@
   [v]
   (pr-str v))
 
+(defn- normalise-lf
+  "Normalise CRLF line endings to bare LF so manifest text is
+  byte-identical on Windows and Linux. Used both at emission
+  (`render-edn`) and at comparison (`check`) so a CRLF working-tree
+  checkout never trips a spurious drift."
+  [s]
+  (str/replace s "\r\n" "\n"))
+
 (defn- render-row
   "Render one manifest row as a single-line EDN map with the canonical
   key order. One row per line keeps git diffs surgical — adding a tool
@@ -153,7 +161,7 @@
                  "\n :tools\n ["
                  (str/join "\n  " (map render-row tools))
                  "]}\n")]
-    (str/replace raw "\r\n" "\n")))
+    (normalise-lf raw)))
 
 (defn build-manifest
   "Build the full manifest data structure from a seq of registry
@@ -167,9 +175,6 @@
 ;; ---------------------------------------------------------------------------
 ;; Drift-check — regenerate-in-memory vs committed.
 ;; ---------------------------------------------------------------------------
-
-(defn- normalise-lf [s]
-  (str/replace s "\r\n" "\n"))
 
 (defn check
   "Compare a freshly-generated manifest string against the committed


### PR DESCRIPTION
## Summary

DUPLICATION-reduction review of `tools/mcp-base/src/**` (rf2-ddfk8, one of the slice-partition dedup beads). Dedup-only, behaviour-preserving; correctness review (rf2-of2cd) already done. Two genuine consolidations found and applied; the rest of the slice is assessed appropriately DRY.

## Consolidations

**1. `cap.cljc` — shared `sum-text-by` under the two sum fns.**
`sum-text-tokens` (`cap.cljc:179`) and `sum-text-chars` (`cap.cljc:194`) were byte-for-byte identical `transduce` folds over `(content-texts io result)` differing only in the per-string measure (`overflow/token-estimate` vs `count`). Extracted a private `sum-text-by io result f` and made both delegate. Public arities unchanged — both remain the public API the servers' tests and `re-frame2-pair-mcp/.../cap.cljs` consume. `apply-cap`'s deliberate single-pass token+char fold (rf2-hyp0z) is intentionally NOT routed through this helper and is left untouched.

**2. `descriptor_manifest.cljc` — reuse `normalise-lf` instead of re-inlining the replace.**
`render-edn` (was `descriptor_manifest.cljc:156`) re-inlined `(str/replace raw "\r\n" "\n")`, the exact CRLF→LF normalisation that the private `normalise-lf` (was line 171) already wraps for `check`. Promoted `normalise-lf` above `render-edn`, gave it a docstring, and reused it at both the emission and comparison sites; dropped the now-duplicate definition.

## DRY assessment of the rest of the slice (no change warranted)

- **EDN read-with-reader-conditional** appears in `cursor.cljc` (tag-rejecting, untrusted wire input) and `descriptor_manifest.cljc` (plain read of a trusted self-generated file, parse failure already caught → `#{}`). Different threat models; the `#?(:clj clojure.edn :cljs cljs.reader)` is 2 lines of ns boilerplate, not shared logic. Consolidating would be a false dedup and would disturb the recently-reviewed cursor correctness surface. Left separate.
- **Patch-tuple accessors** — `section_grouping.cljc` has private `patch-path`/`patch-op`; `diff_encode.cljc` positionally destructures `[path op v]` in hot reduce loops. The shared *grammar* is already the single source of truth (`diff_encode/patch-schema`). Sharing accessors would couple the two and add indirection in a hot path for no clarity gain.
- **`render-scalar`/`render-string-vec`** (descriptor_manifest) — both thin `pr-str` wrappers, but private and they document call-site intent (scalar vs string-vec). Not cross-ns dup; collapsing trades clarity for nothing.
- **Malformed-counter AtomicLong/atom**, the cap transduces, the elision/diff reduce-kv walks — all single-occurrence-per-namespace; no copy-paste across the 11 concern files.

## Gates (cold)

- mcp-base `clojure -M:test` — **181 tests / 506 assertions, 0 failures** (identical to pre-change baseline)
- mcp-base `npm run test:cljs` (CLJS reader-conditional arms) — **8 / 39, 0 failures**
- story-mcp `clojure -M:test` (real consumer of `base-cap/sum-text-tokens` + the descriptor-manifest drift gate) — **205 / 1045, 0 failures**
- `npm run test:mcp-conformance` — **all 6/6 gates green** (incl. wire-vocab 49/629)

## Scope / risk

- Touched only `tools/mcp-base/src/**`; no spec change (no contract surface moved — both public fns keep their arities, the manifest serialiser output is byte-identical).
- Risk: low. Both edits are behaviour-identical refactors; the cap edit preserves the public sum-fn signatures the cap/cursor correctness review depends on.