### PR TITLE
fix(xray): path-scoped get-app-db threads absolute :path into egress walker (rf2-a96xq)

### DIFF
--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -699,13 +699,22 @@ half of MUST-inventory rows #2 / #15 / #17 / #19; callers pass plain
 `:include-sensitive?` / `:include-large?` opts, the fns translate to the
 framework's `:rf.size/*` namespaced opt keys.
 
+`egress-value` also takes an optional `:path` — the **absolute** app-db
+path the value sits at. The framework's schema-declared sensitive / large
+declarations are keyed by absolute path, so a slice egress'd in isolation
+(a `:path`-scoped `get-app-db` read, or one changed-path slice from
+`get-app-db-diff`) MUST tell the walker where the slice lives or the
+declaration won't match and the raw leaf would cross the boundary
+(rf2-a96xq). A whole-db read passes no `:path` (the value IS the walked
+root, `[]`).
+
 ### Inspection band (9 accessors — read-only)
 
 | Accessor (fn) | Tool name | Returns | Reads |
 |---|---|---|---|
 | `get-trace-buffer` | `get-trace-buffer` | `{:ok? true :events <vec> :count <n>}` | `trace-tooling/trace-buffer` — filtered slice of the trace stream. Filter keys are the canonical Spec 009 vocabulary (`:operation` / `:op-type` / `:since` / `:frame` / `:severity` / `:event-id` / `:handler-id` / `:source` / `:origin` / `:dispatch-id` / `:since-ms` / `:between` / `:pred`). |
 | `get-epoch-history` | `get-epoch-history` | `{:ok? true :frame <id> :epochs <vec> :count <n>}` | `rf/epoch-history` per-frame vector of `:rf/epoch-record`. |
-| `get-app-db` | `get-app-db` | `{:ok? true :frame <id> :path <vec> :value <edn>}` | `rf/app-db-value` (optionally scoped by `:path`). |
+| `get-app-db` | `get-app-db` | `{:ok? true :frame <id> :path <vec> :value <edn>}` | `rf/app-db-value` (optionally scoped by `:path`). The `:value` routes through `egress-value`; when `:path` is supplied the absolute path is threaded into the walker so a scoped slice elides against schema-declared sensitive / large paths — fail-closed, symmetric with the whole-db read and the `get-app-db-diff` slices (rf2-a96xq). |
 | `get-app-db-diff` | `get-app-db-diff` | `{:ok? true :frame <id> :epoch-id <uuid> :diff {:added [{:path :value}] :removed [{:path :value}] :changed [{:path :before :after}]}}` | Projects the changed-paths slice diff between a named epoch's `:db-before` + `:db-after` via the canonical Editscript-A* engine (`diff.engine/project`). Only the changed paths' slices egress — each `:value` / `:before` / `:after` routed through `egress-value`, never two whole app-db snapshots (rf2-uv2q2). Heavier nested-diff projection lives MCP-side. |
 | `get-machine-state` | `get-machine-state` | `{:ok? true :frame <id> :machine-id <kw> :state <edn>}` | `rf/machine-meta` for the registered machine spec. |
 | `get-machine-list` | `get-machine-list` | `{:ok? true :machines <map> :count <n>}` | `rf/machines` — map keyed by machine-id. |

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -357,7 +357,11 @@
 (defn get-app-db
   "Tool: `get-app-db`. Current `app-db` value at a frame, optionally
   scoped by `:path`. Routes through `elide-wire-value` (MUST-inventory
-  row #19 — direct-read privacy posture). Returns
+  row #19 — direct-read privacy posture). When `:path` is supplied the
+  absolute path is threaded into the egress walker so a scoped slice is
+  elided against schema-declared sensitive / large paths (keyed by
+  absolute path) — fail-closed, symmetric with the whole-db read and
+  the `get-app-db-diff` slices (rf2-a96xq). Returns
   `{:ok? true :frame <id> :path <vec> :value <edn>}` or
   `{:ok? false :reason :no-frame-resolved}`."
   ([] (get-app-db nil))
@@ -372,8 +376,20 @@
          {:ok?   true
           :frame fid
           :path  (vec path)
+          ;; Thread the ABSOLUTE app-db `:path` into the egress walker so
+          ;; a `:path`-scoped slice is elided against schema-declared
+          ;; sensitive / large paths (keyed by absolute path) — without
+          ;; it the walker starts the sliced value at root `[]` and a
+          ;; declaration registered for e.g. `[:auth :password]` never
+          ;; matches a direct read of `{:path [:auth :password]}`, leaking
+          ;; the raw leaf off-box (rf2-a96xq). Symmetric with the sibling
+          ;; `get-app-db-diff` slices, which egress each leaf at its
+          ;; absolute path. An unscoped read passes `path` = `nil`, and
+          ;; `egress-value` only assoc's `:path` when `(seq path)`, so the
+          ;; whole-db case is unchanged (value IS the walked root).
           :value (egress-value value {:include-sensitive? include-sensitive?
-                                      :include-large?     include-large?})})))))
+                                      :include-large?     include-large?
+                                      :path               path})})))))
 
 (defn- project-changed-paths
   "Project the `(before, after)` pair into the changed-paths slice diff

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -477,6 +477,90 @@
           "non-sensitive slots survive"))))
 
 ;; ---------------------------------------------------------------------------
