### PR TITLE
fix(test-infra): make-reset-runtime-fixture snapshots a stable ns-load baseline (run-order independence) (rf2-7hwnu)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
@@ -32,16 +32,14 @@
    Registrar-baseline note: TodoMVC's events register at THIS ns's load
    time. cljs.test runs every test ns in a single shared bundle, and some
    sibling test ns's `:each` fixture restores the registrar to a snapshot
-   that predates this ns's load — stranding the TodoMVC registrations by
-   the time this deftest runs. The conformance-corpus test handles the
-   same hazard by capturing a baseline at deftest entry; we capture this
-   ns's registrations once at ns-load (`ns-load-registrar`) and reinstate
-   them in an OUTER `:each` fixture that wraps the standard reset fixture,
-   so the inner fixture snapshots a populated registrar and restores it
-   intact."
+   that predates this ns's load — which used to strand the TodoMVC
+   registrations by the time this deftest runs. As of rf2-7hwnu the shared
+   `make-reset-runtime-fixture` pins a stable ns-load baseline at
+   fixture-build time and reinstates it before each test's snapshot, so
+   this ns no longer needs the bespoke outer `reinstate-*` fixture it once
+   carried — run-order independence is now the fixture's contract."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.views]
@@ -52,28 +50,7 @@
             [todomvc.core])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
