### PR TITLE
fix(epoch): bound theirs-marker retention so a stranded child can't accrete (rf2-fxowr)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -644,6 +644,52 @@
             (-> ev :tags :rf.trace/dispatch-id)))
         events))
 
+;; rf2-fxowr — bounded `theirs` retention. A `:event/dispatched` marker that
+;; rides a DIFFERENT dispatch-id ("theirs") is normally claimed as "mine" at
+;; the child's OWN settle — the very next harvest after the parent strands it
+;; (proven: parent harvest leaves it theirs, child run-start makes the next
+;; harvest's settling-id match, marker harvested as mine). So in the normal
+;; child-runs path a marker survives exactly ONE harvest as theirs.
+;;
+;; A child that NEVER runs to a settle (handler unregistered, frame
+;; destroyed / drain-interrupted before dequeue, depth-halt clears the queue
+;; with the child still pending) leaves its marker stranded: no settling-id
+;; will ever match it, so it is re-classified theirs and re-retained on EVERY
+;; subsequent genuine settle for the long-lived frame — slow UNBOUNDED
+;; accretion in the hottest atom (`capture-buffers`). This is the non-nil
+;; sibling of the rf2-ee38b nil-orphan strand: that fix made the harvest
+;; self-cleaning for nil-id orphans; this extends the same self-cleaning to
+;; cover a stranded non-nil child marker.
+;;
+;; The bound: stamp each retained theirs marker with a private survival
+;; counter (`::theirs-harvests`). The FIRST time a marker is theirs it is
+;; retained with the counter at 1 (its child still has its chance to run).
+;; The SECOND time the same marker would be theirs the child has demonstrably
+;; not come to claim it within its run-to-completion window, so it is
+;; RECLAIMED (dropped) rather than re-retained. The normal child-runs path is
+;; untouched: the marker is claimed as mine at the next harvest, before it can
+;; reach the drop threshold. The private key never escapes — only stranded
+;; markers being dropped ever carry it past one harvest, and a marker harvested
+;; as mine is stripped of it (defensive; the normal path never stamps it onto a
+;; mine-classified event anyway).
+(def ^:private theirs-harvests-key ::theirs-harvests)
+
+(def ^:private theirs-retention-limit
+  ;; A theirs marker may survive at most ONE harvest as theirs (the parent's,
+  ;; which strands it); on the harvest that would make it theirs a SECOND time
+  ;; its child never ran, so it is reclaimed. 1 = "retain across one harvest,
+  ;; drop on the next."
+  1)
+
+(defn- strip-strand-stamp
+  "Drop the private rf2-fxowr survival counter from an event map so it never
+  escapes into a harvested epoch's `:trace-events`. A no-op for the
+  overwhelming majority of events (the key is absent)."
+  [ev]
+  (if (contains? ev theirs-harvests-key)
+    (dissoc ev theirs-harvests-key)
+    ev))
+
 (defn harvest-buffer-for-event!
   "Per rf2-nj6p7 — per-event harvest. Atomically read the frame's in-flight
   buffer and split it by the settling event's `:dispatch-id`:
@@ -665,6 +711,11 @@
       one `:dispatch-id` = one epoch). It stays buffered for the child's
       own `harvest-buffer-for-event!` at the child's settle.
 
+  Per rf2-fxowr a stranded theirs marker (its child never ran) is RECLAIMED
+  after surviving more than one harvest as theirs, so the buffer stays bounded
+  — the self-cleaning posture rf2-ee38b established for nil-id orphans, now
+  extended to the non-nil stranded-child case.
+
   Falls back to a full read-and-clear when the buffer carries no
   `:event/run-start` (a rejected / aborted dispatch) — there is no
   settling id to scope by, and `settle!`'s empty-buffer / no-trigger
@@ -679,7 +730,9 @@
       ;;       — a child's `:event/dispatched` marker fired during THIS event's
       ;;         do-fx carrying the CHILD's id; LEFT in the buffer for the
       ;;         child's own settle (Spec 009 §Dispatch correlation: one
-      ;;         dispatch-id = one epoch).
+      ;;         dispatch-id = one epoch) — UNLESS it has already survived a
+      ;;         prior harvest as theirs (rf2-fxowr stranded child), in which
+      ;;         case it is reclaimed below.
       ;;   * ORPHAN (nil event-dispatch-id)
       ;;       — an out-of-cascade emit (e.g. `:frame/created`) with no
       ;;         cascade to ride. DISCARDED here.
