### PR TITLE
fix(epoch): prune mount-attribution per-instance on unmount (rf2-bgapd)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -192,10 +192,24 @@
   updated record is re-fanned to epoch listeners so snapshot consumers
   (Xray's Views panel, which caches `epoch-history` at settle time) re-sync.
 
-  No-op when the frame has no settled epoch yet (an unmount before the first
-  cascade — e.g. a fixture teardown) or when the target epoch has been
-  evicted from the ring — `back-fill-unmount!` returns nil and we skip the
-  re-notify."
+  PRUNE-ON-UNMOUNT (rf2-bgapd): after the back-fill, evict the unmounting
+  instance's `mount-attribution` entry (the `:epoch-id` anchor + learned
+  `:deps` read-set keyed by this `render-key`). Each mount mints a FRESH
+  `instance-token` → a fresh render-key, so without per-instance eviction the
+  map accreted one permanent entry per ever-mounted instance, pruned ONLY on
+  whole-frame destroy — unbounded per-frame heap over a long churning session
+  (the time-travel scenario this surface serves). The eviction runs
+  UNCONDITIONALLY of whether the back-fill found a live epoch: the entry is
+  dead either way once the instance tears down (a fixture-teardown unmount with
+  no settled epoch still strands an entry otherwise). The render-key is read
+  from the same `:rf.view/render-key` tag the mount path uses
+  (`record-render!`); a late mount-burst tail arriving after the prune
+  harmlessly re-mints the entry.
+
+  No-op (for the back-fill leg) when the frame has no settled epoch yet (an
+  unmount before the first cascade — e.g. a fixture teardown) or when the
+  target epoch has been evicted from the ring — `back-fill-unmount!` returns
+  nil and we skip the re-notify."
   [frame-id event]
   (when interop/debug-enabled?
     (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
@@ -203,7 +217,13 @@
         ;; Re-fan the corrected record so snapshot consumers re-read the
         ;; ring. Same failure-isolated fan-out + no-loop contract as the
         ;; render / sub-run back-fill above.
-        (notify-listeners! updated)))))
+        (notify-listeners! updated)))
+    ;; rf2-bgapd — prune the unmounting instance's mount-attribution entry so
+    ;; the map stays bounded across instance churn (NOT retained until
+    ;; whole-frame destroy). Runs whether or not the back-fill found a live
+    ;; epoch — the entry is dead once the instance unmounts.
+    (state/drop-render-key-mount-attribution!
+      frame-id (-> event :tags :rf.view/render-key))))
 
 (defn on-frame-destroyed!
   "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -404,6 +404,34 @@
                (assoc-in m [frame-id render-key :epoch-id] epoch-id)))))
   nil)
 
+(defn drop-render-key-mount-attribution!
+  "Forget the mount-anchor + read-set for a SINGLE `render-key` in
+  `frame-id` (rf2-bgapd) — the per-instance eviction tied to a view
+  instance's UNMOUNT. Without it `mount-attribution` accreted one
+  permanent entry per ever-mounted instance (a fresh `instance-token`
+  per mount → a fresh render-key), pruned ONLY on whole-frame destroy:
+  unbounded per-frame heap growth over a long churning session (lists
+  with churning rows, modals, route-scoped components — exactly the
+  long-running time-travel scenario this surface exists to serve). The
+  per-instance peer of `drop-frame-mount-attribution!`'s whole-frame
+  wipe; called from `record-unmount!` after the trace back-fill.
+
+  Drops the now-empty frame map when this was the frame's last
+  render-key so a churned-then-idle frame leaves NO residual `{frame
+  {}}` shell. Idempotent: dropping an absent render-key is a no-op. A
+  late mount-burst tail render arriving AFTER the unmount (pathological
+  ordering) harmlessly re-mints the entry via `record-mount-epoch!` /
+  `record-render-deps!`."
+  [frame-id render-key]
+  (when (and frame-id render-key)
+    (swap! mount-attribution
+           (fn [m]
+             (let [pruned (update m frame-id dissoc render-key)]
+               (if (empty? (get pruned frame-id))
+                 (dissoc pruned frame-id)
+                 pruned)))))
+  nil)
+
 (defn drop-frame-mount-attribution!
   "Forget every render-key's mount-anchor + read-set for `frame-id`
   (frame teardown). Replaces the four-wiper pair

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -1214,6 +1214,117 @@
       (is (nil? (state/mount-epoch-for :test/dq2b7-b render-key))))))
 
 ;; ===========================================================================
