### PR TITLE
fix(routing): close open-redirect on navigate {:url}, coerce path params, host-symmetric :int, normalize empty fragment (rf2-cylse.4/.5/.1 + rf2-zmcq6 code half)

### DIFF
--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -26,6 +26,7 @@
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.routing.events :as routing-events]
+            [re-frame.routing.url :as url]
             [re-frame.trace :as trace]))
 
 (defn- can-leave-query [route-meta]
@@ -154,81 +155,10 @@
   [_ _]
   {})
 
-(defn- safe-in-app-url?
-  "Fail-CLOSED lexical classifier for the no-browser-origin path (JVM /
-  SSR, and CLJS when `js/window` is unavailable). Returns true ONLY when
-  `url` is PROVABLY a same-origin in-app reference; everything ambiguous
-  or absolute returns false -> classed external (rf2-3bv8o).
-
-  Without a browser `Location` to resolve and origin-compare against
-  (the robust CLJS path below), the runtime cannot prove a URL is
-  same-origin. The pre-rf2-3bv8o JVM path was fail-OPEN: it returned the
-  URL verbatim and classed in-app anything that did not lexically look
-  absolute -- a default-ALLOW that let open-redirect bypass vectors
-  (leading whitespace before a scheme, backslash-prefixed authorities a
-  browser normalises to `//`, embedded tab/newline in the scheme) slip
-  through as in-app pushes. This flips to fail-CLOSED, consistent with
-  the routing fail-closed posture established by rf2-6t1xb (a hostile or
-  ambiguous URL resolves to the safe outcome, not the permissive one).
-
-  A URL is accepted as in-app only when, after rejecting any whitespace
-  or ASCII control character (browsers strip tab/CR/LF mid-URL before
-  parsing -- a lexical check that ignores them is bypassable), it begins
-  with a single `/` NOT followed by `/` or a backslash (a rooted
-  same-origin path) -- OR is a pure query (`?...`) / fragment (`#...`)
-  reference. A leading `//` or `/\\` (protocol-relative authority a
-  browser reads as off-origin), a scheme (`name:`), a bare relative
-  segment, the empty string, and any non-string all fail closed."
-  [url]
-  (boolean
-    (and (string? url)
-         (seq url)
-         ;; Reject any whitespace or ASCII control char (incl. DEL)
-         ;; anywhere: a leading space defeats a `^` scheme anchor, and
-         ;; embedded tab/CR/LF are stripped by browsers before parsing --
-         ;; a lexical check that ignores them is a bypass surface. The
-         ;; `\s` + hex-range class is identical under Java (CLJ) and
-         ;; JS (CLJS) regex.
-         (not (re-find #"[\s\x00-\x1f\x7f]" url))
-         (or
-           ;; Pure query or fragment reference -- unambiguously same-doc.
-           (clojure.string/starts-with? url "?")
-           (clojure.string/starts-with? url "#")
-           ;; Rooted path: a single leading `/` NOT followed by `/` or
-           ;; `\` (which a browser would treat as a protocol-relative
-           ;; authority -> off-origin).
-           (and (clojure.string/starts-with? url "/")
-                (not (clojure.string/starts-with? url "//"))
-                (not (clojure.string/starts-with? url "/\\")))))))
-
-(defn- external-url? [url]
-  #?(:cljs
-     (try
-       (if (and (exists? js/window) (.-location js/window))
-         (let [loc      (.-location js/window)
-               parsed   (js/URL. url (.-href loc))
-               protocol (.-protocol parsed)]
-           (or (not (#{"http:" "https:"} protocol))
-               (not= (.-origin parsed) (.-origin loc))))
-         ;; No browser Location to origin-compare against — fail closed.
-         (not (safe-in-app-url? url)))
-       (catch :default _
-         (not (safe-in-app-url? url))))
-     :clj
-     ;; JVM / SSR: no browser origin — fail closed (rf2-3bv8o).
-     (not (safe-in-app-url? url))))
-
-(defn- request-url->app-url [url]
-  #?(:cljs
-     (try
-       (if (and (exists? js/window) (.-location js/window)
-                (not (external-url? url)))
-         (let [parsed (js/URL. url (.-href (.-location js/window)))]
-           (str (.-pathname parsed) (.-search parsed) (.-hash parsed)))
-         url)
-       (catch :default _ url))
-     :clj
-     url))
+;; rf2-cylse.4: the open-redirect classifier (`safe-in-app-url?` /
+;; `external-url?` / `request-url->app-url`) is now shared in
+;; `re-frame.routing.url` so the programmatic `:rf.route/navigate {:url}`
+;; sink gates through the SAME fail-closed logic as `:rf/url-requested`.
 
 (defn- inject-bypass-leave-guard [event-vec fallback-url]
   (let [event-id (first event-vec)]
@@ -267,8 +197,8 @@
     ;; The :bypass-leave-guard? request flag is the rf2-yursn one-shot
     ;; escape hatch :rf.route/continue uses to re-issue the original
     ;; navigation request without re-running the leave guard.
-    (let [external? (external-url? url)
-          app-url   (request-url->app-url url)
+    (let [external? (url/external-url? url)
+          app-url   (url/request-url->app-url url)
           blocked   (when-not external?
                       (maybe-block-navigation db (or frame :rf/default)
                                               event-vec app-url bypass-leave-guard?))]

--- a/implementation/routing/src/re_frame/routing/nav_fx.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_fx.cljc
@@ -98,11 +98,26 @@ no-op the fx so they don't race with the URL-owning frame (per Spec 012
 
 (defn push-url-handler
   "`:rf.nav/push-url` fx handler. Registered by the façade so a `:reload`
-  re-wires it on a fresh registrar."
+  re-wires it on a fresh registrar.
+
+  rf2-cylse.4 (defence-in-depth): the `.pushState` call is wrapped in
+  try/catch. A browser throws `SecurityError` when asked to push an
+  absolute cross-origin URL — left uncaught that crashes the fx drain (a
+  DoS, worse than the redirect it would otherwise be). The
+  `url/external-url?` gate at the nav-event sinks (rf2-cylse.4) already
+  fails such URLs closed before they reach this fx, so this catch is a
+  second line of defence: any residual throw is downgraded to a
+  `:rf.fx/push-url-failed` trace, keeping the drain alive."
   [{:keys [frame]} url]
   (history-mutation-handler
     :rf.nav/push-url frame url
-    #?(:cljs #(.pushState js/window.history nil "" url) :clj nil)))
+    #?(:cljs #(try
+                (.pushState js/window.history nil "" url)
+                (catch :default e
+                  (trace/emit! :rf.fx :rf.fx/push-url-failed
+                               {:fx-id :rf.nav/push-url :url url
+                                :error (.-message e)})))
+       :clj nil)))
 
 (def replace-url-meta
   "Metadata for the `:rf.nav/replace-url` fx registration. Spec 012

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -17,6 +17,7 @@
             [re-frame.routing.events :as routing-events]
             [re-frame.routing.registry :as registry]
             [re-frame.routing.scroll :as scroll]
+            [re-frame.routing.url :as url]
             [re-frame.trace :as trace]))
 
 ;; Per Spec 012 §Navigation is an event — the arity contract:
@@ -73,12 +74,34 @@
     ;; have a token to thread through stale-suppression.
     (let [opts (or opts {})
           {:keys [route-id path-params query-params matched-fragment unmatched-url
-                  throw-reason requested-url]}
+                  throw-reason requested-url external-url-target?]}
           (cond
             (keyword? target)
             {:route-id     target
              :path-params  (or params {})
              :query-params (:query opts {})}
+
+            ;; rf2-cylse.4 (SECURITY — open-redirect): the `{:url ...}`
+            ;; escape hatch is the untrusted-input sink (Spec 012 §Target
+            ;; form — URL-string: deep-link handlers, server-redirect
+            ;; targets, programmatic redirects from a string). It MUST gate
+            ;; through the SAME fail-closed open-redirect classifier the
+            ;; `:rf/url-requested` link-click path uses — otherwise every
+            ;; rf2-3bv8o bypass vector (`//evil`, `/\evil`, `javascript:`,
+            ;; leading-space, `user@host`) is pushed VERBATIM to
+            ;; `:rf.nav/push-url`. The classifier is hoisted into
+            ;; `re-frame.routing.url` so both sinks share one gate. When the
+            ;; URL classes EXTERNAL we short-circuit BEFORE `match-url` (no
+            ;; match work, no slice rewrite, no push) — the commit body's
+            ;; `external-url-target?` cond arm fails closed identically to
+            ;; `url-requested-handler` (`:rf.route/external-url-requested`
+            ;; trace + `{}`).
+            (and (map? target) (:url target) (url/external-url? (:url target)))
+            {:route-id             :rf.route/not-found
+             :path-params          {}
+             :query-params         {}
+             :requested-url        (:url target)
+             :external-url-target? true}
 
             (and (map? target) (:url target))
             ;; rf2-6t1xb: `match-url` THROWS on the keyword-interning DoS
@@ -122,9 +145,21 @@
                ;; dashboards / SSR projections the DoS cap feeds.
                :throw-reason     throw-reason
                :requested-url    (:url target)}))
-          fragment    (or (:fragment opts)
-                          (and (map? target) (:fragment target))
-                          matched-fragment)
+          ;; rf2-zmcq6: normalize an explicit empty-string fragment to nil
+          ;; at the navigate boundary. `route-url` (the URL builder) treats
+          ;; `:fragment ""` as NO fragment (emits no trailing `#`), but
+          ;; `""` is truthy, so without this normalization
+          ;; `[:rf.route/navigate :route/docs {} {:fragment ""}]` would
+          ;; push `/docs` (no `#`) while writing `:fragment ""` into the
+          ;; route slice — a slice/URL divergence vs URL-driven nav to the
+          ;; same URL (which yields `:fragment nil`). Collapsing `""` → nil
+          ;; here keeps the programmatic and URL-driven paths in agreement:
+          ;; the pushed URL and the slice's `:fragment` match regardless of
+          ;; how the route was reached.
+          fragment    (let [f (or (:fragment opts)
+                                  (and (map? target) (:fragment target))
+                                  matched-fragment)]
+                        (when-not (= "" f) f))
           route-meta  (registrar/lookup :route route-id)
           ;; rf2-1os1c: catch the params/opts positional swap at the
           ;; event boundary. Route-id form only — the `{:url ...}` form
@@ -194,8 +229,15 @@
           ;; (`url-change-fx`), which already keeps the requested URL (it
           ;; changed via link/popstate, so that path emits no push). Per
           ;; Spec 012 §Target form — URL-string.
-          url (if unmatched-url
-                unmatched-url
+          url (cond
+                ;; rf2-cylse.4: an external-classed `{:url ...}` target
+                ;; fails closed below (the `external-url-target?` cond arm)
+                ;; — never built into a push URL, so skip `route-url`
+                ;; entirely (calling it for `:rf.route/not-found` would
+                ;; throw `:no-such-route` when none is registered).
+                external-url-target? nil
+                unmatched-url        unmatched-url
+                :else
                 (try (registry/route-url route-id path-params query-params fragment)
                      (catch #?(:clj Throwable :cljs :default) ex
                        ;; rf2-7d30s — stamp the in-flight cascade's `:frame`
@@ -256,6 +298,22 @@
         ;; Caller-bug schema failure: reject (slice unchanged, no push).
         (= ::reject url)
         {}
+
+        ;; rf2-cylse.4 (SECURITY — open-redirect): the `{:url ...}` target
+        ;; classed EXTERNAL by the shared `url/external-url?` gate. Fail
+        ;; closed IDENTICALLY to `url-requested-handler`: emit
+        ;; `:rf.route/external-url-requested` and return `{}` — no
+        ;; `:rf.nav/push-url`, no slice rewrite, no `:rf.route/transitioned`.
+        ;; The verbatim-push open-redirect sink is closed across all three
+        ;; URL-string nav sinks (the gated `:rf/url-requested`, this
+        ;; `:rf.route/navigate {:url}`, and `:rf.route/continue` re-issuing
+        ;; either).
+        external-url-target?
+        (do
+          (trace/emit! :rf.event :rf.route/external-url-requested
+                       (cond-> {:url requested-url}
+                         frame (assoc :frame frame)))
+          {})
 
         ;; Leave-guard check runs first (mirrors the URL-driven path,
         ;; where `maybe-block-navigation` precedes `url-change-fx`): a

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -118,7 +118,7 @@
   [url]
   (url/malformed-url? url))
 
-(declare compile-query-coercions)
+(declare compile-schema-coercions)
 
 ;; ---- authoring-boundary metadata validation ------------------------------
 ;; Per Spec 012 §Reserved route-metadata keys. `reg-route` has the
@@ -219,11 +219,18 @@
         structural   (when parsed (:rank parsed))
         rank         (when structural (conj structural (- idx)))
         compiled     (when parsed (select-keys parsed [:regex :names :pattern :groups]))
-        query-coerce (compile-query-coercions (:query metadata))
+        query-coerce (compile-schema-coercions (:query metadata))
+        ;; rf2-cylse.5: compile the `:params` schema into a path-coerce
+        ;; table the SAME way as the query side, so PATH captures coerce
+        ;; against their declared type (`:int`/`:uuid`/`:double`/enum)
+        ;; before validation — without it a non-`:string` path-param type
+        ;; makes every valid URL fail :params validation → 404.
+        params-coerce (compile-schema-coercions (:params metadata))
         meta'        (cond-> (source-coords/merge-coords metadata)
-                       rank         (assoc :rf.route/rank rank)
-                       compiled     (assoc :rf.route/compiled compiled)
-                       query-coerce (assoc :rf.route/query-coerce query-coerce))]
+                       rank          (assoc :rf.route/rank rank)
+                       compiled      (assoc :rf.route/compiled compiled)
+                       query-coerce  (assoc :rf.route/query-coerce query-coerce)
+                       params-coerce (assoc :rf.route/params-coerce params-coerce))]
     ;; Spec 012 rule-6 warning: scan existing routes for one whose
     ;; structural rank (rules 1-5) equals ours. The match-time tuple
     ;; (`:rf.route/rank`) carries `(- reg-index)` as its trailing
