### PR TITLE
fix(machines-viz): history pseudo-states + SCXML inline-fn refs + parity (rf2-m285a)

### DIFF
--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -418,9 +418,14 @@ tool, then map, then name where we diverge):
   replay are driven by the Spec 009 `:rf.machine/*` trace bus
   in-process, not by a standalone interpreter sandbox (see
   §Active-state highlighting transport).
-- **No history pseudo-states.** Spec 005 omits `:history` in v1, so
-  the chart has no history-node glyph; XState / SCXML history nodes
-  have no re-frame2 analogue to render.
+- **First-class history pseudo-states (rf2-m285a — no longer a
+  divergence).** Spec 005 has first-class `:type :history` pseudo-states
+  (shallow / deep / `:default-target` — §History states). The chart
+  parses them into non-occupiable history markers (`H` / `H*`), the
+  Mermaid + SCXML emitters preserve the history semantics (SCXML uses the
+  W3C `<history type=...>` element + default transition), and the share
+  payload carries them as topology. See
+  [`001-Topology-Parity.md`](001-Topology-Parity.md) §1.4.
 - **re-frame2-native overlays.** `:after` countdown rings,
   microstep replay, `:spawn-all` join visualisation, and the
   cancellation cascade are projections of re-frame2 substrate

--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -116,21 +116,25 @@ scoping + §3.1 G9).
   history pseudo-state node
   ([stately.ai/docs/parallel-states](https://stately.ai/docs/parallel-states) §history,
   [state-machines-and-statecharts](https://stately.ai/docs/state-machines-and-statecharts)).
-  **(re-frame2 has no `:history` in Spec 005 v1 — see §3 divergences.)**
-  **rf2-az6e2 — VISUAL HOOK ONLY.** The structured grammar defines how a
-  history pseudo-state *renders* (shallow `H` / deep `H*`, a small
-  symbolic node inside the owning compound at the same child level, NOT
-  a normal state box, with direct incoming transitions and no default
-  fallback edge unless the topology explicitly carries one). The
-  renderer (`chart.nodes/history-marker`) is registered in the
-  node-types map, but `chart.layout/parse-definition` emits **no**
-  history pseudo-state node today (the parsed node shape carries no
-  `:history` data), so the projector never produces one. This bead adds
-  the VISUAL rendering for parsed pseudo-state data that already exists —
-  it does **not** add statechart history semantics. When Spec 005 history
-  semantics + the parse land, flip the projector to emit a
-  `{:type "history-marker" :data {:deep? …}}` node and `history-marker`
-  paints it; file the follow-on render-wiring bead then.
+  **re-frame2 has FIRST-CLASS history** — a `:type :history` pseudo-state
+  (shallow / deep / `:default-target`) declared under a compound's
+  `:states` ([Spec 005 §History states](../../../spec/005-StateMachines.md)).
+  **rf2-m285a — WIRED END-TO-END.** A history pseudo-state renders as a
+  small symbolic node inside the owning compound at the same child level
+  (shallow `H` / deep `H*`), NOT a normal state box, with direct incoming
+  transitions and no default fallback edge unless the topology explicitly
+  carries a `:default-target`. The pipeline:
+  - **Parse** (`chart.layout/collect-nodes`) — detects `:type :history`
+    and emits a single `{:history? true :deep? <bool> :default-target …}`
+    node that is NEVER occupiable (not initial / final / compound,
+    declares no transitions; the machine's `:state` is never `[… :hist]`).
+  - **Projection** (`chart.projection/xyflow-graph`) — maps a `:history?`
+    node to xyflow type `"history-marker"` and threads `:data {:deep …}`;
+    it carries no `:onClick` (not an on-state-click target — never
+    occupied). The renderer `chart.nodes/history-marker` paints `H` / `H*`.
+  - Incoming `:target :hist` edges are preserved (a history pseudo-state
+    is a legitimate transition target; at runtime it resolves to the
+    compound's recorded / default leaf configuration).
 
 > **rf2-az6e2 final-state glyph decision.** The final-state marker is the
 > quiet **doubled border** (the UML/SCXML convention) — the previously-
@@ -392,7 +396,7 @@ fill), and colours resolved through the active-theme **chart-tokens**
 | **Final state (success)** | **quiet doubled** border (outer ring proud of corner). **No glyph** (rf2-az6e2 dropped the ✓) | *outer ring in the resting/runtime border colour* |
 | **Final state (error — `:error?`)** | doubled border whose **outer ring is the error hue** (rf2-b4loj — re-frame2 clarity, the terminal routes the parent's `:on-error`; NOT XState/Stately parity). Main border stays runtime-driven so an active error-final composes both | *outer ring in `:final-error` (theme `:error`); main border unchanged* |
 | **Initial marker** | small **neutral** filled dot + unlabelled arrow into the initial state, at every compound level (NOT accent-blue) | *`:pseudo-marker` dot* |
-| **History pseudo-state (HOOK)** | small symbolic node — shallow `H` / deep `H*` — inside the owning compound; NOT a state box. **Renderer registered as a hook; projector emits none until parsed history topology exists** (this bead adds no statechart history semantics) | *`history-marker` node-type registered; `:pseudo-*` constants carry the variant* |
+| **History pseudo-state** | small symbolic node — shallow `H` / deep `H*` — inside the owning compound; NOT a state box, never occupiable, keeps incoming `:target :hist` edges. **WIRED end-to-end (rf2-m285a):** `chart.layout` parses `:type :history` → `{:history? true :deep? …}`; `chart.projection` maps it to xyflow `"history-marker"` + `:data {:deep …}`; `chart.nodes/history-marker` paints `H` / `H*` | *`history-marker` node-type emitted by the projector; `:pseudo-*` constants carry the variant* |
 | **Compound container** | **solid subtle-neutral** box + full-width title strip; NO dashed border, NO accent wash by default | *`:container-body-bg` fill, `:container-border` solid, `:container-header-bg` strip* |
 | **Parallel region container** | **dashed neutral** boundary + full-width region title strip + subtle `∥` glyph + uppercased label. Region identity from **containment/layout**, NOT a rotating border colour | *`:region-border` dashed (same for every region — rotation removed)* |
 | **Parallel region (ACTIVE) — G1/G4** | region boundary firms to **solid** + header carries an **active affordance**; **every** active leaf inside lights **simultaneously** | ✅ shipped (rf2-80rm2 / rf2-az6e2): solid `:active` boundary + `:active-wash` header + `:glow` ring |
@@ -584,6 +588,7 @@ SCXML codec round-trips it faithfully, and the mermaid id is injective.
 | F5 | **rf2-mnp93.4** ✅ — `fix(machines-viz): surface internal action-only :on/:after/:always consistently across chart + mermaid + scxml` | new | isolated (`chart/layout.cljc`, `mermaid.cljc` + JVM/CLJS tests + this doc) | **G9 faithfulness — generalised from `:on-done` (F2) to the ordinary internal transition.** An INTERNAL (action-only, no-`:target`) `:on` / `:after` / `:always` candidate was projected INCONSISTENTLY: the CHART charted internal `:on` (self-anchored, `:internal?`) but SILENTLY DROPPED internal `:after` / `:always` (the `resolve-target-path` inside `keep` returned nil for a target-less candidate — inconsistent even WITHIN the chart); MERMAID dropped ALL three; SCXML kept all three. Three emitters, three projections of one machine. Fix: `chart/layout.cljc`'s `:after` / `:always` branches now detect the target-less candidate and self-anchor it (`:internal? true`), matching the `:on` branch; `mermaid.cljc` renders each internal candidate as a `note right of <state>` line (`<descriptor> [guard] / <action>`) — the SAME action-only-note affordance F2 introduced for `:on-done`. SCXML was already faithful. A new `cross_emitter_agreement_cljs_test` pins the three-emitter count agreement (chart 3 / mermaid 3 / scxml 3 for the bead repro). |
 | F6 | **rf2-mnp93.5** ✅ — `fix(machines-viz): SCXML round-trips an internal action transition (not a forbidden block)` | new | isolated (`scxml.cljc` + JVM/CLJS tests + this doc) | **SCXML round-trip semantic inversion.** An internal action `:on {:tick {:action :log}}` emitted `<transition event="tick"><!-- action: log --></transition>`; the decoder's `strip-comments` discarded the action comment BEFORE tokenizing, so the candidate decoded to the EMPTY map `{}` — which Spec 005 §Forbidden transitions defines as a FORBIDDEN BLOCK (consume-the-event-and-block-inheritance). 'Run an action' → 'block the event entirely' is a SEMANTIC INVERSION, not lossy detail. Fix: a `lift-action-comments` pre-pass folds each `<!-- action: NAME -->` into a synthetic `data_rf_action` attribute on its own `<transition>` BEFORE comments are stripped, and the decoder recovers it into the candidate's `:action`. An internal action transition now round-trips as `{:action :log}` — a VALID Spec-005 internal action transition (the distinguishing feature is the PRESENCE of `:action`, Spec 005 §Forbidden L1346). A genuine `{}` forbidden block still round-trips to `{}` (the lift-pass only recovers a PRESENT action). |
 | F7 | **rf2-mnp93.6** ✅ — `fix(machines-viz): mermaid sanitise-id is injective` | new | isolated (`mermaid.cljc` + JVM/CLJS tests + this doc) | **Mermaid node-id collision.** `sanitise-id` mapped every non-`[a-zA-Z0-9_]` char to `_`, so `:a/b`, `:a-b`, and `:a_b` all collapsed to `a_b`: two distinct states became ONE Mermaid node, mis-wiring every edge to/from either (hyphens are pervasive in re-frame keywords). The SAME collision class the chart's `node-id` was fixed for in rf2-ee38b.21. Fix: port the chart's injective hex-escape scheme (`:a/b` → `a_2fb`, `:a-b` → `a_2db`, `:a_b` → `a_5fb`; `/` ns/name marker → `_2f`, `__` path separator) into `sanitise-id`, so distinct keywords map to distinct mermaid nodes AND the chart + mermaid emitters mint the SAME id for the same path (a tool reading both addresses every node identically). Mermaid node-ids are internal — the visible label comes from `render-state-alias` — so the injective encoding costs no legibility. |
+| F8 | **rf2-m285a** ✅ — `fix(machines-viz): history pseudo-states + SCXML inline-fn refs + parity` | new | isolated (`chart/layout.cljc`, `chart/projection.cljc`, `mermaid.cljc`, `scxml.cljc`, `share.cljs` + JVM/CLJS tests + this doc) | **History pseudo-states were parsed/exported as ordinary occupiable states** — `collect-nodes` made a normal node, projection fell through to xyflow `"state"`, mermaid emitted a bare leaf id, SCXML emitted `<state>`/`<final>` (never `<history>`). This contradicted Spec 005 (history = pseudo-state, never active; a transition to `:hist` resolves to the recorded/default leaf) and lost XState-v5/SCXML history parity. Fix: detect `:type :history` at parse → non-occupiable `{:history? true :deep? … :default-target …}` marker (the `chart.nodes/history-marker` HOOK becomes a live projector path → xyflow `"history-marker"`); mermaid declares a labelled `H` / `H*` marker + a `%% default-target` note; SCXML export/import preserve W3C `<history type="shallow|deep">` + the default `<transition>` and round-trip back to `:type :history`. **Also (F8b)** SCXML export crashed (`ClassCastException`) on an inline-fn `:guard`/`:action` (it passed the fn to `keyword->id-string`); a new `ref->label` tolerates fn refs as opaque/lossy labels (consistent with chart/mermaid + the API promise that fn bodies are lossy, not unsupported). **And (F8c)** the share encoder leaked macro-stamped `:source-coords`/`:source-code` + executable `:fn` DATA (which `strip-meta` — metadata only — never reached); `sanitise-definition` strips them structurally before Transit. |
 
 > **Sibling note (rf2-wnzha — same review pass, NOT a parity row):**
 > parallel regions sharing a state NAME minted COLLIDING node-ids (the
@@ -617,8 +622,10 @@ SCXML codec round-trips it faithfully, and the mermaid id is injective.
 > includes the `:on-done` / XState `onDone` completion transition — rf2-41goo
 > / G9 — AND the ordinary INTERNAL action-only `:on` / `:after` / `:always`
 > transition surfaced consistently across all three emitters — rf2-mnp93.4)
-> except the three **intentional divergences** (no code↔diagram sync,
-> trace-driven not sandbox sim, no history pseudo-states) — and remains
+> except the two **intentional divergences** (no code↔diagram sync,
+> trace-driven not sandbox sim) — history pseudo-states are now
+> FIRST-CLASS (rf2-m285a — Spec 005 §History states; §1.4) and no longer
+> a divergence — and remains
 > **above** the bar on the re-frame2-native overlays (`:after` rings,
 > microstep replay, `:spawn-all` join, cancellation cascade). The three
 > emitters agree on internal-transition projection (rf2-mnp93.4), the SCXML
@@ -641,7 +648,8 @@ SCXML codec round-trips it faithfully, and the mermaid id is injective.
 - [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) —
   the machine model: compound paths, parallel region-map `:state`,
   microsteps, LCA cascade, self-transitions, `:spawn-all`, final
-  states; **no `:history` in v1**.
+  states; **first-class `:type :history` pseudo-states** (shallow / deep
+  / `:default-target` — §History states).
 - [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md)
   — the `:rf.machine/*` trace vocab the trace-driven highlight + fired-
   edge mapping consume.

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1046,11 +1046,15 @@ colour is subordinate to structure**.
   rotating border colour (the prior `region-boundary-palette` rotation is
   removed). Active / focus colour is reserved for runtime state.
 - **Pseudo-states**: initial markers are small **neutral** dots (not
-  accent-blue). A **history** pseudo-state renderer (shallow `H` / deep
-  `H*`, small symbolic node) is registered as a **hook** — the projector
-  emits no history node until parsed history-pseudo-state topology data
-  exists (this bead does not add statechart history semantics). See
-  [`001-Topology-Parity.md`](001-Topology-Parity.md) §History.
+  accent-blue). A **history** pseudo-state (shallow `H` / deep `H*`, small
+  symbolic node, never occupiable) is **wired end-to-end** (rf2-m285a):
+  `chart.layout` parses a `:type :history` node into a non-occupiable
+  `{:history? true :deep? …}` marker, `chart.projection` maps it to xyflow
+  `"history-marker"` + `:data {:deep …}`, and `chart.nodes/history-marker`
+  paints it. The SCXML / Mermaid emitters preserve the history semantics
+  (SCXML uses W3C `<history type="shallow|deep">` + the default
+  `<transition>`). See
+  [`001-Topology-Parity.md`](001-Topology-Parity.md) §1.4.
 - **Arrow/routing**: the two-edge event-node route reads as **one
   transition** — a quiet source→event segment (thinner stroke, small
   `:arrow-width-quiet` arrowhead, `:edge-quiet`) and a primary
@@ -1388,9 +1392,18 @@ encoder:
    the encoder rejects (with `:invalid-chart-state`) anything the decoder
    could not accept — e.g. a `:snapshot` `:state` that is none of the
    three configuration arms — rather than emitting an undecodable URL.
-2. Strips metadata off `:definition` (registered definitions carry
-   source-coord meta per Spec 001; that meta must not propagate
-   into the share payload).
+2. Strips metadata off `:definition` AND structurally sanitises it
+   (rf2-m285a). A macro-stamped spec (Spec 005 §Source-coord stamping)
+   co-locates `:source-coords` / `:source-code` + executable `:fn` values
+   as ordinary DATA inside `:states` / `:guards` / `:actions` /
+   `:on-spawn-actions` — NOT as metadata — so `strip-meta` alone never
+   reached them (a local-filesystem-path leak, and a live `:fn` would make
+   Transit encoding fail). `sanitise-definition` recursively drops the
+   `:source-coords` / `:source-code` debug fields and executable `:fn`
+   values, and replaces any inline-fn slot with a names-only opaque label,
+   so the payload is a viewer-safe topology with no source/paths/fns. The
+   topology references (state ids, transition targets, guard/action NAMES)
+   survive.
 3. Canonicalises map / set ordering (per
    [Principles §Reproducible from the registry alone](./Principles.md)).
 4. Wraps in the versioned envelope.
@@ -1762,6 +1775,7 @@ documenting comment and does **not** survive the parse back.
 | `:after {ms :target}`                 | `<transition event="after.ms" target="target"/>` |
 | `:always [...]`                       | `<transition target="..."/>` (eventless) |
 | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
+| `{:type :history :deep? <b> :default-target <t>}` (rf2-m285a) | W3C `<history type="shallow\|deep">` inside the owning compound; a `:default-target` rides a default `<transition target="…"/>`. NEVER occupiable (a transition TO it resolves to the recorded/default leaf), so it emits `<history>`, never `<state>`/`<final>`. Round-trips back to `:type :history`. |
 | Namespaced ids (`:auth/login`)        | `auth__login` (hex-escaped; `__` separates ns from name) |
 | Multi-dot-ns ids (`:my.app/login`)    | `my_2eapp__login` (ns dots escaped to `_2e`) |
 | Vector-path targets (`[:parent :child]`) | `parent___child` (`___` joins path SEGMENTS) |
@@ -1814,7 +1828,12 @@ documenting comment and does **not** survive the parse back.
 - `:action`s and guard FN bodies — only the *names* survive
   (SCXML `cond="name"` for guards; entry/exit `<script>` would
   require evaluation context, so names are preserved as XML
-  comments on imports/exports).
+  comments on imports/exports). An INLINE-FN `:guard` / `:action`
+  (the Spec 005 escape hatch) is **lossy-not-crash** (rf2-m285a): the
+  exporter surfaces the fn's `:name` meta or a stable `"fn"` fallback
+  (consistent with the chart + Mermaid emitters, and the API promise
+  that fn bodies are lossy, NOT unsupported) — pre-fix it threw a
+  `ClassCastException` when passed to the keyword id codec.
 - Source-coord metadata — stripped at export time (same posture as
   share-URL encoding; see [Principles §No session data in shares](./Principles.md)).
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -106,6 +106,20 @@
     (vector? spec)      (mapcat transition-candidates spec)
     :else               []))
 
+(defn history-node?
+  "rf2-m285a — true when a node under a compound's `:states` is a
+  `:type :history` PSEUDO-STATE (Spec 005 §History states), not an
+  ordinary occupiable substate. A history pseudo-state is NEVER active:
+  a transition *to* it resolves to the compound's recorded / default
+  leaf configuration, so the machine's `:state` is never `[… :hist]`.
+  The projector must paint it as a small `history-marker` glyph inside
+  its owning compound — keeping incoming edges but treating it as
+  neither initial nor final nor compound (it declares only `:type` /
+  `:deep?` / `:default-target`)."
+  [state-node]
+  (and (map? state-node)
+       (= :history (:type state-node))))
+
 (defn- parent-path [path]
   (if (seq path)
     (pop path)
@@ -303,8 +317,27 @@
   SCXML / Mermaid emitters' `<initial>` rendering."
   [parent-path state-map]
   (mapcat (fn [[state-id state-node]]
-            (let [path (conj parent-path state-id)
-                  self (cond-> {:path     path
+            (let [path (conj parent-path state-id)]
+             (if (history-node? state-node)
+              ;; rf2-m285a — a `:type :history` PSEUDO-STATE (Spec 005
+              ;; §History states). NEVER occupiable: not initial / final /
+              ;; compound, declares no transitions. Emit a single
+              ;; `:history?`-flagged marker node carrying `:deep?` +
+              ;; `:default-target` so the projector paints the
+              ;; `history-marker` glyph (`H` / `H*`) and the SCXML / Mermaid
+              ;; emitters preserve the history semantics. It has no children
+              ;; (a history node MUST NOT declare `:states`).
+              [{:path           path
+                :label          (name state-id)
+                :depth          (count parent-path)
+                :history?       true
+                :deep?          (boolean (:deep? state-node))
+                :default-target (:default-target state-node)
+                :initial?       false
+                :final?         false
+                :compound?      false
+                :tags           #{}}]
+              (let [self (cond-> {:path     path
                                 :label    (name state-id)
                                 :depth    (count parent-path)
                                 :initial? (boolean (:initial? state-node))
@@ -338,7 +371,7 @@
                                           c))
                                       raw-children)
                                  raw-children)]
-              (cons self children)))
+                (cons self children)))))
           state-map))
 
 ;; ---- public ids ---------------------------------------------------------

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -716,6 +716,19 @@
                                    ;; chip class rf2-34ff3 fixed for the
                                    ;; machine-root + region containers.
                                    (:parallel-root? n) "machine-root"
+                                   ;; rf2-m285a — a `:type :history`
+                                   ;; PSEUDO-STATE (Spec 005 §History states)
+                                   ;; is NEVER occupiable: it is a transition
+                                   ;; target that resolves to the compound's
+                                   ;; recorded / default leaf, so the machine
+                                   ;; never sits in `[… :hist]`. Paint it as
+                                   ;; the small `history-marker` glyph (`H` /
+                                   ;; `H*`) inside its owning compound — NOT a
+                                   ;; clickable state box. The renderer
+                                   ;; (`chart.nodes/history-marker`) was a
+                                   ;; registered HOOK; this is the projector
+                                   ;; path that finally emits it.
+                                   (:history? n)  "history-marker"
                                    region?        "parallel-region"
                                    (:compound? n) "compound"
                                    :else          "state")
@@ -763,6 +776,13 @@
                                           ;; the state declares none.
                                           :entry          (:entry n)
                                           :exit           (:exit n)
+                                          ;; rf2-m285a — a `:type :history`
+                                          ;; pseudo-state's variant. The
+                                          ;; `history-marker` renderer reads
+                                          ;; `(.-deep props)`: deep history
+                                          ;; paints `H*`, shallow `H`
+                                          ;; (Spec 005 §History states).
+                                          :deep           (boolean (:deep? n))
                                           :chart          chart
                                           :palette        ct}
                                    ;; rf2-34ff3 — `:onClick` (on-state-click)
@@ -781,8 +801,15 @@
                                    ;; they carry no `:onClick` the renderer
                                    ;; would never consume — the inverse of the
                                    ;; original half-wired bug.
+                                   ;; rf2-m285a — a `:type :history`
+                                   ;; pseudo-state is also NOT an
+                                   ;; on-state-click target: it is never
+                                   ;; occupied, so there is no state to select
+                                   ;; (same inert-synthetic-chip posture as the
+                                   ;; machine-root / parallel-root anchors).
                                    (not (or (:machine-root? n)
                                             (:parallel-root? n)
+                                            (:history? n)
                                             region?))
                                    (assoc :onClick on-state-click)
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -121,6 +121,17 @@
        (seq v)
        (every? keyword? v)))
 
