### PR TITLE
fix(core): tighten :fx per-entry shape policing — arity + keyword fx-id (rf2-18kwf)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -750,23 +750,36 @@
 ;;
 ;; Per `:rf/effect-map` (Spec-Schemas §:rf/effect-map) each entry is a
 ;; `[:tuple :keyword :any]` — a `[fx-id args]` vector. The do-fx walk used to
-;; guard with `(when (and (vector? pair) (seq pair)) …)`, which silently
+;; guard with `(when (and (vector? pair) (seq pair)) …)`, which (a) silently
 ;; dropped EVERY non-vector entry with no diagnostic — including the clear
 ;; typo `{:fx [[:good a] :oops]}` (a bare keyword where a `[fx-id args]` pair
-;; was meant). The handler appears to fire its effects but the typo'd entry
-;; vanishes without trace — the same debuggability gap class the framework
-;; polices loudly elsewhere (interceptors-in-metadata, M-8 effect keys, the
-;; `:fx` value shape).
+;; was meant) — and (b) waved ANY non-empty vector through, so a non-keyword
+;; head (`["not-a-keyword" {}]`) reached `handle-one-fx` and was mis-reported
+;; as `:rf.error/no-such-fx` (wrong diagnostic), and a surplus tuple field
+;; (`[:some/fx {:used true} {:dropped true}]`) was SILENTLY truncated because
+;; `handle-one-fx` destructures only `[original-fx-id args]`. Both are shape
+;; violations; the framework polices them loudly elsewhere (interceptors-in-
+;; metadata, M-8 effect keys, the `:fx` value shape) so it must here too.
 ;;
-;; We tolerate the legitimately-empty idiom and police the clear typo:
+;; We tolerate the legitimately-empty idiom and police every clear typo:
 ;;
 ;;   nil / [] (empty)        → silent no-op. The documented conditional-fx
 ;;                             idiom `[(when cond? [:fx-id args])]` nil-pads
 ;;                             entries on purpose; a `[]` is likewise a
 ;;                             deliberate no-op. NO trace.
-;;   non-empty vector        → walked normally. An unregistered fx-id head is
-;;                             still policed downstream by `handle-one-fx`'s
+;;   [:fx-id] / [:fx-id args]→ walked normally. A 1- or 2-element vector whose
+;;                             head is a keyword is the documented pair (the
+;;                             1-arity no-args shorthand `[:fx-id]` is in wide
+;;                             use, e.g. `[[:fx-test/a] [:fx-test/b]]`; the
+;;                             2-arity carries args). An unregistered fx-id head
+;;                             is still policed downstream by `handle-one-fx`'s
 ;;                             :rf.error/no-such-fx path — not our concern here.
+;;   vector, NON-keyword head→ shape violation. `["not-a-keyword" {}]` is NOT an
+;;                             unknown fx-id, it is a bad fx-id type. Emit
+;;                             :rf.error/effect-map-shape, drop, siblings run.
+;;   vector, arity ≥ 3       → shape violation. The surplus slot would be
+;;                             silently discarded by `handle-one-fx`. Emit
+;;                             :rf.error/effect-map-shape, drop, siblings run.
 ;;   non-`nil`, non-empty,   → the clear typo (a keyword / map / string / number
 ;;   NON-vector entry          / list where a `[fx-id args]` vector was meant).
 ;;                             Emit :rf.error/effect-map-shape naming the entry +
