### PR TITLE
fix(ssr/ssr-ring): three P4 streaming/redirect correctness fixes (rf2-kjf3m.4 + rf2-kjf3m.5 + rf2-7rkc0)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -239,7 +239,18 @@
                           streaming/failed-template
                           streaming/resolved-template)]
             (write-chunk! out (tmpl-fn id html))
-            (when (and (not failed?) (some? delta))
+            ;; rf2-kjf3m.5 — emit the per-boundary hydration-delta <script>
+            ;; ONLY when the delta carries something to hydrate. A
+            ;; continuation that merely READS app-db (the common case —
+            ;; deferred subtrees rarely mutate state) yields a delta of
+            ;; `{}` from `streaming/subtree-delta`, which is `some?` but
+            ;; empty; `(seq delta)` is the correct guard (falsy for both
+            ;; `{}` and `nil`) so an unchanged boundary emits NO delta
+            ;; script rather than an inert `<script …>{}</script>` chunk
+            ;; the client would parse and discard. `failed?` continuations
+            ;; carry `:delta nil` (also falsy here), so the `not failed?`
+            ;; arm is now redundant but kept for intent clarity.
+            (when (and (not failed?) (seq delta))
               (write-chunk! out (streaming/hydrate-delta-script id (pr-str delta))))
             ;; Pop the drained entry, append any nested continuations at
             ;; the tail (FIFO), continue until empty.

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -244,6 +244,71 @@
       (is (str/includes? body "</body></html>") "body closes cleanly"))))
 
 ;; ===========================================================================
+;; rf2-kjf3m.5 — the per-boundary hydration-delta <script> is emitted ONLY
+;; for a boundary whose render CHANGED app-db. A continuation that merely
+;; READS state (the common case — deferred subtrees typically subscribe,
+;; they do not mutate) yields an EMPTY delta (`{}`) from `subtree-delta`,
+;; and the writer must emit NO `<script data-rf2-suspense-hydrate>` chunk
+;; for it. Pre-fix the writer guard was `(some? delta)` — `{}` is `some?`,
+;; so every unchanged boundary shipped an inert `…hydrate=…>{}</script>`
+;; the client parsed and discarded; the guard is now `(seq delta)`.
+;; ===========================================================================
+
+(deftest stream-handler-skips-empty-delta-script-on-unchanged-boundary
+  (testing "rf2-kjf3m.5: a boundary whose continuation MUTATES app-db emits
+            its delta script; a boundary whose continuation only READS state
+            (empty/unchanged delta) emits NO `data-rf2-suspense-hydrate`
+            script — not an inert `{}` chunk."
+    ;; A db-mutating event the deferred subtree dispatches during its render
+    ;; — produces a non-empty per-subtree delta for the :changed boundary.
+    (rf/reg-event-db :rf.test/bump-counter
+      {:platforms #{:server}}
+      (fn [db _] (update db :counter (fnil inc 0))))
+    ;; Subtree that mutates app-db during render → non-empty delta.
+    (rf/reg-view ^{:rf/id :test/mutating-section} mutating-section []
+      (rf/dispatch-sync [:rf.test/bump-counter])
+      [:div.mutated "mutated content"])
+    ;; Subtree that only READS app-db (subscribes, no mutation) → empty delta.
+    (rf/reg-view ^{:rf/id :test/reading-section} reading-section []
+      (let [arts @(subscribe [:articles])]
+        (into [:div.read] (for [{:keys [title]} arts] [:span title]))))
+    (rf/reg-view ^{:rf/id :test/delta-root} delta-root []
+      [:main
+       [:h1 "Deltas"]
+       [:rf/suspense-boundary
+        {:id :test/changed :fallback [:p "changed loading"]}
+        [:test/mutating-section]]
+       [:rf/suspense-boundary
+        {:id :test/unchanged :fallback [:p "unchanged loading"]}
+        [:test/reading-section]]
+       [:footer "End"]])
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init]
+                      :root-view [:test/delta-root]
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          body     (drain-stream (:body response))]
+      (is (= 200 (:status response)) "stream still 200")
+      ;; Both boundaries resolved (their bodies are on the wire).
+      (is (str/includes? body "mutated content")
+          "the mutating boundary's resolved body streamed")
+      (is (str/includes? body "Article A")
+          "the reading boundary's resolved body streamed")
+      ;; The mutating boundary SHIPS its delta script.
+      (is (str/includes? body "data-rf2-suspense-hydrate=\":test/changed\"")
+          "the boundary that changed app-db ships its hydration-delta script")
+      ;; THE PIN: the read-only boundary ships NO delta script. Pre-fix this
+      ;; emitted `data-rf2-suspense-hydrate=":test/unchanged" …>{}</script>`.
+      (is (not (str/includes? body "data-rf2-suspense-hydrate=\":test/unchanged\""))
+          "the unchanged boundary ships NO hydration-delta script — an empty
+           `{}` delta is skipped, not emitted as an inert script chunk
+           (rf2-kjf3m.5: guard is `(seq delta)`, not `(some? delta)`)")
+      ;; No empty-EDN delta body anywhere on the wire.
+      (is (not (str/includes? body ">{}</script>"))
+          "no empty-`{}` delta-script body crosses the wire")
+      (is (str/includes? body "__rf_payload") "final payload still emitted"))))
+
+;; ===========================================================================
 ;; rf2-ee38b.11 — streaming redirect short-circuit MUST destroy the
 ;; per-request frame.
 ;;
