### PR TITLE
fix(mcp-base): reject built-in EDN tags (#inst/#uuid) at the cursor boundary (rf2-13wbe)

### DIFF
--- a/tools/mcp-base/spec/cap.md
+++ b/tools/mcp-base/spec/cap.md
@@ -78,10 +78,16 @@ Each consumer reifies `ResultIO` with two methods:
   (build-overflow-result [io marker original-result]      "Fresh result map / object carrying the overflow marker"))
 ```
 
-- `(content-texts io result)` ⇒ seq of strings, the `:text`-slot values inside `result`'s content vector. The platform-specific accessor (`:text` / `j/get :text`) lives behind this method.
+- `(content-texts io result)` ⇒ seq of strings — **one for every serialized, payload-bearing slot that rides the wire**. This is the cap's measurement surface: `apply-cap` sums tokens + chars across exactly these strings, so a slot omitted here is a slot the cap cannot see. At minimum that means the `:text`-slot values inside `result`'s content vector (platform accessor `:text` / `j/get :text` lives behind this method).
 - `(build-overflow-result io marker original-result)` ⇒ a fresh result map / object carrying the overflow marker, shaped for the consumer's transport.
 
 The cap pipeline calls these two methods; everything else is shared. Adding a third consumer is a single reify, not a code copy.
+
+### Contract: count every payload-bearing slot, not only `:content` (rf2-mzndx / rf2-13wbe)
+
+A consumer whose result envelope **duplicates** the payload into a second wire slot MUST surface a stable string representation of that slot from `content-texts` too. The common case is a `:structuredContent` JSON projection emitted **alongside** the `:content[*].text` EDN on **every** result — both re-frame2-pair-mcp's `wire/ok-text` / `err-text` and story-mcp's `text-result` do exactly this (the dual-coded envelope: agent hosts that understand `:structuredContent` read the typed object; the rest fall back to the text). Both copies ride the wire, so both count toward the one budget.
+
+Omitting the second copy undercounts the response by **~50%**: a response whose `:content[*].text` slot is under budget but whose `:structuredContent` is large would slip past the overflow marker and bust the MCP token budget. story-mcp closed this (rf2-mzndx) by appending a `pr-edn`'d `:structuredContent` string to `content-texts`; any dual-coding consumer (pair-mcp's `result-io`) must mirror it (`JSON.stringify` / `pr-str` of the structured value). The unit suites pin the contract with **both** a dual-coding reify (`structured-io` — counts both slots and trips the cap) and a single-slot reify (`map-io` — counts one), so a regression that drops the second copy fails the dual-coding regression.
 
 ### Example reify — re-frame2-pair-mcp (CLJS, JS-object results)
 

--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -81,7 +81,12 @@ The `:reason` slot is the cross-MCP `vocab/cursor-stale-reason` (`:rf.mcp/cursor
 
 ## Tagged-literal rejection
 
