### PR TITLE
fix(pair-mcp): preserve keyword namespaces in wire structuredContent (rf2-t2n04)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -41,10 +41,42 @@
 ;; rest fall back to the EDN text. The two slots always agree on the
 ;; payload by construction — same `v`, two projections.
 ;;
-;; The `:structuredContent` value is `clj->js v` — a JSON-coercible
-;; projection (keywords lose their `:`, sets become arrays, etc.).
-;; The text slot remains the source of truth for cljs-readable round-
-;; trip; the structured slot is the SDK-friendly view.
+;; The `:structuredContent` value is a JSON-coercible projection of `v`
+;; (keywords lose their `:`, sets become arrays, etc.). The text slot
+;; remains the source of truth for the cljs-readable round-trip; the
+;; structured slot is the SDK-friendly view.
+;;
+;; ## Namespaced keywords keep their namespace (rf2-t2n04)
+;;
+;; A bare `(clj->js v)` is namespace-LOSSY in two compounding ways, and
+;; both silently corrupt key-bearing reads:
+;;
+;;   - For MAP KEYS, `clj->js`'s default `:keyword-fn` is `name`, which
+;;     drops the namespace: `:rf/runtime` → `"runtime"`, not `"rf/runtime"`.
+;;   - For keyword VALUES, `clj->js` ALWAYS uses `(name v)` (the
+;;     `:keyword-fn` option is consulted for keys ONLY), so machine-id
+;;     values `:door/main :traffic/light` collapse to `"main" "light"`.
+;;
+;; The damage is not cosmetic: a `snapshot` whose `(keys app-db)` carries
+;; `:rf/runtime` projects to the name-only `"runtime"`, so an agent that
+;; reads the structured slot and threads `[:runtime ...]` back through
+;; `get-path` hits `nil` — the real key is `:rf/runtime`. (This sent a
+;; live 2026-06-04 session down a false "snapshots are empty" path.)
+;; Same defect class as the machines-viz `:door/open` → `"open"` tag
+;; truncation (#2922): stringify keywords to their FULLY-QUALIFIED form
+;; at the `clj->js` boundary so the namespace survives.
+;;
+;; The fix pre-walks `v`, replacing every keyword (key OR value) with
+;; `(str (symbol kw))` — the colon-less fully-qualified token
+;; (`:rf/runtime` → `"rf/runtime"`, `:ok?` → `"ok?"`) — BEFORE `clj->js`
+;; sees it. `clj->js` then only structurally coerces the (now
+;; keyword-free) tree; sets/vectors/maps coerce exactly as before. This
+;; is also what the spec's documented projection already PROMISED —
+;; `:structuredContent` "drops the leading colon — ["rf/default"]"
+;; (003-Tool-Catalogue §Id representation, rf2-cg37y); the code was
+;; merely failing to honour its own contract. The EDN text slot
+;; (`pr-str v`) is untouched: it stays the canonical, fully-typed,
+;; cljs-`read`-able round-trip.
 ;;
 ;; ## structuredContent must never be `null` (rf2-r5erl)
 ;;
@@ -78,22 +110,66 @@
   sentinel and know the payload was empty."
   {"rf.mcp/null" true})
 