@@ -696,20 +749,36 @@
       ;; `event-dispatch-id = settling-id` predicate already guarantees an
       ;; orphan never folds into an epoch's `:trace-events`; this only changes
       ;; whether it lingers in the buffer (no) vs. is dropped (yes).
-      (let [mine   (filterv (fn [ev] (= (-> ev :tags :rf.trace/dispatch-id) settling-id)) buffer)
-            theirs (filterv (fn [ev]
-                              (let [event-dispatch-id (-> ev :tags :rf.trace/dispatch-id)]
-                                (and (some? event-dispatch-id) (not= event-dispatch-id settling-id))))
-                            buffer)]
-        ;; Leave the other-event traces (non-nil, non-matching id) in the
-        ;; buffer for their own event's settle; drop orphans + ours.
+      ;;
+      ;; Per rf2-fxowr the SAME self-cleaning now covers a stranded non-nil
+      ;; child: a theirs marker carries a private `::theirs-harvests` survival
+      ;; counter; one whose counter already reached the retention limit (its
+      ;; child never ran to a settle within its RTC window) is reclaimed rather
+      ;; than re-retained, so `capture-buffers` stays bounded.
+      (let [mine   (mapv strip-strand-stamp
+                         (filterv (fn [ev] (= (-> ev :tags :rf.trace/dispatch-id) settling-id))
+                                  buffer))
+            ;; Theirs markers that have NOT yet exhausted their retention —
+            ;; bumped one survival generation and kept for the child's settle.
+            theirs (into []
+                         (keep (fn [ev]
+                                 (let [event-dispatch-id (-> ev :tags :rf.trace/dispatch-id)]
+                                   (when (and (some? event-dispatch-id)
+                                              (not= event-dispatch-id settling-id))
+                                     (let [survived (get ev theirs-harvests-key 0)]
+                                       (when (< survived theirs-retention-limit)
+                                         (assoc ev theirs-harvests-key (inc survived))))))))
+                         buffer)]
+        ;; Leave the surviving other-event markers in the buffer for their own
+        ;; event's settle; drop orphans, ours, and stranded (retention-exhausted)
+        ;; theirs markers.
         (if (seq theirs)
           (swap! capture-buffers assoc frame-id theirs)
           (swap! capture-buffers dissoc frame-id))
         mine)
       ;; No run-start — rejected/aborted dispatch. Clear and return all.
       (do (swap! capture-buffers dissoc frame-id)
-          buffer))))
+          (mapv strip-strand-stamp buffer)))))
 
 (defn drop-frame-buffer!
   "Drop the frame's in-flight capture buffer."

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -801,7 +801,13 @@
             settling event's id is a child's `:event/dispatched` marker (fired
             during the parent's do-fx) and stays buffered for the child's own
             settle (Spec 009 §Dispatch correlation: one dispatch-id = one
-            epoch). Only nil-id orphans are dropped."
+            epoch). Only nil-id orphans are dropped.
+
+            rf2-fxowr — the retained marker carries a PRIVATE survival counter
+            so a STRANDED marker (its child never settles) can be reclaimed on a
+            later harvest (inv-6c). The counter is internal book-keeping; assert
+            on the marker's identity (its dispatch-id + operation), not bare map
+            equality, since the stamp is now present."
     (let [frame      :test/harvest-child
           run-start  {:op-type :rf.event :operation :rf.event/run-start
                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 1 :rf.trace/event-id :parent}}
@@ -814,14 +820,118 @@
       (state/buffer-event! frame body)
       (state/buffer-event! frame child-mark)
       (state/buffer-event! frame orphan)
-      (let [harvested (state/harvest-buffer-for-event! frame)]
+      (let [harvested (state/harvest-buffer-for-event! frame)
+            retained  (state/buffer-for frame)]
         (is (= [run-start body] harvested)
             "the parent's harvest takes only its own (dispatch-id 1) traces")
         ;; The child marker (dispatch-id 2) is RETAINED; the orphan is DROPPED.
-        (is (= [child-mark] (state/buffer-for frame))
-            "the child's dispatch-id marker stays buffered for the child's own
-             settle; the nil-id orphan is discarded")
+        (is (= 1 (count retained))
+            "exactly the child's marker stays buffered; the nil-id orphan is dropped")
+        (is (= 2 (-> retained first :tags :rf.trace/dispatch-id))
+            "the retained marker IS the child's (dispatch-id 2) marker")
+        (is (= :rf.event/dispatched (-> retained first :operation))
+            "and it is the child's :event/dispatched marker, kept for the child's own settle")
         (state/drop-frame-buffer! frame)))))
+
+(deftest inv-6c-harvest-reclaims-stranded-child-marker
+  (testing "rf2-fxowr — a STRANDED child `:event/dispatched` marker (its child
+            never runs to a settle: unregistered handler, frame
+            destroyed/drain-interrupted before dequeue, or depth-halt clears the
+            queue with the child still pending) must NOT accrete in the hottest
+            atom (`capture-buffers`) indefinitely.
+
+            inv-6b proves a child marker is RETAINED for its own settle — that
+            holds for a child that WILL run (claimed as `mine` at the very next
+            harvest). This invariant proves the complementary bound: a marker
+            whose child never settles is RECLAIMED after surviving more than one
+            harvest as `theirs`, so the buffer stays bounded. The non-nil
+            sibling of inv-6's nil-id orphan self-cleaning — the harvest is
+            self-cleaning for BOTH strand classes, not reliant on the upstream
+            terminal paths (rejected-child settle / depth-halt / drain-interrupt
+            clear) being perfect.
+
+            Pre-rf2-fxowr the marker was re-classified `theirs` and re-retained
+            on EVERY subsequent genuine settle for the long-lived frame — one
+            small residue per stranding incident, never GC'd while the frame
+            lives (slow UNBOUNDED accretion)."
+    (let [frame       :test/harvest-stranded
+          ;; A stranded child marker — its child (dispatch-id 99) never ran, so
+          ;; no settling-id will ever match it.
+          stranded    {:op-type :rf.event :operation :rf.event/dispatched
+                       :tags {:rf.trace/dispatch-id 99 :rf.trace/event-id :child-never-ran}}
+          ;; A first genuine, unrelated event settles for this long-lived frame.
+          rs-1        {:op-type :rf.event :operation :rf.event/run-start
+                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 7 :rf.trace/event-id :genuine-1}}
+          body-1      {:op-type :rf.event :operation :rf.event/db-changed
+                       :tags {:rf.trace/dispatch-id 7}}
+          ;; A second genuine, unrelated event settles later.
+          rs-2        {:op-type :rf.event :operation :rf.event/run-start
+                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 8 :rf.trace/event-id :genuine-2}}
+          body-2      {:op-type :rf.event :operation :rf.event/db-changed
+                       :tags {:rf.trace/dispatch-id 8}}]
+      ;; --- first genuine settle while the stranded marker sits in the buffer ---
+      (state/buffer-event! frame stranded)
+      (state/buffer-event! frame rs-1)
+      (state/buffer-event! frame body-1)
+      (let [h1     (state/harvest-buffer-for-event! frame)
+            after1 (state/buffer-for frame)]
+        (is (= [rs-1 body-1] h1)
+            "the first genuine event harvests ONLY its own (dispatch-id 7) traces")
+        (is (not-any? #(= 99 (-> % :tags :rf.trace/dispatch-id)) h1)
+            "the stranded marker is NOT folded into the genuine event's epoch")
+        (is (= 1 (count after1))
+            "the stranded marker survives the FIRST harvest as theirs (its child
+             still notionally has a chance to run within its RTC window)")
+
+        ;; --- second genuine settle: the child still never ran -> RECLAIM ---
+        (state/buffer-event! frame rs-2)
+        (state/buffer-event! frame body-2)
+        (let [h2     (state/harvest-buffer-for-event! frame)
+              after2 (state/buffer-for frame)]
+          (is (= [rs-2 body-2] h2)
+              "the second genuine event harvests ONLY its own (dispatch-id 8) traces")
+          (is (not-any? #(= 99 (-> % :tags :rf.trace/dispatch-id)) h2)
+              "the stranded marker is STILL not folded into a genuine epoch")
+          (is (empty? after2)
+              "rf2-fxowr — the stranded marker is RECLAIMED, not re-retained;
+               `capture-buffers` for the frame is now empty (bounded)")))
+      (state/drop-frame-buffer! frame))))
+
+(deftest inv-6d-harvested-child-marker-carries-no-private-stamp
+  (testing "rf2-fxowr — the private survival counter is internal book-keeping;
+            it must NEVER escape into a harvested epoch's `:trace-events`. When
+            a retained marker is finally claimed as `mine` at its child's own
+            settle, the harvested event is stripped of the private key so the
+            recorded `:trace-events` shape is unchanged (behaviour-preserving for
+            the normal child-runs path)."
+    (let [frame       :test/harvest-clean
+          ;; Parent cascade strands the child marker (stamps it).
+          parent-rs   {:op-type :rf.event :operation :rf.event/run-start
+                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 1 :rf.trace/event-id :parent}}
+          parent-body {:op-type :rf.event :operation :rf.event/db-changed
+                       :tags {:rf.trace/dispatch-id 1}}
+          child-mark  {:op-type :rf.event :operation :rf.event/dispatched
+                       :tags {:rf.trace/dispatch-id 2 :rf.trace/event-id :child}}
+          ;; The child then RUNS: its run-start + body land in the buffer.
+          child-rs    {:op-type :rf.event :operation :rf.event/run-start
+                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 2 :rf.trace/event-id :child}}
+          child-body  {:op-type :rf.event :operation :rf.event/db-changed
+                       :tags {:rf.trace/dispatch-id 2}}]
+      (state/buffer-event! frame parent-rs)
+      (state/buffer-event! frame parent-body)
+      (state/buffer-event! frame child-mark)
+      (state/harvest-buffer-for-event! frame)          ; parent settles; marker stranded+stamped
+      (state/buffer-event! frame child-rs)
+      (state/buffer-event! frame child-body)
+      (let [child-harvest (state/harvest-buffer-for-event! frame)]
+        (is (= [child-mark child-rs child-body] child-harvest)
+            "the child's settle claims the marker + its own traces, BARE — no
+             private survival key leaks into the harvested epoch")
+        (is (every? #(not (contains? % :re-frame.epoch.state/theirs-harvests)) child-harvest)
+            "no harvested event carries the private rf2-fxowr survival counter")
+        (is (empty? (state/buffer-for frame))
+            "buffer empty after the child settle (normal path fully cleared)"))
+      (state/drop-frame-buffer! frame))))
 
 ;; ===========================================================================
 ;; INVARIANT 7 — a tool / inspector frame's OWN render never pollutes the

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -264,3 +264,46 @@
     (rf/dispatch-sync [:probe/init])
     (is (pos? (count (rf/epoch-history :rf/default)))
         "with the gate ON, a dispatch lands a record in the ring")))
+
+;; ---- 6. Bounded capture buffer — stranded child marker reclaim (rf2-fxowr) --
+;;
+;; The cross-target pin for the JVM `epoch-attribution-test/inv-6c`. The harvest
+;; seam lives in `re-frame.epoch.state` (.cljc), so it runs under CLJS too; this
+;; locks the bounded-`theirs`-retention contract on the CLJS runtime — a child
+;; `:event/dispatched` marker whose child never settles is RECLAIMED after
+;; surviving more than one harvest, so `capture-buffers` (the hottest atom)
+;; stays bounded rather than accreting one residue per stranding incident.
+
+(deftest stranded-child-marker-reclaimed-cljs
+  (testing "rf2-fxowr — a stranded child marker (its child never runs to a
+            settle) does NOT accrete in `capture-buffers`: it is retained across
+            one harvest as theirs, then reclaimed on the next genuine settle."
+    (let [frame    :test/stranded-cljs
+          stranded {:op-type :rf.event :operation :rf.event/dispatched
+                    :tags {:rf.trace/dispatch-id 99 :rf.trace/event-id :child-never-ran}}
+          rs-1     {:op-type :rf.event :operation :rf.event/run-start
+                    :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 7 :rf.trace/event-id :g1}}
+          body-1   {:op-type :rf.event :operation :rf.event/db-changed
+                    :tags {:rf.trace/dispatch-id 7}}
+          rs-2     {:op-type :rf.event :operation :rf.event/run-start
+                    :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 8 :rf.trace/event-id :g2}}
+          body-2   {:op-type :rf.event :operation :rf.event/db-changed
+                    :tags {:rf.trace/dispatch-id 8}}]
+      (state/buffer-event! frame stranded)
+      (state/buffer-event! frame rs-1)
+      (state/buffer-event! frame body-1)
+      (let [h1 (state/harvest-buffer-for-event! frame)]
+        (is (= [rs-1 body-1] h1)
+            "the first genuine event harvests ONLY its own traces")
+        (is (= 1 (count (state/buffer-for frame)))
+            "the stranded marker survives one harvest as theirs"))
+      (state/buffer-event! frame rs-2)
+      (state/buffer-event! frame body-2)
+      (let [h2 (state/harvest-buffer-for-event! frame)]
+        (is (= [rs-2 body-2] h2)
+            "the second genuine event harvests ONLY its own traces")
+        (is (not-any? #(= 99 (-> % :tags :rf.trace/dispatch-id)) h2)
+            "the stranded marker is never folded into a genuine epoch")
+        (is (empty? (state/buffer-for frame))
+            "rf2-fxowr — the stranded marker is RECLAIMED; the buffer is bounded"))
+      (state/drop-frame-buffer! frame))))


