### PR TITLE
fix(core): chain warned-plain-fn-frame-pairs into clear-warn-once chain + governance gate (rf2-z79p8)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -155,4 +155,12 @@
 ;; lives in the adapter ns (not in reagent2.impl.template) to keep the
 ;; vendored `reagent2.*` tree free of any `re-frame.*` edge — bundle
 ;; isolation by construction.
-(spine/install-clear-warn-once-step! template/clear-warned-keyword-prop!)
+;;
+;; rf2-z79p8: enrol with an explicit label but NO arm/armed? probes — the
+;; cache atom is `^:private` in reagent2.impl.template and reaching into it
+;; from here would breach the same bundle-isolation rule. The empirical
+;; governance assertion skips probe-less entries; the source-enumeration
+;; assertion and the dedicated template_keyword_prop re-arm test cover this
+;; cache.
+(spine/install-clear-warn-once-step! template/clear-warned-keyword-prop!
+                                     {:label :reagent-slim/warned-keyword-prop})

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -157,6 +157,75 @@
         (when previous (apply previous args))
         nil))))
 
+;; ---- warn-once clear-fn governance registry (rf2-z79p8) -------------------
+;;
+;; Every process-wide `defonce` warn-once cache in the adapter / views
+;; family (`warned-non-dom-roots`, the rf2-9hoos `seen-render-keys` set,
+;; the slim hiccup interpreter's `warned-keyword-prop` cache, and the
+;; Spec 004 `warned-plain-fn-frame-pairs` plain-fn-under-non-default-frame
+;; set) must be wiped by the standard `make-reset-runtime-fixture` between
+;; tests — otherwise a sibling test's first-encounter warning silently
+;; swallows a later test's same-key warning. The mechanism is the chained
+;; `:adapter/clear-warn-once-caches!` late-bind hook the fixture fires.
+;;
+;; This defect class has now bitten four times: rf2-4edk (the original
+;; source-coord cache), rf2-9hoos (seen-render-keys), rf2-qy6cl (the slim
+;; keyword-prop cache), and rf2-z79p8 (the plain-fn pairs cache — the 4th
+;; straggler). Each fix was the SAME one-liner: chain the clear-fn. The
+;; pattern is fragile because there is no single chokepoint and nothing
+;; asserts the set of `defonce` warn-once caches equals the set of clears
+;; in the chain — a 5th cache can be added with a bare `defonce` + a
+;; standalone clear-fn and silently escape the fixture.
+;;
+;; `register-warn-once-clear-fn!` is that chokepoint: it both (a) chains
+;; the clear-fn into `:adapter/clear-warn-once-caches!` and (b) records
+;; the cache in this governance registry with `:arm` / `:armed?` probes.
+;; The governance assertion (warn_once_clear_governance test) enumerates
+;; the registry, arms every cache, fires the chain once, and asserts each
+;; cache is empty afterwards — so a future 5th cache that registers but
+;; forgets the chain (or escapes the chokepoint entirely) trips the gate.
+
+(defonce
+  ^{:doc "Vector of governance entries for the adapter/views warn-once
+   `defonce` caches that MUST be wiped by the chained
+   `:adapter/clear-warn-once-caches!` fixture hook. Populated at ns-load
+   by `register-warn-once-clear-fn!`. Each entry is
+   `{:label keyword, :clear-fn fn, :arm fn, :armed? fn}`. Consumed only by
+   the warn-once-clear governance assertion (rf2-z79p8); production never
+   reads it. The registry is the authoritative enumeration of the cache
+   class — the assertion proves every member is actually cleared by the
+   single canonical chain."}
+  warn-once-clear-registry
+  (atom []))
+
+(defn register-warn-once-clear-fn!
+  "Canonical chokepoint (rf2-z79p8) for wiring a process-wide warn-once
+  `defonce` cache into the chained `:adapter/clear-warn-once-caches!`
+  fixture-reset hook. Call this — never a bare `chain-fn!` on that key —
+  so the cache is BOTH chained AND enrolled in the governance registry
+  the warn-once-clear assertion checks.
+
+  Args (a single map):
+    :label    — keyword naming the cache (for assertion failure messages).
+    :clear-fn — the zero-arg clear-thunk (resets the cache to empty, nil).
+    :arm      — zero-arg thunk that seeds the cache with a sentinel so
+                `armed?` returns true. Lets the governance assertion drive
+                the cache to a known non-empty state.
+    :armed?   — zero-arg predicate true iff the cache holds the sentinel
+                (i.e. has NOT been cleared).
+
+  Effects: chains `:clear-fn` into `:adapter/clear-warn-once-caches!`
+  (so `make-reset-runtime-fixture` wipes it) and appends the entry to
+  `warn-once-clear-registry`. Returns nil.
+
+  `re-frame.substrate.spine/install-clear-warn-once-step!` delegates here
+  with default arm/armed? probes for the adapters' source-coord caches."
+  [{:keys [label clear-fn arm armed?] :as entry}]
+  (chain-fn! :adapter/clear-warn-once-caches! clear-fn)
+  (swap! warn-once-clear-registry conj
+         {:label label :clear-fn clear-fn :arm arm :armed? armed?})
+  nil)
+
 (defn require-fn!
   "Return the fn registered under `hook-key`, or throw a structured
   `:rf.error/<artefact>-artefact-missing` ex-info when the hook is

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -618,7 +618,7 @@
                    re-frame.adapter.uix]
     :chained?    true
     :design-bead "rf2-4edk"
-    :description "Chained reset of every adapter's warn-once defonce caches. re-frame.views also chains its rf2-9hoos seen-render-keys reset (the :mount? discriminator's per-process set) so the standard runtime-reset fixture wipes it without new call-site wiring."}
+    :description "Chained reset of EVERY adapter/views warn-once defonce cache the standard make-reset-runtime-fixture must wipe between tests. Per rf2-z79p8 every contributor enrols through the single governance chokepoint re-frame.late-bind/register-warn-once-clear-fn! (which chains the clear-fn here AND records it in the warn-once-clear governance registry). Members: re-frame.views.warn-once's warned-non-dom-roots + warned-plain-fn-frame-pairs (the rf2-z79p8 4th straggler), re-frame.views's rf2-9hoos seen-render-keys (:mount? discriminator), the React-hook spine's per-adapter source-coord cache (re-frame.substrate.spine, used by helix/uix), and the slim hiccup interpreter's warned-keyword-prop (re-frame.adapter.reagent-slim, rf2-qy6cl). The warn-once-clear governance assertion enumerates the registry and proves each member is wiped by this chain so a future 5th cache cannot silently escape the fixture."}
    {:key         :adapter/current-frame
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1222,10 +1222,28 @@
   "Wire `clear-fn` into the chained `:adapter/clear-warn-once-caches!`
   late-bind hook. The hook is chained — each adapter and re-frame.views
   contribute a clear-step; `make-reset-runtime-fixture` invokes the top of
-  the chain and every contributor's reset runs. Thin wrapper around
-  `late-bind/chain-fn!` so callers don't need to know the chain key."
-  [clear-fn]
-  (late-bind/chain-fn! :adapter/clear-warn-once-caches! clear-fn))
+  the chain and every contributor's reset runs.
+
+  Delegates to the canonical governance chokepoint
+  `late-bind/register-warn-once-clear-fn!` (rf2-z79p8) so the cache is
+  BOTH chained AND enrolled in the warn-once-clear governance registry the
+  governance assertion checks. Callers don't need to know the chain key.
+
+  Two arities:
+    [clear-fn]            — enrol with a default label and no arm/armed?
+                            probes (the empirical arm/fire assertion skips
+                            it; the source-enumeration assertion still
+                            covers it).
+    [clear-fn governance] — pass `{:label :arm :armed?}` so the empirical
+                            governance assertion can arm the cache, fire
+                            the chain, and prove the cache was wiped. The
+                            React-hook spine threads its `warn-cache` atom
+                            in via this arity."
+  ([clear-fn]
+   (install-clear-warn-once-step! clear-fn {:label :adapter/warned-non-dom-roots}))
+  ([clear-fn governance]
+   (late-bind/register-warn-once-clear-fn!
+     (assoc governance :clear-fn clear-fn))))
 
 ;; ---- subscription hook ----------------------------------------------------
 ;;
