### PR TITLE
fix(http): apply 2-arg clear-in-flight! to schedule-backoff-handle! abort-fn (rf2-meq28)

### DIFF
--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -973,21 +973,56 @@
   (let [{:keys [request-id actor-id]} ctx
         fired?     (atom false)
         timer-cell (atom nil)
+        ;; rf2-meq28 — forward-reference cell for the stamped handle, the
+        ;; same idiom as `timer-cell` here and `handle-holder` in
+        ;; `run-attempt!` (rf2-lz7se). The abort-fn is constructed before
+        ;; `record-in-flight!` returns the handle, so it cannot close over
+        ;; `handle` lexically; it reads it lazily through `@handle-cell` at
+        ;; fire time (always after registration completes).
+        handle-cell (atom nil)
         abort-fn   (fn [reason]
                      ;; Win the once-only transition; a concurrent timer
                      ;; fire that loses here bails without retrying.
                      (when (compare-and-set! fired? false true)
                        (when-let [t @timer-cell]
                          (interop/clear-timeout! t))
-                       ;; Drop the backoff handle from both indexes — the
-                       ;; same teardown a live-fetch abort performs.
-                       (registry/clear-in-flight! request-id)
+                       ;; rf2-meq28 — drop the backoff handle from both
+                       ;; indexes via the 2-arg `clear-in-flight!`, passing
+                       ;; the stamped handle (through `@handle-cell`) so the
+                       ;; actor-in-flight slot is cleared BY IDENTITY,
+                       ;; independent of whether `request-id` is non-nil.
+                       ;; This mirrors the rf2-lz7se fix at the live-fetch
+                       ;; abort-fn in `run-attempt!` and the by-identity
+                       ;; clear the timer-fires path below already uses.
+                       ;; The earlier 1-arg form resolved by request-id and
+                       ;; no-op'd on a nil id — correct only under the
+                       ;; implicit, load-bearing invariant that an anonymous
+                       ;; (request-id-less, issued-from-actor) request can be
+                       ;; aborted SOLELY via actor-destroy (which eager-
+                       ;; dissocs the actor slot first). An anonymous request
+                       ;; can carry a `:retry` config and sit in this backoff
+                       ;; window with `actor-id` set / `request-id` nil; any
+                       ;; future non-pre-clearing trigger (frame-level
+                       ;; abort-all, timeout-driven abort of a sleeping retry)
+                       ;; would strand the handle. Passing the handle drops
+                       ;; that fragility: the 2-arg `remove-from-actor-index!`
+                       ;; is an identity-based vector remove that no-ops
+                       ;; against an already-cleared (or absent) slot, so it
+                       ;; is a safe idempotent no-op on the actor-destroy path
+                       ;; while closing the gap for any future trigger.
+                       (registry/clear-in-flight! request-id @handle-cell)
                        (dispatch-aborted! ctx reason)))
         handle     (registry/record-in-flight!
                      request-id actor-id
                      {:abort-fn   abort-fn
                       :url        (:url ctx)
                       :sensitive? (true? (:sensitive? ctx))})
+        ;; rf2-meq28 — publish the stamped handle so the abort-fn closure
+        ;; (defined above, before `handle` was bound) can pass it to the
+        ;; 2-arg `clear-in-flight!` via `@handle-cell`. The reset! happens
+        ;; synchronously here, before the timer is armed, so the cell is
+        ;; always populated by the time any abort can fire.
+        _          (reset! handle-cell handle)
         ;; Schedule AFTER registering so the request is cancellable the
         ;; instant the timer is armed. The callback wins/loses the same
         ;; `fired?` CAS: on a win it clears its own handle and proceeds;

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -26,13 +26,18 @@
       cleans the actor-in-flight index (rf2-lz7se)
    6b. Registry-level: 2-arg clear-in-flight! empties an anonymous
        handle's actor slot without a pre-clear (the unconditional-
-       correctness guarantee); 1-arg form leaks it (rf2-lz7se)"
+       correctness guarantee); 1-arg form leaks it (rf2-lz7se)
+   6c. `schedule-backoff-handle!`'s abort-fn cleans an anonymous
+       (request-id-less) backoff handle's actor slot when fired by a
+       trigger that does NOT pre-clear the actor slot — the sibling of
+       (6b) at the second abort-fn site (rf2-meq28)"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.http-managed :as http-managed]
             [re-frame.http-registry :as http-registry]
+            [re-frame.http-transport :as http-transport]
             [re-frame.machines :as machines]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -501,3 +506,50 @@
         ;; Clean up via the correct form so the fixture leaves a clean registry.
         (http-registry/clear-in-flight! nil h2)
         (is (empty? (http-managed/actor-in-flight-snapshot)))))))
