### PR TITLE
fix(adapters): use-subscribe render-phase ref-count leak + reagent-slim expand-seq truncation (rf2-879fe + rf2-8u8tx.2 + rf2-8u8tx.1)

### DIFF
--- a/docs/api/14-adapters.md
+++ b/docs/api/14-adapters.md
@@ -69,9 +69,9 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
 - **Kind**: UIx component (function)
 - **Signature**:
   ```clojure
-  ($ uix-adapter/frame-provider {:frame :session :children […]})
+  ($ uix-adapter/frame-provider {:frame :session} child…)
   ```
-- **Description**: The UIx-shaped frame provider.
+- **Description**: The UIx-shaped frame provider. Children ride the idiomatic `$` trailing-args channel — pass them after the `{:frame …}` prop map, exactly as for any other UIx component (no `:children` prop-map key).
 
 ### `uix-adapter/wrap-view`
 
@@ -158,9 +158,9 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
 - **Kind**: Helix component (function)
 - **Signature**:
   ```clojure
-  ($ helix-adapter/frame-provider {:frame :session :children […]})
+  ($ helix-adapter/frame-provider {:frame :session} child…)
   ```
-- **Description**: The Helix-shaped frame provider.
+- **Description**: The Helix-shaped frame provider. Children ride the idiomatic `$` trailing-args channel — pass them after the `{:frame …}` prop map, exactly as for any other Helix component (no `:children` prop-map key).
 
 ### `helix-adapter/wrap-view`
 

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -171,6 +171,16 @@
 (deftest use-subscribe-strictmode-double-mount-refcount-balances
   (suite/assert-use-subscribe-strictmode-double-mount-refcount-balances cfg))
 
+;; rf2-8u8tx.2 — a useMemo factory re-run on unchanged deps (React's
+;; documented perf-opt discard) must not leak a sub-cache ref-count.
+(deftest use-subscribe-memo-recompute-no-refcount-leak
+  (suite/assert-use-subscribe-memo-recompute-no-refcount-leak cfg))
+
+;; rf2-879fe — an abandoned/restarted render that ran use-subscribe before
+;; commit must leave no pinned sub-cache ref-count.
+(deftest use-subscribe-abandoned-render-no-refcount-leak
+  (suite/assert-use-subscribe-abandoned-render-no-refcount-leak cfg))
+
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))
 

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -581,17 +581,27 @@
   builds (`goog.DEBUG=false`) DCE the inner branch."
   [s]
   (let [arr #js []]
-    (loop [items s]
-      (when-let [el (first items)]
-        (when ^boolean js/goog.DEBUG
-          (when (and (vector? el)
-                     (not (get-react-key el))
-                     (exists? js/console))
-            (.warn js/console
-                   (str "[reagent-slim] each child in a list should have a unique"
-                        " :key prop; saw " (pr-str el)))))
-        (.push arr (as-element el))
-        (recur (rest items))))
+    ;; Drive the loop off seq-exhaustion (`seq`), NOT the truthiness of
+    ;; the bound element. A `when-let`/`first`-truthiness loop cannot
+    ;; distinguish "seq exhausted" from a `nil`/`false` element in the
+    ;; middle of the seq, so it terminates early and silently drops that
+    ;; element AND every subsequent child. The idiomatic conditional-list
+    ;; shape — `(for [x xs] (when (pred? x) [:li ...]))` — yields exactly
+    ;; such interior nils and would truncate at the first filtered row.
+    ;; Stock Reagent maps `as-element` over the WHOLE seq (nil → React
+    ;; null, renders nothing); we match that. (rf2-8u8tx.1)
+    (loop [items (seq s)]
+      (when items
+        (let [el (first items)]
+          (when ^boolean js/goog.DEBUG
+            (when (and (vector? el)
+                       (not (get-react-key el))
+                       (exists? js/console))
+              (.warn js/console
+                     (str "[reagent-slim] each child in a list should have a unique"
+                          " :key prop; saw " (pr-str el)))))
+          (.push arr (as-element el))
+          (recur (next items)))))
     arr))
 
 (defn- ^boolean hiccup-tag? [x]

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -472,6 +472,41 @@
       (is (array? arr) "expand-seq returns a JS array")
       (is (= 3 (alength arr))))))
 
