### PR TITLE
fix(adapters): wire reagent-slim warned-keyword-prop into clear-warn-once chain (rf2-qy6cl)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -13,6 +13,7 @@
             [reagent2.ratom            :as ratom]
             [reagent2.dom.client       :as rdc]
             [reagent2.impl.batching    :as batching]
+            [reagent2.impl.template    :as template]
             [re-frame.substrate.spine   :as spine]
             [re-frame.views            :as views]))
 
@@ -139,3 +140,19 @@
                 :dispose!          ratom/dispose!
                 :reactive?         ratom/reactive?
                 :after-render      r/after-render}}))
+
+;; ---- warn-once cache reset wiring (rf2-qy6cl) -----------------------------
+;;
+;; The slim hiccup interpreter carries a second warn-once cache beyond the
+;; spine's source-coord/non-DOM-root one: `reagent2.impl.template`'s
+;; `warned-keyword-prop` defonce (the §7.2 D2 keyword-on-non-HTML-prop
+;; notice). The source-coord cache is already chained into
+;; `:adapter/clear-warn-once-caches!` by `make-ratom-adapter` (rf2-4edk);
+;; the keyword-prop cache was left behind. Chain its clear-step here too —
+;; via the same `spine/install-clear-warn-once-step!` helper — so
+;; `make-reset-runtime-fixture` re-arms BOTH slim caches between tests and
+;; a sibling test cannot silently swallow a later same-pair warning. This
+;; lives in the adapter ns (not in reagent2.impl.template) to keep the
+;; vendored `reagent2.*` tree free of any `re-frame.*` edge — bundle
+;; isolation by construction.
+(spine/install-clear-warn-once-step! template/clear-warned-keyword-prop!)

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -248,6 +248,23 @@
 (defonce ^:private ^{:doc "[k v-name] → true once warned."}
   warned-keyword-prop (atom #{}))
 
+(defn clear-warned-keyword-prop!
+  "Reset the keyword-prop warn-once cache to empty; returns nil.
+
+  The user-facing contract is `warn once per [k name-of-v] pair` for the
+  process lifetime, so this cache is a `defonce`. Tests, however, must
+  re-arm it between cases — otherwise a sibling test that already warned
+  for a given pair silently swallows a later test's same-pair warning
+  (the rf2-4edk test-isolation hazard, applied here per rf2-qy6cl). The
+  reagent-slim adapter ns wires this into the chained
+  `:adapter/clear-warn-once-caches!` late-bind hook (via
+  `spine/install-clear-warn-once-step!`) so `make-reset-runtime-fixture`
+  clears it alongside every other adapter's warn-once cache. Reset-only;
+  no production behaviour changes (the hook is a test-fixture surface)."
+  []
+  (reset! warned-keyword-prop #{})
+  nil)
+
 (defn- warn-once-keyword-prop! [k v]
   (let [key [(name k) (name v)]]
     (when-not (contains? @warned-keyword-prop key)

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_keyword_prop_warn_once_clear_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_keyword_prop_warn_once_clear_cljs_test.cljs
@@ -1,0 +1,104 @@
+(ns reagent2.impl.template-keyword-prop-warn-once-clear-cljs-test
+  "Re-arm coverage for the slim hiccup interpreter's keyword-prop warn-once
+  cache (rf2-qy6cl).
+
+  `reagent2.impl.template` carries a process-wide `defonce` warn-once cache
+  (`warned-keyword-prop`) backing the §7.2 D2 informational notice: a
+  keyword value on a non-HTML-attribute prop passes through unchanged AND
+  fires a one-shot console.warn keyed on `[k name-of-v]`. The user-facing
+  contract is `warn once per pair for the process lifetime`; tests, though,
+  must RE-ARM the cache between cases or a sibling test that already warned
+  for a pair silently swallows a later test's same-pair warning.
+
+  This is the same test-isolation hazard rf2-4edk fixed for the spine's
+  source-coord / non-DOM-root warn-cache. The fix (rf2-qy6cl) chains the
+  keyword-prop cache's clear-step into the SAME
+  `:adapter/clear-warn-once-caches!` late-bind hook — via
+  `spine/install-clear-warn-once-step!`, registered at slim-adapter
+  ns-load. Requiring `re-frame.adapter.reagent-slim` here runs that
+  registration.
+
+  This file proves the re-arm end-to-end: a keyword-prop warning fires,
+  the chained clear hook runs, and the SAME pair warns AGAIN (not
+  swallowed). Mirrors the chained-clear assertion in
+  `re-frame.adapter.react-shared-suite/assert-chained-clear-warn-once-empties-cache`.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            ;; load-bearing: requiring the slim adapter runs the
+            ;; `spine/install-clear-warn-once-step!` registration that wires
+            ;; template/clear-warned-keyword-prop! into the chained hook.
+            [re-frame.adapter.reagent-slim]
+            [re-frame.late-bind :as late-bind]
+            [reagent2.impl.template :as template]))
+
+(defn- with-warn-spy
+  "Run `f` with js/console.warn redirected to record invocations onto an
+  internal vector; return that vector of joined arg-strings. Restores the
+  original on exit, even if `f` throws."
+  [f]
+  (let [calls (atom [])
+        orig  (.-warn js/console)]
+    (try
+      (set! (.-warn js/console)
+            (fn [& args] (swap! calls conj (apply str args))))
+      (f)
+      @calls
+      (finally
+        (set! (.-warn js/console) orig)))))
+
+;; ---------------------------------------------------------------------------
+;; Chained hook re-arms the keyword-prop cache (the rf2-qy6cl fix)
+;; ---------------------------------------------------------------------------
+
+(deftest chained-clear-warn-once-re-arms-keyword-prop-cache
+  (testing "After a keyword-prop warning fires for a pair, the chained
+            :adapter/clear-warn-once-caches! hook re-arms the cache so the
+            SAME pair warns AGAIN — it is no longer silently swallowed
+            (rf2-qy6cl; the rf2-4edk hazard applied to the slim template's
+            keyword-prop cache)."
+    (let [k :rf2-rearm-test-k
+          v :rf2-rearm-test-v
+          phase-1 (with-warn-spy
+                    (fn []
+                      ;; warn-once: three calls, one warning within the phase
+                      (template/convert-prop-value k v)
+                      (template/convert-prop-value k v)
+                      (template/convert-prop-value k v)))]
+      (is (= 1 (count phase-1))
+          (str "phase-1 sanity: warn fires exactly once within a phase; got "
+               (count phase-1) ": " (pr-str phase-1)))
+      (let [chained-hook (late-bind/get-fn :adapter/clear-warn-once-caches!)]
+        (is (some? chained-hook)
+            "precondition: the chained :adapter/clear-warn-once-caches! hook is registered")
+        (chained-hook)
+        (let [phase-2 (with-warn-spy (fn [] (template/convert-prop-value k v)))]
+          (is (= 1 (count phase-2))
+              (str "phase-2 MUST re-emit the warning for the SAME pair AFTER "
+                   "the chained :adapter/clear-warn-once-caches! hook fires "
+                   "(this is the rf2-qy6cl fix; before it the warning was "
+                   "swallowed). Got " (count phase-2) ": " (pr-str phase-2))))))))
+
+;; ---------------------------------------------------------------------------
+;; The direct clear-fn seam the chained hook invokes
+;; ---------------------------------------------------------------------------
+
+(deftest clear-warned-keyword-prop-re-arms-directly
+  (testing "Calling template/clear-warned-keyword-prop! directly also
+            re-arms the cache — the seam the chained hook invokes. Returns
+            nil (the make-clear-warned-fn shape)."
+    (let [k :rf2-rearm-direct-k
+          v :rf2-rearm-direct-v
+          phase-1 (with-warn-spy
+                    (fn []
+                      (template/convert-prop-value k v)
+                      (template/convert-prop-value k v)))]
+      (is (= 1 (count phase-1))
+          (str "phase-1 sanity: warn-once within a phase; got "
+               (count phase-1) ": " (pr-str phase-1)))
+      (is (nil? (template/clear-warned-keyword-prop!))
+          "clear-warned-keyword-prop! returns nil")
+      (let [phase-2 (with-warn-spy (fn [] (template/convert-prop-value k v)))]
+        (is (= 1 (count phase-2))
+            (str "phase-2 re-warns the SAME pair after the direct clear; got "
+                 (count phase-2) ": " (pr-str phase-2)))))))


### PR DESCRIPTION
## Bead
rf2-qy6cl (P3 BUG/RISK — TEST-GAP), from adapters senior-dev review rf2-8q96k.

## Problem
`reagent2.impl.template/warned-keyword-prop` is a process-wide `defonce` warn-once cache (the §7.2 D2 keyword-on-non-HTML-prop notice) that was **not** wired into the chained `:adapter/clear-warn-once-caches!` reset hook. Across tests (or any long session), a warning for a given `[k name-of-v]` pair is swallowed after the first occurrence and never re-armed. The existing template tests only sidestepped this by hand-picking unique pairs per case — a fragile invariant.

This is the **same class** of bug rf2-4edk (PR #347) already fixed for the spine's source-coord / non-DOM-root warn-cache; the keyword-prop cache was left behind.

## Fix (mirrors the 4edk pattern)
- **`template.cljs`** — expose public `clear-warned-keyword-prop!` next to the cache. Pure reagent2, reset-only, returns nil — the `make-clear-warned-fn` / `clear-warned-non-dom-roots!` shape.
- **`re_frame/adapter/reagent_slim.cljs`** — chain it via `spine/install-clear-warn-once-step!` at ns-load (the exact helper that already wires the source-coord clear at spine.cljs:1607). Registration lives in the adapter ns, **not** in the vendored `reagent2.*` tree, so bundle isolation is preserved by construction.

## Test
New `template_keyword_prop_warn_once_clear_cljs_test.cljs` with two assertions:
1. **chained-hook re-arm** — fire a warning, invoke the top of the `:adapter/clear-warn-once-caches!` chain, assert the SAME pair warns AGAIN. Mirrors `react-shared-suite/assert-chained-clear-warn-once-empties-cache`.
2. **direct-seam re-arm** — `clear-warned-keyword-prop!` resets directly and returns nil.

**Verified load-bearing**: temporarily disabling the chain registration fails the chained-hook test with the exact swallowed-warning symptom (`Got 0: []`), then restored.

## Gates (cold, from `implementation/`)
- `npm run test:cljs` — **GREEN** (5582 tests / 19432 assertions, 0 failures, 0 errors)
- `npm run test:reagent-slim:bundle-isolation` — **PASS** (3 contracts, 19 sentinel checks; no stock-Reagent leak)

## Sequencing note
s6j16 (P4 README) + uuzkp (P4 act-resolver cross-ref) are HELD on this slice and should sequence **after** this PR merges.