-The EDN reader inside `decode-cursor` runs with a `:default` data-reader that throws `:rf.error/mcp-cursor-bad-edn-tag` on ANY tagged literal. A hostile / corrupt cursor cannot smuggle a `#js`, `#inst`, or custom tagged literal past the reader. The throw is caught by the surrounding try and surfaces as `::malformed`.
+The EDN reader inside `decode-cursor` rejects **every** tagged literal — custom AND built-in — and surfaces the rejection as `::malformed`:
+
+- A `:default` data-reader throws `:rf.error/mcp-cursor-bad-edn-tag` on every **unregistered** tag (`#js`, `#foo/bar`, …).
+- `:readers` overrides throw on the **built-in** `#inst` / `#uuid` tags. These have registered readers (`clojure.edn` / `cljs.reader` resolve them from `*data-readers*` / the tag-table), so they **bypass `:default`** and would otherwise decode to a host `java.util.Date` / `UUID` (JVM) or `js/Date` / `cljs.core/UUID` (CLJS). Because `:readers` is consulted **before** `:default` on both platforms, the override wins and the built-in tag never materialises a host object.
+
+A hostile / corrupt cursor therefore cannot smuggle any tagged literal — or the host object it would decode to — past the reader. The throw is caught by the surrounding try in `decode-cursor` and surfaces as `::malformed`. (This closes the built-in-tag hole found in the rf2-13wbe correctness review: `pair-mcp`'s permissive `some? :after-id` predicate would have let `{:v 1 :after-id 1 :junk #inst "…"}` survive validation, carrying a `Date` through the MCP cursor boundary.)
 
 ## Why this ns
 

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -77,10 +77,29 @@
   shape-agnostic."
 
   (content-texts [_io result]
-    "Return a seq of strings, the `:text`-slot values from every entry
-    in `result`'s content vector. Non-string `:text` slots and entries
+    "Return a seq of strings — ONE for EVERY serialized, payload-bearing
+    slot that rides the wire in `result`. This is the cap's measurement
+    surface: `apply-cap` sums tokens + chars across exactly these
+    strings, so a slot omitted here is a slot the cap CANNOT see.
+
+    At minimum that means the `:text`-slot values from every entry in
+    `result`'s content vector. Non-string `:text` slots and entries
     without a `:text` slot are skipped. Implementations stay nil-safe:
-    a nil `result` or empty content yields an empty seq.")
+    a nil `result` or empty content yields an empty seq.
+
+    CONTRACT — count every payload-bearing slot, not only `:content`
+    (rf2-mzndx / rf2-13wbe): a consumer whose result envelope DUPLICATES
+    the payload into a second wire slot — most commonly a
+    `:structuredContent` JSON projection emitted alongside the
+    `:content[*].text` EDN on EVERY result (both re-frame2-pair-mcp's
+    `wire/ok-text` / `err-text` and story-mcp's `text-result` do this) —
+    MUST surface a stable string representation of THAT slot here too
+    (e.g. `pr-str` / `JSON.stringify` of the structured value). Both
+    copies ride the wire, so both count toward the one budget; omitting
+    the second copy undercounts the response by ~50% and lets an
+    over-budget payload slip past the overflow marker. The unit suites
+    pin this with both a dual-coding reify (counts both) and a
+    single-slot reify (counts one).")
 
   (build-overflow-result [_io marker original-result]
     "Build a fresh result of the consumer's native shape carrying

--- a/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
@@ -19,9 +19,10 @@
 
   The cursor PAYLOAD differs by domain — story carries
   `{:offset :total :sig}`, pair carries `{:after-id :ms :until-ms
-  :frame}` — but the base64 codec, the EDN read with tagged-literal
-  rejection + size guard, the `::malformed` recovery contract, the
-  `:limit` clamp, and the `cursor-stale-result` envelope are identical.
+  :frame}` — but the base64 codec, the EDN read with ALL-tagged-literal
+  rejection (built-in `#inst`/`#uuid` included) + size guard, the
+  `::malformed` recovery contract, the `:limit` clamp, and the
+  `cursor-stale-result` envelope are identical.
   Earlier the README argued the codec was consumer-side because
   `js/Buffer` vs `java.util.Base64` differ — but story-mcp's
   `cursor.cljc` already proved the codec lifts cleanly as a `.cljc`
@@ -44,9 +45,11 @@
   Pure CLJC. The base64 codec resolves to `java.util.Base64` on the
   JVM (story-mcp) and `js/Buffer` on CLJS (re-frame2-pair-mcp). The EDN
   read uses `clojure.edn/read-string` (JVM) / `cljs.reader/read-string`
-  (CLJS) — both gated by a `:default` tagged-literal handler that
-  throws so a hostile / corrupt cursor cannot smuggle a tagged literal
-  past the reader."
+  (CLJS) — gated so that a hostile / corrupt cursor cannot smuggle ANY
+  tagged literal past the reader: a `:default` handler throws on every
+  UNREGISTERED tag, and `:readers` overrides throw on the BUILT-IN
+  `#inst` / `#uuid` tags (which have registered readers and would
+  otherwise bypass `:default`, decoding to a host `Date` / `UUID`)."
   (:require [clojure.string :as str]
             #?(:clj [clojure.edn :as edn])
             [re-frame.mcp-base.args :as args]
@@ -115,19 +118,48 @@
   (when (map? payload)
     (b64-encode (pr-str payload))))
 
+(defn- bad-tag!
+  "Throw the cursor-boundary tagged-literal rejection. `tag` (a symbol
+  or nil for the built-in arms that don't carry it through) rides the
+  ex-data for diagnosis. Caught by the surrounding try in
+  `decode-cursor` → `::malformed`."
+  [tag]
+  (throw (ex-info ":rf.error/mcp-cursor-bad-edn-tag"
+                  {:rf.error/id :rf.error/mcp-cursor-bad-edn-tag
+                   :where       'mcp-base/decode-cursor
+                   :recovery    :no-recovery
+                   :tag         tag
+                   :reason      "EDN cursor carried a tagged literal — none are permitted"})))
+
+(def ^:private no-tag-readers
+  "Per-tag readers that reject the BUILT-IN EDN tags `#inst` / `#uuid`.
+
+  The `:default` data-reader catches every UNREGISTERED tag, but the
+  built-in `inst` / `uuid` tags have registered readers
+  (`clojure.edn` / `cljs.reader` resolve them from
+  `*data-readers*` / the tag-table) and so BYPASS `:default` entirely —
+  they would otherwise decode to a host `java.util.Date` / `UUID`
+  (JVM) or `js/Date` / `cljs.core/UUID` (CLJS) and smuggle a host
+  object through the cursor boundary. Overriding them here with
+  throwing fns closes that hole so EVERY tag — built-in or custom —
+  is rejected. `:readers` is consulted before `:default` on both
+  platforms, so these win."
+  {'inst (fn [_] (bad-tag! 'inst))
+   'uuid (fn [_] (bad-tag! 'uuid))})
+
 (defn- read-edn-no-tags
-  "Read an EDN string with EVERY tagged literal rejected. The
-  `:default` data-reader throws `:rf.error/mcp-cursor-bad-edn-tag` so a
-  hostile / corrupt cursor cannot smuggle a `#js`, `#inst`, or custom
-  tagged literal past the reader. Caught by the surrounding try in
+  "Read an EDN string with EVERY tagged literal rejected — built-in
+  (`#inst` / `#uuid`) AND custom (`#js`, `#foo/bar`, …). The `:readers`
+  overrides throw on the two built-in tags that would otherwise bypass
+  `:default` (they have registered readers), and the `:default`
+  data-reader throws `:rf.error/mcp-cursor-bad-edn-tag` on every
+  remaining unregistered tag. A hostile / corrupt cursor therefore
+  cannot smuggle ANY tagged literal — or the host object it would
+  decode to — past the reader. Caught by the surrounding try in
   `decode-cursor` → `::malformed`."
   [s]
-  (let [opts {:default (fn [_tag _val]
-                         (throw (ex-info ":rf.error/mcp-cursor-bad-edn-tag"
-                                         {:rf.error/id :rf.error/mcp-cursor-bad-edn-tag
-                                          :where       'mcp-base/decode-cursor
-                                          :recovery    :no-recovery
-                                          :reason      "EDN cursor carried a tagged literal — none are permitted"})))}]
+  (let [opts {:readers no-tag-readers
+              :default (fn [tag _val] (bad-tag! tag))}]
     #?(:clj  (edn/read-string opts s)
        :cljs (cljs.reader/read-string opts s))))
 

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -138,6 +138,81 @@
       (is (identical? r out)))))
 
 ;; ---------------------------------------------------------------------------
