### PR TITLE
refactor(subs): rename make-layer-n-1-memoised-body -> make-layer-n-single-input-memoised-body (rf2-15gza)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -192,7 +192,7 @@
 (declare subscribe unsubscribe)
 
 ;; The memo wrappers (`make-layer-1-memoised-body`,
-;; `make-layer-n-1-memoised-body`, `make-layer-n-memoised-body`) and
+;; `make-layer-n-single-input-memoised-body`, `make-layer-n-memoised-body`) and
 ;; the trace/perf/validate/recover bracket (`validate-and-trace`,
 ;; `maybe-validate-sub!`) live in `re-frame.subs.memo` — extracted
 ;; per rf2-0ytl4 Phase-2 seam S-B. Per-recompute hot path is the closure
@@ -207,7 +207,7 @@
   The compute fn handed to the substrate adapter is built in two
   layers, each named:
 
-    - `make-layer-1-memoised-body` / `make-layer-n-1-memoised-body` /
+    - `make-layer-1-memoised-body` / `make-layer-n-single-input-memoised-body` /
       `make-layer-n-memoised-body` — Spec 006 §No-op via value
       equality (rf2-719e). Wraps the user's body in a `=`-skipping
       memo. The layer-1 form is fixed-arity-1 and compares the db
@@ -247,7 +247,7 @@
                         ;; shape per rf2-v1nu0; specialise to fixed-arity-1
                         ;; for parity with layer-1 (rf2-0y2bp).
                         (= 1 (count input-signals))
-                        (subs-memo/make-layer-n-1-memoised-body
+                        (subs-memo/make-layer-n-single-input-memoised-body
                           body-fn query-id query-v frame-id input-signals sub-meta)
                         :else
                         (subs-memo/make-layer-n-memoised-body

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -440,7 +440,7 @@
             (vreset! last-result computed)
             computed))))))
 
-(defn make-layer-n-1-memoised-body
+(defn make-layer-n-single-input-memoised-body
   "Specialised memo wrapper for layer-2 subs with a single `:<-` input
   (the dominant layer-2 shape — see rf2-v1nu0 perf-sweep finding).
   Fixed-arity-1 — avoids the varargs-seq allocation that a
@@ -516,7 +516,7 @@
   yields nil on every call without touching the memo cells.
 
   See `make-layer-1-memoised-body` for the layer-1 specialisation and
-  `make-layer-n-1-memoised-body` for the layer-2 single-input
+  `make-layer-n-single-input-memoised-body` for the layer-2 single-input
   specialisation (rf2-0y2bp)."
   [body-fn query-id query-v frame-id input-signals sub-meta]
   (let [last-in-vals (volatile! ::unset)


### PR DESCRIPTION
## What

Rename the layer-2 single-input sub memo-wrapper constructor:

- **before:** `make-layer-n-1-memoised-body`
- **after:** `make-layer-n-single-input-memoised-body`

## Why

`make-layer-n-1` reads as arithmetic ("layer N **minus 1**") but actually means "layer-N with **1** input". The hyphenated digit visually collides with the layer-number scheme of its sibling `make-layer-1-memoised-body`, so the trio was genuinely confusing on first read. The new name keeps the three-way distinction legible:

- `make-layer-1-memoised-body` — layer-1, reads app-db directly
- `make-layer-n-single-input-memoised-body` — layer-2+, single `:<-` input (dominant shape; fixed-arity-1)
- `make-layer-n-memoised-body` — layer-2+, two-or-more `:<-` inputs (varargs)

## Scope

Pure rename, **no behaviour change**. All references are slice-internal to `implementation/core` (no public facade export). Updated every reference:

- `subs/memo.cljc` — the `defn` + the docstring cross-ref in `make-layer-n-memoised-body`
- `subs.cljc` — the call site in `compute-and-cache!` + two comment/docstring listings

## Gates (cold, from `implementation/`)

- `npm run test:cljs` — **5614 tests / 19547 assertions, 0 failures, 0 errors**
- core JVM `clojure -M:test` — **864 tests / 3879 assertions, 0 failures, 0 errors**

Elision gate not run: pure symbol rename leaves the function body, its `debug-enabled?` gating, and all conditionals untouched — nothing on the elision path changed.

Closes rf2-15gza.