### PR TITLE
test(examples): guard stock examples/reagent against slim wiring (rf2-hekqp)

### DIFF
--- a/examples/TESTING.md
+++ b/examples/TESTING.md
@@ -74,6 +74,29 @@ itself runs in the `cljs-browser` CI job (the `cljs_browser` changed
 surface, which fires on both `examples/**` source edits and
 `shadow-cljs.edn` build-decl changes).
 
+## Stock / slim Reagent boundary gate (`test:script-policy`)
+
+re-frame2 ships two Reagent substrates with two separate example trees: the
+**stock** tree (`examples/reagent/**`, mounting `reagent.*` +
+`re-frame.adapter.reagent`) and the **slim** tree
+(`examples/reagent-slim/**`, mounting `reagent2.*` +
+`re-frame.adapter.reagent-slim`). The slim wiring exists for bundle isolation
+and belongs **only** to the slim tree.
+
+[`examples/scripts/check-reagent-slim-boundary.cjs`](scripts/check-reagent-slim-boundary.cjs)
+is a pure static scanner that walks every `.clj{,s,c}` source under
+`examples/reagent/` and fails if any of them requires `reagent2.*` or
+`re-frame.adapter.reagent-slim`. Its detector is anchored so the legitimate
+stock wiring (`reagent.core`, `re-frame.adapter.reagent` — note the *absence*
+of the `2` and the `-slim` suffix) is never flagged.
+
+This is **not** a Playwright spec and adds nothing under `examples/` source —
+it preserves the test-free examples policy (rf2-8cevm). Its teeth (slim hits
+flagged; stock wiring not flagged; a live scan of the real tree must be clean;
+a non-vacuous source floor) are pinned by
+[`implementation/scripts/check-reagent-slim-boundary.test.cjs`](../implementation/scripts/check-reagent-slim-boundary.test.cjs),
+which runs in the always-on `test:script-policy` suite.
+
 ## Server-ownership contract (`test:browser`)
 
 The browser-test orchestrator at

