### PR TITLE
fix(examples): correct machines-chapter reference ch.11 -> ch.12 in state_machine_walkthrough (rf2-4lgkb)

### DIFF
--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -1,7 +1,7 @@
 (ns state-machine-walkthrough.core
   "Runnable companion to docs/guide/12-machines.md.
 
-  This is the login-flow chapter as code. Every prose snippet in ch.11
+  This is the login-flow chapter as code. Every prose snippet in ch.12
   appears here in the order the chapter introduces it; each section
   ends with a smoke-test fn that drives the machine through the
   scenario the chapter describes.
@@ -109,7 +109,7 @@
     :submitting
     ;; :auth/busy tag — views query (rf/machine-has-tag? :auth.login/flow
     ;; :auth/busy) to disable inputs and re-label the submit button
-    ;; while the request is in flight (ch.11 §State tags).
+    ;; while the request is in flight (ch.12 §State tags).
     {:tags  #{:auth/busy}
      :entry :issue-request
      :on    {:auth.login/success {:target :authed
@@ -199,7 +199,7 @@
 ;; the named subs below chain off it to project out the convenient
 ;; pieces. The "in :submitting?" / "in :authed?" / "in :locked-out?"
 ;; predicates moved to the `rf/machine-has-tag?` queries in views.cljs
-;; (ch.11 §State tags) — discriminating on the machine's runtime-projected
+;; (ch.12 §State tags) — discriminating on the machine's runtime-projected
 ;; `:tags` set decouples view code from individual state-keyword identity.
 
 (rf/reg-sub :auth.login/state

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -29,7 +29,7 @@
                   :auth.login/flow → :auth.login/submit on submit.
 
                   View-side discriminators read the machine's runtime-projected
-                  `:tags` set (ch.11 §State tags) via `rf/machine-has-tag?`, not boolean
+                  `:tags` set (ch.12 §State tags) via `rf/machine-has-tag?`, not boolean
                   state-predicate subs."}
           login-form []
   (let [state (atom {:email "" :password ""})]


### PR DESCRIPTION
## What

Corrects the four bare `ch.11` chapter-number tokens in the `state_machine_walkthrough` reagent example to `ch.12`, matching the `docs/guide/12-machines.md` links already present throughout the same files.

## Why (rf2-4lgkb)

This guided-walkthrough example exists to be read alongside the machines chapter. The machines chapter is `docs/guide/12-machines.md` (chapter 12); chapter 11 is `11-forms.md`. Every file-path link in these files already points at `12-machines.md`, but four prose snippets said `ch.11` — an internal contradiction that would send a reader to Forms instead of Machines, undercutting the example's credibility as the authoritative companion.

## Changes

Four tokens, prose only (docstrings/comments):
- `core.cljc:4` — "Every prose snippet in ch.11" -> ch.12 (ns docstring)
- `core.cljc:112` — "while the request is in flight (ch.11 §State tags)" -> ch.12
- `core.cljc:202` — "(ch.11 §State tags) — discriminating on..." -> ch.12
- `views.cljs:32` — "`:tags` set (ch.11 §State tags)..." -> ch.12 (login-form docstring)

Confirmed against the actual chapter file: the "Tags / State tags" section lives at line 279 of `docs/guide/12-machines.md`. Links and the section-title phrasing are unchanged.

## Gates
- `npx shadow-cljs compile :examples/state-machine-walkthrough` (cold) — Build completed, 162 files, **0 warnings**
- `mkdocs build --strict` — N/A (example source, not a guide doc / not in mkdocs nav)
- grep — zero remaining `ch.11`/`chapter 11` tokens in `state_machine_walkthrough`; all four now read `ch.12`
- Examples are test-free; no spec.cjs added.

## Notes
- rf2-0v3gf also touches `state_machine_walkthrough/core.cljc` (the `:auth.login/flow` reg-machine id) — a different region. It is held (not running concurrently). My diff is comment/docstring prose only and does not touch the `reg-machine` id definition; disjoint by line and intent.