### PR TITLE
fix(ssr): close safe-redirect scheme-bypass + CRLF-check every cookie attr (rf2-v3eg3, rf2-kjf3m.1)

### DIFF
--- a/docs/api/09-ssr.md
+++ b/docs/api/09-ssr.md
@@ -6,7 +6,7 @@ This works because the framework was designed around immutable data and an expli
 
 This chapter covers the rendering primitives (`render-to-string`, the streaming triple, the structural-hash), the head model (`reg-head`, `active-head`, `render-head`), the per-request response accumulator and its server-only fx, the error-projection seam (`reg-error-projector`, `project-error`), and the `:platforms` metadata that gates fx execution by active platform.
 
-The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces live in `re-frame.ssr` (artefact `day8/re-frame2-ssr`); the Ring host-adapter lives in `re-frame.ssr.ring`. Neither is re-exported from `re-frame.core` — apps targeting SSR add the artefacts to their deps and require the namespace directly.
+The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces live in `re-frame.ssr` (artefact `day8/re-frame2-ssr`); the Ring host-adapter lives in `re-frame.ssr.ring`. The implementation ships in a separate artefact — you add `day8/re-frame2-ssr` to your deps and require the namespace to get the full surface. For convenience, a curated set of the rendering and head primitives is **re-exported from `re-frame.core` as late-bound wrappers** (`render-to-string`, `render-tree-hash`, `project-error`, `render-head`, `active-head`, `head-model->html`, `head-snapshot`): these resolve to the `re-frame.ssr` implementation at call time when the artefact is on the classpath, and throw a clear "SSR not loaded" error otherwise. So apps that already `(:require [re-frame.core :as rf])` can call `rf/render-to-string` directly; the host-adapter surface (`re-frame.ssr.ring`) and the per-request `:rf.server/*` fx are **not** re-exported — require `re-frame.ssr` / `re-frame.ssr.ring` for those.
 
 ## Rendering primitives
 
