### PR TITLE
fix(template): with-Story release elision + CSP matches generated runtime (rf2-l4prz)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
@@ -16,9 +16,21 @@
    `:closure-defines {re-frame.story.config/enabled? false}`, every
    `reg-*` form in `{{namespace}}.stories` elides to `nil` and
    `mount-shell!` short-circuits — the production bundle carries no
-   Story body code. The `:release` shadow build inherits that elision
-   automatically; flip the closure-define in `shadow-cljs.edn` if you
-   need a release-flavoured Story build for visual-regression."
+   Story body code.
+
+   IMPORTANT — elision is OPT-IN, not automatic. `re-frame.story.config/
+   enabled?` defaults to `true`, and `shadow-cljs.edn` does NOT set the
+   closure-define for you. So a plain `npx shadow-cljs release app` SHIPS
+   the Story shell, the `#/stories` route, and every registration to
+   production. To elide Story from the release bundle, add the
+   `:release` compiler-options block to `shadow-cljs.edn`'s `:app`
+   build:
+
+     :release {:compiler-options
+               {:closure-defines {re-frame.story.config/enabled? false}}}
+
+   (Leave it OUT — keep `enabled?` true in release — only when you want
+   a release-flavoured Story build for visual-regression.)"
   (:require [reagent.dom.client       :as rdc]
             [re-frame.core            :as rf]
             [re-frame.story           :as story]
@@ -59,6 +71,25 @@
       (mount-stories!)
       (mount-app!))))
 
+;; -- hashchange listener (hot-reload-safe) --------------------------------
+;;
+;; `init` runs on first boot AND on every shadow hot-reload. The closure
+;; identity of `on-hash-change!` changes on each rebuild, so a naive
+;; `(.addEventListener … on-hash-change!)` in `init` would accumulate one
+;; stale listener per rebuild — every subsequent route change would then
+;; fire the mount switch N times (repeated React root teardown/recreate,
+;; flicker, a growing listener leak). We hold the *installed* listener in
+;; a `defonce` atom that survives reloads, and remove the previous one
+;; before adding the new one — so exactly one hashchange listener is ever
+;; wired, pointing at the current code.
+(defonce ^:private hash-listener (atom nil))
+
+(defn- install-hash-listener! []
+  (when-let [prev @hash-listener]
+    (.removeEventListener js/window "hashchange" prev))
+  (.addEventListener js/window "hashchange" on-hash-change!)
+  (reset! hash-listener on-hash-change!))
+
 (defn ^:export init
   "Called by shadow-cljs (see :init-fn in shadow-cljs.edn). Idempotent —
    shadow's hot-reload pipeline re-invokes it on each rebuild."
@@ -73,6 +104,9 @@
   ;; populated frame.
   (rf/dispatch-sync [:counter/initialise])
   ;; Wire hash-change so reloading `#/stories` lands on the shell
-  ;; without a manual click-through.
-  (.addEventListener js/window "hashchange" on-hash-change!)
+  ;; without a manual click-through. `install-hash-listener!` removes any
+  ;; listener a previous hot-reload installed before adding this one, so
+  ;; reloads never accumulate stale listeners (defonce atom holds the
+  ;; current one).
+  (install-hash-listener!)
   (on-hash-change!))

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -84,10 +84,29 @@ The story registrations live in `src/{{nested-dirs}}/stories.cljs`
 the four shipped `reg-*` macros — `reg-story`, `reg-variant`,
 `reg-tag`, `reg-workspace` — referencing the counter's existing
 event / sub / view ids. Add more `reg-variant` / `reg-tag` /
