### PR TITLE
fix(template): collapse empty Xray gutter in release + guard reg-view drift + comment nits (rf2-3uqbd.1/.2/.3)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/root/dev/scratch.cljs
+++ b/tools/template/resources/day8/re_frame2_template/root/dev/scratch.cljs
@@ -14,7 +14,9 @@
   (rf/dispatch [:counter/increment])
   (rf/dispatch [:counter/increment])
 
-  ;; Read the current value out of the default frame.
+  ;; Obtain the subscription ref for the default frame. `subscribe`
+  ;; returns a reactive ref — deref it (`@…`) to read the current
+  ;; value, as the `with-frame` block below does.
   (rf/subscribe [:counter/value])
 
   ;; Run a scratch experiment against a throw-away frame — leaves

--- a/tools/template/resources/day8/re_frame2_template/root/resources/public/css/app.css
+++ b/tools/template/resources/day8/re_frame2_template/root/resources/public/css/app.css
@@ -1,12 +1,19 @@
 /* {{name}} — minimal stylesheet.
  *
- * Three rules. Plain CSS — no Tailwind, no garden, no spade. Replace
- * or extend as your app grows; or swap to Tailwind via :css :tailwind
- * when that template flag lands. */
+ * A handful of rules. Plain CSS — no Tailwind, no garden, no spade.
+ * Replace or extend as your app grows; or swap to Tailwind via
+ * :css :tailwind when that template flag lands. */
 
 body { font: 16px/1.4 system-ui, sans-serif; margin: 0; }
 .rf2-app-shell { display: flex; min-height: 100vh; }
+/* The Xray host only reserves its column once Xray has populated it.
+ * In dev, the `day8.re-frame2-xray.preload` mounts Xray into the
+ * `[data-rf-xray-host]` aside, making it non-empty and sizing it here.
+ * Release builds drop the preload, so the aside stays empty and
+ * `:empty` collapses it — `#app` then spans the full viewport instead
+ * of shipping a blank ~420px gutter. */
 .rf2-xray-host { flex: 0 0 420px; min-width: 320px; }
