### PR TITLE
fix(machines-viz): region-scope sibling node-ids + project :on-done completion (rf2-wnzha + rf2-41goo)

### DIFF
--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -190,7 +190,7 @@ must tell."
 | **Source-coord stamping** (Spec 001) | Every state, transition, guard, and action carries a source-coord chip — click jumps to the registration. |
 | **`reg-machine` definition as data** | The whole chart layout is a function of the transition table; no reflection, no instrumented build. |
 | **Compound states + parallel regions** | Nested compound states render with recursive active-child highlighting; parallel regions render as side-by-side panes. |
-| **Final states with `:on-done`** | `:final?` nodes render with a doubled border; entering one fires the `:on-done` edge highlight before the auto-destroy. |
+| **Final states + `:on-done` completion** | `:final?` leaves render with a quiet doubled border (UML final-state ring). A compound / parallel-root `:on-done` (XState `onDone`) projects the **completion transition** — a `✓ done` edge advancing the outer flow to the compound's sibling, or a terminal completion affordance for the action-only parallel-root form (rf2-41goo). Distinct from the doubled-border final marker; an EMBEDDED `:final?` leaf signals compound-done and the machine **keeps running** (Spec 005 §The done-state signal), so the completion edge is NOT tied to auto-destroy. |
 
 ## Where it lives in the stack
 