+(defn- qualify-keywords
+  "Recursively replace every keyword in `x` (map KEY or VALUE, at any
+  depth, in maps / vectors / lists / sets) with its colon-less
+  fully-qualified string token via `(str (symbol kw))`
+  (`:rf/runtime` → `\"rf/runtime\"`, `:ok?` → `\"ok?\"`), leaving every
+  non-keyword scalar and collection structure otherwise intact.
+
+  Applied to a payload BEFORE `clj->js` so the structured projection
+  preserves keyword namespaces (rf2-t2n04). `clj->js`'s built-in
+  keyword handling is namespace-lossy for both keys (default
+  `:keyword-fn` is `name`) and values (always `name`); pre-stringifying
+  here is the single point that closes both holes. `clj->js` then sees
+  no keywords and only coerces the surrounding structure
+  (vectors → arrays, sets → arrays, maps → objects) unchanged.
+
+  `(symbol kw)` carries the namespace into the symbol's `str`
+  (`(str (symbol :a/b))` ⇒ `\"a/b\"`); a bare `(name kw)` would drop it.
+  Hand-rolled (rather than `clojure.walk/postwalk`) so it stays a
+  dependency-free, allocation-frugal single pass that touches only the
+  collection branches that can contain keywords."
+  [x]
+  (cond
+    (keyword? x) (str (symbol x))
+    (map? x)     (persistent!
+                  (reduce-kv (fn [m k v]
+                               (assoc! m (qualify-keywords k) (qualify-keywords v)))
+                             (transient {})
+                             x))
+    (set? x)     (into #{} (map qualify-keywords) x)
+    (vector? x)  (mapv qualify-keywords x)
+    (seq? x)     (map qualify-keywords x)
+    :else        x))
+
 (defn- structured-of
   "Project `v` to the `:structuredContent` JS value, guaranteeing a
-  non-null record (rf2-r5erl). `(clj->js v)` is `null` exactly when
-  `v` is `nil`; substitute the `:rf.mcp/null` sentinel object so the
-  SDK's outputSchema validation (which requires an object) never
-  rejects the result at the transport layer."
+  non-null record (rf2-r5erl) AND preserving keyword namespaces
+  (rf2-t2n04).
+
+  Keyword namespaces are kept by pre-walking `v` through
+  `qualify-keywords` before `clj->js` — a bare `clj->js` drops the
+  namespace on both map keys and keyword values. The EDN `:content`
+  text slot (`pr-str v`) is the namespace-faithful canonical form;
+  this slot is the SDK-friendly mirror.
+
+  `(clj->js v)` is `null` exactly when `v` is `nil`; substitute the
+  `:rf.mcp/null` sentinel object so the SDK's outputSchema validation
+  (which requires an object) never rejects the result at the transport
+  layer."
   [v]
   (if (nil? v)
     (clj->js null-structured-sentinel)
-    (let [sc (clj->js v)]
+    (let [sc (clj->js (qualify-keywords v))]
       ;; clj->js of a non-nil scalar can still be a JS primitive (a
       ;; number / string / boolean), which is also not a record. Wrap
       ;; any non-object projection in the sentinel-shaped envelope so
       ;; the slot is always object-typed. (Tool payloads are maps in
-      ;; practice; this is the total-function backstop.)
-      (if (object? sc) sc (clj->js {"rf.mcp/value" v})))))
+      ;; practice; this is the total-function backstop.) The wrapped
+      ;; value reuses the keyword-qualified projection so a bare-keyword
+      ;; payload keeps its namespace inside the envelope too.
+      (if (object? sc) sc (clj->js {"rf.mcp/value" (qualify-keywords v)})))))
 
 (defn ok-text
   "Success result envelope. Always emits both `:content` (the

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/structured_content_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/structured_content_test.cljs
@@ -41,8 +41,9 @@
       (is (some? (j/get result :structuredContent))
           "the :structuredContent slot is present (rf2-hj3pi)")
       ;; The structured slot should be a JS object whose shape mirrors
-      ;; the input. Keywords lose their `:` prefix and become bare keys
-      ;; under clj->js (JSON-coercible projection).
+      ;; the input. Keywords lose their `:` prefix in the JSON-coercible
+      ;; projection but KEEP their namespace (rf2-t2n04 — `:rf/x` →
+      ;; "rf/x"); plain keys like `:ok?` become the bare "ok?".
       (is (object? (j/get result :structuredContent))
           ":structuredContent is a JS object")
       (is (= true (j/get-in result [:structuredContent :ok?]))
@@ -134,3 +135,67 @@
             (str "scalar " (pr-str v) " must wrap to an object structuredContent"))
         (is (= (pr-str v) (content-text result))
             "the EDN text slot still carries the verbatim scalar")))))
+
+;; ---------------------------------------------------------------------------
+;; Namespaced keywords keep their namespace over the wire (rf2-t2n04).
+;;
+;; A bare `(clj->js v)` is namespace-lossy: the default `:keyword-fn` for
+;; map KEYS is `name` (`:rf/runtime` → `"runtime"`), and keyword VALUES
+;; always go through `name` too (`:door/main` → `"main"`). Both drop the
+;; namespace AND the colon, so an agent reading the structured slot then
+;; threading the name-only key back through `get-path` hits `nil`. The
+;; fix stringifies every keyword to its colon-less fully-qualified token
+;; (`"rf/runtime"`) before `clj->js`. The EDN text slot stays the
+;; namespace-faithful, fully-typed canonical round-trip.
+;; ---------------------------------------------------------------------------
+
+(deftest namespaced-keyword-map-key-keeps-namespace-in-structured-slot
+  (testing "a namespaced map KEY survives to the structured slot as ns/name (rf2-t2n04)"
+    (let [payload {:rf/runtime {:loaded? true} :step 3}
+          result  (wire/ok-text payload)]
+      ;; The structured slot key must be the fully-qualified token, NOT
+      ;; the name-only "runtime" the old clj->js produced.
+      (is (some? (j/get-in result [:structuredContent "rf/runtime"]))
+          ":rf/runtime serialises to the \"rf/runtime\" key, not \"runtime\"")
+      (is (nil? (j/get-in result [:structuredContent "runtime"]))
+          "the name-only \"runtime\" key must NOT appear (the lossy old shape)")
+      (is (= true (j/get-in result [:structuredContent "rf/runtime" "loaded?"]))
+          "nested values under the namespaced key still round-trip")
+      ;; A plain (un-namespaced) key keeps its bare name.
+      (is (= 3 (j/get-in result [:structuredContent "step"]))
+          "plain keys remain bare-named")
+      ;; The EDN text slot is the canonical fully-typed form, unchanged.
+      (is (= (pr-str payload) (content-text result))
+          "the EDN text slot carries the verbatim namespace-faithful EDN"))))
+
+(deftest namespaced-keyword-values-keep-namespace-in-structured-slot
+  (testing "namespaced keyword VALUES (e.g. machine-ids) keep their namespace (rf2-t2n04)"
+    ;; clj->js's :keyword-fn applies to KEYS only; keyword values always
+    ;; went through `name`. This pins the value path too.
+    (let [payload {:machine-ids [:door/main :traffic/light :quiz/scorer]
+                   :current     :door/open}
+          result  (wire/ok-text payload)
+          ids     (js->clj (j/get-in result [:structuredContent "machine-ids"]))]
+      (is (= ["door/main" "traffic/light" "quiz/scorer"] ids)
+          "namespaced keyword values serialise as ns/name, not the truncated name")
+      (is (= "door/open" (j/get-in result [:structuredContent "current"]))
+          "a scalar namespaced keyword value keeps its namespace")
+      (is (= (pr-str payload) (content-text result))
+          "EDN text slot unchanged — the canonical round-trip"))))
+
+(deftest namespaced-keyword-round-trips-through-the-structured-slot
+  (testing "reading the structured-slot token back yields the original keyword (rf2-t2n04)"
+    ;; The whole point: an agent that reads the structured slot can
+    ;; reconstruct the exact key it must thread back into get-path.
+    (doseq [kw [:rf/runtime :door/open :examples/step-deck]]
+      (let [payload {kw 1}
+            result  (wire/ok-text payload)
+            ;; The structured key is the colon-less fully-qualified token.
+            token   (-> (j/get result :structuredContent)
+                        js/Object.keys
+                        (aget 0))]
+        (is (= (str (symbol kw)) token)
+            (str kw " serialises to its colon-less fully-qualified token"))
+        ;; Round-trip: prefixing a colon reads back to the original kw.
+        (is (= kw (keyword token))
+            (str "(keyword \"" token "\") reconstructs " kw))))))


