### PR TITLE
fix(xray): frame-scope app-db-diff caches + hot-reload-safe keybinding detach (rf2-nfgps + rf2-t2o6o)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -91,8 +91,21 @@ derives a changed-paths set via the canonical Editscript-A* engine
 
 The framework's `:rf/epoch-record` does **not** pre-compute changed
 paths (the runtime stays cheap); Xray runs the diff on the panel's
-first mount per epoch, caches per `:epoch-id`, and discards on epoch
-age-out.
+first mount per epoch, caches per `[frame-id epoch-id]`, and discards
+on epoch age-out.
+
+> **rf2-nfgps — frame-scoped cache key.** The per-epoch caches key on
+> the COMPOUND `[frame-id epoch-id]`, never `:epoch-id` alone. The
+> framework's epoch contract guarantees `:epoch-id` is unique only
+> WITHIN a frame's history (the global-counter scheme that makes ids
+> incidentally process-unique today is an implementation detail, not a
+> spec promise). In a multi-frame app two frames can carry the same
+> `:epoch-id`; an id-only key would let one frame read another frame's
+> cached diff, and a frame-switch prune would evict a sibling frame's
+> live entries. Compounding `frame-id` keeps each frame's cache
+> isolated (no read-bleed, no cross-frame eviction), and the prune ages
+> out only the observed frame's stale keys — upholding the
+> frame-isolation invariant (frames are isolated contexts).
 
 > **rf2-xuyac migration** (2026-05-27): the App-DB panel + Epoch
 > HANDLER `:db` `:diff` lenses previously routed through the
@@ -560,8 +573,9 @@ faster than re-reading the source.
 
 ## Performance
 
-- **Diff caching** per `:epoch-id`. A second render of the same epoch
-  is O(1).
+- **Diff caching** per `[frame-id epoch-id]` (rf2-nfgps — frame-scoped
+  so two frames with overlapping epoch-ids never collide; see §Diff
+  engine). A second render of the same epoch is O(1).
 - **Slice virtualisation** for slices whose `after` value is large
   (e.g., a 10k-entry vector). The slice mini-panel renders the head
   and tail, with a `… 9970 entries …` ellipsis; click expands.

--- a/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
@@ -9,6 +9,19 @@
   twice per key press. We hold the attached fn under a `defonce`
   sentinel and skip re-attach when the sentinel is already set.
 
+  ## Hot-reload-safe detach (rf2-t2o6o)
+
+  `add`/`removeEventListener` compare listeners by reference, and
+  `handle-keydown` is a `defn` — shadow-cljs `:after-load` recompiles
+  it to a fresh fn object. So `attach!` stashes the EXACT fn it hands
+  to `addEventListener` under a `defonce` atom (`attached-fn`), and
+  `detach!` removes that stored reference. Without the stash, a
+  `detach!` referencing the bare `handle-keydown` var after a reload
+  would `removeEventListener` a fn that was never added — silently
+  leaking the original listener (the embed-host detach-after-reload
+  hazard rf2-4eyik / rf2-q7who set out to close). Mirrors the
+  `mount.cljs` unmount-fn stash.
+
   ## OS conventions
 
   Ctrl+Shift+C is the agreed shortcut on every host OS. macOS users
@@ -65,6 +78,27 @@
   ;; predicate can keep the user-facing `attached?` name without
   ;; shadowing.
   (atom false))
