### PR TITLE
docs(story): reconcile recorder facade contract to impl + pin with tests (rf2-xxnqd)

### DIFF
--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -444,7 +444,7 @@ tooling, and bespoke test integrations consume specific sub-systems;
 this section documents the boundary so a power user reads the right
 ns rather than scanning the facade alone.
 
-The six sub-systems and their public boundaries:
+The seven sub-systems and their public boundaries:
 
 | Sub-system | Lives in | Public surface | Audience |
 |---|---|---|---|
@@ -454,7 +454,7 @@ The six sub-systems and their public boundaries:
 | DOM-capture entries | `re-frame.story.recorder.dom-capture` (CLJS-only) | `install!` / `remove!` (capture-phase listener pair); `record-dom-event!` (write through the atom with `:dom/click` / `:dom/type` / `:dom/submit` shapes); `dom-event?` / `dom-event-kinds` (pure predicates). | `chrome-shell` (paired with the trace-listener install at mount). |
 | Review-dialog | `re-frame.story.recorder` + `re-frame.story.review-dialog` | `open-dialog` / `close-dialog` / `initial-dialog-state`. State-only — the rendering lives in `re-frame.story.ui.recorder-export-dialog`. | `chrome-shell` (the modal that opens on stop). |
 | `:script` snippet codegen | `re-frame.story.recorder` | `gen-play-snippet` (pure: events + opts → EDN string). Re-exported on the facade as `story/gen-play-snippet`. Emits `(reg-variant ... :script {:script [[:dispatch-sync <ev>] ...]})` — the PUBLIC `:script` slot per rf2-7mj4z; each event wrapped as `[:dispatch-sync <ev>]` per rf2-0wrud. | `user-app` (the copy-and-paste form); `mcp-tool` (the structured-output payload for `record-as-variant`). |
-| Rich DOM-aware `:script` export | `re-frame.story.recorder.play-export` + `re-frame.story.recorder.play-export-events` + `re-frame.story.recorder.selector` | The DOM-capture-aware translator that maps `:entries` (with DOM-capture timestamps) into `:click` / `:type` / `:wait` steps + auto-assert tail; `render-variant-form` emits the public `:script` slot (rf2-7mj4z). Sub-namespace export; not on the facade. `gen-play-snippet` is the facade-level entry; this richer translator is the power-user surface. | `chrome-shell`; `mcp-tool`. |
+| Rich DOM-aware `:script` export | `re-frame.story.recorder.play-export` + `re-frame.story.recorder.play-export-events` + `re-frame.story.recorder.selector` | The DOM-capture-aware translator that maps `:entries` (with DOM-capture timestamps) into `:click` / `:type` / `:wait` steps + auto-assert tail; `render-variant-form` emits the public `:script` slot (rf2-7mj4z). The translator entry `recording->play-script` IS re-exported on the facade as `story/recording->play-script` (the runtime counterpart to `gen-play-snippet`, used by the MCP `record-as-variant` write-back); the render-to-EDN fns (`render-play-script` / `render-variant-form`) stay sub-namespace-only. | `chrome-shell`; `mcp-tool`. |
 
 Three architectural observations follow from the map:
 
@@ -465,12 +465,18 @@ Three architectural observations follow from the map:
    (`gen-play-snippet`, `recordable-event?`, `make-assertion`,
    `assertion-vocabulary`) are pure data → data; CLJ-testable on the
    JVM without a process-wide install.
-2. **The facade exposes the headline entries only** (six surfaces:
+2. **The facade exposes the headline entries only** (seven surfaces:
    `start-recording!` / `stop-recording!` / `clear-recording!` /
-   `recording?` / `recorder-state` / `gen-play-snippet`). MCP tool
-   builders and hot-reload tooling that need the assertion-picker or
-   the DOM-capture entries `:require` `re-frame.story.recorder`
-   directly — the sub-ns IS the contract for the power-user surface.
+   `recording?` / `recorder-state` / `gen-play-snippet` /
+   `recording->play-script`). The first six are the recorder-lifecycle
+   + simple text-codegen surfaces; the seventh, `recording->play-script`,
+   is re-exported from `re-frame.story.recorder.play-export` as the
+   runtime data→data counterpart `gen-play-snippet` (it is the body the
+   MCP `record-as-variant` write-back registers). MCP tool builders and
+   hot-reload tooling that need the assertion-picker, the DOM-capture
+   entries, or the render-to-EDN fns `:require`
+   `re-frame.story.recorder` (or its `play-export` sub-ns) directly —
+   the sub-ns IS the contract for the rest of the power-user surface.
 3. **The rich DOM-aware translator is the power-user surface.**
    `gen-play-snippet` emits the simple-projection public `:script` body
    (each captured event wrapped as `[:dispatch-sync <ev>]`). The

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -246,14 +246,17 @@ The pure runner lives at
 ## Recorder facade
 
 The recorder captures canvas-dispatched events into a play body for
