### PR TITLE
fix(epoch): epoch-id in redact warning + sensitive rollup on back-fill + trace-keep default (rf2-wmki8 + rf2-j1ec6.1)

### DIFF
--- a/docs/api/01-core.md
+++ b/docs/api/01-core.md
@@ -541,7 +541,7 @@ Process-level data knobs live behind `(rf/configure! <key> <opts>)`. The vocabul
 
 | Key | Opts | Default | Status | What it tunes |
 |---|---|---|---|---|
-| `:epoch-history` | `{:depth N :trace-events-keep N :redact-fn fn}` | `{:depth 50, :redact-fn nil}` | v1 (dev-only) | Per-frame epoch ring depth (the time-travel buffer), trace-event retention cap per record, and an optional redactor invoked once per assembled record so ring and listeners see the same shape. |
+| `:epoch-history` | `{:depth N :trace-events-keep N :redact-fn fn}` | `{:depth 50, :trace-events-keep 50, :redact-fn nil}` | v1 (dev-only) | Per-frame epoch ring depth (the time-travel buffer), trace-event retention cap per record (defaults to `:depth` so each retained epoch keeps its trace), and an optional redactor invoked once per assembled record so ring and listeners see the same shape. |
 | `:trace-buffer` | `{:depth N}` | `{:depth 200}` | v1 (dev-only) | The dev-only trace event ring depth. 0 disables. |
 | `:elision` | `{:rf.size/threshold-bytes N}` | `{:rf.size/threshold-bytes 16384}` | v1 | The size threshold above which `elide-wire-value` substitutes a `:rf.size/large-elided` marker. 0 disables runtime auto-detect (only declared / schema entries elide). See [11 — Instrumentation](11-instrumentation.md). |
 

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -114,9 +114,19 @@
   "Run the installed `:redact-fn` against `record` and return its
   result. nil `record` and nil `redact` are pass-throughs (no
   invocation, no try/catch overhead). A throwing fn emits
-  `:rf.warning/epoch-redact-fn-exception` carrying `:frame` and
-  `:ex-msg`, then falls back to the raw record so the drain itself
-  is not broken.
+  `:rf.warning/epoch-redact-fn-exception` carrying `:frame`,
+  `:epoch-id`, and `:ex-msg`, then falls back to the raw record so
+  the drain itself is not broken.
+
+  Per Tool-Pair §Time-travel §Redaction hook (spec/Tool-Pair.md:101):
+  the warning MUST carry both `:frame` and `:epoch-id` so a tool can
+  correlate the failure to the specific record that fell back to raw
+  data. The assembled record (and the post-settle back-fill probe,
+  which is shaped `(cond-> record ...)`) both carry `:epoch-id`, so
+  the same `(:epoch-id record)` read covers every invocation path:
+  normal settle, `reset-frame-db!`, `:halted-destroy`, and the
+  post-settle back-fill (where `compute-redacted-delta` hands this fn
+  a probe carrying the ring record's `:epoch-id`).
 
   Per Tool-Pair §Time-travel §Redaction hook + Security.md §Epoch
   privacy posture (rf2-wp70d): the fn runs ONCE per assembled record,
@@ -157,9 +167,10 @@
           ;; so Closure DCE elides the warning emit + literals
           ;; under :advanced + goog.DEBUG=false.
           (trace/emit! :warning :rf.warning/epoch-redact-fn-exception
-                       {:frame  (:frame record)
-                        :ex-msg #?(:clj (.getMessage ^Throwable e)
-                                   :cljs (.-message e))})
+                       {:frame    (:frame record)
+                        :epoch-id (:epoch-id record)
+                        :ex-msg   #?(:clj (.getMessage ^Throwable e)
+                                     :cljs (.-message e))})
           record))
       record)
     record))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -58,7 +58,8 @@
 
   The singletons `config` and `epoch-counter` are irreducible (the
   former is configuration state, the latter a counter source — both
-  read/written by ALL frames, so frame-id keying would be artificial).")
+  read/written by ALL frames, so frame-id keying would be artificial)."
+  (:require [re-frame.privacy :as privacy]))
 
 ;; ---- configuration --------------------------------------------------------
 
