### PR TITLE
refactor(xray/epoch): move decode-malli-explain view→projection (rf2-plev0)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -2901,8 +2901,10 @@ resolves to the schema's source-coord, NOT the handler's:
 
 **Expected / got decomposition row.** When the row's `:explain`
 matches the canonical Malli shape (`{:errors [{:schema … :value …}
-…] :value <root>}`), `decode-malli-explain` extracts a tight
-two-line summary that renders ABOVE the humanized map:
+…] :value <root>}`), the projection's `decode-malli-explain` extracts
+a tight two-line summary and stamps it on the row's `:decoded` slot;
+the view reads that projected field and renders it ABOVE the humanized
+map:
 
 ```
 expected: [:map [:user :string]]

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -2270,13 +2270,55 @@
   #{:rf.error/schema-validation-failure
     :rf.schema/violation})
 
+(defn decode-malli-explain
+  "Decompose a Malli `explain` map into the at-a-glance summary the
+  bead body's §SCHEMA VIOLATION section asks for (rf2-zn6u5).
+
+  Returns `{:expected <schema-form> :got <value> :more-errors <int>}`
+  when `explain` carries the canonical Malli shape — `{:errors [{...}
+  ...] :value <root>}`. Returns `nil` otherwise (non-Malli validators,
+  pre-rf2-2ek7t framework, malformed input) so the caller can drop
+  the decomposition row cleanly.
+
+  - `:expected` reads the FIRST error's `:schema` slot (the schema
+    form that failed at the deepest path Malli reached).
+  - `:got` reads the first error's `:value` when present; falls back
+    to the explain map's root `:value`.
+  - `:more-errors` is `(count errors) - 1` so the call-site can paint
+    a `(+N more)` chip when more than one error rode in.
+
+  Pure data; JVM-testable. rf2-plev0 relocated this from the epoch
+  view (`view.cljs`) into the projection layer beside its sibling
+  `schema-violation-row` — `schema-violation-row` now stamps the
+  decoded summary onto each row's `:decoded` slot so the view
+  consumes projected data rather than computing the transform."
+  [explain]
+  (when (map? explain)
+    (let [errors (:errors explain)]
+      (when (and (sequential? errors) (seq errors))
+        (let [first-err (first errors)]
+          {:expected    (:schema first-err)
+           :got         (if (contains? first-err :value)
+                          (:value first-err)
+                          (:value explain))
+           :more-errors (max 0 (dec (count errors)))})))))
+
 (defn- schema-violation-row
   "Project one schema-violation trace event into the per-row data
   shape (rf2-17vxj). Empty / nil values are kept absent so the view
-  can elide slots cleanly."
+  can elide slots cleanly.
+
+  rf2-plev0 — the row carries a `:decoded` slot when the violation's
+  `:explain` is a canonical Malli explain map (`decode-malli-explain`
+  returns a summary). The view renders the `expected:` / `got:` /
+  `(+N more)` decomposition off this projected field; non-Malli /
+  malformed explains leave `:decoded` absent so the view drops the
+  block cleanly (the same nil-gate it used when it computed the
+  decode itself)."
   [ev]
-  (let [op-kw (op ev)
-        tags  (:tags ev)]
+  (let [op-kw   (op ev)
+        tags    (:tags ev)
+        decoded (decode-malli-explain (:explain tags))]
     (cond-> {:kind               op-kw
              :where              (or (:where tags)
                                      (when (= :rf.schema/violation op-kw) :hot-reload))
@@ -2297,6 +2339,11 @@
              :rollback?          (boolean (:rollback? tags))
              :recovery           (:recovery tags)
              :sensitive?         (boolean (:sensitive? tags))}
+      ;; rf2-plev0 / rf2-zn6u5 — the at-a-glance expected/got/+N-more
+      ;; decomposition, computed here so the view reads it off the row.
+      ;; Absent when the explain isn't a canonical Malli map.
+      (some? decoded)
+      (assoc :decoded decoded)
       (= :rf.schema/violation op-kw)
       (assoc :pre-reload-schema  (:pre-reload-schema tags)
              :post-reload-schema (:post-reload-schema tags)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -4987,34 +4987,12 @@
                     "See " link " for the new shape."]
        [:<> "Schema violation. " link " for details."])]))
 
