### PR TITLE
refactor(xray): extract shared step-and-store body from the two sim handlers (rf2-7qbpn)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
@@ -104,6 +104,31 @@
         :exception   (ex-message e)
         :machines-on-classpath? false}})))
 
+(defn- step-and-store
+  "Fold ONE engine step against `machine-id`'s cloned sim snapshot and
+  store the advanced (or error-stamped) sim-state back into `db`. The
+  shared body behind both step entry-points — the Step button
+  (`:sim-step`) and the on-chart edge click (`:sim-chart-edge-clicked`).
+  The two handlers differ only in how they derive `event-v` (a raw event
+  vector vs an edge-click coercion); the step-and-store logic is
+  identical, so it lives here once.
+
+  No-op (returns `db` unchanged) when there's no sim-state for the
+  machine OR `event-v` is nil — the nil-`event-v` guard makes an inert
+  edge click safe (the edge-click coercion yields nil for non-fireable
+  auto edges)."
+  [db machine-id event-v]
+  (if-let [sim (and event-v
+                    (get-in db [:rf.xray.static.machines/sim-by-machine
+                                machine-id]))]
+    (let [runtime-fn (fn [ev]
+                       (run-machine-transition
+                         (:definition sim) (:snapshot sim) ev))
+          next-sim   (sim-h/step-sim sim event-v runtime-fn)]
+      (assoc-in db [:rf.xray.static.machines/sim-by-machine machine-id]
+        next-sim))
+    db))
+
 ;; ---- subscriptions ------------------------------------------------------
 
 (defn install-subs!
@@ -193,38 +218,23 @@
         db)))
 
   ;; Step the sim — fire one event against the cloned snapshot.
-  ;; `event` is a vector like `[:foo/bar {:x 1}]`.
+  ;; `event` is a vector like `[:foo/bar {:x 1}]`. The step-and-store
+  ;; body is shared with `:sim-chart-edge-clicked` via `step-and-store`.
   (rf/reg-event-db :rf.xray.static.machines/sim-step
     (fn [db [_ {:keys [machine-id event]}]]
-      (if-let [sim (get-in db [:rf.xray.static.machines/sim-by-machine
-                               machine-id])]
-        (let [runtime-fn (fn [ev]
-                           (run-machine-transition
-                             (:definition sim) (:snapshot sim) ev))
-              next-sim   (sim-h/step-sim sim event runtime-fn)]
-          (assoc-in db [:rf.xray.static.machines/sim-by-machine machine-id]
-            next-sim))
-        db)))
+      (step-and-store db machine-id event)))
 
   ;; rf2-u422r — on-chart edge click → step. The chart's clickable edge
   ;; hands us the raw fireable event-id; coerce it to a step event vector
   ;; and fold it through the SAME engine path as the step-button (no new
-  ;; transition logic — `step-sim` + `run-machine-transition` are reused).
-  ;; A nil/non-keyword event-id (an inert auto edge) is a no-op so the
+  ;; transition logic — `step-and-store` runs `step-sim` +
+  ;; `run-machine-transition`, identical to the button path). A
+  ;; nil/non-keyword event-id (an inert auto edge) coerces to nil, which
+  ;; `step-and-store`'s nil-`event-v` guard treats as a no-op so the
   ;; click never produces a malformed dispatch.
   (rf/reg-event-db :rf.xray.static.machines/sim-chart-edge-clicked
     (fn [db [_ {:keys [machine-id event-id]}]]
-      (let [sim     (get-in db [:rf.xray.static.machines/sim-by-machine
-                                machine-id])
-            event-v (sim-h/edge-click->event event-id)]
-        (if (and sim event-v)
-          (let [runtime-fn (fn [ev]
-                             (run-machine-transition
-                               (:definition sim) (:snapshot sim) ev))
-                next-sim   (sim-h/step-sim sim event-v runtime-fn)]
-            (assoc-in db [:rf.xray.static.machines/sim-by-machine machine-id]
-              next-sim))
-          db))))
+      (step-and-store db machine-id (sim-h/edge-click->event event-id))))
 
   ;; Update the pending event-input text (controlled-input).
   (rf/reg-event-db :rf.xray.static.machines/sim-set-pending-event


### PR DESCRIPTION
## Summary

Senior-dev review finding F7. The Static Machines Sim sub-mode's two step handlers — `:rf.xray.static.machines/sim-step` (Step button) and `:rf.xray.static.machines/sim-chart-edge-clicked` (on-chart edge click) — shared an identical step-and-store body: look up the per-machine sim-state, build the same `runtime-fn` closing over `run-machine-transition`, fold one `step-sim`, and `assoc-in` the result back into `db`. They differed only in how the event vector was derived (raw `event` vs `sim-h/edge-click->event` of the clicked edge's `event-id`) plus one nil guard.

This extracts a private `(step-and-store db machine-id event-v)` helper in `static/machines/sim.cljs`; both handlers now resolve `event-v` then delegate.

## Behaviour-preserving

The helper folds the nil guard in via `(if-let [sim (and event-v (get-in db ...))] ...)`:

- **`sim-step`** — `event` is always a non-nil vector (the UI only dispatches a parsed vector), so `(and event-v <get-in>)` reduces to the original `(if-let [sim (get-in ...)])`.
- **`sim-chart-edge-clicked`** — `edge-click->event` returns nil for an inert/non-fireable auto edge; the nil-`event-v` guard keeps that a no-op, identical to the original `(if (and sim event-v) ...)`.

The helper must live in `sim.cljs` (not the pure `.cljc` helpers) because it closes over the private `run-machine-transition`, which calls `rf/machine-transition` and is CLJS-only.

## Gates (cold)

- xray JVM `clojure -M:test` — 1096 tests / 4567 assertions / 0 failures
- `npm run test:cljs` — 5525 tests / 19184 assertions / 0 failures (includes every sim handler test: step OK/fail/throw, edge-click step/nil-noop/fail-guard, chart-binding subs)
- `npm run test:xray-feature-gate` — 16 scenarios / 0 failures (static-sim gated scenario green)

No render path changed (logic-only handler edit), so `test:browser` not required.

Closes rf2-7qbpn.