### PR TITLE
fix(xray): forward fired-edge ids to topology Chart + fix README build-doc drift (rf2-xf5on)

### DIFF
--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -202,16 +202,35 @@ that the tool could be one-shotted from it.
 ```
 tools/xray/
 ├── README.md                                  ; this file
-├── deps.edn                                   ; declares day8/re-frame2-xray
-├── shadow-cljs.edn                            ; build config
+├── deps.edn                                   ; declares day8/re-frame2-xray (artefact deps + :test alias)
 ├── spec/                                      ; normative contract (see above)
 ├── src/day8/re_frame2_xray/
 │   ├── preload.cljs                           ; registers listeners, mounts DOM
 │   ├── core.cljs                              ; user-facing facade (init!, open!, target-frame, ...)
 │   ├── panels/                                ; one ns per panel
 │   └── theme/                                 ; design tokens, theming
+├── testbeds/                                  ; browser feature-gate driving surfaces
 └── test/...
 ```
+
+There is no `tools/xray/shadow-cljs.edn`. The CLJS build is driven from
+the cross-artefact [`implementation/shadow-cljs.edn`](../../implementation/shadow-cljs.edn),
+which wires `../tools/xray/src` + `../tools/xray/test` onto the build
+classpath and registers every `tools/xray/testbeds/*` source dir +
+`:dev-http` port. The runnable feature gates are npm scripts in
+[`implementation/package.json`](../../implementation/package.json) — see
+**Tests** below.
+
+## Tests
+
+| Gate | Command (from `implementation/`) |
+|---|---|
+| JVM/Node unit/helper/view suite | `clojure -M:test` (per-artefact, from `tools/xray/`) or `npm run test:cljs` (cross-artefact node-runtime CLJS) |
+| Browser feature gate | `npm run test:xray-feature-gate` (full) / `npm run test:xray-feature-gate:smoke` (smoke) |
+
+The browser feature gate serves the `tools/xray/testbeds/*` pages from
+`implementation/shadow-cljs.edn`'s `:dev-http` config and drives the
+Playwright scenarios.
 
 ## Bundle isolation
 
@@ -262,9 +281,15 @@ detail panel + 5-tab Static mode), one wired keybinding
 (`Ctrl+Shift+C` toggle), default true-inline mount under
 `[data-rf-xray-host]`, programmatic pop-out via `(xray/popout!)`,
 and a frame-isolated `:rf/xray` registrar.
-Spec corpus landed via rf2-1lls (2026-05-12); the 17-row test
-coverage matrix at [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage-Matrix.md)
-reports `covered` across every row at the unit/helper/view tier.
+Spec corpus landed via rf2-1lls (2026-05-12). The test coverage matrix
+at [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage-Matrix.md)
+tracks per-surface status: most rows are `covered` (unit/helper/view
+tier plus a browser-level path), while several newer rows are `partial`
+— some unit/helper/view or smoke coverage exists, but the deterministic
+browser feature path or failure path is still missing (see the matrix
+for the live per-row status). The 20-event/load re-check is **not
+default CI**; it is an occasional pre-commit / explicit pre-PR gate for
+Xray-heavy work.
 
 Browser testbeds live under `tools/xray/testbeds/` —
 `two_frame_isolation`, `standard_epochs`, `routes_epochs`, `machine_epochs`,

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
@@ -232,6 +232,14 @@
         {:definition             definition
          :machine-id             machine-id
          :current-state          cur-path
+         ;; rf2-xf5on — forward the fired-this-epoch edge ids the view
+         ;; already computes (line ~166) into the chart so the traversed
+         ;; edges paint the FIRED treatment. The docstring's `:trace-events`
+         ;; contract promises `fired-this-epoch` edge highlights; `Chart`
+         ;; exposes + forwards `:fired-edge-ids`, so the wiring must reach
+         ;; it. `#{}` (case-B / no transition this epoch) → no fired
+         ;; highlight, identical to passing none.
+         :fired-edge-ids         fired-ids
          ;; rf2-vcnvj — surface the STATIC context shape (keys + type
          ;; captions of the definition's `:data`) so the root Context
          ;; chrome renders on the blank-state topology. nil when the

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_view_cljs_test.cljs
@@ -2,9 +2,57 @@
   "Pure-data tests for the topology-view composition helpers (rf2-vcnvj).
   Focuses on `static-context-shape` — the root-Context-chrome projection
   the Static-Machines topology path feeds the chart so the root context
-  renders on the blank-state topology without a live snapshot."
+  renders on the blank-state topology without a live snapshot.
+
+  Also pins the `Topology` → `machine-canvas/Chart` prop boundary
+  (rf2-xf5on): the view's `:trace-events` contract promises
+  `fired-this-epoch` edge highlights, so the fired-edge ids it computes
+  must reach the chart mount's `:fired-edge-ids` prop."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
+            [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-xray.panels.machines.topology-view :as tv]))
+
+(defn- toy-definition
+  "Minimal machine: :empty --:populate--> :populated --:submit-->
+  :submitting (final). Mirrors the trace-state test's fixture so the
+  fired-edge ids agree by construction with the live chart's projection."
+  []
+  {:initial :empty
+   :states  {:empty      {:on {:populate :populated}}
+             :populated  {:on {:submit :submitting}}
+             :submitting {:final? true}}})
+
+(defn- canonical-edge-id
+  "The live-chart canonical edge id for `from→to via event`, projected
+  through the SAME `chart.layout/parse-definition` the live MachineChart
+  uses — so the test asserts the EXACT ids the chart paints, not a
+  re-implemented scheme."
+  [definition from-path to-path event]
+  (->> (:edges (chart-layout/parse-definition definition))
+       (some (fn [e]
+               (when (and (= from-path (:from-path e))
+                          (= to-path   (:to-path e))
+                          (= event     (:event e)))
+                 (:id e))))))
+
+(defn- find-chart-props
+  "Walk the hiccup `Topology` returns and return the props map of the
+  `[machine-canvas/Chart {...}]` mount (or nil if absent). Depth-first;
+  returns the first match."
+  [hiccup]
+  (cond
+    (and (vector? hiccup)
+         (= machine-canvas/Chart (first hiccup)))
+    (second hiccup)
+
+    (vector? hiccup)
+    (some find-chart-props hiccup)
+
+    (seq? hiccup)
+    (some find-chart-props hiccup)
+
+    :else nil))
 
 (deftest static-context-shape-maps-keys-to-type-captions
   (testing "rf2-vcnvj — derives `(key → type-caption)` from the
@@ -32,3 +80,42 @@
     (is (nil? (tv/static-context-shape {:initial :a :states {:a {}}})))
     (is (nil? (tv/static-context-shape {:initial :a :data nil :states {:a {}}})))
     (is (nil? (tv/static-context-shape nil)))))
