### PR TITLE
feat(machines-viz): error-final outer-ring affordance (rf2-b4loj)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -138,6 +138,43 @@ scoping + §3.1 G9).
 > unambiguous final-state signal; the glyph competed with the state
 > title for attention against the structure-first grammar.
 
+> **rf2-b4loj error-final terminal KIND (re-frame2 semantic clarity, NOT
+> XState/Stately parity).** Spec 005 §`:final?` lets a `:final?` leaf
+> declare `:error?` true — an **error terminal**. This is a re-frame2
+> **extension**: a child that finishes via an `:error?` final routes the
+> spawning parent's `:spawn` **`:on-error`** transition instead of
+> `:on-done`. XState v5 has final-states-with-output and actor `onError`
+> but **no first-class error-final flag**, and Stately therefore draws no
+> such marker — so this is *not* a parity feature to look up; it is a
+> distinction **the re-frame2 framework acts on** that the chart must not
+> hide.
+>
+> The affordance keeps the structure-first grammar (border/hue, not a
+> competing glyph — consistent with the dropped `✓`): an `:error?` final's
+> **outer ring** is painted in the `:final-error` palette token (the
+> theme's `:error` hue, light + dark). A success final's outer ring stays
+> the **quiet, runtime-coupled** resting border. The **main node border**
+> is unchanged either way — it continues to carry the runtime
+> active/focus/sim signal — so the two compose: an *active* error-final
+> renders the runtime highlight on its main border **and** the static
+> error hue on its outer ring, neither clobbering the other.
+>
+> The terminal KIND threads `:final?` leaf → `:error?` (gated on `:final?`)
+> in `chart.layout/collect-nodes` → `:data {:errorFinal …}` in
+> `chart.projection` → the conditional ring colour in `chart.nodes/`
+> `state-node`. **Scope:** `:output-key` (the all-finals output-display
+> property, Spec 005:2840) is *out* of this affordance — it belongs to a
+> separate all-finals output decision if it earns one.
+>
+> **Text emitters (mermaid / SCXML) carry no error-final distinction.**
+> Mermaid's `[*]` terminal and SCXML's `<final>` element have no
+> first-class error-terminal concept — the error-final ring is a
+> visual-chart affordance only. Both emitters render an `:error?` final
+> identically to a success final (`[*]` / `<final>`); the round-trip is
+> lossless on `:final?` but does **not** preserve `:error?`. This is by
+> design: the chart surfaces a re-frame2-specific routing distinction the
+> portable text formats cannot represent.
+
 ### 1.5 Event labels
 
 Stately labels transitions by **type**: normal → event name; delayed
@@ -200,7 +237,7 @@ parse (`chart/layout.cljc`) + pure projection (`chart/projection.cljc`)
 | **Parallel regions — active CONTAINER chrome** | ✅ **Closed (rf2-80rm2 / G4).** The region (and, for self-consistency, the compound) **container** reads as active when ANY descendant leaf is active — the projector folds the container into `:active` by walking each active leaf UP its `:parent-id` chain (reusing the G1 active set; no duplicate highlight logic). `parallel-region-node` / `compound-node` then paint active chrome (solid emphasised boundary + the `:info` active-token glow ring, the same affordance state nodes use), so an active region reads as active at the zone level, not just the leaf inside it. **Palette delegated to Figma.** | `projection.cljc` `xyflow-graph` (`active-container-ids` parent-id walk); `nodes/parallel_region_node.cljs`; `nodes.cljs` `compound-node`. |
 | **Transition scoping** | ✅ `:on`, `:after`, `:always`, machine-level (top-level `:on`) fallback, **`:on-done` (XState `onDone`) compound / parallel completion** (rf2-41goo), external + internal self-transitions, vector-of-candidates forks. **Machine-level fallback projects ONCE** (rf2-vcnvj): a top-level `:on` is sourced from a synthetic MACHINE-ROOT node into its target as a SINGLE chip — not one back-edge per leaf (the pre-vcnvj per-state expansion repeated the chip AND injected N back-edges that scrambled ELK's top-to-bottom ranking). **`:on-done` (rf2-41goo)**: a COMPOUND's `:on-done` projects a completion edge from the compound to its SIBLING target (resolved at the compound's own level), an `✓ done` chip distinct from an ordinary event arrow; a PARALLEL-ROOT's `:on-done` (action/fx-only — registration rejects a `:target`) renders as a TERMINAL completion affordance (a hanging done chip, no sibling segment). Self-loops render as a small loop (not a degenerate bezier); internal self-transitions render dashed + no arrowhead. | `layout.cljc` `collect-state-edges`, `on-done-edges`, `collect-machine-edges` (root-sourced), `machine-root-id`, `resolve-target-path`; `projection.cljc` (`machine-root` node type, `:onDone` / `:doneState` event-node data); `nodes.cljs` `machine-root-node`; `edges.cljs` (self-loop path, internal dash). |
 | **Initial** | ✅ Filled-dot `initial-marker` node + unlabelled entry edge into the initial state, at **every** compound level (xstate/SCXML semantics). | `nodes.cljs` `initial-marker`; `projection.cljc` (marker-nodes + entry-edges); `layout.cljc` `collect-nodes` (per-level `:initial?`). |
-| **Final** | ✅ Quiet doubled border (outer ring 1px proud) on `state-node`. **No glyph** — the prior `✓` check glyph is DROPPED (rf2-az6e2, §1.4); the doubled border is the unambiguous final-state signal. | `nodes.cljs` `state-node` (final ring; no glyph). |
+| **Final** | ✅ Quiet doubled border (outer ring 1px proud) on `state-node`. **No glyph** — the prior `✓` check glyph is DROPPED (rf2-az6e2, §1.4); the doubled border is the unambiguous final-state signal. **Error-terminal KIND (rf2-b4loj, §1.4 — re-frame2 clarity, NOT XState/Stately parity):** an `:error?` final (Spec 005 §`:final?`, the re-frame2 extension that routes the spawning parent's `:spawn :on-error`) paints its outer ring in the `:final-error` token (theme `:error` hue) while a success final keeps the quiet runtime-coupled ring; the main border stays runtime-driven so an active error-final composes both signals. `:output-key` is out of scope. | `nodes.cljs` `state-node` (conditional error-ring colour); `layout.cljc` `collect-nodes` (`:error?` gated on `:final?`); `projection.cljc` (`:errorFinal` on `:data`); `theme/tokens.cljc` (`:final-error`). |
 | **History** | 🪝 **Render-hook only (rf2-az6e2, §1.4) — NOT yet emitted.** The `history-marker` renderer (shallow `H` / deep `H*`) is registered in the node-types map, but `chart.layout/parse-definition` emits **no** history pseudo-state node today (the parsed node shape carries no history data), so the projector never produces one. First-class `:history` is NOT shipped; the hook is shaped to the grammar awaiting parsed history topology (and Spec 005 history semantics). | `nodes.cljs` `history-marker` (registered hook); `layout.cljc` (no history emission). |
 | **Event labels** | ✅ `event [guard] / action` composed label; `after(<ms>)`, `always`, `* (any)` wildcard segments; opaque chart-bg backplate (rf2-j10sm Phase 1) for legibility against overlapping ink; label is clickable when a fireable event-id + host callback are present. **Multi-event collapse SUPERSEDED + RETIRED** (rf2-j10sm Phase 2 → rf2-qo5xy → rf2-o6vh7): the old collapse rendered N transitions on one `[source target]` pair as ONE arrow + N stacked labels (`:siblingIndex` / `:siblingCount`). Under events-as-nodes (rf2-qo5xy) each event is its OWN event-node, so same-`[source target]` transitions stay DISTINCT event-nodes (no collapse); rf2-o6vh7 removed the dead `:siblingIndex` / `:siblingCount` + `data-sibling-*` machinery. (The rf2-r7vsr post-render collision-avoidance overlay was **retired** in rf2-0xbgx: events-as-nodes moved labels onto event-nodes and left the in/out edges label-less, so the edge-label sweep was inert; elk layout + events-as-nodes makes label-on-node-body collisions a non-issue.) | `layout.cljc` `edge-label`/`event-segment`; `edges.cljs` `transition-edge`; `projection.cljc` `xyflow-graph` (one event-node per parsed transition). |
 | **Guards / actions** | ✅ Guard in `[...]`, action after `/`; entry/exit state actions render as `entry / <name>` / `exit / <name>` rows under the label; state-tag pills above. | `layout.cljc` `edge-label`, `name-of`; `nodes.cljs` `state-node` (entry/exit rows, tag pills). |
@@ -352,7 +389,8 @@ fill), and colours resolved through the active-theme **chart-tokens**
 | **State (FROM — focused-event origin)** | distinct accent on the border (reads as "we left here") | *`:focus` border + `:focus-wash` header* |
 | **State (TO — focused-event landing)** | the **active** affordance, heavier than FROM | *`:active`, heaviest stroke* |
 | **State (sim — what-if, not live)** | a hue reserved for informational/not-live | *`:sim` border + `:sim-wash` header* |
-| **Final state** | **quiet doubled** border (outer ring proud of corner). **No glyph** (rf2-az6e2 dropped the ✓) | *outer ring in the resting/runtime border colour* |
+| **Final state (success)** | **quiet doubled** border (outer ring proud of corner). **No glyph** (rf2-az6e2 dropped the ✓) | *outer ring in the resting/runtime border colour* |
+| **Final state (error — `:error?`)** | doubled border whose **outer ring is the error hue** (rf2-b4loj — re-frame2 clarity, the terminal routes the parent's `:on-error`; NOT XState/Stately parity). Main border stays runtime-driven so an active error-final composes both | *outer ring in `:final-error` (theme `:error`); main border unchanged* |
 | **Initial marker** | small **neutral** filled dot + unlabelled arrow into the initial state, at every compound level (NOT accent-blue) | *`:pseudo-marker` dot* |
 | **History pseudo-state (HOOK)** | small symbolic node — shallow `H` / deep `H*` — inside the owning compound; NOT a state box. **Renderer registered as a hook; projector emits none until parsed history topology exists** (this bead adds no statechart history semantics) | *`history-marker` node-type registered; `:pseudo-*` constants carry the variant* |
 | **Compound container** | **solid subtle-neutral** box + full-width title strip; NO dashed border, NO accent wash by default | *`:container-body-bg` fill, `:container-border` solid, `:container-header-bg` strip* |

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -280,6 +280,16 @@
                                 :depth    (count parent-path)
                                 :initial? (boolean (:initial? state-node))
                                 :final?   (boolean (:final? state-node))
+                                ;; rf2-b4loj — an `:error?` final (Spec 005
+                                ;; §:final?) is a re-frame2 EXTENSION: a child
+                                ;; finishing via it routes the spawning parent's
+                                ;; `:spawn` `:on-error` (vs `:on-done`). Surface
+                                ;; the terminal KIND so the renderer can paint
+                                ;; the error-hue outer ring. `:error?` only
+                                ;; reads on a `:final?` leaf; gate it so a stray
+                                ;; flag on a non-final node never lights the ring.
+                                :error?   (boolean (and (:final? state-node)
+                                                        (:error? state-node)))
                                 :compound? (boolean (:states state-node))
                                 :tags     (set (:tags state-node))}
                          ;; rf2-ee38b.21 — :entry / :exit state actions

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -312,6 +312,12 @@
         to-highlight?  (boolean (.-toHighlight d))
         sim?           (boolean (.-sim d))
         final?         (boolean (.-final d))
+        ;; rf2-b4loj — error-terminal KIND. An `:error?` final (a re-frame2
+        ;; EXTENSION that routes the spawning parent's `:on-error` rather
+        ;; than `:on-done`) paints its outer ring in the error hue so the
+        ;; chart does not hide a distinction the framework acts on. NOT
+        ;; XState/Stately parity — re-frame2 semantic clarity.
+        error-final?   (boolean (.-errorFinal d))
         tags           (js->clj (.-tags d))
         tags-attr      (tag-title-attr tags)
         entry          (.-entry d)
@@ -367,15 +373,26 @@
                                          (str "0 0 0 2px " (:glow ct))
                                          (str "0 1px " state-shadow-blur "px rgba(0,0,0,0.25)"))
                      :transition       "border-color 120ms ease, background 120ms ease"}}
