### PR TITLE
fix(ssr): nested streaming suspense-boundary registers + drains FIFO end-to-end (rf2-sgvn6 + rf2-b1v8v)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -481,7 +481,7 @@
    {:key         :ssr.streaming/render-continuation!
     :producer-ns 're-frame.ssr.streaming
     :design-bead "rf2-ojakd"
-    :description "Render a continuation chunk (resolved-suspense fragment) for an in-flight streaming render."}
+    :description "Render a continuation chunk (resolved-suspense fragment) for an in-flight streaming render. Returns {:id :html :delta :failed? :continuations} — :continuations are nested boundaries discovered during this render that the host appends at the tail of its FIFO drain queue (rf2-sgvn6)."}
    {:key         :ssr.streaming/build-final-payload
     :producer-ns 're-frame.ssr.streaming
     :design-bead "rf2-ojakd"

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -220,15 +220,30 @@
       (write-chunk! out (default-streaming-prefix head-html shell-opts))
       (write-chunk! out shell-html)
       ;; Chunks 2..N+1 — one per continuation, FIFO over registration.
-      (doseq [entry continuations]
-        (let [{:keys [id html delta failed?]}
-              (rf/with-frame frame-id (streaming/render-continuation frame-id entry))
-              tmpl-fn (if failed?
-                        streaming/failed-template
-                        streaming/resolved-template)]
-          (write-chunk! out (tmpl-fn id html))
-          (when (and (not failed?) (some? delta))
-            (write-chunk! out (streaming/hydrate-delta-script id (pr-str delta))))))
+      ;;
+      ;; rf2-sgvn6 / rf2-b1v8v — drain a GROWABLE FIFO worklist, not a
+      ;; fixed (doseq) over the shell's initial vector. A nested
+      ;; `:rf/suspense-boundary` inside a continuation's subtree registers
+      ;; a NEW continuation when that continuation renders (Spec 011
+      ;; §922-924/§966/§983); `streaming/render-continuation` returns those
+      ;; newly-discovered entries on `:continuations`. We append them at
+      ;; the TAIL of the queue (`into` over a PersistentQueue preserves
+      ;; FIFO) and keep draining until the queue empties — so the inner
+      ;; boundary's resolved chunk streams AFTER all originally-registered
+      ;; continuations, exactly as the document-order contract requires.
+      (loop [queue (into clojure.lang.PersistentQueue/EMPTY continuations)]
+        (when-let [entry (peek queue)]
+          (let [{:keys [id html delta failed? continuations]}
+                (rf/with-frame frame-id (streaming/render-continuation frame-id entry))
+                tmpl-fn (if failed?
+                          streaming/failed-template
+                          streaming/resolved-template)]
+            (write-chunk! out (tmpl-fn id html))
+            (when (and (not failed?) (some? delta))
+              (write-chunk! out (streaming/hydrate-delta-script id (pr-str delta))))
+            ;; Pop the drained entry, append any nested continuations at
+            ;; the tail (FIFO), continue until empty.
+            (recur (into (pop queue) continuations)))))
       ;; Chunk N+2 — final canonical __rf_payload.
       (let [final-hash    (rf/with-frame frame-id (ssr/render-tree-hash hiccup))
             final-payload (rf/with-frame frame-id

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -682,3 +682,86 @@
             (is (= 500 status)
                 "render-time sub-throw fail-closed 500 rides the full
                  Jetty round-trip — never a silent 200 (rf2-r06pc)")))))))
+
+;; ===========================================================================
+;; Test 7 (rf2-sgvn6 / rf2-b1v8v) — NESTED suspense boundary drains its
+;;                                  inner chunk on the actual wire (FIFO)
+;; ===========================================================================
+;;
+;; The end-to-end bytes-on-wire proof for the nested-streaming fix. An
+;; OUTER `:rf/suspense-boundary` whose subtree contains an INNER
+;; `:rf/suspense-boundary` must stream the inner boundary's resolved
+;; chunk over the real Jetty transport — the inner registers DURING the
+;; outer continuation's render and the daemon writer's GROWABLE FIFO
+;; appends it at the tail (Spec 011 §922-924/§966/§983).
+;;
+;; Before the fix: the outer continuation rendered its subtree through the
+;; NON-streaming emitter, which threw on the buried `:rf/suspense-boundary`
+;; head (`:rf.error/ssr-suspense-boundary-outside-stream`); the throw was
+;; caught as a FAILED outer continuation that re-emitted its own fallback,
+;; and the inner boundary never registered or resolved — wrong streamed
+;; HTML for nested Suspense UI. This test pins, on the wire:
+;;   - the outer boundary is NOT marked failed,
+;;   - the inner boundary's resolved chunk + body stream,
+;;   - the inner resolved chunk lands AFTER the outer resolved chunk (FIFO),
+;;   - no orphan daemon thread.
+
+(deftest nested-boundary-inner-chunk-streams-on-wire-FIFO
+  (testing "rf2-sgvn6 / rf2-b1v8v: an outer boundary containing an inner
+            boundary streams the inner resolved chunk on the real Jetty
+            wire, at the FIFO tail, with the outer resolved cleanly (not
+            failed)."
+    (rf/reg-event-fx :rf.test.server/init-nested
+      {:platforms #{:server}}
+      (fn [_ _] {:db {}}))
+    (rf/reg-view ^{:rf/id :test/wire-inner} wire-inner []
+      [:div.inner-body "WIRE_INNER_BODY"])
+    (rf/reg-view ^{:rf/id :test/wire-outer} wire-outer []
+      [:section.outer
+       [:p "WIRE_OUTER_CONTENT"]
+       [:rf/suspense-boundary
+        {:id :wire/inner :fallback [:p "wire inner loading"]}
+        [:test/wire-inner]]])
+    (rf/reg-view ^{:rf/id :test/wire-nested-root} wire-nested-root []
+      [:main
+       [:h1 "WireNested"]
+       [:rf/suspense-boundary
+        {:id :wire/outer :fallback [:p "wire outer loading"]}
+        [:test/wire-outer]]
+       [:footer "End"]])
+    (let [handler (ssr-ring/stream-handler
+                    {:on-create [:rf.test.server/init-nested]
+                     :root-view [:test/wire-nested-root]
+                     :payload :rf.ssr.payload/whole-app-db})]
+      (with-jetty [port handler]
+        (let [client (new-http-client)
+              {:keys [status body]} (http-get-string client port "/")
+              idx-outer-resolved (str/index-of body "data-rf2-suspense-id=\":wire/outer\" data-rf2-suspense-resolved=\"1\"")
+              idx-inner-resolved (str/index-of body "data-rf2-suspense-id=\":wire/inner\" data-rf2-suspense-resolved=\"1\"")
+              idx-inner-body     (str/index-of body "WIRE_INNER_BODY")
+              idx-payload        (str/index-of body "__rf_payload")]
+          (is (= 200 status) "nested stream rides the wire as 200")
+          (is (str/includes? body "wire outer loading")
+              "outer fallback in the shell on the wire")
+          (is (some? idx-outer-resolved)
+              "outer resolved chunk on the wire (NOT a failed re-emit)")
+          (is (not (str/includes? body "data-rf2-suspense-id=\":wire/outer\" data-rf2-suspense-resolved=\"1\" data-rf2-suspense-failed=\"1\""))
+              "outer boundary NOT marked failed on the wire (rf2-sgvn6)")
+          (is (some? idx-inner-resolved)
+              "inner boundary's resolved chunk streamed on the wire — the
+               nested continuation registered + drained at the FIFO tail")
+          (is (some? idx-inner-body)
+              "inner resolved chunk carries the inner body bytes on the wire")
+          (is (and idx-outer-resolved idx-inner-resolved
+                   (< idx-outer-resolved idx-inner-resolved))
+              "inner resolved chunk streams AFTER the outer (FIFO tail,
+               Spec 011 §966/§983)")
+          (is (and idx-inner-resolved idx-payload
+                   (< idx-inner-resolved idx-payload))
+              "inner resolved chunk before the final payload")))
+      ;; No orphan daemon thread after the nested stream completes.
+      (let [leaked (await-no-streaming-threads! 5000)]
+        (is (empty? leaked)
+            (str "no orphan rf2-ssr-streaming-* daemon thread after a
+                 nested-boundary stream. Live threads observed: "
+                 (mapv (fn [^Thread t] (.getName t)) leaked)))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -145,6 +145,88 @@
       (is (str/includes? body "Still loading") "fallback materialised in failed chunk")
       (is (str/includes? body "__rf_payload") "final payload still emitted"))))
 
+(deftest stream-handler-nested-boundary-drains-inner-FIFO
+  (testing "rf2-sgvn6 / rf2-b1v8v: an OUTER :rf/suspense-boundary whose
+            subtree contains an INNER :rf/suspense-boundary streams
+            end-to-end. The writer drains a GROWABLE FIFO: the inner
+            boundary registers DURING the outer continuation's render and
+            its resolved chunk streams at the TAIL — AFTER the outer's
+            resolved chunk (Spec 011 §922-924/§966/§983). The outer must
+            NOT be marked failed; the inner must resolve its own body."
+    (rf/reg-view ^{:rf/id :test/inner-section} inner-section []
+      [:div.inner-body "INNER BODY CONTENT"])
+    (rf/reg-view ^{:rf/id :test/outer-section} outer-section []
+      [:section.outer
+       [:p "outer content above inner"]
+       [:rf/suspense-boundary
+        {:id :test/inner :fallback [:p.inner-fallback "inner loading"]}
+        [:test/inner-section]]])
+    (rf/reg-view ^{:rf/id :test/nested-root} nested-root []
+      [:main
+       [:h1 "Nested"]
+       [:rf/suspense-boundary
+        {:id :test/outer :fallback [:p.outer-fallback "outer loading"]}
+        [:test/outer-section]]
+       [:footer "End"]])
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init]
+                      :root-view [:test/nested-root]
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          body     (drain-stream (:body response))
+          ;; Wire offsets pinning the FIFO drain order.
+          idx-outer-fallback (str/index-of body "data-rf2-suspense-id=\":test/outer\" data-rf2-suspense-fallback=\"1\"")
+          idx-outer-resolved (str/index-of body "data-rf2-suspense-id=\":test/outer\" data-rf2-suspense-resolved=\"1\"")
+          idx-inner-fallback (str/index-of body "data-rf2-suspense-id=\":test/inner\" data-rf2-suspense-fallback=\"1\"")
+          idx-inner-resolved (str/index-of body "data-rf2-suspense-id=\":test/inner\" data-rf2-suspense-resolved=\"1\"")
+          idx-inner-body     (str/index-of body "INNER BODY CONTENT")
+          idx-payload        (str/index-of body "__rf_payload")
+          idx-close          (str/index-of body "</body></html>")]
+      (is (= 200 (:status response)) "nested stream still 200")
+      ;; Shell carries the OUTER fallback only — the inner is buried in
+      ;; the unresolved outer subtree.
+      (is (some? idx-outer-fallback) "outer fallback placeholder in the shell")
+      (is (str/includes? body "outer loading") "outer fallback text in the shell")
+      (is (< idx-outer-fallback (or idx-inner-fallback Long/MAX_VALUE))
+          "the inner fallback is NOT in the shell — it appears only inside
+           the outer's resolved chunk, which streams after the shell")
+      ;; CRITICAL — the outer continuation resolved CLEANLY (no failed
+      ;; marker on the outer). Pre-fix the outer was marked failed because
+      ;; the buried inner boundary threw through the non-streaming emitter.
+      (is (some? idx-outer-resolved)
+          "outer resolved chunk emitted (NOT a failed re-emit of its fallback)")
+      (is (not (str/includes? body "data-rf2-suspense-id=\":test/outer\" data-rf2-suspense-resolved=\"1\" data-rf2-suspense-failed=\"1\""))
+          "the OUTER boundary is NOT marked failed — it resolved through
+           the streaming walker (rf2-sgvn6)")
+      (is (str/includes? body "outer content above inner")
+          "the outer subtree's static content resolved")
+      ;; The inner boundary's FALLBACK template appears INSIDE the outer's
+      ;; resolved chunk (the inner is deferred at outer-drain time).
+      (is (some? idx-inner-fallback)
+          "the inner boundary's fallback placeholder appears (inside the
+           outer resolved chunk) — the inner registered during the outer
+           drain")
+      ;; The inner's OWN resolved chunk + body stream LAST (FIFO tail).
+      (is (some? idx-inner-resolved)
+          "the inner boundary's resolved chunk streamed — the nested
+           continuation was appended to the FIFO and drained")
+      (is (some? idx-inner-body)
+          "the inner resolved chunk carries the inner body content")
+      (is (some? idx-payload) "final __rf_payload still emitted")
+      (is (some? idx-close) "body close emitted")
+      ;; FIFO drain-order contract: outer fallback (shell) → outer resolved
+      ;; → inner resolved → final payload → close. The inner resolved chunk
+      ;; lands AFTER the outer resolved chunk (registered at the tail).
+      (is (< idx-outer-fallback idx-outer-resolved)
+          "outer fallback (shell) before outer resolved chunk")
+      (is (< idx-outer-resolved idx-inner-resolved)
+          "inner resolved chunk streams AFTER the outer resolved chunk —
+           FIFO tail registration (Spec 011 §966/§983)")
+      (is (< idx-inner-resolved idx-payload)
+          "inner resolved chunk before the final payload")
+      (is (< idx-payload idx-close)
+          "final payload before body close"))))
+
 (deftest stream-handler-no-boundary-zero-continuations
   (testing "A tree with NO :rf/suspense-boundary still streams cleanly (degenerate case)"
     (rf/reg-view ^{:rf/id :test/static-root} static-root []

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -440,16 +440,32 @@
 
   Returns:
 
-    {:id      <boundary-id>
-     :html    <subtree-html-or-fallback-html>
-     :delta   <app-db-delta-map-or-nil>
-     :failed? <boolean>}
+    {:id            <boundary-id>
+     :html          <subtree-html-or-fallback-html>
+     :delta         <app-db-delta-map-or-nil>
+     :failed?       <boolean>
+     :continuations [{:id … :subtree … :fallback …} …]}
+
+  The subtree is rendered through the SAME streaming shell walker
+  `render-shell` uses (Spec 011 §922-924/§966/§983 — \"the same emitter,
+  recursion-friendly — a nested `:rf/suspense-boundary` re-recurses
+  through this same drain\"). A nested `:rf/suspense-boundary` inside the
+  subtree therefore does NOT throw (the non-streaming emitter would —
+  `emit.cljc` `:rf.error/ssr-suspense-boundary-outside-stream`); instead
+  it materialises its OWN fallback `<template>` inline and registers a
+  NEW continuation. Those newly-discovered continuations are returned on
+  `:continuations` so the host adapter appends them at the TAIL of its
+  FIFO drain queue and keeps draining until empty — preserving the
+  document-order intuition (each chunk hydrates a strictly-later DOM
+  region). `:continuations` is `[]` when the subtree carries no nested
+  boundaries (the common case).
 
   Failure semantics per Spec 011 §Failure semantics — inline fallback:
   a subtree-render throw is caught, the original `:fallback` hiccup is
   materialised in its place, `:rf.ssr/suspense-boundary-failed` is
-  emitted on the trace bus, and the per-subtree delta is omitted (the
-  client keeps its pre-failure delta)."
+  emitted on the trace bus, the per-subtree delta is omitted (the client
+  keeps its pre-failure delta), and `:continuations` is `[]` (a failed
+  outer cannot have registered inner boundaries — the walk aborted)."
   [frame-id {:keys [id subtree fallback]}]
   ;; Snapshot before-db. The continuation may dispatch events
   ;; synchronously during render (subscribe-time computation reads from
@@ -461,13 +477,23 @@
   ;; demonstrates the pattern); see Spec 011 §Streaming SSR.
   (let [before-db (frame/frame-app-db-value frame-id)]
     (try
-      (let [resolved-html (emit/render-to-string subtree nil)
-            after-db      (frame/frame-app-db-value frame-id)
-            delta         (subtree-delta before-db after-db)]
-        {:id      id
-         :html    resolved-html
-         :delta   delta
-         :failed? false})
+      ;; Bind the per-render parse-tag-name memo (mirrors `render-shell`)
+      ;; and drain the subtree through `walk-shell` so a nested boundary
+      ;; registers a continuation instead of hitting the non-streaming
+      ;; emitter's `:rf/suspense-boundary` reject. `dedupe-continuations`
+      ;; applies the same last-write-wins duplicate-id contract within
+      ;; this continuation's nested registrations.
+      (binding [emit/*tag-name-cache* (volatile! {})]
+        (let [acc           (new-continuations-acc)
+              resolved-html (walk-shell subtree acc)
+              nested        (dedupe-continuations @acc)
+              after-db      (frame/frame-app-db-value frame-id)
+              delta         (subtree-delta before-db after-db)]
+          {:id            id
+           :html          resolved-html
+           :delta         delta
+           :failed?       false
+           :continuations nested}))
       (catch #?(:clj Throwable :cljs :default) t
         (trace/emit-error! :rf.ssr/suspense-boundary-failed
                            {:id        id
@@ -482,10 +508,11 @@
                                 ;; side runtime treats an empty
                                 ;; resolved chunk as a no-op.
                                 ""))]
-          {:id      id
-           :html    fallback-html
-           :delta   nil
-           :failed? true})))))
+          {:id            id
+           :html          fallback-html
+           :delta         nil
+           :failed?       true
+           :continuations []})))))
 
 (defn build-final-payload
   "After every continuation has drained, construct the canonical

--- a/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
@@ -113,3 +113,105 @@
           kinds   (mapv :kind wire)]
       (is (= [:shell :resolved :resolved :final-payload :close] kinds)
           "wire-order pins shell → N resolved → final-payload → close"))))
+
+;; ===========================================================================
+;; Nested-boundary fixture — rf2-sgvn6 / rf2-b1v8v. The inner boundary
+;; registers DURING the outer continuation render and drains at the FIFO
+;; tail. Drives spec/conformance/fixtures/ssr-streaming-nested.edn.
+;; ===========================================================================
+
+(defn- load-nested-fixture []
+  (edn/read-string
+    (slurp (io/file "../../spec/conformance/fixtures/ssr-streaming-nested.edn"))))
+
+(defn- reg-nested-fixture-handlers! []
+  (rf/reg-view ^{:rf/id :streaming-nested.test/inner-section} _ni []
+    [:div.inner-body "inner body content"])
+  (rf/reg-view ^{:rf/id :streaming-nested.test/outer-section} _no []
+    [:section.outer
+     [:p "outer content above inner"]
+     [:rf/suspense-boundary
+      {:id :streaming-nested.test/inner
+       :fallback [:p.fallback "Loading inner…"]}
+      [:streaming-nested.test/inner-section]]])
+  (rf/reg-view ^{:rf/id :streaming-nested.test/root} _nr []
+    [:main
+     [:h1 "Nested"]
+     [:rf/suspense-boundary
+      {:id :streaming-nested.test/outer
+       :fallback [:p.fallback "Loading outer…"]}
+      [:streaming-nested.test/outer-section]]
+     [:footer "End"]]))
+
+(deftest nested-fixture-shell-registers-only-outer
+  (testing "rf2-sgvn6: the shell walk registers ONLY the outer
+            continuation; the inner is buried in the unresolved outer
+            subtree and its fallback is NOT in the shell"
+    (reg-nested-fixture-handlers!)
+    (let [fixture    (load-nested-fixture)
+          shell-call (->> (:fixture/calls fixture)
+                          (filter #(= :ssr.streaming/render-shell (:call %)))
+                          first)
+          {:keys [shell-html continuations]}
+          (ssr/streaming-render-shell (:input shell-call))
+          expect     (:expect shell-call)]
+      (doseq [s (:shell-html-includes expect)]
+        (is (str/includes? shell-html s)
+            (str "nested shell-html missing: " (pr-str s))))
+      (doseq [s (:shell-html-excludes expect)]
+        (is (not (str/includes? shell-html s))
+            (str "nested shell-html must NOT carry (inner is buried): " (pr-str s))))
+      (is (= (mapv :id (:continuations expect))
+             (mapv :id continuations))
+          "shell registers exactly the outer continuation"))))
+
+(deftest nested-fixture-outer-drain-registers-inner-fifo
+  (testing "rf2-sgvn6 / rf2-b1v8v: draining the outer continuation resolves
+            cleanly, carries the inner FALLBACK template inline, defers the
+            inner body, and returns the inner continuation on :continuations
+            (FIFO tail). Draining the inner then resolves the inner body."
+    (reg-nested-fixture-handlers!)
+    (let [fixture    (load-nested-fixture)
+          cont-calls (->> (:fixture/calls fixture)
+                          (filter #(= :ssr.streaming/render-continuation (:call %))))
+          outer-call (first cont-calls)
+          inner-call (second cont-calls)
+          fid        :rf/default]
+      ;; Drain the outer.
+      (let [out    (ssr/streaming-render-continuation fid (:input outer-call))
+            expect (:expect outer-call)]
+        (is (= (:failed? expect) (:failed? out))
+            "outer resolves cleanly — NOT failed (the buried inner marker
+             is recognised by the streaming walker, not thrown on)")
+        (doseq [s (:html-includes expect)]
+          (is (str/includes? (:html out) s)
+              (str "outer chunk missing: " (pr-str s))))
+        (doseq [s (:html-excludes expect)]
+          (is (not (str/includes? (:html out) s))
+              (str "outer chunk must NOT carry the deferred inner body: " (pr-str s))))
+        (is (= (mapv :id (:continuations expect))
+               (mapv :id (:continuations out)))
+            "outer drain returns the inner continuation at the FIFO tail"))
+      ;; Drain the inner.
+      (let [in     (ssr/streaming-render-continuation fid (:input inner-call))
+            expect (:expect inner-call)]
+        (is (= (:failed? expect) (:failed? in)))
+        (doseq [s (:html-includes expect)]
+          (is (str/includes? (:html in) s)
+              (str "inner chunk missing: " (pr-str s))))
+        (is (empty? (:continuations in))
+            "the inner subtree registers no further nested boundaries")))))
+
+(deftest nested-fixture-wire-order-pinned
+  (testing "rf2-sgvn6: the nested fixture's wire-order pins shell → outer
+            resolved → inner resolved (FIFO tail) → final-payload → close"
+    (let [fixture (load-nested-fixture)
+          wire    (:fixture/wire-order fixture)
+          kinds   (mapv :kind wire)]
+      (is (= [:shell :resolved :resolved :final-payload :close] kinds))
+      ;; The ord field pins the FIFO: outer (ord 1) before inner (ord 2).
+      (let [resolved (filterv #(= :resolved (:kind %)) wire)]
+        (is (= [:streaming-nested.test/outer :streaming-nested.test/inner]
+               (mapv :id resolved))
+            "outer resolved chunk (ord 1) precedes inner resolved chunk
+             (ord 2) — the inner registered at the FIFO tail")))))

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -133,11 +133,17 @@
 ;; ===========================================================================
 
 (deftest boundary-nested-inside-resolved-subtree-registers-inner-continuation
-  (testing "rf2-u91hb: when a continuation's subtree contains ANOTHER
-            :rf/suspense-boundary, the inner boundary registers during
-            the continuation's render — at the tail of the drain queue
-            per Spec 011 §Boundary nesting and recursion (FIFO over
-            registration order)."
+  (testing "rf2-sgvn6 / rf2-b1v8v: when a continuation's subtree contains
+            ANOTHER :rf/suspense-boundary, the inner boundary registers
+            DURING the continuation's render — render-continuation drains
+            the subtree through the streaming walker (NOT the non-streaming
+            emitter), so the inner boundary materialises its own fallback
+            <template> inline and returns a NEW continuation on
+            :continuations for the host to append at the tail of the FIFO
+            drain queue (Spec 011 §922-924/§966/§983). It does NOT
+            fail-soft — the prior impl rendered the subtree through
+            emit/render-to-string, which THREW on the buried marker and
+            inline-fallback'd, never registering the inner boundary."
     (let [tree [:div
                 [:rf/suspense-boundary
                  {:id :outer :fallback [:p "outer loading"]}
@@ -158,22 +164,13 @@
       (is (not (str/includes? shell-html "inner loading"))
           "inner fallback NOT in the shell (still buried in the
            unresolved outer subtree)")
-      ;; Drain the outer — the inner boundary's hiccup is emitted by
-      ;; the standard emitter (since render-continuation calls
-      ;; emit/render-to-string, not the walker). This means the inner
-      ;; boundary's HICCUP shape lands in the resolved chunk as-is —
-      ;; including the inner's fallback rendered inline. The wire
-      ;; contract per Spec 011: nested boundaries that fire inside a
-      ;; continuation register a new drain entry; the SSR ring adapter
-      ;; threads them through (`stream-handler` re-invokes the walker
-      ;; per resolved chunk). At the pure-streaming level
-      ;; (render-continuation), the inner boundary renders via the
-      ;; non-streaming emitter, which surfaces an exception on the
-      ;; unrecognised :rf/suspense-boundary head — caught as a
-      ;; failure and inline-fallback'd. Pin THAT contract.
+      ;; Drain the outer — render-continuation walks the subtree through
+      ;; the streaming walker, so the buried :rf/suspense-boundary is
+      ;; RECOGNISED: its fallback materialises inline as a <template> and
+      ;; a NEW continuation for the inner is registered + returned on
+      ;; :continuations. The outer does NOT fail.
       ;; rf2-usio0 — drain the outer entry verbatim; its declared
-      ;; :fallback rides from `record-continuation!`. Re-injecting it by
-      ;; hand masks an empty-fallback regression on the fail-soft path.
+      ;; :fallback rides from `record-continuation!`.
       (let [fid    (make-server-frame)
             entry  (first continuations)
             captured (atom [])
@@ -182,21 +179,92 @@
         (is (= [:p "outer loading"] (:fallback entry))
             "record-continuation! stored the outer boundary's declared
              :fallback on the entry")
-        ;; The pure render-continuation path (without the ring
-        ;; adapter's per-chunk re-walker) DOES fail on the buried
-        ;; suspense-boundary keyword — which exercises the
-        ;; inline-fallback contract. The ring host adapter's writer
-        ;; loop is what actually re-walks; the pure runtime layer
-        ;; pins the fail-soft semantics.
-        (is (or (not (:failed? result))
-                (and (:failed? result)
-                     (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
-                           @captured)))
-            "outer continuation either resolves cleanly (renderer
-             passed the unknown head through) OR fails-soft into the
-             fallback (per Spec 011 §Failure semantics — inline
-             fallback). Either is acceptable; what is NOT acceptable
-             is an uncaught throw escaping the drain.")))))
+        (is (not (:failed? result))
+            "the outer continuation resolves cleanly — the streaming
+             walker recognises the buried :rf/suspense-boundary instead
+             of throwing on it (rf2-sgvn6 / rf2-b1v8v)")
+        (is (empty? (filter #(= :rf.ssr/suspense-boundary-failed (:operation %))
+                            @captured))
+            "NO suspense-boundary-failed trace — the nested boundary is
+             registered, not fail-soft'd")
+        ;; The inner boundary's resolved chunk is NOT in the outer's HTML;
+        ;; instead the outer HTML carries the inner's FALLBACK <template>.
+        (is (str/includes? (:html result) "data-rf2-suspense-id=\":inner\"")
+            "the outer's resolved HTML carries the inner boundary's
+             <template> placeholder (its fallback), stamped with the
+             inner id")
+        (is (str/includes? (:html result) "data-rf2-suspense-fallback=\"1\"")
+            "the inner placeholder is a fallback template (deferred), not
+             the resolved inner body")
+        (is (str/includes? (:html result) "inner loading")
+            "the inner's fallback hiccup materialised inline in the
+             outer's resolved chunk")
+        (is (not (str/includes? (:html result) "inner body"))
+            "the inner BODY is NOT in the outer chunk — it is deferred to
+             the inner continuation's own drain")
+        ;; The new continuation lands on :continuations for the host to
+        ;; append at the TAIL of its FIFO drain queue.
+        (is (= 1 (count (:continuations result)))
+            "render-continuation returns the ONE newly-registered inner
+             continuation for the host to append (FIFO tail)")
+        (is (= :inner (-> result :continuations first :id))
+            "the inner boundary's id propagates on the returned
+             continuation entry")
+        (is (= [:p "inner loading"] (-> result :continuations first :fallback))
+            "the inner continuation carries its declared :fallback")
+        ;; Draining the inner continuation now resolves the inner body.
+        (let [inner-entry  (-> result :continuations first)
+              inner-result (streaming/render-continuation fid inner-entry)]
+          (is (not (:failed? inner-result)))
+          (is (str/includes? (:html inner-result) "inner body")
+              "the inner continuation's resolved chunk carries the inner
+               body — drained AFTER the outer, at the tail of the FIFO")
+          (is (empty? (:continuations inner-result))
+              "the inner subtree has no further nested boundaries — its
+               :continuations is empty"))))))
+
+(deftest boundary-three-levels-deep-drains-each-level-FIFO
+  (testing "rf2-sgvn6 / rf2-b1v8v: nesting is UNBOUNDED — a level-1 boundary
+            whose subtree nests a level-2 boundary whose subtree nests a
+            level-3 boundary drains one level per continuation, each
+            registering the next at the FIFO tail. Proves the recursion is
+            genuinely re-entrant (Spec 011 §924 — the same drain re-recurses)."
+    (let [tree [:rf/suspense-boundary
+                {:id :lvl1 :fallback [:p "l1 loading"]}
+                [:section.l1
+                 [:rf/suspense-boundary
+                  {:id :lvl2 :fallback [:p "l2 loading"]}
+                  [:section.l2
+                   [:rf/suspense-boundary
+                    {:id :lvl3 :fallback [:p "l3 loading"]}
+                    [:p "deepest body"]]]]]]
+          {:keys [continuations]} (streaming/render-shell tree)
+          fid (make-server-frame)]
+      (is (= [:lvl1] (mapv :id continuations))
+          "shell sees only level-1; deeper levels are buried")
+      ;; Drain level-1 → registers level-2.
+      (let [r1 (streaming/render-continuation fid (first continuations))]
+        (is (not (:failed? r1)))
+        (is (str/includes? (:html r1) "data-rf2-suspense-id=\":lvl2\"")
+            "level-1 chunk carries level-2's fallback template")
+        (is (not (str/includes? (:html r1) "data-rf2-suspense-id=\":lvl3\""))
+            "level-3 still buried inside the unresolved level-2 subtree")
+        (is (= [:lvl2] (mapv :id (:continuations r1)))
+            "level-1 drain registers exactly level-2 at the tail")
+        ;; Drain level-2 → registers level-3.
+        (let [r2 (streaming/render-continuation fid (-> r1 :continuations first))]
+          (is (not (:failed? r2)))
+          (is (str/includes? (:html r2) "data-rf2-suspense-id=\":lvl3\"")
+              "level-2 chunk carries level-3's fallback template")
+          (is (= [:lvl3] (mapv :id (:continuations r2)))
+              "level-2 drain registers exactly level-3 at the tail")
+          ;; Drain level-3 → resolves the deepest body, no further nesting.
+          (let [r3 (streaming/render-continuation fid (-> r2 :continuations first))]
+            (is (not (:failed? r3)))
+            (is (str/includes? (:html r3) "deepest body")
+                "level-3 resolves the deepest body")
+            (is (empty? (:continuations r3))
+                "no further nesting below level-3")))))))
 
 (deftest boundary-inside-registered-view-body-is-reachable-by-walker
   (testing "rf2-u91hb: when a registered view's body contains

--- a/spec/conformance/fixtures/ssr-streaming-nested.edn
+++ b/spec/conformance/fixtures/ssr-streaming-nested.edn
@@ -1,0 +1,164 @@
+;; Conformance fixture: ssr/streaming-nested
+;;
+;; Pins the NESTED-boundary chunk-ordering contract for
+;; `:rf/suspense-boundary` streaming SSR. Per Spec 011 §Streaming SSR
+;; §Boundary nesting and recursion (rf2-sgvn6 / rf2-b1v8v —
+;; the deferred rf2-v3eg3 finding-2).
+;;
+;; Specs that meet:
+;; [011-SSR §Boundary nesting and recursion](../../011-SSR.md#boundary-nesting-and-recursion),
+;; [011-SSR §Hydration interleaving](../../011-SSR.md#hydration-interleaving--per-subtree-deltas).
+;;
+;; Scenario: a server-side render of a tree carrying ONE outer
+;; `:rf/suspense-boundary` whose subtree contains an INNER
+;; `:rf/suspense-boundary`. The shell walk sees ONLY the outer boundary
+;; (the inner is buried in the unresolved outer subtree). When the outer
+;; continuation drains, the streaming walker recognises the buried inner
+;; boundary: it materialises the inner's FALLBACK `<template>` inline and
+;; registers a NEW continuation. The host appends that inner continuation
+;; at the TAIL of its FIFO drain queue; the inner's resolved chunk
+;; therefore streams AFTER the outer's resolved chunk.
+;;
+;; Pin: (a) the shell registers exactly the outer continuation,
+;; (b) draining the outer resolves cleanly (NOT failed), carries the
+;; inner's fallback template, and returns the inner continuation on
+;; `:continuations`, (c) draining the inner resolves the inner body,
+;; (d) the wire-chunk ordering: shell (outer fallback) → outer resolved
+;; (carrying inner fallback) → inner resolved (inner body) →
+;; final __rf_payload → close.
+
+{:fixture/id           :ssr/streaming-nested
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:ssr/render-to-string
+                         :ssr/suspense-boundary
+                         :ssr/hydration-payload
+                         :ssr/chunked-response}
+ :fixture/doc          "Pins NESTED :rf/suspense-boundary streaming wire shape: the inner boundary registers DURING the outer continuation render (not at shell-walk time) and its resolved chunk streams at the FIFO tail, AFTER the outer resolved chunk. The outer resolves cleanly (NOT failed) — the streaming walker recognises the buried inner marker instead of throwing through the non-streaming emitter. Per Spec 011 §Boundary nesting and recursion (rf2-sgvn6 / rf2-b1v8v)."
+
+ :fixture/registry
+ {:view {:streaming-nested.test/inner-section
+         {:doc "Resolved-via-inner-boundary subtree — the inner body."}
+         :streaming-nested.test/outer-section
+         {:doc "Resolved-via-outer-boundary subtree — wraps the inner boundary."}
+         :streaming-nested.test/root
+         {:doc "Page root with one outer boundary nesting one inner boundary."}}}
+
+ :fixture/handlers
+ {:view {:streaming-nested.test/inner-section
+         [[:hiccup [:div.inner-body "inner body content"]]]
+
+         :streaming-nested.test/outer-section
+         [[:hiccup
+           [:section.outer
+            [:p "outer content above inner"]
+            [:rf/suspense-boundary
+             {:id :streaming-nested.test/inner
+              :fallback [:p.fallback "Loading inner…"]}
+             [:streaming-nested.test/inner-section]]]]]
+
+         :streaming-nested.test/root
+         [[:hiccup
+           [:main
+            [:h1 "Nested"]
+            [:rf/suspense-boundary
+             {:id :streaming-nested.test/outer
+              :fallback [:p.fallback "Loading outer…"]}
+             [:streaming-nested.test/outer-section]]
+            [:footer "End"]]]]}}
+
+ :fixture/frame-config {:platform :server}
+
+ :fixture/calls
+ [;; Step 1 — shell walk. The shell sees ONLY the outer boundary; the
+  ;; inner is buried in the unresolved outer subtree. The shell carries
+  ;; the OUTER fallback placeholder, NOT the inner.
+  {:call   :ssr.streaming/render-shell
+   :input  [:streaming-nested.test/root]
+   :expect
+   {:shell-html-includes
+    ["<main"
+     "<h1>Nested</h1>"
+     "<template data-rf2-suspense-id=\":streaming-nested.test/outer\" data-rf2-suspense-fallback=\"1\">"
+     "<p class=\"fallback\">Loading outer…</p>"
+     "</template>"
+     "<footer>End</footer>"
+     "</main>"]
+    ;; the inner fallback is NOT in the shell — it is still buried.
+    :shell-html-excludes
+    ["Loading inner…"
+     "data-rf2-suspense-id=\":streaming-nested.test/inner\""]
+    :continuations
+    [{:id :streaming-nested.test/outer}]}}
+
+  ;; Step 2 — drain the OUTER continuation. It resolves CLEANLY (NOT
+  ;; failed): the streaming walker recognises the buried inner boundary,
+  ;; materialises the inner FALLBACK template inline, and registers a NEW
+  ;; inner continuation returned on :continuations (FIFO tail). The inner
+  ;; BODY is NOT in the outer chunk — it is deferred.
+  {:call   :ssr.streaming/render-continuation
+   :input  {:id :streaming-nested.test/outer
+            :subtree [:streaming-nested.test/outer-section]}
+   :expect
+   {:html-includes ["<section"
+                    "outer content above inner"
+                    ;; the inner boundary's FALLBACK template, deferred:
+                    "<template data-rf2-suspense-id=\":streaming-nested.test/inner\" data-rf2-suspense-fallback=\"1\">"
+                    "Loading inner…"]
+    :html-excludes ["inner body content"]
+    :failed? false
+    :continuations [{:id :streaming-nested.test/inner}]}}
+
+  ;; Step 3 — drain the INNER continuation (registered at the FIFO tail
+  ;; during step 2). It resolves the inner body and registers no further
+  ;; nested boundaries.
+  {:call   :ssr.streaming/render-continuation
+   :input  {:id :streaming-nested.test/inner
+            :subtree [:streaming-nested.test/inner-section]}
+   :expect
+   {:html-includes ["<div class=\"inner-body\""
+                    "inner body content"]
+    :failed? false
+    :continuations []}}
+
+  ;; Step 4 — final canonical __rf_payload.
+  {:call   :ssr.streaming/build-final-payload
+   :input  {:render-hash "00000000"
+            :version     1
+            :payload     :rf.ssr.payload/whole-app-db}
+   :expect {:payload-keys #{:rf/version :rf/frame-id :rf/app-db :rf/render-hash}
+            :rf/version   1}}]
+
+ ;; Wire-order invariant. The host adapter drains a GROWABLE FIFO: the
+ ;; inner continuation, registered during the outer drain, is appended at
+ ;; the TAIL, so the inner resolved chunk streams AFTER the outer's.
+ :fixture/wire-order
+ [;; chunk 1 — shell prefix + shell-html (outer fallback only)
+  {:kind :shell
+   :must-include ["<!DOCTYPE html>"
+                  "<html"
+                  "<body"
+                  "<div id=\"app\">"
+                  "data-rf2-suspense-id=\":streaming-nested.test/outer\" data-rf2-suspense-fallback=\"1\""]}
+  ;; chunk 2 — outer resolved (carries the inner fallback template)
+  {:kind  :resolved
+   :ord   1
+   :id    :streaming-nested.test/outer
+   :must-include ["data-rf2-suspense-id=\":streaming-nested.test/outer\" data-rf2-suspense-resolved=\"1\""
+                  "outer content above inner"
+                  "data-rf2-suspense-id=\":streaming-nested.test/inner\" data-rf2-suspense-fallback=\"1\""]}
+  ;; chunk 3 — inner resolved (FIFO tail — AFTER the outer resolved chunk)
+  {:kind  :resolved
+   :ord   2
+   :id    :streaming-nested.test/inner
+   :must-include ["data-rf2-suspense-id=\":streaming-nested.test/inner\" data-rf2-suspense-resolved=\"1\""
+                  "inner body content"]}
+  ;; chunk 4 — final canonical __rf_payload
+  {:kind :final-payload
+   :must-include ["<script id=\"__rf_payload\""
+                  "type=\"application/edn\""
+                  ":rf/version"
+                  ":rf/render-hash"]}
+  ;; chunk 5 — shell suffix close
+  {:kind :close
+   :must-include ["</body>"
+                  "</html>"]}]}


### PR DESCRIPTION
## What

Fixes the nested `:rf/suspense-boundary` streaming gap (rf2-sgvn6 P1 + rf2-b1v8v P2 — same issue; b1v8v is the deferred rf2-v3eg3 finding-2).

A valid tree with an outer `:rf/suspense-boundary` whose continuation subtree contains an inner `:rf/suspense-boundary` returned a 200 stream where the **outer continuation was marked failed and re-emitted its fallback**; the inner boundary never registered or resolved — violating Spec 011's nested-boundary FIFO contract (§922-924 / §966 / §983) and producing wrong streamed HTML for nested Suspense-style UI.

### Root cause (two-sided)
1. **ssr** `render-continuation` rendered the continuation subtree through the **non-streaming** emitter (`emit/render-to-string`), which throws `:rf.error/ssr-suspense-boundary-outside-stream` on a buried marker — caught as a failed outer continuation, inline-fallback'd, inner never registered.
2. **ssr-ring** writer loop drained a **static `(doseq)`** over the shell's initial continuations vector — no re-walk, no append for continuations discovered mid-drain.

## The fix (cross-artefact + shared hook)

- **`implementation/ssr/.../streaming.cljc`** — `render-continuation` now drains the subtree through the **same streaming walker** (`walk-shell`) that `render-shell` uses (binding the per-render tag-name memo). A buried `:rf/suspense-boundary` is recognised: it materialises its own fallback `<template>` inline and registers a **new continuation**, returned on a new `:continuations` key. `dedupe-continuations` applies the last-write-wins duplicate-id contract to nested registrations too. Failure semantics preserved (catch → inline-fallback, `:continuations []`).
- **`implementation/ssr-ring/.../streaming.clj`** — writer loop replaces the static `(doseq)` with a **growable `PersistentQueue` FIFO**: each drained continuation's returned `:continuations` are appended at the tail and the loop keeps draining until empty, so a nested boundary's resolved chunk streams **after** all originally-registered continuations (document-order intuition holds).
- **`directory.cljc`** — documents the `:ssr.streaming/render-continuation!` hook's new `{:id :html :delta :failed? :continuations}` return shape.

`spec/011` unchanged (it already specifies this). The first-chunk inline-fallback + fail-closed contracts (rf2-r06pc / #3110) are preserved — all those tests still pass.

## Nested-FIFO end-to-end proof
- Rewrote the corner test that previously **pinned** the fail-soft fallback → now asserts inner-continuation registration + FIFO drain + a clean (non-failed) outer; added a **3-level-deep** re-entrancy test.
- New in-process ssr-ring end-to-end test: outer resolved (not failed), inner fallback inside the outer chunk, inner resolved at the FIFO tail.
- New **bytes-on-wire** ssr-ring test through real Jetty: inner resolved chunk + body stream on the wire, inner after outer (FIFO), no orphan daemon thread.
- New conformance fixture `spec/conformance/fixtures/ssr-streaming-nested.edn` + driver tests (shell registers only outer; outer drain registers inner at tail; inner resolves; wire-order FIFO). Reuses the existing streaming capability set so the CLJS corpus runner skips it out-of-claim exactly like `ssr-streaming.edn`.

## Gates (all cold, all green)
- ssr JVM `clojure -M:test`: **281 tests / 998 assertions / 0 failures**
- ssr-ring JVM `clojure -M:test`: **119 tests / 521 assertions / 0 failures**
- `npm run test:cljs`: **5654 tests / 19728 assertions / 0 failures**

Closes rf2-sgvn6, rf2-b1v8v.