### PR TITLE
fix(epoch): retain child dispatch markers + attribute renders via sub-runs under keep-0 (rf2-bhglx)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -451,21 +451,48 @@
 
 (defn- epoch-value-changed-for-view?
   "True when epoch `record` carries a value-changed `:sub/run` belonging
-  to the view named by `render-key` — i.e. a `:sub/run` with
-  `:value-changed? true` whose `:reader-render-key` is `render-key`
-  (the synchronous in-render deref, when stamped) OR whose `:sub-id` is
-  in the view's learned read-set `deps` (the post-settle reactive
-  recompute, which carries no render-key). `deps` may be nil when the
-  view's read-set was never learned — then only the render-key match
-  applies."
+  to the view named by `render-key`.
+
+  Two evidence sources, in priority order:
+
+    1. The raw `:trace-events` (when retained — within `:trace-events-keep`):
+       a `:sub/run` with `:value-changed? true` whose `:reader-render-key` is
+       `render-key` (the synchronous in-render deref, when stamped) OR whose
+       `:sub-id` is in the view's learned read-set `deps` (the post-settle
+       reactive recompute, which carries no render-key). This is the richer
+       source — it can match by render-key even before the read-set is learned.
+
+    2. The structured `:sub-runs` projection (rf2-bhglx) — consulted ONLY when
+       the record's raw `:trace-events` were elided (the `:trace-events-keep 0`
+       memory/privacy posture drops every record's raw stream while RETAINING
+       the structured rows). A `:sub-runs` row carries `:value-changed?` and
+       `:sub-id` but NO `:reader-render-key` (see `capture/sub-run-row`), so the
+       structured match is `deps`-only: a value-changed row whose `:sub-id` is in
+       the view's learned read-set. Without this, render attribution under
+       keep-0 saw NO value-change evidence and mis-recorded genuine re-renders
+       against the mount/default epoch.
+
+  `deps` may be nil when the view's read-set was never learned — then only the
+  render-key (trace) match applies, and the structured fallback yields nothing.
+  Prefers the trace source when present so the render-key precision is kept;
+  falls back to the structured rows only when traces are absent."
   [record render-key deps]
-  (some (fn [ev]
-          (and (= :rf.sub/run (:operation ev))
-               (true? (-> ev :tags :rf.sub/value-changed?))
-               (let [tags (:tags ev)]
-                 (or (= render-key (:rf.sub/reader-render-key tags))
-                     (and deps (contains? deps (:rf.sub/id tags)))))))
-        (:trace-events record)))
+  (if (contains? record :trace-events)
+    (some (fn [ev]
+            (and (= :rf.sub/run (:operation ev))
+                 (true? (-> ev :tags :rf.sub/value-changed?))
+                 (let [tags (:tags ev)]
+                   (or (= render-key (:rf.sub/reader-render-key tags))
+                       (and deps (contains? deps (:rf.sub/id tags)))))))
+          (:trace-events record))
+    ;; rf2-bhglx — `:trace-events` elided (keep-0, or this record below the
+    ;; elision boundary). The structured `:sub-runs` rows are retained for
+    ;; every record; match a value-changed row by the view's learned read-set.
+    (and deps
+         (some (fn [row]
+                 (and (true? (:value-changed? row))
+                      (contains? deps (:sub-id row))))
+               (:sub-runs record)))))
 
 (defn- value-changed-epoch-for
   "Scan `frame-id`'s ring (most-recent first) for the newest epoch in
@@ -474,43 +501,40 @@
   epoch-id, or nil when no retained epoch shows a value-change for the
   view (a mount / mount-burst tail).
 
-  A view's subs are matched two ways (see `epoch-value-changed-for-view?`):
-  by the `:reader-render-key` stamp (synchronous in-render deref) and by
-  the view's learned read-set (`render-deps-for`) for post-settle reactive
-  recomputes that carry no render-key. The read-set is learned at mount
-  from the stamped synchronous derefs; a view's sub set is stable across
-  its life, so mount-time learning suffices.
+  A view's subs are matched (see `epoch-value-changed-for-view?`): by the
+  `:reader-render-key` stamp (synchronous in-render deref, raw-trace only) and
+  by the view's learned read-set (`render-deps-for`) for post-settle reactive
+  recomputes that carry no render-key. The read-set is learned at mount from
+  the stamped synchronous derefs; a view's sub set is stable across its life,
+  so mount-time learning suffices.
 
-  Reads only `:trace-events`, which the most-recent `:trace-events-keep`
-  records retain — exactly the window a post-settle render can target
-  (the back-fill never reaches older, projection-only records). The scan
-  is BOUNDED by the ELISION boundary: it stops at the first record (newest-
-  first) whose `:trace-events` slot is absent. A record below that boundary
-  had its `:trace-events` elided (`elide-just-crossed-trace-events`), so it
-  carries no value-changed `:sub/run` to find — it can never contribute a
-  hit, and every record older than it is likewise elided (elision is a
-  contiguous oldest-first prefix). Breaking at the boundary makes the scan
-  genuinely O(keep) rather than O(depth) per miss (the common mount /
-  mount-burst-tail case this fn exists to catch), matching the fused-walk
-  / O(keep) framing the rest of this file holds (rf2-3rg4j).
+  EVIDENCE WINDOW (rf2-bhglx). Each record is matched against its raw
+  `:trace-events` when retained (within `:trace-events-keep`), else against its
+  structured `:sub-runs` projection — which is retained for EVERY record
+  regardless of `:trace-events-keep`. The scan therefore reaches index 0:
 
-  WHY THE BOUND READS `:trace-events` PRESENCE, NOT `(- n keep)` (rf2-b2c02):
-  the steady-state elision boundary IS `(- n keep)`, but it is NOT after a
-  RUNTIME `:trace-events-keep` REDUCTION. Elision is non-retroactive (see
-  `elide-just-crossed-trace-events`'s docstring) — immediately after a
-  reduction (e.g. 50 → 5) records that were inside the OLD window but now
-  sit below `(- n new-keep)` STILL carry `:trace-events` until subsequent
-  appends re-elide them. A `(- n keep)` bound would skip those still-trace-
-  bearing records and miss a genuine value-change living in that transient
-  gap, mis-attributing the render to the mount / settling epoch. Bounding
-  on the directly-observable elision state instead tracks reality under any
-  reconfiguration: it scans EXACTLY the records that still carry traces —
-  the only records that can match — and self-heals back to O(keep) as
-  appends re-elide the gap. Cost is never worse than the pre-rf2-3rg4j
-  O(depth) and is identical O(keep) in steady state. A nil / unbounded
-  `keep` leaves every record carrying `:trace-events`, so the scan reaches
-  index 0. One pass newest-first; short-circuits at the first matching
-  epoch."
+    * keep > 0 — the genuine re-render rides one of the most-recent retained
+      cascades, so the newest-first scan short-circuits on the first hit; the
+      common mount / mount-burst-tail miss still walks at most the trace window
+      plus the structured tail. The raw-trace records are matched with full
+      render-key precision; older trace-elided records fall back to the
+      `:sub-runs` `deps`-only match (harmless — they predate the re-render).
+
+    * keep = 0 (rf2-bhglx) — no record retains raw traces, so EVERY record is
+      matched via its structured `:sub-runs`. Pre-fix the scan broke at the
+      first trace-elided record (the NEWEST one under keep-0) and returned nil,
+      so a genuine value-changing sub-run sitting in the newest epoch's
+      `:sub-runs` was never seen and the render was mis-attributed to the
+      mount/default epoch. Consulting `:sub-runs` lets the newest-first scan
+      find it and short-circuit on the current epoch.
+
+  The earlier hard break at the elision boundary (rf2-3rg4j / rf2-b2c02) is
+  GONE: it assumed a trace-elided record can never match, which the structured
+  `:sub-runs` fallback makes false. Under keep-0 the scan is O(depth) to a
+  miss; that is the necessary cost of attribution when no trace window exists,
+  and it still short-circuits on the first (newest) value-change for the common
+  genuine-re-render case. One pass newest-first; short-circuits at the first
+  matching epoch."
   [frame-id render-key]
   (let [history (history-for frame-id)
         deps    (render-deps-for frame-id render-key)
@@ -518,13 +542,9 @@
     (loop [i (dec n)]
       (when (>= i 0)
         (let [record (nth history i)]
-          ;; Elision is a contiguous oldest-first prefix: the first record
-          ;; (newest-first) that has lost its `:trace-events` marks the
-          ;; boundary — it and everything older are elided and unmatchable.
-          (when (contains? record :trace-events)
-            (if (epoch-value-changed-for-view? record render-key deps)
-              (:epoch-id record)
-              (recur (dec i)))))))))
+          (if (epoch-value-changed-for-view? record render-key deps)
+            (:epoch-id record)
+            (recur (dec i))))))))
 
 (defn resolve-render-epoch
   "Resolve the epoch a post-settle render of `render-key` should be
@@ -883,51 +903,41 @@
             (-> ev :tags :rf.trace/dispatch-id)))
         events))
 
