### PR TITLE
fix(security): de-vacuate two adversarial security-tier properties + close a :set path leak (rf2-q0a81.1 + rf2-q0a81.2)

### DIFF
--- a/implementation/security/test/re_frame/security/ssr_escaping_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/ssr_escaping_security_cljs_test.cljc
@@ -34,13 +34,26 @@
 
   ## Net property (verify-by-revert)
 
-  Reverting the `event-handler-allowlist` lower-case lookup (or the
-  camelCase/kebab `event-handler-name-re`) in
-  `html_helpers.cljc` makes the generated-casing test go RED - a live
-  `onX=` attribute appears in `attr-string` output. Reverting
-  `validate-attr-name!`'s grammar throw makes the breakout-key test go
-  RED. Confirmed by temporary local revert + restore (see PR Quality
-  gates)."
+  Two INDEPENDENT generative properties pin the two `event-handler-name?`
+  matcher arms so a revert of EITHER goes RED (each canonical handler is
+  also in the allowlist, so a canonical-casing sweep alone leaves the
+  regex vacuously covered — rf2-q0a81.1):
+
+    1. Reverting the `event-handler-allowlist` lower-case lookup makes
+       `no-recased-canonical-handler-serialises` go RED — the all-
+       lowercase / mixed-lowercase canonical spellings the regex's
+       `[A-Z]`/`-` discriminator CANNOT catch leak as live `onX=`
+       attributes.
+    2. Reverting (or weakening) the camelCase/kebab `event-handler-name-re`
+       makes `no-custom-structural-handler-serialises` go RED — the
+       NON-allowlist structural handlers (`onCustomEvent` / `on-foo-bar`,
+       recased across the `on` prefix) that ONLY the regex catches leak.
+       The canonical sweep never exercises this arm because every
+       canonical handler is in the allowlist.
+
+  Reverting `validate-attr-name!`'s grammar throw makes the breakout-key
+  test go RED. Confirmed by temporary local revert + restore (see PR
+  Quality gates)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
             #?(:clj  [clojure.edn :as edn]
@@ -120,6 +133,73 @@
       (is (nil? result)
           (str "a recased handler leaked as a live attribute: "
                (pr-str result))))))
+
+;; ---------------------------------------------------------------------------
+;; PROPERTY 1b - no NON-ALLOWLIST structural handler ever serialises as a live
+;; attr. This independently exercises `event-handler-name-re` (rf2-q0a81.1):
+;; PROPERTY 1's generator only mints recasings of CANONICAL handlers, and every
+;; canonical handler is in `event-handler-allowlist`, whose lookup lower-cases
+;; the candidate - so the allowlist arm alone strips all 600 draws there and a
+;; revert of the regex leaves PROPERTY 1 GREEN (vacuous w.r.t. the regex). The
+;; framework-shaped CUSTOM handlers below (`:onCustomEvent` / `:on-foo-bar`)
+;; are NOT in the allowlist; ONLY the camelCase/kebab regex strips them, so
+;; reverting/weakening `event-handler-name-re` makes THIS property go RED.
+;; ---------------------------------------------------------------------------
+
+(def ^:private structural-tail-letters
+  (vec "abcdefghijklmnopqrstuvwxyz"))
+
+(defn- recase-on-prefix
+  "Recase ONLY the leading `on` (2 chars) per a 2-bit mask `[b0 b1]`; the rest
+  of the name is kept verbatim so the regex's structural discriminator (the
+  upper-case tail char for camelCase, the `-` for kebab) survives every draw.
+  This sweeps the `[Oo][Nn]` case-insensitivity of the prefix - exactly the
+  rf2-1uex4 casing axis - while keeping the name NON-canonical."
+  [s [b0 b1]]
+  (str (if (= 1 b0) (str/upper-case (subs s 0 1)) (str/lower-case (subs s 0 1)))
+       (if (= 1 b1) (str/upper-case (subs s 1 2)) (str/lower-case (subs s 1 2)))
+       (subs s 2)))
+
+(def ^:private gen-custom-structural-handler
+  "Draws a `[k v]` attribute pair whose KEY is a randomly-recased-prefix
+  NON-allowlist structural event handler - either camelCase (`on` + an
+  upper-case first tail char + a random lower-case tail, e.g. `onFooba`) or
+  kebab (`on-` + a random tail, e.g. `on-fooba`). The random 4-6-letter tail
+  makes the lower-cased name impossible to collide with a canonical allowlist
+  entry, so the ONLY matcher arm that strips it is `event-handler-name-re`.
+  The value is an attacker JS payload string."
+  (gen/gen-fmap
+    (fn [[form prefix-bits tail]]
+      (let [tail-str (apply str tail)
+            base     (case form
+                       :camel (str "on"
+                                   (str/upper-case (subs tail-str 0 1))
+                                   (subs tail-str 1))
+                       :kebab (str "on-" tail-str))]
+        [(keyword (recase-on-prefix base prefix-bits)) "alert(document.cookie)"]))
+    (fn [rng]
+      (let [[form rng1] (gen/rand-nth rng [:camel :kebab])
+            [pb0 rng2]  (gen/rand-nth rng1 [0 1])
+            [pb1 rng3]  (gen/rand-nth rng2 [0 1])
+            [tail rng4] ((gen/gen-vec (gen/gen-int 4 7)
+                                      (gen/gen-elem structural-tail-letters))
+                         rng3)]
+        [[form [pb0 pb1] tail] rng4]))))
+
+(deftest no-custom-structural-handler-serialises
+  (testing "rf2-q0a81.1 - across 600 NON-allowlist structural handler names
+            (camelCase / kebab, recased prefix), attr-string strips every one
+            via event-handler-name-re alone - the allowlist cannot catch these.
+            Reverting/weakening the regex makes this go RED."
+    (let [result (gen/for-all
+                   gen-custom-structural-handler 600 5
+                   (fn [[k v]]
+                     (let [out (h/attr-string {k v})]
+                       (and (= "" out)
+                            (not (live-handler-attr? out))))))]
+      (is (nil? result)
+          (str "a custom structural handler leaked as a live attribute "
+               "(event-handler-name-re regression): " (pr-str result))))))
 
 ;; ---------------------------------------------------------------------------
 ;; HOSTILE CORPUS - the exact rf2-1uex4 casings + structural spellings.