--- a/examples/scripts/check-reagent-slim-boundary.cjs
+++ b/examples/scripts/check-reagent-slim-boundary.cjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/*
+ * `check-reagent-slim-boundary` — STATIC source-boundary gate over the stock
+ * Reagent example tree (rf2-hekqp; follow-up to rf2-2bih3 / PR #3137).
+ *
+ * The boundary this guards
+ * ------------------------
+ * re-frame2 ships TWO Reagent substrates with two separate example trees:
+ *
+ *   examples/reagent/**       — the STOCK Reagent substrate. Mounts via
+ *                               `reagent.dom.client` + the stock adapter
+ *                               `re-frame.adapter.reagent`.
+ *   examples/reagent-slim/**  — the SLIM (day8/reagent-slim) substrate. Mounts
+ *                               via `reagent2.*` + `re-frame.adapter.reagent-slim`.
+ *
+ * The slim substrate's whole point is bundle isolation: its user-facing import
+ * point is `reagent2.*` (not stock `reagent.*`) and it wires
+ * `re-frame.adapter.reagent-slim`. That wiring belongs ONLY to the
+ * examples/reagent-slim/ tree. rf2-2bih3 (PR #3137) confirmed the stock tree
+ * was clean of slim wiring at the time, but shipped WITHOUT a guard keeping it
+ * so — a future edit could silently re-cross the boundary (e.g. a copy/paste
+ * from the slim counter), and no automated gate would catch it.
+ *
+ * What this gate does (STATIC — no browser, no Playwright, no compile)
+ * -------------------------------------------------------------------
+ * It walks every tracked Clojure(Script) source under examples/reagent/ and
+ * FAILS if any of them requires a slim-substrate namespace:
+ *
+ *   - `reagent2.*`                    (the slim substrate's user-facing import)
+ *   - `re-frame.adapter.reagent-slim` (the slim adapter Var)
+ *
+ * The stock adapter `re-frame.adapter.reagent` and stock `reagent.*` (note: NO
+ * trailing `2`) are the LEGITIMATE wiring for this tree and are never flagged —
+ * the detector is anchored so `re-frame.adapter.reagent` does NOT match the
+ * `re-frame.adapter.reagent-slim` rule, and `reagent.core` does NOT match the
+ * `reagent2.*` rule.
+ *
+ * This is NOT a per-example *.spec.cjs — examples/ stays test-free (rf2-8cevm).
+ * It is a pure static scanner, wired into the always-run `test:script-policy`
+ * gate (see implementation/scripts/check-reagent-slim-boundary.test.cjs) so a
+ * slim require leaking into examples/reagent/ turns that gate RED in CI without
+ * a new .github workflow job.
+ *
+ * CLI
+ * ---
+ *   node examples/scripts/check-reagent-slim-boundary.cjs           # scan, exit 0/1
+ *   node examples/scripts/check-reagent-slim-boundary.cjs --list    # print files scanned, exit 0
+ *
+ * The pure scan logic is exported for check-reagent-slim-boundary.test.cjs,
+ * which pins the detector (slim hits flagged, stock wiring NOT flagged) AND
+ * gives the gate teeth by running the real scan over the repo.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// __dirname is <repo>/examples/scripts. REPO_ROOT is <repo>.
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const EXAMPLES_ROOT = path.join(REPO_ROOT, 'examples');
+// The stock Reagent tree this gate guards. The slim tree
+// (examples/reagent-slim/) is the legitimate home of the slim wiring and is
+// NEVER walked — `reagent-slim` !== `reagent`, so a prefix walk over
+// examples/reagent/ does not reach into it.
+const STOCK_REAGENT_ROOT = path.join(EXAMPLES_ROOT, 'reagent');
+
+// ---------------------------------------------------------------------------
+// Forbidden slim-substrate namespaces. Each rule matches a namespace SYMBOL as
+// it appears in a `:require` / `:require-macros` form — a leading `[` or
+// whitespace, then the namespace, then a word boundary (whitespace, `]`, `:`
+// for an alias keyword, or end). Anchoring on the leading boundary is what
+// keeps the stock wiring clean:
+//
+//   reagent2.*  matches `reagent2.core`, `reagent2.dom.client`, … but NOT
+//               stock `reagent.core` (no trailing `2`).
+//   re-frame.adapter.reagent-slim matches the slim adapter but NOT the stock
+//               `re-frame.adapter.reagent` (the `-slim` suffix is required,
+//               and the trailing boundary forbids `re-frame.adapter.reagent`
+//               from matching the slim rule).
+// ---------------------------------------------------------------------------
+const FORBIDDEN = [
+  {
+    id: 'reagent2',
+    label: 'reagent2.* (slim substrate user-facing import)',
+    // (^|[\s[(]) leading boundary; reagent2 then `.` or a trailing boundary.
+    re: /(^|[\s[(]):?reagent2(?=[.\s\][):]|$)/m,
+  },
+  {
+    id: 'reagent-slim-adapter',
+    label: 're-frame.adapter.reagent-slim (slim adapter Var)',
+    re: /(^|[\s[(]):?re-frame\.adapter\.reagent-slim(?=[\s\][):]|$)/m,
+  },
+];
+
+// Clojure(Script) source extensions a runnable example ships.
+const SOURCE_EXTS = new Set(['.clj', '.cljs', '.cljc']);
+
+// ---------------------------------------------------------------------------
+// Source enumeration. Walk the stock-Reagent tree for .clj/.cljs/.cljc files,
+// skipping node_modules / build-output dirs. The slim tree is a SIBLING
+// (examples/reagent-slim/) and is never reached by this prefix walk.
+// ---------------------------------------------------------------------------
+
+function listStockReagentSources(root = STOCK_REAGENT_ROOT) {
+  const out = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '.shadow-cljs') continue;
+        stack.push(full);
+      } else if (entry.isFile() && SOURCE_EXTS.has(path.extname(entry.name))) {
+        out.push(full);
+      }
+    }
+  }
+  return out.sort();
+}
+
+// ---------------------------------------------------------------------------
+// The pure detector. Given a source string, return the list of forbidden-rule
+// ids it matches. Exported so the test can pin the boundary (slim hits flagged,
+// stock wiring NOT flagged) without touching disk.
+// ---------------------------------------------------------------------------
+
+function detectForbidden(source) {
+  const hits = [];
+  for (const rule of FORBIDDEN) {
+    if (rule.re.test(source)) hits.push(rule);
+  }
+  return hits;
+}
+
+function readFileSafe(io, p) {
+  try {
+    return io.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function scanFile(io, absPath) {
+  const rel = path.relative(REPO_ROOT, absPath).split(path.sep).join('/');
+  const source = readFileSafe(io, absPath);
+  if (source == null) {
+    return { rel, errors: [`${rel}: could not read source`] };
+  }
+  const errors = [];
+  for (const rule of detectForbidden(source)) {
+    errors.push(
+      `${rel}: requires ${rule.label} — slim wiring is forbidden in the ` +
+        `stock examples/reagent/ tree. The slim substrate belongs ONLY to ` +
+        `examples/reagent-slim/. Use stock Reagent (reagent.* + ` +
+        `re-frame.adapter.reagent) here, or move the example to ` +
+        `examples/reagent-slim/.`,
+    );
+  }
+  return { rel, errors };
+}
+
+// Run the full scan over every stock-Reagent source.
+function scanAll(opts = {}) {
+  const io = opts.io || fs;
+  const files = opts.files || listStockReagentSources();
+  const results = files.map((f) => scanFile(io, f));
+  const errors = results.flatMap((r) => r.errors);
+  return { results, errors };
+}
+
+module.exports = {
+  REPO_ROOT,
+  EXAMPLES_ROOT,
+  STOCK_REAGENT_ROOT,
+  FORBIDDEN,
+  SOURCE_EXTS,
+  listStockReagentSources,
+  detectForbidden,
+  scanFile,
+  scanAll,
+};
+
+// ---------------------------------------------------------------------------
+// CLI entry-point (skipped when require()'d by the test suite).
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const listOnly = process.argv.slice(2).includes('--list');
+  const files = listStockReagentSources();
+
+  // Non-vacuous guard: a walk that silently recovers nothing must NOT let the
+  // gate pass green having scanned zero files. The stock Reagent tree ships
+  // dozens of sources; require a sane floor so a layout/walk drift fails loud
+  // rather than turning the boundary check into a vacuous pass.
+  if (files.length < 20) {
+    console.error(
+      `check-reagent-slim-boundary: only ${files.length} source file(s) ` +
+        `found under examples/reagent/ — expected the full set. Walk or ` +
+        `layout drift; refusing to pass a vacuous gate.`,
+    );
+    process.exit(1);
+  }
+
+  if (listOnly) {
+    console.log(
+      `check-reagent-slim-boundary: ${files.length} stock-Reagent source(s):`,
+    );
+    for (const f of files) {
+      console.log(`  ${path.relative(REPO_ROOT, f).split(path.sep).join('/')}`);
+    }
+    process.exit(0);
+  }
+
+  const { errors } = scanAll({ files });
+
+  console.log(
+    `check-reagent-slim-boundary: scanning ${files.length} stock-Reagent ` +
+      `source(s) for slim wiring.`,
+  );
+
+  if (errors.length > 0) {
+    console.error(
+      `\ncheck-reagent-slim-boundary: ${errors.length} boundary violation(s):`,
+    );
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error(
+      `\nThe stock examples/reagent/ tree must use stock Reagent wiring only ` +
+        `(reagent.* + re-frame.adapter.reagent). reagent2.* and ` +
+        `re-frame.adapter.reagent-slim belong ONLY to examples/reagent-slim/. ` +
+        `Fix the require, or move the example under examples/reagent-slim/.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `check-reagent-slim-boundary: all ${files.length} stock-Reagent sources ` +
+      `are slim-free (no reagent2.* / re-frame.adapter.reagent-slim require). ` +
+      `Boundary intact.`,
+  );
+}

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -36,7 +36,7 @@
     "test:xray-feature-gate": "node scripts/serve-and-run-xray-feature-gate.cjs",
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs && node scripts/dev-testbed.test.cjs",
     "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }

--- a/implementation/scripts/check-reagent-slim-boundary.test.cjs
+++ b/implementation/scripts/check-reagent-slim-boundary.test.cjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/*
+ * Tests for `examples/scripts/check-reagent-slim-boundary.cjs` — the STATIC
+ * stock-Reagent / slim-Reagent source-boundary gate (rf2-hekqp).
+ *
+ * Two jobs, both with teeth:
+ *
+ *  1. LIVE GATE — run the real scan over the actual examples/reagent/ tree and
+ *     FAIL if it reports any slim-wiring violation. This is what gives the
+ *     always-run `test:script-policy` gate its teeth: a `reagent2.*` or
+ *     `re-frame.adapter.reagent-slim` require leaking into the stock tree turns
+ *     this gate RED in CI. (Today the real tree is clean, so the live scan
+ *     passes — see the teeth-proof in the PR: add a slim require to a stock
+ *     example → RED → restore → GREEN.)
+ *
+ *  2. UNIT TEETH — pin the pure detector against synthetic fixtures so the
+ *     behaviours the gate relies on cannot silently regress to a vacuous pass:
+ *       - slim requires (`reagent2.*`, `re-frame.adapter.reagent-slim`) ARE
+ *         flagged;
+ *       - stock wiring (`reagent.core`, `re-frame.adapter.reagent`) is NOT
+ *         flagged — the boundary must distinguish stock from slim.
+ *
+ * Standalone node-runnable suite — no external test framework, mirroring
+ * `check-examples-assets.test.cjs`. Wired into package.json via
+ * `test:script-policy`.
+ */
+
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+
+const scanner = require('../../examples/scripts/check-reagent-slim-boundary.cjs');
+const {
+  FORBIDDEN,
+  detectForbidden,
+  scanFile,
+  scanAll,
+  listStockReagentSources,
+  STOCK_REAGENT_ROOT,
+} = scanner;
+
+let failed = 0;
+function it(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+  } catch (err) {
+    failed++;
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${(err && err.message) || err}`);
+  }
+}
+
+console.log('check-reagent-slim-boundary tests (rf2-hekqp)');
+
+// ---------------------------------------------------------------------------
+// 1) LIVE GATE — the teeth in CI. Scan the real stock-Reagent tree; any slim
+//    require is RED.
+// ---------------------------------------------------------------------------
+
+const realSources = listStockReagentSources();
+
+it('the real stock-Reagent tree exposes a non-vacuous set of sources', () => {
+  assert.ok(
+    realSources.length >= 20,
+    `expected the full stock-Reagent source set (>=20), got ` +
+      `${realSources.length} — walk/layout drift; a vacuous gate is forbidden`,
+  );
+});
+
+it('LIVE: no stock examples/reagent/ source requires slim wiring', () => {
+  const { errors } = scanAll({ files: realSources });
+  assert.strictEqual(
+    errors.length,
+    0,
+    `the live boundary scan found ${errors.length} violation(s):\n` +
+      errors.map((e) => `    - ${e}`).join('\n'),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 2) UNIT TEETH — synthetic in-memory fixtures so the detector is pinned.
+// A tiny fake io: a map of absolute path -> file contents.
+// ---------------------------------------------------------------------------
+
+function makeIo(files) {
+  const norm = (p) => path.resolve(p);
+  const map = new Map(Object.entries(files).map(([k, v]) => [norm(k), v]));
+  return {
+    readFileSync: (p) => {
+      const v = map.get(norm(p));
+      if (v == null) {
+        const e = new Error(`ENOENT: ${p}`);
+        e.code = 'ENOENT';
+        throw e;
+      }
+      return v;
+    },
+  };
+}
+
+// A realistic stock-Reagent ns form — the shape every examples/reagent/ core
+// ships (stock adapter + stock reagent.dom.client). MUST scan clean.
+const STOCK_NS = [
+  '(ns examples.reagent.counter.core',
+  '  (:require [reagent.dom.client          :as rdc]',
+  '            [re-frame.core               :as rf]',
+  '            [re-frame.views]',
+  '            [re-frame.adapter.reagent    :as reagent-adapter])',
+  '  (:require-macros [re-frame.core :refer [reg-view]]))',
+].join('\n');
+
+// The slim ns form (lifted from examples/reagent-slim/.../core.cljs). MUST be
+// flagged on BOTH rules.
+const SLIM_NS = [
+  '(ns examples.reagent-slim.counter.core',
+  '  (:require [reagent2.dom.client            :as rdc]',
+  '            [reagent2.dom.server            :as rds]',
+  '            [re-frame.core                  :as rf]',
+  '            [re-frame.adapter.reagent-slim  :as reagent-slim-adapter])',
+  '  (:require-macros [re-frame.core :refer [reg-view]]))',
+].join('\n');
+
+// ---- the detector distinguishes stock from slim --------------------------
+
+it('detectForbidden returns no hits for a stock-Reagent ns form', () => {
+  assert.deepStrictEqual(detectForbidden(STOCK_NS), []);
+});
+
+it('TEETH: detectForbidden flags BOTH slim rules on a slim ns form', () => {
+  const ids = detectForbidden(SLIM_NS).map((r) => r.id).sort();
+  assert.deepStrictEqual(ids, ['reagent-slim-adapter', 'reagent2']);
+});
+
+// ---- reagent2.* rule: anchored so stock reagent.* never matches -----------
+
+it('TEETH: a reagent2.* require is flagged', () => {
+  assert.ok(
+    detectForbidden('  (:require [reagent2.core :as r])').some((r) => r.id === 'reagent2'),
+  );
+});
+
+it('TEETH: a deep reagent2 ns (reagent2.dom.server) is flagged', () => {
+  assert.ok(
+    detectForbidden('[reagent2.dom.server :as rds]').some((r) => r.id === 'reagent2'),
+  );
+});
+
+it('stock reagent.core is NOT flagged by the reagent2 rule', () => {
+  assert.ok(!detectForbidden('[reagent.core :as r]').some((r) => r.id === 'reagent2'));
+});
+
+it('stock reagent.dom.client is NOT flagged by the reagent2 rule', () => {
+  assert.ok(
+    !detectForbidden('[reagent.dom.client :as rdc]').some((r) => r.id === 'reagent2'),
+  );
+});
+
+// ---- adapter rule: -slim flagged, stock adapter never ---------------------
+
+it('TEETH: re-frame.adapter.reagent-slim is flagged', () => {
+  assert.ok(
+    detectForbidden('[re-frame.adapter.reagent-slim :as a]').some(
+      (r) => r.id === 'reagent-slim-adapter',
+    ),
+  );
+});
+
+it('the stock re-frame.adapter.reagent is NOT flagged (no -slim suffix)', () => {
+  assert.deepStrictEqual(detectForbidden('[re-frame.adapter.reagent :as reagent-adapter]'), []);
+});
+
+it('the stock adapter on a require line with no alias is NOT flagged', () => {
+  assert.deepStrictEqual(detectForbidden('   [re-frame.adapter.reagent]'), []);
+});
+
+// ---- scanFile / scanAll integration --------------------------------------
+
+it('scanFile reports a clean stock source with no errors', () => {
+  const p = path.join(STOCK_REAGENT_ROOT, 'counter', 'core.cljs');
+  const io = makeIo({ [p]: STOCK_NS });
+  assert.deepStrictEqual(scanFile(io, p).errors, []);
+});
+
+it('TEETH: scanFile reports a slim require leaking into the stock tree', () => {
+  // A stock-tree path that (wrongly) carries slim wiring — exactly the
+  // regression this gate exists to catch.
+  const p = path.join(STOCK_REAGENT_ROOT, 'counter', 'core.cljs');
+  const leaked = STOCK_NS.replace(
+    '[re-frame.adapter.reagent    :as reagent-adapter]',
+    '[re-frame.adapter.reagent-slim :as reagent-adapter]',
+  );
+  const io = makeIo({ [p]: leaked });
+  const { errors } = scanFile(io, p);
+  assert.ok(
+    errors.some(
+      (e) => e.includes('re-frame.adapter.reagent-slim') && e.includes('forbidden'),
+    ),
+    `expected a slim-adapter violation, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: scanAll surfaces a reagent2 leak across the synthetic tree', () => {
+  const clean = path.join(STOCK_REAGENT_ROOT, 'counter', 'core.cljs');
+  const dirty = path.join(STOCK_REAGENT_ROOT, 'demo', 'core.cljs');
+  const io = makeIo({
+    [clean]: STOCK_NS,
+    [dirty]: STOCK_NS.replace('[reagent.dom.client          :as rdc]', '[reagent2.dom.client :as rdc]'),
+  });
+  const { errors } = scanAll({ io, files: [clean, dirty] });
+  assert.strictEqual(errors.length, 1, `expected exactly one violation, got: ${errors.join(' | ')}`);
+  assert.ok(errors[0].includes('reagent2'));
+});
+
+// ---- contract constant sanity --------------------------------------------
+
+it('FORBIDDEN names exactly the two slim-substrate surfaces', () => {
+  assert.deepStrictEqual(
+    FORBIDDEN.map((r) => r.id).sort(),
+    ['reagent-slim-adapter', 'reagent2'],
+  );
+});
+
+if (failed > 0) {
+  console.error(`\ncheck-reagent-slim-boundary tests: ${failed} failed.`);
+  process.exit(1);
+}
+console.log('\ncheck-reagent-slim-boundary tests: all passed.');


