### PR TITLE
fix(examples/ssr): defer create-root into run — mount-isolation (rf2-8h86h)

### DIFF
--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -272,9 +272,11 @@
   {:doc "Client-side init that runs even if the server didn't render this page."}
   (fn [db _] db))
 
-#?(:cljs
-   (defonce react-root
-     (rdc/create-root (js/document.getElementById "app"))))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+#?(:cljs (defonce react-root (atom nil)))
 
 #?(:cljs
    (defn run []
@@ -290,11 +292,15 @@
      ;; the payload's :rf/app-db slice (locked :replace-app-db policy per
      ;; Spec 011 §The :rf/hydrate event). On a "client-only" load (no
      ;; payload script), :ssr/client-bootstrap runs as a no-op and the page
-     ;; renders the empty-articles fallback.
+     ;; renders the empty-articles fallback. Hydrate BEFORE first render so
+     ;; the initial render runs against the seeded app-db.
      (if-let [payload (read-server-payload)]
        (rf/dispatch-sync [:rf/hydrate payload])
        (rf/dispatch-sync [:ssr/client-bootstrap]))
-     (rdc/render react-root [(rf/view :app/root)])))
+     (when (exists? js/document)
+       (when-not @react-root
+         (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+       (rdc/render @react-root [(rf/view :app/root)]))))
 
 ;; The JVM-runnable headless test that exercises the full server flow
 ;; (per-request frame → :rf/server-init → managed-HTTP via a canned stub →

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -201,9 +201,11 @@
 ;; payload) is exercised end-to-end by the browser acceptance test
 ;; `re-frame.ssr.streaming-client-dom-cljs-test`.
 
-#?(:cljs
-   (defonce react-root
-     (rdc/create-root (js/document.getElementById "app"))))
+;; The React root is held in an atom and materialised lazily inside `run`
+;; (not at ns-load) per examples/TESTING.md §Example mount-isolation
+;; convention: ns-load must produce no DOM side effects so co-required
+;; example namespaces don't race `create-root` onto the shared `#app`.
+#?(:cljs (defonce react-root (atom nil)))
 
 #?(:cljs
    (defn run []
@@ -219,9 +221,13 @@
      ;; omitted — the static demo shell carries a placeholder render-hash,
      ;; so hash-mismatch verification would always warn here; a real
      ;; streaming server stamps the genuine hash and a host then passes
-     ;; `:render-tree-fn` to enable mismatch detection.)
+     ;; `:render-tree-fn` to enable mismatch detection.) Hydrate BEFORE
+     ;; first render so the initial render runs against the seeded app-db.
      (ssr/hydrate! {:frame :rf/default})
-     (rdc/render react-root [(rf/view :dashboard/root)])))
+     (when (exists? js/document)
+       (when-not @react-root
+         (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+       (rdc/render @react-root [(rf/view :dashboard/root)]))))
 
 ;; The JVM-runnable headless test that exercises the server stream
 ;; (shell → per-card resolved chunks → final payload) lives in the sibling


### PR DESCRIPTION
## Summary

Both SSR examples created the React root **at ns-load**, breaking the mount-isolation convention every sibling example follows and cites:

- `examples/reagent/ssr/core.cljc` (was ~275–277)
- `examples/reagent/ssr_streaming/core.cljc` (was ~204–206)

Both did `#?(:cljs (defonce react-root (rdc/create-root (js/document.getElementById "app"))))` **outside** `run`. Every other reviewed example (counter, routing, managed_http_counter, …) holds the root in `(defonce react-root (atom nil))` and materialises it lazily inside `run` under `(when (exists? js/document) (when-not @react-root …))`. The convention exists precisely to prevent the co-mount race on the shared `#app` element in the `test:browser` bundle, where every example ns loads into one page (`examples/TESTING.md` §Example mount-isolation convention).

SSR/hydration is the slice most sensitive to mount discipline, and these are the files a reader copies when wiring their own hydration entry point — they should model the house pattern, not the exception.

## Change

Switch both to the deferred `(defonce react-root (atom nil))` + lazy `create-root` inside `run`, matching the sibling shape. Hydrate-before-render ordering preserved (`dispatch-sync :rf/hydrate` / `ssr/hydrate!` still precedes `rdc/render`).

- No DOM side effect at ns-load.
- Server render path (JVM `handle-request`) untouched.
- `:cljs` reader-conditional guard retained (these are `.cljc`, unlike the `.cljs` siblings).

## Quality gates (cold)

- `npx shadow-cljs compile examples/ssr examples/ssr-streaming` → both **Build completed, 0 warnings**.
- Examples are test-free (rf2-8cevm); no specs added. The JVM example tests (`ssr.core-test`, `ssr-streaming.core-test`) exercise only the server `handle-request` path and are unaffected by the `:cljs` `run` change. The streaming browser test (`re-frame.ssr.streaming-client-dom-cljs-test`) tests the framework runtime directly and does not require the example ns.

## Risk

Low. Behaviour-preserving timing move: `create-root` now fires inside `run` (the bundle `:init-fn`) instead of at ns-load. Same hydrate-then-render order; same single root via `defonce` + `when-not @react-root`.

Closes rf2-8h86h.