### PR TITLE
fix(story-mcp): guard scrub-rendered value-redaction against short-scalar over-scrub (rf2-g7cd1)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
@@ -43,7 +43,16 @@
   `elide-wire-value` emits. This honours the Tool-Pair §Direct-read
   privacy MUST intent — 'live runtime state crossing the MCP egress
   is scrubbed' — for the rendered surface, with the same
-  `:include-sensitive` opt-out escape hatch as `:app-db`."
+  `:include-sensitive` opt-out escape hatch as `:app-db`.
+
+  Value-matching is a heuristic; its one collateral hazard is a
+  sensitive path holding a SHORT/COMMON scalar (`0`, `200`, `:ok`),
+  which would scrub every benign leaf that equals it. `sensitive-values`
+  guards that (rf2-g7cd1) by dropping any candidate that ALSO appears at
+  a NON-sensitive app-db path — such a value is already disclosed
+  verbatim by the path-based `:app-db` egress, so excluding it leaks
+  nothing new while restoring the benign leaves. See `sensitive-values`
+  for the fail-SAFE argument."
   (:require [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]
             [re-frame.mcp-base.elision :as base-elision]
@@ -130,6 +139,56 @@
 ;; Derived-tree value-based redaction (rf2-ee38b.17)
 ;; ---------------------------------------------------------------------------
 
+(defn- under-prefix?
+  "True when `path` is `prefix` or descends from it (element-wise
+  prefix match). Both are indexed vectors. Used to decide whether an
+  app-db position is governed by a declared-`:sensitive?` path — a slot
+  marked sensitive covers itself AND everything beneath it."
+  [prefix path]
+  (let [pn (count prefix)]
+    (and (<= pn (count path))
+         (loop [i 0]
+           (cond
+             (== i pn)                       true
+             (= (nth prefix i) (nth path i)) (recur (inc i))
+             :else                           false)))))
+
+(defn- collect-public-values!
+  "Walk `node` at `path`, conj!ing onto transient set `acc!` every value
+  (intermediate collections AND leaves) that (a) is `=` to a candidate
+  secret and (b) sits at a position NOT governed by any sensitive
+  prefix. A value reached only under a sensitive prefix is never
+  collected, so it cannot dilute the candidate set. Returns `acc!`.
+
+  Map keys are walked at the same `path` as their entry (a key is not a
+  distinct app-db segment), so a candidate used as a benign key at a
+  non-sensitive position also counts as public."
+  [acc! node path sensitive-prefixes candidates]
+  (let [governed? (some #(under-prefix? % path) sensitive-prefixes)]
+    (when (and (not governed?) (contains? candidates node))
+      (conj! acc! node))
+    (cond
+      (map? node)
+      (reduce-kv (fn [a k v]
+                   (collect-public-values! a k path sensitive-prefixes candidates)
+                   (collect-public-values! a v (conj path k) sensitive-prefixes candidates))
+                 acc! node)
+
+      (vector? node)
+      (reduce (fn [a i] (collect-public-values! a (nth node i) (conj path i)
+                                                sensitive-prefixes candidates))
+              acc! (range (count node)))
+
+      (or (set? node) (seq? node))
+      ;; Sets / seqs have no stable path segment for elements, so we walk
+      ;; them at the SAME path (the collection's own position). Membership
+      ;; is what matters for value-aliasing, not the index.
+      (reduce (fn [a x] (collect-public-values! a x path sensitive-prefixes candidates))
+              acc! node)
+
+      :else
+      acc!)))
+
 (defn- sensitive-values
   "The set of live values sitting at `variant-id`'s declared-`:sensitive?`
   app-db paths, read out of `app-db`. Used to value-redact derived trees
@@ -140,14 +199,42 @@
   populated from `{:sensitive? true}` schema metadata, same as
   `elide-app-db`'s pre-step). Nil / boolean values are excluded — a `nil`
   or `false` leaf is not a secret and value-matching them would scrub
-  swathes of benign tree."
+  swathes of benign tree.
+
+  ## Non-unique-secret guard (rf2-g7cd1)
+
+  Value-based redaction is a heuristic: it substitutes EVERY derived-tree
+  leaf `=` a sensitive value. When a sensitive path holds a short/common
+  scalar (`0`, an HTTP `200`, `:ok`, `\"\"`), naive value-matching scrubs
+  every benign leaf that merely happens to equal it — degrading the
+  agent's view AND leaking the secret's value-CLASS.
+
+  The guard subtracts any candidate value that ALSO appears at a
+  NON-sensitive app-db position. Such a value is provably NOT a protected
+  secret: `elide-app-db` (path-based) ships it VERBATIM in the `:app-db`
+  slot via that non-sensitive path, so it is already disclosed on the
+  wire. Removing it from the derived-tree secret set therefore leaks
+  nothing new — the fail-SAFE invariant (never leak a genuine secret)
+  holds by construction. A value that appears ONLY under sensitive paths
+  stays in the set and is still redacted everywhere (no under-scrub); the
+  irreducible same-value aliasing case (a uniquely-secret short scalar)
+  still over-scrubs — that residual is fail-SAFE, never under-safe."
   [app-db variant-id]
   (refresh-elision-from-schemas! variant-id)
-  (let [decls (rf/elision-sensitive-declarations variant-id)]
-    (into #{}
-          (comp (map (fn [path] (get-in app-db (vec path) ::absent)))
-                (remove #(or (= ::absent %) (nil? %) (boolean? %))))
-          (keys decls))))
+  (let [decls              (rf/elision-sensitive-declarations variant-id)
+        sensitive-prefixes (mapv vec (keys decls))
+        candidates         (into #{}
+                                 (comp (map (fn [path] (get-in app-db path ::absent)))
+                                       (remove #(or (= ::absent %) (nil? %) (boolean? %))))
+                                 sensitive-prefixes)]
+    (if (empty? candidates)
+      #{}
+      (let [public (persistent!
+                     (collect-public-values! (transient #{}) app-db []
+                                              sensitive-prefixes candidates))]
+        ;; Keep only candidates that appear EXCLUSIVELY under sensitive
+        ;; paths — those are the genuinely-secret values.
+        (into #{} (remove public) candidates)))))
 
 (defn- redact-matching
   "Walk `tree`, substituting any leaf `=` to a member of `secrets` with the

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -2152,6 +2152,87 @@
           (is (identical? hiccup out)
               "no secrets ⇒ no walk, input ref returned"))))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-g7cd1 — value-redaction over-scrub guard.
+;;
+;; The value-based walk substitutes EVERY derived-tree leaf `=` a
+;; declared-sensitive value. When a sensitive path holds a short/common
+;; scalar (`0`, `200`, `:ok`), naive matching scrubs every benign leaf that
+;; merely equals it — degrading the agent's view AND leaking the secret's
+;; value-CLASS. `sensitive-values` guards that: a candidate value that ALSO
+;; sits at a NON-sensitive app-db path is dropped from the secret set, because
+;; the path-based `:app-db` egress already ships that value verbatim (it is
+;; provably already disclosed, so excluding it leaks nothing new). These tests
+;; pin BOTH the precision win AND the fail-SAFE invariant (a value that is
+;; UNIQUELY secret — only under sensitive paths — stays redacted).
+;; ---------------------------------------------------------------------------
+
+(deftest scrub-rendered-short-scalar-aliased-to-public-path-is-not-over-scrubbed
+  (testing "a short sensitive scalar that ALSO sits at a non-sensitive app-db path is provably public — benign leaves equal to it survive"
+    (with-clean-frame [vid :story.button/primary]
+      ;; :http-status is sensitive and holds 0; :retry-count holds the SAME
+      ;; scalar 0 at a NON-sensitive path, so 0 is already shipped verbatim
+      ;; by the path-based :app-db egress — it is not a protectable secret.
+      (let [db     {:http-status 0          ; sensitive path
+                    :retry-count 0           ; benign path, same scalar
+                    :public      "ok"}
+            ;; Derived tree with many benign leaves equal to 0 (a tab-index,
+            ;; an aria level, a count) that the naive walk would have scrubbed.
+            hiccup [:ul {:tabindex 0}
+                    [:li {:data-level 0} "first"]
+                    [:li {:data-level 0} "second"]]]
+        (seed-app-db! vid db)
+        (declare-sensitive! vid [:http-status])
+        (let [scrub-rendered (requiring-resolve 're-frame.story-mcp.tools.egress/scrub-rendered)
+              out            (scrub-rendered hiccup db vid false)]
+          (is (not (tree-contains? out :rf/redacted))
+              "0 appears at a non-sensitive app-db path, so it is dropped from the secret set — no benign 0 leaf is over-scrubbed")
+          (is (= 0 (get-in out [1 :tabindex]))
+              "benign 0 attribute values survive untouched")
+          (is (= 0 (get-in out [2 1 :data-level]))
+              "benign 0 leaves deep in the tree survive")
+          (is (identical? hiccup out)
+              "with no remaining secrets the tree is returned unwalked"))))))
+
+(deftest scrub-rendered-uniquely-secret-short-scalar-stays-redacted
+  (testing "FAIL-SAFE: a short scalar that sits ONLY at the sensitive path (no benign alias) is still redacted — no under-scrub"
+    (with-clean-frame [vid :story.button/primary]
+      ;; The sensitive scalar 7 is UNIQUE to the sensitive path — it does NOT
+      ;; appear at any non-sensitive app-db path, so the guard must keep it in
+      ;; the secret set. (Over-scrub of any benign 7 elsewhere is the
+      ;; irreducible value-aliasing residual and is fail-SAFE.)
+      (let [db     {:pin    7
+                    :public "ok"}
+            hiccup [:input {:type "password" :value 7}]]
+        (seed-app-db! vid db)
+        (declare-sensitive! vid [:pin])
+        (let [scrub-rendered (requiring-resolve 're-frame.story-mcp.tools.egress/scrub-rendered)
+              out            (scrub-rendered hiccup db vid false)]
+          (is (not (tree-contains? out 7))
+              "the uniquely-secret scalar 7 MUST NOT survive on the wire (no under-scrub)")
+          (is (= :rf/redacted (get-in out [1 :value]))
+              "the sensitive leaf is replaced with the :rf/redacted sentinel"))))))
+
+(deftest scrub-rendered-genuine-long-secret-still-redacted
+  (testing "FAIL-SAFE regression: a genuinely-sensitive long secret on its path is still fully redacted (the guard does not weaken distinctive-secret redaction)"
+    (with-clean-frame [vid :story.button/primary]
+      (let [db     {:public "ok"
+                    :token  "sk-live-9f8a7b6c5d4e3f2a1b0c-TOPSECRET"}
+            hiccup [:div {:class "card"}
+                    [:input {:type "password"
+                             :value "sk-live-9f8a7b6c5d4e3f2a1b0c-TOPSECRET"}]
+                    [:span "token: " "sk-live-9f8a7b6c5d4e3f2a1b0c-TOPSECRET"]]]
+        (seed-app-db! vid db)
+        (declare-sensitive! vid [:token])
+        (let [scrub-rendered (requiring-resolve 're-frame.story-mcp.tools.egress/scrub-rendered)
+              out            (scrub-rendered hiccup db vid false)]
+          (is (not (tree-contains? out "sk-live-9f8a7b6c5d4e3f2a1b0c-TOPSECRET"))
+              "the distinctive long secret MUST NOT survive anywhere in the derived tree")
+          (is (tree-contains? out :rf/redacted)
+              "matching leaves are replaced with the :rf/redacted sentinel")
+          (is (= "card" (get-in out [1 :class]))
+              "benign attribute values survive untouched"))))))
+
 ;; The two integration tests below pin the WIRING — that `preview-variant`
 ;; and `run-variant` route `:rendered-hiccup` / `:effective-args` / `:snapshot`
 ;; through `scrub-rendered`. They `with-redefs` `story/run-variant` to a


### PR DESCRIPTION
## Summary

`scrub-rendered` value-redacts derived trees (rendered hiccup, `:effective-args`, `:snapshot`, the `.4` evidence trees) by collecting the live values sitting at a frame's declared-`:sensitive?` app-db paths and substituting any `=`-matching leaf with `:rf/redacted`. The only false-positive guard was excluding nil/booleans.

**Bug (rf2-g7cd1, RISK/privacy-fidelity):** when a sensitive path holds a short/common scalar (`0`, an HTTP `200`, `:ok`, a 1-char string), EVERY benign leaf equal to it across the derived tree got over-scrubbed — degrading the agent's view AND leaking the secret's value-CLASS. This is fail-SAFE (over-scrub, never under-scrub) but degrades fidelity, which is load-bearing for the rf2-ee38b.17 headline leak fix.

## Fix

`tools/story-mcp/.../egress.cljc` — `sensitive-values` now applies a **non-unique-secret guard**: it drops any candidate value that ALSO appears at a NON-sensitive app-db position.

Such a value is **provably not a protected secret** — the path-based `:app-db` egress (`elide-app-db`) ships it verbatim via that non-sensitive path, so it is already disclosed on the wire. Excluding it from the derived-tree secret set therefore leaks nothing new.

- A value appearing ONLY under sensitive paths stays in the set and is still redacted everywhere → **no under-scrub**.
- The irreducible same-value aliasing residual (a *uniquely*-secret short scalar) still over-scrubs → fail-SAFE.

The **fail-safe invariant — never leak a genuine secret — holds by construction.**

New helpers (both `^:private`): `under-prefix?` (a sensitive slot governs itself + its subtree) and `collect-public-values!` (single walk of app-db collecting candidate values seen at non-sensitive positions).

## Tests (`tools_test.clj`)

1. `scrub-rendered-short-scalar-aliased-to-public-path-is-not-over-scrubbed` — `0` is sensitive at `[:http-status]` AND benign at `[:retry-count]`; benign `0` leaves in the derived tree survive (no `:rf/redacted`, tree returned unwalked).
2. `scrub-rendered-uniquely-secret-short-scalar-stays-redacted` — FAIL-SAFE: a short scalar (`7`) unique to the sensitive path is still redacted (no under-scrub).
3. `scrub-rendered-genuine-long-secret-still-redacted` — FAIL-SAFE regression: a distinctive long secret on its path is still fully redacted everywhere.

## Gate

`tools/story-mcp` `clojure -M:test` (cold): **209 tests, 1059 assertions, 0 failures, 0 errors** — includes the existing `egress`/redaction suite plus the 3 new tests.

`egress.cljc` is JVM-only and bundle-isolated (nothing under `implementation/` requires it), so `npm run test:cljs` is not in this change's coverage. No conformance gate lives in `tools/story-mcp` (that's `tools/mcp-conformance`, out of scope).

## Cross-ref

Sibling concern flagged in the bead: the same value-based redaction exists in `tools/re-frame2-pair-mcp` (rf2-6wvh5/rf2-j90sb). Out of scope here; noted for that owner.

Closes rf2-g7cd1.