### PR TITLE
fix(http+flows): four P4 review nits — stale comments, :elapsed-ms value-parity, deterministic overlap pair (rf2-5wecj + rf2-6ecc6 + rf2-a4he6 + rf2-tx1ub)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -206,13 +206,20 @@
               ;; Event Detail, re-frame-10x flow panel) no longer
               ;; need to walk the epoch's `:db-before` snapshot to
               ;; render "wrote [:cart :total] 47.50 -> 52.50". The
-              ;; read happens against `db` (the loop accumulator
-              ;; that includes prior flows' writes in this drain), so
-              ;; a downstream flow whose `:path` overlaps an upstream
-              ;; flow's `:path` sees the UPSTREAM's just-written
-              ;; value as its `:before` — the correct cascade-local
-              ;; semantics. Gated to dev-only so the read is DCE'd
-              ;; under `:advanced` + `goog.DEBUG=false`.
+              ;; read happens against `db` (the loop accumulator that
+              ;; includes prior flows' writes in this drain), so a
+              ;; flow that reads (via `:inputs`) a slot an UPSTREAM
+              ;; flow wrote sees that upstream write — the correct
+              ;; cascade-local semantics. The `:before` at the flow's
+              ;; OWN `:path`, however, can only ever reflect the
+              ;; handler's / pre-existing value, NEVER another flow's
+              ;; write: the rf2-um6d9/#3086 invariant
+              ;; (`detect-output-path-overlap!`, wired into `reg-flow`)
+              ;; rejects any two same-frame flows whose output `:path`s
+              ;; stand in a prefix relationship, so no upstream flow can
+              ;; have written this flow's `:path` earlier in the drain
+              ;; (per Spec 013 §Disjoint output paths). Gated to dev-only
+              ;; so the read is DCE'd under `:advanced` + `goog.DEBUG=false`.
               old-output (when interop/debug-enabled?
                            (get-in db (:path flow)))
               new-db     (assoc-in db (:path flow) new-output)]

--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -79,10 +79,15 @@
   Terminates by construction: a single `for` over the `(< i j)` upper
   triangle of the entry vector (O(F²) prefix comparisons, F = the frame's
   flow count — a handful of nodes at v1, same order as the graph build),
-  short-circuited by `(some ...)`. The reported pair is deterministically
-  ordered by `hash` so the report is stable across runs without requiring
-  flow-ids be mutually comparable (`sort` throws on mixed-type ids) —
-  mirroring `extract-cycle-path`'s deterministic pick."
+  short-circuited by `(some ...)`. The reported pair is canonically
+  ordered by `(juxt hash str)` so the report is GENUINELY stable across
+  runs (rf2-tx1ub): `hash` alone leaves the order undefined on a hash
+  collision (distinct ids, equal hash) — `sort-by` is stable and would
+  fall back to map-iteration order there, a non-contract across JVM runs.
+  The `str` tie-break makes the lo/hi assignment depend only on the ids'
+  values, never on iteration order, while still avoiding the requirement
+  that flow-ids be mutually comparable (`sort` throws on mixed-type ids,
+  but `str` is total). Mirrors `extract-cycle-path`'s deterministic pick."
   [flow-map]
   (let [entries (vec flow-map)
         n       (count entries)]
@@ -92,7 +97,7 @@
                   a-path        (:path a-flow)
                   b-path        (:path b-flow)]
               (when (output-paths-overlap? a-path b-path)
-                (let [[lo-id hi-id]     (sort-by hash [a-id b-id])
+                (let [[lo-id hi-id]     (sort-by (juxt hash str) [a-id b-id])
                       [lo-path hi-path] (if (= lo-id a-id)
                                           [a-path b-path]
                                           [b-path a-path])]

--- a/implementation/flows/test/re_frame/flows_path_overlap_test.clj
+++ b/implementation/flows/test/re_frame/flows_path_overlap_test.clj
@@ -158,6 +158,50 @@
       (is (= (overlap-of) (overlap-of) (overlap-of))
           "repeated detection yields an identical :overlap (deterministic ordering)"))))
 
+(deftest detect-output-path-overlap!-pair-ordering-invariant-to-iteration-order
+  ;; rf2-tx1ub — the reported :overlap pair must be GENUINELY deterministic
+  ;; across runs, not merely run-stable. The prior `sort-by hash` tie-break
+  ;; left the lo/hi assignment undefined on a hash collision: `sort-by` is
+  ;; stable and would fall back to the INPUT (map-iteration) order, which is
+  ;; not a cross-run contract for Clojure hash-maps. The `(juxt hash str)`
+  ;; tie-break makes the result depend only on the ids' VALUES, so feeding
+  ;; the same logical pair in opposite iteration orders MUST yield the same
+  ;; reported pair. Insertion-ordered array-maps below stand in for the two
+  ;; possible cross-run iteration orders.
+  (testing "the reported pair is invariant to flow-map iteration order"
+    (let [flow-a {:id :a :inputs [[:w]] :output identity :path [:x]}
+          flow-b {:id :b :inputs [[:h]] :output identity :path [:x]}
+          overlap-of (fn [m] (-> (try (topo/detect-output-path-overlap! m)
+                                      (catch clojure.lang.ExceptionInfo e (ex-data e)))
+                                 :overlap))
+          a-first (overlap-of (array-map :a flow-a :b flow-b))
+          b-first (overlap-of (array-map :b flow-b :a flow-a))]
+      (is (= a-first b-first)
+          "the same colliding pair reported identically regardless of iteration order")
+      (is (= [:a :b] (:flow-ids a-first))
+          "the pair is canonically ordered by (juxt hash str) — value-derived, not iteration-derived")))
+  (testing "the tie-break is robust on a genuine hash collision (juxt str fallback)"
+    ;; Construct two DISTINCT ids that share a hash so the `hash` key ties
+    ;; and the `str` key alone decides the order — the exact case the old
+    ;; `sort-by hash` left to iteration order. Strings whose hashCodes
+    ;; collide ("Aa"/"BB" is the canonical Java String hashCode collision)
+    ;; give us distinct, equal-hash ids.
+    (let [id-lo "Aa"
+          id-hi "BB"]
+      (is (= (hash id-lo) (hash id-hi))
+          "precondition: the two ids genuinely collide on hash")
+      (let [flow-lo {:id id-lo :inputs [[:w]] :output identity :path [:x]}
+            flow-hi {:id id-hi :inputs [[:h]] :output identity :path [:x]}
+            overlap-of (fn [m] (-> (try (topo/detect-output-path-overlap! m)
+                                        (catch clojure.lang.ExceptionInfo e (ex-data e)))
+                                   :overlap))
+            lo-first (overlap-of (array-map id-lo flow-lo id-hi flow-hi))
+            hi-first (overlap-of (array-map id-hi flow-hi id-lo flow-lo))]
+        (is (= lo-first hi-first)
+            "on a hash collision the pair is STILL identical across iteration orders")
+        (is (= [id-lo id-hi] (:flow-ids lo-first))
+            "the str tie-break orders the colliding pair canonically (\"Aa\" < \"BB\")")))))
+
 ;; ---------------------------------------------------------------------------
 ;; 3. integrated rf/reg-flow — THE bug repro: same-frame overlapping
 ;;    outputs + DISJOINT inputs (no cycle, no edge) must be rejected.

--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -318,14 +318,22 @@
 
       ;; rf2-5zj6t — binary decode modes (`:blob` / `:array-buffer` /
       ;; `:form-data`, the `binary-decode-kinds` set) return the native
-      ;; Fetch body the transport already read via `.blob()` /
-      ;; `.arrayBuffer()` / `.formData()`. On hosts that have no binary
-      ;; body (the JVM transport reads `.body` as a String) `body-binary`
-      ;; is absent and we fall back to the raw `body-text` so the value
-      ;; is at least the payload, not nil. rf2-jkake.9 — the three modes
-      ;; collapse onto the shared `binary-decode-kinds` set (the same set
-      ;; `binary-read-kind` consults) rather than three identical cond
-      ;; arms.
+      ;; binary body the transport already read: the CLJS transport rides
+      ;; it under `:body-binary` via `.blob()` / `.arrayBuffer()` /
+      ;; `.formData()`, and (per rf2-a3wxe) the JVM transport rides the
+      ;; raw `byte[]` it read via `BodyHandlers/ofByteArray` under the
+      ;; SAME `:body-binary` key — so on BOTH real-transport hosts a
+      ;; binary 2xx response arrives here with `body-binary` PRESENT and
+      ;; this arm returns it verbatim (no lossy text fallback). The
+      ;; `body-text` fallback fires only when `body-binary` is genuinely
+      ;; absent — e.g. a synthetic / test ctx that populated only
+      ;; `:body-text` — so the value is at least the payload, not nil.
+      ;; (Pre-rf2-a3wxe the JVM read `.body` as a String and this arm
+      ;; ALWAYS fell through to the lossy text fallback for binary modes;
+      ;; a3wxe eliminated that — see `jvm-fetch`'s ofByteArray read.)
+      ;; rf2-jkake.9 — the three modes collapse onto the shared
+      ;; `binary-decode-kinds` set (the same set `binary-read-kind`
+      ;; consults) rather than three identical cond arms.
       (contains? binary-decode-kinds resolved)
       (if (some? body-binary) body-binary body-text)
 

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -108,6 +108,19 @@
                                      (catch :default _ nil)))
                               #js {:once true}))))
            timeout-handle (atom nil)
+           ;; rf2-6ecc6 — a real measured elapsed for the synthetic
+           ;; timeout, so CLJS `:elapsed-ms` carries the same SEMANTICS as
+           ;; the JVM's (a measured wall-clock delta `>= :limit-ms`), not a
+           ;; synthetic constant always `== :limit-ms`. `performance.now()`
+           ;; is monotonic where present (browser + Node 16+); we fall back
+           ;; to `Date.now()` on targets that lack it. Captured before the
+           ;; timer is armed so the delta spans the whole attempt.
+           now-ms   (fn []
+                      (if (and (exists? js/performance)
+                               (fn? (.-now js/performance)))
+                        (.now js/performance)
+                        (js/Date.now)))
+           started-ms (now-ms)
            ;; rf2-4zldh — the per-attempt timeout must bound the WHOLE
            ;; attempt, headers AND body read. A slow-loris upstream can
            ;; send headers promptly and then stall the body
@@ -198,7 +211,15 @@
                                                           ;; co-stamp the registry-hook signal the
                                                           ;; downstream classifier branches on
                                                           :rf.http/timeout? true
-                                                          :elapsed-ms       timeout-ms
+                                                          ;; rf2-6ecc6 — a MEASURED wall-clock delta
+                                                          ;; (whole ms, monotonic where available),
+                                                          ;; not the synthetic `timeout-ms` constant.
+                                                          ;; The setTimeout fires at ~`timeout-ms`, so
+                                                          ;; this is `>= :limit-ms` by the scheduling
+                                                          ;; margin — the SAME semantics the JVM path
+                                                          ;; reports via `System/nanoTime`, closing the
+                                                          ;; prior cross-host `:elapsed-ms` divergence.
+                                                          :elapsed-ms       (js/Math.round (- (now-ms) started-ms))
                                                           :limit-ms         timeout-ms})))
                                       timeout-ms)))))
            promise
