### PR TITLE
fix(test-quiet): derive failure banner ns from the failing var (rf2-8n97n.1/.2/.3)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet.cljc
+++ b/implementation/test-quiet/src/re_frame/test_quiet.cljc
@@ -52,56 +52,117 @@
 
   Reload-friendly: dropping the `defmethod` overrides at the top of the
   test runtime is fine.  The methods close over the namespace's
-  per-thread atom (`*ns-banner-state*`), which is reset on each
-  `:begin-test-ns`."
+  `printed-banners` atom (a set of namespaces whose banner has already
+  been flushed), which the failure path consults and grows.
+
+  Nested-run correctness (rf2-8n97n.1 / .2): the banner namespace is
+  derived from the FAILING var's metadata at `:fail` / `:error` time,
+  NOT from a single mutable \"current ns\" cell.  A nested
+  `run-tests` called from inside a `deftest` fires its own
+  `:begin-test-ns`; with a single-cell design that clobbers the
+  \"current ns\" to the inner namespace, so a subsequent outer failure
+  is mislabelled (prints the inner ns banner) or — once the inner run
+  flushed its banner — orphaned (no banner at all).  Reading the ns off
+  the var that actually failed makes the banner always match the
+  failure, regardless of nesting."
   (:require
     #?(:clj  [clojure.test]
        :cljs [cljs.test])
     #?(:clj  [clojure.stacktrace])))
 
 ;; ----------------------------------------------------------------------
-;; Per-thread banner state.
+;; Banner state.
 ;;
 ;; A `clojure.test/run-tests` (or `cljs.test/run-tests`) call walks
-;; namespaces serially on the calling thread.  Holding banner state in
-;; a thread-local atom is sufficient for sequential drivers (every
-;; canonical test runner — cognitect-test-runner, shadow.test.node,
-;; shadow.test.browser — is single-threaded on the reporter callback);
-;; we don't need a dynamic var.  A plain atom is fine on the JVM since
-;; the multi-method body runs on the test-driver thread.  Under CLJS
-;; the single-threaded runtime makes the atom trivially safe.
+;; namespaces serially on the calling thread.  Every canonical test
+;; runner — cognitect-test-runner, shadow.test.node, shadow.test.browser
+;; — is single-threaded on the reporter callback, so a plain atom is
+;; sufficient: on the JVM the multi-method body runs on the test-driver
+;; thread, and under CLJS the single-threaded runtime makes it trivially
+;; safe.
 ;;
-;; Shape: {:ns <symbol> :banner-printed? <bool>}.  Reset on each
-;; :begin-test-ns; consulted on each :fail / :error.
+;; We DON'T track a single mutable "current ns" cell — that is the source
+;; of the nested-run mislabel / orphan bugs (rf2-8n97n.1 / .2), because a
+;; nested run's `:begin-test-ns` clobbers it.  Instead we record the SET
+;; of namespaces whose banner has already been flushed, and derive the
+;; namespace to flush from the failing var itself (see `failing-ns`).
+;;
+;; The set is cleared when an OUTERMOST namespace is entered (ns-depth 0
+;; at `:begin-test-ns`) so a fresh `run-tests` — or the next sibling ns
+;; within one run — re-flushes banners.  A NESTED run's `:begin-test-ns`
+;; fires while the outer ns is still open (ns-depth >= 1), so it does NOT
+;; clear: the outer run's already-printed banners stay suppressed while
+;; the inner ns can still print its own.  `:begin-test-ns`/`:end-test-ns`
+;; are balanced per ns and never nested for sibling nses, so the depth
+;; counter rises above 0 only across a nested run-tests boundary.
 
