### PR TITLE
fix(routing): on-match error-trap discrimination + JVM external-url fail-closed (rf2-cgh8q + rf2-3bv8o)

### DIFF
--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -154,11 +154,52 @@
   [_ _]
   {})
 
-(defn- absolute-url-like? [url]
+(defn- safe-in-app-url?
+  "Fail-CLOSED lexical classifier for the no-browser-origin path (JVM /
+  SSR, and CLJS when `js/window` is unavailable). Returns true ONLY when
+  `url` is PROVABLY a same-origin in-app reference; everything ambiguous
+  or absolute returns false -> classed external (rf2-3bv8o).
+
+  Without a browser `Location` to resolve and origin-compare against
+  (the robust CLJS path below), the runtime cannot prove a URL is
+  same-origin. The pre-rf2-3bv8o JVM path was fail-OPEN: it returned the
+  URL verbatim and classed in-app anything that did not lexically look
+  absolute -- a default-ALLOW that let open-redirect bypass vectors
+  (leading whitespace before a scheme, backslash-prefixed authorities a
+  browser normalises to `//`, embedded tab/newline in the scheme) slip
+  through as in-app pushes. This flips to fail-CLOSED, consistent with
+  the routing fail-closed posture established by rf2-6t1xb (a hostile or
+  ambiguous URL resolves to the safe outcome, not the permissive one).
+
+  A URL is accepted as in-app only when, after rejecting any whitespace
+  or ASCII control character (browsers strip tab/CR/LF mid-URL before
+  parsing -- a lexical check that ignores them is bypassable), it begins
+  with a single `/` NOT followed by `/` or a backslash (a rooted
+  same-origin path) -- OR is a pure query (`?...`) / fragment (`#...`)
+  reference. A leading `//` or `/\\` (protocol-relative authority a
+  browser reads as off-origin), a scheme (`name:`), a bare relative
+  segment, the empty string, and any non-string all fail closed."
+  [url]
   (boolean
     (and (string? url)
-         (or (re-find #"^[A-Za-z][A-Za-z0-9+.-]*:" url)
-             (clojure.string/starts-with? url "//")))))
+         (seq url)
+         ;; Reject any whitespace or ASCII control char (incl. DEL)
+         ;; anywhere: a leading space defeats a `^` scheme anchor, and
+         ;; embedded tab/CR/LF are stripped by browsers before parsing --
+         ;; a lexical check that ignores them is a bypass surface. The
+         ;; `\s` + hex-range class is identical under Java (CLJ) and
+         ;; JS (CLJS) regex.
+         (not (re-find #"[\s\x00-\x1f\x7f]" url))
+         (or
+           ;; Pure query or fragment reference -- unambiguously same-doc.
+           (clojure.string/starts-with? url "?")
+           (clojure.string/starts-with? url "#")
+           ;; Rooted path: a single leading `/` NOT followed by `/` or
+           ;; `\` (which a browser would treat as a protocol-relative
+           ;; authority -> off-origin).
+           (and (clojure.string/starts-with? url "/")
+                (not (clojure.string/starts-with? url "//"))
+                (not (clojure.string/starts-with? url "/\\")))))))
 
 (defn- external-url? [url]
   #?(:cljs
@@ -169,11 +210,13 @@
                protocol (.-protocol parsed)]
            (or (not (#{"http:" "https:"} protocol))
                (not= (.-origin parsed) (.-origin loc))))
-         (absolute-url-like? url))
+         ;; No browser Location to origin-compare against — fail closed.
+         (not (safe-in-app-url? url)))
        (catch :default _
-         (absolute-url-like? url)))
+         (not (safe-in-app-url? url))))
      :clj
-     (absolute-url-like? url)))
+     ;; JVM / SSR: no browser origin — fail closed (rf2-3bv8o).
+     (not (safe-in-app-url? url))))
 
 (defn- request-url->app-url [url]
   #?(:cljs

--- a/implementation/routing/src/re_frame/routing/on_match_error.cljc
+++ b/implementation/routing/src/re_frame/routing/on_match_error.cljc
@@ -19,7 +19,10 @@
     - reading the failing record's `:frame`
     - reading that frame's route slice at [:rf/runtime :routing :current]
     - checking `:transition` is `:loading` (the slice is mid-drain)
-    - checking the failing event-id is in the active route's `:on-match`
+    - checking the failing record's full `:event` vector IS one of the
+      active route's declared `:on-match` vectors (rf2-cgh8q —
+      full-vector identity, not bare event-id membership; falls back to
+      id-membership only when the event was wire-elided)
 
   All four together identify the error as originating from an :on-match
   cascade for the currently-loading route. The listener then dispatches
@@ -42,16 +45,73 @@
             [re-frame.frame :as frame]
             [re-frame.router :as router]))
 
+(defn- on-match-event-vecs
+  "Return the set of full event VECTORS declared in `route-meta`'s
+  `:on-match`. Empty when the route declares no `:on-match`. Used by the
+  error-emit listener to discriminate which handler-exception records
+  originated from an `:on-match` dispatch — full-vector identity is the
+  tightest always-on discriminator (see `on-match-attributed?`)."
+  [route-meta]
+  (into #{}
+        (filter vector?)
+        (or (:on-match route-meta) [])))
+
 (defn- on-match-event-ids
-  "Return a set of event-ids declared in `route-meta`'s `:on-match`.
-  Empty when the route declares no `:on-match`. Used by the error-emit
-  listener to discriminate which handler-exception records originated
-  from an `:on-match` dispatch."
+  "Return the set of event-ids (head keywords) declared in `route-meta`'s
+  `:on-match`. The coarse fallback discriminator used only when the
+  failing record's full `:event` vector is unavailable (wire-elided to
+  `:rf.size/large-elided` per Spec 009 §size-elision)."
   [route-meta]
   (into #{}
         (comp (filter vector?)
               (map first))
         (or (:on-match route-meta) [])))
+
+(defn- on-match-attributed?
+  "True when the failing handler-exception `record` should be attributed
+  to the active route's `:on-match` drain.
+
+  rf2-cgh8q — the attribution discriminator. Earlier this was bare
+  event-id MEMBERSHIP: `(contains? (on-match-event-ids meta) event-id)`.
+  That mis-attributes a NON-routing throw to the loading route whenever
+  the app concurrently dispatches an event whose id happens to coincide
+  with one of the route's `:on-match` ids during the loading window — the
+  healthy route is then forced to `:error` and a spurious `:on-error`
+  chains. The id-only check cannot tell the route's own
+  `[[:app/load-x 'from-route']]` dispatch apart from a button handler's
+  `[:app/load-x 'from-button']`.
+
+  The tighter, still-always-on discriminator is full event-VECTOR
+  identity against the route's declared `:on-match` vectors: a button
+  dispatch carrying different args (or a bare `[:app/load-x]` versus the
+  route's `[:app/load-x 42]`) no longer collides. The full `:event`
+  vector rides the always-on error record (Spec 009 §Record shape), so
+  this survives `:advanced` + `goog.DEBUG=false` like the rest of the
+  trap.
+
+  Wire elision (Spec 009 §size-elision) can replace a LARGE `:event`
+  with the sentinel `:rf.size/large-elided`. In that one case the full
+  vector is unavailable, so we fall back to the coarse id-membership
+  check rather than silently dropping a genuine on-match error — losing
+  the `:on-error` chain for a large-payload loader is the worse failure
+  than the (already low-likelihood) coincidence the vector check closes.
+
+  Residual coincidence — a DIFFERENT cascade dispatching the byte-for-
+  byte IDENTICAL on-match vector during the loading window — remains
+  indistinguishable from the genuine on-match throw on the always-on
+  substrate (the error record carries no cause/cascade correlation; the
+  epoch cause-event-id surface is dev-only and elides in production).
+  Documented as an accepted limitation in Spec 012 §`:on-match`
+  exception attribution."
+  [route-meta {:keys [event event-id]}]
+  (let [elided? (= event :rf.size/large-elided)]
+    (if (and (vector? event) (not elided?))
+      ;; Full-vector identity — the tight discriminator.
+      (contains? (on-match-event-vecs route-meta) event)
+      ;; `:event` was wire-elided (large payload): fall back to the
+      ;; coarse id-membership check so a genuine on-match throw on a
+      ;; large-payload loader still routes to `:on-error`.
+      (contains? (on-match-event-ids route-meta) event-id))))
 
 (defn on-match-error-handler
   "`:rf.route.internal/on-match-error` event-fx handler. Registered by
@@ -96,24 +156,26 @@
   chains.
 
   Per Spec 012 §Per-route error handling and rf2-ye7sh."
-  [{:keys [error event-id frame exception] :as _record}]
+  [{:keys [error event-id frame exception] :as record}]
   (when (= :rf.error/handler-exception error)
     (let [db            (frame/frame-app-db-value frame)
           route-slice   (when db (get-in db [:rf/runtime :routing :current]))
           route-id      (:id route-slice)
           transition    (:transition route-slice)
           nav-token     (:nav-token route-slice)
-          route-meta    (when route-id (registrar/lookup :route route-id))
-          on-match-ids  (on-match-event-ids route-meta)]
+          route-meta    (when route-id (registrar/lookup :route route-id))]
       ;; Three discriminators all must hold:
       ;;   1. The slice is mid-drain (`:loading`).
-      ;;   2. The failing event-id is in the active route's `:on-match`.
+      ;;   2. The failing record is attributed to the active route's
+      ;;      `:on-match` drain by full-vector identity (rf2-cgh8q),
+      ;;      falling back to id-membership only when the event was
+      ;;      wire-elided — see `on-match-attributed?`.
       ;;   3. A nav-token is present (otherwise routing is uninitialised).
       ;; All three together mean: the failing handler was an :on-match
       ;; dispatch for the currently-loading route.
       (when (and (= :loading transition)
                  nav-token
-                 (contains? on-match-ids event-id))
+                 (on-match-attributed? route-meta record))
         ;; Build the structured error map (Spec 009 §error-contract).
         ;; The exception itself carries the diagnostic detail; we surface
         ;; the canonical :rf.error/ id + tags so apps can switch on it

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -3179,6 +3179,133 @@
             ":source :router rides on the routing-internal dispatch envelope")))))
 
 ;; ============================================================================
+;; rf2-cgh8q — the on-match error-trap must not mis-attribute a NON-routing
+;; throw to the loading route. Discrimination is now full event-VECTOR
+;; identity against the route's declared :on-match (not bare event-id
+;; membership), so a colliding same-id dispatch carrying different args
+;; during the loading window does NOT flip the healthy route to :error.
+;; ============================================================================
+
+(deftest on-match-error-does-not-mis-attribute-colliding-same-id-throw
+  (testing "a throw from an event whose id coincides with the active route's
+            :on-match id, but whose FULL vector differs (a button handler's
+            `[:app/load-x \"button\"]` vs the route's `[:app/load-x \"route\"]`),
+            mid-loading-window, does NOT flip the route slice to :error or
+            chain :on-error — rf2-cgh8q. Pre-fix the id-membership check
+            mis-attributed it."
+    (let [on-error-fired? (atom false)]
+      ;; The route's own on-match loader — it dispatches the COLLIDING
+      ;; throwing event as a child of its own cascade, so the throw fires
+      ;; while the slice is still :loading (the realistic reproduction
+      ;; window). The child carries DIFFERENT args than the route's
+      ;; declared on-match vector.
+      (rf/reg-event-fx :app/load-x
+                       (fn [{:keys [db]} [_ origin]]
+                         (if (= origin "button")
+                           ;; The "button"-shaped dispatch throws — it is
+                           ;; NOT the route's on-match vector.
+                           (throw (ex-info "button-throw" {:origin origin}))
+                           ;; The route's on-match dispatch: fire the
+                           ;; colliding throwing child, then no-op.
+                           {:db db
+                            :fx [[:dispatch [:app/load-x "button"]]]})))
+      (rf/reg-event-db :app/route-on-error
+                       (fn [db _] (reset! on-error-fired? true) db))
+      (rf/reg-route :route/collide
+                    {:path     "/collide"
+                     :on-match [[:app/load-x "route"]]
+                     :on-error [:app/route-on-error]})
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ _] nil))
+      (rf/dispatch-sync [:rf.route/transitioned "/collide"])
+      (let [slice (get-in (rf/app-db-value :rf/default)
+                          [:rf/runtime :routing :current])]
+        (is (not= :error (:transition slice))
+            "the colliding non-routing throw did NOT flip the route to :error")
+        (is (nil? (:error slice))
+            ":rf.route/error stays empty — no spurious error attribution")
+        (is (false? @on-error-fired?)
+            ":on-error did NOT chain for the mis-attributed throw")))))
+
+(deftest on-match-error-still-flips-on-genuine-on-match-throw
+  (testing "regression guard for rf2-cgh8q — a GENUINE on-match throw
+            (the failing event vector IS one of the route's declared
+            :on-match vectors) still flips :transition :error and chains
+            :on-error. The tightened discrimination must not suppress the
+            real error path."
+    (let [on-error-fired? (atom false)]
+      (rf/reg-event-db :app/genuine-load
+                       (fn [_db [_ arg]]
+                         (throw (ex-info "genuine-boom" {:arg arg}))))
+      (rf/reg-event-db :app/genuine-on-error
+                       (fn [db _] (reset! on-error-fired? true) db))
+      (rf/reg-route :route/genuine
+                    {:path     "/genuine"
+                     ;; on-match carries args — the failing dispatch must
+                     ;; match the FULL vector, not just the id.
+                     :on-match [[:app/genuine-load 42]]
+                     :on-error [:app/genuine-on-error]})
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ _] nil))
+      (rf/dispatch-sync [:rf.route/transitioned "/genuine"])
+      (let [slice (get-in (rf/app-db-value :rf/default)
+                          [:rf/runtime :routing :current])]
+        (is (= :error (:transition slice))
+            "a genuine on-match throw (full-vector match) still flips :error")
+        (is (= :app/genuine-load (:rf.route/on-match-id (:error slice)))
+            ":rf.route/on-match-id names the genuine failing event-id")
+        (is (true? @on-error-fired?)
+            ":on-error chains on the genuine on-match throw")))))
+
+;; ============================================================================
+;; rf2-3bv8o — external-url? fails CLOSED on the JVM / no-browser-origin
+;; path: ambiguous or absolute URLs are classed external (no in-app push),
+;; closing the open-redirect bypass surface (leading whitespace before a
+;; scheme, backslash authorities, embedded control chars). Consistent with
+;; the routing fail-closed posture (rf2-6t1xb).
+;; ============================================================================
+
+(deftest url-requested-fails-closed-on-ambiguous-urls-jvm
+  (testing ":rf/url-requested on the JVM (no browser origin) classes
+            ambiguous / bypass-shaped URLs as EXTERNAL — no :rf.nav/push-url,
+            no slice rewrite — and only PROVABLY same-origin rooted paths
+            push through. rf2-3bv8o."
+    (rf/reg-route :route/home {:path "/"})
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/dispatch-sync [:rf.route/transitioned "/"])
+      (testing "bypass-shaped / absolute / ambiguous URLs do NOT push"
+        (doseq [hostile ["https://evil.invalid/cart"   ;; scheme
+                         "//evil.invalid/cart"          ;; protocol-relative
+                         "/\\evil.invalid"              ;; backslash authority
+                         " /cart"                       ;; leading-space scheme-anchor bypass
+                         "\thttps://evil.invalid"       ;; embedded tab (browser-stripped)
+                         "javascript:alert(1)"          ;; non-http scheme
+                         "mailto:a@b.c"
+                         "cart"                          ;; bare relative segment (not rooted)
+                         ""]]
+          (reset! pushed [])
+          (rf/dispatch-sync [:rf/url-requested {:url hostile}])
+          (is (empty? @pushed)
+              (str "fail-closed: ambiguous/absolute URL " (pr-str hostile)
+                   " classed external, not pushed"))
+          (is (= :route/home (get-in (rf/app-db-value :rf/default)
+                                     [:rf/runtime :routing :current :id]))
+              (str "fail-closed: " (pr-str hostile)
+                   " did not rewrite the active route"))))
+      (testing "provably same-origin rooted paths DO push through"
+        (doseq [safe ["/cart" "/a/b/c" "/cart?q=1" "/cart#frag" "?q=1" "#frag"]]
+          (reset! pushed [])
+          (rf/dispatch-sync [:rf/url-requested {:url safe}])
+          (is (= [safe] @pushed)
+              (str "safe same-origin reference " (pr-str safe)
+                   " pushes through verbatim")))))))
+
+;; ============================================================================
 ;; rf2-5pyyl — :can-leave non-boolean → BLOCK + :rf.error/can-leave-non-boolean
 ;; ============================================================================
 


