### PR TITLE
fix(core): core correctness cluster — drain-depth count, sub ref-leak, no-such-sub tags, redact guard (rf2-agpv2.1..4)

### DIFF
--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -78,7 +78,17 @@
       (empty? path)
       redacted-sentinel
 
-      (some? (get-in payload (butlast path)))
+      ;; rf2-agpv2.4 — the parent must be ASSOCIATIVE for `assoc-in` to
+      ;; descend into it, not merely non-nil. A `(some? …)` guard let a
+      ;; non-nil scalar parent through (e.g. payload `{:auth "tok"}` with
+      ;; redact path `[:auth :password]`): `assoc-in` then recurses into
+      ;; the string and throws ("cannot assoc onto a String"). That throw
+      ;; lands inside a `:before` interceptor and aborts the whole event
+      ;; (classified `:rf.error/interceptor-exception`, no `:db` commit, no
+      ;; `:fx`) — a redaction that silently drops the event. `associative?`
+      ;; treats a non-associative parent as a no-op, matching the
+      ;; missing-leaf no-op posture below.
+      (associative? (get-in payload (butlast path)))
       (assoc-in payload path redacted-sentinel)
 
       :else

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -230,8 +230,21 @@
   (let [query-id      (first query-v)
         sub-meta      (registrar/lookup :sub query-id)
         _             (when (nil? sub-meta)
+                        ;; Per Spec 009 §Error catalogue (`:rf.error/no-such-sub`
+                        ;; tags `:rf.sub/id` / `:unresolved-input` /
+                        ;; `:resolved-inputs`): the unregistered sub is the one
+                        ;; being subscribed here (`query-id`); `:unresolved-input`
+                        ;; carries the full query-vector that failed to resolve
+                        ;; and `:resolved-inputs` is empty — the miss is detected
+                        ;; on `sub-meta` lookup, before any `:<-` input is
+                        ;; resolved. (rf2-agpv2.3 — aligns the emit tag-shape to
+                        ;; Spec 009; recovery is unchanged: nil-yielding reaction,
+                        ;; not cached.)
                         (trace/emit-error! :rf.error/no-such-sub
-                                           {:rf.sub/query-v query-v :frame frame-id}))
+                                           {:rf.sub/id        query-id
+                                            :unresolved-input query-v
+                                            :resolved-inputs  []
+                                            :frame            frame-id}))
         body-fn       (:handler-fn sub-meta)
         input-signals (:input-signals sub-meta)
         layer-1?      (empty? input-signals)
@@ -293,6 +306,26 @@
                          (if (identical? reaction (get-in m [k :reaction]))
                            (dissoc m k)
                            m))))))
+    ;; rf2-agpv2.2 — symmetric input release on the not-cached path.
+    ;; A layer-2+ build already subscribed each `:<-` input above (bumping
+    ;; their ref-counts), but the dispose-wiring that releases them lives
+    ;; ONLY inside the `(when (and cache sub-meta) …)` branch. If the frame
+    ;; was destroyed (or its container torn down) BETWEEN `subscribe`'s
+    ;; frame-record resolution and this re-resolution, `cache` is now nil:
+    ;; the reaction is built and returned but never cached and never
+    ;; dispose-wired, so without this branch nothing would ever call
+    ;; `unsubscribe` for those inputs — a monotonic ref-count leak until
+    ;; `clear-sub-cache!`. Release them here so the input ref-count stays
+    ;; symmetric with the bumps. Layer-1 has no subscribed inputs (its
+    ;; input is the app-db container, not a subscribe), and the
+    ;; no-such-sub miss (`sub-meta` nil) has no `:<-` inputs, so this
+    ;; only fires for a layer-2+ reaction that escaped caching.
+    (when (and (not (and cache sub-meta))
+               (not layer-1?)
+               (seq input-signals))
+      (doseq [input-q input-signals]
+        (try (unsubscribe frame-id input-q)
+             (catch #?(:clj Throwable :cljs :default) _ nil))))
     reaction))
 
 ;; ---- the sub-override subscribe seam (rf2-7pgiz; CLJS, dev-only) ----------

--- a/implementation/core/test/re_frame/drain_test.clj
+++ b/implementation/core/test/re_frame/drain_test.clj
@@ -210,6 +210,47 @@
            (rf/app-db-value :drain.rollback/two))
         "the overflow drain's per-event writes are durable — no whole-drain rollback")))
 
