### PR TITLE
fix(xray/spine): apply self-noise filter inside db->cascades (rf2-qlvq8)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -57,6 +57,7 @@
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.panels.common-helpers :as common]
+            [day8.re-frame2-xray.self-noise :as self-noise]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 ;; ---- pure helpers --------------------------------------------------------
@@ -708,10 +709,23 @@
   Public so cross-panel spine-shim events (e.g. `:rf.xray/select-
   dispatch-id`, relocated from event_detail.cljs to registry.cljs in
   rf2-5gl5r) can reuse the same projection when they need head-id
-  (rf2-xzzih)."
+  (rf2-xzzih).
+
+  Applies the `self-noise/xray-internal-cascade?` filter (rf2-qlvq8) so
+  this event-side walk matches the reactive `:rf.xray/cascades` sub
+  (registry.cljs) and the first-mount seed (mount.cljs), both of which
+  already strip Xray-internal cascades. Without it, the head-id / step /
+  focus / machine-inspector walks could resolve a target to an
+  `:rf.xray/*` cascade dispatched WITHOUT a `{:frame :rf/xray}` option
+  (palette quick-actions, headless helpers) that landed on `:rf/default`
+  and slipped past the ingest gate — a cascade the user never sees in
+  the L2 list. This is the single projection helper every spine event
+  handler shares, so filtering here keeps the event side and the view
+  side reading the same set."
   [db]
   (let [buffer (or (get db :trace-buffer) (trace-collector/snapshot-from-rings))]
-    (projection/group-cascades buffer)))
+    (into [] (remove self-noise/xray-internal-cascade?)
+          (projection/group-cascades buffer))))
 
 (defn- db->epoch-history
   "Read the Xray app-db's `:epoch-history` slot — the per-frame

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -571,6 +571,70 @@
     (is (= :live (:mode r)))))
 
 ;; -------------------------------------------------------------------------
