### PR TITLE
fix(machines-viz/scxml): preserve vector-path transition targets through round-trip (rf2-csq75)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1746,8 +1746,20 @@ documenting comment and does **not** survive the parse back.
 | `:after {ms :target}`                 | `<transition event="after.ms" target="target"/>` |
 | `:always [...]`                       | `<transition target="..."/>` (eventless) |
 | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
-| Namespaced ids (`:auth/login`)        | `auth.login` (dot-separated; SCXML id grammar) |
-| Vector-path targets                   | dot-joined `parent.child.grandchild` |
+| Namespaced ids (`:auth/login`)        | `auth.login` (`.` separates ns from name; SCXML xsd:ID grammar) |
+| Vector-path targets (`[:parent :child]`) | `parent:child` (`:` joins path SEGMENTS; SCXML xsd:ID grammar) |
+
+> **Id codec (rf2-csq75).** Two separators keep the round-trip
+> injective. A `.` separates a *namespaced keyword's* namespace from
+> its name (`:auth/login` → `auth.login`). A `:` joins the *segments of
+> a vector path* (`[:authenticated :browsing]` → `authenticated:browsing`;
+> a namespaced segment keeps its own dot, e.g. `[:auth/region :browsing]`
+> → `auth.region:browsing`). Because the keyword encoder never emits a
+> `:`, the presence of a `:` is the unambiguous marker of a vector path,
+> so a two-segment path (`authenticated:browsing`) can never collide
+> with a single namespaced keyword (`authenticated.browsing`). The
+> decoder is therefore topology-aware (split on `:`), not dot-count
+> based. Both separators are valid SCXML xsd:ID characters.
 
 ### Not supported (lossy or omitted)
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -44,8 +44,8 @@
   | `:after {ms :target}`                 | `<transition event=\"after.ms\" target=\"target\"/>` |
   | `:always [...]`                       | `<transition target=\"...\"/>` (eventless) |
   | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
-  | Namespaced ids (`:auth/login`)        | `auth.login` (dot-separated; SCXML id allows `.`) |
-  | Vector-path targets                   | dot-joined `parent.child.grandchild` |
+  | Namespaced ids (`:auth/login`)        | `auth.login` (`.` separates ns/name; SCXML id allows `.`) |
+  | Vector-path targets (`[:parent :child]`) | `parent:child` (`:` joins path segments — rf2-csq75) |
 
   ## Not supported (lossy or omitted)
 
@@ -79,9 +79,33 @@
 ;;
 ;; Re-frame2 ids are typically keywords (`:idle`, `:auth/login-flow`)
 ;; or vector paths (`[:authenticated :browsing]`). SCXML state ids
