### PR TITLE
fix(story-mcp): derive cell-override allowlist from active-mode effective args (rf2-to3q7)

### DIFF
--- a/tools/story-mcp/spec/001-Wire-Protocol.md
+++ b/tools/story-mcp/spec/001-Wire-Protocol.md
@@ -54,8 +54,15 @@ before the bounded allowlists run.** Concretely:
 - Genuinely data-bearing nested maps keep string keys at ingress and are
   routed through each surface's own **bounded** keyword policy:
   - `:cell-overrides` KEYS are resolved through `safe-keyword` against
-    the variant's declared arg-key set (`read-run-opts`) — a finite,
-    registry-derived allowlist; an override key outside it is dropped.
+    the variant's **effective** arg-key set under the request's
+    `:active-modes` (`read-run-opts`) — a finite, registry-derived
+    allowlist; an override key outside it is dropped. The allowlist is
+    the effective set (variant args ∪ the active modes' contributed
+    keys) rather than the bare variant's declared keys because Story's
+    args precedence merges mode args *before* cell-local overrides, so
+    an arg introduced only by an active mode is a legitimate override
+    target (rf2-to3q7). The active modes are coerced first so the
+    allowlist is derived from the same effective args the render uses.
   - the object-form `register-variant` `:body` is keywordised by
     `coerce-body` only **behind the `--allow-writes` operator gate** and
     only **after** the rf2-g9fje depth cap, so the intern is bounded by

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -112,6 +112,17 @@ of `list-stories`), the server returns
 — the same vocab pair-mcp uses for ring-rotation staleness. The
 agent restarts pagination from offset 0.
 
+The cursor `:offset` and `:total` are validated as **natural integers**
+with `:offset ≤ :total` at decode time. A forged or hand-edited cursor
+that violates this range (a negative offset, or an offset past the
+total) is treated as malformed and recovers through the SAME
+`:rf.mcp/cursor-stale` envelope — it never feeds the slice a bad index
+(which would throw a generic handler exception) nor silently returns an
+empty page that skips registry rows (rf2-to3q7). This is the wire-
+boundary range gate on the opaque cursor; the `:sig` fingerprint
+separately catches a registry that changed under a structurally-valid
+cursor.
+
 The `get-*` / `<thing>->edn` tools are NOT paginated — their return
 is a single record bounded by the registered body's size, not a
 function of registry size. Wire-budget overruns are caught by the

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
@@ -99,16 +99,24 @@
 
 (defn- cell-override-key-set
   "Bounded allowlist for `:cell-overrides` KEYS: the keys of the
-  variant's resolved effective-args map (`story/resolve-args`, no
-  overrides). Cell-overrides exist to override an arg the variant
-  already declares, so the legitimate key universe is exactly that
-  variant's declared arg keys — a finite, registry-derived set. Used by
-  `read-run-opts` to route each caller-supplied override key through
-  `args/safe-keyword` (no JVM intern outside the set; rf2-3luf3).
-  Returns `#{}` for an unresolvable variant — every override key then
-  rejects, which is the honest answer (nothing to override)."
-  [vk]
-  (set (keys (story/resolve-args vk))))
+  variant's EFFECTIVE-args map under the caller's `active-modes`
+  (`story/resolve-args` with `:active-modes`, no cell-overrides).
+  Cell-overrides exist to override an arg already present in the cell's
+  effective args, so the legitimate key universe is exactly the keys the
+  render will carry — a finite, registry-derived set. That universe is
+  the variant's declared args UNION every arg key the active modes
+  contribute, because Story's precedence merges mode args BEFORE
+  cell-local overrides (`re-frame.story.args` §precedence: `… < mode-args
+  < variant-args < cell-overrides`). Building the allowlist from the
+  variant alone would drop a caller override for an arg introduced ONLY
+  by an active mode (rf2-to3q7), so the render would show the mode value
+  instead of the caller override. Used by `read-run-opts` to route each
+  caller-supplied override key through `args/safe-keyword` (no JVM intern
+  outside the set; rf2-3luf3). Returns `#{}` for an unresolvable variant
+  with no active modes — every override key then rejects, which is the
+  honest answer (nothing to override)."
+  [vk active-modes]
+  (set (keys (story/resolve-args vk {:active-modes active-modes}))))
 
 (defn- safe-cell-overrides
   "Coerce a caller-supplied `:cell-overrides` map (string-keyed off the
@@ -155,26 +163,36 @@
   rf2-3luf3: `:cell-overrides` arrives string-keyed off the JSON wire
   (the no-intern ingress no longer keywordises nested arg keys). Its
   KEYS are routed through `args/safe-keyword` against the variant's
-  declared arg-key set (`cell-override-key-set`) — a bounded, registry-
-  derived allowlist — so an override key outside that set is dropped
-  rather than interned. This is the read-side counterpart to the
-  operator-gated write-body keywordisation in `tools.write`."
+  EFFECTIVE arg-key set under the active modes (`cell-override-key-set`)
+  — a bounded, registry-derived allowlist — so an override key outside
+  that set is dropped rather than interned. This is the read-side
+  counterpart to the operator-gated write-body keywordisation in
+  `tools.write`.
+
+  rf2-to3q7: the active modes are coerced FIRST so the cell-override
+  allowlist is derived from the EFFECTIVE args for those modes
+  (`story/resolve-args` with `:active-modes`). Story's precedence merges
+  mode args before cell-local overrides, so an arg key introduced only
+  by an active mode is a legitimate override target; building the
+  allowlist from the bare variant (as before) dropped that override and
+  the render fell back to the mode value."
   [vk arguments]
   (let [substrate-set (cljs-resolve/registered-substrates-set)
-        mode-set      (story/list-modes)]
+        mode-set      (story/list-modes)
+        active-modes  (when (some? (:active-modes arguments))
+                        (into []
+                              (keep #(args/safe-keyword % mode-set))
+                              (:active-modes arguments)))]
     (cond-> {}
       (some? (:substrate arguments))
       (assoc :substrate (args/safe-keyword (:substrate arguments) substrate-set))
 
       (some? (:active-modes arguments))
-      (assoc :active-modes
-             (into []
-                   (keep #(args/safe-keyword % mode-set))
-                   (:active-modes arguments)))
+      (assoc :active-modes active-modes)
 
       (some? (:cell-overrides arguments))
       (assoc :cell-overrides (safe-cell-overrides (:cell-overrides arguments)
-                                                  (cell-override-key-set vk))))))
+                                                  (cell-override-key-set vk active-modes))))))
 
 (defn with-variant
   "Resolve `:variant-id` from `arguments` (required), resolve it against

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
@@ -91,16 +91,41 @@
   [ids]
   (str (hash (vec (sort-by str ids)))))
 
