### PR TITLE
refactor(skills): single-source Tool-Pair surface list in pair-retro routing (rf2-1xk4l)

### DIFF
--- a/skills/re-frame2-pair-retro/SKILL.md
+++ b/skills/re-frame2-pair-retro/SKILL.md
@@ -103,7 +103,7 @@ Filing is a **two-step, approval-gated** mode — distinct from the default diag
 
 After presenting the retrospective, offer filing work only if useful: draft issue text, file via `gh issue create` against the appropriate repo, or split into multiple focused issues.
 
-**Routing.** `re-frame2-pair` — friction in the pair tool (SKILL.md, scripts, recipes, structured results, attach/discovery, cross-platform). `re-frame2` — friction caused by the framework's Tool-Pair contract (missing trace events, gaps in `epoch-history` / `restore-epoch` failure modes, missing registrar query surfaces, source-coord annotation gaps, schema-reflection shortcomings).
+**Routing.** `re-frame2-pair` — friction in the pair tool (SKILL.md, scripts, recipes, structured results, attach/discovery, cross-platform). `re-frame2` — friction caused by the framework's Tool-Pair contract; name the specific surface from [`../shared/tool-pair-surfaces.md`](../shared/tool-pair-surfaces.md) (trace stream, registrar query API, epoch-history / restore, schema reflection, source-coord annotation) rather than re-spelling the list here.
 
 **Filing mechanics — shared recipe.** The procedural rules (redact secrets / tokens / internal URLs / unnecessary local paths, don't dump the raw transcript, search for an existing issue before filing, one issue per materially distinct improvement, and the shell-safe single-quoted here-doc + `--body "$(cat …)"` pattern) live once in [`../shared/issue-filing.md`](../shared/issue-filing.md). Follow it; this skill adds the routing above and the body skeleton in [`references/issue-template.md`](references/issue-template.md) (the worked `gh issue create` example with re-frame2-pair-retro's label scheme).
 

--- a/skills/re-frame2-pair-retro/references/analysis-lenses.md
+++ b/skills/re-frame2-pair-retro/references/analysis-lenses.md
@@ -108,7 +108,7 @@ Also consider higher-upside redesigns:
 Decide which target repo's GitHub issues the filing lives in before drafting:
 
 - **`day8/re-frame2-pair`** — the friction is in the tool's SKILL.md, scripts, attach logic, recipe selection, structured-result shape, cross-platform handling, or any concern that is not part of the framework's commitment.
-- **`day8/re-frame2`** — the friction is caused by a gap or ambiguity in the Tool-Pair contract itself: a missing trace event category, an under-specified `:rf.epoch/*` failure mode, a missing registrar query, a `data-rf2-source-coord` shape question, a schema-reflection limitation, or a private-namespace reach-through that should be promoted to public.
+- **`day8/re-frame2`** — the friction is caused by a gap or ambiguity in the Tool-Pair contract itself. Name the specific surface from [`../../shared/tool-pair-surfaces.md`](../../shared/tool-pair-surfaces.md) (e.g. a missing trace event category, an under-specified `:rf.epoch/*` failure mode, a missing registrar query, a `data-rf2-source-coord` shape question, a schema-reflection limitation) or a private-namespace reach-through that should be promoted to public.
 - **Both** — sometimes the fastest path is a tool-side workaround now plus an upstream issue for the long-term fix. File both, and reference one from the other.
 
 ## Prioritization

--- a/skills/re-frame2-pair-retro/references/issue-template.md
+++ b/skills/re-frame2-pair-retro/references/issue-template.md
@@ -9,7 +9,7 @@ The default filing path is a **GitHub issue** against the target repo — `re-fr
 Before drafting, decide the target repo:
 
 - **`re-frame2-pair`** — friction in the pair tool itself: SKILL.md, scripts, recipes, attach logic, structured results, cross-platform handling.
-- **`re-frame2`** — friction caused by a gap in the framework's Tool-Pair contract: missing trace event category, under-specified `:rf.epoch/*` failure mode, missing registrar query, source-coord shape question, schema-reflection limitation, private-namespace reach-through that should be promoted.
+- **`re-frame2`** — friction caused by a gap in the framework's Tool-Pair contract. Name the specific surface from [`../../shared/tool-pair-surfaces.md`](../../shared/tool-pair-surfaces.md) (e.g. missing trace event category, under-specified `:rf.epoch/*` failure mode, missing registrar query, source-coord shape question, schema-reflection limitation) or a private-namespace reach-through that should be promoted.
 
 When unsure, ask the user. Sometimes both: a tool-side workaround now and an upstream GitHub issue for the long-term fix; cross-link them.
 


### PR DESCRIPTION
## What

DUPLICATION-reduction review of `skills/re-frame2-pair-retro/` (bead rf2-1xk4l). One genuine, drift-prone intra-slice duplication found and consolidated; the rest of the slice is appropriately self-contained.

## The duplication

The repo-routing rule's **inline enumeration of upstream Tool-Pair surfaces** — trace events / `epoch-history`–`restore-epoch` failure modes / registrar query / `data-rf2-source-coord` / schema-reflection — was re-spelled near-verbatim across three operationally-loaded leaves:

- `SKILL.md:106` §Routing
- `references/analysis-lenses.md:111` §Routing the fix
- `references/issue-template.md:12` §Routing first

`skills/shared/tool-pair-surfaces.md` already exists as the **single home** for exactly this enumeration — its header states it exists to stop "the surface enumeration that several skills otherwise restate from memory and let drift out of sync." SKILL.md already cites it elsewhere (its §Guard-rails directive: "Name the specific surface from that leaf rather than gesturing at the contract"), but the three routing blocks did not.

## The change

Each routing block keeps its self-contained "which repo for which friction" sentence (per-leaf standalone readability preserved) but now **cites the shared leaf** for the surface list instead of re-spelling it, with a short illustrative `e.g.` inline so the reader isn't forced to jump. Future surface changes now update one place. 3 files, 3 lines.

## Deliberately NOT consolidated (self-containment respected)

- The six-mode `:rf.epoch/restore-*` list repeated in `analysis-lenses.md:34` + `known-frictions.md:118` — loaded at different decision moments, no authoritative shared single-source to point at; consolidating would break per-leaf self-containment for no single-source gain.
- The `re-frame2-pair` (tool-side) friction list — short, generic, not the drift-prone Tool-Pair surface set.
- `issue-template.md:49` body-skeleton layer hint — a terse template field, not a third copy of the routing rule.
- `README.md:38` — human-facing intro prose, appropriately self-contained.
- `spec/*` — author-facing re-authoring docs; restating the locks is their purpose, out of dedup scope.
- The cross-skill block-level dedup (filing recipe, retro protocol, surface enumeration) was already extracted to `skills/shared/` in prior work — not re-litigated here.

Does **not** touch the rf2-81wr7 generic-to-any-app path fix in `known-frictions.md` (disjoint).

## Gates

- `python3 scripts/check_skill_redirect_anchors.py` — PASS
- `python scripts/check_skill_mcp_drift.py --verbose --ci` — PASS (no skill↔MCP drift)
- `clojure -M -m re-frame.api-manifest.skills-check` — PASS (473 public-var refs in sync)