### PR TITLE
feat(xray/testbeds): machine-epochs multi-machine frame-isolated stepper (rf2-q3lfm)

### DIFF
--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -111,7 +111,7 @@ debug without re-running under a debugger:
 | `tools/xray` unit gate | CLJ/CLJS helper, registry, config, shell, trace bus, and panel view tests. Intended default local/CI coverage for Xray internals. |
 | Frame-singleton guard (rf2-1w07r — EPIC closed via rf2-nesy9) | Source-text JVM guard (`frame_singleton_guard_test.clj`, in the `clojure -M:test` gate) flagging the two singleton-class anti-patterns — a bare `{:frame :rf/xray}` / `(rf/subscribe :rf/xray …)` literal, and a global `rf/dispatch` wired to an `:on-*` handler — in any file under `tools/xray/src`. The rf2-nesy9 sweep migrated EVERY panel / modal / static surface to the captured-instance-frame pattern (reg-view-injected `dispatch`, a threaded `dispatch-fn`, a render-time `(rf/current-frame-id)` capture, or a `(rf/frame-handle)` bundle for async/held ops), so the `pending-migration` allowlist is now **EMPTY** — the whole `tools/xray/src` tree is locked clean (an allowlist-honesty test keeps it empty). The few legitimate production-singleton seams (trace-collector `note-suppressed!`, share-URL on-load restore, per-feature `hydrate!` init) target the shell via the named `defaults/default-frame-id` Var, never a bare map literal. The two-instance state-isolation acceptance (distinct tab/mode/focused-epoch per shell) is pinned by the CLJS `two_instance_isolation_cljs_test.cljs`. |
 | Xray browser smoke gate | Existing lightweight browser coverage from `tools/xray/testbeds/two_frame_isolation` (the canonical multi-frame ISOLATION surface — repointed under rf2-wa8my to mount the `standard_epochs` deck twice, one app in two isolated frames `:above` + `:below`) and `tools/xray/testbeds/standard_epochs` (the single-frame deck). Intended default browser smoke coverage. |
-| Xray browser feature gate | New deterministic feature matrix gate described by this spec. It owns direct and failure paths for each matrix row. It can be sharded by panel but should report one matrix. |
+| Xray browser feature gate | New deterministic feature matrix gate described by this spec. It owns direct and failure paths for each matrix row. It can be sharded by panel but should report one matrix. Includes the `machine-epochs multi-machine frame-isolated stepper` scenario (rf2-q3lfm) over the `:examples/machine-epochs` testbed — see §The machine-epochs frame-isolated stepper below. |
 | Xray 20-event/load gate | Explicit or pre-commit/pre-PR stress gate only. It is not default CI. It reuses the feature testbed and runs the row-specific 20-event/load checks. |
 | Production elision gate | Existing implementation production-elision probes plus any Xray-specific release probe proving preload, keybinding, pill, trace collector, and shell are absent under `goog.DEBUG=false`. |
 
@@ -161,6 +161,63 @@ This closes a structural gap: today's coverage matrix tests
 **surfaces** (does the panel render? does the click work?); the
 bug-class column tests **insight delivery** (does the surface answer
 the question the user came in with?).
