### PR TITLE
fix(schemas): bare-:tuple sensitivity is element-precise — no sibling taint (rf2-ss06u.4)

### DIFF
--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -217,6 +217,24 @@
                      {:rf.size/include-sensitive? true})
                    [:auth :password])))))
 
+(deftest schema-sensitive-tuple-position-precise-redacts
+  ;; rf2-ss06u.4 — a bare :tuple element marked {:sensitive? true} declares a
+  ;; POSITION-pinned path ([:point 0]); the runtime elision walk descends the
+  ;; tuple value (a vector) through its literal-index fork (fork-index-paths,
+  ;; (conj c i)) and matches that exact position — redacting ONLY the declared
+  ;; element while the non-sensitive sibling rides verbatim. This pins the
+  ;; core-elision coordinate-system consistency: the position-bearing walker
+  ;; decl and the runtime indexed path agree.
+  (rf/reg-app-schema [:point]
+                     [:tuple [:string {:sensitive? true}] :int])
+  (is (= [[:point 0]] (rf/populate-sensitive-from-schemas!))
+      "the sensitive tuple element declares its POSITION-pinned path")
+  (let [out (rf/elide-wire-value {:point ["the-secret" 42]})]
+    (is (= :rf/redacted (get-in out [:point 0]))
+        "the declared-sensitive element 0 is redacted")
+    (is (= 42 (get-in out [:point 1]))
+        "the non-sensitive sibling element 1 rides verbatim — no over-redaction")))
+
 (deftest sensitive-wins-over-large
   (rf/reg-app-schema [:secret-pdf]
                      [:string {:large? true

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -142,10 +142,25 @@
       slot props claims the parent path (the op's `base-path`), not a
       child path; dispatch values aren't path segments.
 
-    - Positional / nameless container ops (`:vector`, `:set`, `:sequential`,
-      `:maybe`, `:and`, `:or`, `:not`, `:tuple`, `:cat`, …) descend into
-      each child at the SAME `base-path` — these ops don't introduce a
-      new app-db path segment.
+    - `:tuple` children are POSITION-bearing (rf2-ss06u.4) — each element
+      has its OWN heterogeneous schema, so element `i` descends at
+      `(conj base-path i)`, the integer index being the discriminating
+      segment (the positional analogue of a `:map` key). A `:sensitive?`
+      flag on element 0 of `[:tuple [:string {:sensitive?}] :int]` claims
+      `(conj base 0)`, NOT `base` — so it does not taint the sibling at
+      `(conj base 1)`. This is the index-bearing element-precision the
+      `:vector` / `:map-of` paths already have via their map-key
+      discriminator; for `:tuple` the discriminator IS the index. The
+      position-pinned decl-path is matching-safe against the core-elision
+      coordinate system: the runtime elision walk descends a tuple value
+      (a vector) through its literal-index fork (`fork-index-paths` —
+      `(conj c i)`), which matches a position-pinned declaration exactly.
+
+    - Other positional / nameless container ops (`:vector`, `:set`,
+      `:sequential`, `:maybe`, `:and`, `:or`, `:not`, `:cat`, …) descend
+      into each child at the SAME `base-path` — these ops are homogeneous
+      (one shared element schema) or their index is not a declarable
+      app-db slot, so they don't introduce a new path segment.
 
     - Container-level props on the schema itself (the schema's OWN props,
       not a parent slot's) claim `base-path`. Covers
@@ -209,6 +224,21 @@
                    acc))))
            acc'
            children)
+
+         ;; `:tuple` — position-bearing (rf2-ss06u.4). Each element has its
+         ;; OWN schema; element `i` descends at `(conj base-path i)` so a
+         ;; per-position `:sensitive?` / `:large?` flag claims that exact
+         ;; index, NOT the shared tuple base-path. Mirrors the `:map`
+         ;; name-bearing descent with integer position keys, giving the
+         ;; sibling precision the index-free `:else` descent destroys.
+         (= op :tuple)
+         (first
+           (reduce
+             (fn [[acc i] child]
+               [(walk-flagged-schema flag-key child (conj base-path i) acc)
+                (inc i)])
+             [acc' 0]
+             children))
 
          :else
          (reduce (fn [acc c] (walk-flagged-schema flag-key c base-path acc))
@@ -316,14 +346,23 @@
 ;; app-db path segment. Malli's explainer reports a value-relative `:in`
 ;; path that descends INTO collection elements (`[1 :token]` for a
 ;; vector-of-maps, `["a" :secret]` for a map-of), but the walker builds
-;; its `{path declaration}` map at INDEX-FREE base-paths — positional /
-;; keyed containers descend at the same base-path (walker comment lines
-;; ~144-147) because the element index is not a declarable app-db slot.
-;; Aligning the two coordinate systems means dropping the collection-
-;; navigation segment that these ops contribute. `:map-of` descends into
-;; its VALUE schema (child index 1); the positional ops descend into
-;; their element/Nth-element schema. Per rf2-g5auo — without this
-;; alignment a `:sensitive?` slot nested in a collection leaks verbatim.
+;; its `{path declaration}` map at INDEX-FREE base-paths — homogeneous
+;; positional / keyed containers descend at the same base-path (walker
+;; comment lines ~145-148) because the element index is not a declarable
+;; app-db slot. Aligning the two coordinate systems means dropping the
+;; collection-navigation segment that these ops contribute. `:map-of`
+;; descends into its VALUE schema (child index 1); the homogeneous
+;; positional ops descend into their single element schema. Per rf2-g5auo
+;; — without this alignment a `:sensitive?` slot nested in a collection
+;; leaks verbatim.
+;;
+;; `:tuple` is the membership outlier (rf2-ss06u.4): it is kept in this
+;; set so `sanitize-sensitive-path` treats its integer index as a
+;; navigable locator (KEEP, not scrub), but `align-in-path` handles
+;; `:tuple` in its OWN position-KEEPING branch ABOVE the generic
+;; index-drop branch — a tuple element is heterogeneous (per-position
+;; schema), so the index IS a discriminating segment and must NOT be
+;; dropped, else sibling positions collapse and over-redact.
 (def ^:private index-bearing-ops
   #{:vector :sequential :set :tuple :map-of})
 
@@ -389,15 +428,30 @@
               ;; Key not found in the schema (shape drift) — fail-SAFE.
               [:fallback schema aligned])
 
-            ;; Index-bearing container — drop the index/key segment and
-            ;; descend into the element (or `:map-of` value) schema.
+            ;; `:tuple` — POSITION-bearing (rf2-ss06u.4). Unlike the
+            ;; homogeneous index-bearing ops below, each tuple element has
+            ;; its OWN schema, so the integer index IS a discriminating
+            ;; segment (the positional analogue of a `:map` key). KEEP the
+            ;; index in `aligned` — the walker emits per-position decl-paths
+            ;; (`(conj base i)`), so a failure at element `i` aligns to that
+            ;; same `[… i]` and prefix-matches ONLY that position's
+            ;; declaration. Dropping it (the prior behaviour) collapsed all
+            ;; elements onto the tuple base-path, so marking one element
+            ;; `:sensitive?` over-redacted every sibling failure.
+            (= op :tuple)
+            (if-let [child (when (and (int? seg) (< seg (count children)))
+                             (nth children seg))]
+              (recur child (subvec in 1) (conj aligned seg))
+              [:fallback schema aligned])
+
+            ;; Homogeneous index-bearing container — drop the index/key
+            ;; segment and descend into the element (or `:map-of` value)
+            ;; schema. `:vector`/`:sequential`/`:set` have one shared
+            ;; element schema; `:map-of`'s value schema is child 1. The
+            ;; index/key is not a declarable slot for these, so it is
+            ;; dropped to align with the walker's index-free decl-paths.
             (contains? index-bearing-ops op)
-            (let [child (if (= op :tuple)
-                          (when (and (int? seg) (< seg (count children)))
-                            (nth children seg))
-                          ;; :vector/:sequential/:set have one element
-                          ;; schema; :map-of's value schema is child 1.
-                          (nth children (if (= op :map-of) 1 0) nil))]
+            (let [child (nth children (if (= op :map-of) 1 0) nil)]
               (if (some? child)
                 (recur child (subvec in 1) aligned)
                 [:fallback schema aligned]))

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -567,6 +567,98 @@
                             [:age :int]]]
                   [0 :age])))))
 