+(defn- history-node?
+  "rf2-m285a — true when a node under a compound's `:states` is a
+  `:type :history` PSEUDO-STATE (Spec 005 §History states), not an
+  ordinary occupiable substate. A history pseudo-state is never active:
+  a transition *to* it resolves to the compound's recorded / default
+  leaf. Pre-fix the Mermaid emitter rendered it as a bare leaf id in
+  incoming edges with no declaration, so it read as an ordinary state."
+  [state-node]
+  (and (map? state-node)
+       (= :history (:type state-node))))
+
 (defn- escape-id-segment
   "Escape one keyword ns/name part INJECTIVELY into a Mermaid-id-safe
   string: every char outside `[A-Za-z0-9]` becomes `_<2-hex>` (the
@@ -533,13 +544,38 @@
     (str indent "state \"" (sanitise-state-label label) "\" as "
          (sanitise-id state-path))))
 
+(defn- render-history-marker
+  "rf2-m285a — declare a `:type :history` pseudo-state inside its owning
+  compound block (Spec 005 §History states). Mermaid `stateDiagram-v2`
+  has no portable native history glyph (the `[H]` form is spottily
+  rendered across Mermaid versions / consumers), so — same lossy-static
+  posture the emitter takes elsewhere — we declare a labelled alias node
+  (`H` shallow / `H*` deep) so incoming `:target :hist` edges land on a
+  node that READS as a history marker, not an ordinary state. A
+  `:default-target` rides a `%% comment` so the default config is visible
+  without re-running the machine."
+  [state-path state-node depth]
+  (let [indent (apply str (repeat depth "  "))
+        glyph  (if (:deep? state-node) "H*" "H")
+        dt     (:default-target state-node)]
+    (cond-> [(str indent "state \"" glyph "\" as " (sanitise-id state-path))]
+      (some? dt)
+      (conj (str indent "%% history default-target: "
+                 (if (vector? dt)
+                   (str/join "/" (map keyword-label dt))
+                   (label-value dt)))))))
+
 (defn- render-state-block
   "Render a compound state's `state X { ... }` block (Mermaid
   nesting). Returns a sequence of lines (indented at `depth`).
 
   Leaf states do not need an explicit declaration in Mermaid — they
   appear inline in their outbound edges. We only emit blocks for
