### PR TITLE
fix(ssr): enforce head-resolution failure ships degraded 200, not incidental to ordering (rf2-lia3i)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -219,7 +219,20 @@
   rf2-bof8i (trace-emit on caught throw, Mike decision Option B over
   silent fallback — the always-on error-emit substrate per rf2-vnjfg /
   rf2-bacs4 carries the trace independent of the trace ring buffer's
-  dev-only gating)."
+  dev-only gating).
+
+  Degrade-gracefully is the deliberate counterpoint to the view/sub
+  FAIL-CLOSED posture (rf2-vvwmi / rf2-7d30s, Spec 011 §744/§748-751):
+  a view or reactive sub that throws mid-render projects a non-200
+  (the page is unusable); a head fn that throws ships a 200 with an
+  empty `<head>` (only the metadata is missing — the body still
+  renders + hydrates). To make the degraded-200 outcome ENFORCED rather
+  than incidental to `ssr-handler`'s `get-response`-before-`resolve-head`
+  call ordering, `:rf.error/ssr-head-resolution-failed` is registered as a
+  recoverable-degradation category that the projection listeners skip by
+  design (`re-frame.ssr.error-listener/non-projection-eligible-errors`,
+  rf2-lia3i): the trace ships for observability but is never buffered for
+  status projection, so no call-ordering change can flip the 200."
   [frame-id]
   (try
     (let [model (rf/active-head frame-id)]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -1910,6 +1910,110 @@
           "success path must NOT emit the head-resolution-failed trace"))))
 
 ;; ===========================================================================