@@ -290,13 +297,16 @@
   the global `default-max-decoded-keys`."
   10000)
 
-(defn- compile-query-coercions
+(defn- compile-schema-coercions
   "Flatten a `[:map [k type-or-opts] ...]` Malli vector schema into a
   `{k type-form}` map for O(1) per-key lookup during URL coercion.
   Returns nil when the schema is absent or not a vector. Computed once
   at registration time and cached on the route metadata under
-  `:rf.route/query-coerce` (rf2-yjjrv) — O(1) per-key lookup at nav time
-  rather than re-scanning the schema per query key.
+  `:rf.route/query-coerce` (from the `:query` schema, rf2-yjjrv) and
+  `:rf.route/params-coerce` (from the `:params` schema, rf2-cylse.5) —
+  O(1) per-key lookup at nav time rather than re-scanning the schema per
+  key. Schema-agnostic: the same `[:map ...]` shape drives both the query
+  side and the path side.
 
   Per rf2-3k3o7: when the slot's type-form is a bare `[:enum ...]` with
   all-keyword choices, the type-form is rewritten as `[:rf.route/enum-keyword #{choice-names...}]`
@@ -359,16 +369,47 @@
   hosts, not silently passed through on one."
   #"^-?\d+$")
 
+(def ^:private max-safe-integer
+  "The largest integer magnitude both hosts represent EXACTLY: `2^53 - 1`,
+  the IEEE-754 double safe-integer ceiling (`js/Number.MAX_SAFE_INTEGER`).
+  Above this, a CLJS number loses precision (it is a double) while a JVM
+  `Long` stays exact — the same digit string would coerce to DIFFERENT
+  numeric values server- vs client-side (a Spec 011 hydration mismatch),
+  or coerce on one host and throw/round on the other. rf2-cylse.1."
+  9007199254740991)
+
 (defn- parse-int-strict
   "Coerce `v` to an integer iff it is a whole integer literal per
-  `int-literal-re`; otherwise return `v` unchanged. Identical on JVM and
-  CLJS (rf2-oyw04). On CLJS the digit-string is parsed via `parseInt`
-  base-10 — safe because the regex has already proven the whole string is
-  `^-?\\d+$`, so no NaN / radix-sniffing / trailing-junk path is reachable."
+  `int-literal-re` AND fits within the cross-host safe-integer range;
+  otherwise return `v` unchanged. HOST-SYMMETRIC AND TOTAL — identical
+  result on JVM and CLJS (rf2-oyw04 + rf2-cylse.1).
+
+  rf2-cylse.1: `int-literal-re` (`^-?\\d+$`) makes the parse DECISION a
+  pure function of the string, but NOT the parse RESULT — `^-?\\d+$`
+  matches arbitrarily long digit runs, and the two hosts then disagree on
+  the numeric value for an oversized literal:
+    - in (2^53, 2^63):  JVM `parse-long` → an EXACT `Long`; CLJS
+      `parse-long` → a LOSSY double (e.g. 9007199254740993 → …92);
+    - above 2^63:       JVM → `nil` (out of `Long` range); CLJS → a
+      lossy double — divergent OUTCOME (route-miss vs commit), not just
+      value.
+  Both are the exact cross-host-parity / hydration-mismatch class
+  rf2-oyw04 set out to close. The fix bounds the literal at the shared
+  `max-safe-integer` ceiling (`2^53 - 1`) and PASSES THROUGH AS A STRING
+  on BOTH hosts above it — mirroring the `\"12abc\"` passthrough
+  discipline (the route's `:int` `:query`/`:params` Malli schema then
+  flags the un-coerced string). `parse-long` is host-symmetric and total
+  (returns `nil`, never throws, on overflow), so no
+  `NumberFormatException` can escape `match-url` to a direct facade
+  caller either (the rf2-cylse.1 case-3 undocumented throw)."
   [v]
   (if (and (string? v) (re-matches int-literal-re v))
-    #?(:clj  (Long/parseLong v)
-       :cljs (js/parseInt v 10))
+    (let [n (parse-long v)]
+      (if (and n (<= (- max-safe-integer) n max-safe-integer))
+        n
+        ;; nil (>2^63 on JVM) or out of the safe-integer range on either
+        ;; host → pass through as a string, identically on both hosts.
+        v))
     v))
 
 (defn- coerce-by-type-form
@@ -376,10 +417,20 @@
   vocabulary: `:int` / `:boolean` plus the rf2-3k3o7 keyword variants:
 
   - `:int` — coerced to a number **only when the whole string is an
-    integer literal** (`^-?\\d+$`), identically on JVM and CLJS (rf2-oyw04).
-    Non-integer-literal input (`\"12abc\"`, `\"0x10\"`, `\" 12\"`, `\"abc\"`)
-    stays a string on BOTH hosts; the route's `:query` schema then flags the
-    type mismatch via the layered validator.
+    integer literal** (`^-?\\d+$`) within the cross-host safe-integer
+    range, identically on JVM and CLJS (rf2-oyw04 + rf2-cylse.1).
+    Non-integer-literal or oversized input (`\"12abc\"`, `\"0x10\"`,
+    `\" 12\"`, `\"abc\"`, a >2^53 literal) stays a string on BOTH hosts;
+    the route's `:query`/`:params` schema then flags the type mismatch via
+    the layered validator.
+  - `:double` — coerced to a number via the host-symmetric, total
+    `parse-double` (returns nil → string passthrough on bad input; never
+    throws). rf2-cylse.5.
+  - `:uuid` — coerced to a UUID object via the host-symmetric, total
+    `parse-uuid` (returns nil → string passthrough on a non-UUID; never
+    throws). This is what makes the canonical Spec 012 `:uuid` PATH route
+    (`{:path \"/articles/:id\" :params [:map [:id :uuid]]}`) round-trip a
+    real UUID URL to `{:id #uuid \"...\"}` rather than 404. rf2-cylse.5.
   - `:rf.route/keyword-unbounded` — declared as `:keyword` with no enum
     constraint. **Stays as string** (no intern; the unbounded keyword-
     interning DoS surface is precisely what rf2-3k3o7 guards against).
@@ -388,11 +439,24 @@
     choice are keyword'd, others stay string. Bounded by construction.
 
   Any other type-form (including nil) is a pass-through. Per Spec 012
-  §Query-string coercion and rf2-3k3o7."
+  §Query-string coercion and rf2-3k3o7. Shared by the query side
+  (`coerce-query`) and the path side (`coerce-path`, rf2-cylse.5)."
   [type-form v]
   (cond
     (= :int type-form)
     (parse-int-strict v)
+
+    (= :double type-form)
+    ;; rf2-cylse.5: host-symmetric + total. `parse-double` returns nil on
+    ;; a non-double string (both hosts) → leave the raw string so the
+    ;; layered :params/:query validator flags it.
+    (if (string? v) (or (parse-double v) v) v)
+
+    (= :uuid type-form)
+    ;; rf2-cylse.5: host-symmetric + total. `parse-uuid` returns nil on a
+    ;; non-UUID string (both hosts) → leave the raw string for the
+    ;; validator. Makes the canonical Spec 012 :uuid path route match.
+    (if (string? v) (or (parse-uuid v) v) v)
 
     (= :boolean type-form)
     (case v "true" true "false" false v)
@@ -456,6 +520,36 @@
           (assoc m k v)))
       (array-map)
       raw-query)))
