### PR TITLE
docs(xray): align trace-collector sort-fallback comment with code (rf2-fttd3 + rf2-mcu3u)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/trace_collector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/trace_collector.cljs
@@ -216,7 +216,8 @@
         ;; cross-frame oldest-first invariant the projection code +
         ;; the L2 event list both assume. Frameless events carry no
         ;; :id only in pathological cases (host produced an envelope
-        ;; without one); fall back to ##Inf so they sort to the tail.
+        ;; without one); fall back to js/Number.MAX_SAFE_INTEGER so they
+        ;; sort to the tail.
         all         (into per-frame frameless)]
     (into []
           ;; Privacy gate (rf2-0ax6f): scrub retained-but-sensitive


### PR DESCRIPTION
## What

`snapshot-from-rings` in `tools/xray/src/day8/re_frame2_xray/trace_collector.cljs` documented the nil-:id sort fallback as `##Inf`, but the `sort-by` key actually uses `js/Number.MAX_SAFE_INTEGER`. Both sort id-less frameless events to the tail, so there was **no behavioural bug** — purely a stale comment naming a value the code does not use, a small trust tax in a doc-disciplined codebase.

This corrects the comment to name the value the code actually uses.

## Scope

- **Comment-only.** Zero code change — the `sort-by` fallback (`js/Number.MAX_SAFE_INTEGER`) is already correct and untouched.
- One file, two lines (comment reflows to fit the corrected token).

## Beads

Both beads point at the same comment (rf2-fttd3 from the rf2-wa7tk correctness review; rf2-mcu3u from the 2026-06-04 senior-dev review F6). Fixed once, closes both.

- Closes rf2-fttd3
- Closes rf2-mcu3u

## Gate

xray `clojure -M:test` (cold): 1096 tests, 4567 assertions, 0 failures, 0 errors. Namespace compiles clean. Comment-only — no behaviour change, no browser gate needed.