-       ;; Final-state QUIET double-ring (outer). The ✓ glyph is dropped.
+       ;; Final-state double-ring (outer). The ✓ glyph is dropped.
+       ;; rf2-b4loj — the ring COLOUR is conditional on terminal KIND:
+       ;; an `:error?` final paints the static `:final-error` error hue
+       ;; (re-frame2 semantic clarity — it routes the parent's `:on-error`);
+       ;; a success final keeps the QUIET runtime-coupled `border-col`.
+       ;; The main node border (above) STAYS `border-col` either way, so an
+       ;; active error-final composes: error ring + runtime main-border,
+       ;; neither clobbering the other.
        (when final?
          [:div {:data-testid (str "rf-mv-chart-final-ring-" (.-id props))
+                :data-error-final (str error-final?)
                 :style {:position      "absolute"
                         :top           "-3px"
                         :left          "-3px"
                         :right         "-3px"
                         :bottom        "-3px"
-                        :border        (str "1px solid " border-col)
+                        :border        (str "1px solid "
+                                            (if error-final?
+                                              (:final-error ct)
+                                              border-col))
                         :border-radius (str (inc corner-radius) "px")
                         :pointer-events "none"}}])
        ;; TITLE STRIP — full-width, left-aligned label.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -728,6 +728,13 @@
                                           :sim            (boolean (and active? sim?))
                                           :initial        (boolean (:initial? n))
                                           :final          (boolean (:final? n))
+                                          ;; rf2-b4loj — error-terminal KIND.
+                                          ;; `:error?` finals (a re-frame2
+                                          ;; extension routing the parent's
+                                          ;; `:on-error`) get the error-hue
+                                          ;; outer ring; success finals keep the
+                                          ;; quiet runtime-coupled ring.
+                                          :errorFinal     (boolean (:error? n))
                                           :compound       (boolean (:compound? n))
                                           ;; rf2-vcnvj — serialise each tag
                                           ;; to its FULLY-QUALIFIED string

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -311,6 +311,12 @@
        — re-exported off the palette so a renderer reads one map.
     :active / :focus / :sim / :final
        — runtime-state accents (active = :info, focus = :accent, etc.).
+    :final-error
+       — the error-final OUTER-RING hue (rf2-b4loj). STATIC error-hue
+         signalling an `:error?` terminal (a re-frame2 extension that
+         routes the spawning parent's `:on-error`), distinct from the
+         quiet success-final ring; does not displace the runtime
+         main-border accent.
 
   Pure data → map of strings; JVM-portable. Defaults to `dark-palette`
   so a renderer that never threads a palette still resolves the dark
@@ -348,6 +354,17 @@
       :focus  (g :accent)
       :sim    (g :yellow)
       :final  (g :text-secondary)
+      ;; rf2-b4loj — the error-final OUTER RING hue. A `:error?` final
+      ;; (Spec 005 §:final?) is a re-frame2 EXTENSION: a child finishing
+      ;; via it routes the spawning parent's `:spawn` `:on-error`
+      ;; transition (vs `:on-done`). The chart must not hide a distinction
+      ;; the framework acts on, so the success-final's quiet ring is
+      ;; replaced by the error hue ONLY for error terminals. STATIC (the
+      ;; main border still carries runtime/active/focus/sim), so an active
+      ;; error-final composes: error ring + active main-border, neither
+      ;; clobbering the other. NOT XState/Stately parity — XState has no
+      ;; first-class error-final flag; this is re-frame2 semantic clarity.
+      :final-error (g :error)
       ;; tints used for runtime washes (kept subtle — border/header/glow
       ;; carry the runtime signal, not the whole fill, per the bead)
       :active-wash (with-alpha :info   0.14 palette)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -82,6 +82,16 @@
    :states  {:a {:on {:go :b}}
              :b {:on {:go :a}}}})
 