### PR DESCRIPTION
Two test-integrity / boundary-coverage gaps from the **rf2-q0a81** correctness re-review of `implementation/security`. Each finding's adversarial input did not actually exercise the guard it claimed to protect — both properties shipped GREEN while asserting nothing about the boundary code. Each is fixed by making the test hit the ACTUAL guarded path and assert the real invariant; both strengthened properties were verified to go **RED against pre-fix behaviour** (proving non-vacuity) then GREEN.

## rf2-q0a81.1 — SSR event-handler matcher: regex arm was vacuously covered

`no-recased-canonical-handler-serialises` (600 draws) only minted recasings of **canonical** handlers, every one of which is in `event-handler-allowlist` (whose lookup lower-cases the candidate). The allowlist arm alone strips all 600 draws, so reverting/weakening the camelCase/kebab `event-handler-name-re` left the property GREEN — the regex (whose unique job is custom framework handlers like `:onCustomEvent` / `:on-custom-event`, NOT in the allowlist) was never the sole strip reason. The docstring's verify-by-revert claim was false for the regex.

**Fix:** added `no-custom-structural-handler-serialises` — 600 NON-allowlist structural handlers (`onFooba` / `on-fooba`, random 4-6-letter tails, recased across the `[Oo][Nn]` prefix) that ONLY `event-handler-name-re` strips. Verify-by-revert: breaking the regex makes the **new** property RED while the canonical property stays GREEN (proving the two matcher arms are now independently pinned). Docstring corrected to describe the two independent properties.

## rf2-q0a81.2 — schema-redaction precision dimension invisible + a genuine `:set` leak

The generator (`gen-shape`) planted exactly one `:sensitive?` leaf and forced the failure AT it, so `schema-has-sensitive?` === `schema-sensitive-at?` for every generated and corpus shape — the **path-targeted precision** the rf2-g5auo/rf2-oh4se fix exists for (don't over-redact a benign failure whose SIBLING is sensitive) was wholly untested. A regression reverting the emit-site to the coarse `schema-has-sensitive?` would over-redact every benign failure in a sensitive-sibling schema and stay GREEN.

**Fixes:**
1. Added `non-sensitive-sibling-failure-not-over-redacted` (200 sibling shapes at arbitrary nesting; the failure lands at a benign slot whose sibling is `:sensitive?`). Asserts the benign value rides **verbatim** (a distinctive marker, not just absence of a stamp) and no `:sensitive?` stamp. Verify-by-revert: reverting the emit-site to coarse `schema-has-sensitive?` makes it RED (coarse redacts 200/200, precise 0/200).
2. Added `:set` to the generator's wrap rotation + two `:set` corpus entries — which surfaced a **genuine code-side leak** behind the vacuous test.

### Code-side boundary gap fixed (the `:set` path leak)

A `:set`'s Malli `:in` carries the failing **element value** itself (a set has no positional index — the element IS its own key). The emit-site built `:path` = `(concat reg-path :in)`, so the secret rode verbatim into the structural `:path` AND the `:path`-built `:reason` — even though `:value`/`:explain` were correctly redacted. This violated Spec 010's normative guarantee that `:path` is "structural … does not carry user data". Every other collection type (`:vector` / `:sequential` / `:tuple` / `:map-of`) reports a real index/key and is unaffected.

**Fix:** new `walker/structural-in-path` walks the schema in lockstep with `:in` and substitutes the reserved marker `:rf/set-element` for the value-bearing `:set` segment only, keeping every other segment as-is. The emit-site now builds `:path` from the structural path; `leaf-value` still uses raw `:in` (then redacted via `:value` on sensitive failures). Spec 010 §`:sensitive?` documents the marker and the `:set` exception.

## Gates (cold)

- `npm run test:security` — 21 tests / 167 assertions, 0 failures
- schemas JVM (`clojure -M:test`) — 238 tests / 18435 assertions, 0 failures
- `npm run test:cljs` — 5673 tests / 19791 assertions, 0 failures
- clj-kondo clean on all 5 files; Splint baseline-clean (2 pre-existing warnings, unchanged vs origin/main)

Verify-by-revert evidence (each property shown RED pre-fix, GREEN post-fix) is in the commit body.

## Follow-up

`spec/Conventions.md` (hot-zone) should add `:rf/set-element` to the `:rf/*` reserved-keyword row alongside `:rf/redacted`. Deferred to avoid a hot-zone collision with parallel workers; the normative behaviour is fully documented in the non-hot-zone Spec 010. Filing a follow-up bead.

Closes rf2-q0a81.1, rf2-q0a81.2.