@@ -1603,8 +1621,15 @@
     ;; Chained warn-once clear (rf2-4edk): chained (NOT routed by installed-
     ;; adapter identity) — every loaded adapter's per-process defonce must
     ;; clear between tests because a bundle can mount different adapters
-    ;; across tests.
-    (install-clear-warn-once-step! (:clear-warned-non-dom-roots! spine-fns))
+    ;; across tests. rf2-z79p8: routed through the governance chokepoint
+    ;; with arm/armed? probes over the spine's `warn-cache` atom so the
+    ;; warn-once-clear governance assertion proves the chain wipes it.
+    (let [warn-cache (:warn-cache spine-fns)]
+      (install-clear-warn-once-step!
+        (:clear-warned-non-dom-roots! spine-fns)
+        {:label  :adapter/warned-non-dom-roots
+         :arm    (fn [] (swap! warn-cache conj ::governance-sentinel))
+         :armed? (fn [] (contains? @warn-cache ::governance-sentinel))}))
     ;; Chained SSR emitter install (rf2-4z7bp): `re-frame.ssr.emit` invokes
     ;; `:reagent/set-hiccup-emitter!` at ns-load; every loaded React-shaped
     ;; adapter contributes its own install step so a single

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -674,9 +674,16 @@
 ;; The `:mount?` discriminator (rf2-9hoos) keys off a per-process
 ;; seen-render-keys set; a fixture that reuses a render-key across cases
 ;; would otherwise see the second case's first render reported as a