-;; Capture the registrar AT THIS NS'S LOAD — TodoMVC's events / cofx / fx
-;; are registered by now (todomvc.core's require chain ran above). The
-;; outer fixture below reinstates this baseline so a sibling test ns's
-;; pre-todomvc registrar snapshot can't strand these registrations.
-(def ^:private ns-load-registrar (test-support/snapshot-registrar))
-
-(defn- reinstate-todomvc-registrations
-  "Outer :each fixture — ensure the TodoMVC ns-load registrations are
-   present before the standard reset fixture snapshots the registrar.
-   Merge (don't replace) so any framework registrations that landed after
-   this ns loaded survive too."
-  [test-fn]
-  (let [before @registrar/kind->id->metadata]
-    (reset! registrar/kind->id->metadata
-            (merge-with merge before ns-load-registrar))
-    (try
-      (test-fn)
-      (finally
-        (reset! registrar/kind->id->metadata before)))))
-
 (use-fixtures :each
-  reinstate-todomvc-registrations
   (test-support/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -55,12 +55,17 @@
   ### Fixture machinery
   - [[snapshot-registrar]] — capture the current registrar state.
   - [[restore-registrar!]] — restore the registrar to a captured snapshot.
+  - [[merge-registrar-snapshots]] — two-level merge of two registrar
+    snapshots (overlay wins per `[kind id]`).
   - [[with-fresh-registrar]] — bracket a thunk with snapshot + restore.
   - [[make-reset-runtime-fixture]] — `clojure.test`/`cljs.test` `:each`
     fixture that snapshot/restores the registrar AND resets the
     per-process state held by frames / flows (when the flows artefact
     is loaded, rf2-tfw3) / adapter / machine counters / trace
-    listeners.
+    listeners. Pins a STABLE ns-load baseline (captured at fixture-build
+    time) and reinstates it before each test's snapshot, so example /
+    framework tests are run-order-independent inside the shared
+    `:node-test` bundle (rf2-7hwnu).
 
   ### Test-flavoured helpers (rf2-0l3s / rf2-hkr5 / rf2-8j9m6)
   - [[dispatch-sequence]] — fire a vector of events synchronously,
@@ -143,6 +148,23 @@
   [snapshot]
   (reset! registrar/kind->id->metadata snapshot)
   nil)
+
+(defn merge-registrar-snapshots
+  "Two-level merge of two registrar snapshots (`kind → id → metadata`).
+
+  Entries from `overlay` win on a per-`[kind id]` collision; ids present
+  only in `base` survive; ids present only in `overlay` are added. Because
+  the registrar value is a map of `kind → (map of id → metadata)`, the
+  merge must be two-deep — `(merge-with merge base overlay)` — so that two
+  snapshots that each populate a *different* id under the same `kind` are
+  unioned rather than one `kind` map clobbering the other.
+
+  Used by [[make-reset-runtime-fixture]] to fold a stable ns-load baseline
+  back over whatever the registrar currently holds, so a test ns's own
+  ns-load registrations are present regardless of what a sibling ns's
+  `:each` fixture last restored the registrar to (rf2-7hwnu)."
+  [base overlay]
+  (merge-with merge base overlay))
 
 (defn with-fresh-registrar
   "Run `body-fn` with a snapshot/restore bracket around the registrar.
@@ -249,11 +271,30 @@
   "Build a `clojure.test` / `cljs.test` `:each` fixture that resets the
   per-process re-frame runtime around each test.
 
+  ## Run-order independence (rf2-7hwnu)
+
+  The registrar baseline is captured ONCE, when the fixture is built —
+  i.e. when the test ns's `(use-fixtures :each ...)` form is evaluated,
+  which is AT THIS TEST NS'S LOAD (after its `:require` chain has
+  registered its framework + example handlers / subs / views / machines /
+  fx). `cljs.test` runs every test ns in one shared bundle; a sibling ns's
+  `:each` fixture can restore the registrar to a snapshot that predates
+  this ns's load, stranding this ns's registrations (e.g. leaving the
+  whole `:event` registrar empty for an alphabetically-later example ns).
+  Before each test, the fixture folds the stable ns-load baseline back
+  over the live registrar (via [[merge-registrar-snapshots]]) and only
+  THEN snapshots — so the snapshot it restores to is always populated with
+  this ns's own registrations, regardless of run order. This subsumes the
+  bespoke outer-fixture workarounds the todomvc and conformance-corpus
+  tests previously carried.
+
   Per call (i.e. per test), the fixture:
 
-    1. Captures the current registrar (so user-test registrations can be
-       rolled back without losing ns-load-time framework / example
-       registrations).
+    0. Reinstates the stable ns-load baseline over the live registrar
+       (run-order independence — see above).
+    1. Captures the current (baseline-reinstated) registrar (so user-test
+       registrations can be rolled back without losing ns-load-time
+       framework / example registrations).
     2. Resets `frame/frames` to `{}`, plus the flows registry (via
        `flows/reset-flows!` per rf2-4gvb4 — atoms are private behind
        an accessor seam) and `schemas/schemas-by-frame` (when those
@@ -328,6 +369,26 @@
           {:adapter plain-atom/adapter}))"
   ([] (make-reset-runtime-fixture {}))
   ([{:keys [adapter init-fn clear-kinds clear-app-schemas?]}]
+   ;; Stable ns-load baseline (rf2-7hwnu). `make-reset-runtime-fixture` is
+   ;; called when the test ns's `(use-fixtures :each ...)` form is
+   ;; evaluated — i.e. AT THIS TEST NS'S LOAD, after its `:require` chain
+   ;; (which registers framework + example handlers / subs / views /
+   ;; machines / fx). Capturing the registrar HERE — once, at fixture-build
+   ;; time — pins every registration this ns brought live as a stable
+   ;; baseline.
+   ;;
+   ;; Why this matters: `cljs.test` runs every test ns in ONE shared
+   ;; bundle. A sibling ns's `:each` fixture restores the registrar to a
+   ;; snapshot it captured — and that snapshot can PREDATE this ns's load,
+   ;; stranding this ns's registrations (leaving e.g. the entire `:event`
+   ;; registrar empty for alphabetically-later example ns). The per-test
+   ;; closure below folds this baseline back over the live registrar before
+   ;; snapshotting, so the snapshot the fixture restores to is always
+   ;; populated with this ns's own registrations — run-order-independent.
+   ;; This subsumes the bespoke outer-fixture workarounds that the todomvc
+   ;; (`ns-load-registrar` + `reinstate-todomvc-registrations`) and
+   ;; conformance-corpus (`pretest-registrar`) tests carried.
+   (let [ns-load-baseline (snapshot-registrar)]
    (fn [test-fn]
      ;; Late-bind: when the schemas artefact is loaded, snap and restore
      ;; the per-frame schema registry around the test body. `clear-fn`
@@ -335,6 +396,16 @@
      ;; (the schemas artefact owns its own per-frame side-table — it is
      ;; NOT a registrar kind per rf2-cq1ak, so the registrar's
      ;; `clear-kind!` cannot reach it).
+     ;;
+     ;; rf2-7hwnu — reinstate the stable ns-load baseline over whatever the
+     ;; registrar currently holds BEFORE snapshotting. `merge-registrar-
+     ;; snapshots` keeps any registrations a later-loading ns left live
+     ;; (left arg) while guaranteeing this ns's own ns-load registrations
+     ;; (right arg, wins on collision) are present. The `snap` we then
+     ;; capture — and restore to on the way out — is therefore always
+     ;; populated, so this ns's tests no longer depend on run-order luck.
+     (restore-registrar!
+       (merge-registrar-snapshots (snapshot-registrar) ns-load-baseline))
      (let [snap          (snapshot-registrar)
            snapshot-fn   (late-bind/get-fn :schemas/snapshot-by-frame)
            clear-fn      (late-bind/get-fn :schemas/clear-by-frame!)
@@ -366,7 +437,7 @@
            (when restore-fn (restore-fn schemas-snap))
            (reset! frame/frames {})
            (when-let [reset-flows! (late-bind/get-fn :flows/reset-flows!)]
-             (reset-flows!))))))))
+             (reset-flows!)))))))))
 
 ;; ---- test-flavoured helpers (rf2-0l3s / rf2-hkr5) -------------------------
 ;;

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -431,6 +431,7 @@
   ["re-frame.test-support" "make-reset-runtime-fixture"] {:tier :testing :owner "008" :status "v1"}
   ["re-frame.test-support" "with-fresh-registrar"]      {:tier :testing :owner "008" :status "v1"}
   ["re-frame.test-support" "snapshot-registrar"]        {:tier :testing :owner "008" :status "v1"}
