### PR TITLE
fix(epoch): redact only the appended delta on post-settle back-fills (rf2-qhxz6)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -119,13 +119,23 @@
   is not broken.
 
   Per Tool-Pair §Time-travel §Redaction hook + Security.md §Epoch
-  privacy posture (rf2-wp70d): the fn runs ONCE at build-time,
+  privacy posture (rf2-wp70d): the fn runs ONCE per assembled record,
   BETWEEN `build-record` and ring-append / listener fan-out — the
   ring buffer, every `register-epoch-listener!` listener, and any off-box
   projection through `projected-record` all see the SAME redacted
   shape. The `:rf.epoch/sensitive?` rollup is computed inside
   `build-record` (which runs first) so the rollup reflects the RAW
   signal even when the fn erases the leaves it keyed on.
+
+  Per rf2-qhxz6: a post-settle back-fill (render / sub-run / unmount
+  appended to an already-committed, already-redacted record) does NOT
+  re-run the fn over the whole record — `state/back-fill-event!` hands
+  this helper a probe record carrying ONLY the newly-appended delta in
+  the redactable list slots, so the fn redacts each appended slot value
+  EXACTLY ONCE across the record's lifetime. The 'once per assembled
+  record' contract therefore holds with no idempotency requirement on
+  the app's `:redact-fn` — a non-idempotent fn (hash-and-truncate,
+  append-an-audit-marker, increment-a-counter) is safe.
 
   Caller MUST wrap invocations in `(when interop/debug-enabled? ...)`
   — the whole epoch surface shares that gate; this helper carries no

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -129,18 +129,20 @@
                        (not= target default-epoch)
                        (state/render-key-already-in-epoch?
                          frame-id target render-key))
