### PR TITLE
fix(adapters/reagent-slim): target-aware prop stringify + CSS var + SVG casing + error-boundary state parity (rf2-ygknv)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -647,6 +647,8 @@ Stage 4 ships these tests:
 
 The error-boundary path is React-19-stable; no special-casing needed beyond plumbing `:component-did-catch` to `componentDidCatch`.
 
+**Default-marker state sync (rf2-ygknv finding 4).** The auto-installed default `getDerivedStateFromError` is a *static* method (React's contract) — it receives only the error and returns a state patch React merges into `this.state` (`#js {:cljsHasError true}`). But the advertised public state API (`reagent2.core/state` → derefs the per-instance `.-cljsState` RAtom) reads a *separate* cell, so a boundary render checking `(reagent2.core/state this)` for the marker would never see the React-state patch — the fallback would not render and the boundary could rethrow on every render. The render method bridges this: at render entry (after React has applied the derived-state patch and re-rendered) `sync-error-state!` copies the `cljsHasError` marker from `this.state` into the Reagent state atom additively (leaving user-managed keys intact), guarded so it writes only on the error-state transition and outside the render Reaction (so the write is not captured as a dependency). After the sync, `(reagent2.core/state this)` returns `{:cljsHasError true}` and the user's `:reagent-render` can branch to the fallback.
+
 ### §6.6 `:get-snapshot-before-update` pairing
 
 This is the React-blessed lifecycle that pairs with `:component-did-update`. The contract:
@@ -703,37 +705,43 @@ as-element
 
 The dispatch is small and concrete. Stage 4 references `reagent.impl.template:vec-to-elem` for the canonical shape and re-implements without the compiler-customisation indirection (Stage 1 §2.4 + Stage 2 §2.2).
 
-### §7.2 Narrowed `convert-prop-value`
+### §7.2 Target-aware `convert-prop-value`
 
-Per DECISION-2 + S3-002: stringify named values only for documented HTML-attribute prop names. The static set:
+Per DECISION-2 + S3-002 + rf2-ygknv finding 1: keyword/symbol prop-value stringification is **target-aware**. `convert-props` discriminates on whether the element is a native DOM/string tag (the HiccupTag's `tag` slot is a string) or a custom React component (`:>` interop — the tag slot carries a fn/class):
+
+- **Native DOM/string tags** — every prop on a real DOM element is an HTML attribute whose value is a string, so keyword/symbol values stringify for **any** prop name. `[:button {:type :button}]` reaches React with `props.type === "button"`; `[:a {:target :_blank}]` → `props.target === "_blank"`. This matches both React DOM and the pure server serializer (`dom/server.cljs`), which stringifies every attribute value — closing the SSR/static-vs-client parity gap where the live path used to pass a raw keyword into React DOM.
+
+- **Custom/interop components** — keyword/symbol values stringify only for the documented HTML-attribute prop names (`:class`, `:id`, `:role`, `:data-*`, `:aria-*`); other named values pass through unchanged (with a one-shot dev warning). So `[:> Provider {:value :rf/foo}]` preserves the `:rf/foo` keyword for the React-context Provider.
+
+The static HTML-attribute set (used for the interop/non-native path):
 
 ```clojure
 (def html-attr-names #{:class :id :role})
 ;; Plus prefix-matched: :data-* / :aria-*
 ```
 
-Implementation:
+Implementation (target threaded from `convert-props` as `native?`):
 
 ```clojure
-(defn- html-attr-name? [k]
-  (or (contains? html-attr-names k)
-      (let [n (name k)]
-        (or (str/starts-with? n "data-")
-            (str/starts-with? n "aria-")))))
-
-(defn convert-prop-value [k v]
-  (cond
-    (named? v) (if (html-attr-name? k)
-                 (name v)                ; stringify for HTML attrs
-                 (do                     ; non-HTML: pass through; warn in dev
-                   (when ^boolean js/goog.DEBUG
-                     (warn-once-keyword-prop! k v))
-                   v))
-    (and (map? v) (= :style k)) (clj->js v)
-    :else v))
+(defn convert-prop-value
+  ;; 2-arg: custom/interop semantics (also the public Var's contract).
+  ([k v]
+   (cond
+     (named? v) (if (html-attr-name? k)
+                  (name v)               ; stringify for HTML attrs
+                  (do                     ; non-HTML: pass through; warn in dev
+                    (when ^boolean js/goog.DEBUG
+                      (warn-once-keyword-prop! k v))
+                    v))
+     ...))
+  ;; 3-arg: target-aware. Native DOM tag → stringify every named value.
+  ([k v native?]
+   (if (and native? (named? v) (not (js-val? v)))
+     (name v)
+     (convert-prop-value k v))))
 ```
 
-The dev-mode warn-once cache is a `defonce`-d atom keyed by `[k (name v)]` to avoid spamming. Stage 4 implements the cache + the warning text; the warning includes the prop key, the keyword value, and the migration: "if you intended a string, call (name v) at the call site; if you intended a keyword as a React-context value or a custom prop, the value is now passed through unchanged."
+The dev-mode warn-once cache (interop path only) is a `defonce`-d atom keyed by `[k (name v)]` to avoid spamming. The warning includes the prop key, the keyword value, and the migration: "if you intended a string, call (name v) at the call site; if you intended a keyword as a React-context value or a custom prop, the value is now passed through unchanged."
 
 ### §7.3 Tag parsing — `:div.cls#id` shorthand
 
@@ -839,11 +847,13 @@ Lift the existing implementation from `re-frame.ssr/escape-html` (`ssr.cljc:50-5
 
 The same narrowed `convert-prop-value` rules apply (per S3-005): the static-markup path stringifies keyword values only for HTML-attribute names. (Inside an HTML attribute serialisation, every prop name IS by definition an HTML attribute name — this layer doesn't see React-component props, only DOM-element attrs.)
 
+**Attribute-name casing (`attr-name`) — SVG case-sensitivity (rf2-ygknv finding 3).** `react-dom/server` does NOT blanket-lowercase camelCase attribute names; it consults a fixed attribute-name table. Three observed output shapes for a camelCase hiccup name (the React-camelCase form `cached-prop-name` produces): **preserved** (`viewBox`, `preserveAspectRatio`, `gradientUnits`, `stdDeviation`, `colSpan`, `readOnly`, …), **dasherized** (`clipPath`→`clip-path`, `strokeWidth`→`stroke-width`, `fillOpacity`→`fill-opacity`, `stopColor`→`stop-color`, `httpEquiv`→`http-equiv`, `acceptCharset`→`accept-charset`, …), and **lowercased** (plain HTML camelCase like `tabIndex`→`tabindex`). `reagent2.dom.server` carries `react-attr-name-overrides` — an explicit map pinning the preserved + dasherized shapes to React 19's exact output, extracted from the live `renderToStaticMarkup`. Any camelCase token not in the map falls through to the lowercase rule (correct for the residual HTML attributes). The earlier blanket-lowercase turned case-sensitive SVG names (`:viewBox`→`viewbox`, `:clipPath`→`clippath`, `:strokeWidth`→`strokewidth`) into broken markup. The React-element (client) path was already correct — React itself remaps SVG names at the DOM layer — so only this pure serializer needed the fix; parity is pinned in `parity_cljs_test.cljs` per §8.7.
+
 **Inline-style value serialisation (`emit-style-attr` / `style-string`)** must match `react-dom/server.renderToStaticMarkup`'s `pushStyleAttribute` (rf2-9nyg6):
 
 - A *numeric* value gets a `px` suffix unless the value is `0` or the property is in React's `unitlessNumber` set (`flex`, `flex-grow`, `z-index`, `opacity`, `line-height`, `font-weight`, `order`, the vendor-prefixed entries, …). `{:width 10}` → `width:10px`; `{:flex-grow 1}` → `flex-grow:1`. The `unitless-style-props` set in `reagent2.dom.server` mirrors React 19.2.0's set verbatim — keyed on the *camelCase* property name (the same form the React-element path hands React via `cached-prop-name`), so the hiccup key is camelCased before the lookup, then converted to the kebab CSS name with React's own rule (`([A-Z]) → -$1`, lower-case, `^ms- → -ms-`).
 - An entry whose value is `nil`, a boolean, or `""` is **omitted entirely** (no empty `prop:` declaration).
-- CSS custom properties (`--foo`) are emitted name-and-value verbatim with no `px` logic. (The React-element path's `kv-conv` camelCases all style keys, so it does not itself round-trip `--foo`; the static-markup path handles them directly.)
+- CSS custom properties (`--foo`) are emitted name-and-value verbatim with no `px` logic. The React-element path agrees: `dash-to-prop-name` short-circuits `--`-prefixed names so a style key like `:--gap` is preserved (not camelCased to `Gap`), matching React's style handling and this serializer (rf2-ygknv finding 2 — previously the live path camelCased `--gap` → `Gap`, silently dropping the variable and breaking SSR/client parity).
 
 These rules are pinned by `parity_cljs_test.cljs` against `react-dom/server` (numeric→px, unitless→bare, zero→bare, nil→omitted, string→untouched) per §8.7.
 

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -127,24 +127,215 @@
 ;;   :className       → "class"
 ;;   :for             → "for"
 ;;   :htmlFor         → "for"
-;;   :tab-index       → "tabIndex"  (kebab→camel for React-style names)
+;;   :tab-index       → "tabindex" (kebab→camel via cached-prop-name,
+;;                                  then React lowercases for HTML5)
 ;;   :data-foo        → "data-foo"  (data-* untouched)
 ;;   :aria-label      → "aria-label" (aria-* untouched)
 ;;
-;; React-shape camelCased names (`tabIndex`, `colSpan`) reach the HTML
-;; output already in their React form. `react-dom/server` lowercases
-;; some (`tabindex`, `colspan`) but preserves SVG attrs (`viewBox`,
-;; `clipPath`). For parity simplicity the rewrite emits the React name
-;; as-is for camelCase tokens — the parity test allow-lists this in
-;; the known-difference set per §8.7.
+;; CASE-SENSITIVE SVG ATTRIBUTES (rf2-ygknv finding 3). The previous
+;; rule blanket-lowercased every camelCase token, turning case-SENSITIVE
+;; SVG attribute names into broken markup:
+;;
+;;   :viewBox     → "viewbox"     (WRONG — must stay "viewBox")
+;;   :clipPath    → "clippath"    (WRONG — React emits "clip-path")
+;;   :strokeWidth → "strokewidth" (WRONG — React emits "stroke-width")
+;;
+;; `react-dom/server.renderToStaticMarkup` does NOT lowercase blindly —
+;; it consults a fixed attribute-name table. Three observed shapes for a
+;; camelCase hiccup name (the React-camelCase form `cached-prop-name`
+;; produces):
+;;
+;;   1. PRESERVED camelCase — `viewBox`, `preserveAspectRatio`,
+;;      `gradientUnits`, `stdDeviation`, `colSpan`, `readOnly`, …
+;;   2. DASHERIZED — `clipPath`→`clip-path`, `strokeWidth`→`stroke-width`,
+;;      `fillOpacity`→`fill-opacity`, `stopColor`→`stop-color`,
+;;      `httpEquiv`→`http-equiv`, `acceptCharset`→`accept-charset`, …
+;;   3. LOWERCASED — plain HTML camelCase like `tabIndex`→`tabindex`.
+;;
+;; `react-attr-name-overrides` below pins shapes 1 + 2 exactly to
+;; React 19's emitted output (extracted from `renderToStaticMarkup` —
+;; see `parity_cljs_test.cljs` for the round-trip pin). Any camelCase
+;; token NOT in the map falls through to the lowercase rule (shape 3),
+;; which is correct for the residual HTML attributes. This restores
+;; SVG parity with the React-element path (React itself remaps SVG
+;; names at the DOM layer, so the live path was already correct; only
+;; this pure serializer diverged).
 ;; ---------------------------------------------------------------------------
+
+(def ^:private react-attr-name-overrides
+  "React's canonical HTML/SVG output name for each camelCase hiccup
+  attribute whose serialized form is NOT a plain `lower-case` of the
+  name. Keyed on the React-camelCase token `cached-prop-name` produces;
+  value is the exact string `react-dom/server.renderToStaticMarkup`
+  emits (React 19). Covers the case-sensitive SVG attributes (`viewBox`,
+  `preserveAspectRatio`, …), the dasherized SVG presentation attributes
+  (`clipPath`→`clip-path`, `strokeWidth`→`stroke-width`, …), and the
+  hyphenated HTML specials (`httpEquiv`→`http-equiv`). Pinned against
+  the live React reference in `parity_cljs_test.cljs` per §8.7."
+  {"accentHeight" "accent-height"
+   "acceptCharset" "accept-charset"
+   "accessKey" "accessKey"
+   "alignmentBaseline" "alignment-baseline"
+   "allowReorder" "allowReorder"
+   "arabicForm" "arabic-form"
+   "attributeName" "attributeName"
+   "attributeType" "attributeType"
+   "autoComplete" "autoComplete"
+   "autoPlay" "autoPlay"
+   "autoReverse" "autoReverse"
+   "baseFrequency" "baseFrequency"
+   "baseProfile" "baseProfile"
+   "baselineShift" "baseline-shift"
+   "calcMode" "calcMode"
+   "capHeight" "cap-height"
+   "cellPadding" "cellPadding"
+   "cellSpacing" "cellSpacing"
+   "clipPath" "clip-path"
+   "clipPathUnits" "clipPathUnits"
+   "clipRule" "clip-rule"
+   "colSpan" "colSpan"
+   "colorInterpolation" "color-interpolation"
+   "colorInterpolationFilters" "color-interpolation-filters"
+   "colorProfile" "color-profile"
+   "colorRendering" "color-rendering"
+   "contentEditable" "contentEditable"
+   "contentScriptType" "contentScriptType"
+   "contentStyleType" "contentStyleType"
+   "dateTime" "dateTime"
+   "diffuseConstant" "diffuseConstant"
+   "dominantBaseline" "dominant-baseline"
+   "edgeMode" "edgeMode"
+   "enableBackground" "enable-background"
+   "encType" "encType"
+   "externalResourcesRequired" "externalResourcesRequired"
+   "fillOpacity" "fill-opacity"
+   "fillRule" "fill-rule"
+   "filterRes" "filterRes"
+   "filterUnits" "filterUnits"
+   "floodColor" "flood-color"
+   "floodOpacity" "flood-opacity"
+   "fontFamily" "font-family"
+   "fontSize" "font-size"
+   "fontSizeAdjust" "font-size-adjust"
+   "fontStretch" "font-stretch"
+   "fontStyle" "font-style"
+   "fontVariant" "font-variant"
+   "fontWeight" "font-weight"
+   "formAction" "formAction"
+   "formMethod" "formMethod"
+   "glyphName" "glyph-name"
+   "glyphOrientationHorizontal" "glyph-orientation-horizontal"
+   "glyphOrientationVertical" "glyph-orientation-vertical"
+   "glyphRef" "glyphRef"
+   "gradientTransform" "gradientTransform"
+   "gradientUnits" "gradientUnits"
+   "horizAdvX" "horiz-adv-x"
+   "horizOriginX" "horiz-origin-x"
+   "httpEquiv" "http-equiv"
+   "imageRendering" "image-rendering"
+   "kernelMatrix" "kernelMatrix"
+   "kernelUnitLength" "kernelUnitLength"
+   "keyPoints" "keyPoints"
+   "keySplines" "keySplines"
+   "keyTimes" "keyTimes"
+   "lengthAdjust" "lengthAdjust"
+   "letterSpacing" "letter-spacing"
+   "lightingColor" "lighting-color"
+   "limitingConeAngle" "limitingConeAngle"
+   "markerEnd" "marker-end"
+   "markerHeight" "markerHeight"
+   "markerMid" "marker-mid"
+   "markerStart" "marker-start"
+   "markerUnits" "markerUnits"
+   "markerWidth" "markerWidth"
+   "maskContentUnits" "maskContentUnits"
+   "maskUnits" "maskUnits"
+   "maxLength" "maxLength"
+   "minLength" "minLength"
+   "noValidate" "noValidate"
+   "numOctaves" "numOctaves"
+   "overlinePosition" "overline-position"
+   "overlineThickness" "overline-thickness"
+   "paintOrder" "paint-order"
+   "pathLength" "pathLength"
+   "patternContentUnits" "patternContentUnits"
+   "patternTransform" "patternTransform"
+   "patternUnits" "patternUnits"
+   "pointerEvents" "pointer-events"
+   "pointsAtX" "pointsAtX"
+   "pointsAtY" "pointsAtY"
+   "pointsAtZ" "pointsAtZ"
+   "preserveAlpha" "preserveAlpha"
+   "preserveAspectRatio" "preserveAspectRatio"
+   "primitiveUnits" "primitiveUnits"
+   "readOnly" "readOnly"
+   "refX" "refX"
+   "refY" "refY"
+   "renderingIntent" "rendering-intent"
+   "repeatCount" "repeatCount"
+   "repeatDur" "repeatDur"
+   "requiredExtensions" "requiredExtensions"
+   "requiredFeatures" "requiredFeatures"
+   "shapeRendering" "shape-rendering"
+   "specularConstant" "specularConstant"
+   "specularExponent" "specularExponent"
+   "spellCheck" "spellCheck"
+   "spreadMethod" "spreadMethod"
+   "srcSet" "srcSet"
+   "startOffset" "startOffset"
+   "stdDeviation" "stdDeviation"
+   "stitchTiles" "stitchTiles"
+   "stopColor" "stop-color"
+   "stopOpacity" "stop-opacity"
+   "strikethroughPosition" "strikethrough-position"
+   "strikethroughThickness" "strikethrough-thickness"
+   "strokeDasharray" "stroke-dasharray"
+   "strokeDashoffset" "stroke-dashoffset"
+   "strokeLinecap" "stroke-linecap"
+   "strokeLinejoin" "stroke-linejoin"
+   "strokeMiterlimit" "stroke-miterlimit"
+   "strokeOpacity" "stroke-opacity"
+   "strokeWidth" "stroke-width"
+   "surfaceScale" "surfaceScale"
+   "systemLanguage" "systemLanguage"
+   "tableValues" "tableValues"
+   "targetX" "targetX"
+   "targetY" "targetY"
+   "textAnchor" "text-anchor"
+   "textDecoration" "text-decoration"
+   "textLength" "textLength"
+   "textRendering" "text-rendering"
+   "underlinePosition" "underline-position"
+   "underlineThickness" "underline-thickness"
+   "unicodeBidi" "unicode-bidi"
+   "unicodeRange" "unicode-range"
+   "unitsPerEm" "units-per-em"
+   "useMap" "useMap"
+   "vAlphabetic" "v-alphabetic"
+   "vHanging" "v-hanging"
+   "vIdeographic" "v-ideographic"
+   "vMathematical" "v-mathematical"
+   "vectorEffect" "vector-effect"
+   "vertAdvY" "vert-adv-y"
+   "vertOriginX" "vert-origin-x"
+   "vertOriginY" "vert-origin-y"
+   "viewBox" "viewBox"
+   "viewTarget" "viewTarget"
+   "wordSpacing" "word-spacing"
+   "writingMode" "writing-mode"
+   "xChannelSelector" "xChannelSelector"
+   "xHeight" "x-height"
+   "yChannelSelector" "yChannelSelector"
+   "zoomAndPan" "zoomAndPan"})
 
 (defn- attr-name
   "Hiccup keyword/string → HTML attribute name string. Honours React
-  aliases (`:class` → \"class\", `:for` → \"for\"). Lowercases
-  camelCased tokens for HTML5 conformance (`tabIndex` → `tabindex`,
-  `colSpan` → `colspan`); preserves kebab-case `data-*` / `aria-*`
-  verbatim."
+  aliases (`:class` → \"class\", `:for` → \"for\"). For camelCase
+  tokens, consults `react-attr-name-overrides` to emit React 19's exact
+  output (`viewBox` preserved, `clipPath`→`clip-path`, …); any camelCase
+  token not in the table lowercases for HTML5 conformance
+  (`tabIndex` → `tabindex`). Kebab-case `data-*` / `aria-*` pass through
+  verbatim. Per rf2-ygknv finding 3."
   [k]
   (let [n (cond
             (keyword? k) (template/cached-prop-name k)
@@ -155,12 +346,13 @@
       "htmlFor"   "for"
       ;; data-*/aria-* stay verbatim — cached-prop-name doesn't
       ;; camelCase them. Other non-camel tokens stay verbatim too.
-      (if (or (str/starts-with? n "data-")
-              (str/starts-with? n "aria-")
-              ;; All-lowercase already.
-              (= n (str/lower-case n)))
-        n
-        (str/lower-case n)))))
+      (or (get react-attr-name-overrides n)
+          (if (or (str/starts-with? n "data-")
+                  (str/starts-with? n "aria-")
+                  ;; All-lowercase already.
+                  (= n (str/lower-case n)))
+            n
+            (str/lower-case n))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Attribute value serialisation
@@ -379,17 +571,26 @@
       (.append sb "\""))
 
     (true? v)
-    (let [n (attr-name k)]
-      (when (contains? boolean-attrs n)
+    (let [n      (attr-name k)
+          ;; HTML5 boolean attributes are lowercase (`readonly`,
+          ;; `disabled`, …); `attr-name` may preserve React's casing
+          ;; (`readOnly`), so the boolean-attr membership test + the
+          ;; emitted short-form use the lowercased name (rf2-ygknv
+          ;; finding 3 follow-on: the case-preserving override must not
+          ;; defeat the lowercase boolean-attr set).
+          bool-n (str/lower-case n)]
+      (when (contains? boolean-attrs bool-n)
         (.append sb " ")
-        (.append sb n)))
+        (.append sb bool-n)))
 
     :else
-    (let [n (attr-name k)]
-      (if (contains? boolean-attrs n)
-        ;; Boolean attribute with non-true truthy value: emit the name.
+    (let [n      (attr-name k)
+          bool-n (str/lower-case n)]
+      (if (contains? boolean-attrs bool-n)
+        ;; Boolean attribute with non-true truthy value: emit the
+        ;; (lowercase HTML5) name.
         (do (.append sb " ")
-            (.append sb n))
+            (.append sb bool-n))
         (do (.append sb " ")
             (.append sb n)
             (.append sb "=\"")

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -416,7 +416,11 @@
     ;; getDerivedStateFromError: React-19 requires it (paired with
     ;; componentDidCatch) for the boundary to catch at all. Default
     ;; flips a :cljsHasError marker user :reagent-render can check.
-    ;; Per IMPL-SPEC §6.5.
+    ;; Per IMPL-SPEC §6.5. This is a STATIC method (no `this`), so it
+    ;; can only patch React's own this.state; `sync-error-state!`
+    ;; (called at render entry) bridges the marker into the public
+    ;; Reagent state atom so `(reagent2.core/state this)` sees it too
+    ;; (rf2-ygknv finding 4 — the React-state/Reagent-atom desync).
     (when (:component-did-catch spec)
       (set! (.-getDerivedStateFromError klass)
             (fn [_error]
@@ -435,6 +439,32 @@
 ;; method delegates to wrap-render and runs inside a per-component
 ;; Reaction (reactive-subscription wiring, IMPL-SPEC §4.4 path 1).
 ;; ---------------------------------------------------------------------------
+
+(defn- sync-error-state!
+  "Bridge React's error-boundary state into the public Reagent state
+  atom (rf2-ygknv finding 4).
+
+  The default `getDerivedStateFromError` (installed by
+  `install-lifecycle!`) is a STATIC method — it cannot reach the
+  instance, so it can only patch React's own `this.state` with
+  `#js {:cljsHasError true}`. But the advertised public state API
+  (`reagent2.core/state` → derefs `.-cljsState`) reads a SEPARATE
+  RAtom, so a boundary render checking `(r/state this)` for the marker
+  would never see the patch and the fallback would not render.
+
+  This runs at render entry — AFTER React has applied the derived-state
+  patch and re-rendered — and copies the `cljsHasError` marker from
+  `this.state` into the Reagent state atom (additively, leaving any
+  user-managed keys intact). Guarded so it writes the atom only on the
+  error-state transition: the write happens OUTSIDE the render Reaction
+  (before the capture below), so it neither registers as a render
+  dependency nor churns on subsequent renders once the marker is set."
+  [^js this]
+  (let [react-state (.-state this)]
+    (when (and react-state (true? (.-cljsHasError react-state)))
+      (let [a (state-atom this)]
+        (when-not (:cljsHasError @a)
+          (swap! a assoc :cljsHasError true))))))
 
 (defn- make-render-method
   "Build the React `render` method. Runs the user's render fn inside a
@@ -455,6 +485,10 @@
       ;; getDerivedStateFromProps cannot side-effect on the instance,
       ;; so the copy happens here.
       (copy-argv-from-props! this (.-props this))
+      ;; Bridge the error-boundary marker from React's this.state into
+      ;; the public Reagent state atom (rf2-ygknv finding 4). Outside
+      ;; the render Reaction so it is not captured as a dependency.
+      (sync-error-state! this)
       (binding [*current-component* this]
         (batching/mark-rendered this)
         (let [^js cached-rea (.-cljsRenderRea this)

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -175,11 +175,20 @@
 (defn- dash-to-prop-name [dashed]
   (if (string? dashed)
     dashed
-    (let [name-str (name dashed)
-          [start & parts] (str/split name-str #"-")]
-      (if (dont-camel-case start)
+    (let [name-str (name dashed)]
+      ;; CSS custom properties (`--gap`) are case-sensitive and must NOT
+      ;; be camelCased — `--gap` split on `-` would yield `"Gap"`,
+      ;; silently dropping the variable. React's style handling preserves
+      ;; `--`-prefixed names verbatim; the pure server serializer already
+      ;; does too, so preserving here closes the live-vs-server style
+      ;; parity gap (rf2-ygknv finding 2). Guarded on the `--` prefix so
+      ;; only custom properties are exempted from kebab→camel.
+      (if (str/starts-with? name-str "--")
         name-str
-        (apply str start (map capitalize parts))))))
+        (let [[start & parts] (str/split name-str #"-")]
+          (if (dont-camel-case start)
+            name-str
+            (apply str start (map capitalize parts))))))))
 
 (def ^:private prop-name-cache
   (doto #js {}
@@ -288,6 +297,14 @@
 (defn- kv-conv
   "Reduce-kv step: convert one [k v] pair into the JS props object `o`.
 
+  Used for NESTED maps (style objects, custom-component prop sub-maps)
+  reached via `convert-prop-value`'s `map?` branch — there is no
+  native-DOM-tag context at this depth, so per-key conversion uses the
+  2-arg `convert-prop-value` (interop) rule. The TOP-LEVEL prop map is
+  converted by `convert-props` with the native-aware `top-prop-conv`
+  step instead, which is the seam that makes native-DOM keyword
+  attributes stringify (per rf2-ygknv finding 1).
+
   Per rf2-dwds9 MEDIUM: reserved JS keys (`__proto__`, `prototype`,
   `constructor`) are dropped silently. `aset o \"__proto__\" v` would
   invoke the prototype-setter on the props object — replacing its
@@ -302,14 +319,50 @@
         (aset o k' v')
         o))))
 
+(defn- top-prop-conv
+  "Reduce-kv step for the TOP-LEVEL prop map of a hiccup element. `o`
+  is the JS props object; `[k v]` the prop pair; `native?` whether the
+  element is a native DOM/string tag (vs a `:>` interop / custom React
+  component).
+
+  For native DOM tags, keyword/symbol values stringify for ANY prop
+  name — every prop on a real DOM element is an HTML attribute that
+  takes a string value, and the pure server serializer already
+  stringifies them unconditionally; so `[:button {:type :button}]`
+  must reach React with `props.type === \"button\"` (rf2-ygknv finding
+  1). For custom/interop components, the narrowed (interop) rule
+  applies via the 2-arg `convert-prop-value` — a keyword like
+  `:rf/foo` on a React-context Provider's `:value` is preserved.
+
+  Reserved-key dropping (rf2-dwds9 MEDIUM) is unchanged."
+  [native? o k v]
+  (let [k' (cached-prop-name k)]
+    (if (and (string? k') (reserved-prop-key? k'))
+      o
+      (let [v' (convert-prop-value k v native?)]
+        (aset o k' v')
+        o))))
+
 (defn convert-prop-value
   "Convert a hiccup prop-map value `v` for prop-name `k` to a React-
   shaped JS value.
 
-  Per IMPL-SPEC §7.2 (DECISION-2): narrowed keyword stringification.
-  Keywords stringify only for HTML-attribute prop names
-  (`:class`, `:id`, `:role`, `:data-*`, `:aria-*`).
-  Other named values pass through unchanged.
+  Per IMPL-SPEC §7.2 (DECISION-2) + rf2-ygknv finding 1: keyword/symbol
+  stringification is TARGET-AWARE.
+
+    - NATIVE DOM/string tags (the 3-arg form with `native?` true):
+      keyword/symbol values stringify for ANY prop name — every prop on
+      a real DOM element is an HTML attribute taking a string value, and
+      the pure server serializer stringifies them unconditionally, so
+      the live React path must agree (`[:button {:type :button}]` →
+      `props.type \"button\"`).
+
+    - CUSTOM/INTEROP components (the 2-arg form, or `native?` false):
+      keyword/symbol values stringify only for documented HTML-attribute
+      prop names (`:class`, `:id`, `:role`, `:data-*`, `:aria-*`); other
+      named values pass through unchanged (with a one-shot dev warning),
+      so a keyword like `:rf/foo` on a React-context Provider's `:value`
+      is preserved.
 
   Other rules:
 
@@ -345,6 +398,8 @@
      (ifn? v)     (fn [& args] (apply v args))
      :else        v))
   ([k v]
+   ;; 2-arg form: CUSTOM/INTEROP semantics (the `:>` path + the public
+   ;; Var's documented contract). Narrowed stringification per §7.2.
    (cond
      (js-val? v)  v
      (named? v)  (if (html-attr-name? k)
@@ -357,7 +412,15 @@
      (coll? v)    (clj->js v)
      (fn? v)      v                ; pass through — preserves identity
      (ifn? v)     (fn [& args] (apply v args))
-     :else        v)))
+     :else        v))
+  ([k v native?]
+   ;; 3-arg form: TARGET-AWARE. For a native DOM tag every prop is an
+   ;; HTML attribute, so keyword/symbol values stringify regardless of
+   ;; the prop name — matching the pure server serializer and React DOM.
+   ;; For non-native targets we defer to the 2-arg interop semantics.
+   (if (and native? (named? v) (not (js-val? v)))
+     (name v)
+     (convert-prop-value k v))))
 
 ;; ---------------------------------------------------------------------------
 ;; set-id-class — merge :div.foo#bar parts into the prop map
@@ -442,15 +505,27 @@
   "Convert a hiccup prop map `props` to a React-shape JS props object.
   `parsed` is the HiccupTag with id/class shorthand merged in.
 
+  Target-awareness (rf2-ygknv finding 1): when `parsed`'s tag is a
+  string the element is a NATIVE DOM tag — keyword/symbol prop values
+  stringify for every attribute (HTML attributes are string-valued,
+  matching the pure server serializer + React DOM). When the tag is a
+  fn/class (`:>` interop / custom component) keyword values follow the
+  narrowed interop rule and pass through unchanged. The discriminator
+  is `(string? (.-tag parsed))`: `cached-parse` yields a string tag for
+  DOM elements, while `interop-element`'s synthetic HiccupTag carries
+  the component (fn/class) in the tag slot.
+
   Returns nil for empty input."
   [props ^HiccupTag parsed]
-  (let [collapsed   (collapse-class-keys props)
+  (let [native?     (string? (.-tag parsed))
+        collapsed   (collapse-class-keys props)
         class       (:class collapsed)
         normalised  (cond-> collapsed
                       class (assoc :class (class-names class)))
         with-shorthand (set-id-class normalised parsed)
         ^js js-props (when (seq with-shorthand)
-                       (reduce-kv kv-conv #js {} with-shorthand))]
+                       (reduce-kv (fn [o k v] (top-prop-conv native? o k v))
+                                  #js {} with-shorthand))]
     js-props))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
@@ -153,6 +153,15 @@
     (let [[a b] (=parity [:div {:class "c" :id "i" :title "t"}])]
       (is (= a b)))))
 
+(deftest parity-native-keyword-attr-values
+  (testing "rf2-ygknv finding 1: keyword DOM-attr values stringify on the
+            LIVE React path the same way the server serializer does —
+            [:button {:type :button}] / [:a {:target :_blank}]"
+    (let [[a b] (=parity [:button {:type :button}])]
+      (is (= a b)))
+    (let [[a b] (=parity [:a {:target :_blank :rel :noopener}])]
+      (is (= a b)))))
+
 ;; ---------------------------------------------------------------------------
 ;; Boolean attributes
 ;; ---------------------------------------------------------------------------
@@ -304,10 +313,79 @@
 
 (deftest style-custom-property-verbatim
   (testing "CSS custom property (--foo) passes through verbatim, no px"
-    ;; Direct (non-parity) assertion: the React-element path's `kv-conv`
-    ;; camelCases every style key (incl. `--foo` → `Foo`), so it can't
-    ;; serve as a custom-property reference. The rewrite's standalone
-    ;; behaviour (verbatim name, no px) matches React's `pushStyleAttribute`
-    ;; custom-property branch.
+    ;; rf2-ygknv finding 2: the React-element path now preserves `--foo`
+    ;; style keys verbatim (dash-to-prop-name short-circuits `--` names),
+    ;; so the live path and the pure serializer AGREE — a real parity
+    ;; assertion replaces the old documents-the-bug comment.
+    (let [[a b] (=parity [:div {:style {:--gap "8px"}}])]
+      (is (= a b) "live React path and pure serializer agree on --gap"))
     (is (= "<div style=\"--gap:8\"></div>"
            (via-rewrite [:div {:style {:--gap 8}}])))))
+
+;; ---------------------------------------------------------------------------
+;; SVG attribute-name casing parity (rf2-ygknv finding 3)
+;;
+;; `react-dom/server` is case-sensitive about SVG attribute names: it
+;; preserves `viewBox`/`preserveAspectRatio`/`gradientUnits`/`stdDeviation`,
+;; dasherizes `clipPath`→`clip-path` / `strokeWidth`→`stroke-width` /
+;; `fillOpacity`→`fill-opacity` / `stopColor`→`stop-color`, and lowercases
+;; plain HTML camelCase (`tabIndex`→`tabindex`). The pure serializer used
+;; to blanket-lowercase, turning `viewBox` into the broken `viewbox`. The
+;; =parity assertions pin the serializer against the live React reference;
+;; the explicit-string assertions document the target independently.
+;; ---------------------------------------------------------------------------
+
+(deftest parity-svg-viewbox
+  (testing ":viewBox preserved (case-sensitive SVG attribute)"
+    (let [[a b] (=parity [:svg {:viewBox "0 0 10 10"}])]
+      (is (= a b)))
+    (is (= "<svg viewBox=\"0 0 10 10\"></svg>"
+           (via-rewrite [:svg {:viewBox "0 0 10 10"}])))))
+
+(deftest parity-svg-preserve-aspect-ratio
+  (testing ":preserveAspectRatio preserved verbatim"
+    (let [[a b] (=parity [:svg {:preserveAspectRatio "xMidYMid"}])]
+      (is (= a b)))
+    (is (= "<svg preserveAspectRatio=\"xMidYMid\"></svg>"
+           (via-rewrite [:svg {:preserveAspectRatio "xMidYMid"}])))))
+
+(deftest parity-svg-clip-path-dasherized
+  (testing ":clipPath dasherizes to clip-path (React's output)"
+    (let [[a b] (=parity [:rect {:clipPath "url(#c)"}])]
+      (is (= a b)))
+    (is (= "<rect clip-path=\"url(#c)\"></rect>"
+           (via-rewrite [:rect {:clipPath "url(#c)"}])))))
+
+(deftest parity-svg-stroke-width-dasherized
+  (testing ":strokeWidth dasherizes to stroke-width"
+    (let [[a b] (=parity [:path {:strokeWidth 2 :d "M0 0"}])]
+      (is (= a b)))
+    (is (= "<path stroke-width=\"2\" d=\"M0 0\"></path>"
+           (via-rewrite [:path {:strokeWidth 2 :d "M0 0"}])))))
+
+(deftest parity-svg-tree-with-children
+  (testing "realistic SVG tree: viewBox root + clipPath/strokeWidth children"
+    (let [[a b] (=parity
+                 [:svg {:viewBox "0 0 100 100"
+                        :preserveAspectRatio "xMidYMid meet"}
+                  [:defs [:clipPath {:id "clip"}
+                          [:circle {:cx 50 :cy 50 :r 40}]]]
+                  [:path {:d "M10 10 L90 90"
+                          :strokeWidth 3
+                          :stroke "black"
+                          :clipPath "url(#clip)"}]])]
+      (is (= a b)))))
+
+(deftest parity-svg-fill-stop-color-dasherized
+  (testing ":fillOpacity / :stopColor dasherize like React"
+    (let [[a b] (=parity [:circle {:fillOpacity 0.5}])]
+      (is (= a b)))
+    (let [[a b] (=parity [:stop {:stopColor "red"}])]
+      (is (= a b)))))
+
+(deftest parity-html-tab-index-lowercased
+  (testing ":tab-index still lowercases to tabindex (HTML camelCase)"
+    (let [[a b] (=parity [:div {:tab-index 3}])]
+      (is (= a b)))
+    (is (= "<div tabindex=\"3\"></div>"
+           (via-rewrite [:div {:tab-index 3}])))))

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs
@@ -113,12 +113,17 @@
     (is (= "<div aria-label=\"close\"></div>"
            (server/render-to-static-markup [:div {:aria-label "close"}])))))
 
-(deftest attr-camelcase-lowercased
-  (testing "camelCased prop names lowercase to HTML conventional form"
-    ;; tabIndex → tabindex; colSpan → colspan
+(deftest attr-camelcase-react-canonical-name
+  (testing "camelCased prop names emit React 19's canonical output name"
+    ;; rf2-ygknv finding 3: `attr-name` is no longer a blanket lowercase.
+    ;; React's attribute-name table governs the output:
+    ;;   :tab-index → "tabindex"  (plain HTML camelCase → lowercased)
+    ;;   :col-span  → "colSpan"   (React PRESERVES this camelCase token)
+    ;; The previous "<td colspan>" assertion pinned a divergence from
+    ;; react-dom/server; the corrected expectation matches React exactly.
     (is (= "<div tabindex=\"0\"></div>"
            (server/render-to-static-markup [:div {:tab-index "0"}])))
-    (is (= "<td colspan=\"2\"></td>"
+    (is (= "<td colSpan=\"2\"></td>"
            (server/render-to-static-markup [:td {:col-span "2"}])))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
@@ -477,6 +477,63 @@
       (is (= "commit" (:phase @caught)))
       (is (= err (:error @caught))))))
 
+(deftest error-boundary-derived-state-syncs-into-reagent-atom-rf2-ygknv
+  (testing "rf2-ygknv finding 4: the default getDerivedStateFromError
+            marker (React this.state.cljsHasError) is bridged into the
+            public Reagent state atom at render entry, so a boundary
+            render reading (state-atom this) sees the marker and can
+            show its fallback."
+    (let [render-calls (atom [])
+          ^js klass (component/create-class*
+                      {:reagent-render
+                       (fn [_]
+                         ;; The boundary branches on the PUBLIC state API
+                         ;; (the same cell reagent2.core/state derefs).
+                         ;; A Form-1 render fn reads `this` via
+                         ;; current-component (it does NOT receive it as
+                         ;; an arg) — mirrors the production contract.
+                         (let [this (component/current-component)
+                               s    @(component/state-atom this)]
+                           (swap! render-calls conj s)
+                           (if (:cljsHasError s)
+                             [:div.fallback "Something went wrong"]
+                             [:div.ok "child"])))
+                       :component-did-catch (fn [_ _ _])})
+          inst  (new klass #js {:__rfArgv [(fn [_] nil)]})]
+      (set! (.-forceUpdate inst) (fn [] nil))
+      ;; Initial render — no error yet; state atom empty → ok branch.
+      (let [^js el (.call (.. klass -prototype -render) inst)]
+        (is (= "div" (.-type el)))
+        (is (= "ok" (.-className (.-props el)))
+            "before any error, the boundary renders its normal child"))
+      ;; React applies the derived-state patch after a child throws:
+      ;; getDerivedStateFromError returns #js {:cljsHasError true}, which
+      ;; React merges into this.state. Replicate that here.
+      (let [patch (.call (.-getDerivedStateFromError klass) nil (js/Error. "boom"))]
+        (set! (.-state inst)
+              (js/Object.assign #js {} (.-state inst) patch)))
+      ;; React re-renders the boundary. The render-entry sync must now
+      ;; surface the marker through the public state atom.
+      (let [^js el (.call (.. klass -prototype -render) inst)]
+        (is (true? (:cljsHasError @(component/state-atom inst)))
+            "marker bridged into the Reagent state atom")
+        (is (= "fallback" (.-className (.-props el)))
+            "boundary render reading (state-atom this) shows the fallback UI"))
+      (.call (.. klass -prototype -componentWillUnmount) inst))))
+
+(deftest error-boundary-no-spurious-marker-without-error-rf2-ygknv
+  (testing "rf2-ygknv finding 4: a boundary that never caught an error
+            keeps an empty public state atom (the sync writes only on
+            the error-state transition)"
+    (let [^js klass (component/create-class*
+                      {:reagent-render      (fn [_] [:div])
+                       :component-did-catch (fn [_ _ _])})
+          inst  (new klass #js {:__rfArgv [(fn [_] nil)]})]
+      (set! (.-forceUpdate inst) (fn [] nil))
+      (.call (.. klass -prototype -render) inst)
+      (is (nil? @(component/state-atom inst))
+          "no error → state atom untouched (no spurious :cljsHasError)"))))
+
 (deftest error-boundary-rethrow-bubbles-via-cDC
   (testing "a :component-did-catch fn that throws cascades — the rethrow is the user's choice"
     ;; Per IMPL-SPEC §6.5: re-throwing from cDC bubbles to the next

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -157,6 +157,23 @@
     (is (= :primary
            (template/convert-prop-value :type :primary)))))
 
+(deftest convert-prop-value-3-arg-native-stringifies-any-name
+  (testing "rf2-ygknv finding 1: 3-arg form with native?=true stringifies
+            keyword values for ANY prop name (every DOM attr is a string)"
+    (is (= "button" (template/convert-prop-value :type :button true)))
+    (is (= "_blank" (template/convert-prop-value :target :_blank true)))
+    (is (= "noopener" (template/convert-prop-value :rel :noopener true)))
+    ;; symbol value too
+    (is (= "x" (template/convert-prop-value :name 'x true)))))
+
+(deftest convert-prop-value-3-arg-non-native-narrowed
+  (testing "rf2-ygknv finding 1: 3-arg form with native?=false defers to
+            the interop (narrowed) rule — non-HTML keyword preserved"
+    (is (= :button (template/convert-prop-value :type :button false)))
+    (is (= :rf/foo (template/convert-prop-value :value :rf/foo false)))
+    ;; HTML-attr name still stringifies even on the non-native path
+    (is (= "primary" (template/convert-prop-value :class :primary false)))))
+
 (deftest convert-prop-value-string-passthrough
   (testing "string value passes through unchanged"
     (is (= "hello"
@@ -458,6 +475,83 @@
     (let [my-view (fn [_n] [:div])
           ^js el (template/as-element [my-view 1])]
       (is (component/reagent-class? (.-type el))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ygknv finding 1: target-aware keyword/symbol DOM-attr stringification
+;;
+;; convert-props is shared by native DOM tags and :> custom React
+;; components. For native DOM tags every prop is an HTML attribute, so
+;; keyword/symbol values must stringify (matching the pure server
+;; serializer + React DOM). For custom/interop components the keyword
+;; is preserved (e.g. :rf/foo on a React-context Provider's :value).
+;; ---------------------------------------------------------------------------
+
+(deftest as-element-native-button-type-keyword-stringifies
+  (testing "[:button {:type :button}] → props.type === \"button\""
+    (let [^js el (template/as-element [:button {:type :button}])]
+      (is (= "button" (-> el .-props .-type))))))
+
+(deftest as-element-native-anchor-keyword-attrs-stringify
+  (testing "[:a {:target :_blank :rel :noopener}] → string DOM attrs"
+    (let [^js el (template/as-element [:a {:target :_blank :rel :noopener}])]
+      (is (= "_blank" (-> el .-props .-target)))
+      (is (= "noopener" (-> el .-props .-rel))))))
+
+(deftest as-element-native-symbol-attr-stringifies
+  (testing "native DOM tag stringifies a symbol attr value too"
+    (let [^js el (template/as-element [:input {:name 'q}])]
+      (is (= "q" (-> el .-props .-name))))))
+
+(deftest as-element-interop-preserves-keyword-value
+  (testing "[:> Provider {:value :rf/foo}] preserves the CLJS keyword
+            (custom React component — NOT a native DOM tag)"
+    (let [Provider (fn FakeProvider [_props] nil)
+          ^js el   (template/as-element [:> Provider {:value :rf/foo}])]
+      (is (= Provider (.-type el)))
+      (is (= :rf/foo (-> el .-props .-value))
+          "keyword preserved for the interop component, not stringified"))))
+
+(deftest as-element-interop-non-html-keyword-preserved-html-stringified
+  (testing "interop: HTML-attr keyword stringifies, non-HTML keyword preserved"
+    (let [Comp   (fn FakeComp [_props] nil)
+          ^js el (template/as-element [:> Comp {:role :button :kind :primary}])]
+      (is (= "button" (-> el .-props .-role))
+          ":role is an HTML-attr name → stringified even on interop")
+      (is (= :primary (-> el .-props .-kind))
+          ":kind is a custom prop → keyword preserved on interop"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ygknv finding 2: CSS custom properties (--foo) not camelCased
+;;
+;; The live React-element path's style-map conversion ran every key
+;; through cached-prop-name, camelCasing `--gap` → `Gap` and silently
+;; dropping the variable (while the pure server serializer preserved
+;; it → parity break). dash-to-prop-name now short-circuits `--` names.
+;; ---------------------------------------------------------------------------
+
+(deftest as-element-style-css-var-preserved
+  (testing "[:div {:style {:--gap \"8px\"}}] → props.style[\"--gap\"] === \"8px\""
+    (let [^js el (template/as-element [:div {:style {:--gap "8px"}}])
+          style  (.. el -props -style)]
+      (is (= "8px" (aget style "--gap"))
+          "CSS custom property name preserved verbatim")
+      (is (or (nil? (aget style "Gap")) (= js/undefined (aget style "Gap")))
+          "NO camelCased 'Gap' replacement key created"))))
+
+(deftest as-element-style-css-var-alongside-normal-prop
+  (testing "CSS var coexists with a normal camelCased style prop"
+    (let [^js el (template/as-element [:div {:style {:--accent "red"
+                                                     :font-size "12px"}}])
+          style  (.. el -props -style)]
+      (is (= "red" (aget style "--accent"))
+          "custom property preserved")
+      (is (= "12px" (aget style "fontSize"))
+          "regular kebab style key still camelCased to fontSize"))))
+
+(deftest cached-prop-name-css-var-not-camelcased
+  (testing "rf2-ygknv finding 2: cached-prop-name preserves --foo verbatim"
+    (is (= "--gap" (template/cached-prop-name :--gap)))
+    (is (= "--my-custom-prop" (template/cached-prop-name :--my-custom-prop)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Sequence-as-children + key warnings


### PR DESCRIPTION
Fixes the four correctness findings in `rf2-ygknv` — all in `implementation/adapters/reagent-slim/`. Three are SSR/static-vs-live-React parity bugs; the fix makes the live React-element path and the pure-CLJS server serializer **agree**.

## Findings & fixes

1. **Keyword/symbol DOM attrs not stringified** (`impl/template.cljs`). `convert-props` is shared by native DOM tags and `:>` custom components, but `convert-prop-value` only stringified keywords for `:class`/`:id`/`:role`/`data-*`/`aria-*` — so `[:button {:type :button}]` passed a raw CLJS keyword into React DOM while the server serializer stringified it (`type="button"`). Made prop conversion **target-aware**: `convert-props` discriminates on `(string? (.-tag parsed))` and routes native DOM tags through a 3-arg `convert-prop-value` that stringifies every keyword/symbol attr value; custom/interop components keep the narrowed rule, so `[:> Provider {:value :rf/foo}]` still preserves the keyword.

2. **CSS custom properties camelCased on the live path** (`impl/template.cljs`). `{:style {:--gap "8px"}}` ran `--gap` through `dash-to-prop-name` → `"Gap"`, silently dropping the variable, while the server preserved it. `dash-to-prop-name` now short-circuits `--`-prefixed names, matching React's style handling and the server.

3. **SVG attribute names blanket-lowercased** (`dom/server.cljs`). The serializer lowercased any camelCase token (`:viewBox`→`viewbox`, `:clipPath`→`clippath`, `:strokeWidth`→`strokewidth`). React does **not** lowercase blindly — it consults a fixed attribute-name table. Added `react-attr-name-overrides` (extracted from React 19's `renderToStaticMarkup`) pinning the **preserved** (`viewBox`, `preserveAspectRatio`, `gradientUnits`, `colSpan`, …) and **dasherized** (`clipPath`→`clip-path`, `strokeWidth`→`stroke-width`, `fillOpacity`→`fill-opacity`, …) shapes; tokens not in the table fall through to the lowercase rule (correct for residual HTML camelCase like `tabIndex`→`tabindex`). Boolean-attr detection + short-form emission now lowercase the name so the case-preserving override doesn't defeat the HTML5 boolean-attr set (`readOnly`→`readonly`). The live React path was already correct (React remaps SVG names at the DOM layer) — only the pure serializer diverged.

4. **Error-boundary state desync** (`impl/component.cljs`, was MEDIUM confidence — confirmed real). The default `getDerivedStateFromError` is a **static** method that can only patch React's `this.state` with `cljsHasError`; the public Reagent state API reads a separate `.-cljsState` atom, so a boundary render checking `(reagent2.core/state this)` never saw the marker and the fallback would not render. Added `sync-error-state!` at render entry to bridge the marker into the Reagent state atom additively — guarded to write only on the error-state transition and **outside** the render Reaction (so it is not captured as a render dependency and does not churn).

`IMPL-SPEC.md` §6.5 / §7.2 / §8.3 updated to document the target-aware stringification, the SVG attribute-name table, the CSS-var preservation, and the error-state sync. No back-compat shims; pre-existing tests that pinned the buggy behaviour (`<td colspan>`) were corrected to React's actual output.

## Quality gates

All run from `implementation/` in the worker worktree:

- `npm run test:cljs` — **5747 tests, 20118 assertions, 0 failures, 0 errors** (node-runtime CLJS suite, cross-artefact; includes all new + existing reagent-slim unit + parity tests).
- `npm run test:reagent-slim:bundle-isolation` — **PASS**: 3 contracts, 19 sentinel checks. Slim bundle (462138 chars) contains no stock-Reagent impl and no `react-dom/server` symbols; stock control bundle present. Confirms the changes don't break the slim/pure-CLJS-SSR guarantee.

New parity tests pin the live React path against `react-dom/server` for: keyword DOM attrs (`[:button {:type :button}]`, `[:a {:target :_blank}]`), CSS custom properties (`--gap`), and SVG casing (`viewBox`, `preserveAspectRatio`, `clipPath`→`clip-path`, `strokeWidth`→`stroke-width`, a realistic nested SVG tree, `tabindex` lowercasing).

Closes rf2-ygknv.
