### PR TITLE
fix(pair-mcp): redact sensitive cascade-summary :event-vector at egress (rf2-6nks4)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1973,6 +1973,44 @@
                                (:action-id t)  (assoc :action-id (:action-id t)))))))]
     (when (seq picks) picks)))
 
+(defn- redact-sensitive-event-vector
+  "Egress guard for the cascade-summary `:event-vector` slot (rf2-6nks4,
+  finding-2).
+
+  The `:event-vector` slot copies the epoch's RAW `:trigger-event` — the
+  original dispatch vector, e.g. `[:auth/login {:password \"hunter2\"}]`.
+  When the source epoch is declared sensitive (`:rf.epoch/sensitive?
+  true`) that raw payload MUST NOT cross the off-box egress boundary
+  under the default privacy posture: `cascade-summary` is the ONE place
+  the trigger-event leaves the runtime verbatim, and the consuming MCP
+  tools (`restore-epoch` passes the runtime map through verbatim;
+  `dispatch-dry-run` deliberately does NOT walk `:cascade-summary`,
+  treating it as a counts-only projection) trust this projection to be
+  already-safe. The merged rf2-z7roa elision walker scrubs dispatch-dry-
+  run's `:db-state-after-simulation` / `:would-fire-effects` but left
+  the cascade-summary `:event-vector` UNWALKED — a restore / dry-run of
+  a sensitive historical epoch shipped the raw event payload even under
+  `--allow-sensitive-reads` OFF.
+
+  Fail-closed: when the epoch is sensitive AND the raw-state gate is OFF
+  (the published-build default — the MCP server flips it to OFF the
+  moment a state-emitting tool first fires unless the operator launched
+  with `--allow-sensitive-reads`), the slot redacts to the `:rf/redacted`
+  sentinel — the SAME sentinel the wire-path `elide-wire-value` walker
+  substitutes for a declared-sensitive slot. The redaction is keyed to
+  the epoch-level `:rf.epoch/sensitive?` rollup rather than per-value
+  elision because the trigger-event is not addressed by an app-db path
+  the `[:rf/runtime :elision]` registry can classify — its sensitivity
+  is a property of the epoch, not of a declared-sensitive db slot.
+
+  Raw only on opt-in: when the gate is ON the operator deliberately
+  asked for raw reads, so the verbatim trigger-event rides through. A
+  non-sensitive epoch is never redacted regardless of the gate."
+  [trigger-event sensitive?]
+  (if (and sensitive? (not (:allow-raw-state? @raw-state-config)))
+    :rf/redacted
+    trigger-event))
+
 (defn cascade-summary
   "Project an assembled `:rf/epoch-record` into the compact wire shape
   surfaced by dispatch / reset-frame-db / restore-epoch / dispatch-dry-
@@ -2004,7 +2042,12 @@
                :subs-recomputed (count (or sub-runs []))
                :renders         (count (or renders []))}
         event-id      (assoc :event-id event-id)
-        trigger-event (assoc :event-vector trigger-event)
+        ;; rf2-6nks4 (finding-2): the raw trigger-event is redacted to
+        ;; `:rf/redacted` when the epoch is sensitive and the raw-state
+        ;; gate is OFF (fail-closed default) — see
+        ;; `redact-sensitive-event-vector`. Raw only on opt-in.
+        trigger-event (assoc :event-vector
+                             (redact-sensitive-event-vector trigger-event sensitive?))
         transitions   (assoc :machine-transitions transitions)
         elapsed       (assoc :elapsed-ms elapsed)
         errors        (assoc :errors errors)
@@ -2471,6 +2514,12 @@
     (let [diff       (db-diff-summary pre-db (:db-after target))
           fx-fired   (->> (:effects target) (map :fx-id) distinct vec)
           transitions (machine-transitions-summary (:trace-events target))
+          ;; rf2-6nks4 (finding-2): a restore of a SENSITIVE historical
+          ;; epoch must not ship the target's raw trigger-event under the
+          ;; default off-box posture. Read the target epoch's
+          ;; `:rf.epoch/sensitive?` rollup and redact the `:event-vector`
+          ;; through the same fail-closed gate cascade-summary uses.
+          sensitive?  (:rf.epoch/sensitive? target)
           ;; Every fx in the target's :effects fired BEFORE the restore;
           ;; the restore rewinds db only. They are unreplayable by
           ;; construction.
@@ -2488,7 +2537,10 @@
                 :renders         (count (or (:renders target) []))
                 :restore?       true}
          (:event-id target)      (assoc :event-id (:event-id target))
-         (:trigger-event target) (assoc :event-vector (:trigger-event target))
+         (:trigger-event target) (assoc :event-vector
+                                        (redact-sensitive-event-vector
+                                          (:trigger-event target) sensitive?))
+         sensitive?              (assoc :sensitive? true)
          transitions             (assoc :machine-transitions transitions))
        :unreplayable-effects unreplayable})))
 

