### PR TITLE
fix(skills): correct setup-skill CSS gutter + fabricated diagnostics (rf2-84hk4.1/.2/.3)

### DIFF
--- a/skills/re-frame2-setup/references/first-counter.md
+++ b/skills/re-frame2-setup/references/first-counter.md
@@ -123,10 +123,10 @@ First-run failures, in roughly the order you'll hit them:
 - **Page loads but the browser console shows `main.js` 404 (`GET /js/main.js 404`)** — `:output-dir`, `:asset-path`, and `index.html`'s `<script src>` disagree. The template serves `resources/public` with `:output-dir "resources/public/js"` + `:asset-path "/js"` + `<script src="/js/main.js">`; if you changed any one, change the others to match.
 - **Blank page, no console errors** — `index.html` is missing `<main id="app">`, or the entry ns looks up a different id than `index.html` declares.
 
-If you see a blank page, open the browser console. Most failures land there with a clear error:
+If you see a blank page, open the browser console. Most failures land there with a clear error — but note the missing-sub case below is *silent* on this bare route:
 - `Cannot read property 'getElementById' of undefined` — script ran before DOM was ready; check `index.html` loads `main.js` at the *bottom* of `<body>`.
-- `Could not find frame :rf/default` — `rf/init!` didn't run before render. Check `init` is the `:init-fn` shadow-cljs is calling.
-- `No subscription handler registered for: :count` — registrations didn't run. If you split into multiple namespaces, make sure `core.cljs` `:require`s them so they load.
+- A thrown `:rf.error/no-adapter-installed` (reason: *"was called before `(rf/init! ...)`; require an adapter ns and pass its `adapter` Var"*) — a view subscribed/rendered before `(rf/init! ...)` seated an adapter. `rf/init!` didn't run before render: check `init` is the `:init-fn` shadow-cljs is calling. (There is no "frame not found" error — `:rf/default` is always auto-registered; the real failure is the absent adapter.)
+- A blank/empty subscribed value with **no console error** (e.g. the number never appears) — a subscribe to an unregistered sub builds a nil-yielding reaction and emits `:rf.error/no-such-sub`; it does **not** throw. On this bare route there's no error-sink listener wired, so the miss surfaces only as a silent `nil` render — registrations didn't run. If you split subs into multiple namespaces, make sure `core.cljs` `:require`s them so they load. (The generator template wires an error-sink in `events.cljs` that pushes `:rf.error/no-such-sub` to the console; this minimal counter doesn't, so the only tell is the blank value.)
 
 **No schema errors? That's expected.** This counter attaches no app-db schema, so even with `day8/re-frame2-schemas` on the classpath there's nothing to validate — CLJS soft-passes (Spec 010). Validation only fires once you `reg-app-schema` a schema; until then the absence of errors means "no schema attached," not "validation ran and passed."
 

--- a/skills/re-frame2-setup/references/shadow-cljs.md
+++ b/skills/re-frame2-setup/references/shadow-cljs.md
@@ -80,12 +80,13 @@ A re-frame2 app needs an HTML page that loads the compiled JS and has a mount po
 </html>
 ```
 
-`resources/public/css/app.css` (the minimal layout — three rules carry the host-column contract):
+`resources/public/css/app.css` (the minimal layout — three rules carry the host-column contract, plus the `:empty` collapse that keeps release builds gutter-free):
 
 ```css
 body { font: 16px/1.4 system-ui, sans-serif; margin: 0; }
 .rf2-app-shell { display: flex; min-height: 100vh; }
 .rf2-xray-host { flex: 0 0 420px; min-width: 320px; }
+.rf2-xray-host:empty { display: none; }
 #app { flex: 1; min-width: 0; padding: 2em; }
 ```
 
@@ -94,6 +95,7 @@ Five contractual bits:
 - **`<main id="app"></main>`** — the app mount point. Whatever id you use here, the entry ns must call `(js/document.getElementById "<same-id>")`. By convention it's `"app"`.
 - **`<aside class="rf2-xray-host" data-rf-xray-host></aside>`** — Xray's default true-inline devtools host, the **left** layout column beside `#app`. Order it **first** in the DOM (`<aside>` then `<main>`) so flex flow places Xray on the left, matching the template. When `day8.re-frame2-xray.preload` is enabled Xray auto-opens into this host; if it's missing, Xray logs an actionable diagnostic, also reachable via `window.day8.re_frame2_xray.status()`.
 - **`.rf2-xray-host` flex CSS** — the host app owns sizing. The contract is a fixed-width column (`flex: 0 0 420px; min-width: 320px`) and an app region that can shrink (`#app { flex: 1; min-width: 0 }`). Xray injects its own drag handle on the panel's outer edge (persisted across reloads, double-click to reset), so the consumer's CSS stays this minimal. To change the default width, edit `flex-basis` here; the full resize-affordance / theming surface is the `re-frame2-xray` skill's territory, not greenfield's.
+- **`.rf2-xray-host:empty { display: none; }`** — load-bearing in **release** builds. The preload that mounts Xray into the aside is dev-only (cut from `shadow-cljs release` and `goog.DEBUG`-gated), so in production the `<aside>` stays empty. Without this rule the empty aside still matches the `flex: 0 0 420px` column above and ships a permanent blank ~420px gutter beside `#app`. The `:empty` collapse makes the column disappear when Xray isn't there, so `#app` spans the full viewport. This matches the canonical template scaffold — don't drop it.
 - **CSP + external stylesheet.** The CSP meta tag declares `style-src 'self'`, which blocks inline `<style>`/`style=` attributes — so styles live in `css/app.css`, not inline. Keep them out of the HTML to stay CSP-clean (and matching the template).
 - **`<script src="/js/main.js">`** — `/js/` comes from `:asset-path "/js"`; `main.js` comes from the module name `:main`. If you rename either, this path follows. The absolute path from site root is correct for shadow-cljs's dev server.
 


### PR DESCRIPTION
## Summary

Fixes three CORRECTNESS drifts in `skills/re-frame2-setup` (the greenfield scaffold skill) that send newcomers chasing ghosts. From the `rf2-84hk4` read-only correctness review.

## Fixes

### rf2-84hk4.1 (P2 — template-drift, prod-broken stylesheet)
`references/shadow-cljs.md` gave the greenfield `app.css` as three rules but **omitted** the canonical template's load-bearing 4th rule:

```css
.rf2-xray-host:empty { display: none; }
```

The Xray preload is dev-only (cut from `shadow-cljs release` and `goog.DEBUG`-gated), so in a release build the `<aside data-rf-xray-host>` stays empty. Without the `:empty` collapse it still matches `flex: 0 0 420px` and ships a permanent blank ~420px left gutter — the same prod-gutter bug just fixed in the template scaffold (rf2-3uqbd.1, PR #3172). Aligned the app.css block + prose to the now-corrected template.

Ground: `tools/template/resources/day8/re_frame2_template/root/resources/public/css/app.css:16`.

### rf2-84hk4.2 (P2 — fabricated diagnostic)
`references/first-counter.md:128` cited `Could not find frame :rf/default` for render-before-init. That string has **0 hits** in core, and `:rf/default` is always auto-registered (`frame.cljc:64-67,683`). The real failure is a thrown `:rf.error/no-adapter-installed` (`adapter.cljc:200-206,212,398`). Replaced with the real id + cause.

### rf2-84hk4.3 (P3 — fabricated diagnostic + wrong semantics)
`references/first-counter.md:129` cited `No subscription handler registered for: :count` and implied a throw. Real id is `:rf.error/no-such-sub` (`subs.cljc:224,262,271`), and a missing sub builds a nil-yielding reaction **without throwing**. On the bare skill route (no error-sink listener, unlike the template's `events.cljs:49-55`) the symptom is a **silent blank value**, not a console error. Corrected the id + the real symptom.

## Verification
- Every replacement string verified against current source via `git grep` (fabricated strings: 0 hits; real ids confirmed at the cited lines).
- `skills/re-frame2-setup/references/*.md` are **not** in the mkdocs build (mkdocs nav only includes `docs/skills/*.md` landing pages, which carry none of these strings) — so the gate is markdown integrity + claim-vs-source, both satisfied. No new links/anchors introduced.
- Standing skill constraints honoured: guidance stays generic to any consumer app; the divergence from the dev-only Xray preload is flagged.

Closes rf2-84hk4.1, rf2-84hk4.2, rf2-84hk4.3.