### PR TITLE
refactor(ssr): naming review — rename render-head* meta binding to head-reg (rf2-1irn6)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -136,18 +136,18 @@
   caller-facing `render-head` carries the documented two-shape contract
   on its signature and delegates the work here."
   [head-id {:keys [frame] :as opts}]
-  (let [route (if (contains? opts :route)
-                (:route opts)
-                (frame-route frame))
-        meta  (registrar/lookup :head head-id)]
-    (when-not meta
+  (let [route    (if (contains? opts :route)
+                   (:route opts)
+                   (frame-route frame))
+        head-reg (registrar/lookup :head head-id)]
+    (when-not head-reg
       (throw (ex-info ":rf.error/no-such-head"
                       {:rf.error/id :rf.error/no-such-head
                        :where    'rf/active-head
                        :head-id  head-id
                        :reason   (str "No head registered under " head-id ".")
                        :recovery :no-recovery})))
-    (let [head-fn (:handler-fn meta)
+    (let [head-fn (:handler-fn head-reg)
           db      (when frame (frame/frame-app-db-value frame))
           model   (head-fn db route)]
       (record-fragment! frame head-id model)


### PR DESCRIPTION
## What

Per-slice NAMING review of `implementation/ssr/src/**` (rf2-1irn6, CLARITY-dominant lens).

**Finding: the slice is already exceptionally well-named.** Across all 19 source files the naming is consistent and descriptive — `emit-*` / `walk-*` / `validate-*!` / `*-fx` / `*-template` / `escape-*` / `resolve-*` conventions are applied uniformly, docstrings are thorough, and the public façade is a clean re-export surface. One genuine slice-internal defect met the obvious-rename bar.

## Change

`re-frame.ssr.head.registry/render-head*`: rename the local binding `meta` → `head-reg`.

- The value is the registrar `:head` slot (a registration map carrying `:handler-fn` + source-coords), **not** metadata — `meta` mis-described it.
- `meta` also shadowed `clojure.core/meta`.
- `head-reg` names the value for what it is and matches how the rest of the slice names registrar-lookup results (e.g. `emit/maybe-view`).

Behaviour-preserving: a local rebind inside a private helper. No public surface, no contract, no ids touched.

## Not changed (filed as a bead)

`re-frame.ssr.response/safe-redirect-fx` stamps a `:allow?` error-trace tag whose value is a **vector** (the allowlist), not a boolean — the trailing `?` is misleading. NOT renamed here because the tag is **spec-pinned**: enumerated in `spec/009-Instrumentation.md` (error-event catalogue) and asserted in the ssr e2e test, so a rename touches a hot-zone spec file in lockstep. Filed as **rf2-b9j64** (discovered-from rf2-1irn6).

## Gates (green)

- ssr JVM suite (`clojure -M:test`): 257 tests / 897 assertions / 0 failures — covers the `render-head*` head/meta path directly.
- Full node-runtime CLJS suite (`npm run test:cljs`): 5569 tests / 19401 assertions / 0 failures.

Closes rf2-1irn6.