### PR TITLE
fix(http): timeout bounds the CLJS body read + reject non-set :retry :on (rf2-4zldh)

### DIFF
--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -50,30 +50,63 @@
 
 (defn- validate-retry!
   "Per Spec 014 §Closed-set `:retry :on` validation (rf2-apwkm): a
-  `:retry :on` set may only contain members of `retryable-categories`.
-  Anything outside (a non-retryable `:rf.http/*` category like
-  `:rf.http/aborted`, `:rf.http/decode-failure`, `:rf.http/accept-failure`
-  — or any keyword outside the `:rf.http/*` namespace) throws an
-  `:rf.error/http-bad-retry-on` ex-info per Spec 009 §Error event
-  catalogue. The throw fires at fx-call time, before `run-attempt!`,
-  so the misuse surfaces at the dispatch site rather than being
-  silently swallowed inside the transport retry loop.
+  `:retry :on` value, when present and non-nil, MUST be a SET drawn
+  exclusively from `retryable-categories`. Two failure shapes both throw
+  `:rf.error/http-bad-retry-on` at fx-call time (before `run-attempt!`),
+  so the misuse surfaces at the dispatch site rather than downstream:
 
-  Absent `:retry`, absent `:on`, or an empty `:on` set: no-op. A
-  caller who supplied `:retry` without `:on` already disables retry
-  (the transport loop's `(contains? on-set kind)` gate is false for
-  every kind), so we don't force `:on` to be non-empty here."
+  - SHAPE (rf2-4zldh): a non-set `:on` (keyword, vector, list, string,
+    map, …). Spec 014:372 types `:on` as a *set* of category keywords
+    and the transport loop's membership gate is `(contains? on-set kind)`.
+    `contains?` on a vector/list/string tests INDEX/range membership, not
+    value membership, so a non-set `:on` would silently DISABLE retry for
+    every category — exactly the useless-policy-rides-for-the-lifetime
+    misuse the dispatch-time guard exists to prevent. A bare keyword `:on`
+    was even worse: it threw a raw `IllegalArgumentException` from the
+    `(remove …)` ISeq coercion instead of the canonical error. We reject
+    every non-set non-nil `:on` here, before any of that can happen.
+
+  - MEMBERSHIP: a set `:on` carrying a non-retryable `:rf.http/*` category
+    (`:rf.http/aborted`, `:rf.http/decode-failure`,
+    `:rf.http/accept-failure`) or any keyword outside the `:rf.http/*`
+    retryable subset.
+
+  Both throw `:rf.error/http-bad-retry-on` per Spec 009 §Error event
+  catalogue, distinguished by ex-data (`:bad-shape` vs `:bad-members`).
+
+  Intentional no-retry shapes that pass untouched: absent `:retry`,
+  absent `:on`, explicit `:on nil`, and the empty set `#{}`. A caller
+  who supplies `:retry` with one of these already disables retry (the
+  transport loop's `(contains? on-set kind)` gate is false for every
+  kind), so we do not force `:on` to be non-empty here."
   [args-map]
-  (when-let [on (some-> args-map :retry :on)]
-    (when (seq on)
-      (let [bad-members (into #{} (remove retryable-categories) on)]
-        (when (seq bad-members)
-          (throw (ex-info ":rf.error/http-bad-retry-on"
-                          {:where         :rf.http/managed
-                           :recovery      :no-recovery
-                           :bad-members   bad-members
-                           :retryable-set retryable-categories
-                           :reason        "`:retry :on` must be drawn exclusively from the closed retryable set #{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}; `:rf.http/aborted`, `:rf.http/decode-failure`, and `:rf.http/accept-failure` are non-retryable by construction"})))))))
+  ;; `contains?` separates an explicit `:on nil` (intentional no-retry —
+  ;; pass) from an absent key, so we read `:on` only when the `:retry`
+  ;; map actually carries it and the value is non-nil.
+  (let [retry (:retry args-map)]
+    (when (and (map? retry) (contains? retry :on))
+      (let [on (:on retry)]
+        (when (some? on)
+          ;; SHAPE: `:on` must be a set when present and non-nil.
+          (when-not (set? on)
+            (throw (ex-info ":rf.error/http-bad-retry-on"
+                            {:rf.error/id   :rf.error/http-bad-retry-on
+                             :where         :rf.http/managed
+                             :recovery      :no-recovery
+                             :bad-shape     on
+                             :bad-type      (type on)
+                             :retryable-set retryable-categories
+                             :reason        "`:retry :on` must be a SET of retryable-category keywords per Spec 014 §Closed-set `:retry :on` validation; a non-set value (keyword, vector, list, string, …) is rejected because the transport membership gate `(contains? on-set kind)` tests index membership over a sequential collection and would silently disable retry. Use `#{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}`, `#{}` for no-retry, or omit `:on`"})))
+          ;; MEMBERSHIP: every member must be a retryable category.
+          (let [bad-members (into #{} (remove retryable-categories) on)]
+            (when (seq bad-members)
+              (throw (ex-info ":rf.error/http-bad-retry-on"
+                              {:rf.error/id   :rf.error/http-bad-retry-on
+                               :where         :rf.http/managed
+                               :recovery      :no-recovery
+                               :bad-members   bad-members
+                               :retryable-set retryable-categories
+                               :reason        "`:retry :on` must be drawn exclusively from the closed retryable set #{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}; `:rf.http/aborted`, `:rf.http/decode-failure`, and `:rf.http/accept-failure` are non-retryable by construction"})))))))))
 
 (defn- validate-url!
   "Per Spec 014 §Request envelope `:url` is the only REQUIRED key in the

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -108,78 +108,112 @@
                                      (catch :default _ nil)))
                               #js {:once true}))))
            timeout-handle (atom nil)
+           ;; rf2-4zldh — the per-attempt timeout must bound the WHOLE
+           ;; attempt, headers AND body read. A slow-loris upstream can
+           ;; send headers promptly and then stall the body
+           ;; (`.text()` / `.blob()` / `.arrayBuffer()` / `.formData()`)
+           ;; indefinitely (Spec 014 §`:timeout-ms` security defaults
+           ;; :323). The earlier shape cleared the timer the instant the
+           ;; Response (headers) resolved and only THEN began the body
+           ;; read, leaving the body-reader promise pending forever and
+           ;; the in-flight handle live. The fix: race the timer against
+           ;; the FULL fetch→body-read chain and clear the timer only
+           ;; when that chain SETTLES (`.finally`), not when headers
+           ;; arrive. The timeout still aborts `internal-controller`
+           ;; (which also rejects an in-progress body reader) and rejects
+           ;; with the canonical `:rf.error/http-timeout` ex-info — the
+           ;; same shape `classify-cljs-error` maps to `:rf.http/timeout`
+           ;; and routes through `maybe-retry!` → `finalise-failure!`,
+           ;; whose once-only `:finalised?` CAS clears the in-flight
+           ;; registry and respects abort precedence (no double-abort).
+           read-body
+           (fn [resp]
+             (let [ok?     (.-ok resp)
+                   headers (fetch-headers->map (.-headers resp))
+                   base    {:ok?         ok?
+                            :status      (.-status resp)
+                            :status-text (.-statusText resp)
+                            :headers     headers}
+                   ;; rf2-5zj6t — a Fetch Response body may be
+                   ;; consumed only once, so the body-reader is
+                   ;; chosen up front from the resolved `:decode`
+                   ;; mode (mirroring `decode-response-body`).
+                   ;; Binary modes (`:blob` / `:array-buffer` /
+                   ;; `:form-data`) read the native body and ride
+                   ;; under `:body-binary`; everything else (and
+                   ;; every non-2xx response, whose raw text is
+                   ;; what the 4xx/5xx failure paths carry) reads
+                   ;; `.text()` into `:body-text`. Decode runs
+                   ;; only on 2xx, so a non-OK response always
+                   ;; takes the text path regardless of `:decode`.
+                   binary-read-mode (when ok?
+                                      (decode/binary-read-kind decode headers))]
+               (case binary-read-mode
+                 :blob
+                 (-> (.blob resp)
+                     (.then (fn [b] (assoc base :body-binary b))))
+
+                 :array-buffer
+                 (-> (.arrayBuffer resp)
+                     (.then (fn [b] (assoc base :body-binary b))))
+
+                 :form-data
+                 (-> (.formData resp)
+                     (.then (fn [b] (assoc base :body-binary b))))
+
+                 ;; nil / text-based decode → read text.
+                 (-> (.text resp)
+                     (.then (fn [body-text]
+                              (assoc base :body-text body-text)))))))
+           ;; The full attempt: fetch the Response, then read its body.
+           ;; This is the promise the timeout races against — the timer
+           ;; covers the body read, not just the headers.
+           attempt-promise (-> (js/fetch url init)
+                               (.then read-body))
+           timeout-promise
+           (js/Promise. (fn [_ reject]
+                          ;; Per Spec 014 §`:timeout-ms` security
+                          ;; defaults: BOTH `nil` and `0` are
+                          ;; explicit opt-outs (no per-attempt
+                          ;; timeout). `0` is truthy in CLJS, so
+                          ;; `(when timeout-ms …)` would arm a
+                          ;; `setTimeout(…, 0)` that aborts the
+                          ;; request on the next macrotask — the
+                          ;; opposite of "unbounded". The
+                          ;; `(pos? …)` guard collapses
+                          ;; `nil`/`0`/negative to "no timeout".
+                          (when (and timeout-ms
+                                     (pos? timeout-ms)
+                                     internal-controller)
+                            (reset! timeout-handle
+                                    (js/setTimeout
+                                      (fn []
+                                        (try (.abort internal-controller "timeout")
+                                             (catch :default _ nil))
+                                        (reject (ex-info ":rf.error/http-timeout"
+                                                         {:rf.error/id      :rf.error/http-timeout
+                                                          :where            ':rf.http/managed
+                                                          :recovery         :no-recovery
+                                                          :reason           (str "the request exceeded its " timeout-ms "ms timeout and was aborted")
+                                                          ;; co-stamp the registry-hook signal the
+                                                          ;; downstream classifier branches on
+                                                          :rf.http/timeout? true
+                                                          :elapsed-ms       timeout-ms
+                                                          :limit-ms         timeout-ms})))
+                                      timeout-ms)))))
            promise
-           (-> (js/Promise.race
-                 #js [(js/fetch url init)
-                      (js/Promise. (fn [_ reject]
-                                     ;; Per Spec 014 §`:timeout-ms` security
-                                     ;; defaults: BOTH `nil` and `0` are
-                                     ;; explicit opt-outs (no per-attempt
-                                     ;; timeout). `0` is truthy in CLJS, so
-                                     ;; `(when timeout-ms …)` would arm a
-                                     ;; `setTimeout(…, 0)` that aborts the
-                                     ;; request on the next macrotask — the
-                                     ;; opposite of "unbounded". The
-                                     ;; `(pos? …)` guard collapses
-                                     ;; `nil`/`0`/negative to "no timeout".
-                                     (when (and timeout-ms
-                                                (pos? timeout-ms)
-                                                internal-controller)
-                                       (reset! timeout-handle
-                                               (js/setTimeout
-                                                 (fn []
-                                                   (try (.abort internal-controller "timeout")
-                                                        (catch :default _ nil))
-                                                   (reject (ex-info ":rf.error/http-timeout"
-                                                                    {:rf.error/id      :rf.error/http-timeout
-                                                                     :where            ':rf.http/managed
-                                                                     :recovery         :no-recovery
-                                                                     :reason           (str "the request exceeded its " timeout-ms "ms timeout and was aborted")
-                                                                     ;; co-stamp the registry-hook signal the
-                                                                     ;; downstream classifier branches on
-                                                                     :rf.http/timeout? true
-                                                                     :elapsed-ms       timeout-ms
-                                                                     :limit-ms         timeout-ms})))
-                                                 timeout-ms)))))])
-               (.then (fn [resp]
-                        (when-let [h @timeout-handle] (js/clearTimeout h))
-                        (let [ok?     (.-ok resp)
-                              headers (fetch-headers->map (.-headers resp))
-                              base    {:ok?         ok?
-                                       :status      (.-status resp)
-                                       :status-text (.-statusText resp)
-                                       :headers     headers}
-                              ;; rf2-5zj6t — a Fetch Response body may be
-                              ;; consumed only once, so the body-reader is
-                              ;; chosen up front from the resolved `:decode`
-                              ;; mode (mirroring `decode-response-body`).
-                              ;; Binary modes (`:blob` / `:array-buffer` /
-                              ;; `:form-data`) read the native body and ride
-                              ;; under `:body-binary`; everything else (and
-                              ;; every non-2xx response, whose raw text is
-                              ;; what the 4xx/5xx failure paths carry) reads
-                              ;; `.text()` into `:body-text`. Decode runs
-                              ;; only on 2xx, so a non-OK response always
-                              ;; takes the text path regardless of `:decode`.
-                              binary-read-mode (when ok?
-                                                 (decode/binary-read-kind decode headers))]
-                          (case binary-read-mode
-                            :blob
-                            (-> (.blob resp)
-                                (.then (fn [b] (assoc base :body-binary b))))
-
-                            :array-buffer
-                            (-> (.arrayBuffer resp)
-                                (.then (fn [b] (assoc base :body-binary b))))
-
-                            :form-data
-                            (-> (.formData resp)
-                                (.then (fn [b] (assoc base :body-binary b))))
-
-                            ;; nil / text-based decode → read text.
-                            (-> (.text resp)
-                                (.then (fn [body-text]
-                                         (assoc base :body-text body-text)))))))))]
+           (-> (js/Promise.race #js [attempt-promise timeout-promise])
+               ;; rf2-4zldh — clear the timer only once the WHOLE attempt
+               ;; (headers + body read) settles, success or failure.
+               ;; `.finally` runs on both branches and on the timeout
+               ;; rejection itself, so the timer is always disarmed
+               ;; before this promise hands off to `handle-response!` /
+               ;; the `.catch` → `maybe-retry!` sink. Returning `nil`
+               ;; keeps `.finally` value-transparent (it forwards the
+               ;; original settlement, not the handler's return).
+               (.finally (fn []
+                           (when-let [h @timeout-handle] (js/clearTimeout h))
+                           nil)))]
        promise)))
 
 #?(:cljs

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -408,6 +408,115 @@
                                      "armed a near-instant abort and rejected: " e))
                       (done))))))))
 