+;; (11b) PATH-SCOPED get-app-db threads the absolute :path into the egress
+;;       walker so a scoped slice elides against schema-declared
+;;       sensitive / large paths (rf2-a96xq).
+;; ---------------------------------------------------------------------------
+;;
+;; Before the fix the scoped read called `egress-value` WITHOUT the
+;; absolute :path, so the walker started the sliced leaf at root [] and a
+;; declaration registered for [:auth :password] never matched a direct
+;; read of {:path [:auth :password]} — the raw value crossed the off-box
+;; boundary despite the safe-default contract. These tests pin the
+;; fail-closed default (redact / size-elide) AND the operator opt-in.
+
+(defn- seed-large-schema! []
+  ;; A `{:large? true}` schema slot hydrates the per-frame `:declarations`
+  ;; so the wire walker substitutes the `:rf.size/large-elided` marker for
+  ;; that path on off-box egress (the size sibling of
+  ;; `seed-sensitive-schema!`). Must run AFTER any whole-db reset so the
+  ;; declaration in `[:rf/runtime :elision :declarations]` survives.
+  (rf/reg-app-schema [:blob]
+                     [:map
+                      [:payload {:large? true} :any]])
+  (rf/populate-elision-from-schemas!))
+
+(deftest get-app-db-path-scoped-redacts-sensitive-leaf-by-default
+  (testing "a PATH-scoped get-app-db over a schema-declared sensitive
+            leaf redacts by default — the absolute :path is threaded into
+            the egress walker so the [:auth :password] declaration
+            matches the scoped slice (rf2-a96xq: fail-closed)"
+    (rf/reg-event-db :test/seed-auth
+      (fn [_ _] {:auth {:username "ada" :password "shh"}}))
+    (rf/dispatch-sync [:test/seed-auth])
+    (seed-sensitive-schema!)
+    ;; Scope the read down to the sensitive leaf itself.
+    (let [result (runtime/get-app-db {:path [:auth :password]})]
+      (is (true? (:ok? result)))
+      (is (= [:auth :password] (:path result)) "echoes the requested path")
+      (is (= :rf/redacted (:value result))
+          "the path-scoped sensitive leaf is redacted by default — NOT the raw value")
+      (is (not= "shh" (:value result))
+          "the raw secret never crosses the off-box boundary on the safe default path"))
+    ;; And a scope that STRADDLES the sensitive leaf (one level up) still
+    ;; redacts the nested slot — the threaded :path is the parent and the
+    ;; walker descends to the absolute leaf.
+    (let [result (runtime/get-app-db {:path [:auth]})]
+      (is (= :rf/redacted (get-in result [:value :password]))
+          "a parent-scoped slice still redacts the nested sensitive leaf")
+      (is (= "ada" (get-in result [:value :username]))
+          "non-sensitive sibling survives in the scoped slice"))))
+
+(deftest get-app-db-path-scoped-reveals-sensitive-on-opt-in
+  (testing "a PATH-scoped get-app-db with {:include-sensitive? true}
+            reveals the raw leaf — the operator opt-in still flows through
+            the threaded-path egress (rf2-a96xq: opt-in gate open)"
+    (rf/reg-event-db :test/seed-auth
+      (fn [_ _] {:auth {:username "ada" :password "shh"}}))
+    (rf/dispatch-sync [:test/seed-auth])
+    (seed-sensitive-schema!)
+    (let [result (runtime/get-app-db {:path [:auth :password]
+                                      :include-sensitive? true})]
+      (is (true? (:ok? result)))
+      (is (= "shh" (:value result))
+          ":include-sensitive? true ⇒ the raw leaf is revealed at the scoped path"))))
+
+(deftest get-app-db-path-scoped-elides-large-leaf-by-default
+  (testing "a PATH-scoped get-app-db over a schema-declared :large? leaf
+            emits the :rf.size/large-elided marker by default, and reveals
+            the raw value only on {:include-large? true} (rf2-a96xq:
+            symmetric size minimisation on the scoped path)"
+    (rf/reg-event-db :test/seed-blob
+      (fn [_ _] {:blob {:payload {:big "value"}}}))
+    (rf/dispatch-sync [:test/seed-blob])
+    (seed-large-schema!)
+    (let [result (runtime/get-app-db {:path [:blob :payload]})]
+      (is (true? (:ok? result)))
+      (is (contains? (:value result) :rf.size/large-elided)
+          "the path-scoped large leaf is size-elided by default")
+      (is (not= {:big "value"} (:value result))
+          "the raw large value does not cross the boundary on the safe default path"))
+    (let [result (runtime/get-app-db {:path [:blob :payload]
+                                      :include-large? true})]
+      (is (= {:big "value"} (:value result))
+          ":include-large? true ⇒ the raw large leaf is revealed at the scoped path"))))
+
+;; ---------------------------------------------------------------------------
 ;; (12) get-app-db-diff returns the changed-paths {:added :removed :changed}
 ;;      slice shape — NOT two whole app-db snapshots (rf2-uv2q2).
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes **rf2-a96xq** (P1, privacy boundary / CORRECTNESS).

