### PR TITLE
fix(ssr-ring): render-time sub-throw fails closed on the wire (rf2-c0bq1)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -302,14 +302,40 @@
                            :head        head-html
                            :html-attrs  html-attrs
                            :body-attrs  body-attrs)
-        html        (html-shell body-html payload-edn shell-opts)]
+        html        (html-shell body-html payload-edn shell-opts)
+        ;; rf2-c0bq1 — RE-FLUSH after the render walk. The `resp` arg was
+        ;; read at `ring.clj:343` (the single `get-response`) BEFORE the
+        ;; render ran, so it carries the pre-render status. A reactive
+        ;; sub that THROWS during `render-to-string` under production
+        ;; hardening (`interop/debug-enabled? = false`) recovers to nil —
+        ;; `render-to-string` does NOT throw, so the outer
+        ;; `build-full-response` catch never fires — but the always-on
+        ;; error-emit substrate (rf2-vvwmi) BUFFERS a fail-closed 500 onto
+        ;; pending-error-traces during the walk. Without this re-flush
+        ;; that buffered 500 sits unread until frame-destroy drops it, and
+        ;; the wire ships a silent 200 with the recovered-to-nil broken
+        ;; HTML — defeating the rf2-vvwmi fix end-to-end and breaking the
+        ;; Spec 011 §744/§750 "fail-closed, never a silent 200" contract.
+        ;;
+        ;; `flush-response!` drains the (post-render) buffer through the
+        ;; default projector and stamps the projector's :status onto the
+        ;; response accumulator (last-write-wins, redirect-guarded — see
+        ;; `apply-error-projection!` error_listener.cljc:139). The happy
+        ;; path is unaffected: no error buffered during render → empty
+        ;; buffer → the drain is a no-op → :status stays whatever the
+        ;; pre-render `resp` carried (default 200). A redirect set during
+        ;; render still wins (the projector refuses to overwrite a
+        ;; redirect response). We re-read the FULL response (not just
+        ;; merge :status) so any header / cookie the render walk
+        ;; accumulated also rides the wire.
+        post-render-resp (ssr/flush-response! frame-id)]
     ;; Content-Type defaulting (rf2-uj9z8): the 3-arg form folds the
     ;; header pairs into the Ring map AND defaults Content-Type in one
     ;; walk. The SSR runtime defaults [:rf/response :headers] to include
     ;; content-type so the default is usually a no-op, but we still pass
     ;; `content-type` through so an opts override and absence-of-default
     ;; both work.
