### PR TITLE
fix(flows): detect+reject overlapping output :paths between sibling flows (rf2-um6d9)

### DIFF
--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -394,9 +394,26 @@
             (fn [m]
               (let [prior-frame (get m frame-id)
                     prospective (assoc prior-frame flow-id flow)]
-                ;; Throws :rf.error/flow-cycle if the prospective map is
-                ;; cyclic; the update fn never returns and the CAS never
-                ;; fires, so the atom is unchanged.
+                ;; Two registration-time rejections, both run on the
+                ;; PROSPECTIVE map inside this update fn so they share the
+                ;; cycle check's atomicity (rf2-qxwib): a throw propagates
+                ;; out of `swap!`, the CAS never fires, and the prior
+                ;; registration survives untouched.
+                ;;
+                ;; 1. Throws :rf.error/flow-path-overlap (rf2-um6d9) if the
+                ;;    new flow's output :path overlaps an already-registered
+                ;;    sibling's :path (one a prefix of the other). The topo
+                ;;    dependency rule compares :path vs :inputs only, so
+                ;;    overlapping outputs get no edge and their eval order is
+                ;;    undefined — reject before any state mutates (Spec 013
+                ;;    §Disjoint output paths). Checked BEFORE the cycle sort
+                ;;    so a frame with overlapping outputs reports the more
+                ;;    specific footgun rather than whatever (or no) cycle the
+                ;;    topo walk happens to surface.
+                ;; 2. Throws :rf.error/flow-cycle if the prospective map is
+                ;;    cyclic; the update fn never returns and the CAS never
+                ;;    fires, so the atom is unchanged.
+                (topo/detect-output-path-overlap! prospective)
                 (topo/topo-sort prospective)
                 (assoc m frame-id prospective))))
      ;; Cycle check + commit done atomically above. The :flow registrar

--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -17,7 +17,17 @@
   either direction. Kahn's algorithm produces the order; on cycle we
   reconstruct a DFS path through the stuck nodes and throw
   `:rf.error/flow-cycle` with a closing-repeat cycle vector
-  (e.g. `[:a :b :a]`) — tools like Xray render this directly."
+  (e.g. `[:a :b :a]`) — tools like Xray render this directly.
+
+  This module also owns `detect-output-path-overlap!` — the symmetric
+  check the registry runs alongside the cycle check at `reg-flow` time
+  (Spec 013 §Disjoint output paths): two flows in one frame whose OUTPUT
+  `:path`s overlap (one a prefix of the other, identical included) have
+  no dependency edge between them (the edge rule compares `:path` vs
+  `:inputs`, never `:path` vs `:path`), so their relative evaluation
+  order is undefined and they would race for the shared slot under
+  last-write-wins. That is an authoring footgun, not a valid topology,
+  so it is rejected at registration with `:rf.error/flow-path-overlap`."
   ;; Pure module — no requires. .cljc-portable so the JVM test sweep
   ;; can exercise the algorithm without dragging the CLJS runtime in.
   )
@@ -47,6 +57,88 @@
               (or (prefix? a-path b-input)
                   (prefix? b-input a-path)))
             (:inputs b-flow)))))
