### PR TITLE
refactor(machines-viz): excise dead edge classifier + constants, unify arrowhead, reconcile spec (rf2-dt5b1)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -499,28 +499,36 @@ label for DOM tests; a non-self-loop edge carries no `data-loop-index`.
 
 ### Label rendering — padded backgrounds (rf2-j10sm Phase 1, D)
 
-Every edge label paints with an **opaque chart-bg backplate** (the
-canvas's own `:bg-1` token, alpha-controlled by
-`:edge-label-backplate-opacity`) and **light text** (`:text-primary`)
-on top — so a label sitting over a node, an edge, or another label
-visually "punches through" with the surrounding canvas colour rather
-than merging into the ink below.
+> **Mostly moot under events-as-nodes (rf2-qo5xy).** The event /
+> guard / action text rides on the event-NODE; the structural in/out
+> edges carry an empty `:eventLabel`, so most edges paint no label.
+> The rare labelled edge (a directly-constructed edge) still paints a
+> padded backplate per the geometry below.
+
+A painted edge label uses an **opaque chip backplate** (the active
+theme's `:event-chip-bg` token — the same neutral fill the event-node
+route chip uses) and **light text** (`:text-primary`) on top, so a
+label sitting over a node, an edge, or another label visually "punches
+through" with the surrounding canvas colour rather than merging into
+the ink below.
 
 Geometry is invariant across densities:
 
 | Style key | Value | Why |
 |---|---|---|
 | `border-radius` | 4px | Softens the chip without reading as product chrome (matches the chart's `:corner-radius` family). |
-| `padding` | `2px 6px` | Adequate breathing room for the mono label glyphs at the regular chart-floor font sizes. |
-| `border` | `1px solid border-default` (idle) / `1px solid yellow` (clickable, host-fed sim) | Idle labels read as a "card" against the canvas; clickable labels stay distinct from inert auto edges (`:after` / `:always`). |
-| `background` | `bg-1` × `edge-label-backplate-opacity` | The chart canvas paints `:bg-1`; an opaque-ish label background blends into it so adjacent labels don't form a solid stacked tile. |
-| `color` | `text-primary` | Light text on dark canvas — matches the chart's text-on-bg posture. |
+| `padding` | `2px 6px` | Adequate breathing room for the label glyphs at the regular chart-floor font sizes. |
+| `border` | `1px solid :event-chip-border` (idle) / `1px solid :sim` (clickable, host-fed sim) | Idle labels read as a "card" against the canvas; clickable labels stay distinct from inert auto edges (`:after` / `:always`). |
+| `background` | `:event-chip-bg` (theme token) | An opaque neutral chip fill so adjacent labels don't form a solid stacked tile and the text punches through the ink below. |
+| `color` | `:text-primary` | Light text on dark canvas — matches the chart's text-on-bg posture. |
 | `z-index` | 5 | Above edges + node borders, below xyflow's `Controls` chrome (which renders at z 6+). |
 
-`:edge-label-backplate-opacity` rides the density map (per
-`visual-constants/chart-*`) and is invariant across the three
-densities (the backplate's contrast budget doesn't scale with type
-size — same posture as pre-rf2-j10sm).
+The backplate fill is a flat theme token (`:event-chip-bg`), not a
+density-scaled opacity — its contrast budget doesn't scale with type
+size, so it reads the same across the three densities. (rf2-dt5b1 — the
+unread `:edge-label-backplate-opacity` density key it once referenced
+was removed; the renderer always painted the opaque token, never an
+alpha-scaled `:bg-1`.)
 
 ### Cross-hierarchy label placement (rf2-shv82, Issue 3)
 
@@ -688,12 +696,18 @@ For the supplied `:definition`, the chart shows:
   is the unambiguous final-state signal.
 - **State tags render as a visible pill row + hover tooltip
   (rf2-a2b55; rf2-so5b0).** A state's declared `:tags` set (Spec 005
-  §State tags) renders as a row of `tag-pill-color`-coloured pills
-  positioned BELOW the state name (Stately graph view convention).
-  Each pill carries a `rf-mv-chart-state-tag-<name>` testid + a
-  `data-tag` attr. In parallel, the whole set surfaces on the
-  state-node's `title` attr (native HTML hover tooltip) + `data-tags`
-  attr (sorted space-joined string for DOM tests + host
+  §State tags) renders as a row of **neutral** pills (one structural
+  fill `:container-header-bg` + `:state-border` border + `:text-
+  secondary` text) positioned BELOW the state name (Stately graph view
+  convention). Structure wins over annotation colour for the topology
+  view, so the chart reads as containment + transition flow, not a
+  rainbow of tag hues (rf2-az6e2; the deterministic per-tag colour
+  rotation `tag-pill-color` / `tag-pill-palette` it once used was
+  removed rf2-dt5b1 — it coloured nothing the renderer paints). Each
+  pill carries a `rf-mv-chart-state-tag-<name>` testid + a `data-tag`
+  attr preserving the declared tag identity. In parallel, the whole set
+  surfaces on the state-node's `title` attr (native HTML hover tooltip)
+  + `data-tags` attr (sorted space-joined string for DOM tests + host
   introspection) — the rf2-so5b0 host-introspection contract. (The
   rf2-so5b0 retirement of the visible row was reverted by rf2-a2b55
   on a paradigm-matched look at Stately's graph view, which paints
@@ -721,7 +735,9 @@ For the supplied `:definition`, the chart shows:
   children + the join state. There is deliberately no `spawn` topology
   edge — `:spawn` / `:spawn-all` are state-entry actions, so spawned
   children surface through this overlay, not as a row of nodes (per
-  `chart.projection/choose-edge-type` and
+  the [§Events as nodes](#events-as-nodes--stately-graph-view-paradigm-rf2-qo5xy)
+  paradigm — every projected edge is the canonical `transition` type
+  and the parser emits no spawn edge — and
   [Xray 003 §`:spawn-all` viz](../../xray/spec/003-Machine-Inspector.md#spawn-all-viz)).
 - **Cancellation cascade (overlay, host-fed).** When the host passes an
   `{:id :cancellation-cascade :spec <map> …}` descriptor in the
@@ -858,17 +874,21 @@ product' character (rf2-g6cig) holds. Specifically:
   read as a different chart, not a smaller one; a 'cosy' chart with
   `corner-radius 10` would read as 'product chrome'. The lock means
   the chart's silhouette is the same at every scale.
-- **`edge-label-backplate-opacity` is invariant** across densities
-  (rf2-gg7ws collision-avoidance v1 — the backplate's contrast
-  budget doesn't scale with type size).
-- **`dot-grid-alpha` is invariant** — the backdrop's subtlety
-  doesn't track density.
+
+The chart's two contrast-budget constants — the edge-label backplate
+fill and the dot-grid backdrop subtlety — also do not scale with type
+size, but they are NOT density-map keys: the backplate paints the flat
+`:event-chip-bg` theme token (no opacity key), and the dot grid is
+xyflow's `<Background>` `:gap` / `:size` with no alpha. (rf2-dt5b1 —
+the unread `:edge-label-backplate-opacity` / `:dot-grid-alpha` density
+keys these bullets once named were removed; no renderer read them.)
 
 Every other geometry / typography knob (`stroke-width`, paddings,
-pill geometry, every `*-px` font size, the dot-grid `spacing-px` /
-`radius-px`) tracks the density axis monotonically: `:compact <
-:regular < :cosy`. The three named maps in `visual-constants` share
-the SAME key set (asserted by `visual-constants-cljs-test`).
+pill geometry, every `*-px` font size, the edge `arrow-width` family,
+the dot-grid `spacing-px` / `radius-px`) tracks the density axis
+monotonically: `:compact < :regular < :cosy`. The three named maps in
+`visual-constants` share the SAME key set (asserted by
+`visual-constants-cljs-test`).
 
 ### Resolution rules
 
@@ -1015,8 +1035,13 @@ colour is subordinate to structure**.
   [`001-Topology-Parity.md`](001-Topology-Parity.md) §History.
 - **Arrow/routing**: the two-edge event-node route reads as **one
   transition** — a quiet source→event segment (thinner stroke, small
-  arrowhead, `:edge-quiet`) and a primary event→target segment (full
-  arrowhead). Fired/focused lights **both** segments together.
+  `:arrow-width-quiet` arrowhead, `:edge-quiet`) and a primary
+  event→target segment (full `:arrow-width` arrowhead). Both arrowhead
+  WIDTHS ride the density map alongside the stroke, and the arrowhead
+  COLOUR resolves through the same `theme.tokens/edge-color` helper the
+  SVG stroke uses (so a head and its stroke can never disagree on
+  colour — rf2-dt5b1). Fired/focused lights **both** segments together
+  (`fired?` > `focused?`/`active?` > quiet).
 - **Typography hierarchy** (loudest → quietest): **state title**
   (`state-title-px`, weight 500/600) › **event chip** (`event-chip-px`)
   › **action chip** (`action-pill-px`, weight 500, `text-secondary`) ›

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -593,11 +593,10 @@
 
 ;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
 ;;
-;; rf2-0gmwp — the pure projector (`xyflow-graph` / `choose-edge-type`
-;; / the elk `children` shape) moved to `chart.projection` so the JVM
-;; test corpus can pin it without loading xyflow/elkjs. `chart.cljs`
-;; retains only the JS-interop layout glue above + the React component
-;; below.
+;; rf2-0gmwp — the pure projector (`xyflow-graph` / the elk `children`
+;; shape) moved to `chart.projection` so the JVM test corpus can pin it
+;; without loading xyflow/elkjs. `chart.cljs` retains only the JS-interop
+;; layout glue above + the React component below.
 
 ;; ---- inline keyframes ---------------------------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -9,28 +9,26 @@
 
   ## Edge kinds (per the bead's scope §Custom edges)
 
-    - `transition-edge` — the canonical edge. Renders the route ELK
-      computed (a smooth poly-path THROUGH ELK's bend-points, rf2-cz8v6)
-      with the event label sitting where ELK placed it (rf2-rlq97 —
-      `:labelPos`, ELK's reserved label channel) behind a small
-      backplate rect. When ELK placed no label (the events-as-nodes
-      default — the transition text rides on the event-NODE) the anchor
-      falls back to a geometric midpoint heuristic.
-    - `after-edge` — `:after`-timer edge. Same path as transition-
-      edge but renders the label as `after(<ms>)` and exposes a
-      `:data-after-ms` attr so a host-side overlay can find the
-      ring's bearing node.
+    - `transition-edge` — the canonical (and only) edge type. Renders
+      the route ELK computed (a smooth poly-path THROUGH ELK's bend-
+      points, rf2-cz8v6) with the event label sitting where ELK placed
+      it (rf2-rlq97 — `:labelPos`, ELK's reserved label channel) behind
+      a small backplate rect. When ELK placed no label (the events-as-
+      nodes default — the transition text rides on the event-NODE) the
+      anchor falls back to a geometric midpoint heuristic. Under events-
+      as-nodes EVERY projected edge is this type; `:after`-timer
+      specifics ride the event-NODE (`:variant \"after\"` + `:afterMs`),
+      not a distinct edge type, so the dead `after-edge` alias + the
+      `choose-edge-type` classifier were removed (rf2-dt5b1).
 
   rf2-0gmwp — there is no `spawn` edge type. Per Spec 005 `:spawn` /
   `:spawn-all` are state-entry actions that bring CHILD actor machines
   into existence; they are NOT same-machine transitions, so the parse
-  (`chart.layout`) emits no spawn edge and `chart.projection/`
-  `choose-edge-type` has no `spawn` arm to classify into. Spawned
-  children surface through the `chart.overlays.spawn-all-join`
-  inspector (anchored beside the spawn-bearing state), not as an edge
-  in this chart. The previously-registered `spawn-edge` component was
-  dead registration — never reachable from any parsed edge — and was
-  removed.
+  (`chart.layout`) emits no spawn edge. Spawned children surface
+  through the `chart.overlays.spawn-all-join` inspector (anchored
+  beside the spawn-bearing state), not as an edge in this chart. The
+  previously-registered `spawn-edge` component was dead registration —
+  never reachable from any parsed edge — and was removed.
 
   ## Substrate posture
 
@@ -124,6 +122,13 @@
      (/ (+ (.-y a) (.-y b)) 2)]))
 
 ;; ---- self-loop fan geometry (rf2-shv82, Issue 2) -----------------------
+;;
+;; FALLBACK-ONLY (rf2-dt5b1): the projector never emits `:selfLoop true`
+;; under events-as-nodes (each self-event is its own event-node), so this
+;; perimeter-fan geometry is unreachable from `chart.projection`. It is
+;; retained for direct `edge-path` callers that construct a self-loop edge
+;; explicitly — the spec commits to it (spec/API.md §Self-loop fan;
+;; 001-Topology-Parity.md). Do NOT delete.
 ;;
 ;; Multiple self-loops on the same node (e.g. `:disconnected` has 3:
 ;; `:ws/arm-fail`, `:ws/disarm-fail`, `:ws/clear`) all anchored at the
@@ -339,12 +344,14 @@
   (`ct`): fired = `:edge-fired`, focused/active = `:edge-active`, resting
   = `:edge-quiet`. The QUIET source→event segment (`quiet?`) paints the
   quiet colour even when the route is otherwise resting so the pair reads
-  as one transition with the primary arrowhead on the event→target half."
-  [ct {:keys [active? focused? fired?]}]
-  (cond
-    fired?                (:edge-fired ct)
-    (or focused? active?) (:edge-active ct)
-    :else                 (:edge-quiet ct)))
+  as one transition with the primary arrowhead on the event→target half.
+
+  rf2-dt5b1 — delegates to the shared `tokens/edge-color`, the SINGLE
+  source the projector's arrowhead-`:markerEnd` colour also routes
+  through, so a stroke and its arrowhead can never resolve different
+  colours for the same edge state."
+  [ct flags]
+  (tokens/edge-color ct flags))
 
 (defn- edge-stroke-width
   "rf2-k647w — edge stroke widths read off the resolved density. The
@@ -594,21 +601,6 @@
                            :white-space      "nowrap"}}
             (str "+ " action-str)])]])])))
 