### PR DESCRIPTION
## What

`wire/structured-of` (the single point every tool's `:structuredContent`
projection routes through, via `ok-text`/`err-text`) projected payloads with a
bare `(clj->js v)`. `clj->js` is namespace-lossy in two compounding ways:

- **Map keys** go through the default `:keyword-fn` (`name`), dropping the
  namespace: `:rf/runtime` → `"runtime"`.
- **Keyword values** always go through `name` (the `:keyword-fn` option is
  consulted for keys only), so machine-id values `:door/main` `:traffic/light`
  collapse to `"main"` `"light"`.

The damage is not cosmetic. A `snapshot` whose `(keys app-db)` carries
`:rf/runtime` projected to the name-only `"runtime"`, so an agent reading the
structured slot and threading `[:runtime ...]` back through `get-path` hit
`nil` — the real key is `:rf/runtime`. A live 2026-06-04 session was sent down
a false "snapshots are empty / wrong path" investigation by this. Same defect
class as the machines-viz `:door/open` → `"open"` tag truncation (#2922).

## Fix

Pre-walk the payload through a new `qualify-keywords` (recursive, dependency-
free) that stringifies **every keyword (key OR value, any depth)** to its
colon-less fully-qualified token `(str (symbol kw))` *before* `clj->js`.
`clj->js` then sees a keyword-free tree and only coerces structure
(maps/vectors/sets) exactly as before. The EDN `:content` text slot
(`pr-str v`) is untouched — it stays the namespace-faithful, fully-typed,
`read`-able canonical round-trip.

**Wire representation chosen:** colon-less fully-qualified string token
(`:rf/runtime` → `"rf/runtime"`). This is exactly what `003-Tool-Catalogue.md`
§Id representation (rf2-cg37y) *already documented* the structured slot as
emitting (`["rf/default"]`, "drops the leading colon") — the code was merely
failing to honour its own contract. A colon-prefixed string would have been
redundant (the slot is the lossy SDK-friendly mirror; the EDN text slot is the
canonical typed form), and structured EDN-in-JSON would defeat the point of an
SDK-friendly projection.

## Tests

Pins added to `structured_content_test`:
- namespaced map KEY survives as `"rf/runtime"` (and the name-only `"runtime"`
  key is absent);
- namespaced keyword VALUES (machine-ids in a vector + a scalar) keep their
  namespace;
- round-trip: the structured token reconstructs the original keyword via
  `(keyword token)`.

## Gates (cold, from a fresh worktree)

- `npx shadow-cljs compile server-test` — **0 warnings**; 884 tests / 2711
  assertions / 0 failures / 0 errors.
- `npm run test:mcp-conformance` — **ALL SIX GATES GREEN**, including gate [4]
  (re-frame2-pair-mcp end-to-end via SDK Client driver).

## Scope / overlap

Touches only `tools/re-frame2-pair-mcp/src/.../tools/wire.cljs` and its test.
mvdwv also touches `tools/re-frame2-pair-mcp` but a different file
(`eval_cljs.cljs`) — **not touched here**, no overlap.