### PR TITLE
feat(machines): thread machine-wide :tags union + :all-state into region guard/action ctx — tags as stateIn (rf2-46ly6 + rf2-69d1n)

### DIFF
--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -321,7 +321,43 @@
         (let [rn          (first pending)
               region-spec (region-machine parent-machine rn)
               region-snap (cond-> {:state (get state-map rn)
-                                   :data  cur-data}
+                                   :data  cur-data
+                                   ;; Per rf2-46ly6 / rf2-69d1n: thread the
+                                   ;; cross-region coordination context into
+                                   ;; every region's guard/action ctx — the
+                                   ;; XState v5 `stateIn` / SCXML `In()`
+                                   ;; equivalent.
+                                   ;;
+                                   ;; `:all-state` is the full region-name →
+                                   ;; active-state map (the PRECISE sibling-
+                                   ;; state read); `:tags` is the MACHINE-WIDE
+                                   ;; tag union across every region (the coarse
+                                   ;; tag-as-stateIn substitute — rf2-69d1n).
+                                   ;;
+                                   ;; Both are computed from `new-states`, the
+                                   ;; EVOLVING macrostep snapshot: regions
+                                   ;; processed earlier in THIS broadcast
+                                   ;; already carry their post-transition
+                                   ;; state, so a sibling transition earlier in
+                                   ;; the same broadcast is visible here; this
+                                   ;; region (and later siblings) still carry
+                                   ;; their current (pre-transition) state,
+                                   ;; which is what a guard evaluated BEFORE the
+                                   ;; transition fires must see. Across the FIFO
+                                   ;; raise drain, every re-broadcast rebuilds
+                                   ;; these from the latest `cur-snap` via a
+                                   ;; fresh `reduce-regions`, so the union stays
+                                   ;; current through the macrostep (consistent
+                                   ;; with the rf2-yi7ts broadcast rework).
+                                   ;;
+                                   ;; `:all-state` doubles as the parallel-
+                                   ;; region marker `call-guard`/`call-action`
+                                   ;; key off (transition.cljc) — flat/compound
+                                   ;; machines never set it, so their ctx is
+                                   ;; unchanged.
+                                   :all-state new-states
+                                   :tags      (compute-tags-parallel
+                                                parent-machine new-states)}
                             (some? cur-counter)
                             (assoc :rf/spawn-counter cur-counter)
                             ;; Seed the region snapshot with the shared

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -104,6 +104,8 @@
 ;; user code destructures the ones it needs. Keys present per slot type:
 ;;
 ;;   :guard / :action / :entry / :exit  → :data :event :state :meta
+;;                                         (+ :tags :all-state for a region —
+;;                                          see the cross-region note below)
 ;;   :on-done                            → :data :result
 ;;   :on-spawn                           → :data :id
 ;;   :after  (delay-fn)                  → :snapshot
@@ -119,26 +121,73 @@
 ;; expanding the arity-permutation matrix. Destructuring at the call site
 ;; makes meaningful keys explicit; the runtime delivers them in a single
 ;; map.
+;;
+;; ---- cross-region guard/action context (rf2-46ly6 / rf2-69d1n) ------------
+;;
+;; XState v5 / SCXML gold standard: a parallel region's guard can predicate
+;; on a SIBLING region's active state via `stateIn(stateValue)` (XState v5
+;; `xstate/guards`) / the `In(stateID)` predicate (W3C SCXML B.1). This is
+;; the canonical orthogonal-region coordination primitive — region A's
+;; `:submit` guarded by "region B is in `:valid`".
+;;
+;; re-frame2 expresses this WITHOUT a separate `stateIn` primitive (per
+;; rf2-69d1n — behavioural parity, not API mimicry). When `call-guard` /
+;; `call-action` run for a REGION of a parallel machine, the context map
+;; gains two cross-region keys, threaded in by `parallel/reduce-regions`:
+;;
+;;   :tags       — the MACHINE-WIDE active-configuration tag union across
+;;                 EVERY region (the coarse `stateIn` substitute; a sibling
+;;                 region advertises a state-tag and any region's guard
+;;                 reads `(contains? (:tags ctx) :some/tag)`). It reflects
+;;                 the EVOLVING macrostep snapshot — a sibling region that
+;;                 transitioned earlier in the same macrostep is visible.
+;;   :all-state  — the full region-name → active-state map (the PRECISE
+;;                 `stateIn` equivalent; `(= :valid (:form (:all-state ctx)))`
+;;                 reads a sibling region's discrete state value directly).
+;;
+;; `:all-state` is the unambiguous PARALLEL-REGION marker — only
+;; `reduce-regions` ever sets it. A flat / compound machine's working
+;; snapshot never carries it, so `call-guard` / `call-action` surface
+;; NEITHER key for flat / compound machines: their guard/action ctx is
+;; exactly `{:data :event :state :meta}`, unchanged. (A flat machine's
+;; `stateIn` substitute is its own `:state` — Spec 005 §Guards.) Keying the
+;; cross-region keys off `:all-state` presence means flat machines stay
+;; untouched without stripping the inherited committed `:tags` slot from
+;; their snapshot.
+
+(defn- callback-ctx
+  "Build the unified context-map handed to a `:guard` / `:action` / `:entry`
+  / `:exit` callback. Per Spec 005 §Guards / §Actions (rf2-grw4i /
+  rf2-v0rrr) the base shape is `{:data :event :state :meta}`.
+  Per rf2-46ly6 / rf2-69d1n, a parallel REGION's snapshot additionally
+  carries the machine-wide `:tags` union and the full `:all-state` region
+  map (threaded by `parallel/reduce-regions`) — the cross-region
+  coordination keys (XState v5 `stateIn` / SCXML `In()`). `:all-state` is
+  the parallel-region marker: present iff this is a region snapshot, so
+  flat / compound machines surface neither key and their ctx is unchanged."
+  [snapshot event]
+  (cond-> {:data  (:data snapshot)
+           :event event
+           :state (:state snapshot)
+           :meta  (:meta snapshot)}
+    (contains? snapshot :all-state) (assoc :all-state (:all-state snapshot)
+                                           :tags      (:tags snapshot))))
 
 (defn- call-guard
   "Invoke a resolved guard fn against a snapshot + event with the unified
   context-map contract — `(fn [{:keys [data event state meta]}] boolean)`.
-  Per Spec 005 §Guards (rf2-grw4i / rf2-v0rrr)."
+  Per Spec 005 §Guards (rf2-grw4i / rf2-v0rrr); a parallel region's guard
+  additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n)."
   [g snapshot event]
-  (g {:data  (:data snapshot)
-      :event event
-      :state (:state snapshot)
-      :meta  (:meta snapshot)}))
+  (g (callback-ctx snapshot event)))
 
 (defn- call-action
   "Invoke a resolved action fn against a snapshot + event with the unified
   context-map contract — `(fn [{:keys [data event state meta]}] effects)`.
-  Per Spec 005 §Actions (rf2-grw4i / rf2-v0rrr)."
+  Per Spec 005 §Actions (rf2-grw4i / rf2-v0rrr); a parallel region's action
+  additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n)."
   [f snapshot event]