-;; ---- after-edge ---------------------------------------------------------
-
-;; rf2-gpzb4 — :after-timer edges share the transition-edge body but
-;; carry the after-ms duration as a data-attribute so a host-side
-;; overlay (Xray's machine_after_rings ns) can find the bearing
-;; node and paint a countdown ring on top. The default styling is
-;; identical to transition-edge; future polish (a small countdown-
-;; ring glyph rendered inline on the label) can land in a follow-on
-;; bead.
-
-(def after-edge
-  "Alias for `transition-edge` — `:after`-edge specifics ride on the
-  `:data {:after-ms}` attr; the rendering shape is the same."
-  transition-edge)
-
 ;; ---- edge-types map -----------------------------------------------------
 
 (defn edge-types
@@ -616,10 +608,12 @@
   plain-JS object on every call; callers SHOULD memoise this map at
   component-construction time to avoid re-render churn.
 
-  Only `transition` + `after` are registered — every parsed edge maps
-  to one of those two via `chart.projection/choose-edge-type`. There
-  is no `spawn` type (rf2-0gmwp): spawns are state-entry actions, not
-  edges (see the ns docstring)."
+  Only `transition` is registered — under events-as-nodes EVERY
+  projected edge is the canonical `transition` type (rf2-dt5b1). The
+  `:after`-timer specifics ride the event-NODE (`:variant \"after\"`
+  + `:afterMs`), not a distinct edge type; the dead `after` alias +
+  the `choose-edge-type` classifier it depended on were removed. There
+  is no `spawn` type either (rf2-0gmwp): spawns are state-entry
+  actions, not edges (see the ns docstring)."
   []
-  #js {"transition" transition-edge
-       "after"      after-edge})
+  #js {"transition" transition-edge})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -15,9 +15,10 @@
       `chart.layout/parse-definition` output + a `{node-id position}`
       map into the xyflow `:nodes` + `:edges` shape, carrying the
       per-node / per-edge `:data` payloads (active / from-highlight /
-      to-highlight / sim flags, event labels, tags).
-    - `choose-edge-type` — maps a parsed edge to its registered
-      xyflow edge-type id.
+      to-highlight / sim flags, event labels, tags). Every projected
+      edge is the canonical transition type — under events-as-nodes
+      the `:after`-timer specifics ride the event-NODE (`:variant`
+      after + `:afterMs`), not a distinct edge type.
     - `->elk-children` — the elk.js `children` projection (flat for
       plain machines, nested region containers for parallel ones).
     - The node-size floor constants the elk projection + the node