--- a/skills/re-frame2-pair/tests/runtime/cascade_summary_redaction_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/cascade_summary_redaction_test.clj
@@ -1,0 +1,297 @@
+;;;; tests/runtime/cascade_summary_redaction_test.clj
+;;;;
+;;;; Babashka-runnable verification of the cascade-summary `:event-vector`
+;;;; egress redaction (rf2-6nks4, finding-2) in
+;;;; `preload/re_frame2_pair/runtime.cljs`.
+;;;;
+;;;; THE BUG (rf2-6nks4, finding-2): `cascade-summary` /
+;;;; `restore-cascade-summary` copy the epoch's RAW `:trigger-event` into
+;;;; the projection's `:event-vector` slot verbatim, and the MCP
+;;;; `restore-epoch` + `dispatch-dry-run` tools pass that projection
+;;;; through (restore-epoch ships the runtime map verbatim; dispatch-dry-
+;;;; run DELIBERATELY does not walk `:cascade-summary`). The merged
+;;;; rf2-z7roa elision walker scrubbed dispatch-dry-run's
+;;;; `:db-state-after-simulation` / `:would-fire-effects` but left the
+;;;; cascade-summary `:event-vector` UNWALKED — so a restore / dry-run of
+;;;; a SENSITIVE historical epoch returned the raw event payload (auth
+;;;; tokens, passwords, …) even under `--allow-sensitive-reads` OFF.
+;;;;
+;;;; THE FIX: `redact-sensitive-event-vector` redacts the slot to
+;;;; `:rf/redacted` when the source epoch is `:rf.epoch/sensitive? true`
+;;;; AND the runtime raw-state gate is OFF (the published-build default —
+;;;; the MCP server signals `configure-raw-state! {:allow-raw-state?
+;;;; false}` before restore-epoch / dispatch-dry-run build the summary).
+;;;; Fail-closed: gate OFF redacts; gate ON (operator opted in via
+;;;; `--allow-sensitive-reads`) ships the raw vector. A non-sensitive
+;;;; epoch is never redacted.
+;;;;
+;;;; Why a parallel implementation lives here:
+;;;;
+;;;; `preload/re_frame2_pair/runtime.cljs` is a CLJS-only file loaded into
+;;;; the consumer app via shadow-cljs `:devtools :preloads`. It depends on
+;;;; the live re-frame2 epoch history / trace buffer / `rf/elide-wire-value`,
+;;;; none of which run under bb. This file mirrors the pure projection +
+;;;; gate logic and asserts behaviour against canned epoch records; a
+;;;; structural pin (below) keeps the mirror honest against the source so
+;;;; a regression in the real cljs (e.g. someone re-introduces the raw
+;;;; verbatim assoc) trips a RED here.
+;;;;
+;;;; KEEP IN SYNC WITH preload/re_frame2_pair/runtime.cljs §Cascade summary
+;;;; (`redact-sensitive-event-vector` / `cascade-summary` /
+;;;; `restore-cascade-summary`).
+;;;;
+;;;; Run: bb tests/runtime/cascade_summary_redaction_test.clj
+;;;; Exit: 0 = pass, non-zero = fail.
+
+(ns cascade-summary-redaction-test
+  (:require [clojure.java.io :as io]
+            [clojure.set]
+            [clojure.test :refer [deftest is run-tests testing]]
+            [clojure.walk :as walk]))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of preload/re_frame2_pair/runtime.cljs §Cascade summary
+;; (the `:event-vector` egress redaction slice). KEEP IN SYNC.
+;; ---------------------------------------------------------------------------
+
+;; The runtime gate: `(defonce raw-state-config (atom {:allow-raw-state?
+;; true}))`. Default true ⇒ a bare REPL session sees verbatim; the MCP
+;; server flips it to false via `configure-raw-state!` the moment a
+;; state-emitting tool first fires. We mirror it as a rebindable atom.
+(def ^:private raw-state-config (atom {:allow-raw-state? true}))
+
+(defn- redact-sensitive-event-vector
+  "Mirror of the egress guard. Redacts the raw trigger-event to
+  `:rf/redacted` when the epoch is sensitive AND the raw-state gate is
+  OFF (fail-closed). Raw only on opt-in; non-sensitive never redacts."
+  [trigger-event sensitive?]
+  (if (and sensitive? (not (:allow-raw-state? @raw-state-config)))
+    :rf/redacted
+    trigger-event))
+
+(defn- db-diff-summary
+  [db-before db-after]
+  (cond
+    (and (map? db-before) (map? db-after))
+    (let [ks-b   (set (keys db-before))
+          ks-a   (set (keys db-after))
+          common (clojure.set/intersection ks-b ks-a)]
+      {:added-paths   (vec (sort (map vector (clojure.set/difference ks-a ks-b))))
+       :removed-paths (vec (sort (map vector (clojure.set/difference ks-b ks-a))))
+       :changed-paths (vec (sort (for [k common
+                                       :when (not= (get db-before k) (get db-after k))]
+                                   [k])))})
+    (= db-before db-after)
+    {:added-paths [] :removed-paths [] :changed-paths []}
+    :else
+    {:added-paths [] :removed-paths [] :changed-paths [[]]}))
+
+(defn cascade-summary
+  "Mirror of `cascade-summary` (the slot subset relevant to the
+  `:event-vector` redaction fix). `dispatch-dry-run`'s `:cascade-summary`
+  routes through this same fn in the real runtime."
+  [{:keys [epoch-id event-id trigger-event frame db-before db-after effects]
+    :as record}]
+  (when record
+    (let [diff       (db-diff-summary db-before db-after)
+          fx-fired   (->> effects (map :fx-id) distinct vec)
+          sensitive? (:rf.epoch/sensitive? record)]
+      (cond-> {:epoch-id        epoch-id
+               :frame           frame
+               :outcome         :ok
+               :db-diff         diff
+               :fx-fired        fx-fired}
+        event-id      (assoc :event-id event-id)
+        trigger-event (assoc :event-vector
+                             (redact-sensitive-event-vector trigger-event sensitive?))
+        sensitive?    (assoc :sensitive? true)))))
+
+(defn restore-cascade-summary
+  "Mirror of `restore-cascade-summary`'s `:event-vector` slice — reads the
+  TARGET epoch's `:rf.epoch/sensitive?` rollup and redacts the
+  `:event-vector` through the same gate. (The real fn also computes
+  `:db-diff` from `pre-db`, `:unreplayable-effects`, etc.; this mirror
+  pins only the redaction-relevant slots.)"
+  [target]
+  (let [sensitive? (:rf.epoch/sensitive? target)]
+    {:cascade-summary
+     (cond-> {:epoch-id (:epoch-id target)
+              :frame    (:frame target)
+              :outcome  :ok
+              :restore? true}
+       (:event-id target)      (assoc :event-id (:event-id target))
+       (:trigger-event target) (assoc :event-vector
+                                      (redact-sensitive-event-vector
+                                        (:trigger-event target) sensitive?))
+       sensitive?              (assoc :sensitive? true))}))
+
+;; ---------------------------------------------------------------------------
+;; Canned epoch records.
+;; ---------------------------------------------------------------------------
+
+;; A SENSITIVE epoch — a login cascade whose trigger-event carries a
+;; password in the dispatch vector. The framework stamped the epoch
+;; `:rf.epoch/sensitive? true` (declared-sensitive db slot OR a
+;; `:sensitive? true` registration). The raw `:trigger-event` MUST NOT
+;; ride the `:event-vector` off-box under the default gate-OFF posture.
+(def sensitive-login-epoch
+  {:epoch-id 42
+   :event-id :auth/login
+   :trigger-event [:auth/login {:username "ada" :password "hunter2"}]
+   :frame :rf/default
+   :rf.epoch/sensitive? true
+   :db-before {:auth {}}
+   :db-after  {:auth {:user "ada"}}
+   :effects   [{:fx-id :http}]})
+
+;; A NON-sensitive epoch — an ordinary cart-add. The trigger-event is
+;; safe to surface verbatim regardless of the gate.
+(def benign-cart-epoch
+  {:epoch-id 7
+   :event-id :cart/add
+   :trigger-event [:cart/add {:sku "x"}]
+   :frame :rf/default
+   :db-before {:cart {}}
+   :db-after  {:cart {:items 1}}
+   :effects   []})
+
+;; ---------------------------------------------------------------------------
+;; Behavioural tests — reproduce-then-fix.
+;;
+;; RED on the pre-fix runtime (which copied `:trigger-event` into
+;; `:event-vector` verbatim, so a sensitive epoch leaked the password
+;; under gate OFF). GREEN on the fixed runtime.
+;; ---------------------------------------------------------------------------
+
+(defn- with-gate [allow-raw-state? thunk]
+  (let [prev @raw-state-config]
+    (reset! raw-state-config {:allow-raw-state? allow-raw-state?})
+    (try (thunk) (finally (reset! raw-state-config prev)))))
+
+(deftest sensitive-event-vector-redacted-by-default-in-cascade-summary
+  ;; THE bug. Gate OFF (the published-build default once the MCP server
+  ;; signals it) — the sensitive trigger-event MUST redact, not leak.
+  (with-gate false
+    (fn []
+      (let [summary (cascade-summary sensitive-login-epoch)]
+        (testing "the raw password never appears on the wire"
+          (is (= :rf/redacted (:event-vector summary))
+              ":event-vector redacts to :rf/redacted for a sensitive epoch under gate OFF")
+          (is (not= [:auth/login {:username "ada" :password "hunter2"}]
+                    (:event-vector summary))
+              "the raw trigger-event MUST NOT ride the wire")
+          (is (not (clojure.string/includes? (pr-str summary) "hunter2"))
+              "the password literal appears NOWHERE in the projected summary"))
+        (testing "the sensitivity is still annotated for the consumer"
+          (is (true? (:sensitive? summary))))))))
+
+(deftest sensitive-event-vector-redacted-by-default-in-restore-cascade-summary
+  ;; restore-epoch's projection — same gate, same redaction. RED before
+  ;; the fix (restore-cascade-summary never read :rf.epoch/sensitive? and
+  ;; copied the raw target trigger-event verbatim).
+  (with-gate false
+    (fn []
+      (let [extras  (restore-cascade-summary sensitive-login-epoch)
+            summary (:cascade-summary extras)]
+        (is (= :rf/redacted (:event-vector summary))
+            "restore-epoch's :event-vector redacts for a sensitive target epoch under gate OFF")
+        (is (true? (:sensitive? summary))
+            "restore-cascade-summary annotates :sensitive? true")
+        (is (not (clojure.string/includes? (pr-str extras) "hunter2"))
+            "the password literal appears NOWHERE in the restore projection")))))
+
+;; ---------------------------------------------------------------------------
+;; Negative guards — the redaction must NOT over-fire.
+;; ---------------------------------------------------------------------------
+
+(deftest benign-event-vector-rides-verbatim-regardless-of-gate
+  ;; A non-sensitive epoch's trigger-event is safe — it must ride
+  ;; verbatim whether the gate is ON or OFF.
+  (doseq [gate [true false]]
+    (with-gate gate
+      (fn []
+        (let [summary (cascade-summary benign-cart-epoch)]
+          (is (= [:cart/add {:sku "x"}] (:event-vector summary))
+              (str "benign :event-vector rides verbatim (gate=" gate ")"))
+          (is (nil? (:sensitive? summary))
+              "a non-sensitive epoch carries no :sensitive? slot"))))))
+
+(deftest sensitive-event-vector-rides-verbatim-on-explicit-opt-in
+  ;; Gate ON (operator launched with --allow-sensitive-reads) — the raw
+  ;; vector rides through deliberately. The redaction is opt-in-reversible,
+  ;; not a hard scrub.
+  (with-gate true
+    (fn []
+      (let [summary (cascade-summary sensitive-login-epoch)]
+        (is (= [:auth/login {:username "ada" :password "hunter2"}]
+               (:event-vector summary))
+            "gate ON ships the raw trigger-event (operator opted in)")
+        (is (true? (:sensitive? summary))
+            "the :sensitive? annotation still rides so the consumer knows")))))
+
+;; ---------------------------------------------------------------------------
+;; Structural pin — keep the bb mirror honest against the cljs source.
+;; A regression that re-introduces the raw `(assoc :event-vector
+;; trigger-event)` verbatim (bypassing `redact-sensitive-event-vector`)
+;; trips these.
+;; ---------------------------------------------------------------------------
+
+(def ^:private runtime-cljs-path
+  (some (fn [p] (when (.exists (io/file p)) p))
+        ["preload/re_frame2_pair/runtime.cljs"
+         "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
+         "../preload/re_frame2_pair/runtime.cljs"]))
+
+(defn- read-all-forms [^String src]
+  (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
+    (loop [acc []]
+      (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
+                      (catch Exception _ ::eof))]
+        (if (= ::eof form) acc (recur (conj acc form)))))))
+
+(def ^:private all-forms
+  (when runtime-cljs-path (read-all-forms (slurp runtime-cljs-path))))
+
+(defn- top-level-named [kinds sym]
+  (some (fn [form]
+          (when (and (seq? form) (kinds (first form)) (= sym (second form)))
+            form))
+        all-forms))
+
+(defn- form-contains? [pred form]
+  (let [hit? (atom false)]
+    (walk/postwalk (fn [node] (when (pred node) (reset! hit? true)) node) form)
+    @hit?))
+
+(deftest source-defines-redact-sensitive-event-vector
+  (is (some? runtime-cljs-path) "runtime.cljs must be locatable")
+  (let [form (top-level-named #{'defn 'defn-} 'redact-sensitive-event-vector)]
+    (is (some? form)
+        "runtime.cljs must define `redact-sensitive-event-vector` (rf2-6nks4 finding-2).")
+    (is (form-contains? #(= :rf/redacted %) form)
+        "the guard MUST substitute the :rf/redacted sentinel.")
+    (is (form-contains? #(= :allow-raw-state? %) form)
+        "the guard MUST consult the :allow-raw-state? gate (fail-closed default).")))
+
+(deftest source-cascade-summary-routes-event-vector-through-guard
+  (let [form (top-level-named #{'defn 'defn-} 'cascade-summary)]
+    (is (some? form) "runtime.cljs must define `cascade-summary`")
+    (is (form-contains?
+          (fn [node] (and (seq? node)
+                          (= 'redact-sensitive-event-vector (first node))))
+          form)
+        "cascade-summary MUST route :event-vector through redact-sensitive-event-vector — never a raw verbatim assoc (rf2-6nks4 finding-2).")))
+
+(deftest source-restore-cascade-summary-routes-event-vector-through-guard
+  (let [form (top-level-named #{'defn 'defn-} 'restore-cascade-summary)]
+    (is (some? form) "runtime.cljs must define `restore-cascade-summary`")
+    (is (form-contains?
+          (fn [node] (and (seq? node)
+                          (= 'redact-sensitive-event-vector (first node))))
+          form)
+        "restore-cascade-summary MUST route :event-vector through redact-sensitive-event-vector (rf2-6nks4 finding-2).")
+    (is (form-contains? #(= :rf.epoch/sensitive? %) form)
+        "restore-cascade-summary MUST read the target epoch's :rf.epoch/sensitive? rollup.")))
+
+(let [{:keys [fail error]} (run-tests 'cascade-summary-redaction-test)]
+  (System/exit (if (zero? (+ (or fail 0) (or error 0))) 0 1)))

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -517,7 +517,16 @@ off-box read surfaces above — and `dispatch-dry-run`'s egress slots
    `dispatch-dry-run`'s `:db-state-after-simulation` /
    `:would-fire-effects[*].args`) return the `:rf/redacted` sentinel;
    sensitive trace events / epochs are stripped from streaming
-   payloads.
+   payloads. The `:cascade-summary` `:event-vector` slot — which copies
+   the epoch's raw `:trigger-event` — is likewise redacted to
+   `:rf/redacted` when the source epoch is `:rf.epoch/sensitive? true`
+   (rf2-6nks4). This redaction is applied SERVER-SIDE inside the runtime
+   projection (`restore-cascade-summary` / `cascade-summary`), keyed to
+   the epoch-level sensitivity rollup rather than per-value elision — the
+   trigger-event is not addressed by an app-db path the elision registry
+   classifies. It therefore covers `restore-epoch` and `dispatch-dry-run`
+   (whose `:cascade-summary` is otherwise NOT walked, being a counts-only
+   projection).
 2. Force `:elision true` on every call. Caller-supplied
    `:elision false` is dropped — large slots return the
    `:rf.size/large-elided` marker.
@@ -531,10 +540,13 @@ off-box read surfaces above — and `dispatch-dry-run`'s egress slots
 
    This signal is issued by every tool that taps / egresses app-db,
    between the preload probe and the first state-emitting eval — the
-   read surfaces, `dispatch-dry-run`, AND `reset-frame-db` (rf2-z7roa).
-   `reset-frame-db` in particular MUST issue it before its
-   `app-db-reset!` call so the FIRST reset of a `--allow-writes`
-   session cannot tap raw app-db ahead of the posture landing. The
+   read surfaces, `dispatch-dry-run`, `restore-epoch`, AND
+   `reset-frame-db` (rf2-z7roa / rf2-6nks4). `reset-frame-db` in
+   particular MUST issue it before its `app-db-reset!` call so the FIRST
+   reset of a `--allow-writes` session cannot tap raw app-db ahead of
+   the posture landing. `restore-epoch` issues it so the runtime
+   redacts a sensitive target epoch's `:cascade-summary` `:event-vector`
+   before building the projection. The
    per-build signal cache is marked successful ONLY after the
    `configure-raw-state!` eval resolves, never speculatively — a
    concurrent first caller awaits the same in-flight signal rather than
@@ -779,7 +791,7 @@ marker so consumers can branch.
 |-----------------------|-----------------------------------|-------|
 | `:epoch-id`           | `:any` (integer in ref runtime)   | The assembled epoch's id. |
 | `:event-id`           | keyword                           | The triggering event-id. Absent on synthetic / halted-trigger-less paths. |
-| `:event-vector`       | vector                            | The original dispatch vector. Absent on synthetic paths. |
+| `:event-vector`       | vector or `:rf/redacted`          | The original dispatch vector. Absent on synthetic paths. **Redacted to `:rf/redacted` when the source epoch is `:rf.epoch/sensitive? true` and `--allow-sensitive-reads` is OFF** (rf2-6nks4) — the raw trigger-event payload (auth tokens, passwords, …) must not cross the off-box boundary under the default posture. Rides verbatim only when the operator opted in via `--allow-sensitive-reads`. |
 | `:frame`              | keyword                           | The frame-id the cascade settled in. |
 | `:outcome`            | `:ok` / `:blocked` / `:error`     | The consumer-facing tier per `outcome->consumer-facing`. Forced `:error` when the cascade contained a thrown handler / machine action — see §Contained throws below. |
 | `:db-diff`            | `{:changed-paths [...] :added-paths [...] :removed-paths [...]}` | Depth-1 path summary of the db delta. Each path is a one-key vector (e.g. `[:cart]`); drill in via `get-path`. |

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
@@ -14,6 +14,21 @@
   the gate is closed the tool returns `:rf.error/writes-disabled`
   without touching the nREPL socket. See `tools/writes.cljs`.
 
+  ## Sensitive-read posture (rf2-6nks4, finding-2)
+
+  Restore's success envelope carries a `:cascade-summary` whose
+  `:event-vector` slot copies the TARGET epoch's raw `:trigger-event`.
+  A restore of a SENSITIVE historical epoch must NOT ship that raw
+  payload off-box under the default `--allow-sensitive-reads` OFF
+  posture. Like `dispatch-dry-run` (which restore-epoch's primitive
+  internally drives), this tool issues `raw-state/signal-runtime!`
+  between `ensure-runtime!` and the eval so the runtime's
+  `configure-raw-state!` posture is flipped to the server's boot-gate
+  state BEFORE `restore-cascade-summary` builds the projection. The
+  runtime then redacts the sensitive `:event-vector` to `:rf/redacted`
+  (see `redact-sensitive-event-vector` in the preload runtime).
+  Fail-closed: gate OFF redacts, gate ON (operator opted in) ships raw.
+
   ## epoch-id is `:any`
 
   The `epoch-id` arg is parsed as EDN, not assumed `string?` — the
@@ -28,10 +43,12 @@
   failure modes). The runtime primitive returns `false` on any failure
   (the frame's app-db is unchanged); we surface that as
   `{:ok? false :reason :restore-rejected}`."
-  (:require [re-frame2-pair-mcp.tools.args :as args]
+  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.writes :as writes]))
 
 ;; The `epoch-id` arg is parsed as EDN with NO shape constraint — any
@@ -61,33 +78,46 @@
               call (if frame
                      (ef/rt-call 'restore-epoch epoch-id frame)
                      (ef/rt-call 'restore-epoch epoch-id))
-              form (ef/emit call)]
-          (probe/eval-after-runtime!
-            conn build-id form :restore-epoch-failed
-            (fn [v]
-              ;; Per rf2-6yqdl: the runtime now returns a structured
-              ;; envelope on success carrying `:ok? :restored? :epoch-id
-              ;; :frame :cascade-summary :unreplayable-effects`. Failure
-              ;; remains the legacy `false` so older runtimes still
-              ;; surface as a clean reject envelope here.
-              (wire/ok-text
-                (cond
-                  (map? v)
-                  v
+              form (ef/emit call)
+              on-value
+              (fn [v]
+                ;; Per rf2-6yqdl: the runtime now returns a structured
+                ;; envelope on success carrying `:ok? :restored? :epoch-id
+                ;; :frame :cascade-summary :unreplayable-effects`. Failure
+                ;; remains the legacy `false` so older runtimes still
+                ;; surface as a clean reject envelope here.
+                (wire/ok-text
+                  (cond
+                    (map? v)
+                    v
 
-                  v
-                  {:ok?       true
-                   :restored? true
-                   :epoch-id  epoch-id
-                   :frame     frame}
+                    v
+                    {:ok?       true
+                     :restored? true
+                     :epoch-id  epoch-id
+                     :frame     frame}
 
-                  :else
-                  {:ok?       false
-                   :restored? false
-                   :reason    :restore-rejected
-                   :epoch-id  epoch-id
-                   :frame     frame
-                   :hint      (str "restore-epoch returned false — the epoch-id is not in the "
-                                   "ring, or a drain is in flight. Read the structured reason "
-                                   "with (re-frame.trace.tooling/trace-buffer {:op-type :error}) "
-                                   "filtered to :rf.epoch/*.")})))))))))
+                    :else
+                    {:ok?       false
+                     :restored? false
+                     :reason    :restore-rejected
+                     :epoch-id  epoch-id
+                     :frame     frame
+                     :hint      (str "restore-epoch returned false — the epoch-id is not in the "
+                                     "ring, or a drain is in flight. Read the structured reason "
+                                     "with (re-frame.trace.tooling/trace-buffer {:op-type :error}) "
+                                     "filtered to :rf.epoch/*.")})))]
+          ;; rf2-6nks4 (finding-2): signal the raw-state posture to the
+          ;; runtime BEFORE the restore eval, so the cascade-summary it
+          ;; builds redacts a sensitive `:event-vector` under the default
+          ;; gate-OFF posture. Mirrors dispatch-dry-run's prelude shape
+          ;; (which restore-epoch's primitive internally drives) — we can
+          ;; not use the plain `eval-after-runtime!` prelude because that
+          ;; helper has no `signal-runtime!` step. The signal is idempotent
+          ;; per build per session, so a session that already signalled
+          ;; (e.g. via a prior snapshot/dry-run) pays no extra round-trip.
+          (-> (probe/ensure-runtime! conn build-id)
+              (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
+              (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+              (.then on-value)
+              (.catch (fn [err] (probe/err->result :restore-epoch-failed err)))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/restore_epoch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/restore_epoch_test.cljs
@@ -11,8 +11,10 @@
     - the success / restore-rejected envelope shapes."
   (:require [cljs.test :refer-macros [deftest is async]]
             [cljs.reader]
+            [clojure.string :as str]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.writes :as writes]
             [re-frame2-pair-mcp.tools.restore-epoch :as restore-epoch]))
 
@@ -21,17 +23,46 @@
     (swap! conn assoc :probed-builds #{:app})
     conn))
 
+;; The tool now issues TWO evals on the happy path: the
+;; `configure-raw-state!` signal (raw-state/signal-runtime!, rf2-6nks4)
+;; and the `restore-epoch` form. The stub matches by substring — the
+;; configure eval resolves to nil (swallowed); the restore eval resolves
+;; to `canned-value`. `captured*` records the LAST non-configure form
+;; (the restore form) so the existing form-shape assertions keep working;
+;; `with-captured-all!` (below) records EVERY form for ordering tests.
 (defn- with-captured-eval!
   [captured* canned-value body-fn]
   (let [orig nrepl/cljs-eval-value
+        run  (fn [form-str]
+               (if (str/includes? form-str "configure-raw-state!")
+                 (js/Promise.resolve nil)
+                 (do (reset! captured* form-str)
+                     (js/Promise.resolve canned-value))))
         stub (fn
-               ([_conn _build-id form-str]
-                (reset! captured* form-str)
-                (js/Promise.resolve canned-value))
-               ([_conn _build-id form-str _opts]
-                (reset! captured* form-str)
-                (js/Promise.resolve canned-value)))]
+               ([_conn _build-id form-str] (run form-str))
+               ([_conn _build-id form-str _opts] (run form-str)))]
     (set! nrepl/cljs-eval-value stub)
+    (raw-state/reset-runtime-signal-cache!)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+(defn- with-captured-all!
+  "Record EVERY emitted form (configure + restore) in order, so a test
+  can assert the raw-state signal precedes the restore eval (rf2-6nks4)."
+  [forms* canned-value body-fn]
+  (let [orig nrepl/cljs-eval-value
+        run  (fn [form-str]
+               (swap! forms* conj form-str)
+               (js/Promise.resolve
+                 (if (str/includes? form-str "configure-raw-state!")
+                   nil
+                   canned-value)))
+        stub (fn
+               ([_conn _build-id form-str] (run form-str))
+               ([_conn _build-id form-str _opts] (run form-str)))]
+    (set! nrepl/cljs-eval-value stub)
+    (raw-state/reset-runtime-signal-cache!)
     (-> (js/Promise.resolve nil)
         (.then (fn [_] (body-fn)))
         (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
@@ -193,6 +224,79 @@
                      (is (= [{:fx-id :http :coord [:my.app.cart 42 4]}]
                             (:unreplayable-effects edn))
                          "unreplayable-effects rides through verbatim"))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-6nks4 (finding-2) — sensitive cascade-summary :event-vector egress.
+;;
+;; The runtime's restore-cascade-summary redacts the target epoch's raw
+;; :event-vector to :rf/redacted when the epoch is sensitive AND the
+;; raw-state gate is OFF (the published-build default). For that runtime
+;; redaction to fire, the tool MUST signal `configure-raw-state!` to the
+;; runtime BEFORE the restore eval — exactly like dispatch-dry-run. These
+;; tests pin the WIRE boundary (the signal ordering + gate posture pushed);
+;; the runtime redaction itself is exercised by the bb runtime test
+;; (skills/re-frame2-pair/tests/runtime/cascade_summary_redaction_test.clj).
+;; ---------------------------------------------------------------------------
+
+(deftest signals-raw-state-posture-before-the-restore-eval
+  (async done
+    (let [forms (atom [])
+          prev  (raw-state/allow-raw-state-enabled?)]
+      (raw-state/set-allow-raw-state! false)
+      (-> (with-writes-on!
+            (fn []
+              (with-captured-all! forms true
+                (fn []
+                  (restore-epoch/restore-epoch-tool (fresh-conn) #js {:epoch-id "7"})))))
+          (.then (fn [_]
+                   (let [all      @forms
+                         cfg-idx  (first (keep-indexed (fn [i f] (when (str/includes? f "configure-raw-state!") i)) all))
+                         rst-idx  (first (keep-indexed (fn [i f] (when (str/includes? f "restore-epoch") i)) all))]
+                     (is (some? cfg-idx) "configure-raw-state! is signalled")
+                     (is (some? rst-idx) "the restore-epoch form is evaluated")
+                     (is (< cfg-idx rst-idx)
+                         "raw-state posture is signalled BEFORE the restore eval (so the runtime redacts a sensitive :event-vector)")
+                     (is (str/includes? (nth all cfg-idx) ":allow-raw-state? false")
+                         "the gate-OFF posture is pushed to the runtime"))))
+          (.finally (fn [] (raw-state/set-allow-raw-state! prev) (done)))))))
+
+(deftest redacted-sensitive-event-vector-rides-through
+  ;; The runtime already redacted the sensitive target epoch's
+  ;; :event-vector to :rf/redacted (gate OFF). The tool passes the
+  ;; runtime envelope through verbatim — the redacted marker must survive
+  ;; on the wire, and the raw payload must NOT appear anywhere.
+  (async done
+    (let [redacted-cascade {:epoch-id 7
+                            :event-id :auth/login
+                            :event-vector :rf/redacted
+                            :sensitive? true
+                            :frame :rf/default
+                            :outcome :ok
+                            :db-diff {:changed-paths [[:auth]] :added-paths [] :removed-paths []}
+                            :fx-fired [:http]
+                            :subs-recomputed 1
+                            :renders 1
+                            :restore? true}
+          runtime-envelope {:ok? true :restored? true :epoch-id 7
+                            :frame :rf/default
+                            :cascade-summary redacted-cascade
+                            :unreplayable-effects [{:fx-id :http}]}]
+      (-> (with-writes-on!
+            (fn []
+              (with-captured-eval! (atom nil) runtime-envelope
+                (fn []
+                  (restore-epoch/restore-epoch-tool (fresh-conn) #js {:epoch-id "7"})))))
+          (.then (fn [r]
+                   (is (not (err? r)))
+                   (let [edn  (read-result-text r)
+                         text (tu/extract-text r)]
+                     (is (= :rf/redacted (get-in edn [:cascade-summary :event-vector]))
+                         "the redacted :event-vector marker rides through verbatim")
+                     (is (true? (get-in edn [:cascade-summary :sensitive?]))
+                         "the :sensitive? annotation rides through")
+                     (is (not (str/includes? text "password"))
+                         "no raw payload literal appears on the wire"))
                    (done)))))))
 
 (deftest legacy-true-runtime-falls-back-to-stub-envelope


### PR DESCRIPTION
## Summary

Closes **rf2-6nks4** finding-2: a restore / dry-run of a *sensitive* historical epoch leaked the raw event payload (auth tokens, passwords, …) under default `--allow-sensitive-reads` **OFF**.

The runtime `cascade-summary` / `restore-cascade-summary` copied the epoch's raw `:trigger-event` into the projection's `:event-vector` slot **verbatim**, and the consuming MCP tools passed it through:
- `restore-epoch` ships the runtime map verbatim;
- `dispatch-dry-run` **deliberately does NOT walk** `:cascade-summary` (it is a counts-only projection).

The merged `z7roa` (#3115) elision walker scrubbed dispatch-dry-run's `:db-state-after-simulation` / `:would-fire-effects[*].args` but left the cascade-summary `:event-vector` **UNWALKED**.

> **Finding-1** (wrong rollup key) was already fixed by merged `5613h` (#3109) — verified, no change needed.

## Fix (fail-closed; raw only on opt-in)

- **Runtime** (`runtime.cljs`): new `redact-sensitive-event-vector` guard substitutes `:rf/redacted` for `:event-vector` when the source epoch is `:rf.epoch/sensitive? true` **AND** the raw-state gate is OFF. Keyed to the epoch-level sensitivity rollup (the trigger-event isn't addressed by an app-db path the elision registry can classify). Applied in **both** `cascade-summary` (covers dispatch-dry-run / dispatch / reset-frame-db) and `restore-cascade-summary` (covers restore-epoch / undo-*). `restore-cascade-summary` now also reads the target's `:rf.epoch/sensitive?` rollup and annotates `:sensitive? true`.
- **pair-mcp `restore-epoch` tool**: now signals `configure-raw-state!` to the runtime **before** the restore eval (mirrors dispatch-dry-run's prelude) so the runtime posture reflects the server boot-gate before the projection is built — restore-epoch previously never signalled it.

## Without-fix leak proof

Against the pre-fix logic, gate OFF:
```
PRE-FIX cascade-summary :event-vector = [:auth/login {:username "ada", :password "hunter2"}]
PRE-FIX leaks password literal? => true
```
Fixed: `:event-vector` ⇒ `:rf/redacted`.

## Regression

- **bb runtime** `cascade_summary_redaction_test.clj` (new): behavioural (sensitive `:event-vector` redacts under gate OFF; rides verbatim on opt-in; non-sensitive never redacted) + **structural pins** that go RED on the pre-fix source (raw verbatim assoc / missing guard). Proven RED against a reverted source copy.
- **pair-mcp** `restore_epoch_test.cljs`: signals raw-state before the restore eval; redacted marker rides through verbatim with no raw payload literal on the wire.

## Spec

`003-Tool-Catalogue.md`: documents the `:event-vector` redaction in the cascade-summary slot table + the `--allow-sensitive-reads` egress list; adds restore-epoch to the `configure-raw-state!` signal set.

## Gates (all green, cold)

- pair-mcp tests — **910 tests / 2789 assertions, 0 failures**
- `npm run test:bundle-isolation` — **PASS**
- `npm run test:mcp-conformance` — **all 6 gates GREEN**
- bb runtime suite (new + siblings) — **GREEN**