-  compound states."
+  compound states.
+
+  rf2-m285a — a `:type :history` child is declared as a labelled history
+  marker (`render-history-marker`) so an incoming `:target :hist` edge
+  lands on a node that reads as a history pseudo-state."
   [state-path state-node depth]
   (let [indent     (apply str (repeat depth "  "))
         children   (:states state-node)
@@ -550,9 +586,12 @@
        (when sub-initial
          [(str indent "  [*] --> " (sanitise-id (conj state-path sub-initial)))])
        (mapcat (fn [[child-id child-node]]
-                 (render-state-block (conj state-path child-id)
-                                     child-node
-                                     (inc depth)))
+                 (let [child-path (conj state-path child-id)]
+                   (if (history-node? child-node)
+                     (render-history-marker child-path child-node (inc depth))
+                     (render-state-block child-path
+                                         child-node
+                                         (inc depth)))))
                children)
        [(str indent "}")]))))
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -45,6 +45,7 @@
   | `:after {ms :target}`                 | `<transition event=\"after.ms\" target=\"target\"/>` |
   | `:always [...]`                       | `<transition target=\"...\"/>` (eventless) |
   | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
+  | `{:type :history :deep? <b> :default-target <t>}` (rf2-m285a) | W3C `<history type=\"shallow\\|deep\">` inside the owning compound; a `:default-target` rides a default `<transition target=\"…\"/>`. Round-trips back to `:type :history`. A history pseudo-state is NEVER occupiable — it is a transition TARGET that resolves to the recorded/default leaf — so it emits `<history>`, never `<state>`/`<final>`. |
   | Namespaced ids (`:auth/login`)        | `auth__login` (hex-escaped; `__` separates ns/name) |
   | Multi-dot-ns ids (`:my.app/login`)    | `my_2eapp__login` (dots in the ns are escaped to `_2e`) |
   | Vector-path targets (`[:parent :child]`) | `parent___child` (`___` joins path segments) |
