### PR TITLE
fix(substrate): release all duplicate-source watches + version-independent after-render setter (rf2-he7se)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
@@ -54,6 +54,14 @@
 (deftest after-render-fires-on-native-mount-helix
   (suite/assert-after-render-fires-on-native-mount cfg))
 
+;; rf2-he7se finding 3 — the native after-render driver-root setter is
+;; installed from a LAYOUT effect (flushSync always flushes layout effects
+;; synchronously), so the first native after-render observes the committed
+;; app state synchronously via the post-commit layout-effect drain rather
+;; than the (version-dependent) queueMicrotask fallback.
+(deftest after-render-observes-commit-synchronously-on-native-first-call-helix
+  (suite/assert-after-render-observes-commit-synchronously-on-native-first-call cfg))
+
 ;; rf2-b6nm5 — flush-views! is surfaced from the adapter ns with the
 ;; canonical nil-return shape (Decision 6), converged across all four
 ;; substrates. Node-safe shape pin.

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
@@ -52,6 +52,14 @@
 (deftest after-render-fires-on-native-mount-uix
   (suite/assert-after-render-fires-on-native-mount cfg))
 
+;; rf2-he7se finding 3 — the native after-render driver-root setter is
+;; installed from a LAYOUT effect (flushSync always flushes layout effects
+;; synchronously), so the first native after-render observes the committed
+;; app state synchronously via the post-commit layout-effect drain rather
+;; than the (version-dependent) queueMicrotask fallback.
+(deftest after-render-observes-commit-synchronously-on-native-first-call-uix
+  (suite/assert-after-render-observes-commit-synchronously-on-native-first-call cfg))
+
 ;; rf2-b6nm5 — flush-views! is surfaced from the adapter ns with the
 ;; canonical nil-return shape (Decision 6), converged across all four
 ;; substrates. Node-safe shape pin.

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -302,7 +302,16 @@
           watchers       (atom {})           ;; user-key → wrapper-fn
           on-dispose-fns (atom [])
           ;; Per-source wrapper keys we own so dispose can unwire them.
-          own-keys       (atom {})           ;; source → key
+          ;; A VECTOR of `[source key]` pairs, NOT a `source→key` map
+          ;; (rf2-he7se finding 2): `source-containers` is a vector with
+          ;; no uniqueness precondition (spec/006 §154-170), so the SAME
+          ;; source object may appear more than once. Each occurrence
+          ;; installs its own gensym-keyed watch; a `source→key` map would
+          ;; overwrite earlier keys, so dispose would release only the
+          ;; LAST watch per source and leak the rest. Tracking every
+          ;; `[source key]` pair lets dispose release ALL held inputs
+          ;; (spec/006 §600-613).
+          own-keys       (atom [])           ;; vector of [source key]
           ;; Iterate via `run!` over `vals` rather than `doseq` over
           ;; map-entries — skips one map-entry seq allocation per
           ;; source-change notification.
