### PR TITLE
refactor(story-mcp): consolidate two copy-paste clusters (rf2-c2wbp)

### DIFF
--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -1175,10 +1175,22 @@
   ;; rf2-koq5m: story-mcp adopted the envelope-indicator parity. The
   ;; centralised emit-path is `egress/with-indicators` (delegating to
   ;; the shared mcp-base helper) + `egress/count-elided` (delegating to
-  ;; `count-elided-markers`). This pin asserts the helper exists AND
-  ;; that the three tree-walking tools route their payload through it —
-  ;; the structural guarantee that the omit-when-zero MUST lives in one
-  ;; place, mirroring `indicator_field_test.clj`'s pair-mcp routing pin.
+  ;; `count-elided-markers`). This pin asserts those helpers exist AND
+  ;; that the tree-walking tools route their payload through the
+  ;; centralised egress epilogue — the structural guarantee that the
+  ;; omit-when-zero MUST lives in one place, mirroring
+  ;; `indicator_field_test.clj`'s pair-mcp routing pin.
+  ;;
+  ;; rf2-c2wbp folded the dual-coded `(edn-result (with-indicators
+  ;; payload {:dropped d :elided (count-elided payload)}))` epilogue —
+  ;; previously inlined verbatim at the three live-state read sites
+  ;; (dev/preview-variant, testing/run-variant, testing/read-failures) —
+  ;; into a single `egress/result-with-indicators` helper, alongside
+  ;; `with-indicators` + `count-elided` in `egress.cljc`. The tools now
+  ;; route through `egress/result-with-indicators`, which itself routes
+  ;; through `egress/with-indicators`: the emit-path is MORE centralised,
+  ;; not less. This pin follows the routing into that helper rather than
+  ;; greping each tool body for the now-folded `with-indicators` literal.
   (let [egress-rel "tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc"
         egress-src (fx/read-source egress-rel)]
     (testing "egress.cljc defines the centralised with-indicators helper"
@@ -1193,14 +1205,26 @@
       (is (str/includes? egress-src "base-elision/count-elided-markers")
           (str egress-rel " must reuse "
                "`re-frame.mcp-base.elision/count-elided-markers` for the "
-               ":elided-large count (rf2-koq5m)."))))
+               ":elided-large count (rf2-koq5m).")))
+    (testing "egress.cljc defines the result-with-indicators epilogue helper"
+      (is (str/includes? egress-src "(defn result-with-indicators")
+          (str "`result-with-indicators` helper missing from " egress-rel
+               " — the live-state read tools route their payload through it "
+               "(rf2-c2wbp).")))
+    (testing "result-with-indicators routes through the centralised with-indicators emit-path"
+      (is (str/includes? egress-src "(with-indicators payload")
+          (str egress-rel "'s `result-with-indicators` must thread its payload "
+               "through `with-indicators` — the omit-when-zero MUST stays on "
+               "the single centralised emit-path (rf2-koq5m / rf2-c2wbp)."))))
   (doseq [rel ["tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc"
                "tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc"]]
-    (testing (str rel " — routes payload through egress/with-indicators")
-      (is (str/includes? (fx/read-source rel) "egress/with-indicators")
+    (testing (str rel " — routes payload through egress/result-with-indicators")
+      (is (str/includes? (fx/read-source rel) "egress/result-with-indicators")
           (str rel " does not route its payload through "
-               "`egress/with-indicators` — the centralised emit-path is the "
-               "structural contract for the omit-when-zero MUST (rf2-koq5m).")))))
+               "`egress/result-with-indicators` — the centralised egress "
+               "epilogue (which threads through `egress/with-indicators`) is "
+               "the structural contract for the omit-when-zero MUST "
+               "(rf2-koq5m / rf2-c2wbp).")))))
 
 ;; ---------------------------------------------------------------------------
 ;; `:rf.mcp/cursor-stale` reason-value gate (rf2-i3ffz F-GAP-5).

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
@@ -15,6 +15,9 @@
     prelude shared by ten handlers (see rf2-f0zxa), routing the agent-
     supplied id through the bounded variant-registry allowlist before
     coercing to a keyword (rf2-lqjbk).
+  - `with-story-id` — the story-side peer of `with-variant-id`,
+    resolving `:story-id` through the bounded story-registry allowlist
+    (shared by `get-story` / `get-docs-markdown`).
   - `read-run-opts` — the `:substrate` / `:active-modes` /
     `:cell-overrides` reader for `run-variant` / `preview-variant` /
     `snapshot-identity`, with each kw-typed slot routed through
