### PR TITLE
fix(story-mcp): no-intern argument ingress — allowlist before keywordize (rf2-3luf3)

### DIFF
--- a/tools/story-mcp/spec/001-Wire-Protocol.md
+++ b/tools/story-mcp/spec/001-Wire-Protocol.md
@@ -19,6 +19,53 @@
   response; the loop continues. The cap exists so a hostile or
   runaway producer can't OOM the server with an unterminated frame.
 
+## No-intern argument ingress (rf2-3luf3)
+
+JVM keywords are interned in a global table that **never shrinks**. The
+stdio server is a long-running JVM process, so any code path that mints a
+fresh keyword from an attacker-/AI-supplied string is a slow-burn DoS:
+a hostile or careless agent that streams unique JSON object keys
+permanently burns one keyword-table slot per unique key. This is the
+same threat model the framework's `:rf.http/max-decoded-keys` cap
+defends (see [`../../../spec/014-HTTPRequests.md` §Keyword-interning
+cap](../../../spec/014-HTTPRequests.md)) and the cross-MCP rule in
+[`../../mcp-base/spec/args.md` §Keyword-interning safety](../../mcp-base/spec/args.md).
+
+The ingress invariant: **untrusted nested wire keys are NEVER keywordised
+before the bounded allowlists run.** Concretely:
+
+- `re-frame.story-mcp.protocol/parse-json` parses each frame with
+  **string keys** (`json/parse-string s false`) — no recursive
+  keywordisation. A nested key under `params.arguments`,
+  `cell-overrides`, or a write `body` therefore never interns at parse
+  time.
+- `protocol/normalize-frame` (run by `read-frame` immediately after the
+  parse) keywordises ONLY:
+  - the finite JSON-RPC envelope keys (`protocol/envelope-keys`),
+  - the finite `params` keys (`protocol/params-keys`), and
+  - the bounded top-level **argument-key allowlist**
+    (`protocol/arg-keys`) — the single source of truth for every
+    top-level key a `tool-*` handler reads.
+
+  Each is resolved through `find-keyword` (via
+  `mcp-base.args/safe-keyword`), so a wire string outside the set never
+  mints a fresh keyword. **Keys outside these sets are dropped** at their
+  level — they neither intern nor reach a handler.
+- Genuinely data-bearing nested maps keep string keys at ingress and are
+  routed through each surface's own **bounded** keyword policy:
+  - `:cell-overrides` KEYS are resolved through `safe-keyword` against
+    the variant's declared arg-key set (`read-run-opts`) — a finite,
+    registry-derived allowlist; an override key outside it is dropped.
+  - the object-form `register-variant` `:body` is keywordised by
+    `coerce-body` only **behind the `--allow-writes` operator gate** and
+    only **after** the rf2-g9fje depth cap, so the intern is bounded by
+    both an operator gate and a depth ceiling (the `fresh-keyword`
+    policy). The EDN-string body path is unchanged (the hardened
+    `clojure.edn` reader yields keyword data directly).
+
+This closes the input-side vector. The output-side egress scrubbing
+(rf2-12f2q) is a separate concern documented with the result envelope.
+
 ## Protocol version pin
 
 The MCP protocol revision string is pinned at `2025-06-18` (see

--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -40,6 +40,7 @@
   for the same source of truth (no parallel re-export here)."
   (:require [cheshire.core :as json]
             [clojure.string :as str]
+            [re-frame.mcp-base.args :as args]
             [re-frame.mcp-base.vocab :as vocab]))
 
 ;; ---- sentinels -----------------------------------------------------------
