### PR TITLE
fix(ssr-ring): streaming shell failures fail closed to non-200 (rf2-r06pc)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -149,7 +149,7 @@
         ;; call site not protected by the handler body's catch.
         {:short-circuit (lifecycle/safe-on-error on-error request t)}))))
 
-(defn ^:private render-error-body
+(defn render-error-body
   "Build a minimal HTML body from a public-error map — the host's
   DEFAULT error template (Spec 011 §Server error projection step 5,
   the \"or the host's default error template\" branch). Used when no
@@ -183,7 +183,7 @@
                      (str "Error code: " code* " (status " status* ")")])]]]
     (ssr/render-to-string hiccup {:doctype? true :emit-hash? false})))
 
-(defn ^:private resolve-error-body
+(defn resolve-error-body
   "Resolve the projected-error HTML body (Spec 011 §Server error
   projection step 5 — \"a registered view (or the host's default error
   template) … receiving the public-error map as its prop\").
@@ -337,6 +337,43 @@
     ;; both work.
     (ssr-response->ring-response post-render-resp html content-type)))
 
+(defn project-render-throw->ring-response
+  "Route a render-time `Throwable` through the SSR error projector and
+  materialise the projected (fail-closed, non-200) Ring error response.
+  Shared by the non-streaming `build-full-response` catch arm AND the
+  streaming `stream-handler` shell phase (rf2-r06pc) so BOTH render-side
+  failure surfaces emit one uniform projected-error body contract.
+
+  Steps (Spec 011 §Server error projection §View-time exceptions):
+
+    1. `ssr/project-render-exception!` — synthesises a
+       `:rf.error/ssr-render-failed` trace event, drives the active
+       projector, stamps the public-error's `:status` onto the response
+       accumulator. Returns the public-error map (or nil — frame missing
+       / not a server frame).
+    2. `ssr/peek-response` — pure read of the now-stamped response
+       accumulator (the projection drain already ran).
+    3. `resolve-error-body` — caller-registered `:error-view` (receiving
+       the public-error map) when present, else the host default
+       template.
+    4. `ssr-response->ring-response` — materialise through the SAME
+       happy-path materialiser, so headers / cookies the drain DID
+       accumulate before the throw still ride the wire.
+
+  When projection returns nil (e.g. no server frame) the locked
+  generic-500 public-error is substituted so the wire still carries a
+  well-formed fail-closed body."
+  [frame-id ^Throwable t opts]
+  (let [public-error  (ssr/project-render-exception! frame-id t)
+        resp*         (ssr/peek-response frame-id)
+        public-error* (or public-error
+                          {:status 500 :code :internal-error
+                           :message "Something went wrong"
+                           :retryable? false})
+        body-html     (resolve-error-body frame-id (:error-view opts) public-error*)
+        content-type  (:content-type opts)]
+    (ssr-response->ring-response resp* body-html content-type)))
+
 (defn build-full-response
   "Render the caller's `:root-view` against `frame-id`, build the
   hydration payload, wrap in the html-shell, and materialise to a Ring
@@ -385,24 +422,12 @@
   (try
     (build-full-response* frame-id resp opts)
     (catch Throwable t
-      (let [public-error  (ssr/project-render-exception! frame-id t)
-            ;; The projector stamped :status onto the response
-            ;; accumulator inside `project-render-exception!`;
-            ;; peek-response returns the resolved snapshot without
-            ;; re-draining (the drain already happened). When
-            ;; projection returned nil (e.g. no server frame) the
-            ;; resolved response is whatever was last accumulated;
-            ;; the render-error-body fallback below still emits the
-            ;; locked-500 generic shape, so the wire still carries
-            ;; a well-formed body.
-            resp*         (ssr/peek-response frame-id)
-            public-error* (or public-error
-                              {:status 500 :code :internal-error
-                               :message "Something went wrong"
-                               :retryable? false})
-            ;; Spec 011 §Server error projection step 5: render a
-            ;; caller-registered `:error-view` (receiving the public-
-            ;; error map) when present, else the host default template.
-            body-html     (resolve-error-body frame-id (:error-view opts) public-error*)
-            content-type  (:content-type opts)]
-        (ssr-response->ring-response resp* body-html content-type)))))
+      ;; The projector stamps :status onto the response accumulator and
+      ;; the projected (fail-closed, non-200) error body is materialised
+      ;; through the SAME path the streaming shell phase now reuses
+      ;; (rf2-r06pc — `project-render-throw->ring-response`). Render-time
+      ;; AND drain-time exceptions thus share one wire-body contract,
+      ;; and the streaming + non-streaming shell-failure surfaces project
+      ;; identically (Spec 011 §Server error projection §View-time
+      ;; exceptions).
+      (project-render-throw->ring-response frame-id t opts))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -109,24 +109,33 @@
        "</body>"
        "</html>"))
 
-;; ---- chunk writer --------------------------------------------------------
+;; ---- shell phase (request thread, BEFORE the head commits) --------------
 ;;
-;; The Ring response body is a `PipedInputStream` paired with a writer
-;; thread that pushes chunks onto a `PipedOutputStream`. The writer
-;; thread holds the per-request frame open across continuations and is
-;; the place where exceptions are caught — anything that throws there
-;; gracefully closes the pipe so the client sees a clean EOF rather
-;; than a half-streamed response.
+;; rf2-r06pc — the shell render runs on the REQUEST thread, BEFORE the
+;; Ring response head is committed and BEFORE the writer thread is
+;; spawned. This is the streaming counterpart to the non-streaming
+;; handler's post-render re-flush (rf2-c0bq1, `pipeline.clj`):
 ;;
-;; Per Spec 011 §Failure semantics — inline fallback — exceptions
-;; INSIDE a continuation render are caught by streaming/render-continuation
-;; (which returns {:failed? true :html <fallback-html> :delta nil}); the
-;; writer thread proceeds with the next boundary. Exceptions OUTSIDE a
-;; continuation (e.g. an error projecting the response, or a final-
-;; payload build throw) close the pipe with the partial response that
-;; was already flushed — the client sees a truncated but valid HTML
-;; structure (open tags balanced by what was emitted) and the server
-;; logs the trace via the standard error-projection path.
+;;   - A root-view throw / shell-walk throw escalates to
+;;     `:rf.error/ssr-render-failed` via the projector and FAILS CLOSED
+;;     to a non-200 projected error page (Spec 011 §744/§748/§954) —
+;;     handled by the handler's outer try/catch on the request thread.
+;;   - A production reactive-sub throw during the shell render recovers
+;;     to nil (the walk does NOT throw) but BUFFERS a fail-closed 500 on
+;;     the always-on error-emit substrate (rf2-vvwmi). The handler
+;;     re-reads the response accumulator (`ssr/get-response`) AFTER the
+;;     shell render to pick that status up, exactly as `build-full-
+;;     response*` does — and a non-200 there fails closed to the
+;;     projected error page rather than streaming the broken HTML.
+;;
+;; Only once the shell is KNOWN-RENDERABLE (clean render AND a success
+;; status) does the handler commit the chunked response head and hand
+;; the already-rendered shell + continuations to the daemon writer. The
+;; writer's only remaining failure surface is continuation drains (which
+;; the inline-fallback contract already covers, Spec 011 §942-954) and
+;; the final-payload / suffix writes — and those happen AFTER the first
+;; chunk has committed, so they correctly degrade to a truncate-and-close
+;; rather than re-stamping a status the wire has already sent.
 
 (defn- ->utf8 ^bytes [^String s]
   (.getBytes s StandardCharsets/UTF_8))