A `:path`-scoped `runtime/get-app-db` read sliced the app-db with `get-in` but then called `egress-value` **without** the absolute `:path`. The framework wire-elision walker (`re-frame.core/elide-wire-value`) keys schema-declared sensitive / `:large?` declarations by absolute path and starts walking at `(vec (:path opts))`. A slice egress'd in isolation therefore began at root `[]`, so a declaration registered for e.g. `[:auth :password]` never matched a direct read of `{:path [:auth :password]}` — the **raw** sensitive / large leaf crossed the Xray/MCP off-box boundary despite the fail-closed safe-default contract.

This was asymmetric with the unscoped whole-db read and the sibling `get-app-db-diff` slices (`project-changed-paths`), both of which already egress at the absolute leaf path.

## Fix

Thread the requested `:path` into the `get-app-db` egress call, preserving the `:include-sensitive?` / `:include-large?` operator opt-ins — symmetric with `project-changed-paths`. An unscoped read passes `nil`, and `egress-value` only assoc's `:path` when `(seq path)`, so the whole-db case is unchanged (the value IS the walked root `[]`).

Fail-closed by default; raw value only on explicit operator opt-in.

## Regression test (failing-before / passing-after)

`runtime_cljs_test.cljs` — three new tests + a `seed-large-schema!` helper:
- path-scoped read over a schema-declared sensitive leaf returns `:rf/redacted` by default (and a parent-scoped slice still redacts the nested leaf);
- `{:include-sensitive? true}` reveals the raw leaf at the scoped path;
- path-scoped read over a `{:large? true}` leaf returns the `:rf.size/large-elided` marker by default, and `{:include-large? true}` reveals the raw value.

**Without the fix** these fail with the raw `"shh"` secret and the raw large blob crossing the boundary (5 failing assertions); **with the fix** all pass.

## Spec (mandatory egress-contract update)

`tools/xray/spec/API.md` — documents the `egress-value` `:path` absolute-path contract and updates the `get-app-db` table row to record the path-scoped egress posture.

## Gates (all green)

- `npm run test:cljs` — 5637 tests / 19635 assertions, 0 failures
- xray `clojure -M:test` — 1100 tests / 4526 assertions, 0 failures
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures (EXIT=0)
- `npm run test:bundle-isolation` — PASS (17 entries; 35 sentinels absent; uix/helix reagent-free)