### PR TITLE
fix(examples/reagent): initialize stock Reagent adapter, not reagent-slim (rf2-2bih3)

### DIFF
--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -17,10 +17,10 @@
    framework-shipped `:rf.http/managed-canned-success` per Spec 014
    §Testing, so the canonical reply shape is preserved."
   (:require [clojure.string :as str]
-            [reagent2.dom.client :as rdc]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Required for `rf/init!`.
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]
             ;; Managed-HTTP ships in day8/re-frame2-http. The require
             ;; triggers its fx registrations (:rf.http/managed and
             ;; family) at app boot; without it, the child loaders'
@@ -138,7 +138,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
 
   ;; Override `:rf.http/managed` on the default frame so every child
   ;; loader's GET routes to the per-URL canned stub above. The

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -43,7 +43,7 @@
    - `:rf.fx/reg-flow` / `:rf.fx/clear-flow`        (Spec 013 §Dynamic toggle via fx)
    - reading a flow's output inside an event handler (Spec 013 §Sub integration (a))
    - reading a flow's output via a plain sub over its `:path`  (Spec 013 §Sub integration (b))"
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Flows ship in day8/re-frame2-flows. Requiring re-frame.flows
             ;; here is what publishes the artefact's late-bind hooks
@@ -53,7 +53,7 @@
             ;; convention the schemas / machines / routing examples use.)
             [re-frame.flows]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -291,7 +291,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:cart/initialise])
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -45,15 +45,16 @@
      machines.cljs | events_test.cljs
 
    Kept as a single file here for brevity."
-  ;; Substrate note: this example stays on STOCK Reagent
-  ;; (`reagent.dom.client` + the `re-frame.adapter.reagent` adapter) rather
-  ;; than reagent-slim. login is the canonical cross-substrate base — it is
-  ;; mirrored 1:1 as `login-uix` and `login-helix` (Spec 006 §Adapter
-  ;; shipping convention Decision 7), so keeping it on the reference
-  ;; substrate makes the three substrate variants a clean apples-to-apples
-  ;; comparison. (`counter` / `counter_slim_and_fast` are the dedicated
-  ;; stock-vs-slim contrast pair; the rest of the catalogue defaults to
-  ;; slim.)
+  ;; Substrate note: this example runs on STOCK Reagent
+  ;; (`reagent.dom.client` + the `re-frame.adapter.reagent` adapter), like
+  ;; the rest of the `examples/reagent/` catalogue. login is the canonical
+  ;; cross-substrate base — it is mirrored 1:1 as `login-uix` and
+  ;; `login-helix` (Spec 006 §Adapter shipping convention Decision 7), so
+  ;; keeping it on the reference substrate makes the three substrate
+  ;; variants a clean apples-to-apples comparison. (`counter` /
+  ;; `counter_slim_and_fast` are the dedicated stock-vs-slim contrast pair;
+  ;; the slim build is the only one that mounts `reagent-slim`, and it
+  ;; lives under `examples/reagent-slim/`.)
   (:require [reagent.dom.client :as rdc]
             [reagent.core :as reagent]
             [re-frame.core :as rf]

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -48,13 +48,13 @@
                                   under implementation/adapters/reagent/test/
                                   re_frame/long_running_work_cljs_test.cljs)"
   ;; Substrate note: STOCK Reagent (`reagent.dom.client` +
-  ;; `re-frame.adapter.reagent`), not reagent-slim. This example's
-  ;; load-bearing teaching point is the `r/with-let` finally-cleanup in
-  ;; views.cljs that fires the `:cancel` cascade on view unmount; it stays
-  ;; on stock Reagent's `reagent.core/with-let` — the substrate that path
-  ;; was validated against — so the cancellation demo isn't entangled with
-  ;; a substrate swap. (Most of the catalogue defaults to slim; counter /
-  ;; counter_slim_and_fast is the dedicated stock-vs-slim contrast pair.)
+  ;; `re-frame.adapter.reagent`), like the rest of the
+  ;; `examples/reagent/` catalogue. This example's load-bearing teaching
+  ;; point is the `r/with-let` finally-cleanup in views.cljs that fires the
+  ;; `:cancel` cascade on view unmount, on stock Reagent's
+  ;; `reagent.core/with-let`. (counter / counter_slim_and_fast is the
+  ;; dedicated stock-vs-slim contrast pair; the slim build is the only one
+  ;; that mounts `reagent-slim`, and it lives under `examples/reagent-slim/`.)
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]

