### PR TITLE
test(testbed-support): pin ?project-root override contract via pure seam (rf2-6bq0o)

### DIFF
--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -62,15 +62,38 @@
   [s]
   (when (and (string? s) (seq (str/trim s))) s))
 
+(defn- query-param-from-search
+  "Pure parser for the per-session override knob: given a URL query string
+  `search` (the `?a=b&c=d` form, as produced by `location.search`) and a
+  `param-name`, return that param's value URL-decoded, trimmed, and
+  non-blank — or nil when the param is absent, blank, or the search string
+  itself is blank/nil.
+
+  `js/URLSearchParams` is a host global (present in browsers AND in Node),
+  so this fn carries no `js/window` dependency and is fully exercisable
+  off-browser. It is the testable heart of the override contract: param
+  selection, URL-decoding (`%2F` → `/`), trimming, and the blank-falls-
+  through rule all live here. The only genuinely browser-bound step — reading
+  `location.search` off the live document — is isolated in `query-param`."
+  [search param-name]
+  (when-let [s (non-blank search)]
+    (let [params (js/URLSearchParams. s)]
+      (when-let [raw (non-blank (.get params param-name))]
+        (str/trim raw)))))
+
 (defn- query-param
   "Return the named URL query param as a trimmed non-blank string, or nil
   when absent / blank / running outside a browser. The per-session
-  override knob — not a Xray/Story-API surface, so kept private."
+  override knob — not a Xray/Story-API surface, so kept private.
+
+  Thin browser-only adapter: reads `location.search` off the live document
+  when a `js/window` exists, then delegates the parse/decode/trim/non-blank
+  contract to the pure `query-param-from-search`. Outside a browser (e.g.
+  `:node-test`) there is no `js/window`, so this returns nil and the
+  build-time `repo-root` tier governs (the intended non-browser degradation)."
   [param-name]
   (when (exists? js/window)
-    (let [params (-> js/window .-location .-search (js/URLSearchParams.))]
-      (when-let [raw (non-blank (.get params param-name))]
-        (str/trim raw)))))
+    (query-param-from-search (-> js/window .-location .-search) param-name)))
 
 (defn- strip-trailing-slash
   "Return `s` without a single trailing slash, leaving a lone `\"/\"` intact."

--- a/tools/testbed-support/src/re_frame/testbed/config_cljs_test.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config_cljs_test.cljs
@@ -41,17 +41,32 @@
   code for every build except `:node-test` (which finds it by the
   `cljs-test$` ns regexp) and is tree-shaken out of any release bundle.
 
-  ## Why no `?project-root=` query-override assertion here
+  ## How the `?project-root=` override (tier 1) is pinned here
 
   Tier 1 of the resolution order — the `?project-root=<path>` query
-  string winning over everything — is guarded by `(exists? js/window)`
-  and reads `js/window.location.search`. There is no `js/window` under
-  `:node-test`, so the override branch degrades to `nil` (exactly as
-  intended for a non-browser host) and the `repo-root` tier governs.
-  Faking a `js/window.location` to drive the override under node would
-  be brittle over-mocking of a browser-only seam; the override
-  precedence is a browser concern and the node degradation
-  (no window → query-param nil → repo-root tier) IS asserted below."
+  string winning over everything — used to have NO executable coverage:
+  the override read `js/window.location.search` directly, and there is no
+  `js/window` under `:node-test`, so the branch silently degraded to nil
+  and the cross-machine escape hatch could regress unnoticed (rf2-6bq0o).
+
+  `config.cljs` now isolates the single genuinely browser-bound step —
+  reading `location.search` off the live document — behind the thin
+  `query-param` adapter, and delegates the actual parse/decode/trim/
+  non-blank contract to the PURE `query-param-from-search`, which takes a
+  query string verbatim. `js/URLSearchParams` is a host global present in
+  Node too, so that pure parser runs identically off-browser. That lets us
+  pin, with no `js/window` faking:
+
+    a. the override-parsing contract — param selection, URL-decoding
+       (`%2F` → `/`), trimming, and the blank-falls-through rule — by
+       driving `query-param-from-search` with literal search strings; and
+    b. tier-1 PRECEDENCE — the override winning over a present `repo-root`,
+       a blank override falling through to the `repo-root` tier — by
+       `with-redefs`-ing the private `query-param` (the same technique the
+       join/normalisation tests use for `repo-root`).
+
+  The node degradation (no window → adapter returns nil → repo-root tier)
+  is still asserted in `resolve-project-root-nil-when-root-blank` below."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.testbed.config :as config]))
 
@@ -173,6 +188,107 @@
             `non-blank` gate on the root"
     (with-redefs [config/repo-root "   "]
       (is (nil? (config/resolve-project-root "tools/xray/testbeds"))))))
