### PR TITLE
fix(xray/trace): drop nil-:id rows at projection so React keys stay unique (rf2-wh33n)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
@@ -805,9 +805,23 @@
 
 (defn project-rows
   "Project every event in `events` into a row. Returns a vector in
-  chronological order (oldest first). Pure data → data."
+  chronological order (oldest first). Pure data → data.
+
+  Drops any event lacking an `:id` (rf2-wh33n). The runtime allocates a
+  monotonic `:id` per emit, so a nil-`:id` event is a pathological,
+  malformed envelope (`trace_collector/snapshot-from-rings` already
+  sorts such events to the tail via `MAX_SAFE_INTEGER`). Such a row has
+  no stable identity: `row-key` would key it `\"t:nil\"` — colliding
+  with every other nil-`:id` row into one React key — and it cannot be
+  selected (`find-row` matches on `:id`) or expanded (the toggle
+  dispatches `:id`). Filtering it here is the projection-time guard the
+  bead prescribed, and it keeps `row-key` keying on the stable `:id`
+  alone — no positional fallback, honouring the anti-positional-key
+  contract (`project-feed-from-epoch-rows-carry-no-row-index-slot`)."
   [events]
-  (mapv project-row events))
+  (into [] (comp (filter (comp some? :id))
+                 (map project-row))
+        events))
 
 ;; ---- band projection (spec/023 §2 · §4) ---------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -102,6 +102,27 @@
     (is (= [1 2 3] (mapv :id rows))
         "project-rows keeps the events' oldest-first order")))
 
+(deftest project-rows-drops-nil-id-events
+  (testing "rf2-wh33n — a nil-:id event is a pathological, malformed
+            envelope with no stable identity; project-rows filters it
+            out so it never reaches `row-key` (where two such rows would
+            both key `t:nil`, a React-key collision) nor selection /
+            expansion (both match on :id)"
+    (let [evs  [(ev {:id 1   :op-type :rf.event :operation :rf.event/dispatched :time 100})
+                (ev {:id nil :op-type :rf.event :operation :rf.event/dispatched :time 200})
+                (ev {:id 2   :op-type :rf.fx    :operation :rf.fx/handled       :time 300})
+                (ev {:id nil :op-type :rf.fx    :operation :rf.fx/handled       :time 400})]
+          rows (h/project-rows evs)]
+      (is (= [1 2] (mapv :id rows))
+          "both nil-:id rows are dropped; the well-formed rows survive in order")
+      (is (every? (comp some? :id) rows)
+          "no projected row carries a nil :id")
+      (let [keys (mapv h/row-key rows)]
+        (is (= ["t:1" "t:2"] keys)
+            "surviving rows key on their stable :id")
+        (is (= (count rows) (count (distinct keys)))
+            "no React-key collision among the projected rows")))))
+
 ;; ---- (2) area-badge classification — spec/023 §3 / §5 ------------------
 
 (deftest area-classifies-the-full-vocabulary


### PR DESCRIPTION
## What

Closes **rf2-wh33n** (P4 bug). The Trace panel's `row-key` builds a row's React key as `(str "t:" (pr-str id))`. A trace event lacking an `:id` keyed to `"t:nil"`; two such rows collided on a single React key, remounting / mis-reconciling the viewport.

A nil-`:id` event is the pathological frameless-envelope case `trace_collector/snapshot-from-rings` already sorts to the tail via `MAX_SAFE_INTEGER`. The runtime allocates a monotonic `:id` per emit, so this was latent (not live).

## Fix

`project-rows` now filters out any event with a nil `:id`. Such a row has **no stable identity** — it can't be keyed, selected (`find-row` matches on `:id`), or expanded (the toggle dispatches `:id`) — so dropping it at projection time is the correct guard. This was the bead's preferred option, and it keeps `row-key` keying on the stable `:id` alone with **no positional fallback**, honouring the codebase's explicit anti-positional-key contract (`project-feed-from-epoch-rows-carry-no-row-index-slot`).

Adds a `trace_helpers` JVM/CLJS test asserting nil-:id events are dropped and the surviving rows produce distinct React keys.

## Scope

`tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc` + its `_cljs_test.cljc`. Disjoint from the in-flight xray testbed work and from rf2-nk7w0 (edn-inspector). **Spec unchanged (internal key/projection fix — no contract touched).**

## Gates (all cold, green)

- xray JVM `clojure -M:test` — 1096 tests, 0 failures
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures
- `npm run test:browser` — 151 tests, 0 failures (rendering fix → browser gate per the vcnvj lesson)
- `npm run test:cljs` — 5525 tests, 0 failures