-;; are strings; the W3C grammar (XML Name) accepts `.` `_` `-` and
-;; alphanumerics. We map: `:auth/login` → `"auth.login"`, hyphens
-;; preserved, vector paths dot-joined.
+;; are strings; the W3C grammar (XML xsd:ID) accepts `.` `_` `-` `:`
+;; and alphanumerics. Two SEPARATE separators keep the codec injective:
+;;
+;; - `.` (DOT) joins a namespaced keyword's namespace and name:
+;;   `:auth/login` → `"auth.login"`. A single keyword emits AT MOST one
+;;   logical separation (ns vs name).
+;; - `:` (COLON) joins the segments of a VECTOR PATH:
+;;   `[:authenticated :browsing]` → `"authenticated:browsing"`,
+;;   `[:auth/login :browsing]` → `"auth.login:browsing"`.
+;;
+;; Because `keyword->id-string` never emits a `:` (it only emits the
+;; keyword's own chars plus a `.` between ns and name), the presence of
+;; a `:` in an id string is an UNAMBIGUOUS marker that the id is a
+;; vector path. This is what makes the round-trip topology-aware rather
+;; than dot-count-aware: a single namespaced keyword (`"auth.login"`,
+;; one dot, no colon) can never collide with a two-segment vector path
+;; (`"auth:login"`, one colon). rf2-csq75 — pre-fix the encoder
+;; dot-joined vector paths, so `[:authenticated :browsing]` and
+;; `:authenticated/browsing` both produced `"authenticated.browsing"`
+;; and the decoder (dot-count) collapsed the vector into a namespaced
+;; keyword, silently changing machine semantics.
+
+(def ^:private path-segment-sep
+  "rf2-csq75 — the vector-PATH segment separator. `:` is a valid XML
+  xsd:ID char that `keyword->id-string` never emits, so its presence in
+  an id string is the injective marker of a vector path."
+  ":")
 
 (defn- keyword->id-string
   "Map a single keyword to its SCXML id string."
@@ -92,20 +116,23 @@
 
 (defn- path->id-string
   "Map a re-frame2 id (keyword or vector path) to a single SCXML id
-  string. Path separator is `.` — distinct from the `.` used inside a
-  namespaced keyword because path components are full-segment-joined.
-  Decoders disambiguate by walking the registered state hierarchy
-  from the root, not by counting dots."
+  string. A namespaced keyword uses `.` between ns and name; a vector
+  path joins its per-segment id strings with `:` (`path-segment-sep`).
+  The two separators never collide, so decoders disambiguate a vector
+  path from a namespaced keyword by the PRESENCE of `:`, not by counting
+  dots (rf2-csq75)."
   [id]
   (cond
     (keyword? id) (keyword->id-string id)
-    (vector? id)  (str/join "." (map keyword->id-string id))
+    (vector? id)  (str/join path-segment-sep (map keyword->id-string id))
     (string? id)  id
     :else         (str id)))
 
 (defn- id-string->keyword
-  "Inverse of `keyword->id-string`. Recovers `:ns/name` from
-  `\"ns.name\"`; bare `\"name\"` round-trips to `:name`."
+  "Inverse of `keyword->id-string` for a SINGLE keyword segment.
+  Recovers `:ns/name` from `\"ns.name\"`; bare `\"name\"` round-trips to
+  `:name`. The input is assumed to be a single keyword segment (no `:`
+  path separator) — `unescape-id-string` handles vector-path splitting."
   [s]
   (when s
     (let [parts (str/split s #"\.")]
@@ -408,23 +435,29 @@
 
 (defn- unescape-id-string
   "Convert a SCXML id string back to a re-frame2 keyword (or vector
-  path when the id has more than one logical segment).
+  path). Inverse of `path->id-string` (rf2-csq75).
 
-  We can't distinguish `\"auth.login\"` (one namespaced keyword) from
-  `\"auth.login\"` (a two-segment compound path) at the string level.
-  The convention is: ids the encoder produces from compound paths use
-  dot-joined segments where each segment is either bare (`name`) or
-  namespaced (`ns.name`). Since the encoder only round-trips its own
-  output structurally, we map back via the simplest unambiguous rule:
-  a single dot = namespaced keyword; multi-dot = vector path."
+  The encoder uses TWO separators so the decoding is topology-aware,
+  not dot-count-aware:
+
+  - `:` (`path-segment-sep`) joins VECTOR-PATH segments. Its presence
+    is the injective marker of a vector path — `keyword->id-string`
+    never emits `:`, so it cannot arise from a single keyword.
+  - `.` joins a namespaced keyword's namespace and name WITHIN a
+    segment.
+
+  So: an id containing `:` decodes to a vector of per-segment keywords
+  (each segment via `id-string->keyword`, recovering `:ns/name` from a
+  segment's own dot); an id with NO `:` decodes to a single keyword —
+  one dot ⇒ namespaced (`\"auth.login\"` → `:auth/login`), no dot ⇒
+  bare (`\"idle\"` → `:idle`). A two-segment vector path
+  (`\"authenticated:browsing\"`) no longer collides with a namespaced
+  keyword (`\"authenticated.browsing\"`)."
   [s]
-  (let [dot-count (count (filter #(= % \.) s))]
-    (cond
-      (= 0 dot-count) (keyword s)
-      (= 1 dot-count) (id-string->keyword s)
-      :else
-      (let [parts (str/split s #"\.")]
-        (mapv keyword parts)))))
+  (when s
+    (if (str/includes? s path-segment-sep)
+      (mapv id-string->keyword (str/split s (re-pattern path-segment-sep)))
+      (id-string->keyword s))))
 
 (defn- tokenize
   "Walk an XML string and return a flat seq of token maps:

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -89,6 +89,29 @@
                     :states  {:neutral {:on {:submit :correct}}
                               :correct {:final? true}}}}})
 
+(def vector-path-target-machine
+  "rf2-csq75 — a compound machine whose transition target is a VECTOR
+  PATH `[:authenticated :browsing]` (a deep-target into a compound
+  child). The encoder must distinguish this from the namespaced keyword
+  `:authenticated/browsing`: pre-fix both dot-joined to
+  `\"authenticated.browsing\"` and the decoder collapsed the vector to a
+  namespaced keyword, silently changing machine semantics."
+  {:initial :idle
+   :states  {:idle          {:on {:login [:authenticated :browsing]}}
+             :authenticated {:initial :browsing
+                             :states  {:browsing {:on {:logout :idle}}
+                                       :paying   {}}}}})
+
+(def vector-path-namespaced-segment-machine
+  "rf2-csq75 — a vector-path target whose FIRST segment is itself a
+  namespaced keyword (`[:auth/region :browsing]`). Exercises the
+  `.`-within-segment + `:`-between-segments codec: a namespaced segment
+  inside a vector path must survive both separators independently."
+  {:initial :a
+   :states  {:a          {:on {:go [:auth/region :browsing]}}
+             :auth/region {:initial :browsing
+                           :states  {:browsing {}}}}})
+
 ;; ---------------------------------------------------------------------------
 ;; Emit shape
 
@@ -217,6 +240,42 @@
   (testing ":type :parallel + :regions round-trips through <parallel>"
     (is (round-trips? parallel-machine))))
 
+(deftest round-trip-vector-path-target
+  (testing "rf2-csq75 — a vector-path transition target round-trips as
+            the SAME vector, NOT collapsed to a namespaced keyword"
+    ;; The exact repro from the bead: the target must come back a vector.
+    (let [spec {:initial :idle
+                :states  {:idle          {:on {:login [:authenticated :browsing]}}
+                          :authenticated {:initial :browsing
+                                          :states  {:browsing {}}}}}
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= [:authenticated :browsing]
+             (get-in back [:states :idle :on :login]))
+          "vector target must NOT collapse to :authenticated/browsing")
+      (is (vector? (get-in back [:states :idle :on :login]))
+          "the decoded target is a vector, not a namespaced keyword")
+      (is (= spec back) "the whole spec round-trips exactly"))
+    ;; The colon path-separator must NOT collide with namespaced keywords:
+    ;; a sibling :authenticated/browsing namespaced-keyword target stays a
+    ;; keyword while the vector path stays a vector.
+    (is (round-trips? vector-path-target-machine))
+    (is (round-trips? vector-path-namespaced-segment-machine))
+    (testing "the emitted SCXML uses `:` (not `.`) between vector segments"
+      (let [out (scxml/spec->scxml vector-path-target-machine)]
+        (is (str/includes? out "target=\"authenticated:browsing\"")
+            "vector path joins with the `:` path-segment separator")
+        (is (not (str/includes? out "target=\"authenticated.browsing\""))
+            "the dot-joined (ambiguous) form must NOT appear")))
+    (testing "a namespaced-keyword target stays a namespaced keyword
+              (no false vector promotion)"
+      (let [spec {:initial :a
+                  :states  {:a {:on {:go :auth/login}}
+                            :auth/login {}}}
+            back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+        (is (= :auth/login (get-in back [:states :a :on :go]))
+            "single namespaced keyword must NOT become [:auth :login]")
+        (is (keyword? (get-in back [:states :a :on :go])))))))
+
 ;; ---------------------------------------------------------------------------
 ;; Error cases
 
@@ -262,7 +321,10 @@
                          ["guarded-machine"             guarded-machine]
                          ["after-machine"               after-machine]
                          ["always-machine"              always-machine]
-                         ["parallel-machine"            parallel-machine]]]
+                         ["parallel-machine"            parallel-machine]
+                         ["vector-path-target-machine"  vector-path-target-machine]
+                         ["vector-path-namespaced-segment-machine"
+                          vector-path-namespaced-segment-machine]]]
       (testing name
         (is (= spec (-> spec scxml/spec->scxml scxml/scxml->spec)))))))
 


