### PR TITLE
fix(machines-viz): derive elk container padding from density constants (rf2-8q5pt)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -268,12 +268,18 @@
   Feeding edges INTO elk (alongside the spacing + label-placement keys in
   `default-elk-options`) is what makes elk's Layered algorithm route the
   edges AROUND node boxes instead of the renderer drawing geometric paths
-  that cut across states."
-  [parsed direction layout-options measured-dims]
+  that cut across states.
+
+  rf2-8q5pt — `chart-vc` (the resolved density map from
+  `vc/chart-for-density`) is forwarded to `projection/->elk-children` so
+  each container's `elk.padding` tracks the active density's title-strip
+  + body-pad constants (was a regular-only literal). nil falls back to
+  the regular density inside the projection."
+  [parsed direction layout-options measured-dims chart-vc]
   #js {:id "root"
        :layoutOptions (clj->js (elk-layout-options parsed layout-options
                                                    direction))
-       :children (clj->js (projection/->elk-children parsed measured-dims))
+       :children (clj->js (projection/->elk-children parsed measured-dims chart-vc))
        ;; rf2-rlq97 — edge-label dims share the `measured-dims` map (it is
        ;; keyed by elk-edge-id for any labelled edge); under events-as-nodes
        ;; the transition text is on the event-node so this is normally a
