### PR TITLE
fix(xray): evicted-epoch placeholder across all panels + clipboard egress (rf2-uo0rc.1 + rf2-uo0rc.2)

### DIFF
--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -217,8 +217,8 @@ epoch-history; the body shows the focused epoch's `:db-after`
 |---|---|---|
 | `:rf.xray/focus-slice-path` | `[_ path]` | Sets the "Show me when this changed" focused path. |
 | `:rf.xray/clear-slice-focus` | `[_]` | Drops the focus. |
-| `:rf.xray/copy-value-to-clipboard` | `[_ value]` | `event-fx` — emits `{:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str value)}]]}`. |
-| `:rf.xray/copy-path-to-clipboard` | `[_ path]` | `event-fx` — same shape, `pr-str path`. |
+| `:rf.xray/copy-value-to-clipboard` | `[_ value]` | `event-fx` — routes `value` through `runtime/egress-value` (pinned to the observed frame: `[:focus :frame]` ⇒ `:target-frame`) **before** the clipboard write, then emits `{:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str <elided>)}]]}`. The clipboard is an off-box sink, so sensitive ⇒ `:rf/redacted`, large ⇒ `:rf.size/large-elided`, fail-closed (rf2-uo0rc.2; same class as the palette snapshot rf2-mxzgg + `get-app-db` rf2-a96xq). No raw opt-in. |
+| `:rf.xray/copy-path-to-clipboard` | `[_ path]` | `event-fx` — emits `{:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str path)}]]}`. The path vector carries only key names (no values), so it is not a value-egress site and is not elided. |
 | `:rf.xray/open-segment-inspector` | `[_ path]` | rf2-e9tb0 — opens the segment-inspector popup at `path` (vector). |
 | `:rf.xray/close-segment-inspector` | `[_]` | rf2-e9tb0 — closes the popup. |
 

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -719,6 +719,22 @@ snapshot is always the redacted / size-elided projection — the raw-egress
 opt-in (`{:include-sensitive? true}` / `{:include-large? true}`) is
 reachable only through the runtime accessors, never the palette command.
 
+The **universal copy-to-clipboard affordance** is the same shape of
+off-box sink and routes the same way (rf2-uo0rc.2). The `⎘` copy button
+that rides every value inspector dispatches `:rf.xray/copy-value-to-clipboard`,
+which writes the copied value to the system clipboard via the
+`:rf.xray.fx/copy-to-clipboard` fx — an off-box sink. The event routes the
+value through `egress-value` **before** the clipboard write, pinned to the
+**observed** frame (`[:focus :frame]`, falling back to `:target-frame`) so
+that frame's own schema declarations govern — a `{:sensitive? true}` slot
+copies as `:rf/redacted`, a `{:large? true}` blob as `:rf.size/large-elided`,
+fail-closed (mirroring the snapshot's `with-frame` pinning, rf2-mxzgg).
+The sibling `:rf.xray/copy-path-to-clipboard` copies only the path vector
+(key names, no values), so it is not a value-egress site and is not
+elided. Like the snapshot, the value-copy event exposes no raw opt-in —
+the operator-controlled `{:include-sensitive? true}` / `{:include-large? true}`
+gate is reachable only through the runtime accessors.
+
 ### Inspection band (9 accessors — read-only)
 
 | Accessor (fn) | Tool name | Returns | Reads |

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
@@ -8,7 +8,9 @@
   pinned-watches strip was superseded by the path-segment inspector
   popup (Mike 2026-05-19 Q13). The matching `pin-path` / `unpin-path`
   / `reorder-paths` helpers were pulled in lockstep."
-  (:require [re-frame.core :as rf]))
+  (:require [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [day8.re-frame2-xray.runtime :as runtime]))
 
 (defn install!
   "Install the App-DB Diff events and effects."
@@ -37,10 +39,38 @@
           (.writeText (.-clipboard js/navigator) (str text)))
         (catch :default _ nil))))
 