@@ -468,26 +469,6 @@
    (vec (mapcat #(->elk-edge % label-dims) edges))))
 
 ;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
-
-(defn choose-edge-type
-  "Map a parsed edge to its registered xyflow edge-type id (one of the
-  keys in `chart.edges/edge-types`).
-
-  `:after`-timer edges render via the dedicated `after` type (it adds
-  the `after(<ms>)` label + `data-after-ms` attr the ring overlay
-  reads). Every other edge — plain `:on` transitions AND `:always`
-  eventless transitions — renders via the canonical `transition` type;
-  `:always` carries no distinct edge type (its `always` label segment
-  is composed upstream in `chart.layout/edge-label`).
-
-  Note there is deliberately NO `spawn` arm: per Spec 005 `:spawn` /
-  `:spawn-all` are state-entry actions that bring CHILD actor machines
-  into existence — they are not same-machine transitions, so the parse
-  emits no spawn edge for `choose-edge-type` to classify. Spawned
-  children surface through the `chart.overlays.spawn-all-join`
-  inspector, not as an edge in this chart."
-  [edge]
-  (if (:after edge) "after" "transition"))
 
 (defn xyflow-graph
   "Project the parsed graph + a `{node-id position}` map into the
@@ -966,20 +947,26 @@
         ;; `events-as-nodes-edge` builds one half from those few
         ;; differing values so the shared shape lives in ONE place (the
         ;; two were copy-pasted before, drifting risk on every `:data`
-        ;; key add). `half` is `:in` (quiet source→event, 10px arrowhead)
-        ;; or `:out` (primary event→target, 18px arrowhead).
+        ;; key add). `half` is `:in` (quiet source→event, quiet
+        ;; arrowhead) or `:out` (primary event→target, primary arrowhead).
+        ;; rf2-dt5b1 — the arrowhead COLOUR routes through the shared
+        ;; `tokens/edge-color` (the SAME helper `chart.edges/edge-stroke`
+        ;; uses for the SVG path) so the head + stroke cannot disagree;
+        ;; the arrowhead SIZE reads off the resolved density `chart` map
+        ;; (`:arrow-width-quiet` for `__in`, `:arrow-width` for `__out`)
+        ;; so the head scales with the stroke instead of a baked literal.
         marker-color
         (fn [{:keys [fired? focused? from-active?]}]
-          (cond
-            fired?       (:edge-fired ct)
-            focused?     (:edge-active ct)
-            from-active? (:edge-active ct)
-            :else        (:edge-quiet ct)))
+          (tokens/edge-color ct {:fired?   fired?
+                                 :focused? focused?
+                                 :active?  from-active?}))
         events-as-nodes-edge
         (fn [half {:keys [edge ev-node-id from-active? focused? fired?
                           cross-hier?] :as desc} points label-pos]
           (let [in? (= half :in)
-                w   (if in? 10 18)]
+                w   (if in?
+                      (:arrow-width-quiet chart)
+                      (:arrow-width chart))]
             {:id        (str (:id edge) (if in? "__in" "__out"))
              :source    (if in? (:source edge) ev-node-id)
              :target    (if in? ev-node-id (:target edge))
@@ -1080,10 +1067,14 @@
                  :target      (:id n)
                  :targetHandle "left"
                  :type        "transition"
+                 ;; rf2-dt5b1 — the entry-edge arrowhead is a resting
+                 ;; quiet marker (`tokens/edge-color` with all flags
+                 ;; false ⇒ `:edge-quiet`) sized off the resolved density
+                 ;; (`:arrow-width-entry`) like the route arrowheads.
                  :markerEnd   {:type "arrowclosed"
-                               :color (:edge-quiet ct)
-                               :width 12
-                               :height 12}
+                               :color (tokens/edge-color ct {})
+                               :width  (:arrow-width-entry chart)
+                               :height (:arrow-width-entry chart)}
                  ;; Entry edges are non-interactive, but carry the full
                  ;; edge `:data` shape (flags + threaded callback/chart)
                  ;; so the "every edge has X" projection invariants hold.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -356,6 +356,27 @@
       :glow        (with-alpha :info   0.18 palette)
       :glow-fired  (with-alpha :accent 0.18 palette)})))
 
