### PR TITLE
fix(scripts): strict ns+var Xray projection + centralized explicit-port validation (rf2-0u8kz)

### DIFF
--- a/implementation/scripts/_local-browser-harness.test.cjs
+++ b/implementation/scripts/_local-browser-harness.test.cjs
@@ -11,6 +11,7 @@ const {
   fetchToken,
   findFreePort,
   isPortFree,
+  isValidExplicitPort,
   resolveServePort,
   spawnHarnessProcess,
   terminateProcessTree,
@@ -268,6 +269,55 @@ test('waitForOwnedHttpReady reports token-never-served for a tokenless responder
     assert.equal(result.reason, 'token-never-served');
   } finally {
     server.close();
+  }
+});
+
+// rf2-0u8kz regression — explicit-port validation. An explicit preferred
+// port is usable only as an integer in 1..65535; 0 / negative / overflow /
+// non-integer values must NOT bind net.listen (0 would bind an unusable
+// ephemeral port — a false "free"; the others throw ERR_SOCKET_BAD_PORT).
+test('isValidExplicitPort accepts only integers 1..65535', () => {
+  assert.equal(isValidExplicitPort(1), true);
+  assert.equal(isValidExplicitPort(8037), true);
+  assert.equal(isValidExplicitPort(65535), true);
+  // Invalid: 0, negative, overflow, non-integer, NaN, non-number.
+  assert.equal(isValidExplicitPort(0), false);
+  assert.equal(isValidExplicitPort(-1), false);
+  assert.equal(isValidExplicitPort(65536), false);
+  assert.equal(isValidExplicitPort(99999), false);
+  assert.equal(isValidExplicitPort(8037.5), false);
+  assert.equal(isValidExplicitPort(NaN), false);
+  assert.equal(isValidExplicitPort('8037'), false);
+  assert.equal(isValidExplicitPort(undefined), false);
+  assert.equal(isValidExplicitPort(null), false);
+});
+
+test('isPortFree reports false for 0 / out-of-range / non-integer without throwing', async () => {
+  // Port 0 binds an ephemeral port at the OS layer, but is not a usable
+  // ADVERTISED port — isPortFree must short-circuit to false rather than
+  // bind-and-release it (the bug: returning true here let callers advertise
+  // :0). Negative / overflow / non-integer must not reach net.listen
+  // (which throws ERR_SOCKET_BAD_PORT) — the guard reports false cleanly.
+  assert.equal(await isPortFree(0), false);
+  assert.equal(await isPortFree(-1), false);
+  assert.equal(await isPortFree(65536), false);
+  assert.equal(await isPortFree(99999), false);
+  assert.equal(await isPortFree(8037.5), false);
+  assert.equal(await isPortFree(NaN), false);
+});
+
+test('resolveServePort never returns 0 and falls back (logged) for invalid preferred ports', async () => {
+  for (const bad of [0, -1, 65536, 99999, 8037.5, NaN, undefined, '8037']) {
+    let fellBack = false;
+    let reported;
+    const resolved = await resolveServePort(bad, {
+      onFallback: (preferred) => { fellBack = true; reported = preferred; },
+    });
+    assert.equal(fellBack, true, `expected fallback for preferred=${String(bad)}`);
+    assert.equal(reported, bad, 'onFallback receives the original invalid preferred value');
+    assert.ok(isValidExplicitPort(resolved), `fallback ${resolved} must be a usable port`);
+    assert.notEqual(resolved, 0);
+    assert.equal(await isPortFree(resolved), true);
   }
 });
 

--- a/implementation/scripts/api-manifest/deps.edn
+++ b/implementation/scripts/api-manifest/deps.edn
@@ -35,4 +35,15 @@
          day8/re-frame2-epoch    {:local/root "../../epoch"}
          ;; Tool artefacts with JVM-loadable (.cljc) public namespaces.
          day8/re-frame2-story    {:local/root "../../../tools/story"}