@@ -567,12 +588,16 @@
      `HttpTimeoutException` does not itself surface the elapsed wall
      clock, so `run-attempt!` captures a monotonic start mark
      (`System/nanoTime`) before issuing the request and passes the
-     measured wall-clock delta here. This matches the CLJS path's
-     intent — `cljs-fetch` stamps `:elapsed-ms` on its synthetic timeout
-     rejection (Spec 014 §Failure categories) so a consumer branching on
-     `:elapsed-ms` sees a value on BOTH hosts rather than nil-on-JVM.
-     `elapsed-ms` is nil only when no start mark was threaded (the legacy
-     2-arity test/synthetic callers), preserving back-compat."
+     measured wall-clock delta here. rf2-6ecc6 — this matches the CLJS
+     path's VALUE semantics, not just its shape: `cljs-fetch` likewise
+     stamps a MEASURED `performance.now()`/`Date.now()` delta on its
+     timeout rejection (Spec 014 §Failure categories). So on BOTH hosts
+     `:elapsed-ms` is a measured wall-clock delta `>= :limit-ms` by the
+     scheduling margin — a consumer can compute overshoot
+     (`- :elapsed-ms :limit-ms`) portably (it was the synthetic constant
+     `== :limit-ms` on CLJS before rf2-6ecc6). `elapsed-ms` is nil only
+     when no start mark was threaded (the legacy 2-arity test/synthetic
+     callers), preserving back-compat."
      ([^Throwable t] (classify-jvm-error t nil nil))
      ([^Throwable t timeout-ms] (classify-jvm-error t timeout-ms nil))
      ([^Throwable t timeout-ms elapsed-ms]

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -467,7 +467,17 @@
                             "the stalled-body timeout rejects with the canonical :rf.error/http-timeout")
                         (is (true? (:rf.http/timeout? data))
                             "the registry-hook timeout signal is co-stamped")
