### PR TITLE
fix(skills): align pair-retro re-authoring spec to x0123 single-repo+label routing (rf2-65hn4.1 + rf2-65hn4.2)

### DIFF
--- a/skills/re-frame2-pair-retro/spec/authoring-prompt.md
+++ b/skills/re-frame2-pair-retro/spec/authoring-prompt.md
@@ -56,7 +56,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 > *3. **Default to diagnosis, not contribution.** Do not assume the user wants to file a GitHub issue.*
 > *4. **Never file a GitHub issue or edit another repo without explicit user approval.***
 > *5. **No re-frame-10x routing.** Time-travel + trace consumption ride on re-frame2's native Tool-Pair surfaces.*
-> *6. **If the best fix is upstream in `re-frame2`, say so.** File against the right repo.*
+> *6. **If the best fix is upstream in the framework, say so.** All issues file against `day8/re-frame2`; carry the `pair-mcp` label for tool-side friction, no label for upstream framework friction.*
 >
 > *Output format the skill produces (compact retrospective):*
 >
@@ -72,7 +72,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 >
 > *- **L1 — No re-frame-10x routing.** Cardinal anti-pattern.*
 > *- **L2 — Never file a GitHub issue without explicit user approval.** Cardinal guard-rail.*
-> *- **L3 — Route the fix to the right repo.** `re-frame2-pair` for tool changes; `re-frame2` for upstream contract changes. Skills file GitHub issues against the target repo — `bd` (beads) is the re-frame2 monorepo's internal tracker and is never invoked from a published skill.*
+> *- **L3 — Route the fix to the right layer.** Both kinds of friction file against `day8/re-frame2` (the monorepo that ships the pair tool), distinguished by label: tool changes carry `--label pair-mcp`; upstream contract changes carry no `pair-mcp` label. There is no separate `re-frame2-pair` repo. Skills file GitHub issues against that repo — `bd` (beads) is the re-frame2 monorepo's internal tracker and is never invoked from a published skill.*
 > *- **L10 — No internal `bd`/`rf2-XXXX` ids in user-facing skill content.***
 > *- **L11 — Findings stay local.** Don't commit `ai/` or `findings/`.*
 > *- **L12 — Redact secrets before filing.** GitHub-issue drafts strip secrets, tokens, internal URLs, unnecessary local paths. The body is composed to a file with the `Write` tool and passed via `--body-file` (`gh issue create --body-file /tmp/issue-body.md`), never inline interpolation of transcript-derived text.*

--- a/skills/re-frame2-pair-retro/spec/design.md
+++ b/skills/re-frame2-pair-retro/spec/design.md
@@ -6,7 +6,7 @@ The design rationale and locked decisions for the `re-frame2-pair-retro` skill. 
 
 ## 1. Goal
 
-Help a user **retrospect on a re-frame2-pair session** and turn it into a structured product retrospective. The output is a friction analysis, a classification of root causes, and 2-5 concrete improvement ideas — optionally accompanied by a draft GitHub issue the user can file against `re-frame2-pair` (or `re-frame2` itself, if the root cause is upstream).
+Help a user **retrospect on a re-frame2-pair session** and turn it into a structured product retrospective. The output is a friction analysis, a classification of root causes, and 2-5 concrete improvement ideas — optionally accompanied by a draft GitHub issue the user can file against `day8/re-frame2` (the monorepo that ships the pair tool alongside the framework), labelled `pair-mcp` for tool-side friction and unlabelled for upstream framework friction.
 
 The skill's success criterion: after a session with `re-frame2-pair`, the user invokes this skill and walks away with a clear list of friction points, a credible classification of each, and prioritised improvement ideas — with no speculative GitHub issues filed without explicit approval.
 
@@ -99,7 +99,7 @@ GitHub-issue drafts redact secrets, tokens, internal URLs, and unnecessary local
 - Users finishing a `re-frame2-pair` session who want a structured retrospective.
 - Friction analysis: direct (user complaints) + indirect (repeated commands, fallback to lower-level tools, manual reconstruction).
 - Classification across the nine lenses in `references/analysis-lenses.md`.
-- Drafting GitHub issues against `re-frame2-pair` (tool changes) or `re-frame2` (upstream contract changes).
+- Drafting GitHub issues against `day8/re-frame2`, distinguished by label: `pair-mcp` for tool changes; no label for upstream contract changes.
 - Spotting recurring patterns via `references/known-frictions.md`.
 
 ### Out of scope


### PR DESCRIPTION
## Summary

The **x0123** fix (PR #3104, Mike ruling B) re-pointed `re-frame2-pair-retro`'s tool-side issue filing from the **non-existent** `day8/re-frame2-pair` repo to **`day8/re-frame2` + a `pair-mcp` label**. It landed in every shipped/user-facing leaf (`SKILL.md`, `README.md`, `shared/issue-filing.md`, `references/issue-template.md`, `references/analysis-lenses.md`) and the `design.md` §L2/§L3 locks — but **missed the two re-authoring meta-docs in `spec/`**. Those still encoded the OLD two-repo routing, so a regeneration of the skill would have reintroduced the fixed bug.

This PR aligns the two stragglers to the same single-repo + label model.

## Changes (2 files, 4 lines)

**`spec/authoring-prompt.md`** (rf2-65hn4.1 — the canonical one-shot re-authoring source):
- **L75** — the L3 "lock to preserve verbatim" said *"`re-frame2-pair` for tool changes; `re-frame2` for upstream contract changes."* Re-authoring from this lock would have regenerated `gh issue create --repo day8/re-frame2-pair` → repository-not-found, i.e. the exact x0123 bug. Now: both file against `day8/re-frame2`, tool changes carry `--label pair-mcp`, upstream changes carry none; "There is no separate `re-frame2-pair` repo." Heading also realigned to `design.md` §L3 ("right layer").
- **L59** — cardinal guard-rail #6 ("File against the right repo") reworded to the single-repo + label model.

**`spec/design.md`** (rf2-65hn4.2 — internal contradiction with the same file's corrected §L2/§L3):
- **L9** (§1 Goal) and **L102** (§4 Scope) prose summaries still described the two-repo split. Reworded to mirror the already-correct §L2/§L3 locks.

## Verification

Routing now matches the x0123-corrected model across **all** leaves:

> Both tool-side and framework friction file against **`day8/re-frame2`**, distinguished by the **`pair-mcp`** label (tool-side carries it; framework friction does not). The conceptual tool-vs-framework split is preserved; only the repo target + label model changed.

## Gates

- `git grep -n "day8/re-frame2-pair"` over `skills/re-frame2-pair-retro/spec/` → **zero**; remaining repo-name hits are all in the sibling `skills/re-frame2-pair/` (legitimate npm package names + the standalone Agent-Skill distribution channel).
- `git grep -E "right repo|against re-frame2-pair|..."` over the spec docs → **zero** stale issue-filing routing prose.
- Markdown links in both edited files resolve (`../SKILL.md`, `../../shared/issue-filing.md`).
- `scripts/check_skill_redirect_anchors.py` → pass.
- `scripts/check_skill_mcp_drift.py` → pass.
- `scripts/check_readme_links.py` → pass.

Closes rf2-65hn4.1, closes rf2-65hn4.2.