-codegen back into a `reg-variant` snippet. The emitted EDN uses the
-transitional `:play-script` spelling the registrar lowers; `:script` is
-the public phase-4 key authors target (spec/017 §Public vocabulary).
-The facade exposes six entries on `re-frame.story` (per spec/005
-§Recorder + [001-Authoring.md](001-Authoring.md) §Recorder); the richer
-recorder-driven `:play-script` translator (rf2-d5u89 — derives `:click`
-/ `:type` / `:wait` steps from the recorder's `:entries` stream) lives
-under the recorder's sub-namespace.
+codegen back into a `reg-variant` snippet. The emitted snippet uses the
+PUBLIC `:script` authoring slot (spec/017 §Public vocabulary), not the
+transitional `:play-script` spelling — `gen-play-snippet` renders the
+public spelling so pasted code reads the way the docs teach (rf2-7mj4z).
+The facade exposes seven entries on `re-frame.story` (per spec/005
+§Recorder + [001-Authoring.md](001-Authoring.md) §Recorder). Six are the
+recorder-lifecycle + simple-codegen surfaces; the seventh,
+`recording->play-script`, is re-exported from the recorder's
+`play-export` sub-namespace as the runtime counterpart to
+`gen-play-snippet` — the live `{:script … :auto-run?}` body the MCP
+write-back path (`record-as-variant`) registers (rf2-x9zsr / rf2-d5u89).
 
 | Fn | Signature | Purpose |
 |---|---|---|
@@ -262,20 +265,23 @@ under the recorder's sub-namespace.
 | `clear-recording!` | `(clear-recording!)` | Drop the buffer + return the recorder to idle. |
 | `recording?` | `(recording?)` | Predicate — is a recording in flight? |
 | `recorder-state` | `(recorder-state)` | Read-only view of the current recorder state map. |
-| `gen-play-snippet` | `(gen-play-snippet events opts)` | Pure codegen: render a captured `events` vector as a `(reg-variant <id> {... :play-script {:script [...]}})` EDN snippet. Each captured event vector is wrapped as `[:dispatch-sync <event-vec>]` (rf2-0wrud). See [005-SOTA-Features.md](005-SOTA-Features.md) §Recorder for the round-trip contract. |
+| `gen-play-snippet` | `(gen-play-snippet events opts)` | Pure codegen → string: render a captured `events` vector as a `(reg-variant <id> {... :script {:script [...]}})` EDN snippet. Emits the PUBLIC `:script` slot (rf2-7mj4z); each captured event vector is wrapped as `[:dispatch-sync <event-vec>]` (rf2-0wrud). See [005-SOTA-Features.md](005-SOTA-Features.md) §Recorder for the round-trip contract. |
+| `recording->play-script` | `(recording->play-script events)` / `(recording->play-script events opts)` | Pure data → data: translate a recording (bare `events` vector OR the rich `:entries` vector) into the live, replayable `{:script [...] :auto-run? bool :name str?}` body a runner executes. The runtime counterpart to `gen-play-snippet`'s text output; the MCP write-back path calls this to re-register the variant with a live `:script` slot. Re-exported from `re-frame.story.recorder.play-export`. |
 
-### Rich-DSL `:play-script` export — out of facade
+### Rich-DSL `:script` translator — sub-namespace home
 
 The richer DOM-capture-aware translator (tagged `:click` / `:type` /
 `:wait` steps derived from the recorder's `:entries` capture stream —
-rf2-d5u89) is exported by **`re-frame.story.recorder.play-export`**
-(sub-namespace; not re-exported through `re-frame.story`). The entry
+rf2-d5u89) lives in **`re-frame.story.recorder.play-export`**. Its entry
 fns are `recording->play-script` (translate captured `:entries` into a
-normalised `:play-script` body map) and `render-play-script` /
-`render-variant-form` (render the map to EDN). The facade exposes only
-`gen-play-snippet` (the simpler event-vector → `:dispatch-sync` step
-projection) as the canonical entry; consumers wanting the rich
-DOM-derived DSL `:require` the sub-namespace directly.
+normalised `:script` body map) and `render-play-script` /
+`render-variant-form` (render the map to EDN, emitting the public
+`:script` slot per rf2-7mj4z). Of these, only `recording->play-script`
+is re-exported on the facade as `re-frame.story/recording->play-script`
+(the MCP write-back convenience); `render-play-script` /
+`render-variant-form` are sub-namespace-only — consumers wanting the
+render-to-EDN surface `:require` `re-frame.story.recorder.play-export`
+directly.
 
 ## Effects (fx) registered by Story
 

