### PR TITLE
fix(template/ci): close generated-app gate false-green holes (rf2-jdj17.1/.2/.3)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -195,6 +195,23 @@ else
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
+        # rf2-jdj17.1 — false-green fix. The template's generated `:app`
+        # build compiles `day8/re-frame2-schemas` (events.cljs side-loads
+        # re-frame.schemas + re-frame.schemas.malli; schema.cljs calls
+        # rf/reg-app-schema). The ONLY PR-time gate that compiles the
+        # emitted `:app` (emitted_test_run_test, RF2_TEMPLATE_RUN_EMITTED_TESTS)
+        # fires only under template_expensive. So a PR breaking the
+        # re-frame.schemas / reg-app-schema surface used to merge GREEN at
+        # PR time and surface only in the nightly cron. Fire
+        # template_expensive for an implementation/schemas/* change so
+        # jvm-tools-template runs the emitted-app compile at PR time.
+        # (The other per-feature artefacts here — machines/routing/flows/
+        # http/ssr/ssr-ring/epoch — are NOT pulled into today's scaffold,
+        # so they do not arm template_expensive; add them here if a future
+        # scaffold flag wires one in.)
+        case "$file" in
+          implementation/schemas/*) template_expensive=true ;;
+        esac
         ;;
       spec/conformance/fixtures/*)
         # rf2-qmiiz — Fixtures under spec/conformance/fixtures/*.edn
@@ -280,11 +297,29 @@ else
         # deps.edn, README, EDN, …) still fire the probes conservatively.
         case "$file" in
           tools/story/spec/*.md|tools/xray/spec/*.md)
-            : # spec doc only — no runtime/JVM/MCP/CLJS fan-out
+            : # spec doc only — no runtime/JVM/MCP/CLJS/template fan-out
             ;;
           *)
             tools_jvm=true
             mcp_conformance=true
+            # rf2-jdj17.1 — false-green fix. The template's generated
+            # `:app` build compiles against Story + Xray: the with-story
+            # scaffold's core requires re-frame.story and calls
+            # story/mount-shell! / unmount-shell!, and EVERY scaffold wires
+            # day8.re-frame2-xray.preload via :devtools/preloads in
+            # shadow-cljs.edn. The ONLY PR-time gate that compiles the
+            # emitted `:app` (emitted_test_run_test,
+            # RF2_TEMPLATE_RUN_EMITTED_TESTS) fires only under
+            # template_expensive — so a PR breaking the re-frame.story
+            # shell API or renaming/removing the xray preload ns used to
+            # merge GREEN at PR time and surface only in the nightly cron
+            # (generated apps then fail their first `shadow-cljs watch app`
+            # / `release app`). Fire template_expensive for any non-spec-md
+            # Story/Xray change so jvm-tools-template runs the emitted-app
+            # compile at PR time. Scoped exactly like tools_jvm/mcp above:
+            # a pure spec-md change can't break the generated `:app`
+            # compile, so it stays excluded.
+            template_expensive=true
             ;;
         esac
         # story_xray_browser is narrowed (rf2-k9ekz): it fires ONLY when

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -180,6 +180,63 @@ test('Xray CLJS src change runs cljs (node-test compiles tools/xray) (rf2-f79t8)
   assert.equal(result.cljs_node_test, 'true');
 });
 
+// rf2-jdj17.1 — template_expensive false-green fix. The template's
+// generated `:app` build transitively compiles against tools/xray
+// (:devtools/preloads [day8.re-frame2-xray.preload]),
+// implementation/schemas (events.cljs side-loads re-frame.schemas;
+// schema.cljs calls reg-app-schema), and tools/story (the with-story
+// scaffold requires re-frame.story). The ONLY PR-time gate that compiles
+// the emitted `:app` (emitted_test_run_test, gated on template_expensive)
+// must therefore RUN when any of those three surfaces changes — else a
+// breaking change merges GREEN at PR time and surfaces only in the
+// nightly cron. These assertions lock the classifier OR-ing
+// template_expensive into the xray/story/schemas cases.
+
+test('Xray src change arms template_expensive (generated :app preloads xray) (rf2-jdj17.1)', () => {
+  const result = classify('tools/xray/src/day8/re_frame2_xray/preload.cljs');
+  assert.equal(result.template_expensive, 'true');
+});
+
+test('Story src change arms template_expensive (with-story scaffold requires re-frame.story) (rf2-jdj17.1)', () => {
+  const result = classify('tools/story/src/re_frame/story.cljs');
+  assert.equal(result.template_expensive, 'true');
+});
+
+test('Schemas change arms template_expensive (generated events/schema compile against re-frame.schemas) (rf2-jdj17.1)', () => {
+  const result = classify('implementation/schemas/src/re_frame/schemas.cljc');
+  assert.equal(result.template_expensive, 'true');
+});
+
+test('Story spec-md-only change does NOT arm template_expensive (cannot break :app compile) (rf2-jdj17.1)', () => {
+  const result = classify('tools/story/spec/002-Runtime.md');
+  assert.equal(result.template_expensive, 'false');
+});
+
+test('Xray spec-md-only change does NOT arm template_expensive (rf2-jdj17.1)', () => {
+  const result = classify('tools/xray/spec/017-Test-Coverage-Matrix.md');
+  assert.equal(result.template_expensive, 'false');
+});
+
+test('Other per-feature artefact (machines) does NOT arm template_expensive — not in scaffold (rf2-jdj17.1)', () => {
+  const result = classify('implementation/machines/src/re_frame/machines.cljc');
+  assert.equal(result.template_expensive, 'false');
+});
+
+test('tools/template change still arms template_expensive (regression) (rf2-jdj17.1)', () => {
+  const result = classify('tools/template/src/day8/re_frame2_template/hooks.clj');
+  assert.equal(result.template_expensive, 'true');
+});
+
+test('Core change still arms template_expensive (regression) (rf2-jdj17.1)', () => {
+  const result = classify('implementation/core/src/re_frame/core.cljc');
+  assert.equal(result.template_expensive, 'true');
+});
+
+test('Adapter change still arms template_expensive (regression) (rf2-jdj17.1)', () => {
+  const result = classify('implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs');
+  assert.equal(result.template_expensive, 'true');
+});
+
 // rf2-f79t8 (a) — workflow-level shape: jvm-core + cljs must be
 // job-level gated (needs + if), NOT trigger-filtered, and the
 // pull_request trigger must stay unfiltered so the aggregator is always

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -249,9 +249,31 @@
   stories.cljs that won't load) fails here too rather than shipping
   green (rf2-5v619, G1).
 
+  ## :advanced release build (rf2-jdj17.2)
+
+  When the optional `release?` opt is true, the variant ALSO runs
+  `clojure -M:shadow release app` — a `:advanced`/Closure-optimised
+  compile — after the dev compile+run. NO other gate anywhere compiles
+  the generated app under `:advanced`: every other template compile is
+  dev `:none` (this fn's `compile app test`, the generated ci.yml's
+  `compile test`), so `:advanced`-only failures (Closure DCE, externs,
+  `^:export` munging, `:closure-define` elision) first hit a newcomer's
+  `npm run release`. The release tier asserts exit 0, a non-empty
+  release bundle (`resources/public/js/main.js`), and the cut-from-
+  release invariant: the dev-only `:devtools/preloads
+  [day8.re-frame2-xray.preload]` is stripped from the release build, so
+  the Xray preload ns must NOT appear in the optimised bundle. It is
+  caller-gated to the Reagent variants (default + with-story) — the
+  `:advanced`-specific risks (Story `:closure-define` elision lives in
+  the Reagent with-story scaffold; the `:app` module + `^:export init`
+  shape is substrate-invariant) are exercised there without paying the
+  ~30–60 s `:advanced` cost on all four variants.
+
   Caller is responsible for the env-var gate — this fn always runs."
   ([substrate] (compile-and-run-emitted-test! substrate false))
   ([substrate include-story?]
+   (compile-and-run-emitted-test! substrate include-story? {}))
+  ([substrate include-story? {:keys [release?] :or {release? false}}]
    (let [root  (repo-root)
          label (variant-label substrate include-story?)
          ;; Compile both the `:app` (:browser) build — the only build that
@@ -313,7 +335,59 @@
                    (is (re-find #"Ran \d+ tests? containing \d+ assertions" out)
                        (str "expected 'Ran N tests' summary line in output. Got:\n" out))
                    (is (re-find #"0 failures, 0 errors" out)
-                       (str "expected '0 failures, 0 errors' line in output. Got:\n" out))))))))
+                       (str "expected '0 failures, 0 errors' line in output. Got:\n" out))))))
+
+           ;; --- :advanced release build (rf2-jdj17.2) -----------------------
+           ;; No other gate compiles the generated app under :advanced —
+           ;; every other template compile is dev :none. Run
+           ;; `clojure -M:shadow release app` so an :advanced-only failure
+           ;; (Closure DCE/externs, ^:export munging, :closure-define
+           ;; elision) is caught here rather than on a newcomer's first
+           ;; `npm run release`. The :browser (:app) compile ignores
+           ;; NODE_PATH, so the project-local node_modules symlink/junction
+           ;; (`linked?`) is the same hard requirement as the dev compile.
+           (when release?
+             (testing (str label " — clojure -M:shadow release app (:advanced)")
+               (let [{:keys [exit out]}
+                     (run-process! ["clojure" "-M:shadow" "release" "app"]
+                                   proj env-overrides)]
+                 (is (zero? exit)
+                     (str "`clojure -M:shadow release app` exited " exit
+                          " for " label ". An :advanced-only break "
+                          "(Closure DCE/externs, ^:export munging, "
+                          ":closure-define elision) ships green from the "
+                          "dev :none compile and surfaces only on a "
+                          "newcomer's `npm run release`. Output:\n" out))
+                 ;; The :app module is :main, so the optimised bundle lands
+                 ;; at resources/public/js/main.js. A zero-exit with an
+                 ;; empty/absent bundle would false-green.
+                 (let [release-bundle (io/file proj "resources/public/js/main.js")]
+                   (is (and (.isFile release-bundle)
+                            (pos? (.length release-bundle)))
+                       (str "`shadow release app` must emit a non-empty "
+                            "resources/public/js/main.js for " label
+                            ". Bundle: "
+                            (if (.isFile release-bundle)
+                              (str (.length release-bundle) " bytes")
+                              "absent")))
+                   ;; Cut-from-release invariant: :devtools/preloads
+                   ;; [day8.re-frame2-xray.preload] is dev-only and stripped
+                   ;; from release. The Xray preload ns must not appear in
+                   ;; the optimised bundle (mangled goog ns segments survive
+                   ;; verbatim in shadow's :advanced output for top-level
+                   ;; provides). Guards against a regression that wires Xray
+                   ;; into release or whose dev/release split misfires.
+                   (when (.isFile release-bundle)
+                     (let [bundle-text (slurp release-bundle)]
+                       (is (not (string/includes?
+                                  bundle-text
+                                  "day8.re_frame2_xray.preload"))
+                           (str "Xray preload ns must be CUT from the "
+                                ":advanced release bundle for " label
+                                " (:devtools/preloads is dev-only). Found "
+                                "'day8.re_frame2_xray.preload' in "
+                                "resources/public/js/main.js — the "
+                                "cut-from-release invariant is broken."))))))))))
        (finally
          (delete-recursively tmp))))))
 
@@ -331,7 +405,14 @@
 ;; --- Tests -----------------------------------------------------------------
 
 (deftest reagent-emitted-tests-run-test
-  (testing "the emitted Reagent app's events_test.cljs compiles + runs green"
+  ;; rf2-jdj17.2 — the Reagent default variant also runs the :advanced
+  ;; release build (`release? true`). The `:app` module + `^:export init`
+  ;; shape is substrate-invariant, so the default Reagent variant is the
+  ;; canonical place to assert the release path compiles green and the
+  ;; dev-only Xray preload is cut from the optimised bundle, without
+  ;; paying the :advanced cost on UIx + Helix too.
+  (testing "the emitted Reagent app's events_test.cljs compiles + runs green
+            and the :advanced release build is clean"
     (if-not @enabled?
       (skip-if-disabled! :reagent)
       (do (is @clojure-cli-available?
@@ -339,7 +420,7 @@
           (is @node-available?
               "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
           (when (and @clojure-cli-available? @node-available?)
-            (compile-and-run-emitted-test! :reagent))))))
+            (compile-and-run-emitted-test! :reagent false {:release? true}))))))
 
 (deftest uix-emitted-tests-run-test
   (testing "the emitted UIx app's events_test.cljs compiles + runs green"
@@ -372,8 +453,22 @@
   ;; re-frame.story + the stories ns), `deps_with_story.edn`, and
   ;; `stories.cljs` are all on the compile classpath — a broken
   ;; with-story compile fails the build before `node` ever runs.
+  ;;
+  ;; rf2-jdj17.2 — the with-story variant ALSO runs the :advanced release
+  ;; build (`release? true`). This is where the Story `:closure-define`
+  ;; elision risk lives: core_with_stories.cljs documents the
+  ;; `:closure-defines {re-frame.story.config/enabled? false}` elision,
+  ;; and a regression that makes the elided `:advanced` build fail to
+  ;; compile (a reg-* macro that won't elide cleanly, a dead-code path
+  ;; Closure rejects) ships green from the dev :none compile. NB the
+  ;; template does NOT set that closure-define by default — `enabled?`
+  ;; defaults true — so this tier asserts the release build COMPILES
+  ;; (and the Xray preload is cut), not that Story body code is elided;
+  ;; Story-body-elision is a documented opt-in (flip the closure-define),
+  ;; not the default scaffold's invariant.
   (testing "the emitted with-story Reagent app compiles (story scaffold
-            on the classpath) + events_test.cljs runs green"
+            on the classpath) + events_test.cljs runs green + the
+            :advanced release build is clean"
     (if-not @enabled?
       (skip-if-disabled! "reagent-with-story")
       (do (is @clojure-cli-available?
@@ -381,4 +476,4 @@
           (is @node-available?
               "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
           (when (and @clojure-cli-available? @node-available?)
-            (compile-and-run-emitted-test! :reagent true))))))
+            (compile-and-run-emitted-test! :reagent true {:release? true}))))))

--- a/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
+++ b/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
@@ -1,15 +1,43 @@
 (ns day8.re-frame2-template.version-lockstep-test
   "Pin-lockstep guard for the template's inline version literals
-  (rf2-0kcsu; deps-new port for rf2-c2770).
+  (rf2-0kcsu; deps-new port for rf2-c2770; substrate + clojure(script)
+  pins added rf2-jdj17.3).
 
   Principle P5 (tools/template/spec/Principles.md) declares that the
-  template's three pin literals — `:rf2-version`, `:shadow-version`,
-  `:react-version` — are bumped in lockstep with their external sources
-  of truth:
+  template's pin literals are bumped in lockstep with their external
+  sources of truth in the implementation reference tree. The guarded
+  pins:
 
     - `:rf2-version`    ↔ repo-root `VERSION`
     - `:shadow-version` ↔ `implementation/package.json` shadow-cljs
     - `:react-version`  ↔ `implementation/package.json` react (and react-dom)
+
+  rf2-jdj17.3 — the substrate-lib + clojure(script) pins are now guarded
+  too (they were latent-only before: the emitted-app smoke compiles
+  against the TEMPLATE's own pin, never the impl tree's, so a drift was
+  invisible to every gate):
+
+    - reagent/reagent          ↔ `implementation/core/deps.edn` :deps
+    - com.pitch/uix.core       ↔ `implementation/adapters/uix/deps.edn` :deps
+    - com.pitch/uix.dom        ↔ `implementation/adapters/uix/deps.edn`
+                                  :test alias :extra-deps (the shipped
+                                  uix adapter does NOT require uix.dom —
+                                  rf2-sl7ml — so the impl pin lives in
+                                  the test/testbed classpath; the
+                                  template's :app needs it for its DOM
+                                  mount)
+    - lilactown/helix          ↔ `implementation/adapters/helix/deps.edn` :deps
+    - org.clojure/clojure      ↔ `implementation/core/deps.edn` :deps
+    - org.clojure/clojurescript ↔ `implementation/core/deps.edn` :deps
+
+  Template-owned (NOT guarded — no single impl source-of-truth):
+  cljfmt, clj-kondo/clj-kondo, org.clojure/tools.namespace. The impl
+  tree pins none of these as deps.edn coords — clj-kondo is installed
+  via a script in .github/workflows/lint.yml, cljfmt is not an impl dep,
+  and tools.namespace is a template-only convenience for the generated
+  `:shadow` alias. They are intentionally template-owned; bump them
+  against upstream releases, not the impl tree. (If the impl tree ever
+  grows a canonical pin for one of these, add it to the guarded set.)
 
   The package.json reader searches both `:dependencies` and
   `:devDependencies` (first hit wins) so the guard doesn't false-fail
@@ -27,7 +55,8 @@
             [clojure.java.io :as io]
             [clojure.string :as string]
             [day8.re-frame2-template.test-support
-             :refer [tmp-dir delete-recursively repo-root run-template!]]))
+             :refer [read-edn tmp-dir delete-recursively repo-root
+                     run-template!]]))
 
 ;; --- Helpers ---------------------------------------------------------------
 ;;
@@ -90,6 +119,38 @@
                            " in :dependencies or :devDependencies of "
                            "implementation/package.json")
                       {:pkg pkg})))
+    pin))
+
+;; --- deps.edn :mvn/version readers --------------------------------------
+
+(defn- mvn-pin-in
+  "Pull the `:mvn/version` string for coord `sym` out of a deps-map
+  fragment `m` (e.g. a `:deps` map or an alias's `:extra-deps` map).
+  Returns nil when `sym` is absent or has no `:mvn/version` (a
+  :local/root / :git coord)."
+  [m sym]
+  (get-in m [sym :mvn/version]))
+
+(defn- read-impl-deps-pin
+  "Read the `:mvn/version` for coord `sym` from the deps.edn at
+  `rel-path` (relative to repo-root). Searches `:deps` first, then every
+  alias's `:extra-deps` / `:replace-deps` (first hit wins). Throws with a
+  loud message if the coord isn't found with an `:mvn/version` anywhere —
+  a shape drift in the impl tree must fail this guard, not silently
+  skip it."
+  [rel-path sym]
+  (let [deps  (read-edn (io/file (repo-root) rel-path))
+        alias-maps (->> (vals (:aliases deps))
+                        (mapcat (juxt :extra-deps :replace-deps))
+                        (remove nil?))
+        pin   (or (mvn-pin-in (:deps deps) sym)
+                  (some #(mvn-pin-in % sym) alias-maps))]
+    (when-not pin
+      (throw (ex-info (str "Couldn't find an :mvn/version pin for " sym
+                           " in :deps or any alias of " rel-path
+                           " — impl-tree shape drift; the lockstep guard "
+                           "can't read its source of truth.")
+                      {:coord sym :deps-file rel-path})))
     pin))
 
 ;; --- Template literal extraction ----------------------------------------
@@ -180,3 +241,103 @@
                    "tools/template/src/day8/re_frame2_template/hooks.clj.")))
         (finally
           (delete-recursively tmp))))))
+
+;; --- substrate + clojure(script) lockstep (rf2-jdj17.3) -----------------
+;;
+;; The emitted deps.edn is valid EDN, so we read the pin straight off the
+;; parsed map rather than regexing the text. `emit-deps-pin` generates
+;; the per-substrate scaffold once and pulls the `:mvn/version` for a
+;; coord out of its `:deps`.
+
+(defn- emit-deps-pin
+  "Generate the `substrate` scaffold into `tmp`, read its emitted
+  deps.edn, and return the `:mvn/version` string for coord `sym` (nil if
+  absent). Caller owns the tmp lifecycle so a single emission can be
+  reused for several coord assertions."
+  [tmp substrate sym]
+  (let [root (run-template! tmp "acme/my-app" substrate)
+        deps (read-edn (io/file root "deps.edn"))]
+    (get-in deps [:deps sym :mvn/version])))
+
+(deftest substrate-lib-lockstep
+  (testing "Template's substrate-lib pins match the implementation adapter tree"
+    ;; reagent/reagent — impl source of truth is core/deps.edn :deps
+    ;; (re-frame.views is Reagent-coupled, so reagent rides core).
+    (let [impl-reagent (read-impl-deps-pin "implementation/core/deps.edn"
+                                           'reagent/reagent)
+          tmp          (tmp-dir "rf2-template-lockstep-reagent-")]
+      (try
+        (let [tpl-reagent (emit-deps-pin tmp :reagent 'reagent/reagent)]
+          (is (= impl-reagent tpl-reagent)
+              (str "Template reagent/reagent pin (" tpl-reagent ") must match "
+                   "implementation/core/deps.edn (" impl-reagent ") — P5 "
+                   "lockstep. Bump reagent in the _reagent/deps.edn "
+                   "template resource.")))
+        (finally (delete-recursively tmp))))
+
+    ;; com.pitch/uix.core — impl source of truth is adapters/uix/deps.edn :deps.
+    ;; com.pitch/uix.dom — the shipped uix adapter does NOT require uix.dom
+    ;; (rf2-sl7ml), so the impl pin lives in the :test alias's :extra-deps;
+    ;; the template's :app build needs it for the DOM mount, so the template
+    ;; pins it in :deps. Both must ride the same impl pin.
+    (let [impl-uix-core (read-impl-deps-pin "implementation/adapters/uix/deps.edn"
+                                            'com.pitch/uix.core)
+          impl-uix-dom  (read-impl-deps-pin "implementation/adapters/uix/deps.edn"
+                                            'com.pitch/uix.dom)
+          tmp           (tmp-dir "rf2-template-lockstep-uix-")]
+      (try
+        (let [root         (run-template! tmp "acme/my-app" :uix)
+              tpl-deps     (read-edn (io/file root "deps.edn"))
+              tpl-uix-core (get-in tpl-deps [:deps 'com.pitch/uix.core :mvn/version])
+              tpl-uix-dom  (get-in tpl-deps [:deps 'com.pitch/uix.dom :mvn/version])]
+          (is (= impl-uix-core tpl-uix-core)
+              (str "Template com.pitch/uix.core pin (" tpl-uix-core ") must "
+                   "match implementation/adapters/uix/deps.edn (" impl-uix-core
+                   ") — P5 lockstep. Bump uix.core in the _uix/deps.edn "
+                   "template resource."))
+          (is (= impl-uix-dom tpl-uix-dom)
+              (str "Template com.pitch/uix.dom pin (" tpl-uix-dom ") must "
+                   "match implementation/adapters/uix/deps.edn :test alias ("
+                   impl-uix-dom ") — P5 lockstep. Bump uix.dom in the "
+                   "_uix/deps.edn template resource.")))
+        (finally (delete-recursively tmp))))
+
+    ;; lilactown/helix — impl source of truth is adapters/helix/deps.edn :deps.
+    (let [impl-helix (read-impl-deps-pin "implementation/adapters/helix/deps.edn"
+                                         'lilactown/helix)
+          tmp        (tmp-dir "rf2-template-lockstep-helix-")]
+      (try
+        (let [tpl-helix (emit-deps-pin tmp :helix 'lilactown/helix)]
+          (is (= impl-helix tpl-helix)
+              (str "Template lilactown/helix pin (" tpl-helix ") must match "
+                   "implementation/adapters/helix/deps.edn (" impl-helix ") — "
+                   "P5 lockstep. Bump helix in the _helix/deps.edn template "
+                   "resource.")))
+        (finally (delete-recursively tmp))))))
+
+(deftest clojure-version-lockstep
+  (testing "Template's clojure + clojurescript pins match implementation/core/deps.edn"
+    ;; Both pins ride the impl core deps.edn :deps. They are
+    ;; substrate-invariant in the template (every _<substrate>/deps.edn
+    ;; carries the same two lines), so the Reagent emission recovers them.
+    (let [impl-clj  (read-impl-deps-pin "implementation/core/deps.edn"
+                                        'org.clojure/clojure)
+          impl-cljs (read-impl-deps-pin "implementation/core/deps.edn"
+                                        'org.clojure/clojurescript)
+          tmp       (tmp-dir "rf2-template-lockstep-clj-")]
+      (try
+        (let [root      (run-template! tmp "acme/my-app" :reagent)
+              deps      (read-edn (io/file root "deps.edn"))
+              tpl-clj   (get-in deps [:deps 'org.clojure/clojure :mvn/version])
+              tpl-cljs  (get-in deps [:deps 'org.clojure/clojurescript :mvn/version])]
+          (is (= impl-clj tpl-clj)
+              (str "Template org.clojure/clojure pin (" tpl-clj ") must match "
+                   "implementation/core/deps.edn (" impl-clj ") — P5 lockstep. "
+                   "Bump clojure in every _<substrate>/deps.edn template "
+                   "resource."))
+          (is (= impl-cljs tpl-cljs)
+              (str "Template org.clojure/clojurescript pin (" tpl-cljs ") must "
+                   "match implementation/core/deps.edn (" impl-cljs ") — P5 "
+                   "lockstep. Bump clojurescript in every _<substrate>/deps.edn "
+                   "template resource.")))
+        (finally (delete-recursively tmp))))))


### PR DESCRIPTION
Closes the three false-green / coverage holes in the template's generated-app gate found in the rf2-jdj17 review. One PR, three findings.

## rf2-jdj17.1 (P2 — PR-time false-green)
The generated `:app` build transitively compiles against **tools/xray** (`:devtools/preloads [day8.re-frame2-xray.preload]`), **implementation/schemas** (`events.cljs` side-loads `re-frame.schemas`; `schema.cljs` calls `reg-app-schema`), and **tools/story** (the with-story scaffold requires `re-frame.story`). But `.github/scripts/report-changed-surfaces.sh` armed `template_expensive=true` only for `implementation/core/*`, `implementation/adapters/*`, `tools/template/*`. So a PR breaking the xray preload ns, the `re-frame.schemas`/`reg-app-schema` surface, or the `re-frame.story` shell API **merged GREEN at PR time** — the only PR-time gate that compiles the emitted `:app` (`emitted_test_run_test`, gated on `template_expensive`) was skipped, and the break surfaced only in the nightly cron.

**Fix:** OR `template_expensive` into the classifier's `implementation/schemas/*` case and the non-spec-md `tools/{story,xray}/*` case. Spec-md-only changes stay excluded (can't break the `:app` compile); the other per-feature artefacts (machines/routing/flows/http/ssr/epoch) stay off because today's scaffold doesn't pull them in. Added **9 `template_expensive` assertions** to the classifier conformance test (`implementation/scripts/_changed-surfaces.test.cjs`) — it had **zero** before, which was itself part of the hole.

Demonstration (direct classifier invocation):
- `tools/xray/src/.../preload.cljs` → `template_expensive=true` ✓
- `implementation/schemas/src/...` → `template_expensive=true` ✓
- `tools/story/src/story.cljs` → `template_expensive=true` ✓
- `tools/story/spec/*.md` (spec-md only) → `template_expensive=false` ✓
- `implementation/machines/...` (not in scaffold) → `template_expensive=false` ✓
- core / adapters / template (regression) → `template_expensive=true` ✓

## rf2-jdj17.2 (P3 — no `:advanced` coverage)
No gate anywhere compiled the generated app under `:advanced` — every template compile was dev `:none`. `:advanced`-only failures (Closure DCE/externs, `^:export` munging, `:closure-define` elision) first hit a newcomer's `npm run release`.

**Fix:** `emitted_test_run_test.clj` now runs `clojure -M:shadow release app` for the default-Reagent and with-story-Reagent variants, asserting exit 0, a non-empty release bundle (`resources/public/js/main.js`), and the **cut-from-release invariant** (the dev-only Xray preload is stripped from the optimised bundle). No new CI job — it rides the existing `RF2_TEMPLATE_RUN_EMITTED_TESTS` gate (PR `jvm-tools-template` + nightly `template-emitted-app`). Cost-scoped to the two Reagent variants where the `:app` module + `^:export init` shape and the Story closure-define elision live. Verified green locally (`:advanced` builds ran; assertion count 325→359 with the gate enabled).

## rf2-jdj17.3 (P4 — substrate/clojure pins unguarded)
`version_lockstep_test` guarded only rf2/shadow/react. The substrate libs and clojure(script) could drift from the impl tree silently (the emitted-app smoke compiles against the *template's* pin, never the impl tree's, so a drift was invisible to every gate).

**Fix:** extend `version_lockstep_test.clj` to guard `reagent/reagent`, `com.pitch/uix.core` + `uix.dom`, `lilactown/helix`, and `org.clojure/clojure`(`script`) against the implementation reference tree (impl core deps.edn + per-adapter deps.edn). `cljfmt`/`clj-kondo`/`tools.namespace` are documented as intentionally **template-owned** (the impl tree pins none of them as deps.edn coords). Verified the guard catches a drift (temporarily drifting `reagent/reagent` → red in `substrate-lib-lockstep`, then reverted).

## Gates run (local)
- `tools/template` `clojure -M:test` — 28 tests / 325 assertions green (cheap mode); 359 assertions green with `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` (incl. the new `:advanced` release builds).
- `implementation` `npm run test:script-policy` — all green (classifier conformance now 48 passed, was 39).
- `bash -n` on the changed `.sh` — OK; `node --check` on the changed `.cjs` — OK.
- `clj-kondo --fail-level error` on both changed `.clj` files — 0 errors, 0 warnings.

## Hot-zone note
Single `.github` edit: `.github/scripts/report-changed-surfaces.sh` (classifier). **No `.github/workflows/*.yml` edits** — jdj17.2 went entirely into the template test (no new CI job, rides the existing env gate). Other changes are test-only and non-hot-zone (`tools/template/test/`, `implementation/scripts/*.test.cjs`).