+
+(defn- coerce-path
+  "Coerce a `{keyword-key string-value}` PATH-capture map against the
+  precompiled `params-coerce` table (`{:keyword-key type-form}`, from the
+  route's `:params` schema). Each captured key whose type-form is a known
+  coercion vocabulary entry (`:int` / `:uuid` / `:double` / `:boolean` /
+  `[:enum ...]` keyword allowlist) is coerced; every other key (incl.
+  `:string` and any undeclared capture) passes through unchanged.
+  rf2-cylse.5.
+
+  Unlike `coerce-query`, the keyword-interning DoS concern (rf2-3k3o7 /
+  rf2-5ifai) does NOT apply here: path-capture keys are already keywords
+  produced by `match-against` from the route pattern's FIXED capture
+  names — their cardinality is bounded by the author's pattern, not by
+  attacker-supplied URL keys. So this coerces values in place without a
+  key-allowlist gate.
+
+  Returns `params` unchanged when no `params-coerce` table is present
+  (the common case — a route with no `:params` schema, or an all-string
+  schema)."
+  [params-coerce params]
+  (if (and params-coerce (seq params))
+    (reduce-kv
+      (fn [m k v]
+        (assoc m k (if-let [tf (get params-coerce k)]
+                     (coerce-by-type-form tf v)
+                     v)))
+      params
+      params)
+    params))
 
 (defn- split-fragment
   "Split a URL into [url-without-fragment fragment]. Returns
@@ -629,8 +723,20 @@
           (fn [_ [id route-meta]]
             (when-let [compiled (or (:rf.route/compiled route-meta)
                                     (some-> (:path route-meta) match/parse-pattern))]
-              (when-let [params (match/match-against compiled path)]
-                (let [query-coerce  (:rf.route/query-coerce route-meta)
+              (when-let [raw-params (match/match-against compiled path)]
+                (let [;; rf2-cylse.5: coerce PATH captures against the
+                      ;; route's `:params` schema (precompiled to
+                      ;; `:rf.route/params-coerce`) BEFORE validation —
+                      ;; mirrors the query side. Without this a typed path
+                      ;; param (`:int`/`:uuid`/`:double`/enum) is a raw
+                      ;; string fed to a typed Malli schema → validation
+                      ;; FAILS → the canonical Spec 012 `:uuid` route 404s
+                      ;; for every valid URL. `params` (coerced) is what
+                      ;; both validation AND the `:params` result key use,
+                      ;; so the slice carries `{:id #uuid \"...\"}` per
+                      ;; Spec 012:269/498.
+                      params        (coerce-path (:rf.route/params-coerce route-meta) raw-params)
+                      query-coerce  (:rf.route/query-coerce route-meta)
                       defaults      (:query-defaults route-meta)
                       retain        (:query-retain route-meta)
                       ;; Force the query parse on the first successful path

--- a/implementation/routing/src/re_frame/routing/url.cljc
+++ b/implementation/routing/src/re_frame/routing/url.cljc
@@ -139,3 +139,105 @@
                          (when (and fragment (seq fragment))
                            (nil? (safe-url-decode fragment))))]
     (or path-bad? query-bad? fragment-bad?)))
+
+;; ---- open-redirect classifier (rf2-3bv8o + rf2-cylse.4) ------------------
+;; The shared lexical/origin gate that classifies a URL-string nav target
+;; as same-origin in-app vs external. Hoisted here from
+;; `re-frame.routing.can-leave` (rf2-cylse.4) so EVERY url-string nav sink
+;; — the gated `:rf/url-requested` link-click path AND the previously
+;; ungated `:rf.route/navigate {:url ...}` programmatic path — fails closed
+;; through ONE classifier rather than each entry point re-deciding (and
+;; only one of three being wired). Per Spec 012 §Target form — URL-string:
+;; the `{:url ...}` escape hatch is precisely for untrusted input
+;; (deep-link handlers, server-redirect targets), the same class
+;; `safe-in-app-url?` exists to gate.
+
+(defn safe-in-app-url?
+  "Fail-CLOSED lexical classifier for the no-browser-origin path (JVM /
+  SSR, and CLJS when `js/window` is unavailable). Returns true ONLY when
+  `url` is PROVABLY a same-origin in-app reference; everything ambiguous
+  or absolute returns false -> classed external (rf2-3bv8o).
+
+  Without a browser `Location` to resolve and origin-compare against
+  (the robust CLJS path in `external-url?`), the runtime cannot prove a
+  URL is same-origin. The pre-rf2-3bv8o JVM path was fail-OPEN: it
+  returned the URL verbatim and classed in-app anything that did not
+  lexically look absolute -- a default-ALLOW that let open-redirect
+  bypass vectors (leading whitespace before a scheme, backslash-prefixed
+  authorities a browser normalises to `//`, embedded tab/newline in the
+  scheme) slip through as in-app pushes. This flips to fail-CLOSED,
+  consistent with the routing fail-closed posture established by
+  rf2-6t1xb (a hostile or ambiguous URL resolves to the safe outcome,
+  not the permissive one).
+
+  A URL is accepted as in-app only when, after rejecting any whitespace
+  or ASCII control character (browsers strip tab/CR/LF mid-URL before
+  parsing -- a lexical check that ignores them is bypassable), it begins
+  with a single `/` NOT followed by `/` or a backslash (a rooted
+  same-origin path) -- OR is a pure query (`?...`) / fragment (`#...`)
+  reference. A leading `//` or `/\\` (protocol-relative authority a
+  browser reads as off-origin), a scheme (`name:`), a bare relative
+  segment, the empty string, and any non-string all fail closed."
+  [url]
+  (boolean
+    (and (string? url)
+         (seq url)
+         ;; Reject any whitespace or ASCII control char (incl. DEL)
+         ;; anywhere: a leading space defeats a `^` scheme anchor, and
+         ;; embedded tab/CR/LF are stripped by browsers before parsing --
+         ;; a lexical check that ignores them is a bypass surface. The
+         ;; `\s` + hex-range class is identical under Java (CLJ) and
+         ;; JS (CLJS) regex.
+         (not (re-find #"[\s\x00-\x1f\x7f]" url))
+         (or
+           ;; Pure query or fragment reference -- unambiguously same-doc.
+           (clojure.string/starts-with? url "?")
+           (clojure.string/starts-with? url "#")
+           ;; Rooted path: a single leading `/` NOT followed by `/` or
+           ;; `\` (which a browser would treat as a protocol-relative
+           ;; authority -> off-origin).
+           (and (clojure.string/starts-with? url "/")
+                (not (clojure.string/starts-with? url "//"))
+                (not (clojure.string/starts-with? url "/\\")))))))
+
+(defn external-url?
+  "Classify `url` as external (off-origin / non-http(s) / unsafe) vs an
+  in-app same-origin reference. On CLJS with a live `js/window.location`
+  the URL is resolved against the document origin and compared (the
+  robust path); otherwise (JVM / SSR, or any resolution failure) it falls
+  back to the fail-closed lexical `safe-in-app-url?`. rf2-3bv8o +
+  rf2-cylse.4."
+  [url]
+  #?(:cljs
+     (try
+       (if (and (exists? js/window) (.-location js/window))
+         (let [loc      (.-location js/window)
+               parsed   (js/URL. url (.-href loc))
+               protocol (.-protocol parsed)]
+           (or (not (#{"http:" "https:"} protocol))
+               (not= (.-origin parsed) (.-origin loc))))
+         ;; No browser Location to origin-compare against — fail closed.
+         (not (safe-in-app-url? url)))
+       (catch :default _
+         (not (safe-in-app-url? url))))
+     :clj
+     ;; JVM / SSR: no browser origin — fail closed (rf2-3bv8o).
+     (not (safe-in-app-url? url))))
+
+(defn request-url->app-url
+  "Normalise an in-app `url` to its origin-relative form
+  (`pathname + search + hash`) on CLJS when a browser Location is
+  available and the URL is not external; otherwise return `url`
+  unchanged. Callers must have already confirmed the URL is in-app via
+  `external-url?` — this only canonicalises, it does NOT gate."
+  [url]
+  #?(:cljs
+     (try
+       (if (and (exists? js/window) (.-location js/window)
+                (not (external-url? url)))
+         (let [parsed (js/URL. url (.-href (.-location js/window)))]
+           (str (.-pathname parsed) (.-search parsed) (.-hash parsed)))
+         url)
+       (catch :default _ url))
+     :clj
+     url))

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -625,6 +625,74 @@
     (is (= "abc" (get-in (routing/match-url "/list?page=abc") [:query :page]))
         "fully non-numeric input stays a string (already symmetric)")))
 
+;; rf2-cylse.1: :int coercion must be HOST-SYMMETRIC and TOTAL on OVERSIZED
+;; integer literals. The predecessor `js/parseInt` produced a LOSSY DOUBLE
+;; for a literal above 2^53 (e.g. 9007199254740993 -> ...92) while the JVM
+;; `Long/parseLong` stayed EXACT — the same URL yielded a DIFFERENT :query
+;; slice server vs client (a Spec 011 hydration mismatch), and a >2^63
+;; literal threw NumberFormatException on the JVM (route-miss) while CLJS
+;; committed a lossy float (page render) — a divergent OUTCOME. The fix
+;; bounds the literal at the cross-host safe-integer ceiling (2^53-1) and
+;; passes through AS A STRING above it on BOTH hosts. This CLJS pin asserts
+;; the EXACT outputs the JVM `int-coercion-oversized-host-parity-jvm` test
+;; expects.
+(deftest int-coercion-oversized-host-parity-cljs
+  (testing "rf2-cylse.1: oversized :int literals pass through as STRINGS on
+            CLJS (was a lossy double under js/parseInt), matching the JVM"
+    (register-routes!)
+    (rf/reg-route :hist/items {:path "/items" :query [:map [:page :int]]})
+    (testing "within the safe-integer range still coerces"
+      (is (= 42 (get-in (routing/match-url "/items?page=42") [:query :page])))
+      (is (= 9007199254740991
+             (get-in (routing/match-url "/items?page=9007199254740991") [:query :page]))
+          "2^53-1 (MAX_SAFE_INTEGER) coerces — inclusive ceiling, exact on both hosts"))
+    (testing "above the ceiling passes through as a string (both hosts agree)"
+      (is (= "9007199254740992"
+             (get-in (routing/match-url "/items?page=9007199254740992") [:query :page]))
+          "2^53 exceeds MAX_SAFE_INTEGER → string (js/parseInt would round)")
+      (is (= "9007199254740993"
+             (get-in (routing/match-url "/items?page=9007199254740993") [:query :page]))
+          "the canonical lossy-double case → string on CLJS too (was ...92)")
+      (is (= "-9007199254740993"
+             (get-in (routing/match-url "/items?page=-9007199254740993") [:query :page]))
+          "negative oversized literal also passes through"))
+    (testing "a literal beyond 2^63 does NOT coerce (parse-long is total, returns nil)"
+      (is (= "99999999999999999999999"
+             (get-in (routing/match-url "/items?page=99999999999999999999999") [:query :page]))
+          "string passthrough, matching the JVM (no throw / no lossy float)"))))
+
+;; rf2-cylse.5: PATH params coerce against the :params schema on CLJS too —
+;; the canonical Spec 012 :uuid route must round-trip a real UUID URL to
+;; {:id #uuid ...} on the browser, identically to the JVM (SSR) side.
+(deftest path-param-coercion-cljs
+  (testing "rf2-cylse.5: :int / :uuid PATH params coerce against the
+            :params schema before validation on CLJS"
+    (register-routes!)
+    (rf/reg-route :hist/page    {:path "/page/:n"      :params [:map [:n :int]]})
+    (rf/reg-route :hist/article {:path "/articles/:id" :params [:map [:id :uuid]]})
+    (is (= 42 (get-in (routing/match-url "/page/42") [:params :n]))
+        ":int path param coerced to a number")
+    (let [uuid-str "550e8400-e29b-41d4-a716-446655440000"
+          m        (routing/match-url (str "/articles/" uuid-str))]
+      (is (= (parse-uuid uuid-str) (get-in m [:params :id]))
+          ":uuid path param coerced to a #uuid object")
+      (is (uuid? (get-in m [:params :id])) "the slice carries a UUID object, not a string"))))
+
+;; rf2-zmcq6 (CODE half): {:fragment ""} normalizes to nil at the navigate
+;; boundary on CLJS so the pushed URL and slice fragment agree with
+;; URL-driven nav.
+(deftest navigate-empty-string-fragment-normalized-cljs
+  (testing "rf2-zmcq6: navigate {:fragment \"\"} writes :fragment nil and
+            pushes a fragment-less URL on CLJS"
+    (register-routes!)
+    (rf/reg-route :hist/docs {:path "/docs/:page"})
+    (rf/dispatch-sync [:rf.route/navigate :hist/docs {:page "guide"} {:fragment ""}])
+    (is (nil? (get-in (rf/app-db-value :rf/default)
+                      [:rf/runtime :routing :current :fragment]))
+        "empty-string fragment normalized to nil in the slice")
+    (is (= "/docs/guide" (current-url *history-state*))
+        "the pushed URL has no trailing # for an empty-string fragment")))
+
 ;; =========================================================================
 ;; 4. replaceState — no new history entry
 ;; =========================================================================

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -3325,6 +3325,199 @@
                    " pushes through verbatim")))))))
 
 ;; ============================================================================
+;; rf2-cylse.4 — :rf.route/navigate {:url ...} gates through the SAME
+;; fail-closed open-redirect classifier as :rf/url-requested. Before this
+;; fix the programmatic {:url ...} sink pushed the URL VERBATIM with no
+;; external/safe-url gate — every rf2-3bv8o bypass vector escaped. This is
+;; the rf2-3bv8o matrix re-run through the navigate {:url} sink.
+;; ============================================================================
+
+(deftest navigate-url-target-fails-closed-on-ambiguous-urls-jvm
+  (testing ":rf.route/navigate {:url <hostile>} on the JVM (no browser
+            origin) classes ambiguous / bypass-shaped URLs as EXTERNAL —
+            no :rf.nav/push-url, no slice rewrite — IDENTICALLY to the
+            :rf/url-requested link-click path. rf2-cylse.4."
+    (rf/reg-route :route/home {:path "/"})
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      ;; Land on a known route first so we can prove the slice does not move.
+      (rf/dispatch-sync [:rf.route/transitioned "/cart"])
+      (is (= :route/cart (get-in (rf/app-db-value :rf/default)
+                                 [:rf/runtime :routing :current :id]))
+          "preconditon: active route is :route/cart")
+      (testing "every rf2-3bv8o bypass vector fails closed through navigate {:url}"
+        (doseq [hostile ["https://evil.invalid/phish"   ;; absolute cross-origin
+                         "//evil.invalid/phish"          ;; protocol-relative
+                         "/\\evil.invalid"               ;; backslash authority
+                         " /cart"                        ;; leading-space scheme-anchor bypass
+                         "\thttps://evil.invalid"        ;; embedded tab (browser-stripped)
+                         "javascript:alert(1)"           ;; non-http scheme
+                         "https://good.com@evil.com/x"   ;; userinfo confusion
+                         "mailto:a@b.c"
+                         "cart"]]                          ;; bare relative segment (not rooted)
+          (reset! pushed [])
+          (rf/dispatch-sync [:rf.route/navigate {:url hostile}])
+          (is (empty? @pushed)
+              (str "fail-closed: navigate {:url " (pr-str hostile)
+                   "} classed external, not pushed"))
+          (is (= :route/cart (get-in (rf/app-db-value :rf/default)
+                                     [:rf/runtime :routing :current :id]))
+              (str "fail-closed: navigate {:url " (pr-str hostile)
+                   "} did not rewrite the active route"))))
+      (testing "provably same-origin rooted paths DO push through navigate {:url}"
+        ;; Each safe nav is preceded by landing on a DIFFERENT route so the
+        ;; rule-3 identical-nav no-op never masks the push under test. `/`
+        ;; resolves to :route/home, the rest to :route/cart.
+        (doseq [[safe land-elsewhere] [["/cart"      "/"]
+                                       ["/"          "/cart"]
+                                       ["/cart?q=1"  "/"]
+                                       ["/cart#frag" "/"]]]
+          (rf/dispatch-sync [:rf.route/transitioned land-elsewhere])
+          (reset! pushed [])
+          (rf/dispatch-sync [:rf.route/navigate {:url safe}])
+          (is (seq @pushed)
+              (str "safe same-origin reference " (pr-str safe)
+                   " pushes through navigate {:url}")))))))
+
+;; ============================================================================
+;; rf2-cylse.5 — match-url coerces PATH params against the :params schema
+;; (mirror of the query side). The canonical Spec 012 :uuid route must
+;; round-trip a real UUID URL to {:id #uuid ...}, not 404. Exercised with
+;; a real Malli validator (re-frame.schemas is required by this ns's
+;; fixture), so :validation-failed? actually runs.
+;; ============================================================================
+
+(deftest path-param-coercion-against-params-schema
+  (testing "rf2-cylse.5: a typed PATH param coerces against the route's
+            :params schema BEFORE validation — :int / :uuid round-trip,
+            validation passes, and the canonical Spec 012 :uuid route
+            matches a real UUID URL instead of 404ing"
+    (rf/reg-route :route/page    {:path "/page/:n"      :params [:map [:n :int]]})
+    (rf/reg-route :route/article {:path "/articles/:id" :params [:map [:id :uuid]]})
+    (rf/reg-route :route/double  {:path "/d/:x"         :params [:map [:x :double]]})
+    (rf/reg-route :route/str     {:path "/s/:v"         :params [:map [:v :string]]})
+
+    (testing ":int path param coerces to a number; validation passes"
+      (let [m (routing/match-url "/page/42")]
+        (is (= :route/page (:route-id m)))
+        (is (= 42 (get-in m [:params :n])) "string \"42\" coerced to the number 42")
+        (is (false? (:validation-failed? m))
+            "coerced :int conforms to [:n :int] — no validation failure (was true)")))
+
+    (testing ":uuid path param coerces to a #uuid object; canonical route matches"
+      (let [uuid-str "550e8400-e29b-41d4-a716-446655440000"
+            m        (routing/match-url (str "/articles/" uuid-str))]
+        (is (= :route/article (:route-id m)))
+        (is (= (parse-uuid uuid-str) (get-in m [:params :id]))
+            "string coerced to a real #uuid object (Spec 012:269)")
+        (is (uuid? (get-in m [:params :id])) "the slice carries a UUID object, not a string")
+        (is (false? (:validation-failed? m))
+            "coerced :uuid conforms to [:id :uuid] — the canonical route matches (was 404)")))
+
+    (testing ":double path param coerces to a number"
+      (let [m (routing/match-url "/d/3.14")]
+        (is (= 3.14 (get-in m [:params :x])))
+        (is (false? (:validation-failed? m)))))
+
+    (testing ":string path param stays a string (no coercion); a non-UUID
+              for a :uuid route stays a string and fails validation"
+      (is (= "hello" (get-in (routing/match-url "/s/hello") [:params :v])))
+      (let [m (routing/match-url "/articles/not-a-uuid")]
+        ;; not-a-uuid stays a string (parse-uuid → nil → passthrough), so
+        ;; the :uuid schema flags it — fail-closed, not a crash.
+        (is (= "not-a-uuid" (get-in m [:params :id])))
+        (is (true? (:validation-failed? m))
+            "a non-UUID value for a :uuid route fails validation (string passthrough)")))
+
+    (testing "round-trips: route-url rebuilds the URL from the coerced params"
+      (let [uuid-str "550e8400-e29b-41d4-a716-446655440000"
+            m        (routing/match-url (str "/articles/" uuid-str))]
+        (is (= (str "/articles/" uuid-str)
+               (routing/route-url :route/article (:params m)))
+            "URL → coerced params → URL is byte-identical")))))
+
+;; ============================================================================
+;; rf2-cylse.1 — :int coercion is HOST-SYMMETRIC and TOTAL on oversized
+;; integers. The JVM half of the cross-host parity pin; the CLJS half lives
+;; in routing_history_cljs_test.cljs. Both hosts must agree EXACTLY.
+;; ============================================================================
+
+(deftest int-coercion-oversized-host-parity-jvm
+  (testing "rf2-cylse.1: an integer literal above the cross-host
+            safe-integer ceiling (2^53-1) PASSES THROUGH AS A STRING on
+            the JVM (was: exact Long, which CLJS rounds to a lossy double
+            — a Spec 011 hydration mismatch), and a >2^63 literal does NOT
+            throw (was: NumberFormatException escaping match-url)"
+    (rf/reg-route :route/items {:path "/items" :query [:map [:page :int]]})
+
+    (testing "values within the safe-integer range still coerce"
+      (is (= 42 (get-in (routing/match-url "/items?page=42") [:query :page])))
+      (is (= 9007199254740991
+             (get-in (routing/match-url "/items?page=9007199254740991") [:query :page]))
+          "2^53-1 (MAX_SAFE_INTEGER) coerces — the ceiling is inclusive"))
+
+    (testing "values ABOVE the safe-integer ceiling pass through as strings (both hosts agree)"
+      (is (= "9007199254740992"
+             (get-in (routing/match-url "/items?page=9007199254740992") [:query :page]))
+          "2^53 exceeds MAX_SAFE_INTEGER → string passthrough (CLJS would be lossy)")
+      (is (= "9007199254740993"
+             (get-in (routing/match-url "/items?page=9007199254740993") [:query :page]))
+          "the rf2-cylse.1 canonical lossy-double case → string on BOTH hosts")
+      (is (= "-9007199254740993"
+             (get-in (routing/match-url "/items?page=-9007199254740993") [:query :page]))
+          "negative oversized literal also passes through"))
+
+    (testing "a literal beyond 2^63 does NOT throw (parse-long is total)"
+      (is (= "99999999999999999999999"
+             (get-in (routing/match-url "/items?page=99999999999999999999999") [:query :page]))
+          "no NumberFormatException escapes — direct match-url callers see a clean string"))))
+
+;; ============================================================================
+;; rf2-zmcq6 (CODE half) — :rf.route/navigate {:fragment ""} must agree
+;; with URL-driven nav: an empty-string fragment is normalized to nil at
+;; the navigate boundary, so the pushed URL (no trailing #) and the route
+;; slice (:fragment nil) agree, exactly as a URL-driven nav to the same URL.
+;; ============================================================================
+
+(deftest navigate-empty-string-fragment-normalized
+  (testing "rf2-zmcq6: programmatic navigation with {:fragment \"\"} pushes
+            the fragment-less URL AND writes :fragment nil to the slice —
+            agreeing with URL-driven nav (was: slice carried :fragment \"\"
+            while the URL had no #, a slice/URL divergence)"
+    (rf/reg-route :route/docs {:path "/docs/:page"})
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+
+      ;; URL-driven baseline: navigate to /docs/routing from the URL.
+      (rf/dispatch-sync [:rf.route/transitioned "/docs/routing"])
+      (let [url-driven-frag (get-in (rf/app-db-value :rf/default)
+                                    [:rf/runtime :routing :current :fragment])]
+        (is (nil? url-driven-frag) "URL-driven nav to /docs/routing yields :fragment nil")
+
+        ;; Now reach the SAME URL programmatically with {:fragment ""}.
+        (reset! pushed [])
+        (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "guide"} {:fragment ""}])
+        (let [slice-frag (get-in (rf/app-db-value :rf/default)
+                                 [:rf/runtime :routing :current :fragment])]
+          (is (= ["/docs/guide"] @pushed)
+              "the pushed URL carries NO trailing # for an empty-string fragment")
+          (is (nil? slice-frag)
+              "the slice :fragment is nil (normalized from \"\"), matching URL-driven nav")))
+
+      (testing "a non-empty programmatic fragment still works (regression guard)"
+        (reset! pushed [])
+        (rf/dispatch-sync [:rf.route/navigate :route/docs {:page "api"} {:fragment "section"}])
+        (is (= ["/docs/api#section"] @pushed) "non-empty fragment appends #section")
+        (is (= "section" (get-in (rf/app-db-value :rf/default)
+                                 [:rf/runtime :routing :current :fragment]))
+            "the slice carries the non-empty fragment")))))
+
+;; ============================================================================
 ;; rf2-5pyyl — :can-leave non-boolean → BLOCK + :rf.error/can-leave-non-boolean
 ;; ============================================================================
 


### PR DESCRIPTION
Four CODE findings on `implementation/routing`, fixed in one PR. The DOC halves (cylse.3, cylse.6, zmcq6's doc drift) are a separate hot-zone spec/012 batch and are NOT touched here.

## rf2-cylse.4 (SECURITY — open-redirect)
`:rf.route/navigate {:url ...}` pushed the URL **verbatim** to `:rf.nav/push-url` with no open-redirect gate — every rf2-3bv8o bypass vector (`//evil`, `/\evil`, `javascript:`, leading-space, `user@host`) escaped. The rf2-3bv8o classifier was wired into only **1 of 3** URL-string nav sinks (`:rf/url-requested`).

- Hoisted `safe-in-app-url?` / `external-url?` / `request-url->app-url` out of `can_leave.cljc` into the shared `re-frame.routing.url` ns.
- Gated the `:rf.route/navigate {:url ...}` branch through the same classifier: external URLs **fail closed** (emit `:rf.route/external-url-requested`, no push, no slice rewrite) — identical posture to `:rf/url-requested`. `:rf.route/continue` re-issuing either path inherits the gate.
- Wrapped `push-url-handler`'s `.pushState` in try/catch (defence-in-depth): a residual cross-origin `SecurityError` is downgraded to `:rf.fx/push-url-failed` instead of crashing the fx drain.

**Bypass repro proof** (after fix, JVM plain-atom; before fix all pushed verbatim):
```
navigate {:url "//evil.invalid/phish"}        => pushed []  slice :route/cart  (unchanged)
navigate {:url "/\evil.invalid"}             => pushed []  slice :route/cart
navigate {:url "javascript:alert(1)"}         => pushed []  slice :route/cart
navigate {:url " /cart"}                       => pushed []  slice :route/cart
navigate {:url "https://good.com@evil.com/x"} => pushed []  slice :route/cart
navigate {:url "https://evil.invalid/phish"}  => pushed []  slice :route/cart
```
Without the gate the regression test fails on 17 assertions (verified by temporarily disabling it).

## rf2-cylse.5 (`:uuid`/typed path params 404)
`match-url` validated PATH params against the `:params` schema but never **coerced** them (the query side does), so a non-`:string` path-param type fed a raw string to a typed Malli schema → validation failed → every valid URL 404'd. Broke the canonical Spec 012 `:uuid` route.

- Compile the `:params` schema to `:rf.route/params-coerce` at registration (reusing the now-generalised `compile-schema-coercions`), and coerce path captures in `match-url` **before** validation.
- Extended the shared coercer with host-symmetric `:uuid` (`parse-uuid`) and `:double` (`parse-double`), both total (nil → string passthrough, never throw).
- The canonical `:uuid` route now round-trips `URL -> {:id #uuid "..."} -> URL`.

## rf2-cylse.1 (`:int` cross-host parity)
`parse-int-strict` diverged on oversized literals: JVM `Long/parseLong` threw (>2^63) or stayed exact (>2^53); CLJS `js/parseInt` yielded a lossy float.

- Now uses `parse-long` (total on both hosts; nil on overflow) and bounds the result at the cross-host safe-integer ceiling (`2^53-1`), passing through **as a string** above it on **both** hosts. No `NumberFormatException` can escape `match-url` to a direct facade caller.

## rf2-zmcq6 (CODE half — empty-string fragment)
`{:fragment ""}` wrote `""` into the slice while `route-url` treated `""` as no-fragment → slice/URL divergence vs URL-driven nav. Normalized `""` → nil at the navigate boundary so the pushed URL and slice agree. **DOC half deferred to the spec/012 batch.**

## Tests
- JVM (`clojure -M:test` in `implementation/routing`): **155 tests, 732 assertions, 0 failures**.
- CLJS (`npm run test:cljs`): new routing/history regression tests pass. (7 pre-existing failures in `realworld-articles-feed` are unrelated — http-artefact regression on origin/main, filed as **rf2-g838l**.)
- Each fix has a without-fix-fails test, including the 5 open-redirect bypass vectors through `navigate {:url}` and the canonical `:uuid` round-trip.