### PR TITLE
fix(http): three P4 fixes — actor-id narrowing, abort-config exclusivity, JVM binary decode + timeout elapsed-ms (rf2-b7h0q + rf2-culoe + rf2-a3wxe)

### DIFF
--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -104,6 +104,39 @@
                        :url         url
                        :reason      "`:request :url` is required and must be a non-blank string per Spec 014 §Request envelope; a missing / nil / blank url cannot be dispatched"})))))
 
+(defn- validate-abort-config!
+  "Per Spec 014 §`:abort-signal` (external): `:abort-signal` and
+  `:request-id` are mutually exclusive — \"pick one\" (rf2-culoe).
+
+  A request supplying BOTH gets two independent abort mechanisms wired
+  against the one in-flight request — the caller's external Fetch signal
+  forwarded into the internal controller AND the `:request-id`
+  supersede/managed-abort path — which can race, with behaviour under
+  simultaneous abort undefined-by-spec. Per the pre-alpha reject-misuse
+  posture this is a dispatch-time configuration error, not a tolerated
+  combination: throw `:rf.error/http-bad-abort-config` at the fx-call
+  site (before `run-attempt!`), matching the at-source guarding the rest
+  of the surface already carries (`validate-retry!` →
+  `:rf.error/http-bad-retry-on`, `validate-url!` →
+  `:rf.error/http-bad-request`, `build-reply-event` →
+  `:rf.error/http-bad-reply-target`). This closes the one stated abort
+  constraint that previously had no guard.
+
+  Presence is what's checked, not truthiness: an explicit `:request-id
+  nil` opts out of internal abort (the registry never indexes a nil id),
+  so only a present, non-nil `:request-id` alongside a present, non-nil
+  `:abort-signal` is the conflicting shape. `contains?` + `some?` express
+  that precisely."
+  [{:keys [request-id abort-signal] :as args-map}]
+  (when (and (contains? args-map :request-id)   (some? request-id)
+             (contains? args-map :abort-signal) (some? abort-signal))
+    (throw (ex-info ":rf.error/http-bad-abort-config"
+                    {:rf.error/id :rf.error/http-bad-abort-config
+                     :where       :rf.http/managed
+                     :recovery    :no-recovery
+                     :request-id  request-id
+                     :reason      "`:abort-signal` and `:request-id` are mutually exclusive per Spec 014 §`:abort-signal` (external) — pick one. Supplying both wires two independent abort mechanisms (the external Fetch signal forwarded into the internal controller AND the `:request-id` supersede/managed-abort path) against a single request; their simultaneous-abort behaviour is undefined-by-spec"}))))
+
 (defn- normalise-args
   "Validate + normalise the args map. Returns a context ready for the
   per-host attempt loop.
@@ -202,6 +235,12 @@
   ;; transport loop (or silently dropped when the bad member never
   ;; fires). Per Spec 014 §Closed-set `:retry :on` validation.
   (validate-retry! args-map)
+  ;; rf2-culoe — `:abort-signal` / `:request-id` mutual-exclusivity.
+  ;; Like `validate-retry!`, fires at the dispatch site (before the
+  ;; middleware chain and `run-attempt!`) so the misuse is rejected at
+  ;; source rather than wiring two racing abort mechanisms against one
+  ;; request. Per Spec 014 §`:abort-signal` (external).
+  (validate-abort-config! args-map)
   (let [frame-id     (or (:frame frame-ctx) :rf/default)
         ;; rf2-622e3 — resolve once, thread the result through
         ;; frame-ctx's :event slot so normalise-args reads it

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -232,6 +232,44 @@
 ;; id as either a leaf value (declarative :spawn) or as a value under
 ;; :children (declarative :spawn-all).
 
+(def ^:private spawned-registry-path
+  "The runtime-owned spawn-registry slot in a frame's app-db, per Spec 005
+  §Declarative :spawn (mirrors `re-frame.machines.paths/spawned-path` — the
+  authoritative owner). Pinned here as a single named constant so the
+  structural coupling to the machines runtime's app-db layout has ONE site
+  rather than being inlined at each reader (rf2-b7h0q).
+
+  NOTE on the late-bind boundary: the http artefact does not (and must not)
+  statically `:require` `re-frame.machines`, so it cannot reference
+  `machines.paths/spawned-path` directly — it re-states the path here. The
+  cleaner long-term shape is to invert the existing
+  `:http/abort-on-actor-destroy` hook direction and have machines PUBLISH a
+  `:machines/spawned-actor-id?` membership test (so the structural walk
+  lives next to the registry shape it depends on); that inversion is a
+  cross-artefact change tracked separately and out of scope for this
+  http-only fix."
+  [:rf/runtime :machines :spawned])
+
+(defn- read-spawned-registry
+  "Read ONLY the runtime-owned spawn-registry slot from `frame-id`'s app-db
+  — `(get-in db spawned-registry-path)` — without retaining the whole map.
+
+  PERF (rf2-b7h0q): `frame/frame-app-db-value` is a substrate `deref` that
+  returns the persistent app-db map BY REFERENCE (no structural copy, no
+  scan), so the read is genuinely O(1) regardless of app-db size; the
+  `get-in` that follows is a fixed three-key descent. This is the
+  load-bearing assumption that makes calling this once per managed request
+  (`compute-actor-id`) cheap even for large app-dbs. Apps with no state
+  machines carry no `:spawned` slot, so this returns nil and the caller's
+  `(seq …)` test short-circuits before any structural walk.
+
+  Returns the spawned registry map, or nil when the frame is unregistered /
+  carries no machines runtime."
+  [frame-id]
+  (let [db (frame/frame-app-db-value frame-id)]
+    (when (map? db)
+      (get-in db spawned-registry-path))))
+
 (defn- spawned-actor-id?
   "Return true if `event-id` is currently bound somewhere under
   `[:rf/runtime :machines :spawned <parent> <invoke-id>]` in `spawned`
@@ -260,17 +298,18 @@
 
   Per rf2-hzn1a — fast path for the common case (no spawned actors).
   Apps that don't use state machines never carry a populated `:spawned`
-  registry; we still deref the db to check, but the seq-empty test
-  short-circuits before the O(parents × invokes) walk. This keeps the
-  cost on the no-machines hot path at one deref + one path lookup + one
+  registry; we read only that slot via `read-spawned-registry` (an O(1)
+  by-reference db deref + a fixed three-key descent — see that fn's PERF
+  note, rf2-b7h0q) and the `(seq …)` test short-circuits before the
+  O(parents × invokes) structural walk. This keeps the cost on the
+  no-machines hot path at one by-reference deref + one path lookup + one
   seq-check, rather than a full structural walk against the (always
   empty) registry."
   [frame-id origin-event]
   (let [event-id (when (vector? origin-event) (first origin-event))]
     (when (and event-id
                (not= event-id :rf.http/managed))
-      (let [db      (frame/frame-app-db-value frame-id)
-            spawned (when (map? db) (get-in db [:rf/runtime :machines :spawned]))]
+      (let [spawned (read-spawned-registry frame-id)]
         (when (seq spawned)
           (when (spawned-actor-id? spawned event-id)
             event-id))))))

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -34,6 +34,7 @@
                                   HttpRequest
                                   HttpRequest$BodyPublishers
                                   HttpResponse HttpResponse$BodyHandlers]
+                   [java.nio.charset Charset StandardCharsets]
                    [java.time Duration]
                    [java.util.concurrent CompletableFuture])))
 
@@ -434,31 +435,79 @@
                 (vec vs))]))))
 
 #?(:clj
+   (defn- charset-of
+     "rf2-a3wxe — resolve the response `Content-Type`'s `charset=` parameter
+     to a `java.nio.charset.Charset`, defaulting to UTF-8. Mirrors the
+     no-arg `HttpResponse.BodyHandlers/ofString` semantics (which honour
+     the response charset, defaulting to UTF-8): now that `jvm-fetch` reads
+     `ofByteArray` unconditionally so the binary-decode path can ride raw
+     bytes, the text path must reproduce that charset handling rather than
+     hard-coding UTF-8, so a `text/html; charset=ISO-8859-1` response
+     decodes identically to the prior `ofString` behaviour. An unknown /
+     unparseable charset falls back to UTF-8."
+     ^Charset [headers]
+     (or (when-let [ct (decode/content-type-of headers)]
+           (let [m (re-find #"(?i)charset=\s*\"?([^\";\s]+)" (str ct))]
+             (when-let [cs (second m)]
+               (try (Charset/forName cs)
+                    (catch Exception _ nil)))))
+         StandardCharsets/UTF_8)))
+
+#?(:clj
    (defn- jvm-fetch
      "Issue a single HTTP attempt via java.net.http.HttpClient. Returns a
      CompletableFuture that completes with `{:ok? :status :status-text
-     :headers :body-text}` or completes-exceptionally with an ex-info.
+     :headers :body-text}` (text path) or `{… :body-binary <bytes>}`
+     (binary path), or completes-exceptionally with an ex-info.
 
      `opts` carries `:sensitive?` so `jvm-build-request` can route any
      header-validation warning through the privacy composer (rf2-1jcpm).
      `opts` carries `:redirect` (Spec 014 §Request envelope, default
      `:follow`) so the client honouring the right redirect policy is
-     selected per rf2-ee38b.7."
+     selected per rf2-ee38b.7.
+
+     rf2-a3wxe — binary decode on the JVM. `opts` carries `:decode`; when
+     it resolves to a binary mode (`:blob` / `:array-buffer` / `:form-data`,
+     per `decode/binary-read-kind`, mirroring the CLJS transport's
+     up-front body-reader selection) we read the response body with
+     `BodyHandlers/ofByteArray` and ride the raw bytes under `:body-binary`
+     so `decode-response-body` returns them verbatim. Previously every JVM
+     response read `ofString`, so a `:blob`/`:array-buffer`/`:form-data`
+     decode fell through to the lossy `body-text` fallback in
+     `decode-response-body` — a UTF-8 decode of raw bytes that corrupts
+     binary payloads (worse than a clean no-op). `binary-read-kind`
+     consults the response headers for the `:auto` sniff, so we resolve it
+     AFTER the response is in hand (status known); we only read bytes on a
+     2xx (a non-2xx body is the raw error text the 4xx/5xx paths carry,
+     same as CLJS — see `cljs-fetch`)."
      [opts]
      (let [client ^HttpClient (jvm-http-client-for (:redirect opts))
            req    (jvm-build-request opts)
+           decode (:decode opts)
            future-resp (.sendAsync client req
-                                   (HttpResponse$BodyHandlers/ofString))]
+                                   (HttpResponse$BodyHandlers/ofByteArray))]
        (.thenApply future-resp
                    (reify java.util.function.Function
                      (apply [_ resp]
                        (let [^HttpResponse r resp
-                             status (.statusCode r)]
-                         {:ok? (and (>= status 200) (< status 300))
-                          :status status
-                          :status-text ""
-                          :headers (jvm-headers->map (.headers r))
-                          :body-text (.body r)})))))))
+                             status   (.statusCode r)
+                             ok?      (and (>= status 200) (< status 300))
+                             headers  (jvm-headers->map (.headers r))
+                             ^bytes raw (.body r)
+                             binary?  (and ok?
+                                           (some? (decode/binary-read-kind decode headers)))
+                             base     {:ok?         ok?
+                                       :status      status
+                                       :status-text ""
+                                       :headers     headers}]
+                         (if binary?
+                           (assoc base :body-binary raw)
+                           ;; Text path (and every non-2xx): decode the
+                           ;; bytes as a String using the response charset
+                           ;; (defaulting to UTF-8 via `charset-of`), faithfully
+                           ;; reproducing the prior no-arg `ofString` semantics
+                           ;; for the text/error path.
+                           (assoc base :body-text (String. raw ^Charset (charset-of headers)))))))))))
 
 #?(:clj
    (defn- classify-jvm-error
@@ -478,17 +527,27 @@
      limit, in scope at the `run-attempt!` call sites) fills the
      `:limit-ms` tag on a timeout failure so the JVM shape matches the
      CLJS path (Spec 014 §Failure categories types `:rf.http/timeout` as
-     `:elapsed-ms` / `:limit-ms`). `:elapsed-ms` stays nil on the JVM —
-     the JDK's `HttpTimeoutException` does not surface the elapsed wall
-     clock, and there is no faithful value to synthesise."
-     ([^Throwable t] (classify-jvm-error t nil))
-     ([^Throwable t timeout-ms]
+     `:elapsed-ms` / `:limit-ms`).
+
+     rf2-a3wxe — `:elapsed-ms` is now populated on the JVM. The JDK's
+     `HttpTimeoutException` does not itself surface the elapsed wall
+     clock, so `run-attempt!` captures a monotonic start mark
+     (`System/nanoTime`) before issuing the request and passes the
+     measured wall-clock delta here. This matches the CLJS path's
+     intent — `cljs-fetch` stamps `:elapsed-ms` on its synthetic timeout
+     rejection (Spec 014 §Failure categories) so a consumer branching on
+     `:elapsed-ms` sees a value on BOTH hosts rather than nil-on-JVM.
+     `elapsed-ms` is nil only when no start mark was threaded (the legacy
+     2-arity test/synthetic callers), preserving back-compat."
+     ([^Throwable t] (classify-jvm-error t nil nil))
+     ([^Throwable t timeout-ms] (classify-jvm-error t timeout-ms nil))
+     ([^Throwable t timeout-ms elapsed-ms]
       (let [cause (or (.getCause t) t)
             msg   (.getMessage cause)
             cls   (.getName (class cause))]
         (cond
           (instance? java.net.http.HttpTimeoutException cause)
-          {:kind :rf.http/timeout :elapsed-ms nil :limit-ms timeout-ms :message msg}
+          {:kind :rf.http/timeout :elapsed-ms elapsed-ms :limit-ms timeout-ms :message msg}
 
           (instance? java.util.concurrent.CancellationException cause)
           {:kind :rf.http/aborted :reason :user :message msg}
@@ -511,7 +570,7 @@
                       (true? sensitive?))))))
 
 #?(:clj