+  ;; ---- universal copy-to-clipboard — OFF-BOX EGRESS (rf2-uo0rc.2) ----------
+  ;;
+  ;; The system clipboard is an OFF-BOX SINK (Security.md §Off-box egress,
+  ;; palette/events.cljs §Off-box egress): whatever lands there can be
+  ;; pasted into a teammate's chat or scraped. So the COPIED VALUE must
+  ;; cross it through the runtime's single named fail-closed safe-egress
+  ;; fn `runtime/egress-value` — the SAME projection the palette snapshot
+  ;; (rf2-mxzgg) and the `get-app-db` accessor (rf2-a96xq) use. On the
+  ;; bare call the off-box defaults are baked in: `:sensitive?` slots ⇒
+  ;; `:rf/redacted`, large slots ⇒ `:rf.size/large-elided`. The earlier
+  ;; copy fx wrote the RAW `(pr-str value)` — a `[:auth :token]
+  ;; {:sensitive? true}` slot or a large blob leaked verbatim.
+  ;;
+  ;; The egress is pinned to the OBSERVED frame (the frame Xray is
+  ;; inspecting — `[:focus :frame]`, falling back to the legacy
+  ;; `:target-frame` slot) via `(rf/with-frame …)` so THAT frame's own
+  ;; schema declarations govern the redaction — mirroring the palette's
+  ;; `snapshot-app-db!`, which pins to the focused frame for the same
+  ;; reason (the displayed value's `:sensitive?` / size declarations live
+  ;; on the inspected frame, not the Xray chrome frame the affordance
+  ;; dispatches from). A nil / unregistered observed frame degrades to a
+  ;; bare (current-frame-resolved) egress — still fail-closed.
   (rf/reg-event-fx :rf.xray/copy-value-to-clipboard
-    (fn [_ctx [_ value]]
-      {:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str value)}]]}))
+    (fn [{:keys [db]} [_ value]]
+      (let [observed (or (get-in db [:focus :frame]) (get db :target-frame))
+            elided   (if (and (some? observed) (some? (frame/frame observed)))
+                       (rf/with-frame observed (runtime/egress-value value))
+                       (runtime/egress-value value))]
+        {:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str elided)}]]})))
 
+  ;; The path-copy variant copies ONLY the path vector (key names, no
+  ;; values) so there is nothing to elide — it is not a value-egress site.
   (rf/reg-event-fx :rf.xray/copy-path-to-clipboard
     (fn [_ctx [_ path]]
       {:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str path)}]]})))

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -99,7 +99,8 @@
   on a populated registrar, `rf/app-db-value` on a frame) are read
   by the composite sub in `registry.cljs`; the result is handed to
   this ns as a plain map."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]))
 
 ;; ---- canonical operation taxonomy ---------------------------------------
 
@@ -954,23 +955,22 @@
   cascade's settling `:epoch-id` per spec/018 §6 (Spine events); the
   record's `:trace-events` is the cascade window the lens reads.
 
-  Falls back to the head record when the focused epoch-id is nil
-  (LIVE mode default; matches the views-focused-cascade-pair fallback
-  pattern). Returns nil when the buffer is empty.
+  Routes through the shared `panels.shared.focus-resolver/find-epoch-record`
+  (rf2-uo0rc.1) so the Machine Inspector resolves focus identically to
+  every other L4 panel:
+
+    - NIL focus epoch-id + non-empty history → HEAD record (rf2-h0120
+      head-fallback — the natural LIVE/cold-start debugging UX).
+    - focus epoch-id MATCHES a record → that record.
+    - focus epoch-id pinned but EVICTED from the ring → nil. The panel
+      then renders the §10.7 evicted/blank placeholder rather than
+      silently falling back to HEAD and showing the LATEST machine
+      state, which lied about which epoch the operator was inspecting.
+    - empty history → nil.
 
   Pure fn — JVM-runnable."
   [epoch-history focus]
