### PR TITLE
fix(story-mcp): close :large?-blind under-scrub in derived-tree redaction (rf2-f3kf7)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
@@ -48,11 +48,15 @@
   Value-matching is a heuristic; its one collateral hazard is a
   sensitive path holding a SHORT/COMMON scalar (`0`, `200`, `:ok`),
   which would scrub every benign leaf that equals it. `sensitive-values`
-  guards that (rf2-g7cd1) by dropping any candidate that ALSO appears at
-  a NON-sensitive app-db path — such a value is already disclosed
-  verbatim by the path-based `:app-db` egress, so excluding it leaks
-  nothing new while restoring the benign leaves. See `sensitive-values`
-  for the fail-SAFE argument."
+  guards that (rf2-g7cd1, hardened rf2-f3kf7) by dropping any candidate
+  that ALSO appears, VERBATIM, in the POST-elision `:app-db` (the actual
+  wire bytes) — such a value is already disclosed by the path-based
+  `:app-db` egress, so excluding it leaks nothing new while restoring the
+  benign leaves. Classifying against the elided db (not the raw db) is
+  load-bearing: a secret aliased into a `:large?`-declared subtree is
+  replaced by the `:rf.size/large-elided` marker on the wire, so it is NOT
+  disclosed and MUST stay redacted. See `sensitive-values` for the
+  fail-SAFE argument."
   (:require [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]
             [re-frame.mcp-base.elision :as base-elision]
@@ -140,10 +144,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- under-prefix?
-  "True when `path` is `prefix` or descends from it (element-wise
-  prefix match). Both are indexed vectors. Used to decide whether an
-  app-db position is governed by a declared-`:sensitive?` path — a slot
-  marked sensitive covers itself AND everything beneath it."
+  "True when `path` is `prefix` or descends from it (element-wise prefix
+  match). Both are indexed vectors. Used to decide whether an app-db
+  position is governed by a declared-`:sensitive?` path — a slot marked
+  sensitive covers itself AND everything beneath it."
   [prefix path]
   (let [pn (count prefix)]
     (and (<= pn (count path))
@@ -153,46 +157,93 @@
              (= (nth prefix i) (nth path i)) (recur (inc i))
              :else                           false)))))
 
