### PR TITLE
fix(mcp-base): honor caller strip-fn in single-map scrub guard + reject fractional cap (rf2-li6y2.1, rf2-li6y2.2)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -99,9 +99,11 @@
 
 (def ^:const invalid-arg-hint
   "Recovery hint embedded in the `:rf.mcp/invalid-arg` rejection when a
-  caller supplies a negative `:max-tokens` (rf2-5rdit). States the valid
-  domain AND the disable sentinel so the agent's next call is correct."
-  "max-tokens must be >= 0; 0 disables the cap")
+  caller supplies an out-of-domain `:max-tokens` — a negative (rf2-5rdit)
+  or a fractional positive in (0,1) that would floor to a 0-cap lockout
+  (rf2-li6y2.2). States the valid domain AND the disable sentinel so the
+  agent's next call is correct."
+  "max-tokens must be an integer >= 1; 0 disables the cap")
 
 (defn invalid-arg-marker
   "Build the `{:rf.mcp/invalid-arg {...}}` rejection payload (rf2-5rdit)
@@ -131,8 +133,9 @@
   "Resolve the per-call cap from an ALREADY-EXTRACTED raw value.
   Returns the integer cap in tokens, `nil` when the cap is disabled
   (caller passed `0`), `overflow/default-max-tokens` when absent or
-  not a number, or — for a NEGATIVE number — an
-  `{:rf.mcp/invalid-arg {...}}` REJECTION marker (rf2-5rdit).
+  not a number, or — for an out-of-domain number (a NEGATIVE, rf2-5rdit;
+  or a fractional positive in (0,1) that would floor to a 0-cap lockout,
+  rf2-li6y2.2) — an `{:rf.mcp/invalid-arg {...}}` REJECTION marker.
 
   Each consumer extracts the raw value from its platform-specific args
   object — re-frame2-pair-mcp uses `(j/get args \"max-tokens\")` against a JS
@@ -148,9 +151,11 @@
   - `default-max-tokens` (5000) return ⇒ caller didn't supply a value
     OR supplied a non-number. The default applies.
   - positive integer return ⇒ caller supplied a custom cap.
-  - `{:rf.mcp/invalid-arg {...}}` return ⇒ caller supplied a NEGATIVE
-    number. The consumer surfaces this as an `isError: true` result
-    (test via `invalid-arg?`) and MUST NOT pass it to `apply-cap`.
+  - `{:rf.mcp/invalid-arg {...}}` return ⇒ caller supplied an out-of-domain
+    number: a NEGATIVE (rf2-5rdit) OR a fractional positive in (0,1) that
+    would floor to a real 0-cap lockout (rf2-li6y2.2). The consumer surfaces
+    this as an `isError: true` result (test via `invalid-arg?`) and MUST NOT
+    pass it to `apply-cap`.
 
   ## Why negatives are rejected, not clamped (rf2-5rdit)
 
@@ -169,6 +174,12 @@
     (nil? raw)                       overflow/default-max-tokens
     (and (number? raw) (zero? raw))  nil
     (and (number? raw) (neg? raw))   (invalid-arg-marker :max-tokens raw invalid-arg-hint)
+    ;; A fractional positive in (0,1) — e.g. 0.5 — would `(long …)` floor
+    ;; to a REAL 0 cap (non-nil, NOT the disable sentinel). `apply-cap`
+    ;; then over-trips on EVERY non-empty payload, locking the agent out —
+    ;; the exact lockout class rf2-5rdit rejected for negatives (rf2-li6y2.2).
+    ;; Reject it honestly rather than silently flooring to a 0-cap lockout.
+    (and (number? raw) (< raw 1))    (invalid-arg-marker :max-tokens raw invalid-arg-hint)
     (number? raw)                    (long raw)
     :else                            overflow/default-max-tokens))
 

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -284,10 +284,16 @@
   event shape, reported zero drops, AND carried any secret in that map
   straight past the filter.
 