-`reg-decorator` / `reg-mode` calls there as your app grows. Under a
-`release` build the Story body code elides via
-`:closure-defines {re-frame.story.config/enabled? false}`, so it
-costs nothing in production.
+`reg-decorator` / `reg-mode` calls there as your app grows.
+
+### Eliding Story from your production bundle (opt-in)
+
+Story body code can elide entirely under an `:advanced` release build
+via the `re-frame.story.config/enabled?` closure-define — every `reg-*`
+form collapses to `nil`, `mount-shell!` short-circuits, and Closure
+DCE drops the registration-side namespace graph. **This elision is
+opt-in, not automatic.** The define defaults to `true`, and the
+scaffolded `shadow-cljs.edn` does **not** set it — so a plain
+`npx shadow-cljs release app` SHIPS the Story shell, the `#/stories`
+route, and every registration to production (a bundle-size cost and a
+possible internal-state exposure). To elide Story from release, add a
+`:release` block to the `:app` build in `shadow-cljs.edn`:
+
+```clojure
+;; shadow-cljs.edn :builds :app
+:release {:compiler-options
+          {:closure-defines {re-frame.story.config/enabled? false}}}
+```
+
+Leave it out (keep `enabled?` true in release) only when you want a
+release-flavoured Story build for visual regression.
 
 Story is Reagent-only in this template release; UIx + Helix variants
 follow once Story's adapter coverage matches Reagent's. If you did
@@ -106,20 +125,39 @@ from any static host.
 ## Production hardening
 
 The generated `resources/public/index.html` ships a `<meta http-equiv="Content-Security-Policy" ...>`
-tag so an unconfigured static host still gets a strict default-safe
-baseline. **Prefer setting the same policy as a real response header**
-on your server — meta-tag CSPs are evaluated late (some directives are
-ignored entirely, e.g. `frame-ancestors`) and can be removed by an
-upstream proxy that rewrites HTML.
+tag so an unconfigured static host still gets a baseline. **Prefer
+setting CSP as a real response header** on your server — meta-tag CSPs
+are evaluated late, some directives are ignored entirely when delivered
+via `<meta>` (notably **`frame-ancestors`**, which is why the meta tag
+omits it), and a meta CSP can be removed by an upstream proxy that
+rewrites HTML.
 
-The scaffold loads only same-origin JS/CSS and has no inline
-script/style, so the strict default policy holds without weakening:
+**The shipped meta CSP is development-flavoured.** It sets
+`style-src 'self' 'unsafe-inline'` because the generated views use
+inline `:style` props and the default-on Xray devtools surface injects
+`<style>` blocks and inline styles — a strict `style-src 'self'` would
+emit CSP violations on the first page and block Xray styling. The meta
+tag also drops `frame-ancestors` (browsers ignore it from `<meta>`).
+
+For production, serve the **stricter** policy below as a response
+header. It tightens three things relative to the dev meta tag:
+**drops `'unsafe-inline'`** (do this only after you have externalised
+all inline styles — move the views' `:style` props to `css/app.css`
+classes, and either drop the dev-only Xray preload from your release
+build [it already is — see "In-app devtools" above] or serve Xray under
+a nonce); **drops `ws: wss:`** (no dev hot-reload in production); and
+**adds `frame-ancestors 'none'`** — which is where anti-clickjacking
+protection actually takes effect (NOT the meta tag):
 
 ```
 Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'
 X-Content-Type-Options: nosniff
 Referrer-Policy: strict-origin-when-cross-origin
 ```
+
+If you have not externalised inline styles, keep `style-src 'self'
+'unsafe-inline'` in the production header too — but prefer a nonce or
+hash over wholesale `'unsafe-inline'` for a public deployment.
 
 **`connect-src` — tighten it in production.** The shipped
 `index.html` meta CSP sets `connect-src 'self' ws: wss:` so
@@ -133,9 +171,14 @@ origin), `'self'` will block it — add that origin explicitly, e.g.
 silently forbids any cross-origin request you haven't whitelisted, so
 add API origins here as you wire them up.
 
