### PR TITLE
refactor(epoch): bound value-changed scan to keep-window + rename .write→.tool-pair (rf2-3rg4j + rf2-dga99)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -338,7 +338,7 @@
    {:key         :machines/actor-resolvable?
     :producer-ns 're-frame.machines
     :design-bead "rf2-a2sn1"
-    :description "Epoch-restore precondition companion to :machines/resolve-actor-handler-meta. Returns true iff a recorded actor-id's snapshot in a candidate restore db resolves to a live machine spec via its `:rf/machine-type` (registered TYPE or inline `:definition`). Lets `re-frame.epoch.write/missing-references` treat a spawned-actor snapshot as a VALID restore target — its per-instance handler is, by design, never registered — rather than a `:rf.epoch/restore-missing-handler`."}
+    :description "Epoch-restore precondition companion to :machines/resolve-actor-handler-meta. Returns true iff a recorded actor-id's snapshot in a candidate restore db resolves to a live machine spec via its `:rf/machine-type` (registered TYPE or inline `:definition`). Lets `re-frame.epoch.tool-pair/missing-references` treat a spawned-actor snapshot as a VALID restore target — its per-instance handler is, by design, never registered — rather than a `:rf.epoch/restore-missing-handler`."}
    {:key         :machines/spawn-all-init-fx
     :producer-ns 're-frame.machines
     :description "Effect handler seeding the :spawn-all join state during spawn."}

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -45,7 +45,7 @@
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.listeners :as listeners]
             [re-frame.epoch.state :as state]
-            [re-frame.epoch.write :as write]
+            [re-frame.epoch.tool-pair :as tool-pair]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -443,7 +443,7 @@
 ;; ---- restore --------------------------------------------------------------
 ;;
 ;; Precondition validators, schema/handler/version probes, and
-;; `perform-restore!` live in `re-frame.epoch.write` (Phase-2 seam E,
+;; `perform-restore!` live in `re-frame.epoch.tool-pair` (Phase-2 seam E,
 ;; rf2-0wi86). The orchestrator below stays in the facade — it wires
 ;; the precondition check + the trace emission + the perform step into
 ;; a four-line case-match.
@@ -470,10 +470,10 @@
   [frame-id epoch-id]
   (if-not interop/debug-enabled?
     false
-    (let [{:keys [outcome epoch op tags]} (write/check-restore-preconditions! frame-id epoch-id)]
+    (let [{:keys [outcome epoch op tags]} (tool-pair/check-restore-preconditions! frame-id epoch-id)]
       (case outcome
-        :ok   (write/perform-restore! frame-id epoch)
-        :fail (do (write/emit-precondition-failure! op tags)
+        :ok   (tool-pair/perform-restore! frame-id epoch)
+        :fail (do (tool-pair/emit-precondition-failure! op tags)
                   false)))))
 
 ;; ---- reset-frame-db! (Tool-Pair §Pair-tool writes, rf2-zq55) -------------
@@ -552,15 +552,15 @@
   [frame-id new-db]
   (if-not interop/debug-enabled?
     false
-    (let [{:keys [outcome op tags]} (write/check-reset-frame-db-preconditions! frame-id new-db)]
+    (let [{:keys [outcome op tags]} (tool-pair/check-reset-frame-db-preconditions! frame-id new-db)]
       (case outcome
         :ok   (perform-reset-frame-db! frame-id new-db)
-        :fail (do (write/emit-precondition-failure! op tags)
+        :fail (do (tool-pair/emit-precondition-failure! op tags)
                   false)))))
 
 ;; ---- projected egress -----------------------------------------------------
 ;;
-;; The projection helpers live in `re-frame.epoch.write` (Phase-2
+;; The projection helpers live in `re-frame.epoch.tool-pair` (Phase-2
 ;; seam E, rf2-0wi86); the public docstrings stay here so the facade
 ;; remains the canonical API reference.
 
@@ -593,7 +593,7 @@
   `register-epoch-listener!` registration under `interop/debug-enabled?`
   per Spec 009 §User-side listener registration."
   [record]
-  (write/projected-record record))
+  (tool-pair/projected-record record))
 
 (defn projected-history
   "Convenience: return the projected vector of records for a frame.
@@ -602,7 +602,7 @@
   snapshot, a recorder dumping the full session) can call this once
   rather than walking the raw ring and re-wrapping each record."
   [frame-id]
-  (write/projected-history frame-id))
+  (tool-pair/projected-history frame-id))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -20,7 +20,7 @@
 
   Plus the `current-schema-digest` accessor that both `build-record`
   (digest pinned on the record) and the restore-preconditions seam
-  (`re-frame.epoch.write`) consume.
+  (`re-frame.epoch.tool-pair`) consume.
 
   Per rf2-0wi86 Phase-2 seam D: this namespace is dependency-free
   beyond state (atoms + counter), capture (cascade walks), and the

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -482,13 +482,27 @@
 
   Reads only `:trace-events`, which the most-recent `:trace-events-keep`
   records retain — exactly the window a post-settle render can target