@@ -777,28 +790,51 @@
 (defn- fx-entry-ok?
   "True iff an individual `:fx` entry `pair` is shaped well enough to walk —
   i.e. `nil`, an empty collection (both the legal conditional-fx no-op), or a
-  non-empty vector (the documented `[fx-id args]` pair). A non-`nil`, non-empty,
-  NON-vector entry is the forgot-the-inner-vector typo: emit
+  1- or 2-element vector whose head is a keyword (the documented `[fx-id]` /
+  `[fx-id args]` pair — the 1-arity no-args shorthand is supported because
+  `handle-one-fx` destructures `args` as `nil` for it). Anything else is a
+  shape violation: a non-`nil`, non-empty, NON-vector entry (forgot-the-inner-
+  vector typo), a vector with a NON-keyword head (bad fx-id type — would be
+  mis-reported as an unknown fx-id), or a vector of arity ≥ 3 (the surplus
+  slot would be silently truncated by `handle-one-fx`). On a violation, emit
   :rf.error/effect-map-shape naming the offending entry + handler and return
-  false so the walk drops just that entry. `event` (the originating event
-  vector, when supplied) names the offending handler; absent ⇒ the trace
-  degrades gracefully (nil event-id)."
+  false so the walk drops just that entry — siblings still run. `event` (the
+  originating event vector, when supplied) names the offending handler; absent
+  ⇒ the trace degrades gracefully (nil event-id)."
   [pair frame-id event]
   (cond
     ;; Legal no-op: nil or empty — the conditional-fx idiom. Skip, no trace.
     (nil? pair)               false
     (and (vector? pair)
-         (seq pair))          true        ;; well-shaped, non-empty — walk it
+         (#{1 2} (count pair))
+         (keyword? (first pair))) true     ;; [fx-id] / [fx-id args] — walk it
     (and (coll? pair)
          (empty? pair))       false        ;; empty [] / () — legal no-op, no trace
     :else
-    ;; Non-nil, non-empty, non-vector — the clear typo. Police + drop.
+    ;; A shape violation. Three sub-cases, distinguished only for the human-
+    ;; facing :reason; all drop the entry + emit one :rf.error/effect-map-shape.
     (let [event-id (when (vector? event) (first event))
-          reason   (str "Effect-map for `" event-id "` returned an `:fx` entry of type `"
-                        (pr-str (type pair))
-                        "` (value `" (pr-str pair) "`); each `:fx` entry must be a "
-                        "`[fx-id args]` vector (e.g. `[:dispatch [:saved]]`)"
-                        " — did you forget the inner vector?")]
+          reason   (cond
+                     (not (vector? pair))
+                     (str "Effect-map for `" event-id "` returned an `:fx` entry of type `"
+                          (pr-str (type pair))
+                          "` (value `" (pr-str pair) "`); each `:fx` entry must be a "
+                          "`[fx-id args]` vector (e.g. `[:dispatch [:saved]]`)"
+                          " — did you forget the inner vector?")
+
+                     (not (keyword? (first pair)))
+                     (str "Effect-map for `" event-id "` returned an `:fx` entry `"
+                          (pr-str pair) "` whose fx-id (the first element) is `"
+                          (pr-str (first pair)) "` of type `" (pr-str (type (first pair)))
+                          "`; each `:fx` entry must be a `[fx-id args]` vector whose "
+                          "fx-id is a keyword (e.g. `[:dispatch [:saved]]`).")
+
+                     :else ;; arity ≥ 3 (the empty-vector arity-0 case is handled above)
+                     (str "Effect-map for `" event-id "` returned an `:fx` entry `"
+                          (pr-str pair) "` with " (count pair) " elements; each `:fx` "
+                          "entry must be a `[fx-id args]` vector of at most two elements "
+                          "(e.g. `[:dispatch [:saved]]` or the no-args `[:fx-id]`)"
+                          " — the surplus element(s) would be silently discarded."))]
       (trace/emit-error! :rf.error/effect-map-shape
                          {:failing-id        event-id
                           :rf.trace/event-id event-id

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -724,6 +724,132 @@
       (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
           "no :rf.error/effect-map-shape trace for a clean multi-entry :fx"))))
 
+;; ---- 6d. per-ENTRY arity / fx-id-type policing (rf2-18kwf) ----------------
+;;
+;; 6c (rf2-n6d3m) tightened the do-fx walk to police a non-vector ENTRY. But
+;; the guard still waved through ANY non-empty vector, so two malformed VECTOR
+;; shapes leaked into `handle-one-fx`:
+;;
+;;   (1) a NON-keyword head — `["not-a-keyword" {:x 1}]` reached fx lookup and
+;;       was mis-reported as `:rf.error/no-such-fx` (an UNKNOWN fx-id), when it
+;;       is really a bad fx-id TYPE (a shape violation).
+;;   (2) a surplus 3rd field — `[:some/fx {:used true} {:dropped true}]` was
+;;       SILENTLY truncated because `handle-one-fx` destructures only
+;;       `[original-fx-id args]`; the 3rd slot vanished with no diagnostic.
+;;
+;; Per `:rf/effect-map` the entry shape is `[:tuple :keyword :any]` (Spec-
+;; Schemas §:rf/effect-map; spec/009 §:rf.error/effect-map-shape case (c)).
+;; The fix tightens `fx-entry-ok?` to walk ONLY a 1- or 2-element vector whose
+;; head is a keyword; both malformed shapes above now emit one
+;; :rf.error/effect-map-shape (:offending-key :fx, :logged-and-skipped), drop
+;; just that entry, and let siblings run — symmetric with 6c.
+;;
+;; The 1-arity no-args shorthand `[:fx-id]` stays valid: `handle-one-fx`
+;; destructures `args` as nil for it, and it is in wide use (source-order /
+;; multi-entry tests above). `well-formed-multi-entry-fx-emits-no-shape-trace`
+;; already pins that it emits NO shape trace.
+
+(deftest fx-entry-non-keyword-head-is-policed-and-skipped
+  (testing "a vector :fx entry whose head is NOT a keyword (`[\"str\" {}]`) is a
+            shape violation — :rf.error/effect-map-shape, that entry skipped,
+            siblings still run — NOT mis-reported as an unknown fx-id"
+    (let [traces (collect-traces! ::fx-entry-non-kw)
+          fired  (atom [])]
+      (rf/reg-fx :fx-test/entry-nonkw-sibling
+        (fn [_ args] (swap! fired conj args)))
+      (rf/reg-event-fx :fx-test/entry-non-keyword-head
+        (fn [{:keys [db]} _]
+          {:db (assoc db :seeded? true)
+           :fx [[:fx-test/entry-nonkw-sibling {:k 1}]
+                ["not-a-keyword" {:x 1}]            ;; bad fx-id TYPE, not unknown id
+                [:fx-test/entry-nonkw-sibling {:k 2}]]}))
+      (is (nil? (rf/dispatch-sync [:fx-test/entry-non-keyword-head]))
+          "dispatch returns normally — no uncaught host exception")
+      (rf/unregister-listener! ::fx-entry-non-kw)
+      (is (= [{:k 1} {:k 2}] @fired)
+          "both well-shaped siblings fired in order; the bad-head entry was skipped")
+      (is (= true (:seeded? (rf/app-db-value :rf/default)))
+          ":db committed; only the malformed entry was dropped")
+      ;; The diagnostic must be the SHAPE category, not no-such-fx — a string
+      ;; head is a shape violation, not an unregistered keyword id.
+      (is (empty? (filter #(= :rf.error/no-such-fx (:operation %)) @traces))
+          "a non-keyword head is NOT mis-reported as :rf.error/no-such-fx")
+      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                 @traces)]
+        (is (= 1 (count shape-traces))
+            "exactly one :rf.error/effect-map-shape trace for the bad-head entry")
+        (let [t (first shape-traces)]
+          (is (= :error (:op-type t)))
+          (is (= :logged-and-skipped (:recovery t)))
+          (is (= :fx (get-in t [:tags :offending-key])))
+          (is (= :fx-test/entry-non-keyword-head (get-in t [:tags :rf.trace/event-id]))
+              ":event-id names the offending handler")
+          (is (= :rf/default (get-in t [:tags :frame])))
+          (is (= ["not-a-keyword" {:x 1}] (get-in t [:tags :value]))
+              ":value carries the offending entry verbatim")
+          (is (string? (get-in t [:tags :reason])))
+          (is (re-find #"fx-id" (get-in t [:tags :reason]))
+              ":reason flags the bad fx-id (the first element)"))))))
+
+(deftest fx-entry-surplus-third-field-is-policed-not-truncated
+  (testing "a vector :fx entry with a surplus 3rd field
+            (`[:fx {:used true} {:dropped true}]`) is a shape violation —
+            :rf.error/effect-map-shape, that entry skipped, siblings still run —
+            NOT silently truncated to a 2-tuple by `handle-one-fx`"
+    (let [traces (collect-traces! ::fx-entry-arity3)
+          fired  (atom [])]
+      (rf/reg-fx :fx-test/entry-arity3-sink
+        (fn [_ args] (swap! fired conj args)))
+      (rf/reg-event-fx :fx-test/entry-surplus-field
+        (fn [{:keys [db]} _]
+          {:db (assoc db :seeded? true)
+           :fx [[:fx-test/entry-arity3-sink {:k 1}]
+                [:fx-test/entry-arity3-sink {:used true} {:dropped true}]
+                [:fx-test/entry-arity3-sink {:k 2}]]}))
+      (is (nil? (rf/dispatch-sync [:fx-test/entry-surplus-field]))
+          "dispatch returns normally — no uncaught host exception")
+      (rf/unregister-listener! ::fx-entry-arity3)
+      ;; CRITICAL: the 3-element entry must NOT fire as a silently-truncated
+      ;; 2-tuple `[:fx-test/entry-arity3-sink {:used true}]`. Only the two
+      ;; well-shaped siblings run.
+      (is (= [{:k 1} {:k 2}] @fired)
+          "the surplus-field entry was dropped (NOT truncated + fired); siblings ran")
+      (is (= true (:seeded? (rf/app-db-value :rf/default)))
+          ":db committed; only the malformed entry was dropped")
+      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                 @traces)]
+        (is (= 1 (count shape-traces))
+            "exactly one :rf.error/effect-map-shape trace for the surplus-field entry")
+        (let [t (first shape-traces)]
+          (is (= :logged-and-skipped (:recovery t)))
+          (is (= :fx (get-in t [:tags :offending-key])))
+          (is (= :fx-test/entry-surplus-field (get-in t [:tags :rf.trace/event-id])))
+          (is (= [:fx-test/entry-arity3-sink {:used true} {:dropped true}]
+                 (get-in t [:tags :value]))
+              ":value carries the full over-long entry verbatim")
+          (is (string? (get-in t [:tags :reason])))
+          (is (re-find #"two elements|surplus" (get-in t [:tags :reason]))
+              ":reason flags the surplus element(s)"))))))
+
+(deftest fx-entry-no-args-shorthand-is-valid
+  (testing "the 1-arity no-args shorthand `[:fx-id]` is a VALID entry — it
+            fires (args nil) and emits NO :rf.error/effect-map-shape trace"
+    ;; Pins the lower bound of the tightened arity check: 1-element vectors
+    ;; with a keyword head are the documented no-args shorthand, NOT a shape
+    ;; violation. (The upper bound — arity ≥ 3 — is pinned above.)
+    (let [traces (collect-traces! ::fx-entry-noargs)
+          fired  (atom [])]
+      (rf/reg-fx :fx-test/noargs-sink
+        (fn [_ args] (swap! fired conj args)))
+      (rf/reg-event-fx :fx-test/entry-noargs
+        (fn [_ _] {:fx [[:fx-test/noargs-sink]]}))
+      (rf/dispatch-sync [:fx-test/entry-noargs])
+      (rf/unregister-listener! ::fx-entry-noargs)
+      (is (= [nil] @fired)
+          "the no-args shorthand fired once with nil args")
+      (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
+          "the no-args `[:fx-id]` shorthand emits NO shape trace — it is valid"))))
+
 ;; ---- 7. :fx-overrides function-value branch -------------------------------
 ;;
 ;; Per Spec 002 §`:fx-overrides` §Pattern-level contract vs CLJS reference:


### PR DESCRIPTION
## What

Closes **rf2-18kwf** (P2 correctness review). Tightens per-entry `:fx` shape policing in `implementation/core/src/re_frame/fx.cljc`.

`fx-entry-ok?` returned `true` for **any** non-empty vector — it did not check tuple arity or that the fx-id is a keyword. Two malformed VECTOR entries therefore leaked past the per-entry guard into `handle-one-fx`:

- **non-keyword head** — `["not-a-keyword" {:x 1}]` reached fx lookup and was mis-reported as `:rf.error/no-such-fx` (an *unknown* fx-id), when it is really a bad fx-id **type** (a shape violation).
- **surplus 3rd field** — `[:some/fx {:used true} {:dropped true}]` was **silently truncated** because `handle-one-fx` destructures only `[original-fx-id args]`; the 3rd slot vanished with no diagnostic.

## Fix

Per `:rf/effect-map` the entry shape is `[:tuple :keyword :any]` (`spec/Spec-Schemas.md:465`, `spec/API.md:403`; `spec/009-Instrumentation.md:1643` case **(c)**). `fx-entry-ok?` now walks **only** a 1- or 2-element vector whose head is a keyword. Both malformed shapes now emit exactly one `:rf.error/effect-map-shape` (`:offending-key :fx`, `:recovery :logged-and-skipped`), drop just the offending entry, and let sibling `:fx` entries run — symmetric with the existing non-vector-entry policing.