-(defn decode-malli-explain
-  "Decompose a Malli `explain` map into the at-a-glance summary the
-  bead body's §SCHEMA VIOLATION section asks for (rf2-zn6u5).
-
-  Returns `{:expected <schema-form> :got <value> :more-errors <int>}`
-  when `explain` carries the canonical Malli shape — `{:errors [{...}
-  ...] :value <root>}`. Returns `nil` otherwise (non-Malli validators,
-  pre-rf2-2ek7t framework, malformed input) so the caller can drop
-  the decomposition row cleanly.
-
-  - `:expected` reads the FIRST error's `:schema` slot (the schema
-    form that failed at the deepest path Malli reached).
-  - `:got` reads the first error's `:value` when present; falls back
-    to the explain map's root `:value`.
-  - `:more-errors` is `(count errors) - 1` so the call-site can paint
-    a `(+N more)` chip when more than one error rode in.
-
-  Pure data; JVM-testable."
-  [explain]
-  (when (map? explain)
-    (let [errors (:errors explain)]
-      (when (and (sequential? errors) (seq errors))
-        (let [first-err (first errors)]
-          {:expected    (:schema first-err)
-           :got         (if (contains? first-err :value)
-                          (:value first-err)
-                          (:value explain))
-           :more-errors (max 0 (dec (count errors)))})))))
+;; rf2-plev0 — `decode-malli-explain` (the pure explain-map →
+;; {:expected :got :more-errors} transform) moved to the projection
+;; layer (`projection.cljc`, beside its sibling `schema-violation-row`).
+;; The projection now stamps the decoded summary onto each violation
+;; row's `:decoded` slot; `violation-block` below reads that projected
+;; field rather than computing the transform in the view.
 
 (defn violation-block
   "Render one schema-violation sub-block (rf2-2ek7t redesign,
@@ -5038,7 +5016,7 @@
   value, separate handler + schema 'open' buttons) all retired —
   subsumed by the prose + humanized explain."
   [step-key idx {:keys [where failing-id path rollback? recovery
-                        explain explain-humanized kind sensitive?]
+                        explain explain-humanized kind sensitive? decoded]
                  :as   _row}]
   (let [recovery-label  (violation-recovery-label where rollback? recovery)
         ;; The schema source-coord resolution varies by :where. For
@@ -5057,7 +5035,10 @@
                             (when failing-id
                               (violation-kind-coord :schema failing-id)))
         humanized-shown (or explain-humanized explain)
-        decoded         (decode-malli-explain explain)
+        ;; rf2-plev0 — `:decoded` (the expected/got/+N-more summary) is
+        ;; computed in the projection layer (`schema-violation-row`) and
+        ;; rides on the row; the view consumes it rather than running the
+        ;; decode itself.
         testid-base     (str "rf-xray-epoch-violation-"
                              (name (or step-key :unknown)) "-" idx)]
     [:div {:key (str "violation-" step-key "-" idx)
@@ -5080,14 +5061,16 @@
          recovery-label])]
      ;; 2. Prose sentence with inline schema link
      (violation-prose where schema-coord testid-base)
-     ;; 3. Expected / Got decomposition (rf2-zn6u5) — when the row's
-     ;; `:explain` carries the canonical Malli shape, surface the
-     ;; first error's `:schema` (expected) + `:value` (got) as
-     ;; programmer-friendly summary lines ABOVE the full humanized
-     ;; explain map. Multi-error explain maps gain a `(+N more)` chip
-     ;; so the operator sees the first-error-prominent summary the
-     ;; rf2-xgeag bead body designed. Drops out cleanly when
-     ;; `decode-malli-explain` returns nil (non-Malli validator).
+     ;; 3. Expected / Got decomposition (rf2-zn6u5) — the projection's
+     ;; `schema-violation-row` decoded the row's `:explain` (canonical
+     ;; Malli shape) into `:decoded {:expected :got :more-errors}` and
+     ;; stamped it on the row (rf2-plev0). Surface the first error's
+     ;; `:schema` (expected) + `:value` (got) as programmer-friendly
+     ;; summary lines ABOVE the full humanized explain map. Multi-error
+     ;; explain maps gain a `(+N more)` chip so the operator sees the
+     ;; first-error-prominent summary the rf2-xgeag bead body designed.
+     ;; Drops out cleanly when `:decoded` is absent (non-Malli validator —
+     ;; the projection's `decode-malli-explain` returned nil).
      (when decoded
        [:div {:data-testid (str testid-base "-decoded")
               :style schema-violation-explain-body-style}

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -2768,6 +2768,81 @@
         (is (= "not-an-int"         (:value r)))
         (is (= :logged-and-skipped  (:recovery r)))))))
 
