### PR TITLE
feat(mcp-conformance): add teeth to descriptor + hermetic gates (rf2-yi451 + rf2-ybiz0 + rf2-fphr3)

### DIFF
--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -59,6 +59,61 @@ handshake, walks one canonical workflow per server using `listTools()`
 and `callTool()`, and tears the transport down cleanly. Any spec drift
 on the server side surfaces as an SDK parse-error.
 
+### Coverage boundary — keyword-intern bounds (rf2-fphr3)
+
+The charter's threat model asks whether the corpus has teeth on the
+**keyword-intern bounds** — the DoS surface where a server keywordizes
+an unbounded stream of agent-supplied strings (event ids, sub ids,
+frame ids, mode/slice args) into the JVM's never-shrinking global
+keyword table. **This is NOT a cross-server WIRE contract** (the
+conformance gate's natural remit — egress redaction, overflow markers,
+flag gating, descriptor shape); it is a per-server **input-sanitisation**
+property, and it is **covered, by construction, at the `mcp-base` unit
+layer** — the shared coercion ns every server routes agent-supplied ids
+through (the conformance gate covers the wire; intern bounding is
+covered by `mcp-base`'s `args` tests):
+
+- **`re-frame.mcp-base.args/safe-keyword`** — the bounded-allowlist
+  resolver. Membership-checks BEFORE constructing the keyword (via JVM
+  `find-keyword`, which never interns), so a caller-supplied string
+  outside the finite set never mints a fresh keyword. Pinned by
+  `tools/mcp-base/test/re_frame/mcp_base/args_test.clj`
+  (`safe-keyword-disallowed-string-returns-nil-and-does-not-intern`
+  for the bare-name arm, plus
+  `safe-keyword-disallowed-NAMESPACED-string-returns-nil-and-does-not-intern`
+  — rf2-ynjts.17 — for the namespaced arm the registry-backed frame-id
+  / `:rf.assert/*` coercions actually hit). Both assert via a
+  `find-keyword` probe that the rejected novel name is absent from the
+  table both before and after the call: a literal no-intern-on-rejection
+  proof.
+- **`re-frame.mcp-base.args/parse-mode`** — routes every finite-set arm
+  through `safe-keyword` so the membership check precedes any intern
+  (rf2-ih7g4 flipped the historical intern-then-check order). Pinned by
+  `parse-mode-unknown-string-does-not-intern`.
+- **`re-frame.mcp-base.args/fresh-keyword`** — the deliberately-interning
+  primitive, reserved (per its docstring policy) for **bounded-cost**
+  sites only: operator-gated write paths (story-mcp's `--allow-writes`
+  + the `:story.<path>/<name>` grammar bound), runtime-registry-bounded
+  read paths (re-frame2-pair-mcp's frame-id coercion, where the live
+  registry size caps allocation), and grammar-bounded registrars.
+  Pinned by `fresh-keyword-interns-on-fresh-input` (rf2-xxtrz).
+
+On the wire-validated paths the conformance corpus DOES drive
+(`dispatch` event ids, `read-sub` sub ids), the server additionally
+VALIDATES the id against the live registrar and refuses unknowns with
+`:reason :unknown-id` + `:nearest` matches (rf2-3bu3d.3) — bounding the
+accepted set to the registered universe before any intern. So the
+intern surface is doubly bounded: the `mcp-base` allowlist/registry gate
+upstream, and the registrar validation at the tool body.
+
+This note records the seam so a reviewer does not read the conformance
+gate's silence on intern bounds as "uncovered". If a future open-world
+intern path emerges that is bounded by NEITHER a `mcp-base` allowlist nor
+a runtime registry (e.g. an arbitrary-topic-string surface that
+keywordizes without a finite gate), that is a server-side bug to file
+against `mcp-base` / the owning server — not a hole in this cross-server
+wire gate.
+
 ## Files
 
 - `package.json` — depends on `@modelcontextprotocol/sdk` only
@@ -87,7 +142,11 @@ on the server side surfaces as an SDK parse-error.
   ON + `:include-sensitive true`. Pins BOTH directions so the gate can't
   silently invert. This is the regression net for rf2-6wvh5 (the leak
   the gate let ship green). Gated on `$SHADOW_CLJS_NREPL_PORT` (same
-  posture as the other live variants).
+  posture as the other live variants). Has a standalone
+  `npm run test:re-frame2-pair-live-redaction` script (rf2-ybiz0) for
+  local runnability + parity with the overflow / subscribe variants —
+  without a live port it SKIPs, with one (e.g. an externally-attached
+  shadow-cljs) it runs the full gate.
 - `scripts/run-live-re-frame2-pair-overflow-hermetic.cjs` — hermetic
   orchestrator (rf2-uw6d6) that boots shadow-cljs against the re-frame2-pair
   fixture (`skills/re-frame2-pair/tests/fixture/`), launches headless
