### PR TITLE
fix(mcp-base): redact malformed sensitive diagnostic + count once per event (rf2-el9sw)

### DIFF
--- a/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
@@ -131,12 +131,14 @@
             [kept dropped] (sens/strip-sensitive [ev] false)]
         (is (= [] kept) (str "malformed stamp " (pr-str stamp) " was NOT dropped"))
         (is (= 1 dropped))
-        ;; strip-sensitive scans the event with `some` (fast-path) then
-        ;; `filterv` (drop-path) - each calls `sensitive-event?`, so a single
-        ;; malformed event bumps the counter once per scan. Assert it fired
-        ;; (>= 1), not an exact count tied to the scan strategy.
-        (is (pos? (sens/malformed-count))
-            (str "malformed stamp " (pr-str stamp) " did not bump the counter"))))))
+        ;; rf2-el9sw: `strip-sensitive` now classifies each event EXACTLY
+        ;; ONCE (single-pass), so the malformed counter is a faithful
+        ;; per-event metric. (Pre-fix it ran `sensitive-event?` twice —
+        ;; `some` pre-scan + `filterv` drop-scan — so one event bumped the
+        ;; counter ~2×; the assertion then could only check `(pos? ...)`.)
+        (is (= 1 (sens/malformed-count))
+            (str "malformed stamp " (pr-str stamp)
+                 " must bump the counter exactly once per event"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; PROPERTY 2 - gate ON + opt-in: include? true ships everything verbatim

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -12,7 +12,7 @@ This doc is one of eleven per-namespace contracts indexed from [`README.md`](REA
 - The cross-MCP fail-closed `sensitive-event?` predicate over a trace-event map.
 - The `strip-sensitive` walker (returns `[kept dropped-count]`).
 - The `scrub-snapshot` walker that strips `:traces` / `:epochs` slices from each per-frame snapshot map.
-- The fail-closed malformed-stamp counter (`malformed-count` / `reset-malformed-count!`) — operator-surface observability for the rf2-ih7g4 fail-closed posture; bumped every time a non-boolean truthy `:sensitive?` stamp arrives and is dropped + logged.
+- The fail-closed malformed-stamp counter (`malformed-count` / `reset-malformed-count!`) — operator-surface observability for the rf2-ih7g4 fail-closed posture; bumped exactly **once per dropped malformed event** (a non-boolean truthy `:sensitive?` stamp). `strip-sensitive` / `scrub-snapshot` classify each event exactly once (single-pass — rf2-el9sw), so the count is a faithful per-event metric rather than a scan-strategy-dependent over-count.
 - The fixed cross-server arg-vocabulary name (`:include-sensitive`) every MCP tool surfacing trace-like data MUST accept.
 
 `sensitive` does NOT own:
@@ -26,6 +26,8 @@ This doc is one of eleven per-namespace contracts indexed from [`README.md`](REA
 ### `sensitive-event?` — predicate
 
 Predicate over a trace-event map. **Fail-closed** (rf2-ih7g4): the literal `true` value drops (the documented spec/009 path), AND any other *truthy non-boolean* stamp also drops — with a stderr / `console.warn` contract-drift warning and a bump of the malformed counter. Only an explicit `false` / `nil` / absent stamp passes. The `:rf/trace-event` schema types `:sensitive?` as a boolean (Spec 009 + Spec-Schemas); a non-boolean stamp is a serialisation-bug *contract violation* that we surface (warn + drop) rather than silently treat as non-sensitive.
+
+**The contract-drift warning is value-free (rf2-el9sw).** Logs are an egress boundary on this privacy surface; a malformed stamp is wire-adjacent, untrusted data, and a serialisation bug could put a secret-bearing string / map / vector in `:sensitive?`. The warning therefore carries ONLY a value-free type tag (`type=String`, `type=Keyword`, …) and a fixed `value=:rf/redacted` sentinel — it MUST NOT `pr-str` the raw stamp. The `malformed-count` counter is the quantitative observability hook; the type tag is the qualitative one; neither carries the payload.
 
 Definition (effectively):
 

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -69,6 +69,14 @@
   is the operator-surface observability hook. Public so operator
   dashboards and tests can read the gate's activity.
 
+  This is a faithful PER-EVENT metric (rf2-el9sw): the egress walkers
+  (`strip-sensitive` / `scrub-snapshot`) classify each event exactly
+  once, so a single dropped malformed event bumps the counter exactly
+  once. (Pre-rf2-el9sw `strip-sensitive` ran the predicate twice per
+  event — `some` pre-scan + `filterv` drop-scan — so one malformed
+  event over-counted ~2×.) Direct `sensitive-event?` / `sensitive-stamp?`
+  calls still bump once per call, as before.
+
   Returns a non-negative integer."
   []
   #?(:clj  (.get ^java.util.concurrent.atomic.AtomicLong malformed-counter)
@@ -91,22 +99,55 @@
   #?(:clj  (.incrementAndGet ^java.util.concurrent.atomic.AtomicLong malformed-counter)
      :cljs (swap! malformed-counter inc)))
 
+(defn- stamp-type-tag
+  "A NON-sensitive, value-free class/type tag for a malformed stamp.
+  Logged in place of the raw stamp so the contract-drift warning stays
+  fail-CLOSED at the log boundary (rf2-el9sw): an operator sees the
+  shape of the drift (`String`, `Keyword`, …) and a fixed reason, but
+  never the payload, which on a serialisation bug could carry a secret.
+  Returns a short type-name string — never any of the stamp's data."
+  [stamp]
+  #?(:clj  (or (some-> stamp class .getSimpleName) "nil")
+     :cljs (cond
+             (string? stamp)  "string"
+             (keyword? stamp) "keyword"
+             (symbol? stamp)  "symbol"
+             (number? stamp)  "number"
+             (map? stamp)     "map"
+             (vector? stamp)  "vector"
+             (seq? stamp)     "seq"
+             (set? stamp)     "set"
+             (coll? stamp)    "coll"
+             (nil? stamp)     "nil"
+             :else            "value")))
+
 (defn- log-malformed!
   "Surface a contract-drift warning when a non-boolean truthy
   `:sensitive?` stamp arrives. The runtime contract types this slot
   as a boolean; anything else is a serialisation bug worth fixing at
-  the source. Stderr keeps the warning out of the MCP wire response."
+  the source. Stderr / `console.warn` keep the warning out of the MCP
+  wire response.
+
+  FAIL-CLOSED AT THE LOG BOUNDARY (rf2-el9sw): logs are an egress
+  boundary on this privacy surface. A malformed stamp is wire-adjacent,
+  untrusted data; if a serialisation bug puts a secret-bearing
+  string/map/vector in `:sensitive?`, echoing it with `pr-str` would
+  leak the value to stderr / the JS console even though the event was
+  dropped from MCP output. So we log ONLY a value-free type tag and a
+  fixed reason — never the raw stamp (matching `:rf/redacted` posture).
+  The `malformed-count` counter is the quantitative observability hook;
+  the type tag is the qualitative one. Neither carries the payload."
   [stamp]
-  #?(:clj  (binding [*out* *err*]
-             (println (str "[re-frame.mcp-base.sensitive] WARN: non-boolean truthy "
-                           ":sensitive? stamp dropped (fail-closed) — "
-                           "type=" (some-> stamp class .getName)
-                           " value=" (pr-str stamp))))
-     :cljs (when (and (exists? js/console) js/console.warn)
-             (js/console.warn
-               (str "[re-frame.mcp-base.sensitive] non-boolean truthy "
-                    ":sensitive? stamp dropped (fail-closed) — "
-                    "value=" (pr-str stamp))))))
+  (let [tag (stamp-type-tag stamp)]
+    #?(:clj  (binding [*out* *err*]
+               (println (str "[re-frame.mcp-base.sensitive] WARN: non-boolean truthy "
+                             ":sensitive? stamp dropped (fail-closed) — "
+                             "type=" tag " value=:rf/redacted")))
+       :cljs (when (and (exists? js/console) js/console.warn)
+               (js/console.warn
+                 (str "[re-frame.mcp-base.sensitive] non-boolean truthy "
+                      ":sensitive? stamp dropped (fail-closed) — "
+                      "type=" tag " value=:rf/redacted"))))))
 
 (defn sensitive-stamp?
   "Classify a sensitive-rollup slot value. Fail-closed posture (rf2-ih7g4):
@@ -162,25 +203,48 @@
   §Privacy. Apply it to any vector of trace-event-shaped maps before
   the result crosses the MCP boundary into the agent surface.
 
-  ## Fast-path (rf2-0q30r)
+  ## Fast-path + single-classification (rf2-0q30r, rf2-el9sw)
 
-  The docstring promises identical-vector return when no events drop;
-  the implementation honours that by scanning first with `some` and
-  only allocating a `filterv` vector when at least one match exists.
-  Common-path cost: one linear `some` scan, zero allocation, identity
-  preserved on `events`. Drop-path cost: the same linear scan plus
-  the historical `filterv`/`count`/`count` pass — one extra walk on
-  the rare branch in exchange for zero extra cost on every common
-  call."
+  The docstring promises identical-vector return when no events drop.
+  The implementation honours that with a SINGLE linear pass that
+  classifies each event exactly once: it builds the kept vector while
+  tracking whether anything dropped, and returns the original `events`
+  (identity preserved, no `filterv` allocation) when nothing dropped.
+
+  Why exactly once matters (rf2-el9sw): `sensitive-event?` is
+  SIDE-EFFECTING on the malformed-truthy path — it bumps
+  `malformed-count` and logs a contract-drift warning. The previous
+  two-pass shape (`some` pre-scan THEN `filterv` drop-scan) ran the
+  predicate over each event up to twice, so a single malformed event
+  bumped the counter ~2× and emitted the warning twice. One pass ⇒ one
+  classification ⇒ one bump + one warning per malformed event, so
+  `malformed-count` is a faithful per-event metric for operator
+  dashboards.
+
+  Common-path cost: one linear pass, zero retained allocation, identity
+  preserved on `events`. Drop-path cost: the same single pass plus the
+  kept-vector it was already building."
   [events include?]
   (cond
-    include?                       [events 0]
-    (empty? events)                [events 0]
-    (not (some sensitive-event? events)) [events 0]
+    include?        [events 0]
+    (empty? events) [events 0]
     :else
-    (let [kept (filterv (complement sensitive-event?) events)
-          n    (- (count events) (count kept))]
-      [kept n])))
+    ;; Single classifying pass: `sensitive-event?` runs exactly once per
+    ;; event (so its malformed-path side effects fire exactly once),
+    ;; while `dropped?` tracks whether to allocate. Identity-preserving
+    ;; fast path: if nothing dropped, return the original `events`.
+    (let [n-events (count events)
+          kept     (reduce (fn [acc ev]
+                             (if (sensitive-event? ev)
+                               acc
+                               (conj! acc ev)))
+                           (transient [])
+                           events)
+          kept     (persistent! kept)
+          n        (- n-events (count kept))]
+      (if (zero? n)
+        [events 0]
+        [kept n]))))
 
 (defn scrub-snapshot
   "Walk a per-frame snapshot map and apply a strip-fn to every

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -3,7 +3,8 @@
   across the MCP pair (rf2-vw4sq). The predicate and the filter
   must stay byte-identical across re-frame2-pair-mcp and story-mcp
   — these tests pin the contract."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string]
+            [clojure.test :refer [deftest is testing]]
             [re-frame.mcp-base.sensitive :as sensitive]))
 
 ;; ---------------------------------------------------------------------------
