### PR TITLE
fix(dev-launcher): print managed-http URL + :dev-http drift guard (rf2-d3fb7.1)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -308,6 +308,7 @@ preserving first-seen order.
 | `:examples/routes-epochs` | http://localhost:8032/ |
 | `:examples/machine-epochs` | http://localhost:8033/ |
 | `:examples/edn-inspector` | http://localhost:8034/ |
+| `:examples/managed-http` | http://localhost:8035/ |
 | `:examples/two-frame-isolation` | http://localhost:8030/ |
 | `:testbeds/panel-gallery` | http://localhost:8765/ |
 | `:examples/nine-states-with-stories` | http://localhost:8040/ · `/#/stories` |

--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -83,12 +83,13 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 //
 //   Band        Owner                     Notes
 //   ----------  ------------------------  ----------------------------------
-//   8030-8034   Xray testbeds             :dev-http (shadow-cljs.edn):
+//   8030-8035   Xray testbeds             :dev-http (shadow-cljs.edn):
 //                                           8030 two-frame-isolation
 //                                           8031 standard-epochs
 //                                           8032 routes-epochs
 //                                           8033 machine-epochs
 //                                           8034 edn-inspector
+//                                           8035 managed-http
 //   8040-8043   Story showcases           :dev-http (shadow-cljs.edn):
 //                                           8040 nine-states-with-stories
 //                                           8041 login-with-stories
@@ -99,7 +100,7 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 //                                           (8050; pre-flight + forward scan).
 //   8765        Xray panel-gallery        :dev-http (shadow-cljs.edn).
 //
-// The :dev-http bands (8030-8034 / 8040-8043 / 8765) are mirrored in the
+// The :dev-http bands (8030-8035 / 8040-8043 / 8765) are mirrored in the
 // DEV_HTTP map below (READ-only — shadow-cljs.edn is hot-zone). The 805x
 // examples band is NOT a :dev-http port — it is the test-orchestrator's
 // http-server default, resolved at runtime — so it lives only here + in
