### PR TITLE
fix(story): re-arm warned-both-slots + normalise emit-reports! arg + correct story-mcp version docstrings (rf2-a1lvd + rf2-ngwdf + rf2-ijeu5)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/config.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/config.cljc
@@ -53,9 +53,11 @@
   "The MCP protocol version this server advertises in the `initialize`
   handshake. Pinned to `2025-06-18` — the latest spec at Stage 7 land.
 
-  The spec's version-negotiation rule: if the client requests a version
-  we don't recognise, we still respond with the one we support; the
-  client decides whether to disconnect. Per
+  `handle-initialize` advertises this value unconditionally — it never
+  inspects or echoes the client's requested `protocolVersion`. That is
+  spec-acceptable under the MCP lifecycle version-negotiation rule: the
+  server responds with a version it supports and the client decides
+  whether to disconnect on a mismatch. Per
   https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
   §Version Negotiation."
   "2025-06-18")

--- a/tools/story-mcp/src/re_frame/story_mcp/server.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/server.cljc
@@ -61,10 +61,13 @@
 ;; ---- handshake ------------------------------------------------------------
 
 (defn- handle-initialize
-  "Build the `initialize` response. Echoes the client's `protocolVersion`
-  when we support it (only `2025-06-18` at Stage 7 land); otherwise we
-  reply with our supported version and let the client decide whether to
-  disconnect per the spec's version-negotiation rule."
+  "Build the `initialize` response. Unconditionally advertises the
+  server's pinned protocol-version (`config/protocol-version`) and
+  ignores the client's requested `protocolVersion` entirely — `_params`
+  is never read. This is spec-acceptable: per the MCP lifecycle
+  version-negotiation rule the server replies with a version it supports
+  and the client decides whether to disconnect on a mismatch (we never
+  inspect or echo the client's version)."
   [id _params]
   (proto/response id
                   {:protocolVersion config/protocol-version

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -1592,9 +1592,16 @@
      ;; does not see a key it does not own.
      (let [run-opts (not-empty (dissoc opts :timeout-ms))
            p        (run target run-opts)]
+       ;; rf2-ngwdf — both branches pass `(:variant/id result)`, matching
+       ;; the already-resolved sync branch above. `emit-reports!` ignores
+       ;; its first arg TODAY, so this is behaviour-preserving; it removes
+       ;; the latent trap of three call sites supplying three different
+       ;; shapes (a `:variant/id` value vs. the RAW `target` keyword/map)
+       ;; for the same parameter, should a future change make the arg load-
+       ;; bearing (e.g. stamping the variant id onto each report's message).
        #?(:clj
           (let [result (async/deref-blocking p (get opts :timeout-ms 30000))]
-            (emit-reports! target (result/result->reports result))
+            (emit-reports! (:variant/id result) (result/result->reports result))
             result)
           :cljs
           ;; CLJS run is async; report when it resolves and hand the
@@ -1602,7 +1609,7 @@
           ;; `:timeout-ms` is inert here — the caller's own async deadline
           ;; governs (the JVM is the only path that blocks).
           (async/then p (fn [result]
-                          (emit-reports! target (result/result->reports result))
+                          (emit-reports! (:variant/id result) (result/result->reports result))
                           result)))))))
 
 (defn report-result!

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -101,6 +101,17 @@
   step-boundaries
   (atom {}))
 
+(defonce ^:private ^{:doc "Set of variant ids that have already received
+                          the both-:play-script-and-:plays console
+                          warning. One warning per variant per page
+                          lifetime keeps the console quiet. rf2-a1lvd:
+                          re-armed by `clear-all-runs!` so a fresh test
+                          + each hot-reload reset can warn again (a
+                          warn-once cache that is never reset suppresses
+                          the affordance across test order + hot-reload)."}
+  warned-both-slots
+  (atom #{}))
+
 (defn current-state
   "Read the current run-state for `frame-id`, or nil if no run exists."
   [frame-id]
@@ -186,16 +197,24 @@
   nil)
 
 (defn clear-all-runs!
-  "Wipe ALL per-variant run-state across every frame — the three
-  per-process atoms (`run-state` / `runs-by-play` / `active-play`).
-  Used by the Story test-fixture helper (rf2-lh99f) so a fresh test
-  doesn't observe a previous test's play outcomes; `clear-state!` is
-  the per-frame counterpart called from teardown."
+  "Wipe ALL per-variant run-state across every frame — the four
+  per-process atoms (`run-state` / `runs-by-play` / `active-play` /
+  `step-boundaries`) AND the `warned-both-slots` one-shot warning cache
+  (rf2-a1lvd). Used by the Story test-fixture helper (rf2-lh99f) so a
+  fresh test doesn't observe a previous test's play outcomes;
+  `clear-state!` is the per-frame counterpart called from teardown.
+
+  Clearing `warned-both-slots` here re-arms the both-`:play-script`-and-
+  `:plays` console warning per test and per hot-reload reset, mirroring
+  the established warn-once-clear pattern (cf. rf2-4edk / qy6cl): a
+  warn-once cache that is never reset suppresses the affordance across
+  test order + hot-reload."
   []
   (reset! run-state      {})
   (reset! runs-by-play   {})
   (reset! active-play    {})
   (reset! step-boundaries {})
+  (reset! warned-both-slots #{})
   nil)
 
 (defn- update-state!
@@ -276,13 +295,6 @@
         (runner/parse-spec (when body (:play-script body)))))))
 
 ;; ---- multi-play warning (one-shot) ---------------------------------------
-
-(defonce ^:private ^{:doc "Set of variant ids that have already received
-                          the both-:play-script-and-:plays console
-                          warning. One warning per variant per page
-                          lifetime keeps the console quiet."}
-  warned-both-slots
-  (atom #{}))
 
 (defn- warn-both-slots-once!
   [variant-id]

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -1071,6 +1071,40 @@
            (is (empty? out2)
                "subsequent reads stay silent — warning is one-shot per variant"))))))
 
+;; rf2-a1lvd — the one-shot warning cache (`warned-both-slots`) is re-armed
+;; by `clear-all-runs!` (the test-fixture path). Without the reset, a prior
+;; test (or a prior hot-reload session) that warned for a variant id would
+;; suppress the warning forever after. Verify the full re-arm cycle: warn
+;; fires → clear-all-runs! → warn fires AGAIN.
+#?(:clj
+   (deftest both-slots-warning-re-arms-after-clear-all-runs
+     (testing "clear-all-runs! resets warned-both-slots so the both-slots
+               warning fires again for a previously-warned variant"
+       (require '[re-frame.story.registrar :as registrar])
+       (let [registrar (resolve 're-frame.story.registrar/kind->id->body)]
+         (swap! @registrar assoc-in
+                [:variant :story.multi/both-rearm]
+                {:play-script [[:dispatch [:legacy]]]
+                 :plays       [{:name "p" :script [[:dispatch [:plays]]]}]})
+         (let [warn1 (with-out-str
+                       (binding [*err* *out*]
+                         (re/variant-plays :story.multi/both-rearm)))
+               ;; one-shot in effect: a second read before the clear is silent
+               silent (with-out-str
+                        (binding [*err* *out*]
+                          (re/variant-plays :story.multi/both-rearm)))
+               _      (re/clear-all-runs!)
+               ;; after the reset the suppression set is empty → warns again
+               warn2  (with-out-str
+                        (binding [*err* *out*]
+                          (re/variant-plays :story.multi/both-rearm)))]
+           (is (re-find #":play-script.*:plays" warn1)
+               "first read warns")
+           (is (empty? silent)
+               "second read before the clear stays silent — one-shot holds")
+           (is (re-find #":play-script.*:plays" warn2)
+               "after clear-all-runs! the warning re-arms and fires again"))))))
+
 ;; ---- rf2-ftow6: concurrent-run race fix ---------------------------------
 ;;
 ;; The Playwright matrix-before-load scenario could overshoot counter


### PR DESCRIPTION
Three Story-family P4 nits across `tools/story` + `tools/story-mcp` (adjacent, disjoint files).

## rf2-a1lvd (P4, story) — re-arm `warned-both-slots`
The one-shot `warned-both-slots` console-warning atom was never reset by the test-fixture / hot-reload reset chain (`clear-all-runs!` reset run-state / runs-by-play / active-play / step-boundaries but NOT the warning cache). The both-`:play-script`-and-`:plays` warning was therefore suppressed across test order + hot-reload — same class as the rf2-4edk / qy6cl warn-once-cache bugs.

- Wire `(reset! warned-both-slots #{})` into `clear-all-runs!` (the test-fixture path, called from `story-reset!` and `story_teardown_test`).
- Relocate the `defonce` up with the other process-global state atoms so the reference from `clear-all-runs!` is forward-clean under the strict CLJS reader.
- New re-arm test (`both-slots-warning-re-arms-after-clear-all-runs`): warn fires → `clear-all-runs!` → warn fires again.

## rf2-ngwdf (P4, story) — normalise `emit-reports!` argument
`story/is` JVM-block + CLJS-async branches passed the RAW `target` to `emit-reports!` where the already-resolved sync branch (and `report-result!`) pass `(:variant/id result)`. `emit-reports!` ignores its first arg today, so this is **behaviour-preserving**; it removes the latent trap of three call sites supplying three different shapes (a `:variant/id` value vs. the raw keyword/map) for the same parameter, should a future change make the arg load-bearing.

- Both branches now pass `(:variant/id result)`, matching the sync branch and `report-result!`.

## rf2-ijeu5 (P4, story-mcp) — correct misleading version docstrings
`handle-initialize` + `protocol-version` docstrings described an active version-negotiation/echo behaviour the code does not implement (`_params` is ignored; the pinned version is returned unconditionally). The behaviour is spec-acceptable under the MCP lifecycle rule; only the docstrings were misleading.

- Docstrings now state the actual behaviour: unconditionally advertise the pinned `config/protocol-version`, never inspect or echo the client's request. No code change.

## Quality gates (cold)
- `tools/story` `clojure -M:test` — 1595 tests / 5974 assertions, 0 failures (includes the new re-arm test, +1 over baseline)
- `tools/story-mcp` `clojure -M:test` — 209 tests / 1059 assertions, 0 failures
- `npm run test:cljs` (top-level node CLJS) — 5615 tests / 19561 assertions, 0 failures
