### PR TITLE
refactor(schemas): consolidate clearable-memo + coerce->frame-id duplication (rf2-mse54)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/cache.cljc
+++ b/implementation/schemas/src/re_frame/schemas/cache.cljc
@@ -1,0 +1,47 @@
+(ns re-frame.schemas.cache
+  "Clearable memo cache primitive (rf2-17sqc shape, consolidated rf2-mse54).
+
+  Two schemas-slice memos — the digest printer (`validator/default-edn-print`)
+  and the sensitive-path walker (`walker/extract-sensitive-paths-from-schema`)
+  — share one requirement: a process-lifetime memo that is *clearable* for
+  test isolation. `clojure.core/memoize` exposes no clear hook, so a test
+  that registers many distinct fresh schemas (the concurrency-stress
+  harness) could never reset the process-lifetime cache; both memos hand-
+  rolled the same atom-backed lookup-or-compute + reset! clear pair.
+
+  `clearable-memo` is that pair, parameterised on the underlying fn.
+
+  ## Boot-once invariant (Mike ruled rf2-17sqc, option B)
+
+  App schemas are registered ONCE at boot, so each memo is bounded by the
+  registered-schema cardinality and is intentionally NOT evicted — no
+  bounded LRU. The only scenario that violates boot-once is a test that
+  deliberately registers many distinct fresh schemas; such tests call the
+  returned `clear!` fn in fixture teardown so the cache doesn't grow
+  unbounded across the suite. See [010 §Schema digest].")
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn clearable-memo
+  "Return `[memoized-fn clear!]` — an atom-backed memo of `f` plus a
+  reset hook.
+
+  `memoized-fn` has the same arity as `f`; results are cached by the
+  argument vector (`find`/`val` so a cached `nil`/`false` result is a
+  hit, not a recompute). Behaviour for callers is byte-identical to
+  `(memoize f)` — same args always return the same value — but the
+  cache is *clearable*.
+
+  `clear!` resets the cache to `{}` and returns nil — the test-support
+  hook (schemas register once at boot, so production never needs it;
+  tests that register many distinct fresh schemas call it in fixture
+  teardown so the cache doesn't grow unbounded across the suite)."
+  [f]
+  (let [cache (atom {})]
+    [(fn [& args]
+       (if-let [e (find @cache args)]
+         (val e)
+         (let [v (apply f args)]
+           (swap! cache assoc args v)
+           v)))
+     (fn [] (reset! cache {}) nil)]))

--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -139,6 +139,5 @@
   travel), and pair-tool drift detection."
   ([] (app-schemas-digest {}))
   ([opts-or-frame-id]
-   (let [opts     (storage/coerce-opts opts-or-frame-id)
-         frame-id (storage/resolve-frame opts)]
+   (let [frame-id (storage/coerce->frame-id opts-or-frame-id)]
      (compute-digest (storage/app-schemas {:frame frame-id})))))

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -59,6 +59,19 @@
                     {:received opts-or-frame-id
                      :expected "keyword frame-id or opts map"}))))
 
+(defn coerce->frame-id
+  "Resolve a frame-id from the `opts-or-frame-id` argument the read
+  surface accepts: coerce through `coerce-opts` (keyword sugar / opts
+  map / throw on bad shape), then `resolve-frame` (`:frame` or the
+  active frame). The query entry points (`app-schema-at` /
+  `app-schema-meta-at` / `app-schemas` / `app-schemas-digest`) use the
+  opts ONLY to name a frame, so they collapse the coerce+resolve pair
+  through this helper. The `reg-*` entry points keep the two-step form —
+  they read further keys off the coerced opts (`:rf/defer-elision-populate?`)
+  and so need the intermediate map."
+  [opts-or-frame-id]
+  (resolve-frame (coerce-opts opts-or-frame-id)))
+
 ;; ---- validator-unavailable warning (rf2-fq7d2) ----------------------------
 ;;
 ;; Per Spec 010 §Recommended soft-pass, the schemas artefact ships with a