--- a/examples/reagent/managed_http_counter/README.md
+++ b/examples/reagent/managed_http_counter/README.md
@@ -21,7 +21,7 @@ The compact worked example for [Spec 014
   needing a stub HTTP server.
 - **`:rf.http/managed-abort`** — cancelling an in-flight request by
   `:request-id`.
-- **Substrate** — reagent-slim (the catalogue default).
+- **Substrate** — stock Reagent (`re-frame.adapter.reagent`), like the rest of the `examples/reagent/` catalogue.
 
 ## Why this shape
 

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -23,7 +23,7 @@
   http-managed-*.edn). The example itself is the runnable
   cross-substrate sanity check: the same fx, the same reply shape,
   end-to-end through Reagent and Fetch."
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
             ;; Managed-HTTP ships in day8/re-frame2-http.
@@ -42,7 +42,7 @@
             ;; patch / head / options) that synthesise the canonical
             ;; [:rf.http/managed args-map] envelope.
             [re-frame.http :as rf.http]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- App-db shape ------------------------------------------------------------
@@ -229,7 +229,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -65,7 +65,7 @@
    and `examples/reagent/seven_guis/circle_drawer/core.cljs`. In a real
    codebase this would split per CP-6 conventions across schema / events /
    subs / views / machines files."
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             ;; The Spec 010 schema-attachment ns lives in
@@ -92,7 +92,7 @@
             ;; re-frame.http-test-support.
             [re-frame.http-test-support]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -693,7 +693,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   ;; Install the demo override so `:rf.http/managed` calls route to the
   ;; in-process canned-stub fxs above. The example runs standalone — no
   ;; backend required.

--- a/examples/reagent/nine_states/stories_host.cljs
+++ b/examples/reagent/nine_states/stories_host.cljs
@@ -30,9 +30,9 @@
 
    The host installs the FULL Reagent adapter (`re-frame.adapter.
    reagent`) — the substrate the Story shell itself renders on. The
-   example's own `core.cljs` uses `reagent-slim` for its standalone
-   `:examples/nine-states` build; this showcase host is a separate
-   entry point and runs everything (live app + shell + variant
+   example's own `core.cljs` also mounts on the stock Reagent adapter for
+   its standalone `:examples/nine-states` build; this showcase host is a
+   separate entry point and runs everything (live app + shell + variant
    canvases) on one adapter. `nine-states.core/root-view` is a
    substrate-agnostic `reg-view`, so it renders identically under
    either.
@@ -65,7 +65,7 @@
 ;; `:nine-states.http/managed-demo` stub (no backend). This mirrors what
 ;; `nine-states.core/run` installs on `:rf/default`; we register it here
 ;; so the host owns the full boot (the host does not call
-;; `core/run`, which hardcodes its own reagent-slim mount lifecycle).
+;; `core/run`, which hardcodes its own stock-Reagent mount lifecycle).
 
 (defn- install-live-frame! []
   (rf/reg-frame :rf/default

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -23,12 +23,14 @@
    bold, italic, links, paragraphs, lists) — keeps the bundle small and
    the example free of an extra npm dependency."
   ;; Substrate note: STOCK Reagent (`reagent.dom.client` +
-  ;; `re-frame.adapter.reagent`), not reagent-slim. notebook is the Reagent
-  ;; member of the three-substrate design-led trio (alongside
-  ;; `dashboard-uix` and `process-monitor-helix`), so it sits on the
-  ;; reference Reagent substrate to keep the trio comparable. (Most of the
-  ;; catalogue defaults to slim; counter / counter_slim_and_fast is the
-  ;; dedicated stock-vs-slim contrast pair.)
+  ;; `re-frame.adapter.reagent`), like the rest of the `examples/reagent/`
+  ;; catalogue. notebook is the Reagent member of the three-substrate
+  ;; design-led trio (alongside `dashboard-uix` and
+  ;; `process-monitor-helix`), so it sits on the reference Reagent
+  ;; substrate to keep the trio comparable. (counter /
+  ;; counter_slim_and_fast is the dedicated stock-vs-slim contrast pair;
+  ;; the slim build is the only one that mounts `reagent-slim`, and it
+  ;; lives under `examples/reagent-slim/`.)
   (:require [reagent.dom.client :as rdc]
             [clojure.string     :as str]
             [re-frame.core      :as rf]

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -31,7 +31,7 @@
    `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`;
    the example tree is test-free, rf2-8cevm) run without a network."
   (:require [clojure.string :as str]
-            [reagent2.dom.client :as rdc]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             ;; Managed-HTTP ships in day8/re-frame2-http.
@@ -57,7 +57,7 @@
             ;; `:rf/hydrate`. Without the require those calls raise
             ;; :rf.error/ssr-artefact-missing.
             [re-frame.ssr]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]
             [realworld.schema]
             [realworld.http]
             [realworld.routing :as routing]
