### PR TITLE
fix(http): with-managed-request-stubs installs the :rf.http/managed override (rf2-rzqan)

### DIFF
--- a/docs/api/07-http.md
+++ b/docs/api/07-http.md
@@ -209,7 +209,7 @@ Tests want to drive the cascade without hitting the network. The test-support su
   ```clojure
   (with-managed-request-stubs route-map body+)
   ```
-- **Description**: Lexical-scope stubbing. `route-map` is `{[<method> <url>] {:reply <value-or-failure>}}`. Inside the body, requests matching a stubbed route bypass the real client.
+- **Description**: Lexical-scope stubbing. `route-map` is `{[<method> <url>] {:reply {:ok <value>}}}` (success) or `{[<method> <url>] {:reply {:failure <failure-map>}}}` (failure). Inside the body, requests matching a stubbed route bypass the real client — the helper installs the `:rf.http/managed → :rf.http/managed-test-stub` override for the body, so plain `dispatch-sync` calls auto-route by method + URL with NO manual `:fx-overrides`.
 
 ### `with-managed-request-stubs*`
 
@@ -218,7 +218,7 @@ Tests want to drive the cascade without hitting the network. The test-support su
   ```clojure
   (with-managed-request-stubs* route-map body-fn)
   ```
-- **Description**: Plain-fn surface beneath the macro. Use for computed route-maps or non-literal bodies.
+- **Description**: Plain-fn surface beneath the macro. Use for computed route-maps or non-literal bodies. Like the macro, it installs the `:rf.http/managed` override for `body-fn`'s dynamic extent, so dispatches inside auto-route with no manual `:fx-overrides`.
 
 ### `install-managed-request-stubs!`
 
@@ -227,7 +227,7 @@ Tests want to drive the cascade without hitting the network. The test-support su
   ```clojure
   (install-managed-request-stubs! route-map)
   ```
-- **Description**: Lower-level than `with-managed-request-stubs`: install stubs that persist until `uninstall-managed-request-stubs!`. Use when stubs span multiple `deftest`s.
+- **Description**: Lower-level than `with-managed-request-stubs`: registers the `:rf.http/managed-test-stub` fx that persists until `uninstall-managed-request-stubs!`. Use when stubs span multiple `deftest`s. Unlike the wrapper, this does NOT install the `:rf.http/managed` override — dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it.
 
 ### `uninstall-managed-request-stubs!`
 
