### PR TITLE
fix(http): multi-valued headers + accept-phase isolation + merge-params fragments (rf2-rznrz)

### DIFF
--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -76,13 +76,64 @@
        (str/join "&")))
 
 (defn merge-params
-  "Merge `:params` onto `:url`. If the URL already has a `?`, append with `&`."
+  "Merge `:params` onto `:url`, returning the URL with the encoded query
+  string spliced in BEFORE any `#fragment`.
+
+  Two correctness rules a naive append breaks (rf2-rznrz):
+
+  1. **Fragment-aware splice.** Query params after a `#` are fragment
+     text — real HTTP clients send the fragment to nobody, so a naive
+     append (`/items#frag` + `{:page 2}` → `/items#frag?page=2`)
+     silently drops the params. We split at the first `#`, append the
+     query string to the pre-fragment part with `?` (or `&` when that
+     part already carries a `?`), then reattach the fragment verbatim.
+
+  2. **Decide on the ENCODED query, not the raw params.** A params map
+     can encode to no pairs (e.g. `{:tag []}` → `\"\"` per
+     `params->query`'s empty-sequential rule), so deciding to append
+     from `(seq params)` alone produces a dangling `?`/`&`. We build the
+     query string first and return the URL unchanged when it is blank."
   [url params]
-  (if (seq params)
-    (let [qs (params->query params)
-          sep (if (str/includes? url "?") "&" "?")]
-      (str url sep qs))
-    url))
+  (let [qs (params->query params)]
+    (if (str/blank? qs)
+      url
+      (let [hash-idx (str/index-of url "#")
+            base     (if hash-idx (subs url 0 hash-idx) url)
+            fragment (if hash-idx (subs url hash-idx) "")
+            sep      (if (str/includes? base "?") "&" "?")]
+        (str base sep qs fragment)))))
+
+;; ---- request header normalisation -----------------------------------------
+
+(defn normalize-header-pairs
+  "Flatten a request-headers map into an ordered seq of `[name value]`
+  wire pairs (rf2-rznrz).
+
+  Per Spec 014 §Request envelope a request header value is `string` for
+  the single-value case or `vector-of-strings` (more generally any
+  ordered `sequential?` collection) for the multi-valued case. HTTP
+  represents a multi-valued header as the header NAME repeated once per
+  value — `Accept: a` + `Accept: b`, never a single `Accept: [\"a\" \"b\"]`
+  line. So:
+
+  - a scalar value yields one `[name (str value)]` pair, and
+  - a sequential value yields one `[name (str element)]` pair per
+    element, in order.
+
+  The name is stringified once; values are stringified per element so a
+  keyword / number value lands as its plain string form on the wire (the
+  prior CLJS path assigned a vector straight into a `HeadersInit`, and
+  the JVM path called `(str v)` on the whole vector — both produced a
+  single malformed wire value). An empty sequential value contributes no
+  pair (the header is simply absent), mirroring `params->query`'s
+  empty-sequential rule."
+  [headers]
+  (mapcat (fn [[k v]]
+            (let [name (str k)]
+              (if (sequential? v)
+                (map (fn [el] [name (str el)]) v)
+                [[name (str v)]])))
+          headers))
 
 ;; ---- body encoding --------------------------------------------------------
 
@@ -143,6 +194,26 @@
   (if accept-fn-or-nil
     (accept-fn-or-nil decoded)
     {:ok decoded}))
+
+(defn valid-accept-return?
+  "rf2-rznrz — is `v` a recognised `:accept` return shape? Per Spec 014
+  §`:accept` the contract is `(decoded → {:ok v} | {:failure m})`: a map
+  carrying EXACTLY one of `:ok` / `:failure`.
+
+  Used by `http-transport/handle-response!` to validate the accept-phase
+  return AFTER the request has completed. A malformed return (nil, a
+  non-map, or a map carrying neither key) previously cleared the
+  in-flight request and dispatched NO reply — the caller hung forever.
+  Validating the shape lets the transport classify a malformed return as
+  `:rf.http/accept-failure` and always emit a reply."
+  [v]
+  (and (map? v)
+       (let [has-ok?      (contains? v :ok)
+             has-failure? (contains? v :failure)]
+         ;; Exactly one of the two recognised keys — a map carrying both
+         ;; is ambiguous and rejected alongside the map-carrying-neither
+         ;; case.
+         (not= has-ok? has-failure?))))
 
 ;; ---- reply addressing -----------------------------------------------------
 

--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -280,15 +280,17 @@
         ;; directly instead of re-running the OR-chain.
         origin-event (encoding/resolve-origin-event frame-ctx args-map)
         frame-ctx'   (assoc frame-ctx :event origin-event)
-        ;; rf2-1jcpm — resolve :sensitive? once at handler entry so
-        ;; the middleware-failure trace path (URL leak via
-        ;; `:rf.error/http-interceptor-failed`) and the JVM CLJS-only
-        ;; warning path (`:rf.http/cljs-only-key-ignored-on-jvm`) both
-        ;; redact through the privacy composer. `normalise-args` then
-        ;; re-derives the same flag from `args-map` — the values agree
-        ;; by construction.
+        ;; rf2-1jcpm — resolve :sensitive? at handler entry so the
+        ;; middleware-failure trace path (URL leak via
+        ;; `:rf.error/http-interceptor-failed`) can redact through the
+        ;; privacy composer for a request that arrived already sensitive.
+        ;; rf2-rznrz — this PRE-chain reading is the floor; the EFFECTIVE
+        ;; sensitivity is recomputed below from the post-`:before` request
+        ;; (a `:before` may MARK the request sensitive) before the
+        ;; CLJS-only-key warning and `normalise-args` run. The chain
+        ;; itself recomputes per-interceptor for its own failure-path
+        ;; trace (see `run-chain*` / `run-interceptor-chain!`).
         sensitive?   (privacy/request-sensitive? args-map origin-event)
