### PR TITLE
fix(flows): prune empty frame-id husk on clearing last flow (rf2-4bbaw)

### DIFF
--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -523,7 +523,18 @@
              ;; absent slot, common during teardown).
              (when-not (identical? new-db db)
                (adapter/replace-container! container new-db))))
-         (swap! flows update frame-id dissoc id)
+         ;; Drop the flow from `frame-id`'s per-frame slot; when that was
+         ;; the LAST flow on the frame, prune the now-empty `frame-id` key
+         ;; entirely rather than leave a `{frame-id {}}` husk (rf2-4bbaw).
+         ;; The husk was harmless (bounded by frame count, tolerated by the
+         ;; concurrency-stress invariant) but a naive `flows-snapshot`
+         ;; consumer would iterate the empty entry; pruning keeps the
+         ;; registry exactly symmetric with `teardown-on-frame-destroy!`'s
+         ;; `(swap! flows dissoc frame-id)`.
+         (swap! flows (fn [m]
+                        (let [m' (update m frame-id dissoc id)]
+                          (cond-> m'
+                            (empty? (get m' frame-id)) (dissoc frame-id)))))
          ;; Drop the cleared flow's dirty-check row from THIS frame's own
          ;; `last-inputs` container (rf2-94ol5). Frame-local — a sibling
          ;; frame registering the same id keeps its own row untouched.

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -326,18 +326,23 @@
 
         ;; --- Invariant 4: clean registry — no leak. After every
         ;;     thread cleared its flow, the per-frame registry must
-        ;;     be empty for every test frame, the `last-inputs` map
-        ;;     must hold no entries for any per-thread flow id, and
-        ;;     the global `:flow` registrar slot must be gone for
-        ;;     every per-thread flow id (the LAST frame holding it
-        ;;     released the id per Spec 013 §Frame-scoping).
+        ;;     have the frame-id key fully PRUNED for every test frame,
+        ;;     the `last-inputs` map must hold no entries for any
+        ;;     per-thread flow id, and the global `:flow` registrar slot
+        ;;     must be gone for every per-thread flow id (the LAST frame
+        ;;     holding it released the id per Spec 013 §Frame-scoping).
+        ;;
+        ;; rf2-4bbaw: each per-thread frame had ALL its flows cleared, so
+        ;; clearing the last one prunes the frame-id key entirely — the
+        ;; slot is strictly `nil`, never a `{frame-id {}}` empty husk.
         (let [flows-snapshot       (flows/flows-snapshot)
               last-inputs-snapshot (flows/last-inputs-snapshot)]
           (doseq [{:keys [frame-id flow-id cyc-a cyc-b]} per-thread]
             (let [per-frame-slot (get flows-snapshot frame-id)]
-              (is (or (nil? per-frame-slot) (empty? per-frame-slot))
-                  (str "Frame " frame-id ": expected empty per-frame "
-                       "flow registry after teardown; got "
+              (is (nil? per-frame-slot)
+                  (str "Frame " frame-id ": expected the per-frame flow "
+                       "registry key to be PRUNED after teardown "
+                       "(no {frame-id {}} husk, rf2-4bbaw); got "
                        (pr-str per-frame-slot))))
             (is (not (contains? last-inputs-snapshot flow-id))
                 (str "Flow id " flow-id " must not retain a "

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -89,6 +89,24 @@
   (testing "calling clear-flow on an unknown id is a no-op (does not throw)"
     (rf/clear-flow :no-such-flow)))
 
+(deftest clear-flow-prunes-empty-frame-slot-from-registry
+  ;; rf2-4bbaw: clearing the LAST flow on a frame must dissoc the frame-id
+  ;; key from the per-frame `@flows` registry entirely, not leave a
+  ;; `{frame-id {}}` husk. (Distinct from the leaf-only app-db vacation
+  ;; husk covered by the next deftest — this is about the registry map,
+  ;; not app-db.) Symmetric with `teardown-on-frame-destroy!`'s
+  ;; `(swap! flows dissoc frame-id)`.
+  (testing "clearing the sole flow on a frame removes the frame-id key from flows-snapshot"
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]})
+    (is (contains? (flows/flows-snapshot) :rf/default)
+        "precondition: the frame slot exists while a flow is registered")
+    (rf/clear-flow :area)
+    (is (not (contains? (flows/flows-snapshot) :rf/default))
+        "the frame-id key is GONE from @flows — no {frame-id {}} husk remains")))
+
 (deftest clear-flow-vacates-leaf-only-leaving-empty-parent-husk
   ;; rf2-ee38b.9: clear-flow's vacation contract is LEAF-ONLY. When the
   ;; cleared flow's leaf was the sole key under its parent, an empty


### PR DESCRIPTION
## What

`clear-flow` did `(swap! flows update frame-id dissoc id)`. When the cleared flow was the **last** on the frame, the per-frame map emptied to `{}` but the `frame-id` key itself was not pruned, leaving a `{frame-id {}}` husk in `@flows` until `destroy-frame!` / `reset-flows!`.

This PR prunes the `frame-id` key when its inner map is now empty, making the registry exactly symmetric with `teardown-on-frame-destroy!`'s `(swap! flows dissoc frame-id)`.

The husk was harmless (bounded by frame count, tolerated by the stress invariant, no app-db effect) — the only observable consequence was `flows-snapshot` showing a `{frame-id {}}` entry a naive consumer might iterate. This is the cosmetic-tidy fix the bead authorised.

## Changes

- **`registry.cljc`** — `clear-flow` prunes the empty `frame-id` slot after the inner `dissoc`.
- **`flows_test.clj`** — new `clear-flow-prunes-empty-frame-slot-from-registry`: register one flow, clear it, assert the `frame-id` key is GONE from `flows-snapshot` (not `{frame-id {}}`).
- **`flows_concurrency_stress_test.clj`** — invariant 4 tightened from `(or (nil? slot) (empty? slot))` to strict `(nil? slot)` now the husk is eliminated; comment updated.

## Not affected

- `dissoc-in-safe` / the leaf-only **app-db** vacation husk (`{:wizard {}}`, rf2-ee38b.9) is a deliberate, separate contract — unchanged.
- `no-frame-holds?` (reads `@flows` post-swap) and `flows.cljc:run-flows-on-db` (`(if-not (seq flow-map) ...)`) treat a pruned `nil` slot and an empty `{}` slot identically — no behaviour change.
- Conformance `:flow-registry-after` reads `(keys (get snapshot frame-id {}))` → `#{}` either way.

## Gates (cold)

- flows JVM suite: **125 tests / 527 assertions / 0 failures**
- `npm run test:cljs`: **5524 tests / 19180 assertions / 0 failures**

Closes rf2-4bbaw.