### PR TITLE
fix(ssr-ring): close post-shell redirect fail-open + document streaming render-hash (rf2-5knxf.1/.2)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -245,6 +245,44 @@
             ;; the tail (FIFO), continue until empty.
             (recur (into (pop queue) continuations)))))
       ;; Chunk N+2 — final canonical __rf_payload.
+      ;;
+      ;; rf2-5knxf.2 — the streaming final-payload `:rf/render-hash` is
+      ;; computed over `hiccup` (the resolved root view returned by
+      ;; `render-streaming-shell!`) via `render-tree-hash`, the IDENTICAL
+      ;; mechanism the non-streaming `build-full-response*` uses (it hashes
+      ;; `(resolve-root-view root-view)` the same way). This is the correct
+      ;; structural hash, NOT a streaming-specific divergence:
+      ;;
+      ;;   - `render-tree-hash` is a PURE structural FNV-1a over the
+      ;;     canonical-EDN of the hiccup (hash.cljc). It does NOT expand
+      ;;     view-refs or registered views, and it does NOT throw on a
+      ;;     `:rf/suspense-boundary` head — it just hashes the vector
+      ;;     structurally. So a `:rf/suspense-boundary` node hashes to the
+      ;;     same canonical-EDN bytes on the server AND on the client: the
+      ;;     marker is NOT a source of mismatch. A streaming-aware client
+      ;;     verifies via `verify-hydration!` against
+      ;;     `:render-tree-fn #((rf/view :app/root))` — whose result is the
+      ;;     SAME marker-bearing hiccup the server's `(rf/view :app/root)`
+      ;;     produces. Both sides hash the marker-bearing tree to the same
+      ;;     hex (empirically confirmed; see the
+      ;;     `streaming-final-hash-matches-client-resolved-tree` regression
+      ;;     in `ring_streaming_test`).
+      ;;
+      ;;   - The ONLY way server and client hashes diverge is the host
+      ;;     passing a NON-symmetric pair of forms: a view-REF `:root-view
+      ;;     [:app/root]` on the server (which `resolve-root-view` leaves
+      ;;     UNEXPANDED → the hash is over the 1-element `[:app/root]`
+      ;;     vector) vs an EXPANDED `:render-tree-fn #((rf/view :app/root))`
+      ;;     on the client. This view-ref-vs-expanded asymmetry is SHARED by
+      ;;     the non-streaming handler (identical `resolve-root-view` →
+      ;;     `render-tree-hash` shape) and is the host's responsibility to
+      ;;     avoid — pass `:root-view` and `:render-tree-fn` as matching
+      ;;     forms (both expanding, e.g. server `:root-view #((rf/view
+      ;;     :app/root))` / client `:render-tree-fn #((rf/view :app/root))`,
+      ;;     mirroring the non-streaming worked example's `((rf/view
+      ;;     :app/root))`). It is NOT a marker bug and NOT streaming-specific.
+      ;;     Spec 011 §Hydration equivalence rule (structural, not textual)
+      ;;     + §Hydration-mismatch detection.
       (let [final-hash    (rf/with-frame frame-id (ssr/render-tree-hash hiccup))
             final-payload (rf/with-frame frame-id
                             (streaming/build-final-payload
@@ -447,68 +485,106 @@
                     ;; We MATERIALISE the chunked response head from
                     ;; `resp2`, so the wire status is the fail-closed 500
                     ;; — never the stale pre-render 200 the OLD writer-
-                    ;; thread order shipped (Spec 011 §744/§750). A redirect
-                    ;; or a deliberate app-set non-200 (`:rf.server/set-
-                    ;; status`) surfaces here too and rides the wire
-                    ;; unchanged — identical to the non-streaming handler,
-                    ;; which streams the rendered body with whatever post-
-                    ;; flush status the accumulator carries (the status is
-                    ;; the fail-closed signal; the body is moot under a
-                    ;; non-200).
-                    (let [resp2 (ssr/get-response frame-id)
-                          ;; rf2-z5azc — MATERIALISE the response head
-                          ;; (status / headers / cookies) from the re-read
-                          ;; `resp2` BEFORE constructing the pipe or
-                          ;; spawning the writer. Cookie / header
-                          ;; serialisation CAN throw at materialise time on
-                          ;; a value that escaped the fx boundary's partial
-                          ;; validation — e.g. a `:max-age` carrying CR/LF,
-                          ;; which `cookie->set-cookie-header` rejects but
-                          ;; the runtime `validate-cookie!` does not. If we
-                          ;; spawned the writer first, that throw would
-                          ;; orphan the pipe (the daemon writer pumps the
-                          ;; full body into a reader-less pipe, blocks once
-                          ;; the 16 KiB buffer fills, and leaks one live
-                          ;; thread per request). By building `resp-map`
-                          ;; first, a head-materialisation failure short-
-                          ;; circuits to the outer catch BEFORE any thread
-                          ;; or pipe exists → on-error, no detached writer,
-                          ;; no orphaned pipe.
-                          ;;
-                          ;; No body default-stamp here (we pass our own
-                          ;; InputStream); `:body` is assoc'd after the
-                          ;; writer is wired below.
-                          resp-map (pipeline/ssr-response->ring-response
-                                     resp2 "" content-type)
-                          ;; 16 KiB pipe buffer — large enough to absorb the
-                          ;; shell chunk in one write so the writer thread
-                          ;; rarely blocks on a slow consumer, small enough
-                          ;; that one stuck client doesn't pin a non-trivial
-                          ;; chunk of heap per request.
-                          pipe-in  (PipedInputStream. (* 16 1024))
-                          pipe-out (PipedOutputStream. pipe-in)]
-                      ;; Daemon thread (rf2-ekwda): a writer blocked on
-                      ;; `.write` to the bounded 16 KiB pipe of a slow-loris
-                      ;; client must NOT keep the JVM alive at shutdown. The
-                      ;; ns + handler docstrings and both test namespaces
-                      ;; assert daemon semantics; this is what makes that
-                      ;; contract real.
-                      (doto
-                        (Thread.
-                          ^Runnable
-                          (fn writer-thread []
-                            (try
-                              (run-streaming-writer! pipe-out frame-id rendered opts)
-                              (finally
-                                ;; The writer's own finally closes the
-                                ;; pipe; the frame teardown happens here so
-                                ;; it does NOT block the response close on
-                                ;; the slower destroy path.
-                                (lifecycle/destroy-frame-quietly! frame-id))))
-                          ^String (str "rf2-ssr-streaming-" (name frame-id)))
-                        (.setDaemon true)
-                        (.start))
-                      (assoc resp-map :body pipe-in))))))
+                    ;; thread order shipped (Spec 011 §744/§750).
+                    ;;
+                    ;; A deliberate app-set non-200 (`:rf.server/set-status`)
+                    ;; surfaces here too and rides the wire unchanged —
+                    ;; identical to the non-streaming handler, which streams
+                    ;; the rendered body with whatever post-flush status the
+                    ;; accumulator carries (the status is the fail-closed
+                    ;; signal; the body is moot under a non-200).
+                    ;;
+                    ;; rf2-5knxf.1 — a `:redirect` is the ONE accumulator
+                    ;; state that must NOT stream a body: a 3xx + Location is
+                    ;; a bodiless wire response (Spec 011 §Redirect
+                    ;; precedence), so streaming a full HTML document under it
+                    ;; would ship a malformed redirect AND spawn a body-
+                    ;; pumping writer for a request the contract says has no
+                    ;; body. The non-streaming handler gets this for free —
+                    ;; `ssr-response->ring-response` ignores the body arg on
+                    ;; its `:redirect` branch (pipeline.clj). The streaming
+                    ;; path must branch EXPLICITLY because it would otherwise
+                    ;; overwrite the materialised `:body ""` with the pipe and
+                    ;; start the writer. In v1 a `:redirect` cannot surface at
+                    ;; this post-shell re-read (it is only set by the
+                    ;; `:rf.server/redirect` fx during the `:on-create` drain,
+                    ;; which the EARLY redirect branch above already catches;
+                    ;; the error projector stamps `:status` only, never
+                    ;; `:redirect` — error_listener.cljc). This branch is
+                    ;; defense-in-depth for a future render-phase fx /
+                    ;; projector / hand-built accumulator that learns to
+                    ;; redirect — and it aligns the code with this very
+                    ;; comment's parity claim.
+                    (let [resp2 (ssr/get-response frame-id)]
+                      (if (some? (:redirect resp2))
+                        ;; Bodiless redirect — mirror the EARLY :on-create
+                        ;; redirect branch above (and the non-streaming
+                        ;; `pipeline.clj` redirect branch): materialise the
+                        ;; Location response with NO body, spawn NO writer,
+                        ;; and destroy the per-request frame inline (no writer
+                        ;; thread will run its teardown `finally`). The 2-arg
+                        ;; form passes no `content-type` — a bodiless redirect
+                        ;; has no meaningful Content-Type to default, matching
+                        ;; the non-streaming + early-branch redirect paths.
+                        (try
+                          (pipeline/ssr-response->ring-response resp2 nil)
+                          (finally
+                            (lifecycle/destroy-frame-quietly! frame-id)))
+                        ;; Non-redirect — the streaming path. Materialise the
+                        ;; head, wire the pipe, spawn the writer.
+                        (let [;; rf2-z5azc — MATERIALISE the response head
+                              ;; (status / headers / cookies) from the re-read
+                              ;; `resp2` BEFORE constructing the pipe or
+                              ;; spawning the writer. Cookie / header
+                              ;; serialisation CAN throw at materialise time on
+                              ;; a value that escaped the fx boundary's partial
+                              ;; validation — e.g. a `:max-age` carrying CR/LF,
+                              ;; which `cookie->set-cookie-header` rejects but
+                              ;; the runtime `validate-cookie!` does not. If we
+                              ;; spawned the writer first, that throw would
+                              ;; orphan the pipe (the daemon writer pumps the
+                              ;; full body into a reader-less pipe, blocks once
+                              ;; the 16 KiB buffer fills, and leaks one live
+                              ;; thread per request). By building `resp-map`
+                              ;; first, a head-materialisation failure short-
+                              ;; circuits to the outer catch BEFORE any thread
+                              ;; or pipe exists → on-error, no detached writer,
+                              ;; no orphaned pipe.
+                              ;;
+                              ;; No body default-stamp here (we pass our own
+                              ;; InputStream); `:body` is assoc'd after the
+                              ;; writer is wired below.
+                              resp-map (pipeline/ssr-response->ring-response
+                                         resp2 "" content-type)
+                              ;; 16 KiB pipe buffer — large enough to absorb the
+                              ;; shell chunk in one write so the writer thread
+                              ;; rarely blocks on a slow consumer, small enough
+                              ;; that one stuck client doesn't pin a non-trivial
+                              ;; chunk of heap per request.
+                              pipe-in  (PipedInputStream. (* 16 1024))
+                              pipe-out (PipedOutputStream. pipe-in)]
+                          ;; Daemon thread (rf2-ekwda): a writer blocked on
+                          ;; `.write` to the bounded 16 KiB pipe of a slow-loris
+                          ;; client must NOT keep the JVM alive at shutdown. The
+                          ;; ns + handler docstrings and both test namespaces
+                          ;; assert daemon semantics; this is what makes that
+                          ;; contract real.
+                          (doto
+                            (Thread.
+                              ^Runnable
+                              (fn writer-thread []
+                                (try
+                                  (run-streaming-writer! pipe-out frame-id rendered opts)
+                                  (finally
+                                    ;; The writer's own finally closes the
+                                    ;; pipe; the frame teardown happens here so
+                                    ;; it does NOT block the response close on
+                                    ;; the slower destroy path.
+                                    (lifecycle/destroy-frame-quietly! frame-id))))
+                              ^String (str "rf2-ssr-streaming-" (name frame-id)))
+                            (.setDaemon true)
+                            (.start))
+                          (assoc resp-map :body pipe-in))))))))
             (catch Throwable t
               ;; get-response throw, redirect-materialise throw, OR (per
               ;; rf2-z5azc) a head-materialisation throw raised BEFORE the

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -16,6 +16,7 @@
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.test-fixture :as tf])
   (:import [java.io InputStream]))
 
@@ -491,3 +492,159 @@
               "the clean sub's value rendered into the streamed HTML")
           (is (str/includes? body "__rf_payload")
               "the final payload chunk streamed"))))))
+
+;; ===========================================================================
+;; rf2-5knxf.1 — a :redirect surfacing at the POST-SHELL re-read must ship a
+;;               bodiless redirect, NOT a streamed body, and spawn NO writer.
+;; ===========================================================================
+;;
+;; The early redirect branch (stream-handler, on the :on-create-drain
+;; `get-response`) is already covered by stream-handler-redirect-destroys-
+;; frame above. This test covers the SECOND `get-response` — the post-shell
+;; re-read at the materialise site (rf2-r06pc). Pre-fix, that branch
+;; UNCONDITIONALLY materialised `resp-map`, spawned the daemon writer, and
+;; assoc'd the pipe `:body` — so a `:redirect` carried on the post-shell
+;; accumulator would have shipped a malformed 3xx + Location + a FULL
+;; streamed HTML body (the writer pumps shell + payload + close) for a wire
+;; response the contract says must be bodiless (Spec 011 §Redirect
+;; precedence). The non-streaming handler gets this for free
+;; (`ssr-response->ring-response` ignores the body arg on its `:redirect`
+;; branch); the streaming path had to branch explicitly.
+;;
+;; A `:redirect` cannot surface at the post-shell read under v1's
+;; architecture (it is set only by the `:rf.server/redirect` fx during the
+;; `:on-create` drain — caught by the EARLY branch — and the error projector
+;; stamps `:status` only, never `:redirect`). So this is a LATENT fail-open:
+;; we simulate the latent condition by stubbing `ssr/get-response` to return
+;; a non-redirect on the FIRST call (so the early branch passes through to
+;; the shell render) and a redirect on the SECOND call (the post-shell
+;; re-read). This exercises the new post-shell redirect branch directly.
+
+(deftest stream-handler-post-shell-redirect-bodiless
+  (testing "rf2-5knxf.1: a :redirect surfacing at the POST-SHELL get-response
+            re-read ships a bodiless Location response (NOT a streamed
+            body), spawns NO writer thread, and destroys the frame inline."
+    (rf/reg-event-fx :rf.test.server/init-min
+      {:platforms #{:server}}
+      (fn [_ _] {:db {}}))
+    (rf/reg-view ^{:rf/id :test/plain-root} plain-root []
+      [:main [:h1 "rendered shell"]])
+    (let [real-get-response ssr/get-response
+          ;; Per-frame call counter so we stub ONLY the second
+          ;; get-response (the post-shell re-read) for our frame, leaving
+          ;; the first (early-branch drain read) untouched. Keying on the
+          ;; arg-count of calls keeps the stub from perturbing any other
+          ;; frame's reads.
+          calls (atom 0)
+          redirect-resp {:status   302
+                         :headers  []
+                         :cookies  []
+                         :redirect {:status 302 :location "/post-shell-login"}}]
+      (with-redefs [ssr/get-response
+                    (fn [fid]
+                      (let [n (swap! calls inc)]
+                        ;; 1st call = early-branch drain read → real value
+                        ;; (no redirect, so the handler proceeds to render
+                        ;; the shell). 2nd call = post-shell re-read → inject
+                        ;; the latent redirect.
+                        (if (= n 2)
+                          redirect-resp
+                          (real-get-response fid))))]
+        (let [handler       (ssr-ring/stream-handler
+                              {:on-create [:rf.test.server/init-min]
+                               :root-view [:test/plain-root]
+                               :payload :rf.ssr.payload/whole-app-db})
+              baseline-fids (disj (frame/frame-ids) :rf/default)
+              response      (handler {:uri "/secret" :request-method :get})]
+          (is (= 302 (:status response))
+              "post-shell redirect ships the 3xx status on the wire")
+          (let [headers (:headers response)
+                loc     (or (get headers "Location") (get headers "location"))]
+            (is (= "/post-shell-login" loc)
+                "Location header carries the post-shell redirect target"))
+          (is (= "" (:body response))
+              "post-shell redirect is BODILESS — :body \"\", NOT a streamed
+               full HTML document (the latent fail-open this fix closes)")
+          (is (not (instance? InputStream (:body response)))
+              "post-shell redirect body is NOT a PipedInputStream — no
+               writer pipe is handed out")
+          ;; No writer thread spawned + frame torn down inline (the writer's
+          ;; finally — the streaming teardown path — never runs on this
+          ;; branch, so the inline destroy is load-bearing).
+          (let [end-fids (disj (frame/frame-ids) :rf/default)
+                leaked   (clojure.set/difference end-fids baseline-fids)]
+            (is (empty? leaked)
+                (str "the per-request frame MUST be destroyed inline on the
+                     post-shell redirect branch — leaked frame-ids: "
+                     (vec leaked)))))))))
+
+;; ===========================================================================
+;; rf2-5knxf.2 — the streaming final-payload :rf/render-hash MATCHES the
+;;               client's resolved-tree hash (markers and all) when forms
+;;               are symmetric; the suspense marker is NOT a divergence.
+;; ===========================================================================
+;;
+;; The concern (rf2-5knxf.2) was that the streaming final hash is computed
+;; over the suspense-marker-bearing tree while the client recomputes over a
+;; "resolved" (marker-free) tree, firing a spurious
+;; :rf.ssr/hydration-mismatch on a successful streaming hydration.
+;;
+;; That premise is empirically FALSE. `render-tree-hash` is a PURE
+;; structural FNV-1a over the canonical-EDN of the hiccup — it does not
+;; expand views and does not throw on `:rf/suspense-boundary`; the marker
+;; hashes to the same canonical-EDN bytes on both sides. A streaming-aware
+;; client verifies via `:render-tree-fn #((rf/view :app/root))`, whose
+;; result is the SAME marker-bearing hiccup the server's `(rf/view
+;; :app/root)` produces. This test pins that equality directly, and pins
+;; that the streaming hash is computed by the IDENTICAL mechanism as the
+;; non-streaming handler (the only divergence is the host's choice of
+;; view-ref vs expanded form for :root-view / :render-tree-fn — shared by
+;; both handlers, not a streaming marker bug).
+
+(deftest streaming-final-hash-matches-client-resolved-tree
+  (testing "rf2-5knxf.2: the server's render-tree-hash of the marker-bearing
+            root view EQUALS the client's `#((rf/view :root))` hash — the
+            suspense marker is NOT a divergence (render-tree-hash is a pure
+            structural hash that does not expand or reject the marker)."
+    (rf/reg-event-fx :rf.test.server/init
+      {:platforms #{:server}}
+      (fn [_ _] {:db {:comments [{:body "First!"}]}}))
+    (rf/reg-sub :comments (fn [db _] (:comments db)))
+    (rf/reg-view ^{:rf/id :test/comments-section} comments-view []
+      (let [cs @(subscribe [:comments])]
+        (into [:ul.comments] (for [{:keys [body]} cs] [:li body]))))
+    (rf/reg-view ^{:rf/id :test/hash-root} hash-root []
+      [:main [:h1 "News"]
+       [:rf/suspense-boundary {:id :test/comments :fallback [:p "Loading…"]}
+        [:test/comments-section]]
+       [:footer "End"]])
+    (let [fid (keyword "rf.frame" (str (gensym "f")))]
+      (rf/reg-frame fid {:platform :server :on-create [:rf.test.server/init]})
+      (try
+        (rf/with-frame fid
+          (let [;; The server streaming handler computes the final hash over
+                ;; `hiccup` = (resolve-root-view root-view). When the host
+                ;; passes an EXPANDED form (symmetric with the client's
+                ;; :render-tree-fn), this is the marker-bearing root tree.
+                server-hiccup (lifecycle/resolve-root-view
+                                (fn [] ((rf/view :test/hash-root))))
+                server-hash   (ssr/render-tree-hash server-hiccup)
+                ;; The client verifies via :render-tree-fn #((rf/view :root)).
+                client-hiccup ((rf/view :test/hash-root))
+                client-hash   (ssr/render-tree-hash client-hiccup)]
+            ;; The marker IS present in both trees (the equality is NOT
+            ;; achieved by stripping it).
+            (is (str/includes? (pr-str server-hiccup) ":rf/suspense-boundary")
+                "server hiccup carries the :rf/suspense-boundary marker")
+            (is (str/includes? (pr-str client-hiccup) ":rf/suspense-boundary")
+                "client hiccup carries the :rf/suspense-boundary marker")
+            ;; The load-bearing assertion: marker-bearing server hash ==
+            ;; marker-bearing client hash. No spurious mismatch.
+            (is (= server-hash client-hash)
+                "streaming final-payload render-hash (over the marker-bearing
+                 resolved root) EQUALS the client's resolved-tree hash — the
+                 suspense marker hashes symmetrically on both sides, so a
+                 successful streaming hydration fires NO spurious
+                 :rf.ssr/hydration-mismatch (rf2-5knxf.2)")))
+        (finally
+          (rf/destroy-frame! fid))))))


### PR DESCRIPTION
Two latent streaming-SSR findings from the rf2-5knxf correctness re-review, both in `implementation/ssr-ring` streaming. One PR.

## rf2-5knxf.1 — post-shell redirect fail-open (FIXED, close the latent gap)

`stream-handler`'s post-shell materialise branch unconditionally spawned the daemon writer and `assoc`'d the pipe `:body`, with **no branch on `(:redirect resp2)`** — even though the inline comment claimed a redirect "rides the wire unchanged". A `:redirect` surfacing at the post-shell `get-response` re-read would have shipped a **malformed 3xx + Location + a FULL streamed HTML body** (the writer pumps shell + payload + close) for a wire response the contract says must be **bodiless** (Spec 011 §Redirect precedence), plus a body-pumping writer thread. The non-streaming handler gets this for free (`ssr-response->ring-response` ignores the body arg on its `:redirect` branch); the streaming path had to branch explicitly.

**Not live-reachable in v1** — `:redirect` is set only by the `:rf.server/redirect` fx during the `:on-create` drain (caught by the EARLY redirect branch), the error projector stamps `:status` only (never `:redirect`, error_listener.cljc), and render-phase subs cannot dispatch fx. So it is a **latent fail-open + code-vs-comment divergence**.

**Decision: close the latent gap (defense-in-depth), per the bead's preference.** Low complexity — the new branch mirrors the existing early redirect branch exactly (2-arg bodiless `ssr-response->ring-response`, inline frame destroy in a `finally`, no writer). Aligns the code with its own parity comment.

Regression: `stream-handler-post-shell-redirect-bodiless` — stubs the post-shell `get-response` to inject the latent redirect, asserts `:body ""` (not an `InputStream`) + frame torn down inline. Has discriminating power (fails on the old unconditional-writer code).

## rf2-5knxf.2 — streaming render-hash (INVESTIGATED → document, not a streaming defect)

The concern: the streaming final-payload `:rf/render-hash` is computed over the **suspense-marker-bearing** tree while the client recomputes over a **marker-free "resolved"** tree → spurious `:rf.ssr/hydration-mismatch` on a successful streaming hydration.

**Empirically false.** `render-tree-hash` is a **pure structural FNV-1a over canonical-EDN** — it does not expand views and does not throw on `:rf/suspense-boundary`; the marker hashes to the same bytes on both sides. A streaming-aware client verifies via `:render-tree-fn #((rf/view :root))`, whose result is the **same marker-bearing hiccup** the server's `(rf/view :root)` produces → **the hashes MATCH, markers and all** (proven empirically; pinned by the regression).

The only divergence is the host passing a **view-ref** `:root-view` vs an **expanded** `:render-tree-fn` — and that asymmetry is **shared by the non-streaming handler** (identical `resolve-root-view` → `render-tree-hash` shape; confirmed empirically), so it is the host's symmetry responsibility, **not** a streaming marker bug. Spec 011's "structural equivalence" rule is satisfied when both sides pass matching forms (as the worked example already does).

**Decision: document** at the final-hash site (why the marker is not a divergence; how host symmetry works) + pin with the `streaming-final-hash-matches-client-resolved-tree` regression (asserts marker present on BOTH trees AND hashes equal — equality is not achieved by stripping the marker).

## Gates
- `implementation/ssr-ring` `clojure -M:test` — 121 tests / 529 assertions, 0 failures (was 119; +2 regressions)
- `implementation/ssr` `clojure -M:test` — 281 tests / 998 assertions, 0 failures (hash mechanism unchanged)

Closes rf2-5knxf.1, rf2-5knxf.2.