+(defn edge-color
+  "rf2-dt5b1 — the SINGLE source of an edge's stroke + arrowhead colour
+  given its runtime flags, resolved against a `chart-tokens` map `ct`.
+
+  Both the renderer (`chart.edges/edge-stroke`, painting the SVG path)
+  and the projector (`chart.projection`, baking the `:markerEnd :color`
+  the arrowhead paints) route through this fn so a stroke and its
+  arrowhead can never disagree on colour for the same edge state.
+
+  Ordering (XState/Stately gold standard): `fired?` (the edge traversed
+  THIS epoch) wins over `focused?` / `active?` so a fired arm reads as
+  'what just happened' in the FIRED hue; focused / active share the
+  ACTIVE hue; everything else is the resting QUIET hue.
+
+  Pure data → string; JVM-portable."
+  [ct {:keys [active? focused? fired?]}]
+  (cond
+    fired?                (:edge-fired ct)
+    (or focused? active?) (:edge-active ct)
+    :else                 (:edge-quiet ct)))
+
 (defn theme-palette
   "rf2-az6e2 — resolve a `:theme` keyword (`:dark` / `:light`) to its
   base palette via `palettes`. nil / unknown → `dark-palette` (the Xray
@@ -420,44 +441,12 @@
   [ms]
   (str "calc(" ms "ms * var(" (:scale-var-name motion) ", 1))"))
 
-;; ---- tag-pill palette (rf2-m1b88; rf2-a2b55 restored) ------------------
-;;
-;; rf2-so5b0 retired this pair when the visible state-tag pill row was
-;; dropped. rf2-a2b55 reinstates the visible pill row BELOW the state
-;; name (Stately graph view convention: descriptive tags ride a pill
-;; row directly under the state title, not as ancestor-path chips
-;; above), so the deterministic colour rotation is live again. A given
-;; tag id resolves to the same palette token across renders so tests +
-;; the human eye can rely on identity-by-colour.
-
-(def tag-pill-palette
-  "Deterministic colour rotation for state-tag pills (rf2-m1b88;
-  rf2-a2b55 restored). Skips `:red`, `:accent` and `:info` — all
-  reserved for chart semantics (`:red` for cancellation glyphs, the
-  single `:accent` for the initial-state marker + FROM-highlight,
-  `:info` for the TO-highlight / active state). The remaining five
-  spread across cool/warm/neutral so a typical 2-4 tag count reads
-  distinctly."
-  [:advisory :green :yellow :orange :magenta])
-
-(defn- char-code
-  "Portable char → int. JVM uses `int`; CLJS reaches for
-  `charCodeAt` on the string at the per-char index."
-  [^String s idx]
-  #?(:clj  (int (.charAt s ^int idx))
-     :cljs (.charCodeAt s idx)))
-
-(defn tag-pill-color
-  "Map a tag keyword to a stable palette entry. Deterministic — the
-  same tag id resolves to the same token across renders. Pure data
-  → keyword."
-  [tag]
-  (let [^String s (str (when-let [n (and (keyword? tag) (namespace tag))]
-                         (str n "/"))
-                       (if (keyword? tag) (name tag) (str tag)))
-        n (count s)
-        h (loop [i 0 acc 0]
-            (if (< i n)
-              (recur (inc i) (+ acc (char-code s i)))
-              acc))]
-    (nth tag-pill-palette (mod h (count tag-pill-palette)))))
+;; rf2-dt5b1 — the deterministic tag-pill colour rotation
+;; (`tag-pill-palette` / `tag-pill-color`, rf2-m1b88 / rf2-a2b55) was
+;; RETIRED. `chart.nodes/tag-pill` renders every state-tag chip in ONE
+;; neutral style (`:container-header-bg` fill + `:state-border` border +
+;; `:text-secondary` text): structure wins over annotation colour for the
+;; topology view, so the chart reads as containment + transition flow,
+;; not a rainbow of tag hues. Tag IDENTITY survives on the chip's
+;; `data-tag` / `title` attrs + the state-node's `data-tags`. The rotation
+;; had no live caller (it coloured nothing the renderer paints).

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -21,14 +21,27 @@
   three maps share the SAME key set (asserted by
   `visual-constants-cljs-test`); a key in one is a key in all.
 
