### PR TITLE
fix(epoch): apply :redact-fn to post-settle back-fill re-notify (rf2-82pcg)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -129,8 +129,21 @@
                        (not= target default-epoch)
                        (state/render-key-already-in-epoch?
                          frame-id target render-key))
-          (when-let [updated (state/back-fill-render! frame-id target
-                                                      event (capture/render-row event))]
+          ;; rf2-82pcg — pass `assembly/maybe-redact` so `back-fill-render!`
+          ;; re-runs the installed `:redact-fn` over the record AFTER it
+          ;; appends the RAW render event into `:trace-events` + the RAW
+          ;; projected row into `:renders`. The redacted record is what
+          ;; lands in the ring AND what we re-fan to listeners — so both
+          ;; the pull egress (`epoch-history` / MCP `read-recording` /
+          ;; `restore-epoch`) and the push egress (this fan-out) see the
+          ;; same redacted shape the settle-time primary path produces.
+          ;; Without it the appended slots reach egress bypassing the
+          ;; `:redact-fn` (the leak). The fn is idempotent for the
+          ;; `:rf/redacted` sentinel pattern, so re-applying it to the
+          ;; already-settle-redacted slots is a no-op.
+          (when-let [updated (state/back-fill-render! frame-id target event
+                                                      (capture/render-row event)
+                                                      assembly/maybe-redact)]
             ;; Re-fan the corrected record so snapshot consumers re-read
             ;; the ring. The fan-out is failure-isolated per listener
             ;; (same contract as the settle-time fan-out); a render-driven
@@ -159,8 +172,13 @@
   [frame-id event]
   (when interop/debug-enabled?
     (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
-      (when-let [updated (state/back-fill-sub-run! frame-id epoch-id
-                                                   event (capture/sub-run-row event))]
+      ;; rf2-82pcg — pass `assembly/maybe-redact` so the RAW sub-event
+      ;; appended to `:trace-events` + the RAW `:sub-runs` row are run
+      ;; through the installed `:redact-fn` before they land in the ring
+      ;; / re-fan to listeners (see `record-render!`).
+      (when-let [updated (state/back-fill-sub-run! frame-id epoch-id event
+                                                   (capture/sub-run-row event)
+                                                   assembly/maybe-redact)]
         ;; Re-fan the corrected record so snapshot consumers re-read the
         ;; ring. Same failure-isolated fan-out + no-loop contract as the
         ;; render back-fill above.
@@ -213,7 +231,14 @@
   [frame-id event]
   (when interop/debug-enabled?
     (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
-      (when-let [updated (state/back-fill-unmount! frame-id epoch-id event)]
+      ;; rf2-82pcg — pass `assembly/maybe-redact` so the RAW unmount event
+      ;; appended to `:trace-events` is run through the installed
+      ;; `:redact-fn` before it lands in the ring / re-fans to listeners
+      ;; (see `record-render!`). An unmount carries no structured projection
+      ;; row, so only `:trace-events` is back-filled — but that slot is
+      ;; still egress (Xray's VIEWS-step `unmounted-views-rows` reads it).
+      (when-let [updated (state/back-fill-unmount! frame-id epoch-id event
+                                                   assembly/maybe-redact)]
         ;; Re-fan the corrected record so snapshot consumers re-read the
         ;; ring. Same failure-isolated fan-out + no-loop contract as the
         ;; render / sub-run back-fill above.

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -555,9 +555,11 @@
 (defn- back-fill-event!
   "Append `event` and its projected `row` (into the `slot` projection)
   on the already-committed epoch record identified by `frame-id` +
-  `epoch-id`. Returns the updated record (so the caller can re-notify
-  listeners), or nil when the target epoch is no longer in the ring
-  (evicted, or the event fired before any cascade settled).
+  `epoch-id`, then run the appended record through `redact` and write
+  THAT back to the ring. Returns the redacted updated record (so the
+  caller re-notifies listeners with the same shape the ring now holds),
+  or nil when the target epoch is no longer in the ring (evicted, or the
+  event fired before any cascade settled).
 
   `row` is the structured projection entry, or nil — a render op that
   carries no `:renders` row (`:rf.view/rendered`) or a `:sub/skip` that
@@ -575,40 +577,69 @@
       (Xray Views / Reactive panel) — is always present on a built
       record; the projected row is appended when non-nil.
 
+  REDACTION (rf2-82pcg). `redact` is the installed redaction transform
+  (`assembly/maybe-redact`, injected by the caller so this state ns keeps
+  no `assembly` require — `assembly` already requires this ns). It runs
+  INSIDE the swap, AFTER the raw append, so the redacted record is what
+  lands in the ring AND what is returned for the listener re-fan — the
+  same `:redact-fn`-once-between-build-and-fan-out invariant the settle-
+  time primary path holds (Tool-Pair §Time-travel §Redaction hook,
+  Security.md §Epoch privacy posture). Pre-fix the raw appended slots
+  reached both egress channels (ring-read: `epoch-history` / MCP
+  `read-recording` / `restore-epoch`; and the listener fan-out) bypassing
+  the `:redact-fn`. `redact` defaults to `identity` for callers / tests
+  that need the bare raw append. The fn is idempotent for the
+  `:rf/redacted` sentinel pattern, so re-applying it to the record's
+  already-settle-redacted slots is a no-op while the newly-appended slots
+  get scrubbed.
+
   The `swap!` update fn is PURE — it mutates only the history map and
   smuggles nothing out (the prior shape `reset!`'d a local out-param atom
   from inside the swap fn, a side-effecting-swap-fn that is unsound under
-  CAS retry). The record index is resolved once up-front (within-frame
-  drain is single-threaded — Spec 002 §Run-to-completion — so no append
-  can shift it between this deref and the swap), reused by both the pure
-  swap and the post-swap read. nil when the epoch is absent from the ring
-  (evicted, or fired before any cascade settled)."
-  [frame-id epoch-id slot event row]
-  (let [idx (epoch-index (history-for frame-id) epoch-id)]
-    (when idx
-      (let [append (fn [record]
-                     (cond-> record
-                       (contains? record :trace-events)
-                       (update :trace-events (fnil conj []) event)
-                       (some? row)
-                       (update slot (fnil conj []) row)))]
-        (-> (swap! histories update-in [frame-id idx] append)
-            (get-in [frame-id idx]))))))
+  CAS retry). `redact` is the only injected fn it calls; `maybe-redact`
+  is itself pure (record-in, record-out; a throwing `:redact-fn` is
+  caught there and falls back to the unredacted record), so the swap fn
+  stays retry-safe. The record index is resolved once up-front (within-
+  frame drain is single-threaded — Spec 002 §Run-to-completion — so no
+  append can shift it between this deref and the swap), reused by both the
+  pure swap and the post-swap read. nil when the epoch is absent from the
+  ring (evicted, or fired before any cascade settled)."
+  ([frame-id epoch-id slot event row]
+   (back-fill-event! frame-id epoch-id slot event row identity))
+  ([frame-id epoch-id slot event row redact]
+   (let [idx (epoch-index (history-for frame-id) epoch-id)]
+     (when idx
+       (let [append (fn [record]
+                      (-> (cond-> record
+                            (contains? record :trace-events)
+                            (update :trace-events (fnil conj []) event)
+                            (some? row)
+                            (update slot (fnil conj []) row))
+                          redact))]
+         (-> (swap! histories update-in [frame-id idx] append)
+             (get-in [frame-id idx])))))))
 
 (defn back-fill-render!
   "Back-fill `render-event` and its projected `:renders` `render-row`
   into the already-committed epoch `epoch-id` for `frame-id` (rf2-qs6dl).
-  Thin wrapper over `back-fill-event!` pinning the `:renders` slot."
-  [frame-id epoch-id render-event render-row]
-  (back-fill-event! frame-id epoch-id :renders render-event render-row))
+  Thin wrapper over `back-fill-event!` pinning the `:renders` slot.
+  `redact` (rf2-82pcg) is run over the appended record before it lands in
+  the ring / is returned for the listener re-fan; defaults to `identity`."
+  ([frame-id epoch-id render-event render-row]
+   (back-fill-render! frame-id epoch-id render-event render-row identity))
+  ([frame-id epoch-id render-event render-row redact]
+   (back-fill-event! frame-id epoch-id :renders render-event render-row redact)))
 
 (defn back-fill-sub-run!
   "Back-fill `sub-event` and its projected `:sub-runs` `sub-run-row` into
   the already-committed epoch `epoch-id` for `frame-id` (rf2-wi900). Thin
   wrapper over `back-fill-event!` pinning the `:sub-runs` slot. Symmetric
-  with `back-fill-render!`."
-  [frame-id epoch-id sub-event sub-run-row]
-  (back-fill-event! frame-id epoch-id :sub-runs sub-event sub-run-row))
+  with `back-fill-render!`. `redact` (rf2-82pcg) is run over the appended
+  record before it lands in the ring / is returned; defaults to `identity`."
+  ([frame-id epoch-id sub-event sub-run-row]
+   (back-fill-sub-run! frame-id epoch-id sub-event sub-run-row identity))
+  ([frame-id epoch-id sub-event sub-run-row redact]
+   (back-fill-event! frame-id epoch-id :sub-runs sub-event sub-run-row redact)))
 
 (defn back-fill-unmount!
   "Back-fill a `:rf.view/unmounted` `unmount-event` into the already-
@@ -619,9 +650,13 @@
   VIEWS-step `unmounted-views-rows` reads view teardowns. The `:slot`
   argument is irrelevant when `row` is nil; `:renders` is passed for
   documentary parity with the render sibling. Symmetric with
-  `back-fill-render!` / `back-fill-sub-run!`."
-  [frame-id epoch-id unmount-event]
-  (back-fill-event! frame-id epoch-id :renders unmount-event nil))
+  `back-fill-render!` / `back-fill-sub-run!`. `redact` (rf2-82pcg) is run
+  over the appended record before it lands in the ring / is returned;
+  defaults to `identity`."
+  ([frame-id epoch-id unmount-event]
+   (back-fill-unmount! frame-id epoch-id unmount-event identity))
+  ([frame-id epoch-id unmount-event redact]
+   (back-fill-event! frame-id epoch-id :renders unmount-event nil redact)))
 
 ;; ---- per-cascade capture buffer -------------------------------------------
 ;;

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -507,3 +507,259 @@
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (let [r (last-record :test/main)]
       (is (= {:n 0} (:db-after r))))))
+
+;; ============================================================================
+;;  Invariant 6 — post-settle back-fill re-notify honours :redact-fn (rf2-82pcg)
+;; ============================================================================
+;;
+;; THE LEAK (rf2-82pcg). The settle-time primary path runs `maybe-redact`
+;; ONCE between `build-record` and ring-append / listener fan-out, so the
+;; ring + every listener see the SAME redacted shape (invariant 2 above).
+;; But a post-settle render / sub-run / unmount (React commit / deref /
+;; teardown time, AFTER settle already committed + redacted the epoch) is
+;; back-filled into the already-committed record — `back-fill-*!` appended
+;; the RAW trace event into `:trace-events` + the RAW projected row into
+;; `:renders` / `:sub-runs`, then re-notified listeners — pre-fix WITHOUT
+;; re-running the installed `:redact-fn`. So a value an app scrubs via
+;; `:redact-fn` (but does NOT declare via schema marks — marks-declared
+;; data is redacted UPSTREAM at trace build time) reappeared, unredacted,
+;; in the back-filled slots on BOTH egress channels: the listener re-fan
+;; (push) AND the ring read (`epoch-history` / MCP `read-recording` /
+;; `restore-epoch` — pull).
+;;
+;; THE FIX runs `maybe-redact` over the back-filled record before it lands
+;; in the ring / re-fans to listeners, restoring the settle-time invariant
+;; for the post-settle async classes. These tests pin: (a) a sensitive
+;; value in a back-filled trace-event / sub-run row is REDACTED in the
+;; re-notified record AND in the ring; (b) a non-sensitive value passes
+;; through unchanged (no over-redaction regression — the redact-fn is the
+;; AI/MCP-egress boundary; this fix must close the leak without scrubbing
+;; benign data).
+;;
+;; POST-SETTLE-EMIT TECHNIQUE (mirrors epoch_attribution_test): emit the
+;; trace the substrate's way — op carrying its `:frame` tag, fired OUTSIDE
+;; any cascade (empty in-flight buffer, no `*handler-scope*`) — so the
+;; runtime's back-fill (`record-render!` / `record-sub-run!` /
+;; `record-unmount!`) routes it into the causing cascade's committed record.
+
+(defn- emit-render! [frame-id view-id]
+  (trace/emit! :rf.view :rf.view/rendered
+               {:rf.view/render-key [view-id 0]
+                :frame              frame-id}))
+
+(defn- emit-sub-run! [frame-id sub-id prev-value value]
+  (trace/emit! :rf.sub :rf.sub/run
+               {:rf.sub/id             sub-id
+                :rf.sub/query-v        [sub-id]
+                :frame                 frame-id
+                :rf.sub/value-changed? (not= prev-value value)
+                :rf.sub/prev-value     prev-value
+                :rf.sub/value          value
+                :rf.sub/cascade?       false
+                :rf.sub/cause-sub      nil}))
+
+(defn- emit-unmount! [frame-id view-id]
+  (trace/emit! :rf.view :rf.view/unmounted
+               {:rf.view/id         view-id
+                :rf.view/render-key [view-id 0]
+                :frame              frame-id}))
+
+;; A redact-fn that scrubs a value the app deems sensitive ANYWHERE it
+;; appears in a back-filled slot — the trace-event tags and the sub-run
+;; row both carry the value into the record post-back-fill. This models a
+;; redact-fn-only redaction (NOT schema-mark-declared), which is exactly
+;; the narrow class the leak bit. It walks `:trace-events` (scrubbing the
+;; sentinel tag on each event) and the `:sub-runs` rows (scrubbing the
+;; `:rf.sub/value` slot), and is idempotent: re-applying it to an
+;; already-scrubbed record is a no-op (the marker is already `:rf/redacted`).
+(def ^:private secret "topsecret-not-schema-declared")
+
+(defn- scrub-secret [v]
+  (if (= v secret) :rf/redacted v))
+
+(defn- redact-back-filled-secrets [r]
+  (cond-> r
+    ;; `:trace-events` entries carry the supplied tags under `:tags`
+    ;; (per `re-frame.trace/emit!` envelope assembly). Scrub the two
+    ;; tag slots the post-settle emits route the secret through: the
+    ;; render/unmount `:rf.view/secret` tag and the sub-run
+    ;; `:rf.sub/value` tag.
+    (vector? (:trace-events r))
+    (update :trace-events
+            (fn [evs]
+              (mapv (fn [ev]
+                      (cond-> ev
+                        (contains? (:tags ev) :rf.view/secret)
+                        (update-in [:tags :rf.view/secret] scrub-secret)
+                        (contains? (:tags ev) :rf.sub/value)
+                        (update-in [:tags :rf.sub/value] scrub-secret)))
+                    evs)))
+    ;; The structured `:sub-runs` projection row carries the value at
+    ;; top-level `:value` (per `capture/sub-run-row`).
+    (vector? (:sub-runs r))
+    (update :sub-runs
+            (fn [rows]
+              (mapv #(update % :value scrub-secret) rows)))))
+
+(deftest inv-6-back-fill-sub-run-redacts-appended-value
+  (testing "rf2-82pcg — a post-settle SUB-RUN back-fill carrying a
+            redact-fn-only sensitive value in its appended :sub-runs row is
+            REDACTED in BOTH the re-notified listener record AND the ring
+            (epoch-history / MCP / restore-epoch egress). Pre-fix the raw
+            value leaked on both channels."
+    (rf/reg-frame :test/main {})
+    (rf/configure! :epoch-history {:redact-fn redact-back-filled-secrets})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watch (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+      (let [settle-fanouts (count @seen)]
+        ;; Post-settle reactive recompute: the :secret sub's value is the
+        ;; app's sensitive payload (NOT a schema-declared mark).
+        (emit-sub-run! :test/main :secret nil secret)
+        (is (= (inc settle-fanouts) (count @seen))
+            "the back-fill re-notified exactly once")
+        (let [renotified  (last @seen)
+              sub-run      (->> (:sub-runs renotified)
+                                (filter #(= :secret (:sub-id %))) first)
+              raw-in-trace (some #(= secret (get-in % [:tags :rf.sub/value]))
+                                 (:trace-events renotified))]
+          ;; PUSH egress (listener re-fan) is redacted.
+          (is (some? sub-run) "the back-filled :secret sub-run is present")
+          (is (= :rf/redacted (:value sub-run))
+              "the re-notified :sub-runs row's value is REDACTED, not the
+               raw secret — the leak is closed on the push channel")
+          (is (not raw-in-trace)
+              "the raw secret does not survive in the re-notified
+               :trace-events either")
+          ;; PULL egress (ring read) is the SAME redacted shape.
+          (let [ring (last-record :test/main)]
+            (is (= renotified ring)
+                "ring and listener hold the SAME redacted shape — the
+                 settle-time invariant is restored for the back-fill path")
+            (is (= :rf/redacted
+                   (:value (->> (:sub-runs ring)
+                                (filter #(= :secret (:sub-id %))) first)))
+                "the ring's back-filled :sub-runs row is REDACTED — no leak
+                 on the epoch-history / MCP / restore-epoch pull egress")))))))
+
+(deftest inv-6-back-fill-render-redacts-appended-trace-event
+  (testing "rf2-82pcg — a post-settle RENDER back-fill carrying a sensitive
+            value in its appended :trace-events tag is REDACTED in the
+            re-notified record + the ring."
+    (rf/reg-frame :test/main {})
+    (rf/configure! :epoch-history {:redact-fn redact-back-filled-secrets})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watch (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+      ;; Post-settle render whose trace tags carry the sensitive value.
+      (trace/emit! :rf.view :rf.view/rendered
+                   {:rf.view/render-key [:secret-view 0]
+                    :rf.view/secret     secret
+                    :frame              :test/main})
+      (let [renotified (last @seen)
+            secret-evs (->> (:trace-events renotified)
+                            (filter #(contains? (:tags %) :rf.view/secret)))]
+        (is (seq secret-evs)
+            "the back-filled render trace-event is present")
+        (is (every? #(= :rf/redacted (get-in % [:tags :rf.view/secret]))
+                    secret-evs)
+            "the re-notified :trace-events tag is REDACTED, not the raw
+             secret — the leak is closed for the render back-fill")
+        (is (= renotified (last-record :test/main))
+            "ring and listener hold the SAME redacted shape")))))
+
+(deftest inv-6-back-fill-unmount-redacts-appended-trace-event
+  (testing "rf2-82pcg — a post-settle UNMOUNT back-fill (rides ONLY the
+            :trace-events slot, no structured row) carrying a sensitive
+            value is REDACTED in the re-notified record + the ring. Pins
+            the rf2-59hx3 unmount path through the redaction seam."
+    (rf/reg-frame :test/main {})
+    (rf/configure! :epoch-history {:redact-fn redact-back-filled-secrets})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watch (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+      (let [settle-fanouts (count @seen)]
+        (trace/emit! :rf.view :rf.view/unmounted
+                     {:rf.view/id         :secret-view
+                      :rf.view/render-key [:secret-view 0]
+                      :rf.view/secret     secret
+                      :frame              :test/main})
+        (is (= (inc settle-fanouts) (count @seen))
+            "the unmount back-fill re-notified exactly once")
+        (let [renotified (last @seen)
+              secret-evs (->> (:trace-events renotified)
+                              (filter #(contains? (:tags %) :rf.view/secret)))]
+          (is (seq secret-evs) "the back-filled unmount trace-event is present")
+          (is (every? #(= :rf/redacted (get-in % [:tags :rf.view/secret]))
+                      secret-evs)
+              "the re-notified unmount :trace-events tag is REDACTED")
+          (is (= renotified (last-record :test/main))
+              "ring and listener hold the SAME redacted shape"))))))
+
+(deftest inv-6-back-fill-passes-non-sensitive-value-unchanged
+  (testing "rf2-82pcg — NO over-redaction regression. A back-filled
+            sub-run / render carrying a NON-sensitive value passes through
+            the re-notify redaction UNCHANGED. The redact-fn is the
+            AI/MCP-egress boundary; closing the leak must not start
+            scrubbing benign data."
+    (rf/reg-frame :test/main {})
+    (rf/configure! :epoch-history {:redact-fn redact-back-filled-secrets})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watch (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+      ;; A benign sub-run value — must survive the re-notify redaction.
+      (emit-sub-run! :test/main :counter 0 42)
+      (let [renotified (last @seen)
+            sub-run    (->> (:sub-runs renotified)
+                            (filter #(= :counter (:sub-id %))) first)]
+        (is (some? sub-run) "the benign back-filled sub-run is present")
+        (is (= 42 (:value sub-run))
+            "the non-sensitive value passes through UNCHANGED — no
+             over-redaction")
+        (is (= true (:value-changed? sub-run))
+            "the benign sub-run's value-change attribution survives intact")
+        (is (= renotified (last-record :test/main))
+            "ring and listener still agree")))))
+
+(deftest inv-6-back-fill-no-redact-fn-is-identity-passthrough
+  (testing "rf2-82pcg — with NO :redact-fn installed, the back-fill
+            re-notify path is an identity pass-through (maybe-redact is a
+            no-op) — the rf2-qs6dl/wi900/59hx3 attribution behaviour is
+            byte-for-byte unchanged by the redaction seam."
+    (rf/reg-frame :test/main {})
+    ;; No redact-fn configured (default nil).
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watch (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+      ;; Even the raw secret rides through untouched — no redact-fn means
+      ;; the framework does not scrub (the app opted out; that is the
+      ;; documented default-nil posture).
+      (emit-sub-run! :test/main :secret nil secret)
+      (let [renotified (last @seen)
+            sub-run    (->> (:sub-runs renotified)
+                            (filter #(= :secret (:sub-id %))) first)]
+        (is (= secret (:value sub-run))
+            "no redact-fn — the back-filled value is the RAW shape (the
+             attribution path is unchanged; redaction is opt-in)")
+        (is (= renotified (last-record :test/main))
+            "ring and listener agree on the raw shape")))))


### PR DESCRIPTION
## What

Closes a privacy leak (bead **rf2-82pcg**, P3 BUG): the epoch post-settle back-fill re-notified listeners — and mutated the on-box ring record — with appended `:trace-events` / `:sub-runs` / `:renders` slots that **bypassed the installed `:redact-fn`**. The `:redact-fn` is the AI/MCP-egress privacy boundary, so this was a real (if narrow) leak.

## The leak

The settle-time primary path (`epoch.cljc/commit-record!`) runs `assembly/maybe-redact` **once** between `build-record` and ring-append / listener fan-out, so the ring and every listener see the **same** redacted shape (the documented `:redact-fn`-once invariant — Tool-Pair §Time-travel §Redaction hook, Security.md §Epoch privacy posture).

But a post-settle render / sub-run / unmount (React commit / deref / teardown time, **after** settle committed + redacted the epoch) is back-filled into the already-committed record. `record-render!` / `record-sub-run!` / `record-unmount!` (in `listeners.cljc`) called `state/back-fill-*!`, which appended the **raw** trace event into `:trace-events` + the **raw** projected row into `:renders` / `:sub-runs`, then re-notified listeners — pre-fix **without** re-running `:redact-fn`. So a value an app scrubs via `:redact-fn` (but does **not** declare via schema marks — marks are redacted upstream at trace-build time, so the gap is the redact-fn-only class) reached **both** egress channels unredacted:
- **push** — the listener re-fan (Xray / MCP / `tap>`)
- **pull** — the ring read (`epoch-history` / MCP `read-recording` / `restore-epoch`)

## The fix

Thread the redaction transform (`assembly/maybe-redact`) into `state/back-fill-event!` and run it **inside the swap, after the raw append** — so the redacted record is what lands in the ring **and** what is returned for the re-fan. This restores the redact-fn-once-between-build-and-fan-out invariant for the post-settle async classes, closing **both** egress channels with a single redaction.

- `state.cljc` keeps **no** `assembly` require (the require graph is `assembly → state`; a reverse require would be circular). The redact fn is **injected** by the `listeners.cljc` callers; the back-fill fns default it to `identity` for any other / test caller, so behaviour is unchanged where no fn is threaded.
- `maybe-redact` is pure (record-in / record-out; a throwing `:redact-fn` is caught there and falls back to the unredacted record) and idempotent for the `:rf/redacted` sentinel pattern, so re-applying it to already-settle-redacted slots is a no-op while the newly-appended raw slots get scrubbed. The swap fn stays retry-safe.
- The `:rf.epoch/sensitive?` rollup is **not** disturbed — it is computed in `build-record` at settle time; `maybe-redact` only applies the user fn.

Preserved untouched (only the missing redaction added): the **rf2-59hx3** unmount back-fill, the **rf2-bgapd** per-instance `mount-attribution` prune, and the **rf2-fxowr** stranded-child harvest.

## Tests

`epoch_redact_fn_test` — new **invariant 6** section (post-settle-emit technique mirroring `epoch_attribution_test`):
- a back-filled **sub-run** carrying a redact-fn-only sensitive value is redacted in the re-notified listener record **and** the ring (same shape on both egress channels);
- the **render** and **unmount** back-fills (the latter rides only `:trace-events`) likewise redact the appended slot;
- a **non-sensitive** value passes through unchanged — no over-redaction regression (the redact-fn boundary must close the leak without scrubbing benign data);
- with **no** `:redact-fn` installed the back-fill path is an identity pass-through — the rf2-qs6dl / rf2-wi900 / rf2-59hx3 attribution behaviour is byte-for-byte unchanged.

## Gates (cold, fresh worktree)

- epoch JVM `clojure -M:test` — **256 tests, 966 assertions, 0 failures, 0 errors** (was 251 / 947 before the +5 new tests).
- `npm run test:cljs` — **5589 tests, 19462 assertions, 0 failures, 0 errors**.