@@ -648,3 +713,90 @@
                  :rf.ssr/hydration-mismatch (rf2-5knxf.2)")))
         (finally
           (rf/destroy-frame! fid))))))
+
+;; ===========================================================================
+;; rf2-7rkc0 — STREAMING-path counterpart of the non-streaming
+;; handler-throwing-head-fn-ships-degraded-200 wire pin
+;; (ring_test.clj `handler-throwing-head-fn-ships-degraded-200-not-projected-error`).
+;;
+;; CONTRACT (Spec 011 §1070, lifecycle/resolve-head, rf2-bof8i Option B):
+;; a throwing route `:head` fn is a RECOVERABLE DEGRADATION — the request
+;; still ships a 200 with an empty head fragment + body intact, AND emits
+;; `:rf.error/ssr-head-resolution-failed` for observability; the throwable
+;; message never reaches the wire.
+;;
+;; The STREAMING path resolves the head on the request thread inside
+;; `render-streaming-shell!` (streaming.clj `lifecycle/resolve-head`),
+;; BEFORE the chunked response head + status are committed and BEFORE the
+;; daemon writer is spawned — so a head-resolution failure physically
+;; cannot change the already-committed 200. The streaming path is thus
+;; structurally MORE immune than the non-streaming one; this test pins the
+;; degraded-stream-200 contract so a future refactor of the streaming head
+;; path cannot regress it silently (the non-streaming side had a wire pin,
+;; the streaming side did not — rf2-7rkc0).
+;; ===========================================================================
+
+(deftest stream-handler-throwing-head-fn-ships-degraded-streamed-200
+  (testing "rf2-7rkc0: a throwing route :head fn on the STREAMING path →
+            a streamed 200 (degraded — empty head, body chunks intact),
+            NEVER a projected 4xx/5xx, AND the
+            :rf.error/ssr-head-resolution-failed trace fires once."
+    (rf/reg-head :test.stream/head-throws
+                 (fn [_db _route]
+                   (throw (ex-info "synthetic streaming head failure (rf2-7rkc0)"
+                                   {:reason :test}))))
+    (rf/reg-route :test.stream/route-head-throws
+                  {:doc  "Streaming route whose head fn throws"
+                   :path "/stream-head-throws"
+                   :head :test.stream/head-throws})
+    (rf/reg-event-db :rf.test.stream/seed-throwing-head-route
+      {:platforms #{:server}}
+      (fn [db _]
+        (assoc-in db [:rf/runtime :routing :current]
+                  {:id :test.stream/route-head-throws})))
+    (rf/reg-view ^{:rf/id :test/stream-head-body} stream-head-body []
+      [:main [:h1 "Streamed body rendered fine"]])
+    (let [traces  (atom [])
+          _       (rf/register-listener! ::stream-head-fail-watch
+                    (fn [ev]
+                      (when (= :rf.error/ssr-head-resolution-failed
+                               (:operation ev))
+                        (swap! traces conj ev))))
+          handler (ssr-ring/stream-handler
+                    {:on-create [:rf.test.stream/seed-throwing-head-route]
+                     :root-view [:test/stream-head-body]
+                     :payload   :rf.ssr.payload/whole-app-db})
+          response (try
+                     (handler {:uri "/stream-head-throws" :request-method :get})
+                     (finally
+                       (rf/unregister-listener! ::stream-head-fail-watch)))
+          ;; Drain the chunked body — the head trace fires on the request
+          ;; thread (before the writer), but draining proves the body chunks
+          ;; still ship cleanly after the head degradation.
+          body    (drain-stream (:body response))]
+      ;; THE PIN: the streamed status is 200, not a projected 5xx. The head
+      ;; status/headers are committed BEFORE the writer is spawned, so a
+      ;; head-resolution throw cannot change the already-sent status — were
+      ;; the head trace ever projected (a reorder regression), this 200
+      ;; assertion turns red.
+      (is (= 200 (:status response))
+          "throwing :head fn degrades to a streamed 200 — NEVER a projected
+           4xx/5xx (Spec 011 §1070; the streaming status commits BEFORE the
+           writer thread + the projector-skip belt-and-suspenders, rf2-lia3i)")
+      ;; The streamed body is intact: doctype + the rendered root view.
+      (is (str/includes? body "<!DOCTYPE html>")
+          "the document still streams — the shell + body rendered")
+      (is (str/includes? body "Streamed body rendered fine")
+          "the body view content streams intact — only the head degraded")
+      (is (str/includes? body "__rf_payload")
+          "the final payload chunk still streams")
+      (is (str/includes? body "</body></html>")
+          "the streamed body closes cleanly")
+      ;; The throwable message never crosses the wire.
+      (is (not (str/includes? body "synthetic streaming head failure"))
+          "the throwable's message never reaches the streamed wire")
+      ;; Observability preserved: degrade AND emit.
+      (is (= 1 (count @traces))
+          ":rf.error/ssr-head-resolution-failed fires once for observability
+           on the streaming path too (Spec 011 §1070 Option B) — degraded,
+           not silent"))))

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -114,12 +114,43 @@
                        :recovery :no-recovery})))
     s))
 