+
+(defonce ^:private attached-fn
+  ;; rf2-t2o6o — the EXACT fn object handed to `addEventListener`, stashed
+  ;; under a `defonce` atom so `detach!` removes the same reference that
+  ;; `attach!` added.
+  ;;
+  ;; `add`/`removeEventListener` compare listeners by reference.
+  ;; `handle-keydown` is a `defn`, so shadow-cljs `:after-load`
+  ;; recompiles it to a NEW fn object. The `defonce attached-state`
+  ;; sentinel correctly keeps `attach!` a no-op across reloads (the
+  ;; ORIGINAL closure stays bound — no double-attach), but a `detach!`
+  ;; that referenced the bare `handle-keydown` var would pass the
+  ;; freshly-recompiled object — never the one actually attached — so
+  ;; `removeEventListener` would silently match nothing and leak the
+  ;; original listener (the embed-host detach-after-reload hazard).
+  ;;
+  ;; Stashing the attached fn here (mirroring mount.cljs's unmount-fn
+  ;; stash) makes attach/detach reference-stable across reloads: detach
+  ;; always removes precisely what attach installed. nil when nothing is
+  ;; attached.
+  (atom nil))
 
 (defn- ctrl-shift-key?
   "True when `event` is a Ctrl+Shift keydown (no Meta, no Alt) whose
@@ -165,8 +199,10 @@
       (or (= tag "INPUT")
           (= tag "TEXTAREA")
           (= tag "SELECT")
-          (and (.-isContentEditable target)
-               (boolean (.-isContentEditable target)))))))
+          ;; rf2-t2o6o tidy — the prior `(and (.-isContentEditable t)
+          ;; (boolean (.-isContentEditable t)))` double-read was dead;
+          ;; one coerced read carries the same truth value.
+          (boolean (.-isContentEditable target))))))
 
 (defn- target-inside-modal?
   "True when `event.target` is a DOM node inside one of Xray's modal
@@ -295,7 +331,12 @@
   (when (and (exists? js/document)
              (config/keybinding-attach-enabled?)
              (compare-and-set! attached-state false true))
-    (.addEventListener js/document "keydown" handle-keydown true))
+    ;; rf2-t2o6o — capture the EXACT fn we hand to addEventListener so
+    ;; detach! can remove this same object even after a hot reload
+    ;; rebinds the `handle-keydown` var to a fresh fn.
+    (let [f handle-keydown]
+      (reset! attached-fn f)
+      (.addEventListener js/document "keydown" f true)))
   nil)
 
 (defn detach!
@@ -315,7 +356,14 @@
   []
   (when (and (exists? js/document)
              (compare-and-set! attached-state true false))
-    (.removeEventListener js/document "keydown" handle-keydown true))
+    ;; rf2-t2o6o — remove the EXACT fn attach! stored, not the (possibly
+    ;; hot-reloaded) `handle-keydown` var. Falling back to the var keeps
+    ;; the call safe if the stash is somehow empty while the sentinel is
+    ;; true (defensive; the CAS above guarantees we only reach here when
+    ;; attach! ran and set the stash).
+    (let [f (or @attached-fn handle-keydown)]
+      (.removeEventListener js/document "keydown" f true)
+      (reset! attached-fn nil)))
   nil)
 
 (defn attached?

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -46,29 +46,82 @@
     (some (fn [r] (when (= epoch-id (:epoch-id r)) r))
           history)))
 
