### PR TITLE
docs(machines-viz): correct 000-Vision chart contract to no-:frame-id (rf2-pgf5i)

### DIFF
--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -229,8 +229,11 @@ must tell."
 `tools/xray/` and `tools/story/` both depend on
 `tools/machines-viz/`. The arrow does not invert. Machines-Viz
 does not know about Xray's chrome or Story's variant runtime —
-it only knows it has a `:machine-id`, a `:frame-id`, and two
-callbacks the host wired.
+the chart is presentation-only, so it only knows the
+`:machine-id`, `:definition`, and `:current-state` the host pulled
+and passed in, plus the two callbacks the host wired. It takes no
+`:frame-id` (that survives only as share-envelope payload
+provenance, [`API.md`](./API.md) §ShareEnvelope).
 
 ## Surface set
 


### PR DESCRIPTION
Follow-up to ewirq/#3013 (out of its DESIGN-RATIONALE + Principles scope).

`tools/machines-viz/spec/000-Vision.md:232` said the chart "only knows it has a `:machine-id`, a `:frame-id`, and two callbacks" — the same stale claim ewirq fixed in DESIGN-RATIONALE.md and Principles.md.

The shipped chart (`chart.cljs` `MachineChart`) is **presentation-only**: it takes `:machine-id` / `:definition` / `:current-state` plus `:on-state-click` / `:on-edge-click`, and **no `:frame-id`**. `:frame-id` survives only as share-envelope payload provenance (per API.md §ShareEnvelope — the registered machine's frame at share time, not a chart prop).

This corrects 000-Vision to match the shipped chart and the now-merged DESIGN-RATIONALE / Principles fix.

**Scope:** `tools/machines-viz/spec/000-Vision.md` only. Docs.
**Gates:** grep confirms 000-Vision no longer claims the chart "knows :frame-id" (sole remaining `:frame-id` mention explicitly states the chart takes none). mkdocs `--strict` N/A — machines-viz spec is not in the docs nav.

Closes rf2-pgf5i.