### PR TITLE
fix(template): conform generator Xray layout host to current right-side resizable contract (rf2-29zmf)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/root/resources/public/css/app.css
+++ b/tools/template/resources/day8/re_frame2_template/root/resources/public/css/app.css
@@ -6,13 +6,26 @@
 
 body { font: 16px/1.4 system-ui, sans-serif; margin: 0; }
 .rf2-app-shell { display: flex; min-height: 100vh; }
-/* The Xray host only reserves its column once Xray has populated it.
- * In dev, the `day8.re-frame2-xray.preload` mounts Xray into the
+/* The Xray host reserves a RIGHT-side column (the aside follows
+ * `<main id="app">` in the DOM, so flex flow lays it to the right).
+ * It only takes up space once Xray has populated it. In dev, the
+ * `day8.re-frame2-xray.preload` mounts Xray into the
  * `[data-rf-xray-host]` aside, making it non-empty and sizing it here.
  * Release builds drop the preload, so the aside stays empty and
  * `:empty` collapses it — `#app` then spans the full viewport instead
- * of shipping a blank ~420px gutter. */
-.rf2-xray-host { flex: 0 0 420px; min-width: 320px; }
+ * of shipping a blank gutter.
+ *
+ * `flex-basis` reads `--rf-xray-inline-width` (host-owned resize knob,
+ * default 560px) so a persisted drag-resize width and cascade-level
+ * overrides (`:root`, per-route) take effect. `box-sizing: border-box`
+ * keeps the 1px `border-left` inside the documented width. See the Xray
+ * §Layout host contract (tools/xray/spec/011-Launch-Modes.md). */
+.rf2-xray-host {
+  flex: 0 0 var(--rf-xray-inline-width, 560px);
+  min-width: 320px;
+  box-sizing: border-box;
+  border-left: 1px solid #2a2a2a;
+}
 .rf2-xray-host:empty { display: none; }
 #app { flex: 1; min-width: 0; padding: 2em; }
 button { padding: 0.4em 0.8em; }

--- a/tools/template/resources/day8/re_frame2_template/root/resources/public/index.html
+++ b/tools/template/resources/day8/re_frame2_template/root/resources/public/index.html
@@ -38,8 +38,8 @@
   </head>
   <body>
     <div class="rf2-app-shell">
-      <aside class="rf2-xray-host" data-rf-xray-host></aside>
       <main id="app"></main>
+      <aside class="rf2-xray-host" data-rf-xray-host></aside>
     </div>
     <script src="/js/main.js"></script>
   </body>


### PR DESCRIPTION
Fixes rf2-29zmf. The generator template's day-one scaffold shipped a **stale left-side, fixed-width Xray layout host** that diverged from the current published contract (`tools/xray/spec/011-Launch-Modes.md` §Layout host contract + `examples/_shared/css/structure.css`). Projects scaffolded from the template inherited a non-resizable Xray panel on the wrong side — the same defect the `skills/re-frame2-setup` skill carried (fixed in rf2-w4axt); the template is the source-of-truth that skill mirrors, so they had drifted apart.

## Two changes

**1. `index.html` — DOM order (left → right)**
Reorders the shell so `<main id="app">` precedes `<aside data-rf-xray-host>`. Flex flow then lays the Xray panel to the **right** of the app, matching the §Layout host contract (`<main>` first, `<aside>` second). The `:empty` collapse behaviour is unchanged.

```diff
-      <aside class="rf2-xray-host" data-rf-xray-host></aside>
       <main id="app"></main>
+      <aside class="rf2-xray-host" data-rf-xray-host></aside>
```

**2. `app.css` — resizable, contract-conformant `.rf2-xray-host`**
Replaces the literal `flex: 0 0 420px` with `flex: 0 0 var(--rf-xray-inline-width, 560px)` plus `box-sizing: border-box` and `border-left`, so the host-owned resize knob, the persisted drag-resize width, and cascade-level overrides (`:root`, per-route) all take effect — a literal width ignored them. The default (560px) matches Xray's recommended default (rf2-9ovfb). The `:empty` collapse rule is kept.

```diff
-.rf2-xray-host { flex: 0 0 420px; min-width: 320px; }
+.rf2-xray-host {
+  flex: 0 0 var(--rf-xray-inline-width, 560px);
+  min-width: 320px;
+  box-sizing: border-box;
+  border-left: 1px solid #2a2a2a;
+}
```

This mirrors the variable + `box-sizing` reading of `[data-rf-xray-host]` in `examples/_shared/css/structure.css` and the fuller §Layout host contract / §Resizing-the-inline-host snippet in the Xray spec (which adds the 1px `border-left`, kept inside the documented width by `box-sizing: border-box`).

## Scope / gate
Static template files only (HTML + CSS) — **no build**. Edits are confined to the two resource files under `tools/template/resources/...`; **no template build-id / hot-zone files** (`deps.edn` / `shadow-cljs.edn`) were touched. Verified the template now matches `examples/_shared/css/structure.css` and the right-side DOM order.