@@ -91,8 +92,9 @@
 
 (defn notification?
   "Per JSON-RPC 2.0 §4.1, a notification is a request without an `id`.
-  Notifications get no response. Assumes keys have been keywordised
-  (parse-json does this). This predicate is the single home for the
+  Notifications get no response. Assumes the envelope keys have been
+  keywordised (`normalize-frame` does this — `read-frame` runs it after
+  `parse-json`). This predicate is the single home for the
   request-vs-notification rule — `server/dispatch` calls it rather than
   re-spelling the `(not (contains? message :id))` check inline
   (rf2-ee38b.17)."
@@ -113,20 +115,35 @@
 ;; ---- JSON I/O ------------------------------------------------------------
 
 (defn parse-json
-  "Parse a JSON string into a Clojure map. Returns the parsed value, or
-  throws `ex-info` with `:rf.error/id :rf.error/story-mcp-json-parse-failure`
-  on a malformed payload (the run-loop catches it and writes a `-32700`
-  parse-error response).
+  "Parse a JSON string into a Clojure map with STRING keys (no recursive
+  keywordisation). Returns the parsed value, or throws `ex-info` with
+  `:rf.error/id :rf.error/story-mcp-json-parse-failure` on a malformed
+  payload (the run-loop catches it and writes a `-32700` parse-error
+  response).
 
-  Keys are converted to keywords for ergonomic dispatch — this matches
-  what the rest of the namespace expects (`(:method m)`, `(:jsonrpc m)`,
-  `(:id m)`). String keys inside `params` are NOT converted: tool
-  argument maps are typically keyword-keyed at the tools layer, but
-  user-supplied JSON-keys may be arbitrary strings; the tool dispatcher
-  re-keywordises the top level when it parses arguments."
+  ## No-intern ingress (rf2-3luf3)
+
+  Cheshire's `keywordize-keys` mode (`json/parse-string s true`)
+  recursively interns EVERY object key — including arbitrary attacker-/
+  AI-supplied nested keys under `params.arguments`, `cell-overrides`,
+  write bodies, or any extra args — into the JVM's never-shrinking
+  keyword table, BEFORE any bounded allowlist (`tools.args/safe-keyword`)
+  runs. That both grows the keyword table without bound (a slow-burn DoS
+  mirroring the `:rf.http/max-decoded-keys` threat — see
+  `spec/014-HTTPRequests.md` §Keyword-interning cap) and lets an unknown
+  string key intern into a keyword that a downstream `find-keyword`-based
+  allowlist would then resolve.
+
+  This fn therefore parses with STRING keys. The finite JSON-RPC
+  envelope keys and the known tool-argument keys are converted to
+  keywords downstream by `normalize-frame` (no-intern: unknown keys are
+  dropped, never interned). Genuinely data-bearing nested maps
+  (`:cell-overrides`, the object-form `:body`) stay string-keyed and are
+  routed to the tool layer, which applies its own bounded keyword policy
+  where a value-bearing keyword is required."
   [^String s]
   (try
-    (json/parse-string s true)
+    (json/parse-string s false)
     (catch Throwable e
       (throw (ex-info ":rf.error/story-mcp-json-parse-failure"
                       {:rf.error/id :rf.error/story-mcp-json-parse-failure
@@ -135,6 +152,108 @@
                        :reason   "re-frame2-story-mcp: JSON parse failure"
                        :raw      (when s (subs s 0 (min 200 (count s))))}
                       e)))))
+
+;; ---- no-intern frame normalisation (rf2-3luf3) ---------------------------
+
+(def envelope-keys
+  "The finite JSON-RPC 2.0 / MCP envelope keys `normalize-frame`
+  keywordises at the top level of a frame. Every one is a literal
+  keyword interned at compile time, so resolving the wire string to it
+  via `find-keyword` never mints a fresh keyword. Any other top-level
+  key (a stray field a hostile producer slips into the envelope) is
+  DROPPED — it never interns and the dispatcher never sees it.
+
+  `:result` / `:error` are response-envelope keys: the server only ever
+  *reads* request / notification frames (which carry `:method` +
+  `:params`, never `:result` / `:error`), so they cannot appear on a
+  real inbound frame. They are listed here purely so `normalize-frame`
+  is a faithful round-trip for ANY JSON-RPC envelope — tests write a
+  response then read it back through `read-frame`. Both are compile-time
+  interned, so admitting them carries no intern risk."
+  #{:jsonrpc :id :method :params :result :error})
+
+(def params-keys
+  "The finite `params` keys for the MCP methods we dispatch on. `:name`
+  + `:arguments` are the `tools/call` shape; `initialize` /
+  `notifications/initialized` carry `:protocolVersion` /
+  `:capabilities` / `:clientInfo` which we never read (`handle-initialize`
+  ignores its `_params`), so we keywordise only the slots a handler
+  actually consults. As with `envelope-keys`, each is compile-time
+  interned — resolving to it never mints a fresh keyword."
+  #{:name :arguments})
+
+(def arg-keys
+  "Bounded allowlist of the TOP-LEVEL `tools/call` argument keys any
+  registered handler reads. `normalize-frame` keywordises only these
+  (via `find-keyword` — no intern of anything outside the set); any
+  other agent-supplied argument key is DROPPED before it reaches a
+  handler, so an attacker can neither intern a fresh keyword nor smuggle
+  an unrecognised key into the arguments map.
+
+  This is the single source of truth for the read-side argument
+  vocabulary; it MUST list every key a `tool-*` handler pulls off its
+  `arguments` map. The values these keys point at (variant ids, mode
+  strings, EDN bodies, cell-override maps) are NOT walked here — they
+  ride through to the tool layer as-is (string-keyed where they are
+  JSON objects), where each is routed through its own bounded keyword
+  policy (`safe-keyword` against a live registry, the hardened EDN
+  `read-edn-body`, etc.). Per `spec/001-Wire-Protocol.md` +
+  `tools/mcp-base/spec/args.md` §Keyword-interning safety."
+  #{:variant-id :story-id :new-variant-id :extends           ; ids
+    :substrate :active-modes :cell-overrides :base-url        ; run opts
+    :body :doc :alias                                         ; write payload slots
+    :tags :kind :limit :cursor                                ; filters / pagination
+    :write-back :duration-ms :timeout-ms                      ; behaviour knobs
+    :include-sensitive :max-tokens :dedup})                   ; egress / budget knobs
+
+(defn- rename-allowed-keys
+  "Return `m` (a possibly-string-keyed map) with every key that the
+  bounded `allowed` keyword-set recognises converted to its keyword
+  form, and every other key DROPPED. No-intern: a string key is
+  resolved via `args/safe-keyword` against `allowed`, which routes
+  through `find-keyword` on the JVM and never mints a fresh keyword for
+  an unrecognised input. Non-map input passes through untouched."
+  [m allowed]
+  (if (map? m)
+    (persistent!
+     (reduce-kv
+      (fn [acc k v]
+        (if-let [kw (args/safe-keyword k allowed)]
+          (assoc! acc kw v)
+          acc))
+      (transient {})
+      m))
+    m))
+
+(defn normalize-frame
+  "Normalise a string-keyed parsed JSON frame into the keyword-keyed
+  shape the dispatcher + tool layer expect, WITHOUT interning any
+  attacker-controlled key (rf2-3luf3).
+
+  Only the finite JSON-RPC envelope keys (`envelope-keys`), the finite
+  `params` keys (`params-keys`), and the bounded top-level
+  argument-key allowlist (`arg-keys`) are converted to keywords — each
+  resolved through `find-keyword` (via `args/safe-keyword`) so an
+  unrecognised wire string never mints a fresh JVM keyword. Keys outside
+  these sets are dropped at their level; they neither intern nor reach a
+  handler. Nested data-bearing VALUES (a `:cell-overrides` map, an
+  object-form `:body`) are passed through verbatim — string-keyed —
+  for the tool layer to apply its own bounded keyword policy.
+
+  Non-map input (a bare JSON scalar / array on the wire) passes through
+  untouched; the dispatcher's `valid-envelope?` check then rejects it."
+  [parsed]
+  (if-not (map? parsed)
+    parsed
+    (let [envelope (rename-allowed-keys parsed envelope-keys)]
+      (cond-> envelope
+        (map? (:params envelope))
+        (update :params
+                (fn [params]
+                  (let [p (rename-allowed-keys params params-keys)]
+                    (cond-> p
+                      (map? (:arguments p))
+                      (update :arguments rename-allowed-keys arg-keys)))))))))
 
 (defn write-json
   "Serialise `message` to JSON. Returns the string (no trailing newline —
@@ -213,7 +332,7 @@
                                                 :reason    "re-frame2-story-mcp: frame exceeds cap"
                                                 :max-bytes max-frame-bytes}))
         (str/blank? line)             (recur)