-  (f {:data  (:data snapshot)
-      :event event
-      :state (:state snapshot)
-      :meta  (:meta snapshot)}))
+  (f (callback-ctx snapshot event)))
 
 ;; ---- guard / action evaluation traces -------------------------------------
 ;;

--- a/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
+++ b/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
@@ -1,0 +1,294 @@
+(ns re-frame.cross-region-guard-ctx-test
+  "Per Spec 005 §Cross-region coordination — tags as `stateIn`
+  (rf2-46ly6 / rf2-69d1n).
+
+  XState v5 / SCXML gold standard: a parallel region's guard can
+  predicate on a SIBLING region's active state via `stateIn(stateValue)`
+  (XState v5 `xstate/guards`) / the `In(stateID)` predicate (W3C SCXML
+  B.1) — the canonical orthogonal-region coordination primitive.
+
+  re-frame2 expresses this WITHOUT a separate `stateIn` primitive
+  (rf2-69d1n — behavioural parity, not API mimicry). `reduce-regions`
+  threads the machine-wide active-configuration `:tags` union and the
+  full `:all-state` region map into every region's guard/action ctx
+  (rf2-46ly6). A region guard then reads a sibling region's state via
+  either:
+    - `(contains? (:tags ctx) :some/state-tag)` — the coarse tag query
+      (the documented `stateIn` substitute);
+    - `(= :valid (:form (:all-state ctx)))` — the precise sibling-state
+      read.
+
+  Coverage (the bead's comprehensive test list):
+    (a) a region guard reading `(:tags ctx)` sees a SIBLING region's
+        state-tag and fires / blocks accordingly — the core cross-region
+        coordination case, impossible before rf2-46ly6.
+    (b) the §State-tags-as-stateIn worked example from spec/005 actually
+        works from a region guard.
+    (c) tags reflect the EVOLVING snapshot mid-macrostep — a sibling
+        transition earlier in the same macrostep is visible to a later
+        region's guard.
+    (d) region guards still see their OWN state correctly (regression).
+    (e) non-parallel (flat / compound) guard ctx is UNAFFECTED — neither
+        `:tags` nor `:all-state` appears (regression).
+    (f) action ctx gets the same `:tags` + `:all-state` threading."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]
+            [re-frame.machines.parallel :as parallel]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- snapshot [machine-id]
+  (get-in (rf/app-db-value :rf/default) [:rf/runtime :machines :snapshots machine-id]))
+
+;; ---- (a) region guard reads a sibling region's tag ------------------------
+
+(deftest region-guard-reads-sibling-tag
+  (testing "a :gate region guard reading (:tags ctx) sees the :form region's
+            tag and fires / blocks accordingly"
+    (let [m {:type    :parallel
+             :data    {}
+             :guards  {:form-valid? (fn [{:keys [tags]}]
+                                      (contains? tags :form/valid))}
+             :regions
+             {:form {:initial :invalid
+                     :states  {:invalid {:tags #{:form/invalid} :on {:validate :valid}}
+                               :valid   {:tags #{:form/valid}}}}
+              :gate {:initial :closed
+                     :states  {:closed {:on {:try {:target :open :guard :form-valid?}}}
+                               :open   {}}}}}]
+      (rf/reg-machine :xreg/tag-gate m)
+      ;; Form still :invalid → :gate's :try guard reads NO :form/valid → blocked.
+      (rf/dispatch-sync [:xreg/tag-gate [:try]])
+      (is (= {:form :invalid :gate :closed} (:state (snapshot :xreg/tag-gate)))
+          ":gate stays :closed — sibling :form has not advertised :form/valid")
+      ;; Flip the form valid; now its tag is in the machine-wide union.
+      (rf/dispatch-sync [:xreg/tag-gate [:validate]])
+      (is (= :valid (get-in (snapshot :xreg/tag-gate) [:state :form])))
+      ;; :try again — :gate's guard now reads :form/valid in (:tags ctx) → fires.
+      (rf/dispatch-sync [:xreg/tag-gate [:try]])
+      (is (= :open (get-in (snapshot :xreg/tag-gate) [:state :gate]))
+          ":gate opens — sibling :form now advertises :form/valid in the tag union"))))
+
+;; ---- (a') region guard reads a sibling's precise :all-state value ----------
+
+(deftest region-guard-reads-sibling-all-state
+  (testing "a region guard reading (:all-state ctx) sees the sibling region's
+            discrete state value (the precise stateIn equivalent)"
+    (let [m {:type    :parallel
+             :data    {}
+             :guards  {:form-is-valid? (fn [{:keys [all-state]}]
+                                         (= :valid (:form all-state)))}
+             :regions
+             {:form {:initial :invalid
+                     :states  {:invalid {:on {:validate :valid}}
+                               :valid   {}}}
+              :gate {:initial :closed
+                     :states  {:closed {:on {:try {:target :open :guard :form-is-valid?}}}
+                               :open   {}}}}}]
+      (rf/reg-machine :xreg/state-gate m)
+      (rf/dispatch-sync [:xreg/state-gate [:try]])
+      (is (= :closed (get-in (snapshot :xreg/state-gate) [:state :gate]))
+          ":gate blocked — sibling :form is not :valid")
+      (rf/dispatch-sync [:xreg/state-gate [:validate]])
+      (rf/dispatch-sync [:xreg/state-gate [:try]])
+      (is (= :open (get-in (snapshot :xreg/state-gate) [:state :gate]))
+          ":gate opens — (:all-state ctx) :form read as :valid"))))
+
+;; ---- (b) the spec/005 worked example actually works from a region guard ----
+
+(deftest spec-005-stateIn-substitute-worked-example
+  (testing "the spec/005 §Cross-region coordination worked example —
+            :checkout's :submit guarded on the :form region being :valid —
+            works end to end via the tag union"
+    ;; This mirrors the canonical xstate `stateIn({form: 'valid'})` example,
+    ;; expressed as the re-frame2 tag substitute. The :form region carries a
+    ;; :form/valid tag in its :valid state; the :checkout region's :submit
+    ;; transition is guarded on that tag being in the machine-wide union.
+    (let [m {:type    :parallel
+             :data    {}
+             :guards  {:form-valid? (fn [{:keys [tags]}]
+                                      (contains? tags :form/valid))}
+             :regions
+             {:form     {:initial :editing
+                         :states  {:editing {:tags #{:form/editing}
+                                             :on   {:complete :valid}}
+                                   :valid   {:tags #{:form/valid}}}}
+              :checkout {:initial :idle
+                         :states  {:idle      {:on {:submit {:target :submitting
+                                                             :guard  :form-valid?}}}
+                                   :submitting {:tags #{:checkout/submitting}}}}}}]
+      (rf/reg-machine :xreg/checkout m)
+      ;; :submit while the form is :editing → blocked (no :form/valid tag).
+      (rf/dispatch-sync [:xreg/checkout [:submit]])
+      (is (= :idle (get-in (snapshot :xreg/checkout) [:state :checkout]))
+          ":submit blocked while :form is :editing")
+      ;; Complete the form, then submit → fires.
+      (rf/dispatch-sync [:xreg/checkout [:complete]])
+      (rf/dispatch-sync [:xreg/checkout [:submit]])
+      (is (= :submitting (get-in (snapshot :xreg/checkout) [:state :checkout]))
+          ":submit fires once the :form region advertises :form/valid")
+      (is (contains? (:tags (snapshot :xreg/checkout)) :checkout/submitting)
+          "the committed tag union reflects :checkout's new state too"))))
+
+;; ---- (c) tags reflect the evolving mid-macrostep snapshot ------------------
+
+(deftest tag-union-reflects-evolving-macrostep
+  (testing "a sibling region's transition EARLIER in the same macrostep is
+            visible to a later region's guard via the evolving tag union"
+    ;; Declaration order: :form before :gate. A single :go event makes :form
+    ;; transition :invalid → :valid (advertising :form/valid). Because :form is
+    ;; processed first within the one broadcast, :gate's :go guard — evaluated
+    ;; against the EVOLVING snapshot — already sees :form/valid and fires, all
+    ;; in ONE macrostep with NO intermediate dispatch.
+    (let [m {:type    :parallel
+             :data    {}
+             :guards  {:form-valid? (fn [{:keys [tags]}]
+                                      (contains? tags :form/valid))}
+             :regions
+             {:form {:initial :invalid
+                     :states  {:invalid {:tags #{:form/invalid} :on {:go :valid}}
+                               :valid   {:tags #{:form/valid}}}}
+              :gate {:initial :closed
+                     :states  {:closed {:on {:go {:target :open :guard :form-valid?}}}
+                               :open   {}}}}}]
+      (rf/reg-machine :xreg/evolving m)
+      (rf/dispatch-sync [:xreg/evolving [:go]])
+      (is (= {:form :valid :gate :open} (:state (snapshot :xreg/evolving)))
+          ":gate saw :form's same-macrostep transition to :valid and opened"))))
+
+(deftest tag-union-evolving-pure-fn
+  (testing "pure machine-transition: the evolving union is current as of the
+            region's position in the broadcast (declaration order)"
+    (let [m {:type    :parallel
+             :data    {}
+             :guards  {:form-valid? (fn [{:keys [tags]}]
+                                      (contains? tags :form/valid))}
+             :regions
+             {:form {:initial :invalid
+                     :states  {:invalid {:tags #{:form/invalid} :on {:go :valid}}
+                               :valid   {:tags #{:form/valid}}}}
+              :gate {:initial :closed
+                     :states  {:closed {:on {:go {:target :open :guard :form-valid?}}}
+                               :open   {}}}}}
+          initial {:state {:form :invalid :gate :closed}
+                   :data  {} :tags #{:form/invalid}}
+          {snap ::result/snap} (parallel/machine-transition m initial [:go])]
+      (is (= {:form :valid :gate :open} (:state snap))
+          "pure transition: :gate's guard read the evolving :form/valid")
+      (is (= #{:form/valid} (:tags snap))
+          "committed union reflects both regions' settled states"))))
+
+;; ---- (d) a region guard still sees its OWN state correctly (regression) ---
+
+(deftest region-guard-sees-own-state
+  (testing "a region guard reading :state / :data still resolves against its
+            OWN region (unaffected by the cross-region threading)"
+    (let [seen (atom [])
+          m {:type    :parallel
+             :data    {:n 0}
+             :guards  {:own-idle?  (fn [{:keys [state data]}]
+                                     (swap! seen conj {:state state :data data})
+                                     (= :idle state))}
+             :regions
+             {:a {:initial :idle
+                  :states  {:idle {:on {:advance {:target :busy :guard :own-idle?}}}
+                            :busy {}}}
+              :b {:initial :x
+                  :states  {:x {}}}}}]
+      (rf/reg-machine :xreg/own m)
+      (rf/dispatch-sync [:xreg/own [:advance]])
+      (is (= :busy (get-in (snapshot :xreg/own) [:state :a]))
+          "guard reading its OWN :state (= :idle) fired the transition")
+      (is (every? #(= :idle (:state %)) @seen)
+          "the guard's :state was the region's OWN discrete value, never the
+           sibling's nor the full region map"))))
+
+;; ---- (e) flat / compound guard ctx is UNAFFECTED (regression) -------------
+
+(deftest flat-guard-ctx-has-no-cross-region-keys
+  (testing "a FLAT machine's guard ctx is exactly {:data :event :state :meta}
+            — no :tags, no :all-state"
+    (let [captured (atom nil)
+          m {:initial :idle
+             :data    {:ok true}
+             :guards  {:capture (fn [ctx]
+                                   (reset! captured ctx)
+                                   true)}
+             :states  {:idle {:tags #{:flat/idle}
+                              :on   {:go {:target :done :guard :capture}}}
+                       :done {}}}]
+      (rf/reg-machine :flat/ctx m)
+      (rf/dispatch-sync [:flat/ctx [:go]])
+      (is (= :done (:state (snapshot :flat/ctx))))
+      (is (= #{:data :event :state :meta} (set (keys @captured)))
+          "flat guard ctx carries ONLY the four base keys")
+      (is (not (contains? @captured :tags))
+          "flat guard ctx has no :tags (the committed :tags slot does NOT leak)")
+      (is (not (contains? @captured :all-state))
+          "flat guard ctx has no :all-state (parallel-region marker absent)")
+      (is (= :idle (:state @captured)) "flat guard still sees its OWN :state")
+      (is (= {:ok true} (:data @captured)) "flat guard still sees :data"))))
+
+(deftest compound-guard-ctx-has-no-cross-region-keys
+  (testing "a COMPOUND machine's guard ctx is also exactly the four base keys"
+    (let [captured (atom nil)
+          m {:initial :parent
+             :data    {}
+             :guards  {:capture (fn [ctx] (reset! captured ctx) true)}
+             :states  {:parent {:initial :child
+                                :states  {:child {:on {:go {:target :sibling
+                                                            :guard  :capture}}}
+                                          :sibling {}}}}}]
+      (rf/reg-machine :compound/ctx m)
+      (rf/dispatch-sync [:compound/ctx [:go]])
+      (is (= #{:data :event :state :meta} (set (keys @captured)))
+          "compound guard ctx carries ONLY the four base keys")
+      (is (not (contains? @captured :all-state))))))
+
+;; ---- (f) action ctx gets the same :tags + :all-state threading ------------
+
+(deftest region-action-receives-cross-region-ctx
+  (testing "a region ACTION receives the machine-wide :tags union and the
+            :all-state region map, same as a guard"
+    (let [captured (atom nil)
+          m {:type    :parallel
+             :data    {}
+             :actions {:capture (fn [{:keys [tags all-state] :as ctx}]
+                                  (reset! captured (select-keys ctx [:tags :all-state]))
+                                  {:data {:saw-tags      tags
+                                          :saw-all-state all-state}})}
+             :regions
+             {:form {:initial :valid
+                     :states  {:valid {:tags #{:form/valid}}}}
+              :gate {:initial :closed
+                     :states  {:closed {:on {:snap {:target :closed
+                                                    :action :capture}}}}}}}]
+      (rf/reg-machine :xreg/action-ctx m)
+      (rf/dispatch-sync [:xreg/action-ctx [:snap]])
+      (is (some? @captured) "the action ran")
+      (is (= #{:form/valid} (:tags @captured))
+          "action ctx carries the machine-wide tag union (sibling :form's tag)")
+      (is (= {:form :valid :gate :closed} (:all-state @captured))
+          "action ctx carries the full :all-state region map"))))
+
+;; ---- bonus: cross-region keys do NOT leak into the committed snapshot ------
+
+(deftest cross-region-ctx-keys-do-not-leak-into-snapshot
+  (testing ":all-state is a ctx-only key — it never appears on the committed
+            parallel snapshot (only the derived :tags union does)"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:a {:initial :one :states {:one {:tags #{:a/one}}}}
+                       :b {:initial :two :states {:two {:tags #{:b/two}}}}}}]
+      (rf/reg-machine :xreg/no-leak m)
+      (rf/dispatch-sync [:xreg/no-leak [:no-match]])
+      (let [s (snapshot :xreg/no-leak)]
+        (is (not (contains? s :all-state))
+            ":all-state is ctx-only — never committed onto the snapshot")
+        (is (= #{:a/one :b/two} (:tags s))
+            "the derived :tags union is committed as usual")))))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -340,9 +340,13 @@ Guards or actions that need to branch on the discrete FSM state name or on any u
 
 The context-map shape is uniform across every callback slot — `:state` and `:meta` are always present alongside `:data` and `:event` for `:guard` / `:action` / `:entry` / `:exit`. There is no opt-in flag and no separate 3-arity variant; the runtime delivers the full map and the user's destructure pattern decides what's bound.
 
+For a guard / action running **inside a parallel region**, the context map additionally carries `:tags` (the machine-wide active-configuration tag union) and `:all-state` (the full region-name → active-state map) — the cross-region `stateIn` substitute. These two keys are present only for region callbacks; flat / compound machines never carry them. See [§Cross-region coordination — tags as `stateIn`](#cross-region-coordination--tags-as-statein).
+
 Compound logic is expressed via function composition or as a named entry in the machine's `:guards` map — the name carries semantic content visualisers and AIs read. Resolution is machine-scoped per [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler); unresolved references fail registration with `:rf.error/machine-unresolved-guard`.
 
-**No combinator data form (deliberate divergence from XState v5).** XState ships higher-order guard combinators — `and([...])`, `or([...])`, `not(...)`, `stateIn(...)` (from `xstate/guards`) — so authors can compose named guards declaratively, e.g. `guard: and(['isAuthed', 'hasQuota'])`. re-frame2 has **no `{:and …}` / `{:or …}` / `{:not …}` data form**; a `:guard` is exactly one inline fn or one keyword into the machine's `:guards` map (`GuardRef` in [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table)). Compound logic is ordinary Clojure boolean composition inside one fn, or — preferably — a *named* entry in `:guards` whose name carries the semantic content a visualiser or an AI reads (the `:active-and-under-quota?` idiom above). This follows the spec's bias toward **one explicit primitive over many implicit conveniences** ([Principles](Principles.md)): a combinator tree obscures the predicate's meaning, whereas a name states it. The `stateIn` analog is the `:state` key already present in every guard's context map ([§Snapshot introspection](#snapshot-introspection--state--meta)). An XState migrant reaching for `and`/`or`/`not` writes a fn (or a named guard) instead.
+**No combinator data form (deliberate divergence from XState v5).** XState ships higher-order guard combinators — `and([...])`, `or([...])`, `not(...)`, `stateIn(...)` (from `xstate/guards`) — so authors can compose named guards declaratively, e.g. `guard: and(['isAuthed', 'hasQuota'])`. re-frame2 has **no `{:and …}` / `{:or …}` / `{:not …}` data form**; a `:guard` is exactly one inline fn or one keyword into the machine's `:guards` map (`GuardRef` in [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table)). Compound logic is ordinary Clojure boolean composition inside one fn, or — preferably — a *named* entry in `:guards` whose name carries the semantic content a visualiser or an AI reads (the `:active-and-under-quota?` idiom above). This follows the spec's bias toward **one explicit primitive over many implicit conveniences** ([Principles](Principles.md)): a combinator tree obscures the predicate's meaning, whereas a name states it. An XState migrant reaching for `and`/`or`/`not` writes a fn (or a named guard) instead.
+
+`stateIn(...)`'s substitute depends on what the guard is testing. For a guard reading **this machine's own** active state, it is the `:state` key already present in every guard's context map ([§Snapshot introspection](#snapshot-introspection--state--meta)). For the case `stateIn` actually exists to serve — **one parallel region's guard predicating on a sibling region's active state** — it is the machine-wide `:tags` union (the coarse, idiomatic substitute) or the `:all-state` region map (the precise substitute), both threaded into every region's guard/action ctx; see [§Cross-region coordination — tags as `stateIn`](#cross-region-coordination--tags-as-statein).
 
 ### Actions
 
@@ -1423,6 +1427,59 @@ If **every region** declines the event (no region matched a transition), the mac
 
 The post-broadcast snapshot's `:state` is the map of region-name → that region's new state value. Regions that didn't transition keep their prior value in place.
 
+### Cross-region coordination — tags as `stateIn`
+
+xstate/SCXML term: **`stateIn(stateValue)`** (XState v5, from `xstate/guards`; v4 `in: '#someState'`) / the **`In(stateID)`** predicate (W3C SCXML B.1). This is the canonical orthogonal-region coordination primitive: one region's transition guard predicates on a **sibling** region's active state — region `:checkout`'s `:submit` guarded by "the `:form` region is in `:valid`" — without coupling the regions through shared `:data`.
+
+re-frame2 ships the same **behaviour** without a separate `stateIn` primitive (deliberate divergence — behavioural parity, not API mimicry; see the *No combinator data form* note in [§Guards](#guards)). When a guard or action runs **inside a region** of a parallel machine, its context map carries two extra cross-region keys alongside the usual `:data` / `:event` / `:state` / `:meta`:
+
+| ctx key | value | use |
+|---|---|---|
+| **`:tags`** | the **machine-wide** active-configuration tag union — every active state's `:tags` across **every** region (per [§Tags compose across regions](#tags-compose-across-regions)) | the **coarse** `stateIn` substitute: a sibling region advertises a state-tag, and any region's guard reads `(contains? (:tags ctx) :form/valid)`. This is **the** documented `stateIn` equivalent (the more general / more idiomatic mechanism — a tag is a *named* render-state, exactly the Nine States idiom). |
+| **`:all-state`** | the full region-name → active-state map (`{:form :valid :checkout :idle}`) | the **precise** sibling-state read: `(= :valid (:form (:all-state ctx)))` matches a sibling region's discrete state value directly, the literal analog of `stateIn({form: 'valid'})`. |
+
+Both keys reflect the **evolving macrostep snapshot**: regions transition in declaration order within one broadcast, so a region whose guard runs later sees the *post-transition* state of any sibling that transitioned **earlier in the same macrostep** (and the FIFO `:raise` re-broadcast — per [§`:raise` is the exception](#per-region-always--after--spawn-scoping) — rebuilds the union against the full evolving snapshot on every re-broadcast, consistent with the broadcast/FIFO drain). A region reading its **own** current state uses `:state` (or, for the pre-transition own value, `:all-state` under its own region name — though `:state` is the canonical own-state read); `:all-state` is the mechanism for reading **siblings**.
+
+These two keys appear **only** for region guards/actions. A **flat / compound** machine's guard/action ctx is exactly `{:data :event :state :meta}` — unchanged — because its `stateIn` substitute is its own `:state` (a flat machine has no siblings to coordinate with). The implementation keys the cross-region keys off the parallel-region marker, so flat/compound machines are untouched.
+
+#### Worked example — `:submit` guarded on a sibling region's validity
+
+```clojure
+;; The xstate `stateIn({form: 'valid'})` example, expressed as re-frame2's
+;; tag substitute: :checkout's :submit fires only when the :form region is
+;; in :valid (which advertises :form/valid in the machine-wide tag union).
+(rf/reg-machine :ui/checkout
+  {:type    :parallel
+   :data    {}
+   :guards  {:form-valid? (fn [{:keys [tags]}]
+                            (contains? tags :form/valid))}
+   :regions
+   {:form     {:initial :editing
+               :states  {:editing {:tags #{:form/editing} :on {:complete :valid}}
+                         :valid   {:tags #{:form/valid}}}}
+    :checkout {:initial :idle
+               :states  {:idle       {:on {:submit {:target :submitting
+                                                    :guard  :form-valid?}}}
+                         :submitting {:tags #{:checkout/submitting}}}}}})
+
+(rf/dispatch-sync [:ui/checkout [:submit]])
+;; :form is still :editing → :form/valid is NOT in the union → :submit BLOCKED.
+;; snapshot :state stays {:form :editing :checkout :idle}
+
+(rf/dispatch-sync [:ui/checkout [:complete]])   ; :form → :valid (tag :form/valid)
+(rf/dispatch-sync [:ui/checkout [:submit]])
+;; :checkout's guard now reads :form/valid in (:tags ctx) → :submit FIRES.
+;; snapshot :state → {:form :valid :checkout :submitting}
+```
+
+The precise variant reads the sibling's state value directly:
+
+```clojure
+:guards {:form-is-valid? (fn [{:keys [all-state]}] (= :valid (:form all-state)))}
+```
+
+Both styles ship; prefer the **tag** query — a tag is a named, visualiser-/AI-legible render-state, and it survives a sibling region refactoring its internal state names as long as the tag stays put. (The same-macrostep coordination case — a single event that flips `:form` to `:valid` *and* lets `:checkout` proceed in one macrostep — works because the tag union is the **evolving** snapshot: `:form` is processed before `:checkout` in declaration order, so `:checkout`'s guard already sees `:form/valid`.)
+
 ### Per-region `:always` / `:after` / `:spawn` scoping
 
 Each region's state-node keys (`:always`, `:after`, `:spawn`, `:entry`, `:exit`) operate **scoped to that region**:
@@ -1496,6 +1553,7 @@ Parallel-region transitions emit one `:rf.machine/transition` macrostep trace pe
 
 - [§Snapshot shape](#snapshot-shape) — the three-arm `:state` form.
 - [§State tags](#state-tags) — tag union extends across regions.
+- [§Cross-region coordination — tags as `stateIn`](#cross-region-coordination--tags-as-statein) — the `:tags` / `:all-state` ctx keys threaded into region guards/actions (the XState v5 `stateIn` / SCXML `In()` substitute).
 - [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) — the N-machines-per-region pattern for the independent-features case.
 - [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table) — `:type` + `:regions` schema.
 - [Spec-Schemas §`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot) — `:state` widened.
@@ -1714,7 +1772,7 @@ Per the locked design decision (§9.3): `:tags` is a state-node slot, not a tran
 
 ### What tags are *not*
 
-- **Not a transition-driver.** Guards' inputs are `:data` + the event, not the tag set. A transition can't react to a tag flipping on; if you need that, the right answer is to change the state directly (an `:always` transition guarded on `:data` is the canonical mechanism).
+- **Not an autonomous transition-driver.** A tag flipping on does not, by itself, *fire* a transition — there is no "on this tag appearing" trigger. A transition still needs an event or an eventless `:always` step to fire; if you need a state change to follow a `:data` condition autonomously, the canonical mechanism is an `:always` transition guarded on `:data`. **Guards CAN read the tag set, though** — for a parallel region's guard the machine-wide `:tags` union is in the context map as the cross-region `stateIn` substitute (see [§Cross-region coordination — tags as `stateIn`](#cross-region-coordination--tags-as-statein)), so a guard *can* predicate on a sibling region's render-state. The distinction: tags are a guard **input** (a sibling region advertises one, this region's guard reads it on the next event/`:always`), not a guard **trigger**.
 - **Not a `:meta` synonym.** Per-state `:meta` (the long-standing tooling-visible slot, e.g. `{:terminal? true}`) lives alongside `:tags` and is independently queryable via `(machine-meta id)`. Tags are about **runtime active-configuration projection**; `:meta` is about **static state-node metadata**.
 - **Not user-writable on the snapshot.** Actions can't return `:tags` in their `{:data :fx}` effect map; the slot is runtime-owned.
 - **Not a substitute for `:rf/machine`.** Views that need the whole snapshot still subscribe to `:rf/machine`; `:rf/machine-has-tag?` is for the predicate-shaped query. Both are first-class.


### PR DESCRIPTION
## What

Threads cross-region coordination context into every parallel-region guard/action ctx, making the XState v5 `stateIn` / SCXML `In()` capability reachable from inside a region guard. Implements the two ruled, tightly-coupled beads together:

- **rf2-46ly6** (RULED THREAD) — thread the machine-wide `:tags` union (and the full active configuration) into each region's guard/action ctx so cross-region coordination works.
- **rf2-69d1n** (RULED TAGS-SUBSTITUTE) — no separate `stateIn` primitive; once the union is threaded, tags ARE the in-state predicate. Documented in spec/005 (behavioural parity, not API mimicry).

## Before → after

`parallel.cljc` `reduce-regions` built each region's per-step snapshot as `{:state (get state-map rn) :data ...}` — only the region's OWN `:state`. The machine-wide `:tags` union was committed only at the parent level (`commit-tags-parallel`), never threaded into the per-region guard ctx. So neither the precise (`stateIn`) nor the coarse (tags) cross-region predicate was reachable from a region guard.

Now `reduce-regions` threads two keys onto each region snapshot, computed from the **evolving** `new-states` map:

| ctx key | value | role |
|---|---|---|
| `:tags` | machine-wide active-configuration tag union across every region | coarse, idiomatic `stateIn` substitute (rf2-69d1n) |
| `:all-state` | full region-name → active-state map | precise sibling-state read |

`call-guard` / `call-action` (`transition.cljc`) surface both via a shared `callback-ctx` helper, keyed off the `:all-state` parallel-region marker.

**Sibling `:state` IS threaded** — via `:all-state` (the full region map), the precise `stateIn` analog, alongside the primary tags-union mechanism. Both ship.

## Evolving-snapshot correctness

Tags/`:all-state` are computed from `new-states` (regions processed earlier in the broadcast carry their post-transition state), and the FIFO `:raise` re-broadcast rebuilds them per broadcast — so the union is current through the macrostep, consistent with the yi7ts broadcast/FIFO rework. A single event that flips region A and lets region B proceed works in ONE macrostep.

## Flat/compound untouched

`:all-state` is the parallel-region marker (only `reduce-regions` sets it). Flat/compound ctx stays exactly `{:data :event :state :meta}` — the inherited committed `:tags` slot does NOT leak. The keys are ctx-only and never committed onto the snapshot (asserted).

## Spec (spec/005, hot-zone)

- New §Cross-region coordination — tags as `stateIn` (46ly6 ctx + 69d1n tags-as-stateIn) with a cross-region worked example, citing XState v5 `stateIn` / SCXML `In()`.
- §Guards `stateIn`-analog note corrected (own-state → `:state`; sibling-state → `:tags`/`:all-state`).
- §Snapshot introspection + §State-tags "not a transition-driver" notes corrected (guards CAN read the tag set; tags are a guard input, not a trigger).

## Tests

`cross_region_guard_ctx_test.clj` — (a) region guard reading `(:tags ctx)` sees a sibling's tag and fires/blocks; (a') precise `:all-state` sibling read; (b) the spec worked example end-to-end; (c) evolving mid-macrostep union (single-event cross-region coordination, live + pure-fn); (d) region guard sees its OWN state (regression); (e) flat + compound ctx unaffected — no `:tags`/`:all-state` (regression); (f) action ctx gets the same threading; plus no-leak assertion.

## Gates (cold)

- `npm run test:cljs` — green (5524 tests / 19180 assertions, 0 failures, 0 errors) — full machines + SCXML conformance + new cross-region tests
- machines JVM suite — green (431 tests / 1398 assertions)
- `python scripts/check_doc_slugs.py --verbose` — 0 broken links
- `mkdocs build --strict` — exit 0, no warnings

Closes rf2-46ly6, rf2-69d1n.