### PR TITLE
docs(skills/xray): align Snapshot app-db share guidance to safe egress (rf2-6fgob)

### DIFF
--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -209,11 +209,32 @@ it.
 - **Sharing state with a teammate.** The Share-URL affordance (button +
  modal + `share.cljs` infra) and the per-cascade EDN export were
  **removed** (rf2-nugvv, 2026-06-04 — `share.cljs` and `export/cascade.cljc`
- are deleted). The surviving share unit is the **Snapshot app-db** command
- palette verb (`Cmd/Ctrl+K` → "Snapshot app-db"): it drops the focused
- frame's `app-db` onto the JS console + clipboard for paste-to-a-teammate.
- Source [`palette/sources.cljc`](../../tools/xray/src/day8/re_frame2_xray/palette/sources.cljc)
+ are deleted). The surviving on-box helper is the **Snapshot app-db**
+ command palette verb (`Cmd/Ctrl+K` → "Snapshot app-db"): it puts the
+ focused frame's `app-db` on the JS console + clipboard so a developer can
+ capture the state they're looking at. **The console and the clipboard are
+ off-box egress sinks** — the same trust boundary the rest of the Xray /
+ tool egress story treats as sensitive — so the payload goes through the
+ runtime's safe-egress projection (`runtime/egress-value`), the same
+ fail-closed, default-redaction path `get-app-db` uses: `include-sensitive?`
+ and `include-large?` both default **`false`**, so sensitive slots ship as
+ `:rf/redacted` and large slots as `:rf.size/large-elided` (per
+ [`runtime.cljs`](../../tools/xray/src/day8/re_frame2_xray/runtime.cljs)
+ `egress-value` / `get-app-db`, hardened in rf2-a96xq). Do **not** tell a
+ user this command drops the *raw* `app-db`, and do not present it as a way
+ to copy a secret-bearing value off-box: a focused frame holding
+ `{:auth {:token "secret"}}` (or any schema-/path-declared sensitive value)
+ is redacted in the snapshot by default. Raw capture is only available
+ through an explicit opt-in consistent with the privacy vocabulary — the
+ same `--allow-sensitive-reads` (default **OFF**) plus per-call
+ `:include-sensitive true` posture the AI/MCP read surfaces use (the
+ re-frame2-pair-mcp boundary; see `tools/re-frame2-pair-mcp/`), never the
+ command's default. Source
+ [`palette/sources.cljc`](../../tools/xray/src/day8/re_frame2_xray/palette/sources.cljc)
  (`:snapshot-app-db` command).
+ *(Status: per rf2-6fgob the palette command is being routed through this
+ safe projection; this skill describes the contract the share path MUST
+ honour, so it never teaches a raw off-box share even mid-fix.)*
 
 ---
 


### PR DESCRIPTION
## What

Fixes the privacy-correctness bug in **rf2-6fgob**: the `skills/re-frame2-xray` skill (SKILL.md §"Sharing state with a teammate", lines 209-216) taught the `Snapshot app-db` command palette verb as dropping the focused frame's **raw** app-db onto the JS console + clipboard for paste-to-a-teammate.

The console and clipboard are **off-box egress sinks** — the same trust boundary the rest of the Xray/tool egress story treats as sensitive. Skill guidance is copied verbatim into consumer apps, so teaching a raw off-box drop teaches a leak.

## Change (docs-only)

Rewrote the share guidance to describe the **current (post-rf2-a96xq) default-redaction contract**, verified against the actual tool source:

- The snapshot payload goes through the runtime's named safe-egress projection (`runtime/egress-value`) — the same fail-closed path `get-app-db` uses — with `include-sensitive?` / `include-large?` both defaulting **`false`**: sensitive slots ship as `:rf/redacted`, large slots as `:rf.size/large-elided`.
- A focused frame holding `{:auth {:token "secret"}}` (or any schema-/path-declared sensitive value) is redacted in the snapshot by default.
- Raw capture is only available through the explicit `--allow-sensitive-reads` (default **OFF**) + per-call `:include-sensitive true` opt-in the AI/MCP read surfaces use — never the command's default.
- Adds a short status note pointing at rf2-6fgob for the palette-command implementation fix (owned separately under `tools/xray/`), so the skill describes the contract the share path MUST honour and never teaches a raw share even mid-fix.

Cites verified to exist: `tools/xray/src/day8/re_frame2_xray/runtime.cljs` (`egress-value` / `get-app-db`, rf2-a96xq rationale), `palette/sources.cljc` (`:snapshot-app-db`), `tools/re-frame2-pair-mcp/`.

## Quality gates

Docs-only skill. Correctness bar = guidance matches the actual (post-a96xq) tool egress behaviour, verified by reading the tool source. Skill self-tests pass:

- `check_skill_mcp_drift.py` → exit 0
- `check_skill_redirect_anchors.py` → exit 0
- `check_skill_migration_cites.py` → exit 0

Note: this PR is the **skill-doc** half of rf2-6fgob. The palette-command implementation fix + regression test (acceptance #1/#2, under `tools/xray/`) is a separate surface tracked by the same bead.