### PR TITLE
fix(routing): nil-query elision + fail-closed non-string URLs + frame tags on forward-nav (rf2-w3qgc)

### DIFF
--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -921,6 +921,21 @@
   ([route-id path-params query-params] (route-url route-id path-params query-params nil))
   ([route-id path-params query-params fragment]
    (let [query-params (or query-params {})
+         ;; rf2-w3qgc: elide nil-valued query keys BEFORE :query-schema
+         ;; validation (and reuse the elided map for emission below). Per
+         ;; Spec 012 §Bidirectional URL ↔ params a nil-valued query key is
+         ;; SILENTLY OMITTED — `{:page nil}` emits no key and never throws —
+         ;; so a route declaring e.g. `:query [:map [:sort {:optional true}
+         ;; :string]]` must accept `{:sort nil}` to mean "omit :sort" and
+         ;; return `/search`, NOT raise `:rf.error/route-url-validation`.
+         ;; Validating the raw map first contradicted that policy (nil
+         ;; failed the `:string` branch). A present-but-falsy value
+         ;; (`false`, `0`, `""`) is a legitimate value and is preserved —
+         ;; only `nil` is elided — so non-nil invalid values STILL fail
+         ;; validation against the elided map.
+         emitted-query (into (array-map)
+                             (remove (fn [[_ v]] (nil? v)))
+                             query-params)
          route-meta   (registrar/lookup :route route-id)
          pattern      (:path route-meta)]
      (when (nil? pattern)
@@ -945,7 +960,12 @@
                    :slot     :params
                    :value    path-params
                    :error    p-error}))))
-     (let [[q-failed? q-error] (validate-route-shape route-meta :query query-params)]
+     ;; rf2-w3qgc: validate the NIL-ELIDED query map (`emitted-query`), not
+     ;; the raw `query-params` — a nil-valued optional key is omitted per
+     ;; Spec 012 and must not be presented to the schema (where it would
+     ;; fail an optional non-nil branch). `:value` reports the elided map
+     ;; actually validated.
+     (let [[q-failed? q-error] (validate-route-shape route-meta :query emitted-query)]
        (when q-failed?
          (throw (route-error
                   :rf.error/route-url-validation
@@ -953,7 +973,7 @@
                   (str "the supplied :query did not validate against route " route-id "'s :query schema")
                   {:route-id route-id
                    :slot     :query
-                   :value    query-params
+                   :value    emitted-query
                    :error    q-error}))))
      (let [n      (count pattern)
            ;; Per Spec 012 §Bidirectional URL ↔ params: optional groups
@@ -1056,14 +1076,13 @@
                    :else
                    (recur (inc i) (conj parts (str ch)))))))
            path-out (apply str parts)
