### PR TITLE
fix(story): thread run-opts into plan compilation + clear stale overrides on URL hydration (rf2-2cpoo)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -452,6 +452,24 @@ The plan compiler MUST resolve `[:arg key]` placeholders before
 execution. If a placeholder references a missing arg, plan construction
 MUST fail. `explain` MUST show arg substitutions.
 
+**Run opts feed the SAME effective args the result reports.** The
+effective args are the full precedence chain
+`global < story < active-modes < variant < cell-overrides`
+(`re-frame.story.args/resolve-args`). The runner threads the per-run
+layers — the UI/test surfaces' `:active-modes` and `:cell-overrides` —
+INTO plan compilation (the `:run-args` compiler input), so the substituted
+`[:arg key]` placeholders in **setup, script, db-seed, network replies, and
+sub-overrides**, the `[:world :args]` / `[:world :effective-args]` slots,
+AND the `:plan-hash` all use the SAME effective args the run-result reports
+under `:effective-args`. A cell override or an active mode therefore
+executes the EXACT scenario the result claims — the runner never substitutes
+the static variant args while reporting the override/mode-aware ones
+(rf2-2cpoo). The runtime executes `[:world :scripts]` (the normalized plays),
+so those plays carry the resolved placeholders, not the raw `[:arg …]` forms.
+(`render-variant` keeps its own post-compile path: it layers
+`:control-overrides` on top of the plan-time effective args and re-resolves
+sub-overrides, because rendering does not execute setup/script/db-seed.)
+
 `:effective-args` (the args after control-panel overrides) is a
 first-class plan field, and `(story/render-variant target opts)` renders
 the workshop view from the **same plan** the runner consumes. The live

--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -204,6 +204,13 @@ Share semantics:
   `[:cell-overrides <focused-variant>]` on both mount and back/forward
   (`re-frame.story.ui.url-state/apply-parsed-to-state`), so a pasted URL
   renders the same effective args, not just the selection (rf2-j0hwf);
+- the URL is AUTHORITATIVE for the focused variant's overrides: hydrating a
+  URL that keeps that variant but carries NO overrides CLEARS any stale
+  in-memory override slice for it (not merely skipping the write), so
+  back/forward, a bookmark, or a share link captured before a control edit
+  renders WITHOUT that edit — the address bar stays the source of truth.
+  Only the focused variant's slice is touched; other variants' overrides
+  are left intact (rf2-2cpoo);
 - a shared link restores VIEW STATE (it lands the recipient on the cell);
   it does not replay a run — that is the recorder's `:play-script` export;
 - the reproducibility status is computed (purely) by

--- a/tools/story/src/re_frame/story/args.cljc
+++ b/tools/story/src/re_frame/story/args.cljc
@@ -142,3 +142,47 @@
   call-out (`get-effective-args`). Same arguments, same return."
   ([variant-id] (resolve-args variant-id nil))
   ([variant-id opts] (resolve-args variant-id opts)))
