### PR TITLE
docs(xray/testbeds): doc hygiene for standard/routes/edn/two-frame decks (rf2-v9fxc)

### DIFF
--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -1,25 +1,24 @@
 (ns edn-inspector.core
-  "EDN-INSPECTOR testbed (rf2-74u2s → rf2-1niob → rf2-yucxn → rf2-rrqku) —
-  a queued-step driving surface that exercises the Xray edn-inspector
-  THROUGH its primary use case: the Epoch and App-db PANELS.
+  "EDN-INSPECTOR testbed — a queued-step driving surface that exercises
+  the Xray edn-inspector THROUGH its primary use case: the Epoch and
+  App-db PANELS.
 
-  ## Shape (rf2-rrqku — adopt the shared queued-step RUNNER)
+  ## Shape — the shared queued-step RUNNER
 
   ONE purple `Step` button walks the diff-audit case matrix top to
   bottom while the operator watches how the Xray panels render each
-  step. The runner (`runner.core`, the rf2-8pbjr pilot) is the shared
-  harness; this deck supplies a `steps` vector (CODE DATA) + a testid
-  `prefix`. Each step DISPATCHES one event that makes ONE clean,
-  meaningful app-db transition, and the Xray SIDECAR mounted INLINE on
-  the right (`[data-rf-xray-host]`) shows the change via the EPOCH panel
+  step. The runner (`runner.core`) is the shared harness; this deck
+  supplies a `steps` vector (CODE DATA) + a testid `prefix`. Each step
+  DISPATCHES one event that makes ONE clean, meaningful app-db
+  transition, and the Xray SIDECAR mounted INLINE on the right
+  (`[data-rf-xray-host]`) shows the change via the EPOCH panel
   (db-before / db-after) and the APP-DB panel (the diff). Title:
   `Xray Testbed: edn-inspector`.
 
-  Replaces the bespoke numbered-button ladder: same events, same app-db
-  transitions, same coverage — but driven by the shared runner so the
-  operator presses ONE button and reads each step's per-occurrence
-  `:watch` note while the panels render. After each auto-advance dispatch
-  the runner pins Xray focus to the latest `:rf/default` epoch.
+  The runner is manual-step only: the operator presses Step (or a per-row
+  RUN button) to drive ONE step at a time and reads its `:watch` note
+  while the panels render. There is no auto-advance and no timer, and the
+  runner does NOT pin Xray focus — the operator focuses each epoch.
 
   Both panels render their CLJS values THROUGH the edn-inspector
   (`day8.re-frame2-xray.views.edn-inspector`) — the single value renderer
@@ -28,7 +27,7 @@
   into app-db, and the inspector renders that shape and its diff inside the
   panels.
 
-  ## The matrix (rf2-yucxn — senior-dev base-case audit)
+  ## The matrix
 
   The step vector is organised SIMPLE → COMPLEX along the audit matrix;
   each step drives ONE case, in order:
@@ -52,14 +51,13 @@
     SHOWCASE            — large collection (elision) · deep nesting (collapse
                           summary) · mixed scalar + tagged-literal vector
 
-  ## Per-step delta (rf2-5sjbg — app-db `:step`)
+  ## Per-step delta — app-db `:step`
 
   The runner sets app-db `:step = n` on the run-step epoch; that churn is
-  the per-step App-db / Epoch delta the panels show (it REPLACES the old
-  `:baseline` counter). The per-step matrix case is the ADDITIONAL change
-  the run-step epoch's child event lands.
+  the per-step App-db / Epoch delta the panels show. The per-step matrix
+  case is the ADDITIONAL change the run-step epoch's child event lands.
 
-  ## Runner cursor = app-db `:step` (rf2-5sjbg)
+  ## Runner cursor = app-db `:step`
 
   The runner cursor lives in app-db's `:step` slot, written by
   `runner.core`'s run-step event — NOT a Reagent atom. The deck reads as an
@@ -74,7 +72,7 @@
   `core.cljs` §init!). That keeps the inline-host behaviour identical
   (`[data-rf-xray-host]`, the same shell, the same Epoch + App-db panels)
   WITHOUT touching the hot-zone `implementation/shadow-cljs.edn` (the
-  `:examples/edn-inspector` build-id already exists from #2702).
+  `:examples/edn-inspector` build-id already exists there).
 
   ## Test surface, not tutorial
 
@@ -106,18 +104,18 @@
             ;; lens 'open' chip resolves a classpath-relative `:file` to
             ;; an absolute on-disk URI.
             [day8.re-frame2-xray.config :as xray-config]
