### PR TITLE
refactor(xray): functional-style cleanups in three pure helpers (rf2-dc9p7)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/chart/timing_waterfall.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/chart/timing_waterfall.cljc
@@ -74,26 +74,27 @@
       stack-of-bars (each row starts at 0); the panel can choose either
       mode by reading the same projection."
   [{:keys [phases total-ms]}]
-  (let [clean    (filterv (fn [[_ ms]] (and (number? ms) (pos? ms))) (or phases []))
-        sum      (reduce + 0 (map second clean))
-        total    (or (when (and (number? total-ms) (pos? total-ms)) total-ms)
-                     (when (pos? sum) sum)
-                     0)]
+  (let [clean     (filterv (fn [[_ ms]] (and (number? ms) (pos? ms))) (or phases []))
+        durations (mapv second clean)
+        sum       (reduce + 0 durations)
+        total     (or (when (and (number? total-ms) (pos? total-ms)) total-ms)
+                      (when (pos? sum) sum)
+                      0)]
     (if (or (zero? total) (empty? clean))
       []
-      (loop [acc       []
-             offset    0
-             remaining clean]
-        (if (empty? remaining)
-          acc
-          (let [[ph ms] (first remaining)
-                width   (min 1.0 (max 0.0 (/ (double ms) (double total))))]
-            (recur (conj acc {:phase      ph
-                              :duration-ms ms
-                              :width-pct  width
-                              :offset-pct (min 1.0 (max 0.0 (/ (double offset) (double total))))})
-                   (+ offset ms)
-                   (rest remaining))))))))
+      ;; `:offset-pct` is the running sum of PRECEDING durations as a
+      ;; fraction of total — a scan. `(reductions + 0 durations)` yields
+      ;; `[0 d0 d0+d1 …]`; dropping the final element leaves one
+      ;; preceding-sum per phase, so a single `mapv` projects the rows.
+      (let [pct      (fn [n] (min 1.0 (max 0.0 (/ (double n) (double total)))))
+            offsets  (butlast (reductions + 0 durations))]
+        (mapv (fn [[ph ms] offset]
+                {:phase       ph
+                 :duration-ms ms
+                 :width-pct   (pct ms)
+                 :offset-pct  (pct offset)})
+              clean
+              offsets)))))
 
 (defn slowest-phase
   "Identify the phase that owns the largest share of total elapsed time.

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim_helpers.cljc
@@ -78,18 +78,15 @@
 
 ;; ---- definition introspection -------------------------------------------
 
-(defn- walk-states
-  "Walk `state-map` recursively, calling `(f path node)` for every leaf
-  and compound state node. Returns nothing — purely for side-effecting
-  reduction. The companion `collect-event-ids` / `available-transitions`
-  fns build their own accumulators around it."
-  ([f state-map] (walk-states f [] state-map))
-  ([f parent-path state-map]
-   (doseq [[state-id node] state-map]
-     (let [path (conj parent-path state-id)]
-       (f path node)
-       (when (:states node)
-         (walk-states f path (:states node)))))))
+(defn- all-state-nodes
+  "Depth-first seq of every state-node under `state-map` — each compound
+  state's children are flattened in after the parent. Pure: returns the
+  nodes themselves, so callers aggregate with ordinary transforms rather
+  than a side-effecting walk."
+  [state-map]
+  (mapcat (fn [[_state-id node]]
+            (cons node (all-state-nodes (:states node))))
+          state-map))
 
 (defn event-id-suggestions
   "Return the distinct sorted event-ids declared anywhere in `definition`.
@@ -101,13 +98,11 @@
   [definition]
   (if (or (nil? definition) (nil? (:states definition)))
     []
-    (let [acc (atom #{})]
-      (walk-states
-        (fn [_path node]
-          (doseq [event-id (keys (:on node))]
-            (swap! acc conj event-id)))
-        (:states definition))
-      (vec (sort-by str @acc)))))
+    (->> (all-state-nodes (:states definition))
+         (mapcat (comp keys :on))
+         distinct
+         (sort-by str)
+         vec)))
 
 (defn- node-at
   "Walk `definition`'s `:states` down the given `path` (vector of

--- a/tools/xray/src/day8/re_frame2_xray/theme/a11y.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/a11y.cljs
@@ -127,11 +127,10 @@
     (when (pos? n)
       (let [first-el (nth focusables 0)
             last-el  (nth focusables (dec n))
-            idx      (loop [i 0]
-                       (cond
-                         (= i n)                  nil
-                         (= active (nth focusables i)) i
-                         :else                    (recur (inc i))))]
+            ;; index of `active` within the cycle, or nil when focus
+            ;; sits outside the focusable set.
+            idx      (first (keep-indexed (fn [i el] (when (= active el) i))
+                                          focusables))]
         (cond
           ;; focus outside the cycle → pull to the boundary
           (nil? idx)              (if shift? last-el first-el)


### PR DESCRIPTION
## What

Per-slice **functional-programming-technique review** of `tools/xray` (bead **rf2-dc9p7**). Three behaviour-preserving imperative→functional rewrites in pure helpers where a declarative transform reads more clearly. All three are non-hot-path.

| file:line | before | after | why |
|---|---|---|---|
| `chart/timing_waterfall.cljc:84` | `loop/recur` threading a running `offset` | `reductions`-scan of cumulative durations + single `mapv` | `:offset-pct` is the running sum of preceding durations — a scan; once-per-render layout, not hot |
| `static/machines/sim_helpers.cljc:81,104` | side-effecting `walk-states` + `(atom #{})` accumulator + nested `doseq`/`swap!` | pure `all-state-nodes` depth-first node-seq + `->> mapcat/distinct/sort` pipeline | the sole caller ignored `walk-states`' `path` arg; aggregation belongs in an ordinary transform |
| `theme/a11y.cljs:130` | index-of `loop/recur` | `keep-indexed` lookup | runs only on a modal Tab keypress; declarative index-of reads cleaner |

## Hot/algorithmic loops left imperative (by design)

The review confirmed these legitimately stay imperative — sequential stateful algorithms and/or per-keystroke/per-render perf spots:

- `diff/engine.cljc` — Editscript edit-replay, fixed-point index-shift, lexical path compare (algorithmic core)
- `palette/fuzzy.cljc` — per-keystroke character-scan scorer with transient `indices` (hot)
- `panels/epoch/projection.cljc` — deliberate single-pass O(n) scans with transients + explicit perf rationale (rf2-w6yfq); spec-path `pop` walk
- `panels/app_db_diff_helpers.cljc` `path-touched?` — two-pointer pointer-equality short-circuit walk
- `palette/sources.cljc` / `cancellation_cascade_helpers.cljc` — transient/`volatile!` distinct-by-key dedup (standard efficient idiom)
- `views/edn_widget/widget.cljs` `tokenize-clojure` — hand-rolled lexer
- `filters/typed_predicates.cljc` `cascade-self-and-ancestors`, `panels/machines/topology.cljs` BFS — cycle-guarded graph traversals
- module-level `(atom …)` `defonce`s (caches/registries/runtime/lifecycle) and DOM-mutating `doseq`s — genuine side-effects, not accumulation anti-patterns

## Spec

Spec unchanged because internal-refactor — no documented contract or public signature touched; all three fns keep identical signatures and return values.

## Gates (cold)

- xray `clojure -M:test` — **1095 tests / 4563 assertions, 0 failures**
- `npm run test:cljs` — **5498 tests / 19120 assertions, 0 failures**
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures / 13 matrix rows**, all builds 0 warnings

Browser gate not required — no render path touched (all three are pure data transforms; the a11y change is pure trap math the codebase marks "JVM-runnable without DOM").