+(deftest as-element-seq-children-interior-nil-false
+  ;; rf2-8u8tx.1 — expand-seq must NOT truncate at the first nil/false
+  ;; element. The idiomatic conditional-list shape
+  ;;   (for [x xs] (when (pred? x) [:li ...]))
+  ;; yields interior nils for filtered-out rows; a truthiness-gated loop
+  ;; would stop at the first one and silently drop it AND every later
+  ;; child. Stock Reagent maps as-element over the WHOLE seq (nil → React
+  ;; null), so the list is never truncated.
+  (testing "interior nil does not truncate — later children survive"
+    (let [;; (list [:li 1] nil [:li 3]) — the shape produced by
+          ;; (for [x [1 2 3]] (when (odd? x) [:li {:key x} x]))
+          seq-children (for [n (range 1 4)]
+                         (when (odd? n) ^{:key n} [:li n]))
+          arr (template/expand-seq seq-children)]
+      (is (= 3 (alength arr))
+          "all 3 positions present (nil placeholder kept, not dropped)")
+      (is (some? (aget arr 0)) "[:li 1] survives")
+      (is (nil? (aget arr 1)) "interior nil → React null placeholder")
+      (is (some? (aget arr 2))
+          "[:li 3] survives — NOT truncated by the interior nil")))
+  (testing "interior false does not truncate — later children survive"
+    (let [seq-children (list ^{:key 0} [:span "a"] false ^{:key 2} [:span "c"])
+          arr (template/expand-seq seq-children)]
+      (is (= 3 (alength arr)) "all 3 positions present")
+      (is (some? (aget arr 0)) "first element survives")
+      (is (some? (aget arr 2))
+          "trailing element survives past the interior false")))
+  (testing "leading nil does not abort the whole seq"
+    (let [seq-children (list nil ^{:key 1} [:span "b"] ^{:key 2} [:span "c"])
+          arr (template/expand-seq seq-children)]
+      (is (= 3 (alength arr)))
+      (is (nil? (aget arr 0)))
+      (is (some? (aget arr 1)) "element after leading nil survives")
+      (is (some? (aget arr 2))))))
+
 ;; ---------------------------------------------------------------------------
 ;; Void tags — children rejected per HTML5
 ;; ---------------------------------------------------------------------------

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -167,6 +167,16 @@
 (deftest use-subscribe-strictmode-double-mount-refcount-balances
   (suite/assert-use-subscribe-strictmode-double-mount-refcount-balances cfg))
 
+;; rf2-8u8tx.2 — a useMemo factory re-run on unchanged deps (React's
+;; documented perf-opt discard) must not leak a sub-cache ref-count.
+(deftest use-subscribe-memo-recompute-no-refcount-leak
+  (suite/assert-use-subscribe-memo-recompute-no-refcount-leak cfg))
+
+;; rf2-879fe — an abandoned/restarted render that ran use-subscribe before
+;; commit must leave no pinned sub-cache ref-count.
+(deftest use-subscribe-abandoned-render-no-refcount-leak
+  (suite/assert-use-subscribe-abandoned-render-no-refcount-leak cfg))
+
 (deftest use-subscribe-stable-deps-key
   (suite/assert-use-subscribe-stable-deps-key cfg))
 

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1429,9 +1429,79 @@
                 ;; same-by-= subsequent renders.
                 stable-frame-kw (aget stable-key 0)
                 stable-query-v  (aget stable-key 1)
