### PR TITLE
fix(xray/app-db): mark wholly-new instances/singletons :added vs focused epoch (rf2-227cz)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -755,6 +755,31 @@ each machine, each spawned instance, Route, and every reserved singleton alike. 
 annotation in place on the changed nodes within each section ("← was X"), with the
 ancestor chain force-expanded so the operator never expands to find a change (§10.4).
 
+**Three before-states per section (rf2-227cz).** The section model
+(`current-state-sections`) tags each section / instance / singleton's
+`:before` slot one of three ways, and `value-body` routes each to the
+shared renderer accordingly:
+
+| `:before` slot | Meaning | Renderer call |
+|---|---|---|
+| `no-diff` sentinel | No pre-image threaded (1-arity / cold boot, no focused epoch) | plain current-state — no `:before`, no `:added?` |
+| real prior value | The slice existed in the focused epoch's `:db-before` | `:before` threaded → inline `← was X` diff in place |
+| `added` sentinel | The slice is present in `:value` but **absent** in the focused epoch's `:db-before` — it came into existence this epoch | `:added? true` (the §10.0.13 first-run path) → whole subtree washes `:added` (green) |
+
+The third row is the fix for rf2-227cz: previously an instance /
+singleton absent in the focused epoch's pre-image was tagged `no-diff`
+and rendered identically to an unchanged slice, so the one change that
+should make each event visually distinct — a newly-created machine /
+spawn / route appearing — carried no marker and the per-event diff was
+near-invisible. An absent-in-`:before` slice now reads `:added` via the
+same first-run `:added?` signal the SUBSCRIPTIONS step uses (§10.0.13).
+The `added` sentinel is emitted ONLY in diff mode (a real pre-image is
+present for the focused epoch); the cold-boot 1-arity path still tags
+every slot `no-diff`. The TOP user-domain section needs no sentinel —
+its `:before-top` is the whole prior user-domain map, so a NEW
+user-domain key already classifies `:added` per-key inside the diff
+engine.
+
 ### §4.4 Cascade overlay — downstream subs
 
 Hover (or click) any changed path → popover lists subs and views
@@ -4387,7 +4412,7 @@ signal to render plainly. None set any mode flag:
 |--------------------------------------|--------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | Epoch HANDLER step `:db`             | `panels/epoch/view.cljs` — `handler-db-diff-block` (effective post-handler db `:db-post-handler` = t1, else `db-before` when no-`:db`-with-flow, else fallback `:db-after`; `:before db-before` · rf2-4wywy / rf2-48oc4) | `data-testid="rf-xray-epoch-handler-db-full-with-diff"`                     |
 | Epoch FLOW step `:db`                | `panels/epoch/view.cljs` — `render-flow-step` (path-scoped pre→post diff `:db-pre-flow` (effective post-handler db) → `:db-post-flow` (t2) · rf2-4wywy / rf2-48oc4) | `data-testid="rf-xray-epoch-flow-db-diff-<name>"`                           |
-| App-DB panel (per `:rf/*` section)   | `panels/app_db_diff_state.cljs` — `value-body` (one mount; `:before` via `cond->`)         | App-DB panel-gallery story fixtures + segment-inspector tests               |
+| App-DB panel (per `:rf/*` section)   | `panels/app_db_diff_state.cljs` — `value-body` (one mount; `:before` via `cond->` for a real pre-image; `:added? true` via `cond->` for a slice absent in the focused epoch's pre-image, i.e. the `h/added` sentinel — rf2-227cz §4.3) | App-DB panel-gallery story fixtures + segment-inspector tests               |
 | Machine Inspector snapshot drill-in  | `panels/machine_inspector.cljs` — `snapshot-block` (`:before` via `cond->` when captured)  | `data-testid="rf-xray-machine-snapshot-block-<id>"` with `data-rf-xray-diff-mode="full+diff"` |
 | Epoch SUBSCRIPTIONS step value cells | `panels/epoch/view.cljs` — `subs-value-cell` container branch (`:before` / `:added?`)      | `data-testid="rf-xray-epoch-sub-row-*"` mount                               |
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
@@ -370,6 +370,29 @@
   against nil'. Pure data."
   ::no-diff)
 
