### PR TITLE
refactor(flows): drop dead any-dirty? accumulator from drain (rf2-yuttv)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -379,14 +379,20 @@
             ;; frame is structurally untouched. Restored in the catch below.
             last-inputs-before (registry/frame-last-inputs-snapshot frame-id)]
         (try
-          (loop [remaining  ordered
-                 db         db
-                 any-dirty? false]
+          ;; The drain threads ONLY the transformed `db` — the loop is a pure
+          ;; left-fold over the topo-ordered flows. `evaluate-flow!` returns a
+          ;; `[new-db dirty?]` tuple but the cascade has no consumer for the
+          ;; dirty flag: the router writes the returned db value straight into
+          ;; the `:db` effect slot regardless. So discard the second slot here
+          ;; (the per-flow `:rf.flow/skip` / `:rf.flow/computed` traces carry
+          ;; the dirty/clean signal tools actually read).
+          (loop [remaining ordered
+                 db        db]
             (if (empty? remaining)
               db
-              (let [flow            (flow-map (first remaining))
-                    [new-db dirty?] (evaluate-flow! frame-id db flow)]
-                (recur (rest remaining) new-db (or any-dirty? dirty?)))))
+              (let [flow         (flow-map (first remaining))
+                    [new-db _]   (evaluate-flow! frame-id db flow)]
+                (recur (rest remaining) new-db))))
           (catch #?(:clj Throwable :cljs :default) e
             ;; Atomicity contract: discard ALL flow side-effects of this
             ;; aborted drain. The pending `:db` effect is dropped by the


### PR DESCRIPTION
## What

Functional-style review of `implementation/flows` (bead **rf2-yuttv**, P3).

The slice was previously DRY-closed (lrsdv) and is **largely idiomatic** — `topo.cljc`'s Kahn's-algorithm `loop`/`recur` (legitimate topo-sort hot path, pure over immutable state, `reduce-kv` peel step), the data-driven `validation-rules` table walked by `some`, the `reduce-kv` snapshot accessors, and the `mapv` input reads are all good FP and left untouched.

One genuine cleanup found and applied.

## Change

`run-flows-on-db`'s drain threaded an `any-dirty?` boolean through its `loop`/`recur`, but the value is **dead**: the fn returns a plain db value and the router (`router.cljc`) writes it straight into the `:db` effect slot regardless of dirtiness. No caller reads a dirty flag — the per-flow `:rf.flow/skip` / `:rf.flow/computed` traces carry the dirty/clean signal tools consume.

- `implementation/flows/src/re_frame/flows.cljc:382` — removed the `any-dirty?` loop binding and the per-flow `(or any-dirty? dirty?)` accumulation; the `evaluate-flow!` `[new-db dirty?]` tuple is kept, the dirty slot discarded at the call site. The loop is now a pure left-fold threading only the transformed `db`. Added a rationale comment.

Minor hot-path upside (one fewer boolean op per flow per drain) and a clarity win (the loop's single purpose — accumulate the transformed db — is now explicit).

## Hot paths left imperative (by design)
- `topo.cljc` `topo-sort` / `extract-cycle-path` — `loop`/`recur` Kahn's + DFS; pure, perf-justified, carry their own rationale docstrings.
- `run-flows-on-db` drain itself stays `loop`/`recur` (the dirty-check drain the bead flagged to leave); only the dead accumulator was removed.

## Gate
`npm run test:cljs` (cold, full node-test incl. flows suite): **5500 tests / 19125 assertions, 0 failures, 0 errors.**

## Risk
Very low — behaviour-preserving dead-code removal; full suite green.

Closes rf2-yuttv.