### PR TITLE
fix(pair-mcp): project epoch records before MCP egress + re-signal raw-state on reload (rf2-olvr5)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/cache.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/cache.cljs
@@ -151,9 +151,26 @@
     :else (js->clj args)))
 
 (defn cache-key
-  "Build the cache key tuple for a tool invocation."
-  [tool args]
-  [tool (args->fingerprint args)])
+  "Build the cache key tuple for a tool invocation.
+
+  rf2-olvr5 finding 3 — the key includes the resolved BUILD as well as
+  `(tool, args-fingerprint)`. The same `(tool, args)` against two
+  different shadow-cljs builds reachable over the one nREPL connection is
+  two distinct reads; keying on the build alone (the pre-fix shape)
+  meant a precheck-hash collision across builds could serve one build's
+  payload for the other. `build` is the resolved build-id keyword (from
+  `wire/arg-build`); a legacy call without one passes nil and keys on
+  `(tool, args)` exactly as before.
+
+  Note: the OPERATING FRAME for an omitted-`:frame` call is not knowable
+  here (it resolves runtime-side), so it cannot be folded into the key.
+  That axis is covered by clearing the whole cache on every operating-
+  frame change (`operating-frame` tools call `cache/clear!`), which
+  eliminates any cross-frame stale hit regardless of app-db-hash
+  collisions."
+  ([tool args] (cache-key tool args nil))
+  ([tool args build]
+   [tool build (args->fingerprint args)]))
 
 (defn hash-result
   "Compute the cache hash for an MCP result. We sum every text slot's
@@ -293,14 +310,14 @@
   via the rf2-36xod precheck wiring), it is stored alongside the
   result hash so the NEXT call can short-circuit via `precheck`
   without re-running the tool."
