### PR TITLE
refactor(mcp-conformance): share SDK-spawn ceremony for secondary boots (rf2-0ogn7)

### DIFF
--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -49,12 +49,94 @@
 // The runner returns nothing; it always terminates the process via
 // `process.exit`. Callers that pre-flight skip MUST exit themselves
 // (via `runWithWatchdog.skip`).
+//
+// ## Bare spawn (no watchdog / no exit) — `connectServer` + `closeQuietly`
+//
+// `runWithWatchdog` is the single-boot-per-process form. Two gates need
+// a SECOND in-process server boot it can't serve (it `process.exit`s on
+// every path): `end-to-end-flag-gates.cjs` (three fresh JVMs, one per
+// gate-posture probe) and `live-re-frame2-pair-redaction.cjs` (a second
+// server with `--allow-sensitive-reads` for the gate-ON arm). Both call
+// the shared `connectServer({ transportSpec, clientName, stderrPrefix })`
+// primitive — the exact spawn+stderr-pipe+Client+connect ceremony this
+// header describes — and tear down with `closeQuietly(client)`.
+// `runWithWatchdog` is itself just `connectServer` wrapped in the
+// watchdog + exit-code framing, so the framing has one home (rf2-0ogn7).
 
 const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
 const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
 const { ErrorCode, McpError } = require('@modelcontextprotocol/sdk/types.js');
 
 const CLIENT_VERSION = '0.1.0';
+
+// ---------------------------------------------------------------------
+// Shared SDK-spawn primitive (rf2-0ogn7 dedup).
+//
+// Spawn one MCP server over a `StdioClientTransport`, pipe its stderr
+// to ours, construct an SDK `Client` with the pinned conformance
+// identity, and run the `initialize` handshake. Returns the connected
+// `{ client, transport }` for the caller to drive + tear down.
+//
+// `runWithWatchdog` below is the watchdog-wrapped, single-boot-per-
+// process form (it `process.exit`s on every path). But two gates need
+// a SECOND, in-process server boot the watchdog form can't provide:
+//
+//   - `end-to-end-flag-gates.cjs` boots three fresh JVMs in one process
+//     (the gate is a boot-time atom — flipping it needs a new server).
+//   - `live-re-frame2-pair-redaction.cjs` boots a second server with
+//     `--allow-sensitive-reads` to pin the gate-ON direction.
+//
+// Both previously hand-rolled this exact transport+client+stderr-pipe+
+// connect ceremony. Centralising it here means the framing the runner's
+// header documents has ONE home; a caller that needs a bare boot calls
+// `connectServer` + `closeQuietly`, and `runWithWatchdog` itself is just
+// `connectServer` wrapped in the watchdog + exit-code framing.
+//
+//   - `transportSpec`  — `{ command, args, cwd, env }` forwarded to
+//                        `StdioClientTransport` (`stderr: 'pipe'` is
+//                        spliced in here — non-negotiable so CI logs
+//                        surface server stderr on a failing step).
+//   - `clientName`     — the SDK `Client` `name` slot.
+//   - `stderrPrefix`   — bracketed tag prepended to each piped stderr
+//                        line. Defaults to `[server]`; the redaction
+//                        gate-ON arm passes `[server:gate-on]` to keep
+//                        the two concurrent servers' logs distinguishable.
+// ---------------------------------------------------------------------
+async function connectServer({ transportSpec, clientName, stderrPrefix = '[server]' }) {
+  const transport = new StdioClientTransport({ ...transportSpec, stderr: 'pipe' });
+  const client = new Client({ name: clientName, version: CLIENT_VERSION }, { capabilities: {} });
+  // Pipe the child's stderr to ours with the (prefixed) tag. Same shape
+  // every historical caller used; the closure captures the transport
+  // reference cleanly.
+  transport.stderr?.on('data', (d) => process.stderr.write(stderrPrefix + ' ' + d.toString()));
+  // Initialize handshake. SDK validates the result against
+  // InitializeResultSchema; a malformed envelope throws here. On a
+  // connect-throw, tear the half-open transport down before re-throwing
+  // so the spawned child can't leak — the historical inline form reached
+  // the caller's `finally { client.close() }` on this path, and
+  // `client.close()` closes its transport. Mirror that here so callers
+  // need no transport handle to clean up a failed boot.
+  try {
+    await client.connect(transport);
+  } catch (connectErr) {
+    await closeQuietly(client);
+    throw connectErr;
+  }
+  return { client, transport };
+}
+
+// Best-effort `client.close()` that never throws. A close-error is
+// purely cosmetic — it's independent of whatever outcome the caller
+// already recorded — so we log it and swallow it. Shared by every
+// teardown path (the runner's `finally`, the flag-gate per-boot
+// `finally`, the redaction gate-ON arm's `finally`). rf2-0ogn7.
+async function closeQuietly(client) {
+  try {
+    await client.close();
+  } catch (closeErr) {
+    console.error('NOTE: client.close() raised during teardown:', closeErr.message);
+  }
+}
 
 async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) {
   // Install the watchdog FIRST so even a hang inside transport
@@ -69,30 +151,15 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
     process.exit(2);
   }, watchdogMs);
 
