### PR TITLE
fix(examples/scripts): fail Story play-script gate on pageerror + bind http-server to loopback (rf2-wf5al)

### DIFF
--- a/examples/scripts/serve-and-run-story-feature-load-tests.cjs
+++ b/examples/scripts/serve-and-run-story-feature-load-tests.cjs
@@ -83,7 +83,12 @@ async function main() {
   compileAll();
   stageHtml();
 
-  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(port), '-s', '-c-1'], {
+  // Bind 127.0.0.1 (not the http-server 0.0.0.0 default): the runner
+  // and resolveStoryFeatureLoadPort only ever touch loopback, so binding
+  // every interface is avoidable local-network surface. Matches the
+  // adapter-smoke orchestrator (serve-and-run-examples-tests.cjs).
+  // rf2-wf5al(2).
+  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-a', '127.0.0.1', '-p', String(port), '-s', '-c-1'], {
     cwd: IMPL_ROOT,
     stdio: ['ignore', 'pipe', 'pipe'],
   }));

--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -90,10 +90,16 @@ const TERMINAL_TIMEOUT_MS = Number(
 );
 const VERBOSE = process.env.RF2_VERBOSE_TESTS === '1';
 
-const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
-  paths: [IMPL_ROOT],
-});
-const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
+// Resolve the browser toolchain lazily (inside main()) rather than at
+// module top-level, so the script-policy unit test can `require(...)`
+// this module for its pure helpers without http-server / playwright
+// installed (rf2-wf5al). These are only ever used by the harness path.
+function httpServerBin() {
+  return require.resolve('http-server/bin/http-server', { paths: [IMPL_ROOT] });
+}
+function loadChromium() {
+  return require(require.resolve('playwright', { paths: [IMPL_ROOT] })).chromium;
+}
 
 const cleanup = createHarnessCleanup();
 cleanup.installSignalHandlers();
@@ -227,12 +233,31 @@ async function readPlayRunStateOnce(page, variantId, playKey) {
   );
 }
 
