### PR TITLE
docs(machines)+test: pin :after same-tick tie-break as deliberate XState divergence (rf2-3kvdb)

### DIFF
--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -129,6 +129,83 @@
         (is (= :warn (:state (snapshot :a/multi)))
             "stale 30s firing does not transition")))))
 
+;; ---- same-tick tie-break: first-fired advances epoch, slower drops stale --
+;;
+;; rf2-3kvdb — xstate-parity STEP-ALGORITHM slice (determinism of
+;; simultaneously-enabled transitions).
+;;
+;; XState v5 / SCXML §3.13 resolve simultaneously-enabled transitions by
+;; DOCUMENT ORDER (earlier-listed wins). re-frame2 DELIBERATELY diverges
+;; here (per Spec 005 §Multiple :after per state): `:after` timers are real
+;; HOST-CLOCK deferred events, not entries in a synchronous in-engine queue,
+;; so there is no cross-timer arbitration. The `:after` map is keyed by
+;; delay, so two entries with the SAME delay are impossible (map keys
+;; dedupe). The only race is two entries with DIFFERENT delays whose host
+;; callbacks land in the SAME scheduler tick — each fires as a SEPARATE
+;; synthetic timer-elapsed event. The observable contract is
+;; first-fired-wins, the rest drop stale: the first event to dequeue drives
+;; the transition, the exit advances the per-path epoch, and every other
+;; same-tick timer's event then carries a now-stale epoch and drops
+;; (:rf.machine.timer/stale-after). No double-transition.
+;;
+;; This test PINS that contract (NO engine change — the behaviour already
+;; holds; we prove the deliberate non-guarantee externally). Two timers at
+;; DIFFERENT delays (5000 + 30000) are scheduled at one entry (same epoch);
+;; we capture that epoch, then dispatch BOTH synthetic events back-to-back
+;; — the in-test analogue of two host callbacks landing in the same tick.
+;; The 5000ms event (modelled as the first to dequeue) wins; the 30000ms
+;; event arrives carrying the pre-transition epoch and drops as stale.
+
+(deftest after-same-tick-first-fired-wins-slower-drops-stale
+  (testing "two :after timers (DIFFERENT delays) whose callbacks land in the
+            same tick: first-fired advances the epoch + transitions; the
+            slower one drops stale — no double-transition (rf2-3kvdb)"
+    (let [m {:initial :idle
+             :data    {}
+             :states
+             {:idle    {:on {:fetch :loading}}
+              :loading {:after {5000  :warn
+                                30000 :timeout}
+                        :on    {:loaded :ready}}
+              :warn    {}        ;; terminal — proves NO further transition
+              :timeout {}
+              :ready   {}}}
+          traces (atom [])]
+      (rf/reg-machine :a/tiebreak m)
+      (rf/register-listener! ::tb (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:a/tiebreak [:fetch]])
+      (is (= :loading (:state (snapshot :a/tiebreak))))
+      ;; Both timers were scheduled at THIS entry's epoch — the same-tick
+      ;; precondition: neither has fired yet, so both carry `epoch`.
+      (let [epoch (get-in (snapshot :a/tiebreak) [:data :rf/after-epoch [:loading]])]
+        (is (= 1 epoch) "both timers carry the entry epoch (none fired yet)")
+        ;; First host callback to dequeue (the 5000ms deadline) — fires,
+        ;; transitions :loading → :warn, and the exit advances the epoch.
+        (rf/dispatch-sync [:a/tiebreak [:rf.machine.timer/after-elapsed 5000 epoch [:loading]]])
+        (is (= :warn (:state (snapshot :a/tiebreak)))
+            "first-fired timer wins → :warn")
+        (is (not= epoch
+                  (get-in (snapshot :a/tiebreak) [:data :rf/after-epoch [:loading]]))
+            "the winning transition advanced the [:loading] per-path epoch")
+        (is (some #(and (= :rf.machine.timer/fired (:operation %))
+                        (true?  (:fired? (:tags %)))
+                        (= 5000 (:delay (:tags %))))
+                  @traces)
+            "first timer emits :fired? true")
+        ;; The slower 30000ms callback lands in the SAME tick but dequeues
+        ;; AFTER the transition. It carries the pre-transition `epoch`, which
+        ;; no longer matches — it MUST drop stale, NOT drive a second
+        ;; transition into :timeout.
+        (reset! traces [])
+        (rf/dispatch-sync [:a/tiebreak [:rf.machine.timer/after-elapsed 30000 epoch [:loading]]])
+        (is (= :warn (:state (snapshot :a/tiebreak)))
+            "slower same-tick timer drops stale — NO double-transition to :timeout")
+        (is (some #(and (= :rf.machine.timer/stale-after (:operation %))
+                        (= 30000 (:delay (:tags %))))
+                  @traces)
+            "the slower timer emits :stale-after (deliberate non-guarantee, pinned)"))
+      (rf/unregister-listener! ::tb))))
+
 ;; ---- :guard suppresses one :after; siblings continue ---------------------
 
 (deftest after-guard-suppresses-one-siblings-continue

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -2037,7 +2037,13 @@ Per [§Entry/exit cascading along the LCA](#entryexit-cascading-along-the-lca), 
 
 ### Multiple `:after` per state
 
-All entries in an `:after` map run **independently**. Whichever timer fires first (and matches its `:guard`) triggers its transition; the resulting state exit advances the epoch and the remaining timers all go stale. Order between simultaneously-firing timers is implementation-defined — authors should not rely on tie-break behaviour for two timers with the same delay.
+All entries in an `:after` map run **independently**. Whichever timer fires first (and matches its `:guard`) triggers its transition; the resulting state exit advances the epoch and the remaining timers all go stale.
+
+**Tie-break — the same-tick case (deliberate substrate divergence).** The `:after` map is keyed by delay, so two entries with the *same* delay are impossible — the map keys dedupe. The only race is **two entries with _different_ delays whose host-clock callbacks land in the same scheduler tick** (the same JS macrotask, or the same JVM scheduler quantum). When that happens each fired timer is a **separate** synthetic timer-elapsed event ([§Epoch-based stale detection](#epoch-based-stale-detection)) dispatched independently; the order they reach the router is the **host scheduler's** order, not a machine-document order. There is no cross-timer arbitration step.
+
+The observable outcome is **first-fired-wins, the rest drop stale**: the first synthetic event to dequeue at the parent's handler drives the transition, the state exit advances the scheduling node's per-path epoch, and every other same-tick timer's event then carries a now-stale epoch and silently drops (`:rf.machine.timer/stale-after`). No double-transition occurs.
+
+This is a **deliberate divergence** from the XState v5 / SCXML *document-order conflict resolution* rule (SCXML §3.13: simultaneously-enabled transitions resolve deterministically by document order — earlier-listed wins). The re-frame2 substrate reason: `:after` timers are real **host-clock deferred events**, not entries in a synchronous in-engine queue, so a strict document-order tie-break would require the runtime to **batch** separately-arriving host-clock callbacks into a synthetic same-tick arbitration step. That machinery fights the re-frame runtime model (each timer is its own epoch-bearing deferred event) for a marginal case whose observable outcome — *first valid timer to arrive wins; the transition makes the rest stale* — is already the correct FSM semantic. Authors must therefore **not** rely on a document-order tie-break between two same-tick `:after` timers; the deadline that elapses first (as the host clock reports it) is the one that fires.
 
 ```clojure
 :loading


### PR DESCRIPTION
**Bead:** rf2-3kvdb (P3) — xstate-parity STEP-ALGORITHM slice. Mike-ruled 2026-06-04: **DOC/TEST ONLY, no engine change.** Completes the machines XState-parity chain.

## What & why

The `:after` map is keyed by delay, so two entries with the *same* delay are impossible (map keys dedupe). The spec's tie-break sentence framed the non-guarantee around that impossible case. The **real** race is two entries with **different** delays whose host-clock callbacks land in the same scheduler tick.

re-frame2 **deliberately diverges** from the XState v5 / SCXML §3.13 *document-order conflict resolution* rule. Substrate reason: `:after` timers are real **host-clock deferred events**, not entries in a synchronous in-engine queue — a strict document-order tie-break would require batching separately-arriving host callbacks into a synthetic same-tick arbitration step, which fights the runtime model. The observable outcome — *first valid timer to arrive wins; the transition makes the rest stale* — is already the correct FSM semantic.

## Changes

- **`spec/005-StateMachines.md` §Multiple `:after` per state** — replace the "same delay" framing with the real "different delays, same host tick" case; name the divergence as deliberate; cite SCXML §3.13 / XState v5 document-order as what we differ from + the substrate reason.
- **`implementation/machines/test/re_frame/after_test.clj`** — add `after-same-tick-first-fired-wins-slower-drops-stale`: two `:after` timers (5000 + 30000) scheduled at one entry (same epoch); the 5000 ms event (first to dequeue) advances the per-path epoch + transitions to `:warn`; the 30000 ms event, carrying the pre-transition epoch, drops as `:rf.machine.timer/stale-after` with **no** double-transition into `:timeout`. Pins the deliberate non-guarantee externally.

**No engine source change** — `git diff` is spec + test only.

## Gates (cold worktree)

- machines JVM suite: 460 tests / 1461 assertions — 0 failures, 0 errors
- `npm run test:cljs`: 5580 tests / 19426 assertions — 0 failures, 0 errors
- `python scripts/check_doc_slugs.py --verbose`: 0 broken links (393 files)
- `mkdocs build --strict`: built ok