+(defn- structurally-valid-uri?
+  "True when `s` parses as a structurally-valid URI reference per RFC 3986
+  (java.net.URI's grammar). This is a SHAPE check — it does NOT gate the
+  scheme, host, or origin (that is `:rf.server/safe-redirect`'s job for the
+  caller-untrusted path); it only rejects strings that are not a
+  well-formed URI reference at all (an unencoded space, a stray `^` / `<` /
+  `>` / `{` / `}` / backtick, a `%` not followed by two hex digits, …).
+  Both absolute URLs (`https://example.com/path`) and relative references
+  (`/login`, `a/b`, the empty reference) parse cleanly. On the CLJS branch
+  the fx is no-op'd by `:rf.fx/skipped-on-platform`, so the check is a
+  JVM-only gate and the CLJS branch trivially passes."
+  [s]
+  #?(:clj
+     (try
+       (URI. ^String s)
+       true
+       (catch URISyntaxException _ false)
+       (catch NullPointerException _ false)
+       (catch IllegalArgumentException _ false))
+     :cljs true))
+
 (defn- validate-redirect-location!
   "Throw `:rf.error/redirect-invalid-location` if the redirect location
   `loc` contains CR / LF / NUL. Same CRLF-injection vector as a
   user-controlled `Location` header value: a query param like
   `?next=https://example.com%0d%0aSet-Cookie:%20stolen=1` URL-decodes
-  into literal CRLF and would split the header on the wire."
+  into literal CRLF and would split the header on the wire.
+
+  This is the SHARED CRLF gate — both `:rf.server/redirect` (caller-
+  trusted) and `:rf.server/safe-redirect` (caller-untrusted) run it as a
+  defence-in-depth first step. It deliberately does NOT do the structural
+  URL-shape check: `safe-redirect-fx` does its own full parse + scheme +
+  host gate (emitting the specific `:rf.error/safe-redirect-*`
+  categories), and stacking a throwing structural gate ahead of those
+  would both mask its specific error categories and break its throw-free
+  emit-and-no-op contract. The structural URL-shape gate is layered on the
+  trusted path only, via `validate-redirect-location-shape!` below."
   [loc]
   (let [s (str loc)]
     (when (http-validation/contains-injection-char? s)
@@ -130,6 +161,42 @@
                                       " — forbidden by RFC 7230 §3.2.4"
                                       " (header-splitting injection)")
                        :location loc
+                       :recovery :no-recovery})))
+    s))
+
+(defn- validate-redirect-location-shape!
+  "Throw `:rf.error/redirect-invalid-location` if the redirect location
+  `loc` is not a structurally-valid URI reference (RFC 3986). The
+  structural URL-shape gate Spec 011 §CRLF fail-fast names for the
+  caller-trusted `:rf.server/redirect` (the `Location:` value gets the
+  CRLF check PLUS a structural URL-shape check).
+
+  Rejects a `:location` that is not a well-formed URI reference — an
+  unencoded space, a stray control/delimiter char (`^`, `<`, `>`, `{`,
+  `}`, backtick), a malformed `%`-escape, … — so a structurally-malformed
+  redirect target fails fast at fx-handler time rather than reaching the
+  wire as a broken `Location` header.
+
+  This is a SHAPE check ONLY: `:rf.server/redirect` stays caller-trusted
+  — it accepts arbitrary *origins* without allowlist / relative-only
+  gating (that is `:rf.server/safe-redirect`'s job, rf2-zfm8v). The
+  structural gate merely rejects a target that no `Location:` header could
+  legitimately carry. Called only from `redirect-fx`; `safe-redirect-fx`
+  has its own (richer, emit-based) parse gate."
+  [loc]
+  (let [s (str loc)]
+    (when-not (structurally-valid-uri? s)
+      (throw (ex-info ":rf.error/redirect-invalid-location"
+                      {:rf.error/id :rf.error/redirect-invalid-location
+                       :where    'rf.ssr/response
+                       :reason   (str "redirect :location is not a"
+                                      " structurally-valid URI reference"
+                                      " (RFC 3986) — a structurally-malformed"
+                                      " redirect target cannot be written as a"
+                                      " Location header. Per Spec 011 §CRLF"
+                                      " fail-fast (structural URL-shape check).")
+                       :location loc
+                       :reason-tag :structural-url-shape
                        :recovery :no-recovery})))
     s))
 
@@ -423,7 +490,11 @@
   absent. Multiple writes emit `:rf.warning/multiple-redirects`
   (last-write-wins). Throws `:rf.error/redirect-invalid-location` on a
   location carrying CR/LF/NUL (rf2-hbty2) — a `?next=…` query-param
-  redirect would otherwise let an attacker forge headers.
+  redirect would otherwise let an attacker forge headers — OR on a
+  location that is not a structurally-valid URI reference (RFC 3986), per
+  Spec 011 §CRLF fail-fast (the `Location:` value gets the CRLF check PLUS
+  a structural URL-shape check). The structural check is a SHAPE gate only
+  — it does not gate the redirect's origin (this fx stays caller-trusted).
 
   **Caller-trusted `:location`** — accepts arbitrary URL strings without
   allowlist or relative-only gating. For caller-untrusted location
@@ -437,7 +508,12 @@
                       (:url      redirect-map)
                       (:to       redirect-map))
         _         (when (some? location)
-                    (validate-redirect-location! location))
+                    ;; CRLF gate (shared) + structural URL-shape gate
+                    ;; (trusted-path only, Spec 011 §CRLF fail-fast,
+                    ;; rf2-kjf3m.4). safe-redirect-fx runs the CRLF gate but
+                    ;; NOT this shape gate — it has its own emit-based parse.
+                    (validate-redirect-location! location)
+                    (validate-redirect-location-shape! location))
         status    (or (:status redirect-map) 302)
         normalised (cond-> (assoc redirect-map :status status)
                      location (assoc :location location))

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -486,6 +486,50 @@
           traces :rf.error/redirect-invalid-location
           (str ev " redirect via " ev " alias"))))))
 
