### PR TITLE
fix(ssr-ring): strip Content-Length on streamed body + run CSP allowlist scan in streaming suffix (rf2-h3dg0)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -45,7 +45,8 @@
   in-place and merges the per-subtree `data-rf2-suspense-hydrate` delta as
   chunks arrive, reconciling against the final `__rf_payload`
   (`:replace-app-db`) when it lands."
-  (:require [re-frame.core :as rf]
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.html-helpers :as html]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
@@ -161,7 +162,24 @@
   recovered-to-nil sub case does NOT throw here — its buffered fail-
   closed status is picked up by the handler's post-shell `get-response`
   re-read."
-  [frame-id {:keys [root-view] :as opts}]
+  [frame-id {:keys [root-view body-end csp-script-src-allowlist] :as opts}]
+  ;; rf2-h3dg0 — run the dev-mode `:csp-script-src-allowlist` scan over the
+  ;; raw `:body-end` hook on the REQUEST thread, mirroring what the non-
+  ;; streaming `default-html-shell` does at shell-build time (shell.clj —
+  ;; `check-body-end-csp-hosts!` is the FIRST thing it runs). The streaming
+  ;; suffix (`default-streaming-suffix`) injects `:body-end` RAW just like
+  ;; the non-streaming shell, but it only destructures `:body-end` /
+  ;; `:script-src` and never ran the allowlist scan — so streaming SSR
+  ;; silently lost the defense-in-depth CSP warning that non-streaming SSR
+  ;; emits for the SAME config (Spec 011 §trusted-shell envelope). Running
+  ;; it here (request thread, before the head commits) keeps the warning on
+  ;; the same thread + listener context as the non-streaming path and leaves
+  ;; `default-streaming-suffix` a pure string-builder symmetric with
+  ;; `default-streaming-prefix`. Production builds elide the whole check via
+  ;; `interop/debug-enabled?` inside `check-body-end-csp-hosts!`; the raw
+  ;; emission of `:body-end` into the suffix is UNCHANGED — the scan is a
+  ;; signal, never a block or rewrite.
+  (shell/check-body-end-csp-hosts! body-end csp-script-src-allowlist)
   (rf/with-frame frame-id
     (let [hiccup     (lifecycle/resolve-root-view root-view)
           {:keys [head-html html-attrs body-attrs]}
@@ -316,6 +334,32 @@
       (try (.close out) (catch Throwable _ nil)))))
 
 ;; ---- public surface ------------------------------------------------------
