### PR TITLE
fix(examples): repoint 2 stale test/ path comments + drop redundant ^:private (rf2-eu02v + rf2-ugwkh)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -134,7 +134,7 @@ If you've finished the guide and want to see code:
 3. **Then [`reagent/todomvc/`](reagent/todomvc/README.md)** — classic benchmark shape: persistence, editing, filters, and browser routing pressure.
 4. **Then [`reagent/routing/`](reagent/routing/)** or [`reagent/ssr/`](reagent/ssr/) — pick whichever is closer to your interest.
 5. **Then [`reagent/managed_http_counter/`](reagent/managed_http_counter/)** — the smallest possible Spec 014 demo, before the broader RealWorld surface.
-6. **Then [`reagent/state_machine_walkthrough/`](reagent/state_machine_walkthrough/)** — the ch.11 prose as runnable code; its headless scenarios live in the sibling `state_machine_walkthrough/test/` tree (driven by the `state-machine-walkthrough-runs-headless` gate deftest in [`implementation/core/test/re_frame/examples_test.clj`](../implementation/core/test/re_frame/examples_test.clj)).
+6. **Then [`reagent/state_machine_walkthrough/`](reagent/state_machine_walkthrough/)** — the ch.11 prose as runnable code; its headless scenarios run via the `state-machine-walkthrough-runs-headless` gate deftest in [`implementation/core/test/re_frame/examples_test.clj`](../implementation/core/test/re_frame/examples_test.clj).
 7. **Then [`reagent/seven_guis/`](reagent/seven_guis/)** — survey of the pattern across many UI shapes.
 8. **Then [`reagent/nine_states/`](reagent/nine_states/README.md)** — the page-level cardinality / lifecycle conventions wired together.
 9. **Then [`reagent/realworld/`](reagent/realworld/)** — substantial-app shape across the widest surface in the repo.

--- a/examples/reagent/ssr/index.html
+++ b/examples/reagent/ssr/index.html
@@ -28,8 +28,9 @@
     The data-rf-render-hash attribute would normally be emitted by
     render-to-string with :emit-hash? true; we omit it from the static page
     because we don't recompute the FNV-1a hash here. That side of Spec 011
-    is exercised by the JVM-side ssr-tests fn in test/ssr/core_test.clj (and
-    by the re-frame.ssr conformance suite).
+    is exercised by the JVM-side ssr-example-runs-end-to-end deftest in
+    implementation/core/test/re_frame/examples_test.clj (and by the
+    re-frame.ssr conformance suite).
   -->
   <div id="app">
     <div class="page">

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -95,7 +95,7 @@
   []
   (swap! mock-server-state assoc :sockets {}))
 
-(defn- ^:private later
+(defn- later
   "Run `f` synchronously in mock-sync mode; via `setTimeout` otherwise.
    This is the only knob that separates headless-test mode (sync) from
    the browser-driven example (async, microtask-delivered)."
@@ -104,10 +104,10 @@
     (f)
     (js/setTimeout f 0)))
 
-(defn- ^:private next-mock-socket-id []
+(defn- next-mock-socket-id []
   (str "mock-socket-" (random-uuid)))
 
-(defn- ^:private deliver-to-actor!
+(defn- deliver-to-actor!
   "Dispatch an inbound transport event into the spawned actor. The
    actor's machine handler translates the event into a parent-bound
    `[:ws/connection [:ws/<kind> ...]]` dispatch."
@@ -115,7 +115,7 @@
   (when actor-id
     (rf/dispatch [actor-id [kind payload]])))
 
-(defn- ^:private mock-encode-auth-reply [token]
+(defn- mock-encode-auth-reply [token]
   ;; A real server would validate the JWT; the mock accepts any
   ;; non-empty token and rejects the rest.
   (if (and (string? token) (pos? (count token)))
@@ -179,7 +179,7 @@
 ;; Exposed seams the views (and the headless tests) use to drive the
 ;; mock without dispatching through the actor.
 
-(defn- ^:private deliver-external!
+(defn- deliver-external!
   "Sync-mode-aware variant of `deliver-to-actor!` for callers OUTSIDE
    a running drain (i.e. test bodies, view click handlers). In sync
    mode it uses `dispatch-sync` so the chain runs to fixed point


### PR DESCRIPTION
Cleans up example-code comments/metadata. Examples are the surface newcomers copy (test-free per rf2-8cevm); comments must not point at paths that don't exist.

## rf2-eu02v (P3) — two stale in-tree `test/` path comments
Both survived the rf2-m8lig repoint (PR #3062) and each contradicted a correct impl-tree path nearby — the exact smell m8lig existed to remove.

- **`examples/reagent/ssr/index.html:31`** cited `test/ssr/core_test.clj` (no such dir; `ssr/` holds only README/core.cljc/index.html). Repointed to the JVM-side `ssr-example-runs-end-to-end` deftest in `implementation/core/test/re_frame/examples_test.clj` — matching the already-correct sibling citation in `ssr/core.cljc:305-311`.
- **`examples/README.md:137`** (reading-order item #6) cited "the sibling `state_machine_walkthrough/test/` tree". Dropped the contradicting lead clause; the parenthetical already named the correct `state-machine-walkthrough-runs-headless` gate deftest in the same `examples_test.clj`.

Both target deftests verified present (`examples_test.clj:81` and `:179`); the test file exists.

## rf2-ugwkh (P4) — 5x redundant `defn- ^:private`
`examples/reagent/websocket/messages.cljs` had `(defn- ^:private ...)` at five sites. `defn-` already sets `:private true`, so the explicit tag is doubled. Dropped `^:private` (kept `defn-`) at `later` / `next-mock-socket-id` / `deliver-to-actor!` / `mock-encode-auth-reply` / `deliver-external!`.

## Quality gates
- Examples stay **test-free**: no `*.spec.cjs` added (verified `git status` clean of spec.cjs).
- Residual greps clean: `git grep 'walkthrough/test/|ssr/core_test|state_machine_walkthrough/test/' -- examples/` → none; `git grep 'defn- \^:private' -- examples/` → none.
- Repointed paths verified to exist: `implementation/core/test/re_frame/examples_test.clj` + both named deftests.
- `messages.cljs` form-reads cleanly (29 top-level forms via `clojure -M -e`).
- Comment/metadata-only — zero behavioural change.