### PR TITLE
docs(readme): fix inventory drift from the README cross-link sweep (rf2-27ptt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ testbeds/                      Shared framework-behavior testbed surfaces (consu
   drain_depth_trigger/         Recursive dispatch hitting the drain-depth ceiling
   non_trivial_app_db/          ~5-level nested app-db for diffing visualisation
   large_dispatcher/            Payloads above :rf.size/large-elided threshold
+  ssr_basic/                   SSR hydration baseline — payload → :rf/hydrate → verify-hydration!
+  ssr_hydration_mismatch/      Deliberate hash mismatch — emits :rf.ssr/hydration-mismatch
+  ssr_multi_frame/             Per-frame hydration — three frames, one payload slice each
 implementation/                CLJS reference implementation — per-artefact subdirs
                                (per Conventions §Packaging conventions). Each subdir is its own
                                jar with its own deps.edn, on the top-level shadow-cljs classpath.

--- a/implementation/README.md
+++ b/implementation/README.md
@@ -140,6 +140,21 @@ implementation/
     src/re_frame/epoch.cljc        Per-frame :rf/epoch-record ring buffer + projection
                                    walker for sub-runs / renders / effects.
     test/re_frame/                 JVM epoch tests.
+
+  ssr-ring/                  day8/re-frame2-ssr-ring — Ring host adapter for the SSR pipeline
+                             (rf2-ny6v7).
+    deps.edn                 :local/root deps on ../core and ../ssr (Ring is test-only).
+    src/re_frame/ssr/ring.clj      Ring handler wrapper + :rf.server/* cookie/header glue.
+    test/re_frame/                 JVM Ring-adapter tests.
+
+  test-quiet/                day8/re-frame2-test-quiet — quiet-on-success cljs.test /
+                             clojure.test reporter shared across the test runners (rf2-try1x).
+    deps.edn                 No runtime deps; a test-tooling library.
+    src/re_frame/test_quiet*       Silent-on-success reporter + runner entry points.
+
+  security/                  Cross-cutting security regression tests (MCP egress, schema
+                             redaction, SSR escaping) — test-only, no shipped namespace.
+    test/re_frame/security/        JVM + CLJS security regression suites.
 ```
 
 ## Status by spec area

--- a/testbeds/README.md
+++ b/testbeds/README.md
@@ -22,6 +22,9 @@ testbeds/
   drain_depth_trigger/     <-- handler that recursively dispatches itself; configurable depth ceiling
   non_trivial_app_db/      <-- 55-leaf app-db nested 5 deep; six diff shapes one per button
   large_dispatcher/        <-- four nomination paths for :rf.size/large-elided (auto / declared / fx / schema)
+  ssr_basic/               <-- SSR hydration baseline: payload → :rf/hydrate → render → verify-hydration!
+  ssr_hydration_mismatch/  <-- deliberate-mismatch: known-wrong :rf/render-hash emits :rf.ssr/hydration-mismatch
+  ssr_multi_frame/         <-- three frames, each hydrated from its own slice of the baked payload
 ```
 
 Per-surface conventions (every testbed in this directory follows them):
@@ -46,6 +49,9 @@ shadow-cljs watch testbeds/long-flow-w-failure
 shadow-cljs watch testbeds/drain-depth-trigger
 shadow-cljs watch testbeds/non-trivial-app-db
 shadow-cljs watch testbeds/large-dispatcher
+shadow-cljs watch testbeds/ssr-basic
+shadow-cljs watch testbeds/ssr-hydration-mismatch
+shadow-cljs watch testbeds/ssr-multi-frame
 ```
 
 Then open `http://localhost:9630/build/<build-id>/dashboard` (or the per-testbed index.html served from `implementation/out/testbeds/<name>/`). The Xray preload is wired on every testbed build (mirroring the examples convention) so the trace panel and dev-tools are live on each surface.
@@ -63,6 +69,9 @@ Then open `http://localhost:9630/build/<build-id>/dashboard` (or the per-testbed
 | `drain_depth_trigger/` | Partial epoch record (drain-halt) shows up with non-`:ok` outcome (`:halted-depth`, rf2-v0jwt); the failed cascade's N `:event/dispatched` traces leading up to the halt are visible; the post-halt second drain (the in-app listener's flip) reads cleanly on the next epoch | Recorder captures the Start click + halt deterministically; replay reproduces the same N-deep cascade + rollback shape | `:rf.error/drain-depth-exceeded` event arrives over the wire with `:depth`, `:queue-size`, `:last-event` carried verbatim; the post-rollback `app-db` snapshot reads back to the pre-drain shape via `get-path` |
 | `non_trivial_app_db/` | Six distinct `:event/db-changed` shapes per click against a 55-leaf app-db nested 5 deep; diff renderer drills into vector indices and 5-level subtrees; time-travel scrubs preserve every depth | Snapshot identity reproducible across runs — the deterministic 6-click sequence produces a bit-identical snapshot on replay; variants mounting this surface verify the chrome doesn't choke on realistic app-db | Snapshot-restore round-trip preserves all 55 leaves; `get-path` resolves at every depth without elision (no slot is `:large?`) |
 | `large_dispatcher/` | `:large?` value arrives as `:rf.size/large-elided` marker — schemas are the only nomination path so all three declared buttons (B / C / D) emit `:source :schema`; Button A (un-schema'd large value) does NOT emit a marker but fires the `:rf.warning/large-value-unschema'd` advisory once on first emit | Recorder captures the click deterministically; replay reproduces the same elision marker on each emit | The marker's `:handle` shape is `get-path`-callable; the wire-cap budget stays under 5K-token cap regardless of payload size |
+| `ssr_basic/` | `:rf.ssr/*` + `:rf/hydrate` handshake visible in the trace stream; the payload-seeded `app-db` (`:count`, `:title`, `:rf/response`) reads correctly post-hydrate; no mismatch when the server-hash is `nil` (baseline) | Recorder captures the post-hydrate click sequence deterministically; replay reproduces the seeded-then-mutated `app-db` shape | The hydrated `app-db` slice reads back via `get-path`; the `:rf/hydrate` cascade's epoch record carries the payload's `:rf/frame-id` verbatim |
+| `ssr_hydration_mismatch/` | `:rf.ssr/hydration-mismatch` event highlighted in the trace stream with server-hash / client-hash / failing-id / recovery (`:warned-and-replaced`); the page stays interactive after the warn-and-replace recovery | Recorder captures the deliberate-mismatch boot deterministically; replay reproduces the same `:rf.ssr/hydration-mismatch` payload | The mismatch trace arrives over the wire with `:rf/render-hash`, the computed client hash, and `:recovery` carried verbatim |
+| `ssr_multi_frame/` | Per-frame `:rf/hydrate` dispatch produces one epoch record per frame (`:counter/a` / `:counter/b` / `:log`) with `:frame` tag intact; each frame's seeded `app-db` stays isolated | Time-travel scrub within a variant mounting this surface preserves per-frame hydration isolation | A `{:frame ...}`-addressed `get-path` resolves each frame's hydrated slice independently; the per-frame fan-out is visible across three epoch records |
 
 ## Tier roadmap (rf2-kzcim)
 
@@ -83,6 +92,12 @@ Tier 3 — devtools edge cases:
 - ✅ `drain_depth_trigger/`
 - ✅ `non_trivial_app_db/`
 - ✅ `large_dispatcher/`
+
+SSR — hydration handshake surfaces:
+
+- ✅ `ssr_basic/`
+- ✅ `ssr_hydration_mismatch/`
+- ✅ `ssr_multi_frame/`
 
 Tier 4 — a11y (retired rf2-9jfo1.1):
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -119,15 +119,20 @@ wired into the build, and consumers can use it today.
   [`tools/testbed-support/README.md`](./testbed-support/README.md).
 
 - **`tools/mcp-base/`** — `day8/re-frame2-mcp-base`. Shared primitives
-  for the MCP servers (`re-frame2-pair-mcp`, `story-mcp`): seven
+  for the MCP servers (`re-frame2-pair-mcp`, `story-mcp`): eleven
   namespaces — `vocab` (wire-vocabulary constants `:rf.mcp/*`,
   `:rf.size/*`, JSON-RPC error codes), `sensitive` (spec/009 §Privacy
   default-suppress filter), `elision` (`:rf.size/large-elided`
   wire-boundary walker), `args` (MCP argument coercion helpers),
-  `diff-encode` (path-keyed structural diff, rf2-1wdzp), `overflow`
-  (overflow-marker payload shape, rf2-rvyzy), and `cap` (wire-boundary
-  token-budget cap pipeline, rf2-eyelu). Pure `.cljc` with zero
-  runtime deps beyond `org.clojure/clojure`. Per rf2-vw4sq. See
+  `diff-encode` (path-keyed structural diff, rf2-1wdzp),
+  `section-grouping` (patch-list → path-headed cluster sections,
+  rf2-qeous), `overflow` (overflow-marker payload shape, rf2-rvyzy),
+  `cap` (wire-boundary token-budget cap pipeline, rf2-eyelu), `cursor`
+  (shared cursor-pagination machinery, rf2-ee38b.19), `envelope`
+  (indicator-field `with-indicators` splice, rf2-ee38b.19), and
+  `descriptor-manifest` (tool-descriptor manifest generator +
+  drift-check, rf2-sofwv). Pure `.cljc` with zero runtime deps beyond
+  `org.clojure/clojure`. Per rf2-vw4sq. See
   [`tools/mcp-base/spec/README.md`](./mcp-base/spec/README.md).
 
 - **`tools/mcp-conformance/`** — End-to-end MCP-client conformance

--- a/tools/mcp-base/deps.edn
+++ b/tools/mcp-base/deps.edn
@@ -51,6 +51,12 @@
 ;;                        (`:dropped-sensitive` / `:elided-large`
 ;;                        omit-when-zero MUST) + wire-bounded
 ;;                        `:rf.mcp/*` marker detection (rf2-ee38b.19).
+;;   - `descriptor_manifest.cljc` — shared tool-descriptor manifest
+;;                        generator + drift-check (rf2-sofwv). Projects
+;;                        each server's tool registry to a byte-stable
+;;                        `tool-descriptors.edn` catalogue and
+;;                        regenerate-and-compare `check` so an
+;;                        added/removed/renamed tool trips a CI gate.
 ;;
 ;; What deliberately does NOT live here:
 ;;   - Wire-transport code (cheshire JSON for story-mcp's JVM-side;

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -1,7 +1,7 @@
 # `sensitive` — Spec 009 §Privacy default-suppress filter
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> The cross-MCP privacy filter. Framework-published forwarders — Sentry / Honeybadger, re-frame2-pair server, Story-MCP, Xray-MCP — MUST default-drop trace events whose registration declared `:sensitive? true`. The runtime stamps the flag at the top level of every emitted trace event inside such a registration's handler scope; the forwarder's job is to gate egress on it before any data crosses the trust boundary.
+> The cross-MCP privacy filter. Framework-published forwarders — Sentry / Honeybadger, re-frame2-pair server, Story-MCP (xray-mcp was dropped in rf2-bu21t; xray now ships as a Clojars-only library, not an MCP server) — MUST default-drop trace events whose registration declared `:sensitive? true`. The runtime stamps the flag at the top level of every emitted trace event inside such a registration's handler scope; the forwarder's job is to gate egress on it before any data crosses the trust boundary.
 
 This doc is one of eleven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md), [`cursor.md`](cursor.md), [`envelope.md`](envelope.md), [`descriptor-manifest.md`](descriptor-manifest.md).
 


### PR DESCRIPTION
@-