@@ -155,6 +158,31 @@
             (result/error-result (str "Variant not found: " (pr-str vk)))
             (f vk body)))
         (result/error-result (str "Variant not found: " (pr-str vid)))))))
+
+(defn with-story-id
+  "Resolve `:story-id` from `arguments` (required), resolve it against
+  the registered-stories set (rf2-lqjbk — no JVM intern outside the
+  allowlist), and call `(f sk)` when it resolves. Otherwise short-
+  circuits with an error result:
+
+    - Missing/blank `:story-id` ⇒ `Missing required argument: …`
+      (the shape `required-arg` emits).
+    - Unregistered story ⇒ `Story not found: <sid>` (the raw caller-
+      supplied string is echoed; the safe-keyword gate refused to
+      intern a keyword form).
+
+  The story-side peer of `with-variant-id`. Crystallises the prelude
+  shared by the two docs handlers that resolve a story id directly
+  (`get-story`, `get-docs-markdown`) — both probe
+  `(args/safe-keyword sid (story/ids :story))` and emit the same
+  `Story not found` error on a miss."
+  [arguments f]
+  (let [[sid err] (required-arg arguments :story-id)]
+    (if err
+      err
+      (if-let [sk (args/safe-keyword sid (story/ids :story))]
+        (f sk)
+        (result/error-result (str "Story not found: " (pr-str sid)))))))
 
 (defn with-variant-id
   "Resolve `:variant-id` from `arguments` (required) against the

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -154,10 +154,7 @@
         ;; how many sensitive assertion records were dropped + how many
         ;; over-threshold leaves were elided across the payload. Omitted
         ;; when zero (Conventions §Cross-MCP indicator-field vocabulary).
-        (result/edn-result
-          (egress/with-indicators payload
-                                  {:dropped dropped
-                                   :elided  (egress/count-elided payload)}))))))
+        (egress/result-with-indicators payload dropped)))))
 
 (defn tool-list-substrates
   "Dev: what substrates can be used. Reads the registered substrate set

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -75,15 +75,14 @@
 
   rf2-lqjbk: `:story-id` is resolved through `args/safe-keyword`
   against the registered-stories set — an unknown id returns the
-  documented `Story not found` error without interning."
+  documented `Story not found` error without interning (via the shared
+  `targs/with-story-id` prelude)."
   [args]
-  (let [[sid err] (targs/required-arg args :story-id)]
-    (if err err
-      (if-let [sk (args/safe-keyword sid (story/ids :story))]
-        (let [body (story/handler-meta :story sk)
-              payload {:id sk :body body :variants (sort (story/variants-of sk))}]
-          (result/edn-result payload))
-        (result/error-result (str "Story not found: " (pr-str sid)))))))
+  (targs/with-story-id args
+    (fn [sk]
+      (result/edn-result {:id       sk
+                          :body     (story/handler-meta :story sk)
+                          :variants (sort (story/variants-of sk))}))))
 
 (defn tool-get-variant
   "Docs: one variant's full body (`handler-meta :variant id`)."
@@ -353,17 +352,15 @@
   slot and as a `:markdown` structuredContent slot (paste-target for
   agent hosts that surface structured content)."
   [args]
-  (let [[sid err] (targs/required-arg args :story-id)]
-    (if err err
-      (if-let [sk (args/safe-keyword sid (story/ids :story))]
-        (let [body     (story/handler-meta :story sk)
-              variants (sort (story/variants-of sk))
-              md       (render-story-markdown sk body variants)
-              payload  {:story-id sk
-                        :markdown md
-                        :variants (vec variants)}]
-          (result/text-result md payload))
-        (result/error-result (str "Story not found: " (pr-str sid)))))))
+  (targs/with-story-id args
+    (fn [sk]
+      (let [body     (story/handler-meta :story sk)
+            variants (sort (story/variants-of sk))
+            md       (render-story-markdown sk body variants)
+            payload  {:story-id sk
+                      :markdown md
+                      :variants (vec variants)}]
+        (result/text-result md payload)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Registry descriptors (assembled in `tools.registry/tool-registry`)

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
@@ -48,7 +48,8 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.mcp-base.elision :as base-elision]
             [re-frame.mcp-base.envelope :as base-envelope]
-            [re-frame.mcp-base.sensitive :as sensitive]))
+            [re-frame.mcp-base.sensitive :as sensitive]
+            [re-frame.story-mcp.tools.result :as result]))
 
 ;; ---------------------------------------------------------------------------
 ;; Path-based redaction
@@ -238,3 +239,25 @@
   its slot, so a clean read returns the payload unchanged."
   [payload counts]
   (base-envelope/with-indicators payload counts))
