### PR TITLE
fix(skills): re-point pair-retro issue filing to day8/re-frame2 + pair-mcp label (rf2-x0123)

### DIFF
--- a/skills/re-frame2-pair-retro/README.md
+++ b/skills/re-frame2-pair-retro/README.md
@@ -15,7 +15,7 @@ It is designed for retrospectives like:
 
 It focuses on evidence from the session itself: retries, confusion, workarounds, stale or empty results, missing observability, brittle platform behavior, hidden prerequisites, and trust gaps. It then proposes improvements at the right layer: `SKILL.md`, scripts/runtime ops, warnings/results, tests/fixtures, or — when the friction is caused by the framework rather than the pair tool — an upstream GitHub issue against `day8/re-frame2`.
 
-It can draft a GitHub issue (against `day8/re-frame2-pair` for tool-side friction or `day8/re-frame2` for upstream framework friction), but only if the user wants that.
+It can draft a GitHub issue against `day8/re-frame2` — the monorepo where the pair tool ships, alongside the framework — but only if the user wants that. Tool-side friction is filed under the `pair-mcp` label; upstream framework friction is filed without it, so the two stay distinguishable.
 
 It is intentionally diagnosis-first: the default outcome is a better understanding of what went wrong and which improvements would matter most, not pressure to contribute code or file issues.
 
@@ -48,7 +48,7 @@ A good run of the skill produces:
 2. the main friction points observed in the session
 3. likely root causes
 4. 2-5 high-leverage improvement ideas
-5. optional GitHub-issue candidates (against `day8/re-frame2-pair` and/or `day8/re-frame2`), with draft text or direct filing only after approval
+5. optional GitHub-issue candidates (against `day8/re-frame2`, labelled `pair-mcp` for tool-side friction), with draft text or direct filing only after approval
 
 ## Status
 

--- a/skills/re-frame2-pair-retro/references/analysis-lenses.md
+++ b/skills/re-frame2-pair-retro/references/analysis-lenses.md
@@ -105,11 +105,11 @@ Also consider higher-upside redesigns:
 
 ## Routing the fix
 
-Decide which target repo's GitHub issues the filing lives in before drafting:
+Decide which kind of friction it is before drafting. Both file against **`day8/re-frame2`** (the pair tool ships inside that monorepo), distinguished by label:
 
-- **`day8/re-frame2-pair`** — the friction is in the tool's SKILL.md, scripts, attach logic, recipe selection, structured-result shape, cross-platform handling, or any concern that is not part of the framework's commitment.
-- **`day8/re-frame2`** — the friction is caused by a gap or ambiguity in the Tool-Pair contract itself. Name the specific surface from [`../../shared/tool-pair-surfaces.md`](../../shared/tool-pair-surfaces.md) (e.g. a missing trace event category, an under-specified `:rf.epoch/*` failure mode, a missing registrar query, a `data-rf2-source-coord` shape question, a schema-reflection limitation) or a private-namespace reach-through that should be promoted to public.
-- **Both** — sometimes the fastest path is a tool-side workaround now plus an upstream issue for the long-term fix. File both, and reference one from the other.
+- **pair-tool friction** (`--label pair-mcp`) — the friction is in the tool's SKILL.md, scripts, attach logic, recipe selection, structured-result shape, cross-platform handling, or any concern that is not part of the framework's commitment.
+- **framework friction** (no `pair-mcp` label) — the friction is caused by a gap or ambiguity in the Tool-Pair contract itself. Name the specific surface from [`../../shared/tool-pair-surfaces.md`](../../shared/tool-pair-surfaces.md) (e.g. a missing trace event category, an under-specified `:rf.epoch/*` failure mode, a missing registrar query, a `data-rf2-source-coord` shape question, a schema-reflection limitation) or a private-namespace reach-through that should be promoted to public.
+- **Both** — sometimes the fastest path is a tool-side workaround now (labelled `pair-mcp`) plus an upstream issue for the long-term fix. File both, and reference one from the other.
 
 ## Prioritization
 

--- a/skills/re-frame2-pair-retro/references/issue-template.md
+++ b/skills/re-frame2-pair-retro/references/issue-template.md
@@ -2,14 +2,14 @@
 
 Use this structure when drafting or filing an improvement. Keep it evidence-based and concise.
 
