### PR TITLE
fix(flows): make reg-flow cycle-check + commit atomic (rf2-qxwib)

### DIFF
--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -360,22 +360,48 @@
   ([flow] (reg-flow flow {}))
   ([flow {:keys [frame] :as _opts}]
    (validate-flow flow)
-   (let [frame-id     (or frame (frame/current-frame))
-         flow-id      (:id flow)
-         prior-frame  (get @flows frame-id)
-         ;; Per rf2-7csri: detect cycles on a PROSPECTIVE flow-map
-         ;; BEFORE mutating the atom or the registrar. The earlier
-         ;; write-then-rollback path silently deleted the prior
-         ;; registration along with the rejected one when a REPLACEMENT
-         ;; introduced a cycle — the rollback dissoc'd by flow-id,
-         ;; vacating the slot the prior entry was sharing. Now we run
-         ;; topo-sort on (prior-frame `assoc` new-entry) up-front; if it
-         ;; throws, nothing has been written and the prior registration
-         ;; stays intact.
-         prospective  (assoc prior-frame flow-id flow)]
-     (topo/topo-sort prospective)
-     ;; Cycle check passed — commit. The :flow registrar slot keys on
-     ;; flow-id only; stamp :frame into the metadata so introspection
+   (let [frame-id (or frame (frame/current-frame))
+         flow-id  (:id flow)]
+     ;; ATOMIC check-and-insert (rf2-qxwib). The cycle check and the
+     ;; commit are ONE `swap!` update fn over `@flows`: it reads the
+     ;; frame's CURRENTLY-COMMITTED flow-map, runs topo-sort on the
+     ;; prospective map, and — only if that passes — returns the map
+     ;; with the new flow assoc'd in. `swap!` re-invokes the update fn
+     ;; (re-reading committed state, re-running the cycle check) whenever
+     ;; a concurrent writer wins the compare-and-set, so a cycle can
+     ;; NEVER be admitted by interleaving.
+     ;;
+     ;; Pre-fix (rf2-7csri-era) this was check-THEN-act: it read
+     ;; `@flows` once, built a prospective map, ran topo-sort, then
+     ;; committed in a SEPARATE `swap!`. Two threads reg-flow'ing on the
+     ;; same frame two flows that together form a cycle (T1: A reads B's
+     ;; path; T2: B reads A's path) could each pass the check against the
+     ;; OTHER's not-yet-committed flow (neither sees it), then both
+     ;; commit — leaving a cyclic registry that throws on every drain.
+     ;; Folding the validation into the update fn closes that TOCTOU.
+     ;;
+     ;; Single-threaded path is unchanged in cost: `swap!` invokes the
+     ;; update fn exactly once with no contention, so this runs the same
+     ;; single topo-sort the prior code did. Only contended same-frame
+     ;; registration pays the retry (re-running the cheap Kahn sort over
+     ;; a handful of nodes), and only then to preserve correctness.
+     ;;
+     ;; The cycle-check throw propagates OUT of `swap!`, so on rejection
+     ;; the atom is left untouched and the prior registration survives —
+     ;; preserving the rf2-7csri "a rejected REPLACEMENT does not vacate
+     ;; the slot the prior entry shares" guarantee, now atomically.
+     (swap! flows
+            (fn [m]
+              (let [prior-frame (get m frame-id)
+                    prospective (assoc prior-frame flow-id flow)]
+                ;; Throws :rf.error/flow-cycle if the prospective map is
+                ;; cyclic; the update fn never returns and the CAS never
+                ;; fires, so the atom is unchanged.
+                (topo/topo-sort prospective)
+                (assoc m frame-id prospective))))
+     ;; Cycle check + commit done atomically above. The :flow registrar
+     ;; slot keys on flow-id only; stamp :frame into the metadata so
+     ;; introspection
      ;; / hot-reload hooks can read the owning frame. `register!`
      ;; returns `{:was previous :now metadata}` — `:was` is nil on
      ;; first-time registration, non-nil on hot-reload re-registration.
@@ -397,7 +423,6 @@
                              (assoc flow
                                     :frame      frame-id
                                     :handler-fn (:output flow))))]
-       (swap! flows assoc-in [frame-id flow-id] flow)
        ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires
        ;; on FIRST-TIME registration only. On re-registration the
        ;; cross-kind `:rf.registry/handler-replaced` trace (emitted by

--- a/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
+++ b/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
@@ -1,0 +1,178 @@
+(ns re-frame.flows-reg-flow-toctou-test
+  "Per rf2-qxwib — JVM regression coverage for the reg-flow
+  check-and-insert TOCTOU.
+
+  THE BUG (pre-fix): `reg-flow`'s cycle detection was check-THEN-act.
+  It read `@flows` once, built a PROSPECTIVE flow-map, ran
+  `topo/topo-sort` on it, and — in a SEPARATE step — committed via
+  `swap!`. Two threads registering on the SAME frame two flows that
+  together form a dependency cycle (T1 registers A whose `:inputs` read
+  B's `:path`; T2 registers B whose `:inputs` read A's `:path`) could
+  interleave so that BOTH read the frame's pre-cycle state, BOTH pass
+  their individual prospective check (neither sees the other's
+  not-yet-committed flow), and BOTH commit — leaving a CYCLIC registry.
+  Drain-time topo-sort then throws `:rf.error/flow-cycle` on every drain
+  of that frame, defeating the Spec 013 §Cycle detection promise that a
+  cycle is caught AT REGISTRATION.
+
+  THE FIX: fold the cycle check INTO the `swap!` update fn so the
+  read-validate-commit is one atomic compare-and-set. The update fn
+  reads the committed frame-map, runs topo-sort on the prospective map,
+  and only returns the assoc'd map if that passes. `swap!` re-invokes
+  the update fn (re-reading committed state, re-validating) on
+  contention, so once ONE of the racing pair commits, the OTHER's retry
+  sees the committed edge and its topo-sort throws — exactly one of the
+  pair is admitted, and the committed registry is NEVER cyclic.
+
+  CLJS is single-threaded; this race is JVM-only by construction. The
+  rf2-ztw5p concurrency-stress test deliberately partitions by frame
+  (each thread owns its own frame, and runs its own cyc-a/cyc-b probe
+  sequentially within that frame), so the SAME-frame interleaving this
+  bug needs is out of its scope by design. This namespace targets it
+  directly: two threads, ONE shared frame, the cycle-forming pair
+  registered in lockstep, asserting the committed registry never holds
+  an admitted cycle.
+
+  Many rounds under a `CyclicBarrier` release maximise the interleaving
+  window; round count is env-overridable via
+  `RF2_QXWIB_TOCTOU_ROUNDS`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.flows.topo :as topo]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CyclicBarrier]
+           [java.util.concurrent.atomic AtomicLong]))
+
+;; ---- per-test reset (mirrors flows_concurrency_stress_test.clj) -----------
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-listeners!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; Round count. Each round opens a fresh interleaving window on the
+;; shared frame; the pre-fix race needs only ONE round where both
+;; threads read the pre-cycle state before either commits, so a few
+;; thousand rounds surface it reliably across box/JVM scheduling. CI
+;; can dial down via the env override for a smoke pass.
+(def ^:private rounds
+  (or (some-> (System/getenv "RF2_QXWIB_TOCTOU_ROUNDS") Long/parseLong)
+      4000))
+
+(deftest concurrent-same-frame-reg-flow-cannot-admit-a-cycle
+  ;; rf2-qxwib — the atomic check-and-insert regression.
+  ;;
+  ;; Per round, on ONE shared frame, two threads simultaneously register
+  ;; the two halves of a cycle-forming pair:
+  ;;
+  ;;   A : :inputs [[:b]]  :path [:a]   (A depends on B's output slot)
+  ;;   B : :inputs [[:a]]  :path [:b]   (B depends on A's output slot)
+  ;;
+  ;; Registered together they form the cycle :a → :b → :a. The
+  ;; per-round flow-ids are namespaced by round so a stale registrar /
+  ;; flows entry from a prior round cannot mask the race.
+  ;;
+  ;; INVARIANT (the one that catches the bug): after each round, the
+  ;; frame's COMMITTED flow-map — read via `flows/flows-snapshot` —
+  ;; must NOT be cyclic. We assert this by running `topo/topo-sort` on
+  ;; the committed map: it must not throw. Pre-fix, a round that
+  ;; interleaved the check-then-act admitted BOTH flows, so the
+  ;; committed map was cyclic and this topo-sort throws — the test
+  ;; fails. Post-fix the atomic swap admits at most one of the pair, so
+  ;; the committed map is always acyclic.
+  ;;
+  ;; SECONDARY INVARIANT: at least one of the two registrations must be
+  ;; REJECTED with `:rf.error/flow-cycle` (the loser of the CAS race, or
+  ;; the second of two serialised registrations, sees the committed edge
+  ;; and throws). We count rejections; with a real cycle-forming pair on
+  ;; a shared frame, every round MUST reject at least one half, so the
+  ;; rejection count must be >= rounds. (A round can reject BOTH only if
+  ;; both threads happened to run fully serialised AND the first's commit
+  ;; was then cleared — which never happens here since we clear only
+  ;; AFTER the round's asserts — so the realistic ceiling is one
+  ;; rejection per round, but we assert the lower bound which is the
+  ;; load-bearing one.)
+  (testing (str rounds " rounds: two threads, one shared frame, "
+                "cycle-forming reg-flow pair in lockstep — committed "
+                "registry is never cyclic, at least one half rejected")
+    (let [frame-id    :qxwib.toctou/shared
+          rejections  (AtomicLong. 0)
+          ;; Surfaces the FIRST observed cyclic-commit so a failure
+          ;; report names the offending round + committed map rather
+          ;; than just "topo-sort threw".
+          first-bad   (atom nil)]
+      (rf/reg-frame frame-id {:doc "shared frame for the reg-flow TOCTOU repro"})
+      (dotimes [round rounds]
+        (let [a-id    (keyword "qxwib.toctou" (str "a-" round))
+              b-id    (keyword "qxwib.toctou" (str "b-" round))
+              ;; A reads B's output path; B reads A's output path —
+              ;; together a cycle.
+              flow-a  {:id a-id :inputs [[:b]] :output identity :path [:a]}
+              flow-b  {:id b-id :inputs [[:a]] :output identity :path [:b]}
+              barrier (CyclicBarrier. 2)
+              reg!    (fn [flow]
+                        (fn []
+                          (.await barrier)        ; release both at once
+                          (try
+                            (rf/reg-flow flow {:frame frame-id})
+                            (catch Throwable t
+                              (when (re-find #":rf.error/flow-cycle"
+                                             (or (ex-message t) ""))
+                                (.incrementAndGet rejections))))))
+              fa      (future ((reg! flow-a)))
+              fb      (future ((reg! flow-b)))]
+          ;; Bounded join — a hang (e.g. a swap retry livelock) should
+          ;; surface as a visible failure, not a stuck CI run.
+          (let [va (deref fa 30000 ::timeout)
+                vb (deref fb 30000 ::timeout)]
+            (is (and (not= ::timeout va) (not= ::timeout vb))
+                (str "round " round ": both reg-flow threads completed "
+                     "within 30s")))
+          ;; THE load-bearing assertion: the committed registry for the
+          ;; shared frame is acyclic. topo-sort throws :rf.error/flow-cycle
+          ;; iff a cycle was admitted.
+          (let [committed (get (flows/flows-snapshot) frame-id)]
+            (try
+              (topo/topo-sort committed)
+              (catch Throwable t
+                (when (nil? @first-bad)
+                  (reset! first-bad {:round    round
+                                     :committed committed
+                                     :ex-data  (ex-data t)})))))
+          ;; Clean both ids off the shared frame before the next round so
+          ;; each round starts from the frame's pre-cycle state (the
+          ;; window the race needs). clear-flow no-ops cleanly on the id
+          ;; that was rejected / never committed.
+          (rf/clear-flow a-id {:frame frame-id})
+          (rf/clear-flow b-id {:frame frame-id})))
+
+      ;; --- Invariant 1: no round ever admitted a cycle. ---------------
+      (is (nil? @first-bad)
+          (str "A concurrent same-frame reg-flow round admitted a cycle "
+               "(committed registry is cyclic — the rf2-qxwib TOCTOU). "
+               "First offending round: " (pr-str @first-bad)))
+
+      ;; --- Invariant 2: every round rejected at least one half. -------
+      ;; With a genuine cycle-forming pair on a shared frame, one half
+      ;; MUST always be rejected — the only way neither throws is if a
+      ;; cycle was admitted (caught by invariant 1). So rejections >=
+      ;; rounds confirms the cycle was caught at REGISTRATION every round
+      ;; (Spec 013 §Cycle detection), not deferred to drain time.
+      (is (<= rounds (.get rejections))
+          (str "Expected at least " rounds " cycle rejections (>= one "
+               "per round); got " (.get rejections) ". A short count "
+               "means a round admitted the cycle silently instead of "
+               "rejecting a half at registration.")))))


### PR DESCRIPTION
## What

Closes **rf2-qxwib** (P4 bug) — `reg-flow`'s cycle detection was a check-then-act TOCTOU.

### Root cause
`reg-flow` (registry.cljc) read `@flows` once, built a prospective flow-map, ran `topo/topo-sort`, then committed in a **separate** `swap!`. Two threads `reg-flow`'ing on the **same frame** two flows that together form a dependency cycle (T1: A's `:inputs` read B's `:path`; T2: B's `:inputs` read A's `:path`) could each pass their individual prospective check against the other's *not-yet-committed* flow, then both commit — leaving a **cyclic registry**. Drain-time `topo-sort` then threw `:rf.error/flow-cycle` on every drain of that frame, defeating the Spec 013 §Cycle detection promise that a cycle is caught **at registration**. JVM-only — CLJS is single-threaded.

### Fix
Fold the cycle check **into** the `swap!` update fn on `@flows`, so read-validate-commit is one atomic compare-and-set (`registry.cljc` `reg-flow`). The update fn reads committed state, runs `topo-sort` on the prospective map, and only returns the assoc'd map if that passes. `swap!` re-invokes the fn (re-reading + re-validating) on contention, so once one of a racing pair commits, the other's retry sees the committed edge and throws. A cycle can never be admitted by interleaving.

- **Single-threaded cost unchanged** — `swap!` invokes the update fn exactly once with no contention, running the same single `topo-sort` the prior code did. Only contended same-frame registration pays the retry (a cheap Kahn sort over a handful of nodes).
- **rf2-7csri guarantee preserved, now atomically** — the cycle-check throw still propagates out of `swap!`, leaving the atom untouched, so a rejected *replacement* does not vacate the slot the prior entry shares.
- The registrar/trace/marks side effects move after the atomic commit (registrar `:flow` kind is always valid here; marks is a late-bound no-op) — no partial-commit hazard.

### Test
New `flows_reg_flow_toctou_test.clj`: two threads, one **shared** frame, the cycle-forming pair registered in lockstep under a `CyclicBarrier` over many rounds (env `RF2_QXWIB_TOCTOU_ROUNDS`, default 4000). Asserts (1) the committed registry is **never** cyclic and (2) at least one half is rejected with `:rf.error/flow-cycle` per round.

Verified to **FAIL on the pre-fix code** (round 0 admitted both halves; only 33/2000 rounds rejected) and **PASS on the fix**. The existing rf2-ztw5p concurrency-stress test partitions by frame, so this same-frame interleaving was out of its scope by design — hence the dedicated test.

## Gates (cold, from `implementation/`)
- `clojure -M:test` (flows JVM suite): **126 tests, 4529 assertions, 0 failures** — includes the new TOCTOU test + the rf2-ztw5p concurrency stress test.
- `npm run test:cljs`: **5525 tests, 19184 assertions, 0 failures**.

## Scope
`implementation/flows/` only.