+;; ---- rf2-nfgps — frame-scoped cache keying --------------------------------
+;;
+;; The three per-epoch caches below are keyed by `[frame-id epoch-id]`,
+;; NOT by `:epoch-id` alone. The framework's epoch contract
+;; (`re-frame.epoch/:epoch-id`) guarantees epoch-ids are unique only
+;; WITHIN a frame's history — the global-counter scheme that makes them
+;; incidentally process-unique today is an implementation detail the
+;; spec does not promise. A future per-frame-reset or per-frame-UUID
+;; scheme would let frame A's epoch 5 collide with frame B's epoch 5 in
+;; these global atoms (one frame reading the other's cached diff during
+;; the window before the per-frame prune runs), and a frame-switch prune
+;; keyed on `:epoch-id` alone would evict the other frame's live entries.
+;; Compounding `frame-id` into the key keeps every frame's cache
+;; isolated — no cross-frame read-bleed, no cross-frame eviction —
+;; upholding the frame-isolation invariant (frames are isolated
+;; contexts). The prune (`prune-cache` below) ages out only THIS frame's
+;; stale `[frame-id epoch-id]` entries while leaving every OTHER frame's
+;; entries untouched — a frame switch must never evict a sibling frame's
+;; live cache (the cross-frame-eviction half of the rf2-nfgps bug).
+(defn- cache-key
+  "Compound cache key `[frame-id epoch-id]` for the per-epoch caches.
+  Frame-scoping is what keeps two frames with overlapping epoch-ids from
+  colliding in the process-global cache atoms (rf2-nfgps)."
+  [frame-id epoch-id]
+  [frame-id epoch-id])
+
+(defn- live-cache-keys
+  "The set of `[frame-id epoch-id]` keys still live in the OBSERVED
+  frame's history — the live keyspace for that frame. Computed against
+  the observed frame's own ring (rf2-nfgps)."
+  [frame-id history]
+  (into #{} (map (fn [r] (cache-key frame-id (:epoch-id r)))) history))
+
+(defn- prune-cache
+  "Return `cache` with stale entries of the OBSERVED `frame-id` aged out,
+  every other frame's entries preserved, and `[frame-id epoch-id]`
+  associated to `value` (rf2-nfgps). An entry survives iff it belongs to
+  a DIFFERENT frame (cross-frame isolation — never evict a sibling
+  frame's cache on a frame switch) OR is still live in THIS frame's
+  history (the `live` set). The freshly computed entry is always kept."
+  [cache frame-id history k value]
+  (let [live (live-cache-keys frame-id history)
+        kept (reduce-kv
+               (fn [m [kf _ke :as ck] v]
+                 (if (or (not= kf frame-id) (contains? live ck))
+                   (assoc m ck v)
+                   m))
+               {}
+               cache)]
+    (assoc kept k value)))
+
 (defonce diff-cache
-  ;; Per-`:epoch-id` cache for the diff triples computed by the
-  ;; `:rf.xray/selected-epoch-diff` sub. Tests reset this atom
-  ;; between cases; production callers should only write via the sub.
+  ;; Per-`[frame-id epoch-id]` cache for the diff triples computed by the
+  ;; `:rf.xray/selected-epoch-diff` sub (frame-scoped per rf2-nfgps —
+  ;; see the keying note above). Tests reset this atom between cases;
+  ;; production callers should only write via the sub.
   (atom {}))
 
 (defonce redacted-modified-cache
-  ;; Per-`:epoch-id` cache for the redacted-paths-modified count
-  ;; computed by `:rf.xray/selected-epoch-redacted-modified-count`
-  ;; (rf2-bz1cl). Same caching contract as `diff-cache` above — the
-  ;; walk is bounded by `count-redacted-modified-paths`' structural-
-  ;; sharing short-circuit but cascades replay the same db-before /
-  ;; db-after pair across the inspector's life, so caching the
-  ;; final integer is still cheap insurance. Tests reset this atom
-  ;; between cases.
+  ;; Per-`[frame-id epoch-id]` cache for the redacted-paths-modified
+  ;; count computed by `:rf.xray/selected-epoch-redacted-modified-count`
+  ;; (rf2-bz1cl; frame-scoped per rf2-nfgps). Same caching contract as
+  ;; `diff-cache` above — the walk is bounded by
+  ;; `count-redacted-modified-paths`' structural-sharing short-circuit
+  ;; but cascades replay the same db-before / db-after pair across the
+  ;; inspector's life, so caching the final integer is still cheap
+  ;; insurance. Tests reset this atom between cases.
   (atom {}))
 
 (defonce flow-writes-cache
-  ;; Per-`:epoch-id` cache for the flow-writes projection computed by
-  ;; `:rf.xray/selected-epoch-flow-writes` (rf2-s8r6c). Mirrors
-  ;; `diff-cache`'s contract — the walk over `:trace-events` is O(N)
-  ;; in trace count, and cascades replay the same record across the
-  ;; inspector's life. Tests reset this atom between cases.
+  ;; Per-`[frame-id epoch-id]` cache for the flow-writes projection
+  ;; computed by `:rf.xray/selected-epoch-flow-writes` (rf2-s8r6c;
+  ;; frame-scoped per rf2-nfgps). Mirrors `diff-cache`'s contract — the
+  ;; walk over `:trace-events` is O(N) in trace count, and cascades
+  ;; replay the same record across the inspector's life. Tests reset
+  ;; this atom between cases.
   (atom {}))
 
 (defn install!
@@ -145,13 +198,17 @@
   (rf/reg-sub :rf.xray/selected-epoch-diff
     :<- [:rf.xray/epoch-history]
     :<- [:rf.xray/focus-epoch-id]
-    (fn [[history selected-id] _query]
+    :<- [:rf.xray/observed-frame]
+    (fn [[history selected-id frame-id] _query]
       (let [record (or (when selected-id
                          (find-epoch-in-history history selected-id))
                        (peek history))]
         (when record
           (let [epoch-id (:epoch-id record)
-                cached   (get @diff-cache epoch-id ::miss)]
+                ;; rf2-nfgps — frame-scoped key so two frames whose
+                ;; epoch-ids overlap can never read each other's diff.
+                k        (cache-key frame-id epoch-id)
+                cached   (get @diff-cache k ::miss)]
             (if (not= ::miss cached)
               cached
               (let [proj (diff-engine/project (:db-before record)
@@ -162,13 +219,10 @@
                     ;; epochs read with per-key granularity at every
                     ;; lens (`:diff`, `:full-with-diff`, container
                     ;; ops). No post-processor needed here.
-                    diff (flat-rows->triples (:flat-rows proj))
-                    live (into #{} (map :epoch-id) history)]
-                (swap! diff-cache
-                       (fn [m]
-                         (-> m
-                             (select-keys live)
-                             (assoc epoch-id diff))))
+                    diff (flat-rows->triples (:flat-rows proj))]
+                ;; rf2-nfgps — prune only THIS frame's stale keys; every
+                ;; other frame's cache survives the swap.
+                (swap! diff-cache prune-cache frame-id history k diff)
                 diff)))))))
 
   ;; ---- rf2-bz1cl / rf2-dl3gx — redacted-paths-modified count ----------
@@ -214,13 +268,16 @@
   (rf/reg-sub :rf.xray/selected-epoch-redacted-modified-count
     :<- [:rf.xray/epoch-history]
     :<- [:rf.xray/focus-epoch-id]
-    (fn [[history selected-id] _query]
+    :<- [:rf.xray/observed-frame]
+    (fn [[history selected-id frame-id] _query]
       (let [record (or (when selected-id
                          (find-epoch-in-history history selected-id))
                        (peek history))]
         (if record
           (let [epoch-id (:epoch-id record)
-                cached   (get @redacted-modified-cache epoch-id ::miss)]
+                ;; rf2-nfgps — frame-scoped key (see the keying note above).
+                k        (cache-key frame-id epoch-id)
+                cached   (get @redacted-modified-cache k ::miss)]
             (if (not= ::miss cached)
               cached
               ;; Egress slot wins when present — exact count from the
@@ -231,13 +288,8 @@
                              egress
                              (h/count-redacted-modified-paths
                                (:db-before record)
-                               (:db-after  record)))
-                    live   (into #{} (map :epoch-id) history)]
-                (swap! redacted-modified-cache
-                       (fn [m]
-                         (-> m
-                             (select-keys live)
-                             (assoc epoch-id n))))
+                               (:db-after  record)))]
+                (swap! redacted-modified-cache prune-cache frame-id history k n)
                 n)))
           0))))
 
@@ -255,23 +307,21 @@
   (rf/reg-sub :rf.xray/selected-epoch-flow-writes
     :<- [:rf.xray/epoch-history]
     :<- [:rf.xray/focus-epoch-id]
-    (fn [[history selected-id] _query]
+    :<- [:rf.xray/observed-frame]
+    (fn [[history selected-id frame-id] _query]
       (let [record (or (when selected-id
                          (find-epoch-in-history history selected-id))
                        (peek history))]
         (when record
           (let [epoch-id (:epoch-id record)
-                cached   (get @flow-writes-cache epoch-id ::miss)]
+                ;; rf2-nfgps — frame-scoped key (see the keying note above).
+                k        (cache-key frame-id epoch-id)
+                cached   (get @flow-writes-cache k ::miss)]
             (if (not= ::miss cached)
               cached
               (let [writes (h/flow-writes-from-trace-events
-                             (:trace-events record))
-                    live   (into #{} (map :epoch-id) history)]
-                (swap! flow-writes-cache
-                       (fn [m]
-                         (-> m
-                             (select-keys live)
-                             (assoc epoch-id writes))))
+                             (:trace-events record))]
+                (swap! flow-writes-cache prune-cache frame-id history k writes)
                 writes)))))))
 
   (rf/reg-sub :rf.xray/focused-slice-path

--- a/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
@@ -405,6 +405,52 @@
         (is (= 1 (count @listeners))
             "exactly one listener installed after re-attach")))))
 