-(def ^:private banner-state
-  (atom {:ns nil :banner-printed? false}))
+(def ^:private printed-banners
+  (atom #{}))
 
-(defn- reset-ns-banner!
-  [ns-sym]
-  (reset! banner-state {:ns ns-sym :banner-printed? false}))
+(def ^:private ns-depth
+  (atom 0))
 
-(defn- ensure-banner-printed!
+(defn- on-begin-test-ns!
+  "Track nesting depth and clear the printed-banner set on entry to an
+  outermost namespace so each top-level run (and each sibling ns within
+  it) re-flushes its banner.  Nested-run entries (depth >= 1) preserve
+  the outer run's printed set."
   []
-  (let [{:keys [ns banner-printed?]} @banner-state]
-    (when (and ns (not banner-printed?))
-      (println)
-      (println "Testing" (name ns))
-      (swap! banner-state assoc :banner-printed? true))))
+  (when (zero? @ns-depth)
+    (reset! printed-banners #{}))
+  (swap! ns-depth inc))
+
+(defn- on-end-test-ns!
+  []
+  (swap! ns-depth (fn [d] (max 0 (dec d)))))
+
+(defn- ns-banner-printed?
+  [ns-sym]
+  (contains? @printed-banners ns-sym))
+
+(defn- mark-ns-printed!
+  [ns-sym]
+  (swap! printed-banners conj ns-sym))
+
+(defn- print-banner!
+  "Flush the `Testing <ns>` banner for `ns-sym` exactly once.  No-op if
+  `ns-sym` is nil or its banner was already printed."
+  [ns-sym]
+  (when (and ns-sym (not (ns-banner-printed? ns-sym)))
+    (println)
+    (println "Testing" (name ns-sym))
+    (mark-ns-printed! ns-sym)))
 
 ;; ----------------------------------------------------------------------
 ;; JVM overrides — clojure.test/report dispatches on (:type m).
 
 #?(:clj
+   (defn- failing-ns
+     "The namespace symbol of the var that is currently failing/erroring,
+     read off `clojure.test/*testing-vars*` (the same stack
+     `testing-vars-str` renders).  Returns nil if no var is in scope.
+
+     This is what makes the banner nesting-correct: it is derived from
+     the var that actually failed, so a nested run-tests can never
+     mislabel or orphan the outer failure's banner (rf2-8n97n.1 / .2)."
+     []
+     (when-let [v (first clojure.test/*testing-vars*)]
+       (when-let [ns (:ns (meta v))]
+         (ns-name ns)))))
+
+#?(:clj
    (do
-     (defmethod clojure.test/report :begin-test-ns [m]
+     (defmethod clojure.test/report :begin-test-ns [_m]
        ;; Default behaviour prints "\nTesting <ns>"; we suppress and
-       ;; defer to ensure-banner-printed! on first failure/error.
-       (reset-ns-banner! (ns-name (:ns m))))
+       ;; defer to print-banner! on first failure/error.  The banner ns
+       ;; is derived from the failing var (failing-ns), not from this
+       ;; event, so a nested run-tests can't clobber it — here we only
+       ;; track nesting depth + clear the printed-banner set on an
+       ;; outermost entry.
+       (on-begin-test-ns!))
 
      (defmethod clojure.test/report :end-test-ns [_m]
-       ;; No-op (also the default).
-       )
+       (on-end-test-ns!))
 
      (defmethod clojure.test/report :begin-test-var [_m]
        ;; No-op (also the default).
@@ -113,7 +174,7 @@
 
      (defmethod clojure.test/report :fail [m]
        (clojure.test/with-test-out
-         (ensure-banner-printed!)
+         (print-banner! (failing-ns))
          (clojure.test/inc-report-counter :fail)
          (println "\nFAIL in" (clojure.test/testing-vars-str m))
          (when (seq clojure.test/*testing-contexts*)
@@ -124,7 +185,7 @@
 
      (defmethod clojure.test/report :error [m]
        (clojure.test/with-test-out
-         (ensure-banner-printed!)
+         (print-banner! (failing-ns))
          (clojure.test/inc-report-counter :error)
          (println "\nERROR in" (clojure.test/testing-vars-str m))
          (when (seq clojure.test/*testing-contexts*)
@@ -142,13 +203,28 @@
 ;; [(:reporter env) (:type m)] with default ::cljs.test/default.
 
 #?(:cljs
+   (defn- failing-ns
+     "The namespace symbol of the var currently failing/erroring, read
+     off the env's `:testing-vars` stack (the same stack
+     `testing-vars-str` renders).  Derived from the var that actually
+     failed so a nested run-tests can't mislabel/orphan the outer
+     banner (rf2-8n97n.1 / .2).  Returns nil if no var is in scope."
+     []
+     (when-let [v (first (:testing-vars (cljs.test/get-current-env)))]
+       (let [ns (:ns (meta v))]
+         (when ns (symbol (name ns)))))))
+
+#?(:cljs
    (do
-     (defmethod cljs.test/report [:cljs.test/default :begin-test-ns] [m]
-       (reset-ns-banner! (:ns m)))
+     (defmethod cljs.test/report [:cljs.test/default :begin-test-ns] [_m]
+       ;; Suppress the default "Testing <ns>"; defer to print-banner! on
+       ;; first failure/error (banner ns derived from the failing var,
+       ;; not this event).  Here we only track nesting depth + clear the
+       ;; printed-banner set on an outermost entry.
+       (on-begin-test-ns!))
 
      (defmethod cljs.test/report [:cljs.test/default :end-test-ns] [_m]
-       ;; No-op (also the default).
-       )
+       (on-end-test-ns!))
 
      (defmethod cljs.test/report [:cljs.test/default :begin-test-var] [_m]
        ;; No-op (also the default).
@@ -159,7 +235,7 @@
        )
 
      (defmethod cljs.test/report [:cljs.test/default :fail] [m]
-       (ensure-banner-printed!)
+       (print-banner! (failing-ns))
        (cljs.test/inc-report-counter! :fail)
        (println "\nFAIL in" (cljs.test/testing-vars-str m))
        (when (seq (:testing-contexts (cljs.test/get-current-env)))
@@ -170,7 +246,7 @@
          (println "  actual:" (formatter-fn (:actual m)))))
 
      (defmethod cljs.test/report [:cljs.test/default :error] [m]
-       (ensure-banner-printed!)
+       (print-banner! (failing-ns))
        (cljs.test/inc-report-counter! :error)
        (println "\nERROR in" (cljs.test/testing-vars-str m))
        (when (seq (:testing-contexts (cljs.test/get-current-env)))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -57,6 +57,17 @@
                "            [re-frame.test-quiet]))\n"
                body "\n"))))
 
+(defn- write-raw-fixture!
+  "Write `source` verbatim as `probe/<file-stem>.clj` into `dir`.  Unlike
+  `write-fixture!` this does NOT inject a fixed ns form, so the caller can
+  control the ns name (e.g. a non-`*-test` inner suite the default
+  discovery regex skips) and the require set (e.g. a nested `run-tests`
+  over a sibling ns).  Used by the nested-run banner/tally regressions."
+  [^java.io.File dir file-stem source]
+  (let [pkg-dir (io/file dir "probe")]
+    (.mkdirs pkg-dir)
+    (spit (io/file pkg-dir (str file-stem ".clj")) (str source "\n"))))
+
 (defn- run-runner
   "Relaunch a fresh JVM that runs `re-frame.test-quiet.runner/-main` with
   `extra-args`, putting `fixture-dir` on both the classpath and the
@@ -166,3 +177,179 @@
           (is (not (str/includes? out discovery-banner-marker))
               (str "the discovery banner must be swallowed on error too;"
                    " captured stdout:\n" out)))))))
+
+;; ----------------------------------------------------------------------
+;; Nested-run banner correctness — rf2-8n97n.1 (mislabel) + .2 (orphan).
+;;
+;; A `deftest` that nests a `run-tests` over a sibling namespace and then
+;; fails must still print `Testing <OUTER-ns>` above its own FAIL block.
+;; Pre-fix, a single mutable "current ns" cell — clobbered by the nested
+;; run's `:begin-test-ns` — produced one of two broken outputs:
+;;   .1 MISLABEL: the OUTER failure printed under `Testing <INNER-ns>`;
+;;   .2 ORPHAN:   when the nested run was itself RED, the inner :fail set
+;;                the printed-flag, so the OUTER failure printed with NO
+;;                banner at all.
+;; The fix derives the banner ns from the FAILING var's metadata, so the
+;; banner always matches the var that failed regardless of nesting.
+;;
+;; These run through the REAL `-main` with source-ordered real deftest
+;; vars (the inner suite nests BEFORE the outer assertion in source
+;; order), so they are immune to the ns-interns hashmap-ordering artifact
+;; that made an earlier ad-hoc repro look "correct".  The inner suite is
+;; named `*-suite` (not `*-test`) so cognitect's default discovery skips
+;; it as a top-level ns — it is exercised only via the outer's nested
+;; `run-tests` — and the run is pinned to the outer ns with `-n`.
+
+(deftest nested-green-then-outer-fail-banner
+  (testing "outer fail after a GREEN nested run names the OUTER ns (rf2-8n97n.1)"
+    (with-fixture-dir
+      (fn [dir]
+        (write-raw-fixture! dir "nested_green_inner_suite"
+          (str "(ns probe.nested-green-inner-suite\n"
+               "  (:require [clojure.test :refer [deftest is]]\n"
+               "            [re-frame.test-quiet]))\n"
+               "(deftest inner-passes (is (= 1 1)))"))
+        (write-raw-fixture! dir "nested_green_outer_test"
+          (str "(ns probe.nested-green-outer-test\n"
+               "  (:require [clojure.test :refer [deftest is run-tests]]\n"
+               "            [re-frame.test-quiet]\n"
+               "            [probe.nested-green-inner-suite]))\n"
+               "(deftest outer-fails-after-green\n"
+               "  (run-tests 'probe.nested-green-inner-suite)\n"
+               "  (is (= :outer-exp :outer-act)))"))
+        (let [{:keys [exit out err]}
+              (run-runner dir "-n" "probe.nested-green-outer-test")]
+          (is (= 1 exit)
+              (str "outer fail must exit 1; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "FAIL in (outer-fails-after-green)")
+              (str "the outer FAIL block must reach stdout; got:\n" out))
+          ;; The CORE of rf2-8n97n.1: the banner above the OUTER failure
+          ;; must name the OUTER ns, not the inner one the nested run
+          ;; entered last.
+          (is (str/includes? out "Testing probe.nested-green-outer-test")
+              (str "the outer FAIL must carry its OWN ns banner"
+                   " (rf2-8n97n.1 mislabel); got:\n" out))
+          (is (not (str/includes? out "Testing probe.nested-green-inner-suite"))
+              (str "a GREEN nested run must stay silent — its inner ns"
+                   " banner must NOT appear (and must not be borrowed by"
+                   " the outer failure); got:\n" out)))))))
+
+(deftest nested-red-then-outer-fail-banner
+  (testing "outer fail after a RED nested run keeps BOTH banners correct (rf2-8n97n.2)"
+    (with-fixture-dir
+      (fn [dir]
+        (write-raw-fixture! dir "nested_red_inner_suite"
+          (str "(ns probe.nested-red-inner-suite\n"
+               "  (:require [clojure.test :refer [deftest is]]\n"
+               "            [re-frame.test-quiet]))\n"
+               "(deftest inner-fails (is (= :inner-exp :inner-act)))"))
+        (write-raw-fixture! dir "nested_red_outer_test"
+          (str "(ns probe.nested-red-outer-test\n"
+               "  (:require [clojure.test :refer [deftest is run-tests]]\n"
+               "            [re-frame.test-quiet]\n"
+               "            [probe.nested-red-inner-suite]))\n"
+               "(deftest outer-fails-after-red\n"
+               "  (run-tests 'probe.nested-red-inner-suite)\n"
+               "  (is (= :outer-exp :outer-act)))"))
+        (let [{:keys [exit out err]}
+              (run-runner dir "-n" "probe.nested-red-outer-test")]
+          (is (= 1 exit)
+              (str "outer fail must exit 1; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          ;; Both failures must be visible AND each must carry its own
+          ;; correct banner.
+          (is (str/includes? out "Testing probe.nested-red-inner-suite")
+              (str "the RED inner run must flush its OWN ns banner; got:\n" out))
+          ;; The inner FAIL renders the full nested var stack
+          ;; `(outer-fails-after-red inner-fails)` because the inner var
+          ;; runs inside the outer var's dynamic scope — `inner-fails` is
+          ;; the innermost name, which is what `(first *testing-vars*)`
+          ;; reads for the banner ns.
+          (is (str/includes? out "inner-fails) (nested_red_inner_suite.clj")
+              (str "the inner FAIL block must reach stdout; got:\n" out))
+          ;; The CORE of rf2-8n97n.2: pre-fix the inner :fail set the
+          ;; printed-flag, orphaning the outer failure (NO banner). The
+          ;; outer FAIL must now carry its OWN ns banner.
+          (is (str/includes? out "Testing probe.nested-red-outer-test")
+              (str "the outer FAIL must carry its OWN ns banner, not be"
+                   " orphaned (rf2-8n97n.2); got:\n" out))
+          (is (str/includes? out "FAIL in (outer-fails-after-red)")
+              (str "the outer FAIL block must reach stdout; got:\n" out))
+          ;; Order pin: the outer banner appears AFTER the inner FAIL
+          ;; block, i.e. it is the OUTER failure's own heading, not the
+          ;; inner one mislabelled.
+          (is (< (.indexOf out "nested_red_inner_suite.clj")
+                 (.indexOf out "Testing probe.nested-red-outer-test"))
+              (str "the outer banner must follow the inner FAIL (it heads"
+                   " the OUTER failure, not the inner); got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
+;; Nested-run failure-tally + exit-code soundness — rf2-8n97n.3.
+;;
+;; The behaviour is currently SOUND (the quiet layer never overrides
+;; :summary/:pass and counts :fail/:error exactly once); this pins it so a
+;; future change — overriding :summary, sharing a counter, hoisting banner
+;; handling into the counter path — can't silently turn an outer failure
+;; into a false GREEN, or leak an inner-ignored failure into the outer
+;; tally. cognitect computes the exit code from the outer summary's
+;; fail+error, so asserting BOTH the exit code AND the summary text pins
+;; the whole propagation path.
+
+(deftest nested-green-outer-fail-is-counted
+  (testing "an outer FAIL after a GREEN nested run propagates to summary + exit 1 (rf2-8n97n.3a)"
+    (with-fixture-dir
+      (fn [dir]
+        (write-raw-fixture! dir "tally_green_inner_suite"
+          (str "(ns probe.tally-green-inner-suite\n"
+               "  (:require [clojure.test :refer [deftest is]]\n"
+               "            [re-frame.test-quiet]))\n"
+               "(deftest inner-passes (is (= 1 1)))"))
+        (write-raw-fixture! dir "tally_green_outer_test"
+          (str "(ns probe.tally-green-outer-test\n"
+               "  (:require [clojure.test :refer [deftest is run-tests]]\n"
+               "            [re-frame.test-quiet]\n"
+               "            [probe.tally-green-inner-suite]))\n"
+               "(deftest outer-fails-after-green\n"
+               "  (run-tests 'probe.tally-green-inner-suite)\n"
+               "  (is (= :outer-exp :outer-act)))"))
+        (let [{:keys [exit out err]}
+              (run-runner dir "-n" "probe.tally-green-outer-test")]
+          (is (= 1 exit)
+              (str "the outer failure MUST drive exit 1 — a regression that"
+                   " dropped it would be a false GREEN; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "1 failures, 0 errors.")
+              (str "the OUTER summary must count exactly the outer failure"
+                   " (the green nested run adds nothing); got:\n" out)))))))
+
+(deftest nested-inner-fail-does-not-leak-to-outer
+  (testing "an inner FAIL the outer IGNORES does not leak into the outer tally/exit (rf2-8n97n.3b)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; The outer deftest nests a RED run but makes NO failing
+        ;; assertion of its own. clojure.test scopes *report-counters*
+        ;; per test-ns, so the inner failure is confined to the nested
+        ;; run's summary and must NOT appear in the outer run's tally.
+        (write-raw-fixture! dir "scope_red_inner_suite"
+          (str "(ns probe.scope-red-inner-suite\n"
+               "  (:require [clojure.test :refer [deftest is]]\n"
+               "            [re-frame.test-quiet]))\n"
+               "(deftest inner-fails (is (= :inner-exp :inner-act)))"))
+        (write-raw-fixture! dir "scope_red_outer_test"
+          (str "(ns probe.scope-red-outer-test\n"
+               "  (:require [clojure.test :refer [deftest is run-tests]]\n"
+               "            [re-frame.test-quiet]\n"
+               "            [probe.scope-red-inner-suite]))\n"
+               "(deftest outer-ignores-inner-failure\n"
+               "  (run-tests 'probe.scope-red-inner-suite)\n"
+               "  (is (= 1 1)))"))
+        (let [{:keys [exit out err]}
+              (run-runner dir "-n" "probe.scope-red-outer-test")]
+          (is (zero? exit)
+              (str "the outer run is green — the inner failure the outer"
+                   " ignores must NOT leak into the exit code; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "0 failures, 0 errors.")
+              (str "the OUTER summary must stay clean — the scoped inner"
+                   " failure must not leak into it; got:\n" out)))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -21,7 +21,19 @@
    - console.warn CAPTURE COMPAT: the ns-load `console.warn` stub does
      not break the local save/shim/restore capture pattern that
      warning-assertion tests use — a shim installed over the stub still
-     records, and restore reverts to the stub."
+     records, and restore reverts to the stub.
+
+  NESTED-RUN BANNER (rf2-8n97n.1/.2) — JVM-ONLY SCOPE: the nested-run
+  banner-correctness regressions live in the JVM
+  `re-frame.test-quiet-runner-contract-test`, not here.  A nested
+  `cljs.test/run-tests` cannot be exercised in-process under this
+  runner: `run-tests` is block-based/async and unconditionally fires
+  `:end-run-tests`, which shadow-node overrides to `js/process.exit`
+  (see `end-run-tests-exit-decision` above) — a nested run would tear
+  down the node runner before the outer assertion. The FIX is shared
+  CLJC (the banner ns is derived from the failing var's metadata, not a
+  clobberable global cell), so the CLJS reporter benefits identically
+  for sequential runs; only the nesting REGRESSION is JVM-scoped."
   ;; NB: must NOT require re-frame.test-quiet.shadow-node — that ns is
   ;; `:dev/always` and expands the test-ns-enumeration macro, so a test
   ;; requiring it forms a compile cycle. Pure CLI parsing lives in the


### PR DESCRIPTION
## What

The `re-frame.test-quiet` quiet reporter held a single mutable `{:ns :banner-printed?}` cell that every `:begin-test-ns` reset. A nested `run-tests` called from inside a `deftest` fired its own `:begin-test-ns`, clobbering the cell to the inner ns — so a subsequent **outer** failure was either:

- **mislabelled** — printed under `Testing <inner-ns>` (rf2-8n97n.1), or
- **orphaned** — once a RED nested run set the printed-flag, the outer failure printed with NO banner at all (rf2-8n97n.2).

The summary tally and exit code were already sound (verified by the reviewer); these were **diagnostic-correctness** defects that mis-pointed triage at the wrong namespace. A reusable test-reporter library mis-teaching every consumer about WHERE a failure occurred is a real correctness bug.

## Fix

Derive the banner namespace from the **failing var's metadata** (`(first clojure.test/*testing-vars*)` on JVM, env `:testing-vars` on CLJS) at `:fail`/`:error` time — the same stack `testing-vars-str` renders — so the banner always matches the var that actually failed, regardless of nesting. This is exactly the (commented-out) namespace source upstream `clojure.test` documents.

Banner-once suppression now uses a **set of printed namespaces**, cleared on entry to an *outermost* namespace (tracked via a `:begin-test-ns`/`:end-test-ns` depth counter, which rises above 0 only across a nested-run boundary). A nested run therefore preserves the outer run's already-printed banners while still flushing its own. The fix is shared CLJC, so both the JVM and CLJS reporters benefit identically.

## Regressions (rf2-8n97n.3 + acceptance for .1/.2)

JVM subprocess tests through the **real `-main`** with **source-ordered real `deftest` vars** (immune to the ns-interns hashmap-ordering artifact that made an earlier ad-hoc repro look "correct"):

- `nested-green-then-outer-fail-banner` — outer fail after a GREEN nested run names the **outer** ns (.1).
- `nested-red-then-outer-fail-banner` — outer fail after a RED nested run keeps **both** banners correct, outer banner ordered after the inner block (.2).
- `nested-green-outer-fail-is-counted` — outer FAIL after a green nested run drives exit 1 + `1 failures` in the outer summary (.3a).
- `nested-inner-fail-does-not-leak-to-outer` — a scoped inner failure the outer ignores stays out of the outer tally/exit (.3b).

Verified the two banner regressions go **RED pre-fix** (reproducing the mislabel + orphan) and **GREEN post-fix**; the two tally regressions are green on both (they pin sound behaviour against future false-green regressions).

Nested `cljs.test/run-tests` is unsupported under the shadow node-test runner (`run-tests` is block-based/async and unconditionally fires `:end-run-tests` → `js/process.exit`), so the nesting regression is JVM-scoped; documented in the CLJS contract-test ns docstring.

## Gates (cold)

- `clojure -M:test` (test-quiet JVM): **9 tests / 30 assertions, 0 failures**.
- `npm run test:cljs` (consolidated node-test): **5688 tests / 19843 assertions, 0 failures** — confirms the CLJC change compiles and the green path is unchanged across the whole suite.

Closes rf2-8n97n.1, rf2-8n97n.2, rf2-8n97n.3.