-          ;; rf2-82pcg — pass `assembly/maybe-redact` so `back-fill-render!`
-          ;; re-runs the installed `:redact-fn` over the record AFTER it
-          ;; appends the RAW render event into `:trace-events` + the RAW
-          ;; projected row into `:renders`. The redacted record is what
-          ;; lands in the ring AND what we re-fan to listeners — so both
-          ;; the pull egress (`epoch-history` / MCP `read-recording` /
-          ;; `restore-epoch`) and the push egress (this fan-out) see the
-          ;; same redacted shape the settle-time primary path produces.
-          ;; Without it the appended slots reach egress bypassing the
-          ;; `:redact-fn` (the leak). The fn is idempotent for the
-          ;; `:rf/redacted` sentinel pattern, so re-applying it to the
-          ;; already-settle-redacted slots is a no-op.
+          ;; rf2-82pcg leak-closure + rf2-qhxz6 once-per-slot — pass
+          ;; `assembly/maybe-redact` so `back-fill-render!` runs the
+          ;; installed `:redact-fn` over ONLY the newly-appended delta
+          ;; (the RAW render event for `:trace-events` + the RAW projected
+          ;; row for `:renders`) before splicing it onto the already-
+          ;; redacted record. The redacted record is what lands in the
+          ;; ring AND what we re-fan to listeners — so both the pull egress
+          ;; (`epoch-history` / MCP `read-recording` / `restore-epoch`) and
+          ;; the push egress (this fan-out) see the redacted shape. Without
+          ;; redaction the appended slots reach egress bypassing the
+          ;; `:redact-fn` (the leak). Per rf2-qhxz6 only the delta is
+          ;; redacted, so each slot is scrubbed EXACTLY ONCE — the
+          ;; Tool-Pair 'once per assembled record' contract holds with no
+          ;; idempotency requirement on the app's `:redact-fn`.
           (when-let [updated (state/back-fill-render! frame-id target event
                                                       (capture/render-row event)
                                                       assembly/maybe-redact)]
@@ -172,10 +174,12 @@
   [frame-id event]
   (when interop/debug-enabled?
     (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
-      ;; rf2-82pcg — pass `assembly/maybe-redact` so the RAW sub-event
-      ;; appended to `:trace-events` + the RAW `:sub-runs` row are run
+      ;; rf2-82pcg leak-closure + rf2-qhxz6 once-per-slot — pass
+      ;; `assembly/maybe-redact` so the RAW sub-event appended to
+      ;; `:trace-events` + the RAW `:sub-runs` row (the delta) are run
       ;; through the installed `:redact-fn` before they land in the ring
-      ;; / re-fan to listeners (see `record-render!`).
+      ;; / re-fan to listeners. Only the delta is redacted, so each slot
+      ;; is scrubbed exactly once (see `record-render!`).
       (when-let [updated (state/back-fill-sub-run! frame-id epoch-id event
                                                    (capture/sub-run-row event)
                                                    assembly/maybe-redact)]
@@ -231,12 +235,14 @@
   [frame-id event]
   (when interop/debug-enabled?
     (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
-      ;; rf2-82pcg — pass `assembly/maybe-redact` so the RAW unmount event
-      ;; appended to `:trace-events` is run through the installed
+      ;; rf2-82pcg leak-closure + rf2-qhxz6 once-per-slot — pass
+      ;; `assembly/maybe-redact` so the RAW unmount event appended to
+      ;; `:trace-events` (the delta) is run through the installed
       ;; `:redact-fn` before it lands in the ring / re-fans to listeners
       ;; (see `record-render!`). An unmount carries no structured projection
       ;; row, so only `:trace-events` is back-filled — but that slot is
       ;; still egress (Xray's VIEWS-step `unmounted-views-rows` reads it).
+      ;; Only the appended delta is redacted, so the slot is scrubbed once.
       (when-let [updated (state/back-fill-unmount! frame-id epoch-id event
                                                    assembly/maybe-redact)]
         ;; Re-fan the corrected record so snapshot consumers re-read the

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -566,14 +566,84 @@
 ;; does the ring mutation and the two public fns are thin wrappers
 ;; pinning the slot.
 
+(defn- redact-appended-delta
+  "Run `redact` over ONLY the newly-appended delta (the new `:trace-events`
+  `event` and the new `slot` `row`), then splice the redacted delta back
+  onto `record` — leaving every already-redacted slot value untouched.
+  Returns the updated record. Per rf2-qhxz6: this honours the Tool-Pair
+  §Redaction hook contract literally — `:redact-fn` sees each appended
+  slot value EXACTLY ONCE across the record's whole lifetime, so a
+  NON-idempotent `:redact-fn` (one that transforms a value rather than
+  substituting an idempotent `:rf/redacted` sentinel — e.g. hash-and-
+  truncate, append an audit marker, increment a counter) never re-runs
+  over a slot it already scrubbed.
+
+  HOW. We hand `redact` a probe record shaped exactly like the assembled
+  record (so an `:redact-fn` that keys on whole-record structure — reads
+  `:db-after` / `:frame` / `:rf.epoch/sensitive?` for its decision — still
+  composes) BUT whose `:trace-events` / `slot` lists carry ONLY the new
+  delta element. The fn redacts that delta in place; we extract the
+  redacted element(s) and `conj` them onto `record`'s real (already-
+  redacted) slots. The leak the rf2-82pcg fix closed STAYS closed — the
+  appended slots still pass through `:redact-fn` before reaching either
+  egress channel — but each slot is now redacted once, not 1+K times.
+
+  Slot extraction. When `redact` returns the probe slot still as a vector
+  (the common per-element-transform / sentinel-substitution shape) we take
+  its element(s) — the redacted delta — and `conj` onto the real slot.
+  When `redact` instead COLLAPSES the whole slot to a non-vector sentinel
+  (e.g. `(assoc r :trace-events :rf/redacted)` — a whole-slot scrub), the
+  fn's intent is to redact the entire slot, so we write that sentinel to
+  the real slot. We only `conj` onto a real slot that is a vector (or
+  absent); a real slot already collapsed to a sentinel by a prior
+  whole-slot scrub is left at the sentinel (the delta is subsumed).
+
+  Pure (record-in, record-out); `redact` is the only injected fn it
+  calls, so it stays retry-safe inside the `swap!`."
+  [record slot event row redact]
+  (let [append?  (contains? record :trace-events)
+        ;; Probe = the real record's context with ONLY the new delta in
+        ;; the redactable list slots. Other slots ride unchanged so a
+        ;; whole-record-keyed `:redact-fn` reads the same context it saw
+        ;; at settle time.
+        delta?   (or append? (some? row))
+        ;; No delta to append (an unmount on a record whose `:trace-events`
+        ;; was already dropped by the keep-window cap) → nothing to redact,
+        ;; return the record untouched (do NOT spuriously re-redact it).
+        probe    (when delta?
+                   (cond-> record
+                     append?     (assoc :trace-events [event])
+                     (some? row) (assoc slot [row])))
+        redacted (when delta? (redact probe))
+        ;; Splice a redacted delta value back onto the real slot. `dv` is
+        ;; the redacted probe-slot value: a vector (per-element / sentinel-
+        ;; substitution) → conj its element(s) onto the real slot; a non-
+        ;; vector (whole-slot collapse) → adopt that sentinel for the slot.
+        splice   (fn [rec real-slot dv]
+                   (cond
+                     (and (vector? dv) (vector? (get rec real-slot)))
+                     (update rec real-slot into dv)
+
+                     (and (vector? dv) (not (contains? rec real-slot)))
+                     (assoc rec real-slot (vec dv))
+
+                     (vector? dv)        ; real slot already a sentinel
+                     rec                 ; delta subsumed by prior collapse
+
+                     :else               ; whole-slot collapse by the fn
+                     (assoc rec real-slot dv)))]
+    (cond-> record
+      append?     (splice :trace-events (:trace-events redacted))
+      (some? row) (splice slot (get redacted slot)))))
+
 (defn- back-fill-event!
   "Append `event` and its projected `row` (into the `slot` projection)
   on the already-committed epoch record identified by `frame-id` +
-  `epoch-id`, then run the appended record through `redact` and write
-  THAT back to the ring. Returns the redacted updated record (so the
-  caller re-notifies listeners with the same shape the ring now holds),
-  or nil when the target epoch is no longer in the ring (evicted, or the
-  event fired before any cascade settled).
+  `epoch-id`, redacting ONLY the newly-appended delta, then write THAT
+  back to the ring. Returns the updated record (so the caller re-notifies
+  listeners with the same shape the ring now holds), or nil when the
+  target epoch is no longer in the ring (evicted, or the event fired
+  before any cascade settled).
 
   `row` is the structured projection entry, or nil — a render op that
   carries no `:renders` row (`:rf.view/rendered`) or a `:sub/skip` that
@@ -591,21 +661,24 @@
       (Xray Views / Reactive panel) — is always present on a built
       record; the projected row is appended when non-nil.
 
-  REDACTION (rf2-82pcg). `redact` is the installed redaction transform
-  (`assembly/maybe-redact`, injected by the caller so this state ns keeps
-  no `assembly` require — `assembly` already requires this ns). It runs
-  INSIDE the swap, AFTER the raw append, so the redacted record is what
-  lands in the ring AND what is returned for the listener re-fan — the
-  same `:redact-fn`-once-between-build-and-fan-out invariant the settle-
-  time primary path holds (Tool-Pair §Time-travel §Redaction hook,
-  Security.md §Epoch privacy posture). Pre-fix the raw appended slots
-  reached both egress channels (ring-read: `epoch-history` / MCP
-  `read-recording` / `restore-epoch`; and the listener fan-out) bypassing
-  the `:redact-fn`. `redact` defaults to `identity` for callers / tests
-  that need the bare raw append. The fn is idempotent for the
-  `:rf/redacted` sentinel pattern, so re-applying it to the record's
-  already-settle-redacted slots is a no-op while the newly-appended slots
-  get scrubbed.
+  REDACTION (rf2-82pcg leak-closure + rf2-qhxz6 once-per-slot fix).
+  `redact` is the installed redaction transform (`assembly/maybe-redact`,
+  injected by the caller so this state ns keeps no `assembly` require —
+  `assembly` already requires this ns). It runs INSIDE the swap, over ONLY
+  the newly-appended delta (via `redact-appended-delta`), so the redacted
+  delta is what lands in the ring AND what is returned for the listener
+  re-fan. Pre-rf2-82pcg the raw appended slots reached both egress
+  channels (ring-read: `epoch-history` / MCP `read-recording` /
+  `restore-epoch`; and the listener fan-out) bypassing the `:redact-fn`
+  (the leak). The rf2-82pcg fix re-ran the fn over the WHOLE record on
+  every back-fill — closing the leak but invoking the fn 1+K times for an
+  epoch accruing K back-fills, which corrupts a NON-idempotent fn's prior
+  output. rf2-qhxz6 narrows the redaction to the appended delta so the
+  Tool-Pair §Redaction hook 'once per assembled record' contract holds
+  literally: each slot value is redacted EXACTLY ONCE and the fn carries
+  no idempotency requirement. The leak stays closed — the appended delta
+  is still scrubbed before egress. `redact` defaults to `identity` for
+  callers / tests that need the bare raw append.
 
   The `swap!` update fn is PURE — it mutates only the history map and
   smuggles nothing out (the prior shape `reset!`'d a local out-param atom
@@ -624,12 +697,7 @@
    (let [idx (epoch-index (history-for frame-id) epoch-id)]
      (when idx
        (let [append (fn [record]
-                      (-> (cond-> record
-                            (contains? record :trace-events)
-                            (update :trace-events (fnil conj []) event)
-                            (some? row)
-                            (update slot (fnil conj []) row))
-                          redact))]
+                      (redact-appended-delta record slot event row redact))]
          (-> (swap! histories update-in [frame-id idx] append)
              (get-in [frame-id idx])))))))
 
@@ -637,8 +705,9 @@
   "Back-fill `render-event` and its projected `:renders` `render-row`
   into the already-committed epoch `epoch-id` for `frame-id` (rf2-qs6dl).
   Thin wrapper over `back-fill-event!` pinning the `:renders` slot.
-  `redact` (rf2-82pcg) is run over the appended record before it lands in
-  the ring / is returned for the listener re-fan; defaults to `identity`."
+  `redact` (rf2-82pcg leak-closure / rf2-qhxz6 once-per-slot) is run over
+  ONLY the appended delta before it lands in the ring / is returned for
+  the listener re-fan; defaults to `identity`."
   ([frame-id epoch-id render-event render-row]
    (back-fill-render! frame-id epoch-id render-event render-row identity))
   ([frame-id epoch-id render-event render-row redact]
@@ -648,8 +717,9 @@
   "Back-fill `sub-event` and its projected `:sub-runs` `sub-run-row` into
   the already-committed epoch `epoch-id` for `frame-id` (rf2-wi900). Thin
   wrapper over `back-fill-event!` pinning the `:sub-runs` slot. Symmetric
-  with `back-fill-render!`. `redact` (rf2-82pcg) is run over the appended
-  record before it lands in the ring / is returned; defaults to `identity`."
+  with `back-fill-render!`. `redact` (rf2-82pcg leak-closure / rf2-qhxz6
+  once-per-slot) is run over ONLY the appended delta before it lands in
+  the ring / is returned; defaults to `identity`."
   ([frame-id epoch-id sub-event sub-run-row]
    (back-fill-sub-run! frame-id epoch-id sub-event sub-run-row identity))
   ([frame-id epoch-id sub-event sub-run-row redact]
@@ -664,9 +734,9 @@
   VIEWS-step `unmounted-views-rows` reads view teardowns. The `:slot`
   argument is irrelevant when `row` is nil; `:renders` is passed for
   documentary parity with the render sibling. Symmetric with
-  `back-fill-render!` / `back-fill-sub-run!`. `redact` (rf2-82pcg) is run
-  over the appended record before it lands in the ring / is returned;
-  defaults to `identity`."
+  `back-fill-render!` / `back-fill-sub-run!`. `redact` (rf2-82pcg leak-
+  closure / rf2-qhxz6 once-per-slot) is run over ONLY the appended delta
+  before it lands in the ring / is returned; defaults to `identity`."
   ([frame-id epoch-id unmount-event]
    (back-fill-unmount! frame-id epoch-id unmount-event identity))
   ([frame-id epoch-id unmount-event redact]

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -527,12 +527,14 @@
 ;; (push) AND the ring read (`epoch-history` / MCP `read-recording` /
 ;; `restore-epoch` — pull).
 ;;
-;; THE FIX runs `maybe-redact` over the back-filled record before it lands
-;; in the ring / re-fans to listeners, restoring the settle-time invariant
-;; for the post-settle async classes. These tests pin: (a) a sensitive
-;; value in a back-filled trace-event / sub-run row is REDACTED in the
-;; re-notified record AND in the ring; (b) a non-sensitive value passes
-;; through unchanged (no over-redaction regression — the redact-fn is the
+;; THE FIX runs `maybe-redact` over the back-filled DELTA before it lands
+;; in the ring / re-fans to listeners (rf2-qhxz6 narrowed the original
+;; rf2-82pcg whole-record re-redaction to the appended delta — see
+;; invariant 7 below), restoring the settle-time invariant for the
+;; post-settle async classes. These tests pin: (a) a sensitive value in a
+;; back-filled trace-event / sub-run row is REDACTED in the re-notified
+;; record AND in the ring; (b) a non-sensitive value passes through
+;; unchanged (no over-redaction regression — the redact-fn is the
 ;; AI/MCP-egress boundary; this fix must close the leak without scrubbing
 ;; benign data).
 ;;
@@ -763,3 +765,169 @@
              attribution path is unchanged; redaction is opt-in)")
         (is (= renotified (last-record :test/main))
             "ring and listener agree on the raw shape")))))
+
+;; ============================================================================
+;;  Invariant 7 — once-per-slot back-fill redaction; NON-idempotent fns
+;;                are honoured (rf2-qhxz6)
+;; ============================================================================
+;;
+;; THE CONTRACT (Tool-Pair.md §Redaction hook): ":redact-fn ONCE per
+;; assembled record." That entitles an app author to write a NON-idempotent
+;; fn — one that TRANSFORMS a value rather than substituting an idempotent
+;; `:rf/redacted` sentinel (hash-and-truncate, append-an-audit-marker,
+;; increment-a-closure-counter, base64-a-token).
+;;
+;; THE rf2-82pcg DRIFT (closed here). The rf2-82pcg fix closed the back-fill
+;; leak by re-running the fn over the WHOLE record on EVERY post-settle
+;; back-fill — so an epoch accruing K back-fills invoked the fn 1+K times,
+;; each pass re-redacting the slots prior passes already redacted. A
+;; non-idempotent fn corrupts those already-redacted slots (and
+;; `restore-epoch` rewinds to the corrupted `:db-after`).
+;;
+;; THE rf2-qhxz6 FIX (delta-only). `back-fill-event!` now runs the fn over
+;; ONLY the newly-appended delta. Each slot value is redacted EXACTLY ONCE
+;; across the record's lifetime; the already-redacted slots are never
+;; re-touched; the leak stays closed (the delta IS still redacted). No
+;; idempotency requirement is imposed on the app's `:redact-fn`.
+;;
+;; These tests use a deliberately NON-idempotent fn: it STAMPS a fresh
+;; monotonic counter onto each redactable slot value it touches. If a slot
+;; were re-redacted, its stamp would be a LATER counter than its
+;; first-touch stamp — the test asserts every stamp is its first-touch
+;; value (i.e. each slot touched exactly once).
+
+;; A NON-idempotent redact-fn: each invocation increments a shared counter
+;; and stamps the NEXT counter value onto every :sub-runs row's :value and
+;; every :trace-events :rf.sub/value tag it can see. Re-running it over an
+;; already-stamped value would OVERWRITE the stamp with a later counter —
+;; so a stable first-touch stamp proves once-per-slot. `seq` (call count)
+;; and `touched` (every (slot . stamp) pair, in invocation order) are
+;; exposed for assertions.
+(defn- make-counting-redact-fn []
+  (let [seq*    (atom 0)
+        touched (atom [])]
+    {:seq     seq*
+     :touched touched
+     :redact  (fn [r]
+                (let [n (swap! seq* inc)]
+                  (cond-> r
+                    (vector? (:sub-runs r))
+                    (update :sub-runs
+                            (fn [rows]
+                              (mapv (fn [row]
+                                      (swap! touched conj [:sub-run (:sub-id row) n])
+                                      (assoc row :value [:stamped n (:value row)]))
+                                    rows)))
+                    (vector? (:trace-events r))
+                    (update :trace-events
+                            (fn [evs]
+                              (mapv (fn [ev]
+                                      (if (contains? (:tags ev) :rf.sub/value)
+                                        (do (swap! touched conj [:trace n])
+                                            (update-in ev [:tags :rf.sub/value]
+                                                       (fn [v] [:stamped n v])))
+                                        ev))
+                                    evs))))))}))
+
+(deftest inv-7-non-idempotent-redact-fn-invoked-once-per-slot-across-back-fills
+  (testing "rf2-qhxz6 — a NON-idempotent :redact-fn is invoked EXACTLY ONCE
+            per appended slot across a sequence of post-settle back-fills.
+            The settle-time slots keep their first-touch stamp; each
+            back-fill stamps ONLY its own appended delta; no prior slot is
+            re-stamped (which a whole-record re-redaction would do)."
+    (rf/reg-frame :test/main {})
+    (let [{:keys [seq touched redact]} (make-counting-redact-fn)]
+      (rf/configure! :epoch-history {:redact-fn redact})
+      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+      (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+      (let [settle-calls @seq]
+        ;; THREE post-settle sub-run back-fills onto the SAME last-settled
+        ;; epoch record. A whole-record re-redaction would, on back-fill K,
+        ;; re-stamp all K-1 prior sub-run rows (each call walks the whole
+        ;; growing :sub-runs vector). Delta-only redaction stamps ONLY the
+        ;; newly-appended row each time.
+        (emit-sub-run! :test/main :a 0 100)
+        (emit-sub-run! :test/main :b 0 200)
+        (emit-sub-run! :test/main :c 0 300)
+
+        ;; INVARIANT: exactly one fn invocation per back-fill (plus the
+        ;; settle-time calls). NOT 1+K growth in slot-touches.
+        (is (= (+ settle-calls 3) @seq)
+            "redact-fn invoked once per back-fill — three back-fills =
+             three additional invocations")
+
+        ;; INVARIANT: each :sub-runs row was touched EXACTLY ONCE — the
+        ;; (slot . stamp) ledger holds each sub-id once, at its
+        ;; first-touch counter. A re-redaction would log the same sub-id
+        ;; multiple times (once per subsequent back-fill).
+        (let [sub-run-touches (->> @touched
+                                   (filter #(= :sub-run (first %)))
+                                   (map second))]
+          (is (= [:a :b :c] sub-run-touches)
+              "each sub-id appears EXACTLY ONCE in the touch ledger, in
+               append order — no slot re-redacted on a later back-fill"))
+
+        ;; INVARIANT: the ring record's rows each carry their OWN
+        ;; first-touch stamp (monotonic in append order), NOT a later
+        ;; counter. If row :a had been re-stamped on the :b and :c
+        ;; back-fills its stamp would be the :c-era counter.
+        (let [ring  (last-record :test/main)
+              by-id (into {} (map (juxt :sub-id identity)) (:sub-runs ring))
+              stamp (fn [id] (second (:value (by-id id))))]
+          (is (< (stamp :a) (stamp :b) (stamp :c))
+              "row stamps are strictly increasing in append order — each
+               row carries its first-touch counter; none was re-stamped by
+               a later back-fill (which would equalise / invert the order)")
+          ;; INVARIANT (leak stays closed): the appended delta WAS
+          ;; redacted — every back-filled row's value is the stamped form,
+          ;; not the raw value.
+          (is (= [:stamped (stamp :c) 300] (:value (by-id :c)))
+              "the most-recent back-fill's value IS redacted (stamped) —
+               the leak stays closed for the delta")
+          (is (= [:stamped (stamp :a) 100] (:value (by-id :a)))
+              "the first back-fill's value remains its ORIGINAL stamped
+               form — unchanged by the later :b / :c back-fills"))))))
+
+(deftest inv-7-already-redacted-slots-unchanged-across-back-fill
+  (testing "rf2-qhxz6 — a back-fill leaves every PRE-EXISTING slot value
+            byte-for-byte unchanged; only the appended delta is added. The
+            settle-time :sub-runs / :trace-events / :db-after carry through
+            identically before and after a back-fill (a non-idempotent fn
+            re-run over the whole record would mutate them)."
+    (rf/reg-frame :test/main {})
+    (let [{:keys [redact]} (make-counting-redact-fn)]
+      (rf/configure! :epoch-history {:redact-fn redact})
+      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+      ;; A settling cascade whose own :sub-runs the settle-time pass stamps.
+      (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (emit-sub-run! :test/main :pre 0 1)        ; back-fill #1 — settled slot
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+
+      (let [before        (last-record :test/main)
+            before-subs   (:sub-runs before)
+            before-traces (:trace-events before)
+            before-after  (:db-after before)]
+        ;; A fresh back-fill onto this record appends a NEW sub-run.
+        (emit-sub-run! :test/main :post 0 2)
+        (let [after (last-record :test/main)]
+          (is (= before-subs (drop-last (:sub-runs after)))
+              "every pre-existing :sub-runs row is unchanged — the back-fill
+               only APPENDED the new row, never re-stamped the old ones")
+          (is (= before-traces
+                 (vec (take (count before-traces) (:trace-events after))))
+              "every pre-existing :trace-events entry is unchanged — only
+               the new delta event was appended + stamped")
+          (is (= before-after (:db-after after))
+              ":db-after is byte-for-byte unchanged across the back-fill —
+               a whole-record re-redaction by a non-idempotent fn keyed on
+               :db-after would have re-transformed it")
+          ;; And the appended delta IS redacted (leak closed).
+          (let [post-row (->> (:sub-runs after)
+                              (filter #(= :post (:sub-id %))) first)]
+            (is (and (vector? (:value post-row))
+                     (= :stamped (first (:value post-row))))
+                "the appended :post row IS redacted (stamped) — leak closed")))))))


### PR DESCRIPTION
## Summary

Bead **rf2-qhxz6** (P2 BUG) — follow-on to rf2-82pcg, from the epoch R2 review.

The rf2-82pcg fix closed the post-settle back-fill redaction leak by re-running the installed `:redact-fn` over the **whole record** on every back-fill. For an epoch accruing K back-fills (renders / reactive sub-runs / unmounts between two settles, all targeting the same last-settled-epoch record), the fn was invoked **1+K times**, each pass re-redacting slots that prior passes already redacted.

That broke the `spec/Tool-Pair.md` §Redaction hook contract — *"invokes `:redact-fn` once per assembled record"* — which entitles app authors to write **non-idempotent** redact-fns (hash-and-truncate, append-an-audit-marker, increment-a-counter). A non-idempotent fn corrupted back-filled records, and `restore-epoch` rewinds to the corrupted `:db-after`.

## The fix — option (b): honor the contract

`back-fill-event!` now runs the redact-fn over **only the newly-appended delta** via the new private `redact-appended-delta` helper. It hands the fn a *probe* record shaped exactly like the assembled record (so an `:redact-fn` that keys on whole-record structure — reads `:db-after` / `:frame` / `:rf.epoch/sensitive?` — still composes), but whose `:trace-events` / `slot` lists carry **only the newly-appended element**. The redacted delta is then spliced onto the already-redacted record.

Result:
- Each slot value is redacted **exactly once** across the record's lifetime → the "once per assembled record" contract holds literally.
- Already-redacted slots are **never re-touched** → non-idempotent fns no longer corrupt prior output.
- The **leak stays closed** — the appended delta is still scrubbed before either egress channel (ring read: `epoch-history` / MCP `read-recording` / `restore-epoch`; and the listener re-fan).
- **No idempotency requirement** is imposed on app redact-fns.

The splice handles both shapes a redact-fn can produce: per-element / sentinel-substitution (vector slot → conj the redacted element) and whole-slot collapse (`(assoc r :trace-events :rf/redacted)` → adopt the sentinel).

`spec/Tool-Pair.md` is **unchanged** — the existing "once per assembled record" wording stands; this fix makes the implementation honor it.

## Preserved
Leak-closure (rf2-82pcg), the fxowr harvest, bgapd prune, #2929 ring no-retention, RTC semantics, the `on-frame-destroyed!` `:halted-destroy` settle-equivalent path (legitimately one whole-record redact — not a back-fill).

## Tests (`epoch_redact_fn_test` invariant 7, new)
- A **non-idempotent** redact-fn that stamps a monotonic counter onto each slot it touches is invoked **exactly once per appended slot** across three back-fills (touch ledger holds each sub-id once, in append order; ring-record row stamps strictly increasing — none re-stamped by a later back-fill).
- Already-redacted slots (`:sub-runs` / `:trace-events` / `:db-after`) are **byte-for-byte unchanged** across a back-fill.
- The appended delta **is** redacted (leak closed).

## Gates (cold, terminated)
- Epoch JVM: `clojure -M:test` — 258 tests / 975 assertions, 0 failures.
- `npm run test:cljs` — 5616 tests / 19562 assertions, 0 failures.

Closes rf2-qhxz6.
