### PR TITLE
fix(machines-viz): image exporters capture full chart + seam-keyed root (rf2-sr6l3)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1521,6 +1521,33 @@ EDN on the clipboard instead of the URL. Per
 
 ## Exporters
 
+### What the image exporters capture (rf2-sr6l3)
+
+`chart-as-svg` / `chart-as-png!` capture the **full rendered React Flow
+viewport** — the boxed state nodes, compound / region containers, event
+chips, final rings, labels, the **active-state border + glow
+affordance**, and the edge layer — **not** just the edge `<svg>`.
+
+The chart's visual grammar renders as **inline-styled DOM `<div>`
+nodes** inside `.react-flow__viewport`, *around* xyflow's edge
+`svg.react-flow__edges`. The exporters embed the live viewport DOM in a
+standalone SVG `<foreignObject>`; because every node component renders
+with inline styles, the `<foreignObject>` paints the same grammar the
+operator sees — including the current-state highlight — with no external
+stylesheet to embed. The viewport's own pan/zoom transform is
+neutralised and the SVG is sized to the union of the node flow-boxes, so
+the export frames the **whole topology at 1:1** regardless of the live
+zoom/pan.
+
+**Export-root discovery is keyed on the `_rfMvChartState` seam, not the
+default `data-testid`.** `MachineChart` stamps the seam on its root via
+`:ref` regardless of the host's `:testid` prop, so `chart-element` may
+be the chart **root**, a **descendant** node inside it, or a **wrapping
+element** around it, and the lookup resolves the same root — for the
+default *and* any custom `:testid`. (The prior implementation hard-coded
+`[data-testid='rf-mv-chart']`, which failed to find a custom-`:testid`
+chart from a wrapper / descendant.)
+
 ### PNG
 
 ```clojure
@@ -1533,24 +1560,33 @@ EDN on the clipboard instead of the URL. Per
 ;; => Promise; clipboard contains the PNG + a text/plain alt-text sidecar
 ```
 
-The PNG is rasterised at 2x DPR on a transparent background; the
-current-state highlight is included. An alt-text sidecar (a
-`text/plain` clipboard payload) summarises the machine: id, current
-state, node count, transition count.
+The PNG is rasterised at 2x DPR on a transparent background from the
+complete viewport SVG (above), so it includes the **state boxes** and
+the **current-state highlight** (the active node's accent border +
+box-shadow glow). An alt-text sidecar (a `text/plain` clipboard payload)
+summarises the machine: id, current state, node count, transition count.
 
 ### SVG
 
 ```clojure
 (export/chart-as-svg chart-element)
-;; => String — image/svg+xml with embedded fonts
+;; => String — image/svg+xml (a <foreignObject>-embedded viewport
+;;    capture) with embedded fonts
 
 (export/copy-svg-to-clipboard! chart-element)
 ;; => Promise; clipboard contains the SVG as image/svg+xml
 ```
 
