### PR TITLE
docs(skill/re-frame-migration): elevate React-19/Reagent-2 floor to a first-class pre-flight gate (rf2-jhysu)

### DIFF
--- a/skills/re-frame-migration/README.md
+++ b/skills/re-frame-migration/README.md
@@ -12,8 +12,9 @@ This is the **migration** companion to the main [`re-frame2`](../re-frame2/) ski
 
 ## What it covers
 
-The six-phase migration workflow:
+A pre-flight floor gate plus a six-phase migration workflow:
 
+0. **Pre-flight — the React-19 / Reagent-2 floor gate** — before any dep edit, audit downstream React-coupled deps, confirm the UI component library has a React-19 (Reagent-2 if Reagent-based) release, scan for legacy `ReactDOM.render` call sites, and make an explicit go/no-go. A component library with no React-19 build is a hard blocker surfaced here, not mid-compile.
 1. **Orient** — read the project's dep file; identify the substrate; skim `migration/from-re-frame-v1/README.md` for the rule index.
 2. **Bump (M-0)** — swap `re-frame/re-frame` for `day8/re-frame2` + a substrate-adapter artefact. **Try a compile.** Most codebases require nothing more.
 3. **Sweep** — if Phase 2 surfaced failures, walk the M-rules in order. Apply Type A (mechanical) without asking; flag Type B (judgment-call) for the author.

--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -57,7 +57,9 @@ Exit this skill when the project compiles, tests pass, and Type B items have bee
 
 ## The migration workflow
 