--- a/tools/story/test/re_frame/story_recorder_test.clj
+++ b/tools/story/test/re_frame/story_recorder_test.clj
@@ -29,7 +29,8 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story :as story]
             [re-frame.story.async :as async]
-            [re-frame.story.recorder :as recorder]))
+            [re-frame.story.recorder :as recorder]
+            [re-frame.story.recorder.play-export :as play-export]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -655,3 +656,92 @@
           "the rendered public :script body vector unwraps back to the captured events"))
     (story/destroy-variant! :story.recorder/source)
     (recorder/remove-trace-listener!)))
+
+;; ---- rf2-xxnqd: recorder FACADE contract --------------------------------
+;;
+;; Pins the public `re-frame.story` recorder boundary so the docs
+;; (tools/story/spec/API.md §Recorder facade + spec/005 §Recorder) and
+;; the implementation cannot silently drift again. Two failure modes
+;; this guards:
+;;
+;;   1. Accidental facade growth/shrink — a new recorder helper picked
+;;      up by the namespace, or one of the intended seven removed.
+;;   2. Vocabulary drift — `gen-play-snippet` reverting to the
+;;      transitional `:play-script` spelling at the facade level (the
+;;      recorder-ns test pins the ns; this pins the re-export).
+
+(def ^:private intended-recorder-facade-vars
+  "The exact recorder entries the public `re-frame.story` facade is
+  documented to expose (API.md §Recorder facade). Six recorder-lifecycle
+  + simple-codegen surfaces plus `recording->play-script`, the runtime
+  data->data counterpart re-exported from the `play-export` sub-ns for
+  the MCP `record-as-variant` write-back path."
+  '#{start-recording!
+     stop-recording!
+     clear-recording!
+     recording?
+     recorder-state
+     gen-play-snippet
+     recording->play-script})
+
+(deftest facade-exposes-exactly-the-intended-recorder-vars
+  (testing "every documented recorder entry is present + callable on
+            re-frame.story (API.md §Recorder facade)"
+    (doseq [sym intended-recorder-facade-vars]
+      (let [v (ns-resolve 're-frame.story sym)]
+        (is (some? v)
+            (str "re-frame.story/" sym " is missing from the facade"))
+        (is (fn? (deref v))
+            (str "re-frame.story/" sym " is bound to a fn"))))))
+
+(deftest facade-does-not-expose-the-transitional-play-script-alias
+  (testing "no `:play-script`-spelled recorder alias leaked onto the
+            facade — the public spelling is `:script` / the translator
+            is `recording->play-script` (not `gen-play-script` or a
+            `play-script`-named re-export)"
+    (let [public-syms (set (keys (ns-publics 're-frame.story)))]
+      ;; `recording->play-script` is the ONE intentional `play-script`
+      ;; token on the facade (a fn NAME, not the slot spelling); guard
+      ;; that no OTHER var carries the transitional slot spelling.
+      (is (not (contains? public-syms 'gen-play-script))
+          "the codegen fn is `gen-play-snippet`, not `gen-play-script`")
+      (is (not (contains? public-syms 'render-play-script))
+          "render-play-script is sub-namespace-only, not on the facade")
+      (is (not (contains? public-syms 'render-variant-form))
+          "render-variant-form is sub-namespace-only, not on the facade"))))
+
+(deftest facade-gen-play-snippet-emits-public-script-slot
+  (testing "story/gen-play-snippet (the facade re-export) emits the
+            PUBLIC :script slot, NOT the transitional :play-script
+            (rf2-7mj4z) — pinned at the facade, not just the recorder ns"
+    (let [snip (story/gen-play-snippet [[:counter/inc]]
+                                       {:variant-id :story.x/y})]
+      (is (string? snip))
+      (is (str/includes? snip ":script")
+          "the public :script authoring slot is present")
+      (is (not (str/includes? snip ":play-script"))
+          "the transitional :play-script slot is NOT emitted at the facade"))))
+
+(deftest facade-recording->play-script-delegates-to-play-export
+  (testing "story/recording->play-script (the facade re-export) returns
+            the live {:script ... :auto-run?} body the runner executes —
+            the MCP write-back contract (record-as-variant). Both arities
+            resolve through the play-export sub-ns."
+    (let [events    [[:counter/inc] [:counter/by 7]]
+          one-arg   (story/recording->play-script events)
+          two-arg   (story/recording->play-script events {:name "rt"})]
+      (is (map? one-arg) "one-arg returns a play-body map")
+      (is (vector? (:script one-arg)) ":script is the runner step vector")
+      (is (contains? one-arg :auto-run?) ":auto-run? slot present")
+      (is (not (contains? one-arg :play-script))
+          "the body uses the public :script slot, not :play-script")
+      ;; Each captured event becomes a runner dispatch step — the live
+      ;; counterpart to gen-play-snippet's text projection.
+      (is (= 2 (count (:script one-arg)))
+          "two captured events → two runner steps")
+      (is (= "rt" (:name two-arg))
+          "two-arg threads :name through to the play-export sub-ns")
+      ;; Facade and sub-ns produce the SAME body — the re-export is a
+      ;; thin delegation, not a divergent reimplementation.
+      (is (= one-arg (play-export/recording->play-script events))
+          "facade re-export == sub-namespace fn (pure delegation)"))))


### PR DESCRIPTION
## What

Fixes **rf2-xxnqd** — tools/story recorder facade contract drift. The public `re-frame.story` recorder surface, as documented in `tools/story/spec/API.md` and `spec/005-SOTA-Features.md`, disagreed with the implementation in three ways. Reconciled the docs to reality and added a facade contract test so they cannot drift again.

## The drift (impl-grounded)

| Doc claim | Reality (impl line) |
|---|---|
| `gen-play-snippet` emits transitional `:play-script` slot (API.md:249-251, 265) | Emits PUBLIC `:script` slot — `recorder.cljc:198-252` (rf2-7mj4z); pinned by `story_recorder_test.clj:177-187` |
| Facade exposes **six** entries (API.md:252, 005:468) | **Seven** — `story.cljc:1796-1871` defines `start-recording!` / `stop-recording!` / `clear-recording!` / `recording?` / `recorder-state` / `gen-play-snippet` / `recording->play-script` |
| `recording->play-script` NOT re-exported through `re-frame.story` (API.md:267-278); rich translator "not on the facade" (005:457) | Re-exported at `story.cljc:154-160, 1851-1871`; the MCP `record-as-variant` write-back actively calls `story/recording->play-script` (`story-mcp tools/recorder.cljc:99`) |

## Direction chosen

Per the bead's first suggested option: **keep `recording->play-script` on the facade** — it is the documented, actively-consumed MCP write-back convenience (story-mcp's own `002-Tool-Registry.md:566` relies on `re-frame.story/recording->play-script`). The render-to-EDN fns (`render-play-script` / `render-variant-form`) remain sub-namespace-only.

## Changes

- `tools/story/spec/API.md` §Recorder facade — public `:script` spelling, seven-entry table (adds the `recording->play-script` row), corrected sub-namespace prose.
- `tools/story/spec/005-SOTA-Features.md` §Recorder — fixed the rich-translator row (`recording->play-script` IS on the facade), the "seven surfaces" observation, and the seven-row header count.
- `tools/story/test/re_frame/story_recorder_test.clj` — new facade contract section: exact seven-var membership, no `:play-script` alias leak, facade-level `:script` emission, and `story/recording->play-script` == `play-export/recording->play-script` (pure delegation).

No production source changed — `recording->play-script` was already on the facade; only the docs were wrong. story-mcp spec left untouched (its facade-membership claim is accurate).

## Gates (cold)

- `clojure -M:test` (tools/story): 1606 tests, 6020 assertions, 0 failures / 0 errors
- `npm run story:build`: build completed, 0 warnings
- bundle-isolation not required — no facade source change

Closes rf2-xxnqd.