@@ -83,7 +84,12 @@
   - `:action`s and guard FN bodies — only the *names* survive (SCXML
     `cond=\"name\"` for guards; a transition `:action` name rides an
     `<!-- action: name -->` comment, the only SCXML-tolerable slot, since
-    SCXML proper has no transition-action-id attribute). The action name
+    SCXML proper has no transition-action-id attribute). An INLINE-FN
+    `:guard` / `:action` (the Spec 005 escape hatch) is LOSSY-not-crash
+    (rf2-m285a): `ref->label` surfaces the fn's `:name` meta or a stable
+    `\"fn\"` fallback (consistent with chart/Mermaid; matches the API
+    promise that fn bodies are lossy, not unsupported) — it does NOT
+    round-trip back to the original fn. The action name
     **round-trips** (rf2-mnp93.5): `scxml->spec` lifts the action comment
     back into the candidate's `:action` BEFORE comments are stripped, so an
     internal `:on {:tick {:action :log}}` returns `{:action :log}` — a valid
@@ -198,6 +204,29 @@
     (str (escape-id-segment ns) ns-name-sep (escape-id-segment (name k)))
     (escape-id-segment (name k))))
 
+(defn- ref->label
+  "rf2-m285a — render a transition `:guard` / `:action` REF as an SCXML
+  attribute label, tolerating inline fns the SAME way `chart/layout` +
+  `mermaid` already do.
+
+  A keyword ref keeps the injective, round-tripping `keyword->id-string`
+  codec (the supported subset). An INLINE FN ref is LOSSY by design — the
+  machine grammar permits `:guard (fn …)` / `:action (fn …)` (Spec 005
+  §Guards / §Actions), and the API promise is that fn BODIES are
+  lossy/opaque, NOT unsupported. Pre-fix, `spec->scxml` passed the fn
+  straight to `keyword->id-string`, which calls `(namespace f)` on it and
+  throws a `ClassCastException` — crashing SCXML export for a valid
+  machine. We instead surface the fn's `:name` meta (a named
+  `(fn name […] …)` / `defn`) or a stable `\"fn\"` fallback, mirroring
+  `chart/layout/name-of`. No attempt is made to serialise the executable
+  body."
+  [ref]
+  (cond
+    (keyword? ref) (keyword->id-string ref)
+    (fn? ref)      (or (some-> ref meta :name str) "fn")
+    (nil? ref)     nil
+    :else          (str ref)))
+
 (defn- path->id-string
   "Map a re-frame2 id (keyword or vector path) to a single SCXML id
   string. A keyword uses `keyword->id-string`; a vector path joins its
@@ -274,6 +303,16 @@
   [v]
   (and (vector? v) (seq v) (every? keyword? v)))
 
+(defn- history-node?
+  "rf2-m285a — true when a node under a compound's `:states` is a
+  `:type :history` PSEUDO-STATE (Spec 005 §History states). W3C SCXML has
+  a first-class `<history>` element; pre-fix `emit-state` emitted a
+  `<state>` / `<final>` for it (losing the history semantics on export
+  AND making round-trip produce a DIFFERENT machine)."
+  [state-node]
+  (and (map? state-node)
+       (= :history (:type state-node))))
+
 (defn- parent-path [path] (if (seq path) (pop path) []))
 
 (defn- resolve-target-path
@@ -303,14 +342,18 @@
         parts (cond-> []
                 event-name (conj (str "event=\"" (escape-xml-attr event-name) "\""))
                 target-id  (conj (str "target=\"" (escape-xml-attr target-id) "\""))
-                guard      (conj (str "cond=\"" (escape-xml-attr (keyword->id-string guard)) "\"")))
+                ;; rf2-m285a — `ref->label` tolerates an inline-fn guard
+                ;; (lossy name/`fn` label) instead of crashing in
+                ;; `keyword->id-string` on a non-keyword.
+                guard      (conj (str "cond=\"" (escape-xml-attr (ref->label guard)) "\"")))
         attrs (str/join " " parts)
         self-close? (nil? action)]
     (str (indent-str depth)
          (if self-close?
            (str "<transition " attrs "/>")
            (str "<transition " attrs ">"
-                "<!-- action: " (escape-xml-attr (keyword->id-string action)) " -->"
+                ;; rf2-m285a — likewise tolerate an inline-fn action.
+                "<!-- action: " (escape-xml-attr (ref->label action)) " -->"
                 "</transition>")))))
 
 (defn- emit-transitions-for-on
@@ -350,10 +393,42 @@
   (->> (transition-candidates on-done)
        (map #(emit-transition done-event % source-path depth))))
 
+(defn- emit-history
+  "rf2-m285a — emit a W3C SCXML `<history>` pseudo-state element for a
+  re-frame2 `:type :history` node (Spec 005 §History states). `path` is
+  the history node's absolute path (its unique xsd:ID).
+
+  W3C SCXML §3.10: `<history type=\"shallow|deep\">` carries an OPTIONAL
+  default `<transition target=\"…\"/>` used when the parent has no stored
+  configuration — the exact semantics of re-frame2's `:default-target`
+  (Spec 005: the target when the compound was never entered). A `:deep?
+  true` node emits `type=\"deep\"`; shallow / absent emits
+  `type=\"shallow\"`. The `:default-target` resolves relative to the
+  history node's own level (a keyword target is a sibling — i.e. a direct
+  child of the owning compound — per Spec 005), path-qualified to the
+  destination's unique id (rf2-mnp93.7), and round-trips back via
+  `decode-target`."
+  [path {:keys [deep? default-target]} depth]
+  (let [id-str    (qualified-id path)
+        type-str  (if deep? "deep" "shallow")
+        attrs     (str "id=\"" (escape-xml-attr id-str) "\""
+                       " type=\"" type-str "\"")
+        target-id (when default-target
+                    (qualified-id (resolve-target-path path default-target)))]
+    (if target-id
+      [(str (indent-str depth) "<history " attrs ">")
+       (str (indent-str (inc depth))
+            "<transition target=\"" (escape-xml-attr target-id) "\"/>")
+       (str (indent-str depth) "</history>")]
+      [(str (indent-str depth) "<history " attrs "/>")])))
+
 (defn- emit-state
   "Emit a `<state>` (or `<final>`) block for one state-node. `path` is
   the absolute path (root → this state) used to emit unique xsd:IDs and
-  to qualify transition targets (rf2-mnp93.7)."
+  to qualify transition targets (rf2-mnp93.7).
+
+  rf2-m285a — a `:type :history` child of this state is emitted as a W3C
+  `<history>` element (`emit-history`), NOT a nested `<state>`."
   [path state-node depth]
   (let [{:keys [final? initial states on after always on-done]} state-node
         id-str (qualified-id path)
@@ -374,7 +449,11 @@
             (emit-transitions-for-on-done (str "done.state." id-str)
                                           on-done path (inc depth)))
           (mapcat (fn [[child-id child-node]]
-                    (emit-state (conj (vec path) child-id) child-node (inc depth)))
+                    ;; rf2-m285a — a `:type :history` child is a W3C
+                    ;; `<history>` pseudo-state, not a nested `<state>`.
+                    (if (history-node? child-node)
+                      (emit-history (conj (vec path) child-id) child-node (inc depth))
+                      (emit-state (conj (vec path) child-id) child-node (inc depth))))
                   states))]
     (if (seq children)
       (concat [(str (indent-str depth) "<" tag " " attrs ">")]
@@ -900,6 +979,30 @@
           :else
           (recur (rest remaining) acc))))))
 