-If you add a CDN, embed in an iframe, inline a `<style>` block, or
-load an analytics snippet, **explicitly widen the policy** for that
-origin / hash — don't drop it to `'unsafe-inline'` wholesale.
+`script-src` stays strict (`'self'`, no `'unsafe-inline'`) in both the
+dev meta tag and the production header — the scaffold has no inline
+`<script>`. If you add a CDN, embed in an iframe, inline a `<script>`,
+or load an analytics snippet, **explicitly widen the policy** for that
+origin / hash — don't drop it to `'unsafe-inline'` wholesale. (For
+inline *styles*, see the `style-src` note above: the dev meta tag
+allows them; externalise to `css/app.css` to tighten the production
+header.)
 
 Example **nginx** server block:
 

--- a/tools/template/resources/day8/re_frame2_template/root/resources/public/index.html
+++ b/tools/template/resources/day8/re_frame2_template/root/resources/public/index.html
@@ -3,20 +3,36 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- Default-safe Content Security Policy. The scaffold only loads
-         same-origin JS/CSS and has no inline script/style, so this
-         strict baseline holds without weakening. `connect-src` admits
-         the same origin plus ws:/wss: so shadow-cljs's hot-reload
-         websocket connects in dev (it can route to a different port
-         than the page, which 'self' alone would block). For
-         production, prefer serving the same policy via a
-         Content-Security-Policy response header AND tighten
-         `connect-src` to your real API origin(s) — drop `ws: wss:`
-         unless you use websockets in production (see README
-         "Production hardening"). The meta tag here is the fall-back
-         when no server-side header is set. -->
+    <!-- Development-flavoured Content Security Policy. This meta tag is
+         the dev fall-back when no server-side header is set; it is tuned
+         to the RUNTIME the scaffold actually produces, not an aspirational
+         strict baseline.
+
+         - `style-src 'self' 'unsafe-inline'` — the generated views use
+           inline `:style` props, and the default-on Xray devtools surface
+           injects `<style>` blocks and inline styles. Without
+           `'unsafe-inline'` the first page would emit CSP violations and
+           Xray's styling would be blocked. (To run with a strict
+           `style-src 'self'`, move all inline styles to external CSS /
+           a nonce and drop Xray — see README "Production hardening".)
+         - `connect-src` admits the same origin plus ws:/wss: so
+           shadow-cljs's hot-reload websocket connects in dev (it can
+           route to a different port than the page, which 'self' alone
+           would block).
+         - NO `frame-ancestors` here: browsers IGNORE `frame-ancestors`
+           delivered via a `<meta>` tag — it only takes effect from a
+           response header. Putting it here would imply anti-clickjacking
+           protection the scaffold does not actually have. The
+           anti-clickjacking contract lives in the README's response-header
+           snippets ("Production hardening").
+
+         For production, serve a Content-Security-Policy RESPONSE HEADER
+         (see README "Production hardening"): drop `'unsafe-inline'` once
+         you've externalised styles, drop `ws: wss:` (no dev hot-reload),
+         tighten `connect-src` to your real API origin(s), and add
+         `frame-ancestors 'none'` THERE (where it works). -->
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
+          content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'none'">
     <title>{{name}} — re-frame2</title>
     <link rel="stylesheet" href="/css/app.css">
   </head>

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -262,21 +262,62 @@
                 "ci.yml's GitHub `${{ hashFiles(...) }}` expression
                  survives substitution verbatim"))
 
