### PR TITLE
docs(schemas): align validate.cljc docstring with path-targeted-only sensitivity (rf2-xp3uh)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -49,13 +49,11 @@
 
   Per Spec 010 §`:sensitive?` — privacy in schema-validation error
   traces. The emit-sites redact the failing value before
-  stamping a trace event when either:
-    1. The schema slot at the failing path (or a containing slot)
-       carries `:sensitive? true` in its Malli props.
-    2. The surrounding registration metadata (handler-meta / cofx-meta /
-       sub-meta / fx-meta) carries `:sensitive? true` — applies to
-       every validation failure in that handler's scope as a coarse
-       fallback.
+  stamping a trace event when the schema slot at the failing path
+  (or a containing slot) carries `:sensitive? true` in its Malli
+  props. Sensitivity is path-marked at the schema slot only — the
+  removed handler-meta `:sensitive?` registration-metadata fallback
+  no longer applies (see the NOTE below).
   The substitution sentinel is `:rf/redacted` (the framework-reserved
   keyword per Spec 009 §Privacy). The trace event's `:tags`
   map is stamped with `:sensitive? true` so consumers can route on it


### PR DESCRIPTION
## What

Comment-only fix to `implementation/schemas/src/re_frame/schemas/validate.cljc`. The `run-validation` docstring still described a **two-condition** redaction trigger whose **condition #2** — a registration-metadata (handler-meta / cofx-meta / sub-meta / fx-meta) `:sensitive?` *coarse fallback* — was removed in the handler-meta `:sensitive?` removal thread (010 #2952, Security.md #2997, Spec-Schemas #3007). It directly contradicted the authoritative removal NOTE 40 lines below at `:96-100`.

This was the last residue of that removal thread (flagged by the rf2-xkqg6 worker, out of its docs scope).

## Change

Rewrote the docstring (lines 50-58) to describe the **single live path-targeted condition**: the emit-sites redact when the schema slot at the failing path (or a containing slot) carries `:sensitive? true` in its Malli props. Added a one-line pointer to the authoritative NOTE.

## Code unchanged — verified

The live code drives redaction **purely** from the schema walker:
- `run-validation` (`:262-275`): `sensitive? (and walk-schema? (walker/schema-has-sensitive? schema))` — `reg-meta` is consulted only for `(:schema reg-meta)`.
- app-db emit-site (`:385-410`): `walker/schema-sensitive-at?` / `walker/schema-has-sensitive?`.

`git grep` confirms no live code reads a `:sensitive?` key off registration metadata; the only other matches are the authoritative NOTE and the tests asserting the removal (`schemas_sensitive_test.clj` `event-validation-ignores-handler-meta-sensitive`, `cofx-validation-ignores-meta-sensitive`). **Zero code change** — diff is 5 insertions / 7 deletions, comment only.

## Gates (cold)

- schemas JVM suite: 227 tests / 18367 assertions — 0 failures, 0 errors
- CLJS suite (`npm run test:cljs`): 5525 tests / 19184 assertions — 0 failures, 0 errors

Closes rf2-xp3uh.