-  [result-js {:keys [tool args enabled? precheck-hash]}]
+  [result-js {:keys [tool args enabled? precheck-hash build]}]
   (cond
     (not enabled?)               result-js
     (nil? result-js)             result-js
     (not (cacheable? tool))      result-js
     (boolean (j/get result-js :isError)) result-js
     :else
-    (let [k          (cache-key tool args)
+    (let [k          (cache-key tool args build)
           h          (hash-result result-js)
           prior      (lookup k)
           now        (.getTime (js/Date.))]
@@ -342,13 +359,13 @@
   after the tool runs.
 
   On a hit, it does touch the LRU (so the entry stays warm)."
-  [{:keys [tool args enabled?]} current-precheck-hash]
+  [{:keys [tool args enabled? build]} current-precheck-hash]
   (cond
     (not enabled?)                       nil
     (not (cacheable? tool))              nil
     (nil? current-precheck-hash)         nil
     :else
-    (let [k     (cache-key tool args)
+    (let [k     (cache-key tool args build)
           prior (lookup k)]
       (when (and prior
                  (some? (:precheck-hash prior))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -125,8 +125,13 @@
   ## Precedence (highest first; rf2-3grub adds step 3)
 
     1. `--port-file <path>`   explicit, cwd-independent override
-                              (rf2-3dbwh). Wins outright; `:project-home`
-                              is the dirname of the port file.
+                              (rf2-3dbwh). Wins outright WHEN READABLE;
+                              `:project-home` is the dirname of the port
+                              file. An explicit-but-unreadable / non-
+                              numeric file falls through to steps 2-5
+                              (rf2-olvr5) — mirroring `read-port-from-fs`
+                              — so a stale port file can't strand a live
+                              port reachable via env / roots / HTTP / cwd.
     2. `$SHADOW_CLJS_NREPL_PORT` env var. `:project-home` left nil
                               (env-overridden discovery doesn't surface a
                               root); the per-tool-call port-file re-read
@@ -173,13 +178,19 @@
   the seams explicit and gives tests clean stub-points."
   [explicit-port-file http-port shadow-probe-fn roots-discovery-fn]
   (cond
-    ;; Step 1 — explicit --port-file flag.
-    (and explicit-port-file (seq explicit-port-file))
-    (if-let [port (read-port-file explicit-port-file)]
-      (js/Promise.resolve {:port         port
-                           :project-home (node-path/dirname explicit-port-file)})
-      ;; Explicit but unreadable — record and fall through.
-      (js/Promise.resolve {:port nil}))
+    ;; Step 1 — explicit --port-file flag. Wins ONLY when it actually
+    ;; reads a port. An explicit-but-unreadable / non-numeric port file
+    ;; (a stale leftover, a typo'd path) MUST fall through to env →
+    ;; roots → HTTP → cwd — exactly the precedence `read-port-from-fs`
+    ;; (the sync slice) already implements via its leading `or`. The
+    ;; pre-fix shape hard-resolved `{:port nil}` here, so a stale
+    ;; `--port-file` short-circuited the whole cascade even when the env
+    ;; var / configured roots / shadow HTTP endpoint / cwd scan would
+    ;; have found a live port (rf2-olvr5 finding 4).
+    (and explicit-port-file (seq explicit-port-file)
+         (some? (read-port-file explicit-port-file)))
+    (js/Promise.resolve {:port         (read-port-file explicit-port-file)
+                         :project-home (node-path/dirname explicit-port-file)})
 
     ;; Step 2 — $SHADOW_CLJS_NREPL_PORT.
     (some? (read-env-port))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -78,6 +78,7 @@
             [re-frame2-pair-mcp.tools.cap :as cap]
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.precheck :as precheck]
+            [re-frame2-pair-mcp.tools.operating-frame :as operating-frame]
             [re-frame2-pair-mcp.tools.registry :as registry]
             [re-frame2-pair-mcp.tools.descriptors :as descriptors]))
 
@@ -401,11 +402,34 @@
       ;; agent reads the actionable rejection and corrects the arg.
       (js/Promise.resolve (wire/err-text cap))
       (let [enabled? (args/parse-bool-arg args :cache)
+            ;; rf2-olvr5 finding 3 — fold the RESOLVED build into the
+            ;; cache identity so a precheck-hash collision across two
+            ;; builds on the one nREPL connection can't serve the wrong
+            ;; build's payload. `arg-build` is a pure read (runs AFTER
+            ;; `stick-build!` above so the sticky default is current);
+            ;; the build-alias canonicalisation runs in the pipeline's
+            ;; first step, but the raw resolved id is a sufficient
+            ;; discriminator for the cache key (a suffix vs canonical id
+            ;; only ever maps to ONE running build).
+            build    (wire/arg-build conn args)
             ctx      {:conn       conn
                       :name       name
                       :args       args
                       :extra      extra
                       :result     nil
-                      :cache-opts {:tool name :args args :enabled? enabled?}
+                      :cache-opts {:tool name :args args :enabled? enabled? :build build}
                       :cap-opts   {:tool name :cap cap}}]
-        (bs/run-and-extract wire-boundary-pipeline ctx)))))
+        (-> (bs/run-and-extract wire-boundary-pipeline ctx)
+            ;; rf2-olvr5 finding 3 — a successful operating-frame mutation
+            ;; (set / reset) shifts where every omitted-`:frame` read
+            ;; resolves, so any cached payload keyed only on `(tool, build,
+            ;; args)` would be served against the WRONG frame (the
+            ;; identical-app-db-hash multi-frame case). Flush the whole
+            ;; response cache here at the chokepoint — keeping the cache ns
+            ;; free of an operating-frame require cycle. Skipped on an
+            ;; error result (the pin didn't change).
+            (.then (fn [result-js]
+                     (when (and (operating-frame/operating-frame-mutating? name)
+                                (not (isError? result-js)))
+                       (cache/clear!))
+                     result-js)))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -99,6 +99,8 @@
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.await-promise :as await-promise]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.epoch-egress :as egress]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
@@ -299,6 +301,25 @@
         ;; `reset-frame-db` already route it.
         frame        (some-> (wire/arg args :frame) args/->frame-keyword)
         fx-overrides (when-let [o (wire/arg args :fx-overrides)] (js->clj o :keywordize-keys true))
+        ;; rf2-olvr5 finding 1 — `:trace` (`dispatch-and-collect`) and
+        ;; `:settle` (`dispatch-and-settle!`) return RAW epoch material
+        ;; (`:epoch` carrying `:db-before`/`:db-after`/`:trigger-event`/
+        ;; `:trace-events`; `:settle` also `:render-events`). Unlike the
+        ;; default sync / queued consequence shapes — which carry no raw
+        ;; app-db — these MUST route through the framework's off-box
+        ;; projection (`re-frame.core/projected-record`) before crossing
+        ;; the nREPL/MCP wire, exactly as the pull-mode `trace-window` /
+        ;; `watch-epochs` surfaces do (rf2-6wvh5). The `--allow-sensitive-
+        ;; reads` boot gate (`raw-state-allowed?`, positive sense — true
+        ;; only when the operator opted in at launch) is the single
+        ;; predicate: gate-OFF (default) ⇒ project; gate-ON + opt-in ⇒
+        ;; ship raw (the operator's deliberate choice). `:include-sensitive
+        ;; true` is honoured ONLY behind the gate, mirroring every other
+        ;; egress surface.
+        incl?        (if (raw-state/raw-state-allowed?)
+                       (boolean (wire/arg args :include-sensitive))
+                       false)
+        project?     (not incl?)
         [tag payload] (parse-event-edn event-str)]
     (case tag
       :err
@@ -349,7 +370,18 @@
                            conn build-id timeout-ms sentinel
                            (await-render-callbacks mode))))
                 (.catch (fn [err] (probe/err->result :dispatch-failed err)))))
-          (let [form (ef/emit (ef/rt-call fn-sym event-vec opts-form))]
+          (let [call-src (ef/emit (ef/rt-call fn-sym event-vec opts-form))
+                ;; rf2-olvr5 finding 1 — only the epoch-bearing modes
+                ;; (`:trace` / `:settle`) carry raw `:epoch` /
+                ;; `:render-events`; wrap their emitted form so the
+                ;; projection runs APP-SIDE (where the frame's
+                ;; `[:rf/runtime :elision]` registry is reachable, same as
+                ;; the snapshot / trace-window walkers) before the result
+                ;; crosses the wire. The sync / queued consequence shapes
+                ;; carry no raw app-db, so they emit the bare call.
+                form     (if (contains? #{:trace :settle} mode)
+                           (egress/project-dispatch-result-src call-src project?)
+                           call-src)]
             (probe/eval-after-runtime!
               conn build-id form :dispatch-failed
               (fn [v] (runtime-envelope->result mode v)))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/epoch_egress.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/epoch_egress.cljs
@@ -58,6 +58,62 @@
   the projection single-sourced in the framework and removes the
   \"one missed slot\" leak surface the core docstring warns about.")
 
+(defn project-dispatch-result-src
+  "CLJS source that projects the epoch-bearing slots of a dispatch
+  `:trace` / `:settle` result map for off-box egress (rf2-olvr5
+  finding 1). `result-src` is a raw CLJS expression that evaluates to
+  the runtime dispatch fn's return (a map, or a non-map degraded value).
+
+  `dispatch-and-collect` (`:trace`) returns the cascade envelope PLUS a
+  full `:epoch` — the verbatim assembled `:rf/epoch-record` carrying
+  `:db-before` / `:db-after` / `:trigger-event` / `:trace-events` app-db
+  snapshots. `dispatch-and-settle!` (`:settle`) additionally returns
+  `:render-events` — the view-lifecycle trace events folded out of that
+  epoch's `:trace-events`. Both rode the nREPL/MCP wire VERBATIM before
+  this fix, bypassing the framework's off-box projection: a schema-
+  declared `:sensitive?` slot inside `:db-before`/`:db-after` (or inside
+  a render event's `:rf.event/db` tag) leaked to the MCP/LLM boundary
+  with `--allow-sensitive-reads` OFF (the published default) — the same
+  hole rf2-6wvh5 closed for the pull-mode `trace-window` / `watch-epochs`
+  surfaces.
+
+  When `project?` is true (gate-OFF / not-opted-in) the emitted source
+  routes `:epoch` through `re-frame.core/projected-record` (the single
+  normative off-box-egress emission site — Security.md §Epoch privacy
+  posture) and RE-DERIVES `:render-events` from the projected epoch's
+  now-elided `:trace-events`, so the two stay consistent and the render
+  events can't carry un-elided app-db material the `:epoch` slot already
+  redacted. `:cascade-summary` / `:epoch-id` / `:db-changed?` and the
+  other consequence slots carry no raw app-db material and pass through
+  untouched. When `project?` is false (operator opted in via
+  `--allow-sensitive-reads`) the result passes through verbatim — the
+  raw-egress opt-in, mirroring subscribe's bare-drain path.
+
+  Non-map results (a degraded runtime, or the `:ok? false` frame-
+  untargetable envelope — which carries no epoch) pass through
+  unchanged: the `when (map? ...)` guard keeps the transform total."
+  [result-src project?]
+  (if-not project?
+    result-src
+    (str "(let [r# " result-src "]"
+         "  (if-not (map? r#) r#"
+         "    (let [pe# (when (contains? r# :epoch)"
+         "                (re-frame.core/projected-record (:epoch r#)))]"
+         "      (cond-> r#"
+         "        (contains? r# :epoch)"
+         "        (assoc :epoch pe#)"
+         ;; Re-derive :render-events from the PROJECTED epoch's trace-events
+         ;; so they inherit the same elision the :epoch slot just got — the
+         ;; render events are a filtered view of :trace-events, never an
+         ;; independent payload that could leak after the epoch redacts.
+         "        (contains? r# :render-events)"
+         "        (assoc :render-events"
+         "               (filterv (fn [ev#]"
+         "                          (contains? #{:rf.view/render :rf.view/rendered"
+         "                                       :rf.view/rendered-cap-reached :rf.view/unmounted}"
+         "                                     (:operation ev#)))"
+         "                        (:trace-events pe#)))))))")))
+
 (defn project-page-src
   "CLJS source that projects a let-bound vector of epoch records for
   off-box egress. `page-sym` is the name of the let-bound page (a CLJS

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
@@ -73,6 +73,22 @@
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
+;; rf2-olvr5 finding 3 — the response cache key is `(tool, build,
+;; args-fingerprint)`; it deliberately can NOT include the resolved
+;; operating frame for an omitted-`:frame` call (that resolves runtime-
+;; side, after the key is built). So a `get-path {path X}` with no
+;; `:frame` arg, cached against operating frame A, would serve A's payload
+;; after the session switches to frame B if B happens to share A's
+;; app-db-hash (the multi-frame identical-initial-db case the bead
+;; reproduces). The fix flushes the WHOLE response cache whenever the
+;; operating frame changes — and to avoid a `cache → registry →
+;; operating-frame → cache` require cycle (registry wires these handlers,
+;; cache reads registry's `cacheable?`), the flush is driven from the
+;; `invoke` dispatch chokepoint in `re-frame2-pair-mcp.tools` (which
+;; already requires both `cache` and `registry`) rather than imported
+;; here. `operating-frame-mutating?` is the predicate that chokepoint
+;; consults.
+
 ;; ---------------------------------------------------------------------------
 ;; set-operating-frame
 ;;
@@ -167,6 +183,23 @@
           (if (map? v)
             v
             {:ok? false :reason :unexpected-shape :value v}))))))
+
+(def operating-frame-mutating-tools
+  "Tool names whose successful invocation changes the session's operating
+  frame, invalidating every omitted-`:frame` cached read (rf2-olvr5
+  finding 3). The `invoke` chokepoint flushes the response cache after
+  these run. `get-operating-frame` is a pure read and is NOT included."
+  #{"set-operating-frame" "reset-operating-frame"})
+
+(defn operating-frame-mutating?
+  "True iff `tool-name` is an operating-frame mutation (rf2-olvr5
+  finding 3) — the predicate `re-frame2-pair-mcp.tools/invoke` consults
+  to decide whether to flush the response cache after the call. Lives
+  here (not in `cache`) so the cache ns stays free of an
+  operating-frame require; lives as a name-set check (not a per-result
+  inspection) so the chokepoint never has to parse the tool's envelope."
+  [tool-name]
+  (contains? operating-frame-mutating-tools tool-name))
 
 ;; ---------------------------------------------------------------------------
 ;; get-operating-frame

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/raw_state.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/raw_state.cljs
@@ -17,8 +17,11 @@
   2. FORCES `:elision true` on every snapshot / get-path call,
      regardless of what the caller passed.
   3. Signals the preload runtime to default-elide its `tap>` emissions
-     (see `runtime/configure-raw-state!`). This is one nREPL round-trip
-     issued once per session at first tool use.
+     (see `runtime/configure-raw-state!`). This is one tiny idempotent
+     nREPL round-trip issued before every state-emitting tool eval —
+     re-signalled rather than cached-as-delivered, because the runtime's
+     posture resets to its permissive default on every page/runtime
+     reload (rf2-olvr5 finding 2; see `signal-runtime!`).
 
   When `--allow-sensitive-reads` is ON, the per-call args win — the same
   behaviour re-frame2-pair-mcp shipped pre-rf2-c2dtu.
@@ -122,70 +125,76 @@
 ;; The runtime exposes `configure-raw-state!` (rf2-c2dtu) which sets a
 ;; per-runtime flag controlling whether `app-db-reset!` taps raw values or
 ;; redacts via `elide-wire-value`. The MCP server pushes its boot-gate
-;; state into the runtime once per session.
-
-(defonce ^:private runtime-signalled?
-  ;; Per-build-id flag — true once `configure-raw-state!` has RESOLVED
-  ;; against this build's runtime in the current server lifetime.
-  ;;
-  ;; rf2-z7roa — the flag is set only AFTER the configure eval resolves
-  ;; (success or swallowed-failure), never speculatively before the
-  ;; round-trip lands. Marking it eagerly let a concurrent first tool
-  ;; call short-circuit to resolved-nil and proceed to tap RAW app-db
-  ;; before `configure-raw-state!` had flipped the runtime's posture.
-  ;;
-  ;; Build-keyed because re-frame2-pair-mcp can talk to multiple shadow-cljs builds
-  ;; over the same nREPL connection; each build has its own preloaded
-  ;; runtime atom.
-  (atom #{}))
+;; state into the runtime before every state-emitting eval — the
+;; per-runtime flag resets to its permissive default on every page/runtime
+;; reload, so the posture is re-signalled rather than cached as delivered
+;; (rf2-olvr5 finding 2).
 
 (defonce ^:private runtime-signalling
   ;; Per-build-id IN-FLIGHT configure-raw-state! Promise. A second
   ;; concurrent caller for the same build awaits the SAME Promise rather
   ;; than firing a duplicate signal OR racing ahead while the first
   ;; signal is still in flight (rf2-z7roa). Cleared once resolved.
+  ;;
+  ;; Build-keyed because re-frame2-pair-mcp can talk to multiple shadow-cljs
+  ;; builds over the same nREPL connection; each build has its own
+  ;; preloaded runtime atom.
   (atom {}))
 
 (defn signal-runtime!
-  "Send the boot-gate state to the preload runtime exactly once per
-  build-id per server lifetime. The runtime's `configure-raw-state!`
-  flips its own atom — subsequent `app-db-reset!` calls then elide
-  before emitting through `tap>`.
+  "Reconfigure the preload runtime's raw-state posture before each
+  state-emitting eval. The runtime's `configure-raw-state!` flips its own
+  atom — subsequent `app-db-reset!` calls then elide before emitting
+  through `tap>`.
 
-  Idempotent: a no-op once the signal has RESOLVED for `build-id`. While
-  a signal is in flight for a build, a concurrent caller awaits the same
-  Promise (rf2-z7roa) — it never proceeds to a state-emitting eval ahead
-  of the posture landing. Failure (the runtime predates rf2-c2dtu) is
-  swallowed silently — the wire-side enforcement still holds, so a
-  degraded runtime just means `tap>` consumers see raw values (the
-  pre-rf2-c2dtu posture).
+  ## Why this re-signals on EVERY call rather than caching 'delivered'
+  per build (rf2-olvr5 finding 2)
 
-  rf2-z7roa: the per-build `runtime-signalled?` flag is set ONLY after
-  the configure eval resolves, never speculatively before the round-
-  trip. This guarantees a first state-emitting tool call (snapshot /
-  get-path / subscribe / reset-frame-db / dispatch-dry-run) can never
-  tap raw app-db ahead of `configure-raw-state!` flipping the runtime.
+  The runtime's `raw-state-config` atom defaults to `:allow-raw-state?
+  true` (the bare-CLJS-REPL posture) and is RE-MINTED on every full page
+  reload / CLJS heap reset — a fresh preload evaluation re-`defonce`s it
+  back to the permissive default, and re-mints `session-id` too. The
+  pre-fix shape recorded the signal as DELIVERED once per `build-id` per
+  server lifetime and short-circuited thereafter. So after a reload, the
+  build-id was still in the resolved set, `signal-runtime!` returned a
+  no-op, the freshly-recreated runtime stayed at its permissive default,
+  and the next state-emitting tool (snapshot / get-path / subscribe /
+  reset-frame-db / restore-epoch / dispatch-dry-run / record /
+  watch-until) could tap RAW prev/next app-db through `tap>` even with
+  `--allow-sensitive-reads` OFF.
+
+  The server can't cheaply know the current `session-id` without a
+  round-trip, and `configure-raw-state!` is idempotent + tiny (one
+  bencode round-trip on the persistent socket — same shape every call).
+  So the correct fix is to NOT cache the posture across runtime identity:
+  always reconfigure before a tap-emitting write. The per-build IN-FLIGHT
+  `runtime-signalling` dedup is preserved — a burst of concurrent
+  state-emitting calls for the same build still share ONE configure
+  Promise (the rf2-z7roa race guard: no caller proceeds to its
+  state-emitting eval ahead of the posture landing) — but once that
+  Promise resolves the next call reconfigures afresh rather than skipping.
+
+  Failure (a runtime predating rf2-c2dtu) is swallowed silently — the
+  wire-side enforcement still holds, so a degraded runtime just means
+  `tap>` consumers see raw values (the pre-rf2-c2dtu posture).
 
   Called between `ensure-runtime!` and the first state-emitting eval in
-  each tool body that taps / egresses app-db. Returns a Promise
-  resolving to nil."
+  each tool body that taps / egresses app-db. Returns a Promise resolving
+  to nil."
   [conn build-id]
-  (cond
-    (contains? @runtime-signalled? build-id)
-    (js/Promise.resolve nil)
-
-    (contains? @runtime-signalling build-id)
+  (if (contains? @runtime-signalling build-id)
+    ;; A configure is already in flight for this build — share it so a
+    ;; concurrent caller never races ahead of the posture landing
+    ;; (rf2-z7roa) and we don't fire a duplicate round-trip in the burst.
     (get @runtime-signalling build-id)
-
-    :else
     (let [form (ef/emit
                  (ef/rt-call 'configure-raw-state!
                              {:allow-raw-state? @allow-raw-state?}))
-          ;; Mark the build resolved + drop the in-flight entry. Run on
-          ;; BOTH the success and swallowed-failure arms — once the
-          ;; round-trip lands (or fails), the posture decision is final.
+          ;; Drop the in-flight entry on BOTH the success and swallowed-
+          ;; failure arms. We do NOT record a permanent 'delivered' flag:
+          ;; the runtime's posture resets on reload, so a future call must
+          ;; reconfigure (rf2-olvr5 finding 2).
           finish! (fn []
-                    (swap! runtime-signalled? conj build-id)
                     (swap! runtime-signalling dissoc build-id)
                     nil)
           p       (-> (nrepl/cljs-eval-value conn build-id form)
@@ -193,15 +202,12 @@
                       (.catch (fn [_]
                                 ;; Degraded runtime — predates rf2-c2dtu.
                                 ;; Swallow; the wire-side gate still
-                                ;; enforces. Mark resolved so we don't
-                                ;; re-probe a runtime that can't answer.
+                                ;; enforces.
                                 (finish!))))]
       (swap! runtime-signalling assoc build-id p)
       p)))
 
 (defn reset-runtime-signal-cache!
-  "Clear the per-session signal cache (resolved + in-flight). Exposed
-  for tests."
+  "Clear the per-session signal in-flight map. Exposed for tests."
   []
-  (reset! runtime-signalled? #{})
   (reset! runtime-signalling {}))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reset_frame_db.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reset_frame_db.cljs
@@ -46,11 +46,13 @@
 
   So this tool — like the direct-read surfaces (snapshot / get-path /
   subscribe, rf2-c2dtu) — issues `raw-state/signal-runtime!` AFTER
-  `ensure-runtime!` and BEFORE the `app-db-reset!` eval. The signal is
-  idempotent + build-keyed; `signal-runtime!` only marks the cache
-  successful once the `configure-raw-state!` eval has been issued, so a
-  first reset can never tap raw values ahead of the posture landing.
-  This is why `reset-frame-db` does NOT use the plain
+  `ensure-runtime!` and BEFORE the `app-db-reset!` eval. The signal
+  reconfigures the runtime's posture before every state-emitting eval
+  (rf2-olvr5 finding 2 — the runtime's posture resets on reload, so a
+  cached 'delivered' flag would let a post-reload reset tap raw values);
+  concurrent calls for the same build still share ONE in-flight
+  configure Promise, so a reset can never tap raw values ahead of the
+  posture landing. This is why `reset-frame-db` does NOT use the plain
   `probe/eval-after-runtime!` prelude (which skips the signal step) —
   it threads `signal-runtime!` between the probe and the eval."
   (:require [re-frame2-pair-mcp.nrepl :as nrepl]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
@@ -113,9 +113,11 @@
           ;; gate-OFF posture. Mirrors dispatch-dry-run's prelude shape
           ;; (which restore-epoch's primitive internally drives) — we can
           ;; not use the plain `eval-after-runtime!` prelude because that
-          ;; helper has no `signal-runtime!` step. The signal is idempotent
-          ;; per build per session, so a session that already signalled
-          ;; (e.g. via a prior snapshot/dry-run) pays no extra round-trip.
+          ;; helper has no `signal-runtime!` step. The signal reconfigures
+          ;; the posture before every state-emitting eval (rf2-olvr5
+          ;; finding 2 — the runtime's posture resets on reload, so a
+          ;; cached-delivered flag would leave a post-reload restore tapping
+          ;; raw values); it is one tiny idempotent round-trip.
           (-> (probe/ensure-runtime! conn build-id)
               (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
               (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
@@ -439,6 +439,43 @@
     (is (some? (cache/precheck opts-a h))
         "matching key → precheck hits")))
 
+(deftest precheck-build-discriminates-key
+  ;; rf2-olvr5 finding 3 — the cache key includes the resolved BUILD. A
+  ;; precheck-hash primed for (get-path, args, build-A) MUST NOT serve a
+  ;; lookup for (get-path, args, build-B) even when the hashes collide
+  ;; (two builds on one nREPL connection with the same app-db-hash). The
+  ;; pre-fix key was `(tool, args)` only — a cross-build collision served
+  ;; the wrong build's payload.
+  (let [args   (args-js {:path "[:k]"})
+        h      22222
+        opts-a {:tool "get-path" :args args :enabled? true :build :app}
+        opts-b {:tool "get-path" :args args :enabled? true :build :other}]
+    (cache/apply-cache (mcp-result "{:k :build-a}")
+                       (assoc opts-a :precheck-hash h))
+    (is (nil? (cache/precheck opts-b h))
+        "same (tool,args)+colliding hash but DIFFERENT build → no cross-build hit")
+    (is (some? (cache/precheck opts-a h))
+        "same build → precheck hits")))
+
+(deftest apply-cache-build-discriminates-key
+  ;; The post-eval result-hash path shares the same key, so the build
+  ;; discriminator applies there too: an identical result text for two
+  ;; builds must NOT cross-pollinate.
+  (let [args   (args-js {:path "[:k]"})
+        opts-a {:tool "get-path" :args args :enabled? true :build :app}
+        opts-b {:tool "get-path" :args args :enabled? true :build :other}
+        result (mcp-result "{:k :same-text}")]
+    ;; Prime build-A.
+    (cache/apply-cache result opts-a)
+    ;; Build-B with byte-identical text — FIRST store for build-B's key,
+    ;; so it must pass through unchanged (not a cache-hit marker).
+    (let [out (cache/apply-cache result opts-b)]
+      (is (not (cache-hit-result? out))
+          "identical text under a DIFFERENT build is a fresh store, not a hit"))
+    ;; A second build-A call DOES hit (same key, same text).
+    (is (cache-hit-result? (cache/apply-cache result opts-a))
+        "same build + same text → result-hash hit")))
+
 (deftest precheck-hit-touches-lru
   ;; A precheck hit is still a use of the entry — touch the LRU so
   ;; the entry doesn't rotate out under capacity pressure.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
@@ -14,12 +14,37 @@
       MCP arg (string) → read-string → vector check → rt-call data arg
                               ↑
                               the security gate (rf2-vflrg)"
-  (:require [cljs.test :refer-macros [deftest is async]]
+  (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
             [cljs.reader]
             [clojure.string :as str]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
             [re-frame2-pair-mcp.tools.dispatch :as dispatch]))
+
+;; ## Stub lifetime — fixture-scoped, not Promise-chain-scoped (rf2-wb06a)
+;;
+;; `with-captured-eval!` installs its `cljs-eval-value` stub via a bare
+;; `set!` (no per-test `.finally`); the `:after` fixture below restores
+;; the pristine original captured at ns-load. A `.finally`-scoped restore
+;; fires AFTER cljs.test's `done` has advanced to the NEXT test (often the
+;; next NAMESPACE, e.g. orient-test), where it clobbers that neighbour's
+;; freshly-installed stub mid-eval — surfacing as a `captured = nil`
+;; (the orient-test failure) or a real-socket `EADDRNOTAVAIL`. The fixture
+;; boundary closes that race (the same fix orient_test / invoke_test carry).
+;;
+;; The `--allow-sensitive-reads` boot gate is also module-level state: the
+;; rf2-olvr5 finding-1 tests set it SYNCHRONOUSLY inside each body-fn
+;; (immediately before the synchronous form build, no intervening await)
+;; and the `:after` fixture resets it to the published default (OFF) so a
+;; gate-ON test can't leak its posture into a neighbour.
+
+(def ^:private pristine-eval nrepl/cljs-eval-value)
+
+(use-fixtures :each
+  {:after (fn []
+            (set! nrepl/cljs-eval-value pristine-eval)
+            (raw-state/set-allow-raw-state! false))})
 
 ;; ---------------------------------------------------------------------------
 ;; Stub harness — capture the form string the dispatch tool would have
@@ -35,10 +60,11 @@
 
 (defn- with-captured-eval!
   "Install a stub `cljs-eval-value` that records the form string into
-  `captured*` and resolves to `canned-value`. Restore in `.finally`."
+  `captured*` and resolves to `canned-value`. Cleanup is the `:after`
+  fixture's job (rf2-wb06a) — NOT a per-call `.finally`, which fires after
+  `done` and races a neighbour's stub."
   [captured* canned-value body-fn]
-  (let [orig nrepl/cljs-eval-value
-        stub (fn
+  (let [stub (fn
                ([_conn _build-id form-str]
                 (reset! captured* form-str)
                 (js/Promise.resolve canned-value))
@@ -47,8 +73,7 @@
                 (js/Promise.resolve canned-value)))]
     (set! nrepl/cljs-eval-value stub)
     (-> (js/Promise.resolve nil)
-        (.then (fn [_] (body-fn)))
-        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+        (.then (fn [_] (body-fn))))))
 
 ;; `read-result-text` (EDN read of the wire envelope) and `err?` are the
 ;; shared extractors (rf2-wnrpi) — aliased from `test-utils`.
@@ -209,13 +234,25 @@
   ;; settled epoch). Unlike `:await-render`, the runtime fn returns a map
   ;; directly, so the emitted form is the ordinary `rt-call` (NOT the
   ;; await-promise mailbox wrapper).
+  ;;
+  ;; rf2-olvr5 finding 1 — raw egress requires BOTH the gate ON AND an
+  ;; explicit `:include-sensitive true` (the same two-key contract every
+  ;; other egress surface wears — see `epoch_egress`). With both, the
+  ;; settle form is the BARE call (no projection wrap), so the original
+  ;; structural `read-string` assertions hold verbatim. The default-gate
+  ;; projection is pinned by `settle-projects-epoch-by-default-when-gate-off`.
   (async done
     (let [captured (atom nil)]
       (-> (with-captured-eval! captured {:ok? true :epoch-id 11 :settled? true
                                          :render-events [] :cascade-summary {:renders 1}}
             (fn []
+              ;; Set the gate ON immediately before the synchronous
+              ;; form-build so there's no async-fixture window where it
+              ;; could be flipped back (the gate is global mutable state).
+              (raw-state/set-allow-raw-state! true)
               (dispatch/dispatch-tool (fresh-conn)
-                                      #js {:event "[:list/toggle]" :settle true})))
+                                      #js {:event "[:list/toggle]" :settle true
+                                           :include-sensitive true})))
           (.then (fn [r]
                    (is (not (err? r)))
                    (let [form @captured]
@@ -223,12 +260,108 @@
                          ":settle routes to the synchronous dispatch-and-settle!")
                      (is (not (str/includes? form "__rf2pair_await__"))
                          "NO mailbox wrapper — dispatch-and-settle! is synchronous")
+                     (is (not (str/includes? form "projected-record"))
+                         "gate ON ⇒ no projection wrap — operator opted into raw egress")
                      (let [parsed (cljs.reader/read-string form)]
                        (is (= 're-frame2-pair.runtime/dispatch-and-settle! (first parsed)))
                        (is (= [:list/toggle] (second parsed)))))
                    (let [edn (read-result-text r)]
                      (is (= :settle (:mode edn)) "mode is :settle")
                      (is (true? (:settled? edn)) "the settled flag rides through"))
+                   (raw-state/set-allow-raw-state! false)
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-olvr5 finding 1 — epoch-bearing dispatch modes project before egress.
+;;
+;; `:trace` (dispatch-and-collect) and `:settle` (dispatch-and-settle!)
+;; return RAW `:epoch` records (db-before / db-after / trigger-event /
+;; trace-events) plus, for settle, `:render-events`. With the
+;; `--allow-sensitive-reads` gate OFF (the published default) the emitted
+;; form MUST route the result's epoch slots through
+;; `re-frame.core/projected-record` APP-SIDE before crossing the wire —
+;; mirroring the pull-mode trace-window / watch-epochs egress (rf2-6wvh5).
+;; The default sync / queued consequence shapes carry no raw app-db, so
+;; they stay un-wrapped.
+;; ---------------------------------------------------------------------------
+
+(deftest settle-projects-epoch-by-default-when-gate-off
+  ;; Gate OFF (default) ⇒ the settle form wraps the runtime call so the
+  ;; result's `:epoch` is projected via `projected-record` and
+  ;; `:render-events` is re-derived from the projected (elided) epoch's
+  ;; trace-events. The runtime fn is still invoked (substring intact).
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true :epoch-id 11 :settled? true}
+            (fn []
+              (raw-state/set-allow-raw-state! false)
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:list/toggle]" :settle true})))
+          (.then (fn [_]
+                   (let [form @captured]
+                     (is (str/includes? form "dispatch-and-settle!")
+                         "the runtime settle fn is still the inner call")
+                     (is (str/includes? form "re-frame.core/projected-record")
+                         "gate OFF ⇒ :epoch routes through the framework's off-box projection")
+                     (is (str/includes? form ":render-events")
+                         "the settle form re-derives :render-events from the projected epoch"))
+                   (done)))))))
+
+(deftest trace-projects-epoch-by-default-when-gate-off
+  ;; Gate OFF (default) ⇒ the trace form (dispatch-and-collect) wraps the
+  ;; runtime call so the returned `:epoch` is projected before egress.
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true :epoch-id 7 :epoch {:frame :rf/default}}
+            (fn []
+              (raw-state/set-allow-raw-state! false)
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:list/toggle]" :trace true})))
+          (.then (fn [_]
+                   (let [form @captured]
+                     (is (str/includes? form "dispatch-and-collect")
+                         "the runtime trace fn is still the inner call")
+                     (is (str/includes? form "re-frame.core/projected-record")
+                         "gate OFF ⇒ :epoch routes through projected-record before egress"))
+                   (done)))))))
+
+(deftest trace-ships-raw-when-gate-on
+  ;; Gate ON (--allow-sensitive-reads) AND explicit `:include-sensitive
+  ;; true` ⇒ the trace form is the bare call, no projection — the
+  ;; deliberate raw-egress opt-in, mirroring subscribe's bare-drain path.
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true :epoch-id 7}
+            (fn []
+              (raw-state/set-allow-raw-state! true)
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:list/toggle]" :trace true
+                                           :include-sensitive true})))
+          (.then (fn [_]
+                   (let [form @captured]
+                     (is (str/includes? form "dispatch-and-collect"))
+                     (is (not (str/includes? form "projected-record"))
+                         "gate ON ⇒ raw epoch ships verbatim (operator opt-in)"))
+                   (raw-state/set-allow-raw-state! false)
+                   (done)))))))
+
+(deftest sync-mode-does-not-project
+  ;; The default sync consequence (dispatch-consequence!) carries no raw
+  ;; app-db — it returns :db-changed? / :changed-paths / :effects-fired,
+  ;; not :db-before/:db-after. It must NOT be wrapped in the projection
+  ;; (the wrap is for the epoch-bearing modes only).
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true :epoch-id 7 :db-changed? false}
+            (fn []
+              (raw-state/set-allow-raw-state! false)
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:list/toggle]" :sync true})))
+          (.then (fn [_]
+                   (let [form @captured]
+                     (is (str/includes? form "dispatch-consequence!"))
+                     (is (not (str/includes? form "projected-record"))
+                         "sync consequence carries no raw app-db — no projection wrap"))
                    (done)))))))
 
 (deftest settle-wins-over-other-mode-flags
@@ -604,8 +737,7 @@
   `read-count*` records how many poll reads happened — the deterministic
   proof the server waited for the flush rather than resolving eagerly."
   [{:keys [wrap-form* read-count* pending-polls resolved]} body-fn]
-  (let [orig nrepl/cljs-eval-value
-        respond (fn [form-str]
+  (let [respond (fn [form-str]
                   (cond
                     (await-wrap-form? form-str)
                     (do (reset! wrap-form* form-str)
@@ -625,8 +757,7 @@
                ([_conn _build-id form-str _opts] (respond form-str)))]
     (set! nrepl/cljs-eval-value stub)
     (-> (js/Promise.resolve nil)
-        (.then (fn [_] (body-fn)))
-        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+        (.then (fn [_] (body-fn))))))
 
 (deftest await-render-emits-substrate-agnostic-flush-form
   ;; SHAPE invariant: the settle form must flush via the adapter

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
@@ -53,7 +53,9 @@
             [re-frame2-pair-mcp.cache :as cache]
             [re-frame2-pair-mcp.tools :as tools]
             [re-frame2-pair-mcp.tools.precheck :as precheck]
+            [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.get-path :as get-path]
+            [re-frame2-pair-mcp.tools.operating-frame :as operating-frame]
             [re-frame2-pair-mcp.tools.snapshot :as snapshot]))
 
 ;; ---------------------------------------------------------------------------
@@ -72,11 +74,13 @@
 (def ^:private orig-fetch-precheck-hash precheck/fetch-precheck-hash)
 (def ^:private orig-get-path-tool       get-path/get-path-tool)
 (def ^:private orig-snapshot-tool       snapshot/snapshot-tool)
+(def ^:private orig-reset-operating-frame-tool operating-frame/reset-operating-frame-tool)
 
 (defn- restore-stubs! []
   (set! precheck/fetch-precheck-hash orig-fetch-precheck-hash)
   (set! get-path/get-path-tool       orig-get-path-tool)
-  (set! snapshot/snapshot-tool       orig-snapshot-tool))
+  (set! snapshot/snapshot-tool       orig-snapshot-tool)
+  (set! operating-frame/reset-operating-frame-tool orig-reset-operating-frame-tool))
 
 (use-fixtures :each
   {:before (fn [] (cache/clear!))
@@ -137,10 +141,12 @@
       :fetch-precheck-hash (set! precheck/fetch-precheck-hash stub)
       :get-path-tool       (set! get-path/get-path-tool       stub)
       :snapshot-tool       (set! snapshot/snapshot-tool       stub)
+      :reset-operating-frame-tool (set! operating-frame/reset-operating-frame-tool stub)
       (throw (ex-info (str "Unknown stub kind: " kind)
                       {:kind kind :known #{:fetch-precheck-hash
                                            :get-path-tool
-                                           :snapshot-tool}})))))
+                                           :snapshot-tool
+                                           :reset-operating-frame-tool}})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Phase-1 short-circuit: precheck hit ⇒ dispatch SKIPPED.
@@ -155,10 +161,15 @@
   (async done
     (let [args        (args-js {:cache "true" :path "[:k]"})
           dispatched? (atom false)
+          ;; rf2-olvr5 finding 3 — the cache key now includes the resolved
+          ;; build, so the priming MUST use the same build the `invoke`
+          ;; pipeline will derive (`arg-build nil args` = the env / `:app`
+          ;; default here) or the lookup key won't match.
           _ (cache/apply-cache (mcp-result "{:k :v}")
                                {:tool "get-path"
                                 :args args
                                 :enabled? true
+                                :build (wire/arg-build nil args)
                                 :precheck-hash 42})]
       (set-stubs!
         {:fetch-precheck-hash (fn [_conn _args _frame] (js/Promise.resolve 42))
@@ -545,4 +556,63 @@
                           (get-in (extract-edn second-result)
                                   [:rf.mcp/cache-hit :via]))
                        "via :precheck — the sound short-circuit is preserved")
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-olvr5 finding 3 — an operating-frame change FLUSHES the response
+;; cache. The cache key is `(tool, build, args)` and CANNOT include the
+;; resolved operating frame for an omitted-`:frame` call (it resolves
+;; runtime-side). So a `get-path {path X}` cached against operating frame
+;; A would be served against frame B after a frame switch if B shared A's
+;; app-db hash (multi-frame identical-initial-db). Clearing the whole
+;; cache on every operating-frame mutation closes that hole.
+;; ---------------------------------------------------------------------------
+
+(deftest operating-frame-change-flushes-cache
+  (async done
+    ;; Prime the cache with a no-`:frame` get-path entry (resolved
+    ;; against "operating frame A"). The entry exists.
+    (let [gp-args (args-js {:cache "true" :path "[:k]"})]
+      (cache/apply-cache (mcp-result "{:k :frame-a}")
+                         {:tool "get-path"
+                          :args gp-args
+                          :enabled? true
+                          :build (wire/arg-build nil gp-args)
+                          :precheck-hash 42})
+      (is (= 1 (cache/size)) "cache primed with the frame-A get-path entry")
+      ;; A successful reset-operating-frame must flush the cache.
+      (set-stubs!
+        {:reset-operating-frame-tool
+         (fn [_conn _args]
+           (js/Promise.resolve (mcp-result "{:ok? true :selected nil :operating :rf/b}")))})
+      (-> (tools/invoke nil "reset-operating-frame" (args-js {}) nil)
+          (.then (fn [result]
+                   (is (not (j/get result :isError))
+                       "reset-operating-frame succeeded")
+                   (is (zero? (cache/size))
+                       (str "the operating-frame change flushed the whole response "
+                            "cache — no stale frame-A payload can be served to frame B"))
+                   (done)))))))
+
+(deftest operating-frame-error-does-not-flush-cache
+  (async done
+    ;; A FAILED set-operating-frame (unknown frame) did NOT change the pin,
+    ;; so the cache must be preserved — only a successful mutation flushes.
+    (let [gp-args (args-js {:cache "true" :path "[:k]"})]
+      (cache/apply-cache (mcp-result "{:k :frame-a}")
+                         {:tool "get-path"
+                          :args gp-args
+                          :enabled? true
+                          :build (wire/arg-build nil gp-args)
+                          :precheck-hash 42})
+      (set-stubs!
+        {:reset-operating-frame-tool
+         (fn [_conn _args]
+           (js/Promise.resolve (mcp-result "{:ok? false :reason :boom}" :error? true)))})
+      (-> (tools/invoke nil "reset-operating-frame" (args-js {}) nil)
+          (.then (fn [result]
+                   (is (true? (j/get result :isError))
+                       "the mutation errored")
+                   (is (= 1 (cache/size))
+                       "an errored operating-frame call leaves the cache intact")
                    (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -536,6 +536,36 @@
                      (restore!)
                      (done))))))))
 
+(deftest discover-port-explicit-port-file-unreadable-falls-through-to-env
+  ;; rf2-olvr5 finding 4 — a stale / typo'd explicit --port-file must NOT
+  ;; short-circuit the cascade to `{:port nil}`. When the explicit file is
+  ;; unreadable (ENOENT) the cascade falls through to step 2 ($SHADOW_CLJS_
+  ;; NREPL_PORT) — mirroring `read-port-from-fs`'s leading `or`. Pre-fix
+  ;; this resolved `{:port nil}` and stranded a live env-provided port.
+  (testing "explicit --port-file unreadable → fall through to env var"
+    (async done
+      (let [restore! (install-fs-stub! "7788" throwing-read)]
+        (-> (nrepl/discover-port* "stale/nrepl.port" nil shadow-fails roots-unsupported)
+            (.then (fn [r]
+                     (is (= 7788 (:port r))
+                         "unreadable explicit file falls through to the env var (step 2)")))
+            (.finally (fn [] (restore!) (done))))))))
+
+(deftest discover-port-explicit-port-file-unreadable-falls-through-to-roots
+  ;; rf2-olvr5 finding 4 — with no env var, the unreadable explicit file
+  ;; falls all the way through to the MCP roots/list step (step 3). The
+  ;; explicit-but-stale path is fully transparent to the rest of the cascade.
+  (testing "explicit --port-file unreadable + no env → fall through to roots discovery"
+    (async done
+      (let [restore! (install-fs-stub! nil throwing-read)]
+        (-> (nrepl/discover-port* "stale/nrepl.port" nil shadow-fails (roots-one "/abs/proj" 8799))
+            (.then (fn [r]
+                     (is (= 8799 (:port r))
+                         "unreadable explicit file falls through to roots single-candidate (step 3)")
+                     (is (= "/abs/proj" (:project-home r))
+                         "roots project-home flows through — the stale explicit path is ignored")))
+            (.finally (fn [] (restore!) (done))))))))
+
 (deftest discover-port-env-var-short-circuits-shadow-probe
   (testing "step 2 wins — env-var override skips the HTTP probe and roots discovery"
     (async done

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
@@ -20,9 +20,24 @@
   End-to-end MCP-wire shape coverage lives in
   `re-frame2-pair-mcp.conformance-test` (the corpus has dedicated
   fixtures pinning the gated default and the opt-in path)."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
             [re-frame2-pair-mcp.server :as server]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]))
+
+;; rf2-wb06a — the signal-runtime! tests `set!` the module-level
+;; `nrepl/cljs-eval-value`. Restore the pristine original in a
+;; fixture-scoped `:after` (NOT a per-test `.finally`, which fires after
+;; `done` and can clobber a neighbour namespace's stub mid-eval). Also
+;; clear the signal in-flight cache + reset the gate so each test starts
+;; from the published default.
+(def ^:private pristine-eval nrepl/cljs-eval-value)
+
+(use-fixtures :each
+  {:after (fn []
+            (set! nrepl/cljs-eval-value pristine-eval)
+            (raw-state/reset-runtime-signal-cache!)
+            (raw-state/set-allow-raw-state! false))})
 
 ;; ---------------------------------------------------------------------------
 ;; Default-OFF posture.
@@ -215,20 +230,66 @@
     (is (false? (:eval-allowed? flags)))))
 
 ;; ---------------------------------------------------------------------------
-;; signal-runtime! cache — fires once per (build-id, server-lifetime).
+;; signal-runtime! — re-signals before EVERY state-emitting eval
+;; (rf2-olvr5 finding 2). The runtime's raw-state posture resets to its
+;; permissive default on every page/runtime reload, so caching a per-build
+;; "delivered" flag (the pre-fix shape) left a post-reload runtime tapping
+;; RAW app-db. The signal now reconfigures each call; only a CONCURRENT
+;; in-flight configure for the same build is deduped (the rf2-z7roa race
+;; guard).
 ;; ---------------------------------------------------------------------------
 
-(deftest signal-runtime-caches-per-build
-  ;; The runtime-signal path must be a no-op after the first invocation
-  ;; per build-id — we don't want every state-emitting tool call to
-  ;; pay an extra nREPL round-trip.
-  (raw-state/reset-runtime-signal-cache!)
-  ;; A signal against a stubbed conn would require the nrepl ns; here
-  ;; we just verify the cache shape — after a fake "already-signalled"
-  ;; entry, signal-runtime! must return the cached-no-op Promise.
-  (raw-state/set-allow-raw-state! false)
-  (raw-state/reset-runtime-signal-cache!)
-  ;; Cache empty ⇒ a real signal would fire (we can't drive nrepl from
-  ;; node-tests cleanly). We exercise the cache-reset only.
-  (is (some? (raw-state/reset-runtime-signal-cache!))
-      "reset-runtime-signal-cache! is callable"))
+(deftest signal-runtime-reconfigures-each-call
+  ;; Drive `signal-runtime!` against a stubbed `cljs-eval-value` and count
+  ;; the configure round-trips. Sequential (non-overlapping) calls MUST
+  ;; each fire a fresh configure — no permanent per-build skip — so a
+  ;; post-reload runtime is re-signalled.
+  (async done
+    (let [calls (atom 0)
+          stub (fn
+                 ([_conn _build-id _form]
+                  (swap! calls inc)
+                  (js/Promise.resolve nil))
+                 ([_conn _build-id _form _opts]
+                  (swap! calls inc)
+                  (js/Promise.resolve nil)))]
+      (raw-state/reset-runtime-signal-cache!)
+      (raw-state/set-allow-raw-state! false)
+      (set! nrepl/cljs-eval-value stub)
+      (-> (raw-state/signal-runtime! nil :app)
+          (.then (fn [_] (raw-state/signal-runtime! nil :app)))
+          (.then (fn [_] (raw-state/signal-runtime! nil :app)))
+          (.then (fn [_]
+                   (is (= 3 @calls)
+                       "three sequential signals ⇒ three configure round-trips (no permanent per-build skip)")
+                   (done)))
+          (.catch (fn [_] (done)))))))
+
+(deftest signal-runtime-dedups-concurrent-in-flight
+  ;; Two CONCURRENT signals for the same build (issued before the first
+  ;; configure resolves) share ONE in-flight Promise — the rf2-z7roa race
+  ;; guard, preserved across the rf2-olvr5 re-signal change.
+  (async done
+    (let [calls (atom 0)
+          ;; A configure that only resolves when we tell it to, so both
+          ;; callers are genuinely in-flight at once.
+          resolve-fn* (atom nil)
+          stub (fn
+                 ([_conn _build-id _form]
+                  (swap! calls inc)
+                  (js/Promise. (fn [res _] (reset! resolve-fn* res))))
+                 ([_conn _build-id _form _opts]
+                  (swap! calls inc)
+                  (js/Promise. (fn [res _] (reset! resolve-fn* res)))))]
+      (raw-state/reset-runtime-signal-cache!)
+      (raw-state/set-allow-raw-state! false)
+      (set! nrepl/cljs-eval-value stub)
+      (let [p1 (raw-state/signal-runtime! nil :app)
+            p2 (raw-state/signal-runtime! nil :app)]
+        ;; Both issued before resolution — only ONE configure fired.
+        (is (= 1 @calls)
+            "concurrent in-flight signals for the same build share ONE configure round-trip")
+        (when-let [r @resolve-fn*] (r nil))
+        (-> (js/Promise.all #js [p1 p2])
+            (.then (fn [_] (done)))
+            (.catch (fn [_] (done))))))))


### PR DESCRIPTION
Correctness review of `tools/re-frame2-pair-mcp` — 4 AI/MCP-boundary privacy/correctness findings (rf2-olvr5), all in the privacy threat model (raw sensitive data must not cross to the LLM with `--allow-sensitive-reads` OFF, the default). Touches only `tools/re-frame2-pair-mcp/**`; no framework (`implementation/`) edits.

## Findings fixed

**1. dispatch `:trace` / `:settle` forwarded RAW epoch records** (`tools/dispatch.cljs`). `dispatch-and-collect` (`:trace`) and `dispatch-and-settle!` (`:settle`) return a full `:epoch` (carrying `:db-before` / `:db-after` / `:trigger-event` / `:trace-events`) plus, for settle, `:render-events` — and these rode the nREPL/MCP wire verbatim, bypassing the off-box projection the pull-mode `trace-window` / `watch-epochs` surfaces use (rf2-6wvh5). With the gate OFF a declared-`:sensitive?` slot leaked to the LLM. Fix: project `:epoch` app-side via `re-frame.core/projected-record` and re-derive `:render-events` from the projected (elided) epoch's trace-events, before egress. Raw egress now requires gate-ON **and** explicit `:include-sensitive true` (the same two-key contract `epoch_egress` wears). The default sync / queued consequence shapes carry no raw app-db and stay un-wrapped.

**2. raw-state config reset on reload** (`tools/raw_state.cljs`). `signal-runtime!` cached the posture as delivered per build-id for the server lifetime, but the runtime's `raw-state-config` resets to its permissive default (`allow-raw-state? true`) on every page/runtime reload (the preload re-`defonce`s it and re-mints `session-id`). After a reload the freshly-recreated runtime stayed permissive, so `reset-frame-db` / `restore-epoch` / `dispatch-dry-run` / `snapshot` / `get-path` / `subscribe` / `record` / `watch-until` could tap raw prev/next app-db with the gate OFF. Fix: re-signal the posture before every state-emitting eval (a tiny idempotent round-trip); keep only the concurrent in-flight dedup (the rf2-z7roa race guard), drop the permanent per-build "delivered" skip.

**3. response-cache cross-frame / cross-build staleness** (`cache.cljs` + `tools.cljs` + `tools/operating_frame.cljs`). The cache key was `(tool, args)` only. A precheck-hash collision across two builds on one nREPL connection could serve the wrong build's payload; and an omitted-`:frame` read cached against operating frame A could be served to frame B if B shared A's app-db hash. Fix: fold the resolved build into the cache key, and flush the whole response cache on every operating-frame mutation (set / reset) — driven from the `invoke` chokepoint to avoid a `cache -> registry -> operating-frame -> cache` require cycle.

**4. discover-port stale `--port-file` strands a live port** (`nrepl.cljs`). `discover-port*` resolved an explicit-but-unreadable / non-numeric `--port-file` to `{:port nil}`, short-circuiting the cascade even when `$SHADOW_CLJS_NREPL_PORT` / configured roots / the shadow HTTP endpoint / cwd scan would have found a live port. Fix: an unreadable explicit port file now falls through to steps 2-5, mirroring `read-port-from-fs`.

Regressions added for all four (dispatch projection gate-ON/OFF, signal re-config + concurrent dedup, cache build-discriminator + operating-frame flush, port-file fall-through).

## Quality gates

- `tools/re-frame2-pair-mcp` unit suite (`npm test` → shadow-cljs `:server-test`): **934 tests / 2840 assertions, 0 failures, 0 errors**.
- Production server bundle (`npm run build`): **0 warnings**.
- Descriptor manifest (`npm run check:descriptors`): **in sync (28 tools)**.
- MCP-conformance pair-mcp end-to-end (`mcp-conformance` `test:re-frame2-pair`, SDK Client driver against the compiled `out/server.js`): **GREEN** (handshake, 28-tool catalogue, descriptor ratchet, degraded-path errors, `:structuredContent`).
- Bundle isolation: N/A change-wise — the projection references `re-frame.core/projected-record` only inside an emitted app-side eval string (consistent with the existing `epoch_egress/project-page-src`), so no new `tools -> implementation` `:require` edge is introduced.
- Live-redaction conformance (`test:re-frame2-pair-live-redaction`) requires a running shadow-cljs build + Chromium and is a CI-only heavy gate; not run locally.