### PR TITLE
docs(skills): generic canonical-shape guidance + README routing/status fixes (rf2-fv7pi + rf2-784bq)

### DIFF
--- a/skills/re-frame2/README.md
+++ b/skills/re-frame2/README.md
@@ -12,7 +12,7 @@ This skill carries the recipes, decision rules, and canonical declarations Claud
 |---|---|
 | Writing new re-frame2 code (`.cljs` / `.cljc`) | Greenfield project bootstrap → `re-frame2-setup` |
 | Choosing between slice / region / machine | Inspecting a running app → `re-frame2-pair` |
-| Picking a canonical pattern | Migrating a v1 app → `SKILL-REDIRECT.md` |
+| Picking a canonical pattern | Migrating a v1 app → [`re-frame-migration`](../re-frame-migration/) |
 | Composing patterns | Full API reference / EP rationale → `SKILL-REDIRECT.md` |
 
 ## Layout
@@ -80,7 +80,7 @@ The skill's `description` triggers on natural-language references to re-frame2 s
 
 ## Status
 
-**Alpha.** All scaffolding and leaves are populated: `references/fundamentals/` (including the Flows leaf), `references/state-machines/`, `references/tooling/`, `references/cross-cutting/`, the nine canonical patterns under `patterns/`, and both decision trees (`pick-a-pattern`, `slice-or-machine`). The loading map is reconciled and the derived-from-implementation footers are pinned at main `89bd9c3`. All worked examples the leaves cite — including `examples/reagent/{websocket,long_running_work,flows}/` — have shipped; the evals harness is the only in-flight item and is not a blocker for skill use.
+**Alpha.** All scaffolding and leaves are populated: `references/fundamentals/` (including the Flows leaf), `references/state-machines/`, `references/tooling/`, `references/cross-cutting/`, the nine canonical patterns under `patterns/`, and both decision trees (`pick-a-pattern`, `slice-or-machine`). The loading map is reconciled and the derived-from-implementation footers are pinned at main `89bd9c3`. All worked examples the leaves cite — including `examples/reagent/{websocket,long_running_work,flows}/` — have shipped, and the evals harness has landed under `evals/` (`README.md` + `evals.json`). No in-flight items remain.
 
 ## License
 

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -62,7 +62,7 @@ Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing �
 2. **Recipes over explanations.** Use the canonical shape; do not re-derive from first principles.
 3. **Distinguish orchestration from state.** State machines for *modes* (legal-transitions-depend-on-current-state); slices for *fields*. See [`decision-trees/slice-or-machine.md`](decision-trees/slice-or-machine.md). **For machines, the standing mental model is: think how you'd do it in xstate, then map onto re-frame2** — xstate is the widely-known FSM model in your training data, and most concepts translate cleanly (`:type :parallel`, `:tags`, `:guards`/`:actions`, `:always`, `:after`, final states). A handful of slots re-frame2 deliberately renames or omits (`invoke`→`:spawn`, `context`→`:data`, no `assign`/action-vectors/compound-guard-data); those divergences are the trap. The translation key + divergence flags live in [`references/state-machines/reg-machine.md`](references/state-machines/reg-machine.md).
 4. **Schemas at boundaries.** `reg-app-schema` for paths that cross trust boundaries (HTTP payloads, persisted state, snapshot restores). Do not schema-fence every internal key.
-5. **`examples/reagent/<x>/` is canonical.** When a pattern has a worked example, match its shape.
+5. **Match the canonical shape.** When a pattern has a worked example or reference declaration, match its shape; don't re-derive. (In the re-frame2 repo itself, the canonical worked examples live under `examples/reagent/<x>/`; in a consumer app, the canonical shape is the one in the relevant pattern / fundamentals leaf and any reference views your project already follows.)
 6. **Frames before globals.** Talk to a frame via `dispatch` / `subscribe`. Do not import frame internals or bypass to mutate state.
 7. **`:rf/*` is reserved.** Application keywords pick their own feature prefix (`:cart/...`, `:auth/...`).
 8. **`reg-*` macros over `register-*` functions.** Macros capture source coordinates that tools rely on; functional registrations are for advanced cases only.
@@ -126,7 +126,7 @@ Load at most two leaves per task. If a task seems to need three, it likely spans
 2. Load at most two leaves (the relevant fundamentals or pattern; a second only if the task spans two surfaces).
 3. Match the canonical declaration in the leaf; do not re-derive.
 4. Pick the feature prefix (`:cart/...`, `:auth/...`) — never `:rf/*`.
-5. Cross-check the worked example in `examples/reagent/<x>/` when one exists.
+5. Cross-check a worked example or reference view that uses the same shape when one exists (in the re-frame2 repo, that's `examples/reagent/<x>/`; in a consumer app, your project's own reference views).
 6. Schema only at boundaries.
 7. Use `reg-*` macros unless the macro shape can't express the need.
 8. Cut-test comments: would I write this same comment in a React / Vue / Elm app? If yes, cut it.