+  ["re-frame.test-support" "merge-registrar-snapshots"] {:tier :testing :owner "008" :status "v1"}
   ["re-frame.test-support" "restore-registrar!"]        {:tier :testing :owner "008" :status "v1"}
   ["re-frame.test-support" "with-trace-recorder!"]      {:tier :testing :owner "008" :status "v1"}
 

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 474,
+ :var-count 475,
  :tier-vocab
  [:front-porch
   :advanced
@@ -485,6 +485,7 @@
   {:namespace "re-frame.test-support", :var "assert-path-equals", :tier :testing, :kind :fn, :owner "008", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.test-support", :var "dispatch-sequence", :tier :testing, :kind :fn, :owner "008", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.test-support", :var "make-reset-runtime-fixture", :tier :testing, :kind :fn, :owner "008", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.test-support", :var "merge-registrar-snapshots", :tier :testing, :kind :fn, :owner "008", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.test-support", :var "poll-until", :tier :testing, :kind :fn, :owner "008", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.test-support", :var "restore-registrar!", :tier :testing, :kind :fn, :owner "008", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.test-support", :var "snapshot-registrar", :tier :testing, :kind :fn, :owner "008", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
## What

`make-reset-runtime-fixture` (in `re-frame.test-support`) captured the registrar at fixture-**run** time (per-test ambient state). In the shared `:node-test` bundle, a sibling test ns's `:each` fixture can restore the registrar to a snapshot that **predates a later-loading ns's load**, leaving that ns's entire `:event` registrar empty (count 0) by the time its deftest runs.

`realworld` / `boot` / `nine-states` example tests survived only by **run-order luck**. The `todomvc` (rf2-mzqd4) and `conformance-corpus` tests already worked around the hazard by capturing their ns-load registrations and reinstating them in an **outer** `:each` fixture. This was latent fragility for any future test added to the bundle.

## Fix (fold the workaround into the fixture)

- **Capture a stable ns-load baseline once, at fixture-build time.** The `(use-fixtures :each (make-reset-runtime-fixture …))` form is evaluated at the test ns's load, after its `:require` chain has registered its framework + example handlers / subs / views / machines / fx — so this snapshot pins exactly the registrations that ns brought live.
- **Reinstate the baseline before each test's snapshot.** A new public helper `merge-registrar-snapshots` does a two-level `merge-with merge` (baseline wins per `[kind id]`), folding the baseline back over whatever the registrar currently holds. The fixture only snapshots *after* this merge, so the snapshot it restores to is always populated with this ns's own registrations — regardless of run order.

Each test ns now guarantees its own registrations via its own baseline overlay while preserving whatever else is live, so example / framework tests are **run-order-independent**.

Also **removes the now-redundant bespoke outer `reinstate-todomvc-registrations` fixture** (and its `ns-load-registrar` def + `re-frame.registrar` require) from `todomvc_cljs_test.cljs`, proving the shared fixture subsumes the manual workaround. The `conformance-corpus` test uses its own bespoke `reset-runtime!` (not `make-reset-runtime-fixture`) with a fixture-specific `:route` purge, so it is left untouched.

## Files

- `implementation/core/src/re_frame/test_support.cljc` — new `merge-registrar-snapshots`; ns-load-baseline capture + per-test reinstatement in `make-reset-runtime-fixture`; docstrings.
- `implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs` — drop the redundant outer workaround.

## Gate

`npm run test:cljs` run **locally, green** (fresh worktree, `npm install` + full cold compile):

```
[:node-test] Build completed. (1160 files, 1159 compiled, 0 warnings, 44.83s)
Ran 5779 tests containing 20339 assertions.
0 failures, 0 errors.
```

This exercises the real proof — the shared bundle runs all example/framework tests (incl. todomvc with its workaround **removed**) run-order-dependently in one process, and passes.