-  (let [history (vec (or epoch-history []))]
-    (cond
-      (empty? history) nil
-      (some? (:epoch-id focus))
-      (or (some (fn [r] (when (= (:epoch-id focus) (:epoch-id r)) r))
-                history)
-          ;; Focused epoch-id not in buffer (evicted) → fall back to
-          ;; head so the panel renders something rather than going
-          ;; silent on what is really a buffer-eviction event.
-          (peek history))
-      :else (peek history))))
+  (focus/find-epoch-record (:epoch-id focus) epoch-history))
 
 ;; ---- Dynamic-mode single-instance rule (rf2-8og3k, impl rf2-2n34o) ------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -97,21 +97,29 @@
   `install!` registers `:rf.xray/reactive-data` + the panel-local
   disclosure-toggle state slot. Idempotent."
   (:require [re-frame.core :as rf]
-            [re-frame.subs.tooling :as subs-tooling]))
+            [re-frame.subs.tooling :as subs-tooling]
+            [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]))
 
 ;; ---- pure helpers (exposed for test) ------------------------------------
 
 (defn focused-epoch-record
-  "Locate the focused epoch record in `epoch-history`. Mirrors the
-  legacy Views panel lookup: match by `:epoch-id`, fall back to head
-  when the focus has no `:epoch-id` (LIVE / cold-start) or the focused
-  record has been evicted from the ring."
+  "Locate the focused epoch record in `epoch-history`.
+
+  Routes through the shared `panels.shared.focus-resolver/find-epoch-record`
+  (rf2-uo0rc.1) so the Views panel resolves focus identically to every
+  other L4 panel:
+
+    - NIL `epoch-id` + non-empty history → HEAD record (rf2-h0120
+      head-fallback — the natural LIVE / cold-start debugging UX).
+    - `epoch-id` MATCHES a record → that record.
+    - `epoch-id` pinned but EVICTED from the ring → nil. The composite
+      then reports `:has-cascade? false` and the panel renders its
+      empty/§10.7-evicted placeholder rather than silently falling back
+      to HEAD and showing the LATEST cascade, which lied about which
+      epoch the operator was inspecting.
+    - empty history → nil."
   [epoch-history epoch-id]
-  (when (seq epoch-history)
-    (or (when epoch-id
-          (some (fn [record] (when (= epoch-id (:epoch-id record)) record))
-                epoch-history))
-        (peek (vec epoch-history)))))
+  (focus/find-epoch-record epoch-id epoch-history))
 
 (defn- op-kw
   "Trace-event op keyword. The substrate's `:rf/*` ops carry the kw on

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -367,6 +367,117 @@
       (is (= "{:a 1}" (:text (first @captured))))
       (is (= "[:cart :items]" (:text (second @captured)))))))
 