+(deftest drain-depth-halts-after-exactly-drain-depth-events
+  ;; rf2-agpv2.1 — CANONICAL pin of the drain-depth event count.
+  ;;
+  ;; `:drain-depth` is the MAXIMUM number of events a single drain
+  ;; processes. The router halts at `(>= depth drain-depth)` (router.cljc
+  ;; run-one-pass!), and Spec 002 §Drain-loop pseudocode now matches with
+  ;; `(>= depth (:drain-depth …))`. So for a runaway self-redispatching
+  ;; cascade under drain-depth N, EXACTLY N handler bodies run (depths
+  ;; 0,1,…,N-1) and the (N+1)th event is the halting event that never
+  ;; runs. This test pins that count directly so a future flip back to
+  ;; `>`/`>=` (an off-by-one) fails HERE rather than in a far-away
+  ;; cascade assertion. The `:depth` tag on the halt equals N.
+  (testing "a runaway cascade under drain-depth N runs EXACTLY N handlers, then halts"
+    (doseq [n [1 4 8 100]]
+      (let [frame-id (keyword "drain.count" (str "loop-" n))
+            runs     (atom 0)
+            traces   (atom [])
+            event-id (keyword "drain.count" (str "tick-" n))]
+        (rf/register-listener! ::count (fn [ev] (swap! traces conj ev)))
+        (rf/reg-frame frame-id {:drain-depth n})
+        (rf/reg-event-fx event-id
+          (fn [_ _]
+            (swap! runs inc)
+            {:fx [[:dispatch [event-id]]]}))
+        (rf/dispatch-sync [event-id] {:frame frame-id})
+        (rf/unregister-listener! ::count)
+        (is (= n @runs)
+            (str "exactly " n " handler bodies ran for drain-depth " n
+                 " (got " @runs ")"))
+        (let [hit (some (fn [ev]
+                          (when (= :rf.error/drain-depth-exceeded
+                                   (:operation ev))
+                            ev))
+                        @traces)]
+          (is (some? hit)
+              (str "drain-depth-exceeded trace fired for drain-depth " n))
+          (when hit
+            (is (= n (get-in hit [:tags :depth]))
+                (str ":depth tag equals drain-depth " n
+                     " (the halting event's depth = N)"))))))))
+
 ;; ---- 3. dispatch-sync-in-handler ------------------------------------------
 
 (deftest dispatch-sync-in-handler-jvm

--- a/implementation/core/test/re_frame/redact_interceptor_test.clj
+++ b/implementation/core/test/re_frame/redact_interceptor_test.clj
@@ -150,6 +150,44 @@
           db-changed (first (events-of evs :rf.event/db-changed))]
       (is (= "scalar" (get-in db-changed [:tags :rf.event/v 1]))))))
 