+;; ---- rf2-zn6u5 / rf2-plev0 — Malli explain expected/got decomposition ----
+;;
+;; rf2-plev0 relocated `decode-malli-explain` (and these unit tests) from
+;; the epoch VIEW into the projection layer. The pure transform is data-in
+;; / data-out (no view/DOM deps), so it belongs beside its sibling
+;; `schema-violation-row` and now runs on the JVM `clojure -M:test` gate
+;; via this `.cljc` test ns rather than the node-runtime view-test ns.
+
+(deftest decode-malli-explain-returns-expected-got-test
+  (testing "rf2-zn6u5 — `decode-malli-explain` lifts the first error's
+            :schema + :value into a programmer-friendly summary map.
+            Pure data fn; JVM-testable."
+    (is (= {:expected :int :got "bad" :more-errors 0}
+           (proj/decode-malli-explain
+             {:schema :int
+              :value "bad"
+              :errors [{:path [] :in [] :schema :int :value "bad"}]})))))
+
+(deftest decode-malli-explain-falls-back-to-root-value-test
+  (testing "rf2-zn6u5 — when the first error does NOT carry :value
+            (the value rides on the explain map's root), :got reads
+            from `explain`'s `:value` slot."
+    (is (= {:expected :int :got 42 :more-errors 0}
+           (proj/decode-malli-explain
+             {:schema :int :value 42
+              :errors [{:path [] :schema :int}]})))))
+
+(deftest decode-malli-explain-counts-additional-errors-test
+  (testing "rf2-zn6u5 — multi-error explain maps surface
+            `:more-errors (- N 1)` so the call-site can paint a
+            `(+N more)` chip beneath the first-error summary."
+    (let [exp {:schema [:map [:a :int] [:b :int]]
+               :value {:a "x" :b "y"}
+               :errors [{:path [:a] :schema :int :value "x"}
+                        {:path [:b] :schema :int :value "y"}
+                        {:path [:c] :schema :int :value :extra}]}]
+      (is (= 2 (:more-errors (proj/decode-malli-explain exp)))
+          "explain with 3 errors → :more-errors 2"))))
+
+(deftest decode-malli-explain-non-malli-returns-nil-test
+  (testing "rf2-zn6u5 — non-Malli validators / pre-rf2-2ek7t framework
+            produce explain maps without the canonical {:errors [...]}
+            shape; the decoder degrades to nil so the view drops the
+            decomposition row cleanly."
+    (is (nil? (proj/decode-malli-explain nil)))
+    (is (nil? (proj/decode-malli-explain {})))
+    (is (nil? (proj/decode-malli-explain {:errors []})))
+    (is (nil? (proj/decode-malli-explain {:errors :not-a-vec})))
+    (is (nil? (proj/decode-malli-explain "not a map")))))
+
+(deftest schema-violation-row-stamps-decoded-test
+  (testing "rf2-plev0 — `schema-violation-rows` stamps the projected
+            `:decoded {:expected :got :more-errors}` summary onto a row
+            whose `:explain` is a canonical Malli map, and omits the
+            slot when the explain is non-Malli / absent (so the view's
+            decomposition block drops cleanly)."
+    (let [malli-row (first
+                      (proj/schema-violation-rows
+                        [(schema-violation-ev :app-db :counter/inc [:count]
+                                              "not-an-int" true
+                                              {:schema :int
+                                               :value "not-an-int"
+                                               :errors [{:path [:count]
+                                                         :schema :int
+                                                         :value "not-an-int"}]})]))
+          plain-row (first
+                      (proj/schema-violation-rows
+                        [(schema-violation-ev :app-db :counter/inc [:count]
+                                              "not-an-int" true)]))]
+      (is (= {:expected :int :got "not-an-int" :more-errors 0}
+             (:decoded malli-row))
+          "canonical Malli explain → :decoded summary stamped on the row")
+      (is (not (contains? plain-row :decoded))
+          "no explain → :decoded slot omitted (view drops the block)"))))
+
 ;; `hot-reload-step-conditional-test` retired in rf2-7gf7v
 ;; (commit 9b96f9f6a — `refactor(xray/epoch): retire SCHEMA HOT-RELOAD
 ;; pipeline step + rollback chip wording`). Hot-reload drift is a

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -16,6 +16,7 @@
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.theme.tokens :as tokens]
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.panels.epoch.view :as view]
             [day8.re-frame2-xray.panels.epoch-panel :as epoch-orchestrator]))
 
@@ -2770,63 +2771,32 @@
             attribution)")))))
 
 ;; ---- rf2-zn6u5 — schema-violation Malli expected/got decomposition -------
