### PR TITLE
fix(machines-viz): four :on-done projection-faithfulness gaps (rf2-dblqx + rf2-ay42f + rf2-7i7t3 + rf2-bs3us)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -513,9 +513,22 @@ faithfulness gaps; the `:on-done` projection gap was the parity-relevant
 one (the sibling region-id collision rf2-wnzha is a parse-injectivity
 fix, not a parity row).
 
+A 2026-06-04 R2 re-review (rf2-5nb2v) of the F1 three-emitter projection
+surfaced the F2–F4 follow-ons below: a **compound action-only `:on-done`**
+that F1's mermaid path silently dropped (rf2-ay42f — the G9 "faithful
+across all three" claim was overstated for that shape), the **parallel-root
+anchor** that F1 left clickable as a phantom state (rf2-dblqx — the same
+inert-chip class rf2-34ff3 ruled), and the **parallel-root done-state label**
+that diverged between chart + SCXML (rf2-bs3us). With F2–F4 the three-emitter
+`:on-done` projection is faithful across every reachable Spec 005 shape, and
+the parallel-root anchor is inert.
+
 | Step | Bead | New? | Hot-zone | Notes |
 |---|---|---|---|---|
 | F1 | **rf2-41goo** ✅ — `feat(machines-viz): project :on-done (XState onDone) completion transition (chart + mermaid + scxml)` | existing | isolated (`chart/layout.cljc`, `chart/projection.cljc`, `mermaid.cljc`, `scxml.cljc`, + JVM tests + this doc) | **Closes G9.** `:on-done` was never parsed/projected (zero matches across the three emitters). Now: the COMPOUND completion edge resolves to the SIBLING (`✓ done` chip); the PARALLEL-ROOT completion (action/fx-only) renders as a terminal affordance / mermaid note; the SCXML emitter round-trips the W3C `done.state.<id>` transition. Parses + projects faithfully to the engine's `[:rf.machine/done <path>]` raise. |
+| F2 | **rf2-ay42f** ✅ — `fix(machines-viz): render compound action-only :on-done in mermaid` | new | isolated (`mermaid.cljc` + JVM tests + this doc) | **G9 faithfulness completion.** A COMPOUND whose `:on-done` is ACTION-ONLY (no `:target` — the engine runs an action when the sub-flow completes; the machine stays in the all-final config; a documented Spec 005 shape) surfaced in chart + SCXML but was SILENTLY DROPPED in mermaid (`collect-on-done-edges` kept only target-bearing candidates; the note path covered only the parallel-root). Now mermaid renders a `note right of <compound>` carrying `on-done: ✓ done / <action>` — the same affordance the parallel-root action-only `:on-done` uses — so the completion is visible across **all three** emitters. The G9 "faithful across all three emitters" claim is now accurate for the action-only compound shape. (`collect-compound-on-done-notes` walks the state tree incl. region-nested + deeply-nested compounds.) |
+| F3 | **rf2-dblqx** ✅ — `fix(machines-viz): parallel-root :on-done anchor is inert (not a clickable phantom state)` | new | isolated (`chart/projection.cljc` + JVM tests + this doc) | The synthetic parallel-root completion anchor (F1) fell through the node-`:type` cond to `"state"` AND through the `:onClick` guard (which excluded only `:machine-root?` + region), so it projected as a CLICKABLE `parallel` state box — clicking it dispatched on-state-click against the rendering-sentinel path. The SAME inert-synthetic-chip class **rf2-34ff3** ruled for the machine-root chip + region containers. Fix: type the parallel-root anchor `"machine-root"` (the quiet root-context chip) AND exclude `:parallel-root?` from the `:onClick` guard, mirroring 34ff3. The anchor is now INERT. |
+| F4 | **rf2-bs3us** ✅ — `fix(machines-viz): align chart parallel-root done-state label to SCXML` | new | isolated (`chart/layout.cljc`, `chart/projection.cljc`, `scxml.cljc` + JVM tests + this doc) | The chart's parallel-root `:doneState` label was the degenerate `"done.state."` (the root sentinel path `[]` has an EMPTY `node-id`), diverging from the SCXML emitter's `"done.state.rf2_parallel_root"`. Fix: a shared canonical sentinel id (`layout/parallel-root-done-state-id` = `"rf2_parallel_root"`) is the SINGLE SOURCE OF TRUTH both the chart `:doneState` renderer label and the SCXML `<parallel id=...>` / `done.state.<id>` event read from, so the two emitters agree. Pure label fix (not load-bearing for topology / round-trip). |
 
 > **Sibling note (rf2-wnzha — same review pass, NOT a parity row):**
 > parallel regions sharing a state NAME minted COLLIDING node-ids (the

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -394,6 +394,20 @@
   root sentinel `[]`, distinct from this rendering anchor."
   :rf.machines-viz.layout/parallel-root)
 