+(defn- nat-int?*
+  "A non-negative integer. Used as the cursor `:offset` / `:total`
+  bound. (`clojure.core/nat-int?` exists on the JVM but not in older
+  CLJS cores; this leaf is `.cljc` so we spell the check out to stay
+  portable — `integer?` + non-negative.)"
+  [x]
+  (and (integer? x) (not (neg? x))))
+
 (defn- payload-valid?
-  "The story cursor payload shape: a versioned map carrying the integer
-  offset/total + the whole-set fingerprint. Passed to the shared
-  `base-cursor/decode-cursor` so the codec is shared while the shape
-  check stays story-specific."
+  "The story cursor payload shape: a versioned map carrying the
+  natural-integer offset/total + the whole-set fingerprint. Passed to
+  the shared `base-cursor/decode-cursor` so the codec is shared while
+  the shape check stays story-specific.
+
+  rf2-to3q7 — wire-boundary range gate. `:offset` and `:total` MUST be
+  NATURAL integers (a negative offset would feed `subvec` a negative
+  start and throw a generic handler exception instead of the documented
+  cursor-stale envelope), and `:offset` MUST NOT exceed `:total` (an
+  over-total offset would slice an empty window and silently skip the
+  tail of the registry). A cursor failing this shape decodes to the
+  `::base-cursor/malformed` sentinel, which `page` already maps onto the
+  drop-and-restart cursor-stale recovery — so a tampered/edited cursor
+  recovers through the contract rather than crashing or losing rows.
+
+  Note `:total` is NOT cross-checked against the LIVE total here — this
+  predicate has no registry context. `page` already validates the
+  payload's `:sig` against the live whole-set fingerprint, and the
+  fingerprint changes whenever the id-set (and therefore the count)
+  changes; a stale `:total` is caught there as a sig mismatch."
   [v]
   (and (map? v)
        (= 1 (:v v))
-       (integer? (:offset v))
-       (integer? (:total v))
+       (nat-int?* (:offset v))
+       (nat-int?* (:total v))
+       (<= (:offset v) (:total v))
        (string? (:sig v))))
 
 (defn parse-limit-arg

--- a/tools/story-mcp/test/re_frame/story_mcp/tools/cursor_result_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools/cursor_result_test.clj
@@ -15,8 +15,27 @@
   public helper surface."
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing]]
+            [re-frame.mcp-base.cursor :as base-cursor]
             [re-frame.story-mcp.tools.cursor :as cursor]
             [re-frame.story-mcp.tools.result :as result]))
