### PR TITLE
refactor(xray/epoch): delete 4 dead legacy machine-category projection slots (rf2-bhxtr)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -434,91 +434,15 @@
         {:fx-vec        (:fx fx)
          :other-effects (not-empty (dissoc fx :db :fx))}))))
 
-(defn- machine-lifecycle-rows
-  "Project the `:rf.machine/action-ran` stream into per-phase rows
-  (rf2-82a0u — every action-ran emit carries `:phase` from the closed
-  set `:exit / :transition / :entry / :always / :after-action /
-  :initial-entry / :destroy-exit`).
-
-  Each row carries `:action-id`, `:phase`, `:outcome`, optional
-  `:threw?` + `:exception` (action-throw path emits
-  `:outcome :rf.error/action-threw` + an `:exception` slot), and
-  optional `:fx` (per-action fx attribution per rf2-9c27r — the
-  vector of `[fx-id args]` the action returned in its outcome map's
-  `:fx` slot). Rendered in trace order — the substrate emits in
-  execution order (exit → transition → entry → always …)."
-  [events]
-  (vec
-    (for [ev (filter-op events :rf.machine/action-ran)]
-      (let [outcome (common/tag-of ev :outcome)
-            ;; Per-action fx attribution (rf2-9c27r) — when the
-            ;; action returned a map carrying `:fx`, surface the
-            ;; tuple list so the LIFECYCLE row can show which fx
-            ;; the operator should attribute to this action.
-            action-fx (when (map? outcome) (:fx outcome))
-            action-data (when (map? outcome) (:data outcome))]
-        (cond-> {:action-id (common/tag-of ev :action-id)
-                 :phase     (common/tag-of ev :phase)
-                 :outcome   outcome
-                 :threw?    (= :rf.error/action-threw outcome)
-                 :exception (common/tag-of ev :exception)
-                 :input     (common/tag-of ev :input)}
-          (seq action-fx) (assoc :fx (vec action-fx))
-          (some? action-data) (assoc :data-write action-data))))))
-
-(defn- machine-transition-row
-  "Project the `:rf.machine/transition` event (one per macrostep) into a
-  summary `{:machine-id :before :after :microsteps :event :data-before
-            :data-after}` row. nil when no transition trace fired.
-
-  Per Spec 005 §Trace events the `:before` / `:after` slots carry
-  the full machine snapshot maps (`:state` + `:data` + …); the row
-  hoists `:data-before` / `:data-after` for the rf2-9c27r DATA
-  REDUCTION sub-section so the view layer doesn't re-walk the
-  snapshot map.
-
-  rf2-52u5n — the row also carries the STRUCTURED `:cascade` (the
-  ordered exit/action/entry/microstep step vector the substrate
-  emits on the `:rf.machine/transition` trace per rf2-n9f4z) so the
-  view can render the step-by-step entry/exit cascade under EVENT
-  HANDLER rather than only `{from}→{to} + {n} microstep(s)`. Absent
-  (`nil`) for older traces / non-structured fixtures — the view
-  falls back to the summary in that case."
-  [events]
-  (when-let [ev (find-op events :rf.machine/transition)]
-    (let [before (common/tag-of ev :before)
-          after  (common/tag-of ev :after)]
-      {:machine-id   (common/tag-of ev :machine-id)
-       :event        (common/tag-of ev :event)
-       :before       before
-       :after        after
-       :data-before  (when (map? before) (:data before))
-       :data-after   (when (map? after)  (:data after))
-       :microsteps   (common/tag-of ev :microsteps)
-       :cascade      (common/tag-of ev :cascade)})))
-
-(defn- machine-guard-rows
-  "Project the `:rf.machine/guard-evaluated` stream into rows. Each
-  row carries `:guard-id`, `:outcome` (one of `:pass :fail :threw`
-  per rf2-82a0u). Empty vec when no guards fired."
-  [events]
-  (vec
-    (for [ev (filter-op events :rf.machine/guard-evaluated)]
-      {:guard-id (common/tag-of ev :guard-id)
-       :outcome  (common/tag-of ev :outcome)})))
-
-(defn- machine-timer-rows
-  "Project the `:rf.machine.timer/cancelled` stream (rf2-82a0u —
-  unified across every cancellation path with `:reason` in
-  `:on-exit / :on-destroy / :on-resolution / :on-supersede /
-  :on-frame-destroy`)."
-  [events]
-  (vec
-    (for [ev (filter-op events :rf.machine.timer/cancelled)]
-      {:machine-id (common/tag-of ev :machine-id)
-       :state      (common/tag-of ev :state)
-       :delay      (common/tag-of ev :delay)
-       :reason     (common/tag-of ev :reason)})))
+;; rf2-bhxtr — the 4 legacy category-grouped machine builders
+;; (`machine-lifecycle-rows` / `machine-transition-row` / `machine-guard-rows`
+;; / `machine-timer-rows`) are DELETED. They fed the pre-rf2-u69j7
+;; category-grouped `:machine` map slots (`:lifecycle / :transition / :guards
+;; / :timers`), which post-rf2-u69j7 had ZERO readers — the view + every live
+;; consumer read ONLY `:cascade` (the time-ordered row vector built by
+;; `machine-cascade-rows` below). The per-row category data they projected is
+;; carried verbatim on the cascade rows (`action-cascade-row` /
+;; `transition-cascade-row` / `guard-cascade-row` / `timer-cascade-row`).
 
 ;; ---- machine cascade (time-ordered) -- rf2-u69j7 ------------------------
 ;;