-           ;; Drop nil-valued query keys from emission — `{:page nil}`
-           ;; omits the key rather than emitting a bare `?page=`. Mirrors
-           ;; the path-param `if-some` discipline above: a present-but-
-           ;; falsy value (`false`, `0`, `""`) is a legitimate query value
-           ;; and round-trips, but `nil` means "absent" and is elided.
-           emitted-query (into (array-map)
-                               (remove (fn [[_ v]] (nil? v)))
-                               query-params)
+           ;; rf2-w3qgc: `emitted-query` (the nil-elided query map) is
+           ;; computed once at the top of the fn so the SAME elided map
+           ;; both feeds `:query`-schema validation AND drives URL emission.
+           ;; `{:page nil}` omits the key rather than emitting a bare
+           ;; `?page=`; a present-but-falsy value (`false`, `0`, `""`) is a
+           ;; legitimate query value and round-trips, but `nil` means
+           ;; "absent" and is elided.
            qs (when (seq emitted-query)
                 (str "?"
                      (clojure.string/join "&"

--- a/implementation/routing/src/re_frame/routing/url.cljc
+++ b/implementation/routing/src/re_frame/routing/url.cljc
@@ -210,14 +210,25 @@
   [url]
   #?(:cljs
      (try
-       (if (and (exists? js/window) (.-location js/window))
-         (let [loc      (.-location js/window)
-               parsed   (js/URL. url (.-href loc))
-               protocol (.-protocol parsed)]
-           (or (not (#{"http:" "https:"} protocol))
-               (not= (.-origin parsed) (.-origin loc))))
-         ;; No browser Location to origin-compare against — fail closed.
-         (not (safe-in-app-url? url)))
+       ;; rf2-w3qgc: fail closed (classify EXTERNAL) for any non-string or
+       ;; empty-string `url` BEFORE handing it to `js/URL`. JavaScript
+       ;; stringifies non-strings — `new URL(null, base)` resolves to
+       ;; `/null`, numbers to `/123`, objects via `toString` — so a nil /
+       ;; number / boolean / object could otherwise resolve same-origin and
+       ;; push a fabricated in-app URL. This is an untrusted-URL sink; the
+       ;; JVM / no-window fallback already fails closed via
+       ;; `safe-in-app-url?` (which rejects any non-string), so guarding
+       ;; here removes the host divergence and keeps the contract uniform.
+       (if-not (and (string? url) (seq url))
+         true
+         (if (and (exists? js/window) (.-location js/window))
+           (let [loc      (.-location js/window)
+                 parsed   (js/URL. url (.-href loc))
+                 protocol (.-protocol parsed)]
+             (or (not (#{"http:" "https:"} protocol))
+                 (not= (.-origin parsed) (.-origin loc))))
+           ;; No browser Location to origin-compare against — fail closed.
+           (not (safe-in-app-url? url))))
        (catch :default _
          (not (safe-in-app-url? url))))
      :clj

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -256,7 +256,15 @@
                   event-vec url
                   (:bypass-leave-guard? opts))]
     (or blocked
-        (url-change-fx db url :top nil))))
+        ;; rf2-w3qgc: thread the active `frame` into `url-change-fx` so the
+        ;; forward-nav route-miss / malformed-url / too-many-keys trace sites
+        ;; carry `:frame`, consistent with the popstate / SSR sibling
+        ;; (`handle-url-change-handler`, :restore below) and the programmatic
+        ;; `:rf.route/navigate {:url ...}` path. Spec 009 requires `:frame` on
+        ;; `:rf.error/no-such-handler {:kind :route}` and
+        ;; `:rf.warning/no-not-found-route`. The default frame still tags
+        ;; `:rf/default` (the dispatch cofx supplies it).
+        (url-change-fx db url :top frame))))
 
 (defn handle-url-change-handler
   "`:rf.route/handle-url-change` event-fx handler. Registered by the

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -34,6 +34,10 @@
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.routing :as routing]
+            ;; rf2-w3qgc: internal URL-classifier namespace — `external-url?`
+            ;; / `request-url->app-url` are not facade-exported, so the
+            ;; non-string fail-closed test calls them directly.
+            [re-frame.routing.url :as routing-url]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -308,6 +312,46 @@
     (is (= :hist/home
            (:id (get-in (rf/app-db-value :rf/default) [:rf/runtime :routing :current])))
         "external URL did not rewrite the app route to not-found")))