+;; rf2-bgapd — mount-attribution is bounded across instance churn: a view
+;;             instance's entry is pruned on its per-instance UNMOUNT, not
+;;             retained until whole-frame destroy
+;; ===========================================================================
+;;
+;; THE LEAK (epoch senior-dev review, rf2-bgapd): the render-key is
+;; `[view-id instance-token]` and each MOUNT mints a fresh `instance-token`
+;; (a churning row / re-opened modal / route-scoped component remounts under a
+;; NEW render-key every time). `mount-attribution` is keyed by that render-key
+;; and accumulated an entry (an `:epoch-id` anchor + a `:deps` sub-id set) on
+;; first sighting, removed ONLY by `drop-frame-mount-attribution!` (whole-frame
+;; destroy) — never on per-instance unmount. So for a live frame over a long
+;; churning session the map grew without bound — exactly the long-running
+;; time-travel scenario the epoch surface exists to serve.
+;;
+;; THE FIX: `record-unmount!` now calls `drop-render-key-mount-attribution!`
+;; after the trace back-fill, evicting the unmounting instance's entry.
+
+(deftest drop-render-key-mount-attribution-prunes-single-instance
+  (testing "rf2-bgapd — `drop-render-key-mount-attribution!` evicts ONE
+            render-key's entry (anchor + read-set) and leaves sibling
+            render-keys in the same frame untouched."
+    (let [frame :test/bgapd
+          rk-a  [:row-view 100]
+          rk-b  [:row-view 101]]
+      (state/record-mount-epoch! frame rk-a :epoch/a)
+      (state/record-render-deps! frame rk-a :sub/a)
+      (state/record-mount-epoch! frame rk-b :epoch/b)
+      (state/record-render-deps! frame rk-b :sub/b)
+
+      (state/drop-render-key-mount-attribution! frame rk-a)
+      (is (nil? (state/mount-epoch-for frame rk-a))
+          "instance A's anchor evicted")
+      (is (nil? (state/render-deps-for frame rk-a))
+          "instance A's read-set evicted")
+      (is (= :epoch/b (state/mount-epoch-for frame rk-b))
+          "sibling instance B's anchor survives — eviction is per-render-key")
+      (is (= #{:sub/b} (state/render-deps-for frame rk-b))
+          "sibling instance B's read-set survives")
+
+      ;; Idempotent: dropping an already-absent / never-seen render-key is a
+      ;; no-op, never a throw (a late tail / double-unmount must be harmless).
+      (state/drop-render-key-mount-attribution! frame rk-a)
+      (state/drop-render-key-mount-attribution! frame [:never-mounted 0])
+      (is (= :epoch/b (state/mount-epoch-for frame rk-b))
+          "idempotent prune left the surviving entry intact"))))
+
+(deftest unmount-prunes-mount-attribution-bounded-across-churn
+  (testing "rf2-bgapd — THE leak guard. Mount N instances (each a fresh
+            instance-token → fresh render-key), settle a cascade so the live
+            frame is real, then UNMOUNT every instance. The frame's
+            `mount-attribution` must NOT retain the unmounted instances'
+            entries — it shrinks back toward empty (bounded), NOT retained
+            until whole-frame destroy. Pre-fix every ever-mounted instance
+            left a permanent entry; the map grew without bound across churn."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed       (fn [_ _] {:rows (vec (range 5))}))
+    (rf/reg-event-db :drop-rows  (fn [db _] (assoc db :rows [])))
+
+    ;; A real settled cascade so the frame has a last-settled epoch the
+    ;; unmount back-fill can land in (the live-frame path, not just the
+    ;; direct-state unit above).
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+
+    ;; Mount N row instances — each a DISTINCT instance-token (the churn that
+    ;; mints a fresh render-key per mount). Each learns an anchor + a read-set
+    ;; the way a real mount does (post-settle render + in-render deref).
+    (let [n            8
+          render-keys  (mapv (fn [i] [:row-view i]) (range n))]
+      (doseq [rk render-keys]
+        (emit-render! :test/main rk)
+        (emit-mount-sub-run! :test/main :rows rk nil [0 1 2 3 4]))
+
+      ;; Every instance now carries a mount-attribution entry.
+      (doseq [rk render-keys]
+        (is (some? (state/mount-epoch-for :test/main rk))
+            (str "instance " rk " has a mount anchor before unmount"))
+        (is (some? (state/render-deps-for :test/main rk))
+            (str "instance " rk " has a learned read-set before unmount")))
+
+      ;; The cascade that removes all rows settles; then (React-teardown
+      ;; timing) every instance's unmount fires post-settle.
+      (rf/dispatch-sync [:drop-rows] {:frame :test/main})
+      (doseq [rk render-keys]
+        (emit-unmount! :test/main rk))
+
+      ;; THE assertion: none of the unmounted instances' entries are retained.
+      ;; mount-attribution is BOUNDED across churn — pruned per-instance on
+      ;; unmount, not held until frame-destroy.
+      (doseq [rk render-keys]
+        (is (nil? (state/mount-epoch-for :test/main rk))
+            (str "instance " rk "'s anchor pruned on unmount — not retained"))
+        (is (nil? (state/render-deps-for :test/main rk))
+            (str "instance " rk "'s read-set pruned on unmount — not retained")))
+
+      ;; And the unmount is STILL observable in its causing cascade's
+      ;; :trace-events — the rf2-59hx3 back-fill is preserved alongside the
+      ;; rf2-bgapd prune (the prune evicts the attribution map, NOT the
+      ;; recorded trace).
+      (let [drop-epoch (last-epoch :test/main)]
+        (is (= :drop-rows (:event-id drop-epoch)))
+        (is (= (set render-keys)
+               (->> (:trace-events drop-epoch)
+                    (filter #(= :rf.view/unmounted (:operation %)))
+                    (map #(-> % :tags :rf.view/render-key))
+                    set))
+            "every instance's unmount is back-filled into the drop-rows
+             cascade's :trace-events (rf2-59hx3 preserved) even though its
+             attribution entry was pruned (rf2-bgapd)")))))
+
+;; ===========================================================================
 ;; INVARIANT 8 — a view UNMOUNT is back-filled into its CAUSING cascade's
 ;;                :trace-events, not silently dropped (rf2-59hx3)
 ;; ===========================================================================


### PR DESCRIPTION
## What

Closes **rf2-bgapd** (P2 RISK / memory, epoch senior-dev review).

`mount-attribution` (`{frame-id {render-key {:epoch-id E :deps #{sub-id…}}}}`) accreted **one permanent entry per ever-mounted view instance**. The render-key is `[view-id instance-token]` and every mount mints a **fresh** `instance-token`, so a churning frame — lists with churning rows, re-opened modals, route-scoped components — accumulated an entry per instance. The only eviction was `drop-frame-mount-attribution!` (whole-frame destroy); nothing pruned on **per-instance unmount**. Result: unbounded per-frame heap over a long churning session — exactly the long-running time-travel scenario the epoch surface exists to serve.

## Fix

- **`state.cljc`** — new `drop-render-key-mount-attribution!`: dissocs `[frame-id render-key]` and drops the now-empty `{frame {}}` shell when it was the frame's last render-key. Idempotent (absent render-key = no-op).
- **`listeners.cljc`** — `record-unmount!` calls it after the trace back-fill, reading the render-key from the same `:rf.view/render-key` tag the mount path (`record-render!`) uses. Runs **unconditionally** of whether the back-fill found a live epoch (the entry is dead once the instance tears down; a fixture-teardown unmount with no settled epoch would otherwise strand an entry). A late mount-burst tail arriving after the prune harmlessly re-mints the entry.

## Preserved

- **rf2-59hx3** unmount trace back-fill — the prune evicts the attribution map, NOT the recorded `:trace-events` (asserted in the churn test).
- **#2929** ring-buffer no-SubVector-retention and **rf2-fxowr** stranded-child harvest region — untouched (disjoint regions of `state.cljc`).
- RTC semantics — unchanged (the prune is a post-settle teardown action, same shape as the existing back-fill).

## Tests (`epoch_attribution_test.clj`)

- `drop-render-key-mount-attribution-prunes-single-instance` — per-render-key eviction; sibling render-key untouched; idempotent on absent/double-unmount.
- `unmount-prunes-mount-attribution-bounded-across-churn` — the leak guard: mount 8 distinct-token instances, settle a cascade, unmount all, assert `mount-attribution` retains **none** while every unmount still rides the causing cascade's `:trace-events`.

Verified the churn guard **fails** when the prune call is removed (negative check), then restored.

## Gates (cold worktree)

- epoch JVM `clojure -M:test`: 251 tests / 947 assertions — 0 failures, 0 errors.
- `npm run test:cljs`: 5572 tests / 19406 assertions — 0 failures, 0 errors.