### PR TITLE
fix(pair-mcp): surface eval-cljs compile warnings/errors instead of silent nil (rf2-mvdwv)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -596,7 +596,29 @@
   with an Error if the eval threw or returned an error map). Optional
   `opts` (e.g. `{:timeout-ms 60000}`) tunes the per-op deadline —
   heavy forms (full-epoch-ring walks) can raise it past the 30s
-  default."
+  default.
+
+  ## Compile warnings/errors surface — never swallowed as nil (rf2-mvdwv)
+
+  shadow's `cljs-eval` returns its `{:results :err :out :ns}` map as the
+  JVM eval value (the `outer` map below). A form with an UNRESOLVED
+  symbol (`re-frame.core/frame-db` — a fn that doesn't exist) compiles
+  to JS that references an undefined var, so it does NOT throw at
+  runtime: shadow emits an `:eval-compile-warnings` REPL message, routes
+  the analyzer warning text into the response `:err` field, and STILL
+  pushes a `\"nil\"` into `:results` (see `repl_impl/do-repl` —
+  `(repl-result repl-state nil)` runs after the warning is logged). A
+  genuine compile error (`:eval-compile-error`) takes the same shape:
+  `:err` carries the report, `:results` carries `\"nil\"`.
+
+  The pre-rf2-mvdwv branch order peeked `:results` FIRST whenever it was
+  a vector, so the `\"nil\"` won and the populated `:err` was never read
+  — the form silently nil'd out as `{:ok? true :value nil}`, corrupting
+  debugging (the agent reads the nil as a real value). So a non-blank
+  `:err` on the shadow outer map now takes PRECEDENCE over the `:results`
+  peek: it rejects with a structured `:rf.error/eval-cljs-compile-error`
+  ex-info carrying the warning/error text, which `probe/err->result`
+  surfaces verbatim as `{:ok? false :reason ... :err ...}`."
   ([conn-atom build-id form-str] (cljs-eval-value conn-atom build-id form-str nil))
   ([conn-atom build-id form-str opts]
   (-> (cljs-eval conn-atom build-id form-str opts)
@@ -614,12 +636,26 @@
             :else
             (let [outer (read-edn-safe (str (:value resp)))]
               (cond
+                ;; rf2-mvdwv — a populated :err on shadow's outer response
+                ;; is an analyzer warning (unresolved symbol) or a compile
+                ;; error. It MUST surface, even though shadow also pushed a
+                ;; \"nil\" into :results: peeking :results first would swallow
+                ;; the compile failure as a silent nil. Reject with a
+                ;; structured reason so the caller's .catch projects a clear
+                ;; `:ok? false` envelope instead of `:ok? true :value nil`.
+                (and (map? outer) (not (str/blank? (str (:err outer)))))
+                (js/Promise.reject
+                  (ex-info (str "cljs eval compile error/warning: " (str/trim (str (:err outer))))
+                           {:reason :rf.error/eval-cljs-compile-error
+                            :err    (str/trim (str (:err outer)))
+                            :hint   (str "the eval'd form failed to compile cleanly — most "
+                                         "often an unresolved symbol (a misremembered fn / "
+                                         "namespace) or a syntax/arity error. shadow surfaced "
+                                         "the analyzer warning above; the form did NOT produce "
+                                         "a real value. Fix the symbol/syntax and retry.")}))
+
                 (and (map? outer) (vector? (:results outer)))
                 (when-let [last-result (peek (:results outer))]
                   (read-edn-safe last-result))
-
-                (and (map? outer) (:err outer))
-                (js/Promise.reject
-                  (js/Error. (str "cljs eval error: " (:err outer))))
 
                 :else outer))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
@@ -292,4 +292,20 @@
                                       (await-promise/handle-sentinel
                                         conn resolved-build timeout-ms sentinel
                                         (sentinel-callbacks resolved-build timeout-ms)))))))))
