### PR TITLE
fix(machines): region-identity-scope done.state raises — close the sibling shared-state-name leak (rf2-12ekv)

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -823,36 +823,64 @@
       `:event` (`(= <path> (second event))`) to disambiguate which node is
       done when several could raise it.
 
-  **Parallel-region scoping of arm 2 (rf2-m3arq).** A region-local compound's
-  done signal is re-broadcast across EVERY sibling region by the parent
-  internal-event queue (`parallel/drain-parent-queue` — the correct XState v5 /
-  SCXML `:raise` rule). The raised `[:rf.machine/done <region-relative-path>]`
-  therefore reaches every region's resolver. XState v5 / SCXML scope the
-  `done.state.<id>` event to the region that raised it — a SIBLING region must
-  NOT catch another region's done. Arm 1 (`:on-done` on the done node) is
-  naturally region-scoped (it resolves the done node by `done-path` relative to
-  the region body and only the originating region carries that node on its
-  active path), but the lower-level arm 2 escape hatch matches on the bare
-  reserved event-id and does NOT itself read the path — so an UNGUARDED
-  `:on {:rf.machine/done …}` in a sibling region would otherwise catch a
-  foreign region's done (a silent cross-region leak). To close it by
-  construction: when `machine` is a region (`:rf/region` present), arm 2 only
-  fires when the raised `done-path` is on THIS region's active `path` (the done
-  compound is a prefix of / equal to the active path — the same `prefix-of?`
-  staleness check `pick-after-transition` / `pick-spawn-error-transition` use).
-  A sibling's done-path is not a prefix of this region's active path, so the
-  sibling declines and the broadcast routes the done to its OWN region only.
-  Flat / compound machines carry no `:rf/region`, so the gate is a no-op there:
-  an unguarded `:on {:rf.machine/done …}` stays unambiguous (only the one
-  machine raises into itself). Arm 1 is left exactly as-is — the conformance-
-  verified leak-free common `:on-done` placement.
+  **Parallel-region scoping — by region IDENTITY, not state-name shape
+  (rf2-12ekv, superseding the rf2-m3arq shape-match).** A region-local
+  compound's done signal is re-broadcast across EVERY sibling region by the
+  parent internal-event queue (`parallel/drain-parent-queue` — the correct
+  XState v5 / SCXML `:raise` rule), so the raised done reaches every region's
+  resolver. XState v5 / SCXML scope `done.state.<id>` to the region that raised
+  it BY NODE IDENTITY — a SIBLING region must NOT catch another region's done,
+  even one whose compound shares the leading state-name (a common shape:
+  per-region `:flow` sub-flows, `:loading`/`:loaded` axes).
 