-        _            (transport/check-cljs-only-keys! args-map sensitive?)
         ctx0         {:request    (:request args-map)
                       :args       args-map
                       :frame      frame-id
@@ -303,6 +305,23 @@
         ;; downstream. Mirrors `validate-retry!`'s dispatch-time guard.
         _            (validate-url! (:request ctx))
         args-map'    (assoc args-map :request (:request ctx))
+        ;; rf2-rznrz — recompute the EFFECTIVE :sensitive? from the
+        ;; POST-`:before` request, then run the CLJS-only-key check
+        ;; against that same post-chain request. Both were previously
+        ;; evaluated on the ORIGINAL args BEFORE the chain ran, so:
+        ;;   - a `:before` that MARKED the request sensitive (set
+        ;;     `[:request :sensitive?] true`) did not raise the flag the
+        ;;     CLJS-only warning / `normalise-args` saw — a downstream
+        ;;     trace could leak a now-sensitive URL's query values; and
+        ;;   - a `:before` that ADDED a JVM-degraded CLJS-only key
+        ;;     (`:credentials` / `:mode` / `:cache` / …) into the request
+        ;;     escaped the degraded-key warning entirely (the request
+        ;;     proceeded on JVM silently dropping the key).
+        ;; Recomputing here closes both: the warning fires on the request
+        ;; the transport will actually issue, redacted by the effective
+        ;; sensitivity.
+        sensitive?'  (privacy/request-sensitive? args-map' origin-event)
+        _            (transport/check-cljs-only-keys! args-map' sensitive?')
         ;; rf2-uheqq — carry the post-:before middleware-ctx forward so
         ;; the response-side `:after` chain sees the EXACT same ctx its
         ;; sibling `:before`s ended with. Per Spec 014 §Middleware: a

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -229,7 +229,7 @@
 ;; for `:after`), and the bad-return sentence. The load-bearing comments
 ;; on each wrapper preserve the per-path rationale.
 (defn- run-chain*
-  [{:keys [chain frame-id slot-key invoke sensitive? where phase url-of slot-noun]} init]
+  [{:keys [chain frame-id slot-key invoke sensitive-of where phase url-of slot-noun]} init]
   (reduce
     (fn [acc interceptor]
       (let [{:keys [id]} interceptor
@@ -275,10 +275,19 @@
                   ;; and `:sensitive?` is stamped on the trace event when
                   ;; either the handler/per-call sensitivity OR the URL's
                   ;; query string carries a denylisted param name.
+                  ;;
+                  ;; rf2-rznrz — `sensitive-of` recomputes the EFFECTIVE
+                  ;; sensitivity from the CURRENT accumulator (the evolving
+                  ;; ctx a prior `:before` may have MARKED sensitive), not a
+                  ;; flag captured before the chain ran. Previously a
+                  ;; `:before` that set `[:request :sensitive?] true`
+                  ;; followed by a later `:before` that threw emitted this
+                  ;; diagnostic with the stale non-sensitive flag, leaking
+                  ;; non-denylisted query values for a now-sensitive request.
                   (trace/emit-error! :rf.error/http-interceptor-failed
                                      (privacy/prepare-emit-failure
                                        (ex-data data)
-                                       sensitive?)))
+                                       (sensitive-of acc))))
                 (throw data))))
           acc)))
     init
@@ -310,7 +319,16 @@
      ;; interceptor actually saw it.
      :invoke     (fn [before acc] (before acc))
      :url-of     #(get-in % [:request :url])
-     :sensitive? (true? (:sensitive? ctx))
+     ;; rf2-rznrz — recompute effective sensitivity from the CURRENT
+     ;; accumulator at the failure site, not a flag fixed before the
+     ;; chain ran. A `:before` may MARK the request sensitive (set
+     ;; `[:request :sensitive?] true`) — mirrors `privacy/request-
+     ;; sensitive?`'s top-level-or-`:request` OR-reduction, applied to
+     ;; the threaded ctx so a later `:before`'s throw redacts under the
+     ;; sensitivity the request carries at the moment it failed.
+     :sensitive-of (fn [acc]
+                     (or (true? (:sensitive? acc))
+                         (true? (get-in acc [:request :sensitive?]))))
      :where      'rf.http/run-interceptor-chain!
      :slot-noun  ":before did not return a ctx map"}
     ctx))
@@ -343,7 +361,14 @@
      ;; reduce), so the URL is read from that ctx rather than the acc.
      :invoke     (fn [after acc] (after middleware-ctx acc))
      :url-of     (fn [_acc] (get-in middleware-ctx [:request :url]))