+;; ---- rf2-4zldh — `:timeout-ms` bounds the BODY read, not just headers ----
+;;
+;; A slow-loris upstream can resolve the Fetch Response (headers) promptly
+;; and then stall the body reader (`.text()` / `.blob()` / …) indefinitely.
+;; Spec 014 §`:timeout-ms` security defaults (:323) requires the per-attempt
+;; timeout to protect against exactly this. The pre-fix transport cleared
+;; the timer the instant the Response resolved and only THEN began the body
+;; read, so a stalled body left the body-reader promise pending forever and
+;; the in-flight handle live. The fix races the timer against the FULL
+;; fetch→body-read chain and disarms it only when that chain settles.
+
+(defn- fake-response-stalled-body
+  "A Fetch `Response` stand-in whose HEADERS resolve immediately (the
+  outer `js/fetch` Promise) but whose selected body reader returns a
+  Promise that NEVER settles. Models a server that sends headers then
+  stalls the body — the slow-loris the per-attempt timeout must bound.
+  `read-fired` (an atom) is set true the moment the body reader is
+  invoked, so the test can assert the reader was reached before the
+  timeout fired."
+  [{:keys [status content-type read-fired]}]
+  #js {:ok          (and (>= status 200) (< status 300))
+       :status      status
+       :statusText  ""
+       :headers     #js {:forEach (fn [cb]
+                                    (when content-type (cb content-type "content-type")))}
+       :text        (fn [] (reset! read-fired true) (js/Promise. (fn [_ _])))
+       :blob        (fn [] (reset! read-fired true) (js/Promise. (fn [_ _])))
+       :arrayBuffer (fn [] (reset! read-fired true) (js/Promise. (fn [_ _])))
+       :formData    (fn [] (reset! read-fired true) (js/Promise. (fn [_ _])))})
+
+(deftest cljs-timeout-bounds-stalled-body-read
+  (testing "rf2-4zldh — `cljs-fetch` REJECTS with the canonical
+  :rf.error/http-timeout ex-info when the Response resolves (headers) but
+  the selected body reader never settles past `:timeout-ms`. Pre-fix the
+  timer was cleared on header arrival, so this promise hung forever."
+    (async done
+      (let [read-fired (atom false)
+            resp       (fake-response-stalled-body
+                         {:status 200 :content-type "application/json"
+                          :read-fired read-fired})]
+        (-> (with-stub-fetch resp
+              #(cljs-fetch {:method     :get
+                            :url        "/slow-body"
+                            :headers    {}
+                            :decode     :json
+                            :timeout-ms 40
+                            :internal-controller (js/AbortController.)}))
+            (.then (fn [result]
+                     (is false (str "rf2-4zldh regression — a stalled body "
+                                    "read RESOLVED instead of timing out: " (pr-str result)))
+                     (done)))
+            (.catch (fn [err]
+                      (is (true? @read-fired)
+                          "the body reader was reached (headers resolved) before the timeout fired")
+                      (let [data (ex-data err)]
+                        (is (= :rf.error/http-timeout (:rf.error/id data))
+                            "the stalled-body timeout rejects with the canonical :rf.error/http-timeout")
+                        (is (true? (:rf.http/timeout? data))
+                            "the registry-hook timeout signal is co-stamped")
+                        (is (= 40 (:limit-ms data))))
+                      (done))))))))
+
+(deftest cljs-timeout-stalled-body-finalises-as-timeout-and-clears-registry
+  (testing "rf2-4zldh — driven through the full `:rf.http/managed` pipeline,
+  a response whose body reader stalls past `:timeout-ms` finalises as a
+  :rf.http/timeout failure reply AND clears the in-flight registry. This is
+  the end-to-end acceptance: the slow-loris no longer pins an in-flight
+  handle indefinitely."
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (http-managed/clear-all-in-flight!)
+      (let [replies    (atom [])
+            read-fired (atom false)
+            resp       (fake-response-stalled-body
+                         {:status 200 :content-type "application/json"
+                          :read-fired read-fired})
+            orig       (.-fetch js/globalThis)]
+        (set! (.-fetch js/globalThis) (fn [_url _init] (js/Promise.resolve resp)))
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event-fx :issue/slow-body
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url "/slow-body"}
+                    :decode     :json
+                    :timeout-ms 40
+                    :request-id :loris
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue/slow-body])
+        (-> (test-support/poll-until
+              #(seq @replies)
+              {:timeout-ms 2000 :label "cljs stalled-body timeout reply"})
+            (.then (fn [_]
+                     (is (true? @read-fired)
+                         "the body reader was reached before the timeout fired")
+                     (let [reply (first @replies)]
+                       (is (= :failure (:kind reply)))
+                       (is (= :rf.http/timeout (get-in reply [:failure :kind]))
+                           "a stalled body read finalises as the canonical :rf.http/timeout failure"))
+                     (is (empty? (registry/in-flight-snapshot))
+                         "the in-flight registry is cleared — the slow-loris handle is not pinned")
+                     (set! (.-fetch js/globalThis) orig)
+                     (done)))
+            (.catch (fn [e]
+                      (set! (.-fetch js/globalThis) orig)
+                      (is false (str "rf2-4zldh — unexpected: " e))
+                      (done))))))))
+
 ;; ---- rf2-wj8vv — the retry backoff window is cancellable (CLJS) -----------
 ;;
 ;; The JVM suite (re-frame.http-backoff-cancellation-test) covers all three

