### PR TITLE
fix(xray/palette): route :snapshot-app-db through safe egress (rf2-mxzgg)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1417,7 +1417,7 @@ of them ship post-rf2-ybjkx:
 |---|---|---|---|
 | `:toggle-theme` | Toggle theme (dark ↔ light) | `#{:dynamic :static}` | Flips the `rf-xray-theme-{dark,light}` class on the shell root. |
 | `:cycle-reduced-motion` | Cycle reduced-motion override (OS → always → never) | `#{:dynamic :static}` | Three-state cycle: `:os` (OS pref alone) → `:always` (force reduce) → `:never` (force full). User override of `prefers-reduced-motion: reduce`; rides the `--rf-xray-motion-scale` seam in `theme/global-styles/motion-css`. Persists across reloads. |
-| `:snapshot-app-db` | Snapshot app-db | `#{:dynamic :static}` | Dumps the focused frame's app-db to the JS console + clipboard for sharing. |
+| `:snapshot-app-db` | Snapshot app-db | `#{:dynamic :static}` | Dumps the focused frame's app-db to the JS console + clipboard for sharing. Both are off-box sinks, so the payload is routed through `runtime/egress-value` first (pinned to the focused frame) — sensitive ⇒ `:rf/redacted`, large ⇒ `:rf.size/large-elided`, fail-closed; the verb has no raw opt-in (rf2-mxzgg). |
 | `:jump-to-settings` | Jump to Settings | `#{:dynamic :static}` | Equivalent to the `,` / `s` bare-key shortcut; available from the palette so the user can fuzzy-find the gesture without leaving the keyboard. |
 | `:toggle-mode` | Toggle mode (Dynamic ↔ Static) | `#{:dynamic :static}` | Chord parity with `Cmd-Shift-M`; flips `:rf.xray/mode` between `:dynamic` and `:static`. |
 | `:clear-epoch-history` | Clear epoch history | `#{:dynamic}` | Drops Xray's epoch snapshots (Dynamic-only — no epoch concept under Static). |

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -553,7 +553,7 @@ catalogue.
 |---|---|---|---|---|
 | `:toggle-theme` | Toggle theme (dark ↔ light) | `Settings · Theme` | `[:palette/toggle-theme]` | Dark ↔ Light cycle of the theme class. Popup radio is the canonical UI; this is the keyboard-first ergonomic shortcut. |
 | `:cycle-reduced-motion` | Cycle reduced-motion override (OS → always → never) | `user override of prefers-reduced-motion` | `[:palette/cycle-reduced-motion]` | Three-state cycle `:os → :always → :never → :os`. Overrides `prefers-reduced-motion: reduce` via the `--rf-xray-motion-scale` seam. Persists across reloads. |
-| `:snapshot-app-db` | Snapshot app-db | `→ console.log + clipboard` | `[:palette/snapshot-app-db]` | Drops the focused frame's app-db onto the JS console + clipboard for share-with-teammate capture. |
+| `:snapshot-app-db` | Snapshot app-db | `→ console.log + clipboard` | `[:palette/snapshot-app-db]` | Drops the focused frame's app-db onto the JS console + clipboard for share-with-teammate capture. The console + clipboard are **off-box egress sinks**, so the payload routes through `runtime/egress-value` FIRST (pinned to the focused frame via `with-frame` so that frame's own schema declarations govern) — sensitive slots ⇒ `:rf/redacted`, large slots ⇒ `:rf.size/large-elided`, fail-closed, exactly as the `get-app-db` accessor. The command surfaces no opt-in arg, so the command default is always the redacted/size-elided projection — never the raw db (rf2-mxzgg / rf2-6fgob). |
 | `:jump-to-settings` | Jump to Settings | `,` | `[:palette/jump-to-settings]` | Opens the Settings popup at the General tab. Equivalent to the `,` bare-key shortcut. |
 | `:toggle-mode` | Toggle mode (Dynamic ↔ Static) | `Cmd/Ctrl+Shift+M` | `[:palette/toggle-mode]` | Flip Dynamic ↔ Static. Chord parity with `Cmd/Ctrl+Shift+M` in `keybinding.cljs`. |
 | `:open-popout` | Open Xray in a pop-out window | `rf-xray-popout` | `[:palette/open-popout]` | Opens the same-origin pop-out window via `popout!`. |
