### PR TITLE
fix(pair-mcp): parse-filter-arg fails honestly on malformed filter EDN (rf2-5kbkl)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -2331,6 +2331,12 @@ resource controls](#universal-server-resource-controls-streaming-surfaces)).
 
 - `:reason :unknown-topic` if `topic` is missing or not one of the
   four. Surfaced as `isError: true`.
+- `:reason :invalid-filter-edn` if the `filter` arg was supplied as an
+  EDN string that failed to parse (rf2-5kbkl). Surfaced as
+  `isError: true` WITHOUT touching the nREPL socket or reserving a
+  stream slot; the error echoes the offending `:given` string. A
+  malformed filter is rejected up front rather than streamed as a
+  nonsense filter that would silently match nothing.
 - `:reason :runtime-not-preloaded` if the preload hasn't run.
 - `:reason :subscribe-failed` on any other failure during subscribe.
 - `:reason :rf.error/concurrent-stream-limit` if the session already

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
@@ -339,13 +339,33 @@
 (defn parse-filter-arg
   "MCP-side filter arg can be either a JS object or an EDN string. We
   accept both for ergonomic parity with the bash-shim chain (`pred`
-  has been a JSON object there). Returns an EDN-printable map or nil
-  when missing."
+  has been a JSON object there).
+
+  Returns the tagged `[:ok m]` / `[:err :invalid-filter-edn]` shape
+  (mirroring `read-edn-arg`, rf2-5kbkl) so the caller can surface a bad
+  filter EDN as an honest `:ok? false` error rather than subscribing
+  with a nonsense filter. The two success shapes:
+
+    - `[:ok nil]`  — absent filter (no filtering).
+    - `[:ok m]`    — a parsed EDN string, a CLJS map passed through, or
+                     a JS object keywordised.
+
+  The lone failure shape `[:err :invalid-filter-edn]` is returned when
+  an EDN STRING fails to `read-string`. Pre-rf2-5kbkl this branch
+  returned a `{:invalid-filter-edn raw}` MAP that flowed straight into
+  the runtime `subscribe!` `:filter` slot — a typo'd filter silently
+  became a nonsense filter that streamed the wrong (likely empty) event
+  set with no corrective signal. The tag lets `subscribe-tool`
+  short-circuit to the same honest-error envelope `:unknown-topic`
+  already uses, rather than swallowing the parse failure into a
+  broken-success path."
   [raw]
   (cond
-    (nil? raw)        nil
-    (string? raw)     (try (cljs.reader/read-string raw)
-                           (catch :default _
-                             {:invalid-filter-edn raw}))
-    (map? raw)        raw
-    :else             (js->clj raw :keywordize-keys true)))
+    (nil? raw)        [:ok nil]
+    (string? raw)     (let [parsed (try (cljs.reader/read-string raw)
+                                        (catch :default _ ::reader-fail))]
+                        (if (= ::reader-fail parsed)
+                          [:err :invalid-filter-edn]
+                          [:ok parsed]))
+    (map? raw)        [:ok raw]
+    :else             [:ok (js->clj raw :keywordize-keys true)]))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -488,7 +488,13 @@
 (defn subscribe-tool [conn raw-args extra]
   (let [build-id           (wire/arg-build conn raw-args)
         topic              (wire/arg-keyword raw-args :topic)
-        filter-map         (args/parse-filter-arg (wire/arg raw-args :filter))
+        ;; rf2-5kbkl — `parse-filter-arg` returns the tagged
+        ;; `[:ok m]` / `[:err :invalid-filter-edn]` shape (mirroring
+        ;; `read-edn-arg`). A bad filter EDN short-circuits to an honest
+        ;; `:ok? false` envelope below rather than riding into the
+        ;; runtime `subscribe!` `:filter` slot as a nonsense filter that
+        ;; would silently stream the wrong (likely empty) event set.
+        [filter-tag filter-map] (args/parse-filter-arg (wire/arg raw-args :filter))
         max-buf-events     (wire/arg raw-args :max-buffered-events)
         max-buf-bytes      (wire/arg raw-args :max-buffered-bytes)
         poll-ms            (or (wire/arg raw-args :poll-ms) default-poll-ms)
@@ -524,6 +530,16 @@
         (wire/err-text {:ok? false :reason :unknown-topic
                         :given (wire/arg raw-args :topic)
                         :hint  "Recognised topics: trace, epoch, fx, error, frameless."}))
+
+      ;; rf2-5kbkl — the filter EDN failed to parse. Surface an honest
+      ;; `:ok? false` error (same one-cond-branch shape as
+      ;; `:unknown-topic` above) instead of subscribing with a garbage
+      ;; filter. No nREPL socket touched.
+      (= :err filter-tag)
+      (js/Promise.resolve
+        (wire/err-text {:ok? false :reason :invalid-filter-edn
+                        :given (wire/arg raw-args :filter)
+                        :hint  "filter must be an EDN-readable map (or a JSON object), e.g. \"{:op-type :error}\"."}))
 
       :else
       ;; rf2-3ijbl — reserve a session-wide stream slot BEFORE any

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
@@ -170,18 +170,21 @@
   (is (= [:ok 'nope] (args/read-edn-arg "nope(" :missing :invalid))))
 
 ;; ---------------------------------------------------------------------------
-;; parse-filter-arg — the streaming filter map (rf2-hq49). The nil /
-;; string / map arms are covered in subscribe_test; the `:else` arm
-;; (a JS object that is neither a string nor a CLJS map — the shape an
-;; MCP host sends a structured filter as) routes through
+;; parse-filter-arg — the streaming filter map (rf2-hq49). Returns the
+;; tagged `[:ok m]` / `[:err :invalid-filter-edn]` shape (rf2-5kbkl,
+;; mirroring `read-edn-arg`) so a bad filter EDN surfaces as an honest
+;; `:ok? false` error rather than a nonsense filter the runtime applies.
+;; The nil / string / map arms are covered in subscribe_test; the
+;; `:else` arm (a JS object that is neither a string nor a CLJS map —
+;; the shape an MCP host sends a structured filter as) routes through
 ;; `js->clj :keywordize-keys true` and was untested. Pin it (rf2-ynjts.19).
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-filter-arg-js-object-keywordizes
   (let [obj #js {"op-type" "error" "frame" "rf/default"}
         out (args/parse-filter-arg obj)]
-    (is (= {:op-type "error" :frame "rf/default"} out)
-        "JS-object keys keywordized; values left as-is")))
+    (is (= [:ok {:op-type "error" :frame "rf/default"}] out)
+        "JS-object keys keywordized; values left as-is; wrapped in :ok tag")))
 
 (deftest parse-filter-arg-nested-js-object-keywordizes-deep
   ;; `:keywordize-keys true` recurses — a nested JS object's keys are
@@ -189,4 +192,14 @@
   (let [obj #js {"touches-path" #js ["cart" "items"]
                  "meta" #js {"min-ms" 50}}
         out (args/parse-filter-arg obj)]
-    (is (= {:touches-path ["cart" "items"] :meta {:min-ms 50}} out))))
+    (is (= [:ok {:touches-path ["cart" "items"] :meta {:min-ms 50}}] out))))
+
+(deftest parse-filter-arg-malformed-edn-is-err-tagged
+  ;; rf2-5kbkl — the regression: an unparseable EDN string must NOT
+  ;; become a `{:invalid-filter-edn raw}` map that rides into the runtime
+  ;; `:filter` slot. It returns the honest `[:err :invalid-filter-edn]`
+  ;; tag (mirroring read-edn-arg's :invalid arm) so the caller can
+  ;; short-circuit to an `:ok? false` envelope.
+  (is (= [:err :invalid-filter-edn]
+         (args/parse-filter-arg "(((")) ;; unbalanced delimiters
+      "unparseable filter EDN → honest :err tag, not a nonsense map"))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
@@ -7,10 +7,11 @@
   (notifications/progress emission, abort-signal termination) lives
   in `test/stdio-roundtrip.js` and the live-nREPL integration test
   against a real shadow-cljs build."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing async]]
             [cljs.reader]
             [clojure.string :as str]
             [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.subscribe :as sub]))
