### PR TITLE
fix(machines-viz): three-emitter faithfulness for internal transitions (rf2-mnp93.4/.5/.6)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -561,12 +561,29 @@ that diverged between chart + SCXML (rf2-bs3us). With F2–F4 the three-emitter
 `:on-done` projection is faithful across every reachable Spec 005 shape, and
 the parallel-root anchor is inert.
 
+A 2026-06-05 R3 faithfulness review (rf2-mnp93) surfaced the F5–F7
+follow-ons below — the SAME cross-emitter-asymmetry class as F2, generalised
+to the ORDINARY internal transition (not just `:on-done`): an INTERNAL
+(action-only, no-`:target`) `:on` / `:after` / `:always` candidate (Spec 005
+§Transition slots: "omit for internal") was projected INCONSISTENTLY — the
+chart charted internal `:on` but silently dropped internal `:after` /
+`:always`; mermaid dropped ALL three; SCXML kept all three (rf2-mnp93.4). The
+SAME SCXML internal action transition also round-tripped into a Spec 005
+FORBIDDEN BLOCK — a semantic inversion (rf2-mnp93.5) — and the mermaid
+node-id sanitiser was non-injective (rf2-mnp93.6, the same collision class
+the chart's `node-id` was fixed for in rf2-ee38b.21). With F5–F7 every
+internal transition is surfaced consistently across all three emitters, the
+SCXML codec round-trips it faithfully, and the mermaid id is injective.
+
 | Step | Bead | New? | Hot-zone | Notes |
 |---|---|---|---|---|
 | F1 | **rf2-41goo** ✅ — `feat(machines-viz): project :on-done (XState onDone) completion transition (chart + mermaid + scxml)` | existing | isolated (`chart/layout.cljc`, `chart/projection.cljc`, `mermaid.cljc`, `scxml.cljc`, + JVM tests + this doc) | **Closes G9.** `:on-done` was never parsed/projected (zero matches across the three emitters). Now: the COMPOUND completion edge resolves to the SIBLING (`✓ done` chip); the PARALLEL-ROOT completion (action/fx-only) renders as a terminal affordance / mermaid note; the SCXML emitter round-trips the W3C `done.state.<id>` transition. Parses + projects faithfully to the engine's `[:rf.machine/done <path>]` raise. |
 | F2 | **rf2-ay42f** ✅ — `fix(machines-viz): render compound action-only :on-done in mermaid` | new | isolated (`mermaid.cljc` + JVM tests + this doc) | **G9 faithfulness completion.** A COMPOUND whose `:on-done` is ACTION-ONLY (no `:target` — the engine runs an action when the sub-flow completes; the machine stays in the all-final config; a documented Spec 005 shape) surfaced in chart + SCXML but was SILENTLY DROPPED in mermaid (`collect-on-done-edges` kept only target-bearing candidates; the note path covered only the parallel-root). Now mermaid renders a `note right of <compound>` carrying `on-done: ✓ done / <action>` — the same affordance the parallel-root action-only `:on-done` uses — so the completion is visible across **all three** emitters. The G9 "faithful across all three emitters" claim is now accurate for the action-only compound shape. (`collect-compound-on-done-notes` walks the state tree incl. region-nested + deeply-nested compounds.) |
 | F3 | **rf2-dblqx** ✅ — `fix(machines-viz): parallel-root :on-done anchor is inert (not a clickable phantom state)` | new | isolated (`chart/projection.cljc` + JVM tests + this doc) | The synthetic parallel-root completion anchor (F1) fell through the node-`:type` cond to `"state"` AND through the `:onClick` guard (which excluded only `:machine-root?` + region), so it projected as a CLICKABLE `parallel` state box — clicking it dispatched on-state-click against the rendering-sentinel path. The SAME inert-synthetic-chip class **rf2-34ff3** ruled for the machine-root chip + region containers. Fix: type the parallel-root anchor `"machine-root"` (the quiet root-context chip) AND exclude `:parallel-root?` from the `:onClick` guard, mirroring 34ff3. The anchor is now INERT. |
 | F4 | **rf2-bs3us** ✅ — `fix(machines-viz): align chart parallel-root done-state label to SCXML` | new | isolated (`chart/layout.cljc`, `chart/projection.cljc`, `scxml.cljc` + JVM tests + this doc) | The chart's parallel-root `:doneState` label was the degenerate `"done.state."` (the root sentinel path `[]` has an EMPTY `node-id`), diverging from the SCXML emitter's `"done.state.rf2_parallel_root"`. Fix: a shared canonical sentinel id (`layout/parallel-root-done-state-id` = `"rf2_parallel_root"`) is the SINGLE SOURCE OF TRUTH both the chart `:doneState` renderer label and the SCXML `<parallel id=...>` / `done.state.<id>` event read from, so the two emitters agree. Pure label fix (not load-bearing for topology / round-trip). |
+| F5 | **rf2-mnp93.4** ✅ — `fix(machines-viz): surface internal action-only :on/:after/:always consistently across chart + mermaid + scxml` | new | isolated (`chart/layout.cljc`, `mermaid.cljc` + JVM/CLJS tests + this doc) | **G9 faithfulness — generalised from `:on-done` (F2) to the ordinary internal transition.** An INTERNAL (action-only, no-`:target`) `:on` / `:after` / `:always` candidate was projected INCONSISTENTLY: the CHART charted internal `:on` (self-anchored, `:internal?`) but SILENTLY DROPPED internal `:after` / `:always` (the `resolve-target-path` inside `keep` returned nil for a target-less candidate — inconsistent even WITHIN the chart); MERMAID dropped ALL three; SCXML kept all three. Three emitters, three projections of one machine. Fix: `chart/layout.cljc`'s `:after` / `:always` branches now detect the target-less candidate and self-anchor it (`:internal? true`), matching the `:on` branch; `mermaid.cljc` renders each internal candidate as a `note right of <state>` line (`<descriptor> [guard] / <action>`) — the SAME action-only-note affordance F2 introduced for `:on-done`. SCXML was already faithful. A new `cross_emitter_agreement_cljs_test` pins the three-emitter count agreement (chart 3 / mermaid 3 / scxml 3 for the bead repro). |
+| F6 | **rf2-mnp93.5** ✅ — `fix(machines-viz): SCXML round-trips an internal action transition (not a forbidden block)` | new | isolated (`scxml.cljc` + JVM/CLJS tests + this doc) | **SCXML round-trip semantic inversion.** An internal action `:on {:tick {:action :log}}` emitted `<transition event="tick"><!-- action: log --></transition>`; the decoder's `strip-comments` discarded the action comment BEFORE tokenizing, so the candidate decoded to the EMPTY map `{}` — which Spec 005 §Forbidden transitions defines as a FORBIDDEN BLOCK (consume-the-event-and-block-inheritance). 'Run an action' → 'block the event entirely' is a SEMANTIC INVERSION, not lossy detail. Fix: a `lift-action-comments` pre-pass folds each `<!-- action: NAME -->` into a synthetic `data_rf_action` attribute on its own `<transition>` BEFORE comments are stripped, and the decoder recovers it into the candidate's `:action`. An internal action transition now round-trips as `{:action :log}` — a VALID Spec-005 internal action transition (the distinguishing feature is the PRESENCE of `:action`, Spec 005 §Forbidden L1346). A genuine `{}` forbidden block still round-trips to `{}` (the lift-pass only recovers a PRESENT action). |
+| F7 | **rf2-mnp93.6** ✅ — `fix(machines-viz): mermaid sanitise-id is injective` | new | isolated (`mermaid.cljc` + JVM/CLJS tests + this doc) | **Mermaid node-id collision.** `sanitise-id` mapped every non-`[a-zA-Z0-9_]` char to `_`, so `:a/b`, `:a-b`, and `:a_b` all collapsed to `a_b`: two distinct states became ONE Mermaid node, mis-wiring every edge to/from either (hyphens are pervasive in re-frame keywords). The SAME collision class the chart's `node-id` was fixed for in rf2-ee38b.21. Fix: port the chart's injective hex-escape scheme (`:a/b` → `a_2fb`, `:a-b` → `a_2db`, `:a_b` → `a_5fb`; `/` ns/name marker → `_2f`, `__` path separator) into `sanitise-id`, so distinct keywords map to distinct mermaid nodes AND the chart + mermaid emitters mint the SAME id for the same path (a tool reading both addresses every node identically). Mermaid node-ids are internal — the visible label comes from `render-state-alias` — so the injective encoding costs no legibility. |
 
 > **Sibling note (rf2-wnzha — same review pass, NOT a parity row):**
 > parallel regions sharing a state NAME minted COLLIDING node-ids (the
@@ -594,14 +611,20 @@ the parallel-root anchor is inert.
    (`chart/edges-cljs-test`: nested/parallel ⇒ switch present, flat ⇒
    absent, G2 routing keys pinned). Isolated (`chart.cljs` + test).
 
-> **Parity verdict after Phases A–F (incl. G9):** `MachineChart` reaches
-> **full topology parity** with Stately Studio on all nine concerns
-> (transition scoping now includes the `:on-done` / XState `onDone`
-> completion transition — rf2-41goo / G9) except the three **intentional
-> divergences** (no code↔diagram sync, trace-driven not sandbox sim, no
-> history pseudo-states) — and remains **above** the bar on the
-> re-frame2-native overlays (`:after` rings, microstep replay,
-> `:spawn-all` join, cancellation cascade).
+> **Parity verdict after Phases A–F (incl. G9 + the F5–F7 internal-
+> transition faithfulness pass):** `MachineChart` reaches **full topology
+> parity** with Stately Studio on all nine concerns (transition scoping now
+> includes the `:on-done` / XState `onDone` completion transition — rf2-41goo
+> / G9 — AND the ordinary INTERNAL action-only `:on` / `:after` / `:always`
+> transition surfaced consistently across all three emitters — rf2-mnp93.4)
+> except the three **intentional divergences** (no code↔diagram sync,
+> trace-driven not sandbox sim, no history pseudo-states) — and remains
+> **above** the bar on the re-frame2-native overlays (`:after` rings,
+> microstep replay, `:spawn-all` join, cancellation cascade). The three
+> emitters agree on internal-transition projection (rf2-mnp93.4), the SCXML
+> codec round-trips an internal action transition faithfully without
+> inverting it to a forbidden block (rf2-mnp93.5), and the mermaid node-id
+> is injective like the chart's (rf2-mnp93.6).
 
 ## See also
 

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -313,7 +313,9 @@ or two edges, with these structural rules:
 | `:on {:e :same-state}` — external self-transition | yes | state → ev-node | ev-node → state |
 | `:on {:e {:action :a}}` — INTERNAL (no `:target`) | yes (`:internal true`) | state → ev-node | **none** |
 | `:after {1000 ...}` — timer | yes (`:variant "after"`, `:afterMs 1000`) | state → ev-node | ev-node → target |
+| `:after {1000 {:action :a}}` — INTERNAL timer (no `:target`) (rf2-mnp93.4) | yes (`:variant "after"`, `:internal true`) | state → ev-node | **none** |
 | `:always [{:target ...}]` | yes (`:variant "always"`) | state → ev-node | ev-node → target |
+| `:always [{:action :a}]` — INTERNAL (no `:target`) (rf2-mnp93.4) | yes (`:variant "always"`, `:internal true`) | state → ev-node | **none** |
 | Wildcard `:*` | yes (`:eventId nil`, not user-fireable) | state → ev-node | ev-node → target |
 
 The event-node carries everything the legacy edge `:data` used to

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -233,25 +233,54 @@
                  (:on state-node))
          (mapcat (fn [[delay spec]]
                    (keep (fn [candidate]
-                           (when-let [tp (resolve-target-path state-path
-                                                              (:target candidate))]
-                             {:from   state-path
-                              :to     tp
-                              :event  (keyword (str "after-" delay))
-                              :after  delay
-                              :guard  (:guard candidate)
-                              :action (:action candidate)}))
+                           ;; rf2-mnp93.4 — an internal (action-only,
+                           ;; no-`:target`) `:after` candidate is a
+                           ;; documented Spec 005 shape (the timer just
+                           ;; runs an `:action`; the config is unchanged).
+                           ;; Self-anchor + flag `:internal?`, exactly as
+                           ;; the `:on` branch above already does — pre-fix
+                           ;; `resolve-target-path` returned nil for a
+                           ;; target-less candidate, so `keep` SILENTLY
+                           ;; DROPPED it (inconsistent even WITHIN the chart:
+                           ;; internal `:on` rendered, internal `:after` did
+                           ;; not).
+                           (let [internal? (and (map? candidate)
+                                                (not (contains? candidate :target)))
+                                 tp        (if internal?
+                                             (vec state-path)
+                                             (resolve-target-path state-path
+                                                                  (:target candidate)))]
+                             (when tp
+                               (cond-> {:from   state-path
+                                        :to     tp
+                                        :event  (keyword (str "after-" delay))
+                                        :after  delay
+                                        :guard  (:guard candidate)
+                                        :action (:action candidate)}
+                                 internal? (assoc :internal? true)))))
                          (transition-candidates spec)))
                  (:after state-node))
          (mapcat (fn [candidate]
-                   (when-let [tp (resolve-target-path state-path
-                                                      (:target candidate))]
-                     [{:from   state-path
-                       :to     tp
-                       :event  :always
-                       :always? true
-                       :guard  (:guard candidate)
-                       :action (:action candidate)}]))
+                   ;; rf2-mnp93.4 — an internal (action-only) `:always`
+                   ;; candidate (the canonical re-evaluate-while-condition
+                   ;; loop is a TARGETLESS guarded `:always`, Spec 005
+                   ;; §:reenter? vs a self-`:target` on `:always`) self-
+                   ;; anchors + flags `:internal?` like the `:on`/`:after`
+                   ;; branches — pre-fix it was silently dropped.
+                   (let [internal? (and (map? candidate)
+                                        (not (contains? candidate :target)))
+                         tp        (if internal?
+                                     (vec state-path)
+                                     (resolve-target-path state-path
+                                                          (:target candidate)))]
+                     (when tp
+                       [(cond-> {:from   state-path
+                                 :to     tp
+                                 :event  :always
+                                 :always? true
+                                 :guard  (:guard candidate)
+                                 :action (:action candidate)}
+                          internal? (assoc :internal? true))])))
                  (transition-candidates (:always state-node)))
          ;; rf2-41goo — the compound / region-compound `:on-done`
          ;; completion edge (XState `onDone`). The done node is THIS node

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -121,43 +121,75 @@
        (seq v)
        (every? keyword? v)))
 