--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -95,7 +95,13 @@ itself"). **Delayed** transitions are labelled `after` + interval;
 **eventless** transitions are labelled `always`
 ([editor-states-and-transitions](https://stately.ai/docs/editor-states-and-transitions)).
 Hierarchical transitions resolve along the LCA (entry/exit cascade) —
-xstate/SCXML semantics.
+xstate/SCXML semantics. **`onDone`** — XState draws the compound /
+parallel **completion** transition (the arrow a compound's done-state
+takes to advance the outer flow; SCXML §3.7's `done.state.<id>`); Stately
+Studio renders it as the "do these sub-flows, then continue" arrow off
+the compound. re-frame2 ships it first-class as `:on-done` (Spec 005
+§The done-state signal) — **projected by rf2-41goo** (see §2 transition
+scoping + §3.1 G9).
 
 ### 1.4 Initial / final / history
 
@@ -192,7 +198,7 @@ parse (`chart/layout.cljc`) + pure projection (`chart/projection.cljc`)
 | **Parallel regions — structure** | ✅ **Every** region renders as a synthetic `:region?` compound node with a **distinct dashed boundary per region** (palette rotation) + `∥` glyph + region label; states carry `:region` + `:parent-id`; edges stay region-local. | `layout.cljc` `parse-parallel`/`region-node-id`; `projection.cljc` (`type "parallel-region"`); `nodes/parallel_region_node.cljs`. |
 | **Parallel regions — active highlight** | ✅ **Closed (rf2-yoe6e / rf2-g2svr).** `highlight-ids` resolves the whole snapshot `:state` — flat keyword, compound path, **or region-map** `{region path}` — to the **set** of active-leaf node-ids; `xyflow-graph` threads `:highlight-ids` and marks **every** active leaf, so a parallel snapshot's **N simultaneously-active leaves** all light up at once. A nested region value resolves to its deepest leaf. | `layout.cljc` `highlight-ids`; `projection.cljc` `xyflow-graph` (`:highlight-ids` set). |
 | **Parallel regions — active CONTAINER chrome** | ✅ **Closed (rf2-80rm2 / G4).** The region (and, for self-consistency, the compound) **container** reads as active when ANY descendant leaf is active — the projector folds the container into `:active` by walking each active leaf UP its `:parent-id` chain (reusing the G1 active set; no duplicate highlight logic). `parallel-region-node` / `compound-node` then paint active chrome (solid emphasised boundary + the `:info` active-token glow ring, the same affordance state nodes use), so an active region reads as active at the zone level, not just the leaf inside it. **Palette delegated to Figma.** | `projection.cljc` `xyflow-graph` (`active-container-ids` parent-id walk); `nodes/parallel_region_node.cljs`; `nodes.cljs` `compound-node`. |
-| **Transition scoping** | ✅ `:on`, `:after`, `:always`, machine-level (top-level `:on`) fallback, external + internal self-transitions, vector-of-candidates forks. **Machine-level fallback projects ONCE** (rf2-vcnvj): a top-level `:on` is sourced from a synthetic MACHINE-ROOT node into its target as a SINGLE chip — not one back-edge per leaf (the pre-vcnvj per-state expansion repeated the chip AND injected N back-edges that scrambled ELK's top-to-bottom ranking). Self-loops render as a small loop (not a degenerate bezier); internal self-transitions render dashed + no arrowhead. | `layout.cljc` `collect-state-edges`, `collect-machine-edges` (root-sourced), `machine-root-id`, `resolve-target-path`; `projection.cljc` (`machine-root` node type); `nodes.cljs` `machine-root-node`; `edges.cljs` (self-loop path, internal dash). |
+| **Transition scoping** | ✅ `:on`, `:after`, `:always`, machine-level (top-level `:on`) fallback, **`:on-done` (XState `onDone`) compound / parallel completion** (rf2-41goo), external + internal self-transitions, vector-of-candidates forks. **Machine-level fallback projects ONCE** (rf2-vcnvj): a top-level `:on` is sourced from a synthetic MACHINE-ROOT node into its target as a SINGLE chip — not one back-edge per leaf (the pre-vcnvj per-state expansion repeated the chip AND injected N back-edges that scrambled ELK's top-to-bottom ranking). **`:on-done` (rf2-41goo)**: a COMPOUND's `:on-done` projects a completion edge from the compound to its SIBLING target (resolved at the compound's own level), an `✓ done` chip distinct from an ordinary event arrow; a PARALLEL-ROOT's `:on-done` (action/fx-only — registration rejects a `:target`) renders as a TERMINAL completion affordance (a hanging done chip, no sibling segment). Self-loops render as a small loop (not a degenerate bezier); internal self-transitions render dashed + no arrowhead. | `layout.cljc` `collect-state-edges`, `on-done-edges`, `collect-machine-edges` (root-sourced), `machine-root-id`, `resolve-target-path`; `projection.cljc` (`machine-root` node type, `:onDone` / `:doneState` event-node data); `nodes.cljs` `machine-root-node`; `edges.cljs` (self-loop path, internal dash). |
 | **Initial** | ✅ Filled-dot `initial-marker` node + unlabelled entry edge into the initial state, at **every** compound level (xstate/SCXML semantics). | `nodes.cljs` `initial-marker`; `projection.cljc` (marker-nodes + entry-edges); `layout.cljc` `collect-nodes` (per-level `:initial?`). |
 | **Final** | ✅ Quiet doubled border (outer ring 1px proud) on `state-node`. **No glyph** — the prior `✓` check glyph is DROPPED (rf2-az6e2, §1.4); the doubled border is the unambiguous final-state signal. | `nodes.cljs` `state-node` (final ring; no glyph). |
 | **History** | 🪝 **Render-hook only (rf2-az6e2, §1.4) — NOT yet emitted.** The `history-marker` renderer (shallow `H` / deep `H*`) is registered in the node-types map, but `chart.layout/parse-definition` emits **no** history pseudo-state node today (the parsed node shape carries no history data), so the projector never produces one. First-class `:history` is NOT shipped; the hook is shaped to the grammar awaiting parsed history topology (and Spec 005 history semantics). | `nodes.cljs` `history-marker` (registered hook); `layout.cljc` (no history emission). |
@@ -220,9 +226,16 @@ is now regression-guarded by test. The three **compound-endpoint
 rendering gaps** surfaced post-rf2-xh1lm are now also **closed**
 (rf2-shv82): compound-endpoint edges no longer silently drop (G6
 below), multi-self-loop labels fan to distinct perimeter slots (G7),
-cross-hierarchy labels anchor at the source-side bend point (G8).
+cross-hierarchy labels anchor at the source-side bend point (G8). The
+**`:on-done` (XState `onDone`) completion-transition** projection gap
+(G9) — `:on-done` was NEVER projected in chart / mermaid / scxml
+(pre-rf2-41goo the "COMPLETE" claim overstated parity; §1.3's onDone read
+was unmet) — is now **closed** (rf2-41goo): a compound's `:on-done`
+projects the sibling completion edge, a parallel-root's renders a terminal
+completion affordance, and the SCXML emitter round-trips the W3C
+`done.state.<id>` transition.
 **The machine-topology parity roadmap is COMPLETE (G1 / G2 / G3 / G4 /
-G5 / G6 / G7 / G8 all ✅).** Visual-readability follow-on (rf2-j10sm)
+G5 / G6 / G7 / G8 / G9 all ✅).** Visual-readability follow-on (rf2-j10sm)
 shipped padded label backgrounds (Phase 1, D). Its Phase 2, B
 multi-event collapse (N transitions sharing a `[source target]` pair →
 ONE arrow with N stacked labels via `:siblingIndex` / `:siblingCount`)
@@ -270,6 +283,7 @@ new), and the parity-bar row it serves.
 | **G6** | ✅ **CLOSED (rf2-shv82).** Was: any edge whose source or target was a compound (a parent-level transition like `:active → :disconnected`, a compound self-loop, an inbound `:failed → :active`) was SILENTLY DROPPED from the DOM. The projector emitted it, ELK routed it, but xyflow's `getHandleBounds` returned null for the compound (no `<Handle>` children) → `isNodeInitialized` returned false → `getEdgePosition` returned null → the edge never reached the DOM. No warning. The 5-layer probe trace in the bead proved 4 such edges survived to ELK's output then 0 in the DOM. Now: `compound-node` + `parallel-region-node` render invisible source + target `<Handle>` elements on all four sides; xyflow accepts the compound as an edge endpoint and ELK's routed bend-points anchor on its BORDER the way xstate/Stately Studio paints parent-level transitions. The chart root surfaces `data-edge-count-projected` alongside `data-edge-count` so the parser → projector → DOM parity is regression-guarded end to end. | **High** | §1.3, §1.7 | **impl:** rf2-shv82 ✅ |
 | **G7** | ✅ **CLOSED (rf2-shv82) → SUPERSEDED by events-as-nodes (rf2-qo5xy), collapse RETIRED (rf2-o6vh7).** Was: N self-loops on the same node (e.g. testdeck `:disconnected` carries 3: `:ws/arm-fail`, `:ws/disarm-fail`, `:ws/clear`) all rendered at the same loop anchor → garbled glyph soup. rf2-shv82 shipped a perimeter fan (8 slots, rotated per `:loopIndex`); rf2-j10sm Phase 2 then collapsed same-`[source target]` events into ONE arc + N stacked labels via `:siblingIndex` / `:siblingCount`. **The rf2-qo5xy events-as-nodes paradigm supersedes both**: each self-event is its own `rf2-event` node (`state → event-node → state`), so N self-loops are N DISTINCT event-nodes — no fan, no collapse, no garbled overlap. rf2-o6vh7 RETIRED the dead collapse machinery (`:siblingIndex` / `:siblingCount` and `data-sibling-*` are gone); the fan geometry survives only in `chart.edges/edge-path` for direct callers (every self-loop carries `:loopIndex 0`). | **Medium** | §1.3, §1.9 | **fan:** rf2-shv82 ✅ · **collapse:** rf2-j10sm (retired rf2-o6vh7) |
 | **G8** | ✅ **CLOSED (rf2-shv82).** Was: a cross-hierarchy edge (source and target in different parent containers — e.g. testdeck `:active.authenticating → :failed`) routed via ELK's bend-points had a midpoint that landed far from its visual origin (the label sat at the canvas bottom-left). Now: the projector flags the edge `:crossHierarchy true` when the source's `:parent-id` ≠ the target's (self-loops are never cross-hierarchy regardless of nesting); `chart.edges/edge-path` anchors the label NEAR the source-side first bend point (xstate/Stately convention — the label hugs the bend just outside the container the edge exits, with a small back-bias along the incoming segment so it sits in the routed channel). Degenerate two-point routes fall back to the segment midpoint; the bezier-fallback path is unchanged. Surfaces `data-cross-hierarchy` on each transition edge label. | **Medium** | §1.5, §1.9 | **impl:** rf2-shv82 ✅ |
+| **G9** | ✅ **CLOSED (rf2-41goo).** Was: Spec 005's first-class `:on-done` (XState `onDone` — the COMPOUND / PARALLEL completion transition that advances the outer flow when a sub-flow reaches its `:final?` child; SCXML §3.7 `done.state.<id>`) was **NEVER projected** — zero matches for `on-done` / `onDone` / `done.state` across `chart/layout.cljc`, `mermaid.cljc`, AND `scxml.cljc`. So the chart drew the `:final?` leaf but NOT the "then advance to sibling" arrow that actually fires; the SCXML round-trip was silently lossy for `onDone`; the "COMPLETE" headline overstated parity (§1.3's onDone read was unmet). Now: `layout.cljc/on-done-edges` parses a node's `:on-done`, `collect-state-edges` emits a COMPOUND's completion edge to its SIBLING (resolved at the compound's own level — XState onDone placement) flagged `:on-done?` + carrying the `:done-path`; `parse-parallel` emits the PARALLEL-ROOT's `:on-done` (action/fx-only — registration rejects a `:target`) as a TERMINAL completion affordance (self-anchored, `:internal?`) on a synthetic parallel-root node. `projection.cljc` buckets it as the `:on-done` event-variant and threads `:onDone` + the `done.state.<id>` `:doneState` label onto the event-node; the engine-raised `:rf.machine/done` is NOT click-to-send. `mermaid.cljc` renders the compound sibling edge (`✓ done`) + a parallel-root completion `note`; `scxml.cljc` emits + round-trips the W3C `<transition event="done.state.<id>">` (compound to sibling; parallel inside `<parallel>`). | **Medium** | §1.3, §1.5 | **impl:** rf2-41goo ✅ |
 
 ### 3.2 Deliberate non-parity divergences (intentional, NOT gaps)
 
@@ -492,6 +506,25 @@ together in rf2-shv82.
 |---|---|---|---|---|
 | E1 | **rf2-shv82** ✅ — `fix(machines-viz): compound-endpoint edges + self-loop label fan + cross-hierarchy label placement` | existing | isolated (`chart/nodes.cljs`, `chart/nodes/parallel_region_node.cljs`, `chart/projection.cljc`, `chart/edges.cljs`, `chart.cljs`, + JVM/CLJS/DOM tests + this doc + `API.md`) | **Closes G6 / G7 / G8.** Three independent fixes around one investigation context: (G6) container nodes carry invisible `<Handle>`s so compound-endpoint edges survive xyflow's `getEdgePosition` (which previously returned null for unhandled compounds and silently dropped the edge); (G7) self-loops fan to distinct perimeter slots per source via a `:loopIndex` ordinal; (G8) cross-hierarchy edge labels anchor at the source-side bend point rather than the routed midpoint. End-to-end parity gate `data-edge-count == data-edge-count-projected` is now pinned on every machine. |
 
+### Phase F — `:on-done` completion projection (the senior-dev faithfulness pass)
+
+A 2026-06-04 senior-dev review (rf2-60whl) surfaced two definition→visual
+faithfulness gaps; the `:on-done` projection gap was the parity-relevant
+one (the sibling region-id collision rf2-wnzha is a parse-injectivity
+fix, not a parity row).
+
+| Step | Bead | New? | Hot-zone | Notes |
+|---|---|---|---|---|
+| F1 | **rf2-41goo** ✅ — `feat(machines-viz): project :on-done (XState onDone) completion transition (chart + mermaid + scxml)` | existing | isolated (`chart/layout.cljc`, `chart/projection.cljc`, `mermaid.cljc`, `scxml.cljc`, + JVM tests + this doc) | **Closes G9.** `:on-done` was never parsed/projected (zero matches across the three emitters). Now: the COMPOUND completion edge resolves to the SIBLING (`✓ done` chip); the PARALLEL-ROOT completion (action/fx-only) renders as a terminal affordance / mermaid note; the SCXML emitter round-trips the W3C `done.state.<id>` transition. Parses + projects faithfully to the engine's `[:rf.machine/done <path>]` raise. |
+
+> **Sibling note (rf2-wnzha — same review pass, NOT a parity row):**
+> parallel regions sharing a state NAME minted COLLIDING node-ids (the
+> Spec 005 `:ingest` shape — three regions each with a `:done`). The fix
+> region-SCOPES every region-state node-id (`layout.cljc/region-scoped-id`)
+> so the parse is injective across regions + the G1 multi-active highlight
+> attributes per-region. A correctness/injectivity fix beneath the parity
+> bar, not a new gap row.
+
 ### Proposed NEW beads (for the mayor to file)
 
 1. **N1 — `feat(machines-viz): parallel-region ACTIVE chrome`**
@@ -510,12 +543,14 @@ together in rf2-shv82.
    (`chart/edges-cljs-test`: nested/parallel ⇒ switch present, flat ⇒
    absent, G2 routing keys pinned). Isolated (`chart.cljs` + test).
 
-> **Parity verdict after Phases A–C + N1/N2:** `MachineChart` reaches
+> **Parity verdict after Phases A–F (incl. G9):** `MachineChart` reaches
 > **full topology parity** with Stately Studio on all nine concerns
-> except the three **intentional divergences** (no code↔diagram sync,
-> trace-driven not sandbox sim, no history pseudo-states) — and remains
-> **above** the bar on the re-frame2-native overlays (`:after` rings,
-> microstep replay, `:spawn-all` join, cancellation cascade).
+> (transition scoping now includes the `:on-done` / XState `onDone`
+> completion transition — rf2-41goo / G9) except the three **intentional
+> divergences** (no code↔diagram sync, trace-driven not sandbox sim, no
+> history pseudo-states) — and remains **above** the bar on the
+> re-frame2-native overlays (`:after` rings, microstep replay,
+> `:spawn-all` join, cancellation cascade).
 
 ## See also
 

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -595,11 +595,13 @@ The resolution is pure and JVM-tested, in two layers:
     singleton holding the **deepest leaf** (`node-id` of the full path).
   - **region-map** (`{:data :loading :form :neutral}`) → the **set of N
     leaves**. Each region value is a keyword-or-path **relative to that
-    region's own state-tree**, resolved via `node-id` of the in-region
-    path (the parse keeps a region state's in-region node-id; it does
-    not region-prefix it). A **nested region value** (a region whose
-    value is itself a vector path) resolves to its **deepest leaf**,
-    exactly as the single-compound case does.
+    region's own state-tree**, resolved via `region-scoped-id` of the
+    region + the in-region path (rf2-wnzha — the parse REGION-SCOPES a
+    region state's node-id, prefixing it with the region container id, so
+    two regions sharing a state NAME mint DISTINCT ids; the resolver mints
+    the same scoped id). A **nested region value** (a region whose value
+    is itself a vector path) resolves to its **deepest leaf**, exactly as
+    the single-compound case does.
   - `nil` / anything else → the empty set.
 
   It **subsumes** the single-active `chart.layout/highlight-id` — for a

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -153,6 +153,51 @@
     (target-path? target)  (vec target)
     :else                  nil))
 
+(defn on-done-edges
+  "rf2-41goo — emit the completion edge(s) for a node's `:on-done`
+  (Spec 005 §The done-state signal — XState v5 `onDone`).
+
+  When a **compound** node reaches its `:final?` child the engine raises
+  `[:rf.machine/done <compound-path>]` into the macrostep's FIFO queue; the
+  enclosing `:on-done` TRANSITIONS the outer flow **while the machine keeps
+  running** (the canonical 'do these sub-flows, then continue' pattern).
+  `:on-done`'s value is an `:on`-shaped transition spec resolved **relative
+  to the compound's OWN level** — a keyword target is a SIBLING of the
+  compound (`resolve-target-path` with the compound's own path gives
+  `(conj (parent-path compound-path) target)` = sibling). So the edge reads
+  source=compound → target=sibling, carrying a distinct `:on-done? true`
+  flag + the reserved `:rf.machine/done` event so the renderer paints a
+  completion 'done' chip rather than an ordinary event arrow.
+
+  A candidate that omits `:target` (action/fx only — the parallel-root
+  shape, or a compound whose `:on-done` just runs an action) self-anchors
+  on the node and is flagged `:internal? true` so it renders as a TERMINAL
+  completion affordance (a hanging done chip, no outgoing segment) per the
+  Stately convention — the parallel root is root-only and registration
+  rejects a `:target` on it (`:rf.error/machine-parallel-on-done-target`),
+  so its `:on-done` is always action/fx-only.
+
+  `done-path` is the node-id-carrying path the engine raises (the
+  compound's own path / the parallel-root sentinel); it rides the edge as
+  `:done-path` so the SCXML emitter can mint `done.state.<id>` faithfully."
+  [done-path state-path on-done-spec]
+  (keep (fn [candidate]
+          (let [internal? (and (map? candidate)
+                               (not (contains? candidate :target)))
+                tp        (if internal?
+                            (vec state-path)
+                            (resolve-target-path state-path (:target candidate)))]
+            (when tp
+              (cond-> {:from      (vec state-path)
+                       :to        tp
+                       :event     :rf.machine/done
+                       :on-done?  true
+                       :done-path (vec done-path)
+                       :guard     (:guard candidate)
+                       :action    (:action candidate)}
+                internal? (assoc :internal? true)))))
+        (transition-candidates on-done-spec)))
+
 (defn- collect-state-edges
   "Walk a state node and return edge-maps for every statically-
   resolvable transition declared on it. Compound substates recurse.
@@ -161,7 +206,11 @@
   `:target :same-state` (external) resolves to the source path; a
   candidate that omits `:target` entirely (internal — runs only its
   `:action`) self-anchors and is flagged `:internal? true` so the
-  renderer can distinguish it (no exit/entry re-trigger)."
+  renderer can distinguish it (no exit/entry re-trigger).
+
+  rf2-41goo — a compound node's `:on-done` (XState `onDone`) emits the
+  completion edge (sibling target, or a terminal affordance for the
+  action-only form) via `on-done-edges`."
   [state-path state-node]
   (let [edges-from
         (concat
@@ -203,7 +252,12 @@
                        :always? true
                        :guard  (:guard candidate)
                        :action (:action candidate)}]))
-                 (transition-candidates (:always state-node))))
+                 (transition-candidates (:always state-node)))
+         ;; rf2-41goo — the compound / region-compound `:on-done`
+         ;; completion edge (XState `onDone`). The done node is THIS node
+         ;; (its path is the `done.state.<id>` the engine raises).
+         (when-let [od (:on-done state-node)]
+           (on-done-edges state-path state-path od)))
         nested
         (mapcat (fn [[child-id child-node]]
                   (collect-state-edges (conj state-path child-id) child-node))
@@ -331,6 +385,37 @@
            (escape-id-segment (name region-id)))
          (escape-id-segment (str region-id)))))
 
