### PR TITLE
fix(examples): correct realworld articles.cljs :status docstring (rf2-kpnsn)

### DIFF
--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -5,10 +5,13 @@
    - Pattern-NineStates — one parallel state machine with three orthogonal
      regions (`:feed` × `:filter` × `:data`) replacing the prior multi-axis
      state-in-separate-slices shape.
-   - Pattern-RemoteData lifecycle folded into the `:data` region; the
-     region's state-keyword IS the status. The actual article items still
-     live in app-db slices (`:articles`, `:feed`) so optimistic-update
-     paths in favorites.cljs continue to find articles across slices.
+   - Pattern-RemoteData lifecycle tracked by the `:data` region; the
+     region's state-keyword drives the home-page render decision. This is
+     a deliberate hybrid: unlike the full machine-form fold in `tags.cljs`,
+     the `:articles`/`:feed` slices stay in the standard 5-key slice form
+     (keeping their `:status` field) so the items live in app-db and
+     favorites.cljs's optimistic-update paths can scan across slices. See
+     the `:data` region note below.
    - route-query driven loading (`?tag=` and `?feed=your`) — every
      navigation broadcasts the corresponding feed-region transition.
    - home-page tabs expressed as feed-region state transitions.
@@ -49,10 +52,25 @@
 ;;             without inspecting the feed region.
 ;;
 ;;   :data   — Pattern-NineStates' data lifecycle for whichever feed is
-;;             active. The slice's `:status` field is gone — the region's
-;;             state-keyword IS the lifecycle phase. The :resolving
+;;             active. The region's state-keyword is what drives the
+;;             home-page *render decision* (via the render-priority table
+;;             + the `:articles.home/render` selector sub) — the view
+;;             never branches on the slice's `:status`. The :resolving
 ;;             eventless microstep picks `:empty` or `:some` from the
 ;;             count stamped into the machine's shared `:data`.
+;;
+;;             Note this is a deliberate HYBRID, not the full machine-form
+;;             fold used by `tags.cljs`/`settings.cljs` (where the slice —
+;;             and its `:status` — genuinely disappears). Here the
+;;             `:articles` slice stays in the standard 5-key slice form
+;;             (the slice-form half of the README's "two shapes
+;;             side-by-side" comparison): the article items live in
+;;             app-db so favorites.cljs's optimistic-update paths can scan
+;;             across slices, and the slice keeps its `:status` field
+;;             (required by `schema/RequestSlice`, asserted by the unit
+;;             tests). The machine's `:data` region tracks the same
+;;             lifecycle independently and is the single source of the
+;;             render decision.
 ;;
 ;; Per Spec 005 §Transition broadcast: every event delivered to the
 ;; machine is broadcast to every region. Region-distinct event names


### PR DESCRIPTION
@
## What

`examples/reagent/realworld/articles.cljs` carried a `:data`-region docstring claiming **"the slice's `:status` field is gone — the region's state-keyword IS the lifecycle phase"**, which contradicted the code: `request-slice` and the `:articles/load` / `:articles/loaded` / `:articles/load-failed` handlers all write `[:articles :status]`.

## Investigation (readers grep)

I grepped every reader of the `:articles` slice's `:status` field before deciding remove-vs-migrate:

- **No view or runtime sub reads `[:articles :status]`.** The home view renders via `:articles.home/render` (machine tags) and `:articles.home/active-articles` (machine `:feed` region + slice `:data`). `favorites.cljs`'s `find-article` / `patch-article-everywhere` read only `:data`, never `:status`.
- **But the field is NOT vestigial / removable.** It is a **required** key on `schema/RequestSlice` (`[:status [:enum :idle :loading :fetching :loaded :error]]`), the unit tests assert on it (`articles_test.cljs` lines 27/30/35/47, `ssr_test.cljc` line 12), and the README documents the `:articles` slice as one of the seven **slice-form** Pattern-RemoteData resources in the "two shapes side-by-side" comparison — deliberately kept in slice shape so the items live in app-db and the optimistic-update paths can scan across slices. The sibling `:feed` slice keeps an identical `:status` plus a live `:feed/loading?` sub that reads it.

## Decision: fix the docstring, not the code

This is a **deliberate hybrid**, not the full machine-form fold used by `tags.cljs` / `settings.cljs` (where the slice and its `:status` genuinely disappear). The `home-machine`'s `:data` region tracks the lifecycle independently and is the single source of the **render decision**; the `:articles` slice keeps its slice-form `:status`. The docstring wrongly conflated the two. Removing `:status` would have broken the required-key schema, 4 test assertions, and the README pedagogy.

Corrected the ns docstring and the `:data`-region comment so **code, docstring, schema, tests, and README all agree**. No code / schema / test changes.

## Gates (cold worktree)

- `npx shadow-cljs compile examples/realworld` — Build completed, **0 warnings**.
- `npm run test:cljs` — **5525 tests / 19184 assertions, 0 failures / 0 errors**.

Closes rf2-kpnsn.
@