### PR TITLE
docs(skills): correct reg-fx v2 signature + add :raise to fx reserved table (rf2-swt7o + rf2-he5mo)

### DIFF
--- a/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
+++ b/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
@@ -9,7 +9,7 @@ One-line signatures for the public `re-frame.core` surface. **For full docstring
 | `rf/reg-event-db` | `(id [intercept?] (fn [db ev] new-db))` |
 | `rf/reg-event-fx` | `(id [intercept?] (fn [cofx ev] fx-map))` |
 | `rf/reg-event-ctx` | `(id [intercept?] (fn [ctx] ctx'))` |
-| `rf/reg-fx` | `(id (fn [value] ...))` |
+| `rf/reg-fx` | `(id [metadata?] (fn [ctx args] ...))` — `ctx` is `{:frame :event}`; `args` is the `:fx` entry's 2nd slot |
 | `rf/reg-cofx` | `(id (fn [cofx & args] cofx'))` |
 | `rf/reg-sub` | `(id [signals?] (fn [db\|inputs query-v] value))` |
 | `rf/reg-view` | `(sym [args] body)` — defn-shape, auto-injects `dispatch`/`subscribe` |

--- a/skills/re-frame2/references/fundamentals/fx.md
+++ b/skills/re-frame2/references/fundamentals/fx.md
@@ -34,12 +34,13 @@ Verified in `implementation/core/src/re_frame/fx.cljc` (the `reg-fx` fn). Metada
 
 Each `:fx` entry is a 2-vector: `[fx-id args]`. The runtime walks them in source order, synchronously, after `:db` commits (`fx.cljc:4-9`). Any other top-level key — `:dispatch`, `:dispatch-later`, `:http`, etc — emits `:rf.error/effect-map-shape` and is dropped (`police-effect-map-shape!` in `events.cljc`). v2 deliberately removed v1's auto-routed top-level effect keys.
 
-The reserved fx-ids the core runtime handles directly (`fx.cljc:10-22`):
+The reserved fx-ids the core runtime handles directly (`fx.cljc:10-16`):
 
 | fx-id | args | Effect |
 |---|---|---|
 | `:dispatch` | event-vector | Enqueue at back of frame's router |
 | `:dispatch-later` | `{:ms n :event ev}` | Enqueue after `n` ms |
+| `:raise` | event-vector | Machine-internal: re-enter the machine locally as a pre-commit microstep in the same macrostep (state-machines leaves) |
 | `:rf.fx/reg-flow` / `:rf.fx/clear-flow` | flow spec | (Flows artefact; Spec 013) |
 
 Machine fx-ids (`:rf.machine/spawn`, `:rf.machine/destroy`) ship in `day8/re-frame2-machines`; they register through the same `reg-fx` path when that artefact is loaded.


### PR DESCRIPTION
Two API-reference-correctness fixes in the `skills/re-frame2/` reference leaves. Verified against `implementation/core/src/re_frame/fx.cljc` before editing.

## Fix 1 — rf2-swt7o (P1, WRONG/STALE)

`references/cross-cutting/api-cheatsheet.md` listed `reg-fx` with the v1 **unary** handler form `(id (fn [value] ...))`. The v2 fx-handler is **binary, ctx-first**: `(fn [ctx args])`.

- **Source of truth:** `fx.cljc:40` docstring — `Handler signature: (fn [ctx args] ...) — **v2 changed from v1**`; handler invoked as `((:handler-fn meta) {:frame ... :event ...} args)`.
- **Sibling leaf already correct:** `references/fundamentals/fx.md:13` documents `(fn [ctx args])` — the cheatsheet contradicted both impl and its own sibling.
- **Why P1:** an agent copying the unary form binds `value` to the ctx map `{:frame :event}` and reads the actual payload as the discarded second arg → silently-broken fx handler, no error.

before → after:
```
- | `rf/reg-fx` | `(id (fn [value] ...))` |
+ | `rf/reg-fx` | `(id [metadata?] (fn [ctx args] ...))` — `ctx` is `{:frame :event}`; `args` is the `:fx` entry's 2nd slot |
```
(matches `fx.md` wording + `fx.cljc:53-54`'s two registration shapes.)

## Fix 2 — rf2-he5mo (P4, CLARITY)

`references/fundamentals/fx.md`'s reserved-fx-id table omitted `:raise`. `fx.cljc:10-16` enumerates it: `:raise — machine-internal (machine handler routes locally)`. Added a row, and corrected the stale `fx.cljc:10-22` reference range to `:10-16` (the actual reserved enumeration span).

## Scope / out of scope

- Touches only the two reference leaves. `SKILL.md` (rf2-fv7pi) and the README (rf2-784bq) are deliberately **untouched** — those are separate, held tasks.

## Quality gates

Docs-only, no code changed. The edited files live under `skills/re-frame2/references/...`, **outside the mkdocs corpus** (`docs_dir: docs`; not in nav) — so no mkdocs link/slug surface is affected. Correctness cross-check: the corrected `(fn [ctx args])` signature matches `fx.cljc:40` and the `((:handler-fn meta) ctx args)` invocation.

Closes rf2-swt7o, rf2-he5mo.