+(def ^:private parallel-root-segment
+  "rf2-41goo — the reserved path segment for the synthetic PARALLEL-ROOT
+  completion node a parallel machine's `:on-done` (XState `onDone`) hangs
+  off. Namespaced under `rf.machines-viz.layout` so it can never collide
+  with a real region-id. The node-id mints a stable, escape-injective
+  string; the `done.state` the engine raises for the whole parallel is the
+  root sentinel `[]`, distinct from this rendering anchor."
+  :rf.machines-viz.layout/parallel-root)
+
+(defn region-scoped-id
+  "rf2-wnzha — the region-SCOPED node-id for a state at `in-region-path`
+  inside the parallel region `region-id`. INJECTIVE ACROSS REGIONS: two
+  regions that share a state NAME (the canonical Spec 005 `:ingest`
+  shape, where every region carries its own `:done {:final? true}` leaf)
+  mint DISTINCT ids, so xyflow keeps both nodes (its `:id` keying drops
+  a duplicate) and the multi-active highlight (`highlight-ids`) attributes
+  each region's active leaf to its OWN node.
+
+  Composed as the region container id (`region-node-id`) + the `__`
+  path separator + the in-region `node-id`, e.g.
+  `region__fetch__done`. The prefix is the same `region__`-scoped id
+  the region's `:parent-id` already carries, so a region state's id reads
+  as 'this leaf, under this region container' — XState v5's orthogonal-
+  region-namespace semantics (each region is its own id namespace).
+  Injective because `region-node-id` is injective over region-ids and
+  `node-id` is injective over in-region paths, joined by the `__`
+  separator that `escape-id-segment` guarantees never appears INSIDE a
+  segment (a literal `_` encodes to `_5f`)."
+  [region-id in-region-path]
+  (str (region-node-id region-id) "__" (node-id in-region-path)))
+
 (defn event-segment
   "Render the leading event segment of an edge label per the
   xstate / Stately graph view convention.
@@ -350,9 +435,16 @@
                               convention: infinity glyph replaces the
                               prior `\"always\"` word so an eventless
                               transition reads as a continuation glyph
-                              against ordinary event-labelled arrows)"
-  [{:keys [event after always?]}]
+                              against ordinary event-labelled arrows)
+    - `:on-done` completion  → `\"✓ done\"` (rf2-41goo — XState `onDone`:
+                              a compound / parallel-root completion
+                              transition. A checkmark-done chip reads as
+                              the 'sub-flow finished, advance the outer
+                              flow' arrow Stately Studio renders, distinct
+                              from an ordinary event arrow)"
+  [{:keys [event after always? on-done?]}]
   (cond
+    on-done?         "✓ done"
     after            (str "⌚ " after "ms")
     always?          "∞"
     (= :* event)     "* (any)"
@@ -586,7 +678,24 @@
   so the chart projector can hand xyflow a `parentId`/sub-flow
   grouping (rf2-xh1lm — v12 reads `parentId`). Region order is
   preserved (regions are an ordered map in practice; we keep
-  insertion order via `:regions`)."
+  insertion order via `:regions`).
+
+  rf2-wnzha — every region-state node-id is REGION-SCOPED
+  (`region-scoped-id`): the in-region path is prefixed with the region
+  container's id, so two regions that share a state NAME mint DISTINCT
+  node-ids. Pre-fix, `parse-flat` kept each region's in-region node-id
+  verbatim (e.g. path `[:done]` → `\"done\"` in EVERY region), so the
+  canonical Spec 005 `:ingest` shape — three regions each carrying a
+  `:done {:final? true}` leaf — collided all three `:done` nodes into
+  ONE: xyflow's `:id` keying dropped two, and `highlight-ids`
+  mis-attributed the multi-active (G1) highlight across regions (lighting
+  region A's `:done` also lit B's + C's). Re-keying every node id, its
+  `:parent-id`, AND every edge `:id`/`:source`/`:target` under the region
+  prefix makes the parse injective across regions. The in-region `:path`
+  is preserved verbatim — it is the state's path WITHIN its region's
+  state-tree (the semantic identity the projector + `highlight-ids`
+  resolve against); only the xyflow-facing string ids are region-scoped.
+  XState v5 gold standard: regions are orthogonal id namespaces."
   [definition]
   (let [regions (:regions definition)
         per-region
@@ -594,15 +703,34 @@
           (fn [idx [region-id region-def]]
             (let [rid       (region-node-id region-id)
                   parsed    (parse-flat region-def)
-                  ;; Tag every state node with its region + parent so
-                  ;; the projector emits xyflow `parentId` grouping
-                  ;; (rf2-xh1lm — v12 reads `parentId`).
+                  ;; rf2-wnzha — region-scope every state node-id (so two
+                  ;; same-named region states never collide) and re-point
+                  ;; a nested-compound child's `:parent-id` to its
+                  ;; region-scoped parent id. A top-level region state's
+                  ;; `:parent-id` is the region container `rid`; a deeper
+                  ;; substate's parent is its OWN region-scoped parent.
                   tagged-nodes
                   (mapv (fn [n]
-                          (assoc n
-                            :region    region-id
-                            :parent-id rid))
+                          (let [path (:path n)]
+                            (assoc n
+                              :id        (region-scoped-id region-id path)
+                              :region    region-id
+                              :parent-id (if (> (count path) 1)
+                                           (region-scoped-id region-id (pop path))
+                                           rid))))
                         (:nodes parsed))
+                  ;; rf2-wnzha — re-key every edge's id/source/target under
+                  ;; the region prefix too (an edge to/from a shared-name
+                  ;; state would otherwise resolve to the colliding id
+                  ;; across regions). `:from-path`/`:to-path` stay the
+                  ;; in-region paths the ids derive from.
+                  scoped-edges
+                  (mapv (fn [e]
+                          (assoc e
+                            :id     (str (region-node-id region-id) "__" (:id e))
+                            :source (region-scoped-id region-id (:from-path e))
+                            :target (region-scoped-id region-id (:to-path e))))
+                        (:edges parsed))
                   ;; The synthetic region container node.
                   region-node
                   {:id        rid
@@ -614,10 +742,46 @@
                    :region-index idx
                    :compound? true}]
               {:nodes (into [region-node] tagged-nodes)
-               :edges (:edges parsed)}))
-          regions)]
-    {:nodes        (vec (mapcat :nodes per-region))
-     :edges        (vec (mapcat :edges per-region))
+               :edges scoped-edges}))
+          regions)
+        ;; rf2-41goo — the PARALLEL-ROOT `:on-done` (XState `onDone` on the
+        ;; parallel state). When EVERY region reaches its `:final?` leaf the
+        ;; parallel root's `:on-done` fires. A `:type :parallel` machine is
+        ;; root-only (no sibling flat state to land a `:target` on), so the
+        ;; parallel-root `:on-done` runs `:action` + `:fx` ONLY — registration
+        ;; rejects a `:target` (`:rf.error/machine-parallel-on-done-target`).
+        ;; So it ALWAYS renders as a TERMINAL completion affordance (a hanging
+        ;; done chip, no sibling segment) — `on-done-edges` self-anchors any
+        ;; target-less candidate (`:internal? true`) on the synthetic
+        ;; parallel-root node. `done-path` is the root sentinel `[]` (the
+        ;; whole-parallel `done.state` the engine signals).
+        root-on-done (:on-done definition)
+        root-od-edges
+        (when root-on-done
+          (->> (on-done-edges [] [parallel-root-segment] root-on-done)
+               (map-indexed
+                 (fn [i e]
+                   (let [base (edge-id (:to e) e)]
+                     (assoc e
+                       :parallel-root? true
+                       :id          (if (zero? i) base (str base "__" i))
+                       :source      (node-id (:from e))
+                       :target      (node-id (:to e))
+                       :from-path   (:from e)
+                       :to-path     (:to e)
+                       :event-label (edge-label e)))))
+               vec))
+        root-node (when (seq root-od-edges)
+                    {:id        (node-id [parallel-root-segment])
+                     :path      [parallel-root-segment]
+                     :label     "parallel"
+                     :depth     0
+                     :parallel-root? true
+                     :compound? false})]
+    {:nodes        (vec (concat (mapcat :nodes per-region)
+                                (when root-node [root-node])))
+     :edges        (vec (concat (mapcat :edges per-region)
+                                root-od-edges))
      :initial-path nil
      :parallel?    true}))
 
