### PR TITLE
refactor(examples): standardise [re-frame.views] require across seven_guis (rf2-r57cs)

### DIFF
--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -41,6 +41,7 @@
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
+            [re-frame.views]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [clojure.set]
             [clojure.string :as str])

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -27,6 +27,7 @@
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
+            [re-frame.views]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -24,6 +24,7 @@
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
+            [re-frame.views]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 


### PR DESCRIPTION
## What

The six `seven_guis` examples split on the `[re-frame.views]` ns require: `timer` / `flight_booker` / `temperature` included it; `cells` / `circle_drawer` / `crud` omitted it — yet all six use `reg-view` identically. Six sibling files solving one benchmark should read as one house style; a reader diffing them sees an unexplained require appear and disappear and cannot tell which is canonical (rf2-r57cs).

## Decision: standardise on INCLUDE

Added `[re-frame.views]` to `cells`, `circle_drawer`, and `crud`, in the same ns-form position (between `[re-frame.schemas]` and `[re-frame.adapter.reagent-slim ...]`) the three including siblings already use. All six are now byte-identical in this region.

INCLUDE is the dominant catalogue convention — of the 10 `reg-view`-using reagent examples outside this cluster, 7 include `[re-frame.views]` (counter, flows, managed_http_counter, nine_states, notebook, routing, todomvc); 3 omit (login, long_running_work, realworld). The bead's enumerated FIX preference is INCLUDE ("Given the rest of the catalogue includes [re-frame.views], add it to cells/circle_drawer/crud for uniformity").

## Usage check (per file)

- None of the six references any `re-frame.views/*` symbol directly (`reg-view` is the macro, refer'd from `re-frame.core`; the macro expands only to `re-frame.core/{reg-view*, make-frame-handle, view}`).
- `re-frame.core` already requires `[re-frame.views :as views]` on CLJS (`core.cljc:76`), so the require is **transitively loaded via `[re-frame.core :as rf]`** in all six — it pulls in nothing new at runtime. (Contrast `[re-frame.schemas]`, which `re-frame.core` does NOT require — that one is genuinely load-bearing for its late-bind hooks, hence the existing self-documenting comment.)
- The change is therefore purely ns-form consistency. The quality gate explicitly permits an unused-but-required ns; a MISSING used require would fail compile.

## Gate (cold)

`npx shadow-cljs compile examples/cells examples/circle-drawer examples/crud` on a fresh worktree (post `npm install`):

```
[:examples/cells] Build completed. (149 files, 148 compiled, 0 warnings, 14.05s)
[:examples/circle-drawer] Build completed. (149 files, 148 compiled, 0 warnings, 6.83s)
[:examples/crud] Build completed. (149 files, 148 compiled, 0 warnings, 4.85s)
```

`npm run test:cljs` not applicable — no `examples/` path is on the cljs test build `:source-paths`; examples are test-free (rf2-8cevm). Confirmed no `*.spec.cjs` / `*_test.cljs` under `seven_guis`.

## Conflict check

No leftover conflict markers in `cells` / `crud` / `circle_drawer` (the files touched by the recently-merged yv011 + qlvw3). This PR touches only the ns `:require` forms; no logic.

## Scope

`examples/reagent/seven_guis/{cells,circle_drawer,crud}/core.cljs` — one line each (+3, -0). ns-form only.

Closes rf2-r57cs.