### PR TITLE
fix(story): honour workspace :columns + :for slots in the renderer (rf2-ugmrg)

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -561,9 +561,9 @@ rejected at `reg-workspace` call-time with `:rf.error/workspace-shape`
 {:doc       "..."
  :layout    :grid | :prose | :variants-grid | :tabs | :custom
  :variants  [<variant-id> ...]                    ; for :grid / :variants-grid / :tabs (explicit list)
- :for       <story-id>                            ; for :variants-grid only — auto-enumerate (see anchor note below)
- :story     <story-id>                            ; for :variants-grid only — the renderer-read anchor spelling (see note)
- :columns   <integer>                             ; for :grid / :variants-grid — column count (declared; not yet renderer-honoured)
+ :for       <story-id>                            ; for :variants-grid only — auto-enumerate anchor (canonical spelling; see note below)
+ :story     <story-id>                            ; for :variants-grid only — :for synonym (back-compat; see note)
+ :columns   <integer>                             ; for :grid / :variants-grid — fixed column count (renderer-honoured)
  :content   [{:type :prose :body "md..."} ...]    ; for :prose; bodies render as markdown — see spec/008 §Markdown rendering
  :render    <view-id>                              ; for :custom (a registered view)
  :tags      #{<tag-id> ...}                        ; workspace tag set (subset of the registered vocabulary)
@@ -616,31 +616,33 @@ Declaring **both** `:variants` and `:for` (or its renderer-read synonym
 at registration — they are alternatives, not co-equals (rf2-mantt
 enforces this documented rule on the now-closed schema).
 
-#### Workspace anchor: `:for` (authoring) vs `:story` (renderer) — divergence note (rf2-mantt)
+#### Workspace anchor: `:for` (authoring spelling) + `:story` (synonym) (rf2-ugmrg)
 
 The `:variants-grid` auto-enumerate anchor is authored as `:for
-<story-id>` (above). The **renderer** today reads the anchor from a
-`:story` slot (`re-frame.story.ui.workspace/resolve-layout`), falling
-back to deriving `:story.<path>` from the workspace id's namespace. Both
-`:for` and `:story` are declared on the schema; the `:story` spelling
-lets an author name the anchor explicitly to the path the renderer reads
-now. Reconciling the two spellings (the renderer reading `:for`, or
-`:for` lowering to `:story` at registration like `:setup`→`:events`) is a
-follow-up — until then, an auto-grid that relies on the namespace
-derivation needs no anchor slot at all, and an explicit anchor is most
-reliably given via `:story`.
+<story-id>` (above) — the spec-authoritative spelling. The renderer
+(`re-frame.story.ui.workspace/resolve-layout`) reads the anchor in this
+precedence order: `:for`, then `:story` (a back-compat synonym), then
+deriving `:story.<path>` from the workspace id's namespace. Both `:for`
+and `:story` are declared on the schema and resolve identically; `:for`
+is the canonical authoring spelling and the recommended way to name an
+anchor explicitly. (rf2-ugmrg aligned the impl to the spec spelling,
+XState-style: pick the spec spelling as authoritative and make the
+renderer read it. The earlier divergence — renderer reads `:story`
+only — is resolved.)
 
-#### Workspace `:columns` slot — declared, not yet renderer-honoured (v1) (rf2-mantt)
+#### Workspace `:columns` slot — renderer-honoured (rf2-ugmrg)
 
-The `:columns` integer slot is **declared and documented but not yet
-honoured by the renderer in v1** — the `:grid` / `:variants-grid` CSS
-uses a responsive `auto-fit` template, so an explicit column count is
-accepted at registration (the canonical testbed + the scaffolded
-template + the example apps all author `:columns`) but does not yet pin
-the grid width. Honouring it (a fixed `repeat(N, …)` template when
-`:columns` is present) is a follow-up; the slot is declared so existing
-authoring keeps validating against the closed schema. Same posture as the
-`:modes` slot below.
+The `:columns` integer slot pins the column count of a `:grid` /
+`:variants-grid` workspace. When present, the grid emits a fixed
+`grid-template-columns: repeat(N, minmax(280px, 1fr))` template (N =
+`:columns`); when absent the grid keeps the responsive default
+(`repeat(auto-fit, minmax(280px, 1fr))`), which fits as many 280px-min
+columns as the canvas width allows. `:columns` only affects the
+`:grid` and (isolated) `:variants-grid` layouts — the layouts that lay
+cells out in a CSS grid. `:tabs`, `:variants-grid` with `:isolation
+:shared`, `:prose`, and `:custom` render one-at-a-time or in flow and
+ignore `:columns`. (rf2-ugmrg honoured the slot; the earlier
+declared-not-honoured divergence is resolved.)
 
 #### Workspace `:modes` slot — future-reserved (v1) (rf2-q5e36)
 

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -1082,17 +1082,16 @@
   (rf2-mantt per-key triage). They are declared optional here so closing
   does NOT drop intended authoring:
 
-  - `:columns` — `:grid` / `:variants-grid` column-count hint
-    (spec/001-Authoring.md:561). NOTE: declared + documented but NOT yet
-    honoured by the renderer — the grid CSS uses `auto-fit`. Filed as a
-    spec/impl-divergence follow-up; declared (not dropped) so authoring
-    that already sets it keeps validating.
-  - `:for` — `:variants-grid` auto-enumerate anchor story-id
-    (spec/001-Authoring.md:560, 573-602). Same divergence note: the
-    renderer reads the `:story` anchor slot, not `:for`.
-  - `:story` — the `:variants-grid` anchor slot the renderer ACTUALLY
-    reads (`re-frame.story.ui.workspace/resolve-layout`); declared so a
-    body that names the anchor explicitly validates.
+  - `:columns` — `:grid` / `:variants-grid` fixed column-count
+    (spec/001-Authoring.md §`:columns`). rf2-ugmrg: renderer-honoured —
+    when present the grid emits `repeat(N, minmax(280px,1fr))`; absent it
+    keeps the responsive `auto-fit` default.
+  - `:for` — `:variants-grid` auto-enumerate anchor story-id; the
+    spec-authoritative spelling (spec/001-Authoring.md §`:variants-grid`).
+    rf2-ugmrg: `resolve-layout` reads `:for` first, then `:story`, then
+    the namespace derivation.
+  - `:story` — `:for` back-compat synonym; the renderer reads it when
+    `:for` is absent (`re-frame.story.ui.workspace/resolve-layout`).
   - `:tags` — workspace tag set (the canonical testbed + examples author
     `:tags #{:docs}`).
 
@@ -1103,12 +1102,14 @@
     [:source    {:optional true} SourceCoords]
     [:layout    [:enum :grid :prose :variants-grid :tabs :custom]]
     [:variants  {:optional true} [:vector :keyword]]
-    ;; rf2-mantt — `:for` (spec name) + `:story` (renderer-read anchor)
-    ;; both name the `:variants-grid` auto-enumerate parent story.
+    ;; rf2-mantt + rf2-ugmrg — `:for` (spec-authoritative spelling) +
+    ;; `:story` (back-compat synonym) both name the `:variants-grid`
+    ;; auto-enumerate parent story; the renderer reads `:for` first,
+    ;; then `:story` (see `re-frame.story.ui.workspace/resolve-layout`).
     [:for       {:optional true} :keyword]
     [:story     {:optional true} :keyword]
-    ;; rf2-mantt — `:columns` is a documented `:grid` / `:variants-grid`
-    ;; column-count hint (not yet renderer-honoured; see docstring).
+    ;; rf2-mantt + rf2-ugmrg — `:columns` is a `:grid` / `:variants-grid`
+    ;; fixed column-count (renderer-honoured; see docstring).
     [:columns   {:optional true} [:int {:min 1}]]
     [:content   {:optional true} [:vector WorkspaceContentItem]]
     [:render    {:optional true} :keyword]

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -113,8 +113,16 @@
   Cell ordering matches the workspace's declared `:variants` (for `:grid`
   / `:tabs`) or `:content` (for `:prose`). For `:variants-grid` the
   cells enumerate the registry's variants for the workspace's anchor
-  story; the workspace body's `:story` slot names that anchor (defaults
-  to the workspace id's namespace path stripped of `Workspace.`)."
+  story. The anchor is read in precedence order (rf2-ugmrg):
+
+    1. `:for`   — the spec-authoritative auto-enumerate spelling
+                  (spec/001-Authoring.md §`:variants-grid`);
+    2. `:story` — a back-compat synonym for `:for`;
+    3. otherwise the workspace id's namespace path stripped of
+       `Workspace.` (e.g. `:Workspace.counter/x` → `:story.counter`).
+
+  `:for` and `:story` are mutually exclusive with `:variants` on a
+  `:variants-grid` (enforced by the schema, spec/001-Authoring.md)."
   [workspace-id workspace-body]
   (case (:layout workspace-body)
     :grid
@@ -126,7 +134,8 @@
            {:type :variant :variant-id vid}))
 
     :variants-grid