-         day8/re-frame2-mcp-base {:local/root "../../../tools/mcp-base"}}}
+         day8/re-frame2-mcp-base {:local/root "../../../tools/mcp-base"}}
+ ;; Projection-check unit tests (rf2-0u8kz). Same quiet-runner shape as the
+ ;; per-artefact :test aliases. The tests reconcile synthetic + live inputs
+ ;; through the pure reconcilers so the namespace-qualified resolution
+ ;; contract (a fully-qualified panel symbol must match its EXACT [ns var],
+ ;; never merely share a bare var name) is regression-locked.
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../test-quiet"}
+                       io.github.cognitect-labs/test-runner
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/xray_spec_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/xray_spec_check.clj
@@ -15,15 +15,38 @@
   symbols (the canonical `panels.<area>/Panel` inventory), and (2) the
   `mount-<panel>!` family the doc names as the mountable-panel contract.
 
+  TWO RESOLUTION PATHS, TWO ALLOWLISTS (rf2-0u8kz). The two reference
+  shapes resolve against DIFFERENT manifest indexes, because they carry
+  different identity:
+
+    - A fully-qualified `day8.re-frame2-xray.panels.<area>/Panel` symbol
+      names BOTH a namespace AND a var. It must resolve against the strict
+      `[namespace var]` index — resolving by bare var alone is unsound,
+      because the manifest carries the SAME `:var \"Panel\"` for ten
+      distinct panel namespaces, so a stale / renamed / never-manifested
+      namespace (e.g. `day8.re-frame2-xray.panels.views/Panel` — the
+      pre-rf2-wyvf2 spelling rf2-yxw57 corrected, or a deleted panel ns)
+      would falsely pass the moment ANY Xray namespace still exports a var
+      of that bare name. The bug this check fixes (rf2-0u8kz): a
+      bare-`:var`-set membership test defeated the renamed/removed-panel
+      drift contract.
+
+    - A bare `mount-<panel>!` reference names only a var (the aggregator
+      family all lives in `day8.re-frame2-xray.panels`). It resolves
+      against the bare-var index.
+
+  Each path has its own knowingly-unmanifested allowlist in the sidecar:
+  `:xray-spec-known-unmanifested-qualified` (a set of `[ns var]` vectors,
+  for namespace-qualified prose/removal mentions) and
+  `:xray-spec-known-unmanifested` (a set of bare var-name strings, for
+  removed bare `mount-*!` names the spec still mentions in removal prose).
+
   REPORT-ONLY POSTURE (rf2-gkp0t). The Xray spec FILE is owned by a
-  concurrent worker; this check does not edit it. The manifest's Xray
-  coverage today is the single `mounted?` read, so the live panel + mount
-  surface is carried on the `:xray-spec-known-unmanifested` allowlist in
-  the sidecar — REPORTING that the manifest does not yet carry the Xray
-  public surface (a manifest-expansion follow-on owns that). The check is
-  green today but goes RED the moment a NEW Xray panel/mount symbol enters
-  the spec or an enumerated one is renamed — the keystone allowlist
-  discipline applied to a not-yet-manifested surface."
+  concurrent worker; this check does not edit it. It goes RED the moment a
+  NEW Xray panel/mount symbol enters the spec, an enumerated one is
+  renamed to an unmanifested namespace, or a panel namespace is removed
+  from the manifest while the spec still names it — the keystone allowlist
+  discipline applied to the live panel + mount surface."
   (:require [re-frame.api-manifest.gen :as gen]
             [re-frame.api-manifest.projection :as proj]))
 
@@ -34,35 +57,71 @@
    panel contract (007-UX-IA §Mountable panel contract)."
   #"\bmount-[a-z][a-z-]*!")
 