@@ -95,7 +154,12 @@ on the server side surfaces as an SDK parse-error.
   (`live-re-frame2-pair-overflow.cjs`, `live-re-frame2-pair-subscribe.cjs`,
   `live-re-frame2-pair-redaction.cjs`) against the spawned
   `SHADOW_CLJS_NREPL_PORT`. Closes the CI-coverage gap the SKIP path
-  leaves on each.
+  leaves on each. **Observable-SKIP guard (rf2-ybiz0):** after each inner
+  test exits 0 the orchestrator asserts it printed its `... CONFORMANCE
+  GREEN` sentinel AND did NOT print a `SKIP ` banner — so a setup-path
+  regression that left a load-bearing live gate SKIPping (exit 0, never
+  exercised) turns the hermetic job RED (exit 2, orchestration failure)
+  instead of riding green on the other inner tests.
 - `test/end-to-end-story.cjs` — story-mcp conformance (full write-loop
   with `--allow-writes` enabled) + closed-world read-path success
   envelopes

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -8,6 +8,7 @@
     "test:re-frame2-pair": "node test/end-to-end-re-frame2-pair.cjs",
     "test:re-frame2-pair-live-overflow": "node test/live-re-frame2-pair-overflow.cjs",
     "test:re-frame2-pair-live-subscribe": "node test/live-re-frame2-pair-subscribe.cjs",
+    "test:re-frame2-pair-live-redaction": "node test/live-re-frame2-pair-redaction.cjs",
     "test:re-frame2-pair-live-overflow-hermetic": "node scripts/run-live-re-frame2-pair-overflow-hermetic.cjs",
     "test:story": "node test/end-to-end-story.cjs",
     "test:flag-gates": "node test/end-to-end-flag-gates.cjs",

--- a/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
@@ -158,14 +158,27 @@ const POLL_MS = 100;
 // (rf2-zb5z6). The orchestrator's name keeps `overflow` for backward
 // compatibility with the workflow YAML's script reference; the
 // `INNER_TESTS` list IS the authoritative inventory.
