### PR TITLE
fix(pair-mcp): close two P1 off-box egress leaks — snapshot :epochs + record/watch-until (rf2-8fin7.1 + rf2-8fin7.2)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -3304,6 +3304,45 @@
   ;; 30 s is a generous "let me interact while you watch" window.
   30000)
 
+(defn- maybe-elide-sample
+  "Elide a sampled `:app-db` / `:sub` value for off-box egress (rf2-8fin7.2).
+
+   The signal recorder (`record` / `read-recording`) and the blocking watch
+   (`watch-until`) ship the sampled VALUES of `{:app-db [path]}` and
+   `{:sub [query-v]}` signals back to the model. Those values derive
+   straight from a live app's app-db — a declared-sensitive slot (or a sub
+   deriving from one) would cross the AI/off-box boundary RAW, exactly the
+   leak class `get-path` / `read-sub` / `snapshot` / `list-subscriptions`
+   already close via `re-frame.core/elide-wire-value`. This routes the
+   value through the SAME walker, server-side (app-side, where the
+   `[:rf/runtime :elision]` registry is reachable).
+
+   Gate posture mirrors `maybe-elide-for-tap` + the MCP read surfaces
+   (rf2-c2dtu):
+
+   - Gate OFF (`:allow-raw-state? false`, the published-build default the
+     MCP server signals via `configure-raw-state!`): the value is walked
+     with `:rf.size/include-sensitive? false` — declared-sensitive slots
+     land as `:rf/redacted`, declared-large slots as
+     `:rf.size/large-elided`. A hostile per-call opt-in cannot ship raw
+     when the operator did not pass `--allow-sensitive-reads`.
+   - Gate ON (`:allow-raw-state? true`): `elide-opts` carries the caller's
+     per-call posture. `:include-sensitive? true` (the operator's explicit
+     opt-in) passes declared-sensitive slots through verbatim; absent /
+     false still elides. `elide-opts` `nil` ⇒ gate-OFF-equivalent
+     fail-closed defaults so a bare REPL caller is never less safe than
+     the MCP path.
+
+   `frame-id` is supplied so the walker resolves the right per-frame
+   elision registry."
+  [v frame-id elide-opts]
+  (let [gate-on? (:allow-raw-state? @raw-state-config)
+        ;; Fail-closed: when the gate is OFF, force include-sensitive? false
+        ;; regardless of what the caller threaded — the launch flag wins.
+        opts     (cond-> (merge {:frame frame-id} elide-opts)
+                   (not gate-on?) (assoc :rf.size/include-sensitive? false))]
+    (rf/elide-wire-value v opts)))
+
 (defn- sample-one-signal
   "Read ONE signal's current value. Pure READ — never mutates. `signal`
    is a map naming exactly one observable; the recognised shapes:
@@ -3322,15 +3361,29 @@
    `frame-id` resolves the operating frame for :app-db / :sub signals.
    Returns the sampled value (any EDN-able shape) or nil. Errors degrade
    to `{:rf.recording/error <message>}` so one bad signal never collapses
-   the whole sampler tick."
-  [signal frame-id]
+   the whole sampler tick.
+
+   rf2-8fin7.2 — the value-bearing `:app-db` / `:sub` arms route the
+   sampled value through `maybe-elide-sample` (the off-box-egress walker)
+   so a declared-sensitive app-db slot (or a sub deriving from one) is
+   redacted before it crosses the MCP boundary, under the default
+   `--allow-sensitive-reads OFF` gate. `elide-opts` carries the caller's
+   per-call posture (gate-ON `:include-sensitive` opt-in); `nil` ⇒
+   fail-closed defaults. The `:dom` / `:focus` arms are DOM-text /
+   focus-descriptor reads (no app-db material), so they pass through
+   un-elided."
+  ([signal frame-id] (sample-one-signal signal frame-id nil))
+  ([signal frame-id elide-opts]
   (try
     (cond
       (contains? signal :app-db)
-      (get-in (rf/app-db-value frame-id) (vec (:app-db signal)))
+      (-> (get-in (rf/app-db-value frame-id) (vec (:app-db signal)))
+          (maybe-elide-sample frame-id elide-opts))
 
       (contains? signal :sub)
-      (when frame-id @(rf/subscribe frame-id (vec (:sub signal))))
+      (when frame-id
+        (-> @(rf/subscribe frame-id (vec (:sub signal)))
+            (maybe-elide-sample frame-id elide-opts)))
 
       (contains? signal :dom)
       (when-let [el (.querySelector js/document (:dom signal))]
@@ -3353,7 +3406,7 @@
       :else
       {:rf.recording/error "unrecognised signal shape — expected one of :app-db :sub :dom :focus"})
     (catch :default e
-      {:rf.recording/error (.-message e)})))
+      {:rf.recording/error (.-message e)}))))
 
 (defn sample-signals
   "One-shot read of a signal-set against the operating frame — the pure,
@@ -3363,13 +3416,20 @@
    `watch-until` op polls this server-side (like `tail-build`) so it can
    block on a predicate without installing a rAF loop. The keys of
    `:sample` are the signals' positional indices so the predicate can
-   address `(get sample 0)` regardless of signal shape."
-  ([signals] (sample-signals signals (current-frame)))
-  ([signals frame-id]
+   address `(get sample 0)` regardless of signal shape.
+
+   rf2-8fin7.2 — `elide-opts` (the optional 3rd arg) carries the off-box
+   egress posture for `:app-db` / `:sub` value sampling (gate-ON
+   `:include-sensitive` opt-in). `watch-until` threads it from the MCP
+   gate + per-call args; absent ⇒ fail-closed defaults via
+   `sample-one-signal`."
+  ([signals] (sample-signals signals (current-frame) nil))
+  ([signals frame-id] (sample-signals signals frame-id nil))
+  ([signals frame-id elide-opts]
    {:ok?    true
     :t      (js/Date.now)
     :sample (into {}
-                  (map-indexed (fn [i s] [i (sample-one-signal s frame-id)]))
+                  (map-indexed (fn [i s] [i (sample-one-signal s frame-id elide-opts)]))
                   (vec signals))}))
 
 (defn- recording-sampler-tick!
@@ -3383,9 +3443,14 @@
     (if (or (nil? rec) (not= :recording (:status rec)))
       false
       (let [{:keys [signals frame-id last-values frame-count started-at
-                    stop max-entries]} rec
+                    stop max-entries elide-opts]} rec
             now      (js/Date.now)
-            samples  (mapv #(sample-one-signal % frame-id) signals)
+            ;; rf2-8fin7.2 — each `:app-db` / `:sub` sample is elided for
+            ;; off-box egress before it lands in the change-log (which
+            ;; `read-recording` ships to the model). `elide-opts` carries
+            ;; the gate-ON `:include-sensitive` opt-in; absent ⇒ the
+            ;; runtime's fail-closed gate default.
+            samples  (mapv #(sample-one-signal % frame-id elide-opts) signals)
             ;; Per-signal change detection — structural `=` against the
             ;; last recorded value. The first tick records every signal
             ;; as a baseline (last-values starts empty for each index).
@@ -3472,13 +3537,20 @@
      :frame    operating frame for :app-db / :sub signals. Defaults to the
                session's operating frame.
      :max-entries  drop-oldest ring cap on the change-log (default 2000).
+     :elide-opts  (rf2-8fin7.2) off-box-egress walker opts threaded into
+                  every `:app-db` / `:sub` sample so a declared-sensitive
+                  slot is redacted before it lands in the change-log
+                  `read-recording` ships to the model. The MCP `record`
+                  tool passes the gate + per-call `:include-sensitive`
+                  posture here; absent ⇒ the runtime's fail-closed gate
+                  default (redact under `--allow-sensitive-reads OFF`).
 
    Refuses with `{:ok? false :reason :no-signals}` when `signals` is
    empty, and `{:ok? false :reason :ambiguous-frame}` when an :app-db /
    :sub signal is present but no frame can be resolved (multi-frame
    session, no selection) — read ops must not silently fall back to
    :rf/default."
-  [{:keys [signals stop frame max-entries]}]
+  [{:keys [signals stop frame max-entries elide-opts]}]
   (let [signals  (vec signals)
         needs-frame? (some #(or (contains? % :app-db) (contains? % :sub)) signals)
         frame-id (current-frame frame)]
@@ -3504,6 +3576,10 @@
                   :frame-id    frame-id
                   :stop        stop'
                   :max-entries (or max-entries default-recording-max-entries)
+                  ;; rf2-8fin7.2 — carried through each tick so `:app-db` /
+                  ;; `:sub` samples are elided for off-box egress before
+                  ;; landing in the change-log.
+                  :elide-opts  elide-opts
                   :status      :recording
                   :entries     []
                   :last-values {}

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -147,6 +147,40 @@ the fn erases the leaves it keyed on — `--allow-sensitive-reads OFF`
 strips records that carry the rollup regardless of what the fn
 did to the underlying slots.
 
+### Framework-default projection (the `:redact-fn`-independent backstop, rf2-8fin7.1)
+
+The app-installed `:redact-fn` is **optional** — an app that
+declared a slot `:sensitive?` in its app-db schema but installed
+no `:redact-fn` relies on the framework's own off-box projection,
+not the hook. For the pull-mode epoch tools the framework backstop
+is `re-frame.core/projected-record` (the single normative
+off-box-egress emission site, [Security §Epoch privacy
+posture](../../../spec/Security.md#epoch-privacy-posture--raw-in-process-records-vs-projected-egress)):
+each egressed record is routed through it server-side under the
+`--allow-sensitive-reads OFF` default, so a schema-declared
+sensitive **slot** sitting inside a **non-sensitive** epoch's
+`:db-before` / `:db-after` lands as `:rf/redacted` — even though
+the whole-epoch sensitivity rollup is false and the `:redact-fn`
+was never installed.
+
+`snapshot`'s `:epochs` slot is held to the SAME projection
+contract as `trace-window` / `watch-epochs` (rf2-6wvh5): every
+epoch record in the slice is mapped through `projected-record`
+server-side when the slice expands to `:full`, gated by the
+`:include-sensitive` two-key opt-in (the launch flag AND the
+per-call arg). Before rf2-8fin7.1 the `:epochs` slice was
+`:redact-fn`-only — the client-side sensitive scrub merely DROPS
+whole epochs stamped `:rf.epoch/sensitive? true` and never
+redacts a sensitive slot inside a non-sensitive epoch — so a
+`:redact-fn`-less app leaked the slot off-box under the OFF
+default. The projection closes that asymmetry; `snapshot :epochs`
+now carries the same fail-closed posture as the cursor-paged
+epoch tools.
+
+(`dispatch` trace mode's raw-epoch egress is tracked separately
+under rf2-8fin7.3, a pending decision — it is NOT covered by this
+projection backstop yet.)
+
 ## Universal: `:typicalTokens` on every tool descriptor
 
 Every MCP tool descriptor emitted by `tools/list` carries a

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/record.cljs
@@ -44,13 +44,36 @@
   dispatches, never mutates app-db, never writes the DOM. The descriptors
   carry the read-only annotation (with `:openWorldHint` — the recording
   reaches the browser runtime and has an observable side-effect on the
-  runtime's recording registry, but no app-state mutation)."
+  runtime's recording registry, but no app-state mutation).
+
+  ## Off-box-egress redaction (rf2-8fin7.2)
+
+  Read-only addresses no-MUTATION, NOT sensitive-VALUE egress. The
+  `{:app-db [path]}` / `{:sub [query-v]}` signals sample raw app-db-derived
+  values that `read-recording` ships back to the model — a declared-
+  sensitive slot would cross the AI/off-box boundary verbatim, exactly the
+  leak class `get-path` / `read-sub` / `snapshot` / `list-subscriptions`
+  close. `record` mirrors their posture: the `--allow-sensitive-reads`
+  boot gate (`raw-state/raw-state-allowed?`) + the per-call
+  `:include-sensitive` / `:elision` args resolve an elision-opts map that
+  is threaded into the runtime's `start-recording!` as `:elide-opts`, so
+  every `:app-db` / `:sub` sample is walked through
+  `re-frame.core/elide-wire-value` server-side (app-side, where the
+  per-frame elision registry lives) BEFORE it lands in the change-log.
+  Gate OFF (the published default) forces `:include-sensitive false` ⇒
+  declared-sensitive slots redact to `:rf/redacted`. The tool also issues
+  `raw-state/signal-runtime!` before `start-recording!` so the runtime's
+  own gate is flipped to the OFF posture (a belt-and-suspenders backstop
+  the background sampler tick re-consults each frame)."
   (:require [cljs.reader]
             [clojure.string :as str]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
-            [re-frame2-pair-mcp.tools.probe :as probe]))
+            [re-frame2-pair-mcp.tools.probe :as probe]
+            [re-frame2-pair-mcp.tools.elision :as elision]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]))
 
 ;; ---------------------------------------------------------------------------
 ;; Signal-arg parsing — shared with watch-until.
@@ -197,10 +220,18 @@
   emitted as explicit source: `:signals` / `:frame` / `:max-entries` are
   EDN data literals; `:stop` is built by `stop-map-src` (its `:pred-fn`
   slot carries synthesised CLJS source, which can't ride the EDN-literal
-  arg path)."
-  [signals stop frame max-entries]
+  arg path).
+
+  rf2-8fin7.2 — `elision-opts` is the rendered `elision-opts-edn` walker
+  map (the `--allow-sensitive-reads` gate + per-call `:include-sensitive`
+  posture). It rides as `:elide-opts` so the runtime's sampler elides
+  each `:app-db` / `:sub` value for off-box egress before it lands in the
+  change-log. The map is a plain EDN literal (no synthesised source), so
+  it inlines verbatim."
+  [signals stop frame max-entries elision-opts]
   (let [opts-pairs (cond-> [(str ":signals " (pr-str (vec signals)))
-                            (str ":stop " (stop-map-src stop))]
+                            (str ":stop " (stop-map-src stop))
+                            (str ":elide-opts " elision-opts)]
                      frame       (conj (str ":frame " (pr-str frame)))
                      max-entries (conj (str ":max-entries " (pr-str max-entries))))]
     (ef/emit
@@ -217,7 +248,22 @@
         signals     (parse-signals-arg (wire/arg raw-args :signals))
         stop        (parse-stop-arg (wire/arg raw-args :stop))
         max-entries (let [m (wire/arg raw-args :max-entries)]
-                      (when (and (number? m) (pos? m)) (long m)))]
+                      (when (and (number? m) (pos? m)) (long m)))
+        ;; rf2-8fin7.2 — the `:app-db` / `:sub` samples this recorder ships
+        ;; back via `read-recording` must be elided for off-box egress.
+        ;; Same gate posture as snapshot / get-path / trace-window
+        ;; (rf2-c2dtu / rf2-p1qli): the `--allow-sensitive-reads` boot gate
+        ;; forces `:include-sensitive false` + `:elision true` when OFF
+        ;; (the published default); gate ON honours the per-call args.
+        elision?    (if (raw-state/raw-state-allowed?)
+                      (args/parse-bool-arg raw-args :elision)
+                      true)
+        incl?       (if (raw-state/raw-state-allowed?)
+                      (args/parse-bool-arg raw-args :include-sensitive)
+                      false)
+        ;; rf2-suoj2 polarity — MCP `elision` true = emit markers =
+        ;; `:include-large?` false, hence `(not elision?)`.
+        elision-opts (elision/elision-opts-edn (not elision?) incl?)]
     (cond
       (or (nil? signals) (empty? signals))
       (js/Promise.resolve
@@ -227,10 +273,18 @@
                       "{:app-db [:cart :items]}]' [stop {:ms 30000}] [frame :rf/default]}")}))
 
       :else
-      (let [form (start-recording-form signals stop frame max-entries)]
-        (probe/eval-after-runtime!
-          conn build-id form :record-failed
-          (fn [envelope] (wire/ok-text envelope)))))))
+      (let [form (start-recording-form signals stop frame max-entries elision-opts)]
+        ;; rf2-8fin7.2 — insert `signal-runtime!` between `ensure-runtime!`
+        ;; and the eval (the raw-state tap gate, rf2-c2dtu) so the runtime
+        ;; is in the OFF posture before the background sampler ticks —
+        ;; same prelude shape snapshot / get-path / subscribe use. The
+        ;; plain `eval-after-runtime!` skips this step, so the chain is
+        ;; spelled out here.
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [envelope] (wire/ok-text envelope)))
+            (.catch (fn [err] (probe/err->result :record-failed err))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; read-recording — read back the change-log.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
@@ -17,6 +17,7 @@
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.dedup :as dedup]
             [re-frame2-pair-mcp.tools.elision :as elision]
