### PR TITLE
fix(docs): current machine action signature + correct xray Static-tab docstrings (rf2-sqq0v + rf2-sgjvn)

### DIFF
--- a/spec/Pattern-NineStates.md
+++ b/spec/Pattern-NineStates.md
@@ -69,13 +69,13 @@ One machine. Three regions. Tags on states. One selector sub. One `case` in the 
    :data {:items [] :error nil}                 ;; shared across regions
 
    :guards
-   {:empty?    (fn [d _] (zero? (count (:items d))))
-    :one?      (fn [d _] (= 1 (count (:items d))))
-    :too-many? (fn [d _] (> (count (:items d)) too-many-threshold))}
+   {:empty?    (fn [{:keys [data]}] (zero? (count (:items data))))
+    :one?      (fn [{:keys [data]}] (= 1 (count (:items data))))
+    :too-many? (fn [{:keys [data]}] (> (count (:items data)) too-many-threshold))}
 
    :actions
-   {:set-items (fn [d [_ {:keys [items]}]] {:data (assoc d :items (vec items) :error nil)})
-    :set-error (fn [d [_ {:keys [failure]}]] {:data (assoc d :error failure)})}
+   {:set-items (fn [{data :data [_ {:keys [items]}] :event}] {:data (assoc data :items (vec items) :error nil)})
+    :set-error (fn [{data :data [_ {:keys [failure]}] :event}] {:data (assoc data :error failure)})}
 
    :regions
    {:data

--- a/tools/xray/src/day8/re_frame2_xray/palette/sources.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/palette/sources.cljc
@@ -233,7 +233,7 @@
   ## Static-only verbs
 
   Jump-to-static-tab — selects one of the 5 Static L3 tabs (Machines /
-  Routes / Schemas / Views / Events). Static has no spine so the
+  Routes / Schemas / Flows / Interceptors). Static has no spine so the
   Dynamic tab jumps don't apply.
 
   ## Mode-agnostic verbs (rf2-ybjkx)
@@ -355,7 +355,7 @@
 (defn static-tab-items
   "Static-mode sub-tab jumps (rf2-ybjkx). Five entries mirroring the
   `static/shell.cljs/tabs` inventory: Machines / Routes / Schemas /
-  Views / Events. Each carries `:modes #{:static}` so the aggregator
+  Flows / Interceptors. Each carries `:modes #{:static}` so the aggregator
   filters them out when the palette opens in Dynamic mode."
   [static-tab-entries]
   (mapv


### PR DESCRIPTION
Two small doc/comment correctness nits in different artefacts (pre-alpha masterpiece: CORRECTNESS). Surgical, one PR.

## rf2-sqq0v (P4 BUG) — `spec/Pattern-NineStates.md`
The nine-states machine example used the **older 2-arg** guard/action signature:
- guards `(fn [d _] ...)`
- actions `(fn [d [_ {:keys [...]}]] ...)`

Updated to the **current single-context-map** signature per `spec/005-StateMachines.md`:
- §Guards (L337): `(fn [{:keys [data event state meta]}] boolean)`
- §Actions (L384): `(fn [{:keys [data event state meta]}] effects)`

Guards now destructure `data`; actions use the reference-impl idiom `(fn [{data :data [_ {:keys [...]}] :event}] ...)` (matches `implementation/machines/.../machines_system_id_cljs_test.cljs:77`). This also makes the doc internally consistent with its own prose at L270 (`(count (:items data))`). The separate `reg-event-fx` example later in the doc keeps the standard 2-arg event-handler signature (unchanged — correct as-is).

## rf2-sgjvn (P4 BUG) — `tools/xray/src/day8/re_frame2_xray/palette/sources.cljc`
Two docstrings (`:235-237`, `:355-359`) listed the Static L3 tabs as **Machines / Routes / Schemas / Views / Events**. The live tab registry says otherwise:
- `static/shell.cljs` L62-63 + the L70-72 comment ("rf2-b2fif removed the standalone Static Views + Events sub-tabs")
- the five panel registrations (`:order` 0-4): Machines(0) / Routes(1) / Schemas(2) / Flows(3) / Interceptors(4)

Corrected both docstrings to **Machines / Routes / Schemas / Flows / Interceptors**. (The Xray skill already lists the correct 5; only the source docstrings were stale.)

## Gates
- `mkdocs build --strict`: edit is confined to a fenced code block (no nav/link/heading touched) so it cannot introduce a `--strict` warning; mkdocs not installed locally.
- xray JVM compile-load: `clojure -M -e "(require 'day8.re-frame2-xray.palette.sources)"` → `:LOADED-OK` (docstring-only change; namespace loads clean).

Closes rf2-sqq0v, rf2-sgjvn.