@@ -678,11 +842,13 @@
     simultaneously-active leaves. Each region's value is itself a
     keyword-or-path **relative to that region's own state-tree**, so it
     resolves the SAME way the parse mints region-state ids — via
-    `node-id` of the in-region path (parse-parallel does NOT region-
-    prefix a state's node-id; it tags `:region` + `:parent-id` but keeps
-    the in-region `node-id`). A nested region value (a region whose
-    value is itself a vector path) resolves to its DEEPEST leaf, exactly
-    as the single-compound case does. Returns the set of N leaf ids.
+    `region-scoped-id` of the REGION + the in-region path (rf2-wnzha:
+    parse-parallel region-scopes a state's node-id so two regions sharing
+    a state NAME mint DISTINCT ids; the resolver MUST mint the SAME scoped
+    id or the highlight would target a phantom). A nested region value (a
+    region whose value is itself a vector path) resolves to its DEEPEST
+    leaf, exactly as the single-compound case does. Returns the set of N
+    leaf ids.
 
   - **nil / anything else** — the empty set (no highlight).
 
@@ -695,10 +861,16 @@
     (keyword? state) #{(node-id [state])}
     (vector? state)  #{(node-id state)}
     (map? state)     (into #{}
-                           (keep (fn [[_region region-state]]
+                           ;; rf2-wnzha — region-scope each region's
+                           ;; active-leaf id (the region-map KEY is the
+                           ;; region-id) so it agrees with the node ids
+                           ;; `parse-parallel` minted; otherwise a
+                           ;; same-named leaf would mis-attribute across
+                           ;; regions (or resolve to a phantom).
+                           (keep (fn [[region region-state]]
                                    (cond
-                                     (keyword? region-state) (node-id [region-state])
-                                     (vector? region-state)  (node-id region-state)
+                                     (keyword? region-state) (region-scoped-id region [region-state])
+                                     (vector? region-state)  (region-scoped-id region region-state)
                                      :else                   nil)))
                            state)
     :else            #{}))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -101,12 +101,15 @@
 (defn event-variant
   "rf2-qo5xy — bucket a parsed edge by its event variant for the
   events-as-nodes paradigm: `:after` (clock glyph), `:always`
-  (infinity glyph), or `:on` (regular event keyword). Pure data → keyword."
+  (infinity glyph), `:on-done` (completion ✓ done chip — rf2-41goo, the
+  XState `onDone` compound/parallel completion transition), or `:on`
+  (regular event keyword). Pure data → keyword."
   [edge]
   (cond
-    (:after edge)   :after
-    (:always? edge) :always
-    :else           :on))
+    (:on-done? edge) :on-done
+    (:after edge)    :after
+    (:always? edge)  :always
+    :else            :on))
 
 (defn event-node-id
   "rf2-qo5xy — stable string id for an event-node. The xyflow node
@@ -839,8 +842,12 @@
                       internal?    (boolean (:internal? e))
                       ;; A `:*` wildcard `:on` arm is a real transition
                       ;; but NOT a fireable event (Spec 005 §Wildcard).
+                      ;; rf2-41goo — an `:on-done` completion edge carries
+                      ;; the reserved `:rf.machine/done` (an engine-RAISED
+                      ;; event, not user-fireable), so it is not click-to-send.
                       fireable?    (and (nil? (:after e))
                                         (not (:always? e))
+                                        (not (:on-done? e))
                                         (keyword? (:event e))
                                         (not= :* (:event e)))
                       event-id     (when fireable? (:event e))
@@ -921,6 +928,18 @@
                                        :fired       fired?
                                        :internal    internal?
                                        :machineLevel (boolean (:machine-level? edge))
+                                       ;; rf2-41goo — the XState `onDone`
+                                       ;; completion edge (compound/parallel
+                                       ;; done.state). `:onDone` is the
+                                       ;; renderer hook for the ✓ done chip;
+                                       ;; `:doneState` is the SCXML-style
+                                       ;; `done.state.<id>` label (the node-id
+                                       ;; of the done node's path) so a reader
+                                       ;; sees WHICH sub-flow completed.
+                                       :onDone      (boolean (:on-done? edge))
+                                       :doneState   (when (:on-done? edge)
+                                                      (str "done.state."
+                                                           (layout/node-id (:done-path edge))))
                                        :eventId     event-id
                                        :fromPath    (:from-path edge)
                                        :toPath      (:to-path edge)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -271,6 +271,28 @@
                 :label (edge-label "always" candidate)}]))
           (transition-candidates always)))
 
+(defn- collect-on-done-edges
+  "rf2-41goo — emit the compound / region-compound `:on-done` completion
+  edge (XState `onDone`). When a compound reaches its `:final?` child the
+  engine raises `done.state.<compound>`; the enclosing `:on-done`
+  transitions the outer flow. `:on-done` is resolved relative to the
+  compound's OWN level (a keyword target is a SIBLING — same level as
+  `source-path`), so we resolve against the source's PARENT — exactly the
+  ordinary keyword-target rule (`resolve-target-path` already conj's onto
+  the parent). The edge is labelled `✓ done` so it reads as the completion
+  transition, distinct from an ordinary event arrow. A target-less
+  `:on-done` (action/fx-only — the parallel-root shape, handled
+  separately) emits no sibling edge here."
+  [root-path source-path on-done]
+  (keep (fn [candidate]
+          (when-let [target-path (resolve-target-path root-path
+                                                      source-path
+                                                      (:target candidate))]
+            {:from  source-path
+             :to    target-path
+             :label (edge-label "✓ done" candidate)}))
+        (transition-candidates on-done)))
+
 (defn- collect-root-fallback-edges
   [root-path on-map]
   (let [source-path (conj (vec root-path) root-fallback-segment)]
@@ -297,7 +319,11 @@
         (concat
          (collect-on-edges root-path state-path (:on state-node))
          (collect-after-edges root-path state-path (:after state-node))
-         (collect-always-edges root-path state-path (:always state-node)))
+         (collect-always-edges root-path state-path (:always state-node))
+         ;; rf2-41goo — the compound `:on-done` completion edge (sibling
+         ;; target). A parallel-root `:on-done` (action/fx-only) is
+         ;; rendered separately in `render-parallel-body`.
+         (collect-on-done-edges root-path state-path (:on-done state-node)))
 
         nested-edges
         (mapcat (fn [[child-id child-node]]
@@ -421,8 +447,28 @@
           (interpose ["    --"]
                      (map render-region-block regions))))
 
+(defn- render-parallel-on-done-note
+  "rf2-41goo — the PARALLEL-ROOT `:on-done` (XState `onDone` on a parallel
+  state). When EVERY region settles `:final?`, the parallel root's
+  `:on-done` runs its `:action` + `:fx` (a `:type :parallel` machine is
+  root-only — registration rejects a `:target`, so there is no sibling
+  state to draw an arrow to; the machine STAYS in the all-final config).
+  Mermaid has no transitionable completion glyph for an action-only
+  parallel-done, so we render it as a `note` on the parallel root — the
+  completion is visible (`✓ done`) with its action when present, without
+  inventing a phantom target arrow."
+  [on-done]
+  (when on-done
+    (let [cands  (transition-candidates on-done)
+          action (some :action cands)
+          body   (cond-> "on-done: ✓ done"
+                   action (str " / " (label-value action)))]
+      [(str "  note right of " (sanitise-id parallel-root-path))
+       (str "    " body)
+       "  end note"])))
+
 (defn- render-parallel-body
-  [{:keys [regions on]} header-comment?]
+  [{:keys [regions on on-done]} header-comment?]
   (let [edges       (concat
                      (mapcat (fn [[region-id {:keys [states on]}]]
                                (let [region-path (vector region-id)]
@@ -445,7 +491,10 @@
                (render-parallel-region-blocks regions)
                ["  }"]
                edge-lines
-               final-lines))))
+               final-lines
+               ;; rf2-41goo — the parallel-root completion note (action/fx-
+               ;; only; no sibling target).
+               (render-parallel-on-done-note on-done)))))
 
 (defn- valid-state-tree?
   [{:keys [initial states]}]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -176,10 +176,24 @@
   (->> (transition-candidates always)
        (map #(emit-transition nil % depth))))
 
+(defn- emit-transitions-for-on-done
+  "rf2-41goo — emit the compound / parallel `:on-done` (XState `onDone`)
+  as W3C SCXML's `<transition event=\"done.state.<id>\" .../>`, placed
+  inside the done node's own `<state>` element (SCXML §3.7: reaching a
+  `<final>` child generates `done.state.<id>` into the internal queue; an
+  enclosing transition takes it). `done-event` is the precomputed
+  `\"done.state.<id-str>\"` for THIS node. A target-less candidate
+  (action/fx-only — the parallel-root shape) emits a transition with NO
+  `target` (the action survives as the emitter's `<!-- action -->`
+  comment), faithful to the action-only completion the engine fires."
+  [done-event on-done depth]
+  (->> (transition-candidates on-done)
+       (map #(emit-transition done-event % depth))))
+
 (defn- emit-state
   "Emit a `<state>` (or `<final>`) block for one state-node."
   [state-id state-node depth]
-  (let [{:keys [final? initial states on after always]} state-node
+  (let [{:keys [final? initial states on after always on-done]} state-node
         id-str (path->id-string state-id)
         tag    (if final? "final" "state")
         attrs  (cond-> (str "id=\"" (escape-xml-attr id-str) "\"")
@@ -190,6 +204,11 @@
           (emit-transitions-for-on on (inc depth))
           (emit-transitions-for-after after (inc depth))
           (emit-transitions-for-always always (inc depth))
+          ;; rf2-41goo — the `done.state.<this-id>` completion transition
+          ;; (XState `onDone`). Emitted INSIDE this node's own <state>.
+          (when on-done
+            (emit-transitions-for-on-done (str "done.state." id-str)
+                                          on-done (inc depth)))
           (mapcat (fn [[child-id child-node]]
                     (emit-state child-id child-node (inc depth)))
                   states))]
@@ -232,13 +251,26 @@
             states)
     [(str (indent-str depth) "</scxml>")]))
 
+(def ^:private parallel-root-scxml-id
+  "rf2-41goo — the SCXML id of the synthetic `<parallel>` element. Its
+  W3C completion event is `done.state.<this-id>`."
+  "rf2_parallel_root")
+
 (defn- emit-parallel
-  [{:keys [regions]} depth]
+  [{:keys [regions on-done]} depth]
   (concat
     [(str (indent-str depth)
           "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\""
           " version=\"1.0\">")
-     (str (indent-str (inc depth)) "<parallel id=\"rf2_parallel_root\">")]
+     (str (indent-str (inc depth)) "<parallel id=\"" parallel-root-scxml-id "\">")]
+    ;; rf2-41goo — the parallel-root `:on-done` (XState `onDone`):
+    ;; `done.state.<parallel-id>` raised when ALL regions settle final.
+    ;; A `:type :parallel` machine is root-only — registration rejects a
+    ;; `:target`, so the transition is action/fx-only (no `target`); the
+    ;; action survives as the emitter's `<!-- action -->` comment.
+    (when on-done
+      (emit-transitions-for-on-done (str "done.state." parallel-root-scxml-id)
+                                    on-done (+ depth 2)))
     (mapcat (fn [[region-id region-node]]
               ;; Each region is a state with its own initial + states.
               (emit-state region-id region-node (+ depth 2)))
@@ -494,6 +526,23 @@
                                    [existing simple-cand])
                                  simple-cand))))
 
+                ;; rf2-41goo — a `done.state.<id>` transition is the
+                ;; XState `onDone` completion (SCXML §3.7). It sits inside
+                ;; the done node's own element, so it round-trips back to
+                ;; THIS node's `:on-done` (a single transition spec, not an
+                ;; `:on`-keyed map). The `<id>` payload in the event name is
+                ;; informational (the engine raises it relative to the
+                ;; node); the re-frame2 grammar carries the completion as
+                ;; `:on-done` on the node, so we drop the id suffix.
+                (and event (str/starts-with? event "done.state."))
+                (update acc :on-done
+                        (fn [existing]
+                          (if existing
+                            (if (vector? existing)
+                              (conj existing simple-cand)
+                              [existing simple-cand])
+                            simple-cand)))
+
                 (nil? event)
                 (update acc :always (fnil conj []) cand-map)
 
@@ -586,7 +635,8 @@
                      initial-str     (assoc :initial (unescape-id-string initial-str)))]
     (if (or self? (empty? body))
       [state-id base]
-      (let [{:keys [on after always children-tokens]} (consume-transitions body)
+      (let [{:keys [on after always children-tokens] :as consumed}
+            (consume-transitions body)
             child-blocks (group-children-by-state children-tokens)
             child-states (when (seq child-blocks)
                            (into {}
@@ -595,6 +645,11 @@
                    (seq on)           (assoc :on on)
                    (seq after)        (assoc :after after)
                    (seq always)       (assoc :always always)
+                   ;; rf2-41goo — `:on-done` round-trips from the
+                   ;; `done.state.<id>` transition (may be a bare target,
+                   ;; a candidate map, or a vector — never a collection we
+                   ;; `seq`-test; use the key's presence).
+                   (contains? consumed :on-done) (assoc :on-done (:on-done consumed))
                    (seq child-states) (assoc :states child-states))]
         [state-id node]))))
 
@@ -704,9 +759,17 @@
 
                           :else
                           (recur (inc i) depth)))