@@ -575,10 +576,23 @@
      :row?          <bool — was there a structured `slot` row delta?>
      :trace-events  <redacted :trace-events delta value, when :append?>
      :slot          <the structured slot keyword>
-     :slot-value    <redacted `slot` delta value, when :row?>}
+     :slot-value    <redacted `slot` delta value, when :row?>
+     :sensitive?    <bool — did the RAW back-filled event carry the
+                     `:sensitive?` stamp? (rf2-j1ec6.1 rollup OR-source)>}
 
   Returns `nil` when there is no delta to append (an unmount on a record
   whose `:trace-events` was already dropped by the keep-window cap).
+
+  Per rf2-j1ec6.1 (Security.md:109 §Sensitive rollup): the record-level
+  `:rf.epoch/sensitive?` rollup MUST consider `:trace-events` overlap, but
+  `build-record` computes it ONCE at settle time over the SETTLE-TIME
+  events — a post-settle back-fill that appends a `:sensitive?`-stamped
+  trace event would otherwise leave the rollup stale-false. We capture the
+  RAW (pre-redact) back-filled event's `:sensitive?` stamp HERE so the
+  pure `splice-redacted-delta` can OR it into the record's rollup inside
+  the swap (fail-CLOSED — mayor-ruled option a). The stamp is read off the
+  RAW `event`, not the redacted delta, because a `:redact-fn` may scrub the
+  stamp while the underlying content was still sensitive.
 
   Per rf2-7i872: `redact` (the app-supplied `:redact-fn`, via
   `assembly/maybe-redact`) is INVOKED HERE — exactly ONCE — and the caller
@@ -614,7 +628,16 @@
                        append? (assoc :trace-events [event])
                        row?    (assoc slot [row]))
             redacted (redact probe)]
-        (cond-> {:append? append? :row? row? :slot slot}
+        (cond-> {:append?    append?
+                 :row?       row?
+                 :slot       slot
+                 ;; rf2-j1ec6.1: read the RAW event's sensitivity stamp
+                 ;; BEFORE redaction so the rollup OR survives a redact-fn
+                 ;; that scrubs the stamp. The back-filled `event` is always
+                 ;; the raw trace event (`back-fill-event!` is handed the raw
+                 ;; emit); the `row` is its projection and carries no
+                 ;; independent stamp.
+                 :sensitive? (privacy/sensitive? event)}
           append? (assoc :trace-events (:trace-events redacted))
           row?    (assoc :slot-value (get redacted slot)))))))
 
@@ -638,12 +661,22 @@
   vector (or absent); a real slot already collapsed to a sentinel by a
   prior whole-slot scrub is left at the sentinel (the delta is subsumed).
 
+  Per rf2-j1ec6.1: the record-level `:rf.epoch/sensitive?` rollup is
+  OR'd with the back-filled event's RAW sensitivity (`:sensitive?` on the
+  precomputed `delta`). A post-settle back-fill of a `:sensitive?`-stamped
+  trace event flips the rollup `true`, keeping the Security.md:109
+  invariant (the rollup considers `:trace-events` overlap) literally true
+  post-back-fill — coarse drop-gate consumers that branch on the boolean
+  rollup now correctly drop a record whose only sensitive content arrived
+  via back-fill. The OR is monotonic/idempotent, so it rides safely inside
+  the CAS-retried swap (a retry re-ORs the same true with no corruption).
+
   `delta` nil (no append) is a pass-through — return the record
   untouched (do NOT spuriously re-redact it)."
   [record delta]
   (if (nil? delta)
     record
-    (let [{:keys [append? row? slot trace-events slot-value]} delta
+    (let [{:keys [append? row? slot trace-events slot-value sensitive?]} delta
           splice (fn [rec real-slot dv]
                    (cond
                      (and (vector? dv) (vector? (get rec real-slot)))
@@ -658,8 +691,12 @@
                      :else               ; whole-slot collapse by the fn
                      (assoc rec real-slot dv)))]
       (cond-> record
-        append? (splice :trace-events trace-events)
-        row?    (splice slot slot-value)))))
+        append?    (splice :trace-events trace-events)
+        row?       (splice slot slot-value)
+        ;; rf2-j1ec6.1 fail-CLOSED rollup recompute: OR the back-filled
+        ;; event's sensitivity into the record-level rollup. Only flips
+        ;; false→true (never clears a settle-time true).
+        sensitive? (assoc :rf.epoch/sensitive? true)))))
 
 (defn- back-fill-event!
   "Append `event` and its projected `row` (into the `slot` projection)

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -325,6 +325,101 @@
           "no listener fan-out for a sub-run with no causing cascade"))))
 
 ;; ===========================================================================