+(defn- escape-id-segment
+  "Escape one keyword ns/name part INJECTIVELY into a Mermaid-id-safe
+  string: every char outside `[A-Za-z0-9]` becomes `_<2-hex>` (the
+  underscore itself → `_5f`). Distinct inputs always yield distinct
+  outputs, and the result contains no two consecutive underscores, so
+  the `_2f` ns/name marker and the `__` path separator can never arise
+  from segment content.
+
+  rf2-mnp93.6 — mirrors `chart/layout/escape-id-segment` (the SAME
+  injective scheme the SCXML codec + the chart's xyflow `node-id` use),
+  so the three emitters address every node identically. The naive
+  `str/replace #\"[^a-zA-Z0-9_]\" \"_\"` collapsed `:a/b`, `:a-b`, `:a_b`
+  all to `\"a_b\"` — two distinct states became ONE Mermaid node, silently
+  mis-wiring every edge to/from either."
+  [s]
+  (str/join
+    (map (fn [ch]
+           (if (re-matches #"[A-Za-z0-9]" (str ch))
+             (str ch)
+             (str "_" #?(:clj  (format "%02x" (int ch))
+                         :cljs (let [h (.toString (.charCodeAt (str ch) 0) 16)]
+                                 (if (= 1 (count h)) (str "0" h) h))))))
+         s)))
+
 (defn- id-segment
-  "Render one path segment before Mermaid-safe character replacement."
+  "Render one path segment as an INJECTIVE Mermaid-id-safe string.
+
+  A keyword's namespace and name are each `escape-id-segment`-escaped
+  and joined with `_2f` (the hex escape of `/`, the boundary marker the
+  escaper itself uses for a namespaced keyword — so a namespaced keyword
+  `:auth/login` reads `auth_2flogin` and can never collide with a state
+  literally named `:auth-login` → `auth_2dlogin` (rf2-mnp93.6)."
   [segment]
   (cond
-    (keyword? segment) (let [n (name segment)]
-                         (if-let [ns (namespace segment)]
-                           (str ns "_" n)
-                           n))
-    (string? segment)  segment
+    (keyword? segment) (if-let [ns (namespace segment)]
+                         (str (escape-id-segment ns) "_2f" (escape-id-segment (name segment)))
+                         (escape-id-segment (name segment)))
+    (string? segment)  (escape-id-segment segment)
     (nil? segment)     "nil"
-    :else              (pr-str segment)))
+    :else              (escape-id-segment (pr-str segment))))
 
 (defn- sanitise-id
-  "Map a keyword or vector path `id` to a Mermaid-safe identifier.
+  "Map a keyword or vector path `id` to an INJECTIVE Mermaid-safe
+  identifier — distinct inputs always mint distinct ids.
 
   Mermaid stateDiagram-v2 identifiers are restricted to a subset of
   alphanumerics + underscore. Namespaced keywords (`:auth/login`) and
   hyphenated names (`:login-flow`) are common in re-frame2 machine
-  ids; we map both to underscore-joined names: `:auth/login` →
-  `auth_login`, `:login-flow` → `login_flow`.
+  ids. Each path segment is `id-segment`-escaped (every non-alphanumeric
+  char → `_<hex>`); compound state ids are path-qualified with `__`
+  separators: `[:authenticated :cart :browsing]` →
+  `authenticated__cart__browsing`.
 
-  Compound state ids are path-qualified with `__` separators:
-  `[:authenticated :cart :browsing]` →
-  `authenticated__cart__browsing`."
+  rf2-mnp93.6 — the id is INJECTIVE (the same hex-escape discipline the
+  SCXML codec + the chart's xyflow `node-id` follow). The pre-fix naive
+  `[^a-zA-Z0-9_]`-collapse merged `:a/b`, `:a-b`, `:a_b` into one node;
+  the hex escape keeps them distinct (`a_2fb`, `a_2db`, `a_5fb`). Mermaid
+  node-ids are internal — the visible label comes from
+  `render-state-alias` — so an injective encoding costs no legibility.
+  The id need not start with a letter (Mermaid accepts a leading `_`);
+  every escaped non-alphanumeric leader is a `_`, so the prior
+  leading-digit `s_` guard is unnecessary (a digit-leading name like
+  `:5x` escapes to `_35x` already)."
   [id]
   (when id
-    (let [segments (if (vector? id) id [id])
-          s        (if (seq segments)
-                     (str/join "__" (map id-segment segments))
-                     "root")]
-      (-> s
-          (str/replace #"[^a-zA-Z0-9_]" "_")
-          ;; Mermaid identifiers must start with a letter; prefix a
-          ;; leading digit with `s_`. (Re-frame2's machine ids
-          ;; typically start with a letter; the guard is belt-and-
-          ;; braces.)
-          (#(if (re-find #"^[0-9]" %) (str "s_" %) %))))))
+    (let [segments (if (vector? id) id [id])]
+      (if (seq segments)
+        (str/join "__" (map id-segment segments))
+        "root"))))
 
 (defn- sanitise-label
   "Escape a transition event-id for use as a Mermaid edge label.
@@ -270,6 +302,85 @@
                 :to    target-path
                 :label (edge-label "always" candidate)}]))
           (transition-candidates always)))
