### PR TITLE
test(examples): static _shared asset-contract gate + doc realignment (rf2-8r0mj.2/.3/.4 + rf2-emvyd)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -150,6 +150,7 @@ The `examples/` tree is **test-free** — no `*.spec.cjs` lives under `examples/
 - **`npm run test:xray-feature-gate`** — 14-scenario Xray feature-matrix gate. The canonical browser sweep for cross-cutting feature regressions.
 - **`npm run test:bundle-isolation`** — production bundle grep contract for the per-feature artefact split.
 - **`npm run test:perf-bundle`** — static perf-flag bundle-isolation grep (the live perf-API counterpart at `implementation/core/test/re_frame/performance_emit_nightly_test.cljs` runs in the nightly CLJS suite).
+- **`npm run test:script-policy`** — JS-harness self-tests, including the **static examples asset-contract gate** ([`examples/scripts/check-examples-assets.cjs`](scripts/check-examples-assets.cjs)). For every example `index.html` it verifies each referenced asset (`_shared/*` css/img + transitive `@import` targets) resolves to a real file and that every page carries the required shared assets — favicon, OG card, and `_shared/css/style.css` — unless explicitly allowlisted (TodoMVC opts out of the shared stylesheet but still ships the shared favicon + OG). This catches a broken/renamed/missing `_shared` asset that the adapter-smoke harness cannot, since the testbed pages it serves link none of `_shared`.
 - **`npm run test:story-feature-load`** — Story tool feature/load gate (occasional).
 
 ### Building examples interactively
@@ -161,7 +162,9 @@ If you want to iterate on one example:
 shadow-cljs watch examples/counter
 ```
 
-Stage the `index.html` once (copy `examples/reagent/counter/index.html` next to `out/examples/counter/main.js`) and serve `out/examples/` over HTTP.
+The build's `:output-dir` (see `implementation/shadow-cljs.edn`) is where `main.js` lands. Stage the example's hand-written `index.html` next to that `main.js`, copy the `examples/_shared/` tree alongside it so the `_shared/...` hrefs resolve, then serve that directory over HTTP. (The `npm run test:examples` smoke harness does this automatically for the three adapter testbeds, staging into `implementation/out/examples/adapter-testbeds/<name>/`; the per-build `:output-dir` for a standalone `:examples/*` build is whatever that build declares.)
+
+For TodoMVC, also copy the two vendored CSS files next to `main.js` (its `index.html` links them flat instead of the shared stylesheet — see [`reagent/todomvc/README.md`](reagent/todomvc/README.md) §Official assets).
 
 ### Adding a new example
 

--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -2,11 +2,29 @@
 
 Shared stylesheet, favicon, and Open Graph imagery consumed by every
 example `index.html` across all three substrates (Reagent / UIx / Helix).
-The orchestrator
+The smoke orchestrator
 (`examples/scripts/serve-and-run-examples-tests.cjs`) stages this whole
-tree into each example's `out/examples/<name>/_shared/` directory next to
-`main.js`, so every page references assets at the same relative path
-(`_shared/css/style.css`).
+tree into each staged surface's output dir — for the adapter testbeds it
+drives, that is
+`implementation/out/examples/adapter-testbeds/<name>/_shared/`, next to
+the staged `index.html` + `main.js` — so every page references assets at
+the same relative path (`_shared/css/style.css`). (The exact output dir is
+declared per-entry as `outDir` in
+[`examples/scripts/examples-filter.cjs`](../scripts/examples-filter.cjs);
+the smoke set is the three adapter testbeds, which do not themselves link
+`_shared` — see below.)
+
+**What is actually tested.** The smoke harness stages this tree but the
+three adapter testbed pages it serves link none of `_shared`. The
+"every example index references the shared assets" contract is enforced
+**statically** by
+[`examples/scripts/check-examples-assets.cjs`](../scripts/check-examples-assets.cjs)
+(wired into `npm run test:script-policy`): for every example `index.html`
+it verifies each referenced asset — `_shared/*` css/img plus the
+transitive `@import` targets — resolves to a real file, and that every
+page carries the required shared assets unless explicitly allowlisted
+(TodoMVC opts out of the shared stylesheet; see that scanner's
+`ALLOWLIST`).
 
 ## Visual identity
 

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -1,0 +1,456 @@
+#!/usr/bin/env node
+/*
+ * `check-examples-assets` — STATIC asset-contract gate over every example
+ * index.html (rf2-8r0mj.2 + rf2-8r0mj.3 + rf2-emvyd).
+ *
+ * The gap this closes
+ * -------------------
+ * examples/_shared/ ships a shared design system (stylesheet + favicon +
+ * Open Graph card) that examples/_shared/README.md declares is "consumed by
+ * every example index.html". The only automated gate that touches _shared
+ * is the adapter-smoke harness (npm run test:examples), and that harness
+ * compiles + serves ONLY the three adapter testbeds at
+ * implementation/adapters/<name>/testbed/. Those testbed pages link NONE of
+ * _shared, so a broken shared stylesheet, a missing/renamed _shared asset, a
+ * bad @import target, or a stageShared regression all pass test:examples —
+ * the staged copy is never loaded by any page the runner navigates to. The
+ * shared design system had ZERO automated coverage.
+ *
+ * On top of that, the "every example page references the shared assets"
+ * contract was review-only: nothing failed when a non-exempt page omitted an
+ * asset, and the one real exception (TodoMVC uses the official TodoMVC CSS
+ * packages instead of the shared stylesheet) was not encoded as an explicit
+ * allowlisted exception anywhere.
+ *
+ * What this gate does (STATIC — no browser, no Playwright)
+ * -------------------------------------------------------
+ * It walks every tracked example index.html and, for each:
+ *
+ *   1. RESOLVES every local asset reference (link href, script src,
+ *      og:image meta, and transitively the @import targets inside any
+ *      referenced local CSS) to a real file in the repo source tree. A
+ *      reference to a missing/renamed/typo'd local asset fails the gate.
+ *      External URLs (http(s):// + protocol-relative //) and the build
+ *      output main.js (produced by shadow-cljs, not source) are skipped.
+ *
+ *      Staging-aware resolution: a page references _shared assets at the
+ *      relative path `_shared/...`, but in the SOURCE tree _shared lives
+ *      ONCE at examples/_shared/ (not next to each page) — the orchestrator
+ *      copies it into every page's output dir at stage time. So a
+ *      `_shared/...` reference is resolved against the canonical
+ *      examples/_shared/ source (exactly what gets staged), while a
+ *      non-_shared sibling reference (e.g. TodoMVC's base.css) is resolved
+ *      relative to the page's own directory.
+ *
+ *   2. Asserts the REQUIRED _shared asset contract: every example must
+ *      reference _shared/img/favicon.svg, _shared/img/og.svg, and
+ *      _shared/css/style.css — UNLESS the page is allowlisted out of a
+ *      specific asset (see ALLOWLIST). The TodoMVC stylesheet opt-out is
+ *      encoded there: it is exempt from style.css (it links the vendored
+ *      TodoMVC base.css + index.css) but STILL required to carry the shared
+ *      favicon + OG card.
+ *
+ *   3. Asserts the _shared source tree itself is intact: the required
+ *      _shared files exist on disk and structure.css remains reachable from
+ *      style.css's @import.
+ *
+ * This is NOT a per-example *.spec.cjs — examples/ stays test-free
+ * (rf2-8cevm). It is a pure static scanner, wired into the always-run
+ * `test:script-policy` gate (see implementation/scripts/
+ * check-examples-assets.test.cjs) so a missing/broken _shared asset turns
+ * that gate RED in CI without a new .github workflow job.
+ *
+ * CLI
+ * ---
+ *   node examples/scripts/check-examples-assets.cjs           # scan, exit 0/1
+ *   node examples/scripts/check-examples-assets.cjs --list    # print findings, exit 0
+ *
+ * The pure scan logic is exported for check-examples-assets.test.cjs, which
+ * pins the contract (required-asset detection, @import resolution, the
+ * TodoMVC allowlist) AND gives the gate teeth by running the real scan over
+ * the repo.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// __dirname is <repo>/examples/scripts. REPO_ROOT is <repo>.
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const EXAMPLES_ROOT = path.join(REPO_ROOT, 'examples');
+const SHARED_ROOT = path.join(EXAMPLES_ROOT, '_shared');
+
+// The shared design-system assets every example page is expected to carry,
+// keyed by the canonical relative href every index.html uses. `required`
+// marks the universal contract; a page can be allowlisted out of an
+// individual asset via ALLOWLIST below.
+const REQUIRED_SHARED_ASSETS = [
+  '_shared/img/favicon.svg',
+  '_shared/img/og.svg',
+  '_shared/css/style.css',
+];
+
+// ---------------------------------------------------------------------------
+// Allowlisted exceptions — the ONE encoded place that names a page's opt-out
+// from a required shared asset, with the reason. A reviewer (human or the
+// gate) reads this to know an omission is intentional, not a regression.
+//
+// `assetExemptions` lists the required-asset hrefs a page is allowed to
+// OMIT. `localAssets` lists the page's NON-_shared local references that are
+// staged from somewhere other than the repo source tree (so the resolver
+// must not flag them as missing files on disk).
+// ---------------------------------------------------------------------------
+const ALLOWLIST = {
+  // TodoMVC links the official TodoMVC CSS packages (todomvc-common's
+  // base.css + todomvc-app-css's index.css, pinned in
+  // implementation/package.json and staged from node_modules/) instead of
+  // the shared stylesheet — see examples/reagent/todomvc/README.md
+  // §Official assets. It is therefore exempt from _shared/css/style.css but
+  // STILL required to carry the shared favicon + OG card, and its two
+  // vendored CSS links are not repo-source files (they're npm-staged), so
+  // they're declared here rather than flagged as missing.
+  'examples/reagent/todomvc/index.html': {
+    reason:
+      'TodoMVC uses the official TodoMVC CSS packages (base.css + ' +
+      'index.css, staged from node_modules/) instead of the shared ' +
+      'stylesheet — see examples/reagent/todomvc/README.md §Official assets.',
+    assetExemptions: ['_shared/css/style.css'],
+    localAssets: ['base.css', 'index.css'],
+  },
+};
+
+// Build output produced by shadow-cljs at stage time — never a repo-source
+// file, so the resolver skips it (every index.html ships <script src=main.js>).
+const BUILD_OUTPUTS = new Set(['main.js']);
+
+// ---------------------------------------------------------------------------
+// index.html enumeration. Walk the examples/ tree for index.html files,
+// skipping the _shared tree itself (it holds assets, not example pages) and
+// node_modules / build-output dirs.
+// ---------------------------------------------------------------------------
+
+function listExampleIndexHtml(root = EXAMPLES_ROOT) {
+  const out = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '_shared') continue;
+        stack.push(full);
+      } else if (entry.isFile() && entry.name === 'index.html') {
+        out.push(full);
+      }
+    }
+  }
+  return out.sort();
+}
+
+// ---------------------------------------------------------------------------
+// Reference extraction. We hand-roll focused regexes rather than pull in an
+// HTML/CSS parser — the only shapes we read are attribute-quoted hrefs/srcs,
+// the og:image meta content, and CSS @import url(...) targets.
+// ---------------------------------------------------------------------------
+
+// True for references the resolver does not check on disk: absolute URLs
+// (http://, https://, protocol-relative //), data: URIs, and in-page
+// fragments / mailto etc.
+function isExternalRef(ref) {
+  return (
+    /^[a-z][a-z0-9+.-]*:/i.test(ref) || // any scheme: http:, https:, data:, mailto:
+    ref.startsWith('//') ||             // protocol-relative
+    ref.startsWith('#')                 // in-page fragment
+  );
+}
+
+// Extract every asset reference from an index.html's source: <link href>,
+// <script src>, and the og:image <meta content>. Order-preserving,
+// de-duplicated. Query/hash suffixes are stripped for on-disk resolution.
+function extractHtmlRefs(html) {
+  const refs = [];
+  const push = (raw) => {
+    if (!raw) return;
+    const clean = raw.split(/[?#]/)[0].trim();
+    if (clean && !refs.includes(clean)) refs.push(clean);
+  };
+  // href="..." / href='...' on <link> (and any element — anchors are
+  // in-page or external and get filtered by isExternalRef downstream).
+  for (const m of html.matchAll(/\b(?:href|src)\s*=\s*("([^"]*)"|'([^']*)')/gi)) {
+    push(m[2] != null ? m[2] : m[3]);
+  }
+  // <meta property="og:image" content="...">
+  for (const m of html.matchAll(
+    /<meta\b[^>]*\bproperty\s*=\s*["']og:image["'][^>]*\bcontent\s*=\s*("([^"]*)"|'([^']*)')[^>]*>/gi,
+  )) {
+    push(m[2] != null ? m[2] : m[3]);
+  }
+  return refs;
+}
+
+// Extract local @import targets from a CSS source. Handles both
+// `@import url('x')` / `@import url("x")` / `@import url(x)` and the bare
+// `@import 'x'` / `@import "x"` forms. External targets are returned too so
+// the caller can filter them uniformly via isExternalRef.
+function extractCssImports(css) {
+  const out = [];
+  const push = (raw) => {
+    if (!raw) return;
+    const clean = raw.split(/[?#]/)[0].trim();
+    if (clean && !out.includes(clean)) out.push(clean);
+  };
+  for (const m of css.matchAll(
+    /@import\s+(?:url\(\s*("([^"]*)"|'([^']*)'|([^)'"]*))\s*\)|("([^"]*)"|'([^']*)'))/gi,
+  )) {
+    push(m[2] || m[3] || m[4] || m[6] || m[7]);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The pure scan. Returns { errors: string[], pages: [...] }; the CLI and the
+// test both consume this. Filesystem reads are injected so the test can pin
+// behaviour without touching disk; the CLI passes the real fs.
+// ---------------------------------------------------------------------------
+
+function readFileSafe(io, p) {
+  try {
+    return io.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+// Resolve a local reference from `pageDir` to its real SOURCE location,
+// modelling the orchestrator's staging. A `_shared/...` reference is staged
+// from the single canonical examples/_shared/ tree (copied into every page's
+// output dir at the same relative path), so it resolves against
+// `sharedParent` (examples/), NOT relative to the page. Every other relative
+// reference is a true page-local sibling and resolves relative to `pageDir`.
+function resolveRef(ref, pageDir, sharedParent = EXAMPLES_ROOT) {
+  if (ref === '_shared' || ref.startsWith('_shared/')) {
+    return path.resolve(sharedParent, ref);
+  }
+  return path.resolve(pageDir, ref);
+}
+
+// Resolve + check a single local CSS file's @import targets, recursively.
+// Records an error for any local import that does not resolve to a real file.
+function checkCssImports(io, cssAbsPath, displayRef, errors, seen) {
+  if (seen.has(cssAbsPath)) return;
+  seen.add(cssAbsPath);
+  const css = readFileSafe(io, cssAbsPath);
+  if (css == null) return; // a missing CSS file is reported by its referrer
+  for (const imp of extractCssImports(css)) {
+    if (isExternalRef(imp)) continue;
+    const target = path.resolve(path.dirname(cssAbsPath), imp);
+    if (!io.existsSync(target)) {
+      errors.push(
+        `${displayRef}: @import '${imp}' does not resolve to a file ` +
+          `(looked for ${path.relative(REPO_ROOT, target).split(path.sep).join('/')})`,
+      );
+      continue;
+    }
+    if (target.toLowerCase().endsWith('.css')) {
+      checkCssImports(io, target, `${displayRef} -> ${imp}`, errors, seen);
+    }
+  }
+}
+
+function scanPage(io, indexAbsPath, opts = {}) {
+  const allowlist = opts.allowlist || ALLOWLIST;
+  const required = opts.required || REQUIRED_SHARED_ASSETS;
+  const errors = [];
+  const relIndex = path.relative(REPO_ROOT, indexAbsPath).split(path.sep).join('/');
+  const exempt = allowlist[relIndex] || {};
+  const exemptAssets = new Set(exempt.assetExemptions || []);
+  const allowedLocal = new Set(exempt.localAssets || []);
+
+  const html = readFileSafe(io, indexAbsPath);
+  if (html == null) {
+    errors.push(`${relIndex}: could not read index.html`);
+    return { relIndex, errors, refs: [] };
+  }
+
+  const refs = extractHtmlRefs(html);
+  const pageDir = path.dirname(indexAbsPath);
+  const seenCss = new Set();
+
+  // 1) Resolve every local reference to a real file in the source tree.
+  for (const ref of refs) {
+    if (isExternalRef(ref)) continue;
+    if (BUILD_OUTPUTS.has(ref)) continue; // main.js — build output, not source
+    // Allowlisted non-_shared local assets (e.g. TodoMVC's npm-vendored CSS)
+    // are staged from outside the repo source tree; do not flag as missing,
+    // but still note them so they're visible in --list output.
+    if (allowedLocal.has(ref)) continue;
+    const target = resolveRef(ref, pageDir, opts.sharedParent || EXAMPLES_ROOT);
+    if (!io.existsSync(target)) {
+      errors.push(
+        `${relIndex}: asset '${ref}' does not resolve to a file ` +
+          `(looked for ${path.relative(REPO_ROOT, target).split(path.sep).join('/')})`,
+      );
+      continue;
+    }
+    // Transitively check @import targets inside any referenced local CSS.
+    if (target.toLowerCase().endsWith('.css')) {
+      checkCssImports(io, target, `${relIndex} (${ref})`, errors, seenCss);
+    }
+  }
+
+  // 2) Required shared-asset contract: every page references each required
+  //    asset unless explicitly exempt (allowlist). An exemption that is not
+  //    actually exercised (the page DOES reference the "exempt" asset) is a
+  //    stale allowlist entry — flag it so the allowlist can't rot.
+  const refSet = new Set(refs);
+  for (const need of required) {
+    const isExempt = exemptAssets.has(need);
+    const present = refSet.has(need);
+    if (!present && !isExempt) {
+      errors.push(
+        `${relIndex}: missing required shared asset reference '${need}'. ` +
+          `Either add it to the page's <head>, or (if intentional) encode ` +
+          `the exception in ALLOWLIST in check-examples-assets.cjs with a reason.`,
+      );
+    }
+    if (present && isExempt) {
+      errors.push(
+        `${relIndex}: allowlisted as exempt from '${need}' but the page ` +
+          `DOES reference it — remove the stale exemption from ALLOWLIST ` +
+          `in check-examples-assets.cjs.`,
+      );
+    }
+  }
+
+  return { relIndex, errors, refs };
+}
+
+// Verify the _shared SOURCE tree is intact: the required files exist and
+// structure.css remains reachable from style.css. Independent of any page so
+// a delete/rename of a shared asset is caught even if every page were
+// (wrongly) allowlisted out of it.
+function checkSharedTree(io, opts = {}) {
+  const sharedRoot = opts.sharedRoot || SHARED_ROOT;
+  const errors = [];
+  const mustExist = [
+    path.join(sharedRoot, 'css', 'style.css'),
+    path.join(sharedRoot, 'css', 'structure.css'),
+    path.join(sharedRoot, 'img', 'favicon.svg'),
+    path.join(sharedRoot, 'img', 'og.svg'),
+  ];
+  for (const f of mustExist) {
+    if (!io.existsSync(f)) {
+      errors.push(
+        `examples/_shared: required shared asset missing: ` +
+          `${path.relative(REPO_ROOT, f).split(path.sep).join('/')}`,
+      );
+    }
+  }
+  // structure.css reachable from style.css's @import.
+  const stylePath = path.join(sharedRoot, 'css', 'style.css');
+  const style = readFileSafe(io, stylePath);
+  if (style != null) {
+    const imports = extractCssImports(style).filter((i) => !isExternalRef(i));
+    const reachesStructure = imports.some(
+      (i) => path.basename(i).toLowerCase() === 'structure.css',
+    );
+    if (!reachesStructure) {
+      errors.push(
+        `examples/_shared/css/style.css: no @import resolving to ` +
+          `structure.css — the structural baseline is unreachable.`,
+      );
+    }
+  }
+  return errors;
+}
+
+// Run the full scan over every example index.html plus the _shared tree.
+function scanAll(opts = {}) {
+  const io = opts.io || fs;
+  const indexes = opts.indexes || listExampleIndexHtml();
+  const pages = indexes.map((p) => scanPage(io, p, opts));
+  const sharedErrors = checkSharedTree(io, opts);
+  const errors = [...sharedErrors, ...pages.flatMap((p) => p.errors)];
+  return { pages, sharedErrors, errors };
+}
+
+module.exports = {
+  REPO_ROOT,
+  EXAMPLES_ROOT,
+  SHARED_ROOT,
+  REQUIRED_SHARED_ASSETS,
+  ALLOWLIST,
+  BUILD_OUTPUTS,
+  listExampleIndexHtml,
+  isExternalRef,
+  extractHtmlRefs,
+  extractCssImports,
+  resolveRef,
+  checkCssImports,
+  scanPage,
+  checkSharedTree,
+  scanAll,
+};
+
+// ---------------------------------------------------------------------------
+// CLI entry-point (skipped when require()'d by the test suite).
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const listOnly = process.argv.slice(2).includes('--list');
+  const indexes = listExampleIndexHtml();
+
+  // Non-vacuous guard: a walk that silently recovers nothing must NOT let the
+  // gate pass green having scanned zero pages. The repo ships well over a
+  // dozen example pages; require a sane floor.
+  if (indexes.length < 10) {
+    console.error(
+      `check-examples-assets: only ${indexes.length} example index.html ` +
+        `page(s) found under examples/ — expected the full set. Walk or ` +
+        `layout drift; refusing to pass a vacuous gate.`,
+    );
+    process.exit(1);
+  }
+
+  const { pages, errors } = scanAll({ indexes });
+
+  console.log(
+    `check-examples-assets: scanning ${pages.length} example index.html ` +
+      `page(s) + the _shared tree.`,
+  );
+
+  if (listOnly) {
+    for (const p of pages) {
+      console.log(`  ${p.relIndex}`);
+      for (const r of p.refs) console.log(`      ${r}`);
+    }
+    process.exit(0);
+  }
+
+  if (errors.length > 0) {
+    console.error(
+      `\ncheck-examples-assets: ${errors.length} asset-contract violation(s):`,
+    );
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error(
+      `\nA missing/renamed _shared asset, a broken @import, or a page that ` +
+        `drops a required shared asset without an encoded ALLOWLIST ` +
+        `exception fails this gate. Fix the reference, restore the asset, or ` +
+        `encode the exception (with a reason) in ` +
+        `examples/scripts/check-examples-assets.cjs.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `check-examples-assets: all ${pages.length} pages resolve their assets ` +
+      `and carry the required _shared contract (allowlisted exceptions ` +
+      `honoured). _shared tree intact.`,
+  );
+}

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -36,7 +36,7 @@
     "test:xray-feature-gate": "node scripts/serve-and-run-xray-feature-gate.cjs",
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs && node scripts/dev-testbed.test.cjs",
     "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -1,0 +1,414 @@
+#!/usr/bin/env node
+/*
+ * Tests for `examples/scripts/check-examples-assets.cjs` — the STATIC
+ * examples asset-contract gate (rf2-8r0mj.2 + rf2-8r0mj.3 + rf2-emvyd).
+ *
+ * Two jobs, both with teeth:
+ *
+ *  1. LIVE GATE — run the real scan over the actual repo tree and FAIL if it
+ *     reports any violation. This is what gives the always-run
+ *     `test:script-policy` gate its teeth: a missing/renamed _shared asset, a
+ *     broken @import, or a non-exempt page dropping a required shared asset
+ *     turns this gate RED in CI. (Today the real tree is clean, so the live
+ *     scan passes — see the teeth-proof in the PR: break favicon.svg → RED →
+ *     restore → GREEN.)
+ *
+ *  2. UNIT TEETH — pin the pure scan logic against synthetic in-memory
+ *     fixtures so the behaviours the gate relies on (required-asset
+ *     detection, staging-aware _shared resolution, @import resolution, the
+ *     TodoMVC allowlist, external-URL/main.js skipping) cannot silently
+ *     regress to a vacuous pass.
+ *
+ * Standalone node-runnable suite — no external test framework, mirroring
+ * `_examples-filter.test.cjs` / `check-examples-compile.test.cjs`. Wired into
+ * package.json via `test:script-policy`.
+ */
+
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+
+const scanner = require('../../examples/scripts/check-examples-assets.cjs');
+const {
+  REQUIRED_SHARED_ASSETS,
+  ALLOWLIST,
+  isExternalRef,
+  extractHtmlRefs,
+  extractCssImports,
+  resolveRef,
+  scanPage,
+  checkSharedTree,
+  scanAll,
+  listExampleIndexHtml,
+  EXAMPLES_ROOT,
+} = scanner;
+
+let failed = 0;
+function it(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+  } catch (err) {
+    failed++;
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${(err && err.message) || err}`);
+  }
+}
+
+console.log('check-examples-assets tests (rf2-8r0mj.2 + rf2-8r0mj.3 + rf2-emvyd)');
+
+// ---------------------------------------------------------------------------
+// 1) LIVE GATE — the teeth in CI. Scan the real repo; any violation is RED.
+// ---------------------------------------------------------------------------
+
+const realIndexes = listExampleIndexHtml();
+
+it('the real examples tree exposes a non-vacuous set of index.html pages', () => {
+  assert.ok(
+    realIndexes.length >= 10,
+    `expected the full example set (>=10 index.html), got ` +
+      `${realIndexes.length} — walk/layout drift; a vacuous gate is forbidden`,
+  );
+});
+
+it('LIVE: every real example page resolves its assets + carries the contract', () => {
+  const { errors } = scanAll({ indexes: realIndexes });
+  assert.strictEqual(
+    errors.length,
+    0,
+    `the live asset scan found ${errors.length} violation(s):\n` +
+      errors.map((e) => `    - ${e}`).join('\n'),
+  );
+});
+
+it('LIVE: the real _shared source tree is intact (style.css -> structure.css)', () => {
+  const errors = checkSharedTree(require('fs'));
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `_shared tree errors:\n` + errors.map((e) => `    - ${e}`).join('\n'),
+  );
+});
+
+it('LIVE: TodoMVC is the encoded style.css opt-out (allowlist, not a regression)', () => {
+  const key = 'examples/reagent/todomvc/index.html';
+  const entry = ALLOWLIST[key];
+  assert.ok(entry, 'TodoMVC must be present in ALLOWLIST');
+  assert.ok(
+    entry.assetExemptions.includes('_shared/css/style.css'),
+    'TodoMVC must be exempt from the shared stylesheet',
+  );
+  // Still required to carry favicon + OG (the exemption is stylesheet-only).
+  assert.ok(
+    !entry.assetExemptions.includes('_shared/img/favicon.svg'),
+    'TodoMVC must STILL be required to carry the shared favicon',
+  );
+  assert.ok(
+    !entry.assetExemptions.includes('_shared/img/og.svg'),
+    'TodoMVC must STILL be required to carry the shared OG card',
+  );
+  assert.ok(
+    entry.reason && entry.reason.length > 0,
+    'the exemption must carry a human-readable reason',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 2) UNIT TEETH — synthetic in-memory fs so behaviour is pinned exactly.
+// A tiny fake io: a map of absolute path -> file contents.
+// ---------------------------------------------------------------------------
+
+function makeIo(files) {
+  // Keys are absolute paths. existsSync/readFileSync read from the map.
+  const norm = (p) => path.resolve(p);
+  const map = new Map(Object.entries(files).map(([k, v]) => [norm(k), v]));
+  return {
+    existsSync: (p) => map.has(norm(p)),
+    readFileSync: (p) => {
+      const v = map.get(norm(p));
+      if (v == null) {
+        const e = new Error(`ENOENT: ${p}`);
+        e.code = 'ENOENT';
+        throw e;
+      }
+      return v;
+    },
+  };
+}
+
+const PAGE = path.join(EXAMPLES_ROOT, 'reagent', 'demo', 'index.html');
+const FAVICON = path.join(EXAMPLES_ROOT, '_shared', 'img', 'favicon.svg');
+const OG = path.join(EXAMPLES_ROOT, '_shared', 'img', 'og.svg');
+const STYLE = path.join(EXAMPLES_ROOT, '_shared', 'css', 'style.css');
+const STRUCTURE = path.join(EXAMPLES_ROOT, '_shared', 'css', 'structure.css');
+
+// A well-formed page that links all three shared assets, plus a style.css
+// that @imports structure.css and an external Google-Fonts URL.
+function goodHtml() {
+  return [
+    '<!doctype html><html><head>',
+    '<meta property="og:image" content="_shared/img/og.svg">',
+    '<link rel="icon" href="_shared/img/favicon.svg">',
+    '<link rel="stylesheet" href="_shared/css/style.css">',
+    '</head><body><script src="main.js"></script></body></html>',
+  ].join('\n');
+}
+function goodStyleCss() {
+  return [
+    "@import url('https://fonts.googleapis.com/css2?family=Inter');",
+    "@import url('structure.css');",
+    'body { color: #1A1814; }',
+  ].join('\n');
+}
+function fullIo(overrides = {}) {
+  return makeIo({
+    [PAGE]: goodHtml(),
+    [STYLE]: goodStyleCss(),
+    [STRUCTURE]: '/* structure */',
+    [FAVICON]: '<svg/>',
+    [OG]: '<svg/>',
+    ...overrides,
+  });
+}
+
+// ---- extraction primitives ----------------------------------------------
+
+it('extractHtmlRefs picks up link/script/og:image refs, de-duped', () => {
+  const refs = extractHtmlRefs(goodHtml());
+  assert.ok(refs.includes('_shared/img/favicon.svg'));
+  assert.ok(refs.includes('_shared/css/style.css'));
+  assert.ok(refs.includes('_shared/img/og.svg'));
+  assert.ok(refs.includes('main.js'));
+});
+
+it('extractHtmlRefs strips ?query and #hash for on-disk resolution', () => {
+  const refs = extractHtmlRefs('<link href="a.css?v=2"><link href="b.css#x">');
+  assert.ok(refs.includes('a.css'));
+  assert.ok(refs.includes('b.css'));
+});
+
+it('extractCssImports handles url() and bare-string @import forms', () => {
+  const imports = extractCssImports(
+    "@import url('a.css'); @import \"b.css\"; @import url(c.css);",
+  );
+  assert.deepStrictEqual(imports.sort(), ['a.css', 'b.css', 'c.css']);
+});
+
+it('isExternalRef flags http(s)/protocol-relative/scheme refs, not local', () => {
+  assert.ok(isExternalRef('https://fonts.googleapis.com/x'));
+  assert.ok(isExternalRef('http://example.com'));
+  assert.ok(isExternalRef('//cdn.example.com/x.css'));
+  assert.ok(isExternalRef('data:image/svg+xml,...'));
+  assert.ok(isExternalRef('#frag'));
+  assert.ok(!isExternalRef('_shared/css/style.css'));
+  assert.ok(!isExternalRef('base.css'));
+});
+
+// ---- staging-aware resolution -------------------------------------------
+
+it('resolveRef maps _shared/* to the canonical examples/_shared tree', () => {
+  const target = resolveRef('_shared/css/style.css', path.dirname(PAGE));
+  assert.strictEqual(target, STYLE);
+});
+
+it('resolveRef maps a sibling ref relative to the page dir', () => {
+  const target = resolveRef('base.css', path.dirname(PAGE));
+  assert.strictEqual(target, path.join(path.dirname(PAGE), 'base.css'));
+});
+
+// ---- the happy path is clean --------------------------------------------
+
+it('a well-formed page with all assets present scans clean', () => {
+  const { errors } = scanPage(fullIo(), PAGE);
+  assert.deepStrictEqual(errors, []);
+});
+
+// ---- TEETH: missing _shared asset => error ------------------------------
+
+it('TEETH: a missing _shared favicon is reported', () => {
+  const io = fullIo();
+  // Drop the favicon from the io.
+  const without = makeIo({
+    [PAGE]: goodHtml(),
+    [STYLE]: goodStyleCss(),
+    [STRUCTURE]: '/* structure */',
+    [OG]: '<svg/>',
+    // FAVICON intentionally absent
+  });
+  const { errors } = scanPage(without, PAGE);
+  assert.ok(
+    errors.some((e) => e.includes('favicon.svg') && e.includes('does not resolve')),
+    `expected a missing-favicon error, got: ${errors.join(' | ')}`,
+  );
+  void io;
+});
+
+// ---- TEETH: broken @import target => error ------------------------------
+
+it('TEETH: a style.css @import to a missing structure.css is reported', () => {
+  const without = makeIo({
+    [PAGE]: goodHtml(),
+    [STYLE]: goodStyleCss(),
+    [FAVICON]: '<svg/>',
+    [OG]: '<svg/>',
+    // STRUCTURE intentionally absent
+  });
+  const { errors } = scanPage(without, PAGE);
+  assert.ok(
+    errors.some((e) => e.includes("@import 'structure.css'")),
+    `expected a broken-@import error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: the external Google-Fonts @import is NOT flagged as missing', () => {
+  const { errors } = scanPage(fullIo(), PAGE);
+  assert.ok(
+    !errors.some((e) => e.includes('fonts.googleapis.com')),
+    'an external @import URL must never be checked on disk',
+  );
+});
+
+// ---- TEETH: required-asset contract -------------------------------------
+
+it('TEETH: a non-exempt page dropping style.css is reported', () => {
+  const htmlNoStyle = goodHtml().replace(
+    '<link rel="stylesheet" href="_shared/css/style.css">',
+    '',
+  );
+  const io = fullIo({ [PAGE]: htmlNoStyle });
+  const { errors } = scanPage(io, PAGE);
+  assert.ok(
+    errors.some(
+      (e) =>
+        e.includes("missing required shared asset reference '_shared/css/style.css'"),
+    ),
+    `expected a missing-required-asset error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a non-exempt page dropping favicon is reported', () => {
+  const htmlNoFav = goodHtml().replace(
+    '<link rel="icon" href="_shared/img/favicon.svg">',
+    '',
+  );
+  const io = fullIo({ [PAGE]: htmlNoFav });
+  const { errors } = scanPage(io, PAGE);
+  assert.ok(
+    errors.some((e) =>
+      e.includes("missing required shared asset reference '_shared/img/favicon.svg'"),
+    ),
+    `expected a missing-favicon-reference error, got: ${errors.join(' | ')}`,
+  );
+});
+
+// ---- TEETH: the TodoMVC allowlist exemption is honoured ------------------
+
+it('a page allowlisted out of style.css with vendored CSS scans clean', () => {
+  // A synthetic page modelling TodoMVC: links base.css + index.css (vendored,
+  // not in repo source) instead of the shared stylesheet, but keeps favicon
+  // + OG. With the right allowlist entry it must scan clean.
+  const todoPage = path.join(EXAMPLES_ROOT, 'reagent', 'todomvc', 'index.html');
+  const todoHtml = [
+    '<meta property="og:image" content="_shared/img/og.svg">',
+    '<link rel="icon" href="_shared/img/favicon.svg">',
+    '<link rel="stylesheet" href="base.css">',
+    '<link rel="stylesheet" href="index.css">',
+    '<script src="main.js"></script>',
+  ].join('\n');
+  const io = makeIo({
+    [todoPage]: todoHtml,
+    [FAVICON]: '<svg/>',
+    [OG]: '<svg/>',
+    // base.css / index.css intentionally absent on disk (npm-staged) — the
+    // allowlist's localAssets must keep them from being flagged.
+  });
+  const allowlist = {
+    'examples/reagent/todomvc/index.html': {
+      reason: 'vendored TodoMVC CSS',
+      assetExemptions: ['_shared/css/style.css'],
+      localAssets: ['base.css', 'index.css'],
+    },
+  };
+  const { errors } = scanPage(io, todoPage, { allowlist });
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `allowlisted TodoMVC page should scan clean, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: an allowlisted page still REQUIRES favicon + OG (opt-out is stylesheet-only)', () => {
+  const todoPage = path.join(EXAMPLES_ROOT, 'reagent', 'todomvc', 'index.html');
+  // Drops the favicon — even though style.css is exempt, favicon is not.
+  const todoHtml = [
+    '<meta property="og:image" content="_shared/img/og.svg">',
+    '<link rel="stylesheet" href="base.css">',
+    '<link rel="stylesheet" href="index.css">',
+    '<script src="main.js"></script>',
+  ].join('\n');
+  const io = makeIo({
+    [todoPage]: todoHtml,
+    [OG]: '<svg/>',
+  });
+  const allowlist = {
+    'examples/reagent/todomvc/index.html': {
+      reason: 'vendored TodoMVC CSS',
+      assetExemptions: ['_shared/css/style.css'],
+      localAssets: ['base.css', 'index.css'],
+    },
+  };
+  const { errors } = scanPage(io, todoPage, { allowlist });
+  assert.ok(
+    errors.some((e) =>
+      e.includes("missing required shared asset reference '_shared/img/favicon.svg'"),
+    ),
+    `a stylesheet-only opt-out must still require the favicon, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a stale exemption (page DOES reference the exempt asset) is flagged', () => {
+  // The page references style.css but the allowlist claims it is exempt — an
+  // allowlist that has rotted. The gate must surface it so the allowlist
+  // cannot silently drift out of sync with the pages.
+  const io = fullIo();
+  const allowlist = {
+    'examples/reagent/demo/index.html': {
+      reason: 'stale',
+      assetExemptions: ['_shared/css/style.css'],
+    },
+  };
+  const { errors } = scanPage(io, PAGE, { allowlist });
+  assert.ok(
+    errors.some((e) => e.includes('stale exemption')),
+    `expected a stale-exemption error, got: ${errors.join(' | ')}`,
+  );
+});
+
+// ---- main.js / build output is never flagged ----------------------------
+
+it('the build-output main.js is never resolved on disk', () => {
+  // main.js is absent from the io (it is shadow-cljs output, not source) yet
+  // the page must scan clean.
+  const { errors } = scanPage(fullIo(), PAGE);
+  assert.ok(
+    !errors.some((e) => e.includes('main.js')),
+    'main.js (build output) must never be flagged as a missing source file',
+  );
+});
+
+// ---- contract constant sanity -------------------------------------------
+
+it('REQUIRED_SHARED_ASSETS names favicon, og, and style.css', () => {
+  assert.deepStrictEqual([...REQUIRED_SHARED_ASSETS].sort(), [
+    '_shared/css/style.css',
+    '_shared/img/favicon.svg',
+    '_shared/img/og.svg',
+  ]);
+});
+
+if (failed > 0) {
+  console.error(`\ncheck-examples-assets tests: ${failed} failed.`);
+  process.exit(1);
+}
+console.log('\ncheck-examples-assets tests: all passed.');


### PR DESCRIPTION
## Why

The `examples/_shared` design system (stylesheet + favicon + Open Graph card) ships to **every** example `index.html`, but no gate verified those assets resolve. The only gate that touches `_shared` (`npm run test:examples`) compiles + serves **only** the three adapter testbeds — whose pages link **none** of `_shared`. So a broken/renamed/missing `_shared` asset, a bad `@import` target, or a `stageShared` regression all passed `test:examples`: the staged copy is never loaded by any served page. The "every example references the shared assets" contract was review-only, and the TodoMVC stylesheet opt-out was unencoded.

Measured baseline (28 example index.html): 28/28 favicon, 28/28 OG, 27/28 `style.css` (TodoMVC is the opt-out — it links the vendored TodoMVC `base.css` + `index.css`).

## What

1. **`examples/scripts/check-examples-assets.cjs`** — a STATIC scanner (no Playwright; respects rf2-8cevm, `examples/` stays test-free). For every example `index.html` it:
   - resolves each referenced asset (`_shared/*` css/img + the og:image meta + the transitive `@import` targets inside any referenced local CSS) to a real file in the source tree — external URLs and the build-output `main.js` are skipped;
   - asserts every page carries the required shared assets (`favicon.svg`, `og.svg`, `style.css`) unless explicitly allowlisted;
   - asserts the `_shared` source tree is intact (required files present; `structure.css` reachable from `style.css`'s `@import`).
   - **Staging-aware resolution:** a `_shared/...` href resolves against the canonical `examples/_shared/` source (exactly what the orchestrator stages into each page's output dir), while a sibling href (e.g. TodoMVC's `base.css`) resolves page-relative.
   - **TodoMVC opt-out encoded** in `ALLOWLIST` (with a reason): exempt from `_shared/css/style.css`, **still required** to carry the shared favicon + OG; its npm-vendored `base.css`/`index.css` declared as `localAssets` so they aren't flagged as missing. Stale-exemption detection keeps the allowlist from rotting.

2. **`implementation/scripts/check-examples-assets.test.cjs`** — a LIVE scan over the real repo (the CI teeth: a missing/broken `_shared` asset turns the gate RED) plus synthetic-fixture unit teeth (required-asset detection, `@import` resolution, allowlist behaviour, external-URL/`main.js` skipping).

3. **Wired into `test:script-policy`** in `implementation/package.json` — the always-run `js-harness-self-tests` CI job (`.github/workflows/test.yml:828`). **No new `.github` workflow job; `.github` untouched.**

4. **Doc realignment** (stale staging paths → current `out/examples/adapter-testbeds/<name>/` layout): `examples/_shared/README.md` + `examples/README.md`. Both now also document the new static gate; the README's `spec-helpers.cjs` description was verified accurate (consumed by all three adapter testbed `spec.cjs`) — no change needed.

## Teeth proof

- Break `_shared/img/favicon.svg` → RED (29 violations: the tree check + all 28 page references); restore → GREEN.
- Break `@import` target `structure.css` → RED (tree check + 28 transitive `@import` errors); restore → GREEN.
- Non-exempt page drops `style.css` → RED with an actionable message; restore → GREEN.
- Through the wired gate: breaking `og.svg` makes `node scripts/check-examples-assets.test.cjs` (the LIVE test) exit 1; restore → exit 0.

## Gates

- `npm run test:script-policy` — GREEN (includes the new scanner's 21 tests).

Closes rf2-8r0mj.2, rf2-8r0mj.3, rf2-8r0mj.4, rf2-emvyd.