### PR TITLE
feat(machines): first-class :spawn :on-error child-failure transition (rf2-5hlsh)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -36,6 +36,7 @@
   call-sites."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.resolver :as resolver]
+            [re-frame.machines.lifecycle-fx.spawn-error :as spawn-error]
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.machines.lifecycle-fx.traces :as traces]
             [re-frame.machines.parallel :as parallel]
@@ -170,10 +171,18 @@
                                           (transition/state-path (:state next-snapshot))))
         output-key  (:output-key final-node)
         result      (when output-key (get child-data output-key))
+        ;; Per Spec 005 §Final states §`:on-error` (rf2-5hlsh; XState v5 invoke
+        ;; `onError`): a `:final?` leaf MAY also declare `:error? true` — a
+        ;; designated ERROR terminal. When a `:spawn`-spawned child finishes
+        ;; via an error leaf AND its spawning parent declares `:spawn :on-error`,
+        ;; the runtime routes the failure to a PARENT TRANSITION (control flow,
+        ;; not just observability) instead of the `:data`-only `:on-done`
+        ;; callback. A plain `:final?` leaf keeps firing `:on-done`.
+        error-leaf? (true? (:error? final-node))
         parent-id   (:rf/parent-id child-data)
         invoke-id   (:rf/spawn-id child-data)
-        ;; (1) Find parent's `:on-done`, if this is a `:spawn`-spawned
-        ;; actor. The parent's spec carries the `:spawn` map at
+        ;; (1) Find parent's `:on-done` / `:on-error`, if this is a `:spawn`-
+        ;; spawned actor. The parent's spec carries the `:spawn` map at
         ;; `invoke-id`. Per rf2-a2sn1 — resolve the parent's spec from the
         ;; registrar (a singleton parent) OR, for a NESTED spawn whose
         ;; parent is itself a spawned actor (no per-instance registration),
@@ -187,13 +196,25 @@
         spawn-spec  (when (and parent-meta invoke-id)
                       (find-spawn-spec-at parent-meta invoke-id))
         on-done-fn  (:on-done spawn-spec)
+        ;; `:on-error` is a transition spec (not a fn) — its PRESENCE on the
+        ;; resolved `:spawn` map decides whether the error-leaf trigger routes
+        ;; to a parent transition. The transition itself is resolved natively
+        ;; by the parent's engine (`pick-spawn-error-transition`) when the
+        ;; dispatched `[:rf.machine.spawn/error …]` event arrives, so finalize
+        ;; only decides "fire the dispatch?" here.
+        on-error?   (and error-leaf?
+                         parent-id
+                         (some? (:on-error spawn-spec)))
         parent-path (paths/snapshot-path parent-id)
         ;; (2) Emit `:rf.machine/done` trace BEFORE the destroy cascade
-        ;; (D6 ordering).
+        ;; (D6 ordering). Fired for EVERY finish (success or error leaf) —
+        ;; `:on-error` is additive, the done trace is the actor-finality
+        ;; signal regardless of which spawn hook routes the result.
         _ (trace/emit! :rf.machine :rf.machine/done
                        {:machine-id machine-id
                         :output     result
                         :parent-id  parent-id
+                        :error?     error-leaf?
                         :frame      frame-id})
         ;; (3) Apply :on-done to the parent's `:data`. The parent's
         ;; snapshot lives at [:rf/runtime :machines :snapshots <parent-id>]; we read it,
@@ -202,9 +223,12 @@
         ;; §Final states / rf2-grw4i / rf2-v0rrr the callback receives
         ;; one context-map arg and returns the new `:data` map. If the
         ;; parent has no snapshot (spawned a child but was itself
-        ;; destroyed) or no `:on-done`, this reduces to identity.
+        ;; destroyed) or no `:on-done`, this reduces to identity. An ERROR
+        ;; leaf routing to `:on-error` SKIPS `:on-done` — the two spawn hooks
+        ;; are mutually exclusive per finish (error-leaf → transition,
+        ;; success-leaf → `:data` callback).
         db-after-on-done