+                ;; ---- render-phase acquisition ledger (rf2-879fe + rf2-8u8tx.2) ----
+                ;;
+                ;; The memo factory calls `subs/subscribe`, which bumps the
+                ;; sub-cache ref-count (+1) — a RENDER-phase acquisition. The
+                ;; ONLY release used to be a `useEffect` cleanup keyed on the
+                ;; deps array, which is unbalanced for two documented React
+                ;; behaviours:
+                ;;
+                ;;   (rf2-879fe) An ABANDONED / suspended render that calls the
+                ;;     factory but never commits has no effect — so the cleanup
+                ;;     never runs and the +1 is pinned forever.
+                ;;
+                ;;   (rf2-8u8tx.2) `useMemo` is a performance hint, NOT a
+                ;;     lifecycle: React MAY discard a cached value and re-run the
+                ;;     factory on UNCHANGED deps. Each re-run is another `subscribe`
+                ;;     (+1), but a deps-keyed effect does NOT re-fire without a deps
+                ;;     change, so no matching `unsubscribe` ever balances it.
+                ;;
+                ;; FIX — drive-to-target ledger. Every render-phase `subscribe`
+                ;; is recorded in a `useRef` LEDGER keyed by a stable string
+                ;; `frame|query` token (a VALUE key, stable across renders, so
+                ;; memo-recompute and abandoned-render acquisitions for the SAME
+                ;; logical subscription accumulate in one slot). Each slot tracks
+                ;; `:n` — the ACTUAL outstanding ref-count this hook currently
+                ;; contributes for that (frame, query). Two commit-owned effects
+                ;; DRIVE `:n` toward a target by subscribing/unsubscribing the
+                ;; difference:
+                ;;
+                ;;   • a NO-DEPS reconcile effect (runs after EVERY commit, so a
+                ;;     no-deps-change memo recompute (rf2-8u8tx.2) is still seen)
+                ;;     drives the CURRENT key's `:n` to exactly 1 — RELEASING
+                ;;     memo-recompute duplicates AND, crucially, RE-ACQUIRING if a
+                ;;     prior cleanup drove it to 0 (the StrictMode effect double-
+                ;;     invoke). It drives EVERY OTHER key to 0 (acquisitions from
+                ;;     an abandoned/superseded render this commit replaced —
+                ;;     rf2-879fe).
+                ;;
+                ;;   • a `[stable-key]`-keyed release effect whose CLEANUP drives
+                ;;     the current key's `:n` to 0 on key-change / unmount.
+                ;;
+                ;; Both effects mutate the SAME `:n`, so they never double-release.
+                ;; Driving to target (not blind dec/release) means the reconcile
+                ;; effect restores the one live ref after a StrictMode cleanup
+                ;; zeroed it — re-subscribing yields the same cached reaction
+                ;; (the slot was disposed on its 1→0 edge and rebuilt; its value
+                ;; `=` the prior, so useSyncExternalStore observes no tear). Per
+                ;; Spec 006 §Reference counting and disposal (rf2-cmfln).
+                ;; The ledger lives in a `useRef` as a CLJS persistent map
+                ;;   {ledger-key {:fk frame-kw :qv query-v :n outstanding}}
+                ;; keyed by a stable string token. CLJS map access (no JS
+                ;; property inference) keeps the effects type-clean.
+                ledger-ref (React/useRef nil)
+                _ (when (nil? (.-current ledger-ref))
+                    (set! (.-current ledger-ref) {}))
+                ledger-key (str stable-frame-kw "|" (hash stable-query-v) "|"
+                                (pr-str stable-query-v))
                 reaction
                 (use-memo (fn []
-                            (subs/subscribe stable-frame-kw stable-query-v))
+                            ;; Render-phase acquisition: +1 ref-count AND record
+                            ;; it in the ledger so a later commit (the reconcile
+                            ;; effect) — or this render's release-effect cleanup —
+                            ;; reclaims it even if THIS render is abandoned before
+                            ;; its effects run.
+                            (let [r      (subs/subscribe stable-frame-kw stable-query-v)
+                                  ledger (.-current ledger-ref)
+                                  slot   (or (get ledger ledger-key)
+                                             {:fk stable-frame-kw
+                                              :qv stable-query-v
+                                              :n  0})]
+                              (set! (.-current ledger-ref)
+                                    (assoc ledger ledger-key
+                                           (update slot :n inc)))
+                              r))
                           #js [stable-key])
                 ;; The store-snapshot fn React calls on every render to
                 ;; detect tearing. Pure deref of the reaction.
@@ -1454,27 +1524,67 @@
                       (fn unsubscribe []
                         (when reaction (remove-watch reaction k)))))
                   #js [reaction])]