-                        (is (= 40 (:limit-ms data))))
+                        (is (= 40 (:limit-ms data)))
+                        ;; rf2-6ecc6 — CLJS `:elapsed-ms` is now a MEASURED
+                        ;; wall-clock delta (>= :limit-ms by the scheduling
+                        ;; margin), the SAME value-semantics the JVM path
+                        ;; reports — not the synthetic constant == :limit-ms
+                        ;; it used to be. (The timer fires at ~40ms, so the
+                        ;; measured elapsed is at least that.)
+                        (is (number? (:elapsed-ms data))
+                            ":elapsed-ms is a measured number, not absent")
+                        (is (>= (:elapsed-ms data) (:limit-ms data))
+                            ":elapsed-ms (measured) is >= :limit-ms — same semantics as the JVM path"))
                       (done))))))))
 
 (deftest cljs-timeout-stalled-body-finalises-as-timeout-and-clears-registry

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -188,7 +188,7 @@ A related but distinct JVM degradation is **shape**, not silent no-op: a binary 
 |---|---|---|
 | `:blob` / `:array-buffer` / `:form-data` | args map (top-level) | **Honoured, shape-degraded.** `jvm-fetch` reads `ofByteArray` and rides the raw bytes, so the decode is NOT ignored — but the returned value is a `byte[]`, not the native browser `Blob` / `ArrayBuffer` / `FormData` object the CLJS Fetch path yields. An EXPLICIT binary `:decode` emits one `:rf.http/binary-decode-degraded-on-jvm` warning trace per occurrence (`:auto` is not flagged — it resolves to `:blob` from the response Content-Type, unknown at dispatch time). Per [Spec 009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue). |
 
-`:elapsed-ms` on the `:rf.http/timeout` failure category (see [§Failure categories](#failure-categories-closed-set)) is now populated on the JVM as well as CLJS: `run-attempt!` captures a monotonic `System/nanoTime` start mark before issuing the request and threads the measured wall-clock delta into the failure shape. A consumer branching on `:elapsed-ms` sees a value on BOTH hosts rather than nil-on-JVM.
+`:elapsed-ms` on the `:rf.http/timeout` failure category (see [§Failure categories](#failure-categories-closed-set)) is populated on BOTH hosts with the same semantics: a **measured wall-clock delta** captured across the attempt. The JVM uses a monotonic `System/nanoTime` start mark (`run-attempt!`); CLJS uses a `performance.now()` (or `Date.now()` fallback) delta stamped on the synthetic timeout rejection (`cljs-fetch`). On both hosts `:elapsed-ms` is therefore `>= :limit-ms` by the scheduling margin, so a consumer may compute overshoot (`(- :elapsed-ms :limit-ms)`) portably. (Prior to this, CLJS reported a synthetic constant always `== :limit-ms` — shape-parity, not value-parity; the divergence is now closed.)
 
 ### Body encoding
 
@@ -479,7 +479,7 @@ Every failure carries a `:kind` keyword (under the framework-reserved `:rf.http/
 |---|---|---|
 | `:rf.http/transport` | Network / DNS / connection-refused / connection-reset error before the HTTP transaction completed | `:message`, `:cause` |
 | `:rf.http/cors` | CORS preflight rejected or response blocked by browser CORS policy. Distinct from `:transport` because CORS is a configuration error, not a network error. CLJS-only; JVM never emits this. | `:message`, `:url` |
-| `:rf.http/timeout` | Per-attempt timeout fired | `:elapsed-ms`, `:limit-ms` |
+| `:rf.http/timeout` | Per-attempt timeout fired | `:elapsed-ms` (measured wall-clock delta, `>= :limit-ms`, same semantics on both hosts — see [§JVM transport](#jvm-transport--degraded-behaviour-for-cljs-only-options)), `:limit-ms` (the configured per-attempt budget) |
 | `:rf.http/http-4xx` | Non-2xx 4xx response | `:status`, `:status-text`, `:body` (the raw response text — decode is skipped on non-2xx; see [§Classification order](#classification-order)), `:headers` |
 | `:rf.http/http-5xx` | Non-2xx 5xx response | same as `:http-4xx` |
 | `:rf.http/decode-failure` | A success-eligible (2xx) response whose body the decode pipeline rejected (schema validation error, JSON syntax error, custom decoder threw). Non-2xx responses never produce `:rf.http/decode-failure` — they classify by status. | `:body-text`, `:cause`, `:schema-validation-failure?` |


### PR DESCRIPTION
Four P4 review-R2 findings across `implementation/http` + `implementation/flows` (disjoint files), one PR.

## rf2-5wecj (http) — stale `decode-response-body` comment
The binary-decode cond arm still claimed "the JVM transport reads `.body` as a String" — the **pre-a3wxe** world. After a3wxe the JVM rides the raw `byte[]` under `:body-binary` (`jvm-fetch` reads `BodyHandlers/ofByteArray`), so the `body-text` fallback fires only when `body-binary` is genuinely absent (a synthetic/test ctx), NOT because the JVM reads `.body` as a String. Comment corrected + cross-referenced to a3wxe / the ofByteArray read. No behaviour change.

## rf2-6ecc6 (http) — `:elapsed-ms` cross-host value-divergence (resolved, option b)
Pre-fix, CLJS stamped a **synthetic constant** (`:elapsed-ms == :limit-ms`) on the timeout rejection while the JVM threaded a **measured** wall-clock delta (`>= :limit-ms`) — shape-parity only, undocumented. Rather than just document it, `cljs-fetch` now captures a monotonic `performance.now()`/`Date.now()` start mark and stamps the **measured** delta, so both hosts carry the same value-semantics (`:elapsed-ms >= :limit-ms`), closing the divergence in line with the "no silent degradation" posture. Updated: `cljs-fetch`, `classify-jvm-error` docstring, spec/014 §191 + Failure-categories `:timeout` row. New CLJS regression asserts `:elapsed-ms` is a measured number `>= :limit-ms`.

## rf2-a4he6 (flows) — stale `:before` comment in `evaluate-flow!`
The comment justified the dev-only `old-output` read by citing a downstream-flow-overlaps-upstream-flow `:path` cascade — a case the same-session um6d9/#3086 fix (`detect-output-path-overlap!`, wired into `reg-flow`) made **structurally impossible**. Reworded: the `:before` at a flow's own `:path` can only reflect the handler's/pre-existing value, never another flow's write (output-path overlap rejected at registration, per Spec 013 §Disjoint output paths). Code unchanged.

## rf2-tx1ub (flows) — `first-overlapping-pair` not deterministic across runs
`sort-by hash` left the reported pair's lo/hi order **undefined on a hash collision** (distinct ids, equal hash) — `sort-by` is stable and fell back to map-iteration order, a non-contract across JVM runs. Tie-break is now `(juxt hash str)` so the order is value-derived and genuinely cross-run stable, while still tolerating mixed-type ids (`str` is total; `sort` is not). New regression asserts iteration-order invariance, including a **genuine** hash collision (`"Aa"`/`"BB"`, which collide under Clojure `hash`).

## Quality gates (all green)
- flows `clojure -M:test` — 149 tests, 4599 assertions, 0 failures
- http `clojure -M:test` — 343 tests, 1594 assertions, 0 failures
- `npm run test:cljs` — 5736 tests, 20077 assertions, 0 failures (incl. the new rf2-6ecc6 measured-`:elapsed-ms` assertion)
- rf2-tx1ub determinism regression: same input → same reported pair across iteration orders, incl. a real hash collision