### PR TITLE
fix(routing): emit :rf.warning/malformed-url on navigate {:url} fail-closed miss (rf2-2zyvj)

### DIFF
--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -72,7 +72,8 @@
     ;; the programmatic path matches the URL-driven path so async loaders
     ;; have a token to thread through stale-suppression.
     (let [opts (or opts {})
-          {:keys [route-id path-params query-params matched-fragment unmatched-url]}
+          {:keys [route-id path-params query-params matched-fragment unmatched-url
+                  throw-reason requested-url]}
           (cond
             (keyword? target)
             {:route-id     target
@@ -111,7 +112,16 @@
                                    (:params match {:url (:url target)}))
                :query-params     (:query match {})
                :matched-fragment (:fragment match)
-               :unmatched-url    (when-not (:route-id match) (:url target))}))
+               :unmatched-url    (when-not (:route-id match) (:url target))
+               ;; rf2-2zyvj: thread the match-url throw cause + the
+               ;; requested URL out of this `{:url ...}` branch so the
+               ;; commit body below can emit `:rf.warning/malformed-url`,
+               ;; symmetric with the URL-driven path (url_change.cljc:190).
+               ;; Without this the over-cap / match-error navigate target
+               ;; fails closed SILENTLY — invisible to the security
+               ;; dashboards / SSR projections the DoS cap feeds.
+               :throw-reason     throw-reason
+               :requested-url    (:url target)}))
           fragment    (or (:fragment opts)
                           (and (map? target) (:fragment target))
                           matched-fragment)
@@ -282,6 +292,22 @@
                                              (scroll/lookup-scroll-position db url))
                                 :fragment  fragment})
                   capture-fx (scroll/capture-scroll-fx-entry db)]
