### PR TITLE
fix(ssr/security): allowlist-strip lowercase ontouch* handlers — SSR XSS gap (rf2-cv165)

### DIFF
--- a/implementation/security/test/re_frame/security/ssr_escaping_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/ssr_escaping_security_cljs_test.cljc
@@ -60,6 +60,7 @@
                :cljs [cljs.reader :as edn])
             [clojure.string :as str]
             [re-frame.ssr.html-helpers :as h]
+            [re-frame.ssr.emit :as emit]
             [re-frame.security.gen :as gen]))
 
 ;; ---------------------------------------------------------------------------
@@ -72,7 +73,12 @@
    "onfocus" "onblur" "onkeydown" "onkeyup" "onkeypress" "onchange"
    "oninput" "onwheel" "onscroll" "ondrag" "ondrop" "onpaste" "oncopy"
    "oncut" "onbeforeunload" "onunload" "onhashchange" "onpopstate"
-   "onmessage" "onanimationstart" "ontransitionend" "onpointerdown"])
+   "onmessage" "onanimationstart" "ontransitionend" "onpointerdown"
+   ;; W3C Touch Events Level 2 §8 GlobalEventHandlers (rf2-cv165). The
+   ;; structural regex only catches the camelCase/kebab spellings, so the
+   ;; lower-case canonical touch names are caught by the allowlist alone —
+   ;; an XSS-equivalent gap of the same class as `:onclick`.
+   "ontouchstart" "ontouchmove" "ontouchend" "ontouchcancel"])
 
 (defn- live-handler-attr?
   "True when `rendered` (the output of `attr-string` for ONE attr) contains
@@ -214,7 +220,13 @@
    :onerror :ONERROR :OnError
    :onmouseover :ONMOUSEOVER :OnMouseOver :onMouseOver
    :on-click :ON-CLICK :on-mouse-over :onCustomEvent :on-custom-event
-   :onsubmit :ONSUBMIT :onfocus :onFocus :onkeydown :onKeyDown])
+   :onsubmit :ONSUBMIT :onfocus :onFocus :onkeydown :onKeyDown
+   ;; rf2-cv165 — the lower-case W3C Touch Events L2 GlobalEventHandlers.
+   ;; The structural regex CANNOT catch these (no upper-case tail char, no
+   ;; hyphen), so the allowlist must strip them; `:ontouchstart 'alert`
+   ;; previously rode through as a live ` ontouchstart="alert"` attribute.
+   :ontouchstart :ontouchmove :ontouchend :ontouchcancel
+   :ONTOUCHSTART :OnTouchStart :onTouchStart])
 
 (deftest hostile-handler-corpus-all-stripped
   (testing "rf2-1uex4 corpus - every named hostile handler key strips to \"\""
@@ -225,6 +237,28 @@
                  (pr-str out)))
         (is (not (live-handler-attr? out))
             (str "handler key " (pr-str k) " produced a live on*= attribute"))))))
+
+(deftest touch-handler-payload-never-reaches-wire-html
+  (testing "rf2-cv165 - rendering a hiccup element whose attrs splat a
+            lower-case W3C touch GlobalEventHandler key (the realistic
+            attacker-controlled-key path) MUST emit an element with NO live
+            on* attribute and NO trace of the JS payload. The structural
+            regex cannot catch these lower-case names; the allowlist must."
+    (doseq [k [:ontouchstart :ontouchmove :ontouchend :ontouchcancel]]
+      (let [payload "alert(document.cookie)"
+            html    (emit/emit-element [:div {k payload :id "ok"} "child"])]
+        ;; The element renders (id survives, child text emitted) ...
+        (is (str/includes? html "id=\"ok\"")
+            (str "the benign attr should survive for key " (pr-str k)))
+        (is (str/includes? html "child")
+            (str "the child text should survive for key " (pr-str k)))
+        ;; ... but the handler name and its JS payload are gone from the wire.
+        (is (not (str/includes? (str/lower-case html) (name k)))
+            (str "touch handler name " (pr-str k) " leaked into wire HTML: "
+                 html))
+        (is (not (str/includes? html payload))
+            (str "touch handler JS payload reached wire HTML for key "
+                 (pr-str k) ": " html))))))
 
 (deftest non-handler-on-prefix-keys-survive
   (testing "the matcher must NOT over-strip innocuous English-word keys -

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -258,7 +258,13 @@
 
 ;; WHATWG event-handler content attributes (HTML Living Standard
 ;; §"Event handlers on elements, Document objects, and Window objects",
-;; plus the IDL `on*` attributes on Window/Document/Element). All
+;; plus the IDL `on*` attributes on Window/Document/Element), and the
+;; W3C Touch Events Level 2 §8 `GlobalEventHandlers` touch attributes
+;; (`ontouchstart` / `ontouchmove` / `ontouchend` / `ontouchcancel` —
+;; rf2-cv165: the structural regex only catches the camelCase/kebab
+;; spellings, so the lower-case canonical touch names MUST be enumerated
+;; here or they ride through as live attributes on touch-capable
+;; browsers — an XSS-equivalent gap of the same class as `:onclick`). All
 ;; lower-case; the lookup lower-cases the candidate name first so every
 ;; casing (`onload`, `ONLOAD`, `OnLoad`) is covered. Curated to the
 ;; event-handler names browsers actually fire — NOT a broad `on`-prefix —
@@ -287,7 +293,8 @@
     "onresize" "onscroll" "onscrollend" "onsecuritypolicyviolation"
     "onseeked" "onseeking" "onselect" "onselectionchange"
     "onselectstart" "onslotchange" "onstalled" "onstorage" "onsubmit"
-    "onsuspend" "ontimeupdate" "ontoggle" "ontransitioncancel"
+    "onsuspend" "ontimeupdate" "ontoggle" "ontouchcancel" "ontouchend"
+    "ontouchmove" "ontouchstart" "ontransitioncancel"
     "ontransitionend" "ontransitionrun" "ontransitionstart"
     "onunhandledrejection" "onunload" "onvolumechange" "onwaiting"
     "onwheel"})

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -69,6 +69,29 @@
       (is (= "<div></div>"
              (emit/render-to-string [:div {:on-click "f"}] {}))))))
 
