### PR TITLE
test(test-quiet): pin runner behavioural contracts + correct JVM runner docs (rf2-vespg)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -27,6 +27,12 @@
                 ;; defmethod overrides) and re-frame.test-quiet.shadow-node
                 ;; (the :node-test runner wired via :main above).
                 "test-quiet/src"
+                ;; rf2-vespg — the shadow-node runner's own CLJS contract
+                ;; pin (re-frame.test-quiet-shadow-node-cljs-test) lives
+                ;; under test-quiet/test; listing it here puts the pin on
+                ;; the consolidated :node-test classpath so `npm run
+                ;; test:cljs` runs it (the `cljs-test$` ns-regexp matches).
+                "test-quiet/test"
                 "core/src"
                 "core/test"
                 ;; rf2-2mtte — CLJS-side public-API manifest enumeration

--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -12,48 +12,60 @@
   load time.  By the time cognitect-test-runner discovers tests and
   starts dispatching reports, the overrides are in place.
 
-  We also redirect cognitect-test-runner's one stdout artefact — the
-  `Running tests in #{...}` banner emitted by `cognitect.test-runner/test`
-  — into a captured StringWriter and replay it only when a failure or
-  error count is non-zero.  Same shape as the per-namespace banner
-  suppression in `re-frame.test-quiet`."
+  ## The discovery-banner contract
+
+  cognitect-test-runner emits exactly one stdout artefact of its own —
+  the `\\nRunning tests in #{...}` banner that `cognitect.test-runner/test`
+  prints via bare `println` before kicking off `run-tests`.  We swallow
+  it UNCONDITIONALLY: it lands in a throwaway buffer on both the green
+  and the red path and is never forwarded.
+
+  This is deliberate, not capture-and-replay.  We *cannot* replay it on
+  red even if we wanted to: `cognitect.test-runner/-main` computes the
+  fail/error counts and calls `(System/exit ...)` itself, in-process,
+  before returning.  Control never comes back to this wrapper after the
+  `apply` below — neither on green nor on red — so there is nothing to
+  inspect and nothing to forward.  The banner is therefore gone on every
+  path by construction.
+
+  Losing the banner on red costs nothing: it names only the directory
+  set (constant across runs, recoverable from deps.edn).  The diagnostic
+  signal a failing run needs — the per-ns `Testing <ns>` banner, the
+  `FAIL`/`ERROR` block, the summary — is emitted by the
+  `re-frame.test-quiet` reporter via `clojure.test/with-test-out`, which
+  writes to `clojure.test/*test-out*`.  That var is bound to the REAL
+  `*out*` at top level and is untouched by the `*out*` rebinding below,
+  so all of it reaches the real stdout regardless of the swap.  The
+  contract is exercised by `re-frame.test-quiet-runner-contract-test`.
+
+  Exit code is owned by cognitect-test-runner: 0 on green, 1 on any
+  failure or error (and 1 on a CLI parse error).  This wrapper adds no
+  exit logic and changes none of it."
   (:require
     [re-frame.test-quiet]
     [clojure.test]
     [cognitect.test-runner]))
 
 (defn -main [& args]
-  ;; Swallow the discovery-line "\nRunning tests in #{...}\n" that
-  ;; cognitect-test-runner emits before kicking off `run-tests`.  It
-  ;; runs once per invocation and carries no diagnostic value on green.
-  ;; A failure-time banner from re-frame.test-quiet already names the
-  ;; offending ns; this banner names the directory set, which is
-  ;; constant across runs and recoverable from the deps.edn.
+  ;; Swallow cognitect-test-runner's "\nRunning tests in #{...}\n"
+  ;; discovery line by binding `*out*` to a sink for the duration of the
+  ;; delegated call.  The discovery line uses a bare `println` so it
+  ;; lands in the sink; the reporter's failure output goes through
+  ;; `with-test-out` (bound to the real `*out*`) and bypasses the swap.
   ;;
-  ;; We do this by binding `*out*` around the test call.  Output that
-  ;; matters (clojure.test reporter writes via `with-test-out` which
-  ;; binds to a wrapped writer) bypasses the swap.  The discovery line
-  ;; uses bare `println` so it lands in our captured buffer.
-  ;;
-  ;; The captured text is only forwarded to the real `*out*` if the
-  ;; final summary reports failures or errors.
-  (let [captured (java.io.StringWriter.)
-        real-out *out*
-        summary  (binding [*out* (java.io.PrintWriter.
-                                   (proxy [java.io.Writer] []
-                                     (write
-                                       ([s] (.write captured (str s)))
-                                       ([s off len]
-                                        (.write captured (str s)
-                                                (int off) (int len))))
-                                     (flush [] (.flush captured))
-                                     (close [] (.close captured))))]
-                   (apply cognitect.test-runner/-main args)
-                   ;; clojure.test sets the System exit code via
-                   ;; cognitect.test-runner — we don't reach this line
-                   ;; on a failing suite because -main calls System/exit.
-                   nil)]
-    ;; In practice cognitect.test-runner/-main calls System/exit
-    ;; itself, so this fallthrough is only the green-on-stdout-only
-    ;; path. Forward NOTHING — the silent-on-success contract.
-    summary))
+  ;; `cognitect.test-runner/-main` calls `System/exit` from the computed
+  ;; fail/error counts, so control never returns past the `apply`: the
+  ;; sink is discarded and nothing here forwards it. See the ns docstring
+  ;; for why this is unconditional rather than capture-and-replay.
+  (binding [*out* (java.io.PrintWriter.
+                    (proxy [java.io.Writer] []
+                      (write
+                        ([s] nil)
+                        ([s off len] nil))
+                      (flush [] nil)
+                      (close [] nil)))]
+    (apply cognitect.test-runner/-main args)
+    ;; Unreachable: -main exited the JVM above. Present only so a future
+    ;; change that stops cognitect from calling System/exit fails loud
+    ;; (returns nil, no accidental stdout) rather than leaking the sink.
+    nil))

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -22,10 +22,10 @@
   {:dev/always true}
   (:require
     [re-frame.test-quiet]
+    [re-frame.test-quiet.shadow-node-cli :as cli]
     [shadow.test.env :as env]
     [shadow.test :as st]
-    [cljs.test :as ct]
-    [clojure.string :as str]))
+    [cljs.test :as ct]))
 
 ;; Silence stray runtime warnings on green. See ns docstring for the
 ;; capture-compatibility rationale.  Installed at ns-load time so it's
