### PR TITLE
fix(examples/websocket): tag-drive all status-pill branches (rf2-k7ohr)

### DIFF
--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -375,6 +375,14 @@
   :<- [:ws/snapshot]
   (fn [snap _] (:state snap)))
 
+(rf/reg-sub :ws/connecting?
+  :<- [:ws/snapshot]
+  (fn [snap _] (contains? (:tags snap) :websocket/connecting)))
+
+(rf/reg-sub :ws/authenticating?
+  :<- [:ws/snapshot]
+  (fn [snap _] (contains? (:tags snap) :websocket/authenticating)))
+
 (rf/reg-sub :ws/connected?
   :<- [:ws/snapshot]
   (fn [snap _] (contains? (:tags snap) :websocket/connected)))

--- a/examples/reagent/websocket/test/websocket/test_helpers.cljs
+++ b/examples/reagent/websocket/test/websocket/test_helpers.cljs
@@ -108,6 +108,8 @@
   (rf/reg-machine :ws/connection ws.connection/connection-machine)
   (rf/reg-sub :ws/snapshot       (fn [db _] (get-in db [:rf/runtime :machines :snapshots :ws/connection])))
   (rf/reg-sub :ws/state          :<- [:ws/snapshot] (fn [snap _] (:state snap)))
+  (rf/reg-sub :ws/connecting?    :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/connecting)))
+  (rf/reg-sub :ws/authenticating? :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/authenticating)))
   (rf/reg-sub :ws/connected?     :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/connected)))
   (rf/reg-sub :ws/reconnecting?  :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/reconnecting)))
   (rf/reg-sub :ws/failed?        :<- [:ws/snapshot] (fn [snap _] (contains? (:tags snap) :websocket/failed)))

--- a/examples/reagent/websocket/views.cljs
+++ b/examples/reagent/websocket/views.cljs
@@ -9,11 +9,12 @@
 
    Two things to notice as you read the views:
 
-   1. The status indicator reads `:websocket/connected`,
-      `:websocket/reconnecting`, `:websocket/failed` via `rf/machine-has-tag?` —
-      the view doesn't need to know *which* leaf carries the
-      `:connected` intent, only that the tag is present. This is what
-      `:fsm/tags` buys.
+   1. The status indicator reads `:websocket/connecting`,
+      `:websocket/authenticating`, `:websocket/connected`,
+      `:websocket/reconnecting`, `:websocket/failed` via
+      `rf/machine-has-tag?` — every pill branch is tag-driven. The view
+      doesn't need to know *which* leaf carries the `:connected` intent,
+      only that the tag is present. This is what `:fsm/tags` buys.
 
    2. The send form's `disabled` attribute is driven by an explicit
       :ws/connected? sub (rather than a `:cond` over the snapshot's
@@ -40,22 +41,21 @@
                   Drop click without relying on catching the transient
                   RECONNECTING window in the pill text."}
           status-pill []
-  (let [connected?     @(subscribe [:ws/connected?])
-        reconnecting?  @(subscribe [:ws/reconnecting?])
-        failed?        @(subscribe [:ws/failed?])
-        state          @(subscribe [:ws/state])
-        retries        @(subscribe [:ws/retries])
-        err            @(subscribe [:ws/error])]
+  (let [connected?      @(subscribe [:ws/connected?])
+        authenticating? @(subscribe [:ws/authenticating?])
+        connecting?     @(subscribe [:ws/connecting?])
+        reconnecting?   @(subscribe [:ws/reconnecting?])
+        failed?         @(subscribe [:ws/failed?])
+        retries         @(subscribe [:ws/retries])
+        err             @(subscribe [:ws/error])]
     [:div.status {:data-testid "ws-status"}
      (cond
-       failed?         [:span.pill.failed       "FAILED"]
-       reconnecting?   [:span.pill.reconnecting (str "RECONNECTING (attempt " retries ")")]
-       connected?      [:span.pill.connected    "CONNECTED"]
-       (= [:active :authenticating] state)
-       [:span.pill.authenticating "AUTHENTICATING"]
-       (= [:active :connecting] state)
-       [:span.pill.connecting "CONNECTING"]
-       :else           [:span.pill.disconnected "DISCONNECTED"])
+       failed?         [:span.pill.failed         "FAILED"]
+       reconnecting?   [:span.pill.reconnecting   (str "RECONNECTING (attempt " retries ")")]
+       connected?      [:span.pill.connected      "CONNECTED"]
+       authenticating? [:span.pill.authenticating "AUTHENTICATING"]
+       connecting?     [:span.pill.connecting     "CONNECTING"]
+       :else           [:span.pill.disconnected   "DISCONNECTED"])
      (when err
        [:span.error {:data-testid "ws-error"} (str " — " (pr-str err))])
      ;; Always-visible counter (independent of the pill's transient


### PR DESCRIPTION
## What

The websocket example teaches **tag-based state queries** as its central idiom (ns docstring + the connection machine's whole `:fsm/tags` design pitch: the view asks `:websocket/connected?` etc. via tags and need not know which leaf carries the intent). But `status-pill` branched on the **raw hierarchical `:state` vector** — `(= [:active :authenticating] state)` and `(= [:active :connecting] state)` — for two of its five branches, because no sub exposed the `:websocket/authenticating` / `:websocket/connecting` tags. A reader saw the principle stated and immediately violated.

## Fix

The leaf states already carry those tags (`connection.cljs` — `:connecting` → `#{:websocket/active :websocket/connecting}`, `:authenticating` → `#{:websocket/active :websocket/authenticating}`). So this is purely a missing-subs gap, not a machine change:

- Add `:ws/connecting?` and `:ws/authenticating?` subs, mirroring the existing `:ws/connected?` / `:ws/reconnecting?` / `:ws/failed?` tag subs.
- `status-pill` now consults those subs; the raw-`:state`-vector branches are gone. All five branches are uniformly tag-driven. Dropped the now-unused `:ws/state` binding from the pill (`:ws/state` sub registration stays — it's a legit machine-state accessor used by the headless tests).
- Updated ns docstring note (1) to list the full tag set and state "every pill branch is tag-driven".
- Mirrored the two new subs into `test_helpers.cljs`' re-registration recovery, per that helper's own keep-in-sync mandate.

## Scope

`examples/reagent/websocket/` only. No machine def changes, no new files.

## Gates

- `npx shadow-cljs compile :examples/websocket` — Build completed, **0 warnings** (174 files, cold).
- `npm run test:cljs` — **5498 tests / 19120 assertions, 0 failures, 0 errors** (websocket test dir is on the node-test classpath; new subs integrate cleanly, headless recovery helper still passes).

Examples are test-free (rf2-8cevm) — the status-pill shows the same five states; the AUTHENTICATING/CONNECTING pills now resolve via the `:websocket/authenticating` / `:websocket/connecting` tags rather than raw-vector equality, which is behaviourally identical (those tags are present on exactly those leaves).

Closes rf2-k7ohr.