@@ -554,15 +560,22 @@
   `{node-id {:width :height}}` map of xyflow's reported rendered boxes),
   fed into `->elk-input` so the second (relayout) pass sizes each node
   to its real box. The shorter arities pass nil (first pass / unit
-  tests) — identical to the pre-rf2-d9ro2 single-pass."
+  tests) — identical to the pre-rf2-d9ro2 single-pass.
+
+  rf2-8q5pt — the longest arity also takes `chart-vc` (the resolved
+  density map from `vc/chart-for-density`), fed into `->elk-input` so
+  container `elk.padding` tracks the active density. The shorter arities
+  pass nil → the projection falls back to the regular density."
   ([parsed done-fn]
-   (compute-layout! parsed :tb nil nil nil done-fn))
+   (compute-layout! parsed :tb nil nil nil nil done-fn))
   ([parsed direction layout-options done-fn]
-   (compute-layout! parsed direction layout-options nil nil done-fn))
+   (compute-layout! parsed direction layout-options nil nil nil done-fn))
   ([parsed direction layout-options machine-id done-fn]
-   (compute-layout! parsed direction layout-options machine-id nil done-fn))
+   (compute-layout! parsed direction layout-options machine-id nil nil done-fn))
   ([parsed direction layout-options machine-id measured-dims done-fn]
-   (let [input  (->elk-input parsed direction layout-options measured-dims)
+   (compute-layout! parsed direction layout-options machine-id measured-dims nil done-fn))
+  ([parsed direction layout-options machine-id measured-dims chart-vc done-fn]
+   (let [input  (->elk-input parsed direction layout-options measured-dims chart-vc)
          handle (fn handle-error [e]
                   (report-layout-error! e parsed direction layout-options
                                         machine-id)
@@ -1019,11 +1032,21 @@
             n-states   (count (remove :region? (:nodes parsed)))
             n-regions  (count (filter :region? (:nodes parsed)))
             n-trans    (count (:edges parsed))
+            ;; rf2-8q5pt — resolve the density map ONCE so the ELK pass
+            ;; sizes container `elk.padding` from the active density's
+            ;; title-strip + body-pad constants (was a regular-only
+            ;; literal). `chart-for-density` maps nil → regular and throws
+            ;; on an unknown density (same total resolution the render body
+            ;; does for `chart-vc` at L1177).
+            elk-vc     (vc/chart-for-density density)
             ;; Trigger an elk layout pass when the (definition,
-            ;; direction, layout-options) tuple changes. Keep the
+            ;; direction, layout-options, density) tuple changes. Keep the
             ;; previous positions during in-flight layout to avoid an
-            ;; empty-chart flash.
-            this-key   [definition direction layout-options]
+            ;; empty-chart flash. rf2-8q5pt — `density` joins the key so a
+            ;; density switch (which changes the derived container padding)
+            ;; re-runs ELK rather than rendering the topology with the prior
+            ;; density's header gaps.
+            this-key   [definition direction layout-options density]
             ;; rf2-d9ro2 — one ELK pass. `measured-dims` is nil on the
             ;; FIRST pass (nodes not yet rendered/measured) and the
             ;; xyflow-measured `{node-id {:width :height}}` map on the
@@ -1032,7 +1055,7 @@
             run-layout!
             (fn [measured-dims]
               (compute-layout!
-                parsed direction layout-options machine-id measured-dims
+                parsed direction layout-options machine-id measured-dims elk-vc
                 (fn [result]
                   (when result
                     (reset! layout-state result)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -260,6 +260,32 @@
                      :else              1))
            state-nodes))
 
+(defn container-elk-padding
+  "rf2-8q5pt — the `elk.padding` string for a compound / region container,
+  derived from the active density's `visual-constants` rather than a
+  hardcoded literal.
+
+  The container reserves:
+
+    - TOP   = `:container-title-height` (the solid title strip the
+              `compound-node` paints) PLUS a `:container-body-pad` band
+              so the metadata row (compound tags / entry-exit rows) and
+              the first child clear the header;
+    - LEFT / RIGHT / BOTTOM = `:container-body-pad` — the same inset the
+              container chrome leaves around its children below the strip.
+
+  Both keys are density-dependent (`chart-{compact,regular,cosy}`), so a
+  fixed literal reserved the wrong header gap in the non-regular
+  densities (children crowded the strip in `:cosy`, over-spaced it in
+  `:compact`). Pass the resolved density map (`vc/chart-for-density`);
+  defaults to `vc/chart` (regular) so the nil-arity stays stable."
+  ([] (container-elk-padding vc/chart))
+  ([{:keys [container-title-height container-body-pad]}]
+   (str "[top="   (+ container-title-height container-body-pad)
+        ",left="  container-body-pad
+        ",bottom=" container-body-pad
+        ",right=" container-body-pad "]")))
+
 (defn ->elk-children
   "Project parsed nodes + parsed edges into elk.js's `children` shape.
 
@@ -286,10 +312,19 @@
   `chart.cljs`'s measure-then-relayout pass) is forwarded to every
   `elk-child` / `elk-event-child` so leaf states + event-nodes lay out
   at their REAL rendered box rather than the fixed floor. nil / empty on
-  the first pass — identical to the pre-rf2-d9ro2 single-pass."
-  ([parsed] (->elk-children parsed nil))
-  ([{:keys [nodes edges]} measured-dims]
-  (let [node-by-id (into {} (map (juxt :id identity)) nodes)
+  the first pass — identical to the pre-rf2-d9ro2 single-pass.
+
+  rf2-8q5pt — the optional `chart-vc` (the resolved density map from
+  `vc/chart-for-density`, threaded by `chart.cljs` alongside
+  `measured-dims`) sizes each container's `elk.padding` from the active
+  density's title-strip + body-pad constants via `container-elk-padding`,
+  rather than a regular-only literal. nil falls back to `vc/chart`
+  (regular)."
+  ([parsed] (->elk-children parsed nil nil))
+  ([parsed measured-dims] (->elk-children parsed measured-dims nil))
+  ([{:keys [nodes edges]} measured-dims chart-vc]
+  (let [container-pad (container-elk-padding (or chart-vc vc/chart))
+        node-by-id (into {} (map (juxt :id identity)) nodes)
         ;; The event-node's parent container == the source state's
         ;; parent. Top-level when the source has no `:parent-id`.
         event-children
@@ -319,14 +354,17 @@
                                                     ;; before handing to elk.
                                                     (dissoc k ::event-parent)
                                                     (build k)))))
-                           ;; rf2-az6e2 — the container top padding clears
-                           ;; the solid title strip (26px regular) PLUS a
-                           ;; metadata band for compound tags / entry-exit
-                           ;; rows, so children never collide with the
-                           ;; header. Side/bottom padding tracks the
-                           ;; `:container-body-pad` inset.
+                           ;; rf2-az6e2 / rf2-8q5pt — the container top
+                           ;; padding clears the solid title strip PLUS a
+                           ;; body-pad band (metadata row for compound tags
+                           ;; / entry-exit rows), so children never collide
+                           ;; with the header; side/bottom track the
+                           ;; `:container-body-pad` inset. Density-derived
+                           ;; via `container-elk-padding` (was a regular-only
+                           ;; literal `top=44,…16` — wrong gap in
+                           ;; compact/cosy).
                            :layoutOptions {"elk.algorithm" "layered"
-                                           "elk.padding"   "[top=44,left=16,bottom=16,right=16]"}))))
+                                           "elk.padding"   container-pad}))))
         ;; rf2-ly51l — top-level model order: initial state first,
         ;; machine-root annotation last (see `order-state-children`).
         top-state-children (mapv build (order-state-children

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -1030,6 +1030,58 @@
       (is (every? #(re-find #"top=" (get-in % [:layoutOptions "elk.padding"]))
                   children)))))
 