--- a/skills/re-frame2/decision-trees/slice-or-machine.md
+++ b/skills/re-frame2/decision-trees/slice-or-machine.md
@@ -114,12 +114,12 @@ If you're between slice and machine and none of the four tells clearly fire, the
 
 ## Step 5 — verify against the implementation
 
-Cardinal rule (per SKILL.md §1): when the spec and `implementation/**` disagree, the implementation wins. After picking a shape, point at the example app that uses the same shape:
+Cardinal rule (per SKILL.md §1): when the spec and `implementation/**` disagree, the implementation wins. After picking a shape, cross-check it against a reference declaration that uses the same shape — a worked example or a reference view your project already follows. Match its shape rather than re-deriving:
 
-- A machine? — see `examples/reagent/login/` (state machine + tags + managed-HTTP), `examples/reagent/state_machine_walkthrough/` (the chapter as runnable code), `examples/reagent/nine_states/` (parallel regions).
-- A slice? — see `examples/reagent/counter/` (the smallest possible slice), `examples/reagent/todomvc/` (a list-of-items slice with editing and filters), the 7GUIs cluster.
+- A machine? — match a reference machine that uses state + tags + (where relevant) parallel regions or managed-HTTP. (In the re-frame2 repo itself, see `examples/reagent/login/` for state machine + tags + managed-HTTP, `examples/reagent/state_machine_walkthrough/` for the chapter as runnable code, `examples/reagent/nine_states/` for parallel regions.)
+- A slice? — match a reference slice. (In the re-frame2 repo itself, see `examples/reagent/counter/` for the smallest possible slice, `examples/reagent/todomvc/` for a list-of-items slice with editing and filters, and the 7GUIs cluster.)
 
-If the example contradicts the leaf you'd pick from this tree, **the example wins**. File a bead against the spec; don't silently work around (per Mike's standing directive on file-bead-for-spec-gaps).
+If a reference declaration contradicts the leaf you'd pick from this tree, **the reference wins** — and if that reference is the spec itself disagreeing with `implementation/**`, file a bead against the spec; don't silently work around (per the standing directive on file-bead-for-spec-gaps).
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary

Two skills/re-frame2 doc fixes. Docs-only, no test surface.

### rf2-fv7pi (P3, GENERICITY-LEAK)
`SKILL.md` cardinal rule 5, authoring-workflow step 5, and `decision-trees/slice-or-machine.md` Step 5 gave **normative** instructions pointing an agent at this dev-repo's `examples/reagent/<x>/` path — which a consumer re-frame2 app does not have. Reframed each to the generic mechanism (match the canonical shape in the relevant pattern/fundamentals leaf or your project's own reference views) and **demoted** the `examples/reagent/<x>/` path to a clearly-marked "in the re-frame2 repo itself: …" aside, mirroring `references/fundamentals/project-structure.md`'s framing of the repo-internal convention.

Before → after (cardinal rule 5):
- Before: **`examples/reagent/<x>/` is canonical.** When a pattern has a worked example, match its shape.
- After: **Match the canonical shape.** When a pattern has a worked example or reference declaration, match its shape; don't re-derive. (In the re-frame2 repo itself, the canonical worked examples live under `examples/reagent/<x>/`; in a consumer app, the canonical shape is the one in the relevant pattern / fundamentals leaf and any reference views your project already follows.)

Workflow step 5 and slice-or-machine Step 5 reframed the same way (generic instruction first, repo path as a bracketed example). Leaf footers / provenance lines and cardinal rule 1's "verified against … `examples/reagent/**`" are left untouched — those are provenance, not instruction, per the bead.

### rf2-784bq (P4, CLARITY)
1. README out-of-scope row routed v1 migration to `SKILL-REDIRECT.md` while SKILL.md routes it to the `re-frame-migration` skill. Fixed the README to point at [`re-frame-migration`](../re-frame-migration/), matching SKILL.md's own routing. (The API/EP-rationale row still points at `SKILL-REDIRECT.md` — correct.)
2. Status line called the evals harness "the only in-flight item"; verified it has shipped (`skills/re-frame2/evals/` contains `README.md` + `evals.json`). Status now reads "the evals harness has landed … No in-flight items remain."

## Verification
- `skills/re-frame-migration/README.md` exists (migration redirect target resolves).
- `skills/re-frame2/evals/{README.md,evals.json}` exist (evals shipped).
- All `examples/reagent/{login,state_machine_walkthrough,nine_states,counter,todomvc,seven_guis}` dirs cited in slice-or-machine Step 5 exist.
- `../re-frame-migration/` relative link resolves from `skills/re-frame2/README.md`.

## Scope guard
`api-cheatsheet.md` and `fundamentals/fx.md` untouched (already fixed by swt7o/he5mo #3054).

## Quality gates
Docs-only, no test surface. The edited files (`skills/re-frame2/{SKILL.md,README.md,decision-trees/slice-or-machine.md}`) are **not** in the mkdocs `docs/` corpus — `docs/skills/re-frame2.md` is a stub that links to the GitHub-hosted SKILL.md by external URL and does not embed the content — so `check_doc_slugs.py` / `mkdocs build` do not apply.

Closes rf2-fv7pi, rf2-784bq.