-            (.catch (fn [err] (probe/err->result :eval-error err))))))))
+            (.catch
+              (fn [err]
+                ;; rf2-mvdwv — a compile warning/error (unresolved symbol,
+                ;; syntax/arity error) rejects with a structured
+                ;; `:rf.error/eval-cljs-compile-error` ex-info from
+                ;; `cljs-eval-value`. Surface it as a proper `:isError`
+                ;; envelope (matching the typed eval-error path above), so
+                ;; the agent never reads it as a value — echoing the
+                ;; resolved build / frame for context. Every other
+                ;; rejection (transport, preflight) keeps the existing
+                ;; `err->result` projection.
+                (let [data (ex-data err)]
+                  (if (= :rf.error/eval-cljs-compile-error (:reason data))
+                    (wire/err-text
+                      (cond-> (merge {:ok? false} data {:build build-id})
+                        frame (assoc :frame frame)))
+                    (probe/err->result :eval-error err))))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cljs_eval_value_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cljs_eval_value_test.cljs
@@ -163,8 +163,10 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Inner :err map → reject. When the OUTER EDN parses to a map carrying
-;; an :err key (a shadow-side cljs-eval error, distinct from an nREPL :ex),
-;; the unwrap rejects rather than returning the error map as a "value".
+;; a non-blank :err (a shadow-side cljs-eval compile warning/error,
+;; distinct from an nREPL :ex), the unwrap rejects rather than returning
+;; the error map as a "value". rf2-mvdwv promotes this to a structured
+;; ex-info carrying `:reason :rf.error/eval-cljs-compile-error`.
 ;; ---------------------------------------------------------------------------
 
 (deftest inner-err-map-rejects
@@ -176,10 +178,62 @@
                  (is false "an outer map with :err MUST reject")
                  (done)))
         (.catch (fn [err]
-                  (is (re-find #"cljs eval error: Cannot infer target type"
+                  (is (re-find #"cljs eval compile error/warning: Cannot infer target type"
                                (.-message err))
-                      "inner :err surfaced as a distinct cljs-eval-error message")
+                      "inner :err surfaced as a distinct cljs-eval compile-error message")
+                  (is (= :rf.error/eval-cljs-compile-error (:reason (ex-data err)))
+                      "rejection carries the structured compile-error reason")
+                  (is (= "Cannot infer target type" (:err (ex-data err)))
+                      ":err text rides on the ex-data verbatim")
                   (done))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-mvdwv — an UNRESOLVED SYMBOL is the headline regression. shadow
+;; emits an `:eval-compile-warnings` REPL message: the analyzer warning
+;; text lands in the response `:err`, yet shadow STILL pushes a "nil" into
+;; `:results`. The pre-fix branch order peeked `:results` first, so the
+;; "nil" won and the compile warning was swallowed as a silent
+;; `{:ok? true :value nil}`. The :err branch now takes precedence so the
+;; failure surfaces instead of nil'ing out.
+;; ---------------------------------------------------------------------------
+
+(deftest unresolved-symbol-warning-rejects-not-silent-nil
+  (async done
+    (-> (with-stubbed-cljs-eval!
+          ;; The exact shadow shape for an undeclared var: a "nil" result
+          ;; sitting alongside the analyzer warning in :err.
+          {:value (str "{:results [\"nil\"] "
+                       ":err \"WARNING: Use of undeclared Var re-frame.core/frame-db at line 1 <eval>\" "
+                       ":ns cljs.user}")}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "re-frame.core/frame-db")))
+        (.then (fn [v]
+                 (is false (str "an unresolved symbol MUST reject, never resolve "
+                                "(got " (pr-str v) ", the silent-nil bug)"))
+                 (done)))
+        (.catch (fn [err]
+                  (is (instance? js/Error err))
+                  (is (re-find #"Use of undeclared Var re-frame.core/frame-db"
+                               (.-message err))
+                      "the analyzer warning text is carried into the rejection")
+                  (let [data (ex-data err)]
+                    (is (= :rf.error/eval-cljs-compile-error (:reason data))
+                        "structured compile-error reason")
+                    (is (re-find #"undeclared Var" (:err data))
+                        ":err text rides on the ex-data")
+                    (is (string? (:hint data)) "a corrective hint is offered"))
+                  (done))))))
+
+(deftest clean-results-with-blank-err-still-resolves-value
+  ;; A clean eval leaves :err blank ("") — the :err branch must NOT fire
+  ;; on a blank :err, so the value still unwraps normally. Pins that the
+  ;; rf2-mvdwv precedence flip doesn't hijack the happy path.
+  (async done
+    (-> (with-stubbed-cljs-eval!
+          {:value "{:results [\"42\"] :err \"\" :ns cljs.user}"}
+          (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "(+ 40 2)")))
+        (.then (fn [v]
+                 (is (= 42 v) "a blank :err does not block the value unwrap")
+                 (done))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Non-:results map → returned as-is. A :value that parses to a map

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
@@ -313,6 +313,73 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-mvdwv — END-TO-END unresolved-symbol surfacing. The headline bug:
+;; eval'ing a form with an unresolved symbol (e.g. `re-frame.core/frame-db`,
+;; a fn that doesn't exist) returned `{:ok? true :value nil}` — the form
+;; silently nil'd out and the agent read the nil as a real value.
+;;
+;; Unlike the codec tests above (which stub `cljs-eval-value`, bypassing the
+;; unwrap), this stubs ONE LAYER LOWER — `nrepl/cljs-eval` — so the REAL
+;; `cljs-eval-value` unwrap runs end-to-end. We feed the exact shadow
+;; response shape for an undeclared var (`{:results ["nil"] :err "<warning>"
+;; ...}`) and assert the tool returns `:ok? false` carrying the compile
+;; error, NOT `{:ok? true :value nil}`.
+;; ---------------------------------------------------------------------------
+
+(deftest unresolved-symbol-end-to-end-fails-loud
+  (async done
+    (let [orig-jvm  nrepl/jvm-eval
+          orig-cljs nrepl/cljs-eval
+          ;; active-builds enumeration (JVM-side) — one running build.
+          jvm-stub  (fn
+                      ([_ _]   (js/Promise.resolve {:value "[:app]"}))
+                      ([_ _ _] (js/Promise.resolve {:value "[:app]"})))
+          ;; The lower-level cljs-eval. The sentinel probe must report a
+          ;; live runtime (so preflight passes); the wrapped user form
+          ;; resolves to shadow's compile-warning shape (a "nil" result
+          ;; sitting beside the undeclared-Var analyzer warning in :err).
+          ;; Both arities spelled out — CLJS direct-arity dispatch calls
+          ;; `...$arity$4`, which a rest-arg fn would not expose.
+          cljs-resp (fn [form-str]
+                      (if (sentinel-probe? form-str)
+                        ;; runtime-preloaded? probe → true
+                        {:value "{:results [\"true\"] :ns cljs.user}"}
+                        ;; the actual eval → shadow undeclared-var shape
+                        {:value (str "{:results [\"nil\"] "
+                                     ":err \"WARNING: Use of undeclared Var "
+                                     "re-frame.core/frame-db at line 1 <eval>\" "
+                                     ":ns cljs.user}")}))
+          cljs-stub (fn
+                      ([_conn _build form-str]
+                       (js/Promise.resolve (cljs-resp form-str)))
+                      ([_conn _build form-str _opts]
+                       (js/Promise.resolve (cljs-resp form-str))))]
+      (set! nrepl/jvm-eval jvm-stub)
+      (set! nrepl/cljs-eval cljs-stub)
+      (-> (eval-cljs/eval-cljs-tool (fresh-conn)
+                                    #js {:form "re-frame.core/frame-db" :build "app"})
+          (.then (fn [r]
+                   (is (err? r)
+                       "an unresolved symbol is an isError envelope, not a silent success")
+                   (let [edn (read-edn r)]
+                     (is (false? (:ok? edn))
+                         "MUST be :ok? false — never the silent {:ok? true :value nil}")
+                     (is (not (contains? edn :value))
+                         "no :value slot — the form did not produce a real value")
+                     (is (= :rf.error/eval-cljs-compile-error (:reason edn))
+                         "structured compile-error reason surfaces to the agent")
+                     (is (re-find #"undeclared Var re-frame.core/frame-db" (:err edn))
+                         "the analyzer warning text is carried through to the agent"))
+                   (set! nrepl/jvm-eval orig-jvm)
+                   (set! nrepl/cljs-eval orig-cljs)
+                   (done))
+                 (fn [e]
+                   (set! nrepl/jvm-eval orig-jvm)
+                   (set! nrepl/cljs-eval orig-cljs)
+                   (is false (str "tool promise rejected: " e))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
 ;; Await mode (rf2-xn4f9) — the opt-in `:await true` arg awaits a
 ;; Promise-returning form's resolved value, surfaces rejections as
 ;; `:rf.error/eval-cljs-rejected`, surfaces unbounded waits as


### PR DESCRIPTION
## Bead
rf2-mvdwv (P3 bug). re-frame2-pair MCP `eval-cljs`: a form with an unresolved symbol (e.g. `re-frame.core/frame-db`, a fn that does not exist) silently returned `{:ok? true :value nil}` instead of surfacing the compile error. The agent read the nil as a real value and drew wrong conclusions (bit a real investigation twice).

## Root cause
Verified against the shadow-cljs 3.4.10 source on the classpath (`shadow/cljs/devtools/server/repl_impl.clj`): shadow's `cljs-eval` handles an undeclared var via an `:eval-compile-warnings` REPL message. It routes the analyzer warning text into the response **`:err`** field but **still** pushes a `"nil"` into `:results` (`(repl-result repl-state nil)` runs after the warning is logged). A genuine compile error (`:eval-compile-error`) takes the same shape.

`nrepl/cljs-eval-value` peeked `:results` **first** whenever it was a vector, so the `"nil"` won and the populated `:err` was never read — silent `{:ok? true :value nil}`.

## Fix
- `nrepl.cljs` — a non-blank `:err` on shadow's outer response now takes **precedence** over the `:results` peek, rejecting with a structured `:rf.error/eval-cljs-compile-error` ex-info carrying the warning/error text + a corrective hint.
- `eval_cljs.cljs` — `eval-cljs-tool`'s `.catch` surfaces that reject as a proper `:isError` envelope (matching the existing typed eval-error path), echoing the requested build / frame. Every other rejection keeps the existing `probe/err->result` projection.
- A blank `:err` is unaffected — the happy-path value unwrap is unchanged.

## Tests
- `cljs_eval_value_test`: unresolved-symbol shadow shape (`{:results ["nil"] :err "<warning>"}`) rejects with the structured reason — not a silent nil; updated `inner-err-map-rejects` for the new message/reason; new `clean-results-with-blank-err-still-resolves-value` pins the happy path.
- `eval_cljs_test`: end-to-end `eval-cljs-tool` on an unresolved symbol returns `:ok? false` carrying the compile error (stubbed one layer below — `nrepl/cljs-eval` — so the REAL `cljs-eval-value` unwrap runs).

## Gates (cold)
- `npx shadow-cljs compile server-test` — 884 tests / 2710 assertions, 0 failures, **0 warnings**.
- `npm run test:mcp-conformance` — ALL 6/6 gates GREEN (incl. pair-mcp end-to-end + [4+5/6] conformance).

## Notes
- t2n04 also touches `tools/re-frame2-pair-mcp` but a different file (`wire.cljs`) — NOT edited here; disjoint.