-        (if (and on-done-fn parent-id)
+        (if (and on-done-fn parent-id (not on-error?))
           (let [parent-snap     (get-in db parent-path)
                 parent-data     (:data parent-snap)
                 new-parent-data (try
@@ -253,6 +277,19 @@
     (timer/cancel-actor-timers! frame-id machine-id)
     (traces/emit-system-id-released! frame-id released-sid machine-id)
     (registrar/unregister! :event machine-id)
+    ;; (7) Per Spec 005 §Final states §`:on-error` (rf2-5hlsh): when the child
+    ;; finished via an ERROR leaf AND the spawning parent declares
+    ;; `:spawn :on-error`, dispatch the synthetic reserved failure event into
+    ;; the parent. It resolves natively through the parent's macrostep
+    ;; (`pick-spawn-error-transition`), firing the declarative `:on-error`
+    ;; transition (target / guard / actions) with the error payload on
+    ;; `:event` — the XState `invoke onError` control flow. Dispatched (not
+    ;; raised) because the parent is a SEPARATE actor with its own handler /
+    ;; snapshot — symmetric with how the spawn fx dispatches `:start` into the
+    ;; child. The teardown above already ran (the child auto-destroys on its
+    ;; error leaf, like any `:final?`); this only ROUTES the failure.
+    (when on-error?
+      (spawn-error/dispatch-spawn-error! frame-id parent-id invoke-id result))
     {:db db-after-destroy
      ;; rf2-nahfm — append the destroy-time `:exit` cascade's fx to
      ;; the transition's fx vector so any `:exit`-emitted dispatches /

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -24,6 +24,7 @@
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
             [re-frame.machines.lifecycle-fx.join :as join]
             [re-frame.machines.lifecycle-fx.resolver :as resolver]
+            [re-frame.machines.lifecycle-fx.spawn-error :as spawn-error]
             [re-frame.machines.lifecycle-fx.validation :as validation]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.paths :as paths]
@@ -73,9 +74,23 @@
 
 (defn- trace-action-failure!
   "Emit `:rf.error/machine-action-exception` for a `result/fail` Result's
-  `::result/info` map. Returns `{}` so the handler short-circuits."
-  [machine-id event frame-id info reason]
-  (let [ex         (:exception info)
+  `::result/info` map. Returns `{}` so the handler short-circuits.
+
+  Per Spec 005 §Final states §`:on-error` (rf2-5hlsh; XState v5 invoke
+  `onError`): an uncaught child action exception is the SECOND `:on-error`
+  trigger (the control-flow case — formerly observability-only). When the
+  THROWING actor is a `:spawn`-spawned child whose spawning parent declares
+  `:spawn :on-error`, route the failure to the parent's declarative
+  `:on-error` transition via `spawn-error/dispatch-spawn-error!` — additive to
+  (not a replacement for) the trace above, which still fires for every action
+  exception. `ctx` carries the failing actor's `:db` + `:snapshot` (whose
+  `:data` was stamped with `:rf/parent-id` / `:rf/spawn-id` at spawn time);
+  the exception envelope rides as the parent transition's `:event` payload so
+  a guard / action can branch on it. Singletons (no parent) and parents that
+  declare no `:on-error` route nowhere — the trace IS the signal, unchanged."
+  [ctx event reason info]
+  (let [{:keys [machine-id frame-id db snapshot]} ctx
+        ex         (:exception info)
         ex-msg     #?(:clj  (when ex (.getMessage ^Throwable ex))
                       :cljs (when ex (.-message ex)))
         ex-data    (when ex (ex-data ex))
@@ -94,6 +109,24 @@
                         :exception-data    ex-data
                         :reason            reason
                         :recovery          :no-recovery})
+    ;; (rf2-5hlsh) — additive control-flow routing. Read the spawning
+    ;; parent / invoke-id off the child's stamped `:data`; if the parent
+    ;; declares `:spawn :on-error`, dispatch the failure into it. The error
+    ;; payload carries the exception envelope so the parent transition's
+    ;; guard / action can branch on it.
+    (let [child-data (:data snapshot)
+          parent-id  (:rf/parent-id child-data)
+          invoke-id  (:rf/spawn-id child-data)]
+      (when (spawn-error/parent-declares-on-error? db parent-id invoke-id)
+        (spawn-error/dispatch-spawn-error!
+          frame-id parent-id invoke-id
+          {:rf.error/id       :rf.error/machine-action-exception
+           :machine-id        machine-id
+           :action-id         action-ref
+           :event             event
+           :exception-message ex-msg
+           :exception-data    ex-data
+           :reason            reason})))
     {}))
 
 ;; ---- 4-step pipeline (rf2-2zzyg) ------------------------------------------
@@ -541,10 +574,9 @@
           intercepted
           (let [boot-result (maybe-boot ctx)]
             (if (result/fail? boot-result)
-              (trace-action-failure! (:machine-id ctx) [transition/start-marker]
-                                     (:frame-id ctx)
-                                     (result/info boot-result)
-                                     "Machine initial-entry action threw.")
+              (trace-action-failure! ctx [transition/start-marker]
+                                     "Machine initial-entry action threw."
+                                     (result/info boot-result))
               (result/with-ok [post-boot-snap boot-fx] boot-result
                 ;; Per rf2-gl588 — PURE init-kick (the Job-B cut-point,
                 ;; sub-decision (b)): when the routed inner event IS the
@@ -591,10 +623,9 @@
                        :fx (vec boot-fx)}))
                   (let [step-result (run-step ctx post-boot-snap)]
                     (if (result/fail? step-result)
-                      (trace-action-failure! (:machine-id ctx) (:inner-event ctx)
-                                             (:frame-id ctx)
-                                             (result/info step-result)
-                                             "Machine action threw.")
+                      (trace-action-failure! ctx (:inner-event ctx)
+                                             "Machine action threw."
+                                             (result/info step-result))
                       ;; Per rf2-n9f4z: pass the full `boot-result` (fx +
                       ;; bootstrap-entry cascade), not just `boot-fx`, so a
                       ;; same-call bootstrap's entry cascade prepends the

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
@@ -1,0 +1,106 @@
+(ns re-frame.machines.lifecycle-fx.spawn-error
+  "Spawn `:on-error` routing — the child-failure → parent-transition wiring
+  (rf2-5hlsh; XState v5 `invoke onError`).
+
+  Per Spec 005 §Final states §`:on-error`, when a `:spawn`-spawned child
+  FAILS, the runtime routes the failure to the spawning parent's
+  `:spawn :on-error` TRANSITION (control flow — a declarative parent state
+  change), symmetric with the `:spawn :on-done` teardown hook. Two triggers
+  reach this namespace:
+
+    1. the child reaches a designated ERROR `:final?` leaf (`:error? true`) —
+       fired from `lifecycle-fx.finalize/finalize-machine`;
+    2. an uncaught child action exception
+       (`:rf.error/machine-action-exception`) — fired from
+       `lifecycle-fx.registration`'s action-failure projection.
+
+  Both route through `dispatch-spawn-error!`, which dispatches the reserved
+  event `[<parent-id> [:rf.machine.spawn/error <invoke-id> <error>]]` into the
+  parent. The parent's macrostep resolves it natively via
+  `transition/pick-spawn-error-transition` (the `:on-error` transition is
+  resolved at the `:spawn`-bearing state's level — a keyword target is a
+  sibling), so the parent transition fires with full engine semantics (entry /
+  exit cascade, `:always` / `:raise` drain, traces, and the parent's own
+  finalize). Dispatched (not raised) because the parent is a SEPARATE actor —
+  symmetric with how the spawn fx dispatches `:start` into the newborn child.
+
+  This is ADDITIVE: the existing trace emission (observability — the
+  `:rf.error/machine-action-exception` / `:rf.machine/done` traces) is
+  unchanged, and the explicit dispatch-back-to-parent
+  (`[:fx [[:dispatch [parent-id [:failed err]]]]]`) escape hatch keeps working.
+  `:on-error` is the declarative invoke-site control-flow form; the escape
+  hatch is the lower-level form.
+
+  This namespace is a LEAF over the spawn-resolution helpers it needs
+  (`resolver` + `paths` + `transition` + `late-bind` + `registrar`), so both
+  `finalize` and `registration` may require it without a load cycle."
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.machines.lifecycle-fx.resolver :as resolver]
+            [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.paths :as paths]
+            [re-frame.machines.transition :as transition]
+            [re-frame.registrar :as registrar]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn- resolve-parent-spec
+  "Resolve the spawning parent's machine spec from `parent-id` against `db`.
+  Per rf2-a2sn1 — a singleton parent has a registrar entry; a NESTED spawn
+  whose parent is itself a spawned actor (no per-instance registration) is
+  resolved from its own snapshot's `:rf/machine-type`. Mirrors the resolution
+  `finalize-machine` does for `:on-done`."
+  [db parent-id]
+  (when parent-id
+    (let [m (registrar/lookup :event parent-id)]
+      (if (:rf/machine? m)
+        (:rf/machine m)
+        (resolver/spec-from-snapshot
+          (get-in db (paths/snapshot-path parent-id)))))))
+
+(defn- find-spawn-spec-at
+  "Walk `parent-spec`'s state tree to the `:spawn`-bearing node at `invoke-id`
+  (the absolute prefix-path stamped at spawn time) and return its `:spawn`
+  map. For a parallel-region parent the first element of `invoke-id` is the
+  region name (per rf2-l67o); strip and descend into that region's body.
+  Returns nil if the path doesn't resolve or the node declares no `:spawn`.
+  (Same resolution as `finalize/find-spawn-spec-at` — duplicated here so this
+  leaf namespace stays independent of `finalize`, which depends on it.)"
+  [parent-spec invoke-id]
+  (when (and parent-spec (vector? invoke-id) (seq invoke-id))
+    (let [[head & tail] invoke-id
+          [tree path]   (if (and (parallel/parallel? parent-spec)
+                                 (contains? (:regions parent-spec) head))
+                          [(get-in parent-spec [:regions head]) (vec tail)]
+                          [parent-spec invoke-id])
+          node          (transition/node-at tree path)]
+      (:spawn node))))
+
+(defn parent-declares-on-error?
+  "True iff the child identified by `parent-id` / `invoke-id` was spawned by a
+  parent whose `:spawn` map at `invoke-id` declares `:on-error`. `db` is the
+  frame's app-db (used to resolve a nested-spawn parent's spec). Returns false
+  when the actor is a singleton (no `parent-id`), the parent spec doesn't
+  resolve, or the `:spawn` map carries no `:on-error`."
+  [db parent-id invoke-id]
+  (boolean
+    (when (and parent-id invoke-id)
+      (some-> (resolve-parent-spec db parent-id)
+              (find-spawn-spec-at invoke-id)
+              :on-error
+              some?))))
+
+(defn dispatch-spawn-error!
+  "Dispatch the reserved parent-failure event
+  `[<parent-id> [:rf.machine.spawn/error <invoke-id> <error>]]` into the
+  spawning parent so its macrostep fires the declarative `:spawn :on-error`
+  transition (rf2-5hlsh). `error` is the failure payload that rides on the
+  parent transition's `:event` (the child's `:output-key` slot for the
+  error-leaf trigger, or the exception envelope for the action-exception
+  trigger). No-op when the `:router/dispatch!` hook is absent (pure-fn /
+  conformance callers). `:source :machine-spawn` labels the dispatch so the
+  Epoch panel attributes it to the spawn lifecycle."
+  [frame-id parent-id invoke-id error]
+  (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+    (dispatch! [parent-id [transition/spawn-error-event-id invoke-id error]]
+               {:frame frame-id :source :machine-spawn}))
+  nil)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -528,6 +528,13 @@
      transitions out. `:entry` and `:exit` ARE permitted.
    - A non-final state declaring `:output-key` is a registration error
      (`:rf.error/machine-output-key-without-final`).
+   - Per Spec 005 §`:on-error` (rf2-5hlsh): a `:final?` leaf MAY declare
+     `:error? true` — a designated ERROR terminal (re-frame2's spelling of
+     XState v5's error final). A child finishing via an error leaf routes to
+     the spawning parent's `:spawn :on-error` transition instead of
+     `:on-done`. `:error?` on a NON-final state is meaningless and rejected
+     (`:rf.error/machine-error-flag-without-final`), symmetric with
+     `:output-key`.
 
   Reject malformed declarations at registration time."
   [state-key state-node]
@@ -555,7 +562,43 @@
              :rf.error/machine-output-key-without-final
              ":output-key is only meaningful on a :final? state."
              {:state      state-key
-              :output-key (:output-key state-node)}))))
+              :output-key (:output-key state-node)}))
+
+    ;; Non-final state declaring :error? — error per rf2-5hlsh (symmetric
+    ;; with :output-key). `:error?` designates an error TERMINAL; it is
+    ;; meaningless on a non-final state.
+    (contains? state-node :error?)
+    (throw (validation-error
+             :rf.error/machine-error-flag-without-final
+             (str ":error? is only meaningful on a :final? state (it designates "
+                  "an error terminal — see Spec 005 §`:on-error`).")
+             {:state  state-key
+              :error? (:error? state-node)}))))
+
+(defn- validate-spawn-on-error!
+  "Per Spec 005 §Final states §`:on-error` (rf2-5hlsh): a `:spawn`-bearing
+  state's `:spawn :on-error` is an `:on`-shaped transition spec — a keyword
+  target, a vector-path target, a single transition map `{:target :guard
+  :actions}`, or a guarded candidate vector. Reject a malformed `:on-error`
+  shape at registration (`:rf.error/machine-bad-on-error-clause`); the guard /
+  action ref resolution is checked by the top-level pass (alongside `:on` /
+  `:on-done`). Absent `:on-error` is fine (the spawn simply has no failure
+  routing — the trace + escape-hatch remain)."
+  [state-key state-node]
+  (when-let [spawn (:spawn state-node)]
+    (when (contains? spawn :on-error)
+      (let [oe (:on-error spawn)]
+        (when-not (or (keyword? oe)
+                      (map? oe)
+                      (and (vector? oe) (seq oe)))
+          (throw (validation-error
+                   :rf.error/machine-bad-on-error-clause
+                   (str ":spawn :on-error must be an :on-shaped transition spec — "
+                        "a keyword target, a vector-path target, a single "
+                        "transition map {:target :guard :actions}, or a "
+                        "non-empty guarded candidate vector. Got: " (pr-str oe) ".")
+                   {:state    state-key
+                    :on-error oe})))))))
 
 (defn- compound?
   "A state node is compound iff it declares a non-empty `:states` map."
@@ -711,6 +754,7 @@
     (validate-spawn-all! s n)
     (validate-no-spawn-timeout-ms! s n)
     (validate-final-state! s n)
+    (validate-spawn-on-error! s n)
     (validate-compound-initial! s n))
   ;; The self-loop check needs each declaring node's absolute path to
   ;; resolve vector `:target`s, so it drives off the path-aware walker.