@@ -1524,8 +1448,7 @@
 
   - `:reg-event-db`  → :db (post-handler snapshot)
   - `:reg-event-fx`  → :db + :fx
-  - `:reg-machine`   → :db + :fx + :machine {transition guards
-                                             lifecycle timers}
+  - `:reg-machine`   → :db + :fx + :machine {:cascade …}
 
   The HANDLER `:db` sub-section is rendered from `:db-post-handler`
   (the effective post-handler / pre-flow snapshot) diffed against the
@@ -1536,12 +1459,13 @@
   consumers derive diffs on demand.
 
   Two arities — the 2-arg form (legacy callers / tests) supplies
-  nil/nil for db-before/after. The 4-arg form's `db-after` is no
-  longer read (rf2-sp0n9 removed the flat-row diff that consumed it);
-  the arity is kept stable for existing callers / tests."
+  nil for `db-before`. The 3-arg form takes the epoch record's
+  `:db-before` baseline (the only db snapshot still read). rf2-sp0n9
+  removed the flat-row diff that consumed the post-handler `db-after`;
+  rf2-bhxtr dropped the now-dead `db-after` param entirely."
   ([events event-id]
-   (handler-row events event-id nil nil))
-  ([events event-id db-before _db-after]
+   (handler-row events event-id nil))
+  ([events event-id db-before]
   (let [flavour     (handler-flavour events)
         run-end     (run-end-tags events)
         db-changed  (find-op events :rf.event/db-changed)
@@ -1610,18 +1534,12 @@
       (= :reg-machine flavour)
       (assoc :machine
              ;; rf2-u69j7 — `:cascade` is the time-ordered row vector the
-             ;; view layer renders. The legacy category-grouped slots
-             ;; (`:transition / :guards / :lifecycle / :timers`) are KEPT
-             ;; on the row as projection-side derived data so test fixtures
-             ;; + callers that pre-date the cascade redesign still read
-             ;; the substrate's per-category aggregations cleanly. The
-             ;; view layer reads ONLY `:cascade` post-rf2-u69j7; the
-             ;; legacy slots ride the row as a pure-data convenience.
-             {:cascade     (machine-cascade-rows events)
-              :transition  (machine-transition-row events)
-              :guards      (machine-guard-rows events)
-              :lifecycle   (machine-lifecycle-rows events)
-              :timers      (machine-timer-rows events)})))))
+             ;; view layer renders, the SINGLE source of truth for the
+             ;; machine section. rf2-bhxtr dropped the 4 legacy category-
+             ;; grouped slots (`:transition / :guards / :lifecycle /
+             ;; :timers`): they had no reader post-rf2-u69j7 (the view +
+             ;; every live consumer read only `:cascade`).
+             {:cascade (machine-cascade-rows events)})))))
 
 ;; ---- FLOW step -----------------------------------------------------------
 