+.rf2-xray-host:empty { display: none; }
 #app { flex: 1; min-width: 0; padding: 2em; }
 button { padding: 0.4em 0.8em; }
 h1 { margin: 0 0 1em; }

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -72,16 +72,26 @@
   "Given a `(ns ns-sym ...)` form, return a map
      {alias-symbol  required-ns-symbol
       ...
-      ::required #{ns-sym ...}}
-  for every `:require` / `:refer-clojure` clause. Aliases come from
-  `[ns :as alias]`; bare requires (`[ns]` / `ns`) contribute to
-  `::required` only. Side-effecting requires (no `:as`) still count
-  as 'required' for the purpose of the load-order assertion below."
+      ::required #{ns-sym ...}
+      ::referred {referred-sym required-ns-symbol ...}}
+  for every `:require` / `:require-macros` clause. Aliases come from
+  `[ns :as alias]`; `:refer`-ed symbols (`[ns :refer [a b]]`) contribute
+  to `::referred` (mapping each bare symbol to its source ns). Bare
+  requires (`[ns]` / `ns`) contribute to `::required` only. Side-effecting
+  requires (no `:as`) still count as 'required' for the purpose of the
+  load-order assertion below.
+
+  Both `:require` and `:require-macros` are walked (rf2-3uqbd.2): the
+  Reagent scaffold brings `reg-view` in via `:require-macros [re-frame.core
+  :refer [reg-view]]` and calls it bare, so a `:require`-only parse left
+  that central macro invisible to the surface-drift audit. `:refer`-ed
+  symbols from either clause now feed the bare-symbol audit below."
   [ns-form]
   (let [clauses    (drop 2 ns-form) ;; skip `ns` + ns-sym
-        require?   #(and (sequential? %) (= :require (first %)))
-        req-clause (first (filter require? clauses))
-        body       (when req-clause (rest req-clause))]
+        require?   #(and (sequential? %)
+                         (#{:require :require-macros} (first %)))
+        req-bodies (->> (filter require? clauses)
+                        (mapcat rest))]
     (reduce
       (fn [acc spec]
         (cond
@@ -92,13 +102,20 @@
           (let [ns-sym    (first spec)
                 spec-tail (rest spec)            ;; the `:as alias`, `:refer […]`, … pairs
                 opt-pairs (partition 2 spec-tail)
-                alias-sym (some (fn [[k v]] (when (= k :as) v)) opt-pairs)]
+                alias-sym (some (fn [[k v]] (when (= k :as) v)) opt-pairs)
+                referred  (some (fn [[k v]] (when (= k :refer) v)) opt-pairs)]
             (cond-> (update acc ::required (fnil conj #{}) ns-sym)
-              alias-sym (assoc alias-sym ns-sym)))
+              alias-sym (assoc alias-sym ns-sym)
+              (and (sequential? referred))
+              (update ::referred
+                      (fnil into {})
+                      (->> referred
+                           (filter symbol?)
+                           (map (fn [s] [s ns-sym]))))))
 
           :else acc))
-      {::required #{}}
-      body)))
+      {::required #{} ::referred {}}
+      req-bodies)))
 
 (defn- collect-qualified-symbols
   "Walk `forms` (any nested structure) and collect every symbol with a
@@ -108,6 +125,22 @@
     (walk/postwalk
       (fn [x]
         (when (and (symbol? x) (some? (namespace x)))
+          (vswap! acc conj x))
+        x)
+      forms)
+    @acc))
+
+(defn- collect-bare-symbols
+  "Walk `forms` and collect every unqualified symbol (no namespace
+  component). Returns a set. Used (rf2-3uqbd.2) to detect bare,
+  `:refer`-ed framework symbols — e.g. the Reagent scaffold's
+  `(reg-view …)` calls, which are unqualified and therefore invisible to
+  `collect-qualified-symbols`."
+  [forms]
+  (let [acc (volatile! #{})]
+    (walk/postwalk
+      (fn [x]
+        (when (and (symbol? x) (nil? (namespace x)))
           (vswap! acc conj x))
         x)
       forms)
@@ -268,21 +301,51 @@
 ;; --- Generic ns-surface drift check (events / subs / views / events_test)
 ;; ----------------------------------------------------------------------------
 
+(defn- audit-framework-symbol!
+  "Assert `sym` is defined in framework ns `target-ns`'s source file.
+  `label` describes how the symbol was referenced (qualified vs bare
+  `:refer`) for the failure message."
+  [substrate ^java.io.File file root target-ns sym label]
+  (if-let [framework-file (framework-ns-file root target-ns)]
+    (let [defined (defined-symbols framework-file)]
+      (is (contains? defined sym)
+          (str (.getName file) " (" substrate ") " label " "
+               target-ns "/" sym
+               " but it is NOT defined in "
+               (.getPath framework-file)
+               " — likely a rename/cut. Defined symbols there: "
+               (sort defined))))
+    ;; If the framework file isn't found, that's its own drift
+    ;; signal — the template requires a namespace the framework
+    ;; doesn't ship.
+    (is false
+        (str (.getName file) " (" substrate ") " label " " target-ns
+             " but no source file found under implementation/core/src/"))))
+
 (defn- audit-framework-surface!
-  "For `file`, parse it, collect every `<alias>/<sym>` reference whose
-  alias resolves to a `re-frame.*` ns, and assert each `<sym>` is
-  defined in that framework ns's source file. This is the surface-drift
-  smoke test: catches a rename / cut / relocation of a public var that
-  the template scaffold still references."
+  "For `file`, parse it, collect every framework reference, and assert
+  each is defined in its framework ns's source file. This is the
+  surface-drift smoke test: catches a rename / cut / relocation of a
+  public var that the template scaffold still references. Two reference
+  shapes are audited:
+
+    1. `<alias>/<sym>` qualified references whose alias resolves to a
+       `re-frame.*` ns (e.g. `rf/dispatch`).
+    2. Bare, `:refer`-ed framework symbols (rf2-3uqbd.2) whose source ns
+       is `re-frame.*` (e.g. the Reagent scaffold's `(reg-view …)`,
+       brought in via `:require-macros [re-frame.core :refer [reg-view]]`
+       and called unqualified). Without this, a rename of `reg-view`
+       would ship the Reagent scaffold broken-but-green."
   [substrate ^java.io.File file root]
   (when (.isFile file)
     (let [forms      (read-cljs-forms file)
           ns-form    (first forms)
           requires   (parse-ns-requires ns-form)
           body-forms (rest forms)
-          ;; A vector of [referenced-symbol resolved-ns] pairs for every
-          ;; qualified symbol whose alias resolves to a re-frame.* ns.
-          refs       (->> (collect-qualified-symbols body-forms)
+          ;; (1) A vector of [referenced-symbol resolved-ns] pairs for
+          ;; every qualified symbol whose alias resolves to a re-frame.*
+          ;; ns.
+          qual-refs  (->> (collect-qualified-symbols body-forms)
                           (keep (fn [qsym]
                                   (let [alias-sym (symbol (namespace qsym))
                                         target-ns (get requires alias-sym)]
@@ -296,23 +359,26 @@
                           ;; (e.g. rf/dispatch in views).
                           (group-by (fn [[qsym target-ns]]
                                       [target-ns (symbol (name qsym))]))
-                          keys)]
-      (doseq [[target-ns sym] refs]
-        (if-let [framework-file (framework-ns-file root target-ns)]
-          (let [defined (defined-symbols framework-file)]
-            (is (contains? defined sym)
-                (str (.getName file) " (" substrate ") references "
-                     target-ns "/" sym
-                     " but it is NOT defined in "
-                     (.getPath framework-file)
-                     " — likely a rename/cut. Defined symbols there: "
-                     (sort defined))))
-          ;; If the framework file isn't found, that's its own drift
-          ;; signal — the template requires a namespace the framework
-          ;; doesn't ship.
-          (is false
-              (str (.getName file) " (" substrate ") requires " target-ns
-                   " but no source file found under implementation/core/src/")))))))
+                          keys)
+          ;; (2) Bare, `:refer`-ed framework symbols that actually appear
+          ;; in the body. We intersect the ns form's `:refer` set with the
+          ;; bare symbols the body uses, so an unused `:refer` (dead, but
+          ;; harmless) isn't flagged — only symbols the scaffold relies on.
+          referred   (::referred requires)
+          bare-used  (collect-bare-symbols body-forms)
+          bare-refs  (->> referred
+                          (keep (fn [[sym target-ns]]
+                                  (when (and (contains? bare-used sym)
+                                             (string/starts-with?
+                                               (name target-ns)
+                                               "re-frame."))
+                                    [sym target-ns]))))]
+      (doseq [[target-ns sym] qual-refs]
+        (audit-framework-symbol! substrate file root target-ns sym
+                                 "references"))
+      (doseq [[sym target-ns] bare-refs]
+        (audit-framework-symbol! substrate file root target-ns sym
+                                 "refers (bare)")))))
 
 ;; --- scratch.cljs with-frame shape audit (rf2-ah0gi / rf2-twoc5) -----------
 ;;


### PR DESCRIPTION
Three `tools/template` correctness findings under parent rf2-3uqbd, one PR. The scaffold is a newcomer's first app — generated output must be correct in release builds.

## rf2-3uqbd.1 (P2 BUG) — empty Xray gutter shipped in release
The generated `app.css` sized `.rf2-xray-host` unconditionally (`flex: 0 0 420px; min-width: 320px`), but the Xray preload that populates that aside is stripped from release builds (it rides `:devtools/preloads`, dev-only). So every release build a newcomer ships carried a blank ~420px left column — a third of the viewport reserved for nothing, with `#app` pushed right.

**Fix:** add `.rf2-xray-host:empty { display: none; }`.
- **Dev:** the preload appends `#rf-xray-root` into the aside → non-empty → `:empty` does not match → the `flex: 0 0 420px` rule sizes the column.
- **Release:** preload stripped → aside stays empty → `:empty` collapses it → `#app` (`flex: 1`) spans the full viewport. No gutter.

Compatible with Xray's own toggle-off (it sets an inline `display:none`, which wins regardless) and toggle-on (restores inline display → stylesheet sizes it).

**Verified against a real generated app** (deps rewired to in-repo `:local/root`, `node_modules` junctioned):
- `shadow-cljs release app` → completes clean (0 warnings); shipped `app.css` carries both rules; release `main.js` has **zero** `rf-xray-root`/`data-rf-xray-mode` references (preload-mount code fully stripped).
- `shadow-cljs compile app` (dev) → completes clean; bundle includes `day8.re_frame2_xray.preload.js` + `mount.js` (the host-populating code).

## rf2-3uqbd.2 — reg-view drift was unguarded
The Reagent scaffold's central macro `reg-view` is brought in via `:require-macros [re-frame.core :refer [reg-view]]` and called **bare**. The surface-drift audit parsed only `:require` clauses and only **qualified** `<alias>/<sym>` refs, so `reg-view` was doubly invisible — a future `reg-view` rename/cut would have shipped a broken Reagent scaffold green from the default `clojure -M:test`.

**Fix (extend the static-parse guard, no new harness cost):**
- `parse-ns-requires` now walks `:require-macros` too and captures `:refer`-ed symbols into a new `::referred` map.
- `audit-framework-surface!` now additionally checks every bare `:refer`-ed framework symbol that actually appears in the body against the framework def-set (reusing the existing `defmacro`-aware def scanner).

**Self-tested:** temporarily renaming `reg-view` in `implementation/core/src/re_frame/core.cljc` turns the suite **red** with `views.cljs (:reagent) refers (bare) re-frame.core/reg-view but it is NOT defined … likely a rename/cut`; reverted clean (core.cljc untouched in this PR).

## rf2-3uqbd.3 (P4) — comment-vs-code nits in scaffolded output
- `app.css` header said "Three rules" but six ship → "A handful of rules".
- `scratch.cljs` "Read the current value" sat above a bare `(rf/subscribe …)` (returns a reactive ref, not a value) → comment now states it returns a ref and points at the deref example in the `with-frame` block below.

## Gates (cold)
- `tools/template` `clojure -M:test` (default): **26 tests / 319 assertions, 0 failures**.
- Real-compile gate `RF2_TEMPLATE_RUN_EMITTED_TESTS=1`: **347 assertions, 0 failures** (all three substrates compile + node-run).
- Generated app builds clean in **both dev and release** (see rf2-3uqbd.1 verification).