### PR TITLE
fix(security): seal two egress-redaction leaks at the off-box boundary (rf2-wm9kp)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -251,40 +251,138 @@
                       :hint     "Add `{:large? true}` to the schema slot for this path."
                       :recovery :no-recovery})))))
 
+;; ---- collection-coordinate declaration matching (rf2-wm9kp) ---------------
+;;
+;; Schema-derived declarations are INDEX-FREE: the schema walker descends
+;; positional/keyed containers (`:vector` / `:sequential` / `:set` /
+;; `:map-of`) at the SAME base-path (walker.cljc ~L145), because a vector
+;; index or a `:map-of` key is not a declarable app-db slot. So a schema
+;; `[:items] [:vector [:map [:token {:sensitive? true} :string]]]` declares
+;; the index-free path `[:items :token]`, while the runtime value lives at
+;; the INDEXED path `[:items 0 :token]` (and a `:map-of` value lives at the
+;; KEYED path `[:by-id "a" :secret]` against decl `[:by-id :secret]`).
+;;
+;; The wire-elision walker walks a RUNTIME value, so it sees the indexed /
+;; keyed paths. To match the index-free declarations without re-walking the
+;; schema (the walker doesn't carry it), we thread a SET of candidate
+;; declaration-coordinate paths alongside the concrete runtime path:
+;;
+;;   - Descending a VECTOR / SEQ / SET element: the index/element is a
+;;     collection coordinate, NOT a declarable segment ⇒ candidate decl-
+;;     paths pass through UNCHANGED.
+;;   - Descending a MAP key `k`: a runtime map is structurally ambiguous —
+;;     `k` may be a NAMED `:map` slot (a real segment ⇒ `(conj c k)`) OR a
+;;     `:map-of` key (a collection coordinate ⇒ `c` unchanged). We can't tell
+;;     which from the value alone, so we fork each candidate into BOTH
+;;     interpretations and let the declaration table disambiguate at the leaf
+;;     (only the interpretation that actually matches a declared path fires).
+;;
+;; The fork would grow combinatorially with map depth, so we PRUNE: a
+;; candidate that is not a prefix of ANY declared path can never match and is
+;; dropped. `decl-prefixes` (all prefixes of every sensitive ∪ large decl
+;; path) bounds the live candidate set to the declaration cardinality — tiny
+;; in practice, and empty (so zero overhead) when nothing is declared.
+;;
+;; Precision: the runtime path `[:by-id "a" :secret]` matches decl
+;; `[:by-id :secret]` only because `:secret` is a real map slot under the
+;; `:map-of` value; a sibling NON-sensitive leaf `[:by-id "a" :other]` never
+;; matches (its decl-coordinate candidates `[:by-id :other]` / `[:by-id "a"
+;; :other]` aren't declared). The concrete runtime `path` still drives marker
+;; `:path` / `:handle` and the unschema'd-large warning, so an agent's
+;; follow-up `get-path` lands on the exact indexed location.
+
 (declare walk marker?)
 
+(defn- prefixes
+  "All non-empty prefixes (including the full path) of `path`, as a set.
+  Used to seed `decl-prefixes` so the candidate decl-path fork can be
+  pruned to paths that could still reach a declaration."
+  [path]
+  (into #{} (map #(subvec path 0 %)) (range 1 (inc (count path)))))
+
+(defn- decl-prefix-set
+  "Build the set of every prefix of every declared path (sensitive ∪
+  large). A candidate declaration-coordinate path is kept alive during the
+  walk only while it is a member of this set — anything outside it can
+  never reach a declaration, so dropping it is matching-safe and keeps the
+  forked candidate set bounded by the declaration cardinality."
+  [ctx]
+  (into #{}
+        (mapcat prefixes)
+        (concat (keys (:sensitive ctx)) (keys (:large ctx)))))
+
+(defn- fork-decl-paths
+  "Descend the candidate declaration-coordinate set through a MAP key `k`.
+  Each candidate forks into the NAMED-slot interpretation `(conj c k)` and
+  the `:map-of`-key interpretation `c` (key is a collection coordinate, no
+  segment). Both are retained only when they remain a prefix of some
+  declared path (`decl-prefixes`), bounding the set."
+  [decl-paths k decl-prefixes]
+  (persistent!
+    (reduce (fn [acc c]
+              (let [named (conj c k)
+                    acc   (if (contains? decl-prefixes named) (conj! acc named) acc)]
+                ;; `:map-of`-key interpretation: `c` itself stays a live
+                ;; candidate so a LATER real `:map` segment can extend it
+                ;; (e.g. `[:by-id]` survives the map-of key `"a"` so the
+                ;; subsequent `:secret` can form `[:by-id :secret]`). `c` is
+                ;; already a known decl-prefix (it survived the round that
+                ;; produced it), except the seed `[]` which never matches a
+                ;; declaration (decls have ≥1 segment) so retaining it is
+                ;; harmless. The set thus stays bounded by `decl-prefixes`.
+                (conj! acc c)))
+            (transient #{})
+            decl-paths)))
+
+(defn- decl-match
+  "Test the candidate declaration-coordinate set against a declaration
+  table `tbl` (`:sensitive` or `:large`). Returns the matched declaration
+  value (truthy) for the FIRST candidate present in `tbl`, or nil. For the
+  sensitive table any present entry suffices (membership); for the large
+  table the entry is the marker-hint declaration map."
+  [decl-paths tbl]
+  (some #(get tbl %) decl-paths))
+
+(defn- decl-sensitive?
+  [decl-paths sensitive-tbl]
+  (boolean (some #(contains? sensitive-tbl %) decl-paths)))
+
 (defn- walk-map
-  [m path ctx]
-  (reduce-kv
-    (fn [acc k v]
-      (assoc acc k (walk v (conj path k) ctx)))
-    (empty m)
-    m))
+  [m path decl-paths ctx]
+  (let [decl-prefixes (:decl-prefixes ctx)]
+    (reduce-kv
+      (fn [acc k v]
+        (assoc acc k (walk v
+                           (conj path k)
+                           (fork-decl-paths decl-paths k decl-prefixes)
+                           ctx)))
+      (empty m)
+      m)))
 
 (defn- walk-indexed
-  [v path ctx]
+  [v path decl-paths ctx]
   (let [n (count v)]
     (loop [i 0 acc (transient [])]
       (if (< i n)
         (recur (inc i)
-               (conj! acc (walk (nth v i) (conj path i) ctx)))
+               (conj! acc (walk (nth v i) (conj path i) decl-paths ctx)))
         (persistent! acc)))))
 
 (defn- walk-seq
-  [xs path ctx]
+  [xs path decl-paths ctx]
   (let [idx (volatile! -1)]
     (persistent!
       (reduce (fn [acc v]
                 (vswap! idx inc)
-                (conj! acc (walk v (conj path @idx) ctx)))
+                (conj! acc (walk v (conj path @idx) decl-paths ctx)))
               (transient [])
               xs))))
 
 (defn- walk
-  [v path ctx]
+  [v path decl-paths ctx]
   (let [path        (vec path)
-        large-decl  (get-in ctx [:large path])
-        sensitive?  (contains? (:sensitive ctx) path)
+        large-decl  (decl-match decl-paths (:large ctx))
+        sensitive?  (decl-sensitive? decl-paths (:sensitive ctx))
         include-lg? (:include-large? ctx)
         include-s?  (:include-sensitive? ctx)]
     (cond
@@ -309,16 +407,19 @@
                           :include-digests? (:include-digests? ctx)}))
 
       (map? v)
-      (walk-map v path ctx)
+      (walk-map v path decl-paths ctx)
 
       (vector? v)
-      (walk-indexed v path ctx)
+      (walk-indexed v path decl-paths ctx)
 
       (set? v)
-      (into #{} (map #(walk % path ctx)) v)
+      ;; Set elements are nameless collection coordinates — the runtime
+      ;; `path` and the candidate decl-paths both pass through unchanged
+      ;; (mirrors `:vector`/`:sequential`: the element is not a segment).
+      (into #{} (map #(walk % path decl-paths ctx)) v)
 
       (seq? v)
-      (walk-seq v path ctx)
+      (walk-seq v path decl-paths ctx)
 
       :else
       (do
@@ -345,15 +446,26 @@
          ;; Precedence (API.md L507): explicit opt > configured > default.
          threshold (let [opt (:rf.size/threshold-bytes opts)]
                      (if (some? opt) opt (configured-threshold-bytes)))
+         large     (or (:declarations reg) {})
+         sensitive (or (:sensitive-declarations reg) {})
          ctx       {:frame-id           frame-id
-                    :large              (or (:declarations reg) {})
-                    :sensitive          (or (:sensitive-declarations reg) {})
+                    :large              large
+                    :sensitive          sensitive
+                    ;; Prefix set of every declared path — bounds the forked
+                    ;; candidate decl-path set as the walker descends maps
+                    ;; (rf2-wm9kp). Empty when nothing is declared ⇒ the fork
+                    ;; prunes to {} immediately and the walker is identity.
+                    :decl-prefixes      (decl-prefix-set {:large large :sensitive sensitive})
                     :include-large?     (true? (:rf.size/include-large? opts))
                     :include-sensitive? (true? (:rf.size/include-sensitive? opts))
                     :include-digests?   (true? (:rf.size/include-digests? opts))
                     :threshold-bytes    threshold
-                    :as-of-epoch        (:as-of-epoch opts)}]
-     (walk v (vec (:path opts)) ctx))))
+                    :as-of-epoch        (:as-of-epoch opts)}
+         seed-path (vec (:path opts))]
+     ;; Seed the candidate declaration-coordinate set with the offset path
+     ;; (`#{[]}` for the common no-offset call). The walk forks/prunes it
+     ;; against `:decl-prefixes` on every map-key descent.
+     (walk v seed-path #{seed-path} ctx))))
 
 (defn marker?
   [v]

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -267,15 +267,29 @@
 ;; schema (the walker doesn't carry it), we thread a SET of candidate
 ;; declaration-coordinate paths alongside the concrete runtime path:
 ;;
-;;   - Descending a VECTOR / SEQ / SET element: the index/element is a
-;;     collection coordinate, NOT a declarable segment ⇒ candidate decl-
-;;     paths pass through UNCHANGED.
+;;   - Descending a VECTOR / SEQ element at index `i`: the index is
+;;     UNAMBIGUOUSLY a collection coordinate (never a named slot), so each
+;;     candidate forks into the INDEX-FREE interpretation `c` (unchanged —
+;;     matches schema decls that descend positional containers at the same
+;;     base-path) AND the LITERAL-INDEX interpretation `(conj c i)` (matches
+;;     a declaration that itself pins a concrete index, e.g. `[:tokens 0]`),
+;;     the latter pruned by `decl-prefixes` (see `fork-index-paths`).
+;;     Riding an index never floats a declaration past a NAMED slot, so the
+;;     index-free interpretation is kept for ALL candidates (incl. the empty
+;;     seed) without the map-key skip's position guard. A SET element has no
+;;     stable index ⇒ index-free pass-through only.
 ;;   - Descending a MAP key `k`: a runtime map is structurally ambiguous —
 ;;     `k` may be a NAMED `:map` slot (a real segment ⇒ `(conj c k)`) OR a
 ;;     `:map-of` key (a collection coordinate ⇒ `c` unchanged). We can't tell
 ;;     which from the value alone, so we fork each candidate into BOTH
 ;;     interpretations and let the declaration table disambiguate at the leaf
 ;;     (only the interpretation that actually matches a declared path fires).
+;;     The `:map-of`-key (skip) fork is POSITION-PRECISE: only a NON-EMPTY
+;;     candidate — one that has already consumed ≥1 declared segment — may
+;;     skip a key. The empty seed `[]` advances only via the named fork (see
+;;     `fork-decl-paths`), so a declaration cannot FLOAT past leading named
+;;     map slots and falsely match the same key-sequence at a deeper,
+;;     non-declared position.
 ;;
 ;; The fork would grow combinatorially with map depth, so we PRUNE: a
 ;; candidate that is not a prefix of ANY declared path can never match and is
@@ -285,10 +299,15 @@
 ;;
 ;; Precision: the runtime path `[:by-id "a" :secret]` matches decl
 ;; `[:by-id :secret]` only because `:secret` is a real map slot under the
-;; `:map-of` value; a sibling NON-sensitive leaf `[:by-id "a" :other]` never
-;; matches (its decl-coordinate candidates `[:by-id :other]` / `[:by-id "a"
-;; :other]` aren't declared). The concrete runtime `path` still drives marker
-;; `:path` / `:handle` and the unschema'd-large warning, so an agent's
+;; `:map-of` value (`[:by-id]` is a non-empty partial match, so it legally
+;; skips the map-of key `"a"`); a sibling NON-sensitive leaf
+;; `[:by-id "a" :other]` never matches (its decl-coordinate candidates
+;; `[:by-id :other]` / `[:by-id "a" :other]` aren't declared). And decl
+;; `[:auth :password]` does NOT match the deeper `[:tags :some-other-slot
+;; :auth :password]`: the `[]` seed cannot skip the leading `:tags` /
+;; `:some-other-slot` named slots, so it never reaches the same-named `:auth`
+;; at that non-declared position. The concrete runtime `path` still drives
+;; marker `:path` / `:handle` and the unschema'd-large warning, so an agent's
 ;; follow-up `get-path` lands on the exact indexed location.
 
 (declare walk marker?)
@@ -316,20 +335,73 @@
   Each candidate forks into the NAMED-slot interpretation `(conj c k)` and
   the `:map-of`-key interpretation `c` (key is a collection coordinate, no
   segment). Both are retained only when they remain a prefix of some
-  declared path (`decl-prefixes`), bounding the set."
+  declared path (`decl-prefixes`), bounding the set.
+
+  POSITION-PRECISE skip (rf2-wm9kp follow-up): the `:map-of`-key
+  interpretation — keeping `c` unchanged so the key is treated as a
+  collection coordinate — is only legitimate for a candidate that has
+  ALREADY consumed at least one declared segment (`(seq c)`). A non-empty
+  `c` is a partial declaration-prefix match in progress, so a map key at
+  that position can plausibly be a `:map-of` value key inside that
+  declared subtree (e.g. `[:by-id]` skips the map-of key `\"a\"` so the
+  subsequent `:secret` forms `[:by-id :secret]`). The EMPTY seed `[]` has
+  matched nothing yet: letting it skip a key would let a declaration
+  FLOAT past arbitrary leading NAMED map slots — matching decl
+  `[:auth :password]` against the deeper `[:tags :some-other-slot :auth
+  :password]` where that `:auth`/`:password` is a DIFFERENT position, not
+  the declared one. So `[]` advances only via the named-slot fork; it
+  never survives as a free-floating skip. This keeps the headline goal
+  green (`[:items 0 :token]` matches `[:items :token]`; `[:by-id \"a\"
+  :secret]` matches `[:by-id :secret]`) while sealing the over-redaction
+  of same-named slots at non-declared positions."
   [decl-paths k decl-prefixes]
   (persistent!
     (reduce (fn [acc c]
               (let [named (conj c k)
                     acc   (if (contains? decl-prefixes named) (conj! acc named) acc)]
-                ;; `:map-of`-key interpretation: `c` itself stays a live
-                ;; candidate so a LATER real `:map` segment can extend it
-                ;; (e.g. `[:by-id]` survives the map-of key `"a"` so the
-                ;; subsequent `:secret` can form `[:by-id :secret]`). `c` is
+                ;; `:map-of`-key interpretation: `c` stays a live candidate
+                ;; ONLY when it is a non-empty partial match — see the
+                ;; position-precise rationale in the docstring. `c` is
                 ;; already a known decl-prefix (it survived the round that
-                ;; produced it), except the seed `[]` which never matches a
-                ;; declaration (decls have ≥1 segment) so retaining it is
-                ;; harmless. The set thus stays bounded by `decl-prefixes`.
+                ;; produced it), so retaining it keeps the set bounded by
+                ;; `decl-prefixes`.
+                (if (seq c) (conj! acc c) acc)))
+            (transient #{})
+            decl-paths)))
+
+(defn- fork-index-paths
+  "Descend the candidate declaration-coordinate set through a VECTOR / SEQ
+  element at integer index `i`.
+
+  An element index is UNAMBIGUOUSLY a collection coordinate — unlike a map
+  key, it can never be a named app-db slot. So a vector/seq descent forks
+  each candidate into:
+
+    - the INDEX-FREE interpretation `c` (unchanged): a schema-derived decl
+      descends positional containers at the same base-path, so the
+      index-free `[:items :token]` matches the runtime `[:items 0 :token]`.
+      Retained for ALL candidates (including the empty seed `[]`): riding
+      an index through never floats a declaration past a NAMED slot, so it
+      cannot over-redact the way the map-key skip could.
+
+    - the LITERAL-INDEX interpretation `(conj c i)`: a declaration MAY
+      itself carry a concrete index (`[:tokens 0]`, declared directly
+      against the indexed runtime position rather than schema-derived).
+      Retained only while it remains a prefix of some declared path
+      (`decl-prefixes`), so it is dropped immediately when no decl pins
+      that index — keeping the set bounded.
+
+  Both interpretations are matching-safe: the index-free one matches
+  schema decls, the literal-index one matches directly-declared indexed
+  paths, and only the interpretation actually present in the declaration
+  table fires at the leaf."
+  [decl-paths i decl-prefixes]
+  (persistent!
+    (reduce (fn [acc c]
+              (let [indexed (conj c i)
+                    acc     (if (contains? decl-prefixes indexed)
+                              (conj! acc indexed) acc)]
+                ;; Index-free interpretation: pass `c` through unchanged.
                 (conj! acc c)))
             (transient #{})
             decl-paths)))
@@ -361,20 +433,28 @@
 
 (defn- walk-indexed
   [v path decl-paths ctx]
-  (let [n (count v)]
+  (let [decl-prefixes (:decl-prefixes ctx)
+        n             (count v)]
     (loop [i 0 acc (transient [])]
       (if (< i n)
         (recur (inc i)
-               (conj! acc (walk (nth v i) (conj path i) decl-paths ctx)))
+               (conj! acc (walk (nth v i)
+                                (conj path i)
+                                (fork-index-paths decl-paths i decl-prefixes)
+                                ctx)))
         (persistent! acc)))))
 
 (defn- walk-seq
   [xs path decl-paths ctx]
-  (let [idx (volatile! -1)]
+  (let [decl-prefixes (:decl-prefixes ctx)
+        idx           (volatile! -1)]
     (persistent!
       (reduce (fn [acc v]
                 (vswap! idx inc)
-                (conj! acc (walk v (conj path @idx) decl-paths ctx)))
+                (conj! acc (walk v
+                                 (conj path @idx)
+                                 (fork-index-paths decl-paths @idx decl-prefixes)
+                                 ctx)))
               (transient [])
               xs))))
 

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -403,3 +403,130 @@
                    [:user/name]  {:value "Ada" :ref-count 1}}]
     (is (= sub-cache (rf/elide-wire-value sub-cache))
         "No declarations ⇒ walker returns the sub-cache shape verbatim")))
+
+;; ---------------------------------------------------------------------------
+;; Collection-nested schema-declared elision at direct-read egress
+;; (rf2-wm9kp).
+;;
+;; The schema walker emits INDEX-FREE declarations for positional/keyed
+;; containers — `[:items] [:vector [:map [:token {:sensitive? true} :string]]]`
+;; declares `[:items :token]`, NOT `[:items 0 :token]`; a `:map-of` value
+;; `[:by-id] [:map-of :string [:map [:secret {:sensitive? true} :string]]]`
+;; declares `[:by-id :secret]`, NOT `[:by-id "a" :secret]`. The wire-elision
+;; walker walks a RUNTIME value, so it sees the indexed/keyed paths. Before
+;; rf2-wm9kp the walker matched only EXACT concrete runtime paths, so the
+;; declaration never matched and the secret crossed the direct-read MCP
+;; boundary (`get-app-db` / `get-path` / `snapshot`) RAW. The fix threads a
+;; candidate declaration-coordinate set that drops vector indices / map-of
+;; keys, so the index-free declaration matches the indexed/keyed runtime
+;; path. Mirrors the schema-validation-trace alignment (rf2-g5auo's
+;; `schema-sensitive-at?`), but on the runtime value rather than the schema.
+
+(deftest collection-nested-sensitive-vector-of-maps-redacts
+  ;; rf2-wm9kp Finding 1 (the headline leak). WITHOUT the fix
+  ;; `(rf/elide-wire-value {:items [{:token "SECRET"}]})` returned the
+  ;; secret verbatim because decl `[:items :token]` did not match runtime
+  ;; `[:items 0 :token]`.
+  (rf/reg-app-schema [:items]
+                     [:vector [:map [:token {:sensitive? true} :string]]])
+  (is (= [[:items :token]] (rf/populate-sensitive-from-schemas!))
+      "schema walker declares the index-free path")
+  (let [out (rf/elide-wire-value {:items [{:token "SECRET"}
+                                          {:token "SECRET2"}]})]
+    (is (= :rf/redacted (get-in out [:items 0 :token]))
+        "vector-element sensitive slot redacts at direct-read egress")
+    (is (= :rf/redacted (get-in out [:items 1 :token]))
+        "every vector element redacts, not just index 0"))
+  ;; Opt-in escape hatch still passes the raw value (the get-path /
+  ;; snapshot `:rf.size/include-sensitive? true` path).
+  (is (= "SECRET"
+         (get-in (rf/elide-wire-value {:items [{:token "SECRET"}]}
+                                      {:rf.size/include-sensitive? true})
+                 [:items 0 :token]))
+      "include-sensitive? true ⇒ collection-nested sensitive passes raw"))
+
+(deftest collection-nested-sensitive-map-of-redacts
+  ;; rf2-wm9kp Finding 1 — `:map-of` value-map sensitive slot. Decl
+  ;; `[:by-id :secret]` must match runtime `[:by-id "a" :secret]`.
+  (rf/reg-app-schema [:by-id]
+                     [:map-of :string [:map [:secret {:sensitive? true} :string]]])
+  (rf/populate-sensitive-from-schemas!)
+  (let [out (rf/elide-wire-value {:by-id {"a" {:secret "SECRET"}
+                                          "b" {:secret "SECRET2"}}})]
+    (is (= :rf/redacted (get-in out [:by-id "a" :secret])))
+    (is (= :rf/redacted (get-in out [:by-id "b" :secret]))
+        "map-of value-map sensitive slot redacts for every key")))
+
+(deftest collection-nested-sensitive-sequential-redacts
+  ;; rf2-wm9kp Finding 1 — `:sequential` of maps (the runtime value can
+  ;; arrive as a lazy seq / list, not just a vector).
+  (rf/reg-app-schema [:logs]
+                     [:sequential [:map [:pw {:sensitive? true} :string]]])
+  (rf/populate-sensitive-from-schemas!)
+  (let [out (rf/elide-wire-value {:logs (list {:pw "SECRET"})})]
+    (is (= :rf/redacted (-> out :logs vec (get-in [0 :pw])))
+        "sequential-element sensitive slot redacts")))
+
+(deftest collection-nested-sensitive-set-of-maps-redacts
+  ;; rf2-wm9kp Finding 1 — `:set` element maps descend at the same base
+  ;; path (no positional segment), same as vector/sequential.
+  (rf/reg-app-schema [:tags]
+                     [:set [:map [:s {:sensitive? true} :string]]])
+  (rf/populate-sensitive-from-schemas!)
+  (let [out (rf/elide-wire-value {:tags #{{:s "SECRET"}}})]
+    (is (= :rf/redacted (:s (first (:tags out))))
+        "set-element sensitive slot redacts")))
+
+(deftest collection-nested-sensitive-mixed-map-vector-map-redacts
+  ;; rf2-wm9kp Finding 1 — mixed map → vector → map nesting. Decl
+  ;; `[:root :rows :pw]` matches runtime `[:root :rows N :pw]`.
+  (rf/reg-app-schema [:root]
+                     [:map [:rows [:vector [:map [:pw {:sensitive? true} :string]]]]])
+  (rf/populate-sensitive-from-schemas!)
+  (let [out (rf/elide-wire-value {:root {:rows [{:pw "SECRET"} {:pw "SECRET2"}]}})]
+    (is (= :rf/redacted (get-in out [:root :rows 0 :pw])))
+    (is (= :rf/redacted (get-in out [:root :rows 1 :pw])))))
+
+(deftest collection-nested-no-over-redaction-of-sibling-slots
+  ;; rf2-wm9kp Finding 1 — the matcher must be PRECISE: a non-sensitive
+  ;; sibling leaf inside the same collection element map rides verbatim.
+  ;; The candidate-path fork must not blanket-redact the element.
+  (rf/reg-app-schema [:items]
+                     [:vector [:map
+                               [:token {:sensitive? true} :string]
+                               [:name :string]]])
+  (rf/populate-sensitive-from-schemas!)
+  (let [out (rf/elide-wire-value {:items [{:token "SECRET" :name "Ada"}]})]
+    (is (= :rf/redacted (get-in out [:items 0 :token])))
+    (is (= "Ada" (get-in out [:items 0 :name]))
+        "sibling non-sensitive slot is NOT over-redacted")))
+
+(deftest collection-nested-large-emits-marker-with-runtime-path
+  ;; rf2-wm9kp Finding 1 (symmetry) — a `:large?` slot nested under a
+  ;; collection element map emits the `:rf.size/large-elided` marker, and
+  ;; the marker's `:path` is the CONCRETE indexed runtime path so a
+  ;; follow-up `get-path` lands on the exact element.
+  (rf/reg-app-schema [:docs]
+                     [:vector [:map [:blob {:large? true :hint "blob"} :string]]])
+  (rf/populate-elision-from-schemas!)
+  (let [out  (rf/elide-wire-value {:docs [{:blob "<<5MB-blob>>"}]})
+        slot (get-in out [:docs 0 :blob])]
+    (is (elision/marker? slot)
+        "collection-nested :large? slot emits a size marker")
+    (is (= [:docs 0 :blob] (get-in slot [:rf.size/large-elided :path]))
+        "marker :path is the concrete indexed runtime path (re-fetchable)")
+    (is (= "blob" (get-in slot [:rf.size/large-elided :hint])))))
+
+(deftest collection-nested-sensitive-wins-over-large
+  ;; rf2-wm9kp Finding 1 (symmetry) — when a collection-nested slot is
+  ;; BOTH `:large?` and `:sensitive?`, sensitive wins (redact, no marker),
+  ;; same precedence as the top-level `sensitive-wins-over-large` case.
+  (rf/reg-app-schema [:vault]
+                     [:vector [:map [:k {:large? true :sensitive? true} :string]]])
+  (rf/populate-elision-from-schemas!)
+  (rf/populate-sensitive-from-schemas!)
+  (let [out  (rf/elide-wire-value {:vault [{:k "payload"}]})
+        slot (get-in out [:vault 0 :k])]
+    (is (= :rf/redacted slot))
+    (is (not (elision/marker? slot))
+        "sensitive suppresses the large marker even when nested in a vector")))

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -501,6 +501,83 @@
     (is (= "Ada" (get-in out [:items 0 :name]))
         "sibling non-sensitive slot is NOT over-redacted")))
 
+(deftest collection-nested-no-over-redaction-at-non-declared-position
+  ;; rf2-wm9kp follow-up — the candidate-coordinate match must be
+  ;; POSITION-PRECISE, not a free-floating suffix/anywhere match. A decl
+  ;; `[:auth :password]` must NOT redact the SAME key-sequence
+  ;; `:auth :password` when it sits at a DIFFERENT, non-declared position
+  ;; (nested under leading named map slots `:tags :some-other-slot`). The
+  ;; empty seed candidate must not be allowed to skip the leading named
+  ;; slots and resume the declaration deeper in the tree.
+  (rf/reg-app-schema [:auth]
+                     [:map
+                      [:username :string]
+                      [:password {:sensitive? true} :string]])
+  (rf/populate-sensitive-from-schemas!)
+  (let [out (rf/elide-wire-value
+              {;; the DECLARED position — must redact
+               :auth {:username "ada" :password "shh"}
+               ;; a coincidentally same-named subtree at a NON-declared
+               ;; position — must ride through verbatim
+               :tags {:some-other-slot {:auth {:password "scoped-marker"}}}})]
+    (is (= :rf/redacted (get-in out [:auth :password]))
+        "the declared [:auth :password] position still redacts")
+    (is (= "ada" (get-in out [:auth :username]))
+        "the non-sensitive sibling at the declared position is untouched")
+    (is (= "scoped-marker"
+           (get-in out [:tags :some-other-slot :auth :password]))
+        "the same :auth :password key-sequence at a DIFFERENT position is
+         NOT over-redacted — the match is position-precise, not free-floating")))
+
+(deftest collection-nested-map-of-skip-requires-started-match
+  ;; rf2-wm9kp follow-up — the `:map-of`-key SKIP is only granted to a
+  ;; candidate that has ALREADY begun matching the declaration (a non-empty
+  ;; partial prefix). This pins that the legit map-of path keeps working
+  ;; (`[:by-id]` is a non-empty partial match, so it skips the key `"a"`),
+  ;; while a leaf at a NON-declared top-level map key never matches.
+  (rf/reg-app-schema [:by-id]
+                     [:map-of :string [:map [:secret {:sensitive? true} :string]]])
+  (rf/populate-sensitive-from-schemas!)
+  (let [out (rf/elide-wire-value
+              {:by-id   {"a" {:secret "SECRET"}}
+               ;; `:secret` here is a top-level map slot, NOT under :by-id —
+               ;; decl [:by-id :secret] must not float to match it.
+               :secret  "TOP-LEVEL-NOT-DECLARED"})]
+    (is (= :rf/redacted (get-in out [:by-id "a" :secret]))
+        "the declared map-of-nested :secret redacts (skip after started match)")
+    (is (= "TOP-LEVEL-NOT-DECLARED" (get out :secret))
+        "a same-named leaf at a non-declared position is not over-redacted")))
+
+(deftest collection-nested-literal-index-declaration-redacts
+  ;; rf2-wm9kp follow-up — a declaration may carry a CONCRETE integer index
+  ;; (`[:tokens 0]`, declared directly against the indexed runtime position
+  ;; rather than schema-derived index-free). The candidate-coordinate match
+  ;; must still fire for it: the seq/vector descent forks the literal-index
+  ;; interpretation `(conj c i)`. Pins the origin behaviour (exact indexed
+  ;; path match) that the index-free coordinate threading must not regress
+  ;; (the story-mcp derived-tree scrub relies on this exact match).
+  (let [frame-id :rf/default]
+    (re-frame.elision/swap-elision-slot!
+      frame-id
+      (fn [reg]
+        (assoc reg :sensitive-declarations
+               {[:tokens 0] {:sensitive? true :source :test}})))
+    ;; seq form (list) — the shape story-mcp's derived-tree scrub relies on
+    (let [out (rf/elide-wire-value
+                {:tokens (list "SECRET" "public") :other "x"}
+                {:frame frame-id})]
+      (is (= :rf/redacted (-> out :tokens vec (get 0)))
+          "literal-index decl [:tokens 0] redacts the indexed seq element")
+      (is (= "public" (-> out :tokens vec (get 1)))
+          "the non-declared sibling index rides through verbatim"))
+    ;; vector form — same literal-index decl matches the vector element
+    (let [out (rf/elide-wire-value
+                {:tokens ["SECRET" "public"]}
+                {:frame frame-id})]
+      (is (= :rf/redacted (get-in out [:tokens 0])))
+      (is (= "public" (get-in out [:tokens 1]))
+          "only the literally-declared index redacts"))))
+
 (deftest collection-nested-large-emits-marker-with-runtime-path
   ;; rf2-wm9kp Finding 1 (symmetry) — a `:large?` slot nested under a
   ;; collection element map emits the `:rf.size/large-elided` marker, and

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -268,7 +268,26 @@
   contract — re-frame2-pair-mcp passes its union predicate that also catches
   the epoch-level `:sensitive?` rollup (`sensitive-event? OR
   sensitive-epoch?`). The default arity preserves the
-  trace-event-only filter for story-mcp consumers."
+  trace-event-only filter for story-mcp consumers.
+
+  ## Slice-shape discipline + fail-closed (rf2-wm9kp)
+
+  A `:traces` / `:epochs` slice is a SEQUENTIAL batch of trace-event maps
+  (a vector in the typical runtime emission, or a lazy seq when composed
+  via `concat`/`map`/`filter`). The scrubber only normalises (`vec`) and
+  runs `strip-fn` on a genuinely `sequential?` slice. A non-sequential
+  slice (nil, a scalar, a string, or a single event MAP) is NOT a batch,
+  so it passes through UNCHANGED — honouring the documented contract
+  (`Non-map slices … pass through unchanged`). The prior unconditional
+  `(vec …)` mangled these shapes: `nil → []`, `\"oops\" → [\\o \\o …]`, and
+  a single event map → a vector of map-entries — which silently lost the
+  event shape, reported zero drops, AND carried any secret in that map
+  straight past the filter.
+
+  Fail-CLOSED exception: a single MAP slice that is itself a sensitive
+  event (`sensitive-event?`) is DROPPED, not passed through — shipping it
+  raw would leak the very secret the filter exists to suppress. It is
+  replaced with the empty batch and counted as one drop."
   ([snapshot include?]
    (scrub-snapshot snapshot include? strip-sensitive))
   ([snapshot include? strip-fn]
@@ -283,10 +302,28 @@
      ;; Single walk over the snapshot, same cost as before.
      (let [scrub-slice
            (fn [frame-map slice-key acc]
-             (if (contains? frame-map slice-key)
-               (let [[kept n] (strip-fn (vec (get frame-map slice-key)) false)]
-                 [(assoc frame-map slice-key kept) (+ acc n)])
-               [frame-map acc]))
+             (if-not (contains? frame-map slice-key)
+               [frame-map acc]
+               (let [slice (get frame-map slice-key)]
+                 (cond
+                   ;; Genuine sequential trace-event batch (vector or lazy
+                   ;; seq): normalise + scrub. `(vec …)` realises a lazy
+                   ;; seq before `strip-fn` runs.
+                   (sequential? slice)
+                   (let [[kept n] (strip-fn (vec slice) false)]
+                     [(assoc frame-map slice-key kept) (+ acc n)])
+
+                   ;; Fail-CLOSED: a single map that is itself a sensitive
+                   ;; event is NOT a batch and would leak its secret if
+                   ;; shipped raw — drop it (empty batch) and count it.
+                   (sensitive-event? slice)
+                   [(assoc frame-map slice-key []) (inc acc)]
+
+                   ;; Any other non-sequential shape (nil, scalar, string,
+                   ;; non-sensitive single map) is not a batch — pass it
+                   ;; through byte-identically per the helper contract.
+                   :else
+                   [frame-map acc]))))
            scrub-frame
            (fn [frame-map]
              (let [[fm1 d1] (scrub-slice frame-map :traces 0)]

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -265,6 +265,92 @@
     (is (= [{:id 1} {:id 3}] (get-in out [:rf/default :traces])))))
 
 ;; ---------------------------------------------------------------------------
+;; Slice-shape discipline + fail-closed for malformed slices (rf2-wm9kp
+;; Finding 2). `scrub-snapshot` USED to `(vec …)` any present `:traces` /
+;; `:epochs` value unconditionally — even non-sequential ones. That
+;; mangled the shape (`nil → []`, `"oops" → [\o \o …]`, a single event
+;; map → a vector of map-entries) AND, for a malformed single SENSITIVE
+;; event map, reported zero drops while carrying the secret straight
+;; through (fail-OPEN). The fix only normalises + scrubs a genuinely
+;; `sequential?` batch; non-sequential shapes pass through byte-identical,
+;; and a single sensitive-event map is DROPPED fail-closed.
+;; ---------------------------------------------------------------------------
+
+(deftest scrub-snapshot-nil-slice-passes-through-unchanged
+  ;; rf2-wm9kp F2 — a nil `:traces` / `:epochs` slice is not a batch; it
+  ;; must survive as nil, not be coerced to `[]`.
+  (let [snap {:rf/default {:traces nil :epochs nil}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (zero? dropped))
+    (is (contains? (get out :rf/default) :traces))
+    (is (nil? (get-in out [:rf/default :traces]))
+        "nil :traces survives as nil (no `[]` mangle)")
+    (is (nil? (get-in out [:rf/default :epochs]))
+        "nil :epochs survives as nil")))
+
+(deftest scrub-snapshot-scalar-slice-passes-through-unchanged
+  ;; rf2-wm9kp F2 — a scalar slice is not a batch.
+  (let [snap {:rf/default {:traces 7 :epochs :marker}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (zero? dropped))
+    (is (= 7 (get-in out [:rf/default :traces])))
+    (is (= :marker (get-in out [:rf/default :epochs])))))
+
+(deftest scrub-snapshot-string-slice-passes-through-unchanged
+  ;; rf2-wm9kp F2 — a string is `seqable?` but NOT a trace-event batch.
+  ;; The old `(vec "oops")` produced `[\o \o \p \s]`.
+  (let [snap {:rf/default {:traces "oops"}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (zero? dropped))
+    (is (= "oops" (get-in out [:rf/default :traces]))
+        "string slice survives verbatim (no char-vector mangle)")))
+
+(deftest scrub-snapshot-non-sensitive-single-map-slice-passes-through
+  ;; rf2-wm9kp F2 — a single (non-sensitive) event MAP is not a batch; it
+  ;; passes through byte-identical rather than becoming a vec of entries.
+  (let [snap {:rf/default {:traces {:id 1 :op :something}}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (zero? dropped))
+    (is (= {:id 1 :op :something} (get-in out [:rf/default :traces]))
+        "non-sensitive single map survives verbatim (no entry-vec mangle)")))
+
+(deftest scrub-snapshot-sensitive-single-map-slice-dropped-fail-closed
+  ;; rf2-wm9kp F2 (the leak) — a single MAP slice that is itself a
+  ;; sensitive event must be DROPPED, not shipped raw. Pre-fix the
+  ;; unconditional `(vec …)` turned `{:id 1 :sensitive? true}` into
+  ;; `[[:id 1] [:sensitive? true]]`, reported zero drops, and carried the
+  ;; secret across the boundary. Fail-closed: drop + count.
+  (let [snap {:rf/default {:traces {:id 1 :sensitive? true :payload "SECRET"}}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (= 1 dropped) "the malformed sensitive single-map is counted as a drop")
+    (is (= [] (get-in out [:rf/default :traces]))
+        "the sensitive single-map is dropped (empty batch), not shipped raw")
+    ;; The secret never appears anywhere in the scrubbed output.
+    (is (not (clojure.string/includes? (pr-str out) "SECRET"))
+        "no trace of the secret survives in the scrubbed snapshot")))
+
+(deftest scrub-snapshot-sensitive-single-map-epochs-dropped-fail-closed
+  ;; rf2-wm9kp F2 — the exact bead probe shape: nil `:traces` (passes
+  ;; through) + a malformed sensitive single-map `:epochs` (dropped).
+  (let [snap {:rf/default {:traces nil :epochs {:id 1 :sensitive? true}}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (= 1 dropped))
+    (is (nil? (get-in out [:rf/default :traces])) ":traces nil survives")
+    (is (= [] (get-in out [:rf/default :epochs]))
+        "sensitive single-map :epochs dropped fail-closed")))
+
+(deftest scrub-snapshot-sequential-batch-still-scrubbed
+  ;; rf2-wm9kp F2 — the legitimate path is unchanged: a vector batch is
+  ;; normalised + scrubbed. (Companion to the existing lazy-seq test which
+  ;; pins the seq case.)
+  (let [snap {:rf/default {:traces [{:id 1 :sensitive? true} {:id 2}]
+                           :epochs [{:event-id :a :sensitive? true} {:event-id :b}]}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (= 2 dropped))
+    (is (= [{:id 2}] (get-in out [:rf/default :traces])))
+    (is (= [{:event-id :b}] (get-in out [:rf/default :epochs])))))
+
+;; ---------------------------------------------------------------------------
 ;; Malformed counter — operator-surface observability for the fail-
 ;; closed gate (rf2-8cpsg / F19).
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes rf2-wm9kp (P1). Two distinct schema-sensitive egress gaps that let schema-declared sensitive values cross the AI/MCP direct-read / off-box boundary RAW. Both are NEW (distinct from the merged `el9sw` #3132 strip-sensitive fix and `sk0ql` #3128 path-shape fix). Both now fail-CLOSED.

## Finding 1 (headline) — collection-nested schema-sensitive slots leaked via `elide-wire-value`

The schema walker emits **index-free** declarations for positional/keyed containers (`walker.cljc:145` — vector/sequential/set descend at the same base-path; map-of value descends under the key). So `[:items] [:vector [:map [:token {:sensitive? true} :string]]]` declares `[:items :token]`. But the core elision walker (`elision.cljc`) matched only **exact concrete runtime paths**, so `[:items 0 :token]` (and map-of `[:by-id "a" :secret]` vs decl `[:by-id :secret]`) never matched → `get-app-db` / `get-path` / `snapshot` returned the secret verbatim.

**Without-fix repro proof** (collected from a live JVM probe on the test classpath before the fix):
```
decls 1a: [[:items :token]]
ELIDE 1a (vector-of-map): {:items [{:token "SECRET"}]}   LEAK? true
decls 1b: [[:items :token] [:by-id :secret]]
ELIDE 1b (map-of): {:by-id {"a" {:secret "SECRET"}}}      LEAK? true
decls 1c: [... [:logs :pw]]
ELIDE 1c (sequential): {:logs [{:pw "SECRET"}]}           LEAK? true
```
After the fix all three (plus set, mixed map->vector->map) redact to `:rf/redacted`; sibling non-sensitive leaves ride verbatim (no over-redaction); `:large?` symmetry emits the marker carrying the concrete indexed runtime `:path`; sensitive still wins over large; `:rf.size/include-sensitive? true` still passes raw.

**Fix:** thread a candidate declaration-coordinate set through the walk. A runtime map key forks into the named-slot interpretation (real segment) and the map-of-key interpretation (no segment); vector/seq/set indices add no segment. Candidates are pruned to declared prefixes so the set stays bounded by declaration cardinality (empty ⇒ zero overhead, walker is identity). The concrete runtime path still drives marker `:path` / `:handle` and the unschema'd-large warning. Mirrors rf2-g5auo's `schema-sensitive-at?` coordinate alignment, but on the runtime value rather than the schema.

## Finding 2 — `scrub-snapshot` (vec …) shape-mangle (mcp-base)

`scrub-snapshot` unconditionally `(vec …)`-ed any present `:traces` / `:epochs` value, even non-sequential ones.

**Without-fix repro proof:**
```
INPUT:  {:rf/default {:traces nil, :epochs {:id 1, :sensitive? true}}}
OUTPUT: {:rf/default {:traces [], :epochs [[:id 1] [:sensitive? true]]}}  DROPPED: 0
  nil->[] mangle? true   single-map->vec-of-entries mangle? true
  SECRET STILL PRESENT (sensitive leaked, 0 drops)? true
STRING "oops" -> [\o \o \p \s]
```
A malformed single sensitive-event map became a vec of map-entries, reported **zero drops**, and carried the secret through (fail-OPEN).

**Fix:** only normalise + scrub a genuinely `sequential?` batch (vector or lazy seq — preserves the existing lazy-seq path); non-sequential shapes pass through byte-identical per the helper contract; a single sensitive-event map is **dropped fail-closed** (empty batch + counted). Does not disturb el9sw's merged `strip-sensitive` single-pass fix.

## Regressions added
- `elision_test.clj`: vector-of-maps / map-of / sequential / set / mixed map->vector->map redaction, no-over-redaction of sibling slots, large-marker-with-runtime-path symmetry, sensitive-wins-over-large nested.
- `sensitive_test.clj`: nil / scalar / string / non-sensitive-single-map pass-through, sensitive-single-map fail-closed drop (traces + epochs probe shape), sequential batch still scrubbed.

## Gates (cold, all green)
- core JVM `clojure -M:test`: 881 tests, 0 failures
- `npm run test:cljs`: 5654 tests, 0 failures
- `npm run test:elision`: PASS (production 40/40 absent; control 40/40 present)
- `npm run test:security`: 19 tests, 0 failures
- mcp-base `clojure -M:test`: 193 tests, 0 failures

## Follow-up — position-precise collection-coordinate match (over-redaction + under-scrub fix)

The Finding-1 candidate-coordinate matcher was too loose and caught two touched-surface gates not run in the original push:

- **Over-redaction (epoch + story-mcp red):** the empty seed candidate `[]` survived every map-key descent (the `:map-of`-key "skip" fork was kept unconditionally), letting a declaration FLOAT past arbitrary leading NAMED map slots and re-match the same key-sequence at a non-declared position. Decl `[:auth :password]` wrongly matched the deeper `[:tags :some-other-slot :auth :password]` (epoch `unit-projection-reroots-db-pending-tag-and-redacts` expected `"scoped-marker"`, got `:rf/redacted`). **Fix:** the `:map-of`-key skip is now granted ONLY to a NON-EMPTY candidate (one that has already consumed ≥1 declared segment). The seed `[]` advances solely via the named-slot fork.

- **Under-scrub (story-mcp red, regressed by the index-free threading):** a declaration carrying a CONCRETE index (`[:tokens 0]`, declared directly against the indexed runtime position) no longer matched, because the vector/seq descent passed `decl-paths` through unchanged and never appended the literal index. This silently regressed the origin behaviour the story-mcp seq-indexed derived-tree scrub relies on. **Fix:** new `fork-index-paths` forks each vector/seq descent into the INDEX-FREE interpretation (matches schema decls) AND the LITERAL-INDEX interpretation `(conj c i)` (matches index-pinned decls), pruned by `decl-prefixes`.

Both the seal-the-leak direction (`[:items 0 :token]` matches `[:items :token]`; `[:by-id "a" :secret]` matches `[:by-id :secret]`) and the no-over-redaction direction (`[:tags :some-other-slot :auth :password]` does NOT match `[:auth :password]`) hold. Added `elision_test` regressions: no-over-redaction-at-non-declared-position, map-of-skip-requires-started-match, literal-index-declaration-redacts (seq + vector).

## Quality gates (cold, all green — incl. the two previously-red gates)
- **epoch JVM `clojure -M:test`: 269 tests, 0 failures** (was red — `unit-projection-reroots-db-pending-tag-and-redacts`)
- **story-mcp JVM `clojure -M:test`: 228 tests, 0 failures** (was red — `scrub-rendered-seq-indexed-sensitive-stays-redacted`, 2 failures)
- core JVM `clojure -M:test`: 884 tests, 0 failures
- `npm run test:cljs`: 5661 tests, 0 failures
- `npm run test:elision`: PASS (production 40/40 absent; control 40/40 present)
- `npm run test:security`: 19 tests, 0 failures
- mcp-base `clojure -M:test`: 193 tests, 0 failures

The wm9kp collection-nested + scrub-snapshot regressions stay green.
