### PR TITLE
fix(story): reset all leakable config atoms in test fixtures (rf2-6ez1u)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -885,9 +885,15 @@
   `re-frame.registrar/clear-all!`.
 
   Also:
-  - clears the rf2-835ey global-decorators vector so stale ref-by-id
-    entries do not survive a registrar reset and bleed into the next
-    test;
+  - resets every leakable process-global config atom via
+    `re-frame.story.config/reset-all!` (rf2-6ez1u) — `global-args`
+    (Layer 1 of args resolution), `global-decorators`, `editor`,
+    `project-root`, `show-sensitive?`, and `suppressed-counters` — so
+    a `configure!` (or any config mutation) in one test cannot leak
+    into the next and silently perturb a later variant's effective
+    args. (Subsumes the earlier rf2-835ey global-decorators-only
+    clear; `toggle-off-callbacks` are deliberately left intact — they
+    are load-time module registrations, not per-test state.)
   - resets the rf2-p1ydc auto-install gate so the next `reg-*` call
     after `clear-all!` re-installs the canonical vocabulary on demand
     (the registrar's side-table is now empty — the seven canonical
@@ -895,7 +901,7 @@
     be added)."
   []
   (registrar/clear-all!)
-  (config/set-global-decorators! [])
+  (config/reset-all!)
   (canonical/reset-installed-flag!))
 
 ;; ---- canonical test-fixture helper — DIRECT-REQUIRE, not on this facade -

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -485,3 +485,59 @@
   ([variant-id]
    (swap! suppressed-counters dissoc (or variant-id :global))
    nil))
+
+;; ---- *reset-all!* (rf2-6ez1u — config-leak test-isolation gap) -----------
+;;
+;; Every leakable process-global config atom above is a `defonce` that
+;; survives across tests in the same JVM run / browser page. The test
+;; fixtures (`re-frame.story/clear-all!`, `re-frame.story.test-support/
+;; story-reset!`) historically reset only the registrar side-table, the
+;; global-decorators vector, the canonical auto-install gate, and the
+;; play run-state — they did NOT touch these config atoms.
+;;
+;; That left a green-but-wrong footgun: a test that called
+;; `(story/configure! {:rf.story/global-args {...}})` or flipped
+;; `:rf.privacy/show-sensitive?` leaked that global state into every
+;; SUBSEQUENT test. Because `global-args` is Layer 1 of args resolution
+;; (`re-frame.story.args/resolve-args` reads `(get-global-args)` at
+;; resolve time), a leaked global arg silently changes the EFFECTIVE
+;; args of an unrelated later variant — order-dependent, hard to debug,
+;; and exactly the footgun class `test_support` exists to close.
+;;
+;; `reset-all!` restores every leakable atom to its load-time default so
+;; the test fixtures can call it once and guarantee a clean config slate.
+;; It deliberately does NOT clear `toggle-off-callbacks` — those are
+;; load-time module registrations (`ui.trace` wires its `clear-buffer!`
+;; once at ns-load), not per-test state; wiping them would silently
+;; break the retroactive-scrub hook for the rest of the run.
+;;
+;; `show-sensitive?` is `reset!` directly (not via `set-show-sensitive!`)
+;; so a reset does NOT fire the true → false toggle-off callbacks —
+;; `reset-all!` restores the load-time default, it does not simulate a
+;; live runtime privacy-toggle.
+
+(defn reset-all!
+  "Reset every leakable process-global config atom to its load-time
+  default. Called by the Story test fixtures (`re-frame.story/clear-all!`
+  and `re-frame.story.test-support/story-reset!`) so a `configure!` (or
+  any other config mutation) in one test cannot leak into the next.
+
+  Resets, in declaration order:
+  - `global-args`        → `{}`     (Layer 1 of args resolution)
+  - `global-decorators`  → `[]`
+  - `editor`             → `:vscode`
+  - `project-root`       → `nil`
+  - `show-sensitive?`    → `false`  (reset directly — does NOT fire the
+                                     true → false toggle-off callbacks)
+  - `suppressed-counters`→ `{}`
+
+  Deliberately leaves `toggle-off-callbacks` intact — those are
+  load-time module registrations, not per-test state (per rf2-6ez1u)."
+  []
+  (reset! global-args {})
+  (reset! global-decorators [])
+  (reset! editor :vscode)
+  (reset! project-root nil)
+  (reset! show-sensitive? false)
+  (reset! suppressed-counters {})
+  nil)

--- a/tools/story/src/re_frame/story/test_support.cljc
+++ b/tools/story/src/re_frame/story/test_support.cljc
@@ -111,10 +111,12 @@
   caller's `:install` thunks against the fresh registry."
   [install]
   ;; Mirror `re-frame.story/clear-all!` exactly: reset the side-table,