@@ -394,7 +394,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   ;; Override :rf.http/managed on the default frame so all the realworld
   ;; feature HTTP calls land on the demo stub (no real backend required).
   ;; The auth-guard interceptor (routing.cljs) is prepended to every event

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -11,7 +11,7 @@
    - `:rf.route/handle-url-change` for popstate / initial load
    - `:rf.route/id` and `:rf.route/params` for route reads
    - `:rf/url-requested` for user-initiated anchor clicks"
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
             ;; Routing ships in day8/re-frame2-routing.
@@ -19,7 +19,7 @@
             ;; its load-time hook + reg-sub registrations; without it,
             ;; rf/reg-route below throws :rf.error/routing-artefact-missing.
             [re-frame.routing]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -157,7 +157,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:routing.app/initialise])
   (install-router!)
   (when (exists? js/document)

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -35,14 +35,14 @@
    simple S-expression-flavored calculator (numbers, +, -, *, /, cell refs).
    Excel-style infix is left for a future iteration; the shape of the
    solution doesn't change."
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]
             [clojure.set]
             [clojure.string :as str])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -318,7 +318,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:cells/initialise])
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -21,14 +21,14 @@
    would naturally live in user/library space (cf. re-frame-undo today).
    This example shows the canonical primitive pattern; productionising it is
    library work, not framework work."
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -233,7 +233,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:drawer/initialise])
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -18,14 +18,14 @@
    - Derived filtered list                                 (CP-2 with :<-)
    - Schema-bound entity                                   (CP-8)"
   (:require [clojure.string :as str]
-            [reagent2.dom.client :as rdc]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -209,7 +209,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:crud/initialise])
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -20,14 +20,14 @@
    - Layered subs with :<- chains                          (CP-2)
    - Conditional UI driven by sub return values           (CP-4)
    - Smoke test exercising the constraint surface         (CP-1 checklist)"
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -192,7 +192,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:flight/initialise])
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -19,14 +19,14 @@
    - Pure derivation in subs (Celsius ↔ Fahrenheit)        (CP-2)
    - Schema-bound app-db slice                            (CP-8)"
   (:require [clojure.string :as str]
-            [reagent2.dom.client :as rdc]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -153,7 +153,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:temp/initialise])
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -20,14 +20,14 @@
    - One source of truth (elapsed)                        (state-in-app-db)
    - Layered subs for derived progress %                   (CP-2)
    - Controlled-input slider via dispatch on change       (CP-4)"
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 (def tick-ms
@@ -167,7 +167,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:timer/initialise])
   (when (exists? js/document)
     (when-not @react-root

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -61,8 +61,8 @@
             ;; re-exports raise `:rf.error/ssr-artefact-missing`.
             [re-frame.ssr :as ssr]
             #?(:cljs [cljs.reader])
-            #?(:cljs [reagent2.dom.client :as rdc])
-            #?(:cljs [re-frame.adapter.reagent-slim :as reagent-slim-adapter])))
+            #?(:cljs [reagent.dom.client :as rdc])
+            #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -287,7 +287,7 @@
      ;; Pass the adapter spec map directly. There is no
      ;; default-adapter registry — each adapter ns exports an `adapter`
      ;; var the consumer requires and passes here.
-     (rf/init! reagent-slim-adapter/adapter)
+     (rf/init! reagent-adapter/adapter)
      ;; If the page was server-rendered, `:rf/hydrate` replaces app-db with
      ;; the payload's :rf/app-db slice (locked :replace-app-db policy per
      ;; Spec 011 §The :rf/hydrate event). On a "client-only" load (no

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -25,8 +25,8 @@
   (:require [re-frame.core :as rf]
             [re-frame.schemas]
             [re-frame.ssr :as ssr]
-            #?(:cljs [reagent2.dom.client :as rdc])
-            #?(:cljs [re-frame.adapter.reagent-slim :as reagent-slim-adapter])))
+            #?(:cljs [reagent.dom.client :as rdc])
+            #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -209,7 +209,7 @@
 
 #?(:cljs
    (defn run []
-     (rf/init! reagent-slim-adapter/adapter)
+     (rf/init! reagent-adapter/adapter)
      ;; Install the client-side streaming runtime BEFORE the first render
      ;; so it catches resolved-subtree chunks as they arrive (and sweeps
      ;; any already present). It swaps fallbacks + merges per-subtree

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -15,9 +15,9 @@
   guard and lands at `:locked-out`. That path is exactly what the
   `state-machine-walkthrough-runs-headless` deftest walks through,
   so the stub needs to fail every request."
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]
             [state-machine-walkthrough.core])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -106,7 +106,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   ;; Install the canned-failure override on the default frame so every
   ;; `:rf.http/managed` request resolves :failure. The chapter's
   ;; lockout scenario depends on three consecutive failures.

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -1,9 +1,9 @@
 (ns todomvc.core
   (:require [clojure.string :as str]
-            [reagent2.dom.client :as rdc]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]
             [todomvc.db]
             [todomvc.events]
             [todomvc.subs]
@@ -38,7 +38,7 @@
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:todo/initialise])
   (rf/dispatch-sync [:rf.route/handle-url-change (current-path)])
   (.addEventListener js/window "hashchange"

--- a/examples/reagent/todomvc/views.cljs
+++ b/examples/reagent/todomvc/views.cljs
@@ -1,6 +1,6 @@
 (ns todomvc.views
   (:require [clojure.string :as str]
-            [reagent2.core :as reagent]
+            [reagent.core :as reagent]
             [re-frame.core :as rf]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view]]))

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -34,9 +34,9 @@
 
    Run standalone via `npm run test:examples`; the mock server keeps
    the app self-contained."