+(def ^:private success-and-error-finals
+  "rf2-b4loj — a machine with BOTH a plain success final (:ok) and an
+  `:error?` error final (:boom), so the error-hue outer ring distinction
+  is DOM-assertable. The error final routes the spawning parent's
+  `:on-error` (a re-frame2 extension); the chart must paint it distinctly."
+  {:initial :running
+   :states  {:running {:on {:ok :ok :boom :boom}}
+             :ok      {:final? true}
+             :boom    {:final? true :error? true}}})
+
 (def ^:private parallel-machine
   "A parallel machine: 2 regions, 2 states each (rf2-lkwev)."
   {:type :parallel
@@ -235,6 +245,28 @@
           ;; The dropped ✓ glyph must NOT appear.
           (is (not (re-find #"✓" (.-textContent node)))
               "the ✓ check glyph is dropped (rf2-az6e2)"))))))
+
+(deftest chart-error-final-rings-distinct-from-success
+  (testing "rf2-b4loj — an `:error?` final's outer ring carries the error
+            hue (data-error-final=\"true\") while a success final's ring
+            keeps the quiet runtime-coupled border (data-error-final=
+            \"false\"). The error-final is a re-frame2 extension (routes the
+            spawning parent's `:on-error`) the chart must not hide — NOT
+            XState/Stately parity. success-and-error-finals has one of each."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition success-and-error-finals}
+        (fn [_root node]
+          (let [rings (.querySelectorAll
+                       node "[data-testid^=\"rf-mv-chart-final-ring-\"]")
+                attrs (mapv (fn [i] (.getAttribute (aget rings i) "data-error-final"))
+                            (range (.-length rings)))]
+            (is (= 2 (.-length rings)) "both finals render a ring")
+            (is (some #{"true"} attrs)
+                "the :error? final's ring is flagged data-error-final=\"true\"")
+            (is (some #{"false"} attrs)
+                "the success final's ring stays data-error-final=\"false\"")))))))
 
 ;; ---- Controls / MiniMap / Background presence ---------------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -797,6 +797,48 @@
       (is (false? (:final? idle)) ":final? is false, not nil")
       (is (true?  (:final? success))))))
 