@@ -707,6 +707,17 @@ declarations are keyed by absolute path, so a slice egress'd in isolation
 declaration won't match and the raw leaf would cross the boundary
 (rf2-a96xq). A whole-db read passes no `:path` (the value IS the walked
 root, `[]`).
+
+The accessors are not the only off-box egress sites: the command-palette
+`:snapshot-app-db` verb ships the focused frame's app-db to the JS console
+**and** the system clipboard — both off-box sinks — so it routes the
+captured value through `egress-value` before either sink, pinned to the
+focused frame (`with-frame tf`) so that frame's own declarations govern
+the redaction (rf2-mxzgg). The whole-db snapshot passes no `:path` (the
+value IS the walked root). Because the verb exposes no opt-in arg, the
+snapshot is always the redacted / size-elided projection — the raw-egress
+opt-in (`{:include-sensitive? true}` / `{:include-large? true}`) is
+reachable only through the runtime accessors, never the palette command.
 
 ### Inspection band (9 accessors — read-only)
 

--- a/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
@@ -32,6 +32,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.runtime :as runtime]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.palette.recents :as recents]
             [day8.re-frame2-xray.palette.sources :as sources]))
@@ -116,28 +117,74 @@
 ;; user can paste into a teammate's chat / a gist. Clipboard writes
 ;; can reject (insecure context, no permission); we swallow the throw
 ;; so the console log lands either way.
+;;
+;; ## Off-box egress (rf2-mxzgg / rf2-6fgob)
+;;
+;; The JS console AND the system clipboard are both OFF-BOX egress
+;; sinks (Tool-Pair §Privacy egress, Security.md §Off-box egress):
+;; whatever lands there can be screenshotted, pasted into a teammate's
+;; chat, or scraped from a console log. The raw `(rf/app-db-value tf)`
+;; can carry schema-/path-declared sensitive slots (`{:auth {:token …}}`)
+;; or oversized blobs, so it MUST NOT cross either sink unredacted.
+;;
+;; We therefore route the captured value through the runtime's single
+;; named safe-egress fn `runtime/egress-value` — the SAME fail-closed
+;; projection the `get-app-db` accessor uses (post rf2-a96xq). On the
+;; bare (no-opt) call the off-box defaults are baked in: sensitive
+;; slots ⇒ `:rf/redacted`, large slots ⇒ `:rf.size/large-elided`. The
+;; whole-db read has no `:path` (the value IS the walked root), so the
+;; root-keyed schema declarations match directly. Raw egress is only
+;; ever reachable via the documented operator opt-in
+;; (`{:include-sensitive? true}` / `{:include-large? true}`); the
+;; palette command surfaces NO opt-in arg, so the command default is
+;; always the redacted/elided projection — never the raw db.
+;;
+;; ## Why the egress runs inside `(rf/with-frame tf …)`
+;;
+;; `egress-value` (→ `elide-wire-value`) resolves the schema-declared
+;; sensitive / large declarations from `frame/current-frame` when no
+;; explicit `:frame` opt is passed. The snapshot reads the FOCUSED
+;; frame's db (`tf`), which is NOT necessarily the frame the fx fires
+;; in (the palette dispatches against `:rf/xray`). Pinning the current
+;; frame to `tf` for the egress makes the walker match `tf`'s OWN
+;; declarations — so a host frame's `[:auth :token]` redacts against
+;; the host frame's schema, not the (empty) Xray-frame declarations.
+;; Fail-closed: a frame with no declarations still emits the raw value
+;; only when that frame declared nothing sensitive, exactly as the
+;; per-frame contract intends.
 
 (defn- snapshot-app-db!
-  "Side-effect: drop `(rf/app-db-value target-frame)` onto the JS
-  console and copy a pr-str of it to the clipboard when reachable.
-  No-op when neither console nor clipboard is present (test
-  runtimes). Returns nil."
+  "Side-effect: drop the focused frame's app-db onto the JS console and
+  copy a pr-str of it to the clipboard when reachable. The value is
+  routed through `runtime/egress-value` FIRST (fail-closed off-box
+  defaults — sensitive ⇒ `:rf/redacted`, large ⇒ `:rf.size/large-
+  elided`), pinned to the FOCUSED frame so that frame's own schema
+  declarations govern the redaction, so neither off-box sink ever
+  receives the raw db (rf2-mxzgg). No-op when neither console nor
+  clipboard is present (test runtimes). Returns nil."
   [target-frame]
   (try
-    (let [tf  (or target-frame :rf/default)
-          db  (when (some? (frame/frame tf))
-                (rf/app-db-value tf))
-          tag (str "[rf2-xray] palette snapshot · frame "
-                   (pr-str tf))]
+    (let [tf      (or target-frame :rf/default)
+          ;; Egress BEFORE anything reaches console/clipboard. Both are
+          ;; off-box sinks; `egress-value`'s default polarity redacts
+          ;; sensitive + size-elides large slots. No `:path` — the
+          ;; whole-db snapshot IS the walked root, so root-keyed schema
+          ;; declarations match directly. `with-frame tf` pins the
+          ;; declaration lookup to the focused frame (see comment above).
+          payload (when (some? (frame/frame tf))
+                    (rf/with-frame tf
+                      (runtime/egress-value (rf/app-db-value tf))))
+          tag     (str "[rf2-xray] palette snapshot · frame "
+                       (pr-str tf))]
       (when (and (exists? js/console) (.-log js/console))
         (try
-          (.log js/console tag db)
+          (.log js/console tag payload)
           (catch :default _ nil)))
       (when (and (exists? js/navigator)
                  (.-clipboard js/navigator)
                  (.-writeText (.-clipboard js/navigator)))
         (try
-          (.writeText (.-clipboard js/navigator) (pr-str db))
+          (.writeText (.-clipboard js/navigator) (pr-str payload))
           (catch :default _ nil))))
     (catch :default _ nil))
   nil)
@@ -178,9 +225,12 @@
   (rf/reg-fx :rf.xray.palette.fx/popout popout-fx!)
 
   ;; rf2-ybjkx — snapshot app-db fx. Side-effect handler; reads the
-  ;; focused frame's db and ships it to the JS console + clipboard.
-  ;; Late-bound through the framework's `frame/frame` registry so a
-  ;; nil-frame ctx is a silent no-op rather than a throw.
+  ;; focused frame's db, routes it through `runtime/egress-value` (the
+  ;; fail-closed off-box safe-egress projection, rf2-mxzgg) and ships
+  ;; the REDACTED/size-elided payload to the JS console + clipboard —
+  ;; both off-box sinks. Late-bound through the framework's
+  ;; `frame/frame` registry so a nil-frame ctx is a silent no-op rather
+  ;; than a throw.
   (rf/reg-fx :rf.xray.palette.fx/snapshot-app-db
     (fn [_ctx {:keys [target-frame]}]
       (snapshot-app-db! target-frame)))

