### PR TITLE
fix(xray): per-epoch-delta app-db diff + Static Flows mnemonic (rf2-02j4r + rf2-l1ru8)

### DIFF
--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -94,6 +94,28 @@ paths (the runtime stays cheap); Xray runs the diff on the panel's
 first mount per epoch, caches per `[frame-id epoch-id]`, and discards
 on epoch age-out.
 
+### Diff semantics: per-epoch delta (rf2-02j4r)
+
+The diff is always the **selected epoch N's own delta** —
+`db-before(N) → db-after(N)`, the change introduced by THIS event
+compared to the immediately previous event. Both sides come from the
+**same focused epoch record**: `:db-before` is the pre-image and
+`:db-after` is the post-image (the App-DB panel surfaces `:db-after` as
+its `:value`). The delta is therefore **independent of any later
+event** — scrubbing back to an earlier epoch shows only what that epoch
+changed, never the cumulative change since.
+
+> **rf2-02j4r (2026-06-04)** reversed the earlier rf2-yng0y App-DB-panel
+> design, which diffed the **live** target-frame db against the focused
+> epoch's `:db-before`. That equals the per-epoch delta only when the
+> focused epoch is head; at any non-head epoch it became a cumulative
+> live-vs-`db-before(N)` diff, so later events' changes bled onto earlier
+> selections. The panel now pulls `:value` from the focused record's
+> `:db-after` (see [`021` §4.5](021-Dynamic-Panel-Designs.md#45-per-epoch-delta-not-cumulative-rf2-02j4r)).
+> The Editscript engine call here is unchanged — it always diffed the
+> record's `:db-before`/`:db-after` pair; the reversal was in which value
+> the *panel* presents as the current-state side.
+
 > **rf2-nfgps — frame-scoped cache key.** The per-epoch caches key on
 > the COMPOUND `[frame-id epoch-id]`, never `:epoch-id` alone. The
 > framework's epoch contract guarantees `:epoch-id` is unique only

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -801,17 +801,57 @@ downstream of that path:
 Popover is a Xray-owned component (not a browser title), keyboard-
 dismissable, click-through to Reactive panel via the `⤴` footer link.
 
-### §4.5 No epoch focused (LIVE mode at head)
+### §4.5 Per-epoch delta, not cumulative (rf2-02j4r)
 
-When the L2 spine is at head (no historical epoch focused), the sections
-show the most-recent epoch's state with its diff annotations (head-cascade)
-— current db, sectioned. Same render shape — no second mode.
+The panel shows the **selected epoch's OWN delta** — what THIS event
+changed, compared to the immediately previous event, and nothing later.
+The section model's two slots both come from the **focused epoch's
+record**:
+
+| Slot | Source | Meaning |
+|---|---|---|
+| `:value` | the focused epoch's **`:db-after`** | the post-state OF that event (its own result) |
+| `:before` | the focused epoch's **`:db-before`** | the pre-state OF that event |
+
+The inline diff is therefore exactly `db-before(N) → db-after(N)` —
+epoch N's per-epoch delta, **independent of any later event**. Scrubbing
+back to an earlier epoch N after later events occurred highlights ONLY
+what N changed; a key added by a LATER event is absent from `db-after(N)`
+and does not appear at N's selection.
+
+> **rf2-02j4r reversal (2026-06-04).** This REVERSES the earlier rf2-yng0y
+> design, which set `:value` = the observed frame's **LIVE app-db**
+> ("constant as you scrub", a re-frame-10x current-state-inspector
+> framing). Diffing the live db vs the focused `:db-before` equals the
+> per-epoch delta ONLY when the focused epoch is HEAD (live == that
+> epoch's `:db-after`); at any non-head epoch it became a CUMULATIVE
+> diff — everything changed from the focused epoch forward to NOW — so
+> later events' changes bled onto earlier selections (Mike, reproduced
+> live on machine-epochs: focusing the `:media/deep` epoch wrongly lit
+> `:media/shallow`, which a later event added). Pulling `:value` from the
+> focused record's `:db-after` makes the diff the epoch's own delta at
+> every scrub position, and STRENGTHENS the rf2-yng0y atomicity invariant
+> (every slot from ONE record, never live-db + record-`:before`).
+>
+> The rf2-227cz `added`-sentinel behaviour (§4.3) is correct under the
+> new baseline: a wholly-new instance at epoch N is absent in
+> `db-before(N)` and present in `db-after(N)`, so it lights `:added`.
+
+**At head (LIVE mode, no historical epoch focused)** the focused epoch
+IS the head, so `:value` = head's `:db-after` = the current db. The
+operator sees the most-recent epoch's state with its diff annotations —
+same render shape, no second mode.
+
+**Cold boot (no epoch focused at all)** — no cascade has settled, so
+there is no focused record; `:value` falls back to the LIVE db and
+`:before` is nil. The panel renders plain current-state with no diff
+overlay.
 
 ### §4.6 Queries
 
 | From | Reads |
 |---|---|
-| Trace bus | `:rf/epoch-record` `:db-before` + `:db-after` (existing) for diff; structural-sharing diff per §004 |
+| Trace bus | `:rf/epoch-record` `:db-before` + `:db-after` (existing); the focused epoch's `:db-after` is the panel's `:value` and `:db-before` is the diff pre-image (per-epoch delta · rf2-02j4r). Structural-sharing diff per §004 |
 | Registries | Sub `:input-paths` for the "downstream subs" overlay |
 | Reactive panel state | Re-rendered views set for the overlay popover |
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -336,17 +336,37 @@
         (h/epochs-touching-path history focused-path)
         [])))
 