+;; ---- :error? error-terminal KIND threads through parse (rf2-b4loj) ------
+;;
+;; An `:error?` final (Spec 005 §:final?) is a re-frame2 EXTENSION: a child
+;; finishing via it routes the spawning parent's `:spawn` `:on-error` rather
+;; than `:on-done`. The chart surfaces the terminal KIND so the renderer can
+;; paint the error-hue outer ring (NOT XState/Stately parity — XState has no
+;; first-class error-final flag).
+
+(def success-and-error-finals
+  "Two terminals of distinct KIND: a plain success final and an `:error?`
+  error final."
+  {:initial :running
+   :states  {:running {:on {:ok :ok :boom :boom}}
+             :ok      {:final? true}
+             :boom    {:final? true :error? true}}})
+
+(deftest parse-definition-threads-error-final-kind
+  (testing "rf2-b4loj — :error? threads onto the node ONLY for an :error?
+            final; a success final and every non-final node carry :error?
+            false (boolean-wrapped, never nil)"
+    (let [{:keys [nodes]} (layout/parse-definition success-and-error-finals)
+          running (first (filter #(= [:running] (:path %)) nodes))
+          ok      (first (filter #(= [:ok]      (:path %)) nodes))
+          boom    (first (filter #(= [:boom]    (:path %)) nodes))]
+      (is (false? (:error? running)) "non-final node is :error? false")
+      (is (false? (:error? ok))      "success final is :error? false")
+      (is (true?  (:error? boom))    "error final is :error? true")
+      ;; both terminals are still :final? — the KIND is the only difference.
+      (is (true? (:final? ok)))
+      (is (true? (:final? boom))))))
+
+(deftest parse-definition-error-flag-needs-final
+  (testing "rf2-b4loj — a stray :error? on a NON-final node never lights the
+            ring: :error? is gated on :final? so it stays false"
+    (let [{:keys [nodes]} (layout/parse-definition
+                           {:initial :a
+                            :states  {:a {:error? true :on {:go :b}}
+                                      :b {}}})
+          a (first (filter #(= [:a] (:path %)) nodes))]
+      (is (false? (:final? a)))
+      (is (false? (:error? a)) ":error? requires :final?"))))
+
 ;; ---- :on-done (XState onDone) completion edge (rf2-41goo) ---------------
 ;;
 ;; Spec 005 §The done-state signal: a COMPOUND node's `:on-done` advances

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -207,6 +207,51 @@
           region (node-by-id graph (layout/region-node-id :audio))]
       (is (= "parallel-region" (:type region))))))
 
+;; ---- error-final KIND threading + composition (rf2-b4loj) --------------
+;;
+;; An `:error?` final (Spec 005 §:final?) is a re-frame2 EXTENSION routing
+;; the spawning parent's `:on-error` (vs `:on-done`). The projector threads
+;; the terminal KIND onto `:data {:errorFinal ...}` so the renderer paints
+;; the error-hue OUTER RING for error terminals while a success final keeps
+;; the quiet runtime-coupled ring. NOT XState/Stately parity — re-frame2
+;; semantic clarity. `:output-key` is deliberately OUT of scope here.
+
+(def success-and-error-finals
+  "Two terminals of distinct KIND: a plain success final + an `:error?`
+  error final."
+  {:initial :running
+   :states  {:running {:on {:ok :ok :boom :boom}}
+             :ok      {:final? true}
+             :boom    {:final? true :error? true}}})
+
+(deftest xyflow-graph-threads-error-final-kind
+  (testing "rf2-b4loj — :data :errorFinal is true ONLY for an :error?
+            final; a success final and a non-final node carry false"
+    (let [parsed  (layout/parse-definition success-and-error-finals)
+          graph   (projection/xyflow-graph parsed {} {})
+          running (node-by-id graph (layout/node-id [:running]))
+          ok      (node-by-id graph (layout/node-id [:ok]))
+          boom    (node-by-id graph (layout/node-id [:boom]))]
+      ;; both terminals are :final; only the error final is :errorFinal.
+      (is (true?  (:final (:data ok))))
+      (is (true?  (:final (:data boom))))
+      (is (false? (:errorFinal (:data running))) "non-final → false")
+      (is (false? (:errorFinal (:data ok)))      "success final → false")
+      (is (true?  (:errorFinal (:data boom)))    "error final → true"))))
+
+(deftest xyflow-graph-active-error-final-composes
+  (testing "rf2-b4loj — an :error? final that is ALSO the current state
+            carries BOTH :active true (drives the runtime main-border) AND
+            :errorFinal true (drives the static error-hue ring) on its
+            :data — the two signals compose, neither clobbers the other"
+    (let [parsed (layout/parse-definition success-and-error-finals)
+          hi     (layout/node-id [:boom])
+          graph  (projection/xyflow-graph parsed {} {:highlight-id hi})
+          boom   (node-by-id graph hi)]
+      (is (true? (:active     (:data boom))) "the error final is active")
+      (is (true? (:errorFinal (:data boom))) "AND it is an error terminal")
+      (is (true? (:final      (:data boom)))))))
+
 ;; ---- xyflow-graph :on-state-click threading (rf2-34ff3) ----------------
 ;;
 ;; rf2-34ff3 (A-PRIME) — `:on-state-click` is threaded onto the `:data`

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
@@ -170,6 +170,21 @@
       (is (= (:accent tokens/dark-palette) (:focus ct)))
       (is (not= (:accent tokens/dark-palette) (:container-border ct))))))
 
+(deftest chart-tokens-final-error-is-error-hue
+  (testing "rf2-b4loj — `:final-error` (the error-final OUTER-RING hue)
+            resolves to the palette's `:error` token in BOTH themes, and
+            is DISTINCT from the quiet success-final ring role (`:final`).
+            A static error-hue signalling an `:error?` terminal — a
+            re-frame2 extension routing the parent's `:on-error` — that the
+            chart must not hide."
+    (doseq [palette [tokens/dark-palette tokens/light-palette]]
+      (let [ct (tokens/chart-tokens palette)]
+        (is (= (:error palette) (:final-error ct))
+            "error-final ring tracks the palette error hue")
+        (is (not= (:final ct) (:final-error ct))
+            "the error ring is visually distinct from the quiet success ring")
+        (is (string? (:final-error ct)))))))
+
 (deftest chart-label-stack-is-sans
   (testing "rf2-az6e2 — the chart-label font token is sans (structure-
             first reading); recorded decision: mono retained only for


### PR DESCRIPTION
## rf2-b4loj — error-final outer-ring affordance (Mike RULED B)

Render re-frame2 error-terminal states (`:error?` finals) distinctly via an **error-hue outer ring** on the final-ring layer.

### Why this is re-frame2 CLARITY, not XState/Stately parity
An `:error?` final (Spec 005 §`:final?`) is a re-frame2 **extension**: a child finishing via it routes the spawning parent's `:spawn` **`:on-error`** transition instead of `:on-done`. XState v5 has final-states-with-output and actor `onError` but **no first-class error-final flag**, and Stately therefore draws no such marker. The chart must not hide a distinction the framework acts on — so the affordance is framed as re-frame2 semantic clarity throughout the code, tests, and spec.

### The fix (per the bead's verified implementation pin)
- **`theme/tokens.cljc`** — add the `:final-error` chart-token (theme `:error` hue, light + dark) so the ring hue tracks the theme.
- **`chart/layout.cljc` `collect-nodes`** — thread `:error?`, gated on `:final?` so a stray flag on a non-final node never lights the ring.
- **`chart/projection.cljc`** — thread `:errorFinal` onto node `:data`.
- **`chart/nodes.cljs` `state-node`** — the outer-ring colour is now **conditional**: an error final paints `:final-error`; a success final keeps the quiet, runtime-coupled border. The **main node border stays runtime-driven either way**, so an active error-final composes both signals (error ring + active main border, neither clobbering the other). The ring carries a `data-error-final` attr for host/test introspection.

`:output-key` is **out of scope** (a general all-finals property — a separate all-finals output-display decision if it earns one).

### Spec (same-PR per the Xray-specs-current rule)
`tools/machines-viz/spec/001-Topology-Parity.md` §1.4 + both parity tables updated, framed as clarity (not parity), with a mermaid/SCXML note: the portable text formats carry no error-final distinction by design (`[*]` / `<final>` render identically; the round-trip is lossless on `:final?` but does not preserve `:error?`).

### Tests
- **layout** — parse threads `:error?` (true only for an `:error?` final; gated on `:final?`).
- **projection** — `:errorFinal` threading + the **composition case**: an active error-final carries `:active` AND `:errorFinal` simultaneously.
- **tokens** — `:final-error` resolves to the `:error` hue in both palettes, distinct from the quiet success-final ring.
- **DOM (browser)** — a machine with one error + one success final renders distinct rings (`data-error-final` true vs false).

### Gates
- `clojure -M:test` (machines-viz): 364 tests / 1061 assertions, 0 failures.
- `npm run test:cljs`: 5612 tests / 19564 assertions, 0 failures.