### PR DESCRIPTION
Two P3 routing correctness fixes. Both engine + test, scoped entirely to `implementation/routing/`. No spec touched (see note on hot-zone below).

## rf2-cgh8q — on-match error-trap mis-attributes a non-routing throw

`implementation/routing/src/re_frame/routing/on_match_error.cljc`

The always-on `:on-match` error-trap listener identified an on-match-originated throw purely by **event-id membership** in the active route's `:on-match`. A non-routing throw whose id happened to coincide with an `:on-match` id during the route's `:loading` window was mis-attributed — the healthy route flipped to `:error` and a spurious `:on-error` chained.

**Fix:** tighten discrimination to full event-**vector** identity (`on-match-attributed?`) against the route's declared `:on-match` vectors. The full `:event` vector rides the always-on error record (Spec 009 §Record shape), so this survives `:advanced` + `goog.DEBUG=false` like the rest of the trap. Falls back to the coarse id-membership check only when `:event` was wire-elided to `:rf.size/large-elided` (so a genuine large-payload on-match throw still routes to `:on-error`). The residual byte-for-byte identical-vector coincidence is documented as an accepted limitation in the `on-match-attributed?` docstring (no cause/cascade correlation rides the always-on substrate; the epoch `:cause-event-id` surface is dev-only and elides in production).