-(defn- mount-references
-  "Extract `mount-<panel>!` references from numbered `lines`."
+(defn mount-references
+  "Extract bare `mount-<panel>!` references from numbered `lines`. These
+   carry only a var (no namespace); they resolve against the bare-var
+   index."
   [lines]
   (for [[n text] lines
         m         (re-seq mount-fn-re text)]
     {:var m :line n :raw m}))
 
+(defn reconcile
+  "Pure reconciler (rf2-0u8kz — extracted so the namespace-qualified
+   resolution is unit-testable with synthetic inputs). Returns the seq of
+   problem maps `{:file :line :raw :detail}` for the supplied references.
+
+   `rows`            — manifest rows (each `{:namespace :var ...}`).
+   `qualified-refs`  — fully-qualified refs `{:ns :var :line :raw}`,
+                       resolved STRICTLY against the `[ns var]` index.
+   `bare-refs`       — bare `mount-*!` refs `{:var :line :raw}`, resolved
+                       against the bare-var index.
+   `qualified-allow` — set of `[ns var]` vectors knowingly unmanifested.
+   `bare-allow`      — set of bare var-name strings knowingly unmanifested.
+   `rel`             — repo-relative file path for reporting."
+  [{:keys [rows qualified-refs bare-refs qualified-allow bare-allow rel]}]
+  (let [xray-rows  (filter #(.startsWith ^String (:namespace %) xray-ns-prefix) rows)
+        ;; Strict [ns var] index for qualified refs — the fix: a qualified
+        ;; symbol resolves ONLY if the manifest carries that exact
+        ;; namespace+var pair, never if some OTHER namespace happens to
+        ;; export the same bare var.
+        ns+var     (set (map (juxt :namespace :var) xray-rows))
+        ;; Bare-var index for the mount-*! family.
+        bare-vars  (set (map :var xray-rows))
+        qual-probs (keep (fn [{:keys [ns var line raw]}]
+                           (when-not (or (contains? ns+var [ns var])
+                                         (contains? qualified-allow [ns var]))
+                             {:file rel :line line :raw raw
+                              :detail "no matching day8.re-frame2-xray [namespace var] manifest row"}))
+                         qualified-refs)
+        bare-probs (keep (fn [{:keys [var line raw]}]
+                           (when-not (or (contains? bare-vars var)
+                                         (contains? bare-allow var))
+                             {:file rel :line line :raw raw
+                              :detail "no day8.re-frame2-xray manifest row"}))
+                         bare-refs)]
+    (concat qual-probs bare-probs)))
+
 (defn check!
   []
-  (let [rows      (proj/manifest-rows)
-        ;; Manifest Xray rows, indexed by bare var (the only one today is
-        ;; `mounted?`); a fully-qualified panel symbol resolves if its bare
-        ;; var is carried for ANY Xray namespace.
-        xray-vars (set (map :var (filter #(.startsWith ^String (:namespace %) xray-ns-prefix) rows)))
-        allow     (set (:xray-spec-known-unmanifested (gen/read-sidecar)))
-        file      (proj/repo-file "tools" "xray" "spec" "API.md")
-        rel       (proj/repo-relative file)
-        lines     (proj/numbered-lines file)
-        refs      (concat (proj/qualified-symbol-references xray-ns-prefix lines)
-                          (mount-references lines))
-        ;; De-dup by [var line] so a symbol named twice on one line counts once.
-        refs      (distinct refs)
-        problems  (keep (fn [{:keys [var line raw]}]
-                          (when-not (or (contains? xray-vars var)
-                                        (contains? allow var))
-                            {:file rel :line line :raw raw
-                             :detail "no day8.re-frame2-xray manifest row"}))
-                        refs)]
-    (proj/report-result! "tools/xray/spec/API.md" (count refs) problems)))
+  (let [rows            (proj/manifest-rows)
+        sidecar         (gen/read-sidecar)
+        qualified-allow (set (map vec (:xray-spec-known-unmanifested-qualified sidecar)))
+        bare-allow      (set (:xray-spec-known-unmanifested sidecar))
+        file            (proj/repo-file "tools" "xray" "spec" "API.md")
+        rel             (proj/repo-relative file)
+        lines           (proj/numbered-lines file)
+        qualified-refs  (distinct (proj/qualified-symbol-references xray-ns-prefix lines))
+        bare-refs       (distinct (mount-references lines))
+        problems        (reconcile {:rows            rows
+                                    :qualified-refs  qualified-refs
+                                    :bare-refs       bare-refs
+                                    :qualified-allow qualified-allow
+                                    :bare-allow      bare-allow
+                                    :rel             rel})]
+    (proj/report-result! "tools/xray/spec/API.md"
+                         (+ (count qualified-refs) (count bare-refs))
+                         problems)))
 
 (defn -main [& _]
   (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/xray_spec_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/xray_spec_check_test.clj
@@ -1,0 +1,120 @@
+(ns re-frame.api-manifest.xray-spec-check-test
+  "Regression tests for the Xray API-spec projection check (rf2-0u8kz).
+
+  The bug: a fully-qualified `day8.re-frame2-xray.*/<var>` symbol was
+  resolved by BARE var name, so a stale / renamed / never-manifested panel
+  namespace (e.g. `day8.re-frame2-xray.panels.views/Panel`) falsely passed
+  as long as ANY Xray namespace still exported a var of that bare name
+  (`Panel` is carried for ten distinct panel namespaces). These tests pin
+  the strict `[namespace var]` resolution that fixes it — driven through
+  the pure `reconcile` reconciler with synthetic inputs — plus a live
+  smoke that the committed spec + manifest still reconcile clean."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.api-manifest.gen :as gen]
+            [re-frame.api-manifest.projection :as proj]
+            [re-frame.api-manifest.xray-spec-check :as xray]))
+
+;; A minimal synthetic manifest: two distinct panel namespaces, each
+;; exporting the SAME bare var `Panel`, plus a bare-var mount fn. This is
+;; the exact ambiguity the manifest has in reality (ten `Panel` rows).
+(def ^:private synthetic-rows
+  [{:namespace "day8.re-frame2-xray.panels.trace"        :var "Panel"}
+   {:namespace "day8.re-frame2-xray.panels.epoch-panel"  :var "Panel"}
+   {:namespace "day8.re-frame2-xray.panels"              :var "mount-trace!"}
+   ;; A non-Xray row that must never satisfy an Xray reference.
+   {:namespace "re-frame.core"                           :var "Panel"}])
+
+(defn- problems-for
+  "Run `reconcile` over `qualified-refs` / `bare-refs` against the
+   synthetic manifest with the given allowlists."
+  [{:keys [qualified-refs bare-refs qualified-allow bare-allow]
+    :or   {qualified-refs [] bare-refs [] qualified-allow #{} bare-allow #{}}}]
+  (xray/reconcile {:rows            synthetic-rows
+                   :qualified-refs  qualified-refs
+                   :bare-refs       bare-refs
+                   :qualified-allow qualified-allow
+                   :bare-allow      bare-allow
+                   :rel             "tools/xray/spec/API.md"}))
+
+(deftest qualified-symbol-resolves-by-exact-ns+var
+  (testing "a live fully-qualified panel symbol resolves clean"
+    (is (empty? (problems-for
+                  {:qualified-refs [{:ns "day8.re-frame2-xray.panels.trace"
+                                     :var "Panel" :line 1
+                                     :raw "day8.re-frame2-xray.panels.trace/Panel"}]}))
+        "panels.trace/Panel is a manifest [ns var] row — must pass")))
+
+(deftest stale-namespace-with-shared-bare-var-is-rejected
+  (testing "THE BUG (rf2-0u8kz): a stale/unmanifested Xray namespace whose
+            bare var exists elsewhere must NOT pass"
+    (let [problems (problems-for
+                     {:qualified-refs [{:ns "day8.re-frame2-xray.panels.views"
+                                        :var "Panel" :line 42
+                                        :raw "day8.re-frame2-xray.panels.views/Panel"}]})]
+      (is (= 1 (count problems))
+          "panels.views/Panel is NOT in the manifest — must be flagged even
+           though `Panel` is carried for panels.trace + panels.epoch-panel")
+      (is (= "day8.re-frame2-xray.panels.views/Panel" (:raw (first problems))))
+      (is (= 42 (:line (first problems)))))))
+
+(deftest non-xray-namespace-never-satisfies-xray-reference
+  (testing "a non-Xray manifest row sharing the bare var does not resolve an
+            Xray-qualified reference"
+    ;; re-frame.core/Panel exists in synthetic-rows but is not an Xray ns.
+    (is (= 1 (count (problems-for
+                      {:qualified-refs [{:ns "day8.re-frame2-xray.panels.missing"
+                                         :var "Panel" :line 7
+                                         :raw "day8.re-frame2-xray.panels.missing/Panel"}]}))))))
+
+(deftest qualified-allowlist-is-keyed-by-ns+var
+  (testing "an allowlisted [ns var] qualified reference passes; the same bare
+            var on a DIFFERENT namespace still fails (no bare-name masking)"
+    (let [allow #{["day8.re-frame2-xray.panels.views" "Panel"]}]
+      (is (empty? (problems-for
+                    {:qualified-refs [{:ns "day8.re-frame2-xray.panels.views"
+                                       :var "Panel" :line 1
+                                       :raw "day8.re-frame2-xray.panels.views/Panel"}]
+                     :qualified-allow allow}))
+          "the exact [ns var] is allowlisted — passes")
+      (is (= 1 (count (problems-for
+                        {:qualified-refs [{:ns "day8.re-frame2-xray.panels.gone"
+                                           :var "Panel" :line 1
+                                           :raw "day8.re-frame2-xray.panels.gone/Panel"}]
+                         :qualified-allow allow})))
+          "a DIFFERENT namespace with the same bare var is NOT covered by the
+           [ns var] allowlist entry"))))
+
+(deftest bare-mount-references-resolve-by-bare-var
+  (testing "a bare mount-*! reference resolves against the bare-var index"
+    (is (empty? (problems-for
+                  {:bare-refs [{:var "mount-trace!" :line 1 :raw "mount-trace!"}]})))
+    (testing "and an unmanifested bare mount name is flagged unless allowlisted"
+      (is (= 1 (count (problems-for
+                        {:bare-refs [{:var "mount-gone!" :line 1 :raw "mount-gone!"}]}))))
+      (is (empty? (problems-for
+                    {:bare-refs   [{:var "mount-gone!" :line 1 :raw "mount-gone!"}]
+                     :bare-allow  #{"mount-gone!"}}))))))
+
+(deftest live-spec-and-manifest-reconcile-clean
+  (testing "the committed tools/xray/spec/API.md reconciles against the
+            committed manifest with zero problems (the CI contract)"
+    (let [rows            (proj/manifest-rows)
+          sidecar         (gen/read-sidecar)
+          qualified-allow (set (map vec (:xray-spec-known-unmanifested-qualified sidecar)))
+          bare-allow      (set (:xray-spec-known-unmanifested sidecar))
+          file            (proj/repo-file "tools" "xray" "spec" "API.md")
+          rel             (proj/repo-relative file)
+          lines           (proj/numbered-lines file)
+          qualified-refs  (distinct (proj/qualified-symbol-references
+                                      "day8.re-frame2-xray." lines))
+          bare-refs       (distinct (xray/mount-references lines))
+          problems        (xray/reconcile {:rows            rows
+                                           :qualified-refs  qualified-refs
+                                           :bare-refs       bare-refs
+                                           :qualified-allow qualified-allow
+                                           :bare-allow      bare-allow
+                                           :rel             rel})]
+      (is (pos? (count qualified-refs))
+          "the spec must actually name fully-qualified Xray symbols")
+      (is (empty? problems)
+          (str "live drift: " (pr-str problems))))))

--- a/implementation/scripts/lib/local-browser-harness.cjs
+++ b/implementation/scripts/lib/local-browser-harness.cjs
@@ -8,12 +8,30 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// A "usable explicit port" is an integer in 1..65535 — a port a caller
+// can pin, advertise in a BASE_URL, and probe. Port 0 is excluded: it
+// binds (the OS assigns an ephemeral port) but the assigned port is only
+// knowable by reading it back off the bound socket, so advertising :0 is
+// never what a caller wants. Out-of-range (<1, >65535) and non-integers
+// are excluded because net.listen throws ERR_SOCKET_BAD_PORT on them.
+// (rf2-0u8kz — matches the strict 1..65535 contract the example/Story
+// port resolvers already enforce in examples/scripts/port-resolver.cjs.)
+function isValidExplicitPort(port) {
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
+}
+
 // True if the given TCP port is currently free on 127.0.0.1. We bind a
 // temporary listener and immediately release it; EADDRINUSE (or any
 // other bind error) is treated as "not free" so callers fall back to an
-// OS-chosen port. (rf2-84gzw — shared with serve-and-run-browser-tests
-// and check-story-static, which carry their own copies for now.)
+// OS-chosen port. A port outside 1..65535 (including 0) is reported "not
+// free" WITHOUT touching net.listen — port 0 would otherwise bind an
+// ephemeral port (a false "free" for an unusable advertised port), and
+// negative / overflow values would throw ERR_SOCKET_BAD_PORT instead of
+// the controlled fall-through. (rf2-84gzw / rf2-0u8kz — shared with
+// serve-and-run-browser-tests and check-story-static, which carry their
+// own copies for now.)
 function isPortFree(port) {
+  if (!isValidExplicitPort(port)) return Promise.resolve(false);
   return new Promise((resolve) => {
     const srv = net.createServer();
     srv.once('error', () => resolve(false));
@@ -36,12 +54,18 @@ function findFreePort() {
   });
 }
 
-// Resolve a port to serve on: prefer `preferredPort` when it is free,
-// otherwise fall back to an OS-chosen free port. `onFallback(preferred,
-// fallback)` is invoked (if provided) when the preferred port is busy so
-// callers can log the substitution.
+// Resolve a port to serve on: prefer `preferredPort` when it is a usable
+// explicit port (integer 1..65535) AND currently free, otherwise fall
+// back to an OS-chosen free port. `onFallback(preferred, fallback)` is
+// invoked (if provided) on EITHER fallback trigger — a busy preferred
+// port OR an invalid one (0, negative, overflow, NaN, non-integer) — so
+// callers log the substitution rather than advertising an unusable :0 or
+// crashing net.listen with ERR_SOCKET_BAD_PORT. (rf2-0u8kz centralised
+// the explicit-port validation here; callers that derive preferredPort
+// from an env var — e.g. `Number(process.env.XRAY_FEATURE_GATE_PORT)` —
+// no longer leak 0/out-of-range values into the listen path.)
 async function resolveServePort(preferredPort, opts = {}) {
-  if (Number.isInteger(preferredPort) && (await isPortFree(preferredPort))) {
+  if (isValidExplicitPort(preferredPort) && (await isPortFree(preferredPort))) {
     return preferredPort;
   }
   const fallback = await findFreePort();
@@ -354,6 +378,7 @@ module.exports = {
   fetchToken,
   findFreePort,
   isPortFree,
+  isValidExplicitPort,
   probeHttp,
   resolveServePort,
   sleep,

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -180,9 +180,13 @@ async function resolvePort() {
   const envRaw = process.env.BROWSER_TEST_PORT;
   if (envRaw && envRaw.trim() !== '') {
     const parsed = parseInt(envRaw, 10);
-    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
+    // A usable explicit port is an integer in 1..65535 (rf2-0u8kz). Port 0
+    // is rejected here too: it binds an ephemeral port but is useless as an
+    // advertised BASE_URL, so treat it like any other invalid value and
+    // choose a free port deterministically.
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
       console.error(
-        `BROWSER_TEST_PORT="${envRaw}" is not a valid TCP port; ignoring and choosing a free port.`
+        `BROWSER_TEST_PORT="${envRaw}" is not a valid TCP port (want 1..65535); ignoring and choosing a free port.`
       );
       return await findFreePort();
     }

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -195,6 +195,20 @@
    "popout-full-shell!"}     ; re-frame.story.ui.xray-embed sub-ns
 
  ;; tools/xray/spec/API.md public-var references the manifest does not carry.
+ ;; The Xray-spec projection check (re-frame.api-manifest.xray-spec-check)
+ ;; resolves TWO reference shapes against DIFFERENT indexes, so it carries
+ ;; TWO allowlists (rf2-0u8kz):
+ ;;
+ ;;   - `:xray-spec-known-unmanifested` (BELOW) — bare var-name strings, for
+ ;;     bare `mount-<panel>!` references (the aggregator family). Resolved
+ ;;     against the bare-var index.
+ ;;   - `:xray-spec-known-unmanifested-qualified` (BELOW) — `[ns var]`
+ ;;     vectors, for fully-namespace-qualified `day8.re-frame2-xray.*/<var>`
+ ;;     references (the Panel inventory). Resolved against the STRICT
+ ;;     `[namespace var]` index — a qualified symbol must match the exact
+ ;;     ns+var pair, never merely share a bare var name (e.g. `Panel`) with
+ ;;     some other manifested namespace.
+ ;;
  ;; rf2-jhn46 MIGRATED the live Xray public surface (the `Panel` exports, the
  ;; `mount-<panel>!` aggregator family, the `config` published constants, the
  ;; `open-in-editor` chip, and the `runtime` discovery-sentinel + safe-egress
@@ -208,6 +222,18 @@
  :xray-spec-known-unmanifested
  #{"mount-issues-ribbon!"    ; spec/API.md §Panel reg-views — REMOVED with the Issues tab (rf2-gbz39, Option (c)); named in removal prose only
    "mount-inline-panel!"}    ; spec/API.md §What this doesn't expose — REMOVED (rf2-sbfb7, "A — delete both"); named in removal prose only
+
+ ;; Fully-namespace-qualified Xray references (`[ns var]` vectors) the
+ ;; manifest does not carry — namespace-qualified prose / removal mentions
+ ;; of a panel namespace that no longer exists. Empty today: every
+ ;; fully-qualified `day8.re-frame2-xray.*/<var>` the Xray spec names as a
+ ;; live symbol resolves to a manifest [namespace var] row. A future
+ ;; deliberate prose mention of a removed panel namespace (e.g. the stale
+ ;; `[\"day8.re-frame2-xray.panels.views\" \"Panel\"]` spelling rf2-yxw57
+ ;; corrected) would be allowlisted here as `[ns var]`, NOT as a bare var —
+ ;; so it cannot mask a live-but-renamed panel namespace.
+ :xray-spec-known-unmanifested-qualified
+ #{}
 
  ;; skills/ (excl. re-frame-migration) call-position `(rf/<var>` references
  ;; the manifest does not carry. The checked skills teach against the LIVE


### PR DESCRIPTION
Fixes **rf2-0u8kz** (P1) — two correctness gaps in `implementation/scripts`.

## 1. Xray API-spec projection mis-resolves fully-qualified symbols

`xray_spec_check.clj` parsed fully-qualified `day8.re-frame2-xray.*/<var>` Panel symbols but resolved them against a set of **bare** `:var` names. The manifest carries the same `:var "Panel"` for ten distinct panel namespaces, so a stale / renamed / never-manifested namespace (e.g. `day8.re-frame2-xray.panels.views/Panel`) **falsely passed** as long as any Xray namespace exported a var of that bare name — defeating the renamed/removed-panel drift contract and letting the spec teach a wrong public symbol while CI stayed green.

**Fix:** resolve qualified references against the strict `[namespace var]` index; keep the bare-var path only for the bare `mount-<panel>!` family. The sidecar allowlist is split: the existing bare allowlist (`:xray-spec-known-unmanifested`) covers removed bare mount names, and a new `:xray-spec-known-unmanifested-qualified` (`[ns var]` vectors, empty today) covers namespace-qualified prose/removal mentions — so a removed-panel prose mention can never mask a live-but-renamed panel namespace.

Extracted a pure `reconcile` fn and added a JVM `:test` alias + `xray_spec_check_test.clj`. Verified old-vs-new on the repro:

```
OLD bare-name logic: stale panels.views/Panel would resolve?: true
NEW strict logic:    problems flagged for stale ref: 1
```

## 2. Browser harness accepts unusable / invalid explicit ports

`resolveServePort` returned `preferredPort=0` (port 0 binds an ephemeral port but is useless as an advertised port) and fed negative / `>65535` values straight into `net.listen` (`ERR_SOCKET_BAD_PORT`) instead of the documented controlled fallback.

**Fix:** centralized `isValidExplicitPort` (integer `1..65535`) — the same contract `examples/scripts/port-resolver.cjs` already enforces. `isPortFree` short-circuits invalid ports to `false` without touching `net.listen`; `resolveServePort` falls back (logged via `onFallback`) for `0` / negative / overflow / `NaN` / non-integer preferred ports. `serve-and-run-browser-tests.cjs` now rejects `BROWSER_TEST_PORT=0` too. Added regression tests for `0`, negative, overflow, and non-numeric env values.

## Gates run (all green)
- `clojure -M -m re-frame.api-manifest.xray-spec-check` — OK (23 references in sync)
- `clojure -M:test` (new api-manifest tests) — 6 tests, 12 assertions, 0 failures
- `npm run test:script-helpers` — local-browser-harness 15 passed (3 new), all suites green
- `npm run test:script-policy` — all green
- clj-kondo on changed clj — 0 errors / 0 warnings

## Cross-platform
All changes are pure JS / Clojure logic with no platform-specific paths or shell — the `1..65535` guard and `[ns var]` resolution hold identically on Windows + macOS + Linux. No hot-zone files touched (the lint.yml CI step already invokes the check via `-main`; the edited `deps.edn` is the api-manifest tool's own, not the top-level one).