+
+(deftest url-requested-non-string-url-fails-closed-cljs-rf2-w3qgc
+  (testing "rf2-w3qgc: with a live window/location, a NON-STRING `:url`
+            (nil / number / boolean / object) is classed EXTERNAL and never
+            pushed — JS would otherwise stringify it through `js/URL`
+            (`new URL(null, base)` → `/null`, numbers → `/123`) and class it
+            same-origin, pushing a FABRICATED in-app URL. The browser path
+            must fail closed identically to the JVM/no-window fallback."
+    (register-routes!)
+    ;; Land on /cart so we can prove the slice does NOT move on a bad URL.
+    (rf/dispatch-sync [:rf/url-requested {:url "/cart"}])
+    (is (= :hist/cart
+           (:id (get-in (rf/app-db-value :rf/default) [:rf/runtime :routing :current])))
+        "precondition: active route is :hist/cart")
+    (let [entries-before (:entries @*history-state*)
+          index-before   (:index @*history-state*)]
+      (doseq [bad [nil 123 true false (js-obj "toString" (fn [] "/checkout")) #js {} []]]
+        ;; external-url? classifies the raw value as external (fail closed).
+        (is (true? (routing-url/external-url? bad))
+            (str "non-string url " (pr-str bad) " classes EXTERNAL"))
+        ;; request-url->app-url must NOT canonicalise a non-string (gate is
+        ;; external? → returns the value unchanged, never touching js/URL).
+        (is (= bad (routing-url/request-url->app-url bad))
+            (str "request-url->app-url leaves non-string " (pr-str bad) " unchanged"))
+        ;; End-to-end: the :rf/url-requested sink does not push or rewrite.
+        (rf/dispatch-sync [:rf/url-requested {:url bad}])
+        (is (= entries-before (:entries @*history-state*))
+            (str "non-string url " (pr-str bad) " appended NO history entry"))
+        (is (= index-before (:index @*history-state*))
+            (str "non-string url " (pr-str bad) " did not move the history index"))
+        (is (= :hist/cart
+               (:id (get-in (rf/app-db-value :rf/default) [:rf/runtime :routing :current])))
+            (str "non-string url " (pr-str bad) " did not rewrite the route slice"))))
+    ;; Sanity: a normal same-origin string STILL works through the same path.
+    (rf/dispatch-sync [:rf/url-requested {:url "/checkout"}])
+    (is (= "/checkout" (current-url *history-state*))
+        "a normal same-origin string still pushes through after the guard")
+    (is (= :hist/checkout
+           (:id (get-in (rf/app-db-value :rf/default) [:rf/runtime :routing :current])))
+        "the slice tracks the legitimate same-origin navigation")))
 
 (deftest scroll-position-captured-before-forward-nav-cljs
   (testing "leaving a route captures the current browser scroll position under that route's URL"

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -1603,6 +1603,69 @@
           (is (= :query (:slot (ex-data ex)))))
         (finally (restore))))))
 
+(deftest route-url-elides-nil-query-before-validation-rf2-w3qgc
+  (testing "rf2-w3qgc: nil-valued query keys are elided BEFORE :query-schema
+            validation, so `{:sort nil}` against a
+            `:query [:map [:sort {:optional true} :string]]` route returns
+            `/search` (the key is omitted) rather than throwing
+            :rf.error/route-url-validation. Non-nil invalid values STILL fail."
+    (let [restore (with-stub-validator)]
+      (try
+        ;; Predicate modelling `:query [:map [:sort {:optional true} :string]]`:
+        ;; :sort is OPTIONAL (absent OK), but when PRESENT it must be a
+        ;; string. Because nil is elided before validation, `{:sort nil}`
+        ;; reaches the predicate as `{}` (key absent) and conforms.
+        (rf/reg-route :route/search
+                      {:path  "/search"
+                       :query (fn [m] (or (not (contains? m :sort))
+                                          (string? (:sort m))))})
+        ;; (1) route-url: nil omits the key, no throw, returns /search.
+        (is (= "/search"
+               (routing/route-url :route/search {} {:sort nil}))
+            "route-url with {:sort nil} elides the key BEFORE validation → /search")
+        ;; A valid string still emits the pair.
+        (is (= "/search?sort=name"
+               (routing/route-url :route/search {} {:sort "name"}))
+            "a present, valid :sort string still round-trips into the query")
+        ;; (2) A non-nil INVALID value STILL fails validation (the fix
+        ;; narrows only nil; it does not weaken the schema gate).
+        (let [ex (try (routing/route-url :route/search {} {:sort 123})
+                      nil
+                      (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? ex)
+              "a non-nil invalid :sort (a number) STILL fails validation")
+          (is (= ":rf.error/route-url-validation" (ex-message ex)))
+          (is (= :query (:slot (ex-data ex))))
+          (is (= {:sort 123} (:value (ex-data ex)))
+              ":value reports the elided map actually validated (nil-free)"))
+        (finally (restore)))))
+
+  (testing "rf2-w3qgc: programmatic `:rf.route/navigate` and SSR route-link
+            with `{:sort nil}` push/produce `/search` without a validation
+            error (the same nil-elision path through route-url)"
+    (let [restore (with-stub-validator)]
+      (try
+        (rf/reg-route :route/search
+                      {:path  "/search"
+                       :query (fn [m] (or (not (contains? m :sort))
+                                          (string? (:sort m))))})
+        (let [pushed (atom nil)]
+          (rf/reg-fx :rf.nav/push-url
+                     {:platforms #{:server :client}}
+                     (fn [_ url] (reset! pushed url)))
+          ;; Programmatic navigate with a nil optional query value: the
+          ;; navigate handler resolves the target URL via route-url, which
+          ;; must elide :sort and emit /search (no validation throw).
+          (rf/dispatch-sync [:rf.route/navigate :route/search {} {:query {:sort nil}}])
+          (is (= "/search" @pushed)
+              "programmatic navigate with {:sort nil} pushes /search (no throw)"))
+        ;; SSR route-link emission (server render path) drives the same
+        ;; route-url; the link href must be /search, not a thrown error.
+        (is (= "/search"
+               (routing/route-url :route/search {} {:sort nil}))
+            "SSR route-link href derives from route-url → /search for {:sort nil}")
+        (finally (restore))))))
+
 ;; ---- rf2-b8ugt: :rf/pending-navigation full slot shape -------------------
 ;;
 ;; Per Spec 012 §Navigation blocking — pending-nav protocol and
@@ -2040,6 +2103,74 @@
                        (= :malformed-url (-> ev :tags :reason))))
                 @traces)
           ":rf.error/no-such-handler carries `:reason :malformed-url`"))))