-        :else                         (parse-json line)))))
+        :else                         (normalize-frame (parse-json line))))))
 
 (defn write-frame!
   "Write one newline-delimited JSON frame to `^java.io.Writer writer`,

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
@@ -97,16 +97,52 @@
   []
   (story/ids :variant))
 
+(defn- cell-override-key-set
+  "Bounded allowlist for `:cell-overrides` KEYS: the keys of the
+  variant's resolved effective-args map (`story/resolve-args`, no
+  overrides). Cell-overrides exist to override an arg the variant
+  already declares, so the legitimate key universe is exactly that
+  variant's declared arg keys — a finite, registry-derived set. Used by
+  `read-run-opts` to route each caller-supplied override key through
+  `args/safe-keyword` (no JVM intern outside the set; rf2-3luf3).
+  Returns `#{}` for an unresolvable variant — every override key then
+  rejects, which is the honest answer (nothing to override)."
+  [vk]
+  (set (keys (story/resolve-args vk))))
+
+(defn- safe-cell-overrides
+  "Coerce a caller-supplied `:cell-overrides` map (string-keyed off the
+  JSON wire after the rf2-3luf3 no-intern ingress, or keyword-keyed from
+  a direct-invoke caller) into a keyword-keyed override map, routing
+  every KEY through `args/safe-keyword` against `allowed` — the
+  variant's declared arg-key set. A key outside the set is DROPPED (no
+  intern), so an attacker cannot mint fresh keywords by streaming unique
+  override keys, and a typo'd override simply doesn't apply rather than
+  poisoning the keyword table. Values pass through verbatim — they are
+  data, not identifiers. Non-map input yields `nil` (no overrides)."
+  [overrides allowed]
+  (when (map? overrides)
+    (persistent!
+     (reduce-kv
+      (fn [acc k v]
+        (if-let [kw (args/safe-keyword k allowed)]
+          (assoc! acc kw v)
+          acc))
+      (transient {})
+      overrides))))
+
 (defn read-run-opts
   "Build the `re-frame.story/run-variant` opts map from the standard MCP
-  arg slots (`:substrate`, `:active-modes`, `:cell-overrides`). Each
-  slot lands only when present, so the resulting map is the minimal
-  shape `run-variant` / `snapshot-identity` / `variant-share-url`
-  expect.
+  arg slots (`:substrate`, `:active-modes`, `:cell-overrides`) for the
+  resolved variant `vk`. Each slot lands only when present, so the
+  resulting map is the minimal shape `run-variant` / `snapshot-identity`
+  / `variant-share-url` expect.
 
   Shared by `tool-preview-variant`, `tool-run-variant`, and
   `tool-snapshot-identity` (the latter omits `:cell-overrides`, but
-  the absent-slot-not-present rule keeps the helper general).
+  the absent-slot-not-present rule keeps the helper general). All three
+  call sites resolve `vk` via `with-variant` / `with-variant-id` before
+  calling this, so the variant is always known here.
 
   rf2-lqjbk: `:substrate` and each entry in `:active-modes` are
   coerced through `args/safe-keyword` against the live registry's
