### PR TITLE
fix(machines): true LCCA exit-set — external transition to a proper ancestor restarts it (rf2-emz8l)

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1755,23 +1755,61 @@
         ;; declared target.
         target-base   (if history-restore (:resolved-leaf history-restore) target-base0)
         target-leaf   (some->> target-base (initial-cascade machine))
-        ;; Per Spec 005 §Self-transitions + §Entry/exit cascading: an
-        ;; EXTERNAL self-transition re-enters the declaring state — `:exit`
-        ;; then transition `:action` then `:entry` all fire, the
-        ;; configuration unchanged. The LCA-driven cascade fires `:exit` /
-        ;; `:entry` only on states BELOW the LCA, so a self-target's plain
-        ;; common-prefix LCA (= the full declaring path) would fire neither.
-        ;; Pull the LCA up to the declaring state's PARENT so the declaring
-        ;; state lands in both the exit and entry cascades. A self-target on
-        ;; a compound state re-enters it AND re-runs its `:initial` child
-        ;; cascade (`target-leaf` re-descended above). An INTERNAL
-        ;; self-transition (no `:target`) is untouched — it never reaches
-        ;; here (`internal?` short-circuits exit/entry below). rf2-46ban.
-        self-transition? (and (not internal?) (= target-base decl-path))
+        ;; ---- Exit-set boundary: the true LCCA (rf2-emz8l) ----------------
+        ;; Per Spec 005 §Entry/exit cascading and SCXML §3.13: the exit set
+        ;; of an EXTERNAL transition is bounded by the LEAST COMMON COMPOUND
+        ;; ANCESTOR — the deepest compound state that is a PROPER ancestor of
+        ;; BOTH the source leaf and the target node. Everything strictly
+        ;; below the LCCA on the active path exits; the target plus its
+        ;; ancestors below the LCCA (and the target's `:initial` cascade)
+        ;; enters. `lca-len` is the depth of that LCCA (= the count of the
+        ;; common-ancestor prefix that survives the transition).
+        ;;
+        ;; The LCCA is computed against `target-base` (the resolved target
+        ;; BEFORE its own `:initial` re-descent), NOT `target-leaf` — the
+        ;; initial cascade is part of ENTERING the target, not of locating
+        ;; the common ancestor. Two geometries arise:
+        ;;
+        ;;  (1) TARGET ON THE ACTIVE PATH — `target-base` is a prefix of
+        ;;      `src-path` (the target is the source itself, OR a proper
+        ;;      ANCESTOR of the source). Here `target-base` is itself one of
+        ;;      the states involved, so the common COMPOUND ancestor must be
+        ;;      a PROPER ancestor of `target-base` → pull `lca-len` up to the
+        ;;      target's PARENT (`(count target-base) - 1`). The target then
+        ;;      lands in BOTH the exit and entry cascades: it is exited
+        ;;      (re-running its `:exit`), the transition `:action` fires, the
+        ;;      target is re-entered (re-running its `:entry`) and its
+        ;;      `:initial` chain re-descends (`target-leaf`). This is the
+        ;;      RESTART-the-compound geometry XState v5 / SCXML give an
+        ;;      external transition to an ancestor — without the pull-up the
+        ;;      plain common-prefix LCA equals the full target depth and the
+        ;;      transition is a SILENT NO-OP (rf2-emz8l). It also subsumes the
+        ;;      external SELF-transition (`:target :same-state` / own-keyword;
+        ;;      `target-base == src-path` or `target-base == decl-path`,
+        ;;      always a prefix of the active leaf) — the rf2-46ban precedent,
+        ;;      now one geometry rather than a special case. `max 0` keeps a
+        ;;      root-level target (`target-base == []`) sane: the whole
+        ;;      machine exits + re-enters from the root.
+        ;;
+        ;;  (2) TARGET IN A DISJOINT SUBTREE — sibling-leaf, cross-level to a
+        ;;      sibling subtree, or to the root. `target-base` is NOT a prefix
+        ;;      of `src-path`, so source and target diverge at the common-
+        ;;      prefix node, which is a proper ancestor of both and therefore
+        ;;      the LCCA. `lca-len` is the plain common-prefix length; the
+        ;;      common-ancestor node neither exits nor enters. (Here the LCP
+        ;;      of `src-path` with `target-base` and with `target-leaf` agree
+        ;;      — they diverge before `target-base` ends — so this arm is left
+        ;;      computing against `target-leaf`, unchanged.)
+        ;;
+        ;;  An INTERNAL self-transition (no `:target`) is untouched — it never
+        ;;  reaches the cascade (`internal?` short-circuits exit/entry below).
+        target-on-active-path? (and (not internal?)
+                                    (= (count target-base)
+                                       (common-prefix-length src-path target-base)))
         lca-len       (cond
-                        internal?        (count src-path)
-                        self-transition? (dec (count target-base))
-                        :else            (common-prefix-length src-path target-leaf))
+                        internal?              (count src-path)
+                        target-on-active-path? (max 0 (dec (count target-base)))
+                        :else                  (common-prefix-length src-path target-leaf))
         ;; Walk each path once; reuse the `[prefix node]` pair vectors
         ;; for both the cascade ref derivation AND the spawn/destroy fx
         ;; emission downstream (per audit §T6 #2 — eliminate the double

--- a/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
@@ -291,3 +291,85 @@
           "compound external self-transition re-descends the :initial child")
       (is (= [:exit-active :exit-session :renew :enter-session :enter-active] @log)
           "exit cascade leaf→root → action → entry cascade root→leaf (re-runs :initial)"))))