+
+(defn- forge-cursor
+  "Mint a cursor token from a raw payload WITHOUT going through
+  `cursor/encode-cursor` — so a regression test can craft the out-of-
+  range payloads (`:offset -1`, an over-total offset) that the public
+  encoder would never emit. Mirrors what an agent that hand-edits an
+  opaque cursor token would produce on the wire."
+  [payload]
+  (base-cursor/b64-encode (pr-str payload)))
+
+(defn- live-sig-for
+  "The whole-set fingerprint `cursor/page` will compute for `ids` — read
+  it back off a legitimately-minted cursor so a forged-payload test can
+  reuse the matching `:sig` (isolating the RANGE gate from the
+  fingerprint-drift gate)."
+  [entries ids]
+  (let [[_ _ m] (cursor/page entries ids {:limit 1} "t")]
+    (:sig (cursor/decode-cursor (:next-cursor m)))))
 
 ;; ---------------------------------------------------------------------------
 ;; encode-cursor / decode-cursor round-trip + the end-of-page guard.
@@ -125,6 +144,67 @@
           [res err-result] (cursor/page entries entries {:cursor "garbage!!!"} "list-things")]
       (is (= :err res))
       (is (= :rf.mcp/cursor-stale (-> err-result :structuredContent :reason))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-to3q7 — wire-boundary range gate on the cursor payload.
+;;
+;; The cursor `:offset` / `:total` are NATURAL integers and `:offset <=
+;; :total`. A forged/edited cursor that violates this (negative offset,
+;; over-total offset) must decode to the malformed sentinel and recover
+;; through the documented cursor-stale envelope — NOT feed `subvec` a
+;; bad index (throwing a generic handler exception) or slice an empty
+;; window (silently skipping the tail of the registry). These use a
+;; matching live `:sig` so the RANGE gate is isolated from the
+;; fingerprint-drift gate.
+;; ---------------------------------------------------------------------------
+
+(deftest decode-cursor-rejects-negative-offset
+  (testing "a forged cursor with :offset -1 decodes to malformed, not a payload"
+    (let [forged (forge-cursor {:v 1 :offset -1 :total 5 :sig "any"})]
+      (is (cursor/decode-cursor forged)
+          "a negative-offset cursor is NOT nil — it must surface as malformed")
+      (is (= (cursor/decode-cursor "!!!garbage!!!") (cursor/decode-cursor forged))
+          "the negative-offset cursor reads as the SAME malformed sentinel as raw garbage"))))
+
+(deftest decode-cursor-rejects-negative-total
+  (testing "a forged cursor with a negative :total decodes to malformed"
+    (let [forged (forge-cursor {:v 1 :offset 0 :total -3 :sig "any"})]
+      (is (= (cursor/decode-cursor "!!!garbage!!!") (cursor/decode-cursor forged))))))
+
+(deftest decode-cursor-rejects-offset-over-total
+  (testing "a forged cursor whose :offset exceeds :total decodes to malformed"
+    (let [forged (forge-cursor {:v 1 :offset 99 :total 5 :sig "any"})]
+      (is (= (cursor/decode-cursor "!!!garbage!!!") (cursor/decode-cursor forged))))))
+
+(deftest decode-cursor-accepts-offset-equal-to-total
+  (testing "offset == total is a VALID position (fully-consumed end-of-list)"
+    (let [c (forge-cursor {:v 1 :offset 5 :total 5 :sig "any"})
+          p (cursor/decode-cursor c)]
+      (is (map? p) "offset == total must NOT be rejected — it is the legitimate end position")
+      (is (= 5 (:offset p))))))
+
+(deftest page-negative-offset-cursor-returns-cursor-stale-not-throw
+  (testing "a tampered negative-offset cursor recovers via cursor-stale, never throwing into subvec"
+    (let [entries (vec (range 5))
+          forged  (forge-cursor {:v 1 :offset -1 :total 5 :sig (live-sig-for entries entries)})
+          ;; Pre-fix this threw IndexOutOfBoundsException from subvec;
+          ;; post-fix the bad offset is rejected at decode and page
+          ;; returns the structured stale envelope.
+          [res err-result] (cursor/page entries entries {:cursor forged} "list-things")]
+      (is (= :err res))
+      (is (true? (:isError err-result)))
+      (is (= :rf.mcp/cursor-stale (-> err-result :structuredContent :reason))
+          "the negative-offset cursor recovers through the documented cursor-stale contract")
+      (is (= "list-things" (-> err-result :structuredContent :tool))))))
+
+(deftest page-over-total-offset-cursor-returns-cursor-stale-not-empty-page
+  (testing "an over-total offset recovers via cursor-stale rather than silently skipping the tail"
+    (let [entries (vec (range 5))
+          forged  (forge-cursor {:v 1 :offset 99 :total 5 :sig (live-sig-for entries entries)})
+          [res err-result] (cursor/page entries entries {:cursor forged} "list-things")]
+      (is (= :err res))
+      (is (= :rf.mcp/cursor-stale (-> err-result :structuredContent :reason))
+          "an over-total offset must NOT silently return an empty page that loses rows"))))
 
 ;; ---------------------------------------------------------------------------
 ;; paged-result — folds page + the tool-specific payload build + envelope.

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -3538,6 +3538,45 @@
       (is (= #{:label} (set (keys co))) "the unknown override key was dropped")
       (is (nil? (find-keyword probe)) "and never interned"))))
 