-  ;; clear the global-decorators vector, and reset the canonical-vocab
-  ;; auto-install gate.
+  ;; reset every leakable process-global config atom (rf2-6ez1u —
+  ;; global-args/global-decorators/editor/project-root/show-sensitive?/
+  ;; suppressed-counters; so a `configure!` in one test cannot leak into
+  ;; the next), and reset the canonical-vocab auto-install gate.
   (registrar/clear-all!)
-  (config/set-global-decorators! [])
+  (config/reset-all!)
   (canonical/reset-installed-flag!)
   (runner-events/clear-all-runs!)
   (canonical/install!)

--- a/tools/story/test/re_frame/story/test_support_test.clj
+++ b/tools/story/test/re_frame/story/test_support_test.clj
@@ -24,6 +24,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story :as story]
+            [re-frame.story.config :as config]
             [re-frame.story.test-support :as story-test]
             [re-frame.story.play.runner-events :as runner-events]))
 
@@ -123,3 +124,107 @@
               (:lifecycle (run-target :story.fixture/bracketed))))]
       (is (= :ready lifecycle)
           "the bracketed run reached :ready (no :pre-mount footgun)"))))
+
+;; ---- 4. config-leak isolation (rf2-6ez1u) --------------------------------
+;;
+;; The fixture (`story-reset!`) calls `config/reset-all!`, which restores
+;; every leakable process-global config atom. These tests lock that a
+;; `configure!` (or any config mutation) in one test cannot leak into a
+;; sibling test in the same JVM run. The footgun the bead names:
+;; `global-args` is Layer 1 of args resolution, so a leaked global arg
+;; silently changes the EFFECTIVE args of an unrelated later variant.
+;;
+;; The two `config-isolation-*` tests mirror the `install-thunk-ran-*`
+;; sibling-pair pattern above: whichever runs first asserts the pristine
+;; default (proving NO prior test leaked) THEN mutates config; the other
+;; proves the mutation did not survive the fixture reset — independent of
+;; clojure.test's run order.
+
+(deftest config-reset-all-restores-every-leakable-atom
+  (testing "config/reset-all! (called by the fixture) restores every
+            leakable config atom to its load-time default — direct,
+            order-independent unit coverage of the reset surface
+            (rf2-6ez1u)"
+    ;; Dirty every leakable atom via the public configure! surface…
+    (story/configure! {:rf.story/global-args       {:theme :dark}
+                       :rf.story/editor            :cursor
+                       :rf.story/project-root      "/tmp/proj"
+                       :rf.privacy/show-sensitive? true})
+    (config/note-suppressed! :some.variant/x)
+    (config/add-global-decorator! [:some/global-decorator])
+    ;; sanity: the mutations landed
+    (is (= {:theme :dark} (config/get-global-args)))
+    (is (true? (config/get-show-sensitive)))
+    ;; …then reset and assert the pristine load-time defaults.
+    (config/reset-all!)
+    (is (= {}      (config/get-global-args))      "global-args → {}")
+    (is (= []      (config/get-global-decorators)) "global-decorators → []")
+    (is (= :vscode (config/get-editor))           "editor → :vscode")
+    (is (nil?      (config/get-project-root))     "project-root → nil")
+    (is (false?    (config/get-show-sensitive))   "show-sensitive? → false")
+    (is (= 0       (config/suppressed-count :some.variant/x))
+        "suppressed-counters → {}")))
+
+(deftest config-reset-all-leaves-toggle-off-callbacks
+  (testing "config/reset-all! does NOT clear toggle-off-callbacks — those
+            are load-time module registrations, not per-test state
+            (rf2-6ez1u). Resetting show-sensitive? also does not FIRE them
+            (reset! restores the default; it does not simulate a runtime
+            true → false privacy toggle)."
+    (let [fired (atom 0)]
+      (config/register-toggle-off-callback! ::probe #(swap! fired inc))
+      ;; flip on via the public surface, then reset-all!
+      (config/set-show-sensitive! true)
+      (config/reset-all!)
+      (try
+        (is (false? (config/get-show-sensitive))
+            "the flag was restored to its false default")
+        (is (zero? @fired)
+            "reset-all! restored the flag without firing the toggle-off hook")
+        ;; the callback is still REGISTERED — a real runtime toggle fires it
+        (config/set-show-sensitive! true)
+        (config/set-show-sensitive! false)
+        (is (= 1 @fired)
+            "the load-time callback survived reset-all! and still fires on a
+             real true → false runtime toggle")
+        (finally
+          (config/unregister-toggle-off-callback! ::probe))))))
+
+(deftest config-isolation-a
+  (testing "this test sees a pristine global config (no sibling leaked into
+            it) THEN dirties global-args — the fixture must roll it back
+            before config-isolation-b runs (rf2-6ez1u)"
+    (is (= {} (config/get-global-args))
+        "global-args is the pristine {} default — no sibling test leaked a
+         configure! into this one")
+    (is (false? (config/get-show-sensitive))
+        "show-sensitive? is the pristine false default")
+    ;; A variant with NO args resolves to exactly the empty global layer.
+    (story/reg-variant :story.cfg/probe-a {:tags #{:test}})
+    (is (= {} (story/resolve-args :story.cfg/probe-a))
+        "with a clean global layer, an arg-less variant resolves to {}")
+    ;; Now leak a Layer-1 global arg + flip the privacy gate. If the
+    ;; fixture's config/reset-all! did NOT run, config-isolation-b would
+    ;; observe these.
+    (story/configure! {:rf.story/global-args       {:rf.cfg/leaked :from-a}
+                       :rf.privacy/show-sensitive? true})
+    (is (= {:rf.cfg/leaked :from-a} (story/resolve-args :story.cfg/probe-a))
+        "the leaked global arg IS Layer 1 of resolution within this test —
+         which is exactly why it must not survive into the next")))
+
+(deftest config-isolation-b
+  (testing "the sibling test sees its OWN clean config slate — the
+            global-args + show-sensitive? config-isolation-a set are gone
+            (config/reset-all! ran in the fixture between them) (rf2-6ez1u)"
+    (is (= {} (config/get-global-args))
+        "config-isolation-a's leaked global-args did NOT survive the reset")
+    (is (false? (config/get-show-sensitive))
+        "config-isolation-a's show-sensitive? flip did NOT survive the reset")
+    (story/reg-variant :story.cfg/probe-b {:tags #{:test}})
+    (is (= {} (story/resolve-args :story.cfg/probe-b))
+        "with the global layer reset, an arg-less variant resolves to {} —
+         NOT to {:rf.cfg/leaked :from-a} (the green-but-wrong footgun this
+         closes)")
+    ;; leak our own, symmetric to the a/b pattern — config-isolation-a's
+    ;; reset proves the converse direction too under either run order.
+    (story/configure! {:rf.story/global-args {:rf.cfg/leaked :from-b}})))


### PR DESCRIPTION
## What

`re-frame.story/clear-all!` and the canonical per-test fixture `re-frame.story.test-support/story-reset!` reset the registrar side-table, `global-decorators`, the canonical auto-install gate, and play run-state — but **not** the rest of the leakable process-global config atoms: `config/global-args`, `show-sensitive?`, `editor`, `project-root`, `suppressed-counters`.

Because `global-args` is **Layer 1 of args resolution** (`args/resolve-args` reads `(config/get-global-args)` at resolve time, `args.cljc:133`), a `(story/configure! {:rf.story/global-args {...}})` or `:rf.privacy/show-sensitive?` flip in one test silently leaked into every subsequent test in the same JVM run / browser page — a green-but-wrong, order-dependent footgun, exactly the class `test_support` was built to close (rf2-6ez1u, from the story senior-dev review as4fp).

## Change

- **`config/reset-all!`** (`config.cljc`) — resets every leakable process-global atom to its load-time default: `global-args` to `{}`, `global-decorators` to `[]`, `editor` to `:vscode`, `project-root` to `nil`, `show-sensitive?` to `false`, `suppressed-counters` to `{}`. Deliberately leaves `toggle-off-callbacks` (load-time module registrations, not per-test state). `show-sensitive?` is `reset!` directly — a reset restores the default, it does NOT fire the true to false toggle-off callbacks.
- Wired into **`story/clear-all!`** (subsumes the old `set-global-decorators! []`-only clear; docstring updated) and **`test_support/story-reset!`**.
- **Isolation regression tests** (`test_support_test.clj`, JVM): a direct `reset-all!` surface check, a toggle-off-callback-survival check, and a sibling pair (`config-isolation-a`/`-b`) proving a `configure!` in one test does not leak into the next.

## Verification

- Negative-control: neutering `reset-all!` (no-op body) makes the new isolation tests fail exactly as designed (`config-isolation-b` observes `-a`'s leaked `global-args`), proving the tests have teeth.
- `clojure -M:test` (tools/story): 1594 tests / 5971 assertions, 0 failures, 0 errors.
- `npm run test:cljs` (implementation node-test): 5576 tests / 19411 assertions, 0 failures, 0 errors.
- No existing test depended on the leak — `sensitive_trace_cljs_test` has its own self-contained `reset-config!` fixture (unaffected).

Closes rf2-6ez1u.