+(deftest detach-removes-the-exact-attached-fn-hot-reload-safe
+  (testing "rf2-t2o6o — detach! removes the SAME fn object attach!
+            installed, NOT the (possibly hot-reloaded) handle-keydown
+            var. addEventListener / removeEventListener compare by
+            reference; a shadow-cljs :after-load recompiles
+            handle-keydown to a fresh object, so a detach! that
+            referenced the bare var would removeEventListener a fn that
+            was never added and silently leak the original listener.
+            We prove (a) removing a DIFFERENT fn object — standing in for
+            the recompiled var the bare-var detach! would have passed —
+            does NOT remove the live listener (the leak), and (b)
+            detach! nonetheless drops the listener to zero, which is only
+            possible if it passed the EXACT fn attach! installed."
+    (with-stub-document
+      (fn [{:keys [listeners]}]
+        (keybinding/attach!)
+        (is (= 1 (count @listeners))
+            "attach! installed one listener")
+        ;; Simulate the post-reload divergence: the stub's
+        ;; removeEventListener matches by `identical?`, so removing a
+        ;; DIFFERENT fn object (standing in for the recompiled
+        ;; handle-keydown var the OLD code would have passed) must NOT
+        ;; remove the live listener. This reproduces the exact leak the
+        ;; bare-var detach! caused after :after-load.
+        (let [recompiled-stand-in (fn [_] nil)]
+          (.removeEventListener js/document "keydown" recompiled-stand-in true)
+          (is (= 1 (count @listeners))
+              "removing a fresh (recompiled-like) fn object leaves the
+               real listener intact — the bare-var detach! leak"))
+        ;; detach! removes the stashed object → the listener is gone.
+        ;; This passes ONLY because detach! references the exact fn
+        ;; attach! stored, not the (here-unchanged, but in production
+        ;; recompiled) handle-keydown var.
+        (keybinding/detach!)
+        (is (zero? (count @listeners))
+            "detach! removed the exact attached fn — no leak (rf2-t2o6o)")
+        (is (false? (keybinding/attached?))
+            "sentinel flipped back to false")
+        ;; A subsequent attach!/detach! cycle still round-trips cleanly,
+        ;; proving the stash is reset (no stale fn lingering).
+        (keybinding/attach!)
+        (is (= 1 (count @listeners)))
+        (keybinding/detach!)
+        (is (zero? (count @listeners))
+            "second cycle round-trips — stash cleared on the prior detach!")))))
+
 (deftest detach-on-clean-sentinel-is-safe
   (testing "calling detach! when nothing is attached is a no-op (does
             not throw, does not flip the sentinel below false)"

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cache_isolation_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cache_isolation_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns day8.re-frame2-xray.panels.app-db-diff-cache-isolation-cljs-test
+  "Frame-isolation guard for the App-DB Diff per-epoch caches (rf2-nfgps).
+
+  ## The bug class this catches
+
+  `app-db-diff-subs` holds three process-global `defonce` caches
+  (`diff-cache`, `redacted-modified-cache`, `flow-writes-cache`). Before
+  rf2-nfgps they were keyed by `:epoch-id` ALONE and pruned with
+  `(select-keys live)` where `live` was the CURRENT observed frame's
+  epoch-ids.
+
+  The framework's epoch contract guarantees `:epoch-id` is unique only
+  WITHIN a frame's history — globally-unique epoch-ids are an
+  implementation detail of the current global-counter scheme, NOT a
+  spec promise. So in a multi-frame app two frames can carry the same
+  epoch-id, and an `:epoch-id`-only cache key would:
+
+    1. **Read-bleed** — frame B's read at epoch 5 returns frame A's
+       cached diff (a different frame's data, violating frame isolation).
+    2. **Cross-frame eviction** — a switch to frame B prunes the cache
+       to frame B's epoch-ids, evicting frame A's still-live entries.
+
+  rf2-nfgps keys the caches by `[frame-id epoch-id]` and prunes only the
+  OBSERVED frame's keyspace. This file asserts both isolation halves at
+  the SUB level (the actual write path) plus the pure prune helper.
+
+  ## Why stub source subs (not the full spine chain)
+
+  The unit-under-test is the cache keying inside the three subs. Their
+  three DIRECT inputs are `:rf.xray/epoch-history`,
+  `:rf.xray/focus-epoch-id`, and `:rf.xray/observed-frame` — the latter
+  two the leaf derives from `:rf.xray/focus` + `:rf.xray/target-frame`.
+  We register minimal stub source subs reading controlled app-db slots
+  so we can pin an OVERLAPPING epoch-id (5) across two distinct observed
+  frames deterministically — the precise scenario the global-counter
+  impl never produces today but the contract permits. Driving the deep
+  spine focus-composition chain would auto-assign globally-unique
+  epoch-ids and defeat the test's purpose."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.panels.app-db-diff-subs :as subs]))
+
+;; ---- source-sub + seam stubs --------------------------------------------
+;;
+;; `install!` registers the leaf's own subs (`observed-frame`,
+;; `focus-epoch-id`, the three cached subs, …) but NOT the cross-ns
+;; source subs it depends on (`epoch-history` lives in epoch.cljs,
+;; `focus` in spine.cljs, `target-frame` in epoch.cljs). We register
+;; thin app-db-reading stubs so the test owns the full input triple.
+
+(defn- install-source-stubs! []
+  (rf/reg-sub :rf.xray/epoch-history
+    (fn [db _] (get db :epoch-history [])))
+  ;; `:rf.xray/observed-frame` = (or (:frame focus) target); seed both
+  ;; through the focus map so one slot drives the whole observed-frame +
+  ;; focus-epoch-id derivation.
+  (rf/reg-sub :rf.xray/focus
+    (fn [db _] (get db :focus)))
+  (rf/reg-sub :rf.xray/target-frame
+    (fn [db _] (get db :target-frame :rf/default))))
+
+(defn- seed!
+  "Drive the controlled inputs onto the `:rf/xray` app-db: the focus map
+  (carrying `:frame` = observed frame and `:epoch-id` = focused epoch)
+  and the epoch-history vector."
+  [{:keys [frame epoch-id history]}]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:test/seed
+                       {:focus         {:frame frame :epoch-id epoch-id}
+                        :epoch-history history}])))
+
+(defn- read-diff [frame epoch-id history]
+  (seed! {:frame frame :epoch-id epoch-id :history history})
+  (rf/with-frame :rf/xray
+    (rf/subscribe-once [:rf.xray/selected-epoch-diff])))
+
+(defn- mk-record
+  "Minimal `:rf/epoch-record` carrying the slots the diff sub reads:
+  `:epoch-id`, `:db-before`, `:db-after`."
+  [epoch-id db-before db-after]
+  {:epoch-id  epoch-id
+   :db-before db-before
+   :db-after  db-after})
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn []
+                (reset! subs/diff-cache {})
+                (reset! subs/redacted-modified-cache {})
+                (reset! subs/flow-writes-cache {})
+                ;; The `:rf/xray` frame the subs run in.
+                (rf/reg-frame :rf/xray {})
+                (rf/reg-event-db :test/seed
+                  (fn [_db [_ slots]] slots))
+                (install-source-stubs!)
+                (subs/install!))}))
+
+;; ---- (1) pure prune helper ----------------------------------------------
+
+(deftest cache-key-compounds-frame-and-epoch
+  (testing "rf2-nfgps — the cache key is [frame-id epoch-id], so two
+            frames with the SAME epoch-id occupy DISTINCT keys"
+    (is (= [:frame-a 5] (#'subs/cache-key :frame-a 5)))
+    (is (= [:frame-b 5] (#'subs/cache-key :frame-b 5)))
+    (is (not= (#'subs/cache-key :frame-a 5)
+              (#'subs/cache-key :frame-b 5))
+        "overlapping epoch-id across frames must NOT collapse to one key")))
+
+(deftest prune-cache-preserves-foreign-frames-and-ages-own-stale
+  (testing "rf2-nfgps — prune-cache ages out only the OBSERVED frame's
+            stale entries; every other frame's entry survives, and the
+            freshly-computed entry is always kept"
+    (let [history-a [(mk-record 5 {} {:x 1})]   ; frame-a live = {5}
+          ;; Pre-seed: frame-a's epoch 5 (live) + epoch 9 (stale, not in
+          ;; history-a) + frame-b's epoch 5 (foreign — must survive).
+          cache     {[:frame-a 5] :a5-old
+                     [:frame-a 9] :a9-stale
+                     [:frame-b 5] :b5}
+          pruned    (#'subs/prune-cache cache :frame-a history-a
+                                        [:frame-a 5] :a5-new)]
+      (is (= :a5-new (get pruned [:frame-a 5]))
+          "the freshly-computed entry overwrites and survives")
+      (is (false? (contains? pruned [:frame-a 9]))
+          "frame-a's epoch 9 is stale (absent from history-a) — aged out")
+      (is (= :b5 (get pruned [:frame-b 5]))
+          "frame-b's epoch 5 is a DIFFERENT frame — must NOT be evicted
+           by a frame-a prune (the cross-frame-eviction half of the bug)"))))
+
+;; ---- (2) sub-level read isolation ---------------------------------------
+
+(deftest overlapping-epoch-ids-do-not-bleed-across-frames
+  (testing "rf2-nfgps — two frames sharing epoch-id 5 each read their OWN
+            diff; frame B's read must NOT return frame A's cached diff"
+    ;; Frame A: epoch 5 is {} → {:a 1}.
+    (let [rec-a    (mk-record 5 {} {:a 1})
+          diff-a   (read-diff :frame-a 5 [rec-a])]
+      (is (= [[[:a] nil 1 :added]] diff-a)
+          "frame A's epoch-5 diff is the {} → {:a 1} projection")
+      (is (= diff-a (get @subs/diff-cache [:frame-a 5]))
+          "frame A's diff cached under the compound [frame-a 5] key")
+
+      ;; Frame B: SAME epoch-id 5 but a DIFFERENT pair {:b 2} → {:b 99}.
+      ;; With epoch-id-only keying this read would short-circuit on
+      ;; frame A's cached value (read-bleed). With [frame-id epoch-id]
+      ;; keying it misses and computes frame B's own diff.
+      (let [rec-b  (mk-record 5 {:b 2} {:b 99})
+            diff-b (read-diff :frame-b 5 [rec-b])]
+        (is (= [[[:b] 2 99 :modified]] diff-b)
+            "frame B computed its OWN epoch-5 diff — no read-bleed from
+             frame A's cache")
+        (is (not= diff-a diff-b)
+            "the two frames' epoch-5 diffs are distinct")
+        (is (= diff-b (get @subs/diff-cache [:frame-b 5]))
+            "frame B's diff cached under [frame-b 5]")
+        ;; The eviction half: frame A's entry survives frame B's read.
+        (is (= diff-a (get @subs/diff-cache [:frame-a 5]))
+            "frame A's epoch-5 cache survived frame B's read — no
+             cross-frame eviction (rf2-nfgps isolation invariant)")))))
+
+(deftest re-read-same-frame-epoch-hits-cache
+  (testing "rf2-nfgps — caching still works WITHIN a frame: a second read
+            of the same [frame epoch] returns the cached value (==)"
+    (let [rec    (mk-record 7 {:n 0} {:n 1})
+          first  (read-diff :frame-a 7 [rec])
+          ;; Re-seed identical inputs; the cache must short-circuit and
+          ;; return the SAME (identical) vector it stored on miss.
+          second (read-diff :frame-a 7 [rec])]
+      (is (= first second))
+      (is (identical? first (get @subs/diff-cache [:frame-a 7]))
+          "the stored entry is the very object the first read produced"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -364,9 +364,12 @@
           @(rf/subscribe [:rf.xray/selected-epoch-diff]))
         (is (= 4 (count @app-db-diff-subs/diff-cache))
             "after warming all four selections, cache holds four entries")
-        (is (= #{:e-1 :e-2 :e-3 :e-4}
+        ;; rf2-nfgps — keys are the COMPOUND [frame-id epoch-id]; the
+        ;; observed frame here is the default :rf/default.
+        (is (= #{[:rf/default :e-1] [:rf/default :e-2]
+                 [:rf/default :e-3] [:rf/default :e-4]}
                (set (keys @app-db-diff-subs/diff-cache)))
-            "cache keys match the live history's epoch-ids exactly"))
+            "cache keys match the live history's [frame-id epoch-id] exactly"))
       ;; Rotate to a 2-epoch history; :e-1/:e-2 age out.
       (let [hist-b [(mk-record :e-5 [:e] {:n 4} {:n 5})
                     (mk-record :e-6 [:f] {:n 5} {:n 6})]]
@@ -377,15 +380,17 @@
           @(rf/subscribe [:rf.xray/selected-epoch-diff])
           (is (<= (count @app-db-diff-subs/diff-cache) 2)
               "after rotation + one read, cache size ≤ live history depth")
-          (is (not (contains? @app-db-diff-subs/diff-cache :e-1))
+          ;; rf2-nfgps — keys are [frame-id epoch-id]; observed frame is
+          ;; :rf/default throughout this single-frame scenario.
+          (is (not (contains? @app-db-diff-subs/diff-cache [:rf/default :e-1]))
               ":e-1 (aged out) is no longer in the cache")
-          (is (not (contains? @app-db-diff-subs/diff-cache :e-2))
+          (is (not (contains? @app-db-diff-subs/diff-cache [:rf/default :e-2]))
               ":e-2 (aged out) is no longer in the cache")
-          (is (not (contains? @app-db-diff-subs/diff-cache :e-3))
+          (is (not (contains? @app-db-diff-subs/diff-cache [:rf/default :e-3]))
               ":e-3 (aged out) is no longer in the cache")
-          (is (not (contains? @app-db-diff-subs/diff-cache :e-4))
+          (is (not (contains? @app-db-diff-subs/diff-cache [:rf/default :e-4]))
               ":e-4 (aged out) is no longer in the cache")
-          (is (contains? @app-db-diff-subs/diff-cache :e-6)
+          (is (contains? @app-db-diff-subs/diff-cache [:rf/default :e-6])
               ":e-6 (just read) is in the cache"))))))
 
 (deftest selected-epoch-diff-cache-distinguishes-distinct-epochs


### PR DESCRIPTION
Two unrelated Xray review findings in disjoint files.

## rf2-nfgps (P3) — frame-isolation: app-db-diff per-epoch caches keyed by epoch-id alone

`tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs` held three process-global `defonce` caches (`diff-cache`, `redacted-modified-cache`, `flow-writes-cache`) keyed by `:epoch-id` alone and pruned over the observed frame's epoch-ids. The framework's epoch contract guarantees `:epoch-id` uniqueness only WITHIN a frame's history (the global-counter scheme that makes ids incidentally process-unique is an impl detail, not a spec promise). In a multi-frame app with overlapping epoch-ids this permits:

- **read-bleed** — one frame reads another frame's cached diff;
- **cross-frame eviction** — a frame switch prunes a sibling frame's live entries.

**Fix:** key the caches by `[frame-id epoch-id]` (added `:rf.xray/observed-frame` as a sub input to the three caching subs) and prune only the observed frame's stale keyspace via a new `prune-cache` helper that preserves every other frame's entries.

**Test:** new `app_db_diff_cache_isolation_cljs_test.cljs` — two frames sharing epoch-id 5 each read their own diff (no bleed) and frame A's entry survives frame B's read (no eviction); plus a pure `prune-cache`/`cache-key` test. Updated the two existing audit rf2-i0veg cache-key assertions in `app_db_diff_cljs_test.cljs` to the compound key.

**Spec:** `tools/xray/spec/004-App-DB-Diff.md` Diff-engine + Performance sections now document the `[frame-id epoch-id]` keying contract.

## rf2-t2o6o (P4) — dev hot-reload: keybinding detach! leaks the listener

`tools/xray/src/day8/re_frame2_xray/keybinding.cljs` `detach!` removed the bare `handle-keydown` var. `add`/`removeEventListener` compare by reference and shadow-cljs `:after-load` recompiles `handle-keydown` to a fresh fn object, so post-reload `detach!` matched nothing and leaked the original listener — the embed-host detach-after-reload hazard.

**Fix:** `attach!` stashes the exact attached fn under a `defonce` atom; `detach!` removes that stored reference (mirrors the `mount.cljs` unmount-fn stash). Also collapsed a dead double-read in `target-editable?`.

**Test:** new `detach-removes-the-exact-attached-fn-hot-reload-safe` reproduces the leak (removing a fresh fn object leaves the listener intact) and proves `detach!` removes the right one across a full attach/detach cycle.

## Gates (cold, from a fresh worktree)

- xray `clojure -M:test` (JVM): 1100 tests / 4526 assertions — 0 failures.
- `npm run test:cljs` (node): 5589 tests / 19457 assertions — 0 failures (includes both new tests).
- `npm run test:xray-feature-gate`: 16 scenarios — 0 failures (two consecutive clean runs; one earlier run had a single flake on "static mode chrome and chord" correlated with an http-server crash, not reproduced).

Closes rf2-nfgps. Closes rf2-t2o6o.