+(def added
+  "Sentinel `:before` value meaning 'diff mode IS on, but this whole
+  section / instance / singleton slice is ABSENT in the focused epoch's
+  pre-image — it just came into existence this epoch'. Distinct from
+  `no-diff` (no pre-image at all → render plain) AND from a real prior
+  value (a genuine before → annotate the change in place).
+
+  rf2-227cz: an instance / singleton present in `:value` but absent in
+  `:before` MUST read `:added` (the whole subtree lights up green),
+  NOT plain current-state. Previously such a slot was tagged `no-diff`
+  and rendered identically to an unchanged slice, so the one thing that
+  should make each event visually distinct — the newly-created machine /
+  spawn / route appearing — was invisible. The renderer translates this
+  sentinel to the edn-inspector's `:added? true` first-run signal
+  (rf2-kp7bw), which synthesises the prior side as
+  `engine/missing-sentinel` and washes the whole subtree `:added`.
+
+  Note: this is ONLY emitted in diff mode (a real pre-image is present
+  for the focused epoch). The 1-arity / cold-boot path still uses
+  `no-diff` everywhere — with no focused epoch there is no 'this epoch
+  added it' claim to make. Pure data."
+  ::added)
+
 (defn- instances-of
   "Decompose a map-of-instances reserved-area value into an ordered
   vector of `{:id <instance-id> :value <per-instance-state>
@@ -382,7 +405,13 @@
   instance's `:before` is the prior value at that instance id, so the
   renderer can carry the inline `← changed` annotation (spec/021 §4.3).
   When `before-area` is `no-diff` every instance is tagged `no-diff` —
-  current-state only. Pure data → data."
+  current-state only.
+
+  rf2-227cz: in DIFF mode (`before-area` is NOT `no-diff`) an instance
+  id present now but ABSENT in `before-area` is tagged the `added`
+  sentinel, NOT `no-diff` — the freshly-created machine / spawn must
+  light up `:added` (green) rather than render identically to an
+  unchanged instance. Pure data → data."
   [area-value before-area]
   (if (and (map? area-value) (seq area-value))
     (->> area-value
@@ -391,7 +420,10 @@
                  :value  v
                  :before (if (= no-diff before-area)
                            no-diff
-                           (get before-area id no-diff))}))
+                           ;; Diff mode: a known prior snapshot diffs in
+                           ;; place; an instance absent from `before-area`
+                           ;; is `:added` (rf2-227cz), not `no-diff`.
+                           (get before-area id added))}))
          (sort-by (comp pr-str :id))
          vec)
     []))
@@ -454,6 +486,16 @@
   annotation but stays on the diff engine, which renders identically to
   current-state for unchanged trees.
 
+  rf2-227cz — a third `:before` value, the `added` sentinel, marks a
+  whole instance / singleton slice that is present in `:value` but
+  ABSENT in the focused epoch's pre-image (it came into existence this
+  epoch). The renderer translates `added` to the edn-inspector's
+  `:added? true` first-run signal so the whole subtree washes `:added`
+  (green) rather than rendering as plain unchanged state. (The TOP
+  user-domain section needs no sentinel — `:before-top` is the whole
+  prior user-domain map, so a NEW user-domain key already classifies
+  `:added` per-key inside the diff engine.)
+
   Pure data → data. JVM-runnable. nil-safe throughout (absent db,
   empty db, absent reserved keys, empty registries, absent before-db)."
   ([db] (current-state-sections db no-diff))
@@ -465,7 +507,13 @@
                        (if diff?
                          (let [path (get runtime-areas area-id)
                                v    (get-in before-db path ::absent)]
-                           (if (= ::absent v) no-diff v))
+                           ;; rf2-227cz — in diff mode a singleton slice
+                           ;; absent in `before-db` is `:added` (the slot
+                           ;; appeared this epoch — e.g. first navigation
+                           ;; populating `:rf/route`), NOT `no-diff`. Only
+                           ;; a slot genuinely present (incl. present-nil)
+                           ;; diffs in place.
+                           (if (= ::absent v) added v))
                          no-diff))]
      {:top   (user-domain-db db)
       :before-top (if diff?

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -203,7 +203,18 @@
   containers, and force-expands the ancestor chain over changed
   descendants (spec/021 §4.3 + §10.4). App-db's depth heuristic is
   depth-3-collapsed by default (§10.4). The keyword-accent is already
-  orange (owned by rf2-ad7zx.3)."
+  orange (owned by rf2-ad7zx.3).
+
+  rf2-227cz — a third `before` value, the `h/added` sentinel, marks a
+  whole instance / singleton slice present in `:value` but ABSENT in the
+  focused epoch's pre-image (it came into existence this epoch). For
+  that case the body passes `:added? true` (NOT `:before`) so the
+  edn-inspector's first-run path (rf2-kp7bw) synthesises the prior side
+  as `engine/missing-sentinel` and washes the WHOLE subtree `:added`
+  (green). Without this the freshly-created machine / spawn / route
+  slice rendered identically to an unchanged one and the per-event diff
+  was near-invisible — the focused epoch's actual change (a new instance
+  appearing) carried no visual marker at all."
   [value before render-id title]
   (let [_node-key (str "app-db-state/" render-id)
         ;; rf2-pvsxs — stable `:site-id` so expansion overrides survive
@@ -213,7 +224,11 @@
         ;; site-id reuses the existing per-surface key without
         ;; introducing a new namespace.
         site-id [:rf.xray/app-db render-id]
-        has-before? (not= h/no-diff before)]
+        ;; rf2-227cz — three before-states: `no-diff` (render plain),
+        ;; `added` (this whole slice is new this epoch → `:added? true`),
+        ;; or a real pre-image (diff against it → `:before`).
+        added?      (= h/added before)
+        has-before? (and (not added?) (not= h/no-diff before))]
     ;; rf2-7sdja — App-DB does NOT use `:popup-affordance?` (Mike's
     ;; live-testing call 2026-05-26). The side panel has plenty of
     ;; horizontal room; the whole-tree inspector renders comfortably
@@ -240,7 +255,13 @@
               :zoomable? true
               :header title}
        has-before?
-       (assoc :before (f/display-value before)))]))
+       (assoc :before (f/display-value before))
+       ;; rf2-227cz — a wholly-new slice (absent in the focused epoch's
+       ;; pre-image) opts into the inspector's first-run `:added?` path
+       ;; so the entire subtree washes `:added` (green) rather than
+       ;; rendering as plain unchanged state.
+       added?
+       (assoc :added? true))]))
 
 ;; ---- top (user-domain) section ------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
@@ -398,8 +398,10 @@
 
 (deftest current-state-sections-2-arity-instance-before-is-prior-snapshot
   (testing "each machine instance carries its prior snapshot as :before;
-            an instance absent before-cascade gets the no-diff sentinel.
-            Snapshots live at [:rf/runtime :machines :snapshots]."
+            an instance absent before-cascade gets the `added` sentinel
+            (rf2-227cz — the freshly-created machine must light up
+            :added, NOT render plain like an unchanged one). Snapshots
+            live at [:rf/runtime :machines :snapshots]."
     (let [before {:rf/runtime {:machines {:snapshots {:title/flow {:state :idle}}}}}
           after  {:rf/runtime {:machines {:snapshots {:title/flow {:state :loaded}
                                                        :auth       {:state :idle}}}}}
@@ -409,12 +411,13 @@
       (is (= {:state :idle} (:before flow))
           "title/flow diffs against its prior snapshot")
       (is (= {:state :loaded} (:value flow)))
-      (is (= h/no-diff (:before auth))
-          "a freshly-spawned machine has no pre-image → no-diff"))))
+      (is (= h/added (:before auth))
+          "rf2-227cz — a freshly-spawned machine (absent in before) is
+           the `added` sentinel, not `no-diff`"))))
 
 (deftest current-state-sections-2-arity-singleton-before-is-prior-slice
   (testing "a singleton slice carries its prior value as :before; an
-            absent-before singleton gets the no-diff sentinel"
+            absent-before singleton gets the `added` sentinel (rf2-227cz)"
     (let [before {:rf/runtime {:routing {:current {:id :home}}}}
           after  {:rf/runtime {:routing  {:current {:id :cart}}
                                :machines {:system-ids #{:app}}}}
@@ -423,21 +426,24 @@
           sysids (area-by model :rf/system-ids)]
       (is (= {:id :home} (:before route)) "route diffs old → new")
       (is (= {:id :cart} (:value route)))
-      (is (= h/no-diff (:before sysids))
-          "system-ids absent before-cascade → no-diff"))))
+      (is (= h/added (:before sysids))
+          "rf2-227cz — system-ids absent before-cascade → `added`
+           (the slice appeared this epoch), not `no-diff`"))))
 
 (deftest current-state-sections-2-arity-nil-before-db-safe
   (testing "a nil db-before (boot epoch — every slot is newly added) is
-            handled: before-db degrades to {}, every section's :before is
-            the no-diff sentinel for absent slots"
+            handled: before-db degrades to {}; an absent singleton slot
+            classifies `added` (rf2-227cz — the route slot appeared this
+            epoch)"
     (let [model (h/current-state-sections
                   {:counter 1 :rf/runtime {:routing {:current {:id :home}}}}
                   nil)]
       ;; nil db-before still flips diff? on (no-diff sentinel is the ONLY
       ;; way to opt out), so the user-domain before is {} not the sentinel.
       (is (= {} (:before-top model)))
-      (is (= h/no-diff (:before (area-by model :rf/route)))
-          "an added route slot (absent before) → no-diff"))))
+      (is (= h/added (:before (area-by model :rf/route)))
+          "rf2-227cz — an added route slot (absent before) → `added`,
+           not `no-diff`"))))
 
 ;; ---- (4) 'Show me when this changed' walker -----------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -355,6 +355,72 @@
       (is (= {:state :idle} (-> diff-mts first :opts :before))
           "the threaded `:before` is the prior instance snapshot"))))
 
+;; ---- rf2-227cz: a wholly-new slice reads :added, not plain ---------------
+;;
+;; The bug: an instance / singleton present in `:value` but ABSENT in the
+;; focused epoch's pre-image was tagged `no-diff` and rendered identically
+;; to an unchanged slice — so the one thing that should make each event
+;; visually distinct (the newly-created machine / spawn / route appearing)
+;; carried NO marker. The fix tags it the `h/added` sentinel and the view
+;; translates that to the edn-inspector's `:added? true` first-run signal
+;; (which washes the whole subtree green). These tests assert the view
+;; mounts the inspector with `:added? true` (NOT a `:before` opt) for a
+;; wholly-new instance / singleton.
+
+(deftest newly-added-machine-instance-mounts-added-not-before
+  (testing "rf2-227cz — a machine present in :value but absent in the
+            focused epoch's :before renders :added (not plain): its
+            instance section mounts the inspector with `:added? true`
+            and NO `:before` opt"
+    (let [before (runtime-db {:rf/machines {:door/main {:state :open}}})
+          after  (runtime-db {:rf/machines {:door/main    {:state :open}
+                                            :traffic/light {:state :red}}})
+          model  (h/current-state-sections after before)
+          tree   (state/state-body model)
+          new-mc (find-by-testid
+                   tree "rf-xray-app-db-state-instance-:rf/machines-:traffic/light")
+          mounts (find-edn-inspector-mounts new-mc)]
+      (is (seq mounts) "the newly-added machine's instance section mounts")
+      (is (some #(true? (:added? (:opts %))) mounts)
+          "the new machine mounts with `:added? true` — the whole subtree
+           washes :added (green) for the focused epoch")
+      (is (not-any? #(contains? (:opts %) :before) mounts)
+          "an :added slice carries NO `:before` opt (it has no pre-image —
+           the first-run path synthesises the missing-sentinel)"))))
+
+(deftest existing-machine-instance-still-diffs-not-added
+  (testing "rf2-227cz — a machine present in BOTH :value and :before
+            still threads `:before` (diffs in place); it does NOT get
+            the `:added?` first-run treatment"
+    (let [before (runtime-db {:rf/machines {:door/main {:state :open}}})
+          after  (runtime-db {:rf/machines {:door/main    {:state :closed}
+                                            :traffic/light {:state :red}}})
+          model  (h/current-state-sections after before)
+          tree   (state/state-body model)
+          door   (find-by-testid
+                   tree "rf-xray-app-db-state-instance-:rf/machines-:door/main")
+          mounts (find-edn-inspector-mounts door)]
+      (is (some #(contains? (:opts %) :before) mounts)
+          "the pre-existing machine threads `:before` (a real diff)")
+      (is (not-any? #(true? (:added? (:opts %))) mounts)
+          "a pre-existing machine is NOT marked :added"))))
+
+(deftest newly-added-singleton-slice-mounts-added-not-before
+  (testing "rf2-227cz — a singleton reserved slice (e.g. :rf/route) that
+            appeared this epoch (absent in :before) mounts the inspector
+            with `:added? true` and no `:before`"
+    (let [before (runtime-db {})
+          after  (runtime-db {:rf/route {:id :home}})
+          model  (h/current-state-sections after before)
+          tree   (state/state-body model)
+          route  (find-by-testid tree "rf-xray-app-db-state-area-:rf/route")
+          mounts (find-edn-inspector-mounts route)]
+      (is (seq mounts) "the newly-added route slice mounts")
+      (is (some #(true? (:added? (:opts %))) mounts)
+          "the new route slice mounts with `:added? true`")
+      (is (not-any? #(contains? (:opts %) :before) mounts)
+          "an :added slice carries no `:before` opt"))))
+
 (deftest no-diff-model-renders-current-state-no-annotation
   (testing "the 1-arity (no pre-image) model renders plain current-state
             — every mount is BROWSE mode (no `:before` opt) so the
@@ -366,7 +432,11 @@
       (is (seq mounts) "the panel mounts edn-inspector widget instances")
       (is (every? #(not (contains? (:opts %) :before)) mounts)
           "no mount carries a `:before` opt — no diff annotation
-           without a pre-image"))))
+           without a pre-image")
+      (is (not-any? #(true? (:added? (:opts %))) mounts)
+          "rf2-227cz — and no mount is marked :added in 1-arity / cold-
+           boot mode: with no focused epoch there is no 'this epoch added
+           it' claim, so every slot renders plain current-state"))))
 
 ;; ---- popup affordance (rf2-7sdja) ---------------------------------------
 ;;


### PR DESCRIPTION
## What

Fixes **rf2-227cz** (P2 bug). The App-db panel's per-event diff failed to visually mark a slice that *appeared* in the focused epoch — making the diff near-invisible when an event's only change was "a new key/instance appeared" (machine start, spawn, first navigation populating `:rf/route`, …).

Mike reproduced live on the `machine-epochs` testbed: "the app-db panel shows the same thing no matter which event I select." Every event there just ADDS a machine snapshot, so the live tree always shows all machines; the one thing that should make each event distinct — the newly-created machine lighting up `:added` (green) — did not happen.

## Root cause (NOT reactivity)

The subs recompute per focused epoch and the rendered marker set changes per focus — reactivity is intact. The gap was in the diff **projection**: an instance (machine / spawn) or singleton reserved slice present in `:value` but **absent** in the focused epoch's `:db-before` was tagged the `no-diff` sentinel by `current-state-sections` / `instances-of`, so `value-body` rendered it as **plain current-state**, identical to an unchanged slice — no `:added` marker.

## Fix

Introduce a third `:before` sentinel, `h/added`, distinct from:
- `no-diff` — no pre-image at all (1-arity / cold boot) → render plain
- a real prior value → diff in place (`← was X`)
- **`added`** — slice present in `:value`, absent in the focused epoch's pre-image (came into existence this epoch)

`current-state-sections` / `instances-of` emit `added` for an absent-in-`:before` instance/singleton, **only in diff mode** (a real pre-image is present); the cold-boot 1-arity path still tags everything `no-diff`. `value-body` translates `added` → the edn-inspector's existing first-run `:added? true` signal (rf2-kp7bw), which synthesises the prior side as the missing-sentinel and washes the whole subtree `:added` (green).

The TOP user-domain section needs no sentinel — `:before-top` is the whole prior user-domain map, so a NEW user-domain key already classifies `:added` per-key inside the diff engine.

## Acceptance (per the bead)

Scrubbing the focused epoch on `machine-epochs` now makes the newly-created machine for that epoch visibly `:added` (green): focus 2 → `:door/main` :added; focus 3 → `:traffic/light` :added; focus 8 → `:media/deep` :added.

## Tests

- Updated the three `app_db_diff_helpers` tests that codified the old `no-diff` behaviour for absent-in-before slots → now assert `h/added`.
- Added view-projection tests (`app_db_diff_state`): a newly-added machine instance and a newly-added singleton slice mount the inspector with `:added? true` and NO `:before`; a pre-existing instance still threads `:before` (not `:added`); the 1-arity/cold-boot path marks nothing `:added`.

## Spec

`tools/xray/spec/021-Dynamic-Panel-Designs.md` §4.3 documents the three before-states + the §10 value-body `:added?` threading (xray-spec-currency rule).

## Gates (all cold-green)

- xray JVM `clojure -M:test` — 1095 tests / 4563 assertions, 0 failures
- `npm run test:cljs` — 5503 tests / 19134 assertions, 0 failures
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures (incl. machine-epochs)
- `npm run test:browser` — 151 tests / 443 assertions, 0 failures

## Notes

Disjoint from open PR dc9p7 (#2979) — that touched `timing_waterfall.cljc` / `sim_helpers.cljc` / `a11y.cljs`; this touches `app_db_diff_helpers.cljc` / `app_db_diff_state.cljs` / spec 021 / two test files. No overlap. Branched off current `origin/main`.