### PR TITLE
fix(examples): admit managed-HTTP reply payload in login event schema (rf2-1gz14)

### DIFF
--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -43,11 +43,22 @@
 ;; see examples/reagent/login for the full rationale. The :submit
 ;; sub-event is validated against `Credentials`; framework-internal
 ;; sub-events (:dismiss, :success, :failure) admit :any.
+;;
+;; The trailing `[:? :any]` admits the managed-HTTP reply payload (Spec
+;; 014 §Reply addressing): the framework appends `{:kind ... :value ...}`
+;; / `{:kind ... :failure ...}` as the LAST arg of the explicit
+;; `:on-success` / `:on-failure` event vector, so the delivered reply is
+;; `[:auth.login/flow [:auth.login/success] <payload>]` — three top-level
+;; elements. Without the optional trailing slot the `:cat` rejects every
+;; reply with `:malli.core/input-remaining`, the boundary validation
+;; fails BEFORE the machine handler runs, and the flow is stranded in
+;; `:submitting` (rf2-1gz14).
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
     [:cat [:= :auth.login/submit] Credentials]
-    [:vector :any]]])
+    [:vector :any]]
+   [:? :any]])
 
 (def AuthLoginSnapshot
   [:map

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -110,11 +110,22 @@
 ;; them as :any. Per Spec 010 §Validation order step 1: a malformed
 ;; event vector is rejected at the boundary; the handler is NOT
 ;; invoked (recovery: :no-recovery).
+;;
+;; The trailing `[:? :any]` admits the managed-HTTP reply payload (Spec
+;; 014 §Reply addressing): the framework appends `{:kind ... :value ...}`
+;; / `{:kind ... :failure ...}` as the LAST arg of the explicit
+;; `:on-success` / `:on-failure` event vector, so the delivered reply is
+;; `[:auth.login/flow [:auth.login/success] <payload>]` — three top-level
+;; elements. Without the optional trailing slot the `:cat` rejects every
+;; reply with `:malli.core/input-remaining`, the boundary validation
+;; fails BEFORE the machine handler runs, and the flow is stranded in
+;; `:submitting` (rf2-1gz14).
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
     [:cat [:= :auth.login/submit] Credentials]
-    [:vector :any]]])
+    [:vector :any]]
+   [:? :any]])
 
 ;; The login flow's runtime state lives in the machine snapshot at
 ;; [:rf/runtime :machines :snapshots :auth.login/flow] (per [005 §Where snapshots live]).

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -40,11 +40,22 @@
 ;; see examples/reagent/login for the full rationale. The :submit
 ;; sub-event is validated against `Credentials`; framework-internal
 ;; sub-events (:dismiss, :success, :failure) admit :any.
+;;
+;; The trailing `[:? :any]` admits the managed-HTTP reply payload (Spec
+;; 014 §Reply addressing): the framework appends `{:kind ... :value ...}`
+;; / `{:kind ... :failure ...}` as the LAST arg of the explicit
+;; `:on-success` / `:on-failure` event vector, so the delivered reply is
+;; `[:auth.login/flow [:auth.login/success] <payload>]` — three top-level
+;; elements. Without the optional trailing slot the `:cat` rejects every
+;; reply with `:malli.core/input-remaining`, the boundary validation
+;; fails BEFORE the machine handler runs, and the flow is stranded in
+;; `:submitting` (rf2-1gz14).
 (def AuthLoginEvent
   [:cat [:= :auth.login/flow]
    [:or
     [:cat [:= :auth.login/submit] Credentials]
-    [:vector :any]]])
+    [:vector :any]]
+   [:? :any]])
 
 (def AuthLoginSnapshot
   [:map


### PR DESCRIPTION
## Summary

Fixes **rf2-1gz14** (P1): the login demos stranded the flow at `:submitting` on a valid submit — `Welcome!` never appeared (and the wrong-password path never showed its error).

## Root cause

NOT the `:after-ms` / managed-HTTP delay path (verified correct on both JVM and CLJS). The defect was the `:auth.login/flow` **event schema**.

`AuthLoginEvent` was a strict two-element `[:cat [:= :auth.login/flow] <sub-event>]`. But Spec 014 §Reply addressing appends the reply payload as the LAST arg of the explicit `:on-success` / `:on-failure` event vector, so the delivered reply is:

```clojure
[:auth.login/flow [:auth.login/success] {:kind :success :value {...}}]   ;; 3 top-level elements
```

Malli rejected this with `:malli.core/input-remaining` (`:in [2]`) at the boundary **before** the machine handler ran (recovery `:no-recovery`), so the `:success` / `:failure` transition never fired and the machine sat in `:submitting`. The delay merely made the stuck state observable; the schema rejected every reply — immediate or deferred.

## Fix

Add a trailing optional `[:? :any]` to the outer `:cat` so the schema admits the appended reply payload while still validating the `:submit` credentials at the user boundary:

```clojure
(def AuthLoginEvent
  [:cat [:= :auth.login/flow]
   [:or
    [:cat [:= :auth.login/submit] Credentials]
    [:vector :any]]
   [:? :any]])   ;; trailing managed-HTTP reply payload (Spec 014)
```

Applied identically to all three substrate siblings — they shared the byte-identical defective schema, so Reagent and Helix were broken the same way.

## Verification (in-browser, per substrate)

Compiled each example bundle and drove it with Playwright (outside the repo — examples stay test-free):

| Substrate | Happy path (correct pw) | Failure path (wrong pw) |
|-----------|-------------------------|--------------------------|
| UIx       | `Welcome!` in ~73ms     | "Invalid credentials." then button "Sign in" |
| Reagent   | `Welcome!` in ~126ms    | "Invalid credentials." then button "Sign in" |
| Helix     | `Welcome!` in ~123ms    | "Invalid credentials." then button "Sign in" |

No page errors. Before the fix: stuck at "Signing in…" indefinitely.

## Gates

- All three example builds compile with **0 warnings**.
- `npm run test:examples` passes — **3 specs, 0 failures** (Reagent/UIx/Helix adapter smokes).
- No `*.spec.cjs` added under `examples/` (examples remain test-free).

Closes rf2-1gz14.