-  `done-path` is the node's declaration path (the event's second element).
-  Returns `{:transition t :decl-path p}` or nil (no `:on-done` and no
-  enclosing handler — the done signal is then a benign no-op, exactly as an
-  unhandled reserved-`:rf/*` event)."
+  The earlier rf2-m3arq gate compared two REGION-RELATIVE paths with
+  `prefix-of?` — a state-name SHAPE match, not a region-identity test — so it
+  leaked whenever the sibling shared the leading state-name, and it only guarded
+  arm 2 (arm 1 was ungated). The root-cause fix (rf2-12ekv) makes the done-raise
+  carry a REGION-NAME HEAD (`done-raise-fx` stamps `:rf/region` onto the raised
+  path — the same region-name-prefixing discipline `:after` / `:spawn`
+  `:on-error` already use). Here we strip that head and decline a FOREIGN
+  region's done by region NAME, mirroring `pick-after-transition`
+  (`decline-region?` = `(not= region (first carried-path))`) and
+  `pick-spawn-error-transition`. The region-stripped path is then region-
+  relative again for BOTH arms — arm 1 resolves the done node via the stripped
+  `done-path`, arm 2 walks `:on` for the stripped event — so a sibling sharing
+  the path-SHAPE no longer matches: identity (the region-name head), not shape,
+  decides. Flat / compound machines carry no `:rf/region` and the done-raise
+  carries no head, so the strip / decline is inert — an unguarded
+  `:on {:rf.machine/done …}` stays unambiguous (only the one machine raises into
+  itself).
+
+  `done-path` is the node's declaration path (the event's second element,
+  region-stripped when `machine` is a region). Returns `{:transition t
+  :decl-path p}` or nil (no `:on-done` and no enclosing handler — the done
+  signal is then a benign no-op, exactly as an unhandled reserved-`:rf/*`
+  event; a foreign region's done declines to nil here too)."
   [machine path event snapshot]
-  (let [[_ done-path] event
+  (let [[_ raw-done-path] event
+        region        (:rf/region machine)
+        ;; rf2-12ekv — region-identity scoping. The done-raise carries a
+        ;; region-name HEAD when raised from a parallel region (`done-raise-fx`
+        ;; stamps `:rf/region`). Within a region's resolution `machine` is the
+        ;; region body (region-relative `node-at`) and `path` is in-region, so
+        ;; strip the region-name head. A head naming a DIFFERENT region is not
+        ;; this region's done — decline (the broadcast routes the done to its
+        ;; OWN region only). Mirrors `pick-after-transition` /
+        ;; `pick-spawn-error-transition`. A flat / compound machine (no
+        ;; `:rf/region`) carries no head — the strip is inert.
+        decline-region? (and region
+                             (vector? raw-done-path)
+                             (not= region (first raw-done-path)))
+        done-path     (cond
+                        (not (vector? raw-done-path)) raw-done-path
+                        region (vec (rest raw-done-path))
+                        :else  raw-done-path)
+        ;; The done event also rides on `:event` for a guard / action reading
+        ;; `(second event)`; re-stamp it region-relative so the in-region view
+        ;; is consistent (the region-name head is an internal routing detail).
+        event         (if (and region (vector? raw-done-path))
+                        (assoc (vec event) 1 done-path)
+                        event)
         done-node     (when (vector? done-path) (node-at machine done-path))
         ;; rf2-16gxd — gate on PRESENCE of `:on-done`. The forbidden-transition
         ;; nil→`[{}]` rule in `normalise-candidates` is for a PRESENT value;
@@ -863,21 +891,12 @@
                         (normalise-candidates (:on-done done-node)
                                               :rf.error/machine-bad-on-done-clause))
         on-done-hit   (when (seq on-done-cands)
-                        (select-passing-candidate machine on-done-cands snapshot event))
-        ;; rf2-m3arq — arm-2 region scoping. In a parallel region the done
-        ;; signal is broadcast to every sibling; the explicit-`:on` escape
-        ;; hatch must only catch THIS region's own done. A flat / compound
-        ;; machine (no `:rf/region`) is always own-region — the gate is inert.
-        own-region?   (or (not (:rf/region machine))
-                          (and (vector? done-path)
-                               (prefix-of? done-path path)))]
-    (if on-done-hit
-      {:transition on-done-hit :decl-path (vec done-path)}
-      ;; Fall through to the standard leaf→root `:on` walk (an ancestor's
-      ;; explicit `:on {:rf.machine/done …}`), then the root `:on` — but only
-      ;; for THIS region's own done (rf2-m3arq), so a sibling region's
-      ;; broadcast done cannot be caught by an unguarded escape hatch here.
-      (when own-region?
+                        (select-passing-candidate machine on-done-cands snapshot event))]
+    (when-not decline-region?
+      (if on-done-hit
+        {:transition on-done-hit :decl-path (vec done-path)}
+        ;; Fall through to the standard leaf→root `:on` walk (an ancestor's
+        ;; explicit `:on {:rf.machine/done …}`), then the root `:on`.
         (or
           (path-walk/walk-path-leaf-to-root
             machine path
@@ -2018,11 +2037,30 @@
   `drain-or-defer-raises` / the parallel parent queue) so the enclosing
   `:on-done` transition fires in the SAME macrostep. Returns `[]` when no
   compound is newly done (the common case — most transitions land on an
-  ordinary leaf). `machine` is the flat / compound machine or a region body."
+  ordinary leaf). `machine` is the flat / compound machine or a region body.
+
+  **Region-identity scoping (rf2-12ekv).** When `machine` is a parallel region
+  (`:rf/region` present), `compound-done-paths` returns a REGION-RELATIVE path
+  (region-body `node-at`). The parent internal-event queue re-broadcasts the
+  raise across EVERY sibling region (the correct XState v5 / SCXML `:raise`
+  rule — `drain-parent-queue`), so a bare region-relative path carries NO
+  region-identity discriminator: a sibling sharing the leading state-name would
+  falsely match it. Stamp the region name as the path HEAD — the SAME
+  region-name-prefixing discipline `:after` (carried `decl-path`) and `:spawn`
+  `:on-error` (`prefix-region-spawn-id` on the invoke-id) already use — so the
+  done-raise becomes `[:rf.machine/done [<region-name> & <region-relative-path>]]`.
+  `pick-done-transition` then strips the region head and declines a foreign
+  region's done by region NAME (identity), not state-name shape. XState v5 /
+  SCXML raise `done.state.<region-id>`, not a bare state-name; this matches that
+  by node identity. Flat / compound machines (no `:rf/region`) carry no head —
+  the path stays region-relative and the resolver's gate is inert."
   [machine leaf-path]
-  (mapv (fn [compound-path]
-          [:raise [done-event-id compound-path]])
-        (compound-done-paths machine leaf-path)))
+  (let [region (:rf/region machine)]
+    (mapv (fn [compound-path]
+            [:raise [done-event-id (if region
+                                     (vec (cons region compound-path))
+                                     compound-path)]])
+          (compound-done-paths machine leaf-path))))
 
 (defn apply-on-done-action
   "Per Spec 005 §Final states §The done-state signal (rf2-bnjb3): run a

--- a/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
@@ -680,12 +680,15 @@
            region to :work-done; :status stayed :idle"))))
 
 (deftest scxml-parallel-region-done-not-caught-by-sibling-unguarded-on
-  (testing "rf2-m3arq: a region-local done.state is region-SCOPED — a SIBLING
-            region's UNGUARDED `:on {:rf.machine/done …}` escape hatch must NOT
-            catch another region's done signal, even though the parent
+  (testing "rf2-m3arq + rf2-12ekv: a region-local done.state is region-SCOPED —
+            a SIBLING region's UNGUARDED `:on {:rf.machine/done …}` escape hatch
+            must NOT catch another region's done signal, even though the parent
             internal-event queue re-broadcasts the raise across every region
             (the correct XState v5 / SCXML `:raise` rule). XState v5 / SCXML
-            scope `done.state.<id>` to the region that raised it. Spec 005
+            scope `done.state.<id>` to the region that raised it BY IDENTITY.
+            Strengthened for rf2-12ekv: `:other` now SHARES the leading
+            state-name `:flow` (the rf2-m3arq shape-match leaked on exactly
+            this collision; only region-NAME scoping closes it). Spec 005
             §Final states §The done-state signal × §Parallel regions; the
             arm-2 escape-hatch region scoping in `pick-done-transition`."
     (let [m {:type :parallel :data {}
@@ -700,22 +703,138 @@
                                               :inner-done {:final? true}}}
                               :work-done {}}}
               ;; :other carries an UNGUARDED escape hatch on the SAME reserved
-              ;; event-id. Before rf2-m3arq the re-broadcast of :work's
-              ;; region-local done would be CAUGHT here, leaking :other →
+              ;; event-id AND shares the leading state-name `:flow`. Before
+              ;; rf2-12ekv the re-broadcast of :work's region-relative done
+              ;; [:flow] would be CAUGHT here (shape match), leaking :other →
               ;; :hijacked. It must stay put: :work's done is not :other's done.
-              :other {:initial :idle
+              :other {:initial :flow
                       :on {:rf.machine/done :hijacked}
-                      :states {:idle {} :hijacked {}}}}}
+                      :states {:flow {:initial :wait
+                                      :states {:wait {}}}
+                               :hijacked {}}}}}
           ;; :finish lands :work at [:flow :inner-done]; :flow is done →
-          ;; region-local [:rf.machine/done [:flow]] raise → re-broadcast across
-          ;; BOTH regions. :work catches its own done (region-owned) → :work-done.
-          ;; :other declines (the done-path is not on :other's active path).
-          r (step m {:state {:work [:flow :step] :other :idle} :data {}} [:finish])]
-      (is (= {:work :work-done :other :idle} (:state r))
+          ;; region-scoped [:rf.machine/done [:work :flow]] raise → re-broadcast
+          ;; across BOTH regions. :work catches its own done (region-name head
+          ;; matches) → :work-done. :other declines (head names :work, not
+          ;; :other) even though :other ALSO has a :flow.
+          r (step m {:state {:work [:flow :step] :other [:flow :wait]} :data {}}
+                  [:finish])]
+      (is (= {:work :work-done :other [:flow :wait]} (:state r))
           ":work caught its own region-local done via its explicit `:on`
            escape hatch → :work-done; :other's UNGUARDED `:on {:rf.machine/done}`
-           did NOT catch :work's done (no cross-region leak) → :other stayed
-           :idle"))))
+           did NOT catch :work's done (no cross-region leak) despite sharing the
+           `:flow` state-name → :other stayed [:flow :wait]"))))
+
+(deftest scxml-parallel-region-done-arm2-not-caught-by-sibling-shared-state-name
+  (testing "rf2-12ekv: arm 2 region scoping must be by region IDENTITY, not
+            state-name SHAPE. A region-local done.state is region-SCOPED even
+            when a SIBLING region shares the LEADING state-name on the done
+            compound's region-relative path. XState v5 / SCXML scope
+            `done.state.<id>` to the originating region by node identity, never
+            by a same-named compound in a sibling. The rf2-m3arq arm-2 gate
+            used `prefix-of?` on two REGION-RELATIVE paths — a shape match that
+            falsely passes when the sibling shares the leading state-name. The
+            fix region-name-prefixes the done-raise path (as `:after` /
+            `:on-error` already do) and declines by region-NAME head. Spec 005
+            §Final states §The done-state signal × §Parallel regions
+            (005:2819 — \"sibling regions are untouched\")."
+    (let [m {:type :parallel :data {}
+             :regions
+             ;; :work owns a compound :flow that goes done on :finish, via the
+             ;; lower-level explicit `:on {:rf.machine/done …}` escape hatch
+             ;; (arm 2). Its done-raise carries the region-relative path [:flow].
+             {:work {:initial :flow
+                     :on {:rf.machine/done :work-done}
+                     :states {:flow {:initial :step
+                                     :states {:step {:on {:finish :inner-done}}
+                                              :inner-done {:final? true}}}
+                              :work-done {}}}
+              ;; :other ALSO has a compound named :flow on its active path —
+              ;; SHARING the leading state-name — and an UNGUARDED escape hatch.
+              ;; The bare region-relative done-path [:flow] is a prefix of
+              ;; :other's active path [:flow :wait], so the rf2-m3arq shape-match
+              ;; gate falsely passes and :other's hatch fires → :hijacked. It
+              ;; must stay put: :work's done is not :other's done.
+              :other {:initial :flow
+                      :on {:rf.machine/done :hijacked}
+                      :states {:flow {:initial :wait
+                                      :states {:wait {}}}
+                               :hijacked {}}}}}
+          r (step m {:state {:work [:flow :step] :other [:flow :wait]} :data {}}
+                  [:finish])]
+      (is (= {:work :work-done :other [:flow :wait]} (:state r))
+          ":work caught its OWN region-local done → :work-done; :other shares
+           the leading state-name :flow but its UNGUARDED `:on {:rf.machine/done}`
+           must NOT catch :work's done (region IDENTITY, not name shape) →
+           :other stayed [:flow :wait]"))))
+
+(deftest scxml-parallel-region-done-arm1-not-caught-by-sibling-shared-state-name
+  (testing "rf2-12ekv: arm 1 (`:on-done` on the done node) must ALSO be
+            region-scoped by identity. The rf2-m3arq fix only gated arm 2 (and
+            with a shape match); arm 1 was ungated entirely. A sibling region
+            carrying an `:on-done` on a compound at the SAME region-relative
+            path as the originating region's done compound resolves the done
+            node via `node-at` against the sibling's body and fires on the
+            broadcast — a silent cross-region leak. The fix region-name-prefixes
+            the done-raise path and declines BOTH arms by region-NAME head.
+            Spec 005 §Final states §The done-state signal × §Parallel regions."
+    (let [m {:type :parallel :data {}
+             :regions
+             ;; :work's compound :flow goes done on :finish and advances itself
+             ;; via its own `:on-done` (arm 1) — the headline placement.
+             {:work {:initial :flow
+                     :states {:flow {:initial :step
+                                     :on-done :work-done
+                                     :states {:step {:on {:finish :inner-done}}
+                                              :inner-done {:final? true}}}
+                              :work-done {}}}
+              ;; :other ALSO has a compound :flow at the SAME region-relative
+              ;; path, carrying its OWN `:on-done`. The bare broadcast done-path
+              ;; [:flow] resolves :other's :flow node (same shape) so its ungated
+              ;; arm-1 `:on-done` fires → :hijacked. It must stay put.
+              :other {:initial :flow
+                      :states {:flow {:initial :wait
+                                      :on-done :hijacked
+                                      :states {:wait {}}}
+                               :hijacked {}}}}}
+          r (step m {:state {:work [:flow :step] :other [:flow :wait]} :data {}}
+                  [:finish])]
+      (is (= {:work :work-done :other [:flow :wait]} (:state r))
+          ":work's compound :flow reached final, its `:on-done` advanced :work →
+           :work-done; :other's same-shaped :flow `:on-done` must NOT fire on
+           :work's done (region IDENTITY) → :other stayed [:flow :wait]"))))
+
+(deftest scxml-parallel-region-done-arm1-negative-control-genuine-sibling-done
+  (testing "rf2-12ekv negative control: the region-identity scoping must NOT
+            block a region's OWN compound-done from firing its own `:on-done`
+            when a sibling shares the leading state-name. Both regions go done
+            on the SAME external event; each must advance via its OWN `:on-done`
+            — proving the gate declines a FOREIGN region's done, not the OWN
+            region's. Spec 005 §Final states §The done-state signal × §Parallel
+            regions."
+    (let [m {:type :parallel :data {}
+             :regions
+             {:work {:initial :flow
+                     :states {:flow {:initial :step
+                                     :on-done :work-done
+                                     :states {:step {:on {:finish :inner-done}}
+                                              :inner-done {:final? true}}}
+                              :work-done {}}}
+              :other {:initial :flow
+                      :states {:flow {:initial :step
+                                      :on-done :other-done
+                                      :states {:step {:on {:finish :inner-done}}
+                                               :inner-done {:final? true}}}
+                               :other-done {}}}}}
+          ;; :finish lands BOTH regions at [:flow :inner-done]; each :flow is
+          ;; done → each region raises its OWN region-scoped done → each fires
+          ;; its OWN `:on-done`. No leak, no over-decline.
+          r (step m {:state {:work [:flow :step] :other [:flow :step]} :data {}}
+                  [:finish])]
+      (is (= {:work :work-done :other :other-done} (:state r))
+          "each region's own compound-done fired its OWN `:on-done` even though
+           both share the leading state-name :flow — region scoping declines a
+           FOREIGN region's done, never the OWN region's"))))
 
 ;; ===========================================================================
 ;; §6. Eventless / :always microstep settle (transient transitions)


### PR DESCRIPTION
## Summary

`rf2-m3arq`s cross-region `done.state` leak fix was **incomplete** (`rf2-12ekv`). A region-local `done.state` still leaked to a SIBLING region whenever the sibling shared the leading state-name on the done compounds region-relative path — the common shape of two regions with same-named compounds (per-region `:flow` sub-flows, `:loading`/`:loaded` axes). Failure mode: silent cross-region state corruption.

### Root cause

The done-raise `[:rf.machine/done <compound-path>]` carried a **region-relative** path with **no region discriminator** (unlike `:after`s carried decl-path and `:spawn` `:on-error`s invoke-id, which both carry a region-name head via `prefix-region-spawn-id`). The parent internal-event queue re-broadcasts that bare path across every region, so:

- **arm 2** (explicit `:on {:rf.machine/done}` escape hatch) gated by `prefix-of?` on two region-relative paths — a state-name **SHAPE** match that falsely passes when a sibling shares the leading state-name;
- **arm 1** (`:on-done` on the done node) was **never gated** — a sibling with a node at the same region-relative path fires on the broadcast.

### Fix (root cause, mirrors `:after` / `:spawn :on-error`)

- `done-raise-fx` now stamps the **region name as the raised path HEAD** when the machine is a region (`[:rf.machine/done [<region> & <region-relative-path>]]`).
- `pick-done-transition` **strips that head and declines a FOREIGN regions done by region NAME (identity), not shape** — for **BOTH arms**. It re-stamps `:event` region-relative for guard/action consumption. Flat/compound machines carry no head, so the strip/decline is inert.

This makes the scoping match XState v5 / SCXMLs `done.state.<region-id>` by node identity, and removes the arm-1/arm-2 asymmetry the m3arq docstring incorrectly claimed didnt exist.

### Tests

- New: `scxml-parallel-region-done-arm2-not-caught-by-sibling-shared-state-name` and `...-arm1-...` reproduce the leak with two regions sharing `:flow` (both **fail** against pre-fix `main`).
- New negative control: `...-arm1-negative-control-genuine-sibling-done` — both regions go done on one event, each fires its OWN `:on-done` (proves the gate declines a foreign done, never the own).
- Strengthened the existing `rf2-m3arq` test to share the `:flow` state-name across siblings (it previously passed only by naming accident).

### Without-fix-fails proof (against pre-fix `main`)

```
FAIL in (scxml-parallel-region-done-arm2-not-caught-by-sibling-shared-state-name)
expected: (= {:work :work-done, :other [:flow :wait]} (:state r))
  actual: (not (= {:work :work-done, :other [:flow :wait]} {:work :work-done, :other :hijacked}))

FAIL in (scxml-parallel-region-done-arm1-not-caught-by-sibling-shared-state-name)
expected: (= {:work :work-done, :other [:flow :wait]} (:state r))
  actual: (not (= {:work :work-done, :other [:flow :wait]} {:work :work-done, :other :hijacked}))

Ran 3 tests containing 3 assertions.
2 failures, 0 errors.
```

Both arms leak `:other -> :hijacked` pre-fix; pass post-fix.

## Quality gates

machines JVM `clojure -M:test` (cold, incl. the new tests):

```
Ran 468 tests containing 1480 assertions.
0 failures, 0 errors.
```

`npm run test:cljs` from `implementation/` (cold):

```
Ran 5625 tests containing 19593 assertions.
0 failures, 0 errors.
```

Closes rf2-12ekv.