### PR TITLE
fix(schemas): redact sensitive event payloads + close validator/explainer fail-open (rf2-a5kzs)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -266,6 +266,10 @@
     :producer-ns 're-frame.schemas
     :design-bead "rf2-r2uh"
     :description "Boundary seam: explain using the registered explainer fn."}
+   {:key         :schemas/redact-event-tags
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-a5kzs"
+    :description "Boundary seam: redact a production boundary event-failure trace's value-bearing slots (and stamp :sensitive? true) when the event :schema declares any :sensitive? slot — gives the boundary path the same per-slot redaction the dev-time validate-event! step-1 path applies. Falls through verbatim when the schemas artefact is absent."}
    {:key         :schemas/malli-validate
     :producer-ns 're-frame.schemas.malli
     :design-bead "rf2-t0hq"

--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -181,13 +181,45 @@
                 ctx
 
                 :else
+                ;; Per rf2-a5kzs (finding 2, boundary seam) — the validate
+                ;; seam now isolates a malformed-schema throw and returns
+                ;; `false` (fail CLOSED), so the defensive `(catch … true)`
+                ;; here only guards against a non-schemas validator that
+                ;; throws WITHOUT the seam's isolation. A `false` from the
+                ;; seam (legitimate failure OR malformed schema) skips the
+                ;; handler — the boundary never runs an unvalidated payload.
                 (let [ok? (try (validate-fn schema event)
                                (catch #?(:clj Throwable :cljs :default) _ true))]
                   (if ok?
                     ctx
                     (let [explanation (when explain-fn
                                         (try (explain-fn schema event)
-                                             (catch #?(:clj Throwable :cljs :default) _ nil)))]
+                                             (catch #?(:clj Throwable :cljs :default) _ nil)))
+                          ;; Per rf2-a5kzs (finding 1) — route the failure
+                          ;; tags through the schemas redaction seam so a
+                          ;; sensitive event payload (a `:cat` payload map
+                          ;; carrying `{:sensitive? true}`) is scrubbed at
+                          ;; the boundary exactly as the dev-time step-1
+                          ;; `validate-event!` path scrubs it. The seam is
+                          ;; the `:schemas/redact-event-tags` late-bind hook;
+                          ;; when the schemas artefact is absent the hook is
+                          ;; nil and the tags ride verbatim (no schema =
+                          ;; nothing to redact against).
+                          redact-fn   (late-bind/get-fn-cached :schemas/redact-event-tags)
+                          base-tags   (cond-> {:where      :event
+                                               :event-id   event-id
+                                               :failing-id event-id
+                                               :schema-id  event-id
+                                               :received   event
+                                               :value      event
+                                               :explain    explanation
+                                               :source     :boundary
+                                               :reason     (str "Event " event-id
+                                                                " payload failed boundary "
+                                                                "schema " schema ", got "
+                                                                (error/type-of-value event) ".")
+                                               :recovery   :no-recovery}
+                                        frame (assoc :frame frame))]
                       ;; Emit the failure trace using the same shape as
                       ;; dev-mode step-1 (per Spec 010 L149). Per Spec
                       ;; 009 §Production builds `emit-error!` itself
@@ -196,20 +228,8 @@
                       ;; with debug-enabled? flipped off — exactly the
                       ;; surface the rf2-r2uh tests exercise.
                       (trace/emit-error! :rf.error/schema-validation-failure
-                                         (cond-> {:where      :event
-                                                  :event-id   event-id
-                                                  :failing-id event-id
-                                                  :schema-id  event-id
-                                                  :received   event
-                                                  :value      event
-                                                  :explain    explanation
-                                                  :source     :boundary
-                                                  :reason     (str "Event " event-id
-                                                                   " payload failed boundary "
-                                                                   "schema " schema ", got "
-                                                                   (error/type-of-value event) ".")
-                                                  :recovery   :no-recovery}
-                                           frame (assoc :frame frame)))
+                                         (cond-> base-tags
+                                           redact-fn (->> (redact-fn schema))))
                       ;; Per Spec 010 §Per-step recovery step 1: handler
                       ;; is not invoked. The handler-as-interceptor
                       ;; checks `:rf/skip-handler?` in its :before slot

--- a/implementation/schemas/deps.edn
+++ b/implementation/schemas/deps.edn
@@ -12,12 +12,23 @@
 ;;   {:deps {day8/re-frame2         {:mvn/version "..."}
 ;;           day8/re-frame2-schemas {:mvn/version "..."}}}
 ;;
-;; And require `re-frame.schemas.malli` at app-boot to publish Malli's
-;; validate / explain into the late-bind hook table (rf2-t0hq). Same
-;; pattern on CLJS and the JVM — rf2-qyfie removed the JVM
-;; `requiring-resolve` fallback so the contract is symmetrical.
-;; Without that require the default validator soft-passes per Spec 010
-;; §Recommended soft-pass even if Malli is on the classpath.
+;; Schema implies validation (rf2-v96fh): requiring `re-frame.schemas`
+;; itself `:require`s `re-frame.schemas.malli`, which publishes Malli's
+;; validate / explain / humanize into the late-bind hook table at
+;; ns-load (rf2-t0hq). The default validator is therefore LIVE the moment
+;; a schema is registered — there is NO inert "registered a schema but it
+;; silently validates nothing" soft-pass state. An explicit
+;; `(:require [re-frame.schemas.malli])` at app-boot is harmless but no
+;; longer required. Same pattern on CLJS and the JVM — rf2-qyfie removed
+;; the JVM `requiring-resolve` fallback so the contract is symmetrical.
+;;
+;; Apps that want schemas-as-inert-data without the Malli validation
+;; surface call `(set-schema-validator! nil)` at boot, which disables every
+;; validation site (Spec 010 §Worked example). The residual soft-pass arm
+;; in `re-frame.schemas.validator` is the defensive fallback for a non-Malli
+;; port that never bound the Malli hook (and for test harnesses that
+;; deliberately unbind it) — NOT the default state after a plain
+;; `(:require [re-frame.schemas])`.
 ;;
 ;; Per Spec 006 §Adapter shipping convention (and the
 ;; rf2-p7va extension to per-feature splits): this artefact depends

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -167,6 +167,12 @@
 ;; Production-side boundary-validation seam (rf2-r2uh).
 (def validate-with-registered-fn validate/validate-with-registered-fn)
 (def explain-with-registered-fn  validate/explain-with-registered-fn)
+;; rf2-a5kzs (finding 1) — the production boundary path's `:sensitive?`
+;; redaction seam: the boundary interceptor builds its own event-failure
+;; tags (in core, `re-frame.spec`) and routes them through this fn so a
+;; sensitive event payload is redacted at the boundary exactly as the
+;; dev-time `validate-event!` step-1 path redacts it.
+(def redact-event-tags           validate/redact-event-tags)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
@@ -198,6 +204,8 @@
 ;; Boundary-validation seam (rf2-r2uh integration).
 (late-bind/set-fn! :schemas/validate-with-registered-fn validate-with-registered-fn)
 (late-bind/set-fn! :schemas/explain-with-registered-fn  explain-with-registered-fn)
+;; rf2-a5kzs (finding 1) — boundary-path `:sensitive?` redaction hook.
+(late-bind/set-fn! :schemas/redact-event-tags           redact-event-tags)
 
 ;; Public-API re-export hooks (consumed by re-frame.core-schemas).
 (late-bind/set-fn! :schemas/reg-app-schema        reg-app-schema)

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -121,6 +121,21 @@
 ;; consults `walker/schema-has-sensitive?` to drive the failure-trace
 ;; redaction.
 
+;; The canonical value-bearing tag slots — the ones that carry the failing
+;; value (or a value-bearing lookup key) verbatim and so must be scrubbed
+;; on a `:sensitive?` failure (`redact-tags`) AND dropped entirely from a
+;; `:rf.error/malformed-schema` trace (where the validator never proved
+;; sensitivity, so we cannot redact path-targeted — omitting the value is
+;; fail-closed, mirroring `validate-app-schema!`'s malformed-schema emit).
+;; Per Spec 010 §`:sensitive?` redaction-shape list (rf2-nijom / rf2-adtp2
+;; / rf2-qhq3f). Three are per-surface conditional names carried only on a
+;; subset of emit-sites (`:rf.fx/args` on `:where :fx-args`;
+;; `:rf.sub/query-v` on `:where :sub-return`; `:explain-humanized` only when
+;; the humanize hook is installed); `contains?` guards keep the clauses
+;; no-ops on the surfaces whose tag maps don't carry the slot.
+(def ^:private value-bearing-slots
+  [:value :received :explain :explain-humanized :rf.fx/args :rf.sub/query-v])
+
 (defn- redact-tags
   "Replace value-bearing slots in a tags map with the `:rf/redacted`
   sentinel. Per Spec 010 §`:sensitive?` — privacy in schema-validation
@@ -164,14 +179,11 @@
   `:explain-humanized`, reads `:rf/redacted` rather than falling through
   to a missing slot."
   [tags]
-  (cond-> tags
-    (contains? tags :value)             (assoc :value             redacted-sentinel)
-    (contains? tags :received)          (assoc :received          redacted-sentinel)
-    (contains? tags :explain)           (assoc :explain           redacted-sentinel)
-    (contains? tags :explain-humanized) (assoc :explain-humanized redacted-sentinel)
-    (contains? tags :rf.fx/args)        (assoc :rf.fx/args        redacted-sentinel)
-    (contains? tags :rf.sub/query-v)    (assoc :rf.sub/query-v    redacted-sentinel)
-    true                                (assoc :sensitive? true)))
+  (-> (reduce (fn [t slot]
+                (cond-> t (contains? t slot) (assoc slot redacted-sentinel)))
+              tags
+              value-bearing-slots)
+      (assoc :sensitive? true)))
 
 (defn- common-prefix
   "Return the longest common prefix of two sequential collections (as a
@@ -306,9 +318,40 @@
   app-db value is NOT included — a malformed schema is a programming
   error, and including the value would re-open the very leak the per-entry
   isolation closes (the validator never proved sensitivity, so we cannot
-  redact path-targeted; omitting the value is fail-closed)."
+  redact path-targeted; omitting the value is fail-closed).
+
+  Per rf2-a5kzs the SAME emit now serves the four meta-bearing surfaces
+  (event / cofx / fx / sub) via `run-validation`: a malformed `:schema`
+  on a handler / cofx / fx / sub registration makes the validator throw
+  identically, and the runtime call-sites (`router` / `cofx` / `fx` /
+  `subs`) coerce that throw to a validation PASS via their defensive
+  `(catch … true)` — the same fail-open class. Those surfaces stamp the
+  structural slots they carry (`:where`, the surface id, `:frame`) plus
+  `:schema` / `:reason`, never a value-bearing slot."
   [tags]
   (trace/emit-error! :rf.error/malformed-schema tags))
+
+(defn- safe-explain
+  "Per rf2-a5kzs (finding 3) — invoke the registered explainer inside a
+  try/catch so a throwing custom explainer (or an explainer that itself
+  fails on a structurally degenerate schema) can never abort failure-trace
+  construction. A propagated explainer throw would unwind PAST the
+  legitimate `false` return, and the runtime call-sites
+  (`router` / `cofx` / `fx` / `subs`, and `validate-app-schema!`'s router
+  caller) coerce that throw to a validation PASS via their defensive
+  `(catch … true)` — turning a real validation FAILURE into a silent
+  catch-as-pass (for app-db: the swallowed-backstop returns true / no
+  rollback, so the invalid commit installs).
+
+  The explainer is diagnostic-only enrichment for the `:explain` slot;
+  its failure must NOT change the validation verdict. On a throw this
+  degrades to nil (the failure trace then omits / nil-fills `:explain`,
+  exactly as when no explainer is registered) and the caller continues
+  the original `false`."
+  [schema value]
+  (try
+    (validator/run-explainer schema value)
+    (catch #?(:clj Throwable :cljs :default) _ nil)))
 
 (defn- validate-entry-result
   "Run the registered validator for one `(schema, value)` entry, isolating
@@ -350,7 +393,25 @@
                      pass `false`; cofx / fx / sub-return pass `true`.
     - `build-base-tags`  `(fn [schema explanation] -> map)` — produces
                      the per-fn tag map (`:where`, `:reason`, etc.)
-                     EXCLUDING any sensitivity stamping.
+                     EXCLUDING any sensitivity stamping. Also the source
+                     of the structural locator slots for the malformed-
+                     schema trace (rf2-a5kzs): called with a nil
+                     explanation, then stripped of the value-bearing slots,
+                     so the malformed-schema trace reuses the surface's own
+                     `:where` / id / `:frame` shape without duplicating it.
+
+  Per rf2-a5kzs (findings 2 + 3) this primitive isolates BOTH failure
+  modes that previously fell open through the runtime call-sites'
+  defensive `(catch … true)`:
+
+    - A malformed registered `:schema` (childless `[:vector]`, unknown op)
+      makes the validator THROW. Caught per-call via `validate-entry-result`;
+      a distinct `:rf.error/malformed-schema` trace fires and the fn returns
+      `false`, so each caller applies its normal recovery (skip handler /
+      skip fx / replace sub return) instead of the silent throw-as-pass.
+    - A throwing explainer no longer aborts trace construction — the
+      explainer is invoked through `safe-explain`, which degrades a throw
+      to a nil explanation and preserves the `false` verdict.
 
   Reachability: every call-site lives inside the outermost
   `(if interop/debug-enabled? ...)` gate of its public wrapper.
@@ -378,21 +439,57 @@
   [reg-meta value walk-schema? build-base-tags]
   (if-let [vf @validator/validator-fn]
     (if-let [schema (:schema reg-meta)]
-      (if (vf schema value)
-        true
-        (let [explanation (validator/run-explainer schema value)
-              sensitive?  (and walk-schema?
-                               (walker/schema-has-sensitive? schema))
-              ;; Per rf2-qhq3f — humanize from the RAW explanation here,
-              ;; before redaction, and fold the slot into base-tags so
-              ;; `redact-tags` scrubs it symmetrically with `:explain`
-              ;; on sensitive failures (sentinel present, not omitted).
-              humanized   (humanize-explain explanation)
-              base-tags   (cond-> (build-base-tags schema explanation)
-                            (some? humanized) (assoc :explain-humanized humanized))
-              tags        (cond-> base-tags sensitive? redact-tags)]
-          (emit-validation-failure! tags)
-          false))
+      ;; Per rf2-a5kzs (finding 2) — isolate a malformed-schema throw HERE
+      ;; rather than let it propagate to the call-site `(catch … true)`.
+      (let [result (validate-entry-result vf schema value)]
+        (cond
+          ;; Conformed.
+          (true? result)
+          true
+
+          ;; Malformed registered schema (validator threw). Surface a
+          ;; DISTINCT `:rf.error/malformed-schema` trace built from the
+          ;; surface's own structural slots (`:where` / id / `:frame`),
+          ;; stripped of the value-bearing slots (the validator never
+          ;; proved sensitivity — omitting the value is fail-closed,
+          ;; mirroring `validate-app-schema!`). Return false so the caller
+          ;; runs its normal recovery instead of the swallowed pass.
+          (and (vector? result) (= :malformed (first result)))
+          (let [ex     (second result)
+                reason #?(:clj  (.getMessage ^Throwable ex)
+                          :cljs (ex-message ex))
+                ;; build-base-tags called with a nil explanation, then
+                ;; stripped of value-bearing slots — no value leaks into a
+                ;; malformed-schema trace.
+                base   (apply dissoc (build-base-tags schema nil)
+                              value-bearing-slots)]
+            (emit-malformed-schema!
+              (assoc base
+                     :schema    schema
+                     :reason    (str "Registered schema " (pr-str schema)
+                                     " is malformed and could not be "
+                                     "evaluated: " reason)
+                     :recovery  :no-recovery))
+            false)
+
+          ;; Legitimate validation failure — the existing emit path.
+          :else
+          (let [;; Per rf2-a5kzs (finding 3) — explainer through
+                ;; `safe-explain` so a throwing explainer can't unwind past
+                ;; this false and become a catch-as-pass at the call-site.
+                explanation (safe-explain schema value)
+                sensitive?  (and walk-schema?
+                                 (walker/schema-has-sensitive? schema))
+                ;; Per rf2-qhq3f — humanize from the RAW explanation here,
+                ;; before redaction, and fold the slot into base-tags so
+                ;; `redact-tags` scrubs it symmetrically with `:explain`
+                ;; on sensitive failures (sentinel present, not omitted).
+                humanized   (humanize-explain explanation)
+                base-tags   (cond-> (build-base-tags schema explanation)
+                              (some? humanized) (assoc :explain-humanized humanized))
+                tags        (cond-> base-tags sensitive? redact-tags)]
+            (emit-validation-failure! tags)
+            false)))
       true)
     true))
 
@@ -538,7 +635,17 @@
                  ;; vocabulary rather than minting a new enum value).
                  ;; The router consumes the loop's final boolean to
                  ;; perform the actual container restoration.
-                 (let [explanation (validator/run-explainer schema reg-slice)
+                 ;; Per rf2-a5kzs (finding 3) — the explainer is invoked
+                 ;; through `safe-explain` so a throwing custom explainer
+                 ;; (or an explainer that fails on a degenerate schema)
+                 ;; cannot abort this branch and unwind past the `false`
+                 ;; this entry contributes to the loop's conjoined result.
+                 ;; A propagated throw would reach the router's
+                 ;; swallowed-backstop `(catch … true)` and the invalid
+                 ;; commit would install with no rollback. The explainer is
+                 ;; diagnostic-only; on a throw `:explain` degrades to nil
+                 ;; and the failure verdict is preserved.
+                 (let [explanation (safe-explain schema reg-slice)
                        in-path     (failing-in-path explanation)
                        leaf-value  (if in-path
                                      (get-in reg-slice in-path)
@@ -613,14 +720,28 @@
   so the `:where :event` trace is captured in the same epoch as the
   dispatch that triggered it, exactly like the `:where :app-db` trace.
   The 3-arity stays for direct (non-router) callers (the elision probe,
-  unit tests) where there is no in-flight cascade to attribute to."
+  unit tests) where there is no in-flight cascade to attribute to.
+
+  Per rf2-a5kzs (finding 1) — event validation DOES consult the schema's
+  per-slot `:sensitive?` walker (`walk-schema? true`). An event schema is
+  not itself `:map`-shaped, but its payload commonly IS: a login schema
+  `[:cat [:= :auth/login] [:map [:password {:sensitive? true} :string]]]`
+  marks the password slot sensitive. The previous `false` ignored those
+  annotations, so a failing sensitive event payload leaked verbatim via
+  `:received` / `:value` / `:explain` to trace listeners / off-box
+  consumers — contradicting Spec 010's redaction contract. `walker/
+  schema-has-sensitive?` walks the WHOLE schema form (the `:cat` container
+  descends into its `:map` payload child), so a per-slot `:sensitive?`
+  anywhere in the event schema (incl. container-level props) now drives
+  redaction; non-sensitive event failures still ride verbatim (the walker
+  reports nothing → no redaction)."
   ([event-id event handler-meta] (validate-event! event-id event handler-meta nil))
   ([event-id event handler-meta frame]
    (if interop/debug-enabled?
      (run-validation
        handler-meta
        event
-       false  ;; event vectors aren't `:map`-shaped — no per-slot walk
+       true   ;; consult the event schema's per-slot `:sensitive?` walker
        (fn [schema explanation]
          (cond-> {:where      :event
                   :event-id   event-id
@@ -782,11 +903,11 @@
 ;; artefact is optional per rf2-p7va so the interceptor cannot
 ;; statically `:require [re-frame.schemas]`).
 ;;
-;; Contract: returns true on conform; false on fail; true (pass) when
-;; no validator is registered. Does NOT emit a trace — the boundary
-;; interceptor is responsible for emitting :rf.error/schema-validation-
-;; failure :where :event with the appropriate envelope. Pure check
-;; surface.
+;; Contract: returns true on conform; false on fail (incl. a malformed
+;; schema — fail CLOSED); true (pass) when no validator is registered.
+;; Does NOT emit a trace — the boundary interceptor is responsible for
+;; emitting :rf.error/schema-validation-failure :where :event with the
+;; appropriate envelope. Pure check surface.
 
 (defn validate-with-registered-fn
   "Apply the registered validator to `(schema, value)`. Public seam for
@@ -795,15 +916,58 @@
   call-site treats no-validator as no-validation, mirroring the hot
   path).
 
+  Per rf2-a5kzs (finding 2, boundary seam) — a structurally MALFORMED
+  registered schema makes the validator THROW. This seam isolates that
+  throw and returns `false` (fail CLOSED — the boundary interceptor then
+  skips the handler) rather than letting it propagate to the interceptor's
+  defensive `(catch … true)`, which would coerce the throw to a validation
+  PASS and run the handler on an unvalidated boundary payload. Mirrors the
+  dev-time `run-validation` / `validate-app-schema!` per-entry isolation.
+  A `nil` validator (validation disabled) still passes — `run-validator`
+  returns true and never throws.
+
   Does NOT consult `interop/debug-enabled?` — the boundary interceptor
   runs in production by design."
   [schema value]
-  (validator/run-validator schema value))
+  (try
+    (boolean (validator/run-validator schema value))
+    (catch #?(:clj Throwable :cljs :default) _ false)))
 
 (defn explain-with-registered-fn
   "Apply the registered explainer to `(schema, value)`. Companion to
   `validate-with-registered-fn` for the boundary-validation
   interceptor (rf2-r2uh). Returns the explanation map / data on fail;
-  nil when the schema conforms or no explainer is registered."
+  nil when the schema conforms or no explainer is registered.
+
+  Per rf2-a5kzs (finding 3, boundary seam) — a throwing explainer
+  degrades to nil here rather than propagating; the boundary interceptor
+  already wraps the call in its own try/catch, so this is belt-and-braces
+  symmetry with the dev-time `safe-explain` (the explainer is diagnostic-
+  only and must never change the verdict)."
   [schema value]
-  (validator/run-explainer schema value))
+  (try
+    (validator/run-explainer schema value)
+    (catch #?(:clj Throwable :cljs :default) _ nil)))
+
+(defn redact-event-tags
+  "Redaction seam for the production boundary-validation interceptor
+  (`re-frame.spec`, rf2-a5kzs finding 1). Given the registered event
+  `schema` and the failure trace `tags` the interceptor built, return the
+  tags with the value-bearing slots (`:received` / `:value` / `:explain` /
+  …) scrubbed to `:rf/redacted` and `:sensitive? true` stamped WHEN the
+  event schema declares any slot `:sensitive?` (e.g. a `:cat` payload map
+  `[:map [:password {:sensitive? true} :string]]`); otherwise the tags ride
+  back verbatim.
+
+  The dev-time step-1 path (`validate-event!`) consults the same
+  `walker/schema-has-sensitive?` predicate via `run-validation`'s
+  `walk-schema?`; this seam gives the production boundary path the SAME
+  redaction without the optional schemas artefact and the (core) `re-frame.spec`
+  interceptor coupling — the interceptor reaches it through the
+  `:schemas/redact-event-tags` late-bind hook and falls through verbatim
+  when the hook is unbound (schemas artefact absent).
+
+  Pure; `redact-tags` is idempotent so a double-call is safe."
+  [schema tags]
+  (cond-> tags
+    (walker/schema-has-sensitive? schema) redact-tags))

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -84,11 +84,13 @@
             [re-frame.cofx :as cofx]
             [re-frame.frame :as frame]
             [re-frame.schemas :as schemas]
-            ;; Per rf2-t0hq + rf2-qyfie — the Malli adapter ns must be
-            ;; required at boot to publish the late-bind hook the
-            ;; default validator routes through. The conformance corpus
-            ;; expects Malli-backed validation outcomes; absent the
-            ;; require the validator soft-passes (no failure traces).
+            ;; Per rf2-v96fh (schema implies validation) requiring
+            ;; `re-frame.schemas` above already loads `re-frame.schemas.malli`
+            ;; for its ns-load side effect (publishes the validate/explain
+            ;; late-bind hooks), so the default validator is LIVE — the
+            ;; conformance corpus's Malli-backed outcomes hold without this
+            ;; explicit require. The require is kept as a harmless, explicit
+            ;; statement of the Malli dependency (rf2-a5kzs finding 4).
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.subs :as subs]

--- a/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
@@ -1,0 +1,263 @@
+(ns re-frame.schemas-fail-open-test
+  "JVM tests for the validator-throw / explainer-throw fail-OPEN closure on
+  the four meta-bearing validate-*! surfaces and the production boundary
+  seam (rf2-a5kzs findings 2 + 3).
+
+  ## Finding 2 — malformed-schema fail-open
+
+  `run-validation` (the shared core of validate-event! / validate-cofx! /
+  validate-fx! / validate-sub!) used to invoke the registered validator
+  DIRECTLY. Malli validates schema FORMS lazily — a childless `[:vector]`
+  / unknown op registers fine, then makes the validator THROW on the first
+  validate call. That throw propagated out of validate-*! and the runtime
+  call-sites (`router` / `cofx` / `fx` / `subs`) coerced it to a validation
+  PASS via their defensive `(catch … true)`: the event/cofx handler ran, the
+  fx handler ran, the sub returned its invalid value — all with no trace and
+  no recovery. Same fail-open class already closed for app-db schemas
+  (rf2-ss06u.3).
+
+  The fix isolates the throw inside `run-validation` (via
+  `validate-entry-result`), emits a distinct `:rf.error/malformed-schema`
+  trace, and returns `false` so each caller runs its normal recovery
+  (skip handler / skip fx / replace sub return). The boundary seam
+  `validate-with-registered-fn` isolates the same throw and returns `false`
+  (fail CLOSED → skip the handler).
+
+  ## Finding 3 — explainer-throw catch-as-pass
+
+  After a validator returns false, `run-explainer` / `validate-app-schema!`
+  called the registered explainer WITHOUT a try/catch. A throwing custom
+  explainer aborted trace construction; the throw unwound PAST the
+  legitimate `false` and the runtime caught it as a PASS (for app-db: the
+  router's swallowed-backstop returned true / no rollback, so the invalid
+  commit installed). The fix routes every explainer call through
+  `safe-explain`: a throw degrades to a nil explanation and the `false`
+  verdict is preserved."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
+            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.schemas.validator :as validator]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(defn- capture
+  "Run `body-fn` while collecting trace events; return the captured vector."
+  [body-fn]
+  (let [traces (atom [])
+        cb-id  (keyword (gensym "capture"))]
+    (rf/register-listener! cb-id (fn [ev] (swap! traces conj ev)))
+    (try (body-fn) (finally (rf/unregister-listener! cb-id)))
+    @traces))
+
+(defn- malformed-traces [traces]
+  (filter #(= :rf.error/malformed-schema (:operation %)) traces))
+
+(defn- validation-failures [traces]
+  (filter #(= :rf.error/schema-validation-failure (:operation %)) traces))
+
+;; ===========================================================================
+;; Finding 2 — malformed-schema fails CLOSED on every meta-bearing surface
+;; ===========================================================================
+
+(deftest event-malformed-schema-fails-closed
+  (testing "rf2-a5kzs (finding 2) — a childless [:vector] :schema on a
+            reg-event-* handler does NOT throw-as-pass: the handler is
+            skipped and a :rf.error/malformed-schema trace fires."
+    (let [calls (atom 0)]
+      (rf/reg-event-db :ev/malformed
+        {:schema [:vector]}                       ;; childless — Malli throws at validate-time
+        (fn [db _] (swap! calls inc) db))
+      (let [traces (capture #(rf/dispatch-sync [:ev/malformed :anything]))]
+        (is (= 0 @calls)
+            "handler skipped — the malformed-schema throw no longer coerces to a pass")
+        (let [mal (malformed-traces traces)]
+          (is (= 1 (count mal)) "exactly one malformed-schema trace fired")
+          (let [m (first mal)]
+            (is (= :event (-> m :tags :where)))
+            (is (= [:vector] (-> m :tags :schema)) ":schema carries the malformed form to fix")
+            (is (string? (-> m :tags :reason)))
+            ;; fail-closed: no value-bearing slot leaks into the malformed trace.
+            (is (not (contains? (:tags m) :received)))
+            (is (not (contains? (:tags m) :value)))))))))
+
+(deftest event-unknown-op-schema-fails-closed
+  (testing "rf2-a5kzs (finding 2) — an unknown-op :schema on a reg-event-*
+            handler also fails closed with a distinct trace, no throw."
+    (let [calls (atom 0)]
+      (rf/reg-event-db :ev/unknown
+        {:schema [:not-a-real-op :int]}
+        (fn [db _] (swap! calls inc) db))
+      (let [traces (capture #(rf/dispatch-sync [:ev/unknown 1]))]
+        (is (= 0 @calls) "handler skipped")
+        (is (= 1 (count (malformed-traces traces))) "one malformed-schema trace fired")))))
+
+(deftest cofx-malformed-schema-fails-closed
+  (testing "rf2-a5kzs (finding 2) — a malformed cofx :schema does not run the
+            handler via throw-as-pass; the handler is skipped and a
+            malformed-schema trace fires."
+    (rf/reg-cofx :cf/malformed
+      {:schema [:vector]}
+      (fn [ctx] (assoc-in ctx [:coeffects :cf/malformed] :whatever)))
+    (let [calls (atom 0)]
+      (rf/reg-event-fx :use/malformed-cofx
+        [(rf/inject-cofx :cf/malformed)]
+        (fn [_ _] (swap! calls inc) {}))
+      (let [traces (capture #(rf/dispatch-sync [:use/malformed-cofx]))]
+        (is (= 0 @calls) "handler skipped — cofx malformed-schema is no longer a silent pass")
+        (let [mal (malformed-traces traces)]
+          (is (= 1 (count mal)))
+          (is (= :cofx (-> (first mal) :tags :where))))))))
+
+(deftest fx-malformed-schema-fails-closed-skipping-only-offender
+  (testing "rf2-a5kzs (finding 2) — a malformed fx :schema skips ONLY the
+            offending fx (recovery :skipped); the sibling fx still runs."
+    (let [bad-calls  (atom 0)
+          good-calls (atom 0)]
+      (rf/reg-fx :fx/malformed
+        {:schema [:vector]}
+        (fn [_ _] (swap! bad-calls inc)))
+      (rf/reg-fx :fx/sibling
+        (fn [_ _] (swap! good-calls inc)))
+      (rf/reg-event-fx :emit/both
+        (fn [_ _] {:fx [[:fx/malformed {:any :thing}]
+                        [:fx/sibling   :ok]]}))
+      (let [traces (capture #(rf/dispatch-sync [:emit/both]))]
+        (is (= 0 @bad-calls) "the offending fx was skipped — not run via throw-as-pass")
+        (is (= 1 @good-calls) "the sibling fx still ran")
+        (let [mal (malformed-traces traces)]
+          (is (= 1 (count mal)))
+          (is (= :fx-args (-> (first mal) :tags :where))))))))
+
+(deftest sub-malformed-schema-fails-closed-replaced-with-default
+  (testing "rf2-a5kzs (finding 2) — a malformed sub :schema yields the default
+            (nil) per :replaced-with-default recovery instead of returning the
+            unvalidated value via throw-as-pass; a malformed-schema trace fires."
+    (rf/reg-event-db :sub/init (fn [_ _] {:items [1 2 3]}))
+    (rf/reg-sub :sub/malformed
+      {:schema [:vector]}                          ;; childless — throws at validate-time
+      (fn [db _] (:items db)))
+    (let [traces (capture
+                   (fn []
+                     (rf/dispatch-sync [:sub/init])
+                     (is (nil? (rf/subscribe-once [:sub/malformed]))
+                         "malformed sub schema → nil (replaced-with-default), not the raw value")))]
+      (let [mal (malformed-traces traces)]
+        (is (pos? (count mal)) "a malformed-schema trace fired")
+        (is (= :sub-return (-> (first mal) :tags :where)))))))
+
+(deftest boundary-seam-malformed-schema-returns-false
+  (testing "rf2-a5kzs (finding 2, boundary seam) — validate-with-registered-fn
+            isolates a malformed-schema throw and returns FALSE (fail closed)
+            rather than propagating to the interceptor's (catch … true)."
+    (is (false? (schemas/validate-with-registered-fn [:vector] [:anything]))
+        "childless [:vector] → false (not a throw, not a pass)")
+    (is (false? (schemas/validate-with-registered-fn [:not-a-real-op :int] 1))
+        "unknown op → false")
+    ;; A well-formed schema still returns a real verdict.
+    (is (true?  (schemas/validate-with-registered-fn [:cat [:= :ok] :int] [:ok 1]))
+        "well-formed conforming → true")
+    (is (false? (schemas/validate-with-registered-fn [:cat [:= :ok] :int] [:ok "no"]))
+        "well-formed non-conforming → false")))
+
+(deftest direct-validate-event-malformed-schema-returns-false
+  (testing "rf2-a5kzs (finding 2) — the direct validate-event! call returns
+            false (not a throw) on a malformed schema and emits the trace."
+    (let [traces (capture
+                   (fn []
+                     (is (false? (schemas/validate-event! :ev/x [:ev/x 1] {:schema [:vector]}))
+                         "malformed schema → false, no throw")))]
+      (is (= 1 (count (malformed-traces traces)))))))
+
+;; ===========================================================================
+;; Finding 3 — a throwing explainer must NOT become a catch-as-pass
+;; ===========================================================================
+
+(def ^:private throwing-explainer
+  (fn [_schema _value] (throw (ex-info "explainer boom" {}))))
+
+(deftest app-db-explainer-throw-preserves-failure
+  (testing "rf2-a5kzs (finding 3) — when validate returns false and the
+            registered explainer THROWS, validate-app-schema! still returns
+            false (the commit rolls back) and emits the failure trace with
+            :explain nil — the throw does not abort trace construction nor
+            unwind into the router's catch-as-pass."
+    ;; validate fails; explain throws.
+    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+                              :explain  throwing-explainer})
+    (try
+      (rf/reg-app-schema [:n] [:int])
+      (let [traces (capture
+                     (fn []
+                       (is (false? (schemas/validate-app-schema! {:n "bad"} :n/bad))
+                           "fail-closed: false (rollback) — the explainer throw did not flip the verdict")))]
+        (let [v (first (validation-failures traces))]
+          (is (some? v) "the failure trace still fired")
+          (is (= :app-db (-> v :tags :where)))
+          (is (nil? (-> v :tags :explain)) ":explain degraded to nil — explainer threw")))
+      (finally (schemas/reset-schema-validator!)))))
+
+(deftest sub-return-explainer-throw-preserves-failure
+  (testing "rf2-a5kzs (finding 3) — a throwing explainer on the meta-bearing
+            run-validation path (sub-return) still returns false; the sub
+            yields the default and the failure trace fires with :explain nil."
+    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+                              :explain  throwing-explainer})
+    (try
+      (rf/reg-event-db :s/init (fn [_ _] {:v [1 2 3]}))
+      (rf/reg-sub :s/strict
+        {:schema [:vector :string]}
+        (fn [db _] (:v db)))
+      (let [traces (capture
+                     (fn []
+                       (rf/dispatch-sync [:s/init])
+                       (is (nil? (rf/subscribe-once [:s/strict]))
+                           "sub yields default — the explainer throw did not become a pass")))]
+        (let [v (first (validation-failures traces))]
+          (is (some? v) "the sub-return failure trace fired")
+          (is (= :sub-return (-> v :tags :where)))
+          (is (nil? (-> v :tags :explain)) ":explain degraded to nil")))
+      (finally (schemas/reset-schema-validator!)))))
+
+(deftest direct-validate-event-explainer-throw-preserves-false
+  (testing "rf2-a5kzs (finding 3) — validate-event! returns false (not a
+            throw) when the explainer throws on a real validation failure."
+    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+                              :explain  throwing-explainer})
+    (try
+      (let [traces (capture
+                     (fn []
+                       (is (false? (schemas/validate-event!
+                                     :ev/x [:ev/x "bad"]
+                                     {:schema [:cat [:= :ev/x] :int]}))
+                           "false despite the explainer throwing")))]
+        (let [v (first (validation-failures traces))]
+          (is (some? v))
+          (is (= :event (-> v :tags :where)))
+          (is (nil? (-> v :tags :explain)))))
+      (finally (schemas/reset-schema-validator!)))))
+
+(deftest boundary-explain-seam-isolates-explainer-throw
+  (testing "rf2-a5kzs (finding 3, boundary seam) — explain-with-registered-fn
+            degrades a throwing explainer to nil rather than propagating."
+    (schemas/set-schema-explainer! throwing-explainer)
+    (try
+      (is (nil? (schemas/explain-with-registered-fn [:int] "bad"))
+          "explainer throw → nil, not a propagated exception")
+      (finally (schemas/reset-schema-validator!)))))
+
+;; ===========================================================================
+;; Belt-and-braces — a non-throwing default explainer still attaches :explain
+;; ===========================================================================
+
+(deftest healthy-explainer-still-attaches-explain
+  (testing "rf2-a5kzs — the safe-explain wrapper is transparent on the happy
+            path: a normal Malli failure still carries a non-nil :explain."
+    (rf/reg-app-schema [:n] [:int])
+    (let [traces (capture
+                   #(schemas/validate-app-schema! {:n "bad"} :n/bad))
+          v      (first (validation-failures traces))]
+      (is (some? v))
+      (is (some? (-> v :tags :explain))
+          ":explain is the real Malli explanation — safe-explain didn't swallow it"))))

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -42,11 +42,13 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
-            ;; Per rf2-t0hq + rf2-qyfie — the Malli adapter ns must be
-            ;; required at boot to publish the late-bind hook the
-            ;; default validator routes through; absent the require,
-            ;; the validator soft-passes per Spec 010 §Recommended
-            ;; soft-pass.
+            ;; Per rf2-v96fh (schema implies validation) requiring
+            ;; `re-frame.schemas` above already loads `re-frame.schemas.malli`
+            ;; for its ns-load side effect (publishes the validate/explain
+            ;; late-bind hooks the default validator routes through), so the
+            ;; validator is LIVE without this explicit require — kept as a
+            ;; harmless, explicit statement of the Malli dependency
+            ;; (rf2-a5kzs finding 4).
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]))
 
@@ -715,6 +717,135 @@
         (is (= [:user/register {:email "carol@example.com" :age "no"}]
                (-> v :tags :value))
             ":value rides verbatim")))))
+
+;; ---- rf2-a5kzs (finding 1) — event-schema per-slot :sensitive? redaction --
+;; Pre-fix `validate-event!` passed `walk-schema? false`, so a per-slot
+;; `:sensitive?` inside the event schema (e.g. a `:cat` payload map) was
+;; IGNORED and the failing payload leaked verbatim via :received / :value /
+;; :explain to trace listeners / off-box consumers. The fix flips the walk on
+;; for events (the event schema's `:cat`/`:catn` payload commonly IS map-shaped)
+;; so a per-slot or container-level :sensitive? drives the redaction exactly as
+;; on app-db / cofx / fx / sub surfaces. These fail before the flip and pass
+;; after; the existing handler-meta test above pins that a NON-sensitive event
+;; schema still rides verbatim (no over-redaction).
+
+(deftest event-validation-redacts-sensitive-cat-payload-slot
+  (testing "rf2-a5kzs — a failing event whose :cat payload map carries a
+            per-slot {:sensitive? true} slot redacts :received / :value /
+            :explain and stamps :sensitive? true"
+    (let [secret "hunter2-DO-NOT-LEAK"
+          calls  (atom 0)]
+      (rf/reg-event-db :auth/login
+        {:schema [:cat [:= :auth/login]
+                  [:map
+                   [:user :string]
+                   ;; :password is sensitive AND wrong type (int) → fails.
+                   [:password {:sensitive? true} :int]]]}
+        (fn [db _] (swap! calls inc) db))
+      (let [traces (atom [])]
+        (rf/register-listener! ::login (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:auth/login {:user "ada" :password secret}])
+        (rf/unregister-listener! ::login)
+        (is (= 0 @calls) "handler skipped — validation failed")
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v) "a trace fired")
+          (is (true? (:sensitive? v))
+              "top-level :sensitive? stamp — event schema declares a sensitive slot")
+          (is (= :rf/redacted (-> v :tags :received)) ":received redacted")
+          (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+          (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+          (is (not (str/includes? (pr-str (:tags v)) secret))
+              "the raw secret does NOT appear anywhere in the emitted tags")
+          ;; Structural slots survive.
+          (is (= :event (-> v :tags :where)))
+          (is (= :auth/login (-> v :tags :event-id))))))))
+
+(deftest event-validation-redacts-container-level-sensitive-payload
+  (testing "rf2-a5kzs — a container-level {:sensitive? true} on the event
+            payload schema also drives redaction"
+    (let [secret "TOKEN-leak-check"]
+      (rf/reg-event-db :auth/token
+        ;; The whole payload (element 1 of the :cat) is sensitive; supply an
+        ;; int where :string is expected so it fails.
+        {:schema [:cat [:= :auth/token] [:string {:sensitive? true}]]}
+        (fn [db _] db))
+      (let [traces (atom [])]
+        (rf/register-listener! ::tok (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:auth/token 12345])
+        (rf/unregister-listener! ::tok)
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v))
+          (is (true? (:sensitive? v)) "container-level :sensitive? triggers redaction")
+          (is (= :rf/redacted (-> v :tags :received)))
+          (is (= :rf/redacted (-> v :tags :value))))))))
+
+(deftest event-validation-non-sensitive-cat-still-verbatim
+  (testing "rf2-a5kzs — no over-redaction: an event schema with a payload map
+            that has NO :sensitive? slot still rides verbatim after the walk
+            is enabled"
+    (rf/reg-event-db :user/update
+      {:schema [:cat [:= :user/update] [:map [:name :string] [:age :int]]]}
+      (fn [db _] db))
+    (let [traces (atom [])]
+      (rf/register-listener! ::upd (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:user/update {:name "bob" :age "old"}])
+      (rf/unregister-listener! ::upd)
+      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                             @traces))]
+        (is (some? v))
+        (is (not (contains? v :sensitive?))
+            "no :sensitive? stamp — nothing in the event schema is sensitive")
+        (is (= [:user/update {:name "bob" :age "old"}] (-> v :tags :received))
+            ":received rides verbatim — the walk did not spuriously redact")))))
+
+;; ---- rf2-a5kzs (finding 1) — boundary-path redaction seam ----------------
+;; The production boundary interceptor (`re-frame.spec`) builds its own event-
+;; failure tags and previously emitted them verbatim. The fix routes them
+;; through the `:schemas/redact-event-tags` seam so a sensitive event payload
+;; is redacted at the boundary exactly as the dev-time step-1 path. These test
+;; the seam directly (the schemas-owned redaction surface).
+
+(deftest redact-event-tags-redacts-when-schema-sensitive
+  (testing "rf2-a5kzs — redact-event-tags scrubs the value-bearing boundary
+            tags and stamps :sensitive? when the event schema is sensitive"
+    (let [secret "boundary-secret-9f3a"
+          schema [:cat [:= :auth/login]
+                  [:map [:password {:sensitive? true} :string]]]
+          tags   {:where      :event
+                  :event-id   :auth/login
+                  :failing-id :auth/login
+                  :schema-id  :auth/login
+                  :received   [:auth/login {:password secret}]
+                  :value      [:auth/login {:password secret}]
+                  :explain    {:value secret}
+                  :source     :boundary
+                  :recovery   :no-recovery}
+          out    (schemas/redact-event-tags schema tags)]
+      (is (= :rf/redacted (:received out)) ":received redacted")
+      (is (= :rf/redacted (:value out)) ":value redacted")
+      (is (= :rf/redacted (:explain out)) ":explain redacted")
+      (is (true? (:sensitive? out)) ":sensitive? stamped")
+      (is (not (str/includes? (pr-str out) secret))
+          "the secret does not survive anywhere in the redacted boundary tags")
+      ;; Structural slots survive.
+      (is (= :event (:where out)))
+      (is (= :auth/login (:event-id out)))
+      (is (= :boundary (:source out))))))
+
+(deftest redact-event-tags-rides-verbatim-when-not-sensitive
+  (testing "rf2-a5kzs — redact-event-tags is a no-op when the event schema has
+            no :sensitive? slot (boundary parity with the dev-time path)"
+    (let [schema [:cat [:= :api/strict] :int]
+          tags   {:where    :event
+                  :event-id :api/strict
+                  :received [:api/strict "not-an-int"]
+                  :value    [:api/strict "not-an-int"]
+                  :source   :boundary}
+          out    (schemas/redact-event-tags schema tags)]
+      (is (= tags out) "tags ride back unchanged — nothing sensitive to redact")
+      (is (not (contains? out :sensitive?))))))
 
 ;; ---- redaction at cofx validation site -----------------------------------
 

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -484,6 +484,7 @@
   ["re-frame.schemas" "on-frame-destroyed!"]       {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "validate-app-schema!"]      {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "validate-event!"]           {:tier :internal-public :owner "010" :status "v1"}
+  ["re-frame.schemas" "redact-event-tags"]         {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "validate-fx!"]              {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "validate-cofx!"]            {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "validate-sub!"]             {:tier :internal-public :owner "010" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 473,
+ :var-count 474,
  :tier-vocab
  [:front-porch
   :advanced

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -291,6 +291,7 @@
   {:namespace "re-frame.schemas", :var "frame-schema-entries", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "on-frame-destroyed!", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "printer-fn", :tier :internal-public, :kind :var, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.schemas", :var "redact-event-tags", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "reg-app-schema", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "reg-app-schemas", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "reset-schema-validator!", :tier :advanced, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Fixes **rf2-a5kzs** — Correctness review: implementation/schemas (4 findings). All four findings addressed.

## Finding 1 — PRIVACY LEAK (event-schema `:sensitive?` ignored)
`validate-event!` passed `walk-schema? false`, so a per-slot `:sensitive?` inside an event schema (e.g. `[:cat [:= :auth/login] [:map [:password {:sensitive? true} :string]]]`) was ignored and the failing payload leaked verbatim via `:received`/`:value`/`:explain`.

- **Dispatch path:** flipped `validate-event!` to `walk-schema? true`. `walker/schema-has-sensitive?` walks the whole event schema (the `:cat` container descends into its `:map` payload child), so a per-slot or container-level `:sensitive?` now drives redaction. Non-sensitive event failures still ride verbatim (no over-redaction).
- **Boundary path:** the production boundary interceptor (`re-frame.spec`) now routes its failure tags through a new schemas seam `redact-event-tags` (the `:schemas/redact-event-tags` late-bind hook). When the schemas artefact is absent the hook is nil and tags ride verbatim. This is the one piece that required out-of-`schemas/` wiring (see lane note below).

## Finding 2 — FAIL-OPEN (malformed schema -> throw coerced to pass)
`run-validation` invoked the registered validator directly; a malformed schema (childless `[:vector]`, unknown op) made it throw, and the runtime call-sites' defensive `(catch ... true)` coerced the throw to a validation **pass**.

- `run-validation` now isolates the throw per-call (`validate-entry-result`), emits `:rf.error/malformed-schema` with the surface's structural slots (value-bearing slots stripped — fail-closed, mirroring `validate-app-schema!`), and returns `false` so each caller runs its normal recovery (skip handler / skip fx / replace sub return).
- The boundary seam `validate-with-registered-fn` isolates the same throw and returns `false` (fail closed).

## Finding 3 — EXPLAINER THROW (catch-as-pass)
A throwing explainer aborted trace construction and unwound past the `false` verdict into the runtime's catch-as-pass (app-db: swallowed-backstop returned true / no rollback -> invalid commit installs).

- New `safe-explain` wraps every explainer call (`run-validation`, `validate-app-schema!`, and the boundary `explain-with-registered-fn`). On a throw it degrades to a nil explanation and preserves `false`.

## Finding 4 — DOC (stale packaging guidance)
`schemas/deps.edn` said consumers must require `re-frame.schemas.malli` at boot and that validation soft-passes without it — but `re-frame.schemas` now requires `.malli` for its ns-load side effect (schema-implies-validation, rf2-v96fh). Corrected the packaging comment to the current contract and updated two stale test require-comments.

## Lane note (for mayor review)
The bead scoped the boundary path to this worker. The boundary trace emit lives in `implementation/core/src/re_frame/spec.cljc`, so two **core** files were touched in addition to the five `implementation/schemas/**` files: `re_frame/spec.cljc` (route boundary tags through the redaction seam) and `re_frame/late_bind/directory.cljc` (drift-gate entry for the new hook). Both are disjoint from the http (rznrz) and ssr+security (cv165) sibling lanes — zero conflict surface. Flagging explicitly per the "ONLY implementation/schemas/**" instruction; veto-able if preferred.

## Quality gates
- `cd implementation && npm run test:cljs` — **5727 tests, 20076 assertions, 0 failures, 0 errors** (PASS)
- `cd implementation/schemas && clojure -M:test` — **271 tests, 18569 assertions, 0 failures, 0 errors** (PASS)
- `cd implementation/core && clojure -M:test` (late-bind drift gate + core spine) — **896 tests, 4025 assertions, 0 failures, 0 errors** (PASS)