@@ -774,6 +818,11 @@
       ;; transition (fired when the compound reaches a `:final?` child); its
       ;; guard / action refs must resolve at registration like any other slot.
       (check-transition! (:on-done state-node) s)
+      ;; Per Spec 005 §Final states §`:on-error` (rf2-5hlsh): a `:spawn`-bearing
+      ;; state's `:spawn :on-error` is an `:on`-shaped transition fired when a
+      ;; spawned child fails; its guard / action refs resolve at registration
+      ;; like `:on-done`. (Shape is checked separately by `validate-spawn-on-error!`.)
+      (check-transition! (get-in state-node [:spawn :on-error]) s)
       (check-action! (:entry state-node) s)
       (check-action! (:exit  state-node) s))
     ;; Per Spec 005 §Transition resolution: the machine root's own `:on`

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -61,6 +61,30 @@
   below for the full mechanism (rf2-bnjb3 / rf2-zlmz7)."
   :rf.machine/done)
 
+(def spawn-error-event-id
+  "The reserved inner event-id dispatched into a PARENT machine when one of
+  its `:spawn`-spawned children FAILS — re-frame2's spelling of XState v5
+  `invoke onError` (control flow, not just observability — rf2-5hlsh). Two
+  triggers raise it (both fired from the child's finalize / action-exception
+  path in `lifecycle-fx.finalize` / `lifecycle-fx.registration`):
+
+    1. the child reaches a designated ERROR `:final?` leaf (`:error? true`);
+    2. an uncaught child action exception (`:rf.error/machine-action-exception`).
+
+  The dispatched event shape is `[<parent-id> [:rf.machine.spawn/error
+  <invoke-id> <error>]]` — `<invoke-id>` is the absolute prefix-path of the
+  parent's `:spawn`-bearing state (so the resolver routes to the right
+  `:spawn :on-error`), `<error>` is the error payload (the child's
+  `:output-key` slot for the error-leaf trigger, or the exception envelope for
+  the action-exception trigger). `pick-transition` special-cases it via
+  `pick-spawn-error-transition`, which resolves the active `:spawn`-bearing
+  state's `:on-error` `:on`-shaped transition spec at that state's own level —
+  SYMMETRIC with the `:spawn :on-done` teardown hook, but a TRANSITION
+  (parent state change) rather than a `:data`-only callback. Lives under the
+  framework-reserved `:rf.machine.spawn/*` family (so `unhandled-event-no-op?`
+  exempts it). See `pick-spawn-error-transition` below."
+  :rf.machine.spawn/error)
+
 (defn- chase-ref
   "Follow a keyword reference chain through the machine's named-bindings
   map until it hits a fn (or fails). Tolerates one level of indirection
@@ -829,6 +853,87 @@
         (when-let [hit (match-on-clause machine machine done-event-id event snapshot)]
           {:transition hit :decl-path []})))))
 
