### PR TITLE
fix(machines): region-scope done-state arm-2 escape hatch + fix stale spawn-id docstring (rf2-m3arq + rf2-z69px)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -18,7 +18,10 @@
       (fn [snapshot] ms) computed once at state entry.
     - Declarative :spawn that desugars into [:rf.machine/spawn args]
       on entry and [:rf.machine/destroy actor-id] on exit; deterministic
-      actor ids via a per-process counter.
+      actor ids via the in-snapshot :rf/spawn-counter (declarative) / the
+      frame's app-db [:rf/runtime :machines :spawn-counter <machine-id>]
+      slot (hand-emitted) — no process-global state (rf2-gr8q / rf2-owvvr;
+      the body comment below + spawn.cljc both note the global atom is gone).
     - Declarative :spawn-all — spawn-and-join sugar over N parallel
       :spawn's plus a join condition (:all / :any / {:n N} / {:fn pred}).
     - The :raise reserved fx-id (machine-internal pre-commit dispatch).

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -823,6 +823,30 @@
       `:event` (`(= <path> (second event))`) to disambiguate which node is
       done when several could raise it.
 
+  **Parallel-region scoping of arm 2 (rf2-m3arq).** A region-local compound's
+  done signal is re-broadcast across EVERY sibling region by the parent
+  internal-event queue (`parallel/drain-parent-queue` — the correct XState v5 /
+  SCXML `:raise` rule). The raised `[:rf.machine/done <region-relative-path>]`
+  therefore reaches every region's resolver. XState v5 / SCXML scope the
+  `done.state.<id>` event to the region that raised it — a SIBLING region must
+  NOT catch another region's done. Arm 1 (`:on-done` on the done node) is
+  naturally region-scoped (it resolves the done node by `done-path` relative to
+  the region body and only the originating region carries that node on its
+  active path), but the lower-level arm 2 escape hatch matches on the bare
+  reserved event-id and does NOT itself read the path — so an UNGUARDED
+  `:on {:rf.machine/done …}` in a sibling region would otherwise catch a
+  foreign region's done (a silent cross-region leak). To close it by
+  construction: when `machine` is a region (`:rf/region` present), arm 2 only
+  fires when the raised `done-path` is on THIS region's active `path` (the done
+  compound is a prefix of / equal to the active path — the same `prefix-of?`
+  staleness check `pick-after-transition` / `pick-spawn-error-transition` use).
+  A sibling's done-path is not a prefix of this region's active path, so the
+  sibling declines and the broadcast routes the done to its OWN region only.
+  Flat / compound machines carry no `:rf/region`, so the gate is a no-op there:
+  an unguarded `:on {:rf.machine/done …}` stays unambiguous (only the one
+  machine raises into itself). Arm 1 is left exactly as-is — the conformance-
+  verified leak-free common `:on-done` placement.
+
   `done-path` is the node's declaration path (the event's second element).
   Returns `{:transition t :decl-path p}` or nil (no `:on-done` and no
   enclosing handler — the done signal is then a benign no-op, exactly as an
@@ -839,19 +863,29 @@
                         (normalise-candidates (:on-done done-node)
                                               :rf.error/machine-bad-on-done-clause))
         on-done-hit   (when (seq on-done-cands)
-                        (select-passing-candidate machine on-done-cands snapshot event))]
+                        (select-passing-candidate machine on-done-cands snapshot event))
+        ;; rf2-m3arq — arm-2 region scoping. In a parallel region the done
+        ;; signal is broadcast to every sibling; the explicit-`:on` escape
+        ;; hatch must only catch THIS region's own done. A flat / compound
+        ;; machine (no `:rf/region`) is always own-region — the gate is inert.
+        own-region?   (or (not (:rf/region machine))
+                          (and (vector? done-path)
+                               (prefix-of? done-path path)))]
     (if on-done-hit
       {:transition on-done-hit :decl-path (vec done-path)}
       ;; Fall through to the standard leaf→root `:on` walk (an ancestor's
-      ;; explicit `:on {:rf.machine/done …}`), then the root `:on`.
-      (or
-        (path-walk/walk-path-leaf-to-root
-          machine path
-          (fn [prefix n]
-            (when-let [hit (match-on-clause machine n done-event-id event snapshot)]
-              {:transition hit :decl-path prefix})))
-        (when-let [hit (match-on-clause machine machine done-event-id event snapshot)]
-          {:transition hit :decl-path []})))))
+      ;; explicit `:on {:rf.machine/done …}`), then the root `:on` — but only
+      ;; for THIS region's own done (rf2-m3arq), so a sibling region's
+      ;; broadcast done cannot be caught by an unguarded escape hatch here.
+      (when own-region?
+        (or
+          (path-walk/walk-path-leaf-to-root
+            machine path
+            (fn [prefix n]
+              (when-let [hit (match-on-clause machine n done-event-id event snapshot)]
+                {:transition hit :decl-path prefix})))
+          (when-let [hit (match-on-clause machine machine done-event-id event snapshot)]
+            {:transition hit :decl-path []}))))))
 
 (defn- pick-spawn-error-transition
   "Per Spec 005 §Final states §`:on-error` — child-failure control flow

--- a/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
@@ -679,6 +679,44 @@
           ":work's compound :flow reached final, its :on-done advanced the
            region to :work-done; :status stayed :idle"))))
 
+(deftest scxml-parallel-region-done-not-caught-by-sibling-unguarded-on
+  (testing "rf2-m3arq: a region-local done.state is region-SCOPED — a SIBLING
+            region's UNGUARDED `:on {:rf.machine/done …}` escape hatch must NOT
+            catch another region's done signal, even though the parent
+            internal-event queue re-broadcasts the raise across every region
+            (the correct XState v5 / SCXML `:raise` rule). XState v5 / SCXML
+            scope `done.state.<id>` to the region that raised it. Spec 005
+            §Final states §The done-state signal × §Parallel regions; the
+            arm-2 escape-hatch region scoping in `pick-done-transition`."
+    (let [m {:type :parallel :data {}
+             :regions
+             ;; :work owns a compound :flow that goes done on :finish. It uses
+             ;; the lower-level explicit `:on {:rf.machine/done …}` escape hatch
+             ;; (NOT `:on-done`) so the resolution exercises arm 2.
+             {:work {:initial :flow
+                     :on {:rf.machine/done :work-done}
+                     :states {:flow {:initial :step
+                                     :states {:step {:on {:finish :inner-done}}
+                                              :inner-done {:final? true}}}
+                              :work-done {}}}
+              ;; :other carries an UNGUARDED escape hatch on the SAME reserved
+              ;; event-id. Before rf2-m3arq the re-broadcast of :work's
+              ;; region-local done would be CAUGHT here, leaking :other →
+              ;; :hijacked. It must stay put: :work's done is not :other's done.
+              :other {:initial :idle
+                      :on {:rf.machine/done :hijacked}
+                      :states {:idle {} :hijacked {}}}}}
+          ;; :finish lands :work at [:flow :inner-done]; :flow is done →
+          ;; region-local [:rf.machine/done [:flow]] raise → re-broadcast across
+          ;; BOTH regions. :work catches its own done (region-owned) → :work-done.
+          ;; :other declines (the done-path is not on :other's active path).
+          r (step m {:state {:work [:flow :step] :other :idle} :data {}} [:finish])]
+      (is (= {:work :work-done :other :idle} (:state r))
+          ":work caught its own region-local done via its explicit `:on`
+           escape hatch → :work-done; :other's UNGUARDED `:on {:rf.machine/done}`
+           did NOT catch :work's done (no cross-region leak) → :other stayed
+           :idle"))))
+
 ;; ===========================================================================
 ;; §6. Eventless / :always microstep settle (transient transitions)
 ;;


### PR DESCRIPTION
## Summary

Two machines-engine fixes from the engine senior-dev review (rf2-1l94d), disjoint files.

### rf2-m3arq (P3, RISK) — cross-region done leak through the unguarded escape hatch

A `:type :parallel` machine owns one internal-event queue; a region-local `[:rf.machine/done <path>]` raise is re-broadcast across **every** sibling region (the correct XState v5 / SCXML `:raise` rule). `pick-done-transition` arm 2 — the lower-level enclosing `:on {:rf.machine/done ...}` escape hatch — matches on the bare reserved event-id and does not itself read the path, so an **unguarded** escape hatch in a *sibling* region would catch a foreign region's done: a silent cross-region state leak. XState v5 / SCXML scope `done.state.<id>` to the region that raised it.

**Fix (reviewer rec (b) — make the wrong thing impossible):** arm 2 now gates on `own-region?`. When `machine` is a region (`:rf/region` present), the explicit-`:on` walk only fires when the raised `done-path` is a prefix of this region's active `path` (the same `prefix-of?` staleness check `pick-after-transition` / `pick-spawn-error-transition` already use). A sibling's done-path is not a prefix of its active path, so the sibling declines and the broadcast routes the done to its own region only. Flat / compound machines carry no `:rf/region`, so the gate is **inert** there — an unguarded `:on {:rf.machine/done ...}` stays unambiguous (only one machine raises into itself).

Arm 1 (`:on-done` on the done node) is left **exactly as-is** — the conformance-verified leak-free common placement stays green (`scxml-parallel-region-compound-done-fires-region-local-on-done`).

New test `scxml-parallel-region-done-not-caught-by-sibling-unguarded-on`: region `:work`'s compound goes done and catches its own done via an explicit `:on` escape hatch (exercises arm 2); a sibling `:other` with an **unguarded** `:on {:rf.machine/done}` must NOT be hijacked. **Negative-control verified** — with the gate disabled, exactly this test fails.

### rf2-z69px (P4, DOC) — stale "per-process counter" docstring

`machines.cljc` ns-header `:spawn` line claimed deterministic actor ids "via a per-process counter" — stale since rf2-gr8q moved the spawn-id allocator in-snapshot (`:rf/spawn-counter`, declarative) / the frame's app-db slot `[:rf/runtime :machines :spawn-counter <id>]` (hand-emitted, rf2-owvvr). The header now matches the body comment + `spawn.cljc` (no process-global state).

## Out of scope (untouched)

`validation.cljc` / the `:always` validator (rf2-acdlp is held for Mike) — confirmed not touched. `spec/005` not touched (no doc gates required).

## Quality gates

- `npm run test:cljs` (machines + SCXML-conformance + new m3arq test): **5616 tests / 19562 assertions, 0 failures, 0 errors**
- machines JVM `clojure -M:test`: **465 tests / 1477 assertions, 0 failures, 0 errors**
- Negative control: gate disabled => the new test (and only it) fails

Closes rf2-m3arq, rf2-z69px.