-  Fail-CLOSED exception: a single MAP slice that is itself a sensitive
-  event (`sensitive-event?`) is DROPPED, not passed through — shipping it
-  raw would leak the very secret the filter exists to suppress. It is
-  replaced with the empty batch and counted as one drop."
+  Fail-CLOSED exception: a single MAP slice that the caller-supplied
+  `strip-fn` classifies as sensitive is DROPPED, not passed through —
+  shipping it raw would leak the very secret the filter exists to
+  suppress. It is replaced with the empty batch and counted as one drop.
+  Classification routes through `strip-fn` (the SAME predicate the
+  sequential branch uses), NOT the base `sensitive-event?` — so a
+  union-signal sensitivity the caller's predicate catches (e.g.
+  re-frame2-pair-mcp's `:rf.epoch/sensitive? true` epoch rollup, carrying
+  no unqualified `:sensitive?` stamp) is honoured on the single-map shape
+  too (rf2-li6y2.1)."
   ([snapshot include?]
    (scrub-snapshot snapshot include? strip-sensitive))
   ([snapshot include? strip-fn]
@@ -316,12 +322,24 @@
                    ;; Fail-CLOSED: a single map that is itself a sensitive
                    ;; event is NOT a batch and would leak its secret if
                    ;; shipped raw — drop it (empty batch) and count it.
-                   (sensitive-event? slice)
-                   [(assoc frame-map slice-key []) (inc acc)]
+                   ;; Classify via the SAME caller-supplied `strip-fn` the
+                   ;; sequential branch uses (rf2-li6y2.1) — NOT the base
+                   ;; `sensitive-event?`. Otherwise a single-map slice that
+                   ;; is sensitive ONLY by a union signal the caller's
+                   ;; predicate catches (e.g. re-frame2-pair-mcp's epoch
+                   ;; rollup `:rf.epoch/sensitive? true`, with no unqualified
+                   ;; `:sensitive?` stamp) would slip past this guard to the
+                   ;; `:else` arm and ship RAW — the rf2-5613h leak class
+                   ;; re-surfacing inside the rf2-wm9kp defensive guard.
+                   (map? slice)
+                   (let [[_ n] (strip-fn [slice] false)]
+                     (if (pos? n)
+                       [(assoc frame-map slice-key []) (inc acc)]
+                       [frame-map acc]))
 
-                   ;; Any other non-sequential shape (nil, scalar, string,
-                   ;; non-sensitive single map) is not a batch — pass it
-                   ;; through byte-identically per the helper contract.
+                   ;; Any other non-sequential shape (nil, scalar, string)
+                   ;; is not a batch — pass it through byte-identically per
+                   ;; the helper contract.
                    :else
                    [frame-map acc]))))
            scrub-frame

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -84,6 +84,36 @@
   (is (cap/invalid-arg? (cap/max-tokens -5)) "larger-magnitude negatives reject too")
   (is (cap/invalid-arg? (cap/max-tokens -1.5)) "negative doubles reject too"))
 
+(deftest max-tokens-fractional-positive-rejected-with-invalid-arg
+  ;; rf2-li6y2.2 — a fractional positive in (0,1) — e.g. 0.5 — is neither
+  ;; caught by (zero? raw) nor (neg? raw); pre-fix it fell to (long raw),
+  ;; flooring to a REAL 0 cap (non-nil, NOT the disable sentinel). That 0
+  ;; then over-tripped `apply-cap`'s `over-cap?` on EVERY non-empty payload,
+  ;; locking the agent out — the exact lockout class rf2-5rdit rejected for
+  ;; negatives. The resolver now rejects it honestly as an
+  ;; `{:rf.mcp/invalid-arg {...}}` marker rather than flooring to a 0-cap
+  ;; lockout.
+  (let [out (cap/max-tokens 0.5)]
+    (is (cap/invalid-arg? out)
+        "fractional positive in (0,1) resolves to an :rf.mcp/invalid-arg rejection, NOT a floored 0 cap")
+    (is (not (number? out)) "the rejection is a marker map, not a (0) cap integer")
+    (is (not= 0 out)
+        "must NOT return a real 0 cap — that is the apply-cap lockout shape, distinct from the nil disable-sentinel")
+    (is (some? out)
+        "must NOT return nil — nil is the disable-sentinel, a rejection must be distinguishable")
+    (let [body (get out vocab/invalid-arg-key)]
+      (is (= :max-tokens (:arg body)) "rejection names the offending arg")
+      (is (= 0.5 (:value body)) "rejection echoes the rejected value")
+      (is (string? (:hint body)) "rejection carries an actionable recovery hint")))
+  ;; Other sub-1 positives that would floor to 0 reject identically.
+  (is (cap/invalid-arg? (cap/max-tokens 0.1)) "0.1 rejects")
+  (is (cap/invalid-arg? (cap/max-tokens 0.999)) "0.999 rejects (would floor to 0)")
+  ;; Boundary: exactly 1 (and >= 1 fractionals) are valid usable caps —
+  ;; they floor to >= 1, NOT to a 0-cap lockout.
+  (is (= 1 (cap/max-tokens 1)) "exactly 1 is the smallest valid cap")
+  (is (= 1 (cap/max-tokens 1.0)) "1.0 floors to a usable 1")
+  (is (= 2 (cap/max-tokens 2.9)) "2.9 floors to a usable 2 (benign silent floor, still >= 1)"))
+
 (deftest invalid-arg?-predicate-discriminates
   ;; The predicate consumers gate on. True only for the rejection marker;
   ;; false for every valid `max-tokens` return (cap int, nil-disable,

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -351,6 +351,65 @@
     (is (= [{:event-id :b}] (get-in out [:rf/default :epochs])))))
 
 ;; ---------------------------------------------------------------------------