+;; ---- (7b) clipboard copy is an OFF-BOX EGRESS site (rf2-uo0rc.2) ---------
+;;
+;; The system clipboard is an off-box sink. The copy fx wrote the RAW
+;; (pr-str value) — a `{:sensitive? true}` slot or a large blob leaked
+;; verbatim. The value-copy event now routes through runtime/egress-value
+;; (fail-closed: sensitive ⇒ :rf/redacted, large ⇒ :rf.size/large-elided),
+;; pinned to the observed frame so that frame's schema declarations govern
+;; — the same fix class as the palette snapshot (rf2-mxzgg) + get-app-db
+;; (rf2-a96xq).
+
+(defn- seed-sensitive-schema! []
+  ;; Mirror runtime_cljs_test/seed-sensitive-schema! — a `{:sensitive? true}`
+  ;; schema slot hydrates the per-frame sensitive-declarations so the wire
+  ;; walker substitutes :rf/redacted on off-box egress.
+  (rf/reg-app-schema [:auth]
+                     [:map
+                      [:username :string]
+                      [:password {:sensitive? true} :string]])
+  (rf/populate-sensitive-from-schemas!))
+
+(defn- seed-large-schema! []
+  (rf/reg-app-schema [:blob]
+                     [:map
+                      [:payload {:large? true} :any]])
+  (rf/populate-elision-from-schemas!))
+
+(defn- capture-copy! []
+  (let [captured (atom [])]
+    (rf/reg-fx :rf.xray.fx/copy-to-clipboard
+      (fn [_ctx args] (swap! captured conj args)))
+    captured))
+
+(deftest copy-value-redacts-sensitive-slot
+  (testing "rf2-uo0rc.2 — a copied value carrying a schema-declared
+            sensitive slot is REDACTED before it reaches the clipboard fx;
+            the raw secret never crosses the off-box boundary"
+    (registry/register-xray-handlers!)
+    (frame/reg-frame :rf/default {})
+    (frame/reg-frame :rf/xray {})
+    ;; Declare the sensitive path on the OBSERVED frame (:rf/default) so the
+    ;; egress, pinned to the observed frame, matches the declaration.
+    (rf/with-frame :rf/default (seed-sensitive-schema!))
+    (let [captured (capture-copy!)]
+      ;; Pin the spine focus at the observed frame so the event resolves it.
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
+        (rf/dispatch-sync
+          [:rf.xray/copy-value-to-clipboard
+           {:auth {:username "ada" :password "shh"}}]))
+      (is (= 1 (count @captured)))
+      (let [text (:text (first @captured))]
+        (is (re-find #":rf/redacted" text)
+            (str "the sensitive slot must be redacted on the clipboard text. "
+                 "text: " (pr-str text)))
+        (is (not (re-find #"shh" text))
+            (str "the RAW secret leaked to the clipboard — off-box egress "
+                 "fail-open (rf2-uo0rc.2). text: " (pr-str text)))
+        (is (re-find #"ada" text)
+            "non-sensitive sibling survives the copy")))))
+
+(deftest copy-value-size-elides-large-slot
+  (testing "rf2-uo0rc.2 — a copied value carrying a schema-declared
+            :large? slot is size-elided before it reaches the clipboard fx"
+    (registry/register-xray-handlers!)
+    (frame/reg-frame :rf/default {})
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/default (seed-large-schema!))
+    (let [captured (capture-copy!)]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
+        (rf/dispatch-sync
+          [:rf.xray/copy-value-to-clipboard
+           {:blob {:payload {:big "value"}}}]))
+      (is (= 1 (count @captured)))
+      (let [text (:text (first @captured))]
+        (is (re-find #":rf.size/large-elided" text)
+            (str "the large slot must be size-elided on the clipboard text. "
+                 "text: " (pr-str text)))
+        (is (not (re-find #"\"value\"" text))
+            (str "the RAW large value leaked to the clipboard. text: "
+                 (pr-str text)))))))
+
+(deftest copy-value-non-sensitive-passes-through
+  (testing "rf2-uo0rc.2 — egress is a no-op for a value with no
+            sensitive/large declarations: the copy still round-trips the
+            full value (fail-closed only bites declared slots)"
+    (registry/register-xray-handlers!)
+    (frame/reg-frame :rf/default {})
+    (frame/reg-frame :rf/xray {})
+    (let [captured (capture-copy!)]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
+        (rf/dispatch-sync [:rf.xray/copy-value-to-clipboard {:a 1 :b [2 3]}]))
+      (is (= "{:a 1, :b [2 3]}" (:text (first @captured)))
+          "an undeclared value copies verbatim"))))
+
+(deftest copy-path-is-not-a-value-egress
+  (testing "rf2-uo0rc.2 — the path-copy variant copies only the path
+            vector (key names, no values); it is not a value-egress site
+            and must NOT redact path segments"
+    (registry/register-xray-handlers!)
+    (frame/reg-frame :rf/default {})
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/default (seed-sensitive-schema!))
+    (let [captured (capture-copy!)]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
+        (rf/dispatch-sync [:rf.xray/copy-path-to-clipboard [:auth :password]]))
+      (is (= "[:auth :password]" (:text (first @captured)))
+          "the path vector copies verbatim — it carries no values to elide"))))
+
 ;; ---- (8) view renders — current-state inspector (rf2-okvit) -------------
 ;;
 ;; The app-db tab is a CURRENT-STATE inspector, not a diff. The Panel

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
@@ -799,10 +799,16 @@
       (is (= 7 (:epoch-id (h/focused-epoch-record history nil))))
       (is (= 7 (:epoch-id (h/focused-epoch-record history {:epoch-id nil})))))))
 