--- a/implementation/http/test/re_frame/http_retry_on_validation_test.clj
+++ b/implementation/http/test/re_frame/http_retry_on_validation_test.clj
@@ -76,6 +76,22 @@
               (= bad-members               (:bad-members data))
               (string?                     (:reason data))))))
 
+(defn- bad-retry-shape-throw?
+  "rf2-4zldh — a non-set `:on` throws `:rf.error/http-bad-retry-on` with
+  `:bad-shape` (the offending value) rather than `:bad-members`. The
+  ex-data must carry the canonical error id, the offending value, and a
+  string `:reason`."
+  [ex bad-shape]
+  (and (some? ex)
+       (= ":rf.error/http-bad-retry-on" (.getMessage ex))
+       (let [data (ex-data ex)]
+         (and (= :rf.error/http-bad-retry-on (:rf.error/id data))
+              (= :rf.http/managed            (:where data))
+              (= :no-recovery                (:recovery data))
+              (= bad-shape                   (:bad-shape data))
+              (contains? data :bad-type)
+              (string?                       (:reason data))))))
+
 ;; ---- rejection: non-retryable :rf.http/* categories -----------------------
 
 (deftest aborted-rejected
@@ -123,6 +139,44 @@
       (is (bad-retry-on-throw? ex
             #{:rf.http/aborted :rf.http/decode-failure})))))
 
+;; ---- rejection: non-set `:on` shapes (rf2-4zldh) --------------------------
+
+(deftest keyword-on-rejected
+  (testing "rf2-4zldh — a bare keyword `:on` throws
+    :rf.error/http-bad-retry-on with :bad-shape. Previously this threw a
+    raw IllegalArgumentException (\"Don't know how to create ISeq from:
+    clojure.lang.Keyword\") from the `(remove …)` ISeq coercion."
+    (let [ex (call-managed! {:on :rf.http/transport :max-attempts 3})]
+      (is (bad-retry-shape-throw? ex :rf.http/transport))
+      (is (not (instance? IllegalArgumentException ex))
+          "must be the canonical :rf.error/http-bad-retry-on, not a raw IllegalArgumentException"))))
+
+(deftest vector-on-rejected
+  (testing "rf2-4zldh — a vector `:on` (even with retryable members)
+    throws :rf.error/http-bad-retry-on. Previously a vector reached
+    run-attempt! unchanged, where `(contains? on-set kind)` tests INDEX
+    membership not category membership — silently disabling retry."
+    (let [bad [:rf.http/transport]
+          ex  (call-managed! {:on bad :max-attempts 3})]
+      (is (bad-retry-shape-throw? ex bad)))))
+
+(deftest list-on-rejected
+  (testing "rf2-4zldh — a list `:on` is rejected; only a set is valid."
+    (let [bad (list :rf.http/transport :rf.http/http-5xx)
+          ex  (call-managed! {:on bad :max-attempts 3})]
+      (is (bad-retry-shape-throw? ex bad)))))
+
+(deftest string-on-rejected
+  (testing "rf2-4zldh — a string `:on` is rejected; only a set is valid."
+    (let [ex (call-managed! {:on "rf.http/transport" :max-attempts 3})]
+      (is (bad-retry-shape-throw? ex "rf.http/transport")))))
+
+(deftest map-on-rejected
+  (testing "rf2-4zldh — a map `:on` is rejected; only a set is valid."
+    (let [bad {:rf.http/transport true}
+          ex  (call-managed! {:on bad :max-attempts 3})]
+      (is (bad-retry-shape-throw? ex bad)))))
+
 ;; ---- pass-through: closed-set members and absences ------------------------
 
 (deftest all-closed-set-members-pass-through
@@ -168,5 +222,14 @@
     the validator is a no-op. Equivalent to no retry per the
     transport loop's `(or on #{})` defaulting."
     (let [ex (call-managed! {:max-attempts 3})]
+      (is (not (and (some? ex)
+                    (= ":rf.error/http-bad-retry-on" (.getMessage ex))))))))
+
+(deftest explicit-nil-on-passes-through
+  (testing "rf2-4zldh — `:retry {:on nil :max-attempts 3}`: an explicit
+    nil `:on` is an intentional no-retry shape, not a malformed value.
+    It passes the shape check (the `(some? on)` guard) the same as an
+    absent `:on`. Only present, non-nil, non-set values are rejected."
+    (let [ex (call-managed! {:on nil :max-attempts 3})]
       (is (not (and (some? ex)
                     (= ":rf.error/http-bad-retry-on" (.getMessage ex))))))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -393,7 +393,12 @@ The other `:rf.http/*` categories from [§Failure categories](#failure-categorie
 | `:rf.http/decode-failure` | The next attempt would deterministically reproduce the same schema-validation / parser failure for the same response shape — retrying buys nothing and burns attempts. |
 | `:rf.http/accept-failure` | A `{:failure user-map}` projection from `:accept` is the caller's own classification of a successful transport + decode; retrying the transport will not change the response body. Domain-level retry of this shape belongs to a state machine (see [§Boundary — transport vs semantic retry](#boundary--transport-vs-semantic-retry)), not to `:retry`. |
 
-Implementations **MUST validate `:retry :on` at fx-call time** (when the `:rf.http/managed` fx body is invoked, before any attempt is issued). A non-empty intersection between `:on` and the rejected set throws an `:rf.error/http-bad-retry-on` ex-info, per [Spec 009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue). This catches the misuse at the dispatch site rather than silently letting a useless retry policy ride for the request's lifetime (or, for `:rf.http/aborted`, deferring the rejection to retry-attempt time inside the transport loop). Membership outside the full `:rf.http/*` namespace is also rejected — the set is closed.
+Implementations **MUST validate `:retry :on` at fx-call time** (when the `:rf.http/managed` fx body is invoked, before any attempt is issued). The validation has two parts:
+
+- **Shape.** When present and non-nil, `:on` MUST be a `set`. A non-set value (a bare keyword, a vector, a list, a string, …) is rejected with `:rf.error/http-bad-retry-on` (ex-data `:bad-shape`). This is a hard rejection, not a coercion: the transport membership gate is `(contains? on-set kind)`, and `contains?` over a *sequential* collection tests index/range membership rather than value membership — so a vector `:on` would silently DISABLE retry for every category. An explicit `:on nil` and the empty set `#{}` are intentional no-retry shapes and pass untouched.
+- **Membership.** A non-empty intersection between a set `:on` and the rejected set throws an `:rf.error/http-bad-retry-on` ex-info (ex-data `:bad-members`), per [Spec 009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue). Membership outside the full `:rf.http/*` namespace is also rejected — the set is closed.
+
+Both parts catch the misuse at the dispatch site rather than silently letting a useless retry policy ride for the request's lifetime (or, for `:rf.http/aborted`, deferring the rejection to retry-attempt time inside the transport loop).
 
 Per the spec tighten: implementations MUST NOT accept the old open `:rf.http/*` set. The rejection is hard, not advisory.
 


### PR DESCRIPTION
## Summary

Closes the two Spec 014 HTTP contract gaps from the senior review (`rf2-4zldh`).

### (1) CLJS `:timeout-ms` now bounds the response BODY read

The Fetch transport raced `js/fetch` against the timeout but **cleared the timer the instant the Response (headers) resolved**, then began the body reader (`.text` / `.blob` / `.arrayBuffer` / `.formData`) **unbounded**. A slow-loris upstream that sends headers and then stalls the body left the body-reader promise pending forever while the in-flight handle stayed live — exactly the pin Spec 014:323 says the default timeout must prevent.

**Fix:** race the timer against the **full** fetch→body-read chain and disarm it (via `.finally`) only when that chain **settles**, not when headers arrive. On timeout the existing `internal-controller` abort + canonical `:rf.error/http-timeout` ex-info still fire, so the reject routes through `classify-cljs-error` → `:rf.http/timeout` → `maybe-retry!` → `finalise-failure!`, whose once-only `:finalised?` CAS clears the in-flight registry and respects abort precedence (no double-abort).

### (2) `:retry :on` non-set shapes rejected canonically

A keyword `:on` threw a raw `IllegalArgumentException` (`Don't know how to create ISeq from: clojure.lang.Keyword`); a vector/list/string `:on` reached `run-attempt!` unchanged, where `(contains? on-set kind)` tests **index** membership over a sequential collection — silently **disabling** retry for every category.

**Fix:** `validate-retry!` now requires `:on` to be a **set** when present and non-nil, rejecting any non-set with `:rf.error/http-bad-retry-on` (ex-data `:bad-shape`) at fx-call time, before middleware / `run-attempt!`. `#{}`, absent `:on`, and explicit `:on nil` remain intentional no-retry shapes. Spec 014:396 updated to make the shape rejection normative.

## Tests

- **CLJS**: a stalled body read past `:timeout-ms` makes `cljs-fetch` reject with `:rf.error/http-timeout`, and end-to-end through `:rf.http/managed` finalises as a `:rf.http/timeout` failure reply **and clears the in-flight registry**.
- **JVM**: `:on` as keyword / vector / list / string / map → canonical `:rf.error/http-bad-retry-on`; explicit `:on nil` passes through.

### Without-fix-fails proofs
- Reverting `http_handlers.cljc` to `origin/main`: `keyword-on-rejected` ERRORs with the raw `IllegalArgumentException`; vector/list/string/map shape tests FAIL (no canonical throw). 4 failures, 1 error.
- Reverting `http_transport.cljc` to `origin/main`: the node CLJS run never reaches the `Ran N tests` completion marker — the stalled body read pins a never-settling promise and the runner never reports (truncated output).

## Gates (green with fix)
- http JVM `clojure -M:test` — **329 tests, 1569 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **5617 tests, 19575 assertions, 0 failures, 0 errors**

Existing abort-precedence, retry-backoff cancellation, and binary-decode suites unchanged.