### PR TITLE
fix(scripts): harden shell spawns in browser/story/xray gate scripts (rf2-wn4o1)

### DIFF
--- a/implementation/package.json
+++ b/implementation/package.json
@@ -35,7 +35,7 @@
     "test:xray-feature-gate": "node scripts/serve-and-run-xray-feature-gate.cjs",
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_script-spawn-policy.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs && node scripts/dev-testbed.test.cjs",
     "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/*
+ * Source-policy gate: every `implementation/scripts/**` launcher that
+ * spawns a child process must use the HARDENED, shell-free posture
+ * (rf2-wn4o1). Two accident classes are gated here, both static (no
+ * process is spawned by this suite — it reads the script sources and
+ * asserts on their text):
+ *
+ *   1. No `shell: true` / `shell: isWin` on any spawn in these scripts.
+ *      On Windows `shell:true` + a bare exe name (`npx`/`npm`/`clojure`)
+ *      + a repo-controlled `cwd` resolves a workspace-local `.cmd` ahead
+ *      of PATH — the rf2-33vvc command-hijack accident class. It also
+ *      re-introduces the DEP0190 args-concatenation warning/quoting
+ *      class on every Windows launch.
+ *
+ *   2. No bare `npx` / `npx.cmd` passed as the spawn EXECUTABLE. The
+ *      hardened forms spawn the resolved JS entry-point of the tool
+ *      (`require.resolve('shadow-cljs/cli/runner.js')`,
+ *      `require.resolve('http-server/bin/http-server')`) under THIS node
+ *      binary (`process.execPath`), so the only thing the OS interprets
+ *      is an absolute path that is outside the workspace by
+ *      construction. A user-facing copy/paste hint string that mentions
+ *      `npx http-server ...` is fine — it is text the developer types in
+ *      their own shell, never a spawn argument.
+ *
+ *      EXCEPTION: a bare `'npx'` token that is fed to `resolveTrustedExe`
+ *      and spawned via `cross-spawn` (the test-mcp-conformance.cjs
+ *      posture) is the OTHER blessed hardened form — the name is
+ *      resolved to a single trusted absolute path OUTSIDE the workspace
+ *      before any spawn, and cross-spawn dispatches it shell-free. So a
+ *      `'npx'` literal is only a violation in a file that does NOT route
+ *      through resolveTrustedExe + cross-spawn. A `.cmd`-suffixed literal
+ *      (`'npx.cmd'`) is always a violation: the `.cmd` shim only matters
+ *      when you spawn it directly under a shell, which both hardened
+ *      forms avoid.
+ *
+ * The hardened reference patterns already live in dev-testbed.cjs
+ * (shadow-cljs via require.resolve + process.execPath) and
+ * test-mcp-conformance.cjs (resolveTrustedExe + cross-spawn for
+ * system binaries). New launchers must follow one of those.
+ *
+ * Wired into `package.json` via `test:script-policy`.
+ */
+
+const assert = require('assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPTS_DIR = __dirname;
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+// Strip line- and block-comments so the policy assertions match only
+// EXECUTABLE source, not the explanatory comments that necessarily
+// quote the very strings we forbid (`shell: true`, `npx.cmd`, ...).
+// Deliberately simple: this is a residue gate over our own first-party
+// scripts, not a general-purpose JS parser. String literals are left
+// intact so a real `shell: true` hidden in a literal would still trip.
+function stripComments(src) {
+  let out = '';
+  let i = 0;
+  const n = src.length;
+  let inLine = false;
+  let inBlock = false;
+  let inStr = false;
+  let strQuote = '';
+  while (i < n) {
+    const c = src[i];
+    const c2 = src[i + 1];
+    if (inLine) {
+      if (c === '\n') { inLine = false; out += c; }
+      i += 1;
+      continue;
+    }
+    if (inBlock) {
+      if (c === '*' && c2 === '/') { inBlock = false; i += 2; continue; }
+      i += 1;
+      continue;
+    }
+    if (inStr) {
+      out += c;
+      if (c === '\\') { out += c2 == null ? '' : c2; i += 2; continue; }
+      if (c === strQuote) { inStr = false; strQuote = ''; }
+      i += 1;
+      continue;
+    }
+    if (c === '/' && c2 === '/') { inLine = true; i += 2; continue; }
+    if (c === '/' && c2 === '*') { inBlock = true; i += 2; continue; }
+    if (c === '"' || c === "'" || c === '`') {
+      inStr = true; strQuote = c; out += c; i += 1; continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+// Every `.cjs` launcher in the scripts dir (excludes the test suites and
+// the lib/ helpers — the harness lib carries its own taskkill/spawn that
+// is exercised by _local-browser-harness.test.cjs).
+function gateScriptFiles() {
+  return fs
+    .readdirSync(SCRIPTS_DIR)
+    .filter((f) => f.endsWith('.cjs') && !f.endsWith('.test.cjs'))
+    .map((f) => path.join(SCRIPTS_DIR, f));
+}
+
+const SHELL_OPT_RE = /\bshell\s*:\s*(true|isWin)\b/;
+// A `.cmd`-suffixed npx literal — `'npx.cmd'` / `"npx.cmd"`. Always a
+// violation: the Windows `.cmd` shim only ever needs naming when you
+// spawn it directly under a shell, which every hardened form avoids.
+const NPX_CMD_LITERAL_RE = /(['"])npx\.cmd\1/;
+// A bare `'npx'` / `"npx"` literal (no `.cmd`). Only a violation when the
+// file does NOT use the resolveTrustedExe + cross-spawn posture — that
+// posture resolves the name to a trusted absolute path outside the
+// workspace before any shell-free spawn (test-mcp-conformance.cjs).
+const NPX_BARE_LITERAL_RE = /(['"])npx\1/;
+const TRUSTED_EXE_RE = /resolveTrustedExe/;
+const CROSS_SPAWN_RE = /cross-spawn|crossSpawn/;
+
+for (const file of gateScriptFiles()) {
+  const base = path.basename(file);
+  const code = stripComments(fs.readFileSync(file, 'utf8'));
+  const usesTrustedResolution =
+    TRUSTED_EXE_RE.test(code) && CROSS_SPAWN_RE.test(code);
+
+  test(`${base}: no shell:true / shell:isWin spawn (rf2-wn4o1 / rf2-33vvc)`, () => {
+    assert.doesNotMatch(
+      code,
+      SHELL_OPT_RE,
+      `${base} uses shell:true/shell:isWin — spawn shell-free via ` +
+        `process.execPath + a resolved JS entry-point instead (see ` +
+        `dev-testbed.cjs / serve-and-run-xray-feature-gate.cjs).`,
+    );
+  });
+
+  test(`${base}: no 'npx.cmd' spawn executable (rf2-wn4o1)`, () => {
+    assert.doesNotMatch(
+      code,
+      NPX_CMD_LITERAL_RE,
+      `${base} names 'npx.cmd' as a spawn executable — resolve the ` +
+        `tool's JS entry-point with require.resolve(...) and spawn it ` +
+        `under process.execPath (shell-free) instead.`,
+    );
+  });
+
+  test(`${base}: no bare 'npx' spawn executable outside the resolveTrustedExe+cross-spawn posture (rf2-wn4o1)`, () => {
+    if (usesTrustedResolution) return; // blessed: test-mcp-conformance.cjs
+    assert.doesNotMatch(
+      code,
+      NPX_BARE_LITERAL_RE,
+      `${base} names a bare 'npx' executable without the ` +
+        `resolveTrustedExe + cross-spawn posture — either resolve the ` +
+        `tool's JS entry-point and spawn under process.execPath, or ` +
+        `route the name through resolveTrustedExe + cross-spawn.`,
+    );
+  });
+}
+
+// Positive guards: the three scripts the audit (rf2-wn4o1) hardened must
+// keep their resolved-entry-point + process.execPath posture. These pin
+// the fix so a future edit can't quietly regress to npx-under-a-shell.
+test('serve-and-run-browser-tests.cjs resolves http-server + spawns under process.execPath', () => {
+  const src = fs.readFileSync(
+    path.join(SCRIPTS_DIR, 'serve-and-run-browser-tests.cjs'),
+    'utf8',
+  );
+  assert.match(src, /require\.resolve\(\s*['"]http-server\/bin\/http-server['"]/);
+  assert.match(src, /spawnHarnessProcess\(\s*process\.execPath/);
+});
+
+test('story-build.cjs resolves shadow-cljs runner + spawns under process.execPath', () => {
+  const src = fs.readFileSync(path.join(SCRIPTS_DIR, 'story-build.cjs'), 'utf8');
+  assert.match(src, /require\.resolve\(\s*['"]shadow-cljs\/cli\/runner\.js['"]/);
+  assert.match(src, /spawnSync\(\s*process\.execPath/);
+});
+
+test('serve-and-run-xray-feature-gate.cjs resolves shadow-cljs runner + spawns it under process.execPath', () => {
+  const src = fs.readFileSync(
+    path.join(SCRIPTS_DIR, 'serve-and-run-xray-feature-gate.cjs'),
+    'utf8',
+  );
+  assert.match(src, /require\.resolve\(\s*['"]shadow-cljs\/cli\/runner\.js['"]/);
+  // The compile step spawns the resolved runner constant under node.
+  assert.match(src, /spawnSync\(\s*process\.execPath,\s*args/);
+});
+
+// stripComments sanity: it must remove a forbidden token that appears
+// only in a comment, but keep one that appears in real code. Guards the
+// gate itself against false-negatives (a comment masking a live spawn)
+// and false-positives (a comment tripping the policy).
+test('stripComments removes comment text but preserves code', () => {
+  assert.doesNotMatch(stripComments('// shell: true\nconst x = 1;'), SHELL_OPT_RE);
+  assert.doesNotMatch(stripComments('/* npx.cmd */\nconst y = 2;'), NPX_CMD_LITERAL_RE);
+  assert.match(stripComments('spawn({ shell: true });'), SHELL_OPT_RE);
+  assert.match(stripComments("spawn('npx.cmd', args);"), NPX_CMD_LITERAL_RE);
+  assert.match(stripComments("exe: 'npx'"), NPX_BARE_LITERAL_RE);
+  // A quoted literal that merely CONTAINS the substring is preserved.
+  assert.equal(stripComments('const s = "keep // me";'), 'const s = "keep // me";');
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`script-spawn-policy tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(`script-spawn-policy tests: ${tests.length} passed.`);

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -56,6 +56,30 @@ const ROOT = enforcePolicy(
 );
 const INDEX = path.join(ROOT, 'index.html');
 const RUNNER = path.resolve(__dirname, 'run-browser-tests.cjs');
+// Resolve http-server's own JS entry-point so we can spawn it under THIS
+// `node` binary (`process.execPath`) with `shell:false` — never `npx`/
+// `npx.cmd` under a shell (rf2-wn4o1). Spawning the resolved `.js` under
+// `process.execPath` sidesteps both the Windows command-hijack accident
+// class (a workspace-local `npx.cmd` resolving ahead of PATH when
+// `shell:true` + a repo-controlled `cwd` are combined — rf2-33vvc) and
+// the `.cmd`-under-no-shell `EINVAL` that the CVE-2024-27980 mitigation
+// introduced. Same shell-free posture dev-testbed.cjs uses for
+// shadow-cljs and serve-and-run-xray-feature-gate.cjs uses for
+// http-server. Resolution is rooted at IMPL_ROOT (the implementation's
+// local install) regardless of this script's own cwd.
+const IMPL_ROOT = path.resolve(__dirname, '..');
+let HTTP_SERVER_BIN;
+try {
+  HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
+    paths: [IMPL_ROOT],
+  });
+} catch {
+  console.error(
+    'serve-and-run-browser-tests: could not resolve http-server. Run ' +
+      `\`npm install\` in ${IMPL_ROOT} first.`,
+  );
+  process.exit(1);
+}
 const READY_TIMEOUT_MS = 30000;
 const POLL_MS = 200;
 const cleanup = createHarnessCleanup();
@@ -270,13 +294,14 @@ async function waitForReady(port, expectedToken, deadline, state) {
   const port = await resolvePort();
   console.log(`Serving ${ROOT} on http://127.0.0.1:${port}`);
 
-  const isWin = process.platform === 'win32';
-  // On Windows, npx is a .cmd shim — must go through the shell.
-  const httpServerCmd = isWin ? 'npx.cmd' : 'npx';
-  const args = ['http-server', ROOT, '-p', String(port), '-s', '-c-1'];
-  const server = cleanup.trackProcess(spawnHarnessProcess(httpServerCmd, args, {
+  // Spawn http-server shell-free under this node binary (rf2-wn4o1): the
+  // resolved absolute `.js` entry-point is the only thing the OS
+  // interprets, so a workspace-local `npx.cmd` can no longer hijack the
+  // launch, and there is no `shell:true` warning/quoting class.
+  const args = [HTTP_SERVER_BIN, ROOT, '-p', String(port), '-s', '-c-1'];
+  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, args, {
+    cwd: IMPL_ROOT,
     stdio: ['ignore', 'inherit', 'inherit'],
-    shell: isWin,
   }));
 
   // Track the server's lifecycle so the readiness loop can fail fast

--- a/implementation/scripts/serve-and-run-xray-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-xray-feature-gate.cjs
@@ -117,6 +117,15 @@ const { chromium } = require(require.resolve('playwright', {
 const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
   paths: [IMPL_ROOT],
 });
+// Resolve shadow-cljs's own JS entry-point so the compile step spawns it
+// shell-free under THIS node binary (`process.execPath`) — never `npx`/
+// `npx.cmd` under a shell (rf2-wn4o1). Mirrors the http-server resolution
+// just above and the shell-free spawn the server launch already uses.
+// Sidesteps the Windows command-hijack accident class (rf2-33vvc) and the
+// `.cmd`-under-no-shell `EINVAL` from the CVE-2024-27980 mitigation.
+const SHADOW_CLJS_RUNNER = require.resolve('shadow-cljs/cli/runner.js', {
+  paths: [IMPL_ROOT],
+});
 const cleanup = createHarnessCleanup();
 cleanup.addCleanup(removeOwnershipToken);
 cleanup.installSignalHandlers();
@@ -151,16 +160,17 @@ function cleanAndStageRoot() {
 
 function compileSurfaces() {
   const builds = [...new Set(ACTIVE_SURFACES.map((surface) => surface.build))];
-  const isWin = process.platform === 'win32';
-  const cmd = isWin ? 'npx.cmd' : 'npx';
-  const args = ['shadow-cljs', 'compile', ...builds];
-  const result = spawnSync(cmd, args, {
+  // Spawn shadow-cljs shell-free under this node binary (rf2-wn4o1): the
+  // resolved absolute `.js` runner is the only thing the OS interprets,
+  // so a workspace-local `npx.cmd` can no longer hijack the compile and
+  // there is no `shell:true` warning/quoting class.
+  const args = [SHADOW_CLJS_RUNNER, 'compile', ...builds];
+  const result = spawnSync(process.execPath, args, {
     cwd: IMPL_ROOT,
     stdio: 'inherit',
-    shell: isWin,
   });
   if (result.status !== 0) {
-    console.error(`> ${cmd} ${args.join(' ')}`);
+    console.error(`> shadow-cljs compile ${builds.join(' ')}`);
     throw new Error(`shadow-cljs compile failed (exit ${result.status})`);
   }
 }

--- a/implementation/scripts/story-build.cjs
+++ b/implementation/scripts/story-build.cjs
@@ -101,14 +101,32 @@ const HTML_SRC = enforcePolicy(
 );
 
 function release() {
-  const isWin = process.platform === 'win32';
-  const cmd = isWin ? 'npx.cmd' : 'npx';
-  const args = ['shadow-cljs', 'release', BUILD_TARGET];
-  console.log(`> ${cmd} ${args.join(' ')}`);
-  const result = spawnSync(cmd, args, {
+  // Spawn shadow-cljs shell-free under THIS node binary (rf2-wn4o1):
+  // resolve shadow-cljs's own JS entry-point and run it via
+  // `process.execPath` with `shell:false` — never `npx`/`npx.cmd` under a
+  // shell. This sidesteps both the Windows command-hijack accident class
+  // (a workspace-local `npx.cmd` resolving ahead of PATH under
+  // `shell:true` + a repo-controlled `cwd` — rf2-33vvc) and the
+  // `.cmd`-under-no-shell `EINVAL` from the CVE-2024-27980 mitigation.
+  // Same posture dev-testbed.cjs uses for `shadow-cljs watch`. Resolution
+  // is rooted at IMPL_ROOT so it finds the implementation's local install
+  // regardless of this script's cwd.
+  let shadowRunner;
+  try {
+    shadowRunner = require.resolve('shadow-cljs/cli/runner.js', {
+      paths: [IMPL_ROOT],
+    });
+  } catch {
+    throw new Error(
+      'story-build: could not resolve shadow-cljs. Run `npm install` in ' +
+        `${IMPL_ROOT} first.`,
+    );
+  }
+  const args = [shadowRunner, 'release', BUILD_TARGET];
+  console.log(`> shadow-cljs release ${BUILD_TARGET}`);
+  const result = spawnSync(process.execPath, args, {
     cwd: IMPL_ROOT,
     stdio: 'inherit',
-    shell: isWin,
   });
   if (result.status !== 0) {
     throw new Error(`shadow-cljs release ${BUILD_TARGET} failed (exit ${result.status})`);


### PR DESCRIPTION
## What

Hardens the three `implementation/scripts/**` launchers that still spawned `shadow-cljs` / `http-server` via a bare `npx.cmd` under `shell: isWin`, and adds a static source-policy gate so the posture can not regress.

## Why

On Windows `shell: true`/`shell: isWin` + a bare exe name (`npx`/`npx.cmd`) + a repo-controlled `cwd` resolves a workspace-local `npx.cmd` **ahead of PATH** — the rf2-33vvc command-hijack accident class. The same form also re-introduces the DEP0190 args-concatenation warning/quoting class that `dev-testbed.cjs` deliberately removed. This is the substantive remainder of the rf2-wn4o1 senior-review finding #1.

## How

Replace all three with the shell-free posture already used by `dev-testbed.cjs` (and by the Xray gate's own `http-server` launch): resolve the tool's JS entry-point (`shadow-cljs/cli/runner.js`, `http-server/bin/http-server`) via `require.resolve` and spawn it under `process.execPath` with **no shell**. The only thing the OS interprets is an absolute path outside the workspace by construction — both the hijack class and the `.cmd`-under-no-shell `EINVAL` (CVE-2024-27980 mitigation) are sidestepped, cross-platform.

- `serve-and-run-browser-tests.cjs` — `http-server` via resolved bin + `process.execPath` (the runner spawn was already shell-free).
- `story-build.cjs` — `shadow-cljs release` via resolved runner + `process.execPath`.
- `serve-and-run-xray-feature-gate.cjs` — `shadow-cljs compile` via resolved runner + `process.execPath` (server launch was already hardened).

New `_script-spawn-policy.test.cjs` (wired into `test:script-policy`): a static gate over every `.cjs` launcher in the dir asserting no `shell:true`/`shell:isWin` and no `npx.cmd`/bare-`npx` spawn executable, with the `test-mcp-conformance.cjs` `resolveTrustedExe` + `cross-spawn` posture explicitly exempted (it resolves the name to a trusted absolute path before a shell-free spawn), plus positive guards pinning the three hardened scripts.

## Dedup note

The port-validation half of the bead (`BROWSER_TEST_PORT=0` / `XRAY_FEATURE_GATE_PORT=0` rejection, the `1..65535` `isValidExplicitPort` contract) was already landed by **rf2-0u8kz (#3130)** in `lib/local-browser-harness.cjs` + `serve-and-run-browser-tests.cjs`. Verified in place; not re-done.

## Verification

- `npm run test:script-policy` green (incl. 52 new script-spawn-policy assertions).
- `npm run test:script-helpers` green.
- Smoke: `http-server --version` (-> `v14.1.1`, exit 0) and `shadow-cljs --help` (exit 0) launch correctly under `process.execPath` shell-free on Windows.

Closes rf2-wn4o1.
