### PR TITLE
fix(story/testbed): make recorder-redaction-card self-contained (rf2-k924v)

### DIFF
--- a/tools/story/testbeds/counter_with_stories/events.cljs
+++ b/tools/story/testbeds/counter_with_stories/events.cljs
@@ -1,9 +1,10 @@
 (ns counter-with-stories.events
   "Counter events. The events module is the canonical app slice the
   stories namespace pivots around — three plain `reg-event-db`
-  handlers + one `reg-event-fx` initialiser. Nothing Story-specific
-  lives here; the same handlers run in the live counter app and in
-  the Story playground.
+  handlers + a `reg-event-fx` initialiser + a `:sensitive?` sign-in
+  handler the recorder-redaction variant pivots on. Nothing
+  Story-specific lives here; the same handlers run in the live
+  counter app and in the Story playground.
 
   Per IMPL-SPEC §1.1 + spec/007 §Variants: the variant body is data;
   it references these event ids in its `:events` slot. The handlers
@@ -70,3 +71,41 @@
   (fn [{:keys [db]} _event]
     {:db (assoc db :saving? true)
      :fx [[:counter/sync-to-server {:value (:count db)}]]}))
+
+;; A counter-owned `:sensitive?` handler so the recorder-redaction
+;; variant (`:story.counter-matrix/recorder-redaction`) is
+;; self-contained: the variant references views + events from this
+;; slice only, and the stories namespace's requires
+;; (`counter-with-stories.events` + `.views`) register every handler
+;; the variant dispatches. The card no longer relies on `core.cljs`
+;; happening to require `elision-demo` at live-app boot (which is the
+;; only place `:auth/sign-in` lives) — that hidden cross-namespace
+;; load-order coupling is exactly what a reference testbed should
+;; exclude.
+;;
+;; `:sensitive? true` is the whole-handler privacy escape hatch
+;; (Spec 009 §`:sensitive?`): the registrar copies the flag into the
+;; registry slot's meta, the runtime stamps every trace event emitted
+;; inside this handler's scope, and the Story recorder emits
+;; `[:rf/redacted]` in place of the password in the generated `:play`
+;; snippet while preserving the row position. The handler sees the
+;; unredacted payload (redaction is a trace-consumer concern, not a
+;; handler concern); we stash only a redacted placeholder in app-db —
+;; the password never lives in app-db.
+(rf/reg-event-fx :counter/sign-in
+  {:doc        "Demo sign-in handler — the password rides the event
+                vector. `:sensitive? true` tells trace consumers and
+                always-on substrates to suppress or redact these
+                events."
+   :sensitive? true}
+  (fn handler-counter-sign-in [{:keys [db]} [_ {:keys [email password]}]]
+    ;; In a real app this is where you'd dispatch the http request
+    ;; carrying `email` + `password`. We reference `password` so the
+    ;; handler-body semantic — "the handler sees the unredacted value
+    ;; via `:event`" — is visible in the source, then stash only a
+    ;; redacted placeholder for UI feedback.
+    (assert (string? password) "handler sees the unredacted password")
+    {:db (assoc db
+                :auth/last-sign-in
+                {:email      email
+                 :submitted? true})}))

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -143,6 +143,47 @@
         (is (contains? vs vid) (str vid " registered")))
       (is (= 14 (count vs))))))
 