+(defn- pick-spawn-error-transition
+  "Per Spec 005 §Final states §`:on-error` — child-failure control flow
+  (rf2-5hlsh; XState v5 `invoke onError`): resolve the synthetic parent event
+  `[:rf.machine.spawn/error <invoke-id> <error>]` — dispatched into the PARENT
+  when one of its `:spawn`-spawned children failed — to a transition.
+
+  `<invoke-id>` is the absolute prefix-path of the parent's `:spawn`-bearing
+  state. The resolver routes by it: find the `:spawn`-bearing state node at
+  `<invoke-id>` (the SAME placement the spawn was declared at, so the
+  `:on-error` is resolved at THAT state's level — a keyword target is a
+  SIBLING of the `:spawn`-bearing state, the natural \"child failed → move the
+  parent out of the spawning state\" placement). Its `:spawn :on-error` value
+  is an `:on`-shaped transition spec (a keyword target, vector-path target,
+  single transition map `{:target :guard :actions}`, or guarded candidate
+  vector) — normalised + guard-resolved through the SAME candidate machinery as
+  an `:on` clause. The error payload rides on `:event` (`(nth ev 2)`) so a
+  guard / action can branch on it.
+
+  Two resolution arms, in priority order — symmetric with
+  `pick-done-transition`:
+
+   1. **`:on-error` on the parent's `:spawn` map** — the headline spelling.
+      Resolved at the `:spawn`-bearing state's decl-path. Only fires when the
+      parent's ACTIVE path still includes that state (the spawning state is
+      still occupied — the common case, since the child failing is what should
+      move the parent out of it).
+   2. **An enclosing explicit `:on {:rf.machine.spawn/error …}`** — the
+      lower-level escape hatch (kept additive). When no `:spawn :on-error` is
+      declared (or its candidates all guard-fail), the raised event walks the
+      active path leaf→root like any event, so an ancestor handling the
+      reserved id explicitly can take it. A guard reads the invoke-id /error off
+      `:event` to disambiguate which spawn failed.
+
+  Returns `{:transition t :decl-path p}` or nil (no `:on-error` and no
+  enclosing handler — the failure signal is then a benign no-op, exactly like
+  an unhandled reserved-`:rf/*` event; the existing trace emission + the
+  explicit dispatch-back-to-parent escape hatch remain the lower-level forms)."
+  [machine path event snapshot]
+  (let [[_ raw-invoke-id] event
+        region         (:rf/region machine)
+        ;; Per Spec 005 §Per-region `:spawn` scoping (rf2-l67o): a `:spawn`
+        ;; declared inside a parallel region carries a region-name-prefixed
+        ;; invoke-id (`prefix-region-spawn-id`). Within a region's resolution
+        ;; `machine` is the region body (region-relative `node-at`) and `path`
+        ;; is in-region, so strip the region-name head — mirroring the
+        ;; `pick-after-transition` region handling. A prefix naming a DIFFERENT
+        ;; region is not this region's spawn; decline so the broadcast routes
+        ;; to the bearing region only.
+        invoke-id      (cond
+                         (not (vector? raw-invoke-id)) raw-invoke-id
+                         region (when (= region (first raw-invoke-id))
+                                  (vec (rest raw-invoke-id)))
+                         :else  raw-invoke-id)
+        ;; The `:spawn`-bearing state lives at `invoke-id` (absolute prefix
+        ;; path, region-stripped above). It is only resolvable when still on
+        ;; the active `path` — a transition that already exited the spawning
+        ;; state cannot land an `:on-error` (the spawn is gone). `prefix-of?`
+        ;; mirrors the `:after` staleness check.
+        spawn-node     (when (and (vector? invoke-id)
+                                  (seq invoke-id)
+                                  (prefix-of? invoke-id path))
+                         (node-at machine invoke-id))
+        on-error       (get-in spawn-node [:spawn :on-error])
+        on-error-cands (when (and spawn-node (some? on-error))
+                         (normalise-candidates on-error
+                                               :rf.error/machine-bad-on-error-clause))
+        on-error-hit   (when (seq on-error-cands)
+                         (select-passing-candidate machine on-error-cands snapshot event))]
+    (if on-error-hit
+      {:transition on-error-hit :decl-path (vec invoke-id)}
+      ;; Fall through to the standard leaf→root `:on` walk (an ancestor's
+      ;; explicit `:on {:rf.machine.spawn/error …}`), then the root `:on`.
+      (or
+        (path-walk/walk-path-leaf-to-root
+          machine path
+          (fn [prefix n]
+            (when-let [hit (match-on-clause machine n spawn-error-event-id event snapshot)]
+              {:transition hit :decl-path prefix})))
+        (when-let [hit (match-on-clause machine machine spawn-error-event-id event snapshot)]
+          {:transition hit :decl-path []})))))
+
 (defn- pick-transition
   "Walk path leaf→root looking for a transition that matches event-id and
   whose guard passes. Per Spec 005 §Transition resolution — deepest-wins
@@ -858,6 +963,9 @@
 
       (= done-event-id event-id)
       (pick-done-transition machine path event snapshot)
+
+      (= spawn-error-event-id event-id)
+      (pick-spawn-error-transition machine path event snapshot)
 
       :else
       (or

--- a/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
@@ -1,0 +1,337 @@
+(ns re-frame.machines-on-error-cljs-test
+  "Per rf2-5hlsh — first-class `:spawn :on-error` (XState v5 invoke `onError`).
+
+  When a `:spawn`-spawned child FAILS, the runtime routes the failure to the
+  spawning parent's `:spawn :on-error` TRANSITION (control flow — a declarative
+  parent state change), SYMMETRIC with the existing `:spawn :on-done` teardown
+  hook. Two triggers:
+
+    (1) the child reaches a designated ERROR `:final?` leaf (`:error? true`) —
+        the error payload (`:output-key` slot) rides into the `:on-error`
+        transition's `:event`;
+    (2) an uncaught child action exception
+        (`:rf.error/machine-action-exception`) — the exception envelope rides
+        into the `:on-error` transition's `:event` (this was formerly
+        observability-only).
+
+  `:on-error` is ADDITIVE: the trace emission (observability) and the explicit
+  dispatch-back-to-parent escape hatch both keep working; `:on-error` is the
+  declarative invoke-site control-flow form.
+
+  Tests:
+    (a) child reaches error `:final?` leaf → parent `:on-error :target` fires
+        + error payload in ctx;
+    (b) uncaught child action exception → parent `:on-error` fires (control
+        flow);
+    (c) `:on-error` with `:guard` + `:action`;
+    (d) child SUCCESS → `:on-done` fires, `:on-error` does NOT;
+    (e) no `:on-error` declared → existing behaviour (trace + escape-hatch)
+        unchanged (regression);
+    (f) malformed `:on-error` / `:error?`-without-`:final?` rejected at
+        registration.
+
+  Named `*-cljs-test.cljc` so it runs under both cognitect.test-runner (JVM)
+  and shadow-cljs (CLJS), matching `final_state_cljs_test.cljc`."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; Loading `re-frame.machines` installs the late-bind hooks `reg-machine`
+   ;; resolves through (without it, `rf/reg-machine` throws
+   ;; `:rf.error/machines-artefact-missing`).
+   [re-frame.machines]
+   [re-frame.trace.tooling :as trace-tooling]
+   [re-frame.test-support :as test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter})))
+
+(defn- snapshot
+  [machine-id]
+  (get-in (rf/app-db-value :rf/default) [:rf/runtime :machines :snapshots machine-id]))
+
+(defn- spawned-id-for
+  [parent-id invoke-id]
+  (get-in (rf/app-db-value :rf/default)
+          [:rf/runtime :machines :spawned parent-id invoke-id]))
+
+(defn- traces-for
+  [traces operation]
+  (filter #(= operation (:operation %)) @traces))
+
+(defn- record-traces!
+  [k]
+  (let [a (atom [])]
+    (trace-tooling/register-listener! k (fn [ev] (swap! a conj ev)))
+    a))
+
+;; ---- (a) child reaches error :final? leaf → parent :on-error :target fires ----
+
+(deftest child-error-final-leaf-fires-parent-on-error-transition
+  (testing "child reaching an :error? :final? leaf drives the parent's :on-error :target (with the error payload)"
+    (rf/reg-machine :rf2-5hlsh-a/child
+      {:initial :running
+       :data    {}
+       :states
+       {:running {:on {:boom {:target :failed
+                              :action (fn [{data :data ev :event}]
+                                        {:data (assoc data :err (second ev))})}}}
+        ;; designated ERROR terminal — carries the error via :output-key
+        :failed  {:final?     true
+                  :error?     true
+                  :output-key :err}}})
+    (rf/reg-machine :rf2-5hlsh-a/parent
+      {:initial :idle
+       :data    {}
+       :states
+       {:idle    {:on {:start :working}}
+        :working {:spawn {:machine-id :rf2-5hlsh-a/child
+                          ;; :on-error is an :on-shaped TRANSITION resolved at
+                          ;; :working's level — :errored is a sibling.
+                          :on-error {:target :errored
+                                     :action (fn [{data :data ev :event}]
+                                               ;; ev = [:rf.machine.spawn/error <invoke-id> <error>]
+                                               {:data (assoc data :captured (nth ev 2))})}}
+                  :on    {:done :idle}}
+        :errored {}}})
+    (rf/dispatch-sync [:rf2-5hlsh-a/parent [:start]])
+    (let [child (spawned-id-for :rf2-5hlsh-a/parent [:working])]
+      (is (some? child) "child spawned")
+      (rf/dispatch-sync [child [:boom :network-down]])
+      (is (= :errored (:state (snapshot :rf2-5hlsh-a/parent)))
+          "parent's :on-error :target fired — it moved to :errored")
+      (is (= :network-down (get-in (snapshot :rf2-5hlsh-a/parent) [:data :captured]))
+          "the error payload (child's :output-key slot) rode into the :on-error transition's :event")
+      (is (nil? (snapshot child))
+          "the failed child auto-destroyed (it reached a :final? leaf)"))))
+
+;; ---- (b) uncaught child action exception → parent :on-error fires ----------
+
+(deftest child-action-exception-fires-parent-on-error-transition
+  (testing "an uncaught child action exception routes to the parent's :on-error transition (control flow, was observability-only)"
+    (let [traces (record-traces! ::action-exc)]
+      (rf/reg-machine :rf2-5hlsh-b/child
+        {:initial :running
+         :data    {}
+         :states
+         {:running {:on {:go {:target :next
+                              :action (fn [_] (throw (ex-info "kaboom" {:why :test})))}}}
+          :next    {}}})
+      (rf/reg-machine :rf2-5hlsh-b/parent
+        {:initial :working
+         :data    {}
+         :states
+         {:working {:spawn {:machine-id :rf2-5hlsh-b/child
+                            :on-error {:target :errored}}}
+          :errored {}}})
+      (rf/dispatch-sync [:rf2-5hlsh-b/parent [:rf.machine.spawn/spawned]])
+      (let [child (spawned-id-for :rf2-5hlsh-b/parent [:working])]
+        (rf/dispatch-sync [child [:go]])
+        (is (some #(= :rf.error/machine-action-exception (:operation %)) @traces)
+            "the action-exception trace STILL fired (observability unchanged — additive)")
+        (is (= :errored (:state (snapshot :rf2-5hlsh-b/parent)))
+            "the uncaught exception drove the parent's :on-error :target")))))
+
+;; ---- (c) :on-error with :guard + :action -----------------------------------
+
+(deftest on-error-honours-guard-and-action
+  (testing ":on-error candidate-vector resolves first-guard-pass-wins, runs the chosen :action"
+    (rf/reg-machine :rf2-5hlsh-c/child
+      {:initial :running
+       :data    {}
+       :states
+       {:running {:on {:fail {:target :failed
+                              :action (fn [{data :data ev :event}]
+                                        {:data (assoc data :code (second ev))})}}}
+        :failed  {:final?     true
+                  :error?     true
+                  :output-key :code}}})
+    (rf/reg-machine :rf2-5hlsh-c/parent
+      {:initial :working
+       :data    {}
+       :states
+       {:working {:spawn {:machine-id :rf2-5hlsh-c/child
+                          ;; guarded candidate vector: a 503 retries, anything
+                          ;; else gives up. First guard-pass wins.
+                          :on-error [{:guard  (fn [{ev :event}] (= 503 (nth ev 2)))
+                                      :target :retrying
+                                      :action (fn [{data :data}] {:data (assoc data :route :retry)})}
+                                     {:target :gave-up
+                                      :action (fn [{data :data}] {:data (assoc data :route :give-up)})}]}}
+        :retrying {}
+        :gave-up  {}}})
+    (rf/dispatch-sync [:rf2-5hlsh-c/parent [:rf.machine.spawn/spawned]])
+    (let [child (spawned-id-for :rf2-5hlsh-c/parent [:working])]
+      (rf/dispatch-sync [child [:fail 503]])
+      (is (= :retrying (:state (snapshot :rf2-5hlsh-c/parent)))
+          "the 503 guard passed → :retrying")
+      (is (= :retry (get-in (snapshot :rf2-5hlsh-c/parent) [:data :route]))
+          "the guarded candidate's :action ran"))))
+
+(deftest on-error-guard-fallthrough-to-unguarded
+  (testing ":on-error guarded candidate guard-fails → falls through to the unguarded fallback"
+    (rf/reg-machine :rf2-5hlsh-c2/child
+      {:initial :running
+       :data    {}
+       :states
+       {:running {:on {:fail {:target :failed
+                              :action (fn [{data :data ev :event}]
+                                        {:data (assoc data :code (second ev))})}}}
+        :failed  {:final?     true
+                  :error?     true
+                  :output-key :code}}})
+    (rf/reg-machine :rf2-5hlsh-c2/parent
+      {:initial :working
+       :data    {}
+       :states
+       {:working {:spawn {:machine-id :rf2-5hlsh-c2/child
+                          :on-error [{:guard  (fn [{ev :event}] (= 503 (nth ev 2)))
+                                      :target :retrying}
+                                     {:target :gave-up}]}}
+        :retrying {}
+        :gave-up  {}}})
+    (rf/dispatch-sync [:rf2-5hlsh-c2/parent [:rf.machine.spawn/spawned]])
+    (let [child (spawned-id-for :rf2-5hlsh-c2/parent [:working])]
+      (rf/dispatch-sync [child [:fail 404]])
+      (is (= :gave-up (:state (snapshot :rf2-5hlsh-c2/parent)))
+          "404 failed the 503 guard → unguarded fallback :gave-up fired"))))
+
+;; ---- (d) child SUCCESS → :on-done fires, :on-error does NOT -----------------
+
+(deftest success-leaf-fires-on-done-not-on-error
+  (testing "a plain (non-:error?) :final? leaf fires :on-done; :on-error does NOT fire"
+    (rf/reg-machine :rf2-5hlsh-d/child
+      {:initial :running
+       :data    {}
+       :states
+       {:running {:on {:ok {:target :done
+                            :action (fn [{data :data ev :event}]
+                                      {:data (assoc data :tok (second ev))})}}}
+        :done    {:final?     true
+                  :output-key :tok}}})
+    (rf/reg-machine :rf2-5hlsh-d/parent
+      {:initial :working
+       :data    {}
+       :states
+       {:working {:spawn {:machine-id :rf2-5hlsh-d/child
+                          :on-done  (fn [{data :data result :result}]
+                                      (assoc data :got result))
+                          :on-error {:target :errored}}}
+        :errored {}}})
+    (rf/dispatch-sync [:rf2-5hlsh-d/parent [:rf.machine.spawn/spawned]])
+    (let [child (spawned-id-for :rf2-5hlsh-d/parent [:working])]
+      (rf/dispatch-sync [child [:ok :the-token]])
+      (is (= :the-token (get-in (snapshot :rf2-5hlsh-d/parent) [:data :got]))
+          ":on-done ran against the success result")
+      (is (= :working (:state (snapshot :rf2-5hlsh-d/parent)))
+          "the parent did NOT move to :errored — :on-error did not fire on success"))))
+
+;; ---- (e) no :on-error declared → existing behaviour unchanged (regression) ----
+
+(deftest no-on-error-keeps-trace-and-escape-hatch
+  (testing "without :on-error, an error leaf still fires the :rf.machine/done trace + auto-destroy (regression)"
+    (let [traces (record-traces! ::no-on-error)]
+      (rf/reg-machine :rf2-5hlsh-e/child
+        {:initial :running
+         :data    {}
+         :states
+         {:running {:on {:boom :failed}}
+          :failed  {:final? true :error? true}}})
+      ;; parent declares NO :on-error — error leaf behaves like any :final?:
+      ;; the child auto-destroys, the :rf.machine/done trace fires, the parent
+      ;; is unmoved. The explicit dispatch-back escape hatch (if the child
+      ;; chose it) would still work — exercised by the action emitting a
+      ;; dispatch; here we assert the framework adds NO transition itself.
+      (rf/reg-machine :rf2-5hlsh-e/parent
+        {:initial :working
+         :data    {}
+         :states
+         {:working {:spawn {:machine-id :rf2-5hlsh-e/child}}}})
+      (rf/dispatch-sync [:rf2-5hlsh-e/parent [:rf.machine.spawn/spawned]])
+      (let [child (spawned-id-for :rf2-5hlsh-e/parent [:working])]
+        (rf/dispatch-sync [child [:boom]])
+        (is (nil? (snapshot child))
+            "child auto-destroyed on its error leaf (no :on-error needed)")
+        (is (= :working (:state (snapshot :rf2-5hlsh-e/parent)))
+            "parent unmoved — no :on-error means no framework-driven transition")
+        (let [dones (traces-for traces :rf.machine/done)]
+          (is (= 1 (count dones)) "the :rf.machine/done actor-finality trace still fired")
+          (is (true? (-> (first dones) :tags :error?))
+              ":rf.machine/done carries :error? true for an error leaf"))))))
+
+(deftest escape-hatch-explicit-dispatch-still-works
+  (testing "the lower-level escape hatch ([:fx [[:dispatch [parent [:failed]]]]]) keeps working alongside :on-error"
+    (rf/reg-machine :rf2-5hlsh-e2/child
+      {:initial :running
+       :data    {}
+       :states
+       ;; The child explicitly dispatches a failure event back to its parent
+       ;; from a transition action — the documented lower-level form.
+       {:running {:on {:boom {:target :failed
+                              :action (fn [{data :data}]
+                                        {:data data
+                                         :fx   [[:dispatch [:rf2-5hlsh-e2/parent [:child-failed]]]]})}}}
+        :failed  {:final? true}}})
+    (rf/reg-machine :rf2-5hlsh-e2/parent
+      {:initial :working
+       :data    {}
+       :states
+       {:working {:spawn {:machine-id :rf2-5hlsh-e2/child}
+                  :on    {:child-failed :errored}}
+        :errored {}}})
+    (rf/dispatch-sync [:rf2-5hlsh-e2/parent [:rf.machine.spawn/spawned]])
+    (let [child (spawned-id-for :rf2-5hlsh-e2/parent [:working])]
+      (rf/dispatch-sync [child [:boom]])
+      (is (= :errored (:state (snapshot :rf2-5hlsh-e2/parent)))
+          "the explicit dispatch-back-to-parent escape hatch drove the parent transition"))))
+
+;; ---- (f) malformed :on-error / :error?-without-:final? rejected ------------
+
+(deftest registration-validations
+  (testing "a malformed :spawn :on-error is rejected at registration"
+    (is (thrown-with-msg?
+          #?(:clj Exception :cljs js/Error) #":rf.error/machine-bad-on-error-clause"
+          (rf/reg-machine :rf2-5hlsh-f/bad-on-error
+            {:initial :working
+             :states  {:working {:spawn {:machine-id :whatever
+                                         :on-error   42}}}}))))     ;; not a transition spec
+  (testing ":error? on a NON-final state is rejected"
+    (is (thrown-with-msg?
+          #?(:clj Exception :cljs js/Error) #":rf.error/machine-error-flag-without-final"
+          (rf/reg-machine :rf2-5hlsh-f/bad-error-flag
+            {:initial :a
+             :states  {:a {:error? true
+                           :on     {:go :b}}
+                       :b {}}}))))
+  (testing "a dangling :on-error action ref is rejected at registration"
+    (is (thrown-with-msg?
+          #?(:clj Exception :cljs js/Error) #":rf.error/machine-unresolved-action"
+          (rf/reg-machine :rf2-5hlsh-f/dangling-action
+            {:initial :working
+             :states  {:working {:spawn {:machine-id :whatever
+                                         :on-error   {:target :errored
+                                                      :action :no-such-action}}}
+                       :errored {}}}))))
+  (testing "a well-formed :error? :final? leaf + :on-error validates silently"
+    (is (some? (rf/reg-machine :rf2-5hlsh-f/ok
+                 {:initial :working
+                  :states  {:working {:spawn {:machine-id :whatever
+                                              :on-error {:target :errored}}}
+                            :errored {:final? true :error? true}}})))))
+
+;; NOTE — parallel-PARENT region :on-error. The `pick-spawn-error-transition`
+;; resolver strips the region-name prefix off the invoke-id so a `:spawn`
+;; declared inside a parallel REGION resolves its `:on-error` region-scoped
+;; (mirroring `pick-after-transition`). The end-to-end parallel-region path is
+;; NOT exercised here because a parallel region's DECLARATIVE-`:spawn` child
+;; currently keys its `[:rf/runtime :machines :spawned …]` slot under the
+;; `:rf/transition-pure` parent-id fallback (the region-spec's `:rf/parent-id`
+;; is unset at the spawn reducer) — a PRE-EXISTING parallel-region-spawn quirk
+;; that affects `:on-done` identically, orthogonal to `:on-error`. Filed as a
+;; follow-up. The resolver code is defensively correct for the day that quirk
+;; is fixed; a flat/compound parent (the dominant case, every test above)
+;; exercises the full path.

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -2476,7 +2476,8 @@ The map under `:spawn` accepts the following keys:
 | `:data` | initial data for the child — literal map or `(fn [{:keys [snapshot event]}] data)` (per — unified context-map) | optional |
 | `:id-prefix` | base for the gensym'd actor id (`:request/protocol#42`) | optional; defaults to `:machine-id` |
 | `:on-spawn` | `(fn [{:keys [data id]}] _)` — advisory callback fired with the spawned id; return is ignored (runtime tracks the id at `[:rf/runtime :machines :spawned <parent> <invoke-id>]`) | optional |
-| `:on-done` | `(fn [{:keys [data result]}] new-data)` — fires when the child enters a `:final?` state; `result` is the child's `:data` slot named by the final state's `:output-key` (or `nil` if no `:output-key` declared) — see [§Final states](#final-states-final--on-done--output-key). Returns the parent's new `:data` map. | optional |
+| `:on-done` | `(fn [{:keys [data result]}] new-data)` — fires when the child enters a (non-error) `:final?` state; `result` is the child's `:data` slot named by the final state's `:output-key` (or `nil` if no `:output-key` declared) — see [§Final states](#final-states-final--on-done--output-key). Returns the parent's new `:data` map. | optional |
+| `:on-error` | an `:on`-shaped **transition** spec `{:target :guard :action}` (or keyword / vector-path target, or guarded candidate vector) — fires when the spawned child **FAILS**: it reaches a designated error `:final?` leaf (`:error? true`), or one of its actions throws an uncaught exception. The parent moves to the transition's `:target` (resolved at the `:spawn`-bearing state's own level — a keyword target is a sibling), running its `:guard` / `:action`. The error payload rides on the transition's `:event` (the child's `:output-key` slot for the error-leaf trigger, or the exception envelope for the action-exception trigger). re-frame2's spelling of XState v5 `invoke onError` — control flow, not just observability. See [§`:on-error`](#on-error--child-failure-control-flow). | optional |
 | `:start` | event vector dispatched to the newborn after spawn | optional |
 | `:spawn-id` | explicit id instead of gensym (useful for tests / per-state singleton actors) | optional |
 
@@ -2580,7 +2581,7 @@ The desugaring is uniform — no special-casing for hierarchy. Whatever cascadin
 
 ### Errors
 
-`:spawn` introduces **no new error categories**. Failures route through the existing `:rf.error/*` machinery:
+`:spawn` introduces **no new error categories**. Failures route through the existing `:rf.error/*` machinery (and, when the parent declares `:on-error`, *additionally* drive a declarative parent transition — see [§`:on-error`](#on-error--child-failure-control-flow)):
 
 - If `:data` is a function and it throws, the error surfaces as `:rf.error/machine-action-exception` (the standard category for any user-supplied fn that throws during a machine action — see [Cross-Spec-Interactions §11](Cross-Spec-Interactions.md#11-machine-action-throws)). The transition halts; the snapshot does not commit.
 - If `:machine-id` references an unregistered machine, the spawn fx itself errors per existing spawn semantics — no `:spawn`-specific category.
@@ -2594,7 +2595,7 @@ xstate's `invoke` admits several features re-frame2 deliberately omits. Each has
 |---|---|
 | **`onDone`** — fire a callback when the child reaches a final state | re-frame2 ships first-class final states with parent notification — see [§Final states (`:final?` / `:on-done` / `:output-key`)](#final-states-final--on-done--output-key). A leaf state declares `:final? true` (and optionally `:output-key`); the parent's `:spawn` declares `:on-done (fn [{data :data result :result}] new-data)`. The runtime invokes `:on-done` synchronously when the child enters its final state, then auto-destroys the child. |
 | **Compound / parallel `onDone`** (`done.state.<id>` raised *into the same machine* when a compound reaches its `<final>` child — or a parallel reaches all-regions-final — so an enclosing transition advances *without* tearing the machine down) | **Shipped first-class** (no longer omitted) — see [§The done-state signal](#the-done-state-signal). Declare `:on-done` on the compound (resolved at the compound's level — a keyword target is a sibling) or on the parallel root (action + fx; root-only parallel has no in-machine target). The runtime raises `[:rf.machine/done <node-path>]` into the FIFO `:raise` queue, so the enclosing `:on-done` fires in the same macrostep and the machine keeps running. The depth of the `:final?` leaf disambiguates compound-done (embedded) from whole-machine finality (top-level) — the [§Embedded vs top-level](#embedded-vs-top-level--the-d7-reconciliation) reconciliation. (The former `:raise`-from-non-`:final?`-`:entry` substitute is withdrawn.) |
-| **`onError`** — child error callback | Errors flow through the standard `:rf.error/*` machinery and are visible in trace events. The parent observes via the existing error envelope, not a `:spawn`-specific hook. |
+| **`onError`** — child error callback / **transition** | **Shipped first-class** (no longer observability-only) — see [§`:on-error`](#on-error--child-failure-control-flow). Declare `:on-error` on the parent's `:spawn` map as an `:on`-shaped **transition** spec `{:target :guard :action}`. When the spawned child FAILS — it reaches a designated error `:final?` leaf (`:error? true`), or one of its actions throws — the parent **moves to the `:on-error :target`** (resolved at the `:spawn`-bearing state's level), with the error payload on the transition's `:event`. This is XState v5's `invoke onError` semantics: a transition (control flow), not merely an observable. Errors STILL flow through the `:rf.error/*` machinery + trace events (observability is unchanged — `:on-error` is additive), and the explicit dispatch-back-to-parent (`[:fx [[:dispatch [parent-id [:failed err]]]]]`) remains the lower-level escape hatch. |
 | **Multiple `:spawn` per state** (xstate admits a vector) | One `:spawn` per state. Multiple actors per state suggests refactoring into a compound state where each substate invokes one of the actors. |
 | **`autoForward`** — forward all parent events to the child | Users forward explicitly via `:fx [[:dispatch [child-id ev]]]` from the relevant transitions. Implicit forwarding is invisible at the call site; explicit forwarding is what visualisers and AIs read. |
 
@@ -2656,6 +2657,8 @@ A leaf state may declare `:final? true`. Entering that state **terminates the ma
 - If the machine was spawned by a parent's `:spawn`, the parent's `:spawn :on-done (fn [{data :data result :result}] new-data)` fires (with `result` = the child's `:data` slot named by the final state's `:output-key`, or `nil` when `:output-key` is absent). The child is then **auto-destroyed**.
 - If the machine is a **singleton** (registered top-level, no parent `:spawn`), the machine still auto-destroys on entry to `:final?` — "final means final" (D7 below). Apps wanting a persistent terminal state simply **omit `:final?`** and use an ordinary leaf state.
 
+A `:final?` leaf may additionally declare **`:error? true`** — a designated **error terminal** (re-frame2's spelling of XState v5's error final). When a spawned child finishes via an error leaf AND its spawning parent declares `:spawn :on-error`, the runtime routes the failure to the parent's **`:on-error` transition** rather than the `:data`-only `:on-done` callback — see [§`:on-error`](#on-error--child-failure-control-flow). An error leaf with no parent `:on-error` behaves exactly like any other `:final?` leaf (auto-destroy + the `:rf.machine/done` trace, which carries `:error? true`). `:error?` on a non-final state is a registration error (`:rf.error/machine-error-flag-without-final`, symmetric with `:output-key`).
+
 ```clojure
 ;; Child machine — declares its terminal state with :final? + :output-key.
 (rf/reg-machine :auth-flow
@@ -2704,6 +2707,63 @@ When `:auth-flow` enters `:done`, the runtime:
 | D8 | **`:system-id` interaction** — the runtime auto-clears `[:rf/runtime :machines :system-ids <system-id>]` reverse-index entry on done. The clear runs **after `:on-done` fires** so the hook can still read the binding. |
 | D9 | Specified and implemented in one delivery (no post-v1 deferral). |
 | D10 | Capability-matrix axis: **`:fsm/final-states`** (naming consistent with `:fsm/parallel-regions`, `:fsm/tags`). Conformance fixtures `final-state-singleton-auto-destroys` and `final-state-child-fires-on-done` exercise the contract. |
+
+### `:on-error` — child-failure control flow
+
+> **XState v5 term:** `invoke onError` (a **transition** the parent takes when an invoked actor errors). **rf2-5hlsh** — Mike-ruled 2026-06-04: *XState `onError` is a transition, not just observability; pre-alpha is when to avoid baking in clumsy substitutes.*
+
+`:spawn :on-done` is the *success* notification — a `:data`-only callback the parent runs when a spawned child reaches a (non-error) `:final?` state. `:spawn :on-error` is its **symmetric failure counterpart**, but a **transition** rather than a callback: when a spawned child FAILS, the parent **changes state** declaratively, at the `:spawn` site. This is XState v5's `invoke onError` — the parent reacts to the child failing by transitioning, not merely observing an error envelope.
+
+**The grammar — an `:on`-shaped transition on the parent's `:spawn` map.** `:on-error` sits beside `:on-done` on the parent's `:spawn` map. Its value is an `:on`-shaped transition spec — a keyword target, a vector-path target, a single transition map `{:target :guard :action}`, or a guarded candidate vector — resolved **relative to the `:spawn`-bearing state's own level** (a keyword target is a **sibling** of the spawning state, the natural *"child failed → move the parent out of the spawning state"* placement). It is normalised + guard-resolved through the **same candidate machinery as an `:on` clause**, so first-guard-pass-wins and an unguarded candidate is the unconditional fallback.
+
+```clojure
+;; Child declares a designated error terminal with :error? + :output-key.
+(rf/reg-machine :auth-flow
+  {:initial :running
+   :data    {}
+   :states
+   {:running {:on {:server-error {:target :failed
+                                  :action (fn [{data :data ev :event}]
+                                            {:data (assoc data :reason (second ev))})}
+                   :server-ok    {:target :done
+                                  :action (fn [{data :data ev :event}]
+                                            {:data (assoc data :token (second ev))})}}}
+    :done    {:final? true :output-key :token}
+    :failed  {:final? true :error? true :output-key :reason}}})  ;; ← error terminal
+
+;; Parent: :on-done (success → :data) AND :on-error (failure → transition).
+(rf/reg-machine :login
+  {:initial :idle
+   :data    {}
+   :states
+   {:idle {:on {:submit :authenticating}}
+
+    :authenticating
+    {:spawn {:machine-id :auth-flow
+              :on-done    (fn [{data :data result :result}] (assoc data :token result))
+              :on-error   {:target :error                    ;; ← sibling of :authenticating
+                           :action (fn [{data :data ev :event}]
+                                     ;; ev = [:rf.machine.spawn/error <invoke-id> <error>]
+                                     (assoc data :error (nth ev 2)))}}}
+
+    :error {:on {:retry :authenticating}}}})
+```
+
+**Two failure triggers** (both route to the same `:on-error` transition):
+
+1. **The child reaches a designated error `:final?` leaf** (`:error? true`). The error payload is the child's `:data` slot named by that leaf's `:output-key` (or `nil`). The child auto-destroys (it reached `:final?`), then the failure routes to the parent.
+2. **An uncaught child action exception** (`:rf.error/machine-action-exception`). The exception envelope (`{:rf.error/id :machine-id :action-id :event :exception-message :exception-data :reason}`) is the error payload. (This was *observability-only* before rf2-5hlsh — the action-exception trace fired but nothing drove a parent transition.)
+
+**The mechanism — a dispatch into the parent.** The failure is delivered as the reserved event `[<parent-id> [:rf.machine.spawn/error <invoke-id> <error>]]` dispatched into the parent (a **separate** actor with its own handler / snapshot — so a *dispatch*, symmetric with how the spawn fx dispatches `:start` into the newborn child, not the in-machine `[:raise …]` the compound/parallel `done.state` uses). The parent's macrostep resolves it natively: `:rf.machine.spawn/error` routes to the active `:spawn`-bearing state's `:on-error`, firing the transition with full engine semantics — entry/exit cascade, `:always` / `:raise` drain, traces, and the parent's own finalize. The error payload rides on the transition's `:event` (`(nth ev 2)`), so a guard / action can branch on it.
+
+**Two resolution arms** (priority order — symmetric with the compound `done.state` resolution):
+
+1. **`:on-error` on the parent's `:spawn` map** — the headline spelling above.
+2. **An enclosing explicit `:on {:rf.machine.spawn/error {:guard … :target …}}`** — the lower-level escape hatch. When no `:spawn :on-error` is declared (or its candidates all guard-fail), the dispatched event walks the active path leaf→root (then the root `:on`) like any event, so an ancestor can handle `:rf.machine.spawn/error` directly. A guard reads the invoke-id / error off `:event` to disambiguate which spawn failed.
+
+**`:on-error` is additive — the escape hatch is preserved.** Declaring `:on-error` does NOT replace the lower-level forms. The `:rf.machine/done` / `:rf.error/machine-action-exception` traces STILL fire (observability is unchanged). And the explicit dispatch-back-to-parent — a child action emitting `[:fx [[:dispatch [parent-id [:failed err]]]]]` and the parent declaring `:on {:failed :error}` — keeps working. `:on-error` is the *declarative invoke-site* control-flow form; the explicit dispatch is the *lower-level* form. Choose `:on-error` for the canonical XState-shaped failure routing; reach for the explicit dispatch when the child needs to send a richer, app-shaped failure event the parent's normal `:on` table handles.
+
+**Success vs failure are mutually exclusive per finish.** A child reaching a **plain** `:final?` leaf fires `:on-done` (success → `:data` callback). A child reaching an `:error?` `:final?` leaf fires `:on-error` (failure → transition) and SKIPS `:on-done`. A child throwing fires `:on-error`. (`:on-done` and `:on-error` may both be declared on one `:spawn` map — the runtime picks the right one by how the child finished.)
 
 ### The done-state signal
 
@@ -2772,6 +2832,7 @@ The two `:on-done` hooks are **distinct and complementary**: a node's **own `:on
 - **A `:final?` leaf's meaning depends on its DEPTH (the embedded-vs-top-level rule).** A `:final?` leaf that is a **direct child of the machine root** is **whole-machine finality** (singleton auto-destroy per D7, or the spawning parent's `:spawn :on-done`). A `:final?` leaf **embedded inside a compound** instead raises a transitionable in-machine `done.state.<compound>` — the enclosing `:on-done` advances the outer flow **and the machine keeps running**. So to model "a *sub-flow* completes, then the outer flow continues *in the same machine*" you mark the sub-flow's terminal leaf `:final?` and declare `:on-done` on the enclosing compound — the natural XState `onDone` shape. (The pre-rf2-zlmz7 hand-rolled `:raise`-from-`:entry` substitute is withdrawn — it was a footgun precisely because it required *avoiding* `:final?`.) See [§The done-state signal](#the-done-state-signal) and [§Embedded vs top-level](#embedded-vs-top-level--the-d7-reconciliation).
 - **No `:on`, `:always`, `:after`, `:spawn`, `:spawn-all` on a `:final?` state.** Final means final — no further transitions. `make-machine-handler` rejects these combinations at registration with `:rf.error/machine-final-state-has-transitions`. `:entry` and `:exit` actions ARE permitted (the final-state's `:entry` runs as part of the entering cascade; `:exit` runs from the auto-destroy teardown).
 - **`:output-key` requires `:final?`.** A non-final state declaring `:output-key` is a registration error (`:rf.error/machine-output-key-without-final`). On a final state, `:output-key` is optional — when absent, the `result` passed to `:on-done` is `nil`.
+- **`:error?` requires `:final?`.** A `:final?` leaf MAY declare `:error? true` to mark it an **error terminal** (XState v5's error final) — a child finishing via it routes to the spawning parent's `:spawn :on-error` transition (see [§`:on-error`](#on-error--child-failure-control-flow)) instead of `:on-done`. `:error?` on a non-final state is a registration error (`:rf.error/machine-error-flag-without-final`, symmetric with `:output-key`). An error leaf MAY also carry `:output-key` (to carry the error payload) and `:entry` / `:exit`.
 - **Parallel regions and `:final?`.** A leaf inside one region of a parallel-region machine may declare `:final? true`; the meaning is "**this region** has reached its final state." That region halts (no further transitions accepted for it; sibling regions continue). The parent machine as a whole is done only when EVERY region's active state is `:final?` — at which point the parallel root's `:on-done` fires if declared (the transitionable parallel completion signal — the machine keeps running, per [§The done-state signal](#the-done-state-signal)), else the whole-machine auto-destroy / spawning-parent `:on-done` cascade fires (D7). A **compound region** reaching its own `:final?` child raises a region-local `done.state.<region-compound>` its region-local `:on-done` takes — exactly the compound case, scoped to that region (re-broadcast through the parent's one internal-event queue).
 
 ### Composition with `:entry` / `:exit`
@@ -2782,7 +2843,7 @@ A final state's `:entry` action runs as part of the entering cascade (before the
 
 Synchronous ordering (per D4):
 
-1. `:rf.machine/done` — emitted with `:machine-id` (the finishing actor), `:output` (the value read at `:output-key`, or `nil`), `:parent-id` (the parent's registration id, or `nil` for singletons).
+1. `:rf.machine/done` — emitted with `:machine-id` (the finishing actor), `:output` (the value read at `:output-key`, or `nil`), `:parent-id` (the parent's registration id, or `nil` for singletons), `:error?` (`true` when the actor finished via an `:error?` `:final?` leaf — see [§`:on-error`](#on-error--child-failure-control-flow); `false` otherwise). The done trace fires for EVERY finish — `:on-error` is additive and does not suppress it.
 2. `:rf.machine/destroyed` — enriched with `:reason :rf.machine/finished` (the discriminator that distinguishes "the actor finished naturally" from "the parent cascade destroyed it").
 3. `:rf.machine/system-id-released` — when the actor was `:system-id`-bound. Fires AFTER `:on-done` ran (so `:on-done` could still look up the binding).
 
@@ -2792,9 +2853,10 @@ Existing observers that filter `:rf.machine/destroyed` on `:tags` see the new `:
 
 - [§The done-state signal](#the-done-state-signal) — the transitionable compound / parallel `:on-done` (`done.state.<id>`), distinct from the whole-machine finality above.
 - [§Embedded vs top-level](#embedded-vs-top-level--the-d7-reconciliation) — how the `:final?` leaf's depth selects compound-done-signal vs whole-machine teardown.
-- [§Spec-spec keys](#spec-spec-keys) — `:on-done` is listed alongside `:on-spawn` on the parent's `:spawn` map.
-- [§Deliberate omissions vs xstate](#deliberate-omissions-vs-xstate) — the `onDone` row now records that re-frame2 DOES ship final-state-with-on-done AND first-class compound / parallel `done.state`.
-- [Spec-Schemas §`:rf/state-node`](Spec-Schemas.md#rftransition-table) — schema for `:final?`, `:output-key`, and the `:on-done` node key.
+- [§`:on-error`](#on-error--child-failure-control-flow) — the symmetric child-FAILURE control-flow hook (`:spawn :on-error` transition; `:error?` error terminal), distinct from the `:data`-only success notification `:on-done`.
+- [§Spec-spec keys](#spec-spec-keys) — `:on-done` and `:on-error` are listed alongside `:on-spawn` on the parent's `:spawn` map.
+- [§Deliberate omissions vs xstate](#deliberate-omissions-vs-xstate) — the `onDone` row now records that re-frame2 DOES ship final-state-with-on-done AND first-class compound / parallel `done.state`; the `onError` row records that `:spawn :on-error` ships first-class (control flow, not observability-only).
+- [Spec-Schemas §`:rf/state-node`](Spec-Schemas.md#rftransition-table) — schema for `:final?`, `:output-key`, `:error?`, and the `:on-done` / `:on-error` node keys.
 - [Spec 009 §`:op-type` vocabulary](009-Instrumentation.md#op-type-vocabulary) — `:rf.machine/done` registration (the actor-finality trace; the in-machine `[:rf.machine/done <path>]` raise rides the standard `:raise` queue, not a separate trace family).
 - Conformance fixtures: `final-state-singleton-auto-destroys.edn`, `final-state-child-fires-on-done.edn`.
 - [§Destroy is silent-idempotent](#destroy-is-silent-idempotent) — D4's auto-destroy is followed at most ONCE by an observable `:rf.machine/destroyed` trace; subsequent explicit `[:rf.machine/destroy <id>]` calls on the same finished actor are silent no-ops (aligned with XState convention).
@@ -3825,9 +3887,9 @@ Convergences: machines-as-actors, run-to-completion, encapsulated state, snapsho
 
 ### Deliberate name divergence — `:spawn` (NOT `:invoke`)
 
-re-frame2's declarative child-actor key is **`:spawn`**, not xstate's `:invoke`. This is a deliberate divergence on the single most semantically-loaded machine surface. The convergence of names (`:final?`, `:on-done`, `:guard`, `:action`, `:entry`, `:exit`, `:after`, `:always`, `:tags`, `:type :parallel`, `:regions`, `:system-id`) is high enough that AI agents trained on the xstate corpus would otherwise generate almost-correct code that misses re-frame2's per-feature spec nuances. Renaming the spawn-on-entry / destroy-on-exit slot to `:spawn` breaks the convergence trap on the surface where the semantics diverge the most:
+re-frame2's declarative child-actor key is **`:spawn`**, not xstate's `:invoke`. This is a deliberate divergence on the single most semantically-loaded machine surface. The convergence of names (`:final?`, `:on-done`, `:on-error`, `:guard`, `:action`, `:entry`, `:exit`, `:after`, `:always`, `:tags`, `:type :parallel`, `:regions`, `:system-id`) is high enough that AI agents trained on the xstate corpus would otherwise generate almost-correct code that misses re-frame2's per-feature spec nuances. Renaming the spawn-on-entry / destroy-on-exit slot to `:spawn` breaks the convergence trap on the surface where the semantics diverge the most:
 
-- re-frame2 has no `:onError` sibling — failure flows through the framework's `:rf.error/*` machinery + `:on-child-error` (on `:spawn-all`).
+- re-frame2 ships `:on-error` as a first-class `:spawn` sibling — a **transition** the parent takes when the spawned child fails (XState v5 `invoke onError` parity; see [§`:on-error`](#on-error--child-failure-control-flow)). The `:rf.error/*` machinery + the `:on-child-error` join hook (on `:spawn-all`) remain; `:on-error` is the single-child declarative control-flow form.
 - re-frame2 has no `:onSnapshot` — the snapshot lives in `app-db` and is read by subscribing to `:rf/machine`.
 - re-frame2 has no per-actor mailbox — events route through the per-frame queue.
 - re-frame2's `:spawn` IS state-bound (destroyed on exit) by construction; xstate's `:invoke` shares the property but the surface invites the assumption that other lifetime patterns are also supported (they aren't in v1).


### PR DESCRIPTION
## What

Adds a first-class **`:on-error`** beside the existing `:on-done` on the parent's `:spawn` map — re-frame2's spelling of **XState v5 `invoke onError`**: a **transition** (control flow) the parent takes when a `:spawn`-spawned child **fails**, not merely an observable error envelope. Mike-ruled 2026-06-04 (rf2-5hlsh).

## Two failure triggers (both route to the same declarative `:on-error` transition)

1. **Child reaches a designated error `:final?` leaf** (`:error? true`) — the error payload (the leaf's `:output-key` slot) rides into the `:on-error` transition's `:event`. Fired from `lifecycle_fx/finalize`.
2. **Uncaught child action exception** (`:rf.error/machine-action-exception`) — the exception envelope rides into the `:event`. This was **observability-only** before; now it drives a parent transition. Fired from `lifecycle_fx/registration`'s action-failure projection.

## Mechanism — symmetric with `:spawn :on-done`

The parent is a **separate actor** with its own handler/snapshot, so the failure is **dispatched** into the parent as the reserved event `[<parent-id> [:rf.machine.spawn/error <invoke-id> <error>]]` (symmetric with how the spawn fx dispatches `:start` into the newborn child). The parent's macrostep resolves it natively via `transition/pick-spawn-error-transition`: the `:on-error` spec is resolved **at the `:spawn`-bearing state's own level** (a keyword target is a sibling — the natural "child failed → move the parent out of the spawning state"), firing with **full engine semantics** (entry/exit cascade, `:always`/`:raise` drain, traces, the parent's own finalize). Region-name prefix stripping mirrors `pick-after-transition` for parallel-region spawns.

## Additive — escape hatch preserved

`:on-error` does **not** replace the lower-level forms. The `:rf.machine/done` / `:rf.error/machine-action-exception` traces still fire (observability unchanged), and the explicit dispatch-back-to-parent (`[:fx [[:dispatch [parent-id [:failed err]]]]]`) keeps working. `:on-error` is the declarative invoke-site form; the explicit dispatch is the lower-level form. Success vs failure are mutually exclusive per finish: a plain `:final?` leaf fires `:on-done`; an `:error?` leaf (or a throw) fires `:on-error` and skips `:on-done`.

## Validation

- malformed `:spawn :on-error` → `:rf.error/machine-bad-on-error-clause`
- `:error?` on a non-final state → `:rf.error/machine-error-flag-without-final` (symmetric with `:output-key`)
- `:on-error` guard/action refs resolve at registration (like `:on-done`)

## Files

- `transition.cljc` — `spawn-error-event-id`, `pick-spawn-error-transition`, dispatch wiring
- `lifecycle_fx/finalize.cljc` — error-leaf trigger
- `lifecycle_fx/registration.cljc` — action-exception trigger
- `lifecycle_fx/spawn_error.cljc` (new leaf ns) — shared parent-resolution + dispatch
- `lifecycle_fx/validation.cljc` — `:on-error` shape + `:error?` placement
- `spec/005-StateMachines.md` — `:on-error` section + `:error?` terminal; deliberate-omissions `onError` row flipped to shipped-first-class
- `machines_on_error_cljs_test.cljc` (new) — 8 deftests / 20 assertions covering all six required cases (a–f)

## Gates (cold)

- `npm run test:cljs` — **5584 tests / 19432 assertions, 0 failures, 0 errors** (machines + SCXML-conformance + new `:on-error` tests)
- machines JVM — **459 tests / 1454 assertions, 0/0**
- `python scripts/check_doc_slugs.py` — clean
- `python -m mkdocs build --strict` — OK

## Follow-ups filed

- **rf2-7fb2s** — Spec-Schemas (hot-zone, not touched here) doc-completeness: `:error?` on `:rf/state-node`, `:on-error` on `InvokeSpec` (both maps already open — no runtime breakage)
- **rf2-r09fc** — pre-existing parallel-region declarative-`:spawn` keys its `:spawned` slot under `:rf/transition-pure` (breaks `:on-done` AND `:on-error` parent resolution for parallel-region spawns; the `:on-error` resolver's region-stripping is defensively correct for when that quirk is fixed)

Closes rf2-5hlsh.