+(def parallel-root-done-state-id
+  "rf2-bs3us — the canonical id string for the whole-parallel completion
+  signal (`done.state.<this>`). The engine raises `done.state` for the
+  parallel root with the root sentinel path `[]`, whose `node-id` is the
+  EMPTY string — so a naive `(str \"done.state.\" (node-id done-path))` for
+  the parallel-root yields the degenerate `\"done.state.\"` (trailing dot,
+  no id). This stable, non-empty sentinel id is the SINGLE SOURCE OF TRUTH
+  shared by the chart projector's `:doneState` renderer label AND the SCXML
+  emitter's `<parallel id=...>` / `done.state.<id>` event, so the two
+  emitters agree on the parallel-root done-state label (pre-fix the chart
+  said `\"done.state.\"` while SCXML said `\"done.state.rf2_parallel_root\"`).
+  Matches SCXML's `<parallel>` element id convention."
+  "rf2_parallel_root")
+
 (defn region-scoped-id
   "rf2-wnzha — the region-SCOPED node-id for a state at `in-region-path`
   inside the parallel region `region-id`. INJECTIVE ACROSS REGIONS: two
@@ -703,6 +717,26 @@
           (fn [idx [region-id region-def]]
             (let [rid       (region-node-id region-id)
                   parsed    (parse-flat region-def)
+                  ;; rf2-7i7t3 — a region def is a compound state map and MAY
+                  ;; carry a top-level `:on` (a legal Spec 005 region-level
+                  ;; fallback). `parse-flat` mints a synthetic MACHINE-ROOT
+                  ;; node (`{:path [] :machine-root? true}`) + machine-level
+                  ;; edges (rf2-vcnvj) WHENEVER its definition has a top-level
+                  ;; `:on`. But the machine-root concept is a FLAT/top-level-
+                  ;; machine artifact — a region is NOT a machine; it has no
+                  ;; root context (XState v5: a region is just an orthogonal
+                  ;; compound state, its `:on` is an ordinary region-scoped
+                  ;; transition). Pre-fix, that synthetic root node got region-
+                  ;; scoped to a DEGENERATE id (`region-scoped-id :fetch []` =
+                  ;; `"region__fetch__"`, trailing `__` + empty path segment)
+                  ;; and kept `:machine-root? true`, so the projector painted a
+                  ;; stray `root` chip nested INSIDE the region container. We
+                  ;; DROP the synthetic machine-root node here and re-point its
+                  ;; fallback edges' source to the REGION CONTAINER (`rid`)
+                  ;; below, so a region-level `:on` reads as a fallback hanging
+                  ;; off the region — no phantom root.
+                  region-nodes
+                  (remove :machine-root? (:nodes parsed))
                   ;; rf2-wnzha — region-scope every state node-id (so two
                   ;; same-named region states never collide) and re-point
                   ;; a nested-compound child's `:parent-id` to its
@@ -718,17 +752,27 @@
                               :parent-id (if (> (count path) 1)
                                            (region-scoped-id region-id (pop path))
                                            rid))))
-                        (:nodes parsed))
+                        region-nodes)
                   ;; rf2-wnzha — re-key every edge's id/source/target under
                   ;; the region prefix too (an edge to/from a shared-name
                   ;; state would otherwise resolve to the colliding id
                   ;; across regions). `:from-path`/`:to-path` stay the
                   ;; in-region paths the ids derive from.
+                  ;;
+                  ;; rf2-7i7t3 — a region-level machine fallback edge
+                  ;; (`:machine-level? true`, `:from-path []`) would otherwise
+                  ;; region-scope its source to the DEGENERATE `region__<id>__`
+                  ;; (node-id of `[]` is empty) — the dropped phantom root.
+                  ;; Source it from the REGION CONTAINER (`rid`) instead, so the
+                  ;; fallback chip hangs off the region the way the machine-
+                  ;; level fallback hangs off the top-level machine root.
                   scoped-edges
                   (mapv (fn [e]
                           (assoc e
                             :id     (str (region-node-id region-id) "__" (:id e))
-                            :source (region-scoped-id region-id (:from-path e))
+                            :source (if (:machine-level? e)
+                                      rid
+                                      (region-scoped-id region-id (:from-path e)))
                             :target (region-scoped-id region-id (:to-path e))))
                         (:edges parsed))
                   ;; The synthetic region container node.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -699,6 +699,23 @@
                                    ;; context chip (`chart.nodes/machine-root-
                                    ;; node`), not a state box.
                                    (:machine-root? n) "machine-root"