+;; rf2-j1ec6.1 — :rf.epoch/sensitive? rollup recomputed on back-fill
+;; ===========================================================================
+;;
+;; THE CONTRACT (Security.md:109 §Sensitive rollup at the record level): when
+;; any path the record carries — INCLUDING `:trace-events` — overlaps a
+;; sensitive slot, the record carries `:rf.epoch/sensitive? true`. Consumers
+;; (off-box shippers, recorder drop-gates) branch on the boolean rollup the
+;; same way they branch on the per-trace-event `:sensitive?` stamp.
+;;
+;; THE BUG: `build-record` computes the rollup ONCE at settle time from the
+;; settle-time events. A post-settle back-fill of a `:sensitive?`-stamped
+;; trace event (a sensitive reactive recompute riding React-deref timing)
+;; appended a sensitive event to `:trace-events` but left the rollup
+;; stale-false — so a coarse drop-gate consumer would NOT drop a record whose
+;; only sensitive content arrived via back-fill.
+;;
+;; THE FIX (mayor-ruled option a, fail-CLOSED): the back-fill swap OR's the
+;; rollup with the appended event's RAW sensitivity (`state/compute-redacted-
+;; delta` → `splice-redacted-delta`), flipping false→true.
+
+(defn- emit-sensitive-sub-run!
+  "Emit a reactive `:rf.sub/run` at React-DEREF timing carrying the
+  top-level `:sensitive? true` stamp — exactly what a sensitive reactive
+  recompute emits (the `:sensitive?` tag wins in `trace/compute-sensitive?`
+  and is hoisted to the envelope top level). Post-settle (empty buffer, no
+  render-key) so the runtime back-fills it into the most-recently-settled
+  epoch (rf2-wi900 path)."
+  [frame-id sub-id prev-value value]
+  (trace/emit! :rf.sub :rf.sub/run
+               {:rf.sub/id             sub-id
+                :rf.sub/query-v        [sub-id]
+                :frame                 frame-id
+                :sensitive?            true
+                :rf.sub/value-changed? (not= prev-value value)
+                :rf.sub/prev-value     prev-value
+                :rf.sub/value          value
+                :rf.sub/cascade?       false
+                :rf.sub/cause-sub      nil}))
+
+(deftest sensitive-rollup-recomputed-on-back-fill
+  (testing "rf2-j1ec6.1 — a post-settle back-fill of a :sensitive?-stamped
+            sub-run flips the record-level :rf.epoch/sensitive? rollup
+            false→true, keeping Security.md:109 literally true post-back-fill
+            (the rollup considers :trace-events overlap). Pre-fix the rollup
+            stayed stale-false — a coarse drop-gate consumer would not drop
+            a record whose only sensitive content arrived via back-fill."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})
+
+    (let [epoch (last-epoch :test/main)]
+      ;; PRECONDITION — a non-sensitive cascade settles rollup false.
+      (is (false? (:rf.epoch/sensitive? epoch))
+          "settle-time rollup is false (no sensitive content in the cascade)")
+
+      ;; Post-settle: a sensitive reactive recompute back-fills into this epoch.
+      (emit-sensitive-sub-run! :test/main :secret-sub nil "topsecret")
+
+      (let [r (epoch-by-id :test/main epoch)]
+        ;; The back-filled sub-run is present AND carries the sensitive stamp.
+        (is (contains? (sub-run-ids r) :secret-sub)
+            "the sensitive sub-run was back-filled into the causing cascade")
+        (is (some #(and (= :rf.sub/run (:operation %))
+                        (true? (:sensitive? %)))
+                  (:trace-events r))
+            "the back-filled trace event carries the :sensitive? stamp")
+        ;; THE INVARIANT — the rollup was OR'd true at the back-fill swap.
+        (is (true? (:rf.epoch/sensitive? r))
+            "rf2-j1ec6.1 — back-filled sensitivity flips the record rollup true")))))
+
+(deftest non-sensitive-back-fill-leaves-rollup-false
+  (testing "rf2-j1ec6.1 — a back-fill of a NON-sensitive sub-run does NOT
+            flip the rollup (the OR is fail-CLOSED, not fail-open): a clean
+            cascade with a clean back-fill stays false."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})
+
+    (let [epoch (last-epoch :test/main)]
+      (is (false? (:rf.epoch/sensitive? epoch)))
+      ;; A plain (non-sensitive) reactive recompute back-fills in.
+      (emit-sub-run! :test/main :plain-sub 0 1)
+      (let [r (epoch-by-id :test/main epoch)]
+        (is (contains? (sub-run-ids r) :plain-sub)
+            "the non-sensitive sub-run was back-filled")
+        (is (false? (:rf.epoch/sensitive? r))
+            "rollup stays false — a non-sensitive back-fill never flips it")))))
+
+;; ===========================================================================
 ;; INVARIANT 2 — :rf.view/rendered / :rf.view/render attributed to its CAUSING
 ;;                cascade, not the commit-time / next epoch (rf2-qs6dl)
 ;; ===========================================================================

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -471,15 +471,18 @@
 
 ;; ---- 5. trace-events retention cap ----------------------------------------
 
-(deftest retention-cap-default-finite-five
-  (testing "the default :trace-events-keep is the finite default 5 —
-            drive >5 cascades, the oldest records lose :trace-events
-            but keep the structured projections (per rf2-mrsck)"
+(deftest retention-cap-fixture-override-five
+  (testing "rf2-wmki8 — the TEST FIXTURE forces :trace-events-keep 5 (a
+            keep<depth OVERRIDE, NOT the shipped default of 50) so the
+            elision path is reachable cheaply — drive >5 cascades, the
+            oldest records lose :trace-events but keep the structured
+            projections (per rf2-mrsck)"
     (rf/reg-frame :test/main {})
     (rf/reg-event-db :seed (fn [_ _] {:n 0}))
     (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
 
-    (is (= 5 (:trace-events-keep (epoch/current-config))))
+    (is (= 5 (:trace-events-keep (epoch/current-config)))
+        "fixture OVERRIDE — the shipped runtime default is 50 (= :depth)")
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (dotimes [_ 6] (rf/dispatch-sync [:inc] {:frame :test/main}))

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -293,7 +293,15 @@
         (is (= :test/main (get-in warn [:tags :frame]))
             ":frame tag carries the offending frame-id")
         (is (string? (get-in warn [:tags :ex-msg]))
-            ":ex-msg tag carries the exception message string"))
+            ":ex-msg tag carries the exception message string")
+        ;; rf2-wmki8.1 — the warning MUST carry :epoch-id (Tool-Pair.md:101)
+        ;; so a tool can correlate the failure to the record that fell back
+        ;; to raw data. The settle-time build-record assigned an :epoch-id;
+        ;; it is the record the fall-back landed under.
+        (is (= (:epoch-id (last-record :test/main))
+               (get-in warn [:tags :epoch-id]))
+            ":epoch-id tag matches the record the redact-fn fell back on
+             (normal settle path)"))
 
       ;; Drain not broken — next cascade records as normal.
       (rf/configure! :epoch-history {:redact-fn nil})
@@ -765,6 +773,47 @@
              attribution path is unchanged; redaction is opt-in)")
         (is (= renotified (last-record :test/main))
             "ring and listener agree on the raw shape")))))
+
+(deftest inv-6-back-fill-throwing-redact-fn-warns-with-epoch-id
+  (testing "rf2-wmki8.1 — a throwing redact-fn on a POST-SETTLE back-fill
+            (non-normal path: a React-deref-timed sub-run back-filled into
+            the most-recently-settled epoch) emits
+            :rf.warning/epoch-redact-fn-exception carrying the BACK-FILL
+            TARGET epoch's :epoch-id (Tool-Pair.md:101). The probe record
+            `compute-redacted-delta` hands `maybe-redact` is shaped
+            `(cond-> record ...)`, so it carries the ring record's
+            :epoch-id — the warning correlates to the record the delta fell
+            back into."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    ;; Settle a clean cascade first (no redact-fn) so a back-fill target
+    ;; epoch exists, then install a throwing redact-fn for the back-fill.
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})
+    (let [target   (last-record :test/main)
+          warnings (record-warnings!)]
+      (rf/configure! :epoch-history
+                    {:redact-fn (fn [_] (throw (ex-info "back-fill boom" {})))})
+
+      ;; Post-settle reactive recompute → back-fill into `target`, running
+      ;; the throwing redact-fn over the appended delta.
+      (emit-sub-run! :test/main :counter 0 1)
+
+      (let [warn (->> @warnings
+                      (filter #(= :rf.warning/epoch-redact-fn-exception
+                                  (:operation %)))
+                      first)]
+        (is (some? warn)
+            "back-fill redact-fn throw emits the warning")
+        (is (= :test/main (get-in warn [:tags :frame]))
+            ":frame carries the offending frame-id on the back-fill path")
+        (is (= (:epoch-id target) (get-in warn [:tags :epoch-id]))
+            ":epoch-id carries the BACK-FILL TARGET epoch (the record the
+             appended delta fell back into) — not nil")
+        (is (string? (get-in warn [:tags :ex-msg]))
+            ":ex-msg carries the exception message on the back-fill path")))))
 
 ;; ============================================================================
 ;;  Invariant 7 — once-per-slot back-fill redaction; NON-idempotent fns

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -3221,11 +3221,36 @@
     (is (nil? (epoch/projected-record nil)))
     (is (nil? (epoch/projected-record :not-a-map)))))
 
-(deftest smoke-trace-events-keep-default-finite
-  (testing "rf2-mrsck — current-config reports the finite default
-            :trace-events-keep 5; the older absent-default behaviour
-            (unbounded) is gone (pre-alpha — no back-compat)"
-    (is (= 5 (:trace-events-keep (epoch/current-config))))))
+(deftest smoke-trace-events-keep-fixture-override
+  (testing "rf2-wmki8 — the TEST FIXTURE forces :trace-events-keep 5 (a
+            keep<depth OVERRIDE so the elision path is reachable with a
+            handful of dispatches), NOT the shipped runtime default. This
+            asserts the fixture's override value, deliberately distinct
+            from the shipped default of 50 (see
+            `shipped-trace-events-keep-default-is-50` for the real
+            default)."
+    (is (= 5 (:trace-events-keep (epoch/current-config)))
+        "fixture OVERRIDE — see reset-runtime; NOT the shipped default")))
+
+(deftest shipped-trace-events-keep-default-is-50
+  (testing "rf2-wmki8 — the SHIPPED runtime default :trace-events-keep is
+            50 (= :depth, so every retained epoch keeps its trace; Mike
+            pair-debug 2026-05-27). Asserted against the source-of-truth
+            private `default-trace-events-keep` var, bypassing the
+            fixture's keep<depth override. Pins the default consistently
+            with docs/api/01-core.md and `re-frame.epoch.state`."
+    (is (= 50 @#'state/default-trace-events-keep)
+        "the source-of-truth default var ships 50")
+    ;; The accessor is wired to fall back to that var when the slot is
+    ;; absent from the live config map (the shape a fresh process / a
+    ;; partial `configure!` leaves). Drive a config WITHOUT the slot and
+    ;; confirm the accessor reports the shipped 50 — proving the var is the
+    ;; live default, not just a declared constant.
+    (reset! @#'state/config {:depth 50 :redact-fn nil})
+    (is (= 50 (state/trace-events-keep))
+        "trace-events-keep accessor falls back to the shipped 50 default")
+    (is (= 50 (:trace-events-keep (epoch/current-config) 50))
+        "current-config's :trace-events-keep resolves to the shipped 50")))
 
 ;; ============================================================================
 ;;  rf2-7i872 — write-boundary liveness race (validate-then-destroy)


### PR DESCRIPTION
Two epoch beads (one PR — shared assembly/state surface). Rebased on origin/main (post-#3126 `compute-redacted-delta`/`splice-redacted-delta`).

## rf2-wmki8.1 — redact warning missing `:epoch-id`
`:rf.warning/epoch-redact-fn-exception` emitted only `{:frame :ex-msg}`; spec/Tool-Pair.md:101 requires `{:frame :epoch-id}`. Aligned the code to the (correct) spec: `assembly/maybe-redact` now reads `(:epoch-id record)` into the warning. The same read covers every invocation path — normal settle, `reset-frame-db!`, `:halted-destroy`, and post-settle back-fill (where `compute-redacted-delta` hands a probe shaped `(cond-> record ...)` carrying the ring record's `:epoch-id`).
- Test: `invariant-3-throwing-redact-fn-warns-and-falls-back` extended to assert `:epoch-id` (normal settle).
- Test: `inv-6-back-fill-throwing-redact-fn-warns-with-epoch-id` (post-settle back-fill non-normal path).

## rf2-wmki8.2 — trace-events-keep default drift
Runtime default is 50 (`state.cljc`), but `docs/api/01-core.md` omitted `:trace-events-keep` from the `:epoch-history` default map and two tests mislabeled the fixture's keep<depth override (5) as "the default".
- docs: default map now `{:depth 50, :trace-events-keep 50, :redact-fn nil}`.
- Renamed/reframed the misleading tests as fixture OVERRIDES (`smoke-trace-events-keep-default-finite` → `-fixture-override`; `retention-cap-default-finite-five` → `-fixture-override`).
- Added `shipped-trace-events-keep-default-is-50` asserting the actual runtime default via `default-trace-events-keep` + the accessor fallback.

## rf2-j1ec6.1 — sensitive rollup not recomputed on back-fill (mayor-ruled option a, fail-CLOSED)
`:rf.epoch/sensitive?` was computed once in `build-record`; a post-settle `back-fill-event!` appending a `:sensitive?`-stamped trace event left the rollup stale-false, contradicting Security.md:109 (rollup must consider `:trace-events` overlap). Fix: `compute-redacted-delta` captures the RAW (pre-redact) event's `:sensitive?` stamp; `splice-redacted-delta` ORs it into the record's rollup inside the CAS-retried swap (monotonic OR — only flips false→true, never clears a settle-time true). `state.cljc` gains a `re-frame.privacy` require (no cycle).
- Regression: `sensitive-rollup-recomputed-on-back-fill` (sensitive back-fill flips rollup true) + `non-sensitive-back-fill-leaves-rollup-false`.

Did NOT touch spec/Tool-Pair.md or spec/Security.md (hot-zone, already correct — aligned code to them).

## Quality gates
- epoch JVM `clojure -M:test`: 269 tests, 1026 assertions, 0 failures / 0 errors
- `npm run test:cljs`: 5640 tests, 19655 assertions, 0 failures / 0 errors
- `mkdocs build --strict`: clean (docs/api touched)

Closes rf2-wmki8, rf2-j1ec6.1.