-;; rerender. Chain `clear-seen-render-keys!` into the existing
+;; rerender. Enrol `clear-seen-render-keys!` into the existing
 ;; `:adapter/clear-warn-once-caches!` reset hook (rf2-4edk) so the
 ;; standard runtime-reset fixture wipes it alongside the warn-once
-;; caches — no new fixture wiring needed at call sites.
+;; caches — no new fixture wiring needed at call sites. Routed through
+;; the canonical governance chokepoint `register-warn-once-clear-fn!`
+;; (rf2-z79p8) so this cache is enrolled in the warn-once-clear registry
+;; the governance assertion checks.
 
-(late-bind/chain-fn! :adapter/clear-warn-once-caches! clear-seen-render-keys!)
+(late-bind/register-warn-once-clear-fn!
+  {:label    :views/seen-render-keys
+   :clear-fn clear-seen-render-keys!
+   :arm      (fn [] (swap! seen-render-keys conj ::governance-sentinel))
+   :armed?   (fn [] (contains? @seen-render-keys ::governance-sentinel))})

--- a/implementation/core/src/re_frame/views/warn_once.cljs
+++ b/implementation/core/src/re_frame/views/warn_once.cljs
@@ -232,9 +232,32 @@
 (late-bind/set-fn! :views/clear-plain-fn-warned-pairs!
                    clear-plain-fn-warned-pairs!)
 
-;; Register a clear of the `warned-non-dom-roots` cache under the
-;; chained `:adapter/clear-warn-once-caches!` hook. Each adapter (helix,
-;; uix) and this views ns all contribute a clear-step;
-;; `make-reset-runtime-fixture` invokes the top of the chain and every
-;; contributor's reset runs.
-(late-bind/chain-fn! :adapter/clear-warn-once-caches! clear-warned-non-dom-roots!)
+;; Enrol BOTH warn-once `defonce` caches this ns owns into the chained
+;; `:adapter/clear-warn-once-caches!` hook, via the canonical governance
+;; chokepoint `late-bind/register-warn-once-clear-fn!` (rf2-z79p8). Each
+;; adapter (helix, uix), the slim hiccup interpreter, re-frame.views, and
+;; this ns all contribute a clear-step; `make-reset-runtime-fixture`
+;; invokes the top of the chain and every contributor's reset runs. The
+;; chokepoint also records each cache in the warn-once-clear governance
+;; registry so the governance assertion proves the chain wipes it.
+;;
+;;   1. `warned-non-dom-roots` — the rf2-4edk source-coord / non-DOM-root
+;;      cache (kept chained here as it was at line 240 pre-rf2-z79p8).
+;;   2. `warned-plain-fn-frame-pairs` — the Spec 004 plain-fn-under-non-
+;;      default-frame suppression set (rf2-z79p8: the 4th straggler, NOT
+;;      chained before this fix, so the standard fixture never re-armed
+;;      it — only three test files reset it by hand). The standalone
+;;      `:views/clear-plain-fn-warned-pairs!` hook (set above) is RETAINED
+;;      for the per-frame destroy path / elision-probe direct call; this
+;;      adds the fixture-chain wiring it was missing.
+(late-bind/register-warn-once-clear-fn!
+  {:label    :views/warned-non-dom-roots
+   :clear-fn clear-warned-non-dom-roots!
+   :arm      (fn [] (swap! warned-non-dom-roots conj ::governance-sentinel))
+   :armed?   (fn [] (contains? @warned-non-dom-roots ::governance-sentinel))})
+
+(late-bind/register-warn-once-clear-fn!
+  {:label    :views/warned-plain-fn-frame-pairs
+   :clear-fn clear-plain-fn-warned-pairs!
+   :arm      (fn [] (swap! warned-plain-fn-frame-pairs conj ::governance-sentinel))
+   :armed?   (fn [] (contains? @warned-plain-fn-frame-pairs ::governance-sentinel))})