+(defn- parse-history-block
+  "rf2-m285a — parse a W3C SCXML `<history>` pseudo-state element back into
+  a re-frame2 `[state-id {:type :history …}]` node (Spec 005 §History
+  states). `type=\"deep\"` ⇒ `:deep? true`; `type=\"shallow\"` (or absent)
+  ⇒ `:deep? false`. An OPTIONAL child default `<transition target=\"…\"/>`
+  (W3C SCXML §3.10) round-trips to `:default-target`, decoded back to its
+  relative grammar form (sibling keyword / absolute vector) via
+  `decode-target` — the exact inverse of `emit-history`."
+  [{:keys [start body self?]}]
+  (let [attrs      (:attrs start)
+        id-str     (get attrs "id")
+        abs-path   (id-string->abs-path id-str)
+        state-id   (abs-path->local-key abs-path)
+        deep?      (= "deep" (get attrs "type"))
+        ;; The default transition is the SINGLE direct-child <transition>
+        ;; of the <history> element (target-only — no event / guard).
+        default-tt (when-not self?
+                     (let [t (->> (direct-transitions body)
+                                  (some #(get-in % [:attrs "target"])))]
+                       (when t (decode-target t abs-path))))
+        node (cond-> {:type :history :deep? deep?}
+               (some? default-tt) (assoc :default-target default-tt))]
+    [state-id node]))
+
 (defn- parse-state-block
   "Parse one `<state>` / `<final>` block into a `[state-id state-node]`
   pair. `self?` indicates a self-closing tag with no children.
@@ -907,9 +1010,14 @@
   rf2-mnp93.7 — `id` is a FULLY-QUALIFIED unique xsd:ID (the state's
   absolute path). The LOCAL `:states` key is its last segment; the
   state's absolute path is threaded down so child transitions decode
-  their qualified targets back to the relative grammar form."
-  [{:keys [start body self?]}]
-  (let [tag        (:tag start)
+  their qualified targets back to the relative grammar form.
+
+  rf2-m285a — a `<history>` pseudo-state child is routed to
+  `parse-history-block` (it is `:type :history`, not an ordinary state)."
+  [{:keys [start body self?] :as block}]
+  (if (= "history" (:tag start))
+    (parse-history-block block)
+   (let [tag        (:tag start)
         attrs      (:attrs start)
         id-str     (get attrs "id")
         initial-str (get attrs "initial")
@@ -940,7 +1048,7 @@
                    ;; `seq`-test; use the key's presence).
                    (contains? consumed :on-done) (assoc :on-done (:on-done consumed))
                    (seq child-states) (assoc :states child-states))]
-        [state-id node]))))
+        [state-id node])))))
 
 (defn- parse-parallel-body
   "Parse the children of a `<parallel>` element into a `:regions`

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -169,6 +169,82 @@
       bare)))
 
 ;; ---------------------------------------------------------------------------
+;; Structural definition sanitisation (rf2-m285a)
+;;
+;; `strip-meta` drops Clojure METADATA only. But a macro-stamped machine
+;; spec (Spec 005 §Source-coord stamping) carries debug/source as ordinary
+;; DATA *values* inside `:states`, NOT as metadata:
+;;
+;;   - every `:states`-tree map node (state-node / transition map / `:spawn`
+;;     map) carries `:source-coords {:ns … :file "…/login.cljs" :line … :column …}`;
+;;   - `:guards` / `:actions` / `:on-spawn-actions` entries are
+;;     `{<id> {:fn <compiled-fn> :source-coords … :source-code "(fn …)"}}`;
+;;   - inline `:guard` / `:action` / `:entry` / `:exit` slots may hold a LIVE
+;;     fn value.
+;;
+;; So `strip-meta` left local-FILESYSTEM paths + source snippets in the
+;; payload (a privacy-contract leak — Principles §No session data in shares),
+;; and a live `:fn` value can make Transit encoding FAIL outright. We sanitise
+;; the definition STRUCTURALLY before validation / Transit:
+;;
+;;   - recursively DROP `:source-coords` / `:source-code` everywhere;
+;;   - DROP executable `:fn` values (the `{<id> {:fn …}}` entry collapses to a
+;;     names-only marker — the topology reference by id survives);
+;;   - replace any remaining LIVE fn value (an inline `:guard` / `:action` /
+;;     `:entry` / `:exit`) with an opaque `:fn` LABEL marker so the viewer-safe
+;;     payload encodes (and shows the slot is fn-backed) without serialising a
+;;     body Transit cannot encode.
+
+(def ^:private source-debug-keys
+  "Reference-site debug fields the macro co-locates inside `:states` /
+  `:guards` / `:actions` / `:on-spawn-actions` (Spec 005 §Source-coord
+  stamping). Stripped wholesale from a share payload."
+  #{:source-coords :source-code})
+
+(def ^:private fn-label-marker
+  "rf2-m285a — opaque marker substituted for a LIVE fn value so the payload
+  encodes (Transit cannot serialise an arbitrary fn) and the viewer still
+  sees the slot is fn-backed. Names-only — no executable body, no source."
+  :rf.machines-viz.share/fn)
+
+(defn- fn-name-label
+  "rf2-m285a — a names-only label for a fn ref: its `:name` meta when named,
+  else the opaque `fn-label-marker`. Never serialises the body."
+  [f]
+  (or (when-let [n (some-> f meta :name)]
+        (keyword "rf.machines-viz.share" (str "fn-" (name n))))
+      fn-label-marker))
+
+(defn- sanitise-definition
+  "rf2-m285a — recursively rewrite a (possibly macro-stamped) machine
+  definition into a viewer-safe topology payload: drop `:source-coords` /
+  `:source-code`, drop executable `:fn` values, and replace any live fn slot
+  with an opaque label. Preserves all topology references (state ids,
+  targets, guard/action NAMES via their map keys). Pure structural walk."
+  [x]
+  (cond
+    (fn? x) (fn-name-label x)
+
+    (map? x)
+    (into (empty x)
+          (keep (fn [[k v]]
+                  (cond
+                    ;; Drop reference-site source/debug fields entirely.
+                    (contains? source-debug-keys k) nil
+                    ;; Drop the executable fn off a `:guards`/`:actions`/
+                    ;; `:on-spawn-actions` entry (or any co-located `:fn`):
+                    ;; the entry's KEY already carries the name the topology
+                    ;; references; the body is lossy by contract.
+                    (= :fn k)                        nil
+                    :else [k (sanitise-definition v)]))
+                x))
+
+    (set? x)    (into #{} (map sanitise-definition x))
+    (vector? x) (mapv sanitise-definition x)
+    (seq? x)    (map sanitise-definition x)
+    :else       x))
+
+;; ---------------------------------------------------------------------------
 ;; Schema validation — narrow allowlist
 ;;
 ;; ChartState:
@@ -283,12 +359,19 @@
   "Project `chart-state` onto the ChartState allowlist, dropping every
   key outside it — including any runtime `:data` riding on `:snapshot`
   and any `:source-coords` the caller passed. The definition is
-  metadata-stripped here (macro-captured source coords must not leak)."
+  metadata-stripped AND structurally sanitised here (rf2-m285a): a
+  macro-stamped spec carries `:source-coords` / `:source-code` and
+  executable `:fn` values as ordinary DATA inside `:states` / `:guards` /
+  `:actions` / `:on-spawn-actions` — `strip-meta` (metadata only) does not
+  reach them, so `sanitise-definition` recursively drops the source/debug
+  fields + executable fns (local-filesystem paths must not leak per
+  Principles §No session data in shares, and a live fn would make Transit
+  encoding fail)."
   [chart-state]
   (let [{:keys [machine-id frame-id definition snapshot]} chart-state]
     (cond-> {:machine-id machine-id
              :frame-id   frame-id
-             :definition (strip-meta definition)}
+             :definition (-> definition strip-meta sanitise-definition)}
       ;; :snapshot is allowlisted to :state ONLY — runtime :data and any
       ;; other snapshot key are dropped here structurally even if the
       ;; caller passed a full snapshot. The :state VALUE (a flat keyword,

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -207,6 +207,69 @@
           region (node-by-id graph (layout/region-node-id :audio))]
       (is (= "parallel-region" (:type region))))))
 