-The SVG includes `<title>` and `<desc>` elements summarising the
-machine (same content as the PNG sidecar). Fonts are embedded so the
-SVG renders identically when pasted into a doc or a Figma frame.
+The SVG carries the full viewport (state boxes + active-state
+affordance + edges, per [§What the image exporters capture](#what-the-image-exporters-capture-rf2-sr6l3))
+plus `<title>` and `<desc>` elements summarising the machine (same
+content as the PNG sidecar). Fonts are embedded so the SVG renders with
+the same typography when pasted into a doc or a Figma frame.
+
+Both image exporters throw `:rf.machines-viz.export/no-svg` when the
+chart has not rendered a viewport yet (an empty / nil-definition
+placeholder renders no chart), and `:rf.machines-viz.export/no-chart-state`
+when `chart-element` resolves to no seam-bearing chart root.
 
 ### Share URL
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -22,14 +22,31 @@
   - **Mermaid** is the markdown-paste lane — lossy by design (`:after`
     rings + `:spawn-all` rows omitted; flagged inline). Delegates to
     `day8.re-frame2-machines-viz.mermaid/emit`.
-  - **SVG** serialises the live rendered xyflow `<svg>` with embedded
-    `<title>` / `<desc>` summarising the machine, so a screen-reader
-    pasting the artefact gets the same overview a sighted user has.
-  - **PNG** rasterises that SVG to a 2x-DPR `image/png` Blob on a
-    transparent background; a `text/plain` alt-text sidecar rides the
-    clipboard alongside the image.
+  - **SVG** serialises the FULL rendered React Flow viewport — the
+    boxed state nodes, compound/region containers, event chips, final
+    rings, labels, AND the active-state border/glow affordance, plus
+    the edge layer — by embedding the live viewport DOM in a
+    `<foreignObject>` (rf2-sr6l3). The node bodies render with inline
+    styles, so the foreignObject paints the same visual grammar a
+    sighted user sees, not just the edge `<svg>`. Embedded fonts +
+    `<title>` / `<desc>` summarise the machine for a screen-reader.
+  - **PNG** rasterises that complete SVG to a 2x-DPR `image/png` Blob
+    on a transparent background; a `text/plain` alt-text sidecar rides
+    the clipboard alongside the image. Because the SVG now carries the
+    whole viewport, the PNG includes the state boxes + the current-state
+    highlight (the contract `API.md` §PNG promises).
   - **Share URL** is the full-topology lossless lane — see
     `day8.re-frame2-machines-viz.share`.
+
+  ## Export-root discovery (rf2-sr6l3)
+
+  The export-root lookup is keyed on the `_rfMvChartState` SEAM, not the
+  default `data-testid`. `MachineChart` stamps the seam on its root via
+  `:ref` regardless of the host's `:testid` prop, so export works from
+  the chart root, a descendant node, OR a wrapping element, for the
+  default AND any custom `:testid`. (The prior implementation hard-coded
+  `[data-testid='rf-mv-chart']`, which broke export from a wrapper /
+  descendant of a custom-`:testid` chart.)
 
   Per [`API.md`](../../spec/API.md) §Exporters."
   (:require [clojure.string :as str]
@@ -38,29 +55,68 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Reading the chart-state seam off the DOM
+;;
+;; rf2-sr6l3 — export-root discovery is SEAM-DRIVEN, not testid-driven.
+;; `MachineChart` stamps `_rfMvChartState` on its root via `:ref` no
+;; matter what `:testid` the host passed, so keying on the seam means
+;; export resolves the same root for the default AND a custom `:testid`,
+;; and whether the caller hands us the root, a descendant node, or a
+;; wrapper. The former hard-coded `[data-testid='rf-mv-chart']` selector
+;; missed a custom-testid chart entirely.
 
-(def ^:private chart-testid "rf-mv-chart")
+(defn- has-seam?
+  "True when `el` is an element carrying the `_rfMvChartState` chart-state
+  seam (a CLJS map, as the chart root's `:ref` stamps it)."
+  [^js el]
+  (and (some? el) (map? (.-_rfMvChartState el))))
+
+(defn- ancestor-with-seam
+  "Walk `el` and its ancestors (via `.-parentElement`) returning the
+  first that carries the seam, or nil. Pure DOM walk — no selector — so
+  a custom-`:testid` chart resolves identically to the default."
+  [^js el]
+  (loop [^js node el]
+    (cond
+      (nil? node)      nil
+      (has-seam? node) node
+      :else            (recur (.-parentElement node)))))
+
+(defn- descendant-with-seam
+  "Find the first descendant of `el` carrying the seam (the caller passed
+  a WRAPPER around the chart). Seam-driven: queries broadly and keeps the
+  first match whose `_rfMvChartState` is present, so a custom-`:testid`
+  chart inside a wrapper is found. Returns nil when none is reachable."
+  [^js el]
+  (when (and el (.-querySelectorAll el))
+    ;; `[role='application']` is the chart root's stable, testid-
+    ;; independent attribute (set unconditionally in chart.cljs); it
+    ;; narrows the scan to plausible chart roots before the seam check.
+    ;; Falls back to `*` so a future chrome change can't strand the
+    ;; lookup.
+    (let [scan (fn [sel]
+                 (let [^js nodes (.querySelectorAll el sel)
+                       n         (.-length nodes)]
+                   (loop [i 0]
+                     (when (< i n)
+                       (let [^js node (aget nodes i)]
+                         (if (has-seam? node) node (recur (inc i))))))))]
+      (or (scan "[role='application']")
+          (scan "*")))))
 
 (defn- chart-root
   "Resolve the `MachineChart` root element from `el` — `el` itself when
-  it carries the `_rfMvChartState` seam, otherwise the nearest
-  ancestor / descendant that does. Returns nil when no chart root is
-  reachable."
+  it carries the `_rfMvChartState` seam, otherwise the nearest ancestor
+  carrying it (caller passed a descendant), otherwise the first
+  descendant carrying it (caller passed a wrapper). Returns nil when no
+  chart root is reachable.
+
+  rf2-sr6l3 — keyed on the SEAM, not the default `data-testid`, so it
+  works for the default AND a custom `:testid`, from the root, a
+  descendant, or a wrapper."
   [^js el]
   (when el
-    (cond
-      (some? (.-_rfMvChartState el)) el
-      ;; ancestor walk (caller passed a child node)
-      (and (.-closest el)
-           (.closest el (str "[data-testid='" chart-testid "']"))
-           (some? (.-_rfMvChartState
-                    ^js (.closest el (str "[data-testid='" chart-testid "']")))))
-      (.closest el (str "[data-testid='" chart-testid "']"))
-      ;; descendant lookup (caller passed a wrapper)
-      (and (.-querySelector el)
-           (.querySelector el (str "[data-testid='" chart-testid "']")))
-      (.querySelector el (str "[data-testid='" chart-testid "']"))
-      :else nil)))
+    (or (ancestor-with-seam el)
+        (descendant-with-seam el))))
 
 (defn- chart-state-of
   "Read the `chart-state` seam off `chart-element` as a CLJS map:
@@ -121,52 +177,224 @@
 
 ;; ---------------------------------------------------------------------------
 ;; SVG
+;;
+;; rf2-sr6l3 — the SVG export captures the WHOLE rendered React Flow
+;; viewport, not just the edge `<svg>`. The chart's visual grammar — the
+;; boxed state nodes, compound/region containers, event chips, final
+;; rings, labels, AND the active-state border/glow — renders as DOM
+;; (div) nodes inside `.react-flow__viewport`, AROUND xyflow's edge
+;; `svg.react-flow__edges`. The prior exporter cloned only that edge svg,
+;; so every node body + the current-state highlight were lost.
+;;
+;; The fix embeds the live viewport DOM in a `<foreignObject>` inside a
+;; standalone SVG. Two facts make this faithful AND self-contained:
+;;
+;;   1. Every node component (chart.nodes/*) renders with INLINE styles
+;;      (`:style {...}` on each div — box geometry, border, header wash,
+;;      box-shadow glow, fonts). Inline styles travel with the cloned
+;;      HTML, so the foreignObject paints the same grammar the operator
+;;      sees with no external stylesheet to embed.
+;;   2. xyflow positions each `.react-flow__node` wrapper with an inline
+;;      `transform: translate(Xpx,Ypx)` in FLOW coordinates and renders
+;;      edges in the same flow space. We reset the cloned viewport's own
+;;      pan/zoom transform to identity and size the SVG to the union of
+;;      the node flow-boxes, so the export frames the WHOLE topology at
+;;      1:1 regardless of the live zoom/pan.
 
-(def ^:private svg-font-face
-  "Embedded font-face so the SVG renders with the same mono typography
-  when pasted into a doc or Figma frame (per API.md §SVG — fonts are
-  embedded). Uses a `local()` src so the artefact stays small; falls
-  back to the platform mono stack."
-  "<style>text{font-family:'JetBrains Mono','SF Mono',Menlo,Consolas,monospace;}</style>")
+(def ^:private viewport-css
+  "The minimal xyflow positioning rules the cloned viewport needs, plus
+  the embedded font + edge-path defaults — embedded as a `<style>` inside
+  the export SVG so the `<foreignObject>` lays the chart out correctly.
 
-(defn- find-svg
-  "Locate the rendered xyflow `<svg>` inside `root`. xyflow renders the
-  edges into an `svg.react-flow__edges`; we serialise the full chart by
-  cloning the chart root's first `<svg>`. Returns the SVG element or
-  nil."
-  [root]
+  rf2-sr6l3 — xyflow positions the `.react-flow__node` wrappers via its
+  EXTERNAL stylesheet (`@xyflow/react/dist/base.css` —
+  `position:absolute; transform-origin:0 0`), NOT inline styles. The node
+  BODIES carry inline styles (box, border, header wash, box-shadow glow),
+  but without the wrapper positioning rules a cloned viewport collapses
+  every node to the origin — and a foreignObject has no access to the
+  page stylesheet, so the rules MUST travel inside the SVG. Mirrors the
+  load-bearing subset of base.css (kept narrow + commented so a future
+  xyflow bump is auditable):
+
+    - `.react-flow__node` / `.react-flow__nodes` — absolute positioning +
+      `transform-origin:0 0` so each wrapper's inline
+      `transform:translate(x,y)` lands the node at its flow position.
+    - `.react-flow__edges` (+ its `svg`) — absolute overflow-visible so
+      the edge layer overlays the nodes in the same flow space.
+    - `.react-flow__edge-path` / `text` — stroke/fill + font defaults so
+      edges + edge labels paint (the node-body fonts are inline; the
+      `text,foreignObject *` rule is a safe default for anything that
+      isn't)."
+  (str "<style>"
+       "text,foreignObject *{"
+       "font-family:'JetBrains Mono','SF Mono',Menlo,Consolas,monospace;}"
+       ;; `.react-flow__container` (the class the viewport ALSO carries):
+       ;; position:absolute + full-size. WITHOUT this the cloned viewport
+       ;; has no box, so `.react-flow__nodes`/`.react-flow__edges`
+       ;; (width/height:100%) collapse to 0×0 and the whole capture
+       ;; rasterises BLANK (rf2-sr6l3 — the silent-blank root cause).
+       ".react-flow__container{position:absolute;width:100%;height:100%;"
+       "top:0;left:0;}"
+       ".react-flow__node{position:absolute;transform-origin:0 0;"
+       "box-sizing:border-box;}"
+       ".react-flow__nodes{position:absolute;width:100%;height:100%;"
+       "top:0;left:0;transform-origin:0 0;}"
+       ".react-flow__edges{position:absolute;overflow:visible;}"
+       ".react-flow__edges svg{overflow:visible;position:absolute;}"
+       ".react-flow__edge-path{fill:none;}"
+       ".react-flow__handle{position:absolute;}"
+       "</style>"))
+
+(def ^:private svg-padding
+  "Margin (flow px) reserved around the union node-box so node borders /
+  glow rings + edge arrowheads aren't clipped at the SVG edge."
+  24)
+
+(defn- find-edge-svg
+  "Locate the rendered xyflow edge `<svg>` inside `root` (the
+  `svg.react-flow__edges`, or the first `<svg>` as a fallback). Returns
+  the SVG element or nil. Used only to detect that the chart has
+  rendered (the EXPORT no longer clones this svg alone — see
+  `chart-as-svg`)."
+  [^js root]
   (when (and root (.-querySelector root))
-    (.querySelector root "svg")))
+    (or (.querySelector root "svg.react-flow__edges")
+        (.querySelector root "svg"))))
+
+(defn- find-viewport
+  "Locate the `.react-flow__viewport` inside the chart root — the element
+  xyflow pans/zooms, holding both the node-wrapper divs and the edge
+  `<svg>` in flow coordinates. Returns nil when absent (e.g. the chart
+  has not committed yet)."
+  [^js root]
+  (when (and root (.-querySelector root))
+    (.querySelector root ".react-flow__viewport")))
+
+(defn- node-flow-box
+  "Read a `.react-flow__node` wrapper's FLOW-space box `{:x :y :w :h}`
+  from its inline `transform: translate(Xpx,Ypx)` (xyflow's positioning)
+  + its rendered `offsetWidth`/`offsetHeight`. Returns nil when the
+  transform can't be parsed (degenerate / not yet positioned)."
+  [^js wrapper]
+  (let [transform (some-> wrapper .-style .-transform)
+        m         (when (string? transform)
+                    (re-find #"translate\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px\s*\)"
+                             transform))]
+    (when m
+      {:x (js/parseFloat (nth m 1))
+       :y (js/parseFloat (nth m 2))
+       :w (or (.-offsetWidth wrapper) 0)
+       :h (or (.-offsetHeight wrapper) 0)})))
+
+(defn- viewport-content-bounds
+  "Union the flow-space boxes of every `.react-flow__node` wrapper under
+  `viewport` into `{:min-x :min-y :width :height}` (flow px), padded by
+  `svg-padding`. Returns a sensible default box when no node wrapper is
+  measurable yet (so the export still frames the edge svg + degrades
+  gracefully)."
+  [^js viewport]
+  (let [^js wrappers (when (.-querySelectorAll viewport)
+                       (.querySelectorAll viewport ".react-flow__node"))
+        n            (if wrappers (.-length wrappers) 0)
+        boxes        (->> (range n)
+                          (keep (fn [i] (node-flow-box (aget wrappers i))))
+                          (filterv (fn [{:keys [w h]}] (and (pos? w) (pos? h)))))]
+    (if (seq boxes)
+      (let [min-x (reduce min (map :x boxes))
+            min-y (reduce min (map :y boxes))
+            max-x (reduce max (map (fn [{:keys [x w]}] (+ x w)) boxes))
+            max-y (reduce max (map (fn [{:keys [y h]}] (+ y h)) boxes))]
+        {:min-x  (- min-x svg-padding)
+         :min-y  (- min-y svg-padding)
+         :width  (+ (- max-x min-x) (* 2 svg-padding))
+         :height (+ (- max-y min-y) (* 2 svg-padding))})
+      {:min-x 0 :min-y 0 :width 800 :height 600})))
+
+(defn- clone-viewport-html
+  "Clone `viewport` deep, neutralise its pan/zoom transform (re-based to
+  the content origin so the union box starts at (0,0) inside the
+  foreignObject), and serialise it to a WELL-FORMED XML string via
+  `XMLSerializer`. The node-wrapper transforms INSIDE the viewport stay
+  intact (they carry each node's flow position); only the viewport's OWN
+  transform is re-based. The clone's inline styles carry the full visual
+  grammar.
+
+  rf2-sr6l3 — serialised with `XMLSerializer`, NOT `.-outerHTML`. A
+  `<foreignObject>` parses its contents as XML, and Chromium SILENTLY
+  RENDERS THE FOREIGNOBJECT BLANK when that subtree isn't well-formed XML
+  (HTML's `.outerHTML` can emit void elements unclosed + leave some
+  attributes/entities un-escaped — invalid as XML). `XMLSerializer`
+  emits conformant, self-closing, entity-escaped XML, and stamping the
+  clone with the XHTML namespace makes the browser parse the embedded
+  markup as HTML-equivalent content rather than opaque foreign XML.
+
+  (The OTHER precondition for a non-blank raster is that the chart has
+  actually LAID OUT: xyflow keeps every node `visibility:hidden` until
+  the async elkjs pass delivers positions, so a capture taken before
+  layout settles rasterises blank — call the exporters on a settled
+  chart, which is the normal host path.)"
+  [^js viewport {:keys [min-x min-y]}]
+  (let [^js clone (.cloneNode viewport true)]
+    (set! (.. clone -style -transform)
+          (str "translate(" (- min-x) "px," (- min-y) "px) scale(1)"))
+    (set! (.. clone -style -transformOrigin) "0 0")
+    ;; Stamp the XHTML namespace so the foreignObject subtree is parsed as
+    ;; HTML content (not opaque XML), and serialise to well-formed XML.
+    (.setAttribute clone "xmlns" "http://www.w3.org/1999/xhtml")
+    (.serializeToString (js/XMLSerializer.) clone)))
 
 (defn chart-as-svg
-  "Serialise the rendered chart to an `image/svg+xml` string with
+  "Serialise the FULL rendered chart to an `image/svg+xml` string —
+  boxed state nodes, compound/region containers, event chips, final
+  rings, labels, the active-state border/glow, AND the edge layer — with
   embedded fonts + a `<title>` / `<desc>` machine summary.
 
-  `chart-element` is the in-DOM element rendered by `MachineChart`.
-  Returns the SVG string, or throws `:no-svg` when the chart has not
-  rendered an `<svg>` yet (empty-state placeholders render no SVG)."
+  rf2-sr6l3 — captures the live `.react-flow__viewport` DOM inside a
+  `<foreignObject>` (the visual grammar renders as inline-styled divs
+  AROUND the edge `<svg>`, so cloning only that edge svg — the prior
+  behaviour — lost every node body + the current-state highlight). The
+  viewport's own pan/zoom is neutralised and the SVG is sized to the
+  union node-box, so the export frames the whole topology at 1:1
+  regardless of the live zoom.
+
+  `chart-element` is the in-DOM element rendered by `MachineChart` (the
+  root, a descendant, or a wrapper — the root is resolved off the
+  `_rfMvChartState` seam). Returns the SVG string, or throws `:no-svg`
+  when the chart has not rendered a viewport yet (empty-state
+  placeholders render no chart)."
   [chart-element]
-  (let [root (chart-root chart-element)
-        cs   (chart-state-of chart-element)
-        svg  (find-svg root)]
-    (when-not svg
+  (let [^js root (chart-root chart-element)
+        cs       (chart-state-of chart-element)
+        viewport (find-viewport root)]
+    (when-not (and viewport (find-edge-svg root))
       (throw (ex-info ":rf.machines-viz.export/no-svg"
                       {:rf.error/id :rf.machines-viz.export/no-svg
                        :where       'machines-viz.export/chart-as-svg
                        :recovery    :no-recovery
-                       :reason      "chart has no rendered <svg> to serialise"})))
-    (let [clone   (.cloneNode svg true)
+                       :reason      "chart has no rendered viewport to serialise"})))
+    (let [{:keys [width height] :as bounds} (viewport-content-bounds viewport)
+          inner   (clone-viewport-html viewport bounds)
           summary (alt-text cs)
           title   (str "<title>" (name (or (:machine-id cs) :machine)) "</title>")
           desc    (str "<desc>" summary "</desc>")
-          ;; Ensure the xmlns is present so the standalone string renders.
-          _       (.setAttribute clone "xmlns" "http://www.w3.org/2000/svg")
-          markup  (.-outerHTML clone)
-          ;; Inject <title>/<desc>/<style> right after the opening <svg ...>.
-          insert-at (inc (or (str/index-of markup ">") 0))]
-      (str (subs markup 0 insert-at)
-           title desc svg-font-face
-           (subs markup insert-at)))))
+          w       (max 1 (js/Math.ceil width))
+          h       (max 1 (js/Math.ceil height))]
+      ;; A standalone SVG framing the whole topology. The viewport HTML
+      ;; lives in a `<foreignObject>` (xhtml namespace required so the
+      ;; embedded markup renders as HTML, not opaque XML); inline styles
+      ;; carry the node grammar + active-state affordance.
+      (str "<svg xmlns=\"http://www.w3.org/2000/svg\" "
+           "xmlns:xhtml=\"http://www.w3.org/1999/xhtml\" "
+           "width=\"" w "\" height=\"" h "\" "
+           "viewBox=\"0 0 " w " " h "\">"
+           title desc viewport-css
+           "<foreignObject x=\"0\" y=\"0\" width=\"" w "\" height=\"" h "\">"
+           "<div xmlns=\"http://www.w3.org/1999/xhtml\" "
+           "style=\"width:" w "px;height:" h "px;position:relative;overflow:hidden;\">"
+           inner
+           "</div>"
+           "</foreignObject>"
+           "</svg>"))))
 
 (defn copy-svg-to-clipboard!
   "Write the chart's SVG to the clipboard as `image/svg+xml`. Returns a
@@ -186,24 +414,29 @@
 ;; PNG
 
 (defn chart-as-png!
-  "Rasterise the chart to an `image/png` Blob at 2x DPR on a
+  "Rasterise the FULL chart to an `image/png` Blob at 2x DPR on a
   transparent background. Returns a Promise resolving to the Blob.
 
-  Pipeline: serialise the chart's SVG → load it into an `<img>` via a
-  data-URL → draw onto a 2x-DPR `<canvas>` → `canvas.toBlob`. The
-  current-state affordance lives on the node-box BORDER + box-shadow
-  ring (xyflow div-nodes), not on the SVG; the serialised SVG carries
-  the rendered edges (incl. fired/focused edge styling), so the PNG
-  frames the topology + edge highlights as rendered."
+  Pipeline: serialise the chart's complete SVG (the foreignObject-
+  embedded viewport — `chart-as-svg`) → load it into an `<img>` via a
+  data-URL → draw onto a 2x-DPR `<canvas>` → `canvas.toBlob`.
+
+  rf2-sr6l3 — the SVG now carries the WHOLE rendered viewport (boxed
+  state nodes, event chips, containers, labels) INCLUDING the
+  current-state affordance (the active node's accent BORDER + box-shadow
+  GLOW ring, rendered as inline-styled DOM), so the PNG includes the
+  state boxes + the current-state highlight the API.md §PNG contract
+  promises — not just the edge layer the prior implementation captured.
+  The canvas size is the SVG's framed-topology box (the union node-box
+  from the viewport, NOT the edge-svg bbox)."
   [chart-element]
-  (let [svg-str (chart-as-svg chart-element)
-        root    (chart-root chart-element)
-        svg     (find-svg root)
-        bbox    (when (.-getBoundingClientRect svg)
-                  (.getBoundingClientRect svg))
-        w       (max 1 (js/Math.ceil (or (some-> bbox .-width) 800)))
-        h       (max 1 (js/Math.ceil (or (some-> bbox .-height) 600)))
-        dpr     2
+  (let [svg-str  (chart-as-svg chart-element)
+        ^js root (chart-root chart-element)
+        viewport (find-viewport root)
+        {:keys [width height]} (viewport-content-bounds viewport)
+        w        (max 1 (js/Math.ceil width))
+        h        (max 1 (js/Math.ceil height))
+        dpr      2
         data-url (str "data:image/svg+xml;charset=utf-8,"
                       (js/encodeURIComponent svg-str))]
     (js/Promise.

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
@@ -1,0 +1,415 @@
+(ns day8.re-frame2-machines-viz.export-dom-cljs-test
+  "Browser-side CLJS regression for the chart IMAGE exporters (rf2-sr6l3).
+
+  ## Why this exists
+
+  The PNG / SVG image exporters were EDGE-ONLY: they cloned the first
+  xyflow `<svg>` (the edge layer) and rasterised THAT. But the chart's
+  visual grammar — boxed state nodes, compound/region containers, event
+  chips, final rings, labels, AND the active-state border/glow — renders
+  as inline-styled DOM divs inside `.react-flow__viewport`, AROUND the
+  edge svg. So `chart-as-svg` / `chart-as-png!` could not faithfully
+  export the topology and in particular MISSED the active-state
+  highlight the `API.md` §PNG / §SVG contract promises.
+
+  rf2-sr6l3 reworks the exporters to capture the WHOLE rendered viewport
+  via a `<foreignObject>` (the node bodies' inline styles carry the
+  grammar + the active-affordance) and to resolve the export root off the
+  `_rfMvChartState` SEAM rather than the hard-coded default `data-testid`
+  (so export works from the root / a descendant / a wrapper, for the
+  default AND a custom `:testid`).
+
+  This suite FAILS against the prior edge-only / testid-keyed
+  implementation:
+
+    - the SVG no longer carries any state-box text (edge-only svg has no
+      node bodies) → `svg-includes-state-boxes-and-active-affordance`
+      fails;
+    - the active-affordance attr never appears in the edge-only svg →
+      same test fails;
+    - a custom-`:testid` chart's export from a wrapper threw
+      `:no-chart-state` under the hard-coded selector →
+      `export-resolves-root-from-wrapper-and-custom-testid` fails.
+
+  The share-url + Mermaid lanes are unchanged and stay covered by
+  `export_cljs_test.cljs` (the node-runtime seam tests).
+
+  ## Target
+
+  ns ends in `-dom-cljs-test` so it runs under the `:browser-test`
+  build (real DOM + headless Chromium, real canvas / Image / SVG
+  rasterisation) per `shadow-cljs.edn` (rf2-2hrj8). Under `:node-test`
+  (no DOM) every test short-circuits via `(browser?)` and asserts a
+  trivial truth so the suite stays green on both targets.
+
+  ## Mounting + async note
+
+  Mounts via the substrate-adapter React bridge under React `act()`
+  (same path as `chart_dom_cljs_test`). The node DOM + the
+  `_rfMvChartState` seam + the inline node styles all land on the FIRST
+  commit (they do not depend on the async elkjs layout pass — which only
+  repositions already-mounted nodes), so `chart-as-svg`'s viewport
+  capture is exercisable synchronously. The PNG raster is async (an
+  `<img>` onload), so those tests use `cljs.test`'s `async` form and
+  unmount only after the Promise settles."
+  (:require ["react"            :as React]
+            ["react-dom/client" :as react-dom-client]
+            [clojure.string :as str]
+            [cljs.test :refer-macros [deftest is testing async]]
+            [day8.re-frame2-machines-viz.adapters.react-chart :as react-chart]
+            [day8.re-frame2-machines-viz.export :as export]
+            [day8.re-frame2-machines-viz.share :as share]))
+
+;; ---- sample machine -----------------------------------------------------
+
+(def ^:private idle-loading-done
+  "4 states, 3 transitions. `:loading` is the active state in the tests
+  that pin the current-state highlight."
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :done :err :failed}}
+             :done    {:final? true}
+             :failed  {:final? true}}})
+
+;; ---- DOM mount helpers (mirror chart_dom_cljs_test) ---------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [test-utils (js/require "react-dom/test-utils")]
+          (.-act test-utils))
+        (catch :default _ nil))))
+
+(defn- enable-react-act-env! []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+(defn- mount-node!
+  "Create a sized host div (xyflow needs a non-zero parent box to lay
+  out). The chart mounts INTO this host, so the host is itself a WRAPPER
+  around the chart root — which is what the wrapper-path export tests
+  hand to the exporters."
+  []
+  (let [el (.createElement js/document "div")]
+    (set! (.. el -style -width) "800px")
+    (set! (.. el -style -height) "600px")
+    (.appendChild (.-body js/document) el)
+    el))
+
+(defn- with-mounted-chart
+  "Mount `MachineChart` with `props` via the React bridge under act(),
+  call `(f host-node)` with the HOST node (the outer mount div — NOT the
+  chart root, so the export-root resolution is genuinely exercised), then
+  unmount. Returns nil when no DOM / no act() (the caller asserts the
+  skip)."
+  [props f]
+  (let [act-fn (get-act)]
+    (when (and (browser?) act-fn)
+      (enable-react-act-env!)
+      (let [node (mount-node!)
+            root (react-dom-client/createRoot node)]
+        (try
+          (act-fn (fn [] (.render root (react-chart/chart-element props))))
+          (f node)
+          (finally
+            (try (act-fn (fn [] (.unmount root))) (catch :default _ nil))
+            (try (.removeChild (.-body js/document) node) (catch :default _ nil))))))))
+
+(defn- chart-root-of
+  "The chart root element (carries the `_rfMvChartState` seam +
+  `role=application`) under host `node`, for the given `:testid`."
+  [^js node testid]
+  (.querySelector node (str "[data-testid=\"" testid "\"]")))
+
+(defn- layout-settled?
+  "True once xyflow has laid the chart out: at least one state-node
+  wrapper exists AND none are still `visibility:hidden` (xyflow hides
+  every node until the async elkjs pass delivers positions + it has
+  measured them). Until then a raster of the viewport is BLANK — every
+  node is hidden — so the PNG test must wait for this before capturing."
+  [^js node]
+  (let [wrappers (.querySelectorAll node ".react-flow__node")
+        n        (.-length wrappers)]
+    (and (pos? n)
+         (loop [i 0]
+           (if (< i n)
+             (let [^js w (aget wrappers i)
+                   vis   (.. w -style -visibility)]
+               (if (= "hidden" vis) false (recur (inc i))))
+             true)))))
+
+(defn- with-mounted-chart-after-layout
+  "Mount `MachineChart`, then WAIT (polling) for the async elkjs layout to
+  settle so every node is visible + positioned, then call `(f host-node
+  finish)`. `finish` unmounts + removes the host. The caller MUST call
+  `finish` (then `done`). No-op (calls `(skip)`) when no DOM / no act().
+
+  Unlike `with-mounted-chart` (synchronous, pre-layout), this awaits the
+  real rendered chart — required for the PNG raster, whose foreignObject
+  capture of a pre-layout chart would be blank (all nodes hidden)."
+  [props f skip]
+  (let [act-fn (get-act)]
+    (if-not (and (browser?) act-fn)
+      (skip)
+      (do
+        (enable-react-act-env!)
+        (let [node   (mount-node!)
+              root   (react-dom-client/createRoot node)
+              finish (fn []
+                       (try (act-fn (fn [] (.unmount root))) (catch :default _ nil))
+                       (try (.removeChild (.-body js/document) node) (catch :default _ nil)))
+              deadline (+ (js/Date.now) 8000)]
+          (act-fn (fn [] (.render root (react-chart/chart-element props))))
+          ;; Poll for layout settle. Each tick we flush React under act()
+          ;; (so any elkjs-settle-driven re-render commits), then check the
+          ;; DOM. setTimeout (not a single rAF) so the elkjs Promise +
+          ;; measure-relayout passes have real time to resolve.
+          (letfn [(tick []
+                    (act-fn (fn [] nil)) ;; flush pending React work
+                    (cond
+                      (layout-settled? node) (f node finish)
+                      (> (js/Date.now) deadline)
+                      (do
+                        ;; Timed out — still call f so the test can report a
+                        ;; meaningful failure rather than hang.
+                        (f node finish))
+                      :else (js/setTimeout tick 50)))]
+            (js/setTimeout tick 50)))))))
+
+;; ---- 1. SVG carries the node grammar + active-state affordance ----------
+
+(deftest svg-includes-state-boxes-and-active-affordance
+  (testing "rf2-sr6l3 — chart-as-svg captures the FULL viewport: the
+            exported SVG carries the state-box text (state labels), is a
+            `<foreignObject>`-wrapped capture (not the bare edge svg), and
+            includes the active-state affordance (`data-active-affordance`
+            on the highlighted `:loading` node). The prior edge-only
+            exporter carried NONE of these."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done
+         :current-state :loading}
+        (fn [node]
+          (let [svg (export/chart-as-svg (chart-root-of node "rf-mv-chart"))]
+            (is (string? svg) "chart-as-svg returns a string")
+            ;; It is a full-viewport capture, NOT the bare edge svg.
+            (is (str/includes? svg "foreignObject")
+                "the SVG embeds the viewport via foreignObject")
+            ;; State BOX text — the node labels render in the captured
+            ;; node bodies (edge-only svg had no node text).
+            (is (str/includes? svg "loading")
+                "the SVG carries state-box text (the :loading label)")
+            (is (str/includes? svg "idle")
+                "the SVG carries state-box text (the :idle label)")
+            ;; The active-state AFFORDANCE rides on the captured node DOM:
+            ;; the highlighted leaf carries data-active-affordance=true +
+            ;; a box-shadow glow. Pin the attr (deterministic) AND the
+            ;; box-shadow (the visible glow ring).
+            (is (str/includes? svg "data-active-affordance=\"true\"")
+                "the SVG includes the active-state affordance attr")
+            (is (str/includes? svg "box-shadow")
+                "the active node's inline box-shadow glow survives the capture")
+            ;; <title>/<desc> machine summary (accessibility) preserved.
+            (is (str/includes? svg "<title>")
+                "the SVG carries the <title> machine summary")
+            (is (str/includes? svg "<desc>")
+                "the SVG carries the <desc> machine summary")))))))
+
+(deftest svg-without-active-state-has-no-affordance
+  (testing "rf2-sr6l3 — without :current-state the export carries the
+            state boxes but NO active-affordance attr set true (control:
+            proves the affordance assertion above is signal, not noise)."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [node]
+          (let [svg (export/chart-as-svg (chart-root-of node "rf-mv-chart"))]
+            (is (str/includes? svg "loading")
+                "state boxes still captured with no highlight")
+            (is (not (str/includes? svg "data-active-affordance=\"true\""))
+                "no active node → no true active-affordance in the export")))))))
+
+;; ---- 2. PNG rasterises the full chart (state box + affordance) ----------
+
+(defn- png-blob->image-data
+  "Decode a PNG Blob into the canvas `ImageData` of its raster (so the
+  test can prove the raster is non-empty — i.e. node content actually
+  drew, not just a transparent edge layer). Returns a Promise resolving
+  to `{:width :height :non-transparent-px <int>}`."
+  [blob]
+  (js/Promise.
+    (fn [resolve reject]
+      (let [url (.createObjectURL js/URL blob)
+            img (js/Image.)]
+        (set! (.-onload img)
+              (fn []
+                (try
+                  (let [w (.-width img) h (.-height img)
+                        canvas (.createElement js/document "canvas")]
+                    (set! (.-width canvas) w)
+                    (set! (.-height canvas) h)
+                    (let [ctx (.getContext canvas "2d")]
+                      (.drawImage ctx img 0 0)
+                      (let [data (.-data (.getImageData ctx 0 0 w h))
+                            n    (.-length data)
+                            ;; count pixels with a non-zero alpha channel
+                            non-transparent
+                            (loop [i 3 acc 0]
+                              (if (< i n)
+                                (recur (+ i 4) (if (pos? (aget data i)) (inc acc) acc))
+                                acc))]
+                        (.revokeObjectURL js/URL url)
+                        (resolve {:width w :height h
+                                  :non-transparent-px non-transparent}))))
+                  (catch :default e
+                    (.revokeObjectURL js/URL url)
+                    (reject e)))))
+        (set! (.-onerror img)
+              (fn [_]
+                (.revokeObjectURL js/URL url)
+                (reject (js/Error. "decode of exported PNG failed"))))
+        (set! (.-src img) url)))))
+
+(deftest png-rasterises-full-chart-with-content
+  (testing "rf2-sr6l3 — chart-as-png! resolves to an image/png Blob whose
+            raster is NON-EMPTY (the laid-out node boxes + the
+            active-state glow actually drew onto the canvas). The prior
+            edge-only PNG on a transparent background carried no node
+            boxes. Proves the foreignObject viewport capture rasterises
+            end to end — once the elkjs layout has settled (nodes are
+            `visibility:hidden` until then, so we await layout)."
+    (async done
+      (with-mounted-chart-after-layout
+        {:machine-id :test/flow :definition idle-loading-done
+         :current-state :loading}
+        (fn [node finish]
+          (is (layout-settled? node)
+              "elkjs layout settled — nodes are visible + positioned for capture")
+          (-> (export/chart-as-png! (chart-root-of node "rf-mv-chart"))
+              (.then
+                (fn [blob]
+                  (is (instance? js/Blob blob) "resolves to a Blob")
+                  (is (= "image/png" (.-type blob)) "the Blob is image/png")
+                  (is (pos? (.-size blob)) "the PNG Blob is non-empty bytes")
+                  (png-blob->image-data blob)))
+              (.then
+                (fn [{:keys [width height non-transparent-px]}]
+                  (is (pos? width) "the PNG has a positive width")
+                  (is (pos? height) "the PNG has a positive height")
+                  (is (pos? non-transparent-px)
+                      "the PNG raster has drawn (non-transparent) content —
+                       the node boxes + the active-state glow, not a blank
+                       transparent edge layer")
+                  (finish)
+                  (done)))
+              (.catch
+                (fn [e]
+                  (is false (str "chart-as-png! rejected: " e))
+                  (finish)
+                  (done)))))
+        ;; skip (no DOM / no act)
+        (fn []
+          (is true ":node-test: no DOM — browser-test runner exercises this")
+          (done))))))
+
+;; ---- 3. export-root resolution: root / descendant / wrapper -------------
+;;        for default AND custom :testid (seam-keyed, not testid-keyed)
+
+(deftest export-resolves-root-from-root-descendant-and-wrapper
+  (testing "rf2-sr6l3 — chart-as-svg resolves the export root off the
+            `_rfMvChartState` seam, so it works when called with the chart
+            ROOT, a DESCENDANT node inside it, or a WRAPPER element around
+            it. All three must produce the same node-bearing SVG."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done
+         :current-state :loading}
+        (fn [node]
+          (let [root (chart-root-of node "rf-mv-chart")
+                ;; a descendant node deep inside the chart (a state node)
+                descendant (.querySelector node "[data-testid^=\"rf-mv-chart-node-\"]")
+                ;; the host `node` is itself a WRAPPER around the chart root
+                wrapper node]
+            (is (some? root) "chart root mounted")
+            (is (some? descendant) "a descendant state-node mounted")
+            ;; 1 — from the ROOT.
+            (is (str/includes? (export/chart-as-svg root) "loading")
+                "export from the chart root carries node text")
+            ;; 2 — from a DESCENDANT (ancestor-seam walk).
+            (is (str/includes? (export/chart-as-svg descendant) "loading")
+                "export from a descendant resolves the root via the seam ancestor-walk")
+            ;; 3 — from a WRAPPER (descendant-seam search).
+            (is (str/includes? (export/chart-as-svg wrapper) "loading")
+                "export from a wrapper resolves the root via the seam descendant-search")))))))
+
+(deftest export-resolves-root-from-wrapper-and-custom-testid
+  (testing "rf2-sr6l3 — the seam-keyed lookup works for a CUSTOM `:testid`
+            too. The prior hard-coded `[data-testid='rf-mv-chart']`
+            selector found NOTHING for a custom-testid chart, so export
+            from a wrapper / descendant threw `:no-chart-state`. With the
+            seam-keyed lookup, export from the wrapper (host node) AND from
+            a descendant resolves the custom-testid chart and carries the
+            node grammar."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done
+         :current-state :loading
+         :testid "my-custom-chart"}
+        (fn [node]
+          (let [root (chart-root-of node "my-custom-chart")
+                descendant (.querySelector node "[data-testid^=\"rf-mv-chart-node-\"]")]
+            (is (some? root) "custom-testid chart root mounted")
+            ;; from the wrapper (host node) — descendant-seam search.
+            (let [svg (export/chart-as-svg node)]
+              (is (str/includes? svg "loading")
+                  "export from a wrapper resolves a CUSTOM-testid chart via the seam")
+              (is (str/includes? svg "data-active-affordance=\"true\"")
+                  "the active affordance survives for a custom-testid chart too"))
+            ;; from a descendant — ancestor-seam walk.
+            (is (str/includes? (export/chart-as-svg descendant) "loading")
+                "export from a descendant of a custom-testid chart resolves the root")
+            ;; from the root itself.
+            (is (str/includes? (export/chart-as-svg root) "loading")
+                "export from the custom-testid root carries node text")))))))
+
+;; ---- 4. share-url + mermaid lanes stay unchanged (regression guard) -----
+
+(deftest share-url-and-mermaid-unchanged-on-live-chart
+  (testing "rf2-sr6l3 — reworking the IMAGE exporters leaves the share-url
+            + Mermaid lanes intact: both still derive off the live chart's
+            seam, from the root AND a wrapper. (The node-runtime seam tests
+            in export_cljs_test cover the stub-element path; this guards
+            the live-DOM path stays equivalent.)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done
+         :current-state :loading}
+        (fn [node]
+          (let [root (chart-root-of node "rf-mv-chart")]
+            ;; share-url from the live chart root round-trips.
+            (let [url (export/share-url root)
+                  cs  (:rf.machines-viz.share/chart (share/decode-share-url url))]
+              (is (str/includes? url "#machine=") "share-url is a machine fragment")
+              (is (= :test/flow (:machine-id cs)) "share-url carries the machine-id")
+              (is (= idle-loading-done (:definition cs))
+                  "share-url carries the full definition")
+              (is (= {:state :loading} (:snapshot cs))
+                  "share-url carries the active-state name (no :data)"))
+            ;; share-url from the WRAPPER resolves the same root.
+            (is (str/includes? (export/share-url node) "#machine=")
+                "share-url resolves from a wrapper via the seam too")
+            ;; Mermaid lane still emits a fenced stateDiagram from the seam.
+            (let [md (export/chart-as-mermaid root)]
+              (is (str/includes? md "stateDiagram-v2")
+                  "chart-as-mermaid still emits a stateDiagram from the live seam")
+              (is (str/includes? md "mermaid")
+                  "chart-as-mermaid still fences the block"))))))))


### PR DESCRIPTION
Closes rf2-sr6l3 (P1).

## Problem

The machines-viz PNG/SVG image exporters were **edge-only**: `chart-as-svg` located the first xyflow `<svg>` (the edge layer), cloned it, and rasterised that. But the chart's visual grammar — boxed state nodes, compound/region containers, event chips, final rings, labels, **and the active-state border/glow** — renders as inline-styled DOM `<div>` nodes inside `.react-flow__viewport`, *around* the edge svg. So `chart-as-svg` / `chart-as-png!` could not faithfully export the topology and in particular **missed the current-state highlight** the `API.md` §PNG/§SVG contract promises.

Second defect: export-root discovery hard-coded `[data-testid='rf-mv-chart']`, so export from a descendant/wrapper of a **custom-`:testid`** chart threw `:no-chart-state` even though `:testid` is a public prop.

## Fix

- **`chart-as-svg`** captures the **whole rendered React Flow viewport** in a standalone SVG `<foreignObject>` — node bodies carry inline styles, so the capture paints the full grammar including the active-state affordance. The viewport's pan/zoom transform is neutralised and the SVG is sized to the union node-box, so the export frames the **whole topology at 1:1** regardless of live zoom/pan. Serialised via `XMLSerializer` (not `.outerHTML`) + XHTML-namespaced so the foreignObject is well-formed XML and actually rasterises; a minimal subset of xyflow's positioning CSS is embedded so the cloned viewport lays out.
- **`chart-as-png!`** rasterises that complete SVG, sized to the framed-topology box (not the edge-svg bbox).
- **`chart-root`** is now keyed on the `_rfMvChartState` **seam** (ancestor-walk, then descendant-search), not the default `data-testid` — so export works from the chart **root**, a **descendant**, or a **wrapper**, for the **default and any custom `:testid`**.
- **`tools/machines-viz/spec/API.md`** export section updated to match (full-viewport capture + seam-keyed root discovery) — standing spec rule.

## Before / after export-fidelity proof

Captured the real exported SVG from a mounted sample machine and rasterised it in headless Chromium (the same runtime the browser gate uses):

- **Before** (edge-only svg / pre-fix): the SVG carried no node-box text and no active-state affordance; a foreignObject capture of an un-laid-out chart rasterised to **0 non-transparent pixels**.
- **After** (full-viewport capture, layout settled): the SVG carries every state label + `data-active-affordance="true"` + the `box-shadow` glow, and the PNG rasterises to **~56k non-transparent pixels** (the node boxes + glow actually drew). Root cause of the initial blank raster was diagnosed to xyflow keeping nodes `visibility:hidden` until elkjs layout settles — so the regression test awaits layout before capturing, matching the real host path.

## Tests

New `tools/machines-viz/test/.../export_dom_cljs_test.cljs` (browser-test build — needs real DOM/canvas/Image/SVG rasterisation):

- `chart-as-svg` includes state-box text + the active-affordance attr + `box-shadow` glow + `<title>`/`<desc>`; a no-highlight control proves the affordance assertion is signal.
- `chart-as-png!` resolves to a non-empty `image/png` whose raster has drawn (non-transparent) content — awaiting elkjs layout.
- Export resolves the root from **root / descendant / wrapper**, for **default and custom `:testid`** (this fails against the old hard-coded selector).
- Share-url + Mermaid lanes asserted unchanged on the live chart.

These fail against the prior edge-only / testid-keyed implementation.

## Quality gates (all green, cold)

- machines-viz `clojure -M:test` — 364 tests, 0 failures
- `npm run test:browser` — 160 tests, 493 assertions, 0 failures (includes the new export regression)
- `npm run test:cljs` — only the 7 pre-existing `realworld-articles-feed` failures (the documented main-RED from #3106 sub-id rename, fix 0wt03 already dispatched); no export/machines-viz failures.

xray spec unchanged: `tools/xray/spec/003-Machine-Inspector.md` already states "current-state highlight included" for PNG + SVG — the fix makes the implementation match that existing promise.