+;; ---- rf2-8q5pt: container elk.padding is density-derived ----------------
+;;
+;; The bug: the container `elk.padding` was a regular-only literal
+;; `[top=44,left=16,bottom=16,right=16]`. But `:container-title-height`
+;; and `:container-body-pad` are density-dependent, so compact/cosy
+;; reserved the wrong header gap (children crowded or over-spaced the
+;; title strip). The fix derives every side from the active density's
+;; constants via `container-elk-padding`; these pins make the drift
+;; visible to CI (the old "top= is merely present" assertion above could
+;; not see it).
+
+(deftest container-elk-padding-derives-from-density-constants
+  (testing "rf2-8q5pt — top clears the title strip PLUS a body-pad band;
+            sides are the body-pad inset, all density-derived"
+    (doseq [[density vc-map] [[:compact vc/chart-compact]
+                              [:regular vc/chart-regular]
+                              [:cosy    vc/chart-cosy]]]
+      (let [{:keys [container-title-height container-body-pad]} vc-map
+            expected (str "[top="    (+ container-title-height container-body-pad)
+                          ",left="   container-body-pad
+                          ",bottom=" container-body-pad
+                          ",right="  container-body-pad "]")]
+        (is (= expected (projection/container-elk-padding vc-map))
+            (str "padding tracks the " density " density constants"))))))
+
+(deftest container-elk-padding-defaults-to-regular
+  (testing "rf2-8q5pt — the nil-arity (and a nil chart-vc) fall back to
+            the regular density"
+    (is (= (projection/container-elk-padding vc/chart-regular)
+           (projection/container-elk-padding)))
+    ;; Regular: title strip 26 + body-pad 14 = 40 top; 14 on each side.
+    (is (= "[top=40,left=14,bottom=14,right=14]"
+           (projection/container-elk-padding vc/chart-regular)))))
+
+(deftest elk-children-padding-tracks-threaded-density
+  (testing "rf2-8q5pt — `->elk-children` threads `chart-vc` into every
+            container's elk.padding so a compact chart reserves a SMALLER
+            header gap than a cosy chart (was a fixed literal for both)"
+    (let [parsed       (layout/parse-definition parallel-machine)
+          compact-kids (projection/->elk-children parsed nil vc/chart-compact)
+          cosy-kids    (projection/->elk-children parsed nil vc/chart-cosy)
+          pad-of       (fn [child] (get-in child [:layoutOptions "elk.padding"]))]
+      (is (every? #(= (projection/container-elk-padding vc/chart-compact) (pad-of %))
+                  compact-kids)
+          "compact containers use the compact-density padding")
+      (is (every? #(= (projection/container-elk-padding vc/chart-cosy) (pad-of %))
+                  cosy-kids)
+          "cosy containers use the cosy-density padding")
+      (is (not= (projection/container-elk-padding vc/chart-compact)
+                (projection/container-elk-padding vc/chart-cosy))
+          "the two densities reserve genuinely different gaps"))))
+
 ;; ---- measure-then-relayout: ELK sizes to the real box (rf2-d9ro2) -------
 ;;
 ;; The bug: ELK was fed CONSTANT floor dimensions, never the real


### PR DESCRIPTION
## What

The compound/region container `elk.padding` in `chart/projection.cljc` was a regular-only literal `[top=44,left=16,bottom=16,right=16]`. But `:container-title-height` and `:container-body-pad` are density-dependent (compact 22/11, regular 26/14, cosy 30/18), so compact/cosy charts reserved the wrong header gap — children over-spaced the title strip in compact and crowded it in cosy. The only test asserted that `top=` was merely *present*, so the drift was invisible to CI (senior-dev review finding F3).

## Fix

- **`projection/container-elk-padding`** (new pure helper) derives the padding from the active density: `top = :container-title-height + :container-body-pad` (title strip + a body-pad band so the metadata row clears the header); `left/right/bottom = :container-body-pad` (the inset the container chrome already leaves below the strip). Defaults to `vc/chart` (regular).
- **Threading.** `chart-vc` (the resolved density map) threads through `->elk-children` (new optional 3rd arg) → `->elk-input` → `compute-layout!` (new optional `chart-vc` on the longest arity; shorter arities pass nil → regular fallback). The `MachineChart` component resolves it once via `vc/chart-for-density` and adds `density` to the layout-key so a density switch re-runs ELK with the correct gaps (previously the key was `[definition direction layout-options]` — a density switch alone would not re-layout).
- **Tests.** Replaced the present-only assertion with density-tracking pins: per-density derivation, the regular default (`top=40,sides=14`), and `->elk-children` forwarding compact vs cosy padding distinctly.

## Layout-at-default-density note

This is the **intentional-adjustment** path the bead allowed. At regular the derived padding is `top=40 / sides=14` (vs the hand-tuned `44 / 16`). The old literals over-reserved at regular and, more importantly, were materially wrong at the other densities; the side literal `16` did not even match its own comment's stated `:container-body-pad` (14). Deriving from the constants brings every density into alignment with the az6e2 title-strip grammar. ELK re-flows to the (slightly tighter, correct) gaps; the relayout + auto-fit lifecycle re-frames the topology.

## Overlap flag

This touches chart-area files. The HELD machines-viz decisions **rf2-34ff3** (click-contract) and **rf2-dt5b1** (edge/constants cleanup) also target chart-area files but are NOT running. This change is isolated to the ELK container padding (projection + the layout-threading in `chart.cljs`), disjoint from click-wiring/collapse. A future 34ff3/dt5b1 dispatch should sequence after this merges.

## Spec note

machines-viz spec docs (`001-Topology-Parity.md`, `API.md`) describe the `compute-layout! → ->elk-input → ->elk-children` threading chain conceptually and do not pin the literal padding value or exact arity; that chain is preserved (`chart-vc` threads alongside `measured-dims`), so the spec text remains accurate — no spec change needed.

## Gates (cold, all green)

- machines-viz JVM `clojure -M:test` — 337 tests / 947 assertions, 0 failures
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures, 13 matrix rows
- `npm run test:browser` — 151 tests / 443 assertions, 0 failures, 0 errors

Closes rf2-8q5pt.