@@ -135,23 +144,75 @@
   (.write out (->utf8 s))
   (.flush out))
 
-(defn- run-streaming-writer!
-  "Run the streaming writer on the calling thread. The caller supplies
-  an open `OutputStream` (the pipe sink). On any throw, the catch arm
-  emits a `:rf.error/ssr-streaming-writer-failed` trace and closes the
-  stream cleanly so the Ring server can EOF the response."
-  [^OutputStream out frame-id resp opts]
-  (try
-    (let [{:keys [root-view emit-hash? version schema-digest payload
-                  content-type]} opts
-          hiccup     (rf/with-frame frame-id
-                       (lifecycle/resolve-root-view root-view))
+(defn render-streaming-shell!
+  "Resolve + render the streaming shell on the CALLING (request) thread.
+  Returns the pre-rendered pieces the daemon writer needs to drain the
+  chunk stream:
+
+    {:hiccup        <resolved root hiccup>     ;; for the final-hash
+     :head-html     \"…\"                        ;; resolved <head> fragment
+     :html-attrs    {…} or nil                  ;; stamped on <html>
+     :body-attrs    {…} or nil                  ;; stamped on <body>
+     :shell-html    \"…\"                        ;; chunk 1 body
+     :continuations [{:id … :subtree …} …]}     ;; drain queue (FIFO)
+
+  Throws propagate to the caller (the handler's outer try/catch routes
+  them through the projector → fail-closed non-200, rf2-r06pc). The
+  recovered-to-nil sub case does NOT throw here — its buffered fail-
+  closed status is picked up by the handler's post-shell `get-response`
+  re-read."
+  [frame-id {:keys [root-view] :as opts}]
+  (rf/with-frame frame-id
+    (let [hiccup     (lifecycle/resolve-root-view root-view)
           {:keys [head-html html-attrs body-attrs]}
           (if (:head opts)
             {:head-html (:head opts) :html-attrs nil :body-attrs nil}
             (lifecycle/resolve-head frame-id))
-          {:keys [shell-html continuations]}
-          (rf/with-frame frame-id (streaming/render-shell hiccup))
+          {:keys [shell-html continuations]} (streaming/render-shell hiccup)]
+      {:hiccup        hiccup
+       :head-html     head-html
+       :html-attrs    html-attrs
+       :body-attrs    body-attrs
+       :shell-html    shell-html
+       :continuations continuations})))
+
+;; ---- chunk writer (daemon thread, AFTER the head commits) ---------------
+;;
+;; The Ring response body is a `PipedInputStream` paired with a writer
+;; thread that pushes chunks onto a `PipedOutputStream`. The writer
+;; thread receives the ALREADY-RENDERED shell + continuations from the
+;; request thread (rf2-r06pc) — it no longer resolves/renders the shell
+;; itself, so a shell failure can never reach this thread. It holds the
+;; per-request frame open across continuation drains and is the place
+;; where post-commit exceptions are caught — anything that throws there
+;; gracefully closes the pipe so the client sees a clean EOF rather than
+;; a half-streamed response.
+;;
+;; Per Spec 011 §Failure semantics — inline fallback — exceptions
+;; INSIDE a continuation render are caught by streaming/render-continuation
+;; (which returns {:failed? true :html <fallback-html> :delta nil}); the
+;; writer thread proceeds with the next boundary. Exceptions OUTSIDE a
+;; continuation (e.g. a final-payload build throw, or a downstream pipe
+;; broken-write) close the pipe with the partial response that was
+;; already flushed — the first chunk has already committed the success
+;; status to the wire, so a truncate-and-close is the only safe outcome
+;; (the status can no longer change). The server logs the trace via
+;; `:rf.error/ssr-streaming-writer-failed`.
+
+(defn- run-streaming-writer!
+  "Run the streaming writer on the calling (daemon) thread. The caller
+  supplies an open `OutputStream` (the pipe sink) and the pre-rendered
+  shell pieces from `render-streaming-shell!` (rf2-r06pc — the shell is
+  resolved/rendered on the request thread BEFORE the head commits, so
+  shell failures fail closed there; this thread only drains the chunk
+  stream). On any throw, the catch arm emits a
+  `:rf.error/ssr-streaming-writer-failed` trace and closes the stream
+  cleanly so the Ring server can EOF the response."
+  [^OutputStream out frame-id rendered opts]
+  (try
+    (let [{:keys [emit-hash? version schema-digest payload]} opts
+          {:keys [hiccup head-html html-attrs body-attrs
+                  shell-html continuations]} rendered
           shell-opts (merge opts
                             {:html-attrs html-attrs
                              :body-attrs body-attrs})]
@@ -209,15 +270,30 @@
       circuits to a non-streamed Location response (Spec 011 §Redirect
       precedence) AND destroys the per-request frame inline (the writer
       thread is never spawned on this branch),
-    - otherwise materialises the response head (status / headers /
-      cookies) FIRST — so a header/cookie serialisation throw on a
-      value that escaped the fx boundary's partial validation
-      short-circuits to `:on-error` with no pipe + no thread to orphan
-      (rf2-z5azc) — and only then spawns a streaming writer on a daemon
-      thread that flushes shell → continuations → final payload →
-      close, destroying the frame in that thread's finally so the
-      per-frame side-channels clear (Spec 011 §Per-request frame
-      teardown contract) without blocking the response close.
+    - otherwise RENDERS THE SHELL on the request thread BEFORE committing
+      the chunked response head (rf2-r06pc — the streaming counterpart
+      of the non-streaming post-render re-flush, rf2-c0bq1). A root-view
+      / shell-walk throw escalates to `:rf.error/ssr-render-failed` via
+      the projector and a production reactive-sub throw during the shell
+      render buffers a fail-closed status the post-shell `get-response`
+      re-read picks up — BOTH fail closed to a non-200 projected error
+      page (Spec 011 §744/§748/§954) on the request thread, with NO pipe
+      and NO writer thread spawned. The chunked response is committed
+      ONLY once the shell is known-renderable (clean render AND a success
+      status),
+    - then materialises the response head (status / headers / cookies)
+      — so a header/cookie serialisation throw on a value that escaped
+      the fx boundary's partial validation short-circuits to `:on-error`
+      with no pipe + no thread to orphan (rf2-z5azc) — and only then
+      spawns a streaming writer on a daemon thread that flushes the
+      PRE-RENDERED shell → continuations → final payload → close,
+      destroying the frame in that thread's finally so the per-frame
+      side-channels clear (Spec 011 §Per-request frame teardown contract)
+      without blocking the response close. The writer thread's only
+      remaining failure surface is continuation drains (inline-fallback,
+      Spec 011 §942-954) and the post-first-chunk final-payload / suffix
+      writes — never the shell, which already committed its status on
+      the request thread.
 
   The response body is a `PipedInputStream` Ring accepts directly; the
   pipe's writer side runs on a daemon thread so Jetty/http-kit/Aleph
@@ -291,60 +367,133 @@
                   (pipeline/ssr-response->ring-response resp nil)
                   (finally
                     (lifecycle/destroy-frame-quietly! frame-id)))
-                ;; Streaming path. rf2-z5azc — MATERIALISE the response
-                ;; head (status / headers / cookies) BEFORE constructing
-                ;; the pipe or spawning the writer thread. Cookie / header
-                ;; serialisation CAN throw at materialise time on a value
-                ;; that escaped the fx boundary's partial validation —
-                ;; e.g. a `:max-age` carrying CR/LF or a non-integer
-                ;; `:expires`, which `cookie->set-cookie-header` rejects
-                ;; but the runtime `validate-cookie!` (name/value/path/
-                ;; domain only) does not. If we spawned the writer first
-                ;; (the old order), that throw would orphan the pipe: the
-                ;; daemon writer keeps pumping the full body into a pipe
-                ;; whose reader is never handed out, blocks forever once
-                ;; the 16 KiB buffer fills, and leaks one live thread per
-                ;; such request — a resource-exhaustion vector. By
-                ;; building `resp-map` first, a head-materialisation
-                ;; failure short-circuits to the outer catch BEFORE any
-                ;; thread or pipe exists → on-error, no detached writer,
-                ;; no orphaned pipe. "We committed to streaming" is now
-                ;; atomic with "the response envelope is materialisable".
+                ;; Streaming path. rf2-r06pc — RENDER THE SHELL on THIS
+                ;; (request) thread BEFORE committing the chunked response
+                ;; head, the streaming counterpart of the non-streaming
+                ;; post-render re-flush (rf2-c0bq1). The shell render is
+                ;; the request's structural foundation; its failure modes
+                ;; MUST fail closed to a non-200 (Spec 011 §744/§748/§954),
+                ;; NOT a silent 200/truncated chunked body from a detached
+                ;; daemon thread that can no longer stamp the status.
                 ;;
-                ;; No body default-stamp here (we pass our own
-                ;; InputStream); `:body` is assoc'd after the writer is
-                ;; wired below.
-                (let [resp-map (pipeline/ssr-response->ring-response
-                                 resp "" content-type)
-                      ;; 16 KiB pipe buffer — large enough to absorb the
-                      ;; shell chunk in one write so the writer thread
-                      ;; rarely blocks on a slow consumer, small enough
-                      ;; that one stuck client doesn't pin a non-trivial
-                      ;; chunk of heap per request.
-                      pipe-in  (PipedInputStream. (* 16 1024))
-                      pipe-out (PipedOutputStream. pipe-in)]
-                  ;; Daemon thread (rf2-ekwda): a writer blocked on
-                  ;; `.write` to the bounded 16 KiB pipe of a slow-loris
-                  ;; client must NOT keep the JVM alive at shutdown. The
-                  ;; ns + handler docstrings and both test namespaces
-                  ;; assert daemon semantics; this is what makes that
-                  ;; contract real.
-                  (doto
-                    (Thread.
-                      ^Runnable
-                      (fn writer-thread []
-                        (try
-                          (run-streaming-writer! pipe-out frame-id resp opts)
-                          (finally
-                            ;; The writer's own finally closes the
-                            ;; pipe; the frame teardown happens here so
-                            ;; it does NOT block the response close on
-                            ;; the slower destroy path.
-                            (lifecycle/destroy-frame-quietly! frame-id))))
-                      ^String (str "rf2-ssr-streaming-" (name frame-id)))
-                    (.setDaemon true)
-                    (.start))
-                  (assoc resp-map :body pipe-in))))
+                ;;   - A root-view / shell-walk throw propagates here and
+                ;;     is routed through `project-render-throw->ring-
+                ;;     response` (→ `:rf.error/ssr-render-failed`, projector,
+                ;;     non-200 projected error page) — same wire-body
+                ;;     contract as the non-streaming `build-full-response`
+                ;;     catch arm.
+                ;;   - A production reactive-sub throw during the shell
+                ;;     render recovers to nil (the walk does NOT throw) but
+                ;;     buffers a fail-closed 500 on the always-on error-emit
+                ;;     substrate (rf2-vvwmi). The post-shell `ssr/get-
+                ;;     response` re-read drains that buffer and stamps the
+                ;;     500 onto the response accumulator BEFORE the chunked
+                ;;     head is materialised — so the committed wire status
+                ;;     is the fail-closed 500, never the stale pre-render
+                ;;     200 (the rendered shell still streams as the body,
+                ;;     exactly as the non-streaming handler ships the
+                ;;     recovered body with the 500 — the status is the
+                ;;     fail-closed signal).
+                ;;
+                ;; NO pipe and NO writer thread is constructed until the
+                ;; shell is known-renderable (clean render AND a success
+                ;; status). A shell-render throw is caught by the dedicated
+                ;; inner try below and converted to the PROJECTED error
+                ;; response (NOT the `:on-error` transport net) — matching
+                ;; the non-streaming `build-full-response` catch arm, where
+                ;; a render-time throw projects rather than escaping to
+                ;; `:on-error`. The handler's OUTER try/catch remains the
+                ;; net for the OTHER throws (head materialise, redirect
+                ;; materialise) → `:on-error`.
+                (let [rendered  (try
+                                  (render-streaming-shell! frame-id opts)
+                                  (catch Throwable t
+                                    ;; Shell render threw — fail closed to
+                                    ;; the projected non-200 error page on
+                                    ;; THIS thread, tear the frame down
+                                    ;; inline (no writer was spawned), and
+                                    ;; return. The deref below never runs.
+                                    (let [err-resp (pipeline/project-render-throw->ring-response
+                                                     frame-id t opts)]
+                                      (lifecycle/destroy-frame-quietly! frame-id)
+                                      (reduced err-resp))))]
+                  (if (reduced? rendered)
+                    @rendered
+                    ;; Shell rendered without throwing. Re-read the
+                    ;; response accumulator to surface any fail-closed
+                    ;; status a recovered-to-nil reactive sub buffered
+                    ;; during the shell render (rf2-vvwmi / rf2-r06pc) —
+                    ;; the streaming analogue of `build-full-response*`'s
+                    ;; post-render `ssr/flush-response!` re-read (rf2-c0bq1).
+                    ;; A production reactive sub that throws mid-render
+                    ;; recovers to nil and BUFFERS a fail-closed 500 on the
+                    ;; always-on error-emit substrate; `ssr/get-response`
+                    ;; drains that buffer and stamps the 500 onto `resp2`.
+                    ;; We MATERIALISE the chunked response head from
+                    ;; `resp2`, so the wire status is the fail-closed 500
+                    ;; — never the stale pre-render 200 the OLD writer-
+                    ;; thread order shipped (Spec 011 §744/§750). A redirect
+                    ;; or a deliberate app-set non-200 (`:rf.server/set-
+                    ;; status`) surfaces here too and rides the wire
+                    ;; unchanged — identical to the non-streaming handler,
+                    ;; which streams the rendered body with whatever post-
+                    ;; flush status the accumulator carries (the status is
+                    ;; the fail-closed signal; the body is moot under a
+                    ;; non-200).
+                    (let [resp2 (ssr/get-response frame-id)
+                          ;; rf2-z5azc — MATERIALISE the response head
+                          ;; (status / headers / cookies) from the re-read
+                          ;; `resp2` BEFORE constructing the pipe or
+                          ;; spawning the writer. Cookie / header
+                          ;; serialisation CAN throw at materialise time on
+                          ;; a value that escaped the fx boundary's partial
+                          ;; validation — e.g. a `:max-age` carrying CR/LF,
+                          ;; which `cookie->set-cookie-header` rejects but
+                          ;; the runtime `validate-cookie!` does not. If we
+                          ;; spawned the writer first, that throw would
+                          ;; orphan the pipe (the daemon writer pumps the
+                          ;; full body into a reader-less pipe, blocks once
+                          ;; the 16 KiB buffer fills, and leaks one live
+                          ;; thread per request). By building `resp-map`
+                          ;; first, a head-materialisation failure short-
+                          ;; circuits to the outer catch BEFORE any thread
+                          ;; or pipe exists → on-error, no detached writer,
+                          ;; no orphaned pipe.
+                          ;;
+                          ;; No body default-stamp here (we pass our own
+                          ;; InputStream); `:body` is assoc'd after the
+                          ;; writer is wired below.
+                          resp-map (pipeline/ssr-response->ring-response
+                                     resp2 "" content-type)
+                          ;; 16 KiB pipe buffer — large enough to absorb the
+                          ;; shell chunk in one write so the writer thread
+                          ;; rarely blocks on a slow consumer, small enough
+                          ;; that one stuck client doesn't pin a non-trivial
+                          ;; chunk of heap per request.
+                          pipe-in  (PipedInputStream. (* 16 1024))
+                          pipe-out (PipedOutputStream. pipe-in)]
+                      ;; Daemon thread (rf2-ekwda): a writer blocked on
+                      ;; `.write` to the bounded 16 KiB pipe of a slow-loris
+                      ;; client must NOT keep the JVM alive at shutdown. The
+                      ;; ns + handler docstrings and both test namespaces
+                      ;; assert daemon semantics; this is what makes that
+                      ;; contract real.
+                      (doto
+                        (Thread.
+                          ^Runnable
+                          (fn writer-thread []
+                            (try
+                              (run-streaming-writer! pipe-out frame-id rendered opts)
+                              (finally
+                                ;; The writer's own finally closes the
+                                ;; pipe; the frame teardown happens here so
+                                ;; it does NOT block the response close on
+                                ;; the slower destroy path.
+                                (lifecycle/destroy-frame-quietly! frame-id))))
+                          ^String (str "rf2-ssr-streaming-" (name frame-id)))
+                        (.setDaemon true)
+                        (.start))
+                      (assoc resp-map :body pipe-in))))))
             (catch Throwable t
               ;; get-response throw, redirect-materialise throw, OR (per
               ;; rf2-z5azc) a head-materialisation throw raised BEFORE the

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -15,13 +15,16 @@
   mode contract is structurally different — no caller frame to bubble
   to, no `:on-error` hook to invoke (the response has already started).
 
-  Per Spec 011 §Failure semantics — exceptions OUTSIDE a continuation
-  (root-view throw, head-resolution throw, downstream OutputStream
-  broken-pipe, final-payload build throw) close the pipe with whatever
-  partial response was flushed and emit a structured
+  Per Spec 011 §Failure semantics — exceptions the writer thread STILL
+  owns after rf2-r06pc (a final-payload build throw, a downstream
+  OutputStream broken-pipe, a continuation drain) close the pipe with
+  whatever partial response was flushed and emit a structured
   `:rf.error/ssr-streaming-writer-failed` trace; the writer's `finally`
   closes the OutputStream so the Ring server emits EOF; the daemon
-  thread terminates. The load-bearing contracts:
+  thread terminates. (rf2-r06pc moved root-view / head / shell-walk
+  resolution to the REQUEST thread, before the head commits — those
+  fail closed to a non-200 on the request thread and never reach the
+  writer; see test 3.) The load-bearing contracts:
 
     1. The writer thread MUST NOT escape with an uncaught throwable
        (it is the top-level Runnable of a detached thread — an escaped
@@ -38,26 +41,28 @@
 
   ## Test scope
 
-  Four tests:
+  Tests:
 
     1. `writer-survives-broken-pipe-on-write` — direct call to
        `run-streaming-writer!` against a PipedOutputStream whose sink
-       (`PipedInputStream`) was closed before the writer started.
-       Every `.write` raises `IOException: Pipe closed`. The writer's
-       outer `catch Throwable` arm absorbs; no exception escapes; the
-       OutputStream is closed in `finally`.
+       (`PipedInputStream`) was closed before the writer started, handed
+       a PRE-RENDERED shell (rf2-r06pc — the writer no longer renders
+       the shell). The first chunk write raises `IOException: Pipe
+       closed`. The writer's outer `catch Throwable` arm absorbs; no
+       exception escapes; the OutputStream is closed in `finally`.
     2. `client-disconnect-mid-stream-cleans-up` — real Jetty + a real
        HTTP client that reads only the response head + a few bytes of
        the body then closes the InputStream. The writer thread, mid-
        flight on the next `.write`, hits a broken-pipe IOException;
        same catch + finally semantics; thread terminates within a
        generous bound; no orphan `rf2-ssr-streaming-*` thread remains.
-    3. `writer-survives-root-view-throw` — root-view fn throws on
-       resolution (a failure mode OUTSIDE any `:rf/suspense-boundary` —
-       the throw fires in the writer's outer `try` before any chunk is
-       written). The writer's catch absorbs; the OutputStream closes
-       cleanly so the response EOFs; the daemon thread terminates with
-       no orphan.
+    3. `root-view-throw-fails-closed-non-200-bytes-on-wire` (rf2-r06pc) —
+       root-view fn throws on resolution (a structural shell failure).
+       The shell now renders on the REQUEST thread before the head
+       commits, so the throw escalates to `:rf.error/ssr-render-failed`
+       and FAILS CLOSED to a non-200 projected error page — NOT the
+       silent 200 this test previously (incorrectly) blessed. NO daemon
+       writer thread is spawned at all. (Spec 011 §744/§748/§954.)
     4. `daemon-thread-name-is-frame-scoped` — sanity check that the
        writer thread is named `rf2-ssr-streaming-<frame-id>` so the
        leak-detection assertions above can scope by name prefix and
@@ -75,6 +80,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.streaming :as streaming]
             [re-frame.ssr.test-fixture :as tf]
@@ -256,9 +262,25 @@
           ;; identity of the absorbed throw doesn't matter, only that
           ;; the writer returns normally and the OutputStream is left
           ;; in the closed state.
+          ;; rf2-r06pc — the writer no longer resolves/renders the shell
+          ;; (that moved to `render-streaming-shell!` on the request
+          ;; thread). It now receives PRE-RENDERED shell pieces and only
+          ;; drains the chunk stream, so we hand it a minimal valid
+          ;; `rendered` map. The very first `write-chunk!` of the shell
+          ;; prefix hits the pre-closed pipe → `IOException: Pipe closed`,
+          ;; the exact broken-pipe surface the outer `catch Throwable`
+          ;; absorbs. The contract under test is unchanged: `catch
+          ;; Throwable, then finally close out` — the writer returns
+          ;; normally and the OutputStream is left closed.
+          rendered {:hiccup        [:div]
+                    :head-html     ""
+                    :html-attrs    nil
+                    :body-attrs    nil
+                    :shell-html    "<div></div>"
+                    :continuations []}
           result   (try
                      (@#'streaming/run-streaming-writer!
-                       pipe-out :no-such-frame {} {:root-view [:div]})
+                       pipe-out :no-such-frame rendered {:root-view [:div]})
                      ::returned-normally
                      (catch Throwable t
                        [::escaped t]))]
@@ -267,9 +289,13 @@
            no exception escapes the writer body. The contract is
            `catch Throwable`, not `catch IOException`: arbitrary
            OutputStream failures (broken pipe, SSL shutdown mid-stream,
-           Jetty internal-buffer errors) and arbitrary render-time
-           throws (root-view fn throw, head fn throw, final-payload
-           build throw) MUST all be absorbed.")
+           Jetty internal-buffer errors) and the post-first-chunk
+           render throws the writer still owns (continuation drains —
+           inline-fallback — and the final-payload build) MUST all be
+           absorbed. (rf2-r06pc moved root-view / head / shell-walk
+           resolution to the request thread, so those no longer reach
+           the writer at all — they fail closed BEFORE the writer is
+           spawned.)")
       ;; The writer's finally closes the OutputStream. Probe by
       ;; writing — a closed PipedOutputStream throws on .write, the
       ;; JDK contract that proves the finally arm ran.