-  (:require [reagent2.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]
             [websocket.schema]
             [websocket.connection]
             [websocket.messages]
@@ -75,7 +75,7 @@
 (defonce react-root (atom nil))
 
 (defn run []
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:ws.app/initialise])
   (when (exists? js/document)
     (when-not @react-root


### PR DESCRIPTION
## Summary

Closes **rf2-2bih3** (P1 correctness bug). The stock `examples/reagent/**` catalogue is the canonical Reagent-adapter example set, but 17 runnable entrypoints imported `reagent2.dom.client` and called `rf/init!` with `re-frame.adapter.reagent-slim/adapter`. That meant a developer watching e.g. `:examples/realworld`, `:examples/routing`, `:examples/websocket`, or the 7GUIs builds got the **Reagent Slim** substrate/runtime instead of the stock Reagent bridge — executable runtime drift, not wording-only.

This PR normalizes every stock `examples/reagent/**` runnable source to the stock bridge:
- `reagent2.dom.client` → `reagent.dom.client`
- `re-frame.adapter.reagent-slim` → `re-frame.adapter.reagent` (alias `reagent-adapter`)
- `rf/init! reagent-slim-adapter/adapter` → `rf/init! reagent-adapter/adapter`
- `todomvc/views.cljs`: `reagent2.core` → `reagent.core`

## Files on the wrong adapter (now fixed)

`flows`, `managed_http_counter`, `boot`, `websocket`, `routing`, `nine_states`, `todomvc` (core + views), `realworld`, `state_machine_walkthrough/views`, `ssr` (.cljc), `ssr_streaming` (.cljc), and the six 7GUIs builds (`crud`, `temperature`, `flight_booker`, `timer`, `cells`, `circle_drawer`).

## Also corrected (stale narrative)

The "rest of the catalogue defaults to slim" claim in comments of `login`, `long_running_work`, `notebook` (these were already on stock — comment-only edits) and `nine_states/stories_host.cljs`, plus the `managed_http_counter/README.md` substrate line. The catalogue is now uniformly stock Reagent.

## Scope guard

`examples/reagent-slim/counter_slim_and_fast/` is the **only** intentional slim example and is untouched. `examples/reagent-slim/**` remains the sole tree using the slim adapter/runtime, per the documented per-substrate convention.

## Verification

- All 17 modified example builds compile clean (**0 warnings**) under the stock adapter (`shadow-cljs compile`).
- The `counter-slim-and-fast` slim twin still compiles clean (untouched).
- The Reagent adapter testbed Playwright smoke **PASSes** (stock adapter mount + dispatch + assert).
- Examples stay **test-free** — no `*.spec.cjs` added.
- All touched `.cljs`/`.cljc` files read clean as Clojure forms (no structural breakage).

## Acceptance (rf2-2bih3)

- [x] No runnable source under `examples/reagent/**` imports `reagent2.*` or `re-frame.adapter.reagent-slim`.
- [x] All stock Reagent example `run` fns initialize `re-frame.adapter.reagent/adapter`.
- [x] `examples/reagent-slim/**` remains the only slim example tree.

Note on the suggested regression guard: the bead suggested adding a static check that fails on `reagent2.`/`reagent-slim` in stock examples. That guard belongs outside the test-free example tree (e.g. an `implementation/scripts/` check wired to CI) and is filed as follow-up rather than included here, to keep this PR scoped to the runtime fix.