### PR TITLE
fix(story): close Variant + Workspace authoring-body schemas + migrate template off removed :play (rf2-mantt + rf2-1774m)

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -553,14 +553,20 @@ pane and §Mount lifecycle for how the RHS embed consumes the slot.
 
 Body:
 
+The body `:map` is **closed** (rf2-mantt): a removed / typo'd slot is
+rejected at `reg-workspace` call-time with `:rf.error/workspace-shape`
+(naming the unknown key + nearest declared slot), not silently swallowed.
+
 ```clojure
 {:doc       "..."
  :layout    :grid | :prose | :variants-grid | :tabs | :custom
  :variants  [<variant-id> ...]                    ; for :grid / :variants-grid / :tabs (explicit list)
- :for       <story-id>                            ; for :variants-grid only — auto-enumerate
- :columns   <integer>                             ; for :grid / :variants-grid — column count
+ :for       <story-id>                            ; for :variants-grid only — auto-enumerate (see anchor note below)
+ :story     <story-id>                            ; for :variants-grid only — the renderer-read anchor spelling (see note)
+ :columns   <integer>                             ; for :grid / :variants-grid — column count (declared; not yet renderer-honoured)
  :content   [{:type :prose :body "md..."} ...]    ; for :prose; bodies render as markdown — see spec/008 §Markdown rendering
  :render    <view-id>                              ; for :custom (a registered view)
+ :tags      #{<tag-id> ...}                        ; workspace tag set (subset of the registered vocabulary)
  :modes     #{<mode-id> ...}                       ; future-reserved — see below
  :isolation :isolated | :shared}                   ; rf2-gqid4 — :variants-grid only
 ```
@@ -604,6 +610,37 @@ explicitly so the authoring intent is in the body.
 Other layouts (`:grid`, `:tabs`) take `:variants` only — they have no
 single parent-story to enumerate against. `:prose` and `:custom`
 ignore both slots.
+
+Declaring **both** `:variants` and `:for` (or its renderer-read synonym
+`:story`, below) on a `:variants-grid` raises `:rf.error/workspace-shape`
+at registration — they are alternatives, not co-equals (rf2-mantt
+enforces this documented rule on the now-closed schema).
+
+#### Workspace anchor: `:for` (authoring) vs `:story` (renderer) — divergence note (rf2-mantt)
+
+The `:variants-grid` auto-enumerate anchor is authored as `:for
+<story-id>` (above). The **renderer** today reads the anchor from a
+`:story` slot (`re-frame.story.ui.workspace/resolve-layout`), falling
+back to deriving `:story.<path>` from the workspace id's namespace. Both
+`:for` and `:story` are declared on the schema; the `:story` spelling
+lets an author name the anchor explicitly to the path the renderer reads
+now. Reconciling the two spellings (the renderer reading `:for`, or
+`:for` lowering to `:story` at registration like `:setup`→`:events`) is a
+follow-up — until then, an auto-grid that relies on the namespace
+derivation needs no anchor slot at all, and an explicit anchor is most
+reliably given via `:story`.
+
+#### Workspace `:columns` slot — declared, not yet renderer-honoured (v1) (rf2-mantt)
+
+The `:columns` integer slot is **declared and documented but not yet
+honoured by the renderer in v1** — the `:grid` / `:variants-grid` CSS
+uses a responsive `auto-fit` template, so an explicit column count is
+accepted at registration (the canonical testbed + the scaffolded
+template + the example apps all author `:columns`) but does not yet pin
+the grid width. Honouring it (a fixed `repeat(N, …)` template when
+`:columns` is present) is a follow-up; the slot is declared so existing
+authoring keeps validating against the closed schema. Same posture as the
+`:modes` slot below.
 
 #### Workspace `:modes` slot — future-reserved (v1) (rf2-q5e36)
 

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -68,7 +68,9 @@
   - Loader four-phase lifecycle
   - Play execution
   - Snapshot identity computation"
-  (:require [re-frame.story.late-bind :as late-bind]
+  (:require [clojure.string           :as str]
+            [malli.core               :as m]
+            [re-frame.story.late-bind :as late-bind]
             [re-frame.story.schemas   :as schemas]))
 
 ;; ---- source-coord plumbing ------------------------------------------------
@@ -204,18 +206,102 @@
 
 ;; ---- shape validation -----------------------------------------------------
 