@@ -339,39 +365,50 @@
                      (mapv (fn [^Thread t] (.getName t)) leaked)))))))))
 
 ;; ===========================================================================
-;; Test 3 — writer-fn throws OUTSIDE a continuation: catch arm absorbs
+;; Test 3 (rf2-r06pc) — root-view throw FAILS CLOSED to a non-200 on the
+;;                      request thread; NO writer thread is spawned
 ;; ===========================================================================
 ;;
-;; Per the streaming.clj ns docstring: "Exceptions OUTSIDE a
-;; continuation (e.g. an error projecting the response, or a final-
-;; payload build throw) close the pipe with the partial response that
-;; was already flushed". The `render-continuation` path already has its
-;; own inline-fallback semantics (covered by
-;; `ring_streaming_test/stream-handler-failed-continuation-stays-fallback`).
+;; This test PREVIOUSLY blessed a 200 for a root-view throw — the exact
+;; spec drift rf2-r06pc fixes. The OLD streaming order materialised the
+;; Ring head (status 200) and spawned the daemon writer BEFORE the writer
+;; resolved/rendered the shell, so a root-view / shell-walk throw fired on
+;; the detached daemon thread where it could only emit a trace + close the
+;; pipe — the wire had already committed a silent 200/truncated body.
 ;;