-(deftest focused-epoch-record-falls-back-to-head-when-evicted
-  (testing "Focused :epoch-id no longer in the buffer → fall back to head
-            so the panel renders SOMETHING rather than going silent on a
-            buffer-eviction event"
+(deftest focused-epoch-record-nil-when-evicted
+  (testing "rf2-uo0rc.1 — a PINNED focus :epoch-id no longer in the buffer
+            (evicted from the per-frame ring) resolves to nil, NOT a
+            silent head-fallback. Per spec/021 §10.7 every panel renders
+            the evicted placeholder; the Machine Inspector must not show
+            the LATEST machine state while the operator believes they are
+            inspecting the pinned (evicted) epoch. Routes through the
+            shared focus-resolver/find-epoch-record, matching Issues /
+            Trace / Epoch / App-DB."
     (let [history [{:epoch-id 5 :trace-events []}
                    {:epoch-id 7 :trace-events []}]]
-      (is (= 7 (:epoch-id (h/focused-epoch-record history {:epoch-id 99})))))))
+      (is (nil? (h/focused-epoch-record history {:epoch-id 99}))
+          "evicted pinned epoch must be nil (not the head record)"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
@@ -39,11 +39,24 @@
     (let [history [{:epoch-id :a} {:epoch-id :b} {:epoch-id :c}]]
       (is (= {:epoch-id :b} (subs/focused-epoch-record history :b))))))
 
-(deftest focused-epoch-record-falls-back-to-head-when-no-match
-  (testing "Missing :epoch-id (LIVE) or evicted id → head record"
+(deftest focused-epoch-record-nil-focus-falls-back-to-head
+  (testing "NIL :epoch-id (LIVE / cold-start) → head record (rf2-h0120
+            head-fallback — the natural debugging UX)"
     (let [history [{:epoch-id :a} {:epoch-id :b} {:epoch-id :c}]]
-      (is (= {:epoch-id :c} (subs/focused-epoch-record history nil)))
-      (is (= {:epoch-id :c} (subs/focused-epoch-record history :missing))))))
+      (is (= {:epoch-id :c} (subs/focused-epoch-record history nil))))))
+
+(deftest focused-epoch-record-nil-when-evicted
+  (testing "rf2-uo0rc.1 — a PINNED :epoch-id no longer in the buffer
+            (evicted from the per-frame ring) resolves to nil, NOT a
+            silent head-fallback. Per spec/021 §10.7 every panel renders
+            the evicted placeholder; the Views panel must not show the
+            LATEST cascade while the operator believes they are inspecting
+            the pinned (evicted) epoch. Routes through the shared
+            focus-resolver/find-epoch-record, matching Issues / Trace /
+            Epoch / App-DB."
+    (let [history [{:epoch-id :a} {:epoch-id :b} {:epoch-id :c}]]
+      (is (nil? (subs/focused-epoch-record history :missing))
+          "evicted pinned epoch must be nil (not the head record)"))))
 
 (deftest focused-epoch-record-empty-history-nil
   (testing "Empty history returns nil"

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/evicted_epoch_all_panels_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/evicted_epoch_all_panels_cljs_test.cljs
@@ -1,0 +1,190 @@
+(ns day8.re-frame2-xray.panels-e2e.evicted-epoch-all-panels-cljs-test
+  "Cross-panel regression for rf2-uo0rc.1 — spec/021 §10.7 (Evicted-epoch
+  placeholder).
+
+  ## The invariant (spec/021 §10.7, NORMATIVE)
+
+  'When the operator scrubs onto an epoch evicted from the buffer, EVERY
+  edn-inspector in EVERY panel renders the same placeholder: Epoch evicted
+  from buffer.'
+
+  ## The bug
+
+  On a PINNED (RETRO) focus whose epoch had aged out of the per-frame
+  epoch ring, the L4 panels DISAGREED:
+
+    - Issues / Trace / Epoch (shared `focus-resolver/find-epoch-record`)
+      + App-DB Diff (`find-epoch-in-history`) correctly resolved nil →
+      rendered the evicted placeholder.
+    - Machine Inspector (`machine-inspector-helpers/focused-epoch-record`)
+      + Views (`reactive-panel-subs/focused-epoch-record`) SILENTLY FELL
+      BACK TO HEAD → rendered the LATEST machine state / cascade. The
+      operator believed they were inspecting the pinned (evicted) epoch
+      but saw the most-recent state instead — a state-reconstruction lie.
+
+  ## The fix
+
+  Both panel `focused-epoch-record` helpers now route through the shared
+  `panels.shared.focus-resolver/find-epoch-record`, which returns nil for
+  a pinned-but-evicted epoch (preserving only the spec-correct NIL-focus
+  head-fallback). So ALL panels resolve the evicted epoch to nil and
+  render the §10.7 placeholder.
+
+  This test drives the REAL panel composite subs (`:rf.xray/focus` →
+  `compose-focus` RETRO branch + the per-panel projections) over a
+  directly-seeded spine `:focus` + `:epoch-history` so the eviction is
+  deterministic (no ring-depth/timing race). The RETRO `:else` branch of
+  `compose-focus` preserves the pinned `:epoch-id` even when evicted — the
+  exact state §10.7 governs."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.preload :as preload]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- install-xray! []
+  (trace-collector/reset-for-test!)
+  (xray-test-support/reset-all!)
+  (registry/register-xray-handlers!)
+  (preload/register-trace-collector!)
+  (preload/register-epoch-collector!)
+  ;; A tiny test-local seeder for the spine slots the composite subs read.
+  ;; Stamps a RETRO pin on an epoch-id + an epoch-history ring that does
+  ;; NOT contain it — the exact "scrubbed onto an evicted epoch" state.
+  (rf/reg-event-db :test/seed-evicted-pin
+    (fn [db [_ {:keys [pinned-epoch-id history]}]]
+      (-> db
+          (assoc :epoch-history (vec history))
+          (assoc :focus {:mode :retro :epoch-id pinned-epoch-id}))))
+  nil)
+
+(defn- sub-xray [query]
+  (rf/with-frame :rf/xray @(rf/subscribe query)))
+
+(def ^:private evicted-id 1)
+
+;; The surviving ring — the pinned epoch-id (1) is NOT present, i.e. it
+;; has been evicted. Each surviving record is a fully-shaped epoch with a
+;; distinct machine transition + sub-run + render so a HEAD-fallback bug
+;; would surface NON-empty machine / Views data (catching the regression).
+(def ^:private surviving-history
+  [{:epoch-id 7
+    :dispatch-id :d7
+    :event [:counter/inc]
+    :db-before {:counter 6} :db-after {:counter 7}
+    :sub-runs [{:sub-id :counter/value :recomputed? true :value-changed? true}]
+    :renders [{:render-key [:counter-view 0]}]
+    :trace-events [{:operation :rf.machine/transition
+                    :machine-id :traffic-light
+                    :tags {:rf.machine/id :traffic-light}}
+                   {:operation :rf.view/rendered
+                    :tags {:rf.view/id :counter-view
+                           :rf.view/render-key [:counter-view 0]
+                           :rf.view/mount? false
+                           :rf.view/deref-subs [[:counter/value]]}}]}
+   {:epoch-id 9
+    :dispatch-id :d9
+    :event [:counter/inc]
+    :db-before {:counter 7} :db-after {:counter 8}
+    :sub-runs [{:sub-id :counter/value :recomputed? true :value-changed? true}]
+    :renders [{:render-key [:counter-view 0]}]
+    :trace-events [{:operation :rf.machine/transition
+                    :machine-id :traffic-light
+                    :tags {:rf.machine/id :traffic-light}}
+                   {:operation :rf.view/rendered
+                    :tags {:rf.view/id :counter-view
+                           :rf.view/render-key [:counter-view 0]
+                           :rf.view/mount? false
+                           :rf.view/deref-subs [[:counter/value]]}}]}])
+
+(defn- seed-evicted-pin! []
+  (frame/reg-frame :rf/xray {})
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:test/seed-evicted-pin
+                       {:pinned-epoch-id evicted-id
+                        :history surviving-history}]))
+  nil)
+
+(deftest evicted-pin-surfaces-evicted-epoch-id-on-focus
+  (testing "test setup: compose-focus's RETRO branch preserves the pinned
+            (evicted) :epoch-id — the exact state spec/021 §10.7 governs"
+    (install-xray!)
+    (seed-evicted-pin!)
+    (let [focus (sub-xray [:rf.xray/focus])]
+      (is (= :retro (:mode focus)) "pin must be RETRO")
+      (is (= evicted-id (:epoch-id focus))
+          (str "the pinned-but-evicted :epoch-id must survive on :rf.xray/focus "
+               "so the panels' focused-epoch lookup hits the eviction path. "
+               "focus: " (pr-str focus))))))
+
+(deftest evicted-pin-machine-inspector-renders-placeholder
+  (testing "rf2-uo0rc.1 — Machine Inspector resolves an evicted pin to NO
+            transitions (→ blank/evicted placeholder), NOT the latest
+            machine state. Pre-fix it head-fell-back and showed epoch 9's
+            :traffic-light transition."
+    (install-xray!)
+    (seed-evicted-pin!)
+    (let [records (sub-xray [:rf.xray/machine-transitions-for-focused-event])]
+      (is (= [] records)
+          (str "Machine Inspector showed transitions for an EVICTED pinned "
+               "epoch — spec/021 §10.7 violation (head-fallback bug). "
+               "records: " (pr-str records))))))
+
+(deftest evicted-pin-views-panel-renders-placeholder
+  (testing "rf2-uo0rc.1 — Views (reactive-data) resolves an evicted pin to
+            :has-cascade? false (→ empty/evicted placeholder), NOT the
+            latest cascade. Pre-fix it head-fell-back to epoch 9's cascade."
+    (install-xray!)
+    (seed-evicted-pin!)
+    (let [reactive (sub-xray [:rf.xray/reactive-data])]
+      (is (false? (:has-cascade? reactive))
+          (str "Views showed a cascade for an EVICTED pinned epoch — "
+               "spec/021 §10.7 violation (head-fallback bug). "
+               "reactive: " (pr-str (select-keys reactive
+                                                 [:has-cascade? :epoch-id]))))
+      (is (empty? (:subs-ran reactive))
+          "Views projected sub-runs from the head record on an evicted pin")
+      (is (empty? (:view-rows reactive))
+          "Views projected view-rows from the head record on an evicted pin"))))
+
+(deftest evicted-pin-all-panels-agree-on-placeholder
+  (testing "rf2-uo0rc.1 / spec/021 §10.7 — EVERY focus-scoped panel renders
+            the evicted placeholder for a pinned-evicted epoch; NONE shows
+            HEAD. This is the cross-panel agreement the bug broke (two
+            panels silently showed latest state while four showed evicted)."
+    (install-xray!)
+    (seed-evicted-pin!)
+    (let [trace     (sub-xray [:rf.xray/trace-feed])
+          epoch     (sub-xray [:rf.xray/epoch-pipeline])
+          issues    (sub-xray [:rf.xray/issues-ribbon])
+          app-db    (sub-xray [:rf.xray/selected-epoch-record])
+          machine   (sub-xray [:rf.xray/machine-transitions-for-focused-event])
+          reactive  (sub-xray [:rf.xray/reactive-data])]
+      ;; Already-correct panels (regression-guard they STAY correct).
+      (is (= :epoch-evicted (:empty-kind trace))
+          (str "Trace feed must report :epoch-evicted. trace: "
+               (pr-str (select-keys trace [:empty-kind :epoch-id]))))
+      (is (= :epoch-evicted (:status epoch))
+          (str "Epoch panel must report :epoch-evicted. epoch: "
+               (pr-str (select-keys epoch [:status :epoch-id]))))
+      (is (= :epoch-evicted (:empty-kind issues))
+          (str "Issues ribbon must report :epoch-evicted. issues: "
+               (pr-str (select-keys issues [:empty-kind]))))
+      (is (nil? app-db)
+          "App-DB Diff must resolve no record for an evicted pin")
+      ;; The two panels the fix corrects.
+      (is (= [] machine)
+          "Machine Inspector must resolve no transitions for an evicted pin")
+      (is (false? (:has-cascade? reactive))
+          "Views must report :has-cascade? false for an evicted pin")
+      ;; The headline invariant: NOT ONE panel surfaced the HEAD epoch (9).
+      (is (not= 9 (:epoch-id trace)) "Trace leaked the HEAD epoch")
+      (is (not= 9 (:epoch-id epoch)) "Epoch panel leaked the HEAD epoch")
+      (is (not= 9 (:epoch-id reactive)) "Views leaked the HEAD epoch"))))