-            ;; Pair the memoised `subs/subscribe` (above) with an
-            ;; explicit `subs/unsubscribe` on unmount / key-change so
-            ;; the sub-cache's ref-count is decremented when the
-            ;; component drops the reaction. Without this pairing the
-            ;; useSyncExternalStore subscribe-fn's `remove-watch` would
-            ;; free the React listener but leave the sub-cache entry
-            ;; pinned at ref-count 1. Per Spec 006 §Reference counting
-            ;; and disposal.
+            ;; ---- commit-owned reconcile (rf2-879fe + rf2-8u8tx.2) ----
             ;;
-            ;; Memo can rebuild on key change; pairing the subscribe
-            ;; with a useEffect keyed on the same deps means React
-            ;; fires the previous deps' cleanup before the new effect,
-            ;; so dec-then-inc happens in order. Per rf2-cmfln the
-            ;; cache disposes synchronously on the momentary 1 → 0
-            ;; transition and the new effect rebuilds against a fresh
-            ;; cache miss; the recomputed value `=` the disposed one
-            ;; so the post-rebuild render observes no value change.
+            ;; Runs after EVERY commit (deliberately NO deps array — a memo
+            ;; recompute that does NOT change `stable-key` still re-runs this, so
+            ;; the extra render-phase `subscribe` it made (rf2-8u8tx.2) is
+            ;; reclaimed here). Drives the ledger to target by subscribe/
+            ;; unsubscribe of the difference:
+            ;;
+            ;;   1. CURRENT key  → target 1. If `:n` is above 1, release the
+            ;;      memo-recompute duplicates; if a prior cleanup drove it to 0
+            ;;      (StrictMode effect double-invoke), RE-ACQUIRE one — restoring
+            ;;      the live committed ref.
+            ;;   2. EVERY OTHER key → target 0. Those are render-phase acquisitions
+            ;;      from a render this commit SUPERSEDED (an abandoned/suspended
+            ;;      render that never committed — rf2-879fe — or a stale pre-key-
+            ;;      change slot). Fully released so nothing stays pinned.
+            ;;
+            ;; NO cleanup on this effect (a cleanup would churn the live ref every
+            ;; render); prompt key-change/unmount release is owned by the
+            ;; `[stable-key]`-keyed effect below, which shares the same `:n`.
             (React/useEffect
-              (fn use-subscribe-effect []
+              (fn use-subscribe-reconcile []
+                (let [ledger (.-current ledger-ref)]
+                  ;; First: every OTHER key → target 0 (release abandoned /
+                  ;; superseded render-phase acquisitions, rf2-879fe).
+                  (doseq [[k slot] ledger
+                          :when (not= k ledger-key)]
+                    (dotimes [_ (:n slot)]
+                      (subs/unsubscribe (:fk slot) (:qv slot))))
+                  ;; Then: the CURRENT key → target 1. Recreate the slot if a
+                  ;; prior cleanup dropped it (the StrictMode effect double-
+                  ;; invoke drove it to 0; this re-invoke must restore the one
+                  ;; live committed ref). Re-acquiring yields the same cached
+                  ;; reaction value (`=` the disposed one) so no tear is seen.
+                  (let [slot (or (get ledger ledger-key)
+                                 {:fk stable-frame-kw :qv stable-query-v :n 0})
+                        n    (:n slot)]
+                    (cond
+                      (> n 1) (dotimes [_ (dec n)]
+                                (subs/unsubscribe (:fk slot) (:qv slot)))
+                      (< n 1) (subs/subscribe (:fk slot) (:qv slot)))
+                    ;; ledger now holds ONLY the current key, pinned at 1.
+                    (set! (.-current ledger-ref)
+                          {ledger-key (assoc slot :n 1)})))
+                js/undefined))
+            ;; ---- prompt release on key-change / unmount ----
+            ;;
+            ;; Keyed on `[stable-key]` so React fires this cleanup before the new
+            ;; key's effects (key change) and on unmount. Drives the current key's
+            ;; `:n` to 0 and drops its slot. Per rf2-cmfln the 1 → 0 edge disposes
+            ;; synchronously; on a key change the reconcile effect above then
+            ;; re-pins the new key to 1.
+            (React/useEffect
+              (fn use-subscribe-release []
                 (fn cleanup []
-                  (subs/unsubscribe stable-frame-kw stable-query-v)))
+                  (let [ledger (.-current ledger-ref)
+                        slot   (get ledger ledger-key)]
+                    (when slot
+                      (dotimes [_ (:n slot)]
+                        (subs/unsubscribe (:fk slot) (:qv slot)))
+                      (set! (.-current ledger-ref) (dissoc ledger ledger-key))))))
               #js [stable-key])
             (React/useSyncExternalStore subscribe-fn get-snap get-snap)))
         use-subscribe

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -2883,6 +2883,142 @@
             (finally
               (try (.unmount root) (catch :default _ nil))))))))))
 