+
+;; ---- ambient + run arg layers (rf2-2cpoo) ---------------------------------
+;;
+;; The plan compiler resolves the variant-CHAIN `:args` (the `:extends`-merged
+;; variant body args, the §Total resolution order variant layer) itself, but
+;; the AMBIENT layers (global-args, parent-story `:args`) and the per-RUN
+;; layers (active-modes' `:args`, the controls-panel `:cell-overrides`) live
+;; outside the variant body. `resolve-args` folds all five (`global <
+;; story-args < mode-args < variant-args < cell-overrides`); the plan compiler
+;; needs the four NON-variant layers, split around its own variant layer, so
+;; its `arg-map` — and therefore every `[:arg key]` substitution in
+;; setup/script/db-seed/network/sub-overrides, plus `[:world :effective-args]`
+;; and the plan hash — uses the SAME effective args the run/render surfaces
+;; report (rf2-2cpoo: the run path used to compile with the variant layer
+;; ALONE, so a cell override / active mode reported one effective-args while
+;; the executed plan substituted another).
+
+(defn run-arg-layers
+  "Return the AMBIENT + per-RUN arg layers (everything `resolve-args` folds
+  AROUND the variant layer), split into the `:pre`-variant and `:post`-variant
+  groups the plan compiler deep-merges around its own `:extends`-merged
+  variant `arg-map`:
+
+      :pre  [global-args story-args mode-args]   ; lower precedence than variant
+      :post [cell-overrides]                      ; higher precedence than variant
+
+  So the compiler's effective args are
+  `(deep-merge-all (concat pre [variant-chain-args] post))`, which equals
+  `resolve-args` for the SAME `:active-modes` / `:cell-overrides` whenever the
+  variant carries no `:extends` (and is the strictly-more-correct,
+  extends-aware variant layer when it does — the plan is the single source of
+  truth for the variant layer; this fn supplies only the layers it cannot see).
+
+  `opts` is `{:active-modes [...] :cell-overrides {...}}` — the SAME shape
+  `resolve-args` takes. Pure aside from the registrar/config reads `resolve-args`
+  already performs."
+  ([variant-id] (run-arg-layers variant-id nil))
+  ([variant-id {:keys [active-modes cell-overrides] :as _opts}]
+   (let [story-id   (parent-story-id variant-id)
+         story-body (when story-id (registrar/handler-meta :story story-id))]
+     {:pre  [(config/get-global-args)
+             (:args story-body)
+             (active-modes-args (or active-modes []))]
+      :post [(or cell-overrides {})]})))

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -1154,7 +1154,8 @@
   ([id body lookup] (compile-body id body lookup nil))
   ([id body lookup {:keys [view-lookup validator-fns sub-lookup
                            fragment-lookup check-lookup
-                           global-decorators story-decorators] :as _opts}]
+                           global-decorators story-decorators
+                           run-args] :as _opts}]
   (let [view-lookup  (coerce-kind-lookup :view-lookup view-lookup default-view-lookup)
         sub-lookup   (coerce-kind-lookup :sub-lookup sub-lookup default-sub-lookup)
         frag-lookup  (coerce-kind-lookup :fragment-lookup fragment-lookup
@@ -1256,7 +1257,28 @@
                        (reduce (fn [m l] (args/deep-merge m (get l k)))
                                {}
                                (concat inherited frag-layers [child])))
-        arg-map      (merge-key :args)
+        ;; The `:extends`-merged variant-CHAIN args (the §Total resolution
+        ;; order variant layer). This is the ONLY arg layer the plan body
+        ;; carries; the ambient (global / story) + per-run (active-modes /
+        ;; cell-overrides) layers live OUTSIDE the body and arrive via the
+        ;; `:run-args` opt (rf2-2cpoo).
+        variant-arg-map (merge-key :args)
+        ;; rf2-2cpoo — fold the ambient + per-run layers AROUND the variant
+        ;; layer so the effective `arg-map` (and therefore every `[:arg key]`
+        ;; substitution below, `[:world :args]` / `[:world :effective-args]`,
+        ;; and the plan hash) matches `args/resolve-args` for the SAME
+        ;; `:active-modes` / `:cell-overrides`. `:run-args` is the
+        ;; `{:pre [global story mode] :post [cell-overrides]}` shape
+        ;; `re-frame.story.args/run-arg-layers` produces: `:pre` is lower
+        ;; precedence than the variant layer, `:post` higher. Absent (a pure
+        ;; plan-compile / explain / render-prep with no run opts) ⇒ the
+        ;; variant layer alone, exactly as before.
+        arg-map      (if run-args
+                       (args/deep-merge-all
+                         (concat (:pre run-args)
+                                 [variant-arg-map]
+                                 (:post run-args)))
+                       variant-arg-map)
         argtypes     (merge-key :argtypes)
         ;; ---- arg substitution ----
         subs!        (atom [])
@@ -1267,6 +1289,18 @@
         ;; misplaced verdict surfaces before any run.
         _            (reject-assert-in-setup! id setup)
         script*      (substitute-args script arg-map subs!)
+        ;; rf2-2cpoo — the RUNTIME executes `[:world :scripts]` (the named
+        ;; plays from `normalize-scripts`), NOT the top-level `:script` slot.
+        ;; `normalize-scripts` ran on the RAW body, so each play's `:script`
+        ;; still carries unresolved `[:arg key]` placeholders. Substitute them
+        ;; against the SAME `arg-map` the top-level `:script` resolved against
+        ;; (which now folds the run-opts layers), so the executed plays use the
+        ;; effective args the result reports — not the raw placeholder. (Before
+        ;; this, `[:world :scripts]` was never `[:arg]`-substituted at all, so a
+        ;; `[:arg …]` in a script reached the dispatched event verbatim.)
+        scripts*     (mapv (fn [p]
+                             (update p :script substitute-args arg-map subs!))
+                           scripts)
         ;; rf2-5x1wt.18 — every authored assertion atom (terminal
         ;; `:assertions` AND an in-script `[:assert …]` checkpoint, incl.
         ;; the folded `:assert-db` / `:assert-dom` steps) MUST name a
@@ -1441,7 +1475,7 @@
                               :args           arg-map
                               :argtypes       argtypes
                               :effective-args eff-args
-                              :scripts        scripts
+                              :scripts        scripts*
                               :platforms      platforms}
                        (some? schema)        (assoc :view-args-schema schema)
                        (some? sub-overrides) (assoc-in [:render :sub-overrides] sub-overrides)
@@ -1620,6 +1654,17 @@
     `config/get-global-decorators`, and a `(story-id) → decorators-vec`
     lookup defaulting to the Story side-table `:story` kind. Pure tests
     thread explicit values; the live runtime uses the defaults.
+  - `:run-args` — the ambient + per-run arg layers to fold AROUND the
+    `:extends`-merged variant arg layer (rf2-2cpoo), in the
+    `{:pre [global story mode] :post [cell-overrides]}` shape
+    `re-frame.story.args/run-arg-layers` produces. With it the compiled
+    `[:world :args]` / `[:world :effective-args]`, every `[:arg key]`
+    substitution in setup/script/db-seed/network/sub-overrides, and the
+    plan hash all use the SAME effective args as `args/resolve-args` for
+    those `:active-modes` / `:cell-overrides`. Absent (a bare
+    compile / `explain` / render-prep) ⇒ the variant arg layer alone, so
+    the controls/render path keeps layering its overrides on top of the
+    plan-time effective args exactly as before.
 
   Returns the normalized plan map: `:variant/id`, `:source-chain`,
   `:world` (incl. `:effective-args` and `:view-args-schema` when a view
@@ -1639,7 +1684,8 @@
    (let [lookup-fn    (coerce-kind-lookup :lookup lookup default-lookup)
          compile-opts (select-keys opts [:view-lookup :validator-fns :sub-lookup
                                          :fragment-lookup :check-lookup
-                                         :global-decorators :story-decorators])]
+                                         :global-decorators :story-decorators
+                                         :run-args])]
      (cond
        (keyword? target)
        (if-let [body (lookup-fn target)]

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -708,8 +708,16 @@
   removed; phase-4 drives the rich-DSL step executor through
   `runner-events/run!`."
   [variant-id variant-body opts]
-  (let [{:keys [active-modes]} opts
-        plan (plan/variant-plan variant-id)]
+  (let [;; rf2-2cpoo — compile the plan WITH the per-run arg layers
+        ;; (`:active-modes` / `:cell-overrides`) so the substituted
+        ;; setup/script/db-seed/network/sub-overrides, `[:world :effective-args]`,
+        ;; and the plan hash all use the SAME effective args the result
+        ;; reports. Previously the plan compiled with the static variant args
+        ;; while the result reported the override/mode-aware
+        ;; `args/resolve-args`, so a cell override or active mode executed a
+        ;; different scenario than the one reported.
+        plan (plan/variant-plan variant-id
+                                {:run-args (args/run-arg-layers variant-id opts)})]
     {:variant-id       variant-id
      :variant-body     variant-body
      :plan             plan
@@ -718,9 +726,25 @@
      ;; Threaded down so `record-result-map` can surface the chosen runner +
      ;; fold UNMET requirements into the unified result's :cannot-run.
      :runner-selection (resolve-runner-selection plan opts)
-     :decorator-stack  (decorators/resolve-decorators variant-id
-                                                      {:active-modes active-modes})
-     :effective-args   (args/resolve-args variant-id opts)
+     ;; rf2-2cpoo — resolve the decorator stack from the ALREADY-compiled
+     ;; plan's `[:world :decorators]` refs (the twin of the inline path's
+     ;; `prepare-inline-context`), NOT via `decorators/resolve-decorators`
+     ;; which recompiles the plan WITHOUT `:run-args`. Reusing this plan
+     ;; (a) avoids a redundant second compile, and (b) is correct now that a
+     ;; `[:arg key]` may resolve ONLY through a run-opts layer (an active
+     ;; mode / cell override) — a recompile without `:run-args` would throw
+     ;; `:rf.error/story-missing-arg` substituting that script placeholder.
+     ;; v1 modes carry no decorators (IMPL-SPEC §3.1: modes are :args only),
+     ;; so `:active-modes` does not perturb the decorator refs.
+     :decorator-stack  (decorators/resolve-decorator-refs
+                         (get-in plan [:world :decorators] []))
+     ;; rf2-2cpoo — report the SAME effective args the plan was compiled
+     ;; with (the plan is the single source of truth). The plan folds the
+     ;; ambient + run layers around its `:extends`-aware variant layer, so
+     ;; `[:world :effective-args]` equals `args/resolve-args` for a variant
+     ;; with no `:extends`, and is the strictly-more-correct extends-aware
+     ;; value when the variant inherits args.
+     :effective-args   (get-in plan [:world :effective-args] {})
      :snapshot         (ident/snapshot-identity variant-id opts)}))
 
 (defn- run-phase-0!

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -182,7 +182,16 @@
   selection. Overrides are variant-scoped (the URL carries only the
   focused variant's slice), so they apply solely alongside a kept
   variant. The state-watcher pushes that same slice, so this closes the
-  encode/decode round-trip on back/forward navigation."
+  encode/decode round-trip on back/forward navigation.
+
+  Per rf2-2cpoo: the URL is authoritative for the FOCUSED variant's
+  overrides. When the URL keeps a variant but carries NO overrides, this
+  fn CLEARS any stale `[:cell-overrides variant-id]` slice (not just
+  skipping the write) — so back/forward, a bookmark, or a share link that
+  no longer encodes overrides renders WITHOUT the prior control edits, and
+  the address bar stays the source of truth. Only the focused variant's
+  slice is touched; other variants' overrides are left intact (the URL
+  speaks for the focused variant alone)."
   [state parsed validators]
   (let [{:keys [variant-id workspace-id mode-tab active-modes
                 viewport background tag-filter cell-overrides
@@ -225,6 +234,17 @@
       ;; an override edit pushed to the URL was dropped on back/forward.
       (and keep-variant? (seq cell-overrides))
       (assoc-in [:cell-overrides variant-id] cell-overrides)
+
+      ;; rf2-2cpoo: the URL is the source of truth for the FOCUSED variant's
+      ;; overrides. When the URL keeps this variant but carries NO `overrides=`
+      ;; slice, any stale in-memory overrides for it MUST be cleared — otherwise
+      ;; back/forward, a bookmark, or a share link that no longer encodes
+      ;; overrides would still render the prior control edits, and the address
+      ;; bar would stop being authoritative. (The slice is variant-scoped, so
+      ;; OTHER variants' overrides are deliberately untouched — the URL only
+      ;; speaks for the focused variant.)
+      (and keep-variant? (not (seq cell-overrides)))
+      (update :cell-overrides dissoc variant-id)
 
       (seq active-modes)
       (assoc :active-modes (vec active-modes))

--- a/tools/story/test/re_frame/story/runtime_runpath_test.clj
+++ b/tools/story/test/re_frame/story/runtime_runpath_test.clj
@@ -44,6 +44,7 @@
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
   (rf/reg-event-db :rp/set-status (fn [db [_ v]] (assoc db :status v)))
+  (rf/reg-event-db :rp/set-value  (fn [db [_ v]] (assoc db :value v)))
   (test-fn))
 
 (use-fixtures :each reset-rf!)
@@ -187,3 +188,101 @@
                                (:assertions result)))]
         (is (some? rec) "the visual-snapshot record landed (no longer dropped)")
         (is (= :cannot-run (:status rec)))))))