-              parallel-body (subvec tail 0 end-idx)]
-          {:type    :parallel
-           :regions (parse-parallel-body parallel-body)})
+              parallel-body (subvec tail 0 end-idx)
+              ;; rf2-41goo — the parallel-root `:on-done` rides a
+              ;; `done.state.<parallel-id>` transition that is a DIRECT
+              ;; child of `<parallel>`. `parse-parallel-body` (via
+              ;; `group-children-by-state`) filters transition tokens at
+              ;; this depth, so pick it up directly via
+              ;; `consume-transitions` before they are dropped.
+              parallel-on-done (:on-done (consume-transitions parallel-body))]
+          (cond-> {:type    :parallel
+                   :regions (parse-parallel-body parallel-body)}
+            (some? parallel-on-done) (assoc :on-done parallel-on-done)))
 
         ;; Flat / compound definition
         (let [initial-str (get-in root-start [:attrs "initial"])

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -683,9 +683,10 @@
          :current-state {:audio :paused :display :off}}
         (fn [root _node]
           (let [ids (set (str/split (.getAttribute root "data-highlight-ids") #"\s+"))]
-            (is (contains? ids (layout/node-id [:paused]))
+            ;; rf2-wnzha — region states are region-scoped ids now.
+            (is (contains? ids (layout/region-scoped-id :audio [:paused]))
                 ":audio region's active leaf is in the active set")
-            (is (contains? ids (layout/node-id [:off]))
+            (is (contains? ids (layout/region-scoped-id :display [:off]))
                 ":display region's active leaf is in the active set — SIMULTANEOUSLY")
             (is (= 2 (count ids))
                 "exactly the two active region leaves, no more")

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -183,6 +183,113 @@
     (is (not= (layout/region-node-id :r1) (layout/node-id [:r1]))
         "a region container id differs from the same-named state id")))
 
+;; ---- region-scoped node-ids (rf2-wnzha) --------------------------------
+;;
+;; BUG (P2): pre-rf2-wnzha, `parse-parallel` kept each region's in-region
+;; node-id verbatim, so two regions sharing a state NAME minted IDENTICAL
+;; ids — the canonical Spec 005 `:ingest` shape (three regions each with a
+;; `:done {:final? true}` leaf) collided all three `:done` nodes into one:
+;; xyflow dropped two, and `highlight-ids` mis-attributed the multi-active
+;; highlight across regions. The fix REGION-SCOPES every region-state id.
+
+(deftest region-scoped-id-is-injective-across-regions
+  (testing "rf2-wnzha — the SAME state path in two DIFFERENT regions mints
+            DISTINCT ids (region is part of the id namespace), but composes
+            stably from the region container id + the in-region node-id"
+    (is (= (str (layout/region-node-id :fetch) "__" (layout/node-id [:done]))
+           (layout/region-scoped-id :fetch [:done]))
+        "composed from region-node-id + in-region node-id")
+    (is (not= (layout/region-scoped-id :fetch [:done])
+              (layout/region-scoped-id :validate [:done]))
+        "same state name, two regions → DISTINCT ids")
+    (is (not= (layout/region-scoped-id :fetch [:done])
+              (layout/node-id [:done]))
+        "a region-scoped id differs from the bare in-region id")))
+
+(deftest parse-definition-parallel-same-name-region-states-distinct-nodes
+  (testing "rf2-wnzha — the Spec 005 :ingest shape: three regions each
+            carrying a same-named `:done {:final? true}` leaf. All three
+            `:done` nodes must be PRESENT and DISTINCT (pre-fix they
+            collided into one node-id → xyflow dropped two)"
+    (let [ingest {:type :parallel
+                  :regions {:fetch    {:initial :loading
+                                       :states {:loading {:on {:loaded :done}}
+                                                :done    {:final? true}}}
+                            :validate {:initial :checking
+                                       :states {:checking {:on {:ok :done}}
+                                                :done     {:final? true}}}
+                            :index    {:initial :building
+                                       :states {:building {:on {:built :done}}
+                                                :done     {:final? true}}}}}
+          {:keys [nodes]} (layout/parse-definition ingest)
+          state-nodes (remove :region? nodes)
+          done-nodes  (filter #(= [:done] (:path %)) state-nodes)
+          done-ids    (map :id done-nodes)]
+      (is (= 3 (count done-nodes)) "all three regions' :done leaves survive")
+      (is (= 3 (count (set done-ids)))
+          "the three :done node-ids are DISTINCT (no collision/drop)")
+      (is (= #{(layout/region-scoped-id :fetch [:done])
+               (layout/region-scoped-id :validate [:done])
+               (layout/region-scoped-id :index [:done])}
+             (set done-ids))
+          "each :done id is region-scoped to its own region")
+      ;; The whole projection has globally-unique node ids.
+      (is (= (count nodes) (count (set (map :id nodes))))
+          "every projected node id is globally unique"))))
+
+(deftest parse-definition-parallel-same-name-region-states-edges-region-scoped
+  (testing "rf2-wnzha — an intra-region edge to/from a shared-name state
+            resolves to that region's OWN scoped id (pre-fix the edge
+            endpoints collided across regions)"
+    (let [ingest {:type :parallel
+                  :regions {:fetch    {:initial :loading
+                                       :states {:loading {:on {:loaded :done}}
+                                                :done    {:final? true}}}
+                            :validate {:initial :checking
+                                       :states {:checking {:on {:ok :done}}
+                                                :done     {:final? true}}}}}
+          {:keys [nodes edges]} (layout/parse-definition ingest)
+          node-ids (set (map :id nodes))]
+      ;; every edge endpoint is a REAL projected node (no phantom/collided id)
+      (doseq [e edges]
+        (is (contains? node-ids (:source e))
+            (str "edge source " (:source e) " is a real node"))
+        (is (contains? node-ids (:target e))
+            (str "edge target " (:target e) " is a real node")))
+      ;; the :fetch :loaded→:done edge lands on :fetch's OWN :done, not
+      ;; :validate's
+      (let [fetch-done (layout/region-scoped-id :fetch [:done])]
+        (is (some #(= fetch-done (:target %)) edges)
+            ":fetch's :loaded→:done edge targets :fetch's scoped :done")
+        (is (= (count (set (map :id edges))) (count edges))
+            "every edge id is distinct (no cross-region edge-id collision)")))))
+
+(deftest highlight-ids-same-name-region-states-attribute-per-region
+  (testing "rf2-wnzha (THE HIGHLIGHT FIX) — when two regions are both in a
+            same-named `:done` state, the multi-active highlight lights
+            EACH region's OWN `:done` node — not one node twice. Pre-fix
+            the colliding ids meant lighting region A's :done also lit B's"
+    (let [ingest {:type :parallel
+                  :regions {:fetch    {:initial :loading
+                                       :states {:loading {:on {:loaded :done}}
+                                                :done    {:final? true}}}
+                            :validate {:initial :checking
+                                       :states {:checking {:on {:ok :done}}
+                                                :done     {:final? true}}}}}
+          {:keys [nodes]} (layout/parse-definition ingest)
+          node-ids (set (map :id (remove :region? nodes)))
+          ;; BOTH regions reached their (same-named) :done leaf
+          state    {:fetch :done :validate :done}
+          ids      (layout/highlight-ids state)]
+      (is (= 2 (count ids))
+          "TWO distinct active leaves light up (one per region), not one")
+      (is (= #{(layout/region-scoped-id :fetch [:done])
+               (layout/region-scoped-id :validate [:done])}
+             ids)
+          "each region's :done is attributed to its OWN node-id")
+      (is (every? #(contains? node-ids %) ids)
+          "every active id is a REAL parsed region-state node (no phantom)"))))
+
 ;; ---- highlight-id ------------------------------------------------------
 
 (deftest highlight-id-handles-flat-state
@@ -229,16 +336,17 @@
 (deftest highlight-ids-region-map-is-the-set-of-active-leaves
   (testing "rf2-g2svr (THE NEW CAPABILITY) — a PARALLEL snapshot's
             region-map resolves to the SET of N active leaves, one per
-            region. Each region value resolves the same way the parse
-            mints the region's state ids — via node-id of the in-region
-            path (parse-parallel keeps the in-region node-id; it does NOT
-            region-prefix it)."
+            region. rf2-wnzha — each region value resolves via
+            `region-scoped-id` of the REGION + the in-region path
+            (parse-parallel region-scopes a state's node-id so two regions
+            sharing a state NAME mint DISTINCT ids; the resolver mints the
+            SAME scoped id)."
     (let [state {:data :loading :form :neutral :mode :active}
           ids   (layout/highlight-ids state)]
       (is (= 3 (count ids)) "three regions → three active leaf ids")
-      (is (= #{(layout/node-id [:loading])
-               (layout/node-id [:neutral])
-               (layout/node-id [:active])}
+      (is (= #{(layout/region-scoped-id :data [:loading])
+               (layout/region-scoped-id :form [:neutral])
+               (layout/region-scoped-id :mode [:active])}
              ids)))))
 
 (deftest highlight-ids-region-map-matches-parsed-region-state-ids
@@ -261,7 +369,8 @@
       (is (= 2 (count ids)))
       (is (every? #(contains? node-ids %) ids)
           "every active id is a REAL parsed region-state node")
-      (is (= #{(layout/node-id [:playing]) (layout/node-id [:shown])} ids)))))
+      (is (= #{(layout/region-scoped-id :audio [:playing])
+               (layout/region-scoped-id :video [:shown])} ids)))))
 
 (deftest highlight-ids-nested-region-value-resolves-to-deepest-leaf
   (testing "rf2-g2svr — a region whose value is itself a vector path (a
@@ -270,8 +379,8 @@
             value is a vector path INSIDE that region."
     (let [state {:auth [:authenticated :dashboard] :lifecycle :idle}
           ids   (layout/highlight-ids state)]
-      (is (= #{(layout/node-id [:authenticated :dashboard])
-               (layout/node-id [:idle])}
+      (is (= #{(layout/region-scoped-id :auth [:authenticated :dashboard])
+               (layout/region-scoped-id :lifecycle [:idle])}
              ids))
       (is (= 2 (count ids))
           "the compound region contributes ONE id (its deepest leaf), not
@@ -642,3 +751,109 @@
           success (first (filter #(= [:success] (:path %)) nodes))]
       (is (false? (:final? idle)) ":final? is false, not nil")
       (is (true?  (:final? success))))))
+
+;; ---- :on-done (XState onDone) completion edge (rf2-41goo) ---------------
+;;
+;; Spec 005 §The done-state signal: a COMPOUND node's `:on-done` advances
+;; the OUTER flow to a SIBLING target when its `:final?` child is reached
+;; (the machine KEEPS RUNNING). A PARALLEL-ROOT's `:on-done` runs
+;; action/fx ONLY (no :target — registration rejects one), rendered as a
+;; TERMINAL completion affordance. Pre-rf2-41goo `:on-done` was NEVER
+;; parsed (zero matches across src/test), so the chart understated the
+;; real control flow.
+
+(def checkout-on-done
+  "Spec 005 §The done-state signal example: a sub-flow `:flow` inside a
+  compound. When `:flow` reaches its `:final?` `:paid` child, `:flow`'s
+  `:on-done` advances the machine to the SIBLING `:next`."
+  {:initial :flow
+   :states  {:flow {:initial :collecting
+                    :on-done :next                       ;; ← sibling of :flow
+                    :states  {:collecting {:on {:submit :submitting}}
+                              :submitting {:on {:ok :paid}}
+                              :paid       {:final? true}}}
+             :next {:on {:reset [:flow]}}}})
+
+(deftest parse-definition-compound-on-done-is-sibling-edge
+  (testing "rf2-41goo — a compound `:on-done` projects ONE completion edge
+            from the compound to its SIBLING target (resolved relative to
+            the compound's OWN level), flagged :on-done?, carrying the
+            done-path (the engine's done.state node)"
+    (let [{:keys [edges]} (layout/parse-definition checkout-on-done)
+          od (filter :on-done? edges)]
+      (is (= 1 (count od)) "exactly one :on-done completion edge")
+      (let [e (first od)]
+        (is (= [:flow] (:from e)) "sourced from the compound itself")
+        (is (= [:next] (:to e)) "lands on the SIBLING :next (compound-level resolution)")
+        (is (= :rf.machine/done (:event e)) "carries the reserved done event")
+        (is (= [:flow] (:done-path e)) "the done.state node is the compound's path")
+        (is (= "✓ done" (:event-label e))
+            "renders the completion ✓ done chip, not an ordinary event arrow")
+        (is (not (:internal? e)) "a targeted compound :on-done is a real sibling edge")))))
+
+(deftest parse-definition-no-on-done-emits-no-completion-edge
+  (testing "rf2-41goo — a machine with no :on-done emits no :on-done? edge
+            (no false-positive completion arrows)"
+    (let [{:keys [edges]} (layout/parse-definition compound-machine)]
+      (is (empty? (filter :on-done? edges))))))
+
+(deftest parse-definition-compound-on-done-guarded-candidate-vector
+  (testing "rf2-41goo — an :on-done candidate-vector (guarded forks)
+            projects each target-bearing arm as its own completion edge,
+            mirroring the :on candidate-vector grammar"
+    (let [m {:initial :flow
+             :states  {:flow {:initial :work
+                              :on-done [{:target :ok-next :guard :ok?}
+                                        {:target :err-next :guard :err?}]
+                              :states  {:work {:on {:finish :done}}
+                                        :done {:final? true}}}
+                       :ok-next  {}
+                       :err-next {}}}
+          {:keys [edges]} (layout/parse-definition m)
+          od (filter :on-done? edges)]
+      (is (= 2 (count od)) "both guarded completion arms project")
+      (is (= #{[:ok-next] [:err-next]} (set (map :to od))))
+      (is (every? #(= [:flow] (:from %)) od) "both sourced from the compound")
+      (is (= #{:ok? :err?} (set (map :guard od))) "guards preserved"))))
+
+(def ingest-parallel-on-done
+  "Spec 005 §The done-state signal parallel example: three orthogonal
+  axes; when ALL settle final, the parallel-root `:on-done` runs its
+  action (no :target — a parallel root is root-only)."
+  {:type    :parallel
+   :on-done {:action :announce}                 ;; ← parallel-root onDone (action only)
+   :regions {:fetch    {:initial :loading :states {:loading {:on {:loaded :done}} :done {:final? true}}}
+             :validate {:initial :checking :states {:checking {:on {:ok :done}} :done {:final? true}}}
+             :index    {:initial :building :states {:building {:on {:built :done}} :done {:final? true}}}}})
+
+(deftest parse-definition-parallel-root-on-done-is-terminal-affordance
+  (testing "rf2-41goo — a PARALLEL-ROOT `:on-done` (action/fx-only, no
+            :target — registration rejects one) projects a TERMINAL
+            completion affordance (self-anchored, :internal?), NOT a
+            sibling edge; carries the action + :parallel-root? flag"
+    (let [{:keys [edges nodes]} (layout/parse-definition ingest-parallel-on-done)
+          od (filter :on-done? edges)]
+      (is (= 1 (count od)) "one parallel-root completion affordance")
+      (let [e (first od)]
+        (is (true? (:parallel-root? e)) "flagged parallel-root")
+        (is (true? (:internal? e))
+            "a target-less parallel-root :on-done self-anchors (terminal, no sibling segment)")
+        (is (= (:source e) (:target e)) "terminal affordance: source == target")
+        (is (= :announce (:action e)) "the parallel-root action is preserved")
+        (is (= "✓ done / announce" (:event-label e))
+            "renders the completion chip with its action"))
+      ;; the synthetic parallel-root node is surfaced as the affordance anchor
+      (let [root (first (filter :parallel-root? nodes))]
+        (is (some? root) "a synthetic parallel-root node anchors the affordance")
+        (is (= (:source (first od)) (:id root))
+            "the completion edge anchors on the parallel-root node")))))
+
+(deftest parse-definition-parallel-without-on-done-emits-no-root-node
+  (testing "rf2-41goo — a parallel machine with NO :on-done leaks no
+            synthetic parallel-root node + no completion edge"
+    (let [m {:type :parallel
+             :regions {:a {:initial :x :states {:x {:on {:go :y}} :y {}}}
+                       :b {:initial :p :states {:p {:on {:go :q}} :q {}}}}}
+          {:keys [nodes edges]} (layout/parse-definition m)]
+      (is (empty? (filter :parallel-root? nodes)))
+      (is (empty? (filter :on-done? edges))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -239,7 +239,7 @@
       (let [parsed (layout/parse-definition parallel-machine)
             graph  (projection/xyflow-graph parsed {} {:on-state-click cb})
             region (node-by-id graph (layout/region-node-id :audio))
-            muted  (node-by-id graph (layout/node-id [:muted]))]
+            muted  (node-by-id graph (layout/region-scoped-id :audio [:muted]))]
         (is (= "parallel-region" (:type region)))
         (is (not (contains? (:data region) :onClick))
             "a parallel-region container carries NO :onClick (not a click target)")
@@ -274,7 +274,7 @@
     (let [parsed (layout/parse-definition parallel-machine)
           graph  (projection/xyflow-graph parsed {} {})
           region (node-by-id graph (layout/region-node-id :audio))
-          muted  (node-by-id graph (layout/node-id [:muted]))]
+          muted  (node-by-id graph (layout/region-scoped-id :audio [:muted]))]
       (is (= (layout/region-node-id :audio) (:parentId muted)))
       (is (= "parent" (:extent muted)))
       (is (nil? (:parentId region)) "region container is not nested")
@@ -384,10 +384,11 @@
             region-leaf ids marks BOTH region states `:active`
             simultaneously (parallel multi-active highlight)"
     (let [parsed     (layout/parse-definition parallel-machine)
-          playing-id (layout/node-id [:playing])
-          shown-id   (layout/node-id [:shown])
-          muted-id   (layout/node-id [:muted])
-          hidden-id  (layout/node-id [:hidden])
+          ;; rf2-wnzha — region states are region-scoped ids now.
+          playing-id (layout/region-scoped-id :audio [:playing])
+          shown-id   (layout/region-scoped-id :video [:shown])
+          muted-id   (layout/region-scoped-id :audio [:muted])
+          hidden-id  (layout/region-scoped-id :video [:hidden])
           graph      (projection/xyflow-graph
                        parsed {} {:highlight-ids #{playing-id shown-id}})]
       (is (true? (:active (:data (node-by-id graph playing-id))))
@@ -416,7 +417,8 @@
           active-states (set (map :id (filter #(and (= "state" (:type %))
                                                     (:active (:data %)))
                                               (:nodes graph))))]
-      (is (= #{(layout/node-id [:playing]) (layout/node-id [:shown])} active-states)
+      (is (= #{(layout/region-scoped-id :audio [:playing])
+               (layout/region-scoped-id :video [:shown])} active-states)
           "exactly the two active region leaves are marked active"))))
 
 (deftest xyflow-graph-scalar-highlight-id-still-works
@@ -435,8 +437,8 @@
   (testing "rf2-g2svr — when BOTH `:highlight-id` and `:highlight-ids`
             are supplied the active set is their union"
     (let [parsed (layout/parse-definition parallel-machine)
-          a      (layout/node-id [:playing])
-          b      (layout/node-id [:shown])
+          a      (layout/region-scoped-id :audio [:playing])
+          b      (layout/region-scoped-id :video [:shown])
           graph  (projection/xyflow-graph
                    parsed {} {:highlight-id a :highlight-ids #{b}})]
       (is (true? (:active (:data (node-by-id graph a)))))
@@ -457,7 +459,7 @@
             parallel-region CONTAINER `:active`, so the zone (not just the
             leaf inside it) reads as active"
     (let [parsed     (layout/parse-definition parallel-machine)
-          playing-id (layout/node-id [:playing])
+          playing-id (layout/region-scoped-id :audio [:playing])
           audio-id   (layout/region-node-id :audio)
           graph      (projection/xyflow-graph
                        parsed {} {:highlight-ids #{playing-id}})
@@ -471,7 +473,7 @@
             its container `:active false` (only the active region(s) get
             chrome — orthogonality of the active read)"
     (let [parsed     (layout/parse-definition parallel-machine)
-          playing-id (layout/node-id [:playing])     ; :audio leaf, active
+          playing-id (layout/region-scoped-id :audio [:playing]) ; :audio leaf, active
           audio-id   (layout/region-node-id :audio)
           video-id   (layout/region-node-id :video)
           graph      (projection/xyflow-graph
@@ -563,19 +565,22 @@
   (testing "rf2-g2svr — with N active leaves, an edge touching ANY active
             leaf is `:active`. Each region's self/incident edge lights up
             independently (orthogonality preserved)."
-    (let [parsed   (layout/parse-definition parallel-machine)
-          ids      #{(layout/node-id [:playing]) (layout/node-id [:shown])}
-          graph    (projection/xyflow-graph parsed {} {:highlight-ids ids})
-          active-e (filter #(:active (:data %)) (:edges graph))
+    (let [parsed     (layout/parse-definition parallel-machine)
+          ;; rf2-wnzha — region states are region-scoped ids now.
+          playing-id (layout/region-scoped-id :audio [:playing])
+          shown-id   (layout/region-scoped-id :video [:shown])
+          ids        #{playing-id shown-id}
+          graph      (projection/xyflow-graph parsed {} {:highlight-ids ids})
+          active-e   (filter #(:active (:data %)) (:edges graph))
           ;; edges incident to :playing (audio) and :shown (video)
-          regions  (set (map (fn [e]
-                               (cond
-                                 (or (= (:source e) (layout/node-id [:playing]))
-                                     (= (:target e) (layout/node-id [:playing]))) :audio
-                                 (or (= (:source e) (layout/node-id [:shown]))
-                                     (= (:target e) (layout/node-id [:shown]))) :video
-                                 :else :other))
-                             active-e))]
+          regions    (set (map (fn [e]
+                                 (cond
+                                   (or (= (:source e) playing-id)
+                                       (= (:target e) playing-id)) :audio
+                                   (or (= (:source e) shown-id)
+                                       (= (:target e) shown-id)) :video
+                                   :else :other))
+                               active-e))]
       (is (seq active-e) "at least one edge is active")
       (is (contains? regions :audio) "an :audio-region edge is active")
       (is (contains? regions :video) "a :video-region edge is active"))))
@@ -2217,3 +2222,77 @@
       ;; on any edge :data, entry edges included.
       (is (not (contains? (:data entry) :siblingIndex)))
       (is (not (contains? (:data entry) :siblingCount))))))
+
+;; ---- :on-done (XState onDone) projection (rf2-41goo) -------------------
+;;
+;; The compound / parallel completion transition projects as an
+;; events-as-nodes event-node carrying the ✓ done chip + `:onDone` /
+;; `:doneState` data hooks (the renderer's completion affordance). The
+;; reserved `:rf.machine/done` is engine-RAISED, so the event-node is NOT
+;; click-to-send (no `:eventId`).
+
+(def checkout-on-done
+  "Spec 005 §The done-state signal: a compound `:flow` whose `:on-done`
+  advances to the sibling `:next` when its `:final?` `:paid` is reached."
+  {:initial :flow
+   :states  {:flow {:initial :collecting
+                    :on-done :next
+                    :states  {:collecting {:on {:submit :submitting}}
+                              :submitting {:on {:ok :paid}}
+                              :paid       {:final? true}}}
+             :next {:on {:reset [:flow]}}}})
+
+(def ingest-on-done
+  "Spec 005 §The done-state signal parallel example: parallel-root
+  `:on-done` runs action-only (no :target)."
+  {:type    :parallel
+   :on-done {:action :announce}
+   :regions {:fetch    {:initial :loading :states {:loading {:on {:loaded :done}} :done {:final? true}}}
+             :validate {:initial :checking :states {:checking {:on {:ok :done}} :done {:final? true}}}}})
+
+(deftest xyflow-graph-compound-on-done-projects-done-event-node
+  (testing "rf2-41goo — a compound `:on-done` projects an event-node with
+            the ✓ done chip + :onDone true + the done.state.<id> label;
+            the inbound/outbound edges wire compound → done-node → sibling"
+    (let [parsed   (layout/parse-definition checkout-on-done)
+          od-edge  (first (filter :on-done? (:edges parsed)))
+          graph    (projection/xyflow-graph parsed {} {})
+          ev-node  (event-node-for graph (:id od-edge))]
+      (is (some? od-edge) "fixture sanity: the parse emits an :on-done edge")
+      (is (some? ev-node) "the :on-done transition projects an event-node")
+      (is (= "✓ done" (:eventLabel (:data ev-node))) "the ✓ done completion chip")
+      (is (= "on-done" (:variant (:data ev-node))) "bucketed as the :on-done variant")
+      (is (true? (:onDone (:data ev-node))) "flagged :onDone for the renderer hook")
+      (is (= (str "done.state." (layout/node-id [:flow])) (:doneState (:data ev-node)))
+          "carries the SCXML-style done.state.<id> label")
+      (is (nil? (:eventId (:data ev-node)))
+          "the engine-raised :rf.machine/done is NOT click-to-send")
+      ;; the outbound edge lands on the sibling :next
+      (let [out (outbound-edge-for graph (:id od-edge))]
+        (is (some? out) "a targeted compound :on-done has an outbound segment")
+        (is (= (layout/node-id [:next]) (:target out))
+            "the completion edge advances to the sibling :next")))))
+
+(deftest xyflow-graph-parallel-root-on-done-is-terminal-event-node
+  (testing "rf2-41goo — a parallel-root `:on-done` (action-only, internal)
+            projects a TERMINAL event-node (no outbound segment) carrying
+            the ✓ done chip + the action; not click-to-send"
+    (let [parsed   (layout/parse-definition ingest-on-done)
+          od-edge  (first (filter :on-done? (:edges parsed)))
+          graph    (projection/xyflow-graph parsed {} {})
+          ev-node  (event-node-for graph (:id od-edge))]
+      (is (some? ev-node) "the parallel-root :on-done projects an event-node")
+      (is (true? (:onDone (:data ev-node))))
+      (is (true? (:internal (:data ev-node)))
+          "a parallel-root :on-done is a terminal (internal) affordance")
+      (is (= "announce" (:action (:data ev-node))) "the action surfaces on the chip")
+      ;; internal ⇒ NO outbound edge (terminal affordance, no sibling)
+      (is (nil? (outbound-edge-for graph (:id od-edge)))
+          "a terminal parallel-root :on-done has no outgoing segment"))))
+
+(deftest xyflow-graph-no-on-done-projects-no-done-node
+  (testing "rf2-41goo — a machine with no :on-done projects no :onDone
+            event-node (no false-positive completion chips)"
+    (let [graph (projection/xyflow-graph
+                  (layout/parse-definition compound-machine) {} {})]
+      (is (empty? (filter #(:onDone (:data %)) (:nodes graph)))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
@@ -297,3 +297,53 @@
       (is (str/includes? out ":after rings + :spawn-all rows omitted"))
       ;; Closes the fence
       (is (str/ends-with? out "```")))))
+
+;; -----------------------------------------------------------------------------
+;; :on-done (XState onDone) completion transition (rf2-41goo)
+;;
+;; Spec 005 §The done-state signal: a COMPOUND `:on-done` advances the
+;; outer flow to a SIBLING; a PARALLEL-ROOT `:on-done` runs action-only
+;; (no target — rendered as a note, no phantom arrow). Pre-rf2-41goo
+;; Mermaid projected NO onDone edge.
+
+(def compound-on-done-machine
+  "Spec 005 example: compound `:flow` whose `:on-done` advances to the
+  SIBLING `:next` when its `:final?` `:paid` is reached."
+  {:initial :flow
+   :states  {:flow {:initial :collecting
+                    :on-done :next
+                    :states  {:collecting {:on {:submit :submitting}}
+                              :submitting {:on {:ok :paid}}
+                              :paid       {:final? true}}}
+             :next {:on {:reset [:flow]}}}})
+
+(def parallel-on-done-machine
+  "Spec 005 example: parallel-root `:on-done` runs action-only."
+  {:type    :parallel
+   :on-done {:action :announce}
+   :regions {:fetch    {:initial :loading :states {:loading {:on {:loaded :done}} :done {:final? true}}}
+             :validate {:initial :checking :states {:checking {:on {:ok :done}} :done {:final? true}}}}})
+
+(deftest emit-compound-on-done-renders-sibling-completion-edge
+  (testing "rf2-41goo — a compound `:on-done` renders the completion edge
+            `<compound> --> <sibling> : ✓ done` (the Stately 'do the
+            sub-flow, then continue' arrow), resolved to the SIBLING"
+    (let [out (m/emit compound-on-done-machine {:fenced? false :header-comment? false})]
+      (is (str/includes? out "flow --> next : ✓ done")
+          "the compound advances to its sibling on completion"))))
+
+(deftest emit-parallel-on-done-renders-completion-note
+  (testing "rf2-41goo — a parallel-root `:on-done` (action-only, no
+            target) renders as a note on the parallel root (no phantom
+            target arrow), surfacing the ✓ done completion + its action"
+    (let [out (m/emit parallel-on-done-machine {:fenced? false :header-comment? false})]
+      (is (str/includes? out "note right of")
+          "the parallel-root completion renders as a note")
+      (is (str/includes? out "on-done: ✓ done / announce")
+          "the note carries the completion + its action"))))
+
+(deftest emit-no-on-done-renders-no-completion-affordance
+  (testing "rf2-41goo — a machine with no :on-done renders no ✓ done chip
+            (no false-positive completion arrows)"
+    (let [out (m/emit compound-machine {:fenced? false :header-comment? false})]
+      (is (not (str/includes? out "✓ done"))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -278,3 +278,75 @@
       (is (nil? (:on back)) "the inherited fallback is lost on import")
       (is (= (:states spec) (:states back))
           "the per-state topology DOES round-trip"))))
+
+;; ---------------------------------------------------------------------------
+;; :on-done (XState onDone) — W3C SCXML done.state.<id> (rf2-41goo)
+;;
+;; SCXML §3.7: reaching a `<final>` child generates `done.state.<id>` into
+;; the internal queue, which an enclosing `<transition event="done.state.
+;; <id>">` takes. Pre-rf2-41goo the emitter projected the `<final>` child
+;; but NOT the onDone transition — a silently lossy round-trip.
+
+(def compound-on-done-machine
+  "Spec 005 example: a compound `:flow` whose `:on-done` advances to the
+  SIBLING `:next` when its `:final?` `:paid` is reached."
+  {:initial :flow
+   :states  {:flow {:initial :collecting
+                    :on-done :next
+                    :states  {:collecting {:on {:submit :submitting}}
+                              :submitting {:on {:ok :paid}}
+                              :paid       {:final? true}}}
+             :next {:on {:reset :flow}}}})
+
+(def parallel-on-done-machine
+  "Spec 005 example: a parallel-root `:on-done` runs action-only (no
+  :target). The action survives only as a comment (lossy, like every
+  action), so it round-trips to `:on-done {}` (the empty completion
+  spec) — the COMPLETION TOPOLOGY survives; the action is named-lossy."
+  {:type    :parallel
+   :on-done {}
+   :regions {:fetch    {:initial :loading :states {:loading {:on {:loaded :done}} :done {:final? true}}}
+             :validate {:initial :checking :states {:checking {:on {:ok :done}} :done {:final? true}}}}})
+
+(deftest emit-compound-on-done-renders-done-state-transition
+  (testing "rf2-41goo — a compound `:on-done` emits the W3C SCXML
+            `<transition event=\"done.state.<compound-id>\" target=...>`
+            INSIDE the compound's own <state> (SCXML §3.7)"
+    (let [out (scxml/spec->scxml compound-on-done-machine)]
+      (is (str/includes? out "event=\"done.state.flow\"")
+          "the done.state.<compound> completion event")
+      (is (str/includes? out "target=\"next\"")
+          "advances to the sibling :next"))))
+
+(deftest emit-parallel-on-done-renders-parallel-done-state
+  (testing "rf2-41goo — a parallel-root `:on-done` emits
+            `<transition event=\"done.state.rf2_parallel_root\">` inside
+            the <parallel> element (the whole-parallel completion)"
+    (let [out (scxml/spec->scxml parallel-on-done-machine)]
+      (is (str/includes? out "event=\"done.state.rf2_parallel_root\"")
+          "the whole-parallel done.state completion event"))))
+
+(deftest round-trip-compound-on-done
+  (testing "rf2-41goo — a compound `:on-done` (sibling target) round-trips
+            through `done.state.<id>` back to `:on-done`"
+    (let [spec compound-on-done-machine
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= spec back) "the compound :on-done topology round-trips exactly")
+      (is (= :next (get-in back [:states :flow :on-done]))
+          ":on-done reconstructs on the compound node"))))
+
+(deftest round-trip-parallel-on-done-topology
+  (testing "rf2-41goo — a parallel-root `:on-done` round-trips its
+            COMPLETION topology (the action is named-lossy like every
+            action — survives only as a comment, so the spec carries the
+            empty completion form `{}`)"
+    (let [spec parallel-on-done-machine
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= spec back) "the parallel completion topology round-trips")
+      (is (contains? back :on-done) "the parallel-root :on-done survives import"))))
+
+(deftest no-on-done-emits-no-done-state-transition
+  (testing "rf2-41goo — a compound with no :on-done emits no done.state
+            transition (no false-positive completion edge)"
+    (let [out (scxml/spec->scxml compound-machine)]
+      (is (not (str/includes? out "done.state"))))))


### PR DESCRIPTION
Two definition→visual projection faithfulness fixes in `tools/machines-viz`, from the rf2-60whl senior-dev review. XState v5 is the gold standard for the projected semantics; pre-alpha masterpiece posture (ELEGANCE + CLARITY + CORRECTNESS).

## rf2-wnzha (P2 BUG) — sibling-region node-id collision

`parse-parallel` kept each region's in-region node-id verbatim, so two regions sharing a state NAME — the canonical Spec 005 `:ingest` shape (three regions each carrying a `:done {:final? true}` leaf) — minted **identical** node-ids. Consequences: xyflow's `:id` keying dropped the duplicates (a region's state silently vanished), and `highlight-ids` mis-attributed the G1 multi-active highlight across regions (lighting region A's `:done` also lit B's + C's).

**Fix** (`chart/layout.cljc`): region-SCOPE every region-state node-id via the new `region-scoped-id` (= `region-node-id` + `__` + in-region `node-id`), plus its `:parent-id` and every edge `:id`/`:source`/`:target`. `highlight-ids` region-map resolution mints the same scoped id. Injective across regions by construction (XState v5 orthogonal-namespace semantics). The in-region `:path` is preserved verbatim — only the xyflow-facing string ids are region-scoped.

## rf2-41goo (P2 parity BUG) — `:on-done` (XState `onDone`) never projected

Spec 005's first-class `:on-done` (compound / parallel completion transition — SCXML §3.7 `done.state.<id>`) was **never** parsed or projected in chart, mermaid, OR scxml (zero matches for `on-done`/`onDone`/`done.state` across all three). The chart drew the `:final?` leaf but not the "then advance to sibling" arrow that fires; the SCXML round-trip was silently lossy.

**Fix**:
- `chart/layout.cljc` — `on-done-edges` parses a node's `:on-done`. A **compound's** completion edge resolves to its **sibling** (resolved at the compound's own level — the XState `onDone` placement), flagged `:on-done?` + carrying the `:done-path`. A **parallel-root's** `:on-done` (action/fx-only — registration rejects a `:target`) renders as a **terminal completion affordance** (self-anchored, `:internal?`) on a synthetic parallel-root node.
- `chart/projection.cljc` — buckets the `:on-done` event-variant; threads `:onDone` + the `done.state.<id>` `:doneState` label onto the event-node (`✓ done` chip). The engine-raised `:rf.machine/done` is **not** click-to-send.
- `mermaid.cljc` — compound sibling edge (`✓ done`) + a parallel-root completion `note` (no phantom target arrow).
- `scxml.cljc` — emits + round-trips the W3C `<transition event="done.state.<id>">` (compound→sibling; parallel inside `<parallel>`).

## Spec reconciliation

`001-Topology-Parity.md`'s overstated "COMPLETE" parity claim corrected — adds **G9** (onDone) as closed, updates the transition-scoping row + §1.3 parity bar + Phase F roadmap. `000-Vision.md` L193 onDone drift fixed as a side-effect (rf2-asldn partial). `API.md` `highlight-ids` region-map note updated.

## Gates (cold)

- `tools/machines-viz` `clojure -M:test` — **353 tests / 1012 assertions, 0 failures** (baseline 333/947 + 16 tests / 49 assertions).
- `npm run test:cljs` — **5602 tests / 19496 assertions, 0 failures** (cross-platform CLJS; the machines-viz cljc is on the `node-test` classpath, so this exercises the `:cljs` reader-conditional branches).
- No repo-root `spec/`/`docs/` touched (only tool-local `tools/machines-viz/spec/*`), so doc-slug/mkdocs gates N/A. No new files.

Closes rf2-wnzha, rf2-41goo.

Follow-ons held (not in this PR): rf2-b4loj (P3 error-final), rf2-asldn (P3 vision-doc drift — the onDone L193 line is fixed here as a trivial side-effect; the rest remains), rf2-agu25 (P4).