+
+;; ---- external transition to a PROPER ANCESTOR on the active path ----------
+;; (LCCA ancestor-restart geometry — rf2-emz8l)
+;;
+;; Per Spec 005 §Entry/exit cascading along the LCCA + XState v5 / SCXML
+;; §3.13: an EXTERNAL transition from a descendant leaf to one of its PROPER
+;; ANCESTORS A restarts A — A's active subtree (including A) exits, the
+;; transition action fires at the LCCA (A's parent), then A re-enters and
+;; re-descends its `:initial` chain. Before rf2-emz8l the engine bounded the
+;; exit set by the longest common PREFIX of the source path and the
+;; initial-cascaded target leaf, so an ancestor target was a SILENT NO-OP.
+;; This ns exercises the LIVE runtime (`reg-machine` / `dispatch-sync`); the
+;; pure-engine geometry + ordering is pinned in the SCXML conformance corpus
+;; (`scxml-external-transition-to-proper-ancestor-*`).
+(deftest machine-ancestor-restart-cljs
+  (testing "external transition to a proper ANCESTOR restarts that ancestor —
+            exit subtree (incl. ancestor) → action → re-enter ancestor →
+            re-init its :initial child; configuration restored to the leaf"
+    (let [log (atom [])
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
+          machine
+          {:initial :p
+           :data    {}
+           :actions {:enter-p (tag :enter-p) :exit-p (tag :exit-p)
+                     :enter-a (tag :enter-a) :exit-a (tag :exit-a)
+                     :enter-x (tag :enter-x) :exit-x (tag :exit-x)
+                     :restart (tag :restart)}
+           :states
+           {:p {:entry :enter-p :exit :exit-p          ;; LCCA — neither re-fires
+                :initial :a
+                :states
+                {:a {:entry :enter-a :exit :exit-a
+                     :initial :x
+                     :states
+                     ;; :x targets its grandparent :a (a proper ancestor) by
+                     ;; absolute vector; :a's :initial re-descends back to :x.
+                     {:x {:entry :enter-x :exit :exit-x
+                          :on {:restart {:target [:p :a] :action :restart}}}}}}}}}]
+      (rf/reg-machine :ancestor/restart machine)
+      ;; Drive the bootstrap initial-cascade with a benign unhandled event,
+      ;; then reset the log so only the :restart transition is observed.
+      (rf/dispatch-sync [:ancestor/restart [:rf2-emz8l/prime]])
+      (reset! log [])
+      (rf/dispatch-sync [:ancestor/restart [:restart]])
+      (is (= [:p :a :x] (:state (snapshot :ancestor/restart)))
+          "restarting :a re-descends its :initial back to [:p :a :x]")
+      (is (= [:exit-x :exit-a :restart :enter-a :enter-x] @log)
+          "exit :x then :a (deepest-first, incl. the ancestor) → action → re-enter :a → re-init :x; :p (the LCCA) does NOT re-fire")))
+
+  (testing "ancestor restart re-INITIALISES to the ancestor's :initial child
+            even when a non-initial child was active at restart time"
+    (let [log (atom [])
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
+          machine
+          {:initial :p
+           :data    {}
+           :actions {:enter-a (tag :enter-a)   :exit-a (tag :exit-a)
+                     :enter-one (tag :enter-1) :exit-one (tag :exit-1)
+                     :enter-two (tag :enter-2) :exit-two (tag :exit-2)}
+           :states
+           {:p {:initial :a
+                :states
+                {:a {:entry :enter-a :exit :exit-a
+                     :initial :one
+                     :states
+                     {:one {:entry :enter-one :exit :exit-one
+                            :on {:to-two :two}}
+                      :two {:entry :enter-two :exit :exit-two
+                            ;; restart the ancestor from the NON-initial child
+                            :on {:restart {:target [:p :a]}}}}}}}}}]
+      (rf/reg-machine :ancestor/reinit machine)
+      ;; Bootstrap to [:p :a :one], then advance to the non-initial child :two.
+      (rf/dispatch-sync [:ancestor/reinit [:rf2-emz8l/prime]])
+      (rf/dispatch-sync [:ancestor/reinit [:to-two]])
+      (is (= [:p :a :two] (:state (snapshot :ancestor/reinit)))
+          "now resting at the non-initial child :two")
+      (reset! log [])
+      (rf/dispatch-sync [:ancestor/reinit [:restart]])
+      (is (= [:p :a :one] (:state (snapshot :ancestor/reinit)))
+          "restart re-initialises :a to its :initial child :one (not back to :two)")
+      (is (= [:exit-2 :exit-a :enter-a :enter-1] @log)
+          "exit :two then :a → re-enter :a → re-init :one"))))

--- a/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
@@ -457,6 +457,33 @@
       (is (false? (finalize/all-regions-final? m (:state left-only)))
           "one region still pending ⇒ the parallel machine is NOT done"))))
 