-            ;; Shared testbed-config helper (rf2-5dphw): derives the
-            ;; open-in-editor project-root from the build env.
+            ;; Shared testbed-config helper: derives the open-in-editor
+            ;; project-root from the build env.
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared step-driver runner (rf2-5sjbg). This deck supplies
-            ;; a `steps` vector + registers `:edn-inspector/run-step` via
+            ;; The shared step-driver runner. This deck supplies a `steps`
+            ;; vector + registers `:edn-inspector/run-step` via
             ;; `runner/reg-runner!`; the runner drives the ONE-button series
             ;; + the per-step RUN buttons off app-db `:step`.
             [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
-;; The inspected app frame (rf2-8pbjr — only the app frame is Xray-relevant)
+;; The inspected app frame — only the app frame is Xray-relevant.
 ;; ============================================================================
 
 (def host-frame :rf/default)
@@ -126,12 +124,12 @@
 ;; APP-DB SEED
 ;; ============================================================================
 ;;
-;; One flat, named seed. `:step` is the runner cursor (rf2-5sjbg) — the
-;; index of the last-run step, written by `runner.core`'s run-step event;
-;; its churn every step IS the per-step App-db / Epoch delta (it REPLACES
-;; the old `:baseline` counter). The other slots are the real, meaningful
-;; paths the per-step events write the matrix-case shapes into — the App-db
-;; panel renders them (and their diffs) THROUGH the edn-inspector.
+;; One flat, named seed. `:step` is the runner cursor — the index of the
+;; last-run step, written by `runner.core`'s run-step event; its churn
+;; every step IS the per-step App-db / Epoch delta. The other slots are
+;; the real, meaningful paths the per-step events write the matrix-case
+;; shapes into — the App-db panel renders them (and their diffs) THROUGH
+;; the edn-inspector.
 ;;
 ;; The seed is chosen so EVERY matrix case has something clean to act on:
 ;; a map with keys to add/remove/change, sequentials with entries, a set,
@@ -146,8 +144,8 @@
    :queue      [:task-1 :task-2 :task-3]
    :history    '(:login :browse)
    :tags       #{:alpha :beta :gamma}
-   ;; SCATTERED removal repro (rf2-vu42n) — a four-element lane the
-   ;; scattered-removal step thins to [:a :c] (drops :b@1 + :d@3).
+   ;; SCATTERED removal — a four-element lane the scattered-removal step
+   ;; thins to [:a :c] (drops :b@1 + :d@3).
    :lane       [:a :b :c :d]
    ;; EMPTY vs REMOVAL — a single-member of each kind to empty (key intact)
    ;; alongside a sibling key to remove wholesale.
@@ -179,8 +177,8 @@
 ;; ============================================================================
 ;;
 ;; The per-step App-db / Epoch delta is the runner's `:step` write on the
-;; parent run-step epoch (rf2-5sjbg); each event below writes ONLY its
-;; matrix-case shape, the ADDITIONAL change the App-db diff renders.
+;; parent run-step epoch; each event below writes ONLY its matrix-case
+;; shape, the ADDITIONAL change the App-db diff renders.
 
 ;; -- MAPS --------------------------------------------------------------------
 
@@ -222,12 +220,11 @@
       (assoc db :queue [:task-1 :task-2 :task-3]))))
 
 (rf/reg-event-db :edn-inspector/seq-scattered-removed
-  {:doc "Sequential: SCATTERED / MID-VECTOR removal (rf2-vu42n). Thin :lane
+  {:doc "Sequential: SCATTERED / MID-VECTOR removal. Thin :lane
          `[:a :b :c :d]` → `[:a :c]` — drop :b@1 AND :d@3. The genuinely-
          removed :b and :d render struck IN PLACE; the surviving-shifted :c
          (was index 2 → now 1) must NOT be struck and carries a `(was N)`
-         suffix. Pre-fix the index-aligning renderer struck :c and dropped
-         :b. Toggles back to the full lane so the diff alternates."}
+         suffix. Toggles back to the full lane so the diff alternates."}
   (fn [db _]
     (if (= (:lane db) [:a :b :c :d])
       (assoc db :lane [:a :c])
@@ -256,26 +253,25 @@
 (rf/reg-event-db :edn-inspector/empty-vector
   {:doc "Empty a VECTOR, key intact. `:one-vec [:only]` → `[]` — the element
          removal renders member-level inside the intact (now-empty) vector,
-         NOT a whole-key `~` modify (rf2-yucxn BUG A). Re-seeds when empty."}
+         NOT a whole-key `~` modify. Re-seeds when empty."}
   (fn [db _]
     (assoc db :one-vec (if (seq (:one-vec db)) [] [:only]))))
 
 (rf/reg-event-db :edn-inspector/empty-list
   {:doc "Empty a LIST, key intact. `:one-list (:only)` → `()` — member-level
-         removal inside the intact list (rf2-yucxn BUG A). Re-seeds."}
+         removal inside the intact list. Re-seeds."}
   (fn [db _]
     (assoc db :one-list (if (seq (:one-list db)) '() '(:only)))))
 
 (rf/reg-event-db :edn-inspector/empty-set
   {:doc "Empty a SET, key intact. `:one-set #{:only}` → `#{}` — member-level
-         removal inside the intact set (l0us2 empty-edge expansion). Re-seeds."}
+         removal inside the intact set. Re-seeds."}
   (fn [db _]
     (assoc db :one-set (if (seq (:one-set db)) #{} #{:only}))))
 
 (rf/reg-event-db :edn-inspector/empty-map
   {:doc "Empty a MAP, key intact. `:one-map {:k 1}` → `{}` — member-level
-         removal inside the intact map (rf2-9d4j8 empty-map expansion).
-         Re-seeds."}
+         removal inside the intact map. Re-seeds."}
   (fn [db _]
     (assoc db :one-map (if (seq (:one-map db)) {} {:k 1}))))
 
@@ -334,7 +330,7 @@
 (rf/reg-event-db :edn-inspector/set-multi-adjust
   {:doc "Set: MULTI-MEMBER swap in ONE diff. Swap :labels `#{:x :y :z}` ↔
          `#{:x :p :q}` — `:y :z` removed AND `:p :q` added, `:x` kept,
-         member-level, key intact (rf2-4vp8c)."}
+         member-level, key intact."}
   (fn [db _]
     (-> db
         (update :labels
@@ -352,7 +348,7 @@
   {:doc "Mixed: a SET swap through map→map→vector→set at
          `[:mixed :a :b 0]`. Diffs member-level at the set; no ancestor
          (map or vector) is falsely promoted to a whole-key replace
-         (the l0us2 ancestor-non-promotion property across kinds). Cycles."}
+         (the ancestor-non-promotion property across kinds). Cycles."}
   (fn [db _]
     (-> db
         (update-in [:mixed :a :b 0]
@@ -429,7 +425,7 @@
 ;; `:step = n` (the per-step delta the panels show) and dispatches the
 ;; step's `:event` into the host-frame. The matrix walks SIMPLE → COMPLEX.
 ;; These are synchronous db-only transitions — no async cascade, so manual
-;; stepping needs no pacing (rf2-5sjbg dropped the settle machinery).
+;; stepping needs no pacing.
 
 (def steps
   [;; -- MAPS --
@@ -460,16 +456,16 @@
    ;; -- EMPTY vs REMOVAL (the subtle one) --
    {:label "Empty a VECTOR (key intact)"
     :event [:edn-inspector/empty-vector]
-    :watch ":one-vec [:only] → []: the element removal renders member-level inside the intact (now-empty) vector, NOT a whole-key `~` modify (rf2-yucxn BUG A)."}
+    :watch ":one-vec [:only] → []: the element removal renders member-level inside the intact (now-empty) vector, NOT a whole-key `~` modify."}
    {:label "Empty a LIST (key intact)"
     :event [:edn-inspector/empty-list]
     :watch ":one-list (:only) → (): member-level removal inside the intact list — the key stays, the bracket pair goes empty."}
    {:label "Empty a SET (key intact)"
     :event [:edn-inspector/empty-set]
-    :watch ":one-set #{:only} → #{}: member-level removal inside the intact set (l0us2 empty-edge expansion)."}
+    :watch ":one-set #{:only} → #{}: member-level removal inside the intact set."}
    {:label "Empty a MAP (key intact)"
     :event [:edn-inspector/empty-map]
-    :watch ":one-map {:k 1} → {}: member-level removal inside the intact map (rf2-9d4j8 empty-map expansion)."}
+    :watch ":one-map {:k 1} → {}: member-level removal inside the intact map."}
    {:label "Remove a KEY (wholesale)"
     :event [:edn-inspector/remove-key]
     :watch "dissoc :doomed: a struck-through removed KEY (collapsed removed-ghost) — read it AGAINST the empty-collection steps above; they must look DISTINCT."}
@@ -494,7 +490,7 @@
     :watch ":slots [1 2 3] ↔ [1 9 3 4]: index 1 modified (`~`@1: 2→9) AND index 3 appended (`+`@3) in ONE diff."}
    {:label "Set: multi-member swap"
     :event [:edn-inspector/set-multi-adjust]
-    :watch ":labels #{:x :y :z} ↔ #{:x :p :q}: `−:y −:z +:p +:q` member-level, key intact (rf2-4vp8c)."}
+    :watch ":labels #{:x :y :z} ↔ #{:x :p :q}: `−:y −:z +:p +:q` member-level, key intact."}
 
    ;; -- DEEP / MIXED --
    {:label "Deep scalar change"
@@ -502,7 +498,7 @@
     :watch "[:deep :a :b :c :d] bumped FIVE levels deep: every ancestor reads `:children` (◴ + rail); none promotes to a whole-key replace."}
    {:label "Mixed-kind deep swap"
     :event [:edn-inspector/mixed-deep-change]
-    :watch "Set swap at [:mixed :a :b 0] through map→map→vector→set: diffs member-level at the set; no ancestor (map or vector) is falsely promoted (l0us2 across kinds)."}
+    :watch "Set swap at [:mixed :a :b 0] through map→map→vector→set: diffs member-level at the set; no ancestor (map or vector) is falsely promoted."}
 
    ;; -- SENTINELS --
    {:label "Sensitive → :rf/redacted"
@@ -524,7 +520,7 @@
     :watch "A vector of every scalar kind + #uuid + #inst at [:cache :scalar-mix]: every syntax-palette token + the default formatters' compact headers."}])
 
 ;; ============================================================================
-;; RUNNER WIRING (rf2-5sjbg) — register the deck's run-step event
+;; RUNNER WIRING — register the deck's run-step event
 ;; ============================================================================
 
 (runner/reg-runner! {:id         :edn-inspector/run-step
@@ -559,8 +555,8 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-;; rf2-5dphw — open-in-editor project-root is derived from the build
-;; environment, not a hardcoded personal path (mirrors standard_epochs).
+;; The open-in-editor project-root is derived from the build environment,
+;; not a hardcoded personal path (mirrors standard_epochs).
 (defn- resolve-project-root []
   (testbed-config/resolve-project-root "tools/xray/testbeds"))
 

--- a/tools/xray/testbeds/routes_epochs/core.cljs
+++ b/tools/xray/testbeds/routes_epochs/core.cljs
@@ -1,10 +1,10 @@
 (ns routes-epochs.core
-  "ROUTES-EPOCHS testbed (rf2-5crg4 → rf2-3xakq) — the ROUTING sibling of the
-  `standard_epochs` deck, converted to the shared queued-step RUNNER
-  (`runner.core`, the rf2-8pbjr pilot). A deliberately simple Xray driving
-  surface aimed squarely at the **Routing panel** (`rf-xray-routing`).
+  "ROUTES-EPOCHS testbed — the ROUTING sibling of the `standard_epochs`
+  deck, on the shared queued-step RUNNER (`runner.core`). A deliberately
+  simple Xray driving surface aimed squarely at the **Routing panel**
+  (`rf-xray-routing`).
 
-  ## Shape (rf2-3xakq — adopt the shared queued-step RUNNER)
+  ## Shape — the shared queued-step RUNNER
 
   ONE purple Step button (`routes-epochs-step`) walks the routing ladder
   top to bottom while the operator watches how Xray's Routing panel renders
@@ -18,13 +18,10 @@
         show (the runner sets `:step = n`), and
     (b) exercises exactly ONE additional ROUTING feature via a child dispatch.
 
-  Replaces the bespoke numbered-button ladder (`routes-epochs-rung-<n>`):
-  same events, same routing features, same coverage — but driven by the
-  shared runner. The runner's per-step RUN-THIS-STEP affordance (rf2-kipb5)
-  is exactly the RANDOM-ACCESS addressing the feature-matrix scenario needs
-  — it drives rungs OUT OF ORDER (#3, #1, #4, #5, #7, #10, #11), asserting
-  the Routing panel after each, which the runner's sequential cursor alone
-  could not provide.
+  The runner's per-step RUN-THIS-STEP affordance is the RANDOM-ACCESS
+  addressing the feature-matrix scenario needs — it drives rungs OUT OF
+  ORDER (#3, #1, #4, #5, #7, #10, #11), asserting the Routing panel after
+  each, which the runner's sequential cursor alone could not provide.
 
   Progressive: step 1 is a plain `navigate`; each later step layers one
   more routing concept on top. A SINGLE frame, plainly mounted, with the
@@ -72,13 +69,13 @@
     #11 guarded/blocked nav — a `:can-leave` guard refuses; outcome
                              `blocked` + `:rf/pending-navigation` is set.
 
-  ## Runner cursor = app-db `:step` (rf2-5sjbg)
+  ## Runner cursor = app-db `:step`
 
   The runner cursor lives in app-db's `:step` slot, written by
   `runner.core`'s run-step event. `:step` churning every step IS the
-  per-step App-db / Epoch delta the panels show (it REPLACES the old
-  `:baseline` counter — same thing). The deck reads as an ordinary
-  re-frame2 app: app-db + events + subs, NO Reagent atom for step state.
+  per-step App-db / Epoch delta the panels show. The deck reads as an
+  ordinary re-frame2 app: app-db + events + subs, NO Reagent atom for step
+  state.
 
   ## Test surface, not tutorial
 
@@ -109,18 +106,18 @@
             ;; lens 'open' chip resolves a classpath-relative `:file` to
             ;; an absolute on-disk URI.
             [day8.re-frame2-xray.config :as xray-config]
-            ;; Shared testbed-config helper (rf2-5dphw): derives the
-            ;; open-in-editor project-root from the build env.
+            ;; Shared testbed-config helper: derives the open-in-editor
+            ;; project-root from the build env.
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared step-driver runner (rf2-5sjbg). This deck supplies
-            ;; a `steps` vector + registers `:routes-epochs/run-step` via
+            ;; The shared step-driver runner. This deck supplies a `steps`
+            ;; vector + registers `:routes-epochs/run-step` via
             ;; `runner/reg-runner!`; the runner drives the ONE-button series
             ;; + the per-step RUN buttons off app-db `:step`.
             [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
-;; The inspected app frame (rf2-8pbjr — only the app frame is Xray-relevant)
+;; The inspected app frame — only the app frame is Xray-relevant.
 ;; ============================================================================
 
 (def host-frame :rf/default)
@@ -203,12 +200,12 @@
 ;; APP-DB SEED
 ;; ============================================================================
 ;;
-;; `:step` is the runner cursor (rf2-5sjbg) — the index of the last-run
-;; step, written by `runner.core`'s run-step event; its churn every step IS
-;; the per-step App-db / Epoch delta (it REPLACES the old `:baseline`
-;; counter). `:articles` feeds the params / nested-route targets.
-;; `:profile` is the slot the route-driven loader (step #8) fills from the
-;; route params. `:settings-dirty?` arms the `:can-leave` guard (step #11).
+;; `:step` is the runner cursor — the index of the last-run step, written
+;; by `runner.core`'s run-step event; its churn every step IS the per-step
+;; App-db / Epoch delta. `:articles` feeds the params / nested-route
+;; targets. `:profile` is the slot the route-driven loader (step #8) fills
+;; from the route params. `:settings-dirty?` arms the `:can-leave` guard
+;; (step #11).
 
 (def initial-db
   {:step            nil
@@ -270,8 +267,8 @@
 ;; settings?`. The guard returns `false` (block) while `:settings-dirty?`
 ;; is set — so a navigation AWAY from settings is refused, the runtime
 ;; writes `:rf/pending-navigation`, and the Routing panel's NAVIGATION
-;; THIS EPOCH outcome reads `blocked`. The contract is closed (rf2-5pyyl):
-;; only literal `true` / `false` are accepted, hence `(boolean ...)`.
+;; THIS EPOCH outcome reads `blocked`. The guard contract accepts only
+;; literal `true` / `false`, hence `(boolean ...)`.
 
 (rf/reg-sub :routes-epochs/can-leave-settings?
   (fn [db _] (boolean (not (:settings-dirty? db)))))
@@ -329,13 +326,12 @@
 ;; step's `:event` into the host-frame. Navigation cascades through
 ;; `:routes-epochs/go` (→ :rf.route/navigate); the redirect step (#6) fires a
 ;; SECOND navigation cascade via its route's `:on-match`. Manual stepping
-;; needs no pacing — each cascade fires + renders while the operator watches
-;; (rf2-5sjbg dropped the settle machinery).
+;; needs no pacing — each cascade fires + renders while the operator watches.
 ;;
-;; The ladder order matches the historical numbered rungs 1..11 (1-based):
-;; step index 0 = rung #1, step index N-1 = rung #N. The feature-matrix
-;; scenario keeps the 1-based rung vocabulary and drives the runner's
-;; per-step RUN button at index (rung - 1).
+;; The 0-based step index maps to the 1-based rung vocabulary the
+;; feature-matrix scenario uses: step index 0 = rung #1, step index N-1 =
+;; rung #N. The scenario drives the runner's per-step RUN button at index
+;; (rung - 1).
 
 (def steps
   [;; -- Navigation basics — CURRENT ROUTE + NAVIGATION THIS EPOCH --
@@ -382,7 +378,7 @@
     :watch "Attempt → home FROM dirty settings · the guard refuses · CURRENT ROUTE STAYS :settings · outcome blocked · :rf/pending-navigation fills."}])
 
 ;; ============================================================================
-;; RUNNER WIRING (rf2-5sjbg) — register the deck's run-step event
+;; RUNNER WIRING — register the deck's run-step event
 ;; ============================================================================
 
 (runner/reg-runner! {:id         :routes-epochs/run-step
@@ -457,11 +453,11 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-;; rf2-5dphw — open-in-editor project-root is derived from the build
-;; environment, not a hardcoded personal path. `re-frame.testbed.config`
-;; joins the build-time repo-root goog-define with this testbed's
-;; tool-relative subdir; `?project-root=<path>` still overrides per
-;; session. See that ns for the cross-platform mechanism.
+;; The open-in-editor project-root is derived from the build environment,
+;; not a hardcoded personal path. `re-frame.testbed.config` joins the
+;; build-time repo-root goog-define with this testbed's tool-relative
+;; subdir; `?project-root=<path>` still overrides per session. See that ns
+;; for the cross-platform mechanism.
 (defn- resolve-project-root []
   (testbed-config/resolve-project-root "tools/xray/testbeds"))
 

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -1,17 +1,16 @@
 (ns standard-epochs.core
-  "STANDARD-EPOCHS testbed (rf2-gsr6z, runner-shaped rf2-3xakq) — a
-  deliberately simple Xray driving surface that supersedes the step-deck.
+  "STANDARD-EPOCHS testbed — a deliberately simple Xray driving surface.
 
-  ## Shape (rf2-3xakq — adopt the shared queued-step RUNNER)
+  ## Shape — the shared queued-step RUNNER
 
   ONE purple Step button (`<prefix>-step`) walks a step ladder top to
   bottom while the operator watches how Xray's panels render each step;
   EVERY step row's index is ALSO a RANDOM-ACCESS RUN-THIS-STEP button
   (`<prefix>-step-<n>-run`, n = 0-based step index) so any step can be
-  driven directly. The runner (`runner.core`, the rf2-8pbjr pilot) is the
-  shared harness; this deck supplies the `steps` vector (CODE DATA) and is
-  mounted with a runner atom + a host-frame + a testid prefix. Each step
-  DISPATCHES one event that
+  driven directly. The runner (`runner.core`) is the shared harness; this
+  deck supplies the `steps` vector (CODE DATA) and is mounted with a
+  host-frame + a testid prefix (the cursor lives in app-db's `:step`, not
+  a passed atom). Each step DISPATCHES one event that
 
     (a) lands on the run-step epoch as the `:step` app-db delta the panels
         show (the runner sets `:step = n`), and
@@ -21,12 +20,12 @@
   There are NO tabs, NO routing/URL machinery, NO machines, NO SSR. Read
   each step's `:watch` note; Xray itself is the check.
 
-  ## Parameterised root (rf2-3xakq → rf2-5sjbg — the two-frame mount)
+  ## Parameterised root — the two-frame mount
 
-  `root` is a PURE ladder taking `[host-frame prefix]` — just the runner +
-  the two children + the diamond probe, NO header, NO reset button
-  (rf2-7prmj), NO runner atom (rf2-5sjbg: the runner cursor lives in
-  app-db's `:step`, not a passed atom). The single-frame deck (`run`) mounts
+  `root` is a PURE ladder taking `[host-frame prefix run-step-event]` —
+  just the runner + the two children + the diamond probe, NO header, NO
+  reset button, NO runner atom (the runner cursor lives in app-db's
+  `:step`, not a passed atom). The single-frame deck (`run`) mounts
   the `standalone` wrapper, which renders the deck's title + intro header
   ABOVE `[root :rf/default \"standard-epochs\"]` on the plain default frame,
   Xray auto-mounting inline. The TWO-FRAME isolation testbed
@@ -50,11 +49,10 @@
               dispatched child event); #2 adds a coeffect to the event
               detail, #4 a one-shot fx, #5 a cascade dispatch-id tree.
     App-db  — the `:step` cursor churns every step · #5 flow writes a
-              derived slot. (The rich
-              App-db DIFF shapes — added / removed-to-empty / changed
-              (diff-mode-3) — plus the large-collection / edn-inspector
-              cases live in the sibling `edn_inspector` deck, which drives
-              them through the App-db panel — rf2-74u2s → rf2-1niob.)
+              derived slot. (The rich App-db DIFF shapes — added /
+              removed-to-empty / changed — plus the large-collection /
+              edn-inspector cases live in the sibling `edn_inspector` deck,
+              which drives them through the App-db panel.)
     Views   — two children make re-render CAUSES separable. Child A is
               SUBSCRIPTION-driven (an own L1→L2→L3 chain + the arg-keyed
               `[:standard-epochs/greater-than? N]` sub); Child B is
@@ -79,7 +77,7 @@
               app-db schema violation (survives rollback).
     Reactive— #20 diamond probe (c ← a,b ← root): the join sub's recompute
               count surfaces whether the substrate double-computes an
-              intermediate sub per single root change (rf2-kt5nx).
+              intermediate sub per single root change.
 
   ## Test surface, not tutorial
 
@@ -113,11 +111,11 @@
             ;; lens 'open' chip resolves a classpath-relative `:file` to
             ;; an absolute on-disk URI.
             [day8.re-frame2-xray.config :as xray-config]
-            ;; Shared testbed-config helper (rf2-5dphw): derives the
-            ;; open-in-editor project-root from the build env.
+            ;; Shared testbed-config helper: derives the open-in-editor
+            ;; project-root from the build env.
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared step-driver runner (rf2-5sjbg). This deck supplies
-            ;; a `steps` vector + registers `:standard-epochs/run-step` via
+            ;; The shared step-driver runner. This deck supplies a `steps`
+            ;; vector + registers `:standard-epochs/run-step` via
             ;; `runner/reg-runner!`; the runner drives the ONE-button series
             ;; + the per-step RUN buttons off app-db `:step`. The two-frame
             ;; testbed reuses `root` + `steps` with its own per-frame
@@ -129,11 +127,10 @@
 ;; APP-DB SEED
 ;; ============================================================================
 ;;
-;; One flat, named seed. `:step` is the runner cursor (rf2-5sjbg) — the
-;; index of the last-run step, written by `runner.core`'s run-step event.
-;; It REPLACES the old `:baseline` counter: `:step` churning every step IS
-;; the per-step App-db / Epoch delta the panels show. `:base` feeds button
-;; #5's flow only.
+;; One flat, named seed. `:step` is the runner cursor — the index of the
+;; last-run step, written by `runner.core`'s run-step event. `:step`
+;; churning every step IS the per-step App-db / Epoch delta the panels
+;; show. `:base` feeds button #5's flow only.
 ;;
 ;; `:views` holds the Views/subscriptions section's OWN state — kept on
 ;; its own slots, so the section's mount/unmount/sub behaviour is exercised
@@ -162,8 +159,8 @@
 (rf/reg-event-db :standard-epochs/reset
   {:doc "Seed event — re-seed app-db and unmount both child views. Used by
          `run` (dispatch-sync on load) and by two_frame_isolation's per-frame
-         :on-create. There is no on-page reset button (rf2-7prmj); a reload
-         re-seeds. The runner cursor `:step` re-seeds to nil here."}
+         :on-create. There is no on-page reset button; a reload re-seeds.
+         The runner cursor `:step` re-seeds to nil here."}
   (fn handler-reset [_db _ev]
     initial-db))
 
@@ -226,9 +223,8 @@
 ;; throws on the way back out of the chain (button #14). The foil to the
 ;; :before interceptor above: the failing step is the interceptor's :after,
 ;; not the handler, so the per-step placement renders the exception under
-;; the interceptor's :after step (rf2-yz57h) and the framework attributes
-;; it to the interceptor rather than collapsing it into a handler
-;; exception (rf2-mszrz).
+;; the interceptor's :after step and the framework attributes it to the
+;; interceptor rather than collapsing it into a handler exception.
 (def throwing-interceptor-after
   (rf/->interceptor
     :id    :standard-epochs/throwing-interceptor-after
@@ -505,8 +501,17 @@
   (fn [root [_ threshold]] (> root threshold)))
 
 ;; ============================================================================
-;; DIAMOND — redundant-recompute probe (rf2-kt5nx)
+;; DIAMOND — redundant-recompute probe
 ;; ============================================================================
+;;
+;; MEASUREMENT INSTRUMENT — DO NOT COPY THIS PATTERN. The `:diamond-c` sub
+;; below deliberately side-effects in its compute fn (`swap!` a counter) to
+;; MEASURE how many times the substrate runs it. That is the one and only
+;; reason a sub here breaks subs-must-be-pure: the raw reaction-run count is
+;; precisely the thing under observation. It is a diagnostic probe, NOT app
+;; code, and NOT a pattern to lift into a real subscription. The safety is
+;; structural: `diamond-c-runs` is a plain atom (NOT a ratom) and is NOT an
+;; input to any sub, so the `swap!` cannot feed back into the reactive graph.
 ;;
 ;; A classic reactive DIAMOND:
 ;;
@@ -516,17 +521,12 @@
 ;;          \        /
 ;;        :diamond-c             (the JOINING sub :<- a,b)
 ;;
-;; Button #20 bumps the root ONCE. The join sub `:diamond-c` increments a
+;; Button #20 bumps the root ONCE. The join sub `:diamond-c` increments the
 ;; counter each time its compute fn RUNS. Press once: the counter should rise
 ;; by exactly 1; a rise of 2 means the substrate recomputes the intermediate
 ;; join sub TWICE per single root change (the push-based diamond redundant-
 ;; recompute). The count is shown by the `diamond-display` view below and is
 ;; cross-checkable against Xray's Reactive / Trace lens.
-;;
-;; Side-effecting in a sub compute fn is deliberate HERE — this is a
-;; diagnostic instrument, not app code, and the raw reaction-run count is the
-;; thing we want to observe. `diamond-c-runs` is a plain atom (not a ratom)
-;; and is NOT an input to any sub, so the swap! cannot feed back into the graph.
 
 (defonce diamond-c-runs (atom 0))
 
@@ -630,10 +630,9 @@
 ;; RUN button) dispatches `[:standard-epochs/run-step n]`, which sets app-db
 ;; `:step = n` (the per-step delta the panels show) and dispatches the step's
 ;; `:event` into the host-frame. The ladder walks Events →
-;; Views/subscriptions → Errors/Issues → Reactive (the historical button
-;; order 1..20 preserved). Manual stepping needs no pacing — each async step
-;; (cascade, mount/unmount, slow fx) fires + renders on its own schedule
-;; while the operator watches (rf2-5sjbg dropped the settle machinery).
+;; Views/subscriptions → Errors/Issues → Reactive (steps 1..20). Manual
+;; stepping needs no pacing — each async step (cascade, mount/unmount,
+;; slow fx) fires + renders on its own schedule while the operator watches.
 
 (def steps
   [;; -- Events — Epoch / Trace / App-db scalar --
@@ -705,7 +704,7 @@
     :watch "Diamond c ← a,b ← root: bump the root once; c's recompute count should rise by 1 (clean), 2 = double-compute."}])
 
 ;; ============================================================================
-;; THE HOST FRAME + THE RUNNER WIRING (rf2-5sjbg)
+;; THE HOST FRAME + THE RUNNER WIRING
 ;; ============================================================================
 ;;
 ;; `host-frame` is the inspected app frame the runner drives. The standalone
@@ -724,13 +723,13 @@
 ;; ROOT — pure ladder, parameterised over (host-frame, prefix, run-step-event)
 ;; ============================================================================
 ;;
-;; rf2-3xakq → rf2-5sjbg — `root` takes the host-frame + testid prefix + the
-;; deck's run-step event id so the deck is mountable BOTH on its own single
-;; (`:rf/default`) frame (via the `standalone` wrapper below) AND twice (once
-;; per `:above` / `:below` frame) by the two-frame isolation testbed. rf2-7prmj
-;; — `root` is a PURE ladder (runner + children + diamond): the title + intro
-;; header live in the standalone `run` path only, and there is no deck-reset
-;; button, so the two-frame cards stay clean per-frame ladders. The
+;; `root` takes the host-frame + testid prefix + the deck's run-step event
+;; id so the deck is mountable BOTH on its own single (`:rf/default`) frame
+;; (via the `standalone` wrapper below) AND twice (once per `:above` /
+;; `:below` frame) by the two-frame isolation testbed. `root` is a PURE
+;; ladder (runner + children + diamond): the title + intro header live in
+;; the standalone `run` path only, and there is no deck-reset button, so the
+;; two-frame cards stay clean per-frame ladders. The
 ;; reg-view-injected `subscribe` closes over the surrounding frame-provider's
 ;; frame id, so the same source drives an isolated reactive context (and an
 ;; isolated per-frame `:step`) per mount; the runner dispatches the run-step
@@ -767,11 +766,11 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-;; rf2-5dphw — open-in-editor project-root is derived from the build
-;; environment, not a hardcoded personal path. `re-frame.testbed.config`
-;; joins the build-time repo-root goog-define with this testbed's
-;; tool-relative subdir; `?project-root=<path>` still overrides per
-;; session. See that ns for the cross-platform mechanism.
+;; The open-in-editor project-root is derived from the build environment,
+;; not a hardcoded personal path. `re-frame.testbed.config` joins the
+;; build-time repo-root goog-define with this testbed's tool-relative
+;; subdir; `?project-root=<path>` still overrides per session. See that ns
+;; for the cross-platform mechanism.
 (defn- resolve-project-root []
   (testbed-config/resolve-project-root "tools/xray/testbeds"))
 
@@ -779,9 +778,9 @@
 ;; STANDALONE WRAPPER — header (title + intro) above the shared `root`
 ;; ============================================================================
 ;;
-;; rf2-7prmj — the title + intro live HERE, not in the shared `root`, because
-;; `root` is mounted TWICE by `two_frame_isolation` (once per :above / :below
-;; frame). Extracting the header keeps the shared `root` a pure ladder, so the
+;; The title + intro live HERE, not in the shared `root`, because `root` is
+;; mounted TWICE by `two_frame_isolation` (once per :above / :below frame).
+;; Extracting the header keeps the shared `root` a pure ladder, so the
 ;; two-frame cards stay clean (no per-frame title duplication) while the
 ;; standalone deck still shows the Epochs header. There is no deck-reset
 ;; button: reloading re-seeds via `run` (the frames re-seed via :on-create),

--- a/tools/xray/testbeds/two_frame_isolation/core.cljs
+++ b/tools/xray/testbeds/two_frame_isolation/core.cljs
@@ -1,6 +1,6 @@
 (ns two-frame-isolation.core
-  "Two-frame isolation testbed (rf2-6qgbs.1, repointed under rf2-wa8my) —
-  THE canonical multi-frame isolation surface for Xray.
+  "Two-frame isolation testbed — THE canonical multi-frame isolation
+  surface for Xray.
 
   ## Shape
 
@@ -27,15 +27,11 @@
 
   ## Why standard-epochs ×2
 
-  The earlier shape mounted the (now-deleted) shared `testdeck.*`
-  tabs-as-routes panel. That coupled this testbed to a bespoke
-  multi-module app whose tabs-as-routes machinery doubled as a manual
-  multi-frame ROUTING demo. The routing surface now has its own home
-  (`routes_epochs`, the gate's Routing-panel deck); the multi-frame
-  isolation gate assertion lives on the framework `testbeds/multi_frame`
-  surface. This testbed's single job is therefore the cleanest possible
-  per-frame ISOLATION proof: mount the SAME deck twice and watch the two
-  reactive contexts stay independent.
+  This testbed's single job is the cleanest possible per-frame ISOLATION
+  proof: mount the SAME deck twice and watch the two reactive contexts stay
+  independent. The routing surface has its own home (`routes_epochs`, the
+  gate's Routing-panel deck); the multi-frame isolation gate assertion lives
+  on the framework `testbeds/multi_frame` surface.
 
   `standard-epochs.core` registers every event / sub / view / cofx / fx /
   flow / schema ONCE globally at namespace load (requiring it below is
@@ -45,11 +41,11 @@
   reuse only its registrations + its `root` Var, and supply our own
   two-frame harness + mount here.
 
-  ## Per-frame run-step events (rf2-3xakq → rf2-5sjbg — isolation-preserving)
+  ## Per-frame run-step events — isolation-preserving
 
   `standard-epochs.core/root` is the shared step-driver runner
   (`runner.core`), parameterised over `[host-frame prefix run-step-event]`.
-  The runner's cursor now lives in app-db's `:step` slot — and per-frame
+  The runner's cursor lives in app-db's `:step` slot — and per-frame
   app-db gives EACH frame mount its OWN `:step`, so the two cursors are
   isolated by construction. This testbed registers a DISTINCT run-step event
   per frame (each closing over its frame's host-frame so the step's child
@@ -63,7 +59,7 @@
   frame — no shared cursor, correct per-frame isolation. Pressing Step (or a
   RUN-THIS-STEP button) in `:above` moves ONLY `:above`'s app-db (including
   its `:step`) / sub-cache / epoch history. There is NO Reagent atom for step
-  state anywhere (rf2-5sjbg).
+  state anywhere.
 
   ## What this proves — per-frame isolation
 
@@ -110,18 +106,18 @@
             ;; event (that targets `:rf/default`).
             [standard-epochs.core :as se]
             [re-frame.adapter.reagent :as reagent-adapter]
-            ;; rf2-6jyf6 — Xray's `configure!` to seed `:project-root`
-            ;; so the Event lens 'open' chip resolves a classpath-relative
-            ;; `:file` slot to an absolute on-disk URI.
+            ;; Xray's `configure!` to seed `:project-root` so the Event
+            ;; lens 'open' chip resolves a classpath-relative `:file` slot
+            ;; to an absolute on-disk URI.
             [day8.re-frame2-xray.config :as xray-config]
-            ;; Shared testbed-config helper (rf2-5dphw): derives the
-            ;; open-in-editor project-root from the build env.
+            ;; Shared testbed-config helper: derives the open-in-editor
+            ;; project-root from the build env.
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared step-driver runner (rf2-5sjbg). We register a
-            ;; DISTINCT run-step event per frame (each targeting that
-            ;; frame's host-frame) so each mount's Step button drives ONLY
-            ;; its own frame — the isolation proof. The cursor itself lives
-            ;; in each frame's app-db `:step`.
+            ;; The shared step-driver runner. We register a DISTINCT
+            ;; run-step event per frame (each targeting that frame's
+            ;; host-frame) so each mount's Step button drives ONLY its own
+            ;; frame — the isolation proof. The cursor itself lives in each
+            ;; frame's app-db `:step`.
             [runner.core :as runner])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -133,7 +129,7 @@
 (def frame-below :below)
 
 ;; ============================================================================
-;; PER-FRAME RUN-STEP EVENTS (rf2-5sjbg — distinct driver per mount)
+;; PER-FRAME RUN-STEP EVENTS — distinct driver per mount
 ;; ============================================================================
 ;;
 ;; The standard-epochs `root` is the step-driver runner; the cursor lives in
@@ -214,11 +210,11 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-;; rf2-5dphw — open-in-editor project-root derived from the build
-;; environment (the build-time `re-frame.testbed.config/repo-root`
-;; goog-define joined with this testbed's tool-relative subdir), not a
-;; hardcoded personal path. `?project-root=<path>` still overrides per
-;; session. See `re-frame.testbed.config` for the cross-platform mechanism.
+;; The open-in-editor project-root is derived from the build environment
+;; (the build-time `re-frame.testbed.config/repo-root` goog-define joined
+;; with this testbed's tool-relative subdir), not a hardcoded personal
+;; path. `?project-root=<path>` still overrides per session. See
+;; `re-frame.testbed.config` for the cross-platform mechanism.
 (defn- resolve-project-root []
   (testbed-config/resolve-project-root "tools/xray/testbeds"))
 


### PR DESCRIPTION
## Summary

Doc-and-comment hygiene for the four Xray testbed decks that lacked a separate code bead: `standard_epochs`, `routes_epochs`, `edn_inspector`, `two_frame_isolation`. **Doc/comment only — zero code changes** (verified: no `(defn`/`(reg`/`(def` lines in the diff).

Per **rf2-v9fxc**:

- **ITEM 1 (CLARITY)** — Trimmed backward-looking bead-id migration narration and before-state comparisons from the deck headers + in-body comments, keeping the forward-looking coverage maps and what-to-look-for notes. Dropped the "earlier shape mounted the now-deleted `testdeck.*`" archaeology in `two_frame_isolation` and the "historical button order / numbered rungs" framing, while keeping the load-bearing 0-based-index ↔ 1-based-rung mapping the feature-matrix scenario relies on. The project-wide test-free-lock ruling id (`rf2-8cevm`) is retained as a normative policy citation.

- **ITEM 2 (CORRECTNESS)** — Fixed stale claims:
  - `edn_inspector` header claimed the runner *auto-advances* and *pins Xray focus to the latest epoch after each dispatch*. Verified against `runner.core`: the runner is **manual-step only** (no timer, no auto-advance, no settle machinery) and does **not** pin focus. Corrected to the manual-step reality, matching the other decks.
  - `standard_epochs` header carried a stale "mounted with a runner atom" claim; the cursor lives in app-db `:step`, no atom.

- **ITEM 3 (GOOD-PRACTICE)** — The `standard_epochs` `:diamond-c` recompute probe deliberately side-effects in its sub compute fn to count redundant recomputes. The comment now **leads** with a clear `MEASUREMENT INSTRUMENT — DO NOT COPY THIS PATTERN` note so a reader scanning for anti-patterns sees the sanctioned-diagnostic framing first. No code change — the probe is correct and structurally safe (plain atom, not a sub input).

## Stale claims verified before editing

| Claim | Said | Now |
| --- | --- | --- |
| edn_inspector runner advances | "After each auto-advance dispatch the runner pins Xray focus to the latest epoch" | "manual-step only … no auto-advance and no timer … does NOT pin Xray focus" |
| standard_epochs mount | "mounted with a runner atom + a host-frame + a testid prefix" | "mounted with a host-frame + a testid prefix (the cursor lives in app-db's `:step`, not a passed atom)" |

## Scope note

`tools/xray/spec/*` unchanged — these are testbed surfaces, not an Xray feature contract.

## Test plan

- `npm run test:xray-feature-gate` — **green** (cold): 16 scenarios, 0 failures, 13 matrix rows; all four touched testbeds compile with 0 warnings.
- `npm run test:xray-feature-gate:smoke` — exit 0.
- No `spec.cjs` in these testbeds (test-free policy), so no smoke to re-run.

Closes rf2-v9fxc.
