### PR TITLE
feat(machines): forbidden transitions — {:on {E nil}} blocks parent inheritance (rf2-16gxd)

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -456,19 +456,34 @@
     a vector of maps       -> multiple guarded candidates    (first guard-pass wins)
     a single transition map
 
-  Returns a vector of candidate transition maps (possibly empty for a nil
-  value). Keeping `:on` and `:after` on this ONE normaliser is what stops
-  the two value-form grammars drifting apart — the guarded candidate-vector
-  form (`[{:guard g :target s} {:target s2 :action a}]`) resolves
-  identically whether it is reached through an `:on` clause or an `:after`
-  delay entry.
+  Returns a vector of candidate transition maps. Keeping `:on` and `:after`
+  on this ONE normaliser is what stops the two value-form grammars drifting
+  apart — the guarded candidate-vector form (`[{:guard g :target s}
+  {:target s2 :action a}]`) resolves identically whether it is reached
+  through an `:on` clause or an `:after` delay entry.
+
+  rf2-16gxd — the FORBIDDEN-TRANSITION value form. A nil VALUE (the key is
+  PRESENT in the table with value nil — `{:on {:logout nil}}`) normalises to
+  a single unguarded INTERNAL candidate `[{}]`, exactly as the empty map
+  `{:on {:logout {}}}` does. Both are enabled, targetless (internal) no-ops
+  that the leaf→root walk treats as a match — halting deepest-wins at this
+  level and thereby BLOCKING a parent's inherited transition for the event
+  (re-frame2's spelling of XState v5 `on: {LOGOUT: undefined}` / a SCXML
+  targetless internal `<transition event=\"E\"/>`). nil is the natural
+  Clojure analogue of XState `undefined`, so the nil and empty-map forms are
+  unified here — there is no nil-vs-`{}` trap. NOTE: this is the rule for a
+  PRESENT value; an ABSENT key is a different thing entirely (no candidates,
+  the walk continues to the parent). Callers that look up an OPTIONAL slot
+  (`match-on-clause`'s `:on` tier select, `pick-done-transition` / the
+  parallel-root `apply-on-done-action`'s `:on-done`) gate the call on the
+  key's PRESENCE so absence never reaches this nil arm.
 
   `bad-value-id` names the error category to throw for an unrecognised
   value form so each caller surfaces its own slot-specific taxonomy
   (`:on` → `machine-bad-on-clause`, `:after` → `machine-bad-after-spec`)."
   [v bad-value-id]
   (cond
-    (nil? v)                        []
+    (nil? v)                        [{}]
     (keyword? v)                    [{:target v}]
     (and (vector? v)
          (every? map? v)
@@ -731,12 +746,24 @@
   [machine node event-id event snapshot]
   (let [on            (:on node)
         select        (fn [k]
-                        (select-passing-candidate
-                          machine
-                          (normalise-candidates
-                            (get on k)
-                            :rf.error/machine-bad-on-clause)
-                          snapshot event))
+                        ;; rf2-16gxd — gate on PRESENCE. An ABSENT key yields
+                        ;; no candidates (this tier is not enabled → fall
+                        ;; through to the next tier, then to the parent). A
+                        ;; PRESENT key normalises its value, where a nil value
+                        ;; (`{:on {E nil}}`) is the FORBIDDEN-transition form —
+                        ;; it normalises to an enabled internal candidate
+                        ;; (`[{}]`) exactly like the empty map `{:on {E {}}}`,
+                        ;; so the walk halts here and blocks a parent's
+                        ;; inherited E. Distinguishing absent from present-nil
+                        ;; is the whole point of the forbidden idiom: absence ≠
+                        ;; block.
+                        (when (contains? on k)
+                          (select-passing-candidate
+                            machine
+                            (normalise-candidates
+                              (get on k)
+                              :rf.error/machine-bad-on-clause)
+                            snapshot event)))
         ;; Tier 1 — exact event-id. Tier 2 — `:ns/*` (skipped for a
         ;; non-namespaced event-id; `ns-key` is nil and `select` is never
         ;; called). Tier 3 — total `:*`. Most-specific wins; each tier is
@@ -779,7 +806,12 @@
   [machine path event snapshot]
   (let [[_ done-path] event
         done-node     (when (vector? done-path) (node-at machine done-path))
-        on-done-cands (when done-node
+        ;; rf2-16gxd — gate on PRESENCE of `:on-done`. The forbidden-transition
+        ;; nil→`[{}]` rule in `normalise-candidates` is for a PRESENT value;
+        ;; an ABSENT `:on-done` must yield no candidates so resolution falls
+        ;; through to the enclosing explicit `:on {:rf.machine/done …}` walk
+        ;; (it must NOT synthesise a blocking internal no-op on the done node).
+        on-done-cands (when (and done-node (contains? done-node :on-done))
                         (normalise-candidates (:on-done done-node)
                                               :rf.error/machine-bad-on-done-clause))
         on-done-hit   (when (seq on-done-cands)

--- a/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
@@ -1,0 +1,268 @@
+(ns re-frame.machines-forbidden-transition-cljs-test
+  "Per Spec 005 §Transition resolution §Forbidden transitions + §Wildcard
+  transitions, and rf2-16gxd (Mike ruled 2026-06-04: DOCUMENT + nil-BLOCKS;
+  NO new sentinel).
+
+  The forbidden-transition idiom — re-frame2's spelling of XState v5's
+  `on: {LOGOUT: undefined}` / an SCXML targetless internal
+  `<transition event=\"logout\"/>`: a child `:on` entry that MATCHES but is
+  internal halts the deepest-wins leaf→root walk AT the child, and an
+  internal transition leaves the configuration unchanged — so a parent's
+  inherited transition for the event is NEVER reached. The child has opted
+  OUT of the inherited transition.
+
+  Two unified spellings of the matching internal no-op:
+    - `{:on {:logout {}}}`   — explicit empty transition map (always blocked);
+    - `{:on {:logout nil}}`  — a PRESENT key with a nil value; nil is the
+      Clojure analogue of XState `undefined`, so rf2-16gxd makes it ALSO
+      block (it previously fell through to the parent — the nil-vs-{} trap).
+
+  The whole idiom turns on PRESENCE: a child with NO `:logout` key still
+  INHERITS the parent's (absence ≠ block). And a forbidden block is an
+  ENABLED internal candidate, so — unlike a GUARD-BLOCKED candidate, which
+  falls through to `:ns/*` / `:*` / the parent (rf2-icj9t) — it shadows
+  every coarser descriptor AND every ancestor for that event.
+
+  Exercised through `reg-machine` / `dispatch-sync` — the same runtime
+  surface real apps use (mirrors machines-wildcard-fallthrough-cljs-test)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(defn- snapshot
+  "Read the snapshot for `machine-id` from the default frame's app-db."
+  [machine-id]
+  (get-in (rf/app-db-value :rf/default) [:rf/runtime :machines :snapshots machine-id]))
+
+(defn- seed-snapshot!
+  "Force the snapshot for `machine-id` to a known value via an event-db so a
+  test can reposition the machine to a non-initial leaf without rebuilding
+  the machine, and so the no-op is measured against an INSTALLED state (the
+  snapshot is synthesised lazily on first dispatch)."
+  [machine-id snap]
+  (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
+    (rf/reg-event-db seed-id
+      (fn [db _] (assoc-in db [:rf/runtime :machines :snapshots machine-id] snap)))
+    (rf/dispatch-sync [seed-id])))
+
+;; ---------------------------------------------------------------------------
+;; (a) `{:on {:logout {}}}` on a child BLOCKS the parent's inherited :logout
+;;     (the existing empty-map block — internal no-op, state unchanged)
+;; ---------------------------------------------------------------------------
+
+(deftest empty-map-child-entry-blocks-parent-inherited-transition
+  (testing "child `{:on {:logout {}}}` blocks the parent's inherited :logout (no-op)"
+    (let [machine
+          {:initial :authenticated
+           :data    {}
+           :states
+           {:authenticated
+            {:initial :dashboard
+             :on      {:logout [:unauthenticated]}     ;; factored to the parent
+             :states
+             ;; :modal opts OUT of the inherited :logout with an empty map.
+             {:dashboard {:on {:open-modal :modal}}
+              :modal     {:on {:logout {}              ;; FORBIDDEN — empty map
+                               :close  :dashboard}}}}
+            :unauthenticated {}}}]
+      (rf/reg-machine :forbid/empty machine)
+      ;; Reposition into :modal where the block lives.
+      (seed-snapshot! :forbid/empty {:state [:authenticated :modal] :data {}})
+      (rf/dispatch-sync [:forbid/empty [:logout]])
+      (is (= [:authenticated :modal] (:state (snapshot :forbid/empty)))
+          "the empty-map child entry matched + halted the walk — parent :logout NOT inherited; state unchanged"))))
+
+;; ---------------------------------------------------------------------------
+;; (b) `{:on {:logout nil}}` ALSO blocks — THE FIX (was falling through)
+;; ---------------------------------------------------------------------------
+
+(deftest nil-child-entry-also-blocks-parent-inherited-transition
+  (testing "child `{:on {:logout nil}}` ALSO blocks (rf2-16gxd nil-blocks — was a fallthrough)"
+    (let [machine
+          {:initial :authenticated
+           :data    {}
+           :states
+           {:authenticated
+            {:initial :dashboard
+             :on      {:logout [:unauthenticated]}
+             :states
+             ;; :modal opts OUT with a PRESENT nil value — the XState
+             ;; `LOGOUT: undefined` analogue. Pre-fix this fell through to
+             ;; the parent's :logout (the nil-vs-{} trap); post-fix it blocks.
+             {:dashboard {:on {:open-modal :modal}}
+              :modal     {:on {:logout nil             ;; FORBIDDEN — present nil
+                               :close  :dashboard}}}}
+            :unauthenticated {}}}]
+      (rf/reg-machine :forbid/nil machine)
+      (seed-snapshot! :forbid/nil {:state [:authenticated :modal] :data {}})
+      (rf/dispatch-sync [:forbid/nil [:logout]])
+      (is (= [:authenticated :modal] (:state (snapshot :forbid/nil)))
+          "the present-nil child entry matched + halted the walk — parent :logout NOT inherited; state unchanged"))))
+
+;; ---------------------------------------------------------------------------
+;; (c) a child with NO :logout entry STILL INHERITS the parent's (regression)
+;;     — absence ≠ block. This is the case the present-nil must NOT regress.
+;; ---------------------------------------------------------------------------
+
+(deftest absent-child-entry-still-inherits-parent-transition
+  (testing "child with NO :logout key inherits the parent's :logout (absence ≠ block)"
+    (let [machine
+          {:initial :authenticated
+           :data    {}
+           :states
+           {:authenticated
+            {:initial :dashboard
+             :on      {:logout [:unauthenticated]}
+             :states
+             ;; :dashboard declares NO :logout — it must inherit the parent's.
+             {:dashboard {:on {:open-modal :modal}}
+              :modal     {:on {:logout nil :close :dashboard}}}}
+            :unauthenticated {}}}]
+      (rf/reg-machine :forbid/absent machine)
+      ;; Rest at :dashboard (no :logout key) and dispatch :logout.
+      (seed-snapshot! :forbid/absent {:state [:authenticated :dashboard] :data {}})
+      (rf/dispatch-sync [:forbid/absent [:logout]])
+      (is (= [:unauthenticated] (:state (snapshot :forbid/absent)))
+          "absent child :logout key → walk continues to the parent → inherited :logout fired"))))
+
+;; ---------------------------------------------------------------------------
+;; (d) the blocking child INTERNAL transition runs its :action then halts
+;;     — for both the empty-map-with-action and... the nil form takes no
+;;     action (nil carries none), so :action coverage rides the map form.
+;; ---------------------------------------------------------------------------
+
+(deftest forbidden-block-runs-its-action-then-halts
+  (testing "a child block carrying an :action runs the action AND blocks the parent (internal, state unchanged)"
+    (let [log (atom [])
+          machine
+          {:initial :authenticated
+           :data    {}
+           :actions {:warn   (fn [_] (swap! log conj :warn) {})
+                     :logout-action (fn [_] (swap! log conj :parent-logout) {})}
+           :states
+           {:authenticated
+            {:initial :dashboard
+             ;; parent's :logout carries an action too, so we can prove it
+             ;; did NOT run (the child block shadowed it).
+             :on      {:logout {:target [:unauthenticated] :action :logout-action}}
+             :states
+             {:dashboard {:on {:open-modal :modal}}
+              :modal     {:on {:logout {:action :warn}   ;; block + action, no :target
+                               :close  :dashboard}}}}
+            :unauthenticated {}}}]
+      (rf/reg-machine :forbid/action machine)
+      (seed-snapshot! :forbid/action {:state [:authenticated :modal] :data {}})
+      (reset! log [])
+      (rf/dispatch-sync [:forbid/action [:logout]])
+      (is (= [:warn] @log)
+          "the child block's :action ran; the parent's :logout action did NOT")
+      (is (= [:authenticated :modal] (:state (snapshot :forbid/action)))
+          "internal transition — state unchanged; parent :logout still blocked"))))
+
+;; ---------------------------------------------------------------------------
+;; (e) compound coverage — the block lives on a deeper leaf and shadows a
+;;     transition factored TWO levels up.
+;; ---------------------------------------------------------------------------
+
+(deftest forbidden-block-shadows-grandparent-inherited-transition
+  (testing "a deep leaf's `{:on {:logout nil}}` blocks a :logout factored two levels up"
+    (let [machine
+          {:initial :app
+           :data    {}
+           :states
+           {:app
+            {:initial :authenticated
+             :on      {:logout [:bye]}                 ;; factored to the ROOT-child :app
+             :states
+             {:authenticated
+              {:initial :checkout
+               :states
+               ;; :checkout is two levels below the :logout declaration; it
+               ;; blocks with a present nil.
+               {:checkout {:on {:logout nil :cancel :browsing}}
+                :browsing {:on {:checkout :checkout}}}}}}
+            :bye {}}}]
+      (rf/reg-machine :forbid/compound machine)
+      (seed-snapshot! :forbid/compound
+                      {:state [:app :authenticated :checkout] :data {}})
+      (rf/dispatch-sync [:forbid/compound [:logout]])
+      (is (= [:app :authenticated :checkout] (:state (snapshot :forbid/compound)))
+          "deep-leaf nil block halted the walk — the :logout factored two levels up was NOT inherited")
+      ;; And from a sibling leaf WITHOUT the block, :logout is inherited.
+      (seed-snapshot! :forbid/compound
+                      {:state [:app :authenticated :browsing] :data {}})
+      (rf/dispatch-sync [:forbid/compound [:logout]])
+      (is (= [:bye] (:state (snapshot :forbid/compound)))
+          ":browsing has no :logout key → walk continues to :app → inherited :logout fired"))))
+
+;; ---------------------------------------------------------------------------
+;; (f) forbidden block vs :* / :ns/* fallthrough — the headline semantic.
+;;     A forbidden block (enabled internal candidate) does NOT fall to a
+;;     same-level wildcard, NOR to a parent wildcard — it is a deliberate
+;;     consume-here. This is the OPPOSITE of a GUARD-BLOCKED exact, which
+;;     DOES fall through (rf2-icj9t). Test both halves so the distinction is
+;;     pinned.
+;; ---------------------------------------------------------------------------
+
+(deftest forbidden-block-does-not-fall-through-to-wildcards
+  (testing "a forbidden `{:on {:logout {}}}` does NOT fall to a same-level :* / parent :*"
+    (let [log (atom [])
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
+          machine
+          {:initial :authenticated
+           :data    {}
+           :actions {:leaf-star   (tag :leaf-star)
+                     :parent-star (tag :parent-star)
+                     :ns-star     (tag :ns-star)}
+           :states
+           {:authenticated
+            {:initial :modal
+             :on      {:* {:action :parent-star}}        ;; parent :* present
+             :states
+             ;; leaf has a FORBIDDEN block on the exact key, AND a same-level
+             ;; :ns/* and :* — none of which must fire, because the block is
+             ;; an ENABLED candidate that wins the exact tier and halts.
+             {:modal {:on {:auth/logout {}              ;; FORBIDDEN block (namespaced exact)
+                           :auth/*      {:action :ns-star}
+                           :*           {:action :leaf-star}}}}}}}]
+      (rf/reg-machine :forbid/wild machine)
+      (seed-snapshot! :forbid/wild {:state [:authenticated :modal] :data {}})
+      (reset! log [])
+      (rf/dispatch-sync [:forbid/wild [:auth/logout]])
+      (is (empty? @log)
+          "the forbidden exact block fired (a no-op) — NO wildcard at any tier/level ran")
+      (is (= [:authenticated :modal] (:state (snapshot :forbid/wild)))
+          "state unchanged — the block consumed the event"))))
+
+(deftest forbidden-block-contrasts-with-guard-blocked-fallthrough
+  (testing "CONTRAST: a GUARD-BLOCKED exact DOES fall through to :* (rf2-icj9t) — proving the block is the difference"
+    (let [log (atom [])
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
+          machine
+          {:initial :authenticated
+           :data    {}
+           :guards  {:never (fn [_] false)}
+           :actions {:leaf-star (tag :leaf-star)
+                     :blocked   (tag :blocked)}
+           :states
+           {:authenticated
+            {:initial :modal
+             :states
+             ;; SAME shape as above but the exact entry is GUARD-BLOCKED
+             ;; (not a forbidden block) — it must fall through to the
+             ;; same-level :*, firing :leaf-star.
+             {:modal {:on {:auth/logout {:guard :never :action :blocked}
+                           :*           {:action :leaf-star}}}}}}}]
+      (rf/reg-machine :forbid/guard-contrast machine)
+      (seed-snapshot! :forbid/guard-contrast {:state [:authenticated :modal] :data {}})
+      (reset! log [])
+      (rf/dispatch-sync [:forbid/guard-contrast [:auth/logout]])
+      (is (= [:leaf-star] @log)
+          "guard-blocked exact is NOT enabled → falls through to the same-level :* (rf2-icj9t)")
+      (is (not (some #{:blocked} @log))
+          "the guard-blocked action did not run"))))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -311,6 +311,11 @@ Precedence inside the standard transition lookup, **at each level**:
 
 A coarser descriptor fires after the more specific ones **at the same level**. Only if *no enabled exact, `:ns/*`, or `:*` candidate* exists at this level does the runtime walk up to the next level and try again (steps 1–3 repeat at each ancestor) — so a leaf `:ns/*` (or `:*`) shadows an exact match on the parent for the same event, and a guard-blocked exact at the leaf falls through to the leaf's own `:ns/*` then `:*` *before* any parent is consulted. This is **XState v5's transition-selection order**: a machine descends the priority ladder within a state (exact, partial-descriptor, catch-all) before walking out to an ancestor; a transition whose guard is not met is simply *not selected*, leaving lower-priority descriptors — including the wildcards — eligible. The full leaf-up-to-root walk is canonically specified at [§Transition resolution — deepest-wins with parent fallthrough](#transition-resolution--deepest-wins-with-parent-fallthrough); for a flat machine the path is one level deep and the three-step rule above is the whole story. If no enabled exact *or* wildcard candidate exists at any level, the snapshot is unchanged and the runtime emits a single benign `:rf.machine.event/unhandled-no-op` trace (see [§Transition resolution](#transition-resolution--deepest-wins-with-parent-fallthrough) for the canonical name + the xstate-v5-parity rationale — an unhandled event is a no-op, not an error).
 
+**A forbidden block is NOT a fallthrough.** Distinguish two superficially-similar exact-key cases — they resolve oppositely:
+
+- An exact entry whose **guard is blocked** is *not enabled*, so resolution falls through to the same-level `:ns/*`, then `:*`, then up the hierarchy (the rule above).
+- A **forbidden block** — `{:on {E {}}}` or `{:on {E nil}}` (see [§Forbidden transitions](#forbidden-transitions--a-child-opts-out-of-an-inherited-transition)) — is an *enabled* internal candidate (it has no guard, so it passes). It **wins its tier** and halts the walk: it does **not** fall through to a same-level `:ns/*` / `:*`, nor to a parent's exact or wildcard. The forbidden block is a deliberate "consume E here", so it shadows every coarser descriptor *and* every ancestor for that event — exactly the intent of opting out of an inherited transition. (This mirrors XState v5, where a guard-failed transition leaves lower-priority descriptors eligible while a `{E: undefined}` forbidden transition is itself selected and stops selection.)
+
 ### Self-transitions (external vs internal)
 
 - `:target :same-state` — **external** self-transition. `:exit` of source and `:entry` of target both fire.
@@ -1305,6 +1310,35 @@ If **no level enables a transition** for an **unknown user event** — no level 
 **Reserved-`:rf/*` lifecycle carve-out.** The no-op classifies an **unknown user event** a machine author may have forgotten to handle — it is NOT emitted for framework lifecycle traffic whose event-id lives in the reserved `:rf/*` root namespace (per [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)). The synthetic creation marker `[:rf.machine/start]` (per [§Synthetic creation marker](#synthetic-creation-marker--rfmachinestart)), the spawn kick-off `[:rf.machine.spawn/spawned]` (per [§Spawn lifecycle — ordering](#spawn-lifecycle--ordering)), and the stories runtime's lifecycle / assertion pings (`:rf.story.lifecycle/*`, `:rf.assert/*`) are framework init, not events the author missed — a machine that declines them simply has no clause for them. (The eager `:rf.machine/start` kick is a pure init-kick that stops before the transition step, so it does not reach the no-op site as a trigger at all; the carve-out subsumes the marker only in its cascade-threaded-`:event`-placeholder role.) This **aligns with xstate**: xstate's own init (`xstate.init`) runs the initial-entry and is NOT reported as an unhandled event — only unknown user events are silently ignored. Distinguishing re-frame2's creation / spawn-kickoff makes us MORE like xstate, not a v5-parity violation. The carve-out is purely about **labelling, not severity** — nothing throws either way; it is a conscious refinement that restores the semantic distinction (severity stays benign, as in the rf2-ugdas downgrade) without reinstating any error advisory.
 
 The deepest-wins rule means a child state can **override** a parent's transition for the same event by declaring its own. Combined with parent fallthrough, this is how hierarchy factors common behaviour to the parent (every authenticated descendant inherits `:logout`) while still allowing local override.
+
+#### Forbidden transitions — a child opts OUT of an inherited transition
+
+Parent fallthrough is what *factors* a common transition to an ancestor; a child sometimes needs the inverse — to **opt out** of an inherited transition *without* replacing it with a real one. The mechanism falls out of the deepest-wins walk: a child `:on` entry that **matches but is internal** halts the leaf→root walk *at the child*, and an internal transition leaves the configuration unchanged — so the parent's inherited transition for that event is **never reached**. This is the **forbidden-transition idiom** — re-frame2's spelling of [XState v5's `on: {LOGOUT: undefined}`](https://stately.ai/docs/transitions#forbidden-transitions) (v4 `LOGOUT: undefined`) and of an [SCXML](https://www.w3.org/TR/scxml/#transition) **targetless internal** `<transition event="logout"/>`: a transition that *consumes* the event so the deepest-wins selection stops at the declaring node and the ancestor's transition is not taken.
+
+Two equivalent spellings — a present `:on` key whose value is the **empty map** or **`nil`**:
+
+```clojure
+{:initial :authenticated
+ :states
+ {:authenticated
+  {:initial :dashboard
+   :on      {:logout [:unauthenticated]}    ;; factored to the parent — every descendant inherits it
+   :states
+   {:dashboard {:on {:open-modal :modal}}    ;; inherits the parent's :logout normally
+    :modal     {:on {:logout {}}             ;; FORBIDDEN — empty map: a matching internal no-op,
+                                             ;;            halts the walk → blocks the parent's :logout
+                     ;; equivalently:  :logout nil
+                     :close      :dashboard}}}}}}
+```
+
+While the machine rests in `:modal`, dispatching `:logout` resolves at `:modal` (a match) to an internal transition with no `:target` and no `:action` — the state is unchanged and the parent's `[:unauthenticated]` is **not** inherited. Leave `:modal` (e.g. `:close` → `:dashboard`) and `:logout` is inherited from `:authenticated` again. The idiom is the natural fit for "this substate must not honour a factored-to-parent transition right now" — an authenticated flow that blocks `:logout` while a modal / unsaved-edit guard is open.
+
+Both forms are unified:
+
+- **`{:on {:logout {}}}`** — an explicit empty transition map. Matches; internal (no `:target`); no-op (no `:action`).
+- **`{:on {:logout nil}}`** — a **present** key with a `nil` value. `nil` is the natural Clojure analogue of XState's `undefined`, so it normalises to the **same** matching internal no-op — it **also blocks**. (Add an `:action` to either form — `{:on {:logout {:action :warn-cannot-logout}}}` — and the block still halts the walk *and* runs the action; the parent transition is still not inherited.)
+
+**Absence is NOT a block.** This turns entirely on the key being **present**. A child whose `:on` table simply has *no* `:logout` entry inherits the parent's `:logout` as usual — absence means "I don't handle this; keep walking", presence-with-`nil`/`{}` means "I consume this here; stop walking". The distinction is the whole point: a missing key must keep falling through, a deliberately-`nil` key must block. (See [§Wildcard transitions](#wildcard-transitions) for how a forbidden block — an *enabled* internal candidate — differs from a *guard-blocked* candidate where the wildcard / parent fallthrough still applies.)
 
 ### Worked example — auth flow
 


### PR DESCRIPTION
Closes rf2-16gxd. Mike ruled 2026-06-04: **DOCUMENT + nil-BLOCKS**, no new sentinel.

## What

XState v5 supports the *forbidden transition* — `on: {LOGOUT: undefined}` declared on a child to **opt out** of a parent's inherited transition (SCXML: a targetless internal `<transition event="logout"/>`). re-frame2 already had the mechanism: a child `:on` entry that matches but is internal (`{:on {E {}}}`) halts the deepest-wins leaf→root walk and runs no `:target`, so the parent's transition is never inherited. But a bare `{:on {E nil}}` silently *fell through* to the parent — the nil-vs-`{}` trap.

This makes `{:on {E nil}}` **also block**, unifying nil with the empty-map form (`nil` is the Clojure analogue of XState `undefined`).

## Engine (`transition.cljc`)

- `normalise-candidates`: a nil **value** now normalises to `[{}]` (a matching internal candidate) instead of `[]` (no match).
- `match-on-clause`'s per-tier `select` now gates on **key presence** (`contains?`): an **absent** key yields no candidates and falls through to the next tier / the parent (absence ≠ block); a **present** key normalises its value (where present-nil is the forbidden block).
- `pick-done-transition` gates `:on-done` on presence so an absent `:on-done` is unaffected by the nil→`[{}]` rule (still falls through to the enclosing `:on {:rf.machine/done …}` walk). `apply-on-done-action`'s caller already guards `(nil? on-done)`, so the parallel-root path is untouched.

### Forbidden-vs-wildcard semantics (the headline decision)

A forbidden block is an **enabled** internal candidate, so it **wins its tier and halts** — it does **not** fall through to a same-level `:ns/*` / `:*` nor to a parent. This is the *opposite* of a **guard-blocked** exact candidate, which **does** fall through (rf2-icj9t). The two cases are pinned by contrasting tests. This matches XState v5: a guard-failed transition leaves lower-priority descriptors eligible; a `{E: undefined}` forbidden transition is itself selected and stops selection.

## Spec 005 (hot-zone — sole owner)

- §Transition resolution: new **§Forbidden transitions** subsection documenting the idiom, the two unified spellings (`{}` / `nil`), the present-vs-absent distinction, with the auth-flow worked-example shape.
- §Wildcard transitions: a **"forbidden block is NOT a fallthrough"** note drawing the guard-blocked-vs-forbidden distinction.

## Tests (8 new, `machines_forbidden_transition_cljs_test.cljs`)

(a) empty-map child blocks parent `:logout`; (b) **nil** child also blocks (the fix); (c) absent child key still inherits (regression — absence ≠ block); (d) block carrying an `:action` runs it then halts (parent action does not run, state unchanged); (e) two-level compound — deep-leaf nil block shadows a `:logout` factored two levels up, sibling without the block inherits; (f) forbidden block does **not** fall to `:ns/*` / `:*` / parent `:*`, plus the guard-blocked-fallthrough contrast.

## Gates (all cold, from a fresh `npm install`)

- `npm run test:cljs` — **5573 tests / 19400 assertions, 0 failures** (machines + SCXML-conformance + the 8 new tests). Test execution verified via a temporary sentinel assertion (reverted).
- machines JVM `clojure -M:test` — **451 tests / 1434 assertions, 0 failures** (pure transition + SCXML-conformance + conformance corpus).
- `python scripts/check_doc_slugs.py --verbose` — no broken links.
- `python -m mkdocs build --strict` — built clean, exit 0.