### PR TITLE
fix(epoch): three race/atomicity correctness bugs (rf2-7i872)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -506,31 +506,44 @@
   Records a synthetic `:rf/epoch-record` (so `restore-epoch` can rewind
   the prior state), emits `:rf.epoch/db-replaced`, replaces the
   container, and fans the record out to registered listeners. Returns
-  `true`."
+  `true` on a real write.
+
+  Per rf2-7i872 (validate-then-destroy race): re-resolves the container
+  at the write boundary via `tool-pair/live-container-or-fail`. If the
+  frame was destroyed between the precondition pass and now, the container
+  is nil and `replace-container!` would silently no-op — so instead of
+  recording a synthetic epoch for a destroyed frame, fanning it out to
+  listeners, emitting `:rf.epoch/db-replaced`, and returning `true` (a
+  FALSE success against a frame that no longer exists), this emits the
+  canonical `:rf.error/no-such-handler` (kind `:frame`) failure trace and
+  returns `false`, matching the destroyed-frame contract."
   [frame-id new-db]
-  (let [container (frame/app-db-container frame-id)
-        db-before (when container (adapter/read-container container))]
-    (adapter/replace-container! container new-db)
-    ;; Record a synthetic epoch so `restore-epoch` can rewind the
-    ;; previous state. The record's :trigger-event is the
-    ;; pair-tool injection sentinel (no application event ran).
-    ;; Per rf2-wp70d: `maybe-redact` runs once between assembly and
-    ;; the record!/notify-listeners! split so ring + listeners see
-    ;; the SAME redacted shape on this synthetic record too.
-    (let [record (assembly/maybe-redact
-                   (assoc (assembly/build-record frame-id db-before new-db [])
-                          :event-id      :rf.epoch/db-replaced
-                          :trigger-event [:rf.epoch/db-replaced]))]
-      (state/record! record)
-      ;; Per rf2-qs6dl: a `reset-frame-db!` re-renders the views that read
-      ;; the replaced state; attribute those post-settle renders back to
-      ;; this synthetic epoch rather than the next real cascade.
-      (state/set-last-settled-epoch! frame-id (:epoch-id record))
-      (trace/emit! :rf.epoch :rf.epoch/db-replaced
-                   {:frame       frame-id
-                    :rf.epoch/id (:epoch-id record)})
-      (listeners/notify-listeners! record))
-    true))
+  (let [{:keys [outcome op tags container]} (tool-pair/live-container-or-fail frame-id)]
+    (if (= :fail outcome)
+      (do (tool-pair/emit-precondition-failure! op tags)
+          false)
+      (let [db-before (adapter/read-container container)]
+        (adapter/replace-container! container new-db)
+        ;; Record a synthetic epoch so `restore-epoch` can rewind the
+        ;; previous state. The record's :trigger-event is the
+        ;; pair-tool injection sentinel (no application event ran).
+        ;; Per rf2-wp70d: `maybe-redact` runs once between assembly and
+        ;; the record!/notify-listeners! split so ring + listeners see
+        ;; the SAME redacted shape on this synthetic record too.
+        (let [record (assembly/maybe-redact
+                       (assoc (assembly/build-record frame-id db-before new-db [])
+                              :event-id      :rf.epoch/db-replaced
+                              :trigger-event [:rf.epoch/db-replaced]))]
+          (state/record! record)
+          ;; Per rf2-qs6dl: a `reset-frame-db!` re-renders the views that read
+          ;; the replaced state; attribute those post-settle renders back to
+          ;; this synthetic epoch rather than the next real cascade.
+          (state/set-last-settled-epoch! frame-id (:epoch-id record))
+          (trace/emit! :rf.epoch :rf.epoch/db-replaced
+                       {:frame       frame-id
+                        :rf.epoch/id (:epoch-id record)})
+          (listeners/notify-listeners! record))
+        true))))
 
 (defn reset-frame-db!
   "Replace `frame-id`'s `app-db` with `new-db`, bypassing the dispatch

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -566,60 +566,85 @@
 ;; does the ring mutation and the two public fns are thin wrappers
 ;; pinning the slot.
 
-(defn- redact-appended-delta
+(defn- compute-redacted-delta
   "Run `redact` over ONLY the newly-appended delta (the new `:trace-events`
-  `event` and the new `slot` `row`), then splice the redacted delta back
-  onto `record` — leaving every already-redacted slot value untouched.
-  Returns the updated record. Per rf2-qhxz6: this honours the Tool-Pair
-  §Redaction hook contract literally — `:redact-fn` sees each appended
-  slot value EXACTLY ONCE across the record's whole lifetime, so a
-  NON-idempotent `:redact-fn` (one that transforms a value rather than
-  substituting an idempotent `:rf/redacted` sentinel — e.g. hash-and-
-  truncate, append an audit marker, increment a counter) never re-runs
-  over a slot it already scrubbed.
+  `event` and the new `slot` `row`) and return a MAP of the redacted delta
+  VALUES keyed by their target slot:
+
+    {:append?       <bool — was there a :trace-events delta?>
+     :row?          <bool — was there a structured `slot` row delta?>
+     :trace-events  <redacted :trace-events delta value, when :append?>
+     :slot          <the structured slot keyword>
+     :slot-value    <redacted `slot` delta value, when :row?>}
+
+  Returns `nil` when there is no delta to append (an unmount on a record
+  whose `:trace-events` was already dropped by the keep-window cap).
+
+  Per rf2-7i872: `redact` (the app-supplied `:redact-fn`, via
+  `assembly/maybe-redact`) is INVOKED HERE — exactly ONCE — and the caller
+  runs this OUTSIDE the `swap!` retry loop. A JVM CAS retry of the ring
+  mutation must NOT re-invoke the app's `:redact-fn`: it is documented
+  non-idempotent (hash-and-truncate, increment-a-counter) and a throwing
+  fn emits a `:rf.warning/epoch-redact-fn-exception` warning per call — a
+  retry would corrupt the prior output and emit DUPLICATE warnings. Only
+  the PURE splice (`splice-redacted-delta`) rides inside the swap.
 
   HOW. We hand `redact` a probe record shaped exactly like the assembled
   record (so an `:redact-fn` that keys on whole-record structure — reads
   `:db-after` / `:frame` / `:rf.epoch/sensitive?` for its decision — still
   composes) BUT whose `:trace-events` / `slot` lists carry ONLY the new
   delta element. The fn redacts that delta in place; we extract the
-  redacted element(s) and `conj` them onto `record`'s real (already-
-  redacted) slots. The leak the rf2-82pcg fix closed STAYS closed — the
-  appended slots still pass through `:redact-fn` before reaching either
-  egress channel — but each slot is now redacted once, not 1+K times.
+  redacted element(s) for the caller to splice onto the real slots. The
+  leak the rf2-82pcg fix closed STAYS closed — the appended slots still
+  pass through `:redact-fn` before reaching either egress channel — and
+  per rf2-qhxz6 each slot is redacted exactly once (no idempotency
+  requirement on `:redact-fn`).
 