-Six phases. Each links to a leaf for the detail; the SKILL.md carries only the workflow shape.
+A pre-flight gate plus six phases. Each links to a leaf for the detail; the SKILL.md carries only the workflow shape.
+
+**Phase 0 — Pre-flight: the React-19 / Reagent-2 floor gate (run before any dep edit).** re-frame2's substrate adapters target React 19 (the Reagent bridge runs on Reagent 2.x). For a project already on React 19 with a React-19-ready component library this is a fast pass; for the rest of the v1 population (React 17/18 + Reagent 1.x) it is the single largest and riskiest part of the migration, and the blocking case must be discovered *here* — not deep inside a failed compile loop after the coord swap. Run four checks before touching any dep coord: (1) **downstream React-lib compat audit** — enumerate `package.json` deps with a `react`/`react-dom` peer dependency and bucket each as React-19-ready / needs-bump / needs-replacement; (2) **component/substrate-library check** — confirm the project's UI component library has a React-19 (and, if Reagent-based, Reagent-2) release — **if it does not, STOP: this is a go/no-go BLOCKER, surface it to the author before any edit**; (3) **legacy-API scan** — flag surviving `ReactDOM.render` / `react-dom` legacy call sites (removed in React 18, still gone in 19) for the `createRoot` rewrite; (4) **explicit go/no-go** — GO carries the React/Reagent bump into M-0; NO-GO stops the migration until the blocker resolves. → [`references/setup.md`](references/setup.md#the-react-19--reagent-2-floor-gate-pre-flight--run-before-m-0) for the full gate. This is a gate, not a footnote — clear it before Phase 1.
 
 **Phase 1 — Orient.** Read the project's dep file (`deps.edn` / `project.clj` / `shadow-cljs.edn` / `bb.edn`), then [`MIGRATION.md`](../../migration/from-re-frame-v1/README.md) Part 1, then the project's test-suite shape. → [`references/setup.md`](references/setup.md) for the M-0 dep swap.
 
@@ -82,10 +84,11 @@ If the project's dev deps hold `day8.re-frame/re-frame-10x` (the v1 devtools pan
 
 ## Kickoff (paste-ready)
 
-For delegating the migration to a fresh Claude session: [`references/kickoff-prompt.md`](references/kickoff-prompt.md). The author drops it into a session opened in the root of their v1 project; the session loads this skill and walks the six phases, surfacing Type B checkpoints.
+For delegating the migration to a fresh Claude session: [`references/kickoff-prompt.md`](references/kickoff-prompt.md). The author drops it into a session opened in the root of their v1 project; the session loads this skill and walks the pre-flight gate plus six phases, surfacing Type B checkpoints.
 
 ## Done checklist
 
+- [ ] React-19 / Reagent-2 floor gate cleared (Phase 0): downstream React-lib compat audited, component-library React-19 build confirmed (or the blocker resolved/the migration held), legacy `ReactDOM.render` call sites flagged, go/no-go recorded.
 - [ ] `re-frame/re-frame` removed from every dep file; `day8/re-frame2` + adapter at a matching VERSION.
 - [ ] Project compiles cleanly with re-frame2 on the classpath.
 - [ ] Every tripped M-rule has been applied (Type A) or resolved by the author (Type B).

--- a/skills/re-frame-migration/references/kickoff-prompt.md
+++ b/skills/re-frame-migration/references/kickoff-prompt.md
@@ -10,7 +10,7 @@ Steps:
 
 1. The author installs this skill in the project (project-level `.claude/skills/re-frame-migration/`) or globally (`~/.claude/skills/re-frame-migration/`).
 2. The author opens a fresh Claude Code session in the project root.
-3. The author pastes the prompt below verbatim. The session loads the `re-frame-migration` skill on its own (the description triggers it) and walks the six phases from `SKILL.md`.
+3. The author pastes the prompt below verbatim. The session loads the `re-frame-migration` skill on its own (the description triggers it) and walks the pre-flight gate plus the six phases from `SKILL.md`.
 
 ---
 
@@ -22,9 +22,11 @@ Steps:
 >
 > *Target v2 version (load-bearing). The v2 release I want to land on is `<v2-version>`. Use that exact string in every dep coord. Do not auto-select "latest from GitHub"; if `<v2-version>` is unset, stop and ask me.*
 >
+> *Phase 0 — Pre-flight: the React-19 / Reagent-2 floor gate. Before touching ANY dep coord, clear this gate (re-frame2's adapters target React 19; the Reagent bridge runs on Reagent 2.x). Run four read-only checks and report each: (1) downstream React-lib compat audit — bucket each `package.json` dep with a `react`/`react-dom` peer dependency as React-19-ready / needs-bump / needs-replacement; (2) component/substrate-library check — confirm my UI component library has a React-19 (Reagent-2 if Reagent-based) release; if it does NOT, STOP and tell me — that's a go/no-go BLOCKER, not a mid-compile surprise; (3) legacy-API scan — flag surviving `ReactDOM.render` / `react-dom` legacy call sites; (4) go/no-go — GO carries the React/Reagent bump into Phase 2's M-0 pass, NO-GO stops until I resolve the blocker. I run any `npm install`/upgrade. Already on React 19 with a React-19-ready component library? Fast pass — confirm and move on.*
+>
 > *Phase 1 — Orient. Read the dep file (whichever exists: `deps.edn` / `project.clj` / `shadow-cljs.edn` / `bb.edn`), confirm we're actually on `re-frame/re-frame` today, and identify the substrate (assume Reagent unless the codebase shows otherwise). Then load the pinned [`MIGRATION.md`](../../../migration/from-re-frame-v1/README.md) from the local checkout above and skim Part 1's rule index so you know what's available.*
 >
-> *Phase 2 — Apply M-0. Swap `re-frame/re-frame` for `day8/re-frame2` + the substrate-adapter coord (`day8/re-frame2-reagent` for Reagent), at `<v2-version>`. Then **stop**. Print the exact compile command for this project's build tool (`shadow-cljs compile <build>`, `clj -M:dev`, the npm script — whatever fits) and ask me to run it and paste the output. Do **not** run compile/test/smoke commands yourself — that's my loop, not yours (see cardinal rule 10). If the compile is clean, ask me to run the tests. Most codebases require no other changes — verify that before doing more work.*
+> *Phase 2 — Apply M-0 (only if Phase 0 returned GO). Carry the Phase-0 React/Reagent bump (and any component-lib bumps) into this pass, then swap `re-frame/re-frame` for `day8/re-frame2` + the substrate-adapter coord (`day8/re-frame2-reagent` for Reagent), at `<v2-version>`. Then **stop**. Print the exact compile command for this project's build tool (`shadow-cljs compile <build>`, `clj -M:dev`, the npm script — whatever fits) and ask me to run it and paste the output. Do **not** run compile/test/smoke commands yourself — that's my loop, not yours (see cardinal rule 10). If the compile is clean, ask me to run the tests. Most codebases require no other changes — verify that before doing more work.*
 >
 > *Phase 3 — If anything broke. Sweep the failures against the M-rules in [`MIGRATION.md`](../../../migration/from-re-frame-v1/README.md), in the order they're listed. Apply Type A (mechanical) rules without asking. For Type B (judgment-call) rules, identify every affected call site, explain the risk the rule documents, and **wait for my approval** before rewriting. Cite the rule id (`M-N`) for every change.*
 >
@@ -59,11 +61,12 @@ Two common amendments the author may add:
 
 ## Why a kickoff prompt at all
 
-The skill description triggers on a wide range of v1→v2 phrasings, but the **opening shape of the migration** is identical regardless of phrasing — the six phases above. Giving the author a paste-ready prompt:
+The skill description triggers on a wide range of v1→v2 phrasings, but the **opening shape of the migration** is identical regardless of phrasing — the pre-flight floor gate plus the six phases above. Giving the author a paste-ready prompt:
 
 - Locks the workflow shape the first time, so the session doesn't drift mid-migration.
+- Puts the React-19 / Reagent-2 floor gate first, so the blocking component-library case is a go/no-go decision *before* any dep edit — not a surprise mid-compile.
 - Makes the Type B "ask first" rule explicit upfront — the session can't silently rewrite timing-sensitive code.
 - Frames the migration as "bump and verify first" — matching [`MIGRATION.md`](../../../migration/from-re-frame-v1/README.md)'s headline expectation that most codebases need no further changes.
 - Reuses the report format from [`MIGRATION.md`](../../../migration/from-re-frame-v1/README.md) Part 2 so the report stays consistent across migrations.
 
-The prompt is short (under 400 words) so the author doesn't lose anything by pasting it verbatim, but rigid enough that a fresh session executing it walks the migration the same way every time.
+The prompt is compact enough to paste verbatim without losing anything, but rigid enough that a fresh session executing it walks the migration the same way every time.

--- a/skills/re-frame-migration/references/setup.md
+++ b/skills/re-frame-migration/references/setup.md
@@ -1,9 +1,10 @@
 # setup
 
-Operational detail for **M-0 — the dep-coord swap**. This is the precondition for every other rule. Apply this leaf's content first; verify the project compiles; *then* sweep for breakage.
+Operational detail for two early steps: the **React-19 / Reagent-2 floor gate** (the pre-flight that runs *before* any dep edit) and **M-0 — the dep-coord swap** (the precondition for every other rule). Clear the gate first; then apply the coord swap; then verify the project compiles; *then* sweep for breakage.
 
 ## Contents
 
+- The React-19 / Reagent-2 floor gate (pre-flight — run before M-0)
 - The coord swap (M-0)
 - Per-build-tool shapes
 - Picking the substrate-adapter artefact
@@ -13,11 +14,49 @@ Operational detail for **M-0 — the dep-coord swap**. This is the precondition 
 
 ---
 
-## The coord swap (M-0)
+## The React-19 / Reagent-2 floor gate (pre-flight — run before M-0)
 
-### Prerequisites — JS-level deps
+> **This is a go/no-go gate, not a footnote.** Run all four checks below *before* you touch any dep coord. For a codebase already on React 19 it is a fast pass — read the four checks, confirm each, move on. For the rest of the v1 population (overwhelmingly React 17/18 + Reagent 1.x) this gate is the single largest and riskiest part of the whole migration, and the blocking case (check 2) must be discovered here — not deep inside a failed compile loop after the coord swap.
 
-**React 19 is the only supported floor for `day8/re-frame2-reagent`.** The Reagent bridge adapter targets Reagent 2.x, which ships against React 19; Reagent 1.x is no longer supported. The bridge loads `reagent.dom.client` (the `createRoot` path); if the project's `package.json` pins `react`/`react-dom` to 17 or 18, the build either fails at module-resolve time or succeeds and crashes on first render against React-19-only API surfaces. If your `package.json` pins `react` 17 or 18, bump to `^19` in the same M-0 pass:
+**Why this comes first.** re-frame2's substrate adapters target React 19. The `day8/re-frame2-reagent` bridge runs on Reagent 2.x, which ships against React 19 (it loads `reagent.dom.client` — the `createRoot` path); Reagent 1.x is no longer supported. UIx and Helix hit the same floor — all three substrates target React 19. So a v1 codebase on React 17/18 must clear a forced React → 19 (and, for Reagent, Reagent → 2.x) upgrade *and the cascade it drags in* — the component library, React-coupled JS deps, and any hand-rolled render call site — before the coord swap can succeed. If `package.json` still pins `react`/`react-dom` to 17 or 18 when the swap lands, the build either fails at module-resolve time or compiles and then crashes on first render against React-19-only API surfaces.
+
+The four checks, in order:
+
+### Check 1 — Downstream React-lib compatibility audit
+
+Enumerate every `package.json` dependency that declares a `react` or `react-dom` **peer dependency** — these are the JS libraries that will break if React's major version moves under them. Typical culprits in a view-heavy app: animation, toast/notification, portal/modal, drag-and-drop, virtualised-list, date-picker, and chart libraries.
+
+For each one, check its current React-19 support (its published `peerDependencies` range, its release notes, or its changelog). Produce a list with three buckets:
+
+- **Already React-19-compatible** — peer range admits `19` (e.g. `^18 || ^19`, `>=18`). No action.
+- **Needs a bump** — a newer release of the *same* library supports React 19. Note the target version.
+- **Needs a replacement / has no React-19 release** — the library is abandoned or has not shipped React-19 support. This is a blocker dimension; surface it to the author for a decision (upgrade path, replacement library, or hold the migration).
+
+You can list the peer-dependency declarations with a read-only search over the lockfile / installed packages — e.g. `rg -l '"react"' node_modules/*/package.json` (or the package manager's own `why`/`ls` for `react`). The skill enumerates and reports; the **author** runs any `npm install` / upgrade command (cardinal rule 10).
+
+### Check 2 — Component / substrate-library check (the go/no-go BLOCKER)
+
+If the project leans on a **UI component library** — any Reagent-based or React-based component kit (a design-system wrapper, a Reagent component suite, a React component library consumed from CLJS) — confirm it has a release compatible with **React 19** (and, if it is a Reagent component lib, **Reagent 2.x**).
+
+- If it does: note the target version; it joins the Check-1 bump list.
+- **If it does not: STOP. This is a go/no-go blocker.** Do not touch any dep coord. Surface it to the operator/author as an explicit decision: wait for a React-19 release of the component library, replace it, vendor/patch it, or hold the migration. A Reagent component library with no Reagent-2 / React-19 build cannot be carried across the floor, and discovering that *after* the coord swap means unwinding a half-migrated tree. Discover it here.
+
+This is the one check most likely to turn a "cheap coord swap" into a multi-week project — which is exactly why it runs before any edit.
+
+### Check 3 — Legacy React-API scan
+
+Scan the source for surviving hand-rolled React-DOM **legacy** call sites — chiefly `ReactDOM.render` (and `ReactDOM.hydrate` / `ReactDOM.unmountComponentAtNode`). These were removed in React 18 and remain gone in React 19; any survivor must migrate to the `createRoot` API (`react-dom/client`) in the same pass.
+
+Most v1 codebases route their root mount through Reagent and never call `ReactDOM.render` directly, so this is usually empty — but a flag here, found pre-flight, is far cheaper than a runtime crash. A read-only search such as `rg -n 'ReactDOM\.(render|hydrate|unmountComponentAtNode)'` over the source tree surfaces them; flag each for the author.
+
+### Check 4 — Explicit go / no-go
+
+Decide and record the gate outcome before proceeding:
+
+- **GO** — React already at 19 (or cleanly bumpable), and every Check-1/Check-2 library has a React-19-compatible target, and Check-3 is empty or its call sites are slated for the `createRoot` rewrite. Carry the React/Reagent bump and any component-lib bumps into the M-0 pass below, then continue. (For a project already on React 19 with a React-19-ready component library, this is the fast path — the gate adds minutes, not weeks.)
+- **NO-GO** — any Check-2 component library (or a load-bearing Check-1 dep) has no React-19 release. **Stop here.** Do not edit any dep coord. Report the blocker and the options to the author; the migration resumes once the blocker is resolved.
+
+**The React/Reagent bump itself**, once the gate is GO. If `package.json` pins `react`/`react-dom` to 17 or 18, bump both to `^19` (Reagent users are simultaneously on Reagent 2.x — that rides in via the `day8/re-frame2-reagent` adapter, not a separate `package.json` pin unless the project pins Reagent directly):
 
 ```json
 "dependencies": {
@@ -26,9 +65,13 @@ Operational detail for **M-0 — the dep-coord swap**. This is the precondition 
 }
 ```
 
-Then `npm install` (or the project's package manager equivalent) before the first dev build. UIx and Helix users hit the same floor — all three substrates target React 19 — so the bump applies regardless of substrate. If the project is already on React 19, leave it alone; do not downgrade.
+The author then runs `npm install` (or the project's package-manager equivalent) before the first dev build. If the project is already on React 19, leave it alone; do not downgrade.
 
-If the v1 codebase has its own hand-rolled `ReactDOM.render` call surviving anywhere (rare; usually wrapped by Reagent), flag it — `ReactDOM.render` was removed in React 18 and is still gone in React 19; that call site needs to migrate to `createRoot` in the same pass. Most v1 codebases route through Reagent and never see this.
+---
+
+## The coord swap (M-0)
+
+Run this only after the React-19 floor gate above returns **GO**. The dep-coord swap and the React/Reagent bump land in the same M-0 pass.
 
 ### The swap itself
 

--- a/skills/re-frame-migration/spec/design.md
+++ b/skills/re-frame-migration/spec/design.md
@@ -96,7 +96,7 @@ skills/re-frame-migration/
 ├── .claude-plugin/plugin.json     (Claude Code plugin metadata)
 ├── references/
 │   ├── kickoff-prompt.md           (~70 lines)
-│   ├── setup.md                    (~170 lines)
+│   ├── setup.md                    (~215 lines; incl. the React-19 / Reagent-2 floor pre-flight gate)
 │   ├── xray-replaces-10x.md        (~240 lines; devtools swap — re-frame-10x → Xray)
 │   ├── breaking-changes.md         (~150 lines)
 │   ├── sequencing.md               (~150 lines)
@@ -120,7 +120,7 @@ skills/re-frame-migration/
 
 The eleven reference leaves are sized to load on demand without spending context budget on irrelevant detail. Typical migration session loads:
 
-- **Phase 2 (bump-only success)**: `setup.md` + `output-format.md`. ~285 LoC.
+- **Phase 0 + Phase 2 (bump-only success)**: `setup.md` (floor gate + coord swap) + `output-format.md`. ~330 LoC.
 - **Phase 3 (sweep with Type A only)**: `auto-call-site-rewrites.md` + `auto-cross-cutting.md` + `breaking-changes.md` + `sequencing.md` + `output-format.md`. ~960 LoC.
 - **Phase 3 (sweep with Type A + Type B)**: add the relevant `guided-*.md` (typically one; both for cross-surface migrations). ~1,120–1,280 LoC.
 - **Full migration (rare)**: all eleven reference leaves. ~1,850 LoC.


### PR DESCRIPTION
## What

Field-friction fix for the `re-frame-migration` Claude Code skill (bead **rf2-jhysu**, P2).

The **React-19 / Reagent-2 hard floor** is the single largest and riskiest piece of a typical v1→v2 migration — the v1 population overwhelmingly runs React 17/18 + Reagent 1.x, and the real work is the forced React→19 / Reagent→2.x upgrade *and the cascade it drags in* (component library, React-coupled JS deps, hand-rolled render call sites). The skill previously presented this floor as a prerequisite paragraph under M-0 with **no downstream-lib compatibility audit**. An unwary run did the coord swap first and only discovered a blocking component-library incompatibility deep in a failed compile loop.

## Change

Restructured the floor content in `references/setup.md` into a **first-class pre-flight gate** (its own section, run *before* M-0), with four checks:

1. **Downstream React-lib compatibility audit** — enumerate every `package.json` dep declaring a `react`/`react-dom` peer dependency; bucket each as React-19-ready / needs-bump / needs-replacement.
2. **Component/substrate-library check** — confirm the project's UI component library has a React-19 (Reagent-2 if Reagent-based) release. **No build = an explicit go/no-go BLOCKER, surfaced before any dep edit.**
3. **Legacy-API scan** — flag surviving `ReactDOM.render` / `react-dom` legacy call sites (removed in React 18, still gone in 19) for the `createRoot` rewrite. (The old `setup.md` flag, folded into the gate.)
4. **Explicit go/no-go** — GO carries the React/Reagent bump into the M-0 pass; NO-GO stops the migration until the blocker resolves. The cheap-coord-swap optimism is preserved as a fast path for repos already on React 19.

Reflected the new **Phase 0** across the workflow surfaces: `SKILL.md` (workflow + Done checklist + anchor link into the new gate), `references/kickoff-prompt.md` (paste-ready prompt + rationale), `README.md` (phase list), and `spec/design.md` (leaf-inventory LoC figures).

## Generic

Stays general to **any** v1 re-frame repo — no monorepo-internal paths, artefact names, or structure. Only the public `day8/re-frame2-*` Maven target coords appear (the migration's destination, same convention the existing skill already uses). Audit examples are read-only `rg` searches; the **author** runs all `npm install` / build commands (cardinal rule 10).

## Quality gates (green)

- `python scripts/check_skill_redirect_anchors.py` → exit 0
- `python scripts/check_doc_slugs.py` → exit 0 (the new gate anchor `#the-react-19--reagent-2-floor-gate-pre-flight--run-before-m-0` validated against the pymdownx slugifier)
- `python scripts/check_skill_migration_cites.py` → exit 0

Closes rf2-jhysu.