+/**
+ * Shared terminal-status predicate. Symmetric with the CLJS
+ * `re-frame.story.play.ci-runner/terminal?` (spec/017 §`:cannot-run`):
+ * a run is terminal once its status is `pass`, `fail`, OR `cannot-run`.
+ *
+ * rf2-wf5al(3): `cannot-run` is a genuine terminal run status (the
+ * runner core finishes a play as cannot-run when every unmet step is a
+ * capability/refusal row). Treating only pass/fail as terminal made an
+ * honest cannot-run look like a hang — the wait loops below burned the
+ * full STORY_PLAY_SCRIPT_TERMINAL_TIMEOUT_MS per affected row before
+ * the (no-state-change) timeout surfaced the failure. Accepting it here
+ * returns immediately so `expectedStatusFor` can mark it as an
+ * unexpected outcome (it never equals the expected pass/fail) and the
+ * refusal is reported at once.
+ */
+function isTerminalStatus(status) {
+  return status === 'pass' || status === 'fail' || status === 'cannot-run';
+}
+
 async function waitForTerminalState(page, variantId) {
   const deadline = Date.now() + TERMINAL_TIMEOUT_MS;
   let last = null;
   while (Date.now() < deadline) {
     last = await readRunStateOnce(page, variantId);
-    if (last && (last.status === 'pass' || last.status === 'fail')) {
+    if (last && isTerminalStatus(last.status)) {
       return last;
     }
     await new Promise((r) => setTimeout(r, 100));
@@ -248,7 +273,7 @@ async function waitForPlayTerminalState(page, variantId, playKey) {
   let last = null;
   while (Date.now() < deadline) {
     last = await readPlayRunStateOnce(page, variantId, playKey);
-    if (last && (last.status === 'pass' || last.status === 'fail')) {
+    if (last && isTerminalStatus(last.status)) {
       return last;
     }
     await new Promise((r) => setTimeout(r, 100));
@@ -370,13 +395,18 @@ function summariseResults(results) {
  * Best-effort: a write failure here must never mask the real gate verdict,
  * so it is logged and swallowed.
  */
-function writeFailureReport(failures, allResults, browserMessages) {
+function writeFailureReport(failures, allResults, browserMessages, pageErrors = []) {
   const report = {
     gate: 'story-play-scripts',
     bead: 'rf2-5x1wt.7 / rf2-315cf',
     capturedAt: new Date().toISOString(),
     totalRows: allResults.length,
     unexpectedOutcomes: failures.length,
+    // rf2-wf5al(1): record uncaught browser exceptions explicitly so a
+    // pageerror-only RED gate (all play rows matched, but the shell
+    // threw) still produces an actionable post-mortem.
+    uncaughtPageErrors: pageErrors.length,
+    pageErrors: pageErrors.slice(-40),
     failures: failures.map((r) => ({
       variantId: r.variantId,
       playKey: r.playKey || null,
@@ -393,6 +423,28 @@ function writeFailureReport(failures, allResults, browserMessages) {
   } catch (err) {
     log(`(warning) could not write failure report: ${err.message}`);
   }
+}
+
+/**
+ * rf2-wf5al(1): compute the gate verdict from BOTH signals — the
+ * per-row play-status matches AND any uncaught browser `pageerror`.
+ *
+ * Previously the runner returned success solely from `failures.length`
+ * (derived from play-status expectation matches), so an uncaught
+ * runtime/browser exception could FALSE-GREEN the :play-script gate as
+ * long as every play row still reported its expected pass/fail status.
+ * That contradicted the pageerror discipline the adjacent example and
+ * Story feature-load runners already keep. Any pageerror is now fatal.
+ *
+ * Console errors are intentionally NOT fatal: they are captured (under
+ * RF2_VERBOSE_TESTS) for diagnostics only, matching the adjacent
+ * runners, which likewise gate on crashes/`pageerror` and not on
+ * console noise. Pure inputs → exit code, so it is unit-testable.
+ */
+function computeExitCode({ failures, pageErrors }) {
+  const unexpectedOutcomes = (failures && failures.length) || 0;
+  const uncaughtErrors = (pageErrors && pageErrors.length) || 0;
+  return unexpectedOutcomes === 0 && uncaughtErrors === 0 ? 0 : 1;
 }
 
 /**
@@ -413,11 +465,21 @@ async function runAllVariants(browser, baseUrl) {
   const context = await browser.newContext();
   const page = await context.newPage();
   const browserMessages = [];
+  // rf2-wf5al(1): pageErrors are tracked SEPARATELY from browserMessages
+  // so an uncaught browser/runtime exception can flip the gate verdict
+  // regardless of RF2_VERBOSE_TESTS. browserMessages stays diagnostics
+  // -only (and only populated when VERBOSE); pageErrors is the fatal
+  // signal fed to computeExitCode below.
+  const pageErrors = [];
   page.on('console', (msg) => {
     if (VERBOSE) browserMessages.push(`[browser:${msg.type()}] ${msg.text()}`);
   });
   page.on('pageerror', (err) => {
-    browserMessages.push(`[browser:pageerror] ${err.message}`);
+    const message = `[browser:pageerror] ${err.message}`;
+    pageErrors.push(message);
+    // Mirror into browserMessages so the existing diagnostics dump and
+    // the failure-report's `browserDiagnostics` slice still surface it.
+    browserMessages.push(message);
   });
 
   try {
@@ -500,14 +562,25 @@ async function runAllVariants(browser, baseUrl) {
 
     const { lines, failures } = summariseResults(results);
     log(lines);
-    if (failures.length > 0 && browserMessages.length > 0) {
+    // rf2-wf5al(1): an uncaught browser `pageerror` is fatal even when
+    // every play row matched its expected status — otherwise a runtime
+    // regression (shell/hydration/dispatch exception) false-greens the
+    // gate behind a clean play-status summary.
+    if (pageErrors.length > 0) {
+      log('');
+      log(
+        `Detected ${pageErrors.length} uncaught browser pageerror(s) — failing the gate (rf2-wf5al).`,
+      );
+    }
+    const gateFailed = failures.length > 0 || pageErrors.length > 0;
+    if (gateFailed && browserMessages.length > 0) {
       log('--- browser diagnostics ---');
       for (const msg of browserMessages.slice(-40)) log(msg);
     }
-    if (failures.length > 0) {
-      writeFailureReport(failures, results, browserMessages);
+    if (gateFailed) {
+      writeFailureReport(failures, results, browserMessages, pageErrors);
     }
-    return failures.length === 0 ? 0 : 1;
+    return computeExitCode({ failures, pageErrors });
   } finally {
     await context.close();
   }
@@ -523,10 +596,16 @@ async function main() {
   compileTestbed();
   stageTestbedHtml();
 
+  // Bind 127.0.0.1 (not the http-server 0.0.0.0 default): the runner
+  // only ever hits http://127.0.0.1:<port>, and resolveStoryFeatureLoadPort
+  // pre-flights loopback — so exposing implementation/out/examples on
+  // every interface is avoidable local-network surface. Matches the
+  // adapter-smoke orchestrator (serve-and-run-examples-tests.cjs).
+  // rf2-wf5al(2).
   const server = cleanup.trackProcess(
     spawnHarnessProcess(
       process.execPath,
-      [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(port), '-s', '-c-1'],
+      [httpServerBin(), OUT_ROOT, '-a', '127.0.0.1', '-p', String(port), '-s', '-c-1'],
       {
         cwd: IMPL_ROOT,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -572,7 +651,7 @@ async function main() {
     return 1;
   }
 
-  const browser = await chromium.launch({ headless: true });
+  const browser = await loadChromium().launch({ headless: true });
   cleanup.addCleanup(async () => {
     try {
       await browser.close();
@@ -588,19 +667,28 @@ async function main() {
   }
 }
 
-main()
-  .then(async (code) => {
-    exiting = true;
-    await cleanup.cleanup();
-    process.exit(code == null ? 1 : code);
-  })
-  .catch(async (err) => {
-    exiting = true;
-    console.error(err && err.stack ? err.stack : err);
-    await cleanup.cleanup();
-    process.exit(1);
-  });
+// Only launch the harness when run directly (`node serve-and-run-...`).
+// Guarding on `require.main` lets the script-policy unit test
+// (_story-play-scripts-policy.test.cjs) `require(...)` this module to
+// exercise the pure helpers below WITHOUT spawning the browser harness
+// or calling process.exit (rf2-wf5al).
+if (require.main === module) {
+  main()
+    .then(async (code) => {
+      exiting = true;
+      await cleanup.cleanup();
+      process.exit(code == null ? 1 : code);
+    })
+    .catch(async (err) => {
+      exiting = true;
+      console.error(err && err.stack ? err.stack : err);
+      await cleanup.cleanup();
+      process.exit(1);
+    });
+}
 
 module.exports = {
   expectedStatusFor,
+  isTerminalStatus,
+  computeExitCode,
 };

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -36,7 +36,7 @@
     "test:xray-feature-gate": "node scripts/serve-and-run-xray-feature-gate.cjs",
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_story-script-runners-policy.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs && node scripts/dev-testbed.test.cjs",
     "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }

--- a/implementation/scripts/_story-script-runners-policy.test.cjs
+++ b/implementation/scripts/_story-script-runners-policy.test.cjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/*
+ * Policy + unit gate for the two Story CI-as-test orchestrators under
+ * examples/scripts/ (rf2-wf5al). Lives in implementation/scripts/ (NOT
+ * under examples/) so it respects the "examples are test-free / no
+ * *.spec.cjs under examples/" lock while still pinning the runner
+ * behaviour. Wired into package.json via `test:script-policy`.
+ *
+ * Covers all three rf2-wf5al findings:
+ *
+ *   1. The :play-script runner must FAIL on an uncaught browser
+ *      `pageerror` even when every play row matched its expected status
+ *      — otherwise a runtime regression false-greens the gate behind a
+ *      clean play-status summary. Asserted via the pure
+ *      `computeExitCode({failures, pageErrors})` helper.
+ *
+ *   2. Both Story http-server orchestrators must bind loopback
+ *      explicitly (`-a 127.0.0.1`) rather than the http-server 0.0.0.0
+ *      default. Asserted statically over the runner sources.
+ *
+ *   3. The runner's terminal-status predicate must accept `cannot-run`
+ *      (the unified THIRD terminal status, spec/017) so an honest
+ *      cannot-run is surfaced immediately instead of burning the full
+ *      per-row terminal timeout. Asserted via `isTerminalStatus`, kept
+ *      symmetric with the CLJS `ci-runner/terminal?`.
+ */
+
+const assert = require('assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPTS_DIR = path.resolve(__dirname, '..', '..', 'examples', 'scripts');
+const PLAY_SCRIPTS_RUNNER = path.join(
+  SCRIPTS_DIR,
+  'serve-and-run-story-play-scripts.cjs',
+);
+const FEATURE_LOAD_RUNNER = path.join(
+  SCRIPTS_DIR,
+  'serve-and-run-story-feature-load-tests.cjs',
+);
+
+// Safe to require: the runner guards its top-level main() behind
+// `require.main === module`, so this pulls in only the pure exports.
+const {
+  computeExitCode,
+  isTerminalStatus,
+} = require(PLAY_SCRIPTS_RUNNER);
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+// ---- Finding 1: pageerror is fatal, even with all play rows matched ----
+
+test('computeExitCode: clean run (no failures, no pageerrors) → 0', () => {
+  assert.equal(computeExitCode({ failures: [], pageErrors: [] }), 0);
+});
+
+test('computeExitCode: a pageerror fails the gate even when all play rows matched (rf2-wf5al.1)', () => {
+  // The false-green case the bead describes: every play row reported its
+  // expected pass/fail status (failures empty) but the shell threw an
+  // uncaught exception. Must be RED.
+  assert.equal(
+    computeExitCode({ failures: [], pageErrors: ['[browser:pageerror] boom'] }),
+    1,
+  );
+});
+
+test('computeExitCode: a play-status mismatch fails the gate (regression guard)', () => {
+  assert.equal(
+    computeExitCode({ failures: [{ variantId: 'x' }], pageErrors: [] }),
+    1,
+  );
+});
+
+test('computeExitCode: both signals dirty → 1', () => {
+  assert.equal(
+    computeExitCode({
+      failures: [{ variantId: 'x' }],
+      pageErrors: ['[browser:pageerror] boom'],
+    }),
+    1,
+  );
+});
+
+test('computeExitCode: missing/undefined arrays are treated as empty', () => {
+  assert.equal(computeExitCode({}), 0);
+  assert.equal(computeExitCode({ failures: undefined, pageErrors: undefined }), 0);
+});
+
+// The runner must actually FEED pageErrors into the verdict, not just
+// define the helper. Pin the call-site so a refactor can't silently drop
+// the pageerror signal back to a failures-only verdict.
+test('play-scripts runner verdict is computed from BOTH failures and pageErrors (rf2-wf5al.1)', () => {
+  const src = fs.readFileSync(PLAY_SCRIPTS_RUNNER, 'utf8');
+  assert.match(
+    src,
+    /return\s+computeExitCode\(\{\s*failures,\s*pageErrors\s*\}\)/,
+    'runAllVariants must return computeExitCode({ failures, pageErrors }) — ' +
+      'the pageerror signal must reach the verdict.',
+  );
+  assert.match(
+    src,
+    /pageErrors\.push\(/,
+    'the pageerror handler must record into the separately-tracked pageErrors array.',
+  );
+});
+
+// ---- Finding 2: both Story orchestrators bind loopback explicitly ----
+
+// Match the http-server spawn argument array and assert it carries the
+// `-a 127.0.0.1` loopback flag adjacent to the http-server bin token
+// (the play-scripts runner resolves it lazily via httpServerBin(); the
+// feature-load runner uses the HTTP_SERVER_BIN constant — accept both).
+// NB `[\s\S]{0,80}?` (not `[^]]`): the latter is the JS-regex gotcha
+// `[^]` (any char) followed by a literal `]`, which would NOT match here.
+const LOOPBACK_BIND_RE =
+  /(?:httpServerBin\(\)|HTTP_SERVER_BIN),[\s\S]{0,80}?['"]-a['"]\s*,\s*['"]127\.0\.0\.1['"]/;
+
+for (const runner of [PLAY_SCRIPTS_RUNNER, FEATURE_LOAD_RUNNER]) {
+  const base = path.basename(runner);
+  test(`${base}: http-server is bound to 127.0.0.1 explicitly (rf2-wf5al.2)`, () => {
+    const src = fs.readFileSync(runner, 'utf8');
+    assert.match(
+      src,
+      LOOPBACK_BIND_RE,
+      `${base} must spawn http-server with '-a', '127.0.0.1' (loopback only) — ` +
+        `the http-server default is 0.0.0.0, and the runner only ever hits ` +
+        `127.0.0.1. Match serve-and-run-examples-tests.cjs.`,
+    );
+  });
+}
+
+// ---- Finding 3: cannot-run is a terminal status ----
+
+test('isTerminalStatus: pass / fail / cannot-run are terminal (rf2-wf5al.3)', () => {
+  assert.equal(isTerminalStatus('pass'), true);
+  assert.equal(isTerminalStatus('fail'), true);
+  // The crux: an honest cannot-run must be terminal so the wait loop
+  // returns immediately instead of burning the full timeout.
+  assert.equal(isTerminalStatus('cannot-run'), true);
+});
+
+test('isTerminalStatus: non-terminal / unknown statuses are not terminal', () => {
+  assert.equal(isTerminalStatus('running'), false);
+  assert.equal(isTerminalStatus('queued'), false);
+  assert.equal(isTerminalStatus(undefined), false);
+  assert.equal(isTerminalStatus(null), false);
+  assert.equal(isTerminalStatus(''), false);
+});
+
+// Pin both wait loops to the shared predicate so neither can regress to
+// an inline pass/fail-only check that re-strands cannot-run.
+test('both wait loops gate on isTerminalStatus (rf2-wf5al.3)', () => {
+  const src = fs.readFileSync(PLAY_SCRIPTS_RUNNER, 'utf8');
+  const matches = src.match(/isTerminalStatus\(last\.status\)/g) || [];
+  assert.ok(
+    matches.length >= 2,
+    'waitForTerminalState and waitForPlayTerminalState must both gate on ' +
+      'isTerminalStatus(last.status).',
+  );
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`story-script-runners-policy tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(`story-script-runners-policy tests: ${tests.length} passed.`);


### PR DESCRIPTION
Correctness review of `examples/scripts` (bead **rf2-wf5al**) surfaced three findings in the two Story CI-as-test orchestrators. All three are fixed, plus a node policy/unit test.

## 1. `:play-script` gate could false-green on an uncaught browser exception (high)

`serve-and-run-story-play-scripts.cjs` recorded page errors into `browserMessages` but derived its verdict **solely** from `failures.length` (the play-status expectation matches). So an uncaught browser/runtime exception (shell / hydration / dispatch crash) could pass the `:play-script` CI gate as long as every play row still reported its expected pass/fail status — contradicting the pageerror discipline the adjacent example and feature-load runners keep.

**Fix:**
- `pageErrors` is now tracked **separately** from `browserMessages` (so it flips the verdict regardless of `RF2_VERBOSE_TESTS`).
- New pure helper `computeExitCode({ failures, pageErrors })` → exit 1 if **either** signal is dirty.
- On a pageerror, the runner prints a `Detected N uncaught browser pageerror(s)` line, dumps `--- browser diagnostics ---`, and writes `failure-report.json` with new `uncaughtPageErrors` count + `pageErrors` array.
- **Console errors stay non-fatal** (captured for diagnostics only) — matching the adjacent runners, which gate on crashes/`pageerror`, not console noise. (Flagged in the bead as a decision point; aligned to the adjacent runners' discipline.)

### pageerror-logic trace (verification)
`runAllVariants` → `page.on('pageerror', …)` pushes into both `pageErrors` and `browserMessages` → after all rows: `gateFailed = failures.length > 0 || pageErrors.length > 0` → `return computeExitCode({ failures, pageErrors })`.

Truth table (asserted by the unit test, and run live):
| failures | pageErrors | exit |
|---|---|---|
| 0 | 0 | **0** |
| 0 | 1 (all rows matched + crash) | **1** ← the false-green, now closed |
| 1 | 0 | **1** |
| 1 | 1 | **1** |

Live check: `computeExitCode({failures:[], pageErrors:['boom']}) === 1` and `…({failures:[], pageErrors:[]}) === 0` both confirmed by running the module.

## 2. Both Story orchestrators bound `0.0.0.0` instead of loopback (high)

`serve-and-run-story-feature-load-tests.cjs` and `serve-and-run-story-play-scripts.cjs` launched `http-server` **without** `-a 127.0.0.1`, so it bound all interfaces while the port preflight + URLs use `127.0.0.1`. The adapter-smoke orchestrator (`serve-and-run-examples-tests.cjs`) already passes `-a 127.0.0.1`.

**Fix:** added `'-a', '127.0.0.1'` to both `http-server` spawn argument arrays.

## 3. `:cannot-run` was not treated as terminal (high)

`waitForTerminalState` / `waitForPlayTerminalState` stopped only on `pass`/`fail`. But `:cannot-run` is the unified THIRD terminal run status (spec/017; the CLJS `re-frame.story.play.ci-runner/terminal?` accepts `:pass`/`:fail`/`:cannot-run`). A play that honestly reached `cannot-run` looked like a hang and burned the full `STORY_PLAY_SCRIPT_TERMINAL_TIMEOUT_MS` (30s) per affected row before the no-state-change timeout surfaced it.

**Fix:** added a shared `isTerminalStatus(status)` predicate accepting `pass`/`fail`/`cannot-run`, used by both wait loops (symmetric with the CLJS predicate). `cannot-run` stays an **unexpected** outcome — `matched: actual === expected` never equals the expected `pass`/`fail`, so it lands in `failures` and is reported **immediately** instead of after the timeout. (No expected-cannot-run policy added, per the bead.)

## Tests

New `implementation/scripts/_story-script-runners-policy.test.cjs`, wired into `test:script-policy`. Placed in `implementation/scripts/` (NOT under `examples/`) so it respects the *examples-are-test-free / no `*.spec.cjs` under `examples/`* lock while pinning the runner behaviour. Covers all three findings:
- `computeExitCode` truth table incl. the all-rows-matched + pageerror → exit 1 case, and a static guard that `runAllVariants` actually returns `computeExitCode({ failures, pageErrors })`.
- Both Story runners' `http-server` spawns carry `-a 127.0.0.1` (static).
- `isTerminalStatus` accepts `cannot-run` (+ rejects non-terminal), and both wait loops gate on it (static).

**Result:** `node scripts/_story-script-runners-policy.test.cjs` → `story-script-runners-policy tests: 11 passed.` Adjacent `_story-feature-load-port.test.cjs` still green (4 passed). `node --check` clean on all three edited `.cjs`.

### Supporting change
The play-scripts runner now resolves the browser toolchain (`http-server` / `playwright`) **lazily** inside `main()` and guards top-level `main()` behind `require.main === module`, so the policy test can `require(...)` it for the pure helpers without the browser toolchain installed and without launching the harness.

Bead: rf2-wf5al