+
+;; ---- Topology → Chart fired-edge prop boundary (rf2-xf5on) --------------
+
+(deftest topology-forwards-fired-edge-ids-to-chart
+  (testing "rf2-xf5on — the fired-this-epoch edge ids the view computes from
+            `:trace-events` reach the `machine-canvas/Chart` mount's
+            `:fired-edge-ids` prop (the docstring's contract). Before the
+            fix the prop was absent and the fired treatment was silently
+            dropped."
+    (let [def         (toy-definition)
+          populate-id (canonical-edge-id def [:empty] [:populated] :populate)
+          events      [{:operation :rf.machine/transition
+                        :tags      {:machine-id :cart}
+                        :from      [:empty] :to [:populated]
+                        :event     :populate}]
+          props       (find-chart-props
+                        (tv/Topology {:machine-id   :cart
+                                      :definition   def
+                                      :trace-events events}))]
+      (is (some? props)
+          "the :else branch mounts machine-canvas/Chart")
+      (is (string? populate-id))
+      (is (contains? props :fired-edge-ids)
+          "Chart mount carries the :fired-edge-ids prop")
+      (is (= #{populate-id} (:fired-edge-ids props))
+          "and it is exactly the canonical fired-edge id set the live
+           chart paints"))))
+
+(deftest topology-passes-empty-fired-edges-when-no-transition-this-epoch
+  (testing "rf2-xf5on — case-B (no transition this epoch) forwards `#{}`,
+            identical to passing no fired highlight."
+    (let [def   (toy-definition)
+          props (find-chart-props
+                  (tv/Topology {:machine-id   :cart
+                                :definition   def
+                                :trace-events []}))]
+      (is (some? props))
+      (is (= #{} (:fired-edge-ids props))
+          "empty fired set → no fired highlight on the blank-epoch chart"))))


### PR DESCRIPTION
Closes rf2-xf5on (senior review: tools/xray topology contract and build-doc drift).

## Topology -> Chart fired-edge contract gap (finding 1)

`topology-view/Topology` computed `fired-ids` from `:trace-events` (via `trace-state/extract-fired-edge-ids`) but used them only for the `data-no-transition-this-epoch` attribute — they were never passed to `machine-canvas/Chart`. Yet `Chart` exposes `:fired-edge-ids` and forwards it to `mv-chart/MachineChart` (the prop that paints the fired treatment), and `Topology`'s docstring promises `:trace-events` derives `fired-this-epoch` edge highlights. Any caller using `Topology` with focused-epoch traces got the current-state annotation but silently lost the fired-edge treatment.

**Fix:** forward `:fired-edge-ids fired-ids` into the `Chart` mount.

**Regression test** (`topology_view_cljs_test.cljs`): expands the `Topology` hiccup tree, locates the `[machine-canvas/Chart {...}]` mount, and asserts `:fired-edge-ids` equals the exact canonical edge-id set the live chart paints — projected through the same `chart.layout/parse-definition` the chart uses (ids agree by construction). A case-B test pins the `#{}` no-transition path.

Acceptance verified: the test FAILS before the fix (3 failures — `:fired-edge-ids` absent from the Chart mount map) and PASSES after.

## README build-doc drift (finding 2)

- Removed the nonexistent `tools/xray/shadow-cljs.edn` file-layout entry (`Test-Path` returns false). Named the real CLJS build config — the cross-artefact `implementation/shadow-cljs.edn` (wires `../tools/xray/src` + `../tools/xray/test` + every testbed `:dev-http` port) — and the runnable gates in `implementation/package.json`. Added a Tests table + a `testbeds/` entry to the layout.
- Replaced the stale "matrix reports `covered` across every row" Status claim with the actual mixed `covered`/`partial` reality, and called out that the 20-event/load re-check is not default CI — matching `spec/017-Test-Coverage-Matrix.md`.

## Spec

No `tools/xray/spec/*` change needed: the fired-edge contract in `003-Machine-Inspector.md` and the renderer-side ownership (machines-viz `001-Topology-Parity.md`) were already correct — the impl was dropping the prop, not the spec mis-describing it. The README was the doc that had drifted.

## Gates (cold)

- `tools/xray` `clojure -M:test` — 1101 tests / 4532 assertions, 0 failures.
- `npm run test:cljs` — 5663 tests / 19765 assertions, 0 failures (includes the new topology-view regression tests).
- `npm run test:xray-feature-gate:smoke` — 4 scenarios, 0 failures.
- `mkdocs build --strict` not required — `tools/xray/README.md` is not part of the `docs/`-rooted mkdocs site.
