### PR TITLE
fix(ssr): safe-redirect args schema + ifn? Var-headed components + production-gate source-coords (rf2-wtd8z)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -277,6 +277,7 @@ Validation order: (1) URL must parse — :rf.error/safe-redirect-invalid-url;
 (4) :allow allowlist mismatch — :rf.error/safe-redirect-host-disallowed
 (:reason :not-in-allowlist); (5) pass — set Location header. Per
 rf2-zfm8v (Mike decision, Option A, 2026-05-14)."
+   :schema    server-fx-schemas/safe-redirect-args ;; :rf.fx.server/safe-redirect-args (rf2-wtd8z finding 1)
    :platforms #{:server}}
   response/safe-redirect-fx)
 

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -22,6 +22,7 @@
 
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [clojure.string]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.ssr.hash :as hash]
@@ -391,11 +392,21 @@
                maybe-view (registrar/lookup :view head)]
            (if maybe-view
              (let [raw   (apply (:handler-fn maybe-view) (rest el))
-                   ;; Spec 006 §Source-coord annotation: inject the
-                   ;; data-rf2-source-coord attribute on the registered
-                   ;; view's root DOM element when the slot's metadata
-                   ;; carries source coords.
-                   coord (format-view-source-coord head maybe-view)
+                   ;; Spec 006 §Source-coord annotation / Spec 011 §SSR
+                   ;; production elision: inject the data-rf2-source-coord
+                   ;; attribute on the registered view's root DOM element
+                   ;; when the slot's metadata carries source coords —
+                   ;; but ONLY when the debug gate is on. Source coords are
+                   ;; internal ns/symbol/line info; emitting them in a
+                   ;; production render leaks them into public HTML and
+                   ;; violates the SSR production-elision contract
+                   ;; (rf2-wtd8z finding 3). Gating the computation behind
+                   ;; `interop/debug-enabled?` means a production JVM render
+                   ;; never even calls `format-view-source-coord` for an
+                   ;; annotated slot, so `coord` is nil and the injection is
+                   ;; skipped — identical to the no-coords path.
+                   coord (when interop/debug-enabled?
+                           (format-view-source-coord head maybe-view))
                    out   (if coord
                            (inject-coord-on-root-hiccup coord raw)
                            raw)]
@@ -420,10 +431,19 @@
                         (emit-children children)
                         "</" tag-name ">"))))))
 
-         (fn? head)
-         ;; Pass root-attrs through fn-headed component resolution too —
-         ;; the wrapping fn is structurally the same kind of indirection as
-         ;; a registered-view ref.
+         ;; Callable component head — a plain fn OR a Var reference
+         ;; (`[#'component & args]`). On the JVM a Var is `ifn?` but NOT
+         ;; `fn?`, so a bare `(fn? head)` test let a Var-headed component
+         ;; fall through to `:else (str el)` and emit the EDN text
+         ;; `[#'user/component "ok"]` instead of resolving it (rf2-wtd8z
+         ;; finding 2). `ifn?` covers both — keywords/`:<>`/`:>`/
+         ;; `:rf/suspense-boundary` are all consumed by the branches above,
+         ;; so the only callables reaching here are fns and Var references.
+         ;; Pass root-attrs through this indirection too — structurally the
+         ;; same kind of wrapping as a registered-view ref, so the root
+         ;; hash / source-coord thread through the Var head onto the
+         ;; resolved DOM root.
+         (ifn? head)
          (emit-element (apply head (rest el)) root-attrs)
 
          :else (str el)))

--- a/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
+++ b/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
@@ -182,3 +182,37 @@
    [:location {:optional true} :string]
    [:url      {:optional true} :string]
    [:to       {:optional true} :string]])