+
+;; ===========================================================================
+;; rf2-2cpoo — run opts (:cell-overrides / :active-modes) thread into PLAN
+;; compilation, so the EXECUTED `[:arg …]` substitutions match the REPORTED
+;; `:effective-args`. Before the fix the runtime compiled the plan with the
+;; static variant args while reporting `args/resolve-args` (override/mode
+;; aware), so a cell override or active mode executed a DIFFERENT scenario
+;; than the one the result claimed — a false pass/fail + misleading snapshot.
+;; ===========================================================================
+
+(deftest cell-override-threads-into-script-arg-substitution
+  (testing "a :cell-override drives an `[:arg …]` placeholder in the SCRIPT;
+            the executed app-db AND the reported :effective-args BOTH reflect
+            the override value — not the static story arg (rf2-2cpoo)"
+    (story/reg-variant
+      :story.opts/scripted
+      {:args   {:value "static"}
+       ;; `[:arg :value]` is resolved at plan-compile time; the run opts must
+       ;; thread into compilation so the dispatched value IS the override.
+       :script [[:dispatch-sync [:rp/set-value [:arg :value]]]
+                [:assert [:rf.assert/path-equals [:value] "override"]]]})
+    (let [result (run-target :story.opts/scripted
+                             {:cell-overrides {:value "override"}})]
+      (is (= "override" (get-in result [:app-db :value]))
+          "the SCRIPT dispatched the OVERRIDE value (plan compiled with run opts)")
+      (is (= "override" (get-in result [:effective-args :value]))
+          "the reported :effective-args carries the override")
+      (is (= :pass (:status result))
+          "the [:arg]-driven assertion against the override value PASSES — the
+           executed plan and the reported effective args agree")
+      (is (every? :passed? (:assertions result))))))
+
+(deftest cell-override-threads-into-db-seed-arg-substitution
+  (testing "a :cell-override drives an `[:arg …]` placeholder in the :db-seed;
+            the seeded app-db reflects the override, matching :effective-args
+            (rf2-2cpoo — db-seed substitution uses the run-opts effective args)"
+    (story/reg-variant
+      :story.opts/seeded
+      {:args    {:value "static"}
+       :db-seed {:seeded [:arg :value]}})
+    (let [result (run-target :story.opts/seeded
+                             {:cell-overrides {:value "override"}})]
+      (is (= "override" (get-in result [:app-db :seeded]))
+          "the :db-seed seeded the OVERRIDE value (plan compiled with run opts)")
+      (is (= "override" (get-in result [:effective-args :value]))
+          "the reported :effective-args carries the override")
+      (is (= :pass (:status result))))))
+
+(deftest active-mode-threads-into-arg-substitution
+  (testing "an :active-mode's :args drive an `[:arg …]` placeholder for an arg
+            the variant does NOT itself set; the executed app-db AND the
+            reported :effective-args BOTH reflect the mode value (rf2-2cpoo —
+            mode args fold into plan compilation at `mode < variant` precedence,
+            so the mode supplies args the variant leaves open)"
+    (story/reg-mode :Mode.test/big {:args {:value "from-mode"}})
+    (story/reg-variant
+      :story.opts/moded
+      ;; the variant declares NO :value, so the mode's :value flows through
+      ;; (precedence `mode < variant`: the mode fills args the variant omits).
+      {:script [[:dispatch-sync [:rp/set-value [:arg :value]]]
+                [:assert [:rf.assert/path-equals [:value] "from-mode"]]]})
+    (let [result (run-target :story.opts/moded
+                             {:active-modes [:Mode.test/big]})]
+      (is (= "from-mode" (get-in result [:app-db :value]))
+          "the SCRIPT dispatched the MODE value (mode args threaded into compile)")
+      (is (= "from-mode" (get-in result [:effective-args :value]))
+          "the reported :effective-args carries the mode value")
+      (is (= :pass (:status result)))
+      (is (every? :passed? (:assertions result))))))
+
+(deftest cell-override-wins-over-active-mode-in-arg-substitution
+  (testing "precedence holds end-to-end: mode < cell-override; the SCRIPT
+            dispatches the override (highest layer), matching :effective-args
+            (rf2-2cpoo — the plan folds layers in resolve-args precedence)"
+    (story/reg-mode :Mode.test/mid {:args {:value "from-mode"}})
+    (story/reg-variant
+      :story.opts/precedence
+      {:args   {:value "static"}
+       :script [[:dispatch-sync [:rp/set-value [:arg :value]]]]})
+    (let [result (run-target :story.opts/precedence
+                             {:active-modes   [:Mode.test/mid]
+                              :cell-overrides {:value "override"}})]
+      (is (= "override" (get-in result [:app-db :value]))
+          "cell-override beats the active mode in the EXECUTED substitution")
+      (is (= "override" (get-in result [:effective-args :value]))
+          "and in the reported :effective-args — executed == reported"))))
+
+(deftest no-run-opts-still-uses-static-args
+  (testing "with NO run opts the run still substitutes the STATIC variant args —
+            the run-args threading is purely additive (rf2-2cpoo regression
+            guard: the absent-opts path is unchanged)"
+    (story/reg-variant
+      :story.opts/plain
+      {:args   {:value "static"}
+       :script [[:dispatch-sync [:rp/set-value [:arg :value]]]]})
+    (let [result (run-target :story.opts/plain)]
+      (is (= "static" (get-in result [:app-db :value])))
+      (is (= "static" (get-in result [:effective-args :value]))))))

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -292,6 +292,67 @@
       (is (= {:label "Save, continue" :n 3}
              (get-in out [:cell-overrides :foo/bar]))))))
 