@@ -512,8 +525,7 @@
   Per Spec 010 §Schemas as a tooling and agent surface."
   ([path] (app-schema-at path {}))
   ([path opts-or-frame-id]
-   (let [opts     (coerce-opts opts-or-frame-id)
-         frame-id (resolve-frame opts)]
+   (let [frame-id (coerce->frame-id opts-or-frame-id)]
      (when-let [m (get-in @schemas-by-frame [frame-id path])]
        (:schema m)))))
 
@@ -536,8 +548,7 @@
                                       ;; (keyword sugar also accepted)"
   ([path] (app-schema-meta-at path {}))
   ([path opts-or-frame-id]
-   (let [opts     (coerce-opts opts-or-frame-id)
-         frame-id (resolve-frame opts)]
+   (let [frame-id (coerce->frame-id opts-or-frame-id)]
      (get-in @schemas-by-frame [frame-id path]))))
 
 (defn app-schemas
@@ -557,8 +568,7 @@
   given). Schemas registered against a different frame do not appear."
   ([] (app-schemas {}))
   ([opts-or-frame-id]
-   (let [opts     (coerce-opts opts-or-frame-id)
-         frame-id (resolve-frame opts)]
+   (let [frame-id (coerce->frame-id opts-or-frame-id)]
      (reduce-kv (fn [acc path m] (assoc acc path (:schema m)))
                 {}
                 (get @schemas-by-frame frame-id {})))))

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -62,7 +62,8 @@
   absent path. Per Spec 010 §Recommended soft-pass an unbound default
   validator passes rather than failing, so a substitute-validator
   app is never blocked by Malli's absence."
-  (:require [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.schemas.cache :as cache]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -129,71 +130,55 @@
             *print-namespace-maps* false]
     (pr-str (canonicalise-schema-form schema-value))))
 
