### PR TITLE
refactor(epoch): purify back-fill-event! swap fn — drop atom-as-out-param (rf2-zls01)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -545,24 +545,27 @@
       right cascade.
     * the structured `slot` projection — the primary consumer surface
       (Xray Views / Reactive panel) — is always present on a built
-      record; the projected row is appended when non-nil."
+      record; the projected row is appended when non-nil.
+
+  The `swap!` update fn is PURE — it mutates only the history map and
+  smuggles nothing out (the prior shape `reset!`'d a local out-param atom
+  from inside the swap fn, a side-effecting-swap-fn that is unsound under
+  CAS retry). The record index is resolved once up-front (within-frame
+  drain is single-threaded — Spec 002 §Run-to-completion — so no append
+  can shift it between this deref and the swap), reused by both the pure
+  swap and the post-swap read. nil when the epoch is absent from the ring
+  (evicted, or fired before any cascade settled)."
   [frame-id epoch-id slot event row]
-  (let [updated (atom nil)]
-    (swap! histories update frame-id
-           (fn [history]
-             (let [history (or history [])
-                   idx     (epoch-index history epoch-id)]
-               (if (nil? idx)
-                 history
-                 (let [record   (nth history idx)
-                       record+  (cond-> record
-                                  (contains? record :trace-events)
-                                  (update :trace-events (fnil conj []) event)
-                                  (some? row)
-                                  (update slot (fnil conj []) row))]
-                   (reset! updated record+)
-                   (assoc history idx record+))))))
-    @updated))
+  (let [idx (epoch-index (history-for frame-id) epoch-id)]
+    (when idx
+      (let [append (fn [record]
+                     (cond-> record
+                       (contains? record :trace-events)
+                       (update :trace-events (fnil conj []) event)
+                       (some? row)
+                       (update slot (fnil conj []) row)))]
+        (-> (swap! histories update-in [frame-id idx] append)
+            (get-in [frame-id idx]))))))
 
 (defn back-fill-render!
   "Back-fill `render-event` and its projected `:renders` `render-row`


### PR DESCRIPTION
## What

Per **rf2-zls01** — GOOD-FUNCTIONAL-PROGRAMMING-TECHNIQUE review of `implementation/epoch`.

The slice is overwhelmingly idiomatic functional Clojure already (the product of prior reviews: rf2-ee38b clarity, rf2-ecu37/rf2-txrq9 fused single-walk reducers, rf2-1e38x O(1) elision, rf2-np5zy dedup, the rf2-33lpr eight-atom decision). The review found exactly **one** genuine imperative offender.

## The fix — `re-frame.epoch.state/back-fill-event!`

The fn recovered the updated record from inside its `swap!` by `reset!`-ing a local `(atom nil)` from the swap update fn:

```clojure
(let [updated (atom nil)]
  (swap! histories update frame-id
         (fn [history] ... (reset! updated record+) (assoc history idx record+)))
  @updated)
```

A **side-effecting swap fn is unsound under CAS retry** (the `reset!` would run once per attempt) and reads imperatively. Replaced with a pure form:

- resolve the record index once up-front from a deref — safe because within-frame drain is single-threaded (Spec 002 §Run-to-completion), the same invariant the original implicitly relied on;
- gate on `idx`, run a pure `update-in [frame-id idx]`;
- recover the updated record from the `swap!` **return value** via `get-in`.

No local mutable atom; the swap fn now mutates only the history map.

## Behaviour-preserving

- absent epoch (`idx` nil) → returns nil (was `@updated` nil)
- present epoch → returns the updated record (was `record+`)

All three call paths (`back-fill-render!` / `back-fill-sub-run!` / `back-fill-unmount!`) are unchanged thin wrappers.

## Left imperative by design (noted, not changed)

- **`capture/project-all` + the `:s/:r/:e` transient accumulators** — documented per-cascade hot path; transients are the right call.
- **`state/append-record` `(into [] (subvec history+ ...))`** — the **#2929 no-SubVector-retention** bounded-ring fix; preserved verbatim (a bare `subvec` view leaks the whole session's records).
- **`listeners/notify-listeners!` + `on-frame-destroyed!` `doseq`** — side-effecting fan-out / trace emission; `doseq` is the correct functional idiom for per-item side effects.
- **`state/value-changed-epoch-for` `loop/recur`** — newest-first reverse scan with short-circuit; clear and allocation-free.

## Gates

- epoch JVM suite — **246 tests / 894 assertions, 0 failures**
- full `npm run test:cljs` node gate — **5500 tests / 19125 assertions, 0 failures**