+;; (8b) Self-noise filter agreement (rf2-qlvq8)
+;; -------------------------------------------------------------------------
+;;
+;; The event-side `spine/db->cascades` walk (head-id / step / focus
+;; resolution + the machine-inspector scrubber) MUST return the same
+;; filtered set as the reactive `:rf.xray/cascades` sub. Both strip
+;; Xray-internal cascades via `self-noise/xray-internal-cascade?`. The
+;; case the filter exists for: an `:rf.xray/*` event dispatched WITHOUT
+;; a `{:frame :rf/xray}` option lands on `:rf/default` and slips past
+;; the ingest gate, surfacing as a cascade in the raw projection. Before
+;; rf2-qlvq8 the sub stripped it but `db->cascades` did not, so j/k
+;; stepping / click-on-head LIVE detection / composed focus could
+;; resolve a target the user never sees in L2.
+
+(defn- seed-mixed-cascades!
+  "Seed the trace buffer with two cascades on `:rf/default`: a normal
+  host event (`:order/submit`) and a frameless `:rf.xray/*` event
+  (`:rf.xray/select-tab`) that landed on the host frame. The xray-
+  internal one is the projection head (last) — exactly the position
+  that would mis-resolve head-id if it survived the event-side walk."
+  []
+  (let [events [{:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                 :tags {:rf.trace/dispatch-id :c-host
+                        :frame :rf/default
+                        :rf.event/v [:order/submit]}}
+                {:id 2 :op-type :rf.event :operation :rf.event/dispatched
+                 :tags {:rf.trace/dispatch-id :c-xray
+                        :frame :rf/default
+                        :rf.event/v [:rf.xray/select-tab]}}]]
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/sync-trace-buffer (vec events)]))))
+
+(deftest db->cascades-strips-xray-internal-cascade
+  (testing "rf2-qlvq8 — db->cascades applies the self-noise filter so the
+            frameless :rf.xray/* cascade on :rf/default is absent from the
+            event-side walk"
+    (setup-xray-frame!)
+    (seed-mixed-cascades!)
+    (let [db        @(frame/app-db-container :rf/xray)
+          cascades  (spine/db->cascades db)
+          ids       (mapv :dispatch-id cascades)]
+      (is (= [:c-host] ids)
+          ":c-xray (an :rf.xray/* cascade) stripped from db->cascades")
+      (is (= :c-host (spine/head-dispatch-id cascades))
+          "head-id resolves to the host cascade, not the xray-internal one")
+      (is (= :c-host (spine/focusable-head-id cascades))
+          "focusable-head-id ignores the xray-internal cascade"))))
+
+(deftest db->cascades-agrees-with-reactive-cascades-sub
+  (testing "rf2-qlvq8 — the event-side walk and the reactive sub return the
+            SAME filtered set for the frameless :rf.xray/*-on-:rf/default
+            case the filter handles"
+    (setup-xray-frame!)
+    (seed-mixed-cascades!)
+    (let [db          @(frame/app-db-container :rf/xray)
+          event-side  (spine/db->cascades db)
+          reactive    (rf/with-frame :rf/xray
+                        @(rf/subscribe [:rf.xray/cascades]))]
+      (is (= event-side reactive)
+          "db->cascades and :rf.xray/cascades agree")
+      (is (= [:c-host] (mapv :dispatch-id reactive))
+          "both omit the xray-internal cascade — sanity that the filter fired"))))
+
+;; -------------------------------------------------------------------------
 ;; (9) Live auto-follow head (rf2-s0s5x Phase A)
 ;; -------------------------------------------------------------------------
 ;;


### PR DESCRIPTION
@
## What

`spine/db->cascades` — the event-handler cascade walk used for head-id / step / focus resolution and by the machine-inspector scrubber — omitted the `(remove self-noise/xray-internal-cascade?)` filter that the reactive `:rf.xray/cascades` sub (`registry.cljs:413-417`) and the first-mount seed (`mount.cljs:486-488`) both apply.

## Why it bit

An `:rf.xray/*` event dispatched WITHOUT a `{:frame :rf/xray}` option (palette quick-actions, headless helpers) chain-resolves onto `:rf/default`, slips past the ingest gate, and surfaces as a cascade in the raw projection. The reactive L2 list stripped it; the event-side walk did not — so j/k stepping, click-on-head LIVE detection and the composed focus could resolve a head/step target to a cascade the user never sees in L2. The two sides could disagree under exactly the case the filter was added (rf2-g1pt8) to handle.

## Fix

Apply the filter inside `db->cascades` (`spine.cljs`) — the single projection helper every spine event handler + the machine-inspector share — so the event side and the view side read the same filtered set. Minimal, single-site edit; the reactive sub keeps its own identical filter (it composes off `:rf.xray/trace-buffer`, not the db), so both now apply the exact same `(remove self-noise/xray-internal-cascade?)`.

## Tests

`spine_cljs_test.cljs` section 8b (rf2-qlvq8):
- `db->cascades-strips-xray-internal-cascade` — frameless `:rf.xray/select-tab` on `:rf/default` is absent from `db->cascades`; `head-dispatch-id` / `focusable-head-id` resolve to the host cascade.
- `db->cascades-agrees-with-reactive-cascades-sub` — `db->cascades` returns the SAME filtered vector as `@(subscribe [:rf.xray/cascades])` for the frameless-`:rf.xray/*`-on-`:rf/default` case.

## Spec

Spec unchanged. `tools/xray/spec/013-Trace-Consumer.md` already prescribes the spine as a downstream consumer of the filtered projection ("Every downstream consumer reads from this projection; the L2 event list, the spine, ..."); this aligns the implementation to the existing contract.

## Gates (cold, in worktree)

- `npm run test:cljs` — 5574 tests / 19411 assertions, 0 failures.
- xray `clojure -M:test` — 1100 tests / 4526 assertions, 0 failures.
- `npm run test:xray-feature-gate` — 16 scenarios over 13 matrix rows, 0 failures.
- `test:browser` skipped — no render/hiccup path changed; the feature gate is the targeted browser coverage and is green.

Closes rf2-qlvq8.
@