-          ;; -- Security baseline (rf2-sh3l8) --
+          ;; -- Security baseline (rf2-sh3l8; CSP-runtime parity rf2-l4prz) --
           (let [index-text  (slurp (io/file root "resources/public/index.html"))
+                ;; The actual CSP policy is the `content="…"` attribute of
+                ;; the CSP meta tag — NOT the surrounding HTML comment
+                ;; (which legitimately discusses directives like
+                ;; frame-ancestors). Pull just the policy string so the
+                ;; directive assertions below test the live policy, not
+                ;; documentation prose (rf2-l4prz).
+                csp-policy  (some-> (re-find #"http-equiv=\"Content-Security-Policy\"\s+content=\"([^\"]*)\""
+                                             index-text)
+                                    second)
                 readme-text (slurp (io/file root "README.md"))]
             (is (.contains index-text "Content-Security-Policy")
                 "index.html ships a CSP meta tag")
-            (is (.contains index-text "default-src 'self'")
+            (is (some? csp-policy)
+                "the CSP meta tag's content=\"…\" policy string is parseable")
+            (is (.contains csp-policy "default-src 'self'")
                 "index.html CSP uses default-src 'self'")
-            (is (.contains index-text "frame-ancestors 'none'")
-                "index.html CSP forbids framing (anti-clickjacking)")
-            (is (.contains index-text "object-src 'none'")
+            (is (.contains csp-policy "object-src 'none'")
                 "index.html CSP forbids plugin objects")
             (is (.contains index-text "data-rf-xray-host")
                 "index.html provides Xray's default true-inline layout host")
+
+            ;; rf2-l4prz Finding 2 — the dev meta CSP MUST permit inline
+            ;; styles: the generated views use inline :style props and the
+            ;; default-on Xray surface injects <style> blocks + inline
+            ;; styles. A strict `style-src 'self'` would emit CSP
+            ;; violations on the first page and block Xray. Assert the
+            ;; meta tag's style-src admits 'unsafe-inline' so the shipped
+            ;; runtime renders clean under its own policy.
+            (is (.contains csp-policy "style-src 'self' 'unsafe-inline'")
+                "index.html meta CSP permits inline styles (generated
+                 views + default-on Xray both rely on them — rf2-l4prz
+                 Finding 2)")
+
+            ;; rf2-l4prz Finding 3 — `frame-ancestors` delivered via a
+            ;; <meta> tag is IGNORED by browsers; only a response header
+            ;; honours it. Asserting it on the meta tag (as the old test
+            ;; did) was a false anti-clickjacking pass. The CSP POLICY must
+            ;; NOT carry frame-ancestors; the anti-clickjacking contract
+            ;; lives in the README's response-header snippets, asserted
+            ;; below. (The HTML comment may mention it — we test the
+            ;; policy string, not the file.)
+            (is (not (.contains csp-policy "frame-ancestors"))
+                "index.html meta CSP policy does NOT carry frame-ancestors —
+                 browsers ignore it from <meta>; it belongs in a response
+                 header (rf2-l4prz Finding 3)")
+
             (is (.contains readme-text "Production hardening")
                 "README documents Production hardening")
+            ;; The anti-clickjacking contract: frame-ancestors lives in
+            ;; the README's response-header snippets, where it works.
+            (is (.contains readme-text "frame-ancestors 'none'")
+                "README's production response-header snippets carry
+                 frame-ancestors 'none' (the real anti-clickjacking
+                 contract — rf2-l4prz Finding 3)")
             (is (.contains readme-text "X-Content-Type-Options")
                 "README covers nosniff header")
             (is (.contains readme-text "Referrer-Policy")
@@ -508,7 +549,23 @@
                 "with-stories core.cljs routes #/stories to the shell")
             (is (.contains core-text "acme.my-app.stories")
                 "with-stories core.cljs requires the stories ns so its
-                 reg-* calls fire at boot"))
+                 reg-* calls fire at boot")
+            ;; rf2-l4prz Finding 4 — `init` runs on every hot-reload, and
+            ;; the hashchange listener's closure identity changes per
+            ;; rebuild. Without a defonce-held listener + removeEventListener
+            ;; before re-adding, reloads accumulate stale listeners (each
+            ;; route change then fires the mount switch N times: repeated
+            ;; React root teardown, flicker, a listener leak). Assert the
+            ;; hot-reload-safe wiring is present.
+            (is (.contains core-text "defonce")
+                "with-stories core.cljs holds hot-reload state in a defonce
+                 (the hashchange listener must survive reloads — rf2-l4prz
+                 Finding 4)")
+            (is (.contains core-text "removeEventListener")
+                "with-stories core.cljs removes the previously-installed
+                 hashchange listener before re-adding on hot-reload, so
+                 reloads don't accumulate stale listeners (rf2-l4prz
+                 Finding 4)"))
           ;; -- stories.cljs uses the four shipped reg-* macros and
           ;;    references the template's existing event/sub/view ids --
           (let [stories-text (slurp (io/file root "src/acme/my_app/stories.cljs"))]
@@ -530,6 +587,85 @@
             (is (.contains stories-text ":acme.my-app.views/counter-app")
                 "stories.cljs references the template's view by namespaced
                  id (Story renders by id, not by symbol)")))
+        (finally
+          (delete-recursively tmp))))))
+
+;; --- with-Story release elision: config ⇆ docs agreement (rf2-l4prz) -----
+;;
+;; Finding 1: the with-Story core docstring + the generated README must
+;; NOT claim that `npx shadow-cljs release app` elides Story
+;; automatically / for free. It does NOT — `re-frame.story.config/enabled?`
+;; defaults true and the emitted shadow-cljs.edn sets no `:release`
+;; closure-define, so a plain release SHIPS the Story shell + `#/stories`
+;; route + every registration. The docs and the config must AGREE that
+;; elision is OPT-IN, and the docs must give the exact closure-define a
+;; user adds to elide.
+;;
+;; This test pins that agreement three ways:
+;;   (a) the emitted shadow-cljs.edn does NOT set the Story closure-define
+;;       (matches the "opt-in" story — if a future edit DID add it, the
+;;       docs would need to flip to "automatic" and this test reminds us);
+;;   (b) the with-Story core docstring + README both carry the exact
+;;       opt-in closure-define string AND flag it as opt-in;
+;;   (c) neither doc carries the retired false-automatic claims
+;;       ("inherits that elision automatically" / "costs nothing in
+;;       production") that asserted free release elision.
+
+(deftest with-story-release-elision-docs-config-agree-test
+  (testing "with-Story scaffold: the release-elision docs (core docstring
+            + README) agree with the emitted shadow-cljs.edn — elision is
+            documented as OPT-IN with the exact closure-define, and the
+            config does not silently set it (rf2-l4prz Finding 1)"
+    (let [tmp (tmp-dir "rf2-template-story-elision-")]
+      (try
+        (let [root      (run-template! tmp "acme/my-app" :reagent true)
+              core-text (slurp (io/file root "src/acme/my_app/core.cljs"))
+              readme    (slurp (io/file root "README.md"))
+              scs       (read-edn (io/file root "shadow-cljs.edn"))
+              ;; The exact closure-define a user adds to elide Story.
+              define-sym 're-frame.story.config/enabled?]
+
+          ;; (a) The emitted shadow-cljs.edn must NOT set the Story
+          ;;     closure-define anywhere — that is what makes elision
+          ;;     opt-in. Walk the whole build map for the define symbol so
+          ;;     a `:release`/`:dev`/`:compiler-options` placement is all
+          ;;     caught.
+          (let [scs-str (pr-str scs)]
+            (is (not (.contains scs-str (str define-sym)))
+                (str "emitted shadow-cljs.edn must NOT set "
+                     define-sym " — Story release elision is opt-in (the "
+                     "docs say so). If a future change DOES set it by "
+                     "default, the docs must flip to 'automatic' and this "
+                     "assertion + the doc text must be updated together "
+                     "(rf2-l4prz Finding 1).")))
+
+          ;; (b) Both docs carry the exact opt-in closure-define AND mark
+          ;;     it opt-in. `enabled? false` is the literal token a user
+          ;;     copies; "opt-in" / "OPT-IN" marks it as not automatic.
+          (doseq [[label text] [["with-Story core.cljs" core-text]
+                                ["README" readme]]]
+            (is (.contains text "re-frame.story.config/enabled? false")
+                (str label " gives the exact closure-define a user adds "
+                     "to elide Story from release (rf2-l4prz Finding 1)"))
+            (is (.contains (clojure.string/lower-case text) "opt-in")
+                (str label " marks Story release elision as OPT-IN "
+                     "(not automatic) (rf2-l4prz Finding 1)")))
+
+          ;; (c) The retired false-automatic claims must be gone from both
+          ;;     docs — these asserted free/automatic release elision.
+          ;;     `inherits that elision automatically` (whitespace-folded)
+          ;;     and `costs nothing in production` were the two phrases
+          ;;     that promised a free/automatic release elision.
+          (doseq [[label text] [["with-Story core.cljs" core-text]
+                                ["README" readme]]]
+            (let [folded (clojure.string/replace text #"\s+" " ")]
+              (is (not (.contains folded "inherits that elision automatically"))
+                  (str label " no longer claims the release build inherits "
+                       "elision automatically (rf2-l4prz Finding 1)")))
+            (is (not (.contains text "costs nothing in production"))
+                (str label " no longer claims Story 'costs nothing in "
+                     "production' (it ships unless you opt in) "
+                     "(rf2-l4prz Finding 1)"))))
         (finally
           (delete-recursively tmp))))))
 


### PR DESCRIPTION
Correctness review of `tools/template` (the deps-new scaffolding tool that emits starter apps). Fixes all 4 findings in rf2-l4prz. All changes are confined to `tools/template/**`.

## Findings fixed

**1. with-Story release elision documented as automatic, but is opt-in.**
The with-Story core docstring + generated README claimed `:release` inherits `:closure-defines {re-frame.story.config/enabled? false}` and "costs nothing in production". But the emitted `shadow-cljs.edn` sets no such define and `enabled?` defaults `true` — a plain `npx shadow-cljs release app` SHIPS the Story shell, the `#/stories` route, and every registration to production (bundle surprise + internal-state exposure). The template's own behavioural-test comment already acknowledged elision is opt-in; the docs disagreed. Fix: corrected the core docstring + README to state elision is OPT-IN, with the exact `:release` closure-define to add. Added an emission test (`with-story-release-elision-docs-config-agree-test`) that fails if the docs and the emitted `shadow-cljs.edn` disagree.

**2. Default CSP `style-src 'self'` blocked the generated runtime.**
Every substrate's generated views use inline `:style` props and the default-on Xray devtools surface injects `<style>` blocks + inline styles, so the first generated page emitted CSP violations and Xray styling was blocked. The README also falsely claimed "no inline script/style". Fix: relaxed the dev meta CSP to `style-src 'self' 'unsafe-inline'` (documented as dev-flavoured), kept a stricter production response-header in the README, and corrected the README claim.

**3. `frame-ancestors` via `<meta>` is ignored by browsers — false anti-clickjacking pass.**
The old test asserted `frame-ancestors 'none'` on the meta tag as anti-clickjacking proof, but browsers honour it only from a response header. Fix: removed `frame-ancestors` from the meta tag; the anti-clickjacking contract now lives only in the README response-header snippets. Test asserts the meta POLICY omits it and the README header snippets carry it.

**4. with-Story `init` leaked hashchange listeners on hot-reload.**
`init` called `.addEventListener "hashchange" on-hash-change!` on every reload with no `defonce` guard / removal; reloads accumulated stale listeners (multiplied mount switches, flicker, leak). Fix: hold the listener in a `defonce` atom, `removeEventListener` the previous one before re-adding. Emission test asserts the `defonce` + `removeEventListener` wiring is present.

## Quality gates

- `tools/template` artefact suite — `clojure -M:test`: **29 tests, 339 assertions, 0 failures, 0 errors.**
- with-Story behavioural + `:advanced` release smoke — `RF2_TEMPLATE_RUN_EMITTED_TESTS=1`, `reagent-with-story-emitted-tests-run-test`: **1 test, 11 assertions, 0 failures, 0 errors.** Generates the with-Story app, runs `shadow-cljs compile app test`, `node out/node-test.js`, and `shadow-cljs release app` (`:advanced`) — confirming the modified `core_with_stories.cljs` compiles + runs green under Closure optimisation and the Xray preload is cut from release.

Test discipline: emission/static tests only (the template's existing pattern); no per-generated-app browser smokes added.