### PR TITLE
fix(examples/reagent): styled TodoMVC CSS + honest coverage docs + idempotent route listeners (rf2-8r0mj.1 + rf2-a1b39.1 + rf2-a1b39.2)

### DIFF
--- a/examples/reagent/realworld/README.md
+++ b/examples/reagent/realworld/README.md
@@ -1,6 +1,6 @@
 # RealWorld (Conduit) in re-frame2
 
-> **Canonical multi-artefact integration test.** This example is the canonical multi-artefact integration test for re-frame2. It exercises `day8/re-frame2` (core) + `-schemas` + `-machines` + `-routing` + `-flows` + `-http` together in a single app. CI runs it on every PR via `npm run test:examples` from `implementation/`. When a per-artefact change accidentally breaks cross-artefact composition, this is the test that catches it. See [docs/release-process.md](../../../docs/release-process.md) for how this slots into the multi-artefact deploy pipeline.
+> **Canonical multi-artefact integration test.** This example is the canonical multi-artefact integration test for re-frame2. It exercises `day8/re-frame2` (core) + `-schemas` + `-machines` + `-routing` + `-flows` + `-http` together in a single app. CI runs its CLJS fixtures on every PR via `npm run test:cljs` from `implementation/` (the example tree is test-free per rf2-8cevm — `npm run test:examples` drives only the three adapter smokes and never builds this example). When a per-artefact change accidentally breaks cross-artefact composition, this is the test that catches it. See [docs/release-process.md](../../../docs/release-process.md) for how this slots into the multi-artefact deploy pipeline.
 
 The canonical re-frame2 demo for **Spec 014 — `:rf.http/managed`**. Built on the [RealWorld spec](https://github.com/gothinkster/realworld), the de-facto cross-framework benchmark for SPA frameworks.
 

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -188,9 +188,17 @@
       (str (.. js/window -location -search)
            (.. js/window -location -hash))))
 
+;; Named handler so the listener install is idempotent: repeated
+;; `install-router!` (shadow hot reload, or a co-required test host
+;; invoking run twice) must not stack duplicate popstate listeners,
+;; mirroring the `when-not @react-root` mount guard. We remove-then-add
+;; the same Var so the registration is deduped even when the Var is
+;; redefined on reload.
+(defn- on-popstate [_]
+  (rf/dispatch [:rf.route/handle-url-change (current-url)]))
+
 (defn install-router! []
-  (.addEventListener js/window "popstate"
-    (fn [_]
-      (rf/dispatch [:rf.route/handle-url-change (current-url)])))
+  (.removeEventListener js/window "popstate" on-popstate)
+  (.addEventListener js/window "popstate" on-popstate)
   (rf/dispatch-sync [:rf.route/handle-url-change (current-url)]))
 

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -138,10 +138,17 @@
        (.. js/window -location -search)
        (.. js/window -location -hash)))
 
+;; Named handler so the listener install is idempotent: repeated `run`
+;; (shadow hot reload, or a co-required test host invoking run twice)
+;; must not stack duplicate popstate listeners, mirroring the
+;; `when-not @react-root` mount guard. We remove-then-add the same Var so
+;; the registration is deduped even when the Var is redefined on reload.
+(defn- on-popstate [_]
+  (rf/dispatch [:rf.route/handle-url-change (current-url)]))
+
 (defn install-router! []
-  (.addEventListener js/window "popstate"
-    (fn [_]
-      (rf/dispatch [:rf.route/handle-url-change (current-url)])))
+  (.removeEventListener js/window "popstate" on-popstate)
+  (.addEventListener js/window "popstate" on-popstate)
   (rf/dispatch-sync [:rf.route/handle-url-change (current-url)]))
 
 ;; ============================================================================

--- a/examples/reagent/todomvc/README.md
+++ b/examples/reagent/todomvc/README.md
@@ -26,10 +26,14 @@ The example uses the official TodoMVC CSS packages, pinned in
 `implementation/package.json` (so `npm install` fetches them into
 `node_modules/`) rather than vendored into this repo:
 
-- `todomvc-common` `1.0.5`
-- `todomvc-app-css` `2.4.3`
+- `todomvc-common` `1.0.5` — ships `base.css`
+- `todomvc-app-css` `2.4.3` — ships `index.css`
 
-That keeps the rendered surface close to the current TodoMVC template without vendoring upstream CSS into this repo.
+`index.html` links both files flat (`base.css`, `index.css`), so stage
+them next to `main.js` from `node_modules/` (see **Running it**). The
+`index.css` href intentionally matches the `todomvc-app-css` package
+file name. That keeps the rendered surface close to the current TodoMVC
+template without vendoring upstream CSS into this repo.
 
 ## Running it
 
@@ -40,9 +44,16 @@ npm install
 shadow-cljs watch examples/todomvc
 ```
 
-Stage the `index.html` (and the TodoMVC CSS from `node_modules/`) next
-to the build's `main.js` under `out/examples/todomvc/` and serve that
-directory over HTTP.
+Stage `index.html` next to the build's `main.js` under
+`out/examples/todomvc/`, copy the two TodoMVC CSS files there from
+`node_modules/` so the flat `<link>` hrefs resolve, then serve that
+directory over HTTP:
+
+```bash
+cp examples/reagent/todomvc/index.html out/examples/todomvc/
+cp node_modules/todomvc-common/base.css out/examples/todomvc/base.css
+cp node_modules/todomvc-app-css/index.css out/examples/todomvc/index.css
+```
 
 Per the test-free examples policy this example carries no per-example
 spec; real-regression coverage of the primitives it exercises lives in

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -36,13 +36,22 @@
 (defn- current-path []
   (hash->path (.. js/window -location -hash)))
 
+;; Named handler so the listener install is idempotent: repeated `run`
+;; (shadow hot reload, or a co-required test host invoking run twice)
+;; must not stack duplicate hashchange listeners, mirroring the
+;; `when-not @react-root` mount guard below. We remove-then-add the same
+;; Var so the registration is deduped even when the Var is redefined on
+;; reload.
+(defn- on-hashchange [_]
+  (rf/dispatch [:rf.route/handle-url-change (current-path)]))
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:todo/initialise])
   (rf/dispatch-sync [:rf.route/handle-url-change (current-path)])
-  (.addEventListener js/window "hashchange"
-    (fn [_] (rf/dispatch [:rf.route/handle-url-change (current-path)])))
+  (.removeEventListener js/window "hashchange" on-hashchange)
+  (.addEventListener js/window "hashchange" on-hashchange)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))

--- a/examples/reagent/todomvc/index.html
+++ b/examples/reagent/todomvc/index.html
@@ -14,7 +14,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" type="image/svg+xml" href="_shared/img/favicon.svg">
   <link rel="stylesheet" href="base.css">
-  <link rel="stylesheet" href="todomvc-app.css">
+  <link rel="stylesheet" href="index.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -32,8 +32,10 @@
      `:reconnecting` `:after` re-enters `:active` which spawns a
      fresh one.
 
-   Run standalone via `npm run test:examples`; the mock server keeps
-   the app self-contained."
+   Coverage lives in the CLJS substrate contract tests (`npm run
+   test:cljs`, ns `re-frame.websocket-cljs-test`); the mock server keeps
+   the app self-contained. The example tree is test-free (rf2-8cevm), so
+   `npm run test:examples` does not build this example."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]


### PR DESCRIPTION
@-