+
+(defn output-paths-overlap?
+  "True iff two flows' OUTPUT `:path`s collide on the same app-db slot —
+  i.e. one path is a prefix of the other (identical paths included, since
+  every vector is a prefix of itself). Per Spec 013 §Disjoint output
+  paths: `[:x]` overlaps `[:x]` (identical), `[:x]` overlaps `[:x :y]`
+  (parent/child — writing `[:x]` clobbers everything under it, and writing
+  `[:x :y]` lands inside `[:x]`'s value), but `[:x :y]` and `[:x :z]` are
+  disjoint (siblings — neither is a prefix of the other)."
+  [a-path b-path]
+  (or (prefix? a-path b-path)
+      (prefix? b-path a-path)))
+
+(defn- first-overlapping-pair
+  "Scan the prospective per-frame `flow-map` (`{flow-id flow-map}`) for the
+  first pair of DISTINCT flows whose output `:path`s overlap (one a prefix
+  of the other). Return `{:flow-ids [lo hi] :paths [lo-path hi-path]}` for
+  the offending pair, or `nil` if every pair is disjoint.
+
+  Terminates by construction: a single `for` over the `(< i j)` upper
+  triangle of the entry vector (O(F²) prefix comparisons, F = the frame's
+  flow count — a handful of nodes at v1, same order as the graph build),
+  short-circuited by `(some ...)`. The reported pair is deterministically
+  ordered by `hash` so the report is stable across runs without requiring
+  flow-ids be mutually comparable (`sort` throws on mixed-type ids) —
+  mirroring `extract-cycle-path`'s deterministic pick."
+  [flow-map]
+  (let [entries (vec flow-map)
+        n       (count entries)]
+    (some (fn [[i j]]
+            (let [[a-id a-flow] (nth entries i)
+                  [b-id b-flow] (nth entries j)
+                  a-path        (:path a-flow)
+                  b-path        (:path b-flow)]
+              (when (output-paths-overlap? a-path b-path)
+                (let [[lo-id hi-id]     (sort-by hash [a-id b-id])
+                      [lo-path hi-path] (if (= lo-id a-id)
+                                          [a-path b-path]
+                                          [b-path a-path])]
+                  {:flow-ids [lo-id hi-id]
+                   :paths    [lo-path hi-path]}))))
+          (for [i (range n)
+                j (range (inc i) n)]
+            [i j]))))
+
+(defn detect-output-path-overlap!
+  "Symmetric with `topo-sort`'s cycle check (Spec 013 §Disjoint output
+  paths). Given a prospective per-frame `flow-map` (`{flow-id flow-map}`),
+  throw `:rf.error/flow-path-overlap` if any two distinct flows have
+  overlapping output `:path`s — otherwise return `flow-map` unchanged so
+  the caller can thread it.
+
+  WHY this is a registration error, not a topo edge: the dependency rule
+  (`depends-on?`) compares one flow's `:path` against another's `:inputs`,
+  never `:path` vs `:path`. Two same-frame flows whose outputs overlap but
+  whose inputs are disjoint therefore get NO edge — both are 'ready' at
+  topo-sort start and their relative order falls out of map-iteration
+  order, a non-contract. The loser of that undefined order silently loses
+  the shared slot under last-write-wins. Rejecting at `reg-flow` (inside
+  the atomic `swap!`, like the cycle check) closes the footgun before any
+  state mutates.
+
+  The `ex-info` carries the canonical thrown-error shape (per Spec 009
+  §The thrown-error shape) — `:rf.error/id` / `:where` / `:recovery`
+  `:fix-registration` (the caller fixes one flow's `:path` and retries,
+  exactly like the cycle / validate-flow rejections) / `:reason` — plus
+  `:overlap`, the offending `{:flow-ids [id-a id-b] :paths [path-a
+  path-b]}` pair, so tools (Xray's flow panel) name the colliding flows
+  directly.
+
+  Pure-data, no requires (the shape is inlined rather than reaching for
+  `registry.cljc`'s `flow-error` helper) — same posture as the cycle
+  throw in `topo-sort`."
+  [flow-map]
+  (when-let [overlap (first-overlapping-pair flow-map)]
+    (throw (ex-info ":rf.error/flow-path-overlap"
+                    {:rf.error/id :rf.error/flow-path-overlap
+                     :where    'rf/reg-flow
+                     :recovery :fix-registration
+                     :reason   "Two flows in the same frame have overlapping output :paths (one is a prefix of the other, identical included). Their relative evaluation order is undefined — the topo-sort dependency rule compares :path against :inputs, never :path against :path, so no edge orders them and the shared slot would be written last-write-wins in map-iteration order (per Spec 013 §Disjoint output paths). Give each flow a disjoint :path."
+                     :overlap  overlap})))
+  flow-map)
 
 (defn- extract-cycle-path
   "Given the dependency graph `id → #{deps...}` and the set of stuck

--- a/implementation/flows/test/re_frame/flows_path_overlap_test.clj
+++ b/implementation/flows/test/re_frame/flows_path_overlap_test.clj
@@ -1,0 +1,248 @@
+(ns re-frame.flows-path-overlap-test
+  "Per rf2-um6d9 — overlapping output `:path`s between sibling flows are
+  rejected at registration.
+
+  THE FINDING (senior-dev review rf2-y7lm8): the topo dependency rule
+  (`topo/depends-on?`, Spec 013 §Topological sort) compares ONLY flow A's
+  `:path` against flow B's `:inputs` — never `:path` vs `:path`. So two
+  flows in the SAME frame whose OUTPUT `:path`s overlap (one a prefix of
+  the other, identical included) but whose `:inputs` are disjoint from
+  each other's outputs get NO dependency edge. Both are 'ready' at
+  topo-sort start; their relative evaluation order falls out of
+  `(keys flow-map)` map-iteration order — a non-contract — so the shared
+  app-db slot is written last-write-wins, non-deterministically, with no
+  detection and no warning.
+
+  THE FIX: detect-and-reject at `reg-flow`, symmetric with the existing
+  cycle check and inside the same atomic `swap!` — two registered flows on
+  the same frame with overlapping output `:path`s is an error
+  (`:rf.error/flow-path-overlap`). See `topo/detect-output-path-overlap!`
+  and the registry `reg-flow` update fn.
+
+  This file pins both ends:
+    - the pure `topo` helpers (`output-paths-overlap?` /
+      `detect-output-path-overlap!`) — algorithm-level, no runtime;
+    - the integrated `rf/reg-flow` path — the rejection actually fires at
+      registration, the prior registration survives, and DISJOINT
+      sibling outputs (the common, valid case) still register cleanly.
+
+  TERMINATION NOTE (rf2-um6d9 redo): `detect-output-path-overlap!` scans
+  the upper triangle of the frame's flow pairs via `(some ... (for ...))`
+  — terminating by construction. The disjoint-map and disjoint-sibling
+  tests below are the explicit regression guard: pre-fix the scan looped
+  forever on any frame with ≥2 disjoint flows, hanging the whole JVM suite."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.flows.topo :as topo]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- per-test reset (mirrors flows_test.clj) ------------------------------
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-listeners!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---------------------------------------------------------------------------
+;; 1. topo/output-paths-overlap? — the prefix-relation predicate
+;; ---------------------------------------------------------------------------
+
+(deftest output-paths-overlap?-identical-paths
+  (testing "identical :paths overlap (a vector is a prefix of itself)"
+    (is (true? (topo/output-paths-overlap? [:x] [:x])))
+    (is (true? (topo/output-paths-overlap? [:a :b] [:a :b])))))
+
+(deftest output-paths-overlap?-prefix-in-either-direction
+  (testing "parent/child overlap — one :path is a prefix of the other (Spec 013 §Disjoint output paths)"
+    (is (true? (topo/output-paths-overlap? [:x] [:x :y]))
+        "[:x] is a prefix of [:x :y] — writing [:x] clobbers the child")
+    (is (true? (topo/output-paths-overlap? [:x :y] [:x]))
+        "symmetric: [:x] is still a prefix of [:x :y] with args flipped")))
+
+(deftest output-paths-overlap?-disjoint-siblings
+  (testing "sibling leaves under a shared parent do NOT overlap — neither is a prefix of the other"
+    (is (false? (topo/output-paths-overlap? [:x :y] [:x :z]))
+        "[:x :y] and [:x :z] are disjoint (each owns its own leaf)")
+    (is (false? (topo/output-paths-overlap? [:a] [:b]))
+        "wholly unrelated single-key paths are disjoint")
+    (is (false? (topo/output-paths-overlap? [:a :b :c] [:a :b :d]))
+        "deeper sibling leaves [:a :b :c] / [:a :b :d] are disjoint too")
+    (is (true? (topo/output-paths-overlap? [:a :b] [:a :b :c :d]))
+        "but a deep child [:a :b :c :d] DOES overlap its ancestor [:a :b]")))
+
+(deftest output-paths-overlap?-shared-non-prefix-element
+  (testing "shared NON-prefix element is not an overlap (prefix-based, not membership-based)"
+    ;; [:x :y] vs [:y :x] share both elements but neither is a prefix of
+    ;; the other → disjoint. Mirrors depends-on?'s prefix-not-membership
+    ;; rule (flows_topo_test.clj depends-on?-false-when-...share-element).
+    (is (false? (topo/output-paths-overlap? [:x :y] [:y :x])))))
+
+;; ---------------------------------------------------------------------------
+;; 2. topo/detect-output-path-overlap! — the prospective-map scanner
+;; ---------------------------------------------------------------------------
+
+(deftest detect-output-path-overlap!-passes-disjoint-map
+  (testing "a frame map of pairwise-disjoint output paths passes (returns the map unchanged) — and TERMINATES"
+    ;; REGRESSION GUARD (rf2-um6d9 redo): pre-fix the scan looped forever on
+    ;; a ≥2-flow disjoint map; this assertion only completes if the scan
+    ;; terminates.
+    (let [flow-map {:a {:id :a :inputs [[:w]] :output identity :path [:x :a]}
+                    :b {:id :b :inputs [[:h]] :output identity :path [:x :b]}
+                    :c {:id :c :inputs [[:q]] :output identity :path [:y]}}]
+      (is (= flow-map (topo/detect-output-path-overlap! flow-map))
+          "disjoint outputs: no throw, threads the map through"))))
+
+(deftest detect-output-path-overlap!-throws-on-identical-paths
+  (testing "two flows with identical output :paths throw :rf.error/flow-path-overlap with the canonical thrown-error shape"
+    (let [flow-map {:a {:id :a :inputs [[:w]] :output identity :path [:x]}
+                    :b {:id :b :inputs [[:h]] :output identity :path [:x]}}
+          thrown   (try (topo/detect-output-path-overlap! flow-map)
+                        nil
+                        (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? thrown) "overlapping outputs raise")
+      (is (= ":rf.error/flow-path-overlap" (.getMessage ^Throwable thrown))
+          "ex-info message is the documented category")
+      (let [data (ex-data thrown)]
+        (is (= :rf.error/flow-path-overlap (:rf.error/id data))
+            "ex-data carries the canonical :rf.error/id discriminator (Spec 009 §The thrown-error shape)")
+        (is (= 'rf/reg-flow (:where data))
+            "ex-data carries :where 'rf/reg-flow — the user-facing call site")
+        (is (= :fix-registration (:recovery data))
+            "ex-data carries :recovery :fix-registration — caller-fixable like the cycle / validate-flow rejections")
+        (is (string? (:reason data))
+            "ex-data carries :reason as a human-readable string")
+        (let [{:keys [flow-ids paths]} (:overlap data)]
+          (is (= #{:a :b} (set flow-ids))
+              "ex-data :overlap names the colliding flow-ids")
+          (is (= 2 (count paths))
+              "ex-data :overlap carries the two colliding paths")
+          (is (every? #{[:x]} paths)
+              "both colliding paths are [:x]"))
+        (is (= #{:rf.error/id :where :recovery :reason :overlap}
+               (set (keys data)))
+            "ex-data carries exactly the canonical slots + :overlap")))))
+
+(deftest detect-output-path-overlap!-throws-on-prefix-paths
+  (testing "two flows where one :path is a PREFIX of the other throw :rf.error/flow-path-overlap"
+    (let [flow-map {:parent {:id :parent :inputs [[:w]] :output identity :path [:x]}
+                    :child  {:id :child  :inputs [[:h]] :output identity :path [:x :y]}}
+          thrown   (try (topo/detect-output-path-overlap! flow-map)
+                        nil
+                        (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? thrown) "prefix-related outputs raise")
+      (is (= :rf.error/flow-path-overlap (:rf.error/id (ex-data thrown))))
+      (is (= #{:parent :child} (set (:flow-ids (:overlap (ex-data thrown))))))
+      (is (= #{[:x] [:x :y]} (set (:paths (:overlap (ex-data thrown)))))
+          "the parent and child paths are both reported"))))
+
+(deftest detect-output-path-overlap!-deterministic-pair-ordering
+  (testing "the reported :overlap pair is stable across runs (sort-by hash, not iteration order)"
+    (let [flow-map {:a {:id :a :inputs [[:w]] :output identity :path [:x]}
+                    :b {:id :b :inputs [[:h]] :output identity :path [:x]}}
+          overlap-of (fn [] (-> (try (topo/detect-output-path-overlap! flow-map)
+                                     (catch clojure.lang.ExceptionInfo e (ex-data e)))
+                                :overlap))]
+      (is (= (overlap-of) (overlap-of) (overlap-of))
+          "repeated detection yields an identical :overlap (deterministic ordering)"))))
+
+;; ---------------------------------------------------------------------------
+;; 3. integrated rf/reg-flow — THE bug repro: same-frame overlapping
+;;    outputs + DISJOINT inputs (no cycle, no edge) must be rejected.
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-rejects-overlapping-output-paths-with-disjoint-inputs
+  (testing "rf2-um6d9 — two same-frame flows whose OUTPUT :paths overlap but whose INPUTS are disjoint are rejected at registration"
+    ;; This is the exact silent-footgun shape: A reads [:src-a] writes
+    ;; [:dest]; B reads [:src-b] writes [:dest]. Inputs are disjoint
+    ;; (neither reads the other's output) so the topo dependency rule
+    ;; produces NO edge — pre-fix both were 'ready' and the shared slot
+    ;; [:dest] was written in undefined order. Post-fix the second
+    ;; registration is rejected.
+    (rf/reg-flow {:id :a :inputs [[:src-a]] :output identity :path [:dest]})
+    (let [thrown (try
+                   (rf/reg-flow {:id :b :inputs [[:src-b]] :output identity :path [:dest]})
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? thrown)
+          "registering a second flow on the same frame with an overlapping output :path throws")
+      (is (= :rf.error/flow-path-overlap (:rf.error/id (ex-data thrown)))
+          "the rejection is :rf.error/flow-path-overlap")
+      (is (= #{:a :b} (set (:flow-ids (:overlap (ex-data thrown)))))
+          "the offending pair is named in :overlap"))
+    ;; The rejected REPLACEMENT must not have vacated / disturbed the
+    ;; prior registration (symmetric with the cycle-check atomicity).
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :a)
+        "the prior flow :a survives the rejected registration")
+    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :b))
+        "the rejected flow :b never lands in the committed registry")))
+
+(deftest reg-flow-allows-disjoint-sibling-output-paths
+  (testing "rf2-um6d9 — flows writing to DISJOINT sibling paths under a shared parent register cleanly (the common valid case is unaffected) — and TERMINATES"
+    ;; REGRESSION GUARD (rf2-um6d9 redo): the integrated equivalent of the
+    ;; disjoint-map test — pre-fix this reg-flow call hung the suite.
+    (rf/reg-flow {:id :w :inputs [[:in-w]] :output identity :path [:rect :w]})
+    (rf/reg-flow {:id :h :inputs [[:in-h]] :output identity :path [:rect :h]})
+    (let [committed (get (flows/flows-snapshot) :rf/default)]
+      (is (contains? committed :w) "the [:rect :w] flow registered")
+      (is (contains? committed :h) "the [:rect :h] flow registered — no false-positive overlap"))))
+
+(deftest reg-flow-overlap-is-frame-scoped
+  (testing "rf2-um6d9 — overlapping output :paths on DIFFERENT frames are NOT an overlap (frames are isolated app-dbs)"
+    (rf/reg-frame :frame-a {:doc "isolated frame a"})
+    (rf/reg-frame :frame-b {:doc "isolated frame b"})
+    ;; Same flow-id-shape, same output :path, but DIFFERENT frames —
+    ;; their writes land in different app-dbs, so no collision.
+    (rf/reg-flow {:id :x :inputs [[:in]] :output identity :path [:dest]} {:frame :frame-a})
+    (rf/reg-flow {:id :x :inputs [[:in]] :output identity :path [:dest]} {:frame :frame-b})
+    (is (contains? (get (flows/flows-snapshot) :frame-a) :x)
+        "frame-a holds its :x flow")
+    (is (contains? (get (flows/flows-snapshot) :frame-b) :x)
+        "frame-b holds its own :x flow — overlap detection is per-frame, not cross-frame")))
+
+(deftest reg-flow-re-registration-does-not-self-overlap
+  (testing "rf2-um6d9 — re-registering an existing flow-id with the SAME :path (hot-reload) is NOT a self-overlap"
+    ;; The footgun-adjacent case: a flow keeps its :path across a
+    ;; hot-reload re-registration. The prospective map is
+    ;; (assoc prior-frame flow-id flow) — the same key, so the map still
+    ;; holds ONE entry for :a and detect-output-path-overlap! (which
+    ;; scans DISTINCT entries) never compares :a's path against itself.
+    ;; A false positive here would break hot-reload of any flow.
+    (rf/reg-flow {:id :a :inputs [[:src]] :output identity :path [:dest]})
+    (is (nil? (try
+                (rf/reg-flow {:id :a :inputs [[:src]] :output (fn [v] v) :path [:dest]})
+                nil
+                (catch clojure.lang.ExceptionInfo e e)))
+        "re-registering :a with the same :path must not throw :rf.error/flow-path-overlap")
+    (is (contains? (get (flows/flows-snapshot) :rf/default) :a)
+        "the re-registered flow :a is committed")))
+
+(deftest reg-flow-still-rejects-cycles-and-passes-clean-topologies
+  (testing "rf2-um6d9 — adding the overlap check does not disturb the cycle check or the happy path"
+    ;; Happy path: a real dependency (B reads what A writes) registers and
+    ;; topo-sorts cleanly — disjoint OUTPUTS, a genuine input edge.
+    (rf/reg-flow {:id :a :inputs [[:seed]]  :output identity :path [:a-out]})
+    (rf/reg-flow {:id :b :inputs [[:a-out]] :output identity :path [:b-out]})
+    (is (= #{:a :b} (set (keys (get (flows/flows-snapshot) :rf/default))))
+        "a clean dependency topology (disjoint outputs, real edge) registers both flows")
+    ;; Cycle check still fires: C reads B's output [:b-out]; re-registering
+    ;; B to read C's output [:c-out] closes the cycle b → c → b.
+    (rf/reg-flow {:id :c :inputs [[:b-out]] :output identity :path [:c-out]})
+    (let [thrown (try
+                   (rf/reg-flow {:id :b :inputs [[:a-out] [:c-out]] :output identity :path [:b-out]})
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/flow-cycle (:rf.error/id (ex-data thrown)))
+          "a cycle-forming re-registration is still rejected with :rf.error/flow-cycle"))))

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -225,6 +225,24 @@ The closing repeat is the contract: tools rendering the cycle (e.g. Xray) displa
 
 Cycles can also form *during* flow registration if the new flow completes a cycle that was incomplete before it was registered. The detection runs every `reg-flow` call.
 
+**Disjoint output paths.** Flows in the same frame **MUST** write to pairwise-disjoint output `:path`s — no two flows' `:path`s may stand in a prefix relationship (identical paths included). `reg-flow` throws `:rf.error/flow-path-overlap` at registration time when a new flow's `:path` overlaps an already-registered sibling's. This is checked on every `reg-flow` call, inside the same atomic check-and-insert as cycle detection — the error fires before any state mutates, and the prior registration survives.
+
+The reason this is an error and not merely a topological edge: the dependency rule above compares one flow's `:path` against another's **`:inputs`**, never `:path` against `:path`. Two flows whose *outputs* overlap but whose *inputs* are disjoint therefore get **no edge** between them — both are ready at topsort start, and their relative order falls out of map-iteration order, which is not a contract. The flow that runs second silently wins the shared slot under last-write-wins, with no detection and no documented ordering. Rejecting at registration removes the footgun rather than papering over it with a tie-break that would leave the collision silent.
+
+```clojure
+;; All of these throw at registration — the second flow's :path
+;; overlaps the first's (one is a prefix of the other, identical included):
+(rf/reg-flow {:id :a :inputs [[:w]] :output identity :path [:x]})
+(rf/reg-flow {:id :b :inputs [[:h]] :output identity :path [:x]})
+;; → ex-info ":rf.error/flow-path-overlap"  (identical paths)
+
+(rf/reg-flow {:id :c :inputs [[:w]] :output identity :path [:x]})
+(rf/reg-flow {:id :d :inputs [[:h]] :output identity :path [:x :y]})
+;; → ex-info ":rf.error/flow-path-overlap"  (:x is a prefix of [:x :y])
+```
+
+The thrown `ex-info`'s `ex-data` carries `:overlap` — `{:flow-ids [id-a id-b] :paths [path-a path-b]}` naming the colliding pair (deterministically ordered so the report is stable across runs) — alongside the canonical `:rf.error/id` / `:where` `'rf/reg-flow` / `:recovery :fix-registration` slots ([009 §The thrown-error shape](009-Instrumentation.md#the-thrown-error-shape--the-rferrorid-ex-data-contract)). The caller gives one of the two flows a disjoint `:path` and retries. Sibling paths that merely share a non-prefix element are **not** an overlap: `[:x :y]` and `[:x :z]` are disjoint (each writes its own leaf under a shared parent), and only the prefix relationship — where one write would clobber or be subsumed by the other — is rejected.
+
 ## Dirty-check semantics
 
 A flow recomputes only when its inputs change by **`=`-equality** since its last evaluation:


### PR DESCRIPTION
Closes rf2-um6d9 (do not merge until reviewed).

## The bug (nondeterminism)

`topo/depends-on?` (Spec 013 §Topological sort) compares one flow's `:path` against another's `:inputs` — never `:path` vs `:path`. Two flows in the same frame whose **output** `:path`s overlap (one a prefix of the other, identical included) but whose `:inputs` are disjoint get **no dependency edge**: both are `ready` at topo-sort start and their relative evaluation order falls out of map-iteration order — not a contract. The loser silently loses the shared app-db slot under last-write-wins, with no detection, no warning, no documented ordering.

## The fix (ruling (a)+(b))

- **`topo/output-paths-overlap?`** — prefix-relation predicate. Identical and parent/child paths overlap; sibling leaves (`[:x :y]` vs `[:x :z]`) are disjoint.
- **`topo/detect-output-path-overlap!`** — scans the upper triangle of the prospective per-frame flow map via `(some ... (for ...))` and throws `:rf.error/flow-path-overlap` (canonical thrown-error shape + `:overlap {:flow-ids ... :paths ...}` pair, deterministically ordered by `hash`).
- **registry `reg-flow`** — runs the overlap check before the cycle sort, inside the same atomic `swap!` as cycle detection. A throw aborts the CAS, so the prior registration survives untouched.
- **Spec 013 §Disjoint output paths** documents the `MUST` and the rationale.

## Why the prior stranded attempt hung the box

The prior (uncommitted) `detect-output-path-overlap!` used a hand-rolled nested `loop`/`recur` whose trailing `(recur (inc i))` was lexically **inside the inner `loop [j ...]`** — so it rebound `j`, not `i`. On any frame with ≥2 disjoint flows the inner loop oscillated forever (confirmed: 2,000,001 iterations on a 3-flow disjoint map without terminating), hanging the entire flows JVM suite. This redo replaces the nested loop with a single short-circuited comprehension over distinct pairs — terminating by construction.

## Gates (all TIMEOUT-GUARDED, all TERMINATED + GREEN)

- `timeout 180 clojure -M:test` (flows JVM) → **139 tests / 4567 assertions / 0 failures / 0 errors**, exit 0 (clean main was 126/4529; +13 from the new test file).
- `timeout 540 npm run test:cljs` → **5616 tests / 19562 assertions / 0 failures / 0 errors**, exit 0.
- spec/013 touched → `check_doc_slugs.py` exit 0; `mkdocs build --strict` exit 0.

Regression guards in the test file (`detect-output-path-overlap!-passes-disjoint-map`, `reg-flow-allows-disjoint-sibling-output-paths`) only complete if the scan terminates — they are the explicit guard against the prior runaway.