### PR TITLE
fix(mcp-conformance): harden test:mcp-conformance entry-point against command-hijack (rf2-1irs7)

### DIFF
--- a/implementation/package-lock.json
+++ b/implementation/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-SNAPSHOT",
       "devDependencies": {
         "@xyflow/react": "12.4.2",
+        "cross-spawn": "^7.0.6",
         "elkjs": "^0.11.1",
         "http-server": "14.1.1",
         "playwright": "1.59.1",
@@ -285,6 +286,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/d3-color": {
@@ -788,6 +827,16 @@
         "opener": "bin/opener-bin.js"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
@@ -949,6 +998,29 @@
       "integrity": "sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -5,6 +5,7 @@
   "description": "CLJS test target for re-frame2 (node-runtime).",
   "devDependencies": {
     "@xyflow/react": "12.4.2",
+    "cross-spawn": "^7.0.6",
     "elkjs": "^0.11.1",
     "http-server": "14.1.1",
     "playwright": "1.59.1",

--- a/implementation/scripts/test-mcp-conformance.cjs
+++ b/implementation/scripts/test-mcp-conformance.cjs
@@ -44,7 +44,6 @@
 'use strict';
 
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 
 const HERE = __dirname;
 const IMPL_ROOT = path.resolve(HERE, '..');
@@ -56,27 +55,72 @@ const PAIR_MCP = path.join(TOOLS, 're-frame2-pair-mcp');
 const CONFORMANCE = path.join(TOOLS, 'mcp-conformance');
 const WIRE_VOCAB = path.join(CONFORMANCE, 'wire-vocab');
 
-// `clojure` and `npm`/`npx` are resolved via PATH on Windows as `.cmd`
-// shims and on POSIX as plain binaries. `shell: true` lets the OS shell
-// do that resolution for us so the same `command` string works
-// cross-platform without per-platform branching.
+// ---------------------------------------------------------------------
+// Exec-safety: no `shell: true`, no bare-name spawns (rf2-1irs7).
+//
+// The original form spawned every step with
+// `spawnSync(bareCommandString, { shell: true, cwd })`. On Windows that
+// is the rf2-33vvc command-hijack accident class: `shell: true` + a
+// bare exe name (`npm`/`npx`/`clojure`) + a repo-controlled `cwd`
+// resolves against the cwd ahead of PATH, so a checkout that ever
+// carried a `npm.cmd` / `npx.cmd` / `clojure.cmd` in one of these dirs
+// (a fixture dir, anywhere in PATHEXT order) would silently execute it.
+//
+// The mcp-conformance slice already SOLVED this for its inner spawn
+// sites (`tools/mcp-conformance/test/end-to-end-story.cjs`,
+// `scripts/run-live-...-hermetic.cjs`): resolve each tool name to a
+// single trusted absolute path OUTSIDE the workspace via
+// `resolveTrustedExe`, then spawn with an args ARRAY and NO shell. We
+// reuse that exact primitive here rather than hand-roll a second one.
+//
+// `cross-spawn` (the slice's own spawn helper) is the cross-platform
+// piece: given the trusted absolute path `resolveTrustedExe` returns —
+// on Windows that is typically the extensionless `npm`/`npx` shim under
+// the Node install dir, NOT the `.cmd` — Node's built-in `spawnSync`
+// with `shell: false` fails (ENOENT on the shim; EINVAL on a `.cmd`
+// since the CVE-2024-27980 fix). `cross-spawn` reads the shebang /
+// dispatches the `.cmd` correctly without re-introducing the shell, so
+// `resolveTrustedExe` + `cross-spawn` is the only combination that is
+// both hardened and cross-platform (Windows / macOS / Linux).
+const crossSpawn = require('cross-spawn');
+const { resolveTrustedExe } = require(
+  path.join(CONFORMANCE, 'lib', 'exec-safety.cjs'),
+);
+
+// Cache one resolution per tool name; the lookup walks PATH + PATHEXT
+// and is identical for every step that uses the same tool.
+const TRUSTED_EXE_CACHE = new Map();
+function trustedExe(name) {
+  if (TRUSTED_EXE_CACHE.has(name)) return TRUSTED_EXE_CACHE.get(name);
+  const resolved = resolveTrustedExe(name, { workspaceRoot: REPO_ROOT });
+  TRUSTED_EXE_CACHE.set(name, resolved);
+  return resolved;
+}
+
+// `node` steps use `process.execPath` — always an absolute path,
+// always the currently-running Node, always outside the workspace by
+// construction — so they skip the PATH walk entirely (the same posture
+// the slice's `scripts/test-all.cjs` uses for its own node sub-tests).
 const STEPS = [
   // ---- prep ----
   {
     name: 'install tools/re-frame2-pair-mcp deps',
-    command: 'npm install',
+    exe: 'npm',
+    args: ['install'],
     cwd: PAIR_MCP,
     prep: true,
   },
   {
     name: 'compile re-frame2-pair-mcp server bundle (shadow-cljs :server)',
-    command: 'npx shadow-cljs compile server',
+    exe: 'npx',
+    args: ['shadow-cljs', 'compile', 'server'],
     cwd: PAIR_MCP,
     prep: true,
   },
   {
     name: 'install tools/mcp-conformance deps',
-    command: 'npm install',
+    exe: 'npm',
+    args: ['install'],
     cwd: CONFORMANCE,
     prep: true,
   },
@@ -84,22 +128,26 @@ const STEPS = [
   // ---- the six gates ----
   {
     name: '[1/6] JVM tools/story-mcp (clojure -M:test)',
-    command: 'clojure -M:test',
+    exe: 'clojure',
+    args: ['-M:test'],
     cwd: STORY_MCP,
   },
   {
     name: '[2/6] Node tools/story-mcp stdio roundtrip (rf2-h8z5l)',
-    command: 'node test/stdio-roundtrip.js',
+    node: true,
+    args: ['test/stdio-roundtrip.js'],
     cwd: STORY_MCP,
   },
   {
     name: '[3/6] Node tools/re-frame2-pair-mcp (shadow-cljs :server-test)',
-    command: 'npm test',
+    exe: 'npm',
+    args: ['test'],
     cwd: PAIR_MCP,
   },
   {
     name: '[4+5/6] MCP conformance tools/re-frame2-pair-mcp + tools/story-mcp (rf2-cum40)',
-    command: 'node scripts/test-all.cjs',
+    node: true,
+    args: ['scripts/test-all.cjs'],
     cwd: CONFORMANCE,
     // tools/mcp-conformance/npm test == node scripts/test-all.cjs;
     // it covers BOTH gates [4] (re-frame2-pair-mcp end-to-end + live-*
@@ -111,7 +159,8 @@ const STEPS = [
   },
   {
     name: '[6/6] MCP conformance wire-vocab (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)',
-    command: 'clojure -M:test',
+    exe: 'clojure',
+    args: ['-M:test'],
     cwd: WIRE_VOCAB,
   },
 ];
@@ -125,11 +174,25 @@ const results = [];
 let firstFailure = null;
 
 for (const step of STEPS) {
-  banner('▶ ' + step.name + '\n  cwd: ' + step.cwd + '\n  cmd: ' + step.command);
-  const child = spawnSync(step.command, {
+  // Resolve the executable up-front: `node` steps use the absolute
+  // `process.execPath`; native-tool steps resolve their bare name to a
+  // trusted absolute path outside the workspace (rf2-1irs7 / rf2-33vvc).
+  const exe = step.node ? process.execPath : trustedExe(step.exe);
+  banner(
+    '▶ ' + step.name +
+      '\n  cwd: ' + step.cwd +
+      '\n  exe: ' + exe +
+      '\n  args: ' + step.args.join(' '),
+  );
+  // `cross-spawn` + args ARRAY + NO `shell`: the resolved absolute path
+  // is the only thing the OS interprets, so a workspace-local
+  // `npm.cmd` / `npx.cmd` / `clojure.cmd` can no longer hijack the
+  // invocation (rf2-1irs7). cross-spawn handles the Windows `.cmd` /
+  // extensionless-shim dispatch that built-in `spawnSync` can't under
+  // `shell: false`.
+  const child = crossSpawn.sync(exe, step.args, {
     cwd: step.cwd,
     stdio: 'inherit',
-    shell: true,
     env: process.env,
   });
   const status = child.status === null ? 'signal:' + child.signal : child.status;


### PR DESCRIPTION
## What

Hardens the `npm run test:mcp-conformance` entry-point (`implementation/scripts/test-mcp-conformance.cjs`) against the **rf2-33vvc command-hijack accident class** — the exact property the mcp-conformance slice's own exec-safety lib (`resolveTrustedExe`) gates against at its inner spawn sites.

Authoritative bead: **rf2-1irs7** (P2, RISK — accident-gating regression; from the mcp-conformance senior-dev review rf2-v0xlh).

## The finding

The entry-point (added in rf2-gt4pf / #2389) spawned every step with:

```js
spawnSync(bareCommandString, { shell: true, cwd: step.cwd })
```

where `step.command` is a bare string (`"npm install"`, `"npx shadow-cljs compile server"`, `"clojure -M:test"`) and `cwd` is a repo-controlled dir. On Windows, `shell: true` + a bare exe name + a repo-controlled `cwd` resolves the command against the cwd **ahead of PATH** (PATHEXT order). A checkout that ever carried a `npm.cmd` / `npx.cmd` / `clojure.cmd` in one of those dirs would silently execute it. A reviewer reading the slice would reasonably assume the accident is gated everywhere — it wasn't on the operator's primary command.

## The fix (reuses the slice's existing primitive — no new one hand-rolled)

- Resolve each native tool (`npm` / `npx` / `clojure`) to a **trusted absolute path outside the workspace** via `resolveTrustedExe` from `tools/mcp-conformance/lib/exec-safety.cjs` (read-only require; lib unchanged).
- Spawn via **`cross-spawn`** with an **args ARRAY** and **NO `shell`**. `cross-spawn` is required because `resolveTrustedExe` returns the extensionless `npm`/`npx` shim on Windows, which built-in `spawnSync` cannot dispatch under `shell:false` (and a `.cmd` path throws EINVAL since the CVE-2024-27980 fix); `cross-spawn` handles the `.cmd` / shim dispatch cross-platform — this is the exact `resolveTrustedExe` + `cross-spawn` pattern the slice's `runTrusted` / hermetic runner already use.
- `node` steps use `process.execPath` (absolute by construction; no PATH walk — same posture as the slice's `scripts/test-all.cjs`).
- Add `cross-spawn ^7.0.6` (the slice's version) as an `implementation` devDependency so it resolves from the `implementation/` entry-point.

## Verification

- **End-to-end green**: `npm run test:mcp-conformance` passes all six gates (re-run exit 0). Every step now logs a resolved absolute exe path (e.g. `C:\Program Files\nodejs\npm`, `...\clojure\clojure.EXE`) instead of a shell command string.
- **Cross-platform**: `resolveTrustedExe`'s PATHEXT walk + `cross-spawn`'s `.cmd`/shim dispatch cover Windows; on POSIX both resolve to plain binaries. Verified on Windows (the reporter's platform).
- No `shell: true` remains; all args are arrays. No new-file leaks; lockfile delta is `cross-spawn` + its 5 transitive deps only.

Closes rf2-1irs7.