### PR TITLE
fix(flows): serialize clear-flow + re-registration against the frame drain (rf2-2woz9)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -227,6 +227,87 @@
       (adapter/replace-container! container new-db)
       new-db)))
 
+;; ---- lifecycle-vs-drain serialization (rf2-2woz9) -------------------------
+;;
+;; Some per-frame registry mutations must be ATOMIC with respect to that
+;; frame's event drain — they read-modify-write shared registry state AND
+;; app-db, and a concurrent drain that interleaves between the steps can
+;; observe a half-applied lifecycle change. The flows artefact has two such
+;; ops (rf2-2woz9):
+;;
+;;   - `clear-flow` vacates the output path THEN removes the flow from the
+;;     registry. A drain that starts in that window still sees the flow,
+;;     recomputes it, and re-commits the output that clear-flow already
+;;     vacated — leaving stale derived state no live flow maintains.
+;;   - `reg-flow` replacement publishes the new flow into the registry
+;;     (visible to the drain) BEFORE the registrar replacement-hook drops
+;;     the stale `last-inputs` row. A drain in that window sees the new flow
+;;     with the OLD input cache and skips recompute on `=`-equal inputs.
+;;
+;; The frame's `:drain-lock` is the existing single-drainer serialization
+;; primitive (the router CAS-acquires it for the whole drain pass — see
+;; `re-frame.router/drain-loop!`). `call-serialized-with-drain!` runs `f`
+;; under that lock so the lifecycle mutation is mutually exclusive with any
+;; concurrent drain, closing the windows above with ONE mechanism rather
+;; than per-op reordering / token threading (which would touch the hot
+;; dirty-check path). The drain path itself is untouched — it still just
+;; CAS-acquires the lock as before; only the cold lifecycle ops now contend
+;; for it.
+;;
+;; REENTRANCY is the load-bearing subtlety. `clear-flow` / `reg-flow` can be
+;; invoked MID-DRAIN via the `:rf.fx/clear-flow` / `:rf.fx/reg-flow` effects
+;; (do-fx runs inside the drain pass, on the draining thread, which already
+;; holds `:drain-lock`). A naive acquire would deadlock the drainer against
+;; a lock it itself holds. So we first ask the router whether THIS thread is
+;; the frame's active drainer (the same `:in-drain?` thread marker the
+;; `dispatch-sync` nesting guard reads): if so we are already inside the
+;; single-drainer window and run `f` directly; only a DIFFERENT thread (or a
+;; non-drain call site) acquires the lock. On CLJS — single-threaded — the
+;; marker is `true`/`nil` and the same equality discriminates; an
+;; uncontended top-level call CAS-acquires the false lock on the first try.
+
+(defn- current-thread-is-drainer?
+  "True when the calling thread is the frame's currently-active drainer.
+  Reads the router's `:in-drain?` marker (stamped by
+  `re-frame.router/mark-drainer!` to the drainer thread on JVM, `true` on
+  CLJS). The flows lifecycle ops use this to take the reentrant fast-path
+  when invoked mid-drain via `:rf.fx/reg-flow` / `:rf.fx/clear-flow` — they
+  are already inside the single-drainer window, so re-taking `:drain-lock`
+  would self-deadlock."
+  [frame-record]
+  (let [in-drain (:in-drain? @(:router frame-record))]
+    #?(:clj  (identical? in-drain (Thread/currentThread))
+       :cljs (true? in-drain))))
+
+(defn call-serialized-with-drain!
+  "Run thunk `f` serialized against `frame-id`'s event drain, returning its
+  value (rf2-2woz9). Used by per-frame registry mutations that must not
+  interleave with a concurrent `run-flows-on-db` pass.
+
+  - Frame absent (unregistered / destroyed): nothing can be draining it, so
+    just run `f`.
+  - Calling thread is the frame's active drainer (mid-drain `:rf.fx/*`
+    call): already inside the single-drainer window — run `f` directly to
+    avoid self-deadlocking on `:drain-lock`.
+  - Otherwise: spin-CAS-acquire `:drain-lock` (the same acquire shape
+    `re-frame.router/drain-block!` uses — bounded wait: an active drainer
+    holds it for at most `drain-depth` events), run `f`, release in a
+    `finally`."
+  [frame-id f]
+  (if-let [frame-record (frame frame-id)]
+    (if (current-thread-is-drainer? frame-record)
+      (f)
+      (let [drain-lock (:drain-lock frame-record)]
+        (loop []
+          (when-not (compare-and-set! drain-lock false true)
+            #?(:clj (Thread/yield))
+            (recur)))
+        (try
+          (f)
+          (finally
+            (reset! drain-lock false)))))
+    (f)))
+
 ;; ---- frame presets (Spec 002 §Frame presets) ------------------------------
 ;;
 ;; A :preset key in metadata expands at registration time into a fixed

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -411,71 +411,97 @@
      ;; registration of `flow-id` on THIS frame (even if a SIBLING frame
      ;; already holds the global registrar slot).
      (let [prior-on-frame (volatile! nil)]
-       (swap! flows
-              (fn [m]
-                (let [prior-frame (get m frame-id)]
-                  (vreset! prior-on-frame (get prior-frame flow-id))
-                  (let [prospective (assoc prior-frame flow-id flow)]
-                    ;; Two registration-time rejections, both run on the
-                    ;; PROSPECTIVE map inside this update fn so they share
-                    ;; the cycle check's atomicity (rf2-qxwib): a throw
-                    ;; propagates out of `swap!`, the CAS never fires, and
-                    ;; the prior registration survives untouched.
-                    ;;
-                    ;; 1. Throws :rf.error/flow-path-overlap (rf2-um6d9) if
-                    ;;    the new flow's output :path overlaps an already-
-                    ;;    registered sibling's :path (one a prefix of the
-                    ;;    other). The topo dependency rule compares :path vs
-                    ;;    :inputs only, so overlapping outputs get no edge
-                    ;;    and their eval order is undefined — reject before
-                    ;;    any state mutates (Spec 013 §Disjoint output
-                    ;;    paths). Checked BEFORE the cycle sort so a frame
-                    ;;    with overlapping outputs reports the more specific
-                    ;;    footgun rather than whatever (or no) cycle the topo
-                    ;;    walk happens to surface.
-                    ;; 2. Throws :rf.error/flow-cycle if the prospective map
-                    ;;    is cyclic; the update fn never returns and the CAS
-                    ;;    never fires, so the atom is unchanged.
-                    (topo/detect-output-path-overlap! prospective)
-                    (topo/topo-sort prospective)
-                    (assoc m frame-id prospective)))))
-       ;; rf2-73pi1 finding 2: a same-frame re-registration that MOVES the
-       ;; output to a new `:path` must vacate the OLD path from this
-       ;; frame's app-db — otherwise the previous definition's last write
-       ;; lingers and downstream reads see stale derived state at the
-       ;; abandoned slot. Only fires on a real same-frame replacement
-       ;; (`prior-on-frame` non-nil) whose `:path` actually changed; the
-       ;; commit above already installed the new definition, so the new
-       ;; path recomputes on the next drain. First-time registration and
-       ;; same-path hot-reload leave app-db untouched.
-       (when-let [prior @prior-on-frame]
-         (let [old-path (:path prior)]
-           (when (not= old-path (:path flow))
-             (vacate-output-path! frame-id old-path))))
-       ;; Cycle check + commit done atomically above. The :flow registrar
-       ;; slot keys on flow-id only; stamp :frame into the metadata so
-       ;; introspection
-       ;; / hot-reload hooks can read the owning frame. `register!`
-       ;; returns `{:was previous :now metadata}` — `:was` is nil on
-       ;; first-time registration, non-nil on hot-reload re-registration.
-       ;; Per rf2-v5ttb: stamp `:handler-fn` so the registrar's
-       ;; `:different-fn?` calculation (registrar.cljc) can tell a real
-       ;; body change from an idempotent reload. The registrar reads
-       ;; `:handler-fn` uniformly across kinds; events / subs / fx all
-       ;; populate it at their registration sites, but flows historically
-       ;; stored the body under `:output` only — so `(not= nil nil)` was
-       ;; the answer for every flow re-registration and `:different-fn?`
-       ;; was always `false` (re-frame-10x's flow panel / Xray / re-frame2-pair
-       ;; missed every real body swap). The `:output` slot is preserved
-       ;; for the flow-eval site that reads it; the additional
-       ;; `:handler-fn` stamp aligns the cross-kind hot-reload trace
-       ;; surface Spec 001 standardises.
-       (registrar/register!
-         :flow flow-id
-         (source-coords/merge-coords
-           (assoc flow
-                  :frame      frame-id
-                  :handler-fn (:output flow))))
+       ;; rf2-2woz9 finding 2: a same-frame `reg-flow` REPLACEMENT publishes
+       ;; the new flow into `flows` (visible to a drain) in the `swap!`
+       ;; below, but the stale-`last-inputs` invalidation only fires later
+       ;; via `registrar/register!` → `invalidate-flow-on-replace!`. Pre-fix,
+       ;; a drain that started in that window saw the NEW flow with the OLD
+       ;; input cache and skipped recompute on `=`-equal inputs, so the first
+       ;; post-replacement drain kept stale output (violating Spec 013's
+       ;; re-registration contract that the new flow re-evaluates on the next
+       ;; event regardless of input equality). Serializing publish →
+       ;; path-vacate → invalidation against the frame drain (`:drain-lock`)
+       ;; makes them one indivisible step: no drain can observe the new flow
+       ;; before its stale dirty-check row is dropped. The atomic check-and-
+       ;; insert `swap!` (rf2-qxwib) is preserved verbatim INSIDE the
+       ;; serialized region — its TOCTOU cycle guarantee is unchanged; we
+       ;; only add the outer drain-exclusion. Reentrant: a mid-drain
+       ;; `:rf.fx/reg-flow` runs directly inside the single-drainer window
+       ;; (see `frame/call-serialized-with-drain!`).
+       (frame/call-serialized-with-drain!
+         frame-id
+         (fn []
+           (swap! flows
+                  (fn [m]
+                    (let [prior-frame (get m frame-id)]
+                      (vreset! prior-on-frame (get prior-frame flow-id))
+                      (let [prospective (assoc prior-frame flow-id flow)]
+                        ;; Two registration-time rejections, both run on the
+                        ;; PROSPECTIVE map inside this update fn so they share
+                        ;; the cycle check's atomicity (rf2-qxwib): a throw
+                        ;; propagates out of `swap!`, the CAS never fires, and
+                        ;; the prior registration survives untouched.
+                        ;;
+                        ;; 1. Throws :rf.error/flow-path-overlap (rf2-um6d9) if
+                        ;;    the new flow's output :path overlaps an already-
+                        ;;    registered sibling's :path (one a prefix of the
+                        ;;    other). The topo dependency rule compares :path vs
+                        ;;    :inputs only, so overlapping outputs get no edge
+                        ;;    and their eval order is undefined — reject before
+                        ;;    any state mutates (Spec 013 §Disjoint output
+                        ;;    paths). Checked BEFORE the cycle sort so a frame
+                        ;;    with overlapping outputs reports the more specific
+                        ;;    footgun rather than whatever (or no) cycle the topo
+                        ;;    walk happens to surface.
+                        ;; 2. Throws :rf.error/flow-cycle if the prospective map
+                        ;;    is cyclic; the update fn never returns and the CAS
+                        ;;    never fires, so the atom is unchanged.
+                        (topo/detect-output-path-overlap! prospective)
+                        (topo/topo-sort prospective)
+                        (assoc m frame-id prospective)))))
+           ;; rf2-73pi1 finding 2: a same-frame re-registration that MOVES the
+           ;; output to a new `:path` must vacate the OLD path from this
+           ;; frame's app-db — otherwise the previous definition's last write
+           ;; lingers and downstream reads see stale derived state at the
+           ;; abandoned slot. Only fires on a real same-frame replacement
+           ;; (`prior-on-frame` non-nil) whose `:path` actually changed; the
+           ;; commit above already installed the new definition, so the new
+           ;; path recomputes on the next drain. First-time registration and
+           ;; same-path hot-reload leave app-db untouched.
+           (when-let [prior @prior-on-frame]
+             (let [old-path (:path prior)]
+               (when (not= old-path (:path flow))
+                 (vacate-output-path! frame-id old-path))))
+           ;; Cycle check + commit done atomically above. The :flow registrar
+           ;; slot keys on flow-id only; stamp :frame into the metadata so
+           ;; introspection
+           ;; / hot-reload hooks can read the owning frame. `register!`
+           ;; returns `{:was previous :now metadata}` — `:was` is nil on
+           ;; first-time registration, non-nil on hot-reload re-registration.
+           ;; Per rf2-v5ttb: stamp `:handler-fn` so the registrar's
+           ;; `:different-fn?` calculation (registrar.cljc) can tell a real
+           ;; body change from an idempotent reload. The registrar reads
+           ;; `:handler-fn` uniformly across kinds; events / subs / fx all
+           ;; populate it at their registration sites, but flows historically
+           ;; stored the body under `:output` only — so `(not= nil nil)` was
+           ;; the answer for every flow re-registration and `:different-fn?`
+           ;; was always `false` (re-frame-10x's flow panel / Xray / re-frame2-pair
+           ;; missed every real body swap). The `:output` slot is preserved
+           ;; for the flow-eval site that reads it; the additional
+           ;; `:handler-fn` stamp aligns the cross-kind hot-reload trace
+           ;; surface Spec 001 standardises.
+           ;;
+           ;; This `register!` is what fires the `invalidate-flow-on-replace!`
+           ;; replacement hook (:759) that drops the stale `last-inputs` row —
+           ;; keeping it INSIDE the serialized region is the fix for finding
+           ;; 2 (the publish above and this invalidation are now indivisible
+           ;; to a concurrent drain).
+           (registrar/register!
+             :flow flow-id
+             (source-coords/merge-coords
+               (assoc flow
+                      :frame      frame-id
+                      :handler-fn (:output flow))))))
        ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires
        ;; on FIRST-TIME registration AGAINST THIS FRAME. Pre-rf2-mb9vq
        ;; this gated on the GLOBAL registrar `:was` (flow-id-scoped, not
@@ -653,31 +679,46 @@
    (let [frame-id (or frame (frame/current-frame))]
      (when-let [flow (get-in @flows [frame-id id])]
        (let [path (:path flow)]
-         (vacate-output-path! frame-id path)
-         ;; Drop the flow from `frame-id`'s per-frame slot; when that was
-         ;; the LAST flow on the frame, prune the now-empty `frame-id` key
-         ;; entirely rather than leave a `{frame-id {}}` husk (rf2-4bbaw).
-         ;; The husk was harmless (bounded by frame count, tolerated by the
-         ;; concurrency-stress invariant) but a naive `flows-snapshot`
-         ;; consumer would iterate the empty entry; pruning keeps the
-         ;; registry exactly symmetric with `teardown-on-frame-destroy!`'s
-         ;; `(swap! flows dissoc frame-id)`.
-         (swap! flows (fn [m]
-                        (let [m' (update m frame-id dissoc id)]
-                          (cond-> m'
-                            (empty? (get m' frame-id)) (dissoc frame-id)))))
-         ;; Drop the cleared flow's dirty-check row from THIS frame's own
-         ;; `last-inputs` container (rf2-94ol5). Frame-local — a sibling
-         ;; frame registering the same id keeps its own row untouched.
-         (drop-frame-flow-row! frame-id id)
-         ;; Keep the shared `:flow` registrar slot aligned with a live
-         ;; owner (rf2-73pi1): unregister when this was the LAST frame
-         ;; holding the id, or re-point the slot to a surviving owner
-         ;; when the cleared frame was the slot's current (now-stale)
-         ;; metadata writer. Pre-fix this only unregistered on
-         ;; last-owner-release, leaving the slot pointing at the cleared
-         ;; frame whenever a sibling still held the id.
-         (realign-registrar-owner! @flows id frame-id)
+         ;; rf2-2woz9 finding 1: the vacate-then-deregister sequence below
+         ;; MUST be atomic w.r.t. the frame drain. Pre-fix, `vacate-output-
+         ;; path!` ran, then a same-frame drain could start, observe the
+         ;; STILL-registered flow, recompute it, and re-commit the output
+         ;; this clear vacated — and clear-flow, having already vacated,
+         ;; never vacated again, leaving stale derived state in app-db
+         ;; (violating Spec 013's clear-flow cleanup contract). Serializing
+         ;; the whole mutation against the drain (`:drain-lock`) makes the
+         ;; flow vanish from registry + app-db as one indivisible step the
+         ;; drain can never interleave with. Reentrant: a mid-drain
+         ;; `:rf.fx/clear-flow` runs directly inside the single-drainer
+         ;; window (see `frame/call-serialized-with-drain!`).
+         (frame/call-serialized-with-drain!
+           frame-id
+           (fn []
+             (vacate-output-path! frame-id path)
+             ;; Drop the flow from `frame-id`'s per-frame slot; when that was
+             ;; the LAST flow on the frame, prune the now-empty `frame-id` key
+             ;; entirely rather than leave a `{frame-id {}}` husk (rf2-4bbaw).
+             ;; The husk was harmless (bounded by frame count, tolerated by the
+             ;; concurrency-stress invariant) but a naive `flows-snapshot`
+             ;; consumer would iterate the empty entry; pruning keeps the
+             ;; registry exactly symmetric with `teardown-on-frame-destroy!`'s
+             ;; `(swap! flows dissoc frame-id)`.
+             (swap! flows (fn [m]
+                            (let [m' (update m frame-id dissoc id)]
+                              (cond-> m'
+                                (empty? (get m' frame-id)) (dissoc frame-id)))))
+             ;; Drop the cleared flow's dirty-check row from THIS frame's own
+             ;; `last-inputs` container (rf2-94ol5). Frame-local — a sibling
+             ;; frame registering the same id keeps its own row untouched.
+             (drop-frame-flow-row! frame-id id)
+             ;; Keep the shared `:flow` registrar slot aligned with a live
+             ;; owner (rf2-73pi1): unregister when this was the LAST frame
+             ;; holding the id, or re-point the slot to a surviving owner
+             ;; when the cleared frame was the slot's current (now-stale)
+             ;; metadata writer. Pre-fix this only unregistered on
+             ;; last-owner-release, leaving the slot pointing at the cleared
+             ;; frame whenever a sibling still held the id.
+             (realign-registrar-owner! @flows id frame-id)))
          ;; Per Spec 009 §:op-type vocabulary: :rf.flow/cleared fires after
          ;; clear-flow has removed the flow from the per-frame registry
          ;; and dissoc-in'd its output path. Tools observe this to drop

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -1,0 +1,269 @@
+(ns re-frame.flows-lifecycle-drain-race-test
+  "Per rf2-2woz9 — JVM regression coverage for the two flow-lifecycle vs
+  drain interleaving races.
+
+  Both bugs are window races between a flow LIFECYCLE op (`clear-flow` /
+  `reg-flow` replacement) and a concurrent EVENT DRAIN on the SAME frame.
+  Pre-fix, the lifecycle op's multi-step registry+app-db mutation was not
+  serialized against the frame's `:drain-lock`, so a drain could interleave
+  between steps and observe a half-applied change:
+
+    FINDING 1 (clear-flow stale output). `clear-flow` vacated the output
+    `:path` BEFORE removing the flow from the per-frame registry. A
+    same-frame drain that started in that window saw the STILL-registered
+    flow, recomputed it, and re-committed the output `clear-flow` had just
+    vacated. `clear-flow` then removed the registry / last-inputs rows but
+    NEVER vacated again — so a cleared flow left stale derived state in
+    app-db (violating Spec 013's clear-flow cleanup contract).
+
+    FINDING 2 (re-registration skips recompute). A same-frame `reg-flow`
+    REPLACEMENT published the new flow into `flows` (visible to a drain) in
+    the `swap!`, but the stale-`last-inputs` invalidation only fired later
+    via `registrar/register!` → `invalidate-flow-on-replace!`. A drain that
+    started after the new flow was visible but before `last-inputs` was
+    dropped saw the new flow with the OLD input cache and skipped recompute
+    on `=`-equal inputs — so the first post-replacement drain KEPT the stale
+    output (violating Spec 013's re-registration contract that the new flow
+    re-evaluates on the next event regardless of input equality).
+
+  THE FIX (rf2-2woz9): both lifecycle ops now run their registry+app-db
+  mutation under `frame/call-serialized-with-drain!`, which takes the
+  frame's `:drain-lock` (the existing single-drainer serialization
+  primitive) so the mutation is atomic w.r.t. any concurrent drain. A drain
+  can therefore NEVER observe a half-applied lifecycle change. (Reentrant:
+  a mid-drain `:rf.fx/clear-flow` / `:rf.fx/reg-flow` runs directly inside
+  the single-drainer window rather than self-deadlocking on the lock.)
+
+  TEST STRATEGY. Each test reproduces the dangerous interleaving
+  DETERMINISTICALLY by pausing the lifecycle op at the exact pre-fix gap
+  (via `with-redefs` of a private fn the op calls mid-region — NO production
+  test-seam) while a DIFFERENT thread attempts the racing dispatch. With the
+  fix the lifecycle op holds the drain-lock across the pause, so the racing
+  dispatch BLOCKS on the lock until the op fully completes; the post-
+  condition the bead pins (clean app-db / fresh recompute) then holds. A
+  pre-fix build would let the paused-window dispatch run and leave the
+  stale state — the asserts would fail.
+
+  CLJS is single-threaded; this race is JVM-only by construction."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.flows.registry :as registry]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+;; ---- per-test reset (mirrors flows_concurrency_stress_test.clj) -----------
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-listeners!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- await! [^CountDownLatch latch where]
+  (is (.await latch 30 TimeUnit/SECONDS)
+      (str "latch '" where "' did not trip within 30s — a deadlock or a "
+           "racing thread that never reached the rendezvous")))
+
+;; ---------------------------------------------------------------------------
+;; Finding 1 — clear-flow must not leave stale output when a drain races the
+;; vacate→deregister window.
+;; ---------------------------------------------------------------------------
+
+(deftest clear-flow-output-stays-vacated-when-a-drain-races-the-window
+  ;; rf2-2woz9 finding 1. Pause `clear-flow` AFTER it has vacated the output
+  ;; path (the pre-fix gap), launch an input-changing dispatch on another
+  ;; thread, then resume `clear-flow` and assert that after it returns the
+  ;; registry / last-inputs rows are gone AND the output path is absent.
+  ;;
+  ;; The pause is injected by redefining the private `vacate-output-path!`
+  ;; so it does its real work, signals "vacated", then blocks on a release
+  ;; latch — leaving `clear-flow` parked exactly in the pre-fix window while
+  ;; still HOLDING the drain-lock (the fix). The racing dispatch on thread B
+  ;; therefore cannot acquire the lock and run until `clear-flow` completes;
+  ;; it observes no flow and never re-commits the vacated output.
+  (testing "a same-frame dispatch racing the vacate window cannot re-commit cleared output"
+    (let [;; `vacate-output-path!` is private to the registry ns; reach it
+          ;; through the var-quote reader (privacy gates bare-symbol
+          ;; resolution, not `#'`).
+          vacate-var  #'re-frame.flows.registry/vacate-output-path!
+          orig-vacate @vacate-var
+          vacated     (CountDownLatch. 1)
+          raced       (CountDownLatch. 1)
+          release     (CountDownLatch. 1)]
+      (rf/reg-event-db :seed       (fn [_ _] {:n 5}))
+      (rf/reg-event-db :bump-input (fn [db [_ n]] (assoc db :n n)))
+      (rf/reg-flow {:id     :doubled
+                    :inputs [[:n]]
+                    :output (fn [n] (* 2 (or n 0)))
+                    :path   [:out]})
+      (rf/dispatch-sync [:seed])
+      (is (= 10 (:out (rf/app-db-value :rf/default)))
+          "precondition: the flow materialised :out = 2 × :n")
+
+      ;; `with-redefs` can't bind a PRIVATE var from another ns (it expands
+      ;; to `(var sym)`, which enforces privacy). Patch the var root directly
+      ;; via the var-quote (which reads private vars) and restore in finally.
+      (alter-var-root vacate-var
+                      (constantly
+                        (fn [frame-id path]
+                          ;; Real work first (the pre-fix order: vacate, THEN
+                          ;; the registry removal clear-flow does next), then
+                          ;; park in the window with the drain-lock held.
+                          (orig-vacate frame-id path)
+                          (.countDown vacated)
+                          (await! release "clear-flow release"))))
+      (try
+        (let [clearer
+              (future
+                (rf/clear-flow :doubled {:frame :rf/default}))
+              ;; Thread B: once clear-flow has vacated (and is parked under
+              ;; the drain-lock), fire an input-changing event. Pre-fix this
+              ;; would slip into the window, recompute the still-registered
+              ;; flow, and re-commit :out. Post-fix it spin-CAS-waits on the
+              ;; drain-lock until clear-flow finishes, then drains against an
+              ;; empty flow registry and leaves :out absent.
+              racer
+              (future
+                (await! vacated "vacate")
+                (rf/dispatch-sync [:bump-input 99] {:frame :rf/default})
+                (.countDown raced))]
+          ;; Give the racer a real chance to RUN its dispatch inside the
+          ;; vacate window before releasing clear-flow. Bounded wait, not a
+          ;; hard rendezvous: under the FIX the racer BLOCKS on the
+          ;; drain-lock (held by the parked clear-flow), so `raced` never
+          ;; trips here and we fall through after the timeout to release
+          ;; clear-flow — the racer then drains against an empty registry. A
+          ;; PRE-FIX build lets the racer complete its drain (and re-commit
+          ;; :out) within the window, tripping `raced` fast; the final
+          ;; assert below then catches the stale output. Either way we must
+          ;; not hang.
+          (await! vacated "vacate (main)")
+          (.await raced 3 TimeUnit/SECONDS)
+          (.countDown release)
+          (is (not= ::timeout (deref clearer 30000 ::timeout))
+              "clear-flow returned within 30s")
+          (is (not= ::timeout (deref racer 30000 ::timeout))
+              "the racing dispatch completed within 30s"))
+        (finally
+          (alter-var-root vacate-var (constantly orig-vacate))))
+
+      ;; --- The load-bearing post-conditions (bead acceptance) -----------
+      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :doubled))
+          "registry row gone: clear-flow removed :doubled from the per-frame registry")
+      (is (not (contains? (flows/last-inputs-snapshot) :doubled))
+          "last-inputs row gone: clear-flow dropped the dirty-check row")
+      (is (not (contains? (rf/app-db-value :rf/default) :out))
+          (str "output path ABSENT after clear-flow returned — the racing "
+               "drain did NOT re-commit the vacated :out. Pre-fix it would "
+               "hold the stale value " (:out (rf/app-db-value :rf/default))))
+      (is (nil? (registrar/lookup :flow :doubled))
+          "the :flow registrar slot was vacated (last owner released the id)"))))
+
+;; ---------------------------------------------------------------------------
+;; Finding 2 — a re-registration must re-evaluate on the next drain even when
+;; a drain races the publish→invalidate window.
+;; ---------------------------------------------------------------------------
+
+(deftest re-registration-recomputes-when-a-drain-races-the-invalidate-window
+  ;; rf2-2woz9 finding 2. Pause the `reg-flow` REPLACEMENT after it has
+  ;; published the new flow into `flows` but BEFORE `registrar/register!`
+  ;; fires the `invalidate-flow-on-replace!` hook that drops the stale
+  ;; `last-inputs` row (the pre-fix gap), dispatch an UNRELATED event on
+  ;; another thread, then resume and assert the first post-replacement drain
+  ;; materialises the NEW output.
+  ;;
+  ;; The pause is injected by redefining `registrar/register!` to signal
+  ;; "published" then block on a release latch on the `:flow` kind only — so
+  ;; reg-flow parks in the window while still HOLDING the drain-lock (the
+  ;; fix). The racing dispatch on thread B cannot acquire the lock and run
+  ;; until reg-flow completes its invalidation; the drain then sees the new
+  ;; flow with a DROPPED last-inputs row and recomputes regardless of input
+  ;; equality.
+  (testing "an unrelated dispatch racing the invalidate window still gets a fresh recompute"
+    (let [orig-register registrar/register!
+          published     (CountDownLatch. 1)
+          raced         (CountDownLatch. 1)
+          release       (CountDownLatch. 1)]
+      (rf/reg-event-db :seed     (fn [_ _] {:n 5}))
+      (rf/reg-event-db :unrelated (fn [db _] (assoc db :touched true)))
+      ;; Original flow: :out = 2 × :n.
+      (rf/reg-flow {:id     :scaled
+                    :inputs [[:n]]
+                    :output (fn [n] (* 2 (or n 0)))
+                    :path   [:out]})
+      (rf/dispatch-sync [:seed])
+      (is (= 10 (:out (rf/app-db-value :rf/default)))
+          "precondition: the original flow materialised :out = 2 × :n = 10")
+
+      (with-redefs [registrar/register!
+                    (fn [kind id metadata]
+                      (if (= kind :flow)
+                        (do
+                          ;; The new flow is ALREADY published into `flows`
+                          ;; by reg-flow's swap! before this call; parking
+                          ;; here reproduces the pre-fix publish→invalidate
+                          ;; gap. Signal, block, THEN run the real register!
+                          ;; (which fires invalidate-flow-on-replace!).
+                          (.countDown published)
+                          (await! release "reg-flow release")
+                          (orig-register kind id metadata))
+                        (orig-register kind id metadata)))]
+        (let [;; Thread A: re-register :scaled as :out = 100 × :n. Publishes
+              ;; the new flow, then parks at register! under the drain-lock.
+              replacer
+              (future
+                (rf/reg-flow {:id     :scaled
+                              :inputs [[:n]]
+                              :output (fn [n] (* 100 (or n 0)))
+                              :path   [:out]}
+                             {:frame :rf/default}))
+              ;; Thread B: once the new flow is published (but invalidation
+              ;; not yet applied), dispatch an UNRELATED event. Its inputs
+              ;; ([:n]) are =-equal to the previous run, so pre-fix the drain
+              ;; would skip recompute and KEEP :out = 10. Post-fix it
+              ;; spin-CAS-waits on the drain-lock until reg-flow drops the
+              ;; stale last-inputs row, then recomputes :out = 500.
+              racer
+              (future
+                (await! published "publish")
+                (rf/dispatch-sync [:unrelated] {:frame :rf/default})
+                (.countDown raced))]
+          ;; Bounded wait (not a hard rendezvous): under the FIX the racer
+          ;; BLOCKS on the drain-lock held by the parked reg-flow, so `raced`
+          ;; never trips and we fall through to release after the timeout — a
+          ;; PRE-FIX build lets the racer drain within the publish→invalidate
+          ;; window (skipping recompute on =-equal inputs, keeping :out = 10),
+          ;; tripping `raced` fast. The final assert then catches the stale
+          ;; output. Either way we must not hang.
+          (await! published "publish (main)")
+          (.await raced 3 TimeUnit/SECONDS)
+          (.countDown release)
+          (is (not= ::timeout (deref replacer 30000 ::timeout))
+              "reg-flow replacement returned within 30s")
+          (is (not= ::timeout (deref racer 30000 ::timeout))
+              "the racing unrelated dispatch completed within 30s")))
+
+      ;; --- The load-bearing post-condition (bead acceptance) ------------
+      ;; The first post-replacement drain (the unrelated event) MUST have
+      ;; materialised the NEW output. Inputs were =-equal across the
+      ;; replacement, so a recompute only happens if the stale last-inputs
+      ;; row was invalidated BEFORE the drain could observe the new flow —
+      ;; which the serialization guarantees.
+      (is (= 500 (:out (rf/app-db-value :rf/default)))
+          (str "first post-replacement drain materialised the NEW output "
+               "(100 × 5 = 500). Pre-fix the =-equal-inputs skip kept the "
+               "stale 10. Got " (:out (rf/app-db-value :rf/default))))
+      (is (:touched (rf/app-db-value :rf/default))
+          "the unrelated event's own write also landed"))))


### PR DESCRIPTION
Fixes **rf2-2woz9** — two correctness findings in `implementation/flows`, both window races between a flow **lifecycle op** and a concurrent same-frame **event drain**.

## The bugs

1. **clear-flow stale output** (`registry.cljc`). `clear-flow` vacated the output `:path` BEFORE removing the flow from the per-frame registry. A same-frame drain that started in that window saw the still-registered flow, recomputed it, and re-committed the output `clear-flow` had just vacated — `clear-flow` never vacated again, so a cleared flow left stale derived state in app-db (violated Spec 013's clear-flow cleanup contract).

2. **re-registration skips recompute** (`registry.cljc`). A same-frame `reg-flow` replacement published the new flow into `flows` (visible to the drain) in the `swap!`, but the stale-`last-inputs` invalidation only fired later via `registrar/register!` → `invalidate-flow-on-replace!`. A drain that started after the new flow was visible but before `last-inputs` was dropped saw the new flow with the OLD input cache and skipped recompute on `=`-equal inputs — the first post-replacement drain kept stale output (violated Spec 013's re-registration contract).

## The fix

Both ops now run their registry+app-db mutation under a new `frame/call-serialized-with-drain!`, which takes the frame's `:drain-lock` (the existing single-drainer serialization primitive — the router CAS-acquires it for the whole drain pass). The lifecycle mutation is therefore atomic w.r.t. any concurrent drain: a drain can never observe a half-applied lifecycle change. One mechanism closes both windows; the hot drain path is untouched (it still just CAS-acquires the lock — only the cold lifecycle ops now contend).

**Reentrancy** is the load-bearing subtlety: `clear-flow` / `reg-flow` can be invoked mid-drain via `:rf.fx/clear-flow` / `:rf.fx/reg-flow` (do-fx runs on the draining thread, which already holds the lock). The helper first asks the router whether THIS thread is the frame's active drainer (the same `:in-drain?` thread marker the `dispatch-sync` nesting guard reads); if so it runs the thunk directly rather than self-deadlocking. CLJS (single-threaded) takes the uncontended first-try CAS.

This is an implementation fix that makes the runtime honour the already-correct Spec 013 contracts (clear-flow cleanup; re-registration re-evaluates regardless of input equality) — no spec change. The `:drain-lock` is a Spec 002 runtime concept, not a Spec 013 surface, so documenting the serialization mechanism in the normative spec would be over-specification.

## New regressions

`implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj` deterministically reproduces each interleaving: it pauses the lifecycle op in the exact pre-fix window (via a private-var redef — no production seam) while another thread races the dispatch, then asserts the bead's post-conditions. Both tests **fail** against a serialization-bypassed build (finding 1 leaves stale `:out`=198; finding 2 keeps stale `:out`=10) and **pass** with the fix — verified, not vacuous.

## Quality gates

| Command | Result |
|---|---|
| `cd implementation/flows && clojure -M:test` | **151 tests, 4617 assertions, 0 failures, 0 errors** (was 149; +2 new regressions) |
| `cd implementation && npm run test:cljs` | **5727 tests, 20076 assertions, 0 failures, 0 errors** |
| `cd implementation/core && clojure -M:test -n re-frame.frame-lifecycle-test -n re-frame.router-drain-race-test -n re-frame.concurrency-stress-test` | **39 tests, 172 assertions, 0 failures, 0 errors** |
| `cd implementation/flows && RF2_ZTW5P_STRESS_ITERS=2000 RF2_QXWIB_TOCTOU_ROUNDS=2000 clojure -M:test -n re-frame.flows-concurrency-stress-test -n re-frame.flows-reg-flow-toctou-test` | **2 tests, 2062 assertions, 0 failures, 0 errors** (no deadlock under real contention) |
| Regression probe (serialization bypassed) | both new tests **FAIL** as expected, proving they catch the bug |