+;; ---- rf2-agpv2.4: a non-associative parent value is a redaction no-op -----
+
+(deftest redact-path-with-scalar-parent-does-not-abort-the-event
+  (testing "a 2+-segment redact path whose intermediate is a non-associative
+            scalar is a no-op — it must NOT throw inside the `:before` chain
+            and abort the event. Pre-fix the `(some? …)` parent guard let a
+            non-nil scalar through, and `assoc-in` recursed into it
+            (\"cannot assoc onto a String\"), turning a privacy-redaction
+            into a dropped event (classified :rf.error/interceptor-exception,
+            no :db commit, no :fx). The fix guards with `associative?`."
+    (let [seen (atom nil)]
+      ;; Redact path [:auth :password] but the payload's :auth is a SCALAR
+      ;; string, so the parent (get-in payload [:auth]) is non-nil but
+      ;; non-associative — the exact mis-declaration the bead calls out.
+      (rf/reg-event-db :auth/scalar-parent
+        [(rf/redact-interceptor [[:auth :password]])]
+        (fn [db [_ payload]]
+          (reset! seen payload)
+          (assoc db :committed payload)))
+      (let [evs        (record-traces
+                         #(rf/dispatch-sync
+                            [:auth/scalar-parent {:auth "a-token-string"}]))
+            db-changed (first (events-of evs :rf.event/db-changed))
+            errors     (events-of evs :rf.error/interceptor-exception)]
+        ;; (1) No throw escaped the `:before` chain → no interceptor-exception.
+        (is (empty? errors)
+            "the scalar-parent redact path did NOT abort the event")
+        ;; (2) The handler ran and its :db commit landed (event not dropped).
+        (is (= {:auth "a-token-string"} @seen)
+            "handler body ran with the raw payload")
+        (is (= {:auth "a-token-string"}
+               (:committed (rf/app-db-value :rf/default)))
+            ":db commit landed — the event was NOT aborted")
+        ;; (3) The trace surface left the scalar untouched (no-op redaction).
+        (is (some? db-changed) "a db-changed trace was emitted")
+        (is (= "a-token-string" (get-in db-changed [:tags :rf.event/v 1 :auth]))
+            "the non-associative parent passed through unredacted (no-op)")))))
+
 ;; ---- (removed) composition with handler-meta `:sensitive?` ---------------
 ;;
 ;; The handler-meta `:sensitive?` annotation has been removed. The trace-

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -557,6 +557,104 @@
     (is (not (contains? (cache-keys) [:a])))
     (is (not (contains? (cache-keys) [:b])))))
 