+
+;; ---- query-param-from-search: the pure override parser (tier 1) --------
+;;
+;; The override knob's parse/decode/trim/non-blank contract, exercised
+;; off-browser by handing the pure parser literal `location.search`
+;; strings. `js/URLSearchParams` is a Node global too, so this is the
+;; same code path the browser adapter runs — no `js/window` fakery.
+
+(deftest query-param-from-search-reads-the-named-param
+  (testing "the named param's value is returned, trimmed + non-blank"
+    (is (= "/home/dev/re-frame2"
+           (#'config/query-param-from-search
+            "?project-root=/home/dev/re-frame2" "project-root")))
+    (is (= "/home/dev/re-frame2"
+           (#'config/query-param-from-search
+            "project-root=/home/dev/re-frame2" "project-root"))
+        "a leading ? is optional — URLSearchParams tolerates either form")))
+
+(deftest query-param-from-search-url-decodes-the-value
+  (testing "percent-encoded path separators (and spaces) are decoded, so a
+            `?project-root=` value that travelled through a URL arrives as a
+            real on-disk path"
+    (is (= "/home/dev/re-frame2"
+           (#'config/query-param-from-search
+            "?project-root=%2Fhome%2Fdev%2Fre-frame2" "project-root")))
+    (is (= "C:/Users/me/my code"
+           (#'config/query-param-from-search
+            "?project-root=C%3A%2FUsers%2Fme%2Fmy%20code" "project-root"))
+        "a Windows drive path with an encoded space round-trips")))
+
+(deftest query-param-from-search-picks-the-right-param
+  (testing "only the named param is read; other params are ignored"
+    (is (= "/wanted"
+           (#'config/query-param-from-search
+            "?other=/nope&project-root=/wanted&more=x" "project-root")))
+    (is (nil? (#'config/query-param-from-search
+               "?other=/nope" "project-root"))
+        "absent param → nil")))
+
+(deftest query-param-from-search-blank-and-missing-fall-through-to-nil
+  (testing "a blank/whitespace param value, an empty search, or a nil
+            search all yield nil so the override falls through to the
+            build-time repo-root tier (never an empty override that would
+            shadow a real root)"
+    (is (nil? (#'config/query-param-from-search
+               "?project-root=" "project-root"))
+        "empty value → nil")
+    (is (nil? (#'config/query-param-from-search
+               "?project-root=%20%20%20" "project-root"))
+        "whitespace-only value (encoded spaces) → nil")
+    (is (nil? (#'config/query-param-from-search "" "project-root"))
+        "empty search string → nil")
+    (is (nil? (#'config/query-param-from-search nil "project-root"))
+        "nil search string → nil")))
+
+;; ---- resolve-project-root: tier-1 override PRECEDENCE -------------------
+;;
+;; `query-param` is the private browser-only adapter (no window under
+;; node → nil). Redefining it stands in a deterministic override value
+;; so the precedence rule — tier 1 over tier 2 — is asserted without a
+;; browser, mirroring how the join tests redefine `repo-root`.
+
+(deftest resolve-project-root-override-wins-over-repo-root
+  (testing "a present `?project-root=` override is used VERBATIM and beats
+            the build-time repo-root tier entirely — the subdir is NOT
+            appended (the override already names the final on-disk root)"
+    (with-redefs [config/query-param (fn [param]
+                                       (when (= param "project-root")
+                                         "/override/path"))
+                  config/repo-root "/home/dev/re-frame2"]
+      (is (= "/override/path"
+             (config/resolve-project-root "tools/xray/testbeds"))
+          "override wins; repo-root + subdir is not joined")
+      (is (= "/override/path"
+             (config/resolve-project-root "tools/story/testbeds"))
+          "the subdir the caller passes is irrelevant when the override is set"))))
+
+(deftest resolve-project-root-override-wins-even-when-repo-root-blank
+  (testing "the override governs regardless of the repo-root tier's state —
+            it is the highest-precedence source"
+    (with-redefs [config/query-param (fn [param]
+                                       (when (= param "project-root")
+                                         "/override/path"))
+                  config/repo-root ""]
+      (is (= "/override/path"
+             (config/resolve-project-root "tools/xray/testbeds"))))))
+
+(deftest resolve-project-root-blank-override-falls-through-to-repo-root
+  (testing "when the override is absent (adapter returns nil) the
+            build-time repo-root tier governs — this is the path every
+            non-browser host (e.g. :node-test) and every override-free
+            browser session takes"
+    (with-redefs [config/query-param (constantly nil)
+                  config/repo-root "/home/dev/re-frame2"]
+      (is (= "/home/dev/re-frame2/tools/xray/testbeds"
+             (config/resolve-project-root "tools/xray/testbeds"))
+          "no override → repo-root + subdir join governs"))
+    (with-redefs [config/query-param (constantly nil)
+                  config/repo-root ""]
+      (is (nil? (config/resolve-project-root "tools/xray/testbeds"))
+          "no override AND no repo-root → nil (graceful no-op)"))))
 
 ;; ---- public-surface stability sentinel ---------------------------------
 

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -204,8 +204,12 @@
 ;; The URI build is invariant to the host page URL — `resolve-uri` reads the
 ;; configured root, not `window.location`. The query-param branch only
 ;; influences which root we PASS to the configure! call; the resolver itself
-;; never reaches into the document. The unit test
-;; `panel-gallery-project-root-invariant-to-host-url` pins that contract.
+;; never reaches into the document. Two real tests pin this contract: the
+;; URI-build invariance to host URL is pinned by
+;; `re-frame2-xray.open-in-editor-cljs-test/resolve-uri-invariant-to-host-url`,
+;; and the `?project-root=` override branch (parse / URL-decode / trim and
+;; its precedence over the build-time repo-root) is pinned by
+;; `re-frame.testbed.config-cljs-test` in tools/testbed-support.
 
 ;; rf2-5dphw — open-in-editor project-root derived from the build
 ;; environment (the build-time `re-frame.testbed.config/repo-root`
@@ -214,8 +218,10 @@
 ;; session. The URI build stays invariant to the host page URL — the
 ;; resolver reads the configured root, not `window.location`; the
 ;; query-param branch only influences which root we PASS to `configure!`.
-;; The unit test `panel-gallery-project-root-invariant-to-host-url` pins
-;; that contract.
+;; The host-URL invariance is pinned by
+;; `re-frame2-xray.open-in-editor-cljs-test/resolve-uri-invariant-to-host-url`;
+;; the `?project-root=` override parse + precedence is pinned by
+;; `re-frame.testbed.config-cljs-test` in tools/testbed-support.
 (defn- resolve-project-root []
   (testbed-config/resolve-project-root "tools/xray/testbeds"))
 


### PR DESCRIPTION
## Bead

rf2-6bq0o — senior review: tools/testbed-support browser override coverage.

## Gap

`tools/testbed-support`'s highest-precedence override path — the `?project-root=<path>` query string — had **no executable coverage**. The reader (`config.cljs` `query-param`) touched `js/window.location.search` directly, and `:node-test` has no `js/window`, so the branch silently degraded to `nil` and the cross-machine escape hatch could regress unnoticed. `config_cljs_test` documented the omission; the panel-gallery comments cited a test (`panel-gallery-project-root-invariant-to-host-url`) that **does not exist**.

## Fix — inject a pure seam

Isolate the single genuinely browser-bound step (reading `location.search` off the live document) behind the thin `query-param` adapter, and delegate the parse/decode/trim/non-blank contract to a **pure** `query-param-from-search` that takes a search string verbatim. `js/URLSearchParams` is a host global present in Node too, so that pure parser runs identically off-browser — no `js/window` fakery, no brittle browser mock.

Public surface (`resolve-project-root`, `repo-root`) is unchanged; the override resolution order and value handling are behaviour-preserving. The helper stays dev/testbed-only.

## Coverage added (all under `:node-test`)

- **`query-param-from-search`** — param selection, URL-decoding (`%2F` → `/`, encoded spaces), trimming, and the blank / missing / nil-search → falls-through-to-nil rule.
- **`resolve-project-root` tier-1 PRECEDENCE** — a present override wins **verbatim** over the `repo-root` tier (subdir not appended) regardless of `repo-root` state; a blank/absent override falls through to the `repo-root` join. Driven by `with-redefs`-ing the private `query-param`, mirroring how the existing join tests redef `repo-root`. This distinguishes query-override behaviour from the already-covered build-root join, per the acceptance criteria.

## Stale references corrected

panel-gallery comments now point at the **real** guards:
- `re-frame2-xray.open-in-editor-cljs-test/resolve-uri-invariant-to-host-url` for host-URL invariance, and
- `re-frame.testbed.config-cljs-test` for the override parse + precedence.

## Acceptance check

- ✅ A regression that removes/breaks `?project-root` precedence now fails an automated test.
- ✅ The test distinguishes query-override behaviour from the build-root join.
- ✅ Stale `panel-gallery-project-root-invariant-to-host-url` references corrected.
- ✅ No production-bundle dependency introduced; helper remains dev/testbed-only.

## Gates

- `npm run test:cljs` — 5661 tests / 19743 assertions, **0 failures, 0 errors**.
- `npm run test:bundle-isolation` — **PASS** (bundle-isolation + uix-helix-reagent-free).
- `clojure -M:test` in `tools/testbed-support/` — N/A (no `deps.edn`; tests run under `:node-test`).