### PR TITLE
refactor(story-mcp): clarity renames of 3 slice-internal let-bindings (rf2-eul80)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/config.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/config.cljc
@@ -189,14 +189,14 @@
   The caller (`-main`) merges in CLI overrides before calling
   `apply-config!`."
   []
-  (let [wsysprop (System/getProperty "rf.story-mcp.allow-writes")
-        wenv     (System/getenv "RF_STORY_MCP_ALLOW_WRITES")
-        ssysprop (System/getProperty "rf.story-mcp.allow-sensitive-reads")
-        senv     (System/getenv "RF_STORY_MCP_ALLOW_SENSITIVE_READS")]
-    {:allow-writes?          (or (args/parse-boolean wsysprop false)
-                                 (args/parse-boolean wenv false))
-     :allow-sensitive-reads? (or (args/parse-boolean ssysprop false)
-                                 (args/parse-boolean senv false))}))
+  (let [writes-sysprop    (System/getProperty "rf.story-mcp.allow-writes")
+        writes-env        (System/getenv "RF_STORY_MCP_ALLOW_WRITES")
+        sensitive-sysprop (System/getProperty "rf.story-mcp.allow-sensitive-reads")
+        sensitive-env     (System/getenv "RF_STORY_MCP_ALLOW_SENSITIVE_READS")]
+    {:allow-writes?          (or (args/parse-boolean writes-sysprop false)
+                                 (args/parse-boolean writes-env false))
+     :allow-sensitive-reads? (or (args/parse-boolean sensitive-sysprop false)
+                                 (args/parse-boolean sensitive-env false))}))
 
 (defn apply-config!
   "Apply a boot-config map to the runtime atoms. Returns the applied map."

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -217,14 +217,14 @@
   [arguments]
   (targs/with-variant-id arguments
     (fn [vk]
-      (let [atomv (try
-                    (when violations-by-frame-var
-                      (deref @violations-by-frame-var))
-                    (catch Throwable _ nil))
-            violations (when atomv (get atomv vk))
+      (let [by-frame (try
+                       (when violations-by-frame-var
+                         (deref @violations-by-frame-var))
+                       (catch Throwable _ nil))
+            violations (when by-frame (get by-frame vk))
             payload {:variant-id vk
                      :violations (vec (or violations []))
-                     :note       (when (nil? atomv)
+                     :note       (when (nil? by-frame)
                                    "a11y is CLJS-only; this JVM-standalone deploy can't run axe-core. Run the panel in-browser; the violations atom is read by this tool.")}]
         (result/edn-result payload)))))
 

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
@@ -152,10 +152,10 @@
   [result enabled?]
   (if (or (not enabled?) (nil? result))
     result
-    (let [sc (:structuredContent result)]
-      (if (dedup/empty-payload? sc)
+    (let [structured (:structuredContent result)]
+      (if (dedup/empty-payload? structured)
         result
-        (let [deduped (dedup/dedup-value sc true)
+        (let [deduped (dedup/dedup-value structured true)
               text    (result/pr-edn deduped)]
           (-> result
               (assoc :structuredContent deduped)


### PR DESCRIPTION
Per-slice NAMING / best-practice review of `tools/story-mcp/` (rf2-eul80).

## Assessment

The slice is **already well-named throughout** — namespaces, files, functions, `def`s, the MCP tool ids, the wire vocabulary (`:rf.mcp/*`), and the descriptor-manifest surface all read clearly with thorough docstrings. No public/contract renames are warranted (those would be large-blast across mcp-base + conformance, and the names are correct anyway). No follow-up beads filed — nothing uncertain or contentious surfaced.

The only CLARITY wins were three terse slice-internal `let`-bindings, renamed behaviour-preserving:

| File:fn | old -> new |
|---|---|
| `config.cljc` / `read-boot-config` | `wsysprop`/`wenv`/`ssysprop`/`senv` -> `writes-sysprop`/`writes-env`/`sensitive-sysprop`/`sensitive-env` |
| `tools/wire_pipeline.cljc` / `apply-dedup` | `sc` -> `structured` (the `:structuredContent` slot) |
| `tools/testing.cljc` / `tool-run-a11y` | `atomv` -> `by-frame` (the violations-by-frame map) |

No descriptor `:description` or any internal symbol consumed by the manifest generator changed, so `tool-descriptors.edn` is unchanged.

## Gates (cold, from `tools/story-mcp/` + repo npm)

- `clojure -M:test` — 206 tests / 1050 assertions, 0 failures
- `clojure -M:gen --check` — `OK: tool-descriptors.edn in sync (20 tools)`
- `npm run test:mcp-conformance` — ALL GATES GREEN (6/6: JVM tests, stdio roundtrip, pair-mcp, story-mcp end-to-end, CLI flag-vocab, wire-vocab)

Closes rf2-eul80.