+(deftest ssr-redirect-rejects-structurally-malformed-location
+  (testing "rf2-kjf3m.4 — :rf.server/redirect with a structurally-malformed
+            :location (not a valid RFC 3986 URI reference) fails fast with
+            :rf.error/redirect-invalid-location. Per Spec 011 §CRLF
+            fail-fast: the Location: value gets the CRLF check PLUS a
+            structural URL-shape check. The structural-malformity classes
+            (unencoded space, stray delimiter chars, malformed %-escape)
+            surface the same error keyword as the CRLF case."
+    (doseq [[label loc] [["unencoded space"        "https://example.com/a b"]
+                         ["stray caret"            "https://example.com/^"]
+                         ["unbalanced brace"       "/path/{id"]
+                         ["malformed percent-esc"  "/path%zz"]
+                         ["bare control via %1"    "/path%1"]]]
+      (rf/reg-event-fx :redirect/malformed
+        (fn [_ _]
+          {:fx [[:rf.server/redirect {:location loc}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-fx-traces!
+                     (fn [] (rf/dispatch-sync [:redirect/malformed] {:frame f})))]
+        (expect-fx-error-keyword!
+          traces :rf.error/redirect-invalid-location
+          (str "structurally-malformed redirect :location (" label ")")))))
+
+  (testing "rf2-kjf3m.4 — regression guard: the structural check stays a
+            SHAPE gate, NOT an origin gate. The caller-trusted redirect
+            still accepts arbitrary well-formed targets — absolute http(s)
+            URLs to any origin, protocol-relative, relative refs, and the
+            structurally-valid edge cases (query / fragment / port / encoded
+            space) all flow through without error."
+    (doseq [loc ["https://example.com/path?q=1&r=2#frag"
+                 "https://other.example.org:8443/deep/path"
+                 "//cdn.example.com/asset"
+                 "/login"
+                 "dashboard"
+                 "a/b/c"
+                 "/path%20with%20encoded%20space"]]
+      (rf/reg-event-fx :redirect/well-formed
+        (fn [_ _]
+          {:fx [[:rf.server/redirect {:location loc}]]}))
+      (let [f    (rf/make-frame {:platform :server :on-create [:redirect/well-formed]})
+            resp (get-response f)]
+        (is (= loc (-> resp :redirect :location))
+            (str "well-formed redirect :location survives the structural gate: " loc))))))
+
 (deftest ssr-header-clean-values-still-accepted
   (testing "rf2-hbty2 — regression guard: legitimate header values still flow
             through. Whitespace, semicolons, quoted-strings, full URLs are


### PR DESCRIPTION
Three disjoint P4 correctness fixes across `implementation/ssr` + `implementation/ssr-ring`.

## rf2-kjf3m.4 (ssr) — structural URL-shape check on `:rf.server/redirect`
`validate-redirect-location!` previously checked only CR/LF/NUL. Spec 011 §CRLF fail-fast (and Security.md §181: "CRLF / malformed-URL injection") names a structural URL-shape check for the trusted `:rf.server/redirect` path. Added `validate-redirect-location-shape!` (a `java.net.URI` parse) so a structurally-malformed `:location` (unencoded space, stray `^`/`<`/`>`/`{`/`}`/backtick, malformed `%`-escape) fails fast with `:rf.error/redirect-invalid-location`.

- It is a SHAPE gate only — it does NOT gate origin/scheme/host (that stays `:rf.server/safe-redirect`'s job; the trusted variant remains caller-trusted about *where* it redirects).
- The shared `validate-redirect-location!` keeps its CRLF-only contract; `safe-redirect-fx` still calls only it (NOT the new shape gate) so its own emit-based parse/scheme/host gates and the specific `:rf.error/safe-redirect-*` categories surface unchanged.
- Spec 011 read, not edited — the impl now matches what §446 / Security.md §181 already say.

## rf2-kjf3m.5 (ssr-ring) — no empty `{}` delta script on unchanged boundary
`subtree-delta` returns `{}` (not `nil`) when a continuation doesn't mutate app-db — the common case (deferred subtrees usually only READ state). The writer's emit guard `(some? delta)` is truthy for `{}`, so every unchanged boundary shipped an inert `<script data-rf2-suspense-hydrate=…>{}</script>`. Changed the guard to `(seq delta)` — falsy for both `{}` and `nil` — so an unchanged boundary emits nothing.

## rf2-7rkc0 (ssr-ring) — streaming throwing-`:head` degraded-200 wire pin
Added the handler-level streaming regression mirroring the existing non-streaming pin: a throwing route `:head` fn → a streamed 200 (empty head, body chunks intact, throwable message never on the wire) + the `:rf.error/ssr-head-resolution-failed` trace fires once. Closes the streaming/non-streaming coverage asymmetry the round-2 review flagged.

## Gates (cold)
- `implementation/ssr` `clojure -M:test` — 284 tests / 1030 assertions, 0 failures
- `implementation/ssr-ring` `clojure -M:test` — 123 tests / 543 assertions, 0 failures
- `npm run test:cljs` — 5736 tests / 20075 assertions, 0 failures
- Each new test verified to FAIL against the pre-fix code path (kjf3m.5 shown red with `some? delta`; kjf3m.4 / 7rkc0 hit the actual paths).