-;; The OTHER class of throw — root-view resolution failure, head fn
-;; throw, render-shell throw — fires in the writer's outer try BEFORE
-;; (or between) chunk writes. The catch arm absorbs; the finally
-;; closes the pipe; the Ring server EOFs the response.
+;; Spec 011 §744/§748/§954: a shell-walk (or root-view) throw is the
+;; request's structural foundation failing; it MUST escalate to
+;; `:rf.error/ssr-render-failed` through the standard error-projection
+;; path and FAIL CLOSED to a non-200 projected error page — NOT a 200.
 ;;
-;; This test uses a `root-view` fn that throws on invocation. The
-;; writer's `lifecycle/resolve-root-view` invokes the fn inside the
-;; outer try, so the throw hits the writer's catch arm exactly as if a
-;; final-payload build had thrown. We observe via the client side: the
-;; response status was already committed (200, since Jetty had not yet
-;; seen any body bytes when the writer started), the body is whatever
-;; chunks were flushed before the throw (zero in this case — the throw
-;; fires before the shell prefix), and the daemon thread terminates
-;; cleanly without escape.
+;; The fix (rf2-r06pc) renders the shell on the REQUEST thread, before the
+;; head commits, mirroring the non-streaming post-render re-flush
+;; (rf2-c0bq1). A root-view throw now propagates on the request thread and
+;; is routed through the projector (`project-render-throw->ring-response`)
+;; → a non-200 projected error page returned as an ORDINARY (non-chunked)
+;; Ring response. NO pipe and NO daemon writer thread is ever spawned.
+;;
+;; This test pins BOTH halves of the spec-aligned contract:
+;;   - the wire status is non-200 (500, the default projector's
+;;     `:rf.error/ssr-render-failed` mapping), bytes-on-wire through Jetty,
+;;   - no orphan `rf2-ssr-streaming-*` daemon thread (none is spawned at
+;;     all on a shell-render failure).
+;; The direct-handler half of this contract lives in
+;; `ring_streaming_test/stream-handler-root-view-throw-fails-closed`.
 
