### PR TITLE
fix(examples/reagent): websocket timeout event shape + timer re-arm + 2 more (rf2-8bwh0)

### DIFF
--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -112,6 +112,34 @@
 ;; `dangerouslySetInnerHTML` escape hatch, and the example stays free of
 ;; an extra npm dependency.
 
+(def ^:private safe-link-schemes
+  "Allowlist of URI schemes a markdown link may carry in the preview.
+   Anything else (notably `javascript:` and `data:`) is treated as
+   unsafe and rendered as inert text rather than a clickable anchor."
+  #{"http" "https" "mailto"})
+
+(defn- safe-href
+  "Return `href` when it is safe to put on an `:a {:href ...}` in the
+   preview, else nil. Safe = an allowlisted absolute scheme, or a
+   scheme-less link (relative path or `#fragment`). Scheme detection
+   matches a leading `word:` prefix per RFC 3986 §3.1; a `:` that only
+   appears after a `/`, `?` or `#` is part of the path/query/fragment,
+   not a scheme, so such links are scheme-less and allowed."
+  [href]
+  (let [h (str/trim (or href ""))
+        ;; A scheme is `ALPHA *( ALPHA / DIGIT / + / - / . ) :` at the
+        ;; very start. If the first `:` is preceded by a `/`, `?` or `#`
+        ;; it is not a scheme delimiter.
+        m      (re-find #"(?i)^([a-z][a-z0-9+.-]*):" h)
+        scheme (some-> m second str/lower-case)]
+    (cond
+      ;; No leading scheme → relative path or fragment → safe.
+      (nil? scheme) href
+      ;; Allowlisted absolute scheme → safe.
+      (contains? safe-link-schemes scheme) href
+      ;; Anything else (javascript:, data:, vbscript:, …) → unsafe.
+      :else nil)))
+
 (defn- split-by-regex
   "Walk `coll` (a flat seq of strings + hiccup-vectors). For each
    string element, find non-overlapping matches of `re`; each match
@@ -150,10 +178,20 @@
   [s]
   (-> [s]
       (split-by-regex #"\[([^\]]+)\]\(([^)]+)\)"
-                      (fn [m] [:a {:href (nth m 2)
-                                   :rel "noopener noreferrer"
-                                   :target "_blank"}
-                                (nth m 1)]))
+                      (fn [m]
+                        (let [text (nth m 1)]
+                          ;; Sanitize the destination: only allowlisted
+                          ;; schemes (and scheme-less relative links)
+                          ;; become clickable anchors. Disallowed schemes
+                          ;; — `javascript:`, `data:`, … — render as inert
+                          ;; text so the preview never exposes an unsafe
+                          ;; clickable link on this user-controlled surface.
+                          (if-let [href (safe-href (nth m 2))]
+                            [:a {:href   href
+                                 :rel    "noopener noreferrer"
+                                 :target "_blank"}
+                             text]
+                            [:span.nb-unsafe-link text]))))
       (split-by-regex #"\*\*([^*]+)\*\*"
                       (fn [m] [:strong (nth m 1)]))
       (split-by-regex #"\*([^*]+)\*"

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -104,7 +104,29 @@
 (rf/reg-sub :flight/start-text  (fn [db _] (get-in db [:flight :start-text])))
 (rf/reg-sub :flight/return-text (fn [db _] (get-in db [:flight :return-text])))
 
-(defn valid-date? [s] (boolean (re-matches date-pattern (or s ""))))
+(defn valid-date?
+  "True when `s` is a real ISO `yyyy-mm-dd` calendar date. The regex
+   alone only checks shape, so it would accept impossible dates like
+   `2026-99-99`, `2026-00-00`, or `2026-02-31`. We round-trip the
+   parsed fields through a UTC `js/Date` and require every component to
+   come back unchanged — this rejects out-of-range months/days and is
+   leap-year-correct (e.g. `2025-02-29` overflows to March and fails,
+   `2024-02-29` round-trips and passes)."
+  [s]
+  (let [s (or s "")]
+    (boolean
+      (when (re-matches date-pattern s)
+        (let [y  (js/parseInt (subs s 0 4) 10)
+              m  (js/parseInt (subs s 5 7) 10)
+              d  (js/parseInt (subs s 8 10) 10)
+              dt (js/Date. 0)]
+          ;; setUTCFullYear avoids the legacy 0-99 → 1900-1999 mapping
+          ;; that the `js/Date.UTC` two-digit-year rule applies, so
+          ;; four-digit years like 0026 round-trip honestly.
+          (.setUTCFullYear dt y (dec m) d)
+          (and (= y (.getUTCFullYear dt))
+               (= (dec m) (.getUTCMonth dt))
+               (= d (.getUTCDate dt))))))))
 
 (rf/reg-sub :flight/return-enabled?
   :<- [:flight/trip-type]

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -62,6 +62,12 @@
 ;; a fresh tick under the new generation, so the chain continues. This
 ;; generation guard makes the 0.0 reading correct regardless of dispatch
 ;; timing — Reset uses ordinary `dispatch`, like every other UI handler.
+;;
+;; :timer/set-duration reuses the same generation mechanism: when the tick
+;; chain has already stopped (elapsed reached the old duration) and the
+;; user raises the duration, the handler bumps :tick-gen and arms one fresh
+;; tick — resuming the chain without a Reset. This is what makes "the slider
+;; changes the duration on the fly" hold after completion.
 
 (rf/reg-event-fx :timer/initialise
   {:doc "Seed the timer slice and start the periodic tick."}
@@ -87,11 +93,29 @@
             (and tick-active? (not done?))
             (assoc :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick gen]}]])))))))
 