-   (defn check-cljs-only-keys! [{:keys [request abort-signal]} sensitive?]
+   (defn check-cljs-only-keys! [{:keys [request abort-signal decode]} sensitive?]
      (let [url (:url request)]
        ;; rf2-ee38b.7 — `:credentials` joins the JVM-degraded set. Unlike
        ;; `:redirect` (now honoured on JVM via the redirect-policy client),
@@ -527,7 +586,26 @@
          (when (contains? request k)
            (emit-cljs-only-skipped! k url sensitive?)))
        (when abort-signal
-         (emit-cljs-only-skipped! :abort-signal url sensitive?)))))
+         (emit-cljs-only-skipped! :abort-signal url sensitive?))
+       ;; rf2-a3wxe — binary decode SHAPE-degradation notice on JVM.
+       ;; A `:blob` / `:array-buffer` / `:form-data` decode is now HONOURED
+       ;; on the JVM (jvm-fetch reads `ofByteArray` and rides the raw bytes
+       ;; — no more lossy String fallback), but the returned value is a
+       ;; `byte[]`, NOT the native browser `Blob` / `ArrayBuffer` /
+       ;; `FormData` object the CLJS Fetch path yields. That host-shape
+       ;; difference is a degradation worth surfacing — a caller asking
+       ;; for a `Blob` gets bytes and would otherwise never learn. Emit a
+       ;; dedicated one-line trace (NOT `:rf.http/cljs-only-key-ignored-
+       ;; on-jvm`, since the decode is honoured rather than ignored). We
+       ;; only flag an EXPLICIT binary `:decode` here: `:auto` resolves to
+       ;; `:blob` from the response Content-Type, which isn't known at
+       ;; dispatch time. Per Spec 014 §JVM degradation table.
+       (when (and interop/debug-enabled?
+                  (contains? #{:blob :array-buffer :form-data} decode))
+         (trace/emit! :warning :rf.http/binary-decode-degraded-on-jvm
+                      (privacy/prepare-emit-tags
+                        {:decode decode :url url}
+                        (true? sensitive?)))))))
 
 ;; A no-op JVM-only no-op stub on CLJS so callers can reach
 ;; `http-transport/check-cljs-only-keys!` unconditionally without