+(deftest render-to-string-strips-lowercase-touch-handlers
+  (testing "rf2-cv165 — the lower-case W3C Touch Events L2 GlobalEventHandlers
+            (`ontouchstart` / `ontouchmove` / `ontouchend` / `ontouchcancel`)
+            are stripped through the FULL `render-to-string` emit composition.
+            These have no upper-case tail char and no hyphen, so the structural
+            `event-handler-name-re` CANNOT catch them — the allowlist arm is
+            the only thing that strips them. Reverting the four allowlist
+            entries makes this go RED (the JVM-side counterpart of the
+            security tier's render-to-string assertion)."
+    (doseq [k [:ontouchstart :ontouchmove :ontouchend :ontouchcancel]]
+      (testing (str k " is stripped through render-to-string")
+        (let [html (emit/render-to-string
+                     [:div {k "alert(document.cookie)" :id "x"} [:p "body"]] {})]
+          (is (str/includes? html "id=\"x\"")
+              (str "the legit attr should survive for " k))
+          (is (str/includes? html "<p>body</p>")
+              (str "the child should render for " k))
+          (is (not (str/includes? (str/lower-case html) (name k)))
+              (str "touch handler name " k " leaked into wire HTML: " html))
+          (is (not (str/includes? html "alert(document.cookie)"))
+              (str "touch handler payload reached wire HTML for " k ": "
+                   html)))))))
+
 (deftest render-to-string-strips-function-valued-props
   (testing "rf2-usio0 / rf2-dwds9 — a function-valued prop has no HTML
             serialisation and is dropped through the full emit


### PR DESCRIPTION
## Summary

The SSR `on*` event-handler allowlist (`re-frame.ssr.html-helpers/event-handler-allowlist`) omitted the lower-case **W3C Touch Events Level 2 §8 GlobalEventHandlers** — `ontouchstart`, `ontouchmove`, `ontouchend`, `ontouchcancel`. The structural `event-handler-name-re` only catches camelCase/kebab spellings, so:

- `h/attr-string {:ontouchstart 'alert}` emitted a **LIVE** ` ontouchstart="alert"` attribute (verified), while
- `:onTouchStart` correctly stripped.

On touch-capable browsers this is an **XSS-equivalent SSR gap** when an app splats attacker-controlled attribute keys into hiccup — the same class as the `:onclick` regression (rf2-1uex4) the security tier is meant to pin.

## Changes

- **Production fix** — add the four lower-case touch handlers to `event-handler-allowlist` (`implementation/ssr/src/re_frame/ssr/html_helpers.cljc`), with a comment pinning the W3C Touch Events L2 source so the gap can't silently reopen.
- **Security tier** (`implementation/security/test/.../ssr_escaping_security_cljs_test.cljc`):
  - added the four touch names to `canonical-handlers` (feeds the generative per-character recasing property — 600-draw sweep now covers touch casings).
  - added lower/upper/Title/camel touch keys to the named hostile corpus (`hostile-handler-keys`) — direct strip-to-`""` assertions.
  - added `touch-handler-payload-never-reaches-wire-html`: a **render-to-string** assertion via `emit/emit-element` proving the JS payload + handler name never reach wire HTML while the benign attr/child survive.
- **SSR JVM tier** (`implementation/ssr/test/re_frame/ssr_emit_test.clj`) — added `render-to-string-strips-lowercase-touch-handlers`, the JVM-side counterpart pinning the allowlist arm through the full `render-to-string` emit composition (the existing JVM cases only exercised the structural-regex arm).

### Scope notes
- Added **exactly the four** touch handlers named in the finding — the complete W3C Touch Events L2 GlobalEventHandlers set. No speculative additions; no other lower-case canonical `on*` handlers in the same XSS-equivalent class were found trivially missing from the (already comprehensive) allowlist.
- **Spec unchanged.** `spec/011-SSR.md §XSS at output boundaries` and `spec/Security.md §XSS at output boundaries` state the contract generically ("strip all `on*` event-handler props"); the canonical name set is an implementation realisation, not an enumerated spec list — so the touch contract was already covered and no spec edit was required.

## Quality gates

| Command (cwd) | Result |
|---|---|
| `npm run test:security` (`implementation/`) | **23 tests / 212 assertions, 0 failures, 0 errors** |
| `clojure -M:test` (`implementation/ssr/`) | **285 tests / 1046 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (`implementation/`) | **5728 tests / 20106 assertions, 0 failures, 0 errors** |

**Verify-by-revert:** temporarily removing the four allowlist entries makes `npm run test:security` go **RED — 17 failures**, including the literal reproduction `<div ontouchcancel="alert(document.cookie)" id="ok">child</div>`. Restoring the entries returns the gate green. This pins the fix against re-opening.

Closes rf2-cv165.