### PR DESCRIPTION
## What

`harvest-buffer-for-event!` (the per-event epoch harvest seam) classifies a child's `:event/dispatched` marker — non-nil `dispatch-id` that differs from the settling event's id — as **theirs** and LEAVES it buffered for the child's own settle. Correct when the child runs (claimed as `mine` at the next harvest). But a child that **never runs to a settle** (unregistered handler, frame destroyed / drain-interrupted before dequeue, or depth-halt clearing the queue with the child still pending) leaves the marker **stranded**: no settling-id ever matches it, so every subsequent genuine settle on the long-lived frame re-classifies it theirs and re-retains it — slow **unbounded accretion** in the hottest atom (`capture-buffers`), one residue per stranding incident, never GC'd while the frame lives.

## Fix

The non-nil sibling of the rf2-ee38b nil-orphan strand. That fix made the harvest self-cleaning for nil-id orphans; this extends the same posture to the stranded non-nil child:

- Stamp each retained theirs marker with a private survival counter (`::theirs-harvests`).
- Reclaim (drop) a marker once it has survived more than one harvest as theirs — its child has demonstrably not come to claim it within its run-to-completion window.

The buffer stays bounded and the seam no longer relies on the upstream terminal paths (rejected-child settle / depth-halt / drain-interrupt clear) being perfect.