+;; ---- :tuple element-precision — no sibling taint (rf2-ss06u.4) ------------
+;; A bare :tuple's elements are HETEROGENEOUS — each position carries its own
+;; schema, so the integer index IS the discriminating segment (the positional
+;; analogue of a :map key). Marking ONE tuple position {:sensitive? true} must
+;; NOT redact a failure at a DIFFERENT, non-sensitive position. The prior
+;; behaviour emitted the element flag at the index-free tuple base-path and
+;; align-in-path dropped the tuple index, collapsing all positions onto the
+;; base-path so any one sensitive element tainted every sibling (privacy-SAFE
+;; over-redaction, but a precision divergence from the rf2-oh4se no-sibling-
+;; taint contract the :vector path holds — schemas_sensitive_test.clj:563-568).
+;; The fix makes the walker emit position-pinned decl-paths ((conj base i))
+;; and align-in-path KEEP the tuple index, so each position is independent —
+;; mirroring the :vector / :map-of map-key discriminator with the index as the
+;; tuple's discriminator. These assert the false (sibling) cases that returned
+;; true before the fix; the true (self / ancestor / descendant) cases pin the
+;; redaction direction is unchanged.
+
+(deftest schema-sensitive-at-tuple-position-precise
+  (testing "rf2-ss06u.4 — a bare :tuple's sensitivity is element-precise: a
+            failure at a NON-sensitive sibling position is NOT redacted, while
+            the declared-sensitive position (and ancestor/descendant) still is"
+    (let [s0 [:tuple [:string {:sensitive? true}] :int]]   ;; element 0 sensitive
+      ;; SELF — the sensitive position fails → redact.
+      (is (true? (schemas/schema-sensitive-at? s0 [0]))
+          "the declared-sensitive position 0 redacts")
+      ;; SIBLING — the non-sensitive position fails → must NOT redact.
+      (is (false? (schemas/schema-sensitive-at? s0 [1]))
+          "element 0 sensitive must NOT taint a failure at the non-sensitive element 1"))
+    (let [s1 [:tuple :int [:string {:sensitive? true}]]]   ;; element 1 sensitive
+      (is (true? (schemas/schema-sensitive-at? s1 [1]))
+          "the declared-sensitive position 1 redacts")
+      (is (false? (schemas/schema-sensitive-at? s1 [0]))
+          "element 1 sensitive must NOT taint a failure at the non-sensitive element 0"))
+    ;; ANCESTOR / DESCENDANT — a tuple element that is itself a container with
+    ;; a nested sensitive slot: a failure at the slot, at the whole element, or
+    ;; at the whole tuple all redact (the value carries the secret); a failure
+    ;; at the OTHER element does not.
+    (let [s [:tuple [:map [:tok {:sensitive? true} :string]] :int]]
+      (is (true?  (schemas/schema-sensitive-at? s [0 :tok])) "exact nested slot")
+      (is (true?  (schemas/schema-sensitive-at? s [0]))      "ancestor of the secret")
+      (is (true?  (schemas/schema-sensitive-at? s []))       "whole tuple carries the secret")
+      (is (false? (schemas/schema-sensitive-at? s [1]))      "non-sensitive sibling element 1"))))
+
+(deftest extract-tuple-emits-position-pinned-paths
+  (testing "rf2-ss06u.4 — the walker emits a tuple element flag at its
+            POSITION-pinned path ((conj base i)), not the index-free tuple
+            base-path; this is what gives the sibling precision"
+    (is (= {[0] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:tuple [:string {:sensitive? true}] :int] [])))
+    (is (= {[1] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:tuple :int [:string {:sensitive? true}]] [])))
+    ;; base-path threads through.
+    (is (= {[:pt 0] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:tuple [:string {:sensitive? true}] :int] [:pt])))))
+
+(deftest app-db-validation-tuple-sibling-not-over-redacted
+  (testing "rf2-ss06u.4 + rf2-oh4se — END-TO-END: a :tuple with one sensitive
+            and one non-sensitive element, where ONLY the non-sensitive sibling
+            fails, must ride VERBATIM (no :sensitive? stamp, no :rf/redacted) —
+            mirrors the g5auo :vector no-sibling-taint contract"
+    ;; element 0 is {:sensitive?} :string (valid value "ok");
+    ;; element 1 is :int but supplied a string → only element 1 fails.
+    (let [v (app-db-failure-trace
+              [:point]
+              [:tuple [:string {:sensitive? true}] :int]
+              {:point ["ok" "not-an-int"]}
+              :point/bad)]
+      (is (some? v) "a trace fired")
+      (is (not (contains? v :sensitive?))
+          "the failing element 1 is not sensitive; its sensitive sibling at element 0 doesn't taint it")
+      (is (not= :rf/redacted (-> v :tags :value))
+          ":value rides verbatim — only the non-sensitive element 1 failed"))))
+
+(deftest app-db-validation-tuple-sensitive-element-still-redacts
+  (testing "rf2-ss06u.4 — no regression: when the SENSITIVE tuple element fails,
+            the value is redacted and stamped (the precision fix must not
+            under-redact the declared position)"
+    ;; element 0 is {:sensitive?} :string but supplied an int → element 0 fails.
+    (let [v (app-db-failure-trace
+              [:point]
+              [:tuple [:string {:sensitive? true}] :int]
+              {:point [99 7]}
+              :point/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v))
+          "the sensitive element 0 failed — top-level :sensitive? stamp present")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted"))))
+
 ;; ---- redaction at event validation site ----------------------------------
 
 (deftest event-validation-ignores-handler-meta-sensitive


### PR DESCRIPTION
## Summary

A bare `:tuple` sensitivity declaration **over-redacted a non-sensitive SIBLING element**. The index-free walker descent emitted every tuple element's flag at the tuple's OWN base-path, and `align-in-path` dropped the tuple index — so all positions collapsed onto the base-path. Marking ONE tuple slot `{:sensitive? true}` redacted EVERY sibling failure.

Privacy-SAFE (over-redaction, never a leak) but a precision divergence from the rf2-oh4se / rf2-g5auo **no-sibling-taint** contract that the `:vector` / `:map-of` paths already hold (closes **rf2-ss06u.4**, child of rf2-ss06u correctness review).

## Root cause

A `:tuple` is **heterogeneous** — each position carries its OWN schema — so the integer index IS the discriminating segment (the positional analogue of a `:map` key). This is unlike the homogeneous `:vector` / `:sequential` / `:set` (one shared element schema) and `:map-of` (one shared value schema), where the index/key is not a declarable slot and is correctly dropped. The prior code lumped `:tuple` in with the homogeneous ops in both the walker descent and `align-in-path`, collapsing positions.

## Fix — extend the SAME ss06u.1/.2 mechanism, position-precise

- **`walker.cljc` `walk-flagged-schema`**: a dedicated `:tuple` branch descends each element `i` at `(conj base-path i)`. Element 0's `{:sensitive?}` now claims `[… 0]`, not `[… ]` — it no longer taints the sibling at `[… 1]`. Mirrors the `:map` name-bearing descent with integer position keys.
- **`walker.cljc` `align-in-path`**: a dedicated `:tuple` branch KEEPS the index segment (above the generic index-drop branch), so a failure at element `i` aligns to `[… i]` and prefix-matches ONLY that position's declaration.
- **`sanitize-sensitive-path`**: unchanged — already keeps the tuple index as a navigable `:path` locator; `:tuple` stays in `index-bearing-ops` for that.

## Consistency with the core-elision coordinate system (rf2-wm9kp)

The position-pinned decl-path is matching-safe. The runtime elision walk descends a tuple value (a vector) through its **literal-index fork** (`fork-index-paths` — `(conj c i)`), which matches a position-pinned declaration exactly. The walker is shared by `:large?` too; the same position-precision applies and is matching-safe. Pinned by a new end-to-end `elision_test`.

## Before / after

```clojure
;; element 0 sensitive, failure at the NON-sensitive element 1:
(schema-sensitive-at? [:tuple [:string {:sensitive? true}] :int] [1])
;; before => true   (over-redact: sibling :rf/redacted)
;; after  => false  (sibling rides verbatim)

;; the sensitive position itself is unchanged:
(schema-sensitive-at? [:tuple [:string {:sensitive? true}] :int] [0]) ;; => true
```

## Tests

- `schemas_sensitive_test`: `schema-sensitive-at-tuple-position-precise`, `extract-tuple-emits-position-pinned-paths`, and two end-to-end `app-db-failure-trace` regressions (sibling verbatim / sensitive element redacted) mirroring the g5auo `:vector` no-sibling-taint test.
- `elision_test`: `schema-sensitive-tuple-position-precise-redacts` — runtime redaction proves the position-pinned decl matches via the core-elision literal-index fork.

## Quality gates (all green)

- schemas `clojure -M:test` — 254 tests, 18503 assertions, 0 failures
- core `clojure -M:test` — 893 tests, 4003 assertions, 0 failures
- `npm run test:security` (adversarial redaction gate) — 22 tests, 182 assertions, 0 failures (privacy invariants confirmed: sentinel never leaks at any nesting incl. tuples; no-over-redaction property holds)
- `npm run test:cljs` — 5727 tests, 20022 assertions, 0 failures

No spec edit: Spec 010 mandates precision (redact the failing slot), not the imprecise collapse; this strengthens conformance.