@@ -1334,37 +1412,51 @@
            (.catch (fn [err]
                      (maybe-retry! ctx' (classify-cljs-error err url)))))
        :clj
-       (try
-         (let [^CompletableFuture cf
-               (jvm-fetch {:method     method
-                           :url        url
-                           :headers    headers
-                           :body       enc-body
-                           :timeout-ms timeout-ms
-                           ;; rf2-ee38b.7 — honour the spec's `:redirect`
-                           ;; envelope key on the JVM (default `:follow`).
-                           ;; Selects the redirect-policy-specific client.
-                           :redirect   (:redirect request)
-                           :sensitive? (true? (:sensitive? ctx))})]
-           ;; rf2-on7sj — publish cf to the abort-fn closure's holder
-           ;; BEFORE wiring whenComplete. A racing abort that arrives
-           ;; between `jvm-fetch` returning and `.whenComplete`
-           ;; registering still finds cf in the holder and can cancel
-           ;; it.
-           (reset! cf-holder cf)
-           ;; rf2-on7sj — the whenComplete callback fires even after
-           ;; `.cancel cf true`: the cancel completes-exceptionally
-           ;; with a CancellationException, which routes through this
-           ;; BiConsumer as `throwable`. `maybe-retry!` →
-           ;; `finalise-failure!` is then guarded by the once-only
-           ;; `:finalised?` CAS (the abort-fn already finalised), so
-           ;; the abort's reply is the only one that ever reaches the
-           ;; user.
-           (.whenComplete cf
-                          (reify java.util.function.BiConsumer
-                            (accept [_ result throwable]
-                              (if throwable
-                                (maybe-retry! ctx' (classify-jvm-error throwable timeout-ms))
-                                (handle-response! ctx' result))))))
-         (catch Throwable t
-           (maybe-retry! ctx' (classify-jvm-error t timeout-ms)))))))
+       ;; rf2-a3wxe — monotonic start mark for the per-host timeout
+       ;; `:elapsed-ms`. `System/nanoTime` is the JDK's monotonic clock
+       ;; (immune to wall-clock adjustments); the delta is converted to
+       ;; whole milliseconds at the failure site. Captured BEFORE the
+       ;; request is issued so the measured elapsed spans the whole attempt.
+       (let [started-ns (System/nanoTime)
+             elapsed-ms #(quot (- (System/nanoTime) started-ns) 1000000)]
+         (try
+           (let [^CompletableFuture cf
+                 (jvm-fetch {:method     method
+                             :url        url
+                             :headers    headers
+                             :body       enc-body
+                             :timeout-ms timeout-ms
+                             ;; rf2-a3wxe — thread the resolved `:decode`
+                             ;; so `jvm-fetch` can read the response body
+                             ;; with `ofByteArray` for binary decode modes
+                             ;; (`:blob` / `:array-buffer` / `:form-data`)
+                             ;; and ride the raw bytes under `:body-binary`
+                             ;; instead of the lossy String fallback.
+                             :decode     (:decode ctx)
+                             ;; rf2-ee38b.7 — honour the spec's `:redirect`
+                             ;; envelope key on the JVM (default `:follow`).
+                             ;; Selects the redirect-policy-specific client.
+                             :redirect   (:redirect request)
+                             :sensitive? (true? (:sensitive? ctx))})]
+             ;; rf2-on7sj — publish cf to the abort-fn closure's holder
+             ;; BEFORE wiring whenComplete. A racing abort that arrives
+             ;; between `jvm-fetch` returning and `.whenComplete`
+             ;; registering still finds cf in the holder and can cancel
+             ;; it.
+             (reset! cf-holder cf)
+             ;; rf2-on7sj — the whenComplete callback fires even after
+             ;; `.cancel cf true`: the cancel completes-exceptionally
+             ;; with a CancellationException, which routes through this
+             ;; BiConsumer as `throwable`. `maybe-retry!` →
+             ;; `finalise-failure!` is then guarded by the once-only
+             ;; `:finalised?` CAS (the abort-fn already finalised), so
+             ;; the abort's reply is the only one that ever reaches the
+             ;; user.
+             (.whenComplete cf
+                            (reify java.util.function.BiConsumer
+                              (accept [_ result throwable]
+                                (if throwable
+                                  (maybe-retry! ctx' (classify-jvm-error throwable timeout-ms (elapsed-ms)))
+                                  (handle-response! ctx' result))))))
+           (catch Throwable t
+             (maybe-retry! ctx' (classify-jvm-error t timeout-ms (elapsed-ms)))))))))

--- a/implementation/http/test/re_frame/http_abort_config_validation_test.clj
+++ b/implementation/http/test/re_frame/http_abort_config_validation_test.clj
@@ -1,0 +1,143 @@
+(ns re-frame.http-abort-config-validation-test
+  "Spec 014 §`:abort-signal` (external) — `:abort-signal` / `:request-id`
+  mutual-exclusivity dispatch-time validation (rf2-culoe) — JVM tests.
+
+  Spec 014 states `:abort-signal` and `:request-id` are mutually
+  exclusive — \"pick one\". A request supplying BOTH wires two
+  independent abort mechanisms (the external Fetch signal forwarded into
+  the internal controller AND the `:request-id` supersede/managed-abort
+  path) against one request; their simultaneous-abort behaviour is
+  undefined-by-spec. The `:rf.http/managed` fx body now rejects that
+  combination at the dispatch site with an `:rf.error/http-bad-abort-config`
+  ex-info — matching the at-source guarding the rest of the surface
+  carries (`:rf.error/http-bad-retry-on`, `:rf.error/http-bad-request`,
+  `:rf.error/http-bad-reply-target`).
+
+  Presence (not truthiness) is the test: an explicit `:request-id nil`
+  opts out of internal abort, so only a present non-nil `:request-id`
+  alongside a present non-nil `:abort-signal` is the conflicting shape."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.http-handlers :as handlers]
+            [re-frame.http-managed :as http-managed]))
+
+;; ---- per-test reset --------------------------------------------------------
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.http-managed :reload)
+  (http-managed/clear-all-in-flight!)
+  (http-managed/clear-all-http-interceptors!)
+  (t))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- call-managed!
+  "Invoke `:rf.http/managed` via the public handler with the given full
+  args-map. Returns nil on success / no-throw, or the ex-info on a throw."
+  [args-map]
+  (try (handlers/managed-handler {:frame :rf/default :event [:no-op]}
+                                 args-map)
+       nil
+       (catch clojure.lang.ExceptionInfo e e)))
+
+(defn- bad-abort-config-throw?
+  [ex request-id]
+  (and (some? ex)
+       (= ":rf.error/http-bad-abort-config" (.getMessage ex))
+       (let [data (ex-data ex)]
+         (and (= :rf.error/http-bad-abort-config (:rf.error/id data))
+              (= :rf.http/managed              (:where data))
+              (= :no-recovery                  (:recovery data))
+              (= request-id                    (:request-id data))
+              (string?                         (:reason data))))))
+
+;; a stand-in for an AbortController.signal handle — any non-nil value.
+(def ^:private signal-stub (Object.))
+(def ^:private base-request {:method :get :url "http://localhost/x"})
+
+;; ---- rejection: BOTH present and non-nil ----------------------------------
+
+(deftest both-abort-signal-and-request-id-rejected
+  (testing "rf2-culoe — supplying BOTH a non-nil :abort-signal AND a
+            non-nil :request-id throws :rf.error/http-bad-abort-config at
+            the dispatch site"
+    (is (bad-abort-config-throw?
+          (call-managed! {:request      base-request
+                          :request-id   :article/load
+                          :abort-signal signal-stub})
+          :article/load))))
+
+(deftest both-with-vector-request-id-rejected
+  (testing "rf2-culoe — the conflicting shape is rejected regardless of the
+            :request-id value shape (a compound vector id here)"
+    (is (bad-abort-config-throw?
+          (call-managed! {:request      base-request
+                          :request-id   [:articles :load "hello"]
+                          :abort-signal signal-stub})
+          [:articles :load "hello"]))))
+
+;; ---- pass-through: exactly one (or neither) -------------------------------
+
+(deftest only-request-id-passes
+  (testing "rf2-culoe — :request-id alone (no :abort-signal) is the
+            canonical internal-abort case and must NOT trigger the guard"
+    (let [ex (call-managed! {:request    base-request
+                             :request-id :article/load})]
+      (is (not (and (some? ex)
+                    (= ":rf.error/http-bad-abort-config" (.getMessage ex))))
+          ":request-id alone must not be rejected"))))
+
+(deftest only-abort-signal-passes
+  (testing "rf2-culoe — :abort-signal alone (no :request-id) is the
+            external-abort case and must NOT trigger the guard. (On JVM
+            :abort-signal is a no-op with a degradation trace; here we only
+            assert the abort-config guard did not fire.)"
+    (let [ex (call-managed! {:request      base-request
+                             :abort-signal signal-stub})]
+      (is (not (and (some? ex)
+                    (= ":rf.error/http-bad-abort-config" (.getMessage ex))))
+          ":abort-signal alone must not be rejected"))))
+
+(deftest neither-passes
+  (testing "rf2-culoe — neither key present: no guard"
+    (let [ex (call-managed! {:request base-request})]
+      (is (not (and (some? ex)
+                    (= ":rf.error/http-bad-abort-config" (.getMessage ex))))
+          "a request with neither abort key must not be rejected"))))
+
+;; ---- presence-not-truthiness boundary -------------------------------------
+
+(deftest explicit-nil-request-id-with-signal-passes
+  (testing "rf2-culoe — an explicit :request-id nil opts OUT of internal
+            abort (the registry never indexes a nil id), so :abort-signal +
+            (request-id nil) is NOT the conflicting shape and must pass"
+    (let [ex (call-managed! {:request      base-request
+                             :request-id   nil
+                             :abort-signal signal-stub})]
+      (is (not (and (some? ex)
+                    (= ":rf.error/http-bad-abort-config" (.getMessage ex))))
+          "an explicit nil :request-id alongside :abort-signal must pass"))))
+
+(deftest explicit-nil-abort-signal-with-request-id-passes
+  (testing "rf2-culoe — symmetric: an explicit :abort-signal nil alongside a
+            real :request-id is not the conflicting shape"
+    (let [ex (call-managed! {:request      base-request
+                             :request-id   :article/load
+                             :abort-signal nil})]
+      (is (not (and (some? ex)
+                    (= ":rf.error/http-bad-abort-config" (.getMessage ex))))
+          "an explicit nil :abort-signal alongside :request-id must pass"))))

--- a/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
@@ -1,0 +1,230 @@
+(ns re-frame.http-jvm-binary-decode-test
+  "Spec 014 §Decoding + §JVM degradation table — JVM binary decode +
+  per-host timeout `:elapsed-ms` (rf2-a3wxe).
+
+  Two gaps closed:
+
+  1. Binary decode on JVM. The JVM transport used to read every response
+     body as a String (`BodyHandlers/ofString`), so a `:blob` /
+     `:array-buffer` / `:form-data` decode fell through to the lossy
+     `body-text` fallback in `decode-response-body` — a UTF-8 decode of
+     raw bytes that CORRUPTS binary payloads. `jvm-fetch` now reads
+     `BodyHandlers/ofByteArray` and, when the resolved decode mode is
+     binary (`binary-read-kind`), rides the raw `byte[]` under
+     `:body-binary` so the bytes survive verbatim. The text path
+     reproduces `ofString`'s charset handling via `charset-of`.
+
+  2. Per-host timeout `:elapsed-ms`. The JDK's `HttpTimeoutException`
+     does not surface the elapsed wall clock, so `classify-jvm-error`
+     used to leave `:elapsed-ms nil` on JVM. `run-attempt!` now captures
+     a monotonic start mark and threads the measured wall-clock delta in,
+     matching the CLJS path's intent (a value on both hosts, not nil-on-JVM).
+
+  These exercise the live JVM transport via an in-process JDK HttpServer
+  (real socket, real `HttpClient`) — they fail deterministically against
+  the pre-fix code (which UTF-8-decoded the bytes / left elapsed-ms nil)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.http-transport :as transport]
+            [re-frame.test-support :as test-support])
+  (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
+           [java.net InetSocketAddress]))
+
+;; ---- per-test reset --------------------------------------------------------
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.http-managed :reload)
+  (http-managed/clear-all-in-flight!)
+  (http-managed/clear-all-http-interceptors!)
+  (t))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- a tiny in-process HTTP server (raw-bytes capable) --------------------
+
+(defn- start-server! [handler]
+  (let [server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)
+        ctx    (.createContext server "/")]
+    (.setHandler ctx (reify HttpHandler (handle [_ ex] (handler ex))))
+    (.setExecutor server nil)
+    (.start server)
+    {:server server :port (.getPort (.getAddress server))}))
+
+(defn- stop-server! [{:keys [server]}] (.stop server 0))
+
+(defn- write-bytes! [^HttpExchange ex status content-type ^bytes body]
+  (when content-type
+    (-> ex .getResponseHeaders (.set "Content-Type" content-type)))
+  (.sendResponseHeaders ex status (long (count body)))
+  (with-open [os (.getResponseBody ex)]
+    (.write os body)))
+
+(defn- await-reply! [pred]
+  (test-support/poll-until
+    #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
+    {:timeout-ms 5000 :label "http binary reply"}))
+
+;; ---- (1) binary decode honours the bytes on JVM (rf2-a3wxe) ---------------
+
+;; A payload with non-UTF-8 high bytes — a lossy String decode (the pre-fix
+;; behaviour) would substitute U+FFFD replacement chars and re-encoding
+;; would NOT round-trip to these bytes. ofByteArray preserves them exactly.
+(def ^:private raw-bytes (byte-array [(byte 0x00) (byte -1) (byte -2)
+                                      (byte 0x7f) (byte -128) (byte 0x42)]))
+
+(deftest jvm-blob-decode-returns-raw-bytes
+  (testing "rf2-a3wxe — :decode :blob on JVM rides the raw byte[] under
+            :body-binary (ofByteArray), NOT a lossy UTF-8 String"
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-bytes! ex 200 "application/octet-stream" raw-bytes)))]
+      (try
+        (rf/reg-event-fx :blob/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/bin")}
+                      :decode  :blob}]]})))
+        (rf/dispatch-sync [:blob/load {}])
+        (let [db    (await-reply! #(some? (:reply %)))
+              value (get-in db [:reply :value])]
+          (is (= :success (get-in db [:reply :kind])))
+          (is (bytes? value)
+              "the decoded value must be a byte[] (the raw bytes), not a String")
+          (is (= (seq raw-bytes) (seq value))
+              "the bytes must survive verbatim — no lossy UTF-8 round-trip"))
+        (finally (stop-server! srv))))))
+
+(deftest jvm-array-buffer-decode-returns-raw-bytes
+  (testing "rf2-a3wxe — :decode :array-buffer on JVM also rides raw bytes"
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-bytes! ex 200 "application/octet-stream" raw-bytes)))]
+      (try
+        (rf/reg-event-fx :ab/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/bin")}
+                      :decode  :array-buffer}]]})))
+        (rf/dispatch-sync [:ab/load {}])
+        (let [db    (await-reply! #(some? (:reply %)))
+              value (get-in db [:reply :value])]
+          (is (bytes? value))
+          (is (= (seq raw-bytes) (seq value))))
+        (finally (stop-server! srv))))))
+
+(deftest jvm-text-decode-still-uses-response-charset
+  (testing "rf2-a3wxe — the text path still decodes via the response charset
+            (charset-of), faithfully reproducing the prior ofString
+            behaviour for a non-UTF-8 charset"
+    (let [latin1-bytes (.getBytes "café" "ISO-8859-1")
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-bytes! ex 200 "text/plain; charset=ISO-8859-1" latin1-bytes)))]
+      (try
+        (rf/reg-event-fx :text/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/t")}
+                      :decode  :text}]]})))
+        (rf/dispatch-sync [:text/load {}])
+        (let [db (await-reply! #(some? (:reply %)))]
+          (is (= "café" (get-in db [:reply :value]))
+              "ISO-8859-1 bytes must decode via the declared charset, not raw UTF-8"))
+        (finally (stop-server! srv))))))
+
+;; ---- (1b) charset-of unit coverage ----------------------------------------
+
+(deftest charset-of-resolves-declared-charset
+  (testing "rf2-a3wxe — charset-of parses the Content-Type charset param"
+    (let [charset-of @#'transport/charset-of]
+      (is (= "ISO-8859-1"
+             (.name ^java.nio.charset.Charset
+                    (charset-of {"content-type" "text/plain; charset=ISO-8859-1"}))))
+      (is (= "UTF-8"
+             (.name ^java.nio.charset.Charset
+                    (charset-of {"content-type" "application/json; charset=utf-8"})))))))
+
+(deftest charset-of-defaults-to-utf8
+  (testing "rf2-a3wxe — absent / unparseable charset falls back to UTF-8"
+    (let [charset-of @#'transport/charset-of]
+      (is (= "UTF-8" (.name ^java.nio.charset.Charset (charset-of {}))))
+      (is (= "UTF-8" (.name ^java.nio.charset.Charset
+                            (charset-of {"content-type" "application/json"}))))
+      (is (= "UTF-8" (.name ^java.nio.charset.Charset
+                            (charset-of {"content-type" "text/x; charset=not-a-real-charset"})))
+          "an unparseable charset name must not throw — falls back to UTF-8"))))
+
+;; ---- (2) per-host timeout :elapsed-ms (rf2-a3wxe) --------------------------
+
+(deftest classify-jvm-error-stamps-elapsed-ms-on-timeout
+  (testing "rf2-a3wxe — classify-jvm-error's 3-arity stamps the measured
+            :elapsed-ms onto a timeout failure (was nil pre-fix)"
+    (let [classify @#'transport/classify-jvm-error
+          timeout  (java.net.http.HttpTimeoutException. "request timed out")
+          failure  (classify timeout 30000 1234)]
+      (is (= :rf.http/timeout (:kind failure)))
+      (is (= 1234 (:elapsed-ms failure)) "measured elapsed wall-clock is carried")
+      (is (= 30000 (:limit-ms failure)) "the configured limit is preserved"))))
+
+(deftest classify-jvm-error-elapsed-ms-nil-for-legacy-arities
+  (testing "rf2-a3wxe — the 2-arity (and 1-arity) preserve back-compat:
+            :elapsed-ms is nil when no start mark was threaded"
+    (let [classify @#'transport/classify-jvm-error
+          timeout  (java.net.http.HttpTimeoutException. "request timed out")]
+      (is (nil? (:elapsed-ms (classify timeout 30000))))
+      (is (nil? (:elapsed-ms (classify timeout)))))))
+
+(deftest jvm-real-timeout-populates-elapsed-ms
+  (testing "rf2-a3wxe — a live JVM request that exceeds its per-attempt
+            timeout surfaces :rf.http/timeout with a NON-nil :elapsed-ms
+            (the end-to-end run-attempt! → classify-jvm-error path)"
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              ;; Stall well past the request's tiny timeout-ms.
+              (Thread/sleep 800)
+              (write-bytes! ex 200 "application/json"
+                            (.getBytes "{\"ok\":true}" "UTF-8"))))]
+      (try
+        (rf/reg-event-fx :slow/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request    {:url (str "http://127.0.0.1:" port "/slow")}
+                      :decode     :json
+                      :timeout-ms 50}]]})))
+        (rf/dispatch-sync [:slow/load {}])
+        (let [db      (await-reply! #(some? (:reply %)))
+              failure (get-in db [:reply :failure])]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/timeout (:kind failure)))
+          (is (= 50 (:limit-ms failure)))
+          (is (some? (:elapsed-ms failure))
+              ":elapsed-ms must be populated on the JVM (was nil pre-fix)")
+          (is (and (number? (:elapsed-ms failure))
+                   (>= (:elapsed-ms failure) 0))
+              ":elapsed-ms is a non-negative measured wall-clock delta"))
+        (finally (stop-server! srv))))))