+
+(defn result-with-indicators
+  "Build the final `edn-result` for a live-state read, splicing on the
+  MUST-level egress indicator counts (rf2-koq5m). The
+  `:dropped`-sensitive count is supplied by the caller (from
+  `scrub-assertions+count`); the `:elided`-large count is derived here
+  by walking the FINAL payload for `:rf.size/large-elided` markers via
+  `count-elided`.
+
+  This is the dual-coded epilogue the three live-state handlers shared
+  verbatim — `preview-variant` / `run-variant` / `read-failures` each
+  closed with `(result/edn-result (with-indicators payload {:dropped d
+  :elided (count-elided payload)}))`. Named once so each handler reads
+  as 'return this payload with its egress indicators' rather than
+  re-spelling the count-derive-and-splice dance. Counts omit their slot
+  when zero (Conventions §Cross-MCP indicator-field vocabulary), so a
+  clean read returns the bare payload."
+  [payload dropped]
+  (result/edn-result
+    (with-indicators payload
+                     {:dropped dropped
+                      :elided  (count-elided payload)})))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -179,10 +179,7 @@
         ;; dropped sensitive assertion records + elided over-threshold
         ;; leaves across every value-bearing slot. Omitted when zero
         ;; (Conventions §Cross-MCP indicator-field vocabulary).
-        (result/edn-result
-          (egress/with-indicators payload
-                                  {:dropped dropped
-                                   :elided  (egress/count-elided payload)}))))))
+        (egress/result-with-indicators payload dropped)))))
 
 (defn tool-snapshot-identity
   "Testing: content-hash of the canonicalised variant (for external
@@ -284,10 +281,7 @@
         ;; how many sensitive assertion records were dropped at egress
         ;; (+ any elided leaves). Omitted when zero (Conventions
         ;; §Cross-MCP indicator-field vocabulary).
-        (result/edn-result
-          (egress/with-indicators payload
-                                  {:dropped dropped
-                                   :elided  (egress/count-elided payload)}))))))
+        (egress/result-with-indicators payload dropped)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Registry descriptors (assembled in `tools.registry/tool-registry`)


### PR DESCRIPTION
## Summary

DRY-reduction review of `tools/story-mcp` (rf2-c2wbp). The slice is already moderately DRY (recent #2923 / #2960 activity, plus prior `rf2-jkake.20` / `rf2-f0zxa` / `rf2-ee38b.17` consolidations). Two genuine copy-paste clusters remained — both consolidated here, behaviour-preserving.

### 1. `args/with-story-id` — story-side peer of `with-variant-id`

The `required-arg :story-id -> safe-keyword against (story/ids :story) -> "Story not found"` prelude was duplicated verbatim in `docs/tool-get-story` and `docs/tool-get-docs-markdown`. `args.cljc` already houses `with-variant` / `with-variant-id` for the variant side; the story side simply lacked its peer. Extracted to the same home.

### 2. `egress/result-with-indicators` — the live-state read epilogue

`(result/edn-result (egress/with-indicators payload {:dropped dropped :elided (egress/count-elided payload)}))` was identical at three sites: `dev/preview-variant`, `testing/run-variant`, `testing/read-failures`. Folded into one helper in `egress.cljc`, where `with-indicators` and `count-elided` already live, so the count-derive-and-splice recipe has a single home.

### Left intact (not copy-paste)

The `run-variant` / `preview-variant` lifecycle `try`/`catch` looks similar but the error-outcome maps genuinely differ (`:lifecycle :error` vs `:frame vk`), and each handler's payload projection is substantively distinct with dense per-tool egress rationale. Extracting a shared "run lifecycle" abstraction would be a larger, riskier refactor with no clear win — that verbosity is intrinsic, not duplication.

## Descriptors

No descriptor `:description` / input-keys / `output?` / annotations touched — handler internals only. `clojure -M:gen --check` prints **"in sync (20 tools)"**; `tool-descriptors.edn` unchanged.

## Gates (from `tools/story-mcp/`, cold)

- `clojure -M:test` — 206 tests, 1050 assertions, 0 failures, 0 errors
- `clojure -M:gen --check` — `OK: tool-descriptors.edn in sync (20 tools).`
- story-mcp MCP conformance — stdio roundtrip GREEN; `test:story` end-to-end (exercises get-story / preview-variant / run-variant / read-failures omit-when-zero / gated writes) GREEN; `test:flag-gates` GREEN

(The full `npm run test:mcp-conformance` orchestrator additionally compiles the pair-mcp shadow bundle and runs wire-vocab JVM tests — neither touches story-mcp source, and this change is confined to story-mcp handler internals.)
