### PR TITLE
fix(examples/realworld): post-login :return-to, auth-gate favorite/follow, JWT-in-SSR + edge fixes (rf2-ygh4m)

### DIFF
--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -64,6 +64,21 @@
         (assoc-in [:auth :user] nil)
         (assoc-in [:auth :token] nil))))
 
+(rf/reg-event-fx :auth/post-login-redirect
+  {:doc "Bounce the freshly-authenticated user back to the route the auth
+         guard intercepted (`[:auth :return-to]`, set in routing.cljs), or
+         home when there is none. Dispatched by the auth machine's
+         `:store-session` action — machine actions can't navigate or read
+         `:db` directly (Spec 005 §Hard-disallow `:db`), so the bounce is an
+         ordinary event. Reads AND clears the slot in one step so a later
+         plain login can't re-bounce to a stale target."}
+  (fn [{:keys [db]} _]
+    (let [return-to (get-in db [:auth :return-to])]
+      {:db (update db :auth dissoc :return-to)
+       :fx [[:dispatch (if return-to
+                         [:rf.route/navigate (:id return-to) (:params return-to)]
+                         [:rf.route/navigate :realworld/home])]]})))
+
 ;; ============================================================================
 ;; AUTH STATE MACHINE
 ;; ============================================================================
@@ -127,11 +142,16 @@
 
       :store-session
       (fn [{[_ {:keys [value]}] :event}]
+        ;; Per Spec 005 §Hard-disallow `:db`, a machine action sees no
+        ;; `:db` and emits no `:db`; the post-login bounce-back therefore
+        ;; runs as an ordinary event (`:auth/post-login-redirect`) that
+        ;; reads the guard-stashed `:return-to` slot, navigates there (or
+        ;; home), and clears it. See routing.cljs for where the slot is set.
         (let [user (:user value)]
           {:data {:error nil}
            :fx [[:dispatch [:auth/store-session user]]
                 [:auth.session/persist {:token (:token user)}]
-                [:dispatch [:rf.route/navigate :realworld/home]]]}))
+                [:dispatch [:auth/post-login-redirect]]]}))
 
       :record-error
       (fn [{[_ {:keys [failure]}] :event}]
@@ -174,6 +194,17 @@
 (rf/reg-event-fx :auth/initialise
   [(rf/inject-cofx :auth.session/token)]
   (fn handler-auth-initialise [{:keys [db auth.session/token]} _]
+    ;; ITEM 8 (rf2-ygh4m): we dispatch `:auth/flow [:auth/restore token]`
+    ;; UNCONDITIONALLY — even when `token` is nil — on purpose. This first
+    ;; delivery is what spawns the auth machine's snapshot (the machine
+    ;; materialises at `:idle` on its first event), so the navbar's
+    ;; `:auth/state` sub reads `:idle` rather than `nil` from cold boot.
+    ;; The do-we-have-a-token? decision is then made by the machine's
+    ;; `:idle` `:has-token?` guard: a blank token routes to the no-op
+    ;; `{:target :idle}` branch, a real one kicks `:begin-restore`. Guarding
+    ;; the dispatch here would skip the machine spawn on a no-token boot —
+    ;; the guard stays where it belongs (one source of truth for the
+    ;; token decision, in the machine).
     {:db (assoc db :auth {:user nil
                           :token token})
      :fx [[:dispatch [:auth/flow [:auth/restore token]]]]}))

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -198,12 +198,16 @@
     (let [saved (:comment value)]
       (-> db
           (assoc-in [:comment-form] (comment-form-defaults))
+          ;; Replace the optimistic temp card IN PLACE with the saved
+          ;; comment — preserve its position so a confirmed comment does
+          ;; not visibly teleport from where it was appended (the bottom)
+          ;; to the top. Mirrors favorites.cljs/update-article-in-list:
+          ;; map, swap the matching entry, keep order.
           (update-in [:comments :data]
                      (fn [comments]
-                       (->> (or comments [])
-                            (remove #(= temp-id (:id %)))
-                            (concat [saved])
-                            vec)))))))
+                       (mapv (fn [comment]
+                               (if (= temp-id (:id comment)) saved comment))
+                             (or comments []))))))))
 
 (rf/reg-event-db :comment-form/submit-error
   (fn [db [_ temp-id {:keys [failure]}]]
@@ -326,7 +330,14 @@
        (= article-status :loading)
        [:div.article-preview "Loading article…"]
 
-       article-error
+       ;; Only surface the error view when there is NO article to show.
+       ;; A failed RE-fetch (`:status :error`) of an already-loaded
+       ;; article leaves the prior `:data` in place — render it (the
+       ;; `article` branch below) rather than blanking a page the user is
+       ;; reading. Pattern-RemoteData: never blank loaded data on a
+       ;; refresh failure. (cf. tags.cljs, where the machine keeps prior
+       ;; `:tags` visible across a `:fetch-failed`.)
+       (and article-error (nil? article))
        [:div.article-preview.error
         (str "Couldn't load article: " (pr-str article-error))]
 

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -205,6 +205,14 @@
 ;; wrapper fx so the demo doesn't have to know one URL ahead of time.
 ;; ----------------------------------------------------------------------------
 
+(def ^:private demo-reply-delay-ms
+  "How long the demo stub defers each canned reply (via the canned-success
+   fx's `:after-ms`, dispatched through `:dispatch-later` — observable in
+   the tape, time-travel-safe, NOT raw `js/setTimeout`). Small but non-zero
+   so the `:loading` UI state is observable in the standalone demo. A
+   demo-seam knob, not a production value."
+  20)
+
 (def ^:private demo-articles
   [{:slug "hello-conduit"
     :title "Hello, Conduit"
@@ -318,8 +326,9 @@
 
                Delegates straight to the framework-shipped
                `:rf.http/managed-canned-success` (Spec 014 §Testing) with
-               the per-URL canned payload and `:after-ms` (rf2-j1mo4): the
-               framework defers the reply via `:dispatch-later` (20 ms) —
+               the per-URL canned payload and `:after-ms`
+               (`demo-reply-delay-ms`, rf2-j1mo4): the framework defers the
+               reply via `:dispatch-later` —
                observable in the tape, time-travel-safe, NOT raw
                `js/setTimeout`. The delay lets the `:loading` UI state be
                observable; `:after-ms` collapses the former schedule-reply
@@ -329,7 +338,7 @@
   (fn fx-managed-demo-stub [frame-ctx args-map]
     (let [payload (demo-payload-for-args args-map)
           stub    (registrar/handler :fx :rf.http/managed-canned-success)]
-      (stub frame-ctx (assoc args-map :after-ms 20 :value payload)))))
+      (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))
 
 ;; React root named `react-root` (not `root`) so it does NOT collide with
 ;; the `root-view` reg-view above. Held in an atom and populated lazily
@@ -361,6 +370,18 @@
 ;; with `realworld.http/request` (which threads the header explicitly)
 ;; — both shapes work; the interceptor pattern is the lighter option
 ;; once the auth slot is established.
+;;
+;; DELIBERATE DUALITY (rf2-ygh4m ITEM 4): this example wires BOTH shapes
+;; live at once so a reader can see them side by side, so every authed
+;; request actually gets the Bearer header written twice — once by
+;; `rh/request` and once here. This is intentional and harmless: the
+;; interceptor `assoc-in`s the SAME header to the SAME value, so the
+;; second write is idempotent (no duplicate header, no precedence
+;; surprise). A real app would pick ONE source of truth — drop the token
+;; logic from `rh/request` (leaving `:auth? false` as a header
+;; suppressor) and keep this single read site, or vice versa. The
+;; side-by-side wiring is a teaching choice, not the recommended
+;; production shape.
 
 (defn- bearer-auth-interceptor [ctx]
   (let [token (some-> (rf/app-db-value (:frame ctx))

--- a/examples/reagent/realworld/favorites.cljs
+++ b/examples/reagent/realworld/favorites.cljs
@@ -111,30 +111,61 @@
 ;; ============================================================================
 ;; FAVORITES
 ;; ============================================================================
+;;
+;; Optimistic rollback shapes across the app (rf2-ygh4m ITEM 5). realworld
+;; has three optimistic-with-rollback flows and they DELIBERATELY use three
+;; different rollback shapes — because the thing being rolled back differs:
+;;
+;;   - favorite (here): snapshots {:favorited :favoritesCount} and patches
+;;     the article EVERYWHERE it appears (across the :articles / :feed /
+;;     :profile.* slices) via the shared `patch-article-everywhere` /
+;;     `update-article-in-list` helpers below — the cross-slice case.
+;;   - follow (profile.cljs): snapshots a single boolean — one field, one
+;;     slice — so a helper would be heavier than the `assoc-in` it replaces.
+;;   - comment-delete (comments.cljs): snapshots {:index :comment} and
+;;     re-inserts the removed comment at its original position — a positional
+;;     splice the map-and-swap helper here can't express (the entry is gone,
+;;     not present-to-map-over).
+;;
+;; A single shared optimistic helper would have to abstract over "patch a
+;; field across N slices", "flip one boolean", and "re-insert at an index" —
+;; obscuring more than it saves. The shared surface that DOES pay off
+;; (cross-slice article patching) is already factored out below and reused
+;; by `:comment-form/submit-success`'s in-place swap. So: shared where it
+;; helps, distinct where the data shapes genuinely differ — not an oversight.
 
 (rf/reg-event-fx :article/toggle-favorite
   {:doc "Optimistically flip the favorited flag and bump the count, then
          POST or DELETE the favorite. On failure the prior state is
-         restored (rollback)."
+         restored (rollback).
+
+         Auth-gated: favoriting requires a session. An unauthenticated
+         click navigates to login instead of issuing a tokenless request
+         that the real Conduit backend would 401 — so there is no
+         optimistic flip-then-rollback flicker for a logged-out user. (The
+         demo stub 200s everything, which would mask the 401; gating here
+         keeps the example correct against the real backend it documents.)"
    :rf.http/decode-schemas [schema/ArticleResponse]}
   (fn [{:keys [db]} [_ slug]]
-    (if-let [article (find-article db slug)]
-      (let [prior {:favorited      (:favorited article)
-                   :favoritesCount (:favoritesCount article)}
-            favorited? (:favorited article)
-            next-count (if favorited?
-                         (max 0 (dec (:favoritesCount article)))
-                         (inc (:favoritesCount article)))]
-        {:db (patch-article-everywhere db slug
-                                       #(assoc % :favorited (not favorited?)
-                                                 :favoritesCount next-count))
-         :fx [[:rf.http/managed
-               (rh/request {:method     (if favorited? :delete :post)
-                            :path       (str "/articles/" slug "/favorite")
-                            :decode     schema/ArticleResponse
-                            :on-success [:article/favorite-synced slug]
-                            :on-failure [:article/favorite-rollback slug prior]})]]})
-      {})))
+    (if (nil? (get-in db [:auth :user]))
+      {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
+      (if-let [article (find-article db slug)]
+        (let [prior {:favorited      (:favorited article)
+                     :favoritesCount (:favoritesCount article)}
+              favorited? (:favorited article)
+              next-count (if favorited?
+                           (max 0 (dec (:favoritesCount article)))
+                           (inc (:favoritesCount article)))]
+          {:db (patch-article-everywhere db slug
+                                         #(assoc % :favorited (not favorited?)
+                                                   :favoritesCount next-count))
+           :fx [[:rf.http/managed
+                 (rh/request {:method     (if favorited? :delete :post)
+                              :path       (str "/articles/" slug "/favorite")
+                              :decode     schema/ArticleResponse
+                              :on-success [:article/favorite-synced slug]
+                              :on-failure [:article/favorite-rollback slug prior]})]]})
+        {}))))
 
 (rf/reg-event-db :article/favorite-synced
   (fn [db [_ slug {:keys [value]}]]

--- a/examples/reagent/realworld/profile.cljs
+++ b/examples/reagent/realworld/profile.cljs
@@ -275,34 +275,44 @@
 ;; ============================================================================
 
 (rf/reg-event-fx :profile/follow
-  {:doc "Optimistically mark the profile as followed; reconcile on reply."
+  {:doc "Optimistically mark the profile as followed; reconcile on reply.
+
+         Auth-gated (same rationale as favorites.cljs/:article/toggle-favorite):
+         following requires a session, so an unauthenticated click navigates
+         to login rather than optimistically flipping `:following` and then
+         rolling back after the real backend 401s."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
-    (let [username (username-from-db db)]
-      {:db (assoc-in db [:profile :data :following] true)
-       :fx [[:rf.http/managed
-             (rh/request {:method     :post
-                          :path       (str "/profiles/" username "/follow")
-                          :decode     schema/ProfileResponse
-                          :on-success [:profile/followed]
-                          :on-failure [:profile/follow-rollback false]})]]})))
+    (if (nil? (get-in db [:auth :user]))
+      {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
+      (let [username (username-from-db db)]
+        {:db (assoc-in db [:profile :data :following] true)
+         :fx [[:rf.http/managed
+               (rh/request {:method     :post
+                            :path       (str "/profiles/" username "/follow")
+                            :decode     schema/ProfileResponse
+                            :on-success [:profile/followed]
+                            :on-failure [:profile/follow-rollback false]})]]}))))
 
 (rf/reg-event-db :profile/followed
   (fn [db [_ {:keys [value]}]]
     (assoc-in db [:profile :data] (:profile value))))
 
 (rf/reg-event-fx :profile/unfollow
-  {:doc "Optimistically clear the followed flag; reconcile on reply."
+  {:doc "Optimistically clear the followed flag; reconcile on reply.
+         Auth-gated like `:profile/follow` above."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
-    (let [username (username-from-db db)]
-      {:db (assoc-in db [:profile :data :following] false)
-       :fx [[:rf.http/managed
-             (rh/request {:method     :delete
-                          :path       (str "/profiles/" username "/follow")
-                          :decode     schema/ProfileResponse
-                          :on-success [:profile/unfollowed]
-                          :on-failure [:profile/follow-rollback true]})]]})))
+    (if (nil? (get-in db [:auth :user]))
+      {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
+      (let [username (username-from-db db)]
+        {:db (assoc-in db [:profile :data :following] false)
+         :fx [[:rf.http/managed
+               (rh/request {:method     :delete
+                            :path       (str "/profiles/" username "/follow")
+                            :decode     schema/ProfileResponse
+                            :on-success [:profile/unfollowed]
+                            :on-failure [:profile/follow-rollback true]})]]}))))
 
 (rf/reg-event-db :profile/unfollowed
   (fn [db [_ {:keys [value]}]]

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -112,24 +112,55 @@
 ;; the on-match drain runs; for THIS sketch we gate the programmatic
 ;; navigation surface the navbar uses, which is the path the headless
 ;; tests exercise.)
+;;
+;; Bounce-back (`:return-to`). The headline of an auth guard is returning
+;; the user to where they were headed once they sign in. `:rf.route/navigate`
+;; opts (the 3rd arg) are NOT persisted by the runtime — the navigate
+;; handler reads `:query` / `:fragment` / `:replace?` / `:scroll` /
+;; `:bypass-leave-guard?` from opts and drops everything else (Spec 012
+;; §Navigation is an event), so an opts-borne `:return-to` would silently
+;; evaporate. We therefore stash the original target in `app-db` instead:
+;; the `:before` records the intended target on the ctx, and an `:after`
+;; folds it into the login navigation's committed `:db` at
+;; `[:auth :return-to]`. The auth machine's `:store-session` action reads
+;; that slot on a successful login and bounces there (falling back to
+;; home), then clears it (auth.cljs).
+
+(def ^:private guard-target-key
+  "Private top-level ctx slot the `:before` uses to signal the `:after`
+   that it redirected, carrying the original {:id :params} target. Lives
+   on the ctx (not in `:coeffects`/`:effects`) so it is invisible to the
+   handler and to the committed app-db — pure intra-interceptor signalling."
+  :realworld.routing/guard-return-to)
 
 (def auth-guard
   {:id     :realworld.routing/auth-guard
    :before (fn auth-guard-before [ctx]
-             (let [event (get-in ctx [:coeffects :event])]
-               (if (= :rf.route/navigate (first event))
-                 (let [target      (second event)
-                       route-meta  (rf/handler-meta :route target)
+             (let [[ev-id target params] (get-in ctx [:coeffects :event])]
+               (if (= :rf.route/navigate ev-id)
+                 (let [route-meta  (rf/handler-meta :route target)
                        needs-auth? (boolean (some #{:requires-auth} (:tags route-meta)))
                        logged-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
                    (if (and needs-auth? (not logged-in?))
-                     ;; Rewrite the in-flight event to a login redirect.
-                     ;; `:rf.route/navigate` is [_ target params opts]; the
-                     ;; original target rides through under :return-to.
-                     (assoc-in ctx [:coeffects :event]
-                               [:rf.route/navigate :realworld.auth/login {} {:return-to target}])
+                     ;; Rewrite the in-flight event to a login redirect and
+                     ;; record the original target so the `:after` can stash
+                     ;; it for post-login bounce-back.
+                     (-> ctx
+                         (assoc-in [:coeffects :event]
+                                   [:rf.route/navigate :realworld.auth/login])
+                         (assoc guard-target-key {:id target :params (or params {})}))
                      ctx))
-                 ctx)))})
+                 ctx)))
+   :after  (fn auth-guard-after [ctx]
+             ;; Only acts when the `:before` redirected (the slot is set)
+             ;; AND the login navigation actually committed a `:db` effect
+             ;; (a no-op re-nav or rejected navigation writes none — leave
+             ;; it alone). Folds the stashed target into the committed db.
+             (if-let [return-to (get ctx guard-target-key)]
+               (if (get-in ctx [:effects :db])
+                 (assoc-in ctx [:effects :db :auth :return-to] return-to)
+                 ctx)
+               ctx))})
 
 ;; ============================================================================
 ;; ROUTER WIRING

--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -129,10 +129,20 @@
 (def AuthSlice
   "The auth slice. :user holds the current :User payload (or nil);
    :token is the JWT (or nil). The auth machine snapshot itself lives at
-   [:rf/runtime :machines :snapshots :auth/flow]."
+   [:rf/runtime :machines :snapshots :auth/flow].
+
+   :return-to is the optional post-login bounce-back target stashed by the
+   routing auth-guard (routing.cljs) when an unauthenticated user is
+   redirected away from a `:requires-auth` route; `:auth/post-login-redirect`
+   reads and clears it (auth.cljs). Present only between the redirect and the
+   next successful login."
   [:map
-   [:user  [:maybe User]]
-   [:token [:maybe :string]]])
+   [:user      [:maybe User]]
+   [:token     [:maybe :string]]
+   [:return-to {:optional true}
+    [:map
+     [:id     :keyword]
+     [:params [:maybe :map]]]]])
 
 (def AuthFlowSnapshot
   [:map

--- a/examples/reagent/realworld/ssr.cljc
+++ b/examples/reagent/realworld/ssr.cljc
@@ -30,7 +30,14 @@
    :comment-form])
 
 (defn exportable-db [db]
-  (select-keys db ssr-slice-keys))
+  ;; Secrets do not cross the SSR seam. The bearer JWT lives at
+  ;; [:auth :token]; embedding it in server-rendered HTML would leak a
+  ;; live credential into page source (view-source-visible, proxy-logged,
+  ;; CDN-cacheable). Redact it at the payload boundary — the client
+  ;; re-derives the token from localStorage on hydrate via
+  ;; `:auth/initialise` (auth.cljs), so dropping it here costs nothing.
+  (cond-> (select-keys db ssr-slice-keys)
+    (contains? db :auth) (update :auth dissoc :token)))
 
 (defn hydration-payload [db render-tree]
   {:rf/version     1

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -279,7 +279,3 @@
 (rf/reg-sub :home/selected-tag
   :<- [:home/query]
   (fn [query _] (:tag query)))
-
-(rf/reg-sub :home/feed-kind
-  :<- [:home/query]
-  (fn [query _] (if (= "your" (:feed query)) :your :global)))

--- a/examples/reagent/realworld/test/realworld/favorites_test.cljs
+++ b/examples/reagent/realworld/test/realworld/favorites_test.cljs
@@ -16,6 +16,11 @@
   (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/favorite-rollback}})]
     (rf/dispatch-sync [:articles/initialise] {:frame f})
+    ;; :article/toggle-favorite is auth-gated (rf2-ygh4m): a logged-out
+    ;; click navigates to login instead of issuing a tokenless request.
+    ;; Authenticate first so this test exercises the optimistic-rollback
+    ;; path it is here to cover.
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :email "a@b.c" :token "jwt" :bio nil :image nil}] {:frame f})
     (rf/dispatch-sync [:articles/loaded
                        {:kind :success
                         :value {:articles [{:slug "hello"

--- a/examples/reagent/realworld/test/realworld/routing_test.cljs
+++ b/examples/reagent/realworld/test/realworld/routing_test.cljs
@@ -42,8 +42,24 @@
     (assert (= :realworld/home (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
             "unguarded route navigates normally with the guard installed")
 
+    ;; Bounce-back stash (rf2-ygh4m ITEM 1): the redirect to login also
+    ;; records the original target at [:auth :return-to] so a post-login
+    ;; handler can return the user there. (We are still on /login from the
+    ;; first redirect above; navigate back to a guarded route to re-stash.)
+    (rf/dispatch-sync [:rf.route/navigate :realworld.user/settings {}] {:frame f})
+    (assert (= {:id :realworld.user/settings :params {}}
+               (get-in (rf/app-db-value f) [:auth :return-to]))
+            "the redirect stashes the original target for post-login bounce-back")
+
     ;; Authenticated: the same guarded nav now proceeds.
     (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
     (rf/dispatch-sync [:rf.route/navigate :realworld.user/settings {}] {:frame f})
     (assert (= :realworld.user/settings (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
-            "authenticated nav to a :requires-auth route proceeds")))
+            "authenticated nav to a :requires-auth route proceeds")
+
+    ;; The post-login bounce-back event consumes the stashed target and
+    ;; clears the slot. With a stash present it navigates THERE; we assert
+    ;; the slot is cleared after one consumption.
+    (rf/dispatch-sync [:auth/post-login-redirect] {:frame f})
+    (assert (nil? (get-in (rf/app-db-value f) [:auth :return-to]))
+            ":auth/post-login-redirect clears the :return-to slot")))

--- a/examples/reagent/realworld/test/realworld/ssr_test.cljc
+++ b/examples/reagent/realworld/test/realworld/ssr_test.cljc
@@ -11,6 +11,15 @@
             :auth {:user {:username "alice"} :token "jwt"}
             :articles {:status :loaded :data [] :error nil :loaded-at 1 :attempt 1}
             :transient {:popup true}}
-        payload (ssr/hydration-payload db [:div "hello"])]
+        payload (ssr/hydration-payload db [:div "hello"])
+        exported-auth (get-in payload [:rf/app-db :auth])]
     (assert (= #{:rf/runtime :auth :articles}
-               (set (keys (:rf/app-db payload)))))))
+               (set (keys (:rf/app-db payload)))))
+    ;; rf2-ygh4m ITEM 7 — the bearer JWT must NOT cross the SSR seam.
+    ;; The :auth slice still rides along (the client needs :user), but
+    ;; :token is redacted at the payload boundary (ssr/exportable-db);
+    ;; the client re-derives it from localStorage on hydrate.
+    (assert (= {:username "alice"} (:user exported-auth))
+            "the :auth :user payload survives hydration")
+    (assert (not (contains? exported-auth :token))
+            "the JWT must be redacted from the SSR hydration payload")))