### PR DESCRIPTION
Two P2 correctness defects from the tools/xray correctness re-review (parent rf2-uo0rc).

## rf2-uo0rc.1 — evicted-epoch placeholder (spec/021 §10.7)

On an EVICTED-epoch focus (operator pinned an epoch, then enough cascades arrived to evict it from the per-frame ring), the Machine Inspector + Views panels **silently fell back to the HEAD epoch** and rendered the latest machine state / cascade — while Issues / Trace / Epoch / App-DB correctly rendered the evicted placeholder. spec/021 §10.7 is normative: *every* panel renders the evicted placeholder.

**Fix:** both panel `focused-epoch-record` helpers now route through the shared `panels.shared.focus-resolver/find-epoch-record`, which returns `nil` on eviction (preserving only the spec-correct **nil-focus** head-fallback). All six focus-scoped panels now agree.

- `machine_inspector_helpers/focused-epoch-record` (cljc) → delegates to shared resolver
- `reactive_panel_subs/focused-epoch-record` (cljs) → delegates to shared resolver
- No spec change needed — §10.7 already mandates this; the code is catching up.

## rf2-uo0rc.2 — clipboard copy fx is an off-box egress site

`:rf.xray/copy-value-to-clipboard` wrote raw `(pr-str value)` to the system clipboard (an off-box sink) **without** `runtime/egress-value` — the exact class already fixed for the palette snapshot (rf2-mxzgg) + get-app-db (rf2-a96xq). A `{:sensitive? true}` slot or a large blob copied verbatim.