-  Slot extraction. When `redact` returns the probe slot still as a vector
-  (the common per-element-transform / sentinel-substitution shape) we take
-  its element(s) — the redacted delta — and `conj` onto the real slot.
-  When `redact` instead COLLAPSES the whole slot to a non-vector sentinel
-  (e.g. `(assoc r :trace-events :rf/redacted)` — a whole-slot scrub), the
-  fn's intent is to redact the entire slot, so we write that sentinel to
-  the real slot. We only `conj` onto a real slot that is a vector (or
-  absent); a real slot already collapsed to a sentinel by a prior
-  whole-slot scrub is left at the sentinel (the delta is subsumed).
-
-  Pure (record-in, record-out); `redact` is the only injected fn it
-  calls, so it stays retry-safe inside the `swap!`."
+  `record` is the current ring record — supplies the probe CONTEXT (the
+  immutable post-settle fields a whole-record-keyed `:redact-fn` reads).
+  The redacted delta VALUES it returns are spliced by the caller; the
+  context fields themselves are never written back (the real record's
+  already-redacted slots are left untouched)."
   [record slot event row redact]
-  (let [append?  (contains? record :trace-events)
-        ;; Probe = the real record's context with ONLY the new delta in
-        ;; the redactable list slots. Other slots ride unchanged so a
-        ;; whole-record-keyed `:redact-fn` reads the same context it saw
-        ;; at settle time.
-        delta?   (or append? (some? row))
-        ;; No delta to append (an unmount on a record whose `:trace-events`
-        ;; was already dropped by the keep-window cap) → nothing to redact,
-        ;; return the record untouched (do NOT spuriously re-redact it).
-        probe    (when delta?
-                   (cond-> record
-                     append?     (assoc :trace-events [event])
-                     (some? row) (assoc slot [row])))
-        redacted (when delta? (redact probe))
-        ;; Splice a redacted delta value back onto the real slot. `dv` is
-        ;; the redacted probe-slot value: a vector (per-element / sentinel-
-        ;; substitution) → conj its element(s) onto the real slot; a non-
-        ;; vector (whole-slot collapse) → adopt that sentinel for the slot.
-        splice   (fn [rec real-slot dv]
+  (let [append? (contains? record :trace-events)
+        row?    (some? row)
+        delta?  (or append? row?)]
+    (when delta?
+      (let [probe    (cond-> record
+                       append? (assoc :trace-events [event])
+                       row?    (assoc slot [row]))
+            redacted (redact probe)]
+        (cond-> {:append? append? :row? row? :slot slot}
+          append? (assoc :trace-events (:trace-events redacted))
+          row?    (assoc :slot-value (get redacted slot)))))))
+
+(defn- splice-redacted-delta
+  "PURE splice of a precomputed redacted delta (from
+  `compute-redacted-delta`) onto `record`'s real slots — leaving every
+  already-redacted slot value untouched. Returns the updated record.
+
+  Per rf2-7i872: this is the ONLY part of the back-fill that rides inside
+  the ring `swap!`. It invokes NO injected fn — a CAS retry re-runs this
+  splice (re-reading the retried record's real slots) but NEVER re-invokes
+  the app's `:redact-fn`, so the non-idempotent / throwing-fn contract is
+  preserved across contention.
+
+  Slot extraction. When the precomputed delta value is still a vector
+  (the common per-element-transform / sentinel-substitution shape) we
+  `conj` its element(s) onto the real slot. When `redact` instead
+  COLLAPSED the whole slot to a non-vector sentinel (e.g.
+  `(assoc r :trace-events :rf/redacted)` — a whole-slot scrub), we adopt
+  that sentinel for the slot. We only `conj` onto a real slot that is a
+  vector (or absent); a real slot already collapsed to a sentinel by a
+  prior whole-slot scrub is left at the sentinel (the delta is subsumed).
+
+  `delta` nil (no append) is a pass-through — return the record
+  untouched (do NOT spuriously re-redact it)."
+  [record delta]
+  (if (nil? delta)
+    record
+    (let [{:keys [append? row? slot trace-events slot-value]} delta
+          splice (fn [rec real-slot dv]
                    (cond
                      (and (vector? dv) (vector? (get rec real-slot)))
                      (update rec real-slot into dv)
@@ -632,9 +657,9 @@
 
                      :else               ; whole-slot collapse by the fn
                      (assoc rec real-slot dv)))]
-    (cond-> record
-      append?     (splice :trace-events (:trace-events redacted))
-      (some? row) (splice slot (get redacted slot)))))
+      (cond-> record
+        append? (splice :trace-events trace-events)
+        row?    (splice slot slot-value)))))
 
 (defn- back-fill-event!
   "Append `event` and its projected `row` (into the `slot` projection)
@@ -661,44 +686,57 @@
       (Xray Views / Reactive panel) — is always present on a built
       record; the projected row is appended when non-nil.
 
-  REDACTION (rf2-82pcg leak-closure + rf2-qhxz6 once-per-slot fix).
+  REDACTION (rf2-82pcg leak-closure + rf2-qhxz6 once-per-slot +
+  rf2-7i872 redact-outside-swap fix).
   `redact` is the installed redaction transform (`assembly/maybe-redact`,
   injected by the caller so this state ns keeps no `assembly` require —
-  `assembly` already requires this ns). It runs INSIDE the swap, over ONLY
-  the newly-appended delta (via `redact-appended-delta`), so the redacted
-  delta is what lands in the ring AND what is returned for the listener
-  re-fan. Pre-rf2-82pcg the raw appended slots reached both egress
-  channels (ring-read: `epoch-history` / MCP `read-recording` /
-  `restore-epoch`; and the listener fan-out) bypassing the `:redact-fn`
-  (the leak). The rf2-82pcg fix re-ran the fn over the WHOLE record on
-  every back-fill — closing the leak but invoking the fn 1+K times for an
-  epoch accruing K back-fills, which corrupts a NON-idempotent fn's prior
-  output. rf2-qhxz6 narrows the redaction to the appended delta so the
-  Tool-Pair §Redaction hook 'once per assembled record' contract holds
-  literally: each slot value is redacted EXACTLY ONCE and the fn carries
-  no idempotency requirement. The leak stays closed — the appended delta
-  is still scrubbed before egress. `redact` defaults to `identity` for
-  callers / tests that need the bare raw append.
+  `assembly` already requires this ns). It runs over ONLY the newly-
+  appended delta (via `compute-redacted-delta`), so the redacted delta is
+  what lands in the ring AND what is returned for the listener re-fan.
+  Pre-rf2-82pcg the raw appended slots reached both egress channels
+  (ring-read: `epoch-history` / MCP `read-recording` / `restore-epoch`;
+  and the listener fan-out) bypassing the `:redact-fn` (the leak). The
+  rf2-82pcg fix re-ran the fn over the WHOLE record on every back-fill —
+  closing the leak but invoking the fn 1+K times for an epoch accruing K
+  back-fills, which corrupts a NON-idempotent fn's prior output. rf2-qhxz6
+  narrowed the redaction to the appended delta so the Tool-Pair §Redaction
+  hook 'once per assembled record' contract holds literally: each slot
+  value is redacted EXACTLY ONCE and the fn carries no idempotency
+  requirement. The leak stays closed — the appended delta is still
+  scrubbed before egress. `redact` defaults to `identity` for callers /
+  tests that need the bare raw append.
 