+;; ---- rf2-agpv2.2: input ref-count must not leak on the not-cached path ----
+;;
+;; `compute-and-cache!` subscribes each layer-2+ `:<-` input (bumping its
+;; ref-count) BEFORE it re-resolves the frame to read `:sub-cache`. The
+;; on-dispose that SYMMETRICALLY releases those inputs is wired only inside
+;; `(when (and cache sub-meta) …)`. If the frame is destroyed (or its
+;; container torn down) BETWEEN `subscribe`'s frame-record resolution and
+;; `compute-and-cache!`'s re-resolution, `cache` is nil: the parent
+;; reaction is built and returned but never cached and never dispose-wired,
+;; so without the compensating release the just-subscribed inputs leak
+;; forever. We reproduce the narrow seam deterministically by redefining
+;; `frame/frame` to return the live record while the inputs are resolved,
+;; then nil on the parent's cache-read re-resolution (= "frame destroyed at
+;; the seam"). The fix releases the inputs on that not-cached path.
+
+(deftest layer-2-input-refs-released-when-frame-destroyed-mid-build
+  (testing "a layer-2 build whose parent cache-read sees a destroyed frame
+            still releases the inputs it subscribed (no ref-count leak)"
+    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :sum :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
+    (rf/dispatch-sync [:init])
+
+    (let [real-frame  frame/frame
+          ;; Trip the parent's cache-read re-resolution (and only that one)
+          ;; to nil: once BOTH inputs are present in the real cache, the
+          ;; next `frame/frame` call for :rf/default is the parent's
+          ;; `(:sub-cache (frame/frame …))` read inside `compute-and-cache!`
+          ;; for [:sum]. Returning nil there is exactly "the frame was
+          ;; destroyed between line-500 resolution and line-269 re-read".
+          tripped?    (atom false)
+          inputs-cached? (fn []
+                           (let [c @(:sub-cache (real-frame :rf/default))]
+                             (and (contains? c [:a]) (contains? c [:b]))))]
+      (with-redefs [frame/frame
+                    (fn [id]
+                      (if (and (= id :rf/default)
+                               (not @tripped?)
+                               (inputs-cached?))
+                        (do (reset! tripped? true) nil) ;; the parent cache-read
+                        (real-frame id)))]
+        (let [r (rf/subscribe [:sum])]
+          ;; The reaction is still built+returned (callers don't explode);
+          ;; under :replaced-with-default the parent simply isn't cached.
+          (is (some? r) "a reaction is still returned on the not-cached path")
+          (is (true? @tripped?)
+              "the parent cache-read re-resolution was tripped to nil")))
+
+      ;; The parent [:sum] was NOT cached (cache was nil at the read).
+      (is (not (contains? (cache-keys) [:sum]))
+          "[:sum] was not cached — the destroyed-frame seam")
+      ;; THE FIX: the inputs subscribed during the layer-2 build were
+      ;; released on the not-cached path, so they cascaded to ref-count 0
+      ;; and disposed. Pre-fix they would sit orphaned at ref-count 1.
+      (is (not (contains? (cache-keys) [:a]))
+          "input :a released (no orphaned ref) — rf2-agpv2.2")
+      (is (not (contains? (cache-keys) [:b]))
+          "input :b released (no orphaned ref) — rf2-agpv2.2"))))
+
+;; ---- rf2-agpv2.3: no-such-sub trace tag-shape matches Spec 009 -------------
+;;
+;; Spec 009 §Error catalogue documents `:rf.error/no-such-sub` tags as
+;; `:rf.sub/id` / `:unresolved-input` / `:resolved-inputs`. Spec/Ownership
+;; names 009 as the canonical owner of the trace-event model; the
+;; `NoSuchSubTags` projection in Spec-Schemas is non-canonical. This pins
+;; the emit to the canonical shape so tooling keying off the documented tag
+;; names finds them. Recovery (nil-yielding reaction, not cached) is
+;; unchanged and covered by `subscribe-before-register-does-not-cache`.
+
+(deftest no-such-sub-trace-tags-match-spec-009
+  (testing "subscribing an unregistered sub emits Spec-009 tag-shape"
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/dispatch-sync [:init])
+    (let [traces (atom [])]
+      (rf/register-listener! ::no-such (fn [ev] (swap! traces conj ev)))
+      ;; [:missing/sub] is not registered → :rf.error/no-such-sub.
+      (let [r (rf/subscribe [:missing/sub])]
+        (is (nil? @r) ":replaced-with-default — the reaction yields nil"))
+      (rf/unregister-listener! ::no-such)
+      (let [hit (some (fn [ev]
+                        (when (= :rf.error/no-such-sub (:operation ev)) ev))
+                      @traces)]
+        (is (some? hit) "no-such-sub trace fired")
+        (when hit
+          (let [tags (:tags hit)]
+            ;; Canonical Spec-009 shape.
+            (is (= :missing/sub (:rf.sub/id tags))
+                ":rf.sub/id is the unregistered sub's id")
+            (is (= [:missing/sub] (:unresolved-input tags))
+                ":unresolved-input is the full query-vector that failed to resolve")
+            (is (= [] (:resolved-inputs tags))
+                ":resolved-inputs is empty — the miss is detected before input resolution")
+            (is (contains? tags :frame) ":frame tag retained for routing")
+            ;; The pre-fix shape MUST be gone.
+            (is (not (contains? tags :rf.sub/query-v))
+                "the pre-fix :rf.sub/query-v tag is gone (aligned to Spec 009)")))))))
+
 ;; ---- ref-counting and hot-reload smoke (relocated from smoke_test.clj, rf2-zqar3) ----
 
 (deftest sub-cache-ref-counting

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -1007,7 +1007,15 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
           (trace! :rf.frame/drain-interrupted
                   {:frame (:id frame) :dropped dropped}))
         (throw ::halt))
