### PR TITLE
docs(adapters): optional-fns count (2->3) + act()-resolver React-floor asymmetry note (rf2-s6j16 + rf2-uuzkp)

### DIFF
--- a/implementation/adapters/README.md
+++ b/implementation/adapters/README.md
@@ -25,7 +25,7 @@ The `reagent-slim` adapter has landed Stage 4 (the full `reagent2.*` rewrite —
 Each adapter implements the surface defined in [Spec 006 §The adapter API contract](../../spec/006-ReactiveSubstrate.md):
 
 - **Required (6):** `make-state-container`, `read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string`.
-- **Optional (2):** `subscribe-container`, `register-context-provider` — the core falls back when these are absent.
+- **Optional (3):** `subscribe-container`, `register-context-provider`, `flush-render!` — the core falls back (or no-ops) when these are absent. `flush-render!` is the production-grade synchronous render-commit (distinct from the `flush-views!` test helper), implemented by all four React-shaped adapters.
 - **Lifecycle (1):** `dispose-adapter!`.
 
 An adapter is a Clojure map carrying these fns under the matching keys plus a `:kind` discriminator keyword (e.g. `:rf.adapter/reagent-slim`). See [`re-frame.substrate.adapter`](../core/src/re_frame/substrate/adapter.cljc) for the live contract.

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
@@ -83,13 +83,32 @@
 (defn- resolve-act
   "Look up React's `act`. Returns the fn or nil. Re-resolved on every
   call (not cached) so a test fixture that swaps the React module
-  mid-run sees the swap on the next `flush-views!`."
+  mid-run sees the swap on the next `flush-views!`.
+
+  React-floor asymmetry (rf2-uuzkp). This SUBSTRATE-level resolver is
+  React-19-floored BY INTENT: it probes only `(.-act react)` and has NO
+  `react-dom/test-utils` fallback, so under a React-18.2 dev tree (where
+  `act` lived in test-utils) the substrate-level `flush-views!` below
+  degrades to a plain synchronous flush. This is NOT in conflict with the
+  CANONICAL cross-substrate test-flush path: the adapter-ns `flush-views!`
+  Var (`re-frame.adapter.reagent-slim/flush-views!`, surfaced identically
+  across all four substrates per rf2-b6nm5 Decision 6) routes through the
+  spine's `resolve-act-fn` (`re-frame.substrate.spine`), which DOES carry
+  the test-utils fallback (rf2-jk7hr) and so works under React 18.x. The
+  fallback there is load-bearing for the stock-Reagent (non-slim) adapter;
+  this substrate-level resolver intentionally omits it. A future React-floor
+  change, or a caller reaching this substrate-level `flush-views!` directly
+  (e.g. for its Promise return / Suspense ordering), should expect the
+  React-19 floor here and use the adapter-ns Var when React-18 graceful
+  degradation is required."
   []
   (or (.-act react)
       ;; Fallback: pre-18.3 lived in react-dom/test-utils. We don't
       ;; require that ns up top because Stage 4-B's React floor is
       ;; 19+; the .-act check on the react module is the only path
-      ;; we exercise.
+      ;; we exercise. See the React-floor asymmetry note above for why
+      ;; the canonical adapter-ns flush-views! (via the spine resolver)
+      ;; still degrades gracefully under React 18.x while this one does not.
       nil))
 
 (defn- microtask-tick


### PR DESCRIPTION
Two P4 adapters doc nits from the senior-dev adapters review (rf2-8q96k).

## rf2-s6j16 (P4, DOC) — README optional-fns undercount

`implementation/adapters/README.md` "What an adapter implements" listed **Optional (2)** and omitted `flush-render!`. The live contract — `re-frame.substrate.adapter` ns docstring (`adapter.cljc:13-14`) — and Spec 006 (`006-ReactiveSubstrate.md:97`) both carry **three** optional fns: `subscribe-container`, `register-context-provider`, `flush-render!`. `flush-render!` (rf2-40a84) is implemented by all four React-shaped adapters.

**Fix:** README → "Optional (3)", add `flush-render!` with a one-line note that it is the production-grade synchronous render-commit (distinct from the `flush-views!` test helper). Now in lockstep with the contract it points readers to.

## rf2-uuzkp (P4, RISK/DOC) — act()-resolver asymmetry

Two independent `act()` resolvers in the slim stack:

- `reagent2.dom.client/resolve-act` (`client.cljs:83-93`) — the SUBSTRATE-level Suspense-ordering primitive (Promise-returning). Probes only `(.-act react)`, React-19-floored by intent, **no** `react-dom/test-utils` fallback.
- `re-frame.substrate.spine/resolve-act-fn` (`spine.cljs:835-845`) — used by the CANONICAL adapter-ns `flush-views!` Var. **Has** the rf2-jk7hr test-utils fallback, so works under React 18.x.

Not a correctness break (the canonical cross-substrate `flush-views!` routes through the spine resolver), but a latent inconsistency: a caller reaching the substrate-level `flush-views!` under React 18.2 silently degrades to a synchronous flush.

**Fix:** cross-ref note at `reagent2.dom.client/resolve-act` documenting the React-floor asymmetry and pointing to the canonical spine path — per the bead's recommendation (a). No code change; the React-19 floor for the substrate-level resolver is intentional for slim.

## Gates

Docs/comments only — no test surface (no behavioural change; the uuzkp edit is a docstring + comment expansion).

Closes rf2-s6j16, rf2-uuzkp.