-  The `swap!` update fn is PURE — it mutates only the history map and
-  smuggles nothing out (the prior shape `reset!`'d a local out-param atom
-  from inside the swap fn, a side-effecting-swap-fn that is unsound under
-  CAS retry). `redact` is the only injected fn it calls; `maybe-redact`
-  is itself pure (record-in, record-out; a throwing `:redact-fn` is
-  caught there and falls back to the unredacted record), so the swap fn
-  stays retry-safe. The record index is resolved once up-front (within-
-  frame drain is single-threaded — Spec 002 §Run-to-completion — so no
-  append can shift it between this deref and the swap), reused by both the
-  pure swap and the post-swap read. nil when the epoch is absent from the
-  ring (evicted, or fired before any cascade settled)."
+  Per rf2-7i872: the `:redact-fn` is invoked exactly ONCE, by
+  `compute-redacted-delta`, BEFORE and OUTSIDE the ring `swap!`. The swap
+  update fn is `splice-redacted-delta` — PURE: it splices the
+  PRECOMPUTED redacted delta onto the (re-read) ring record, invoking NO
+  injected fn. A JVM CAS retry re-runs only the pure splice; it NEVER
+  re-invokes the app's `:redact-fn`. This matters because the documented
+  `:redact-fn` is non-idempotent (hash-and-truncate, increment-a-counter)
+  and a throwing fn emits one `:rf.warning/epoch-redact-fn-exception`
+  warning per call — re-invoking it inside a retryable swap would corrupt
+  the prior output and emit DUPLICATE warnings (the bug rf2-7i872 closed:
+  the old `redact-appended-delta` ran `redact` inside the swap fn). The
+  swap fn also smuggles nothing out (the pre-rf2-qhxz6 shape `reset!`'d a
+  local out-param atom from inside the swap fn, itself unsound under CAS
+  retry). The record index is resolved once up-front (within-frame drain
+  is single-threaded — Spec 002 §Run-to-completion — so no append can
+  shift it between this deref and the swap), reused by the delta probe,
+  the pure swap, and the post-swap read. nil when the epoch is absent from
+  the ring (evicted, or fired before any cascade settled)."
   ([frame-id epoch-id slot event row]
    (back-fill-event! frame-id epoch-id slot event row identity))
   ([frame-id epoch-id slot event row redact]
    (let [idx (epoch-index (history-for frame-id) epoch-id)]
      (when idx
-       (let [append (fn [record]
-                      (redact-appended-delta record slot event row redact))]
-         (-> (swap! histories update-in [frame-id idx] append)
+       ;; rf2-7i872: invoke `redact` (the app `:redact-fn`) ONCE here,
+       ;; OUTSIDE the swap, against the current ring record (the probe
+       ;; context). The swap below only splices the precomputed redacted
+       ;; delta — a CAS retry re-runs the pure splice, never the fn.
+       (let [record (get-in @histories [frame-id idx])
+             delta  (compute-redacted-delta record slot event row redact)
+             splice (fn [rec] (splice-redacted-delta rec delta))]
+         (-> (swap! histories update-in [frame-id idx] splice)
              (get-in [frame-id idx])))))))
 
 (defn back-fill-render!
@@ -1012,14 +1050,34 @@
   `frame-id`. Guards against re-firing the atom watcher on the
   no-op case (cb already observes that frame) — for the common
   long-lived listener observing the same frame on every cascade,
-  this is a single deref + membership check with no swap."
+  this is a single deref + membership check with no swap.
+
+  Per rf2-7i872 (unregister-mid-fan-out race): `notify-listeners!`
+  iterates a listener SNAPSHOT, then calls this fn per cb-id BEFORE
+  invoking the callback. If `unregister-epoch-listener!` removed the cb
+  between the snapshot and now, recording an observation would
+  RE-INTRODUCE bookkeeping for a cb that no longer exists — the stale
+  cb-id then lingers in `observed-frames-by-cb` and later receives a
+  bogus `:rf.epoch.cb/silenced-on-frame-destroy` trace on frame destroy.
+  The swap is therefore made conditional on the cb-id STILL being a live
+  listener AT RECORD TIME: the swap update fn re-reads the (live)
+  `listeners` map and refuses to (re)add an observation for a cb that has
+  since been dropped. The liveness check rides INSIDE the swap so the
+  drop-vs-record decision is taken against a consistent listener snapshot
+  on every CAS retry — a `drop-listener!` landing mid-swap is honoured."
   [cb-id frame-id]
   (when frame-id
     (let [current @observed-frames-by-cb]
-      (when-not (contains? (get current cb-id) frame-id)
+      (when (and (not (contains? (get current cb-id) frame-id))
+                 (contains? @listeners cb-id))
         (swap! observed-frames-by-cb
                (fn [m]
-                 (if (contains? (get m cb-id) frame-id)
+                 (if (or (contains? (get m cb-id) frame-id)
+                         ;; Liveness re-check inside the swap: a
+                         ;; `drop-listener!` that landed between the
+                         ;; outer guard and this CAS attempt must not be
+                         ;; undone by re-adding the cb's observation.
+                         (not (contains? @listeners cb-id)))
                    m
                    (update m cb-id (fnil conj #{}) frame-id))))))))
 

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -348,18 +348,65 @@
 
                   {:outcome :ok :epoch epoch})))))))))
 
+;; ---- write-boundary liveness guard (rf2-7i872) ----------------------------
+;;
+;; Precondition validation (`check-restore-preconditions!` /
+;; `check-reset-frame-db-preconditions!`) resolves the frame, but a frame
+;; can be destroyed in the window BETWEEN the precondition pass and the
+;; actual container write (the validate-then-destroy race — most often a
+;; tool gesture interleaving with the owning component's teardown). Once
+;; destroyed, `frame/app-db-container` returns nil and the choke-point
+;; `adapter/replace-container!` no-ops the write with a
+;; `:rf.warning/write-after-destroy` trace (`adapter.cljc`). Per Tool-Pair
+;; §Surface behaviour against destroyed frames the mutating surfaces must
+;; report this as the SAME structural failure a frame-miss caught at
+;; validate-time produces (`:rf.error/no-such-handler`, kind `:frame`,
+;; returns `false`) — NOT a synthetic success. This helper resolves the
+;; container at the write boundary and yields the canonical no-such-handler
+;; failure when it has disappeared, so `perform-restore!` /
+;; `perform-reset-frame-db!` can bail BEFORE emitting success, recording a
+;; synthetic epoch, or fanning out to listeners.
+
+(defn live-container-or-fail
+  "Resolve `frame-id`'s app-db container at the write boundary. Returns
+  `{:outcome :ok :container <container>}` when the frame is still live, or
+  the canonical no-such-handler precondition-failure result
+  (`{:outcome :fail :op :rf.error/no-such-handler :tags {:kind :frame
+  :frame frame-id}}`) when the frame was destroyed between precondition
+  validation and now (the validate-then-destroy race, rf2-7i872). Mirrors
+  `frame-exists-or-fail`'s failure shape so the destroyed-frame write race
+  surfaces identically to a frame-miss caught at validate-time."
+  [frame-id]
+  (if-let [container (frame/app-db-container frame-id)]
+    {:outcome :ok :container container}
+    {:outcome :fail
+     :op      :rf.error/no-such-handler
+     :tags    {:kind  :frame
+               :frame frame-id}}))
+
 (defn perform-restore!
   "Carry out the actual `app-db` rewind once preconditions have passed.
   Replaces the frame's container with `epoch`'s `:db-after` and emits
-  `:rf.epoch/restored`. Returns `true`."
+  `:rf.epoch/restored`. Returns `true` on a real write.
+
+  Per rf2-7i872 (validate-then-destroy race): re-resolves the container at
+  the write boundary via `live-container-or-fail`. If the frame was
+  destroyed between the precondition pass and now, the container is nil and
+  `replace-container!` would silently no-op — so instead of emitting
+  `:rf.epoch/restored` and returning `true` (a FALSE success), this emits
+  the canonical `:rf.error/no-such-handler` (kind `:frame`) failure trace
+  and returns `false`, matching the destroyed-frame contract."
   [frame-id epoch]
-  (let [container (frame/app-db-container frame-id)
-        db-target (:db-after epoch)]
-    (adapter/replace-container! container db-target)
-    (trace/emit! :rf.epoch :rf.epoch/restored
-                 {:frame    frame-id
-                  :epoch-id (:epoch-id epoch)})
-    true))
+  (let [{:keys [outcome op tags container]} (live-container-or-fail frame-id)]
+    (if (= :fail outcome)
+      (do (emit-precondition-failure! op tags)
+          false)
+      (let [db-target (:db-after epoch)]
+        (adapter/replace-container! container db-target)
+        (trace/emit! :rf.epoch :rf.epoch/restored
+                     {:frame    frame-id
+                      :epoch-id (:epoch-id epoch)})
+        true))))
 
 ;; ---- reset-frame-db! preconditions ----------------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -115,6 +115,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.state :as state]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
@@ -539,3 +540,142 @@
           (str "Diagnostic — reads: " @read-count
                ", restore-ok: " @ok-count
                ", restore-fail: " @fail-count)))))