-The default filing path is a **GitHub issue** against the target repo — `re-frame2-pair` for pair-tool friction, `re-frame2` for upstream / framework friction. (Tracker boundary: never `bd` — see Filing rules below.)
+The default filing path is a **GitHub issue** against `day8/re-frame2` — the pair tool ships inside that monorepo (`skills/re-frame2-pair/` + `tools/re-frame2-pair-mcp/`). Pair-tool friction and upstream / framework friction both file there; a **`pair-mcp` label** distinguishes pair-tool issues from framework issues. (Tracker boundary: never `bd` — see Filing rules below.)
 
 ## Routing first
 
-Before drafting, decide the target repo:
+Before drafting, decide which kind of friction it is — both target `day8/re-frame2`, distinguished by label:
 
-- **`re-frame2-pair`** — friction in the pair tool itself: SKILL.md, scripts, recipes, attach logic, structured results, cross-platform handling.
-- **`re-frame2`** — friction caused by a gap in the framework's Tool-Pair contract. Name the specific surface from [`../../shared/tool-pair-surfaces.md`](../../shared/tool-pair-surfaces.md) (e.g. missing trace event category, under-specified `:rf.epoch/*` failure mode, missing registrar query, source-coord shape question, schema-reflection limitation) or a private-namespace reach-through that should be promoted.
+- **pair-tool friction** (`--label pair-mcp`) — friction in the pair tool itself: SKILL.md, scripts, recipes, attach logic, structured results, cross-platform handling.
+- **framework friction** (no `pair-mcp` label) — friction caused by a gap in the framework's Tool-Pair contract. Name the specific surface from [`../../shared/tool-pair-surfaces.md`](../../shared/tool-pair-surfaces.md) (e.g. missing trace event category, under-specified `:rf.epoch/*` failure mode, missing registrar query, source-coord shape question, schema-reflection limitation) or a private-namespace reach-through that should be promoted.
 
 When unsure, ask the user. Sometimes both: a tool-side workaround now and an upstream GitHub issue for the long-term fix; cross-link them.
 
@@ -71,17 +71,17 @@ Once the body is drafted and the user has approved, file via the GitHub CLI. Nev
    …
    ```
 
-2. File it against the target repo's issues with one `gh issue create` command:
+2. File it against `day8/re-frame2` with one `gh issue create` command. For **pair-tool friction**, add the `pair-mcp` label so it is distinguishable from framework issues:
 
    ```bash
    gh issue create \
-     --repo day8/re-frame2-pair \
+     --repo day8/re-frame2 \
      --title "<short title>" \
      --body-file /tmp/issue-body.md \
-     --label retro
+     --label retro,pair-mcp
    ```
 
-For an upstream issue against re-frame2:
+For **framework friction** (a gap in the Tool-Pair contract), file against the same repo without the `pair-mcp` label:
 
 ```bash
 gh issue create \

--- a/skills/re-frame2-pair-retro/spec/design.md
+++ b/skills/re-frame2-pair-retro/spec/design.md
@@ -29,14 +29,16 @@ Per the parent `re-frame2-pair` skill's L2: re-frame2's pair tooling does not de
 
 The skill drafts issue text on request; it does not file issues autonomously. After presenting the retrospective, the skill offers to file *only if asked*. Filing is opt-in, not opt-out. This is a cardinal guard-rail.
 
-**Tracker boundary.** Filings target the **target repo's GitHub issues** (`day8/re-frame2-pair` for tool-side friction; `day8/re-frame2` for upstream framework friction). `bd` (beads) is the re-frame2 monorepo's internal tracker and is never invoked from a published skill. The body is composed to a file with the `Write` tool and passed via `gh`'s native `--body-file` flag — `gh issue create --body-file /tmp/issue-body.md` — never inline interpolation of transcript-derived text. See `skills/README.md` §Published-skill `allowed-tools` baseline for the canonical shape.
+**Tracker boundary.** Filings target **`day8/re-frame2`'s GitHub issues** — the pair tool ships inside that monorepo (`skills/re-frame2-pair/` + `tools/re-frame2-pair-mcp/`), so both tool-side and framework friction file there, distinguished by the `pair-mcp` label (tool-side carries it; framework friction does not). `bd` (beads) is the re-frame2 monorepo's internal tracker and is never invoked from a published skill. The body is composed to a file with the `Write` tool and passed via `gh`'s native `--body-file` flag — `gh issue create --body-file /tmp/issue-body.md` — never inline interpolation of transcript-derived text. See `skills/README.md` §Published-skill `allowed-tools` baseline for the canonical shape.
 