-  rf2-cd053 / rf2-gg7ws — `chart-regular` state-label + edge-label
-  font sizes walked up from the previous spec/007-UX-IA refused-floor
-  (11 / 9) to a chart-appropriate 13 / 11 per the 2026-05-20 visual-
-  quality lift. The refused-floor was set for dense data-grid
-  surfaces; applying it to a chart that competes with xstate-stately's
-  typography was a category error. `chart-compact` deliberately walks
-  back to 11/9 since the compact density IS the dense-grid surface
-  the original floor existed for; `chart-cosy` walks up to 15/13.
+  rf2-cd053 / rf2-gg7ws — `chart-regular`'s edge-label font size walked
+  up from the previous spec/007-UX-IA refused-floor (9) to a chart-
+  appropriate 11 per the 2026-05-20 visual-quality lift. The refused-
+  floor was set for dense data-grid surfaces; applying it to a chart
+  that competes with xstate-stately's typography was a category error.
+  `chart-compact` deliberately walks back to 9 since the compact density
+  IS the dense-grid surface the original floor existed for; `chart-cosy`
+  walks up to 13. (The state-node label rides `:state-title-px` under
+  the rf2-az6e2 structured grammar; the old `:state-label-px` key it
+  superseded was removed rf2-dt5b1 — see below.)
+
+  rf2-dt5b1 — removed seven density-map keys no renderer ever read:
+  `:state-label-px` (superseded by `:state-title-px`), `:compound-pad-x`
+  / `:compound-pad-y` / `:compound-stroke-dash` / `:compound-title-px`
+  (the compound chrome reads the `:container-*` keys), `:dot-grid-alpha`
+  (the dot grid is xyflow's `<Background>` `:gap`/`:size`, no alpha),
+  and `:edge-label-backplate-opacity` (the edge-label backplate paints
+  the opaque `:event-chip-bg` theme token, no separate opacity). Added
+  `:arrow-width` / `:arrow-width-quiet` / `:arrow-width-entry` so the
+  arrowhead size rides the density alongside the stroke (the projector
+  baked literal 10 / 18 / 12 before, ignoring `:density`).
 
   rf2-g6cig — corner-radius locked at 6px across every density. The
   React Flow default (8) reads as 'product chrome'; brutalist (0)
@@ -76,21 +89,20 @@
     :stroke-width             — default node + edge stroke width
     :stroke-width-emphasis    — emphasised node/edge stroke width
                                 (active / focused-event lens)
-    :compound-pad-x           — horizontal inset on compound
-                                container around its children
-    :compound-pad-y           — vertical inset (extra top padding
-                                leaves room for the title strip)
-    :compound-stroke-dash     — dashed pattern for compound borders
-    :state-label-px           — state node label font-size
-                                (rf2-gg7ws lift — regular: 13)
     :edge-label-px            — edge label font-size
                                 (rf2-gg7ws lift — regular: 11)
-    :edge-label-backplate-opacity
-                              — opacity of the small white rect
-                                painted behind each edge label so
-                                overlapping labels remain legible
-                                (rf2-gg7ws — collision-avoidance v1)
-    :compound-title-px        — compound container title font-size
+    :arrow-width              — PRIMARY arrowhead width/height in px,
+                                on the `__out` (event→target) half of an
+                                events-as-nodes route (rf2-dt5b1 — now
+                                rides the density so the head scales with
+                                the stroke instead of a baked literal)
+    :arrow-width-quiet        — QUIET arrowhead width/height on the
+                                `__in` (source→event) half — smaller so
+                                the primary head reads as the route's
+                                terminus and the pair reads as ONE
+                                transition (rf2-dt5b1)
+    :arrow-width-entry        — initial-marker entry-edge arrowhead
+                                width/height (rf2-dt5b1)
     :compound-radius          — compound container corner radius
                                 (rf2-k647w — distinct from the
                                 state-node `:corner-radius` lock; the
@@ -116,22 +128,21 @@
                                 anchor (state label / edge event line)
     :dot-grid-spacing-px      — dot-grid background pattern spacing
                                 (rf2-m4nj4 — 16px)
-    :dot-grid-radius-px       — single dot radius
-    :dot-grid-alpha           — dot opacity (0..1)"
+    :dot-grid-radius-px       — single dot radius"
   {;; ── geometry ─────────────────────────────────────────────────
    :corner-radius          6
    :stroke-width           1.5
    :stroke-width-emphasis  2.5
-   :compound-pad-x         16
-   :compound-pad-y         24
-   :compound-stroke-dash   "4 3"
    :compound-radius        10
 
    ;; ── typography (rf2-gg7ws — chart-regular floor 13/11) ───────
-   :state-label-px         13
    :edge-label-px          11
-   :edge-label-backplate-opacity 0.85
-   :compound-title-px      13
+
+   ;; ── edge arrowheads (rf2-dt5b1 — ride the density so the head
+   ;;    scales with the stroke; quiet `__in` < primary `__out`) ───
+   :arrow-width            18
+   :arrow-width-quiet      10
+   :arrow-width-entry      12
 
    ;; ── state-tag pills (rf2-m1b88; rf2-a2b55 restored — sit BELOW
    ;;    the state name per Stately graph view convention) ─────────
@@ -191,8 +202,7 @@
 
    ;; ── dot-grid background (rf2-m4nj4) ──────────────────────────
    :dot-grid-spacing-px    16
-   :dot-grid-radius-px     1.0
-   :dot-grid-alpha         0.06})
+   :dot-grid-radius-px     1.0})
 
 (def chart-compact
   "Chart visual constants — COMPACT density.
@@ -216,16 +226,15 @@
    :corner-radius          6           ;; rf2-g6cig lock — same in every density
    :stroke-width           1.0
    :stroke-width-emphasis  2.0
-   :compound-pad-x         10
-   :compound-pad-y         18
-   :compound-stroke-dash   "3 2"
    :compound-radius        8           ;; ~25% tighter than regular's 10
 
    ;; ── typography (rf2-gg7ws refused-floor revisited for thumbnails)
-   :state-label-px         11
    :edge-label-px          9
-   :edge-label-backplate-opacity 0.85
-   :compound-title-px      11
+
+   ;; ── edge arrowheads (rf2-dt5b1 — ~25% tighter than regular) ──
+   :arrow-width            14
+   :arrow-width-quiet      8
+   :arrow-width-entry      10
 
    ;; ── state-tag pills (tighter than the regular 16/6/9/8) ──────
    :tag-pill-height        13
@@ -276,8 +285,7 @@
 
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    12
-   :dot-grid-radius-px     0.85
-   :dot-grid-alpha         0.06})
+   :dot-grid-radius-px     0.85})
 
 (def chart-cosy
   "Chart visual constants — COSY density.
@@ -299,16 +307,15 @@
    :corner-radius          6           ;; rf2-g6cig lock — same in every density
    :stroke-width           1.75
    :stroke-width-emphasis  3.0
-   :compound-pad-x         20
-   :compound-pad-y         30
-   :compound-stroke-dash   "5 4"
    :compound-radius        12          ;; ~25% looser than regular's 10
 
    ;; ── typography (walked up one notch from the regular floor) ──
-   :state-label-px         15
    :edge-label-px          13
-   :edge-label-backplate-opacity 0.85
-   :compound-title-px      15
+
+   ;; ── edge arrowheads (rf2-dt5b1 — ~25% looser than regular) ───
+   :arrow-width            22
+   :arrow-width-quiet      12
+   :arrow-width-entry      15
 
    ;; ── state-tag pills (looser than the regular 16/6/9/8) ───────
    :tag-pill-height        19
@@ -359,8 +366,7 @@
 
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    20
-   :dot-grid-radius-px     1.15
-   :dot-grid-alpha         0.06})
+   :dot-grid-radius-px     1.15})
 
 (def chart
   "Default chart visual constants — alias for `chart-regular`.

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -25,8 +25,8 @@
 
 (def idle-loading
   "Flat machine with a plain `:on` transition + an `:after` timer + an
-  `:always` eventless transition, so every `choose-edge-type` arm is
-  represented in one parse."
+  `:always` eventless transition, so every transition kind (plain,
+  timer, eventless) is represented in one parse."
   {:initial :idle
    :states  {:idle    {:on    {:start :loading}}
              :loading {:after {1000 {:target :timeout}}
@@ -148,51 +148,36 @@
   [graph parsed-edge-id]
   (edge-by-id graph (str parsed-edge-id "__out")))
 
-;; ---- choose-edge-type (G2) ---------------------------------------------
+;; ---- edge :type (single canonical "transition") ------------------------
+;;
+;; rf2-dt5b1 — the `choose-edge-type` classifier was removed: under
+;; events-as-nodes EVERY projected edge is the canonical `transition`
+;; type (the `:after`-timer specifics ride the event-NODE, not a distinct
+;; edge type). These pins assert the projector emits ONLY `transition`
+;; edges across the parse arms `choose-edge-type` once classified (plain
+;; `:on`, `:after`-timer, `:always` eventless).
 
-(deftest choose-edge-type-plain-transition
-  (testing "a plain `:on` edge → the canonical `transition` type"
-    (is (= "transition"
-           (projection/choose-edge-type {:event :start})))))
+(deftest every-projected-edge-is-transition-type
+  (testing "rf2-dt5b1 — every edge a real parse emits projects as the
+            canonical `transition` type (no `after` / `spawn` arms);
+            `idle-loading` exercises plain `:on` + `:after` + `:always`."
+    (let [graph (projection/xyflow-graph
+                  (layout/parse-definition idle-loading) {} {})]
+      (is (seq (:edges graph)))
+      (is (every? #{"transition"} (map :type (:edges graph)))
+          "all projected edges are the single canonical transition type"))))
 
-(deftest choose-edge-type-after-timer
-  (testing "an `:after`-timer edge → the dedicated `after` type"
-    (is (= "after"
-           (projection/choose-edge-type {:after 1000 :event :after-1000})))))
-
-(deftest choose-edge-type-always-falls-to-transition
-  (testing "an `:always` eventless edge has no distinct edge type — it
-            renders via `transition` (its `always` label segment is
-            composed upstream in chart.layout/edge-label, not here)"
-    (is (= "transition"
-           (projection/choose-edge-type {:always? true :event :always})))))
-
-(deftest choose-edge-type-after-wins-over-always
-  (testing "an edge carrying BOTH `:after` and `:always?` is an
-            `:after`-timer first — the `after` arm precedes the
-            transition fall-through"
-    (is (= "after"
-           (projection/choose-edge-type {:after 500 :always? true})))))
-
-(deftest choose-edge-type-has-no-spawn-arm
-  (testing "rf2-0gmwp — `choose-edge-type` NEVER returns `spawn`.
-            Per Spec 005 `:spawn` / `:spawn-all` are state-entry
-            actions (they spawn child actor machines), not same-machine
-            transitions, so the parser emits no spawn edge and there is
-            no spawn arm to classify into. The dead `spawn-edge`
-            registration was removed. Even an edge map with a stray
-            `:spawn` key falls through to `transition`."
-    (is (not= "spawn" (projection/choose-edge-type {:event :foo})))
-    (is (= "transition" (projection/choose-edge-type {:spawn true :event :foo})))))
-
-(deftest choose-edge-type-matches-live-parsed-edges
-  (testing "every edge a real parse emits classifies to a type that is
-            actually registered in chart.edges/edge-types (transition |
-            after) — pins choose-edge-type against the parser's output"
-    (let [{:keys [edges]} (layout/parse-definition idle-loading)]
-      (is (seq edges))
-      (is (every? #{"transition" "after"}
-                  (map projection/choose-edge-type edges))))))
+(deftest after-timer-rides-the-event-node-not-an-edge-type
+  (testing "rf2-dt5b1 — an `:after`-timer's specifics ride the event-NODE
+            (`:variant \"after\"` + `:afterMs`), NOT a distinct edge type;
+            the structural edges around it are plain `transition` edges."
+    (let [graph      (projection/xyflow-graph
+                       (layout/parse-definition idle-loading) {} {})
+          after-node (first (filter #(= "after" (:variant (:data %)))
+                                    (:nodes graph)))]
+      (is (some? after-node) "the :after timer projects as an event-node")
+      (is (= 1000 (:afterMs (:data after-node))))
+      (is (every? #{"transition"} (map :type (:edges graph)))))))
 
 ;; ---- xyflow-graph node :type dispatch (G1) -----------------------------
 
@@ -936,23 +921,25 @@
 
 (deftest xyflow-graph-density-changes-threaded-constants
   (testing "rf2-k647w — switching the density threads a DIFFERENT
-            constants map: the regular projection's state-label font
+            constants map: the regular projection's state-title font
             size differs from the compact projection's, proving
             `:density` actually changes what the renderer paints.
 
-            rf2-so5b0 — historical assertions on `:tag-pill-height`
-            replaced with `:state-label-px` since the tag-pill family
-            retired with the visible pill row; the state-label keys
-            are now the density's load-bearing typography surface."
+            rf2-so5b0 → rf2-dt5b1 — historical assertions on
+            `:tag-pill-height` (then `:state-label-px`) walk to
+            `:state-title-px`: the tag-pill family retired with the
+            visible pill row, and `:state-label-px` was removed
+            (rf2-dt5b1, unread — the state-node label rides
+            `:state-title-px` under the rf2-az6e2 structured grammar)."
     (let [parsed   (layout/parse-definition idle-loading)
           idle-id  (layout/node-id [:idle])
           regular  (-> (projection/xyflow-graph parsed {} {:chart vc/chart-regular})
                        (node-by-id idle-id) :data :chart)
           compact  (-> (projection/xyflow-graph parsed {} {:chart vc/chart-compact})
                        (node-by-id idle-id) :data :chart)]
-      (is (not= (:state-label-px regular) (:state-label-px compact)))
-      (is (= 13 (:state-label-px regular)))
-      (is (= 11 (:state-label-px compact)))
+      (is (not= (:state-title-px regular) (:state-title-px compact)))
+      (is (= 13 (:state-title-px regular)))
+      (is (= 11 (:state-title-px compact)))
       ;; corner-radius is the locked invariant — identical across both
       (is (= (:corner-radius regular) (:corner-radius compact) 6)))))
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
@@ -3,11 +3,13 @@
   (rf2-pyvmr — with-alpha;
    rf2-xfx6l — motion/duration-css).
 
-  rf2-so5b0 retired the `tag-pill-color` / `tag-pill-palette` helpers
-  with the visible state-tag pill row; rf2-a2b55 reinstates BOTH
-  helpers AND the pill row (positioned BELOW the state name per
-  Stately graph view convention). Determinism + reserved-token tests
-  for the helper restored at the end of this ns."
+  rf2-dt5b1 — the `tag-pill-color` / `tag-pill-palette` deterministic
+  colour rotation (rf2-m1b88 / rf2-a2b55) was RETIRED: `chart.nodes/`
+  `tag-pill` renders every chip in one neutral style (structure wins
+  over annotation colour for the topology view), so the rotation
+  coloured nothing the renderer paints. The pill row itself + its
+  geometry keys remain. The shared `edge-color` stroke + arrowhead
+  colour helper (rf2-dt5b1) is pinned at the end of this ns."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [clojure.string :as str]
@@ -174,27 +176,36 @@
             the raw-EDN context panel."
     (is (= tokens/sans-stack tokens/chart-label-stack))))
 
-;; ---- tag-pill colour rotation (rf2-m1b88; rf2-a2b55 restored) ----------
+;; ---- edge-color — shared stroke + arrowhead colour (rf2-dt5b1) ---------
+;;
+;; `tokens/edge-color` is the SINGLE source both `chart.edges/edge-stroke`
+;; (the SVG path) and `chart.projection` (the arrowhead `:markerEnd`
+;; colour) route through, so a stroke + its arrowhead cannot disagree.
+;; Ordering (XState/Stately gold standard): fired > focused/active >
+;; quiet.
 
-(deftest tag-pill-color-is-deterministic
-  (testing "rf2-m1b88 — `tag-pill-color` resolves the same tag id to
-            the same palette entry across calls, so the human eye can
-            track 'tag X = blue pill' across renders. Pure data →
-            keyword; the same id MUST resolve to the same hue."
-    (let [tag :ws/connecting]
-      (is (= (tokens/tag-pill-color tag)
-             (tokens/tag-pill-color tag))))))
+(deftest edge-color-fired-wins
+  (testing "rf2-dt5b1 — `fired?` wins over `focused?` / `active?`: a
+            fired-this-epoch edge reads as 'what just happened'."
+    (let [ct (tokens/chart-tokens)]
+      (is (= (:edge-fired ct)
+             (tokens/edge-color ct {:fired? true :focused? true :active? true})))
+      (is (= (:edge-fired ct)
+             (tokens/edge-color ct {:fired? true}))))))
 
-(deftest tag-pill-color-skips-reserved-tokens
-  (testing "rf2-m1b88 — `:red` / `:accent` / `:info` are reserved for
-            chart semantics (cancellation glyph; initial-state +
-            FROM-highlight; TO-highlight + active). The palette
-            rotation MUST NOT land on any of those — a state-tag pill
-            sharing a hue with an active-state border would read as
-            'this state is active' on a tag that has nothing to do
-            with activity. Pinned across a small sweep of tag ids."
-    (let [reserved #{:red :accent :info}]
-      (doseq [tag [:a :b :c :ws/active :ws/connecting :foo/bar
-                   :idle :running :error :timeout :loaded]]
-        (is (not (contains? reserved (tokens/tag-pill-color tag)))
-            (str "tag " tag " maps to a reserved chart-semantic token"))))))
+(deftest edge-color-focused-or-active-is-active-hue
+  (testing "rf2-dt5b1 — focused OR active (but not fired) → the ACTIVE
+            hue; the two share one treatment."
+    (let [ct (tokens/chart-tokens)]
+      (is (= (:edge-active ct) (tokens/edge-color ct {:focused? true})))
+      (is (= (:edge-active ct) (tokens/edge-color ct {:active? true})))
+      (is (= (:edge-active ct)
+             (tokens/edge-color ct {:focused? true :active? true}))))))
+
+(deftest edge-color-resting-is-quiet
+  (testing "rf2-dt5b1 — no flags (the resting / quiet segment) → the
+            QUIET hue."
+    (let [ct (tokens/chart-tokens)]
+      (is (= (:edge-quiet ct) (tokens/edge-color ct {})))
+      (is (= (:edge-quiet ct)
+             (tokens/edge-color ct {:fired? false :focused? false :active? false}))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -56,15 +56,14 @@
     :corner-radius
     :stroke-width
     :stroke-width-emphasis
-    :compound-pad-x
-    :compound-pad-y
-    :compound-stroke-dash
     :compound-radius                ;; rf2-k647w — render constant promoted
-    ;; typography (rf2-gg7ws — lifted 11/9 → 13/11)
-    :state-label-px
+    ;; typography (rf2-gg7ws — edge-label lifted 9 → 11)
     :edge-label-px
-    :edge-label-backplate-opacity
-    :compound-title-px
+    ;; edge arrowheads (rf2-dt5b1 — ride the density so the head scales
+    ;; with the stroke; quiet `__in` < primary `__out`)
+    :arrow-width
+    :arrow-width-quiet
+    :arrow-width-entry
     ;; rf2-6d4y3 — :final-glyph-px removed: the final-state ✓ glyph was
     ;; dropped (rf2-az6e2 — the quiet doubled border is the unambiguous
     ;; final-state signal) and no renderer ever read the constant; it
@@ -72,6 +71,13 @@
     ;; rf2-ee38b.21 — :caption-strip-px / :caption-text-px removed:
     ;; no renderer ever read them (there is no caption strip in the
     ;; chart). They were carried only to satisfy this parity test.
+    ;; rf2-dt5b1 — :state-label-px / :compound-pad-x / :compound-pad-y /
+    ;; :compound-stroke-dash / :compound-title-px / :edge-label-backplate-
+    ;; opacity / :dot-grid-alpha removed: no renderer ever read them (the
+    ;; state label rides :state-title-px; the compound chrome reads the
+    ;; :container-* keys; the dot grid is xyflow's <Background> :gap/:size
+    ;; with no alpha; the edge-label backplate paints the opaque
+    ;; :event-chip-bg theme token). They were carried only for this test.
     ;; state-tag pills (rf2-m1b88; rf2-a2b55 restored under state-name)
     :tag-pill-height
     :tag-pill-pad-x
@@ -121,8 +127,7 @@
     :root-context-pad
     ;; dot-grid background (rf2-m4nj4)
     :dot-grid-spacing-px
-    :dot-grid-radius-px
-    :dot-grid-alpha})
+    :dot-grid-radius-px})
 
 ;; ---- shape pins ---------------------------------------------------------
 
@@ -145,18 +150,13 @@
         "every vc/chart entry resolves to a non-nil value")))
 
 (deftest chart-numeric-keys-are-numbers
-  (testing "every key that the chart code uses as a numeric (geometry,
-            typography sizes, padding, alpha, opacity) resolves to a
-            number"
-    (let [numeric-keys (disj expected-chart-keys :compound-stroke-dash)]
-      (doseq [k numeric-keys]
-        (is (number? (get vc/chart k))
-            (str "vc/chart key " k " resolves to a number"))))))
-
-(deftest chart-compound-stroke-dash-is-string
-  (testing ":compound-stroke-dash is the SVG `stroke-dasharray` attr
-            string, not a number"
-    (is (string? (:compound-stroke-dash vc/chart)))))
+  (testing "every chart key resolves to a number (geometry, typography
+            sizes, padding, arrowhead widths). rf2-dt5b1 — the only
+            string-valued key (:compound-stroke-dash) was removed, so
+            every remaining key is numeric."
+    (doseq [k expected-chart-keys]
+      (is (number? (get vc/chart k))
+          (str "vc/chart key " k " resolves to a number")))))
 
 (deftest chart-corner-radius-locked-at-six
   (testing "rf2-g6cig — corner-radius is locked at 6px per the
@@ -168,15 +168,16 @@
     (is (= 6 (:corner-radius vc/chart)))))
 
 (deftest chart-typography-meets-chart-floor
-  (testing "rf2-gg7ws — state-label-px + edge-label-px lifted from the
+  (testing "rf2-gg7ws — state-title-px + edge-label-px lifted from the
             spec/007-UX-IA refused-floor (11 / 9) to a chart-
             appropriate 13 / 11 per the 2026-05-20 visual-quality
             audit. The refused-floor was set for dense data-grid
             surfaces; applying it to a chart that competes with
             xstate-stately's typography was a category error. Pin so a
             future layout-fit win that walks back under the chart
-            floor fails CI."
-    (is (= 13 (:state-label-px vc/chart)))
+            floor fails CI. (rf2-dt5b1 — the state label rides
+            `:state-title-px`; the unread `:state-label-px` was removed.)"
+    (is (= 13 (:state-title-px vc/chart)))
     (is (= 11 (:edge-label-px vc/chart)))))
 
 (deftest chart-regular-compound-radius-matches-shipped-render
@@ -186,22 +187,17 @@
             as a looser container."
     (is (= 10 (:compound-radius vc/chart)))))
 
-(deftest chart-edge-label-backplate-opacity-is-fractional
-  (testing "rf2-gg7ws — edge-label backplate opacity is in (0, 1).
-            At 1 the backplate would be opaque white (overprinted
-            chart canvas); at 0 it would be invisible (no
-            collision-avoidance). ~0.85 is the sweet spot."
-    (let [a (:edge-label-backplate-opacity vc/chart)]
-      (is (pos? a))
-      (is (< a 1.0)))))
-
-(deftest chart-dot-grid-alpha-is-fractional
-  (testing "rf2-m4nj4 — dot-grid is a subtle backdrop; alpha must
-            stay in (0, 1) — a value at 1 would make the dots opaque
-            and overwhelm chart content"
-    (let [a (:dot-grid-alpha vc/chart)]
-      (is (pos? a))
-      (is (< a 1.0)))))
+(deftest chart-arrowhead-quiet-smaller-than-primary
+  (testing "rf2-dt5b1 — the QUIET `__in` arrowhead is smaller than the
+            PRIMARY `__out` arrowhead so the primary head reads as the
+            route's terminus and the source→event→target pair reads as
+            ONE transition. The entry-marker head sits between."
+    (is (< (:arrow-width-quiet vc/chart)
+           (:arrow-width-entry vc/chart)
+           (:arrow-width vc/chart)))
+    (is (= 18 (:arrow-width vc/chart)))
+    (is (= 10 (:arrow-width-quiet vc/chart)))
+    (is (= 12 (:arrow-width-entry vc/chart)))))
 
 ;; ---- density variants (rf2-32gw5) --------------------------------------
 ;;
@@ -242,29 +238,34 @@
     (is (= 6 (:corner-radius vc/chart-cosy)))))
 
 (deftest density-typography-monotonic
-  (testing "rf2-32gw5 — `state-label-px` is monotonic across the
+  (testing "rf2-32gw5 — `state-title-px` is monotonic across the
             density axis: compact < regular < cosy. If a density's
             type walks back or up unexpectedly the picker UI would
             ship a 'cosy' value that's actually tighter than
             'regular' — a labelling bug. Same monotonicity holds for
-            edge labels."
-    (is (< (:state-label-px vc/chart-compact)
-           (:state-label-px vc/chart-regular)
-           (:state-label-px vc/chart-cosy)))
+            edge labels. (rf2-dt5b1 — `:state-title-px` carries the
+            state label; the unread `:state-label-px` was removed.)"
+    (is (< (:state-title-px vc/chart-compact)
+           (:state-title-px vc/chart-regular)
+           (:state-title-px vc/chart-cosy)))
     (is (< (:edge-label-px vc/chart-compact)
            (:edge-label-px vc/chart-regular)
            (:edge-label-px vc/chart-cosy)))))
 
 (deftest density-geometry-monotonic
-  (testing "rf2-32gw5 — compound padding + dot-grid spacing are also
-            monotonic. Compact tightens; cosy loosens. Density is
-            ONE knob — every quantity that should track it does."
-    (is (< (:compound-pad-x vc/chart-compact)
-           (:compound-pad-x vc/chart-regular)
-           (:compound-pad-x vc/chart-cosy)))
+  (testing "rf2-32gw5 — dot-grid spacing + (rf2-dt5b1) arrowhead widths
+            are also monotonic. Compact tightens; cosy loosens. Density
+            is ONE knob — every quantity that should track it does. The
+            arrowhead scaling is the rf2-dt5b1 fix: the head no longer
+            sits at a baked literal regardless of the stroke density."
     (is (< (:dot-grid-spacing-px vc/chart-compact)
            (:dot-grid-spacing-px vc/chart-regular)
-           (:dot-grid-spacing-px vc/chart-cosy)))))
+           (:dot-grid-spacing-px vc/chart-cosy)))
+    (doseq [k [:arrow-width :arrow-width-quiet :arrow-width-entry]]
+      (is (< (get vc/chart-compact k)
+             (get vc/chart-regular k)
+             (get vc/chart-cosy k))
+          (str "arrowhead key " k " is monotonic compact < regular < cosy")))))
 
 (deftest density-compound-radius-monotonic
   (testing "rf2-k647w — `:compound-radius` (the render constant the


### PR DESCRIPTION
Closes rf2-dt5b1. ONE coherent cleanup pass over the machines-viz edge / projection / constants surface plus a spec reconciliation. Item 1 (sibling-collapse) was already excised by rf2-o6vh7; this PR does the remaining items.

## Per-item outcome

**Item 2 — dead edge-type classifier (CLARITY).** Deleted `chart.projection/choose-edge-type` and the `chart.edges/after-edge` alias; shrank `edge-types` to the single live `"transition"` entry. `xyflow-graph` hardcodes `:type "transition"` at both edge-emission sites (projection.cljc:986, :1082) — the classifier had zero live callers. Under events-as-nodes the `:after`-timer specifics ride the event-NODE (`:variant` after + `:afterMs`), not a distinct edge type. Verified DEAD code, not a design decision (the only repo matches for `after-edge` were xray's unrelated `after-edges` fn + a test name).

**Item 3 — signpost the self-loop fan (CLARITY).** Added a fallback-only banner at the `edges.cljs` self-loop-fan section head: the projector never emits `:selfLoop true` under events-as-nodes; the geometry is retained for direct `edge-path` callers (spec commits to it). No geometry deleted.

**Item 4 — unify arrowhead colour + size (GOOD-PRACTICE).** New shared pure `theme.tokens/edge-color` is the SINGLE source both `edge-stroke` (SVG path) and the projector's `:markerEnd :color` route through, so a head + its stroke can never resolve different colours for the same edge state (XState/Stately ordering: fired > focused/active > quiet). Added `:arrow-width` / `:arrow-width-quiet` / `:arrow-width-entry` to the three density maps and read them in the projector so the arrowhead size rides the density (was baked literals 18 / 10 / 12, ignoring `:density`). Small intended behaviour change: arrowheads now scale with density.

**Item 5 — dead tag-pill colour fns + unread keys (CLARITY).** Deleted `tag-pill-color` / `tag-pill-palette` / the private `char-code` (the per-tag colour rotation `chart.nodes/tag-pill` deliberately does not use — it renders neutral chips). Removed seven density-map keys no renderer reads (`:state-label-px`, `:compound-pad-x`, `:compound-pad-y`, `:compound-stroke-dash`, `:compound-title-px`, `:edge-label-backplate-opacity`, `:dot-grid-alpha`) and relaxed the key-parity test accordingly.

**Spec reconcile (spec/API.md edge/constants sections only).** §Label rendering (the backplate paints the opaque `:event-chip-bg` theme token, not an alpha-scaled `:bg-1` — the renderer never read `:edge-label-backplate-opacity`); §State tags (neutral pills, not `tag-pill-color`-rotated); §spawn-all + §Density implementation notes (dropped the `choose-edge-type` citation + the removed-key invariance bullets); §Visual grammar Arrow/routing (shared `edge-color` + density-scaled head). Did NOT touch §Multi-event-collapse (o6vh7), §Share-URL (9l8h8), or §:on-state-click (34ff3).

## Zero-reader proof
`git grep` on tracked source confirms every deleted fn / alias / key has zero live readers — all remaining references are removal tombstone comments.

## Quality gates (cold)
- machines-viz `clojure -M:test` — 333 tests, 0 failures
- `npm run test:cljs` — 5564 tests, 0 failures
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures
- `npm run test:browser` — 153 tests, 0 failures (edge rendering changed — browser gate per the vcnvj lesson)