@@ -3181,7 +3099,6 @@
   [epoch-record]
   (let [events    (or (:trace-events epoch-record) [])
         db-before (:db-before epoch-record)
-        db-after  (:db-after epoch-record)
         event-id  (or (:event-id epoch-record)
                       (when-let [ev (find-op events :rf.event/dispatched)]
                         (let [v (or (common/tag-of ev :rf.event/v)
@@ -3324,7 +3241,7 @@
                           ;; nil (filtered out below) when no interceptor
                           ;; threw in that phase this cascade.
                           [(interceptor-step events :before)
-                           (handler-row events event-id db-before db-after)
+                           (handler-row events event-id db-before)
                            (interceptor-step events :after)]
                           ;; APP-DB DIFF removed pair-debug 2026-05-26 —
                           ;; redundant with the HANDLER step's `:db`
@@ -3403,17 +3320,10 @@
   (let [ms (:duration-ms step)]
     (and (number? ms) (> ms long-step-threshold-ms))))
 
-;; ---- lifecycle grouping (view-shared data) ------------------------------
-
-(defn group-lifecycle-by-phase
-  "Group machine lifecycle rows by `:phase`. Returns a map from phase
-  keyword → rows-vec. Pure fn for the view to render per-phase
-  sub-sections."
-  [lifecycle-rows]
-  (reduce (fn [acc row]
-            (update acc (or (:phase row) :unknown) (fnil conj []) row))
-          {}
-          (or lifecycle-rows [])))
+;; rf2-bhxtr — `group-lifecycle-by-phase` is DELETED. It grouped the
+;; now-removed `:lifecycle` category slot's rows by `:phase` for the
+;; pre-rf2-u69j7 per-phase view sub-sections; with the slot gone (and the
+;; cascade carrying `:phase` per-row) it had no live reader.
 
 (defn empty-pipeline?
   "True iff `(project record)` would produce zero steps (no dispatch,

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -447,21 +447,29 @@
       (is (= #{:db :navigate} (into #{} (map :fx-id (:fx r))))))))
 
 (deftest handler-row-reg-machine-test
-  (testing "action-ran present → reg-machine flavour; machine block populated"
+  (testing "rf2-bhxtr — action-ran present → reg-machine flavour; the
+            `:machine` block carries the SINGLE `:cascade` row vector (the
+            legacy category slots :transition / :guards / :lifecycle /
+            :timers were dropped — the cascade carries the same per-row data
+            keyed by `:kind`)."
     (let [evs [(machine-transition-ev :ws/conn [:idle] [:connecting])
                (machine-guard-ev :ready? :pass)
                (machine-action-ev :open-socket :entry :ok)
                (machine-action-ev :close-socket :exit :ok)
                (machine-timer-cancel-ev :ws/conn [:idle] 250 :on-exit)]
           r (proj/handler-row evs :ws/start)
-          m (:machine r)]
+          m (:machine r)
+          cascade (:cascade m)
+          by-kind (group-by :kind cascade)]
       (is (= :reg-machine (:flavour r)))
       (is (some? m))
-      (is (= :ws/conn (-> m :transition :machine-id)))
-      (is (= 1 (count (:guards m))))
-      (is (= 2 (count (:lifecycle m))))
-      (is (= 1 (count (:timers m))))
-      (is (= :on-exit (-> m :timers first :reason))))))
+      (is (= [:cascade] (keys m))
+          "the machine block carries ONLY :cascade post-rf2-bhxtr")
+      (is (= :ws/conn (-> (:transition by-kind) first :machine-id)))
+      (is (= 1 (count (:guard by-kind))))
+      (is (= 2 (count (:action by-kind))))
+      (is (= 1 (count (:timer by-kind))))
+      (is (= :on-exit (-> (:timer by-kind) first :reason))))))
 
 (deftest handler-row-machine-transition-no-action-test
   (testing "rf2-eue07 — a real macrostep that fires NO `:rf.machine/action-ran`
@@ -486,13 +494,14 @@
                                        [:hvac/power-cycle] 2)
                (db-changed-ev [[[:hvac/controller] {} {} :modified]])]
           r   (proj/handler-row evs :hvac/power-cycle)
-          m   (:machine r)]
+          m   (:machine r)
+          tx  (first (filterv #(= :transition (:kind %)) (:cascade m)))]
       (is (= :reg-machine (:flavour r))
           "a transition with NO action-ran still classifies :reg-machine")
       (is (some? m)
           "the machine section is populated, not the raw :db diff")
-      (is (= :hvac/controller (-> m :transition :machine-id))
-          "the transition row threads through into the machine block"))))
+      (is (= :hvac/controller (:machine-id tx))
+          "the transition row threads through into the machine cascade"))))
 
 (deftest handler-row-bootstrap-initial-entry-transition-test
   (testing "rf2-eue07 — the post-carve-out bootstrap macrostep (rf2-t4582:
@@ -532,10 +541,11 @@
           "no fx, no machine trace → reg-event-db, unchanged")
       (is (nil? (:machine r))))))
 
