### PR TITLE
fix(adapters/reagent): complete mpk41 sub-id rename in realworld test — unblock main (rf2-0wt03)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -182,14 +182,14 @@
 
   (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles}})]
-    (is (= :idle (:status (rf/compute-sub [:articles] (rf/app-db-value f)))))
+    (is (= :idle (:status (rf/compute-sub [:articles/slice] (rf/app-db-value f)))))
     (rf/dispatch-sync [:articles/load] {:frame f})
-    (let [slice (rf/compute-sub [:articles] (rf/app-db-value f))]
+    (let [slice (rf/compute-sub [:articles/slice] (rf/app-db-value f))]
       (is (= :loaded (:status slice)))
       (is (= 1 (count (:data slice))))
       (is (= "hello-world" (-> slice :data first :slug))))
     (rf/dispatch-sync [:articles/load] {:frame f})
-    (let [slice (rf/compute-sub [:articles] (rf/app-db-value f))]
+    (let [slice (rf/compute-sub [:articles/slice] (rf/app-db-value f))]
       (is (= :loaded (:status slice)))
       (is (= 2 (:attempt slice))))))
 
@@ -202,7 +202,7 @@
   (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles-failure}})]
     (rf/dispatch-sync [:articles/load] {:frame f})
-    (is (= :error (:status (rf/compute-sub [:articles] (rf/app-db-value f)))))
+    (is (= :error (:status (rf/compute-sub [:articles/slice] (rf/app-db-value f)))))
     (is (some? (rf/compute-sub [:articles/error] (rf/app-db-value f))))))
 
 ;; ============================================================================


### PR DESCRIPTION
## What

`rf2-mpk41` (#3106) renamed `examples/reagent` bare layer-2 sub-ids to `/slice` forms but scoped its orphan-grep to `examples/reagent` only, missing the adapter test tree. `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs` called `(rf/compute-sub [:articles] …)` at four sites (`:185/:187/:192/:205`); with `:articles` now registered as `:articles/slice` (`articles.cljs:298`), `[:articles]` resolved to no-such-sub → `nil` → **7 node-test failures → main RED, blocking all PRs**.

## Fix

Updated the four `[:articles]` refs to `[:articles/slice]`. A full sweep of the file (and the whole `implementation/` tree) confirms **no other bare renamed-id refs** — the test's other reads (`:articles/data`, `:articles/error`, `:article/data`, `:comments/data`, `:comment-form/draft`, `:profile/data`, `:profile.articles/data`, `:editor/can-submit?`, …) are already on their new namespaced ids. Event ids (`:articles/load`, `:articles/initialise`) and already-namespaced subs are correct and left unchanged.

## SSR JVM gates

`ssr` and `ssr-ring` JVM gates are **green as-is, no change needed**. The only `subscribe [:articles]`/`[:comments]` refs in the ssr-ring tree live in `streaming_robustness_test.clj` + `ring_streaming_test.clj`, which **register their own local `:articles`/`:comments` subs** (self-contained, not example-dependent) — and are owned by open PR #3110, so deliberately untouched here. No follow-up bead required.

## Gates

- `npm run test:cljs` → **0 failures** (5615 tests / 19567 assertions) — the red gate, now green
- `ssr` JVM (`clojure -M:test`) → 0 failures / 266 tests
- `ssr-ring` JVM (`clojure -M:test`) → 0 failures / 110 tests

Closes rf2-0wt03. **This PR unblocks main.**