### PR DESCRIPTION
## Summary

Fixes **finding 2** of rf2-csq75 (P1): the SCXML round-trip corrupted vector-path transition targets.

The emitter dot-joined vector-path segments (`[:authenticated :browsing]` -> `"authenticated.browsing"`) — lexically identical to a namespaced keyword's encoding (`:authenticated/browsing` -> `"authenticated.browsing"`). The decoder disambiguated by **dot-count** (one dot = namespaced keyword, multi-dot = path), so a two-segment vector path collapsed into a namespaced keyword on import, silently changing machine semantics. `spec/API.md` lists vector-path targets as supported, so this violated the documented round-trip contract.

## Fix

Two separators make the codec injective and the decode **topology-aware**, not dot-count-aware:

- `.` separates a namespaced keyword's namespace from its name (`:auth/login` -> `auth.login`) — unchanged.
- `:` joins the **segments of a vector path** (`[:authenticated :browsing]` -> `authenticated:browsing`; `[:auth/region :browsing]` -> `auth.region:browsing`).

The keyword encoder never emits `:`, so its presence is the unambiguous marker of a vector path — a two-segment path (`authenticated:browsing`) can no longer collide with a single namespaced keyword (`authenticated.browsing`). Both separators are valid SCXML `xsd:ID` characters. `unescape-id-string` now splits on `:` instead of counting dots.

## Repro proof

Before: `(-> {:initial :idle :states {:idle {:on {:login [:authenticated :browsing]}} ...}} spec->scxml scxml->spec)` returned `{:on {:login :authenticated/browsing}}` (vector collapsed to namespaced keyword).

After: returns the SAME vector `[:authenticated :browsing]`; full spec round-trips `(= spec back)`.

## Tests

- New `round-trip-vector-path-target` deftest pins the exact bead repro + asserts the emitted SCXML uses `target="authenticated:browsing"` (not the ambiguous dot form) + a no-false-promotion check that a lone namespaced-keyword target stays a keyword.
- New `vector-path-target-machine` + `vector-path-namespaced-segment-machine` fixtures added to the property-pinned round-trip list.

## Spec

`spec/API.md` §SCXML supported-grammar-subset + the `scxml.cljc` ns docstring updated with the two-separator id codec.

## Finding 1 (not re-fixed)

Finding 1 (SVG/PNG export dropping state nodes) was **already fixed by the merged rf2-sr6l3 (#3120)** — the `<foreignObject>` full-viewport capture, with PNG inheriting it via `chart-as-svg`, and a browser-DOM regression in `export_dom_cljs_test.cljs` asserting state-box text + active affordance survive export. Verified, not re-fixed here.

## Quality gates (green)

- machines-viz `clojure -M:test`: 365 tests, 1072 assertions, 0 failures.
- `npm run test:cljs`: 5635 tests, 19634 assertions, 0 failures.

Closes rf2-csq75.