+
+(def safe-redirect-args
+  "Args of `:rf.server/safe-redirect` — `:rf.fx.server/safe-redirect-args`.
+  `{:location <string> :status? <int> :relative-only? <boolean>
+    :allow? [<string> …]}` — the caller-UNtrusted redirect (open-redirect
+  mitigation, rf2-zfm8v). `:location` is the validation target, so unlike
+  the caller-trusted `:rf.server/redirect` (which has a documented no-
+  target graceful path, rf2-ee38b.11) safe-redirect REQUIRES a `:location`
+  to validate — a target-less safe-redirect is a programmer error with no
+  defensible interpretation. The five-step URL-parse / scheme / relative-
+  only? / allowlist gate lives in `re-frame.ssr.response/safe-redirect-fx`
+  and emits the specific `:rf.error/safe-redirect-*` categories; this is
+  the structural SHAPE check, completing the `:schema` boundary the other
+  six `:rf.server/*` fxs already carry (rf2-kjf3m.2 / rf2-wtd8z finding 1).
+
+  The closed gap (rf2-wtd8z finding 1): pre-fix the reg-fx carried only
+  `:platforms` — no `:schema` — so the Spec 010 §step-5 fx-args boundary
+  never ran. A `{:location \"/ok\" :status \"not-int\"}` arg flowed its
+  string `:status` straight through `safe-redirect-fx`'s step-5 pass onto
+  the response accumulator (and onto the wire). With this schema attached
+  the malformed `:status` surfaces as `:rf.error/schema-validation-failure
+  :where :fx-args` at the dispatch site, the fx is skipped, and the
+  response is left unmodified — matching the sibling six.
+
+  PERMISSIVE where the spec intends optionality (the #3202 lesson): only
+  `:location` is required; `:status` / `:relative-only?` / `:allow` are
+  optional. `:allow` is a SEQUENCE of host strings (the fx reads `:allow`,
+  not a scalar `:allowlist`). Closed map is avoided — extra keys pass —
+  so the shape gate never over-constrains a legitimate call."
+  [:map
+   [:location       :string]
+   [:status         {:optional true} :int]            ;; default 302
+   [:relative-only? {:optional true} :boolean]
+   [:allow          {:optional true} [:sequential :string]]])

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -58,6 +58,7 @@
   (:require [clojure.data]
             [clojure.string]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.ssr.emit :as emit]
@@ -378,8 +379,12 @@
                 ;; `emit/emit-element` on its registered-view branch;
                 ;; we mirror the structural-injection shape here on
                 ;; the walked subtree so streamed shells still carry
-                ;; the annotation.
-                coord (emit/format-view-source-coord head v)
+                ;; the annotation. Gated on `interop/debug-enabled?` so a
+                ;; production streamed render elides the internal source
+                ;; coords — same production-elision contract the non-
+                ;; streaming emitter obeys (rf2-wtd8z finding 3).
+                coord (when interop/debug-enabled?
+                        (emit/format-view-source-coord head v))
                 out   (if coord
                         (emit/inject-coord-on-root-hiccup coord raw)
                         raw)]
@@ -391,8 +396,16 @@
           ;; saved by short-circuiting to `emit/emit-element`.
           (walk-dom-tag el acc))))
 
-    (and (vector? el) (fn? (first el)))
-    ;; fn-headed component — invoke + recurse on the body.
+    (and (vector? el) (ifn? (first el)))
+    ;; Callable component head — a plain fn OR a Var reference
+    ;; (`[#'component & args]`). On the JVM a Var is `ifn?` but NOT `fn?`,
+    ;; so a bare `(fn? …)` test left a Var-headed component falling through
+    ;; to the `(sequential? el)` / scalar arms and emitting EDN text rather
+    ;; than resolving it (rf2-wtd8z finding 2 — same gap as the non-
+    ;; streaming emitter). The keyword branch above (DOM tags, fragments,
+    ;; `:>`, registered views) is reached first, so the only callables
+    ;; reaching here are fns and Var references. Invoke + recurse on the
+    ;; body so the shell walk threads through the Var head.
     (walk-shell (apply (first el) (rest el)) acc)
 
     (sequential? el)

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -524,3 +524,76 @@
     (is (= "<button disabled>Go</button>"
            (emit/render-to-string [:button {:disabled true :title nil} "Go"] {}))
         "boolean + nil attrs compose on a non-void element alongside text")))