+              ;; rf2-2zyvj: structured telemetry for a `match-url` THROW
+              ;; that failed closed on the `{:url ...}` target form (the
+              ;; DoS-cap `:too-many-keys`, rf2-3k3o7, or an unexpected
+              ;; `:match-error`). Symmetric with the URL-driven entry point
+              ;; (url_change.cljc:190-193): the SAME hostile-URL stream must
+              ;; surface a `:rf.warning/malformed-url` carrying the `:reason`
+              ;; so security dashboards / SSR error-projections see it
+              ;; regardless of WHICH of the three nav events the over-cap
+              ;; URL arrived on (spec/012-Routing.md §Keyword-interning cap).
+              ;; Before this fix the programmatic navigate fail-closed path
+              ;; failed closed SILENTLY — the over-cap attack was visible via
+              ;; popstate/link but invisible via `[:rf.route/navigate {:url}]`.
+              (when throw-reason
+                (trace/emit! :warning :rf.warning/malformed-url
+                             (cond-> {:url requested-url :reason throw-reason}
+                               frame (assoc :frame frame))))
               ;; Spec 012 §Route-not-found rule 3 (rf2-0zr2o): when an
               ;; unmatched URL-string target resolved to
               ;; `:rf.route/not-found` and no such route is registered,

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -2415,15 +2415,19 @@
     (rf/reg-route :route/search {:path "/search"})
     (rf/reg-route :rf.route/not-found {:path "/404"})
     (let [pushed (atom [])
+          traces (atom [])
           url    (over-cap-url)]
       (rf/reg-fx :rf.nav/push-url
                  {:platforms #{:server :client}}
                  (fn [_ u] (swap! pushed conj u)))
+      (rf/register-listener! ::navigate-over-cap-trace
+                             (fn [ev] (swap! traces conj ev)))
       (is (= ::ok
              (try (rf/dispatch-sync [:rf.route/navigate {:url url}]) ::ok
                   (catch Throwable _ ::threw)))
           "the over-cap {:url ...} target drains cleanly — no throw escapes
            (pre-fix this propagated :rf.error/route-too-many-keys)")
+      (rf/unregister-listener! ::navigate-over-cap-trace)
       (let [slice (get-in (rf/app-db-value :rf/default) [:rf/runtime :routing :current])]
         (is (= :rf.route/not-found (:id slice))
             "over-cap URL-string target fails closed to :rf.route/not-found")
@@ -2435,7 +2439,22 @@
             "a fresh nav-token is allocated for the not-found navigation"))
       (is (= [url] @pushed)
           ":rf.nav/push-url pushed the REQUESTED (over-cap) url VERBATIM —
-           NOT the not-found route's /404 (rf2-0zr2o address-bar parity)"))))
+           NOT the not-found route's /404 (rf2-0zr2o address-bar parity)")
+      ;; rf2-2zyvj: the SAME hostile-URL signal the URL-driven path emits
+      ;; (url-changed-over-cap → :rf.warning/malformed-url) MUST also fire on
+      ;; the programmatic `{:url ...}` fail-closed path, or the over-cap
+      ;; navigate attack is invisible to the security dashboards / SSR
+      ;; error-projections the DoS cap feeds (spec/012 §Keyword-interning
+      ;; cap). Assert the TRACE — not just the slice `:reason` — so the
+      ;; telemetry-symmetry gap with url_change regression-trips.
+      (is (some (fn [ev]
+                  (and (= :rf.warning/malformed-url (:operation ev))
+                       (= url (-> ev :tags :url))
+                       (= :too-many-keys (-> ev :tags :reason))))
+                @traces)
+          ":rf.warning/malformed-url trace fires on the navigate fail-closed
+           over-cap path, carrying the requested URL + :reason :too-many-keys
+           — symmetric with the URL-driven path (url_change.cljc:190-193)"))))
 
 ;; ---- rf2-5ifai: no :query vocabulary -> all string keys ------------------
 ;;


### PR DESCRIPTION
## What

Closes **rf2-2zyvj** (P2 RISK — routing R2 review finding).

The programmatic `[:rf.route/navigate {:url ...}]` fail-closed path (`implementation/routing/src/re_frame/routing/navigate.cljc`) caught a `match-url` throw (the keyword-interning DoS cap `:too-many-keys`, rf2-3k3o7, or a `:match-error`) and stamped `:reason` onto the route slice's `:params`, but emitted **NO** `:rf.warning/malformed-url` telemetry — **asymmetric** with the URL-driven path (`url_change.cljc:190-193`), which does emit it.

## Why it matters (security-observability gap)

An over-cap navigate-form attack routed to `:rf.route/not-found` correctly (fail-closed, no drain crash) but was **invisible** to the security dashboards / SSR error-projections the DoS cap was built to feed. `spec/012-Routing.md:839` states the property generically for **all three** nav events (`:rf.route/navigate` — the `{:url ...}` form, `:rf.route/transitioned`, `:rf.route/handle-url-change`): "a `:rf.warning/malformed-url` trace carries the `:reason` for security dashboards / SSR projections." The rf2-6t1xb fail-closed fix landed asymmetrically across the two entry points — the warning fired for `url_change`, not for `navigate`.

The same hostile-URL stream was therefore VISIBLE via popstate/link but INVISIBLE via programmatic navigate.

## Fix

- Thread the `throw-reason` + requested URL out of the `{:url ...}` resolution branch.
- Emit `:rf.warning/malformed-url` in the commit body, matching `url_change`'s trace shape **exactly**: `(cond-> {:url requested-url :reason throw-reason} frame (assoc :frame frame))`.

## Test

`navigate-url-form-over-cap-url-fails-closed-not-found` (`routing_test.clj`) now asserts the **trace** fires (operation `:rf.warning/malformed-url` + `:url` + `:reason :too-many-keys`), not just the slice `:reason` — so the telemetry-symmetry gap regression-trips.

## Scope / hot-zone

Impl + test only. `spec/012:839` already states the contract — **not touched** (no doc gate needed). The two routing R2 doc findings (fzca4, 7y41n) that ARE spec/012 hot-zone are held and untouched here.

## Gates (cold, from worktree)

- Routing JVM `clojure -M:test`: **685 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **19562 assertions, 0 failures, 0 errors**