+                                   ;; rf2-dblqx — the synthetic PARALLEL-ROOT
+                                   ;; node (rf2-41goo) is the anchor the
+                                   ;; whole-parallel `:on-done` completion
+                                   ;; affordance hangs off — NOT a statechart
+                                   ;; state. Route it through the quiet
+                                   ;; root-context chip (`machine-root-node`)
+                                   ;; so it reads as the completion anchor, not
+                                   ;; a clickable state box. Pre-dblqx it fell
+                                   ;; through to `"state"` AND carried an
+                                   ;; `:onClick` (the click guard below excluded
+                                   ;; only machine-root + region), so a user
+                                   ;; could click a phantom `parallel` state and
+                                   ;; fire on-state-click against the rendering
+                                   ;; sentinel path. The SAME inert-synthetic-
+                                   ;; chip class rf2-34ff3 fixed for the
+                                   ;; machine-root + region containers.
+                                   (:parallel-root? n) "machine-root"
                                    region?        "parallel-region"
                                    (:compound? n) "compound"
                                    :else          "state")
@@ -747,13 +764,19 @@
                                    ;; states (clickable TITLE STRIP; body stays
                                    ;; pointer-transparent so child-leaf clicks
                                    ;; pass through). The synthetic machine-root
-                                   ;; chip and parallel-region containers are
-                                   ;; NOT `:on-state-click` targets (no region-
-                                   ;; selection concept yet), so they carry no
-                                   ;; `:onClick` the renderer would never
-                                   ;; consume — the inverse of the original
-                                   ;; half-wired bug.
-                                   (not (or (:machine-root? n) region?))
+                                   ;; chip, parallel-region containers, AND the
+                                   ;; synthetic parallel-root completion anchor
+                                   ;; (rf2-dblqx) are NOT `:on-state-click`
+                                   ;; targets (no region-selection concept yet;
+                                   ;; the parallel-root is a completion
+                                   ;; affordance whose path is a rendering
+                                   ;; sentinel, not a real statechart state), so
+                                   ;; they carry no `:onClick` the renderer
+                                   ;; would never consume — the inverse of the
+                                   ;; original half-wired bug.
+                                   (not (or (:machine-root? n)
+                                            (:parallel-root? n)
+                                            region?))
                                    (assoc :onClick on-state-click)
 
                                    region? (assoc :regionId    (:region n)
@@ -936,10 +959,25 @@
                                        ;; `done.state.<id>` label (the node-id
                                        ;; of the done node's path) so a reader
                                        ;; sees WHICH sub-flow completed.
+                                       ;;
+                                       ;; rf2-bs3us — the PARALLEL-ROOT done-
+                                       ;; path is the engine's root sentinel
+                                       ;; `[]`, whose `node-id` is the EMPTY
+                                       ;; string — so the naive form yielded a
+                                       ;; degenerate `"done.state."` (trailing
+                                       ;; dot, no id) that diverged from the
+                                       ;; SCXML emitter's
+                                       ;; `"done.state.rf2_parallel_root"`. Use
+                                       ;; the shared canonical sentinel id for
+                                       ;; the parallel-root so the chart label
+                                       ;; matches SCXML (single source of truth
+                                       ;; in `layout/parallel-root-done-state-id`).
                                        :onDone      (boolean (:on-done? edge))
                                        :doneState   (when (:on-done? edge)
                                                       (str "done.state."
-                                                           (layout/node-id (:done-path edge))))
+                                                           (if (:parallel-root? edge)
+                                                             layout/parallel-root-done-state-id
+                                                             (layout/node-id (:done-path edge)))))
                                        :eventId     event-id
                                        :fromPath    (:from-path edge)
                                        :toPath      (:to-path edge)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -293,6 +293,62 @@
              :label (edge-label "✓ done" candidate)}))
         (transition-candidates on-done)))
 