@@ -243,7 +243,7 @@ All the test-support surfaces live in `re-frame.http-test-support` (the single h
 ```clojure
 (deftest cart-loads
   (with-managed-request-stubs
-    {[:get "/api/cart"] {:reply [{:id 1 :name "widget"}]}}
+    {[:get "/api/cart"] {:reply {:ok [{:id 1 :name "widget"}]}}}
     (rf/dispatch-sync [:cart/load])
     (is (= 1 (count (subscribe-once [:cart/items]))))))
 ```

--- a/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
@@ -144,7 +144,9 @@
 ;; ---- 6. with-managed-request-stubs* helper --------------------------------
 
 (deftest with-managed-request-stubs-cljs
-  (testing "with-managed-request-stubs* installs a per-call fx that consults [method url] → reply"
+  (testing "rf2-rzqan — with-managed-request-stubs* routes [method url] → reply
+            with NO per-call :fx-overrides (the helper installs the
+            :rf.http/managed override for the thunk's dynamic extent)"
     (rf/reg-event-fx :articles/list
       (fn [_ [_ msg]]
         (if-let [reply (:rf/reply msg)]
@@ -155,11 +157,45 @@
     (rf/with-managed-request-stubs*
       {[:get "/articles"] {:reply {:ok [:hello :world]}}}
       (fn []
-        (rf/dispatch-sync [:articles/list]
-                          {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+        ;; NO manual :fx-overrides — the documented auto-routing form.
+        (rf/dispatch-sync [:articles/list])
         (let [db (rf/app-db-value :rf/default)]
           (is (= :success (get-in db [:result :kind])))
           (is (= [:hello :world] (get-in db [:result :value]))))))))
+
+;; ---- 6a. rf2-rzqan — bare thunk INTERCEPTS, never reaching the real fx ----
+;;
+;; CLJS counterpart of the JVM interception regression. The documented
+;; `with-managed-request-stubs*` form must route `:rf.http/managed` through
+;; the stub by ITSELF; pre-fix the thunk's bare dispatch reached the real
+;; production Fetch transport. We shadow `:rf.http/managed` with a sentinel
+;; — reaching it proves the override was absent.
+
+(deftest with-managed-request-stubs-intercepts-without-manual-override-cljs-rf2-rzqan
+  (testing "rf2-rzqan — inside with-managed-request-stubs*, a plain dispatch-sync
+            (NO per-call :fx-overrides) is intercepted by the stub and the real
+            :rf.http/managed fx slot is NEVER invoked"
+    (let [real-fx-invoked? (atom false)]
+      (rf/reg-fx :rf.http/managed
+                 (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
+      (rf/reg-event-fx :rzqan/load
+        (fn [_ [_ msg]]
+          (if-let [reply (:rf/reply msg)]
+            {:db {:result reply}}
+            {:fx [[:rf.http/managed
+                   {:request {:method :get :url "/rzqan"}
+                    :decode  :json}]]})))
+      (rf/with-managed-request-stubs*
+        {[:get "/rzqan"] {:reply {:ok {:stubbed true}}}}
+        (fn []
+          (rf/dispatch-sync [:rzqan/load])
+          (let [db (rf/app-db-value :rf/default)]
+            (is (= :success (get-in db [:result :kind]))
+                "the stubbed reply landed via the route-map stub")
+            (is (= {:stubbed true} (get-in db [:result :value])))
+            (is (false? @real-fx-invoked?)
+                "the real :rf.http/managed fx was NEVER invoked — the helper
+                 intercepted (pre-fix: this fired the real Fetch transport)")))))))
 
 ;; ---- 7. with-managed-request-stubs* — failure mapping --------------------
 
@@ -176,8 +212,8 @@
       {[:get "/articles"] {:reply {:failure {:kind   :rf.http/http-4xx
                                              :status 404}}}}
       (fn []
-        (rf/dispatch-sync [:articles/list]
-                          {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+        ;; Auto-routing — no manual :fx-overrides (rf2-rzqan).
+        (rf/dispatch-sync [:articles/list])
         (let [db (rf/app-db-value :rf/default)]
           (is (= :failure (get-in db [:result :kind])))
           (is (= :rf.http/http-4xx (get-in db [:result :failure :kind])))
@@ -198,8 +234,10 @@
       ;; Configure stubs that do NOT match the request URL.
       {[:get "/articles"] {:reply {:ok []}}}
       (fn []
-        (rf/dispatch-sync [:unmatched/load]
-                          {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+        ;; Auto-routing — no manual :fx-overrides (rf2-rzqan). The unmatched
+        ;; route still routes THROUGH the stub (which then synthesises the
+        ;; no-match transport failure), never reaching the real client.
+        (rf/dispatch-sync [:unmatched/load])
         (let [db (rf/app-db-value :rf/default)]
           (is (= :failure (get-in db [:result :kind])))
           (is (= :rf.http/transport (get-in db [:result :failure :kind]))))))))

--- a/implementation/http/src/re_frame/http_test_support.cljc
+++ b/implementation/http/src/re_frame/http_test_support.cljc
@@ -82,7 +82,8 @@
             [re-frame.http-encoding        :as encoding]
             [re-frame.http-machine-wrapper :as machine-wrapper]
             [re-frame.http-middleware      :as middleware]
-            [re-frame.late-bind            :as late-bind]))
+            [re-frame.late-bind            :as late-bind]
+            [re-frame.router               :as router]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -235,11 +236,17 @@
 
 (defn install-managed-request-stubs!
   "Test-time helper. `stubs` is `{[method url] {:reply <:ok|:failure>}}`.
-  Registers a per-call fx-override target that consults `stubs` and
-  synthesises the configured reply.
+  Registers the `:rf.http/managed-test-stub` fx — a route-map-consulting
+  override target that synthesises the configured reply.
 
-  Use with `:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}`
-  on `dispatch-sync`, or wrap the test body via `with-managed-request-stubs`.
+  NOTE: this lower-level fn only REGISTERS the stub fx; it does not route
+  `:rf.http/managed` through it. To route, either dispatch with
+  `:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}`, or — far
+  more usually — wrap the test body via `with-managed-request-stubs` /
+  `with-managed-request-stubs*`, which install BOTH the stub fx AND the
+  `:rf.http/managed → :rf.http/managed-test-stub` override for the body's
+  dynamic extent, so plain `dispatch-sync` calls auto-route with no manual
+  `:fx-overrides`.
 
   Per Spec 014 §Testing — the framework ships canonical stub fxs."
   [stubs]
@@ -259,11 +266,30 @@
   nil)
 
 (defn with-managed-request-stubs*
-  "Function form: install stubs, run thunk, uninstall. Test-time helper."
+  "Function form: install stubs, route `:rf.http/managed` through them for
+  the dynamic extent of `thunk`, run `thunk`, then uninstall. Test-time
+  helper.
+
+  `stubs` is `{[method url] {:reply <:ok|:failure>}}`. Beyond registering
+  the `:rf.http/managed-test-stub` fx, this also binds the lexical-scope
+  fx-override `{:rf.http/managed :rf.http/managed-test-stub}`
+  (`re-frame.router/*fx-overrides*`, the public `rf/with-fx-overrides`
+  seam) for the thunk's dynamic extent. So every `dispatch-sync` inside
+  the body auto-routes by `:request :method` + `:request :url` with NO
+  per-call `:fx-overrides` — matching the documented contract (Spec 014
+  §Testing). A dispatch that deliberately supplies its OWN `:fx-overrides`
+  still wins: the router merges the lexical default UNDER the per-call opt
+  (per-call > lexical > per-frame)."
   [stubs thunk]
   (try
     (install-managed-request-stubs! stubs)
-    (thunk)
+    ;; Bind the lexical-scope override so plain dispatches in the body
+    ;; route `:rf.http/managed` → the route-map stub automatically. The
+    ;; thunk's dispatches run synchronously within this dynamic extent;
+    ;; per-call `:fx-overrides` still take precedence (router merge).
+    (binding [router/*fx-overrides* (merge router/*fx-overrides*
+                                           {:rf.http/managed stub-fx-id})]
+      (thunk))
     (finally
       (uninstall-managed-request-stubs!))))
 
@@ -272,6 +298,9 @@
      "Test-time helper. `stubs` is `{[method url] {:reply <:ok|:failure>}}`.
      Installs a per-call fx-override on `:rf.http/managed` that consults
      the stub map, synthesises the configured reply, and runs `body`.
+     Every `dispatch-sync` in the body auto-routes by method + URL — no
+     manual `:fx-overrides` needed (the helper installs the override for
+     the body's dynamic extent).
 
      Per Spec 014 §Testing."
      [stubs & body]

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -902,7 +902,11 @@
 ;; ---- 11. with-managed-request-stubs helper --------------------------------
 
 (deftest with-managed-request-stubs-helper
-  (testing "with-managed-request-stubs routes :method+:url to the configured reply"
+  (testing "rf2-rzqan — with-managed-request-stubs routes :method+:url to the
+            configured reply with NO per-call :fx-overrides (the documented
+            wrapper contract: the helper installs the
+            :rf.http/managed → :rf.http/managed-test-stub override for the
+            body's dynamic extent, so plain dispatch-sync auto-routes)"
     (rf/reg-event-fx :articles/list
       (fn [{:keys [db]} [_ msg]]
         (if-let [reply (:rf/reply msg)]
@@ -912,11 +916,81 @@
                   :decode  :json}]]})))
     (rf/with-managed-request-stubs
       {[:get "/articles"] {:reply {:ok [:hello :world]}}}
-      (rf/dispatch-sync [:articles/list]
-                        {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+      ;; NO manual :fx-overrides — this is the documented form. Pre-fix this
+      ;; dispatch ran the real :rf.http/managed transport.
+      (rf/dispatch-sync [:articles/list])
       (let [db (await-reply! #(some? (:result %)) 2000)]
         (is (= :success (get-in db [:result :kind])))
         (is (= [:hello :world] (get-in db [:result :value])))))))
+
+;; ---- 11a. rf2-rzqan — bare wrapper INTERCEPTS, never reaching the real fx ---
+;;
+;; The load-bearing regression for rf2-rzqan: the documented
+;; `with-managed-request-stubs` wrapper must route `:rf.http/managed`
+;; through the route-map stub by ITSELF — the body must NOT need a manual
+;; `:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}`. Pre-fix
+;; the helper only registered the stub fx but did NOT install the override,
+;; so a plain `dispatch-sync` inside the body ran the REAL production
+;; transport (network IO / hang / nondeterminism / false-green).
+;;
+;; To prove the REAL fx is never reached we shadow `:rf.http/managed` with
+;; a sentinel that flips an atom. If the override were absent the bare
+;; dispatch would land on this sentinel (the real fx slot) and the atom
+;; would flip; with the helper-installed override the dispatch routes to
+;; the stub instead and the sentinel stays untouched while the stubbed
+;; reply lands.
+
+(deftest with-managed-request-stubs-intercepts-without-manual-override-rf2-rzqan
+  (testing "rf2-rzqan — inside with-managed-request-stubs, a plain dispatch-sync
+            (NO per-call :fx-overrides) is intercepted by the stub and the real
+            :rf.http/managed fx slot is NEVER invoked"
+    (let [real-fx-invoked? (atom false)]
+      ;; Shadow the production fx slot with a sentinel. Reaching THIS proves
+      ;; the override was absent (the pre-fix bug). The stub path bypasses it.
+      (rf/reg-fx :rf.http/managed
+                 (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
+      (rf/reg-event-fx :rzqan/load
+        (fn [{:keys [db]} [_ msg]]
+          (if-let [reply (:rf/reply msg)]
+            {:db (assoc db :result reply)}
+            {:fx [[:rf.http/managed
+                   {:request {:method :get :url "/rzqan"}
+                    :decode  :json}]]})))
+      (rf/with-managed-request-stubs
+        {[:get "/rzqan"] {:reply {:ok {:stubbed true}}}}
+        ;; Bare wrapper form — the helper alone must route to the stub.
+        (rf/dispatch-sync [:rzqan/load])
+        (let [db (await-reply! #(some? (:result %)) 2000)]
+          (is (= :success (get-in db [:result :kind]))
+              "the stubbed reply landed via the route-map stub")
+          (is (= {:stubbed true} (get-in db [:result :value]))
+              "the configured :ok value rode through the synthesised success reply")
+          (is (false? @real-fx-invoked?)
+              "the real :rf.http/managed fx was NEVER invoked — the helper's
+               installed override intercepted the dispatch (pre-fix: this fired
+               the real transport)"))))))
+
+(deftest with-managed-request-stubs-per-call-override-still-wins-rf2-rzqan
+  (testing "rf2-rzqan — a per-call :fx-overrides inside the wrapper still wins
+            over the helper-installed lexical default (precedence preserved:
+            per-call > lexical > per-frame)"
+    (let [chosen (atom nil)]
+      ;; A deliberately-supplied per-call override target.
+      (rf/reg-fx :rzqan/explicit-override
+                 (fn [_frame-ctx _args] (reset! chosen :explicit) nil))
+      (rf/reg-event-fx :rzqan/load-explicit
+        (fn [_ _]
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/rzqan-explicit"}
+                  :decode  :json}]]}))
+      (rf/with-managed-request-stubs
+        {[:get "/rzqan-explicit"] {:reply {:ok {:via :stub}}}}
+        ;; The body deliberately overrides :rf.http/managed itself; this must
+        ;; beat the helper's lexical default and land on the explicit target.
+        (rf/dispatch-sync [:rzqan/load-explicit]
+                          {:fx-overrides {:rf.http/managed :rzqan/explicit-override}})
+        (is (= :explicit @chosen)
+            "the per-call :fx-overrides won over the helper's lexical default")))))
 
 ;; ---- 11b. canned-stub fxs gated on explicit test-support require (rf2-cdmle)
 ;;


### PR DESCRIPTION
## Summary

`with-managed-request-stubs` / `with-managed-request-stubs*` (`implementation/http/src/re_frame/http_test_support.cljc`) only registered the `:rf.http/managed-test-stub` fx — they never installed the `:rf.http/managed → :rf.http/managed-test-stub` override. The documented wrapper form therefore ran the **real production HTTP fx** (network IO / hang / nondeterminism / false-green) unless the body manually passed `{:fx-overrides {…}}` on every dispatch.

This contradicted the helper name and every doc surface:
- `spec/014-HTTPRequests.md §Testing` — "inspects each `:rf.http/managed` invocation … routes by method + URL", example body has **no** manual `:fx-overrides`.
- `docs/guide/13-testing.md` — plain `dispatch-sync` inside the wrapper body.
- `docs/api/07-http.md` — "requests matching a stubbed route bypass the real client".

## Fix

`with-managed-request-stubs*` now binds `re-frame.router/*fx-overrides*` (the public `with-fx-overrides` seam) to `{:rf.http/managed :rf.http/managed-test-stub}` for the thunk's dynamic extent. Plain `dispatch-sync` inside the body is auto-intercepted. Per-call `:fx-overrides` still take precedence (the router merges the lexical default *under* the per-call opt: per-call > lexical > per-frame).

## Tests

- Rewrote the existing JVM + CLJS helper tests to exercise the **documented** form (no manual `:fx-overrides`).
- Added JVM + CLJS interception tests that shadow `:rf.http/managed` with a sentinel fx and assert the real fx is **NEVER** invoked under the bare wrapper while the stubbed reply lands.
- Added a precedence test: a per-call `:fx-overrides` inside the wrapper still wins over the helper's lexical default.

**Without-fix proof:** temporarily removing the binding makes the documented helper test + the interception test fail (2 failures + 1 poll-until-timeout error) — confirming the bare wrapper reached the real client pre-fix.

## Docs

- `docs/api/07-http.md`: corrected the inert `{:reply [...]}` example to the matching `{:reply {:ok …}}` shape and documented the auto-routing / no-manual-override contract.
- `spec/014-HTTPRequests.md` (hot-zone) already documents the correct behaviour and is **unchanged** — the code was what was wrong.

## Gates

- http JVM `clojure -M:test`: 331 tests / 1573 assertions, 0 failures, 0 errors.
- `npm run test:cljs`: 5621 tests / 19589 assertions, 0 failures, 0 errors.

Closes rf2-rzqan.