+
+## The machine-epochs frame-isolated stepper (rf2-q3lfm)
+
+The `:examples/machine-epochs` testbed (port 8033,
+`tools/xray/testbeds/machine_epochs/`) is the MULTI-MACHINE,
+FRAME-ISOLATED state-machine stepper. It is a testbed surface that
+CONSUMES the existing Xray frame-switcher contract
+(`:rf.xray/select-frame`, `018-Event-Spine.md` §Frame dropdown +
+`frame_switcher.cljs`) — it adds **no new Xray contract**; this section
+documents the testbed's shape so the browser feature gate's
+`machine-epochs multi-machine frame-isolated stepper` scenario has a
+normative reference.
+
+**Shape.** Eight machine domains (door · traffic · quiz · brew ·
+session · fuse · hvac · media) each run in their OWN frame
+(`:machine/<track>`) and own their OWN Xray epoch ring. A left-rail
+PICKER selects a track; selecting a track:
+
+1. sets the SHELL frame's (`:rf/default`) runner bookkeeping
+   (`:rf.runner/selected` + per-track `:rf.runner/cursors`),
+2. LAZILY creates the track's `:machine/<track>` frame on first entry
+   (`rf/reg-frame` with an `:on-create` boot event — BOOT-ON-SELECT, so
+   the first observed epoch is the machine's START cascade), and
+3. re-points Xray at that frame via the host-facing focus channel
+   (`day8.re-frame2-xray.focus/focus!` with `{:frame :machine/<track>}`,
+   which fires `:rf.xray/select-frame`), so the Epoch panel cascade,
+   the time-travel scrubber, the App-db panel, and the Machine Inspector
+   all show ONLY that machine's isolated arc.
+
+**Stepping.** A step writes the per-track cursor in the SHELL (not
+observed) and dispatches the step's machine event INTO the machine
+frame (`{:frame :machine/<track>}`) — two epochs: a shell cursor write
++ the machine cascade in the machine frame (observed). The cursor and
+selection live in app-db (events + subs), not Reagent atoms (rf2-5sjbg).
+
+**Restart** resets the selected track's machine frame
+(`rf/reset-frame!` = destroy + re-`reg-frame` with the same
+`:on-create`), so the ring clears and the machine re-arcs from boot;
+the track cursor clears. The fuse track's boot-on-select THROWS (its
+initial `:entry` action throws on boot) — that is the sole
+machine-action-exception trigger.
+
+**Isolation invariant (the lens).** Each machine's progression is a
+clean scrubbable arc in its own ring — switching switches WHICH
+isolated arc Xray shows, never interleaving, including across
+switch-and-return (pick A → step → pick B → step → return to A: A's
+ring is intact and resumes). The browser feature gate asserts this with
+a cross-frame flip + a per-track frame-snapshot read
+(`:machine/<track>` app-db, not `:rf/default`).
+
+**Localized runner.** The multi-track / frame-per-machine machinery is
+machine-epochs-LOCAL (the deck's own ns); the shared `runner.core`
+(consumed by the five single-track decks) is UNCHANGED — the deck
+reuses its host-frame + cross-frame-dispatch idiom as a building block
+only. The CLJS render-fidelity harness
+(`panels.epoch.machine-epochs-harness-cljs-test`) drives the substrate
+directly and is decoupled from this view.
 
 ## Cross-references
 

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -2918,16 +2918,16 @@ async function runRoutesEpochs(page, state) {
 //
 // What this scenario can / cannot assert:
 // —————————————————————————————————————————————————————————————
-// The deck OWNS its `:door/main` + `:traffic/light` machines and drives
-// them through the REAL `reg-machine` + machine-event-routing surface, so
-// every rung's machine FEATURE (plain transition · entry/exit data delta ·
-// guard pass vs fail · parallel-region broadcast · ignored event) is
-// genuinely exercised and is observable in the host's `:rf/default`
-// app-db machine snapshots, read directly via the public
-// `re-frame.core/app-db-value` accessor (rf2-5sgwn — the deck's on-page
-// status strip was removed; `readMachineStrip` now reads the substrate
-// snapshot and reconstructs the same text). We assert those snapshot
-// facts — they are the robust, non-flaky proof each machine feature fired.
+// rf2-q3lfm — the deck OWNS all 8 machine domains and drives each through the
+// REAL `reg-machine` + machine-event-routing surface, but each domain now
+// runs in its OWN frame (`:machine/<track>`). Every step's machine FEATURE
+// (plain transition · entry/exit data delta · guard pass vs fail ·
+// parallel-region broadcast · ignored event · microstep · timer · spawn ·
+// deep-compound LCA · history) is genuinely exercised and is observable in
+// THAT track's frame app-db machine snapshot, read directly via the public
+// `re-frame.core/app-db-value` accessor (`readTrackSnapshots`, scoped to
+// `:machine/<track>`). We assert those per-frame snapshot facts — they are
+// the robust, non-flaky proof each machine feature fired in its own frame.
 //
 // We additionally open the Machines tab and confirm `rf-xray-machine-
 // inspector` mounts on a focused machine event, plus that machine activity
@@ -2942,45 +2942,47 @@ async function runRoutesEpochs(page, state) {
 // deck's job is the real-machine-feature step-up surface, asserted through
 // the substrate snapshot + the panel handoff.
 
-// Drive a deck step by its (1-based) ladder rung number.
+// rf2-q3lfm — the deck was reworked into a MULTI-MACHINE, FRAME-ISOLATED
+// stepper. Each machine domain now lives in its OWN frame (`:machine/<id>`)
+// and the left rail is a PICKER: selecting a track
+// (`machine-epochs-track-<id>`) shows its step path AND re-points Xray at
+// that machine's frame. The per-track step rows are still RANDOM-ACCESS
+// RUN-THIS-STEP buttons (`machine-epochs-step-<n>-run`, n = 0-based index
+// WITHIN the selected track's path), so this scenario first selects a track,
+// then drives that track's steps by their per-track index.
 //
-// rf2-kipb5 — the deck was converted to the shared queued-step runner
-// (`runner.core`). It no longer mounts a bespoke `machine-epochs-rung-<n>`
-// button per rung; instead the runner renders one step row per step, and
-// each row's index is a RANDOM-ACCESS RUN-THIS-STEP button
-// (`machine-epochs-step-<n>-run`, n = 0-based step index). The runner's
-// per-step run affordance is exactly the random-access addressing this
-// scenario needs — it drives steps OUT OF ORDER at the end (re-driving the
-// fresh-transition / unhandled-no-op / boot-entry-throw steps for the
-// Inspector + throw/no-op-contrast handoff), which the runner's sequential
-// cursor alone could not provide.
-//
-// The scenario keeps the historical 1-based rung vocabulary (rung 1 = the
-// first step) and maps it onto the 0-based runner step index here, so every
-// call site below reads unchanged. The step ORDER is identical to the old
-// ladder (same events, same machine features); only the driving affordance
-// moved to the runner.
-async function clickMachineRung(page, n) {
-  await clickTestId(page, `machine-epochs-step-${n - 1}-run`);
+// Select a track by its id (`:door` -> `machine-epochs-track-door`). The
+// select boots the track's machine(s) into its frame (boot-on-select) and
+// re-points Xray, so the track's first observed epoch is its START cascade.
+async function selectMachineTrack(page, trackId) {
+  await clickTestId(page, `machine-epochs-track-${trackId}`);
+  // The step panel re-renders for the selected track.
+  await expectVisible(page.locator('[data-testid="machine-epochs-panel"]'), 5000);
 }
 
-// Read every machine's snapshot directly from the host's `:rf/default`
-// app-db and reconstruct a `state … · tags …` text for each machine — the
-// robust, non-flaky proof each machine feature landed its configuration.
+// Drive step `n` (0-based, within the currently-selected track's path) via
+// its RUN-THIS-STEP button.
+async function clickMachineStep(page, n) {
+  await clickTestId(page, `machine-epochs-step-${n}-run`);
+}
+
+// Restart the currently-selected track (resets its machine frame's ring +
+// re-arcs from boot).
+async function restartMachineTrack(page) {
+  await clickTestId(page, 'machine-epochs-restart');
+}
+
+// Read one machine's snapshot directly from its OWN `:machine/<track>` frame
+// app-db (rf2-q3lfm — per-machine frame isolation; snapshots no longer live
+// in `:rf/default`). Reconstructs the same `state … · tags …` text the old
+// `:rf/default` strip produced, scoped to the given track's frame, so the
+// per-machine assertions below read robustly. Returns `{ mounted, ... }`.
 //
-// rf2-5sgwn — the deck's `machine-epochs-status-strip` (and the deck subs
-// it consumed) were removed: the Xray Epoch panel + Machine Inspector are
-// the on-screen read-out, not a host strip. The snapshot is the canonical
-// machine state — `[:rf/machine <id>]` is just `(get-in db [:rf/runtime
-// :machines :snapshots <id>])` — so this helper reads it through the
-// PUBLIC `re-frame.core/app-db-value` accessor and `pr-str`s the same
-// fields the strip rendered. The reconstructed `stripText` keeps every
-// existing rung-assertion regex working unchanged; the per-machine
-// `*State` fields feed the `state.machineEpochs` record. This is the
-// robust, non-flaky proof each machine feature fired, decoupled from any
-// deck view.
-async function readMachineStrip(page) {
-  return page.evaluate(() => {
+// `trackId` is the track name (e.g. 'door', 'media'); the frame id is
+// `:machine/<trackId>`. `machineIds` is the set of machine-ids the track
+// boots into that one frame (media boots two).
+async function readTrackSnapshots(page, trackId, machineIds) {
+  return page.evaluate(({ trackId, machineIds }) => {
     const cljs = window.cljs && window.cljs.core;
     const rf = window.re_frame && window.re_frame.core;
     if (!cljs || !rf || typeof rf.app_db_value !== 'function') {
@@ -2998,9 +3000,8 @@ async function readMachineStrip(page) {
         ? cljs.keyword.call(null, trimmed)
         : cljs.keyword(trimmed);
     }
-    const db = rf.app_db_value(keyword(':rf/default'));
-    if (db == null) return { mounted: false, reason: 'no :rf/default app-db' };
-    // Snapshot path: [:rf/runtime :machines :snapshots <machine-id>].
+    const db = rf.app_db_value(keyword(`:machine/${trackId}`));
+    if (db == null) return { mounted: false, reason: `no :machine/${trackId} app-db` };
     function snapshot(machineId) {
       const path = cljs.PersistentVector.fromArray([
         keyword(':rf/runtime'), keyword(':machines'),
@@ -3019,321 +3020,317 @@ async function readMachineStrip(page) {
     function pr(v) {
       return v == null ? 'nil' : cljs.pr_str(v);
     }
-    // Reconstruct one strip row: "<label> state: <state> · tags: <tags>".
-    function row(label, machineId) {
-      const snap = snapshot(machineId);
-      const state = field(snap, ':state');
-      const tags = field(snap, ':tags');
-      return `${label} state: ${pr(state)} · tags: ${pr(tags)}`;
+    const lines = [];
+    for (const mid of machineIds) {
+      const snap = snapshot(mid);
+      lines.push(`${mid} state: ${pr(field(snap, ':state'))} · tags: ${pr(field(snap, ':tags'))}`);
+      lines.push(`${mid} data: ${pr(field(snap, ':data'))}`);
+      lines.push(`${mid} :rf/history: ${pr(field(snap, ':rf/history'))}`);
     }
-    const doorData = field(snapshot(':door/main'), ':data');
-    const quizData = field(snapshot(':quiz/scorer'), ':data');
-    const mediaDeepHistory = field(snapshot(':media/deep'), ':rf/history');
-    const mediaShallowHistory = field(snapshot(':media/shallow'), ':rf/history');
-    const lines = [
-      row(':door/main', ':door/main'),
-      `:door/main data: ${pr(doorData)}`,
-      row(':traffic/light', ':traffic/light'),
-      row(':quiz/scorer', ':quiz/scorer'),
-      `:quiz/scorer data: ${pr(quizData)}`,
-      row(':brew/machine', ':brew/machine'),
-      row(':session/flow', ':session/flow'),
-      `:session/flow data: ${pr(field(snapshot(':session/flow'), ':data'))}`,
-      row(':hvac/controller', ':hvac/controller'),
-      row(':media/deep', ':media/deep'),
-      `:media/deep :rf/history: ${pr(mediaDeepHistory)}`,
-      row(':media/shallow', ':media/shallow'),
-      `:media/shallow :rf/history: ${pr(mediaShallowHistory)}`,
-    ];
     const stripText = lines.join(' ').replace(/\s+/g, ' ').trim();
-    function stateText(label, machineId) {
-      const state = field(snapshot(machineId), ':state');
-      return `${label} state: ${pr(state)}`;
-    }
-    return {
-      mounted: true,
-      stripText,
-      doorState: stateText(':door/main', ':door/main'),
-      trafficState: stateText(':traffic/light', ':traffic/light'),
-      quizState: stateText(':quiz/scorer', ':quiz/scorer'),
-      brewState: stateText(':brew/machine', ':brew/machine'),
-      sessionState: stateText(':session/flow', ':session/flow'),
-      hvacState: stateText(':hvac/controller', ':hvac/controller'),
-      sessionData: pr(field(snapshot(':session/flow'), ':data')),
-    };
-  });
+    return { mounted: true, stripText };
+  }, { trackId, machineIds });
 }
 
+// Convenience: wait until a track's reconstructed snapshot text matches a
+// predicate.
+async function waitForTrackSnapshot(page, trackId, machineIds, pred, description) {
+  return waitForValue(
+    () => readTrackSnapshots(page, trackId, machineIds),
+    (snap) => snap.mounted && pred(snap.stripText || ''),
+    { timeoutMs: 10000, description },
+  );
+}
+
+// (rf2-q3lfm — the old single-`:rf/default` `readMachineStrip` is gone; the
+// per-machine-frame `readTrackSnapshots` above is the snapshot reader now,
+// since each machine's snapshot lives in its own `:machine/<track>` frame.)
+
 async function runMachineEpochs(page, state) {
-  // The deck's `run` bootstraps every machine, so the snapshots are
-  // populated immediately. Assert the door booted to :locked before driving
-  // the ladder. Each rung's machine FEATURE is asserted off the host's
-  // `:rf/default` app-db machine snapshot (read directly via
-  // `re-frame.core/app-db-value` in `readMachineStrip`) after each
-  // cascade; the deep RENDER-FIDELITY assertions (cascade kinds/order,
-  // microsteps, timer-cancel, spawn/destroy, set-diff, throw-as-error) live
-  // in the CLJS unit test
+  // rf2-q3lfm — the MULTI-MACHINE, FRAME-ISOLATED stepper. Each machine
+  // domain runs in its OWN frame (`:machine/<track>`); the left rail is a
+  // PICKER that, on select, boots the track's machine(s) (boot-on-select) AND
+  // re-points Xray at that frame. We SELECT a track, then drive its per-track
+  // step rows by their 0-based index WITHIN the track, asserting each step's
+  // machine FEATURE off THAT track's frame snapshot (`readTrackSnapshots`,
+  // reading `:machine/<track>`). The deep RENDER-FIDELITY assertions (cascade
+  // kinds/order, microsteps, timer-cancel, spawn/destroy, set-diff,
+  // throw-as-error) live in the CLJS unit test
   // `panels.epoch.machine-epochs-harness-cljs-test` per the Causa/Story-as-
-  // CLJS rule. Here we confirm each rung lands the expected configuration
-  // WITHOUT contradiction (the browser-side legibility sanity check) and the
-  // Machine Inspector mounts on a focused machine event.
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => snap.mounted && /:door\/main state: :locked/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: 'machine-epochs door machine boots to :locked' },
+  // CLJS rule. Here we confirm each step lands the expected configuration in
+  // its OWN frame, prove the per-machine frame isolation with a cross-frame
+  // flip, and confirm the Machine Inspector mounts.
+
+  // The deck auto-selects :door on boot, so its frame should already exist +
+  // be booted to :locked.
+  await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :locked/.test(t),
+    'machine-epochs door track auto-selected + booted to :locked',
   );
 
-  // ===== Door (FLAT) =====================================================
-  // #1 start machine — bootstrap re-fires; door stays :locked.
-  await clickMachineRung(page, 1);
+  // ===== Door (FLAT) — select the track, drive its path ==================
+  await selectMachineTrack(page, 'door');
 
-  // #2 plain transition — :locked -> :closed.
-  await clickMachineRung(page, 2);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:door\/main state: :closed/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#2 insert-coin -> door :closed' },
+  // step 0 plain transition — :locked -> :closed.
+  await clickMachineStep(page, 0);
+  await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :closed/.test(t),
+    'door#0 insert-coin -> :closed',
   );
 
-  // #3 entry + exit actions — :closed -> :open; :open's :entry bumps
-  //    :opened-count to 1.
-  await clickMachineRung(page, 3);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) =>
-      /:door\/main state: :open/.test(snap.stripText || '') &&
-      /:opened-count 1/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#3 push -> door :open + :opened-count 1' },
+  // step 1 entry + exit actions — :closed -> :open; :open's :entry bumps
+  //   :opened-count to 1.
+  await clickMachineStep(page, 1);
+  await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :open/.test(t) && /:opened-count 1/.test(t),
+    'door#1 push -> :open + :opened-count 1',
   );
 
-  // #4 guard ALLOWED — :open -> :closed.
-  await clickMachineRung(page, 4);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:door\/main state: :closed/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#4 close -> guard allowed, door :closed' },
+  // step 2 guard ALLOWED — :open -> :closed.
+  await clickMachineStep(page, 2);
+  await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :closed/.test(t),
+    'door#2 close -> guard allowed, :closed',
   );
 
-  // #5 guard BLOCKED — re-open, arm :held-open?, attempt close. Guard FAILS,
-  //    door STAYS :open + the hold flag remains set.
-  await clickMachineRung(page, 5);
-  const afterBlocked = await waitForValue(
-    () => readMachineStrip(page),
-    (snap) =>
-      /:door\/main state: :open/.test(snap.stripText || '') &&
-      /:held-open\? true/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#5 reopen-hold-close -> guard blocked, door STAYS :open' },
+  // step 3 guard BLOCKED — re-open, arm :held-open?, attempt close. Guard
+  //   FAILS, door STAYS :open + the hold flag remains set.
+  await clickMachineStep(page, 3);
+  const afterBlocked = await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :open/.test(t) && /:held-open\? true/.test(t),
+    'door#3 reopen-hold-close -> guard blocked, STAYS :open',
   );
 
-  // #6 transition-with-effect — :open -> :alarming; :enter-alarm's :fx
-  //    dispatches :alarm-acknowledged.
-  await clickMachineRung(page, 6);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:door\/main state: :alarming/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#6 trip -> door :alarming' },
+  // step 4 transition-with-effect — :open -> :alarming; :enter-alarm's :fx
+  //   dispatches :alarm-acknowledged.
+  await clickMachineStep(page, 4);
+  await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :alarming/.test(t),
+    'door#4 trip -> :alarming',
   );
 
-  // #7 unhandled -> benign no-op — insert-coin into :alarming has no :on
-  //    entry; the door STAYS :alarming.
-  await clickMachineRung(page, 7);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:door\/main state: :alarming/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#7 insert-coin into :alarming -> benign no-op' },
+  // step 5 unhandled -> benign no-op — insert-coin into :alarming has no :on
+  //   entry; the door STAYS :alarming.
+  await clickMachineStep(page, 5);
+  await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :alarming/.test(t),
+    'door#5 insert-coin into :alarming -> benign no-op',
   );
 
-  // #8 ROOT :on fallthrough (gap 6) — :alarming has no :door/audit; the
-  //    machine ROOT :on handles it -> :alarming -> :locked.
-  await clickMachineRung(page, 8);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:door\/main state: :locked/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#8 audit -> root :on fallthrough -> door :locked' },
+  // step 6 ROOT :on fallthrough — :alarming has no :door/audit; the machine
+  //   ROOT :on handles it -> :alarming -> :locked.
+  await clickMachineStep(page, 6);
+  await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :locked/.test(t),
+    'door#6 audit -> root :on fallthrough -> :locked',
   );
+
+  // ===== Cross-frame flip acceptance (rf2-q3lfm de-risk) =================
+  // The linchpin of the redesign: switch A -> B -> back to A and confirm each
+  // machine's frame snapshot is ISOLATED. Pick traffic, drive it, return to
+  // door and confirm DOOR's ring/state is intact (:locked, NOT touched by the
+  // traffic steps) — the proof the two frames never interleave.
 
   // ===== Traffic (PARALLEL) =============================================
-  // #9 parallel regions — one tick broadcasts to BOTH regions.
-  await clickMachineRung(page, 9);
-  const afterParallel = await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => {
-      const t = snap.stripText || '';
-      return /:vehicle :green/.test(t) && /:pedestrian :dont-walk/.test(t);
-    },
-    { timeoutMs: 10000, description: '#9 tick -> BOTH regions advanced (vehicle :green + pedestrian :dont-walk)' },
+  await selectMachineTrack(page, 'traffic');
+
+  // step 0 parallel regions — one tick broadcasts to BOTH regions.
+  await clickMachineStep(page, 0);
+  const afterParallel = await waitForTrackSnapshot(
+    page, 'traffic', [':traffic/light'],
+    (t) => /:vehicle :green/.test(t) && /:pedestrian :dont-walk/.test(t),
+    'traffic#0 tick -> BOTH regions advanced (vehicle :green + pedestrian :dont-walk)',
   );
 
-  // #10 history ribbon — a second tick advances both regions again; the
-  //     :tags member swap (gap 7) is asserted in the CLJS harness.
-  await clickMachineRung(page, 10);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => {
-      const t = snap.stripText || '';
-      return /:vehicle :amber/.test(t) && /:pedestrian :walk/.test(t);
-    },
-    { timeoutMs: 10000, description: '#10 second tick -> vehicle :amber + pedestrian :walk' },
+  // step 1 history ribbon — a second tick advances both regions again.
+  await clickMachineStep(page, 1);
+  const afterTraffic = await waitForTrackSnapshot(
+    page, 'traffic', [':traffic/light'],
+    (t) => /:vehicle :amber/.test(t) && /:pedestrian :walk/.test(t),
+    'traffic#1 second tick -> vehicle :amber + pedestrian :walk',
   );
 
-  // #11 multiple machines — one cascade resets the door AND ticks traffic.
-  await clickMachineRung(page, 11);
-  const afterMulti = await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => {
-      const t = snap.stripText || '';
-      return /:door\/main state: :locked/.test(t) && /:vehicle :red/.test(t);
-    },
-    { timeoutMs: 10000, description: '#11 reset door + tick traffic -> door :locked + vehicle :red' },
+  // Switch BACK to door: its frame's snapshot must be UNTOUCHED by the
+  // traffic steps (door is still :locked from its last step) — frame
+  // isolation, the core lens of rf2-q3lfm. Re-selecting resumes door's ring.
+  await selectMachineTrack(page, 'door');
+  const doorAfterReturn = await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :locked/.test(t),
+    'switch-and-return: door frame intact (:locked) after driving traffic — isolation proven',
+  );
+  // And traffic's frame is ALSO intact (still :amber/:walk) — not reset by
+  // returning to door.
+  await waitForTrackSnapshot(
+    page, 'traffic', [':traffic/light'],
+    (t) => /:vehicle :amber/.test(t) && /:pedestrian :walk/.test(t),
+    'switch-and-return: traffic frame intact (:amber/:walk) after returning to door',
   );
 
-  // ===== Quiz (MICROSTEP — :always eventless settle, gap 1) =============
-  // #12 answer below the mark — score climbs, quiz STAYS :asking (0
-  //     microsteps).
-  await clickMachineRung(page, 12);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:quiz\/scorer state: :asking/.test(snap.stripText || '') &&
-              /:score 1/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#12 answer -> :score 1, quiz STAYS :asking (0 microsteps)' },
+  // RESTART door: resets its machine frame (ring clears, re-arcs from boot) —
+  // door returns to :locked and the cursor clears. (Door is already :locked,
+  // so we assert the restart does not crash + the frame re-boots clean.)
+  await restartMachineTrack(page);
+  await waitForTrackSnapshot(
+    page, 'door', [':door/main'],
+    (t) => /:door\/main state: :locked/.test(t),
+    'restart: door frame reset + re-arced from boot (:locked)',
   );
 
-  // #13 answer to the pass mark — the guarded :always chain SETTLES the
-  //     quiz :asking -> :passed over N>0 microsteps (THE biggest gap).
-  await clickMachineRung(page, 13);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:quiz\/scorer state: :passed/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#13 answer to mark -> :always settles quiz :asking -> :passed (microsteps > 0)' },
+  // ===== Quiz (MICROSTEP — :always eventless settle) ====================
+  await selectMachineTrack(page, 'quiz');
+
+  // step 0 answer below the mark — score climbs, quiz STAYS :asking.
+  await clickMachineStep(page, 0);
+  await waitForTrackSnapshot(
+    page, 'quiz', [':quiz/scorer'],
+    (t) => /:quiz\/scorer state: :asking/.test(t) && /:score 1/.test(t),
+    'quiz#0 answer -> :score 1, STAYS :asking (0 microsteps)',
   );
 
-  // ===== Brew (TIMER — :after + cancel, gap 2) ==========================
-  // #14 start brew — schedules the :after timer; brew enters :brewing.
-  await clickMachineRung(page, 14);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:brew\/machine state: :brewing/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#14 start -> :brewing (:after timer scheduled)' },
+  // step 1 answer to the pass mark — the guarded :always chain SETTLES the
+  //   quiz :asking -> :passed over N>0 microsteps.
+  await clickMachineStep(page, 1);
+  const afterQuiz = await waitForTrackSnapshot(
+    page, 'quiz', [':quiz/scorer'],
+    (t) => /:quiz\/scorer state: :passed/.test(t),
+    'quiz#1 answer to mark -> :always settles :asking -> :passed (microsteps > 0)',
   );
 
-  // #15 let the :after timer elapse — auto-fires :brewing -> :ready.
-  await clickMachineRung(page, 15);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:brew\/machine state: :ready/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#15 :after-elapsed -> :brewing -> :ready (auto-fire)' },
+  // ===== Brew (TIMER — :after + cancel) =================================
+  await selectMachineTrack(page, 'brew');
+
+  // step 0 start brew — schedules the :after timer; brew enters :brewing.
+  await clickMachineStep(page, 0);
+  await waitForTrackSnapshot(
+    page, 'brew', [':brew/machine'],
+    (t) => /:brew\/machine state: :brewing/.test(t),
+    'brew#0 start -> :brewing (:after timer scheduled)',
   );
 
-  // #16 re-start then CANCEL — exit beats the timer -> :rf.machine.timer/
-  //     cancelled (:on-exit); brew returns to :idle.
-  await clickMachineRung(page, 16);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:brew\/machine state: :idle/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#16 start+abort -> :after timer cancelled (:on-exit), brew :idle' },
+  // step 1 let the :after timer elapse — auto-fires :brewing -> :ready.
+  await clickMachineStep(page, 1);
+  await waitForTrackSnapshot(
+    page, 'brew', [':brew/machine'],
+    (t) => /:brew\/machine state: :ready/.test(t),
+    'brew#1 :after-elapsed -> :ready (auto-fire)',
   );
 
-  // ===== Session (LIFECYCLE — spawn/final/on-done/destroy, gaps 3,4,5) ==
-  // #17 open session — :idle -> :authenticating SPAWNS the child actor.
-  await clickMachineRung(page, 17);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:session\/flow state: :authenticating/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#17 open -> :authenticating (child :session/login spawned)' },
+  // step 2 re-start then CANCEL — exit beats the timer; brew returns to :idle.
+  await clickMachineStep(page, 2);
+  await waitForTrackSnapshot(
+    page, 'brew', [':brew/machine'],
+    (t) => /:brew\/machine state: :idle/.test(t),
+    'brew#2 start+abort -> :after timer cancelled (:on-exit), :idle',
   );
 
-  // #18 child succeeds — :final + :on-done reports the token to the parent +
-  //     the child auto-destroys. The strip surfaces the parent's :session-token
-  //     (written into its :data by the :on-done callback) — the observable
-  //     proof the callback ran; the auto-destroy / :rf.machine/finished trace
-  //     is asserted in the CLJS harness.
-  await clickMachineRung(page, 18);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:session\/flow state: :authenticating/.test(snap.stripText || '') &&
-              /:session-token/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#18 child :final -> :on-done ran on the parent (data carries :session-token) + child auto-destroyed' },
+  // ===== Session (LIFECYCLE — spawn/final/on-done/destroy) ==============
+  await selectMachineTrack(page, 'session');
+
+  // step 0 open session — :idle -> :authenticating SPAWNS the child actor.
+  await clickMachineStep(page, 0);
+  await waitForTrackSnapshot(
+    page, 'session', [':session/flow'],
+    (t) => /:session\/flow state: :authenticating/.test(t),
+    'session#0 open -> :authenticating (child :session/login spawned)',
   );
 
-  // ===== Fuse (WILDCARD-THROW) — asserted as the throw contrast below ====
-
-  // ===== Hvac (DEEP-COMPOUND) ===========================================
-  // #20 parallel broadcast — ONE :hvac/power-cycle moves BOTH regions;
-  //     :climate descends its deep initial cascade.
-  await clickMachineRung(page, 20);
-  const afterHvacPower = await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => {
-      const t = snap.stripText || '';
-      return /:climate \[:running :conditioning :heating\]/.test(t) &&
-             /:fan :on/.test(t);
-    },
-    { timeoutMs: 10000, description: '#20 power-cycle -> BOTH regions moved (climate deep leaf + fan :on)' },
+  // step 1 child succeeds — :final + :on-done reports the token to the parent
+  //   (data carries :session-token) + the child auto-destroys.
+  await clickMachineStep(page, 1);
+  await waitForTrackSnapshot(
+    page, 'session', [':session/flow'],
+    (t) => /:session\/flow state: :authenticating/.test(t) && /:session-token/.test(t),
+    'session#1 child :final -> :on-done ran on parent (:session-token) + child auto-destroyed',
   );
 
-  // #21 multi-level LCA cascade — :heating -> :cooling crossing the LCA
-  //     :conditioning. The deep compound leaf moves to :cooling (the LCA
-  //     cascade ORDER is pinned in the CLJS harness off the structured
-  //     :cascade).
-  await clickMachineRung(page, 21);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:climate \[:running :conditioning :cooling\]/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#21 mode-toggle -> deep leaf :cooling (crosses the :conditioning LCA)' },
+  // ===== HVAC (DEEP-COMPOUND) ===========================================
+  await selectMachineTrack(page, 'hvac');
+
+  // step 0 parallel broadcast — ONE :hvac/power-cycle moves BOTH regions;
+  //   :climate descends its deep initial cascade.
+  await clickMachineStep(page, 0);
+  const afterHvacPower = await waitForTrackSnapshot(
+    page, 'hvac', [':hvac/controller'],
+    (t) => /:climate \[:running :conditioning :heating\]/.test(t) && /:fan :on/.test(t),
+    'hvac#0 power-cycle -> BOTH regions moved (climate deep leaf + fan :on)',
   );
 
-  // #22 EXTERNAL self-transition (:hvac/nudge) — :target :same-state re-enters
-  //     :on (exit -> entry boundary, asserted in the CLJS harness); fan STAYS
-  //     :on.
-  await clickMachineRung(page, 22);
-  await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:fan :on/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#22 nudge -> external self-transition, fan STAYS :on' },
+  // step 1 multi-level LCA cascade — :heating -> :cooling crossing the LCA
+  //   :conditioning.
+  await clickMachineStep(page, 1);
+  await waitForTrackSnapshot(
+    page, 'hvac', [':hvac/controller'],
+    (t) => /:climate \[:running :conditioning :cooling\]/.test(t),
+    'hvac#1 mode-toggle -> deep leaf :cooling (crosses the :conditioning LCA)',
   );
 
-  // #23 INTERNAL self-transition (:hvac/tweak) — its :tweak-fan action runs
-  //     (bumps :tweaks); no exit/entry boundary (asserted in the CLJS harness);
-  //     fan STAYS :on.
-  await clickMachineRung(page, 23);
-  const afterHvacTweak = await waitForValue(
-    () => readMachineStrip(page),
-    (snap) => /:fan :on/.test(snap.stripText || ''),
-    { timeoutMs: 10000, description: '#23 tweak -> internal self-transition (action-only), fan STAYS :on' },
+  // step 2 EXTERNAL self-transition (:hvac/nudge) — re-enters :on; fan STAYS :on.
+  await clickMachineStep(page, 2);
+  await waitForTrackSnapshot(
+    page, 'hvac', [':hvac/controller'],
+    (t) => /:fan :on/.test(t),
+    'hvac#2 nudge -> external self-transition, fan STAYS :on',
   );
 
-  // ===== History (gap 8 — reject-now) ===================================
-  // #24 register a :history machine — REJECTED today; the deck swallows the
-  //     throw and the door stays put. The rejection shape is asserted in the
-  //     CLJS harness; here we confirm the rung does not crash the deck.
-  await clickMachineRung(page, 24);
-  // #25 (SHALLOW history restore) / #26 (DEEP history restore) are LIVE steps
-  // (rf2-mle6e.5); their full restore-cascade render assertions live in the
-  // CLJS harness (`history-shallow-restore-...` / `history-deep-restore-...`),
-  // which drives the substrate directly. The browser scenario does not need to
-  // re-drive them here — the harness owns that coverage.
+  // step 3 INTERNAL self-transition (:hvac/tweak) — action-only; fan STAYS :on.
+  await clickMachineStep(page, 3);
+  const afterHvacTweak = await waitForTrackSnapshot(
+    page, 'hvac', [':hvac/controller'],
+    (t) => /:fan :on/.test(t),
+    'hvac#3 tweak -> internal self-transition (action-only), fan STAYS :on',
+  );
+
+  // ===== Media (HISTORY) — the placement reject + live restore steps =====
+  // The media track boots BOTH machine-ids (:media/deep + :media/shallow)
+  // into the one media frame. Step 0 drives the placement-rejection probe
+  // (advances no snapshot); steps 1/2 drive the shallow/deep restore — their
+  // full restore-cascade render assertions live in the CLJS harness. Here we
+  // confirm the steps resolve + do not crash the deck, and the two media
+  // machines both booted into the one frame.
+  await selectMachineTrack(page, 'media');
+  await waitForTrackSnapshot(
+    page, 'media', [':media/deep', ':media/shallow'],
+    (t) => /:media\/deep state:/.test(t) && /:media\/shallow state:/.test(t),
+    'media track booted BOTH machine-ids into the one media frame',
+  );
+  await clickMachineStep(page, 0); // placement rejection probe
+  await clickMachineStep(page, 1); // shallow restore
+  await clickMachineStep(page, 2); // deep restore
 
   // ===== Xray Machine Inspector handoff + the throw/no-op contrast ======
   await openXray(page);
 
-  // rf2-4yrr6 / rf2-gl588 — :fuse/box must NOT throw on boot / rungs 1-24.
-  // The reset handler DELIBERATELY does not eager-start :fuse/box (its
-  // initial `:entry` action throws on the boot cascade); rung 19 (clicked
-  // below) lazily boots it and is the SOLE machine-action-exception trigger.
+  // rf2-q3lfm — the FUSE track throws on BOOT (boot-on-select): its initial
+  // :entry action :blow-fuse throws when the fuse frame is created on select.
+  // So the SOLE machine-action-exception trigger is now SELECTING fuse (not a
+  // late "rung 19"). Before selecting fuse, NO machine-action-exception may
+  // have fired from any other track's boot-on-select.
   {
     const bootTrace = await readTrace(page);
     const bootThrow = bootTrace.filter((e) =>
       /:rf\.error\/machine-action-exception/.test(e));
     if (bootThrow.length > 0) {
       failWithDetails(
-        'rf2-4yrr6 — a machine threw on boot / rungs 1-24; rung 19 must be the '
-        + 'sole machine-action-exception trigger',
+        'rf2-q3lfm — a non-fuse track threw a machine-action-exception on its '
+        + 'boot-on-select; only SELECTING the fuse track may throw',
         { machineActionExceptions: bootThrow });
     }
   }
 
+  // Re-select door + drive a fresh transition so the Machine Inspector mounts
+  // on a focused DOOR machine event (door is its own frame).
+  await selectMachineTrack(page, 'door');
   await clearTrace(page);
-  await clickMachineRung(page, 2); // :locked -> :closed — a fresh transition
+  await clickMachineStep(page, 0); // :locked -> :closed — a fresh transition
   await waitForTraceMatch(
     page,
     /:rf\.machine\/transition|:rf\.machine\/guard-evaluated|:door\/main/,
@@ -3343,36 +3340,36 @@ async function runMachineEpochs(page, state) {
   await expectVisible(
     page.locator('[data-testid="rf-xray-machine-inspector"]'), 5000);
 
-  // rf2-ugdas / rf2-e7yhv / rf2-gl588 — the xstate-v5 unhandled-event
-  // CONTRAST. #7 (unhandled event -> benign no-op) emits the benign
-  // :rf.machine.event/unhandled-no-op trace; #19 (an initial `:entry` action
-  // that throws on the lazy boot) emits the REAL
-  // :rf.error/machine-action-exception. The Trace panel shows both; the
-  // inverse pink-wash / epoch-render assertions live in the CLJS harness.
+  // The xstate-v5 unhandled-event CONTRAST. The door's step 5 (unhandled
+  // event -> benign no-op) emits the benign :rf.machine.event/unhandled-no-op
+  // trace; SELECTING the fuse track boots :armed whose :entry action THROWS,
+  // emitting the REAL :rf.error/machine-action-exception. Drive door to
+  // :alarming first so its step-5 unhandled-no-op fires.
   await clickTab(page, 'trace', 'rf-xray-trace');
   await clearTrace(page);
-  await clickMachineRung(page, 7); // unhandled -> benign no-op
+  await clickMachineStep(page, 1); // :closed -> :open
+  await clickMachineStep(page, 4); // :open -> :alarming
+  await clickMachineStep(page, 5); // insert-coin into :alarming -> benign no-op
   await waitForTraceMatch(
     page,
     /:rf\.machine\.event\/unhandled-no-op/,
-    '#7 unhandled event emits the benign :rf.machine.event/unhandled-no-op trace',
+    'door unhandled event emits the benign :rf.machine.event/unhandled-no-op trace',
   );
   await clearTrace(page);
-  await clickMachineRung(page, 19); // initial :entry action THROWS on boot
+  await selectMachineTrack(page, 'fuse'); // boot-on-select: :armed :entry THROWS
   await waitForTraceMatch(
     page,
     /:rf\.error\/machine-action-exception|fuse blown on boot/,
-    '#19 boot :entry-action throw emits :rf.error/machine-action-exception',
+    'selecting fuse boots :armed whose :entry action THROWS -> :rf.error/machine-action-exception',
   );
 
   state.machineEpochs = {
-    blocked: { doorState: afterBlocked.doorState },
-    parallel: { trafficState: afterParallel.trafficState },
-    multi: { doorState: afterMulti.doorState, trafficState: afterMulti.trafficState },
-    // rf2-g27vv — the redesigned matrix: the microstep / timer / lifecycle
-    // rungs' landed configuration plus the hard machine's.
-    quiz:    { quizState: (await readMachineStrip(page)).quizState },
-    hard:    { powerState: afterHvacPower.hvacState, tweakState: afterHvacTweak.hvacState },
+    blocked: { doorText: afterBlocked.stripText },
+    parallel: { trafficText: afterParallel.stripText },
+    trafficFinal: { trafficText: afterTraffic.stripText },
+    isolation: { doorAfterReturn: doorAfterReturn.stripText },
+    quiz: { quizText: afterQuiz.stripText },
+    hard: { powerText: afterHvacPower.stripText, tweakText: afterHvacTweak.stripText },
     inspectorMounted: true,
   };
 }
@@ -3552,27 +3549,33 @@ const SCENARIOS = [
     run: runRoutesEpochs,
   },
   {
-    // rf2-w06op + rf2-g27vv + rf2-kipb5 — machine-epochs assertion-backed
-    // render harness, runner-shaped (driven through `runner.core`'s per-step
-    // RUN-THIS-STEP buttons). Drives the real `reg-machine` + machine-event-
-    // routing surface for the FULL feature x Xray-cascade-render matrix and
-    // asserts each step's machine FEATURE landed via the host's snapshot
-    // mirror: door (plain · entry/exit · guards allowed/blocked · internal ·
-    // effect · unhandled no-op · root-:on RESOLUTION), traffic (parallel
-    // regions · history · tag-set member swap), quiz (:always MICROSTEPS),
-    // brew (:after TIMER + cancel), session (SPAWN · child :final · :on-done ·
-    // DESTROY), fuse (boot :entry THROW), hvac (deep compound · LCA cascade ·
-    // self-transitions), history (placement reject + live shallow/deep restore
-    // — the restore-cascade render is asserted in the CLJS harness). Then opens
-    // the Xray Machine Inspector
-    // (`rf-xray-machine-inspector`) and confirms the panel mounts on a
-    // focused machine event + the no-op/throw trace contrast. The deep
+    // rf2-w06op + rf2-g27vv + rf2-kipb5 + rf2-q3lfm — machine-epochs
+    // assertion-backed render harness, reworked into the MULTI-MACHINE,
+    // FRAME-ISOLATED stepper. Each machine domain runs in its OWN frame
+    // (`:machine/<track>`); the left rail is a PICKER that, on select, boots
+    // the track's machine(s) (boot-on-select) AND re-points Xray
+    // (`:rf.xray/select-frame`) at that frame. The scenario SELECTS each track
+    // then drives its per-track step rows, asserting each step's machine
+    // FEATURE off THAT track's frame snapshot: door (plain · entry/exit ·
+    // guards allowed/blocked · internal · effect · unhandled no-op · root-:on
+    // RESOLUTION), traffic (parallel regions · history · tag-set member swap),
+    // quiz (:always MICROSTEPS), brew (:after TIMER + cancel), session (SPAWN ·
+    // child :final · :on-done · DESTROY), fuse (boot-on-select :entry THROW),
+    // hvac (deep compound · LCA cascade · self-transitions), media (placement
+    // reject + live shallow/deep restore — the restore-cascade render is
+    // asserted in the CLJS harness). It also proves the per-machine frame
+    // ISOLATION with a cross-frame flip (door -> traffic -> back to door:
+    // each frame's snapshot stays intact, never interleaved) + a Restart
+    // (frame reset + re-arc from boot). Then opens the Xray Machine Inspector
+    // (`rf-xray-machine-inspector`) and confirms the panel mounts on a focused
+    // machine event + the no-op/throw trace contrast (the fuse track's
+    // boot-on-select is the SOLE machine-action-exception trigger). The deep
     // RENDER-FIDELITY assertions (cascade kinds/order, microsteps, timer-
     // cancel, spawn/destroy, set-diff, throw-as-error) live in the CLJS unit
     // test `panels.epoch.machine-epochs-harness-cljs-test` per the Causa/
     // Story-as-CLJS rule (the chart-render shim-survival probe stays owned by
     // the `deep machine inspector substrate` scenario).
-    name: 'machine-epochs machine ladder (rf2-g27vv full feature x render matrix: start/transition/entry-exit/guards/internal/effect/unhandled-no-op/root-:on RESOLUTION; parallel regions + history + TAG-SET delta; :always MICROSTEPS; :after TIMER + cancel; SPAWN/:final/:on-done/DESTROY lifecycle; boot :entry THROW; deep-compound LCA + self-transitions; :history reject-now)',
+    name: 'machine-epochs multi-machine frame-isolated stepper (rf2-q3lfm: pick a machine -> Xray follows its own epoch ring; per-track door/traffic/quiz/brew/session/fuse/hvac/media paths; cross-frame flip isolation; restart = frame reset; boot-on-select fuse THROW)',
     url: '/testbeds/machine-epochs/',
     panels: ['machines'],
     coveredRows: ['Machines'],

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -1,99 +1,89 @@
 (ns machine-epochs.core
-  "MACHINE-EPOCHS testbed — the STATE-MACHINE consumer of the shared
-  queued-step RUNNER (`runner.core`). It drives a COMPREHENSIVE,
-  ASSERTION-BACKED machine × Xray-cascade-render REGRESSION SURFACE aimed
-  squarely at the **Epoch panel's EVENT HANDLER machine cascade** + the
-  **Machine Inspector** (`rf-xray-machine-inspector`).
+  "MACHINE-EPOCHS testbed — the MULTI-MACHINE, FRAME-ISOLATED state-machine
+  stepper (rf2-q3lfm). It is the STATE-MACHINE consumer of the shared
+  queued-step RUNNER (`runner.core`) re-expressed as a multi-track picker:
+  each machine domain lives in its OWN frame and owns its OWN Xray epoch
+  ring, and the picker re-points Xray (`:rf.xray/select-frame`) at the
+  selected machine's frame so EVERY observation panel (the Epoch panel
+  cascade, the time-travel scrubber, the App-db panel, the Machine
+  Inspector) shows ONLY that machine's isolated arc.
 
-  ## Shape
+  ## The lens (rf2-q3lfm)
 
-  ONE purple Step button (`machine-epochs-step`) advances the machine ×
-  render-surface matrix one step at a time while the operator watches how
-  the Xray panels render each step; EVERY step row's index is ALSO a
-  RANDOM-ACCESS RUN-THIS-STEP button (`machine-epochs-step-<n>-run`) so any
-  step can be driven directly. The runner (`runner.core`) is the shared
-  harness; this deck supplies a `steps` vector (CODE DATA) + the testid
-  prefix `machine-epochs`. Each step DISPATCHES one event that exercises
-  exactly ONE machine FEATURE × the Xray cascade-render SURFACE it lights
-  up. Title: `Xray Testbed: Machine Epochs`. A Step / per-step click is
-  manual (operator-driven focus — the runner does not pin focus).
+  THE VALUE is seeing the Xray progression for EACH machine IN ISOLATION.
+  All 8 machine domains used to dispatch into ONE frame (`:rf/default`), so
+  they shared ONE epoch ring — a machine's progression was scattered through
+  a global timeline interleaved with seven others (worst in the
+  switch-and-return flow). One frame per machine fixes that at the root:
+  switching switches WHICH isolated arc Xray shows — no interleaving, ever,
+  including across switch-and-return.
 
-  ## The FEATURE × RENDER-SURFACE matrix
+  ## Two layers of frame
 
-  Each step maps (machine feature) × (the Xray cascade-render surface it
-  lights up), and EACH is backed by a CLJS-UNIT ASSERTION in the harness
-  (`day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test`)
-  so re-driving the deck is a real regression test of Xray rendering, not
-  just a visual deck. The harness drives the IDENTICAL machine specs
-  (shared via `machine-epochs.machines`) through the LIVE substrate and
-  asserts BOTH machine outcome AND the Xray cascade-render projection —
-  it is decoupled from THIS view (it drives `dispatch-sync` directly).
+  - SHELL frame (`:rf/default`) — runner bookkeeping + the picker UI. Holds
+    `{:rf.runner/selected <track-id> :rf.runner/cursors {<track-id>
+    <last-run-index>}}`. NOT the observed frame.
+  - PER-MACHINE frames (`:machine/door`, `:machine/traffic`, …) — each holds
+    ONLY that domain's machine snapshot(s) at `[:rf/runtime :machines
+    :snapshots …]` and owns its own epoch ring. This is what Xray observes.
 
-  ## Cascade order is read off the structured `:cascade`
+  ## Event flow
 
-  Cascade ORDER (exit-deepest-first → action @ LCA → entry-shallowest-first,
-  microsteps, the per-region walk) is exposed by the engine's structured
-  `:cascade` off the transition row, so the harness keys its order assertions
-  directly off the Xray-surface projection. The deck has no on-page snapshot
-  read-out; the Xray Inspector / Epoch panel is the read-out (and the actual
-  check), and the harness drives the substrate directly.
+  - SELECT — `:machine-epochs/select <track-id>` sets `:rf.runner/selected`
+    in the shell, LAZILY creates the track's `:machine/<id>` frame (boot on
+    first entry via the frame's `:on-create`), and re-points Xray with
+    `:rf.xray/select-frame :machine/<id>` (through the host-facing
+    `day8.re-frame2-xray.focus/focus!` channel — the same channel the runner
+    uses to pin focus, so the deck never reaches into Xray's `:rf/xray`
+    frame directly).
+  - STEP / RUN-AT — `:machine-epochs/run-step [track-id n]` writes the
+    per-track cursor in the SHELL (not observed) AND dispatches step n's
+    machine `:event` INTO the machine frame (`{:frame :machine/<id>}`). Two
+    epochs: a cursor write in the shell + the machine cascade in the machine
+    frame (observed).
+  - RESTART — `:machine-epochs/restart <track-id>` RESETS the machine frame
+    (`rf/reset-frame!` = destroy + re-`reg-frame` with the same `:on-create`,
+    so the ring clears and re-arcs from boot) and clears the track cursor.
 
-  ## The machine set (each a coherent clean domain; collectively the matrix)
+  ## Boot-on-select (the smaller call, applied — rf2-q3lfm)
 
-    - door     (FLAT)            — plain · entry/exit · transition-action ·
-                                   guard pass/fail · internal · fx ·
-                                   unhandled-no-op · root-`:on` fallthrough
-                                   (TRANSITION RESOLUTION, gap 6).
-    - traffic  (PARALLEL-FLAT)   — parallel regions · history ribbon ·
-                                   TAG-SET delta member-swap (gap 7).
-    - quiz     (MICROSTEP)       — `:always` EVENTLESS microsteps that settle
-                                   over N>0 microsteps (gap 1).
-    - brew     (TIMER)           — `:after` DELAYED transition that auto-fires
-                                   + a path that CANCELS a pending timer (gap 2).
-    - session  (LIFECYCLE)       — SPAWN a child actor → child reaches
-                                   `:final?` firing `:on-done` → auto-DESTROY
-                                   + exit-cascade-on-destroy (gaps 3, 4, 5).
-    - hvac     (DEEP-COMPOUND)   — compound · initial cascade · LCA cascade ·
-                                   internal/external self-transitions.
-    - fuse     (THROW-ON-BOOT)   — initial `:entry` action THROWS on boot
-                                   (exception card + pink-wash; the foil to
-                                   the no-op).
-    - media    (HISTORY, gap 8)  — a `:player` compound owning a `:type
-                                   :history` pseudo-state; shallow + deep
-                                   eject/restore drive the
-                                   `:rf.machine.history/restored` banner + the
-                                   per-`:entry`-step `:source` chip.
+  Selecting a track boots its machine(s) so the FIRST observed epoch is the
+  machine's START cascade — directly answering 'choose a machine and see it
+  start'. Consequence: selecting the FUSE track boots `:armed`, whose
+  `:entry` action THROWS, so selecting fuse shows the exception card
+  immediately (arguably the point of the fuse track). We keep that — the
+  throw is the headline of the fuse arc.
 
-  ## HISTORY steps (gap 8)
+  With boot-on-select, entering a track produces the START epoch
+  automatically as the ring's FIRST entry, so we DROPPED the explicit
+  'start machine' step rows: every track's first observed epoch is its
+  START badge for free (the door step-0 START-badge demo is preserved for
+  all tracks).
 
-    - the PLACEMENT rejection step: a ROOT `:type :history` machine is still
-      rejected (`:rf.error/machine-history-misplaced`) — a pseudo-state must
-      have an owning compound.
-    - SHALLOW history restore: position deep into `:player`, eject (records
-      the direct CHILD), re-insert → restores the recorded child then descends
-      its `:initial` chain. The Epoch cascade shows the
-      `:rf.machine.history/restored` banner (source `:recorded`, shallow).
-    - DEEP history restore: same eject/insert dance on `:media/deep` → restores
-      the FULL nested LEAF path. The banner reads DEEP.
+  ## Tracks (code data — the single source of truth)
 
-  The `:rf/history` snapshot slot is inspectable in the App-db panel (inside
-  `[:rf/runtime :machines :snapshots <id> :rf/history]`).
+  A `tracks` vector replaces the old flat `steps`. Each track is
+  `{:id :label :blurb :machines #{machine-ids} :path [{:label :event :watch}
+  …]}`. `:machines` is a SET so the media track can own TWO machine-ids
+  (`:media/shallow` + `:media/deep`) in one observed domain; `:on-create`
+  boots every machine in the set. The cross-machine fan-out steps of the old
+  deck were DROPPED (Mike ruling 5): every track drives exactly its own
+  domain.
 
-  ## Per-step delta + runner cursor = app-db `:step`
+  ## Localized runner (rf2-q3lfm)
 
-  The runner sets app-db `:step = n` on the run-step epoch; that churn is
-  the per-step App-db / Epoch delta the panels show. The per-step machine
-  feature is the child event the run-step epoch dispatches into the
-  host-frame. The cursor lives in app-db's `:step` slot, written by
-  `runner.core`'s run-step event — NOT a Reagent atom. The deck reads as an
-  ordinary re-frame2 app: app-db + events + subs.
+  The shared `runner.core` is consumed by six decks and stays UNTOUCHED. The
+  multi-track + frame-per-machine machinery is machine-epochs-LOCAL (this
+  ns). We REUSE the shared runner's host-frame + cross-frame-dispatch idiom
+  (`{:frame host-frame}`) as a building block — the multi-machine-observation
+  UX is specific to this deck (the only multi-machine one), so localizing
+  contains blast radius (YAGNI: generalize only if a second deck needs it).
 
-  ## Inline Xray sidecar (preload)
+  ## Idiomatic re-frame2 (rf2-5sjbg)
 
-  Like the `_epochs` trio (standard_epochs / routes_epochs), this deck wires
-  `day8.re-frame2-xray.preload` in shadow-cljs (the `:examples/machine-epochs`
-  build, port 8033); the preload auto-mounts the inline shell into
-  `[data-rf-xray-host]` so every lens reads the single `:rf/default` frame.
+  app-db + events + subs ONLY — no Reagent atoms threaded through views, no
+  frame-ids as view args. The picker rail, the step panel, the cursor, and
+  the selection all read/write app-db through events + subs.
 
   ## Test surface, not tutorial
 
@@ -105,11 +95,13 @@
   No `spec.cjs` lives here. Regression coverage lives in the Xray test
   surface: the CLJS unit test
   `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test`
-  (each step's BOTH-layers assertion, drives the substrate directly) + the
-  feature-matrix gate (`tools/xray/testbeds/feature_matrix/scenarios.cjs` —
-  the `machine-epochs machine ladder` scenario, which drives the runner's
-  per-step RUN-THIS-STEP buttons). The machine specs live in the sibling ns
-  `machine-epochs.machines`, shared with the harness."
+  (drives the substrate directly, decoupled from this view — unchanged by
+  this redesign) + the feature-matrix gate
+  (`tools/xray/testbeds/feature_matrix/scenarios.cjs` — the
+  `machine-epochs machine ladder` scenario, which selects each track then
+  drives its per-step RUN buttons + reads the per-machine frame's snapshot).
+  The machine specs live in the sibling ns `machine-epochs.machines`, shared
+  with the harness."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; State-machines artefact — load-time hook so `reg-machine`,
@@ -120,27 +112,20 @@
             ;; machines artefact's single source of truth for the
             ;; `[:rf/runtime :machines …]` spelling. `:machine-epochs/finish-login`
             ;; resolves the spawned child id through `machine-paths/spawned-path`
-            ;; (parent-id + invoke-id) rather than a literal four-deep vector, so
-            ;; a spawn-registry reshape surfaces at THIS call site (the path
-            ;; constructor moves with it) and the miss-case fails loud.
+            ;; rather than a literal four-deep vector.
             [re-frame.machines.paths :as machine-paths]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-xray.config :as xray-config]
+            ;; The host-facing Xray focus channel — the SAME surface the
+            ;; shared runner uses to pin focus. We use its `:frame` field to
+            ;; re-point Xray at the selected machine's frame
+            ;; (`:rf.xray/select-frame`) without the deck reaching into Xray's
+            ;; own `:rf/xray` frame.
+            [day8.re-frame2-xray.focus :as xray-focus]
             [re-frame.testbed.config :as testbed-config]
-            ;; The shared step-driver runner (rf2-5sjbg). This deck supplies
-            ;; a `steps` vector + registers `:machine-epochs/run-step` via
-            ;; `runner/reg-runner!`; the runner drives the ONE-button series
-            ;; + the per-step run affordance off app-db `:step`.
-            [runner.core :as runner]
             [machine-epochs.machines :as machines])
   (:require-macros [re-frame.core :refer [reg-view]]))
-
-;; ============================================================================
-;; The inspected app frame (rf2-8pbjr — only the app frame is Xray-relevant)
-;; ============================================================================
-
-(def host-frame :rf/default)
 
 ;; ============================================================================
 ;; MACHINE REGISTRATION
@@ -148,39 +133,44 @@
 ;;
 ;; The machine SPECS live in `machine-epochs.machines` (a sibling ns) so the
 ;; assertion harness can `:require` and register the IDENTICAL specs without
-;; pulling in this deck's Reagent mount. That keeps the testbed's machines
-;; and the harness's machines literally the SAME values — a drift between
-;; "what the operator sees" and "what the test drives" is impossible.
+;; pulling in this deck's Reagent mount. Registration is GLOBAL (the spec
+;; registry is shared); the per-machine STATE (snapshots) lives in whichever
+;; frame the machine event is dispatched into — which is exactly the
+;; frame-isolation this deck exploits.
 
 (machines/register-all!)
 
 ;; ============================================================================
-;; APP-DB SEED + the shared send driver
+;; THE SHELL FRAME + PER-MACHINE FRAME IDS
+;; ============================================================================
+
+(def shell-frame
+  "The SHELL frame — runner bookkeeping (`:rf.runner/selected` +
+  `:rf.runner/cursors`) + the picker UI. NOT an observed machine frame."
+  :rf/default)
+
+(defn machine-frame-id
+  "The per-machine frame id for a track. `:door` -> `:machine/door`. Each
+  track gets exactly one frame (even the media track, which boots two
+  machine-ids into that one observed frame)."
+  [track-id]
+  (keyword "machine" (name track-id)))
+
+;; ============================================================================
+;; MACHINE EVENTS — the per-track path drivers (one event per path step)
 ;; ============================================================================
 ;;
-;; `:step` is the runner cursor (rf2-5sjbg) — the index of the last-run
-;; step, written by `runner.core`'s run-step event; its churn every step IS
-;; the per-step App-db / Epoch delta (it REPLACES the old `:baseline`
-;; counter). The machines own their own runtime state under
-;; `[:rf/runtime :machines :snapshots …]`.
+;; These are the SAME machine features the old flat deck drove; only the
+;; cross-machine fan-out steps were dropped. A step's `:event` is dispatched
+;; INTO the track's machine frame, so a multi-dispatch helper (e.g.
+;; `:machine-epochs/reopen-then-block`) fans out within that one frame's
+;; cascade — its child `:dispatch`es inherit the frame from the handler's
+;; envelope (Spec 002 §Cascade propagation).
 
-(def initial-db {:step nil})
-
-;; A reusable "send" event-fx: every machine step routes through here so a
-;; step can fan out to one OR several machines in one cascade. `sends` is a
-;; vector of fully-formed machine-event vectors. The per-step App-db delta is
-;; the runner's `:step` write on the parent run-step epoch.
-(rf/reg-event-fx :machine-epochs/send
-  {:doc "Dispatch the supplied machine event(s). The shared driver behind
-         every machine step (a step may fan out to several machines)."}
-  (fn handler-send [{:keys [db]} [_ sends]]
-    {:db db
-     :fx (mapv (fn [send] [:dispatch send]) sends)}))
-
-;; re-open the door (after a close left it :closed), arm the `:held-open?` flag
-;; via the `:door/hold` internal transition, then attempt the guarded close.
-;; The close fails `:may-close?` because the flag is now armed, so the door
-;; STAYS in `:open` and GUARDS RUN shows the failed guard.
+;; re-open the door, arm the `:held-open?` flag via the `:door/hold` internal
+;; transition, then attempt the guarded close. The close fails `:may-close?`
+;; because the flag is armed, so the door STAYS in `:open` and GUARDS RUN
+;; shows the failed guard.
 (rf/reg-event-fx :machine-epochs/reopen-then-block
   {:doc ":door/push (re-open) → :door/hold (arm the guard input) → :door/close.
          The :may-close? guard FAILS, so the close is blocked and the machine
@@ -211,20 +201,9 @@
           [:dispatch [:brew/machine [:brew/abort]]]]}))
 
 ;; drive the spawned :session/login child to its :final? state. The child's
-;; deterministic spawn-id is resolved through `machine-paths/spawned-path`
-;; — the machines artefact's path constructor for the runtime-owned
-;; `[:rf/runtime :machines :spawned <parent> <invoke-id>]` slot the parent's
-;; `:spawn` wrote on entry to :authenticating. The invoke-id is the spawning
-;; state's prefix `[:authenticating]` (no explicit `:spawn-id` on the spec, so
-;; the per-state singleton keys off the state path); the leaf holds the
-;; single-spawn child id directly.
-;;
-;; FAIL LOUD ON A MISS (rf2-4i0ac): the prior literal-vector reach paired with
-;; a `cond->` guard turned a missing slot into a silent no-op — a spawn-registry
-;; reshape (or a deck-ordering regression that runs this step before the spawn)
-;; would no-op the dispatch with no error, and neither the runner nor the
-;; substrate harness would catch the breakage. An `assert` surfaces the miss as
-;; a loud failure at the call site instead.
+;; deterministic spawn-id is resolved through `machine-paths/spawned-path`.
+;; FAIL LOUD ON A MISS (rf2-4i0ac): an `assert` surfaces a missing slot as a
+;; loud failure at the call site rather than a silent no-op.
 (rf/reg-event-fx :machine-epochs/finish-login
   {:doc "Resolve the spawned :session/login child via the machines artefact's
          spawned-path constructor, then dispatch [:succeed <token>] to drive it
@@ -245,9 +224,7 @@
 
 ;; answer twice more so the running score reaches the `:enough?` pass mark (3)
 ;; and the guarded `:always` chain settles `:asking` ──► `:passed` in N>0
-;; microsteps. (The first :quiz/answer step already answered once.) Two answers
-;; in one cascade so the LAST `:answer` is the one whose macrostep carries the
-;; microstep.
+;; microsteps. (The first :quiz/answer step already answered once.)
 (rf/reg-event-fx :machine-epochs/answer-to-pass
   {:doc ":quiz/answer ×2 so the score reaches the pass mark and the guarded
          :always chain fires (microsteps > 0)."}
@@ -256,12 +233,11 @@
      :fx [[:dispatch [:quiz/scorer [:quiz/answer]]]
           [:dispatch [:quiz/scorer [:quiz/answer]]]]}))
 
-;; probe the :history PLACEMENT constraint. History is FIRST-CLASS (rf2-mle6e),
-;; but a :type :history pseudo-state MUST have an owning compound, so a ROOT
-;; :type :history machine throws synchronously at reg-machine time
-;; (:rf.error/machine-history-misplaced). The deck event swallows the throw
-;; (the step's job is to DRIVE the rejection; the harness asserts the throw
-;; shape directly). The per-step delta is the runner's `:step` write.
+;; probe the :history PLACEMENT constraint. A :type :history pseudo-state MUST
+;; have an owning compound, so a ROOT :type :history machine throws
+;; synchronously at reg-machine time (:rf.error/machine-history-misplaced).
+;; The deck event swallows the throw (the step's job is to DRIVE the
+;; rejection; the harness asserts the throw shape directly).
 (rf/reg-event-db :machine-epochs/probe-history-rejection
   {:doc "Attempt to register a ROOT :type :history machine and confirm the
          PLACEMENT constraint rejects it (a pseudo-state needs an owning
@@ -271,17 +247,10 @@
     (assoc db :machine-epochs/history-rejected? (machines/history-rejected?))))
 
 ;; the HISTORY restore dance (rf2-mle6e.5). To make the RESTORE the focal
-;; cascade the operator inspects, the step first POSITIONS the player deep
-;; (`:insert` → `:play` → `:seek` lands it at [:player :playing :mid-track]) and
-;; EJECTS it (recording :player's last config into :rf/history), then fires the
-;; final `:insert` — which is the restore whose cascade carries the
-;; :rf.machine.history/restored banner + the :source-chipped :entry steps. The
-;; restore is the LAST dispatch so it is the headline of the step's epoch.
-;;
-;; SHALLOW (:media/shallow) records the direct child (:playing) and restores
-;; [:player :playing :at-start] (the child descended through its :initial).
-;; DEEP (:media/deep) records + restores the exact leaf [:player :playing
-;; :mid-track]. The two share the driver shape; only the machine-id differs.
+;; cascade, the step first POSITIONS the player deep (`:insert` → `:seek`)
+;; and EJECTS it (recording :player's last config into :rf/history), then
+;; fires the final `:insert` — the restore whose cascade carries the
+;; :rf.machine.history/restored banner + the :source-chipped :entry steps.
 (defn- history-restore-fx
   "The fx vector that positions `machine-id` deep, ejects (records), and
   re-inserts (restores). The trailing :insert is the focal restore."
@@ -310,178 +279,561 @@
      :fx (history-restore-fx :media/deep)}))
 
 ;; ============================================================================
-;; RESET
-;; ============================================================================
-
-(rf/reg-event-fx :machine-epochs/reset
-  {:doc "Re-seed app-db and START every NON-throwing machine to its initial
-         state. Start clean.
-
-         Each `[id [:rf.machine/start]]` is the eager kick (xstate
-         `createActor(m).start()`): per F‴ (rf2-gl588) it runs the
-         initial-entry cascade then STOPS — a PURE init-kick, never re-fed
-         into the transition step.
-
-         :fuse/box is DELIBERATELY NOT started here: its initial state :armed
-         declares an `:entry` action `:blow-fuse` that THROWS on boot, so an
-         eager `[:fuse/box [:rf.machine/start]]` would raise during the
-         initial-entry cascade and pollute the clean reset. The fuse box
-         throws ONLY when its step presses it — its first real event lazily
-         boots :armed, whose `:entry` throws. Net: clean boot."}
-  (fn handler-reset [_ _ev]
-    {:db initial-db
-     :fx (mapv (fn [id] [:dispatch [id [:rf.machine/start]]])
-               [:door/main :traffic/light :quiz/scorer :brew/machine
-                :session/flow :hvac/controller :media/deep :media/shallow])}))
-
-;; ============================================================================
-;; THE STEP VECTOR — code data (the single source of truth)
+;; PER-TRACK BOOT EVENTS — each frame's `:on-create` (boot-on-select)
 ;; ============================================================================
 ;;
-;; The deck reads NO machine snapshots on-page — the Xray Epoch panel +
-;; Machine Inspector are the read-out, and the harness drives the substrate
-;; directly. So this deck registers no on-page subs; the runner reads the
-;; shared `:rf.runner/step` sub for its highlight + counter.
+;; A track's machine frame is created lazily on first SELECT via
+;; `rf/reg-frame :machine/<id> {:on-create [<boot-event>]}`. The boot event
+;; runs synchronously IN the new frame, so its initial-entry cascade is the
+;; ring's FIRST observed epoch — the machine's START badge. `reset-frame!`
+;; (RESTART) re-runs the SAME `:on-create`, so a restart re-arcs from boot.
 ;;
-;; Each step: {:event [...] :watch "<what to look for>" :label "<short row
-;; label>"}. The runner renders :watch per STEP; pressing Step (or a per-row
-;; RUN button) dispatches `[:machine-epochs/run-step n]`, which sets app-db
-;; `:step = n` (the per-step delta) and dispatches the step's `:event` into
-;; the host-frame. Manual stepping needs no pacing — each machine fires its
-;; own `:after` timers / cascades on its own schedule while the operator
-;; watches (rf2-5sjbg dropped the settle machinery). The events are the SAME
-;; ones the bespoke ladder drove (the machine FEATURES are unchanged).
+;; `[id [:rf.machine/start]]` is the eager kick (xstate `createActor().start()`):
+;; per F‴ (rf2-gl588) it runs the initial-entry cascade then STOPS — a PURE
+;; init-kick, never re-fed into the transition step.
+
+(defn- boot-machines-fx
+  "An :fx vector that starts every machine in `machine-ids` to its initial
+  state. The frame's `:on-create` for a track."
+  [machine-ids]
+  (mapv (fn [id] [:dispatch [id [:rf.machine/start]]]) machine-ids))
+
+(rf/reg-event-fx :machine-epochs/boot-door
+  {:doc "Boot the door machine — its START cascade is the door frame's first
+         observed epoch (the START badge demo, for free)."}
+  (fn [_ _] {:fx (boot-machines-fx [:door/main])}))
+
+(rf/reg-event-fx :machine-epochs/boot-traffic
+  {:doc "Boot the parallel traffic machine — both regions enter their initial
+         leaves in the START cascade."}
+  (fn [_ _] {:fx (boot-machines-fx [:traffic/light])}))
+
+(rf/reg-event-fx :machine-epochs/boot-quiz
+  {:doc "Boot the quiz machine to :asking."}
+  (fn [_ _] {:fx (boot-machines-fx [:quiz/scorer])}))
+
+(rf/reg-event-fx :machine-epochs/boot-brew
+  {:doc "Boot the brew machine to :idle."}
+  (fn [_ _] {:fx (boot-machines-fx [:brew/machine])}))
+
+(rf/reg-event-fx :machine-epochs/boot-session
+  {:doc "Boot the session parent machine to :idle (the child is spawned later
+         by the Session: open step)."}
+  (fn [_ _] {:fx (boot-machines-fx [:session/flow])}))
+
+(rf/reg-event-fx :machine-epochs/boot-fuse
+  {:doc "Boot the fuse machine — its initial state :armed declares an :entry
+         action :blow-fuse that THROWS, so booting fuse raises a real
+         :rf.error/machine-action-exception immediately. The exception card +
+         pink-wash is the headline of the fuse arc (boot-on-select, rf2-q3lfm)."}
+  (fn [_ _] {:fx (boot-machines-fx [:fuse/box])}))
+
+(rf/reg-event-fx :machine-epochs/boot-hvac
+  {:doc "Boot the deep-compound HVAC machine — both regions enter their deep
+         initial leaves in the START cascade."}
+  (fn [_ _] {:fx (boot-machines-fx [:hvac/controller])}))
+
+(rf/reg-event-fx :machine-epochs/boot-media
+  {:doc "Boot BOTH media machines (:media/deep + :media/shallow) into the one
+         media frame — the media track owns two machine-ids in one observed
+         domain (rf2-q3lfm). Both start at :tray."}
+  (fn [_ _] {:fx (boot-machines-fx [:media/deep :media/shallow])}))
+
+;; ============================================================================
+;; THE TRACK CATALOGUE — code data (the single source of truth)
+;; ============================================================================
 ;;
-;; The `:label` carries the section/domain prefix (Door · Traffic · …) so the
-;; flat runner list stays legible without a section-separator concept.
+;; Each track: {:id :label :blurb :machines #{…} :boot <boot-event-id>
+;;              :path [{:label :event :watch} …]}.
 ;;
-;; Step indices are 0-based; the feature-matrix scenario names each step via
-;; the runner's `machine-epochs-step-<n>-run` button (n = step index). The
-;; CLJS harness is INDEPENDENT of this view (it drives the substrate directly),
-;; so it neither reads these testids nor depends on the step ordering.
+;; - `:machines` is a SET (media = two machine-ids in one observed domain).
+;; - `:boot` is the frame's `:on-create` event — runs in the machine frame so
+;;   the START cascade is the ring's first observed epoch (boot-on-select).
+;; - `:path` is the ordered step list. Each step's `:event` is dispatched INTO
+;;   the track's machine frame. The explicit 'start machine' rows of the old
+;;   deck were DROPPED — boot-on-select produces the START epoch for free.
+;;
+;; The 8 domains are the same clean machine features the old flat deck drove;
+;; the cross-machine fan-out steps ('Reset door + tick traffic' and the
+;; multi-machine no-op) were DROPPED (Mike ruling 5).
 
-(def steps
-  [;; -- DOOR (FLAT) — start · transition · entry/exit · effect --
-   {:label "Door: start machine (:rf.machine/start)"
-    :event [:door/main [:rf.machine/start]]
-    :watch "Inspector: the door chart renders; live-highlight lands on :locked. Epoch: a [START] badge (initial state + data) — a pure init-kick, NOT a transition / no-op."}
-   {:label "Door: insert coin (:locked ──► :closed)"
-    :event [:machine-epochs/send [[:door/main [:door/insert-coin]]]]
-    :watch "Focused-transition lens: plain FROM → TO, no guard / no action; cascade = exit→TRANSITION→entry rows."}
-   {:label "Door: push (:closed ──► :open) — entry + exit"
-    :event [:machine-epochs/send [[:door/main [:door/push]]]]
-    :watch "ACTIONS RUN: :closed's :exit (:clear-hold) + :open's :entry (:count-open); snapshot :opened-count++."}
-   {:label "Door: close (:open ──► :closed) — guard ALLOWED"
-    :event [:machine-epochs/send [[:door/main [:door/close]]]]
-    :watch "GUARDS RUN: :may-close? → pass; transition completes to :closed."}
-   {:label "Door: re-open, hold, then close — guard BLOCKED"
-    :event [:machine-epochs/reopen-then-block]
-    :watch "GUARDS RUN: :may-close? → fail (held-open?); state STAYS :open (no branch matches)."}
-   {:label "Door: trip (:open ──► :alarming) — with effect"
-    :event [:machine-epochs/send [[:door/main [:door/trip]]]]
-    :watch "ACTIONS RUN: :enter-alarm → :fx :dispatch → [:alarm-acknowledged] (downstream cascade child)."}
-   {:label "Door: insert coin into :alarming — UNHANDLED no-op"
-    :event [:machine-epochs/send [[:door/main [:door/insert-coin]]]]
-    :watch "Epoch: ONE [NO OP] staying in :alarming row; NO transition row; event row NOT pink — the foil to the throw."}
-   {:label "Door: audit from :alarming — ROOT :on fallthrough"
-    :event [:machine-epochs/send [[:door/main [:door/audit]]]]
-    :watch "Resolution: :alarming has no :door/audit; the ROOT :on handles it → :alarming ──► :locked (deepest-wins fallthrough)."}
+(def tracks
+  [{:id       :door
+    :label    "Door"
+    :blurb    "FLAT — plain · entry/exit · guard pass/fail · internal · fx · unhandled no-op · root-:on fallthrough."
+    :machines #{:door/main}
+    :boot     :machine-epochs/boot-door
+    :path
+    [{:label "Insert coin (:locked ──► :closed)"
+      :event [:door/main [:door/insert-coin]]
+      :watch "Focused-transition lens: plain FROM → TO, no guard / no action; cascade = exit→TRANSITION→entry rows."}
+     {:label "Push (:closed ──► :open) — entry + exit"
+      :event [:door/main [:door/push]]
+      :watch "ACTIONS RUN: :closed's :exit (:clear-hold) + :open's :entry (:count-open); snapshot :opened-count++."}
+     {:label "Close (:open ──► :closed) — guard ALLOWED"
+      :event [:door/main [:door/close]]
+      :watch "GUARDS RUN: :may-close? → pass; transition completes to :closed."}
+     {:label "Re-open, hold, then close — guard BLOCKED"
+      :event [:machine-epochs/reopen-then-block]
+      :watch "GUARDS RUN: :may-close? → fail (held-open?); state STAYS :open (no branch matches)."}
+     {:label "Trip (:open ──► :alarming) — with effect"
+      :event [:door/main [:door/trip]]
+      :watch "ACTIONS RUN: :enter-alarm → :fx :dispatch → [:alarm-acknowledged] (downstream cascade child)."}
+     {:label "Insert coin into :alarming — UNHANDLED no-op"
+      :event [:door/main [:door/insert-coin]]
+      :watch "Epoch: ONE [NO OP] staying in :alarming row; NO transition row; event row NOT pink — the foil to the throw."}
+     {:label "Audit from :alarming — ROOT :on fallthrough"
+      :event [:door/main [:door/audit]]
+      :watch "Resolution: :alarming has no :door/audit; the ROOT :on handles it → :alarming ──► :locked (deepest-wins fallthrough)."}]}
 
-   ;; -- TRAFFIC (PARALLEL) — regions · history · TAG-SET delta (gap 7) --
-   {:label "Traffic: tick (parallel regions)"
-    :event [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]
-    :watch "Inspector: ONE event broadcasts to :vehicle + :pedestrian; chart highlights BOTH active leaves; tags swap members."}
-   {:label "Traffic: tick ×1 more (history ribbon)"
-    :event [:machine-epochs/send [[:traffic/light [:traffic/tick]]]]
-    :watch "Transition-history ribbon accumulates state → state entries; logical-state DELTA box shows :tags member swap (rf2-l0us2)."}
-   {:label "Reset door + tick traffic (two machines, one cascade)"
-    :event [:machine-epochs/send [[:door/main [:door/reset]] [:traffic/light [:traffic/tick]]]]
-    :watch "Inspector: one event transitions BOTH machines; instance selection picks the first in trace order; multi-machine no-op names its machine."}
+   {:id       :traffic
+    :label    "Traffic"
+    :blurb    "PARALLEL — orthogonal regions · history ribbon · TAG-SET delta member-swap."
+    :machines #{:traffic/light}
+    :boot     :machine-epochs/boot-traffic
+    :path
+    [{:label "Tick (parallel regions)"
+      :event [:traffic/light [:traffic/tick]]
+      :watch "Inspector: ONE event broadcasts to :vehicle + :pedestrian; chart highlights BOTH active leaves; tags swap members."}
+     {:label "Tick ×1 more (history ribbon)"
+      :event [:traffic/light [:traffic/tick]]
+      :watch "Transition-history ribbon accumulates state → state entries; logical-state DELTA box shows :tags member swap (rf2-l0us2)."}]}
 
-   ;; -- QUIZ (MICROSTEP) — :always EVENTLESS microsteps (gap 1) --
-   {:label "Quiz: answer — score climbs (microsteps 0)"
-    :event [:machine-epochs/send [[:quiz/scorer [:quiz/answer]]]]
-    :watch "Cascade: the :answer action bumps :score; the :always guard is NOT yet met → 0 microsteps; quiz stays :asking."}
-   {:label "Quiz: answer ×2 more — :always SETTLES (microsteps > 0)"
-    :event [:machine-epochs/answer-to-pass]
-    :watch "Cascade: :answer reaches the pass mark; the guarded :always chain fires → N microstep(s) + the microstep cascade to :passed."}
+   {:id       :quiz
+    :label    "Quiz"
+    :blurb    "MICROSTEP — :always EVENTLESS microsteps that settle over N>0 microsteps."
+    :machines #{:quiz/scorer}
+    :boot     :machine-epochs/boot-quiz
+    :path
+    [{:label "Answer — score climbs (microsteps 0)"
+      :event [:quiz/scorer [:quiz/answer]]
+      :watch "Cascade: the :answer action bumps :score; the :always guard is NOT yet met → 0 microsteps; quiz stays :asking."}
+     {:label "Answer ×2 more — :always SETTLES (microsteps > 0)"
+      :event [:machine-epochs/answer-to-pass]
+      :watch "Cascade: :answer reaches the pass mark; the guarded :always chain fires → N microstep(s) + the microstep cascade to :passed."}]}
 
-   ;; -- BREW (TIMER) — :after delayed transition + cancel (gap 2) --
-   {:label "Brew: start — schedules an :after timer"
-    :event [:machine-epochs/send [[:brew/machine [:brew/start]]]]
-    :watch "Cascade: :idle ──► :brewing; the :after timer is SCHEDULED (no fire yet). Watch the AFTER TIMERS sub-section."}
-   {:label "Brew: let the :after timer ELAPSE (auto-fire)"
-    :event [:machine-epochs/send [[:brew/machine [:rf.machine.timer/after-elapsed 5000 1 [:brewing]]]]]
-    :watch "Cascade: the synthetic :after-elapsed fires → :brewing ──► :ready; DISPATCH row labels 'from :after timer'."}
-   {:label "Brew: re-start then CANCEL — exit beats the timer"
-    :event [:machine-epochs/cancel-brew]
-    :watch "Cascade: re-enter :brewing (schedule) then :brew/abort exits before fire → :rf.machine.timer/cancelled (:on-exit) — the :cancelled chip."}
+   {:id       :brew
+    :label    "Brew"
+    :blurb    "TIMER — :after DELAYED transition that auto-fires + a path that CANCELS a pending timer."
+    :machines #{:brew/machine}
+    :boot     :machine-epochs/boot-brew
+    :path
+    [{:label "Start — schedules an :after timer"
+      :event [:brew/machine [:brew/start]]
+      :watch "Cascade: :idle ──► :brewing; the :after timer is SCHEDULED (no fire yet). Watch the AFTER TIMERS sub-section."}
+     {:label "Let the :after timer ELAPSE (auto-fire)"
+      :event [:brew/machine [:rf.machine.timer/after-elapsed 5000 1 [:brewing]]]
+      :watch "Cascade: the synthetic :after-elapsed fires → :brewing ──► :ready; DISPATCH row labels 'from :after timer'."}
+     {:label "Re-start then CANCEL — exit beats the timer"
+      :event [:machine-epochs/cancel-brew]
+      :watch "Cascade: re-enter :brewing (schedule) then :brew/abort exits before fire → :rf.machine.timer/cancelled (:on-exit) — the :cancelled chip."}]}
 
-   ;; -- SESSION (LIFECYCLE) — spawn · child :final · :on-done · destroy --
-   {:label "Session: open — SPAWN child actor"
-    :event [:machine-epochs/send [[:session/flow [:session/open]]]]
-    :watch "Cascade: :idle ──► :authenticating spawns :session/login child; spawn fx renders; the instance spine spans parent + child."}
-   {:label "Session: child succeeds — :final + :on-done + auto-DESTROY"
-    :event [:machine-epochs/finish-login]
-    :watch "Cascade: drive the child to :final? → :on-done reports the token to the parent → child auto-destroys (exit-cascade-on-destroy + destroyed trace)."}
+   {:id       :session
+    :label    "Session"
+    :blurb    "LIFECYCLE — SPAWN a child actor → child reaches :final? firing :on-done → auto-DESTROY + exit-cascade-on-destroy."
+    :machines #{:session/flow}
+    :boot     :machine-epochs/boot-session
+    :path
+    [{:label "Open — SPAWN child actor"
+      :event [:session/flow [:session/open]]
+      :watch "Cascade: :idle ──► :authenticating spawns :session/login child; spawn fx renders; the instance spine spans parent + child."}
+     {:label "Child succeeds — :final + :on-done + auto-DESTROY"
+      :event [:machine-epochs/finish-login]
+      :watch "Cascade: drive the child to :final? → :on-done reports the token to the parent → child auto-destroys (exit-cascade-on-destroy + destroyed trace)."}]}
 
-   ;; -- FUSE (THROW-ON-BOOT) — initial `:entry` action THROWS on lazy boot --
-   {:label "Fuse: first event to :fuse/box — initial :entry THROWS on boot"
-    :event [:machine-epochs/send [[:fuse/box [:fuse/short-circuit]]]]
-    :watch "Epoch: the first event lazily boots :armed, whose :entry action :blow-fuse THROWS. EXCEPTION card (message + ex-data + coord) attributing the initial :entry action; event row IS pink; cascade-summary :outcome :error."}
+   {:id       :fuse
+    :label    "Fuse"
+    :blurb    "THROW-ON-BOOT — the initial :entry action THROWS on boot (exception card + pink-wash; the foil to the no-op)."
+    :machines #{:fuse/box}
+    :boot     :machine-epochs/boot-fuse
+    :path
+    [{:label "Re-trigger :fuse/box — :entry THROWS again"
+      :event [:fuse/box [:fuse/short-circuit]]
+      :watch "Epoch: selecting fuse ALREADY booted :armed (throw on boot — the headline). This step re-fires :armed's :entry; the EXCEPTION card (message + ex-data + coord) re-renders; event row IS pink; cascade-summary :outcome :error."}]}
 
-   ;; -- HVAC (DEEP-COMPOUND) — compound · LCA cascade · self-transitions --
-   {:label "Hvac: power-cycle (parallel — BOTH regions, deep initial cascade)"
-    :event [:machine-epochs/send [[:hvac/controller [:hvac/power-cycle]]]]
-    :watch "Cascade: ONE event → :climate :idle──►:running (entry+initial cascade to [:running :conditioning :heating]) AND :fan :off──►:on."}
-   {:label "Hvac: mode-toggle (:heating ⇄ :cooling — multi-level LCA cascade)"
-    :event [:machine-epochs/send [[:hvac/controller [:hvac/mode-toggle]]]]
-    :watch "Cascade ORDER: exit :heating (deepest-first) → :swap-mode @ LCA :conditioning → entry :cooling (shallowest-first)."}
-   {:label "Hvac: nudge fan — EXTERNAL self-transition (:target :same-state :reenter? true)"
-    :event [:machine-epochs/send [[:hvac/controller [:hvac/nudge]]]]
-    :watch "Cascade: :fan :on re-enters itself — exit :fan-on → :nudge-fan → entry :fan-on; NO spurious {:on}→{:on} no-op row."}
-   {:label "Hvac: tweak fan — INTERNAL self-transition (omit :target)"
-    :event [:machine-epochs/send [[:hvac/controller [:hvac/tweak]]]]
-    :watch "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to the nudge; NO spurious no-op row."}
+   {:id       :hvac
+    :label    "HVAC"
+    :blurb    "DEEP-COMPOUND — compound · initial cascade · multi-level LCA cascade · internal/external self-transitions."
+    :machines #{:hvac/controller}
+    :boot     :machine-epochs/boot-hvac
+    :path
+    [{:label "Power-cycle (parallel — BOTH regions, deep initial cascade)"
+      :event [:hvac/controller [:hvac/power-cycle]]
+      :watch "Cascade: ONE event → :climate :idle──►:running (entry+initial cascade to [:running :conditioning :heating]) AND :fan :off──►:on."}
+     {:label "Mode-toggle (:heating ⇄ :cooling — multi-level LCA cascade)"
+      :event [:hvac/controller [:hvac/mode-toggle]]
+      :watch "Cascade ORDER: exit :heating (deepest-first) → :swap-mode @ LCA :conditioning → entry :cooling (shallowest-first)."}
+     {:label "Nudge fan — EXTERNAL self-transition (:target :same-state :reenter? true)"
+      :event [:hvac/controller [:hvac/nudge]]
+      :watch "Cascade: :fan :on re-enters itself — exit :fan-on → :nudge-fan → entry :fan-on; NO spurious {:on}→{:on} no-op row."}
+     {:label "Tweak fan — INTERNAL self-transition (omit :target)"
+      :event [:hvac/controller [:hvac/tweak]]
+      :watch "Cascade: ACTION ONLY (:tweak-fan) — no exit, no entry; the foil to the nudge; NO spurious no-op row."}]}
 
-   ;; -- HISTORY (LIVE, gap 8) — first-class shallow + deep restore (rf2-mle6e) --
-   {:label "History: register a ROOT :history machine — REJECTED (placement)"
-    :event [:machine-epochs/probe-history-rejection]
-    :watch "History is FIRST-CLASS; a ROOT :type :history is still rejected :rf.error/machine-history-misplaced (a pseudo-state needs an owning compound)."}
-   {:label "History: SHALLOW restore (:media/shallow eject → re-insert)"
-    :event [:machine-epochs/history-shallow-restore]
-    :watch "Epoch: the :rf.machine.history/restored banner (source :recorded, SHALLOW); restored :entry steps chip 'from history'; restores the CHILD then its :initial."}
-   {:label "History: DEEP restore (:media/deep eject → re-insert)"
-    :event [:machine-epochs/history-deep-restore]
-    :watch "Epoch: the banner reads DEEP; the :entry steps descend to the EXACT recorded leaf [:player :playing :mid-track], each chipped 'from history'."}])
+   {:id       :media
+    :label    "Media (history)"
+    :blurb    "HISTORY — a :player compound owning a :type :history pseudo-state; shallow + deep restore. TWO machine-ids in one frame."
+    :machines #{:media/deep :media/shallow}
+    :boot     :machine-epochs/boot-media
+    :path
+    [{:label "Register a ROOT :history machine — REJECTED (placement)"
+      :event [:machine-epochs/probe-history-rejection]
+      :watch "History is FIRST-CLASS; a ROOT :type :history is still rejected :rf.error/machine-history-misplaced (a pseudo-state needs an owning compound). Drives the rejection; advances no machine snapshot."}
+     {:label "SHALLOW restore (:media/shallow eject → re-insert)"
+      :event [:machine-epochs/history-shallow-restore]
+      :watch "Epoch: the :rf.machine.history/restored banner (source :recorded, SHALLOW); restored :entry steps chip 'from history'; restores the CHILD then its :initial."}
+     {:label "DEEP restore (:media/deep eject → re-insert)"
+      :event [:machine-epochs/history-deep-restore]
+      :watch "Epoch: the banner reads DEEP; the :entry steps descend to the EXACT recorded leaf [:player :playing :mid-track], each chipped 'from history'."}]}])
+
+(def track-by-id
+  "Index `tracks` by `:id` for O(1) lookup in handlers + subs."
+  (into {} (map (juxt :id identity)) tracks))
+
+(def default-track
+  "The track auto-selected on boot so the operator lands on a live arc, not
+  an empty shell (the SHELL-FRAME-FIRST-PAINT smaller call — we auto-select
+  :door)."
+  :door)
 
 ;; ============================================================================
-;; RUNNER WIRING (rf2-5sjbg) — register the deck's run-step event
+;; SHELL APP-DB SEED
+;; ============================================================================
+;;
+;; The shell frame holds runner bookkeeping ONLY: the selected track-id and
+;; the per-track cursors (`{track-id last-run-index}`). Machine snapshots do
+;; NOT live here — each lives in its own `:machine/<id>` frame.
+
+(def initial-shell-db
+  {:rf.runner/selected nil
+   :rf.runner/cursors  {}})
+
+;; Seed the shell bookkeeping (:rf.runner/selected + :rf.runner/cursors).
+;; Machine snapshots do NOT live here — each lives in its own :machine/<id>
+;; frame. `run` dispatch-syncs this at boot before the first paint.
+(rf/reg-event-db :machine-epochs/seed
+  {:doc "Seed the shell frame's runner bookkeeping (:rf.runner/selected +
+         :rf.runner/cursors)."}
+  (fn handler-seed [db _ev]
+    (merge db initial-shell-db)))
+
+;; ============================================================================
+;; LOCAL RUNNER EVENTS — select / step / restart (machine-epochs-LOCAL)
+;; ============================================================================
+;;
+;; These are the deck-local multi-track runner. They do NOT touch the shared
+;; `runner.core`; they REUSE its cross-frame-dispatch idiom (`{:frame …}`) as
+;; a building block.
+
+(defn- ensure-machine-frame!
+  "LAZILY create the track's `:machine/<id>` frame if it does not yet exist,
+  with the track's boot event as `:on-create` (boot-on-select). Idempotent —
+  `rf/frame` returns nil for an unregistered/destroyed frame; a re-select of
+  an already-created frame is a no-op (its ring + cursor are preserved, so
+  switch-and-return RESUMES). Returns the frame id."
+  [track]
+  (let [frame-id (machine-frame-id (:id track))]
+    (when-not (rf/frame-meta frame-id)
+      (rf/reg-frame frame-id {:on-create [(:boot track)]
+                              :doc       (str "machine-epochs observed frame for the "
+                                              (:label track) " track — owns its own "
+                                              "epoch ring + machine snapshot(s).")}))
+    frame-id))
+
+;; SELECT — set the selected track in the SHELL, lazily create + boot its
+;; machine frame, and re-point Xray at that frame. The Xray re-point goes
+;; through the host-facing focus channel (`xray-focus/focus!`), which fires
+;; `:rf.xray/select-frame` into Xray's own `:rf/xray` frame for us — the deck
+;; never reaches into Xray internals.
+(rf/reg-event-fx :machine-epochs/select
+  {:doc "Select a track: set :rf.runner/selected in the shell, lazily create +
+         boot the track's :machine/<id> frame (boot-on-select), and re-point
+         Xray (:rf.xray/select-frame) at that frame so every observation panel
+         shows ONLY that machine's isolated arc."}
+  (fn handler-select [{:keys [db]} [_ track-id]]
+    (if-let [track (track-by-id track-id)]
+      (let [frame-id (ensure-machine-frame! track)]
+        {:db (assoc db :rf.runner/selected track-id)
+         :fx [[:machine-epochs/point-xray-at frame-id]]})
+      {:db db})))
+
+;; The Xray re-point effect — kept as a named fx so the SELECT handler stays
+;; declarative and the one place the deck reaches into Xray is isolated +
+;; testable. `focus!` with only a `:frame` field fires `[:rf.xray/select-frame
+;; <frame-id>]` (re-seeding :target-frame + :epoch-history) without flipping
+;; the operator's chosen L4 tab.
+;;
+;; The :rf/xray frame is lazy-registered by Xray's preload AFTER the host's
+;; rf/init! (mount/auto-open-inline! polls for the adapter then opens). So at
+;; BOOT — when `run` auto-selects :door before Xray has mounted — the frame
+;; may not exist yet. We guard on `(rf/frame-meta :rf/xray)`: pre-mount the
+;; re-point is a no-op (Xray's head-frame default already scopes to the most
+;; recent event's frame, which IS the just-booted machine frame), and any
+;; user SELECT after Xray opens re-points explicitly. This keeps the boot
+;; path from dispatching into an unregistered frame.
+(rf/reg-fx :machine-epochs/point-xray-at
+  (fn [_ctx frame-id]
+    (when (rf/frame-meta :rf/xray)
+      (xray-focus/focus! {:frame frame-id}))))
+
+;; STEP / RUN-AT — write the per-track cursor in the SHELL and dispatch step
+;; n's machine `:event` INTO the machine frame. Two epochs: the cursor write
+;; here (not observed) + the machine cascade in the machine frame (observed).
+;; An out-of-range n (or an unselected/unknown track) is a no-op.
+(rf/reg-event-fx :machine-epochs/run-step
+  {:doc "Run step n of the CURRENTLY SELECTED track: write the per-track cursor
+         in the shell (:rf.runner/cursors), and dispatch step n's machine
+         :event into the track's :machine/<id> frame. The machine cascade is
+         the observed epoch; the cursor write is shell bookkeeping.
+
+         The track is read from :rf.runner/selected, NOT passed by the button —
+         the step rows are always for the selected track, and deriving it from
+         the authoritative shell slot avoids a stale-closure race where a row's
+         click handler still carries the PREVIOUS track right after a select
+         (React commits the new handler asynchronously)."}
+  (fn handler-run-step [{:keys [db]} [_ n]]
+    (let [track-id (:rf.runner/selected db)
+          track    (track-by-id track-id)
+          path     (:path track)]
+      (if (and track (integer? n) (<= 0 n) (< n (count path)))
+        (let [event    (:event (nth path n))
+              frame-id (machine-frame-id track-id)]
+          (assert event (str "machine-epochs track " track-id " step " n " has no :event"))
+          {:db (assoc-in db [:rf.runner/cursors track-id] n)
+           ;; This handler runs in the SHELL frame (it writes the shell
+           ;; cursor), so the machine event can NOT ride envelope inheritance
+           ;; into the observed frame — it must be explicitly re-framed. The
+           ;; dedicated `:machine-epochs/dispatch-into` fx targets the machine
+           ;; frame directly; the cursor write + the machine cascade are two
+           ;; distinct epochs (shell + machine-frame).
+           :fx [[:machine-epochs/dispatch-into [frame-id event]]]})
+        {:db db}))))
+
+;; Cross-frame dispatch fx — dispatch `event` into `frame-id`. The run-step
+;; handler runs in the SHELL frame (it writes the shell cursor), so the
+;; machine event can't ride envelope inheritance; this fx targets the frame
+;; explicitly. This is the deck-local re-expression of the shared runner's
+;; `{:frame host-frame}` idiom for the two-layer (shell + machine) split.
+(rf/reg-fx :machine-epochs/dispatch-into
+  (fn [_ctx [frame-id event]]
+    (rf/dispatch event {:frame frame-id})))
+
+;; RESTART — reset the track's machine frame (destroy + re-`reg-frame` with the
+;; same :on-create, so the ring clears and re-arcs from boot) and clear the
+;; track cursor. The :session track's spawned child is torn down by the frame
+;; destroy (the :rf.machine/destroy cascade on frame teardown). Re-points Xray
+;; at the freshly-reset frame so the operator sees the clean re-boot arc.
+(rf/reg-event-fx :machine-epochs/restart
+  {:doc "Restart the CURRENTLY SELECTED track: RESET its :machine/<id> frame
+         (clears the ring, re-arcs from boot via the frame's :on-create) and
+         clear the track cursor. Re-points Xray at the reset frame. The track
+         is read from :rf.runner/selected (see :machine-epochs/run-step's note
+         on the stale-closure race)."}
+  (fn handler-restart [{:keys [db]} _ev]
+    (let [track-id (:rf.runner/selected db)]
+      (if (track-by-id track-id)
+        (let [frame-id (machine-frame-id track-id)]
+          {:db (update db :rf.runner/cursors dissoc track-id)
+           :fx [[:machine-epochs/reset-frame frame-id]
+                [:machine-epochs/point-xray-at frame-id]]})
+        {:db db}))))
+
+;; Frame-reset fx — `rf/reset-frame!` is destroy + re-reg with the same config
+;; (including :on-create), so the machine re-boots clean. Kept as a named fx
+;; so the RESTART handler stays declarative.
+(rf/reg-fx :machine-epochs/reset-frame
+  (fn [_ctx frame-id]
+    (when (rf/frame-meta frame-id)
+      (rf/reset-frame! frame-id))))
+
+;; ============================================================================
+;; SUBS — selected / per-track cursor / per-track current state (shell)
+;; ============================================================================
+;;
+;; All read the SHELL frame's app-db (the deck root renders in :rf/default).
+;; The per-track current-state sub reads each machine's snapshot from ITS OWN
+;; frame (via the public `re-frame.core/app-db-value` accessor) — the rail
+;; shows the live state of each track without merging frames.
+
+(rf/reg-sub :machine-epochs/selected
+  (fn [db _] (:rf.runner/selected db)))
+
+(rf/reg-sub :machine-epochs/cursor
+  (fn [db [_ track-id]]
+    (get-in db [:rf.runner/cursors track-id])))
+
+(rf/reg-sub :machine-epochs/cursors
+  (fn [db _] (:rf.runner/cursors db)))
+
+(defn- machine-state
+  "Read `machine-id`'s current state from its own frame's app-db (the
+  snapshot's `:state`). Returns nil before the machine has booted (frame not
+  yet created). Reads through the PUBLIC `re-frame.core/app-db-value` — the
+  rail shows live per-track state without reaching across frames in a sub
+  (the read is a one-shot value, not a cross-frame subscription)."
+  [track-id machine-id]
+  (when-let [db (rf/app-db-value (machine-frame-id track-id))]
+    (get-in db (machine-paths/snapshot-path machine-id :state))))
+
+;; ============================================================================
+;; VIEWS — picker rail + selected track's step panel (subscribe + dispatch)
 ;; ============================================================================
 
-(runner/reg-runner! {:id         :machine-epochs/run-step
-                     :steps      steps
-                     :host-frame host-frame})
+(defn- track-progress
+  "A 'n / total' progress label for a track from its cursor."
+  [cursor total]
+  (str (if (nil? cursor) 0 (inc cursor)) " / " total))
 
-;; ============================================================================
-;; VIEWS
-;; ============================================================================
+(reg-view track-rail-row
+  "One row in the left machine-picker rail: the track label, its progress
+  (cursor / total), and its current machine state(s). The selected row is
+  highlighted. Clicking selects the track (`:machine-epochs/select`). The row
+  subscribes to the selection + its own cursor, so only the affected rows
+  re-render on a selection / cursor change."
+  [track]
+  (let [track-id  (:id track)
+        selected  @(subscribe [:machine-epochs/selected])
+        cursor    @(subscribe [:machine-epochs/cursor track-id])
+        selected? (= track-id selected)
+        states    (map (fn [mid] [mid (machine-state track-id mid)]) (:machines track))]
+    [:button {:data-testid (str "machine-epochs-track-" (name track-id))
+              :on-click    #(dispatch [:machine-epochs/select track-id])
+              :style {:display       "block" :width "100%" :text-align "left"
+                      :cursor        "pointer" :margin "0.25em 0"
+                      :padding       "0.5em 0.7em" :border-radius "6px"
+                      :border        (if selected? "1px solid #7C5CFF" "1px solid #e3def9")
+                      :background    (if selected? "#f1ecff" "#fff")
+                      :font-family   "inherit"}}
+     [:div {:style {:display "flex" :justify-content "space-between"
+                    :align-items "baseline" :gap "0.5em"}}
+      [:span {:style {:font-weight "600" :color "#333"}} (:label track)]
+      [:span {:data-testid (str "machine-epochs-track-" (name track-id) "-progress")
+              :style {:font-size "11px" :color "#888"}}
+       (track-progress cursor (count (:path track)))]]
+     [:div {:data-testid (str "machine-epochs-track-" (name track-id) "-state")
+            :style {:font-size "11px" :color "#7C5CFF" :margin-top "0.15em"
+                    :font-family "ui-monospace, monospace"}}
+      (->> states
+           (map (fn [[mid st]] (str (name mid) " " (if (some? st) (pr-str st) "—"))))
+           (interpose " · ")
+           (apply str))]]))
+
+(reg-view track-rail
+  "The left machine-picker rail: one row per track. Selecting a track shows
+  its step path AND re-points Xray at its frame."
+  []
+  [:div {:data-testid "machine-epochs-rail"
+         :style {:flex "0 0 220px"}}
+   [:h3 {:style {:margin "0 0 0.5em 0" :font-size "13px" :color "#555"
+                 :text-transform "uppercase" :letter-spacing "0.04em"}}
+    "Machines"]
+   (for [track tracks]
+     ^{:key (:id track)}
+     [track-rail-row track])])
+
+(reg-view step-row
+  "One step row in the selected track's panel: index + label + :watch. The
+  current row (the last-run cursor) is highlighted. The index is a clickable
+  RUN-THIS-STEP button. Subscribes to the track's cursor itself so only the
+  affected rows re-render."
+  [track-id n step]
+  (let [cursor   @(subscribe [:machine-epochs/cursor track-id])
+        current? (= n cursor)
+        done?    (and (some? cursor) (< n cursor))]
+    [:div {:data-testid (str "machine-epochs-step-" n)
+           :style {:display "grid" :grid-template-columns "auto 1fr"
+                   :gap "0.75em" :align-items "baseline" :margin "0.25em 0"
+                   :padding "0.4em 0.6em" :border-radius "6px"
+                   :border (if current? "1px solid #7C5CFF" "1px solid #eee")
+                   :background (cond current? "#f1ecff" done? "#fafafa" :else "#fff")}}
+     [:button {:data-testid (str "machine-epochs-step-" n "-run")
+               :title "Run this step"
+               ;; Dispatch into the SHELL frame explicitly — a runner control's
+               ;; on-click fires OUTSIDE the React frame-provider context, so an
+               ;; un-targeted dispatch would land on the ambient frame. The
+               ;; run-step handler reads the selected track from shell app-db
+               ;; (not a closed-over arg) + re-frames the machine event into the
+               ;; observed frame via its fx.
+               :on-click #(dispatch [:machine-epochs/run-step n]
+                                    {:frame shell-frame})
+               :style {:font-weight "bold" :cursor "pointer"
+                       :padding "0.1em 0.45em" :border-radius "5px"
+                       :border (if current? "1px solid #7C5CFF" "1px solid #e3def9")
+                       :background (if current? "#7C5CFF" "#fff")
+                       :color (cond current? "#fff" done? "#aaa" :else "#7C5CFF")}}
+      (str (inc n) ".")]
+     [:div
+      [:div {:style {:font-weight "600" :color "#333"}} (:label step)]
+      [:div {:data-testid (str "machine-epochs-step-" n "-watch")
+             :style {:color "#666" :font-size "12px" :margin-top "0.15em"}}
+       "Watch: " (:watch step)]]]))
+
+(reg-view track-panel
+  "The selected track's step panel: a Step + Restart control bar then the
+  step list. Step advances to the NEXT step (wrapping); Restart resets the
+  track's machine frame. Reads the selected track + its cursor off subs."
+  []
+  (let [selected @(subscribe [:machine-epochs/selected])]
+    (if-let [track (track-by-id selected)]
+      (let [track-id (:id track)
+            path     (:path track)
+            total    (count path)
+            cursor   @(subscribe [:machine-epochs/cursor track-id])
+            next-n   (if (or (nil? cursor) (>= (inc cursor) total)) 0 (inc cursor))]
+        [:div {:data-testid "machine-epochs-panel" :style {:flex "1" :min-width 0}}
+         [:div {:style {:margin-bottom "0.5em"}}
+          [:h3 {:style {:margin "0 0 0.15em 0"}} (:label track)]
+          [:p {:style {:margin 0 :color "#666" :font-size "12px"}} (:blurb track)]]
+         [:div {:data-testid "machine-epochs-controls"
+                :style {:display "flex" :gap "0.5em" :align-items "center"
+                        :flex-wrap "wrap" :padding "0.6em 0.75em" :margin "0.5em 0"
+                        :border "1px solid #cfc8ff" :border-radius "8px"
+                        :background "#faf8ff"}}
+          [:button {:data-testid "machine-epochs-step"
+                    :on-click #(dispatch [:machine-epochs/run-step next-n]
+                                         {:frame shell-frame})
+                    :style {:padding "0.45em 0.9em" :cursor "pointer"
+                            :border "1px solid #7C5CFF" :border-radius "6px"
+                            :background "#7C5CFF" :color "#fff" :font-weight "bold"}}
+           "⏭ Step"]
+          [:button {:data-testid "machine-epochs-restart"
+                    :on-click #(dispatch [:machine-epochs/restart]
+                                         {:frame shell-frame})
+                    :style {:padding "0.45em 0.9em" :cursor "pointer"
+                            :border "1px solid #cfc8ff" :border-radius "6px"
+                            :background "#fff" :color "#7C5CFF" :font-weight "bold"}}
+           "↺ Restart"]
+          [:span {:data-testid "machine-epochs-status"
+                  :style {:color "#666" :font-size "12px" :margin-left "0.25em"}}
+           (str "step " (if (nil? cursor) 0 (inc cursor)) " / " total)]]
+         [:div {:data-testid "machine-epochs-steps"}
+          (map-indexed
+            (fn [n step]
+              ^{:key n}
+              [step-row track-id n step])
+            path)]])
+      ;; No selection — the shell-first-paint cold state. We auto-select :door
+      ;; on boot so this branch is only ever momentary.
+      [:div {:data-testid "machine-epochs-panel-empty"
+             :style {:flex "1" :color "#888"}}
+       "Pick a machine on the left to observe its isolated arc."])))
 
 (reg-view root []
   [:div {:data-testid "machine-epochs-root"
          :style {:font-family "system-ui, sans-serif" :padding "1em"
-                 :max-width "880px"}}
+                 :max-width "980px"}}
    [:header {:style {:margin-bottom "0.5em"}}
     [:h2 {:data-testid "machine-epochs-title" :style {:margin 0}}
      "Xray Testbed: Machine Epochs"]
     [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "Shows how xray displays state machine activity - particularly the Epoch panel."]
-    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
-     "Takes Four different state machines through various transitions"]]
-   [runner/runner {:run-step-event :machine-epochs/run-step
-                   :steps          steps
-                   :prefix         "machine-epochs"
-                   :host-frame     host-frame}]])
+     "Pick a machine to observe it IN ISOLATION — each machine runs in its "
+     "own frame and owns its own Xray epoch ring. Selecting a machine "
+     "re-points Xray at that frame, so the Epoch panel, scrubber, App-db "
+     "panel, and Machine Inspector show ONLY that machine's arc. Switch, "
+     "step, switch back (resume), or Restart (re-arc from boot)."]]
+   [:div {:style {:display "flex" :gap "1em" :align-items "flex-start"}}
+    [track-rail]
+    [track-panel]]])
 
 ;; ============================================================================
 ;; MOUNT
@@ -496,5 +848,10 @@
 (defn ^:export run []
   (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:machine-epochs/reset])
+  ;; Seed the SHELL frame's bookkeeping, then auto-select the default track so
+  ;; the operator lands on a live arc (the SHELL-FRAME-FIRST-PAINT smaller
+  ;; call) rather than an empty shell. The select creates + boots the door
+  ;; frame and re-points Xray at it.
+  (rf/dispatch-sync [:machine-epochs/seed])
+  (rf/dispatch-sync [:machine-epochs/select default-track])
   (rdc/render react-root [root]))


### PR DESCRIPTION
Reworks the `machine-epochs` Xray testbed (`tools/xray/testbeds/machine_epochs/`, port 8033 / `:examples/machine-epochs`) into a **MULTI-MACHINE, FRAME-ISOLATED stepper** per **rf2-q3lfm** (Mike-co-designed, 5 ruled decisions). The value: seeing each machine's Xray progression **in isolation** — machine = frame = its own epoch ring.

## What changed

- **Frame-per-machine.** Each of the 8 domains (door/traffic/quiz/brew/session/fuse/hvac/media) runs in its own `:machine/<track>` frame and owns its own Xray epoch ring. The old design dispatched all 8 into one `:rf/default` ring (interleaved arcs).
- **Picker re-points Xray.** Selecting a track sets the shell's `:rf.runner/selected`, **lazily creates + boots** its `:machine/<track>` frame (`reg-frame` + `:on-create`, boot-on-select), and re-points Xray via the host-facing focus channel (`focus! {:frame :machine/<track>}` → `:rf.xray/select-frame`). Every observation panel auto-follows.
- **Two frame layers.** SHELL (`:rf/default`) holds runner bookkeeping (`:rf.runner/selected` + per-track `:rf.runner/cursors`) + the picker UI; per-machine frames hold only that domain's snapshot(s).
- **STEP / RESTART.** Step writes the shell cursor + dispatches the step's machine event into the machine frame (two epochs: shell cursor + observed cascade). Restart = `reset-frame!` (clears the ring, re-arcs from boot via `:on-create`).
- **Tracks data model.** A `tracks` vector (code data) replaces the flat `steps`; `:machines` is a set (media = two machine-ids in one frame). **Cross-machine fan-out steps dropped** (Mike ruling 5).
- **Idiomatic re-frame2.** app-db + events + subs only; no atoms through views, no frame-ids as view args.
- **Localized runner.** The multi-track machinery is machine-epochs-LOCAL; the shared `runner.core` and the 5 single-track decks are **untouched** (the deck reuses the host-frame + cross-frame-dispatch idiom as a building block).

## Smaller calls applied (all 3 recommended)

- **Boot-on-select** — first observed epoch is the machine's START cascade. Selecting fuse boots `:armed` whose `:entry` throws → the exception card is the headline of the fuse arc.
- **Dropped explicit start-machine rows** — boot-on-select produces the START epoch for free.
- **Auto-select `:door` on boot** — operator lands on a live arc, not an empty shell.

## Tests

- Feature-matrix scenario reworked: selects each track, drives its per-track steps, reads **per-machine-frame** snapshots, and asserts the **cross-frame flip isolation** (door → traffic → back to door: each frame intact, never interleaved) + **restart** (frame reset) + **boot-on-select fuse throw** (the sole machine-action-exception trigger).
- The CLJS render-fidelity harness (`machine-epochs-harness-cljs-test`) drives the substrate directly and is **unchanged + green**.
- `tools/xray/spec/017-Test-Coverage-Matrix.md` documents the testbed contract (it CONSUMES the existing frame-switcher API; **no new Xray contract**).

## Gates (all green, cold)

- xray `clojure -M:test` — 1083 tests, 0 failures
- `npm run test:cljs` — 5724 tests, 0 failures
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures (incl. the new multi-machine frame-isolated stepper with the live cross-frame flip)
- `:examples/machine-epochs` build — 0 warnings

No `shadow-cljs.edn` change (the 8033 build already exists; frames are created at runtime).

Closes rf2-q3lfm