+(defn- on-done-action-only?
+  "rf2-ay42f — true when an `:on-done` spec is ACTION-ONLY: it has at
+  least one candidate, and EVERY candidate is target-less (the engine just
+  runs an action when the sub-flow completes; the machine stays in the
+  all-final config). A target-bearing candidate routes a `✓ done` edge
+  (`collect-on-done-edges`); a target-less one has no arrow to draw."
+  [on-done]
+  (let [cands (transition-candidates on-done)]
+    (and (seq cands)
+         (every? #(nil? (resolve-target-path [] [] (:target %))) cands))))
+
+(defn- on-done-action-label
+  "rf2-ay42f — the `on-done: ✓ done / <action>` note body for an
+  action-only `:on-done` (the same caption `render-parallel-on-done-note`
+  paints for the parallel-root form). The first candidate's `:action`
+  surfaces when present."
+  [on-done]
+  (let [action (some :action (transition-candidates on-done))]
+    (cond-> "on-done: ✓ done"
+      action (str " / " (label-value action)))))
+
+(defn- collect-compound-on-done-notes
+  "rf2-ay42f — emit a `note right of <compound>` for every COMPOUND state
+  whose `:on-done` is ACTION-ONLY (target-less). Mermaid has no
+  transitionable completion glyph for an action-only done (there is no
+  sibling state to arrow to — the engine just runs the action; the machine
+  stays in the all-final config), so — exactly as the PARALLEL-ROOT
+  action-only `:on-done` is rendered (`render-parallel-on-done-note`) — we
+  render a note carrying `on-done: ✓ done / <action>`.
+
+  Pre-fix, `collect-on-done-edges` kept ONLY target-bearing candidates, so
+  a compound action-only `:on-done` (a documented Spec 005 shape — see
+  `on-done-edges`' docstring in `chart/layout.cljc`) was SILENTLY DROPPED
+  in mermaid while the chart + SCXML emitters surfaced it — breaking the
+  G9 'faithful across all three emitters' parity claim. This closes the
+  asymmetry: a target-bearing compound `:on-done` routes a `✓ done` edge,
+  an action-only one carries a note, so the completion is always visible.
+
+  Walks the state tree the same way `collect-edges` does (compound
+  substates recurse), so a deeply-nested compound's action-only completion
+  is covered too. Returns a flat seq of note lines."
+  [root-path states]
+  (mapcat
+    (fn [[state-id state-node]]
+      (let [state-path (conj (vec root-path) state-id)
+            self       (when (and (:states state-node)
+                                  (on-done-action-only? (:on-done state-node)))
+                         [(str "  note right of " (sanitise-id state-path))
+                          (str "    " (on-done-action-label (:on-done state-node)))
+                          "  end note"])
+            child      (when (:states state-node)
+                         (collect-compound-on-done-notes state-path
+                                                         (:states state-node)))]
+        (concat self child)))
+    states))
+
 (defn- collect-root-fallback-edges
   [root-path on-map]
   (let [source-path (conj (vec root-path) root-fallback-segment)]
@@ -415,7 +471,12 @@
                                fallback-edges)
         edge-lines     (map render-edge edges)
         final-lines    (render-final-edges root-path states)
-        compound-lines (render-compound-blocks root-path states 1)]
+        compound-lines (render-compound-blocks root-path states 1)
+        ;; rf2-ay42f — a COMPOUND whose `:on-done` is action-only
+        ;; (target-less) has no sibling arrow to draw; render its
+        ;; completion as a note so it is not silently dropped (the
+        ;; chart + SCXML emitters both surface it).
+        on-done-notes  (collect-compound-on-done-notes root-path states)]
     (str/join "\n"
               (concat
                (when header-comment? [header-comment])
@@ -424,7 +485,8 @@
                (render-root-fallback-alias root-path on 1)
                compound-lines
                edge-lines
-               final-lines))))
+               final-lines
+               on-done-notes))))
 
 (defn- region-initial-line
   [region-path initial depth]
@@ -459,13 +521,12 @@
   inventing a phantom target arrow."
   [on-done]
   (when on-done
-    (let [cands  (transition-candidates on-done)
-          action (some :action cands)
-          body   (cond-> "on-done: ✓ done"
-                   action (str " / " (label-value action)))]
-      [(str "  note right of " (sanitise-id parallel-root-path))
-       (str "    " body)
-       "  end note"])))
+    ;; rf2-ay42f — share the `on-done: ✓ done / <action>` caption with the
+    ;; COMPOUND action-only note (`on-done-action-label`) so the two
+    ;; action-only completion forms read identically.
+    [(str "  note right of " (sanitise-id parallel-root-path))
+     (str "    " (on-done-action-label on-done))
+     "  end note"]))
 
 (defn- render-parallel-body
   [{:keys [regions on on-done]} header-comment?]
@@ -480,7 +541,14 @@
         edge-lines  (map render-edge edges)
         final-lines (mapcat (fn [[region-id {:keys [states]}]]
                               (render-final-edges [region-id] states))
-                            regions)]
+                            regions)
+        ;; rf2-ay42f — a COMPOUND inside a region whose `:on-done` is
+        ;; action-only renders the same completion note the flat/compound
+        ;; emitter and the parallel-root use (no sibling arrow to draw).
+        region-on-done-notes
+        (mapcat (fn [[region-id {:keys [states]}]]
+                  (collect-compound-on-done-notes [region-id] states))
+                regions)]
     (str/join "\n"
               (concat
                (when header-comment? [header-comment])
@@ -492,6 +560,7 @@
                ["  }"]
                edge-lines
                final-lines
+               region-on-done-notes
                ;; rf2-41goo — the parallel-root completion note (action/fx-
                ;; only; no sibling target).
                (render-parallel-on-done-note on-done)))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -68,7 +68,11 @@
   with a `:reason` keyword for programmatic dispatch.
 
   Per [`API.md`](../../spec/API.md) §SCXML import/export."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            ;; rf2-bs3us — share the canonical parallel-root done-state id