+
+;; --- internal (action-only) transition notes (rf2-mnp93.4) ---------------
+;;
+;; An INTERNAL transition candidate (a map that OMITS `:target` — Spec 005
+;; §Transition slots: "omit for internal"; §Self-transitions: the internal
+;; default runs only the `:action`, the config is unchanged) has NO arrow to
+;; draw in Mermaid (there is no destination state). Pre-fix, the `:on` /
+;; `:after` / `:always` collectors all silently DROPPED every target-less
+;; candidate, while the chart + SCXML emitters surfaced it — breaking the G9
+;; 'faithful across all three emitters' parity claim
+;; (001-Topology-Parity.md §3.1). We close the asymmetry exactly the way the
+;; action-only `:on-done` was closed (rf2-ay42f): render the internal
+;; transition as a `note right of <state>` so the action it runs is visible.
+
+(defn- internal-candidate?
+  "rf2-mnp93.4 — true when a transition candidate is INTERNAL: a map that
+  omits `:target` (the action-only / no-config-change shape). A keyword /
+  vector-path candidate always carries a target, so only a map can be
+  internal."
+  [candidate]
+  (and (map? candidate)
+       (not (contains? candidate :target))))
+
+(defn- internal-note-line
+  "rf2-mnp93.4 — the note body for one internal (target-less) candidate.
+  Reads `<descriptor> [guard] / <action>` (the same `event [guard] /
+  action` order edges use), so an internal `:on :tick {:action :log}`
+  surfaces as `on tick / log`, an `:after 1000 {:action :timeout}` as
+  `after(1000) / timeout`, an `:always {:action :poll}` as `always / poll`."
+  [descriptor candidate]
+  (let [guard  (when (:guard candidate)
+                 (str " [" (sanitise-label (:guard candidate)) "]"))
+        action (when (:action candidate)
+                 (str " / " (label-value (:action candidate))))]
+    (str "    " (sanitise-label descriptor) guard action)))
+
+(defn- internal-candidate-lines
+  "rf2-mnp93.4 — note-body lines for every INTERNAL candidate declared on
+  one state's `:on` / `:after` / `:always`. `:on` candidates carry their
+  event id as the descriptor; `:after` candidates `after(<delay>)`;
+  `:always` candidates `always`."
+  [state-node]
+  (concat
+    (mapcat (fn [[event-id spec]]
+              (->> (transition-candidates spec)
+                   (filter internal-candidate?)
+                   (map #(internal-note-line (label-value event-id) %))))
+            (:on state-node))
+    (mapcat (fn [[delay spec]]
+              (->> (transition-candidates spec)
+                   (filter internal-candidate?)
+                   (map #(internal-note-line (str "after(" (label-value delay) ")") %))))
+            (:after state-node))
+    (->> (transition-candidates (:always state-node))
+         (filter internal-candidate?)
+         (map #(internal-note-line "always" %)))))
+
+(defn- collect-internal-transition-notes
+  "rf2-mnp93.4 — emit a `note right of <state>` for every state with one or
+  more INTERNAL (action-only, target-less) `:on` / `:after` / `:always`
+  candidates. Walks the state tree the same way `collect-edges` does so a
+  nested state's internal transitions are covered too. Returns a flat seq
+  of note lines. Pre-fix these candidates were silently dropped while the
+  chart self-anchored them (`:internal? true`) and SCXML emitted them as
+  target-less `<transition>`s — this restores three-emitter agreement."
+  [root-path states]
+  (mapcat
+    (fn [[state-id state-node]]
+      (let [state-path (conj (vec root-path) state-id)
+            lines      (internal-candidate-lines state-node)
+            self       (when (seq lines)
+                         (concat [(str "  note right of " (sanitise-id state-path))]
+                                 lines
+                                 ["  end note"]))
+            child      (when (:states state-node)
+                         (collect-internal-transition-notes state-path
+                                                            (:states state-node)))]
+        (concat self child)))
+    states))
 
 (defn- collect-on-done-edges
   "rf2-41goo — emit the compound / region-compound `:on-done` completion
@@ -476,7 +587,12 @@
         ;; (target-less) has no sibling arrow to draw; render its
         ;; completion as a note so it is not silently dropped (the
         ;; chart + SCXML emitters both surface it).
-        on-done-notes  (collect-compound-on-done-notes root-path states)]
+        on-done-notes  (collect-compound-on-done-notes root-path states)
+        ;; rf2-mnp93.4 — an INTERNAL (action-only, target-less) `:on` /
+        ;; `:after` / `:always` candidate has no arrow to draw; render it
+        ;; as a note so it is not silently dropped (the chart self-anchors
+        ;; it `:internal? true`, SCXML emits a target-less <transition>).
+        internal-notes (collect-internal-transition-notes root-path states)]
     (str/join "\n"
               (concat
                (when header-comment? [header-comment])
@@ -486,7 +602,8 @@
                compound-lines
                edge-lines
                final-lines
-               on-done-notes))))
+               on-done-notes
+               internal-notes))))
 
 (defn- region-initial-line
   [region-path initial depth]
@@ -548,6 +665,13 @@
         region-on-done-notes
         (mapcat (fn [[region-id {:keys [states]}]]
                   (collect-compound-on-done-notes [region-id] states))
+                regions)
+        ;; rf2-mnp93.4 — an INTERNAL (action-only) `:on` / `:after` /
+        ;; `:always` candidate on a state inside a region renders as a note
+        ;; too (no arrow to draw), matching the flat/compound emitter.
+        region-internal-notes
+        (mapcat (fn [[region-id {:keys [states]}]]
+                  (collect-internal-transition-notes [region-id] states))
                 regions)]
     (str/join "\n"
               (concat
@@ -561,6 +685,7 @@
                edge-lines
                final-lines
                region-on-done-notes
+               region-internal-notes
                ;; rf2-41goo — the parallel-root completion note (action/fx-
                ;; only; no sibling target).
                (render-parallel-on-done-note on-done)))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -41,6 +41,7 @@
   | `:final? true`                        | `<final id=\"...\">` |
   | `:on {:event :target}`                | `<transition event=\"event\" target=\"target\"/>` |
   | `:on {:event {:target ... :guard G}}` | `<transition cond=\"G\" .../>` |
+  | `:on {:event {:action A}}` — INTERNAL (no `:target`) | `<transition event=\"event\"><!-- action: A --></transition>` — round-trips to `{:action A}`, NOT the `{}` forbidden block (rf2-mnp93.5) |
   | `:after {ms :target}`                 | `<transition event=\"after.ms\" target=\"target\"/>` |
   | `:always [...]`                       | `<transition target=\"...\"/>` (eventless) |
   | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
@@ -79,10 +80,18 @@
     root-level transitions), so these are exported as a documenting
     XML comment and do **not** round-trip back through `scxml->spec`.
   - `:tags` — re-frame2-specific; not part of W3C SCXML.
-  - `:action`s and guard FN bodies — only the *names* survive
-    (SCXML `cond=\"name\"` for guards; entry/exit `<script>` would
-    require evaluation context, so names are preserved as XML
-    comments on imports/exports).
+  - `:action`s and guard FN bodies — only the *names* survive (SCXML
+    `cond=\"name\"` for guards; a transition `:action` name rides an
+    `<!-- action: name -->` comment, the only SCXML-tolerable slot, since
+    SCXML proper has no transition-action-id attribute). The action name
+    **round-trips** (rf2-mnp93.5): `scxml->spec` lifts the action comment
+    back into the candidate's `:action` BEFORE comments are stripped, so an
+    internal `:on {:tick {:action :log}}` returns `{:action :log}` — a valid
+    Spec-005 internal action transition — NOT the empty `{}` FORBIDDEN BLOCK
+    a naive comment-strip would synthesise (a semantic inversion). FN
+    BODIES are still lost (only the name survives). Entry/exit actions would
+    require an evaluation context, so their names are preserved as XML
+    comments but are not part of this round-trip.
   - Source-coord metadata — stripped at export time (same posture as
     share-URL encoding; see `Principles.md` §No session data in shares).
 
@@ -528,11 +537,50 @@
   [s]
   (str/replace s #"(?s)^\s*<\?xml[^?]*\?>\s*" ""))
 
+;; rf2-mnp93.5 — the synthetic attribute the action-comment lift-pass folds
+;; an action name into. `parse-attrs`' `(\w+)` key pattern forbids hyphens,
+;; so the key uses underscores; it can never collide with a real SCXML
+;; attribute (W3C SCXML has no `data_rf_action`). It is stripped from the
+;; emitted output (the emitter writes the action as a COMMENT for external
+;; tooling); it exists ONLY transiently between `lift-action-comments` and
+;; `parse-attrs` on the DECODE side.
+(def ^:private action-attr "data_rf_action")
+
+(defn- lift-action-comments
+  "rf2-mnp93.5 — fold every transition action COMMENT into a synthetic
+  attribute on its OWN `<transition>` start-tag BEFORE comments are
+  stripped, so the action name survives the round-trip.
+
+  The emitter writes an action-bearing transition as
+  `<transition ATTRS><!-- action: NAME --></transition>` (the comment is
+  how the action survives for external SCXML tooling, which has no
+  transition-action slot). Pre-fix, `strip-comments` discarded the comment
+  globally, so an INTERNAL action transition (`:on {:tick {:action :log}}`)
+  decoded to the EMPTY candidate map `{}` — which Spec 005 §Forbidden
+  transitions defines as a FORBIDDEN BLOCK (consume-the-event-and-block-
+  inheritance), the OPPOSITE of 'run an action'. A semantic inversion, not
+  a lossy detail (rf2-mnp93.5).
+
+  This pass rewrites `<transition ATTRS><!-- action: NAME --></transition>`
+  to `<transition ATTRS data_rf_action=\"NAME\"/>` so the decoder recovers
+  the action into the candidate map's `:action` — yielding a VALID Spec-005
+  internal action transition (`{:action :log}`), never the forbidden-block
+  `{}`. Per Spec 005 §Forbidden transitions L1346, an action-bearing
+  internal transition halts the walk AND runs the action; the distinguishing
+  shape feature is the PRESENCE of `:action`."
+  [s]
+  (str/replace
+    s
+    #"(?s)(<transition\b[^>]*?)>\s*<!--\s*action:\s*(\S+)\s*-->\s*</transition>"
+    (fn [[_ start-tag action-name]]
+      (str start-tag " " action-attr "=\"" action-name "\"/>"))))
+
 (defn- strip-comments
-  "Drop `<!-- ... -->` comments. Used by the parser to discard the
-  action-name comments the emitter injects on transitions with
-  actions (the action survives the round-trip as a comment because
-  SCXML proper has no action-id-on-transition slot)."
+  "Drop `<!-- ... -->` comments. The action-name comments the emitter
+  injects on transitions are first lifted into a synthetic attribute by
+  `lift-action-comments` (rf2-mnp93.5) so they survive the round-trip;
+  this then drops the remaining (documenting / machine-level) comments,
+  which SCXML proper has no slot for."
   [s]
   (str/replace s #"(?s)<!--.*?-->" ""))
 
@@ -690,6 +738,11 @@
                   event    (get attrs "event")
                   target   (get attrs "target")
                   guard-s  (get attrs "cond")
+                  ;; rf2-mnp93.5 — the action name lifted from the
+                  ;; `<!-- action: NAME -->` comment by `lift-action-comments`
+                  ;; (a single keyword, never a vector path — decode it the
+                  ;; same way the guard `cond=` does).
+                  action-s (get attrs action-attr)
                   cand-map (cond-> {}
                              ;; rf2-mnp93.7 — decode the qualified target id
                              ;; back to its relative grammar form (sibling
@@ -703,7 +756,14 @@
                              ;; single keyword (never a vector path), so route
                              ;; it through `id-string->keyword`, not
                              ;; `unescape-id-string`.
-                             guard-s (assoc :guard (id-string->keyword guard-s)))]
+                             guard-s (assoc :guard (id-string->keyword guard-s))
+                             ;; rf2-mnp93.5 — recover the action so an INTERNAL
+                             ;; action transition (`:on {:tick {:action :log}}`)
+                             ;; round-trips to a VALID Spec-005 internal action
+                             ;; transition (`{:action :log}`) — NOT the empty
+                             ;; `{}` FORBIDDEN BLOCK the comment-strip used to
+                             ;; synthesise (a semantic inversion).
+                             action-s (assoc :action (id-string->keyword action-s)))]
               (cond
                 (and event (str/starts-with? event "after."))
                 (let [d-str (subs event 6)
@@ -922,7 +982,7 @@
                      :recovery :no-recovery
                      :reason   "scxml->spec expects a string"
                      :input    scxml-string})))
-  (let [tokens (-> scxml-string strip-prolog strip-comments tokenize vec)
+  (let [tokens (-> scxml-string strip-prolog lift-action-comments strip-comments tokenize vec)
         root-start (first (filter #(= "scxml" (:tag %)) tokens))]
     (when-not root-start
       (throw (ex-info ":scxml/parse-error"

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -771,6 +771,40 @@
         (is (nil? (outbound-edge-for graph (:id internal)))
             "internal transition has NO event→target segment")))))
 
+(def internal-after-always-machine
+  "rf2-mnp93.4 — a state carrying an internal (action-only, no `:target`)
+  `:after` AND `:always`. Both project as terminal event-nodes (no outbound
+  segment), exactly like the internal `:on` form — pre-fix BOTH were silently
+  dropped by the chart's `:after` / `:always` branches."
+  {:initial :a
+   :states  {:a {:after  {1000 {:action :timeout-log}}
+                 :always [{:action :poll}]}}})
+
+(deftest xyflow-graph-internal-after-always-no-outbound-segment
+  (testing "rf2-mnp93.4 — an internal (action-only) :after / :always
+            projects the inbound terminal segment but NO outbound segment,
+            consistent with the internal :on form (pre-fix both were dropped
+            entirely by the chart parse)"
+    (let [parsed (layout/parse-definition internal-after-always-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          aft    (first (filter #(and (:internal? %) (:after %)) (:edges parsed)))
+          alw    (first (filter #(and (:internal? %) (:always? %)) (:edges parsed)))]
+      (is (some? aft) "the internal :after edge is parsed (not dropped)")
+      (is (some? alw) "the internal :always edge is parsed (not dropped)")
+      ;; both keep the inbound terminal segment + an event-node, and have NO
+      ;; outbound target segment (terminal route — the action-only chip).
+      (is (some? (event-node-for graph (:id aft))) "internal :after gets an event-node")
+      (is (some? (inbound-edge-for graph (:id aft))) "internal :after keeps source→event")
+      (is (nil? (outbound-edge-for graph (:id aft))) "internal :after has NO event→target")
+      (is (some? (event-node-for graph (:id alw))) "internal :always gets an event-node")
+      (is (some? (inbound-edge-for graph (:id alw))) "internal :always keeps source→event")
+      (is (nil? (outbound-edge-for graph (:id alw))) "internal :always has NO event→target")
+      ;; the event-node carries the variant (after / always) AND the internal flag.
+      (is (= "after" (:variant (:data (event-node-for graph (:id aft))))))
+      (is (true? (:internal (:data (event-node-for graph (:id aft))))))
+      (is (= "always" (:variant (:data (event-node-for graph (:id alw))))))
+      (is (true? (:internal (:data (event-node-for graph (:id alw)))))))))
+
 ;; ---- xyflow-graph misc payload + style ---------------------------------
 
 (deftest xyflow-graph-region-style-from-measured-position

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
@@ -1,0 +1,208 @@
+(ns day8.re-frame2-machines-viz.cross-emitter-agreement-cljs-test
+  "Cross-emitter agreement (G9) regression tests — the three viz emitters
+  (chart / mermaid / SCXML) must AGREE on how they project a machine
+  (001-Topology-Parity.md §3.1 G9: 'faithful across all three emitters'). A
+  diagram that drops or inverts a transition in ONE emitter mis-teaches the
+  user relative to the others.
+
+  rf2-mnp93.4 — the canonical asymmetry these tests pin: an INTERNAL
+  (action-only, no-`:target`) `:on` / `:after` / `:always` transition (Spec
+  005 §Transition slots: 'omit for internal'). Pre-fix:
+
+  - CHART: charted internal `:on` (self-anchored, `:internal? true`) but
+    SILENTLY DROPPED internal `:after` / `:always` (the `resolve-target-path`
+    inside `keep` returned nil for a target-less candidate) — inconsistent
+    even WITHIN the chart.
+  - MERMAID: dropped EVERY target-less candidate (internal `:on`, `:after`,
+    AND `:always`).
+  - SCXML: kept all of them as target-less `<transition>`s.
+
+  Three emitters, three different projections of ONE machine. These tests
+  assert the post-fix agreement: every emitter SURFACES every internal
+  candidate (chart self-anchors `:internal?`, mermaid renders a note, SCXML
+  emits a target-less `<transition>`)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [day8.re-frame2-machines-viz.mermaid :as mermaid]
+            [day8.re-frame2-machines-viz.scxml :as scxml]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — the internal-transition shapes the three emitters used to
+;; disagree on.
+
+(def internal-on-machine
+  {:initial :a :states {:a {:on {:tick {:action :log}}}}})
+
+(def internal-after-machine
+  {:initial :a :states {:a {:after {1000 {:action :timeout-log}}}}})
+
+(def internal-always-machine
+  {:initial :a :states {:a {:always [{:action :poll}]}}})
+
+(def all-three-internal-machine
+  "One state carrying an internal `:on`, `:after`, AND `:always` — the exact
+  bead-mnp93.4 repro fixture."
+  {:initial :a
+   :states  {:a {:on     {:tick {:action :log}}
+                 :after  {1000 {:action :timeout-log}}
+                 :always [{:action :poll}]}}})
+
+;; --- per-emitter 'surfaces this internal candidate?' probes --------------
+
+(defn- chart-internal-edges
+  "The internal (self-anchored, `:internal? true`) edges the chart projects
+  for a definition."
+  [definition]
+  (->> (layout/parse-definition definition)
+       :edges
+       (filter :internal?)))
+
+(defn- mermaid-body [definition]
+  (mermaid/emit definition {:fenced? false :header-comment? false}))
+
+(defn- scxml-internal-transition-count
+  "The number of target-less `<transition>` elements SCXML emits (the
+  internal-transition projection)."
+  [definition]
+  (let [out (scxml/spec->scxml definition)]
+    ;; A target-less transition has NO `target=` attribute. Count
+    ;; <transition ...> openings that carry no target.
+    (->> (re-seq #"<transition\b[^>]*>" out)
+         (remove #(str/includes? % "target="))
+         count)))
+
+;; ---------------------------------------------------------------------------
+;; G9 — every emitter SURFACES the internal transition.
+
+(deftest internal-on-surfaced-by-all-three-emitters
+  (testing "rf2-mnp93.4 — an internal action `:on` is surfaced by chart
+            (self-anchored :internal?), mermaid (note), AND SCXML (target-
+            less <transition>)"
+    ;; CHART
+    (let [edges (chart-internal-edges internal-on-machine)
+          tick  (first (filter #(= :tick (:event %)) edges))]
+      (is (some? tick) "chart surfaces the internal :tick")
+      (is (true? (:internal? tick)) "chart flags it :internal?")
+      (is (= (:source tick) (:target tick)) "chart self-anchors it"))
+    ;; MERMAID
+    (let [out (mermaid-body internal-on-machine)]
+      (is (str/includes? out "note right of a") "mermaid surfaces it as a note")
+      (is (str/includes? out "tick / log") "mermaid note carries the action"))
+    ;; SCXML
+    (is (= 1 (scxml-internal-transition-count internal-on-machine))
+        "scxml emits the target-less <transition>")))
+
+(deftest internal-after-surfaced-by-all-three-emitters
+  (testing "rf2-mnp93.4 — an internal action `:after` is surfaced by ALL
+            three emitters (pre-fix: dropped by chart AND mermaid)"
+    (let [edges (chart-internal-edges internal-after-machine)
+          aft   (first (filter :after edges))]
+      (is (some? aft) "chart surfaces the internal :after (pre-fix dropped)")
+      (is (true? (:internal? aft)) "chart flags it :internal?")
+      (is (= 1000 (:after aft))))
+    (let [out (mermaid-body internal-after-machine)]
+      (is (str/includes? out "note right of a"))
+      (is (str/includes? out "after(1000) / timeout-log")))
+    (is (= 1 (scxml-internal-transition-count internal-after-machine)))))
+
+(deftest internal-always-surfaced-by-all-three-emitters
+  (testing "rf2-mnp93.4 — an internal action `:always` is surfaced by ALL
+            three emitters (pre-fix: dropped by chart AND mermaid)"
+    (let [edges (chart-internal-edges internal-always-machine)
+          alw   (first (filter :always? edges))]
+      (is (some? alw) "chart surfaces the internal :always (pre-fix dropped)")
+      (is (true? (:internal? alw)) "chart flags it :internal?"))
+    (let [out (mermaid-body internal-always-machine)]
+      (is (str/includes? out "note right of a"))
+      (is (str/includes? out "always / poll")))
+    (is (= 1 (scxml-internal-transition-count internal-always-machine)))))
+
+(deftest all-three-internal-kinds-agree-across-emitters
+  (testing "rf2-mnp93.4 (bead repro) — a state with an internal :on + :after
+            + :always: the chart charts THREE internal edges, mermaid emits
+            THREE note lines, SCXML emits THREE target-less <transition>s.
+            Pre-fix the COUNTS diverged (chart 1, mermaid 0, SCXML 3)."
+    (let [chart-count   (count (chart-internal-edges all-three-internal-machine))
+          out           (mermaid-body all-three-internal-machine)
+          ;; Mermaid note-body lines for the three internal candidates.
+          mermaid-lines (->> (str/split-lines out)
+                             (filter #(or (str/includes? % "tick / log")
+                                          (str/includes? % "after(1000) / timeout-log")
+                                          (str/includes? % "always / poll")))
+                             count)
+          scxml-count   (scxml-internal-transition-count all-three-internal-machine)]
+      (is (= 3 chart-count)  "chart: 3 internal edges")
+      (is (= 3 mermaid-lines) "mermaid: 3 internal note lines")
+      (is (= 3 scxml-count)  "scxml: 3 target-less <transition>s")
+      (is (= chart-count mermaid-lines scxml-count)
+          "ALL THREE emitters agree on the internal-transition count (G9)"))))
+
+(deftest no-emitter-draws-a-phantom-arrow-for-internal-transition
+  (testing "rf2-mnp93.4 — an internal transition must NOT become a visible
+            state-change arrow in any emitter (it is action-only; the config
+            is unchanged). The chart self-anchors (source==target), mermaid
+            uses a note, SCXML a target-less transition — none invents a
+            cross-state edge."
+    ;; CHART: every internal edge is a self-loop (source == target), never a
+    ;; cross-state arrow.
+    (doseq [e (chart-internal-edges all-three-internal-machine)]
+      (is (= (:source e) (:target e))
+          "chart internal edge is a self-loop, not a cross-state arrow"))
+    ;; MERMAID: no `a --> <other>` arrow (the only state is :a; an internal
+    ;; transition draws no arrow).
+    (let [out (mermaid-body all-three-internal-machine)]
+      (is (not (str/includes? out "a --> "))
+          "mermaid draws no arrow for an internal transition"))
+    ;; SCXML: the internal transitions carry no target= attribute.
+    (let [out (scxml/spec->scxml all-three-internal-machine)]
+      (is (not (str/includes? out "target="))
+          "scxml internal transitions carry no target"))))
+
+;; ---------------------------------------------------------------------------
+;; G9 — SCXML round-trip preserves the internal action transition (so the
+;; codec agrees with itself + the other emitters on the SEMANTICS, not just
+;; the topology). Ties rf2-mnp93.4 (cross-emitter) to rf2-mnp93.5 (round-trip
+;; validity): a dropped/inverted internal transition would break BOTH.
+
+(deftest internal-action-round-trips-without-semantic-inversion
+  (testing "rf2-mnp93.4/.5 — the internal action transitions the emitters
+            surface also SURVIVE the SCXML round-trip as VALID internal
+            action transitions (not the `{}` forbidden block)"
+    (is (= internal-on-machine
+           (-> internal-on-machine scxml/spec->scxml scxml/scxml->spec)))
+    (is (= internal-after-machine
+           (-> internal-after-machine scxml/spec->scxml scxml/scxml->spec)))
+    (is (= internal-always-machine
+           (-> internal-always-machine scxml/spec->scxml scxml/scxml->spec)))
+    (is (= all-three-internal-machine
+           (-> all-three-internal-machine scxml/spec->scxml scxml/scxml->spec))
+        "the combined repro fixture round-trips exactly")))
+
+;; ---------------------------------------------------------------------------
+;; G9 — chart + mermaid agree on INJECTIVE node-ids (rf2-mnp93.6). The chart's
+;; `node-id` was already injective (rf2-ee38b.21); mermaid's `sanitise-id` was
+;; not. They must now mint the SAME id for the same path so a tool reading
+;; both addresses every node identically.
+
+(deftest chart-and-mermaid-mint-the-same-injective-ids
+  (testing "rf2-mnp93.6 — the mermaid output addresses each state by the SAME
+            injective hex-escaped id the chart's public `node-id` mints (so a
+            tool reading both emitters addresses every node identically). The
+            three collision-class forms `:a/b` / `:a-b` / `:a_b` stay distinct."
+    (let [m   {:initial :start
+               :states  {:start {:on {:one :a/b :two :a-b :three :a_b}}
+                         :a/b {} :a-b {} :a_b {}}}
+          out (mermaid/emit m {:fenced? false :header-comment? false})]
+      (doseq [k [:a/b :a-b :a_b]]
+        (testing (pr-str k)
+          ;; mermaid must reference the EXACT chart node-id for this state.
+          (is (str/includes? out (layout/node-id [k]))
+              "mermaid output contains the chart's injective node-id")))
+      ;; The three chart node-ids are pairwise distinct (no collision) — and
+      ;; the mermaid output therefore contains three distinct target nodes.
+      (is (= 3 (count (distinct (map #(layout/node-id [%]) [:a/b :a-b :a_b])))))
+      (is (str/includes? out (str "start --> " (layout/node-id [:a/b])  " : one")))
+      (is (str/includes? out (str "start --> " (layout/node-id [:a-b])  " : two")))
+      (is (str/includes? out (str "start --> " (layout/node-id [:a_b])  " : three"))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
@@ -163,14 +163,19 @@
       (is (str/includes? out "authenticated__browsing --> unauth : logout")))))
 
 (deftest emit-sanitises-namespaced-and-hyphenated-ids
-  (testing "namespaced + hyphenated keywords map to underscore-joined ids"
+  (testing "namespaced + hyphenated keywords map to INJECTIVE hex-escaped ids"
     (let [out (m/emit namespaced-ids-machine)]
-      ;; :auth/idle → auth_idle, :auth/loading → auth_loading
-      (is (str/includes? out "auth_idle"))
-      (is (str/includes? out "auth_loading"))
+      ;; rf2-mnp93.6 — the id is INJECTIVE: every non-alphanumeric char is
+      ;; `_<hex>`-escaped (`/` → `_2f`), so `:auth/idle` → `auth_2fidle`
+      ;; and `:auth/loading` → `auth_2floading`. The pre-fix naive
+      ;; `[^a-zA-Z0-9_]`-collapse merged `:auth/idle` with a hypothetical
+      ;; `:auth-idle` (both → `auth_idle`); the hex escape keeps them
+      ;; distinct (`auth_2fidle` vs `auth_2didle`).
+      (is (str/includes? out "auth_2fidle"))
+      (is (str/includes? out "auth_2floading"))
       ;; :rf/load → "rf/load" as the edge label (sanitise-label keeps
-      ;; the slash; only sanitise-id strips it)
-      (is (str/includes? out "auth_idle --> auth_loading : rf/load")))))
+      ;; the slash; only sanitise-id escapes it)
+      (is (str/includes? out "auth_2fidle --> auth_2floading : rf/load")))))
 
 (deftest emit-validates-definition
   (testing "definitions missing :initial or :states throw :invalid-definition"
@@ -224,7 +229,8 @@
                          :validating {}
                          :rejected {}}}
           out (m/emit m)]
-      (is (str/includes? out "editing --> rate_limited : submit [over-limit?]"))
+      ;; rf2-mnp93.6 — `:rate-limited` → `rate_2dlimited` (hyphen hex-escaped).
+      (is (str/includes? out "editing --> rate_2dlimited : submit [over-limit?]"))
       (is (str/includes? out "editing --> validating : submit [email-valid?]"))
       (is (str/includes? out "editing --> rejected : submit")))))
 
@@ -232,7 +238,8 @@
   (testing ":after and :always targets render as lossy labelled edges"
     (let [out (m/emit timed-and-eventless-machine)]
       (is (str/includes? out "loading --> timeout : after(5000)"))
-      (is (str/includes? out "loading --> hard_error : after(30000) [still-loading?]"))
+      ;; rf2-mnp93.6 — `:hard-error` → `hard_2derror` (hyphen hex-escaped).
+      (is (str/includes? out "loading --> hard_2derror : after(30000) [still-loading?]"))
       (is (str/includes? out "checking --> ready : always [ready?]"))
       (is (str/includes? out "checking --> blocked : always")))))
 
@@ -244,15 +251,18 @@
                :on      {:reset :b
                          :*     :a}}
           out (m/emit m)]
-      (is (str/includes? out "state \"root fallback\" as rf_machines_viz_mermaid_root_fallback"))
-      (is (str/includes? out "rf_machines_viz_mermaid_root_fallback --> b : reset (root fallback)"))
-      (is (str/includes? out "rf_machines_viz_mermaid_root_fallback --> a : * (root fallback)")))))
+      ;; rf2-mnp93.6 — the reserved root-fallback segment is a namespaced
+      ;; keyword; every `.`/`-`/`/` hex-escapes (`_2e`/`_2d`/`_2f`).
+      (is (str/includes? out "state \"root fallback\" as rf_2emachines_2dviz_2emermaid_2froot_2dfallback"))
+      (is (str/includes? out "rf_2emachines_2dviz_2emermaid_2froot_2dfallback --> b : reset (root fallback)"))
+      (is (str/includes? out "rf_2emachines_2dviz_2emermaid_2froot_2dfallback --> a : * (root fallback)")))))
 
 (deftest emit-renders-parallel-region-machines
   (testing ":type :parallel renders each region inside a synthetic parallel root"
     (let [out (m/emit parallel-region-machine)]
-      (is (str/includes? out "[*] --> rf_machines_viz_mermaid_parallel_root"))
-      (is (str/includes? out "state rf_machines_viz_mermaid_parallel_root {"))
+      ;; rf2-mnp93.6 — the reserved parallel-root segment hex-escapes too.
+      (is (str/includes? out "[*] --> rf_2emachines_2dviz_2emermaid_2fparallel_2droot"))
+      (is (str/includes? out "state rf_2emachines_2dviz_2emermaid_2fparallel_2droot {"))
       (is (str/includes? out "state data {"))
       (is (str/includes? out "[*] --> data__nothing"))
       (is (str/includes? out "data__nothing --> data__loading : fetch"))
@@ -262,15 +272,24 @@
       (is (str/includes? out "form__correct --> [*]"))
       (is (str/includes? out "broadcast macrostep semantics are lossy")))))
 
-(deftest emit-drops-target-less-transitions
-  (testing "internal / fn-shaped transitions without a resolvable :target are dropped"
+(deftest emit-surfaces-internal-and-drops-fn-shaped-transitions
+  (testing "internal (action-only) transitions surface as a note; fn-shaped transitions are dropped"
     (let [m   {:initial :a
-               :states  {:a {:on {:go     {:action :record}        ;; no :target
+               :states  {:a {:on {:go     {:action :record}        ;; internal (no :target)
                                   :reset  (fn [_ _] {:state :a})}} ;; fn-shaped
                          :b {}}}
           out (m/emit m)]
-      ;; Neither :go nor :reset can be rendered without a known target;
-      ;; both should be silently dropped (the topology stays valid).
+      ;; rf2-mnp93.4 — an INTERNAL action-only candidate has no arrow to
+      ;; draw, but it MUST NOT be silently dropped (the chart self-anchors
+      ;; it, SCXML emits a target-less <transition>). Mermaid surfaces it
+      ;; as a note so the three emitters agree.
+      (is (str/includes? out "note right of a"))
+      (is (str/includes? out "go / record"))
+      ;; A fn-shaped transition cannot be statically rendered (we can't run
+      ;; it to learn its target), so it is still dropped.
+      (is (not (str/includes? out "reset")))
+      ;; No state-change arrow is drawn from :a (the action-only :go is a
+      ;; note, the fn-shaped :reset is dropped).
       (is (not (str/includes? out "a --> "))))))
 
 ;; -----------------------------------------------------------------------------
@@ -417,3 +436,117 @@
           "a target-bearing :on-done keeps its sibling completion arrow")
       (is (not (str/includes? out "note right of flow"))
           "a target-bearing :on-done does NOT also render a note"))))
+
+;; ---- internal (action-only) :on / :after / :always notes (rf2-mnp93.4) --
+;;
+;; An INTERNAL transition candidate (a map omitting `:target` — Spec 005
+;; §Transition slots: "omit for internal") runs only its `:action`; the
+;; config is unchanged, so there is NO arrow to draw. Pre-fix, the `:on` /
+;; `:after` / `:always` collectors all SILENTLY DROPPED every target-less
+;; candidate, while the chart self-anchored it (`:internal? true`) and SCXML
+;; emitted a target-less `<transition>` — breaking the G9 'faithful across
+;; all three emitters' parity claim (001-Topology-Parity.md §3.1). The fix
+;; surfaces them as a note (exactly the rf2-ay42f action-only :on-done
+;; pattern), so all three emitters agree.
+
+(deftest emit-internal-on-transition-renders-note
+  (testing "rf2-mnp93.4 — an INTERNAL (action-only) :on candidate renders as
+            a note (NOT silently dropped) carrying `<event> / <action>`"
+    (let [m   {:initial :a :states {:a {:on {:tick {:action :log}}}}}
+          out (m/emit m {:fenced? false :header-comment? false})]
+      (is (str/includes? out "note right of a"))
+      (is (str/includes? out "tick / log"))
+      (is (not (str/includes? out "a --> "))
+          "no phantom arrow for an internal action :on"))))
+
+(deftest emit-internal-after-and-always-render-notes
+  (testing "rf2-mnp93.4 — internal (action-only) :after / :always candidates
+            render as notes too (the SAME asymmetry the :on branch had)"
+    (let [m   {:initial :a
+               :states  {:a {:after  {1000 {:action :timeout-log}}
+                             :always [{:action :poll}]}}}
+          out (m/emit m {:fenced? false :header-comment? false})]
+      (is (str/includes? out "note right of a"))
+      (is (str/includes? out "after(1000) / timeout-log")
+          "internal :after surfaces as a note line")
+      (is (str/includes? out "always / poll")
+          "internal :always surfaces as a note line")
+      (is (not (str/includes? out "a --> "))
+          "no phantom arrow for internal :after / :always"))))
+
+(deftest emit-internal-transition-with-guard-renders-note
+  (testing "rf2-mnp93.4 — an internal candidate's guard surfaces in its note
+            line: `<event> [guard] / <action>`"
+    (let [m   {:initial :a :states {:a {:on {:tick {:action :log :guard :ready?}}}}}
+          out (m/emit m {:fenced? false :header-comment? false})]
+      (is (str/includes? out "tick [ready?] / log")))))
+
+(deftest emit-mixes-internal-note-with-targeted-edge
+  (testing "rf2-mnp93.4 — a state with BOTH a targeted :on AND an internal
+            :on renders the arrow for the targeted one and a note for the
+            internal one (the mixed-candidate case is not all-or-nothing)"
+    (let [m   {:initial :a
+               :states  {:a {:on {:go   :b                 ;; targeted → arrow
+                                  :tick {:action :log}}}    ;; internal → note
+                         :b {}}}
+          out (m/emit m {:fenced? false :header-comment? false})]
+      (is (str/includes? out "a --> b : go") "the targeted :on keeps its arrow")
+      (is (str/includes? out "note right of a") "the internal :on gets a note")
+      (is (str/includes? out "tick / log")))))
+
+;; ---- INJECTIVE sanitise-id (rf2-mnp93.6) --------------------------------
+;;
+;; `sanitise-id` mapped every non-[a-zA-Z0-9_] char to `_`, so `:auth/login`,
+;; `:auth-login`, and `:auth_login` all collapsed to `auth_login`: two
+;; distinct states became ONE Mermaid node, and every edge to/from either
+;; pointed at the merged node — silently mis-wiring the diagram. Hyphens are
+;; pervasive in re-frame keywords (`:logged-in`, `:rate-limited`), so the
+;; collision is readily reachable. The fix ports the chart's injective
+;; hex-escape scheme (`:a/b` → `a_2fb`, `:a-b` → `a_2db`): distinct keywords
+;; map to distinct mermaid nodes.
+
+(deftest emit-sanitise-id-is-injective
+  (testing "rf2-mnp93.6 — `:a/b` and `:a-b` mint DISTINCT mermaid nodes (the
+            non-injective collapse merged them into one)"
+    (let [m   {:initial :a
+               :states  {:a {:on {:go :auth/login :back :auth-login}}
+                         :auth/login {} :auth-login {}}}
+          out (m/emit m {:fenced? false :header-comment? false})]
+      ;; The two edges target DISTINCT nodes (pre-fix both read `a --> auth_login`).
+      (is (str/includes? out "a --> auth_2flogin : go")
+          ":auth/login → auth_2flogin (slash hex-escaped to _2f)")
+      (is (str/includes? out "a --> auth_2dlogin : back")
+          ":auth-login → auth_2dlogin (hyphen hex-escaped to _2d)")
+      (is (not= "auth_2flogin" "auth_2dlogin")
+          "the two ids are distinct (sanity)"))))
+
+(deftest emit-sanitise-id-distinguishes-all-three-collision-forms
+  (testing "rf2-mnp93.6 — `:a/b`, `:a-b`, AND `:a_b` (the three forms the
+            naive collapse merged) all mint DISTINCT mermaid nodes"
+    (let [m   {:initial :start
+               :states  {:start {:on {:one :a/b :two :a-b :three :a_b}}
+                         :a/b {} :a-b {} :a_b {}}}
+          out (m/emit m {:fenced? false :header-comment? false})]
+      (is (str/includes? out "start --> a_2fb : one")  ":a/b → a_2fb")
+      (is (str/includes? out "start --> a_2db : two")  ":a-b → a_2db")
+      (is (str/includes? out "start --> a_5fb : three") ":a_b → a_5fb (underscore → _5f)")
+      ;; All three node-ids are pairwise distinct — no merge.
+      (is (= 3 (count (distinct ["a_2fb" "a_2db" "a_5fb"])))))))
+
+(deftest emit-sanitise-id-no-two-consecutive-underscores-within-segment
+  (testing "rf2-mnp93.6 — within a single segment the escaper never emits two
+            consecutive underscores, so the `__` path separator can never be
+            confused with segment content (it only appears BETWEEN path
+            segments)"
+    (let [m   {:initial :left
+               :states  {:left  {:initial :child-node
+                                 :states  {:child-node {:on {:swap [:right :child-node]}}}}
+                         :right {:initial :child-node
+                                 :states  {:child-node {}}}}}
+          out (m/emit m {:fenced? false :header-comment? false})]
+      ;; A hyphen inside a segment is `_2d`, NOT a bare `_`, so a compound id
+      ;; reads `left__child_2dnode` — the ONLY `__` is the path boundary.
+      (is (str/includes? out "left__child_2dnode")
+          "compound id: hyphen → _2d, single __ is the path separator")
+      (is (str/includes? out "right__child_2dnode")
+          "the two same-named child-node leaves stay DISTINCT (path-qualified)"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -651,3 +651,94 @@
                          ["mixed-candidate-on-machine"         mixed-candidate-on-machine]]]
       (testing name
         (is (= spec (-> spec scxml/spec->scxml scxml/scxml->spec)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-mnp93.5 — an INTERNAL ACTION transition must NOT round-trip into a
+;; Spec-005 FORBIDDEN BLOCK.
+;;
+;; `:on {:tick {:action :log}}` is an internal action transition: it RUNS an
+;; action and leaves the config unchanged (Spec 005 §Transition slots — "omit
+;; for internal"). Pre-fix, the action rode an XML COMMENT that the decoder's
+;; `strip-comments` discarded BEFORE tokenizing, so the candidate decoded to
+;; the EMPTY map `{}` — which Spec 005 §Forbidden transitions (L1335-1346)
+;; defines as a FORBIDDEN BLOCK: an enabled internal no-op that CONSUMES the
+;; event and shadows every coarser descriptor + ancestor (opts OUT of
+;; inheritance). 'Run an action' decoding to 'block the event entirely' is a
+;; SEMANTIC INVERSION, not lossy detail. The distinguishing shape feature is
+;; the PRESENCE of `:action` (L1346: an action-bearing internal transition
+;; halts the walk AND runs the action). The fix lifts the action comment into
+;; the candidate so it round-trips as `{:action :log}` — a VALID internal
+;; action transition.
+
+(def internal-action-on-machine
+  "An INTERNAL action `:on` transition (no `:target`)."
+  {:initial :a
+   :states  {:a {:on {:tick {:action :log}}}}})
+
+(def internal-action-after-machine
+  "An INTERNAL action `:after` transition (no `:target`)."
+  {:initial :a
+   :states  {:a {:after {1000 {:action :timeout-log}}}}})
+
+(def internal-action-always-machine
+  "An INTERNAL action `:always` transition (no `:target`)."
+  {:initial :a
+   :states  {:a {:always [{:action :poll}]}}})
+
+(def internal-guarded-action-machine
+  "An INTERNAL action `:on` transition with a guard (no `:target`)."
+  {:initial :a
+   :states  {:a {:on {:tick {:action :log :guard :ready?}}}}})
+
+(def internal-ns-action-machine
+  "An INTERNAL action `:on` transition whose action is NAMESPACED — the
+  action codec must round-trip its namespace too."
+  {:initial :a
+   :states  {:a {:on {:tick {:action :log/append}}}}})
+
+(deftest internal-action-transition-not-forbidden-block
+  (testing "rf2-mnp93.5 — an internal action `:on` round-trips to a VALID
+            internal action transition, NOT the `{}` forbidden block"
+    (let [back (-> internal-action-on-machine scxml/spec->scxml scxml/scxml->spec)
+          cand (get-in back [:states :a :on :tick])]
+      (is (= {:action :log} cand)
+          "the candidate keeps its :action (NOT the empty {} forbidden block)")
+      (is (not= {} cand)
+          "explicitly: it is NOT the Spec-005 forbidden block shape")
+      (is (contains? cand :action)
+          "the distinguishing :action key is present")
+      (is (not (contains? cand :target))
+          "still internal — no :target")
+      (is (= internal-action-on-machine back)
+          "exact value round-trip")))
+
+  (testing "rf2-mnp93.5 — internal action `:after` round-trips faithfully"
+    (let [back (-> internal-action-after-machine scxml/spec->scxml scxml/scxml->spec)]
+      (is (= internal-action-after-machine back))
+      (is (= {:action :timeout-log} (get-in back [:states :a :after 1000])))))
+
+  (testing "rf2-mnp93.5 — internal action `:always` round-trips faithfully"
+    (let [back (-> internal-action-always-machine scxml/spec->scxml scxml/scxml->spec)]
+      (is (= internal-action-always-machine back))
+      (is (= [{:action :poll}] (get-in back [:states :a :always])))))
+
+  (testing "rf2-mnp93.5 — an internal action transition WITH a guard keeps
+            both :action and :guard (still not a forbidden block)"
+    (let [back (-> internal-guarded-action-machine scxml/spec->scxml scxml/scxml->spec)
+          cand (get-in back [:states :a :on :tick])]
+      (is (= {:action :log :guard :ready?} cand))
+      (is (not= {} cand))))
+
+  (testing "rf2-mnp93.5 — a NAMESPACED action round-trips its namespace"
+    (let [back (-> internal-ns-action-machine scxml/spec->scxml scxml/scxml->spec)]
+      (is (= internal-ns-action-machine back))
+      (is (= :log/append (get-in back [:states :a :on :tick :action])))))
+
+  (testing "rf2-mnp93.5 — a genuine FORBIDDEN block ({} — no action, no
+            target) still round-trips to `{}` (the action lift-pass only
+            recovers a PRESENT action; absence stays absent — no false
+            action synthesised)"
+    (let [spec {:initial :a :states {:a {:on {:tick {}}}}}
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (= {} (get-in back [:states :a :on :tick]))
+          "an empty-map forbidden block survives as `{}`, not invented an action"))))


### PR DESCRIPTION
## Summary

Closes the 2026-06-05 faithfulness review cluster **rf2-mnp93** (.4/.5/.6) — three cross-emitter / round-trip correctness bugs in the chart / mermaid / SCXML viz emitters. A diagram that drops or inverts a transition mis-teaches the user, so the three emitters must agree with each other AND with the Spec 005 machine (G9, `001-Topology-Parity.md` §3.1).

### rf2-mnp93.4 — cross-emitter asymmetry (internal :after/:always dropped in chart + mermaid)
An INTERNAL (action-only, no-`:target`) `:on` / `:after` / `:always` candidate (Spec 005 §Transition slots: "omit for internal") was projected INCONSISTENTLY:
- **chart**: charted internal `:on` (self-anchored, `:internal?`) but **silently dropped** internal `:after` / `:always` (inconsistent even within the chart);
- **mermaid**: dropped **all three**;
- **SCXML**: kept all three.

Three emitters, three projections of one machine. **Fix:** the chart's `:after` / `:always` branches now self-anchor target-less candidates (`:internal? true`) exactly like the `:on` branch; mermaid renders each internal candidate as a `note right of <state>` line — the same affordance rf2-ay42f introduced for action-only `:on-done`. SCXML was already faithful.

### rf2-mnp93.5 — SCXML round-trip turns an internal action transition into a Spec 005 forbidden block
`:on {:tick {:action :log}}` emitted `<transition event="tick"><!-- action: log --></transition>`; the decoder's `strip-comments` discarded the action comment **before** tokenizing, so the candidate decoded to the empty map `{}` — which Spec 005 §Forbidden transitions defines as a FORBIDDEN BLOCK (consume-the-event-and-block-inheritance). 'Run an action' → 'block the event entirely' is a **semantic inversion**. **Fix:** a `lift-action-comments` pre-pass folds each `<!-- action: NAME -->` into a synthetic attribute on its own `<transition>` before comments are stripped; the decoder recovers it into `:action`. An internal action transition round-trips as `{:action :log}` — a valid Spec-005 internal action transition (the distinguishing feature is the PRESENCE of `:action`). A genuine `{}` forbidden block still round-trips to `{}`.

### rf2-mnp93.6 — mermaid sanitise-id non-injective
`sanitise-id` mapped every non-`[a-zA-Z0-9_]` char to `_`, so `:a/b`, `:a-b`, `:a_b` all collapsed to `a_b`: two distinct states became ONE mermaid node, mis-wiring every edge. **Fix:** ported the chart's injective hex-escape scheme (`:a/b` → `a_2fb`, `:a-b` → `a_2db`, `:a_b` → `a_5fb`) into `sanitise-id`, so distinct keywords map to distinct nodes AND chart + mermaid mint the SAME id for the same path.

## Spec
- `tools/machines-viz/spec/001-Topology-Parity.md` — F5–F7 rows + updated R3 review pass + parity verdict.
- `tools/machines-viz/spec/API.md` — internal `:after` / `:always` chart event-node rows, internal `:on` SCXML row.
- `scxml.cljc` ns docstring — action names now round-trip; supported-subset table.

## Gates
- machines-viz `clojure -M:test` — **389 tests, 1206 assertions, 0 failures**.
- `npm run test:cljs` — **5704 tests, 19929 assertions, 0 failures**.
- New regression coverage:
  - cross-emitter agreement (`cross_emitter_agreement_cljs_test`): the same internal transition renders consistently across chart / mermaid / SCXML (count agreement 3/3/3 for the bead repro);
  - SCXML internal-transition round-trip validity (`scxml_cljs_test` — internal action transition → `{:action ...}`, not `{}`);
  - mermaid injectivity (`mermaid_cljs_test` — `:a/b` / `:a-b` / `:a_b` mint distinct nodes);
  - chart-pipeline internal `:after` / `:always` projection (`projection_cljs_test` — event-node + no outbound segment).

Surface is `tools/machines-viz/` only. No edits to `spec/005` (hot-zone).
