### PR TITLE
fix(examples/realworld): gate auth-guard on all nav entry points (rf2-mzqd4.3)

### DIFF
--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -105,13 +105,36 @@
 ;; It is wired into the demo frame via `reg-frame :interceptors` in
 ;; core.cljs (`:interceptors` are "prepended to every event in this
 ;; frame", Spec 002 §reg-frame). To keep it cheap and correct it short-
-;; circuits to the unchanged ctx for everything except a programmatic
-;; `:rf.route/navigate` — the one event whose `(second event)` is a route
-;; id whose tags we want to gate on. (Anchor clicks land here too: the
-;; framework `:rf/url-requested` handler resolves the URL to a route and
-;; the on-match drain runs; for THIS sketch we gate the programmatic
-;; navigation surface the navbar uses, which is the path the headless
-;; tests exercise.)
+;; circuits to the unchanged ctx for everything except a navigation
+;; event, and gates EVERY navigation ENTRY POINT so a `:requires-auth`
+;; route is unreachable logged-out by ANY access path (rf2-mzqd4.3):
+;;
+;;   - `:rf.route/navigate`          — programmatic nav (the navbar);
+;;     `(second event)` IS the target route id.
+;;   - `:rf/url-requested`           — anchor (`rf/route-link`) click;
+;;     the request map carries `:to` (the target route id) + `:params`.
+;;   - `:rf.route/handle-url-change` — URL-bar entry / reload / popstate;
+;;     `(second event)` is a URL string resolved to a route via
+;;     `rf/match-url`.
+;;
+;; An earlier sketch gated ONLY `:rf.route/navigate`, so the guard FAILED
+;; OPEN on the most common access path: a logged-out user who typed
+;; `/settings`, reloaded a protected page, or followed an anchor reached
+;; the route (and the on-match drain then fired a request the real
+;; Conduit backend would 401). Gating all three entry points closes that
+;; gap — `resolve-nav-target` normalises each event to an `{:id :params}`
+;; target so ONE redirect path handles them all.
+;;
+;; The redirect: the `:before` SKIPS the original handler (`:rf/skip-
+;; handler?`) so the protected route's slice never commits and its
+;; on-match drain never fires, then dispatches `:rf.route/navigate
+;; :realworld.auth/login` itself. This is the same login navigation the
+;; programmatic path produced, but it works uniformly for ALL three
+;; events — the runtime selects the handler from the ORIGINAL event id
+;; before interceptors run, so rewriting `[:coeffects :event]` across
+;; event ids (e.g. feeding a route-id to `:rf.route/handle-url-change`'s
+;; URL slot) would run the wrong handler. Skip-and-dispatch sidesteps
+;; that entirely.
 ;;
 ;; Bounce-back (`:return-to`). The headline of an auth guard is returning
 ;; the user to where they were headed once they sign in. `:rf.route/navigate`
@@ -120,46 +143,66 @@
 ;; `:bypass-leave-guard?` from opts and drops everything else (Spec 012
 ;; §Navigation is an event), so an opts-borne `:return-to` would silently
 ;; evaporate. We therefore stash the original target in `app-db` instead:
-;; the `:before` records the intended target on the ctx, and an `:after`
-;; folds it into the login navigation's committed `:db` at
-;; `[:auth :return-to]`. The auth machine's `:store-session` action reads
-;; that slot on a successful login and bounces there (falling back to
-;; home), then clears it (auth.cljs).
+;; the `:before` writes it to `[:auth :return-to]` via a `:db` effect
+;; (committed before the login dispatch's `:fx` runs, so the redirect's
+;; slice merge preserves it). The auth machine's `:store-session` action
+;; reads that slot on a successful login and bounces there (falling back
+;; to home), then clears it (auth.cljs).
 
-(def ^:private guard-target-key
-  "Private top-level ctx slot the `:before` uses to signal the `:after`
-   that it redirected, carrying the original {:id :params} target. Lives
-   on the ctx (not in `:coeffects`/`:effects`) so it is invisible to the
-   handler and to the committed app-db — pure intra-interceptor signalling."
-  :realworld.routing/guard-return-to)
+(defn- resolve-nav-target
+  "Normalise a navigation event into its target `{:id <route-id>
+   :params <map>}`, or nil when `event` is not a navigation (so the guard
+   short-circuits). One resolver for all three entry points (rf2-mzqd4.3)
+   so the redirect path below is identical regardless of HOW the user
+   reached the route:
+
+     - `:rf.route/navigate`          → `(second event)` is the route id,
+       `(nth event 2)` its path params (programmatic nav).
+     - `:rf/url-requested`           → anchor click; the request map
+       carries `:to` (route id) + `:params`. Falls back to resolving
+       `:url` via `rf/match-url` if `:to` is absent.
+     - `:rf.route/handle-url-change` → URL-bar / reload / popstate; the
+       URL string is resolved to a route via `rf/match-url`."
+  [[ev-id a b]]
+  (case ev-id
+    :rf.route/navigate
+    {:id a :params (or b {})}
+
+    :rf/url-requested
+    (let [{:keys [to params url]} a]
+      (cond
+        to  {:id to :params (or params {})}
+        url (when-let [{:keys [route-id params]} (rf/match-url url)]
+              {:id route-id :params (or params {})})))
+
+    :rf.route/handle-url-change
+    (when-let [{:keys [route-id params]} (rf/match-url a)]
+      {:id route-id :params (or params {})})
+
+    nil))
 
 (def auth-guard
   {:id     :realworld.routing/auth-guard
    :before (fn auth-guard-before [ctx]
-             (let [[ev-id target params] (get-in ctx [:coeffects :event])]
-               (if (= :rf.route/navigate ev-id)
-                 (let [route-meta  (rf/handler-meta :route target)
-                       needs-auth? (boolean (some #{:requires-auth} (:tags route-meta)))
-                       logged-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
-                   (if (and needs-auth? (not logged-in?))
-                     ;; Rewrite the in-flight event to a login redirect and
-                     ;; record the original target so the `:after` can stash
-                     ;; it for post-login bounce-back.
-                     (-> ctx
-                         (assoc-in [:coeffects :event]
-                                   [:rf.route/navigate :realworld.auth/login])
-                         (assoc guard-target-key {:id target :params (or params {})}))
-                     ctx))
-                 ctx)))
-   :after  (fn auth-guard-after [ctx]
-             ;; Only acts when the `:before` redirected (the slot is set)
-             ;; AND the login navigation actually committed a `:db` effect
-             ;; (a no-op re-nav or rejected navigation writes none — leave
-             ;; it alone). Folds the stashed target into the committed db.
-             (if-let [return-to (get ctx guard-target-key)]
-               (if (get-in ctx [:effects :db])
-                 (assoc-in ctx [:effects :db :auth :return-to] return-to)
-                 ctx)
+             (if-let [{:keys [id params]} (resolve-nav-target
+                                            (get-in ctx [:coeffects :event]))]
+               (let [route-meta  (rf/handler-meta :route id)
+                     needs-auth? (boolean (some #{:requires-auth} (:tags route-meta)))
+                     logged-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
+                 (if (and needs-auth? (not logged-in?))
+                   ;; Skip the original handler (so the protected slice +
+                   ;; on-match never commit), stash the intended target for
+                   ;; post-login bounce-back, and dispatch the login
+                   ;; navigation — the SAME redirect for every entry point.
+                   (-> ctx
+                       (assoc :rf/skip-handler? true)
+                       (assoc-in [:effects :db]
+                                 (assoc-in (get-in ctx [:coeffects :db])
+                                           [:auth :return-to]
+                                           {:id id :params params}))
+                       (assoc-in [:effects :fx]
+                                 [[:dispatch [:rf.route/navigate :realworld.auth/login]]]))
+                   ctx))
                ctx))})
 
 ;; ============================================================================

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -697,6 +697,84 @@
     (is (nil? (get-in (rf/app-db-value f) [:auth :return-to]))
         ":auth/post-login-redirect clears the :return-to slot")))
 
+(defn- auth-guard-all-access-paths-test []
+  ;; rf2-mzqd4.3 — the guard must FAIL CLOSED on EVERY navigation entry
+  ;; point, not just the programmatic `:rf.route/navigate` the navbar
+  ;; uses. Pre-fix the guard gated only `:rf.route/navigate`, so a
+  ;; logged-out user reaching a `:requires-auth` route via the MOST
+  ;; common access path — a direct URL / reload (`:rf.route/handle-url-
+  ;; change`) or an anchor click (`:rf/url-requested`) — bypassed the
+  ;; guard and landed on the protected page (fail OPEN). These cases
+  ;; assert all three paths now redirect to login.
+
+  ;; --- direct-URL / reload / popstate (`:rf.route/handle-url-change`) ---
+  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+                                 :interceptors [routing/auth-guard]})]
+    ;; Logged-out direct URL (or reload) to a :requires-auth route.
+    (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
+    (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
+        "logged-out direct-URL/reload to a :requires-auth route redirects to login")
+    (is (= {:id :realworld.user/settings :params {}}
+           (get-in (rf/app-db-value f) [:auth :return-to]))
+        "the direct-URL redirect stashes the original target for bounce-back")
+
+    ;; Editor route via direct URL with path params is also gated, and
+    ;; the stash carries the params.
+    (rf/dispatch-sync [:rf.route/handle-url-change "/editor/my-slug"] {:frame f})
+    (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
+        "logged-out direct-URL to a :requires-auth editor route redirects to login")
+    (is (= {:id :realworld.editor/edit :params {:slug "my-slug"}}
+           (get-in (rf/app-db-value f) [:auth :return-to]))
+        "the editor direct-URL redirect stashes id + params for bounce-back")
+
+    ;; A non-auth route via direct URL is unaffected.
+    (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
+    (is (= :realworld.profile/show (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
+        "logged-out direct-URL to a non-auth route is unaffected"))
+
+  ;; --- anchor click (`:rf/url-requested`) ---
+  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+                                 :interceptors [routing/auth-guard]})]
+    ;; An anchor whose href targets a :requires-auth route. The
+    ;; framework `rf/route-link` dispatches `:rf/url-requested` with the
+    ;; resolved url + :to route-id.
+    (rf/dispatch-sync [:rf/url-requested {:url "/settings"
+                                          :to  :realworld.user/settings}]
+                      {:frame f})
+    (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
+        "logged-out anchor click to a :requires-auth route redirects to login")
+    (is (= {:id :realworld.user/settings :params {}}
+           (get-in (rf/app-db-value f) [:auth :return-to]))
+        "the anchor redirect stashes the original target for bounce-back")
+
+    ;; A url-only request (no :to) still gates via match-url resolution.
+    (rf/dispatch-sync [:rf/url-requested {:url "/editor"}] {:frame f})
+    (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
+        "logged-out url-only anchor to a :requires-auth route redirects to login")
+
+    ;; A non-auth anchor is unaffected.
+    (rf/dispatch-sync [:rf/url-requested {:url "/profile/eve"
+                                          :to  :realworld.profile/show
+                                          :params {:username "eve"}}]
+                      {:frame f})
+    (is (= :realworld.profile/show (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
+        "logged-out anchor to a non-auth route is unaffected"))
+
+  ;; --- authenticated: every entry point now PASSES through ---
+  (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+                                 :interceptors [routing/auth-guard]})]
+    (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
+    ;; direct-URL / reload to a guarded route proceeds when logged in.
+    (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
+    (is (= :realworld.user/settings (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
+        "authenticated direct-URL to a :requires-auth route proceeds")
+    ;; anchor click to a guarded route also proceeds when logged in.
+    (rf/dispatch-sync [:rf/url-requested {:url "/settings"
+                                          :to  :realworld.user/settings}]
+                      {:frame f})
+    (is (= :realworld.user/settings (rf/compute-sub [:rf.route/id] (rf/app-db-value f)))
+        "authenticated anchor click to a :requires-auth route proceeds")))
+
 ;; ============================================================================
 ;; ssr — `hydration-payload` selects the SSR-safe slice keys
 ;; ============================================================================
@@ -794,7 +872,9 @@
   (testing "navigate, handle-url-change, query, and not-found all resolve"
     (routing-tests))
   (testing "auth-guard redirects unauthenticated nav to :requires-auth routes (Spec 012)"
-    (auth-guard-test)))
+    (auth-guard-test))
+  (testing "auth-guard fails CLOSED on direct-URL / anchor / reload entry points (rf2-mzqd4.3)"
+    (auth-guard-all-access-paths-test)))
 
 (deftest realworld-ssr
   (testing "hydration-payload selects the SSR-safe slice keys"


### PR DESCRIPTION
## What

The realworld (Conduit) example's `auth-guard` interceptor (`examples/reagent/realworld/routing.cljs`) gated **only** programmatic `:rf.route/navigate`. The two most common access paths bypassed it entirely:

- **Direct URL / reload / popstate** → `:rf.route/handle-url-change`
- **Anchor click** (`rf/route-link`) → `:rf/url-requested`

So a logged-out user who typed `/settings`, reloaded a protected page, or followed an anchor landed on the `:requires-auth` route — and the route's `:on-match` then fired a request the real Conduit backend would 401. The guard **failed OPEN** on the canonical way users reach a deep link. As the re-frame2 teaching surface, a copier inherited a security-relevant auth guard that does not actually protect the route.

This is rf2-mzqd4.3 (ruled CLEAR-FIX, option (a): extend the guard to all access paths).

## How

A single `resolve-nav-target` normalises each of the three navigation entry points to an `{:id <route-id> :params <map>}` target:

- `:rf.route/navigate` — carries the route id directly.
- `:rf/url-requested` — carries `:to` (route id) + `:params`; falls back to `rf/match-url` on `:url`.
- `:rf.route/handle-url-change` — resolves its URL string via `rf/match-url`.

When a logged-out target needs auth, the `:before`:
1. sets `:rf/skip-handler?` so the protected route's slice + on-match never commit;
2. stashes the intended target at `[:auth :return-to]` (a `:db` effect) for post-login bounce-back;
3. dispatches `:rf.route/navigate :realworld.auth/login` — the same login redirect for every path.

**Skip-and-dispatch** (rather than rewriting `[:coeffects :event]`) is required because the runtime selects the handler from the *original* event id before interceptors run — a cross-id event rewrite would run the wrong handler (e.g. feed a route-id into `handle-url-change`'s URL slot). This also lets the bounce-back stash drop the old `:after` + private signalling key entirely; the guard is now a single `:before`.

## Verify

Regression coverage added to the **reagent framework test tree** (per rf2-8cevm — not a per-example spec): `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`, the existing realworld auth-guard test. It asserts logged-out direct-URL / reload / anchor / url-only access to a `:requires-auth` route all redirect to login (and stash id+params), non-auth routes are unaffected, and logged-in access proceeds on every path.

- **Pre-fix**: the new cases fail (7 failures) — fail-open reproduced (`:rf.route/handle-url-change "/settings"` → `:realworld.user/settings`, etc.).
- **Post-fix**: `npm run test:cljs` → 5733 tests, 20037 assertions, 0 failures, 0 errors.
- `npm run test:examples-compile` → all 39 example builds, 0 warnings.

Closes rf2-mzqd4.3.