+            ;; with the chart projector so the two emitters agree on the
+            ;; `done.state.<id>` label (single source of truth).
+            [day8.re-frame2-machines-viz.chart.layout :as layout]))
 
 ;; ---------------------------------------------------------------------------
 ;; Id mapping
@@ -253,8 +257,13 @@
 
 (def ^:private parallel-root-scxml-id
   "rf2-41goo — the SCXML id of the synthetic `<parallel>` element. Its
-  W3C completion event is `done.state.<this-id>`."
-  "rf2_parallel_root")
+  W3C completion event is `done.state.<this-id>`.
+
+  rf2-bs3us — sourced from the shared canonical sentinel
+  (`layout/parallel-root-done-state-id`) so the SCXML emitter's
+  `done.state.<id>` event and the chart projector's `:doneState` renderer
+  label agree on the parallel-root done-state id."
+  layout/parallel-root-done-state-id)
 
 (defn- emit-parallel
   [{:keys [regions on-done]} depth]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -8,6 +8,7 @@
   surface that survived the migration."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
             [day8.re-frame2-machines-viz.chart.layout :as layout]))
 
 ;; ---- fixtures ----------------------------------------------------------
@@ -263,6 +264,50 @@
             ":fetch's :loaded→:done edge targets :fetch's scoped :done")
         (is (= (count (set (map :id edges))) (count edges))
             "every edge id is distinct (no cross-region edge-id collision)")))))