@@ -302,6 +303,105 @@
       "reset returns the new value (zero)")
   (is (zero? (sensitive/malformed-count))
       "reset zeroes the counter for the next test"))
+
+;; ---------------------------------------------------------------------------
+;; rf2-el9sw — the malformed-stamp diagnostic must not LEAK and must not
+;; OVERCOUNT. Logs are an egress boundary on this privacy surface: a
+;; malformed truthy `:sensitive?` stamp is wire-adjacent, untrusted data,
+;; and a serialisation bug could carry a secret in it. The fail-closed
+;; posture drops the event from MCP output; the diagnostic must NOT then
+;; re-leak the value across the log boundary, and the malformed counter
+;; must be a faithful PER-EVENT metric (one bump per dropped malformed
+;; event), not a scan-strategy-dependent over-count. Subsumes rf2-lxm3e
+;; (leak) and rf2-5uqwa (over-count).
+;; ---------------------------------------------------------------------------
+
+(deftest malformed-warning-redacts-raw-stamp-value
+  ;; rf2-el9sw / rf2-lxm3e: the contract-drift warning must carry a
+  ;; value-free type tag + a fixed `:rf/redacted` sentinel — NEVER the
+  ;; raw stamp, which could be a secret-bearing string / map / vector.
+  (sensitive/reset-malformed-count!)
+  (doseq [[stamp leak-needle] [["sk_live_SECRET_TOKEN_abc123" "sk_live_SECRET_TOKEN_abc123"]
+                               [:secret/api-key-VALUE          "api-key-VALUE"]
+                               [{:api_key "AKIA_LEAK"
+                                 :token   "bearer_LEAK"}       "AKIA_LEAK"]
+                               [["leaky-vector-ELEMENT"]       "leaky-vector-ELEMENT"]
+                               [42424242                        "42424242"]]]
+    (let [sw   (java.io.StringWriter.)
+          _    (binding [*err* sw]
+                 (sensitive/sensitive-event? {:operation :rf.event/dispatched
+                                              :sensitive? stamp}))
+          text (str sw)]
+      (is (not (.contains text leak-needle))
+          (str "malformed warning leaked the raw stamp payload for " (pr-str stamp)))
+      (is (.contains text ":rf/redacted")
+          (str "malformed warning must emit the :rf/redacted sentinel for " (pr-str stamp)))
+      (is (.contains text "non-boolean truthy")
+          "warning must still surface the fail-closed contract-drift reason")))
+  (sensitive/reset-malformed-count!))
+
+(deftest strip-sensitive-malformed-count-is-exactly-one-per-event
+  ;; rf2-el9sw / rf2-5uqwa: `sensitive-event?` is side-effecting on the
+  ;; malformed path (bump + log). The OLD `strip-sensitive` ran the
+  ;; predicate twice per event (`some` pre-scan + `filterv` drop-scan),
+  ;; so a single malformed event bumped the counter ~2×. The single-pass
+  ;; classifier fixes this: each event is classified exactly once, so the
+  ;; counter is a faithful per-event metric.
+  (sensitive/reset-malformed-count!)
+  (binding [*err* (java.io.StringWriter.)] ; absorb the warnings
+    (let [evts          [{:id 1 :sensitive? false}
+                         {:id 2 :sensitive? "true"} ; malformed → drop, bump 1
+                         {:id 3}
+                         {:id 4 :sensitive? :yes}    ; malformed → drop, bump 1
+                         {:id 5 :sensitive? true}]   ; well-formed → drop, NO bump
+          [kept dropped] (sensitive/strip-sensitive evts false)]
+      (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+      (is (= 3 dropped) "all three sensitive events drop")
+      (is (= 2 (sensitive/malformed-count))
+          "exactly one bump per MALFORMED event — not ~2× per scan")))
+  (sensitive/reset-malformed-count!))
+
+(deftest strip-sensitive-malformed-warning-emitted-once-per-event
+  ;; rf2-el9sw / rf2-lxm3e: the over-count bug also doubled the WARNING.
+  ;; One malformed event ⇒ exactly one warning line on stderr through
+  ;; `strip-sensitive` (single-pass classification).
+  (sensitive/reset-malformed-count!)
+  (let [sw (java.io.StringWriter.)]
+    (binding [*err* sw]
+      (sensitive/strip-sensitive [{:id 1 :sensitive? "sk_live_ONCE"}] false))
+    (let [lines (->> (clojure.string/split-lines (str sw))
+                     (filter #(.contains ^String % "non-boolean truthy")))]
+      (is (= 1 (count lines))
+          "exactly one contract-drift warning per malformed event (no double-log)")
+      (is (not (.contains (str sw) "sk_live_ONCE"))
+          "and that one warning still does not leak the raw value")))
+  (sensitive/reset-malformed-count!))
+
+(deftest scrub-snapshot-malformed-count-is-exactly-one-per-event
+  ;; rf2-el9sw / rf2-5uqwa: `scrub-snapshot` delegates each slice to
+  ;; `strip-sensitive`, so the per-event count guarantee must hold
+  ;; through the snapshot scrubber too — one malformed trace event in a
+  ;; `:traces` slice bumps the counter exactly once.
+  (sensitive/reset-malformed-count!)
+  (binding [*err* (java.io.StringWriter.)]
+    (let [snap {:rf/default {:traces [{:id 1 :sensitive? "true"}  ; malformed → 1 bump
+                                      {:id 2}]
+                             :epochs [{:event-id :auth :sensitive? :yes}]}} ; malformed → 1 bump
+          [_ dropped] (sensitive/scrub-snapshot snap false)]
+      (is (= 2 dropped))
+      (is (= 2 (sensitive/malformed-count))
+          "scrub-snapshot bumps the counter exactly once per malformed event")))
+  (sensitive/reset-malformed-count!))
+
+(deftest strip-sensitive-no-drop-preserves-identity
+  ;; rf2-el9sw: the single-pass rewrite must keep the rf2-0q30r fast-path
+  ;; identity guarantee — when nothing drops, return the ORIGINAL vector
+  ;; (no fresh allocation).
+  (let [evts [{:id 1} {:id 2 :sensitive? false} {:id 3}]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
+    (is (identical? evts kept)
+        "no-drop path must return the identical input vector (zero allocation)")
+    (is (zero? dropped))))
 
 (deftest scrub-snapshot-2-arity-delegates-to-strip-sensitive
   ;; The 2-arity form is the default-suppress shape used by story-mcp;


### PR DESCRIPTION
@
## What

Fixes two correctness defects in the fail-closed malformed-`:sensitive?` path of `re-frame.mcp-base.sensitive` — the shared MCP privacy egress helper. Both are on the AI/MCP/**log** boundary, which is in scope for this privacy surface.

Authoritative bead: **rf2-el9sw** (P1). Subsumes **rf2-lxm3e** (P2, leak) and **rf2-5uqwa** (P4, per-scan over-count) as duplicates of the same class.

### 1. LEAK (rf2-lxm3e)
`log-malformed!` echoed the raw malformed stamp with `(pr-str stamp)` to stderr / `console.warn`. A serialisation bug that places a secret-bearing string/map/vector in `:sensitive?` was correctly dropped from MCP output, but the value still leaked across the **log** boundary.

**Fix:** the contract-drift warning now carries only a value-free type tag (`type=String`, `type=Keyword`, …) plus a fixed `value=:rf/redacted` sentinel — never the payload. Matches the fail-closed `:rf/redacted` posture.

### 2. OVERCOUNT (rf2-5uqwa)
`strip-sensitive` ran the side-effecting `sensitive-event?` predicate **twice per event** — `(some ...)` pre-scan then `(filterv ...)` drop-scan — so one malformed event bumped `malformed-count` ~2× and emitted the warning twice.

**Fix:** replaced the two-pass shape with a **single classifying pass** that builds the kept vector once. The rf2-0q30r identity-preserving fast path is retained (no-drop returns the original vector, zero allocation). Each event is now classified exactly once ⇒ one bump + one warning per malformed event ⇒ `malformed-count` is a faithful per-event metric.

## Scope note
`sensitive-stamp?` / `sensitive-event?` keep their fail-closed semantics and stay side-effecting (per the bead — they were just promoted public, #3109). Direct callers, including re-frame2-pair-mcp`s `sensitive-epoch?`, still bump once per call; only the base `strip-sensitive` double-scan was removed. re-frame2-pair-mcp`s own `strip-sensitive` was already single-pass (`filterv` only) and is unaffected.

## Tests
- Malformed warning omits the raw value for string / keyword / map / vector / number stamps; emits `:rf/redacted`.
- `strip-sensitive` and `scrub-snapshot` bump `malformed-count` exactly once per malformed event.
- Exactly one warning line per malformed event through `strip-sensitive`.
- No-drop path preserves input-vector identity.
- Tightened the security-egress companion assertion from `(pos? ...)` to `(= 1 ...)` (the old comment documented the over-count it can no longer hide).

Spec `tools/mcp-base/spec/sensitive.md` + docstrings updated.

## Gates (cold, all green)
- `tools/mcp-base` `clojure -M:test` — 186 tests, 530 assertions, 0 failures
- `tools/mcp-base` `npm run test:cljs` — 8 tests, 39 assertions, 0 failures (0 warnings)
- `implementation` `npm run test:security` — 15 tests, 132 assertions, 0 failures
- `tools/re-frame2-pair-mcp` `npm test` — 908 tests, 2781 assertions, 0 failures
- `implementation` `npm run test:mcp-conformance` — all gates green (incl. wire-vocab 49/631)

## Without-fix leak proof
Before fix, `strip-sensitive [{:sensitive? "sk_live_SECRET_LEAK_TOKEN"}] false` emitted to stderr:
```
... value="sk_live_SECRET_LEAK_TOKEN"   (TWICE)
malformed-count == 2   (one event)
```
After fix:
```
... type=String value=:rf/redacted   (ONCE)
malformed-count == 1
```
@