+;; ---- render-phase ref-count-leak regressions (rf2-879fe + rf2-8u8tx.2) ----
+;;
+;; The shared spine's `use-subscribe` acquires the sub-cache ref by calling
+;; `subs/subscribe` inside the `useMemo` factory — a RENDER-phase acquisition.
+;; The release used to live ONLY in a deps-keyed `useEffect` cleanup, which
+;; left two ways for the cache ref-count to leak. These two assertions pin
+;; both triggers; both reuse the refcount-probe cfg surface.
+;;
+;;   • rf2-8u8tx.2 — `useMemo` is a perf hint, not a lifecycle: React may
+;;     DISCARD a cached memo and re-run the factory on UNCHANGED deps. Each
+;;     re-run was another `subscribe` (+1) with no matching cleanup (the
+;;     deps-keyed effect does not re-fire without a deps change) ⇒ the
+;;     ref-count climbs per discarded memo. We simulate the documented
+;;     discard by patching `React.useMemo` to always re-run its factory while
+;;     forcing several committed re-renders, then assert the ref-count stayed
+;;     pinned at exactly 1 (not N) and dropped to 0 on unmount.
+;;
+;;   • rf2-879fe — a concurrent render that runs `use-subscribe` (the memo
+;;     factory subscribes) and is then ABANDONED before commit (React
+;;     restarts the render) has no committed effect of its own, but the SAME
+;;     fiber's eventual committed render reconciles the accumulated render-
+;;     phase acquisitions back to one. We simulate the abandoned-then-
+;;     restarted render by making the memo factory run multiple times across
+;;     renders that do commit (the realistic concurrent-interrupt shape) and
+;;     assert no ref-count is pinned beyond the single live subscription.
+
+(defn assert-use-subscribe-memo-recompute-no-refcount-leak
+  "rf2-8u8tx.2: a `useMemo` factory re-run on UNCHANGED deps (React's
+  documented perf-opt discard) must NOT leak a sub-cache ref-count. Patches
+  `React.useMemo` so its factory re-runs every render, drives several
+  committed re-renders of the use-subscribe refcount probe, and asserts the
+  (frame, query) cache ref-count stays pinned at exactly 1 throughout — then
+  drops to 0/absent on unmount. On the pre-fix spine the ref-count climbs by
+  one per discarded memo and never returns to 0.
+
+  cfg keys: reuses the refcount-probe surface
+    :probe-refcount-element / :refcount-target / :rc-frame / :rc-query"
+  [{:keys [name probe-refcount-element refcount-target rc-frame rc-query]}]
+  (testing (str name " — use-subscribe survives useMemo recompute with no refcount leak (rf2-8u8tx.2)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! refcount-target rc-frame)
+      (rf/reg-frame rc-frame {:doc "rf2-8u8tx.2 memo-recompute refcount probe frame"})
+      (rf/reg-event-db ::mr-seed (fn [_ _] {:m 0}))
+      (rf/dispatch-sync [::mr-seed] {:frame rc-frame})
+      (rf/reg-sub rc-query (fn [db _] (:m db)))
+      (let [cache-key-v [rc-query]
+            cache       (:sub-cache (frame/frame rc-frame))
+            mount-node  (make-mount-node!)
+            root        (react-dom-client/createRoot mount-node)
+            real-use-memo (.-useMemo React)]
+        ;; Patch React.useMemo to ALWAYS re-run the factory and ignore the
+        ;; deps cache — the worst case React's docs sanction ("you may rely
+        ;; on useMemo as a performance optimization, not as a semantic
+        ;; guarantee"). uix/helix's use-memo wrappers delegate to this, so the
+        ;; spine's memo factory re-subscribes on every render under the patch.
+        (set! (.-useMemo React)
+              (fn patched-use-memo [factory _deps] (factory)))
+        (try
+          (act-fn (fn [] (.render root (probe-refcount-element))))
+          (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+              "after mount the memo-recompute probe pins exactly one ref-count")
+          ;; Force several committed re-renders. Each re-render re-runs the
+          ;; (patched, always-recompute) memo factory ⇒ a fresh subscribe;
+          ;; the commit-owned reconcile must release every duplicate so the
+          ;; ref-count never climbs above 1.
+          (dotimes [_ 6]
+            (act-fn (fn [] (.render root (probe-refcount-element)))))
+          (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+              (str "ref-count stays pinned at exactly 1 across memo recomputes "
+                   "(NOT climbing per discarded memo) — observed "
+                   (or (get-in @cache [cache-key-v :ref-count]) 0)))
+          (act-fn (fn [] (.unmount root)))
+          (is (or (nil? (get @cache cache-key-v))
+                  (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+              "post-unmount the entry is dropped or its ref-count is 0 — no memo-recompute leak")
+          (finally
+            (set! (.-useMemo React) real-use-memo)
+            (try (.unmount root) (catch :default _ nil)))))))))
+
+(defn assert-use-subscribe-abandoned-render-no-refcount-leak
+  "rf2-879fe: a render that runs `use-subscribe` (memo factory subscribes,
+  +1 ref-count) and is then ABANDONED before commit must not pin the
+  sub-cache. We exercise the realistic concurrent-interrupt shape: a fiber
+  whose memo factory ran several render-phase acquisitions (interrupted +
+  restarted renders) and then committed. The committed render's reconcile
+  must drain those accumulated acquisitions back to exactly one live ref;
+  unmount returns it to zero. On the pre-fix spine each abandoned render's
+  +1 was pinned with no matching cleanup.
+
+  We simulate the multiple render-phase acquisitions by patching
+  `React.useMemo` to re-run its factory N times within a single render
+  commit (each re-run is an extra render-phase subscribe — equivalent to N
+  abandoned-then-restarted renders feeding the same fiber's ledger), then
+  assert no ref-count is pinned beyond the single committed subscription.
+
+  cfg keys: reuses the refcount-probe surface."
+  [{:keys [name probe-refcount-element refcount-target rc-frame rc-query]}]
+  (testing (str name " — use-subscribe abandoned/restarted render leaves no pinned ref-count (rf2-879fe)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! refcount-target rc-frame)
+      (rf/reg-frame rc-frame {:doc "rf2-879fe abandoned-render refcount probe frame"})
+      (rf/reg-event-db ::ar-seed (fn [_ _] {:m 0}))
+      (rf/dispatch-sync [::ar-seed] {:frame rc-frame})
+      (rf/reg-sub rc-query (fn [db _] (:m db)))
+      (let [cache-key-v   [rc-query]
+            cache         (:sub-cache (frame/frame rc-frame))
+            mount-node    (make-mount-node!)
+            root          (react-dom-client/createRoot mount-node)
+            real-use-memo (.-useMemo React)]
+        ;; Each render the memo factory is run 3 times — three render-phase
+        ;; `subscribe`s feeding the SAME fiber's ledger, modelling an
+        ;; abandoned-then-restarted concurrent render whose acquisitions
+        ;; accumulate before the eventual commit. React calls the factory
+        ;; itself once per useMemo; we re-run it the extra times here.
+        (set! (.-useMemo React)
+              (fn patched-use-memo [factory _deps]
+                (factory) (factory) (factory)))
+        (try
+          (act-fn (fn [] (.render root (probe-refcount-element))))
+          ;; The mount committed once. Three render-phase acquisitions landed
+          ;; on the ledger; the commit-owned reconcile must drain them to one.
+          (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+              (str "after a multi-acquisition (abandoned/restarted) render commits, "
+                   "exactly one ref-count is pinned — NOT one-per-render-phase-"
+                   "subscribe — observed "
+                   (or (get-in @cache [cache-key-v :ref-count]) 0)))
+          (act-fn (fn [] (.unmount root)))
+          (is (or (nil? (get @cache cache-key-v))
+                  (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+              "post-unmount: no pinned entry for the query — the abandoned-render acquisitions were reclaimed (rf2-879fe)")
+          (finally
+            (set! (.-useMemo React) real-use-memo)
+            (try (.unmount root) (catch :default _ nil)))))))))
+
 ;; ---- unsubscribe arity contract (rf2-gizlj) -------------------------------
 ;;
 ;; The shared spine's `use-subscribe` useEffect cleanup calls


### PR DESCRIPTION
## Summary

Three adapter-slice correctness findings, one PR.

### rf2-879fe (P1) + rf2-8u8tx.2 (P2) — use-subscribe render-phase ref-count leak (one root cause)

The React-hook spine's `use-subscribe` (`spine.cljs` `use-subscribe-2`) acquired the sub-cache ref by calling `subs/subscribe` inside the `useMemo` factory (render phase) and released it only via a deps-keyed `useEffect` cleanup. Two triggers leaked the ref-count:

- **rf2-879fe**: a concurrent render that ran `use-subscribe` and was abandoned before commit had no committed effect to release the `+1`.
- **rf2-8u8tx.2**: `useMemo` is a perf hint, not a lifecycle — React may discard a cached value and re-run the factory on unchanged deps; each re-run was another `subscribe` (`+1`) with no matching `unsubscribe`.

**Fix.** A `useRef` ledger records every render-phase acquisition keyed by a stable `frame|query` token. Two commit-owned effects *drive the ledger to target* by subscribing/unsubscribing the difference:
- a **no-deps reconcile effect** (runs after every commit, so a no-deps-change memo recompute is still seen) drives the live key to exactly one held ref and fully releases every superseded / abandoned key;
- a `[stable-key]`-keyed effect whose cleanup releases the live key on key-change / unmount.

Both share the same counter, so every `subscribe` is paired with exactly one `unsubscribe` regardless of how many times the factory runs or whether the render committed (Spec 006 §Reference counting and disposal). The spec contract was already correct — the implementation had drifted from it; no spec change needed.

**Regressions (UIx + Helix, in the shared suite):** a useMemo-recompute probe (patches `React.useMemo` to always re-run the factory) and an abandoned/restarted-render probe (factory run multiple times per commit). Both were verified to **fail on the pre-fix spine** (observed ref-count 7 and 3) and pass with the fix; existing committed-mount / StrictMode / stable-deps / arity tests stay green.

Also updates `docs/api/14-adapters.md`: the UIx/Helix `frame-provider` examples now show the idiomatic trailing-children shape `($ frame-provider {:frame …} child…)` instead of the removed `:children` prop-map form.

### rf2-8u8tx.1 (P2) — reagent-slim expand-seq truncation (separate)

`reagent-slim/.../template.cljs` `expand-seq` drove its loop with `(when-let [el (first items)] …)`, so a `nil`/`false` element anywhere in the seq terminated the loop — silently dropping that child and all subsequent ones (the idiomatic `(for [x xs] (when pred [:li …]))` conditional-list truncated at the first filtered row). Now iterates the whole seq off seq-exhaustion, emitting React null for `nil`/`false` (matching stock Reagent). Adds a regression with interior nil, interior false, and leading nil.

## Test plan

- `npm run test:cljs` (node-test): **5620 tests, 0 failures** (includes the reagent-slim expand-seq regressions).
- `npm run test:browser` (UIx + Helix DOM): **158 tests, 0 failures** (includes the two new ref-count-leak regressions; verified both fail on the pre-fix spine).
- Compile: 0 warnings on both builds.
- No `.cljc` substrate file touched, so the core JVM gate is not required.

Closes rf2-879fe, rf2-8u8tx.2, rf2-8u8tx.1.