-  (the back-fill never reaches older, projection-only records). One pass
-  newest-first; short-circuits at the first matching epoch."
+  (the back-fill never reaches older, projection-only records). The scan
+  is BOUNDED to that keep-window: a record past it had its `:trace-events`
+  elided (`elide-just-crossed-trace-events`), so `epoch-value-changed-for-
+  view?` short-circuits to `false` on it via `(some f nil)` — it can never
+  contribute a hit. Stopping at `(- (count history) keep)` makes the scan
+  genuinely O(keep) rather than O(depth) per miss (the common mount /
+  mount-burst-tail case this fn exists to catch), matching the fused-walk
+  / O(keep) framing the rest of this file holds (rf2-3rg4j). A nil `keep`
+  means every record retains `:trace-events`, so the scan reaches index 0.
+  One pass newest-first; short-circuits at the first matching epoch."
   [frame-id render-key]
   (let [history (history-for frame-id)
-        deps    (render-deps-for frame-id render-key)]
-    (loop [i (dec (count history))]
-      (when (>= i 0)
+        deps    (render-deps-for frame-id render-key)
+        n       (count history)
+        keep    (trace-events-keep)
+        ;; Older records carry no `:trace-events`, so they can never match;
+        ;; stop the scan at the keep-window's oldest retained index. nil
+        ;; `keep` = retain everything → scan to index 0.
+        lo      (if (nat-int? keep) (max 0 (- n keep)) 0)]
+    (loop [i (dec n)]
+      (when (>= i lo)
         (let [record (nth history i)]
           (if (epoch-value-changed-for-view? record render-key deps)
             (:epoch-id record)

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -1,7 +1,15 @@
-(ns re-frame.epoch.write
-  "Tool-Pair write surfaces — the preconditions, restore-perform, and
+(ns re-frame.epoch.tool-pair
+  "Tool-Pair boundary surfaces — the preconditions, restore-perform, and
   off-box projection helpers behind `restore-epoch`, `reset-frame-db!`,
   `projected-record`, and `projected-history`.
+
+  The name (rf2-dga99) covers BOTH halves of the seam: the WRITE-in
+  boundary (precondition validators + `perform-restore!` behind the
+  Tool-Pair time-travel surfaces) AND the off-box egress READ boundary
+  (`projected-record` / `projected-history`, the privacy projection per
+  Security.md §Epoch privacy posture). The former `write` name accurately
+  named the first half but undersold the projection egress — both are
+  Tool-Pair-contract surfaces, so `tool-pair` names the seam honestly.
 
   Responsibilities:
 

--- a/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
@@ -2,7 +2,7 @@
   "Coverage for the `:trace-events` re-root in off-box egress projection
   (rf2-ynjts.7 testing-review gap-fill).
 
-  Per rf2-ta0y7 (`re-frame.epoch.write/reroot-trace-event-db-slots` +
+  Per rf2-ta0y7 (`re-frame.epoch.tool-pair/reroot-trace-event-db-slots` +
   `elide-trace-events-slot`): the `:rf.event/db-pending` (t1) and
   `:rf.event/db-pending-post-flow` (t2) trace events each carry the FULL
   pending app-db value under `:tags :rf.event/db`. The bulk


### PR DESCRIPTION
Two epoch P4 nits.

## rf2-3rg4j (P4, perf/doc) — `value-changed-epoch-for` O(depth) vs docstring O(keep)

**Determination:** option (a) — bound the scan (the bead's preferred fix). `value-changed-epoch-for` looped newest-first over the *full* ring; on a miss (the common mount / mount-burst-tail case it exists to catch) it walked all `:depth` records though only the most-recent `:trace-events-keep` could ever match — records past the keep-window had their `:trace-events` elided by `elide-just-crossed-trace-events`, so `epoch-value-changed-for-view?` short-circuits to `false` on them via `(some f nil)`. The loop still iterated them: O(depth), not the O(keep) the docstring claimed.

**Fix:** bound the loop's lower index to `(max 0 (- (count history) keep))`, making the scan genuinely O(keep). `nil keep` (retain-everything config) scans to index 0. Correctness-preserving — the skipped records returned `false` anyway. Docstring corrected to describe the bound.

Call path: `listeners/back-fill-render!` → `resolve-render-epoch` → `value-changed-epoch-for`, fired per `:view/render` commit, dev-only (`interop/debug-enabled?`). Default `keep == depth == 50` makes the distinction moot today; it bites only when an app sets a small `trace-events-keep` with `depth` left at 50.

## rf2-dga99 (P4, naming) — `re-frame.epoch.write` undersells its egress-projection content

The ns held BOTH Tool-Pair write-in surfaces (restore/reset preconditions + `perform-restore!`) AND the off-box egress READ projection (`projected-record` / `projected-history`). "write" named the first half but undersold the projection.

**Rename:** `re-frame.epoch.write` → `re-frame.epoch.tool-pair` (the bead's `.tool-pair` candidate). Names the spec surface both halves implement; matches the sibling noun-named seams (`assembly` / `capture` / `listeners` / `state`). Pure rename, no behaviour change.

- File git-mv'd `write.cljc` → `tool_pair.cljc` (git records 97% rename; old removed, no orphan).
- ns form + docstring updated; alias `:as write` → `:as tool-pair`.
- All 6 tree-wide references updated: `epoch.cljc` (require + 6 callsites + 2 comments), `assembly.cljc` doc, `core/.../late_bind/directory.cljc` hook description, `epoch_egress_trace_events_test.clj` docstring.
- grep-confirmed zero orphan refs to the old ns (excl. `.beads/`). No `tools/` consumer requires it (the xray-test match was an incidental "write/read" string).

## Gates (cold)
- epoch JVM `clojure -M:test`: **256 tests / 966 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5615 tests / 19561 assertions, 0 failures, 0 errors** (CLJS build resolving the renamed ns across the cross-artefact classpath is itself the rename-correctness proof)

## Consumer-rebase risk
None. No in-flight worker (story / story-mcp / pair-mcp) requires `re-frame.epoch.write`; the rename is confined to `implementation/epoch/` + one core doc-string.

Closes rf2-3rg4j. Closes rf2-dga99.