### PR TITLE
docs(examples): document the deliberate slim-counter :counter/* id-reuse exception for adapter parity (rf2-y52v2.2)

### DIFF
--- a/examples/TESTING.md
+++ b/examples/TESTING.md
@@ -220,6 +220,64 @@ runs against a fresh frame — but the *registrations* themselves are
 shared across the whole bundle. Prefix discipline is what keeps them
 non-overlapping.
 
+### Named exception — the stock/slim counter `:counter/*` id share
+
+The prefix convention has **exactly one blessed exception** in the
+example tree (parallel to how [`spec/Conventions.md`](../spec/Conventions.md)
+names `:rf.fx/reg-flow` its single principled carve-out from a general
+rule). It is deliberate, narrow, and load-bearing — not an oversight:
+
+> **[`examples/reagent/counter`](reagent/counter/) and
+> [`examples/reagent-slim/counter_slim_and_fast`](reagent-slim/counter_slim_and_fast/)
+> intentionally register the *same* `:counter/*` event and subscription
+> ids** — `:counter/initialise`, `:counter/inc`, `:counter/dec`
+> (`reg-event-db`) and `:counter/value` (`reg-sub`). The id-identity *is*
+> the demonstration: it proves **adapter parity** — byte-for-byte
+> identical dataflow driven through a different reactive substrate (the
+> stock `day8/re-frame2-reagent` bridge vs the ground-up
+> `day8/reagent-slim` rewrite). Renaming the slim ids to a
+> `:counter-slim-and-fast/*` stem would conform to the prefix rule but
+> *weaken* the parity claim the two fixtures exist to make, so it is not
+> done.
+
+The exception is bounded by four conditions, all of which must hold:
+
+1. **Scope is the shared event + subscription ids only.** The two
+   fixtures' **views are NOT shared.** `reg-view` auto-namespaces each
+   registration as `(keyword *ns* sym)`, so the views land under
+   `:counter.core/*` (stock) and `:counter-slim-and-fast.core/*` (slim) —
+   distinct ids that already satisfy the convention. The carve-out covers
+   *only* the four `:counter/*` event+sub ids; do not read it as "shared
+   views".
+2. **Allowed *only* because they are separate standalone builds that MUST
+   NOT be co-required into one runtime.** Stock builds as
+   `:examples/counter` (`:init-fn counter.core/run`); slim builds as
+   `:examples/counter-slim-and-fast`
+   (`:init-fn counter-slim-and-fast.core/run`) — two independent `:browser`
+   modules with distinct build-ids, init-fns, and namespaces. They never
+   share a JS runtime, so the identical registry ids never collide. The
+   collision is purely theoretical *and already prevented by the build
+   split*; it is not a risk the convention needs to guard against here.
+3. **If either fixture is ever added to a shared wrapper / showcase /
+   `test:browser` bundle, the ids MUST be revisited and prefixed.** The
+   moment a `*-cljs-test` wrapper (or any combined demo) co-`:require`s
+   both `counter.core` and `counter-slim-and-fast.core` into one bundle,
+   the shared ids would overwrite each other in the single shared registry
+   — and, because the handlers are currently byte-identical, *silently*
+   until the twins diverge. This exception does not survive co-loading;
+   prefix one (or both) stems before that happens.
+4. **The bundle-isolation gate is the regression surface that keeps this
+   boundary honest.** `npm run test:reagent-slim:bundle-isolation`
+   (the `cljs-reagent-slim-bundle-isolation` CI job) releases each fixture
+   as its own advanced bundle and greps it in isolation — it is the
+   binding contract that the two builds stay separate, which is precisely
+   what makes the shared ids safe.
+
+Framing note: the **stock** `:counter/*` ids do **not** violate the
+convention even in spirit — `:counter/*` *is* `examples/reagent/counter`'s
+own kebab-folder stem. Only the **slim** fixture is the exception, by
+borrowing the canonical counter's feature namespace rather than its own.
+
 ## Adding a new browser-test example
 
 A new example added to the `test:browser` surface needs:

--- a/examples/reagent-slim/README.md
+++ b/examples/reagent-slim/README.md
@@ -16,7 +16,7 @@ The example sits in its own folder with the CLJS source (`core.cljs`) and a hand
 ## What the example demonstrates
 
 - **`reagent-slim/counter_slim_and_fast/`** ([build id `examples/counter-slim-and-fast`](../../implementation/shadow-cljs.edn))
-  The same `:counter/*` events, subs, and view as the canonical Reagent counter, mounted on the slim substrate. Its `run` fn deliberately exercises `reagent2.dom.server/render-to-static-markup` at boot so the pure-CLJS SSR contract is non-vacuous. The paired verifier asserts two bundle-isolation invariants on the `:advanced` bundle:
+  The same `:counter/*` events and subs as the canonical Reagent counter, mounted on the slim substrate. (Sharing the `:counter/*` event+sub ids with the stock fixture is a **deliberate, documented exception** to the example id-prefix convention — it demonstrates adapter parity; see [`examples/TESTING.md` § Named exception — the stock/slim counter `:counter/*` id share](../TESTING.md#named-exception--the-stockslim-counter-counter-id-share). The views are *not* shared: `reg-view` auto-namespaces them under `:counter-slim-and-fast.core/*` vs the stock `:counter.core/*`.) Its `run` fn deliberately exercises `reagent2.dom.server/render-to-static-markup` at boot so the pure-CLJS SSR contract is non-vacuous. The paired verifier asserts two bundle-isolation invariants on the `:advanced` bundle:
 
   1. **Stock-Reagent impl isolation** — no `reagent.impl.*` symbols (the slim rewrite has its own `reagent2.impl.*` substrate; the bridge's impl tree must be entirely absent).
   2. **Pure-CLJS SSR** — no `react-dom/server` symbols, even though the example runs `reagent2.dom.server/render-to-static-markup` at boot (per IMPL-SPEC §8 + S3-005).

--- a/examples/reagent-slim/counter_slim_and_fast/README.md
+++ b/examples/reagent-slim/counter_slim_and_fast/README.md
@@ -41,6 +41,28 @@ the changed-surface CI job is `cljs-reagent-slim-bundle-isolation` in
 The slim adapter is also a drop-in for the bridge at the
 behavioural level: same clicks, same counts.
 
+## Shared `:counter/*` ids — a deliberate, documented exception
+
+This fixture registers the **same** `:counter/*` event and subscription
+ids as the canonical [`examples/reagent/counter/`](../../reagent/counter/)
+— `:counter/initialise`, `:counter/inc`, `:counter/dec`, and
+`:counter/value`. That id-identity is **intentional**: it is how the two
+fixtures demonstrate **adapter parity** (byte-for-byte identical dataflow
+on a different reactive substrate). It is the one blessed exception to the
+example-tree id-prefix convention, narrowed and justified in
+[`examples/TESTING.md` § Named exception — the stock/slim counter
+`:counter/*` id share](../../TESTING.md#named-exception--the-stockslim-counter-counter-id-share).
+
+The share is safe **only** because stock and slim build as two separate
+standalone bundles that must never be co-required into one runtime; the
+`npm run test:reagent-slim:bundle-isolation` gate is the regression
+surface that keeps that boundary honest. The carve-out covers the four
+event+sub ids **only** — the views are *not* shared: `reg-view`
+auto-namespaces them under `:counter-slim-and-fast.core/*` here vs
+`:counter.core/*` in the stock fixture. If either fixture is ever folded
+into a shared wrapper/showcase/`test:browser` bundle, the ids must be
+prefixed first.
+
 ## Files
 
 ```


### PR DESCRIPTION
Resolves **rf2-y52v2.2** (RULING A, doc-only).

## What & why

The slim counter fixture (`examples/reagent-slim/counter_slim_and_fast`) registers the **same** `:counter/*` event + subscription ids as the canonical stock counter (`examples/reagent/counter`). Per Mike''s ruling on rf2-y52v2.2, this is a **deliberate, narrow exception** — the id-identity *is* the demonstration of **adapter parity** (byte-for-byte identical dataflow on a different reactive substrate). It is documented, not renamed (the rename option was considered and rejected: it would weaken the parity claim for a theoretical, build-prevented collision).

## Changes (doc-only — no code/id changes)

- **`examples/TESTING.md`** — adds a **named exception** under § Event-id and subscription-id namespacing (parallel to how `spec/Conventions.md` names its single principled carve-out from a general rule).
- **`examples/reagent-slim/counter_slim_and_fast/README.md`** — adds a cross-linked "Shared `:counter/*` ids" section.
- **`examples/reagent-slim/README.md`** — cross-links the exception and **corrects** the prior "events, subs, **and view**" wording (views are NOT shared).

## Narrow scope + required caveats (all stated in the note)

1. **Scope = the four shared `:counter/*` EVENT + SUB ids ONLY.** The views are **not** shared — `reg-view` auto-namespaces them under `:counter.core/*` (stock) vs `:counter-slim-and-fast.core/*` (slim). The note explicitly says "do not read it as shared views".
2. **Allowed ONLY because** stock (`:examples/counter`) and slim (`:examples/counter-slim-and-fast`) build as separate standalone bundles with distinct build-ids/init-fns/namespaces that **must never be co-required** into one runtime.
3. **If either fixture is ever added to a shared wrapper / showcase / `test:browser` bundle, the ids MUST be revisited/prefixed first** (the share would silently overwrite in one shared registry until the byte-identical twins diverge).
4. **The bundle-isolation gate** (`npm run test:reagent-slim:bundle-isolation`, CI job `cljs-reagent-slim-bundle-isolation`) is the **regression surface** that keeps the boundary honest.

Framing correction also noted: the **stock** `:counter/*` ids do **not** violate the convention — `:counter/*` is the stock fixture''s own kebab-folder stem; only **slim** is the (now-blessed) exception, by borrowing the canonical counter''s feature namespace.

## Gate

Doc-only. `examples/TESTING.md` is **not** under the mkdocs `docs_dir` (`docs/`), so `mkdocs build --strict` does not cover these files — the cross-links are GitHub-relative repo links. Verified best-effort instead: all three cross-link target paths resolve to real files, and the anchor slug (`#named-exception--the-stockslim-counter-counter-id-share`) matches this repo''s established GitHub-anchor convention (confirmed against existing in-repo em-dash anchors). `examples/TESTING.md` is not a hot-zone file.