### PR TITLE
refactor(mcp-base): scrub-snapshot pure fold replaces volatile! side-channel (rf2-yxctl)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -203,18 +203,30 @@
   ([snapshot include? strip-fn]
    (if (or include? (not (map? snapshot)))
      [snapshot 0]
-     (let [dropped (volatile! 0)
-           scrub-slice
-           (fn [items]
-             (let [[kept n] (strip-fn (vec items) false)]
-               (vswap! dropped + n)
-               kept))
+     ;; Pure fold: thread BOTH the scrubbed map and the running drop
+     ;; count through the `reduce-kv` accumulator `[frame-map count]`
+     ;; rather than side-channelling the count through a mutable cell.
+     ;; `scrub-frame` returns `[scrubbed-frame dropped]` for one frame;
+     ;; the slice-scrub returns `[kept dropped]` straight from `strip-fn`,
+     ;; so the count rides the value the whole way down — no `volatile!`.
+     ;; Single walk over the snapshot, same cost as before.
+     (let [scrub-slice
+           (fn [frame-map slice-key acc]
+             (if (contains? frame-map slice-key)
+               (let [[kept n] (strip-fn (vec (get frame-map slice-key)) false)]
+                 [(assoc frame-map slice-key kept) (+ acc n)])
+               [frame-map acc]))
            scrub-frame
            (fn [frame-map]
-             (cond-> frame-map
-               (contains? frame-map :traces) (update :traces scrub-slice)
-               (contains? frame-map :epochs) (update :epochs scrub-slice)))
-           scrubbed (reduce-kv (fn [m k v]
-                                 (assoc m k (if (map? v) (scrub-frame v) v)))
-                               {} snapshot)]
-       [scrubbed @dropped]))))
+             (let [[fm1 d1] (scrub-slice frame-map :traces 0)]
+               (scrub-slice fm1 :epochs d1)))
+           [scrubbed dropped]
+           (reduce-kv
+             (fn [[m total] k v]
+               (if (map? v)
+                 (let [[scrubbed-frame n] (scrub-frame v)]
+                   [(assoc m k scrubbed-frame) (+ total n)])
+                 [(assoc m k v) total]))
+             [{} 0]
+             snapshot)]
+       [scrubbed dropped]))))


### PR DESCRIPTION
## What

FUNCTIONAL-PROGRAMMING-technique review of `tools/mcp-base/src/**` (bead **rf2-yxctl**, P3).

**Assessment:** the slice is overwhelmingly idiomatic — pure functions, `transduce`/`reduce`/`reduce-kv` folds, threading macros, `cond` dispatch (consistent with the recent #2953 dedup review). The documented perf carve-outs (the `diff-encode` accumulator-threading `collect-patches-into`, rf2-c2k9k; the single-pass `apply-cap` `transduce`; the `cap`/`overflow` hot folds) are correctly imperative-leaning-for-perf and are LEFT AS-IS. The `common-prefix` `loop`/`recur` is an idiomatic index walk for longest-common-prefix. The `sensitive` malformed-counter `AtomicLong`/`atom` is a justified process-wide thread-safe observability singleton.

**One genuine win shipped:** `sensitive/scrub-snapshot` (3-arity) threaded its running drop-count through a `volatile!` cell side-channelled around a `cond->`/`update` walk — the one `atom-as-local-mutable` / side-effect-accumulation pattern the bead names. Replaced with a pure `reduce-kv` fold whose accumulator carries BOTH the scrubbed map and the running count (`[map count]`). The count now rides the value the whole way down; no mutable cell.

## Behaviour-preserving

- Same single walk over the snapshot (no extra pass) — no perf regression.
- Same `(contains? frame-map slice-key)` guard semantics: a present key with a nil value still gets `(vec nil)` → `[]` scrubbed, identical to the prior `cond->` arm.
- Same `[scrubbed total-dropped]` public return; 2-arity form + public signature unchanged. mcp-base is consumed by story-mcp + pair-mcp — no public-API change.

## Gates (cold)

- mcp-base JVM `clojure -M:test` — **181 tests / 506 assertions, 0 failures**
- mcp-base CLJS `npm run test:cljs` — **8 tests / 39 assertions, 0 failures**
- `npm run test:mcp-conformance` — **all 6 gates GREEN** (incl. wire-vocab 49 tests / 629 assertions; the suite consumes mcp-base from both story-mcp JVM and pair-mcp CLJS)

Closes rf2-yxctl.