**Fix:** the value-copy event now routes the value through `runtime/egress-value` before the clipboard write, pinned to the **observed** frame (`[:focus :frame]` ⇒ `:target-frame`) so that frame's schema declarations govern — sensitive ⇒ `:rf/redacted`, large ⇒ `:rf.size/large-elided`, fail-closed. The path-copy variant copies only key names (no values) and is untouched.

## Regressions added

- `evicted_epoch_all_panels_cljs_test` — focus-pin an evicted epoch ⇒ every panel renders the placeholder, none shows HEAD.
- `app_db_diff_cljs_test` — sensitive value copied ⇒ elided; large value ⇒ size-elided; undeclared value ⇒ verbatim; path copy ⇒ not elided.
- Existing `machine_inspector_helpers` + `reactive_panel_subs` eviction tests flipped from head-fallback to nil-on-eviction.

## Spec currency

- `spec/API.md` §Privacy egress names the clipboard copy fx as an off-box egress site (previously only the palette snapshot + runtime accessors).
- `spec/014-Registry-Catalogue` updates the stale `:rf.xray/copy-value-to-clipboard` row.

## Gates (all green, cold worktree)

- `clojure -M:test` (xray JVM): 1101 tests, 0 failures
- `npm run test:cljs`: 5697 tests / 19867 assertions, 0 failures
- `npm run test:xray-feature-gate`: 16 scenarios, 0 failures