+;; ---- rf2-2cpoo: URL is authoritative — clear stale overrides on hydrate ---
+
+(deftest apply-parsed-clears-stale-overrides-when-url-omits-them
+  (testing "rf2-2cpoo — hydrating a URL that KEEPS the focused variant but
+            carries NO overrides CLEARS the stale in-memory overrides for it.
+            Previously the write-only branch left them intact, so back/forward,
+            a bookmark, or a share link that no longer encoded overrides still
+            rendered the prior control edits — the address bar stopped being the
+            source of truth."
+    (let [stale {:selected-variant :story.foo/bar
+                 :cell-overrides   {:story.foo/bar {:label "stale edit"}}}
+          ;; parsed URL: same variant, NO :cell-overrides slice.
+          out   (us/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
+      (is (= :story.foo/bar (:selected-variant out)))
+      (is (nil? (get-in out [:cell-overrides :story.foo/bar]))
+          "the focused variant's stale overrides are cleared — URL wins"))))
+
+(deftest apply-parsed-overwrites-stale-overrides-when-url-has-new
+  (testing "rf2-2cpoo — a URL that carries DIFFERENT overrides for the kept
+            variant overwrites the stale slice (not a deep-merge); the slice
+            equals the URL payload exactly"
+    (let [stale {:selected-variant :story.foo/bar
+                 :cell-overrides   {:story.foo/bar {:label "stale" :keep "old"}}}
+          out   (us/apply-parsed-to-state
+                  stale {:variant-id     :story.foo/bar
+                         :cell-overrides {:label "fresh"}} {})]
+      (is (= {:label "fresh"} (get-in out [:cell-overrides :story.foo/bar]))
+          "the slice is REPLACED by the URL payload, dropping the stale :keep"))))
+
+(deftest apply-parsed-clear-leaves-other-variants-overrides-intact
+  (testing "rf2-2cpoo — clearing the focused variant's overrides touches ONLY
+            its slice; another variant's overrides survive (the URL speaks for
+            the focused variant alone)"
+    (let [stale {:selected-variant :story.foo/bar
+                 :cell-overrides   {:story.foo/bar   {:label "stale"}
+                                    :story.other/baz {:n 7}}}
+          out   (us/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
+      (is (nil? (get-in out [:cell-overrides :story.foo/bar]))
+          "the focused variant's slice is cleared")
+      (is (= {:n 7} (get-in out [:cell-overrides :story.other/baz]))
+          "an unfocused variant's overrides are left intact"))))
+
+(deftest apply-parsed-share-back-forward-scenario
+  (testing "rf2-2cpoo — the back/forward + share scenario end-to-end: an
+            override edit, then navigating to an override-free URL for the same
+            variant (a bookmark / share link from before the edit) renders
+            WITHOUT the edit. state → params (with edit) → params (without) →
+            hydrate the override-free one ⇒ no stale slice."
+    (let [;; 1. user edits a control — overrides live in state + would push to URL.
+          edited      {:selected-variant :foo/bar
+                       :cell-overrides   {:foo/bar {:label "edited"}}}
+          ;; 2. a share link / bookmark captured BEFORE the edit: same variant,
+          ;;    no overrides. params-from-state of a no-override shell yields no slice.
+          shared-proj (us/params-from-state {:selected-variant :foo/bar})
+          ;; 3. navigating to that URL must clear the in-memory edit.
+          out         (us/apply-parsed-to-state edited shared-proj {})]
+      (is (= :foo/bar (:selected-variant out)))
+      (is (nil? (get-in out [:cell-overrides :foo/bar]))
+          "navigating to the override-free shared URL clears the stale edit —
+           the address bar is authoritative"))))
+
 (deftest apply-parsed-full-round-trip-through-state
   (testing "URL → parsed → state, then state → URL produces equivalent
             params (allowing for set vs vec re-ordering)"


### PR DESCRIPTION
Fixes the two correctness findings in **rf2-2cpoo** (tools/story).

## Finding 1 — run-opts not threaded into plan compilation

`runtime/prepare-context` compiled the variant plan with
`(plan/variant-plan variant-id)` — with **no** run opts — while reporting
`:effective-args` from `args/resolve-args variant-id opts`. So every
`[:arg …]` substitution in setup / script / db-seed / network / sub-overrides
used the **static** variant args, while the result + snapshot claimed the
override/mode-aware effective args. Canvas / Test Mode executed a *different*
scenario than the one reported → false pass/fail + misleading snapshots.

- `re-frame.story.args/run-arg-layers` exposes the ambient (global/story) +
  per-run (active-modes/cell-overrides) arg layers, split `:pre`/`:post`
  around the variant layer, in `resolve-args` precedence
  (`global < story < mode < variant < cell-overrides`).
- `plan/variant-plan` + `compile-body` accept a `:run-args` opt and fold
  those layers around the `:extends`-merged variant `arg-map`, so
  `[:world :args]` / `[:world :effective-args]`, **every** `[:arg key]`
  substitution, and the `:plan-hash` use the SAME effective args
  `resolve-args` produces.
- The runtime executes `[:world :scripts]` (the normalized plays), which
  `normalize-scripts` had **never** `[:arg]`-substituted — placeholders
  reached the dispatched event verbatim. `compile-body` now substitutes the
  plays with the same `arg-map`.
- `prepare-context` compiles the plan **once** with `:run-args`, reports the
  plan's `[:world :effective-args]` (plan = single source of truth), and
  resolves the decorator stack from that plan's `[:world :decorators]` refs
  (the twin of the inline path) instead of recompiling without run-args via
  `resolve-decorators` — avoiding a redundant compile and correctly handling
  an `[:arg]` resolvable only through a run-opts layer.

## Finding 2 — URL hydration didn't clear stale overrides

`url-state/apply-parsed-to-state` only **wrote** `[:cell-overrides variant-id]`
when the parsed URL carried non-empty overrides; selecting the same variant
with no `overrides=` left stale in-memory control edits intact, so
back/forward / bookmarks / share links rendered stale state and the address
bar stopped being the source of truth. It now **clears** the focused
variant's slice when the URL omits overrides (URL is authoritative); other
variants' slices are deliberately untouched.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| Story artefact JVM | `clojure -M:test` (from `tools/story`) | **1634 tests, 6088 assertions, 0 failures, 0 errors** |
| Implementation CLJS | `npm run test:cljs` (from `implementation`) | **5755 tests, 20215 assertions, 0 failures, 0 errors** |

New regression tests (CLJS unit, not Playwright):
- `runtime_runpath_test.clj` — cell-override → script `[:arg]`; cell-override
  → db-seed `[:arg]`; active-mode → `[:arg]`; cell-override beats active-mode
  (precedence end-to-end); no-run-opts still uses static args. Each asserts
  executed app-db == reported `:effective-args`.
- `ui/url_state_test.cljc` — clear stale overrides when URL omits them;
  overwrite (not merge) when URL has new; clear leaves other variants intact;
  full share + back/forward scenario.

## Specs

- `tools/story/spec/017-Testing-Story.md` (§Args) — run opts feed the SAME
  effective args the result reports; the runner threads `:active-modes` /
  `:cell-overrides` into plan compilation; `[:world :scripts]` carries the
  resolved placeholders.
- `tools/story/spec/022-Story-UI-Docs-And-Share.md` (§Share) — the URL is
  authoritative for the focused variant's overrides; hydration clears stale
  slices when the URL omits them.