+
+(deftest url-changed-forward-nav-traces-carry-frame-rf2-w3qgc
+  (testing "rf2-w3qgc: forward URL-driven nav (`:rf.route/transitioned`)
+            threads the active `frame` through `url-change-fx`, so the
+            route-miss / malformed-url / no-not-found diagnostics carry
+            `:frame` — consistent with the popstate/SSR sibling
+            (`:rf.route/handle-url-change`) and the programmatic
+            `:rf.route/navigate {:url ...}` path. Spec 009 requires `:frame`
+            on `:rf.error/no-such-handler {:kind :route}` and
+            `:rf.warning/no-not-found-route`."
+    (rf/reg-frame :rf/default {})
+    (rf/reg-frame :route/owner {})
+    (rf/reg-route :route/home {:path "/"})
+    ;; No :rf.route/not-found registered → the bare-miss path also emits
+    ;; :rf.warning/no-not-found-route.
+    (rf/reg-fx :rf.nav/push-url
+               {:platforms #{:server :client}}
+               (fn [_ _] nil))
+
+    (testing "non-default frame: malformed URL → frame-tagged traces"
+      (let [traces (atom [])]
+        (rf/register-listener! ::w3qgc-malformed
+                               (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:rf.route/transitioned "/articles/%"] {:frame :route/owner})
+        (rf/unregister-listener! ::w3qgc-malformed)
+        (is (some (fn [ev]
+                    (and (= :rf.warning/malformed-url (:operation ev))
+                         (= "/articles/%" (-> ev :tags :url))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.warning/malformed-url carries :frame :route/owner on forward nav")
+        (is (some (fn [ev]
+                    (and (= :rf.error/no-such-handler (:operation ev))
+                         (= :route (-> ev :tags :kind))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.error/no-such-handler {:kind :route} carries :frame :route/owner")))
+
+    (testing "non-default frame: bare miss with no 404 route → frame-tagged
+              :rf.warning/no-not-found-route + :rf.error/no-such-handler"
+      (let [traces (atom [])]
+        (rf/register-listener! ::w3qgc-nonotfound
+                               (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:rf.route/transitioned "/no/such/route"] {:frame :route/owner})
+        (rf/unregister-listener! ::w3qgc-nonotfound)
+        (is (some (fn [ev]
+                    (and (= :rf.warning/no-not-found-route (:operation ev))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.warning/no-not-found-route carries :frame :route/owner")
+        (is (some (fn [ev]
+                    (and (= :rf.error/no-such-handler (:operation ev))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.error/no-such-handler carries :frame :route/owner")))
+
+    (testing "default-frame forward nav STILL tags :rf/default (regression guard)"
+      (let [traces (atom [])]
+        (rf/register-listener! ::w3qgc-default
+                               (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:rf.route/transitioned "/articles/%"] {:frame :rf/default})
+        (rf/unregister-listener! ::w3qgc-default)
+        (is (some (fn [ev]
+                    (and (= :rf.error/no-such-handler (:operation ev))
+                         (= :rf/default (-> ev :tags :frame))))
+                  @traces)
+            "default-frame dispatch tags :rf/default (not nil) — matches the
+             popstate/SSR sibling and the programmatic path")))))
 
 (deftest url-changed-well-formed-url-does-not-emit-malformed-trace
   (testing "the regular happy path emits NO :rf.warning/malformed-url"


### PR DESCRIPTION
Fixes the 3 correctness findings in `rf2-w3qgc` (Surface: `implementation/routing`). All are spec-conformance fixes — the impl is conformed to the already-written Spec 012 (nil-policy) and Spec 009 (trace catalogue); no spec docs touched.

## Finding 1 — nil query-param crash (`registry.cljc`)
`route-url` validated the raw `query-params` map against the `:query` schema BEFORE nil-valued keys were elided, contradicting Spec 012 (a nil-valued query key is silently omitted). With `:query [:map [:sort {:optional true} :string]]`, `(route-url :route/search {} {:sort nil})` threw `:rf.error/route-url-validation` instead of returning `/search`.

**Fix:** compute the nil-elided query map once at the top of `route-url`; validate the elided map and reuse it for URL emission. A present-but-falsy value (`false`/`0`/`""`) is preserved, so non-nil invalid values STILL fail validation. This also fixes the SSR `route-link` href path (`route-link-render-ssr` derives href from `route-url`) and the programmatic `:rf.route/navigate` path (calls `route-url` before push).

## Finding 2 — non-string URL fails OPEN (`url.cljc`) — security-class
The CLJS browser path passed `url` to `js/URL` without a `string?` check. JS stringifies non-strings (`new URL(null, base)` → `/null`, numbers → `/123`, objects via `toString`), so nil/number/bool/object could be classed same-origin and push a fabricated in-app URL — a host divergence vs the JVM/no-window fallback, which already fails closed via `safe-in-app-url?`.

**Fix:** `external-url?` returns `true` (external) for any non-string or empty-string `url` BEFORE touching `js/URL`. `request-url->app-url` is gated on `(not (external-url? url))`, so it now also leaves non-strings uncanonicalised. Fail-closed, matching the JVM path. Normal same-origin strings still work.

## Finding 3 — frameless trace tags on forward-nav (`url_change.cljc`)
`transitioned-handler` destructured `frame` but called `(url-change-fx db url :top nil)`, so forward-nav route-miss / malformed-url / too-many-keys / no-not-found trace sites emitted WITHOUT `:frame`. Spec 009 requires `:frame` on `:rf.error/no-such-handler {:kind :route}` and `:rf.warning/no-not-found-route`. The popstate/SSR sibling (`handle-url-change-handler`) already passed `frame`.

**Fix:** thread `frame` through (`(url-change-fx db url :top frame)`). `url-change-fx` already `cond->`-tags `:frame` when truthy; the dispatch cofx seeds `:frame` (`:rf/default` by default), so default-frame nav still tags `:rf/default`.

## Quality gates

| Command (from `implementation/` unless noted) | Result |
|---|---|
| `cd implementation/routing && clojure -M:test` | **158 tests, 756 assertions, 0 failures, 0 errors** |
| `cd implementation && npm run test:cljs` | **5728 tests, 20114 assertions, 0 failures, 0 errors** |
| `cd implementation/ssr && clojure -M:test` (route-link path) | **284 tests, 1030 assertions, 0 failures, 0 errors** |

### Regression coverage added
- `routing_test.clj` — `route-url-elides-nil-query-before-validation-rf2-w3qgc` (route-url + programmatic navigate + SSR route-link with `{:sort nil}` → `/search`; non-nil invalid still throws) and `url-changed-forward-nav-traces-carry-frame-rf2-w3qgc` (forward nav frame tags on malformed-url / no-such-handler / no-not-found; default-frame still tags `:rf/default`).
- `routing_history_cljs_test.cljs` — `url-requested-non-string-url-fails-closed-cljs-rf2-w3qgc` (window/location stub: nil/number/bool/object classed external, no push, no slice rewrite; same-origin string still works).

Closes rf2-w3qgc.