-### L3 — Route the fix to the right repo
+### L3 — Route the fix to the right layer
 
-- **`re-frame2-pair`** — friction inside the pair tool: SKILL.md, scripts/MCP tools, recipes, structured results, attach/discovery brittleness, cross-platform handling.
-- **`re-frame2`** — friction caused by the framework's Tool-Pair contract: missing trace events, gaps in `epoch-history` / `restore-epoch` failure modes, missing registrar query surfaces, source-coordinate annotation gaps, schema-reflection shortcomings.
+Both kinds of friction file against `day8/re-frame2`, distinguished by label:
 
-The skill is explicit about which repo each draft issue targets. Mis-routing wastes the maintainer's time.
+- **pair-tool friction** (`--label pair-mcp`) — friction inside the pair tool: SKILL.md, scripts/MCP tools, recipes, structured results, attach/discovery brittleness, cross-platform handling.
+- **framework friction** (no `pair-mcp` label) — friction caused by the framework's Tool-Pair contract: missing trace events, gaps in `epoch-history` / `restore-epoch` failure modes, missing registrar query surfaces, source-coordinate annotation gaps, schema-reflection shortcomings.
+
+The skill is explicit about which label each draft issue carries (both target `day8/re-frame2`). Mis-labelling wastes the maintainer's time.
 
 ### L4 — Diagnosis-first workflow
 

--- a/skills/shared/issue-filing.md
+++ b/skills/shared/issue-filing.md
@@ -10,7 +10,7 @@ Drafting issue text is always fine; running `gh issue create` is gated on a fres
 
 ## Tracker boundary
 
-Skills file **GitHub issues** against the target repo via `gh issue create`. `bd` (beads) is the re-frame2 monorepo's internal tracker and is **never** invoked from these skills. Route the issue to the repo the layer rules pick (`re-frame2-pair` for pair-tool friction, `re-frame2` for upstream Tool-Pair friction).
+Skills file **GitHub issues** against the target repo via `gh issue create`. `bd` (beads) is the re-frame2 monorepo's internal tracker and is **never** invoked from these skills. For the re-frame2-pair tool both kinds of friction file against `day8/re-frame2` (the monorepo that ships the tool), distinguished by label: pair-tool friction carries the `pair-mcp` label, upstream Tool-Pair friction does not.
 
 ## Search before filing
 


### PR DESCRIPTION
@
## What

The `re-frame2-pair-retro` skill routed **tool-side** issue filing to `day8/re-frame2-pair` — a repo that **does not exist**. The pair tool ships inside the `day8/re-frame2` monorepo (`skills/re-frame2-pair/` + `tools/re-frame2-pair-mcp/`, npm `@day8/re-frame2-pair-mcp`), so the worked `gh issue create --repo day8/re-frame2-pair ...` command failed with repository-not-found at the moment of filing — after the agent drafted the issue and got user approval.

## Ruling (Mike, B — rf2-x0123)

Re-point tool-side filing to `day8/re-frame2` scoped by a **`pair-mcp` label**. Both tool-side and framework friction now file against the same (real) repo; the label distinguishes them. The conceptual tool-vs-framework split is preserved — only the tool-side TARGET changed (repo + label, not a separate repo). Reversible if the pair tool is later split into its own repo.

## Changes (docs-only)

- `references/issue-template.md` — worked `gh issue create` example now `--repo day8/re-frame2 --label retro,pair-mcp`; routing prose updated.
- `references/analysis-lenses.md` — §Routing the fix re-expressed as label-based.
- `README.md` — stops naming `day8/re-frame2-pair` as a distinct repo.
- `shared/issue-filing.md` — tracker-boundary routing re-pointed.
- `spec/design.md` — tracker boundary + L3 routing updated for consistency.

`skills/README.md` generic single-source left untouched (already correct).

## Quality gates

Docs-only skill change.

- (a) **Zero** `--repo day8/re-frame2-pair` anywhere under `skills/` (`git grep` clean). No routing reference in `skills/re-frame2-pair-retro/` or `skills/shared/` points to the non-existent repo. (Remaining `@day8/re-frame2-pair*` matches are npm package names + the `npx skills add` distribution slug — not issue-filing targets, out of scope.)
- (b) The worked `gh issue create` example now targets `day8/re-frame2` (an existing repo) with `--label retro,pair-mcp` — no repository-not-found at the file step.
- Tool-side vs framework friction remain distinguishable (now by label).
@