### PR TITLE
fix(examples): attach child-snapshot schemas via machine :schema slot (rf2-6qm6n)

### DIFF
--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -78,7 +78,7 @@
             ;; the ns registers the fx; without it, the child loaders
             ;; can't issue requests.
             [re-frame.http-managed]
-            [boot.schema]))
+            [boot.schema :as schema]))
 
 ;; ============================================================================
 ;; STAGING-SLOT WRITER
@@ -113,6 +113,15 @@
 
 (rf/reg-machine :boot/loader
   {:initial :idle
+   ;; Validates each spawned loader's initial `:data` at spawn time,
+   ;; before the snapshot installs (Spec 005 §Schema validation
+   ;; §Spawn-time validation). The loader is only ever spawned (one
+   ;; instance per asset, gensym'd id e.g. `:boot/loader#0`), so its
+   ;; snapshot lives at a per-instance path no fixed `reg-app-schema`
+   ;; can reach — the machine `:schema` slot is the mechanism that
+   ;; boundary-checks the spawn. The per-child `:data` fn (see :app/boot
+   ;; below) replaces this base map with the planted identity at spawn.
+   :schema  schema/LoaderData
    :data    {:parent-id   nil
              :child-id    nil
              :staging-key nil

--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -5,8 +5,23 @@
    owns the initialisation graph. Three parallel sub-fetches (config,
    feature flags, initial user) run via `:spawn-all`; the boot
    machine reaches `:ready` only when every child reports done. The
-   schemas describe the wire shape returned by each mocked endpoint
-   and the boot-machine snapshot itself."
+   schemas describe the wire shape returned by each mocked endpoint,
+   the boot-machine snapshot itself, and the child loader's `:data`.
+
+   Two attachment mechanisms appear here, picked by how the runtime
+   addresses each snapshot:
+
+   - The singleton `:app/boot` machine, the `[:boot/staging]` slot, and
+     the four top-level slices live at fixed app-db paths, so they are
+     attached with `rf/reg-app-schema` on those paths.
+   - The `:boot/loader` child is spawned (once per asset) and gets a
+     gensym'd id (e.g. `:boot/loader#0`), so its snapshot lives at an
+     unknown per-instance path no fixed `reg-app-schema` can reach.
+     `LoaderData` is therefore attached via the child machine's
+     `:schema` slot on `reg-machine` (see `boot.cljs`), which validates
+     each spawned instance's initial `:data` at spawn time, before the
+     snapshot installs (Spec 005 §Schema validation §Spawn-time
+     validation)."
   (:require [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
@@ -81,20 +96,43 @@
             [:routes [:maybe Routes]]
             [:error  [:maybe :any]]]]])
 
-(def LoaderSnapshot
-  "Snapshot shape for the generic `:boot/loader` child machine.
-   Each child loader holds the parent-id + child-id + URL it was
-   spawned with, fetches once, and dispatches `:boot/asset-loaded`
-   (or `:boot/asset-failed`) back to its parent on transition into
-   `:done` (or `:failed`)."
+;; ============================================================================
+;; CHILD LOADER :data SHAPE — :boot/loader (one instance per asset)
+;; ============================================================================
+;;
+;; The `:data` slot of the generic `:boot/loader` child machine. Each
+;; loader holds the parent-id + child-id + staging-key + URL it was
+;; spawned with, fetches once, and dispatches `:boot/asset-loaded` (or
+;; `:boot/asset-failed`) back to its parent on transition into `:done`
+;; (or `:failed`). Attached via the child machine's `:schema` slot on
+;; `(reg-machine :boot/loader ...)` in `boot.cljs` — the runtime owns
+;; the surrounding snapshot, so the machine `:schema` describes `:data`
+;; only (Spec 005 §Schema validation) and validates each spawned
+;; instance's initial `:data` at spawn time, regardless of its gensym'd
+;; id. The per-child `:data` fn (see :app/boot) plants identity only, so
+;; the fetch-result fields below are optional — they appear later, as
+;; the loader transitions through `:loading` into `:done` / `:failed`.
+
+(def LoaderData
   [:map
-   [:state [:enum :idle :loading :done :failed]]
-   [:data  [:map
-            [:parent-id :keyword]
-            [:child-id  :keyword]
-            [:url       :string]
-            [:payload   :any]
-            [:error     [:maybe :any]]]]])
+   ;; Identity, planted by the parent's per-child spawn-spec `:data` fn —
+   ;; present from spawn (see :app/boot in boot.cljs).
+   [:parent-id   :keyword]
+   [:child-id    :keyword]
+   [:staging-key :keyword]
+   [:url         :string]
+   ;; Filled in only once the fetch replies (the `:asset/replied` action
+   ;; writes :payload or :error). Absent at spawn — the per-child `:data`
+   ;; fn plants identity only — so both are optional.
+   [:payload     {:optional true} :any]
+   [:error       {:optional true} [:maybe :any]]
+   ;; Runtime-stamped address keys — the spawn fx stamps these into the
+   ;; spawned actor's initial :data (Spec 005 §Reserved snapshot-internal
+   ;; keys). Optional + declared so the schema documents them; a Malli
+   ;; :map is open, so they'd pass undeclared too.
+   [:rf/self-id   {:optional true} :any]
+   [:rf/parent-id {:optional true} :any]
+   [:rf/spawn-id  {:optional true} :any]])
 
 (def BootStagingSlice
   "Shape of `[:boot/staging]` — the per-child hand-off slot the

--- a/examples/reagent/long_running_work/schema.cljs
+++ b/examples/reagent/long_running_work/schema.cljs
@@ -8,17 +8,31 @@
    `:cancel`, or unmount) which cascades a teardown to every surviving
    child.
 