## rf2-3bv8o — external-url? fail-open on the JVM / SSR path

`implementation/routing/src/re_frame/routing/can_leave.cljc`

On CLJS with a browser `Location`, `external-url?` origin-compares robustly. On the JVM (and CLJS without `js/window`) it fell back to a lexical `scheme-or-//` check and `request-url->app-url` returned the URL verbatim — a **default-ALLOW**: anything not lexically absolute was treated as in-app and pushed, leaving open-redirect bypass surface (leading-whitespace scheme anchor, backslash authorities a browser normalises to `//`, embedded tab/CR/LF the browser strips before parsing).

**Fix:** flip the no-browser-origin path to **fail-CLOSED** via `safe-in-app-url?` — a URL is classed in-app only when provably a same-origin rooted path (`/x`, not `//` or `/\`), a pure query (`?…`), or a pure fragment (`#…`); everything ambiguous, absolute, control-char-bearing, or non-string is classed external (no push). Consistent with the routing fail-closed posture established by rf2-6t1xb.

## rf2-b9j64 — NOT in this PR (scope + hot-zone collision)

The third bead in the cluster brief (`:allow?` tag rename) lives in `implementation/ssr` + the hot-zone `spec/009-Instrumentation.md` + the ssr e2e test — **not** `implementation/routing/`. It is out of this PR's scope, and `spec/009` is currently being edited by an in-flight worker (`flows-path-overlap-um6d9`), so editing it here would collide on a hot-zone file (sequential-never-parallel rule). Left OPEN for its own change, as the bead itself recommends.

## Tests

- cgh8q: `on-match-error-does-not-mis-attribute-colliding-same-id-throw` (a `[:app/load-x "button"]` child throw during the loading window does NOT flip the route whose on-match is `[[:app/load-x "route"]]`) + `on-match-error-still-flips-on-genuine-on-match-throw` (full-vector match still flips `:error` + chains `:on-error`).
- 3bv8o: `url-requested-fails-closed-on-ambiguous-urls-jvm` — matrix over hostile/ambiguous URLs (no push) + provably-safe rooted paths/queries/fragments (push through).

## Gates (cold)

- routing JVM `clojure -M:test`: 151 tests, 684 assertions, 0 failures, 0 errors.
- `npm run test:cljs`: 5614 tests, 19547 assertions, 0 failures, 0 errors.

No `spec/012` change (hot-zone, in-flight by `um6d9`); the accepted-limitation note is captured in the source docstring and a follow-up bead.