-  // `stderr: 'pipe'` is non-negotiable — every conformance test pipes
-  // the server's stderr so CI logs surface the server-side debug
-  // output when a step fails. Splice it in here rather than asking
-  // the caller to remember it.
-  const transport = new StdioClientTransport({ ...transportSpec, stderr: 'pipe' });
-
-  const client = new Client({ name: clientName, version: CLIENT_VERSION }, { capabilities: {} });
-
-  // Pipe the child's stderr to ours with a `[server]` prefix. Same
-  // shape every historical caller used; the closure captures the
-  // transport reference cleanly.
-  transport.stderr?.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
-
-  // Drive `body` to completion, recording its outcome in `exitCode`.
-  // Teardown lives in `finally` so a throw from `client.close()` can't
-  // re-enter the catch and mask the body's success state. Three exit
-  // codes: 0 = body green, 1 = body or initialize threw, 2 = watchdog
-  // (process.exit happens inside the timer callback, never here).
+  // Spawn + connect via the shared primitive. A throw here (bad cwd, a
+  // malformed initialize envelope) is caught below and surfaces as
+  // exit 1, exactly as the historical inline form did.
+  let client;
   let exitCode;
   let bodyError;
   try {
-    // Initialize handshake. SDK validates the result against
-    // InitializeResultSchema; a malformed envelope throws here.
-    await client.connect(transport);
+    let transport;
+    ({ client, transport } = await connectServer({ transportSpec, clientName }));
     await body(client, transport);
     exitCode = 0;
   } catch (err) {
@@ -103,12 +170,9 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
     // outcome: if `client.close()` raises on a green body, we still
     // exit 0 (the conformance assertions passed). If it raises on a
     // failed body, the original `bodyError` is still the load-bearing
-    // signal and the close-error is purely cosmetic.
-    try {
-      await client.close();
-    } catch (closeErr) {
-      console.error('NOTE: client.close() raised during teardown:', closeErr.message);
-    }
+    // signal and the close-error is purely cosmetic. `client` may be
+    // undefined if `connectServer` threw before constructing it.
+    if (client) await closeQuietly(client);
     clearTimeout(watchdog);
     if (bodyError) {
       console.error('FAIL:', bodyError.message);
@@ -323,4 +387,10 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
   }
 }
 
-module.exports = { runWithWatchdog, assertJsonRpcErrorCodes, assertDescriptorShape };
+module.exports = {
+  runWithWatchdog,
+  connectServer,
+  closeQuietly,
+  assertJsonRpcErrorCodes,
+  assertDescriptorShape,
+};

--- a/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
+++ b/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
@@ -71,12 +71,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const {
-  Client,
-} = require('@modelcontextprotocol/sdk/client/index.js');
-const {
-  StdioClientTransport,
-} = require('@modelcontextprotocol/sdk/client/stdio.js');
+const { connectServer, closeQuietly } = require('./_runner.cjs');
 const { resolveTrustedExe } = require('../lib/exec-safety.cjs');
 
 const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
