### PR TITLE
fix(core/subs): evict transitive :<- dependents on sub re-registration (rf2-kboyu)

### DIFF
--- a/implementation/core/src/re_frame/subs/cache.cljc
+++ b/implementation/core/src/re_frame/subs/cache.cljc
@@ -176,11 +176,46 @@
 
 ;; ---- hot-reload invalidation ---------------------------------------------
 ;;
-;; Per Spec 001 §Hot-reload semantics: when a :sub re-registers, every
-;; cached reaction whose query-id is that sub MUST be disposed and
-;; evicted across every frame's cache. Cached reactions hold the OLD
-;; body via closure; without explicit invalidation, they'd silently
-;; serve stale values.
+;; Per Spec 001 §Hot-reload semantics + Cross-Spec-Interactions §18: when a
+;; :sub re-registers, every cached reaction whose query-id is that sub MUST
+;; be disposed and evicted across every frame's cache — AND so must every
+;; cached DOWNSTREAM sub that depends on it (directly or transitively) via
+;; `:<-`. Cached reactions hold the OLD body via closure (and downstream
+;; reactions hold the OLD input reaction); without invalidating the whole
+;; transitive dependent closure, a downstream slot like `[:sum] :<- [:a]`
+;; keeps its stale input reaction and serves the old `:a` body's value.
+
+(defn- transitive-dependent-closure
+  "Given a cache map `m` and a re-registered sub `id`, return the set of
+  cache keys to evict: the re-registered sub's own slots PLUS every slot
+  that depends on it transitively through the `:<-` topology recorded in
+  each entry's `:inputs` (the vector of input query-vectors).
+
+  A slot is a dependent iff any of its `:inputs` query-vectors either
+  (a) has head = `id` — a DIRECT `:<-` on the re-registered sub — or
+  (b) equals a key already in the evict set — a TRANSITIVE dependency on
+  an already-condemned slot. The fixpoint loop grows the set until no new
+  key is added; it only ever ADDS keys not already present, so a cyclic
+  `:<-` graph cannot loop forever (each key is admitted at most once)."
+  [m id]
+  (let [;; Static index: cache-key → the seq of its input query-vectors.
+        inputs-of  (fn [k] (:inputs (get m k)))
+        depends-on (fn [k condemned]
+                     ;; k depends on the re-registration iff one of its
+                     ;; inputs targets `id` directly or a condemned slot.
+                     (boolean
+                       (some (fn [input-q]
+                               (or (= id (first input-q))
+                                   (contains? condemned input-q)))
+                             (inputs-of k))))
+        seed       (into #{} (filter #(= id (first %))) (keys m))]
+    (loop [condemned seed]
+      (let [next-set (into condemned
+                           (filter #(depends-on % condemned))
+                           (keys m))]
+        (if (= next-set condemned)
+          condemned
+          (recur next-set))))))
 
 (defn- invalidate-sub-on-replace!
   [{:keys [kind id]}]
@@ -190,12 +225,13 @@
         ;; The swap-fn body is pure — it returns only the new cache map.
         ;; Reactions to dispose are read from the diff between `old` and
         ;; `new` AFTER the CAS commits (so a retried `swap!` can't fire
-        ;; dispose 2+ times).
+        ;; dispose 2+ times). The condemned set is the transitive `:<-`
+        ;; dependent closure, recomputed inside the swap-fn against the
+        ;; map the CAS actually sees (a retry recomputes against fresh m).
         (let [[old new] (swap-vals! cache
                                     (fn [m]
-                                      (let [hit-keys (->> (keys m)
-                                                          (filter #(= id (first %))))]
-                                        (apply dissoc m hit-keys))))
+                                      (apply dissoc m
+                                             (transitive-dependent-closure m id))))
               ;; The keys actually evicted by THIS swap are those present
               ;; in `old` but absent in `new`. A concurrent evictor that
               ;; won the CAS race would have removed its keys before our

--- a/implementation/core/test/re_frame/hot_reload_test.clj
+++ b/implementation/core/test/re_frame/hot_reload_test.clj
@@ -164,6 +164,79 @@
       (is (= 500 (rf/subscribe-once :right [:answer]))
           "right frame's next subscribe uses v2 (5 * 100)"))))
 
+;; ---- (2b) :sub re-register evicts the transitive :<- dependent closure ----
+;;
+;; Per Cross-Spec-Interactions §18.2 — re-registering a sub invalidates not
+;; just its own cache slot but every DOWNSTREAM cache slot that depended on
+;; it through `:<-`. rf2-kboyu: before the fix, `invalidate-sub-on-replace!`
+;; only evicted keys whose query-vector HEAD equalled the re-registered id;
+;; a cached `[:sum] :<- [:a]` kept its old input reaction and served the OLD
+;; `:a` body's value after `:a` was re-registered.
+
+(deftest sub-re-register-evicts-transitive-dependents
+  (testing "re-registering an upstream sub evicts its DOWNSTREAM :<- dependents
+            so they recompute against the new upstream body"
+    (rf/reg-event-db :seed (fn [_ _] {:n 10}))
+    (rf/dispatch-sync [:seed])
+    ;; v1 of :a is the identity over :n (= 10); :sum is :a + 0 (= 10).
+    (rf/reg-sub :a (fn [db _] (:n db)))
+    (rf/reg-sub :sum :<- [:a] (fn [a _] (+ a 0)))
+    ;; Pin the DOWNSTREAM reaction so ref-counting cannot evict it; this is
+    ;; the slot that, pre-fix, survives the re-registration with a stale
+    ;; input reaction. Subscribing [:sum] also subscribes [:a] (its input).
+    (let [pin-sum (rf/subscribe :rf/default [:sum])
+          cache   (:sub-cache (frame/frame :rf/default))]
+      (is (= 10 @pin-sum) ":sum reads 10 under v1 of :a")
+      (is (contains? @cache [:sum]) "downstream [:sum] is cached")
+      (is (contains? @cache [:a])   "upstream [:a] is cached")
+      ;; Re-register :a so its body now doubles :n (= 20). The body fn is a
+      ;; fresh closure; the OLD reaction for [:a] (and [:sum]'s held input)
+      ;; close over the v1 body.
+      (rf/reg-sub :a (fn [db _] (* 2 (:n db))))
+      ;; Both the re-registered sub's own slot AND the transitive dependent
+      ;; MUST be gone — the closure walk evicted [:a] (head match) and [:sum]
+      ;; (depends on [:a] via :<-).
+      (is (not (contains? @cache [:a]))
+          "[:a] (the re-registered sub) cache slot was evicted")
+      (is (not (contains? @cache [:sum]))
+          "[:sum] (transitive :<- dependent) cache slot was evicted")
+      ;; The next subscribe rebuilds [:sum] (and its [:a] input) against the
+      ;; new :a body: 2 * 10 = 20, NOT the stale 10.
+      (is (= 20 (rf/subscribe-once :rf/default [:sum]))
+          "next subscribe of [:sum] observes the new :a body (2 * 10 = 20)")
+      ;; A held reaction taken AFTER the re-registration also reads the new
+      ;; body — the stale input reaction is no longer reachable from the cache.
+      (let [pin-sum-v2 (rf/subscribe :rf/default [:sum])]
+        (is (= 20 @pin-sum-v2)
+            "a freshly-held [:sum] reaction reads the new :a body (20)")))))
+
+(deftest sub-re-register-transitive-eviction-terminates-on-cyclic-inputs
+  (testing "the transitive closure walk terminates even when the recorded
+            :<- topology contains a cycle — each key is admitted at most once"
+    ;; A pathological dev-time graph: :p :<- [:q] and :q :<- [:p]. The
+    ;; registrar permits the registrations; we synthesise the cyclic cache
+    ;; entries directly so the closure walk is exercised against a cycle
+    ;; without needing the reactive build to succeed.
+    (rf/reg-event-db :seed (fn [_ _] {:n 1}))
+    (rf/dispatch-sync [:seed])
+    (rf/reg-sub :base (fn [db _] (:n db)))
+    (let [cache (:sub-cache (frame/frame :rf/default))]
+      ;; Hand-craft a cycle in the cache's :inputs topology. No live
+      ;; reactions are needed for the closure walk (it reads only :inputs);
+      ;; :reaction nil means the dispose loop skips disposal for these slots.
+      (swap! cache assoc
+             [:p]    {:reaction nil :inputs [[:q] [:base]] :ref-count 1}
+             [:q]    {:reaction nil :inputs [[:p]]         :ref-count 1}
+             [:base] (or (get @cache [:base])
+                         {:reaction nil :inputs [] :ref-count 1}))
+      ;; Re-registering :base must evict :base AND its transitive dependents
+      ;; :p (direct :<- [:base]) and :q (depends on :p) — and TERMINATE despite
+      ;; the :p ↔ :q cycle.
+      (rf/reg-sub :base (fn [db _] (* 100 (:n db))))
+      (is (not (contains? @cache [:base])) "[:base] evicted (re-registered)")
+      (is (not (contains? @cache [:p]))    "[:p] evicted (transitive dependent)")
+      (is (not (contains? @cache [:q]))    "[:q] evicted (cyclic transitive dependent)"))))
+
 ;; ---- (3) :frame re-register preserves snapshot ---------------------------
 
 (deftest frame-re-register-preserves-snapshot


### PR DESCRIPTION
## Summary

Fixes the rf2-kboyu correctness finding: hot-reload invalidation missed transitive `:<-` dependents.

`invalidate-sub-on-replace!` (`implementation/core/src/re_frame/subs/cache.cljc`) previously evicted only cache slots whose query-vector HEAD equalled the re-registered sub id. Cached DOWNSTREAM subs that depended on it via `:<-` stayed cached, kept their old input reaction, and served the old upstream body's value. Repro: `:sum :<- [:a]`; after re-registering `:a`, slot `[:sum]` survived and both `(subscribe-once [:sum])` and the held reaction returned the OLD value (10) instead of the new `:a` body's 20.

This contradicts **Cross-Spec-Interactions §18.2** — "downstream cache slots that depended on the re-registered sub are invalidated through the existing sub-cache invalidation path."

## Fix

New private `transitive-dependent-closure` computes the set of cache keys to evict from each entry's `:inputs` (`:<-` query-vector) topology:

- **Seed:** every slot whose query-vector head = re-registered `id` (the sub's own slots).
- **Expand (fixpoint):** any slot one of whose `:inputs` query-vectors either has head = `id` (direct `:<-`) or equals an already-condemned key (transitive). Loop until no new key is added.
- **Cycle-safe / terminating:** the loop only ever ADDS keys, so each key is admitted at most once — a cyclic `:<-` graph cannot loop forever.

The condemned set is computed inside the `swap-fn` (so a CAS retry recomputes against the fresh map); disposal stays single-fire via the existing `swap-vals!` old/new diff discipline, disposing each evicted reaction exactly once.

## Tests

`implementation/core/test/re_frame/hot_reload_test.clj`:
- `sub-re-register-evicts-transitive-dependents` — pins `[:sum] :<- [:a]`, re-registers `:a` (body now doubles), asserts both `[:a]` and `[:sum]` slots are evicted and the next subscribe / a freshly-held reaction observe the new body (20, not the stale 10).
- `sub-re-register-transitive-eviction-terminates-on-cyclic-inputs` — synthesises a `:p ↔ :q` cycle in the `:inputs` topology and asserts the closure walk evicts the dependents AND terminates.

## Quality gates

| Command | Result |
|---|---|
| `cd implementation/core && clojure -M:test` | `Ran 898 tests containing 4032 assertions. 0 failures, 0 errors.` |
| `cd implementation && npm run test:cljs` | `Ran 5727 tests containing 20076 assertions. 0 failures, 0 errors.` |

Closes rf2-kboyu.