-   Two snapshots live under `[:rf/runtime :machines :snapshots ...]` at runtime:
+   Two machines run at runtime, and each gets a schema attached via
+   the mechanism that fits HOW the runtime addresses its snapshot:
 
-   - `:work/flow`       — the parent coordinator. Tracks per-shard
-                          progress in `:data :progress` and the chunk
-                          size / total in `:data :total`.
-   - `:work/processor`  — the child machine type. Each child gets a
-                          gensym'd id (e.g. `:work/processor#1`)
-                          assigned by the runtime at spawn time.
+   - `:work/flow`       — the parent coordinator, a singleton at a
+                          fixed id. Its snapshot lives at the fixed
+                          path `[:rf/runtime :machines :snapshots
+                          :work/flow]`, so `FlowSnapshot` is attached
+                          with `rf/reg-app-schema` on that path.
+   - `:work/processor`  — the child machine type. Each child is
+                          spawned via `:spawn-all` and gets a gensym'd
+                          id (e.g. `:work/processor#0`) assigned by the
+                          runtime at spawn time, so its snapshot lives
+                          at an UNKNOWN path that varies per instance.
+                          A fixed `reg-app-schema` path cannot reach it.
+                          Instead, `ProcessorData` is attached via the
+                          child machine's `:schema` slot on `reg-machine`
+                          (see `worker.cljs`), which validates each spawned
+                          instance's initial `:data` at spawn time, before
+                          the snapshot installs (Spec 005 §Schema
+                          validation §Spawn-time validation) — so a child
+                          spawned with malformed `:data` never enters the
+                          runtime, regardless of its gensym'd id.
 
-   The shapes are stamped as `reg-app-schema` so writes to those paths
-   are boundary-validated in development (Spec 010)."
+   Both shapes are boundary-validated in development (Spec 010 §Per-step
+   recovery row 7 — `:where :machine-data` for the child)."
   (:require [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
@@ -58,35 +72,39 @@
             [:outcome  [:maybe [:enum :complete :cancelled :error]]]]]])
 
 ;; ============================================================================
-;; CHILD SNAPSHOT — :work/processor (one instance per shard)
+;; CHILD :data SHAPE — :work/processor (one instance per shard)
 ;; ============================================================================
 ;;
-;; Shape:
-;;   {:state    <:idle | :processing | :checking-done | :yielding | :done | :cancelled>
-;;    :data     {:shard      <keyword>          ;; the parent-assigned id
-;;               :total      <int>               ;; items in this shard
-;;               :processed  <int>               ;; how many done so far
-;;               :tick-ms    <int>               ;; ms between chunks (browser yield)}
-;;    :tags     #{...}}
+;; The child machine's `:data` slot — the user-domain working memory the
+;; child carries. The runtime owns the surrounding snapshot (`:state`, the
+;; `:tags` union, the reserved `:rf/*` slots), so the machine `:schema`
+;; describes `:data` ONLY (Spec 005 §Schema validation). Attached via the
+;; `:schema` slot on `(reg-machine :work/processor ...)` in `worker.cljs`,
+;; which validates each spawned instance's initial `:data` at spawn time —
+;; the value here is what the parent's per-child `:spawn-all` invoke-spec
+;; plants (every field below is supplied, so all are required).
 
-(def ProcessorSnapshot
+(def ProcessorData
   [:map
-   [:state [:enum :idle :processing :checking-done :yielding :done :cancelled]]
-   [:data  [:map
-            [:shard     :keyword]
-            [:total     :int]
-            [:processed :int]
-            [:tick-ms   :int]]]])
+   [:shard     :keyword]   ;; the parent-assigned shard id
+   [:total     :int]       ;; items in this shard
+   [:processed :int]       ;; how many done so far
+   [:tick-ms   :int]       ;; ms between chunks (browser yield)
+   ;; Runtime-stamped address keys — the spawn fx stamps these into the
+   ;; spawned actor's initial :data (Spec 005 §Reserved snapshot-internal
+   ;; keys). Optional + declared so the schema documents them; a Malli
+   ;; :map is open, so they'd pass undeclared too.
+   [:rf/self-id   {:optional true} :any]
+   [:rf/parent-id {:optional true} :any]
+   [:rf/spawn-id  {:optional true} :any]])
 
 ;; ============================================================================
