### PR TITLE
test(mcp-conformance): give two false-green conformance gates teeth (rf2-x0pr0)

### DIFF
--- a/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
@@ -21,11 +21,19 @@
 //   2. We `tools/call subscribe` to `:trace` with a short
 //      `max-ms` (1500ms) so the tool returns promptly with a
 //      terminal summary.
-//   3. While subscribe streams, we `tools/call dispatch` a known
-//      event from a concurrent task — the trace bus emission flows
-//      back through subscribe's drain loop and produces at least one
-//      `notifications/progress` tick.
-//   4. We assert the collected progress frames pass the canonical
+//   3. While subscribe streams, we `tools/call dispatch` the fixture's
+//      `[:counter/inc "<NONCE>"]` event — repeatedly, on a short cadence,
+//      until a progress frame carrying that per-run NONCE is observed
+//      (rf2-x0pr0). The trace bus emission for the cascade WE caused flows
+//      back through subscribe's drain loop. Re-dispatching removes the
+//      timing race: the subscription is installed asynchronously
+//      (ensure-runtime! → signal-runtime! → subscribe! eval), so the
+//      FIRST probe to land after registration produces the causal frame —
+//      readiness is PROVEN by the observed nonce, never assumed by a clock.
+//   4. We assert (a) the observed cascade is CAUSALLY ours — at least one
+//      frame's `:message` carries the dispatched NONCE, so an unrelated bus
+//      emission can no longer false-green the gate — and (b) every collected
+//      progress frame passes the canonical
 //      `ReFrame2PairProgressNotificationParams` shape pinned by `wire-vocab/`
 //      (the JVM-side schema). A drift between the JS-side assertion
 //      below and the Malli schema trips the cross-encoding gate in
@@ -47,6 +55,14 @@
 //     `:overflow-reason` are the documented contract slots).
 //   - subscribe entirely failing to emit a progress frame on a
 //     well-formed dispatch (e.g. drain loop regression).
+//   - the subscribe→dispatch→drain CAUSAL path silently breaking: a frame
+//     that does NOT correspond to our dispatched event (e.g. the cascade
+//     for `:counter/inc` never reaches the sub's queue) no longer passes,
+//     because the NONCE assertion requires the observed frame to be the
+//     cascade we caused (rf2-x0pr0).
+//   - a refused / failed dispatch silently passing: the probe's `isError`
+//     is now FATAL, so a dispatch that never landed fails the gate rather
+//     than riding alongside an unrelated frame (rf2-x0pr0).
 //
 // ## Gating
 //
@@ -75,6 +91,7 @@
 // generic helper would dissolve that per-schema attribution and weaken
 // the conformance contract.
 
+const crypto = require('node:crypto');
 const path = require('node:path');
 const os = require('node:os');
 const { runWithWatchdog } = require('./_runner.cjs');
@@ -86,6 +103,19 @@ const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 
 // needing to wait for the runtime to push an unrelated frame. Per
 // re-frame2-pair-mcp's spec the four valid topics are `trace | epoch | fx | error`.
 const TOPIC = 'trace';
+
+// Per-run unique nonce (rf2-x0pr0). We dispatch `[:counter/inc
+// "<NONCE>"]` — the `:counter/inc` event-db handler ignores its event
+// args, so the extra string is inert, but the FULL event vector rides
+// into the trace cascade's `:event` slot and is `pr-str`'d into the
+// progress frame's `:message`. Asserting at least one progress frame's
+// `message` carries this nonce makes the gate CAUSAL: it proves the
+// observed frame is the cascade from OUR dispatch, not an unrelated bus
+// emission that happened to arrive during the window. Before this, the
+// gate accepted ANY progress frame (`frames.length > 0`), so a spurious
+// emission while our dispatch raced / failed could false-green it.
+const NONCE = 'rf2-subscribe-probe-' + crypto.randomUUID();
+const PROBE_EVENT = '[:counter/inc "' + NONCE + '"]';
 
 // Subscribe duration. Short enough that the harness completes well
 // under the runner's 60s watchdog; long enough that a single dispatch
@@ -237,78 +267,97 @@ runWithWatchdog(
       { onprogress: onProgress },
     );
 