+//
+// Per rf2-ybiz0: each entry carries the test's success `sentinel` — the
+// `... CONFORMANCE GREEN` line it prints ONLY on a real (non-skipped)
+// pass. The hermetic env guarantees `$SHADOW_CLJS_NREPL_PORT` is set, so
+// the inner test's SKIP gate MUST NOT fire here — yet a SKIP still
+// exits 0. Without a sentinel check, a regression that broke the
+// orchestrator's SETUP path (port probe, bundle compile, runtime
+// sentinel) short of an inner-test FAILURE could leave the load-bearing
+// redaction gate SKIPping (exit 0) while CI shows the hermetic job green
+// via the OTHER inner tests. Asserting the sentinel (and the absence of
+// a `SKIP ` banner) makes a silent in-hermetic SKIP turn the gate RED.
 const INNER_TESTS = [
   {
     name: 'live overflow conformance',
     path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-overflow.cjs'),
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE OVERFLOW CONFORMANCE GREEN',
   },
   {
     name: 'live subscribe / notifications/progress conformance',
     path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-subscribe.cjs'),
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE SUBSCRIBE CONFORMANCE GREEN',
   },
   {
     // rf2-q4o83 — egress-redaction regression net for the pull-mode
@@ -175,6 +188,7 @@ const INNER_TESTS = [
     // gate-ON. This is the gate that would have caught rf2-6wvh5 RED.
     name: 'live egress-redaction conformance (pull-mode epoch tools)',
     path: path.join(MCP_CONFORMANCE_ROOT, 'test', 'live-re-frame2-pair-redaction.cjs'),
+    sentinel: 'RE-FRAME2-PAIR-MCP LIVE EGRESS-REDACTION CONFORMANCE GREEN',
   },
 ];
 
@@ -708,13 +722,20 @@ async function main() {
     for (const test of INNER_TESTS) {
       const testFile = path.basename(test.path);
       log(`running ${testFile} - ${test.name}`);
+      // Capture the inner test's stdout so we can assert it actually RAN
+      // (printed its GREEN sentinel) — not merely exited 0 (a SKIP also
+      // exits 0). Per rf2-ybiz0.
+      let stdoutText = '';
       const testStatus = await new Promise((resolve, reject) => {
         const child = crossSpawn(process.execPath, [test.path], {
           cwd: MCP_CONFORMANCE_ROOT,
           stdio: ['ignore', 'pipe', 'pipe'],
           env: testEnv,
         });
-        child.stdout.on('data', (d) => recordChunk(`[${testFile}:stdout] `, d));
+        child.stdout.on('data', (d) => {
+          stdoutText += String(d);
+          recordChunk(`[${testFile}:stdout] `, d);
+        });
         child.stderr.on('data', (d) => recordChunk(`[${testFile}:stderr] `, d, 'stderr'));
         child.on('error', reject);
         child.on('exit', (code, signal) => {
@@ -743,6 +764,37 @@ async function main() {
         err.exitCode = testStatus;
         throw err;
       }
+      // ---- Observable-SKIP guard (rf2-ybiz0) ------------------------------
+      // The inner test exited 0 — but a SKIP also exits 0. The hermetic
+      // env sets $SHADOW_CLJS_NREPL_PORT, so the inner test's SKIP gate
+      // MUST NOT have fired. Assert it printed its success sentinel AND
+      // did NOT print a SKIP banner. A broken setup path that left the
+      // test SKIPping (port-file probe / bundle-compile / runtime-sentinel
+      // wait silently regressed in a way that didn't propagate the env)
+      // would otherwise leave this load-bearing gate UN-EXERCISED while
+      // the hermetic job stayed green on the other inner tests. This is
+      // an ORCHESTRATION failure (exit 2): the contract didn't fail, the
+      // setup did.
+      if (stdoutText.includes('\nSKIP ') || stdoutText.startsWith('SKIP ')) {
+        throw new Error(
+          `${testFile} SKIPped inside the hermetic orchestrator (exit 0) — ` +
+            'but the hermetic env guarantees $SHADOW_CLJS_NREPL_PORT is set, ' +
+            'so a SKIP here means the setup path regressed and left this ' +
+            'load-bearing live gate UN-EXERCISED (a silent SKIP would ship ' +
+            'green via the other inner tests). rf2-ybiz0. Inner stdout tail: ' +
+            stdoutText.slice(-400),
+        );
+      }
+      if (test.sentinel && !stdoutText.includes(test.sentinel)) {
+        throw new Error(
+          `${testFile} exited 0 but did NOT print its success sentinel ` +
+            `("${test.sentinel}"). The live gate did not actually run to ` +
+            'completion (a SKIP, an early return, or a truncated run). ' +
+            'rf2-ybiz0 requires each inner test to PROVE it ran, not just ' +
+            'exit 0. Inner stdout tail: ' + stdoutText.slice(-400),
+        );
+      }
+      log(`${testFile} ran to completion (sentinel observed)`);
     }
     log('RE-FRAME2-PAIR-MCP LIVE HERMETIC CONFORMANCE GREEN (' +
       INNER_TESTS.length + ' inner tests)');

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -387,10 +387,163 @@ function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
   }
 }
 
+// ---------------------------------------------------------------------
+// Per-descriptor CONTENT ratchet (rf2-yi451).
+//
+// `assertDescriptorShape` (above) pins that EVERY descriptor carries
+// SOME classification hint and a `max-tokens` PROP — but never WHICH
+// classifier, nor that the budget hint carries prose. The `tools/list`
+// name ratchet (`tool-names.json`, compared in each end-to-end-*.cjs)
+// pins WHICH tools exist. NEITHER pins per-tool CONTENT, so for an
+// UNCHANGED tool-set:
+//
+//   - a destructive write tool (restore-epoch, reset-frame-db,
+//     register-variant, …) silently re-classified `readOnlyHint:true`
+//     / `destructiveHint` dropped still passes — `readOnlyHint` alone
+//     satisfies the "≥1 set" check. annotations are the TRUST SIGNAL an
+//     agent host uses to auto-approve a call, so a destructive tool
+//     re-labelled read-only is a real (if narrow) safety regression;
+//   - a tool that dropped its `max-tokens` budget-hint PROSE ships green
+//     — only the PROP presence is pinned, not the description text.
+//
+// This ratchet closes both gaps. `expected` is a per-server fixture
+// (`test/fixtures/<server>-classifications.json`):
+//
+//   - `classifications` — tool-name -> posture, one of:
+//       `read-only`   readOnlyHint===true  AND destructiveHint!==true
+//       `destructive` destructiveHint===true AND readOnlyHint!==true
+//       `neither`     readOnlyHint!==true  AND destructiveHint!==true
+//                     (session-pin / streaming tools — classified via
+//                      openWorldHint; pinning `neither` catches a
+//                      side-effecting tool that wrongly gained
+//                      readOnlyHint, masking its effect)
+//   - `closed-world`  — tools whose descriptor MUST carry
+//                       `openWorldHint:false` (inline / no-runtime-reach
+//                       tools, e.g. get-re-frame2-pair-instructions). All
+//                       OTHER tools are not pinned on openWorldHint here
+//                       — the read-only/destructive axis is the trust-
+//                       classification a flipped-hint regression breaks;
+//                       the openWorld axis is the per-server `allowOpenWorld`
+//                       dimension `assertDescriptorShape` already handles.
+//
+// Also pins, per descriptor, that the `max-tokens` property carries a
+// NON-EMPTY `description` (the budget-hint prose — TOKEN-BUDGETS.md
+// §"Per-call override slot").
+//
+// The fixture's `classifications` key-set MUST match the live tool-set
+// EXACTLY (every tool pinned, no stale rows) — a tool present on the
+// wire but absent from the fixture (or vice-versa) trips, so a NEW tool
+// can't slip past unclassified and a REMOVED tool can't leave a dangling
+// row. Throws on the first violation with a server-agnostic message.
+// ---------------------------------------------------------------------
+function assertClassificationRatchet(tools, expected) {
+  const table = (expected && expected.classifications) || {};
+  const closedWorld = new Set((expected && expected['closed-world']) || []);
+  const liveNames = tools.map((t) => t.name).sort();
+  const pinnedNames = Object.keys(table).sort();
+
+  // 0. The fixture must pin EXACTLY the live tool-set — no unclassified
+  // new tool, no stale removed row. (The name ratchet already pins the
+  // live set against tool-names.json; this keeps the classification
+  // fixture in lockstep so a new tool can't ship unclassified.)
+  if (JSON.stringify(liveNames) !== JSON.stringify(pinnedNames)) {
+    const missing = liveNames.filter((n) => !table[n]);
+    const stale = pinnedNames.filter((n) => !tools.some((t) => t.name === n));
+    throw new Error(
+      'classification ratchet (rf2-yi451): the fixture must pin every live ' +
+        'tool exactly.\n  unclassified live tools (add a row): ' +
+        JSON.stringify(missing) +
+        '\n  stale fixture rows (no such tool): ' +
+        JSON.stringify(stale),
+    );
+  }
+
+  for (const t of tools) {
+    const a = t.annotations || {};
+    const posture = table[t.name];
+    const ro = a.readOnlyHint === true;
+    const de = a.destructiveHint === true;
+
+    // 1. The load-bearing classification: the EXACT readOnly/destructive
+    // posture. A flipped or dropped hint trips here.
+    if (posture === 'read-only') {
+      if (!ro || de) {
+        throw new Error(
+          'tool ' + t.name + ' classification regressed: fixture pins ' +
+            '`read-only` (readOnlyHint:true, destructiveHint NOT true) but the ' +
+            'live descriptor has readOnlyHint=' + JSON.stringify(a.readOnlyHint) +
+            ', destructiveHint=' + JSON.stringify(a.destructiveHint) +
+            '. annotations are the trust signal an agent host uses to ' +
+            'auto-approve a call — a misclassification is a safety regression ' +
+            '(rf2-yi451). Got annotations: ' + JSON.stringify(a),
+        );
+      }
+    } else if (posture === 'destructive') {
+      if (!de || ro) {
+        throw new Error(
+          'tool ' + t.name + ' classification regressed: fixture pins ' +
+            '`destructive` (destructiveHint:true, readOnlyHint NOT true) but the ' +
+            'live descriptor has readOnlyHint=' + JSON.stringify(a.readOnlyHint) +
+            ', destructiveHint=' + JSON.stringify(a.destructiveHint) +
+            '. A destructive write tool silently re-labelled read-only would ' +
+            'be auto-approved by an agent host — the exact false-green this ' +
+            'ratchet exists to turn RED (rf2-yi451). Got annotations: ' +
+            JSON.stringify(a),
+        );
+      }
+    } else if (posture === 'neither') {
+      if (ro || de) {
+        throw new Error(
+          'tool ' + t.name + ' classification regressed: fixture pins ' +
+            '`neither` (a session-pin / streaming tool — NEITHER readOnlyHint ' +
+            'NOR destructiveHint true) but the live descriptor has ' +
+            'readOnlyHint=' + JSON.stringify(a.readOnlyHint) +
+            ', destructiveHint=' + JSON.stringify(a.destructiveHint) +
+            '. A side-effecting tool that gained readOnlyHint would be ' +
+            'wrongly auto-approved (rf2-yi451). Got annotations: ' +
+            JSON.stringify(a),
+        );
+      }
+    } else {
+      throw new Error(
+        'tool ' + t.name + ' fixture posture ' + JSON.stringify(posture) +
+          ' is not one of read-only / destructive / neither (rf2-yi451 fixture bug)',
+      );
+    }
+
+    // 2. openWorld posture for the closed-world (no-runtime-reach) tools.
+    // These ship static / inline content; openWorldHint MUST be false so
+    // a host doesn't treat them as reaching an external world.
+    if (closedWorld.has(t.name) && a.openWorldHint !== false) {
+      throw new Error(
+        'tool ' + t.name + ' is pinned closed-world (inline / no runtime ' +
+          'reach) but the live descriptor has openWorldHint=' +
+          JSON.stringify(a.openWorldHint) + ' (MUST be false). rf2-yi451.',
+      );
+    }
+
+    // 3. Budget-hint PROSE — the `max-tokens` property must carry a
+    // non-empty description (TOKEN-BUDGETS.md §"Per-call override slot").
+    // `assertDescriptorShape` pins the PROP presence; this pins that the
+    // hint text wasn't dropped/emptied.
+    const props = (t.inputSchema && t.inputSchema.properties) || {};
+    const mt = props['max-tokens'];
+    if (!mt || typeof mt.description !== 'string' || mt.description.trim().length === 0) {
+      throw new Error(
+        'tool ' + t.name + " 'max-tokens' property MUST carry a non-empty " +
+          'budget-hint description (TOKEN-BUDGETS.md §"Per-call override slot"; ' +
+          'a dropped hint ships green under the prop-presence-only check). ' +
+          'rf2-yi451. Got: ' + JSON.stringify(mt),
+      );
+    }
+  }
+}
+
 module.exports = {
   runWithWatchdog,
   connectServer,
   closeQuietly,
   assertJsonRpcErrorCodes,
   assertDescriptorShape,
+  assertClassificationRatchet,
 };

--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -33,10 +33,21 @@ const {
   runWithWatchdog,
   assertJsonRpcErrorCodes,
   assertDescriptorShape,
+  assertClassificationRatchet,
 } = require('./_runner.cjs');
 
 const RE_FRAME2_PAIR_MCP_DIR = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp');
 const SERVER = path.join(RE_FRAME2_PAIR_MCP_DIR, 'out', 'server.js');
+
+// Per-tool annotation-classification ratchet (rf2-yi451). Pins each
+// descriptor's EXACT readOnly/destructive posture + budget-hint prose so
+// a tool silently re-classified (a destructive write re-labelled
+// readOnly — a trust-boundary regression an agent host would auto-approve)
+// turns this gate RED for an unchanged tool-set. Sourced from this
+// slice's own fixture (mirrors tools/re-frame2-pair-mcp/tool-descriptors.edn).
+const EXPECTED_CLASSIFICATIONS = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'fixtures', 're-frame2-pair-classifications.json'), 'utf8'),
+);
 
 // Canonical tool-name list — sourced from re-frame2-pair-mcp's own fixture
 // (rf2-drke0, mirrors story-mcp's rf2-36upq TE7) so this conformance
@@ -101,6 +112,19 @@ runWithWatchdog(
     assertDescriptorShape(listed.tools, { allowOpenWorld: true });
     console.log(
       'OK   every tool descriptor: inputSchema(type=object,max-tokens) + outputSchema + annotations hint',
+    );
+
+    // 2e. Per-tool classification CONTENT ratchet (rf2-yi451). The shape
+    // check above pins that SOME classifier is set; this pins WHICH —
+    // the exact readOnly/destructive posture per tool + the budget-hint
+    // prose. A destructive write tool (dispatch, eval-cljs, restore-epoch,
+    // reset-frame-db) silently re-classified readOnly would ship green
+    // under the shape check (readOnlyHint alone satisfies "≥1 set") but
+    // turns RED here. See _runner.cjs for the per-posture rationale.
+    assertClassificationRatchet(listed.tools, EXPECTED_CLASSIFICATIONS);
+    console.log(
+      'OK   per-tool classification ratchet: readOnly/destructive posture + ' +
+        'budget-hint prose pinned (rf2-yi451)',
     );
 
     // 3. Canonical workflow (degraded, since no nREPL is available).

--- a/tools/mcp-conformance/test/end-to-end-story.cjs
+++ b/tools/mcp-conformance/test/end-to-end-story.cjs
@@ -57,6 +57,7 @@ const {
   runWithWatchdog,
   assertJsonRpcErrorCodes,
   assertDescriptorShape,
+  assertClassificationRatchet,
 } = require('./_runner.cjs');
 const { resolveTrustedExe } = require('../lib/exec-safety.cjs');
 const { decodeDedupEnvelope } = require('../lib/dedup-envelope.cjs');
@@ -81,6 +82,15 @@ const CLOJURE = process.env.STORY_MCP_CMD
 const EXPECTED_TOOLS = JSON.parse(
   fs.readFileSync(path.join(STORY_MCP_CWD, 'test', 'fixtures', 'tool-names.json'), 'utf8'),
 ).names;
+
+// Per-tool annotation-classification ratchet (rf2-yi451). Pins each
+// descriptor's EXACT readOnly/destructive posture + budget-hint prose so
+// a tool silently re-classified turns this gate RED for an unchanged
+// tool-set. Sourced from this slice's own fixture (mirrors
+// tools/story-mcp/tool-descriptors.edn).
+const EXPECTED_CLASSIFICATIONS = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'fixtures', 'story-classifications.json'), 'utf8'),
+);
 
 // Fixture variant — namespaced under `story.mcp-conformance` so it
 // won't collide with anything the canonical-vocabulary install