-(defn- collect-public-values!
-  "Walk `node` at `path`, conj!ing onto transient set `acc!` every value
-  (intermediate collections AND leaves) that (a) is `=` to a candidate
-  secret and (b) sits at a position NOT governed by any sensitive
-  prefix. A value reached only under a sensitive prefix is never
-  collected, so it cannot dilute the candidate set. Returns `acc!`.
+(defn- collect-governed-values!
+  "Walk the RAW `node` at `path`, conj!ing onto transient set `acc!` every
+  scalar value sitting at (or beneath) a `:sensitive?` prefix — the
+  candidate secrets. Returns `acc!`.
 
-  Map keys are walked at the same `path` as their entry (a key is not a
-  distinct app-db segment), so a candidate used as a benign key at a
-  non-sensitive position also counts as public."
-  [acc! node path sensitive-prefixes candidates]
+  Indexing MIRRORS `elide-wire-value`'s walk so a declared path lands on
+  the SAME node the elider redacts: maps descend by key, vectors AND seqs
+  descend by integer index (the fix for the seq-indexed `[:tokens 0]`
+  facet — `get-in` cannot read a seq index, so the old candidate-by-`get-in`
+  extraction silently dropped seq-indexed secrets => under-scrub), and
+  sets are walked at their own path (set elements have no stable index, so
+  a whole sensitive-declared set contributes all its members).
+
+  Only governed positions contribute, and `nil` / boolean leaves are
+  skipped (a `nil`/`false` is not a secret and value-matching it would
+  scrub swathes of benign tree). Collections that ARE governed still
+  recurse so nested scalars under a sensitive subtree are all collected."
+  [acc! node path sensitive-prefixes]
   (let [governed? (some #(under-prefix? % path) sensitive-prefixes)]
-    (when (and (not governed?) (contains? candidates node))
+    (when (and governed?
+               (not (coll? node))
+               (not (nil? node))
+               (not (boolean? node)))
       (conj! acc! node))
     (cond
       (map? node)
       (reduce-kv (fn [a k v]
-                   (collect-public-values! a k path sensitive-prefixes candidates)
-                   (collect-public-values! a v (conj path k) sensitive-prefixes candidates))
+                   (collect-governed-values! a v (conj path k) sensitive-prefixes))
                  acc! node)
 
       (vector? node)
-      (reduce (fn [a i] (collect-public-values! a (nth node i) (conj path i)
-                                                sensitive-prefixes candidates))
+      (reduce (fn [a i] (collect-governed-values! a (nth node i) (conj path i)
+                                                  sensitive-prefixes))
               acc! (range (count node)))
 
-      (or (set? node) (seq? node))
-      ;; Sets / seqs have no stable path segment for elements, so we walk
-      ;; them at the SAME path (the collection's own position). Membership
-      ;; is what matters for value-aliasing, not the index.
-      (reduce (fn [a x] (collect-public-values! a x path sensitive-prefixes candidates))
+      (seq? node)
+      (let [idx (volatile! -1)]
+        (reduce (fn [a x]
+                  (collect-governed-values! a x (conj path (vswap! idx inc))
+                                            sensitive-prefixes))
+                acc! node))
+
+      (set? node)
+      ;; Sets have no stable element index; walk members at the set's own
+      ;; path so a sensitive-declared set contributes every member.
+      (reduce (fn [a x] (collect-governed-values! a x path sensitive-prefixes))
               acc! node)
 
       :else
       acc!)))
 
+(defn- collect-wire-values!
+  "Walk the POST-elision `node`, conj!ing onto transient set `acc!` every
+  value (intermediate collections AND leaves) that is `=` to a candidate
+  secret. `node` is the elided `:app-db` — the actual wire bytes — so any
+  candidate found here is one the path-based `:app-db` egress ships
+  VERBATIM. Returns `acc!`.
+
+  Because the input is already elided, every `:sensitive?` slot is the
+  `:rf/redacted` sentinel and every `:large?` (or auto-detected) slot is
+  the `:rf.size/large-elided` marker — the secret value simply is not
+  present at any governed position, so there is no path-shape reasoning to
+  get right (no prefix walk, no seq-index correction). Membership is the
+  only question; map keys, vector elements, and set/seq elements are all
+  walked, since a candidate aliased to ANY surviving wire position is
+  disclosed."
+  [acc! node candidates]
+  (when (contains? candidates node)
+    (conj! acc! node))
+  (cond
+    (map? node)
+    (reduce-kv (fn [a k v]
+                 (collect-wire-values! a k candidates)
+                 (collect-wire-values! a v candidates))
+               acc! node)
+
+    (coll? node)
+    (reduce (fn [a x] (collect-wire-values! a x candidates))
+            acc! node)
+
+    :else
+    acc!))
+
 (defn- sensitive-values
   "The set of live values sitting at `variant-id`'s declared-`:sensitive?`
-  app-db paths, read out of `app-db`. Used to value-redact derived trees
-  (rendered hiccup, effective-args, snapshot) where the same value
+  app-db paths, read out of the RAW `app-db`. Used to value-redact derived
+  trees (rendered hiccup, effective-args, snapshot) where the same value
   reappears at a non-app-db path the path-based walker can't reach.
 
   Refreshes the schema-owned declarations first (the elision registry is
@@ -201,7 +252,7 @@
   or `false` leaf is not a secret and value-matching them would scrub
   swathes of benign tree.
 
-  ## Non-unique-secret guard (rf2-g7cd1)
+  ## Non-unique-secret guard (rf2-g7cd1, hardened rf2-f3kf7)
 
   Value-based redaction is a heuristic: it substitutes EVERY derived-tree
   leaf `=` a sensitive value. When a sensitive path holds a short/common
@@ -209,31 +260,51 @@
   every benign leaf that merely happens to equal it — degrading the
   agent's view AND leaking the secret's value-CLASS.
 
-  The guard subtracts any candidate value that ALSO appears at a
-  NON-sensitive app-db position. Such a value is provably NOT a protected
-  secret: `elide-app-db` (path-based) ships it VERBATIM in the `:app-db`
-  slot via that non-sensitive path, so it is already disclosed on the
-  wire. Removing it from the derived-tree secret set therefore leaks
-  nothing new — the fail-SAFE invariant (never leak a genuine secret)
-  holds by construction. A value that appears ONLY under sensitive paths
-  stays in the set and is still redacted everywhere (no under-scrub); the
-  irreducible same-value aliasing case (a uniquely-secret short scalar)
-  still over-scrubs — that residual is fail-SAFE, never under-safe."
+  The guard subtracts any candidate value that ALSO appears, VERBATIM, on
+  the wire — i.e. in the POST-elision `:app-db` (`elide-app-db` of the raw
+  db). Such a value is provably NOT a protected secret: the path-based
+  `:app-db` egress already discloses it, so removing it from the
+  derived-tree secret set leaks nothing new — the fail-SAFE invariant
+  (never leak a genuine secret) holds by construction.
+
+  Classifying against the elided db (rather than the raw db) is the
+  correction for rf2-f3kf7: the original guard walked the RAW db, so a
+  secret that ALSO lived under a `:large?`-declared non-sensitive path was
+  seen at that position and dropped from the secret set — yet
+  `elide-app-db` replaces a `:large?` slot with the `:rf.size/large-elided`
+  marker, so the secret was NOT on the wire and then leaked VERBATIM into
+  the derived trees. Reasoning against the actual wire bytes closes that
+  hole AND is robust to any future elision class (digests, new markers,
+  the string auto-detect threshold), not just `:large?` — and it subsumes
+  the seq-indexed `:sensitive?` edge (an indexed element redacted by
+  `elide-wire-value` simply does not appear in the elided db).
+
+  A value that survives ONLY under sensitive / large positions (so is
+  absent from the elided db) stays in the set and is redacted everywhere
+  (no under-scrub); the irreducible same-value aliasing case (a
+  uniquely-secret short scalar) still over-scrubs — that residual is
+  fail-SAFE, never under-safe."
   [app-db variant-id]
   (refresh-elision-from-schemas! variant-id)
   (let [decls              (rf/elision-sensitive-declarations variant-id)
         sensitive-prefixes (mapv vec (keys decls))
-        candidates         (into #{}
-                                 (comp (map (fn [path] (get-in app-db path ::absent)))
-                                       (remove #(or (= ::absent %) (nil? %) (boolean? %))))
-                                 sensitive-prefixes)]
+        ;; Collect candidate secrets by WALKING the raw db at governed
+        ;; positions (mirroring the elider's indexing) rather than reading
+        ;; each declared path with `get-in` — `get-in` cannot index into a
+        ;; seq, so seq-indexed declarations (`[:tokens 0]`) would otherwise
+        ;; silently yield no candidate and the secret would leak.
+        candidates         (persistent!
+                             (collect-governed-values! (transient #{}) app-db []
+                                                        sensitive-prefixes))]
     (if (empty? candidates)
       #{}
-      (let [public (persistent!
-                     (collect-public-values! (transient #{}) app-db []
-                                              sensitive-prefixes candidates))]
-        ;; Keep only candidates that appear EXCLUSIVELY under sensitive
-        ;; paths — those are the genuinely-secret values.
+      ;; Classify "public" against the actual wire bytes: the elided
+      ;; app-db. A candidate present here is shipped verbatim by the
+      ;; :app-db egress (already disclosed) so it is dropped; one that is
+      ;; absent (redacted / elided away) stays redacted in derived trees.
+      (let [wire   (rf/elide-wire-value app-db {:frame variant-id})
+            public (persistent!
+                     (collect-wire-values! (transient #{}) wire candidates))]
         (into #{} (remove public) candidates)))))
 
 (defn- redact-matching

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -2160,11 +2160,12 @@
 ;; scalar (`0`, `200`, `:ok`), naive matching scrubs every benign leaf that
 ;; merely equals it — degrading the agent's view AND leaking the secret's
 ;; value-CLASS. `sensitive-values` guards that: a candidate value that ALSO
-;; sits at a NON-sensitive app-db path is dropped from the secret set, because
-;; the path-based `:app-db` egress already ships that value verbatim (it is
+;; appears, verbatim, in the POST-elision `:app-db` (the actual wire bytes —
+;; hardened from the raw db in rf2-f3kf7) is dropped from the secret set,
+;; because the path-based `:app-db` egress already ships that value (it is
 ;; provably already disclosed, so excluding it leaks nothing new). These tests
 ;; pin BOTH the precision win AND the fail-SAFE invariant (a value that is
-;; UNIQUELY secret — only under sensitive paths — stays redacted).
+;; UNIQUELY secret — absent from the elided db — stays redacted).
 ;; ---------------------------------------------------------------------------
 
 (deftest scrub-rendered-short-scalar-aliased-to-public-path-is-not-over-scrubbed
@@ -2232,6 +2233,112 @@
               "matching leaves are replaced with the :rf/redacted sentinel")
           (is (= "card" (get-in out [1 :class]))
               "benign attribute values survive untouched"))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-f3kf7 — :large?-blind under-scrub (the headline fix).
+;;
+;; The g7cd1 guard dropped any candidate that ALSO appeared at a non-sensitive
+;; app-db path, on the premise that elide-app-db ships such a value verbatim.
+;; That premise is FALSE for a :large?-declared non-sensitive path:
+;; elide-wire-value replaces the slot with the :rf.size/large-elided marker, so
+;; the value is NOT on the wire — yet the old guard walked the RAW db, saw the
+;; secret at the :large? position, classified it public, and dropped it from
+;; the secret set, leaking it VERBATIM into the derived trees. The fix
+;; classifies "public" against the POST-elision :app-db (the actual wire
+;; bytes), so a value masked by ANY elision class stays redacted. These tests
+;; pin the no-under-scrub invariant on the in-scope MCP egress.
+;; ---------------------------------------------------------------------------
+
+(deftest scrub-rendered-secret-aliased-into-large-subtree-stays-redacted
+  (testing "FAIL-SAFE (rf2-f3kf7): a secret at a sensitive path that ALSO lives inside a :large?-declared subtree MUST stay redacted — the :large? slot is the marker on the wire, NOT the verbatim value, so it does not license dropping the secret"
+    (with-clean-frame [vid :story.button/primary]
+      ;; The repro: the token sits at sensitive [:auth :token] AND nested in
+      ;; [:cache :blob], which is :large?-declared. The :app-db egress ships
+      ;; [:cache :blob] as the :rf.size/large-elided marker (token NOT
+      ;; disclosed), so the token must remain a protected secret everywhere.
+      (let [token  "sk-live-DISTINCTIVE-TOPSECRET-9f8a7b6c"
+            db     {:public "ok"
+                    :auth   {:token token}
+                    :cache  {:blob {:size 9001 :payload token}}}
+            ;; Derived trees re-embed the token at non-app-db positions
+            ;; (narrative :db-before/:after, rendered hiccup, snapshot).
+            hiccup [:div [:input {:type "password" :value token}]
+                    [:span "narrative db-before: " token]]]
+        (seed-app-db! vid db)
+        (declare-sensitive! vid [:auth :token])
+        (declare-large! vid [:cache :blob])
+        ;; Sanity: the :app-db egress masks the :large? subtree (token gone)
+        ;; AND redacts the sensitive path — so the token is NOT on the
+        ;; :app-db wire via either route, which is exactly why the derived
+        ;; tree must keep it redacted.
+        (let [elide-app-db (requiring-resolve 're-frame.story-mcp.tools.egress/elide-app-db)
+              wire-db      (elide-app-db db vid false)]
+          (is (not (tree-contains? wire-db token))
+              "the token is NOT shipped verbatim in the :app-db slot (large-masked + sensitive-redacted)")
+          (is (= :rf/redacted (get-in wire-db [:auth :token]))
+              "the sensitive path is redacted in the wire :app-db")
+          (is (contains? (get-in wire-db [:cache :blob]) :rf.size/large-elided)
+              "the :large? subtree is replaced by the marker in the wire :app-db"))
+        (let [scrub-rendered (requiring-resolve 're-frame.story-mcp.tools.egress/scrub-rendered)
+              out            (scrub-rendered hiccup db vid false)]
+          (is (not (tree-contains? out token))
+              "the secret MUST NOT survive anywhere in the derived tree (no under-scrub)")
+          (is (tree-contains? out :rf/redacted)
+              "matching leaves are replaced with the :rf/redacted sentinel")
+          (is (= "narrative db-before: " (get-in out [2 1]))
+              "benign leaves are preserved"))))))
+
+(deftest scrub-rendered-seq-indexed-sensitive-stays-redacted
+  (testing "FAIL-SAFE (rf2-f3kf7 secondary): a seq-indexed :sensitive? declaration [:tokens 0] keeps its element redacted in derived trees — the set/seq same-path walk no longer misclassifies it public"
+    (with-clean-frame [vid :story.button/primary]
+      ;; [:tokens 0] is sensitive and is a UNIQUE value (no benign alias on
+      ;; the wire). The slot is a SEQ (list), the shape the old guard
+      ;; mis-walked: `collect-public-values!` walked set/seq elements at the
+      ;; PARENT path `[:tokens]`, so `under-prefix? [:tokens 0] [:tokens]`
+      ;; returned false (prefix longer than the walk-path) — the element was
+      ;; treated as non-governed/public and dropped from the secret set =>
+      ;; under-scrub. The fix classifies against the POST-elision db, where
+      ;; `elide-wire-value`'s walk-seq HAS indexed + redacted the element, so
+      ;; it never appears at a public wire position and stays in the set.
+      (let [secret "uniq-seq-secret-TOPSECRET"
+            db     {:public "ok"
+                    :tokens (list secret "second-public-token")}
+            hiccup [:ul [:li {:data-idx 0} secret]
+                    [:li {:data-idx 1} "second-public-token"]]]
+        (seed-app-db! vid db)
+        (declare-sensitive! vid [:tokens 0])
+        (let [scrub-rendered (requiring-resolve 're-frame.story-mcp.tools.egress/scrub-rendered)
+              out            (scrub-rendered hiccup db vid false)]
+          (is (not (tree-contains? out secret))
+              "the seq-indexed secret MUST NOT survive in the derived tree (no under-scrub)")
+          (is (tree-contains? out :rf/redacted)
+              "the matching leaf is replaced with the :rf/redacted sentinel")
+          (is (tree-contains? out "second-public-token")
+              "the non-sensitive sibling element survives untouched"))))))
+
+(deftest scrub-rendered-large-aliased-public-scalar-not-over-scrubbed
+  (testing "g7cd1 NOT regressed (rf2-f3kf7): a short sensitive scalar aliased to a PLAIN non-sensitive path is still un-over-scrubbed — the fix only tightens against ELIDED positions, not plain ones"
+    (with-clean-frame [vid :story.button/primary]
+      ;; The g7cd1 common case must survive the elided-db reclassification:
+      ;; 0 sits at sensitive :http-status AND at the PLAIN non-sensitive
+      ;; :retry-count (no :large?, no :sensitive?), so 0 IS on the wire
+      ;; verbatim and must NOT scrub benign 0 leaves.
+      (let [db     {:http-status 0     ; sensitive
+                    :retry-count 0      ; plain non-sensitive, same scalar
+                    :public      "ok"}
+            hiccup [:ul {:tabindex 0}
+                    [:li {:data-level 0} "first"]
+                    [:li {:data-level 0} "second"]]]
+        (seed-app-db! vid db)
+        (declare-sensitive! vid [:http-status])
+        (let [scrub-rendered (requiring-resolve 're-frame.story-mcp.tools.egress/scrub-rendered)
+              out            (scrub-rendered hiccup db vid false)]
+          (is (not (tree-contains? out :rf/redacted))
+              "0 is on the wire at the plain :retry-count path, so it is dropped from the secret set — no benign 0 over-scrubbed (g7cd1 preserved)")
+          (is (= 0 (get-in out [1 :tabindex]))
+              "benign 0 attribute values survive untouched")
+          (is (= 0 (get-in out [2 1 :data-level]))
+              "benign 0 leaves deep in the tree survive"))))))
 
 ;; The two integration tests below pin the WIRING — that `preview-variant`
 ;; and `run-variant` route `:rendered-hiccup` / `:effective-args` / `:snapshot`


### PR DESCRIPTION
## Summary

Closes the **verbatim-secret leak** on the story-mcp AI/MCP egress reported in **rf2-f3kf7** (P2 RISK/BUG, from the R2 story-mcp review). The g7cd1 non-unique-secret guard broke its own no-under-scrub fail-safe invariant.

### The bug

`sensitive-values` (in `tools/story-mcp/.../egress.cljc`) dropped any candidate secret that ALSO appeared at a non-sensitive app-db path, on the premise that `elide-app-db` ships such a value verbatim in the `:app-db` slot. That premise is **FALSE** for a `:large?`-declared non-sensitive path: `elide-wire-value` replaces the slot with the `:rf.size/large-elided` marker, so the value is NOT on the wire — yet the guard walked the **raw** db, saw the secret at the `:large?` position, classified it public, and dropped it from the secret set. The secret then leaked verbatim into every derived/evidence tree (`:rendered-hiccup`, narrative `:db-before`/`:after`, `:snapshot`, `:effective-args`, …).

**Repro:** secret at sensitive `[:auth :token]` AND nested inside a `:large?`-declared `[:cache :blob]`. The `:app-db` ships `[:cache :blob]` as the large-elided marker (token not disclosed); the derived trees shipped the token RAW.

**Secondary facet:** candidates were read via `get-in` at each declared path, but `get-in` cannot index into a seq, so a seq-indexed `:sensitive?` declaration (`[:tokens 0]`) silently yielded no candidate ⇒ the secret leaked.

### The fix (post-elision classification)

Of the two reviewer-recommended options, this takes the more robust one: classify "public" against the **POST-elision `:app-db`** (the actual wire bytes) rather than the raw db. A candidate present in the elided db is genuinely disclosed (dropped, preserving g7cd1); one absent (redacted or large-elided) stays in the secret set. This realises the docstring's "already disclosed on the wire" premise literally and is robust to ANY elision class — `:large?`, sensitive, future digests, the string auto-detect threshold — not just the path-set the original guard reasoned against.

Candidate collection now **walks** the raw db at governed positions, mirroring the elider's indexing (maps by key, vectors AND seqs by integer index, sets at their own path), fixing the seq-indexed facet.

### Tests

- `scrub-rendered-secret-aliased-into-large-subtree-stays-redacted` — the `:large?` repro (proven to FAIL against `origin/main`)
- `scrub-rendered-seq-indexed-sensitive-stays-redacted` — the seq-indexed facet (proven to FAIL against `origin/main`)
- `scrub-rendered-large-aliased-public-scalar-not-over-scrubbed` — g7cd1 common case **not regressed**

Each leak test was verified to fail against the pre-fix code (4 failures) and pass with the fix.

### Gate

`tools/story-mcp/ clojure -M:test`: **212 tests / 1071 assertions, 0 failures, 0 errors** (cold).

### Scope

`tools/story-mcp/` only (egress.cljc + tests). No shared `implementation/` cljc touched (egress.cljc is tool-side and bundle-isolated), so `npm run test:cljs` is not on this change's path.