-;; rf2-fxowr — bounded `theirs` retention. A `:event/dispatched` marker that
-;; rides a DIFFERENT dispatch-id ("theirs") is normally claimed as "mine" at
-;; the child's OWN settle — the very next harvest after the parent strands it
-;; (proven: parent harvest leaves it theirs, child run-start makes the next
-;; harvest's settling-id match, marker harvested as mine). So in the normal
-;; child-runs path a marker survives exactly ONE harvest as theirs.
+;; rf2-bhglx — claim-based `theirs` retention. A `:event/dispatched` marker
+;; that rides a DIFFERENT dispatch-id ("theirs") is a CHILD's queue-time
+;; dispatch row: it fires during the PARENT's do-fx (so it lands in the
+;; parent's window) but carries the CHILD's `:dispatch-id`. Under per-event
+;; epochs it must ride the CHILD's epoch, not the parent's (Spec 009 §Dispatch
+;; correlation: one `:dispatch-id` = one epoch), so it is LEFT in the buffer
+;; for the child's own `harvest-buffer-for-event!`, where the child's
+;; run-start makes the settling-id match and the marker is CLAIMED as "mine".
 ;;
-;; A child that NEVER runs to a settle (handler unregistered, frame
-;; destroyed / drain-interrupted before dequeue, depth-halt clears the queue
-;; with the child still pending) leaves its marker stranded: no settling-id
-;; will ever match it, so it is re-classified theirs and re-retained on EVERY
-;; subsequent genuine settle for the long-lived frame — slow UNBOUNDED
-;; accretion in the hottest atom (`capture-buffers`). This is the non-nil
-;; sibling of the rf2-ee38b nil-orphan strand: that fix made the harvest
-;; self-cleaning for nil-id orphans; this extends the same self-cleaning to
-;; cover a stranded non-nil child marker.
+;; The marker is retained until that claim — NOT for a fixed number of
+;; harvests. The earlier rf2-fxowr fix dropped an unclaimed marker after it had
+;; survived ONE intervening harvest as theirs, on the theory that the very next
+;; harvest is always the child's own settle. That theory is FALSE for a valid
+;; router interleaving: ordinary `:dispatch` fx children go to the router FIFO
+;; TAIL (`router/enqueue-envelope!` — `conj` on the PersistentQueue), so a
+;; SIBLING event already queued behind the parent settles BEFORE the child.
+;; That sibling's harvest consumed the child's one retained pass and dropped
+;; the marker before the child ever ran — the delayed child epoch then lost its
+;; queue-time dispatch/source row (parent-dispatch-id, source, source-detail,
+;; origin, call-site) and parent-child causality. The harvest-count heuristic
+;; conflated "a sibling ran ahead of the child" (legitimate — must retain) with
+;; "the child never ran" (a strand). Retaining until the matching run-start
+;; claims the marker is correct for ANY number of intervening sibling settles.
 ;;
-;; The bound: stamp each retained theirs marker with a private survival
-;; counter (`::theirs-harvests`). The FIRST time a marker is theirs it is
-;; retained with the counter at 1 (its child still has its chance to run).
-;; The SECOND time the same marker would be theirs the child has demonstrably
-;; not come to claim it within its run-to-completion window, so it is
-;; RECLAIMED (dropped) rather than re-retained. The normal child-runs path is
-;; untouched: the marker is claimed as mine at the next harvest, before it can
-;; reach the drop threshold. The private key never escapes — only stranded
-;; markers being dropped ever carry it past one harvest, and a marker harvested
-;; as mine is stripped of it (defensive; the normal path never stamps it onto a
-;; mine-classified event anyway).
-(def ^:private theirs-harvests-key ::theirs-harvests)
-
-(def ^:private theirs-retention-limit
-  ;; A theirs marker may survive at most ONE harvest as theirs (the parent's,
-  ;; which strands it); on the harvest that would make it theirs a SECOND time
-  ;; its child never ran, so it is reclaimed. 1 = "retain across one harvest,
-  ;; drop on the next."
-  1)
-
-(defn- strip-strand-stamp
-  "Drop the private rf2-fxowr survival counter from an event map so it never
-  escapes into a harvested epoch's `:trace-events`. A no-op for the
-  overwhelming majority of events (the key is absent)."
-  [ev]
-  (if (contains? ev theirs-harvests-key)
-    (dissoc ev theirs-harvests-key)
-    ev))
+;; The memory bound rf2-fxowr guarded is preserved WITHOUT the count: a child
+;; that NEVER runs to a settle has its marker cleared by the same terminal path
+;; that ends the child's life — `on-frame-destroyed!` / `discard-buffer!` drop
+;; the whole frame buffer (frame destroyed / drain-interrupted), the per-event
+;; depth-halt `commit-halt-record!` reads-and-CLEARS the whole buffer
+;; (`harvest-buffer!`), and a rejected/aborted child dispatch reaches the
+;; no-run-start branch below which clears-and-returns the whole buffer. Each of
+;; those wholesale-clears the stranded marker; none leaves it to accrete. The
+;; nil-id orphan self-cleaning rf2-ee38b established at this same seam (an
+;; orphan has no settle to ever claim it AND rides no terminal clear of its own)
+;; is unchanged — orphans are still dropped here on every harvest.
 
 (defn harvest-buffer-for-event!
   "Per rf2-nj6p7 — per-event harvest. Atomically read the frame's in-flight
@@ -950,10 +960,11 @@
       one `:dispatch-id` = one epoch). It stays buffered for the child's
       own `harvest-buffer-for-event!` at the child's settle.
 
-  Per rf2-fxowr a stranded theirs marker (its child never ran) is RECLAIMED
-  after surviving more than one harvest as theirs, so the buffer stays bounded
-  — the self-cleaning posture rf2-ee38b established for nil-id orphans, now
-  extended to the non-nil stranded-child case.
+  Per rf2-bhglx a theirs marker is RETAINED until its child's own run-start
+  claims it (any number of intervening sibling settles), not for a fixed
+  harvest count. A child that never runs is bounded by the terminal paths that
+  clear the whole buffer (frame destroy / drain-interrupt / depth-halt /
+  rejected dispatch); see the design note above this defn.
 
   Falls back to a full read-and-clear when the buffer carries no
   `:event/run-start` (a rejected / aborted dispatch) — there is no
@@ -969,9 +980,10 @@
       ;;       — a child's `:event/dispatched` marker fired during THIS event's
       ;;         do-fx carrying the CHILD's id; LEFT in the buffer for the
       ;;         child's own settle (Spec 009 §Dispatch correlation: one
-      ;;         dispatch-id = one epoch) — UNLESS it has already survived a
-      ;;         prior harvest as theirs (rf2-fxowr stranded child), in which
-      ;;         case it is reclaimed below.
+      ;;         dispatch-id = one epoch). RETAINED across every intervening
+      ;;         sibling harvest until the child's own run-start claims it as
+      ;;         mine (rf2-bhglx — siblings queued ahead of a FIFO-tail child
+      ;;         settle first, so the child's claim can be many harvests away).
       ;;   * ORPHAN (nil event-dispatch-id)
       ;;       — an out-of-cascade emit (e.g. `:frame/created`) with no
       ;;         cascade to ride. DISCARDED here.
@@ -989,35 +1001,31 @@
       ;; orphan never folds into an epoch's `:trace-events`; this only changes
       ;; whether it lingers in the buffer (no) vs. is dropped (yes).
       ;;
-      ;; Per rf2-fxowr the SAME self-cleaning now covers a stranded non-nil
-      ;; child: a theirs marker carries a private `::theirs-harvests` survival
-      ;; counter; one whose counter already reached the retention limit (its
-      ;; child never ran to a settle within its RTC window) is reclaimed rather
-      ;; than re-retained, so `capture-buffers` stays bounded.
-      (let [mine   (mapv strip-strand-stamp
-                         (filterv (fn [ev] (= (-> ev :tags :rf.trace/dispatch-id) settling-id))
-                                  buffer))
-            ;; Theirs markers that have NOT yet exhausted their retention —
-            ;; bumped one survival generation and kept for the child's settle.
-            theirs (into []
-                         (keep (fn [ev]
-                                 (let [event-dispatch-id (-> ev :tags :rf.trace/dispatch-id)]
-                                   (when (and (some? event-dispatch-id)
-                                              (not= event-dispatch-id settling-id))
-                                     (let [survived (get ev theirs-harvests-key 0)]
-                                       (when (< survived theirs-retention-limit)
-                                         (assoc ev theirs-harvests-key (inc survived))))))))
-                         buffer)]
-        ;; Leave the surviving other-event markers in the buffer for their own
-        ;; event's settle; drop orphans, ours, and stranded (retention-exhausted)
-        ;; theirs markers.
+      ;; Per rf2-bhglx a stranded non-nil child (one that never runs to a
+      ;; settle) is bounded WITHOUT a per-marker survival counter: the
+      ;; terminal path that ends the child's life clears the whole buffer (see
+      ;; the design note above this defn). A harvest-count reclaim would have
+      ;; dropped a LEGITIMATE child whose sibling merely ran ahead of it on the
+      ;; FIFO, losing the child's queue-time dispatch row — so the marker is
+      ;; retained here on every sibling harvest.
+      (let [mine   (filterv (fn [ev] (= (-> ev :tags :rf.trace/dispatch-id) settling-id))
+                            buffer)
+            ;; Other-event markers: a non-nil dispatch-id that isn't the
+            ;; settling event's. Kept verbatim for the child's own settle.
+            theirs (filterv (fn [ev]
+                              (let [event-dispatch-id (-> ev :tags :rf.trace/dispatch-id)]
+                                (and (some? event-dispatch-id)
+                                     (not= event-dispatch-id settling-id))))
+                            buffer)]
+        ;; Leave the other-event markers in the buffer for their own event's
+        ;; settle; drop orphans (nil dispatch-id) and the harvested-mine events.
         (if (seq theirs)
           (swap! capture-buffers assoc frame-id theirs)
           (swap! capture-buffers dissoc frame-id))
         mine)
       ;; No run-start — rejected/aborted dispatch. Clear and return all.
       (do (swap! capture-buffers dissoc frame-id)
-          (mapv strip-strand-stamp buffer)))))
+          buffer))))
 
 (defn drop-frame-buffer!
   "Drop the frame's in-flight capture buffer."

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -615,6 +615,64 @@
                a genuine re-render rides its own cascade, never collapses back
                to the mount epoch"))))))
 
+(deftest inv-3-keep-0-render-attributed-via-sub-runs-to-current-epoch
+  (testing "rf2-bhglx — with `:trace-events-keep 0` every record's raw
+            `:trace-events` are elided while the structured `:sub-runs` rows are
+            RETAINED (the memory/privacy posture). A genuine re-render's
+            value-change evidence then lives ONLY in the newest epoch's
+            `:sub-runs`. Pre-fix `value-changed-epoch-for` scanned only
+            `:trace-events` and broke at the first trace-elided record (the
+            NEWEST one under keep-0), so it found no value-change and the render
+            was mis-attributed to the mount/default epoch. The fix consults the
+            structured `:sub-runs` (learned dep + `:value-changed? true`) when
+            the raw stream is absent, so the render lands on the CURRENT epoch."
+    (rf/configure! :epoch-history {:trace-events-keep 0})
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed        (fn [_ _] {:counter 0}))
+    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+
+    ;; Mount: seed cascade + the synchronous in-render deref that teaches the
+    ;; view's read-set (`:counter`). The render-deps learning is independent of
+    ;; `:trace-events-keep`, so the read-set is learned even under keep-0.
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (let [mount-epoch (last-epoch :test/main)]
+      (emit-mount-sub-run! :test/main :counter cv-rk nil 0)
+      (emit-render! :test/main cv-rk)
+
+      ;; A later cascade genuinely changes the view's input. The value-changing
+      ;; sub-run back-fills into THIS cascade's `:sub-runs` (the structured row
+      ;; is appended even though the raw `:trace-events` are elided), then the
+      ;; re-render commits post-settle.
+      (rf/dispatch-sync [:counter-inc] {:frame :test/main})
+      (let [inc-epoch (last-epoch :test/main)]
+        (emit-sub-run! :test/main :counter 0 1)
+        (emit-render! :test/main cv-rk)
+
+        (let [mount-rec (epoch-by-id :test/main mount-epoch)
+              inc-rec   (epoch-by-id :test/main inc-epoch)]
+          ;; Precondition: the structured evidence the scan must consult is
+          ;; present on the current epoch, while its raw trace stream is gone.
+          (is (not (contains? inc-rec :trace-events))
+              "keep-0 elided the current epoch's raw :trace-events")
+          (is (some (fn [row] (and (= :counter (:sub-id row))
+                                   (true? (:value-changed? row))))
+                    (:sub-runs inc-rec))
+              "the value-changing :counter sub-run is in the current epoch's
+               structured :sub-runs")
+          ;; The fix: the genuine re-render lands on the CURRENT epoch (its
+          ;; cause). Pre-fix the scan found no value-change (raw traces elided,
+          ;; structured rows ignored), resolved to the mount epoch where cv-rk
+          ;; already had its mount render, and the re-render was DEDUP'd away —
+          ;; so the current epoch carried NO cv-rk render at all.
+          (is (contains? (rendered-keys inc-rec) cv-rk)
+              "rf2-bhglx — the re-render is attributed to the current epoch via
+               its :sub-runs value-change, even with raw traces elided")
+          ;; The mount epoch carries its OWN mount render (correct), but NOT a
+          ;; second one — the re-render did not also collapse onto it.
+          (is (= 1 (count (filter #(= cv-rk (:render-key %)) (:renders mount-rec))))
+              "the mount epoch carries exactly its mount render for cv-rk, not
+               the re-render too"))))))
+
 ;; ===========================================================================
 ;; INVARIANT 4 — :rf.sub/value-changed? + :rf.sub/cause-sub land on the correct epoch
 ;;                (rf2-wi900 / rf2-l1jz8)
@@ -891,18 +949,16 @@
              self-cleaning, not reliant on the upstream guard")))))
 
 (deftest inv-6b-harvest-retains-child-marker-for-its-own-settle
-  (testing "rf2-ee38b — the self-cleaning harvest must NOT discard a CHILD's
-            dispatch-id marker: a non-nil dispatch-id that differs from the
-            settling event's id is a child's `:event/dispatched` marker (fired
-            during the parent's do-fx) and stays buffered for the child's own
-            settle (Spec 009 §Dispatch correlation: one dispatch-id = one
+  (testing "rf2-ee38b / rf2-bhglx — the self-cleaning harvest must NOT discard a
+            CHILD's dispatch-id marker: a non-nil dispatch-id that differs from
+            the settling event's id is a child's `:event/dispatched` marker
+            (fired during the parent's do-fx) and stays buffered for the child's
+            own settle (Spec 009 §Dispatch correlation: one dispatch-id = one
             epoch). Only nil-id orphans are dropped.
 
-            rf2-fxowr — the retained marker carries a PRIVATE survival counter
-            so a STRANDED marker (its child never settles) can be reclaimed on a
-            later harvest (inv-6c). The counter is internal book-keeping; assert
-            on the marker's identity (its dispatch-id + operation), not bare map
-            equality, since the stamp is now present."
+            rf2-bhglx — the retained marker is kept VERBATIM (no private survival
+            counter); claim-based retention holds it until the child's run-start
+            claims it. Bare map equality is the right assertion now."
     (let [frame      :test/harvest-child
           run-start  {:op-type :rf.event :operation :rf.event/run-start
                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 1 :rf.trace/event-id :parent}}
@@ -919,113 +975,154 @@
             retained  (state/buffer-for frame)]
         (is (= [run-start body] harvested)
             "the parent's harvest takes only its own (dispatch-id 1) traces")
-        ;; The child marker (dispatch-id 2) is RETAINED; the orphan is DROPPED.
-        (is (= 1 (count retained))
-            "exactly the child's marker stays buffered; the nil-id orphan is dropped")
-        (is (= 2 (-> retained first :tags :rf.trace/dispatch-id))
-            "the retained marker IS the child's (dispatch-id 2) marker")
-        (is (= :rf.event/dispatched (-> retained first :operation))
-            "and it is the child's :event/dispatched marker, kept for the child's own settle")
+        ;; The child marker (dispatch-id 2) is RETAINED VERBATIM; orphan DROPPED.
+        (is (= [child-mark] retained)
+            "exactly the child's marker stays buffered, bare (no private stamp);
+             the nil-id orphan is dropped")
         (state/drop-frame-buffer! frame)))))
 
-(deftest inv-6c-harvest-reclaims-stranded-child-marker
-  (testing "rf2-fxowr — a STRANDED child `:event/dispatched` marker (its child
-            never runs to a settle: unregistered handler, frame
-            destroyed/drain-interrupted before dequeue, or depth-halt clears the
-            queue with the child still pending) must NOT accrete in the hottest
-            atom (`capture-buffers`) indefinitely.
+(deftest inv-6c-harvest-retains-child-marker-across-sibling-settles
+  (testing "rf2-bhglx — a child's `:event/dispatched` marker (fired during the
+            parent's do-fx, carrying the CHILD's id) must survive EVERY
+            intervening sibling settle until the child's own run-start claims it.
+            Ordinary `:dispatch` fx children go to the router FIFO TAIL
+            (`router/enqueue-envelope!`), so a sibling already queued behind the
+            parent settles BEFORE the child — possibly several of them. The child
+            epoch must still get its queue-time dispatch/source row (parent-
+            dispatch-id, source, origin, call-site) and parent-child causality.
 
-            inv-6b proves a child marker is RETAINED for its own settle — that
-            holds for a child that WILL run (claimed as `mine` at the very next
-            harvest). This invariant proves the complementary bound: a marker
-            whose child never settles is RECLAIMED after surviving more than one
-            harvest as `theirs`, so the buffer stays bounded. The non-nil
-            sibling of inv-6's nil-id orphan self-cleaning — the harvest is
-            self-cleaning for BOTH strand classes, not reliant on the upstream
-            terminal paths (rejected-child settle / depth-halt / drain-interrupt
-            clear) being perfect.
-
-            Pre-rf2-fxowr the marker was re-classified `theirs` and re-retained
-            on EVERY subsequent genuine settle for the long-lived frame — one
-            small residue per stranding incident, never GC'd while the frame
-            lives (slow UNBOUNDED accretion)."
-    (let [frame       :test/harvest-stranded
-          ;; A stranded child marker — its child (dispatch-id 99) never ran, so
-          ;; no settling-id will ever match it.
-          stranded    {:op-type :rf.event :operation :rf.event/dispatched
-                       :tags {:rf.trace/dispatch-id 99 :rf.trace/event-id :child-never-ran}}
-          ;; A first genuine, unrelated event settles for this long-lived frame.
-          rs-1        {:op-type :rf.event :operation :rf.event/run-start
-                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 7 :rf.trace/event-id :genuine-1}}
-          body-1      {:op-type :rf.event :operation :rf.event/db-changed
-                       :tags {:rf.trace/dispatch-id 7}}
-          ;; A second genuine, unrelated event settles later.
-          rs-2        {:op-type :rf.event :operation :rf.event/run-start
-                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 8 :rf.trace/event-id :genuine-2}}
-          body-2      {:op-type :rf.event :operation :rf.event/db-changed
-                       :tags {:rf.trace/dispatch-id 8}}]
-      ;; --- first genuine settle while the stranded marker sits in the buffer ---
-      (state/buffer-event! frame stranded)
-      (state/buffer-event! frame rs-1)
-      (state/buffer-event! frame body-1)
-      (let [h1     (state/harvest-buffer-for-event! frame)
-            after1 (state/buffer-for frame)]
-        (is (= [rs-1 body-1] h1)
-            "the first genuine event harvests ONLY its own (dispatch-id 7) traces")
-        (is (not-any? #(= 99 (-> % :tags :rf.trace/dispatch-id)) h1)
-            "the stranded marker is NOT folded into the genuine event's epoch")
-        (is (= 1 (count after1))
-            "the stranded marker survives the FIRST harvest as theirs (its child
-             still notionally has a chance to run within its RTC window)")
-
-        ;; --- second genuine settle: the child still never ran -> RECLAIM ---
-        (state/buffer-event! frame rs-2)
-        (state/buffer-event! frame body-2)
-        (let [h2     (state/harvest-buffer-for-event! frame)
-              after2 (state/buffer-for frame)]
-          (is (= [rs-2 body-2] h2)
-              "the second genuine event harvests ONLY its own (dispatch-id 8) traces")
-          (is (not-any? #(= 99 (-> % :tags :rf.trace/dispatch-id)) h2)
-              "the stranded marker is STILL not folded into a genuine epoch")
-          (is (empty? after2)
-              "rf2-fxowr — the stranded marker is RECLAIMED, not re-retained;
-               `capture-buffers` for the frame is now empty (bounded)")))
+            The earlier rf2-fxowr count-based reclaim DROPPED the marker after
+            one intervening harvest, which is exactly this legitimate
+            interleaving — the bug rf2-bhglx fixes. Memory is bounded by the
+            terminal paths that clear the whole buffer (drain-interrupt / depth-
+            halt / rejected dispatch), proven by inv-6c-bound below; it is NOT
+            bounded by a per-marker harvest count."
+    (let [frame       :test/harvest-sibling
+          child-mark  {:op-type :rf.event :operation :rf.event/dispatched
+                       :tags {:rf.trace/dispatch-id 99 :rf.trace/event-id :child
+                              :rf.trace/parent-dispatch-id 1 :source :reframe}}
+          ;; Three genuine, unrelated SIBLING events settle ahead of the child
+          ;; (queued behind the parent on the FIFO before the child's enqueue).
+          rs    (fn [id eid] {:op-type :rf.event :operation :rf.event/run-start
+                              :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id id :rf.trace/event-id eid}})
+          body  (fn [id]     {:op-type :rf.event :operation :rf.event/db-changed
+                              :tags {:rf.trace/dispatch-id id}})]
+      ;; The child marker is stranded into the buffer alongside the FIRST sibling.
+      (state/buffer-event! frame child-mark)
+      (doseq [[id eid] [[7 :sib-1] [8 :sib-2] [9 :sib-3]]]
+        (state/buffer-event! frame (rs id eid))
+        (state/buffer-event! frame (body id))
+        (let [h (state/harvest-buffer-for-event! frame)]
+          (is (= [(rs id eid) (body id)] h)
+              (str "sibling " eid " harvests ONLY its own traces"))
+          (is (not-any? #(= 99 (-> % :tags :rf.trace/dispatch-id)) h)
+              "the child marker is never folded into a sibling's epoch")
+          (is (= [child-mark] (state/buffer-for frame))
+              "rf2-bhglx — the child marker survives this sibling settle, kept
+               VERBATIM for the child's own settle")))
+      ;; Finally the child itself settles — its run-start claims the marker.
+      (state/buffer-event! frame (rs 99 :child))
+      (state/buffer-event! frame (body 99))
+      (let [child-harvest (state/harvest-buffer-for-event! frame)]
+        (is (= [child-mark (rs 99 :child) (body 99)] child-harvest)
+            "the child's settle finally claims its dispatch marker + own traces —
+             the queue-time dispatch/source row survives the FIFO interleaving")
+        (is (= 1 (->> child-harvest first :tags :rf.trace/parent-dispatch-id))
+            "the claimed marker still carries its parent-dispatch-id (causality)")
+        (is (empty? (state/buffer-for frame))
+            "buffer empty after the child settle"))
       (state/drop-frame-buffer! frame))))
 
-(deftest inv-6d-harvested-child-marker-carries-no-private-stamp
-  (testing "rf2-fxowr — the private survival counter is internal book-keeping;
-            it must NEVER escape into a harvested epoch's `:trace-events`. When
-            a retained marker is finally claimed as `mine` at its child's own
-            settle, the harvested event is stripped of the private key so the
-            recorded `:trace-events` shape is unchanged (behaviour-preserving for
-            the normal child-runs path)."
-    (let [frame       :test/harvest-clean
-          ;; Parent cascade strands the child marker (stamps it).
-          parent-rs   {:op-type :rf.event :operation :rf.event/run-start
-                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 1 :rf.trace/event-id :parent}}
-          parent-body {:op-type :rf.event :operation :rf.event/db-changed
-                       :tags {:rf.trace/dispatch-id 1}}
-          child-mark  {:op-type :rf.event :operation :rf.event/dispatched
-                       :tags {:rf.trace/dispatch-id 2 :rf.trace/event-id :child}}
-          ;; The child then RUNS: its run-start + body land in the buffer.
-          child-rs    {:op-type :rf.event :operation :rf.event/run-start
-                       :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 2 :rf.trace/event-id :child}}
-          child-body  {:op-type :rf.event :operation :rf.event/db-changed
-                       :tags {:rf.trace/dispatch-id 2}}]
-      (state/buffer-event! frame parent-rs)
-      (state/buffer-event! frame parent-body)
-      (state/buffer-event! frame child-mark)
-      (state/harvest-buffer-for-event! frame)          ; parent settles; marker stranded+stamped
-      (state/buffer-event! frame child-rs)
-      (state/buffer-event! frame child-body)
-      (let [child-harvest (state/harvest-buffer-for-event! frame)]
-        (is (= [child-mark child-rs child-body] child-harvest)
-            "the child's settle claims the marker + its own traces, BARE — no
-             private survival key leaks into the harvested epoch")
-        (is (every? #(not (contains? % :re-frame.epoch.state/theirs-harvests)) child-harvest)
-            "no harvested event carries the private rf2-fxowr survival counter")
+(deftest inv-6c-bound-stranded-marker-cleared-by-terminal-path
+  (testing "rf2-bhglx — a child that NEVER runs to a settle (handler
+            unregistered, frame destroyed / drain-interrupted, depth-halt clears
+            the queue) leaves its marker stranded, but it does NOT accrete: the
+            terminal path that ends the child's life clears the WHOLE buffer.
+            `drop-frame-buffer!` (frame destroy / discard) and the no-run-start
+            full clear-and-return (rejected dispatch) both wipe the stranded
+            marker. This is the memory bound that replaces the rf2-fxowr harvest-
+            count reclaim — bounded by lifecycle, not by a per-marker counter."
+    (let [frame    :test/harvest-stranded-bound
+          stranded {:op-type :rf.event :operation :rf.event/dispatched
+                    :tags {:rf.trace/dispatch-id 99 :rf.trace/event-id :child-never-ran}}]
+      ;; (a) drain-interrupt / frame-destroy terminal clear.
+      (state/buffer-event! frame stranded)
+      (is (= [stranded] (state/buffer-for frame))
+          "the stranded marker is buffered")
+      (state/drop-frame-buffer! frame)
+      (is (empty? (state/buffer-for frame))
+          "drop-frame-buffer! (destroy / discard) clears the stranded marker")
+
+      ;; (b) rejected-dispatch terminal clear: a buffer with NO run-start (the
+      ;; child's dispatch was rejected) reaches the no-run-start branch, which
+      ;; clears-and-returns the whole buffer.
+      (state/buffer-event! frame stranded)
+      (let [returned (state/harvest-buffer-for-event! frame)]
+        (is (= [stranded] returned)
+            "a no-run-start harvest returns the buffer (the degenerate record is
+             suppressed downstream by settle!'s empty-buffer policy)")
         (is (empty? (state/buffer-for frame))
-            "buffer empty after the child settle (normal path fully cleared)"))
+            "and clears it — the stranded marker does not accrete")))))
+
+(deftest inv-6c-bead-sibling-queued-behind-parent-does-not-drop-child
+  (testing "rf2-bhglx (the bead's named scenario) — queue B behind parent A; A
+            dispatches child C (C's `:event/dispatched` marker rides A's window
+            but carries C's id, and C goes to the FIFO TAIL behind B). When B
+            settles BEFORE C, B's harvest must NOT consume C's marker; C must
+            still receive its `:event/dispatched` marker at its own settle, while
+            neither A nor B carries it.
+
+            Pre-rf2-bhglx the count-1 reclaim dropped C's marker on B's harvest
+            (the one allowed intervening pass), so C lost its queue-time dispatch
+            row. The harvest seam is the exact locus; this drives it directly to
+            stay deterministic (the FIFO timing is unreproducible in synchronous
+            dispatch-sync)."
+    (let [frame    :test/bead-abc
+          a-rs     {:op-type :rf.event :operation :rf.event/run-start
+                    :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id :A :rf.trace/event-id :parent-a}}
+          a-body   {:op-type :rf.event :operation :rf.event/db-changed
+                    :tags {:rf.trace/dispatch-id :A}}
+          ;; C's dispatch marker fires during A's do-fx — lands in A's window.
+          c-mark   {:op-type :rf.event :operation :rf.event/dispatched
+                    :tags {:rf.trace/dispatch-id :C :rf.trace/event-id :child-c
+                           :rf.trace/parent-dispatch-id :A}}
+          b-rs     {:op-type :rf.event :operation :rf.event/run-start
+                    :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id :B :rf.trace/event-id :sibling-b}}
+          b-body   {:op-type :rf.event :operation :rf.event/db-changed
+                    :tags {:rf.trace/dispatch-id :B}}
+          c-rs     {:op-type :rf.event :operation :rf.event/run-start
+                    :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id :C :rf.trace/event-id :child-c}}
+          c-body   {:op-type :rf.event :operation :rf.event/db-changed
+                    :tags {:rf.trace/dispatch-id :C}}]
+      ;; A settles, stranding C's marker in the buffer.
+      (state/buffer-event! frame a-rs)
+      (state/buffer-event! frame a-body)
+      (state/buffer-event! frame c-mark)
+      (let [a-harvest (state/harvest-buffer-for-event! frame)]
+        (is (= [a-rs a-body] a-harvest) "A's epoch carries A's traces only")
+        (is (not-any? #(= :C (-> % :tags :rf.trace/dispatch-id)) a-harvest)
+            "A does NOT carry C's dispatch marker"))
+
+      ;; B settles next (it was queued ahead of FIFO-tail C). B must leave C's
+      ;; marker alone — this is the exact harvest the count-1 reclaim broke.
+      (state/buffer-event! frame b-rs)
+      (state/buffer-event! frame b-body)
+      (let [b-harvest (state/harvest-buffer-for-event! frame)]
+        (is (= [b-rs b-body] b-harvest) "B's epoch carries B's traces only")
+        (is (not-any? #(= :C (-> % :tags :rf.trace/dispatch-id)) b-harvest)
+            "B does NOT carry C's dispatch marker")
+        (is (= [c-mark] (state/buffer-for frame))
+            "rf2-bhglx — C's marker SURVIVES B's intervening settle (not dropped
+             by a harvest-count reclaim)"))
+
+      ;; C finally settles — claims its own marker (+ queue-time dispatch row).
+      (state/buffer-event! frame c-rs)
+      (state/buffer-event! frame c-body)
+      (let [c-harvest (state/harvest-buffer-for-event! frame)]
+        (is (= [c-mark c-rs c-body] c-harvest)
+            "C's epoch finally claims its :event/dispatched marker + own traces")
+        (is (= :A (-> c-harvest first :tags :rf.trace/parent-dispatch-id))
+            "C's claimed marker still names parent A (parent-child causality kept)"))
       (state/drop-frame-buffer! frame))))
 
 ;; ===========================================================================

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -265,22 +265,26 @@
     (is (pos? (count (rf/epoch-history :rf/default)))
         "with the gate ON, a dispatch lands a record in the ring")))
 
-;; ---- 6. Bounded capture buffer — stranded child marker reclaim (rf2-fxowr) --
+;; ---- 6. Capture buffer — claim-based child marker retention (rf2-bhglx) ----
 ;;
-;; The cross-target pin for the JVM `epoch-attribution-test/inv-6c`. The harvest
+;; The cross-target pin for the JVM `epoch-attribution-test/inv-6c…`. The harvest
 ;; seam lives in `re-frame.epoch.state` (.cljc), so it runs under CLJS too; this
-;; locks the bounded-`theirs`-retention contract on the CLJS runtime — a child
-;; `:event/dispatched` marker whose child never settles is RECLAIMED after
-;; surviving more than one harvest, so `capture-buffers` (the hottest atom)
-;; stays bounded rather than accreting one residue per stranding incident.
+;; locks the claim-based retention contract on the CLJS runtime — a child
+;; `:event/dispatched` marker is RETAINED VERBATIM across every intervening
+;; sibling settle until the child's own run-start claims it (ordinary :dispatch
+;; fx children go to the FIFO tail, so siblings can settle ahead of the child).
+;; The earlier rf2-fxowr count-1 reclaim dropped a legitimate child marker on
+;; the first intervening sibling harvest; rf2-bhglx removes that, bounding memory
+;; via the terminal paths that clear the whole buffer instead.
 
-(deftest stranded-child-marker-reclaimed-cljs
-  (testing "rf2-fxowr — a stranded child marker (its child never runs to a
-            settle) does NOT accrete in `capture-buffers`: it is retained across
-            one harvest as theirs, then reclaimed on the next genuine settle."
+(deftest child-marker-retained-across-sibling-settles-cljs
+  (testing "rf2-bhglx — a child marker survives intervening sibling settles and
+            is claimed only at the child's own settle; a truly-stranded marker is
+            bounded by the terminal buffer clear (drop-frame-buffer!)."
     (let [frame    :test/stranded-cljs
-          stranded {:op-type :rf.event :operation :rf.event/dispatched
-                    :tags {:rf.trace/dispatch-id 99 :rf.trace/event-id :child-never-ran}}
+          c-mark   {:op-type :rf.event :operation :rf.event/dispatched
+                    :tags {:rf.trace/dispatch-id 99 :rf.trace/event-id :child
+                           :rf.trace/parent-dispatch-id 7}}
           rs-1     {:op-type :rf.event :operation :rf.event/run-start
                     :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 7 :rf.trace/event-id :g1}}
           body-1   {:op-type :rf.event :operation :rf.event/db-changed
@@ -288,22 +292,38 @@
           rs-2     {:op-type :rf.event :operation :rf.event/run-start
                     :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 8 :rf.trace/event-id :g2}}
           body-2   {:op-type :rf.event :operation :rf.event/db-changed
-                    :tags {:rf.trace/dispatch-id 8}}]
-      (state/buffer-event! frame stranded)
+                    :tags {:rf.trace/dispatch-id 8}}
+          c-rs     {:op-type :rf.event :operation :rf.event/run-start
+                    :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 99 :rf.trace/event-id :child}}
+          c-body   {:op-type :rf.event :operation :rf.event/db-changed
+                    :tags {:rf.trace/dispatch-id 99}}]
+      ;; Parent (id 7) settles, stranding C's marker; then sibling (id 8) settles.
+      (state/buffer-event! frame c-mark)
       (state/buffer-event! frame rs-1)
       (state/buffer-event! frame body-1)
       (let [h1 (state/harvest-buffer-for-event! frame)]
-        (is (= [rs-1 body-1] h1)
-            "the first genuine event harvests ONLY its own traces")
-        (is (= 1 (count (state/buffer-for frame)))
-            "the stranded marker survives one harvest as theirs"))
+        (is (= [rs-1 body-1] h1) "parent harvests ONLY its own traces")
+        (is (= [c-mark] (state/buffer-for frame))
+            "C's marker survives the parent harvest, verbatim"))
       (state/buffer-event! frame rs-2)
       (state/buffer-event! frame body-2)
       (let [h2 (state/harvest-buffer-for-event! frame)]
-        (is (= [rs-2 body-2] h2)
-            "the second genuine event harvests ONLY its own traces")
+        (is (= [rs-2 body-2] h2) "the sibling harvests ONLY its own traces")
         (is (not-any? #(= 99 (-> % :tags :rf.trace/dispatch-id)) h2)
-            "the stranded marker is never folded into a genuine epoch")
-        (is (empty? (state/buffer-for frame))
-            "rf2-fxowr — the stranded marker is RECLAIMED; the buffer is bounded"))
-      (state/drop-frame-buffer! frame))))
+            "C's marker is never folded into the sibling's epoch")
+        (is (= [c-mark] (state/buffer-for frame))
+            "rf2-bhglx — C's marker SURVIVES the intervening sibling settle"))
+      ;; C finally settles, claiming its own marker.
+      (state/buffer-event! frame c-rs)
+      (state/buffer-event! frame c-body)
+      (let [hc (state/harvest-buffer-for-event! frame)]
+        (is (= [c-mark c-rs c-body] hc)
+            "C's settle claims its dispatch marker + own traces")
+        (is (= 7 (-> hc first :tags :rf.trace/parent-dispatch-id))
+            "the claimed marker still names its parent (causality kept)")
+        (is (empty? (state/buffer-for frame)) "buffer empty after C settles"))
+      ;; A truly-stranded marker is bounded by the terminal buffer clear.
+      (state/buffer-event! frame c-mark)
+      (state/drop-frame-buffer! frame)
+      (is (empty? (state/buffer-for frame))
+          "rf2-bhglx — drop-frame-buffer! (terminal path) clears a stranded marker"))))


### PR DESCRIPTION
@-