@@ -150,6 +160,17 @@ runWithWatchdog(
     assertDescriptorShape(listed.tools, { allowOpenWorld: false });
     console.log(
       'OK   every tool descriptor: inputSchema(type=object,max-tokens) + outputSchema + annotations hint',
+    );
+
+    // Per-tool classification CONTENT ratchet (rf2-yi451). Pins WHICH
+    // classifier per tool (the exact readOnly/destructive posture) +
+    // the budget-hint prose — not just that SOME classifier is set. A
+    // gated write tool (register-variant, unregister-variant,
+    // record-as-variant) silently re-classified readOnly turns RED here.
+    assertClassificationRatchet(listed.tools, EXPECTED_CLASSIFICATIONS);
+    console.log(
+      'OK   per-tool classification ratchet: readOnly/destructive posture + ' +
+        'budget-hint prose pinned (rf2-yi451)',
     );
 
     // 2e. Closed-world read-path SUCCESS-envelope conformance

--- a/tools/mcp-conformance/test/fixtures/re-frame2-pair-classifications.json
+++ b/tools/mcp-conformance/test/fixtures/re-frame2-pair-classifications.json
@@ -1,0 +1,36 @@
+{
+  "_doc": "Per-tool annotation-CLASSIFICATION ratchet for re-frame2-pair-mcp (rf2-yi451). The sibling `tool-names.json` ratchet pins WHICH tools exist; `assertDescriptorShape`'s name-agnostic check pins that SOME classifier is set. NEITHER pins WHICH classifier — so a destructive write tool silently re-classified readOnlyHint:true (a real trust-boundary safety regression — annotations are the signal an agent host uses to auto-approve a call), a flipped destructiveHint, or a dropped budget hint ships GREEN for an unchanged tool-set. This fixture closes that gap: one row per tool pinning its EXACT classification posture, asserted by `assertClassificationRatchet` against the live wire descriptor. A flipped hint turns the gate RED. Sourced from tools/re-frame2-pair-mcp/tool-descriptors.edn (the generated manifest) — keep in lockstep; adding/reclassifying a tool updates one row here. POSTURES: `read-only` = readOnlyHint:true MUST be set, destructiveHint MUST NOT be true (the auto-approvable read surface); `destructive` = destructiveHint:true MUST be set, readOnlyHint MUST NOT be true (the safety-load-bearing write surface an agent host gates behind confirmation — these are the rows the bead names as load-bearing: dispatch / eval-cljs / restore-epoch / reset-frame-db); `neither` = NEITHER readOnlyHint NOR destructiveHint is true (the session-pin + streaming tools — set-operating-frame / reset-operating-frame / subscribe / unsubscribe — classified via openWorldHint; pinning `neither` catches a streaming/session tool that wrongly gained readOnlyHint, masking its side-effect). Every posture additionally requires openWorldHint:true (every pair tool reaches the live browser runtime over nREPL — an external process) EXCEPT get-re-frame2-pair-instructions, which ships static text from the bundle with no runtime reach (openWorldHint:false); that exception is pinned via `closed-world` below.",
+  "classifications": {
+    "discover-app": "read-only",
+    "dispatch": "destructive",
+    "dispatch-dry-run": "read-only",
+    "eval-cljs": "destructive",
+    "get-operating-frame": "read-only",
+    "get-path": "read-only",
+    "get-re-frame2-pair-instructions": "read-only",
+    "handler-meta": "read-only",
+    "list-handlers": "read-only",
+    "list-streams": "read-only",
+    "list-subscriptions": "read-only",
+    "orient": "read-only",
+    "read-dom": "read-only",
+    "read-recording": "read-only",
+    "read-sub": "read-only",
+    "read-ui": "read-only",
+    "record": "read-only",
+    "reset-frame-db": "destructive",
+    "reset-operating-frame": "neither",
+    "restore-epoch": "destructive",
+    "set-operating-frame": "neither",
+    "snapshot": "read-only",
+    "subscribe": "neither",
+    "tail-build": "read-only",
+    "trace-window": "read-only",
+    "unsubscribe": "neither",
+    "watch-epochs": "read-only",
+    "watch-until": "read-only"
+  },
+  "closed-world": [
+    "get-re-frame2-pair-instructions"
+  ]
+}

--- a/tools/mcp-conformance/test/fixtures/story-classifications.json
+++ b/tools/mcp-conformance/test/fixtures/story-classifications.json
@@ -1,0 +1,26 @@
+{
+  "_doc": "Per-tool annotation-CLASSIFICATION ratchet for story-mcp (rf2-yi451). See the sibling re-frame2-pair-classifications.json _doc for the full rationale. POSTURES: `read-only` = readOnlyHint:true MUST be set + destructiveHint MUST NOT be true; `destructive` = destructiveHint:true MUST be set + readOnlyHint MUST NOT be true (the safety-load-bearing write surface — register-variant / unregister-variant / record-as-variant are the gated `--allow-writes` writers; preview-variant / run-variant execute a variant lifecycle so they carry destructiveHint). story-mcp is CLOSED-WORLD overall (reads + fixture writes, no live runtime), but every tool's descriptor still carries openWorldHint:true in the generated manifest — so this ratchet does NOT pin openWorldHint posture (that is the per-server `allowOpenWorld` axis the existing assertDescriptorShape already handles); it pins ONLY the readOnly/destructive trust-classification, which is the dimension a flipped-hint regression would silently break. Sourced from tools/story-mcp/tool-descriptors.edn — keep in lockstep; one row per tool.",
+  "classifications": {
+    "explain-variant": "read-only",
+    "get-docs-markdown": "read-only",
+    "get-story": "read-only",
+    "get-story-instructions": "read-only",
+    "get-variant": "read-only",
+    "list-assertions": "read-only",
+    "list-decorators": "read-only",
+    "list-modes": "read-only",
+    "list-stories": "read-only",
+    "list-substrates": "read-only",
+    "list-tags": "read-only",
+    "preview-variant": "destructive",
+    "read-failures": "read-only",
+    "record-as-variant": "destructive",
+    "register-variant": "destructive",
+    "run-a11y": "read-only",
+    "run-variant": "destructive",
+    "snapshot-identity": "read-only",
+    "unregister-variant": "destructive",
+    "variant->edn": "read-only"
+  },
+  "closed-world": []
+}


### PR DESCRIPTION
Three conformance-gate hardening fixes, all in `tools/mcp-conformance/`. Each closes a false-green gap so a regression now turns the gate RED. Project stance: pre-alpha masterpiece — CORRECTNESS + GOOD PRACTICE; a conformance gate's value is its teeth.

## rf2-yi451 (P3) — per-descriptor CONTENT ratchet

**Gap.** The `tools/list` ratchet (`tool-names.json`) pins tool NAMES only; `assertDescriptorShape` pins "≥1 classifier set" but never WHICH. So for an UNCHANGED tool-set, a destructive write tool silently re-classified `readOnlyHint:true`, a flipped `destructiveHint`, or a dropped budget-hint ships GREEN. annotations are the trust signal an agent host uses to auto-approve a call — a misclassification is a real safety regression.

**Fix.** New `assertClassificationRatchet` (in `_runner.cjs`, wired into both end-to-end harnesses) pins, per descriptor:
- the EXACT readOnly / destructive / neither posture (one row per tool in a per-server fixture, mirroring each `tool-descriptors.edn`);
- the closed-world `openWorldHint:false` exception (inline / no-runtime-reach tools);
- the `max-tokens` budget-hint PROSE (a dropped/emptied description trips);
- fixture key-set ↔ live tool-set EXACT match (a new tool can't ship unclassified; a removed tool can't leave a stale row).

**Teeth (live wire, proven).** Flipping `restore-epoch` `destructive→read-only` in the real descriptor and recompiling turned the gate RED with a precise message, while the name ratchet stayed green (28 tools, unchanged set) — i.e. the OLD gate would have shipped it green. Reverted; `git status` clean on `tools/re-frame2-pair-mcp/`.

## rf2-ybiz0 (P3) — observable SKIP

**Gap.** The load-bearing live redaction gate (the rf2-6wvh5 regression net) runs for-real only inside the hermetic orchestrator and SKIPs (exit 0) by default. It had no standalone npm script, and the orchestrator forwarded inner exit codes but never asserted the inner tests actually RAN — so a broken hermetic SETUP path could leave the gate un-exercised while the job stayed green via the other two inner tests.

**Fix.**
- Added a standalone `test:re-frame2-pair-live-redaction` npm script (parity with overflow/subscribe + local runnability).
- Added an observable-SKIP guard in the orchestrator: after each inner test exits 0, assert it printed its `... CONFORMANCE GREEN` sentinel AND did NOT print a `SKIP ` banner. The hermetic env guarantees `$SHADOW_CLJS_NREPL_PORT`, so an in-hermetic SKIP means the setup regressed — now turns the gate RED (exit 2, orchestration failure) instead of riding green.

**Teeth (proven).** The real `live-re-frame2-pair-redaction.cjs` SKIPs (exit 0, `SKIP ...` banner) with the env unset — exactly the bead's failure mode. That real SKIP output fed through the orchestrator's guard condition trips RED. Guard logic additionally proven against all four cases (green / SKIP-at-start / SKIP-mid / exit-0-truncated).

## rf2-fphr3 (P4) — coverage-boundary doc

**Determination.** Keyword-intern bounds are NOT a cross-server WIRE contract — they are a per-server input-sanitisation property, OWNED + tested at the `mcp-base` unit layer: `re-frame.mcp-base.args/safe-keyword` (membership-check-before-intern, no-intern-on-rejection — both bare + namespaced arms), `parse-mode` (membership-before-intern), `fresh-keyword` (bounded-cost intern for operator-gated / registry-bounded write paths). Pinned by `mcp-base/test/.../args_test.clj` (rf2-ih7g4 + rf2-xxtrz + rf2-ynjts.17), each asserting via a `find-keyword` probe that a rejected novel name never enters the table. On the wire paths the corpus drives (`dispatch`/`read-sub` ids), registrar id-validation is a second bound. NOT uncovered → documented the seam (no duplicate assertion).

**Doc.** Added a "Coverage boundary — keyword-intern bounds" note to `README.md §"What this is"`, mirroring the `flag-gates.cjs` Coverage-boundary precedent, so a reviewer doesn't read the gate's silence as "uncovered".

## Quality gates

`npm run test:mcp-conformance` (from `implementation/`) — **GREEN end-to-end, cold, all six gates exit 0.** The new classification ratchet ran green on the live wire for both servers. (Note: one transient flake of gate `[3/6]` pair-mcp `:server-test` in an early chained run — abrupt exit-1 with zero test output, the documented Windows worktree shadow-cljs/JVM contention; confirmed green in isolation at 894 tests / 2741 assertions / 0 failures, and green in the final chained run.)

## Scope

Entirely `tools/mcp-conformance/` (corpus + ratchet fixtures + one npm script + the hermetic orchestrator). Did NOT touch `implementation/scripts/test-mcp-conformance.cjs` (rf2-1irs7's surface). The mcp-conformance `spec/` exemption is documented + unchanged.