+
+;; ---- Scenario 4 (rf2-7i872) ----------------------------------------------
+;;
+;; CAS-retry double-invoke of the app `:redact-fn`. `back-fill-event!`
+;; mutates the single global `histories` atom under `swap!`. Pre-rf2-7i872
+;; the redaction transform (which invokes the app `:redact-fn`) ran INSIDE
+;; the swap update fn (`redact-appended-delta`), so a JVM CAS retry of the
+;; ring mutation RE-RAN the update fn → RE-INVOKED `:redact-fn`. A
+;; non-idempotent fn (the documented contract — hash-and-truncate,
+;; increment-a-counter) is corrupted by the re-run, and a THROWING fn emits
+;; one `:rf.warning/epoch-redact-fn-exception` warning PER invocation, so a
+;; retry emits DUPLICATE warnings. rf2-7i872 moved the `:redact-fn`
+;; invocation (`compute-redacted-delta`) OUTSIDE the swap; only the PURE
+;; splice (`splice-redacted-delta`) rides inside, so a retry re-splices but
+;; never re-invokes the fn.
+;;
+;; This scenario drives N threads, each performing M post-settle sub-run
+;; back-fills (`state/back-fill-sub-run!`) against its OWN frame's settled
+;; epoch — but ALL frames share the single global `histories` atom, so the
+;; CAS on that atom is heavily contended and retries WILL occur (the whole
+;; point — pre-fix this is where the double-invoke manifests). Each thread
+;; counts its own `:redact-fn` invocations.
+;;
+;;   Invariant 1 (non-idempotent): total `:redact-fn` invocations EQUALS
+;;     total back-fills. A CAS retry re-invoking the fn would push the count
+;;     ABOVE the back-fill count.
+;;   Invariant 2 (throwing fn): a throwing `:redact-fn` emits EXACTLY ONE
+;;     `:rf.warning/epoch-redact-fn-exception` warning per back-fill — never
+;;     a duplicate from a retried update fn.
+;;
+;; CLJS is single-threaded; the race cannot manifest there — JVM-only.
+
+(defn- sub-run-event
+  "A bare `:rf.sub/run` trace-event map (the shape `back-fill-sub-run!`
+  appends to `:trace-events`). We call `state/back-fill-sub-run!` directly
+  (the production post-settle path) rather than firing through `trace/emit!`
+  so the test drives concurrent back-fills against the contended global
+  `histories` atom from N threads — the cross-frame CAS contention the
+  runtime's per-frame single-drainer would otherwise serialise away."
+  [frame-id sub-id value]
+  {:op-type   :rf.sub
+   :operation :rf.sub/run
+   :tags      {:rf.sub/id      sub-id
+               :rf.sub/query-v [sub-id]
+               :frame          frame-id
+               :rf.sub/value   value}})
+
+(deftest redact-fn-invoked-once-per-back-fill-under-cas-contention
+  (testing (str n-threads " threads × " stress-iters
+                " sub-run back-fills each, all contending the single global "
+                "histories atom — the app :redact-fn (a counting, throwing "
+                "fn) is invoked EXACTLY ONCE per back-fill (no CAS-retry "
+                "double-invoke) and emits EXACTLY ONE warning per back-fill "
+                "(rf2-7i872)")
+    (rf/configure! :epoch-history {:depth (* 2 stress-iters)})
+    ;; ONE process-global :redact-fn (the shape `maybe-redact` reads from the
+    ;; config atom) shared across every thread. It counts every invocation
+    ;; and ALWAYS throws — so it drives BOTH invariants at once:
+    ;;   * invocation count (the catch-side increment + the throw) must equal
+    ;;     the total number of back-fills, never more;
+    ;;   * each throw routes through `maybe-redact`'s try/catch, emitting one
+    ;;     `:rf.warning/epoch-redact-fn-exception` warning per invocation.
+    (let [n          n-threads
+          invokes    (atom 0)
+          warnings   (atom 0)
+          redact-fn  (fn [_r]
+                       (swap! invokes inc)
+                       (throw (ex-info "rf2-7i872 boom" {})))]
+      (rf/configure! :epoch-history {:redact-fn redact-fn})
+      (rf/register-listener!
+        ::warn-watcher
+        (fn [ev]
+          (when (and (= :warning (:op-type ev))
+                     (= :rf.warning/epoch-redact-fn-exception
+                        (:operation ev)))
+            (swap! warnings inc))))
+
+      (let [frames (mapv (fn [t] (keyword "rf7i872.cas" (str "frame-" t)))
+                         (range n))]
+        ;; Seed each frame with one settled epoch (the back-fill target).
+        ;; NOTE: the seed cascade itself runs maybe-redact once at settle —
+        ;; account for those baseline invocations below.
+        (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+        (doseq [frame-id frames]
+          (rf/reg-frame frame-id {})
+          (rf/dispatch-sync [:seed] {:frame frame-id}))
+        ;; Baseline: invocations + warnings accrued from the n seed settles
+        ;; (one maybe-redact pass per settle; each throws + warns). Reset the
+        ;; ledgers so the contended back-fill phase is measured in isolation.
+        (reset! invokes 0)
+        (reset! warnings 0)
+
+        (let [latch   (CountDownLatch. 1)
+              futures (mapv
+                        (fn [frame-id]
+                          (future
+                            (.await latch)
+                            (let [epoch-id (-> (rf/epoch-history frame-id)
+                                               first :epoch-id)]
+                              (dotimes [i stress-iters]
+                                (let [sid (keyword (str "s" i))]
+                                  ;; Production post-settle path: maybe-redact
+                                  ;; is the redact transform (reads the global
+                                  ;; :redact-fn), exactly as
+                                  ;; listeners/record-sub-run! passes it.
+                                  (state/back-fill-sub-run!
+                                    frame-id epoch-id
+                                    (sub-run-event frame-id sid i)
+                                    {:sub-id sid :value i}
+                                    assembly/maybe-redact)))
+                              :done)))
+                        frames)]
+          (.countDown latch)
+          (let [results (mapv await-future futures)]
+            (doseq [r results]
+              (is (not= ::timeout r) "back-fill thread completed within timeout"))
+
+            (let [total-back-fills (* n stress-iters)]
+              ;; --- Invariant 1: the :redact-fn was invoked EXACTLY ONCE per
+              ;;     back-fill — never more. A count ABOVE total-back-fills
+              ;;     means a CAS retry on the contended histories atom
+              ;;     re-invoked the fn (the rf2-7i872 double-invoke bug, when
+              ;;     the redact ran INSIDE the swap). Equality also proves the
+              ;;     fix didn't accidentally DROP the redaction.
+              (is (= total-back-fills @invokes)
+                  (str ":redact-fn invoked " @invokes " times for "
+                       total-back-fills " back-fills (" n " frames × "
+                       stress-iters "). A count above means a CAS retry "
+                       "re-invoked the fn inside the swap (rf2-7i872)."))
+
+              ;; --- Invariant 2: EXACTLY ONE warning per back-fill — never a
+              ;;     duplicate from a retried update fn re-running the
+              ;;     throwing fn.
+              (is (= total-back-fills @warnings)
+                  (str "Expected " total-back-fills
+                       " redact-fn-exception warnings (one per back-fill); "
+                       "got " @warnings ". A higher count means a CAS retry "
+                       "re-invoked the throwing fn and emitted a duplicate "
+                       "warning (rf2-7i872).")))))))))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -41,6 +41,7 @@
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.listeners :as epoch.listeners]
             [re-frame.epoch.state :as state]