@@ -102,7 +97,6 @@ const FIXTURE_BODY_EDN = '{:doc "flag-gate conformance probe." :tags #{:dev}}';
 // MCP surface, which is exactly the point). Three sequential boots fit
 // comfortably under the watchdog with margin.
 const WATCHDOG_MS = 180000;
-const CLIENT_VERSION = '0.1.0';
 
 // ---------------------------------------------------------------------------
 // Boot one story-mcp server with the given extra CLI args, run `body`
@@ -111,35 +105,25 @@ const CLIENT_VERSION = '0.1.0';
 //
 // Each call spawns a fresh JVM so the boot-time gate atom reflects ONLY
 // the args passed here — no cross-contamination between the default-OFF,
-// opt-in, and rename-rejection probes.
+// opt-in, and rename-rejection probes. The spawn+connect+teardown
+// ceremony is the shared `connectServer` / `closeQuietly` primitive
+// (rf2-0ogn7) — `runWithWatchdog`'s single-boot-per-process form can't
+// serve this gate, which needs three fresh in-process JVM boots.
 // ---------------------------------------------------------------------------
 async function withStoryServer(extraArgs, body) {
-  const transport = new StdioClientTransport({
-    command: CLOJURE,
-    args: ['-M', '-m', 're-frame.story-mcp.server', ...extraArgs],
-    cwd: STORY_MCP_CWD,
-    env: { ...process.env },
-    stderr: 'pipe',
+  const { client } = await connectServer({
+    clientName: 'mcp-conformance-flag-gates',
+    transportSpec: {
+      command: CLOJURE,
+      args: ['-M', '-m', 're-frame.story-mcp.server', ...extraArgs],
+      cwd: STORY_MCP_CWD,
+      env: { ...process.env },
+    },
   });
-  const client = new Client(
-    { name: 'mcp-conformance-flag-gates', version: CLIENT_VERSION },
-    { capabilities: {} },
-  );
-  transport.stderr?.on('data', (d) =>
-    process.stderr.write('[server] ' + d.toString()),
-  );
-  await client.connect(transport);
   try {
     return await body(client);
   } finally {
-    try {
-      await client.close();
-    } catch (closeErr) {
-      console.error(
-        'NOTE: client.close() raised during teardown:',
-        closeErr.message,
-      );
-    }
+    await closeQuietly(client);
   }
 }
 

--- a/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
@@ -72,15 +72,21 @@
 // (same as the sibling harness). Exits 0 on success or SKIP. Exits 1
 // on any conformance violation.
 
-// ## DRY-on-3 trigger (rf2-1bwph)
+// ## DRY-on-3 resolution (rf2-1bwph → rf2-0ogn7)
 //
-// This file and its sibling `live-re-frame2-pair-subscribe.cjs` share
-// LIVE-specific fixture setup (nREPL gating via $SHADOW_CLJS_NREPL_PORT,
-// SDK Client construction against the spawned server, watchdog ceremony).
-// The shared `_runner.cjs` already covers the common SDK-spawn ceremony.
-// We deliberately do NOT factor the LIVE-specific setup at 2 files —
-// factoring at 2 is premature; the right shape only emerges at 3. When a
-// 3rd `live-*` script lands, lift the shared bits per rf2-1bwph.
+// This file and its `live-re-frame2-pair-*.cjs` siblings (subscribe,
+// redaction) share the nREPL SKIP-gate (via $SHADOW_CLJS_NREPL_PORT) and
+// the SDK-spawn ceremony. Both are now factored: the SKIP gate routes
+// through `runWithWatchdog.skip`, and the spawn+connect+teardown ceremony
+// is `_runner.cjs`'s `connectServer` / `closeQuietly` (the redaction arm's
+// second-server boot uses it directly). What is NOT shared — by design —
+// is each variant's data-driven field validator (`REQUIRED_FIELDS` +
+// `assertOverflowBody` here; `REQUIRED_PARAMS` + `assertProgressParams` in
+// subscribe). Each pins a DISTINCT Malli schema (`ReFrame2PairOverflowBody`
+// vs `ReFrame2PairProgressNotificationParams`) and the JVM cross-encoding
+// gate in `wire_vocab_test.clj` greps each function's literal source rows
+// by name — collapsing them into one generic helper would dissolve that
+// per-schema attribution and weaken the conformance contract.
 
 const path = require('node:path');
 const os = require('node:os');

--- a/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
@@ -68,9 +68,7 @@
 
 const path = require('node:path');
 const os = require('node:os');
-const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
-const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
-const { runWithWatchdog } = require('./_runner.cjs');
+const { runWithWatchdog, connectServer, closeQuietly } = require('./_runner.cjs');
 
 const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
 
@@ -311,21 +309,21 @@ if (!process.env.SHADOW_CLJS_NREPL_PORT) {
 // would pass a gate-OFF-only test but break the operator's deliberate
 // raw-state read.
 async function runGateOnArm() {
-  const transport = new StdioClientTransport({
-    command: process.execPath,
-    args: [SERVER, '--allow-sensitive-reads'],
-    cwd: os.tmpdir(),
-    env: { ...process.env },
-    stderr: 'pipe',
+  // Stand up the second server via the shared spawn+connect primitive
+  // (rf2-0ogn7). The `[server:gate-on]` stderr prefix keeps this
+  // concurrent boot's logs distinguishable from the runner-managed
+  // gate-OFF server's `[server]` lines.
+  const { client } = await connectServer({
+    clientName: 'mcp-conformance-re-frame2-pair-redaction-gate-on',
+    stderrPrefix: '[server:gate-on]',
+    transportSpec: {
+      command: process.execPath,
+      args: [SERVER, '--allow-sensitive-reads'],
+      cwd: os.tmpdir(),
+      env: { ...process.env },
+    },
   });
-  const client = new Client(
-    { name: 'mcp-conformance-re-frame2-pair-redaction-gate-on', version: '0.1.0' },
-    { capabilities: {} },
-  );
-  transport.stderr?.on('data', (d) => process.stderr.write('[server:gate-on] ' + d.toString()));
   try {
-    await client.connect(transport);
-
     // Same seed: enable epoch recording, declare the sensitive slot, and
     // write the sentinel into app-db on this server's runtime.
     await seedRuntime(client, 'gate-on');
@@ -362,7 +360,7 @@ async function runGateOnArm() {
     }
     console.log('OK   gate-ON watch-epochs (+:include-sensitive) -> sentinel SHIPS (opt-in honoured)');
   } finally {
-    try { await client.close(); } catch (_e) { /* best-effort */ }
+    await closeQuietly(client);
   }
 }
 

--- a/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
@@ -58,15 +58,22 @@
 // (`scripts/run-live-re-frame2-pair-overflow-hermetic.cjs`) wires the env when
 // run as part of the hermetic suite.
 
-// ## DRY-on-3 trigger (rf2-1bwph)
+// ## DRY-on-3 resolution (rf2-1bwph → rf2-0ogn7)
 //
-// This file and its sibling `live-re-frame2-pair-overflow.cjs` share
-// LIVE-specific fixture setup (nREPL gating via $SHADOW_CLJS_NREPL_PORT,
-// SDK Client construction against the spawned server, watchdog ceremony).
-// The shared `_runner.cjs` already covers the common SDK-spawn ceremony.
-// We deliberately do NOT factor the LIVE-specific setup at 2 files —
-// factoring at 2 is premature; the right shape only emerges at 3. When a
-// 3rd `live-*` script lands, lift the shared bits per rf2-1bwph.
+// This file and its `live-re-frame2-pair-*.cjs` siblings (overflow,
+// redaction) share the nREPL SKIP-gate (via $SHADOW_CLJS_NREPL_PORT) and
+// the SDK-spawn ceremony. Both are now factored: the SKIP gate routes
+// through `runWithWatchdog.skip`, and the spawn+connect+teardown ceremony
+// is `_runner.cjs`'s `connectServer` / `closeQuietly` (the redaction arm's
+// second-server boot uses it directly). What is NOT shared — by design —
+// is each variant's data-driven field validator (`REQUIRED_PARAMS` /
+// `REQUIRED_DATA` + `assertProgressParams` here; `REQUIRED_FIELDS` +
+// `assertOverflowBody` in overflow). Each pins a DISTINCT Malli schema
+// (`ReFrame2PairProgressNotificationParams` vs `ReFrame2PairOverflowBody`)
+// and the JVM cross-encoding gate in `wire_vocab_test.clj` greps each
+// function's literal source rows by name — collapsing them into one
+// generic helper would dissolve that per-schema attribution and weaken
+// the conformance contract.
 
 const path = require('node:path');
 const os = require('node:os');


### PR DESCRIPTION
## What

DRY-reduction review of `tools/mcp-conformance/` (rf2-0ogn7). One genuine duplication found and consolidated; the rest of the slice is appropriately DRY.

## The duplication

`_runner.cjs` documents (in its header) the transport+client+stderr-pipe+connect+close ceremony as the boilerplate it exists to eliminate via `runWithWatchdog`. But `runWithWatchdog` `process.exit()`s on every path, so it cannot serve a gate that needs a **second in-process server boot**. Two gates hand-rolled that exact ceremony to work around this:

- `end-to-end-flag-gates.cjs` → `withStoryServer` (three fresh JVM boots, one per gate-posture probe — the gate is a boot-time atom)
- `live-re-frame2-pair-redaction.cjs` → `runGateOnArm` (a `--allow-sensitive-reads` server for the gate-ON direction)

Both re-implemented `new StdioClientTransport({...stderr:'pipe'})` + `new Client({name, version:'0.1.0'}, {capabilities:{}})` + `transport.stderr?.on('data', ...)` + `client.connect` + `try/finally{ client.close() }` inline.

## The fix

Extract two primitives into `_runner.cjs` (file:line):

- `connectServer({ transportSpec, clientName, stderrPrefix })` — `_runner.cjs:105` — spawn + stderr-pipe + Client + initialize handshake; returns `{ client, transport }`. Tears down its half-open transport on a connect-throw so a failed boot can't leak the child.
- `closeQuietly(client)` — `_runner.cjs:123` — best-effort `client.close()` that logs + swallows.

`runWithWatchdog` (`_runner.cjs:131`) now delegates to both, so the spawn framing has one home. The two hand-rolled call sites consume the shared pair; the redaction gate-ON arm passes `stderrPrefix: '[server:gate-on]'` to keep the two concurrent servers' logs distinguishable. Removes the duplicated SDK imports + per-boot `CLIENT_VERSION` constant from the two gates.

## What is deliberately NOT consolidated

The per-schema field validators — `REQUIRED_FIELDS`/`assertOverflowBody` (overflow) and `REQUIRED_PARAMS`/`REQUIRED_DATA`/`assertProgressParams` (subscribe) — look like the same data-driven pattern but each pins a **distinct** Malli schema, and the JVM cross-encoding gate in `wire_vocab_test.clj` greps each function's literal source rows **by name** (`js-assertOverflowBody-pins-every-...`, `js-assertProgressParams-pins-every-...`). Collapsing them into one generic helper would dissolve that per-schema attribution and weaken the conformance contract. The stale rf2-1bwph "DRY-on-3 trigger" comments in the two non-redaction live-* files are refreshed to record this resolution.

The CLJ side (`wire-vocab/`) is already well-deduped into a shared `fixtures.clj` (rf2-113ti / rf2-rto1l / rf2-zvv65 / rf2-qnmne / rf2-re2tv); `lib/dedup-envelope.cjs`, `lib/exec-safety.cjs`, and the `test-all.cjs` orchestrator are single-source. No further consolidation warranted.

## Gate (cold)

- `node scripts/test-all.cjs` — GREEN: exec-safety + pair end-to-end + 3 live SKIPs + story end-to-end + flag-gates (all exit 0).
- wire-vocab `clojure -M:test` — GREEN: 49 tests, 629 assertions, 0 failures.
- `connectServer` / `closeQuietly` + custom `stderrPrefix` verified directly against the compiled pair server bundle.

Behaviour-preserving; no conformance assertion weakened.
