### PR TITLE
fix(impl): three P4 misc fixes — dead transducer branch + no-such-cofx frame stamp + dead schemas re-export (rf2-oetnk + rf2-fxlgi + rf2-7gclb)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -319,12 +319,26 @@
            ;; rf2-ryri7.
            (trace/with-call-site (or captured-cs
                                      (some-> trace/*handler-scope* :call-site))
-             (let [event (interceptor/get-coeffect ctx :event)]
+             (let [event    (interceptor/get-coeffect ctx :event)
+                   ;; rf2-fxlgi — the in-flight cascade's frame, read from
+                   ;; the `:frame` coeffect (same source as the
+                   ;; `:rf.cofx/run` / `:skipped-on-platform` siblings'
+                   ;; `frame-id`). `frame-id` itself is bound in the
+                   ;; cofx-found branch's `let`, out of scope here, so
+                   ;; re-read it locally.
+                   frame-id (interceptor/get-coeffect ctx :frame)]
+               ;; rf2-fxlgi — stamp `:frame` so this dev-only misconfig
+               ;; diagnostic is frame-attributed like its siblings above,
+               ;; and so `re-frame.epoch.capture/capture-event!` (which
+               ;; buffers only frame-tagged traces) surfaces it on the
+               ;; emitting frame's epoch / Xray timeline. Consistency tail
+               ;; of the rf2-7d30s error-emit frame-stamp pass.
                (trace/emit-error! :rf.error/no-such-cofx
                                   (cond-> {:rf.cofx/id        cofx-id
                                            :rf.trace/event-id (when (vector? event) (first event))
                                            :recovery          :no-recovery}
-                                    valued? (assoc :rf.cofx/value value)))
+                                    frame-id (assoc :frame frame-id)
+                                    valued?  (assoc :rf.cofx/value value)))
                ctx))))))))
 
 ;; ---- standard cofx --------------------------------------------------------

--- a/implementation/core/src/re_frame/router_transducer.cljc
+++ b/implementation/core/src/re_frame/router_transducer.cljc
@@ -202,8 +202,7 @@
          true            (assoc :db db-after)
          true            (update :steps conj step)
          (seq fx)        (apply-fx-eager fx)
-         (some? error)   (update :errors conj error)
-         (= step :ok)    identity)))))
+         (some? error)   (update :errors conj error))))))
 
 (defn queued-rf
   "Reducing function: commits eagerly per step (same as `sync-rf` for

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -134,8 +134,12 @@
 (def clear-walker-opaque-warned!
   storage/clear-walker-opaque-warned!)
 
-;; Per-slot flag walker (rf2-nwv63 / rf2-kj51z / rf2-oghml).
-(def walk-flagged-schema              walker/walk-flagged-schema)
+;; Per-slot flag walker (rf2-nwv63 / rf2-kj51z / rf2-oghml). The
+;; parameterised `walk-flagged-schema` recursion primitive stays internal
+;; to `re-frame.schemas.walker`; the public surface is the two single-flag
+;; entry points below (the late-bind hooks elision consumes) plus the two
+;; sensitivity predicates — not the raw flag-key-parameterised walker
+;; (rf2-7gclb: dead re-export dropped, no consumer reached it).
 (def extract-large-paths-from-schema  walker/extract-large-paths-from-schema)
 (def extract-sensitive-paths-from-schema walker/extract-sensitive-paths-from-schema)
 (def schema-has-sensitive?            walker/schema-has-sensitive?)

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -463,7 +463,6 @@
   ["re-frame.schemas" "validate-sub!"]             {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "validate-with-registered-fn"] {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "explain-with-registered-fn"]  {:tier :internal-public :owner "010" :status "v1"}
-  ["re-frame.schemas" "walk-flagged-schema"]                {:tier :internal-public :owner "015" :status "v1"}
   ["re-frame.schemas" "schema-has-sensitive?"]              {:tier :internal-public :owner "015" :status "v1"}
   ["re-frame.schemas" "schema-sensitive-at?"]               {:tier :internal-public :owner "015" :status "v1"}
   ["re-frame.schemas" "extract-sensitive-paths-from-schema"] {:tier :internal-public :owner "015" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 472,
+ :var-count 471,
  :tier-vocab
  [:front-porch
   :advanced
@@ -308,7 +308,6 @@
   {:namespace "re-frame.schemas", :var "validate-sub!", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "validate-with-registered-fn", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "validator-fn", :tier :internal-public, :kind :var, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.schemas", :var "walk-flagged-schema", :tier :internal-public, :kind :fn, :owner "015", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "adapter", :tier :internal-public, :kind :var, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "apply-error-projection!", :tier :internal-public, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "clear-request!", :tier :internal-public, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Three small, disjoint P4 implementation fixes across core + schemas.

## rf2-oetnk (P4, BUG) — core/router_transducer.cljc
`sync-rf` carried a dead `(= step :ok) identity` `cond->` clause. The destructured `step` is the `:rf/step` value (not the step-map), so the predicate *can* be true — but the action is `identity`, which is a no-op in `cond->` regardless. Removed the dead clause. The transducer scaffold is non-wired (NOT on the live dispatch path — `re-frame.router-transducer` is a Phase-1 reference), so zero behaviour change. The `sync-rf` test only counts `:steps`, so it is unaffected.

`router_transducer.cljc:206` before → after:
- `(= step :ok)    identity` clause removed.

## rf2-fxlgi (P4, consistency) — core/cofx.cljc
The `:rf.error/no-such-cofx` emit site was left unframed by the rf2-7d30s frame-stamp pass. Stamped `:frame` there, read from the `:frame` coeffect — matching the `:rf.cofx/run` / `:skipped-on-platform` siblings in the same file and the rf2-7d30s `spec.cljc`/`subs.cljc` pattern. `frame-id` is bound only in the cofx-found branch's `let` (out of scope in the no-such-cofx else branch), so it is re-read locally; stamp is conditional (`frame-id (assoc :frame frame-id)`) since the no-frame injection context has no `:frame` coeffect. Now the dev-only misconfig diagnostic is frame-attributed and surfaced by `re-frame.epoch.capture/capture-event!` (which buffers only frame-tagged traces) on the emitting frame's epoch / Xray timeline.

`cofx.cljc:323` emit map gains `frame-id (assoc :frame frame-id)`.

## rf2-7gclb (P4, clarity/DRY) — schemas facade
`schemas.cljc:138` re-exported `walk-flagged-schema` with zero consumers (verified via `git grep`: elision uses only the two per-flag `extract-*` late-bind hooks; not in the core facade; not a late-bind hook; no source or test calls the facade form — only `walker.cljc`'s internal recursion + a docstring mention). Dropped the dead public re-export; the parameterised walker stays internal to `re-frame.schemas.walker`. Regenerated `spec/api-manifest.edn` and removed the stale curated sidecar row in `spec/api-manifest-metadata.edn` so the api-manifest drift gate stays green (472 → 471 public vars).

## Quality gates (cold worktree)
- core JVM `clojure -M:test`: 864 tests / 3879 assertions / 0 failures
- schemas JVM `clojure -M:test`: 227 tests / 18367 assertions / 0 failures
- `npm run test:cljs` (core + schemas + api-manifest CLJS probe): 5615 tests / 19561 assertions / 0 failures
- `npm run test:elision`: production 40/40 absent + control 40/40 present
- api-manifest `--check`: in sync (471 vars)

Closes rf2-oetnk, rf2-fxlgi, rf2-7gclb.