-     :sensitive? (true? (:sensitive? middleware-ctx))
+     ;; rf2-rznrz — the `:after` chain threads the RESPONSE through `acc`;
+     ;; the request ctx is the fixed `middleware-ctx` the `:before` chain
+     ;; ended with, so effective sensitivity is recomputed from THAT
+     ;; (constant across `:after` steps), not the evolving response acc.
+     ;; Mirrors `privacy/request-sensitive?`'s OR-reduction.
+     :sensitive-of (fn [_acc]
+                     (or (true? (:sensitive? middleware-ctx))
+                         (true? (get-in middleware-ctx [:request :sensitive?]))))
      :where      'rf.http/run-after-chain!
      :phase      :after
      :slot-noun  ":after did not return a response map"}

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -79,8 +79,20 @@
      (let [init     #js {}
            _        (do (aset init "method" (str/upper-case (name method)))
                         (when (seq headers)
-                          (let [h #js {}]
-                            (doseq [[k v] headers] (aset h k v))
+                          ;; rf2-rznrz — build a Fetch `Headers` object and
+                          ;; `.append` each normalised wire pair. A scalar
+                          ;; header value yields one pair; a vector/seq value
+                          ;; yields one pair per element (`encoding/normalize-
+                          ;; header-pairs`), and `.append` ACCUMULATES repeated
+                          ;; names into the multi-valued wire form (`Accept: a`
+                          ;; + `Accept: b`) rather than overwriting. The prior
+                          ;; shape assigned the vector straight into a plain JS
+                          ;; object via `aset`, so a documented multi-valued
+                          ;; request header serialised as a single malformed
+                          ;; `[\"a\" \"b\"]` wire value.
+                          (let [h (js/Headers.)]
+                            (doseq [[k v] (encoding/normalize-header-pairs headers)]
+                              (.append h k v))
                             (aset init "headers" h)))
                         (when (some? body) (aset init "body" body))
                         (when credentials  (aset init "credentials" (name credentials)))
@@ -425,7 +437,7 @@
        ;; "no timeout" so the JDK request carries no per-request deadline.
        (when (and timeout-ms (pos? timeout-ms))
          (.timeout b (Duration/ofMillis (long timeout-ms))))
-       (doseq [[k v] headers]
+       (doseq [[k v] (encoding/normalize-header-pairs headers)]
          ;; rf2-9lun0 — surface JDK HttpClient header-validation throws
          ;; via a `:rf.warning/http-header-invalid` trace rather than
          ;; silently dropping. Stray `\r`/`\n` / control chars / empty
@@ -436,19 +448,27 @@
          ;; the offending header so a stray bad header doesn't sink
          ;; an otherwise-valid request; the trace is the alarm.
          ;;
+         ;; rf2-rznrz — `encoding/normalize-header-pairs` expands a
+         ;; documented multi-valued request header (string → vector of
+         ;; strings) into one `[name value]` pair per element, so we call
+         ;; `.header` ONCE PER VALUE — the JDK accumulates repeated names
+         ;; into the multi-valued wire form (`Accept: a` + `Accept: b`).
+         ;; The prior `(str v)` on the whole value stringified a vector
+         ;; into a single malformed `[\"a\" \"b\"]` header line.
+         ;;
          ;; rf2-1jcpm — the `:url` slot on the warning event is routed
          ;; through `privacy/prepare-emit-tags` so a denylisted query
          ;; param (`?api_key=…`) is scrubbed and `:sensitive?` is
          ;; stamped when the request is sensitive. Previously the raw
          ;; URL rode the trace surface even when the handler / request
          ;; was declared sensitive.
-         (try (.header b (str k) (str v))
+         (try (.header b k v)
               (catch Throwable t
                 (when interop/debug-enabled?
                   (trace/emit! :warning :rf.warning/http-header-invalid
                                (privacy/prepare-emit-tags
                                  {:url     url
-                                  :header  (str k)
+                                  :header  k
                                   :cause   (.getMessage t)}
                                  (true? sensitive?)))))))
        (.build b))))
@@ -1227,34 +1247,52 @@
                      :headers     headers})
 
       ok?
-      (try
-        (let [decoded  (decode/decode-response-body
-                         {:body-text        body-text
-                          ;; rf2-5zj6t — the CLJS transport reads a native
-                          ;; Blob / ArrayBuffer / FormData for binary decode
-                          ;; modes and rides it here; `decode-response-body`
-                          ;; returns it verbatim for `:blob` / `:array-buffer`
-                          ;; / `:form-data`. Absent on the text path / on JVM.
-                          :body-binary      body-binary
-                          :headers          headers
-                          :decode           decode
-                          :decode-supplied? decode-supplied?
-                          :request-id       request-id
-                          :url              url
-                          ;; rf2-xuvj7 — the originating event-id keys the
-                          ;; one-shot-per-handler decode-defaulted latch.
-                          ;; Nil for synthetic / test-path callers with no
-                          ;; origin event; the latch degrades to a shared
-                          ;; runtime-wide slot in that case.
-                          :handler-id       (first (:origin-event ctx))
-                          :sensitive?       (:sensitive? ctx)
-                          ;; rf2-wu1n5 — thread the keyword-cap from the
-                          ;; normalised ctx into the decoder; nil means
-                          ;; the reader uses its default.
-                          :max-decoded-keys (:max-decoded-keys ctx)})
-              accepted (encoding/run-accept accept decoded)]
-          (finalise-success! (assoc ctx :decoded decoded) accepted))
-        (catch #?(:clj Throwable :cljs :default) e
+      ;; rf2-rznrz — DECODE and ACCEPT are SEPARATE phases (Spec 014
+      ;; §Classification order steps 3 + 4). They were previously fused
+      ;; under one try/catch, so an `:accept` throw was misclassified as
+      ;; `:rf.http/decode-failure` (step-4 error masquerading as step-3),
+      ;; and a malformed `:accept` return (nil / a map without :ok/:failure)
+      ;; fell through `finalise-success!`'s `cond` with no matching branch —
+      ;; clearing the in-flight request and dispatching NO reply, so the
+      ;; caller hung forever. Now:
+      ;;
+      ;;   - the decode try/catch catches ONLY decoder exceptions →
+      ;;     `:rf.http/decode-failure`;
+      ;;   - accept runs in its OWN try/catch and its return is SHAPE-
+      ;;     VALIDATED (`encoding/valid-accept-return?`); an accept throw OR
+      ;;     a malformed return classifies as `:rf.http/accept-failure`
+      ;;     (the closed-set canonical bad-accept category) and ALWAYS
+      ;;     dispatches a reply.
+      (let [decode-result
+            (try
+              {:decoded
+               (decode/decode-response-body
+                 {:body-text        body-text
+                  ;; rf2-5zj6t — the CLJS transport reads a native
+                  ;; Blob / ArrayBuffer / FormData for binary decode
+                  ;; modes and rides it here; `decode-response-body`
+                  ;; returns it verbatim for `:blob` / `:array-buffer`
+                  ;; / `:form-data`. Absent on the text path / on JVM.
+                  :body-binary      body-binary
+                  :headers          headers
+                  :decode           decode
+                  :decode-supplied? decode-supplied?
+                  :request-id       request-id
+                  :url              url
+                  ;; rf2-xuvj7 — the originating event-id keys the
+                  ;; one-shot-per-handler decode-defaulted latch.
+                  ;; Nil for synthetic / test-path callers with no
+                  ;; origin event; the latch degrades to a shared
+                  ;; runtime-wide slot in that case.
+                  :handler-id       (first (:origin-event ctx))
+                  :sensitive?       (:sensitive? ctx)
+                  ;; rf2-wu1n5 — thread the keyword-cap from the
+                  ;; normalised ctx into the decoder; nil means
+                  ;; the reader uses its default.
+                  :max-decoded-keys (:max-decoded-keys ctx)})}
+              (catch #?(:clj Throwable :cljs :default) e
+                {:decode-error e}))]
+        (if-let [e (:decode-error decode-result)]
           (let [d (ex-data e)
                 ;; rf2-mdxd7 — the keyword-interning DoS cap (Spec 014
                 ;; §Keyword-interning cap) throws a structured
@@ -1285,7 +1323,50 @@
                 ;; with no `:cause`/`:limit`) carries no `:reason`/`:limit`
                 ;; slots — only the cap-overflow shape does.
                 (some? reason) (assoc :reason reason)
-                (some? limit)  (assoc :limit limit))))))
+                (some? limit)  (assoc :limit limit))))
+          ;; ---- ACCEPT phase (rf2-rznrz) -----------------------------
+          ;; Decode succeeded. Run `:accept` in its OWN try/catch and
+          ;; shape-validate the return. Three outcomes:
+          ;;   - returns `{:ok v}` / `{:failure m}` → hand to
+          ;;     `finalise-success!`, which dispatches the success reply
+          ;;     or the `:rf.http/accept-failure` domain-failure reply;
+          ;;   - throws → `:rf.http/accept-failure` (the throw is the
+          ;;     app's accept bug; misclassifying it as decode-failure
+          ;;     pointed telemetry at the wrong phase);
+          ;;   - returns a malformed shape (nil / non-map / map without
+          ;;     exactly one of :ok/:failure) → `:rf.http/accept-failure`.
+          ;;     Previously this stranded the request with no reply.
+          ;; `:rf.http/accept-failure` is non-retryable by construction
+          ;; (Spec 014 §Failure categories), so we route straight to
+          ;; `finalise-failure!` — never `maybe-retry!`.
+          (let [decoded (:decoded decode-result)
+                ctx'    (assoc ctx :decoded decoded)
+                outcome (try
+                          {:accepted (encoding/run-accept accept decoded)}
+                          (catch #?(:clj Throwable :cljs :default) e
+                            {:accept-error e}))]
+            (cond
+              (:accept-error outcome)
+              (finalise-failure!
+                ctx'
+                {:kind       :rf.http/accept-failure
+                 :detail     {:rf.http/bad-accept :threw
+                              :message #?(:clj (.getMessage ^Throwable (:accept-error outcome))
+                                          :cljs (.-message ^js (:accept-error outcome)))}
+                 :decoded    decoded
+                 :request-id request-id})
+
+              (encoding/valid-accept-return? (:accepted outcome))
+              (finalise-success! ctx' (:accepted outcome))
+
+              :else
+              (finalise-failure!
+                ctx'
+                {:kind       :rf.http/accept-failure
+                 :detail     {:rf.http/bad-accept :malformed-return
+                              :returned (:accepted outcome)}
+                 :decoded    decoded
+                 :request-id request-id})))))
 
       :else
       ;; Non-2xx that didn't fall in 4xx/5xx (e.g., 1xx/3xx that the

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -379,6 +379,42 @@
                      (done)))
             (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
 
+;; ---- rf2-rznrz — CLJS multi-valued request headers -----------------------
+
+(deftest cljs-fetch-multi-valued-request-header-appends-each-value
+  (testing "rf2-rznrz — a request header whose value is a vector of strings
+  is normalised into a Fetch `Headers` object with one APPEND per element,
+  so the multi-valued wire form (`X-Multi: alpha` + `X-Multi: beta`) is
+  produced. The pre-fix transport `aset` the vector straight into a plain
+  JS object, serialising it as a single malformed `[\"alpha\" \"beta\"]`
+  value."
+    (async done
+      (let [captured-init (atom nil)
+            resp (fake-response {:status 200 :content-type "application/json"
+                                 :text-val "{}"})]
+        (-> (with-init-capturing-fetch resp captured-init
+              #(cljs-fetch {:method  :get
+                            :url     "/x"
+                            :headers {"X-Multi" ["alpha" "beta" "gamma"]
+                                      "X-One"   "solo"}
+                            :decode  :json
+                            :internal-controller (js/AbortController.)}))
+            (.then (fn [_]
+                     (let [h (aget @captured-init "headers")]
+                       (is (instance? js/Headers h)
+                           "headers is a Fetch `Headers` object, not a plain JS map")
+                       ;; `Headers.get` joins repeated values with ", " — three
+                       ;; appended values produce the joined multi-value string,
+                       ;; NOT a serialised-vector blob.
+                       (is (= "alpha, beta, gamma" (.get h "X-Multi"))
+                           "each vector element was appended as its own value")
+                       (is (not (re-find #"\[" (.get h "X-Multi")))
+                           "no serialised-vector bracket leaked onto the wire value")
+                       (is (= "solo" (.get h "X-One"))
+                           "a scalar header value is a single appended value"))
+                     (done)))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+
 (deftest zero-timeout-ms-does-not-arm-near-instant-abort
   (testing "rf2-ee38b.7 — `:timeout-ms 0` is an explicit opt-out (no
   per-attempt timeout) per Spec 014 §`:timeout-ms` security defaults,

--- a/implementation/http/test/re_frame/http_encoding_test.clj
+++ b/implementation/http/test/re_frame/http_encoding_test.clj
@@ -343,6 +343,44 @@
     (is (= "/items" (encoding/merge-params "/items" {})))
     (is (= "/items" (encoding/merge-params "/items" nil)))))
 
+(deftest merge-params-splices-before-fragment
+  (testing "rf2-rznrz — params are spliced BEFORE a `#fragment`, never after.
+            Query text after a `#` is fragment text — real HTTP clients send
+            the fragment to nobody, so appending the query AFTER the `#` (the
+            prior `(str url sep qs)` shape) silently drops the params."
+    (is (= "/items?page=2#frag"
+           (encoding/merge-params "/items#frag" {:page 2}))
+        "no existing `?` → the query is inserted with `?` BEFORE `#frag`,
+         and the fragment is reattached verbatim AFTER the query")
+    (is (= "/items?sort=asc&page=2#frag"
+           (encoding/merge-params "/items?sort=asc#frag" {:page 2}))
+        "existing `?` in the pre-fragment part → join with `&`, fragment
+         stays at the very end")
+    (testing "the broken `#frag?page=2` shape is NOT produced"
+      (is (not= "/items#frag?page=2"
+                (encoding/merge-params "/items#frag" {:page 2}))
+          "params MUST NOT land after the `#` where they'd be dropped on the wire"))))
+
+(deftest merge-params-no-encoded-pairs-leaves-url-unchanged
+  (testing "rf2-rznrz — when the params map encodes to NO query pairs (e.g.
+            `{:tag []}` per params->query's empty-sequential rule) the URL is
+            returned UNCHANGED — no dangling `?` / `&`. The decision keys off
+            the ENCODED query string, not `(seq params)`."
+    (is (= "/items"
+           (encoding/merge-params "/items" {:tag []}))
+        "an all-empty-sequential params map yields no pairs → no dangling `?`")
+    (is (= "/items?sort=asc"
+           (encoding/merge-params "/items?sort=asc" {:tag []}))
+        "an existing query is preserved with no dangling `&`")
+    (is (= "/items#frag"
+           (encoding/merge-params "/items#frag" {:tag []}))
+        "a fragment-only URL with no encodable params is returned verbatim")
+    (testing "a mix of empty + non-empty still encodes the non-empty pairs"
+      (is (= "/items?page=2#frag"
+             (encoding/merge-params "/items#frag" {:tag [] :page 2}))
+          "the empty-sequential drops out; the scalar sibling still splices
+           before the fragment"))))
+
 ;; ---- encode-body — Spec 014 §Body encoding --------------------------------
 ;;
 ;; Returns a tuple [encoded-body content-type]; content-type may be nil
@@ -447,3 +485,64 @@
       (is (= {:failure {:kind :domain :reason :invalid}}
              (encoding/run-accept accept {:valid? false}))
           "the user :accept can fail a 2xx response (domain-level rejection)"))))
+
+;; ---- valid-accept-return? — Spec 014 §`:accept` shape validation ----------
+
+(deftest valid-accept-return-recognises-ok-and-failure
+  (testing "rf2-rznrz — a map carrying EXACTLY one of :ok / :failure is the
+            recognised accept-return shape"
+    (is (encoding/valid-accept-return? {:ok 42}))
+    (is (encoding/valid-accept-return? {:ok nil})
+        "{:ok nil} is valid — the key presence is what matters, not the value")
+    (is (encoding/valid-accept-return? {:failure {:kind :domain}}))
+    (is (encoding/valid-accept-return? {:ok 1 :extra :ignored})
+        "extra keys alongside the single recognised key are tolerated")))
+
+(deftest valid-accept-return-rejects-malformed-shapes
+  (testing "rf2-rznrz — nil, non-maps, and maps without exactly one of
+            :ok/:failure are MALFORMED (these previously stranded the
+            request with no reply)"
+    (is (not (encoding/valid-accept-return? nil))
+        "nil return is malformed")
+    (is (not (encoding/valid-accept-return? {}))
+        "an empty map carries neither key")
+    (is (not (encoding/valid-accept-return? {:status :good}))
+        "a map without :ok/:failure is malformed")
+    (is (not (encoding/valid-accept-return? {:ok 1 :failure {}}))
+        "a map carrying BOTH keys is ambiguous → rejected")
+    (is (not (encoding/valid-accept-return? :ok))
+        "a bare keyword is not a map")
+    (is (not (encoding/valid-accept-return? [:ok 1]))
+        "a vector is not a map")
+    (is (not (encoding/valid-accept-return? "ok"))
+        "a string is not a map")))
+
+;; ---- normalize-header-pairs — Spec 014 §Request envelope (multi-valued) ---
+
+(deftest normalize-header-pairs-scalar-yields-one-pair
+  (testing "rf2-rznrz — a scalar header value yields exactly one [name value]
+            wire pair, stringified"
+    (is (= [["Accept" "application/json"]]
+           (encoding/normalize-header-pairs {"Accept" "application/json"})))
+    (is (= [["X-Count" "42"]]
+           (encoding/normalize-header-pairs {"X-Count" 42}))
+        "a non-string scalar value is stringified per element")))
+
+(deftest normalize-header-pairs-vector-yields-pair-per-element
+  (testing "rf2-rznrz — a vector/seq header value yields ONE wire pair per
+            element (the HTTP multi-valued idiom = repeat the name), NOT a
+            single pair carrying the vector"
+    (is (= [["Accept" "text/html"] ["Accept" "application/json"]]
+           (encoding/normalize-header-pairs {"Accept" ["text/html" "application/json"]}))
+        "each element gets its own [name value] pair, in order")
+    (is (= [["X-Tag" "1"] ["X-Tag" "2"] ["X-Tag" "3"]]
+           (encoding/normalize-header-pairs {"X-Tag" [1 2 3]}))
+        "numeric elements are stringified per element")
+    (is (= [["X-Tag" "a"] ["X-Tag" "b"]]
+           (encoding/normalize-header-pairs {"X-Tag" (list "a" "b")}))
+        "a seq value is treated like a vector"))
+  (testing "an empty sequential value contributes NO pair (header absent)"
+    (is (= [] (encoding/normalize-header-pairs {"X-Empty" []})))
+    (is (= [["Accept" "application/json"]]
+           (encoding/normalize-header-pairs {"X-Empty" [] "Accept" "application/json"}))
+        "the empty-sequential drops out; scalar siblings still emit")))

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -597,6 +597,108 @@
     (is (= {} @http-managed/interceptors)
         "atom stays empty")))
 
+;; ---- rf2-rznrz — sensitivity recomputed from the POST-:before request -----
+;;
+;; A `:before` that MARKS the request sensitive (sets [:request :sensitive?]
+;; true) followed by a LATER :before that throws must produce a
+;; :rf.error/http-interceptor-failed trace redacted under the EFFECTIVE
+;; (post-mark) sensitivity — not the stale pre-chain flag. We assert against
+;; a NON-denylisted query param (`customer_email`) so the only thing that can
+;; redact it is the per-request :sensitive? flag the first :before set; the
+;; query-param denylist alone would leave it verbatim.
+
+(deftest before-marked-sensitive-then-throw-redacts-under-effective-sensitivity
+  (testing "rf2-rznrz — a :before sets [:request :sensitive?] true, a later
+            :before throws; the interceptor-failed trace redacts the
+            NON-denylisted query value because effective sensitivity is
+            recomputed from the post-mark request (not the stale pre-chain
+            flag)"
+    (let [traces      (atom [])
+          listener-id (gensym "rznrz-mark-sensitive-")]
+      (try
+        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        ;; First :before marks the request sensitive.
+        (rf/reg-http-interceptor :mark-sensitive
+          {:before (fn [ctx] (assoc-in ctx [:request :sensitive?] true))})
+        ;; Second :before throws — fires AFTER the mark.
+        (rf/reg-http-interceptor :boom
+          {:before (fn [_ctx] (throw (ex-info "kaboom" {})))})
+        (rf/reg-event-fx :rznrz/load
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   ;; customer_email is NOT in the query-param denylist, so
+                   ;; it only redacts when the request is effectively sensitive.
+                   {:request {:url "https://api.example.invalid/v1?customer_email=alice%40example.com&page=2"}
+                    :decode     :json
+                    :on-success nil
+                    :on-failure nil}]]}))
+        (rf/dispatch-sync [:rznrz/load])
+        (test-support/poll-until
+          #(some (fn [t] (= :rf.error/http-interceptor-failed (:operation t))) @traces)
+          {:label ":rf.error/http-interceptor-failed surfaced (sensitivity recompute)"})
+        (let [w    (first (filter #(= :rf.error/http-interceptor-failed (:operation %)) @traces))
+              tags (:tags w)]
+          (is (some? w))
+          ;; A sensitive request redacts ALL query values (broader than the
+          ;; denylist), so BOTH the non-denylisted customer_email AND page
+          ;; scrub. The load-bearing signal is that customer_email — which the
+          ;; denylist alone would leave verbatim — is redacted: that can only
+          ;; happen if the trace saw the post-:before-mark (sensitive) request.
+          (is (= "https://api.example.invalid/v1?customer_email=:rf/redacted&page=:rf/redacted"
+                 (:url tags))
+              "the NON-denylisted query value is redacted — proving the trace
+               saw the post-:before-mark (sensitive) request, not the stale
+               pre-chain non-sensitive flag (a sensitive request scrubs ALL params)")
+          (is (true? (:sensitive? w))
+              ":sensitive? stamped because the effective request is sensitive"))
+        (finally
+          (trace/unregister-listener! listener-id))))))
+
+;; ---- rf2-rznrz — CLJS-only-key check runs on the POST-:before request -----
+;;
+;; A :before that ADDS a JVM-degraded CLJS-only key (:credentials / :mode /
+;; …) into the request must trip the :rf.http/cljs-only-key-ignored-on-jvm
+;; warning. Previously check-cljs-only-keys! ran on the ORIGINAL args before
+;; the chain, so a :before-added key proceeded on JVM with no degraded-key
+;; warning at all.
+
+(deftest before-added-cljs-only-key-trips-degradation-warning
+  (testing "rf2-rznrz — a :before that adds a CLJS-only key (:credentials)
+            into the request trips :rf.http/cljs-only-key-ignored-on-jvm; the
+            check now runs against the post-:before request, not the original
+            args"
+    (let [traces      (atom [])
+          listener-id (gensym "rznrz-cljs-only-")
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        ;; The request as DISPATCHED carries no CLJS-only key; the :before
+        ;; adds :credentials into the request map.
+        (rf/reg-http-interceptor :add-credentials
+          {:before (fn [ctx] (assoc-in ctx [:request :credentials] :include))})
+        (rf/reg-event-fx :rznrz.cljsonly/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/x")}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:rznrz.cljsonly/load])
+        (await-reply! #(some? (:reply %)) 5000)
+        (let [warns (filter #(= :rf.http/cljs-only-key-ignored-on-jvm (:operation %))
+                            @traces)
+              keys-seen (set (map #(get-in % [:tags :key]) warns))]
+          (is (contains? keys-seen :credentials)
+              "the :before-added :credentials key trips the JVM degradation
+               warning — proving check-cljs-only-keys! ran on the post-chain
+               request, not the original (key-free) args"))
+        (finally
+          (trace/unregister-listener! listener-id)
+          (stop-server! srv))))))
+
 ;; ---- rf2-oyd1b — direct unit tests for the fx wrappers --------------------
 ;;
 ;; The :rf.fx/reg-http-interceptor + :rf.fx/clear-http-interceptor fxs

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -1786,3 +1786,187 @@
               "the caller's explicit Content-Type is preserved and NOT
                supplemented by the encode-body content-type (clash guard)"))
         (finally (stop-server! srv))))))
+
+;; ===========================================================================
+;; rf2-rznrz — finding 1: multi-valued REQUEST headers reach the wire as
+;; repeated header instances, not a single malformed `["a" "b"]` value.
+;; ===========================================================================
+
+(deftest jvm-vector-request-header-sent-as-repeated-values
+  (testing "rf2-rznrz — a request header whose value is a vector of strings
+            (the documented multi-valued shape) arrives at the server as N
+            repeated header instances, NOT one line carrying the stringified
+            vector. The JVM transport now calls .header once per element."
+    (let [seen-accept (atom nil)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              ;; .get returns the List of ALL values for the header name —
+              ;; one entry per wire instance.
+              (reset! seen-accept (vec (.get (.getRequestHeaders ex) "X-Multi")))
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :multihdr/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url     (str "http://127.0.0.1:" port "/m")
+                                :headers {"X-Multi" ["alpha" "beta" "gamma"]}}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:multihdr/load])
+        (await-reply! #(some? (:reply %)) 5000)
+        (let [vs @seen-accept]
+          (is (= 3 (count vs))
+              "the vector value produced THREE separate wire header instances")
+          (is (= ["alpha" "beta" "gamma"] vs)
+              "each element arrives as its own value, in order — NOT a single
+               '[\"alpha\" \"beta\" \"gamma\"]' stringified line")
+          (is (not-any? #(clojure.string/includes? % "[")
+                        vs)
+              "no element carries a serialised-vector bracket (the prior bug)"))
+        (finally (stop-server! srv))))))
+
+(deftest jvm-scalar-request-header-still-single-value
+  (testing "rf2-rznrz — a scalar request header value is unchanged: one wire
+            instance carrying the stringified scalar (the 99% path)"
+    (let [seen (atom nil)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (reset! seen (vec (.get (.getRequestHeaders ex) "X-One")))
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :scalarhdr/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url     (str "http://127.0.0.1:" port "/s")
+                                :headers {"X-One" "only"}}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:scalarhdr/load])
+        (await-reply! #(some? (:reply %)) 5000)
+        (is (= ["only"] @seen)
+            "a scalar header value is a single wire instance")
+        (finally (stop-server! srv))))))
+
+;; ===========================================================================
+;; rf2-rznrz — finding 2: :accept phase isolation + shape validation.
+;;   - an :accept THROW classifies as :rf.http/accept-failure (NOT
+;;     :rf.http/decode-failure — the prior fused try/catch misclassified it);
+;;   - a MALFORMED :accept return (nil / map without :ok/:failure) classifies
+;;     as :rf.http/accept-failure and ALWAYS dispatches a reply (previously
+;;     it stranded the caller with no reply at all).
+;; ===========================================================================
+
+(deftest jvm-accept-throw-classifies-as-accept-failure-not-decode-failure
+  (testing "rf2-rznrz — an :accept fn that THROWS on a 2xx response
+            classifies as :rf.http/accept-failure (step-4 error), NOT
+            :rf.http/decode-failure (step-3). The decode succeeded; the
+            accept phase is now isolated in its own try/catch."
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :acceptthrow/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/a")}
+                      :decode  :json
+                      :accept  (fn [_decoded]
+                                 (throw (ex-info "accept boom" {})))}]]})))
+        (rf/dispatch-sync [:acceptthrow/load])
+        (let [db      (await-reply! #(some? (:reply %)) 5000)
+              failure (get-in db [:reply :failure])]
+          (is (= :failure (get-in db [:reply :kind]))
+              "a thrown :accept produces a FAILURE reply (caller is not stranded)")
+          (is (= :rf.http/accept-failure (:kind failure))
+              "the throw classifies as :rf.http/accept-failure, NOT
+               :rf.http/decode-failure — decode succeeded; accept is the failing phase")
+          (is (= {:ok true} (:decoded failure))
+              "the pre-accept decoded value rides through as :decoded for context"))
+        (finally (stop-server! srv))))))
+
+(deftest jvm-accept-nil-return-classifies-as-accept-failure-and-replies
+  (testing "rf2-rznrz — an :accept fn returning nil (a malformed shape) is
+            classified as :rf.http/accept-failure and ALWAYS dispatches a
+            reply. Previously this fell through finalise-success!'s cond with
+            no matching branch: the in-flight request was cleared and NO reply
+            was dispatched — the caller hung forever."
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :acceptnil/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/n")}
+                      :decode  :json
+                      ;; Returns nil — neither {:ok ..} nor {:failure ..}.
+                      :accept  (fn [_decoded] nil)}]]})))
+        (rf/dispatch-sync [:acceptnil/load])
+        (let [db      (await-reply! #(some? (:reply %)) 5000)
+              failure (get-in db [:reply :failure])]
+          (is (= :failure (get-in db [:reply :kind]))
+              "a nil :accept return STILL dispatches a reply (no infinite hang)")
+          (is (= :rf.http/accept-failure (:kind failure))
+              "the malformed return classifies as :rf.http/accept-failure")
+          (is (= {:ok true} (:decoded failure))
+              "the pre-accept decoded value rides through as :decoded"))
+        (finally (stop-server! srv))))))
+
+(deftest jvm-accept-map-without-ok-or-failure-classifies-as-accept-failure
+  (testing "rf2-rznrz — an :accept fn returning a map that carries NEITHER
+            :ok NOR :failure is malformed and classifies as
+            :rf.http/accept-failure with a reply (was a silent hang)"
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :acceptbad/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/b")}
+                      :decode  :json
+                      ;; A map, but neither :ok nor :failure.
+                      :accept  (fn [_decoded] {:status :weird})}]]})))
+        (rf/dispatch-sync [:acceptbad/load])
+        (let [db      (await-reply! #(some? (:reply %)) 5000)
+              failure (get-in db [:reply :failure])]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/accept-failure (:kind failure))
+              "a map without :ok/:failure is a malformed accept return"))
+        (finally (stop-server! srv))))))
+
+(deftest jvm-accept-well-formed-ok-still-succeeds
+  (testing "rf2-rznrz — a well-formed {:ok v} accept return is unaffected:
+            the success reply carries v (regression guard for the phase split)"
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json" "{\"value\":42}")))]
+      (try
+        (rf/reg-event-fx :acceptok/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/o")}
+                      :decode  :json
+                      :accept  (fn [decoded] {:ok (:value decoded)})}]]})))
+        (rf/dispatch-sync [:acceptok/load])
+        (let [db (await-reply! #(some? (:reply %)) 5000)]
+          (is (= :success (get-in db [:reply :kind])))
+          (is (= 42 (get-in db [:reply :value]))
+              "a well-formed {:ok v} still projects the success value"))
+        (finally (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -105,6 +105,24 @@
       (is (= :rf/redacted (get r "set-cookie")))
       (is (= :rf/redacted (get r "Set-cookie"))))))
 
+(deftest redact-headers-redacts-vector-valued-sensitive-header
+  (testing "rf2-rznrz — a denylisted header whose value is a VECTOR (the
+            documented multi-valued request-header shape, string → vector
+            of strings) is redacted WHOLE to the sentinel, never per-element
+            and never leaked. The redactor matches by header NAME, so the
+            value shape (scalar vs vector) is irrelevant to whether it is
+            scrubbed — a multi-valued `Authorization` / `Cookie` must not
+            survive in trace output just because it arrived as a vector."
+    (let [m {"Authorization" ["Bearer one" "Bearer two"]
+             "Cookie"        ["a=1" "b=2"]
+             "X-Multi"       ["keep-1" "keep-2"]}
+          r (headers/redact-headers m)]
+      (is (= :rf/redacted (get r "Authorization"))
+          "the entire vector value is replaced by the sentinel — no element leaks")
+      (is (= :rf/redacted (get r "Cookie")))
+      (is (= ["keep-1" "keep-2"] (get r "X-Multi"))
+          "a non-denylisted multi-valued header keeps its vector value intact"))))
+
 ;; ---- 3. request-sensitive? -------------------------------------------------
 
 (deftest request-sensitive-per-call-true

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -354,6 +354,13 @@ Returns either:
 
 The default `:accept` returns `{:ok decoded}` for 2xx responses, `{:failure {:kind :http-status :status N :body decoded}}` otherwise.
 
+**The accept phase is isolated from decode, and its return is shape-validated.** A recognised return is a map carrying *exactly one* of `:ok` / `:failure`. Two misuse paths classify as `:rf.http/accept-failure` (never `:rf.http/decode-failure` — the accept phase is step 4, distinct from the step-3 decode phase per [§Classification order](#classification-order)) and **always dispatch a reply**:
+
+- **An `:accept` fn that throws.** The throw is the application's accept bug; classifying it as a decode failure would point telemetry at the wrong phase. The pre-`:accept` decoded value rides at `:decoded`.
+- **A malformed `:accept` return** — `nil`, a non-map, a map carrying neither key, or a map carrying *both* `:ok` and `:failure`. A malformed return MUST NOT strand the caller: the request has already completed, so failing to emit either a success or a failure reply would leave `:on-success` / `:on-failure` un-dispatched forever. The runtime classifies it as `:rf.http/accept-failure` and dispatches the failure reply.
+
+Both carry a framework-supplied `:detail` describing the bad-accept condition alongside the `:decoded` value for context.
+
 ## Retry and backoff
 
 `:rf.http/managed`'s `:retry` slot owns **transport-level retry only** — retries whose decision is a pure function of the failure category and the attempt count. Network errors, 5xx, per-attempt timeouts, CORS rejection: each is a `:rf.http/*` category the runtime classifies before decode, and the policy is "given attempt N and a category from `:on`, wait `backoff(N)` ms, then re-issue the same request." The failure category, the attempt count, and the configured backoff are the only inputs; the response body, the application state, and the outcome of any other request never enter the picture.
@@ -483,7 +490,7 @@ Every failure carries a `:kind` keyword (under the framework-reserved `:rf.http/
 | `:rf.http/http-4xx` | Non-2xx 4xx response | `:status`, `:status-text`, `:body` (the raw response text — decode is skipped on non-2xx; see [§Classification order](#classification-order)), `:headers` |
 | `:rf.http/http-5xx` | Non-2xx 5xx response | same as `:http-4xx` |
 | `:rf.http/decode-failure` | A success-eligible (2xx) response whose body the decode pipeline rejected (schema validation error, JSON syntax error, custom decoder threw). Non-2xx responses never produce `:rf.http/decode-failure` — they classify by status. | `:body-text`, `:cause`, `:schema-validation-failure?` |
-| `:rf.http/accept-failure` | `:accept` returned `{:failure user-map}`. The user's failure map sits at `:detail`; `:decoded` carries the pre-`:accept` decoded value for context. | `:detail` (user's verbatim failure map), `:decoded` |
+| `:rf.http/accept-failure` | `:accept` returned `{:failure user-map}` — OR `:accept` threw / returned a malformed shape (see [§`:accept`](#accept--domain-failure-normalisation)). For the `{:failure user-map}` case the user's failure map sits at `:detail`; for the throw / malformed-return cases `:detail` is a framework descriptor of the bad-accept condition. `:decoded` carries the pre-`:accept` decoded value for context. | `:detail` (user's verbatim failure map, or framework bad-accept descriptor), `:decoded` |
 | `:rf.http/aborted` | The request was aborted via `:request-id` or `:abort-signal` | `:request-id` (if any), `:reason` (`:user` on the reply; `:request-id-superseded` is trace-only — see [§`:request-id` (internal)](#request-id-internal)) |
 
 The category vocabulary is **closed for v1** — additions require a Spec change. The `:rf.http/*` namespace makes these unambiguous wherever they leak: trace events, error projector, `:retry :on` sets, epoch records.


### PR DESCRIPTION
Fixes all 4 correctness findings on `implementation/http` from bead **rf2-rznrz**.

## Finding 1 — multi-valued request headers reach the wire as repeated values
A request header documented as supporting `string → vector-of-strings` was serialized as a single malformed value (CLJS `aset` the vector into a plain JS object; JVM `(str v)`-ed the whole vector). New pure helper `encoding/normalize-header-pairs` flattens a headers map to ordered `[name value]` wire pairs — scalar → one pair, vector/seq → one pair per element (empty seq → no pair). CLJS now builds a Fetch `Headers` object and `.append`s each pair (accumulates repeated names); JVM calls `.header` once per value (JDK accumulates). Privacy redaction already scrubs a denylisted header **whole** regardless of scalar/vector shape — added explicit coverage proving a vector-valued `Authorization`/`Cookie` redacts to `:rf/redacted`.

## Finding 2 — `:accept` phase isolated + shape-validated
Decode and accept were fused in one try/catch, so an `:accept` throw was misclassified as `:rf.http/decode-failure`, and a malformed accept return (nil / map without `:ok`/`:failure`) fell through `finalise-success!`'s `cond` with no branch — clearing the in-flight request and dispatching **no reply** (caller hung forever). Now: decode runs in its own try/catch (→ `:rf.http/decode-failure`); accept runs in a separate try/catch and its return is validated via new pure helper `encoding/valid-accept-return?` (a map carrying *exactly one* of `:ok`/`:failure`). An accept throw OR a malformed return classifies as `:rf.http/accept-failure` (closed-set canonical category) and **always** dispatches a reply. Abort-precedence is preserved (the accept-failure routes through `finalise-failure!`, which reclassifies to `:rf.http/aborted` when the request was aborted).

## Finding 3 — `merge-params` is fragment-aware + decides on the encoded query
Built the query string first; return the URL unchanged when blank; split at the first `#`, splice the query into the pre-fragment part with `?`/`&`, reattach the fragment. Fixes `/items#frag` + `{:page 2}` → `/items?page=2#frag` (was `/items#frag?page=2`, dropped on the wire) and `{:tag []}` → no dangling `?`.

## Finding 4 — sensitivity + CLJS-only-key check use the POST-`:before` request
`managed-handler` now runs `check-cljs-only-keys!` against the post-chain request and recomputes effective `:sensitive?` from it (a `:before` that adds `:credentials`/`:mode`/… or marks the request sensitive is now honoured). `run-chain*` recomputes effective sensitivity from the threaded `acc` at the failure site (`:sensitive-of` fn), so a `:before` that marks the request sensitive followed by a later `:before` that throws redacts the interceptor-failed trace under the effective sensitivity instead of a stale pre-chain flag.

Spec 014 §`:accept` + §Failure-categories table updated for the accept-phase isolation + bad-accept classification.

## Quality gates
| Command | Result |
|---|---|
| `cd implementation && npm run test:cljs` (node CLJS gate) | **0 failures, 0 errors** — 5728 tests / 20080 assertions |
| `cd implementation/http && clojure -M:test` (http JVM gate) | **0 failures, 0 errors** — 358 tests / 1640 assertions |

JVM gate re-run after rebasing onto `origin/main` (2 beads-only heartbeat commits, no source overlap): still **0 failures, 0 errors**. CLJS gate exercises the new `cljs-fetch-multi-valued-request-header-appends-each-value` test; JVM gate exercises the new vector-header, accept-throw/nil/malformed, merge-params-fragment, vector-redaction, and finding-4 interceptor tests.