+
+;; ---- (6c) the SECOND abort-fn site — schedule-backoff-handle! (rf2-meq28) ---
+;; ----      sibling of (6b): a backoff-window abort fired WITHOUT a -----------
+;; ----      pre-clear must clean the anonymous handle's actor slot -----------
+
+(def ^:private schedule-backoff-handle!
+  @#'http-transport/schedule-backoff-handle!)
+
+(deftest backoff-abort-fn-cleans-anonymous-handle-without-actor-slot-preclear
+  (testing "schedule-backoff-handle!'s abort-fn — the SECOND of two structurally-identical abort-fns — cleans an anonymous (request-id-less, issued-from-actor) backoff handle's actor-in-flight slot when fired by a trigger that does NOT pre-clear the slot first. This is the rf2-meq28 sibling of (6b): the abort-fn now passes its in-scope handle to the 2-arg clear-in-flight!, so the actor slot is removed by identity regardless of the nil request-id. The earlier 1-arg form no-op'd on the nil id and stranded the handle under any abort trigger that does not pre-clear (actor-destroy's eager dissoc was the only thing masking the leak)"
+    (http-managed/clear-all-in-flight!)
+    (let [actor-id :worker/anon-backoff#1
+          ;; Anonymous request sitting in a backoff window: request-id nil,
+          ;; actor-id set. A request issued from inside a spawned actor with
+          ;; a `:retry` config and no `:request-id` lands here. The ctx
+          ;; silences its reply via explicit `:on-failure nil` so the
+          ;; abort-fn's `dispatch-aborted!` reply-dispatch is a clean no-op,
+          ;; isolating this test on the registry teardown.
+          ctx      {:request-id          nil
+                    :actor-id            actor-id
+                    :url                 "http://x/anon-backoff"
+                    :sensitive?          false
+                    :explicit-on-failure {:supplied? true :value nil}}
+          ;; A very long delay so the retry timer never fires during the
+          ;; test — the abort-fn wins the once-only `fired?` CAS and the
+          ;; timer callback (which would otherwise also reach the registry)
+          ;; bails on its lost CAS.
+          _        (schedule-backoff-handle! ctx 600000)
+          slot     (get (http-managed/actor-in-flight-snapshot) actor-id)
+          handle   (first slot)]
+      (is (= 1 (count slot))
+          "the anonymous backoff handle is registered solely in the actor-in-flight index")
+      (is (empty? (http-managed/in-flight-snapshot))
+          "anonymous backoff handle is absent from the request-id index (request-id is nil)")
+      (is (nil? (:request-id handle))
+          "the registered backoff handle carries no :request-id — the leak vector the 1-arg form left open")
+      ;; Fire the abort-fn DIRECTLY (the abort trigger) WITHOUT touching the
+      ;; actor slot first — this simulates a future non-pre-clearing trigger
+      ;; (frame-level abort-all, a timeout-driven abort of a sleeping retry).
+      ;; Before rf2-meq28 the abort-fn's 1-arg clear-in-flight! no-op'd on the
+      ;; nil id and the handle stranded here; the 2-arg form (the fix) removes
+      ;; it from the actor index by identity.
+      ((:abort-fn handle) :actor-destroyed)
+      (is (empty? (http-managed/actor-in-flight-snapshot))
+          "the backoff abort-fn's handle-passing 2-arg clear-in-flight! removed the anonymous handle from the actor index — no stranded slot")
+      (is (empty? (http-managed/in-flight-snapshot))
+          "request-id index remains empty"))))


### PR DESCRIPTION
## Summary

Round-2 finding `rf2-meq28` (re-review of `rf2-lz7se`): the lz7se fix was applied to only **one of two** structurally-identical abort-fns in `http_transport.cljc`. This applies the same idiom to the second site.

`rf2-lz7se` made `run-attempt!`'s live-fetch abort-fn pass the stamped handle to the **2-arg** `clear-in-flight!` (via a `handle-holder` forward-reference atom), so an anonymous-from-actor request's `actor-in-flight` slot is cleared **by identity** regardless of a nil `request-id`. But `schedule-backoff-handle!`'s abort-fn (`:984` before) still used the fragile **1-arg** `(clear-in-flight! request-id)` — even though its own timer-fires callback (`:998`) already used the 2-arg form.

### The latent leak
An anonymous-from-actor request can carry a `:retry` config and sit in a backoff window with `actor-id` set / `request-id` nil. A future non-pre-clearing abort trigger (frame-level abort-all, a timeout-driven abort of a sleeping retry) would strand the handle in `actor-in-flight` permanently — the exact latent leak lz7se eliminated, at the second site. It does **not** manifest today only because `abort-on-actor-destroy` eager-dissocs the actor slot before firing the abort-fn — the same implicit, load-bearing invariant lz7se set out to remove.

## Fix (file:line)
`implementation/http/src/re_frame/http_transport.cljc`, `schedule-backoff-handle!`:
- Add a `handle-cell` forward-reference atom (same idiom as the existing `timer-cell` here and `handle-holder` in `run-attempt!`), `reset!` after `record-in-flight!` returns the stamped handle.
- abort-fn: `(registry/clear-in-flight! request-id)` → `(registry/clear-in-flight! request-id @handle-cell)`.
- One-line cross-reference comment to lz7se so the two abort teardowns read as the single intended by-identity shape.

The once-only `fired?` CAS guard and the backoff timing (`set-timeout!` + `delay-ms`) are untouched. The 2-arg `remove-from-actor-index!` is an identity-based vector remove that no-ops against an already-cleared slot, so it stays a safe idempotent no-op on the actor-destroy path while closing the gap for any future trigger.

### Symmetry with lz7se
After this change, **both** file-level abort-fns (`run-attempt!` + `schedule-backoff-handle!`) use the 2-arg by-identity form, and **both** paths inside `schedule-backoff-handle!` (abort + timer-fires) agree — the internal and cross-fn divergences the bead flagged are gone.

## Test
`(6c) backoff-abort-fn-cleans-anonymous-handle-without-actor-slot-preclear` in `http_actor_destroy_cancellation_test.clj` — the sibling of the lz7se `(6b)` registry-level test. Registers an anonymous backoff handle via `schedule-backoff-handle!`, fires its recorded `:abort-fn` directly via a trigger that does **not** pre-clear the actor slot, asserts the handle is removed from `actor-in-flight` (strand-cleaned, not leaked). Reply silenced via explicit `:on-failure nil` to isolate the registry teardown.

## Quality gates (green cold)
- http JVM (`clojure -M:test`): **323 tests / 1562 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5616 tests / 19562 assertions, 0 failures, 0 errors**

Closes rf2-meq28.