### PR TITLE
docs(examples): clarify login/walkthrough :auth.login/flow parallel variant (rf2-0v3gf)

### DIFF
--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -22,16 +22,24 @@
    - Open-map idiom                        — every shape on the wire is an open map
 
    Test-free per the examples policy (no inline test fn, no sibling
-   `test/` tree): the login flow this file wires is the same
+   `test/` tree): the login flow this file wires is a near-twin of the
    `:auth.login/flow` machine the sibling `state_machine_walkthrough`
    example exercises headlessly — its `test/state_machine_walkthrough/
    core_test.cljc` drives the happy-path / retry-then-lockout / pure
    machine-transition scenarios, gated by the
    `state-machine-walkthrough-runs-headless` deftest in
-   `implementation/core/test/re_frame/examples_test.clj`. Broader login
-   contract coverage lives in the substrate contract suite
-   (`npm run test:cljs`) and the framework gates (see
-   `examples/README.md`).
+   `implementation/core/test/re_frame/examples_test.clj`. The walkthrough
+   registers its OWN parallel `:auth.login/flow` variant (same states,
+   guards, actions; it adds an `:auth/locked` tag on `:locked-out`
+   because its root-view renders a dedicated lockout panel — this file
+   omits that tag since its view never branches on lockout). That is a
+   deliberate pedagogical variant, not the literal same registration:
+   a machine id is a per-frame registry key, never a global handle, so
+   two examples may name-share without colliding (and they never co-load
+   — the walkthrough runs JVM-headless with `remove-ns` between runs;
+   login builds standalone). Broader login contract coverage lives in
+   the substrate contract suite (`npm run test:cljs`) and the framework
+   gates (see `examples/README.md`).
 
    In a real codebase, this single file would be split per CP-6 conventions:
      login/schema.cljc | events.cljs | subs.cljs | views.cljs |

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -46,9 +46,17 @@
 ;; map; cross-machine reuse is via Clojure vars (define a fn, name it
 ;; locally in each machine's :guards / :actions).
 ;;
-;; This is intentionally the SAME login machine as the `login` example
-;; (examples/reagent/login/core.cljs) — same states, guards, and actions.
-;; The two examples differ in what they teach AROUND the machine: `login`
+;; This is a near-twin of the login machine in the `login` example
+;; (examples/reagent/login/core.cljs) — same states, guards, actions, and
+;; transitions. The one deliberate divergence: this variant tags `:locked-out`
+;; with `:auth/locked` because the walkthrough's root-view renders a dedicated
+;; lockout panel that branches on that tag (views.cljs); the `login` example
+;; omits the tag since its view never distinguishes lockout. The two examples
+;; register the id `:auth.login/flow` independently — a machine id is a
+;; per-frame registry key, not a global handle, and the two never co-load
+;; (this walkthrough runs JVM-headless with `remove-ns` between runs; login
+;; builds standalone), so the shared name is parallel, not a collision.
+;; The two examples also differ in what they teach AROUND the machine: `login`
 ;; wires it into a live Reagent view; this walkthrough drives it HEADLESSLY
 ;; (the sibling core-test ns) to show the pure machine-transition + drain
 ;; testing story from docs/guide/12-machines.md. Read `login` first for the


### PR DESCRIPTION
## What

The `login` and `state_machine_walkthrough` reagent examples both register a machine under the id `:auth.login/flow`, with near-identical but **divergent** specs:

- **walkthrough** tags `:locked-out` with `:auth/locked` (its root-view renders a dedicated lockout panel that branches on that tag — see `views.cljs`)
- **login** omits the tag (its view never distinguishes lockout)

Otherwise the two machines are identical (same states, guards, actions, transitions).

`login`'s docstring previously called it the same `:auth.login/flow` machine the walkthrough exercises. A reader following login's see-the-sibling pointer lands on a machine with a different tag set under an identical id, with no note that it is a variant — inviting the wrong inference that machine ids are global and the two are one registration.

## Fix (rf2-0v3gf)

Comment/docstring-only — chose the clarifying-note path over a distinct id because the divergence is intentionally pedagogical (a one-tag variant of the same flow), not two genuinely different machines:

- `login/core.cljs` cross-reference: now states the walkthrough registers its OWN parallel `:auth.login/flow` variant, names the one-tag (`:auth/locked`) divergence and why, and notes a machine id is a per-frame registry key (not a global handle) so the shared name is parallel, not a collision (and the two never co-load).
- `state_machine_walkthrough/core.cljc` transition-table header: corrected the prior "intentionally the SAME login machine" overclaim to acknowledge the one deliberate tag divergence, plus the per-frame-registry / never-co-load rationale.

No code changes.

## Gates

- `npx shadow-cljs compile :examples/login :examples/state-machine-walkthrough` — both **0 warnings** (cold, after `npm install`).
- Examples are test-free per policy; changes are comment-only so the headless walkthrough deftest is unaffected.

## Notes

- rf2-4lgkb (walkthrough chapter-refs) already merged and touched a different region of `core.cljc`; no conflict.
- Closes rf2-0v3gf.