### PR DESCRIPTION
@
## What

Adds a static regression guard so the **stock / slim Reagent boundary** in the examples tree stays clean.

- `examples/scripts/check-reagent-slim-boundary.cjs` — pure static scanner. Walks every `.clj{,s,c}` source under `examples/reagent/` and FAILS if any requires `reagent2.*` or `re-frame.adapter.reagent-slim`. The detector is anchored so legitimate stock wiring (`reagent.core`, `re-frame.adapter.reagent` — no trailing `2`, no `-slim` suffix) is **never** flagged. The slim tree (`examples/reagent-slim/`) is a sibling and is never walked.
- `implementation/scripts/check-reagent-slim-boundary.test.cjs` — gives the gate teeth: a LIVE scan of the real tree (red on any slim leak) plus synthetic-fixture unit teeth pinning the detector (slim flagged; stock NOT flagged).
- Wired into the always-run `test:script-policy` gate (`implementation/package.json`).
- `examples/TESTING.md` — documents the gate.

Mirrors the existing `check-examples-assets.cjs` static-gate pattern. **Not** a per-example Playwright spec; preserves the test-free examples policy (rf2-8cevm).

## Why

Follow-up to rf2-2bih3 (#3137). That fix confirmed the stock `examples/reagent/**` tree was clean of slim wiring but shipped **without** a guard keeping it so — a future edit (e.g. a copy/paste from the slim counter) could silently re-cross the boundary with no automated gate to catch it.

## Teeth proof

Temporarily added a slim require (`reagent2.dom.client` + `re-frame.adapter.reagent-slim`) to `examples/reagent/counter/core.cljs`:

- **RED**: LIVE gate failed, exit 1, 2 violations reported.
- Restored the file → **GREEN**, exit 0; example file unchanged in git.

## Gates

`npm run test:script-policy` passes cold with the new guard integrated (all sub-suites green, including the 15 new boundary tests). Live scan finds 52 stock-Reagent sources, all slim-free.

Closes rf2-hekqp.
@