### PR TITLE
fix(story): run-loop! always settles done-cb on abort — no run-variant hang (rf2-9x5fm)

### DIFF
--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -155,6 +155,17 @@ Strict order, per spec/007:
      play-runner bridges them into the step result so the registered
      assertion handlers record into `:rf.story/assertions` (no throw —
      see [`004-Assertions.md`](004-Assertions.md)).
+   - **The phase-4 run always settles the `run-variant` promise.** A
+     play that is ABORTED before completing — the variant frame is torn
+     down mid-run (e.g. a hot-reload reset / `destroy-variant!` lands
+     during an async `:wait` yield), or a concurrent re-run takes over
+     the variant's run slot — still resolves the awaiting promise rather
+     than stranding it. The runner builds the result from whatever the
+     run accumulated against the (possibly torn-down) frame; an aborted
+     run never hangs the host's `await`. (`run-variant` chains only the
+     play promise's success continuation, so a non-settling abort would
+     hang forever — the runner is responsible for settling every exit
+     path.)
 
 Phase 1 and 4 are async-safe; phases 2 and 3 are sync (per re-frame's
 run-to-completion drain).

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -1116,6 +1116,30 @@
     (try (done-cb (current-state-for-play frame-id play-key))
          (catch #?(:clj Throwable :cljs :default) _ nil))))
 
+(defn- settle-abort!
+  "Settle `done-cb` for a run-loop that ABORTED before finishing — the frame
+  was torn down mid-run (run-state vanished) or a newer `run!` took over the
+  state slot (token mismatch, rf2-ftow6). rf2-9x5fm: every exit path of the
+  run loop MUST settle the awaiting continuation, otherwise the play-promise
+  (and the outer `run-variant` promise chained off it) hangs forever. The
+  abort is reachable on CLJS, where an async `:wait` yield gives a hot-reload
+  reset / concurrent `run!` / teardown a window to mutate the shared
+  run-state between steps.
+
+  Unlike `finish!`, this does NOT call `update-state!` / `runner/finish` — an
+  aborted loop must NOT clobber the shared run-state slot, which by this point
+  may belong to the NEWER run that took over (token mismatch) or be gone (frame
+  torn down). It resolves the awaiting `done-cb` with the last-known state
+  (`current-state-for-play`, possibly nil) so the continuation advances and the
+  promise settles. The continuation only chains the next play / builds the
+  result from the frame's accumulated assertions; it does not re-read this
+  state for correctness."
+  [frame-id play-key done-cb]
+  (when done-cb
+    (try (done-cb (current-state-for-play frame-id play-key))
+         (catch #?(:clj Throwable :cljs :default) _ nil)))
+  nil)
+
 (defn- run-loop!
   "Iterate over the script, running each step. `:wait` steps yield
   to the scheduler and resume from the wait time onwards.
@@ -1139,15 +1163,24 @@
   [frame-id play-key token done-cb]
   (let [state (current-state-for-play frame-id play-key)]
     (cond
-      ;; abort if state has gone missing (frame torn down mid-run)
+      ;; abort if state has gone missing (frame torn down mid-run).
+      ;; rf2-9x5fm: still settle `done-cb` so the awaiting continuation
+      ;; advances and the play-promise (and the outer `run-variant`
+      ;; promise) resolves rather than hanging forever. We do NOT
+      ;; `finish!` here — the run-state slot is gone, so there is nothing
+      ;; to transition; we only release the continuation.
       (nil? state)
-      nil
+      (settle-abort! frame-id play-key done-cb)
 
       ;; abort if a newer run! has taken over the state slot — the
       ;; newer loop owns continuation now, so the stale loop bails
-      ;; silently rather than racing it. rf2-ftow6.
+      ;; rather than racing it. rf2-ftow6. rf2-9x5fm: the stale loop
+      ;; must STILL settle ITS OWN `done-cb` (the continuation/promise
+      ;; for THIS run) so it does not strand the chain — but via
+      ;; `settle-abort!` (no `update-state!`), so it never clobbers the
+      ;; newer run's run-state slot.
       (and token (some? (:run-token state)) (not= token (:run-token state)))
-      nil
+      (settle-abort! frame-id play-key done-cb)
 
       (runner/done? state)
       (finish! frame-id play-key done-cb)

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -246,6 +246,90 @@
 ;; (coerce-script-lifts-bare-event-vectors + parse-spec-lifts-bare-
 ;; vectors-inside-map). The wrong-layer copy added no signal.
 
+;; ---- CLJS+JVM: every run-loop! exit path settles done-cb (rf2-9x5fm) -----
+;;
+;; The run loop has TWO silent-abort branches that previously returned `nil`
+;; WITHOUT invoking `done-cb`:
+;;
+;;   1. `(nil? state)` — the frame was torn down mid-run (run-state entry
+;;      gone). Reachable on CLJS when a hot-reload reset / teardown clears the
+;;      run-state during an async `:wait` yield.
+;;   2. token mismatch (rf2-ftow6) — a concurrent `run!` took over the
+;;      run-state slot, stamping a fresher `:run-token`.
+;;
+;; When either fired, `done-cb` was never called, so the awaiting continuation
+;; (`runtime/run-phase-4!`'s `step!`) never resolved the play-promise, and the
+;; outer `run-variant` promise hung forever (it chains only `then`, no `catch`
+;; / timeout). The fix routes both branches through `settle-abort!`, which
+;; ALWAYS settles `done-cb` (with the last-known/aborted state) WITHOUT
+;; mutating the shared run-state slot — so the stale loop releases its
+;; continuation but never clobbers a newer run's state.
+;;
+;; These drive `run-loop!` directly (private, var-quoted — the established
+;; Story-test seam). Both abort branches are the FIRST `cond` clauses and
+;; return synchronously (no `setTimeout` yield), so the test is deterministic
+;; on both runtimes: it asserts `done-cb` fired, which is the exact fact a hang
+;; violates. Runs under `npm run test:cljs` — the CLJS runtime where the hang
+;; was reachable.
+
+(def ^:private run-loop!    @#'re/run-loop!)
+(def ^:private set-state!   @#'re/set-state!)
+(def ^:private settle-abort! @#'re/settle-abort!)
+
+(deftest run-loop-aborts-on-missing-state-still-settles-done-cb
+  (testing "rf2-9x5fm — the `(nil? state)` abort branch (frame torn down
+            mid-run) STILL invokes done-cb so the awaiting continuation
+            resolves rather than hanging the play-promise forever"
+    (let [frame-id :story.abort/torn-down
+          settled  (atom :unset)]
+      ;; No run-state entry exists for this [frame-id nil] slot — the frame
+      ;; was torn down (clear-state! wiped it). The loop's first cond clause
+      ;; `(nil? state)` fires.
+      (is (nil? (re/current-state-for-play frame-id nil))
+          "precondition: no run-state for the torn-down frame")
+      (run-loop! frame-id nil "tok-A" (fn [final] (reset! settled final)))
+      (is (not= :unset @settled)
+          "done-cb fired on the torn-down-frame abort — the continuation is
+           released, so the play-promise (and the outer run-variant promise)
+           cannot hang")
+      (is (nil? @settled)
+          "the aborted continuation settles with the last-known state — nil
+           when the slot is gone"))))
+
+(deftest run-loop-aborts-on-token-mismatch-still-settles-done-cb
+  (testing "rf2-9x5fm — the token-mismatch abort branch (a newer run! took
+            over the slot, rf2-ftow6) STILL invokes the STALE loop's done-cb
+            so its continuation resolves; it does NOT clobber the newer run's
+            run-state (no finish! / update-state!)"
+    (let [frame-id :story.abort/token-swap
+          settled  (atom :unset)
+          ;; Seed the slot with a NEWER token than the stale loop carries.
+          newer    (runner/start
+                     (runner/initial-state {:script [[:dispatch [:noop]]] :name nil})
+                     1)]
+      (set-state! frame-id nil (assoc newer :run-token "tok-NEWER"))
+      ;; The stale loop carries "tok-STALE" — it mismatches the slot's
+      ;; "tok-NEWER", so the second cond clause fires.
+      (run-loop! frame-id nil "tok-STALE" (fn [final] (reset! settled final)))
+      (is (not= :unset @settled)
+          "the stale loop's done-cb fired on token mismatch — its continuation
+           is released, never stranded")
+      ;; The newer run still OWNS the slot — the stale abort must not have
+      ;; transitioned it via finish!/update-state!.
+      (let [slot (re/current-state-for-play frame-id nil)]
+        (is (= "tok-NEWER" (:run-token slot))
+            "the slot still carries the NEWER run's token — the stale abort
+             did not clobber it")
+        (is (= :running (:status slot))
+            "the slot's status was NOT transitioned to a terminal status by the
+             stale abort (finish! would have set :pass/:fail/:cannot-run)")))))
+
+(deftest settle-abort-tolerates-nil-done-cb
+  (testing "rf2-9x5fm — settle-abort! is a clean no-op when done-cb is nil
+            (a run! called with no completion hook) and never throws"
+    (is (nil? (settle-abort! :story.abort/no-cb nil nil))
+        "no done-cb → settle-abort! returns nil without throwing")))
+
 ;; ---- JVM-only: integration tests against a live re-frame frame ----------
 ;;
 ;; These reuse the namespace-wide `bridge-reset!` fixture above (which

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -19,7 +19,8 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story :as story]
             [re-frame.story.async :as async-lib]
-            [re-frame.story.loaders :as loaders]))
+            [re-frame.story.loaders :as loaders]
+            [re-frame.story.play.runner-events :as re]))
 
 ;; ---- fixtures ------------------------------------------------------------
 ;;
@@ -128,6 +129,87 @@
         ":loaders-complete-when disqualifies")
     (is (false? (loaders/events-only-variant? {} {:frame-setup [{:body {}}]}))
         ":frame-setup decorators disqualify")))
+
+;; ---- rf2-9x5fm — the run-variant promise resolves even when the play -----
+;;      runner aborts mid-:wait (frame torn down during the async yield) ----
+;;
+;; The defect: `runner-events/run-loop!` had two silent-abort branches that
+;; returned WITHOUT invoking done-cb — the `(nil? state)` branch (frame torn
+;; down mid-run) and the token-mismatch branch (a concurrent run! took over).
+;; When either fired during an async `:wait` yield (CLJS `js/setTimeout`), the
+;; play-promise never resolved → `run-phase-4!`'s continuation never fired →
+;; `finalise-run!`'s `then` never fired → the outer `run-variant` promise hung
+;; FOREVER (it chains only `then`, never `catch` / a timeout).
+;;
+;; This is the end-to-end regression guard for the ACTUAL failing path: a
+;; variant whose play has a `:wait` step, with the frame destroyed during the
+;; wait yield. Before the fix this test would NEVER call `done` and the
+;; cljs.test async runner would time out (a red hang). With the fix the
+;; aborted run still settles, so `run-variant` resolves and `done` fires.
+
+(deftest cljs-run-variant-resolves-when-frame-torn-down-mid-wait
+  (testing "rf2-9x5fm — tearing the variant frame down DURING a play's
+            `:wait` yield must still resolve the run-variant promise; the
+            aborted run loop settles its continuation instead of hanging"
+    (rf/reg-event-db :test.hang/touch
+      (fn [db _] (update db :n (fnil inc 0))))
+    (story/reg-variant :story.cljs.hang/torn-down
+      {:events      []
+       :play-script {:script [[:dispatch-sync [:test.hang/touch]]
+                              ;; The async yield window: the frame is
+                              ;; destroyed while this :wait's setTimeout is
+                              ;; pending, so the run loop resumes onto a
+                              ;; vanished run-state.
+                              [:wait 60]
+                              [:dispatch-sync [:test.hang/touch]]]}})
+    (async done
+      (let [p (story/run-variant :story.cljs.hang/torn-down)]
+        ;; Destroy the frame mid-:wait (after run-phase-4! has scheduled the
+        ;; wait's setTimeout, before it resumes). This wipes the run-state
+        ;; slot (`clear-state!` via the :drop-run-state teardown hook), so the
+        ;; resuming loop hits the `(nil? state)` abort branch.
+        (js/setTimeout #(story/destroy-variant! :story.cljs.hang/torn-down) 15)
+        (-> p
+            (async-lib/then
+              (fn [r]
+                (is (map? r)
+                    "the run-variant promise RESOLVED — the torn-down-mid-wait
+                     run settled instead of hanging forever (rf2-9x5fm)")
+                (done))))))))
+
+(deftest cljs-run-variant-resolves-when-concurrent-run-takes-over-mid-wait
+  (testing "rf2-9x5fm — a concurrent `run!` that takes over the run-state slot
+            (token swap, rf2-ftow6) DURING a play's `:wait` yield must still
+            resolve the original run-variant promise; the stale loop settles
+            its own continuation rather than stranding the chain"
+    (rf/reg-event-db :test.hang2/touch
+      (fn [db _] (update db :n (fnil inc 0))))
+    (story/reg-variant :story.cljs.hang/token-swap
+      {:events      []
+       :play-script {:auto-run? false
+                     :script [[:dispatch-sync [:test.hang2/touch]]
+                              [:wait 60]
+                              [:dispatch-sync [:test.hang2/touch]]]}})
+    (async done
+      (let [p (story/run-variant :story.cljs.hang/token-swap)]
+        (-> p
+            (async-lib/then
+              (fn [r]
+                (is (map? r)
+                    "the original run-variant promise RESOLVED even though a
+                     concurrent run! swapped the run-state token mid-:wait —
+                     the stale loop's continuation settled (rf2-9x5fm)")
+                (story/destroy-variant! :story.cljs.hang/token-swap)
+                (done))))
+        ;; Mid-:wait, fire a concurrent runner-events/run! for the SAME
+        ;; variant. It stamps a fresher :run-token onto the shared slot, so
+        ;; when the original run's loop resumes it sees a token mismatch and
+        ;; aborts — but must still settle ITS continuation. The concurrent run
+        ;; itself is allowed to complete; we only assert the ORIGINAL promise
+        ;; resolves.
+        (js/setTimeout
+          #(re/run! :story.cljs.hang/token-swap)
+          15)))))
 
 ;; ---- snapshot-identity --------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes **rf2-9x5fm** (P2 bug, found during rf2-booyu correctness review).

The rich-DSL play runner's `run-loop!` (`tools/story/src/re_frame/story/play/runner_events.cljc`) had two silent-abort branches that returned `nil` **without** invoking `done-cb`:

1. `(nil? state)` — the variant frame was torn down mid-run (run-state entry gone).
2. token mismatch (rf2-ftow6) — a concurrent `run!` took over the run-state slot, stamping a fresher `:run-token`.

When either fired during an async `:wait` yield (CLJS `js/setTimeout`), the play-promise never resolved → `runtime/run-phase-4!`'s `step!` continuation never fired → `finalise-run!`'s `then` never fired → the outer `run-variant` promise **hung forever** (it chains only `then`, never `catch` / a timeout).

Reachable only on CLJS: a `:wait` yields a tick during which a hot-reload reset / concurrent `run!` / teardown can mutate the shared run-state. On JVM `:wait` is synchronous, so `run!` completes before any interleaving (confirmed non-reproducible on JVM in the original review).

## Fix

Both abort branches now route through a new `settle-abort!` that **always** invokes `done-cb` (with the last-known/aborted state) — so **every exit path of the run loop settles the awaiting continuation**. Unlike `finish!`, `settle-abort!` does **not** call `update-state!` / `runner/finish`: an aborted loop must not clobber the shared run-state slot, which by that point may belong to the newer run that took over (token mismatch) or be gone (frame torn down). It only releases the continuation; the continuation builds the result from the frame's accumulated assertions and never re-reads this state for correctness.

## Tests

- **`runner_events_cljs_test` (CLJS+JVM):** three synchronous unit tests drive `run-loop!` directly through both abort branches and assert `done-cb` fires. The token-mismatch test also asserts the newer run's slot is **not** clobbered (token + non-terminal `:running` status preserved).
- **`story_runtime_cljs_test` (CLJS):** two end-to-end async tests reproduce the **actual** hang path — a play with a `:wait` step whose frame is torn down (or whose run slot is taken over by a concurrent `run!`) mid-yield — and assert the `run-variant` promise still resolves. **Verified RED-before:** with the buggy `nil` returns restored, the cljs.test async runner hangs and never prints its summary (timed out at 90s/180s).

## Spec

`002-Runtime.md` §Phase 4 now states the always-settles invariant — an aborted phase-4 run resolves the `run-variant` promise rather than stranding the host's `await`. (The run-variant contract lives in story's own spec; no `tools/xray/spec/*` change is involved since the fix is in `tools/story/src`.)

## Gates (cold)

- `clojure -M:test` (story JVM): 1590 tests, 5953 assertions, **0 failures / 0 errors**
- `npm run test:cljs` (CLJS node-test — where the hang lived): 5498 tests, 19120 assertions, **0 failures / 0 errors**
- `story:build` not needed (pure runtime logic, no built-artefact content)

## Scope

`tools/story/` only — 4 files. No new files, no overlap with in-flight examples / spec005 / story-mcp-trio work.