### PR TITLE
fix(core): avoid :invalid-arithmetic warning on char literals in editor_uri (rf2-ltedz)

### DIFF
--- a/implementation/core/src/re_frame/source_coords/editor_uri.cljc
+++ b/implementation/core/src/re_frame/source_coords/editor_uri.cljc
@@ -281,11 +281,12 @@
   (or (str/starts-with? path "/")
       (str/starts-with? path "\\")
       (str/starts-with? (str/lower-case path) "file:")
-      (and (>= (count path) 2)
-           (= \: (.charAt path 1))
-           (let [c (.charAt path 0)]
-             (or (and (>= (int c) (int \a)) (<= (int c) (int \z)))
-                 (and (>= (int c) (int \A)) (<= (int c) (int \Z))))))))
+      ;; Drive-letter prefix: an ASCII letter followed by `:` (e.g. `C:` /
+      ;; `c:/...`). Matched with a regex rather than per-char arithmetic so
+      ;; CLJS doesn't emit `:invalid-arithmetic` warnings — under CLJS a char
+      ;; literal / `.charAt` result is a single-char string, and `(int <char>)`
+      ;; fed to the comparison's `bit-or` trips `[string number]` (rf2-ltedz).
+      (boolean (re-find #"(?i)^[a-z]:" path))))
 
 (defn- compose-path
   "Combine `project-root` and the source-coord's `:file` into a single


### PR DESCRIPTION
## What & why (rf2-ltedz, P3 build-warning)

`re-frame.source-coords.editor-uri/absolute-path?` detected a Windows
drive-letter prefix with per-char arithmetic:

```clojure
(and (>= (count path) 2)
     (= \: (.charAt path 1))
     (let [c (.charAt path 0)]
       (or (and (>= (int c) (int \a)) (<= (int c) (int \z)))
           (and (>= (int c) (int \A)) (<= (int c) (int \Z))))))
```

Under ClojureScript the `int` macro expands to a bitwise-OR
(`cljs/core.cljc`: `(defmacro int [x] (list 'js* "(~{} | 0)" x))`), and a
char literal (`\a`) is represented as a single-char **string**. So each
`(int \<char>)` feeds a string into the OR and the analyzer emits
`:invalid-arithmetic` — *"cljs.core/bit-or, all arguments must be numbers,
got [string number] instead"* — **x4**. Harmless at runtime, but every
consumer that builds re-frame2 from source (e.g. via `:local/root`) sees the
noise. Surfaced during an rf8 migration build.

## Change

Replace the per-char arithmetic with a portable regex:

```clojure
(boolean (re-find #"(?i)^[a-z]:" path))
```

- Matches an ASCII letter followed by `:` — identical to the old
  `a-z` / `A-Z` range check, case-insensitive.
- No `(int <char>)` anywhere → the `bit-or [string number]` trigger is
  structurally gone.
- Also subsumes the `(= \: (.charAt path 1))` char-vs-string compare.
- `re-find` is in both `clojure.core` and `cljs.core`; the `.cljc` stays
  JVM-loadable for `re-frame.source-coords/absolutise-file` (the JVM
  macro-expansion consumer at `source_coords.cljc:369`).

Single-file change; isolated surface.

## Gate

- **JVM behavioural parity — PASS.** Ran the old vs new predicate on the JVM
  (the `.cljc` runs identically there) across the `editor_uri` test corpus:
  14/14 cases agree, including every drive-letter case the unit tests
  exercise — `C:/abs/x.cljs`, `c:/abs/x.cljs`, `D:\code\proj` → absolute;
  `AB:cd`, `1:foo`, `:foo`, `a/b:c`, relative paths → not absolute; `/…`,
  `\…`, `file:…` handled by the unchanged earlier branches.
- **Isolated CLJS compile of the fixed `editor_uri.cljc` — PASS.** Compiled
  the namespace via `cljs.build.api` (CLJS 1.12.145 from `~/.m2`):
  0 warnings, 0 `:invalid-arithmetic`.
- **Mechanism proven** by extracting the `int` macro from the CLJS jar (the
  `(~{} | 0)` bit-or expansion above).
- **Deferred to CI:** the full shadow-cljs build was not run here
  (`node_modules` absent in this fresh worktree; `npm install` impractical).
  An isolated `cljs.build.api` probe did not reliably *reproduce* the
  original 4 warnings (shadow's full-build warning config differs from a bare
  standalone compile + analyzer-cache nondeterminism), so the definitive
  before/after numeric reproduction lands in CI's shadow-cljs gate. The
  static guarantee holds regardless: zero `(int <char-literal>)` remain.