@@ -362,7 +371,7 @@
       ;; against settled inputs (glitch-free, single notification).
       (doseq [s source-containers]
         (let [k (gensym gensym-prefix)]
-          (swap! own-keys assoc s k)
+          (swap! own-keys conj [s k])
           (add-watch s k (fn [_ _ _ _] (mark-dirty!)))))
       (reify
         IDeref
@@ -390,7 +399,7 @@
         rf-disposable/IDisposable
         (-dispose [_]
           (doseq [[s k] @own-keys] (remove-watch s k))
-          (reset! own-keys {})
+          (reset! own-keys [])
           (reset! watchers {})
           (doseq [f @on-dispose-fns] (f))
           (reset! on-dispose-fns []))
@@ -481,7 +490,7 @@
 ;; first time `after-render` is called with no app-tree sentinel
 ;; present. The hook mounts the sentinel component into a detached
 ;; (never-attached-to-the-document) React root via `createRoot`; the
-;; sentinel's `useEffect` stashes its `set-tick` setter into
+;; sentinel's mount LAYOUT effect stashes its `set-tick` setter into
 ;; `set-tick-ref` exactly as the Fragment-wrap sentinel does, so the
 ;; same `set-tick` → commit → `useLayoutEffect`-drain machinery now
 ;; drives post-commit timing on the native-mount path too. The driver
@@ -539,14 +548,21 @@
 
     1. On mount, stashes its `setState` setter in `set-tick-ref` so
        `:adapter/after-render` can trigger a commit. Cleared on unmount.
+       Installed from a LAYOUT effect (rf2-he7se finding 3) so the
+       singleton-driver-root setup's `flushSync` arms the slot
+       synchronously before it decides setter-present vs. microtask
+       fallback. `flushSync` ALWAYS flushes layout effects synchronously
+       (a documented guarantee); its flushing of PASSIVE `useEffect`s is a
+       React-19 implementation detail, not a contract — so the prior
+       passive install was not robust across React versions/configs.
     2. On every commit, fires `React.useLayoutEffect` to drain
        `queue-cell` — same timing as `r/after-render`'s post-commit
        run.
 
   The sentinel uses raw React hooks (`React/useState`,
-  `React/useEffect`, `React/useLayoutEffect`) rather than the
-  substrate's hook ns so the same impl works for UIx, Helix, and any
-  future React-shaped substrate using this spine.
+  `React/useLayoutEffect`) rather than the substrate's hook ns so the
+  same impl works for UIx, Helix, and any future React-shaped substrate
+  using this spine.
 
   Returned value is the bare function component, suitable for
   `(React/createElement sentinel-cmp nil)`."
@@ -554,7 +570,21 @@
   (fn after-render-sentinel [_props]
     (let [tick+setter (React/useState 0)
           set-tick    (aget tick+setter 1)]
-      (React/useEffect
+      ;; Install the setter from a LAYOUT effect, not a passive useEffect
+      ;; (rf2-he7se finding 3). `ensure-after-render-driver-root!` renders
+      ;; this sentinel inside `react-dom/flushSync` and EXPECTS the setter
+      ;; present in `set-tick-ref` the instant flushSync returns, so it can
+      ;; bump the tick rather than falling through to the microtask drain.
+      ;; `flushSync` ALWAYS flushes layout effects synchronously during the
+      ;; commit; whether it flushes passive (`useEffect`) effects is a
+      ;; React-19 implementation detail, NOT a documented guarantee. Where
+      ;; passives are deferred (older React / future configs) a passive
+      ;; setter-install would leave the slot nil on flushSync's return, so
+      ;; the hook would take the `queueMicrotask` fallback and the queue
+      ;; could drain BEFORE the app commit after-render is meant to
+      ;; observe. A layout mount effect makes the arm-before-decide
+      ;; ordering version-INDEPENDENT.
+      (React/useLayoutEffect
         (fn mount-effect []
           (reset! set-tick-ref set-tick)
           (fn cleanup []
@@ -584,7 +614,7 @@
   "Lazily mount the per-adapter SINGLETON DRIVER ROOT (rf2-t0x90). If
   `driver-root-cell` is empty, create a detached host node + React root,
   render `sentinel-cmp` into it inside `react-dom/flushSync` so the
-  sentinel's mount `useEffect` runs SYNCHRONOUSLY and stashes its
+  sentinel's mount LAYOUT effect runs SYNCHRONOUSLY and stashes its
   `set-tick` setter into `set-tick-ref` before this fn returns. The host
   node is never attached to the document — the sentinel renders nil, so
   no DOM is produced. Idempotent: a populated cell is left untouched.
@@ -594,9 +624,15 @@
     (let [host (.createElement js/document "div")
           root (react-dom-client/createRoot host)]
       (reset! driver-root-cell root)
-      ;; flushSync so the sentinel's mount effect (which stashes
+      ;; flushSync so the sentinel's mount LAYOUT effect (which stashes
       ;; set-tick into set-tick-ref) runs synchronously — the caller
       ;; bumps the tick immediately after, expecting the setter present.
+      ;; flushSync ALWAYS runs layout effects synchronously; passive
+      ;; `useEffect`s are not contractually flushed by it (React-19 detail
+      ;; only), so the layout-effect install keeps the slot armed on return
+      ;; regardless of React version — without it the slot could be nil and
+      ;; force the microtask fallback that drains before the pending app
+      ;; commit (rf2-he7se finding 3).
       (react-dom/flushSync
         (fn [] (.render root (React/createElement sentinel-cmp nil))))))
   nil)

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -1545,6 +1545,61 @@
       (unsub))))
 
 ;; ===========================================================================