-
-(deftest decode-malli-explain-returns-expected-got-test
-  (testing "rf2-zn6u5 — `decode-malli-explain` lifts the first error's
-            :schema + :value into a programmer-friendly summary map.
-            Pure data fn; JVM-testable."
-    (is (= {:expected :int :got "bad" :more-errors 0}
-           (view/decode-malli-explain
-             {:schema :int
-              :value "bad"
-              :errors [{:path [] :in [] :schema :int :value "bad"}]})))))
-
-(deftest decode-malli-explain-falls-back-to-root-value-test
-  (testing "rf2-zn6u5 — when the first error does NOT carry :value
-            (the value rides on the explain map's root), :got reads
-            from `explain`'s `:value` slot."
-    (is (= {:expected :int :got 42 :more-errors 0}
-           (view/decode-malli-explain
-             {:schema :int :value 42
-              :errors [{:path [] :schema :int}]})))))
-
-(deftest decode-malli-explain-counts-additional-errors-test
-  (testing "rf2-zn6u5 — multi-error explain maps surface
-            `:more-errors (- N 1)` so the call-site can paint a
-            `(+N more)` chip beneath the first-error summary."
-    (let [exp {:schema [:map [:a :int] [:b :int]]
-               :value {:a "x" :b "y"}
-               :errors [{:path [:a] :schema :int :value "x"}
-                        {:path [:b] :schema :int :value "y"}
-                        {:path [:c] :schema :int :value :extra}]}]
-      (is (= 2 (:more-errors (view/decode-malli-explain exp)))
-          "explain with 3 errors → :more-errors 2"))))
-
-(deftest decode-malli-explain-non-malli-returns-nil-test
-  (testing "rf2-zn6u5 — non-Malli validators / pre-rf2-2ek7t framework
-            produce explain maps without the canonical {:errors [...]}
-            shape; the decoder degrades to nil so the view drops the
-            decomposition row cleanly."
-    (is (nil? (view/decode-malli-explain nil)))
-    (is (nil? (view/decode-malli-explain {})))
-    (is (nil? (view/decode-malli-explain {:errors []})))
-    (is (nil? (view/decode-malli-explain {:errors :not-a-vec})))
-    (is (nil? (view/decode-malli-explain "not a map")))))
+;;
+;; rf2-plev0 — the pure `decode-malli-explain` transform + its unit tests
+;; moved to the projection layer (`projection.cljc` /
+;; `projection_cljs_test.cljc`). The projection's `schema-violation-row`
+;; now stamps the decoded summary onto each row's `:decoded` slot. The
+;; view-render tests below exercise `violation-block` against PROJECTED
+;; rows — they stamp `:decoded` via `proj/decode-malli-explain` so the
+;; fixture mirrors the real projected shape the view consumes.
 
 (deftest violation-block-renders-expected-got-summary-test
-  (testing "rf2-zn6u5 — when a violation's :explain carries Malli's
-            canonical shape, the sub-block paints `expected:` + `got:`
+  (testing "rf2-zn6u5 / rf2-plev0 — when a violation's row carries the
+            projected `:decoded` summary (from a canonical Malli
+            `:explain`), the sub-block paints `expected:` + `got:`
             summary lines via `ei/mini` ABOVE the full humanized
             explain map render."
-    (let [row {:kind :rf.error/schema-validation-failure
+    (let [explain {:schema :int
+                   :value "not-an-int"
+                   :errors [{:path [:count] :schema :int
+                             :value "not-an-int"}]}
+          row {:kind :rf.error/schema-validation-failure
                :where :app-db
                :failing-id :counter/inc
                :path [:count]
                :value "not-an-int"
-               :explain {:schema :int
-                         :value "not-an-int"
-                         :errors [{:path [:count] :schema :int
-                                   :value "not-an-int"}]}
+               :explain explain
+               :decoded (proj/decode-malli-explain explain)
                :explain-humanized {:errors ["must be int"]}
                :rollback? true
                :sensitive? false}
@@ -2842,15 +2812,18 @@
             "got line renders the failing value via ei/mini")))))
 
 (deftest violation-block-multi-error-paints-more-chip-test
-  (testing "rf2-zn6u5 — multi-error explain maps surface a
-            `(+N more)` chip below the first-error summary."
-    (let [row {:where :app-db
+  (testing "rf2-zn6u5 / rf2-plev0 — multi-error explain maps surface a
+            `(+N more)` chip below the first-error summary (read off the
+            projected `:decoded` summary)."
+    (let [explain {:schema [:map [:a :int] [:b :int]]
+                   :value {:a "x" :b "y"}
+                   :errors [{:path [:a] :schema :int :value "x"}
+                            {:path [:b] :schema :int :value "y"}]}
+          row {:where :app-db
                :failing-id :user/profile
                :path [:user]
-               :explain {:schema [:map [:a :int] [:b :int]]
-                         :value {:a "x" :b "y"}
-                         :errors [{:path [:a] :schema :int :value "x"}
-                                  {:path [:b] :schema :int :value "y"}]}}
+               :explain explain
+               :decoded (proj/decode-malli-explain explain)}
           tree (view/violation-block :handler 0 row)
           chip-text (text-of tree "rf-xray-epoch-violation-handler-0-more-errors")]
       (is (some? chip-text))

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/trace_event_builders.cljc
@@ -458,16 +458,23 @@
   `:app-db / :cofx / :sub-return / :fx-args`). Drives the SCHEMA
   VIOLATIONS step.
 
-  4-arg form omits the rollback flag; 5-arg form stamps it."
+  4-arg form omits the rollback flag; 5-arg form stamps it; 6-arg form
+  additionally carries a Malli `:explain` map (rf2-plev0 — the
+  projection's `schema-violation-row` decodes it into the `:decoded`
+  expected/got summary, mirroring the substrate emit shape that stamps
+  `:explain`)."
   ([where failing-id path value]
    (schema-violation-ev where failing-id path value nil))
   ([where failing-id path value rollback?]
+   (schema-violation-ev where failing-id path value rollback? nil))
+  ([where failing-id path value rollback? explain]
    (ev :error :rf.error/schema-validation-failure
        (cond-> {:where      where
                 :failing-id failing-id
                 :path       path
                 :value      value}
-         (some? rollback?) (assoc :rollback? rollback?)))))
+         (some? rollback?) (assoc :rollback? rollback?)
+         (some? explain)   (assoc :explain explain)))))
 
 (defn schema-hot-reload-ev
   "`:rf.schema/violation` trace (rf2-17vxj) — the hot-reload drift


### PR DESCRIPTION
## What

Senior-dev review finding F4 (rf2-plev0): `decode-malli-explain` — a pure `explain-map → {:expected :got :more-errors}` transform whose own docstring claims "Pure data; JVM-testable" — was the one pure projection helper that leaked into the `.cljs` epoch **view**, where it was tested through the view on the node runtime rather than on the JVM-testable `.cljc` projection ns where its sibling `schema-violation-rows` lives.

This relocates the transform to the projection layer so the view consumes projected data instead of computing it.

## Changes

- **`panels/epoch/projection.cljc`** — added `decode-malli-explain` (verbatim, confirmed pure — no view/DOM deps) beside `schema-violation-row`. `schema-violation-row` now decodes the row's `:explain` and stamps the result on a new `:decoded` slot (omitted when the explain is non-Malli/absent, preserving the view's nil-gate).
- **`panels/epoch/view.cljs`** — removed the `decode-malli-explain` defn; `violation-block` now reads `:decoded` off the destructured row instead of running the decode. Behaviour-preserving.
- **`panels/epoch/projection_cljs_test.cljc`** — the 4 `decode-malli-explain-*` unit tests moved here (retargeted `view/` → `proj/`) so they run on the JVM `clojure -M:test` gate; plus a round-trip test asserting `schema-violation-rows` stamps `:decoded`.
- **`panels/epoch/view_cljs_test.cljs`** — the two `violation-block` *render* tests stay (they exercise the view) but build their fixtures through `proj/decode-malli-explain` to mirror the real projected row shape.
- **`test_helpers/trace_event_builders.cljc`** — `schema-violation-ev` gains a 6-arg `:explain` form (mirrors the substrate emit shape).
- **`spec/021-Dynamic-Panel-Designs.md`** — names the projection layer + `:decoded` slot. Internal layering only; no contract change.

## Spec currency

Spec touched only to name the layer accurately — no contract change (internal layering move per xray-spec-currency).

## Gates (cold, in worktree)

- `clojure -M:test` (xray JVM): 1100 tests / 4574 assertions, 0 failures — the moved tests now run on the JVM gate
- `npm run test:cljs`: 5525 / 19183, 0 failures
- `npm run test:xray-feature-gate`: 16 scenarios / 13 matrix rows, 0 failures
- `npm run test:browser`: 151 / 443, 0 failures — proves the decoded explain still renders identically via the epoch view render path

Closes rf2-plev0.