+;; ---- recorder-redaction variant is self-contained (rf2-k924v) -----------
+;;
+;; This test ns requires `counter-with-stories.events` + `.stories`
+;; (which itself requires events + views) — but NOT
+;; `counter-with-stories.elision-demo`. The recorder-redaction-card
+;; dispatches `:counter/sign-in`, a `:sensitive?` handler owned by the
+;; counter events slice. If the card still depended on elision-demo's
+;; `:auth/sign-in` (the pre-rf2-k924v coupling) this handler-meta probe
+;; would come back nil, because nothing here boots elision-demo.
+
+(deftest recorder-redaction-sensitive-handler-registered-self-contained
+  (testing "the `:counter/sign-in` handler the recorder-redaction-card
+            dispatches is registered by the counter events slice — the
+            same requires that bring in the variant — and carries
+            `:sensitive? true` in its registry meta, with NO reliance on
+            elision-demo being booted by core.cljs."
+    (let [m (rf/handler-meta :event :counter/sign-in)]
+      (is (some? m)
+          ":counter/sign-in registration meta is populated by
+           counter-with-stories.events (required here; elision-demo is not)")
+      (is (true? (:sensitive? m))
+          "the registrar copied :sensitive? true from the handler metadata"))))
+
+(deftest recorder-redaction-variant-runs-self-contained
+  (testing ":story.counter-matrix/recorder-redaction runs to :ready and its
+            play assertion passes WITHOUT elision-demo boot wiring. The
+            variant's card dispatches the counter-owned `:counter/sign-in`
+            handler, so the variant's own requires satisfy every event it
+            can dispatch."
+    (async done
+      (-> (story/run-variant :story.counter-matrix/recorder-redaction)
+          (async-lib/then
+            (fn [result]
+              (is (= :ready (:lifecycle result)) "lifecycle reached :ready")
+              (is (= 11 (-> result :app-db :count))
+                  "the :counter/initialise 11 seed applied")
+              (is (story/assertions-passing? result)
+                  (str "play assertions: " (pr-str (:assertions result))))
+              (story/destroy-variant! :story.counter-matrix/recorder-redaction)
+              (done)))))))
+
 (deftest failing-fx-stub-miss-variant-fails-with-canonical-reason
   (testing "rf2-0uo4e testbed — :story.counter-matrix/failing-fx-stub-miss runs
             and its :rf.assert/effect-emitted assertion FAILS with the

--- a/tools/story/testbeds/counter_with_stories/views.cljs
+++ b/tools/story/testbeds/counter_with_stories/views.cljs
@@ -120,7 +120,13 @@
                  :flex-direction "column"
                  :gap "0.75em"}}
    [counter-card {:label label}]
-   [:button {:on-click   #(dispatch [:auth/sign-in
+   ;; `:counter/sign-in` is the counter slice's own `:sensitive?`
+   ;; handler (counter-with-stories.events) — so this card is
+   ;; self-contained: the same requires that bring in the variant
+   ;; (events + views) register the handler it dispatches. No reliance
+   ;; on core.cljs requiring the sibling elision-demo namespace at
+   ;; live-app boot.
+   [:button {:on-click   #(dispatch [:counter/sign-in
                                       {:email "redaction@example.com"
                                        :password "browser-secret"}])
              :aria-label "Dispatch sensitive sign-in event"


### PR DESCRIPTION
## What

The counter testbed's `recorder-redaction-card` dispatched `[:auth/sign-in ...]` — a `:sensitive?` handler registered **only** in `elision_demo.cljs`. The card worked only because `core.cljs` requires `elision-demo` at live-app boot (to mount the unrelated elision card). `stories.cljs` and `stories_cljs_test.cljs` never require `elision-demo`, so the `:story.counter-matrix/recorder-redaction` variant's button dispatched a handler that the variant's own requires never registered — a hidden cross-namespace, load-order coupling. A consumer copying this testbed would see a view dispatching an event with no locally discoverable handler.

## Fix

- Register a counter-owned `:counter/sign-in` `:sensitive?` handler in `events.cljs` (the canonical app slice the stories pivot around) and dispatch **that** from `recorder-redaction-card`.
- The handler mirrors the `:sensitive?` escape hatch (Spec 009 §`:sensitive?`): registrar copies the flag to the registry slot meta, the recorder emits `[:rf/redacted]` in the generated `:play` snippet, only a redacted placeholder lands in app-db (the password never lives in app-db).
- `elision_demo`'s `:auth/sign-in` is left **untouched** and stays elision-demo-owned (its README/test coverage is unaffected).
- Two new CLJS tests in `stories_cljs_test.cljs` (which does **not** require elision-demo): one asserts `:counter/sign-in` registry-meta carries `:sensitive? true`; the other runs the recorder-redaction variant to `:ready` with its play assertion passing — both prove self-containment with no elision-demo boot wiring.

## Acceptance (bead rf2-k924v)

- [x] recorder-redaction-card dispatches an event whose handler is registered by the same requires that bring in the variant — no reliance on `core.cljs` requiring elision-demo.
- [x] The recorder-redaction variant runs correctly under `stories_cljs_test.cljs` without depending on elision-demo boot wiring.

`tools/story/spec/*` unchanged (not affected by this fix).

## Gates (cold)

- `npm run test:cljs` — 5500 tests / 19125 assertions, 0 failures / 0 errors
- `clojure -M:test` (from `tools/story/`) — 1590 tests / 5953 assertions, 0 failures / 0 errors
- `npm run story:build` — counter-with-stories static export, 0 warnings

## Sequencing note

Overlaps `rf2-mxjn7` (HELD, not running): mxjn7 ITEM 1 re-narrates the `events.cljs` namespace docstring (`:events`→`:setup`) at the same docstring block I touched (a different sentence — handler inventory vs the `:events` slot line). Sequence on `events.cljs`; whichever lands second re-anchors its docstring edit.
