### PR TITLE
fix(story): faithful share-URL override round-trip (rf2-j0hwf)

### DIFF
--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -195,6 +195,15 @@ Share semantics:
 - it encodes the variant + workspace + mode-tab + active modes + viewport
   + background + tag-filter + the focused variant's cell-overrides +
   substrate (`re-frame.story.share/build-params`);
+- the cell-overrides are encoded as one `pr-str`-printed EDN map and read
+  back as one map (rf2-j0hwf), so the encode/decode round-trip is
+  faithful — including string override values that carry the list
+  separator (a comma); the legacy comma-pair wire form is still decoded
+  for already-shared / bookmarked URLs;
+- the decoded overrides hydrate the shell under
+  `[:cell-overrides <focused-variant>]` on both mount and back/forward
+  (`re-frame.story.ui.url-state/apply-parsed-to-state`), so a pasted URL
+  renders the same effective args, not just the selection (rf2-j0hwf);
 - a shared link restores VIEW STATE (it lands the recipient on the cell);
   it does not replay a run — that is the recorder's `:play-script` export;
 - the reproducibility status is computed (purely) by

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -28,7 +28,11 @@
   - `<id>` for variant / workspace — the id as `:story.foo/bar`
   - `<id>` for mode-tab — one of `dev` / `docs` / `test`
   - `<list>` for modes / tag-filter — comma-separated keyword ids
-  - `<list>` for overrides — comma-separated `arg-key:EDN-value` pairs
+  - `<map>` for overrides — one `pr-str`-printed EDN map of
+                            `{arg-key value}` (rf2-j0hwf — delimiter-safe;
+                            a string value may contain commas). The legacy
+                            comma-separated `arg-key:EDN-value` form is
+                            still decoded for already-shared URLs.
   - `<id-or-WxH>` for viewport — preset keyword (`tablet`) or
                                   `WxH` custom (e.g. `800x600`)
   - `<id-or-#rrggbb>` for background — preset keyword (`dark`) or a
@@ -203,7 +207,63 @@
     (catch #?(:clj Exception :cljs :default) _
       [false nil])))
 