@@ -19,32 +20,76 @@
 ;; `re-frame2-pair-mcp.tools.args/parse-filter-arg`. Tests pin the
 ;; public surface directly so a rename or signature change surfaces
 ;; as a failing test rather than a silent contract drift.
+;;
+;; rf2-5kbkl — the parser returns the tagged `[:ok m]` /
+;; `[:err :invalid-filter-edn]` shape (mirroring `read-edn-arg`). A
+;; malformed filter EDN surfaces as an honest `:ok? false` error rather
+;; than the pre-fix `{:invalid-filter-edn raw}` MAP that flowed straight
+;; into the runtime `:filter` slot as a nonsense filter.
 
 (deftest filter-arg-nil-passes-through
-  (is (nil? (args/parse-filter-arg nil))))
+  (is (= [:ok nil] (args/parse-filter-arg nil))))
 
 (deftest filter-arg-edn-string-reads
-  (is (= {:op-type :error}
+  (is (= [:ok {:op-type :error}]
          (args/parse-filter-arg "{:op-type :error}"))))
 
 (deftest filter-arg-edn-string-with-touches-path
-  (is (= {:touches-path [:cart :items]}
+  (is (= [:ok {:touches-path [:cart :items]}]
          (args/parse-filter-arg "{:touches-path [:cart :items]}"))))
 
-(deftest filter-arg-malformed-edn-surfaces-marker
-  (is (= {:invalid-filter-edn "((("}
+(deftest filter-arg-malformed-edn-is-err-tagged
+  ;; The regression: an unparseable EDN string must NOT become a
+  ;; nonsense `{:invalid-filter-edn raw}` map — it returns the honest
+  ;; `[:err :invalid-filter-edn]` tag so the caller short-circuits.
+  (is (= [:err :invalid-filter-edn]
          (args/parse-filter-arg "(((")))) ;; unbalanced delimiters
 
 (deftest filter-arg-js-object-keywordises
   (let [obj #js {:op-type "error" :event-id "user/login"}
-        out (args/parse-filter-arg obj)]
+        [tag out] (args/parse-filter-arg obj)]
+    (is (= :ok tag))
     (is (map? out))
     (is (= "error" (:op-type out)))
     (is (= "user/login" (:event-id out)))))
 
 (deftest filter-arg-clj-map-passes-through
-  (is (= {:op-type :error}
+  (is (= [:ok {:op-type :error}]
          (args/parse-filter-arg {:op-type :error}))))
+
+;; rf2-5kbkl — end-to-end at the tool boundary: a malformed filter EDN
+;; makes `subscribe-tool` short-circuit to an honest `:ok? false`
+;; envelope (`:reason :invalid-filter-edn`, `:isError true`) WITHOUT
+;; touching the nREPL socket or reserving a stream slot — rather than
+;; subscribing with a garbage filter. A VALID filter is unaffected (it
+;; falls through to the normal subscribe path; covered by the
+;; subscribe-form tests above).
+
+(deftest subscribe-tool-malformed-filter-errors-honestly
+  ;; The headline regression. A malformed filter EDN makes
+  ;; `subscribe-tool` short-circuit to an honest `:ok? false` envelope
+  ;; (`:reason :invalid-filter-edn`, `:isError true`) — the `cond`
+  ;; branch fires BEFORE the `:else` arm reserves a stream slot or
+  ;; touches the nREPL socket, so this resolves synchronously with no
+  ;; live runtime needed and no resource-controls state mutated.
+  (async done
+    (-> (sub/subscribe-tool nil #js {:topic "trace" :filter "((("} nil)
+        (.then (fn [r]
+                 (is (tu/error? r)
+                     "malformed filter EDN surfaces as :isError true")
+                 (let [edn (tu/extract-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :invalid-filter-edn (:reason edn))
+                       "honest :reason, not a silent subscribe with a garbage filter")
+                   (is (= "(((" (:given edn))))
+                 (done))))))
+
+;; The VALID-filter path "works unchanged" is pinned by the
+;; `subscribe-form-with-trace-and-filter` / `-fx-topic` round-trip tests
+;; above: a well-formed filter rides into the runtime `subscribe!`
+;; `:filter` opts slot. With the rf2-5kbkl change those still hold
+;; because `parse-filter-arg` now unwraps the `[:ok m]` tag back to the
+;; same `filter-map` the form constructor consumes.
 
 ;; The subscribe-form constructor is private. Re-implement here over
 ;; the eval-form DSL to pin the IR + emitted source we send to the


### PR DESCRIPTION
## What

`parse-filter-arg` (`tools/re-frame2-pair-mcp/.../args.cljs`) swallowed an unparseable filter EDN string into a `{:invalid-filter-edn raw}` MAP. `subscribe-tool` (`subscribe.cljs`) then passed that map straight into the runtime `subscribe!` `:filter` slot — so a fat-fingered filter EDN silently became a nonsense filter that streamed the wrong (likely empty) event set, with no corrective signal to the agent. It was the one arg parser in this surface converting a parse failure into a broken-success path (dispatch/read-edn-arg/etc. all signal failure honestly).

## Fix

- `parse-filter-arg` now returns the tagged `[:ok m]` / `[:err :invalid-filter-edn]` shape, mirroring the established `read-edn-arg` sibling. `[:ok nil]` for an absent filter; `[:ok m]` for a parsed string / passed-through CLJS map / keywordised JS object.
- `subscribe-tool` destructures the tag and short-circuits to `wire/err-text {:ok? false :reason :invalid-filter-edn :given <raw> :hint ...}` — the same one-`cond`-branch honest-error shape `:unknown-topic` already uses, fired BEFORE reserving a stream slot or touching the nREPL socket.
- Spec `003-Tool-Catalogue.md` failure-modes section documents the new `:reason :invalid-filter-edn`.

## Scope / contract

Internal error-handling only. No wire/tool-name or MCP descriptor-surface change — `parse-filter-arg`'s return shape is internal between two pair-mcp namespaces, and the new `:reason` rides the existing `wire/err-text` envelope. `mcp-conformance` stays green (confirms no wire-contract change).

## Tests

- `parse-filter-arg-malformed-edn-is-err-tagged` (args_test + subscribe_test): malformed EDN -> `[:err :invalid-filter-edn]`, not a nonsense map.
- `subscribe-tool-malformed-filter-errors-honestly` (subscribe_test): a malformed filter makes the tool resolve to an `:ok? false` / `:isError true` envelope with `:reason :invalid-filter-edn` — no garbage subscription.
- The valid-filter "works unchanged" path remains pinned by the existing `subscribe-form-with-trace-and-filter` / `-fx-topic` round-trip tests (now unwrapping the `[:ok m]` tag).

## Gates (cold, in worktree)

- pair-mcp `npm test`: 896 tests, 2747 assertions, 0 failures, 0 errors.
- `npm run test:mcp-conformance`: ALL MCP-CONFORMANCE GATES GREEN (6/6).

Closes rf2-5kbkl.