-    (ssr-response->ring-response resp html content-type)))
+    (ssr-response->ring-response post-render-resp html content-type)))
 
 (defn build-full-response
   "Render the caller's `:root-view` against `frame-id`, build the

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
@@ -1,0 +1,220 @@
+(ns re-frame.ssr.ring-rendertime-sub-failclosed-test
+  "Per rf2-c0bq1 — the handler-level tripwire for the RENDER-TIME reactive
+  sub-exception fail-closed contract through the REAL Ring handler order.
+
+  ## The gap this closes (and the bug it pins)
+
+  rf2-vvwmi made a reactive sub that throws during `render-to-string`
+  route `:rf.error/sub-exception` through the ALWAYS-ON error-emit
+  substrate so the SSR projection listener BUFFERS a fail-closed 500 onto
+  pending-error-traces even under production hardening
+  (`interop/debug-enabled? = false`). That fix is correct at the
+  core/accumulator layer — but it did NOT reach the wire through the
+  reference Ring adapter:
+
+    1. `ssr-handler` reads `(ssr/get-response frame-id)` ONCE at
+       `ring.clj:343` — BEFORE the render walk. The render has not run,
+       so the buffer is empty and `:status` is the default 200.
+    2. `build-full-response*` (`pipeline.clj`) runs the render walk inside
+       `with-frame`. The reactive sub throws HERE. Under
+       `debug-enabled? = false` the sub-run catch (`subs/memo.cljc`)
+       routes the always-on `dispatch-on-error!` (which BUFFERS the 500)
+       and then RETURNS nil — so `render-to-string` does NOT throw, and
+       `build-full-response`'s outer try/catch never fires.
+    3. Before rf2-c0bq1, `build-full-response*` materialised the wire
+       response from the STALE pre-render `resp` (the 200 from step 1).
+       The buffered 500 sat in pending-error-traces until frame-destroy
+       dropped it. The wire shipped a SILENT 200 with the recovered-to-nil
+       broken HTML — defeating rf2-vvwmi end-to-end and breaking the
+       Spec 011 §744 / §750 contract (\"fail-closed to a non-200 … never a
+       silent 200 with the recovered-to-nil HTML\").
+
+  The rf2-c0bq1 fix re-flushes the response accumulator AFTER the render
+  walk (`ssr/flush-response!` in `build-full-response*`), so the
+  post-render-buffered 500 reaches the wire. This suite is the regression
+  tripwire: it drives a render-time THROWING reactive sub through the real
+  `ssr-handler` order and asserts the WIRE `:status` is 500, NOT a silent
+  200.
+
+  ## Why the existing tests missed it
+
+    - `ssr_sub_exception_two_frame_attribution_test` (the rf2-vvwmi/vdk33
+      proof) calls `subscribe-once` FIRST (running the sub body, buffering
+      the 500) and `get-response` AFTER — the INVERSE of the handler order
+      (sub-run-then-read vs the handler's read-then-render). It proves the
+      core listener / accumulator / attribution layer, but never the Ring
+      read-before-render wire path, so it gave false end-to-end
+      confidence. (That suite now carries an explicit note pointing here.)
+    - `ring_test.clj` `handler-render-error-*` covers a root-VIEW that
+      THROWS (the throwable propagates → the catch arm → projected 500).
+      That path works. A reactive SUB-throw recovers-to-nil → never
+      reaches the catch — the untested gap.
+    - `ring_draintime_error_test` covers drain-time categories that fire
+      BEFORE `get-response`, so the single pre-render read sees them.
+
+  TEST + SOURCE: the source fix lives in `pipeline.clj`
+  (`build-full-response*` re-flush); this suite is its acceptance test.
+  Mirrors `ring_draintime_error_test.clj`'s harness: direct in-process
+  handler call AND bytes-on-the-wire through Jetty + `java.net.http`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.test-fixture :as tf]
+            [ring.adapter.jetty :as jetty])
+  (:import [java.net URI]
+           [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
+           [java.time Duration]
+           [org.eclipse.jetty.server Server]))
+
+(use-fixtures :each tf/reset-runtime)
+
+;; ===========================================================================
+;; Jetty + java.net.http harness (mirrors ring_draintime_error_test.clj)
+;; ===========================================================================
+
+(defn- start-jetty!
+  [handler]
+  (let [^Server server (jetty/run-jetty handler
+                                        {:port                 0
+                                         :host                 "127.0.0.1"
+                                         :join?                false
+                                         :send-server-version? false
+                                         :send-date-header?    false})
+        port (.. server (getURI) (getPort))]
+    {:server server :port port}))
+
+(defn- stop-jetty!
+  [^Server server]
+  (.stop server))
+
+(defmacro with-jetty
+  [[port-sym handler-expr] & body]
+  `(let [{server# :server port# :port} (start-jetty! ~handler-expr)
+         ~port-sym port#]
+     (try
+       ~@body
+       (finally
+         (stop-jetty! server#)))))
+
+(defn- new-http-client []
+  (-> (HttpClient/newBuilder)
+      (.connectTimeout (Duration/ofSeconds 5))
+      (.build)))
+
+(defn- http-get
+  "Issue a real HTTP GET against `http://127.0.0.1:<port><path>` and
+  return `{:status :body}` observed on the wire."
+  [^HttpClient client port path]
+  (let [req  (-> (HttpRequest/newBuilder)
+                 (.uri (URI/create (str "http://127.0.0.1:" port path)))
+                 (.timeout (Duration/ofSeconds 30))
+                 (.GET)
+                 (.build))
+        resp (.send client req (HttpResponse$BodyHandlers/ofString))]
+    {:status (.statusCode resp)
+     :body   (.body resp)}))
+
+;; ===========================================================================
+;; A root-view whose reactive sub THROWS during the render walk.
+;; ===========================================================================
+
+(defn- register-throwing-sub-view! []
+  ;; The sub throws while computing its value. Under
+  ;; `interop/debug-enabled? = false` the reactive sub-run catch
+  ;; (subs/memo.cljc) routes the always-on `dispatch-on-error!`
+  ;; (buffering the fail-closed 500 per rf2-vvwmi) and RETURNS nil — so
+  ;; `render-to-string` does NOT throw. This is precisely the
+  ;; recover-to-nil case that bypasses build-full-response's render-time
+  ;; catch arm.
+  (rf/reg-sub :throwing-sub (fn [_db _] (throw (ex-info "sub-boom" {}))))
+  ;; The root-view derefs the throwing sub during the render walk. The
+  ;; deref returns nil (recovered), so the view renders without throwing —
+  ;; the HTML is structurally "fine" but semantically broken (the sub's
+  ;; intended content is missing). That is the exact "silent 200 with
+  ;; recovered-to-nil broken HTML" the spec forbids.
+  (rf/reg-view* :pages/uses-throwing-sub
+    (fn []
+      (let [v @(rf/subscribe [:throwing-sub])]
+        [:main.broken
+         [:h1 "header that renders"]
+         [:p (str "value: " v)]]))))
+
+;; ===========================================================================
+;; Test 1 — render-time sub-throw fails closed to 500 on the wire (the
+;;          tripwire). Without the rf2-c0bq1 re-flush this ships a silent
+;;          200; with it the buffered fail-closed 500 reaches the wire.
+;; ===========================================================================
+
+(deftest rendertime-sub-throw-fails-closed-to-500-on-the-wire
+  (testing "rf2-c0bq1: a reactive subscription that THROWS during the
+            render walk under production hardening
+            (`interop/debug-enabled? = false`) must fail-closed to a 500
+            on the wire — NOT a silent 200 with the recovered-to-nil
+            broken HTML (Spec 011 §744 / §750). Driven through the REAL
+            ssr-handler order (read-get-response-then-render), the order
+            the rf2-vvwmi/vdk33 attribution test inverted. Before the
+            rf2-c0bq1 re-flush this shipped 200 (the buffered 500 was read
+            BEFORE the render that buffers it, then dropped at
+            frame-destroy)."
+    (register-throwing-sub-view!)
+    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (let [handler (ssr-ring/ssr-handler
+                    {:on-create [:init/ok]
+                     :root-view [:pages/uses-throwing-sub]
+                     :ssr       {:public-error-id   :rf.ssr/default-error-projector
+                                 :dev-error-detail? false}
+                     :payload :rf.ssr.payload/whole-app-db})]
+      ;; Production hardening — the dev-only trace listener elides; the
+      ;; always-on error-emit substrate is the status source of truth.
+      (with-redefs [interop/debug-enabled? false]
+        (testing "direct in-process handler call — render-time sub-throw
+                  fails closed to 500 (the buffered fail-closed status,
+                  re-flushed after the render walk per rf2-c0bq1)"
+          (let [response (handler {:uri "/uses-throwing-sub" :request-method :get})]
+            (is (= 500 (:status response))
+                "render-time sub-throw → buffered fail-closed 500 re-read
+                 AFTER the render walk → ring :status 500. Before the
+                 rf2-c0bq1 re-flush this was a silent 200 (the stale
+                 pre-render status materialised onto the wire).")))
+
+        (testing "bytes-on-the-wire through Jetty — the 500 survives the
+                  full round-trip"
+          (with-jetty [port handler]
+            (let [client (new-http-client)
+                  {:keys [status]} (http-get client port "/uses-throwing-sub")]
+              (is (= 500 status)
+                  "the render-time sub-throw fail-closed 500 rides the
+                   full Jetty round-trip — never a silent 200"))))))))
+
+;; ===========================================================================
+;; Test 2 — the happy path is unaffected (last-write-wins / empty-buffer
+;;          no-op). A clean reactive sub renders 200 through the same
+;;          re-flushing path.
+;; ===========================================================================
+
+(deftest happy-path-clean-sub-stays-200-after-reflush
+  (testing "rf2-c0bq1: the post-render re-flush is benign for the happy
+            path — a render walk with NO buffered error leaves the buffer
+            empty, the drain is a no-op, and the response keeps its
+            default 200. Confirms the fix is last-write-wins, not a
+            blanket status rewrite."
+    (rf/reg-sub :clean-sub (fn [_db _] :ok))
+    (rf/reg-view* :pages/uses-clean-sub
+      (fn []
+        (let [v @(rf/subscribe [:clean-sub])]
+          [:main [:h1 "clean"] [:p (str "value: " v)]])))
+    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (let [handler (ssr-ring/ssr-handler
+                    {:on-create [:init/ok]
+                     :root-view [:pages/uses-clean-sub]
+                     :ssr       {:public-error-id   :rf.ssr/default-error-projector
+                                 :dev-error-detail? false}
+                     :payload :rf.ssr.payload/whole-app-db})]
+      (with-redefs [interop/debug-enabled? false]
+        (let [response (handler {:uri "/uses-clean-sub" :request-method :get})]
+          (is (= 200 (:status response))
+              "clean render → empty error buffer → re-flush no-op → 200")
+          (is (str/includes? (:body response) "value: :ok")
+              "the clean sub's value rendered into the wire HTML"))))))

--- a/implementation/ssr/test/re_frame/ssr_sub_exception_two_frame_attribution_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_sub_exception_two_frame_attribution_test.clj
@@ -40,10 +40,34 @@
        `:exception` / message / internal detail across the HTTP
        boundary).
 
+  ## SCOPE — core/accumulator layer ONLY (rf2-c0bq1)
+
+  IMPORTANT: this suite drives `(rf/subscribe-once …)` FIRST — which runs
+  the sub body SYNCHRONOUSLY and buffers the projected status — and reads
+  `(ssr/get-response …)` AFTER. That is the INVERSE of the reference Ring
+  handler order, which reads `get-response` ONCE *before* the render walk
+  (the walk being where a reactive sub actually throws). So this suite
+  proves the listener / accumulator / per-frame-attribution layer is
+  correct, but it does NOT — and must not be read as — proof that the
+  fail-closed 500 reaches the WIRE. rf2-c0bq1 documented exactly that
+  false-confidence trap: the reference adapter shipped a silent 200 for a
+  render-time sub-throw despite every assertion here being green, because
+  the adapter read the (empty) buffer before the render that fills it.
+
+  The WIRE/end-to-end fail-closed contract is pinned by the handler-level
+  tripwire `re-frame.ssr.ring-rendertime-sub-failclosed-test` (ssr-ring
+  artefact), which drives a render-time throwing sub through the REAL
+  read-then-render handler order and asserts a non-200 on the wire. Do not
+  extend THIS suite to cover the wire path — the layering split is
+  deliberate (this = core attribution; that = adapter wire ordering).
+
   Companion suites:
     - `ssr_error_two_frame_attribution_test`     — two-frame, DEV path.
     - `ssr_error_projector_substrate_test`       — always-on path, single frame.
-    - `re-frame.trace-test`                      — the core sub-exception emit site."
+    - `re-frame.trace-test`                      — the core sub-exception emit site.
+    - `re-frame.ssr.ring-rendertime-sub-failclosed-test` (ssr-ring) — the
+      WIRE-level fail-closed tripwire that this suite's inverse ordering
+      could NOT prove (rf2-c0bq1)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
@@ -99,6 +123,12 @@
         ;; Both frames are live registered server frames — the exact
         ;; >1-server-frame shape the removed fallback could not handle.
         ;; frame-a derefs the throwing sub; frame-b derefs the clean one.
+        ;;
+        ;; rf2-c0bq1 — NOTE THE ORDERING: subscribe-once (runs the sub,
+        ;; buffers the status) THEN get-response. This is the INVERSE of
+        ;; the Ring handler (get-response-then-render). It proves the core
+        ;; attribution layer, NOT the wire. The wire fail-closed contract
+        ;; lives in `ring-rendertime-sub-failclosed-test`.
         (rf/subscribe-once fa [:throwing-sub])
         (rf/subscribe-once fb [:clean-sub])
 


### PR DESCRIPTION
## rf2-c0bq1 (P1 BUG) — render-time sub-exception fail-closed 500 was LOST on the wire

The `vvwmi` fix correctly **buffers** a fail-closed 500 when a reactive sub throws mid-`render-to-string` under production hardening (`debug=false`), but the reference Ring adapter **defeated it end-to-end** — shipping a silent HTTP 200 with recovered-to-nil broken HTML, breaking the Spec 011 §744/§750 contract (*"fail-closed, never a silent 200"*) that Mike's ruled `vvwmi`=A exists to guarantee.

### Root cause (handler ordering)
1. `ssr-handler` reads `ssr/get-response` **once** at `ring.clj:343` — **before** the render walk. Buffer empty → default 200.
2. The reactive sub throws **during** the render walk in `build-full-response*` (`pipeline.clj`). Under `debug=false` the sub-run recovers to `nil` (so `render-to-string` does **not** throw) but the always-on error-emit substrate (vvwmi) **buffers** a fail-closed 500.
3. `build-full-response*` materialised the wire response from the **stale pre-render** `resp` (200). The buffered 500 sat unread until frame-destroy dropped it.
4. The only post-render re-flush is the `build-full-response` catch arm — gated on `render-to-string` actually throwing, which a recovered-to-nil sub never reaches.

Same *get-response-before-render / safe-by-timing-only* class as rf2-lia3i, but the **worse direction** (lost fail-closed).

### The fix (honors vvwmi=A — minimal, low-blast-radius)
Re-flush the response accumulator **after** the render walk in `build-full-response*` via `ssr/flush-response!`, and materialise from the post-render response. The buffered fail-closed 500 now reaches the wire.
- **Happy path unaffected** — no buffered error → empty buffer → drain is a no-op → status stays the pre-render default 200 (last-write-wins).
- **Redirect precedence preserved** — `apply-error-projection!` refuses to overwrite a redirect response.

### Tests
- **NEW handler-level tripwire** `ring_rendertime_sub_failclosed_test` — drives a render-time throwing reactive sub through the **real** handler order (read-then-render) and asserts a **non-200 (500)** on the wire, in-process **and** through a real Jetty round-trip. Plus a happy-path test confirming a clean sub stays 200 after the re-flush.
  - **Proven to FAIL without the fix**: temporarily reverting the re-flush reproduces the silent-200 (`actual: (not (= 500 200))`) on both assertions; restoring it → green.
- **Corrected the false-green vdk33 test** — `ssr_sub_exception_two_frame_attribution_test` calls `subscribe-once` then `get-response` (the **inverse** of the handler order), so it proved the core attribution layer but gave false end-to-end confidence. Added a docstring + call-site note documenting the trap and pointing at the new wire-level tripwire.

### Not in scope
- The bead flags an **alternative** (rethrow the sub under server-frame + `debug=false` so it propagates to the existing render-time catch). **Not taken** — it changes the recover-to-nil core behaviour and needs a separate Mike ruling. The re-flush honors the already-ruled vvwmi=A and is the minimal correct fix. Noted for awareness.
- **No spec change**: Spec 011 §744/§750 already mandate this contract (the reference adapter simply didn't fulfil it end-to-end).
- rf2-sccp5 (the second emit-site projection-skip, P3) is a separate held bead in this area — deliberately **not** folded in.

### Gates (cold, from `implementation/`)
- `npm run test:cljs` — 5616 tests / 19562 assertions, 0 failures
- ssr-ring JVM `clojure -M:test` — 110 tests / 477 assertions, 0 failures
- ssr JVM `clojure -M:test` — 263 tests / 911 assertions, 0 failures

Closes rf2-c0bq1.
