### PR TITLE
refactor(story): idiomatic FP for index-by + max-or-nil (rf2-xxkzv)

### DIFF
--- a/tools/story/src/re_frame/story/decorators.cljc
+++ b/tools/story/src/re_frame/story/decorators.cljc
@@ -355,9 +355,9 @@
                          :response     response
                          :decorator-id (:id r)}))
                     fx-override-decorators)
-        ;; Last-wins on fx-id: dedupe pairs preserving the LAST entry
-        ;; per fx-id.
-        by-fx (reduce (fn [acc p] (assoc acc (:fx-id p) p)) {} pairs)
+        ;; Last-wins on fx-id: index pairs by :fx-id so a later entry
+        ;; overwrites an earlier one for the same fx-id.
+        by-fx (into {} (map (juxt :fx-id identity)) pairs)
         finals (vals by-fx)]
     {:overrides     (into {}
                           (map (fn [p] [(:fx-id p) (:stub-id p)]))

--- a/tools/story/src/re_frame/story/ui/view_state.cljc
+++ b/tools/story/src/re_frame/story/ui/view_state.cljc
@@ -184,11 +184,12 @@
   variant rests on no rung (a bare as-mounted render). A variant can be
   upgraded only above its lowest active rung. Pure data → int|nil."
   [plan]
-  (let [active (plan-fidelity plan)]
-    (->> ladder-rungs
-         (filter #(contains? active (:rung %)))
-         (map :rank)
-         (reduce (fn [acc r] (if acc (max acc r) r)) nil))))
+  (let [active (plan-fidelity plan)
+        ranks  (->> ladder-rungs
+                    (filter #(contains? active (:rung %)))
+                    (map :rank))]
+    (when (seq ranks)
+      (apply max ranks))))
 
 ;; ===========================================================================
 ;; PURE: source / provenance summaries


### PR DESCRIPTION
@
## What

Per-slice good-FP-technique review of `tools/story/src` (bead **rf2-xxkzv**). Two small, behaviour-preserving functional-style cleanups; the rest of the slice is already idiomatic.

### Changes

- **`decorators/fx-overrides-map`** (`decorators.cljc:360`) — the hand-rolled `(reduce (fn [acc p] (assoc acc (:fx-id p) p)) {} pairs)` index-by becomes the canonical `(into {} (map (juxt :fx-id identity)) pairs)`. Same last-wins-per-`:fx-id` semantics, clearer intent.
- **`view-state/lowest-active-rank`** (`view_state.cljc:191`) — `(reduce (fn [acc r] (if acc (max acc r) r)) nil ranks)`, a hand-rolled max-or-nil-on-empty, becomes `(when (seq ranks) (apply max ranks))`.

## Why no broader refactor

The slice is consistently idiomatic. The `loop`/`recur`, `transient`, `doseq`, and local-`atom` uses are each in a justified place and were left as-is:

- `loop`/`recur` — genuine recursion: `:extends` chain resolution with cycle detection (`plan.cljc`), the CommonMark line-walker (`ui/markdown.cljc`), the DOM sibling walk (`recorder/selector.cljc`, with an explicit allocation-avoidance comment), and the recorder wait-insertion fold (`recorder/play_export.cljc`).
- `transient`/`persistent!` — hot-path canonicalisation in `fingerprint.cljc`.
- `doseq` — side-effect iteration (dispatching into frames, registering tags, invoking callbacks, DOM attribute mutation).
- local `(atom …)` — async trace-event collectors across listener boundaries (`frames.cljc`, `invariants.cljc`, `runtime.cljc`) and JS-interop handler refs in cleanup closures (`ui/a11y_dialog.cljs`, `ui/xray_embed.cljs`, etc.).

## Gates (cold, from `tools/story/` and `implementation/`)

- `clojure -M:test` → 1590 tests, 5953 assertions, 0 failures, 0 errors.
- `npm run test:cljs` → 5500 tests, 19125 assertions, 0 failures, 0 errors.

`story:build` not required — no built-artefact logic touched. Stayed entirely in `tools/story/src` (no `testbeds/` — mxjn7 owns those).
@