+
+;; ===========================================================================
+;; rf2-wtd8z finding 2 — Var-headed component resolution (emit.cljc +
+;; streaming.cljc). On the JVM a Var (`#'component`) is `ifn?` but NOT
+;; `fn?`, so the prior `(fn? head)` test let a Var-headed component fall
+;; through to the scalar/`:else` arm and emit the EDN text
+;; `[#'re-frame.ssr-emit-test/var-component "ok"]` instead of resolving it
+;; to `<span>ok</span>`. The emitter / streaming walker now test `ifn?`,
+;; which resolves both fns and Var references. These tests pin standard +
+;; streaming resolution AND the root-attr threading (render-hash +
+;; source-coord) through the Var-head indirection.
+;; ===========================================================================
+
+(defn var-component
+  "A plain component fn referenced via its Var (`#'var-component`) so the
+  emitter's callable-head branch sees an `ifn?`-but-not-`fn?` head on the
+  JVM. Returns a DOM-rooted hiccup so root-attr threading has a tag to
+  land on."
+  [label]
+  [:span label])
+
+(deftest render-to-string-var-headed-component
+  (testing "rf2-wtd8z finding 2 — a Var-headed component `[#'component & args]`
+            is invoked and its hiccup emitted (NOT stringified as EDN)"
+    (is (= "<span>ok</span>"
+           (emit/render-to-string [#'var-component "ok"] {}))
+        "the Var head resolves: invoked with its args, returned hiccup emits")
+    (testing "a Var-headed component nested as a child resolves too"
+      (is (= "<ul><span>a</span><span>b</span></ul>"
+             (emit/render-to-string [:ul [#'var-component "a"] [#'var-component "b"]] {}))
+          "Var-heads in child position resolve via emit-children → emit-element"))
+    (testing "root render-hash threads through the Var head onto the resolved DOM root"
+      (let [html (emit/render-to-string [#'var-component "ok"] {:emit-hash? true})]
+        (is (re-find #"<span [^>]*data-rf-render-hash=\"[^\"]+\">ok</span>" html)
+            (str "the root data-rf-render-hash lands on the Var head's resolved"
+                 " <span> root; got: " html))))))
+
+(deftest render-to-string-var-headed-registered-view
+  (testing "rf2-wtd8z finding 2 — a registered view whose body is a
+            Var-headed component resolves (no EDN leak); the source-coord
+            follows the documented fn/component-head exemption
+            (inject-coord-on-root-hiccup only annotates keyword-headed
+            roots — a Var-headed body is one level of indirection above
+            the resolved DOM root, same as a fn-headed body or a :<>
+            fragment), while the render-hash root-attr DOES thread through
+            the Var head onto the resolved DOM root"
+    (rf/reg-view ^{:rf/id :rf.ssr-emit-test/var-view} var-view []
+      [#'var-component "v"])
+    (let [html (emit/render-to-string [:rf.ssr-emit-test/var-view] {})]
+      (is (= "<span>v</span>" html)
+          (str "the Var head resolved to <span>v</span> (NOT EDN text); the "
+               "source-coord is exempt on a Var-headed view root, matching "
+               "the fn-head / fragment exemption; got: " html)))
+    (testing "render-hash threads through the Var-headed view root onto the resolved DOM root"
+      (let [html (emit/render-to-string [:rf.ssr-emit-test/var-view] {:emit-hash? true})]
+        (is (re-find #"<span [^>]*data-rf-render-hash=\"[^\"]+\">v</span>" html)
+            (str "the root data-rf-render-hash threads through the view-ref AND "
+                 "the Var head onto the resolved <span> root; got: " html))))))
+
+(deftest render-shell-var-headed-component
+  (testing "rf2-wtd8z finding 2 — the streaming shell walker resolves a
+            Var-headed component just like the non-streaming emitter
+            (ifn?, not fn?), recursing on its returned hiccup"
+    (let [{:keys [shell-html]} (streaming/render-shell [#'var-component "streamed"])]
+      (is (= "<span>streamed</span>" shell-html)
+          (str "the streaming walker resolved the Var head + recursed on its"
+               " body; got: " shell-html)))
+    (testing "a Var head nested in a DOM tree streams resolved too"
+      (let [{:keys [shell-html]} (streaming/render-shell
+                                   [:section [#'var-component "x"]])]
+        (is (= "<section><span>x</span></section>" shell-html)
+            (str "nested Var head resolved in the shell walk; got: "
+                 shell-html))))))

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -2168,7 +2168,44 @@
             traces (capture-schema-failures!
                      (fn [] (rf/dispatch-sync [:bad/redirect-status] {:frame f})))]
         (expect-fx-args-schema-failure!
-          traces :rf.server/redirect ":rf.server/redirect non-int :status")))))
+          traces :rf.server/redirect ":rf.server/redirect non-int :status")))
+
+    (testing ":rf.server/safe-redirect with non-int :status → rejected + response unmodified"
+      ;; rf2-wtd8z finding 1: pre-fix safe-redirect carried only :platforms
+      ;; — no :schema — so a valid-location-but-non-int-:status arg passed
+      ;; the (absent) boundary and safe-redirect-fx's step-5 pass wrote the
+      ;; string :status straight onto the response accumulator. With the new
+      ;; :rf.fx.server/safe-redirect-args schema attached, the malformed
+      ;; :status surfaces at the Spec 010 §step-5 fx-args boundary, the fx
+      ;; is SKIPPED, and the response is left unmodified — matching the
+      ;; sibling six.
+      (rf/reg-event-fx :bad/safe-redirect-status
+        (fn [_ _] {:fx [[:rf.server/safe-redirect
+                         {:location "/ok" :status "not-int"}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/safe-redirect-status] {:frame f})))
+            resp   (get-response f)]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/safe-redirect ":rf.server/safe-redirect non-int :status")
+        (is (nil? (:redirect resp))
+            "the malformed safe-redirect was skipped — no :redirect landed")
+        (is (not= "not-int" (:status resp))
+            "the non-int status never reached the response accumulator")))
+
+    (testing ":rf.server/safe-redirect missing :location → rejected"
+      ;; safe-redirect REQUIRES a :location (its validation target) — a
+      ;; target-less safe-redirect is a programmer error, NOT the documented
+      ;; no-target graceful path that the caller-trusted :rf.server/redirect
+      ;; carries. The schema marks :location required, so a no-location call
+      ;; fails the shape gate.
+      (rf/reg-event-fx :bad/safe-redirect-no-location
+        (fn [_ _] {:fx [[:rf.server/safe-redirect {:status 302}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-schema-failures!
+                     (fn [] (rf/dispatch-sync [:bad/safe-redirect-no-location] {:frame f})))]
+        (expect-fx-args-schema-failure!
+          traces :rf.server/safe-redirect ":rf.server/safe-redirect missing :location")))))
 
 (deftest ssr-server-fx-args-schema-accepts-well-formed
   (testing "rf2-kjf3m.2 — regression guard: well-formed server fx args pass
@@ -2203,7 +2240,33 @@
       (is (= 2 (count (:cookies resp)))
           "both set-cookie + delete-cookie landed")
       (is (= {:status 302 :location "/dashboard"} (:redirect resp))
-          "redirect landed"))))
+          "redirect landed")))
+
+  (testing "rf2-wtd8z finding 1 — a well-formed :rf.server/safe-redirect
+            (string :location, int :status, boolean :relative-only?,
+            vector :allow) passes the new :rf.fx.server/safe-redirect-args
+            boundary cleanly and lands its redirect"
+    (rf/reg-event-fx :good/safe-redirect
+      (fn [_ _]
+        {:fx [[:rf.server/safe-redirect
+               {:location       "https://app.example.com/dashboard"
+                :status         302
+                :relative-only? false
+                :allow          ["app.example.com"]}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-schema-failures!
+                   (fn [] (rf/dispatch-sync [:good/safe-redirect] {:frame f})))
+          resp   (get-response f)]
+      (is (empty? (filter (fn [ev] (and (= :fx-args (-> ev :tags :where))
+                                        (= :rf.server/safe-redirect
+                                           (-> ev :tags :failing-id))))
+                          traces))
+          (str "no :fx-args schema failure for well-formed safe-redirect; saw: "
+               (pr-str (mapv (comp :failing-id :tags) traces))))
+      (is (= "https://app.example.com/dashboard" (-> resp :redirect :location))
+          "the well-formed safe-redirect landed on the response :redirect slot")
+      (is (= 302 (-> resp :redirect :status))
+          "the int :status flowed through"))))
 
 ;; ===========================================================================
 ;; ssr-with-fx-override / ssr-end-to-end — relocated from core/smoke_test.clj

--- a/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
@@ -19,6 +19,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]))
 
@@ -115,3 +116,66 @@
         (is (= "<p>p</p>" html)
             (str "programmatic registration (no macro coords) renders "
                  "without annotation; got: " html))))))
+
+;; ---- production gate: source-coords elided when debug-enabled? false -----
+;;
+;; rf2-wtd8z finding 3 / Spec 011 §SSR production elision: the JVM SSR
+;; annotation site MUST obey the `re-frame.interop/debug-enabled?`
+;; production gate — the counterpart to CLJS `goog.DEBUG=false`. Source
+;; coords are internal ns/symbol/line info; a production render must not
+;; leak them into public HTML. Pre-fix the emitter injected whenever the
+;; slot carried coords, ignoring the gate, so a production JVM render
+;; could ship `data-rf2-source-coord` into the wire HTML. These tests pin
+;; both arms: debug ON → annotated (the existing contract); debug OFF →
+;; elided.
+;;
+;; `debug-enabled?` is read once at ns load into a plain Var; the emitter
+;; reads it through that Var at call time, so `with-redefs` flips it for
+;; the duration of the body — the standard way to exercise the gate
+;; without a JVM restart.
+
+(deftest source-coord-injected-when-debug-enabled
+  (testing "rf2-wtd8z finding 3: with interop/debug-enabled? true the
+            registered-view root carries data-rf2-source-coord (the
+            dev-mode contract is preserved)"
+    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/gated-on} gated-on-view []
+      [:h2 "on"])
+    (with-redefs [interop/debug-enabled? true]
+      (let [html (ssr/render-to-string [:rf.ssr-coord-test/gated-on] {})]
+        (is (re-find #"data-rf2-source-coord=\"rf\.ssr-coord-test:gated-on:\d+:\d+\""
+                     html)
+            (str "debug ON → source-coord injected; got: " html))))))
+
+(deftest source-coord-elided-when-debug-disabled
+  (testing "rf2-wtd8z finding 3: with interop/debug-enabled? false the SSR
+            emitter elides data-rf2-source-coord on a registered-view root
+            whose slot carries coords — a production render must not leak
+            internal source coordinates into public HTML"
+    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/gated-off} gated-off-view []
+      [:h2 "off"])
+    (with-redefs [interop/debug-enabled? false]
+      (let [html (ssr/render-to-string [:rf.ssr-coord-test/gated-off] {})]
+        (is (= "<h2>off</h2>" html)
+            (str "debug OFF → no source-coord leaked into the rendered "
+                 "HTML; got: " html))
+        (is (not (str/includes? html "data-rf2-source-coord"))
+            "no data-rf2-source-coord attribute in a production render")))))
+
+(deftest streaming-source-coord-respects-debug-gate
+  (testing "rf2-wtd8z finding 3: the streaming shell walker reuses the
+            same source-coord helper and MUST obey the same production
+            gate — debug ON injects, debug OFF elides"
+    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/stream-gated} stream-gated-view []
+      [:article "streamed"])
+    (let [render-shell (requiring-resolve 're-frame.ssr.streaming/render-shell)]
+      (with-redefs [interop/debug-enabled? true]
+        (let [{:keys [shell-html]} (render-shell [:rf.ssr-coord-test/stream-gated])]
+          (is (re-find #"data-rf2-source-coord=\"rf\.ssr-coord-test:stream-gated:\d+:\d+\""
+                       shell-html)
+              (str "streaming debug ON → source-coord injected; got: "
+                   shell-html))))
+      (with-redefs [interop/debug-enabled? false]
+        (let [{:keys [shell-html]} (render-shell [:rf.ssr-coord-test/stream-gated])]
+          (is (not (str/includes? shell-html "data-rf2-source-coord"))
+              (str "streaming debug OFF → no source-coord leaked; got: "
+                   shell-html)))))))