### PR DESCRIPTION
Senior-dev review fixes for `examples/reagent/realworld` (the flagship RealWorld/Conduit example). Closes rf2-ygh4m. Single isolated app dir; no spec change (example code).

## P1 correctness
- **ITEM 1 — post-login `:return-to` now consumed.** The runtime drops `:rf.route/navigate` opts (only `:query`/`:fragment`/`:replace?`/`:scroll`/`:bypass-leave-guard?` are read), so the old opts-borne `:return-to` silently evaporated. The auth-guard now stashes the original target into `[:auth :return-to]` (a `:before`/`:after` interceptor pair), and a new `:auth/post-login-redirect` event reads + clears it and bounces the user there, falling back to home. Machine actions can't read/write `:db` (Spec 005 §Hard-disallow `:db`), so the bounce is an ordinary event dispatched from `:store-session`.
- **ITEM 2 — favorite + follow/unfollow auth-gated.** An unauthenticated click now navigates to login instead of optimistically flipping state then rolling back after the real backend 401s — no flicker for logged-out users.

## P2 correctness
- **ITEM 3 — optimistic comment stays in place.** `:comment-form/submit-success` replaces the temp card by id (map-and-swap, position preserved); no bottom-to-top teleport.
- **ITEM 6 — article-detail re-fetch error no longer blanks a loaded article.** The error branch is gated on `(and article-error (nil? article))`.
- **ITEM 7 — JWT redacted from the SSR hydration payload.** `exportable-db` drops `[:auth :token]` at the payload boundary (the client re-derives it from localStorage on hydrate via `:auth/initialise`), with a why-secrets-don't-cross-the-seam comment.