-  ;; ---- rf2-yng0y — ATOMIC current-state + focused-epoch before-image --
+  ;; ---- rf2-02j4r — PER-EPOCH-DELTA current-state + before-image -------
   ;;
-  ;; The app-db tab is a CURRENT-STATE inspector (re-frame-10x style)
-  ;; that ALSO carries the focused epoch's diff inline (spec/021 §4.1 —
-  ;; "what does state LOOK LIKE — and what just changed?"):
+  ;; The app-db tab shows the SELECTED epoch's OWN delta — what THIS
+  ;; event changed, and nothing later (spec/021 §4.1, spec/004
+  ;; §Diff-semantics):
   ;;
-  ;;   :value  = the observed frame's LIVE app-db (constant as you scrub)
-  ;;   :before = the focused epoch's `:db-before` (the inline-diff
-  ;;             pre-image — the ONLY thing that changes per epoch)
+  ;;   :value  = the focused epoch's `:db-after`  (the post-state OF that
+  ;;             event — moves per epoch as you scrub)
+  ;;   :before = the focused epoch's `:db-before` (the pre-state OF that
+  ;;             event — moves per epoch as you scrub)
   ;;
-  ;; ## Why one sub, not a 5-deep chain (rf2-yng0y root-cause fix)
+  ;; Both come from the SAME focused record, so the inline diff is
+  ;; exactly `db-before(N) → db-after(N)` — epoch N's per-epoch delta,
+  ;; independent of any later event. Selecting :media/deep highlights
+  ;; ONLY what :media/deep changed; :media/shallow stays unhighlighted
+  ;; until you select ITS epoch.
+  ;;
+  ;; ## Why per-epoch-delta, not live-vs-before (rf2-02j4r reversal)
+  ;;
+  ;; The rf2-yng0y design set `:value = the LIVE target-frame-db`
+  ;; ("constant as you scrub", a re-frame-10x current-state framing).
+  ;; Diffing LIVE-value vs focused-`:db-before` equals the per-epoch
+  ;; delta ONLY when the focused epoch is HEAD (live == that epoch's
+  ;; `:db-after`). Scrub to ANY non-head epoch and it became a
+  ;; CUMULATIVE diff — everything changed from the focused epoch forward
+  ;; to NOW — so later events' changes bled onto earlier selections.
+  ;; That actively misled during the core time-travel use case (Mike,
+  ;; 2026-06-04). The fix: `:value` follows the focused epoch's
+  ;; `:db-after`, so the diff is the epoch's own delta at every position.
+  ;;
+  ;; ## Why one sub, not a 5-deep chain (rf2-yng0y root-cause fix KEPT)
   ;;
   ;; Previously the section model resolved through a deep composed
   ;; chain — `:rf.xray/focus → :rf.xray/focus-epoch-id →
@@ -361,21 +381,24 @@
   ;;
   ;; This sub collapses the chain: it joins the live db, the epoch
   ;; history, and the spine `:rf.xray/focus` map DIRECTLY, then resolves
-  ;; the focused record's `:db-before` and `:epoch-id` together in ONE
-  ;; computation. `:before` and `:epoch-id` are pulled from the SAME
-  ;; `record`, so they can NEVER disagree — there is no intermediate
-  ;; reaction layer carrying a stale `:before` for a frame, and so no
-  ;; stale projection can paint. (Note: `(peek history)` is NOT a
-  ;; fallback here — the App-DB before-image follows the FOCUSED epoch;
-  ;; the `(peek history)` fallback that `:rf.xray/selected-epoch-diff`
-  ;; uses is a separate Epoch-panel/MCP concern.)
+  ;; the focused record's `:db-after`, `:db-before` and `:epoch-id`
+  ;; together in ONE computation. All three are pulled from the SAME
+  ;; `record`, so they can NEVER disagree — pulling `:value` from the
+  ;; focused record too STRENGTHENS the atomicity (every slot from one
+  ;; record, not value-from-live + before-from-record). (Note: `(peek
+  ;; history)` is NOT a fallback here — the App-DB diff follows the
+  ;; FOCUSED epoch; the `(peek history)` fallback that
+  ;; `:rf.xray/selected-epoch-diff` uses is a separate Epoch-panel/MCP
+  ;; concern.)
   ;;
   ;; ATOMICITY INVARIANT (asserted by the deterministic unit test):
-  ;;   for any returned map, `(= :before (:db-before <record of
-  ;;   :epoch-id>))` — `:before` is, by construction, the `:db-before`
-  ;;   of the epoch named by `:epoch-id`. When no epoch is focused
-  ;;   (cold boot, no cascades) both are nil and the panel renders plain
-  ;;   current-state.
+  ;;   for any returned map with a focused epoch, `:value` =
+  ;;   `(:db-after <record of :epoch-id>)` AND `:before` =
+  ;;   `(:db-before <record of :epoch-id>)` — both are, by construction,
+  ;;   the slots of the epoch named by `:epoch-id`. When no epoch is
+  ;;   focused (cold boot, no cascades) `:value` falls back to the LIVE
+  ;;   db and `:before` is nil — the panel renders plain current-state
+  ;;   with no diff overlay (unchanged from rf2-yng0y).
   (rf/reg-sub :rf.xray/app-db-current+diff
     :<- [:rf.xray/target-frame-db]
     :<- [:rf.xray/epoch-history]
@@ -384,9 +407,15 @@
       (let [epoch-id (:epoch-id focus)
             record   (when epoch-id (find-epoch-in-history history epoch-id))
             before   (when record (:db-before record))]
-        {:value    db
-         ;; `:before` and `:epoch-id` come from the SAME record — they
-         ;; move together, never one-frame apart.
+        {;; rf2-02j4r — `:value` is the focused epoch's `:db-after` (its
+         ;; OWN post-state), so the inline diff is db-before(N) →
+         ;; db-after(N) = epoch N's per-epoch delta, not the cumulative
+         ;; live-vs-db-before(N) that bled later events onto earlier
+         ;; selections. Cold boot / no focus → fall back to the LIVE db
+         ;; (plain current-state, no diff).
+         :value    (if record (:db-after record) db)
+         ;; `:value`, `:before` and `:epoch-id` all come from the SAME
+         ;; record — they move together, never one-frame apart.
          :before   before
          :epoch-id (when record epoch-id)})))
 

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -365,10 +365,17 @@
   ;; tab registry. Contiguous order: machines 0 · routes 1 · schemas 2
   ;; · flows 3 · interceptors 4 (the standalone :views / :events tabs
   ;; rf2-b2fif removed previously left orders 3 + 5 as gaps).
+  ;; rf2-l1ru8 — mnemonic is "f" (first-letter-of-label, the Static-mode
+  ;; convention: Machines→m, Routes→r, Interceptors→i). "f" is free in the
+  ;; Static mnemonic set (Schemas uses "c" because "s" is the Settings
+  ;; key; Flows has no such collision), and the Static shell's own
+  ;; canonical IA listing (`static/shell.cljs` "Flows (f)") documents "f"
+  ;; as the intended binding. The prior "l" was an off-convention impl
+  ;; value that disagreed with both the shell docstring and the skill.
   (panel-registry/reg-l4-tab!
     {:id    :flows
      :label "Flows"
-     :mnem  "l"
+     :mnem  "f"
      :modes #{:static}
      :order 3
      :panel Panel

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
@@ -114,23 +114,30 @@
             "rf2-70tkv — LIVE mode auto-follows the head cascade; the
              App-db Diff panel rebinds to the new head's diff")))))
 
-;; ---- rf2-yng0y — atomic focused-epoch before-image ----------------------
+;; ---- rf2-02j4r / rf2-yng0y — atomic per-epoch-delta before+after --------
 ;;
 ;; The zoom-nav stale-frame flash (rf2-yng0y) was a stale `:before` that
 ;; lagged the focused `:epoch-id` by one animation frame, because the
 ;; before-image resolved through a deep composed chain
 ;; (`:focus → focus-epoch-id → selected-epoch-record → app-db-state`).
 ;; The fix collapses that chain into ONE sub
-;; (`:rf.xray/app-db-current+diff`) that resolves `:before` and
-;; `:epoch-id` from the SAME epoch record in a single computation, so
-;; they can never disagree.
+;; (`:rf.xray/app-db-current+diff`) that resolves the focused record's
+;; slots in a single computation, so they can never disagree.
+;;
+;; rf2-02j4r REVERSED the rf2-yng0y `:value = live-db` design: `:value`
+;; is now the focused epoch's `:db-after`, so the inline diff is the
+;; per-epoch delta `db-before(N) → db-after(N)` — NOT the cumulative
+;; live-vs-`db-before(N)` that bled later events onto earlier selections.
+;; Both `:value` and `:before` are pulled from the SAME focused record,
+;; which STRENGTHENS atomicity (every slot from one record).
 ;;
 ;; The flash itself is timing-sensitive (it only paints under real mouse
 ;; timing vs rAF batching, which a unit test cannot reproduce
 ;; deterministically). What we CAN assert deterministically is the
 ;; ATOMICITY INVARIANT that makes the flash impossible by construction:
-;; the sub never returns a `{:before :epoch-id}` pair where `:before`
-;; differs from the `:db-before` of the record named by `:epoch-id`.
+;; the sub never returns a `{:value :before :epoch-id}` triple where
+;; `:value`/`:before` differ from the `:db-after`/`:db-before` of the
+;; record named by `:epoch-id`.
 
 (defn- db-before-of
   "The `:db-before` of the `epoch-id` record in the fixture history,
@@ -139,49 +146,65 @@
   (some (fn [r] (when (= epoch-id (:epoch-id r)) (:db-before r)))
         epoch-history))
 
+(defn- db-after-of
+  "The `:db-after` of the `epoch-id` record in the fixture history,
+  or nil when `epoch-id` is nil / absent."
+  [epoch-id]
+  (some (fn [r] (when (= epoch-id (:epoch-id r)) (:db-after r)))
+        epoch-history))
+
 (defn- assert-atomic!
   "Read `:rf.xray/app-db-current+diff` and assert the atomicity
-  invariant: `:before` equals the `:db-before` of `:epoch-id`."
+  invariant: `:before` equals the `:db-before` of `:epoch-id` AND
+  `:value` equals its `:db-after` (per-epoch-delta, rf2-02j4r)."
   [label]
-  (let [{:keys [before epoch-id]} (h/read-sub :rf.xray/app-db-current+diff)]
+  (let [{:keys [value before epoch-id]} (h/read-sub :rf.xray/app-db-current+diff)]
     (is (= (db-before-of epoch-id) before)
         (str label " — :before must equal the :db-before of :epoch-id "
              "(atomicity invariant rf2-yng0y); got before=" (pr-str before)
              " epoch-id=" (pr-str epoch-id)))
+    (is (= (db-after-of epoch-id) value)
+        (str label " — :value must equal the :db-after of :epoch-id "
+             "(per-epoch-delta, rf2-02j4r); got value=" (pr-str value)
+             " epoch-id=" (pr-str epoch-id)))
     epoch-id))
 
 (deftest current+diff-before-is-atomic-with-epoch-id
-  (testing "rf2-yng0y — the atomic sub's `:before` is ALWAYS the
-            `:db-before` of its own `:epoch-id`, across every focus
-            selection. There is no `{:before :epoch-id}` pair where the
-            two name different epochs — the stale-`before` glitch is
-            impossible by construction."
+  (testing "rf2-yng0y / rf2-02j4r — the atomic sub's `:before` is ALWAYS
+            the `:db-before` of its own `:epoch-id` and `:value` is its
+            `:db-after`, across every focus selection. No
+            `{:value :before :epoch-id}` triple names a different epoch
+            for any slot — the stale-`before` glitch is impossible by
+            construction, and the diff is always the epoch's own delta."
     (h/setup-xray-frame!)
     (h/seed-cascades! cascades)
     (h/seed-epoch-history! epoch-history)
-    ;; Focus :c1 (epoch :e1, db-before {}).
+    ;; Focus :c1 (epoch :e1, db-before {}, db-after {:counter 1}).
     (h/focus-cascade! :c1)
     (is (= :e1 (assert-atomic! "focus :c1")))
-    (let [{:keys [before epoch-id]} (h/read-sub :rf.xray/app-db-current+diff)]
+    (let [{:keys [value before epoch-id]} (h/read-sub :rf.xray/app-db-current+diff)]
       (is (= :e1 epoch-id))
-      (is (= {} before) ":e1's db-before is the empty map"))
-    ;; Flip to :c2 (epoch :e2, db-before {:counter 1}) — the slot the
-    ;; flash used to surface on. before + epoch-id move together.
+      (is (= {} before) ":e1's db-before is the empty map")
+      (is (= {:counter 1} value) ":e1's db-after is {:counter 1}"))
+    ;; Flip to :c2 (epoch :e2, db-before {:counter 1}, db-after
+    ;; {:counter 2}) — the slot the flash used to surface on. value +
+    ;; before + epoch-id all move together.
     (h/focus-cascade! :c2)
     (is (= :e2 (assert-atomic! "focus :c2")))
-    (let [{:keys [before epoch-id]} (h/read-sub :rf.xray/app-db-current+diff)]
+    (let [{:keys [value before epoch-id]} (h/read-sub :rf.xray/app-db-current+diff)]
       (is (= :e2 epoch-id))
-      (is (= {:counter 1} before) ":e2's db-before is {:counter 1}"))
+      (is (= {:counter 1} before) ":e2's db-before is {:counter 1}")
+      (is (= {:counter 2} value) ":e2's db-after is {:counter 2}"))
     ;; Flip back — invariant holds in both directions.
     (h/focus-cascade! :c1)
     (is (= :e1 (assert-atomic! "focus :c1 (return)")))))
 
-(deftest current+diff-value-is-stable-while-before-tracks-focus
-  (testing "rf2-yng0y — the App-DB tab is a CURRENT-STATE inspector:
-            `:value` is the live target-frame-db (constant as the
-            operator scrubs epochs); only `:before` moves per epoch.
-            Confirms the panel's atomic contract — value steady, before
-            tracking — so the diff overlay is the sole per-epoch change."
+(deftest current+diff-value-and-before-both-track-focus
+  (testing "rf2-02j4r — the App-DB tab shows the SELECTED epoch's OWN
+            delta: BOTH `:value` (db-after) and `:before` (db-before)
+            move per epoch, so the inline diff is db-before(N) →
+            db-after(N) and nothing later bleeds in. (This REVERSES the
+            rf2-yng0y `:value = live-db, constant as you scrub` design.)"
     (h/setup-xray-frame!)
     (h/seed-cascades! cascades)
     (h/seed-epoch-history! epoch-history)
@@ -191,11 +214,75 @@
       (h/focus-cascade! :c2)
       (let [v2 (:value (h/read-sub :rf.xray/app-db-current+diff))
             b2 (:before (h/read-sub :rf.xray/app-db-current+diff))]
-        (is (= v1 v2)
-            ":value is constant across the scrub (live target-frame-db)")
+        (is (not= v1 v2)
+            ":value moves with the focused epoch (db-after(N)) — NOT a
+             constant live-db (rf2-02j4r reversal)")
         (is (not= b1 b2)
-            ":before moves with the focused epoch — the diff overlay is
-             the only per-epoch change")))))
+            ":before moves with the focused epoch (db-before(N))")
+        (is (= {:counter 1} v1) ":e1's value is its db-after")
+        (is (= {:counter 2} v2) ":e2's value is its db-after")))))
+
+;; ---- rf2-02j4r — no later-event bleed onto an earlier selection ---------
+;;
+;; THE BUG: focusing a NON-head epoch N showed the CUMULATIVE diff
+;; live-db vs db-before(N) — every change from N forward to NOW lit up,
+;; so a key added by a LATER event bled onto epoch N's selection. This
+;; test focuses an EARLIER epoch after a later event has occurred and
+;; asserts the sub yields exactly epoch N's own delta (db-after(N)),
+;; with no trace of the later event's key. The head-only test passes
+;; under the OLD buggy code (live == db-after at head); this one focuses
+;; a non-head epoch, so it FAILS under the old code and PASSES only with
+;; the per-epoch-delta fix.
+
+(def bleed-cascades
+  [(h/cascade :early :rf/default)
+   (h/cascade :late  :rf/default)])
+
+(def bleed-history
+  ;; :early adds :media/deep; :late (the LATER event) adds :media/shallow.
+  ;; The live head db carries BOTH keys.
+  [(h/mock-epoch :ep-early :early
+                 {:counter 1}
+                 {:counter 1 :media/deep :on})
+   (h/mock-epoch :ep-late  :late
+                 {:counter 1 :media/deep :on}
+                 {:counter 1 :media/deep :on :media/shallow :on})])
+
+(deftest earlier-epoch-shows-own-delta-no-later-bleed
+  (testing "rf2-02j4r — selecting an EARLIER epoch after a later event
+            occurred shows ONLY that epoch's own delta; the later
+            event's added key does NOT bleed in. Focus :ep-early (which
+            added :media/deep): :value must be ep-early's db-after
+            (carrying :media/deep but NOT :media/shallow), and the diff
+            against :before introduces ONLY :media/deep."
+    (h/setup-xray-frame!)
+    (h/seed-cascades! bleed-cascades)
+    (h/seed-epoch-history! bleed-history)
+    ;; Scrub BACK to the earlier epoch (the head is :ep-late).
+    (h/focus-cascade! :early)
+    (let [{:keys [value before epoch-id]}
+          (h/read-sub :rf.xray/app-db-current+diff)]
+      (is (= :ep-early epoch-id) "focus resolved to the earlier epoch")
+      (is (= {:counter 1 :media/deep :on} value)
+          ":value is ep-early's OWN db-after — :media/deep present")
+      (is (not (contains? value :media/shallow))
+          "rf2-02j4r — :media/shallow (added by the LATER :late event)
+           must NOT bleed into the earlier selection's :value")
+      (is (= {:counter 1} before)
+          ":before is ep-early's db-before (no :media/* keys yet)")
+      ;; The inline diff (value vs before) introduces ONLY :media/deep.
+      (let [added-keys (remove (set (keys before)) (keys value))]
+        (is (= [:media/deep] (vec added-keys))
+            "the per-epoch delta adds exactly :media/deep — nothing the
+             later event introduced")))
+    ;; Sanity: focusing the LATER epoch shows ITS own delta (:media/shallow).
+    (h/focus-cascade! :late)
+    (let [{:keys [value before]} (h/read-sub :rf.xray/app-db-current+diff)]
+      (is (contains? value :media/shallow)
+          ":late's db-after carries :media/shallow")
+      (let [added-keys (remove (set (keys before)) (keys value))]
+        (is (= [:media/shallow] (vec added-keys))
+            ":late's per-epoch delta adds exactly :media/shallow")))))
 
 (deftest app-db-state-section-model-tracks-focused-before
   (testing "rf2-yng0y — `:rf.xray/app-db-state` (the panel's consumed


### PR DESCRIPTION
## Summary

Two disjoint-file Xray fixes.

### rf2-02j4r (P2 BUG, Mike-ruled) — app-db panel per-epoch delta

The app-db panel showed a **cumulative** diff (live db vs focused `:db-before`) instead of the selected epoch's **own** delta, so later events' changes bled onto earlier selections when scrubbing history (the core time-travel use case). Reproduced live on machine-epochs: focusing the `:media/deep` epoch wrongly lit `:media/shallow` (added by a later event).

Per Mike's ruling, `:rf.xray/app-db-current+diff` now sets `:value` to the focused epoch's **`:db-after`** (its own post-state), so the inline diff is `db-before(N) → db-after(N)` — epoch N's per-epoch delta, independent of any later event. Cold-boot / no-focus falls back to the live db (plain current-state, unchanged).

- **Reverses** the rf2-yng0y `value=live, constant as you scrub` design.
- **Strengthens** the atomicity invariant — every slot (`:value` / `:before` / `:epoch-id`) now comes from one focused record.
- **Composes with** the rf2-nfgps `[frame-id epoch-id]` cache keying (untouched; lives in the sibling `selected-epoch-diff` sub).
- rf2-227cz added-instance behaviour stays correct under the new baseline.

Added a bleed test (`earlier-epoch-shows-own-delta-no-later-bleed`) reproducing the bead's `:media/deep` / `:media/shallow` scenario on a **non-head** focused epoch — fails under the old code, passes with the fix. Updated the rf2-yng0y atomicity tests to assert `:value = db-after(N)`.

### rf2-l1ru8 (P2) — Static Flows tab mnemonic

Investigated: the Static Flows tab registered `:mnem "l"`, off-convention. **Determination: impl bug.**
- `f` is **free** in the Static mnemonic set (Machines `m` / Routes `r` / Schemas `c` / Interceptors `i`).
- The convention is **first-letter-of-label** (Machines→m, Routes→r, Interceptors→i; Schemas uses `c` because `s` is the Settings key — Flows has no such collision).
- The Static shell's own canonical IA listing (`static/shell.cljs`) documents **"Flows (f)"** as intended.

Fixed the panel to `:mnem "f"`. The skill (which already says `f`) is correct and is **not** edited here.

### Spec

`tools/xray/spec/004-App-DB-Diff.md` §Diff-semantics + `021-Dynamic-Panel-Designs.md` §4.5/§4.6 now document per-epoch-delta, replacing the yng0y cumulative wording.

## Test plan

- `npm run test:cljs` — **5615 tests, 19561 assertions, 0 failures, 0 errors** (cold; 0 compile warnings)
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, 13 matrix rows** (cold)

Closes rf2-02j4r and rf2-l1ru8.