### PR TITLE
perf(flows): cache validate-output! late-bind lookup (rf2-sk1fp)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -108,9 +108,9 @@
   surface DCEs in CLJS production (Spec 009 §Production builds)."
   [frame-id flow new-output]
   (when-let [schema (:schema flow)]
-    (when-let [validate (late-bind/get-fn :schemas/validate-with-registered-fn)]
+    (when-let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
       (when-not (validate schema new-output)
-        (let [explain     (late-bind/get-fn :schemas/explain-with-registered-fn)
+        (let [explain     (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
               explanation (when explain (explain schema new-output))]
           (trace/emit-error! :rf.error/schema-validation-failure
                              {:category   :rf.error/schema-validation-failure


### PR DESCRIPTION
## What

`validate-output!` in `implementation/flows/src/re_frame/flows.cljc` resolved the `:schemas/validate-with-registered-fn` and `:schemas/explain-with-registered-fn` late-bind seams via the **uncached** `late-bind/get-fn` on the per-recompute dev validation path. `get-fn` re-derefs the global `hooks` atom and re-walks the map on every flow recompute.

Switch both lookups to `late-bind/get-fn-cached` (flows.cljc:111, :113).

## Why

This matches the established corpus hot-path convention:

- `late-bind/get-fn-cached`'s own docstring (core/src/re_frame/late_bind.cljc:115-135) names the `:schemas/validate-*` seam as a hot-path key that should use the sticky cached variant.
- `machines/data_validation.cljc:67,101` already uses `get-fn-cached` for the **identical** seams.
- The flows router already uses `get-fn-cached` for `:flows/run-flows-on-db`; this brings the per-flow validate lookup in line.

Per the authoritative bead (rf2-sk1fp), this is a low-severity hot-path convention nit. This PR fixes the flows-slice site; the broader corpus-wide consistency pass (routing/registry.cljc, core/subs.cljc, core/spec.cljc) is out of scope here.

## Behaviour preservation

`get-fn-cached` returns the same resolved fn (nil resolutions stay uncached so deferred publication is visible; the cache is invalidated on `set-fn!`/`chain-fn!` so dev hot-reload re-resolves). No observable behaviour change — purely removes redundant per-recompute resolution.

## DCE-elision

The change lives entirely inside the caller's `debug-enabled?` gate (flows.cljc:269), so the surface remains DCE-elided in CLJS production. Confirmed by the elision probe: production 40/40 absent.

## Gates (all timeout-guarded, all TERMINATED + GREEN)

- `timeout 180 clojure -M:test` (flows JVM) — 139 tests, 4567 assertions, 0 failures/0 errors
- `timeout 540 npm run test:cljs` — 5616 tests, 19562 assertions, 0 failures/0 errors
- `npm run test:elision` — PASS (production 40/40 absent; control 40/40 present)

No new tests added: the existing `flows_schema_validation_test.clj` suite already covers the full `validate-output!` behaviour (conforming / non-conforming / no-schema / no-validator soft-pass / production-gate elision / per-flow cascade). The swap is behaviour-preserving, so a caching-count assertion would be redundant with `late-bind`'s own artefact-level coverage.

Closes rf2-sk1fp.