--- a/implementation/core/test/re_frame/late_bind_drift_test.clj
+++ b/implementation/core/test/re_frame/late_bind_drift_test.clj
@@ -83,13 +83,21 @@
   #"\(substrate-adapter/route-hook!\s+\S+\s+(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
 
 (def ^:private chain-fn-call-re
-  "Match `(late-bind/chain-fn! :namespace/key ...`.
+  "Match `(late-bind/chain-fn! :namespace/key ...` and the bare
+  `(chain-fn! :namespace/key ...` form.
 
   Per rf2-1fh5h chained hooks are published through `chain-fn!`
   (which calls `set-fn!` internally, wrapping the step-fn in a
   chain-into-previous closure). Drift scan treats this call shape as
-  equivalent to direct `set-fn!` publication."
-  #"\(late-bind/chain-fn!\s+(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
+  equivalent to direct `set-fn!` publication.
+
+  The `late-bind/` alias prefix is OPTIONAL (rf2-z79p8): the canonical
+  warn-once-clear chokepoint `register-warn-once-clear-fn!` lives INSIDE
+  `re-frame.late-bind` and calls `chain-fn!` unqualified there, so the
+  authoritative `:adapter/clear-warn-once-caches!` publication is a bare
+  `(chain-fn! :adapter/clear-warn-once-caches! ...)` literal. Matching the
+  unqualified form keeps that key documented as published."
+  #"\((?:late-bind/)?chain-fn!\s+(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
 
 (def ^:private set-fns-block-re
   "Match a `(late-bind/set-fns! { ... })` map-form block; the named

--- a/implementation/core/test/re_frame/warn_once_clear_governance_cljs_test.cljs
+++ b/implementation/core/test/re_frame/warn_once_clear_governance_cljs_test.cljs
@@ -1,0 +1,223 @@
+(ns re-frame.warn-once-clear-governance-cljs-test
+  "Governance gate for the adapter/views warn-once `defonce` cache class
+  (rf2-z79p8) — the class that has now bitten FOUR times:
+
+    * rf2-4edk  — `warned-non-dom-roots` (the source-coord / non-DOM-root
+                  cache) was left out of the fixture-reset chain.
+    * rf2-9hoos — `seen-render-keys` (the :mount? discriminator's set).
+    * rf2-qy6cl — the slim hiccup interpreter's `warned-keyword-prop`.
+    * rf2-z79p8 — `warned-plain-fn-frame-pairs` (the Spec 004 plain-fn-
+                  under-non-default-frame suppression set) — the 4th
+                  straggler, chained by THIS change.
+
+  Each recurrence was the SAME defect: a process-wide `defonce` warn-once
+  cache whose clear-fn was published standalone but NEVER chained into the
+  canonical `:adapter/clear-warn-once-caches!` hook that
+  `make-reset-runtime-fixture` fires — so the standard fixture silently
+  failed to re-arm it between tests, and a sibling test's first-encounter
+  warning could swallow a later same-key warning.
+
+  rf2-z79p8 ENDS the class. Every contributor now enrols through the
+  single chokepoint `re-frame.late-bind/register-warn-once-clear-fn!`,
+  which both chains the clear-fn AND records the cache (with `:arm` /
+  `:armed?` probes where the cache atom is in scope) in the
+  `warn-once-clear-registry`. This test enumerates that registry and
+  proves, empirically, that firing the canonical chain ONCE wipes every
+  registered cache. A future 5th cache that registers but forgets the
+  chain (impossible through the chokepoint, but a bare `chain-fn!` could
+  still drift) — or that escapes the chokepoint entirely — is caught:
+
+    * the empirical assertion arms every probe-carrying cache, fires the
+      chain, and asserts each is wiped → a registered-but-unchained cache
+      survives the chain and FAILS;
+    * the would-fail negative proof registers a SYNTHETIC unchained cache
+      directly into the registry (NOT through the chokepoint) and shows
+      the same assertion catches it — proving the gate has teeth.
+
+  The companion source-enumeration assertion lives in the JVM test
+  `re-frame.warn-once-clear-governance-test` (it greps every `defonce`
+  warn-once cache out of source and asserts each is routed through the
+  chokepoint) — that layer catches a 5th cache that never registers at
+  all.
+
+  Loading the four adapter/views producer namespaces below populates the
+  registry at ns-load (each adapter's `make-react-adapter` /
+  `make-ratom-adapter` runs its enrolment at require time).
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.set :as set]
+            [re-frame.late-bind :as late-bind]
+            ;; load-bearing requires — each populates the warn-once-clear
+            ;; registry at ns-load:
+            ;;   re-frame.views          → seen-render-keys
+            ;;   re-frame.views.warn-once → warned-non-dom-roots
+            ;;                              + warned-plain-fn-frame-pairs
+            ;;   re-frame.adapter.uix     → the React-hook spine's per-
+            ;;                              adapter source-coord cache
+            ;;                              (make-react-adapter enrols it)
+            ;;   re-frame.adapter.reagent-slim → warned-keyword-prop
+            [re-frame.views]
+            [re-frame.views.warn-once]
+            [re-frame.adapter.uix]
+            [re-frame.adapter.reagent-slim]))
+
+;; ---------------------------------------------------------------------------
+;; Enumeration — every named cache of the class is enrolled
+;; ---------------------------------------------------------------------------
+
+(def ^:private expected-labels
+  "Every warn-once cache of the rf2-4edk/9hoos/qy6cl/z79p8 class that MUST
+  be enrolled in the registry (and therefore chained). A 5th cache that
+  forgets to enrol trips the source-enumeration JVM assertion; one that
+  enrols under a new label lands here once Mike/the reviewer adds it."
+  #{:views/warned-non-dom-roots
+    :views/warned-plain-fn-frame-pairs
+    :views/seen-render-keys
+    :adapter/warned-non-dom-roots          ;; the React-hook spine's per-adapter cache
+    :reagent-slim/warned-keyword-prop})
+
+(deftest registry-enrols-every-named-cache-of-the-class
+  (testing "the warn-once-clear governance registry enrols every named
+            cache of the rf2-z79p8 class (incl. the 4th straggler
+            :views/warned-plain-fn-frame-pairs)"
+    (let [enrolled (set (map :label @late-bind/warn-once-clear-registry))
+          missing  (set/difference expected-labels enrolled)]
+      (is (empty? missing)
+          (str "these warn-once caches are NOT enrolled in the governance "
+               "registry (so they are NOT chained into "
+               ":adapter/clear-warn-once-caches! and the standard fixture "
+               "will not re-arm them — the rf2-z79p8 defect class): "
+               (pr-str missing)
+               ". Enrolled labels: " (pr-str enrolled))))))
+
+;; ---------------------------------------------------------------------------
+;; Empirical proof — firing the canonical chain wipes every enrolled cache
+;; ---------------------------------------------------------------------------
+
+(defn- probed-entries
+  "Registry entries that carry both :arm and :armed? probes — the ones the
+  empirical arm/fire/assert-empty check can drive. (Probe-less entries —
+  e.g. the slim keyword-prop cache, whose atom is private behind the
+  reagent2.* bundle-isolation boundary — are covered by the enrolment
+  enumeration above + the source-enumeration JVM assertion + their own
+  dedicated re-arm test.)"
+  []
+  (filter (fn [{:keys [arm armed?]}] (and (fn? arm) (fn? armed?)))
+          @late-bind/warn-once-clear-registry))
+
+(deftest canonical-chain-wipes-every-enrolled-cache
+  (testing "arming every probe-carrying warn-once cache, then firing the
+            canonical :adapter/clear-warn-once-caches! chain ONCE, wipes
+            ALL of them — proving each enrolled cache is genuinely a member
+            of the chain the standard fixture drives (rf2-z79p8)"
+    (let [entries (probed-entries)
+          chain   (late-bind/get-fn :adapter/clear-warn-once-caches!)]
+      (is (seq entries)
+          "precondition: at least one probe-carrying cache is enrolled")
+      (is (some? chain)
+          "precondition: the canonical :adapter/clear-warn-once-caches! chain is registered")
+      ;; Arm every cache so each :armed? is true.
+      (doseq [{:keys [arm]} entries] (arm))
+      (doseq [{:keys [label armed?]} entries]
+        (is (true? (boolean (armed?)))
+            (str "precondition: " label " is armed before the chain fires")))
+      ;; Fire the canonical chain ONCE.
+      (chain)
+      ;; Every cache must now be wiped.
+      (doseq [{:keys [label armed?]} entries]
+        (is (false? (boolean (armed?)))
+            (str label " survived the canonical :adapter/clear-warn-once-"
+                 "caches! chain — its clear-fn is enrolled in the registry "
+                 "but NOT actually wired into the chain (the rf2-z79p8 "
+                 "defect class). The standard make-reset-runtime-fixture "
+                 "will not re-arm it between tests."))))))
+
+;; ---------------------------------------------------------------------------
+;; Re-arm of warned-plain-fn-frame-pairs — the 4th straggler (rf2-z79p8)
+;; ---------------------------------------------------------------------------
+
+(defn- plain-fn-entry []
+  (some (fn [e] (when (= :views/warned-plain-fn-frame-pairs (:label e)) e))
+        @late-bind/warn-once-clear-registry))
+
+(deftest plain-fn-cache-re-arms-via-the-chain
+  (testing "the warned-plain-fn-frame-pairs cache (Spec 004 plain-fn-under-
+            non-default-frame suppression set) re-arms when the chained
+            :adapter/clear-warn-once-caches! hook fires — the rf2-z79p8 fix.
+            Before this change the cache was NOT chained, so the standard
+            fixture left a sibling test's pair in the set and a later same-
+            pair warning was silently swallowed. This drives the REAL cache
+            through the REAL chain via its registry probes (the production
+            seam), mirroring the chained-clear re-arm in
+            template_keyword_prop_warn_once_clear_cljs_test (rf2-qy6cl) and
+            assert-chained-clear-warn-once-empties-cache (rf2-e54wc)."
+    (let [{:keys [arm armed?]} (plain-fn-entry)
+          chain (late-bind/get-fn :adapter/clear-warn-once-caches!)]
+      (is (and (fn? arm) (fn? armed?))
+          "the plain-fn cache is enrolled with arm/armed? probes")
+      ;; Phase 1 — a pair is recorded (the production code does this the
+      ;; first time a plain fn warns; once recorded the SAME pair is
+      ;; suppressed). Simulate via the production arm seam.
+      (arm)
+      (is (true? (boolean (armed?)))
+          "phase 1: the pair is in the suppression set (a same-pair warning would now be swallowed)")
+      ;; The chained fixture-reset hook fires (what make-reset-runtime-
+      ;; fixture does between every test).
+      (chain)
+      ;; Phase 2 — the cache is empty again: the same pair would warn
+      ;; AFRESH, no longer swallowed. This is the re-arm the 4th straggler
+      ;; was missing before rf2-z79p8.
+      (is (false? (boolean (armed?)))
+          (str "phase 2: AFTER the chained :adapter/clear-warn-once-caches! "
+               "hook fires, the warned-plain-fn-frame-pairs cache MUST be "
+               "empty so the same pair warns again (it was silently "
+               "swallowed before rf2-z79p8 chained this cache)")))))
+
+;; ---------------------------------------------------------------------------
+;; Negative proof — the gate has teeth (a registered-but-unchained cache
+;; is caught)
+;; ---------------------------------------------------------------------------
+
+(deftest governance-gate-catches-an-unchained-cache
+  (testing "PROOF the gate would FAIL for a 5th cache that registers but is
+            NOT chained: inject a SYNTHETIC entry straight into the registry
+            (bypassing register-warn-once-clear-fn!, so it never reaches the
+            chain), arm it, fire the canonical chain, and confirm the same
+            arm/fire/assert-empty logic the gate uses flags it as surviving
+            (rf2-z79p8). The synthetic entry is removed afterwards so the
+            real gate stays green."
+    (let [survivor (atom #{})
+          synthetic {:label    :rf-test/unchained-synthetic-cache
+                     ;; NOTE: this clear-fn is NEVER chained — the entry is
+                     ;; conj'd directly, NOT via register-warn-once-clear-fn!.
+                     :clear-fn (fn [] (reset! survivor #{}) nil)
+                     :arm      (fn [] (swap! survivor conj ::sentinel))
+                     :armed?   (fn [] (contains? @survivor ::sentinel))}]
+      (try
+        (swap! late-bind/warn-once-clear-registry conj synthetic)
+        (let [{:keys [arm armed?]} synthetic
+              chain (late-bind/get-fn :adapter/clear-warn-once-caches!)]
+          (arm)
+          (is (true? (boolean (armed?))) "synthetic cache armed")
+          (chain)
+          ;; The chain does NOT clear it (it was never wired in) — exactly
+          ;; what the empirical gate flags as a failure for a real cache.
+          (is (true? (boolean (armed?)))
+              "the synthetic UNCHAINED cache survives the canonical chain —
+               this is the failure the empirical gate raises for any real
+               cache that registers but forgets the chain. The gate has
+               teeth.")
+          ;; And confirm that, by contrast, a properly-enrolled cache IS
+          ;; cleared by the same chain fire (so the gate distinguishes the
+          ;; two — it isn't vacuously green).
+          (let [{real-arm :arm real-armed? :armed?} (plain-fn-entry)]
+            (real-arm)
+            ;; fire again so both synthetic and the real cache see the chain
+            (chain)
+            (is (false? (boolean (real-armed?)))
+                "by contrast, a properly-enrolled cache IS wiped by the chain")))
+        (finally
+          ;; Drop the synthetic entry so the real gate above stays clean.
+          (swap! late-bind/warn-once-clear-registry
+                 (fn [reg] (vec (remove #(= :rf-test/unchained-synthetic-cache (:label %)) reg)))))))))

--- a/implementation/core/test/re_frame/warn_once_clear_governance_test.clj
+++ b/implementation/core/test/re_frame/warn_once_clear_governance_test.clj
@@ -1,0 +1,160 @@
+(ns re-frame.warn-once-clear-governance-test
+  "JVM source-enumeration half of the warn-once-clear governance gate
+  (rf2-z79p8). The CLJS half
+  (`re-frame.warn-once-clear-governance-cljs-test`) proves, at runtime,
+  that firing the canonical `:adapter/clear-warn-once-caches!` chain wipes
+  every cache enrolled in the `warn-once-clear-registry`. This half proves,
+  at the source level, that there is exactly ONE way to enrol a cache into
+  that chain — the chokepoint `register-warn-once-clear-fn!` — so a future
+  5th cache cannot quietly chain itself with a bare `chain-fn!` (which
+  would chain it WITHOUT recording it in the registry, re-opening the
+  rf2-4edk/9hoos/qy6cl/z79p8 defect class the CLJS gate can no longer see).
+
+  Two assertions:
+
+    1. SINGLE CHOKEPOINT — no source file other than `re-frame.late-bind`
+       itself (which DEFINES the chokepoint) may call
+       `(chain-fn! :adapter/clear-warn-once-caches! ...)` directly. Every
+       contributor goes through `register-warn-once-clear-fn!` (core/views)
+       or `install-clear-warn-once-step!` (the spine/adapter seam, itself a
+       thin delegator). This guarantees enrolment-and-chaining are atomic:
+       you cannot chain without registering.
+
+    2. ENROLMENT COVERAGE — every standalone warn-once clear-fn the
+       adapter/views family publishes as a `clear-*warned*!`-shaped
+       late-bind hook (the historical straggler shape — a `defonce` cache
+       with a hand-published clear-fn) is routed through the chokepoint
+       somewhere in source.
+
+  Walks the same source tree as `re-frame.late-bind-drift-test`.")
+
+(require '[clojure.java.io :as io]
+         '[clojure.string :as str]
+         '[clojure.test :refer [deftest is testing]])
+
+(def ^:private repo-implementation-root
+  (-> (io/file "..") .getCanonicalFile))
+
+(defn- source-files
+  "Every `.clj{,c,s}` under `implementation/**/src/` (skips `test/`)."
+  []
+  (->> (file-seq repo-implementation-root)
+       (filter #(.isFile ^java.io.File %))
+       (filter (fn [^java.io.File f]
+                 (let [n (.getName f)]
+                   (or (str/ends-with? n ".clj")
+                       (str/ends-with? n ".cljc")
+                       (str/ends-with? n ".cljs")))))
+       (filter (fn [^java.io.File f]
+                 (let [norm (str/replace (.getPath f) "\\" "/")]
+                   (and (str/includes? norm "/src/")
+                        (not (str/includes? norm "/test/"))))))))
+
+(defn- ns-name-of
+  "Best-effort `(ns ...)` symbol of a source file (first ns form)."
+  [content]
+  (when-let [m (re-find #"\(ns\s+([a-zA-Z][a-zA-Z0-9.\-]*)" content)]
+    (second m)))
+
+;; ---------------------------------------------------------------------------
+;; 1. Single chokepoint — only re-frame.late-bind may chain the key directly
+;; ---------------------------------------------------------------------------
+
+(def ^:private raw-chain-re
+  "Match a direct `chain-fn!` (qualified or not) on the warn-once-clear
+  key. The chokepoint `register-warn-once-clear-fn!` (in re-frame.late-bind)
+  is the ONLY legitimate such call site."
+  #"\((?:late-bind/)?chain-fn!\s+:adapter/clear-warn-once-caches!")
+
+(deftest only-the-chokepoint-chains-the-warn-once-clear-key
+  (testing "no source file other than re-frame.late-bind calls
+            (chain-fn! :adapter/clear-warn-once-caches! ...) directly —
+            every contributor enrols through register-warn-once-clear-fn!
+            so chaining and registry-enrolment are atomic (rf2-z79p8)"
+    (let [offenders
+          (for [^java.io.File f (source-files)
+                :let [content (slurp f)]
+                :when (re-find raw-chain-re content)
+                :let [ns-sym (ns-name-of content)]
+                :when (not= "re-frame.late-bind" ns-sym)]
+            (str ns-sym " (" (.getPath f) ")"))]
+      (is (empty? offenders)
+          (str "These source files chain :adapter/clear-warn-once-caches! "
+               "with a RAW chain-fn! instead of the canonical chokepoint "
+               "re-frame.late-bind/register-warn-once-clear-fn! (or the "
+               "spine seam install-clear-warn-once-step!). A raw chain-fn! "
+               "wires the cache into the fixture chain WITHOUT recording it "
+               "in the warn-once-clear-registry, so the CLJS governance "
+               "assertion can no longer see it — re-opening the "
+               "rf2-4edk/9hoos/qy6cl/z79p8 defect class. Route through the "
+               "chokepoint:\n  "
+               (str/join "\n  " (sort offenders)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Enrolment coverage — every published clear-*warned* hook is chokepointed
+;; ---------------------------------------------------------------------------
+
+(def ^:private clear-warned-hook-re
+  "Match a late-bind publication of a `clear-…warned…`-shaped clear-fn —
+  the historical straggler shape (a standalone hand-published clear-fn for
+  a warn-once cache). e.g. `(late-bind/set-fn! :views/clear-plain-fn-warned-pairs! …`."
+  #"\(late-bind/set-fn!\s+(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/clear-[a-zA-Z0-9!?*+\-]*warned[a-zA-Z0-9!?*+\-]*)")
+
+(defn- published-clear-warned-hooks
+  "Map of `clear-*warned*` hook-key → producing-ns-sym across all source."
+  []
+  (into {}
+        (for [^java.io.File f (source-files)
+              :let [content (slurp f)
+                    ns-sym  (ns-name-of content)]
+              k (->> (re-seq clear-warned-hook-re content)
+                     (map (comp keyword #(subs % 1) second)))]
+          [k ns-sym])))
+
+(defn- files-routing-through-chokepoint
+  "Source whose content references the chokepoint or its spine seam by the
+  name of a clear-fn — used as a coarse 'this cache is wired in' signal."
+  []
+  (->> (source-files)
+       (map (fn [^java.io.File f] [(.getPath f) (slurp f)]))
+       (into {})))
+
+(deftest every-clear-warned-hook-is-routed-through-the-chokepoint
+  (testing "every standalone clear-*warned* warn-once clear-fn the
+            adapter/views family publishes is also wired into the chain via
+            the chokepoint (rf2-z79p8) — so it is enrolled in the registry
+            and the CLJS gate covers it"
+    (let [hooks      (published-clear-warned-hooks)
+          all-source (vals (files-routing-through-chokepoint))
+          ;; A clear-fn is 'wired' if SOME source file enrols it through
+          ;; the chokepoint or the spine seam. We match on the unqualified
+          ;; fn name (the symbol after the last `/` in the hook key, minus
+          ;; the `clear-`/`!` decoration is too lossy — instead match the
+          ;; fn-name token the clear-fn is defined under, which by
+          ;; convention is the hook key's local name).
+          enrol-tokens ["register-warn-once-clear-fn!"
+                        "install-clear-warn-once-step!"]
+          chokepoint-source (filter (fn [s]
+                                      (some #(str/includes? s %) enrol-tokens))
+                                    all-source)]
+      (is (seq hooks)
+          "sanity: at least one clear-*warned* hook is published in source")
+      (is (seq chokepoint-source)
+          "sanity: the chokepoint / spine seam is referenced in source")
+      ;; For each published clear-*warned* hook, its local fn name should
+      ;; appear in a chokepoint-routing source file. The hook key's local
+      ;; name mirrors the clear-fn symbol (e.g.
+      ;; :views/clear-plain-fn-warned-pairs! ↔ clear-plain-fn-warned-pairs!).
+      (let [unrouted
+            (for [[hook-key _producer] hooks
+                  :let [fn-name (name hook-key)]
+                  :when (not (some #(str/includes? % fn-name) chokepoint-source))]
+              hook-key)]
+        (is (empty? unrouted)
+            (str "These clear-*warned* warn-once clear-fns are published as "
+                 "standalone late-bind hooks but their fn-name is NOT "
+                 "referenced at any chokepoint (register-warn-once-clear-fn! "
+                 "/ install-clear-warn-once-step!) call site — they may be "
+                 "stragglers NOT wired into the fixture chain (the "
+                 "rf2-z79p8 defect class):\n  "
+                 (str/join "\n  " (sort (map str unrouted)))))))))


### PR DESCRIPTION
## Summary

Closes the **4th recurrence** of the warn-once-`defonce`-not-in-clear-chain defect class (after rf2-4edk, rf2-9hoos, rf2-qy6cl) and adds a governance gate that **ends the class**.

`warned-plain-fn-frame-pairs` (`re-frame.views.warn-once`, the Spec 004 plain-fn-under-non-default-frame suppression set) was the straggler: its clear-fn was published only as the standalone `:views/clear-plain-fn-warned-pairs!` late-bind hook and was **absent** from the chained `:adapter/clear-warn-once-caches!` hook that `make-reset-runtime-fixture` fires. The standard fixture never re-armed it (only three test files cleared it by hand), so a sibling test's first-encounter warning could swallow a later same-pair warning — and `directory.cljc`'s "reset of every adapter warn-once cache" contract was factually wrong.

## The fix (two parts)

**1. Wire the 4th cache via a single chokepoint.** New `re-frame.late-bind/register-warn-once-clear-fn!` both chains a clear-fn into `:adapter/clear-warn-once-caches!` **and** records the cache (with `:arm`/`:armed?` probes) in a `warn-once-clear-registry`. Every contributor now routes through it:
- `warned-non-dom-roots` + `warned-plain-fn-frame-pairs` — `views/warn_once.cljs`
- `seen-render-keys` — `views.cljs`
- React-hook spine per-adapter source-coord cache — `spine.cljs` `make-react-adapter` (helix/uix)
- slim `warned-keyword-prop` — `reagent-slim` adapter, via the `install-clear-warn-once-step!` seam (now a thin delegator to the chokepoint)

**2. Governance gate that catches the whole class:**
- **CLJS** (`warn_once_clear_governance_cljs_test`) — enumerates the registry, arms every probe-carrying cache, fires the canonical chain **once**, and asserts each is wiped. Includes a dedicated **re-arm test** for the plain-fn pairs cache (arm → chain → empty) and a **would-fail negative proof**: a synthetic *unchained* cache injected straight into the registry survives the chain, proving the empirical assertion has teeth (and that a properly-enrolled cache, by contrast, IS wiped).
- **JVM** (`warn_once_clear_governance_test`) — single-chokepoint invariant: no source file but `re-frame.late-bind` may chain the key with a raw `chain-fn!` (a raw chain would wire a cache in *without* registry enrolment, blinding the CLJS gate). Plus enrolment coverage for every standalone `clear-*warned*` hook.

`directory.cljc` description updated to name all four members + the chokepoint; the late-bind drift-test `chain-fn` regex now also matches the bare `(chain-fn! ...)` form inside the chokepoint's defining ns.

## Quality gates (cold)
- core JVM `clojure -M:test` — **866 tests / 3883 assertions, 0 failures**
- `npm run test:cljs` — **5620 tests / 19581 assertions, 0 failures** (incl. the 4 new governance/re-arm tests)
- `npm run test:elision` — **PASS, 40/40 absent in production** (warn-once changes do not leak into the production bundle)

Closes rf2-z79p8.