@@ -117,6 +118,7 @@ const DEV_HTTP = {
   ':examples/routes-epochs': { port: 8032 },
   ':examples/machine-epochs': { port: 8033 },
   ':examples/edn-inspector': { port: 8034 },
+  ':examples/managed-http': { port: 8035 },
   ':testbeds/panel-gallery': { port: 8765 },
   ':examples/nine-states-with-stories': { port: 8040, story: true },
   ':examples/login-with-stories': { port: 8041, story: true },

--- a/implementation/scripts/dev-testbed.test.cjs
+++ b/implementation/scripts/dev-testbed.test.cjs
@@ -19,7 +19,135 @@
 'use strict';
 
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 const { DEV_HTTP, resolveArgs, urlsForBuild } = require('./dev-testbed.cjs');
+const { IMPL_ROOT } = require('./_path-policy.cjs');
+
+// ---------------------------------------------------------------------------
+// Drift guard helpers (rf2-d3fb7.1).
+//
+// shadow-cljs.edn is the source of truth for which dev-testbed builds are
+// served on a `:dev-http` port; DEV_HTTP in dev-testbed.cjs mirrors it
+// (READ-only — shadow-cljs.edn is hot-zone). The managed-http omission
+// (port 8035 present in :dev-http, absent from DEV_HTTP + the README) shipped
+// green because nothing tied the two surfaces together. This guard parses the
+// `:dev-http` map straight out of shadow-cljs.edn and asserts every served
+// build appears in DEV_HTTP at the matching port, so a future testbed
+// addition that forgets the launcher map fails THIS gate instead of silently
+// printing no URL.
+//
+// The `:dev-http` map keys port -> [roots]; the build-id is recovered by
+// matching the build's `:output-dir` root (`out/...`) against the build defs
+// in the same file. We deliberately hand-roll a focused parser rather than
+// pull in an EDN dependency — the shapes we read (a flat port->vector map and
+// per-build `:output-dir` strings) are simple and stable.
+// ---------------------------------------------------------------------------
+
+/** Read shadow-cljs.edn from the implementation root. */
+function readShadowEdn() {
+  return fs.readFileSync(path.join(IMPL_ROOT, 'shadow-cljs.edn'), 'utf8');
+}
+
+/**
+ * Strip line comments (`;` to end-of-line) so they can't be mistaken for
+ * map content. Naive but sufficient: shadow-cljs.edn carries no `;` inside
+ * the string literals we parse (output-dir / dev-http roots).
+ */
+function stripEdnComments(edn) {
+  return edn
+    .split('\n')
+    .map((line) => {
+      const i = line.indexOf(';');
+      return i === -1 ? line : line.slice(0, i);
+    })
+    .join('\n');
+}
+
+/**
+ * Parse the `:dev-http` map into { port -> [roots...] }. The map binds an
+ * integer port to a vector of string roots.
+ */
+function parseDevHttp(edn) {
+  const src = stripEdnComments(edn);
+  const start = src.indexOf(':dev-http');
+  assert.ok(start !== -1, 'shadow-cljs.edn must contain a :dev-http map');
+  const open = src.indexOf('{', start);
+  assert.ok(open !== -1, ':dev-http must be followed by a map');
+  // Walk to the matching close brace.
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  assert.ok(end !== -1, ':dev-http map must be balanced');
+  const body = src.slice(open + 1, end);
+  // Each entry is `<port> [ "root" "root" ... ]`.
+  const entries = {};
+  const re = /(\d{2,5})\s*\[([^\]]*)\]/g;
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    const port = Number(m[1]);
+    const roots = (m[2].match(/"([^"]*)"/g) || []).map((s) => s.slice(1, -1));
+    entries[port] = roots;
+  }
+  return entries;
+}
+
+/**
+ * Parse every build def's `:output-dir` into { outputDir -> buildId }.
+ * Build defs are top-level `:<group>/<name> { ... :output-dir "out/..." ...}`.
+ */
+function parseBuildOutputDirs(edn) {
+  const src = stripEdnComments(edn);
+  const map = {};
+  // build-id immediately followed by an opening brace, then somewhere a
+  // :output-dir string before the next build-id. We scan build-id positions
+  // and read the FIRST :output-dir that follows each.
+  const idRe = /(:[a-zA-Z][\w.-]*\/[\w.-]+)\s*\{/g;
+  const ids = [];
+  let m;
+  while ((m = idRe.exec(src)) !== null) {
+    ids.push({ id: m[1], at: m.index });
+  }
+  for (let i = 0; i < ids.length; i++) {
+    const from = ids[i].at;
+    const to = i + 1 < ids.length ? ids[i + 1].at : src.length;
+    const slice = src.slice(from, to);
+    const od = slice.match(/:output-dir\s+"([^"]*)"/);
+    if (od) map[od[1]] = ids[i].id;
+  }
+  return map;
+}
+
+/**
+ * Recover { buildId -> port } for every `:dev-http`-served dev-testbed build,
+ * by matching each port's `out/...` root against the build defs.
+ */
+function servedBuildPorts(edn) {
+  const devHttp = parseDevHttp(edn);
+  const byOutputDir = parseBuildOutputDirs(edn);
+  const result = {};
+  for (const [port, roots] of Object.entries(devHttp)) {
+    const outRoot = roots.find((r) => r.startsWith('out/'));
+    if (!outRoot) continue; // no compiled build behind this port — skip.
+    const buildId = byOutputDir[outRoot];
+    assert.ok(
+      buildId,
+      `:dev-http port ${port} serves '${outRoot}' but no build def has that ` +
+        `:output-dir — parser or shadow-cljs.edn drift`,
+    );
+    result[buildId] = Number(port);
+  }
+  return result;
+}
 
 let failed = 0;
 