-(deftest machine-transition-row-hoists-data-snapshots-test
-  (testing "rf2-9c27r — `machine-transition-row` exposes `:data-before /
-            :data-after` from the `:before / :after` snapshots, plus the
-            `:event` + `:microsteps` slots for the design's TRANSITION sub"
+(deftest machine-transition-cascade-row-hoists-data-snapshots-test
+  (testing "rf2-9c27r / rf2-bhxtr — the `:transition` CASCADE row exposes
+            `:data-before / :data-after` from the `:before / :after`
+            snapshots, plus the `:event` + `:microsteps` slots (formerly
+            asserted via the dropped `:machine :transition` slot)"
     (let [snap-before {:state [:idle]      :data {:count 0}}
           snap-after  {:state [:connected] :data {:count 1}}
           evs [(machine-transition-ev :ws/conn snap-before snap-after
@@ -546,7 +556,7 @@
                ;; when the flavour is :reg-machine).
                (machine-action-ev :open-socket :entry :ok)]
           r   (proj/handler-row evs :ws/start)
-          mt  (-> r :machine :transition)]
+          mt  (first (filterv #(= :transition (:kind %)) (-> r :machine :cascade)))]
       (is (= [:ws/start]    (:event mt)))
       (is (= 2              (:microsteps mt)))
       (is (= snap-before    (:before mt)))
@@ -557,8 +567,9 @@
           ":data-after hoisted off the after snapshot"))))
 
 (deftest machine-action-fx-attribution-test
-  (testing "rf2-9c27r — when a lifecycle action returns a map carrying
-            `:fx`, the row exposes the per-action fx attribution"
+  (testing "rf2-9c27r / rf2-bhxtr — when an action returns a map carrying
+            `:fx`, the `:action` CASCADE row exposes the per-action fx
+            attribution (formerly asserted via the dropped `:lifecycle` slot)"
     (let [outcome {:fx [[:http/get {:url "/x"}]
                         [:dispatch [:other]]]
                    :data {:n 1}}
@@ -568,31 +579,22 @@
                     :outcome   outcome
                     :input     {:data {} :event nil}})]
           r   (proj/handler-row evs :ws/start)
-          row (-> r :machine :lifecycle first)]
+          row (first (filterv #(= :action (:kind %)) (-> r :machine :cascade)))]
       (is (= 2 (count (:fx row)))
-          "per-action fx tuple list rides on the lifecycle row")
+          "per-action fx tuple list rides on the action cascade row")
       (is (= :http/get (-> row :fx (nth 0) first))
           "first fx-id is :http/get")
       (is (= {:n 1} (:data-write row))
           "the action's :data write is also surfaced for attribution"))))
 
 (deftest machine-action-without-fx-omits-slot-test
-  (testing "rf2-9c27r — actions whose outcome carries no :fx leave the
-            `:fx` slot ABSENT (not nil) so the row stays minimal"
+  (testing "rf2-9c27r / rf2-bhxtr — actions whose outcome carries no :fx
+            leave the `:fx` slot ABSENT (not nil) on the `:action` cascade row"
     (let [evs [(machine-action-ev :open-socket :entry :ok)]
           r   (proj/handler-row evs :ws/start)
-          row (-> r :machine :lifecycle first)]
+          row (first (filterv #(= :action (:kind %)) (-> r :machine :cascade)))]
       (is (not (contains? row :fx))
           ":fx slot absent on actions without per-action fx"))))
-
-(deftest machine-lifecycle-grouped-by-phase-test
-  (testing "group-lifecycle-by-phase produces phase → rows map"
-    (let [rows [{:action-id :a1 :phase :exit}
-                {:action-id :a2 :phase :entry}
-                {:action-id :a3 :phase :exit}]
-          grouped (proj/group-lifecycle-by-phase rows)]
-      (is (= 2 (count (:exit grouped))))
-      (is (= 1 (count (:entry grouped)))))))
 
 ;; ---- rf2-u69j7 — machine cascade (time-ordered) -----------------------
 
@@ -1131,22 +1133,17 @@
             {:kind :action :state [:asking] :region nil :action :win  :data-delta {:won true}}
             {:kind :entry  :state [:winner] :region nil :action nil  :data-delta {}}]}])
 
-(deftest machine-transition-row-threads-structured-cascade-test
-  (testing "rf2-52u5n — `machine-transition-row` threads the structured
-            `:cascade` step vector off the `:rf.machine/transition` trace
-            so the view can render the step-by-step entry/exit cascade.
-            RED before this bead: the row had only `{:before :after
-            :microsteps :event}` — no `:cascade`."
+(deftest transition-cascade-row-threads-structured-cascade-test
+  (testing "rf2-52u5n / rf2-bhxtr — the `:transition` CASCADE row threads the
+            structured `:cascade` step vector off the `:rf.machine/transition`
+            trace so the view can render the step-by-step entry/exit cascade."
     (let [snap-before {:state {:climate :idle :fan :off} :data {}}
           snap-after  {:state {:climate [:running :conditioning :heating] :fan :on} :data {}}
           evs [(machine-transition-ev :hvac/controller snap-before snap-after
                                        [:hvac/power-cycle] 0 hvac-power-cycle-cascade)
                (machine-action-ev :enter-heating :entry :ok)]
           r   (proj/handler-row evs :hvac/controller)
-          mt  (-> r :machine :transition)
           tx  (first (filterv #(= :transition (:kind %)) (-> r :machine :cascade)))]
-      (is (= hvac-power-cycle-cascade (:cascade mt))
-          "the summary transition row carries the structured cascade")
       (is (= hvac-power-cycle-cascade (:cascade tx))
           "the transition CASCADE row threads the structured cascade for the view"))))
 
@@ -1227,10 +1224,7 @@
                                        [:ws/start] 1) ;; 5-arg: NO :cascade
                (machine-action-ev :open-socket :entry :ok)]
           r   (proj/handler-row evs :ws/start)
-          mt  (-> r :machine :transition)
           tx  (first (filterv #(= :transition (:kind %)) (-> r :machine :cascade)))]
-      (is (nil? (:cascade mt))
-          "no structured cascade on the summary row → fall back to summary")
       (is (nil? (:cascade tx))
           "no structured cascade on the transition cascade row")
       (is (= [] (proj/cascade-regions nil)))
@@ -2541,9 +2535,10 @@
                          (machine-transition-ev :ws/conn [:idle] [:connecting])
                          (machine-action-ev :open-socket :entry :ok)])
           steps (proj/project rec)
-          h     (some #(when (= :handler (:step %)) %) steps)]
+          h     (some #(when (= :handler (:step %)) %) steps)
+          tx    (first (filterv #(= :transition (:kind %)) (-> h :machine :cascade)))]
       (is (= :reg-machine (:flavour h)))
-      (is (= :ws/conn (-> h :machine :transition :machine-id))))))
+      (is (= :ws/conn (:machine-id tx))))))
 
 (deftest project-empty-test
   (testing "empty trace events → empty step vector"
@@ -3111,14 +3106,14 @@
                    (handler-exception-ev :standard-epochs/throw-handler "boom" nil)
                    (run-end-ev 1)]
                   :standard-epochs/throw-handler
-                  {:n 1} {:n 1})]
+                  {:n 1})]
       (is (false? (:db-write? threw))
           "handler that threw before returning a :db → db-write? false"))
     (let [wrote (proj/handler-row
                   [(db-pending-ev {:count 1})
                    (db-changed-ev [[[:count] 0 1 :modified]])
                    (run-end-ev 1)]
-                  :counter/inc {:count 0} {:count 1})]
+                  :counter/inc {:count 0})]
       (is (true? (:db-write? wrote))
           "handler that wrote a :db → db-write? true"))))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -713,8 +713,7 @@
                  {:step :handler :badge :HANDLER :step-number 3
                   :flavour :reg-machine :event-id :ws/start
                   :fx []
-                  :machine {:transition nil :guards []
-                            :lifecycle [] :timers []}})]
+                  :machine {:cascade []}})]
       (is (nil? (th/find-by-testid tree "rf-xray-epoch-handler-db-diff"))
           "no standalone :db diff under machine handlers — folded into
            SNAPSHOT DIFF per design"))))


### PR DESCRIPTION
## What

Deletes the 4 dead legacy machine-category slots + their builders from the Xray Epoch-panel projection layer (`tools/xray/.../panels/epoch/projection.cljc`). Bead rf2-bhxtr (P3, senior-dev review finding F1).

Post-rf2-u69j7 the machine-handler section renders ONLY the time-ordered `:cascade` row vector. The 4 category-grouped `:machine` map slots (`:transition / :guards / :lifecycle / :timers`) were kept "for callers that pre-date the cascade redesign" but had **zero live readers** — the view destructures `{:keys [cascade]}` and every live consumer reads `:cascade`.

## Deleted (grep-verified zero readers)

- **4 builder defns**: `machine-transition-row`, `machine-guard-rows`, `machine-lifecycle-rows`, `machine-timer-rows` — each `defn-` private, consumed only by the slots being removed.
- **4 slots** from the `:machine` map → now `{:cascade …}` only.
- **`group-lifecycle-by-phase`** — orphaned by the `:lifecycle` slot removal (its sole caller was its own test; the cascade already carries `:phase` per-row). Same dead lineage, removed to fully complete the dead-code sweep.
- **dead `db-after` param** on `handler-row` (rf2-sp0n9 removed its last reader); 4-arg arity collapses to 3-arg, `:db-before` baseline retained. The unused `db-after` let-binding in `project` is dropped too.

## Zero-reader proof

`machine-transition-row` / `machine-guard-rows` / `machine-lifecycle-rows` / `machine-timer-rows` matched only: their own defns, the 4 deleted slot call-sites, and 2 test references (re-pointed). The view (`panels/epoch/view.cljs`) reads `(:cascade machine-row)` exclusively — no `(:transition/:guards/:lifecycle/:timers (:machine …))` anywhere. No subs, no production code, no other tool (trace_panel/wh33n, edn_inspector/nk7w0 are distinct files — no overlap).

## Tests

Re-pointed the affected projection + view tests at the equivalent `:cascade` rows (same per-row data keyed by `:kind`), preserving coverage rather than deleting it. The view-test fixture's stale dead-slot machine map updated to the `{:cascade []}` shape.

## Spec

Unchanged — the dropped slots were never documented (internal projection detail). `tools/xray/spec/021-Dynamic-Panel-Designs.md` already states the legacy category-grouped layout is REPLACED (not augmented) by the cascade.

## Gates (cold, local)

- `tools/xray` `clojure -M:test`: 1094 tests, 4560 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 5523 tests, 19177 assertions, 0 failures, 0 errors
- `npm run test:xray-feature-gate`: 16 scenarios, 0 failures, 13 matrix rows (proves the slots were truly dead at live-render; deep-machine + machine-epochs surfaces exercise the cascade); smoke tier exit 0