+(deftest scxml-parallel-region-ancestor-restart-is-region-local
+  (testing "SCXML §3.4 + §3.13 (rf2-emz8l): the LCCA ancestor-restart applies
+            PER REGION — a transition to a region-local compound ancestor
+            restarts ONLY that region's subtree (exit+re-enter+re-init); the
+            sibling region is untouched. Each region runs the same transition
+            engine, so the LCCA fix is inherited. Spec 005 §Parallel regions
+            §Entry/exit cascading along the LCCA."
+    (let [[log mk] (order-recorder)
+          m {:type :parallel :data {}
+             :regions
+             {:left {:initial :grp
+                     :states
+                     {:grp {:entry (mk :entry-grp) :exit (mk :exit-grp)
+                            :initial :one
+                            ;; declared on the region-local compound ancestor
+                            :on {:reset {:target [:grp] :action (mk :L-action)}}
+                            :states {:one {:entry (mk :entry-1) :exit (mk :exit-1)
+                                           :on {:adv :two}}
+                                     :two {:entry (mk :entry-2) :exit (mk :exit-2)}}}}}
+              :right {:initial :idle :states {:idle {:entry (mk :entry-R)} :busy {}}}}}
+          ;; Position :left at the NON-initial child :two, :right at :idle.
+          r (step m {:state {:left [:grp :two] :right :idle} :data {}} [:reset])]
+      (is (= {:left [:grp :one] :right :idle} (:state r))
+          ":left's :grp restarts and re-inits to :one; :right (declines :reset) stays put")
+      (is (= [:exit-2 :exit-grp :L-action :entry-grp :entry-1] @log)
+          "ONLY :left's region cascades: exit :two,:grp → action → re-enter :grp → re-init :one; :right untouched"))))
+
 ;; ===========================================================================
 ;; §6. Eventless / :always microstep settle (transient transitions)
 ;;
@@ -702,6 +729,144 @@
           "a self-naming keyword target stays at the source state")
       (is (= [:exit :action :entry] @log)
           "onexit → action → onentry — identical to the `:same-state` sentinel"))))