+;; Single-map fail-closed branch routes through the caller-supplied strip-fn
+;; (rf2-li6y2.1). The rf2-wm9kp guard classified a single-map slice with the
+;; BASE `sensitive-event?` instead of the caller's `strip-fn`. So a single-map
+;; slice sensitive ONLY by a UNION signal the caller's predicate catches
+;; (re-frame2-pair-mcp's epoch rollup `:rf.epoch/sensitive? true`, carrying no
+;; unqualified `:sensitive?` stamp) slipped past the guard to the `:else` arm
+;; and shipped RAW with dropped=0 — the rf2-5613h leak class re-surfacing
+;; inside the rf2-wm9kp defensive guard. The single-map branch now classifies
+;; via the SAME strip-fn the sequential branch uses.
+;; ---------------------------------------------------------------------------
+
+;; The pair-mcp UNION strip-fn (mirrors tools/re-frame2-pair-mcp
+;; sensitive/strip-sensitive): base trace-event stamp OR the epoch-level
+;; `:rf.epoch/sensitive?` rollup, classified via the shared fail-closed
+;; `sensitive-stamp?`.
+(defn- union-strip [items _include?]
+  (let [drop? (fn [x] (or (sensitive/sensitive-event? x)
+                          (and (map? x)
+                               (sensitive/sensitive-stamp? (:rf.epoch/sensitive? x)))))
+        kept  (filterv (complement drop?) items)]
+    [kept (- (count items) (count kept))]))
+
+(deftest scrub-snapshot-single-map-sensitive-by-union-signal-dropped
+  ;; rf2-li6y2.1 (the leak) — a single-MAP :epochs slice sensitive ONLY by
+  ;; the union signal (`:rf.epoch/sensitive? true`, NO unqualified
+  ;; `:sensitive?` stamp). Pre-fix the single-map branch hardcoded the base
+  ;; `sensitive-event?` (which returns false here — no `:sensitive?` stamp),
+  ;; so the slice fell to the `:else` arm and PASSED THROUGH RAW with
+  ;; dropped=0, leaking the secret. The branch now routes through the
+  ;; caller-supplied union strip-fn, so the union sensitivity is honoured.
+  (let [snap {:rf/default {:epochs {:rf.epoch/sensitive? true
+                                    :event-id :auth/sign-in
+                                    :secret "TOKEN_LEAK"}}}
+        [out dropped] (sensitive/scrub-snapshot snap false union-strip)]
+    (is (= 1 dropped)
+        "single-map slice sensitive by the union signal is counted as a drop")
+    (is (= [] (get-in out [:rf/default :epochs]))
+        "the union-sensitive single-map :epochs is dropped (empty batch), not shipped raw")
+    (is (not (clojure.string/includes? (pr-str out) "TOKEN_LEAK"))
+        "the secret never survives in the scrubbed output (fail-closed)"))
+  ;; Symmetric :traces shape.
+  (let [snap {:rf/default {:traces {:rf.epoch/sensitive? true :secret "TRACE_LEAK"}}}
+        [out dropped] (sensitive/scrub-snapshot snap false union-strip)]
+    (is (= 1 dropped))
+    (is (= [] (get-in out [:rf/default :traces])))
+    (is (not (clojure.string/includes? (pr-str out) "TRACE_LEAK")))))
+
+(deftest scrub-snapshot-single-map-not-sensitive-by-union-passes-through
+  ;; rf2-li6y2.1 — symmetric safety: a single-map slice the union strip-fn
+  ;; does NOT classify as sensitive (no `:sensitive?` stamp, no
+  ;; `:rf.epoch/sensitive?` rollup) still passes through byte-identically.
+  ;; The fix must not over-drop benign single maps.
+  (let [snap {:rf/default {:epochs {:event-id :ui/click :data 42}}}
+        [out dropped] (sensitive/scrub-snapshot snap false union-strip)]
+    (is (zero? dropped))
+    (is (= {:event-id :ui/click :data 42} (get-in out [:rf/default :epochs]))
+        "a single map the caller's strip-fn keeps survives verbatim")))
+
+;; ---------------------------------------------------------------------------
 ;; Malformed counter — operator-surface observability for the fail-
 ;; closed gate (rf2-8cpsg / F19).
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
@
Two correctness/privacy findings from the `tools/mcp-base` review (parent rf2-li6y2). One PR.