+
+(deftest parse-definition-region-top-level-on-no-machine-root-node
+  (testing "rf2-7i7t3 — a parallel region whose def carries a TOP-LEVEL :on
+            fallback must NOT project a malformed region-scoped MACHINE-ROOT
+            node. Pre-fix `parse-flat` minted a `{:path [] :machine-root?
+            true}` node (rf2-vcnvj) for the region's top-level :on; the
+            region-scope then mangled it to the degenerate id
+            `region__fetch__` (trailing `__`, empty path segment) nested
+            INSIDE the region — a stray `root` chip. A region is a compound
+            state, not a machine; its :on is an ordinary region-scoped
+            fallback (XState v5)."
+    (let [ingest {:type :parallel
+                  :regions {:fetch    {:initial :loading
+                                       :on      {:abort :loading}
+                                       :states {:loading {:on {:loaded :done}}
+                                                :done    {:final? true}}}
+                            :validate {:initial :checking
+                                       :states {:checking {:on {:ok :done}}
+                                                :done     {:final? true}}}}}
+          {:keys [nodes edges]} (layout/parse-definition ingest)
+          node-ids (set (map :id nodes))]
+      ;; NO synthetic machine-root node inside any region
+      (is (empty? (filter :machine-root? nodes))
+          "no synthetic machine-root node is minted for a region :on")
+      ;; NO degenerate region-scoped empty-path id
+      (is (not (contains? node-ids (str (layout/region-node-id :fetch) "__")))
+          "no degenerate `region__fetch__` (empty path segment) node")
+      (is (every? #(not (str/ends-with? % "__")) node-ids)
+          "no node id ends in a trailing `__` (the degenerate root marker)")
+      ;; the region-level fallback edge IS still projected, sourced from the
+      ;; REGION CONTAINER (rid) into its in-region target — every edge
+      ;; endpoint is a real projected node (no phantom/empty id).
+      (doseq [e edges]
+        (is (contains? node-ids (:source e))
+            (str "edge source " (:source e) " is a real node"))
+        (is (contains? node-ids (:target e))
+            (str "edge target " (:target e) " is a real node")))
+      (let [fallback (first (filter :machine-level? edges))]
+        (is (some? fallback)
+            "the region's top-level :on fallback edge is still projected")
+        (is (= (layout/region-node-id :fetch) (:source fallback))
+            "the region fallback sources from the region container, not a phantom root")
+        (is (= (layout/region-scoped-id :fetch [:loading]) (:target fallback))
+            "the fallback resolves to the in-region target (:loading)")))))
 
 (deftest highlight-ids-same-name-region-states-attribute-per-region
   (testing "rf2-wnzha (THE HIGHLIGHT FIX) — when two regions are both in a

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -16,6 +16,7 @@
   machines-viz helper test uses."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
             [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.chart.projection :as projection]
             [day8.re-frame2-machines-viz.theme.tokens :as tokens]
@@ -2296,3 +2297,75 @@
     (let [graph (projection/xyflow-graph
                   (layout/parse-definition compound-machine) {} {})]
       (is (empty? (filter #(:onDone (:data %)) (:nodes graph)))))))
+
+;; ---- parallel-root completion ANCHOR is inert (rf2-dblqx) ---------------
+;;
+;; rf2-dblqx — the synthetic PARALLEL-ROOT node (rf2-41goo's anchor for the
+;; whole-parallel `:on-done` completion affordance) is NOT a statechart
+;; state — it is a rendering sentinel (`:path
+;; [:rf.machines-viz.layout/parallel-root]`). Pre-fix it fell through the
+;; node-:type cond to `"state"` AND through the `:onClick` guard (which
+;; excluded only `:machine-root?` + region), so it projected as a CLICKABLE
+;; `parallel` state box — clicking it would dispatch on-state-click against
+;; the phantom sentinel path. The SAME inert-synthetic-chip class rf2-34ff3
+;; fixed for the machine-root chip + region containers; this pins that the
+;; parallel-root anchor is INERT (typed `"machine-root"`, carries NO
+;; `:onClick`), mirroring the 34ff3 guard.
+
+(defn- parallel-root-anchor
+  "The synthetic parallel-root completion-anchor node in a projected
+  parallel-with-:on-done graph. It is the only `\"machine-root\"`-typed
+  node in `ingest-on-done` (the regions carry no top-level `:on`, so no
+  region mints a machine-root chip)."
+  [graph]
+  (first (filter #(= "machine-root" (:type %)) (:nodes graph))))
+
+(deftest xyflow-graph-parallel-root-anchor-is-inert
+  (testing "rf2-dblqx — the parallel-root :on-done anchor is INERT: it is
+            NOT typed `state` and carries NO :onClick (mirroring the
+            rf2-34ff3 inert machine-root + region containers), so a user
+            cannot click a phantom `parallel` state and fire on-state-click
+            against the rendering sentinel path."
+    (let [cb     (fn [_path] :clicked)
+          parsed (layout/parse-definition ingest-on-done)
+          graph  (projection/xyflow-graph parsed {} {:on-state-click cb})
+          anchor (parallel-root-anchor graph)]
+      (is (some? anchor)
+          "a parallel machine with a root :on-done projects the anchor node")
+      (is (= "machine-root" (:type anchor))
+          "the parallel-root anchor is a quiet root-context chip, NOT a state box")
+      (is (not= "state" (:type anchor))
+          "rf2-dblqx — the anchor must NOT fall through to the `state` type")
+      (is (not (contains? (:data anchor) :onClick))
+          "rf2-dblqx — the parallel-root anchor carries NO :onClick (not an
+           on-state-click target — its path is a rendering sentinel)")
+      ;; the real region leaves still carry :onClick (the fix is surgical)
+      (let [leaf (node-by-id graph (layout/region-scoped-id :fetch [:loading]))]
+        (is (= cb (:onClick (:data leaf)))
+            "a real leaf inside a region still carries :onClick")))))
+
+;; ---- parallel-root done-state label matches SCXML (rf2-bs3us) -----------
+;;
+;; rf2-bs3us — the parallel-root done-path is the engine's root sentinel
+;; `[]`, whose `node-id` is the EMPTY string, so the naive
+;; `(str "done.state." (node-id done-path))` yielded the degenerate
+;; `"done.state."` (trailing dot, no id) — diverging from the SCXML
+;; emitter's `"done.state.rf2_parallel_root"`. The chart now uses the
+;; shared canonical sentinel id so the two emitters agree.
+
+(deftest xyflow-graph-parallel-root-done-state-matches-scxml
+  (testing "rf2-bs3us — the parallel-root :on-done :doneState label is the
+            non-degenerate `done.state.<id>` form (matching the SCXML
+            emitter), not the empty `done.state.`"
+    (let [parsed  (layout/parse-definition ingest-on-done)
+          od-edge (first (filter :on-done? (:edges parsed)))
+          graph   (projection/xyflow-graph parsed {} {})
+          ev-node (event-node-for graph (:id od-edge))
+          done    (:doneState (:data ev-node))]
+      (is (some? ev-node))
+      (is (= (str "done.state." layout/parallel-root-done-state-id) done)
+          "the chart label uses the shared canonical parallel-root id")
+      (is (not= "done.state." done)
+          "rf2-bs3us — NOT the degenerate empty-suffix label")
+      (is (str/ends-with? done "rf2_parallel_root")
+          "matches the SCXML emitter's done.state.rf2_parallel_root form"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
@@ -347,3 +347,73 @@
             (no false-positive completion arrows)"
     (let [out (m/emit compound-machine {:fenced? false :header-comment? false})]
       (is (not (str/includes? out "✓ done"))))))
+
+;; ---- compound ACTION-ONLY :on-done note (rf2-ay42f) --------------------
+;;
+;; rf2-ay42f — a COMPOUND whose `:on-done` is ACTION-ONLY (no :target; the
+;; engine just runs an action when the sub-flow completes; the machine
+;; stays in the all-final config) is a documented Spec 005 shape
+;; (`on-done-edges` docstring in chart/layout.cljc names it). The chart +
+;; SCXML emitters both surface it as a terminal completion affordance, but
+;; PRE-FIX mermaid SILENTLY DROPPED it: `collect-on-done-edges` kept only
+;; target-bearing candidates, and the note path covered only the
+;; parallel-root. So the G9 'faithful across all three emitters' claim was
+;; false for this shape. The fix renders a `note` (the same way the
+;; parallel-root action-only :on-done is rendered), so all three emitters
+;; surface the completion.
+
+(def compound-action-only-on-done-machine
+  "rf2-ay42f — a compound `:flow` whose `:on-done` is ACTION-ONLY (no
+  :target — the engine runs `:announce` on completion; the machine stays
+  in the all-final config). The shape `on-done-edges` names in its
+  docstring."
+  {:initial :flow
+   :states  {:flow {:initial :collecting
+                    :on-done {:action :announce}
+                    :states  {:collecting {:on {:submit :submitting}}
+                              :submitting {:on {:ok :paid}}
+                              :paid       {:final? true}}}}})
+
+(deftest emit-compound-action-only-on-done-renders-completion-note
+  (testing "rf2-ay42f — a COMPOUND action-only :on-done (no target) renders
+            a completion note (no phantom arrow) so mermaid is faithful to
+            the chart + SCXML emitters (closing the G9 cross-emitter gap)"
+    (let [out (m/emit compound-action-only-on-done-machine
+                      {:fenced? false :header-comment? false})]
+      (is (str/includes? out "note right of flow")
+          "the compound's completion renders as a note on the compound")
+      (is (str/includes? out "on-done: ✓ done / announce")
+          "the note carries the completion + its action")
+      ;; an action-only :on-done has NO sibling — so NO phantom `✓ done`
+      ;; EDGE (the target-bearing form's `--> ... : ✓ done` arrow).
+      (is (not (str/includes? out "--> flow : ✓ done"))
+          "no phantom completion arrow for an action-only compound :on-done"))))
+
+(deftest emit-region-compound-action-only-on-done-renders-note
+  (testing "rf2-ay42f — a compound INSIDE a parallel region whose :on-done
+            is action-only also renders a completion note (the walk covers
+            nested + region-scoped compounds, not just the top level)"
+    (let [machine {:type    :parallel
+                   :regions {:audio {:initial :session
+                                     :states  {:session {:initial :idle
+                                                         :on-done {:action :chime}
+                                                         :states  {:idle {:on {:go :busy}}
+                                                                   :busy {:final? true}}}}}
+                             :video {:initial :hidden
+                                     :states  {:hidden {:on {:show :shown}}
+                                               :shown  {:final? true}}}}}
+          out     (m/emit machine {:fenced? false :header-comment? false})]
+      (is (str/includes? out "note right of audio__session")
+          "the region-nested compound's completion renders as a note")
+      (is (str/includes? out "on-done: ✓ done / chime")
+          "the note carries the completion + its action"))))
+
+(deftest emit-target-bearing-on-done-renders-edge-not-note
+  (testing "rf2-ay42f regression guard — a TARGET-bearing compound :on-done
+            still renders the sibling completion EDGE (not a note); only
+            the action-only form gets a note"
+    (let [out (m/emit compound-on-done-machine {:fenced? false :header-comment? false})]
+      (is (str/includes? out "flow --> next : ✓ done")
+          "a target-bearing :on-done keeps its sibling completion arrow")
+      (is (not (str/includes? out "note right of flow"))
+          "a target-bearing :on-done does NOT also render a note"))))


### PR DESCRIPTION
R2 review (rf2-5nb2v) follow-ons to the rf2-41goo three-emitter `:on-done` projection + the rf2-wnzha region re-key. All four isolated to `tools/machines-viz/` (disjoint from the in-flight surfaces).

## The four fixes

**rf2-dblqx (P3 BUG)** — the synthetic parallel-root `:on-done` anchor projected as a CLICKABLE `"state"` box: it fell through the node-`:type` cond to `"state"` AND through the `:onClick` guard (which excluded only `:machine-root?` + region). Clicking dispatched on-state-click against the rendering-sentinel path. The SAME inert-synthetic-chip class **rf2-34ff3** ruled. Fix: type the anchor `"machine-root"` (the quiet root-context chip) + exclude `:parallel-root?` from the `:onClick` guard, mirroring 34ff3. The anchor is now INERT.
- `chart/projection.cljc` — node-`:type` cond + `:onClick` guard.

**rf2-ay42f (P3 BUG)** — a COMPOUND action-only `:on-done` (no `:target`; a documented Spec 005 shape) surfaced in chart + scxml but was SILENTLY DROPPED in mermaid (`collect-on-done-edges` kept only target-bearing candidates; the note path covered only the parallel-root). Fix: mermaid renders a `note right of <compound>` carrying `on-done: ✓ done / <action>` — the same affordance the parallel-root action-only `:on-done` uses — via `collect-compound-on-done-notes` (walks the state tree incl. region-nested + deeply-nested compounds). All three emitters now surface the completion.
- `mermaid.cljc` — `collect-compound-on-done-notes` + wired into `render-flat-or-compound-body` and `render-parallel-body`; `render-parallel-on-done-note` shares the `on-done-action-label` caption.

**rf2-7i7t3 (P3 BUG)** — a parallel region with a top-level `:on` fallback projected a malformed region-scoped MACHINE-ROOT node (`{:path [] :machine-root? true}` → degenerate id `"region__fetch__"`, trailing `__` + empty path segment). A region is a compound state, not a machine (XState v5). Fix: `parse-parallel` drops the synthetic machine-root node inside a region and re-points its fallback edges' source to the region container `rid`.
- `chart/layout.cljc` — `parse-parallel` region-node filter + machine-level edge re-source.

**rf2-bs3us (P4 nit)** — the chart parallel-root `:doneState` was the degenerate `"done.state."` (the root sentinel path `[]` has an empty `node-id`), diverging from scxml's `"done.state.rf2_parallel_root"`. Fix: a shared canonical sentinel id (`layout/parallel-root-done-state-id`) is the single source of truth both the chart `:doneState` label and the scxml `<parallel>` emitter read from, so the two agree.
- `chart/layout.cljc` (new public constant), `chart/projection.cljc` (`:doneState` special-case), `scxml.cljc` (sources the shared constant).

## Tests (+6 deftests / +28 assertions)
- `projection_cljs_test.cljc` — dblqx inert anchor (type + no `:onClick`); bs3us label matches scxml.
- `mermaid_cljs_test.cljc` — ay42f compound action-only note; region-nested compound action-only note; target-bearing regression guard.
- `layout_cljs_test.cljc` — 7i7t3 no machine-root node + region-container-sourced fallback + no degenerate id.

## Spec
`spec/001-Topology-Parity.md` Phase F extended with F2–F4 rows + the G9 "faithful across all three emitters" reconciliation (now accurate for the action-only compound shape).

## Gates (cold)
- machines-viz `clojure -M:test`: **359 tests, 1040 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (node-runtime CLJS, picks up machines-viz cljc): **5622 tests, 19590 assertions, 0 failures, 0 errors**.

Closes rf2-dblqx, rf2-ay42f, rf2-7i7t3, rf2-bs3us.