@@ -213,7 +213,7 @@ Full rationale: [Conventions §Configuration surfaces](../../spec/Conventions.md
 
 ## Hydration
 
-The server-rendered HTML carries a `__rf_payload` chunk that the client deserialises into `app-db` on bootstrap. The structural-hash from `render-tree-hash` is captured at render time and checked at hydration; mismatch surfaces `:rf.ssr/version-mismatch` or `:rf.ssr/schema-digest-mismatch` rather than silently mounting a broken DOM.
+The server-rendered HTML carries a `__rf_payload` chunk that the client deserialises into `app-db` on bootstrap. The structural-hash from `render-tree-hash` is captured at render time and checked at hydration; a mismatch between the server-render hash and the client-render hash surfaces **`:rf.ssr/hydration-mismatch`** (in `:hard-error` mode it also throws; otherwise it warns and re-renders client-side) rather than silently mounting a broken DOM. This is distinct from the two payload-provenance checks the reference `:rf/hydrate` handler runs — `:rf.ssr/version-mismatch` (the payload was produced by a different framework version) and `:rf.ssr/schema-digest-mismatch` (the app's schema set drifted since the payload was built); those guard payload compatibility, while `:rf.ssr/hydration-mismatch` guards the render-tree structural hash.
 
 The hydration payload shape lives at [Spec-Schemas §`:rf/hydration-payload`](../../spec/Spec-Schemas.md#rfhydration-payload).
 

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -522,12 +522,20 @@
 ;; `ssr-response->ring-response` folds the response accumulator's
 ;; cookies/headers into the Ring head, and cookie/header serialisation
 ;; CAN throw at materialise time on a value that escaped the fx
-;; boundary's PARTIAL validation: the runtime `validate-cookie!` checks
-;; only :name / :value / :path / :domain, but `cookie->set-cookie-header`
-;; additionally rejects a CR/LF-bearing :max-age and a non-integer
-;; :expires. So a cookie like {:name "s" :value "v" :max-age "1\r\n2"}
-;; PASSES the fx gate, is stored on the accumulator, and THEN throws when
-;; the host adapter materialises the head.
+;; boundary's PARTIAL validation. The fx-boundary `validate-cookie!`
+;; gate is a CR/LF/NUL injection check (it str-coerces every attribute
+;; and bans header-splitting chars), but `cookie->set-cookie-header`
+;; carries an ADDITIONAL type contract the fx gate does not replicate:
+;; `:expires` must be `integer?` (it is fed to `Instant/ofEpochMilli`
+;; as a primitive long). So a cookie like
+;; {:name "s" :value "v" :expires "not-an-int"} — a non-integer
+;; :expires with no CR/LF — PASSES the fx gate (no injection char), is
+;; stored on the accumulator, and THEN throws
+;; `:rf.error/cookie-invalid-expires` when the host adapter materialises
+;; the head. (Before rf2-kjf3m.1 this test used a CR/LF-bearing
+;; :max-age; that attribute is now CRLF-gated at the fx boundary too, so
+;; it no longer reaches head materialisation — the non-integer :expires
+;; type-contract divergence is the genuine remaining escape path.)
 ;;
 ;; The bug (rf2-z5azc): the old streaming branch spawned + started the
 ;; daemon writer thread BEFORE materialising the head. When the head
@@ -554,16 +562,19 @@
   (testing "rf2-z5azc — a cookie that throws at head materialisation
             (escaped the fx boundary) short-circuits to :on-error with
             NO writer thread spawned + NO orphaned pipe"
-    ;; :on-create sets a cookie whose :max-age carries CR/LF. The fx
-    ;; boundary (`validate-cookie!`) gates only :name/:value/:path/
-    ;; :domain, so this passes the gate and is stored on the response
-    ;; accumulator. The host materialiser's `cookie->set-cookie-header`
-    ;; then throws `:rf.error/cookie-invalid-attribute` on :max-age.
+    ;; :on-create sets a cookie whose :expires is a non-integer string.
+    ;; The fx boundary (`validate-cookie!`) is a CR/LF/NUL injection gate
+    ;; — it str-coerces every attribute and bans header-splitting chars,
+    ;; but does NOT type-check :expires — so this cookie (no injection
+    ;; char) passes the gate and is stored on the response accumulator.
+    ;; The host materialiser's `cookie->set-cookie-header` carries the
+    ;; primitive-long type contract (:expires → `Instant/ofEpochMilli`)
+    ;; and throws `:rf.error/cookie-invalid-expires` at head materialise.
     (rf/reg-event-fx :rf.test.server/init-bad-cookie
       {:platforms #{:server}}
       (fn [_ _]
         {:db {}
-         :fx [[:rf.server/set-cookie {:name "s" :value "v" :max-age "1\r\n2"}]]}))
+         :fx [[:rf.server/set-cookie {:name "s" :value "v" :expires "not-an-int"}]]}))
     ;; A root-view emitting a body well past the 16 KiB pipe buffer, so
     ;; that under the OLD (buggy) ordering the orphaned writer would
     ;; block forever on `.write` — making the leak deterministic. Under

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -2293,20 +2293,27 @@
 (deftest ssr-handler-throwing-on-error-on-success-path-is-contained
   (testing "rf2-ljjh0 — symmetric: a caller :on-error that throws on the
             SUCCESS path is also contained. Driven by a cookie whose
-            :max-age carries CR/LF — it passes the fx boundary
-            (`validate-cookie!` gates only :name/:value/:path/:domain)
-            but throws at head materialisation. That throw escapes
-            `build-full-response`'s own catch (its error-path materialise
-            re-folds the SAME bad cookie and throws again), reaching the
-            handler body's :on-error catch — the success-path call site."
+            :expires is a non-integer string — it passes the fx boundary
+            (`validate-cookie!` is a CR/LF/NUL injection gate, it does
+            NOT type-check :expires) but throws
+            `:rf.error/cookie-invalid-expires` at head materialisation
+            (`cookie->set-cookie-header`'s primitive-long :expires type
+            contract). That throw escapes `build-full-response`'s own
+            catch (its error-path materialise re-folds the SAME bad
+            cookie and throws again), reaching the handler body's
+            :on-error catch — the success-path call site."
     (rf/reg-event-fx :rf.test/init-bad-cookie
       {:platforms #{:server}}
       (fn [_ _]
-        ;; CR/LF in :max-age escapes the fx boundary (`validate-cookie!`
-        ;; gates only :name/:value/:path/:domain) and throws at host
-        ;; materialise time in `cookie->set-cookie-header`.
+        ;; A non-integer :expires escapes the fx boundary
+        ;; (`validate-cookie!` is a CR/LF/NUL injection gate — it does
+        ;; not type-check :expires) and throws at host materialise time
+        ;; in `cookie->set-cookie-header` (the primitive-long :expires
+        ;; type contract). Before rf2-kjf3m.1 this used a CR/LF-bearing
+        ;; :max-age; that is now CRLF-gated at the fx boundary, so the
+        ;; non-integer :expires divergence is the genuine escape path.
         {:db {}
-         :fx [[:rf.server/set-cookie {:name "s" :value "v" :max-age "1\r\n2"}]]}))
+         :fx [[:rf.server/set-cookie {:name "s" :value "v" :expires "not-an-int"}]]}))
     (let [throwing-on-error
           (fn [_req _t]
             (throw (ex-info "boom in the caller's on-error" {:internal :topology})))

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -198,9 +198,16 @@
 
 (defn- validate-cookie-attr!
   "Throw `:rf.error/cookie-invalid-<field>` if the cookie attribute
-  string contains CR / LF / NUL. Applied to `:value`, `:path`, `:domain`
-  — the string-typed fields that are concatenated verbatim into the
-  Set-Cookie wire form by host adapters. Per rf2-z7gor."
+  string contains CR / LF / NUL. Applied to EVERY attribute that a host
+  adapter concatenates into the Set-Cookie wire form — `:value`, `:path`,
+  `:domain`, `:max-age`, `:same-site`, `:expires`. The value is
+  `str`-coerced first because callers legitimately pass non-string
+  forms (`:max-age` as an int, `:expires` as an instant); the CR/LF/NUL
+  ban applies to the serialised form a host adapter would emit. Per
+  rf2-z7gor (the fx-boundary gate) and rf2-kjf3m.1 (Spec 011 §CRLF
+  fail-fast mandates checking EVERY attribute, not just :value — an
+  attacker who controls any one attribute must not be able to re-enter
+  the header line as CRLF-bearing payload)."
   [field-key v]
   (let [s (str v)]
     (when (http-validation/contains-injection-char? s)
@@ -220,12 +227,27 @@
 (defn- validate-cookie!
   "Run name + field validators across the cookie map. Per rf2-z7gor —
   gate the structured cookie at the fx boundary so misuse surfaces with
-  the dispatching event in scope rather than as a deep adapter exception."
+  the dispatching event in scope rather than as a deep adapter exception.
+
+  CRLF-checks EVERY attribute a host adapter serialises into the
+  Set-Cookie line, not just `:value` (rf2-kjf3m.1 / Spec 011 §CRLF
+  fail-fast). The fx boundary is the single enforcement point for
+  non-Ring host adapters (Pedestal / HttpKit / custom) that read the
+  accumulator and serialise cookies themselves; the Ring materialiser
+  re-checks at wire-write time, but the two boundaries must not diverge
+  on what they accept. `:max-age` and `:expires` are commonly non-string
+  (int / instant) — `validate-cookie-attr!` `str`-coerces before the
+  CR/LF/NUL ban, so a string `:max-age` sourced from request context
+  (`\"3600\\r\\nSet-Cookie: admin=1\"`) is rejected at the fx boundary
+  rather than splitting the header on a non-Ring host."
   [cookie]
   (validate-cookie-name! (:name cookie))
-  (when (some? (:value  cookie)) (validate-cookie-attr! :value  (:value  cookie)))
-  (when (some? (:path   cookie)) (validate-cookie-attr! :path   (:path   cookie)))
-  (when (some? (:domain cookie)) (validate-cookie-attr! :domain (:domain cookie)))
+  (when (some? (:value     cookie)) (validate-cookie-attr! :value     (:value     cookie)))
+  (when (some? (:path      cookie)) (validate-cookie-attr! :path      (:path      cookie)))
+  (when (some? (:domain    cookie)) (validate-cookie-attr! :domain    (:domain    cookie)))
+  (when (some? (:max-age   cookie)) (validate-cookie-attr! :max-age   (:max-age   cookie)))
+  (when (some? (:same-site cookie)) (validate-cookie-attr! :same-site (:same-site cookie)))
+  (when (some? (:expires   cookie)) (validate-cookie-attr! :expires   (:expires   cookie)))
   cookie)
 
 (def status-writes-key   :rf.server/_status-writes)
@@ -438,19 +460,40 @@
 ;;
 ;; The caller-untrusted variant of :rf.server/redirect. Where redirect-fx
 ;; accepts arbitrary :location strings, safe-redirect-fx parses the URL
-;; and runs a five-step gate before populating the :redirect slot:
+;; and gates on the parsed URL SHAPE — not merely on the presence of a
+;; host — before populating the :redirect slot:
 ;;
 ;;   1. URL must parse — :rf.error/safe-redirect-invalid-url on failure.
 ;;   2. Reject javascript: / data: / vbscript: schemes (no safe redirect
 ;;      interpretation; consistent with the rf2-vwcsq custom-editor
 ;;      scheme-rejection policy) — :rf.error/safe-redirect-scheme-rejected.
-;;   3. :relative-only? true AND URL has a host →
+;;   2b. Reject any scheme outside #{http https} outright — a redirect
+;;      Location is only ever an http(s) absolute URL or a relative
+;;      reference; mailto:, ftp:, and other schemes have no place as a
+;;      redirect target — :rf.error/safe-redirect-scheme-rejected.
+;;   2c. Reject a SCHEME-BEARING URL whose host is not extractable. An
+;;      http(s) URI that is opaque (`http:evil.example.com` — scheme
+;;      present, authority absent) or hierarchical-without-authority
+;;      (`http:/evil` — no `//host`) parses cleanly but has nil host.
+;;      Java's URI.getHost returns nil for these, so the host-based gates
+;;      (steps 3/4) cannot see them — yet a browser given
+;;      `Location: http:evil.example.com` navigates OFF-ORIGIN. These
+;;      have no defensible redirect interpretation →
+;;      :rf.error/safe-redirect-invalid-url (:reason :scheme-without-host).
+;;   3. :relative-only? true AND the URL is NOT a relative reference →
 ;;      :rf.error/safe-redirect-host-disallowed (:reason :relative-only-violation).
+;;      A relative reference is `scheme == nil AND authority == nil`
+;;      (e.g. `/dashboard`, `dashboard`, `a/b`). A protocol-relative
+;;      `//evil.example.com` HAS an authority and is therefore NOT
+;;      relative — it is rejected under :relative-only? .
 ;;   4. :allow [...] supplied AND URL's host not in allowlist →
 ;;      :rf.error/safe-redirect-host-disallowed (:reason :not-in-allowlist).
+;;      A non-relative target that reaches this gate has, after step 2c,
+;;      an extractable host; if it is absent from the allowlist it is
+;;      rejected.
 ;;   5. Pass — set Location header (same shape as redirect-fx).
 ;;
-;; All four failure modes EMIT (via re-frame.trace) rather than THROW.
+;; All failure modes EMIT (via re-frame.trace) rather than THROW.
 ;; Throwing would bubble out as :rf.error/fx-handler-exception and the
 ;; programmer reading the trace would see a generic fx-handler-exception
 ;; pointing at safe-redirect-fx rather than the specific category.
@@ -459,13 +502,27 @@
 ;; the specific :rf.error/safe-redirect-* category.
 ;;
 ;; Mitigation for the open-redirect class (security audit 2026-05-14
-;; §P3.2): an attacker-controlled ?next=... URL parameter cannot redirect
-;; off-origin when the app uses safe-redirect-fx instead of redirect-fx.
+;; §P3.2; scheme-bypass hardening rf2-v3eg3 finding 1): an
+;; attacker-controlled ?next=... URL parameter cannot redirect off-origin
+;; when the app uses safe-redirect-fx instead of redirect-fx — including
+;; the scheme-bearing opaque-URI bypass (`http:evil.example.com`) that
+;; defeats a host-presence-only gate.
 
 (def ^:private rejected-schemes
   "Closed set of schemes the safe-redirect-fx rejects outright. Per
   rf2-zfm8v decision step 2 and rf2-vwcsq's custom-editor scheme policy."
   #{"javascript" "data" "vbscript"})
+
+(def ^:private allowed-schemes
+  "Closed set of schemes a redirect Location may legitimately carry. A
+  redirect target is either a relative reference (no scheme) or an
+  absolute http(s) URL — every other scheme (mailto, ftp, file, tel, …)
+  is rejected outright as a redirect target. Per rf2-v3eg3 finding 1
+  (scheme-bypass hardening): the safe-redirect gate decides non-http(s)
+  schemes by rejecting them rather than by maintaining a per-app scheme
+  allowlist — an opt-in scheme allowlist can be layered later if a real
+  use case appears."
+  #{"http" "https"})
 
 (def ^:private scheme-prefix-re
   "Matches the scheme prefix of an absolute URL — `<scheme>:` where the
@@ -529,19 +586,29 @@
      :allow          [\"app.example.com\" \"alt.example.com\"]  ;; host allowlist
      :status         302}                  ;; defaults 302 if absent
 
-  Validation order (per Spec 009 §Error event catalogue):
+  Validation order (per Spec 009 §Error event catalogue). The gate is on
+  the parsed URL SHAPE, not merely on host presence (rf2-v3eg3 finding 1):
 
-    1. URL parses → :rf.error/safe-redirect-invalid-url on failure
-    2. scheme ∈ #{javascript data vbscript} → :rf.error/safe-redirect-scheme-rejected
-    3. :relative-only? true + URL has host → :rf.error/safe-redirect-host-disallowed
-       (:reason :relative-only-violation)
-    4. :allow supplied + host ∉ allow → :rf.error/safe-redirect-host-disallowed
-       (:reason :not-in-allowlist)
-    5. Pass → set :redirect (same shape as :rf.server/redirect)
+    1.  URL parses → :rf.error/safe-redirect-invalid-url on failure
+    2.  scheme ∈ #{javascript data vbscript} → :rf.error/safe-redirect-scheme-rejected
+    2b. scheme ∉ #{http https} → :rf.error/safe-redirect-scheme-rejected
+        (:reason :scheme-not-allowed) — mailto:, ftp:, file:, … rejected
+    2c. scheme present but host not extractable (opaque `http:evil` or
+        authority-less `http:/evil`) → :rf.error/safe-redirect-invalid-url
+        (:reason :scheme-without-host) — the scheme-bearing open-redirect
+        bypass that defeats a host-presence-only gate
+    3.  :relative-only? true + URL is NOT a relative reference (has a
+        scheme OR an authority — incl. protocol-relative `//host`) →
+        :rf.error/safe-redirect-host-disallowed (:reason :relative-only-violation)
+    4.  :allow supplied + host ∉ allow → :rf.error/safe-redirect-host-disallowed
+        (:reason :not-in-allowlist)
+    5.  Pass → set :redirect (same shape as :rf.server/redirect)
 
-  Mitigation for the open-redirect class (audit 2026-05-14 §P3.2):
-  an attacker-controlled ?next=... URL parameter cannot redirect
-  off-origin when the app uses safe-redirect-fx.
+  Mitigation for the open-redirect class (audit 2026-05-14 §P3.2;
+  scheme-bypass hardening rf2-v3eg3 finding 1): an attacker-controlled
+  ?next=... URL parameter cannot redirect off-origin when the app uses
+  safe-redirect-fx — including scheme-bearing opaque URIs such as
+  `http:evil.example.com`.
 
   Per rf2-zfm8v (Mike decision, Option A — ship safe-redirect-fx
   alongside redirect-fx, 2026-05-14)."
@@ -580,30 +647,78 @@
                                       :reason   "URL did not parse"})
 
           :else
-          (let [scheme #?(:clj (.getScheme ^URI uri) :cljs nil)
-                host   #?(:clj (.getHost   ^URI uri) :cljs nil)]
+          (let [scheme    #?(:clj (.getScheme    ^URI uri) :cljs nil)
+                host      #?(:clj (.getHost       ^URI uri) :cljs nil)
+                authority #?(:clj (.getAuthority  ^URI uri) :cljs nil)
+                scheme-lc (when scheme (clojure.string/lower-case scheme))
+                ;; A relative reference carries neither a scheme nor an
+                ;; authority — `/dashboard`, `dashboard`, `a/b`. This is
+                ;; the open-redirect-safe shape: the browser resolves it
+                ;; against the current origin. A protocol-relative
+                ;; `//evil.example.com` has an authority (host non-nil)
+                ;; and is NOT relative. A scheme-bearing opaque URI
+                ;; `http:evil.example.com` has a scheme and is NOT
+                ;; relative — even though Java reports its host as nil.
+                ;; (rf2-v3eg3 finding 1: shape, not host-presence.)
+                relative? (and (nil? scheme) (nil? authority))]
             (cond
               ;; Step 2: scheme rejection (post-parse path — covers
               ;; schemes whose body DID parse cleanly, e.g.
               ;; `javascript:foo` without parens).
-              (and scheme (rejected-schemes (clojure.string/lower-case scheme)))
+              (and scheme-lc (rejected-schemes scheme-lc))
               (emit-safe-redirect-error! :rf.error/safe-redirect-scheme-rejected
                                          {:frame    frame
                                           :location location
                                           :scheme   scheme})
 
-              ;; Step 3: :relative-only? gate
-              (and relative-only? host)
+              ;; Step 2b: any non-http(s) scheme is rejected outright. A
+              ;; redirect Location is an http(s) absolute URL or a
+              ;; relative reference — mailto:, ftp:, file:, tel:, etc.
+              ;; have no defensible redirect interpretation and would
+              ;; otherwise slip the host-based gates (nil host).
+              ;; (rf2-v3eg3 finding 1.)
+              (and scheme-lc (not (allowed-schemes scheme-lc)))
+              (emit-safe-redirect-error! :rf.error/safe-redirect-scheme-rejected
+                                         {:frame    frame
+                                          :location location
+                                          :scheme   scheme
+                                          :reason   :scheme-not-allowed})
+
+              ;; Step 2c: a scheme-bearing http(s) URL whose host is not
+              ;; extractable — an opaque URI (`http:evil.example.com`) or
+              ;; a hierarchical URI with no authority (`http:/evil`).
+              ;; These parse cleanly with a nil host, so the host-based
+              ;; gates below cannot see them, yet a browser navigates
+              ;; off-origin on `Location: http:evil.example.com`. No
+              ;; defensible redirect interpretation. (rf2-v3eg3 finding 1
+              ;; — the scheme-bypass that defeated the host-presence-only
+              ;; open-redirect gate.)
+              (and scheme-lc (nil? host))
+              (emit-safe-redirect-error! :rf.error/safe-redirect-invalid-url
+                                         {:frame    frame
+                                          :location location
+                                          :scheme   scheme
+                                          :reason   :scheme-without-host})
+
+              ;; Step 3: :relative-only? gate — reject anything that is
+              ;; NOT a relative reference (has a scheme OR an authority),
+              ;; not merely anything whose host is extractable. This
+              ;; closes the opaque-URI and protocol-relative bypasses.
+              (and relative-only? (not relative?))
               (emit-safe-redirect-error! :rf.error/safe-redirect-host-disallowed
                                          {:frame    frame
                                           :location location
                                           :host     host
                                           :reason   :relative-only-violation})
 
-              ;; Step 4: :allow [...] allowlist. DNS hostnames are
+              ;; Step 4: :allow [...] allowlist. After step 2c every
+              ;; non-relative target reaching here has an extractable
+              ;; host. A relative reference (no host) is allowed through
+              ;; — :allow gates absolute targets, it does not block
+              ;; same-origin relative redirects. DNS hostnames are
               ;; case-insensitive (RFC 1035 §2.3.3), so lower-case both
-              ;; sides — matching the header/cookie token-grammar treatment
-              ;; elsewhere in this file.
+              ;; sides — matching the header/cookie token-grammar
+              ;; treatment elsewhere in this file.
               (and (seq allow)
                    host
                    (not (contains? (into #{} (map clojure.string/lower-case) allow)

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -1465,6 +1465,150 @@
       (is (nil? (:redirect (get-response f)))
           "rejection is a no-op"))))
 
+;; --- rf2-v3eg3 finding 1: scheme-bearing open-redirect BYPASS -------------
+;;
+;; The pre-fix gate used java.net.URI.getHost as the policy discriminator
+;; and only rejected when host was truthy. Java reports a nil host for a
+;; scheme-bearing OPAQUE URI (`http:evil.example.com` — scheme present,
+;; no authority) and for a hierarchical URI with no authority
+;; (`http:/evil`). Those slipped BOTH the :relative-only? and the :allow
+;; host gates and populated :redirect — a browser given
+;; `Location: http:evil.example.com` navigates OFF-ORIGIN. The fix gates
+;; on parsed-URL SHAPE: a relative reference is `scheme==nil AND
+;; authority==nil`; anything else is non-relative and subject to the
+;; host gates, and a scheme-bearing-but-host-less URL has no defensible
+;; redirect interpretation.
+
+(deftest safe-redirect-rejects-scheme-bearing-opaque-http-bypass
+  (testing "rf2-v3eg3 finding 1: `http:evil.example.com` (opaque, host=nil)
+            is the open-redirect bypass — it MUST be rejected (no :redirect)
+            under :relative-only?, under :allow, AND with no policy"
+    (doseq [[label policy] [["no-policy"      {}]
+                            ["relative-only?" {:relative-only? true}]
+                            ["allow"          {:allow ["app.example.com"]}]]]
+      (rf/reg-event-fx :sr/opaque-http
+        (fn [_ _]
+          {:fx [[:rf.server/safe-redirect
+                 (merge {:location "http:evil.example.com"} policy)]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-safe-redirect-traces!
+                     (fn [] (rf/dispatch-sync [:sr/opaque-http] {:frame f})))]
+        (is (seq traces)
+            (str "[" label "] a :rf.error/safe-redirect-* trace fires — "
+                 "the bypass is closed"))
+        (is (nil? (:redirect (get-response f)))
+            (str "[" label "] no :redirect mutation — the off-origin "
+                 "scheme-bearing opaque URI is rejected"))))))
+
+(deftest safe-redirect-rejects-scheme-bearing-opaque-https-bypass
+  (testing "rf2-v3eg3 finding 1: `https:evil.example.com` (opaque, host=nil)
+            rejected as :rf.error/safe-redirect-invalid-url
+            (:reason :scheme-without-host)"
+    (rf/reg-event-fx :sr/opaque-https
+      (fn [_ _]
+        {:fx [[:rf.server/safe-redirect {:location "https:evil.example.com"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-safe-redirect-traces!
+                   (fn [] (rf/dispatch-sync [:sr/opaque-https] {:frame f})))]
+      (is (some #(and (= :rf.error/safe-redirect-invalid-url (:operation %))
+                      (= :scheme-without-host (-> % :tags :reason)))
+                traces)
+          ":scheme-without-host reason names the shape failure")
+      (is (nil? (:redirect (get-response f)))
+          "rejection is a no-op"))))
+
+(deftest safe-redirect-rejects-mailto-scheme
+  (testing "rf2-v3eg3 finding 1: `mailto:user@example.com` — a non-http(s)
+            scheme is rejected outright as scheme-rejected
+            (:reason :scheme-not-allowed)"
+    (rf/reg-event-fx :sr/mailto
+      (fn [_ _]
+        {:fx [[:rf.server/safe-redirect {:location "mailto:user@example.com"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-safe-redirect-traces!
+                   (fn [] (rf/dispatch-sync [:sr/mailto] {:frame f})))]
+      (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
+                      (= "mailto" (-> % :tags :scheme))
+                      (= :scheme-not-allowed (-> % :tags :reason)))
+                traces)
+          "mailto: rejected as :scheme-not-allowed")
+      (is (nil? (:redirect (get-response f)))
+          "rejection is a no-op"))))
+
+(deftest safe-redirect-rejects-ftp-scheme
+  (testing "rf2-v3eg3 finding 1: `ftp:example.com` — non-http(s) scheme
+            rejected outright (opaque form, host=nil)"
+    (rf/reg-event-fx :sr/ftp
+      (fn [_ _]
+        {:fx [[:rf.server/safe-redirect {:location "ftp:example.com"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-safe-redirect-traces!
+                   (fn [] (rf/dispatch-sync [:sr/ftp] {:frame f})))]
+      (is (some #(= :rf.error/safe-redirect-scheme-rejected (:operation %))
+                traces)
+          "ftp: rejected (non-http(s) scheme)")
+      (is (nil? (:redirect (get-response f)))
+          "rejection is a no-op"))))
+
+(deftest safe-redirect-rejects-protocol-relative-under-policy
+  (testing "rf2-v3eg3 finding 1: `//evil.example.com/path` (protocol-relative,
+            authority=evil.example.com) is NOT a relative reference — it is
+            rejected under :relative-only? and under :allow (host mismatch)"
+    (doseq [[label policy expected-reason]
+            [["relative-only?" {:relative-only? true} :relative-only-violation]
+             ["allow"          {:allow ["app.example.com"]} :not-in-allowlist]]]
+      (rf/reg-event-fx :sr/protocol-relative
+        (fn [_ _]
+          {:fx [[:rf.server/safe-redirect
+                 (merge {:location "//evil.example.com/path"} policy)]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-safe-redirect-traces!
+                     (fn [] (rf/dispatch-sync [:sr/protocol-relative] {:frame f})))]
+        (is (some #(and (= :rf.error/safe-redirect-host-disallowed (:operation %))
+                        (= expected-reason (-> % :tags :reason)))
+                  traces)
+            (str "[" label "] protocol-relative rejected with reason "
+                 expected-reason))
+        (is (nil? (:redirect (get-response f)))
+            (str "[" label "] no :redirect mutation"))))))
+
+(deftest safe-redirect-accepts-normal-relative-path-control
+  (testing "rf2-v3eg3 finding 1 CONTROL: a normal relative path still passes
+            cleanly under :relative-only? — the hardening did not over-reject
+            the legitimate same-origin case"
+    (rf/reg-event-fx :sr/relative-control
+      (fn [_ _]
+        {:fx [[:rf.server/safe-redirect
+               {:location "/account/settings" :relative-only? true}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-safe-redirect-traces!
+                   (fn [] (rf/dispatch-sync [:sr/relative-control] {:frame f})))
+          resp   (get-response f)]
+      (is (empty? traces)
+          "no :rf.error/safe-redirect-* trace on a legitimate relative path")
+      (is (= "/account/settings" (-> resp :redirect :location))
+          ":location lands on the response :redirect slot")
+      (is (= 302 (-> resp :redirect :status))
+          ":status defaults to 302"))))
+
+(deftest safe-redirect-still-accepts-allowed-absolute-host-control
+  (testing "rf2-v3eg3 finding 1 CONTROL: a well-formed absolute http(s) URL
+            whose host IS in the allowlist still passes — the shape gate
+            did not break the legitimate absolute-redirect path"
+    (rf/reg-event-fx :sr/abs-control
+      (fn [_ _]
+        {:fx [[:rf.server/safe-redirect
+               {:location "https://app.example.com/dashboard"
+                :allow    ["app.example.com"]}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-safe-redirect-traces!
+                   (fn [] (rf/dispatch-sync [:sr/abs-control] {:frame f})))
+          resp   (get-response f)]
+      (is (empty? traces)
+          "no trace on an allowlisted absolute host")
+      (is (= "https://app.example.com/dashboard" (-> resp :redirect :location))
+          ":location passes through"))))
+
 ;; --- CRLF defence-in-depth still holds ------------------------------------
 
 (deftest safe-redirect-also-rejects-crlf-injection
@@ -1687,6 +1831,95 @@
       (expect-fx-error-keyword!
         traces :rf.error/cookie-invalid-path
         "delete-cookie with CRLF in :path"))))
+
+(deftest ssr-set-cookie-crlf-checks-every-attribute
+  (testing "rf2-kjf3m.1 / Spec 011 §CRLF fail-fast: :rf.server/set-cookie
+            CRLF-checks EVERY attribute the host adapter serialises —
+            :max-age, :same-site, :expires — not just :value/:path/:domain.
+            The fx boundary is the single enforcement point for non-Ring
+            host adapters; a string :max-age sourced from request context
+            must not re-enter the header line as CRLF-bearing payload."
+    ;; The concrete failing scenario from the bead: string :max-age
+    ;; carrying a forged second Set-Cookie line.
+    (testing ":max-age (string form) with CRLF → :rf.error/cookie-invalid-max-age"
+      (rf/reg-event-fx :ck/crlf-in-max-age
+        (fn [_ _]
+          {:fx [[:rf.server/set-cookie
+                 {:name    "session"
+                  :value   "x"
+                  :max-age "3600\r\nSet-Cookie: admin=1; Path=/"}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-fx-traces!
+                     (fn [] (rf/dispatch-sync [:ck/crlf-in-max-age] {:frame f})))]
+        (expect-fx-error-keyword!
+          traces :rf.error/cookie-invalid-max-age
+          "set-cookie with CRLF in :max-age")
+        (is (empty? (:cookies (get-response f)))
+            "no cookie lands on the accumulator — rejection is a no-op")))
+
+    (testing ":same-site with CRLF → :rf.error/cookie-invalid-same-site"
+      (rf/reg-event-fx :ck/crlf-in-same-site
+        (fn [_ _]
+          {:fx [[:rf.server/set-cookie
+                 {:name      "session"
+                  :value     "x"
+                  :same-site "Lax\r\nSet-Cookie: admin=1"}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-fx-traces!
+                     (fn [] (rf/dispatch-sync [:ck/crlf-in-same-site] {:frame f})))]
+        (expect-fx-error-keyword!
+          traces :rf.error/cookie-invalid-same-site
+          "set-cookie with CRLF in :same-site")))
+
+    (testing ":expires with CRLF → :rf.error/cookie-invalid-expires"
+      (rf/reg-event-fx :ck/crlf-in-expires
+        (fn [_ _]
+          {:fx [[:rf.server/set-cookie
+                 {:name    "session"
+                  :value   "x"
+                  :expires "Wed, 09 Jun 2027 10:18:14 GMT\r\nSet-Cookie: admin=1"}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-fx-traces!
+                     (fn [] (rf/dispatch-sync [:ck/crlf-in-expires] {:frame f})))]
+        (expect-fx-error-keyword!
+          traces :rf.error/cookie-invalid-expires
+          "set-cookie with CRLF in :expires")))
+
+    (testing "bare LF / bare CR / NUL in :max-age all rejected"
+      (doseq [hostile ["lf\nbad" "cr\rbad" (str "nul" (char 0) "bad")]]
+        (rf/reg-event-fx :ck/probe-max-age
+          (fn [_ _]
+            {:fx [[:rf.server/set-cookie
+                   {:name "s" :value "x" :max-age hostile}]]}))
+        (let [f      (rf/make-frame {:platform :server})
+              traces (capture-fx-traces!
+                       (fn [] (rf/dispatch-sync [:ck/probe-max-age] {:frame f})))]
+          (expect-fx-error-keyword!
+            traces :rf.error/cookie-invalid-max-age
+            (str "hostile :max-age " (pr-str hostile))))))))
+
+(deftest ssr-set-cookie-clean-attributes-still-accepted
+  (testing "rf2-kjf3m.1 regression guard: legitimate cookie attributes still
+            flow — integer :max-age, keyword/string :same-site, a clean
+            :expires string. The CRLF gate str-coerces and only bans
+            CR/LF/NUL; benign values pass."
+    (rf/reg-event-fx :ck/clean-attrs
+      (fn [_ _]
+        {:fx [[:rf.server/set-cookie
+               {:name      "session"
+                :value     "abc123"
+                :max-age   3600                ;; int — (str 3600) is clean
+                :same-site "Strict"
+                :path      "/"
+                :expires   "Wed, 09 Jun 2027 10:18:14 GMT"}]]}))
+    (let [f       (rf/make-frame {:platform :server :on-create [:ck/clean-attrs]})
+          cookies (:cookies (get-response f))]
+      (is (= 1 (count cookies))
+          "the clean cookie lands on the accumulator")
+      (is (= 3600 (-> cookies first :max-age))
+          "integer :max-age survives unchanged (not coerced to string)")
+      (is (= "Strict" (-> cookies first :same-site))
+          ":same-site survives"))))
 
 (deftest ssr-clean-names-still-accepted
   (testing "rf2-z7gor — regression guard: legitimate header names + cookie


### PR DESCRIPTION
Senior review hardening of `implementation/ssr`. Three must-fix items landed; one investigated and deferred (cross-artefact). spec/011 untouched (the spec is already correct for all of these). Closes rf2-v3eg3 + rf2-kjf3m.1.

## Finding 1 — SECURITY: safe-redirect scheme-bypass (open-redirect)

`:rf.server/safe-redirect` used `java.net.URI.getHost` as the policy discriminator and only rejected when host was truthy. Java reports a **nil host** for scheme-bearing **opaque** URIs (`http:evil.example.com`, `https:evil.example.com`, `mailto:`, `ftp:`) and for hierarchical URIs with no authority (`http:/evil`) — so those slipped **both** the `:relative-only?` and `:allow` host gates and populated `:redirect`. A browser handed `Location: http:evil.example.com` navigates off-origin, defeating the open-redirect mitigation.

**Fix** (`response.cljc`): discriminate on parsed-URL **shape**, not host presence.
- relative reference = `scheme == nil AND authority == nil` (`/dashboard`, `dashboard`, `a/b`)
- any non-http(s) scheme rejected outright → `:rf.error/safe-redirect-scheme-rejected` (`:reason :scheme-not-allowed`)
- http(s) scheme present but no extractable host → `:rf.error/safe-redirect-invalid-url` (`:reason :scheme-without-host`)
- `:relative-only?` rejects anything that is **not** a relative reference (closes the opaque-URI **and** protocol-relative `//host` bypasses)
- `:allow` still requires the (now-guaranteed-present) absolute host to be in the allowlist

**Bypass proof** (old vs new gate against the real `java.net.URI` parser):

| input | policy | OLD | NEW |
|---|---|---|---|
| `http:evil.example.com` | relative-only | **PASSED** | rejected-scheme-without-host |
| `http:evil.example.com` | allow=[app] | **PASSED** | rejected-scheme-without-host |
| `https:evil.example.com` | relative-only | **PASSED** | rejected-scheme-without-host |
| `mailto:user@example.com` | (none) | **PASSED** | rejected-scheme-not-allowed |
| `ftp:example.com` | (none) | **PASSED** | rejected-scheme-not-allowed |
| `//evil.example.com/path` | relative-only | rejected | rejected-relative-only |
| `/dashboard` | relative-only | passed | passed |
| `https://app.example.com/x` | allow=[app] | passed | passed |

## kjf3m.1 — set-cookie CRLF on every attribute (Spec 011 §CRLF fail-fast)

`validate-cookie!` skipped the CR/LF/NUL check on `:max-age` / `:same-site` / `:expires`. The fx boundary is the single enforcement point for non-Ring host adapters; a string `:max-age` sourced from request context could re-enter the header line as a forged second `Set-Cookie`. **Fix**: CRLF-check every attribute (str-coerced first, so int `:max-age` / instant `:expires` still pass).

## Finding 3 — docs/api/09-ssr.md vs impl

- Said SSR is **not** re-exported from `re-frame.core` — but core exposes seven late-bound SSR/head wrappers (`render-to-string`, `render-tree-hash`, `project-error`, `render-head`, `active-head`, `head-model->html`, `head-snapshot`). Corrected (also resolves the internal contradiction with the `head-snapshot` row that already claimed re-export).
- Said structural-hash mismatch surfaces `:rf.ssr/version-mismatch` / `:rf.ssr/schema-digest-mismatch` — the impl emits **`:rf.ssr/hydration-mismatch`** (`hydrate.cljc`). Corrected, and clarified the distinction from the two payload-provenance checks.

## Finding 2 — streaming nested suspense-boundary: DEFERRED → rf2-b1v8v

Investigated. The spec (011 §922-924, §966, §983) is **explicit and unambiguous** that nested boundaries register during continuation render and drain FIFO — **no spec change needed/made**. But the impl gap is **cross-artefact**: `render-continuation` (`streaming.cljc`) renders via the non-streaming emitter (which throws on `:rf/suspense-boundary`), AND the ring writer loop (`ssr-ring/streaming.clj:223`) drains a **static** `(doseq)` vector with no re-walk/append. Making it work also changes the shared `:ssr.streaming/render-continuation!` late-bind return shape. ssr-ring is outside this worker's ownership, so a partial fix would worsen the split-brain. Filed **rf2-b1v8v** (P2) with full scope.

## Gates (cold)
- SSR JVM `clojure -M:test`: **275 tests / 948 assertions, 0 failures**
- `npm run test:cljs`: **5620 tests / 19586 assertions, 0 failures**
- `mkdocs build --strict`: clean

NOT merged — for review.


---

## Quality gates (greenup — downstream ssr-ring fix)

The `kjf3m.1` CRLF-check-every-attribute hardening had a **downstream** consequence the original change didn't catch: two ssr-ring JVM tests (`streaming_robustness_test/head-materialisation-throw-does-not-orphan-writer` and `ring_test/ssr-handler-throwing-on-error-on-success-path-is-contained`) deliberately set a cookie `{:max-age "1\r\n2"}` that **slipped the fx boundary** to throw later at **head materialisation** — the trigger for the streaming fail-closed contract (head throw → locked `:on-error` string body, no orphaned `rf2-ssr-streaming-*` writer thread). Now that `:max-age` is CRLF-gated at the fx boundary, that cookie no longer reaches the materialiser, so the contract was no longer being exercised (red gate: body was a `PipedInputStream` + a leaked writer thread instead of the `"Internal error"` string).

**Root cause**: the new cookie validation is correct (CRLF in `:max-age` MUST be rejected — that is the whole point of `kjf3m.1`); the test's throw-trigger went stale. **Option (a)** — re-triggered the head-materialisation throw via the genuine remaining fx-boundary/materialiser divergence: a **non-integer `:expires`**. The fx boundary `validate-cookie!` is a CR/LF/NUL injection gate (it str-coerces every attribute and bans header-splitting chars) and does **not** type-check `:expires`, so `{:expires "not-an-int"}` passes it; `cookie->set-cookie-header` carries the primitive-long `:expires` type contract (`Instant/ofEpochMilli`) and throws `:rf.error/cookie-invalid-expires` at head materialise. Test intent (rf2-z5azc / rf2-ljjh0) preserved; the security/CRLF fix is **not** weakened.

Gates re-run after the fix:
- **ssr-ring JVM `clojure -M:test`** (the red gate): **115 tests / 492 assertions, 0 failures, 0 errors** ✅
- ssr JVM `clojure -M:test`: **275 tests / 948 assertions, 0 failures** ✅
- `npm run test:cljs`: **5634 tests / 19623 assertions, 0 failures** ✅
- `mkdocs build --strict`: clean (exit 0) ✅
