### PR TITLE
fix(epoch): bound cascade-cause :value-changed-subs by sub-cap (rf2-7n0kf)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -325,15 +325,18 @@
                       trigger event).
     :cause-subs     — distinct sub-ids that ran in the cascade so far,
                       in first-seen order, capped at sub-cap.
-    :value-changed-subs — the SUBSET of :cause-subs whose :sub/run
-                      reported :rf.sub/value-changed? true (rf2-8wrzz.1).
-                      A `set` of sub-ids, NOT capped independently — it is
-                      drawn from the already-capped first-seen scan, so it
-                      is bounded by sub-cap. Used by the views.cljs emit
-                      site to derive :rf.view/triggered-by — the first sub
-                      in THIS view's own read-set whose value changed (the
-                      precise per-view re-render cause). Empty when no sub
-                      changed value (a structural re-render).
+    :value-changed-subs — the SUBSET of subs whose :sub/run reported
+                      :rf.sub/value-changed? true (rf2-8wrzz.1). A `set`
+                      of sub-ids, independently bounded by sub-cap: the
+                      walk gates value-changed accumulation on its own
+                      count, mirroring the first-seen scan's cap on :subs
+                      (rf2-7n0kf — the value-changed scan is independent
+                      of the first-seen scan, so it needs its own guard).
+                      Used by the views.cljs emit site to derive
+                      :rf.view/triggered-by — the first sub in THIS view's
+                      own read-set whose value changed (the precise
+                      per-view re-render cause). Empty when no sub changed
+                      value (a structural re-render).
     :rendered-so-far — count of :rf.view/rendered already emitted into
                       this cascade. Used by the views.cljs emit site to
                       enforce the per-cascade view-render cap.
@@ -368,13 +371,22 @@
 
                            ;; rf2-8wrzz.1 — accumulate the value-changed
                            ;; subset (a set, deduped) so the views.cljs emit
-                           ;; site can derive :rf.view/triggered-by. Tracked
-                           ;; alongside the first-seen scan above; a sub that
-                           ;; ran multiple times in the cascade contributes
-                           ;; once. Bounded by the same buffer the scan walks.
+                           ;; site can derive :rf.view/triggered-by. A sub
+                           ;; that ran multiple times in the cascade
+                           ;; contributes once (set semantics). rf2-7n0kf —
+                           ;; independently bounded by `sub-cap`: this scan
+                           ;; gates value-changed accumulation on its OWN
+                           ;; count, just as the first-seen scan above caps
+                           ;; `:subs`. Without this guard a pathological
+                           ;; full-page cascade with > sub-cap distinct
+                           ;; value-changed sub-ids would grow the set past
+                           ;; the cap, contradicting the documented bound and
+                           ;; defeating the per-cascade view-render cap's
+                           ;; intent for this slot.
                            (and (= :rf.sub/run op)
                                 (some? (:rf.sub/id tags))
-                                (true? (:rf.sub/value-changed? tags)))
+                                (true? (:rf.sub/value-changed? tags))
+                                (< (count (:value-changed-subs acc)) sub-cap))
                            (update :value-changed-subs conj (:rf.sub/id tags))
 
                            ;; Count both :rf.view/rendered AND the one-shot

--- a/implementation/epoch/test/re_frame/epoch_cascade_cause_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_cascade_cause_test.clj
@@ -207,6 +207,31 @@
       (is (= #{:a} (:value-changed-subs result))
           "repeats collapse — :value-changed-subs is a deduped set"))))
 
+(deftest value-changed-subs-respects-sub-cap
+  (testing ":value-changed-subs is INDEPENDENTLY bounded by `sub-cap`
+            (rf2-7n0kf). The value-changed scan is independent of the
+            first-seen `:subs` scan, so it carries its own cap guard. A
+            pathological cascade with > sub-cap distinct value-changed
+            sub-ids must NOT grow the set past sub-cap — that is the
+            documented bound + the per-cascade view-render cap's intent"
+    (rf/reg-frame :test/cc {})
+    (seed-buffer! :test/cc
+                  (into [(run-start :ev)]
+                        (map (fn [i] (sub-run (keyword (str "v" i)) true)))
+                        (range 10)))
+    (testing "explicit sub-cap of 3 truncates the value-changed set to 3"
+      (let [result (capture/cascade-cause :test/cc 3)]
+        (is (= 3 (count (:value-changed-subs result)))
+            "value-changed-subs capped at the sub-cap (3), not the 10
+             distinct value-changed sub-ids present in the buffer")
+        (is (= #{:v0 :v1 :v2} (:value-changed-subs result))
+            "the FIRST 3 (first-seen) value-changed subs are kept; the
+             rest dropped — independent of the first-seen :subs scan")))
+    (testing "the default cap (100) admits all 10 value-changed subs"
+      (let [result (capture/cascade-cause :test/cc)]
+        (is (= 10 (count (:value-changed-subs result)))
+            "well under the default 100 cap — all value-changed subs surface")))))
+
 ;; ---- rendered-so-far: counts both rendered + cap-reached ------------------
 
 (deftest rendered-so-far-counts-rendered-emits


### PR DESCRIPTION
## What

`re-frame.epoch.capture/cascade-cause` accumulated `:value-changed-subs` gated only on `(= :rf.sub/run op)` / `(some? sub-id)` / `(true? value-changed?)` — with **no** sub-cap guard, unlike the first-seen `:subs` scan above it which gates on `(< (count (:subs acc)) sub-cap)`.

The docstring asserted the set was *"drawn from the already-capped first-seen scan, so it is bounded by sub-cap"* — **false**: the value-changed scan is independent of the first-seen scan, so a pathological full-page cascade with `> sub-cap` distinct value-changed sub-ids would grow the set past the documented bound, defeating the per-cascade view-render cap's intent for this slot.

## Decision: apply the bound (bead direction (b))

Per the bead's preferred direction and the latent-memory rationale, this **applies the bound** rather than weakening the docstring:

- Gate the value-changed accumulation on its own count `(< (count (:value-changed-subs acc)) sub-cap)`, mirroring the first-seen `:subs` cap. (`capture.cljc` ~line 387)
- Docstring corrected to describe the independently-applied cap (the prior "drawn from the already-capped first-seen scan" claim was the inaccurate part).

## Why it's safe

The downstream consumer (`views.cljs` `:rf.view/triggered-by` derivation) only does a `(contains? changed qid)` membership test against the view's *own* read-set. A view's own subs that changed value are already within the first-seen-capped `:cause-subs`, so the cap does not lose any per-view re-render cause.

The value-changed set is freshly built inside the `reduce` (set semantics, no `SubVector` view), so the **#2929 no-SubVector-retention** memory characteristic is preserved.

## Test

`value-changed-subs-respects-sub-cap` pins the bound: a `sub-cap` of 3 against a 10-distinct-value-changed buffer truncates to the first 3 (`#{:v0 :v1 :v2}`), and the default 100 cap admits all 10. Confirmed **RED** against the unguarded impl (grew to all 10), **GREEN** with the fix.

## Gates (cold)

- `npm run test:cljs` — 5524 tests / 19180 assertions, 0 failures (cold, fresh `npm install`)
- JVM epoch suite (`clojure -M:test` from `implementation/epoch/`) — 247 tests / 897 assertions, 0 failures

Closes rf2-7n0kf.