-(rf/reg-event-db :timer/set-duration
-  {:doc "User dragged the slider."
+(rf/reg-event-fx :timer/set-duration
+  {:doc "User dragged the slider. Update the duration, and — if the tick
+         chain had already stopped because elapsed reached the *old*
+         duration — re-arm it under a bumped generation so a longer
+         duration resumes ticking without a Reset. Bumping :tick-gen
+         retires any still-pending tick, so exactly one chain runs.
+         If a chain is still live (elapsed < old duration) we just
+         update the duration; the running tick keeps going against the
+         new target."
    :schema [:cat [:= :timer/set-duration] :int]}
-  (fn handler-timer-set-duration [db [_ ms]]
-    (assoc-in db [:timer :duration-ms] ms)))
+  (fn handler-timer-set-duration [{:keys [db]} [_ ms]]
+    (let [{:keys [elapsed-ms duration-ms tick-active? tick-gen]} (:timer db)
+          ;; The chain stops scheduling once elapsed reaches duration
+          ;; (see :timer/tick's `done?`). Detect that stopped state.
+          was-stopped? (>= elapsed-ms duration-ms)
+          ;; Re-arm only when stopped, still active, and the new
+          ;; duration leaves elapsed below target (room to advance).
+          rearm?       (and was-stopped? tick-active? (> ms elapsed-ms))
+          next-gen     (if rearm? (inc tick-gen) tick-gen)
+          db'          (cond-> (assoc-in db [:timer :duration-ms] ms)
+                         rearm? (assoc-in [:timer :tick-gen] next-gen))]
+      (cond-> {:db db'}
+        rearm? (assoc :fx [[:dispatch-later {:ms tick-ms :event [:timer/tick next-gen]}]])))))
 
 (rf/reg-event-fx :timer/reset
   {:doc "User clicked Reset. Zero elapsed, retire any in-flight tick by

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -210,11 +210,11 @@
                 ;; `:current-socket?` guard drops stale timeouts from
                 ;; a prior connection epoch.
                 [:dispatch-later
-                 {:ms       timeout-ms
-                  :dispatch [:ws/connection
-                             [:ws/request-timeout
-                              {:request-id       request-id
-                               :source-socket-id (:socket-id data)}]]}]]})
+                 {:ms    timeout-ms
+                  :event [:ws/connection
+                          [:ws/request-timeout
+                           {:request-id       request-id
+                            :source-socket-id (:socket-id data)}]]}]]})
 
       :clear-request
       (fn action-clear-request [{data :data [_ {:keys [request-id]}] :event}]


### PR DESCRIPTION
Fixes the four correctness findings from **rf2-8bwh0** in the Reagent example catalogue. Example **code** fixes only — no per-example tests added (locked test-free-examples policy, rf2-8cevm).

## Findings fixed

1. **`websocket/connection.cljs` — request-timeout never scheduled.** The timeout `:dispatch-later` payload used the legacy `:dispatch` key, but the runtime's reserved `:dispatch-later` fx handler destructures `{:keys [ms event]}` (`re-frame.fx`). `event` resolved to `nil`, so the deferred dispatch fired `(dispatch! nil opts)` — an unanswered request stayed `:in-flight` forever. Changed to `:event`.

2. **`seven_guis/timer/core.cljs` — set-duration didn't re-arm the tick.** `:timer/set-duration` only wrote `[:timer :duration-ms]`. Once the tick chain stopped (elapsed reached the old duration, `done?` true → no further scheduling), raising the duration left the display frozen until Reset. Now (as a `reg-event-fx`) it detects the stopped state and, when the new duration leaves room to advance, bumps `:tick-gen` and arms exactly one fresh tick — reusing the existing generation guard so no double-chain. A still-live chain just updates the target and keeps running (shrinking below elapsed still fills to 100% via the live tick).

3. **`notebook/core.cljs` — unsafe markdown link schemes.** Link destinations were rendered verbatim, so `[x](javascript:alert(1))` and `data:` URLs became clickable on the user-editable preview surface. Added `safe-href`: allowlist `http`/`https`/`mailto` plus scheme-less relative/fragment links; disallowed schemes render as inert `:span.nb-unsafe-link` text instead of an anchor.

4. **`seven_guis/flight_booker/core.cljs` — impossible dates passed validation.** `valid-date?` only matched the `yyyy-mm-dd` shape, so `2026-99-99`, `2026-00-00`, `2026-02-31` enabled booking. Now round-trips the parsed fields through a UTC `js/Date` (via `setUTCFullYear` to avoid the 0-99→1900s legacy mapping) and requires every component to come back unchanged — leap-year-correct (`2024-02-29` passes, `2025-02-29` fails).

## Quality gates

- `npm run test:cljs` — **5769 tests, 20291 assertions, 0 failures, 0 errors.**
- `npm run test:examples-compile` — **all 39 example builds compiled, 0 warnings** (incl. `flight-booker`, `notebook`, `timer`, `websocket`).
- Adapter smokes not run: no change touches an `adapters/<name>/testbed/spec.cjs` smoke path.

## Deferred regression coverage (substrate tests, not examples)

Per the test-free-examples lock, the findings' "add a test" suggestions are NOT actioned under `examples/`. Recommended follow-ups for the `implementation/` substrate tests:

- **Finding 1 timeout:** the existing websocket integration test (`implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs`) overrides `:dispatch-later` to `nil` in its fixture (`new-frame`), which is exactly why the stale `:dispatch` shape went uncaught. A focused test that lets `:dispatch-later` fire (or asserts the emitted fx payload uses `:event`) and proves an unanswered request is removed from `[:data :in-flight]` — while a stale timeout from a prior socket-id is ignored by `:current-socket?` — would lock this in.
- **Finding 2 timer re-arm:** a unit test that drives the timer to completion, dispatches `[:timer/set-duration larger-ms]`, and asserts a subsequent scheduled tick advances elapsed without Reset.
- **Findings 3 & 4** (`safe-href` scheme allowlist; `valid-date?` calendar bounds) are pure functions and would suit small unit tests if a substrate home is desired.
