### PR TITLE
fix(examples): control crud filter input + guard filtered-out selection (rf2-yv011)

### DIFF
--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -137,8 +137,16 @@
                  people)))))
 
 (rf/reg-sub :crud/can-update?
+  {:doc "Update/Delete are enabled only when the selected row is *visible*
+         under the active filter. A selection hidden by the filter must not
+         be actionable — Update/Delete would otherwise touch an invisible row.
+         This is the master/detail edge the 7GUIs CRUD task is meant to model:
+         the answer is derived state (a sub of the filtered list), so the
+         selection is preserved and re-enables itself when the filter clears."}
   :<- [:crud/selected-id]
-  (fn [id _] (some? id)))
+  :<- [:crud/filtered-people]
+  (fn sub-crud-can-update? [[id visible-people] _]
+    (boolean (and id (some #(= id (:id %)) visible-people)))))
 
 ;; ============================================================================
 ;; VIEW
@@ -146,6 +154,7 @@
 
 (reg-view crud-view []
   (let [people      @(subscribe [:crud/filtered-people])
+        filter-text @(subscribe [:crud/filter-text])
         selected-id @(subscribe [:crud/selected-id])
         d-name      @(subscribe [:crud/draft-name])
         d-surname   @(subscribe [:crud/draft-surname])
@@ -155,6 +164,7 @@
       [:label "Filter prefix: "]
       [:input {:type      "text"
                :data-testid "crud-filter"
+               :value     filter-text
                :on-change #(dispatch [:crud/set-filter (.. % -target -value)])}]]
      [:div.row
       [:select.list {:size      6


### PR DESCRIPTION
## What

Fixes two master/detail bugs in `examples/reagent/seven_guis/crud/core.cljs` (bead rf2-yv011, P3).

### 1. Filter input was uncontrolled (IDIOM)
The filter input had `:on-change` dispatching `:crud/set-filter` but **no `:value`**, while every other text input in the suite (crud name/surname, flight_booker, temperature, cells) is controlled. The CRUD headline teaching point is that inputs **are** a sub of state — leaving the filter uncontrolled contradicted that thesis in the same file, and a programmatic reset of `:filter-text` would not reflect in the box.

**Fix:** bind `:value @(subscribe [:crud/filter-text])` on the filter input.

### 2. Selection could target a filter-hidden row (CORRECTNESS)
The select lists `:crud/filtered-people` but its `:value` is `selected-id` from the full set. Selecting a row then typing a filter that excludes it left `can-update?` true (`(some? id)`), so Update/Delete acted on a now-invisible row — the classic CRUD master/detail edge.

**Fix:** derive `:crud/can-update?` from `:crud/filtered-people` — gated on the selected id being **present in the filtered set**. Update/Delete disable when the selection is hidden and re-enable when the filter clears. Selection is **preserved**, not discarded (better UX, and stays purely derived state — no event-side reconciliation fighting the filter). Reuses the existing memoised `:crud/filtered-people` sub.

## Scope
`examples/reagent/seven_guis/crud/core.cljs` only.

## Gates
- `npx shadow-cljs compile :examples/crud` → **Build completed, 0 warnings**.
- Examples are test-free (rf2-8cevm); the crud example is not on the `test:cljs` node-test classpath, so no CLJS unit tests apply.

## Notes
- **rf2-r57cs overlap:** that held bead (`[re-frame.views]` require across the six seven_guis) touches this file's **ns form**. This PR does **not** touch the ns `:require` — only the filter input `:value` and the `:crud/can-update?` sub + view `let`. Flagged for sequencing.

Closes rf2-yv011.
