### PR TITLE
refactor(examples/reagent): namespace bare layer-2 extractor sub-ids (rf2-mpk41)

### DIFF
--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -447,12 +447,12 @@
 ;; SUBSCRIPTIONS — slice readers + the render-model selector
 ;; ============================================================================
 
-(rf/reg-sub :new-todo
+(rf/reg-sub :new-todo/slice
   (fn sub-new-todo [db _] (get db :new-todo)))
 
-(rf/reg-sub :new-todo/draft   :<- [:new-todo] (fn [s _] (:draft s)))
-(rf/reg-sub :new-todo/errors  :<- [:new-todo] (fn [s _] (:errors s)))
-(rf/reg-sub :new-todo/touched :<- [:new-todo] (fn [s _] (:touched s)))
+(rf/reg-sub :new-todo/draft   :<- [:new-todo/slice] (fn [s _] (:draft s)))
+(rf/reg-sub :new-todo/errors  :<- [:new-todo/slice] (fn [s _] (:errors s)))
+(rf/reg-sub :new-todo/touched :<- [:new-todo/slice] (fn [s _] (:touched s)))
 
 (rf/reg-sub :new-todo/field-error
   {:doc "Per-field error, only after the user has touched the field."}

--- a/examples/reagent/realworld/article_editor.cljs
+++ b/examples/reagent/realworld/article_editor.cljs
@@ -364,19 +364,19 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-(rf/reg-sub :editor
+(rf/reg-sub :editor/slice
   (fn [db _] (:editor db)))
 
-(rf/reg-sub :editor/draft :<- [:editor] (fn [editor _] (:draft editor)))
-(rf/reg-sub :editor/errors :<- [:editor] (fn [editor _] (:errors editor)))
-(rf/reg-sub :editor/submit-error :<- [:editor]
+(rf/reg-sub :editor/draft :<- [:editor/slice] (fn [editor _] (:draft editor)))
+(rf/reg-sub :editor/errors :<- [:editor/slice] (fn [editor _] (:errors editor)))
+(rf/reg-sub :editor/submit-error :<- [:editor/slice]
   (fn [editor _] (:submit-error editor)))
 
 (rf/reg-sub :editor/field-error
   {:doc "Per-field validation error. Per Pattern-Forms §Error
          visibility: reveal every error after the first submit click,
          OR once the field is :touched."}
-  :<- [:editor]
+  :<- [:editor/slice]
   (fn [editor [_ field]]
     (when (or (:submit-attempted? editor)
               (contains? (:touched editor) field))
@@ -385,12 +385,12 @@
 (rf/reg-sub :editor/form-error
   {:doc "Whole-form prompt (the :_form key under :errors) — populated
          when a submit attempt failed client-side validation."}
-  :<- [:editor]
+  :<- [:editor/slice]
   (fn [editor _]
     (when (:submit-attempted? editor)
       (get-in editor [:errors :_form]))))
 (rf/reg-sub :editor/dirty?
-  :<- [:editor]
+  :<- [:editor/slice]
   (fn [editor _]
     (not= (:draft editor) (:baseline editor))))
 

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -295,9 +295,9 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-(rf/reg-sub :articles            (fn [db _] (:articles db)))
-(rf/reg-sub :articles/data       :<- [:articles] (fn [s _] (:data s)))
-(rf/reg-sub :articles/error      :<- [:articles] (fn [s _] (:error s)))
+(rf/reg-sub :articles/slice      (fn [db _] (:articles db)))
+(rf/reg-sub :articles/data       :<- [:articles/slice] (fn [s _] (:data s)))
+(rf/reg-sub :articles/error      :<- [:articles/slice] (fn [s _] (:error s)))
 
 ;; The `:tags/data` sub is defined in `realworld.tags`. The
 ;; popular-tags lifecycle is the :data-region machine variant of

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -305,14 +305,14 @@
 (rf/reg-sub :auth.login-form/draft
   (fn [db _] (get-in db [:auth :login-form :draft])))
 
-(rf/reg-sub :auth.login-form
+(rf/reg-sub :auth.login-form/slice
   (fn [db _] (get-in db [:auth :login-form])))
 
 (rf/reg-sub :auth.login-form/field-error
   {:doc "Per-field validation error for the login form. Per
          Pattern-Forms §Error visibility: reveal every error after the
          first submit click, OR once a field is :touched."}
-  :<- [:auth.login-form]
+  :<- [:auth.login-form/slice]
   (fn [form [_ field]]
     (when (or (:submit-attempted? form)
               (contains? (:touched form) field))
@@ -321,14 +321,14 @@
 (rf/reg-sub :auth.register-form/draft
   (fn [db _] (get-in db [:auth :register-form :draft])))
 
-(rf/reg-sub :auth.register-form
+(rf/reg-sub :auth.register-form/slice
   (fn [db _] (get-in db [:auth :register-form])))
 
 (rf/reg-sub :auth.register-form/field-error
   {:doc "Per-field validation error for the register form. Per
          Pattern-Forms §Error visibility: reveal every error after the
          first submit click, OR once a field is :touched."}
-  :<- [:auth.register-form]
+  :<- [:auth.register-form/slice]
   (fn [form [_ field]]
     (when (or (:submit-attempted? form)
               (contains? (:touched form) field))

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -256,15 +256,15 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-(rf/reg-sub :article (fn [db _] (:article db)))
-(rf/reg-sub :article/data :<- [:article] (fn [slice _] (:data slice)))
-(rf/reg-sub :article/status :<- [:article] (fn [slice _] (:status slice)))
-(rf/reg-sub :article/error :<- [:article] (fn [slice _] (:error slice)))
+(rf/reg-sub :article/slice (fn [db _] (:article db)))
+(rf/reg-sub :article/data :<- [:article/slice] (fn [slice _] (:data slice)))
+(rf/reg-sub :article/status :<- [:article/slice] (fn [slice _] (:status slice)))
+(rf/reg-sub :article/error :<- [:article/slice] (fn [slice _] (:error slice)))
 
-(rf/reg-sub :comments (fn [db _] (:comments db)))
-(rf/reg-sub :comments/data :<- [:comments] (fn [slice _] (:data slice)))
-(rf/reg-sub :comments/status :<- [:comments] (fn [slice _] (:status slice)))
-(rf/reg-sub :comments/error :<- [:comments] (fn [slice _] (:error slice)))
+(rf/reg-sub :comments/slice (fn [db _] (:comments db)))
+(rf/reg-sub :comments/data :<- [:comments/slice] (fn [slice _] (:data slice)))
+(rf/reg-sub :comments/status :<- [:comments/slice] (fn [slice _] (:status slice)))
+(rf/reg-sub :comments/error :<- [:comments/slice] (fn [slice _] (:error slice)))
 
 (rf/reg-sub :comment-form/draft
   (fn [db _] (get-in db [:comment-form :draft])))
@@ -275,14 +275,14 @@
 (rf/reg-sub :comment-form/submit-error
   (fn [db _] (get-in db [:comment-form :submit-error])))
 
-(rf/reg-sub :comment-form
+(rf/reg-sub :comment-form/slice
   (fn [db _] (:comment-form db)))
 
 (rf/reg-sub :comment-form/field-error
   {:doc "Per-field validation error for the comment form. Per
          Pattern-Forms §Error visibility: reveal every error after the
          first submit click, OR once the field is :touched."}
-  :<- [:comment-form]
+  :<- [:comment-form/slice]
   (fn [form [_ field]]
     (when (or (:submit-attempted? form)
               (contains? (:touched form) field))

--- a/examples/reagent/realworld/favorites.cljs
+++ b/examples/reagent/realworld/favorites.cljs
@@ -188,9 +188,9 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-(rf/reg-sub :feed (fn [db _] (:feed db)))
-(rf/reg-sub :feed/data :<- [:feed] (fn [slice _] (:data slice)))
-(rf/reg-sub :feed/error :<- [:feed] (fn [slice _] (:error slice)))
-(rf/reg-sub :feed/loading? :<- [:feed]
+(rf/reg-sub :feed/slice (fn [db _] (:feed db)))
+(rf/reg-sub :feed/data :<- [:feed/slice] (fn [slice _] (:data slice)))
+(rf/reg-sub :feed/error :<- [:feed/slice] (fn [slice _] (:error slice)))
+(rf/reg-sub :feed/loading? :<- [:feed/slice]
   (fn [slice _] (#{:loading :fetching} (:status slice))))
 

--- a/examples/reagent/realworld/profile.cljs
+++ b/examples/reagent/realworld/profile.cljs
@@ -326,9 +326,9 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-(rf/reg-sub :profile         (fn [db _] (:profile db)))
-(rf/reg-sub :profile/data    :<- [:profile] (fn [s _] (:data s)))
-(rf/reg-sub :profile/error   :<- [:profile] (fn [s _] (:error s)))
+(rf/reg-sub :profile/slice   (fn [db _] (:profile db)))
+(rf/reg-sub :profile/data    :<- [:profile/slice] (fn [s _] (:data s)))
+(rf/reg-sub :profile/error   :<- [:profile/slice] (fn [s _] (:error s)))
 
 (rf/reg-sub :profile.articles/data
   (fn [db _] (get-in db [:profile.articles :data])))

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -158,25 +158,25 @@
 
 ;; Layer-2 slice sub. The Layer-3 readers below chain off this one via
 ;; `:<-`, so the [:drawer ...] traversal happens once per app-db swap
-;; (in `:drawer`) rather than once per dependent recompute. Matches the
-;; realworld layering pattern (`:articles → :articles/data → ...`).
+;; (in `:drawer/slice`) rather than once per dependent recompute. Matches
+;; the realworld layering pattern (`:articles/slice → :articles/data → ...`).
 
-(rf/reg-sub :drawer (fn [db _] (:drawer db)))
+(rf/reg-sub :drawer/slice (fn [db _] (:drawer db)))
 
 (rf/reg-sub :drawer/circles
-  :<- [:drawer]
+  :<- [:drawer/slice]
   (fn [drawer _] (:circles drawer)))
 
 (rf/reg-sub :drawer/dialog
-  :<- [:drawer]
+  :<- [:drawer/slice]
   (fn [drawer _] (:dialog drawer)))
 
 (rf/reg-sub :drawer/can-undo?
-  :<- [:drawer]
+  :<- [:drawer/slice]
   (fn [drawer _] (seq (:undo drawer))))
 
 (rf/reg-sub :drawer/can-redo?
-  :<- [:drawer]
+  :<- [:drawer/slice]
   (fn [drawer _] (seq (:redo drawer))))
 
 ;; ============================================================================

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -147,7 +147,7 @@
 ;; SUBSCRIPTIONS / VIEWS
 ;; ============================================================================
 
-(rf/reg-sub :articles (fn [db _] (:articles db)))
+(rf/reg-sub :articles/slice (fn [db _] (:articles db)))
 
 (rf/reg-sub :articles/show-bodies?
   (fn [db _]
@@ -168,7 +168,7 @@
 ;; the reaction so re-renders fire on app-db changes. Same code, both
 ;; sides — that's the SSR/CLJS parity Spec 011 promises.
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
-  (let [arts         @(subscribe [:articles])
+  (let [arts         @(subscribe [:articles/slice])
         show-bodies? @(subscribe [:articles/show-bodies?])]
     [:div.page
      [:h1 "Recent articles"]

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -56,11 +56,11 @@
 ;; SUBSCRIPTIONS / VIEWS
 ;; ============================================================================
 
-(rf/reg-sub :cards (fn [db _] (:cards db)))
-(rf/reg-sub :card  (fn [db [_ id]] (get-in db [:cards id])))
+(rf/reg-sub :cards/slice (fn [db _] (:cards db)))
+(rf/reg-sub :card/by-id   (fn [db [_ id]] (get-in db [:cards id])))
 
 (rf/reg-view ^{:rf/id :dashboard/card} card-view [card-id]
-  (let [card @(subscribe [:card card-id])]
+  (let [card @(subscribe [:card/by-id card-id])]
     [:div.card
      [:h3 (:title card)]
      [:p.value (str (:value card))]]))

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -394,17 +394,17 @@
     {:db (assoc db :messages {:draft "" :received [] :last-reply nil :rx-count 0})}))
 
 ;; --- subs -------------------------------------------------------------
-(rf/reg-sub :messages
+(rf/reg-sub :messages/slice
   (fn [db _] (:messages db)))
 
 (rf/reg-sub :messages/draft
-  :<- [:messages]
+  :<- [:messages/slice]
   (fn [m _] (:draft m)))
 
 (rf/reg-sub :messages/received
-  :<- [:messages]
+  :<- [:messages/slice]
   (fn [m _] (:received m)))
 
 (rf/reg-sub :messages/last-reply
-  :<- [:messages]
+  :<- [:messages/slice]
   (fn [m _] (:last-reply m)))


### PR DESCRIPTION
Implements **rf2-mpk41** (Mike RULED B — light `/slice` form). Namespaces the bare (un-namespaced) layer-2 extractor sub-ids in `examples/reagent` so every registered sub id is feature-namespaced, matching the house style the rest of the slice already demonstrates.

**Scope:** sub-ids + their `:<-`/`subscribe` references ONLY. App-db slice keys stay bare (e.g. `[:articles]`), as do event-ids, flow-ids, schema paths, and suspense-boundary/view ids.

## Renames

| File | Bare | Namespaced |
|---|---|---|
| `realworld/articles.cljs` | `:articles` | `:articles/slice` |
| `realworld/comments.cljs` | `:article` | `:article/slice` |
| `realworld/comments.cljs` | `:comments` | `:comments/slice` |
| `realworld/comments.cljs` | `:comment-form` | `:comment-form/slice` |
| `realworld/favorites.cljs` | `:feed` | `:feed/slice` |
| `realworld/profile.cljs` | `:profile` | `:profile/slice` |
| `realworld/article_editor.cljs` | `:editor` | `:editor/slice` |
| `realworld/auth.cljs` | `:auth.login-form` | `:auth.login-form/slice` |
| `realworld/auth.cljs` | `:auth.register-form` | `:auth.register-form/slice` |
| `seven_guis/circle_drawer/core.cljs` | `:drawer` | `:drawer/slice` |
| `ssr/core.cljc` | `:articles` | `:articles/slice` |
| `ssr_streaming/core.cljc` | `:cards` | `:cards/slice` |
| `ssr_streaming/core.cljc` | `:card` | `:card/by-id` |
| `nine_states/core.cljs` | `:new-todo` | `:new-todo/slice` |
| `websocket/messages.cljs` | `:messages` | `:messages/slice` |

## Per-id judgment / deviations from the bead's table

Per the bead's instruction to *grep every ref rather than trust the table* and its absolute acceptance criterion ("no bare extractor sub ids remain; every `reg-sub` id is feature-namespaced"):

- **`nine_states` `:new-todo`** — the table proposed `:new-todo/text` on the premise that the sub is the input-text scalar. The sub actually returns the whole `:new-todo` **map slice** (`{:draft :errors :touched}`) feeding three `:<-` derived subs. Named **`/slice`** for consistency and to preserve the layered structure; `/text` would have been misleading.
- **`ssr_streaming` `:card`** — a parameterised item lookup `(fn [db [_ id]] (get-in db [:cards id]))`, so the natural name **`:card/by-id`** (per the bead's "natural name if `:card` is an item/param sub").
- **`realworld/auth.cljs` (`:auth.login-form`, `:auth.register-form`) and `websocket/messages.cljs` (`:messages`)** — same defect class (bare slice extractor alongside namespaced derived subs) but not in the enumerated table; namespaced to satisfy the absolute acceptance criterion.

## Verification

- All bare extractor sub-ids removed: a `reg-sub`-with-bare-id grep over `examples/reagent` returns **zero** matches.
- No orphaned references: `:<-`/`subscribe`/`<sub`/`use-sub` of every old bare id return zero.
- App-db slice keys unchanged (still bare).
- Layered structure preserved (e.g. `:articles/slice → :articles/data → :articles.home/render`).
- All 11 touched files form-read cleanly (both `:clj`/`:cljs` reader-conditional branches for the `.cljc` files).
- No `*.spec.cjs` added (examples are test-free).

Closes rf2-mpk41.