### PR TITLE
refactor(skills/pair): fold SKILL.md port-discovery depth into mcp-transport.md (rf2-6szy1)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -171,15 +171,7 @@ If any precondition fails, the script returns a structured edn error like `{:ok?
 
 > **Example (illustrative — this repo only; do NOT transcribe these values into a session against another app).** A `shadow-cljs.edn` with a top-level `:dev-http {8033 ["out/examples/machine-epochs"]}` entry serves port `8033` from `out/examples/machine-epochs`, which is the `:output-dir` of the `:examples/machine-epochs` build — so a tab at `http://localhost:8033` is the `:examples/machine-epochs` build, and you'd pass `build :examples/machine-epochs`. Every app's ports, roots, and build ids differ — read *its* config, never reuse these.
 
-**Port discovery (canonical MCP transport).** On the first tool call the MCP server discovers the live shadow-cljs nREPL via a five-step cascade — `--port-file <abs>` flag, then `$SHADOW_CLJS_NREPL_PORT` env var, then **MCP `roots/list`** asking the agent host for its open workspace roots and walking each for `shadow-cljs.edn` + `.shadow-cljs/nrepl.port` (rf2-3grub — the zero-config primary path), then shadow's HTTP probe at `:9630/api/project-info` (rf2-umoz2), then a CWD-relative scan. Multiple running shadow builds in the workspace trigger an `elicitation/create` prompt so the user picks the project to attach to. Shadow restarts are absorbed transparently — every subsequent tool call re-reads the cached port file and reconnects if it changed.
-
-If discovery still misses (no running shadow, non-default `:http :port`, exotic setup), pass `--port-file <abs>` in the MCP config or set `SHADOW_CLJS_NREPL_PORT` — both are explicit operator overrides that win the cascade.
-
-**Bash-shim transport (back-compat appendix).** The shim finds the nREPL port by scanning shadow-cljs's standard port-file locations (`target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, `.nrepl-port`) at both the shell CWD *and* under `implementation/`, then picks the **most-recently-modified** file — so a freshly (re)started dev build always wins over a stale leftover port file. Override with `SHADOW_CLJS_NREPL_PORT`:
-
-```
-SHADOW_CLJS_NREPL_PORT=51708 scripts/discover-app.sh
-```
+**Port discovery is automatic — you don't configure it.** On the first tool call the MCP server discovers the live shadow-cljs nREPL on its own (a cascade ending in shadow's `roots/list` / HTTP probe; multiple running builds trigger a host prompt so you pick one), and absorbs shadow restarts transparently. When discovery misses (no running shadow, non-default port, exotic setup), the operator passes `--port-file <abs>` or sets `SHADOW_CLJS_NREPL_PORT`. The full cascade, the overrides, and the retired bash-shim's port-scanning are in [references/mcp-transport.md §Install / configure](references/mcp-transport.md#install--configure-one-time) — you rarely need any of it.
 
 Between user turns, the nREPL session persists. A full page refresh in the browser drops the runtime, but the preload re-installs it on the next bundle load — no manual reconnect step is needed. Every op checks the load-time marker (`js/globalThis.__re_frame2_pair_runtime`) before proceeding; if it's missing the op refuses with the structured `:runtime-not-preloaded` hint above.
 


### PR DESCRIPTION
## Dedup review — `skills/re-frame2-pair` (rf2-6szy1)

Systematic block-level duplication review of the loaded skill-guidance surface (SKILL.md + `references/`). Verdict: the slice is **largely DRY by design** — the router/leaf split (SKILL.md restates framing for trigger-time; `references/` own the depth) and per-leaf self-containment are deliberate context-economy patterns, not duplication to collapse. One genuine block-level duplication found and consolidated.

### Consolidated

**SKILL.md §Connect-first port-discovery block** restated the full five-step nREPL-discovery cascade — `rf2-3grub`/`rf2-umoz2` ticket detail, `:9630/api/project-info`, the retired bash-shim's port-file scanning, and the `SHADOW_CLJS_NREPL_PORT=… scripts/discover-app.sh` example — **verbatim** with [`references/mcp-transport.md` §Install / configure](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-pair/references/mcp-transport.md) (lines 33-42), which owns that depth.

Two reasons this is duplication rather than legitimate restatement:
- SKILL.md's own preamble says *"The trigger-time guard rails live below; the operational depth … lives in `references/` and is loaded on demand."* The full cascade enumeration is operational depth, not a trigger-time guard rail.
- The bash-shim port-scanning is **doubly** redundant: this skill's `allowed-tools:` exposes no shell tool, so the shim is unreachable from the router — its mechanics belong only in the appendix (ops.md / mcp-transport.md own it).

`SKILL.md:174-182` (two paragraphs + a code fence) → one "discovery is automatic" framing line + a cross-reference to the leaf. Net **-8 lines**. Trigger-time guidance (connect-first ordering, the `:freshness` table, build-resolution, arg-forms, the illustrative dev-repo example) is untouched.

### Assessed and deliberately left intact (appropriately self-contained)

- **Bash-shim "retired / e2e-harness-only" disclaimer** (ops.md, mcp-transport.md, recipes.md) — a one-sentence framing in each *independently-loaded* reference. Single-sourcing would break standalone readability for no token win.
- **`:rf/xray` "entire working set / overflowed past 100K tokens" warning** (SKILL.md ×2, ops.md, mcp-transport.md) — load-bearing safety guidance restated at each point of use; each instance is contextualised differently (orient-vs-drill, the `snapshot` tool's enforced refusal, the slice-modes section).
- **Privacy posture** — already single-sourced in `references/vocabulary.md §Privacy posture` with cross-refs from SKILL.md / ops.md / streaming-subscriptions.md / wire-size-budget.md. Exemplary existing DRY; no change.

### Quality gate

`bb tests/prompts/prompt_regression_test.clj` — **8 tests, 28 assertions, 0 failures**. The cross-reference target (`references/mcp-transport.md` + the `#install--configure-one-time` anchor) verified present.

Closes rf2-6szy1.