## rf2-li6y2.1 (P2 — privacy / composition-gap)

`scrub-snapshot`s single-map fail-closed branch (`sensitive.cljc`) hardcoded the base `sensitive-event?` predicate instead of the **caller-supplied `strip-fn`**. A single-MAP `:epochs`/`:traces` slice sensitive ONLY via re-frame2-pair-mcps union signal (`:rf.epoch/sensitive? true`, no unqualified `:sensitive?` stamp) fell to the `:else` arm and **passed through raw with dropped=0** — the rf2-5613h leak class re-surfacing inside the rf2-wm9kp defensive guard.

**Fix:** the single-map branch now classifies via the SAME `strip-fn` the sequential branch already uses, so the union-signal sensitivity is honored on the single-map shape too. Docstring updated.

Live repro (pair-mcp union strip-fn, single-map `:epochs` slice carrying a secret):

```
BEFORE: dropped=0, output retains {:rf.epoch/sensitive? true … :secret "TOKEN_LEAK"}  (secret leaks=true)
AFTER:  dropped=1, :epochs [],  secret leaks=false
```

**Vector-path contract is unchanged** — the sequential branch already routed through `strip-fn`; only the single-map branch changed. Behavior-preserving for the in-parallel re-frame2-pair-mcp consumer (8fin7).

## rf2-li6y2.2 (P4 — edge / agent lockout)

`cap/max-tokens` (`cap.cljc`): a fractional positive in (0,1) e.g. `0.5` floored via `(long raw)` to a real **0** cap (non-nil, NOT the disable sentinel) → `apply-cap` over-tripped on every payload, locking the agent out — the same lockout class rf2-5rdit fixed for negatives.

**Fix:** a sub-1 positive is now rejected as `:rf.mcp/invalid-arg`, consistent with the rf2-5rdit honest-rejection posture.

```
BEFORE: (max-tokens 0.5) => 0          (real 0-cap lockout)
AFTER:  (max-tokens 0.5) => {:rf.mcp/invalid-arg {...}}
        (max-tokens 1)   => 1   (max-tokens 1.0) => 1   (max-tokens 2.9) => 2   (unchanged, usable)
        (max-tokens 0)   => nil (disable, unchanged)    (max-tokens nil) => 5000 (default, unchanged)
```

## Tests

- `sensitive_test.clj`: single-map union-signal scrub regression (drop + counted + no-leak; symmetric `:traces`; + benign single-map passthrough so the fix does not over-drop).
- `cap_test.clj`: fractional-cap edge (`0.5`/`0.1`/`0.999` reject; `1`/`1.0`/`2.9` usable boundary).
- `clojure -M:test`: **196 tests, 570 assertions, 0 failures, 0 errors.**

Closes rf2-li6y2.1, rf2-li6y2.2.
@