+;; rf2-lia3i — head-resolution failure correctness is ENFORCED at the
+;; handler level (not incidental to call ordering)
+;; ===========================================================================
+;;
+;; CONTRACT (Spec 011 §1070, lifecycle/resolve-head, rf2-bof8i Option B):
+;; a throwing route `:head` fn is a RECOVERABLE DEGRADATION — the request
+;; ships a 200 with an empty `<head>` fragment ("a buggy head fn can't
+;; take down the request") AND emits `:rf.error/ssr-head-resolution-failed`
+;; for observability. This is the deliberate counterpoint to the view/sub
+;; FAIL-CLOSED posture (rf2-vvwmi / rf2-7d30s, Spec 011 §744/§748-751):
+;; a view or reactive sub that throws mid-render projects a non-200
+;; because the page is unusable; a head fn that throws degrades to a 200
+;; because only the `<head>` metadata is missing — the body still renders.
+;;
+;; Pre-rf2-lia3i the degraded-200 outcome was SAFE BY TIMING ONLY:
+;; `ssr-handler` reads `get-response` (ring.clj:343 — drains + reads the
+;; status) BEFORE `build-full-response` → `resolve-head` fires the head
+;; trace (pipeline.clj:286), so the buffered head trace was never
+;; projected onto the already-captured status. A reorder (head resolution
+;; before `get-response`, a second flush after the render, or a re-read of
+;; `get-response`) would have let the default projector map the head trace
+;; → 500 and silently flip the degraded 200 to a 500.
+;;
+;; rf2-lia3i enforces the contract at the projection BUFFERING chokepoint:
+;; `re-frame.ssr.error-listener` skips `:rf.error/ssr-head-resolution-failed`
+;; in BOTH projection listeners (dev-only + always-on), so the head trace
+;; is never buffered for status projection regardless of call ordering.
+;; This handler-level test PINS the wire contract: a throwing `:head` fn
+;; → a 200 (degraded) response with the body intact + the observability
+;; trace fired. The default projector maps `:rf.error/*` → 500, so if a
+;; future change ever let the head trace project, the status assertion
+;; below turns red — the reordering-regression tripwire.
+
+(defn- register-head-throwing-app!
+  "Register an app whose active route declares a `:head` fn that throws.
+  The body view renders cleanly — only head resolution fails — so the
+  test isolates the head-degradation contract from the view/sub
+  fail-closed path."
+  []
+  (rf/reg-head :head/throws
+               (fn [_db _route]
+                 (throw (ex-info "synthetic head failure (rf2-lia3i)"
+                                 {:reason :test}))))
+  (rf/reg-route :route/head-throws
+                {:doc  "Route whose head fn throws"
+                 :path "/head-throws"
+                 :head :head/throws})
+  (rf/reg-event-db :init/seed-throwing-head-route
+    {:platforms #{:server}}
+    (fn [db _]
+      (assoc-in db [:rf/runtime :routing :current]
+                {:id :route/head-throws})))
+  (rf/reg-view* :pages/head-throws-body
+    (fn [] [:div.page [:h1 "Body rendered fine"]])))
+
+(deftest handler-throwing-head-fn-ships-degraded-200-not-projected-error
+  (testing "rf2-lia3i: a throwing route :head fn → ssr-handler returns a
+            200 (degraded — empty head, body intact), NOT a projected
+            4xx/5xx. The head-resolution failure is a recoverable
+            degradation (Spec 011 §1070), enforced not incidental."
+    (register-head-throwing-app!)
+    (let [traces  (atom [])
+          _       (rf/register-listener! ::head-fail-watch
+                    (fn [ev]
+                      (when (= :rf.error/ssr-head-resolution-failed
+                               (:operation ev))
+                        (swap! traces conj ev))))
+          handler (ssr-ring/ssr-handler
+                    {:on-create [:init/seed-throwing-head-route]
+                     :root-view [:pages/head-throws-body]
+                     :payload   :rf.ssr.payload/whole-app-db})
+          response (try
+                     (handler {:uri "/head-throws" :request-method :get})
+                     (finally
+                       (rf/unregister-listener! ::head-fail-watch)))]
+      ;; THE PIN: a throwing head fn must NOT take down the request.
+      ;; The default projector maps any projected :rf.error/* → 500;
+      ;; were the head trace ever projected (a reorder regression),
+      ;; this would be 500 and the assertion turns red.
+      (is (= 200 (:status response))
+          "throwing :head fn degrades to a 200 — NEVER a projected
+           4xx/5xx (Spec 011 §1070 degrade-gracefully contract;
+           ENFORCED via the projector-skip, not incidental to the
+           get-response/resolve-head ordering)")
+      (let [body (:body response)]
+        (is (string? body))
+        (is (str/includes? body "<!DOCTYPE html>")
+            "the document still ships — the body rendered")
+        (is (str/includes? body "Body rendered fine")
+            "the body view content is intact — only the head degraded")
+        ;; Empty head fragment: the throwing head fn contributed no
+        ;; route-specific tags. The shell's hardcoded charset meta is an
+        ;; envelope concern (rf2-q78s1), not produced by resolve-head, so
+        ;; its presence does not contradict the empty-fragment contract;
+        ;; the synthetic-failure marker simply never reaches the wire.
+        (is (not (str/includes? body "synthetic head failure"))
+            "the throwable's message never crosses the wire"))
+      ;; Observability preserved: the spec contract is degrade AND emit.
+      (is (= 1 (count @traces))
+          ":rf.error/ssr-head-resolution-failed still fires for
+           observability (Spec 011 §1070 Option B) — degraded, not
+           silent"))))
+
+;; ===========================================================================
 ;; rf2-joibj — per-request frame-id keyword is EDN-spec-compliant
 ;;
 ;; `setup-request-frame!` builds the frame-id via

--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -41,6 +41,44 @@
     (when (and tag-frame (error-projector/server-frame? tag-frame))
       tag-frame)))
 
+;; Categories that are RECOVERABLE DEGRADATIONS, not request failures.
+;; They fire `:op-type :error` for observability (per Spec 011 §1070 the
+;; spec is the artefact: the always-on error-emit substrate carries the
+;; trace to user observability stacks) yet MUST NOT project a non-200
+;; status — the request continues with a degraded fragment.
+;;
+;; `:rf.error/ssr-head-resolution-failed` (rf2-bof8i Option B) is the
+;; canonical member: `resolve-head` degrades a throwing `:head` fn to an
+;; empty fragment so a buggy head fn "can't take down the request"
+;; (Spec 011 §1070 + lifecycle/resolve-head docstring). This is the
+;; deliberate, spec-pinned counterpoint to the view/sub fail-closed
+;; posture (rf2-vvwmi / rf2-7d30s, Spec 011 §744/§748-751): a view or
+;; reactive sub that throws mid-render projects a 5xx because the page is
+;; unusable; a head fn that throws degrades to a 200 because only the
+;; `<head>` metadata is missing — the body still renders and hydrates.
+;;
+;; rf2-lia3i — ENFORCING the contract at the buffering chokepoint (both
+;; the dev-only `error-projection-listener` and the always-on
+;; `error-emit-projection-listener` route through here) makes the
+;; degraded-200 outcome a PROPERTY OF THE PROJECTOR, not an incidental
+;; consequence of `ssr-handler` reading `get-response` (ring.clj:343)
+;; BEFORE `build-full-response` fires the head trace (pipeline.clj:286).
+;; Without this skip the immunity was timing-only: a future reorder (head
+;; resolution before `get-response`, a second flush after the render, a
+;; re-read of `get-response` on the same frame) would let a buffered head
+;; trace project the default `:rf.error/*` → status and silently flip a
+;; degraded 200 to a 4xx/5xx. The skip closes that hole by construction.
+(def ^:private non-projection-eligible-errors
+  #{:rf.error/ssr-head-resolution-failed})
+
+(defn- non-projection-eligible-error?
+  "True when `operation` names a recoverable-degradation error category
+  that must NOT be buffered for status projection (it ships its trace for
+  observability but the request continues with a degraded fragment).
+  Currently `:rf.error/ssr-head-resolution-failed` (rf2-lia3i)."
+  [operation]
+  (contains? non-projection-eligible-errors operation))
+
 ;; Per-frame buffer of captured error trace events. The trace listener
 ;; appends here synchronously when the error fires; apply-pending-
 ;; error-projection! drains the buffer and stamps the projected status
@@ -201,8 +239,12 @@
   [event]
   (when (= :error (:op-type event))
     (let [op (:operation event)]
-      ;; Skip our own sanitisation traces to avoid recursion.
-      (when-not (= :rf.error/sanitised-on-projection op)
+      ;; Skip our own sanitisation traces to avoid recursion, and skip
+      ;; recoverable-degradation categories (rf2-lia3i — e.g.
+      ;; `:rf.error/ssr-head-resolution-failed`) that must ship their
+      ;; trace for observability without projecting a non-200 status.
+      (when-not (or (= :rf.error/sanitised-on-projection op)
+                    (non-projection-eligible-error? op))
         (when-let [frame-id (candidate-frame-for-error event)]
           (buffer-error-trace! frame-id event))))))
 
@@ -229,8 +271,17 @@
     ;; sanitisation records to avoid recursion. (As of rf2-fb598
     ;; `:rf.error/sanitised-on-projection` is not delivered through the
     ;; error-emit substrate, but keep the guard so a future routing
-    ;; change can't reintroduce a re-entrant projection.)
-    (when-not (= :rf.error/sanitised-on-projection op)
+    ;; change can't reintroduce a re-entrant projection.) Also refuse
+    ;; recoverable-degradation categories (rf2-lia3i —
+    ;; `:rf.error/ssr-head-resolution-failed`): if a future host-adapter
+    ;; change routes the head-failure trace through the always-on
+    ;; substrate (it rides only the dev trace bus today, but non-Ring
+    ;; adapters MUST emit the same category per Spec 011 §1070), it must
+    ;; STILL not project a non-200 — the skip is symmetric across both
+    ;; buffering paths so the degraded-200 contract holds regardless of
+    ;; which substrate carries the trace.
+    (when-not (or (= :rf.error/sanitised-on-projection op)
+                  (non-projection-eligible-error? op))
       (let [;; The error-emit record carries the frame on its flat `:frame`
             ;; slot directly. Per rf2-7d30s every error-emit site reachable
             ;; inside a server-frame drain stamps that slot from the

--- a/implementation/ssr/test/re_frame/ssr_head_resolution_no_project_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_resolution_no_project_test.clj
@@ -1,0 +1,138 @@
+(ns re-frame.ssr-head-resolution-no-project-test
+  "Per rf2-lia3i — `:rf.error/ssr-head-resolution-failed` is a RECOVERABLE
+  DEGRADATION, not a request failure, and MUST NOT project a non-200
+  status onto the response accumulator.
+
+  CONTRACT (Spec 011 §1070 — `resolve-head` emits the category before
+  fallback; rf2-bof8i Option B): a route `:head` fn that throws degrades
+  to an empty `<head>` fragment so 'a buggy head fn can't take down the
+  request', AND emits `:rf.error/ssr-head-resolution-failed` for
+  observability. This is the deliberate counterpoint to the view/sub
+  FAIL-CLOSED posture (rf2-vvwmi / rf2-7d30s, Spec 011 §744/§748-751):
+  a view or reactive sub that throws mid-render projects a non-200 (the
+  page is unusable); a head fn that throws ships a 200 (only the metadata
+  is missing — the body still renders + hydrates).
+
+  WHY THIS SUITE EXISTS. Pre-rf2-lia3i the degraded-200 outcome was safe
+  by TIMING ONLY: the Ring `ssr-handler` reads `get-response` (drains +
+  reads status) BEFORE `build-full-response` → `resolve-head` fires the
+  head trace, so the buffered head trace was never projected onto the
+  already-captured status. The immunity was incidental to call ordering;
+  a reorder (head resolution before `get-response`, a second flush after
+  the render, a re-read of `get-response`) would have let the default
+  projector map the head trace → 500 and silently flip the degraded 200.
+
+  rf2-lia3i ENFORCES the contract at the projection BUFFERING chokepoint:
+  `re-frame.ssr.error-listener` lists the category in
+  `non-projection-eligible-errors` and both projection listeners (the
+  dev-only `error-projection-listener` AND the always-on
+  `error-emit-projection-listener`) skip it — so the head trace is never
+  buffered for status projection, regardless of call ordering or which
+  substrate carried it. This suite pins the skip directly at the core
+  level, independent of the Ring handler (whose own wire-level pin lives
+  in `re-frame.ssr.ring-test/handler-throwing-head-fn-ships-degraded-200-
+  not-projected-error`)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.error-listener :as error-listener]
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(def ^:private server-frame :ssr/head-no-project-frame)
+
+(defn- make-server-frame []
+  ;; `:platform :server` so `error-projector/server-frame?` recognises it;
+  ;; the default projector would map any PROJECTED `:rf.error/*` → 500, so
+  ;; a 200 below proves the head trace was NOT projected.
+  (rf/reg-frame server-frame
+    {:platform :server
+     :ssr      {:public-error-id   :rf.ssr/default-error-projector
+                :dev-error-detail? false}})
+  server-frame)
+
+;; ===========================================================================
+;; (1) Dev path — the actual `resolve-head` emit route.
+;;     `resolve-head` calls `trace/emit-error!`, which (under
+;;     `interop/debug-enabled?`) delivers to the dev trace bus feeding
+;;     `error-projection-listener`. The head trace must be SKIPPED there:
+;;     status stays 200 and nothing is buffered.
+;; ===========================================================================
+
+(deftest dev-path-head-failure-trace-is-not-buffered-or-projected
+  (testing "rf2-lia3i: firing `:rf.error/ssr-head-resolution-failed` the
+            same way `resolve-head` does (frame-stamped, via
+            `trace/emit-error!`) does NOT buffer the trace for projection
+            and does NOT flip the response status off 200 — the dev-only
+            `error-projection-listener` skips the category by design."
+    (let [fid (make-server-frame)]
+      ;; Stamp the frame exactly as resolve-head's catch arm does.
+      (trace/emit-error! :rf.error/ssr-head-resolution-failed
+                         {:frame     fid
+                          :exception (ex-info "synthetic head failure" {:reason :test})
+                          :recovery  :no-recovery})
+      (is (empty? (get @error-listener/pending-error-traces fid))
+          "the head trace was SKIPPED — not buffered into
+           pending-error-traces (so a later get-response can't project it)")
+      (is (= 200 (:status (ssr/get-response fid)))
+          "status stays 200 — the head failure degraded gracefully; the
+           default projector (→ 500) never ran for this category"))))
+
+;; ===========================================================================
+;; (2) A buffering chokepoint contrast — a NON-degradation category fired
+;;     the same way DOES buffer + project. Proves the skip is specific to
+;;     the head category, not a blanket no-op of the listener.
+;; ===========================================================================
+
+(deftest dev-path-control-non-head-error-still-projects
+  (testing "rf2-lia3i (control): a frame-stamped NON-degradation error
+            category (`:rf.error/schema-validation-failure`) fired through
+            the same dev listener IS buffered and projects a non-200 —
+            confirming the head-category skip is targeted, not a listener
+            that silently drops everything."
+    (let [fid (make-server-frame)]
+      (trace/emit-error! :rf.error/schema-validation-failure
+                         {:frame     fid
+                          :exception (ex-info "schema boom" {})
+                          :recovery  :no-recovery})
+      (is (seq (get @error-listener/pending-error-traces fid))
+          "a non-degradation category IS buffered for projection")
+      (is (not= 200 (:status (ssr/get-response fid)))
+          "and it projects a non-200 — the listener is doing real work;
+           the head-category skip in (1) is therefore meaningful"))))
+
+;; ===========================================================================
+;; (3) Always-on substrate — symmetry guard. The head trace rides only the
+;;     dev bus today (`trace/emit-error!`), but non-Ring host adapters MUST
+;;     emit the same category (Spec 011 §1070), and a future change could
+;;     route it through the always-on `register-error-listener!` substrate.
+;;     The skip is symmetric, so the degraded-200 contract holds under
+;;     production hardening too.
+;; ===========================================================================
+
+(deftest always-on-path-head-failure-record-is-not-buffered-or-projected
+  (testing "rf2-lia3i: a head-failure record delivered to the ALWAYS-ON
+            `error-emit-projection-listener` (the production-survivable
+            substrate, exercised under `interop/debug-enabled? = false`)
+            is ALSO skipped — neither buffered nor projected. Symmetric
+            with the dev path so the contract holds whichever substrate
+            carries the trace."
+    (let [fid (make-server-frame)]
+      (with-redefs [interop/debug-enabled? false]
+        ;; The error-emit record shape per `error-emit/dispatch-on-error!`.
+        (error-listener/error-emit-projection-listener
+          {:error      :rf.error/ssr-head-resolution-failed
+           :event      nil
+           :event-id   nil
+           :frame      fid
+           :time       0
+           :exception  (ex-info "synthetic head failure" {})
+           :elapsed-ms 0})
+        (is (empty? (get @error-listener/pending-error-traces fid))
+            "the always-on listener also skips the head category — not
+             buffered")
+        (is (= 200 (:status (ssr/get-response fid)))
+            "status stays 200 on the production substrate too")))))


### PR DESCRIPTION
## What

The non-streaming `ssr-ring` handler shipped a degraded **200** on a throwing route `:head` fn **only by call ordering**: `get-response` (`ring.clj:343`) drained + read the status BEFORE `build-full-response` → `resolve-head` (`pipeline.clj:286`) buffered the `:rf.error/ssr-head-resolution-failed` trace. A future reorder (head resolution before `get-response`, a second flush after the render, or a re-read of `get-response` on the same frame) would have let the default projector map the head trace → 500 and silently flip the degraded 200 to a 5xx.

## Contract determination

Spec 011 §1070 (rf2-bof8i Option B) pins head-resolution failure as a **RECOVERABLE DEGRADATION** — empty `<head>` fragment + observability trace, request continues ("a buggy head fn can't take down the request"). This is the deliberate counterpoint to the view/sub **fail-closed** posture (rf2-vvwmi / rf2-7d30s, §744 / §748-751), where a mid-render throw projects a non-200 because the page is unusable. A head fn throw ships a 200 because only the `<head>` metadata is missing — the body still renders + hydrates. So the intended contract is **recover-to-200-with-degraded-head** (bead option (b)), and the current behaviour was correct-but-fragile, not a wrong-status bug.

## Fix — enforce, don't rely on ordering

Enforce the contract at the projection **buffering chokepoint**: `re-frame.ssr.error-listener` lists `:rf.error/ssr-head-resolution-failed` in a new `non-projection-eligible-errors` set; both projection listeners (dev-only `error-projection-listener` AND always-on `error-emit-projection-listener`) skip it. The head trace is therefore never buffered for status projection, regardless of call ordering or which substrate carries it. The degraded-200 outcome becomes a **property of the projector**, not an accident of `ssr-handler`'s drain-before-render sequence. The `resolve-head` docstring (`lifecycle.clj`) now names the contract + cross-refs the enforcement.

## Tests (the reordering tripwire)

- **`implementation/ssr/test/re_frame/ssr_head_resolution_no_project_test.clj`** (new) — pins the skip directly at the core level: a frame-stamped head-failure trace fired through the dev path (`trace/emit-error!`, exactly as `resolve-head` does) and the always-on substrate is neither buffered nor projected; status stays 200. A non-head control (`:rf.error/schema-validation-failure`) IS buffered + projects a non-200, proving the skip is targeted. **Removing the skip turns this suite red — verified.** (The handler-level test alone does NOT catch the regression: at the handler level the immunity is genuinely timing-incidental, which is precisely why the enforcement + its tripwire live at the projector chokepoint.)
- **`ssr-ring/.../ring_test.clj`** — `handler-throwing-head-fn-ships-degraded-200-not-projected-error`: drives the real `ssr-handler` with a throwing route `:head` fn and pins the wire contract — a 200 (degraded, body intact), the throwable message never crosses the wire, and the observability trace still fires.

## Gates (cold)

- `npm run test:cljs` — 5614 tests / 19547 assertions, 0 failures
- ssr core JVM `clojure -M:test` — 263 / 911, 0 failures
- ssr-ring JVM `clojure -M:test` — 108 / 473, 0 failures

Closes rf2-lia3i.