@@ -116,6 +244,61 @@ it('every DEV_HTTP build-id is a colon-prefixed build coord', () => {
   for (const build of Object.keys(DEV_HTTP)) {
     assert.ok(build.startsWith(':'), `${build} should be a :build coord`);
   }
+});
+
+it('urlsForBuild prints the live URL for the managed-http testbed (rf2-d3fb7.1)', () => {
+  assert.deepStrictEqual(urlsForBuild(':examples/managed-http'), [
+    'http://localhost:8035/',
+  ]);
+});
+
+// --- Drift guard (rf2-d3fb7.1) --------------------------------------------
+// Tie DEV_HTTP to shadow-cljs.edn's :dev-http map so the next testbed
+// addition can't ship with a served port that the launcher knows nothing
+// about (which is exactly how managed-http/8035 shipped green). Parses
+// shadow-cljs.edn directly (READ-only — it's a hot-zone file) and asserts
+// every :dev-http-served build appears in DEV_HTTP at the matching port.
+it('DEV_HTTP covers every :dev-http-served build in shadow-cljs.edn (drift guard)', () => {
+  const edn = readShadowEdn();
+  const served = servedBuildPorts(edn);
+
+  // Sanity-check the parser actually found the known builds — a silently
+  // empty parse must NOT pass this guard vacuously.
+  assert.ok(
+    Object.keys(served).length >= 6,
+    `parser recovered only ${Object.keys(served).length} served builds from ` +
+      `shadow-cljs.edn :dev-http — expected the full dev-testbed set`,
+  );
+  assert.strictEqual(
+    served[':examples/managed-http'],
+    8035,
+    'parser must recover managed-http -> 8035 from shadow-cljs.edn',
+  );
+
+  const missing = [];
+  const mismatched = [];
+  for (const [buildId, port] of Object.entries(served)) {
+    const info = DEV_HTTP[buildId];
+    if (!info) {
+      missing.push(`${buildId} (served on ${port})`);
+    } else if (info.port !== port) {
+      mismatched.push(`${buildId}: DEV_HTTP=${info.port} but :dev-http=${port}`);
+    }
+  }
+  assert.strictEqual(
+    missing.length,
+    0,
+    `DEV_HTTP (dev-testbed.cjs) is missing builds served on a :dev-http ` +
+      `port in shadow-cljs.edn: ${missing.join(', ')}. Add each to DEV_HTTP ` +
+      `(and the README build->port table) so the launcher prints its URL.`,
+  );
+  assert.strictEqual(
+    mismatched.length,
+    0,
+    `DEV_HTTP port(s) disagree with shadow-cljs.edn :dev-http: ${mismatched.join(
+      '; ',
+    )}.`,
+  );
 });
 
 if (failed > 0) {


### PR DESCRIPTION
## What

`:examples/managed-http` is a fully-wired Xray dev testbed (port **8035** in `shadow-cljs.edn` `:dev-http`, build def at lines 928-939) but was **missing** from the launcher's `DEV_HTTP` map (`implementation/scripts/dev-testbed.cjs`) and the README build→port table. Three surfaces disagreed: shadow-cljs.edn had it; `DEV_HTTP` + README did not.

The launcher's documented "print each watched build's served URL" invariant was broken for this testbed.

### Repro (current `main`)
```
cd implementation
node -e "const {urlsForBuild}=require('./scripts/dev-testbed.cjs'); console.log(JSON.stringify(urlsForBuild(':examples/managed-http')))"
=> []        # expected ["http://localhost:8035/"]
```
`npm run dev -- :examples/managed-http` printed no served URL.

## Fix (non-hot-zone files only)

1. **`dev-testbed.cjs`** — add `:examples/managed-http` → 8035 to `DEV_HTTP` (plain build, no story flag); refresh the band-comment to `8030-8035`.
2. **`README.md`** — add the matching row (`http://localhost:8035/`), restoring the footer's claim that the table mirrors `:dev-http`.
3. **`dev-testbed.test.cjs`** — add a **drift guard**: parse `shadow-cljs.edn`'s `:dev-http` map (READ-only — it's hot-zone) and assert every served build appears in `DEV_HTTP` at the matching port. This closes the coverage gap that let the omission ship green (the suite tested other builds but never managed-http, and nothing tied `DEV_HTTP` to `:dev-http`). A future testbed addition that forgets the launcher map now fails `test:script-helpers`.

`shadow-cljs.edn` already had the correct entry and is **NOT** edited here.

## Verification

- `urlsForBuild(':examples/managed-http')`: `[]` → `["http://localhost:8035/"]`.
- `npm run test:script-helpers` — green (incl. the new managed-http assertion + drift guard).
- **Drift guard has teeth**: removing the new `DEV_HTTP` entry makes the guard FAIL with an actionable message naming the missing build + port, then PASS once restored.

Closes rf2-d3fb7.1.