+;; rf2-mantt — the Story authoring-body schemas are now `{:closed true}`
+;; (re-frame.story.schemas), so a removed / typo'd slot fails validation
+;; with a `:malli.core/extra-key` error rather than being silently
+;; swallowed. The helpers below turn that structural error into an
+;; actionable `:reason` that NAMES the unknown key(s) and the nearest
+;; declared slot ('did you mean :plays?') — the swallow-class fix's
+;; trust-boundary payoff: an author who typos or carries a removed slot
+;; gets told exactly what to fix, at the `reg-*` call site.
+
+(defn- edit-distance
+  "Levenshtein edit distance between keyword/string names. Clean,
+  allocation-light DP over two rolling rows."
+  [a b]
+  (let [a (name a) b (name b)
+        m (count a) n (count b)]
+    (cond
+      (zero? m) n
+      (zero? n) m
+      :else
+      (loop [i 1
+             prev (vec (range (inc n)))]
+        (if (> i m)
+          (nth prev n)
+          (let [ai (nth a (dec i))
+                cur (reduce
+                     (fn [row j]
+                       (let [cost (if (= ai (nth b (dec j))) 0 1)]
+                         (conj row (min (inc (nth prev j))     ; deletion
+                                        (inc (peek row))       ; insertion
+                                        (+ cost (nth prev (dec j))))))) ; substitution
+                     [i]
+                     (range 1 (inc n)))]
+            (recur (inc i) cur)))))))
+
+(defn- nearest-key
+  "The declared key closest to `unknown` by edit distance, or nil when
+  the closest is too far to be a plausible typo (distance > half the
+  unknown's length, min 2)."
+  [unknown declared]
+  (when (seq declared)
+    (let [[k d] (apply min-key second
+                       (map (fn [k] [k (edit-distance unknown k)]) declared))
+          threshold (max 2 (quot (count (name unknown)) 2))]
+      (when (<= d threshold) k))))
+
+(defn- extra-key-errors
+  "Pull the `:malli.core/extra-key` errors out of a malli `explain`.
+  Each carries the offending key in `:in` and the offending `:map`
+  subschema in `:schema` (from which the declared key set is read).
+  Dedups by unknown key (an `:or` schema reports one per branch)."
+  [explain]
+  (->> (:errors explain)
+       (filter #(= :malli.core/extra-key (:type %)))
+       (reduce (fn [acc {:keys [in schema]}]
+                 (let [k (first in)]
+                   (if (contains? acc k) acc (assoc acc k schema))))
+               {})))
+
+(defn- unknown-key-reason
+  "Build the actionable unknown-key clause for the error `:reason`, or
+  nil when the explain carries no `:malli.core/extra-key` errors (a
+  different shape failure — :reason falls back to the generic message)."
+  [kind explain]
+  (let [extras (extra-key-errors explain)]
+    (when (seq extras)
+      (let [declared (sort (m/explicit-keys (val (first extras))))
+            clauses  (for [k (sort (keys extras))
+                           :let [hint (nearest-key k declared)]]
+                       (str k
+                            (when hint (str " (did you mean " hint "?)"))))]
+        (str "re-frame2-story: unknown " (name kind) " slot(s) "
+             (str/join ", " clauses)
+             " — the " (name kind) " authoring body is closed (rf2-mantt). "
+             "Allowed keys: " (pr-str (vec declared)) ". "
+             "Remove the slot, or fix the typo.")))))
+
 (defn- validate-shape!
   "Validate `body` against the schema for `kind`. Throws `:rf.error/<kind>-shape`
-  on a miss. Returns the body unchanged on success."
+  on a miss. Returns the body unchanged on success.
+
+  rf2-mantt — when the failure is an unknown / removed slot (the closed-
+  schema `:malli.core/extra-key` error) the `:reason` names the offending
+  key(s) and the nearest declared slot; otherwise it falls back to the
+  generic schema-mismatch message. The full malli `:explain` rides
+  `ex-data` either way."
   [kind id body]
   (when-let [explain (schemas/validate kind body)]
-    (let [error-kw (keyword "rf.error" (str (name kind) "-shape"))]
+    (let [error-kw (keyword "rf.error" (str (name kind) "-shape"))
+          unknown  (unknown-key-reason kind explain)]
       (throw (ex-info (str error-kw)
                       {:rf.error/id error-kw
                        :where    'rf.story/reg-story
                        :recovery :fix-registration
-                       :reason   (str "re-frame2-story: " (name kind) " body for "
-                                      id " does not match " (name kind) " schema")
+                       :reason   (or unknown
+                                     (str "re-frame2-story: " (name kind) " body for "
+                                          id " does not match " (name kind) " schema"))
                        :kind     kind
                        :id       id
                        :explain  explain}))))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -291,6 +291,29 @@
   unrecognised values back to `:light` at resolve time."
   [:or :keyword :string])
 
+;; ---- source coordinates ---------------------------------------------------
+
+(def SourceCoords
+  "Schema for the registrar-stamped `:source` slot every authoring body
+  carries after `re-frame.story.registrar/merge-coords` runs.
+
+  The macro path (`re-frame.story.macros/coords-form`) captures `:ns` /
+  `:file` / `:line` / `:column` from `(meta &form)`; programmatic /
+  REPL / MCP-write registrations may carry a partial or absent stamp
+  (only `:ns`, or nothing). The slot is therefore optional on every body
+  schema, and every coordinate key inside it is optional too — but it
+  MUST be declared so the now-`{:closed true}` body schemas accept the
+  registrar's own stamp rather than rejecting it as an unknown key.
+
+  All four keys are optional: `:ns` is a symbol, `:file` a string,
+  `:line` / `:column` positive integers. Per spec/001 §Source-coord
+  stamping."
+  [:map
+   [:ns     {:optional true} :symbol]
+   [:file   {:optional true} :string]
+   [:line   {:optional true} [:int {:min 1}]]
+   [:column {:optional true} [:int {:min 1}]]])
+
 ;; ---- :rf/story ------------------------------------------------------------
 
 (def XrayPreset
@@ -377,19 +400,40 @@
   - `:xray` — per-story Xray preset (auto-open, tab focus, filter
     pre-population). See `XrayPreset` schema. The preset is read on
     variant mount and applied via `re-frame.story.xray-preset/
-    apply-preset!`. (rf2-q9kv5)."
-  [:map
+    apply-preset!`. (rf2-q9kv5).
+
+  ## Closed shape (rf2-mantt)
+
+  The `:map` is `{:closed true}`: a removed / typo'd slot is rejected at
+  `reg-story` call-time with `:rf.error/story-shape` rather than silently
+  swallowed and dropped on the floor. `:source` is the registrar's
+  source-coord stamp (declared so the closed map accepts it)."
+  [:map {:closed true}
    [:doc        {:optional true} :string]
+   [:source     {:optional true} SourceCoords]
    [:component  {:optional true} :keyword]
    [:decorators {:optional true} DecoratorRefs]
    [:args       {:optional true} ArgMap]
    [:argtypes   {:optional true} ArgtypesMap]
+   ;; rf2-mantt — explicit view-args/props schema slots. The canonical
+   ;; first-match key order is `[:rf/props :schema]` (per
+   ;; `re-frame.story.malli-schema/view-args-schema-keys`); `:rf/props`
+   ;; wins over `:schema`. The value is a Malli schema form. Declared so
+   ;; a story body that pins its component's props schema (the canonical
+   ;; testbed's `:story.counter-matrix`) validates on the closed map.
+   [:rf/props   {:optional true} :any]
+   [:schema     {:optional true} :any]
    [:tags       {:optional true} TagSet]
    [:modes      {:optional true} ModeRefSet]
    [:substrates {:optional true} SubstrateSet]
    [:platforms  {:optional true} PlatformSet]
    [:dispatch-console? {:optional true} :boolean]
    [:xray      {:optional true} XrayPreset]
+   ;; rf2-mantt — story-level `:xray-panel` (rf2-6qm77): the default Xray
+   ;; panel-id a variant inherits unless it carries its own `:xray-panel`
+   ;; (the variant slot beats the story slot — `effective-panel` reads
+   ;; variant-first then story). A registered panel-id keyword.
+   [:xray-panel {:optional true} :keyword]
    ;; rf2-zll4h — viewport + background switchers. Per-story override
    ;; that wins over the chrome toolbar selection at canvas mount time.
    ;; Both slots are optional; absent means 'inherit the toolbar
@@ -698,10 +742,37 @@
   Pre-alpha posture: the legacy `:play` slot (vector of event vectors)
   has been removed entirely — there is no transitional dual-acceptance.
   Authors migrate event-vector lists by wrapping each entry as
-  `[:dispatch-sync <event-vec>]` in a `:script` body."
+  `[:dispatch-sync <event-vec>]` in a `:script` body.
+
+  ## Closed shape (rf2-mantt)
+
+  The `:map` is `{:closed true}`: a removed slot (the REMOVED `:play`
+  above) or a typo'd slot is rejected at `reg-variant` call-time with
+  `:rf.error/variant-shape`, naming the unknown key, rather than being
+  silently accepted and then dropped on the floor at runtime (the
+  swallow-class bug rf2-1774m bit the scaffolded template with). Two
+  registrar-stamped slots are declared so the closed map accepts them:
+  `:source` (the source-coord stamp) and `:origin` (the write-surface tag
+  the story-mcp `register-variant` / `record-as-variant` tools stamp per
+  spec/Cross-Cutting-Designs.md §5)."
   [:and
-   [:map
+   [:map {:closed true}
     [:doc                   {:optional true} :string]
+    [:source                {:optional true} SourceCoords]
+    ;; rf2-mantt — `:origin` is the write-surface tag stamped by the
+    ;; story-mcp write tools (`reg-variant*` with `:origin config/origin`)
+    ;; per spec/Cross-Cutting-Designs.md §5 Origin tagging. Declared so
+    ;; the closed map accepts a programmatically-written variant body.
+    [:origin                {:optional true} :keyword]
+    ;; rf2-mantt — `:run-artifact` is the framework-stamped source-artifact
+    ;; back-link a PROMOTED variant carries (spec/017 §Promotion;
+    ;; `re-frame.story.promotion/provenance-link`). Not author-facing — the
+    ;; promotion path writes it into the registered body. A trimmed
+    ;; provenance projection (`:artifact/kind` / `:seed` / `:event-program`
+    ;; / `:fx-decisions` / `:network` / …); left a loose `:map` so the
+    ;; closed body schema accepts it without coupling to the artifact's
+    ;; evolving internal shape.
+    [:run-artifact          {:optional true} [:map-of :any :any]]
     [:extends               {:optional true} :keyword]
     ;; rf2-5x1wt.15 — `:compose` includes registered fragments + checks
     ;; explicitly, applied in declared order (spec/017 §`:compose`).
@@ -732,6 +803,13 @@
     [:plays                 {:optional true} PlaysSpec]
     [:args                  {:optional true} ArgMap]
     [:argtypes              {:optional true} ArgtypesMap]
+    ;; rf2-mantt — explicit view-args/props schema slots (canonical
+    ;; first-match order `[:rf/props :schema]`; see the Story schema +
+    ;; `re-frame.story.malli-schema/view-args-schema-keys`). A variant
+    ;; MAY pin a narrower/stricter props schema than its component-wide
+    ;; one. The value is a Malli schema form.
+    [:rf/props              {:optional true} :any]
+    [:schema                {:optional true} :any]
     ;; rf2-5x1wt.14 — first-class managed-HTTP request stubs. A map of
     ;; `[method url]` → `{:reply {:ok|:failure …}}`. The plan compiler
     ;; lowers `:network` to `[:world :network]` and on to the managed-
@@ -804,6 +882,26 @@
     ;; overrides the parent story's preset.
     [:dispatch-console?     {:optional true} :boolean]
     [:xray                 {:optional true} XrayPreset]
+    ;; rf2-mantt — `:component` is the per-variant view-id override. A
+    ;; variant inherits its parent story's `:component` but MAY name its
+    ;; own; the renderer resolves variant-first, then story
+    ;; (`re-frame.story.ui.canvas` / `multi-substrate` / `workspace`:
+    ;; `(or (:component variant-body) (:component story-body))`).
+    [:component             {:optional true} :keyword]
+    ;; rf2-mantt — `:xray-panel` (rf2-6qm77) is the per-variant Xray
+    ;; panel-id override the RHS embed reads variant-first then story
+    ;; (`re-frame.story.ui.xray-embed/effective-panel`); a registered
+    ;; panel-id keyword (`:app-db` / `:routing` / …). Membership is not
+    ;; enforced here — the embed falls back to the default panel on an
+    ;; unknown id (its own runtime guard).
+    [:xray-panel            {:optional true} :keyword]
+    ;; rf2-mantt — `:frame-binding` (`#{:fresh :attached}`) + `:mcp-bound`
+    ;; (boolean) drive the sidebar frame-binding chip
+    ;; (`re-frame.story.ui.sidebar-signals/frame-binding-signal`). MCP is
+    ;; a binding, not a runner tier — `:mcp-bound` is the UI affordance
+    ;; on top of an `:attached` binding.
+    [:frame-binding         {:optional true} [:enum :fresh :attached]]
+    [:mcp-bound             {:optional true} :boolean]
     ;; rf2-zll4h — viewport + background per-variant overrides. Resolved
     ;; with variant-first, then story-level, then chrome toolbar.
     [:viewport              {:optional true} ViewportSlot]
@@ -871,10 +969,17 @@
   `:checks` / `:assertions` (those compose as checks — `reg-check` — or
   ride the variant's own `:assertions`). Composing a check is done by
   naming the check-id in the variant's `:compose`, not by nesting it in a
-  fragment."
+  fragment.
+
+  ## Closed shape (rf2-mantt)
+
+  `{:closed true}`: a typo'd fragment slot rejects at `reg-fragment`
+  call-time rather than silently no-opping. `:source` is the registrar's
+  source-coord stamp."
   [:and
-   [:map
+   [:map {:closed true}
     [:doc                   {:optional true} :string]
+    [:source                {:optional true} SourceCoords]
     [:args                  {:optional true} ArgMap]
     [:argtypes              {:optional true} ArgtypesMap]
     [:setup                 {:optional true} [:vector EventVector]]
@@ -928,9 +1033,15 @@
   Checks are the inheritable expectation form (distinct from own-only
   `:assertions` on a variant): they inherit through `:extends` and compose
   through `:compose`. A check carries no world/behaviour — no setup,
-  script, args, or overrides — so the body is intentionally tight."
-  [:map
+  script, args, or overrides — so the body is intentionally tight.
+
+  ## Closed shape (rf2-mantt)
+
+  `{:closed true}`: a typo'd check slot rejects at `reg-check` call-time.
+  `:source` is the registrar's source-coord stamp."
+  [:map {:closed true}
    [:doc        {:optional true} :string]
+   [:source     {:optional true} SourceCoords]
    [:assertions [:vector AssertionVector]]])
 
 ;; ---- :rf/workspace --------------------------------------------------------
@@ -959,14 +1070,49 @@
   frame-provider (the rf2-sszlr / `gallery_chrome.cljs` pattern):
   parallel cells of such views share their interior state because the
   last-seeded cell's app-db clobbers the others. Only honoured by
-  `:variants-grid`; ignored on other layouts."
+  `:variants-grid`; ignored on other layouts.
+
+  ## Closed shape (rf2-mantt)
+
+  The `:map` is `{:closed true}`: a typo'd or removed workspace slot is
+  rejected at `reg-workspace` call-time with `:rf.error/workspace-shape`
+  rather than silently swallowed. Closing the schema surfaced four slots
+  that the canonical testbed + both example apps + spec/001-Authoring.md
+  §reg-workspace ALREADY author but the open `:map` never declared
+  (rf2-mantt per-key triage). They are declared optional here so closing
+  does NOT drop intended authoring:
+
+  - `:columns` — `:grid` / `:variants-grid` column-count hint
+    (spec/001-Authoring.md:561). NOTE: declared + documented but NOT yet
+    honoured by the renderer — the grid CSS uses `auto-fit`. Filed as a
+    spec/impl-divergence follow-up; declared (not dropped) so authoring
+    that already sets it keeps validating.
+  - `:for` — `:variants-grid` auto-enumerate anchor story-id
+    (spec/001-Authoring.md:560, 573-602). Same divergence note: the
+    renderer reads the `:story` anchor slot, not `:for`.
+  - `:story` — the `:variants-grid` anchor slot the renderer ACTUALLY
+    reads (`re-frame.story.ui.workspace/resolve-layout`); declared so a
+    body that names the anchor explicitly validates.
+  - `:tags` — workspace tag set (the canonical testbed + examples author
+    `:tags #{:docs}`).
+
+  `:source` is the registrar's source-coord stamp."
   [:and
-   [:map
+   [:map {:closed true}
     [:doc       {:optional true} :string]
+    [:source    {:optional true} SourceCoords]
     [:layout    [:enum :grid :prose :variants-grid :tabs :custom]]
     [:variants  {:optional true} [:vector :keyword]]
+    ;; rf2-mantt — `:for` (spec name) + `:story` (renderer-read anchor)
+    ;; both name the `:variants-grid` auto-enumerate parent story.
+    [:for       {:optional true} :keyword]
+    [:story     {:optional true} :keyword]
+    ;; rf2-mantt — `:columns` is a documented `:grid` / `:variants-grid`
+    ;; column-count hint (not yet renderer-honoured; see docstring).
+    [:columns   {:optional true} [:int {:min 1}]]
     [:content   {:optional true} [:vector WorkspaceContentItem]]
     [:render    {:optional true} :keyword]
+    [:tags      {:optional true} TagSet]
     [:modes     {:optional true} ModeRefSet]
     [:isolation {:optional true} [:enum :isolated :shared]]]
    ;; Layout-specific requirements. :grid / :variants-grid / :tabs need
@@ -980,7 +1126,20 @@
         :variants-grid true                  ; enumerates from registry
         :prose         (vector? content)
         :custom        (keyword? render)
-        false))]])
+        false))]
+   ;; rf2-mantt — `:variants` (explicit list) and `:for` / `:story`
+   ;; (auto-enumerate anchor) are ALTERNATIVES on a `:variants-grid`, not
+   ;; co-equals (spec/001-Authoring.md §`:variants-grid` — "Declaring both
+   ;; raises :rf.error/workspace-shape at registration"). Enforce that
+   ;; documented rule here. `:story` is the renderer's spelling of `:for`,
+   ;; so it counts as an auto-enumerate anchor for the exclusivity check.
+   [:fn {:error/message
+         (str ":variants (explicit list) and :for / :story (auto-enumerate "
+              "anchor) are mutually exclusive on a :variants-grid — pick one "
+              "(spec/001-Authoring.md §`:variants-grid`)")}
+    (fn [body]
+      (not (and (some? (:variants body))
+                (or (some? (:for body)) (some? (:story body))))))]])
 
 ;; ---- :rf/mode -------------------------------------------------------------
 
@@ -993,19 +1152,32 @@
   layout. When present, the toolbar renders one labelled group per axis
   with **single-select-within-axis** semantics. Modes without `:axis`
   render in a trailing un-grouped section with multi-select semantics.
-  The schema change is additive — unchanged bodies remain valid."
-  [:map
-   [:doc  {:optional true} :string]
-   [:axis {:optional true} :keyword]
+  The schema change is additive — unchanged bodies remain valid.
+
+  ## Closed shape (rf2-mantt)
+
+  `{:closed true}`: a typo'd mode slot rejects at `reg-mode` call-time.
+  `:source` is the registrar's source-coord stamp."
+  [:map {:closed true}
+   [:doc    {:optional true} :string]
+   [:source {:optional true} SourceCoords]
+   [:axis   {:optional true} :keyword]
    [:args ArgMap]])
 
 ;; ---- :rf/story-panel ------------------------------------------------------
 
 (def StoryPanel
   "Schema for the body of `reg-story-panel`. Per spec/007 §Story-tool
-  extension hook and IMPL-SPEC §3.1."
-  [:map
+  extension hook and IMPL-SPEC §3.1.
+
+  ## Closed shape (rf2-mantt)
+
+  `{:closed true}`: a typo'd story-panel slot rejects at
+  `reg-story-panel` call-time. `:source` is the registrar's source-coord
+  stamp."
+  [:map {:closed true}
    [:doc       {:optional true} :string]
+   [:source    {:optional true} SourceCoords]
    [:title     :string]
    [:placement [:enum :right :left :bottom :top :modal]]
    [:render    :keyword]
@@ -1022,9 +1194,15 @@
   lives at the decorator's *registration site* — not in a variant body.
 
   The fn-shape is enforced behaviourally (`(fn? wrap)`) and structurally
-  via the schema below. Both JVM and CLJS recognise `(fn? ...)`."
-  [:map
-   [:doc  {:optional true} :string]
+  via the schema below. Both JVM and CLJS recognise `(fn? ...)`.
+
+  ## Closed shape (rf2-mantt)
+
+  `{:closed true}`: a typo'd decorator slot rejects at `reg-decorator`
+  call-time. `:source` is the registrar's source-coord stamp."
+  [:map {:closed true}
+   [:doc    {:optional true} :string]
+   [:source {:optional true} SourceCoords]
    [:kind [:= :hiccup]]
    [:wrap fn?]])
 
@@ -1039,10 +1217,16 @@
   counterpart of `:init` and `002-Runtime.md` §Loader teardown contract.
   Composition order at destroy is reverse-declaration: innermost
   decorator's `:teardown` runs first. The slot is optional; only `:init`,
-  `:app-db-patch`, or `:teardown` need be present (any combination)."
+  `:app-db-patch`, or `:teardown` need be present (any combination).
+
+  ## Closed shape (rf2-mantt)
+
+  `{:closed true}`: a typo'd decorator slot rejects at `reg-decorator`
+  call-time. `:source` is the registrar's source-coord stamp."
   [:and
-   [:map
+   [:map {:closed true}
     [:doc          {:optional true} :string]
+    [:source       {:optional true} SourceCoords]
     [:kind         [:= :frame-setup]]
     [:init         {:optional true} [:vector EventVector]]
     [:teardown     {:optional true} [:vector EventVector]]
@@ -1067,15 +1251,23 @@
     built-in uses this shape so authors can pass `(fx-id, response)` at
     the reference site: `[:rf.story/force-fx-stub :http {...}]`. The
     Stage 5 decorator-resolution layer expands the ref-args into a
-    per-reference body."
+    per-reference body.
+
+  ## Closed shape (rf2-mantt)
+
+  Both branches are `{:closed true}`: a typo'd decorator slot rejects at
+  `reg-decorator` call-time. `:source` is the registrar's source-coord
+  stamp."
   [:or
-   [:map
+   [:map {:closed true}
     [:doc      {:optional true} :string]
+    [:source   {:optional true} SourceCoords]
     [:kind     [:= :fx-override]]
     [:fx-id    :keyword]
     [:response :any]]
-   [:map
+   [:map {:closed true}
     [:doc       {:optional true} :string]
+    [:source    {:optional true} SourceCoords]
     [:kind      [:= :fx-override]]
     [:ref-args? [:= true]]]])
 
@@ -1105,9 +1297,16 @@
     sidebar tag filter at boot. `:exclude` hides variants carrying
     this tag from the default sidebar view (e.g. `:internal` /
     `:experimental` start excluded so they don't crowd the dev shell).
-    Tags without `:default-filter` default to `:include` semantics."
-  [:map
+    Tags without `:default-filter` default to `:include` semantics.
+
+  ## Closed shape (rf2-mantt)
+
+  `{:closed true}`: a typo'd tag slot rejects at `reg-tag` call-time.
+  `:source` is the registrar's source-coord stamp (absent for the
+  auto-installed canonical tags, which register via `reg-tag*` directly)."
+  [:map {:closed true}
    [:doc            {:optional true} :string]
+   [:source         {:optional true} SourceCoords]
    [:axis           {:optional true} :keyword]
    [:default-filter {:optional true} [:enum :include :exclude]]])
 

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -187,6 +187,144 @@
         (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
 
 ;; ===========================================================================
+;; rf2-mantt — CLOSED authoring-body schemas (swallow-class fix)
+;; ===========================================================================
+;;
+;; The Variant + Workspace (and sibling) authoring-body `:map`s are
+;; `{:closed true}`: a removed slot (the REMOVED `:play`, rf2-0wrud) or a
+;; typo is REJECTED at `reg-*` call-time with an actionable
+;; `:rf.error/<kind>-shape` that NAMES the unknown key + nearest declared
+;; slot — rather than silently swallowed and dropped at runtime (the
+;; failure mode that shipped a dead Story scaffold, rf2-1774m).
+
+(deftest reg-variant-rejects-removed-play-slot
+  (testing "the REMOVED :play slot (rf2-0wrud) is rejected at reg-time —
+            the closed Variant schema does not silently swallow it"
+    (try
+      (story/reg-variant :story.swallow/play
+        {:events []
+         :play   [[:rf.assert/path-equals [:counter/value] 0]]})
+      (is false "expected an exception — :play must NOT be silently accepted")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e)))
+            "ex-data carries the :rf.error/variant-shape sentinel")
+        (let [reason (:reason (ex-data e))]
+          (is (re-find #":play" reason)
+              ":reason names the offending :play key")
+          (is (re-find #"did you mean :plays\?" reason)
+              ":reason suggests the nearest declared slot")
+          (is (re-find #"closed" reason)
+              ":reason explains the body is closed"))))))
+
+(deftest reg-variant-rejects-typoed-slot-with-nearest-suggestion
+  (testing "a typo'd variant slot is rejected and the nearest declared
+            slot is suggested (e.g. :scripts → :script)"
+    (try
+      (story/reg-variant :story.swallow/typo
+        {:setup   []
+         :scripts [[:dispatch [:x]]]})              ; typo for :script
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))
+        (is (re-find #"did you mean :script\?" (:reason (ex-data e)))
+            "the nearest-key suggestion points at :script")))))
+
+(deftest reg-variant-migrated-setup-script-authoring-validates
+  (testing "the migrated authoring shape (the template scaffold, rf2-1774m)
+            — :setup preconditions + :script with [:assert [:rf.assert/…]]
+            checkpoints + dispatch-sync increments — VALIDATES cleanly"
+    ;; The exact bodies the migrated template scaffold ships.
+    (is (some? (story/reg-variant :story.migrated/empty
+                 {:doc    "Fresh counter at zero."
+                  :setup  [[:counter/initialise]]
+                  :script [[:assert [:rf.assert/path-equals [:counter/value] 0]]]
+                  :tags   #{:dev :docs :test}
+                  :substrates #{:reagent}}))
+        "empty-variant migrated body validates")
+    (is (some? (story/reg-variant :story.migrated/incremented
+                 {:doc    "three increments dispatched from :script."
+                  :setup  [[:counter/initialise]]
+                  :script [[:dispatch-sync [:counter/increment]]
+                           [:dispatch-sync [:counter/increment]]
+                           [:dispatch-sync [:counter/increment]]
+                           [:assert [:rf.assert/path-equals [:counter/value] 3]]
+                           [:assert [:rf.assert/sub-equals  [:counter/value] 3]]
+                           [:assert [:rf.assert/dispatched? [:counter/increment]]]]
+                  :tags   #{:dev :docs :test}
+                  :substrates #{:reagent}}))
+        "incremented-variant migrated body validates")
+    ;; The lowering ran: :setup → :events, :script → :play-script.
+    (let [body (story/handler-meta :variant :story.migrated/incremented)]
+      (is (contains? body :events) ":setup lowered to :events")
+      (is (contains? body :play-script) ":script lowered to :play-script")
+      (is (not (contains? body :play)) "no dead :play slot survives"))))
+
+(deftest reg-variant-accepts-mcp-origin-stamp
+  (testing "the story-mcp write surface stamps :origin onto the variant
+            body (spec/Cross-Cutting-Designs.md §5) — the closed schema
+            MUST accept it or the MCP register-variant path breaks"
+    (is (some? (story/reg-variant* :story.mcp/written
+                 {:events [] :origin :story-mcp}))
+        ":origin is a declared optional slot")))
+
+(deftest reg-workspace-rejects-typoed-slot
+  (testing "a typo'd workspace slot is rejected at reg-time (closed schema)"
+    (try
+      (story/reg-workspace :Workspace.swallow/typo
+        {:layout :grid :variants [:a] :collumns 2})   ; typo for :columns
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/workspace-shape (:rf.error/id (ex-data e))))
+        (is (re-find #"did you mean :columns\?" (:reason (ex-data e)))
+            "the nearest-key suggestion points at :columns")))))
+
+(deftest reg-workspace-accepts-documented-grid-slots
+  (testing "the documented :variants-grid / :grid slots the canonical
+            testbed + examples + spec/001-Authoring.md author — :columns,
+            :for, :story, :tags — VALIDATE on the closed schema (closing
+            must not drop intended authoring, rf2-mantt triage)"
+    (is (some? (story/reg-workspace :Workspace.docslots/auto
+                 {:doc     "auto-enumerated grid"
+                  :layout  :variants-grid
+                  :for     :story.counter
+                  :columns 2
+                  :tags    #{:docs}}))
+        ":variants-grid + :for + :columns + :tags validates")
+    (is (some? (story/reg-workspace :Workspace.docslots/grid
+                 {:layout   :grid
+                  :variants [:story.counter/empty]
+                  :columns  3
+                  :tags     #{:docs}}))
+        ":grid + :variants + :columns + :tags validates")
+    (is (some? (story/reg-workspace :Workspace.docslots/anchored
+                 {:layout :variants-grid
+                  :story  :story.counter}))
+        ":story (renderer-read anchor slot) validates")))
+
+(deftest reg-workspace-rejects-both-variants-and-for
+  (testing ":variants (explicit) and :for / :story (auto-enumerate anchor)
+            are mutually exclusive on a :variants-grid — declaring both
+            raises :rf.error/workspace-shape (spec/001-Authoring.md
+            §`:variants-grid`)"
+    (try
+      (story/reg-workspace :Workspace.both/variants-and-for
+        {:layout   :variants-grid
+         :variants [:story.counter/empty]
+         :for      :story.counter})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/workspace-shape (:rf.error/id (ex-data e))))))
+    (testing "and the :story spelling of the anchor is caught too"
+      (try
+        (story/reg-workspace :Workspace.both/variants-and-story
+          {:layout   :variants-grid
+           :variants [:story.counter/empty]
+           :story    :story.counter})
+        (is false "expected an exception")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :rf.error/workspace-shape (:rf.error/id (ex-data e)))))))))
+
+;; ===========================================================================
 ;; rf2-tl7zk — :plays multi-play schema contract
 ;; ===========================================================================
 

--- a/tools/template/resources/day8/re_frame2_template/_shared/stories.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/stories.cljs
@@ -14,8 +14,10 @@
    - `reg-tag`         — `:{{main}}/canonical` (project-scoped tag).
    - `reg-workspace`   — `:Workspace.counter/all` (auto-grid layout).
 
-   Per spec/007 §Variants every variant body is plain data — no
-   fn-slots. The view at the centre of each variant is referenced by
+   Per spec/017-Testing-Story.md §Public vocabulary every variant body
+   is plain data — no fn-slots; the public authoring keys are `:setup`
+   (preconditions) + `:script` (behaviour-under-test). The view at the
+   centre of each variant is referenced by
    id (`:{{namespace}}.views/counter-app`); the events the variant
    dispatches reference event-ids. Add more `reg-variant` / `reg-tag`
    / `reg-decorator` / `reg-mode` calls below as your app grows."
@@ -50,23 +52,33 @@
      :substrates #{:reagent}})
 
   ;; -- reg-variant — empty (zero) + incremented (three clicks) -------------
+  ;;
+  ;; The authoring surface is `:setup` (preconditions, dispatched before
+  ;; the play runs) + `:script` (the ordered behaviour-under-test). Per
+  ;; spec/017-Testing-Story.md §Public vocabulary `:setup` / `:script`
+  ;; are the public keys. A `:script` step is a tagged vector; an
+  ;; `:rf.assert/*` checkpoint rides the `[:assert [...]]` step tag, and a
+  ;; bare event vector lifts to `[:dispatch ...]`. This is what makes a
+  ;; Story double as a test — the `:rf.assert/*` checkpoints are the
+  ;; assertions, run by the CI play-runner.
   (story/reg-variant :story.counter/empty
     {:doc    "Fresh counter at zero."
-     :events [[:counter/initialise]]
-     :play   [[:rf.assert/path-equals [:counter/value] 0]]
+     :setup  [[:counter/initialise]]
+     :script [[:assert [:rf.assert/path-equals [:counter/value] 0]]]
      :tags   #{:dev :docs :test :{{main}}/canonical}
      :substrates #{:reagent}})
 
   (story/reg-variant :story.counter/incremented
-    {:doc    "Counter after three increments. Dispatched from :play so
-             :rf.assert/dispatched? observes them."
-     :events [[:counter/initialise]]
-     :play   [[:counter/increment]
-              [:counter/increment]
-              [:counter/increment]
-              [:rf.assert/path-equals [:counter/value] 3]
-              [:rf.assert/sub-equals  [:counter/value] 3]
-              [:rf.assert/dispatched? [:counter/increment]]]
+    {:doc    "Counter after three increments. The increments are
+             dispatch-sync'd FROM the :script (not seeded in :setup) so
+             :rf.assert/dispatched? observes them on the trace bus."
+     :setup  [[:counter/initialise]]
+     :script [[:dispatch-sync [:counter/increment]]
+              [:dispatch-sync [:counter/increment]]
+              [:dispatch-sync [:counter/increment]]
+              [:assert [:rf.assert/path-equals [:counter/value] 3]]
+              [:assert [:rf.assert/sub-equals  [:counter/value] 3]]
+              [:assert [:rf.assert/dispatched? [:counter/increment]]]]
      :tags   #{:dev :docs :test}
      :substrates #{:reagent}})
 

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -71,8 +71,8 @@ routing on the same `:app` build:
 
 - **`#/`** — the live counter app.
 - **`#/stories`** — the Story shell: every registered story / variant /
-  workspace, with the `:rf.assert/*` play steps and the canonical
-  tag set.
+  workspace, with the `:script` play steps and their `:rf.assert/*`
+  checkpoints and the canonical tag set.
 
 `npx shadow-cljs watch app` serves both — no second build. Visit
 <http://localhost:8280/#/stories> for the playground and


### PR DESCRIPTION
## What

Fail-CLOSED the **swallow-class** correctness bug on the Story authoring surface (rf2-mantt P3 root cause + rf2-1774m P2 symptom — landed together).

The Story authoring-body `:map` schemas were **OPEN**, so a removed or typo'd slot in a `reg-*` body was silently accepted at registration and then dropped on the floor at runtime — no error. That shipped a **dead Story scaffold** in the template: it authored the REMOVED `:play` slot (rf2-0wrud, 2026-05-20), so its "stories double as tests" lesson ran zero assertions, with no diagnostic.

## Changes

**Schemas (`tools/story/src/re_frame/story/schemas.cljc`)**
- `{:closed true}` on every authoring-body `:map`: `Story`, `Variant`, `Fragment`, `Check`, `Workspace`, `Mode`, `StoryPanel`, `Tag`, and the `Decorator` sub-schemas.
- Declared `:source` (the registrar's source-coord stamp) on each so the closed maps accept the registrar's own stamp.
- **Per-key triage** (`git grep` across ALL Story authoring) surfaced real, intended-but-undeclared slots the open schema was hiding. Per the bead's rule, these are **declared (not dropped)** so closing keeps all intended behaviour:
  - `Variant`: `:component`, `:xray-panel`, `:frame-binding`, `:mcp-bound`, `:origin` (story-mcp write-surface tag, spec/Cross-Cutting-Designs §5), `:run-artifact` (promotion back-link, spec/017 §Promotion), `:rf/props` + `:schema` (view-args schema).
  - `Story`: `:xray-panel`, `:rf/props`, `:schema`.
  - `Workspace`: `:columns`, `:for`, `:story` (the renderer-read anchor), `:tags`.
- Enforced the **spec-documented** `:variants` xor `:for`/`:story` mutual-exclusion on `:variants-grid` (spec/001-Authoring.md said it raises at registration; the open schema never enforced it).

**Registrar (`tools/story/src/re_frame/story/registrar.cljc`)**
- `validate-shape!` turns a `:malli.core/extra-key` error into an **actionable** `:reason` naming the unknown key(s) + the **nearest declared slot** (`"did you mean :plays?"`) + the allowed-key list. Edit-distance suggestion; declared keys read off the malli schema (self-maintaining, no duplicated key list).

**Template scaffold — rf2-1774m (`tools/template/resources/.../_shared/stories.cljs` + `root/README.md`)**
- Migrated the two variants off the removed `:play` slot to the public `:setup`/`:script` vocabulary: bare `[:rf.assert/...]` → `[:assert [...]]` under `:script`; increments `dispatch-sync`'d from `:script` so `:rf.assert/dispatched?` observes them (mirrors the canonical testbed).
- Fixed stale `spec/007 §Variants` → `spec/017-Testing-Story.md §Public vocabulary`; reworded README `:rf.assert/* play steps` → `:script play steps with :rf.assert/* checkpoints`.

**Spec (`tools/story/spec/001-Authoring.md`)**
- `reg-workspace` body documented as closed; added `:story` anchor + `:tags`; authoritative notes that `:columns` / `:for` are **declared but not yet renderer-honoured** (the renderer reads `:story`, uses `auto-fit`) — tracked as follow-up **rf2-ugmrg**.

## Per-key triage outcome

| Swallowed key | Decision |
|---|---|
| `:play` (Variant) | **removed/dead** → kept out of schema; closing now rejects it (the fix) + migrated the template authoring |
| `:columns`, `:for`, `:tags`, `:story` (Workspace) | **intended + spec-documented** → declared optional |
| `:component`, `:xray-panel`, `:frame-binding`, `:mcp-bound`, `:origin`, `:run-artifact`, `:rf/props`, `:schema` (Variant) | **intended, runtime-read** → declared optional |
| `:xray-panel`, `:rf/props`, `:schema` (Story) | **intended, runtime-read** → declared optional |
| `:columns` / `:for` not honoured by renderer | spec/impl divergence → declared + flagged in spec → follow-up **rf2-ugmrg** |

## Tests
Added to `story_authoring_validation_test.clj`: closed schema REJECTS `:play` (and typo'd slots, asserting the nearest-slot suggestion) at reg-time; migrated `:setup`/`:script` authoring validates + lowers (no dead `:play`); documented workspace slots validate; `:variants`+`:for`/`:story` rejected; the `:origin` write path is accepted.

## Gates (all green, cold)
- story `clojure -M:test` — 1602 tests, 0 failures
- `npm run test:cljs` — 5615 tests, 0 failures
- `npm run story:build` — 0 warnings, export OK
- `npm run test:bundle-isolation` — PASS
- story-mcp `clojure -M:test` — 212 tests, 0 failures (verifies the `:origin` write path against the closed schema)

Closes rf2-mantt, rf2-1774m. Follow-up: rf2-ugmrg.