-    // Yield briefly so subscribe has a chance to install its drain
-    // loop before the dispatch lands. The runtime's poll cadence is
-    // ~250ms — a 100ms head-start guarantees the first tick window
-    // catches our event.
-    await new Promise((r) => setTimeout(r, 100));
-
-    const dispatchPromise = client.callTool({
-      name: 'dispatch',
-      // Per re-frame2-pair-mcp's `dispatch` schema the arg slot is `event` (a
-      // single EDN-vector string, parsed server-side per rf2-vflrg).
-      // An earlier draft used `event-v` (the runtime-side `pair-dispatch!`
-      // ARG name); that doesn't match the MCP tool's `inputSchema` —
-      // the server rejected with `:reason :missing-event` and the
-      // streaming trace bus never fired (no event → no trace frame →
-      // 0 ticks → :max-ms-reached with delivered 0).
-      //
-      // The event MUST be a handler that is REGISTERED in the fixture
-      // (rf2-3bu3d.3): `dispatch` now validates the event-id against the
-      // LIVE registry at the wire boundary and REFUSES an unknown id with
-      // `:ok? false :dispatched? false :nearest [...]` — it does NOT enter
-      // the dispatch loop, so an unregistered probe event fires NO trace
-      // cascade and the streaming gate sees 0 ticks. The earlier
-      // `[:rf-conformance/subscribe-probe :hello]` probe pre-dated that
-      // call-time validation; under the old contract any event vector
-      // entered the loop and emitted a `:rf.event/dispatched` trace even
-      // with no handler. We dispatch the fixture's real `:counter/inc`
-      // event-db handler (counter/core.cljs) so the dispatch actually
-      // lands and the trace bus emits — the precondition for the
-      // `notifications/progress` frame this test exists to observe. The
-      // handler is a pure `(update :count inc)`.
-      //
-      // `:queued true` routes through the runtime `pair-dispatch!`
-      // transport-ack path rather than the default `dispatch-consequence!`
-      // (rf2-3bu3d.2) — see the NOTE block below for why (the fixture
-      // boots with epoch recording at depth 0, so the consequence read
-      // would report `:no-epoch-recorded`; the trace cascade fires
-      // regardless of epoch recording).
-      arguments: { event: '[:counter/inc]', queued: true },
-    });
-
-    // Wait for both calls to settle. subscribe returns the terminal
-    // summary; dispatch returns whatever the runtime echoed.
-    const [subResp, dispatchResp] = await Promise.all([subscribePromise, dispatchPromise]);
-
-    // Surface the dispatch result for diagnostics. We do NOT fail on it:
-    // this gate's load-bearing assertion is the `notifications/progress`
-    // frame, which the trace bus emits whenever the event runs. The
-    // dispatch's OWN result is a separate concern.
+    // ---- Causality-based readiness, NOT a fixed-sleep proxy (rf2-x0pr0) ----
     //