+;; 4b. structuredContent must count toward the budget on the CLJS/pair path
+;;     (rf2-13wbe). re-frame2-pair-mcp's `wire/ok-text` / `err-text` emit
+;;     a `:structuredContent` JS projection alongside the `:content[*].text`
+;;     EDN on EVERY result — the SAME payload, twice on the wire. The
+;;     mcp-base `content-texts` contract (rf2-mzndx / rf2-13wbe) requires a
+;;     dual-coding consumer to surface a stable string of that slot too;
+;;     otherwise the cap undercounts by ~50% and a small-`:content` /
+;;     huge-`:structuredContent` response slips past the overflow marker.
+;;
+;;     These are JS-object-shaped reifies (matching pair-mcp's real
+;;     `#js {:content #js [...] :structuredContent ...}` envelope) so the
+;;     regression bites on the CLJS/pair shape, not just story's CLJ map.
+;; ---------------------------------------------------------------------------
+
+(defn- js-text-slots
+  "Pull the `:text` strings off a pair-mcp-shaped `#js [...]` content
+  array via native interop (mcp-base carries no `js-interop` dep)."
+  [^js content]
+  (let [n (if (array? content) (.-length content) 0)]
+    (loop [i 0 acc []]
+      (if (< i n)
+        (recur (inc i) (conj acc (.-text ^js (aget content i))))
+        acc))))
+
+(def ^:private structured-pair-io
+  "Pair-shaped reify that HONOURS the dual-slot contract: `content-texts`
+  surfaces both the `#js`-array `:text` slots AND a `js/JSON.stringify`
+  of the `:structuredContent` JS object — the exact bytes the npm SDK
+  serialises. This is the shape pair-mcp's `result-io` must adopt
+  (rf2-13wbe). Mirrors story-mcp's `structured-io` on the JS side."
+  (reify cap/ResultIO
+    (content-texts [_ result]
+      (let [sc      (.-structuredContent ^js result)
+            sc-text (when (some? sc) (js/JSON.stringify sc))]
+        (cond-> (js-text-slots (.-content ^js result))
+          (some? sc-text) (conj sc-text))))
+    (build-overflow-result [_ marker _original]
+      #js {:content          #js [#js {:type "text" :text (pr-str marker)}]
+           :structuredContent (clj->js marker)})))
+
+(def ^:private content-only-pair-io
+  "Pair-shaped reify that IGNORES `:structuredContent` (the pre-rf2-13wbe
+  pair-mcp behaviour). Used only to demonstrate the undercount the
+  contract forbids — the same payload passes the cap here while
+  `structured-pair-io` trips it."
+  (reify cap/ResultIO
+    (content-texts [_ result]
+      (js-text-slots (.-content ^js result)))
+    (build-overflow-result [_ marker _original]
+      #js {:content          #js [#js {:type "text" :text (pr-str marker)}]
+           :structuredContent (clj->js marker)})))
+
+(deftest structured-content-counted-on-pair-shape
+  ;; A pair-mcp-shaped result: tiny `:content` text, huge dual-coded
+  ;; `:structuredContent`. The honest reify MUST trip the cap; the
+  ;; structuredContent-ignoring reify under-counts and lets it through.
+  (let [huge   (clj->js {:big (apply str (repeat 30000 "x"))})
+        result #js {:content          #js [#js {:type "text" :text "ok"}]
+                    :structuredContent huge}
+        cap    1000
+        out-honest (cap/apply-cap structured-pair-io result {:tool "snapshot" :cap cap})
+        out-under  (cap/apply-cap content-only-pair-io result {:tool "snapshot" :cap cap})
+        ;; the overflow REPLACEMENT carries the marker's pr-str in its
+        ;; `:content[0].text` slot — `:rf.mcp/overflow` is the tell.
+        honest-text (.-text ^js (aget (.-content ^js out-honest) 0))]
+    (testing "honest dual-slot reify trips the cap (structuredContent counts)"
+      (is (not (identical? result out-honest))
+          "the over-budget response was replaced, not passed through")
+      (is (re-find #":rf\.mcp/overflow" honest-text)
+          "overflow marker emitted — the structured slot pushed it over budget"))
+    (testing "the ~50% undercount the contract forbids: ignoring structuredContent passes a huge response"
+      (is (identical? result out-under)
+          "structuredContent-blind reify under-counts and lets the over-budget payload through unchanged"))))
+
+;; ---------------------------------------------------------------------------
 ;; 5. Cross-host strict integer-parse contract (rf2-ee38b.19). The string
 ;;    arm of `parse-int*` previously diverged: raw `js/parseInt` parses a
 ;;    numeric PREFIX (`"12abc"` ⇒ 12) while JVM `Long/parseLong` rejects