+            [re-frame2-pair-mcp.tools.epoch-egress :as egress]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.reserved-frame-guard :as guard]))
 
@@ -83,6 +84,58 @@
         ;; MCP arg `elision` true = emit markers = `:include-large?` false,
         ;; hence the local `(not elision?)`.
         elision-opts-form (elision/elision-opts-edn (not elision?) incl?)
+        ;; rf2-8fin7.1 — the `:epochs` slice ships whole `:rf/epoch-record`s
+        ;; (each carrying `:db-before` / `:db-after` app-db snapshots),
+        ;; NOT bare app-db slices, so it MUST route through
+        ;; `re-frame.core/projected-record` — the framework's single
+        ;; normative off-box-egress emission site for epoch records — NOT
+        ;; the per-slot `elide-wire-value` walker that handles `:app-db` /
+        ;; `:sub-cache`. Before this fix the `:epochs` slice rode the wire
+        ;; verbatim: the client-side sensitive scrub only DROPS whole
+        ;; epochs stamped `:rf.epoch/sensitive? true`; it never redacts a
+        ;; schema-declared-sensitive SLOT (e.g. `[:auth :token]`) sitting
+        ;; inside a NON-sensitive epoch's `:db-before` / `:db-after`. So a
+        ;; sensitive slot leaked off-box under the default
+        ;; `--allow-sensitive-reads` OFF posture whenever the slice
+        ;; expanded to `:full`. The projection is gated by `incl?` (the
+        ;; sensitive opt-in), NOT by `elision?` (the large-slot toggle) —
+        ;; same posture trace-window / watch-epochs use (rf2-6wvh5). Gate
+        ;; OFF forces `incl?` false ⇒ `project-epochs?` true ⇒ every epoch
+        ;; record is projected; gate ON + `:include-sensitive true` ⇒
+        ;; records ship raw (the operator's deliberate opt-in).
+        project-epochs?   (not incl?)
+        ;; The whole `walked` reduction is needed when EITHER transform
+        ;; fires: `:app-db`/`:sub-cache` elision (`elision?`) OR `:epochs`
+        ;; projection (`project-epochs?`). When neither fires (gate ON +
+        ;; `:elision false` + `:include-sensitive true`) the snapshot
+        ;; passes through verbatim — the full raw-egress opt-in.
+        walk-snapshot?    (or elision? project-epochs?)
+        ;; Source fragment that applies the active per-slot transforms to
+        ;; one frame's slice map `fmap`. `elision?` wraps `:app-db` /
+        ;; `:sub-cache` through `elide-wire-value`; `project-epochs?` maps
+        ;; the `:epochs` vector through `projected-record`. Emitted as a
+        ;; threaded `let` so a frame can carry both transforms. The
+        ;; `opts` / `f` (`elide-wire-value`) bindings are emitted ONLY in
+        ;; the `elision?` branch — `:epochs` projection never touches the
+        ;; per-slot walker (`projected-record` carries its own elision),
+        ;; so a gate-ON `:elision false` read emits NO `elide-wire-value`
+        ;; (the `:raw-state/snapshot-opt-in-honours-elision-false`
+        ;; conformance contract) while still projecting `:epochs`.
+        slice-walk-src    (str "(let ["
+                               (if elision?
+                                 (str " opts (merge {:frame fid} " elision-opts-form ")"
+                                      " f    (fn [v] (re-frame.core/elide-wire-value v opts))"
+                                      " fmap (if (contains? fmap :app-db)"
+                                      "        (update fmap :app-db f) fmap)"
+                                      " fmap (if (contains? fmap :sub-cache)"
+                                      "        (update fmap :sub-cache f) fmap)")
+                                 "")
+                               (if project-epochs?
+                                 (str " fmap (if (contains? fmap :epochs)"
+                                      "        (update fmap :epochs"
+                                      "                (fn [es] " (egress/project-page-src "es" true) ")) fmap)")
+                                 "")
+                               "] fmap)")
         ;; rf2-3bu3d.6 — when the resolved scope is the DEFAULT `:app`
         ;; (reserved `:rf/*` tool frames excluded), piggyback the list of
         ;; tool frames that the scope dropped onto the same round-trip, so
@@ -95,7 +148,7 @@
         tool-frames-form (if (= :app frames)
                            "(filterv re-frame2-pair.runtime/reserved-tool-frame? (re-frame.core/frame-ids))"
                            "[]")
-        form     (if elision?
+        form     (if walk-snapshot?
                    (ef/emit
                      (ef/rt-let
                        ['snap (ef/rt-call 'snapshot-state opts)
@@ -103,13 +156,7 @@
                                   (str "(reduce-kv"
                                        " (fn [m fid fmap]"
                                        "   (if (map? fmap)"
-                                       "     (let [opts (merge {:frame fid} " elision-opts-form ")"
-                                       "           f    (fn [v] (re-frame.core/elide-wire-value v opts))"
-                                       "           fmap (if (contains? fmap :app-db)"
-                                       "                  (update fmap :app-db f) fmap)"
-                                       "           fmap (if (contains? fmap :sub-cache)"
-                                       "                  (update fmap :sub-cache f) fmap)]"
-                                       "       (assoc m fid fmap))"
+                                       "     (assoc m fid " slice-walk-src ")"
                                        "     (assoc m fid fmap)))"
                                        " {} snap)"))]
                        (ef/rt-raw

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_until.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_until.cljs
@@ -46,6 +46,8 @@
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]
+            [re-frame2-pair-mcp.tools.elision :as elision]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.record :as record]))
 
 (def ^:private default-timeout-ms
@@ -67,11 +69,23 @@
   `{:held? bool :sample {...} :t <ms>}`. `pred-src` is the predicate fn
   source (from `record/pred-source`); when nil the form reports
   `:held? false` every tick (a no-predicate watch can only time out — the
-  refusal is enforced at the tool boundary, so this is defensive)."
-  [signals frame pred-src]
-  (let [sample-call (if frame
-                      (ef/rt-call 'sample-signals signals frame)
-                      (ef/rt-call 'sample-signals signals))]
+  refusal is enforced at the tool boundary, so this is defensive).
+
+  rf2-8fin7.2 — `elision-opts` (the rendered `elision-opts-edn` walker
+  map) rides as the 3rd `sample-signals` arg so each sampled `:app-db` /
+  `:sub` value is elided for off-box egress (the `:sample` slot is what
+  the tool egresses on a hold AND the `:last-sample` on timeout). When no
+  explicit `frame` is supplied the form resolves the operating frame via
+  the runtime's `current-frame` so the 3-arity (which carries the elision
+  opts) is always reached — the bare 1-arity would skip the redaction."
+  [signals frame pred-src elision-opts]
+  (let [frame-src   (if frame
+                      (ef/emit frame)
+                      (ef/emit (ef/rt-call 'current-frame)))
+        sample-call (ef/rt-call 'sample-signals
+                                signals
+                                (ef/rt-raw frame-src)
+                                (ef/rt-raw elision-opts))]
     (ef/emit
       (ef/rt-let
         ['r       sample-call
@@ -100,7 +114,20 @@
                        :else nil))
         timeout-ms (let [t (wire/arg raw-args :timeout-ms)]
                      (if (and (number? t) (pos? t)) (long t) default-timeout-ms))
-        pred-src   (record/pred-source pred)]
+        pred-src   (record/pred-source pred)
+        ;; rf2-8fin7.2 — the `:sample` (on hold) and `:last-sample` (on
+        ;; timeout) slots ship raw `:app-db` / `:sub` values back to the
+        ;; model. Elide them for off-box egress under the same gate posture
+        ;; as snapshot / get-path / record (rf2-c2dtu / rf2-p1qli): gate
+        ;; OFF (the published default) forces `:include-sensitive false`
+        ;; + `:elision true`; gate ON honours the per-call args.
+        elision?   (if (raw-state/raw-state-allowed?)
+                     (args/parse-bool-arg raw-args :elision)
+                     true)
+        incl?      (if (raw-state/raw-state-allowed?)
+                     (args/parse-bool-arg raw-args :include-sensitive)
+                     false)
+        elision-opts (elision/elision-opts-edn (not elision?) incl?)]
     (cond
       (or (nil? signals) (empty? signals))
       (js/Promise.resolve
@@ -117,8 +144,14 @@
                       "or {:signal 0 :changed true}. Without one it can only time out.")}))
 
       :else
-      (let [form (watch-form signals frame pred-src)]
+      (let [form (watch-form signals frame pred-src elision-opts)]
         (-> (probe/ensure-runtime! conn build-id)
+            ;; rf2-8fin7.2 — flip the runtime's raw-state gate to the OFF
+            ;; posture before the first poll (the raw-state tap gate,
+            ;; rf2-c2dtu) so the sampler is fail-closed even if the eval
+            ;; form's threaded opts were somehow bypassed — same prelude
+            ;; step snapshot / get-path / record use.
+            (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
             (.then
               (fn [_]
                 (js/Promise.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/egress_elision_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/egress_elision_test.cljs
@@ -55,7 +55,10 @@
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.trace-window :as tw]
             [re-frame2-pair-mcp.tools.watch-epochs :as we]
-            [re-frame2-pair-mcp.tools.list-subscriptions :as ls]))
+            [re-frame2-pair-mcp.tools.list-subscriptions :as ls]
+            [re-frame2-pair-mcp.tools.snapshot :as snap]
+            [re-frame2-pair-mcp.tools.record :as record]
+            [re-frame2-pair-mcp.tools.watch-until :as watch-until]))
 
 ;; ---------------------------------------------------------------------------
 ;; Gate state is process-global (an atom in raw-state.cljs). Reset to the
@@ -63,7 +66,15 @@
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
-  {:after (fn [] (raw-state/set-allow-raw-state! false))})
+  {:before (fn []
+             ;; The signal-runtime! cache is process-global; clear it so a
+             ;; test's `configure-raw-state!` round-trip is never skipped by
+             ;; a prior test having already signalled the build (rf2-8fin7.2
+             ;; — snapshot / record / watch-until now issue signal-runtime!).
+             (raw-state/reset-runtime-signal-cache!))
+   :after  (fn []
+             (raw-state/set-allow-raw-state! false)
+             (raw-state/reset-runtime-signal-cache!))})
 
 ;; ---------------------------------------------------------------------------
 ;; Form-capturing stub. The probe form (substring `__re_frame2_pair_runtime`)
@@ -302,4 +313,183 @@
                        (is (= :rf/redacted (get-in epoch [:db-after :auth :password]))
                            "the redacted sentinel rides the wire — no raw secret")
                        (is (= :rf/redacted (get-in epoch [:db-before :auth :password])))
+                       (done)))))))))
+
+;; ===========================================================================
+;; rf2-8fin7.1 — snapshot :epochs slice raw :db-* egress
+;; ===========================================================================
+;;
+;; The snapshot eval form elided ONLY :app-db / :sub-cache; the :epochs
+;; slice rode raw. The client scrub merely DROPS whole sensitive epochs, so
+;; a schema-declared-sensitive SLOT inside a NON-sensitive epoch's
+;; :db-before / :db-after leaked off-box in :full mode under the gate-OFF
+;; default. The fix routes the :epochs slice through projected-record (the
+;; same projection trace-window / watch-epochs use), gated by the
+;; include-sensitive two-key opt-in — parity with rf2-6wvh5.
+
+;; The snapshot eval form returns {:value <snap> :elided-count N
+;; :tool-frames-excluded []}. The slice content is irrelevant to the
+;; form-contract assertions (we read the captured form, not the response);
+;; hand back an empty per-frame snap so the client pipeline resolves
+;; cleanly.
+(def ^:private snapshot-canned
+  {:value                 {:rf/default {:app-db {} :epochs []}}
+   :elided-count          0
+   :tool-frames-excluded  []})
+
+(deftest snapshot-epochs-gate-off-projects-records
+  (testing "gate OFF (default): the snapshot :epochs slice is mapped through projected-record"
+    (async done
+      (raw-state/set-allow-raw-state! false)
+      (let [forms (atom [])]
+        (-> (with-capture! forms snapshot-canned
+              ;; mode "full" expands the :epochs slice — the leak path.
+              (fn [] (snap/snapshot-tool nil (tu/args->js {:frames "[:rf/default]"
+                                                           :include "[:epochs]"
+                                                           :mode "full"}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (some? form) "the tool shipped a snapshot eval form")
+                       (is (str/includes? form "mapv re-frame.core/projected-record")
+                           "gate-off MUST route the :epochs slice through projected-record")
+                       (is (str/includes? form ":epochs")
+                           "the :epochs slot is the projection target")
+                       (done)))))))))
+
+(deftest snapshot-epochs-gate-on-include-sensitive-ships-raw
+  (testing "gate ON + include-sensitive true: NO :epochs projection — records ship raw (operator opted in)"
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms snapshot-canned
+              (fn [] (snap/snapshot-tool nil (tu/args->js {:frames "[:rf/default]"
+                                                           :include "[:epochs]"
+                                                           :mode "full"
+                                                           :include-sensitive true}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (not (str/includes? form "projected-record"))
+                           "gate-on + include-sensitive true bypasses :epochs projection — raw egress")
+                       (done)))))))))
+
+(deftest snapshot-epochs-gate-on-default-still-projects
+  (testing "gate ON but include-sensitive omitted (default false): :epochs STILL projected"
+    ;; Two-key opt-in: the launch flag alone does not flip the per-call
+    ;; default — a forgetful caller still gets redaction.
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms snapshot-canned
+              (fn [] (snap/snapshot-tool nil (tu/args->js {:frames "[:rf/default]"
+                                                           :include "[:epochs]"
+                                                           :mode "full"}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (str/includes? form "mapv re-frame.core/projected-record")
+                           "gate-on alone (no per-call opt-in) still projects :epochs — fail-safe default")
+                       (done)))))))))
+
+(deftest snapshot-epochs-projection-independent-of-elision-toggle
+  (testing "gate ON + elision false (no :app-db/:sub-cache walk) STILL projects :epochs"
+    ;; The :epochs projection is gated by include-sensitive (incl?), NOT by
+    ;; the :app-db/:sub-cache large-elision toggle (elision?). Turning
+    ;; elision off must not re-open the epoch leak.
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms snapshot-canned
+              (fn [] (snap/snapshot-tool nil (tu/args->js {:frames "[:rf/default]"
+                                                           :include "[:epochs]"
+                                                           :mode "full"
+                                                           :elision false}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (str/includes? form "mapv re-frame.core/projected-record")
+                           "elision false (incl? still false) MUST still project :epochs")
+                       (is (not (str/includes? form "re-frame.core/elide-wire-value"))
+                           "elision false means no :app-db/:sub-cache walk — only the epoch projection")
+                       (done)))))))))
+
+;; ===========================================================================
+;; rf2-8fin7.2 — record / watch-until raw :app-db & :sub signal egress
+;; ===========================================================================
+;;
+;; record (read back via read-recording) and watch-until sample {:app-db
+;; [path]} / {:sub [query-v]} signals and ship the SAMPLED VALUES back to
+;; the model. Before the fix neither routed the value through
+;; elide-wire-value / a raw-state gate, so a declared-sensitive slot leaked
+;; off-box under the gate-OFF default. The fix threads an elision-opts map
+;; (gate + per-call posture) into the runtime sampler via :elide-opts
+;; (record) / the 3rd sample-signals arg (watch-until), and issues
+;; signal-runtime! before sampling — parity with get-path / read-sub /
+;; snapshot.
+
+(def ^:private record-canned
+  {:ok? true :recording-id "rec-x" :signals [{:app-db [:auth :token]}]
+   :frame :rf/default :stop {:ms 30000}})
+
+(deftest record-gate-off-threads-elision-opts
+  (testing "gate OFF (default): start-recording! carries :elide-opts with include-sensitive? false"
+    (async done
+      (raw-state/set-allow-raw-state! false)
+      (let [forms (atom [])]
+        (-> (with-capture! forms record-canned
+              (fn [] (record/record-tool nil (tu/args->js {:signals "[{:app-db [:auth :token]}]"
+                                                           :stop "{:ms 1000}"}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (some? form) "the tool shipped a start-recording! form")
+                       (is (str/includes? form ":elide-opts")
+                           "gate-off MUST thread :elide-opts so the sampler redacts off-box egress")
+                       (is (str/includes? form ":rf.size/include-sensitive? false")
+                           "gate-off forces include-sensitive? false ⇒ sensitive samples redact")
+                       (done)))))))))
+
+(deftest record-gate-on-include-sensitive-passes-raw
+  (testing "gate ON + include-sensitive true: :elide-opts threads include-sensitive? true (raw samples)"
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms record-canned
+              (fn [] (record/record-tool nil (tu/args->js {:signals "[{:app-db [:auth :token]}]"
+                                                           :stop "{:ms 1000}"
+                                                           :include-sensitive true}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (str/includes? form ":rf.size/include-sensitive? true")
+                           "gate-on + include-sensitive true ⇒ declared-sensitive samples pass raw")
+                       (done)))))))))
+
+(deftest watch-until-gate-off-threads-elision-opts
+  (testing "gate OFF (default): the poll form threads elision-opts into sample-signals, include-sensitive? false"
+    (async done
+      (raw-state/set-allow-raw-state! false)
+      (let [forms (atom [])]
+        (-> (with-capture! forms {:held? true :sample {0 :rf/redacted} :t 1}
+              (fn [] (watch-until/watch-until-tool
+                       nil (tu/args->js {:signals "[{:app-db [:auth :token]}]"
+                                         :pred #js {:signal 0 :changed true}}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (some? form) "the tool shipped a poll form")
+                       (is (str/includes? form "re-frame2-pair.runtime/sample-signals")
+                           "the poll samples server-side")
+                       (is (str/includes? form ":rf.size/include-sensitive? false")
+                           "gate-off forces include-sensitive? false ⇒ sensitive :sample values redact")
+                       (done)))))))))
+
+(deftest watch-until-gate-on-include-sensitive-passes-raw
+  (testing "gate ON + include-sensitive true: the poll form threads include-sensitive? true (raw :sample)"
+    (async done
+      (raw-state/set-allow-raw-state! true)
+      (let [forms (atom [])]
+        (-> (with-capture! forms {:held? true :sample {0 "secret-xyz"} :t 1}
+              (fn [] (watch-until/watch-until-tool
+                       nil (tu/args->js {:signals "[{:app-db [:auth :token]}]"
+                                         :pred #js {:signal 0 :changed true}
+                                         :include-sensitive true}))))
+            (.then (fn [_]
+                     (let [form (slice-form forms)]
+                       (is (str/includes? form ":rf.size/include-sensitive? true")
+                           "gate-on + include-sensitive true ⇒ declared-sensitive :sample values pass raw")
                        (done)))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/record_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/record_test.cljs
@@ -111,7 +111,9 @@
                [{:focus true} {:app-db [:cart]}]
                {:ms 15000 :pred {:signal 0 :equals :done}}
                :rf/default
-               2000)]
+               2000
+               ;; rf2-8fin7.2 — the rendered elision-opts walker map.
+               "{:rf.size/include-large? false :rf.size/include-sensitive? false}")]
     (testing "calls the runtime start-recording! with the signals + stop"
       (is (str/includes? form "re-frame2-pair.runtime/start-recording!"))
       (is (str/includes? form ":signals"))
@@ -121,14 +123,19 @@
       (is (str/includes? form ":max-entries 2000")))
     (testing "the data predicate compiles into a :pred-fn slot (not raw :pred)"
       (is (str/includes? form ":pred-fn"))
-      (is (not (str/includes? form ":pred {")) "the data :pred key must not ride verbatim"))))
+      (is (not (str/includes? form ":pred {")) "the data :pred key must not ride verbatim"))
+    (testing "the elision-opts ride as :elide-opts (rf2-8fin7.2)"
+      (is (str/includes? form ":elide-opts"))
+      (is (str/includes? form ":rf.size/include-sensitive? false")))))
 
 (deftest record-and-watch-forms-are-read-only
   ;; READ-ONLY by construction — neither form may carry an app-mutation
   ;; host-form. The whole point of the recorder is observation.
-  (let [rec-form   (#'record/start-recording-form [{:focus true}] {:ms 1000} nil nil)
+  (let [rec-form   (#'record/start-recording-form [{:focus true}] {:ms 1000} nil nil
+                                                   "{:rf.size/include-large? false :rf.size/include-sensitive? false}")
         watch-form (watch-until/watch-form [{:app-db [:x]}] :rf/default
-                                           (record/pred-source {:signal 0 :equals 1}))]
+                                           (record/pred-source {:signal 0 :equals 1})
+                                           "{:rf.size/include-large? false :rf.size/include-sensitive? false}")]
     (doseq [form [rec-form watch-form]
             mutator ["pair-dispatch" "reset-frame-db" "app-db-reset"
                      ".setAttribute" ".dispatchEvent" ".innerHTML"
@@ -291,7 +298,8 @@
   ;; not the whole sample-set re-tested client-side.
   (let [form (watch-until/watch-form
                [{:app-db [:x]}] :rf/default
-               (record/pred-source {:signal 0 :equals 1}))]
+               (record/pred-source {:signal 0 :equals 1})
+               "{:rf.size/include-large? false :rf.size/include-sensitive? false}")]
     (is (str/includes? form "re-frame2-pair.runtime/sample-signals"))
     (is (str/includes? form ":held?"))
     (is (str/includes? form ":sample"))))


### PR DESCRIPTION
## Summary

Two P1 privacy / spec-divergence leaks where a pair-mcp tool result slot ships a **raw app-db-derived value off-box** under the default `--allow-sensitive-reads` **OFF** gate — bypassing the `projected-record` / `elide-wire-value` + raw-state-gate posture the rest of the pair-mcp read surface already adopts. Parent: rf2-8fin7 correctness review.

### rf2-8fin7.1 — `snapshot` `:epochs` slice (sensitive-slot leak)

The snapshot eval form elided **only** `:app-db` / `:sub-cache`; the `:epochs` slice shipped whole `:rf/epoch-record` values raw. The client-side scrub merely **drops whole** epochs stamped `:rf.epoch/sensitive? true` — it never redacts a schema-declared-sensitive **slot** (e.g. `[:auth :token]`) sitting inside a **non-sensitive** epoch's `:db-before` / `:db-after`. A sensitive slot therefore leaked off-box whenever the slice expanded to `:full`.

**Fix:** route the `:epochs` slice through `re-frame.core/projected-record` (the framework's single normative off-box-egress emission site) server-side, gated by the `:include-sensitive` two-key opt-in — the **same** posture `trace-window` / `watch-epochs` use (rf2-6wvh5). The projection is gated by `incl?` (sensitive opt-in), **not** by the `:app-db`/`:sub-cache` large-elision toggle, so a gate-ON `:elision false` read still projects `:epochs` while emitting no `elide-wire-value` (preserving the `:raw-state/snapshot-opt-in-honours-elision-false` conformance contract).

### rf2-8fin7.2 — `record` / `watch-until` signal-value egress (sensitive-value leak)

`record` (read back via `read-recording`) and `watch-until` sample `{:app-db [path]}` / `{:sub [query-v]}` signals and ship the sampled **values** back to the model with **no** `elide-wire-value`, **no** raw-state gate, **no** `signal-runtime!` — unlike every other read tool.

**Fix:** the runtime sampler (`sample-one-signal`) elides the `:app-db` / `:sub` value arms via `elide-wire-value` (gate-aware, fail-closed), threaded with an `:elide-opts` map the tools compute from the gate + per-call `:include-sensitive` / `:elision` args (parity with `get-path` / `read-sub` / `snapshot`). `record` stores `:elide-opts` on the recording (consumed each sampler tick); `watch-until` passes it as the 3rd `sample-signals` arg. Both tools now issue `raw-state/signal-runtime!` before sampling so the runtime is in the OFF posture first.

## Gate-OFF / ON repro (form-level)

| path | gate OFF (default) | gate ON + `include-sensitive` |
|---|---|---|
| snapshot `:epochs` (`mode full`) | `(update fmap :epochs (fn [es] (mapv re-frame.core/projected-record es)))` | no `:epochs` projection (raw) |
| record | `:elide-opts {:rf.size/include-sensitive? false ...}` | `:elide-opts {:rf.size/include-sensitive? true ...}` |
| watch-until | `sample-signals` 3rd arg `{:rf.size/include-sensitive? false ...}` | `{:rf.size/include-sensitive? true ...}` |

## Tests / gates (all green, cold)

- pair-mcp `clojure -M:test` / `npm test` — **920 tests, 0 failures**. New gate-OFF/ON cases for snapshot `:epochs`, record, and watch-until added to `egress_elision_test.cljs` (`record_test` had **zero** sensitive coverage).
- `npm run test:mcp-conformance` — all 6 gates green (incl. pair-mcp end-to-end + live-redaction conformance).
- runtime recorder structural test (`bb tests/runtime/recorder_test.clj`) — green (read-only invariant intact).

## Scope notes

- **`tools/mcp-base` untouched** — relies on the existing `scrub-snapshot` / `projected-record` contract (li6y2.1 owns the parallel scrub-snapshot fix).
- **rf2-8fin7.3** (dispatch{trace} raw epoch) is a separate decision bead — **not touched** here.
- Catalogue §Universal `:redact-fn` updated to mandate the framework-default `projected-record` backstop for snapshot `:epochs` (closing the `:redact-fn`-only asymmetry).