### PR TITLE
fix(skills/re-frame2-xray): correct launch/config contract drift (rf2-3ppsg.1/.2/.3 + rf2-4d94j.1)

### DIFF
--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -4,7 +4,7 @@
 
 `re-frame2-xray` is a Claude Code **tour skill** for [Xray](https://github.com/day8/re-frame2/tree/main/tools/xray) — the re-frame2 in-app devtools panel. It answers three questions, and only three:
 
-1. **How do I launch Xray?** — the inline panel, the pop-out, the programmatic `init!`, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
+1. **How do I launch Xray?** — the inline panel, the overlay fallback (`open-overlay!`, for hosts that can't give Xray a layout column), the pop-out, the programmatic `init!`, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
 2. **Which tab shows X?** — a one-line purpose for each tab across both modes: the 6 Dynamic event-spine tabs (Epoch · app-db · Views · Trace · Machine · Routes) and the 5 Static registry-browse tabs.
 3. **What's the chrome around the tabs for?** — the first-screen navigation primitives: time-travel inspect / `Reset`-rewind, the filter-pill cluster, the command palette, and the Settings popup.
 
@@ -19,7 +19,7 @@ Xray is the **human-facing** panel; for an AI agent surface against the running 
 ## Repo contents
 
 - `SKILL.md` — the skill itself
-- `references/launch-modes.md` — full launch-mode decision tree (preload vs `init!`, suppress-auto-open, `:rf.xray/layout-host-selector`, host-CSS-variable resize, pop-out lifecycle, wired hotkeys)
+- `references/launch-modes.md` — full launch-mode decision tree (preload vs `init!`, suppress-auto-open, `:rf.xray/layout-host-selector`, host-CSS-variable resize, the `open-overlay!` no-layout-host fallback, pop-out lifecycle, wired hotkeys)
 - `references/panels.md` — the full tab tour in depth (6 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance)
 - `references/shared-components.md` — the components every L4 panel reuses (`edn-inspector/render-node`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
 - `evals/evals.json` — trigger-eval fixtures (should-trigger + should-not-trigger entries, per skill-creator's description-optimisation contract)

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -115,12 +115,14 @@ panel; re-frame2-pair-mcp is the AI-facing surface.
 
 ## Launching Xray — pick a mode
 
-Three launch modes ship today. Pick the one that matches the user's
-situation.
+Four launch surfaces ship today (one mount facade with three open verbs
+— inline / overlay / window — plus the programmatic `init!`). Pick the
+one that matches the user's situation.
 
 | User wants to … | Use | How |
 |---|---|---|
 | Inspect the runtime while developing locally | **Default true-inline panel** | Add the preload + a `[data-rf-xray-host]` column in the app layout. Xray auto-opens on page load. |
+| Mount where the host can't give Xray a layout column (full-screen canvas, story-only / prototype host, no `[data-rf-xray-host]`) | **Overlay (fallback)** | `(xray/open-overlay!)` from CLJS, or `window.day8.re_frame2_xray.open_overlay_BANG_()` from devtools. Floats the shell above the host under `document.body` — no layout column needed. The supported fallback for hosts that can't accommodate a right column; **not** the default path (per `spec/011-Launch-Modes.md` + `spec/API.md` §rf2-sa4fr). |
 | Put Xray on a second monitor with the app full-screen | **Pop-out window** | `(xray/popout!)` from CLJS, or `window.day8.re_frame2_xray.popout_BANG_()` (call it — note the parens) from devtools. |
 | Mount Xray from code (no preload, or alternative wiring) | **Programmatic `init!`** | Call `(xray/init! opts)` after `rf/init!`. Idempotent. |
 | Browse what's *registered* instead of one dispatch | **Static mode** | Flip the L1 mode pill or press `Cmd/Ctrl+Shift+M`. Static drops the event spine and shows the 5 registry-browse tabs. |
@@ -129,7 +131,8 @@ situation.
 
 For the decision tree in depth (preload vs `init!`, suppress-auto-open
 on tool-only pages, the `:rf.xray/layout-host-selector` knob, host-CSS-variable
-resize, pop-out lifecycle), see [`references/launch-modes.md`](references/launch-modes.md).
+resize, the `open-overlay!` no-layout-host fallback, pop-out lifecycle),
+see [`references/launch-modes.md`](references/launch-modes.md).
 
 ### Wired hotkeys
 
@@ -203,8 +206,12 @@ it.
  depth / trace-buffer keep, and app-db diff thresholds. (The Theme tab
  was removed, rf2-ou3pn — the ribbon theme icon is canonical; the Filters
  tab was removed, rf2-wknb3 — filter UI lives on the L1.5 events ribbon.)
- This runtime popup (not `init!` opts) is where `:density` / buffer-depth
- actually get tuned. Source
+ Two layers tune `:density` / buffer-depth: `init!` (and `configure!`) set
+ the **boot-time defaults** for `:theme` / `:density` / `:buffer-depths` —
+ each supplied opt is written to the persisted Settings shape and applied
+ immediately at boot (no reload); this runtime popup is the **runtime
+ user-mutable override** layer on top. Merge order is `defaults <`
+ `configure! < Settings` (rf2-g2a5v). Source
  [`settings/view.cljs`](../../tools/xray/src/day8/re_frame2_xray/settings/view.cljs).
 - **Sharing state with a teammate.** The Share-URL affordance (button +
  modal + `share.cljs` infra) and the per-cascade EDN export were
@@ -232,9 +239,11 @@ it.
  command's default. Source
  [`palette/sources.cljc`](../../tools/xray/src/day8/re_frame2_xray/palette/sources.cljc)
  (`:snapshot-app-db` command).
- *(Status: per rf2-6fgob the palette command is being routed through this
- safe projection; this skill describes the contract the share path MUST
- honour, so it never teaches a raw off-box share even mid-fix.)*
+ *(Status: shipped. The palette command routes the snapshot through
+ `runtime/egress-value` by default — sensitive ⇒ `:rf/redacted`, large ⇒
+ `:rf.size/large-elided`, pinned to the focused frame, fail-closed, no
+ command-level raw opt-in (rf2-mxzgg, PR #3155). The contract prose above
+ is what the share path honours today, not an in-flight target.)*
 
 ---
 

--- a/skills/re-frame2-xray/references/launch-modes.md
+++ b/skills/re-frame2-xray/references/launch-modes.md
@@ -26,15 +26,17 @@ Is the host app's dev build running with the Xray preload? ── no ──► �
  inline host on page load. diagnostic (console.error +
  Toggle with Ctrl+Shift+C. window.day8.re_frame2_xray.status)
  │ │
- ▼ ▼
- Need a second monitor? §Layout host contract (add the column)
- │
- yes
- │
- ▼
- (xray/popout!) — same-origin
- second window, reads the
- opener's runtime atoms directly.
+ ▼ ┌────────────┴────────────┐
+ Need a second monitor? Can the host give Xray a layout column?
+ │ │
+ yes ┌─────────┴─────────┐
+ │ yes no
+ ▼ │ │
+ (xray/popout!) — same-origin ▼ ▼
+ second window, reads the §Layout host §Overlay fallback
+ opener's runtime atoms directly. contract (open-overlay!) —
+ (add the column) floats above the host,
+ no column needed.
 ```
 
 ## Install the preload
@@ -152,6 +154,37 @@ App dev pages should keep the default `true` posture and provide
 :closure-defines {re-frame.interop/debug-enabled? false}
 ```
 
+## Overlay fallback (open-overlay!)
+
+For hosts that **cannot accommodate a right column** — a full-screen
+canvas, a story-only or prototype host, any page with no
+`[data-rf-xray-host]` — the supported fallback is the overlay mount verb.
+It floats the shell above the host under `document.body`, so it needs no
+layout column.
+
+```clojure
+(require '[day8.re-frame2-xray.core :as xray])
+(xray/open-overlay!)
+;; or, from a devtools console:
+;; window.day8.re_frame2_xray.open_overlay_BANG_()
+```
+
+`open-overlay!` is one of the mount facade's three open verbs by design
+(`open!` inline · `open-overlay!` modal overlay · `popout!` window — per
+[`spec/API.md` §rf2-sa4fr](../../../tools/xray/spec/API.md), the three
+naming distinct mount surfaces, not modal variants of one shape). It is
+the **optional, non-default** path: the inline panel is the canonical
+developer experience, and `open-overlay!` is explicitly documented as a
+real-but-non-primary surface — per
+[`spec/011-Launch-Modes.md`](../../../tools/xray/spec/011-Launch-Modes.md),
+the overlay debug surface "remains an optional debug mode and must not be
+described as the primary path." Prefer adding the `[data-rf-xray-host]`
+column when the host can host one; reach for `open-overlay!` only when it
+can't. Source
+[`mount.cljs`](../../../tools/xray/src/day8/re_frame2_xray/mount.cljs)
+(`open-overlay!`), exported via
+[`core.cljs`](../../../tools/xray/src/day8/re_frame2_xray/core.cljs).
+
 ## Programmatic init!
 
 Alternative to the preload — call `(xray/init! opts)` from app code
@@ -243,7 +276,7 @@ When Xray is toggled off (Ctrl+Shift+C while open), the shell stays
 mounted with `display: none` on the container. The app receives no
 body padding, no viewport overlay, no fixed chrome. Re-open is a
 CSS-only `display: block` — no React remount, internal state
-(selected tab, scroll, AI conversation) survives. The first paint after
+(selected tab, scroll, selected epoch) survives. The first paint after
 the first toggle hits the <80ms target per
 [`spec/007-UX-IA.md` §Animation](../../../tools/xray/spec/007-UX-IA.md).
 


### PR DESCRIPTION
## Summary

Four doc-correctness fixes to the `skills/re-frame2-xray` Claude Code skill, each verified against current Xray source. Stale/incorrect skill guidance was mis-teaching the AI driving Xray.

## Findings fixed

**rf2-3ppsg.1 (P2) — launch tour omitted `open-overlay!`**
The skill claimed "Three launch modes ship today" and never mentioned `open-overlay!`, a real public mount verb. Added it as the **fourth, optional, non-default** launch surface (the supported fallback for hosts that can't host a layout column — full-screen canvas, story-only / prototype host, no `[data-rf-xray-host]`):
- `SKILL.md` launch table: new Overlay row + corrected count.
- `references/launch-modes.md`: new "Overlay fallback (open-overlay!)" section + a missing-host decision-tree branch routing to it.
- `README.md`: launch-coverage enumeration + leaf description.
Framed per `spec/011-Launch-Modes.md` ("optional debug mode … must not be described as the primary path") and `spec/API.md` §rf2-sa4fr ("three distinct verbs by design"). Verified against `core.cljs:86-89` (export) and `mount.cljs:596-606` (impl).

**rf2-3ppsg.2 (P2) — init! wrongly said NOT to tune density/buffer-depth**
`SKILL.md:206` said density/buffer-depth are tuned via the Settings popup "(not init! opts)". Corrected to the two-layer model: `init!`/`configure!` set boot-time `:theme`/`:density`/`:buffer-depths` (applied immediately, no reload); the Settings popup is the runtime user-mutable override. Merge order `defaults < configure! < Settings` (rf2-g2a5v). Verified against `core.cljs:155-172`; now agrees with the skill's own `launch-modes.md:171-187` leaf.

**rf2-3ppsg.3 (P3, STALE) — "AI conversation" hidden state**
`references/launch-modes.md:246` listed "AI conversation" as surviving hidden state. No such surface exists (per `000-Vision.md` AI-panel lock). Replaced with "selected epoch".

**rf2-4d94j.1 (P3, STALE) — snapshot-app-db status note**
`SKILL.md:235-237` described the safe-egress projection as "being routed" / "even mid-fix". rf2-mxzgg is closed (PR #3155); `palette/events.cljs:156-190` already routes through `runtime/egress-value` (redacts by default). Updated status to shipped; contract prose unchanged.

## Quality gates

- These skill docs are **not** in the mkdocs build (`docs/skills/re-frame2-xray.md` is a separate hand-maintained page), so the gate is markdown link/anchor integrity + claim-vs-source.
- All new link targets resolve (`API.md`, `011-Launch-Modes.md`, `mount.cljs`, `core.cljs`).
- Every changed claim verified against the cited current source.
- No residual stale strings ("three launch", "AI conversation", "being routed", "mid-fix", "not init! opts").

Closes rf2-3ppsg.1, rf2-3ppsg.2, rf2-3ppsg.3, rf2-4d94j.1.