+;; derived-value duplicate-source disposal regression (rf2-he7se finding 2)
+;; ===========================================================================
+
+(defn- source-watch-count
+  "Number of live watches currently installed on a state-container source.
+  `make-state-container` returns a plain CLJS atom whose `.-watches` field
+  is the live `key→fn` map, so its `count` is the physical watch tally —
+  the ground truth the leak this regression pins is measured against."
+  [src]
+  (count (.-watches ^cljs.core/Atom src)))
+
+(defn assert-derived-dispose-releases-duplicate-source-watches
+  "rf2-he7se finding 2: `make-derived-value` adds ONE watch per source
+  OCCURRENCE, but the disposal bookkeeping used to be a `source→key` map —
+  so when the SAME source object appeared more than once in
+  `source-containers` (spec/006-ReactiveSubstrate.md:154-170 types it as a
+  vector with NO uniqueness precondition), each occurrence's gensym key
+  overwrote the prior, and dispose (spec/006:600-613 — release ALL held
+  inputs) removed only the LAST watch, leaking the earlier one(s) forever.
+
+  This pins disposal-releases-everything two ways:
+
+    1. PHYSICAL — after `[src src]` derive then dispose, ZERO watches
+       remain on `src` (the leaked-watch ground truth).
+    2. BEHAVIOURAL — a recompute counter in `compute-fn` proves the
+       disposed derived value does NOT recompute when `src` later mutates;
+       a leaked watch would still `mark-dirty!` → flush → recompute."
+  [{:keys [adapter name]}]
+  (testing (str name " — make-derived-value dispose releases ALL duplicate-source watches (rf2-he7se)")
+    (let [src        (mk-source adapter 1)
+          recomputes (atom 0)
+          ;; SAME source object twice — the duplicate the bead names.
+          derived    (mk-derive adapter [src src]
+                                (fn [a b] (swap! recomputes inc) (+ a b)))]
+      (is (zero? @recomputes)
+          "derived is lazy: compute-fn not yet run at construction (rf2-ee38b.1)")
+      ;; Establish the baseline (first deref recomputes once) and confirm
+      ;; BOTH occurrences installed a watch — the duplicate is real, not
+      ;; coalesced away.
+      (is (= 2 @derived) "baseline derived = src + src")
+      (is (= 1 @recomputes) "first deref recomputed exactly once")
+      (is (= 2 (source-watch-count src))
+          "both [src src] occurrences each installed a distinct watch")
+      ;; Dispose. Pre-fix, only the LAST watch was tracked → one watch leaks.
+      (rf-disposable/-dispose derived)
+      (is (zero? (source-watch-count src))
+          "dispose released EVERY watch the duplicate source held — zero remain")
+      ;; Behavioural proof: mutate src; the disposed derived must not recompute.
+      (reset! recomputes 0)
+      (mk-write! adapter src 99)
+      (is (zero? @recomputes)
+          "a disposed derived value does NOT recompute on source change —
+           no leaked watch survived to mark it dirty"))))
+
+;; ===========================================================================
 ;; managed HTTP (Spec 014) — port of `*_http_managed`
 ;;
 ;; The http-managed suite requires the entry-file fixture to call
@@ -2368,6 +2423,88 @@
           (is (= 2 @fired)
               "subsequent after-render also fires via the driver root")
           (finally
+            (try (act-fn (fn [] (.unmount root))) (catch :default _ nil)))))))))
+
+(defn assert-after-render-observes-commit-synchronously-on-native-first-call
+  "rf2-he7se finding 3 — the GUARANTEE: on the FIRST native-mount
+  after-render call (fresh per-adapter driver root — the `:each` reset
+  fixture disposed any prior one), the callback fires SYNCHRONOUSLY inside
+  the `react-dom/flushSync` that `ensure-after-render-driver-root!` runs,
+  and observes the COMMITTED app state — NOT a deferred microtask drain.
+
+  How the fix secures this. The driver-root sentinel installs its
+  `set-tick` setter from a LAYOUT effect (not a passive `useEffect`).
+  `flushSync` ALWAYS flushes layout effects synchronously during the
+  commit, so the setter is armed on flushSync's return and the hook takes
+  the post-commit `set-tick` path rather than the `queueMicrotask`
+  fallback — a version-INDEPENDENT guarantee. (The fallback is itself only
+  reachable with no `document`; with the layout-effect install it is never
+  taken on the native-mount path when a DOM is present.)
+
+  Why layout, not passive (rf2-he7se finding 3). The original install was
+  a PASSIVE `useEffect`. `flushSync` flushing passive effects is a
+  React-19 implementation detail (React ≤18 / future configs do NOT
+  guarantee it), so the setter-availability-after-flushSync assumption the
+  setup path relied on was not robust: where passives are deferred, the
+  slot stays nil on return and the hook falls to `queueMicrotask`, which
+  can drain BEFORE the app commit it must observe. The layout-effect
+  install removes that version dependency entirely.
+
+  The call is made OUTSIDE `act` with `IS_REACT_ACT_ENVIRONMENT` off so
+  the real `flushSync` commit path runs (act's boundary effect-flush does
+  not stand in for it) — per the bead's `outside act/rAF` direction. The
+  native probe is mounted under `act` first so it commits cleanly.
+
+  Assertions (deterministic — no rAF / timer):
+
+    1. SYNCHRONOUS OBSERVATION — the moment the after-render call returns,
+       the callback has already run (the flushSync-driven commit drained
+       the layout effect) and observed the committed app state.
+    2. NO MICROTASK FALLBACK — `queueMicrotask` is not used on this path
+       when a DOM is present; the driver root drives the drain.
+
+  cfg keys:
+    :probe-element  reused native probe ELEMENT thunk."
+  [{:keys [name probe-element]}]
+  (testing (str name " — native first-call after-render observes the commit synchronously (rf2-he7se)")
+    (with-browser-act
+     (fn [act-fn]
+      (let [observed       (atom ::unobserved)
+            app-state      (atom :pre-commit)
+            callback       (fn cb [] (reset! observed @app-state))
+            mount-node     (make-mount-node!)
+            root           (react-dom-client/createRoot mount-node)
+            orig-qm        (when (exists? js/queueMicrotask) js/queueMicrotask)
+            qm-calls       (atom 0)]
+        (try
+          ;; NATIVE mount (raw createRoot + .render) — no app-tree sentinel,
+          ;; so the after-render hook must arm the singleton driver root.
+          (act-fn (fn [] (.render root (probe-element))))
+          ;; Spy on queueMicrotask to detect the (DOM-absent-only) fallback.
+          (when orig-qm
+            (set! js/queueMicrotask
+                  (fn [f] (swap! qm-calls inc) (orig-qm f))))
+          ;; Commit the app state, THEN call after-render — OUTSIDE act,
+          ;; with the act-env flag off so the real `flushSync` commit path
+          ;; inside `ensure-after-render-driver-root!` runs (not act's
+          ;; effect-flush). The layout-effect setter install guarantees the
+          ;; drain runs synchronously here regardless of React version.
+          (reset! app-state :committed)
+          (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+          (try
+            (interop/after-render callback)
+            (finally
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+          (is (= :committed @observed)
+              "the callback fired SYNCHRONOUSLY (the flushSync-driven
+               driver-root commit drained the layout effect) and observed
+               the committed app state — not a deferred pre-commit drain")
+          (is (zero? @qm-calls)
+              "with a DOM present the driver root drove the drain; the
+               queueMicrotask fallback was not taken")
+          (finally
+            (when orig-qm (set! js/queueMicrotask orig-qm))
+            (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
             (try (act-fn (fn [] (.unmount root))) (catch :default _ nil)))))))))
 
 ;; ---- hydrate render branch (rf2-ee38b.1 — closes the React-hook spine

--- a/implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj
@@ -205,6 +205,10 @@
    {:test 'derived-baseline-multi-source
     :fn   'assert-derived-baseline-multi-source}
 
+   {:section "derived-value duplicate-source disposal (rf2-he7se finding 2)"}
+   {:test 'derived-dispose-releases-duplicate-source-watches
+    :fn   'assert-derived-dispose-releases-duplicate-source-watches}
+
    {:section "managed HTTP (Spec 014 / *_http_managed)"}
    {:test 'http-canned-success-default-reply
     :fn   'assert-http-canned-success-default-reply}


### PR DESCRIPTION
Fixes findings 2 and 3 of the adapters correctness review (**rf2-he7se**, P1). Finding 1 was already fixed by #3116 (rf2-879fe) and is verified covered below — not re-fixed.

## Finding 1 — use-subscribe abandoned-render ref-count leak (ALREADY FIXED by #3116)
Verified covered by #3116's drive-to-target ledger in `spine.cljs`. Each render-phase `subs/subscribe` (+1) is recorded in a `useRef` ledger keyed by a stable `frame|query` token. The no-deps reconcile effect runs after every commit and drives **every key other than the current one to target 0** — those "other" keys are exactly the render-phase acquisitions from a render that was abandoned/superseded before commit. So a `subscribe` from an aborted render is released by the next committed render's reconcile pass. No change made here.

## Finding 2 — make-derived-value duplicate-source watch-key loss
`own-keys` tracked per-source watches as a `source→key` map. When `source-containers` held the **same source object more than once** (spec/006:154-170 types it as a vector with no uniqueness precondition), each occurrence's gensym key overwrote the prior, so dispose (spec/006:600-613 — release ALL held inputs) removed only the **last** watch and leaked the earlier ones.

Fix: track every `[source key]` pair in a vector; dispose removes every installed watch.

**Regression** (`react_shared_suite`, runs under node + browser, both UIx + Helix): derive `[src src]`, dispose, assert (1) zero watches remain physically on `src` and (2) the disposed value does not recompute on a later `src` mutation. **Proven to fail against the buggy `source→key` map** — 4 failures (physical + behavioural × UIx + Helix).

## Finding 3 — native after-render setter availability (version-independence hardening)
The driver-root sentinel installed its `set-tick` setter from a **passive `useEffect`**, then `ensure-after-render-driver-root!`'s `flushSync` assumed the slot was armed on return. `flushSync` **always** flushes layout effects synchronously, but its flushing of passive effects is a React-19 implementation detail, **not a contract**. Where passives defer (older React / future configs), the slot is nil on return and the hook falls to the `queueMicrotask` fallback, which can drain **before** the pending app commit after-render is meant to observe.

Fix: install the setter from a **layout effect**, making the arm-before-decide ordering version-independent.

**Note on reproducibility:** On React 19 (this repo) the described failure does **not** manifest — `flushSync` flushes the passive effect synchronously AND the queue is enqueued before the driver-root mount, so the mount-commit's drain layout-effect drains it regardless. This fix removes the reliance on that React-19 detail. The regression asserts the genuine version-independent guarantee (first native-mount call, made **outside `act`** on the real `flushSync` path, observes the committed state synchronously and does not take the microtask fallback) rather than a non-discriminating bug-catcher.

## Gates (cold, both green, 0 warnings)
- `npm run test:cljs` — 5637 tests / 19634 assertions, 0 failures
- `npm run test:browser` (UIx + Helix) — 166 tests / 507 assertions, 0 failures

No `.cljc` touched (only `.cljs` + a `.clj` compile-time macro file). No spec change: both fixes align the implementation with existing spec/006 contracts (release-all-inputs; post-commit after-render timing); the effect-type and watch-bookkeeping are internal spine details.