--- a/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
@@ -9,8 +9,14 @@
 
   The palette pop-out fx is replaced with a counting stub so the
   Ctrl+Enter / open-popout invocations can be asserted without
-  driving the mount layer (which would need a real `window.open`)."
+  driving the mount layer (which would need a real `window.open`).
+
+  rf2-mxzgg — the snapshot-app-db egress tests stub `js/console.log`
+  and a clipboard `writeText` so the off-box payload (both sinks) can
+  be captured and asserted to carry the redacted/size-elided
+  projection rather than the raw secret."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [goog.object :as gobj]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -429,3 +435,146 @@
        false]))
   (is (empty? (:palette-recents (xray-db)))
       "panel jumps don't pollute the recents vector"))
+
+;; ---- rf2-mxzgg — snapshot-app-db routes off-box payload through safe egress
+
+;; The `:palette/snapshot-app-db` verb fires the
+;; `:rf.xray.palette.fx/snapshot-app-db` fx, which reads the focused
+;; frame's app-db and ships it to TWO off-box sinks: `console.log` and
+;; `navigator.clipboard.writeText`. Pre-rf2-mxzgg it shipped the RAW
+;; `(rf/app-db-value tf)` — a schema-declared sensitive slot
+;; (`{:auth {:password "shh"}}`) crossed both sinks unredacted. The fix
+;; routes the value through `runtime/egress-value` (the same fail-closed
+;; projection `get-app-db` uses) FIRST, so the off-box payload carries
+;; `:rf/redacted` by default. These tests capture both sinks and assert
+;; the secret never leaves the box on the command default.
+
+(defn- capture-snapshot-sinks!
+  "Stub `js/console.log` + a `navigator.clipboard.writeText` so the
+  snapshot fx's two off-box payloads are captured rather than emitted.
+  Returns `{:console (atom []) :clipboard (atom [])}` carrying every
+  payload each sink received; the caller restores nothing because the
+  test fixture resets the runtime + the node globals are per-process
+  scratch (the real console.log is restored explicitly below)."
+  []
+  (let [console-payloads   (atom [])
+        clipboard-payloads (atom [])
+        orig-log           (when (and (exists? js/console) (.-log js/console))
+                             (.-log js/console))]
+    ;; console.log(tag, value) — capture the SECOND arg (the payload),
+    ;; but ONLY when the first arg is the snapshot tag so we don't
+    ;; swallow the test reporter's own output (CLJS `println` on the
+    ;; node-test target routes through `js/console.log`; a blanket stub
+    ;; would eat a FAIL banner emitted while the stub is installed).
+    (set! (.-log js/console)
+          (fn [& args]
+            (when (and (string? (first args))
+                       (re-find #"\[rf2-xray\] palette snapshot" (first args)))
+              (swap! console-payloads conj (second args)))
+            (when orig-log (apply orig-log args))
+            nil))
+    ;; Install a clipboard whose writeText records the EDN string. node
+    ;; test runtimes have no navigator.clipboard, so we synthesise one.
+    (let [nav (if (exists? js/navigator)
+                js/navigator
+                (let [n (js-obj)]
+                  (set! js/navigator n)
+                  n))]
+      (gobj/set nav "clipboard"
+                (js-obj "writeText"
+                        (fn [s] (swap! clipboard-payloads conj s) nil))))
+    {:console   console-payloads
+     :clipboard clipboard-payloads
+     :restore   (fn [] (when orig-log (set! (.-log js/console) orig-log)))}))
+
+;; The focused frame is the HOST app's frame, NOT Xray's own `:rf/xray`
+;; frame — the palette dispatches against `:rf/xray` but the snapshot
+;; reads the frame the L1 picker focused (`:target-frame`). We model that
+;; faithfully with a dedicated `:rf/host` frame: the secret + the schema
+;; declarations live on `:rf/host`, and the fix's `(with-frame tf …)`
+;; egress pin makes the walker resolve `:rf/host`'s declarations even
+;; though the fx fires in the `:rf/xray` frame.
+
+(def ^:private host-frame :rf/host)
+
+(defn- seed-sensitive-host! [db-fn]
+  ;; Register the sensitive schema + seed the secret INTO the host frame
+  ;; (not Xray's). `reg-app-schema` / `populate-…!` default to
+  ;; `frame/current-frame`, so we run them inside `(with-frame host …)`.
+  (frame/reg-frame host-frame {})
+  (rf/with-frame host-frame
+    (rf/reg-app-schema [:auth]
+                       [:map
+                        [:username :string]
+                        [:password {:sensitive? true} :string]])
+    (rf/populate-sensitive-from-schemas!)
+    (rf/reg-event-db :test/seed-host (fn [db _] (db-fn db)))
+    (rf/dispatch-sync [:test/seed-host])))
+
+(defn- drive-snapshot-of-host! []
+  ;; Focus the host frame (the slot the L1 picker writes) then drive the
+  ;; real `:palette/snapshot-app-db` verb from the `:rf/xray` frame.
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-frame host-frame])
+    (rf/dispatch-sync [:rf.xray/palette-open])
+    (rf/dispatch-sync
+      [:rf.xray/palette-invoke
+       {:source :command
+        :id     :snapshot-app-db
+        :label  "Snapshot app-db"
+        :action [:palette/snapshot-app-db]}
+       false])))
+
+(deftest snapshot-app-db-redacts-sensitive-slot-on-both-off-box-sinks
+  ;; rf2-mxzgg — the command default MUST route the snapshot through
+  ;; safe egress before EITHER off-box sink receives it. The egress is
+  ;; pinned to the focused (host) frame so that frame's own schema
+  ;; declarations govern the redaction.
+  (setup!)
+  (let [sinks (capture-snapshot-sinks!)]
+    (try
+      (seed-sensitive-host!
+        (fn [db] (assoc db :auth {:username "ada" :password "hunter2"})))
+      (drive-snapshot-of-host!)
+      ;; --- console sink ---
+      (let [payload (first @(:console sinks))]
+        (is (some? payload) "the console.log sink received a payload")
+        (is (= :rf/redacted (get-in payload [:auth :password]))
+            "console payload redacts the schema-declared sensitive slot")
+        (is (not= "hunter2" (get-in payload [:auth :password]))
+            "the raw secret never crosses the console off-box sink")
+        (is (= "ada" (get-in payload [:auth :username]))
+            "non-sensitive sibling survives in the console payload"))
+      ;; --- clipboard sink (pr-str of the SAME egressed payload) ---
+      (let [edn (first @(:clipboard sinks))]
+        (is (string? edn) "the clipboard sink received a pr-str payload")
+        (is (re-find #":rf/redacted" edn)
+            "clipboard payload carries the :rf/redacted marker")
+        (is (not (re-find #"hunter2" edn))
+            "the raw secret never crosses the clipboard off-box sink"))
+      (finally ((:restore sinks))))))
+
+(deftest snapshot-app-db-size-elides-large-slot-on-both-off-box-sinks
+  ;; rf2-mxzgg — size minimisation rides the same safe-egress default
+  ;; (polarity parity with the runtime accessors): a schema-declared
+  ;; `:large?` slot is replaced with the `:rf.size/large-elided` marker.
+  (setup!)
+  (let [sinks (capture-snapshot-sinks!)]
+    (try
+      (frame/reg-frame host-frame {})
+      (rf/with-frame host-frame
+        (rf/reg-app-schema [:blob]
+                           [:map
+                            [:payload {:large? true} :any]])
+        (rf/populate-elision-from-schemas!)
+        (rf/reg-event-db :test/seed-blob
+          (fn [db _] (assoc db :blob {:payload {:big "value"}})))
+        (rf/dispatch-sync [:test/seed-blob]))
+      (drive-snapshot-of-host!)
+      (let [payload (first @(:console sinks))]
+        (is (some? payload) "the console.log sink received a payload")
+        (is (contains? (get-in payload [:blob :payload]) :rf.size/large-elided)
+            "console payload size-elides the schema-declared large slot")
+        (is (not= {:big "value"} (get-in payload [:blob :payload]))
+            "the raw large value never crosses the console off-box sink"))
+      (finally ((:restore sinks))))))


### PR DESCRIPTION
## Summary

The CODE half of rf2-6fgob (skill-doc half landed in #3148). The Xray command-palette `:snapshot-app-db` verb read the RAW focused-frame app-db (`tools/xray/src/day8/re_frame2_xray/palette/events.cljs`) and shipped it to the JS **console** AND the system **clipboard** — both off-box egress sinks — bypassing the runtime's named safe-egress path. A focused frame holding a schema-/path-declared sensitive value (e.g. `{:auth {:token "secret"}}`) or an oversized blob was logged + copied RAW.

## Fix

Route the captured value through `runtime/egress-value` before either sink — the same fail-closed projection `get-app-db` uses (post rf2-a96xq). Off-box defaults are baked in: sensitive ⇒ `:rf/redacted`, large ⇒ `:rf.size/large-elided`.

The egress is pinned to the focused frame via `(rf/with-frame tf …)` so that frame's OWN schema declarations govern the redaction — the fx fires in the `:rf/xray` frame, but the snapshot reads the host frame the L1 picker focused. Without the pin the walker would resolve the (empty) Xray-frame declarations and a host frame's sensitive slot would still leak.

The verb surfaces no opt-in arg, so the command default is always the redacted/size-elided projection — the raw-egress opt-in (`{:include-sensitive? true}` / `{:include-large? true}`) is reachable only through the runtime accessors, never the palette command.

## Regression test

`events_cljs_test.cljs` drives the REAL `:palette/snapshot-app-db` fx against a dedicated host frame carrying a sensitive (and, separately, a large) slot, capturing BOTH off-box sinks (console + clipboard) and asserting they carry the redacted / size-elided marker, never the raw value. Proven to fail against the pre-fix raw read (6 failures showing raw `"hunter2"` + raw blob crossing both sinks).

## Spec

Standing rule (palette egress contract changed): `API.md` (command-verb row + Privacy egress section) and `007-UX-IA.md` command-table row now document the palette snapshot as an off-box egress site routed through `egress-value`.

## Gates

- xray JVM `clojure -M:test` — 1101 tests, 0 failures
- `npm run test:cljs` — 5656 tests, 0 failures
- `npm run test:bundle-isolation` — PASS (runtime require does not leak into production bundles)
- `test:xray-feature-gate` not relevant — this egress fix is covered by CLJS unit tests (the real fx path), not a visual feature-matrix surface

Closes rf2-mxzgg.