@@ -114,8 +150,16 @@
   `run-variant`'s opts contract already tolerates as 'no override')
   rather than as a freshly-interned keyword. The substrates set is
   CLJS-only (the JVM-standalone deploy reads `nil`); the modes set
-  is the registered-mode id set."
-  [arguments]
+  is the registered-mode id set.
+
+  rf2-3luf3: `:cell-overrides` arrives string-keyed off the JSON wire
+  (the no-intern ingress no longer keywordises nested arg keys). Its
+  KEYS are routed through `args/safe-keyword` against the variant's
+  declared arg-key set (`cell-override-key-set`) — a bounded, registry-
+  derived allowlist — so an override key outside that set is dropped
+  rather than interned. This is the read-side counterpart to the
+  operator-gated write-body keywordisation in `tools.write`."
+  [vk arguments]
   (let [substrate-set (cljs-resolve/registered-substrates-set)
         mode-set      (story/list-modes)]
     (cond-> {}
@@ -128,7 +172,9 @@
                    (keep #(args/safe-keyword % mode-set))
                    (:active-modes arguments)))
 
-      (some? (:cell-overrides arguments)) (assoc :cell-overrides (:cell-overrides arguments)))))
+      (some? (:cell-overrides arguments))
+      (assoc :cell-overrides (safe-cell-overrides (:cell-overrides arguments)
+                                                  (cell-override-key-set vk))))))
 
 (defn with-variant
   "Resolve `:variant-id` from `arguments` (required), resolve it against

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -113,7 +113,7 @@
   [arguments]
   (targs/with-variant arguments
     (fn [vk _body]
-      (let [opts       (targs/read-run-opts arguments)
+      (let [opts       (targs/read-run-opts vk arguments)
             base-url   (or (:base-url arguments) "")
             share-url  (story/variant-share-url vk base-url opts)
             outcome    (try

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -116,7 +116,7 @@
   [arguments]
   (targs/with-variant arguments
     (fn [vk _body]
-      (let [opts     (targs/read-run-opts arguments)
+      (let [opts     (targs/read-run-opts vk arguments)
             timeout  (min max-timeout-ms
                           (args/parse-positive-int (:timeout-ms arguments) default-timeout-ms))
             outcome  (try
@@ -188,7 +188,7 @@
   [arguments]
   (targs/with-variant arguments
     (fn [vk _body]
-      (result/edn-result (story/snapshot-identity vk (targs/read-run-opts arguments))))))
+      (result/edn-result (story/snapshot-identity vk (targs/read-run-opts vk arguments))))))
 
 ;; `re-frame.story.ui.a11y/violations-by-frame` is the CLJS-side panel
 ;; atom — resolved once at ns-load via `cljs-resolve/resolve-cljs-var`. JVM-

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -136,17 +136,71 @@
             parsed))))
     (catch Throwable _ ::edn-error)))
 
+(defn- keywordize-body-keys
+  "Recursively convert the STRING keys of an object-form `:body` (and
+  its nested maps) into keywords, INTERNING as it goes. This is the
+  operator-gated write-path counterpart to the rf2-3luf3 no-intern
+  ingress: `protocol/parse-json` now parses the whole frame with string
+  keys, so the JSON object-form body arrives string-keyed. The
+  registrar's variant schema demands keyword slots (`:doc` / `:args` /
+  `:tags` / …), so this path re-keywordises the body — but the intern is
+  BOUNDED:
+
+    - the handler reaches here only after the `--allow-writes`
+      operator gate (`assert-writes-allowed`), and
+    - the body was already depth-capped at `max-edn-depth` by the
+      caller (`coerce-body` runs `value-depth` before this), and
+      size-capped on the EDN-string arm,
+
+  so a hostile caller cannot mint unbounded keywords through it. Mirrors
+  the `fresh-keyword` policy (`tools/mcp-base/spec/args.md` §Keyword-
+  interning safety): interning is permitted only behind a gate that
+  bounds the allocation cost. Non-string keys (already-keyword keys from
+  the direct-invoke test path) pass through unchanged; non-collection
+  values are returned as-is."
+  [v]
+  (cond
+    (map? v)
+    (persistent!
+     (reduce-kv
+      (fn [acc k val]
+        (let [k' (cond-> k (string? k) keyword)]
+          (assoc! acc k' (keywordize-body-keys val))))
+      (transient {})
+      v))
+
+    (vector? v) (mapv keywordize-body-keys v)
+    (set? v)    (into #{} (map keywordize-body-keys) v)
+    (seq? v)    (map keywordize-body-keys v)
+    :else       v))
+
 (defn- coerce-body
-  "Normalise the `:body` arg to a Clojure map, or return one of two
-  sentinel keywords on parse / shape failure:
+  "Normalise the `:body` arg to a keyword-keyed Clojure map, or return
+  one of two sentinel keywords on parse / shape failure:
 
     `::edn-error` — `:body` was a string but `read-edn-body` threw or
                     the parsed value violated the size / depth /
                     tagged-literal hardening (rf2-g9fje).
-    `::not-a-map` — `:body` parsed (or was passed) but is not a map."
+    `::not-a-map` — `:body` parsed (or was passed) but is not a map.
+
+  Two input arms:
+
+    - **Object-form body** (a JSON object) arrives STRING-keyed from
+      `protocol/parse-json` (rf2-3luf3 no-intern ingress). Its depth is
+      checked against `max-edn-depth`, then its keys are recursively
+      keywordised via `keywordize-body-keys` — a bounded intern gated by
+      `--allow-writes` (the handler reached this fn only past the
+      write gate). A direct-invoke caller passing an already keyword-
+      keyed map is a no-op on the keys (`keywordize-body-keys` leaves
+      keyword keys alone).
+    - **EDN-string body** is parsed by the hardened `read-edn-body`
+      (no custom readers, tagged-literal reject, size/depth caps),
+      which yields keyword-keyed data directly."
   [body]
   (cond
-    (map? body)    body
+    (map? body)    (if (> (value-depth body) max-edn-depth)
+                     ::edn-error
+                     (keywordize-body-keys body))
     (string? body) (let [v (read-edn-body body)]
                      (cond
                        (= v ::edn-error) ::edn-error

--- a/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
@@ -13,6 +13,7 @@
   Story's registrar — the dispatcher and tool implementations are
   separate (tools_test.clj covers those)."
   (:require [cheshire.core :as json]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.mcp-base.vocab :as vocab]
             [re-frame.story-mcp.protocol :as proto]))
@@ -65,9 +66,21 @@
 
 ;; ---- JSON parse / encode --------------------------------------------------
 
-(deftest json-parse-keywordises-keys
-  (testing "parsed map has keyword keys"
+(deftest json-parse-keeps-string-keys
+  ;; rf2-3luf3: `parse-json` now parses with STRING keys (no recursive
+  ;; keywordisation). Envelope + known-arg keywordisation happens
+  ;; downstream in `normalize-frame` (exercised via `read-frame`). This
+  ;; closes the attacker-controlled-nested-key intern surface.
+  (testing "parsed map has STRING keys (no recursive keywordise)"
     (let [m (proto/parse-json "{\"method\":\"tools/list\",\"id\":1}")]
+      (is (= "tools/list" (get m "method")))
+      (is (= 1 (get m "id")))
+      (is (nil? (:method m)) "no keyword key — parse-json is string-keyed now"))))
+
+(deftest normalize-frame-keywordises-envelope
+  (testing "normalize-frame converts the JSON-RPC envelope keys to keywords"
+    (let [m (proto/normalize-frame (proto/parse-json "{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}"))]
+      (is (= "2.0" (:jsonrpc m)))
       (is (= "tools/list" (:method m)))
       (is (= 1 (:id m))))))
 
@@ -120,6 +133,22 @@
         (catch clojure.lang.ExceptionInfo e
           (is (= :rf.error/story-mcp-json-parse-failure (:rf.error/id (ex-data e)))))))))
 
+;; NB (rf2-3luf3): `read-frame` is the INBOUND-frame reader — it
+;; normalises a request/notification frame and deliberately keywordises
+;; ONLY the envelope + the bounded arg-key allowlist (nested `:result`
+;; payload keys are NOT walked, since the server never reads its own
+;; responses). These write-frame tests therefore deserialise the written
+;; RESPONSE with a plain keywordising `json/parse-string` — that is the
+;; correct way to read back the server's own output, and it keeps the
+;; tests focused on `write-frame!`'s contract (newline + no embedded
+;; newlines + faithful serialisation).
+(defn- parse-line
+  "Read back one written JSON line as a fully-keywordised Clojure map —
+  the appropriate deserialiser for the server's OWN response output (not
+  the no-intern ingress reader)."
+  [^String s]
+  (json/parse-string (str/trim s) true))
+
 (deftest write-frame-roundtrips
   (testing "write-frame appends a newline; round-trip via reader"
     (let [sw (java.io.StringWriter.)
@@ -128,19 +157,19 @@
       (is (.endsWith out "\n"))
       (is (not (.contains (subs out 0 (dec (count out))) "\n"))
           "no embedded newlines per MCP stdio transport rules")
-      (let [r (reader-of out)]
-        (is (= {:jsonrpc "2.0" :id 1 :result {:ok true}}
-               (proto/read-frame r)))))))
+      (is (= {:jsonrpc "2.0" :id 1 :result {:ok true}}
+             (parse-line out))))))
 
 (deftest write-frame-multiple-frames-on-one-stream
   (testing "two frames produce two readable lines"
     (let [sw (java.io.StringWriter.)]
       (proto/write-frame! sw {:jsonrpc "2.0" :id 1 :result {}})
       (proto/write-frame! sw {:jsonrpc "2.0" :id 2 :result {:n 7}})
-      (let [r (reader-of (.toString sw))]
-        (is (= {:jsonrpc "2.0" :id 1 :result {}}     (proto/read-frame r)))
-        (is (= {:jsonrpc "2.0" :id 2 :result {:n 7}} (proto/read-frame r)))
-        (is (= proto/eof-sentinel                    (proto/read-frame r)))))))
+      (let [lines (->> (str/split-lines (.toString sw))
+                       (filter seq))]
+        (is (= 2 (count lines)) "two newline-delimited frames")
+        (is (= {:jsonrpc "2.0" :id 1 :result {}}     (parse-line (nth lines 0))))
+        (is (= {:jsonrpc "2.0" :id 2 :result {:n 7}} (parse-line (nth lines 1))))))))
 
 ;; ---- error-helpers --------------------------------------------------------
 

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -21,6 +21,7 @@
             [re-frame.story-mcp.config :as config]
             [re-frame.story-mcp.protocol :as proto]
             [re-frame.story-mcp.server :as server]
+            [re-frame.story-mcp.tools.args :as targs]
             [re-frame.story-mcp.tools.wire-pipeline :as wire-pipeline]
             [re-frame.story-mcp.tools.dev :as dev]
             [re-frame.story-mcp.tools.egress :as egress]
@@ -3287,6 +3288,188 @@
         (is (= vocab/code-parse-error (-> (nth frames 0) :error :code))
             "oversize frame routes through the parse-error response shape")
         (is (= 11 (:id (nth frames 1))) "the loop continued to the next frame")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-3luf3 — MCP JSON ingress must NOT intern attacker-controlled nested
+;; keys before the bounded allowlists run.
+;;
+;; The pre-fix `protocol/parse-json` called `(json/parse-string s true)`,
+;; recursively keywordising EVERY object key in the frame — including
+;; arbitrary keys under `params.arguments`, `cell-overrides`, and write
+;; bodies — and interning them into the never-shrinking JVM keyword table
+;; BEFORE `tools.args/safe-keyword` could reject them. That both grows the
+;; keyword table without bound (a slow-burn DoS) and can let an unknown
+;; string key intern into a keyword a downstream allowlist then resolves.
+;;
+;; The fix parses the frame string-keyed and keywordises ONLY the finite
+;; JSON-RPC envelope keys + the bounded top-level argument-key allowlist
+;; (no-intern via `find-keyword`); nested data-bearing maps keep string
+;; keys and are routed through each surface's own bounded keyword policy.
+;;
+;; These tests drive the FULL stdio path (`server/run-loop!` /
+;; `proto/read-frame` over a real JSON frame) — the gap the existing
+;; direct-`invoke` no-intern tests (rf2-lqjbk) leave open, since those
+;; bypass `parse-json` / `read-frame`.
+;; ---------------------------------------------------------------------------
+
+(defn- run-frames!
+  "Drive `server/run-loop!` over `in-text` (one JSON frame per line) and
+  return the parsed response frames (keywordised for assertion
+  ergonomics). stderr is captured so the test output stays clean."
+  [in-text]
+  (let [reader (java.io.BufferedReader. (java.io.StringReader. in-text))
+        sw     (java.io.StringWriter.)
+        err    (java.io.StringWriter.)]
+    (binding [*err* err]
+      (server/run-loop! reader sw))
+    (->> (clojure.string/split-lines (.toString sw))
+         (filter seq)
+         (mapv #(cheshire.core/parse-string % true)))))
+
+(deftest ingress-does-not-intern-unknown-nested-arguments-key
+  (testing "a fresh unknown nested :arguments key is NOT interned over the wire (rf2-3luf3)"
+    (let [probe-name (str "rf2-3luf3-nested-probe-" (System/nanoTime))
+          ;; The attacker slips an unknown key into the arguments map of a
+          ;; tools/call. Pre-fix, parse-json interned it immediately.
+          frame      (str "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                          "\"params\":{\"name\":\"get-variant\","
+                          "\"arguments\":{\"" probe-name "\":1,"
+                          "\"variant-id\":\"story.button/primary\"}}}\n")]
+      (is (nil? (find-keyword probe-name))
+          "precondition: the probe keyword has not been interned yet")
+      (let [frames (run-frames! frame)]
+        (is (= 1 (count frames)) "one tools/call response")
+        (is (= 1 (:id (first frames))) "the legitimate call still dispatched"))
+      (is (nil? (find-keyword probe-name))
+          "rf2-3luf3: the attacker-supplied nested arguments key MUST NOT have been interned"))))
+
+(deftest ingress-does-not-intern-unknown-envelope-key
+  (testing "a stray unknown top-level envelope key is NOT interned over the wire (rf2-3luf3)"
+    (let [probe-name (str "rf2-3luf3-envelope-probe-" (System/nanoTime))
+          frame      (str "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"ping\",\"" probe-name "\":99}\n")]
+      (is (nil? (find-keyword probe-name)) "precondition")
+      (run-frames! frame)
+      (is (nil? (find-keyword probe-name))
+          "rf2-3luf3: a stray envelope key MUST NOT intern"))))
+
+(deftest ingress-does-not-intern-cell-overrides-key
+  (testing "an unknown :cell-overrides KEY is NOT interned over the wire (rf2-3luf3)"
+    (let [probe-name (str "rf2-3luf3-cell-probe-" (System/nanoTime))
+          frame      (str "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\","
+                          "\"params\":{\"name\":\"preview-variant\","
+                          "\"arguments\":{\"variant-id\":\"story.button/primary\","
+                          "\"cell-overrides\":{\"" probe-name "\":\"x\"}}}}\n")]
+      (is (nil? (find-keyword probe-name)) "precondition")
+      (run-frames! frame)
+      (is (nil? (find-keyword probe-name))
+          "rf2-3luf3: an unknown cell-override key (outside the variant's declared args) MUST NOT intern"))))
+
+(deftest read-run-opts-keeps-known-cell-override-key-drops-unknown
+  (testing "a declared arg key is kept (keywordised) and an unknown one dropped (rf2-3luf3)"
+    ;; story.button/primary declares :args {:label "Save"} — so :label is
+    ;; in its bounded arg-key set; a random key is not. Simulate the
+    ;; post-parse-json string-keyed cell-overrides shape.
+    (let [probe (str "rf2-3luf3-co-" (System/nanoTime))
+          opts  (targs/read-run-opts :story.button/primary
+                                     {:cell-overrides {"label" "Override"
+                                                       probe   "x"}})
+          co    (:cell-overrides opts)]
+      (is (= "Override" (:label co)) "the declared :label override keywordised + kept")
+      (is (= #{:label} (set (keys co))) "the unknown override key was dropped")
+      (is (nil? (find-keyword probe)) "and never interned"))))
+
+(deftest ingress-unknown-variant-id-over-wire-does-not-intern
+  (testing "an unknown :variant-id sent over JSON is rejected WITHOUT interning (rf2-3luf3)"
+    ;; This is the wire-level peer of the rf2-lqjbk direct-invoke test —
+    ;; it proves the allowlist still gates correctly once parse-json no
+    ;; longer pre-interns the value.
+    (let [ns-str   "story.rf2-3luf3-wire"
+          name-str (str "unknown-" (System/nanoTime))
+          frame    (str "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\","
+                        "\"params\":{\"name\":\"get-variant\","
+                        "\"arguments\":{\"variant-id\":\"" ns-str "/" name-str "\"}}}\n")]
+      (is (nil? (find-keyword ns-str name-str)) "precondition")
+      (let [frames (run-frames! frame)
+            result (-> frames first :result)]
+        (is (true? (:isError result)) "unknown variant id errors as a tool result")
+        (is (re-find #"(?i)variant not found" (-> result :content first :text))))
+      (is (nil? (find-keyword ns-str name-str))
+          "rf2-3luf3: the unknown variant id MUST NOT have been interned over the wire"))))
+
+(deftest ingress-legitimate-wire-keys-still-dispatch
+  (testing "known JSON wire arg keys still normalise + dispatch correctly (rf2-3luf3)"
+    ;; variant-id + max-tokens + include-sensitive are read by get-variant /
+    ;; the wire-pipeline; all must survive the no-intern normalisation.
+    (let [frame  (str "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\","
+                      "\"params\":{\"name\":\"get-variant\","
+                      "\"arguments\":{\"variant-id\":\"story.button/primary\","
+                      "\"max-tokens\":4000,\"include-sensitive\":false}}}\n")
+          frames (run-frames! frame)
+          result (-> frames first :result)]
+      (is (= 5 (:id (first frames))))
+      (is (not (true? (:isError result))) "the legitimate call succeeds")
+      ;; get-variant's structuredContent carries the resolved variant under
+      ;; `:id`; over JSON the keyword serialises to a bare string. Its
+      ;; presence proves `variant-id` keywordised + resolved through the
+      ;; allowlist (an unresolved id would have produced an :isError result).
+      (is (= "story.button/primary" (-> result :structuredContent :id))
+          "the variant-id arg keywordised + resolved through the allowlist")
+      (is (= "Primary button." (-> result :structuredContent :body :doc))
+          "the variant body came back, confirming a real dispatch"))))
+
+(deftest register-variant-object-body-over-wire-keywordises-under-gate
+  (testing "an object-form :body sent as JSON registers with keyword slots (rf2-3luf3 write-path)"
+    ;; Post no-intern ingress the object-form body arrives string-keyed;
+    ;; `coerce-body` re-keywordises it under the (operator-gated) write
+    ;; path. This proves the spec's documented "object body (preferred)"
+    ;; form keeps working over the real wire — its keys become keywords.
+    (config/set-allow-writes! true)
+    (let [r (invoke "register-variant"
+                    {:variant-id "story.button/wire-obj"
+                     ;; Simulate the post-parse-json wire shape: a
+                     ;; STRING-keyed object body.
+                     :body {"doc"  "Object body over wire."
+                            "args" {"label" "OK"}}})]
+      (is (success? r) "object-form body registers under the write gate")
+      (let [edn (story/variant->edn :story.button/wire-obj)]
+        (is (= "Object body over wire." (:doc edn))
+            "the body's top-level string keys were keywordised")
+        (is (= "OK" (-> edn :args :label))
+            "nested object-body keys were keywordised recursively")))))
+
+(deftest register-variant-object-body-rejects-overdeep
+  (testing "an object-form :body past the depth cap is rejected, not interned (rf2-3luf3 / rf2-g9fje)"
+    (config/set-allow-writes! true)
+    ;; Build a string-keyed map nested far past max-edn-depth (64). The
+    ;; depth check in coerce-body must reject it BEFORE keywordize-body-keys
+    ;; walks (and interns) any of the pathological keys.
+    (let [probe (str "rf2-3luf3-deep-" (System/nanoTime))
+          deep  (reduce (fn [acc i] {(str probe "-" i) acc})
+                        {(str probe "-leaf") 1}
+                        (range 70))
+          r     (invoke "register-variant"
+                        {:variant-id "story.button/wire-deep" :body deep})]
+      (is (error? r) "an over-deep object body is rejected")
+      (is (nil? (find-keyword (str probe "-leaf")))
+          "rf2-3luf3: a rejected over-deep body MUST NOT have interned its keys"))))
+
+(deftest normalize-frame-drops-unknown-arg-keys-but-keeps-known
+  (testing "normalize-frame keeps allowlisted arg keys (keyword) and drops the rest (rf2-3luf3)"
+    (let [probe   (str "rf2-3luf3-drop-" (System/nanoTime))
+          parsed  (proto/parse-json
+                   (str "{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\","
+                        "\"params\":{\"name\":\"run-variant\","
+                        "\"arguments\":{\"variant-id\":\"story.button/primary\","
+                        "\"" probe "\":1,\"substrate\":\"reagent\"}}}"))
+          norm    (proto/normalize-frame parsed)
+          arg-map (-> norm :params :arguments)]
+      (is (= "story.button/primary" (:variant-id arg-map)) "known key keywordised + kept")
+      (is (= "reagent" (:substrate arg-map)) "known key keywordised + kept")
+      (is (= #{:variant-id :substrate} (set (keys arg-map)))
+          "ONLY the two allowlisted keys survive; the unknown key is dropped at both string + keyword form")
+      ;; NB: do not call `(keyword probe)` here — that would itself intern
+      ;; the probe and defeat the assertion below.
+      (is (nil? (find-keyword probe)) "and the unknown key never interned"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cap accounting includes :structuredContent size (rf2-mzndx)


### PR DESCRIPTION
## Summary

Closes the **input-side** keyword-interning vulnerability in `tools/story-mcp` (bead **rf2-3luf3**, P1). The MCP boundary parses untrusted AI-supplied wire args; pre-fix it interned attacker-controlled nested keys **before** the bounded allowlists ran.

### The bug
`re-frame.story-mcp.protocol/parse-json` called `(json/parse-string s true)`, which recursively keywordizes (and on the JVM, **interns**) *every* object key in the frame — including arbitrary keys under `params.arguments`, `cell-overrides`, or a write `body` — into the never-shrinking JVM keyword table, BEFORE `tools.args/safe-keyword` could reject them. Two consequences:

1. **Slow-burn DoS / keyword-table poisoning** — a hostile or careless agent streaming unique JSON keys permanently burns one keyword slot per unique key (the same threat the framework's `:rf.http/max-decoded-keys` cap defends).
2. **Allowlist bypass** — a string key the allowlist would reject is interned into a keyword that a downstream `find-keyword`-based check then resolves.

**Repro (read-only eval, pre-fix):** parsing `{"params":{"arguments":{"rf2-3luf3-attacker-probe-abc":1,"variant-id":"story.x/y"}}}` with `json/parse-string … true` left `(find-keyword "rf2-3luf3-attacker-probe-abc")` returning the interned keyword. The new regression tests reproduce this over the full stdio path and FAIL against the old `parse-json` (verified by temporarily reverting the one-line parse change: 7 assertions flip to FAIL).

### The fix
Parse frames **string-keyed**, then keywordize ONLY the finite envelope + bounded arg-key allowlist via `find-keyword` (no-intern; unknown keys dropped). Nested data-bearing maps stay string-keyed and route through each surface's own bounded policy:

- `parse-json` → `json/parse-string s false`; `normalize-frame` (run by `read-frame`) keywordizes `envelope-keys` / `params-keys` / `arg-keys` only.
- `:cell-overrides` KEYS → `safe-keyword` against the variant's declared arg-key set (`read-run-opts` now takes `vk`).
- object-form `register-variant` `:body` → keywordized by `coerce-body` only behind the `--allow-writes` gate and after the rf2-g9fje depth cap (bounded intern; the documented `fresh-keyword` policy).

Grounded in `tools/story-mcp/spec/001-Wire-Protocol.md` §No-intern argument ingress (added) + the cross-MCP rule in `tools/mcp-base/spec/args.md`.

### Tests
Regression tests drive the **full stdio path** (`server/run-loop!` / `read-frame`) — the gap the existing direct-`invoke` no-intern tests (rf2-lqjbk) left open since they bypass `parse-json`. They assert `find-keyword` stays `nil` for unknown nested-arguments / envelope / cell-override / over-deep-body keys, while legitimate wire keys (`variant-id`, `max-tokens`, declared `:cell-overrides`, object-form body) still dispatch.

### Gates (all green)
- story-mcp `clojure -M:test` — **228 tests, 1134 assertions, 0 failures**
- story-mcp stdio roundtrip + SDK-driven MCP conformance (`test:story` + `test:flag-gates`) — **GREEN**
- `npm run test:bundle-isolation` — **PASS** (change is JVM-only; no production CLJS touched)

Distinct from **rf2-12f2q** (PR #3113, merged) which scrubbed the **output** side; this is the **input** side.