### PR TITLE
test(mcp-conformance): tighten redaction-gate hook-installed check to a structured assertion (rf2-6r5qe.2)

### DIFF
--- a/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
@@ -472,11 +472,18 @@ async function seedRuntime(client, label) {
 
   const enable = await client.callTool({ name: 'eval-cljs', arguments: { form: ENABLE_CONFIGURE_FORM } });
   assertOk(enable, label + ' eval-cljs configure-epoch');
-  if (!responseText(enable).includes('true')) {
+  // Assert the STRUCTURED `:hook-installed? true` slot, not a bare 'true'
+  // substring. The form returns `{:hook-installed? <bool> :depth <int>}`;
+  // a substring search for 'true' anywhere in the rendered EDN would be
+  // satisfied by a stray 'true' in any future-added slot (a note string,
+  // a richer map) even with the hook NOT installed. Pin the typed value
+  // by matching the key+value as a full token — mirror the `:epoch-count
+  // \s+0\b` regex style used for the seed assertion below.
+  if (!/:hook-installed\?\s+true\b/.test(responseText(enable))) {
     throw new Error(
       label + ' eval-cljs configure-epoch did not install the :epoch/settle! hook ' +
-        '(epoch recording would stay disabled and no epoch would be recorded). ' +
-        'Got: ' + responseText(enable).slice(0, 300),
+        '(:hook-installed? not true — epoch recording would stay disabled and no ' +
+        'epoch would be recorded). Got: ' + responseText(enable).slice(0, 300),
     );
   }
 
@@ -524,11 +531,13 @@ async function enableEpochRecording(client, label) {
   assertOk(req, label + ' eval-cljs require-epoch');
   const enable = await client.callTool({ name: 'eval-cljs', arguments: { form: ENABLE_CONFIGURE_FORM } });
   assertOk(enable, label + ' eval-cljs configure-epoch');
-  if (!responseText(enable).includes('true')) {
+  // Structured `:hook-installed? true` token, not a bare 'true' substring
+  // — same rationale as the seedRuntime check above (rf2-6r5qe.2).
+  if (!/:hook-installed\?\s+true\b/.test(responseText(enable))) {
     throw new Error(
       label + ' eval-cljs configure-epoch did not install the :epoch/settle! hook ' +
-        '(epoch recording would stay disabled and no epoch would be recorded). ' +
-        'Got: ' + responseText(enable).slice(0, 300),
+        '(:hook-installed? not true — epoch recording would stay disabled and no ' +
+        'epoch would be recorded). Got: ' + responseText(enable).slice(0, 300),
     );
   }
 }


### PR DESCRIPTION
## What

Tightens the epoch-recording setup check in `tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs` from a loose substring match to a structured token assertion. Closes **rf2-6r5qe.2** (correctness review of `tools/mcp-conformance`).

## Why

`seedRuntime` (and the sibling `enableEpochRecording`) verified the `:epoch/settle!` hook install with:

```js
if (!responseText(enable).includes('true')) { throw ... }
```

against the `ENABLE_CONFIGURE_FORM` return `{:hook-installed? <bool> :depth <int>}`. A bare `includes('true')` matches the word anywhere in the rendered EDN — a stray `'true'` in a future-added slot (a `:note` string, a richer map) would satisfy it even when `:hook-installed?` is **false**, masking a genuine hook-install failure. The check asserted less than its own comment claimed.

This is **not** exploitable into a privacy false-green today: the load-bearing assertions are downstream and robust (`assertDropped` requires the sentinel ABSENT *and* `:dropped-sensitive >= 1`; the seed pins `:epoch-count != 0`). But it is exactly the loose-assertion shape the false-green review campaign targets, and it was latent against future form edits.

## Change

Both call sites now pin the typed slot:

```js
if (!/:hook-installed\?\s+true\b/.test(responseText(enable))) { throw ... }
```

mirroring the `/:epoch-count\s+0\b/` token-style read already used for the seed assertion in the same file.

## Teeth

The new regex was verified against the exact EDN shapes:

| input | new check | old `includes('true')` |
|---|---|---|
| `{:hook-installed? true, :depth 50}` (genuine install) | pass | pass |
| `{:hook-installed? false, :depth 50}` (hook NOT installed) | **reject** | reject |
| `{:hook-installed? false :depth 50 :note "recording-true-path"}` (bead repro) | **reject** | wrongly passes |
| `{:hook-installed? false, :truncated? true}` (stray `true`) | **reject** | wrongly passes |

The tightened check fails if the hook genuinely isn't installed, not merely if the word `'true'` appears somewhere in the payload.

## Gates

`npm run test:mcp-conformance` — all 6 gates green (the live redaction test SKIPs without `$SHADOW_CLJS_NREPL_PORT`, same posture as its siblings; its assertion path is exercised by the hermetic orchestrator on CI).