### PR TITLE
refactor(xray): de-stutter edn-widget ns + repoint stale 002 §-refs (rf2-q79c2 + rf2-n8tdw)

### DIFF
--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -464,7 +464,7 @@ const ARTEFACTS = [
   // zprint — the canonical pretty-printer Xray's EDN widget
   // `code-block` uses to pre-format handler-source strings before the
   // in-bundle tokenizer renders them
-  // (tools/xray/src/.../views/edn_widget/widget.cljs). Same posture
+  // (tools/xray/src/.../views/edn_widget.cljs). Same posture
   // as cljs-devtools: dev-only, consumed only by tools/ (Xray), gated
   // behind the Xray `:devtools/preloads`. Production bundles MUST
   // NOT pull zprint — the formatter body + its rewrite-clj dep weigh

--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -568,8 +568,9 @@ Not present:
 
 If the user wants to mutate `app-db`, they do so via `(rf/dispatch
 ...)` from the REPL, or via the Re-dispatch affordance from the event
-log. Xray's writes are funnelled through dispatch (per
-[`002-Time-Travel.md`](./002-Time-Travel.md) §The read-only constraint).
+log. Xray's writes are funnelled through dispatch — inspection is the
+default, rewind is opt-in (per
+[Tool-Pair §Time-travel: epoch snapshots and undo](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo)).
 
 ## "Show me when this changed"
 

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -595,9 +595,10 @@ chrome affordances besides the tabs:
   change).
   - **No dialog, no confirmation** — the button just does it (programmers
     are power users). This is a deliberate departure from the deleted Time
-    Travel panel's modal-confirmation flow ([`002-Time-Travel.md`](002-Time-Travel.md)
-    §Restore failure modes / §Failure surfacing described the now-removed
-    panel's modal).
+    Travel panel's modal-confirmation flow (see the
+    [`002-Time-Travel.md`](002-Time-Travel.md) tombstone); the surviving
+    `restore-epoch` failure-mode contract now lives in
+    [Tool-Pair §Time-travel: epoch snapshots and undo](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo).
   - **Disabled** (dimmed, `not-allowed` cursor) when no epoch is focused.
   - **Failure** (the rare framework cases — epoch aged out of the buffer,
     or a restore-during-drain rejection → `rf/restore-epoch` returns

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -3531,7 +3531,7 @@ spec/015 sentinels, and renders inline diff annotations when a
 `:before` opt is supplied. The cljs-devtools dep is dropped
 (rf2-oqa60); the legacy `edn-inspector.render` engine +
 `theme.data-inspector` chrome ns are deleted in phase 5 (rf2-q3dzw).
-The EDN-widget facade at `views.edn-widget.widget` is retained as a
+The EDN-widget facade at `views.edn-widget` is retained as a
 thin delegate so existing call sites compile; new call sites should
 reach for `[edn-inspector value opts]` directly.
 
@@ -3739,7 +3739,7 @@ Phases 2-5 file as separate beads chained off rf2-oqa60:
 
 #### §10.0.5 Code-block (separate surface)
 
-`views.edn-widget.widget/code-block {:source src :lang :clojure}`
+`views.edn-widget/code-block {:source src :lang :clojure}`
 is the in-bundle Clojure source-text highlighter for the Event
 panel's HANDLER slot — distinct from the value renderer (cljs-
 devtools never owned this, and the in-bundle tokenizer + zprint
@@ -4658,7 +4658,7 @@ component instance so two mounts in the same panel are isolated.
 
 Phase 1 wires the App-DB panel through the new widget directly; the
 remaining surfaces (Trace, Sub, Machine, Issues) reach through the
-legacy `views.edn-widget.widget` facade for now, which delegates to
+legacy `views.edn-widget` facade for now, which delegates to
 the new widget. Phases 2-4 migrate each surface to call
 `[edn-inspector …]` directly. Phase 5 (rf2-q3dzw) **completes** the
 subsumption: diff is now an opt-in mode on the same widget

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -27,7 +27,7 @@
       Absent / empty areas still render, as an empty-state placeholder.
 
   Values render through the canonical EDN widget's cljs-devtools
-  current-state path (`views.edn-widget.widget/inspect`), the same
+  current-state path (`views.edn-widget/inspect`), the same
   engine re-frame-10x adopted.
 
   Canonical exemplar of the panel facade pattern documented in

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_format.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_format.cljs
@@ -23,7 +23,7 @@
   §5 — short labels stay one-line `pr-str` for scan-ability.
 
   L4 detail-tab VALUE displays go through
-  `day8.re-frame2-xray.views.edn-widget.widget/inspect` (rf2-8q4f4 —
+  `day8.re-frame2-xray.views.edn-widget/inspect` (rf2-8q4f4 —
   one widget, many call sites) for the cljs-devtools-shaped renderer;
   only short labels / paths come through here."
   [v]

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
@@ -52,7 +52,7 @@
             [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]
-            [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
+            [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 ;; ---- subs ----------------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -61,7 +61,7 @@
             [day8.re-frame2-xray.panels.shared.coord-chip :as coord-chip]
             [day8.re-frame2-xray.panels.shared.coord-link :as coord-link]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
-            [day8.re-frame2-xray.views.edn-widget.widget :as edn]
+            [day8.re-frame2-xray.views.edn-widget :as edn]
             [day8.re-frame2-xray.views.resizable-table :as rt]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack spacing type-scale with-alpha]]))

--- a/tools/xray/src/day8/re_frame2_xray/panels/hydration_pane_render.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hydration_pane_render.cljs
@@ -43,7 +43,7 @@
             [day8.re-frame2-xray.panels.app-db-diff-format :as f]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
