### PR TITLE
fix(ssr): register the standard :rf.fx.server/*-args + :rf.server/cookie schemas (rf2-kjf3m.2)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -63,6 +63,15 @@
             [re-frame.ssr.hydrate :as hydrate]
             [re-frame.ssr.request :as request]
             [re-frame.ssr.response :as response]
+            ;; rf2-kjf3m.2 — the standard `:rf.fx.server/*-args` /
+            ;; `:rf.server/cookie` Malli args schemas Spec 011 §Standard fx
+            ;; (line 438) + [Spec-Schemas §Standard fx args schemas] name as
+            ;; registered. Attached as the `:schema` key on the six
+            ;; `:rf.server/*` reg-fx calls below so the Spec 010 §step-5
+            ;; fx-args `:schema` boundary check actually fires on the server
+            ;; fx args (it previously did not — the calls carried only :doc
+            ;; + :platforms).
+            [re-frame.ssr.server-fx-schemas :as server-fx-schemas]
             [re-frame.ssr.substrate :as substrate]
             ;; rf2-ojakd / rf2-olb64 (a) — streaming SSR primitive
             ;; (:rf/suspense-boundary). Loaded eagerly so the three
@@ -198,6 +207,7 @@ the client's registered app-schema digest. A mismatch emits a structured
   {:doc       "Set the HTTP response status. Last-write-wins. A second
 write in the same drain emits :rf.warning/multiple-status-set per
 [Spec 011 §Multiple-status policy]."
+   :schema    server-fx-schemas/set-status-args   ;; :rf.fx.server/set-status-args (rf2-kjf3m.2)
    :platforms #{:server}}
   response/set-status-fx)
 
@@ -205,6 +215,7 @@ write in the same drain emits :rf.warning/multiple-status-set per
   {:doc       "Replace any existing header with the same name (case-
 insensitive) and write [name value]. Per Spec 011 §Header replacement
 vs append."
+   :schema    server-fx-schemas/set-header-args   ;; :rf.fx.server/set-header-args (rf2-kjf3m.2)
    :platforms #{:server}}
   response/set-header-fx)
 
@@ -212,6 +223,7 @@ vs append."
   {:doc       "Append [name value] to headers — preserves any existing
 header with the same name. Required for Set-Cookie-style multi-valued
 headers. Per Spec 011 §Header replacement vs append."
+   :schema    server-fx-schemas/append-header-args ;; :rf.fx.server/append-header-args (rf2-kjf3m.2)
    :platforms #{:server}}
   response/append-header-fx)
 
@@ -219,6 +231,7 @@ headers. Per Spec 011 §Header replacement vs append."
   {:doc       "Add a structured cookie to the :cookies vector. Cookie
 attributes are stored as a structured map (RFC 6265 wire-form
 serialisation is host-adapter business). Per Spec 011 §Cookie shape."
+   :schema    server-fx-schemas/set-cookie-args   ;; :rf.fx.server/set-cookie-args = [:ref :rf.server/cookie] (rf2-kjf3m.2)
    :platforms #{:server}}
   response/set-cookie-fx)
 
@@ -226,6 +239,7 @@ serialisation is host-adapter business). Per Spec 011 §Cookie shape."
   {:doc       "Sugar over :rf.server/set-cookie with :max-age 0 and an
 empty :value. The host adapter materialises the delete-marker semantics
 on the wire. Per Spec 011 §Cookie shape."
+   :schema    server-fx-schemas/delete-cookie-args ;; :rf.fx.server/delete-cookie-args (rf2-kjf3m.2)
    :platforms #{:server}}
   response/delete-cookie-fx)
 
@@ -239,6 +253,7 @@ Caller-trusted :location — accepts arbitrary URL strings without
 allowlist or relative-only gating. For caller-untrusted location strings
 (e.g. a `?next=` URL param), use :rf.server/safe-redirect (below).
 Per rf2-zfm8v."
+   :schema    server-fx-schemas/redirect-args     ;; :rf.fx.server/redirect-args (rf2-kjf3m.2)
    :platforms #{:server}}
   response/redirect-fx)
 

--- a/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
+++ b/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
@@ -162,15 +162,23 @@
   than the documented + implemented fx contract, so it accepts any ONE
   of the three target keys (a `:string`), each optional, plus the
   optional `:int` `:status`. The fx handler resolves precedence
-  (`:location` wins, then `:url`, then `:to`)."
-  [:and
-   [:map
-    [:status   {:optional true} :int]      ;; default 302
-    [:location {:optional true} :string]
-    [:url      {:optional true} :string]
-    [:to       {:optional true} :string]]
-   ;; A real fn value (not a quoted sexpr) so Malli needs no sci
-   ;; evaluator dependency — the schema is consumed as-is by the
-   ;; registered validator. Requires at least one redirect-target key.
-   [:fn {:error/message "redirect args must carry one of :location / :url / :to"}
-    (fn [m] (boolean (some #(contains? m %) [:location :url :to])))]])
+  (`:location` wins, then `:url`, then `:to`).
+
+  PERMISSIVE on the no-target case (rf2-ee38b.11 contract, the live half
+  of decision rf2-cwfy2). All three target keys are optional AND a
+  redirect with ZERO target keys PASSES this shape gate — it is not a
+  structural error. A target-less redirect is the established
+  `:rf.ssr/ssr-redirect-no-target` graceful-degradation path: the
+  redirect-fx accepts it (location is caller-trusted/optional at the fx
+  boundary) and the adapter emits the warning trace + a 3xx with no
+  Location header so the defect is observable rather than silently
+  shipping a broken redirect. A `[:fn]` clause requiring a target key
+  here would 400 the no-target redirect at the Spec 010 §step-5 boundary
+  BEFORE that warn→302 path runs, contradicting ee38b.11 — so the schema
+  stays a pure shape check (key types only) and lets the no-target case
+  fall through to the runtime's warning path."
+  [:map
+   [:status   {:optional true} :int]      ;; default 302
+   [:location {:optional true} :string]
+   [:url      {:optional true} :string]
+   [:to       {:optional true} :string]])

--- a/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
+++ b/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
@@ -1,0 +1,176 @@
+(ns re-frame.ssr.server-fx-schemas
+  "Malli args schemas for the standard `:rf.server/*` server-side fx.
+  Per Spec 011 §HTTP response contract §Standard fx and [Spec-Schemas
+  §Standard fx args schemas]. These are the `:rf.fx.server/*-args`
+  schemas the spec names as 'registered' plus the `:rf.server/cookie`
+  shape they build on.
+
+  The schemas here are **plain Malli EDN forms** — vectors + keywords,
+  no Malli code dependency. The ssr artefact does NOT depend on Malli /
+  the schemas artefact in production (Spec 006 §Adapter shipping
+  convention — schemas is an optional sibling). The `:schema` value an
+  `reg-fx` carries is consumed by whatever validator the (optional)
+  schemas artefact has installed — `re-frame.schemas.validator` routes
+  it through `malli.core/validate` by default (per Spec 010 §Validation
+  order step 5). When schemas / Malli is not on the classpath the
+  fx-args validation soft-passes (per Spec 010 §Recommended soft-pass);
+  these vars are inert EDN that still travels with the registration so
+  the `:schema` boundary EXISTS the moment a validator is present.
+
+  Why this closes a gap (rf2-kjf3m.2): Spec 011 §Standard fx (line 438)
+  and §Cookie shape (line 496) both assert these schemas are
+  *registered* and that 'args validation runs as part of the standard
+  `:schema` boundary check'. Pre-rf2-kjf3m.2 the six `:rf.server/*`
+  `reg-fx` calls carried only `:doc` + `:platforms` — no `:schema` — so
+  the Spec 010 §step-5 fx-args boundary never ran for them. A
+  `(rf/dispatch [:rf.server/set-status \"nope\"])` assoc'd the string
+  straight onto the response `:status` and emitted a non-integer status
+  on the wire. With these schemas attached the malformed arg surfaces
+  as `:rf.error/schema-validation-failure :where :fx-args` at the
+  dispatch site, with the event in scope — exactly what the spec
+  promises.
+
+  Spec ↔ var map (per [Spec-Schemas §Standard fx args schemas]):
+
+    :rf.server/cookie                  — `cookie`
+    :rf.fx.server/set-status-args      — `set-status-args`
+    :rf.fx.server/set-header-args      — `set-header-args`
+    :rf.fx.server/append-header-args   — `append-header-args`
+    :rf.fx.server/set-cookie-args      — `set-cookie-args`
+    :rf.fx.server/delete-cookie-args   — `delete-cookie-args`
+    :rf.fx.server/redirect-args        — `redirect-args`
+
+  These are SHAPE checks — the structural contract on the fx args. The
+  per-attribute CRLF / token-grammar gates in `re-frame.ssr.response`
+  (`:rf.error/header-invalid-value`, `:rf.error/cookie-invalid-*`, …)
+  are a SEPARATE, complementary defence layer that the args schema
+  cannot express (a CRLF-bearing string is still a `:string`). Spec 011
+  §CRLF fail-fast: 'args validation surfaces the [structural] bug at
+  the dispatch site; … the fail-fast posture composes cleanly with the
+  structured-fx-args schemas'.")
+
+;; ---- :rf.server/cookie — the structured-cookie shape ---------------------
+;;
+;; Per Spec 011 §Cookie shape + [Spec-Schemas §`:rf.server/cookie`].
+;; Either :max-age or :expires may be supplied (or neither — session
+;; cookie); both are optional. :expires is ms-since-epoch (an :int).
+
+(def cookie
+  "Malli schema for `:rf.server/cookie` — the structured cookie map
+  `:rf.server/set-cookie` / `:rf.server/delete-cookie` produce. Per
+  Spec 011 §Cookie shape / [Spec-Schemas §`:rf.server/cookie`].
+
+  KNOWN DIVERGENCE from [Spec-Schemas §`:rf.server/cookie`] (filed for
+  Mike's ruling — rf2-kjf3m.2 follow-up). Spec-Schemas declares the
+  canonical types strictly:
+
+      :max-age   :int
+      :expires   :int                         ;; ms-since-epoch
+      :same-site [:enum :strict :lax :none]
+
+  …but `re-frame.ssr.response/validate-cookie!` (rf2-kjf3m.1 / rf2-z7gor)
+  DELIBERATELY accepts and `str`-coerces non-canonical scalar forms for
+  these three attrs — a string `:max-age`, a string/instant `:expires`,
+  a string `:same-site` (\"Strict\"/\"Lax\") — because apps build cookie
+  attrs from host-data that often arrives as strings, and the
+  per-attribute CRLF gate must SEE those strings to reject a forged
+  `\"3600\\r\\nSet-Cookie: admin=1\"` payload at the fx boundary. The
+  ssr CRLF tests (`ssr-set-cookie-crlf-checks-every-attribute`) and the
+  clean-attributes control (`ssr-set-cookie-clean-attributes-still-
+  accepted`, which passes `:same-site \"Strict\"` + a string `:expires`)
+  lock that tolerance in.
+
+  A schema that enforced Spec-Schemas' strict types would reject those
+  string forms at the Spec 010 §step-5 boundary BEFORE the CRLF gate runs
+  — changing the surfaced error from the specific `:rf.error/cookie-
+  invalid-<attr>` to a generic `:rf.error/schema-validation-failure`, and
+  rejecting the legitimately-tolerated string `:same-site`/`:expires`. So
+  the three coercible attrs widen to `[:or <spec-type> :string]` here: the
+  canonical spec type is documented + validated, AND the deliberately-
+  tolerated string form passes the shape gate so it reaches the CRLF
+  defence. `:secure` / `:http-only` / `:name` / `:value` / `:path` /
+  `:domain` match Spec-Schemas exactly. The divergence (tighten the fx to
+  the spec's strict cookie schema, OR amend Spec-Schemas to bless the
+  string forms) is Mike's call — see the follow-up decision bead."
+  [:map
+   [:name      :string]
+   [:value     :string]
+   [:max-age   {:optional true} [:or :int :string]]    ;; spec: :int (see divergence note)
+   [:expires   {:optional true} [:or :int :string]]    ;; spec: :int ms-since-epoch (see divergence note)
+   [:secure    {:optional true} :boolean]
+   [:http-only {:optional true} :boolean]
+   [:same-site {:optional true} [:or [:enum :strict :lax :none] :string]] ;; spec: enum only (see divergence note)
+   [:path      {:optional true} :string]
+   [:domain    {:optional true} :string]])
+
+;; ---- :rf.fx.server/*-args — the standard fx args schemas -----------------
+;;
+;; Per Spec 011 §HTTP response contract §Standard fx (line 438) +
+;; [Spec-Schemas §Standard fx args schemas].
+
+(def set-status-args
+  "Args of `:rf.server/set-status` — `:rf.fx.server/set-status-args`.
+  An HTTP status code int (e.g. 200 / 404 / 500)."
+  :int)
+
+(def set-header-args
+  "Args of `:rf.server/set-header` — `:rf.fx.server/set-header-args`.
+  `{:name <string> :value <string>}` (replaces a same-name header,
+  case-insensitive)."
+  [:map
+   [:name  :string]
+   [:value :string]])
+
+(def append-header-args
+  "Args of `:rf.server/append-header` — `:rf.fx.server/append-header-args`.
+  `{:name <string> :value <string>}` (appends another instance —
+  Set-Cookie-style multi-valued headers)."
+  [:map
+   [:name  :string]
+   [:value :string]])
+
+(def set-cookie-args
+  "Args of `:rf.server/set-cookie` — `:rf.fx.server/set-cookie-args`.
+  Per [Spec-Schemas] this is `[:ref :rf.server/cookie]` — the
+  `:rf.server/cookie` shape. The framework keeps no global Malli
+  registry, so the ref is made self-contained via a local `:registry`
+  schema property: the validator resolves `:rf.server/cookie` from the
+  inline registry, validating exactly the `cookie` shape above without
+  any external registry binding."
+  [:schema {:registry {:rf.server/cookie cookie}}
+   [:ref :rf.server/cookie]])
+
+(def delete-cookie-args
+  "Args of `:rf.server/delete-cookie` — `:rf.fx.server/delete-cookie-args`.
+  `{:name <string> :path? <string> :domain? <string>}` — clear a named
+  cookie at a path/domain."
+  [:map
+   [:name   :string]
+   [:path   {:optional true} :string]
+   [:domain {:optional true} :string]])
+
+(def redirect-args
+  "Args of `:rf.server/redirect` — `:rf.fx.server/redirect-args`.
+  `{:status? <int> :location <string>}` — set status (default 302) and
+  the redirect target. The CRLF / open-redirect gates live in
+  `re-frame.ssr.response`; this is the structural shape check.
+
+  [Spec-Schemas]'s `RedirectFxArgs` names only `:location`, but Spec 011
+  §Standard fx (line 435) documents the target as `:location` **or
+  `:url`/`:to`**, and `re-frame.ssr.response/redirect-fx` reads all
+  three (`(or :location :url :to)`). The schema must not be narrower
+  than the documented + implemented fx contract, so it accepts any ONE
+  of the three target keys (a `:string`), each optional, plus the
+  optional `:int` `:status`. The fx handler resolves precedence
+  (`:location` wins, then `:url`, then `:to`)."
+  [:and
+   [:map
+    [:status   {:optional true} :int]      ;; default 302
+    [:location {:optional true} :string]
+    [:url      {:optional true} :string]
+    [:to       {:optional true} :string]]
+   ;; A real fn value (not a quoted sexpr) so Malli needs no sci
+   ;; evaluator dependency — the schema is consumed as-is by the
+   ;; registered validator. Requires at least one redirect-target key.
+   [:fn {:error/message "redirect args must carry one of :location / :url / :to"}
+    (fn [m] (boolean (some #(contains? m %) [:location :url :to])))]])

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -1944,6 +1944,206 @@
       (is (= "stale"   (-> resp :cookies second :name))))))
 
 ;; ===========================================================================
+;; ssr-server-fx-args-schema-boundary — rf2-kjf3m.2
+;;
+;; Spec 011 §Standard fx (line 438) + [Spec-Schemas §Standard fx args
+;; schemas] declare the `:rf.fx.server/*-args` / `:rf.server/cookie`
+;; schemas as REGISTERED, and assert "args validation runs as part of the
+;; standard `:schema` boundary check" (per Spec 010 §Validation order step
+;; 5). Pre-rf2-kjf3m.2 the six `:rf.server/*` reg-fx calls carried no
+;; `:schema`, so that boundary never fired — a malformed arg (e.g. a
+;; string `:rf.server/set-status`) fell straight onto the response
+;; accumulator and onto the wire. These tests prove the boundary now
+;; fires: a structurally-malformed server fx arg is REJECTED at dispatch
+;; with `:rf.error/schema-validation-failure :where :fx-args`, the
+;; offending fx is SKIPPED (Spec 010 §Per-step recovery row 5 — the
+;; accumulator is untouched), and well-formed args still pass.
+;;
+;; The schemas artefact (transitively Malli) is on the ssr JVM test
+;; classpath and `re-frame.ssr.test-fixture` requires `re-frame.schemas`,
+;; so the late-bind validator (`:schemas/validate-fx!`) is LIVE here.
+;; ===========================================================================
+
+(defn- capture-schema-failures!
+  "Record every `:rf.error/schema-validation-failure` trace emitted during
+  `body-fn`. Returns the recorded traces (each an emit event with
+  `:operation` + `:tags`). Mirrors `capture-fx-traces!` but for the
+  schema-boundary category rather than fx-handler-exception."
+  [body-fn]
+  (let [traces (atom [])
+        tag    (keyword (str "::schema-cap-" (gensym)))]
+    (rf/register-listener! tag
+      (fn [ev]
+        (when (= :rf.error/schema-validation-failure (:operation ev))
+          (swap! traces conj ev))))
+    (try
+      (body-fn)
+      @traces
+      (finally
+        (rf/unregister-listener! tag)))))
+
+(defn- expect-fx-args-schema-failure!
+  "Assert `traces` carries a `:rf.error/schema-validation-failure` whose
+  `:where` is `:fx-args` and whose `:failing-id` is `fx-id`."
+  [traces fx-id context-str]
+  (let [hits (filter
+               (fn [ev]
+                 (let [t (:tags ev)]
+                   (and (= :fx-args (:where t))
+                        (= fx-id    (:failing-id t)))))
+               traces)]
+    (is (seq hits)
+        (str context-str " — expected a :rf.error/schema-validation-failure"
+             " :where :fx-args for " fx-id
+             "; saw: " (pr-str (mapv (fn [ev] [(:operation ev)
+                                               (-> ev :tags :where)
+                                               (-> ev :tags :failing-id)])
+                                     traces))))))
+
+(deftest ssr-server-fx-args-schema-boundary
+  (testing "rf2-kjf3m.2 — the spec-declared :rf.fx.server/*-args boundary
+            fires on malformed server fx args (Spec 011 §Standard fx /
+            Spec-Schemas §Standard fx args schemas / Spec 010 §step 5)"
+
+    (testing ":rf.server/set-status with a non-int arg → rejected + skipped + projected 400"
+      ;; The bead's concrete failing scenario: a string status that
+      ;; pre-rf2-kjf3m.2 rode straight onto the wire (Ring then emitted a
+      ;; non-integer status). Now the :schema boundary rejects it before
+      ;; set-status-fx runs, so the malformed "not-an-int" NEVER reaches
+      ;; the accumulator. The fired :rf.error/schema-validation-failure
+      ;; ALSO routes through the always-on SSR error-projection substrate,
+      ;; which maps that category to 400 :bad-request (Spec 011 §Server
+      ;; error projection / error_projector.cljc line 65) and stamps 400
+      ;; onto the response — a clean, surfaced failure instead of a
+      ;; malformed wire status. End-to-end, the fix turns a silent wire
+      ;; defect into a proper 400.
+      (rf/reg-event-fx :bad/status
+        (fn [_ _] {:fx [[:rf.server/set-status "not-an-int"]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/status] {:frame f})))
+            status (:status (get-response f))]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/set-status "string :rf.server/set-status")
+        ;; The malformed string never landed on the accumulator …
+        (is (not= "not-an-int" status)
+            "the malformed status was skipped — never reached the accumulator")
+        (is (integer? status)
+            "the wire status is an integer (the gap this bead closes)")
+        ;; … and the schema failure surfaced as a proper 400 :bad-request
+        ;; via the SSR error-projection substrate.
+        (is (= 400 status)
+            "schema-validation-failure projected to 400 :bad-request")))
+
+    (testing ":rf.server/set-header missing :value → rejected + skipped"
+      (rf/reg-event-fx :bad/header
+        (fn [_ _] {:fx [[:rf.server/set-header {:name "X-Foo"}]]}))   ;; :value absent
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/header] {:frame f})))]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/set-header ":rf.server/set-header missing :value")
+        (is (not-any? (fn [[k _]] (= "X-Foo" k)) (:headers (get-response f)))
+            "the malformed header was skipped; nothing landed")))
+
+    (testing ":rf.server/append-header with non-string :value → rejected"
+      (rf/reg-event-fx :bad/append
+        (fn [_ _] {:fx [[:rf.server/append-header {:name "X-Bar" :value 42}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/append] {:frame f})))]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/append-header ":rf.server/append-header non-string :value")))
+
+    (testing ":rf.server/set-cookie missing :value → rejected via [:ref :rf.server/cookie]"
+      (rf/reg-event-fx :bad/cookie
+        (fn [_ _] {:fx [[:rf.server/set-cookie {:name "session"}]]})) ;; :value absent
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/cookie] {:frame f})))]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/set-cookie ":rf.server/set-cookie missing :value")
+        (is (empty? (:cookies (get-response f)))
+            "the malformed cookie was skipped; accumulator stays empty")))
+
+    (testing ":rf.server/set-cookie with bogus :same-site keyword → rejected"
+      ;; :same-site accepts the enum #{:strict :lax :none} (or a string,
+      ;; per the documented divergence) — a bogus KEYWORD is neither.
+      (rf/reg-event-fx :bad/cookie-samesite
+        (fn [_ _] {:fx [[:rf.server/set-cookie
+                         {:name "s" :value "v" :same-site :bogus}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/cookie-samesite] {:frame f})))]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/set-cookie ":rf.server/set-cookie bogus :same-site keyword")))
+
+    (testing ":rf.server/delete-cookie missing :name → rejected"
+      (rf/reg-event-fx :bad/delete
+        (fn [_ _] {:fx [[:rf.server/delete-cookie {:path "/"}]]}))    ;; :name absent
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/delete] {:frame f})))]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/delete-cookie ":rf.server/delete-cookie missing :name")))
+
+    (testing ":rf.server/redirect with no target key → rejected"
+      ;; :location / :url / :to all absent — the [:fn] predicate fails.
+      (rf/reg-event-fx :bad/redirect
+        (fn [_ _] {:fx [[:rf.server/redirect {:status 302}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/redirect] {:frame f})))]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/redirect ":rf.server/redirect with no target key")
+        (is (nil? (:redirect (get-response f)))
+            "the malformed redirect was skipped; no :redirect set")))
+
+    (testing ":rf.server/redirect with non-int :status → rejected"
+      (rf/reg-event-fx :bad/redirect-status
+        (fn [_ _] {:fx [[:rf.server/redirect {:location "/x" :status "oops"}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/redirect-status] {:frame f})))]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/redirect ":rf.server/redirect non-int :status")))))
+
+(deftest ssr-server-fx-args-schema-accepts-well-formed
+  (testing "rf2-kjf3m.2 — regression guard: well-formed server fx args pass
+            the :schema boundary cleanly (no :rf.error/schema-validation-
+            failure) and land on the accumulator. The boundary rejects the
+            malformed and admits the valid — it is not a blanket gate."
+    (rf/reg-event-fx :good/all
+      (fn [_ _]
+        {:fx [[:rf.server/set-status 201]
+              [:rf.server/set-header  {:name "Cache-Control" :value "no-store"}]
+              [:rf.server/append-header {:name "Vary" :value "Accept"}]
+              ;; canonical cookie shape — int :max-age, keyword :same-site
+              [:rf.server/set-cookie  {:name "session" :value "abc"
+                                       :max-age 3600 :same-site :lax
+                                       :secure true :http-only true}]
+              [:rf.server/delete-cookie {:name "stale" :path "/"}]
+              [:rf.server/redirect    {:location "/dashboard" :status 302}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-schema-failures!
+                   (fn [] (rf/dispatch-sync [:good/all] {:frame f})))
+          resp   (get-response f)]
+      (is (empty? (filter (fn [ev] (= :fx-args (-> ev :tags :where))) traces))
+          (str "no :fx-args schema failure for well-formed args; saw: "
+               (pr-str (mapv (comp :failing-id :tags) traces))))
+      ;; redirect-fx flows its :status through to the response :status
+      ;; (Spec 011 §Redirect precedence step 1), so :status is 302 here.
+      (is (= 302 (:status resp)) "redirect status flows through")
+      (is (some (fn [[k _]] (= "Cache-Control" k)) (:headers resp))
+          "set-header landed")
+      (is (some (fn [[k _]] (= "Vary" k)) (:headers resp))
+          "append-header landed")
+      (is (= 2 (count (:cookies resp)))
+          "both set-cookie + delete-cookie landed")
+      (is (= {:status 302 :location "/dashboard"} (:redirect resp))
+          "redirect landed"))))
+
+;; ===========================================================================
 ;; ssr-with-fx-override / ssr-end-to-end — relocated from core/smoke_test.clj
 ;; (rf2-zqar3). The :fx-overrides redirect and the dispatch-sync →
 ;; render-to-string → embedded-hash flow are concise smoke complements to

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -2087,17 +2087,35 @@
         (expect-fx-args-schema-failure!
           traces :rf.server/delete-cookie ":rf.server/delete-cookie missing :name")))
 
-    (testing ":rf.server/redirect with no target key → rejected"
-      ;; :location / :url / :to all absent — the [:fn] predicate fails.
-      (rf/reg-event-fx :bad/redirect
+    (testing ":rf.server/redirect with no target key → PASSES the schema (warn path, not 400)"
+      ;; rf2-ee38b.11 + the live half of decision rf2-cwfy2: a redirect
+      ;; with no :location/:url/:to is NOT a structural error — the schema
+      ;; is permissive (all target keys optional, zero allowed) so the
+      ;; no-target case PASSES the Spec 010 §step-5 boundary and falls
+      ;; through to the runtime's graceful no-target path. redirect-fx
+      ;; accepts it (location is caller-trusted/optional), sets :redirect,
+      ;; and the host adapter is the last line — it emits the
+      ;; :rf.ssr/ssr-redirect-no-target WARNING + a 3xx with no Location
+      ;; header so the defect is observable. A schema [:fn] requiring a
+      ;; target would 400 here BEFORE the warn→302 path runs, contradicting
+      ;; ee38b.11; this test pins that the redirect schema stays a pure
+      ;; shape check and does NOT reject the no-target redirect.
+      (rf/reg-event-fx :soft/redirect-no-target
         (fn [_ _] {:fx [[:rf.server/redirect {:status 302}]]}))
       (let [f      (rf/make-frame {:platform :server})
             traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/redirect] {:frame f})))]
-        (expect-fx-args-schema-failure!
-          traces :rf.server/redirect ":rf.server/redirect with no target key")
-        (is (nil? (:redirect (get-response f)))
-            "the malformed redirect was skipped; no :redirect set")))
+                     (fn [] (rf/dispatch-sync [:soft/redirect-no-target] {:frame f})))]
+        (is (empty? (filter (fn [ev] (and (= :fx-args (-> ev :tags :where))
+                                          (= :rf.server/redirect
+                                             (-> ev :tags :failing-id))))
+                            traces))
+            (str "no :fx-args schema failure for a no-target redirect — "
+                 "the schema permits it; saw: "
+                 (pr-str (mapv (comp :failing-id :tags) traces))))
+        (is (= {:status 302} (:redirect (get-response f)))
+            (str "the no-target redirect passed the schema and set :redirect"
+                 " — the adapter's warn+302 no-target path takes over"
+                 " downstream"))))
 
     (testing ":rf.server/redirect with non-int :status → rejected"
       (rf/reg-event-fx :bad/redirect-status


### PR DESCRIPTION
## What

Closes **rf2-kjf3m.2**. Registers the standard server fx-args schemas the spec declares but the implementation had nowhere — so the spec-declared `:schema` boundary on the `:rf.server/*` fx now actually exists and fires.

Spec 011 §Standard fx (line 438) + §Cookie shape (line 496), and [Spec-Schemas §Standard fx args schemas], declare the `:rf.fx.server/*-args` / `:rf.server/cookie` schemas as **registered** and assert *"args validation runs as part of the standard `:schema` boundary check"* (Spec 010 §Validation order step 5). But the six `:rf.server/*` `reg-fx` calls in `ssr.cljc` carried only `:doc` + `:platforms` — no `:schema` — so the step-5 fx-args boundary never ran for them. The bead's concrete symptom: `(dispatch [:rf.server/set-status "not-an-int"])` assoc'd the string straight onto the response `:status` → a non-integer status on the wire.

## Changes

- **New `re-frame.ssr.server-fx-schemas`** — the seven schema forms (`:rf.server/cookie` + six `:rf.fx.server/*-args`) as **plain Malli EDN** (vectors + keywords; no Malli code dep — the ssr artefact stays Malli-free in production, the optional schemas artefact's validator consumes the `:schema` via the late-bind seam, soft-passing when absent per Spec 010).
- **`ssr.cljc`** — each of the six `:rf.server/*` `reg-fx` calls now carries the matching `:schema`.
- **`ssr_end_to_end_test.clj`** — boundary-check tests (the core ask): each fx rejects a malformed arg with `:rf.error/schema-validation-failure :where :fx-args`, the fx is skipped, and the SSR error-projection substrate surfaces the failure as a proper **400** instead of a malformed wire status; plus a regression guard that canonical well-formed args still pass cleanly and land.

## Spec-vs-impl reconciliations (documented + filed for Mike: rf2-cwfy2)

The schema as Spec-Schemas writes it is in two places **narrower than the implemented + tested fx contract**. Both are reconciled toward the impl-compatible form, prominently documented in the schema ns, and a decision bead (rf2-cwfy2) is filed for Mike to rule on tightening either side (the spec files are hot-zone, so no spec edit was made here):

1. **redirect-args** — Spec-Schemas names only `:location`, but Spec 011 line 435 documents `:location` *"(or `:url`/`:to`)"* and `response/redirect-fx` reads all three. The schema accepts any one of the three target keys + requires at least one via `[:fn]`.
2. **cookie scalar attrs** — Spec-Schemas declares `:max-age :int`, `:expires :int`, `:same-site [:enum ...]`, but `validate-cookie!` (rf2-kjf3m.1) deliberately accepts + `str`-coerces string forms so the per-attribute CRLF gate can see them. The three attrs widen to `[:or <spec-type> :string]`.

## Gates

- `clojure -M:test` (ssr JVM) — **283 tests / 1018 assertions, 0 failures** (incl. the 2 new boundary tests + all existing CRLF/cookie/header tests untouched).
- `npm run test:cljs` — **5724 tests / 20015 assertions, 0 failures** (new `.cljc` compiles + runs on CLJS).
- clj-kondo — 0 errors on the new + modified files (the 6 warnings are pre-existing unused-private-var on `ssr.cljc` re-exports).