### PR TITLE
refactor(schemas): naming review — rename meta let-binding to schema-meta (rf2-fwvtm)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -396,9 +396,15 @@
          ;; hot-reload `:rf.schema/violation` check (rf2-ee38b.6) can
          ;; compare pre- vs post-reload shapes. nil on first registration.
          prior-schema (get-in @schemas-by-frame [frame-id path :schema])
-         meta         (source-coords/merge-coords
+         ;; The per-frame schema-metadata map (the {path → schema-meta}
+         ;; entry value) — `:schema` + `:path` + `:frame` + source-coords.
+         ;; Named `schema-meta` to match the slice vocabulary
+         ;; (`frame-schema-entries`, `app-schema-meta-at`, the
+         ;; `validate-app-schema!` destructure) and to avoid shadowing
+         ;; `clojure.core/meta`.
+         schema-meta  (source-coords/merge-coords
                         {:schema schema :path path :frame frame-id})]
-     (swap! schemas-by-frame assoc-in [frame-id path] meta)
+     (swap! schemas-by-frame assoc-in [frame-id path] schema-meta)
      ;; Per rf2-fq7d2: dev-time nudge when `:schemas/malli-validate` is
      ;; unbound AND the framework-default validator is still installed —
      ;; the default soft-passes per Spec 010 §Recommended soft-pass, so a


### PR DESCRIPTION
## What

NAMING / best-practice review of the `implementation/schemas` slice (bead rf2-fwvtm, P3). Lens: CLARITY dominant.

## Finding

The slice is exceptionally mature — names already follow consistent conventions and have been deliberately tuned across many prior beads (rf2-s2jgz tuned the `validate-*!` family onto the kind axis; rf2-13meg renamed `set-schema-fns!` for honesty; rf2-froe / rf2-wla45 established the validator/explainer/printer trio). Every fn carries an accurate docstring. Namespaces, files, operation ids, and the public surface are all well-named.

One genuine, obvious, slice-internal clarity nit:

- In `reg-app-schema` (storage.cljc) the let-binding holding the per-frame schema-metadata map was named `meta` — it **shadowed `clojure.core/meta`** and diverged from the slice's own pervasive `schema-meta` vocabulary (`frame-schema-entries`'s `{path → schema-meta}` shape, `app-schema-meta-at`, and the `validate-app-schema!` `[reg-path schema-meta]` destructure).

Renamed `meta` → `schema-meta`. Single 3-line local scope; behaviour-preserving; no external blast radius.

## Not changed (deliberately well-named)

- The five `validate-*!` entry points — slice-public via late-bind hooks (router/cofx/subs/epoch) + `core-schemas`; already named on the kind axis per rf2-s2jgz.
- `run-validator` / `run-explainer` / `run-printer`, `coerce-opts` / `coerce->frame-id` / `resolve-frame`, the walker helpers — all clear and consistent. No beads filed; nothing uncertain or contentious surfaced.

## Gate

`npm run test:cljs` from `implementation/`: **5566 tests / 19389 assertions, 0 failures, 0 errors** (schemas suite + the ~18k-assertion concurrency stress harness).

Closes rf2-fwvtm.