+;; ---- history pseudo-state projection (rf2-m285a) -----------------------
+
+(def shallow-history-machine
+  "rf2-m285a — a compound with a SHALLOW `:type :history` pseudo-state
+  targeted by an outer transition."
+  {:initial :off
+   :states  {:off    {:on {:resume [:player :hist]}}
+             :player {:initial :stopped
+                      :states  {:stopped {:on {:play :playing}}
+                                :playing {:on {:stop :stopped}}
+                                :hist    {:type :history :deep? false}}
+                      :on      {:power-off :off}}}})
+
+(def deep-history-machine
+  (assoc-in shallow-history-machine [:states :player :states :hist]
+            {:type :history :deep? true :default-target :playing}))
+
+(deftest xyflow-graph-history-node-type
+  (testing "rf2-m285a — a `:type :history` pseudo-state projects as a
+            `history-marker`-type node, NOT a `state`"
+    (let [parsed (layout/parse-definition shallow-history-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          hist   (node-by-id graph (layout/node-id [:player :hist]))]
+      (is (some? hist) "the history node is present in the projection")
+      (is (= "history-marker" (:type hist))
+          "it projects to the registered history-marker node-type")
+      (is (false? (:deep (:data hist)))
+          "shallow history threads :deep false to the renderer"))))
+
+(deftest xyflow-graph-deep-history-node
+  (testing "rf2-m285a — a DEEP history pseudo-state threads :deep true"
+    (let [parsed (layout/parse-definition deep-history-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          hist   (node-by-id graph (layout/node-id [:player :hist]))]
+      (is (= "history-marker" (:type hist)))
+      (is (true? (:deep (:data hist)))))))
+
+(deftest history-node-is-not-occupiable
+  (testing "rf2-m285a — a history pseudo-state is NEVER occupiable: not
+            initial / final / compound, and not an on-state-click target"
+    (let [parsed (layout/parse-definition shallow-history-machine)
+          ;; the parsed node (pre-projection) carries the pseudo-state flags
+          hist-n (first (filter #(= [:player :hist] (:path %)) (:nodes parsed)))]
+      (is (true? (:history? hist-n)))
+      (is (false? (:initial? hist-n)) "never initial")
+      (is (false? (:final? hist-n))   "never final")
+      (is (false? (:compound? hist-n)) "never compound"))
+    (let [graph (projection/xyflow-graph (layout/parse-definition shallow-history-machine) {} {})
+          hist  (node-by-id graph (layout/node-id [:player :hist]))]
+      (is (nil? (:onClick (:data hist)))
+          "a history marker carries no on-state-click handler"))))
+
+(deftest history-node-keeps-incoming-edge
+  (testing "rf2-m285a — a transition targeting the history pseudo-state keeps
+            its incoming edge (the marker is a legitimate transition target),
+            sourced from the off state's event node"
+    (let [parsed (layout/parse-definition shallow-history-machine)
+          ;; one parsed edge :resume from :off → [:player :hist]
+          resume (first (filter #(= [:player :hist] (:to-path %)) (:edges parsed)))]
+      (is (some? resume) "the :resume → :hist edge is projected")
+      (is (= (layout/node-id [:player :hist]) (:target resume))
+          "the edge target is the history marker's node id"))))
+
 ;; ---- error-final KIND threading + composition (rf2-b4loj) --------------
 ;;
 ;; An `:error?` final (Spec 005 §:final?) is a re-frame2 EXTENSION routing

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
@@ -206,3 +206,50 @@
       (is (str/includes? out (str "start --> " (layout/node-id [:a/b])  " : one")))
       (is (str/includes? out (str "start --> " (layout/node-id [:a-b])  " : two")))
       (is (str/includes? out (str "start --> " (layout/node-id [:a_b])  " : three"))))))
+
+;; ---------------------------------------------------------------------------
+;; G9 — history pseudo-states agree across the three emitters (rf2-m285a).
+;; A `:type :history` node must surface as a HISTORY pseudo-state in every
+;; emitter (NOT an ordinary occupiable state): chart → `history-marker` node,
+;; mermaid → labelled `H`/`H*` marker, SCXML → `<history>` element. Pre-fix all
+;; three rendered it as a normal state/edge — three emitters mis-teaching the
+;; same topology.
+
+(def deep-history-machine
+  {:initial :off
+   :states  {:off    {:on {:resume [:player :hist]}}
+             :player {:initial :stopped
+                      :states  {:stopped {:on {:play :playing}}
+                                :playing {:on {:stop :stopped}}
+                                :hist    {:type :history :deep? true}}
+                      :on      {:power-off :off}}}})
+
+(deftest history-pseudo-state-agrees-across-emitters
+  (testing "rf2-m285a — a `:type :history` node surfaces as a history
+            pseudo-state in chart, mermaid, AND SCXML (never an ordinary
+            occupiable state)"
+    ;; CHART — a `history-marker`-flagged, non-occupiable node.
+    (let [hist (->> (layout/parse-definition deep-history-machine)
+                    :nodes
+                    (filter #(= [:player :hist] (:path %)))
+                    first)]
+      (is (true? (:history? hist)) "chart parses it as a history pseudo-state")
+      (is (true? (:deep? hist))    "deep variant preserved")
+      (is (false? (:final? hist))  "never final")
+      (is (false? (:compound? hist)) "never compound"))
+    ;; MERMAID — labelled H* marker, not a bare leaf id / final edge.
+    (let [out (mermaid/emit deep-history-machine {:fenced? false :header-comment? false})]
+      (is (str/includes? out "state \"H*\" as player__hist")
+          "mermaid declares the deep-history H* marker")
+      (is (not (str/includes? out "player__hist --> [*]"))
+          "mermaid does not render it as a final state"))
+    ;; SCXML — a <history type="deep"> element, not <state>/<final>.
+    (let [out (scxml/spec->scxml deep-history-machine)]
+      (is (str/includes? out "<history ") "scxml emits a <history> element")
+      (is (str/includes? out "type=\"deep\"") "deep variant preserved")
+      (is (not (re-find #"<state id=\"player___hist\"" out))
+          "scxml does NOT emit it as an occupiable <state>"))
+    ;; SCXML round-trips back to `:type :history` (not a state).
+    (let [back (-> deep-history-machine scxml/spec->scxml scxml/scxml->spec)]
+      (is (= :history (get-in back [:states :player :states :hist :type]))
+          "round-trips back to a :type :history pseudo-state"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/mermaid_cljs_test.cljc
@@ -550,3 +550,58 @@
           "compound id: hyphen → _2d, single __ is the path separator")
       (is (str/includes? out "right__child_2dnode")
           "the two same-named child-node leaves stay DISTINCT (path-qualified)"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-m285a — `:type :history` pseudo-states render as a LABELLED history
+;; marker (`H` shallow / `H*` deep) inside the owning compound, NOT as an
+;; ordinary bare-id leaf state in incoming edges.
+
+(def shallow-history-machine
+  {:initial :off
+   :states  {:off    {:on {:resume [:player :hist]}}
+             :player {:initial :stopped
+                      :states  {:stopped {:on {:play :playing}}
+                                :playing {:on {:stop :stopped}}
+                                :hist    {:type :history :deep? false}}
+                      :on      {:power-off :off}}}})
+
+(def deep-history-machine
+  (assoc-in shallow-history-machine [:states :player :states :hist]
+            {:type :history :deep? true}))
+
+(def default-target-history-machine
+  (assoc-in shallow-history-machine [:states :player :states :hist]
+            {:type :history :deep? false :default-target :playing}))
+
+(deftest emit-history-marker-shallow
+  (testing "rf2-m285a — a SHALLOW history pseudo-state declares a labelled
+            `H` marker inside its owning compound block"
+    (let [out (m/emit shallow-history-machine {:fenced? false :header-comment? false})]
+      (is (str/includes? out "state \"H\" as player__hist")
+          "the history node is declared as a labelled `H` marker, not a bare state")
+      ;; the incoming edge still lands on the marker id
+      (is (str/includes? out "player__hist")
+          "incoming :target :hist edge targets the marker"))))
+
+(deftest emit-history-marker-deep
+  (testing "rf2-m285a — a DEEP history pseudo-state declares `H*`"
+    (let [out (m/emit deep-history-machine {:fenced? false :header-comment? false})]
+      (is (str/includes? out "state \"H*\" as player__hist")
+          "deep history renders the H* glyph"))))
+
+(deftest emit-history-default-target-note
+  (testing "rf2-m285a — a history :default-target surfaces as a documenting
+            %% comment so the default config is visible"
+    (let [out (m/emit default-target-history-machine {:fenced? false :header-comment? false})]
+      (is (str/includes? out "state \"H\" as player__hist"))
+      (is (str/includes? out "%% history default-target: playing")
+          "the default-target rides a %% comment"))))
+
+(deftest emit-history-not-an-ordinary-final-or-state-decl
+  (testing "rf2-m285a — the history node never appears as a `--> [*]` final
+            edge nor a `state X { }` compound block"
+    (let [out (m/emit shallow-history-machine {:fenced? false :header-comment? false})]
+      (is (not (str/includes? out "player__hist --> [*]"))
+          "a history pseudo-state is not a final state")
+      (is (not (str/includes? out "state player__hist {"))
+          "a history pseudo-state is not a compound block"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -742,3 +742,166 @@
           back (-> spec scxml/spec->scxml scxml/scxml->spec)]
       (is (= {} (get-in back [:states :a :on :tick]))
           "an empty-map forbidden block survives as `{}`, not invented an action"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-m285a — `:type :history` pseudo-states export as W3C `<history>`
+;; (NOT `<state>` / `<final>`), preserving the shallow / deep / default-target
+;; semantics, and round-trip back to `:type :history` nodes.
+
+(def shallow-history-machine
+  "Compound with a SHALLOW `:type :history` pseudo-state targeted by an
+  outer transition. The history node is NEVER occupiable — a transition
+  to `:hist` resolves to the compound's recorded direct child at runtime.
+  Uses the normalised `:deep? false` shape `rf/machine-meta` returns (an
+  absent `:deep?` reads as shallow per Spec 005; SCXML's `<history>`
+  always carries an explicit `type`, so the decode is `:deep? false`)."
+  {:initial :off
+   :states  {:off    {:on {:resume [:player :hist]}}
+             :player {:initial :stopped
+                      :states  {:stopped {:on {:play :playing}}
+                                :playing {:on {:stop :stopped}}
+                                :hist    {:type :history :deep? false}}
+                      :on      {:power-off :off}}}})
+
+(def deep-history-machine
+  "Compound with a DEEP history pseudo-state (`:deep? true`)."
+  {:initial :off
+   :states  {:off    {:on {:resume [:player :hist]}}
+             :player {:initial :stopped
+                      :states  {:stopped {:on {:play :playing}}
+                                :playing {:on {:stop :stopped}}
+                                :hist    {:type :history :deep? true}}
+                      :on      {:power-off :off}}}})
+
+(def default-target-history-machine
+  "History pseudo-state with an explicit `:default-target` (a sibling — a
+  direct child of the owning compound)."
+  {:initial :off
+   :states  {:off    {:on {:resume [:player :hist]}}
+             :player {:initial :stopped
+                      :states  {:stopped {:on {:play :playing}}
+                                :playing {:on {:stop :stopped}}
+                                :hist    {:type :history :deep? false
+                                          :default-target :playing}}
+                      :on      {:power-off :off}}}})
+
+(deftest history-exports-as-w3c-history-element
+  (testing "rf2-m285a — a SHALLOW history pseudo-state emits <history
+            type=\"shallow\">, NOT a <state>/<final>"
+    (let [xml (scxml/spec->scxml shallow-history-machine)]
+      (is (str/includes? xml "<history ")
+          "a <history> element is emitted")
+      (is (str/includes? xml "type=\"shallow\"")
+          "shallow history carries type=\"shallow\"")
+      ;; The history node id is the qualified path player___hist; assert it
+      ;; rides a <history>, never a <state>/<final> for that id.
+      (is (not (re-find #"<state id=\"player___hist\"" xml))
+          "the history node is NOT exported as an occupiable <state>")
+      (is (not (re-find #"<final id=\"player___hist\"" xml))
+          "the history node is NOT exported as a <final>")))
+
+  (testing "rf2-m285a — a DEEP history pseudo-state emits type=\"deep\""
+    (let [xml (scxml/spec->scxml deep-history-machine)]
+      (is (str/includes? xml "<history "))
+      (is (str/includes? xml "type=\"deep\""))))
+
+  (testing "rf2-m285a — a history :default-target rides a default
+            <transition target=...> inside the <history>"
+    (let [xml (scxml/spec->scxml default-target-history-machine)]
+      (is (str/includes? xml "<history "))
+      ;; the default-target :playing is a sibling — qualified id player___playing
+      (is (re-find #"<history[^>]*>\s*<transition target=\"player___playing\"/>" xml)
+          "the default transition targets the qualified default-target leaf"))))
+
+(deftest history-round-trips-to-type-history
+  (testing "rf2-m285a — a SHALLOW history pseudo-state round-trips to
+            `:type :history` (NOT an ordinary state)"
+    (let [back (-> shallow-history-machine scxml/spec->scxml scxml/scxml->spec)
+          hist (get-in back [:states :player :states :hist])]
+      (is (= :history (:type hist))
+          "the node decodes back to a :type :history pseudo-state")
+      (is (= false (:deep? hist))
+          "shallow ⇒ :deep? false")
+      (is (= shallow-history-machine back)
+          "exact value round-trip")))
+
+  (testing "rf2-m285a — a DEEP history pseudo-state round-trips with :deep? true"
+    (let [back (-> deep-history-machine scxml/spec->scxml scxml/scxml->spec)
+          hist (get-in back [:states :player :states :hist])]
+      (is (= :history (:type hist)))
+      (is (= true (:deep? hist)))
+      (is (= deep-history-machine back))))
+
+  (testing "rf2-m285a — a :default-target round-trips to its relative
+            (sibling-keyword) grammar form"
+    (let [back (-> default-target-history-machine scxml/spec->scxml scxml/scxml->spec)
+          hist (get-in back [:states :player :states :hist])]
+      (is (= :history (:type hist)))
+      (is (= :playing (:default-target hist))
+          "the default-target decodes back to the sibling keyword")
+      (is (= default-target-history-machine back))))
+
+  (testing "rf2-m285a — an absent `:deep?` exports as shallow and decodes to
+            the normalised `:deep? false` (Spec 005: absent ⇒ shallow)"
+    (let [spec {:initial :off
+                :states {:off    {:on {:resume [:player :hist]}}
+                         :player {:initial :stopped
+                                  :states  {:stopped {:on {:play :playing}}
+                                            :hist    {:type :history}}}}}
+          xml  (scxml/spec->scxml spec)
+          back (scxml/scxml->spec xml)
+          hist (get-in back [:states :player :states :hist])]
+      (is (str/includes? xml "type=\"shallow\"")
+          "an absent :deep? exports as type=\"shallow\"")
+      (is (= :history (:type hist)))
+      (is (= false (:deep? hist))
+          "decodes to the normalised :deep? false"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-m285a — SCXML export tolerates INLINE-FN guard / action refs
+;; (lossy name/`fn` label), instead of crashing in keyword->id-string.
+
+(deftest inline-fn-guard-action-does-not-crash
+  (testing "rf2-m285a — a NAMED inline-fn guard exports as a lossy name
+            label without throwing (chart/Mermaid already tolerate it)"
+    (let [guard-fn (with-meta (fn [_] true) {:name 'ready?})
+          spec     {:initial :a
+                    :states  {:a {:on {:go {:target :b :guard guard-fn}}}
+                              :b {}}}
+          xml      (scxml/spec->scxml spec)]
+      (is (string? xml) "export succeeds (no ClassCastException)")
+      (is (str/includes? xml "cond=\"ready?\"")
+          "the named fn surfaces its :name meta as the cond label")))
+
+  (testing "rf2-m285a — an ANONYMOUS inline-fn guard exports as the stable
+            `fn` fallback label without throwing"
+    (let [spec {:initial :a
+                :states  {:a {:on {:go {:target :b :guard (fn [_] true)}}}
+                          :b {}}}
+          xml  (scxml/spec->scxml spec)]
+      (is (string? xml))
+      (is (str/includes? xml "cond=\"fn\"")
+          "an anonymous fn falls back to the opaque \"fn\" label")))
+
+  (testing "rf2-m285a — an inline-fn ACTION exports as a lossy label
+            (action comment) without throwing"
+    (let [action-fn (with-meta (fn [_] {}) {:name 'log!})
+          spec      {:initial :a
+                     :states  {:a {:on {:tick {:action action-fn}}}
+                               :b {}}}
+          xml       (scxml/spec->scxml spec)]
+      (is (string? xml))
+      (is (str/includes? xml "<!-- action: log! -->")
+          "the named fn action surfaces its name in the action comment")))
+
+  (testing "rf2-m285a — guard + action BOTH inline fns on one transition
+            export without throwing"
+    (let [spec {:initial :a
+                :states  {:a {:on {:go {:target :b
+                                        :guard  (fn [_] true)
+                                        :action (fn [_] {})}}}
+                          :b {}}}
+          xml  (scxml/spec->scxml spec)]
+      (is (string? xml))
+      (is (str/includes? xml "cond=\"fn\""))
+      (is (str/includes? xml "<!-- action: fn -->")))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -271,6 +271,84 @@
       (is (not (str/includes? url "proj")) "the file path never reaches the bytes"))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-m285a — macro-stamped DATA (not metadata) sanitisation. A reg-machine
+;; macro co-locates `:source-coords` / `:source-code` + executable `:fn`
+;; values as ordinary DATA inside `:states` / `:guards` / `:actions` /
+;; `:on-spawn-actions` (Spec 005 §Source-coord stamping). `strip-meta` (which
+;; touches Clojure METADATA only) does NOT reach them, so the share encoder
+;; leaked local-filesystem paths + source snippets and could fail to encode a
+;; live `:fn`. `sanitise-definition` strips them structurally.
+
+(def macro-stamped-like-definition
+  "Mimics the reg-machine macro's dev-arm output: per-node `:source-coords`
+  inside `:states`, `:guards` / `:actions` entries carrying
+  `{:fn .. :source-coords .. :source-code ..}`, and inline live fns on
+  `:guard` / `:action`."
+  {:initial :idle
+   :guards  {:form-valid? {:fn            (fn [_] true)
+                           :source-coords {:ns 'app.login :file "/Users/mike/proj/login.cljs"
+                                           :line 47 :column 13}
+                           :source-code   "(fn [{data :data}] (valid? data))"}}
+   :actions {:commit      {:fn            (fn [_] {})
+                          :source-coords {:ns 'app.login :file "/Users/mike/proj/login.cljs"
+                                          :line 52 :column 13}
+                          :source-code   "(fn [{data :data}] {:fx [[:http ...]]})"}}
+   :states  {:idle {:on            {:submit {:target :done
+                                             :guard  :form-valid?
+                                             :action (fn [_] {})   ;; inline live fn
+                                             :source-coords {:ns 'app.login
+                                                             :file "/Users/mike/proj/login.cljs"
+                                                             :line 80 :column 23}}}
+                    :source-coords {:ns 'app.login :file "/Users/mike/proj/login.cljs"
+                                    :line 78 :column 11}}
+             :done {:final?        true
+                    :source-coords {:ns 'app.login :file "/Users/mike/proj/login.cljs"
+                                    :line 84 :column 11}}}})
+
+(deftest macro-stamped-source-coords-do-not-leak
+  (testing "rf2-m285a — nested :source-coords / :source-code on :states /
+            :guards / :actions are stripped before Transit (no local path leak)"
+    (let [cs   (assoc chart-state :definition macro-stamped-like-definition)
+          url  (share/encode-share-url cs)
+          back (:rf.machines-viz.share/chart (share/decode-share-url url))
+          dfn  (:definition back)]
+      ;; The encoded BYTES carry no local-filesystem path / source snippet.
+      (is (not (str/includes? url "Users")) "no local-filesystem path in the URL bytes")
+      (is (not (str/includes? url "proj"))  "no repo dir in the URL bytes")
+      ;; The decoded payload carries no debug/source fields anywhere.
+      (is (nil? (get-in dfn [:states :idle :source-coords])))
+      (is (nil? (get-in dfn [:states :idle :on :submit :source-coords])))
+      (is (nil? (get-in dfn [:states :done :source-coords])))
+      (is (nil? (get-in dfn [:guards :form-valid? :source-coords])))
+      (is (nil? (get-in dfn [:guards :form-valid? :source-code])))
+      (is (nil? (get-in dfn [:actions :commit :source-code])))
+      ;; Topology references survive: the transition target + guard NAME.
+      (is (= :done       (get-in dfn [:states :idle :on :submit :target])))
+      (is (= :form-valid? (get-in dfn [:states :idle :on :submit :guard])))
+      (is (true? (get-in dfn [:states :done :final?])))
+      ;; The guard / action ids survive (as keys) — names-only, no body.
+      (is (contains? (:guards dfn) :form-valid?))
+      (is (contains? (:actions dfn) :commit)))))
+
+(deftest macro-stamped-executable-fns-do-not-block-encoding
+  (testing "rf2-m285a — a live :fn on a guards/actions entry AND an inline-fn
+            action encode successfully (instead of crashing Transit) — the
+            executable body is dropped / labelled, not serialised"
+    (let [cs  (assoc chart-state :definition macro-stamped-like-definition)
+          url (share/encode-share-url cs)
+          dfn (:definition
+                (:rf.machines-viz.share/chart (share/decode-share-url url)))]
+      (is (string? url) "encoding succeeds")
+      ;; The :guards / :actions entries no longer carry an executable :fn.
+      (is (nil? (get-in dfn [:guards :form-valid? :fn])))
+      (is (nil? (get-in dfn [:actions :commit :fn])))
+      ;; The inline-fn :action slot was replaced by an opaque names-only label
+      ;; (not a live fn, not a source body).
+      (let [a (get-in dfn [:states :idle :on :submit :action])]
+        (is (not (fn? a)) "the inline fn was not serialised as an executable")
+        (is (keyword? a)  "it became an opaque label keyword")))))
+
+;; ---------------------------------------------------------------------------
 ;; Versioning + failure modes
 
 (deftest unknown-version-rejected


### PR DESCRIPTION
Fixes the 3 correctness-review findings in `tools/machines-viz` (rf2-m285a). XState v5 / SCXML is the gold standard — history pseudo-states now match v5 behaviour end-to-end.

## Finding 1 — history pseudo-states exported as ordinary states
`:type :history` pseudo-states (Spec 005 §History states) were parsed and exported as ordinary occupiable leaf states across all emitters. They are now first-class:

- **Parse** (`chart/layout.cljc`) — `collect-nodes` detects `:type :history` and emits a single non-occupiable marker `{:history? true :deep? <b> :default-target <t>}` (never initial / final / compound; declares no transitions; the machine's `:state` is never `[… :hist]`).
- **Projection** (`chart/projection.cljc`) — a `:history?` node maps to xyflow type `"history-marker"` (the previously-registered `chart.nodes/history-marker` HOOK now has a live projector path) and threads `:data {:deep …}`; it carries no `:onClick` (never occupied → not an on-state-click target). Incoming `:target :hist` edges are preserved.
- **Mermaid** (`mermaid.cljc`) — declares a labelled `H` (shallow) / `H*` (deep) marker inside the owning compound + a `%% history default-target:` comment, instead of a bare leaf id.
- **SCXML** (`scxml.cljc`) — exports a W3C `<history type="shallow|deep">` element with an optional default `<transition target="…"/>` for `:default-target`, never `<state>`/`<final>`; imports `<history>` back to a `:type :history` node. Round-trip is exact.

## Finding 2 — SCXML export crashed on inline-fn guard/action
`spec->scxml` passed `:guard`/`:action` straight to `keyword->id-string`, throwing `ClassCastException` for a valid machine using an inline-fn escape hatch (`:guard (fn …)`). A new `ref->label` tolerates fn refs as opaque/lossy labels (`:name` meta or stable `"fn"` fallback), consistent with the chart + Mermaid emitters and the API promise that fn bodies are lossy, not unsupported.

## Finding 3 — share encoder leaked macro-stamped source/fn DATA
`allowlist-chart-state` only `strip-meta`'d the definition, but the `reg-machine` macro stamps `:source-coords` / `:source-code` and executable `:fn` values as ordinary DATA inside `:states` / `:guards` / `:actions` / `:on-spawn-actions` (Spec 005 §Source-coord stamping) — `strip-meta` (metadata only) never reached them. So local-filesystem paths/source survived to Transit, and a live `:fn` could fail encoding. New `sanitise-definition` recursively drops `:source-coords` / `:source-code` + executable `:fn`, and replaces any inline-fn slot with a names-only opaque label. Topology references (state ids, transition targets, guard/action NAMES) survive.

## Machines-viz spec update
Updated the stale topology specs (finding 1 noted them stale, still claiming "no history in v1"):
- `spec/000-Vision.md` — "No history pseudo-states" divergence → "First-class history pseudo-states".
- `spec/001-Topology-Parity.md` — §1.4 history, the parity matrix row, the F8 row in the faithfulness table, and the verdict (two intentional divergences now, history removed).
- `spec/API.md` — pseudo-state rendering, SCXML supported-subset (history row + inline-fn lossy note), share-encoder sanitisation step.
SCXML ns docstring also updated (history mapping + inline-fn lossy posture).

## Quality gates
- `tools/machines-viz` artefact tests — `clojure -M:test`: **401 tests, 1264 assertions, 0 failures, 0 errors** (was 389/1206; +12 deftests covering shallow/deep/default-target history in chart projection / Mermaid / SCXML + round-trip, inline-fn guard/action export, share source/fn sanitisation, and three-emitter history agreement).
- `cd implementation && npm run test:cljs` (Node CLJS suite — exercises machines-viz share/scxml/mermaid/projection there): **5769 tests, 20291 assertions, 0 failures, 0 errors**.

Closes rf2-m285a.