### PR DESCRIPTION
Three `implementation/http/` P4 fixes, each verified against source + tested. Scope confined to `implementation/http/`.

## rf2-b7h0q — compute-actor-id app-db deref (perf/clarity)
`http_registry.cljc`. `compute-actor-id` derefs the frame app-db on every managed request. The deref is genuinely O(1) by-reference (the bead's own analysis: `frame-app-db-value` returns the persistent map by reference, no copy), so the perf angle is informational. Fix is clarity + decoupling:
- New `read-spawned-registry` helper — reads ONLY the `[:rf/runtime :machines :spawned]` slot, with the load-bearing O(1)-by-reference assumption pinned in its docstring.
- New `spawned-registry-path` const — the Spec 005 structural coupling to the machines runtime's app-db layout now lives in ONE named site instead of inlined.
- Correctness preserved: NO cache (the spawned registry mutates as actors spawn/destroy; a memo would break actor-destroy cancellation).
- The cleaner long-term shape (machines publishing a `:machines/spawned-actor-id?` hook, inverting `:http/abort-on-actor-destroy`) is noted in-code as a cross-artefact follow-up — out of scope for this http-only fix.

## rf2-culoe — :abort-signal / :request-id mutual-exclusivity (correctness)
`http_handlers.cljc`. Spec 014 §`:abort-signal` states the two are mutually exclusive ("pick one") but nothing enforced it — both could be supplied, wiring two racing abort mechanisms. New dispatch-time `validate-abort-config!` throws `:rf.error/http-bad-abort-config` when both are present + non-nil, fired alongside `validate-retry!` (before the middleware chain / `run-attempt!`), matching the surface's existing reject-misuse-at-source posture. Presence-not-truthiness: an explicit `:request-id nil` opts out and is allowed.

## rf2-a3wxe — JVM binary decode + per-host timeout elapsed-ms (JVM transport)
`http_transport.cljc`. CLJS path is the reference (`cljs-fetch` picks the Fetch body-reader from the resolved decode mode via `binary-read-kind`, rides native body under `:body-binary`; stamps `:elapsed-ms` on its synthetic timeout).
- **(a) binary decode:** `jvm-fetch` read every body as `ofString`, so `:blob`/`:array-buffer`/`:form-data` fell through to a LOSSY UTF-8 `body-text` fallback (corrupts bytes — worse than a no-op). Now reads `ofByteArray` and rides the raw `byte[]` under `:body-binary` for binary modes (resolved via `binary-read-kind`, mirroring CLJS). The text path reproduces `ofString`'s charset handling via a new `charset-of` helper (so e.g. `charset=ISO-8859-1` still round-trips). A dedicated `:rf.http/binary-decode-degraded-on-jvm` trace flags the `byte[]`-not-native-`Blob` host-shape difference.
- **(b) timeout elapsed-ms:** was `nil` on JVM (`HttpTimeoutException` doesn't surface it). `run-attempt!` now captures a `System/nanoTime` start mark and threads the measured wall-clock delta into a 3-arity `classify-jvm-error`, so `:rf.http/timeout` carries `:elapsed-ms` on both hosts. Legacy 1-/2-arities keep `:elapsed-ms nil` (back-compat).

## Tests
- `http_abort_config_validation_test.clj` (culoe) — both-present rejection, only-one / neither pass-through, explicit-nil boundary.
- `http_jvm_binary_decode_test.clj` (a3wxe) — live in-process JDK `HttpServer` roundtrips proving `:blob`/`:array-buffer` survive as raw bytes (non-UTF-8 payload that a lossy decode would corrupt), text path honours response charset, real timeout populates `:elapsed-ms`; plus `classify-jvm-error` / `charset-of` units.

## Gates (cold)
- http JVM `clojure -M:test`: **322 tests / 1557 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5615 tests / 19561 assertions, 0 failures, 0 errors**

## Deferred
Spec 009/014 catalogue rows for the new error/trace surfaces filed as **rf2-tnkx8** — `spec/009` + `spec/014` are hot-zone with an in-flight `spec-doc-hygiene` worker, so no parallel edits. Spec 014 already states the culoe constraint (line 582) and types `:rf.http/timeout` as `:elapsed-ms`/`:limit-ms` (line 467, now honoured on JVM), so no spec contradiction is introduced.

Closes rf2-b7h0q, rf2-culoe, rf2-a3wxe.