+
+(defn strip-content-length
+  "Remove any `Content-Length` header (case-insensitively) from a Ring
+  response header map. The streaming body is a chunk-producing
+  `PipedInputStream` whose final byte count is unknown when the head
+  commits, so the response MUST use `Transfer-Encoding: chunked`
+  framing (Spec 011 §Streaming SSR — the wire shape pins chunked
+  transfer). A stale fixed `Content-Length` — set/appended by app or
+  server init code (`:rf.server/set-header` / `:rf.server/append-header`
+  during the `:on-create` drain) before streaming was chosen — would
+  otherwise survive onto the streamed response, and a Ring server may
+  honour that length instead of chunking: truncated HTML, clients
+  waiting on the wrong byte count, or lost progressive chunks.
+
+  Ring header NAMES are caller-cased verbatim by the materialiser
+  (`headers/merge-pair-into-header-map` preserves whatever casing the
+  fx supplied), so a `Content-Length` can land under any casing
+  (`Content-Length`, `content-length`, `CONTENT-LENGTH`, …). RFC 7230
+  §3.2 makes header names case-insensitive tokens, so we drop EVERY
+  key whose lower-case is `content-length` — letting the Ring server
+  own transfer framing for the InputStream body."
+  [headers-map]
+  (into {}
+        (remove (fn [[k _v]]
+                  (= "content-length" (str/lower-case (str k)))))
+        headers-map))
 
 (defn stream-handler
   "Return a synchronous Ring handler that streams SSR responses via
@@ -565,8 +609,29 @@
                               ;; No body default-stamp here (we pass our own
                               ;; InputStream); `:body` is assoc'd after the
                               ;; writer is wired below.
-                              resp-map (pipeline/ssr-response->ring-response
-                                         resp2 "" content-type)
+                              ;;
+                              ;; rf2-h3dg0 — STRIP any `Content-Length` header
+                              ;; (case-insensitively) from the materialised
+                              ;; head before wiring the chunk-writer body. App
+                              ;; / server init can `:rf.server/set-header` (or
+                              ;; `append-header`) a `Content-Length` during the
+                              ;; `:on-create` drain — a fixed length that is
+                              ;; meaningless (and actively harmful) once the
+                              ;; body becomes a chunk-producing PipedInputStream
+                              ;; of unknown final size. Left in place, a Ring
+                              ;; server may honour that length instead of using
+                              ;; chunked transfer framing → truncated HTML /
+                              ;; clients blocked on the wrong byte count / lost
+                              ;; chunks, violating Spec 011's chunked-transfer
+                              ;; streaming contract. The non-streaming handler
+                              ;; never hits this — its body is a finished string
+                              ;; whose Content-Length (if any) is correct. The
+                              ;; streaming path owns transfer framing for the
+                              ;; InputStream body, so it MUST drop the stale
+                              ;; length and let the server frame the stream.
+                              resp-map (-> (pipeline/ssr-response->ring-response
+                                             resp2 "" content-type)
+                                           (update :headers strip-content-length))
                               ;; 16 KiB pipe buffer — large enough to absorb the
                               ;; shell chunk in one write so the writer thread
                               ;; rarely blocks on a slow consumer, small enough

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -800,3 +800,165 @@
           ":rf.error/ssr-head-resolution-failed fires once for observability
            on the streaming path too (Spec 011 §1070 Option B) — degraded,
            not silent"))))
+
+;; ===========================================================================
+;; rf2-h3dg0 — stale Content-Length on the streamed body
+;;
+;; `stream-handler` materialises the response head from the accumulator and
+;; then replaces the body with a chunk-producing PipedInputStream. If app /
+;; server init set a `Content-Length` header during the `:on-create` drain
+;; (a fixed byte count for a body that no longer exists), that stale length
+;; must NOT survive onto the streamed response — a Ring server may honour it
+;; instead of chunking, truncating the HTML / blocking the client on the
+;; wrong byte count / losing progressive chunks (Spec 011 §Streaming SSR —
+;; chunked-transfer framing). The fix strips `Content-Length`
+;; case-insensitively before wiring the InputStream body.
+;; ===========================================================================
+
+(defn- header-keys-lower
+  "Lower-cased set of a Ring response's header keys — for
+  case-insensitive header-presence assertions."
+  [response]
+  (into #{} (map (fn [k] (clojure.string/lower-case (str k))))
+        (keys (:headers response))))
+
+(deftest stream-handler-strips-stale-content-length-header
+  (testing "rf2-h3dg0: an :on-create-set Content-Length is stripped
+            (case-insensitively) from the streamed response so the Ring
+            server owns chunked-transfer framing; the body still streams in
+            full with NO Content-Length header surviving"
+    (rf/reg-event-fx :rf.test.server/init-with-content-length
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:db {:articles [{:id "a" :title "Article A"}]
+              :comments [{:body "First!"}]}
+         ;; A deliberately WRONG fixed length set before streaming was
+         ;; chosen — both a canonical-cased and a lower-cased variant, to
+         ;; prove the strip is case-insensitive across the materialiser's
+         ;; verbatim header casing.
+         :fx [[:rf.server/set-header {:name "Content-Length" :value "7"}]
+              [:rf.server/append-header {:name "content-length" :value "13"}]]}))
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init-with-content-length]
+                      :root-view [:test/root]
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          ;; Capture the head BEFORE draining (the head is committed on the
+          ;; request thread; the body pipe is separate).
+          keys-lc  (header-keys-lower response)
+          body     (drain-stream (:body response))]
+      (is (= 200 (:status response)) "streamed response still 200")
+      (is (instance? InputStream (:body response))
+          "the body is the streaming PipedInputStream")
+      (is (not (contains? keys-lc "content-length"))
+          (str "NO Content-Length header survives on the streamed response "
+               "(any casing) — the server frames the InputStream body as "
+               "chunked. Header keys (lower-cased): " (pr-str keys-lc)))
+      ;; The full payload is readable end-to-end — the strip did not break
+      ;; the stream, and no byte-count cap truncated it.
+      (is (str/includes? body "<!DOCTYPE html>") "shell streamed")
+      (is (str/includes? body "Article A")
+          "the resolved body content streamed in full")
+      (is (str/includes? body "__rf_payload")
+          "the final payload chunk streamed")
+      (is (str/includes? body "</body></html>")
+          "the streamed body closed cleanly — full payload readable, not
+           truncated to a stale Content-Length"))))
+
+(deftest stream-handler-preserves-content-type-when-stripping-content-length
+  (testing "rf2-h3dg0: stripping Content-Length leaves the other head
+            machinery intact — Content-Type still rides the streamed
+            response"
+    (rf/reg-event-fx :rf.test.server/init-cl-and-ct
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:db {:articles [] :comments []}
+         :fx [[:rf.server/set-header {:name "Content-Length" :value "999"}]]}))
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init-cl-and-ct]
+                      :root-view [:test/root]
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/" :request-method :get})
+          keys-lc  (header-keys-lower response)
+          _drain   (drain-stream (:body response))]
+      (is (not (contains? keys-lc "content-length"))
+          "Content-Length stripped")
+      (is (contains? keys-lc "content-type")
+          "Content-Type default survives the strip — only Content-Length
+           is removed"))))
+
+;; ===========================================================================
+;; rf2-h3dg0 — streaming suffix runs the CSP allowlist scan (parity with
+;;             the non-streaming default-html-shell)
+;;
+;; The streaming suffix injects `:body-end` RAW, exactly like the
+;; non-streaming shell, but never ran the dev-mode
+;; `:csp-script-src-allowlist` scan. The fix runs
+;; `shell/check-body-end-csp-hosts!` on the request thread (in
+;; `render-streaming-shell!`), so a disallowed absolute script host in
+;; `:body-end` now emits `:rf.ssr/csp-allowlist-violation` under streaming
+;; SSR too — the same defense-in-depth warning non-streaming SSR emits for
+;; the same config (Spec 011 §trusted-shell envelope). The raw `:body-end`
+;; emission is preserved (the scan is a signal, never a block).
+;; ===========================================================================
+
+(deftest stream-handler-csp-allowlist-warns-on-disallowed-body-end-host
+  (testing "rf2-h3dg0: a disallowed absolute <script src> host in :body-end
+            triggers :rf.ssr/csp-allowlist-violation under STREAMING SSR
+            (parity with non-streaming default-html-shell), while the raw
+            :body-end still rides the streamed wire"
+    (let [traces   (atom [])
+          _        (rf/register-listener! ::stream-csp-watch
+                     (fn [ev]
+                       (when (= :rf.ssr/csp-allowlist-violation (:operation ev))
+                         (swap! traces conj ev))))
+          handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init]
+                      :root-view [:test/root]
+                      :body-end  (str "<script src=\"https://evil.example.com/track.js\">"
+                                      "</script>")
+                      :csp-script-src-allowlist #{"cdn.allowed.com"}
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (try
+                     (handler {:uri "/" :request-method :get})
+                     (finally
+                       (rf/unregister-listener! ::stream-csp-watch)))
+          body     (drain-stream (:body response))]
+      (is (= 1 (count @traces))
+          (str "exactly one :rf.ssr/csp-allowlist-violation under streaming "
+               "for the disallowed :body-end host; saw "
+               (count @traces) " — the streaming suffix now runs the same "
+               "allowlist scan as the non-streaming shell (rf2-h3dg0)"))
+      (when (seq @traces)
+        (is (= "evil.example.com" (-> @traces first :tags :host))
+            "the violation names the disallowed origin"))
+      ;; Raw emission preserved — the script tag still reaches the wire; the
+      ;; warning is the signal, NOT a block or rewrite.
+      (is (str/includes? body "https://evil.example.com/track.js")
+          "the raw :body-end <script> still streams onto the wire — the CSP
+           scan is defense-in-depth signalling, not a block (rf2-h3dg0)"))))
+
+(deftest stream-handler-csp-allowlist-no-warning-on-allowed-body-end-host
+  (testing "rf2-h3dg0: an allowlisted :body-end <script src> host emits NO
+            violation under streaming — the opt-in feature stays quiet for
+            compliant configs (parity with non-streaming)"
+    (let [traces   (atom [])
+          _        (rf/register-listener! ::stream-csp-watch-ok
+                     (fn [ev]
+                       (when (= :rf.ssr/csp-allowlist-violation (:operation ev))
+                         (swap! traces conj ev))))
+          handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.server/init]
+                      :root-view [:test/root]
+                      :body-end  "<script src=\"https://cdn.allowed.com/ok.js\"></script>"
+                      :csp-script-src-allowlist #{"cdn.allowed.com"}
+                      :payload :rf.ssr.payload/whole-app-db})
+          response (try
+                     (handler {:uri "/" :request-method :get})
+                     (finally
+                       (rf/unregister-listener! ::stream-csp-watch-ok)))
+          body     (drain-stream (:body response))]
+      (is (zero? (count @traces))
+          "no violation when every :body-end script host is allowlisted")
+      (is (str/includes? body "https://cdn.allowed.com/ok.js")
+          "the allowlisted script still streams onto the wire"))))


### PR DESCRIPTION
Fixes the two correctness-review findings in `implementation/ssr-ring` (rf2-h3dg0).

## Finding 1 — stale `Content-Length` on the streamed body

`stream-handler` materialises the response head from the accumulator (`pipeline/ssr-response->ring-response`) and then replaces the body with a chunk-producing `PipedInputStream`. A `Content-Length` set or appended during the `:on-create` drain (via `:rf.server/set-header` / `:rf.server/append-header`) survived onto that streamed response — a fixed byte count for a body that no longer exists. A Ring server may honour the stale length instead of chunking the stream, causing truncated HTML, clients blocked on the wrong byte count, or lost progressive chunks (violates Spec 011's chunked-transfer streaming contract).

**Fix:** before wiring the InputStream body, strip any `Content-Length` header *case-insensitively* from the materialised head (`strip-content-length` — Ring header names are caller-cased verbatim by the materialiser, so the strip drops every key whose lower-case is `content-length` per RFC 7230 §3.2). The Ring server now owns transfer framing for the InputStream body. The non-streaming handler is unaffected — its body is a finished string whose Content-Length is correct.

## Finding 2 — streaming suffix skipped the CSP allowlist scan

`default-streaming-suffix` injects `:body-end` RAW exactly like the non-streaming `default-html-shell`, but only destructured `:body-end` / `:script-src` — it never ran the dev-mode `:csp-script-src-allowlist` scan that `default-html-shell` runs (`shell/check-body-end-csp-hosts!`). Streaming SSR therefore silently lost the defense-in-depth `:rf.ssr/csp-allowlist-violation` warning that non-streaming SSR emits for the same config (Spec 011 trusted-shell envelope).

**Fix:** run `shell/check-body-end-csp-hosts!` with `:body-end` + `:csp-script-src-allowlist` on the **request thread** inside `render-streaming-shell!` — mirroring where `default-html-shell` runs the same scan, on the same thread + listener context as the non-streaming path. `default-streaming-suffix` stays a pure string-builder symmetric with `default-streaming-prefix`. Production builds elide the whole check via `interop/debug-enabled?`; the raw `:body-end` emission is unchanged (the scan is a signal, never a block or rewrite).

## Lane note

Touches only `implementation/ssr-ring/**`. Finding 2 calls the existing `re-frame.ssr.ring.shell/check-body-end-csp-hosts!` (already an ssr-ring fn, already required in `streaming.clj`) — no change to `implementation/ssr/`, which a sibling worker (wtd8z) is editing concurrently.

## Quality gates

- `cd implementation/ssr-ring && clojure -M:test` → **127 tests, 557 assertions, 0 failures, 0 errors** (was 123/~545 before the 4 new regressions)
- `cd implementation/ssr && clojure -M:test` → **285 tests, 1046 assertions, 0 failures, 0 errors** (consumed artefact — parity confirmed)
- `cd implementation && npm run test:cljs` → **5728 tests, 20106 assertions, 0 failures, 0 errors**

New regressions (in `ring_streaming_test.clj`):
- `stream-handler-strips-stale-content-length-header` — `:on-create` sets `Content-Length` (canonical + lower-cased); streamed response carries NO `Content-Length` (any casing) and the full payload reads end-to-end.
- `stream-handler-preserves-content-type-when-stripping-content-length` — only `Content-Length` is removed; `Content-Type` survives.
- `stream-handler-csp-allowlist-warns-on-disallowed-body-end-host` — captures `:rf.ssr/csp-allowlist-violation` for a disallowed absolute host under streaming, raw `:body-end` still on the wire.
- `stream-handler-csp-allowlist-no-warning-on-allowed-body-end-host` — allowlisted host emits no violation.