### PR TITLE
docs(skills): genericize pair-retro known-frictions conformance-path reference (rf2-81wr7)

### DIFF
--- a/skills/re-frame2-pair-retro/references/known-frictions.md
+++ b/skills/re-frame2-pair-retro/references/known-frictions.md
@@ -135,7 +135,7 @@ Typical improvements:
 
 Signals:
 - the retrospective is unsure whether a tool the user "should have reached for" was actually exposed by the running re-frame2-pair-mcp build, or whether it was reasoning from stale docs
-- the session reasons about tool availability from `re-frame2-pair/references/ops.md` alone — that doc can drift from the live `tools.cljs` catalogue (the re-frame2-pair-mcp conformance corpus at `tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs` is the drift gate that pins each tool's wire shape, but it does not catch a recipe citing a tool that the running build never exposed)
+- the session reasons about tool availability from `re-frame2-pair/references/ops.md` alone — that doc can drift from the live tool catalogue the running re-frame2-pair-mcp server actually exposes (the build's pair-MCP conformance corpus — the test suite that pins each tool's wire shape against the Tool-Pair contract — is the drift gate, but it does not catch a recipe citing a tool that the running build never exposed; the authoritative live catalogue is whatever the attached server returns from `tools/list`)
 - a "why didn't they use tool X?" thread surfaces with no way to confirm X was actually callable in that session
 
 Typical improvements:


### PR DESCRIPTION
## What

`skills/re-frame2-pair-retro/references/known-frictions.md:138` cited a dev-repo-internal absolute path and file name as the tool-catalogue drift gate:

- `tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs`
- the dev-repo file name `tools.cljs`

A downstream consumer re-frame2 app has no such conformance corpus or path. Per the **skill-generic-to-any-app** posture, pair/pair-retro guidance must work on any consumer app, with repo-specifics as examples only.

## Fix (option (b) from rf2-81wr7)

Single-line edit. Replaced the path + dev-repo file name with the generic mechanism:

- The pair-MCP conformance corpus described as *the test suite that pins each tool's wire shape against the Tool-Pair contract* (no absolute path).
- The authoritative live catalogue named as *whatever the attached server returns from `tools/list`* — the mechanism a consumer's session actually has access to.

## Scope

`skills/re-frame2-pair-retro/references/known-frictions.md` only. No overlap with the recently-merged 1xk4l (which touched SKILL.md).

## Gates

- `git grep` confirms no `conformance_test` / `tools.cljs` / `tools/re-frame2-pair-mcp` references remain in the skill.
- Markdown well-formed: backticks balanced file-wide and on the edited line; bullet structure intact.
- No `check_skill_*` drift script exists for this skill; no other file links to the changed anchor, so no internal links break.

Closes rf2-81wr7.