+;; ---- overrides codec (rf2-j0hwf) ----------------------------------------
+;;
+;; The overrides payload is a single EDN map, `pr-str`-printed then
+;; percent-encoded as one token (`build-overrides-token`). Decoding
+;; reads the whole token back as one EDN map (`parse-overrides-param`).
+;;
+;; The earlier wire shape — a comma-joined list of `<arg-token>:<edn>`
+;; pairs — could not round-trip an EDN value containing a comma (e.g.
+;; the string "Save, continue"): the decoder split the whole payload on
+;; every comma before reading each value, shredding any value carrying
+;; the list separator. Printing one EDN map sidesteps delimiter
+;; collisions entirely — the reader balances strings / collections —
+;; so any EDN-valued override round-trips faithfully.
+;;
+;; A `:` immediately after the leading `{` (i.e. NOT inside the EDN map)
+;; would never appear in a printed map, so the legacy comma-pair form is
+;; recognised by the ABSENCE of a leading `{` and parsed best-effort for
+;; backward compatibility with already-shared / bookmarked URLs.
+
+(defn- ^:no-doc edn-map-payload?
+  "True when `s` looks like the EDN-map wire form (a printed map) rather
+  than the legacy `k:v,k:v` comma-pair form."
+  [s]
+  (str/starts-with? (str/triml s) "{"))
+
+(defn- ^:no-doc keywordish-key
+  "Coerce a parsed override key to a keyword. Override arg-keys are
+  keywords; a value read as a symbol (e.g. an unquoted token) coerces
+  to the same keyword so author-typed maps stay forgiving. Returns nil
+  for anything that can't be a keyword."
+  [k]
+  (cond
+    (keyword? k) k
+    (symbol? k)  (keyword (namespace k) (name k))
+    (string? k)  (parse-keyword-token k)
+    :else        nil))
+
+(defn- ^:no-doc parse-overrides-edn-map
+  "Read the EDN-map wire form. Returns `{:overrides <map-or-nil>
+  :dropped [<token> ...]}`. A non-map / unreadable payload reports the
+  whole token as dropped; per-entry keys that can't coerce to a keyword
+  are dropped individually (their `pr-str` entry naming the drop)."
+  [s]
+  (let [[ok? data] (read-edn s)]
+    (if (and ok? (map? data))
+      (let [parsed  (mapv (fn [[k v]] [(keywordish-key k) k v]) data)
+            kept    (into {} (keep (fn [[kk _ v]] (when kk [kk v])) parsed))
+            dropped (->> parsed
+                         (remove (fn [[kk _ _]] kk))
+                         (mapv (fn [[_ k v]] (str (pr-str k) " " (pr-str v)))))]
+        {:overrides (not-empty kept) :dropped dropped})
+      {:overrides nil :dropped [s]})))
+
 (defn- ^:no-doc parse-override-entry
+  "Parse one legacy `<arg-token>:<edn-value>` pair into `[k v]`, or nil
+  when malformed. Splits on the FIRST `:` so EDN keyword values keep
+  their colon."
   [entry]
   (when-let [idx (and (string? entry) (str/index-of entry ":"))]
     (let [k-token (subs entry 0 idx)
@@ -213,42 +273,66 @@
       (when (and k ok?)
         [k v]))))
 
-(defn parse-overrides-param
-  "Parse an `overrides=` URLSearchParams value into a cell-overrides
-  map. The v1 wire shape is a comma-separated list of
-  `<arg-token>:<edn-value>` pairs; malformed entries are ignored so a
-  stale share URL degrades to the valid subset instead of poisoning the
-  shell state."
+(defn- ^:no-doc parse-overrides-legacy
+  "Parse the legacy comma-pair wire form. Returns `{:overrides ...
+  :dropped [<entry-string> ...]}`. Malformed entries (no separator,
+  unparseable EDN) are reported individually."
   [s]
-  (when (and (string? s) (seq (str/trim s)))
-    (not-empty
-      (into {}
-            (keep parse-override-entry)
-            (str/split s #",")))))
+  (let [entries  (str/split s #",")
+        parsed   (mapv (fn [e] [e (parse-override-entry e)]) entries)
+        kept     (into {} (keep (fn [[_ kv]] kv) parsed))
+        dropped  (->> parsed
+                      (remove (fn [[_ kv]] kv))
+                      (mapv first))]
+    {:overrides (not-empty kept) :dropped dropped}))
+
+(defn build-overrides-token
+  "Encode a `{arg-key → value}` cell-overrides map into the single
+  percent-encoded `overrides=` wire token (rf2-j0hwf). The map is
+  printed via `pr-str` (keys sorted for deterministic output) so any
+  EDN value round-trips faithfully — including string values that
+  carry the list separator. Returns nil for an empty/nil map."
+  [cell-overrides]
+  (when (seq cell-overrides)
+    (url-encode
+      (pr-str (into (sorted-map-by (fn [a b] (compare (kw->str a) (kw->str b))))
+                    cell-overrides)))))
 
 (defn parse-overrides-param*
-  "Like `parse-overrides-param` but also reports any entries that were
-  dropped (malformed token, unparseable EDN, etc.). Returns a map
-  `{:overrides ... :dropped [<entry-string> ...]}` — both keys always
-  present so callers can pattern-match without an else-branch.
+  "Parse an `overrides=` URLSearchParams value into a cell-overrides
+  map AND report any entries that were dropped (unparseable / invalid
+  key). Returns a map `{:overrides ... :dropped [<token> ...]}` — both
+  keys always present so callers can pattern-match without an
+  else-branch.
+
+  Two wire forms are accepted (rf2-j0hwf):
+
+  - the current EDN-map form: the whole payload is one `pr-str`-printed
+    map, read back as one EDN map (delimiter-safe — string values may
+    contain commas);
+  - the legacy `<arg-token>:<edn-value>` comma-pair form, kept for
+    already-shared / bookmarked URLs; entries are split on commas and
+    parsed best-effort.
 
   Powers the share-import hint (rf2-9jthx): the share UI surfaces a
   non-blocking note when N>0 overrides from a stale share URL no
   longer apply (variant args refactored, renamed, removed). Pure;
-  JVM-testable. The legacy `parse-overrides-param` keeps its silent-
-  drop signature for the param-parsing call sites that don't care
-  about the dropped set."
+  JVM-testable."
   [s]
   (if (and (string? s) (seq (str/trim s)))
-    (let [entries  (str/split s #",")
-          parsed   (mapv (fn [e] [e (parse-override-entry e)]) entries)
-          kept     (into {} (keep (fn [[_ kv]] kv) parsed))
-          dropped  (->> parsed
-                        (remove (fn [[_ kv]] kv))
-                        (mapv first))]
-      {:overrides (not-empty kept)
-       :dropped   dropped})
+    (if (edn-map-payload? s)
+      (parse-overrides-edn-map s)
+      (parse-overrides-legacy s))
     {:overrides nil :dropped []}))
+
+(defn parse-overrides-param
+  "Parse an `overrides=` URLSearchParams value into a cell-overrides
+  map (silent-drop). Accepts both the current EDN-map wire form and the
+  legacy comma-pair form (see `parse-overrides-param*`). Malformed
+  entries are ignored so a stale share URL degrades to the valid subset
+  instead of poisoning the shell state."
+  [s]
+  (:overrides (parse-overrides-param* s)))
 
 (defn- ^:no-doc kv-pair
   "Build a `k=v` URL parameter fragment. `k` is a keyword;
@@ -322,7 +406,7 @@
   - `:viewport`   — chrome-wide viewport selection (preset kw or `WxH`)
   - `:background` — chrome-wide background selection (preset kw or hex)
   - `:tag-filter` — comma-separated stable list of active tag-filter keys
-  - `:overrides`  — comma-separated `arg-key:EDN-value` pairs
+  - `:overrides`  — one `pr-str`-printed EDN map (delimiter-safe; rf2-j0hwf)
   - `:substrate`  — substrate id (omitted when `:reagent` default)
 
   Returns a vector of `k=v` URL fragments. Pure data → data;
@@ -360,11 +444,7 @@
                        (map kw->str (sort-by kw->str tag-filter))))))
 
     (seq cell-overrides)
-    (conj (kv-pair :overrides
-                   (url-encode
-                     (str/join ","
-                       (for [[k v] (sort-by (comp kw->str key) cell-overrides)]
-                         (str (kw->str k) ":" (pr-str v)))))))
+    (conj (kv-pair :overrides (build-overrides-token cell-overrides)))
 
     (and substrate (not= substrate :reagent))
     (conj (kv-pair :substrate (url-encode (name substrate))))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -847,8 +847,12 @@
          ;; rf2-o4u18: subscribe to popstate so the back-button restores
          ;; prior URL state, and watch shell-state-atom so user-driven
          ;; selection / viewport / background / tag-filter changes
-         ;; pushState the canonical URL. Cell-override edits are NOT
-         ;; pushed (too chatty) — they ride the share popover.
+         ;; pushState the canonical URL. The focused variant's
+         ;; cell-override edits ARE pushed (rf2-5fyo3 — the share popover
+         ;; that once owned override serialisation was retired by
+         ;; rf2-ymnfx, so the live address bar is the only sharing
+         ;; surface) and restored on popstate via apply-parsed-to-state
+         ;; (rf2-j0hwf — closes the override round-trip on back/forward).
          (url-state/install-popstate-listener!
            state/shell-state-atom
            (url-state-apply-fn))

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -174,10 +174,19 @@
   Per rf2-hscut: workspace + variant are mutually exclusive in the
   sidebar (selecting one clears the other). If the URL carries both
   the variant wins (variant is the canonical sharable unit; workspace
-  groupings are derived)."
+  groupings are derived).
+
+  Per rf2-j0hwf: parsed `:cell-overrides` are installed under
+  `[:cell-overrides variant-id]` when a variant is kept, so a shared
+  URL / popstate restores the same effective args — not just the
+  selection. Overrides are variant-scoped (the URL carries only the
+  focused variant's slice), so they apply solely alongside a kept
+  variant. The state-watcher pushes that same slice, so this closes the
+  encode/decode round-trip on back/forward navigation."
   [state parsed validators]
   (let [{:keys [variant-id workspace-id mode-tab active-modes
-                viewport background tag-filter substrate]} parsed
+                viewport background tag-filter cell-overrides
+                substrate]} parsed
         variant-ok? (or (nil? (:variant? validators))
                         ((:variant? validators) variant-id))
         ws-ok?      (or (nil? (:workspace? validators))
@@ -204,6 +213,18 @@
 
       (and keep-variant? mode-tab)
       (assoc-in [:active-mode-tab variant-id] mode-tab)
+
+      ;; rf2-j0hwf: install the focused variant's parsed cell-overrides
+      ;; under [:cell-overrides variant-id] so a popstate / shared-URL
+      ;; hydration restores the same effective args (not just the
+      ;; selection). Overrides are variant-scoped — the URL carries only
+      ;; the focused variant's slice (params-from-state), so they apply
+      ;; solely when the variant is kept. The state-watcher pushes this
+      ;; same slice (url-relevant-slots-changed? + params-from-state), so
+      ;; without this branch the encode/decode round-trip was asymmetric:
+      ;; an override edit pushed to the URL was dropped on back/forward.
+      (and keep-variant? (seq cell-overrides))
+      (assoc-in [:cell-overrides variant-id] cell-overrides)
 
       (seq active-modes)
       (assoc :active-modes (vec active-modes))

--- a/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
@@ -84,6 +84,37 @@
       (is (= {:label "Hi"} (:cell-overrides out)))
       (is (= :uix (:substrate out))))))
 
+;; ---- rf2-j0hwf: full override round-trip via URLSearchParams ------------
+
+(deftest override-round-trip-through-urlsearchparams
+  (testing "rf2-j0hwf — the focused-variant override round-trip as a single
+            invariant: shell-state → params-from-state → build-params →
+            URLSearchParams encode/decode → parse-params →
+            apply-parsed-to-state restores [:cell-overrides variant-id]
+            equal to the source slice — INCLUDING a string value carrying
+            the list separator (comma), which the old comma-split codec
+            dropped."
+    (let [variant  :foo/bar
+          slice    {:label "Save, continue" :count 3 :items [1 2 3]}
+          shell    {:selected-variant variant
+                    :cell-overrides   {variant slice}}
+          ;; encode: project → build params → real URLSearchParams string
+          proj     (us/params-from-state shell)
+          ps       (share/build-params proj)
+          qs       (str/join "&" ps)
+          usp      (js/URLSearchParams. qs)
+          getter   {"variant"   (.get usp "variant")
+                    "overrides" (.get usp "overrides")}
+          ;; decode: parse-params → apply back into a fresh shell state
+          parsed   (share/parse-params getter)
+          out      (us/apply-parsed-to-state {} parsed {})]
+      (is (= variant (:selected-variant out)))
+      (is (= slice (get-in out [:cell-overrides variant]))
+          "decoded overrides equal the encoded overrides (round-trip)")
+      ;; explicit: the comma-bearing value is intact, not shredded
+      (is (= "Save, continue"
+             (get-in out [:cell-overrides variant :label]))))))
+
 ;; ---- pushState idempotence ----------------------------------------------
 ;;
 ;; Under the node runner `js/window.history` is mocked by jsdom. The

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -245,6 +245,53 @@
               {} {:substrate :uix} {})]
     (is (= :uix (:substrate out)))))
 
+;; ---- rf2-j0hwf: cell-overrides hydration --------------------------------
+
+(deftest apply-parsed-installs-cell-overrides-under-focused-variant
+  (testing "rf2-j0hwf — parsed :cell-overrides are written under
+            [:cell-overrides variant-id] so a shared URL / popstate
+            restores the same effective args, not just the selection.
+            (Reproduces the bead's verification: previously this
+            destructure dropped :cell-overrides entirely.)"
+    (let [out (us/apply-parsed-to-state
+                {} {:variant-id     :story.foo/bar
+                    :cell-overrides {:label "Hi"}} {})]
+      (is (= :story.foo/bar (:selected-variant out)))
+      (is (= {:label "Hi"} (get-in out [:cell-overrides :story.foo/bar]))
+          "overrides land under the focused variant"))))
+
+(deftest apply-parsed-overrides-dropped-when-variant-invalid
+  (testing "rf2-j0hwf — overrides are variant-scoped: when the variant id
+            is rejected by the validator (stale URL) the overrides are
+            not installed (no orphan slice under an unfocused variant)"
+    (let [out (us/apply-parsed-to-state
+                {} {:variant-id     :ghost/x
+                    :cell-overrides {:label "Hi"}}
+                {:variant? (fn [vid] (= vid :foo/bar))})]
+      (is (nil? (:selected-variant out)))
+      (is (nil? (get-in out [:cell-overrides :ghost/x]))
+          "no overrides installed for a rejected variant"))))
+
+(deftest apply-parsed-overrides-ignored-without-variant
+  (testing "rf2-j0hwf — overrides without a variant id never install
+            (the URL carries only the focused variant's slice)"
+    (let [out (us/apply-parsed-to-state
+                {} {:cell-overrides {:label "Hi"}} {})]
+      (is (nil? (:selected-variant out)))
+      (is (empty? (:cell-overrides out))))))
+
+(deftest apply-parsed-overrides-round-trip-through-state
+  (testing "rf2-j0hwf — state → params-from-state → apply-parsed-to-state
+            restores the focused variant's overrides slice (the URL
+            carries the focused variant only, so the projected
+            :cell-overrides is the bare slice, not the side-table)"
+    (let [shell  {:selected-variant :foo/bar
+                  :cell-overrides   {:foo/bar {:label "Save, continue" :n 3}}}
+          proj   (us/params-from-state shell)
+          out    (us/apply-parsed-to-state {} proj {})]
+      (is (= {:label "Save, continue" :n 3}
+             (get-in out [:cell-overrides :foo/bar]))))))
+
 (deftest apply-parsed-full-round-trip-through-state
   (testing "URL → parsed → state, then state → URL produces equivalent
             params (allowing for set vs vec re-ordering)"

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -99,6 +99,70 @@
     (is (= {:label "Shared Label" :count 9}
            (share/parse-overrides-param "label:\"Shared Label\",count:9")))))
 
+;; ---- rf2-j0hwf: overrides codec round-trip -------------------------------
+;;
+;; The earlier comma-joined `k:v` wire form could not round-trip an EDN
+;; value containing the list separator — the decoder split the whole
+;; payload on every comma before reading each value. The codec now prints
+;; one EDN map (delimiter-safe) and reads it back as one map.
+
+(defn- url-decode [t] (java.net.URLDecoder/decode (str t) "UTF-8"))
+
+(defn- overrides-round-trip
+  "Encode `ov` to the wire token, URL-decode it (as URLSearchParams.get
+  would), and parse it back. Returns the reconstructed overrides map."
+  [ov]
+  (share/parse-overrides-param (url-decode (share/build-overrides-token ov))))
+
+(deftest overrides-codec-round-trips-simple
+  (testing "rf2-j0hwf — simple overrides round-trip through build/parse"
+    (let [ov {:label "Click me" :count 5}]
+      (is (= ov (overrides-round-trip ov))))))
+
+(deftest overrides-codec-round-trips-comma-value
+  (testing "rf2-j0hwf — a string override value containing the list
+            separator (comma) round-trips faithfully instead of being
+            shredded into malformed entries and dropped"
+    (let [ov {:label "Save, continue"}]
+      (is (= ov (overrides-round-trip ov))
+          "comma-containing string value survives the round-trip"))
+    (testing "comma value alongside other entries"
+      (let [ov {:label "Save, continue" :count 3 :title "A, B, C"}]
+        (is (= ov (overrides-round-trip ov)))))))
+
+(deftest overrides-codec-round-trips-collection-values
+  (testing "rf2-j0hwf — vector / map / set / nested EDN values (which all
+            carry internal separators) round-trip"
+    (let [ov {:items [1 2 3]
+              :opts  {:a 1 :b 2}
+              :tags  #{:x :y}
+              :pair  [:k "v, with comma"]}]
+      (is (= ov (overrides-round-trip ov))))))
+
+(deftest overrides-codec-deterministic-order
+  (testing "rf2-j0hwf — the encoded token is stable across calls (keys
+            sorted) so the URL is canonical and idempotent pushes no-op"
+    (let [ov {:zed 1 :alpha 2 :mid 3}]
+      (is (= (share/build-overrides-token ov)
+             (share/build-overrides-token ov))))))
+
+(deftest overrides-codec-legacy-comma-pair-still-decodes
+  (testing "rf2-j0hwf — already-shared / bookmarked URLs carrying the
+            legacy comma-pair wire form still decode (back-compat)"
+    (is (= {:label "Shared Label" :count 9}
+           (share/parse-overrides-param "label:\"Shared Label\",count:9")))
+    (is (= {:label "OK"}
+           (share/parse-overrides-param "label:\"OK\",bogus"))
+        "legacy malformed-entry drop preserved")))
+
+(deftest overrides-codec-empty-and-nil
+  (testing "rf2-j0hwf — empty/nil overrides produce no token, and blank
+            input parses to nil"
+    (is (nil? (share/build-overrides-token {})))
+    (is (nil? (share/build-overrides-token nil)))
+    (is (nil? (share/parse-overrides-param nil)))
+    (is (nil? (share/parse-overrides-param "")))))
+
 ;; ---- rf2-9jthx: parse-overrides-param* surfaces dropped entries ----------
 
 (deftest parse-overrides-param*-clean-input
@@ -155,6 +219,24 @@
     (is (= {:label "OK"}
            (share/parse-overrides-param "label:\"OK\",bogus")))))
 
+(deftest parse-overrides-param*-edn-map-form
+  (testing "rf2-j0hwf — parse-overrides-param* reads the EDN-map wire form
+            (one printed map) and reports keys it cannot coerce to a
+            keyword as :dropped, so the share-import hint still surfaces
+            on the new delimiter-safe encoding"
+    (let [{:keys [overrides dropped]}
+          (share/parse-overrides-param* "{:label \"OK\", :size 7}")]
+      (is (= {:label "OK" :size 7} overrides))
+      (is (= [] dropped) "clean EDN map drops nothing"))
+    (let [{:keys [overrides dropped]}
+          (share/parse-overrides-param* "{:label \"OK\", 5 :bad-key}")]
+      (is (= {:label "OK"} overrides) "non-keyword key dropped, rest kept")
+      (is (= 1 (count dropped))))
+    (let [{:keys [overrides dropped]}
+          (share/parse-overrides-param* "{:label \"unterminated")]
+      (is (nil? overrides) "unreadable EDN payload yields no overrides")
+      (is (= 1 (count dropped)) "whole token reported dropped"))))
+
 (deftest variant-share-url-preserves-hash-route
   (testing "variant-share-url inserts params before # so the Story route survives"
     (let [url (share/variant-share-url
@@ -167,7 +249,9 @@
             url
             "https://example.test/counter-with-stories/?variant=story.counter%2Floaded"))
       (is (str/includes? url "&modes=Mode.app%2Fdark"))
-      (is (str/includes? url "overrides=label%3A%22Share+Slice%22"))
+      ;; rf2-j0hwf: overrides encode as one pr-str EDN map (delimiter-safe),
+      ;; URL-encoded: {:label "Share Slice"} → %7B%3Alabel+%22Share+Slice%22%7D.
+      (is (str/includes? url "overrides=%7B%3Alabel+%22Share+Slice%22%7D"))
       (is (str/ends-with? url "#/stories")))))
 
 (deftest variant-share-url-public-export


### PR DESCRIPTION
## Summary

Two correctness defects broke the tools/story share-URL override round-trip (rf2-j0hwf) — an override encoded into the share URL did not decode back to the same value, so a shared story state did not reconstruct.

### 1. Parsed `:cell-overrides` dropped during hydration
`url-state/apply-parsed-to-state` destructured every parsed slot **except** `:cell-overrides`, so a pasted URL (and every back/forward `popstate`) selected the variant but rendered **default args**. The state-watcher already *pushes* the focused variant's overrides slice (`url-relevant-slots-changed?` + `params-from-state`, rf2-5fyo3), so the encode/decode round-trip was asymmetric. **Fix:** install parsed overrides under `[:cell-overrides variant-id]` when the variant is kept.

### 2. Codec could not round-trip a value containing the list separator
`build-params` comma-joined `k:pr-str(v)` pairs while the decoder split the whole payload on **every** comma before reading each value — shredding a value like `"Save, continue"` into malformed entries that were silently dropped. **Fix:** encode the whole overrides map as one `pr-str` EDN map (delimiter-safe; the reader balances strings/colls) and read it back as one map. The legacy comma-pair wire form is still decoded for already-shared / bookmarked URLs.

## Before / after (JVM eval)

```
;; {:label "Save, continue" :n 3 :v [1 2 3]}
BEFORE  parse(build(...)) => nil          ; comma-split shredded the value
AFTER   parse(build(...)) => same map     ; EQUAL? true
```

## Tests
Regression coverage added: simple overrides, comma-containing string values, collection values (vector/map/set/nested), deterministic encoding order, legacy comma-pair back-compat, `apply-parsed-to-state` hydration of parsed overrides, and a full `state → build-params → URLSearchParams → parse-params → apply-parsed-to-state` round-trip asserting **decoded == encoded** (incl. a comma-bearing value) through the real `js/URLSearchParams`.

## Gates
- story `clojure -M:test` — 1617 tests / 6044 assertions, 0 failures
- `npm run story:build` — Build completed, 0 warnings
- `npm run test:cljs` — 5655 tests / 19731 assertions, 0 failures

Spec note added to `022-Story-UI-Docs-And-Share.md` documenting the delimiter-safe EDN-map wire form and the round-trip hydration.

Closes rf2-j0hwf.