-    // Note on the dispatch envelope under the new contract: we send
-    // `:queued true` (below) so the dispatch routes through the runtime's
-    // `pair-dispatch!` transport-ack path rather than the default
-    // `dispatch-consequence!` (rf2-3bu3d.2). `dispatch-consequence!`
-    // reads back the RECORDED EPOCH to report `:db-changed?` /
-    // `:changed-paths`; the re-frame2-pair fixture boots with epoch
-    // recording at depth 0 (it never enables it), so the consequence path
-    // returns `:ok? false :reason :no-epoch-recorded` even though the
-    // event dispatched and the TRACE cascade fired. The trace bus is
-    // independent of epoch recording, so `:queued` gives us the cascade
-    // (the progress-frame precondition) without coupling this streaming
-    // gate to the fixture's epoch-recording posture. `:counter/inc` is a
-    // registered fixture handler, so the rf2-3bu3d.3 event-id validation
-    // passes regardless of path.
-    if (dispatchResp && dispatchResp.isError) {
-      console.log(
-        'NOTE dispatch returned isError (non-fatal — the trace cascade is ' +
-          'what this gate needs): ' +
-          (dispatchResp.content?.[0]?.text || '').slice(0, 160),
+    // Pre-fix, the test slept a fixed 100ms and then dispatched ONCE,
+    // TREATING the sleep as proof the subscription was installed. But the
+    // server only registers the runtime subscription after `ensure-runtime!`
+    // + `signal-runtime!` + the `subscribe!` nREPL eval all complete — on a
+    // cold runtime that can exceed 100ms. If the single dispatch raced ahead
+    // of registration its cascade was lost and the gate either flaked (zero
+    // frames) or, worse, false-greened on an unrelated frame.
+    //
+    // We now drive readiness CAUSALLY: re-dispatch the nonce-tagged probe
+    // event on a short cadence until a progress frame carrying our NONCE is
+    // observed (`sawNonceFrame()`), or the subscribe window is nearly closed.
+    // Each `[:counter/inc "<nonce>"]` is a harmless idempotent increment, so
+    // repeating it is safe; the FIRST one to land after registration produces
+    // the causal frame and the loop stops. There is no fixed-time assumption
+    // — registration completing late just means a later probe is the one that
+    // lands. This is the "deterministic 'subscription installed' signal" the
+    // acceptance criterion asks for: the installed state is proven by the
+    // observed cascade, not assumed by a clock.
+    const sawNonceFrame = () =>
+      frames.some(
+        (f) => typeof f.message === 'string' && f.message.includes(NONCE),
       );
-    } else {
-      console.log('OK   tools/call dispatch [:counter/inc] (:queued) acked');
+
+    // The event arg slot is `event` (a single EDN-vector string parsed
+    // server-side per rf2-vflrg). The event-id MUST be a REGISTERED fixture
+    // handler — `:counter/inc` (counter/core.cljs, a pure `(update :count
+    // inc)`) — so the dispatch actually lands and the trace bus emits. An
+    // unregistered id would be refused (no cascade). `:queued true` routes
+    // through the runtime `pair-dispatch!` transport-ack path rather than the
+    // default `dispatch-consequence!` (rf2-3bu3d.2): the re-frame2-pair fixture
+    // boots with epoch recording at depth 0, so the consequence path would
+    // report `:no-epoch-recorded` even though the event dispatched and the
+    // TRACE cascade fired. The trace bus is independent of epoch recording, so
+    // `:queued` gives us the cascade without coupling this gate to the
+    // fixture's epoch-recording posture.
+    const dispatchProbe = () =>
+      client.callTool({
+        name: 'dispatch',
+        arguments: { event: PROBE_EVENT, queued: true },
+      });
+
+    // First probe + retry loop. Each dispatch is FATAL on refusal (see
+    // below): a refused dispatch means our cascade never ran, so we must not
+    // limp on toward a frame assertion that an unrelated emission could
+    // satisfy. We retry until the causal frame appears or we approach the
+    // subscribe window's end (leave a ~300ms margin so the final probe still
+    // has a drain tick to flow through before subscribe terminates).
+    const RETRY_CADENCE_MS = 200;
+    const RETRY_DEADLINE = Date.now() + MAX_MS - 300;
+    let dispatchCount = 0;
+    let lastDispatchResp = null;
+    while (Date.now() < RETRY_DEADLINE && !sawNonceFrame()) {
+      lastDispatchResp = await dispatchProbe();
+      dispatchCount++;
+      // ---- Dispatch result is FATAL on refusal (rf2-x0pr0) ----
+      //
+      // Pre-fix a dispatch `isError` was logged-and-ignored ("non-fatal").
+      // That was a false-green vector: a REFUSED dispatch (parse error,
+      // `:runtime-not-preloaded`, nREPL flap, an unknown event-id) means OUR
+      // cascade never ran, yet the old "at least one frame" gate would still
+      // pass on an unrelated emission. `:queued` returns `{:ok? true
+      // :queued? true ...}` on a real enqueue; the server maps a runtime
+      // `:ok? false` (or any failure) to an `isError` envelope
+      // (`runtime-envelope->result`, rf2-ldfnx). So `isError` here is exactly
+      // "the dispatch did not land" — fatal. (The benign
+      // `:no-epoch-recorded`/`:settled? false` posture does NOT surface as
+      // isError under `:queued`, so we stay decoupled from the fixture's
+      // epoch-recording depth.)
+      if (lastDispatchResp && lastDispatchResp.isError) {
+        throw new Error(
+          'dispatch ' + PROBE_EVENT + ' (:queued) returned isError — the ' +
+            'probe dispatch did NOT land, so the trace cascade this gate ' +
+            'exists to observe never fired. Failing rather than false-green ' +
+            'on an unrelated frame (rf2-x0pr0). Got: ' +
+            (lastDispatchResp.content?.[0]?.text ||
+              JSON.stringify(lastDispatchResp)).slice(0, 300),
+        );
+      }
+      if (sawNonceFrame()) break;
+      await new Promise((r) => setTimeout(r, RETRY_CADENCE_MS));
     }
+    console.log(
+      'OK   tools/call dispatch ' + PROBE_EVENT + ' (:queued) acked x' +
+        dispatchCount,
+    );
+
+    // Wait for subscribe to return its terminal summary (it blocks until
+    // max-ms). Dispatches already settled in the loop above.
+    const subResp = await subscribePromise;
 
     // subscribe MUST return a terminal `ok? true` summary — a
     // streaming error (e.g. nREPL flap mid-stream) would isError and
@@ -322,12 +371,11 @@ runWithWatchdog(
     }
     console.log('OK   tools/call subscribe -> isError=false, terminal summary received');
 
-    // Now the load-bearing assertion: at least one
-    // `notifications/progress` frame arrived from the streaming
-    // window. Zero frames means subscribe's drain loop never delivered
-    // — either the bus emission never made it (regression) or the
-    // notification handler installation never reached the server
-    // (SDK regression).
+    // First gate: at least one `notifications/progress` frame arrived
+    // from the streaming window. Zero frames means subscribe's drain
+    // loop never delivered — either the bus emission never made it
+    // (regression) or the notification handler installation never
+    // reached the server (SDK regression).
     if (frames.length === 0) {
       throw new Error(
         'no notifications/progress frame arrived during ' + MAX_MS + 'ms ' +
@@ -337,6 +385,46 @@ runWithWatchdog(
     }
     console.log(
       'OK   notifications/progress -> ' + frames.length + ' frame(s) received',
+    );
+
+    // ---- LOAD-BEARING CAUSALITY ASSERTION (rf2-x0pr0) ----
+    //
+    // Pre-fix the gate stopped at "at least one frame arrived" — which a
+    // spurious, unrelated bus emission during the window could satisfy
+    // even if OUR dispatch raced ahead of subscription registration or
+    // failed silently. The `:trace` topic carries EVERY dispatch on the
+    // runtime, so "a frame" is NOT proof the frame is the cascade we
+    // caused.
+    //
+    // We now require at least ONE frame whose `:message` (the EDN-printed
+    // batch — on `:trace` a `:cascades` vector, each bundle carrying its
+    // `:event` slot = the dispatched event vector) contains our per-run
+    // NONCE. Since we dispatched `[:counter/inc "<NONCE>"]`, the cascade's
+    // `:event` slot is that exact vector and the nonce string appears in
+    // the `pr-str`'d message. A frame from any OTHER source cannot carry
+    // this freshly-minted UUID. This makes the gate genuinely causal:
+    // it fails unless the observed progress frame corresponds to the
+    // specific event we dispatched.
+    const causalFrame = frames.find(
+      (f) => typeof f.message === 'string' && f.message.includes(NONCE),
+    );
+    if (!causalFrame) {
+      const messages = frames
+        .map((f, i) => '#' + i + ': ' + String(f.message || '').slice(0, 200))
+        .join('\n      ');
+      throw new Error(
+        'received ' + frames.length + ' progress frame(s) but NONE carried ' +
+          'the dispatched nonce ' + JSON.stringify(NONCE) + ' in its ' +
+          '`message`. The streaming gate cannot confirm the observed ' +
+          'frame is the cascade from OUR `[:counter/inc <nonce>]` dispatch ' +
+          '— a frame without the nonce is an unrelated bus emission, not ' +
+          'proof the subscribe→dispatch→drain path delivered our event ' +
+          '(rf2-x0pr0). Frame messages:\n      ' + messages,
+      );
+    }
+    console.log(
+      'OK   notifications/progress frame carries the dispatched nonce — ' +
+        'cascade causally attributed to [:counter/inc <nonce>]',
     );
 
     // Every frame MUST satisfy the cross-MCP shape pinned by

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -62,5 +62,19 @@
                        ;; gate a tool that stopped diff-encoding
                        ;; `:db-after` would pass every conformance check.
                        day8/re-frame2-mcp-base
-                       {:local/root "../../mcp-base"}}
+                       {:local/root "../../mcp-base"}
+                       ;; rf2-x0pr0 — the canonical structural-dedup
+                       ;; encoder so the `:rf.mcp/dedup-table` gate can
+                       ;; drive the REAL `de-dupe.core/de-dupe-eq` and
+                       ;; assert (a) its output validates against the
+                       ;; tightened `DedupTable` schema and (b) the
+                       ;; emitted root cache-id agrees byte-for-byte with
+                       ;; the Node decoder's `ROOT_CACHE_ID`
+                       ;; (`lib/dedup-envelope.cjs`). Lockstep on the same
+                       ;; tag pair-mcp + story-mcp pin so the gate sees
+                       ;; the same algorithm the servers emit.
+                       day8/de-dupe
+                       {:git/url "https://github.com/day8/de-dupe.git"
+                        :git/tag "v0.3.0"
+                        :git/sha "367de784faf13c710a895bed867f36a36e594a2a"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -86,6 +86,7 @@
   authored fixtures to the actual source/spec text."
   (:require [clojure.string  :as str]
             [clojure.test    :refer [deftest is testing]]
+            [de-dupe.core    :as dd]
             [malli.core      :as m]
             [malli.error     :as me]
             [re-frame.mcp-base.cursor :as mcp-cursor]
@@ -173,17 +174,71 @@
   "`{:rf.mcp/summary SummaryBody}` — the wrapper shape."
   [:map [:rf.mcp/summary SummaryBody]])
 
+(def root-cache-id-name
+  "The de-dupe library's canonical root cache-id, as a bare name string
+  (no `:` / symbol-quote prefix). `de-dupe.core/expand` ALWAYS begins
+  reconstruction at `(make-cache-element 0)` = `de-dupe.cache/cache-0`,
+  and `create-cache-internal` ALWAYS assocs that key as the root entry
+  (day8/de-dupe v0.3.0 `core.cljc:253-255` + `:132`). A cache map with no
+  `cache-0` entry is therefore un-expandable — the Node-side decoder
+  (`tools/mcp-conformance/lib/dedup-envelope.cjs` `ROOT_CACHE_ID`) throws
+  on exactly that shape. Pinned here so the JVM schema and the Node
+  decoder agree on the required root (rf2-x0pr0 finding 2)."
+  "de-dupe.cache/cache-0")
+
+(defn- dedup-cache-root-key?
+  "True when `k` names the de-dupe root cache element
+  (`de-dupe.cache/cache-0`). Accepts BOTH wire representations of the
+  same key:
+
+  - the EDN/CLJS form `de-dupe.core/de-dupe-eq` actually emits — a
+    namespaced SYMBOL `de-dupe.cache/cache-0` (`make-cache-element` is
+    `(symbol ...)`); and
+  - the namespaced-KEYWORD form `:de-dupe.cache/cache-0` the JVM
+    wire-vocab fixtures author it as.
+
+  `(name k)`/`(namespace k)` are identical across symbol and keyword,
+  so one predicate covers both. A string key (the JSON-on-the-wire form
+  the Node decoder sees) is matched verbatim — that path is exercised by
+  the live JVM↔Node agreement test below."
+  [k]
+  (or (= root-cache-id-name k)
+      (and (or (keyword? k) (symbol? k))
+           (= "de-dupe.cache" (namespace k))
+           (= "cache-0"       (name k)))))
+
+(defn- has-dedup-root?
+  "True when `cache` is a non-empty map carrying the canonical
+  `de-dupe.cache/cache-0` root entry (in symbol, keyword, or string
+  form). This is the load-bearing structural invariant: an
+  agent/client decoder calls `de-dupe.core/expand`, which starts at the
+  root — a table with no root is un-expandable and the Node decoder
+  rejects it. `{}` and a root-less cache both fail here."
+  [cache]
+  (and (map? cache)
+       (boolean (some dedup-cache-root-key? (keys cache)))))
+
 (def DedupTable
   "`{:rf.mcp/dedup-table <flat-cache>}` — the structural-dedup wrapper.
 
-  The body is the day8/de-dupe cache map: `{:de-dupe.cache/cache-0
-  <root> :de-dupe.cache/cache-N <subtree> ...}`. re-frame2-pair-mcp's actual
-  cache uses the de-dupe library's namespaced-keyword form; integer-
-  keyed examples (`{1 {...} 2 {...}}`) are also permitted — the
-  load-bearing claim is the top-level `:rf.mcp/dedup-table` marker
-  key and that the value is a *map* (the agent host calls
-  `de-dupe.core/expand` on it)."
-  [:map [:rf.mcp/dedup-table :map]])
+  The body is the day8/de-dupe cache map. re-frame2-pair-mcp's and
+  story-mcp's actual caches key it by the de-dupe library's namespaced
+  symbols `de-dupe.cache/cache-N` (the wire-vocab fixtures author the
+  same keys in keyword form). The load-bearing claim is the top-level
+  `:rf.mcp/dedup-table` marker key AND that the value is a cache map
+  the agent host can actually expand — i.e. it MUST carry the canonical
+  `de-dupe.cache/cache-0` ROOT entry. `de-dupe.core/expand` begins
+  reconstruction at that root (day8/de-dupe v0.3.0 `core.cljc:132`); a
+  cache with no root is un-expandable and the Node-side decoder
+  (`lib/dedup-envelope.cjs`) throws on it.
+
+  Pre-rf2-x0pr0 the schema was `[:map [:rf.mcp/dedup-table :map]]`,
+  which accepted `{}` and root-less caches that the Node decoder
+  rejects — the JVM contract was looser than the client-visible one.
+  The `has-dedup-root?` predicate closes that gap so both encodings
+  agree on the accepted cache shape (rf2-x0pr0 finding 2; acceptance
+  criteria 3 + 4)."
+  [:map [:rf.mcp/dedup-table [:and :map [:fn has-dedup-root?]]]])
 
 (def DiffFromBody
   "An epoch's `:db-after` slot, diff-encoded against `:db-before` and
@@ -449,12 +504,18 @@
     :fixtures {:re-frame2-pair-mcp         {:rf.mcp/dedup-table
                                    {:de-dupe.cache/cache-0 [:de-dupe.cache/cache-1 :de-dupe.cache/cache-1]
                                     :de-dupe.cache/cache-1 {:event-id :foo :handler-id :bar}}}
-               ;; Integer-keyed example variant — both forms validate
-               ;; against the schema; pinned to keep the alternate
-               ;; keying schema-validated even without a second server.
-               :re-frame2-pair-mcp-integer {:rf.mcp/dedup-table
-                                   {1 {:event-id :foo :handler-id :bar}
-                                    2 {:event-id :baz}}}
+               ;; rf2-x0pr0 — the integer-keyed fixture
+               ;; (`{1 {...} 2 {...}}`) was REMOVED. It was fiction: the
+               ;; day8/de-dupe library ALWAYS keys the cache by the
+               ;; namespaced symbol `de-dupe.cache/cache-N` (root
+               ;; `cache-0`) — never integers (v0.3.0 `core.cljc`
+               ;; `make-cache-element` / `create-cache-internal`). A
+               ;; root-less integer-keyed table has no `cache-0` entry,
+               ;; so the Node-side decoder (`lib/dedup-envelope.cjs`)
+               ;; THROWS on it — the exact JVM-loose / Node-strict
+               ;; disagreement this gate now closes. The
+               ;; `DedupTable`-rejects-malformed negative tests below
+               ;; pin that the schema refuses it.
                ;; story-mcp emission (rf2-90eft) — the `run-variant`
                ;; payload re-keys the same `:app-db` value into
                ;; `:rendered-hiccup` and `:snapshot`; dedup collapses
@@ -589,6 +650,147 @@
                            :cap-tokens 5000
                            :hint       "..."}}))
         "re-frame2-pair-shape emit missing :token-count must fail")))
