### PR TITLE
refactor(testbeds): extract shared Story-host hash-router helper (rf2-tq26t + rf2-uv7sn)

### DIFF
--- a/examples/reagent/login/stories_host.cljs
+++ b/examples/reagent/login/stories_host.cljs
@@ -43,8 +43,7 @@
    the Story body carries no code into a production bundle. The
    bundle-isolation gate verifies the Story / Xray sentinel sets stay
    out of the plain `:examples/login` build."
-  (:require [reagent.dom.client :as rdc]
-            [re-frame.core  :as rf]
+  (:require [re-frame.core  :as rf]
             [re-frame.story :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-xray.config :as xray-config]
@@ -52,7 +51,10 @@
             ;; demo fx / subs / views) and the Story artefacts. Requiring
             ;; `login.stories` transitively requires `login.core`.
             [login.core :as core]
-            [login.stories])
+            [login.stories]
+            ;; Shared Story-host helper (rf2-tq26t / rf2-uv7sn): owns the
+            ;; live-app↔Story-shell hash router + React-root handle.
+            [re-frame.testbed.story-host :as story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- The live-app frame ----------------------------------------------------
@@ -82,37 +84,10 @@
 
 ;; -- Routing between the live app and the Story shell ----------------------
 ;;
-;; The live app and the Story shell each own a React root on the same
-;; `#app` node, one at a time. The live app's root lives in `app-root`;
-;; the Story shell allocates and owns its own root inside `mount-shell!`.
-;; We tear one down before mounting the other (mirrors
+;; The live-app↔Story-shell hash router + React-root host handle live in the
+;; shared `re-frame.testbed.story-host` helper (rf2-tq26t / rf2-uv7sn); `run`
+;; hands it `login-app` as the live-app surface (mirrors
 ;; nine-states.stories-host).
-
-(defonce ^:private app-root (atom nil))
-
-(defn- ensure-app-root! []
-  (when (nil? @app-root)
-    (reset! app-root (rdc/create-root (js/document.getElementById "app")))))
-
-(defn- tear-down-app-root! []
-  (when-let [r @app-root]
-    (try (rdc/unmount r) (catch :default _ nil))
-    (reset! app-root nil)))
-
-(defn- mount-app! []
-  (story/unmount-shell!)
-  (ensure-app-root!)
-  (rdc/render @app-root [login-app]))
-
-(defn- mount-stories! []
-  (tear-down-app-root!)
-  (story/mount-shell! (js/document.getElementById "app")))
-
-(defn- on-hash-change! []
-  (let [hash (or (.. js/window -location -hash) "")]
-    (if (re-find #"^#/stories" hash)
-      (mount-stories!)
-      (mount-app!))))
 
 (defn ^:export run []
   ;; Keep Xray's collectors + keybinding installed but do not auto-open
@@ -124,7 +99,6 @@
   ;; `reg-*` in `login.stories` (loaded via the require above)
   ;; auto-installs the canonical Story vocabulary (rf2-p1ydc).
   (install-live-frame!)
-  ;; Wire hash-change so reloading `#/stories` lands on the shell
-  ;; without a manual click-through.
-  (.addEventListener js/window "hashchange" on-hash-change!)
-  (on-hash-change!))
+  ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
+  ;; `#/stories` lands on the shell without a manual click-through.
+  (story-host/mount-with-hash-routing! login-app))

--- a/examples/reagent/nine_states/stories_host.cljs
+++ b/examples/reagent/nine_states/stories_host.cljs
@@ -45,8 +45,7 @@
    short-circuits — the Story body carries no code into a production
    bundle. The bundle-isolation gate verifies the Story / Xray
    sentinel sets stay out of the plain `:examples/nine-states` build."
-  (:require [reagent.dom.client :as rdc]
-            [re-frame.core  :as rf]
+  (:require [re-frame.core  :as rf]
             [re-frame.story :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-xray.config :as xray-config]
@@ -55,7 +54,10 @@
             ;; and the Story artefacts. Requiring `nine-states.stories`
             ;; transitively requires `nine-states.core`.
             [nine-states.core :as core]
-            [nine-states.stories])
+            [nine-states.stories]
+            ;; Shared Story-host helper (rf2-tq26t / rf2-uv7sn): owns the
+            ;; live-app↔Story-shell hash router + React-root handle.
+            [re-frame.testbed.story-host :as story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- The live-app frame ----------------------------------------------------
@@ -86,37 +88,10 @@
 
 ;; -- Routing between the live app and the Story shell ----------------------
 ;;
-;; The live app and the Story shell each own a React root on the same
-;; `#app` node, one at a time. The live app's root lives in `app-root`;
-;; the Story shell allocates and owns its own root inside `mount-shell!`.
-;; We tear one down before mounting the other (mirrors
+;; The live-app↔Story-shell hash router + React-root host handle live in the
+;; shared `re-frame.testbed.story-host` helper (rf2-tq26t / rf2-uv7sn); `run`
+;; hands it `nine-states-app` as the live-app surface (mirrors
 ;; counter-with-stories.core).
-
-(defonce ^:private app-root (atom nil))
-
-(defn- ensure-app-root! []
-  (when (nil? @app-root)
-    (reset! app-root (rdc/create-root (js/document.getElementById "app")))))
-
-(defn- tear-down-app-root! []
-  (when-let [r @app-root]
-    (try (rdc/unmount r) (catch :default _ nil))
-    (reset! app-root nil)))
-
-(defn- mount-app! []
-  (story/unmount-shell!)
-  (ensure-app-root!)
-  (rdc/render @app-root [nine-states-app]))
-
-(defn- mount-stories! []
-  (tear-down-app-root!)
-  (story/mount-shell! (js/document.getElementById "app")))
-
-(defn- on-hash-change! []
-  (let [hash (or (.. js/window -location -hash) "")]
-    (if (re-find #"^#/stories" hash)
-      (mount-stories!)
-      (mount-app!))))
 
 (defn ^:export run []
   ;; Keep Xray's collectors + keybinding installed but do not auto-open
@@ -128,7 +103,6 @@
   ;; `reg-*` in `nine-states.stories` (loaded via the require above)
   ;; auto-installs the canonical Story vocabulary (rf2-p1ydc).
   (install-live-frame!)
-  ;; Wire hash-change so reloading `#/stories` lands on the shell
-  ;; without a manual click-through.
-  (.addEventListener js/window "hashchange" on-hash-change!)
-  (on-hash-change!))
+  ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
+  ;; `#/stories` lands on the shell without a manual click-through.
+  (story-host/mount-with-hash-routing! nine-states-app))

--- a/tools/story/testbeds/counter_with_stories/core.cljs
+++ b/tools/story/testbeds/counter_with_stories/core.cljs
@@ -13,8 +13,7 @@
   carries no Story body code. The bundle-isolation grep at
   `implementation/scripts/check-bundle-isolation.cjs` verifies the
   Story-sentinel set is absent under that build."
-  (:require [reagent.dom.client :as rdc]
-            [re-frame.core      :as rf]
+  (:require [re-frame.core      :as rf]
             [re-frame.story     :as story]
             [re-frame.story.play.ci-runner :as story-ci]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -33,7 +32,10 @@
             [counter-with-stories.stories]
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
-            [re-frame.testbed.config :as testbed-config])
+            [re-frame.testbed.config :as testbed-config]
+            ;; Shared Story-host helper (rf2-tq26t / rf2-uv7sn): owns the
+            ;; live-app↔Story-shell hash router + React-root handle.
+            [re-frame.testbed.story-host :as story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- The live-app root view ------------------------------------------------
@@ -77,37 +79,10 @@
 
 ;; -- Routing between app and story shell ----------------------------------
 ;;
-;; The live app and the Story shell each own their own React root on
-;; the same `#app` DOM node, one at a time. The live app's root lives
-;; in `app-root` here; the Story shell allocates and owns its root
-;; internally via `rdc/create-root` inside `mount-shell!`. We tear
-;; one down before mounting the other.
-
-(defonce ^:private app-root (atom nil))
-
-(defn- ensure-app-root! []
-  (when (nil? @app-root)
-    (reset! app-root (rdc/create-root (js/document.getElementById "app")))))
-
-(defn- tear-down-app-root! []
-  (when-let [r @app-root]
-    (try (rdc/unmount r) (catch :default _ nil))
-    (reset! app-root nil)))
-
-(defn- mount-app! []
-  (story/unmount-shell!)
-  (ensure-app-root!)
-  (rdc/render @app-root [counter-app]))
-
-(defn- mount-stories! []
-  (tear-down-app-root!)
-  (story/mount-shell! (js/document.getElementById "app")))
-
-(defn- on-hash-change! []
-  (let [hash (or (.. js/window -location -hash) "")]
-    (if (re-find #"^#/stories" hash)
-      (mount-stories!)
-      (mount-app!))))
+;; The live-app↔Story-shell hash router + React-root host handle live in
+;; the shared `re-frame.testbed.story-host` helper (rf2-tq26t / rf2-uv7sn);
+;; `run` hands it `counter-app` as the live-app surface. The helper tears
+;; one React root down before mounting the other on the same `#app` node.
 
 (defn ^:export run []
   ;; Story owns this page's full-width browser-test canvas. When the
@@ -149,7 +124,6 @@
   ;; to install unconditionally because the function body is gated
   ;; on Story being enabled (the ns itself is Story-tooling).
   (story-ci/install-ci-hooks!)
-  ;; Wire hash-change so reloading `#/stories` lands on the shell
-  ;; without a manual click-through.
-  (.addEventListener js/window "hashchange" on-hash-change!)
-  (on-hash-change!))
+  ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
+  ;; `#/stories` lands on the shell without a manual click-through.
+  (story-host/mount-with-hash-routing! counter-app))

--- a/tools/story/testbeds/login_form/core.cljs
+++ b/tools/story/testbeds/login_form/core.cljs
@@ -13,8 +13,7 @@
   short-circuits; the bundle carries no Story body code. The
   bundle-isolation grep at `implementation/scripts/check-bundle-
   isolation.cjs` covers the Story-sentinel absence."
-  (:require [reagent.dom.client :as rdc]
-            [re-frame.core      :as rf]
+  (:require [re-frame.core      :as rf]
             [re-frame.story     :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-xray.config :as xray-config]
@@ -24,7 +23,10 @@
             [login-form.stories]
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
-            [re-frame.testbed.config :as testbed-config])
+            [re-frame.testbed.config :as testbed-config]
+            ;; Shared Story-host helper (rf2-tq26t / rf2-uv7sn): owns the
+            ;; live-app↔Story-shell hash router + React-root handle.
+            [re-frame.testbed.story-host :as story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ---------------------------------------------------------------------------
@@ -78,32 +80,10 @@
 ;; ---------------------------------------------------------------------------
 ;; Hash-routing between the live app and the Story shell
 ;; ---------------------------------------------------------------------------
-
-(defonce ^:private app-root (atom nil))
-
-(defn- ensure-app-root! []
-  (when (nil? @app-root)
-    (reset! app-root (rdc/create-root (js/document.getElementById "app")))))
-
-(defn- tear-down-app-root! []
-  (when-let [r @app-root]
-    (try (rdc/unmount r) (catch :default _ nil))
-    (reset! app-root nil)))
-
-(defn- mount-app! []
-  (story/unmount-shell!)
-  (ensure-app-root!)
-  (rdc/render @app-root [login-app]))
-
-(defn- mount-stories! []
-  (tear-down-app-root!)
-  (story/mount-shell! (js/document.getElementById "app")))
-
-(defn- on-hash-change! []
-  (let [hash (or (.. js/window -location -hash) "")]
-    (if (re-find #"^#/stories" hash)
-      (mount-stories!)
-      (mount-app!))))
+;;
+;; The live-app↔Story-shell hash router + React-root host handle live in the
+;; shared `re-frame.testbed.story-host` helper (rf2-tq26t / rf2-uv7sn); `run`
+;; hands it `login-app` as the live-app surface.
 
 (defn ^:export run []
   ;; Story owns this page's full-width browser-test canvas. When the
@@ -134,5 +114,5 @@
   ;; Without this, the live page's state-pill renders "state: "
   ;; (nil) until the user submits.
   (rf/dispatch-sync [:login/flow [:login/dismiss]])
-  (.addEventListener js/window "hashchange" on-hash-change!)
-  (on-hash-change!))
+  ;; Wire the live-app↔Story-shell hash router (shared helper).
+  (story-host/mount-with-hash-routing! login-app))

--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -1,10 +1,13 @@
 # tools/testbed-support/
 
 A small **dev-only** support library shared by the Xray and Story
-browser testbeds. One namespace — `re-frame.testbed.config` — that
-derives the on-disk project root those testbeds hand to their
-"open in editor" source-coord resolvers, cross-platform and with no
-hardcoded checkout path.
+browser testbeds. Two namespaces:
+
+- `re-frame.testbed.config` — derives the on-disk project root those
+  testbeds hand to their "open in editor" source-coord resolvers,
+  cross-platform and with no hardcoded checkout path.
+- `re-frame.testbed.story-host` — the live-app ↔ Story-shell hash-toggle
+  host harness the Story showcase testbeds share (rf2-tq26t / rf2-uv7sn).
 
 ## What it is
 
@@ -30,6 +33,26 @@ other clone and every Mac/Linux maintainer (rf2-5dphw).
   testbed configures no root — "open in editor" degrades to a graceful
   no-op rather than a broken link.
 
+## The Story host harness (`story-host`)
+
+Every Story showcase entry point hosts two surfaces on the same `#app`
+node, one React root at a time — `#/` the live app, `#/stories` the Story
+shell. The plumbing that switches between them (a `defonce` React-root
+handle, the tear-down-one-before-mounting-the-other dance, and the
+`hashchange` listener) is pure React-DOM-root juggling — identical across
+every testbed but for the live-app root view. It was copy-pasted across
+five files (`counter_with_stories`, `login_form`, the `login` and
+`nine_states` examples, plus the template scaffolding), already drifting in
+the per-testbed boot specifics they each add.
+
+`re-frame.testbed.story-host/mount-with-hash-routing!` owns that harness:
+the testbed does its own boot (Xray config, `rf/init!`, `story/configure!`,
+`:fx-overrides`, seed dispatches, CI hooks) and calls the helper LAST with
+its live-app root view. Four of the five copies now call it; the **template
+copy stays standalone by design** — it is `resources/` scaffolding emitted
+into a fresh consumer project whose classpath has no access to this
+dev-repo-internal helper.
+
 ## Layout
 
 ```
@@ -37,7 +60,8 @@ tools/testbed-support/
 ├── README.md                                 ; this file
 └── src/re_frame/testbed/
     ├── config.cljs                           ; resolve-project-root + the repo-root goog-define
-    └── config_cljs_test.cljs                 ; CLJS unit tests for the resolver
+    ├── config_cljs_test.cljs                 ; CLJS unit tests for the resolver
+    └── story_host.cljs                       ; mount-with-hash-routing! (live-app↔shell host)
 ```
 
 ## How it's wired

--- a/tools/testbed-support/src/re_frame/testbed/story_host.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/story_host.cljs
@@ -1,0 +1,111 @@
+(ns re-frame.testbed.story-host
+  "Shared Story-host helper — the live-app ↔ Story-shell hash-toggle host
+  harness the Story showcase testbeds copied verbatim (rf2-tq26t /
+  rf2-uv7sn).
+
+  ## Why this exists
+
+  Every Story showcase entry point hosts TWO surfaces on the same `#app`
+  DOM node, one React root at a time:
+
+  - `#/`        → the live app (the testbed's own root view).
+  - `#/stories` → the Story shell mounted via `re-frame.story/mount-shell!`.
+
+  The plumbing that switches between them — a private `app-root` atom,
+  `ensure-app-root!` / `tear-down-app-root!` / `mount-app!` /
+  `mount-stories!`, and the `hashchange` listener — is pure React-DOM-root
+  juggling, identical across every testbed but for the live-app root view.
+  Five copies (`counter_with_stories`, `login_form`, the `login` and
+  `nine_states` examples, plus the template scaffolding) invited drift:
+  they already diverged in their `run` boot specifics (CI hooks, elision
+  listener, `:fx-overrides`) while carrying byte-identical host blocks.
+
+  ## What it owns
+
+  This namespace owns the React-root handle and the hash router ONLY — the
+  documented mount-handle exception to the app-db+events+subs rule
+  (rf2-5sjbg). The root atom is a `defonce` here so a testbed's hot-reload
+  re-`run` reuses the same root rather than leaking one per reload, exactly
+  as the per-file copies did. Everything else (Xray config, `rf/init!`,
+  `story/configure!`, per-frame `:fx-overrides`, seed dispatches, CI hooks)
+  stays inline in each testbed's `run` — those are the genuinely per-testbed
+  boot specifics, not host boilerplate.
+
+  ## How it's wired
+
+  Co-located with `re-frame.testbed.config` under `tools/testbed-support/
+  src`, which is already on every testbed build's shadow-cljs source path —
+  so consuming testbeds need no build-wiring change. Bundle-isolation holds:
+  nothing under `implementation/` `:require`s it (it lives under tools/)."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.story :as story]))
+
+;; -- The live-app React root ----------------------------------------------
+;;
+;; The live app and the Story shell each own their own React root on the
+;; same `#app` DOM node, one at a time. The live app's root lives in
+;; `app-root` here; the Story shell allocates and owns its own root
+;; internally via `rdc/create-root` inside `mount-shell!`. We tear one down
+;; before mounting the other so React owns the target node exclusively.
+;;
+;; `defonce` so a testbed's hot-reload re-`run` reuses the same root rather
+;; than leaking a fresh one per reload (the contract every per-file copy
+;; encoded).
+
+(defonce ^:private app-root (atom nil))
+
+;; The live-app root view in play, set by `mount-with-hash-routing!`. Held
+;; in an atom so the single stable `hashchange` listener (below) reads the
+;; current view rather than closing over a per-`run` value — this keeps the
+;; listener reference identical across hot-reload re-`run`s, so
+;; `addEventListener` deduplicates it (the browser no-ops a repeat add of the
+;; same fn reference), exactly as the per-file copies' named-fn listener did.
+(defonce ^:private root-view* (atom nil))
+
+(defn- app-node []
+  (js/document.getElementById "app"))
+
+(defn- ensure-app-root! []
+  (when (nil? @app-root)
+    (reset! app-root (rdc/create-root (app-node)))))
+
+(defn- tear-down-app-root! []
+  (when-let [r @app-root]
+    (try (rdc/unmount r) (catch :default _ nil))
+    (reset! app-root nil)))
+
+(defn- mount-app! []
+  (story/unmount-shell!)
+  (ensure-app-root!)
+  (rdc/render @app-root [@root-view*]))
+
+(defn- mount-stories! []
+  (tear-down-app-root!)
+  (story/mount-shell! (app-node)))
+
+(defn- on-hash-change! []
+  (let [hash (or (.. js/window -location -hash) "")]
+    (if (re-find #"^#/stories" hash)
+      (mount-stories!)
+      (mount-app!))))
+
+;; -- The public host entry -------------------------------------------------
+
+(defn mount-with-hash-routing!
+  "Wire the live-app ↔ Story-shell hash router for `root-view` (a 0-arg
+  Reagent component — pass the live-app root view, e.g. `counter-app`).
+
+  Installs the `hashchange` listener and renders the surface the current
+  URL hash selects: `#/stories…` mounts the Story shell, anything else
+  mounts `root-view` as the live app. Call this at the END of a testbed's
+  `run`, after the testbed has done its own boot specifics (Xray config,
+  `rf/init!`, `story/configure!`, `:fx-overrides`, seed dispatches, …).
+
+  Idempotent across hot-reload: the React root is a `defonce` here, and the
+  `hashchange` listener is `on-hash-change!` (a stable top-level fn), so a
+  re-`run` reuses the root and `addEventListener` deduplicates the listener
+  — matching the per-file named-fn listener the copies installed."
+  [root-view]
+  (reset! root-view* root-view)
+  (.addEventListener js/window "hashchange" on-hash-change!)
+  (on-hash-change!))


### PR DESCRIPTION
## What

Two Story-host testbed dedup findings (one PR): **rf2-tq26t** + **rf2-uv7sn**.

The live-app↔Story-shell hash-toggle host harness — a `defonce` React-root handle, the tear-down-one-before-mounting-the-other dance, and the `hashchange` listener — was copy-pasted near-verbatim across five Story showcase entry points, differing only by the live-app root view symbol. The copies had already started drifting in their per-testbed `run` boot specifics (CI hooks, elision listener, `:fx-overrides`) while carrying byte-identical host blocks.

## How

Extract the harness into one shared helper:

```clojure
(re-frame.testbed.story-host/mount-with-hash-routing! root-view)
```

Co-located with `re-frame.testbed.config` under `tools/testbed-support/src` — already on every testbed build's shadow-cljs source path, so **no build-wiring change** (no hot-zone `shadow-cljs.edn` / `deps.edn` edit). Each testbed keeps its own boot specifics inline (Xray config, `rf/init!`, `story/configure!`, `:fx-overrides`, seed dispatches, CI hooks / elision listener) and calls the helper LAST with its root view.

### Call-sites collapsed (4 of 5)

- `tools/story/testbeds/counter_with_stories/core.cljs`
- `tools/story/testbeds/login_form/core.cljs`
- `examples/reagent/login/stories_host.cljs`
- `examples/reagent/nine_states/stories_host.cljs`

### Template copy stays standalone (by design)

`tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs` is `resources/` scaffolding emitted into a fresh consumer project (mustache `{{namespace}}` placeholders); that generated project's classpath has no access to this dev-repo-internal helper. Folding it in would emit a broken consumer project — matching rf2-uv7sn's explicit guidance ("template copy may legitimately stay inlined").

## Behaviour-preserving

The helper keeps the `defonce` root (no per-reload leak), the `try/catch` around unmount, the `#"^#/stories"` hash regex, and a **stable named listener fn** so `addEventListener` deduplicates on hot-reload — matching the per-file named-fn listeners exactly. `tools/story/spec/*` unchanged (no Story-renderer or spec surface touched).

## Gates (cold)

- story `clojure -M:test` — 1625 tests, 6066 assertions, **0 fail / 0 error**
- `npm run test:cljs` — 5733 tests, 20026 assertions, **0 fail / 0 error** (compiles all testbeds)
- `npm run story:build` — **0 warnings** (`:advanced`/release compile of the counter testbed tree)
- `:examples/counter-with-stories` · `:examples/login-form` · `:examples/nine-states-with-stories` · `:examples/login-with-stories` — all compile, **0 warnings** each (their `:init-fn`s call the new wiring end-to-end)

Closes rf2-tq26t, rf2-uv7sn.
