### PR TITLE
refactor(examples): dedup routing back-link + collapse redundant not-found (rf2-1vek8)

### DIFF
--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -101,18 +101,17 @@
 (reg-view article-detail-page []
   (let [id      (:id @(subscribe [:rf.route/params]))
         article @(subscribe [:routing.app/article-by-id id])]
-    (if article
-      [:div
-       [:h1 (:title article)]
-       [:p (:body article)]
-       [:p [rf/route-link {:to :routing.app/articles
-                           :data-testid "route-link-back-to-articles"}
-            "← Back"]]]
-      [:div
-       [:p "Article not found."]
-       [:p [rf/route-link {:to :routing.app/articles
-                           :data-testid "route-link-back-to-articles"}
-            "← Back"]]])))
+    ;; The back-link is page-chrome shared by both the found and
+    ;; not-found states, so compute only the differing inner content
+    ;; per branch and render the link once.
+    [:div
+     (if article
+       [:<> [:h1 (:title article)]
+            [:p (:body article)]]
+       [:p "Article not found."])
+     [:p [rf/route-link {:to :routing.app/articles
+                         :data-testid "route-link-back-to-articles"}
+          "← Back"]]]))
 
 (reg-view not-found-page []
   (let [url (:url @(subscribe [:rf.route/params]))]
@@ -128,8 +127,7 @@
     :routing.app/home           [home-page]
     :routing.app/articles       [articles-page]
     :routing.app/article-detail [article-detail-page]
-    :rf.route/not-found   [not-found-page]
-    [not-found-page]))
+    :rf.route/not-found         [not-found-page]))
 
 ;; ============================================================================
 ;; ROUTER WIRING


### PR DESCRIPTION
## What

Behaviour-preserving dedup of `examples/reagent/routing/core.cljs`, per **rf2-1vek8** (senior-dev review of the reagent concept-demos, verified against Spec 012 Routing).

### Item 1 — duplicated Back link (ELEGANCE)
`article-detail-page` rendered an identical `[:p [rf/route-link ... "Back"]]` in **both** branches of `(if article ...)`. The back-link is page-chrome shared by the found and not-found states. Now each branch computes only its differing inner content (a `:<>` fragment of title+body, or the not-found `:p`), and the back-link renders **once** after it.

### Item 2 — redundant not-found case + default (CLARITY)
`root-view` had **both** an explicit `:rf.route/not-found [not-found-page]` clause **and** a trailing default `[not-found-page]`. The runtime always routes unmatched URLs to the registered `:rf.route/not-found` id (Spec 012 `handle-url-change`, match-url nil/validation policy), so the explicit clause catches every not-found case and the default was unreachable. Dropped the default to match the Spec 012 canonical root-view shape (012-Routing.md ~line 482: single `:rf.route/not-found` clause, no default) and fixed the clause's misindentation.

## Render equivalence (manual pass — examples are test-free)

- Found article: `<div><h1>...</h1><p>...</p><p>Back</p></div>` (fragment emits children only) — identical.
- Not-found article: `<div><p>Article not found.</p><p>Back</p></div>` — identical.
- root-view: all four matched route-ids render the same view; only the unreachable default was removed.

## Quality gates

- Cold `npx shadow-cljs compile examples/routing` → **142 files compiled, 0 warnings**.
- `examples/` tree is test-free (rf2-8cevm); no specs added. The `npm run test:examples` runner only drives the 3 adapter smokes and does not stage the routing example, so the compile + manual reasoning pass is the gate.

## Scope

Single file: `examples/reagent/routing/core.cljs`. No spec change (example code, not contract). No new files.

Closes rf2-1vek8.