- Composes with the whole-`:fx`-value check (`events.cljc/fx-value-ok?`, which only rejects a non-sequential `:fx` value) one level up — **no double-tracing** (the two layers operate at different levels).
- The 1-arity no-args shorthand `[:fx-id]` stays **valid** — `handle-one-fx` binds `args` to `nil` for it, and it is in wide use across the source-order / multi-entry tests. Matched the actual contract; did not over-tighten.
- The `:reason` string is now case-specific (forgot-the-inner-vector / bad fx-id type / surplus elements) for human-facing diagnostics.

## Tests

Added three regression tests (prior coverage at `fx_test.clj:612/660/709` missed these):

1. **non-keyword head** → one `:rf.error/effect-map-shape`, entry skipped, siblings run, and explicitly **NOT** mis-reported as `:rf.error/no-such-fx`.
2. **surplus 3rd field** → one `:rf.error/effect-map-shape`, and explicitly **NOT** silently truncated-and-fired as a 2-tuple.
3. **no-args `[:fx-id]` shorthand** → fires with `nil` args and emits **no** shape trace (pins the lower arity bound).

**Without-fix proof:** reverting `fx-entry-ok?` to the old lenient `(and (vector? pair) (seq pair))` guard makes the new tests fail (16 failures + 2 errors in `re-frame.fx-test`).

## Gates

- core JVM `clojure -M:test` — **873 tests / 3937 assertions / 0 failures**
- CLJS `npm run test:cljs` — **5633 tests / 19620 assertions / 0 failures**