@@ -188,7 +263,25 @@
   (testing "tagged literals in the cursor are rejected"
     (let [evil (cursor/b64-encode "#js {:a 1}")]
       (is (= :re-frame.mcp-base.cursor/malformed
-             (cursor/decode-cursor evil any?))))))
+             (cursor/decode-cursor evil any?)))))
+  (testing "built-in #inst / #uuid tags in a valid map are rejected on CLJS too (rf2-13wbe)"
+    ;; `cljs.reader` resolves built-in `inst` / `uuid` from its tag-table
+    ;; and BYPASSES `:default` — without the `:readers` override these
+    ;; decode to a host `js/Date` / `cljs.core/UUID` and smuggle a host
+    ;; object through the boundary inside an otherwise-valid map.
+    (let [permissive? (fn [m] (and (map? m) (some? (:after-id m))))
+          pair-inst   (cursor/b64-encode
+                        "{:v 1 :after-id 1 :junk #inst \"2024-01-01T00:00:00.000-00:00\"}")
+          pair-uuid   (cursor/b64-encode
+                        "{:v 1 :after-id 1 :junk #uuid \"00000000-0000-0000-0000-000000000000\"}")]
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor pair-inst permissive?)))
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor pair-uuid permissive?)))
+      ;; a clean cursor still survives the permissive predicate
+      (is (= {:v 1 :after-id "ev-9"}
+             (cursor/decode-cursor (cursor/encode-cursor {:v 1 :after-id "ev-9"})
+                                   permissive?))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 7. Shared with-indicators envelope helper under CLJS (rf2-ee38b.19).

--- a/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
@@ -138,12 +138,47 @@
 
 (deftest decode-cursor-rejects-tagged-literals
   ;; The hardening contract: a cursor smuggling a tagged literal must
-  ;; be rejected by the reader's :default handler → ::malformed, never
-  ;; evaluated.
+  ;; be rejected by the reader → ::malformed, never evaluated.
   (let [evil-inst (cursor/b64-encode "#inst \"2024-01-01\"")
         evil-map  (cursor/b64-encode "{:v 1 :offset #foo/bar 0 :total 5 :sig \"s\"}")]
     (is (= ::cursor/malformed (cursor/decode-cursor evil-inst offset-cursor?)))
     (is (= ::cursor/malformed (cursor/decode-cursor evil-map offset-cursor?)))))
+
+(deftest decode-cursor-rejects-builtin-tags-inside-valid-map
+  ;; rf2-13wbe: the BUILT-IN EDN tags `#inst` / `#uuid` have registered
+  ;; readers (`clojure.edn` / `cljs.reader` resolve them from
+  ;; `*data-readers*` / the tag-table) and BYPASS the `:default`
+  ;; handler entirely. Before the fix they decoded to a host
+  ;; `java.util.Date` / `UUID` (JVM) / `js/Date` / `cljs.core/UUID`
+  ;; (CLJS), smuggling a host object through the cursor boundary inside
+  ;; an OTHERWISE-VALID payload map. Pair-mcp's predicate is permissive
+  ;; (`some? :after-id`), so the tagged value would survive validation
+  ;; instead of being treated as malformed.
+  ;;
+  ;; The `:readers` overrides now throw on `#inst` / `#uuid`, so EVERY
+  ;; tag is rejected. Covered for both a story-style strict predicate
+  ;; and a pair-style permissive predicate; both expect ::malformed.
+  (let [permissive? (fn [m] (and (map? m) (some? (:after-id m))))
+        ;; pair-style permissive map with a built-in tag in a junk slot
+        pair-inst (cursor/b64-encode
+                    "{:v 1 :after-id 1 :junk #inst \"2024-01-01T00:00:00.000-00:00\"}")
+        pair-uuid (cursor/b64-encode
+                    "{:v 1 :after-id 1 :junk #uuid \"00000000-0000-0000-0000-000000000000\"}")
+        ;; story-style map with a built-in tag in a valid-shape slot
+        story-inst (cursor/b64-encode
+                     "{:v 1 :offset 0 :total 5 :sig #inst \"2024-01-01\"}")
+        story-uuid (cursor/b64-encode
+                     "{:v 1 :offset 0 :total #uuid \"00000000-0000-0000-0000-000000000000\" :sig \"s\"}")]
+    (testing "pair-style permissive predicate — #inst / #uuid in a valid map ⇒ ::malformed"
+      (is (= ::cursor/malformed (cursor/decode-cursor pair-inst permissive?)))
+      (is (= ::cursor/malformed (cursor/decode-cursor pair-uuid permissive?))))
+    (testing "story-style strict predicate — #inst / #uuid in a valid map ⇒ ::malformed"
+      (is (= ::cursor/malformed (cursor/decode-cursor story-inst offset-cursor?)))
+      (is (= ::cursor/malformed (cursor/decode-cursor story-uuid offset-cursor?))))
+    (testing "a clean pair-style cursor still passes the permissive predicate"
+      (is (= {:v 1 :after-id "ev-9"}
+             (cursor/decode-cursor (cursor/encode-cursor {:v 1 :after-id "ev-9"})
+                                   permissive?))))))
 
 (deftest malformed?-predicate
   (is (true? (cursor/malformed? ::cursor/malformed)))


### PR DESCRIPTION
Fixes the two findings from the **rf2-13wbe** correctness review of `tools/mcp-base`.

## Finding 1 — built-in EDN tag-literal injection through the cursor boundary (fixed)

`cursor/read-edn-no-tags` relied solely on the reader's `:default` data-reader to reject tagged literals. But the **built-in** EDN tags `#inst` / `#uuid` have *registered* readers (`clojure.edn` / `cljs.reader` resolve them from `*data-readers*` / the tag-table) and **bypass `:default` entirely**. A hostile/corrupt cursor could therefore decode `{:v 1 :after-id 1 :junk #inst "…"}` to a host `java.util.Date` / `UUID` (JVM) or `js/Date` / `cljs.core/UUID` (CLJS) — a host object carried through the MCP cursor boundary inside an otherwise-valid payload map. pair-mcp's permissive `some? :after-id` predicate let it survive validation rather than being treated as `::malformed`.

**Fix:** add `:readers` overrides that throw on `inst` / `uuid` (consulted *before* `:default` on both platforms), in addition to the existing `:default`. Every tag — built-in or custom — is now rejected, and the decode fails closed to `::malformed`. Verified the clean cursor still round-trips.

Tests added (JVM `cursor_test.clj` + CLJS `cljs_branches_cljs_test.cljs`): `#inst` / `#uuid` inside a story-style strict map AND a pair-style permissive map → `::malformed`, plus a clean-cursor pass-through.

## Finding 2 — `ResultIO/content-texts` undercounts dual-coded payloads (mcp-base side closed; pair-mcp code filed as rf2-ycfu1)

The `ResultIO/content-texts` contract specified only "the `:text`-slot values", which lets a consumer that **duplicates** the payload into a second wire slot (`:structuredContent`, emitted on *every* result by both pair-mcp's `wire/ok-text` / `err-text` and story-mcp's `text-result`) undercount the wire size by ~50% — a small-`:content` / huge-`:structuredContent` response would slip past the overflow marker and bust the MCP token budget (the rf2-mzndx class story-mcp already fixed for itself).

**This PR closes the mcp-base side:** tightened the `content-texts` protocol docstring + `cap.md` to require counting *every serialized payload-bearing slot*, and added a CLJS/pair-shaped regression (`structured-content-counted-on-pair-shape`) pinning the honest-vs-undercount contrast — a dual-slot reify (counts `JSON.stringify` of `:structuredContent`) trips the cap, a `:structuredContent`-blind reify under-counts and lets the over-budget payload through.

The remaining pair-mcp **code** change (`result-io/content-texts` must append a `JSON.stringify`'d `:structuredContent`, mirroring story-mcp's `wire_pipeline.cljc`) is **out of this worker's lane** (mcp-base only) and is filed as **rf2-ycfu1** with an acceptance test spec.

## Quality gates

| Gate | Result |
| --- | --- |
| mcp-base JVM (`clojure -M:test`) | 197 tests, 575 assertions, 0 failures, 0 errors |
| mcp-base CLJS (`npm run test:cljs`) | 9 tests, 45 assertions, 0 failures, 0 errors |
| `npm run test:mcp-conformance` (all 6 gates) | ALL MCP-CONFORMANCE GATES GREEN |

Scope: `tools/mcp-base/**` only (lane respected). `tools/mcp-base/spec/*` kept current (cursor.md tagged-literal section + cap.md ResultIO contract).