-    (let [anchor (or (:story workspace-body)
+    (let [anchor (or (:for workspace-body)
+                     (:story workspace-body)
                      ;; Derive `:story.<path>` from `:Workspace.<path>/<name>`.
                      (when-let [ns (namespace workspace-id)]
                        (when (and (>= (count ns) 10)
@@ -196,6 +205,35 @@
      :warn?          (budgets/matrix-warn? [total])
      :over-hard-cap? over?}))
 
+;; ---- pure: :columns grid template (rf2-ugmrg) ---------------------------
+;;
+;; The workspace body's optional `:columns` integer pins the grid's column
+;; count. Absent, the grid uses the responsive `auto-fit` default (fit as
+;; many 280px-min columns as the canvas width allows). Present, it pins a
+;; fixed `repeat(N, minmax(280px, 1fr))` template. Pure string → string so
+;; the JVM test suite covers the template selection without a DOM.
+
+(def ^:private grid-min-cell-width
+  "Minimum cell width in the grid track template (px). Shared between the
+  responsive `auto-fit` default and the fixed `:columns` template."
+  "280px")
+
+(defn grid-template-columns
+  "Return the CSS `grid-template-columns` value for a workspace grid given
+  its body's `:columns` slot (or nil).
+
+  - `:columns N` (a positive int) → `repeat(N, minmax(280px, 1fr))` —
+    a fixed N-column track template (rf2-ugmrg).
+  - absent / nil / non-positive → `repeat(auto-fit, minmax(280px, 1fr))`
+    — the responsive default (fit as many columns as fit at 280px min).
+
+  Pure; JVM-testable."
+  [columns]
+  (let [track (str "minmax(" grid-min-cell-width ", 1fr)")]
+    (if (and (integer? columns) (pos? columns))
+      (str "repeat(" columns ", " track ")")
+      (str "repeat(auto-fit, " track ")"))))
+
 ;; ---- styling -------------------------------------------------------------
 
 #?(:cljs
@@ -208,8 +246,12 @@
                       :color (:info colors/tokens)
                       :font-family mono-stack
                       :margin-bottom "12px"}
+      ;; rf2-ugmrg — `:grid-template-columns` is set per-render from the
+      ;; workspace body's `:columns` slot via `grid-template-columns`
+      ;; (responsive `auto-fit` default; fixed `repeat(N, …)` when
+      ;; `:columns` is present). The static base carries only the display
+      ;; + gap; the renderer merges the computed template in.
       :grid          {:display "grid"
-                      :grid-template-columns "repeat(auto-fit, minmax(280px, 1fr))"
                       :gap "12px"}
       :cell          {:background (:bg-2 colors/tokens)
                       :border "1px solid #3c3c3c"
@@ -716,8 +758,13 @@
 
      Cells render in a CSS grid; the expander + advisory sit outside it so
      they read as page chrome, not cells. Per spec/018 §10 the grid fails by
-     summarizing + offering expansion, never by flooding the canvas."
-     [cells]
+     summarizing + offering expansion, never by flooding the canvas.
+
+     `columns` (rf2-ugmrg) is the workspace body's `:columns` slot (or
+     nil). When a positive int it pins a fixed `repeat(N, …)` grid track
+     template; otherwise the grid uses the responsive `auto-fit` default.
+     See `grid-template-columns`."
+     [cells columns]
      (r/with-let [expanded? (r/atom false)]
        (let [{:keys [shown hidden total warn? over-hard-cap?]}
              (bound-grid-cells cells @expanded?)]
@@ -736,7 +783,10 @@
                (str "⚠ dense matrix: " total " cells (≥ "
                     budgets/matrix-warn-threshold
                     "). Consider narrowing the variants axis."))])
-          [:div {:style (:grid styles)}
+          [:div {:style (assoc (:grid styles)
+                               :grid-template-columns
+                               (grid-template-columns columns))
+                 :data-test-grid-columns (str (or columns "auto-fit"))}
            (for [[i cell] (map-indexed vector shown)]
              (grid-cell-hiccup i cell))]
           ;; G1 — the cap-and-page expander. Reveals the elided cells up to
@@ -829,5 +879,8 @@
               ;; offers a `+N more` expander rather than freezing the canvas
               ;; (spec/018 §10). Cells stay variant-id-keyed inside it, so
               ;; the rf2-kgn0c frame-allocation invariant is preserved.
+              ;; rf2-ugmrg — the body's `:columns` slot pins a fixed grid
+              ;; track template; absent it keeps the responsive `auto-fit`
+              ;; default. Threaded into the capped-grid renderer.
               :else
-              [capped-grid-renderer cells])])))))
+              [capped-grid-renderer cells (:columns body)])])))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -394,9 +394,9 @@
     ;; inner fn (same `[fn cells]` shape as tabs) to get the rendered
     ;; cell tree, then walk for variant-id keys.
     (let [render  (fn [ws-id]
-                    (let [{renderer :fn cells :cells}
+                    (let [{renderer :fn cells :cells args :args}
                           (find-tabs-renderer-call (workspace/workspace-view ws-id))]
-                      (renderer cells)))
+                      (apply renderer cells args)))
           keys-a  (collect-cell-keys (render :Workspace.rf2-kgn0c.a/grid))
           keys-b  (collect-cell-keys (render :Workspace.rf2-kgn0c.b/grid))]
       (is (= 2 (count keys-a)) "workspace-a yields one key per cell")
@@ -424,9 +424,9 @@
     ;; rf2-ba86n.18 — isolated `:variants-grid` also mounts the capped-grid
     ;; renderer; extract + invoke its inner fn to reach the cell tree.
     (let [render  (fn [ws-id]
-                    (let [{renderer :fn cells :cells}
+                    (let [{renderer :fn cells :cells args :args}
                           (find-tabs-renderer-call (workspace/workspace-view ws-id))]
-                      (renderer cells)))
+                      (apply renderer cells args)))
           keys-a  (collect-cell-keys (render :Workspace.rf2-kgn0c-vg.a/all))
           keys-b  (collect-cell-keys (render :Workspace.rf2-kgn0c-vg.b/all))]
       (is (seq keys-a))
@@ -472,26 +472,30 @@
 ;; so we can walk the rendered output.
 
 (defn- find-tabs-renderer-call
-  "Walk `tree` for a hiccup vector of the shape `[fn cells-vec]` where
-  cells-vec is a non-empty vector of cell maps. Returns
-  `{:fn renderer :cells cells}` or nil. The workspace-view mounts
-  `:tabs` as `[tabs-renderer cells]` AND `:grid` / isolated
-  `:variants-grid` as `[capped-grid-renderer cells]` (rf2-ba86n.18) —
-  both share this `[fn cells]` shape, so this helper extracts either
-  renderer's inner call. Callers invoke `(renderer cells)` to get the
-  rendered hiccup tree they walk."
+  "Walk `tree` for a hiccup vector of the shape `[fn cells-vec & args]`
+  where cells-vec is a non-empty vector of cell maps. Returns
+  `{:fn renderer :cells cells :args trailing-args}` or nil. The
+  workspace-view mounts `:tabs` as `[tabs-renderer cells]` AND `:grid` /
+  isolated `:variants-grid` as `[capped-grid-renderer cells columns]`
+  (rf2-ba86n.18; rf2-ugmrg added the trailing `:columns` arg) — both
+  share the `[fn cells …]` shape, so this helper extracts either
+  renderer's inner call regardless of trailing args. Callers invoke
+  `(apply renderer cells args)` (or `(renderer cells)` for the
+  no-trailing-arg tabs case) to get the rendered hiccup tree they walk."
   [tree]
   (->> (tree-seq coll? seq tree)
        (filter (fn [node]
                  (and (vector? node)
-                      (= 2 (count node))
+                      (>= (count node) 2)
                       (fn? (first node))
                       (vector? (second node))
                       (seq (second node))
                       (every? map? (second node))
                       (every? #(contains? % :type) (second node)))))
        first
-       (#(when % {:fn (first %) :cells (second %)}))))
+       (#(when % {:fn    (first %)
+                  :cells (second %)
+                  :args  (vec (drop 2 %))}))))
 
 (defn- count-variant-cells-in
   "Count `[variant-cell vid]` invocations in a hiccup tree —
@@ -696,10 +700,10 @@
     ;; rf2-ba86n.18 — `:grid` mounts the capped-grid renderer; invoke its
     ;; inner fn to reach the rendered cells (3 variants < the 100 visible
     ;; cap, so all three render and the layout-difference contract holds).
-    (let [{grid-fn :fn grid-cells :cells}
+    (let [{grid-fn :fn grid-cells :cells grid-args :args}
                      (find-tabs-renderer-call
                        (workspace/workspace-view :Workspace.rf2-ktnl8.gt/grid))
-          grid-tree  (grid-fn grid-cells)
+          grid-tree  (apply grid-fn grid-cells grid-args)
           grid-n     (count-variant-cells-in grid-tree)
           {tabs-fn :fn tabs-cells :cells}
                      (find-tabs-renderer-call
@@ -712,6 +716,93 @@
       (is (= 1 tabs-n)
           (str ":tabs layout MUST mount exactly one cell at a time "
                "(got " tabs-n ")")))))
+
+;; ---- workspace :columns grid template (rf2-ugmrg) -----------------------
+;;
+;; The workspace body's `:columns` slot pins the CSS grid's column count.
+;; Pre-fix it was declared + documented but the renderer ignored it — the
+;; grid CSS hardcoded `repeat(auto-fit, minmax(280px, 1fr))`. Post-fix the
+;; capped-grid renderer emits `repeat(N, minmax(280px, 1fr))` when
+;; `:columns` is present and keeps the `auto-fit` default when absent.
+;;
+;; These tests walk the rendered grid div's inline `grid-template-columns`
+;; style — the load-bearing render output an author observes.
+
+(defn- grid-div-style
+  "Find the workspace grid container div in `tree` and return its inline
+  style map. The grid div carries `:data-test-grid-columns` (rf2-ugmrg)."
+  [tree]
+  (->> (tree-seq coll? seq tree)
+       (filter (fn [node]
+                 (and (vector? node)
+                      (= :div (first node))
+                      (map? (second node))
+                      (contains? (second node) :data-test-grid-columns))))
+       first
+       second
+       :style))
+
+(defn- render-grid-tree
+  "Mount `ws-id`'s workspace-view, extract the capped-grid renderer call,
+  and invoke it to get the rendered hiccup tree."
+  [ws-id]
+  (let [{renderer :fn cells :cells args :args}
+        (find-tabs-renderer-call (workspace/workspace-view ws-id))]
+    (apply renderer cells args)))
+
+(deftest workspace-grid-columns-pins-fixed-template-rf2-ugmrg
+  (testing ":grid with :columns N emits a fixed repeat(N, …) template —
+            pre-fix this slot was silently ignored (rf2-ugmrg)"
+    (story/reg-variant :story.ugmrg-cols/a {:events []})
+    (story/reg-variant :story.ugmrg-cols/b {:events []})
+    (story/reg-variant :story.ugmrg-cols/c {:events []})
+    (story/reg-workspace :Workspace.ugmrg-cols/grid
+      {:layout   :grid
+       :columns  3
+       :variants [:story.ugmrg-cols/a
+                  :story.ugmrg-cols/b
+                  :story.ugmrg-cols/c]})
+    (let [style (grid-div-style
+                  (render-grid-tree :Workspace.ugmrg-cols/grid))]
+      (is (= "repeat(3, minmax(280px, 1fr))"
+             (:grid-template-columns style))
+          (str ":columns 3 MUST pin a 3-column grid template; got "
+               (pr-str (:grid-template-columns style)))))))
+
+(deftest workspace-grid-without-columns-keeps-auto-fit-rf2-ugmrg
+  (testing ":grid without :columns keeps the responsive auto-fit default
+            (rf2-ugmrg — :columns is opt-in; absent it must not change
+            existing behaviour)"
+    (story/reg-variant :story.ugmrg-auto/a {:events []})
+    (story/reg-variant :story.ugmrg-auto/b {:events []})
+    (story/reg-workspace :Workspace.ugmrg-auto/grid
+      {:layout   :grid
+       :variants [:story.ugmrg-auto/a
+                  :story.ugmrg-auto/b]})
+    (let [style (grid-div-style
+                  (render-grid-tree :Workspace.ugmrg-auto/grid))]
+      (is (= "repeat(auto-fit, minmax(280px, 1fr))"
+             (:grid-template-columns style))
+          (str "absent :columns MUST keep the auto-fit default; got "
+               (pr-str (:grid-template-columns style)))))))
+
+(deftest workspace-variants-grid-columns-pins-fixed-template-rf2-ugmrg
+  (testing "isolated :variants-grid honours :columns too (same capped-grid
+            renderer; rf2-ugmrg)"
+    (story/reg-variant :story.ugmrg-vg/a {:events []})
+    (story/reg-variant :story.ugmrg-vg/b {:events []})
+    (story/reg-workspace :Workspace.ugmrg-vg/all
+      {:layout  :variants-grid
+       :for     :story.ugmrg-vg
+       :columns 2})
+    (let [tree  (render-grid-tree :Workspace.ugmrg-vg/all)
+          style (grid-div-style tree)]
+      (is (= "repeat(2, minmax(280px, 1fr))"
+             (:grid-template-columns style))
+          ":columns 2 MUST pin a 2-column variants-grid template")
+      ;; also pins that :for drove the enumeration (2 variants rendered)
+      (is (= 2 (count-variant-cells-in tree))
+          ":for anchor MUST enumerate both variants (rf2-ugmrg)"))))
 
 ;; ---- workspace cells re-run on full run-key (rf2-c56hr) -----------------
 ;;

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -642,6 +642,70 @@
       (is (= isolated shared))
       (is (= 2 (count shared))))))
 
+;; ---- rf2-ugmrg :for anchor + :columns template --------------------------
+
+(deftest variants-grid-for-anchor-is-read
+  (testing ":variants-grid reads the spec-authoritative :for anchor
+            (rf2-ugmrg — previously :for was silently ignored and only
+            :story / the namespace derivation worked)"
+    (story/reg-variant :story.for-anchor/a {:events []})
+    (story/reg-variant :story.for-anchor/b {:events []})
+    (story/reg-variant :story.other-anchor/x {:events []})
+    (let [cells (workspace/resolve-layout
+                  ;; deliberately a NON-matching workspace ns so the
+                  ;; namespace derivation cannot supply the anchor — only
+                  ;; :for can. (`:Workspace.unrelated/grid` derives
+                  ;; `:story.unrelated`, which has no variants.)
+                  :Workspace.unrelated/grid
+                  {:layout :variants-grid :for :story.for-anchor})]
+      (is (= 2 (count cells))
+          ":for MUST drive the enumeration anchor")
+      (is (every? #(= :variant (:type %)) cells))
+      (is (= #{:story.for-anchor/a :story.for-anchor/b}
+             (set (map :variant-id cells)))))))
+
+(deftest variants-grid-for-takes-precedence-over-story
+  (testing "when both :for and :story are present, :for wins (the
+            spec-authoritative spelling — rf2-ugmrg). NOTE: the closed
+            schema rejects co-declaring them on a real reg-workspace; this
+            pins resolve-layout's precedence directly."
+    (story/reg-variant :story.prec-for/a {:events []})
+    (story/reg-variant :story.prec-for/b {:events []})
+    (story/reg-variant :story.prec-story/x {:events []})
+    (let [cells (workspace/resolve-layout
+                  :Workspace.prec/grid
+                  {:layout :variants-grid
+                   :for    :story.prec-for
+                   :story  :story.prec-story})]
+      (is (= #{:story.prec-for/a :story.prec-for/b}
+             (set (map :variant-id cells)))
+          ":for MUST take precedence over :story"))))
+
+(deftest variants-grid-story-still-honoured-without-for
+  (testing ":story remains a back-compat synonym when :for is absent"
+    (story/reg-variant :story.syn/a {:events []})
+    (story/reg-variant :story.syn/b {:events []})
+    (let [cells (workspace/resolve-layout
+                  :Workspace.unrelated2/grid
+                  {:layout :variants-grid :story :story.syn})]
+      (is (= 2 (count cells))))))
+
+(deftest grid-template-columns-honours-columns
+  (testing "grid-template-columns emits a fixed repeat(N, …) template when
+            :columns is a positive int (rf2-ugmrg)"
+    (is (= "repeat(3, minmax(280px, 1fr))"
+           (workspace/grid-template-columns 3)))
+    (is (= "repeat(1, minmax(280px, 1fr))"
+           (workspace/grid-template-columns 1))))
+  (testing "absent / nil / non-positive :columns keeps the responsive
+            auto-fit default"
+    (is (= "repeat(auto-fit, minmax(280px, 1fr))"
+           (workspace/grid-template-columns nil)))
+    (is (= "repeat(auto-fit, minmax(280px, 1fr))"
+           (workspace/grid-template-columns 0)))
+    (is (= "repeat(auto-fit, minmax(280px, 1fr))"
+           (workspace/grid-template-columns -2)))))
+
 ;; ---- docs mode (rf2-rodx) -----------------------------------------------
 
 ;; rf2-ee38b.3: the `docs/parent-story-id` re-export was dropped; the


### PR DESCRIPTION
## What

The Story workspace `:columns` and `:for` slots are **declared + documented** in `tools/story/spec/001-Authoring.md` but were **silently ignored by the renderer** — a workspace that set them rendered as if they were absent (spec/impl divergence, surfaced by rf2-mantt closing the Workspace schema). This aligns the impl to the spec.

## Spec behaviour implemented

- **`:for`** — `spec/001-Authoring.md §:variants-grid` makes `:for <story-id>` the spec-authoritative auto-enumerate anchor. `resolve-layout` now reads the anchor in precedence order: `:for` → `:story` (back-compat synonym) → workspace-id namespace derivation. Previously only `:story` / the namespace derivation worked and an explicit `:for` was a no-op. (XState-style ruling: pick the spec spelling as authoritative and align the impl.)
- **`:columns`** — `spec/001-Authoring.md §:columns` documents it as the `:grid` / `:variants-grid` column-count. The capped-grid renderer now emits a fixed `grid-template-columns: repeat(N, minmax(280px, 1fr))` template when `:columns` is present, keeping the responsive `repeat(auto-fit, minmax(280px, 1fr))` default when absent. New pure `grid-template-columns` helper (JVM-testable). Affects `:grid` / isolated `:variants-grid` only; `:tabs` / `:shared` / `:prose` / `:custom` ignore it (one-at-a-time / flow layouts).

## Before / after

- Before: `{:layout :grid :columns 3 :variants [...]}` → rendered `repeat(auto-fit, …)` (3 ignored). `{:layout :variants-grid :for :story.counter}` (non-matching workspace ns) → 0 cells (anchor ignored).
- After: `:columns 3` → `repeat(3, minmax(280px, 1fr))`. `:for :story.counter` → enumerates every variant of `:story.counter`.

The canonical testbed (`counter_with_stories`) + both reagent example apps already author these shapes, so the feature is exercised end-to-end on real workspaces. No testbed host files were touched (renderer-only fix per the bead's scope split).

## Docs

`spec/001-Authoring.md` + `schemas.cljc` docstrings updated: the "declared, not yet renderer-honoured" divergence notes for `:columns` and the `:for`/`:story` anchor are removed and replaced with the now-honoured semantics.

## Gates

- `tools/story` `clojure -M:test` — 1621 tests / 6054 assertions, 0 failures.
- `npm run test:cljs` — 5730 tests / 20026 assertions, 0 failures, 0 build warnings.
- New regression tests: JVM (`:for` anchor precedence, `:story` fallback, `grid-template-columns` template selection) + CLJS (rendered grid div carries `repeat(3,…)` for `:columns 3`, `auto-fit` when absent, `:variants-grid` + `:for` + `:columns` end-to-end).

Closes rf2-ugmrg. Cross-ref: surfaced by rf2-mantt.