-            [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
+            [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 ;; ---- node-key + small helpers ------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
@@ -47,7 +47,7 @@
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack with-alpha]]
             [day8.re-frame2-xray.theme.section :as section]
-            [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
+            [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 ;; Section rhythm hoisted to `theme/section.cljc` per rf2-pie8q —
 ;; identical visual contract is shared with `panels/event_detail`.

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -96,7 +96,7 @@
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
-            [day8.re-frame2-xray.views.edn-widget.widget :as edn]
+            [day8.re-frame2-xray.views.edn-widget :as edn]
             [day8.re-frame2-xray.views.resizable-table :as rt]))
 
 ;; ---- resizable-table columns (rf2-jnxfj · rf2-aqusw) --------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -51,7 +51,7 @@
             [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale mono-stack sans-stack]]
-            [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
+            [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 ;; ---- pure helpers --------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/row_expand.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/row_expand.cljs
@@ -33,7 +33,7 @@
             [day8.re-frame2-xray.static.routes.simulate-nav :as sim-nav]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
-            [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
+            [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 (defn- section-label
   [label]

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -60,7 +60,7 @@
             [day8.re-frame2-xray.static.shared.search-box :as search-box]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale mono-stack sans-stack]]
-            [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
+            [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 ;; ---- pure helpers --------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -179,7 +179,7 @@
    ;; ── syntax-highlighter palette (rf2-79ojx · One Dark / Calva default) ──
    ;; Dedicated tokens for CLJS-value rendering in the edn-inspector widget
    ;; (`views/edn_inspector.cljs`) AND the in-bundle Clojure source-text
-   ;; highlighter (`views/edn_widget/widget.cljs`). One palette, shared by
+   ;; highlighter (`views/edn_widget.cljs`). One palette, shared by
    ;; both surfaces, so a `:foo` keyword in the source-text panel paints
    ;; the same hue as `:foo` rendered as a value in the App-DB panel.
    ;;

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
@@ -1,4 +1,4 @@
-(ns day8.re-frame2-xray.views.edn-widget.widget
+(ns day8.re-frame2-xray.views.edn-widget
   "Canonical Xray EDN widget facade — thin wrapper over the first-
   class `views.edn-inspector` widget.
 

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_widget_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_widget_cljs_test.cljs
@@ -1,4 +1,4 @@
-(ns day8.re-frame2-xray.views.edn-widget.widget-cljs-test
+(ns day8.re-frame2-xray.views.edn-widget-cljs-test
   "Tests for the Xray EDN widget facade — post-rf2-oqa60 phase 1.
 
   After the edn-inspector rebuild the facade is a thin delegate over
@@ -22,7 +22,7 @@
      hiccup whose root data-attribute identifies the new widget."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
-            [day8.re-frame2-xray.views.edn-widget.widget :as w]
+            [day8.re-frame2-xray.views.edn-widget :as w]
             [day8.re-frame2-xray.theme.tokens :refer [tokens]]))
 
 ;; ---- helpers ------------------------------------------------------------


### PR DESCRIPTION
Two tools/xray P4 nits.

## rf2-q79c2 — naming: de-stutter the `edn-widget.widget` ns

The EDN-widget facade lived at `day8.re-frame2-xray.views.edn-widget.widget` (file `views/edn_widget/widget.cljs`) — the directory `edn-widget` and leaf `widget` restated the same noun. The `edn_widget/` directory held exactly one leaf, so this flattens it (option (a) in the bead):

- `views/edn_widget/widget.cljs` -> `views/edn_widget.cljs`, ns `...views.edn-widget.widget` -> `...views.edn-widget`
- test moves in lockstep: `views/edn_widget/widget_cljs_test.cljs` -> `views/edn_widget_cljs_test.cljs`, ns `...edn-widget.widget-cljs-test` -> `...edn-widget-cljs-test` (still `-test`-suffixed, still discovered by both runners)

Updated every reference: 8 `:require` sites, the `app-db-diff` / `app-db-diff-format` docstrings, the `tokens.cljc` palette comment, the `check-bundle-isolation.cjs` path comment, and the 3 prose mentions in `spec/021`. `git grep` on tracked files shows **zero orphan** references to the old ns/path.

## rf2-n8tdw — spec-stale: repoint deleted-002 §-refs

After `002-Time-Travel.md` was reduced to a tombstone, two prose §-mentions named sections that no longer exist:

- **004 §The read-only constraint** -> [Tool-Pair §Time-travel: epoch snapshots and undo] ("inspection is the default, rewind is opt-in").
- **018 §Restore failure modes / §Failure surfacing** -> the `002-Time-Travel.md` tombstone (for the deleted-panel fact) + Tool-Pair §Time-travel (for the surviving `restore-epoch` failure-mode contract).

The other `002-Time-Travel.md` links in xray spec (011/014/021/README) are file-level links that land on the redirect tombstone as intended — not deleted-section refs — so left untouched.

## Note on the bead's "decision" framing

rf2-q79c2 was filed as a decision-bead leaning to option (c) (leave as-is). This PR executes option (a) per the explicit dispatch brief. Easy to revert if the conservative call is preferred.

## Gates (cold worktree)

- xray `clojure -M:test` — **1100 tests, 4526 assertions, 0 failures**
- `npm run test:cljs` — **5615 tests, 19561 assertions, 0 failures**
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures**, all builds 0 warnings
- `check_doc_slugs.py` + `check_readme_links.py` — exit 0

Closes rf2-q79c2, rf2-n8tdw.