@@ -55,31 +55,9 @@
       (env/reset-test-data!)))
 
 ;; ----------------------------------------------------------------------
-;; CLI arg parsing — same shape shadow.test.node ships so the existing
-;; `npm run test:cljs -- --test=foo` form keeps working.
-
-(defn parse-args [args]
-  (reduce
-    (fn [opts arg]
-      (cond
-        (= "--help" arg)
-        (assoc opts :help true)
-
-        (= "--list" arg)
-        (assoc opts :list true)
-
-        (str/starts-with? arg "--test=")
-        (let [test-arg (subs arg 7)
-              test-syms
-              (->> (str/split test-arg ",")
-                   (map symbol))]
-          (update opts :test-syms into test-syms))
-
-        :else
-        (do (println (str "Unknown arg: " arg))
-            opts)))
-    {:test-syms []}
-    args))
+;; CLI arg parsing lives in `re-frame.test-quiet.shadow-node-cli` so it
+;; can be unit-pinned without a compile cycle (this ns is `:dev/always`
+;; + expands the `env/get-test-data` test-ns-enumeration macro).
 
 (defn find-matching-test-vars [test-syms]
   (let [test-namespaces (->> test-syms (filter simple-symbol?) (set))
@@ -117,5 +95,5 @@
   (reset-test-data!)
   (if env/UI-DRIVEN
     (js/console.log "Waiting for UI ...")
-    (let [opts (parse-args args)]
+    (let [opts (cli/parse-args args)]
       (execute-cli opts))))

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
@@ -1,0 +1,48 @@
+(ns re-frame.test-quiet.shadow-node-cli
+  "Pure CLI-arg parsing for the `:node-test` runner
+  `re-frame.test-quiet.shadow-node` (rf2-vespg).
+
+  Lives apart from the runner so it can be unit-pinned: the runner ns
+  carries `{:dev/always true}` and expands `shadow.test.env/get-test-data`
+  (a macro that enumerates the build's test namespaces at compile time),
+  which makes the runner compile-time-depend on every test ns in the
+  build.  A test ns that required the runner directly would form a
+  compile cycle.  `parse-args` has no such dependency, so factoring it
+  here lets `re-frame.test-quiet-shadow-node-cljs-test` pin the `--test=`
+  selection contract directly.
+
+  Same shape `shadow.test.node` ships, so the existing
+  `npm run test:cljs -- --test=foo` form keeps working."
+  (:require [clojure.string :as str]))
+
+(defn parse-args
+  "Parse shadow-node CLI args into
+  `{:test-syms [..] :help? :list?}` (flags present only when set).
+
+   - `--help` / `--list` set their boolean flag.
+   - `--test=a,b` splits on comma into symbols and accumulates into
+     `:test-syms` (repeated `--test=` flags accumulate).  A simple
+     symbol selects a whole namespace; a qualified symbol selects a
+     single var.
+   - any other arg is reported as unknown and otherwise ignored."
+  [args]
+  (reduce
+    (fn [opts arg]
+      (cond
+        (= "--help" arg)
+        (assoc opts :help true)
+
+        (= "--list" arg)
+        (assoc opts :list true)
+
+        (str/starts-with? arg "--test=")
+        (let [test-arg  (subs arg 7)
+              test-syms (->> (str/split test-arg ",")
+                             (map symbol))]
+          (update opts :test-syms into test-syms))
+
+        :else
+        (do (println (str "Unknown arg: " arg))
+            opts)))
+    {:test-syms []}
+    args))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -1,0 +1,168 @@
+(ns re-frame.test-quiet-runner-contract-test
+  "Subprocess contract pin for the JVM entry point
+  `re-frame.test-quiet.runner/-main` (rf2-vespg).
+
+  The stdout-line-count pin in `re-frame.test-quiet-pin-test` drives a
+  green sub-suite through `clojure.test/run-tests` directly — it never
+  touches the actual `-main` path the per-artefact `:test` aliases use,
+  the JVM failure/error path, or the discovery-banner contract.  Those
+  are the highest-risk promises in the runner's ns docs, and they can
+  only be observed across a process boundary: `cognitect.test-runner`
+  calls `System/exit` from the computed fail/error counts, so an
+  in-process call would kill this test JVM.
+
+  Each test here therefore relaunches a fresh JVM
+  (`java -cp <this-classpath>+<fixtures> clojure.main -m
+  re-frame.test-quiet.runner ...`) against a throwaway fixture suite
+  and asserts on the captured stdout / stderr / exit code.  Reusing the
+  running JVM's own `java.class.path` keeps the subprocess on the same
+  classpath this test already has (src + cognitect-test-runner +
+  clojure) without re-resolving deps or shelling through the `clojure`
+  launcher — which dodges Windows path-escaping in `-Sdeps`.
+
+  Contracts pinned (all against the REAL `-main`, not `run-tests`):
+
+   - GREEN: exit 0; canonical silent-on-success summary; the
+     cognitect `Running tests in #{...}` discovery banner is absent.
+   - RED:   exit 1; the per-ns `Testing <ns>` banner + the `FAIL`
+     block + `expected:`/`actual:` lines are present (diagnostic
+     output survives the `*out*` swap via `with-test-out`); the
+     discovery banner is STILL absent (swallowed unconditionally, not
+     replayed on red — the documented capture-and-replay was
+     unreachable and the docs now match this).
+   - ERROR: exit 1; the `ERROR in` block + the thrown message reach
+     stdout."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [clojure.java.io :as io]))
+
+;; ----------------------------------------------------------------------
+;; Subprocess harness.
+
+(def ^:private discovery-banner-marker
+  "The bare-`println` artefact cognitect-test-runner emits in
+  `cognitect.test-runner/test` — the one stdout line the runner swallows."
+  "Running tests in")
+
+(defn- write-fixture!
+  "Write a fixture test ns `probe.<file-stem>` into `dir` under the
+  underscore file layout cognitect-test-runner's classpath `require`
+  expects.  `body` is the deftest source."
+  [^java.io.File dir file-stem ns-suffix body]
+  (let [pkg-dir (io/file dir "probe")]
+    (.mkdirs pkg-dir)
+    (spit (io/file pkg-dir (str file-stem ".clj"))
+          (str "(ns probe." ns-suffix "\n"
+               "  (:require [clojure.test :refer [deftest is]]\n"
+               "            [re-frame.test-quiet]))\n"
+               body "\n"))))
+
+(defn- run-runner
+  "Relaunch a fresh JVM that runs `re-frame.test-quiet.runner/-main` with
+  `extra-args`, putting `fixture-dir` on both the classpath and the
+  runner's `-d` discovery set.  Returns {:exit :out :err}."
+  [^java.io.File fixture-dir & extra-args]
+  (let [java-bin (str (io/file (System/getProperty "java.home") "bin"
+                               (if (str/includes?
+                                     (str/lower-case (System/getProperty "os.name"))
+                                     "win")
+                                 "java.exe" "java")))
+        sep      (System/getProperty "path.separator")
+        cp       (str (System/getProperty "java.class.path") sep
+                      (.getAbsolutePath fixture-dir))
+        cmd      (into [java-bin "-cp" cp "clojure.main"
+                        "-m" "re-frame.test-quiet.runner"
+                        "-d" (.getAbsolutePath fixture-dir)]
+                       extra-args)
+        proc     (-> (ProcessBuilder. ^java.util.List cmd)
+                     (.redirectErrorStream false)
+                     (.start))
+        out      (slurp (.getInputStream proc))
+        err      (slurp (.getErrorStream proc))
+        exit     (.waitFor proc)]
+    {:exit exit :out out :err err}))
+
+(defn- with-fixture-dir
+  "Make a fresh temp dir, run `f` with it, then delete it."
+  [f]
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                       "tq-contract"
+                       (make-array java.nio.file.attribute.FileAttribute 0)))]
+    (try
+      (f dir)
+      (finally
+        (doseq [file (reverse (file-seq dir))]
+          (.delete ^java.io.File file))))))
+
+;; ----------------------------------------------------------------------
+;; Green path.
+
+(deftest green-runner-contract
+  (testing "a green suite through the real -main: exit 0, silent-on-success"
+    (with-fixture-dir
+      (fn [dir]
+        (write-fixture! dir "green_jvm_fixture_test" "green-jvm-fixture-test"
+                        "(deftest a-passing-test (is (= 1 1)))")
+        (let [{:keys [exit out err]} (run-runner dir)
+              non-blank (->> (str/split-lines out)
+                             (remove str/blank?))]
+          (is (zero? exit)
+              (str "green suite must exit 0; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (not (str/includes? out discovery-banner-marker))
+              (str "the cognitect discovery banner must be swallowed on"
+                   " green; captured stdout:\n" out))
+          (is (<= (count non-blank) 3)
+              (str "green stdout must be the canonical <=3-line summary;"
+                   " got " (count non-blank) " non-blank lines:\n"
+                   (str/join "\n" non-blank)))
+          (is (str/includes? out "0 failures, 0 errors.")
+              (str "green stdout must carry the summary line; got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
+;; Red path — failure.
+
+(deftest red-runner-contract
+  (testing "a failing suite through the real -main: exit 1, diagnostics survive"
+    (with-fixture-dir
+      (fn [dir]
+        (write-fixture! dir "red_jvm_fixture_test" "red-jvm-fixture-test"
+                        "(deftest a-failing-test (is (= :exp :act)))")
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (= 1 exit)
+              (str "failing suite must exit 1; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "Testing probe.red-jvm-fixture-test")
+              (str "the per-ns banner must be flushed on failure; got:\n" out))
+          (is (str/includes? out "FAIL in (a-failing-test)")
+              (str "the FAIL block must reach stdout; got:\n" out))
+          (is (and (str/includes? out "expected:")
+                   (str/includes? out "actual:"))
+              (str "expected:/actual: lines must reach stdout; got:\n" out))
+          (is (str/includes? out "1 failures, 0 errors.")
+              (str "the failing summary must reach stdout; got:\n" out))
+          (is (not (str/includes? out discovery-banner-marker))
+              (str "the discovery banner must STILL be swallowed on red"
+                   " (it is not replayed); captured stdout:\n" out)))))))
+
+;; ----------------------------------------------------------------------
+;; Red path — error.
+
+(deftest error-runner-contract
+  (testing "an erroring suite through the real -main: exit 1, ERROR block survives"
+    (with-fixture-dir
+      (fn [dir]
+        (write-fixture! dir "error_jvm_fixture_test" "error-jvm-fixture-test"
+                        (str "(deftest an-erroring-test"
+                             " (is (= 1 (throw (ex-info \"boom-marker\" {})))))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (= 1 exit)
+              (str "erroring suite must exit 1; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "ERROR in (an-erroring-test)")
+              (str "the ERROR block must reach stdout; got:\n" out))
+          (is (str/includes? out "boom-marker")
+              (str "the thrown exception message must reach stdout; got:\n" out))
+          (is (not (str/includes? out discovery-banner-marker))
+              (str "the discovery banner must be swallowed on error too;"
+                   " captured stdout:\n" out)))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -1,0 +1,159 @@
+(ns re-frame.test-quiet-shadow-node-cljs-test
+  "Contract pin for the CLJS `:node-test` entry point
+  `re-frame.test-quiet.shadow-node` (rf2-vespg).
+
+  The shadow-node runner carries custom CLI parsing, var-filtering, an
+  exit-code defmethod, and a global `console.warn` stub — none of which
+  had coverage.  This namespace pins the surfaces that can be exercised
+  in-process; the two that cannot (`st/run-all-tests` discovery and the
+  `js/process.exit` calls) are pinned at the level of the pure decision
+  they branch on, since calling them would tear down the node runner.
+
+  Contracts pinned:
+
+   - `--test=` SELECTION: comma-split into symbols, simple symbols are
+     namespace selectors and qualified symbols are single-var
+     selectors; `--list` / `--help` flags; unknown args are tolerated.
+   - FAILURE EXIT: the `:end-run-tests` defmethod exits 0 iff the
+     summary is `cljs.test/successful?`, 1 otherwise — pinned via the
+     predicate the defmethod branches on (calling the defmethod itself
+     would `process.exit` and kill this runner).
+   - console.warn CAPTURE COMPAT: the ns-load `console.warn` stub does
+     not break the local save/shim/restore capture pattern that
+     warning-assertion tests use — a shim installed over the stub still
+     records, and restore reverts to the stub."
+  ;; NB: must NOT require re-frame.test-quiet.shadow-node — that ns is
+  ;; `:dev/always` and expands the test-ns-enumeration macro, so a test
+  ;; requiring it forms a compile cycle. Pure CLI parsing lives in the
+  ;; `-cli` ns; the console.warn stub it installs is live at runtime
+  ;; anyway because shadow-node is the :node-test build's :main.
+  (:require [cljs.test :refer-macros [deftest is testing] :refer [successful?]]
+            [re-frame.test-quiet.shadow-node-cli :as cli]))
+
+;; ----------------------------------------------------------------------
+;; --test= selection / flag parsing.
+
+(deftest parse-args-test-selection
+  (testing "--test= splits on comma into symbols"
+    (is (= {:test-syms '[my.ns]}
+           (cli/parse-args ["--test=my.ns"]))
+        "a single simple symbol selects a whole namespace")
+    (is (= {:test-syms '[my.ns other.ns]}
+           (cli/parse-args ["--test=my.ns,other.ns"]))
+        "comma-separated values become multiple symbols")
+    (is (= {:test-syms '[my.ns/a-test]}
+           (cli/parse-args ["--test=my.ns/a-test"]))
+        "a qualified symbol selects a single var")
+    (is (= {:test-syms '[my.ns my.ns/a-test]}
+           (cli/parse-args ["--test=my.ns,my.ns/a-test"]))
+        "ns and fqn selectors coexist")
+    (is (= {:test-syms '[a b c d]}
+           (cli/parse-args ["--test=a,b" "--test=c,d"]))
+        "repeated --test= flags accumulate into one list")))
+
+(deftest parse-args-flags
+  (testing "--list and --help set their flags and default an empty test-syms"
+    (is (= {:test-syms [] :list true} (cli/parse-args ["--list"])))
+    (is (= {:test-syms [] :help true} (cli/parse-args ["--help"]))))
+  (testing "no args yields the run-all default (empty test-syms, no flags)"
+    (is (= {:test-syms []} (cli/parse-args []))))
+  (testing "unknown args are tolerated and do not abort parsing"
+    (is (= {:test-syms '[ok.ns]}
+           (cli/parse-args ["--bogus" "--test=ok.ns"]))
+        "an unknown flag is skipped; later valid flags still parse")))
+
+;; ----------------------------------------------------------------------
+;; Var filtering — simple symbols match by ns, qualified by fully-qualified
+;; name.  Driven against synthetic var-like maps so the pin does not depend
+;; on the live test-data registry.
+
+(defn- fake-var
+  "A stand-in for a test var: `meta` returns {:ns :name}, matching what
+  `find-matching-test-vars` reads."
+  [ns name]
+  (with-meta (fn []) {:ns ns :name name}))
+
+(deftest find-matching-test-vars-filtering
+  ;; find-matching-test-vars reads (env/get-test-vars); we cannot inject
+  ;; that registry here, but we CAN pin the selection predicate it builds
+  ;; — the (or (contains? namespaces ns) (contains? fqns (symbol ns name)))
+  ;; rule — by reproducing it over fake vars. This locks the documented
+  ;; "simple symbol = whole ns, qualified symbol = single var" contract.
+  (let [vars        [(fake-var 'my.ns 'a-test)
+                     (fake-var 'my.ns 'b-test)
+                     (fake-var 'other.ns 'c-test)]
+        select      (fn [test-syms]
+                      (let [namespaces (->> test-syms (filter simple-symbol?) set)
+                            fqns       (->> test-syms (filter qualified-symbol?) set)]
+                        (->> vars
+                             (filter (fn [v]
+                                       (let [{:keys [name ns]} (meta v)]
+                                         (or (contains? namespaces ns)
+                                             (contains? fqns (symbol ns name))))))
+                             (map (fn [v] (let [{:keys [ns name]} (meta v)]
+                                            (symbol ns name)))))))]
+    (testing "a simple symbol selects every var in that namespace"
+      (is (= '[my.ns/a-test my.ns/b-test] (select '[my.ns]))))
+    (testing "a qualified symbol selects exactly that var"
+      (is (= '[my.ns/b-test] (select '[my.ns/b-test]))))
+    (testing "ns + fqn selectors combine"
+      (is (= '[my.ns/a-test my.ns/b-test other.ns/c-test]
+             (select '[my.ns other.ns/c-test]))))
+    (testing "an unmatched selector yields nothing"
+      (is (= '[] (select '[absent.ns]))))))
+
+;; ----------------------------------------------------------------------
+;; Failure-exit decision — pinned via the predicate the :end-run-tests
+;; defmethod branches on. (Invoking the defmethod itself calls
+;; js/process.exit, which would tear down this runner.)
+
+(deftest end-run-tests-exit-decision
+  (testing "successful? is the green/red branch the exit defmethod uses"
+    (is (true? (successful? {:fail 0 :error 0}))
+        "0 failures + 0 errors is green -> the defmethod exits 0")
+    (is (false? (successful? {:fail 1 :error 0}))
+        "any failure is red -> the defmethod exits 1")
+    (is (false? (successful? {:fail 0 :error 1}))
+        "any error is red -> the defmethod exits 1"))
+  (testing "the exit defmethod is registered for the default reporter"
+    (is (some? (get-method cljs.test/report
+                           [:cljs.test/default :end-run-tests]))
+        "shadow-node must own the process-exit signal")))
+
+;; ----------------------------------------------------------------------
+;; console.warn stub compatibility — the ns-load stub must not break the
+;; local capture pattern warning-assertion tests rely on.
+
+(deftest console-warn-capture-compat
+  (testing "the save/shim/restore capture pattern round-trips over the live baseline"
+    ;; Under the real :node-test build, shadow-node is :main, so the live
+    ;; `console.warn` at this point IS its silencing stub.  Warning-assertion
+    ;; tests don't depend on WHICH baseline is installed — only that the
+    ;; save -> install-recording-shim -> run -> restore pattern records the
+    ;; body's warnings and reverts cleanly.  Pinning the round-trip (rather
+    ;; than `identical?`-ing against the stub, which would require coupling
+    ;; to shadow-node and re-form the compile cycle) is the contract that
+    ;; keeps those tests working whether or not the stub is in place.
+    (let [saved    (.-warn js/console)
+          recorded (atom [])]
+      (set! (.-warn js/console) (fn [& args] (swap! recorded conj (vec args))))
+      (try
+        (js/console.warn "captured-marker" 42)
+        (is (= [["captured-marker" 42]] @recorded)
+            "the recording shim receives the warning call unchanged")
+        (finally
+          (set! (.-warn js/console) saved)))
+      (is (identical? saved (.-warn js/console))
+          "restore reverts console.warn to exactly the saved baseline")
+      ;; After restore, the recording shim is gone: a further warning does
+      ;; not leak back into the capture atom.
+      (reset! recorded [])
+      (js/console.warn "post-restore-marker")
+      (is (= [] @recorded)
+          "after restore the recording shim no longer captures (clean revert)")))
+  (testing "the ns-load stub is installed in this build (shadow-node is :main)"
+    ;; Soft evidence the silencing stub is live: calling console.warn at
+    ;; the baseline must not throw. This catches a regression that replaced
+    ;; the stub with something that errors on a bare call.
+    (is (nil? (js/console.warn "stub-smoke"))
+        "the live baseline console.warn must accept a bare call without throwing")))


### PR DESCRIPTION
@-