+            [re-frame.epoch.tool-pair :as tool-pair]
             ;; rf2-v6z0: machines is a separate artefact whose late-bind
             ;; hook publishes `rf/reg-machine` only when the namespace is
             ;; loaded. Several restore-* tests register machines via
@@ -3225,4 +3226,248 @@
             :trace-events-keep 5; the older absent-default behaviour
             (unbounded) is gone (pre-alpha — no back-compat)"
     (is (= 5 (:trace-events-keep (epoch/current-config))))))
+
+;; ============================================================================
+;;  rf2-7i872 — write-boundary liveness race (validate-then-destroy)
+;; ============================================================================
+;;
+;; restore-epoch / reset-frame-db! validate preconditions against a LIVE
+;; frame, then write the frame's container. A frame destroyed in the window
+;; BETWEEN validation and the write (a tool gesture interleaving with the
+;; owning component's teardown) leaves `frame/app-db-container` returning
+;; nil, so the choke-point `adapter/replace-container!` silently no-ops the
+;; write. Pre-rf2-7i872 the epoch surfaces still emitted success and
+;; returned `true` (and `reset-frame-db!` recorded + fanned out a SYNTHETIC
+;; epoch for the destroyed frame). Per Tool-Pair §Surface behaviour against
+;; destroyed frames a destroyed-frame write is a STRUCTURAL FAILURE
+;; (:rf.error/no-such-handler, kind :frame, returns false).
+;;
+;; The race window is reproduced two ways:
+;;   (a) the SEAM — validate (live) → destroy → perform!, exactly the two
+;;       steps the public fn sequences, with the destroy injected between.
+;;   (b) the PUBLIC surface — with-redefs the precondition check to destroy
+;;       the frame after a real (live) validation, proving the public
+;;       restore-epoch / reset-frame-db! honour the write-boundary guard.
+
+(deftest restore-epoch-validate-then-destroy-reports-honest-failure-seam
+  (testing "rf2-7i872 — perform-restore! against a frame destroyed AFTER a
+            live precondition pass returns false, emits
+            :rf.error/no-such-handler (kind :frame), and does NOT emit
+            :rf.epoch/restored. The drop is the no-op write
+            adapter/replace-container! makes against the now-nil container."
+    (rf/reg-frame :test/short-lived {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/dispatch-sync [:seed] {:frame :test/short-lived})
+    (rf/dispatch-sync [:inc]  {:frame :test/short-lived})
+
+    (let [target-id (-> (rf/epoch-history :test/short-lived) first :epoch-id)
+          ;; (1) Validate against the LIVE frame — passes, yields the epoch.
+          {:keys [outcome epoch]} (tool-pair/check-restore-preconditions!
+                                    :test/short-lived target-id)]
+      (is (= :ok outcome) "precondition validation passed against the live frame")
+
+      ;; (2) The race: the frame is destroyed in the validate→write window.
+      (rf/destroy-frame! :test/short-lived)
+
+      ;; (3) Perform the write at the boundary — the container is now nil.
+      (let [recorded (record-trace!)
+            result   (tool-pair/perform-restore! :test/short-lived epoch)]
+        (is (false? result)
+            "perform-restore! reports HONEST failure (false) — NOT a synthetic
+             success — when the frame disappeared between validate and write")
+        (is (has-error-op? @recorded :rf.error/no-such-handler)
+            ":rf.error/no-such-handler fired at the write boundary")
+        (let [ev (some #(when (= :rf.error/no-such-handler (:operation %)) %)
+                       @recorded)]
+          (is (= :frame (:kind (:tags ev))) "tags carry :kind :frame")
+          (is (= :test/short-lived (:frame (:tags ev))) "tags carry :frame"))
+        (is (not-any? #(= :rf.epoch/restored (:operation %)) @recorded)
+            "no :rf.epoch/restored success trace for the destroyed frame")))))
+
+(deftest restore-epoch-public-validate-then-destroy-returns-false
+  (testing "rf2-7i872 — the PUBLIC restore-epoch returns false (not a false
+            success) when the frame is destroyed AFTER a live precondition
+            pass but BEFORE the container write. The precondition check is
+            real; the destroy is injected into the validate→write window."
+    (rf/reg-frame :test/short-lived {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/short-lived})
+
+    (let [target-id (-> (rf/epoch-history :test/short-lived) first :epoch-id)
+          real-check tool-pair/check-restore-preconditions!
+          recorded   (record-trace!)]
+      ;; Inject the destroy into the validate→write window: run the REAL
+      ;; (live) precondition check, then destroy the frame before the
+      ;; orchestrator reaches perform-restore!.
+      (with-redefs [tool-pair/check-restore-preconditions!
+                    (fn [frame-id epoch-id]
+                      (let [r (real-check frame-id epoch-id)]
+                        (rf/destroy-frame! frame-id)
+                        r))]
+        (let [result (rf/restore-epoch :test/short-lived target-id)]
+          (is (false? result)
+              "public restore-epoch returns false for the validate-then-destroy
+               race — the write-boundary guard caught the no-op write")
+          (is (has-error-op? @recorded :rf.error/no-such-handler)
+              ":rf.error/no-such-handler fired")
+          (is (not-any? #(= :rf.epoch/restored (:operation %)) @recorded)
+              "no :rf.epoch/restored success trace"))))))
+
+(deftest reset-frame-db-validate-then-destroy-reports-honest-failure-seam
+  (testing "rf2-7i872 — perform-reset-frame-db! against a frame destroyed
+            AFTER a live precondition pass returns false, emits
+            :rf.error/no-such-handler (kind :frame), and does NOT record a
+            synthetic epoch, emit :rf.epoch/db-replaced, or fan a record to
+            listeners for the destroyed frame."
+    (rf/reg-frame :test/short-lived {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/short-lived})
+
+    ;; (1) Validate against the LIVE frame — passes.
+    (let [{:keys [outcome]} (tool-pair/check-reset-frame-db-preconditions!
+                              :test/short-lived {:n 999})]
+      (is (= :ok outcome) "precondition validation passed against the live frame")
+
+      ;; A listener that records every fanned record — it must NOT see a
+      ;; record for the destroyed frame.
+      (let [fanned   (atom [])]
+        (rf/register-epoch-listener! ::fan-watcher (fn [r] (swap! fanned conj r)))
+        ;; Let the listener observe the live frame once so it has an
+        ;; observation entry (mirrors a real tool); reset the ledger after.
+        (rf/dispatch-sync [:seed] {:frame :test/short-lived})
+        (reset! fanned [])
+
+        ;; (2) The race: destroy in the validate→write window.
+        (rf/destroy-frame! :test/short-lived)
+
+        ;; (3) Perform the reset at the boundary — container is now nil.
+        (let [recorded (record-trace!)
+              result   (#'epoch/perform-reset-frame-db! :test/short-lived {:n 999})]
+          (is (false? result)
+              "perform-reset-frame-db! reports HONEST failure (false) — NOT a
+               synthetic success — for the validate-then-destroy race")
+          (is (has-error-op? @recorded :rf.error/no-such-handler)
+              ":rf.error/no-such-handler fired at the write boundary")
+          (let [ev (some #(when (= :rf.error/no-such-handler (:operation %)) %)
+                         @recorded)]
+            (is (= :frame (:kind (:tags ev))) "tags carry :kind :frame")
+            (is (= :test/short-lived (:frame (:tags ev))) "tags carry :frame"))
+          (is (not-any? #(= :rf.epoch/db-replaced (:operation %)) @recorded)
+              "no :rf.epoch/db-replaced success trace for the destroyed frame")
+          (is (empty? @fanned)
+              "no synthetic epoch fanned out to listeners for the destroyed frame")
+          (is (= [] (rf/epoch-history :test/short-lived))
+              "no synthetic epoch recorded into the (dropped) ring for the
+               destroyed frame"))))))
+
+(deftest reset-frame-db-public-validate-then-destroy-returns-false
+  (testing "rf2-7i872 — the PUBLIC reset-frame-db! returns false when the
+            frame is destroyed AFTER a live precondition pass but BEFORE the
+            container write."
+    (rf/reg-frame :test/short-lived {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/short-lived})
+
+    (let [real-check tool-pair/check-reset-frame-db-preconditions!
+          recorded   (record-trace!)]
+      (with-redefs [tool-pair/check-reset-frame-db-preconditions!
+                    (fn [frame-id new-db]
+                      (let [r (real-check frame-id new-db)]
+                        (rf/destroy-frame! frame-id)
+                        r))]
+        (let [result (rf/reset-frame-db! :test/short-lived {:n 999})]
+          (is (false? result)
+              "public reset-frame-db! returns false for the validate-then-destroy
+               race")
+          (is (has-error-op? @recorded :rf.error/no-such-handler)
+              ":rf.error/no-such-handler fired")
+          (is (not-any? #(= :rf.epoch/db-replaced (:operation %)) @recorded)
+              "no :rf.epoch/db-replaced success trace"))))))
+
+;; ============================================================================
+;;  rf2-7i872 — listener observation bookkeeping race (unregister mid-fan-out)
+;; ============================================================================
+;;
+;; notify-listeners! iterates a listener SNAPSHOT, then per cb-id calls
+;; record-observation! (writing the separate observed-frames-by-cb atom)
+;; BEFORE invoking the callback. If unregister-epoch-listener! removes a cb
+;; between the snapshot and the record-observation! call, the stale cb-id
+;; would (pre-rf2-7i872) be RE-INTRODUCED into observed-frames-by-cb and
+;; later receive a bogus :rf.epoch.cb/silenced-on-frame-destroy trace on
+;; frame destroy. The fix gates record-observation! on the cb-id still being
+;; a live listener at record time.
+
+(deftest record-observation-skips-unregistered-cb-no-stale-bookkeeping
+  (testing "rf2-7i872 — record-observation! against a cb that has been
+            unregistered does NOT re-introduce an observed-frames-by-cb
+            entry. (The exact ordering notify-listeners! exposes: snapshot
+            taken, cb dropped, then record-observation! fires for the stale
+            id.)"
+    (rf/reg-frame :test/main {})
+    ;; Register then unregister a cb — it is GONE from the listener registry.
+    (rf/register-epoch-listener! ::ghost (fn [_] nil))
+    (rf/unregister-epoch-listener! ::ghost)
+    (is (not (contains? (state/listeners-snapshot) ::ghost))
+        "::ghost is no longer a registered listener")
+
+    ;; Simulate the racing fan-out: record-observation! is called for the
+    ;; now-stale ::ghost id (as notify-listeners! would for a snapshot taken
+    ;; before the unregister).
+    (state/record-observation! ::ghost :test/main)
+
+    (is (not (contains? (state/observations-snapshot) ::ghost))
+        "no stale observed-frames-by-cb entry for the unregistered cb —
+         record-observation! refused to re-introduce bookkeeping for a dead cb")))
+
+(deftest unregister-mid-fanout-no-bogus-silencing-trace
+  (testing "rf2-7i872 — the precise unregister-mid-fan-out interleaving
+            notify-listeners! exposes: a listener snapshot is taken (carrying
+            ::victim), ::victim is unregistered, THEN record-observation! is
+            invoked for the stale ::victim id from the snapshot. The stale id
+            must NOT be re-introduced into observed-frames-by-cb, so when the
+            frame is later destroyed ::victim receives NO bogus
+            :rf.epoch.cb/silenced-on-frame-destroy trace.
+
+            Modelled by replaying notify-listeners!'s loop body manually
+            against a hand-built snapshot — the synchronous JVM path can't
+            otherwise pin the snapshot-then-unregister-then-record ordering
+            deterministically (map iteration order is unspecified)."
+    (rf/reg-frame :test/main {})
+
+    (let [recorded (record-trace!)]
+      ;; ::victim is a freshly-registered listener that has NOT yet observed
+      ;; any frame (put-listener! clears its observation ledger). It is live
+      ;; in the registry when the fan-out snapshot is taken.
+      (rf/register-epoch-listener! ::victim (fn [_] nil))
+      (let [;; (1) notify-listeners! takes the snapshot (includes ::victim).
+            snapshot (state/listeners-snapshot)]
+        (is (contains? snapshot ::victim)
+            "::victim is in the fan-out snapshot")
+
+        ;; (2) ::victim is unregistered AFTER the snapshot — the exact race.
+        (rf/unregister-epoch-listener! ::victim)
+
+        ;; (3) notify-listeners! reaches the snapshot's ::victim entry and
+        ;; calls record-observation! for it (the loop iterates the stale
+        ;; snapshot). Replay that single step.
+        (doseq [[id _f] snapshot]
+          (state/record-observation! id :test/main)))
+
+      (is (not (contains? (state/listeners-snapshot) ::victim))
+          "::victim was unregistered during fan-out")
+      (is (not (contains? (state/observations-snapshot) ::victim))
+          "::victim carries NO stale observed-frames-by-cb entry after the
+           snapshot-then-unregister-then-record interleaving")
+
+      ;; Destroy the frame — the silencing pass reads observations-snapshot.
+      ;; ::victim must NOT receive a silencing trace.
+      (rf/destroy-frame! :test/main)
+      (let [victim-silenced (filter #(and (= :rf.epoch.cb/silenced-on-frame-destroy
+                                             (:operation %))
+                                          (= ::victim (:cb-id (:tags %))))
+                                    @recorded)]
+        (is (empty? victim-silenced)
+            "no bogus :rf.epoch.cb/silenced-on-frame-destroy trace for the
+             unregistered ::victim cb")))))
 


### PR DESCRIPTION
Closes the three epoch race/atomicity correctness bugs in **rf2-7i872** (P1). Scope: `implementation/epoch/` + the epoch facade in `epoch.cljc`. Report-failure-honestly only — no throw-vs-recover change (that is the separate pending rf2-2hvga).

## Bugs fixed

### 1. False-success after destroy
`restore-epoch` / `reset-frame-db!` validate preconditions against a live frame, then write the container. A frame destroyed in the **validate→write window** leaves `frame/app-db-container` nil, so the choke-point `adapter/replace-container!` silently no-ops (`:rf.warning/write-after-destroy`) — yet the epoch surfaces still emitted success and returned `true`, and `reset-frame-db!` recorded + fanned out a **synthetic epoch for a destroyed frame**.

Fix: new `tool-pair/live-container-or-fail` re-resolves the container at the write boundary. When the frame has disappeared, `perform-restore!` / `perform-reset-frame-db!` emit the canonical `:rf.error/no-such-handler` (kind `:frame`) structural failure and return `false` — matching Tool-Pair §Surface behaviour against destroyed frames. No success trace, no synthetic record, no fan-out.

### 2. Listener bookkeeping race
`notify-listeners!` iterates a listener snapshot and calls `record-observation!` per cb-id before invoking the callback. An `unregister-epoch-listener!` landing between snapshot and record re-introduced the stale cb-id into `observed-frames-by-cb`, which later drew a bogus `:rf.epoch.cb/silenced-on-frame-destroy` trace on frame destroy.

Fix: `record-observation!` now checks listener liveness **at record time** — an outer guard plus an in-swap re-check against the live `listeners` registry — so a dropped cb is never re-armed.

### 3. Redact-fn inside `swap!` retry
Post-settle back-fill invoked the app `:redact-fn` **inside** the `histories` `swap!` update fn, so a JVM CAS retry re-ran it — violating the once-per-slot / non-idempotent contract and emitting **duplicate** warnings for a throwing fn.

Fix: split `redact-appended-delta` into `compute-redacted-delta` (invokes `redact` exactly once, **outside** the swap) and `splice-redacted-delta` (pure; rides inside the swap and re-runs on CAS retry without re-invoking the fn). AI/MCP-boundary redaction stays **fail-closed**.

## Regression coverage (each proven to fail on the pre-fix code)
- validate-then-destroy **seam** + **public-surface** tests for both `restore-epoch` and `reset-frame-db!` — no false success, no synthetic epoch/fan-out (18 assertions red pre-fix)
- unregister-mid-fan-out — no stale `observed-frames-by-cb` entry, no bogus silencing trace (3 assertions red pre-fix)
- CAS-contention stress (8 frames hammering the single global `histories` atom) — `:redact-fn` invoked **exactly once** per back-fill, **exactly one** warning per back-fill. Pre-fix this showed **100,616 invocations for 16,000 back-fills** (the double-invoke under retry).

## Gates (cold)
- epoch JVM `clojure -M:test` — **265 tests, 1011 assertions, 0 failures**
- `npm run test:cljs` — **5620 tests, 19586 assertions, 0 failures**