### PR TITLE
fix(docs): MIGRATION M-15 single-vector :on-create + managed-http accept-failure taxonomy (rf2-gx5v2 + rf2-k72t9)

### DIFF
--- a/migration/from-re-frame-v1/README.md
+++ b/migration/from-re-frame-v1/README.md
@@ -515,7 +515,7 @@ Per [012 §Tooling and AI-amenability](../../spec/012-Routing.md#tooling-and-ai-
 
 **Type B** (semantic flag).
 
-Per [002 §Re-registration — surgical update](../../spec/002-Frames.md), a *fresh* `reg-frame` (i.e. the first registration for a given keyword) initialises `app-db` to `{}` and then runs `:on-create`. Apps that synchronously poke `re-frame.db/app-db` at top level (`(reset! re-frame.db/app-db {...})` in a namespace body, before any `reg-frame` runs) are doubly affected: M-1 forbids the private-namespace access (mechanical rewrite to `(reg-frame :rf/default {:on-create [[:app/seed initial-state]]})`), and the seeded value must move into the `:on-create` event.
+Per [002 §Re-registration — surgical update](../../spec/002-Frames.md), a *fresh* `reg-frame` (i.e. the first registration for a given keyword) initialises `app-db` to `{}` and then runs `:on-create`. Apps that synchronously poke `re-frame.db/app-db` at top level (`(reset! re-frame.db/app-db {...})` in a namespace body, before any `reg-frame` runs) are doubly affected: M-1 forbids the private-namespace access (mechanical rewrite to `(reg-frame :rf/default {:on-create [:app/seed initial-state]})`), and the seeded value must move into the `:on-create` event.
 
 **What to look for:** top-level `(reset! re-frame.db/app-db ...)` (or `(swap! re-frame.db/app-db ...)`) calls in namespace bodies.
 

--- a/skills/re-frame2/patterns/managed-http.md
+++ b/skills/re-frame2/patterns/managed-http.md
@@ -30,7 +30,7 @@ Out of scope: streaming responses (chunked / SSE), bidirectional WebSocket (see 
 | `:accept` post-decode normalisation | `(fn [decoded] {:ok v} or {:failure m})` lets a structurally-valid 200 surface as a domain failure. |
 | `:retry` — transport-level only | Function of failure category + attempt count; nothing else. Semantic retry belongs in a state machine — see *§The retry-ownership boundary*. |
 | `:request-id` abort | Stable `=`-comparable id; `[:rf.http/managed-abort id]` cancels in-flight, dispatching `:rf.http/aborted` via the reply path. |
-| Eight-category failure taxonomy | `:rf.http/transport`, `:rf.http/cors`, `:rf.http/timeout`, `:rf.http/aborted`, `:rf.http/http-4xx`, `:rf.http/http-5xx`, `:rf.http/decode-failure`, `:rf.http/payload`. Closed set. |
+| Eight-category failure taxonomy | `:rf.http/transport`, `:rf.http/cors`, `:rf.http/timeout`, `:rf.http/aborted`, `:rf.http/http-4xx`, `:rf.http/http-5xx`, `:rf.http/decode-failure`, `:rf.http/accept-failure`. Closed set. |
 | Machine-form wrapper | A child invokable machine of `:rf.http/managed` — `:spawn` it like any other; on reply it transitions to `:succeeded` / `:failed` and dispatches `[<parent-id> [:succeeded value]]` / `[<parent-id> [:failed failure]]` back. Destroying the wrapper aborts in-flight. |
 
 ## Canonical declaration — fx form


### PR DESCRIPTION
Two independent one-token doc corrections, cross-checked against the cited implementation.

## rf2-gx5v2 — MIGRATION.md M-15 nested vector-of-vectors
`migration/from-re-frame-v1/README.md:518` showed the M-15 seed rewrite as `{:on-create [[:app/seed initial-state]]}` (nested vector-of-vectors). Corrected to the single-vector shape `{:on-create [:app/seed initial-state]}`.

Verified against `spec/002-Frames.md:120`:
> `:on-create` accepts a **single** event vector. The framework dispatch-syncs it into the freshly-created frame...

## rf2-k72t9 — managed-http.md stale `:rf.http/payload`
`skills/re-frame2/patterns/managed-http.md:33` listed `:rf.http/payload` as the eighth failure category — it exists nowhere in `implementation/` or `spec/`. Replaced with the real eighth member `:rf.http/accept-failure`.

Verified against:
- `implementation/http/src/re_frame/http_handlers.cljc:45-49` (retryable subset) + `:70-71` (the three non-retryable: `:rf.http/aborted`, `:rf.http/decode-failure`, `:rf.http/accept-failure`)
- `implementation/http/src/re_frame/http_transport.cljc:923` — `(dispatch-failure! ... {:kind :rf.http/accept-failure ...})`
- `spec/014-HTTPRequests.md` (`:rf.http/accept-failure` present; `:rf.http/payload` absent)

## rf2-ocbcp — NOT changed (false positive)
The bead asked to change `spec/005-StateMachines.md:3009` from `:rf.error/machine-grammar-not-in-v1` to `:rf.error/machine-history-misplaced`. On cross-check this would be a **regression**, so it was deliberately left unchanged:

- Line 3009 describes the **UNCLAIMED-`:fsm/history`** disposition ("A port that does **not** claim `:fsm/history` rejects a `:type :history` node at registration..."). For unclaimed-capability grammar, `:rf.error/machine-grammar-not-in-v1` is the **canonical, live** error category — defined at `spec/005:3841-3848` (`{:operation :rf.error/machine-grammar-not-in-v1 ... :feature ;; e.g. :after, :type :history}`) and used identically for `:tags` (`:1877`), `:spawn-all` (`:3329`), `:parallel` (`:1605`), and in the migration README (`:1635`) + `docs/guide/12-machines.md:336` + `spec/AI-Audit.md:131`.
- The impl's `:rf.error/machine-history-misplaced` (`validation.cljc:486-506`) is the **PLACEMENT** error — a port that *does* claim `:fsm/history` but puts the node with no owning compound. The cited fixture `machine-reg-error-grammar-not-in-v1.edn` claims `:fsm/history` (line 20) and tests exactly that placement case — it does NOT exercise line 3009's unclaimed path.
- The impl comment "Replaces the withdrawn `machine-grammar-not-in-v1` deferral" refers to withdrawing the keyword's old use as a *history-specific post-v1 deferral* (history is now a claimed capability), NOT retiring the keyword — it remains live for every unclaimed-capability rejection.

Recommendation: keep `spec/005:3009` as-is. The bead correctly flagged this needed maintainer review; the answer is "no change". Closing rf2-ocbcp as resolved-no-change with this finding.

## Gates
- `python scripts/check_skill_migration_cites.py` → exit 0 (M-15 prose change preserves all M-id cites)
- `python -m mkdocs build --strict` → exit 0