-(deftest writer-survives-root-view-throw
-  (testing "root-view throw → writer catch absorbs, pipe closes, daemon terminates"
+(deftest root-view-throw-fails-closed-non-200-bytes-on-wire
+  (testing "rf2-r06pc: a root-view throw fails closed to a non-200 on the
+            full Jetty round-trip (was incorrectly 200 before the fix) AND
+            spawns NO daemon writer thread — the shell renders on the
+            request thread before the head commits, so a structural shell
+            failure escalates to `:rf.error/ssr-render-failed` and projects
+            a non-200 (Spec 011 §744/§748/§954)."
     (rf/reg-event-fx :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
     (let [throwing-root  (fn root-view-fn []
                            (throw (ex-info ":rf.test/intentional-root-view-throw"
-                                           {:reason "writer-thread robustness probe"})))
+                                           {:reason "shell-render fail-closed probe"})))
           handler        (ssr-ring/stream-handler
                            {:on-create [:rf.test.server/init-min]
                             :root-view throwing-root
@@ -382,30 +419,27 @@
               response (.send client req (HttpResponse$BodyHandlers/ofString))
               status   (.statusCode response)
               body     (.body response)]
-          ;; Status is whatever the response accumulator carried at
-          ;; setup time — by default 200. The writer threw before any
-          ;; body chunk, so the response is empty (or truncated). Both
-          ;; are valid wire outcomes per Spec 011 §Failure semantics —
-          ;; what matters is that the wire EOFs cleanly rather than
-          ;; hanging.
-          (is (= 200 status)
-              "response status was committed before the writer threw —
-               Spec 011 §Streaming failure: pre-flush throws leave the
-               default status in place; partial wire body EOFs cleanly")
-          (is (or (str/blank? body)
-                  ;; Some JDKs / Jetty versions may emit chunk framing
-                  ;; bytes before the writer body throws; the load-
-                  ;; bearing assertion is that the response COMPLETED
-                  ;; (didn't hang) — the .send call returned with a
-                  ;; body string.
-                  (string? body))
-              "the wire EOF'd cleanly — `.send` returned, body is a
-               (possibly empty) String, no read-side hang"))
-        ;; Daemon-thread cleanup: same contract as test 2.
+          (is (= 500 status)
+              "root-view throw fails closed to a 500 on the wire (default
+               projector maps `:rf.error/ssr-render-failed` → 500) — NOT
+               the silent 200 the OLD daemon-writer-first order shipped
+               (rf2-r06pc / Spec 011 §744/§748/§954)")
+          (is (string? body)
+              "the wire EOF'd cleanly — `.send` returned a body string,
+               no read-side hang")
+          (is (not (str/includes? body "intentional-root-view-throw"))
+              "the projected error body carries no internal exception
+               detail — the topology-leak boundary holds (Spec 011
+               §Where sanitisation happens)"))
+        ;; NO writer thread is spawned on a shell-render failure — the
+        ;; throw fires on the request thread before the pipe/thread exist.
+        ;; So there is nothing to leak; assert the absence explicitly.
         (let [leaked (await-no-streaming-threads! 5000)]
           (is (empty? leaked)
-              (str "no orphan rf2-ssr-streaming-* daemon thread after
-                   a root-view throw. Live threads observed: "
+              (str "no rf2-ssr-streaming-* daemon thread after a root-view
+                   throw — the shell-render failure short-circuits on the
+                   request thread, before any writer is spawned. Live
+                   threads observed: "
                    (mapv (fn [^Thread t] (.getName t)) leaked))))))))
 
 ;; ===========================================================================
@@ -569,3 +603,71 @@
                  spawned until the head is known materialisable
                  (rf2-z5azc). Live threads observed: "
                  (mapv (fn [^Thread t] (.getName t)) leaked)))))))
+
+;; ===========================================================================
+;; Test 6 (rf2-r06pc) — production reactive-sub throw during the streaming
+;;                      shell render fails closed to a non-200 ON THE WIRE
+;; ===========================================================================
+;;
+;; The streaming counterpart of `ring_rendertime_sub_failclosed_test`
+;; (which pins the NON-streaming handler). A reactive subscription that
+;; throws during the shell render under production hardening
+;; (`interop/debug-enabled? = false`) recovers to nil (the render does NOT
+;; throw) but BUFFERS a fail-closed 500 on the always-on error-emit
+;; substrate (rf2-vvwmi). The OLD streaming order committed the Ring head
+;; (status 200) before the daemon writer ran the render, so that buffered
+;; 500 never reached the wire — a silent 200 with the recovered-to-nil
+;; broken HTML, defeating the rf2-vvwmi fix end-to-end (Spec 011 §744 /
+;; §750).
+;;
+;; The fix (rf2-r06pc) renders the shell on the request thread and re-reads
+;; the response accumulator (`ssr/get-response`) AFTER the render — exactly
+;; as the non-streaming `build-full-response*` does (rf2-c0bq1) — so the
+;; buffered 500 is committed onto the chunked head before the writer is
+;; spawned. This test drives the throwing sub through the REAL stream-
+;; handler order and asserts the WIRE status is 500, bytes-on-wire through
+;; Jetty.
+
+(defn- http-get-string
+  "Issue a real HTTP GET and return `{:status :body}` observed on the
+  wire (full body read as a String)."
+  [^HttpClient client port path]
+  (let [resp (.send client (http-get-request port path)
+                    (HttpResponse$BodyHandlers/ofString))]
+    {:status (.statusCode resp)
+     :body   (.body resp)}))
+
+(deftest rendertime-sub-throw-fails-closed-non-200-bytes-on-wire
+  (testing "rf2-r06pc / rf2-vvwmi: a production-mode reactive sub that
+            throws during the STREAMING shell render fails closed to a
+            non-200 on the full Jetty round-trip — NOT a silent 200 with
+            the recovered-to-nil broken HTML (Spec 011 §744/§750). Before
+            rf2-r06pc the streaming handler committed the 200 head before
+            the daemon writer ran the render that buffers the 500."
+    (rf/reg-sub :throwing-sub (fn [_db _] (throw (ex-info "sub-boom" {}))))
+    (rf/reg-view ^{:rf/id :test/uses-throwing-sub} uses-throwing-sub []
+      (let [v @(rf/subscribe [:throwing-sub])]
+        [:main.broken
+         [:h1 "header that renders"]
+         [:p (str "value: " v)]]))
+    (rf/reg-event-fx :rf.test.server/init-min
+      {:platforms #{:server}}
+      (fn [_ _] {:db {}}))
+    (let [handler (ssr-ring/stream-handler
+                    {:on-create [:rf.test.server/init-min]
+                     :root-view [:test/uses-throwing-sub]
+                     :ssr       {:public-error-id   :rf.ssr/default-error-projector
+                                 :dev-error-detail? false}
+                     :payload :rf.ssr.payload/whole-app-db})]
+      ;; Production hardening — the always-on error-emit substrate is the
+      ;; status source of truth. NB: the redef is in force on THIS (the
+      ;; request) thread, which is where rf2-r06pc now runs the shell
+      ;; render + the post-shell re-read — so the buffered 500 is observed
+      ;; and committed before the response is returned to Jetty.
+      (with-redefs [interop/debug-enabled? false]
+        (with-jetty [port handler]
+          (let [client (new-http-client)
+                {:keys [status]} (http-get-string client port "/")]
+            (is (= 500 status)
+                "render-time sub-throw fail-closed 500 rides the full
+                 Jetty round-trip — never a silent 200 (rf2-r06pc)")))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -10,7 +10,9 @@
 
     1. broken-pipe absorbed, OutputStream closed by `finally`,
     2. real-network disconnect cleans up,
-    3. root-view throw absorbed, daemon terminates,
+    3. root-view throw fails closed to a non-200 on the request thread
+       (rf2-r06pc — the shell render moved off the writer; a root-view
+       throw never reaches the daemon writer now),
     4. daemon thread name carries the frame-id.
 
   What it does NOT cover — and what `re-frame.ssr.ring.streaming/run-
@@ -30,14 +32,14 @@
   absence-of-escape and pipe-close), the gap re-opens silently and
   ops loses the signal.
 
-  Second gap covered here: the writer thread's `finally` arm wraps
-  the per-request frame destroy (`lifecycle/destroy-frame-quietly!`
-  in `stream-handler`'s spawn body — `streaming.clj` line 273). The
-  contract is that EVEN WHEN the writer body throws, the destroy
-  still runs in the spawned-thread `finally`. The existing tests
-  cover writer-body throws AND daemon thread cleanup, but not the
-  composition: a writer-body throw co-occurs with a frame whose
-  side-channel atoms become observable via the destroy hook."
+  Second gap covered here: the per-request frame destroy on a render
+  failure. Post rf2-r06pc a shell-render throw (root-view throw) fails
+  closed on the REQUEST thread and tears the frame down INLINE (the
+  shell-render catch arm in `stream-handler`), before any writer thread
+  is spawned. The continuation/final-payload writer-body throws that
+  DO still reach the daemon thread tear the frame down in the spawned-
+  thread `finally`. Either way the destroy MUST run; this ns pins the
+  composition the existing tests test independently."
   (:require [clojure.set]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
@@ -45,7 +47,6 @@
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.streaming :as streaming]
             [re-frame.ssr.test-fixture :as tf]
-            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [java.io InputStream PipedInputStream PipedOutputStream]))
 
@@ -74,13 +75,18 @@
           pipe-out (PipedOutputStream. pipe-in)
           _        (.close pipe-in) ;; pre-broken pipe — every write throws
           captured (atom [])]
-      ;; Drive the writer body directly against the pre-broken pipe;
-      ;; the writer's outer try fires on the first internal
-      ;; with-frame deref (no such frame) AND on every subsequent
-      ;; pipe write. Either way the catch arm runs.
+      ;; Drive the writer body directly against the pre-broken pipe.
+      ;; rf2-r06pc — the writer no longer resolves/renders the shell
+      ;; (that moved to the request thread); we hand it a PRE-RENDERED
+      ;; shell. The first chunk write of the shell prefix hits the
+      ;; pre-broken pipe → IOException → the catch arm runs and emits
+      ;; the trace.
       (with-trace-capture captured
         #(@#'streaming/run-streaming-writer!
-           pipe-out :no-such-frame {} {:root-view [:div]}))
+           pipe-out :no-such-frame
+           {:hiccup [:div] :head-html "" :html-attrs nil :body-attrs nil
+            :shell-html "<div></div>" :continuations []}
+           {:root-view [:div]}))
       (let [hits (filterv #(= :rf.error/ssr-streaming-writer-failed (:operation %))
                           @captured)]
         (is (= 1 (count hits))
@@ -106,23 +112,32 @@
                  specific requests in JFR / log streams")))))))
 
 ;; ===========================================================================
-;; Writer-throw composition with frame destroy — even when the writer
-;; body throws, the spawned-thread `finally` MUST run destroy-frame-
-;; quietly! so the per-request frame's app-db + side-channel slots are
-;; released. Pin the composition the existing tests test independently.
+;; Shell-render-throw composition with frame destroy — when the shell
+;; render throws (root-view throw), the per-request frame MUST still be
+;; destroyed so its app-db + side-channel slots are released. Pin the
+;; composition the existing tests test independently.
+;;
+;; rf2-r06pc — a root-view / shell-walk throw now fails closed on the
+;; REQUEST thread (before the head commits + before any writer is
+;; spawned): the shell-render catch arm projects a non-200 error page AND
+;; tears the frame down inline. So this is now a SYNCHRONOUS teardown on
+;; the request thread (no spawned-thread `finally` to wait on, no
+;; InputStream body to drain). The frame-no-leak contract is unchanged —
+;; only the mechanism moved earlier.
 ;; ===========================================================================
 
-(deftest stream-handler-destroys-frame-when-writer-body-throws
-  (testing "rf2-u91hb: when the streaming writer body throws (root-view
-            throw), the spawned thread's finally MUST still invoke
-            destroy-frame-quietly! so the per-request frame's app-db
-            / sub-cache / side-channel slots are released. Without this
-            composition every aborted/failed streaming request would
-            leak a frame record. Per stream-handler line ~268-273."
+(deftest stream-handler-destroys-frame-when-shell-render-throws
+  (testing "rf2-u91hb / rf2-r06pc: when the shell render throws (root-view
+            throw), the per-request frame's app-db / sub-cache / side-
+            channel slots MUST still be released. Post rf2-r06pc the
+            teardown happens INLINE on the request thread (the shell-
+            render fail-closed catch arm), not in a spawned-thread
+            finally — the throw never reaches a writer thread. Without
+            this every failed streaming request would leak a frame record."
     (rf/reg-event-fx :rf.test.writer/init
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
-    (let [throwing-root (fn [] (throw (ex-info "writer-thread teardown probe"
+    (let [throwing-root (fn [] (throw (ex-info "shell-render teardown probe"
                                                {:reason :rf2-u91hb})))
           handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.writer/init]
@@ -130,22 +145,20 @@
                       :payload :rf.ssr.payload/whole-app-db})
           ;; Frame ids BEFORE the request — baseline.
           baseline-fids (disj (frame/frame-ids) :rf/default)
-          response (handler {:uri "/" :request-method :get})
-          ;; Drain the body so the writer thread runs to completion +
-          ;; the spawned-thread `finally` fires.
-          _drain   (slurp ^InputStream (:body response))]
-      ;; Poll until the spawned thread's `finally` has run the destroy
-      ;; (rf2-fun38). The frame-set returning to baseline IS the
-      ;; observable signal; no need for a fixed wait.
-      (test-support/poll-until
-        (fn []
-          (let [end-fids (disj (frame/frame-ids) :rf/default)]
-            (empty? (clojure.set/difference end-fids baseline-fids))))
-        {:timeout-ms 2000
-         :label "per-request frame destroyed after writer-throw"})
+          response (handler {:uri "/" :request-method :get})]
+      ;; rf2-r06pc — the shell render threw on the request thread, so the
+      ;; response is the projected non-200 error page (an ordinary String
+      ;; body), NOT a streamed InputStream. The frame teardown already ran
+      ;; inline by the time the handler returned.
+      (is (= 500 (:status response))
+          "root-view throw fails closed to a non-200 projected error page
+           on the request thread (rf2-r06pc)")
+      (is (not (instance? InputStream (:body response)))
+          "no streamed InputStream body — the chunked response was never
+           committed (the shell render failed before the head commit)")
       (let [end-fids (disj (frame/frame-ids) :rf/default)
             leaked   (clojure.set/difference end-fids baseline-fids)]
         (is (empty? leaked)
             (str "the per-request frame MUST be destroyed even though
-                 the writer body threw — found leaked frame-ids: "
+                 the shell render threw — found leaked frame-ids: "
                  (vec leaked)))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -13,6 +13,7 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.test-fixture :as tf])
@@ -247,3 +248,164 @@
                            (get (:headers ns-resp) "content-type"))]
         (is (= ct ns-ct)
             "streaming + non-streaming redirect paths agree on Content-Type")))))
+
+;; ===========================================================================
+;; rf2-r06pc — STREAMING SHELL FAILURES FAIL CLOSED to a non-200
+;; ===========================================================================
+;;
+;; The bug: streaming materialised the Ring response head (status 200) and
+;; spawned the daemon writer BEFORE the writer resolved/rendered the shell.
+;; So a root-view throw, a shell-walk throw, and a production-mode reactive
+;; sub throw during the shell render could NOT stamp the HTTP status or
+;; render the projected error page — the wire shipped a silent 200 /
+;; truncated body. The non-streaming handler already fixed the recovered-
+;; sub variant with a post-render re-flush (rf2-c0bq1, `pipeline.clj`).
+;;
+;; The fix (rf2-r06pc): render the shell on the REQUEST thread before the
+;; head commits. A throw escalates to `:rf.error/ssr-render-failed` (→
+;; projected non-200 error page); a recovered-to-nil sub buffers a fail-
+;; closed status the post-shell `get-response` re-read picks up onto the
+;; committed Ring head. Only a known-renderable shell + success status
+;; commits the chunked response. These direct-handler tests pin the
+;; contract in-process; the bytes-on-wire counterparts (root-view throw +
+;; production-sub throw through Jetty) live in `streaming_robustness_test`.
+;; ===========================================================================
+
+(defn- streamed-body
+  "Drain a Ring response body to a string when it is an InputStream
+  (the streamed-chunk path), else return it verbatim (a projected error
+  page is an ordinary non-chunked String body)."
+  [body]
+  (if (instance? InputStream body)
+    (drain-stream body)
+    body))
+
+(deftest stream-handler-root-view-throw-fails-closed
+  (testing "rf2-r06pc: a root-view fn that throws on resolution fails
+            closed to a non-200 PROJECTED error response on the request
+            thread — NOT a streamed 200. No InputStream body is handed
+            out (the chunked response was never committed)."
+    (rf/reg-event-fx :rf.test.server/init-min
+      {:platforms #{:server}}
+      (fn [_ _] {:db {}}))
+    (let [throwing-root (fn root-view-fn []
+                          (throw (ex-info ":rf.test/root-view-throw"
+                                          {:reason "shell-render fail-closed probe"})))
+          handler       (ssr-ring/stream-handler
+                          {:on-create [:rf.test.server/init-min]
+                           :root-view throwing-root
+                           :payload :rf.ssr.payload/whole-app-db})
+          response      (handler {:uri "/" :request-method :get})]
+      (is (= 500 (:status response))
+          "root-view throw → `:rf.error/ssr-render-failed` projection →
+           non-200 (default projector maps to 500) on the request thread,
+           not a streamed 200 (Spec 011 §744/§748/§954)")
+      (is (not (instance? InputStream (:body response)))
+          "the body is a projected error page (ordinary String), NOT a
+           PipedInputStream — the chunked response was never committed")
+      (is (not (str/includes? (str (:body response)) "root-view-throw"))
+          "the projected body carries no internal exception detail"))))
+
+(deftest stream-handler-shell-walk-throw-fails-closed
+  (testing "rf2-r06pc: a view INSIDE the shell walk (NOT inside a
+            `:rf/suspense-boundary`) that throws fails closed to a
+            non-200 — the shell-walk throw is a structural failure that
+            escalates per Spec 011 §954 (the inline-fallback boundary
+            stops at continuations)."
+    (rf/reg-event-fx :rf.test.server/init-min
+      {:platforms #{:server}}
+      (fn [_ _] {:db {}}))
+    ;; A view that throws during the shell walk — it is NOT wrapped in a
+    ;; `:rf/suspense-boundary`, so the inline-fallback path does NOT apply.
+    (rf/reg-view ^{:rf/id :test/shell-throwing-section} shell-throwing-section []
+      (throw (ex-info ":rf.test/shell-walk-throw" {})))
+    (rf/reg-view ^{:rf/id :test/shell-throwing-root} shell-throwing-root []
+      [:main
+       [:h1 "Header"]
+       [:test/shell-throwing-section]
+       [:footer "End"]])
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init-min]
+                      :root-view [:test/shell-throwing-root]
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})]
+      (is (= 500 (:status response))
+          "shell-walk throw escalates to `:rf.error/ssr-render-failed` →
+           non-200; the inline-fallback boundary stops at continuations
+           (Spec 011 §954)")
+      (is (not (instance? InputStream (:body response)))
+          "shell-walk throw fails closed to a projected error page, not a
+           streamed chunked body"))))
+
+(deftest stream-handler-rendertime-sub-throw-fails-closed
+  (testing "rf2-r06pc / rf2-vvwmi: a production-mode reactive sub that
+            THROWS during the streaming shell render recovers to nil (the
+            walk does NOT throw) but buffers a fail-closed 500 on the
+            always-on error-emit substrate; the post-shell `get-response`
+            re-read stamps the 500 onto the committed Ring head — NOT the
+            stale pre-render 200 the old daemon-writer-first order shipped
+            (Spec 011 §744/§750)."
+    (rf/reg-sub :throwing-sub (fn [_db _] (throw (ex-info "sub-boom" {}))))
+    (rf/reg-view ^{:rf/id :test/uses-throwing-sub} uses-throwing-sub []
+      (let [v @(rf/subscribe [:throwing-sub])]
+        [:main.broken
+         [:h1 "header that renders"]
+         [:p (str "value: " v)]]))
+    (rf/reg-event-fx :rf.test.server/init-min
+      {:platforms #{:server}}
+      (fn [_ _] {:db {}}))
+    (let [handler (ssr-ring/stream-handler
+                    {:on-create [:rf.test.server/init-min]
+                     :root-view [:test/uses-throwing-sub]
+                     :ssr       {:public-error-id   :rf.ssr/default-error-projector
+                                 :dev-error-detail? false}
+                     :payload :rf.ssr.payload/whole-app-db})]
+      ;; Production hardening — the dev-only trace listener elides; the
+      ;; always-on error-emit substrate is the status source of truth.
+      (with-redefs [interop/debug-enabled? false]
+        (let [response (handler {:uri "/" :request-method :get})]
+          (is (= 500 (:status response))
+              "render-time sub-throw under production hardening →
+               buffered fail-closed 500 re-read AFTER the shell render →
+               committed Ring status 500. Before rf2-r06pc this was a
+               silent 200 (the stale pre-render status committed onto the
+               chunked head before the daemon writer ran the render).")
+          ;; The shell recovered-to-nil and rendered, so the streamed body
+          ;; (carried under the 500 status) is still well-formed HTML —
+          ;; the status is the fail-closed signal, mirroring the non-
+          ;; streaming handler (rf2-c0bq1).
+          (let [body (streamed-body (:body response))]
+            (is (str/includes? body "header that renders")
+                "the recovered shell still streamed (the 500 status is the
+                 fail-closed signal; the body is moot under a non-200)")))))))
+
+(deftest stream-handler-clean-render-stays-200
+  (testing "rf2-r06pc: the request-thread shell render + post-shell
+            re-read is benign for the happy path — a clean shell render
+            with no buffered error keeps the default 200 and streams
+            normally. Confirms the fix is fail-closed-on-error, not a
+            blanket divert."
+    (rf/reg-sub :clean-sub (fn [_db _] :ok))
+    (rf/reg-view ^{:rf/id :test/uses-clean-sub} uses-clean-sub []
+      (let [v @(rf/subscribe [:clean-sub])]
+        [:main [:h1 "clean"] [:p (str "value: " v)]]))
+    (rf/reg-event-fx :rf.test.server/init-min
+      {:platforms #{:server}}
+      (fn [_ _] {:db {}}))
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init-min]
+                      :root-view [:test/uses-clean-sub]
+                      :ssr       {:public-error-id   :rf.ssr/default-error-projector
+                                  :dev-error-detail? false}
+                      :payload :rf.ssr.payload/whole-app-db})]
+      (with-redefs [interop/debug-enabled? false]
+        (let [response (handler {:uri "/" :request-method :get})
+              body     (streamed-body (:body response))]
+          (is (= 200 (:status response))
+              "clean shell render → empty error buffer → re-read no-op → 200")
+          (is (instance? InputStream (:body response))
+              "happy path streams a chunked InputStream body")
+          (is (str/includes? body "value: :ok")
+              "the clean sub's value rendered into the streamed HTML")
+          (is (str/includes? body "__rf_payload")
+              "the final payload chunk streamed"))))))


### PR DESCRIPTION
## Summary

Streaming Ring SSR render failures were committed as silent **200/truncated** responses instead of failing closed to a non-200 — the same family as the c0bq1/vvwmi non-streaming fixes. The writer thread was started and the Ring response head materialised **before** the root shell was resolved/rendered, so a root-view throw, a shell-walk throw, or a production reactive-sub throw during shell render could not stamp the HTTP status or render the projected error page (they ran on a detached daemon thread that had already committed a 200). A test in `streaming_robustness_test.clj:391` BLESSED the 200.

## Fix (per Spec 011 §744/§748/§954)

Render/resolve the streaming shell under the **request thread** BEFORE committing the chunked response head — the streaming counterpart of the non-streaming post-render re-flush (rf2-c0bq1):

- **root-view / shell-walk throw** → propagates on the request thread → routed through the shared `pipeline/project-render-throw->ring-response` (→ `:rf.error/ssr-render-failed`, projector, non-200 projected error page). No pipe / writer thread spawned.
- **production reactive-sub throw during shell render** → recovers to nil, buffers a fail-closed 500 on the always-on error-emit substrate (rf2-vvwmi); the post-shell `ssr/get-response` re-read stamps the 500 onto the committed Ring head before materialise.

Only a known-renderable shell + success status commits the chunked response. The daemon writer now receives the **pre-rendered** shell and only drains the chunk stream.

**Preserved:** continuation-failure inline-fallback semantics (`data-rf2-suspense-failed`, no writer-thread leak) — those still fire on the writer thread AFTER the first chunk commits. Also preserved: the rf2-z5azc head-materialisation no-orphan contract and the rf2-ee38b.11 redirect teardown.

## Tests

- **Rewrote** the contradictory `streaming_robustness_test` 200-expectation for a root-view throw → spec-aligned non-200 (bytes-on-wire through Jetty), now also asserting NO writer thread is spawned.
- **Added** direct-handler tests: root-view throw, shell-walk throw, production reactive-sub throw each fail closed to non-200; plus a happy-path 200 regression guard.
- **Added** bytes-on-wire (Jetty) tests for root-view throw and production reactive-sub throw.
- Updated `streaming_writer_trace_test` for the new writer signature + the inline (request-thread) teardown on shell-render failure.

**Without-fix-fails proof:** simulating the old ordering (swallow shell throw + stale pre-shell status) makes all 7 new fail-closed assertions fail with `actual: 200`; the fix flips them to 500.

## Gates (cold)

- ssr-ring JVM `clojure -M:test`: **115 tests / 492 assertions, 0 failures** (incl. Jetty bytes-on-wire + rewritten robustness test)
- `npm run test:cljs`: **5615 tests / 19567 assertions, 0 failures**

Spec unchanged — §744/§748/§954 already specify this fail-closed contract; this brings the implementation into conformance.

Closes rf2-r06pc.