+(deftest read-run-opts-allows-active-mode-introduced-cell-override-key
+  (testing "an override for an arg introduced ONLY by an active mode is preserved (rf2-to3q7)"
+    ;; story.button/primary declares :args {:label "Save"} — :theme is
+    ;; NOT among its base args. The fixture's :Mode.theme/dark mode
+    ;; contributes :args {:theme :dark}. Story precedence merges mode
+    ;; args before cell-local overrides, so with that mode active a
+    ;; caller :theme override is a LEGITIMATE override target. Before
+    ;; rf2-to3q7 the allowlist was built from the bare variant (no
+    ;; active modes), so the :theme override was dropped as 'unknown'
+    ;; and the render fell back to the mode's :dark value.
+    (let [probe (str "rf2-to3q7-co-" (System/nanoTime))
+          opts  (targs/read-run-opts
+                  :story.button/primary
+                  {:active-modes   [":Mode.theme/dark"]
+                   :cell-overrides {"theme" ":light"   ; arg introduced by the active mode
+                                    "label" "Override"  ; arg on the variant itself
+                                    probe   "x"}})      ; genuinely-unknown key
+          co    (:cell-overrides opts)]
+      (is (= [:Mode.theme/dark] (:active-modes opts)) "the mode coerced through the bounded set")
+      (is (= ":light" (:theme co))
+          "rf2-to3q7: the mode-introduced :theme override is PRESERVED, not dropped")
+      (is (= "Override" (:label co)) "the variant's own :label override is kept")
+      (is (= #{:theme :label} (set (keys co)))
+          "the genuinely-unknown key is still dropped — the allowlist widened only to the mode args")
+      (is (nil? (find-keyword probe)) "the unknown key never interned"))))
+
+(deftest read-run-opts-without-active-mode-still-drops-mode-only-key
+  (testing "without the active mode, the mode-only arg key is correctly NOT an allowed override (rf2-to3q7)"
+    ;; Mirror of the test above with the mode absent: :theme is not in
+    ;; the variant's effective args, so the override IS unknown and must
+    ;; drop — proving the widening is scoped to the ACTIVE modes, not a
+    ;; blanket relaxation.
+    (let [opts (targs/read-run-opts
+                 :story.button/primary
+                 {:cell-overrides {"theme" ":light" "label" "Override"}})
+          co   (:cell-overrides opts)]
+      (is (= #{:label} (set (keys co)))
+          "with no active mode, :theme is not a declared arg and the override drops"))))
+
 (deftest ingress-unknown-variant-id-over-wire-does-not-intern
   (testing "an unknown :variant-id sent over JSON is rejected WITHOUT interning (rf2-3luf3)"
     ;; This is the wire-level peer of the rf2-lqjbk direct-invoke test —


### PR DESCRIPTION
Fixes the two correctness findings in `tools/story-mcp` from rf2-to3q7. This is the MCP-layer mirror of the just-merged story precedence fix rf2-2cpoo (#3248).

## Finding 1 — cell-override allowlist built before active-modes applied

`read-run-opts` (`tools/story_mcp/tools/args.cljc`) built the `:cell-overrides` key allowlist via `cell-override-key-set` from `(story/resolve-args vk)` — the bare variant's effective args — **before** the caller's `:active-modes` were applied. Story's args precedence merges active-mode args *before* cell-local overrides (`re-frame.story.args` §precedence: `… < mode-args < variant-args < cell-overrides`), and the MCP API exposes `:active-modes` + `:cell-overrides` together. So an override for an arg key introduced **only** by an active mode was dropped as "unknown", and preview/run/share/snapshot rendered the mode value instead of the caller override (wrong reproductions).

**Fix:** coerce `:active-modes` first, then derive the cell-override allowlist from the effective args for those modes — `(story/resolve-args vk {:active-modes active-modes})` — before `safe-cell-overrides`. The allowlist widens to exactly `variant-args ∪ active-mode-arg-keys`; genuinely-unknown keys are still dropped without interning, and behaviour is byte-identical when no modes are active.

Reproduction confirmed pre-fix: with `:active-modes [":Mode.theme/dark"]` (a mode contributing `{:theme :dark}`) and `:cell-overrides {"theme" ":light" ...}`, the resulting `:cell-overrides` was `{:label …}` — the `:theme` override silently dropped. Post-fix it is `{:theme ":light" :label …}`.

## Finding 2 — cursor `:offset`/`:total` range validation hole

`payload-valid?` (`tools/story_mcp/tools/cursor.cljc`) accepted any integer `:offset`/`:total`. A forged/edited cursor with `:offset -1` (matching the live `:sig`) passed shape validation, then fed `subvec` a negative start → generic `IndexOutOfBoundsException` instead of the documented `:rf.mcp/cursor-stale` envelope. An over-total offset silently returned an empty page, skipping registry rows.

**Fix:** require `:offset`/`:total` to be **natural integers** with `:offset ≤ :total`. An out-of-range cursor now decodes to `::malformed`, which `page` already maps onto the drop-and-restart cursor-stale recovery — so a tampered cursor recovers through the contract rather than crashing or losing rows. `:offset == :total` (the legitimate fully-consumed end position) is still accepted. The `:total`-vs-live cross-check is intentionally left to `page`'s existing `:sig` fingerprint gate (the predicate has no registry context, and the fingerprint changes whenever the count does — noted in the docstring).

## Regression tests

- `tools_test.clj`: a registered mode introduces an arg key and an MCP `:cell-overrides` entry for that key is **preserved** under `:active-modes`, while a genuinely-unknown key is still dropped without interning; plus the mirror proving the widening is scoped to the *active* modes (without the mode, the mode-only key still drops).
- `cursor_result_test.clj`: forged negative-offset, negative-total, and over-total cursors decode to malformed and `page` returns the structured `:rf.mcp/cursor-stale` envelope with no thrown handler exception; `:offset == :total` is accepted as valid.

## Specs

- `001-Wire-Protocol.md`: cell-override allowlist is the variant's **effective** arg-key set under `:active-modes` (variant args ∪ active modes' keys), not the bare variant's declared keys.
- `API.md`: documents the cursor natural-integer + `offset ≤ total` range gate and that an out-of-range cursor recovers via `:rf.mcp/cursor-stale`.

## Quality gates

- `tools/story-mcp` artefact tests (`clojure -M:test`): **241 tests, 1180 assertions, 0 failures, 0 errors** (was 233/1162 — +8 regression tests).
- `npm run test:mcp-conformance`: **ALL GATES GREEN** — JVM story-mcp, Node stdio roundtrip, story-mcp end-to-end, CLI flag-vocabulary, wire-vocab (52 tests / 640 assertions). story-mcp request path exercised end-to-end.
- `npm run test:cljs`: **not applicable** — `tools/story-mcp` is a JVM-only `.cljc` artefact and is not on the shadow-cljs node-test classpath (only `tools/story` is). Its coverage is the artefact test + the conformance suite above.

Lane: changes confined to `tools/story-mcp/**`. Does not modify `tools/story` (consumed via its public `resolve-args` API).