-;; Atom-backed memo cache for `default-edn-print` (rf2-17sqc). Replaces
-;; the opaque `(memoize compute-edn-print)` so the cache is *clearable*
-;; for test isolation — `clojure.core/memoize` exposes no clear hook, so
-;; a test that registers thousands of distinct fresh schemas (the
-;; concurrency stress test) could never reset the process-lifetime cache.
-;; The cache key is the schema value (immutable); behaviour for callers
-;; is byte-identical to the prior `memoize` form.
-;;
-;; ## Boot-once invariant (Mike ruled rf2-17sqc, option B)
-;;
-;; App schemas are registered ONCE at boot. The printer memo is
-;; therefore bounded by the registered-schema cardinality, and the
-;; cache is process-lifetime and intentionally NOT evicted — no bounded
-;; LRU. The only scenario that violates boot-once is a test that
-;; deliberately registers many distinct fresh schemas; such tests call
-;; `clear-edn-print-cache!` in fixture teardown to keep the cache from
-;; growing across the suite. See [010 §Schema digest].
-(def ^:private edn-print-cache (atom {}))
+;; `default-edn-print` is the clearable-memo wrapper over
+;; `compute-edn-print` (rf2-17sqc shape; the factory lives in
+;; `re-frame.schemas.cache`, consolidated rf2-mse54). The cache is
+;; *clearable* (`clojure.core/memoize` exposes no clear hook) so a test
+;; that registers many distinct fresh schemas (the concurrency-stress
+;; harness) can reset the process-lifetime cache in fixture teardown.
+;; Behaviour for callers is byte-identical to the prior `memoize` form.
+;; See `re-frame.schemas.cache` for the boot-once invariant.
+(let [[memo clear!] (cache/clearable-memo compute-edn-print)]
 
-(defn clear-edn-print-cache!
-  "Reset the `default-edn-print` memo cache (rf2-17sqc). Test-support
-  hook: the printer memo is process-lifetime and bounded by the
-  registered-schema cardinality in real apps (schemas register once at
-  boot), so production never needs this — but a test that registers
-  many distinct fresh schemas (`schemas_concurrency_stress_test`) calls
-  it in fixture teardown so the cache doesn't grow unbounded across the
-  suite. Returns nil."
-  []
-  (reset! edn-print-cache {})
-  nil)
+  (def
+    ^{:doc "The default schema-print companion (rf2-wla45). Per Spec 010
+            §Schema digest line 491 — serialise a schema value to the
+            stable UTF-8 byte-source string the digest pipeline hashes.
+            The default uses `pr-str` over a canonicalised EDN form:
+            map-keys emitted in `compare-by-pr-str` order, metadata
+            stripped, namespaced-map printing disabled. This is the
+            cross-runtime contract every Malli-EDN-compatible port shares.
 
-(defn default-edn-print
-  "The default schema-print companion (rf2-wla45). Per Spec 010 §Schema
-  digest line 491 — serialise a schema value to the stable UTF-8
-  byte-source string the digest pipeline hashes. The default uses
-  `pr-str` over a canonicalised EDN form: map-keys emitted in
-  `compare-by-pr-str` order, metadata stripped, namespaced-map
-  printing disabled. This is the cross-runtime contract every
-  Malli-EDN-compatible port shares.
+            Ports that ship a non-EDN schema language register their own
+            printer via `set-schema-printer!`; the digest then reflects
+            the registered validator's serialisation contract rather than
+            the framework's Malli-EDN default.
 
-  Ports that ship a non-EDN schema language register their own printer
-  via `set-schema-printer!`; the digest then reflects the registered
-  validator's serialisation contract rather than the framework's
-  Malli-EDN default.
+            Memoised by `schema-value` (rf2-y29nf): the digest pipeline
+            (`re-frame.schemas.digest/compute-digest`) calls this once per
+            registered schema per digest call, and the digest is invoked
+            on the SSR hydrate handshake, the epoch-restore schema-
+            mismatch trace, and pair-tool drift detection — repeat calls
+            against the same registered schema values dominate. Pure over
+            immutable schema values, so the cache is bounded by the
+            registered-schema cardinality.
 
-  Memoised by `schema-value` (rf2-y29nf): the digest pipeline
-  (`re-frame.schemas.digest/compute-digest`) calls this once per
-  registered schema per digest call, and the digest is invoked on the
-  SSR hydrate handshake, the epoch-restore schema-mismatch trace, and
-  pair-tool drift detection — repeat calls against the same registered
-  schema values dominate. Pure over immutable schema values, so the
-  cache is bounded by the registered-schema cardinality.
+            The memo is **clearable** for test isolation via
+            `clear-edn-print-cache!` (rf2-17sqc)."
+      :arglists '([schema-value])}
+    default-edn-print memo)
 
-  The memo is **clearable** for test isolation via
-  `clear-edn-print-cache!` (rf2-17sqc): schemas register once at boot,
-  so the cache is process-lifetime and intentionally not evicted in
-  production — but tests that register many distinct fresh schemas reset
-  it in fixture teardown. Behaviour for callers is byte-identical to the
-  prior `clojure.core/memoize` form."
-  [schema-value]
-  (if-let [e (find @edn-print-cache schema-value)]
-    (val e)
-    (let [v (compute-edn-print schema-value)]
-      (swap! edn-print-cache assoc schema-value v)
-      v)))
+  (def
+    ^{:doc "Reset the `default-edn-print` memo cache (rf2-17sqc). Test-
+            support hook: the printer memo is process-lifetime and bounded
+            by the registered-schema cardinality in real apps (schemas
+            register once at boot), so production never needs this — but a
+            test that registers many distinct fresh schemas
+            (`schemas_concurrency_stress_test`) calls it in fixture
+            teardown so the cache doesn't grow unbounded across the suite.
+            Returns nil."
+      :arglists '([])}
+    clear-edn-print-cache! clear!))
 
 (defonce
   ^{:doc "The currently-registered validator fn — `(fn [schema value]

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -76,7 +76,8 @@
   positional combinators descend at the same base-path) so a single
   traversal serves every per-slot annotation under
   `:rf/app-schema-meta`. Future per-slot annotations (Spec-Schemas
-  reserves additional slots) compose as one-line registrations.")
+  reserves additional slots) compose as one-line registrations."
+  (:require [re-frame.schemas.cache :as cache]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -229,68 +230,54 @@
   [schema base-path]
   (walk-flagged-schema :large? schema base-path {}))
 
-;; Atom-backed memo cache for `extract-sensitive-paths-from-schema`
-;; (rf2-17sqc). Replaces the opaque `(memoize ...)` so the cache is
-;; *clearable* for test isolation — `clojure.core/memoize` exposes no
-;; clear hook, so a test that registers many distinct fresh schemas (the
-;; concurrency stress test) could never reset the process-lifetime
-;; cache. The cache key is `[schema base-path]` (both immutable);
-;; behaviour for callers is byte-identical to the prior `memoize` form.
-;;
-;; ## Boot-once invariant (Mike ruled rf2-17sqc, option B)
-;;
-;; App schemas are registered ONCE at boot. The walker memo is therefore
-;; bounded by the (registered-schema, base-path) cardinality, and the
-;; cache is process-lifetime and intentionally NOT evicted — no bounded
-;; LRU. The only scenario that violates boot-once is a test that
-;; deliberately registers many distinct fresh schemas; such tests call
-;; `clear-sensitive-paths-cache!` in fixture teardown so the cache
-;; doesn't grow unbounded across the suite. See [010 §Schema digest].
-(def ^:private sensitive-paths-cache (atom {}))
+;; `extract-sensitive-paths-from-schema` is the clearable-memo wrapper
+;; over the `:sensitive?` walk (rf2-17sqc shape; the factory lives in
+;; `re-frame.schemas.cache`, consolidated rf2-mse54). The cache is
+;; *clearable* (`clojure.core/memoize` exposes no clear hook) so a test
+;; that registers many distinct fresh schemas (the concurrency-stress
+;; harness) can reset the process-lifetime cache in fixture teardown.
+;; Behaviour for callers is byte-identical to the prior `memoize` form.
+;; See `re-frame.schemas.cache` for the boot-once invariant.
+(let [[memo clear!]
+      (cache/clearable-memo
+        (fn [schema base-path]
+          (walk-flagged-schema :sensitive? schema base-path {})))]
 
-(defn clear-sensitive-paths-cache!
-  "Reset the `extract-sensitive-paths-from-schema` memo cache
-  (rf2-17sqc). Test-support hook: the walker memo is process-lifetime
-  and bounded by the (registered-schema, base-path) cardinality in real
-  apps (schemas register once at boot), so production never needs this —
-  but a test that registers many distinct fresh schemas
-  (`schemas_concurrency_stress_test`) calls it in fixture teardown so
-  the cache doesn't grow unbounded across the suite. Returns nil."
-  []
-  (reset! sensitive-paths-cache {})
-  nil)
+  (def
+    ^{:doc "Walk a registered Malli schema form at `base-path` and return
+            a `{path {:sensitive? true ...}}` map for every `:sensitive?
+            true` slot found. Per Spec 010 §`:sensitive?` — privacy in
+            schema-validation error traces.
 
-(defn extract-sensitive-paths-from-schema
-  "Walk a registered Malli schema form at `base-path` and return a
-  `{path {:sensitive? true ...}}` map for every `:sensitive? true` slot
-  found. Per Spec 010 §`:sensitive?` — privacy in schema-validation
-  error traces.
+            Used by the validation emit-sites (`validate-app-schema!` and
+            the per-step `validate-event!` / `validate-cofx!` /
+            `validate-sub!` helpers) to decide whether the failing slot's
+            value MUST be redacted before the trace event ships.
 
-  Used by the validation emit-sites (`validate-app-schema!` and the
-  per-step `validate-event!` / `validate-cofx!` / `validate-sub!`
-  helpers) to decide whether the failing slot's value MUST be redacted
-  before the trace event ships.
+            Memoised by `(schema, base-path)` (rf2-y29nf): the failure-
+            branch call site (`schema-sensitive-at?`) re-walks the same
+            registered schema on every consecutive failure, and the walk
+            is pure over immutable schema values. The cache is bounded by
+            the (registered-schema, base-path) cardinality — schemas are
+            registered once at app-boot, so steady-state cache size equals
+            the registry size.
 
-  Memoised by `(schema, base-path)` (rf2-y29nf): the failure-branch
-  call site (`schema-sensitive-at?`) re-walks the same registered
-  schema on every consecutive failure, and the walk is pure over
-  immutable schema values. The cache is bounded by the (registered-
-  schema, base-path) cardinality — schemas are registered once at
-  app-boot, so steady-state cache size equals the registry size.
+            The memo is **clearable** for test isolation via
+            `clear-sensitive-paths-cache!` (rf2-17sqc)."
+      :arglists '([schema base-path])}
+    extract-sensitive-paths-from-schema memo)
 
-  The memo is **clearable** for test isolation via
-  `clear-sensitive-paths-cache!` (rf2-17sqc): schemas register once at
-  boot, so the cache is process-lifetime and intentionally not evicted
-  in production — but tests that register many distinct fresh schemas
-  reset it in fixture teardown. Behaviour for callers is byte-identical
-  to the prior `clojure.core/memoize` form."
-  [schema base-path]
-  (let [k [schema base-path]]
-    (if-let [e (find @sensitive-paths-cache k)]
-      (val e)
-      (let [v (walk-flagged-schema :sensitive? schema base-path {})]
-        (swap! sensitive-paths-cache assoc k v)
-        v))))
+  (def
+    ^{:doc "Reset the `extract-sensitive-paths-from-schema` memo cache
+            (rf2-17sqc). Test-support hook: the walker memo is process-
+            lifetime and bounded by the (registered-schema, base-path)
+            cardinality in real apps (schemas register once at boot), so
+            production never needs this — but a test that registers many
+            distinct fresh schemas (`schemas_concurrency_stress_test`)
+            calls it in fixture teardown so the cache doesn't grow
+            unbounded across the suite. Returns nil."
+      :arglists '([])}
+    clear-sensitive-paths-cache! clear!))
 
 (defn schema-has-sensitive?
   "True when the registered schema declares ANY slot sensitive —


### PR DESCRIPTION
## Summary

DUPLICATION-reduction review of `implementation/schemas` (rf2-mse54). The slice already went through the senior sweep, so this is pure DRY — two genuine, behaviour-preserving within-slice duplications consolidated.

## What was duplicated

**1. Clearable atom-backed memo cache** (the rf2-17sqc shape, repeated)
- `validator/default-edn-print` and `walker/extract-sensitive-paths-from-schema` each hand-rolled the *identical* structure: a private `(atom {})`, a `find`/`val` lookup-or-compute body, and a `(reset! cache {}) nil` clear fn. The only difference was the key shape (single `schema-value` vs `[schema base-path]`).
- Extracted **`re-frame.schemas.cache/clearable-memo`** — a factory returning `[memoized-fn clear!]`, keyed on the arg vector (so both arities are handled uniformly; a cached `nil`/`false` is still a hit). Both sites derive their public memo fn + clear fn from it.
- The public clear hooks (`clear-edn-print-cache!` / `clear-sensitive-paths-cache!`) keep their **exact names and docstrings** for the `re-frame.schemas` facade re-exports + the test-fixture. Caching behaviour for callers is byte-identical.

**2. `coerce-opts` → `resolve-frame` pair** (5 sites in storage + 1 in digest)
- The four *read* entry points (`app-schema-at` / `app-schema-meta-at` / `app-schemas` / `app-schemas-digest`) used `opts` ONLY to name a frame, repeating the 2-line `(coerce-opts → resolve-frame)` form.
- Added **`storage/coerce->frame-id`** collapsing it. The two `reg-*` entry points keep the two-step form deliberately — they read further keys off the coerced opts (`:rf/defer-elision-populate?`, `entry-opts`) and so need the intermediate map.

## Correctness

No validation/redaction semantics touched. The memo refactor preserves byte-identical cache behaviour; the frame-id helper is a literal inline of the existing two calls. No spec/010 change (no contract change from a dedup).

## Gates
- `npm run test:cljs` — 5486 tests / 19095 assertions, 0 failures, 0 errors, 0 warnings (cold install + compile).
- schemas JVM suite (`clojure -M:test`) — 227 tests / 18367 assertions, 0 failures, 0 errors (incl. the concurrency-stress harness that exercises the clear hooks).