### PR TITLE
fix(examples/_shared): scope the 240px text-input rule so Cells grid inputs stay compact (rf2-gv5xd)

### DIFF
--- a/examples/_shared/css/structure.css
+++ b/examples/_shared/css/structure.css
@@ -152,6 +152,13 @@ dl.boot-summary dd { margin: 0; }
   align-items: center;
 }
 
+/* Shared text-input baseline. Despite living under the WebSocket block this
+ * rule is the comfortable form-input default for every bare `[:input
+ * {:type "text"}]` across the examples (CRUD, Temperature, Flight Booker,
+ * Nine States, the WebSocket send form, …). The `min-width:240px`
+ * keeps those single-line forms readable. The 7GUIs Cells grid renders a
+ * deliberately compact cell editor that opts out below — see `.cells-grid
+ * input`. */
 input[type="text"] {
   padding: 8px 12px;
   flex: 1;
@@ -209,7 +216,14 @@ hr {
 }
 
 .cells-grid input {
+  /* The cell editor is a compact spreadsheet input, not a form field, so it
+   * opts out of the shared `input[type="text"]` baseline above. `min-width: 0`
+   * is load-bearing: this rule and the baseline have EQUAL specificity, so
+   * without an explicit reset here the baseline's `min-width: 240px` is the
+   * only `min-width` on the element and blows the column out to >=240px on
+   * edit, wrecking the compact A1..Z100 grid (rf2-gv5xd). */
   width: 56px;
+  min-width: 0;
   box-sizing: border-box;
 }
 

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -54,6 +54,14 @@
  *      _shared files exist on disk and structure.css remains reachable from
  *      style.css's @import.
  *
+ *   4. Pins ONE load-bearing CSS-cascade invariant the static resolver can't
+ *      see (rf2-gv5xd): the 7GUIs Cells grid's compact cell editor
+ *      (`.cells-grid input`) must keep its `min-width: 0` reset so the shared
+ *      `input[type="text"]` baseline's `min-width: 240px` cannot re-expand it
+ *      — while that shared baseline still carries a `min-width` (so the
+ *      WebSocket send form + other bare text inputs keep working). See
+ *      checkCellsInputCompact below.
+ *
  * This is NOT a per-example *.spec.cjs — examples/ stays test-free
  * (rf2-8cevm). It is a pure static scanner, wired into the always-run
  * `test:script-policy` gate (see implementation/scripts/
@@ -371,14 +379,121 @@ function checkSharedTree(io, opts = {}) {
   return errors;
 }
 
+// ---------------------------------------------------------------------------
+// CSS-cascade regression guard (rf2-gv5xd). The static asset gate checks that
+// references resolve; it does NOT model the cascade. One specific cascade
+// invariant is load-bearing and easy to silently break, so we pin it here.
+//
+// structure.css ships a shared `input[type="text"]` baseline (comfortable
+// form inputs: `min-width: 240px`) consumed by every bare text input across
+// the examples — CRUD, Temperature, Flight Booker, the WebSocket send form,
+// etc. The 7GUIs Cells grid renders a *compact* cell editor (`width: 56px`)
+// as a text input inside `.cells-grid`. `input[type="text"]` and
+// `.cells-grid input` have EQUAL specificity, so the only thing stopping the
+// 240px baseline from re-expanding the cell on edit — blowing out the compact
+// A1..Z100 grid — is the explicit `min-width: 0` reset on `.cells-grid input`.
+// Drop that reset and the grid silently regresses. This guard fails the gate
+// if the reset disappears, while also asserting the shared baseline still
+// carries its `min-width` (so the WebSocket/CRUD/etc. forms keep working —
+// i.e. the fix scoped the override, it didn't gut the baseline).
+// ---------------------------------------------------------------------------
+
+// Extract the declaration block (the text between { and the next }) for the
+// FIRST rule whose selector list exactly matches `selector` (whitespace-
+// normalised). Hand-rolled to match this file's regex-not-parser philosophy;
+// structure.css is a flat, comment-light, nesting-free stylesheet so a
+// balanced-brace parser is unnecessary. Returns the inner block string, or
+// null if no such rule exists.
+function extractCssRuleBody(css, selector) {
+  // Strip block comments so a selector mentioned inside a /* ... */ comment
+  // (structure.css references `.cells-grid input` in prose) is never matched.
+  const noComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const wanted = selector.replace(/\s+/g, ' ').trim();
+  const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+  let m;
+  while ((m = ruleRe.exec(noComments)) !== null) {
+    const sel = m[1].replace(/\s+/g, ' ').trim();
+    if (sel === wanted) return m[2];
+  }
+  return null;
+}
+
+// True iff the declaration block declares `prop` with a value matching
+// `valueRe` (the value text up to the next `;` or block end).
+function blockDeclares(block, prop, valueRe) {
+  const re = new RegExp(`(?:^|;)\\s*${prop}\\s*:\\s*([^;]+)`, 'i');
+  const m = block.match(re);
+  return m != null && valueRe.test(m[1].trim());
+}
+
+function checkCellsInputCompact(io, opts = {}) {
+  const sharedRoot = opts.sharedRoot || SHARED_ROOT;
+  const errors = [];
+  const structurePath = path.join(sharedRoot, 'css', 'structure.css');
+  const css = readFileSafe(io, structurePath);
+  if (css == null) {
+    // A missing structure.css is already reported by checkSharedTree; don't
+    // double-report here.
+    return errors;
+  }
+  const rel = 'examples/_shared/css/structure.css';
+
+  const cellRule = extractCssRuleBody(css, '.cells-grid input');
+  if (cellRule == null) {
+    errors.push(
+      `${rel}: no \`.cells-grid input\` rule found — the 7GUIs Cells grid ` +
+        `relies on it to override the shared text-input baseline (rf2-gv5xd).`,
+    );
+  } else {
+    if (!blockDeclares(cellRule, 'min-width', /^0(px)?$/)) {
+      errors.push(
+        `${rel}: \`.cells-grid input\` must declare \`min-width: 0\` to reset ` +
+          `the shared \`input[type="text"]\` baseline's \`min-width: 240px\` ` +
+          `(equal specificity). Without it, editing a Cells cell re-expands ` +
+          `the column to >=240px and wrecks the compact grid (rf2-gv5xd).`,
+      );
+    }
+    if (!blockDeclares(cellRule, 'width', /^56px$/)) {
+      errors.push(
+        `${rel}: \`.cells-grid input\` must keep \`width: 56px\` (the intended ` +
+          `compact cell-editor size) (rf2-gv5xd).`,
+      );
+    }
+  }
+
+  // The shared baseline must STILL carry a min-width — proof the override was
+  // scoped, not achieved by gutting the baseline (which would shrink the
+  // WebSocket send form + CRUD/Temperature/Flight-Booker inputs).
+  const baseRule = extractCssRuleBody(css, 'input[type="text"]');
+  if (baseRule == null) {
+    errors.push(
+      `${rel}: the shared \`input[type="text"]\` baseline is gone — the ` +
+        `WebSocket send form + other bare text inputs rely on it (rf2-gv5xd).`,
+    );
+  } else if (!blockDeclares(baseRule, 'min-width', /\d/)) {
+    errors.push(
+      `${rel}: the shared \`input[type="text"]\` baseline lost its ` +
+        `\`min-width\` — scope the Cells override instead of gutting the ` +
+        `shared baseline (rf2-gv5xd).`,
+    );
+  }
+
+  return errors;
+}
+
 // Run the full scan over every example index.html plus the _shared tree.
 function scanAll(opts = {}) {
   const io = opts.io || fs;
   const indexes = opts.indexes || listExampleIndexHtml();
   const pages = indexes.map((p) => scanPage(io, p, opts));
   const sharedErrors = checkSharedTree(io, opts);
-  const errors = [...sharedErrors, ...pages.flatMap((p) => p.errors)];
-  return { pages, sharedErrors, errors };
+  const cascadeErrors = checkCellsInputCompact(io, opts);
+  const errors = [
+    ...sharedErrors,
+    ...cascadeErrors,
+    ...pages.flatMap((p) => p.errors),
+  ];
+  return { pages, sharedErrors, cascadeErrors, errors };
 }
 
 module.exports = {
@@ -396,6 +511,9 @@ module.exports = {
   checkCssImports,
   scanPage,
   checkSharedTree,
+  extractCssRuleBody,
+  blockDeclares,
+  checkCellsInputCompact,
   scanAll,
 };
 

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -39,6 +39,9 @@ const {
   resolveRef,
   scanPage,
   checkSharedTree,
+  extractCssRuleBody,
+  blockDeclares,
+  checkCellsInputCompact,
   scanAll,
   listExampleIndexHtml,
   EXAMPLES_ROOT,
@@ -88,6 +91,15 @@ it('LIVE: the real _shared source tree is intact (style.css -> structure.css)', 
     errors,
     [],
     `_shared tree errors:\n` + errors.map((e) => `    - ${e}`).join('\n'),
+  );
+});
+
+it('LIVE: the real structure.css keeps the Cells cascade invariant (rf2-gv5xd)', () => {
+  const errors = checkCellsInputCompact(require('fs'));
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `Cells-input cascade errors:\n` + errors.map((e) => `    - ${e}`).join('\n'),
   );
 });
 
@@ -394,6 +406,115 @@ it('the build-output main.js is never resolved on disk', () => {
   assert.ok(
     !errors.some((e) => e.includes('main.js')),
     'main.js (build output) must never be flagged as a missing source file',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3) CSS-CASCADE TEETH (rf2-gv5xd) — pin the Cells-input compactness guard.
+// The static resolver can't see the cascade, so checkCellsInputCompact pins
+// one load-bearing invariant: `.cells-grid input { min-width: 0; width: 56px }`
+// resets the shared `input[type="text"]` baseline (which keeps min-width:240px
+// for the WebSocket/CRUD/etc. forms). These fixtures prove the guard has teeth.
+// ---------------------------------------------------------------------------
+
+// A structure.css with both the shared baseline and the Cells override.
+// `cells` and `base` are spliced in so each direction can be broken in turn.
+function structureCss({ cells, base } = {}) {
+  const baseBlock =
+    base != null
+      ? base
+      : 'input[type="text"] { padding: 8px 12px; flex: 1; min-width: 240px; }';
+  const cellsBlock =
+    cells != null
+      ? cells
+      : '.cells-grid input { width: 56px; min-width: 0; box-sizing: border-box; }';
+  return [
+    '/* a comment mentioning .cells-grid input must NOT be matched as a rule */',
+    baseBlock,
+    '.queue-depth { font-style: italic; }',
+    cellsBlock,
+  ].join('\n');
+}
+
+function cascadeIo(structure) {
+  return makeIo({ [STRUCTURE]: structure });
+}
+
+it('extractCssRuleBody pulls a rule body by exact selector, ignoring comments', () => {
+  const css = structureCss();
+  const cell = extractCssRuleBody(css, '.cells-grid input');
+  assert.ok(cell && cell.includes('min-width: 0'), `got: ${cell}`);
+  const base = extractCssRuleBody(css, 'input[type="text"]');
+  assert.ok(base && base.includes('min-width: 240px'), `got: ${base}`);
+  // Whitespace in the queried selector is normalised.
+  assert.ok(extractCssRuleBody(css, '.cells-grid    input') != null);
+  // A selector that only appears inside a comment is not a rule.
+  assert.strictEqual(extractCssRuleBody('/* .foo bar */ .baz {x:1}', '.foo bar'), null);
+});
+
+it('blockDeclares matches a declared prop value, up to the next semicolon', () => {
+  assert.ok(blockDeclares('width: 56px; min-width: 0;', 'min-width', /^0$/));
+  assert.ok(blockDeclares('min-width:0px', 'min-width', /^0(px)?$/));
+  assert.ok(!blockDeclares('width: 56px;', 'min-width', /^0$/));
+  assert.ok(!blockDeclares('min-width: 240px;', 'min-width', /^0$/));
+});
+
+it('a well-formed structure.css passes the Cells cascade guard', () => {
+  const errors = checkCellsInputCompact(cascadeIo(structureCss()));
+  assert.deepStrictEqual(errors, [], `expected clean, got: ${errors.join(' | ')}`);
+});
+
+it('TEETH: dropping `min-width: 0` from `.cells-grid input` fails the guard', () => {
+  // The exact regression rf2-gv5xd guards against: the cell input keeps only
+  // width:56px, so the shared baseline's min-width:240px re-wins on edit.
+  const errors = checkCellsInputCompact(
+    cascadeIo(structureCss({ cells: '.cells-grid input { width: 56px; box-sizing: border-box; }' })),
+  );
+  assert.ok(
+    errors.some((e) => e.includes('min-width: 0') && e.includes('.cells-grid input')),
+    `expected a missing min-width:0 error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: dropping `width: 56px` from `.cells-grid input` fails the guard', () => {
+  const errors = checkCellsInputCompact(
+    cascadeIo(structureCss({ cells: '.cells-grid input { min-width: 0; box-sizing: border-box; }' })),
+  );
+  assert.ok(
+    errors.some((e) => e.includes('width: 56px')),
+    `expected a missing width:56px error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: removing the `.cells-grid input` rule entirely fails the guard', () => {
+  const errors = checkCellsInputCompact(
+    cascadeIo(structureCss({ cells: '/* cells override deleted */' })),
+  );
+  assert.ok(
+    errors.some((e) => e.includes('no `.cells-grid input` rule found')),
+    `expected a missing-rule error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: gutting the shared baseline min-width fails the guard (scope, do not gut)', () => {
+  // Modelling the WRONG fix (Option A taken too far): scoping the baseline so
+  // hard it loses min-width would shrink the WebSocket/CRUD/etc. inputs.
+  const errors = checkCellsInputCompact(
+    cascadeIo(structureCss({ base: 'input[type="text"] { padding: 8px 12px; }' })),
+  );
+  assert.ok(
+    errors.some((e) => e.includes('min-width') && e.includes('baseline')),
+    `expected a gutted-baseline error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: removing the shared baseline rule entirely fails the guard', () => {
+  const errors = checkCellsInputCompact(
+    cascadeIo(structureCss({ base: '/* baseline deleted */' })),
+  );
+  assert.ok(
+    errors.some((e) => e.includes('baseline is gone')),
+    `expected a baseline-gone error, got: ${errors.join(' | ')}`,
   );
 });
 


### PR DESCRIPTION
## What

The 7GUIs **Cells** example renders each inline cell editor as a text input inside `.cells-grid`, where the shared CSS intends cell inputs to be `width: 56px`. But `examples/_shared/css/structure.css` ships a global `input[type="text"]` baseline (`padding: 8px 12px; flex: 1; min-width: 240px`) that applies to **every** text input across the examples. Because `.cells-grid input` declared only `width` and never reset `min-width`, the baseline's `min-width: 240px` (equal specificity, only `min-width` on the element) won on edit — **expanding the cell/column to ≥240px and blowing out the compact A1..Z100 grid.**

## The fix (scoped, minimal blast radius)

Add `min-width: 0` to the existing `.cells-grid input` rule so the compact cell editor opts out of the shared baseline. The cascade now resolves as intended: `width: 56px` with no competing `min-width`.

**Why not scope the global rule down to `.send-form input[type="text"]`?** The bead offered that as an alternative, but the global `input[type="text"]` rule is *not* actually WebSocket-specific despite the comment context — it's the comfortable baseline for every bare `[:input {:type "text"}]` across the examples: **CRUD** (filter/name/surname), **Temperature** (celsius/fahrenheit), **Flight Booker** (dates), **Nine States**, and the **WebSocket send form**. None of those carry an example-specific input rule; they all rely on this baseline. Scoping it down to `.send-form` would strip padding/min-width from 5+ examples — a visual regression. The surgical `.cells-grid input { min-width: 0 }` override fixes exactly the Cells defect and touches nothing else.

### WebSocket send form still works
The shared baseline is untouched. `examples/reagent/websocket/views.cljs` renders `[:form.send-form … [:input {:type "text" …}]]`; that input keeps `flex: 1; min-width: 240px` and fills the send row exactly as before.

## Regression guard (examples stay test-free)

The static asset gate (`check-examples-assets`) resolves references but doesn't model the CSS cascade. Added `checkCellsInputCompact` to `examples/scripts/check-examples-assets.cjs`, wired through `scanAll`, so the **always-run `test:script-policy` gate** fails if the invariant breaks. It pins:
- `.cells-grid input` must keep `min-width: 0` **and** `width: 56px`, and
- the shared `input[type="text"]` baseline must still carry a `min-width` (proof the override was scoped, not the baseline gutted).

`implementation/scripts/check-examples-assets.test.cjs` adds a LIVE assertion over the real `structure.css` plus six teeth fixtures (drop `min-width:0` → RED, drop `width:56px` → RED, delete either rule → RED, gut/remove the baseline → RED). The check and its tests live **outside** `examples/`, honouring the examples-are-test-free lock (rf2-8cevm) — no `*.spec.cjs` added under `examples/`.

## Gate reasoning
- **Cascade:** `.cells-grid input` now wins `min-width` (equal specificity, later source order + explicit reset) → effective width is `56px`, not `max(240px, 56px)`. The 240px baseline no longer reaches Cells inputs.
- `node implementation/scripts/check-examples-assets.test.cjs` → 30/30 pass (incl. the new LIVE + 6 teeth).
- `node examples/scripts/check-examples-assets.cjs` → green (28 pages, _shared intact, cascade guard runs).

Closes the finding in rf2-gv5xd.
