### PR TITLE
perf(late-bind): cache :schemas/validate-* seams at registry/subs/spec (rf2-bqfw1)

### DIFF
--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -143,8 +143,8 @@
         ;; Production path. Reach validation through the late-bind
         ;; seam so this namespace stays decoupled from the optional
         ;; schemas artefact.
-        (let [validate-fn (late-bind/get-fn :schemas/validate-with-registered-fn)
-              explain-fn  (late-bind/get-fn :schemas/explain-with-registered-fn)]
+        (let [validate-fn (late-bind/get-fn-cached :schemas/validate-with-registered-fn)
+              explain-fn  (late-bind/get-fn-cached :schemas/explain-with-registered-fn)]
           (if (nil? validate-fn)
             ;; Schemas artefact not on the classpath, or no validator
             ;; registered. Per Spec 010 §Non-Malli validators / nil

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -335,14 +335,14 @@
      [value query-v sub-meta frame-id]
      (let [schema (:schema sub-meta)]
        (if (and schema (some? sub-meta))
-         (if-let [validate (late-bind/get-fn :schemas/validate-with-registered-fn)]
+         (if-let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
            (if (try (validate schema value)
                     ;; A throwing validator must not crash the render; treat
                     ;; it as a pass (mirrors `subs.memo/maybe-validate-sub!`).
                     (catch :default _ true))
              value
              (let [sub-id  (first query-v)
-                   explain (when-let [exp (late-bind/get-fn
+                   explain (when-let [exp (late-bind/get-fn-cached
                                             :schemas/explain-with-registered-fn)]
                              (try (exp schema value) (catch :default _ nil)))]
                (trace/emit-error! :rf.error/schema-validation-failure

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -502,12 +502,12 @@
   (let [schema (get route-meta slot)]
     (if-not schema
       [false nil]
-      (let [validate (late-bind/get-fn :schemas/validate-with-registered-fn)]
+      (let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
         (if-not validate
           [false nil]
           (if (validate schema value)
             [false nil]
-            (let [explain  (late-bind/get-fn :schemas/explain-with-registered-fn)
+            (let [explain  (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
                   details  (when explain (explain schema value))]
               [true details])))))))
 


### PR DESCRIPTION
Closes rf2-bqfw1 (cross-ref rf2-sk1fp #3087).

## What

Swap the **uncached** `late-bind/get-fn` → `get-fn-cached` for the `:schemas/validate-with-registered-fn` / `:schemas/explain-with-registered-fn` seams at the three remaining hot/per-recompute sites, matching the `get-fn-cached` docstring (which explicitly names `:schemas/validate-*` as a key that SHOULD cache) and the established `flows.cljc` (#3087) + `machines/data_validation.cljc` convention.

| Site | Path | Hot path |
|------|------|----------|
| 1 | `routing/registry.cljc:505,510` (`validate-route-shape`) | per `match-url` route match |
| 2 | `core/subs.cljc:338,346` (`:sub-override` validation) | per sub recompute |
| 3 | `core/spec.cljc:146,147` (at-boundary interceptor `:before`) | per dispatched event (production path) |

All three verified as genuine per-recompute / per-dispatch `:schemas/validate-*` seams before swapping. No site skipped.

## Behaviour-preserving

`get-fn-cached` returns the same fn, leaves `nil` uncached (a deferred publication is still visible on the next call), and invalidates on `set-fn!`/`chain-fn!` (dev hot-reload re-resolves). These are dev/debug-gated paths — **DCE-elision preserved**.

## Gates (cold, all GREEN, all terminated)

- `npm run test:cljs` — 5616 tests / 19562 assertions, 0 failures, 0 errors
- core `clojure -M:test` — 864 tests / 3879 assertions, 0 failures, 0 errors
- routing `clojure -M:test` — 151 tests / 684 assertions, 0 failures, 0 errors
- `npm run test:elision` — PASS: production 40/40 absent, control 40/40 present