## Behaviour-preserving for the normal (child-runs) path

Under per-frame run-to-completion the child's own settle is the **very next harvest** after the parent strands the marker, so it is claimed as `mine` (stamp stripped) before it can reach the drop threshold. Two unrelated genuine settles cannot interleave before the child's own settle (FIFO + same-drain dequeue), so the retention limit of 1 is correct and not over-eager. The #2929 ring-buffer no-SubVector-retention contract and per-frame RTC semantics are untouched.

## Tests

- **JVM** (`epoch-attribution-test`): `inv-6c` (stranded marker reclaimed across harvests, never folded into a genuine epoch), `inv-6d` (the private stamp never escapes a harvested epoch's `:trace-events`); `inv-6b` updated to assert on marker identity rather than bare map equality (the retained marker now carries the internal stamp).
- **CLJS** (`epoch-cljs-test`): `stranded-child-marker-reclaimed-cljs` pins the cross-target bound (the harvest seam is `.cljc`, runs on both runtimes).

## Gates (cold, this worktree)

- `npm run test:cljs` — 5577 tests / 19417 assertions, 0 failures.
- epoch JVM `clojure -M:test` — 249 tests / 908 assertions, 0 failures (incl. the concurrency stress harness: 3 tests / 49 assertions).

Closes rf2-fxowr.