### PR TITLE
fix(machines-viz): widen share :snapshot to a state configuration (rf2-9l8h8)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1301,9 +1301,10 @@ https://acme.example.com/path/to/viewer.html#machine=<base64-edn>
   - `:machine-id` from the payload's `:chart-state` (per
     [§Share-URL payload schema](#share-url-payload-schema)).
   - `:definition` from the payload's `:definition`.
-  - `:current-state` set to the payload snapshot's `:state` keyword
-    (the share schema carries the state name only; there is no
-    runtime `:data` to render).
+  - `:current-state` set to the payload snapshot's `:state`
+    configuration — a flat keyword, a compound vector-path, or a
+    parallel region-map (the share schema carries the state
+    configuration only; there is no runtime `:data` to render).
   - `:read-only?` set to `true`, which no-op's `:on-state-click`.
   - The `:overlays` slot left unset (`nil`) — a static share has no
     live trace bus to project the host-fed overlay descriptors from.
@@ -1358,10 +1359,15 @@ Source: lifted from
 [§Share-URL payload schema](#share-url-payload-schema) below. The
 encoder:
 
-1. Validates `chart-state` against the schema. Anything outside the
-   allowlist is silently dropped — including runtime `:data` on
-   `:snapshot` and any `:source-coords` the caller passes (per
-   [Principles §No session data in shares](./Principles.md)).
+1. Allowlists `chart-state` (anything outside the allowlist is
+   silently dropped — including runtime `:data` on `:snapshot` and any
+   `:source-coords` the caller passes, per
+   [Principles §No session data in shares](./Principles.md)), then
+   validates the allowlisted result against the schema with the **same**
+   predicate the decoder uses. Encode and decode are therefore symmetric:
+   the encoder rejects (with `:invalid-chart-state`) anything the decoder
+   could not accept — e.g. a `:snapshot` `:state` that is none of the
+   three configuration arms — rather than emitting an undecodable URL.
 2. Strips metadata off `:definition` (registered definitions carry
    source-coord meta per Spec 001; that meta must not propagate
    into the share payload).
@@ -1405,8 +1411,8 @@ Per [DESIGN-RATIONALE Lock #3](./DESIGN-RATIONALE.md).
 Share URLs are **viewer-side artefacts** — they exist solely to let
 a remote recipient render the chart. The schema is deliberately
 narrow: it carries the machine topology and the active-state
-**name** for visual continuity, and nothing else. Two classes of
-data are structurally excluded:
+**configuration** (its name/address) for visual continuity, and
+nothing else. Two classes of data are structurally excluded:
 
 - **Runtime `:data`** — the machine's per-snapshot data value is
   not part of the share payload. A well-intentioned operator
@@ -1429,23 +1435,46 @@ data are structurally excluded:
    [:rf.machines-viz.share/chart  ChartState]
    [:rf.machines-viz.share/created :int]])   ;; wall-clock ms at encode time
 
+;; A snapshot `:state` is a STATE CONFIGURATION — one of the three
+;; Spec 005 §Snapshot-shape arms (the same arms `MachineChart`
+;; `:current-state` accepts). Vector paths + region-maps are state
+;; names/addresses, NOT runtime data.
+(def SnapshotState
+  [:or
+   keyword?                              ;; flat machine        — :idle
+   [:and vector? [:sequential {:min 1} keyword?]] ;; compound machine    — [:auth :authing]
+   [:map-of keyword?                     ;; parallel machine    — {:data :loading
+    [:or keyword?                        ;;                         :form [:edit :dirty]}
+     [:and vector? [:sequential {:min 1} keyword?]]]]])
+
 (def ChartState
   [:map
    [:machine-id  keyword?]              ;; the registered machine's id
    [:frame-id    keyword?]              ;; the registered machine's frame
    [:definition  MachineDefinition]     ;; the topology (states, transitions, guards, actions, :spawn, :spawn-all, :after)
-   [:snapshot   {:optional true}        ;; the current-state name at share time — name ONLY, no :data
+   [:snapshot   {:optional true}        ;; the current-state configuration at share time — state CONFIGURATION only; no runtime data
     [:map {:closed true}
-     [:state    keyword?]]]])           ;; the registered state-id; nothing else permitted in :snapshot
+     [:state    SnapshotState]]]])      ;; the active state name/address; nothing else permitted in :snapshot
 ```
 
 The `:snapshot` map is `{:closed true}` and carries `:state` only.
-Runtime `:data` is structurally absent from the share payload; the
-encoder neither reads nor serialises it. The decoder rejects any
-`:snapshot` carrying additional keys with `:invalid-chart-state`.
-The viewer page mounts `MachineChart` with `:current-state` set to the
-snapshot's `:state` keyword (there is no runtime `:data` to render);
-the chart highlights the state node without any data-driven affordance.
+Its `:state` value is a **state configuration** — a flat keyword, a
+compound vector-path, or a parallel region-map (the three Spec 005
+§Snapshot-shape arms) — so a compound or parallel machine's active
+configuration shares + round-trips intact. Vector paths and region-maps
+are state names/addresses, **not** runtime data. Runtime `:data` is
+structurally absent from the share payload; the encoder neither reads
+nor serialises it. **Encode and decode validate the same schema** (the
+encoder validates the allowlisted chart state — including the snapshot
+shape — *before* serialising), so the two stay symmetric: the encoder
+never emits a payload the decoder would reject, and a malformed `:state`
+(none of the three configuration arms) is rejected at encode rather than
+producing an undecodable URL. The decoder rejects any `:snapshot`
+carrying additional keys, or a `:state` outside the three arms, with
+`:invalid-chart-state`. The viewer page mounts `MachineChart` with
+`:current-state` set to the snapshot's `:state` configuration (there is
+no runtime `:data` to render); the chart highlights every active leaf
+without any data-driven affordance.
 (`:frame-id` is a payload provenance field — the registered machine's
 frame at share time — not a `MachineChart` prop: the viewer hands the
 chart the `:definition` directly rather than resolving a frame.)

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -328,17 +328,34 @@ framework ships its `re-frame.machines` public API.
 
 ---
 
-## Lock #5 — Current-state in share-URL: state name only, no `:data`
+## Lock #5 — Current-state in share-URL: state configuration only, no `:data`
 
 **Locked 2026-05-13 (Mike, lifted from Xray 003; tightened
-2026-05-14 per rf2-li3o4).** **The share-URL payload carries the
-topology + the current state's name (`:state` keyword only). No
-runtime `:data`; no transition history; no event vector; no
-app-db slices; no source-coords.**
+2026-05-14 per rf2-li3o4; widened 2026-06-04 per rf2-9l8h8).** **The
+share-URL payload carries the topology + the current state's
+CONFIGURATION (`:state` only — one of the three Spec 005
+§Snapshot-shape arms: a flat keyword, a compound vector-path, or a
+parallel region-map). State configuration only; no runtime data. Vector
+paths and region-maps are state names/addresses, NOT data. No runtime
+`:data`; no transition history; no event vector; no app-db slices; no
+source-coords.**
 
 ### Question
 
 What state-information does the share-URL carry?
+
+> **rf2-9l8h8 (2026-06-04) — widened `:state` to a state CONFIGURATION.**
+> The original wording said "the state name only" and the schema typed
+> `:snapshot {:state keyword?}`. That accepted only a flat keyword — but
+> the encoder happily serialised compound (vector-path) and parallel
+> (region-map) `:current-state` values, which the keyword-only decoder
+> then rejected: an **undecodable URL**. The fix widens `:state` to the
+> three Spec 005 §Snapshot-shape arms `MachineChart` `:current-state`
+> already accepts, and makes encode validate the full allowlisted chart
+> state (incl. the snapshot shape) before serialising so encode/decode
+> are symmetric. The lock's substance is unchanged: state configuration
+> only, no runtime `:data`. Vector paths + region-maps are state
+> names/addresses, not data.
 
 ### Options considered
 
@@ -356,22 +373,28 @@ What state-information does the share-URL carry?
   URL" click would exfiltrate tokens, form contents, and request
   payloads. The accident-class beats the visual-continuity
   marginal benefit.
-- **Topology + the state name only.** The chart highlights the
-  active state node; `:data` is unavailable to the viewer (which
+- **Topology + the state configuration only.** The chart highlights
+  the active state node(s); `:data` is unavailable to the viewer (which
   has no per-data affordance anyway — the chart's data display
   is operator-side, in Xray's inspector chrome). The recipient
-  has a "show idle" toggle to clear the highlight.
+  has a "show idle" toggle to clear the highlight. The configuration
+  is one of the three Spec 005 §Snapshot-shape arms (flat keyword,
+  compound vector-path, parallel region-map) — all state
+  names/addresses, none of them runtime data.
 
 ### Pick
 
-**Topology + the state name only (`:snapshot` is `{:closed true}`
-with `:state` only).**
+**Topology + the state configuration only (`:snapshot` is
+`{:closed true}` with `:state` only — a flat keyword, a compound
+vector-path, or a parallel region-map; no runtime data).**
 
 ### Why
 
-- **Visual continuity holds** — the recipient sees which state the
-  sharer was in; the static active-state affordance needs the
-  state name only.
+- **Visual continuity holds** — the recipient sees which state(s) the
+  sharer was in; the static active-state affordance needs the state
+  configuration only (the address, not the data). A compound or
+  parallel machine's configuration is a vector-path or region-map —
+  still a name/address, not runtime data.
   The chart's data display is operator-side chrome (Xray's
   inspector panel), not a `MachineChart` affordance.
 - **Privacy is structural, not prose** — the encoder cannot emit
@@ -380,8 +403,8 @@ with `:state` only).**
   operator who wants to share a data value pastes it explicitly
   via a different channel.
 - **Reproducible-from-registry-alone** holds for the topology;
-  the state name is the only non-reproducible bit and is purely
-  a visual hint.
+  the state configuration is the only non-reproducible bit and is
+  purely a visual hint.
 - **"Show idle" toggle** — the viewer page offers a one-click
   "clear active state" if the recipient wants to discuss the
   machine in the abstract. Xray 003 §Share-URL §Read-only viewer

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -10,7 +10,8 @@
   it — the fns walk up to the chart root). `MachineChart` stashes a
   share-relevant `chart-state` on that root node as the JS property
   `._rfMvChartState` (set via the component's root `:ref`): topology +
-  the active-state NAME + summary counts. The export fns read that seam
+  the active-state CONFIGURATION (its name/address) + summary counts.
+  The export fns read that seam
   rather than scraping the SVG for structure — so the share-URL +
   alt-text summaries are derived from the SAME definition the chart
   rendered, with no runtime `:data` ever in scope (per
@@ -81,15 +82,36 @@
                        :element     chart-element})))
     seam))
 
+(defn- state-label
+  "Render a `:current-state` value — any of the three Spec 005
+  §Snapshot-shape arms — to a human-readable label for alt-text:
+
+  - flat keyword `:loading`           → `\"loading\"`
+  - compound path `[:auth :authing]`  → `\"auth.authing\"`
+  - parallel region-map               → `\"data=loading, form=neutral\"`
+
+  Guards against `(name …)` blowing up on the vector/map arms (the seam
+  now legitimately carries compound + parallel configurations)."
+  [state]
+  (cond
+    (keyword? state) (name state)
+    (vector? state)  (str/join "." (map #(if (keyword? %) (name %) (str %)) state))
+    (map? state)     (str/join ", "
+                               (map (fn [[region region-state]]
+                                      (str (name region) "=" (state-label region-state)))
+                                    state))
+    :else            (str state)))
+
 (defn- alt-text
   "A one-line machine summary used as the SVG `<desc>`, the PNG
   clipboard alt-text sidecar, and the share preview. Same content
   across PNG + SVG so the accessible overview matches (per
-  `API.md` §Accessibility)."
+  `API.md` §Accessibility). `:current-state` may be any of the three
+  Spec 005 §Snapshot-shape arms — `state-label` renders all three."
   [{:keys [machine-id current-state node-count edge-count region-count]}]
   (str "State machine"
        (when machine-id (str " " (name machine-id)))
-       (when current-state (str " — currently " (name current-state)))
+       (when current-state (str " — currently " (state-label current-state)))
        ": " node-count " " (if (= 1 node-count) "state" "states")
        ", " edge-count " " (if (= 1 edge-count) "transition" "transitions")
        (when (and region-count (pos? region-count))
@@ -261,11 +283,17 @@
 (defn- element->chart-state
   "Project the DOM seam into the `ChartState` shape `share/encode-share-url`
   accepts. The `:frame-id` is not on the seam (the chart is
-  presentation-only and doesn't know its frame); when absent we omit
-  `:snapshot`'s data entirely and pass `:frame-id` as the machine-id's
-  namespace-less marker so the encoder's schema is satisfied. Hosts
-  that know the frame should call `share/encode-share-url` directly with
-  the full ChartState."
+  presentation-only and doesn't know its frame); when absent we pass
+  `:frame-id` as the machine-id so the encoder's schema is satisfied.
+  Hosts that know the frame should call `share/encode-share-url` directly
+  with the full ChartState.
+
+  `:current-state` off the seam is the chart's whole `:state` value — a
+  flat keyword, a compound vector-path, or a parallel region-map (the
+  three Spec 005 §Snapshot-shape arms). It is threaded verbatim into
+  `:snapshot {:state …}`; the share schema accepts all three arms (they
+  are state names/addresses, not runtime data), so a compound or
+  parallel chart shares + round-trips cleanly."
   [chart-element {:keys [frame-id]}]
   (let [{:keys [machine-id definition current-state]} (chart-state-of chart-element)]
     (cond-> {:machine-id machine-id
@@ -275,8 +303,8 @@
 
 (defn share-url
   "Derive a share-URL from the rendered `chart-element`. Reads the
-  topology + active-state name off the DOM seam, projects them into a
-  `ChartState`, and delegates to `share/encode-share-url`.
+  topology + active-state configuration off the DOM seam, projects them
+  into a `ChartState`, and delegates to `share/encode-share-url`.
 
   `opts` is passed to `share/encode-share-url` (`{:host ...}`), and may
   also carry `:frame-id` (the chart element doesn't know its frame; a

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -5,14 +5,18 @@
   A share-URL is a **viewer-side artefact**: its only job is to let a
   remote recipient render a chart from a pasted link, with no running
   app and no trace bus. The payload carries the machine topology plus
-  the active state's NAME — and nothing else. Two classes of data are
-  structurally excluded (per `Principles.md` §No session data in
-  shares):
+  the active state's CONFIGURATION (its name/address) — and nothing
+  else. Two classes of data are structurally excluded (per
+  `Principles.md` §No session data in shares):
 
   - **Runtime `:data`** off the snapshot — a machine's `:data` value
     may carry tokens, form contents, or request payloads. The
     `:snapshot` map is `{:closed true}` and carries `:state` only; the
-    encoder neither reads nor serialises `:data`.
+    encoder neither reads nor serialises `:data`. The `:state` value
+    is a state CONFIGURATION (the three Spec 005 §Snapshot-shape arms:
+    a flat keyword, a compound vector-path, or a parallel region-map);
+    vector paths and region-maps are state names/addresses, NOT runtime
+    data.
   - **Local-filesystem `:source-coords`** — they reveal usernames /
     workstation layout / repo structure and are useless to a viewer
     with no editor handler wired. The encoder strips definition
@@ -171,13 +175,31 @@
 ;;   {:machine-id keyword?
 ;;    :frame-id   keyword?
 ;;    :definition <MachineDefinition>
-;;    :snapshot   {:state keyword?}  ;; OPTIONAL, {:closed true}, :state only}
+;;    :snapshot   {:state <state-configuration>}}  ;; OPTIONAL, {:closed true}, :state only
+;;
+;; The `:snapshot` `:state` is a STATE CONFIGURATION — one of the three
+;; Spec 005 §Snapshot-shape arms that `MachineChart` `:current-state`
+;; (via `chart.layout/highlight-ids`) already accepts:
+;;
+;;   - flat keyword       `:idle`
+;;   - compound path      `[:auth :authing]`              (vector of keywords)
+;;   - parallel region-map `{:data :loading :form :neutral}`
+;;                          (region-name keyword → flat-or-compound arm)
+;;
+;; Vector paths + region-maps are state names/ADDRESSES, not runtime
+;; data — they are allowed. Runtime `:data` is NOT.
 ;;
 ;; Anything outside the allowlist is silently dropped at encode time;
 ;; the decoder REJECTS extra keys on :snapshot (the security-relevant
 ;; closed map) with :invalid-chart-state, but tolerates unknown
 ;; top-level keys on inbound payloads only insofar as they were never
 ;; emitted (a hand-edited URL adding :snapshot {:data ...} must fail).
+;;
+;; Encode + decode validate the SAME `valid-chart-state?` (incl. the
+;; snapshot shape) so the two are SYMMETRIC: the encoder never emits a
+;; payload the decoder would reject (the rf2-9l8h8 bug was an encoder
+;; that accepted compound/parallel snapshots a keyword-only decoder
+;; then refused — an undecodable URL).
 
 (defn- valid-definition?
   "A MachineDefinition is either a flat/compound spec (`:initial` +
@@ -188,19 +210,54 @@
        (or (and (:initial d) (map? (:states d)) (seq (:states d)))
            (and (= :parallel (:type d)) (map? (:regions d)) (seq (:regions d))))))
 
+(defn- valid-state-path?
+  "A compound `:state` arm: a non-empty vector of keywords naming the
+  path from the root state-node to the active leaf (`[:auth :authing]`).
+  Mirrors the vector arm `chart.layout/highlight-ids` resolves."
+  [v]
+  (and (vector? v)
+       (seq v)
+       (every? keyword? v)))
+
+(defn- valid-state-configuration?
+  "A snapshot `:state` value is a STATE CONFIGURATION — one of the three
+  Spec 005 §Snapshot-shape arms (the same arms `MachineChart`
+  `:current-state` accepts via `chart.layout/highlight-ids`):
+
+  - **flat keyword** — `:idle`.
+  - **compound path** — a non-empty vector of keywords (`[:auth :authing]`).
+  - **parallel region-map** — a non-empty map of region-name keyword →
+    that region's own flat-or-compound arm (keyword or vector path),
+    e.g. `{:data :loading :form [:edit :dirty]}`.
+
+  Vector paths + region-maps are state names/addresses, NOT runtime
+  data."
+  [state]
+  (cond
+    (keyword? state) true
+    (vector? state)  (valid-state-path? state)
+    (map? state)     (and (seq state)
+                          (every? (fn [[region region-state]]
+                                    (and (keyword? region)
+                                         (or (keyword? region-state)
+                                             (valid-state-path? region-state))))
+                                  state))
+    :else            false))
+
 (defn- valid-snapshot?
-  "A :snapshot (when present) is a closed map carrying :state only."
+  "A :snapshot (when present) is a closed map carrying :state only,
+  where `:state` is a valid STATE CONFIGURATION (one of the three
+  Spec 005 §Snapshot-shape arms — see `valid-state-configuration?`)."
   [s]
   (and (map? s)
-       (keyword? (:state s))
-       (= #{:state} (set (keys s)))))
+       (= #{:state} (set (keys s)))
+       (valid-state-configuration? (:state s))))
 
 (defn- valid-core-chart-state?
   "Validate the load-bearing ChartState slots (`:machine-id`,
-  `:frame-id`, `:definition`). `:snapshot` is NOT checked here — the
-  encoder allowlists it (dropping runtime `:data`) before serialising,
-  so a caller passing a full snapshot is tolerated rather than rejected.
-  Used at encode time."
+  `:frame-id`, `:definition`). `:snapshot` is NOT checked here — see
+  `valid-chart-state?` for the whole-shape check used at BOTH encode and
+  decode time."
   [cs]
   (and (map? cs)
        (keyword? (:machine-id cs))
@@ -209,9 +266,14 @@
 
 (defn- valid-chart-state?
   "Validate a fully-allowlisted ChartState shape. `:snapshot` is
-  optional; when present it must be `{:state <kw>}` EXACTLY. Used on the
-  decode side, where an inbound `:snapshot` carrying extra keys (a
-  hand-edited URL smuggling `:data`) MUST be rejected."
+  optional; when present it must be `{:state <state-configuration>}`
+  EXACTLY (closed; `:state` only). Used on BOTH sides so encode/decode
+  stay symmetric — the encoder validates the allowlisted chart state
+  with this same predicate before serialising, so it never emits a
+  payload the decoder would reject (a hand-edited URL smuggling `:data`
+  onto `:snapshot`, or a malformed `:state` that is none of the three
+  arms, is rejected at decode; an in-process caller passing the same is
+  rejected at encode)."
   [cs]
   (and (valid-core-chart-state? cs)
        (or (not (contains? cs :snapshot))
@@ -227,8 +289,11 @@
     (cond-> {:machine-id machine-id
              :frame-id   frame-id
              :definition (strip-meta definition)}
-      ;; :snapshot is allowlisted to :state ONLY — :data is dropped here
-      ;; structurally even if the caller passed a full snapshot.
+      ;; :snapshot is allowlisted to :state ONLY — runtime :data and any
+      ;; other snapshot key are dropped here structurally even if the
+      ;; caller passed a full snapshot. The :state VALUE (a flat keyword,
+      ;; a compound vector-path, or a parallel region-map) is preserved
+      ;; intact — it is a state name/address, not runtime data.
       (and (map? snapshot) (contains? snapshot :state))
       (assoc :snapshot {:state (:state snapshot)}))))
 
@@ -268,35 +333,44 @@
   {:machine-id :auth/login-flow
    :frame-id   :app/main
    :definition {:initial :idle :states {...}}
-   :snapshot   {:state :loading}}   ;; optional; :state ONLY
+   :snapshot   {:state :loading}}   ;; optional; :state ONLY (a state
+                                    ;; CONFIGURATION — flat keyword,
+                                    ;; compound vector-path, or parallel
+                                    ;; region-map)
   ```
 
-  The encoder (1) validates + allowlists `chart-state` (dropping
-  runtime `:data` + `:source-coords`), (2) strips definition metadata,
-  (3) canonicalises map / set ordering, (4) wraps in the versioned
-  envelope, (5) transit-writes (json) → base64url-encodes, (6) wraps
-  the fragment into `:host`.
+  The encoder (1) allowlists `chart-state` (dropping runtime `:data` +
+  `:source-coords` + extra `:snapshot` keys) and strips definition
+  metadata, (2) VALIDATES the allowlisted result against the SAME
+  `valid-chart-state?` the decoder uses — so encode/decode stay
+  symmetric and the encoder never emits a payload the decoder would
+  reject, (3) canonicalises map / set ordering, (4) wraps in the
+  versioned envelope, (5) transit-writes (json) → base64url-encodes,
+  (6) wraps the fragment into `:host`.
 
   Throws `:rf.machines-viz.share/encode-failed` (an ex-info with
-  `:reason :invalid-chart-state`) when `chart-state` does not validate."
+  `:reason :invalid-chart-state`) when the chart state does not validate
+  — including a `:snapshot` `:state` that is none of the three allowed
+  configuration arms (a malformed `:state` would yield an undecodable
+  URL, so it is rejected at encode)."
   ([chart-state] (encode-share-url chart-state nil))
   ([chart-state {:keys [host] :or {host default-host}}]
-   (when-not (valid-core-chart-state? chart-state)
-     (throw (ex-info ":rf.machines-viz.share/encode-failed — invalid-chart-state"
-                     {:rf.error/id :rf.machines-viz.share/encode-failed
-                      :where       'machines-viz.share/encode-share-url
-                      :recovery    :no-recovery
-                      :reason      :invalid-chart-state
-                      :chart-state chart-state})))
-   (let [allowlisted (allowlist-chart-state chart-state)
-         envelope    (canonicalise
-                       {:rf.machines-viz.share/v       current-version
-                        :rf.machines-viz.share/chart   allowlisted
-                        :rf.machines-viz.share/created (js/Date.now)})
-         writer      (transit/writer :json)
-         transit-str (transit/write writer envelope)
-         fragment    (bytes->base64url transit-str)]
-     (str host "#" fragment-key "=" fragment))))
+   (let [allowlisted (allowlist-chart-state chart-state)]
+     (when-not (valid-chart-state? allowlisted)
+       (throw (ex-info ":rf.machines-viz.share/encode-failed — invalid-chart-state"
+                       {:rf.error/id :rf.machines-viz.share/encode-failed
+                        :where       'machines-viz.share/encode-share-url
+                        :recovery    :no-recovery
+                        :reason      :invalid-chart-state
+                        :chart-state chart-state})))
+     (let [envelope    (canonicalise
+                         {:rf.machines-viz.share/v       current-version
+                          :rf.machines-viz.share/chart   allowlisted
+                          :rf.machines-viz.share/created (js/Date.now)})
+           writer      (transit/writer :json)
+           transit-str (transit/write writer envelope)
+           fragment    (bytes->base64url transit-str)]
+       (str host "#" fragment-key "=" fragment)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Decoder
@@ -402,8 +476,11 @@
   `MachineChart` prop map the viewer page mounts (per `API.md`
   §Read-only viewer): `:machine-id` + `:definition` from the payload,
   `:current-state` from `:snapshot`'s `:state` (nil → no highlight),
-  and `:read-only? true`. `:frame-id` is payload provenance, not a
-  chart prop, so it is not threaded onto the props."
+  and `:read-only? true`. The `:state` value is a state configuration —
+  a flat keyword, a compound vector-path, or a parallel region-map — and
+  is passed through verbatim; `MachineChart` `:current-state` accepts all
+  three arms. `:frame-id` is payload provenance, not a chart prop, so it
+  is not threaded onto the props."
   [envelope]
   (let [chart (:rf.machines-viz.share/chart envelope)]
     (cond-> {:machine-id (:machine-id chart)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
@@ -54,6 +54,34 @@
       (is (= {:state :loading} (:snapshot cs))
           "active-state name rides as the snapshot; no :data"))))
 
+(def compound-definition
+  {:initial :authenticated
+   :states  {:authenticated {:initial :cart
+                             :states  {:cart {:initial :browsing
+                                              :states  {:browsing {} :checkout {}}}}}}})
+
+(def parallel-definition
+  {:type :parallel
+   :regions {:data {:initial :clean :states {:clean {} :dirty {}}}
+             :form {:initial :idle  :states {:idle {} :busy {}}}}})
+
+(deftest share-url-compound-current-state-rides-through
+  (testing "a COMPOUND vector-path :current-state on the seam round-trips (rf2-9l8h8)"
+    (let [el  (stub-element (assoc seam
+                                   :definition compound-definition
+                                   :current-state [:authenticated :cart :browsing]))
+          cs  (:rf.machines-viz.share/chart (share/decode-share-url (export/share-url el)))]
+      (is (= {:state [:authenticated :cart :browsing]} (:snapshot cs))))))
+
+(deftest share-url-parallel-current-state-rides-through
+  (testing "a PARALLEL region-map :current-state on the seam round-trips (rf2-9l8h8)"
+    (let [el  (stub-element (assoc seam
+                                   :definition parallel-definition
+                                   :region-count 2
+                                   :current-state {:data :dirty :form :busy}))
+          cs  (:rf.machines-viz.share/chart (share/decode-share-url (export/share-url el)))]
+      (is (= {:state {:data :dirty :form :busy}} (:snapshot cs))))))
+
 (deftest share-url-honours-host-and-frame
   (testing ":host + :frame-id opts thread through"
     (let [el  (stub-element seam)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -4,6 +4,11 @@
   Coverage:
   - `encode-share-url` → `decode-share-url` round-trip preserves the
     ChartState (machine-id, frame-id, definition, snapshot state).
+  - Snapshot `:state` configuration arms (rf2-9l8h8): flat keyword,
+    compound vector-path, and parallel region-map all round-trip; a
+    malformed `:state` is rejected at ENCODE (encode/decode symmetric —
+    no undecodable URL), and the closed-map rule still rejects extra
+    `:snapshot` keys for every arm.
   - Canonicalisation: the same ChartState encodes byte-for-byte
     identically regardless of input map/set ordering (Principles
     §Reproducible from the registry alone).
@@ -56,6 +61,17 @@
                 :regions {:data {:initial :clean :states {:clean {} :dirty {}}}
                           :form {:initial :idle  :states {:idle {} :busy {}}}}}})
 
+(def compound-definition
+  "A compound (hierarchical) machine — its snapshot `:state` is a vector
+  path from the root to the active leaf."
+  {:initial :authenticated
+   :states  {:authenticated
+             {:initial :cart
+              :states  {:cart    {:initial :browsing
+                                  :states  {:browsing {} :checkout {}}}
+                        :account {}}}
+             :anonymous {}}})
+
 ;; ---------------------------------------------------------------------------
 ;; Round-trip
 
@@ -85,6 +101,78 @@
                  (share/decode-share-url (share/encode-share-url cs)))]
       (is (not (contains? back :snapshot)))
       (is (= idle-loading-success (:definition back))))))
+
+;; ---------------------------------------------------------------------------
+;; Snapshot :state CONFIGURATION — the three Spec 005 §Snapshot-shape arms
+;; (rf2-9l8h8). The bug: encode accepted compound/parallel snapshots but a
+;; keyword-only decoder rejected them → an undecodable URL. All three arms
+;; must now round-trip cleanly and stay encode/decode symmetric.
+
+(deftest round-trip-flat-snapshot
+  (testing "a FLAT keyword :state round-trips"
+    (let [cs   (assoc chart-state :snapshot {:state :loading})
+          back (:rf.machines-viz.share/chart
+                 (share/decode-share-url (share/encode-share-url cs)))]
+      (is (= {:state :loading} (:snapshot back)))
+      (is (keyword? (get-in back [:snapshot :state]))))))
+
+(deftest round-trip-compound-snapshot
+  (testing "a COMPOUND vector-path :state round-trips (was rejected pre-9l8h8)"
+    (let [cs   {:machine-id :shop/store
+                :frame-id   :app/main
+                :definition compound-definition
+                :snapshot   {:state [:authenticated :cart :browsing]}}
+          back (:rf.machines-viz.share/chart
+                 (share/decode-share-url (share/encode-share-url cs)))]
+      (is (= {:state [:authenticated :cart :browsing]} (:snapshot back)))
+      (is (vector? (get-in back [:snapshot :state]))))))
+
+(deftest round-trip-parallel-snapshot
+  (testing "a PARALLEL region-map :state round-trips (was rejected pre-9l8h8)"
+    (let [cs   (assoc parallel-state :snapshot {:state {:data :dirty :form :busy}})
+          back (:rf.machines-viz.share/chart
+                 (share/decode-share-url (share/encode-share-url cs)))]
+      (is (= {:state {:data :dirty :form :busy}} (:snapshot back)))
+      (is (map? (get-in back [:snapshot :state])))))
+  (testing "a PARALLEL region-map whose region value is itself a compound path"
+    (let [cs   (assoc parallel-state
+                      :snapshot {:state {:data :dirty :form [:edit :touched]}})
+          back (:rf.machines-viz.share/chart
+                 (share/decode-share-url (share/encode-share-url cs)))]
+      (is (= {:state {:data :dirty :form [:edit :touched]}} (:snapshot back))))))
+
+(deftest malformed-state-rejected-at-encode
+  (testing "a :state that is none of the three arms is rejected at ENCODE — symmetric, no undecodable URL"
+    (doseq [bad-state [42
+                       "loading"
+                       []                              ;; empty vector path
+                       [:auth "authing"]               ;; non-keyword in path
+                       {}                              ;; empty region-map
+                       {:data "loading"}               ;; non-keyword/path region value
+                       {"data" :loading}]]             ;; non-keyword region name
+      (let [cs (assoc chart-state :snapshot {:state bad-state})
+            d  (try (share/encode-share-url cs)
+                    (catch :default e (ex-data e)))]
+        (is (= :invalid-chart-state (:reason d))
+            (str "encode must reject malformed :state " (pr-str bad-state)))
+        (is (= :rf.machines-viz.share/encode-failed (:rf.error/id d)))))))
+
+(deftest encode-decode-symmetric-for-all-arms
+  (testing "every arm the encoder accepts, the decoder also accepts (no undecodable URL)"
+    (doseq [state [:loading
+                   [:authenticated :cart :browsing]
+                   {:data :dirty :form :busy}
+                   {:data :dirty :form [:edit :touched]}]]
+      (let [cs  (assoc chart-state
+                       :definition compound-definition
+                       :snapshot {:state state})
+            url (share/encode-share-url cs)
+            ;; decode-share-url-safe never throws — an undecodable URL
+            ;; (the pre-9l8h8 bug) would surface as {:error ...}.
+            r   (share/decode-share-url-safe url)]
+        (is (some? (:ok r)) (str "arm round-trips cleanly: " (pr-str state)))
+        (is (nil? (:error r)))
+        (is (= state (get-in (:ok r) [:rf.machines-viz.share/chart :snapshot :state])))))))
 
 (deftest url-shape
   (testing "encoded URL carries the #machine= fragment + uses base64url alphabet"
@@ -216,6 +304,31 @@
       (is (= :invalid-chart-state (:reason d))
           "the closed :snapshot schema rejects extra keys at decode time"))))
 
+(deftest decoded-snapshot-extra-key-alongside-compound-state-rejected
+  (testing "a closed :snapshot is still closed for compound/parallel arms — extra keys rejected on decode"
+    (let [smuggled (envelope->url
+                     {:rf.machines-viz.share/v       "1"
+                      :rf.machines-viz.share/chart   (assoc chart-state
+                                                            :definition compound-definition
+                                                            :snapshot {:state [:authenticated :cart :browsing]
+                                                                       :data  {:token "leak"}})
+                      :rf.machines-viz.share/created 0})
+          d (try (share/decode-share-url smuggled)
+                 (catch :default e (ex-data e)))]
+      (is (= :invalid-chart-state (:reason d))
+          "widening :state to a configuration does NOT loosen the closed-map rule"))))
+
+(deftest decoded-malformed-state-rejected
+  (testing "a hand-edited URL whose :state is none of the three arms is rejected on decode (symmetric)"
+    (let [smuggled (envelope->url
+                     {:rf.machines-viz.share/v       "1"
+                      :rf.machines-viz.share/chart   (assoc chart-state
+                                                            :snapshot {:state {:data "not-a-keyword-or-path"}})
+                      :rf.machines-viz.share/created 0})
+          d (try (share/decode-share-url smuggled)
+                 (catch :default e (ex-data e)))]
+      (is (= :invalid-chart-state (:reason d))))))
+
 (deftest malformed-fragment-rejected
   (testing "a URL with no #machine= fragment throws :malformed-fragment"
     (is (thrown-with-msg? :default #"malformed-fragment"
@@ -269,4 +382,14 @@
     (let [env   (share/decode-share-url (share/encode-share-url (dissoc chart-state :snapshot)))
           props (share/chart-state->props env)]
       (is (not (contains? props :current-state)))
-      (is (true? (:read-only? props))))))
+      (is (true? (:read-only? props)))))
+  (testing "compound vector-path snapshot projects :current-state verbatim"
+    (let [cs    {:machine-id :shop/store :frame-id :app/main
+                 :definition compound-definition
+                 :snapshot   {:state [:authenticated :cart :browsing]}}
+          props (share/chart-state->props (share/decode-share-url (share/encode-share-url cs)))]
+      (is (= [:authenticated :cart :browsing] (:current-state props)))))
+  (testing "parallel region-map snapshot projects :current-state verbatim"
+    (let [cs    (assoc parallel-state :snapshot {:state {:data :dirty :form :busy}})
+          props (share/chart-state->props (share/decode-share-url (share/encode-share-url cs)))]
+      (is (= {:data :dirty :form :busy} (:current-state props))))))


### PR DESCRIPTION
## What

Fixes **rf2-9l8h8** (P2 bug) — Mike ruled **C** (2026-06-04): WIDEN the share `:snapshot` `:state` schema to carry a STATE CONFIGURATION (not just a scalar keyword), keep `:snapshot` closed, keep excluding runtime `:data`, and make encode VALIDATE the allowlisted chart state before serialising so encode/decode stay SYMMETRIC.

## The bug

`export`'s `element->chart-state` passes the chart's whole `:current-state` through into `:snapshot {:state …}`. For **compound** (vector-path) and **parallel** (region-map) machines the encoder happily serialised those arms, but the keyword-only decoder (`valid-snapshot?` required `(keyword? (:state s))`) rejected them on decode — an **undecodable URL**.

## The fix

- **`share.cljs`** — new `valid-state-path?` / `valid-state-configuration?` predicates mirror the three Spec 005 §Snapshot-shape arms `MachineChart` `:current-state` already accepts (via `chart.layout/highlight-ids`): flat keyword, compound vector-of-keywords, parallel region-map (region-name keyword → keyword-or-path). `valid-snapshot?` now validates `{:state <configuration>}` (still closed, `:state` only). The **encoder allowlists first, then validates the allowlisted result with the SAME `valid-chart-state?` the decoder uses** — so a malformed `:state` (none of the three arms) is rejected at encode rather than emitted as an undecodable URL. `allowlist-chart-state` still strips `:data` + every extra `:snapshot` key.
- **`export.cljs`** — confirmed `element->chart-state` threads all three arms verbatim. Also fixed `alt-text`, which called `(name current-state)` and would throw on the vector/map arms now legitimately on the seam — added `state-label` to render all three.
- **`spec/API.md`** §Share-URL payload schema — added a `SnapshotState` schema (the 3 arms); reworded "name ONLY" → "state configuration only; no runtime data"; documented the encode/decode symmetry.
- **`DESIGN-RATIONALE.md`** Lock #5 — reworded "state name only" → "state configuration only; no runtime data" (vector paths/region-maps are names/addresses, not data) + an rf2-9l8h8 widening note. Lock substance unchanged: no runtime `:data`.

## Tests

Round-trip (encode→URL→decode) for **flat keyword**, **compound vector-path**, and **parallel region-map** snapshots (incl. a region whose value is itself a compound path) — all clean now. Plus: malformed `:state` rejected at **encode** (symmetric) and at **decode**; `:snapshot :data` + extra keys still stripped/rejected for every arm; `chart-state->props` projects compound/parallel `:current-state` verbatim; export-side compound/parallel `:current-state` rides through.

## Gates

`npm run test:cljs` (node-runtime, the authoritative gate for share/export encode-decode logic) — **5554 tests / 19210 assertions, 0 failures, 0 errors**, 0 compile warnings. machines-viz spec is not in the mkdocs nav, so `mkdocs build --strict` does not cover these files; no new internal links introduced. No render path changed (pure encode/decode), so the browser xray-feature-gate is not exercised by this change.

## Scope note (sequencing)

Held bead **dt5b1** touches `API.md` §edge/constants — a DIFFERENT section from §Share-URL; flag for sequencing only (no overlap with this PR).