-;; SCHEMA REGISTRATION (Spec 010 §Path-based attachment)
+;; SCHEMA REGISTRATION
 ;; ============================================================================
+;;
+;; `:work/flow` is a singleton at a fixed id, so its full snapshot is
+;; attached on the fixed snapshot path. (The `:work/processor` children
+;; are attached via the machine `:schema` slot in `worker.cljs` — see the
+;; ns docstring for why a fixed path cannot reach a gensym'd-id snapshot.)
 
 (rf/reg-app-schema [:rf/runtime :machines :snapshots :work/flow] FlowSnapshot)
-;; The :work/processor children get gensym'd ids (e.g. :work/processor#1);
-;; we register a wildcard-style schema on the prefix so the rebound
-;; per-instance snapshots are validated against the same shape. The
-;; framework's path-based attachment walks the path; the per-instance
-;; id falls outside the registered prefix and is not boundary-checked
-;; directly — that's intentional, the dispatched-by-runtime spawn fx
-;; writes a known-good shape.

--- a/examples/reagent/long_running_work/worker.cljs
+++ b/examples/reagent/long_running_work/worker.cljs
@@ -33,7 +33,7 @@
             ;; (called below at ns-load) and the `:rf/machine` /
             ;; `:rf/machine-has-tag?` framework subs resolve.
             [re-frame.machines]
-            [long-running-work.schema]))
+            [long-running-work.schema :as schema]))
 
 ;; ============================================================================
 ;; CONSTANTS
@@ -97,6 +97,15 @@
          :on-child-done keyword (`:work/child-done`)."
 
    :initial :idle
+
+   ;; Validates the child's initial `:data` at spawn time, before the
+   ;; snapshot installs (Spec 005 §Schema validation §Spawn-time
+   ;; validation). This is how a spawned child's shape is boundary-
+   ;; checked: the runtime addresses each instance by a gensym'd id
+   ;; (e.g. `:work/processor#0`), so no fixed `reg-app-schema` path can
+   ;; reach it — the machine `:schema` slot validates the spawn
+   ;; regardless of id. (See schema.cljs ns docstring.)
+   :schema  schema/ProcessorData
 
    ;; The :data is materialised from the parent's per-child invoke-spec
    ;; :data slot at spawn time (see :work/flow below). :shard is the


### PR DESCRIPTION
## What

Bead **rf2-6qm6n** (P3, ELEGANCE). Both the `boot` and `long_running_work` reagent examples defined a fully-documented child-snapshot Malli schema (`LoaderSnapshot` / `ProcessorSnapshot`) that was **never attached** to anything, and the `long_running_work` ns docstring falsely claimed both child shapes were stamped as `reg-app-schema`.

## Why the defs were dead

A `reg-app-schema` on a fixed snapshot path cannot reach a spawned child. Spawned actors land at a **gensym'd id** (e.g. `:boot/loader#0`, `:work/processor#0`), so `[:rf/runtime :machines :snapshots :work/processor]` is never written — validating nothing. The example's own comment even admitted "the per-instance id falls outside the registered prefix and is not boundary-checked directly."

## Fix — attach via the canonical per-instance mechanism

Per **Spec 005 §Schema validation**, a spawned child's `:data` shape is attached via the machine's **`:schema` slot** on `reg-machine`, which the runtime validates **per-instance at spawn time** (§Spawn-time validation) regardless of the gensym'd id.

- **boot**: `LoaderSnapshot` (full snapshot) → `LoaderData` (`:data` shape), attached via `:schema` on `(reg-machine :boot/loader ...)`. `:payload` / `:error` are `{:optional true}` (the per-child `:data` fn plants identity only; fetch results appear later). Added `:staging-key`, which the old def omitted.
- **long_running_work**: `ProcessorSnapshot` → `ProcessorData`, attached via `:schema` on `(reg-machine :work/processor ...)`. `FlowSnapshot` stays attached via `reg-app-schema` (the parent is a singleton at a fixed id).
- Both: document the two attachment mechanisms and why each fits; declare the runtime-stamped `:rf/*` address keys as optional.

Docstrings now describe only what is actually enforced — and what they claim is enforced is now true.

## Acceptance

- [x] Neither `schema.cljs` carries a child-snapshot schema that is defined but never attached.
- [x] Docstrings describe only what is actually enforced.

## Gates

- `npx shadow-cljs compile examples/boot examples/long-running-work` — **0 warnings** (cold).
- `npm run test:cljs` — **5498 tests, 19120 assertions, 0 failures, 0 errors**. The `re-frame.boot-cljs-test` and `re-frame.long-running-work-cljs-test` suites drive the spawn path the new `:schema` slots validate (a too-strict schema rejects the spawn and the boot machine sticks at `:configuring` — caught and fixed during this PR: the loader's spawn-time `:data` omits `:payload`/`:error`).
- Examples remain test-free (no `*.spec.cjs` added).