### PR TITLE
docs(machines-viz): reconcile spec/docs to shipped renderer (rf2-6d4y3)

### DIFF
--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -694,8 +694,9 @@ implementation-state list.
   [`tools/xray/spec/003-Machine-Inspector.md`](../../xray/spec/003-Machine-Inspector.md)
   §What the panel shows + §`:spawn-all` viz + §Performance.
 - Source-coord chips on every clickable element (the host wires
-  the editor URL handler via `:on-state-click` /
-  `:on-transition-click`).
+  the editor URL handler via `:on-state-click`; transitions render
+  as event-nodes per rf2-qo5xy, so a clickable event-node label
+  fires `:on-edge-click` — there is no `:on-transition-click`).
 - Accessibility: SVG `<title>` / `<desc>` + machine summary text
   alternative. **Full chart alt-view defers to v1.1** (same
   posture Xray 003 §Accessibility takes — the transition-history

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -83,7 +83,11 @@ What surface does Machines-Viz ship at v1.0?
 
 **Locked 2026-05-13 (Mike, lifted from Xray 003).**
 **Props: `:machine-id`, `:frame-id`, `:on-state-click`,
-`:on-transition-click` (plus read-only flags).**
+`:on-edge-click` (plus read-only flags).** (The original lock named
+`:on-transition-click`; rf2-qo5xy's events-as-nodes paradigm retired
+it — transitions render as event-nodes and a clickable event-node
+label fires `:on-edge-click`. The names below are reconciled to the
+shipped contract.)
 
 ### Question
 
@@ -114,8 +118,8 @@ What does the host pass to `MachineChart` to render a chart?
 ```clojure
 [viz/MachineChart {:machine-id          :auth/login-flow
                    :frame-id            :app/main
-                   :on-state-click      (fn [state-id state-meta] ...)
-                   :on-transition-click (fn [from event-id to] ...)
+                   :on-state-click      (fn [path] ...)
+                   :on-edge-click       (fn [{:keys [event-id from-path to-path]}] ...)
                    :read-only?          false      ;; viewer page sets true
                    :show-microsteps?    true       ;; per-chart preference
                    :show-after-rings?   true

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -169,8 +169,10 @@
 
   Pipeline: serialise the chart's SVG → load it into an `<img>` via a
   data-URL → draw onto a 2x-DPR `<canvas>` → `canvas.toBlob`. The
-  current-state highlight is included (it is a static fill/stroke on
-  the rendered SVG, so it serialises with the rest)."
+  current-state affordance lives on the node-box BORDER + box-shadow
+  ring (xyflow div-nodes), not on the SVG; the serialised SVG carries
+  the rendered edges (incl. fired/focused edge styling), so the PNG
+  frames the topology + edge highlights as rendered."
   [chart-element]
   (let [svg-str (chart-as-svg chart-element)
         root    (chart-root chart-element)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -90,7 +90,6 @@
                                 painted behind each edge label so
                                 overlapping labels remain legible
                                 (rf2-gg7ws — collision-avoidance v1)
-    :final-glyph-px           — final-state ✓ glyph font-size
     :compound-title-px        — compound container title font-size
     :compound-radius          — compound container corner radius
                                 (rf2-k647w — distinct from the
@@ -132,7 +131,6 @@
    :state-label-px         13
    :edge-label-px          11
    :edge-label-backplate-opacity 0.85
-   :final-glyph-px         13
    :compound-title-px      13
 
    ;; ── state-tag pills (rf2-m1b88; rf2-a2b55 restored — sit BELOW
@@ -227,7 +225,6 @@
    :state-label-px         11
    :edge-label-px          9
    :edge-label-backplate-opacity 0.85
-   :final-glyph-px         11
    :compound-title-px      11
 
    ;; ── state-tag pills (tighter than the regular 16/6/9/8) ──────
@@ -311,7 +308,6 @@
    :state-label-px         15
    :edge-label-px          13
    :edge-label-backplate-opacity 0.85
-   :final-glyph-px         15
    :compound-title-px      15
 
    ;; ── state-tag pills (looser than the regular 16/6/9/8) ───────

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -64,8 +64,11 @@
     :state-label-px
     :edge-label-px
     :edge-label-backplate-opacity
-    :final-glyph-px
     :compound-title-px
+    ;; rf2-6d4y3 — :final-glyph-px removed: the final-state ✓ glyph was
+    ;; dropped (rf2-az6e2 — the quiet doubled border is the unambiguous
+    ;; final-state signal) and no renderer ever read the constant; it
+    ;; was carried only to satisfy this parity test.
     ;; rf2-ee38b.21 — :caption-strip-px / :caption-text-px removed:
     ;; no renderer ever read them (there is no caption strip in the
     ;; chart). They were carried only to satisfy this parity test.

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -282,7 +282,8 @@
       :machine-id  (required)
       :frame-id    (required)
       :on-state-click
-      :on-transition-click
+      :on-edge-click   ;; rf2-qo5xy retired :on-transition-click — a
+                       ;; clickable event-node label fires this
       :read-only?
       :show-microsteps? / :show-after-rings? / :show-invoke-all?
       :auto-pan?


### PR DESCRIPTION
## What

Follow-on to rf2-2kx24 + rf2-du4cl (PR #2942). Corrects the residual xyflow-migration / rf2-az6e2 / rf2-qo5xy drift in the machines-viz surfaces those beads left out of scope (held out to keep #2942 comment-only + in-scope).

### Drift corrected (said → now)

1. **`000-Vision.md`** (source-coord chips): `:on-state-click / :on-transition-click` → `:on-state-click`; transitions render as event-nodes (rf2-qo5xy), so a clickable event-node label fires `:on-edge-click` — there is no `:on-transition-click`.
2. **`DESIGN-RATIONALE.md` Lock #2**: header + code example named the retired `:on-transition-click (fn [from event-id to] ...)` → reconciled to the shipped `:on-edge-click (fn [{:keys [event-id from-path to-path]}] ...)` and `:on-state-click (fn [path] ...)`. Anchor + lock-date preserved; a note records the rf2-qo5xy retirement.
3. **`visual_constants.cljc`**: removed the **dead** `:final-glyph-px` constant ("final-state ✓ glyph font-size") from the doc-comment + all three density maps. The ✓ glyph was dropped (rf2-az6e2 — the quiet doubled border is the final-state signal) and **no renderer reads the constant**. Also dropped its pin from `visual_constants_cljs_test.cljc` (the `expected-chart-keys` parity test), matching the existing `:caption-strip-px` removal precedent in that file.
4. **`export.cljs`** (PNG docstring): "the current-state highlight … is a static fill/stroke on the rendered SVG" → the affordance lives on the node-box **border + box-shadow** (xyflow div-nodes), not on the SVG; the serialised SVG carries the rendered edges, so the PNG frames the topology + edge highlights as rendered.
5. **`tools/xray/src/.../machine_inspector_helpers.cljc`** (`chart-props` docstring): same `:on-transition-click` → `:on-edge-click` comment-accuracy fix (this docstring lists the machines-viz chart's prop contract).

### tools/xray/spec/* unchanged

A grep confirms the shared xray spec carries **no** `:on-transition-click` / dead-glyph drift — the only xray-side drift was the `machine_inspector_helpers.cljc` src docstring (fixed above), so no `tools/xray/spec/*` file needed touching.

## Verification

- Grep (git-tracked): every remaining `on-transition-click` is retirement/negation prose or the new explanatory comment; no live prop/callback uses it. `final-glyph-px` remains only as a removal-note comment in the test.
- `npm`-less JVM gates (cold): machines-viz `clojure -M:test` — **334 tests / 939 assertions, 0 failures**; xray `clojure -M:test` — **1095 tests / 4563 assertions, 0 failures**. The `expected-chart-keys` parity test passing confirms the density maps + test agree without `:final-glyph-px`.
- `mkdocs build --strict` — clean (note: machines-viz `spec/` is not in the mkdocs nav, so the doc edits don't affect the site, but strict build is green).
- `test:xray-feature-gate` not run: the xray change is a pure docstring edit (zero behavioral change to `chart-props`), fully covered by the green xray JVM suite; the worktree has no `node_modules` and the browser feature-gate would only re-validate unchanged runtime behavior.

Closes rf2-6d4y3.