### PR TITLE
docs(skills/xray): dedup the repeated three-issue-channels block in panels.md (rf2-uwxfz)

### DIFF
--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -508,12 +508,10 @@ cross-panel-arrow glyph reference live in
 Per §021 §15 (Dynamic mode) + §007 §Static mode:
 
 - **No Issues tab.** Removed (rf2-gbz39 #2540, Mike Option (c),
- 2026-05-31 — `panels/issues_ribbon.cljs` deleted). Issues are NOT a
- Dynamic tab; they surface inline in the **Epoch** cascade (per-step
- ✓/✗ + the shared "Exception Thrown" card), via the **L2 pink-wash**
- (rf2-b8guz), and via the always-on **`:rf.xray/issues-ribbon`** signal
- (auto-open-on-error). The session-wide aggregate / triage list was
- consciously dropped.
+ 2026-05-31 — `panels/issues_ribbon.cljs` deleted); the session-wide
+ aggregate / triage list was consciously dropped. The three inline
+ channels issues surface through instead are detailed in §Issues — no
+ longer a Dynamic tab above.
 - **No Event tab.** Retired (rf2-5gl5r, 2026-05-27 —
  `panels/event_detail.cljs` deleted). The **Epoch** panel (numbered
  cascade, `:order -1`) is the canonical "what happened" surface.


### PR DESCRIPTION
## Summary

DUPLICATION-reduction review of `skills/re-frame2-xray/` (rf2-uwxfz, one of the slice-partition dedup beads). The slice is largely DRY by design; one genuine intra-file block-level copy-paste was found and consolidated.

## The duplication

Within `references/panels.md`, the full "three inline issue channels" explanation appears twice:
- **§Issues — no longer a Dynamic tab** (lines ~432-457) — the canonical home: heading + numbered three-channel list with impl refs.
- **§What's deliberately NOT here → No Issues tab bullet** (lines ~510-516) — re-expanded the same three channels (Epoch ✓/✗ + L2 pink-wash + `:rf.xray/issues-ribbon` signal, with `rf2-b8guz`), inside an otherwise-terse summary list.

The second is verbatim re-explanation in the same file. Compressed it to the headline (the dropped-tab fact + `rf2-gbz39` ref retained so the summary item stays self-explanatory) plus a back-reference to the canonical section.

## What was deliberately NOT consolidated

Per the self-containment principle (each leaf must read standalone), cross-file restatements were left intact:
- **Wired-hotkeys table** — present in both `SKILL.md` and `references/launch-modes.md`. Two self-contained documents; the tables already diverge in column header + prose, signalling maintained-standalone, not copy-paste. Folding either into the other would break leaf self-containment.
- **Issue-channels framing** — `SKILL.md §Where issues surface now` and `panels.md §Issues` are full expansions in two different documents; the SKILL.md intro and retired-panels-table mentions are proper one-line forward-references, not duplicate expansions.

`SKILL.md` is internally clean — one full issue-channels expansion, properly cross-referenced.

## Gate

No skills build/lint exists. Verified manually: markdown headings intact, no broken tables, back-reference anchor (`§Issues — no longer a Dynamic tab`) resolves, and all 34 relative link targets in `panels.md` resolve.

## Risk

Minimal — one summary bullet compressed; no normative fact dropped (rf2-gbz39 + the "consciously dropped triage list" claim retained; the three-channel detail still lives in full in the same file, now single-sourced).

Closes rf2-uwxfz.