### PR TITLE
refactor(xray): re-sync :rf.error/no-such-sub consumers to spec/009 shape (rf2-qn9ss)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -697,10 +697,20 @@ Common keys (`:category`, `:failing-id`, `:reason`, `:frame`) are inherited from
    [:exception-message :string]])
 
 (def NoSuchSubTags
+  ;; Per Spec 009 §Error catalogue (`:rf.error/no-such-sub`) + the emit
+  ;; site in `re-frame.subs/build-and-cache-sub` (rf2-agpv2.3): the tags
+  ;; are `:rf.sub/id` (the unregistered sub being subscribed),
+  ;; `:unresolved-input` (the full query-vector that failed to resolve),
+  ;; and `:resolved-inputs` (the `:<-` inputs resolved before the miss —
+  ;; empty, since the miss is detected on the `sub-meta` lookup before any
+  ;; input is resolved). Re-synced from the pre-agpv2.3 `:rf.sub/query-v`
+  ;; shape (rf2-qn9ss).
   [:map
-   [:category      :keyword]            ;; [:= :rf.error/no-such-sub] in a closed schema
-   [:rf.sub/query-v [:vector :any]]
-   [:frame         {:optional true} :keyword]])
+   [:category         :keyword]         ;; [:= :rf.error/no-such-sub] in a closed schema
+   [:rf.sub/id        :keyword]
+   [:unresolved-input [:vector :any]]
+   [:resolved-inputs  [:vector :any]]
+   [:frame            {:optional true} :keyword]])
 
 (def NoSuchHandlerTags
   [:map

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1307,6 +1307,14 @@ Silent-by-default — a clean epoch shows a calm positive state, not an error lo
 Each error carries the responsible handler's source coord (`:rf.trace/trigger-handler`) for
 jump-to-source, and rides the cascade's `:dispatch-id` so the row → Epoch pivot works.
 
+The **short description** lifts a terse per-category detail from the trace event's `:tags`
+(`issues-ribbon-helpers/short-description`, priority order): `:reason` → `:exception-message`
+→ `:rf.event/v` → `:unresolved-input` → `:failing-id` → `:path` → bare-op fallback. The
+`:unresolved-input` slot is the `:rf.error/no-such-sub` row's failing query-vector — re-synced
+(rf2-qn9ss) from the legacy `:rf.sub/query-v` to spec/009's
+`{:rf.sub/id :unresolved-input :resolved-inputs}` catalogue shape after agpv2.3 (#3107) re-shaped
+the `re-frame.subs` emit; the legacy slot is no longer read.
+
 ### §8.4 Cross-panel navigation
 
 | Click | Navigates to |

--- a/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon_helpers.cljc
@@ -224,9 +224,15 @@
     1. `[:tags :reason]`           — most categories carry this
     2. `[:tags :exception-message]` — handler / fx exceptions
     3. `[:tags :rf.event/v]`        — dispatched event vector
-    4. `[:tags :failing-id]`        — registrar miss / effect-map shape
-    5. `[:tags :path]`              — schema validation
-    6. `(str operation)` only — fallback
+    4. `[:tags :unresolved-input]`  — `:rf.error/no-such-sub` (the query
+                                      vector that failed to resolve; per
+                                      Spec 009 §Error catalogue +
+                                      `re-frame.subs` emit, rf2-agpv2.3 /
+                                      rf2-qn9ss — re-synced from the
+                                      pre-agpv2.3 `:rf.sub/query-v` slot)
+    5. `[:tags :failing-id]`        — registrar miss / effect-map shape
+    6. `[:tags :path]`              — schema validation
+    7. `(str operation)` only — fallback
 
   Pure data → string; JVM-testable."
   [{:keys [operation tags] :as _ev}]
@@ -235,6 +241,9 @@
                    (:exception-message tags)
                    (when (vector? (:rf.event/v tags))
                      (pr-str (:rf.event/v tags)))
+                   (when (some? (:unresolved-input tags))
+                     (try (pr-str (:unresolved-input tags))
+                          (catch #?(:clj Throwable :cljs :default) _ nil)))
                    (when (some? (:failing-id tags))
                      (str (:failing-id tags)))
                    (when (some? (:path tags))

--- a/tools/xray/test/day8/re_frame2_xray/panels/issues_ribbon_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/issues_ribbon_helpers_cljs_test.cljc
@@ -497,6 +497,42 @@
            (h/short-description
              (error-ev 1 :rf.error/handler-exception {:tags {}}))))))
 
+(deftest short-description-surfaces-no-such-sub-under-spec-009-shape
+  ;; rf2-qn9ss — agpv2.3 (#3107) re-shaped the `:rf.error/no-such-sub`
+  ;; emit tags from the legacy `{:rf.sub/query-v _}` to spec/009's
+  ;; `{:rf.sub/id _ :unresolved-input _ :resolved-inputs _ :frame _}`
+  ;; (verified against the `re-frame.subs` emit site). The ribbon's
+  ;; description reader now reads `:unresolved-input` so the row surfaces
+  ;; WHICH sub failed to resolve, rather than the bare op keyword.
+  (testing "the failing sub's query-vector is lifted from :unresolved-input"
+    (let [ev   (error-ev 1 :rf.error/no-such-sub
+                         {:tags {:rf.sub/id        :cart/total
+                                 :unresolved-input [:cart/total]
+                                 :resolved-inputs  []
+                                 :frame            :rf/default}})
+          desc (h/short-description ev)]
+      (is (re-find #":cart/total" desc)
+          "the unresolved sub query-vector reads into the description")
+      (is (re-find #":rf.error/no-such-sub" desc)
+          "the operation keyword still leads the line")))
+  (testing "the legacy :rf.sub/query-v slot is NOT read — it is no longer
+            emitted post-agpv2.3, so a description carrying ONLY the legacy
+            slot falls through to the bare-op fallback (regression guard)"
+    (is (= ":rf.error/no-such-sub"
+           (h/short-description
+             (error-ev 1 :rf.error/no-such-sub
+                       {:tags {:rf.sub/query-v [:cart/total]}})))))
+  (testing "project-issue round-trips a no-such-sub error into a row whose
+            description names the unresolved sub"
+    (let [row (h/project-issue
+                (error-ev 7 :rf.error/no-such-sub
+                          {:tags {:rf.sub/id        :cart/items
+                                  :unresolved-input [:cart/items]
+                                  :resolved-inputs  []}}))]
+      (is (= :error (:severity row)))
+      (is (= "no-such-sub" (:category row)))
+      (is (re-find #":cart/items" (:description row))))))
+
 ;; ---- (13) source-coord ------------------------------------------
 
 (deftest source-coord-projection


### PR DESCRIPTION
## What

agpv2.3 (#3107) re-shaped the `:rf.error/no-such-sub` emit tags from the legacy `{:rf.sub/query-v :frame}` to spec/009's catalogue shape `{:rf.sub/id :unresolved-input :resolved-inputs :frame}`. Two downstream consumers still carried the old shape and lagged. This re-syncs both.

**Verified emit shape** (`implementation/core/src/re_frame/subs.cljc`, the agpv2.3 site):
```clojure
(trace/emit-error! :rf.error/no-such-sub
                   {:rf.sub/id        query-id
                    :unresolved-input query-v
                    :resolved-inputs  []
                    :frame            frame-id})
```
Matches spec/009 §Error catalogue (`:rf.sub/id`, `:unresolved-input`, `:resolved-inputs`).

## Changes

- **`spec/Spec-Schemas.md` `NoSuchSubTags`** (hot-zone) — replaced the stale `:rf.sub/query-v` slot with `:rf.sub/id` / `:unresolved-input` / `:resolved-inputs`, mirroring the spec/009 catalogue + the emit site.
- **xray issues-ribbon `short-description`** (`tools/xray/src/.../panels/issues_ribbon_helpers.cljc`) — the no-such-sub row now lifts the failing query-vector from `:unresolved-input` (the legacy `:rf.sub/query-v` is no longer emitted → the row previously fell through to the bare op keyword). The reader's priority chain gains an `:unresolved-input` clause.
- **Tests** (`issues_ribbon_helpers_cljs_test.cljc`, runs JVM + node) — a no-such-sub trace renders its unresolved sub under the new shape; the legacy `:rf.sub/query-v`-only slot is NOT read (regression guard); `project-issue` round-trips a no-such-sub row whose description names the sub.
- **`tools/xray/spec/021-Dynamic-Panel-Designs.md` §8.3** — documents the description tag-sourcing chain per the standing xray-spec-current rule.

## Gates (cold)

- xray `clojure -M:test` — 1101 tests, 4532 assertions, 0 failures.
- `npm run test:cljs` — 5650 tests, 19701 assertions, 0 failures.
- `mkdocs build --strict` — built clean (Spec-Schemas in the site).
- `test:xray-feature-gate` — NOT relevant: the feature-matrix browser scenarios carry no `:rf.error/no-such-sub` issues-ribbon case; the changed `short-description` reader is a pure-data fn fully covered by the two unit gates above.

Closes rf2-qn9ss.