### PR DESCRIPTION
Fixes the three correctness-review findings on `implementation/ssr` from **rf2-wtd8z**. All impl-side; no `spec/` (hot-zone) edits.

## Finding 1 — `:rf.server/safe-redirect` had no args schema
`ssr.cljc:260` / `response.cljc:814`: the fx carried only `:platforms` metadata while the sibling six `:rf.server/*` fxs each attach a `:schema`, so the Spec 010 §step-5 fx-args boundary never ran for safe-redirect. `(safe-redirect-fx {:frame :f} {:location "/ok" :status "not-int"})` flowed the string `:status` straight through the step-5 pass onto the response accumulator.

Fix: added `re-frame.ssr.server-fx-schemas/safe-redirect-args` (`:rf.fx.server/safe-redirect-args`) — `:location` REQUIRED string; `:status` OPTIONAL int; `:relative-only?` OPTIONAL boolean; `:allow` OPTIONAL `[:sequential :string]` (the fx reads `:allow`, a host-string sequence — not a scalar `:allowlist`; the bead's parenthetical is loose, the schema matches the actual fx contract) — and attached it to the `reg-fx`.

**#3202 lesson honoured:** PERMISSIVE where the spec intends optionality — only `:location` is required; status/relative-only?/allow stay optional, map is open (extra keys pass). `:location` is required because it is safe-redirect's *validation target* (a target-less safe-redirect is a programmer error, NOT the documented no-target graceful path that the caller-trusted `:rf.server/redirect` carries — so this does not reintroduce the #3202 no-target→400 regression, which was on `:rf.server/redirect`). The mandatory ssr-ring gate confirms no regression.

## Finding 2 — Var-headed components not rendered
`emit.cljc:423` / `streaming.cljc:394`: head resolution tested `(fn? head)`; on the JVM a Var is `ifn?` but NOT `fn?`, so `[#'component "ok"]` fell through to scalar/`:else` emission and leaked the EDN text `[#'user/component "ok"]` instead of `<span>ok</span>`.

Fix: resolve callable heads with `ifn?` in BOTH `emit.cljc` and `streaming.cljc`. The keyword / `:<>` / `:>` / `:rf/suspense-boundary` / registered-view branches all run first, so the only callables reaching the branch are fns and Var references. Root `data-rf-render-hash` threads through the Var head onto the resolved DOM root (the source-coord follows the pre-existing fn/component-head exemption — `inject-coord-on-root-hiccup` only annotates keyword-headed roots, same as a fn-headed body or `:<>` fragment).

## Finding 3 — source-coord injection not production-gated
`emit.cljc:398`: registered-view source-coord injection ran whenever `format-view-source-coord` returned a value, ignoring `re-frame.interop/debug-enabled?`, so a production JVM render could leak internal ns/symbol/line info into public HTML (violates Spec 011 §SSR production elision).

Fix: gate the coord computation behind `interop/debug-enabled?` in BOTH `emit.cljc` and `streaming.cljc` (require `re-frame.interop` in each). Production render → `coord` is nil → injection skipped, identical to the no-coords path.

## Tests added
- `ssr_end_to_end_test.clj`: safe-redirect non-int `:status` rejected + response unmodified; missing `:location` rejected; well-formed safe-redirect (int status, vector `:allow`, boolean `:relative-only?`) passes the boundary and lands.
- `ssr_emit_test.clj`: standard + streaming Var-headed component resolution; nested-in-DOM Var heads; render-hash threading through the Var head; registered-view Var-headed body resolves (no EDN leak) with source-coord following the documented fn-head exemption.
- `ssr_source_coord_test.clj`: source-coord injected with `debug-enabled?` true / elided with false — standard render AND streaming shell.

## Spec follow-up (flagged, not edited)
`spec/Spec-Schemas.md` is hot-zone with another PR mid-merge; the new `:rf.fx.server/safe-redirect-args` row should be documented there in a follow-up PR (the schema var name + spec map comment are in place).

## Quality gates
| Gate | Command | Result |
|------|---------|--------|
| ssr (your artefact) | `cd implementation/ssr && clojure -M:test` | **291 tests, 1065 assertions, 0 failures, 0 errors** |
| ssr-ring (MANDATORY cross-artefact — the #3202 consumer) | `cd implementation/ssr-ring && clojure -M:test` | **123 tests, 543 assertions, 0 failures, 0 errors** |
| CLJS (node) | `cd implementation && npm run test:cljs` | **5728 tests, 20106 assertions, 0 failures, 0 errors** |
| production elision (finding 3) | `cd implementation && npm run test:elision` | **PASS — production 40/40 absent, control 40/40 present** |

No dedicated `npm run test:ssr*` script exists — SSR streaming/CLJS coverage runs inside `test:cljs` (green above). All gates re-run green after rebasing onto current `origin/main`.