+
+;; ---------------------------------------------------------------------------
+;; DedupTable root-cache contract (rf2-x0pr0 finding 2).
+;;
+;; The pre-fix schema was `[:map [:rf.mcp/dedup-table :map]]` — it
+;; accepted ANY map, including `{}` and caches with no `cache-0` root.
+;; But `de-dupe.core/expand` (what an agent host calls) ALWAYS starts at
+;; the `de-dupe.cache/cache-0` root, and the Node-side decoder
+;; (`tools/mcp-conformance/lib/dedup-envelope.cjs`) THROWS on a missing
+;; root. So the canonical JVM contract was strictly LOOSER than the
+;; client-visible / Node decoder contract: a root-less table that no
+;; real client can expand validated JVM-side. These gates pin the
+;; tightened schema's teeth — it now rejects exactly the shapes the Node
+;; decoder rejects.
+;; ---------------------------------------------------------------------------
+
+(deftest dedup-table-rejects-rootless-cache
+  (testing "empty cache `{}` (no root entry) fails validation"
+    (is (not (m/validate DedupTable {:rf.mcp/dedup-table {}}))
+        "DedupTable must reject an empty cache — it has no de-dupe.cache/cache-0 root, so the agent host's `expand` (and the Node decoder) cannot reconstruct it."))
+  (testing "cache with subtrees but NO cache-0 root fails validation"
+    ;; cache-1 / cache-2 present but the load-bearing cache-0 root is
+    ;; absent — `expand` begins at cache-0 and would throw. The Node
+    ;; decoder throws the same way.
+    (is (not (m/validate DedupTable
+                         {:rf.mcp/dedup-table
+                          {:de-dupe.cache/cache-1 {:event-id :foo}
+                           :de-dupe.cache/cache-2 {:event-id :bar}}}))
+        "DedupTable must reject a cache missing the de-dupe.cache/cache-0 root."))
+  (testing "integer-keyed table (de-dupe NEVER emits this) fails validation"
+    ;; The removed fixture's shape — fiction the old schema accepted.
+    ;; day8/de-dupe keys by namespaced symbols only; an integer-keyed
+    ;; table has no cache-0 root and the Node decoder throws on it.
+    (is (not (m/validate DedupTable
+                         {:rf.mcp/dedup-table
+                          {1 {:event-id :foo :handler-id :bar}
+                           2 {:event-id :baz}}}))
+        "DedupTable must reject an integer-keyed table — de-dupe never emits one and it carries no cache-0 root."))
+  (testing "a valid namespaced cache WITH a cache-0 root still validates"
+    ;; Guard against over-tightening — the canonical shape MUST pass.
+    (is (m/validate DedupTable
+                    {:rf.mcp/dedup-table
+                     {:de-dupe.cache/cache-0 [:de-dupe.cache/cache-1 :de-dupe.cache/cache-1]
+                      :de-dupe.cache/cache-1 {:event-id :foo}}})
+        "DedupTable must accept the canonical namespaced cache with a cache-0 root."))
+  (testing "the predicate also accepts the symbol root form de-dupe-eq actually emits"
+    ;; `de-dupe.core/de-dupe-eq` keys by namespaced SYMBOLS, not
+    ;; keywords — assert the schema accepts that representation too.
+    (is (m/validate DedupTable
+                    {:rf.mcp/dedup-table
+                     {'de-dupe.cache/cache-0 {:a 1}}})
+        "DedupTable must accept the symbol-keyed root form the encoder emits.")))
+
+;; ---------------------------------------------------------------------------
+;; LIVE dedup-table emission + JVM↔Node root agreement (rf2-x0pr0).
+;;
+;; Drive the REAL `de-dupe.core/de-dupe-eq` encoder (the same fn both
+;; pair-mcp and story-mcp call at their wire boundary) over a
+;; duplicate-rich value and assert:
+;;
+;;   1. the wrapped marker validates against the tightened DedupTable
+;;      schema (the encoder genuinely emits a cache-0 root — the
+;;      regression the fixture-only layer would miss); and
+;;   2. after a JSON round-trip (the symbol→string coercion every JSON
+;;      transport performs), the table's root key is the byte-for-byte
+;;      string the Node decoder hardcodes as `ROOT_CACHE_ID`. This pins
+;;      the JVM-encoder ⇄ Node-decoder agreement directly — the cross-
+;;      MCP root convention can no longer drift on one side silently
+;;      (acceptance criterion 4).
+;; ---------------------------------------------------------------------------
+
+(def ^:private node-decoder-root-cache-id
+  "The literal `ROOT_CACHE_ID` the Node decoder
+  (`tools/mcp-conformance/lib/dedup-envelope.cjs`) requires as the cache
+  root. Mirrored here so the live test below pins the JVM-encoder's
+  emitted root against the Node-decoder's expectation. A drift on EITHER
+  side trips this gate."
+  "de-dupe.cache/cache-0")
+
+(deftest dedup-table-emitted-live-by-canonical-encoder
+  ;; The load-bearing live-emission gate for `:rf.mcp/dedup-table`. A
+  ;; payload with repeated subtrees so de-dupe actually pools them.
+  (let [payload   [{:event-id :user/sign-in  :handler-id :auth}
+                   {:event-id :user/sign-in  :handler-id :auth}
+                   {:event-id :user/sign-out :handler-id :auth}]
+        cache     (dd/de-dupe-eq payload)
+        wrapped   {:rf.mcp/dedup-table cache}]
+    (testing "the encoder emits a cache carrying the canonical cache-0 root"
+      (is (contains? cache (dd/make-cache-element 0))
+          (str "de-dupe-eq MUST emit a de-dupe.cache/cache-0 root entry. "
+               "If this fails the library's root convention changed and "
+               "the Node decoder's ROOT_CACHE_ID is now wrong. Got keys: "
+               (pr-str (keys cache)))))
+    (testing "the live-emitted marker validates against the tightened DedupTable schema"
+      (is (m/validate DedupTable wrapped)
+          (str "Live-emitted dedup-table failed DedupTable validation:\n"
+               (me/humanize (m/explain DedupTable wrapped)))))
+    (testing "the round-tripped value expands back to the original payload"
+      (is (= payload (dd/expand cache))
+          "live de-dupe-eq → expand round-trips the payload"))
+    (testing "JVM↔Node root agreement: the JSON string form of the root key matches the Node decoder's ROOT_CACHE_ID"
+      ;; The cache keys are namespaced SYMBOLS (`de-dupe.cache/cache-N`).
+      ;; The real story-mcp wire serialises them with Cheshire, whose
+      ;; `generate-string` renders a namespaced symbol key as its FULL
+      ;; `(str sym)` form — namespace preserved — i.e.
+      ;; `"de-dupe.cache/cache-0"`. (`clojure.data.json` is the wrong
+      ;; model here: it DROPS the namespace to `"cache-0"`, which would
+      ;; never round-trip through the Node decoder — so we pin the
+      ;; library-independent `(str key)` form Cheshire and the MCP wire
+      ;; actually emit.) Assert the root key's string form is exactly
+      ;; the literal the Node decoder hardcodes; a drift in the encoder's
+      ;; root convention turns THIS gate red before it breaks real
+      ;; clients.
+      (let [root-key-strs (set (map str (keys cache)))]
+        (is (contains? root-key-strs node-decoder-root-cache-id)
+            (str "The cache's root key, in its on-the-wire string form, "
+                 "MUST be " (pr-str node-decoder-root-cache-id)
+                 " — the literal the Node decoder (lib/dedup-envelope.cjs "
+                 "ROOT_CACHE_ID) requires. Got key string forms: "
+                 (pr-str root-key-strs)))))))
+
+;; ---------------------------------------------------------------------------
+;; Node decoder ROOT_CACHE_ID literal pin (rf2-x0pr0).
+;;
+;; The live test above pins that the JVM encoder's root agrees with the
+;; Node decoder's hardcoded `ROOT_CACHE_ID`. This complementary gate
+;; pins the OTHER direction: the Node decoder source MUST still declare
+;; `ROOT_CACHE_ID = 'de-dupe.cache/cache-0'`. If someone edits the Node
+;; decoder's root constant (or the live JVM root convention shifts),
+;; one of the two gates trips — they cannot drift independently.
+;; ---------------------------------------------------------------------------
+
+(deftest node-decoder-root-cache-id-literal-pinned
+  (let [src (fx/read-source "tools/mcp-conformance/lib/dedup-envelope.cjs")]
+    (is (str/includes? src
+                       (str "ROOT_CACHE_ID = '" node-decoder-root-cache-id "'"))
+        (str "The Node decoder MUST declare ROOT_CACHE_ID = '"
+             node-decoder-root-cache-id
+             "'. If it changed, the JVM DedupTable schema's required-root "
+             "and the live JVM↔Node agreement test are now out of sync — "
+             "update root-cache-id-name + this pin together."))))
 
 ;; ---------------------------------------------------------------------------
 ;; LIVE marker emission (rf2-80y2h).


### PR DESCRIPTION
Closes rf2-x0pr0. Two `tools/mcp-conformance` gates could pass without verifying the contract they pin. Both are tightened so they genuinely fail on regression, each proven via temporary adversarial-RED (restored after).

## 1. Live subscribe gate — `live-re-frame2-pair-subscribe.cjs`

**False-green closed:** the gate accepted ANY progress frame (`frames.length > 0`) and treated the dispatch result as non-fatal. The `:trace` topic carries *every* dispatch, so an unrelated bus emission during the window false-greened it even when our dispatch raced ahead of subscription registration or was refused.

**Fix:**
- Dispatch `[:counter/inc "<nonce>"]` (the handler ignores args; the full event vector flows into the cascade `:event` slot → the `pr-str`'d progress `:message`). The gate now requires at least one frame to carry the per-run **nonce** — it is genuinely **causal** (the observed frame must be the cascade *we* caused).
- A refused/failed dispatch (`isError`) is now **FATAL** rather than logged-and-ignored.
- The fixed-100ms-sleep readiness proxy is replaced by a re-dispatch loop that drives readiness causally (retry until the nonce frame lands), removing the timing coupling the bead flagged.

**Adversarial-RED proof (hermetic orchestrator):**
- Drop the nonce from the event → 5 *real* progress frames arrive, but the gate goes RED ("received 5 frame(s) but NONE carried the dispatched nonce"). Confirms the old `frames.length>0` gate would have false-greened on real-but-unrelated emissions.
- Malformed event (`[:counter/inc`) → RED on the now-fatal `:reason :invalid-event-edn` refusal.

## 2. Dedup-table schema — `wire_vocab_test.clj`

**False-green closed:** `DedupTable` was `[:map [:rf.mcp/dedup-table :map]]` — it accepted `{}`, root-less caches, and the fictional integer-keyed shape. But `de-dupe.core/expand` always begins at the `de-dupe.cache/cache-0` root and the Node decoder (`lib/dedup-envelope.cjs`) **throws** on a missing root. The JVM contract was strictly looser than the client-visible/Node-decoder contract.

**Fix:**
- Schema now requires the canonical `cache-0` root (accepts symbol/keyword/string key forms).
- Removed the bogus integer-keyed fixture (day8/de-dupe v0.3.0 never emits integer keys; verified against the library source).
- Added: negative tests (empty / root-less / integer-keyed all rejected), a **live-emission** test driving the real `de-dupe-eq`, a **JVM↔Node root-agreement** assertion, and a Node `ROOT_CACHE_ID` literal pin so the two sides can't drift independently. Added de-dupe to the wire-vocab test classpath.

**Adversarial-RED proof:**
- Revert schema to loose `:map` → the 3 negative assertions RED.
- Wrong root id → agreement + literal-pin gates RED.
- Strip the live root → live-emission test RED (4 assertions).

## Quality gates
- `npm run test:mcp-conformance` GREEN — all 6 sub-gates; wire-vocab 52 tests / 640 assertions (was 49 / 631).
- Full hermetic orchestrator GREEN — 3 inner tests, subscribe nonce-causality assertion firing.