+
+;; ===========================================================================
+;; §10b. External transition to a PROPER ANCESTOR on the active path
+;;       (LCCA-restart geometry — rf2-emz8l)
+;;
+;; SCXML §3.13 `getEffectiveTargetStates` + `findLCCA`: a transition from a
+;; descendant leaf to one of its PROPER ANCESTORS A is (by default) EXTERNAL.
+;; The LCCA of {source, A} is A's PARENT (A is a proper ancestor of the
+;; source but NOT of itself), so the exit set is A's whole active subtree
+;; INCLUDING A, and the entry set re-enters A and re-descends A's default-
+;; initial chain. Net effect: A's onexit + onentry both fire and A
+;; re-initialises. This is the natural generalisation of the external
+;; SELF-transition (§10) — a self-target is the degenerate case where A is
+;; the source leaf itself.
+;;
+;; BEFORE rf2-emz8l the engine bounded the exit set by the longest common
+;; PREFIX of the source path and the (initial-cascaded) target leaf. For an
+;; ancestor target whose `:initial` chain re-descends to the source, that
+;; LCP equals the full path → the exit AND entry sets were BOTH empty → a
+;; SILENT NO-OP where XState fires A's exit+entry and re-initialises A. The
+;; fix computes the true LCCA against the target BASE (pre-initial-cascade):
+;; when the target is a prefix of the active path, the LCCA is pulled up to
+;; the target's parent. Spec 005 §Entry/exit cascading along the LCCA.
+;; ===========================================================================
+
+(deftest scxml-external-transition-to-proper-ancestor-restarts-subtree
+  (testing "SCXML §3.13: an EXTERNAL transition from a descendant leaf to a
+            PROPER ANCESTOR A restarts A — exit A's active subtree (deepest-
+            first, INCLUDING A), run the transition action at the LCCA
+            (A's parent), then re-enter A and re-descend A's :initial chain
+            (shallowest-first). Before rf2-emz8l this was a silent no-op.
+            Spec 005 §Entry/exit cascading along the LCCA."
+    (let [[log mk] (order-recorder)
+          ;; Active config [:p :a :x]; :x targets its grandparent :a via an
+          ;; absolute vector. A's :initial is :x, so the restart re-descends
+          ;; back to [:p :a :x] — the exact case the LCP-as-LCA missed.
+          m {:initial :p :data {}
+             :states
+             {:p {:entry (mk :entry-P) :exit (mk :exit-P)     ;; LCCA — neither fires
+                  :initial :a
+                  :states
+                  {:a {:entry (mk :entry-A) :exit (mk :exit-A)
+                       :initial :x
+                       :states
+                       {:x {:entry (mk :entry-X) :exit (mk :exit-X)
+                            :on {:restart {:target [:p :a] :action (mk :ACTION)}}}}}}}}}
+          r (step m {:state [:p :a :x] :data {}} [:restart])]
+      (is (= [:p :a :x] (:state r))
+          "after restarting A the configuration re-descends A's :initial back to [:p :a :x]")
+      (is (= [:exit-X :exit-A :ACTION :entry-A :entry-X] @log)
+          "exit deepest-first (X then A) → action at the LCCA (:p) → re-enter A → re-descend A's :initial (X); :p (the LCCA) neither exits nor enters"))))
+
+(deftest scxml-external-transition-to-ancestor-diverging-initial-re-inits
+  (testing "SCXML §3.13: restarting ancestor A re-descends A's CURRENT
+            :initial child even when A's active child differed from :initial
+            at restart time. Source [:p :a :two]; A's :initial is :one, so
+            the restart re-enters A and re-descends to [:p :a :one] (the
+            re-initialisation the LCCA restart guarantees). Spec 005
+            §Entry/exit cascading along the LCCA."
+    (let [[log mk] (order-recorder)
+          m {:initial :p :data {}
+             :states
+             {:p {:initial :a
+                  :states
+                  {:a {:entry (mk :entry-A) :exit (mk :exit-A)
+                       :initial :one
+                       :states
+                       {:one {:entry (mk :entry-1) :exit (mk :exit-1)}
+                        :two {:entry (mk :entry-2) :exit (mk :exit-2)
+                              :on {:restart {:target [:p :a]}}}}}}}}}
+          ;; Seed the active config at the NON-initial child :two.
+          r (step m {:state [:p :a :two] :data {}} [:restart])]
+      (is (= [:p :a :one] (:state r))
+          "restarting A re-initialises it to its :initial child :one (not back to :two)")
+      (is (= [:exit-2 :exit-A :entry-A :entry-1] @log)
+          "exit :two then A → re-enter A → re-descend A's :initial (:one)"))))
+
+(deftest scxml-external-transition-to-ancestor-via-same-state-on-ancestor
+  (testing "SCXML §3.13 / Spec 005 §Self-transitions: `:target :same-state`
+            declared ON an ancestor and matched while a DESCENDANT leaf is
+            active restarts the ancestor — the same LCCA-restart geometry as
+            the §10 compound external self-transition, exercised through the
+            pure engine. The descendant declines the event, the ancestor
+            handles it. Spec 005 §Entry/exit cascading along the LCCA."
+    (let [[log mk] (order-recorder)
+          m {:initial :session :data {}
+             :states
+             {:session
+              {:entry (mk :entry-session) :exit (mk :exit-session)
+               :initial :active
+               ;; declared on the COMPOUND ancestor; :active declines :reauth
+               :on {:reauth {:target :same-state :action (mk :renew)}}
+               :states
+               {:active {:entry (mk :entry-active) :exit (mk :exit-active)}}}}}
+          r (step m {:state [:session :active] :data {}} [:reauth])]
+      (is (= [:session :active] (:state r))
+          "the compound self-restart re-descends :session's :initial child")
+      (is (= [:exit-active :exit-session :renew :entry-session :entry-active] @log)
+          "exit cascade leaf→root (:active, :session) → action → entry cascade root→leaf (re-runs :initial)"))))
+
+(deftest scxml-ancestor-restart-regression-disjoint-targets-unchanged
+  (testing "REGRESSION GUARD (rf2-emz8l): the LCCA fix must NOT disturb
+            DISJOINT-subtree targets. A sibling-leaf transition and a
+            cross-level-to-sibling-subtree transition keep their plain
+            common-prefix LCA — the common-ancestor node neither exits nor
+            enters. Spec 005 §Entry/exit cascading along the LCCA."
+    ;; (a) sibling-leaf: [:p :a] -> :b (sibling under :p). LCCA = :p; only
+    ;;     the leaves cross the boundary, :p untouched.
+    (let [[log mk] (order-recorder)
+          m {:initial :p :data {}
+             :states {:p {:entry (mk :entry-P) :exit (mk :exit-P)
+                          :initial :a
+                          :states {:a {:entry (mk :entry-A) :exit (mk :exit-A)
+                                       :on {:go :b}}
+                                   :b {:entry (mk :entry-B) :exit (mk :exit-B)}}}}}
+          r (step m {:state [:p :a] :data {}} [:go])]
+      (is (= [:p :b] (:state r)) "sibling-leaf transition lands at the sibling")
+      (is (= [:exit-A :entry-B] @log)
+          "only :a exits and :b enters; the common ancestor :p neither exits nor enters (unchanged)"))
+    ;; (b) cross-level to a sibling SUBTREE: [:p :a :x] -> [:p :b :y].
+    ;;     LCCA = :p; mirrors scxml-lca-cascade-* — must be untouched by the fix.
+    (let [[log mk] (order-recorder)
+          m {:initial :p :data {}
+             :states
+             {:p {:entry (mk :entry-P) :exit (mk :exit-P)
+                  :initial :a
+                  :states
+                  {:a {:entry (mk :entry-A) :exit (mk :exit-A)
+                       :initial :x
+                       :states {:x {:entry (mk :entry-X) :exit (mk :exit-X)
+                                    :on {:go {:target [:p :b :y]}}}}}
+                   :b {:entry (mk :entry-B) :exit (mk :exit-B)
+                       :initial :y
+                       :states {:y {:entry (mk :entry-Y) :exit (mk :exit-Y)}}}}}}}
+          r (step m {:state [:p :a :x] :data {}} [:go])]
+      (is (= [:p :b :y] (:state r)) "cross-level lands at the sibling subtree leaf")
+      (is (= [:exit-X :exit-A :entry-B :entry-Y] @log)
+          "exit X,A → enter B,Y; the LCCA :p untouched (sibling-subtree case unchanged by the fix)"))))
 
 ;; ===========================================================================
 ;; §11. :after — delayed transitions (SEMANTIC CORE: fire + stale)

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -299,6 +299,8 @@ The wildcard fires after specific matches **at the same level**. Only if *neithe
 
 Internal transitions are how to update `:data` without re-running entry/exit machinery.
 