## Architecture items — confirmed deliberate, noted not unified (per the bead's judgment guidance)
- **ITEM 4 — dual Bearer-token injection.** Added a note that the per-call (`rh/request`) and frame-interceptor shapes are both wired live on purpose for side-by-side demonstration, and the second write is idempotent (same header, same value).
- **ITEM 5 — three rollback shapes.** Noted they differ because the data differs (cross-slice field patch / single boolean / positional list splice); the shared surface that pays off (`patch-article-everywhere`) is already factored out and is now also reused by the comment in-place swap.

## Polish
- **ITEM 8** — kept the unconditional `:auth/restore` dispatch (it spawns the auth machine snapshot at boot; guarding it would leave `:auth/state` at `nil` on a no-token boot) with a clarifying note pointing at the machine's `:has-token?` guard.
- **ITEM 9** — deleted the dead `:home/feed-kind` sub (zero consumers, grep-confirmed across tracked files + tests).
- **ITEM 10** — lifted the demo `:after-ms 20` literal to a named `demo-reply-delay-ms`.

## Tests / schema
- `AuthSlice` gains an optional `:return-to` key (documents the slot).
- `favorites_test`: authenticate before toggling (the auth-gate now requires a session to reach the rollback path).
- `routing_test`: added end-to-end bounce-back coverage (stash on redirect + clear on consume).
- `ssr_test`: added a token-redaction assertion (`:user` survives, `:token` is gone).

## Quality gates (cold)
- `npx shadow-cljs compile examples/realworld` → **0 warnings** (242 files).
- `npm run test:cljs` → **5493 tests, 19111 assertions, 0 failures, 0 errors**.