-      (when (> depth (:drain-depth (:config frame)))
+      ;; `>=` not `>`: `:drain-depth` is the MAX number of events a single
+      ;; drain processes (rf2-agpv2.1). The loop enters with `depth` = the
+      ;; count of events already processed this drain; events run at depths
+      ;; 0,1,…,(drain-depth-1) — exactly `drain-depth` events — and the
+      ;; halt fires when `depth` first reaches `drain-depth` (the
+      ;; (drain-depth+1)th event never runs). This matches the `:test`
+      ;; preset's "drain bounded at 100" = at-most-100 reading and the
+      ;; `:halted-depth` epoch's `:depth` tag (= `drain-depth`).
+      (when (>= depth (:drain-depth (:config frame)))
         ;; Per-event epochs (rule 3): already-settled events kept their own
         ;; durable :ok epochs + db writes — there is NO whole-drain rollback,
         ;; so :rollback? is false. Drop the remaining queue (the next, halting


### PR DESCRIPTION
Four findings from the core correctness review, fixed in one PR. Surfaces: `implementation/core/src/re_frame/*` + `spec/002` (agpv2.1 only).

## rf2-agpv2.1 — drain-depth off-by-one (spec ↔ code reconcile)

`router.cljc` `run-one-pass!` halts at `(>= depth drain-depth)` → exactly `drain-depth` events run (depths 0..N-1). `spec/002` drain-loop pseudocode used `(> depth …)` → N+1 events. **Canonical decision: the code's "at most N events" reading is authoritative** (the `:test` preset doc reads "drain bounded at 100" = at-most-100), so the **spec moves to `>=`**. No code change. Added `drain-depth-halts-after-exactly-drain-depth-events` pinning the event count and the `:depth` tag (= N) across drain-depths 1 / 4 / 8 / 100.

## rf2-agpv2.2 — layer-2+ input ref-count leak (cache-nil race)

`compute-and-cache!` subscribed each `:<-` input (bumping ref-counts) **before** the `(when (and cache sub-meta) …)` guard that wires the symmetric on-dispose. If the frame is destroyed between `subscribe`'s frame-record resolution and `compute-and-cache!`'s re-resolution, `cache` is nil → the parent reaction is built but never cached / never dispose-wired → the inputs leak. Fix: release the just-subscribed inputs on the not-cached path. Added `layer-2-input-refs-released-when-frame-destroyed-mid-build` (reproduces the seam deterministically via a tripped `frame/frame` redef).

## rf2-agpv2.3 — no-such-sub trace tag-shape (spec/009 alignment)

The emit used `{:rf.sub/query-v :frame}`; `spec/009` (the canonical owner of the trace-event model per `Ownership.md`) documents `{:rf.sub/id :unresolved-input :resolved-inputs}`. Aligned the **code emit** to spec/009 (`:rf.sub/id` = query-id, `:unresolved-input` = query-v, `:resolved-inputs` = `[]`, `:frame` retained). Recovery (nil-yielding reaction, not cached) unchanged. spec/009 prose left untouched per brief. Added `no-such-sub-trace-tags-match-spec-009`.

> Note: `Spec-Schemas.md`'s `NoSuchSubTags` projection still carries the old `{:rf.sub/query-v}` shape, as does the xray `NoSuchSubTags` consumer (`tools/xray/...`). Both are downstream of the canonical 009 and now lag it. Out of this PR's authorized surface (Spec-Schemas is hot-zone; xray owned by another reviewer) — flagged for a follow-up.

## rf2-agpv2.4 — redact-path throw on non-associative parent

`privacy/redact-path` guarded the `assoc-in` parent with `(some? …)`, so a non-nil **non-associative** scalar parent (e.g. payload `{:auth "tok"}`, redact path `[:auth :password]`) made `assoc-in` recurse into the string and throw inside a `:before` chain → `:rf.error/interceptor-exception` → the whole event aborts. Fix: guard with `associative?` (non-associative parent = no-op, matching the missing-leaf posture). Added `redact-path-with-scalar-parent-does-not-abort-the-event`.

## Gates

- core JVM `clojure -M:test` — 870 tests / 3912 assertions, 0 failures
- `npm run test:cljs` — 5615 tests / 19567 assertions, 0 failures
- `mkdocs build --strict` — clean (spec/002 touched)

Closes rf2-agpv2.1, rf2-agpv2.2, rf2-agpv2.3, rf2-agpv2.4.