+A `:target` naming the declaring state's own keyword (e.g. `:target :idle` on a state-node keyed `:idle`) is equivalent to `:target :same-state` — it names the same state as the source, so it is also **external**. On a **compound** source, the external self-transition re-enters the state *and* re-descends its `:initial` chain (a full restart of its subtree). This is the degenerate case (target = source) of the more general **ancestor-restart** geometry: an external `:target` naming a **proper ancestor** A on the active path restarts A the same way — exit A's subtree (including A), then re-enter and re-initialise A. See [§Entry/exit cascading along the LCA §Computing the LCCA](#computing-the-lcca--the-longest-common-prefix-shortcut-and-its-one-exception) for the exit-set geometry that makes both cases fall out of the same LCCA rule.
+
 ### Guards
 
 A guard is **`(fn [{:keys [data event state meta]}] boolean)`** — a single context-map argument. **One inline fn or one keyword reference into the machine's `:guards` map** — never a compound data form.
@@ -964,10 +966,10 @@ A transition that fires runs an ordered sequence of action slots. **Flat machine
 
 Each slot is optional; absent slots are skipped.
 
-**Compound machines** generalise the slot list along the LCA-cascade described in [§Hierarchical compound states §Entry/exit cascading](#entryexit-cascading-along-the-lca). Given source path A and target path B, with LCA L (longest common prefix):
+**Compound machines** generalise the slot list along the LCCA-cascade described in [§Hierarchical compound states §Entry/exit cascading](#entryexit-cascading-along-the-lca). Given source path A and target path B, with LCCA L (the **least common compound ancestor** — see that section for the exact definition; it is the longest common prefix *except* when B lies on A's active path, where it pulls up to re-enter the targeted ancestor):
 
 1. **Exit cascade** — `:exit` actions of A's states from leaf back to (but not including) L. **Deepest-first.**
-2. **Transition `:action`** — fires once at the LCA boundary.
+2. **Transition `:action`** — fires once at the LCCA boundary.
 3. **Entry cascade** — `:entry` actions of B's states from (the level just below) L down to leaf. **Shallowest-first.**
 4. **Initial cascade** — if B's leaf is itself a compound state, descend its `:initial` chain; each cascaded state's `:entry` action fires shallowest-first as the path lengthens.
 
@@ -1234,13 +1236,27 @@ A target naming a compound state implicitly cascades through its `:initial` chai
 
 ### Entry/exit cascading along the LCA
 
-When the snapshot transitions from path A to path B, the runtime walks both paths and computes the **LCA** (longest common prefix). Three boundaries fire, in this order:
+When the snapshot transitions from path A (the source) to path B (the target), the runtime walks both paths and computes the **LCCA** — the **least common compound ancestor**, the deepest compound state that is a **proper** ancestor of *both* A's leaf and B's target node. (XState v5 / SCXML §3.13 `findLCCA`; "LCA" is the historical short name and the section anchor, but the computation is the LCCA.) Three boundaries fire, in this order:
 
-1. **Exit cascade.** Walk A from leaf back toward LCA, firing each state's `:exit` action — **deepest-first**. Stop at LCA exclusive (LCA itself does not exit; we are not leaving it).
-2. **Transition `:action`.** Runs once at the LCA boundary, between exit and entry.
-3. **Entry cascade.** Walk B from (the level just below) LCA down to leaf, firing each state's `:entry` action — **shallowest-first**. If B's leaf is itself a compound state, continue cascading via its `:initial` chain; the cascaded states' `:entry` actions fire as the path extends.
+1. **Exit cascade.** Walk A from leaf back toward the LCCA, firing each state's `:exit` action — **deepest-first**. Stop at the LCCA exclusive (the LCCA itself does not exit; we are not leaving it).
+2. **Transition `:action`.** Runs once at the LCCA boundary, between exit and entry.
+3. **Entry cascade.** Walk B from (the level just below) the LCCA down to the target node, firing each state's `:entry` action — **shallowest-first**. If the target is itself a compound state, continue cascading via its `:initial` chain; the cascaded states' `:entry` actions fire as the path extends.
 
-This is a generalisation of the flat exit → action → entry rule (where path length is 1 and LCA is the root).
+#### Computing the LCCA — the longest-common-prefix shortcut and its one exception
+
+For the **common case** — A and B lie in *disjoint* subtrees (a sibling-leaf transition, a cross-level transition to a sibling subtree, or a transition to the root) — the LCCA *is* the longest common prefix of A and B: the two paths diverge at some node, and that node's parent (the last shared element) is a proper ancestor of both, so it survives the transition (it neither exits nor enters). This is why the longest-common-prefix shortcut is correct for the vast majority of transitions, and the worked examples below all fall in this case.
+
+The shortcut **breaks in exactly one geometry**: when **B (the target node, *before* its own `:initial` cascade) lies on A's active path** — i.e. the target is the source state itself (an [external self-transition](#self-transitions-external-vs-internal)) or a **proper ancestor of the source**. Here B is *itself* one of the states the transition involves, so the common *compound* ancestor must be a **proper** ancestor of B. The LCCA pulls **up to B's parent**, and the geometry becomes a **restart of B**:
+
+- B and everything below it on the active path **exit** (deepest-first, **including B** — B's `:exit` runs);
+- the transition `:action` fires at the LCCA (B's parent);
+- B **re-enters** (B's `:entry` runs) and **re-descends its `:initial` chain** — B re-initialises to its initial child, regardless of which child was active when the transition fired.
+
+Net effect for a target naming a proper ancestor A of the source: `exit (source-subtree leaf→A) → action → enter A → re-descend A's :initial`. This is the XState v5 / SCXML default for an external transition to an ancestor (the LCCA of {source, A} is A's parent, so A is in the exit set), and it makes "transition to A" a first-class **restart this compound state** operation. The external [self-transition](#self-transitions-external-vs-internal) is the degenerate case where A is the source leaf itself.
+
+> **Why the LCCA, not the plain longest common prefix?** If the LCA were computed as the longest common prefix of A and B's *initial-cascaded leaf*, an ancestor target whose `:initial` chain re-descends to the source would yield a common prefix equal to the *full* source path — the exit and entry sets would **both be empty** and the transition would be a **silent no-op**: A's `:exit`/`:entry` would not fire and A would not re-initialise. Getting the exit set wrong this way is the classic hierarchical-state-machine "LCCA trap". The LCCA is therefore computed against the target **base** (the resolved target node *before* its `:initial` re-descent — the initial cascade is part of *entering* the target, not of locating the common ancestor): when that base lies on the active path, the boundary is pulled up to the target's parent and A restarts.
+
+This is a generalisation of the flat exit → action → entry rule (where path length is 1 and the LCCA is the root).
 
 ### Transition resolution — deepest-wins with parent fallthrough
 

--- a/spec/conformance/fixtures/hierarchical-ancestor-restart-transition.edn
+++ b/spec/conformance/fixtures/hierarchical-ancestor-restart-transition.edn
@@ -1,0 +1,77 @@
+;; Conformance fixture: machine/hierarchical-ancestor-restart-transition
+;;
+;; External transition to a PROPER ANCESTOR on the active path (the LCCA
+;; ancestor-RESTART geometry — rf2-emz8l). A transition from a descendant
+;; leaf whose `:target` names a PROPER ANCESTOR A (by absolute vector) is, by
+;; default, EXTERNAL. The Least Common COMPOUND Ancestor of {source, A} is
+;; A's PARENT — so the exit set is A's whole active subtree INCLUDING A, the
+;; transition action fires at the LCCA boundary, then A re-enters and
+;; re-descends its `:initial` chain. Net effect: A's :exit + :entry both fire
+;; and A re-initialises.
+;;
+;; This is the case the longest-common-PREFIX-as-LCA computation missed: the
+;; ancestor target's `:initial` chain re-descends to the source, so the LCP
+;; equalled the full path and the exit AND entry sets were BOTH empty — a
+;; SILENT NO-OP. The true LCCA (computed against the target BASE, before its
+;; own initial cascade) pulls the boundary up to A's parent so A restarts.
+;;
+;; Per [005 §Entry/exit cascading along the LCA]
+;; (../../005-StateMachines.md#entryexit-cascading-along-the-lca).
+;; XState v5 / SCXML §3.13 (`findLCCA` / `getEffectiveTargetStates`).
+;; Contrast with hierarchical-cross-level-transition.edn (DISJOINT subtree
+;; target — the common-ancestor node is NOT re-entered).
+
+{:fixture/id           :machine/hierarchical-ancestor-restart-transition
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/flat :fsm/hierarchical}
+ :fixture/doc          "External transition to a proper ANCESTOR A on the active path restarts A: exit A's active subtree (deepest-first, INCLUDING A) → transition action at the LCCA (A's parent) → re-enter A → re-descend A's :initial chain. The LCCA-restart geometry (rf2-emz8l); the longest-common-prefix LCA made this a silent no-op."
+
+ :fixture/registry
+ {:machine-action
+  {:auth/log-exit-x  {:doc "Logs exiting leaf :x."}
+   :auth/log-exit-a  {:doc "Logs exiting compound :a (the restarted ancestor)."}
+   :auth/log-action  {:doc "Transition action at the LCCA (:p)."}
+   :auth/log-enter-a {:doc "Logs re-entering compound :a."}
+   :auth/log-enter-x {:doc "Logs re-entering leaf :x (A's re-initialised child)."}}}
+
+ :fixture/handlers
+ {:machine-action
+  {:auth/log-exit-x  [[:fx :log {:msg "exit x"}]]
+   :auth/log-exit-a  [[:fx :log {:msg "exit a"}]]
+   :auth/log-action  [[:fx :log {:msg "restart action"}]]
+   :auth/log-enter-a [[:fx :log {:msg "enter a"}]]
+   :auth/log-enter-x [[:fx :log {:msg "enter x"}]]}}
+
+ :fixture/calls
+ [{:call         :machine-transition
+   :definition
+   {:initial :p
+    :data    {}
+    :states
+    {:p {:initial :a                         ;; :p is the LCCA — neither exits nor enters
+         :states
+         {:a {:entry   :auth/log-enter-a
+              :exit    :auth/log-exit-a
+              :initial :x
+              :states
+              ;; :x targets its grandparent :a (a proper ancestor) by
+              ;; absolute vector; :a's :initial re-descends back to :x.
+              {:x {:entry :auth/log-enter-x
+                   :exit  :auth/log-exit-x
+                   :on    {:restart {:target [:p :a]      ;; vector :target — PROPER ANCESTOR
+                                     :action :auth/log-action}}}}}}}}}
+   :snapshot     {:state [:p :a :x] :data {}}
+   :event        [:restart]
+   ;; The :restart transition is declared on :x; target [:p :a] is a PROPER
+   ;; ANCESTOR of [:p :a :x]. LCCA = :a's parent = :p. Order:
+   ;;   1. Exit cascade (deepest-first):   x → a   (INCLUDING the ancestor :a)
+   ;;   2. Transition :action (at the LCCA): restart action
+   ;;   3. Entry cascade (shallowest-first): a → x (re-init :a's :initial)
+   ;; :p (the LCCA) neither exits nor enters; the configuration is restored
+   ;; to [:p :a :x] after re-descending :a's :initial.
+   :expect-next-snapshot {:state [:p :a :x] :data {}}
+   :expect-effects       [[:log {:msg "exit x"}]
+                          [:log {:msg "exit a"}]
+                          [:log {:msg "restart action"}]
+                          [:log {:msg "enter a"}]
+                          [:log {:msg "enter x"}]]}]}


### PR DESCRIPTION
## Summary

Fixes **rf2-emz8l** (P2). An external transition whose `:target` names a **proper ancestor** on the active path was a **silent no-op**. The engine bounded the exit set by the longest common **prefix** (LCP) of the source path and the *initial-cascaded* target leaf; an ancestor target whose `:initial` chain re-descends to the source yielded a common prefix equal to the full path, so the exit **and** entry sets were both empty — the ancestor's `:exit`/`:entry` never fired and it never re-initialised. This is the classic LCCA trap.

Fixed to **true LCCA** semantics (XState v5 / SCXML §3.13 `findLCCA`), per Mike's ruling on the bead: a target to a proper ancestor must **restart** that ancestor's active subtree (exit + re-enter + re-init to its `:initial` child).

## The change

`transition.cljc` (`compute-cascade-paths`): the exit boundary is now computed against the **target base** (the resolved target *before* its own `:initial` cascade — the initial cascade is part of *entering* the target, not of locating the common ancestor).

```
;; before
self-transition? (and (not internal?) (= target-base decl-path))
lca-len (cond
          internal?        (count src-path)
          self-transition? (dec (count target-base))
          :else            (common-prefix-length src-path target-leaf))

;; after
target-on-active-path? (and (not internal?)
                            (= (count target-base)
                               (common-prefix-length src-path target-base)))
lca-len (cond
          internal?              (count src-path)
          target-on-active-path? (max 0 (dec (count target-base)))
          :else                  (common-prefix-length src-path target-leaf))
```

When `target-base` is a prefix of `src-path` (the target is the source itself **or** a proper ancestor), the boundary pulls up to the target's parent → the target exits, the action fires, the target re-enters and re-descends its `:initial`. This **generalises and subsumes** the rf2-46ban external-self-transition pull-up into one geometry — the degenerate self-target is just the case where the ancestor is the source leaf. The `:else` (disjoint-subtree) arm is unchanged, so sibling-leaf / cross-level-to-sibling / cross-level-to-root / descendant targets keep their exact prior behaviour.

Parallel-region targets fall out for free: each region runs the same single-machine engine, so a region-local ancestor target restarts only that region.

## Spec (spec/005 — hot-zone, sole owner this pass)

- Corrected both "LCA = longest common prefix" definitions (§Level 2 slot list + §Entry/exit cascading along the LCA) to **true LCCA**.
- Added **§Computing the LCCA — the longest-common-prefix shortcut and its one exception** documenting the ancestor-restart geometry and *why* the LCP shortcut breaks (with the silent-no-op explanation). Cite XState v5 / SCXML §3.13.
- Cross-referenced from §Self-transitions. Section anchor `#entryexit-cascading-along-the-lca` kept stable.

## Tests

- **SCXML conformance** (`scxml_conformance_cljs_test.cljc`, pure engine, dual-runtime):
  - core ancestor-restart (`[:p :a :x]` → `[:p :a]`): asserts `exit-X → exit-A → ACTION → entry-A → entry-X`, configuration restored to `[:p :a :x]`;
  - re-init from a **non-initial** child (active `:two`, `:initial :one` → restarts to `:one`);
  - `:target :same-state` declared on the **ancestor**, matched while a descendant leaf is active;
  - **parallel-region**-local ancestor restart (only the targeted region cascades; sibling untouched);
  - **regression guard**: disjoint-subtree targets (sibling-leaf + cross-level-to-sibling) unchanged.
- **Live runtime** (`machines_hierarchical_cljs_test.cljs`, Reagent / `dispatch-sync`): ancestor restart + re-init.
- **Mode-B conformance fixture** (`hierarchical-ancestor-restart-transition.edn`): runs in both the machines JVM gate and core's downstream runner (proven exercised, not skipped).

## Gates (cold, after rebase onto current origin/main)

- `npm run test:cljs` — **5524 tests / 19180 assertions, 0 failures, 0 errors**
- machines JVM `clojure -M:test` — **421 tests / 1372 assertions, 0 failures, 0 errors**
- `python scripts/check_doc_slugs.py --verbose` — **0 broken links**
- `python -m mkdocs build --strict` — **exit 0, no warnings/errors**

## Risks

Low. The change is confined to one `cond` arm in the exit-set computation; the disjoint-subtree path (the overwhelming majority of transitions) is byte-identical. Depth-bound, atomic rollback, and the macrostep/raise/`:always` integration (yi7ts/505ic) are untouched — the change is upstream of the cascade runner. The only behavioural change is exactly the bug case the bead targets, plus the now-unified self-transition path (covered by existing + new tests).

Closes rf2-emz8l.